### PR TITLE
ARROW-6896: [Java] Vector schema root should not share vectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -159,38 +159,29 @@ public class VectorSchemaRoot implements AutoCloseable {
   }
 
   /**
-   * Add vector to the record batch, producing a new VectorSchemaRoot.
-   * @param index field index
-   * @param vector vector to be added.
-   * @return out VectorSchemaRoot with vector added
+   * Add a vector to the record batch.
+   * @param index position of the new vector.
+   * @param vector the vector to be added.
    */
-  public VectorSchemaRoot addVector(int index, FieldVector vector) {
+  public void addVector(int index, FieldVector vector) {
     Preconditions.checkNotNull(vector);
     Preconditions.checkArgument(index >= 0 && index < fieldVectors.size());
-    List<FieldVector> newVectors = new ArrayList<>();
-    for (int i = 0; i < fieldVectors.size(); i++) {
-      if (i == index) {
-        newVectors.add(vector);
-      }
-      newVectors.add(fieldVectors.get(i));
-    }
-    return new VectorSchemaRoot(newVectors);
+
+    fieldVectors.add(index, vector);
+    syncSchema();
   }
 
   /**
-   * Remove vector from the record batch, producing a new VectorSchemaRoot.
-   * @param index field index
-   * @return out VectorSchemaRoot with vector removed
+   * Remove a vector from the record batch.
+   * @param index the index of the vector to remove
+   * @return the removed vector.
    */
-  public VectorSchemaRoot removeVector(int index) {
+  public FieldVector removeVector(int index) {
     Preconditions.checkArgument(index >= 0 && index < fieldVectors.size());
-    List<FieldVector> newVectors = new ArrayList<>();
-    for (int i = 0; i < fieldVectors.size(); i++) {
-      if (i != index) {
-        newVectors.add(fieldVectors.get(i));
-      }
-    }
-    return new VectorSchemaRoot(newVectors);
+
+    FieldVector ret = fieldVectors.remove(index);
+    syncSchema();
+    return ret;
   }
 
   public Schema getSchema() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorSchemaRoot.java
@@ -165,7 +165,7 @@ public class VectorSchemaRoot implements AutoCloseable {
    */
   public void addVector(int index, FieldVector vector) {
     Preconditions.checkNotNull(vector);
-    Preconditions.checkArgument(index >= 0 && index < fieldVectors.size());
+    Preconditions.checkArgument(index >= 0 && index <= fieldVectors.size());
 
     fieldVectors.add(index, vector);
     syncSchema();

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
@@ -160,15 +160,14 @@ public class TestVectorSchemaRoot {
          final IntVector intVector2 = new IntVector("intVector2", allocator);
          final IntVector intVector3 = new IntVector("intVector3", allocator);) {
 
-      VectorSchemaRoot original = new VectorSchemaRoot(Arrays.asList(intVector1, intVector2));
-      assertEquals(2, original.getFieldVectors().size());
+      try (VectorSchemaRoot original = new VectorSchemaRoot(Arrays.asList(intVector1, intVector2))) {
+        assertEquals(2, original.getFieldVectors().size());
 
-      VectorSchemaRoot newRecordBatch = original.addVector(1, intVector3);
-      assertEquals(3, newRecordBatch.getFieldVectors().size());
-      assertEquals(intVector3, newRecordBatch.getFieldVectors().get(1));
+        original.addVector(1, intVector3);
 
-      original.close();
-      newRecordBatch.close();
+        assertEquals(3, original.getFieldVectors().size());
+        assertTrue(intVector3 == original.getFieldVectors().get(1));
+      }
     }
   }
 
@@ -178,17 +177,16 @@ public class TestVectorSchemaRoot {
         final IntVector intVector2 = new IntVector("intVector2", allocator);
         final IntVector intVector3 = new IntVector("intVector3", allocator);) {
 
-      VectorSchemaRoot original =
-          new VectorSchemaRoot(Arrays.asList(intVector1, intVector2, intVector3));
-      assertEquals(3, original.getFieldVectors().size());
+      try (VectorSchemaRoot original =
+          new VectorSchemaRoot(Arrays.asList(intVector1, intVector2, intVector3))) {
+        assertEquals(3, original.getFieldVectors().size());
 
-      VectorSchemaRoot newRecordBatch = original.removeVector(0);
-      assertEquals(2, newRecordBatch.getFieldVectors().size());
-      assertEquals(intVector2, newRecordBatch.getFieldVectors().get(0));
-      assertEquals(intVector3, newRecordBatch.getFieldVectors().get(1));
-
-      original.close();
-      newRecordBatch.close();
+        IntVector removed = (IntVector) original.removeVector(0);
+        assertEquals(2, original.getFieldVectors().size());
+        assertTrue(intVector2 == original.getFieldVectors().get(0));
+        assertTrue(intVector3 == original.getFieldVectors().get(1));
+        assertTrue(intVector1 == removed);
+      }
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
@@ -163,10 +163,12 @@ public class TestVectorSchemaRoot {
       try (VectorSchemaRoot original = new VectorSchemaRoot(Arrays.asList(intVector1, intVector2))) {
         assertEquals(2, original.getFieldVectors().size());
 
-        original.addVector(1, intVector3);
+        original.addVector(2, intVector3);
 
         assertEquals(3, original.getFieldVectors().size());
-        assertTrue(intVector3 == original.getFieldVectors().get(1));
+        assertTrue(intVector1 == original.getFieldVectors().get(0));
+        assertTrue(intVector2 == original.getFieldVectors().get(1));
+        assertTrue(intVector3 == original.getFieldVectors().get(2));
       }
     }
   }


### PR DESCRIPTION
Vector schema root should not share vectors. Otherwise, unexpectd behavior would happen.

Please note that VectorSchemaRoot is not just a container for vectors, it is also a resource (it implements the AutoClosable interface), and it manages the life cycle of its inner vectors.

When two VectorSchemaRoots share vectors, something unexpected may happen. Consider the following scenario, which is frequently encountered in a SQL engine.

1. We create a batch:
VectorSchemaRoot oldBatch = ...

2. We add a vector to it, which results in a new batch
VectorSchemaRoot newBatch = oldBatch.addVector(vector);

3. We are done with the old batch, and release the resource
oldBatch.close();

4. We continue to use the new batch, but gets an exception, because some inner vectors have been released by the old batch.