### PR TITLE
ARROW-6866: [Java] Improve the performance of calculating hash code for struct vector

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -119,14 +119,14 @@ public class NonNullableStructVector extends AbstractStructVector {
 
   @Override
   public void setInitialCapacity(int numRecords) {
-    for (final ValueVector v : (Iterable<ValueVector>) this) {
+    for (final ValueVector v : this) {
       v.setInitialCapacity(numRecords);
     }
   }
 
   @Override
   public void setInitialCapacity(int valueCount, double density) {
-    for (final ValueVector vector : (Iterable<ValueVector>) this) {
+    for (final ValueVector vector : this) {
       if (vector instanceof DensityAwareVector) {
         ((DensityAwareVector)vector).setInitialCapacity(valueCount, density);
       } else {
@@ -141,7 +141,7 @@ public class NonNullableStructVector extends AbstractStructVector {
       return 0;
     }
     long buffer = 0;
-    for (final ValueVector v : (Iterable<ValueVector>) this) {
+    for (final ValueVector v : this) {
       buffer += v.getBufferSize();
     }
 
@@ -155,7 +155,7 @@ public class NonNullableStructVector extends AbstractStructVector {
     }
 
     long bufferSize = 0;
-    for (final ValueVector v : (Iterable<ValueVector>) this) {
+    for (final ValueVector v : this) {
       bufferSize += v.getBufferSizeFor(valueCount);
     }
 
@@ -305,10 +305,9 @@ public class NonNullableStructVector extends AbstractStructVector {
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     int hash = 0;
-    for (String child : getChildFieldNames()) {
-      ValueVector v = getChild(child);
-      if (v != null && index < v.getValueCount()) {
-        hash = ByteFunctionHelpers.combineHash(hash, v.hashCode(index, hasher));
+    for (FieldVector v : getChildren()) {
+      if (index < v.getValueCount()) {
+        hash = ByteFunctionHelpers.combineHash(hash, v.hashCode(index));
       }
     }
     return hash;


### PR DESCRIPTION
Improve the performance of hashCode(int) method for StructVector:
1. We can get the child vectors directly, so there is no need to get the name from the child vector and then use the name to get the vector.
2. The child vectors cannot be null, so there is no need to check it.

The performance improvement depends on the complexity of the hash algorithm. For computational intensive hash algorithms, the improvement can be small; while for simple hash algorithms, the improvement can be notable.