### PR TITLE
ARROW-4748: [Rust] [DataFusion] Optimize GROUP BY aggregate queries

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -274,7 +274,7 @@ impl ExecutionContext {
                 input,
                 group_expr,
                 aggr_expr,
-                schema,
+                ..
             } => {
                 let input = self.create_physical_plan(input, batch_size)?;
                 let input_schema = input.as_ref().schema().clone();
@@ -287,10 +287,7 @@ impl ExecutionContext {
                     .map(|e| self.create_aggregate_expr(e, &input_schema))
                     .collect::<Result<Vec<_>>>()?;
                 Ok(Arc::new(HashAggregateExec::try_new(
-                    group_expr,
-                    aggr_expr,
-                    input,
-                    schema.clone(),
+                    group_expr, aggr_expr, input,
                 )?))
             }
             LogicalPlan::Selection { input, expr, .. } => {


### PR DESCRIPTION
Various optimizations to GROUP BY aggregate queries, resulting in a 25% improvement in the current benchmark, and close to a 2x improvement when running queries against large data sets.

- Re-use vector for grouping keys instead of creating a new vector for each row (benchmark went from 47 us to 39 us)
- Two pass approach where pass one builds a vector of references to accumulators, and the second pass processes one column at a time, updating the accumulators (now 37.6 us)
- Create aggregate schema once when plan is constructed, instead of once per batch per partition (now 36.5 us)
- Avoid converting final aggregate map into a vector (now 34.8 us)
