### PR TITLE
ARROW-6662: [Java] Implement equals/approxEquals API for VectorSchemaRoot

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -358,6 +358,7 @@ public class VectorSchemaRoot implements AutoCloseable {
       return false;
     }
 
+    Range range = new Range(0, 0, 0);
     for (int i = 0; i < fieldVectors.size(); i++) {
       FieldVector vector = fieldVectors.get(i);
       FieldVector otherVector = other.fieldVectors.get(i);
@@ -365,7 +366,7 @@ public class VectorSchemaRoot implements AutoCloseable {
         return false;
       }
       ApproxEqualsVisitor visitor = new ApproxEqualsVisitor(vector, otherVector);
-      Range range = new Range(0, 0, vector.getValueCount());
+      range.setLength(vector.getValueCount());
       if (!visitor.rangeEquals(range)) {
         return false;
       }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -36,6 +36,15 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
 
   /**
    * Constructs a new instance.
+   * @param left left vector
+   * @param right right vector
+   */
+  public ApproxEqualsVisitor(ValueVector left, ValueVector right) {
+    this (left, right, 1.0E-6f, 1.0E-6f);
+  }
+
+  /**
+   * Constructs a new instance.
    *
    * @param left left vector
    * @param right right vector

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -35,12 +35,18 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
   private final VectorValueEqualizer<Float8Vector> doubleDiffFunction;
 
   /**
-   * Constructs a new instance.
+   * Default epsilons for diff functions.
+   */
+  public static final float DEFAULT_FLOAT_EPSILON = 1.0E-6f;
+  public static final double DEFAULT_DOUBLE_EPSILON = 1.0E-6;
+
+  /**
+   * Constructs a new instance with default tolerances.
    * @param left left vector
    * @param right right vector
    */
   public ApproxEqualsVisitor(ValueVector left, ValueVector right) {
-    this (left, right, 1.0E-6f, 1.0E-6f);
+    this (left, right, DEFAULT_FLOAT_EPSILON, DEFAULT_DOUBLE_EPSILON);
   }
 
   /**

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
@@ -239,6 +239,69 @@ public class TestVectorSchemaRoot {
   }
 
   @Test
+  public void testEquals() {
+    try (final IntVector intVector1 = new IntVector("intVector1", allocator);
+         final IntVector intVector2 = new IntVector("intVector2", allocator);
+         final IntVector intVector3 = new IntVector("intVector3", allocator);) {
+
+      intVector1.setValueCount(5);
+      for (int i = 0; i < 5; i++) {
+        intVector1.set(i, i);
+      }
+
+      VectorSchemaRoot root1 =
+          new VectorSchemaRoot(Arrays.asList(intVector1, intVector2, intVector3));
+
+      VectorSchemaRoot root2 =
+          new VectorSchemaRoot(Arrays.asList(intVector1, intVector2));
+
+      VectorSchemaRoot root3 =
+          new VectorSchemaRoot(Arrays.asList(intVector1, intVector2, intVector3));
+
+      assertFalse(root1.equals(root2));
+      assertTrue(root1.equals(root3));
+
+      root1.close();
+      root2.close();
+      root3.close();
+    }
+  }
+
+  @Test
+  public void testApproxEquals() {
+    try (final Float4Vector float4Vector1 = new Float4Vector("floatVector", allocator);
+         final Float4Vector float4Vector2 = new Float4Vector("floatVector", allocator);
+         final Float4Vector float4Vector3 = new Float4Vector("floatVector", allocator);) {
+
+      float4Vector1.setValueCount(5);
+      float4Vector2.setValueCount(5);
+      float4Vector3.setValueCount(5);
+      final float epsilon = 1.0E-6f;
+      for (int i = 0; i < 5; i++) {
+        float4Vector1.set(i, i);
+        float4Vector2.set(i, i + epsilon * 2);
+        float4Vector3.set(i, i + epsilon / 2);
+      }
+
+      VectorSchemaRoot root1 =
+          new VectorSchemaRoot(Arrays.asList(float4Vector1));
+
+      VectorSchemaRoot root2 =
+          new VectorSchemaRoot(Arrays.asList(float4Vector2));
+
+      VectorSchemaRoot root3 =
+          new VectorSchemaRoot(Arrays.asList(float4Vector3));
+
+      assertFalse(root1.approxEquals(root2));
+      assertTrue(root1.approxEquals(root3));
+
+      root1.close();
+      root2.close();
+      root3.close();
+    }
+  }
+
+  @Test
   public void testSchemaSync() {
     //create vector schema root
     try (VectorSchemaRoot schemaRoot = createBatch()) {


### PR DESCRIPTION
Related to [ARROW-6662](https://issues.apache.org/jira/browse/ARROW-6662).

Currently with the new added visitor APIs(ARROW-6211), we could implement equals/approxEquals for VectorSchemaRoot.
