### PR TITLE
ARROW-6877: [C++] Add additional Boost versions to support 1.71 and the presumed next 2 future versions

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -586,6 +586,12 @@ if(MSVC AND ARROW_USE_STATIC_CRT)
   set(Boost_USE_STATIC_RUNTIME ON)
 endif()
 set(Boost_ADDITIONAL_VERSIONS
+    "1.73.0"
+    "1.73"
+    "1.72.0"
+    "1.72"
+    "1.71.0"
+    "1.71"
     "1.70.0"
     "1.70"
     "1.69.0"


### PR DESCRIPTION
Boost 1.71 was released and July and landed in conda-forge about 3 weeks ago. 