### PR TITLE
ARROW-6789: [Python] Improve ergonomics by automatically boxing Action and Result in do_action RPC

### DIFF
--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1583,14 +1583,8 @@ cdef CStatus _do_action_result_next(
 
     try:
         action_result = next(<object> self)
-        if isinstance(action_result, str):
-            action_result = Result(action_result.encode('utf-8'))
-        elif isinstance(action_result, (bytes, Buffer)):
+        if not isinstance(action_result, Result):
             action_result = Result(action_result)
-        elif not isinstance(action_result, Result):
-            raise TypeError("Result of FlightServerBase.do_action must "
-                            "return an iterator of Result or "
-                            "bytes-like objects")
         c_result = (<Result> action_result).result.get()
         result.reset(new CFlightResult(deref(c_result)))
     except StopIteration:

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1010,13 +1010,35 @@ cdef class FlightClient:
 
         return result
 
-    def do_action(self, action: Action, options: FlightCallOptions = None):
-        """Execute an action on a service."""
+    def do_action(self, action, options: FlightCallOptions = None):
+        """
+        Execute an action on a service.
+
+        Parameters
+        ----------
+        action : str, tuple, or Action
+            Can be action type name (no body), type and body, or any Action
+            object
+        options : FlightCallOptions
+            RPC options
+
+        Returns
+        -------
+        results : iterator of Result values
+        """
         cdef:
             unique_ptr[CResultStream] results
             Result result
-            CAction c_action = Action.unwrap(action)
             CFlightCallOptions* c_options = FlightCallOptions.unwrap(options)
+
+        if isinstance(action, (str, bytes)):
+            action = Action(action, b'')
+        elif isinstance(action, tuple):
+            action = Action(*action)
+        elif not isinstance(action, Action):
+            raise TypeError("Action must be Action instance, string, or tuple")
+
+        cdef CAction c_action = Action.unwrap(<Action> action)
         with nogil:
             check_flight_status(
                 self.client.get().DoAction(deref(c_options), c_action,
@@ -1561,9 +1583,14 @@ cdef CStatus _do_action_result_next(
 
     try:
         action_result = next(<object> self)
-        if not isinstance(action_result, Result):
+        if isinstance(action_result, str):
+            action_result = Result(action_result.encode('utf-8'))
+        elif isinstance(action_result, (bytes, Buffer)):
+            action_result = Result(action_result)
+        elif not isinstance(action_result, Result):
             raise TypeError("Result of FlightServerBase.do_action must "
-                            "return an iterator of Result objects")
+                            "return an iterator of Result or "
+                            "bytes-like objects")
         c_result = (<Result> action_result).result.get()
         result.reset(new CFlightResult(deref(c_result)))
     except StopIteration:

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1000,10 +1000,8 @@ cdef class Buffer:
     def __eq__(self, other):
         if isinstance(other, Buffer):
             return self.equals(other)
-        elif isinstance(other, bytes):
-            return self.equals(py_buffer(other))
         else:
-            return NotImplemented
+            return self.equals(py_buffer(other))
 
     def __reduce_ex__(self, protocol):
         if protocol >= 5:

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1000,6 +1000,8 @@ cdef class Buffer:
     def __eq__(self, other):
         if isinstance(other, Buffer):
             return self.equals(other)
+        elif isinstance(other, bytes):
+            return self.equals(py_buffer(other))
         else:
             return NotImplemented
 

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -586,6 +586,35 @@ def test_list_actions():
             ListActionsFlightServer.expected_actions()
 
 
+class ConvenienceServer(FlightServerBase):
+    """
+    Server for testing various implementation conveniences (auto-boxing, etc.)
+    """
+    @property
+    def simple_action_results(self):
+        return [b'foo', b'bar', b'baz']
+
+    def do_action(self, context, action):
+        if action.type == 'simple-action':
+            return iter(self.simple_action_results)
+        elif action.type == 'echo':
+            return iter([action.body])
+
+
+def test_do_action_result_convenience():
+    with ConvenienceServer() as server:
+        client = FlightClient(('localhost', server.port))
+
+        # do_action as action type without body
+        results = [x.body for x in client.do_action('simple-action')]
+        assert results == server.simple_action_results
+
+        # do_action with tuple of type and body
+        body = b'the-body'
+        results = [x.body for x in client.do_action(('echo', body))]
+        assert results == [body]
+
+
 def test_get_port():
     """Make sure port() works."""
     server = GetInfoFlightServer("grpc://localhost:0")

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -599,6 +599,8 @@ class ConvenienceServer(FlightServerBase):
             return iter(self.simple_action_results)
         elif action.type == 'echo':
             return iter([action.body])
+        elif action.type == 'bad-action':
+            return iter(['foo'])
 
 
 def test_do_action_result_convenience():
@@ -613,6 +615,10 @@ def test_do_action_result_convenience():
         body = b'the-body'
         results = [x.body for x in client.do_action(('echo', body))]
         assert results == [body]
+
+        # ARROW-6884 raise a more specific and helpful exception
+        with pytest.raises(Exception):
+            list(client.do_action('bad-action'))
 
 
 def test_get_port():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -424,6 +424,12 @@ def test_buffer_equals():
     eq(buf2, buf5)
 
 
+def test_buffer_eq_bytes():
+    buf = pa.py_buffer(b'some data')
+    assert buf == b'some data'
+    assert buf != b'some dat1'
+
+
 def test_buffer_getitem():
     data = bytearray(b'some data!')
     buf = pa.py_buffer(data)

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -431,7 +431,7 @@ def test_buffer_eq_bytes():
     assert buf != b'some dat1'
 
     with pytest.raises(TypeError):
-        buf == 'some data'
+        buf == u'some data'
 
 
 def test_buffer_getitem():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -427,6 +427,7 @@ def test_buffer_equals():
 def test_buffer_eq_bytes():
     buf = pa.py_buffer(b'some data')
     assert buf == b'some data'
+    assert buf == bytearray(b'some data')
     assert buf != b'some dat1'
 
 

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -430,6 +430,9 @@ def test_buffer_eq_bytes():
     assert buf == bytearray(b'some data')
     assert buf != b'some dat1'
 
+    with pytest.raises(TypeError):
+        buf == 'some data'
+
 
 def test_buffer_getitem():
     data = bytearray(b'some data!')


### PR DESCRIPTION
This allows clients to invoke actions like

```
client.do_action('bodyless-action-name')
client.do_action(('action-with-body', b'action-body'))
```

On the server side, the results of `do_action` can be `str`, `bytes`, or `pyarrow.Buffer` and will be automatically converted to `Result`. 