### PR TITLE
ARROW-6852: [C++] Fix build issue on memory-benchmark

### DIFF
--- a/cpp/src/arrow/io/memory_benchmark.cc
+++ b/cpp/src/arrow/io/memory_benchmark.cc
@@ -198,7 +198,6 @@ BENCHMARK_TEMPLATE(MemoryBandwidth, PlatformMemcpy)->Apply(SetMemoryBandwidthArg
 
 #endif  // _MSC_VER
 #endif  // ARROW_WITH_BENCHMARKS_REFERENCE
-#endif  // ARROW_HAVE_SSE4_2
 
 static void ParallelMemoryCopy(benchmark::State& state) {  // NOLINT non-const reference
   const int64_t n_threads = state.range(0);
@@ -272,3 +271,4 @@ BENCHMARK(BufferOutputStreamSmallWrites)->UseRealTime();
 BENCHMARK(BufferOutputStreamLargeWrites)->UseRealTime();
 
 }  // namespace arrow
+#endif  // ARROW_HAVE_SSE4_2


### PR DESCRIPTION
After the new commit: ARROW-6381 was merged in master,
build would fail on Arm64 when DARROW_BUILD_BENCHMARKS is enabled.
