### PR TITLE
ARROW-6865: [Java] Improve the performance of comparing an ArrowBuf against a byte array

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -231,6 +231,28 @@ public class ByteFunctionHelpers {
     long lPos = laddr + lStart;
     int rPos = rStart;
 
+    while (n > 7) {
+      long leftLong = PlatformDependent.getLong(lPos);
+      long rightLong = PlatformDependent.getLong(right, rPos);
+      if (leftLong != rightLong) {
+        return unsignedLongCompare(Long.reverseBytes(leftLong), Long.reverseBytes(rightLong));
+      }
+      lPos += 8;
+      rPos += 8;
+      n -= 8;
+    }
+
+    while (n > 3) {
+      int leftInt = PlatformDependent.getInt(lPos);
+      int rightInt = PlatformDependent.getInt(right, rPos);
+      if (leftInt != rightInt) {
+        return unsignedIntCompare(Integer.reverseBytes(leftInt), Integer.reverseBytes(rightInt));
+      }
+      lPos += 4;
+      rPos += 4;
+      n -= 4;
+    }
+
     while (n-- != 0) {
       byte leftByte = PlatformDependent.getByte(lPos);
       byte rightByte = right[rPos];


### PR DESCRIPTION
We change the way of comparing an ArrowBuf against a byte array from byte wise comparison to comparison by long/int/byte.

Benchmark shows that there is a 6.7x performance improvement.