### PR TITLE
ARROW-6853: [Java] Support vector and dictionary encoder use different hasher for calculating hashCode

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -253,7 +253,17 @@ public class ByteFunctionHelpers {
    */
   public static final int hash(final ArrowBuf buf, int start, int end) {
 
-    ArrowBufHasher hasher = SimpleHasher.INSTANCE;
+    return hash(SimpleHasher.INSTANCE, buf, start, end);
+  }
+
+  /**
+   * Compute hashCode with the given {@link ArrowBufHasher}, {@link ArrowBuf} and start/end index.
+   */
+  public static final int hash(ArrowBufHasher hasher, final ArrowBuf buf, int start, int end) {
+
+    if (hasher == null) {
+      hasher = SimpleHasher.INSTANCE;
+    }
 
     return hasher.hashCode(buf, start, end - start);
   }

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -18,6 +18,7 @@
 import io.netty.buffer.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.StructVector;
@@ -46,6 +47,7 @@ import org.apache.arrow.vector.complex.impl.ComplexCopier;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.util.OversizedAllocationException;
 import org.apache.arrow.util.Preconditions;
@@ -684,8 +686,13 @@ public class UnionVector implements FieldVector {
 
     @Override
     public int hashCode(int index) {
-      return getVector(index).hashCode(index);
+      return hashCode(index, null);
     }
+
+    @Override
+    public int hashCode(int index, ArrowBufHasher hasher) {
+    return getVector(index).hashCode(index, hasher);
+  }
 
     @Override
     public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -691,8 +691,8 @@ public class UnionVector implements FieldVector {
 
     @Override
     public int hashCode(int index, ArrowBufHasher hasher) {
-    return getVector(index).hashCode(index, hasher);
-  }
+      return getVector(index).hashCode(index, hasher);
+    }
 
     @Override
     public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
@@ -879,9 +880,14 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
 
   @Override
   public int hashCode(int index) {
+    return hashCode(index, null);
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
     int start = typeWidth * index;
     int end = typeWidth * (index + 1);
-    return ByteFunctionHelpers.hash(this.getDataBuffer(), start, end);
+    return ByteFunctionHelpers.hash(hasher, this.getDataBuffer(), start, end);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -27,6 +27,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
@@ -1367,9 +1368,14 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
 
   @Override
   public int hashCode(int index) {
+    return hashCode(index, null);
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
     final int start = getStartOffset(index);
     final int end = getStartOffset(index + 1);
-    return ByteFunctionHelpers.hash(this.getDataBuffer(), start, end);
+    return ByteFunctionHelpers.hash(hasher, this.getDataBuffer(), start, end);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.NullReader;
@@ -231,6 +232,11 @@ public class NullVector implements FieldVector {
 
   @Override
   public int hashCode(int index) {
+    return 31 * valueCount;
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
     return 31 * valueCount;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ValueVector.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types.MinorType;
@@ -240,9 +241,14 @@ public interface ValueVector extends Closeable, Iterable<ValueVector> {
   boolean isNull(int index);
 
   /**
-   * Returns hashCode of element in index.
+   * Returns hashCode of element in index with the default hasher.
    */
   int hashCode(int index);
+
+  /**
+   * Returns hashCode of element in index with the given hasher.
+   */
+  int hashCode(int index, ArrowBufHasher hasher);
 
   /**
    * Copy a cell value from a particular index in source vector to a particular

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.TransferPair;
 
@@ -51,6 +52,11 @@ public final class ZeroVector extends NullVector {
 
   @Override
   public int hashCode(int index) {
+    return 0;
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
     return 0;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -31,6 +31,7 @@ import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.AddOrGetResult;
 import org.apache.arrow.vector.BaseValueVector;
@@ -528,12 +529,17 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
 
   @Override
   public int hashCode(int index) {
+    return hashCode(index, null);
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
       return 0;
     }
     int hash = 0;
     for (int i = 0; i < listSize; i++) {
-      hash = ByteFunctionHelpers.combineHash(hash, vector.hashCode(index * listSize + i));
+      hash = ByteFunctionHelpers.combineHash(hash, vector.hashCode(index * listSize + i, hasher));
     }
     return hash;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -29,6 +29,7 @@ import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.AddOrGetResult;
 import org.apache.arrow.vector.BitVectorHelper;
@@ -419,6 +420,11 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
 
   @Override
   public int hashCode(int index) {
+    return hashCode(index, null);
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
       return 0;
     }
@@ -426,7 +432,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
     final int start = offsetBuffer.getInt(index * OFFSET_WIDTH);
     final int end = offsetBuffer.getInt((index + 1) * OFFSET_WIDTH);
     for (int i = start; i < end; i++) {
-      hash = ByteFunctionHelpers.combineHash(hash, vector.hashCode(i));
+      hash = ByteFunctionHelpers.combineHash(hash, vector.hashCode(i, hasher));
     }
     return hash;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.DensityAwareVector;
 import org.apache.arrow.vector.FieldVector;
@@ -298,11 +299,16 @@ public class NonNullableStructVector extends AbstractStructVector {
 
   @Override
   public int hashCode(int index) {
+    return hashCode(index, null);
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
     int hash = 0;
     for (String child : getChildFieldNames()) {
       ValueVector v = getChild(child);
       if (v != null && index < v.getValueCount()) {
-        hash = ByteFunctionHelpers.combineHash(hash, v.hashCode(index));
+        hash = ByteFunctionHelpers.combineHash(hash, v.hashCode(index, hasher));
       }
     }
     return hash;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.BitVectorHelper;
@@ -482,10 +483,15 @@ public class StructVector extends NonNullableStructVector implements FieldVector
 
   @Override
   public int hashCode(int index) {
+    return hashCode(index, null);
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
       return 0;
     } else {
-      return super.hashCode(index);
+      return super.hashCode(index, hasher);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryEncoder.java
@@ -18,6 +18,8 @@
 package org.apache.arrow.vector.dictionary;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
+import org.apache.arrow.memory.util.hash.SimpleHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseIntVector;
 import org.apache.arrow.vector.FieldVector;
@@ -38,15 +40,20 @@ public class DictionaryEncoder {
   private final Dictionary dictionary;
   private final BufferAllocator allocator;
 
-  //TODO pass custom hasher.
-
   /**
    * Construct an instance.
    */
   public DictionaryEncoder(Dictionary dictionary, BufferAllocator allocator) {
+    this (dictionary, allocator, SimpleHasher.INSTANCE);
+  }
+
+  /**
+   * Construct an instance.
+   */
+  public DictionaryEncoder(Dictionary dictionary, BufferAllocator allocator, ArrowBufHasher hasher) {
     this.dictionary = dictionary;
     this.allocator = allocator;
-    hashTable = new DictionaryHashTable(dictionary.getVector());
+    hashTable = new DictionaryHashTable(dictionary.getVector(), hasher);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector.dictionary;
 
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
+import org.apache.arrow.memory.util.hash.SimpleHasher;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
@@ -74,10 +76,12 @@ public class DictionaryHashTable {
 
   private final ValueVector dictionary;
 
+  private final ArrowBufHasher hasher;
+
   /**
    * Constructs an empty map with the specified initial capacity and load factor.
    */
-  public DictionaryHashTable(int initialCapacity, ValueVector dictionary) {
+  public DictionaryHashTable(int initialCapacity, ValueVector dictionary, ArrowBufHasher hasher) {
     if (initialCapacity < 0) {
       throw new IllegalArgumentException("Illegal initial capacity: " +
           initialCapacity);
@@ -90,14 +94,20 @@ public class DictionaryHashTable {
 
     this.dictionary = dictionary;
 
+    this.hasher = hasher;
+
     // build hash table
     for (int i = 0; i < this.dictionary.getValueCount(); i++) {
       put(i);
     }
   }
 
+  public DictionaryHashTable(ValueVector dictionary, ArrowBufHasher hasher) {
+    this(DEFAULT_INITIAL_CAPACITY, dictionary, hasher);
+  }
+
   public DictionaryHashTable(ValueVector dictionary) {
-    this(DEFAULT_INITIAL_CAPACITY, dictionary);
+    this(dictionary, SimpleHasher.INSTANCE);
   }
 
   /**
@@ -135,7 +145,7 @@ public class DictionaryHashTable {
    * @return dictionary vector index or -1 if no value equals.
    */
   public int getIndex(int indexInArray, ValueVector toEncode) {
-    int hash = toEncode.hashCode(indexInArray);
+    int hash = toEncode.hashCode(indexInArray, this.hasher);
     int index = indexFor(hash, table.length);
 
     RangeEqualsVisitor equalVisitor = new RangeEqualsVisitor(dictionary, toEncode, false);
@@ -163,7 +173,7 @@ public class DictionaryHashTable {
       inflateTable(threshold);
     }
 
-    int hash = dictionary.hashCode(indexInDictionary);
+    int hash = dictionary.hashCode(indexInDictionary, this.hasher);
     int i = indexFor(hash, table.length);
     for (DictionaryHashTable.Entry e = table[i]; e != null; e = e.next) {
       if (e.hash == hash && e.index == indexInDictionary) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
@@ -206,7 +207,12 @@ public class TestExtensionType {
 
     @Override
     public int hashCode(int index) {
-      return getUnderlyingVector().hashCode(index);
+      return hashCode(index, null);
+    }
+
+    @Override
+    public int hashCode(int index, ArrowBufHasher hasher) {
+      return getUnderlyingVector().hashCode(index, hasher);
     }
 
     public void set(int index, UUID uuid) {


### PR DESCRIPTION
Related to [ARROW-6853](https://issues.apache.org/jira/browse/ARROW-6853).

Hasher interface was introduce in ARROW-5898 and now have two different implementations (MurmurHasher and SimpleHasher) and it could be more in the future.

And currently ValueVector#hashCode and DictionaryHashTable only use SimpleHasher for calculating hashCode. This issue enables them to use different hasher or even user-defined hasher for their own use cases.