### PR TITLE
ARROW-6888: [Java] Support copy operation for vector value comparators

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/CompositeVectorComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/CompositeVectorComparator.java
@@ -59,4 +59,13 @@ public class CompositeVectorComparator extends  VectorValueComparator<ValueVecto
     }
     return 0;
   }
+
+  @Override
+  public VectorValueComparator<ValueVector> createNew() {
+    VectorValueComparator[] newInnerComparators = new VectorValueComparator[innerComparators.length];
+    for (int i = 0; i < innerComparators.length; i++) {
+      newInnerComparators[i] = innerComparators[i].createNew();
+    }
+    return new CompositeVectorComparator(newInnerComparators);
+  }
 }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
@@ -99,7 +99,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<TinyIntVector> copy() {
+    public VectorValueComparator<TinyIntVector> clone() {
       return new ByteComparator();
     }
   }
@@ -122,7 +122,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<SmallIntVector> copy() {
+    public VectorValueComparator<SmallIntVector> clone() {
       return new ShortComparator();
     }
   }
@@ -145,7 +145,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<IntVector> copy() {
+    public VectorValueComparator<IntVector> clone() {
       return new IntComparator();
     }
   }
@@ -169,7 +169,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<BigIntVector> copy() {
+    public VectorValueComparator<BigIntVector> clone() {
       return new LongComparator();
     }
   }
@@ -193,7 +193,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<UInt1Vector> copy() {
+    public VectorValueComparator<UInt1Vector> clone() {
       return new UInt1Comparator();
     }
   }
@@ -216,7 +216,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<UInt2Vector> copy() {
+    public VectorValueComparator<UInt2Vector> clone() {
       return new UInt2Comparator();
     }
   }
@@ -239,7 +239,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<UInt4Vector> copy() {
+    public VectorValueComparator<UInt4Vector> clone() {
       return new UInt4Comparator();
     }
   }
@@ -262,7 +262,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<UInt8Vector> copy() {
+    public VectorValueComparator<UInt8Vector> clone() {
       return new UInt8Comparator();
     }
   }
@@ -299,7 +299,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<Float4Vector> copy() {
+    public VectorValueComparator<Float4Vector> clone() {
       return new Float4Comparator();
     }
   }
@@ -336,7 +336,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<Float8Vector> copy() {
+    public VectorValueComparator<Float8Vector> clone() {
       return new Float8Comparator();
     }
   }
@@ -366,7 +366,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<BaseVariableWidthVector> copy() {
+    public VectorValueComparator<BaseVariableWidthVector> clone() {
       return new VariableWidthComparator();
     }
   }
