### PR TITLE
ARROW-6884: [Python] Format friendlier message in Python when a server-side RPC handler fails

### DIFF
--- a/cpp/src/arrow/flight/internal.cc
+++ b/cpp/src/arrow/flight/internal.cc
@@ -21,6 +21,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
 
@@ -57,9 +58,12 @@ Status FromGrpcStatus(const grpc::Status& grpc_status) {
       return Status::IOError("gRPC cancelled call, with message: ",
                              grpc_status.error_message())
           .WithDetail(std::make_shared<FlightStatusDetail>(FlightStatusCode::Cancelled));
-    case grpc::StatusCode::UNKNOWN:
-      return Status::UnknownError("gRPC returned unknown error, with message: ",
-                                  grpc_status.error_message());
+    case grpc::StatusCode::UNKNOWN: {
+      std::stringstream ss;
+      ss << "Flight RPC failed with message: " << grpc_status.error_message();
+      return Status::UnknownError(ss.str()).WithDetail(
+          std::make_shared<FlightStatusDetail>(FlightStatusCode::Failed));
+    }
     case grpc::StatusCode::INVALID_ARGUMENT:
       return Status::Invalid("gRPC returned invalid argument error, with message: ",
                              grpc_status.error_message());

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -65,6 +65,8 @@ enum class FlightStatusCode : int8_t {
   Unauthorized,
   /// The remote service cannot handle this request at the moment.
   Unavailable,
+  /// A request failed for some other reason
+  Failed
 };
 
 // Silence warning

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -23,6 +23,7 @@ from __future__ import absolute_import
 import collections
 import contextlib
 import enum
+import re
 import socket
 import time
 import threading
@@ -74,11 +75,15 @@ cdef int check_flight_status(const CStatus& status) nogil except -1:
     return check_status(status)
 
 
+_FLIGHT_SERVER_ERROR_REGEX = re.compile(
+    r'Flight RPC failed with message: (.*). Detail: '
+    r'Python exception: (.*)',
+    re.DOTALL
+)
+
+
 def _munge_grpc_python_error(message):
-    import re
-    pat = re.compile(r'Flight RPC failed with message: (.*). Detail: '
-                     r'Python exception: (.*)')
-    m = pat.match(message)
+    m = _FLIGHT_SERVER_ERROR_REGEX.match(message)
     if m:
         return ('Flight RPC failed with Python exception \"{}: {}\"'
                 .format(m.group(2), m.group(1)))

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -57,6 +57,8 @@ cdef int check_flight_status(const CStatus& status) nogil except -1:
             message = frombytes(status.message())
             if detail.get().code() == CFlightStatusInternal:
                 raise FlightInternalError(message)
+            elif detail.get().code() == CFlightStatusFailed:
+                raise FlightServerError(message)
             elif detail.get().code() == CFlightStatusTimedOut:
                 raise FlightTimedOutError(message)
             elif detail.get().code() == CFlightStatusCancelled:
@@ -128,6 +130,11 @@ cdef class FlightTimedOutError(FlightError, ArrowException):
 cdef class FlightCancelledError(FlightError, ArrowException):
     cdef CStatus to_status(self):
         return MakeFlightError(CFlightStatusCancelled, tobytes(str(self)))
+
+
+cdef class FlightServerError(FlightError, ArrowException):
+    cdef CStatus to_status(self):
+        return MakeFlightError(CFlightStatusFailed, tobytes(str(self)))
 
 
 cdef class FlightUnauthenticatedError(FlightError, ArrowException):

--- a/python/pyarrow/flight.py
+++ b/python/pyarrow/flight.py
@@ -40,6 +40,7 @@ from pyarrow._flight import (  # noqa
     FlightInternalError,
     FlightTimedOutError,
     FlightCancelledError,
+    FlightServerError,
     FlightUnauthenticatedError,
     FlightUnauthorizedError,
     FlightUnavailableError,

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -318,6 +318,8 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
         " arrow::flight::FlightStatusCode::Unauthorized"
     CFlightStatusCode CFlightStatusUnavailable \
         " arrow::flight::FlightStatusCode::Unavailable"
+    CFlightStatusCode CFlightStatusFailed \
+        " arrow::flight::FlightStatusCode::Failed"
 
     cdef cppclass FlightStatusDetail" arrow::flight::FlightStatusDetail":
         CFlightStatusCode code()

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -577,7 +577,10 @@ def test_list_actions():
     # ARROW-6392
     with ListActionsErrorFlightServer() as server:
         client = FlightClient(('localhost', server.port))
-        with pytest.raises(pa.ArrowException, match=".*unknown error.*"):
+        with pytest.raises(
+                flight.FlightServerError,
+                match="Results of list_actions must be ActionType or tuple"
+        ):
             list(client.list_actions())
 
     with ListActionsFlightServer() as server:
@@ -616,8 +619,12 @@ def test_do_action_result_convenience():
         results = [x.body for x in client.do_action(('echo', body))]
         assert results == [body]
 
-        # ARROW-6884 raise a more specific and helpful exception
-        with pytest.raises(Exception):
+
+def test_nicer_server_exceptions():
+    with ConvenienceServer() as server:
+        client = FlightClient(('localhost', server.port))
+        with pytest.raises(flight.FlightServerError,
+                           match="a bytes-like object is required"):
             list(client.do_action('bad-action'))
 
 

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -579,7 +579,8 @@ def test_list_actions():
         client = FlightClient(('localhost', server.port))
         with pytest.raises(
                 flight.FlightServerError,
-                match="Results of list_actions must be ActionType or tuple"
+                match=("TypeError: Results of list_actions must be "
+                       "ActionType or tuple")
         ):
             list(client.list_actions())
 
@@ -624,7 +625,7 @@ def test_nicer_server_exceptions():
     with ConvenienceServer() as server:
         client = FlightClient(('localhost', server.port))
         with pytest.raises(flight.FlightServerError,
-                           match="a bytes-like object is required"):
+                           match="TypeError: a bytes-like object is required"):
             list(client.do_action('bad-action'))
 
 


### PR DESCRIPTION
I added a "Failure" Flight error code to communicate to Python to create the ServerError exception type. 

Now we have server exceptions like

```
pyarrow._flight.FlightServerError: Flight RPC failed with Python exception "TypeError: Results of list_actions must be ActionType or tuple"
```

instead of

```
pyarrow.lib.ArrowException: Unknown error: gRPC returned unknown error, with message: Results of list_actions must be ActionType or tuple. Detail: Python exception: TypeError
```

It's a small thing but makes it more clear what's going on.