### PR TITLE
ARROW-6836: [Format] add a custom_metadata:[KeyValue] field to the Footer table in File.fbs

### DIFF
--- a/format/File.fbs
+++ b/format/File.fbs
@@ -31,6 +31,9 @@ table Footer {
   dictionaries: [ Block ];
 
   recordBatches: [ Block ];
+
+  /// User-defined metadata
+  custom_metadata: [ KeyValue ];
 }
 
 struct Block {


### PR DESCRIPTION
This is ARROW-6836 ... a separate issue (ARROW-6837) pertains to accessing the new field.  Unsure whether these are separate issues and/or pull-requests.  In case they are separate, here is the format one.