### PR TITLE
ARROW-6889: [Java] ComplexCopier enable FixedSizeList type & fix RangeEqualsVisitor StackOverFlow

### DIFF
--- a/java/vector/src/main/codegen/templates/ComplexCopier.java
+++ b/java/vector/src/main/codegen/templates/ComplexCopier.java
@@ -15,6 +15,9 @@
  * limitations under the License.
  */
 
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.complex.writer.FieldWriter;
+
 <@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/ComplexCopier.java" />
 
@@ -47,16 +50,16 @@ public class ComplexCopier {
 
       case LIST:
       case MAP:
+      case FIXED_SIZE_LIST:
         if (reader.isSet()) {
           writer.startList();
+          FieldWriter dataWriter = getListWriterForReader(reader.reader(), writer);
           while (reader.next()) {
-            writeValue(reader.reader(), getListWriterForReader(reader.reader(), writer));
+            writeValue(reader.reader(), dataWriter);
           }
           writer.endList();
         }
         break;
-      case FIXED_SIZE_LIST:
-        throw new UnsupportedOperationException("Copy fixed size list");
       case STRUCT:
         if (reader.isSet()) {
           writer.start();
@@ -102,7 +105,9 @@ public class ComplexCopier {
     </#list></#list>
     case STRUCT:
       return (FieldWriter) writer.struct(name);
+    case FIXED_SIZE_LIST:
     case LIST:
+    case MAP:
       return (FieldWriter) writer.list(name);
     default:
       throw new UnsupportedOperationException(reader.getMinorType().toString());
@@ -121,7 +126,9 @@ public class ComplexCopier {
     </#list></#list>
     case STRUCT:
       return (FieldWriter) writer.struct();
+    case FIXED_SIZE_LIST:
     case LIST:
+    case MAP:
       return (FieldWriter) writer.list();
     default:
       throw new UnsupportedOperationException(reader.getMinorType().toString());

--- a/java/vector/src/main/codegen/templates/ComplexCopier.java
+++ b/java/vector/src/main/codegen/templates/ComplexCopier.java
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 
 <@pp.dropOutputFile />

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/RangeEqualsVisitor.java
@@ -342,7 +342,7 @@ public class RangeEqualsVisitor implements VectorVisitor<Boolean, Range> {
     }
 
     int listSize = leftVector.getListSize();
-    RangeEqualsVisitor innerVisitor = createInnerVisitor(leftVector, rightVector);
+    RangeEqualsVisitor innerVisitor = createInnerVisitor(leftVector.getDataVector(), rightVector.getDataVector());
     Range innerRange = new Range(0, 0, listSize);
 
     for (int i = 0; i < range.getLength(); i++) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -30,10 +30,12 @@ import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.ZeroVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.complex.impl.NullableStructWriter;
+import org.apache.arrow.vector.complex.impl.UnionFixedSizeListWriter;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
 import org.apache.arrow.vector.holders.NullableFloat4Holder;
 import org.apache.arrow.vector.holders.NullableFloat8Holder;
@@ -195,6 +197,39 @@ public class TestRangeEqualsVisitor {
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector1, vector2);
       assertTrue(visitor.rangeEquals(new Range(1, 1, 3)));
+    }
+  }
+
+  @Test
+  public void testFixedSizeListVectorRangeEquals() {
+    try (final FixedSizeListVector vector1 = FixedSizeListVector.empty("list", 2, allocator);
+         final FixedSizeListVector vector2 = FixedSizeListVector.empty("list", 2, allocator);) {
+
+      UnionFixedSizeListWriter writer1 = vector1.getWriter();
+      writer1.allocate();
+
+      //set some values
+      writeFixedSizeListVector(writer1, new int[] {1, 2});
+      writeFixedSizeListVector(writer1, new int[] {3, 4});
+      writeFixedSizeListVector(writer1, new int[] {5, 6});
+      writeFixedSizeListVector(writer1, new int[] {7, 8});
+      writeFixedSizeListVector(writer1, new int[] {9, 10});
+      writer1.setValueCount(5);
+
+      UnionFixedSizeListWriter writer2 = vector2.getWriter();
+      writer2.allocate();
+
+      //set some values
+      writeFixedSizeListVector(writer2, new int[] {0, 0});
+      writeFixedSizeListVector(writer2, new int[] {3, 4});
+      writeFixedSizeListVector(writer2, new int[] {5, 6});
+      writeFixedSizeListVector(writer2, new int[] {7, 8});
+      writeFixedSizeListVector(writer2, new int[] {0, 0});
+      writer2.setValueCount(5);
+
+      RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector1, vector2);
+      assertTrue(visitor.rangeEquals(new Range(1, 1, 3)));
+      assertFalse(visitor.rangeEquals(new Range(0, 0, 5)));
     }
   }
 
@@ -483,6 +518,14 @@ public class TestRangeEqualsVisitor {
   }
 
   private void writeListVector(UnionListWriter writer, int[] values) {
+    writer.startList();
+    for (int v: values) {
+      writer.integer().writeInt(v);
+    }
+    writer.endList();
+  }
+
+  private void writeFixedSizeListVector(UnionFixedSizeListWriter writer, int[] values) {
     writer.startList();
     for (int v: values) {
       writer.integer().writeInt(v);

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector.complex.impl;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -82,7 +83,7 @@ public class TestComplexCopier {
     }
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testInvalidCopyFixedSizeListVector() {
     try (FixedSizeListVector from = FixedSizeListVector.empty("from", 3, allocator);
         FixedSizeListVector to = FixedSizeListVector.empty("to", 2, allocator)) {
@@ -105,11 +106,9 @@ public class TestComplexCopier {
       // copy values
       FieldReader in = from.getReader();
       FieldWriter out = to.getWriter();
-      for (int i = 0; i < COUNT; i++) {
-        in.setPosition(i);
-        out.setPosition(i);
-        ComplexCopier.copy(in, out);
-      }
+      IllegalStateException e = assertThrows(IllegalStateException.class,
+          () -> ComplexCopier.copy(in, out));
+      assertTrue(e.getMessage().contains("greater than listSize"));
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.complex.impl;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.compare.VectorEqualsVisitor;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.reader.FieldReader;
+import org.apache.arrow.vector.complex.writer.FieldWriter;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestComplexCopier {
+
+  private BufferAllocator allocator;
+
+  private static final int COUNT = 100;
+
+  @Before
+  public void init() {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+  }
+
+  @After
+  public void terminate() throws Exception {
+    allocator.close();
+  }
+
+  @Test
+  public void testCopyFixedSizeListVector() {
+    try (FixedSizeListVector from = FixedSizeListVector.empty("from", 3, allocator);
+         FixedSizeListVector to = FixedSizeListVector.empty("to", 3, allocator)) {
+
+      from.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
+      to.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
+
+      // populate from vector
+      UnionFixedSizeListWriter writer = from.getWriter();
+      for (int i = 0; i < COUNT; i++) {
+        writer.startList();
+        writer.integer().writeInt(i);
+        writer.integer().writeInt(i * 2);
+        writer.integer().writeInt(i * 3);
+        writer.endList();
+      }
+      from.setValueCount(COUNT);
+      to.setValueCount(COUNT);
+
+      // copy values
+      FieldReader in = from.getReader();
+      FieldWriter out = to.getWriter();
+      for (int i = 0; i < COUNT; i++) {
+        in.setPosition(i);
+        out.setPosition(i);
+        ComplexCopier.copy(in, out);
+      }
+
+      // validate equals
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
+
+    }
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testInvalidCopyFixedSizeListVector() {
+    try (FixedSizeListVector from = FixedSizeListVector.empty("from", 3, allocator);
+        FixedSizeListVector to = FixedSizeListVector.empty("to", 2, allocator)) {
+
+      from.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
+      to.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
+
+      // populate from vector
+      UnionFixedSizeListWriter writer = from.getWriter();
+      for (int i = 0; i < COUNT; i++) {
+        writer.startList();
+        writer.integer().writeInt(i);
+        writer.integer().writeInt(i * 2);
+        writer.integer().writeInt(i * 3);
+        writer.endList();
+      }
+      from.setValueCount(COUNT);
+      to.setValueCount(COUNT);
+
+      // copy values
+      FieldReader in = from.getReader();
+      FieldWriter out = to.getWriter();
+      for (int i = 0; i < COUNT; i++) {
+        in.setPosition(i);
+        out.setPosition(i);
+        ComplexCopier.copy(in, out);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Related to [ARROW-6889](https://issues.apache.org/jira/browse/ARROW-6889).

i. Enable ComplexCopier copy FixedSizeListVector value, add related tests
ii. Fix RangeEqualsVisitor#compareFixedSizeListVectors StackOverFlow
