### PR TITLE
ARROW-6690: [Rust] [DataFusion] Optimize aggregates without GROUP BY to use SIMD

### DIFF
--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -114,50 +114,74 @@ pub fn get_scalar_value(array: &ArrayRef, row: usize) -> Result<Option<ScalarVal
     }
     let value: Option<ScalarValue> = match array.data_type() {
         DataType::UInt8 => {
-            let z = array.as_any().downcast_ref::<array::UInt8Array>().unwrap();
-            Some(ScalarValue::UInt8(z.value(row)))
+            let array = array
+                .as_any()
+                .downcast_ref::<array::UInt8Array>()
+                .expect("Failed to cast array");
+            Some(ScalarValue::UInt8(array.value(row)))
         }
         DataType::UInt16 => {
-            let z = array.as_any().downcast_ref::<array::UInt16Array>().unwrap();
-            Some(ScalarValue::UInt16(z.value(row)))
+            let array = array
+                .as_any()
+                .downcast_ref::<array::UInt16Array>()
+                .expect("Failed to cast array");
+            Some(ScalarValue::UInt16(array.value(row)))
         }
         DataType::UInt32 => {
-            let z = array.as_any().downcast_ref::<array::UInt32Array>().unwrap();
-            Some(ScalarValue::UInt32(z.value(row)))
+            let array = array
+                .as_any()
+                .downcast_ref::<array::UInt32Array>()
+                .expect("Failed to cast array");
+            Some(ScalarValue::UInt32(array.value(row)))
         }
         DataType::UInt64 => {
-            let z = array.as_any().downcast_ref::<array::UInt64Array>().unwrap();
-            Some(ScalarValue::UInt64(z.value(row)))
+            let array = array
+                .as_any()
+                .downcast_ref::<array::UInt64Array>()
+                .expect("Failed to cast array");
+            Some(ScalarValue::UInt64(array.value(row)))
         }
         DataType::Int8 => {
-            let z = array.as_any().downcast_ref::<array::Int8Array>().unwrap();
-            Some(ScalarValue::Int8(z.value(row)))
+            let array = array
+                .as_any()
+                .downcast_ref::<array::Int8Array>()
+                .expect("Failed to cast array");
+            Some(ScalarValue::Int8(array.value(row)))
         }
         DataType::Int16 => {
-            let z = array.as_any().downcast_ref::<array::Int16Array>().unwrap();
-            Some(ScalarValue::Int16(z.value(row)))
+            let array = array
+                .as_any()
+                .downcast_ref::<array::Int16Array>()
+                .expect("Failed to cast array");
+            Some(ScalarValue::Int16(array.value(row)))
         }
         DataType::Int32 => {
-            let z = array.as_any().downcast_ref::<array::Int32Array>().unwrap();
-            Some(ScalarValue::Int32(z.value(row)))
+            let array = array
+                .as_any()
+                .downcast_ref::<array::Int32Array>()
+                .expect("Failed to cast array");
+            Some(ScalarValue::Int32(array.value(row)))
         }
         DataType::Int64 => {
-            let z = array.as_any().downcast_ref::<array::Int64Array>().unwrap();
-            Some(ScalarValue::Int64(z.value(row)))
+            let array = array
+                .as_any()
+                .downcast_ref::<array::Int64Array>()
+                .expect("Failed to cast array");
+            Some(ScalarValue::Int64(array.value(row)))
         }
         DataType::Float32 => {
-            let z = array
+            let array = array
                 .as_any()
                 .downcast_ref::<array::Float32Array>()
                 .unwrap();
-            Some(ScalarValue::Float32(z.value(row)))
+            Some(ScalarValue::Float32(array.value(row)))
         }
         DataType::Float64 => {
-            let z = array
+            let array = array
                 .as_any()
                 .downcast_ref::<array::Float64Array>()
                 .unwrap();
-            Some(ScalarValue::Float64(z.value(row)))
+            Some(ScalarValue::Float64(array.value(row)))
         }
         other => {
             return Err(ExecutionError::ExecutionError(format!(

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -24,7 +24,9 @@ use std::sync::{Arc, Mutex};
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::BatchIterator;
 
-use arrow::datatypes::Schema;
+use crate::logicalplan::ScalarValue;
+use arrow::array::{self, ArrayRef};
+use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
 /// Iterator over a vector of record batches
@@ -103,4 +105,66 @@ pub fn build_file_list(dir: &str, filenames: &mut Vec<String>, ext: &str) -> Res
         }
     }
     Ok(())
+}
+
+/// Get a value from an array as a ScalarValue
+pub fn get_scalar_value(array: &ArrayRef, row: usize) -> Result<Option<ScalarValue>> {
+    if array.is_null(row) {
+        return Ok(None);
+    }
+    let value: Option<ScalarValue> = match array.data_type() {
+        DataType::UInt8 => {
+            let z = array.as_any().downcast_ref::<array::UInt8Array>().unwrap();
+            Some(ScalarValue::UInt8(z.value(row)))
+        }
+        DataType::UInt16 => {
+            let z = array.as_any().downcast_ref::<array::UInt16Array>().unwrap();
+            Some(ScalarValue::UInt16(z.value(row)))
+        }
+        DataType::UInt32 => {
+            let z = array.as_any().downcast_ref::<array::UInt32Array>().unwrap();
+            Some(ScalarValue::UInt32(z.value(row)))
+        }
+        DataType::UInt64 => {
+            let z = array.as_any().downcast_ref::<array::UInt64Array>().unwrap();
+            Some(ScalarValue::UInt64(z.value(row)))
+        }
+        DataType::Int8 => {
+            let z = array.as_any().downcast_ref::<array::Int8Array>().unwrap();
+            Some(ScalarValue::Int8(z.value(row)))
+        }
+        DataType::Int16 => {
+            let z = array.as_any().downcast_ref::<array::Int16Array>().unwrap();
+            Some(ScalarValue::Int16(z.value(row)))
+        }
+        DataType::Int32 => {
+            let z = array.as_any().downcast_ref::<array::Int32Array>().unwrap();
+            Some(ScalarValue::Int32(z.value(row)))
+        }
+        DataType::Int64 => {
+            let z = array.as_any().downcast_ref::<array::Int64Array>().unwrap();
+            Some(ScalarValue::Int64(z.value(row)))
+        }
+        DataType::Float32 => {
+            let z = array
+                .as_any()
+                .downcast_ref::<array::Float32Array>()
+                .unwrap();
+            Some(ScalarValue::Float32(z.value(row)))
+        }
+        DataType::Float64 => {
+            let z = array
+                .as_any()
+                .downcast_ref::<array::Float64Array>()
+                .unwrap();
+            Some(ScalarValue::Float64(z.value(row)))
+        }
+        other => {
+            return Err(ExecutionError::ExecutionError(format!(
+                "Unsupported data type {:?} for result of aggregate expression",
+                other
+            )));
+        }
+    };
+    Ok(value)
 }

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -22,6 +22,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::error::{ExecutionError, Result};
+use crate::execution::physical_plan::common::get_scalar_value;
 use crate::execution::physical_plan::{Accumulator, AggregateExpr, PhysicalExpr};
 use crate::logicalplan::{Operator, ScalarValue};
 use arrow::array::{
@@ -32,6 +33,7 @@ use arrow::array::{
     Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder,
     Int8Builder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
 };
+use arrow::compute;
 use arrow::compute::kernels::arithmetic::{add, divide, multiply, subtract};
 use arrow::compute::kernels::boolean::{and, or};
 use arrow::compute::kernels::cast::cast;
@@ -73,6 +75,210 @@ pub fn col(i: usize) -> Arc<dyn PhysicalExpr> {
     Arc::new(Column::new(i))
 }
 
+fn array_min(array: &ArrayRef) -> Result<Option<ScalarValue>> {
+    match array.data_type() {
+        DataType::UInt8 => {
+            match compute::min(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt8(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt16 => {
+            match compute::min(array.as_any().downcast_ref::<UInt16Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt16(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt32 => {
+            match compute::min(array.as_any().downcast_ref::<UInt32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt32(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt64 => {
+            match compute::min(array.as_any().downcast_ref::<UInt64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt64(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int8 => {
+            match compute::min(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int8(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int16 => {
+            match compute::min(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int16(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int32 => {
+            match compute::min(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int32(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int64 => {
+            match compute::min(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int64(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Float32 => {
+            match compute::min(array.as_any().downcast_ref::<Float32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Float32(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Float64 => {
+            match compute::min(array.as_any().downcast_ref::<Float64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Float64(n))),
+                None => Ok(None),
+            }
+        }
+        _ => Err(ExecutionError::ExecutionError(
+            "Unsupported data type for MIN".to_string(),
+        )),
+    }
+}
+
+fn array_max(array: &ArrayRef) -> Result<Option<ScalarValue>> {
+    match array.data_type() {
+        DataType::UInt8 => {
+            match compute::max(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt8(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt16 => {
+            match compute::max(array.as_any().downcast_ref::<UInt16Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt16(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt32 => {
+            match compute::max(array.as_any().downcast_ref::<UInt32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt32(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt64 => {
+            match compute::max(array.as_any().downcast_ref::<UInt64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt64(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int8 => {
+            match compute::max(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int8(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int16 => {
+            match compute::max(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int16(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int32 => {
+            match compute::max(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int32(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int64 => {
+            match compute::max(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int64(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Float32 => {
+            match compute::max(array.as_any().downcast_ref::<Float32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Float32(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Float64 => {
+            match compute::max(array.as_any().downcast_ref::<Float64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Float64(n))),
+                None => Ok(None),
+            }
+        }
+        _ => Err(ExecutionError::ExecutionError(
+            "Unsupported data type for MAX".to_string(),
+        )),
+    }
+}
+
+fn array_sum(array: &ArrayRef) -> Result<Option<ScalarValue>> {
+    match array.data_type() {
+        DataType::UInt8 => {
+            match compute::sum(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt8(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt16 => {
+            match compute::sum(array.as_any().downcast_ref::<UInt16Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt16(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt32 => {
+            match compute::sum(array.as_any().downcast_ref::<UInt32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt32(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::UInt64 => {
+            match compute::sum(array.as_any().downcast_ref::<UInt64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::UInt64(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int8 => {
+            match compute::sum(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int8(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int16 => {
+            match compute::sum(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int16(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int32 => {
+            match compute::sum(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int32(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Int64 => {
+            match compute::sum(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Int64(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Float32 => {
+            match compute::sum(array.as_any().downcast_ref::<Float32Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Float32(n))),
+                None => Ok(None),
+            }
+        }
+        DataType::Float64 => {
+            match compute::sum(array.as_any().downcast_ref::<Float64Array>().unwrap()) {
+                Some(n) => Ok(Some(ScalarValue::Float64(n))),
+                None => Ok(None),
+            }
+        }
+        _ => Err(ExecutionError::ExecutionError(
+            "Unsupported data type for SUM".to_string(),
+        )),
+    }
+}
+
 /// SUM aggregate expression
 pub struct Sum {
     expr: Arc<dyn PhysicalExpr>,
@@ -112,91 +318,82 @@ impl AggregateExpr for Sum {
     }
 
     fn create_accumulator(&self) -> Rc<RefCell<dyn Accumulator>> {
-        Rc::new(RefCell::new(SumAccumulator {
-            expr: self.expr.clone(),
-            sum: None,
-        }))
+        Rc::new(RefCell::new(SumAccumulator { sum: None }))
     }
 
-    fn create_combiner(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
+    fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
         Arc::new(Sum::new(Arc::new(Column::new(column_index))))
     }
 }
 
 macro_rules! sum_accumulate {
-    ($SELF:ident, $ARRAY:ident, $ROW_INDEX:expr, $ARRAY_TYPE:ident, $SCALAR_VARIANT:ident, $TY:ty) => {{
-        if let Some(array) = $ARRAY.as_any().downcast_ref::<$ARRAY_TYPE>() {
-            if $ARRAY.is_valid($ROW_INDEX) {
-                let value = array.value($ROW_INDEX);
-                $SELF.sum = match $SELF.sum {
-                    Some(ScalarValue::$SCALAR_VARIANT(n)) => {
-                        Some(ScalarValue::$SCALAR_VARIANT(n + value as $TY))
-                    }
-                    Some(_) => {
-                        return Err(ExecutionError::InternalError(
-                            "Unexpected ScalarValue variant".to_string(),
-                        ))
-                    }
-                    None => Some(ScalarValue::$SCALAR_VARIANT(value as $TY)),
-                };
+    ($SELF:ident, $VALUE:expr, $ARRAY_TYPE:ident, $SCALAR_VARIANT:ident, $TY:ty) => {{
+        $SELF.sum = match $SELF.sum {
+            Some(ScalarValue::$SCALAR_VARIANT(n)) => {
+                Some(ScalarValue::$SCALAR_VARIANT(n + $VALUE as $TY))
             }
-            Ok(())
-        } else {
-            Err(ExecutionError::General(
-                "Failed to downcast array".to_string(),
-            ))
-        }
+            Some(_) => {
+                return Err(ExecutionError::InternalError(
+                    "Unexpected ScalarValue variant".to_string(),
+                ))
+            }
+            None => Some(ScalarValue::$SCALAR_VARIANT($VALUE as $TY)),
+        };
     }};
 }
 
 struct SumAccumulator {
-    expr: Arc<dyn PhysicalExpr>,
     sum: Option<ScalarValue>,
 }
 
 impl Accumulator for SumAccumulator {
-    fn accumulate(
-        &mut self,
-        batch: &RecordBatch,
-        array: &ArrayRef,
-        row_index: usize,
-    ) -> Result<()> {
-        match self.expr.data_type(batch.schema())? {
-            DataType::Int8 => {
-                sum_accumulate!(self, array, row_index, Int8Array, Int64, i64)
+    fn accumulate_scalar(&mut self, value: Option<ScalarValue>) -> Result<()> {
+        if let Some(value) = value {
+            match value {
+                ScalarValue::Int8(value) => {
+                    sum_accumulate!(self, value, Int8Array, Int64, i64);
+                }
+                ScalarValue::Int16(value) => {
+                    sum_accumulate!(self, value, Int16Array, Int64, i64);
+                }
+                ScalarValue::Int32(value) => {
+                    sum_accumulate!(self, value, Int32Array, Int64, i64);
+                }
+                ScalarValue::Int64(value) => {
+                    sum_accumulate!(self, value, Int64Array, Int64, i64);
+                }
+                ScalarValue::UInt8(value) => {
+                    sum_accumulate!(self, value, UInt8Array, UInt64, u64);
+                }
+                ScalarValue::UInt16(value) => {
+                    sum_accumulate!(self, value, UInt16Array, UInt64, u64);
+                }
+                ScalarValue::UInt32(value) => {
+                    sum_accumulate!(self, value, UInt32Array, UInt64, u64);
+                }
+                ScalarValue::UInt64(value) => {
+                    sum_accumulate!(self, value, UInt64Array, UInt64, u64);
+                }
+                ScalarValue::Float32(value) => {
+                    sum_accumulate!(self, value, Float32Array, Float32, f32);
+                }
+                ScalarValue::Float64(value) => {
+                    sum_accumulate!(self, value, Float64Array, Float64, f64);
+                }
+                other => {
+                    return Err(ExecutionError::General(format!(
+                        "SUM does not support {:?}",
+                        other
+                    )))
+                }
             }
-            DataType::Int16 => {
-                sum_accumulate!(self, array, row_index, Int16Array, Int64, i64)
-            }
-            DataType::Int32 => {
-                sum_accumulate!(self, array, row_index, Int32Array, Int64, i64)
-            }
-            DataType::Int64 => {
-                sum_accumulate!(self, array, row_index, Int64Array, Int64, i64)
-            }
-            DataType::UInt8 => {
-                sum_accumulate!(self, array, row_index, UInt8Array, UInt64, u64)
-            }
-            DataType::UInt16 => {
-                sum_accumulate!(self, array, row_index, UInt16Array, UInt64, u64)
-            }
-            DataType::UInt32 => {
-                sum_accumulate!(self, array, row_index, UInt32Array, UInt64, u64)
-            }
-            DataType::UInt64 => {
-                sum_accumulate!(self, array, row_index, UInt64Array, UInt64, u64)
-            }
-            DataType::Float32 => {
-                sum_accumulate!(self, array, row_index, Float32Array, Float32, f32)
-            }
-            DataType::Float64 => {
-                sum_accumulate!(self, array, row_index, Float64Array, Float64, f64)
-            }
-            other => Err(ExecutionError::General(format!(
-                "SUM does not support {:?}",
-                other
-            ))),
         }
+        Ok(())
+    }
+
+    fn accumulate_batch(&mut self, array: &ArrayRef) -> Result<()> {
+        let accumulated_value = array_sum(array)?;
+        self.accumulate_scalar(accumulated_value)
     }
 
     fn get_value(&self) -> Result<Option<ScalarValue>> {
@@ -251,70 +448,65 @@ impl AggregateExpr for Avg {
 
     fn create_accumulator(&self) -> Rc<RefCell<dyn Accumulator>> {
         Rc::new(RefCell::new(AvgAccumulator {
-            expr: self.expr.clone(),
             sum: None,
             count: None,
         }))
     }
 
-    fn create_combiner(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
+    fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
         Arc::new(Avg::new(Arc::new(Column::new(column_index))))
     }
 }
 
 macro_rules! avg_accumulate {
-    ($SELF:ident, $ARRAY:ident, $ROW_INDEX:expr, $ARRAY_TYPE:ident) => {{
-        if let Some(array) = $ARRAY.as_any().downcast_ref::<$ARRAY_TYPE>() {
-            if $ARRAY.is_valid($ROW_INDEX) {
-                let value = array.value($ROW_INDEX);
-                match ($SELF.sum, $SELF.count) {
-                    (Some(sum), Some(count)) => {
-                        $SELF.sum = Some(sum + value as f64);
-                        $SELF.count = Some(count + 1);
-                    }
-                    _ => {
-                        $SELF.sum = Some(value as f64);
-                        $SELF.count = Some(1);
-                    }
-                };
+    ($SELF:ident, $VALUE:expr, $ARRAY_TYPE:ident) => {{
+        match ($SELF.sum, $SELF.count) {
+            (Some(sum), Some(count)) => {
+                $SELF.sum = Some(sum + $VALUE as f64);
+                $SELF.count = Some(count + 1);
             }
-            Ok(())
-        } else {
-            Err(ExecutionError::General(
-                "Failed to downcast array".to_string(),
-            ))
-        }
+            _ => {
+                $SELF.sum = Some($VALUE as f64);
+                $SELF.count = Some(1);
+            }
+        };
     }};
 }
 struct AvgAccumulator {
-    expr: Arc<dyn PhysicalExpr>,
     sum: Option<f64>,
     count: Option<i64>,
 }
 
 impl Accumulator for AvgAccumulator {
-    fn accumulate(
-        &mut self,
-        batch: &RecordBatch,
-        array: &ArrayRef,
-        row_index: usize,
-    ) -> Result<()> {
-        match self.expr.data_type(batch.schema())? {
-            DataType::Int8 => avg_accumulate!(self, array, row_index, Int8Array),
-            DataType::Int16 => avg_accumulate!(self, array, row_index, Int16Array),
-            DataType::Int32 => avg_accumulate!(self, array, row_index, Int32Array),
-            DataType::Int64 => avg_accumulate!(self, array, row_index, Int64Array),
-            DataType::UInt8 => avg_accumulate!(self, array, row_index, UInt8Array),
-            DataType::UInt16 => avg_accumulate!(self, array, row_index, UInt16Array),
-            DataType::UInt32 => avg_accumulate!(self, array, row_index, UInt32Array),
-            DataType::UInt64 => avg_accumulate!(self, array, row_index, UInt64Array),
-            DataType::Float32 => avg_accumulate!(self, array, row_index, Float32Array),
-            DataType::Float64 => avg_accumulate!(self, array, row_index, Float64Array),
-            other => Err(ExecutionError::General(format!(
-                "AVG does not support {:?}",
-                other
-            ))),
+    fn accumulate_scalar(&mut self, value: Option<ScalarValue>) -> Result<()> {
+        if let Some(value) = value {
+            match value {
+                ScalarValue::Int8(value) => avg_accumulate!(self, value, Int8Array),
+                ScalarValue::Int16(value) => avg_accumulate!(self, value, Int16Array),
+                ScalarValue::Int32(value) => avg_accumulate!(self, value, Int32Array),
+                ScalarValue::Int64(value) => avg_accumulate!(self, value, Int64Array),
+                ScalarValue::UInt8(value) => avg_accumulate!(self, value, UInt8Array),
+                ScalarValue::UInt16(value) => avg_accumulate!(self, value, UInt16Array),
+                ScalarValue::UInt32(value) => avg_accumulate!(self, value, UInt32Array),
+                ScalarValue::UInt64(value) => avg_accumulate!(self, value, UInt64Array),
+                ScalarValue::Float32(value) => avg_accumulate!(self, value, Float32Array),
+                ScalarValue::Float64(value) => avg_accumulate!(self, value, Float64Array),
+                other => {
+                    return Err(ExecutionError::General(format!(
+                        "AVG does not support {:?}",
+                        other
+                    )))
+                }
+            }
         }
+        Ok(())
+    }
+
+    fn accumulate_batch(&mut self, array: &ArrayRef) -> Result<()> {
+        for row in 0..array.len() {
+            self.accumulate_scalar(get_scalar_value(array, row)?)?;
+        }
+        Ok(())
     }
 
     fn get_value(&self) -> Result<Option<ScalarValue>> {
@@ -371,94 +563,85 @@ impl AggregateExpr for Max {
     }
 
     fn create_accumulator(&self) -> Rc<RefCell<dyn Accumulator>> {
-        Rc::new(RefCell::new(MaxAccumulator {
-            expr: self.expr.clone(),
-            max: None,
-        }))
+        Rc::new(RefCell::new(MaxAccumulator { max: None }))
     }
 
-    fn create_combiner(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
+    fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
         Arc::new(Max::new(Arc::new(Column::new(column_index))))
     }
 }
 
 macro_rules! max_accumulate {
-    ($SELF:ident, $ARRAY:ident, $ROW_INDEX:expr, $ARRAY_TYPE:ident, $SCALAR_VARIANT:ident, $TY:ty) => {{
-        if let Some(array) = $ARRAY.as_any().downcast_ref::<$ARRAY_TYPE>() {
-            if $ARRAY.is_valid($ROW_INDEX) {
-                let value = array.value($ROW_INDEX);
-                $SELF.max = match $SELF.max {
-                    Some(ScalarValue::$SCALAR_VARIANT(n)) => {
-                        if n > (value as $TY) {
-                            Some(ScalarValue::$SCALAR_VARIANT(n))
-                        } else {
-                            Some(ScalarValue::$SCALAR_VARIANT(value as $TY))
-                        }
-                    }
-                    Some(_) => {
-                        return Err(ExecutionError::InternalError(
-                            "Unexpected ScalarValue variant".to_string(),
-                        ))
-                    }
-                    None => Some(ScalarValue::$SCALAR_VARIANT(value as $TY)),
-                };
+    ($SELF:ident, $VALUE:expr, $ARRAY_TYPE:ident, $SCALAR_VARIANT:ident, $TY:ty) => {{
+        $SELF.max = match $SELF.max {
+            Some(ScalarValue::$SCALAR_VARIANT(n)) => {
+                if n > ($VALUE as $TY) {
+                    Some(ScalarValue::$SCALAR_VARIANT(n))
+                } else {
+                    Some(ScalarValue::$SCALAR_VARIANT($VALUE as $TY))
+                }
             }
-            Ok(())
-        } else {
-            Err(ExecutionError::General(
-                "Failed to downcast array".to_string(),
-            ))
-        }
+            Some(_) => {
+                return Err(ExecutionError::InternalError(
+                    "Unexpected ScalarValue variant".to_string(),
+                ))
+            }
+            None => Some(ScalarValue::$SCALAR_VARIANT($VALUE as $TY)),
+        };
     }};
 }
 struct MaxAccumulator {
-    expr: Arc<dyn PhysicalExpr>,
     max: Option<ScalarValue>,
 }
 
 impl Accumulator for MaxAccumulator {
-    fn accumulate(
-        &mut self,
-        batch: &RecordBatch,
-        array: &ArrayRef,
-        row_index: usize,
-    ) -> Result<()> {
-        match self.expr.data_type(batch.schema())? {
-            DataType::Int8 => {
-                max_accumulate!(self, array, row_index, Int8Array, Int64, i64)
+    fn accumulate_scalar(&mut self, value: Option<ScalarValue>) -> Result<()> {
+        if let Some(value) = value {
+            match value {
+                ScalarValue::Int8(value) => {
+                    max_accumulate!(self, value, Int8Array, Int64, i64);
+                }
+                ScalarValue::Int16(value) => {
+                    max_accumulate!(self, value, Int16Array, Int64, i64)
+                }
+                ScalarValue::Int32(value) => {
+                    max_accumulate!(self, value, Int32Array, Int64, i64)
+                }
+                ScalarValue::Int64(value) => {
+                    max_accumulate!(self, value, Int64Array, Int64, i64)
+                }
+                ScalarValue::UInt8(value) => {
+                    max_accumulate!(self, value, UInt8Array, UInt64, u64)
+                }
+                ScalarValue::UInt16(value) => {
+                    max_accumulate!(self, value, UInt16Array, UInt64, u64)
+                }
+                ScalarValue::UInt32(value) => {
+                    max_accumulate!(self, value, UInt32Array, UInt64, u64)
+                }
+                ScalarValue::UInt64(value) => {
+                    max_accumulate!(self, value, UInt64Array, UInt64, u64)
+                }
+                ScalarValue::Float32(value) => {
+                    max_accumulate!(self, value, Float32Array, Float32, f32)
+                }
+                ScalarValue::Float64(value) => {
+                    max_accumulate!(self, value, Float64Array, Float64, f64)
+                }
+                other => {
+                    return Err(ExecutionError::General(format!(
+                        "MAX does not support {:?}",
+                        other
+                    )))
+                }
             }
-            DataType::Int16 => {
-                max_accumulate!(self, array, row_index, Int16Array, Int64, i64)
-            }
-            DataType::Int32 => {
-                max_accumulate!(self, array, row_index, Int32Array, Int64, i64)
-            }
-            DataType::Int64 => {
-                max_accumulate!(self, array, row_index, Int64Array, Int64, i64)
-            }
-            DataType::UInt8 => {
-                max_accumulate!(self, array, row_index, UInt8Array, UInt64, u64)
-            }
-            DataType::UInt16 => {
-                max_accumulate!(self, array, row_index, UInt16Array, UInt64, u64)
-            }
-            DataType::UInt32 => {
-                max_accumulate!(self, array, row_index, UInt32Array, UInt64, u64)
-            }
-            DataType::UInt64 => {
-                max_accumulate!(self, array, row_index, UInt64Array, UInt64, u64)
-            }
-            DataType::Float32 => {
-                max_accumulate!(self, array, row_index, Float32Array, Float32, f32)
-            }
-            DataType::Float64 => {
-                max_accumulate!(self, array, row_index, Float64Array, Float64, f64)
-            }
-            other => Err(ExecutionError::General(format!(
-                "MAX does not support {:?}",
-                other
-            ))),
         }
+        Ok(())
+    }
+
+    fn accumulate_batch(&mut self, array: &ArrayRef) -> Result<()> {
+        self.accumulate_scalar(array_max(array)?)?;
+        Ok(())
     }
 
     fn get_value(&self) -> Result<Option<ScalarValue>> {
@@ -510,94 +693,85 @@ impl AggregateExpr for Min {
     }
 
     fn create_accumulator(&self) -> Rc<RefCell<dyn Accumulator>> {
-        Rc::new(RefCell::new(MinAccumulator {
-            expr: self.expr.clone(),
-            min: None,
-        }))
+        Rc::new(RefCell::new(MinAccumulator { min: None }))
     }
 
-    fn create_combiner(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
+    fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
         Arc::new(Min::new(Arc::new(Column::new(column_index))))
     }
 }
 
 macro_rules! min_accumulate {
-    ($SELF:ident, $ARRAY:ident, $ROW_INDEX:expr, $ARRAY_TYPE:ident, $SCALAR_VARIANT:ident, $TY:ty) => {{
-        if let Some(array) = $ARRAY.as_any().downcast_ref::<$ARRAY_TYPE>() {
-            if $ARRAY.is_valid($ROW_INDEX) {
-                let value = array.value($ROW_INDEX);
-                $SELF.min = match $SELF.min {
-                    Some(ScalarValue::$SCALAR_VARIANT(n)) => {
-                        if n < (value as $TY) {
-                            Some(ScalarValue::$SCALAR_VARIANT(n))
-                        } else {
-                            Some(ScalarValue::$SCALAR_VARIANT(value as $TY))
-                        }
-                    }
-                    Some(_) => {
-                        return Err(ExecutionError::InternalError(
-                            "Unexpected ScalarValue variant".to_string(),
-                        ))
-                    }
-                    None => Some(ScalarValue::$SCALAR_VARIANT(value as $TY)),
-                };
+    ($SELF:ident, $VALUE:expr, $ARRAY_TYPE:ident, $SCALAR_VARIANT:ident, $TY:ty) => {{
+        $SELF.min = match $SELF.min {
+            Some(ScalarValue::$SCALAR_VARIANT(n)) => {
+                if n < ($VALUE as $TY) {
+                    Some(ScalarValue::$SCALAR_VARIANT(n))
+                } else {
+                    Some(ScalarValue::$SCALAR_VARIANT($VALUE as $TY))
+                }
             }
-            Ok(())
-        } else {
-            Err(ExecutionError::General(
-                "Failed to downcast array".to_string(),
-            ))
-        }
+            Some(_) => {
+                return Err(ExecutionError::InternalError(
+                    "Unexpected ScalarValue variant".to_string(),
+                ))
+            }
+            None => Some(ScalarValue::$SCALAR_VARIANT($VALUE as $TY)),
+        };
     }};
 }
 struct MinAccumulator {
-    expr: Arc<dyn PhysicalExpr>,
     min: Option<ScalarValue>,
 }
 
 impl Accumulator for MinAccumulator {
-    fn accumulate(
-        &mut self,
-        batch: &RecordBatch,
-        array: &ArrayRef,
-        row_index: usize,
-    ) -> Result<()> {
-        match self.expr.data_type(batch.schema())? {
-            DataType::Int8 => {
-                min_accumulate!(self, array, row_index, Int8Array, Int64, i64)
+    fn accumulate_scalar(&mut self, value: Option<ScalarValue>) -> Result<()> {
+        if let Some(value) = value {
+            match value {
+                ScalarValue::Int8(value) => {
+                    min_accumulate!(self, value, Int8Array, Int64, i64);
+                }
+                ScalarValue::Int16(value) => {
+                    min_accumulate!(self, value, Int16Array, Int64, i64)
+                }
+                ScalarValue::Int32(value) => {
+                    min_accumulate!(self, value, Int32Array, Int64, i64)
+                }
+                ScalarValue::Int64(value) => {
+                    min_accumulate!(self, value, Int64Array, Int64, i64)
+                }
+                ScalarValue::UInt8(value) => {
+                    min_accumulate!(self, value, UInt8Array, UInt64, u64)
+                }
+                ScalarValue::UInt16(value) => {
+                    min_accumulate!(self, value, UInt16Array, UInt64, u64)
+                }
+                ScalarValue::UInt32(value) => {
+                    min_accumulate!(self, value, UInt32Array, UInt64, u64)
+                }
+                ScalarValue::UInt64(value) => {
+                    min_accumulate!(self, value, UInt64Array, UInt64, u64)
+                }
+                ScalarValue::Float32(value) => {
+                    min_accumulate!(self, value, Float32Array, Float32, f32)
+                }
+                ScalarValue::Float64(value) => {
+                    min_accumulate!(self, value, Float64Array, Float64, f64)
+                }
+                other => {
+                    return Err(ExecutionError::General(format!(
+                        "MIN does not support {:?}",
+                        other
+                    )))
+                }
             }
-            DataType::Int16 => {
-                min_accumulate!(self, array, row_index, Int16Array, Int64, i64)
-            }
-            DataType::Int32 => {
-                min_accumulate!(self, array, row_index, Int32Array, Int64, i64)
-            }
-            DataType::Int64 => {
-                min_accumulate!(self, array, row_index, Int64Array, Int64, i64)
-            }
-            DataType::UInt8 => {
-                min_accumulate!(self, array, row_index, UInt8Array, UInt64, u64)
-            }
-            DataType::UInt16 => {
-                min_accumulate!(self, array, row_index, UInt16Array, UInt64, u64)
-            }
-            DataType::UInt32 => {
-                min_accumulate!(self, array, row_index, UInt32Array, UInt64, u64)
-            }
-            DataType::UInt64 => {
-                min_accumulate!(self, array, row_index, UInt64Array, UInt64, u64)
-            }
-            DataType::Float32 => {
-                min_accumulate!(self, array, row_index, Float32Array, Float32, f32)
-            }
-            DataType::Float64 => {
-                min_accumulate!(self, array, row_index, Float64Array, Float64, f64)
-            }
-            other => Err(ExecutionError::General(format!(
-                "MIN does not support {:?}",
-                other
-            ))),
         }
+        Ok(())
+    }
+
+    fn accumulate_batch(&mut self, array: &ArrayRef) -> Result<()> {
+        self.accumulate_scalar(array_min(array)?)?;
+        Ok(())
     }
 
     fn get_value(&self) -> Result<Option<ScalarValue>> {
@@ -640,7 +814,7 @@ impl AggregateExpr for Count {
         Rc::new(RefCell::new(CountAccumulator { count: 0 }))
     }
 
-    fn create_combiner(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
+    fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
         Arc::new(Sum::new(Arc::new(Column::new(column_index))))
     }
 }
@@ -650,15 +824,15 @@ struct CountAccumulator {
 }
 
 impl Accumulator for CountAccumulator {
-    fn accumulate(
-        &mut self,
-        _batch: &RecordBatch,
-        array: &ArrayRef,
-        row_index: usize,
-    ) -> Result<()> {
-        if array.is_valid(row_index) {
+    fn accumulate_scalar(&mut self, value: Option<ScalarValue>) -> Result<()> {
+        if value.is_some() {
             self.count += 1;
         }
+        Ok(())
+    }
+
+    fn accumulate_batch(&mut self, array: &ArrayRef) -> Result<()> {
+        self.count += array.len() as u64 - array.null_count() as u64;
         Ok(())
     }
 
@@ -945,6 +1119,7 @@ pub fn lit(value: ScalarValue) -> Arc<dyn PhysicalExpr> {
 mod tests {
     use super::*;
     use crate::error::Result;
+    use crate::execution::physical_plan::common::get_scalar_value;
     use arrow::array::{BinaryArray, PrimitiveArray};
     use arrow::datatypes::*;
 
@@ -1092,7 +1267,7 @@ mod tests {
         assert_eq!("SUM".to_string(), sum.name());
         assert_eq!(DataType::Int64, sum.data_type(&schema)?);
 
-        let combiner = sum.create_combiner(0);
+        let combiner = sum.create_reducer(0);
         assert_eq!("SUM".to_string(), combiner.name());
         assert_eq!(DataType::Int64, combiner.data_type(&schema)?);
 
@@ -1107,7 +1282,7 @@ mod tests {
         assert_eq!("MAX".to_string(), max.name());
         assert_eq!(DataType::Int64, max.data_type(&schema)?);
 
-        let combiner = max.create_combiner(0);
+        let combiner = max.create_reducer(0);
         assert_eq!("MAX".to_string(), combiner.name());
         assert_eq!(DataType::Int64, combiner.data_type(&schema)?);
 
@@ -1122,7 +1297,7 @@ mod tests {
         assert_eq!("MIN".to_string(), min.name());
         assert_eq!(DataType::Int64, min.data_type(&schema)?);
 
-        let combiner = min.create_combiner(0);
+        let combiner = min.create_reducer(0);
         assert_eq!("MIN".to_string(), combiner.name());
         assert_eq!(DataType::Int64, combiner.data_type(&schema)?);
 
@@ -1136,7 +1311,7 @@ mod tests {
         assert_eq!("AVG".to_string(), avg.name());
         assert_eq!(DataType::Float64, avg.data_type(&schema)?);
 
-        let combiner = avg.create_combiner(0);
+        let combiner = avg.create_reducer(0);
         assert_eq!("AVG".to_string(), combiner.name());
         assert_eq!(DataType::Float64, combiner.data_type(&schema)?);
 
@@ -1473,7 +1648,7 @@ mod tests {
         let input = sum.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
         for i in 0..batch.num_rows() {
-            accum.accumulate(&batch, &input, i)?;
+            accum.accumulate_scalar(get_scalar_value(&input, i)?)?;
         }
         accum.get_value()
     }
@@ -1484,7 +1659,7 @@ mod tests {
         let input = max.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
         for i in 0..batch.num_rows() {
-            accum.accumulate(&batch, &input, i)?;
+            accum.accumulate_scalar(get_scalar_value(&input, i)?)?;
         }
         accum.get_value()
     }
@@ -1495,7 +1670,7 @@ mod tests {
         let input = min.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
         for i in 0..batch.num_rows() {
-            accum.accumulate(&batch, &input, i)?;
+            accum.accumulate_scalar(get_scalar_value(&input, i)?)?;
         }
         accum.get_value()
     }
@@ -1506,7 +1681,7 @@ mod tests {
         let input = count.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
         for i in 0..batch.num_rows() {
-            accum.accumulate(&batch, &input, i)?;
+            accum.accumulate_scalar(get_scalar_value(&input, i)?)?;
         }
         accum.get_value()
     }
@@ -1517,7 +1692,7 @@ mod tests {
         let input = avg.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
         for i in 0..batch.num_rows() {
-            accum.accumulate(&batch, &input, i)?;
+            accum.accumulate_scalar(get_scalar_value(&input, i)?)?;
         }
         accum.get_value()
     }

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -75,210 +75,6 @@ pub fn col(i: usize) -> Arc<dyn PhysicalExpr> {
     Arc::new(Column::new(i))
 }
 
-fn array_min(array: &ArrayRef) -> Result<Option<ScalarValue>> {
-    match array.data_type() {
-        DataType::UInt8 => {
-            match compute::min(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt8(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt16 => {
-            match compute::min(array.as_any().downcast_ref::<UInt16Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt16(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt32 => {
-            match compute::min(array.as_any().downcast_ref::<UInt32Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt32(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt64 => {
-            match compute::min(array.as_any().downcast_ref::<UInt64Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt64(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int8 => {
-            match compute::min(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int8(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int16 => {
-            match compute::min(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int16(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int32 => {
-            match compute::min(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int32(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int64 => {
-            match compute::min(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int64(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Float32 => {
-            match compute::min(array.as_any().downcast_ref::<Float32Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Float32(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Float64 => {
-            match compute::min(array.as_any().downcast_ref::<Float64Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Float64(n))),
-                None => Ok(None),
-            }
-        }
-        _ => Err(ExecutionError::ExecutionError(
-            "Unsupported data type for MIN".to_string(),
-        )),
-    }
-}
-
-fn array_max(array: &ArrayRef) -> Result<Option<ScalarValue>> {
-    match array.data_type() {
-        DataType::UInt8 => {
-            match compute::max(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt8(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt16 => {
-            match compute::max(array.as_any().downcast_ref::<UInt16Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt16(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt32 => {
-            match compute::max(array.as_any().downcast_ref::<UInt32Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt32(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt64 => {
-            match compute::max(array.as_any().downcast_ref::<UInt64Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt64(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int8 => {
-            match compute::max(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int8(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int16 => {
-            match compute::max(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int16(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int32 => {
-            match compute::max(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int32(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int64 => {
-            match compute::max(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int64(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Float32 => {
-            match compute::max(array.as_any().downcast_ref::<Float32Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Float32(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Float64 => {
-            match compute::max(array.as_any().downcast_ref::<Float64Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Float64(n))),
-                None => Ok(None),
-            }
-        }
-        _ => Err(ExecutionError::ExecutionError(
-            "Unsupported data type for MAX".to_string(),
-        )),
-    }
-}
-
-fn array_sum(array: &ArrayRef) -> Result<Option<ScalarValue>> {
-    match array.data_type() {
-        DataType::UInt8 => {
-            match compute::sum(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt8(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt16 => {
-            match compute::sum(array.as_any().downcast_ref::<UInt16Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt16(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt32 => {
-            match compute::sum(array.as_any().downcast_ref::<UInt32Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt32(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::UInt64 => {
-            match compute::sum(array.as_any().downcast_ref::<UInt64Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::UInt64(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int8 => {
-            match compute::sum(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int8(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int16 => {
-            match compute::sum(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int16(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int32 => {
-            match compute::sum(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int32(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Int64 => {
-            match compute::sum(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Int64(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Float32 => {
-            match compute::sum(array.as_any().downcast_ref::<Float32Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Float32(n))),
-                None => Ok(None),
-            }
-        }
-        DataType::Float64 => {
-            match compute::sum(array.as_any().downcast_ref::<Float64Array>().unwrap()) {
-                Some(n) => Ok(Some(ScalarValue::Float64(n))),
-                None => Ok(None),
-            }
-        }
-        _ => Err(ExecutionError::ExecutionError(
-            "Unsupported data type for SUM".to_string(),
-        )),
-    }
-}
-
 /// SUM aggregate expression
 pub struct Sum {
     expr: Arc<dyn PhysicalExpr>,
@@ -392,8 +188,77 @@ impl Accumulator for SumAccumulator {
     }
 
     fn accumulate_batch(&mut self, array: &ArrayRef) -> Result<()> {
-        let accumulated_value = array_sum(array)?;
-        self.accumulate_scalar(accumulated_value)
+        let sum = match array.data_type() {
+            DataType::UInt8 => {
+                match compute::sum(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::UInt8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt16 => {
+                match compute::sum(array.as_any().downcast_ref::<UInt16Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt32 => {
+                match compute::sum(array.as_any().downcast_ref::<UInt32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt64 => {
+                match compute::sum(array.as_any().downcast_ref::<UInt64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int8 => {
+                match compute::sum(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int16 => {
+                match compute::sum(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int32 => {
+                match compute::sum(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int64 => {
+                match compute::sum(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float32 => {
+                match compute::sum(array.as_any().downcast_ref::<Float32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float64 => {
+                match compute::sum(array.as_any().downcast_ref::<Float64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float64(n))),
+                    None => Ok(None),
+                }
+            }
+            _ => Err(ExecutionError::ExecutionError(
+                "Unsupported data type for SUM".to_string(),
+            )),
+        }?;
+        self.accumulate_scalar(sum)
     }
 
     fn get_value(&self) -> Result<Option<ScalarValue>> {
@@ -640,8 +505,77 @@ impl Accumulator for MaxAccumulator {
     }
 
     fn accumulate_batch(&mut self, array: &ArrayRef) -> Result<()> {
-        self.accumulate_scalar(array_max(array)?)?;
-        Ok(())
+        let max = match array.data_type() {
+            DataType::UInt8 => {
+                match compute::max(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::UInt8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt16 => {
+                match compute::max(array.as_any().downcast_ref::<UInt16Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt32 => {
+                match compute::max(array.as_any().downcast_ref::<UInt32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt64 => {
+                match compute::max(array.as_any().downcast_ref::<UInt64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int8 => {
+                match compute::max(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int16 => {
+                match compute::max(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int32 => {
+                match compute::max(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int64 => {
+                match compute::max(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float32 => {
+                match compute::max(array.as_any().downcast_ref::<Float32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float64 => {
+                match compute::max(array.as_any().downcast_ref::<Float64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float64(n))),
+                    None => Ok(None),
+                }
+            }
+            _ => Err(ExecutionError::ExecutionError(
+                "Unsupported data type for MAX".to_string(),
+            )),
+        }?;
+        self.accumulate_scalar(max)
     }
 
     fn get_value(&self) -> Result<Option<ScalarValue>> {
@@ -770,8 +704,77 @@ impl Accumulator for MinAccumulator {
     }
 
     fn accumulate_batch(&mut self, array: &ArrayRef) -> Result<()> {
-        self.accumulate_scalar(array_min(array)?)?;
-        Ok(())
+        let min = match array.data_type() {
+            DataType::UInt8 => {
+                match compute::min(array.as_any().downcast_ref::<UInt8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::UInt8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt16 => {
+                match compute::min(array.as_any().downcast_ref::<UInt16Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt32 => {
+                match compute::min(array.as_any().downcast_ref::<UInt32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::UInt64 => {
+                match compute::min(array.as_any().downcast_ref::<UInt64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::UInt64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int8 => {
+                match compute::min(array.as_any().downcast_ref::<Int8Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int8(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int16 => {
+                match compute::min(array.as_any().downcast_ref::<Int16Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int16(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int32 => {
+                match compute::min(array.as_any().downcast_ref::<Int32Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Int64 => {
+                match compute::min(array.as_any().downcast_ref::<Int64Array>().unwrap()) {
+                    Some(n) => Ok(Some(ScalarValue::Int64(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float32 => {
+                match compute::min(array.as_any().downcast_ref::<Float32Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float32(n))),
+                    None => Ok(None),
+                }
+            }
+            DataType::Float64 => {
+                match compute::min(array.as_any().downcast_ref::<Float64Array>().unwrap())
+                {
+                    Some(n) => Ok(Some(ScalarValue::Float64(n))),
+                    None => Ok(None),
+                }
+            }
+            _ => Err(ExecutionError::ExecutionError(
+                "Unsupported data type for MIN".to_string(),
+            )),
+        }?;
+        self.accumulate_scalar(min)
     }
 
     fn get_value(&self) -> Result<Option<ScalarValue>> {

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -72,18 +72,15 @@ pub trait AggregateExpr: Send + Sync {
     /// Create an aggregate expression for combining the results of accumulators from partitions.
     /// For example, to combine the results of a parallel SUM we just need to do another SUM, but
     /// to combine the results of parallel COUNT we would also use SUM.
-    fn create_combiner(&self, column_index: usize) -> Arc<dyn AggregateExpr>;
+    fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr>;
 }
 
 /// Aggregate accumulator
 pub trait Accumulator {
     /// Update the accumulator based on a row in a batch
-    fn accumulate(
-        &mut self,
-        batch: &RecordBatch,
-        input: &ArrayRef,
-        row_index: usize,
-    ) -> Result<()>;
+    fn accumulate_scalar(&mut self, value: Option<ScalarValue>) -> Result<()>;
+    /// Update the accumulator based on an array in a batch
+    fn accumulate_batch(&mut self, array: &ArrayRef) -> Result<()>;
     /// Get the final value for the accumulator
     fn get_value(&self) -> Result<Option<ScalarValue>>;
 }


### PR DESCRIPTION
45% improvement of benchmark for aggregate operations that do not have a GROUP BY. This is an optimization that we already had in the original query execution logic and I have just ported that over to the new physical query plan.

```
aggregate_query_no_group_by                                                                             
                        time:   [13.228 us 13.246 us 13.264 us]
                        change: [-45.563% -45.218% -44.879%] (p = 0.00 < 0.05)
                        Performance has improved.
```