### PR TITLE
ARROW-6847: [C++] Add range_expression adapter to Iterator

### DIFF
--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -215,6 +215,9 @@ class Result {
     return *this;
   }
 
+  /// Compare to another Result.
+  bool operator==(const Result& other) const { return variant_ == other.variant_; }
+
   /// Indicates whether the object contains a `T` value.  Generally instead
   /// of accessing this directly you will want to use ASSIGN_OR_RAISE defined
   /// below.

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "arrow/status.h"
+#include "arrow/util/compare.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/variant.h"
 
@@ -86,7 +87,7 @@ ARROW_EXPORT void DieWithMessage(const std::string& msg);
 ///   arrow::Result<int> CalculateFoo();
 /// ```
 template <class T>
-class Result {
+class Result : public util::EqualityComparable<Result<T>> {
   template <typename U>
   friend class Result;
   using VariantType = arrow::util::variant<T, Status, const char*>;
@@ -216,7 +217,7 @@ class Result {
   }
 
   /// Compare to another Result.
-  bool operator==(const Result& other) const { return variant_ == other.variant_; }
+  bool Equals(const Result& other) const { return variant_ == other.variant_; }
 
   /// Indicates whether the object contains a `T` value.  Generally instead
   /// of accessing this directly you will want to use ASSIGN_OR_RAISE defined

--- a/cpp/src/arrow/result_test.cc
+++ b/cpp/src/arrow/result_test.cc
@@ -585,5 +585,23 @@ TEST(ResultTest, TemplateMoveConstruct) {
   //  NOLINTNEXTLINE use after move.
 }
 
+TEST(ResultTest, Equality) {
+  EXPECT_EQ(Result<int>(), Result<int>());
+  EXPECT_EQ(Result<int>(3), Result<int>(3));
+  EXPECT_EQ(Result<int>(Status::Invalid("error")), Result<int>(Status::Invalid("error")));
+
+  EXPECT_NE(Result<int>(), Result<int>(3));
+  EXPECT_NE(Result<int>(Status::Invalid("error")), Result<int>(3));
+  EXPECT_NE(Result<int>(3333), Result<int>(0));
+  EXPECT_NE(Result<int>(Status::Invalid("error")),
+            Result<int>(Status::Invalid("other error")));
+
+  Result<int> moved_from(3);
+  auto moved_to = std::move(moved_from);
+  //  NOLINTNEXTLINE use after move.
+  EXPECT_NE(Result<int>(3), moved_from);
+  //  NOLINTNEXTLINE use after move.
+}
+
 }  // namespace
 }  // namespace arrow

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -125,7 +125,8 @@ class ARROW_EXPORT StatusDetail {
 ///
 /// Additionally, if an error occurred, a specific error message is generally
 /// attached.
-class ARROW_EXPORT Status : public util::EqualityComparable<Status> {
+class ARROW_EXPORT Status : public util::EqualityComparable<Status>,
+                            public util::ToStringOstreamable<Status> {
  public:
   // Create a success status.
   Status() noexcept : state_(NULLPTR) {}
@@ -347,11 +348,6 @@ class ARROW_EXPORT Status : public util::EqualityComparable<Status> {
   void CopyFrom(const Status& s);
   inline void MoveFrom(Status& s);
 };
-
-static inline std::ostream& operator<<(std::ostream& os, const Status& x) {
-  os << x.ToString();
-  return os;
-}
 
 void Status::MoveFrom(Status& s) {
   delete state_;

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <utility>
 
+#include "arrow/util/compare.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/string_builder.h"
 #include "arrow/util/visibility.h"
@@ -124,7 +125,7 @@ class ARROW_EXPORT StatusDetail {
 ///
 /// Additionally, if an error occurred, a specific error message is generally
 /// attached.
-class ARROW_EXPORT Status {
+class ARROW_EXPORT Status : public util::EqualityComparable<Status> {
  public:
   // Create a success status.
   Status() noexcept : state_(NULLPTR) {}
@@ -148,7 +149,7 @@ class ARROW_EXPORT Status {
   inline Status(Status&& s) noexcept;
   inline Status& operator=(Status&& s) noexcept;
 
-  inline bool operator==(const Status& s) const noexcept;
+  inline bool Equals(const Status& s) const;
 
   // AND the statuses.
   inline Status operator&(const Status& s) const noexcept;
@@ -377,7 +378,7 @@ Status& Status::operator=(Status&& s) noexcept {
   return *this;
 }
 
-bool Status::operator==(const Status& s) const noexcept {
+bool Status::Equals(const Status& s) const {
   if (state_ == s.state_) {
     return true;
   }

--- a/cpp/src/arrow/status_test.cc
+++ b/cpp/src/arrow/status_test.cc
@@ -106,4 +106,12 @@ TEST(StatusTest, AndStatus) {
   ASSERT_TRUE(res.IsInvalid());
 }
 
+TEST(StatusTest, TestEquality) {
+  ASSERT_EQ(Status(), Status::OK());
+  ASSERT_EQ(Status::Invalid("error"), Status::Invalid("error"));
+
+  ASSERT_NE(Status::Invalid("error"), Status::OK());
+  ASSERT_NE(Status::Invalid("error"), Status::Invalid("other error"));
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/util/compare.h
+++ b/cpp/src/arrow/util/compare.h
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "arrow/util/macros.h"
+
+namespace arrow {
+namespace util {
+
+/// CRTP helper for declaring equality comparison. Defines operator== and operator!=
+template <typename T>
+class EqualityComparable {
+ public:
+  ~EqualityComparable() {
+    static_assert(
+        std::is_same<decltype(std::declval<const T>().Equals(std::declval<const T>())),
+                     bool>::value,
+        "EqualityComparable depends on the method T::Equals(const T&) const");
+  }
+
+  template <typename... Extra>
+  bool Equals(const std::shared_ptr<T>& other, Extra&&... extra) const {
+    if (other == NULLPTR) {
+      return false;
+    }
+    return cast().Equals(*other, std::forward<Extra>(extra)...);
+  }
+
+  bool operator==(const T& other) const { return cast().Equals(other); }
+
+  bool operator!=(const T& other) const { return !(cast() == other); }
+
+ private:
+  const T& cast() const { return static_cast<const T&>(*this); }
+};
+
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -26,6 +26,7 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/util/compare.h"
 #include "arrow/util/functional.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
@@ -45,7 +46,7 @@ struct IterationTraits {
 
 /// \brief A generic Iterator that can return errors
 template <typename T>
-class Iterator {
+class Iterator : public util::EqualityComparable<Iterator<T>> {
  public:
   /// \brief Iterator may be constructed from any type which has a member function
   /// with signature Status Next(T*);
@@ -89,7 +90,7 @@ class Iterator {
   }
 
   /// Iterators will only compare equal if they are both null
-  bool operator==(const Iterator& other) const { return ptr_ == other.ptr_; }
+  bool Equals(const Iterator& other) const { return ptr_ == other.ptr_; }
 
   explicit operator bool() const { return ptr_ != NULLPTR; }
 

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -89,7 +89,9 @@ class Iterator : public util::EqualityComparable<Iterator<T>> {
     return status;
   }
 
-  /// Iterators will only compare equal if they are both null
+  /// Iterators will only compare equal if they are both null.
+  /// Equality comparability is required to make an Iterator of Iterators
+  /// (to check for the end condition).
   bool Equals(const Iterator& other) const { return ptr_ == other.ptr_; }
 
   explicit operator bool() const { return ptr_ != NULLPTR; }

--- a/cpp/src/arrow/util/iterator_test.cc
+++ b/cpp/src/arrow/util/iterator_test.cc
@@ -177,6 +177,31 @@ TEST(TestVectorIterator, Basic) {
   AssertIteratorNoMatch({1, 2, 3, 1}, VectorIt({1, 2, 3}));
 }
 
+TEST(TestVectorIterator, RangeForLoop) {
+  std::vector<TestInt> ints = {1, 2, 3, 4};
+
+  auto ints_it = ints.begin();
+  Status status;
+  for (auto v : VectorIt(ints).AsRange(&status)) {
+    ASSERT_EQ(v, *ints_it++);
+  }
+  ASSERT_OK(status);
+  ASSERT_EQ(ints_it, ints.end());
+
+  std::vector<std::unique_ptr<TestInt>> vec;
+  for (TestInt i : ints) {
+    vec.emplace_back(new TestInt(i));
+  }
+
+  // also works with move only types
+  ints_it = ints.begin();
+  for (auto v : MakeVectorIterator(std::move(vec)).AsRange(&status)) {
+    ASSERT_EQ(*v, *ints_it++);
+  }
+  ASSERT_OK(status);
+  ASSERT_EQ(ints_it, ints.end());
+}
+
 TEST(FilterIterator, Basic) {
   AssertIteratorMatch({1, 2, 3, 4}, FilterIt(VectorIt({1, 2, 3, 4}),
                                              [](TestInt i, TestInt* o, bool* accept) {

--- a/cpp/src/arrow/util/iterator_test.cc
+++ b/cpp/src/arrow/util/iterator_test.cc
@@ -202,6 +202,24 @@ TEST(TestVectorIterator, RangeForLoop) {
   ASSERT_EQ(ints_it, ints.end());
 }
 
+TEST(TestFunctionIterator, RangeForLoop) {
+  int i = 0;
+  auto fails_at_3 = MakeFunctionIterator([&](TestInt* out) {
+    if (i >= 3) {
+      return Status::IndexError("fails at 3");
+    }
+    out->value = i++;
+    return Status::OK();
+  });
+  Status status;
+  int j = 0;
+  for (TestInt i : fails_at_3.AsRange(&status)) {
+    ASSERT_LT(i.value, 3);
+    ASSERT_EQ(i.value, j++);
+  }
+  ASSERT_RAISES(IndexError, status);
+}
+
 TEST(FilterIterator, Basic) {
   AssertIteratorMatch({1, 2, 3, 4}, FilterIt(VectorIt({1, 2, 3, 4}),
                                              [](TestInt i, TestInt* o, bool* accept) {

--- a/cpp/src/arrow/util/string_builder.h
+++ b/cpp/src/arrow/util/string_builder.h
@@ -63,6 +63,24 @@ std::string StringBuilder(Args&&... args) {
   return ss.str();
 }
 
+/// CRTP helper for declaring string representation. Defines operator<<
+template <typename T>
+class ToStringOstreamable {
+ public:
+  ~ToStringOstreamable() {
+    static_assert(
+        std::is_same<decltype(std::declval<const T>().ToString()), std::string>::value,
+        "ToStringOstreamable depends on the method T::ToString() const");
+  }
+
+ private:
+  const T& cast() const { return static_cast<const T&>(*this); }
+
+  friend inline std::ostream& operator<<(std::ostream& os, const ToStringOstreamable& t) {
+    return os << t.cast().ToString();
+  }
+};
+
 }  // namespace util
 }  // namespace arrow
 


### PR DESCRIPTION
Allows `Iterator<T>` to be used in a range-for loop