### PR TITLE
ARROW-6834: [C++][TRIAGE] Pin gtest version 1.8.1 to unblock Appveyor builds

### DIFF
--- a/ci/conda_env_cpp.yml
+++ b/ci/conda_env_cpp.yml
@@ -27,7 +27,7 @@ gflags
 glog
 gmock>=1.8.1
 grpc-cpp>=1.21.4
-gtest>=1.8.1
+gtest=1.8.1
 libprotobuf
 lz4-c
 ninja


### PR DESCRIPTION
Let's leave the JIRA issue open until we can see if the project can be upgraded to googletest 1.10.0