### PR TITLE
ARROW-6844: [C++][Parquet] Fix regression in reading List types with item name that is not "item"

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -545,7 +545,7 @@ class TestParquetIO : public ::testing::Test {
     // Also test that slice offsets are respected
     values = values->Slice(5, values->length() - 5);
     std::shared_ptr<ListArray> lists;
-    ASSERT_OK(MakeListArray(values, size, nullable_lists ? null_count : 0,
+    ASSERT_OK(MakeListArray(values, size, nullable_lists ? null_count : 0, "element",
                             nullable_elements, &lists));
     *out = MakeSimpleTable(lists->Slice(3, size - 6), nullable_lists);
   }
@@ -564,10 +564,10 @@ class TestParquetIO : public ::testing::Test {
     ASSERT_OK(NullableArray<TestType>(size * 6, nullable_elements ? null_count : 0,
                                       kDefaultSeed, &values));
     std::shared_ptr<ListArray> lists;
-    ASSERT_OK(MakeListArray(values, size * 3, nullable_lists ? null_count : 0,
+    ASSERT_OK(MakeListArray(values, size * 3, nullable_lists ? null_count : 0, "item",
                             nullable_elements, &lists));
     std::shared_ptr<ListArray> parent_lists;
-    ASSERT_OK(MakeListArray(lists, size, nullable_parent_lists ? null_count : 0,
+    ASSERT_OK(MakeListArray(lists, size, nullable_parent_lists ? null_count : 0, "item",
                             nullable_lists, &parent_lists));
     *out = MakeSimpleTable(parent_lists, nullable_parent_lists);
   }
@@ -1829,7 +1829,7 @@ void MakeDoubleTable(int num_columns, int num_rows, int nchunks,
   *out = Table::Make(schema, columns);
 }
 
-void MakeListArray(int num_rows, int max_value_length,
+void MakeListArray(int num_rows, int max_value_length, const std::string& item_name,
                    std::shared_ptr<DataType>* out_type,
                    std::shared_ptr<Array>* out_array) {
   std::vector<int32_t> length_draws;
@@ -1859,10 +1859,9 @@ void MakeListArray(int num_rows, int max_value_length,
                                                       value_draws, &values);
   ::arrow::ArrayFromVector<::arrow::Int32Type, int32_t>(offset_values, &offsets);
 
-  ASSERT_OK(::arrow::ListArray::FromArrays(*offsets, *values, default_memory_pool(),
-                                           out_array));
-
-  *out_type = ::arrow::list(::arrow::int8());
+  *out_type = ::arrow::list(::arrow::field(item_name, ::arrow::int8()));
+  *out_array = std::make_shared<ListArray>(*out_type, offsets->length() - 1,
+                                           offsets->data()->buffers[1], values);
 }
 
 TEST(TestArrowReadWrite, MultithreadedRead) {
@@ -2023,7 +2022,7 @@ TEST(TestArrowReadWrite, ListLargeRecords) {
   std::shared_ptr<Array> list_array;
   std::shared_ptr<DataType> list_type;
 
-  MakeListArray(num_rows, 20, &list_type, &list_array);
+  MakeListArray(num_rows, 20, "item", &list_type, &list_array);
 
   auto schema = ::arrow::schema({::arrow::field("a", list_type)});
 
@@ -2099,7 +2098,7 @@ auto GenerateInt32 = [](int length, std::shared_ptr<DataType>* type,
 
 auto GenerateList = [](int length, std::shared_ptr<DataType>* type,
                        std::shared_ptr<Array>* array) {
-  MakeListArray(length, 100, type, array);
+  MakeListArray(length, 100, "element", type, array);
 };
 
 std::shared_ptr<Table> InvalidTable() {

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1829,9 +1829,9 @@ void MakeDoubleTable(int num_columns, int num_rows, int nchunks,
   *out = Table::Make(schema, columns);
 }
 
-void MakeListArray(int num_rows, int max_value_length, const std::string& item_name,
-                   std::shared_ptr<DataType>* out_type,
-                   std::shared_ptr<Array>* out_array) {
+void MakeSimpleListArray(int num_rows, int max_value_length, const std::string& item_name,
+                         std::shared_ptr<DataType>* out_type,
+                         std::shared_ptr<Array>* out_array) {
   std::vector<int32_t> length_draws;
   randint(num_rows, 0, max_value_length, &length_draws);
 
@@ -2022,7 +2022,7 @@ TEST(TestArrowReadWrite, ListLargeRecords) {
   std::shared_ptr<Array> list_array;
   std::shared_ptr<DataType> list_type;
 
-  MakeListArray(num_rows, 20, "item", &list_type, &list_array);
+  MakeSimpleListArray(num_rows, 20, "item", &list_type, &list_array);
 
   auto schema = ::arrow::schema({::arrow::field("a", list_type)});
 
@@ -2098,7 +2098,7 @@ auto GenerateInt32 = [](int length, std::shared_ptr<DataType>* type,
 
 auto GenerateList = [](int length, std::shared_ptr<DataType>* type,
                        std::shared_ptr<Array>* array) {
-  MakeListArray(length, 100, "element", type, array);
+  MakeSimpleListArray(length, 100, "element", type, array);
 };
 
 std::shared_ptr<Table> InvalidTable() {

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -1264,6 +1264,7 @@ Status ReconstructNestedList(const std::shared_ptr<Array>& arr,
                              const int16_t* rep_levels, int64_t total_levels,
                              ::arrow::MemoryPool* pool, std::shared_ptr<Array>* out) {
   // Walk downwards to extract nullability
+  std::vector<std::string> item_names;
   std::vector<bool> nullable;
   std::vector<std::shared_ptr<::arrow::Int32Builder>> offset_builders;
   std::vector<std::shared_ptr<::arrow::BooleanBuilder>> valid_bits_builders;
@@ -1277,6 +1278,7 @@ Status ReconstructNestedList(const std::shared_ptr<Array>& arr,
       }
       field = field->type()->child(0);
     }
+    item_names.push_back(field->name());
     offset_builders.emplace_back(
         std::make_shared<::arrow::Int32Builder>(::arrow::int32(), pool));
     valid_bits_builders.emplace_back(
@@ -1360,7 +1362,7 @@ Status ReconstructNestedList(const std::shared_ptr<Array>& arr,
   // TODO(wesm): Use passed-in field
   for (int64_t j = list_depth - 1; j >= 0; j--) {
     auto list_type =
-        ::arrow::list(::arrow::field("item", (*out)->type(), nullable[j + 1]));
+        ::arrow::list(::arrow::field(item_names[j], (*out)->type(), nullable[j + 1]));
     *out = std::make_shared<::arrow::ListArray>(list_type, list_lengths[j], offsets[j],
                                                 *out, valid_bits[j], null_counts[j]);
   }

--- a/cpp/src/parquet/arrow/test_util.h
+++ b/cpp/src/parquet/arrow/test_util.h
@@ -368,8 +368,8 @@ typename std::enable_if<is_arrow_bool<ArrowType>::value, Status>::type NullableA
 ///
 /// This helper function only supports (size/2) nulls.
 Status MakeListArray(const std::shared_ptr<Array>& values, int64_t size,
-                     int64_t null_count, bool nullable_values,
-                     std::shared_ptr<::arrow::ListArray>* out) {
+                     int64_t null_count, const std::string& item_name,
+                     bool nullable_values, std::shared_ptr<::arrow::ListArray>* out) {
   // We always include an empty list
   int64_t non_null_entries = size - null_count - 1;
   int64_t length_per_entry = values->length() / non_null_entries;
@@ -397,7 +397,7 @@ Status MakeListArray(const std::shared_ptr<Array>& values, int64_t size,
   }
   offsets_ptr[size] = static_cast<int32_t>(values->length());
 
-  auto value_field = ::arrow::field("item", values->type(), nullable_values);
+  auto value_field = ::arrow::field(item_name, values->type(), nullable_values);
   *out = std::make_shared<::arrow::ListArray>(::arrow::list(value_field), size, offsets,
                                               values, null_bitmap, null_count);
 


### PR DESCRIPTION
This fixes the regression reported in the JIRA. I think this bug got introduced during the various refactorings since 0.14.0.