### PR TITLE
ARROW-6704: [C++] Check for out of bounds timestamp in unsafe cast

### DIFF
--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -427,7 +427,7 @@ void ShiftTime(FunctionContext* ctx, const CastOptions& options, const bool is_m
       out_data[i] = static_cast<out_type>(in_data[i]);
     }
   } else if (is_multiply) {
-    if (options.allow_time_truncate) {
+    if (options.allow_time_overflow) {
       for (int64_t i = 0; i < input.length; i++) {
         out_data[i] = static_cast<out_type>(in_data[i] * factor);
       }

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -443,20 +443,20 @@ void ShiftTime(FunctionContext* ctx, const CastOptions& options, const bool is_m
         internal::BitmapReader bit_reader(input.buffers[0]->data(), input.offset,
                                           input.length);
         for (int64_t i = 0; i < input.length; i++) {
-          out_data[i] = static_cast<out_type>(in_data[i] * factor);
           if (bit_reader.IsSet() && (in_data[i] < min_val || in_data[i] > max_val)) {
             RAISE_OVERFLOW_CAST(in_data[i]);
             break;
           }
+          out_data[i] = static_cast<out_type>(in_data[i] * factor);
           bit_reader.Next();
         }
       } else {
         for (int64_t i = 0; i < input.length; i++) {
-          out_data[i] = static_cast<out_type>(in_data[i] * factor);
           if (in_data[i] < min_val || in_data[i] > max_val) {
             RAISE_OVERFLOW_CAST(in_data[i]);
             break;
           }
+          out_data[i] = static_cast<out_type>(in_data[i] * factor);
         }
       }
 

--- a/cpp/src/arrow/compute/kernels/cast.h
+++ b/cpp/src/arrow/compute/kernels/cast.h
@@ -38,12 +38,14 @@ struct ARROW_EXPORT CastOptions {
   CastOptions()
       : allow_int_overflow(false),
         allow_time_truncate(false),
+        allow_time_overflow(false),
         allow_float_truncate(false),
         allow_invalid_utf8(false) {}
 
   explicit CastOptions(bool safe)
       : allow_int_overflow(!safe),
         allow_time_truncate(!safe),
+        allow_time_overflow(!safe),
         allow_float_truncate(!safe),
         allow_invalid_utf8(!safe) {}
 
@@ -53,6 +55,7 @@ struct ARROW_EXPORT CastOptions {
 
   bool allow_int_overflow;
   bool allow_time_truncate;
+  bool allow_time_overflow;
   bool allow_float_truncate;
   // Indicate if conversions from Binary/FixedSizeBinary to string must
   // validate the utf8 payload.

--- a/cpp/src/arrow/compute/kernels/cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/cast_test.cc
@@ -685,6 +685,22 @@ TEST_F(TestCast, TimestampToTimestamp) {
                             timestamp(TimeUnit::MILLI), options);
   CheckFails<TimestampType>(timestamp(TimeUnit::NANO), v10, is_valid,
                             timestamp(TimeUnit::SECOND), options);
+
+  // Multiply overflow
+
+  // 1000-01-01, 1800-01-01 , 2000-01-01, 2300-01-01, 3000-01-01
+  std::vector<int64_t> v11 = {-30610224000, -5364662400, 946684800, 10413792000,
+                              32503680000};
+  std::vector<int64_t> e11 = {6283264147419103232, -5364662400000000000,
+                              946684800000000000, -8032952073709551616,
+                              -4389808147419103232};
+
+  options.allow_time_truncate = true;
+  CheckTimestampCast(options, TimeUnit::SECOND, TimeUnit::NANO, v11, e11, is_valid);
+
+  options.allow_time_truncate = false;
+  CheckFails<TimestampType>(timestamp(TimeUnit::SECOND), v11, is_valid,
+                            timestamp(TimeUnit::NANO), options);
 }
 
 TEST_F(TestCast, TimestampToDate32_Date64) {

--- a/cpp/src/arrow/compute/kernels/cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/cast_test.cc
@@ -691,11 +691,8 @@ TEST_F(TestCast, TimestampToTimestamp) {
   // 1000-01-01, 1800-01-01 , 2000-01-01, 2300-01-01, 3000-01-01
   std::vector<int64_t> v11 = {-30610224000, -5364662400, 946684800, 10413792000,
                               32503680000};
-  std::vector<int64_t> e11 = {6283264147419103232, -5364662400000000000,
-                              946684800000000000, -8032952073709551616,
-                              -4389808147419103232};
 
-  options.allow_time_truncate = false;
+  options.allow_time_overflow = false;
   CheckFails<TimestampType>(timestamp(TimeUnit::SECOND), v11, is_valid,
                             timestamp(TimeUnit::NANO), options);
 }
@@ -977,6 +974,15 @@ TEST_F(TestCast, DurationToCompatible) {
                            duration(TimeUnit::MILLI), options);
   CheckFails<DurationType>(duration(TimeUnit::NANO), v10, is_valid,
                            duration(TimeUnit::SECOND), options);
+
+  // Multiply overflow
+
+  // 1000-01-01, 1800-01-01 , 2000-01-01, 2300-01-01, 3000-01-01
+  std::vector<int64_t> v11 = {10000000000, 1, 2, 3, 10000000000};
+
+  options.allow_time_overflow = false;
+  CheckFails<DurationType>(duration(TimeUnit::SECOND), v11, is_valid,
+                           duration(TimeUnit::NANO), options);
 }
 
 TEST_F(TestCast, ToDouble) {

--- a/cpp/src/arrow/compute/kernels/cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/cast_test.cc
@@ -695,9 +695,6 @@ TEST_F(TestCast, TimestampToTimestamp) {
                               946684800000000000, -8032952073709551616,
                               -4389808147419103232};
 
-  options.allow_time_truncate = true;
-  CheckTimestampCast(options, TimeUnit::SECOND, TimeUnit::NANO, v11, e11, is_valid);
-
   options.allow_time_truncate = false;
   CheckFails<TimestampType>(timestamp(TimeUnit::SECOND), v11, is_valid,
                             timestamp(TimeUnit::NANO), options);

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1339,6 +1339,16 @@ class TestConvertDateTimeLikeTypes(object):
                 dtype='datetime64[s]')
         _check_array_from_pandas_roundtrip(datetime64_s)
 
+    def test_timestamp_to_pandas_ns(self):
+        # non-ns timestamp gets cast to ns on conversion to pandas
+        arr = pa.array([1, 2, 3], pa.timestamp('ms'))
+        expected = pd.Series(pd.to_datetime([1, 2, 3], unit='ms'))
+        s = arr.to_pandas()
+        tm.assert_series_equal(s, expected)
+        arr = pa.chunked_array([arr])
+        s = arr.to_pandas()
+        tm.assert_series_equal(s, expected)
+
     @pytest.mark.parametrize('dtype', [pa.date32(), pa.date64()])
     def test_numpy_datetime64_day_unit(self, dtype):
         datetime64_d = np.array([


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-6704