### PR TITLE
ARROW-6864: [C++] Add compression-related compile definitions before adding any unit tests

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -145,6 +145,40 @@ set(ARROW_SRCS
     vendored/base64.cpp
     vendored/datetime/tz.cpp)
 
+if(ARROW_WITH_BOOST_FILESYSTEM)
+  add_definitions(-DARROW_WITH_BOOST_FILESYSTEM)
+endif()
+
+if(ARROW_WITH_BROTLI)
+  add_definitions(-DARROW_WITH_BROTLI)
+  list(APPEND ARROW_SRCS util/compression_brotli.cc)
+endif()
+
+if(ARROW_WITH_BZ2)
+  add_definitions(-DARROW_WITH_BZ2)
+  list(APPEND ARROW_SRCS util/compression_bz2.cc)
+endif()
+
+if(ARROW_WITH_LZ4)
+  add_definitions(-DARROW_WITH_LZ4)
+  list(APPEND ARROW_SRCS util/compression_lz4.cc)
+endif()
+
+if(ARROW_WITH_SNAPPY)
+  add_definitions(-DARROW_WITH_SNAPPY)
+  list(APPEND ARROW_SRCS util/compression_snappy.cc)
+endif()
+
+if(ARROW_WITH_ZLIB)
+  add_definitions(-DARROW_WITH_ZLIB)
+  list(APPEND ARROW_SRCS util/compression_zlib.cc)
+endif()
+
+if(ARROW_WITH_ZSTD)
+  add_definitions(-DARROW_WITH_ZSTD)
+  list(APPEND ARROW_SRCS util/compression_zstd.cc)
+endif()
+
 set(ARROW_TESTING_SRCS
     io/test_common.cc
     ipc/test_common.cc
@@ -297,40 +331,6 @@ endif()
 
 if(ARROW_WITH_URIPARSER)
   list(APPEND ARROW_SRCS util/uri.cc)
-endif()
-
-if(ARROW_WITH_BOOST_FILESYSTEM)
-  add_definitions(-DARROW_WITH_BOOST_FILESYSTEM)
-endif()
-
-if(ARROW_WITH_BROTLI)
-  add_definitions(-DARROW_WITH_BROTLI)
-  list(APPEND ARROW_SRCS util/compression_brotli.cc)
-endif()
-
-if(ARROW_WITH_BZ2)
-  add_definitions(-DARROW_WITH_BZ2)
-  list(APPEND ARROW_SRCS util/compression_bz2.cc)
-endif()
-
-if(ARROW_WITH_LZ4)
-  add_definitions(-DARROW_WITH_LZ4)
-  list(APPEND ARROW_SRCS util/compression_lz4.cc)
-endif()
-
-if(ARROW_WITH_SNAPPY)
-  add_definitions(-DARROW_WITH_SNAPPY)
-  list(APPEND ARROW_SRCS util/compression_snappy.cc)
-endif()
-
-if(ARROW_WITH_ZLIB)
-  add_definitions(-DARROW_WITH_ZLIB)
-  list(APPEND ARROW_SRCS util/compression_zlib.cc)
-endif()
-
-if(ARROW_WITH_ZSTD)
-  add_definitions(-DARROW_WITH_ZSTD)
-  list(APPEND ARROW_SRCS util/compression_zstd.cc)
 endif()
 
 if(NOT APPLE AND NOT MSVC)


### PR DESCRIPTION
Apparently when `add_definitions` is called it does not necessarily affect executables that have already been added. 