### PR TITLE
ARROW-6832: [R] Implement Codec::IsAvailable

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -236,6 +236,10 @@ util___Codec__name <- function(codec){
     .Call(`_arrow_util___Codec__name` , codec)
 }
 
+util___Codec__IsAvailable <- function(codec){
+    .Call(`_arrow_util___Codec__IsAvailable` , codec)
+}
+
 io___CompressedOutputStream__Make <- function(codec, raw){
     .Call(`_arrow_io___CompressedOutputStream__Make` , codec, raw)
 }

--- a/r/R/compression.R
+++ b/r/R/compression.R
@@ -52,6 +52,10 @@ Codec$create <- function(type = "gzip", compression_level = NA) {
   type
 }
 
+codec_is_available <- function(type) {
+  util___Codec__IsAvailable(compression_from_name(type))
+}
+
 compression_from_name <- function(name) {
   map_int(name, ~CompressionType[[match.arg(toupper(.x), names(CompressionType))]])
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -922,6 +922,21 @@ RcppExport SEXP _arrow_util___Codec__name(SEXP codec_sexp){
 
 // compression.cpp
 #if defined(ARROW_R_WITH_ARROW)
+bool util___Codec__IsAvailable(arrow::Compression::type codec);
+RcppExport SEXP _arrow_util___Codec__IsAvailable(SEXP codec_sexp){
+BEGIN_RCPP
+	Rcpp::traits::input_parameter<arrow::Compression::type>::type codec(codec_sexp);
+	return Rcpp::wrap(util___Codec__IsAvailable(codec));
+END_RCPP
+}
+#else
+RcppExport SEXP _arrow_util___Codec__IsAvailable(SEXP codec_sexp){
+	Rf_error("Cannot call util___Codec__IsAvailable(). Please use arrow::install_arrow() to install required runtime libraries. ");
+}
+#endif
+
+// compression.cpp
+#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::io::CompressedOutputStream> io___CompressedOutputStream__Make(const std::unique_ptr<arrow::util::Codec>& codec, const std::shared_ptr<arrow::io::OutputStream>& raw);
 RcppExport SEXP _arrow_io___CompressedOutputStream__Make(SEXP codec_sexp, SEXP raw_sexp){
 BEGIN_RCPP
@@ -5009,6 +5024,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_ChunkedArray__Equals", (DL_FUNC) &_arrow_ChunkedArray__Equals, 2}, 
 		{ "_arrow_util___Codec__Create", (DL_FUNC) &_arrow_util___Codec__Create, 2}, 
 		{ "_arrow_util___Codec__name", (DL_FUNC) &_arrow_util___Codec__name, 1}, 
+		{ "_arrow_util___Codec__IsAvailable", (DL_FUNC) &_arrow_util___Codec__IsAvailable, 1}, 
 		{ "_arrow_io___CompressedOutputStream__Make", (DL_FUNC) &_arrow_io___CompressedOutputStream__Make, 2}, 
 		{ "_arrow_io___CompressedInputStream__Make", (DL_FUNC) &_arrow_io___CompressedInputStream__Make, 2}, 
 		{ "_arrow_compute___CastOptions__initialize", (DL_FUNC) &_arrow_compute___CastOptions__initialize, 3}, 

--- a/r/src/compression.cpp
+++ b/r/src/compression.cpp
@@ -33,6 +33,11 @@ std::string util___Codec__name(const std::unique_ptr<arrow::util::Codec>& codec)
 }
 
 // [[arrow::export]]
+bool util___Codec__IsAvailable(arrow::Compression::type codec) {
+  return arrow::util::Codec::IsAvailable(codec);
+}
+
+// [[arrow::export]]
 std::shared_ptr<arrow::io::CompressedOutputStream> io___CompressedOutputStream__Make(
     const std::unique_ptr<arrow::util::Codec>& codec,
     const std::shared_ptr<arrow::io::OutputStream>& raw) {

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+skip_if_not_available <- function(feature) {
+  # This is currently for compression only but we can extend to other features
+  if (!codec_is_available(feature)) {
+    skip(paste("Arrow C++ not built with support for", feature))
+  }
+}

--- a/r/tests/testthat/test-compressed.R
+++ b/r/tests/testthat/test-compressed.R
@@ -17,7 +17,24 @@
 
 context("Compressed.*Stream")
 
+test_that("codec_is_available", {
+  expect_true(codec_is_available("uncompressed")) # Always true
+  expect_error(codec_is_available("sdfasdf"), "'arg' should be one of")
+  skip_if_not_available("gzip")
+  expect_true(codec_is_available("gzip"))
+  expect_true(codec_is_available("GZIP"))
+})
+
+test_that("Codec attributes", {
+  skip_if_not_available("gzip")
+  cod <- Codec$create("gzip")
+  expect_equal(cod$name, "gzip")
+  # TODO: implement $level
+  expect_error(cod$level)
+})
+
 test_that("can write Buffer to CompressedOutputStream and read back in CompressedInputStream", {
+  skip_if_not_available("gzip")
   buf <- buffer(as.raw(sample(0:255, size = 1024, replace = TRUE)))
 
   tf1 <- tempfile()

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -20,7 +20,7 @@ context("Parquet file reading/writing")
 pq_file <- system.file("v0.7.1.parquet", package="arrow")
 
 test_that("reading a known Parquet file to tibble", {
-  skip_if_not_available("parquet")
+  skip_if_not_available("snappy")
   df <- read_parquet(pq_file)
   expect_true(tibble::is_tibble(df))
   expect_identical(dim(df), c(10L, 11L))
@@ -38,7 +38,7 @@ test_that("simple int column roundtrip", {
 })
 
 test_that("read_parquet() supports col_select", {
-  skip_if_not_available("parquet")
+  skip_if_not_available("snappy")
   df <- read_parquet(pq_file, col_select = c(x, y, z))
   expect_equal(names(df), c("x", "y", "z"))
 
@@ -47,7 +47,7 @@ test_that("read_parquet() supports col_select", {
 })
 
 test_that("read_parquet() with raw data", {
-  skip_if_not_available("parquet")
+  skip_if_not_available("snappy")
   test_raw <- readBin(pq_file, what = "raw", n = 5000)
   df <- read_parquet(test_raw)
   expect_identical(dim(df), c(10L, 11L))

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -51,6 +51,7 @@ test_that("read_parquet() with raw data", {
 })
 
 test_that("write_parquet() handles various compression= specs", {
+  skip_if_not_available("snappy")
   tab <- Table$create(x1 = 1:5, x2 = 1:5, y = 1:5)
 
   expect_parquet_roundtrip(tab, compression = "snappy")
@@ -59,6 +60,7 @@ test_that("write_parquet() handles various compression= specs", {
 })
 
 test_that("write_parquet() handles various compression_level= specs", {
+  skip_if_not_available("gzip")
   tab <- Table$create(x1 = 1:5, x2 = 1:5, y = 1:5)
 
   expect_parquet_roundtrip(tab, compression = "gzip", compression_level = 4)

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -20,6 +20,7 @@ context("Parquet file reading/writing")
 pq_file <- system.file("v0.7.1.parquet", package="arrow")
 
 test_that("reading a known Parquet file to tibble", {
+  skip_if_not_available("parquet")
   df <- read_parquet(pq_file)
   expect_true(tibble::is_tibble(df))
   expect_identical(dim(df), c(10L, 11L))
@@ -37,6 +38,7 @@ test_that("simple int column roundtrip", {
 })
 
 test_that("read_parquet() supports col_select", {
+  skip_if_not_available("parquet")
   df <- read_parquet(pq_file, col_select = c(x, y, z))
   expect_equal(names(df), c("x", "y", "z"))
 
@@ -45,6 +47,7 @@ test_that("read_parquet() supports col_select", {
 })
 
 test_that("read_parquet() with raw data", {
+  skip_if_not_available("parquet")
   test_raw <- readBin(pq_file, what = "raw", n = 5000)
   df <- read_parquet(test_raw)
   expect_identical(dim(df), c(10L, 11L))


### PR DESCRIPTION
Adds `codec_is_available()` and a test skip helper that uses it. Also fills in some missing test coverage nearby.