### PR TITLE
ARROW-6863: [Java] Provide parallel searcher

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/search/ParallelSearcher.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/search/ParallelSearcher.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.search;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.compare.Range;
+import org.apache.arrow.vector.compare.RangeEqualsVisitor;
+
+/**
+ * Search for a value in the vector by multiple threads.
+ * This is often used in scenarios where the vector is large or
+ * low response time is required.
+ * @param <V> the vector type.
+ */
+public class ParallelSearcher<V extends ValueVector> {
+
+  /**
+   * The target vector to search.
+   */
+  private final V vector;
+
+  /**
+   * The thread pool.
+   */
+  private final ExecutorService threadPool;
+
+  /**
+   * The number of threads to use.
+   */
+  private final int numThreads;
+
+  /**
+   * The position of the key in the target vector, if any.
+   */
+  private int keyPosition = -1;
+
+  /**
+   * Constructs a parallel searcher.
+   * @param vector the vector to search.
+   * @param threadPool the thread pool to use.
+   * @param numThreads the number of threads to use.
+   */
+  public ParallelSearcher(V vector, ExecutorService threadPool, int numThreads) {
+    this.vector = vector;
+    this.threadPool = threadPool;
+    this.numThreads = numThreads;
+  }
+
+  /**
+   * Search for the key in the target vector.
+   * @param keyVector the vector containing the search key.
+   * @param keyIndex the index of the search key in the key vector.
+   * @return the position of a matched value in the target vector,
+   *     or -1 if none is found.
+   * @throws ExecutionException if an exception occurs in a thread.
+   * @throws InterruptedException if a thread is interrupted.
+   */
+  public int search(V keyVector, int keyIndex) throws ExecutionException, InterruptedException {
+    keyPosition = -1;
+    final int valueCount = vector.getValueCount();
+    final CompletableFuture<Boolean>[] futures = new CompletableFuture[numThreads];
+    for (int i = 0; i < futures.length; i++) {
+      futures[i] = new CompletableFuture<>();
+    }
+
+    for (int i = 0; i < numThreads; i++) {
+      final int tid = i;
+      threadPool.submit(() -> {
+        // convert to long to avoid overflow
+        int start = (int) (((long) valueCount) * tid / numThreads);
+        int end = (int) ((long) valueCount) * (tid + 1) / numThreads;
+
+        if (start >= end) {
+          // no data assigned to this task.
+          futures[tid].complete(false);
+          return;
+        }
+
+        RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector, keyVector, false);
+        Range range = new Range(0, 0, 1);
+        for (int pos = start; pos < end; pos++) {
+          if (keyPosition != -1) {
+            // the key has been found by another task
+            futures[tid].complete(false);
+            return;
+          }
+          range.setLeftStart(pos).setRightStart(keyIndex);
+          if (visitor.rangeEquals(range)) {
+            keyPosition = pos;
+            futures[tid].complete(true);
+            return;
+          }
+        }
+
+        // no match value is found.
+        futures[tid].complete(false);
+      });
+    }
+
+    CompletableFuture.allOf(futures).get();
+    return keyPosition;
+  }
+}

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/search/ParallelSearcher.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/search/ParallelSearcher.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import org.apache.arrow.algorithm.sort.VectorValueComparator;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
@@ -70,7 +71,11 @@ public class ParallelSearcher<V extends ValueVector> {
    * @param keyVector the vector containing the search key.
    * @param keyIndex the index of the search key in the key vector.
    * @return the position of a matched value in the target vector,
-   *     or -1 if none is found.
+   *     or -1 if none is found. Please note that if there are multiple
+   *     matches of the key in the target vector, this method makes no
+   *     guarantees about which instance is returned.
+   *     For an alternative search implementation that always finds the first match of the key,
+   *     see {@link VectorSearcher#linearSearch(ValueVector, VectorValueComparator, ValueVector, int)}.
    * @throws ExecutionException if an exception occurs in a thread.
    * @throws InterruptedException if a thread is interrupted.
    */

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/search/TestParallelSearcher.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/search/TestParallelSearcher.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.search;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link ParallelSearcher}.
+ */
+public class TestParallelSearcher {
+
+  private static final int THREAD_COUNT = 10;
+
+  private static final int VECTOR_LENGTH = 10000;
+
+  private BufferAllocator allocator;
+
+  private ExecutorService threadPool;
+
+  @Before
+  public void prepare() {
+    allocator = new RootAllocator(1024 * 1024);
+    threadPool = Executors.newFixedThreadPool(THREAD_COUNT);
+  }
+
+  @After
+  public void shutdown() {
+    allocator.close();
+    threadPool.shutdown();
+  }
+
+  @Test
+  public void testParallelIntSearch() throws ExecutionException, InterruptedException {
+    try (IntVector targetVector = new IntVector("targetVector", allocator);
+    IntVector keyVector = new IntVector("keyVector", allocator)) {
+      targetVector.allocateNew(VECTOR_LENGTH);
+      keyVector.allocateNew(VECTOR_LENGTH);
+
+      for (int i = 0; i < VECTOR_LENGTH; i++) {
+        targetVector.set(i, i);
+        keyVector.set(i, i * 2);
+      }
+      targetVector.setValueCount(VECTOR_LENGTH);
+      keyVector.setValueCount(VECTOR_LENGTH);
+
+      ParallelSearcher<IntVector> searcher = new ParallelSearcher<>(targetVector, threadPool, THREAD_COUNT);
+      for (int i = 0; i < VECTOR_LENGTH; i++) {
+        int pos = searcher.search(keyVector, i);
+        if (i * 2 < VECTOR_LENGTH) {
+          assertEquals(i * 2, pos);
+        } else {
+          assertEquals(-1, pos);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testParallelStringSearch() throws ExecutionException, InterruptedException {
+    try (VarCharVector targetVector = new VarCharVector("targetVector", allocator);
+         VarCharVector keyVector = new VarCharVector("keyVector", allocator)) {
+      targetVector.allocateNew(VECTOR_LENGTH);
+      keyVector.allocateNew(VECTOR_LENGTH);
+
+      for (int i = 0; i < VECTOR_LENGTH; i++) {
+        targetVector.setSafe(i, String.valueOf(i).getBytes());
+        keyVector.setSafe(i, String.valueOf(i * 2).getBytes());
+      }
+      targetVector.setValueCount(VECTOR_LENGTH);
+      keyVector.setValueCount(VECTOR_LENGTH);
+
+      ParallelSearcher<VarCharVector> searcher = new ParallelSearcher<>(targetVector, threadPool, THREAD_COUNT);
+      for (int i = 0; i < VECTOR_LENGTH; i++) {
+        int pos = searcher.search(keyVector, i);
+        if (i * 2 < VECTOR_LENGTH) {
+          assertEquals(i * 2, pos);
+        } else {
+          assertEquals(-1, pos);
+        }
+      }
+    }
+  }
+}

--- a/java/performance/pom.xml
+++ b/java/performance/pom.xml
@@ -77,6 +77,12 @@
             <artifactId>arrow-jdbc</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-algorithm</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/java/performance/src/test/java/org/apache/arrow/algorithm/search/ParallelSearcherBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/algorithm/search/ParallelSearcherBenchmarks.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.search;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmarks for {@link ParallelSearcher}.
+ */
+public class ParallelSearcherBenchmarks {
+
+  private static final int VECTOR_LENGTH = 1024 * 1024;
+
+  /**
+   * State object for the benchmarks.
+   */
+  @State(Scope.Benchmark)
+  public static class SearchState {
+
+    @Param({"1", "2", "5", "10", "20", "50", "100"})
+    int numThreads;
+
+    BaseAllocator allocator;
+
+    ExecutorService threadPool;
+
+    IntVector targetVector;
+
+    IntVector keyVector;
+
+    ParallelSearcher<IntVector> searcher;
+
+    @Setup(Level.Trial)
+    public void prepare() {
+      allocator = new RootAllocator(Integer.MAX_VALUE);
+      targetVector = new IntVector("target vector", allocator);
+      targetVector.allocateNew(VECTOR_LENGTH);
+      keyVector = new IntVector("key vector", allocator);
+      keyVector.allocateNew(1);
+      threadPool = Executors.newFixedThreadPool(numThreads);
+
+      for (int i = 0; i < VECTOR_LENGTH; i++) {
+        targetVector.set(i, i);
+      }
+      targetVector.setValueCount(VECTOR_LENGTH);
+
+      keyVector.set(0, VECTOR_LENGTH / 3);
+      keyVector.setValueCount(1);
+    }
+
+    @Setup(Level.Invocation)
+    public void prepareInvoke() {
+      searcher = new ParallelSearcher<>(targetVector, threadPool, numThreads);
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDownState() {
+      targetVector.close();
+      keyVector.close();
+      allocator.close();
+      threadPool.shutdown();
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void searchBenchmark(SearchState state) throws Exception {
+    state.searcher.search(state.keyVector, 0);
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt = new OptionsBuilder()
+            .include(ParallelSearcherBenchmarks.class.getSimpleName())
+            .forks(1)
+            .build();
+
+    new Runner(opt).run();
+  }
+}


### PR DESCRIPTION
For scenarios where the vector is large and the a low response time is required, we need to search the vector in parallel to improve the responsiveness.

This issue tries to provide a parallel searcher for the equality semantics (the support for ordering semantics is not ready yet, as we need a way to distribute the comparator).

The implementation is based on multi-threading.