@@ -408,8 +408,8 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<BaseRepeatedValueVector> copy() {
-      VectorValueComparator<T> newInnerComparator = innerComparator.copy();
+    public VectorValueComparator<BaseRepeatedValueVector> clone() {
+      VectorValueComparator<T> newInnerComparator = innerComparator.clone();
       return new RepeatedValueComparator(newInnerComparator);
     }
 

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
@@ -99,7 +99,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<TinyIntVector> clone() {
+    public VectorValueComparator<TinyIntVector> createNew() {
       return new ByteComparator();
     }
   }
@@ -122,7 +122,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<SmallIntVector> clone() {
+    public VectorValueComparator<SmallIntVector> createNew() {
       return new ShortComparator();
     }
   }
@@ -145,7 +145,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<IntVector> clone() {
+    public VectorValueComparator<IntVector> createNew() {
       return new IntComparator();
     }
   }
@@ -169,7 +169,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<BigIntVector> clone() {
+    public VectorValueComparator<BigIntVector> createNew() {
       return new LongComparator();
     }
   }
@@ -193,7 +193,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<UInt1Vector> clone() {
+    public VectorValueComparator<UInt1Vector> createNew() {
       return new UInt1Comparator();
     }
   }
@@ -216,7 +216,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<UInt2Vector> clone() {
+    public VectorValueComparator<UInt2Vector> createNew() {
       return new UInt2Comparator();
     }
   }
@@ -239,7 +239,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<UInt4Vector> clone() {
+    public VectorValueComparator<UInt4Vector> createNew() {
       return new UInt4Comparator();
     }
   }
@@ -262,7 +262,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<UInt8Vector> clone() {
+    public VectorValueComparator<UInt8Vector> createNew() {
       return new UInt8Comparator();
     }
   }
@@ -299,7 +299,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<Float4Vector> clone() {
+    public VectorValueComparator<Float4Vector> createNew() {
       return new Float4Comparator();
     }
   }
@@ -336,7 +336,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<Float8Vector> clone() {
+    public VectorValueComparator<Float8Vector> createNew() {
       return new Float8Comparator();
     }
   }
@@ -366,7 +366,7 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<BaseVariableWidthVector> clone() {
+    public VectorValueComparator<BaseVariableWidthVector> createNew() {
       return new VariableWidthComparator();
     }
   }
@@ -408,8 +408,8 @@ public class DefaultVectorComparators {
     }
 
     @Override
-    public VectorValueComparator<BaseRepeatedValueVector> clone() {
-      VectorValueComparator<T> newInnerComparator = innerComparator.clone();
+    public VectorValueComparator<BaseRepeatedValueVector> createNew() {
+      VectorValueComparator<T> newInnerComparator = innerComparator.createNew();
       return new RepeatedValueComparator(newInnerComparator);
     }
 

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
@@ -97,6 +97,11 @@ public class DefaultVectorComparators {
       byte value2 = vector2.get(index2);
       return value1 - value2;
     }
+
+    @Override
+    public VectorValueComparator<TinyIntVector> copy() {
+      return new ByteComparator();
+    }
   }
 
   /**
@@ -115,6 +120,11 @@ public class DefaultVectorComparators {
       short value2 = vector2.get(index2);
       return value1 - value2;
     }
+
+    @Override
+    public VectorValueComparator<SmallIntVector> copy() {
+      return new ShortComparator();
+    }
   }
 
   /**
@@ -132,6 +142,11 @@ public class DefaultVectorComparators {
       int value1 = vector1.get(index1);
       int value2 = vector2.get(index2);
       return value1 - value2;
+    }
+
+    @Override
+    public VectorValueComparator<IntVector> copy() {
+      return new IntComparator();
     }
   }
 
@@ -152,6 +167,11 @@ public class DefaultVectorComparators {
 
       return Long.signum(value1 - value2);
     }
+
+    @Override
+    public VectorValueComparator<BigIntVector> copy() {
+      return new LongComparator();
+    }
   }
 
   /**
@@ -171,6 +191,11 @@ public class DefaultVectorComparators {
 
       return (value1 & 0xff) - (value2 & 0xff);
     }
+
+    @Override
+    public VectorValueComparator<UInt1Vector> copy() {
+      return new UInt1Comparator();
+    }
   }
 
   /**
@@ -188,6 +213,11 @@ public class DefaultVectorComparators {
       char value1 = vector1.get(index1);
       char value2 = vector2.get(index2);
       return value1 - value2;
+    }
+
+    @Override
+    public VectorValueComparator<UInt2Vector> copy() {
+      return new UInt2Comparator();
     }
   }
 
@@ -207,6 +237,11 @@ public class DefaultVectorComparators {
       int value2 = vector2.get(index2);
       return ByteFunctionHelpers.unsignedIntCompare(value1, value2);
     }
+
+    @Override
+    public VectorValueComparator<UInt4Vector> copy() {
+      return new UInt4Comparator();
+    }
   }
 
   /**
@@ -224,6 +259,11 @@ public class DefaultVectorComparators {
       long value1 = vector1.get(index1);
       long value2 = vector2.get(index2);
       return ByteFunctionHelpers.unsignedLongCompare(value1, value2);
+    }
+
+    @Override
+    public VectorValueComparator<UInt8Vector> copy() {
+      return new UInt8Comparator();
     }
   }
 
@@ -257,6 +297,11 @@ public class DefaultVectorComparators {
 
       return (int) Math.signum(value1 - value2);
     }
+
+    @Override
+    public VectorValueComparator<Float4Vector> copy() {
+      return new Float4Comparator();
+    }
   }
 
   /**
@@ -289,6 +334,11 @@ public class DefaultVectorComparators {
 
       return (int) Math.signum(value1 - value2);
     }
+
+    @Override
+    public VectorValueComparator<Float8Vector> copy() {
+      return new Float8Comparator();
+    }
   }
 
   /**
@@ -313,6 +363,11 @@ public class DefaultVectorComparators {
       vector1.getDataPointer(index1, reusablePointer1);
       vector2.getDataPointer(index2, reusablePointer2);
       return reusablePointer1.compareTo(reusablePointer2);
+    }
+
+    @Override
+    public VectorValueComparator<BaseVariableWidthVector> copy() {
+      return new VariableWidthComparator();
     }
   }
 
@@ -350,6 +405,12 @@ public class DefaultVectorComparators {
         }
       }
       return length1 - length2;
+    }
+
+    @Override
+    public VectorValueComparator<BaseRepeatedValueVector> copy() {
+      VectorValueComparator<T> newInnerComparator = innerComparator.copy();
+      return new RepeatedValueComparator(newInnerComparator);
     }
 
     @Override

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/StableVectorComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/StableVectorComparator.java
@@ -60,8 +60,8 @@ public class StableVectorComparator<V extends ValueVector> extends VectorValueCo
   }
 
   @Override
-  public VectorValueComparator<V> copy() {
-    return new StableVectorComparator<V>(innerComparator.copy());
+  public VectorValueComparator<V> clone() {
+    return new StableVectorComparator<V>(innerComparator.clone());
   }
 
 

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/StableVectorComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/StableVectorComparator.java
@@ -59,5 +59,10 @@ public class StableVectorComparator<V extends ValueVector> extends VectorValueCo
     return result != 0 ? result : index1 - index2;
   }
 
+  @Override
+  public VectorValueComparator<V> copy() {
+    return new StableVectorComparator<V>(innerComparator.copy());
+  }
+
 
 }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/StableVectorComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/StableVectorComparator.java
@@ -60,9 +60,7 @@ public class StableVectorComparator<V extends ValueVector> extends VectorValueCo
   }
 
   @Override
-  public VectorValueComparator<V> clone() {
-    return new StableVectorComparator<V>(innerComparator.clone());
+  public VectorValueComparator<V> createNew() {
+    return new StableVectorComparator<V>(innerComparator.createNew());
   }
-
-
 }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.ValueVector;
  * This is used for vector sorting.
  * @param <V> type of the vector.
  */
-public abstract class VectorValueComparator<V extends ValueVector> {
+public abstract class VectorValueComparator<V extends ValueVector> implements Cloneable {
 
   /**
    * The first vector to compare.
@@ -119,5 +119,6 @@ public abstract class VectorValueComparator<V extends ValueVector> {
    * Creates a comparator of the same type.
    * @return the newly created comparator.
    */
-  public abstract VectorValueComparator<V> copy();
+  @Override
+  public abstract VectorValueComparator<V> clone();
 }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
@@ -114,4 +114,10 @@ public abstract class VectorValueComparator<V extends ValueVector> {
    *     values are equal.
    */
   public abstract int compareNotNull(int index1, int index2);
+
+  /**
+   * Creates a comparator of the same type.
+   * @return the newly created comparator.
+   */
+  public abstract VectorValueComparator<V> copy();
 }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VectorValueComparator.java
@@ -24,7 +24,7 @@ import org.apache.arrow.vector.ValueVector;
  * This is used for vector sorting.
  * @param <V> type of the vector.
  */
-public abstract class VectorValueComparator<V extends ValueVector> implements Cloneable {
+public abstract class VectorValueComparator<V extends ValueVector> {
 
   /**
    * The first vector to compare.
@@ -119,6 +119,5 @@ public abstract class VectorValueComparator<V extends ValueVector> implements Cl
    * Creates a comparator of the same type.
    * @return the newly created comparator.
    */
-  @Override
-  public abstract VectorValueComparator<V> clone();
+  public abstract VectorValueComparator<V> createNew();
 }

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
@@ -123,7 +123,7 @@ public class TestDefaultVectorComparator {
                   DefaultVectorComparators.createDefaultComparator(listVector1);
           comparator.attachVectors(listVector1, listVector2);
 
-          VectorValueComparator<ListVector> copyComparator = comparator.clone();
+          VectorValueComparator<ListVector> copyComparator = comparator.createNew();
           copyComparator.attachVectors(listVector1, listVector2);
 
           assertEquals(comparator.compare(0, 0), copyComparator.compare(0, 0));

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
@@ -123,7 +123,7 @@ public class TestDefaultVectorComparator {
                   DefaultVectorComparators.createDefaultComparator(listVector1);
           comparator.attachVectors(listVector1, listVector2);
 
-          VectorValueComparator<ListVector> copyComparator = comparator.copy();
+          VectorValueComparator<ListVector> copyComparator = comparator.clone();
           copyComparator.attachVectors(listVector1, listVector2);
 
           assertEquals(comparator.compare(0, 0), copyComparator.compare(0, 0));

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestDefaultVectorComparator.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.algorithm.sort;
 
 import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.OFFSET_WIDTH;
+import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -109,6 +110,25 @@ public class TestDefaultVectorComparator {
 
       // list vector elements equal
       assertTrue(comparator.compare(0, 0) == 0);
+    }
+  }
+
+  @Test
+  public void testCopiedComparatorForLists() {
+    for (int i = 1; i < 10; i++) {
+      for (int j = 1; j < 10; j++) {
+        try (ListVector listVector1 = createListVector(10);
+             ListVector listVector2 = createListVector(11)) {
+          VectorValueComparator<ListVector> comparator =
+                  DefaultVectorComparators.createDefaultComparator(listVector1);
+          comparator.attachVectors(listVector1, listVector2);
+
+          VectorValueComparator<ListVector> copyComparator = comparator.copy();
+          copyComparator.attachVectors(listVector1, listVector2);
+
+          assertEquals(comparator.compare(0, 0), copyComparator.compare(0, 0));
+        }
+      }
     }
   }
 

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestStableVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestStableVectorComparator.java
@@ -128,5 +128,10 @@ public class TestStableVectorComparator {
       byte b2 = vector2.get(index2)[0];
       return b1 - b2;
     }
+
+    @Override
+    public VectorValueComparator<VarCharVector> copy() {
+      return new TestVarCharSorter();
+    }
   }
 }

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestStableVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestStableVectorComparator.java
@@ -130,7 +130,7 @@ public class TestStableVectorComparator {
     }
 
     @Override
-    public VectorValueComparator<VarCharVector> copy() {
+    public VectorValueComparator<VarCharVector> clone() {
       return new TestVarCharSorter();
     }
   }

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestStableVectorComparator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestStableVectorComparator.java
@@ -130,7 +130,7 @@ public class TestStableVectorComparator {
     }
 
     @Override
-    public VectorValueComparator<VarCharVector> clone() {
+    public VectorValueComparator<VarCharVector> createNew() {
       return new TestVarCharSorter();
     }
   }


### PR DESCRIPTION
In this issue, we provide copy operations for vector value comparators. This operation creates another comparator with the same type and comparison logic.

This feature is useful in multi-threading scenarios where multiple threads uses the comparator to perform their own task. In this scenario, we have no way of making sure the compare method is thread safe. So a safe way is to create a new comparator for each thread. The copy operation will support this.

An immediate application of this is the parallel searcher for ordering semantics.