### PR TITLE
ARROW-6898: [Java] Fix potential memory leak in ArrowWriter and several test classes

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.VectorUnloader;
@@ -189,7 +190,10 @@ public abstract class ArrowWriter implements AutoCloseable {
     try {
       end();
       out.close();
-    } catch (IOException e) {
+      if (!dictWritten) {
+        AutoCloseables.close(dictionaries);
+      }
+    } catch (Exception e) {
       throw new RuntimeException(e);
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBufferOwnershipTransfer.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBufferOwnershipTransfer.java
@@ -49,6 +49,12 @@ public class TestBufferOwnershipTransfer {
 
     assertEquals(0, childAllocator1.getAllocatedMemory());
     assertEquals(totalAllocatedMemory, childAllocator2.getAllocatedMemory());
+
+    v1.close();
+    v2.close();
+    childAllocator1.close();
+    childAllocator2.close();
+    allocator.close();
   }
 
   @Test
@@ -69,6 +75,12 @@ public class TestBufferOwnershipTransfer {
 
     assertEquals(0, childAllocator1.getAllocatedMemory());
     assertEquals(memoryBeforeTransfer, childAllocator2.getAllocatedMemory());
+
+    v1.close();
+    v2.close();
+    childAllocator1.close();
+    childAllocator2.close();
+    allocator.close();
   }
 
   private static class Pointer<T> {
@@ -111,5 +123,9 @@ public class TestBufferOwnershipTransfer {
 
     assertFalse(trigger1.value);
     assertFalse(trigger2.value);
+
+    v1.close();
+    v2.close();
+    allocator.close();
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
@@ -70,16 +71,28 @@ import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.arrow.vector.util.JsonStringHashMap;
 import org.apache.arrow.vector.util.Text;
 import org.apache.arrow.vector.util.TransferPair;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import io.netty.buffer.ArrowBuf;
 
 public class TestComplexWriter {
 
-  private static final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
+  private BufferAllocator allocator;
 
   private static final int COUNT = 100;
+
+  @Before
+  public void init() {
+    allocator = new RootAllocator(Integer.MAX_VALUE);
+  }
+
+  @After
+  public void terminate() throws Exception {
+    allocator.close();
+  }
 
   @Test
   public void simpleNestedTypes() {
@@ -98,19 +111,19 @@ public class TestComplexWriter {
   public void transferPairSchemaChange() {
     SchemaChangeCallBack callBack1 = new SchemaChangeCallBack();
     SchemaChangeCallBack callBack2 = new SchemaChangeCallBack();
-    NonNullableStructVector parent = populateStructVector(callBack1);
+    try (NonNullableStructVector parent = populateStructVector(callBack1)) {
+      TransferPair tp = parent.getTransferPair("newVector", allocator, callBack2);
 
-    TransferPair tp = parent.getTransferPair("newVector", allocator, callBack2);
+      ComplexWriter writer = new ComplexWriterImpl("newWriter", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
+      IntWriter intWriter = rootWriter.integer("newInt");
+      intWriter.writeInt(1);
+      writer.setValueCount(1);
 
-    ComplexWriter writer = new ComplexWriterImpl("newWriter", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
-    IntWriter intWriter = rootWriter.integer("newInt");
-    intWriter.writeInt(1);
-    writer.setValueCount(1);
-
-    assertTrue(callBack1.getSchemaChangedAndReset());
-    // The second vector should not have registered a schema change
-    assertFalse(callBack1.getSchemaChangedAndReset());
+      assertTrue(callBack1.getSchemaChangedAndReset());
+      // The second vector should not have registered a schema change
+      assertFalse(callBack1.getSchemaChangedAndReset());
+    }
   }
 
   private NonNullableStructVector populateStructVector(CallBack callBack) {
@@ -195,150 +208,156 @@ public class TestComplexWriter {
 
   @Test
   public void testList() {
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
 
-    rootWriter.start();
-    rootWriter.bigInt("int").writeBigInt(0);
-    rootWriter.list("list").startList();
-    rootWriter.list("list").bigInt().writeBigInt(0);
-    rootWriter.list("list").endList();
-    rootWriter.end();
+      rootWriter.start();
+      rootWriter.bigInt("int").writeBigInt(0);
+      rootWriter.list("list").startList();
+      rootWriter.list("list").bigInt().writeBigInt(0);
+      rootWriter.list("list").endList();
+      rootWriter.end();
 
-    rootWriter.start();
-    rootWriter.bigInt("int").writeBigInt(1);
-    rootWriter.end();
+      rootWriter.start();
+      rootWriter.bigInt("int").writeBigInt(1);
+      rootWriter.end();
 
-    writer.setValueCount(2);
+      writer.setValueCount(2);
 
-    StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
+      StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
 
-    rootReader.setPosition(0);
-    assertTrue("row 0 list is not set", rootReader.reader("list").isSet());
-    assertEquals(Long.valueOf(0), rootReader.reader("list").reader().readLong());
+      rootReader.setPosition(0);
+      assertTrue("row 0 list is not set", rootReader.reader("list").isSet());
+      assertEquals(Long.valueOf(0), rootReader.reader("list").reader().readLong());
 
-    rootReader.setPosition(1);
-    assertFalse("row 1 list is set", rootReader.reader("list").isSet());
+      rootReader.setPosition(1);
+      assertFalse("row 1 list is set", rootReader.reader("list").isSet());
+    }
   }
 
   @Test
   public void listScalarType() {
-    ListVector listVector = ListVector.empty("list", allocator);
-    listVector.allocateNew();
-    UnionListWriter listWriter = new UnionListWriter(listVector);
-    for (int i = 0; i < COUNT; i++) {
-      listWriter.startList();
-      for (int j = 0; j < i % 7; j++) {
-        if (j % 2 == 0) {
-          listWriter.writeInt(j);
-        } else {
-          IntHolder holder = new IntHolder();
-          holder.value = j;
-          listWriter.write(holder);
+    try (ListVector listVector = ListVector.empty("list", allocator)) {
+      listVector.allocateNew();
+      UnionListWriter listWriter = new UnionListWriter(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listWriter.startList();
+        for (int j = 0; j < i % 7; j++) {
+          if (j % 2 == 0) {
+            listWriter.writeInt(j);
+          } else {
+            IntHolder holder = new IntHolder();
+            holder.value = j;
+            listWriter.write(holder);
+          }
         }
+        listWriter.endList();
       }
-      listWriter.endList();
-    }
-    listWriter.setValueCount(COUNT);
-    UnionListReader listReader = new UnionListReader(listVector);
-    for (int i = 0; i < COUNT; i++) {
-      listReader.setPosition(i);
-      for (int j = 0; j < i % 7; j++) {
-        listReader.next();
-        assertEquals(j, listReader.reader().readInteger().intValue());
+      listWriter.setValueCount(COUNT);
+      UnionListReader listReader = new UnionListReader(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listReader.setPosition(i);
+        for (int j = 0; j < i % 7; j++) {
+          listReader.next();
+          assertEquals(j, listReader.reader().readInteger().intValue());
+        }
       }
     }
   }
 
   @Test
   public void listDecimalType() {
-    ListVector listVector = ListVector.empty("list", allocator);
-    listVector.allocateNew();
-    UnionListWriter listWriter = new UnionListWriter(listVector);
-    DecimalHolder holder = new DecimalHolder();
-    holder.buffer = allocator.buffer(DecimalUtility.DECIMAL_BYTE_LENGTH);
-    for (int i = 0; i < COUNT; i++) {
-      listWriter.startList();
-      for (int j = 0; j < i % 7; j++) {
-        if (j % 2 == 0) {
-          listWriter.writeDecimal(new BigDecimal(j));
-        } else {
-          DecimalUtility.writeBigDecimalToArrowBuf(new BigDecimal(j), holder.buffer, 0);
-          holder.start = 0;
-          holder.scale = 0;
-          holder.precision = 10;
-          listWriter.write(holder);
+    try (ListVector listVector = ListVector.empty("list", allocator)) {
+      listVector.allocateNew();
+      UnionListWriter listWriter = new UnionListWriter(listVector);
+      DecimalHolder holder = new DecimalHolder();
+      holder.buffer = allocator.buffer(DecimalUtility.DECIMAL_BYTE_LENGTH);
+      for (int i = 0; i < COUNT; i++) {
+        listWriter.startList();
+        for (int j = 0; j < i % 7; j++) {
+          if (j % 2 == 0) {
+            listWriter.writeDecimal(new BigDecimal(j));
+          } else {
+            DecimalUtility.writeBigDecimalToArrowBuf(new BigDecimal(j), holder.buffer, 0);
+            holder.start = 0;
+            holder.scale = 0;
+            holder.precision = 10;
+            listWriter.write(holder);
+          }
+        }
+        listWriter.endList();
+      }
+      listWriter.setValueCount(COUNT);
+      UnionListReader listReader = new UnionListReader(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listReader.setPosition(i);
+        for (int j = 0; j < i % 7; j++) {
+          listReader.next();
+          Object expected = new BigDecimal(j);
+          Object actual = listReader.reader().readBigDecimal();
+          assertEquals(expected, actual);
         }
       }
-      listWriter.endList();
-    }
-    listWriter.setValueCount(COUNT);
-    UnionListReader listReader = new UnionListReader(listVector);
-    for (int i = 0; i < COUNT; i++) {
-      listReader.setPosition(i);
-      for (int j = 0; j < i % 7; j++) {
-        listReader.next();
-        Object expected = new BigDecimal(j);
-        Object actual = listReader.reader().readBigDecimal();
-        assertEquals(expected, actual);
-      }
+      holder.buffer.close();
     }
   }
 
   @Test
   public void listScalarTypeNullable() {
-    ListVector listVector = ListVector.empty("list", allocator);
-    listVector.allocateNew();
-    UnionListWriter listWriter = new UnionListWriter(listVector);
-    for (int i = 0; i < COUNT; i++) {
-      if (i % 2 == 0) {
-        listWriter.setPosition(i);
-        listWriter.startList();
-        for (int j = 0; j < i % 7; j++) {
-          listWriter.writeInt(j);
+    try (ListVector listVector = ListVector.empty("list", allocator)) {
+      listVector.allocateNew();
+      UnionListWriter listWriter = new UnionListWriter(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        if (i % 2 == 0) {
+          listWriter.setPosition(i);
+          listWriter.startList();
+          for (int j = 0; j < i % 7; j++) {
+            listWriter.writeInt(j);
+          }
+          listWriter.endList();
         }
-        listWriter.endList();
       }
-    }
-    listWriter.setValueCount(COUNT);
-    UnionListReader listReader = new UnionListReader(listVector);
-    for (int i = 0; i < COUNT; i++) {
-      listReader.setPosition(i);
-      if (i % 2 == 0) {
-        assertTrue("index is set: " + i, listReader.isSet());
-        assertEquals("correct length at: " + i, i % 7, ((List<?>) listReader.readObject()).size());
-      } else {
-        assertFalse("index is not set: " + i, listReader.isSet());
-        assertNull("index is not set: " + i, listReader.readObject());
+      listWriter.setValueCount(COUNT);
+      UnionListReader listReader = new UnionListReader(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listReader.setPosition(i);
+        if (i % 2 == 0) {
+          assertTrue("index is set: " + i, listReader.isSet());
+          assertEquals("correct length at: " + i, i % 7, ((List<?>) listReader.readObject()).size());
+        } else {
+          assertFalse("index is not set: " + i, listReader.isSet());
+          assertNull("index is not set: " + i, listReader.readObject());
+        }
       }
     }
   }
 
   @Test
   public void listStructType() {
-    ListVector listVector = ListVector.empty("list", allocator);
-    listVector.allocateNew();
-    UnionListWriter listWriter = new UnionListWriter(listVector);
-    StructWriter structWriter = listWriter.struct();
-    for (int i = 0; i < COUNT; i++) {
-      listWriter.startList();
-      for (int j = 0; j < i % 7; j++) {
-        structWriter.start();
-        structWriter.integer("int").writeInt(j);
-        structWriter.bigInt("bigInt").writeBigInt(j);
-        structWriter.end();
+    try (ListVector listVector = ListVector.empty("list", allocator)) {
+      listVector.allocateNew();
+      UnionListWriter listWriter = new UnionListWriter(listVector);
+      StructWriter structWriter = listWriter.struct();
+      for (int i = 0; i < COUNT; i++) {
+        listWriter.startList();
+        for (int j = 0; j < i % 7; j++) {
+          structWriter.start();
+          structWriter.integer("int").writeInt(j);
+          structWriter.bigInt("bigInt").writeBigInt(j);
+          structWriter.end();
+        }
+        listWriter.endList();
       }
-      listWriter.endList();
-    }
-    listWriter.setValueCount(COUNT);
-    UnionListReader listReader = new UnionListReader(listVector);
-    for (int i = 0; i < COUNT; i++) {
-      listReader.setPosition(i);
-      for (int j = 0; j < i % 7; j++) {
-        listReader.next();
-        Assert.assertEquals("record: " + i, j, listReader.reader().reader("int").readInteger().intValue());
-        Assert.assertEquals(j, listReader.reader().reader("bigInt").readLong().longValue());
+      listWriter.setValueCount(COUNT);
+      UnionListReader listReader = new UnionListReader(listVector);
+      for (int i = 0; i < COUNT; i++) {
+        listReader.setPosition(i);
+        for (int j = 0; j < i % 7; j++) {
+          listReader.next();
+          Assert.assertEquals("record: " + i, j, listReader.reader().reader("int").readInteger().intValue());
+          Assert.assertEquals(j, listReader.reader().reader("bigInt").readLong().longValue());
+        }
       }
     }
   }
@@ -509,47 +528,50 @@ public class TestComplexWriter {
 
   @Test
   public void promotableWriter() {
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
-    for (int i = 0; i < 100; i++) {
-      BigIntWriter bigIntWriter = rootWriter.bigInt("a");
-      bigIntWriter.setPosition(i);
-      bigIntWriter.writeBigInt(i);
-    }
-    Field field = parent.getField().getChildren().get(0).getChildren().get(0);
-    Assert.assertEquals("a", field.getName());
-    Assert.assertEquals(Int.TYPE_TYPE, field.getType().getTypeID());
-    Int intType = (Int) field.getType();
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
 
-    Assert.assertEquals(64, intType.getBitWidth());
-    Assert.assertTrue(intType.getIsSigned());
-    for (int i = 100; i < 200; i++) {
-      VarCharWriter varCharWriter = rootWriter.varChar("a");
-      varCharWriter.setPosition(i);
-      byte[] bytes = Integer.toString(i).getBytes();
-      ArrowBuf tempBuf = allocator.buffer(bytes.length);
-      tempBuf.setBytes(0, bytes);
-      varCharWriter.writeVarChar(0, bytes.length, tempBuf);
-    }
-    field = parent.getField().getChildren().get(0).getChildren().get(0);
-    Assert.assertEquals("a", field.getName());
-    Assert.assertEquals(Union.TYPE_TYPE, field.getType().getTypeID());
-    Assert.assertEquals(Int.TYPE_TYPE, field.getChildren().get(0).getType().getTypeID());
-    Assert.assertEquals(Utf8.TYPE_TYPE, field.getChildren().get(1).getType().getTypeID());
-    StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
-    for (int i = 0; i < 100; i++) {
-      rootReader.setPosition(i);
-      FieldReader reader = rootReader.reader("a");
-      Long value = reader.readLong();
-      Assert.assertNotNull("index: " + i, value);
-      Assert.assertEquals(i, value.intValue());
-    }
-    for (int i = 100; i < 200; i++) {
-      rootReader.setPosition(i);
-      FieldReader reader = rootReader.reader("a");
-      Text value = reader.readText();
-      Assert.assertEquals(Integer.toString(i), value.toString());
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
+      for (int i = 0; i < 100; i++) {
+        BigIntWriter bigIntWriter = rootWriter.bigInt("a");
+        bigIntWriter.setPosition(i);
+        bigIntWriter.writeBigInt(i);
+      }
+      Field field = parent.getField().getChildren().get(0).getChildren().get(0);
+      Assert.assertEquals("a", field.getName());
+      Assert.assertEquals(Int.TYPE_TYPE, field.getType().getTypeID());
+      Int intType = (Int) field.getType();
+
+      Assert.assertEquals(64, intType.getBitWidth());
+      Assert.assertTrue(intType.getIsSigned());
+      for (int i = 100; i < 200; i++) {
+        VarCharWriter varCharWriter = rootWriter.varChar("a");
+        varCharWriter.setPosition(i);
+        byte[] bytes = Integer.toString(i).getBytes();
+        ArrowBuf tempBuf = allocator.buffer(bytes.length);
+        tempBuf.setBytes(0, bytes);
+        varCharWriter.writeVarChar(0, bytes.length, tempBuf);
+        tempBuf.close();
+      }
+      field = parent.getField().getChildren().get(0).getChildren().get(0);
+      Assert.assertEquals("a", field.getName());
+      Assert.assertEquals(Union.TYPE_TYPE, field.getType().getTypeID());
+      Assert.assertEquals(Int.TYPE_TYPE, field.getChildren().get(0).getType().getTypeID());
+      Assert.assertEquals(Utf8.TYPE_TYPE, field.getChildren().get(1).getType().getTypeID());
+      StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
+      for (int i = 0; i < 100; i++) {
+        rootReader.setPosition(i);
+        FieldReader reader = rootReader.reader("a");
+        Long value = reader.readLong();
+        Assert.assertNotNull("index: " + i, value);
+        Assert.assertEquals(i, value.intValue());
+      }
+      for (int i = 100; i < 200; i++) {
+        rootReader.setPosition(i);
+        FieldReader reader = rootReader.reader("a");
+        Text value = reader.readText();
+        Assert.assertEquals(Integer.toString(i), value.toString());
+      }
     }
   }
 
@@ -558,21 +580,22 @@ public class TestComplexWriter {
    */
   @Test
   public void promotableWriterSchema() {
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
-    rootWriter.bigInt("a");
-    rootWriter.varChar("a");
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
+      rootWriter.bigInt("a");
+      rootWriter.varChar("a");
 
-    Field field = parent.getField().getChildren().get(0).getChildren().get(0);
-    Assert.assertEquals("a", field.getName());
-    Assert.assertEquals(ArrowTypeID.Union, field.getType().getTypeID());
+      Field field = parent.getField().getChildren().get(0).getChildren().get(0);
+      Assert.assertEquals("a", field.getName());
+      Assert.assertEquals(ArrowTypeID.Union, field.getType().getTypeID());
 
-    Assert.assertEquals(ArrowTypeID.Int, field.getChildren().get(0).getType().getTypeID());
-    Int intType = (Int) field.getChildren().get(0).getType();
-    Assert.assertEquals(64, intType.getBitWidth());
-    Assert.assertTrue(intType.getIsSigned());
-    Assert.assertEquals(ArrowTypeID.Utf8, field.getChildren().get(1).getType().getTypeID());
+      Assert.assertEquals(ArrowTypeID.Int, field.getChildren().get(0).getType().getTypeID());
+      Int intType = (Int) field.getChildren().get(0).getType();
+      Assert.assertEquals(64, intType.getBitWidth());
+      Assert.assertTrue(intType.getIsSigned());
+      Assert.assertEquals(ArrowTypeID.Utf8, field.getChildren().get(1).getType().getTypeID());
+    }
   }
 
   private Set<String> getFieldNames(List<Field> fields) {
@@ -590,63 +613,64 @@ public class TestComplexWriter {
 
   @Test
   public void structWriterMixedCaseFieldNames() {
-    // test case-sensitive StructWriter
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("rootCaseSensitive", parent, false, true);
-    StructWriter rootWriterCaseSensitive = writer.rootAsStruct();
-    rootWriterCaseSensitive.bigInt("int_field");
-    rootWriterCaseSensitive.bigInt("Int_Field");
-    rootWriterCaseSensitive.float4("float_field");
-    rootWriterCaseSensitive.float4("Float_Field");
-    StructWriter structFieldWriterCaseSensitive = rootWriterCaseSensitive.struct("struct_field");
-    structFieldWriterCaseSensitive.varChar("char_field");
-    structFieldWriterCaseSensitive.varChar("Char_Field");
-    ListWriter listFieldWriterCaseSensitive = rootWriterCaseSensitive.list("list_field");
-    StructWriter listStructFieldWriterCaseSensitive = listFieldWriterCaseSensitive.struct();
-    listStructFieldWriterCaseSensitive.bit("bit_field");
-    listStructFieldWriterCaseSensitive.bit("Bit_Field");
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
+      // test case-sensitive StructWriter
+      ComplexWriter writer = new ComplexWriterImpl("rootCaseSensitive", parent, false, true);
+      StructWriter rootWriterCaseSensitive = writer.rootAsStruct();
+      rootWriterCaseSensitive.bigInt("int_field");
+      rootWriterCaseSensitive.bigInt("Int_Field");
+      rootWriterCaseSensitive.float4("float_field");
+      rootWriterCaseSensitive.float4("Float_Field");
+      StructWriter structFieldWriterCaseSensitive = rootWriterCaseSensitive.struct("struct_field");
+      structFieldWriterCaseSensitive.varChar("char_field");
+      structFieldWriterCaseSensitive.varChar("Char_Field");
+      ListWriter listFieldWriterCaseSensitive = rootWriterCaseSensitive.list("list_field");
+      StructWriter listStructFieldWriterCaseSensitive = listFieldWriterCaseSensitive.struct();
+      listStructFieldWriterCaseSensitive.bit("bit_field");
+      listStructFieldWriterCaseSensitive.bit("Bit_Field");
 
-    List<Field> fieldsCaseSensitive = parent.getField().getChildren().get(0).getChildren();
-    Set<String> fieldNamesCaseSensitive = getFieldNames(fieldsCaseSensitive);
-    Assert.assertEquals(11, fieldNamesCaseSensitive.size());
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("int_field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("Int_Field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("float_field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("Float_Field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("struct_field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("struct_field::char_field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("struct_field::Char_Field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$::bit_field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$::Bit_Field"));
+      List<Field> fieldsCaseSensitive = parent.getField().getChildren().get(0).getChildren();
+      Set<String> fieldNamesCaseSensitive = getFieldNames(fieldsCaseSensitive);
+      Assert.assertEquals(11, fieldNamesCaseSensitive.size());
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("int_field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("Int_Field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("float_field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("Float_Field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("struct_field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("struct_field::char_field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("struct_field::Char_Field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$::bit_field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$::Bit_Field"));
 
-    // test case-insensitive StructWriter
-    ComplexWriter writerCaseInsensitive = new ComplexWriterImpl("rootCaseInsensitive", parent, false, false);
-    StructWriter rootWriterCaseInsensitive = writerCaseInsensitive.rootAsStruct();
+      // test case-insensitive StructWriter
+      ComplexWriter writerCaseInsensitive = new ComplexWriterImpl("rootCaseInsensitive", parent, false, false);
+      StructWriter rootWriterCaseInsensitive = writerCaseInsensitive.rootAsStruct();
 
-    rootWriterCaseInsensitive.bigInt("int_field");
-    rootWriterCaseInsensitive.bigInt("Int_Field");
-    rootWriterCaseInsensitive.float4("float_field");
-    rootWriterCaseInsensitive.float4("Float_Field");
-    StructWriter structFieldWriterCaseInsensitive = rootWriterCaseInsensitive.struct("struct_field");
-    structFieldWriterCaseInsensitive.varChar("char_field");
-    structFieldWriterCaseInsensitive.varChar("Char_Field");
-    ListWriter listFieldWriterCaseInsensitive = rootWriterCaseInsensitive.list("list_field");
-    StructWriter listStructFieldWriterCaseInsensitive = listFieldWriterCaseInsensitive.struct();
-    listStructFieldWriterCaseInsensitive.bit("bit_field");
-    listStructFieldWriterCaseInsensitive.bit("Bit_Field");
+      rootWriterCaseInsensitive.bigInt("int_field");
+      rootWriterCaseInsensitive.bigInt("Int_Field");
+      rootWriterCaseInsensitive.float4("float_field");
+      rootWriterCaseInsensitive.float4("Float_Field");
+      StructWriter structFieldWriterCaseInsensitive = rootWriterCaseInsensitive.struct("struct_field");
+      structFieldWriterCaseInsensitive.varChar("char_field");
+      structFieldWriterCaseInsensitive.varChar("Char_Field");
+      ListWriter listFieldWriterCaseInsensitive = rootWriterCaseInsensitive.list("list_field");
+      StructWriter listStructFieldWriterCaseInsensitive = listFieldWriterCaseInsensitive.struct();
+      listStructFieldWriterCaseInsensitive.bit("bit_field");
+      listStructFieldWriterCaseInsensitive.bit("Bit_Field");
 
-    List<Field> fieldsCaseInsensitive = parent.getField().getChildren().get(1).getChildren();
-    Set<String> fieldNamesCaseInsensitive = getFieldNames(fieldsCaseInsensitive);
-    Assert.assertEquals(7, fieldNamesCaseInsensitive.size());
-    Assert.assertTrue(fieldNamesCaseInsensitive.contains("int_field"));
-    Assert.assertTrue(fieldNamesCaseInsensitive.contains("float_field"));
-    Assert.assertTrue(fieldNamesCaseInsensitive.contains("struct_field"));
-    Assert.assertTrue(fieldNamesCaseInsensitive.contains("struct_field::char_field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$"));
-    Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$::bit_field"));
+      List<Field> fieldsCaseInsensitive = parent.getField().getChildren().get(1).getChildren();
+      Set<String> fieldNamesCaseInsensitive = getFieldNames(fieldsCaseInsensitive);
+      Assert.assertEquals(7, fieldNamesCaseInsensitive.size());
+      Assert.assertTrue(fieldNamesCaseInsensitive.contains("int_field"));
+      Assert.assertTrue(fieldNamesCaseInsensitive.contains("float_field"));
+      Assert.assertTrue(fieldNamesCaseInsensitive.contains("struct_field"));
+      Assert.assertTrue(fieldNamesCaseInsensitive.contains("struct_field::char_field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$"));
+      Assert.assertTrue(fieldNamesCaseSensitive.contains("list_field::$data$::bit_field"));
+    }
   }
 
   @Test
@@ -655,41 +679,43 @@ public class TestComplexWriter {
     final long expectedSecs = 981173106L;
     final LocalDateTime expectedSecDateTime = LocalDateTime.of(2001, 2, 3, 4, 5, 6, 0);
 
-    // write
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
+      // write
 
-    {
-      TimeStampSecWriter timeStampSecWriter = rootWriter.timeStampSec("sec");
-      timeStampSecWriter.setPosition(0);
-      timeStampSecWriter.writeTimeStampSec(expectedSecs);
-    }
-    {
-      TimeStampSecTZWriter timeStampSecTZWriter = rootWriter.timeStampSecTZ("secTZ", "UTC");
-      timeStampSecTZWriter.setPosition(1);
-      timeStampSecTZWriter.writeTimeStampSecTZ(expectedSecs);
-    }
-    // schema
-    List<Field> children = parent.getField().getChildren().get(0).getChildren();
-    checkTimestampField(children.get(0), "sec");
-    checkTimestampTZField(children.get(1), "secTZ", "UTC");
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
 
-    // read
-    StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
-    {
-      FieldReader secReader = rootReader.reader("sec");
-      secReader.setPosition(0);
-      LocalDateTime secDateTime = secReader.readLocalDateTime();
-      Assert.assertEquals(expectedSecDateTime, secDateTime);
-      long secLong = secReader.readLong();
-      Assert.assertEquals(expectedSecs, secLong);
-    }
-    {
-      FieldReader secTZReader = rootReader.reader("secTZ");
-      secTZReader.setPosition(1);
-      long secTZLong = secTZReader.readLong();
-      Assert.assertEquals(expectedSecs, secTZLong);
+      {
+        TimeStampSecWriter timeStampSecWriter = rootWriter.timeStampSec("sec");
+        timeStampSecWriter.setPosition(0);
+        timeStampSecWriter.writeTimeStampSec(expectedSecs);
+      }
+      {
+        TimeStampSecTZWriter timeStampSecTZWriter = rootWriter.timeStampSecTZ("secTZ", "UTC");
+        timeStampSecTZWriter.setPosition(1);
+        timeStampSecTZWriter.writeTimeStampSecTZ(expectedSecs);
+      }
+      // schema
+      List<Field> children = parent.getField().getChildren().get(0).getChildren();
+      checkTimestampField(children.get(0), "sec");
+      checkTimestampTZField(children.get(1), "secTZ", "UTC");
+
+      // read
+      StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
+      {
+        FieldReader secReader = rootReader.reader("sec");
+        secReader.setPosition(0);
+        LocalDateTime secDateTime = secReader.readLocalDateTime();
+        Assert.assertEquals(expectedSecDateTime, secDateTime);
+        long secLong = secReader.readLong();
+        Assert.assertEquals(expectedSecs, secLong);
+      }
+      {
+        FieldReader secTZReader = rootReader.reader("secTZ");
+        secTZReader.setPosition(1);
+        long secTZLong = secTZReader.readLong();
+        Assert.assertEquals(expectedSecs, secTZLong);
+      }
     }
   }
 
@@ -699,44 +725,44 @@ public class TestComplexWriter {
     final long expectedMillis = 981173106123L;
     final LocalDateTime expectedMilliDateTime = LocalDateTime.of(2001, 2, 3, 4, 5, 6, 123 * 1_000_000);
 
-    // write
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
-    {
-      TimeStampMilliWriter timeStampWriter = rootWriter.timeStampMilli("milli");
-      timeStampWriter.setPosition(0);
-      timeStampWriter.writeTimeStampMilli(expectedMillis);
-    }
-    String tz = "UTC";
-    {
-      TimeStampMilliTZWriter timeStampTZWriter = rootWriter.timeStampMilliTZ("milliTZ", tz);
-      timeStampTZWriter.setPosition(0);
-      timeStampTZWriter.writeTimeStampMilliTZ(expectedMillis);
-    }
-    // schema
-    List<Field> children = parent.getField().getChildren().get(0).getChildren();
-    checkTimestampField(children.get(0), "milli");
-    checkTimestampTZField(children.get(1), "milliTZ", tz);
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);) {
+      // write
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
+      {
+        TimeStampMilliWriter timeStampWriter = rootWriter.timeStampMilli("milli");
+        timeStampWriter.setPosition(0);
+        timeStampWriter.writeTimeStampMilli(expectedMillis);
+      }
+      String tz = "UTC";
+      {
+        TimeStampMilliTZWriter timeStampTZWriter = rootWriter.timeStampMilliTZ("milliTZ", tz);
+        timeStampTZWriter.setPosition(0);
+        timeStampTZWriter.writeTimeStampMilliTZ(expectedMillis);
+      }
+      // schema
+      List<Field> children = parent.getField().getChildren().get(0).getChildren();
+      checkTimestampField(children.get(0), "milli");
+      checkTimestampTZField(children.get(1), "milliTZ", tz);
 
-    // read
-    StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
+      // read
+      StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
 
-    {
-      FieldReader milliReader = rootReader.reader("milli");
-      milliReader.setPosition(0);
-      LocalDateTime milliDateTime = milliReader.readLocalDateTime();
-      Assert.assertEquals(expectedMilliDateTime, milliDateTime);
-      long milliLong = milliReader.readLong();
-      Assert.assertEquals(expectedMillis, milliLong);
+      {
+        FieldReader milliReader = rootReader.reader("milli");
+        milliReader.setPosition(0);
+        LocalDateTime milliDateTime = milliReader.readLocalDateTime();
+        Assert.assertEquals(expectedMilliDateTime, milliDateTime);
+        long milliLong = milliReader.readLong();
+        Assert.assertEquals(expectedMillis, milliLong);
+      }
+      {
+        FieldReader milliTZReader = rootReader.reader("milliTZ");
+        milliTZReader.setPosition(0);
+        long milliTZLong = milliTZReader.readLong();
+        Assert.assertEquals(expectedMillis, milliTZLong);
+      }
     }
-    {
-      FieldReader milliTZReader = rootReader.reader("milliTZ");
-      milliTZReader.setPosition(0);
-      long milliTZLong = milliTZReader.readLong();
-      Assert.assertEquals(expectedMillis, milliTZLong);
-    }
-
   }
 
   private void checkTimestampField(Field field, String name) {
@@ -755,45 +781,45 @@ public class TestComplexWriter {
     final long expectedMicros = 981173106123456L;
     final LocalDateTime expectedMicroDateTime = LocalDateTime.of(2001, 2, 3, 4, 5, 6, 123456 * 1000);
 
-    // write
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
+      // write
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
 
-    {
-      TimeStampMicroWriter timeStampMicroWriter = rootWriter.timeStampMicro("micro");
-      timeStampMicroWriter.setPosition(0);
-      timeStampMicroWriter.writeTimeStampMicro(expectedMicros);
-    }
-    String tz = "UTC";
-    {
-      TimeStampMicroTZWriter timeStampMicroWriter = rootWriter.timeStampMicroTZ("microTZ", tz);
-      timeStampMicroWriter.setPosition(1);
-      timeStampMicroWriter.writeTimeStampMicroTZ(expectedMicros);
-    }
+      {
+        TimeStampMicroWriter timeStampMicroWriter = rootWriter.timeStampMicro("micro");
+        timeStampMicroWriter.setPosition(0);
+        timeStampMicroWriter.writeTimeStampMicro(expectedMicros);
+      }
+      String tz = "UTC";
+      {
+        TimeStampMicroTZWriter timeStampMicroWriter = rootWriter.timeStampMicroTZ("microTZ", tz);
+        timeStampMicroWriter.setPosition(1);
+        timeStampMicroWriter.writeTimeStampMicroTZ(expectedMicros);
+      }
 
-    // schema
-    List<Field> children = parent.getField().getChildren().get(0).getChildren();
-    checkTimestampField(children.get(0), "micro");
-    checkTimestampTZField(children.get(1), "microTZ", tz);
+      // schema
+      List<Field> children = parent.getField().getChildren().get(0).getChildren();
+      checkTimestampField(children.get(0), "micro");
+      checkTimestampTZField(children.get(1), "microTZ", tz);
 
-    // read
-    StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
-    {
-      FieldReader microReader = rootReader.reader("micro");
-      microReader.setPosition(0);
-      LocalDateTime microDateTime = microReader.readLocalDateTime();
-      Assert.assertEquals(expectedMicroDateTime, microDateTime);
-      long microLong = microReader.readLong();
-      Assert.assertEquals(expectedMicros, microLong);
+      // read
+      StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
+      {
+        FieldReader microReader = rootReader.reader("micro");
+        microReader.setPosition(0);
+        LocalDateTime microDateTime = microReader.readLocalDateTime();
+        Assert.assertEquals(expectedMicroDateTime, microDateTime);
+        long microLong = microReader.readLong();
+        Assert.assertEquals(expectedMicros, microLong);
+      }
+      {
+        FieldReader microReader = rootReader.reader("microTZ");
+        microReader.setPosition(1);
+        long microLong = microReader.readLong();
+        Assert.assertEquals(expectedMicros, microLong);
+      }
     }
-    {
-      FieldReader microReader = rootReader.reader("microTZ");
-      microReader.setPosition(1);
-      long microLong = microReader.readLong();
-      Assert.assertEquals(expectedMicros, microLong);
-    }
-
   }
 
   @Test
@@ -802,46 +828,48 @@ public class TestComplexWriter {
     final long expectedNanos = 981173106123456789L;
     final LocalDateTime expectedNanoDateTime = LocalDateTime.of(2001, 2, 3, 4, 5, 6, 123456789);
 
-    // write
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
+      // write
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
 
-    {
-      TimeStampNanoWriter timeStampNanoWriter = rootWriter.timeStampNano("nano");
-      timeStampNanoWriter.setPosition(0);
-      timeStampNanoWriter.writeTimeStampNano(expectedNanos);
-    }
-    String tz = "UTC";
-    {
-      TimeStampNanoTZWriter timeStampNanoWriter = rootWriter.timeStampNanoTZ("nanoTZ", tz);
-      timeStampNanoWriter.setPosition(0);
-      timeStampNanoWriter.writeTimeStampNanoTZ(expectedNanos);
-    }
-    // schema
-    List<Field> children = parent.getField().getChildren().get(0).getChildren();
-    checkTimestampField(children.get(0), "nano");
-    checkTimestampTZField(children.get(1), "nanoTZ", tz);
-    // read
-    StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
+      {
+        TimeStampNanoWriter timeStampNanoWriter = rootWriter.timeStampNano("nano");
+        timeStampNanoWriter.setPosition(0);
+        timeStampNanoWriter.writeTimeStampNano(expectedNanos);
+      }
+      String tz = "UTC";
+      {
+        TimeStampNanoTZWriter timeStampNanoWriter = rootWriter.timeStampNanoTZ("nanoTZ", tz);
+        timeStampNanoWriter.setPosition(0);
+        timeStampNanoWriter.writeTimeStampNanoTZ(expectedNanos);
+      }
+      // schema
+      List<Field> children = parent.getField().getChildren().get(0).getChildren();
+      checkTimestampField(children.get(0), "nano");
+      checkTimestampTZField(children.get(1), "nanoTZ", tz);
+      // read
+      StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
 
-    {
-      FieldReader nanoReader = rootReader.reader("nano");
-      nanoReader.setPosition(0);
-      LocalDateTime nanoDateTime = nanoReader.readLocalDateTime();
-      Assert.assertEquals(expectedNanoDateTime, nanoDateTime);
-      long nanoLong = nanoReader.readLong();
-      Assert.assertEquals(expectedNanos, nanoLong);
+      {
+        FieldReader nanoReader = rootReader.reader("nano");
+        nanoReader.setPosition(0);
+        LocalDateTime nanoDateTime = nanoReader.readLocalDateTime();
+        Assert.assertEquals(expectedNanoDateTime, nanoDateTime);
+        long nanoLong = nanoReader.readLong();
+        Assert.assertEquals(expectedNanos, nanoLong);
+      }
+      {
+        FieldReader nanoReader = rootReader.reader("nanoTZ");
+        nanoReader.setPosition(0);
+        long nanoLong = nanoReader.readLong();
+        Assert.assertEquals(expectedNanos, nanoLong);
+        NullableTimeStampNanoTZHolder h = new NullableTimeStampNanoTZHolder();
+        nanoReader.read(h);
+        Assert.assertEquals(expectedNanos, h.value);
+      }
     }
-    {
-      FieldReader nanoReader = rootReader.reader("nanoTZ");
-      nanoReader.setPosition(0);
-      long nanoLong = nanoReader.readLong();
-      Assert.assertEquals(expectedNanos, nanoLong);
-      NullableTimeStampNanoTZHolder h = new NullableTimeStampNanoTZHolder();
-      nanoReader.read(h);
-      Assert.assertEquals(expectedNanos, h.value);
-    }
+
   }
 
   @Test
@@ -861,70 +889,75 @@ public class TestComplexWriter {
       bufs[i].setBytes(0, values[i]);
     }
 
-    // write
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
+      // write
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
 
-    String fieldName = "fixedSizeBinary";
-    FixedSizeBinaryWriter fixedSizeBinaryWriter = rootWriter.fixedSizeBinary(fieldName, byteWidth);
-    for (int i = 0; i < numValues; i++) {
-      fixedSizeBinaryWriter.setPosition(i);
-      fixedSizeBinaryWriter.writeFixedSizeBinary(bufs[i]);
+      String fieldName = "fixedSizeBinary";
+      FixedSizeBinaryWriter fixedSizeBinaryWriter = rootWriter.fixedSizeBinary(fieldName, byteWidth);
+      for (int i = 0; i < numValues; i++) {
+        fixedSizeBinaryWriter.setPosition(i);
+        fixedSizeBinaryWriter.writeFixedSizeBinary(bufs[i]);
+      }
+
+      // schema
+      List<Field> children = parent.getField().getChildren().get(0).getChildren();
+      Assert.assertEquals(fieldName, children.get(0).getName());
+      Assert.assertEquals(ArrowType.FixedSizeBinary.TYPE_TYPE, children.get(0).getType().getTypeID());
+
+      // read
+      StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
+
+      FieldReader fixedSizeBinaryReader = rootReader.reader(fieldName);
+      for (int i = 0; i < numValues; i++) {
+        fixedSizeBinaryReader.setPosition(i);
+        byte[] readValues = fixedSizeBinaryReader.readByteArray();
+        Assert.assertArrayEquals(values[i], readValues);
+      }
     }
 
-    // schema
-    List<Field> children = parent.getField().getChildren().get(0).getChildren();
-    Assert.assertEquals(fieldName, children.get(0).getName());
-    Assert.assertEquals(ArrowType.FixedSizeBinary.TYPE_TYPE, children.get(0).getType().getTypeID());
-
-    // read
-    StructReader rootReader = new SingleStructReaderImpl(parent).reader("root");
-
-    FieldReader fixedSizeBinaryReader = rootReader.reader(fieldName);
-    for (int i = 0; i < numValues; i++) {
-      fixedSizeBinaryReader.setPosition(i);
-      byte[] readValues = fixedSizeBinaryReader.readByteArray();
-      Assert.assertArrayEquals(values[i], readValues);
-    }
+    AutoCloseables.close(bufs);
   }
 
   @Test
   public void complexCopierWithList() {
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    ComplexWriter writer = new ComplexWriterImpl("root", parent);
-    StructWriter rootWriter = writer.rootAsStruct();
-    ListWriter listWriter = rootWriter.list("list");
-    StructWriter innerStructWriter = listWriter.struct();
-    IntWriter outerIntWriter = listWriter.integer();
-    rootWriter.start();
-    listWriter.startList();
-    outerIntWriter.writeInt(1);
-    outerIntWriter.writeInt(2);
-    innerStructWriter.start();
-    IntWriter intWriter = innerStructWriter.integer("a");
-    intWriter.writeInt(1);
-    innerStructWriter.end();
-    innerStructWriter.start();
-    intWriter = innerStructWriter.integer("a");
-    intWriter.writeInt(2);
-    innerStructWriter.end();
-    listWriter.endList();
-    rootWriter.end();
-    writer.setValueCount(1);
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
+      ComplexWriter writer = new ComplexWriterImpl("root", parent);
+      StructWriter rootWriter = writer.rootAsStruct();
+      ListWriter listWriter = rootWriter.list("list");
+      StructWriter innerStructWriter = listWriter.struct();
+      IntWriter outerIntWriter = listWriter.integer();
+      rootWriter.start();
+      listWriter.startList();
+      outerIntWriter.writeInt(1);
+      outerIntWriter.writeInt(2);
+      innerStructWriter.start();
+      IntWriter intWriter = innerStructWriter.integer("a");
+      intWriter.writeInt(1);
+      innerStructWriter.end();
+      innerStructWriter.start();
+      intWriter = innerStructWriter.integer("a");
+      intWriter.writeInt(2);
+      innerStructWriter.end();
+      listWriter.endList();
+      rootWriter.end();
+      writer.setValueCount(1);
 
-    StructVector structVector = (StructVector) parent.getChild("root");
-    TransferPair tp = structVector.getTransferPair(allocator);
-    tp.splitAndTransfer(0, 1);
-    NonNullableStructVector toStructVector = (NonNullableStructVector) tp.getTo();
-    JsonStringHashMap<?, ?> toMapValue = (JsonStringHashMap<?, ?>) toStructVector.getObject(0);
-    JsonStringArrayList<?> object = (JsonStringArrayList<?>) toMapValue.get("list");
-    assertEquals(1, object.get(0));
-    assertEquals(2, object.get(1));
-    JsonStringHashMap<?, ?> innerStruct = (JsonStringHashMap<?, ?>) object.get(2);
-    assertEquals(1, innerStruct.get("a"));
-    innerStruct = (JsonStringHashMap<?, ?>) object.get(3);
-    assertEquals(2, innerStruct.get("a"));
+      StructVector structVector = (StructVector) parent.getChild("root");
+      TransferPair tp = structVector.getTransferPair(allocator);
+      tp.splitAndTransfer(0, 1);
+      NonNullableStructVector toStructVector = (NonNullableStructVector) tp.getTo();
+      JsonStringHashMap<?, ?> toMapValue = (JsonStringHashMap<?, ?>) toStructVector.getObject(0);
+      JsonStringArrayList<?> object = (JsonStringArrayList<?>) toMapValue.get("list");
+      assertEquals(1, object.get(0));
+      assertEquals(2, object.get(1));
+      JsonStringHashMap<?, ?> innerStruct = (JsonStringHashMap<?, ?>) object.get(2);
+      assertEquals(1, innerStruct.get("a"));
+      innerStruct = (JsonStringHashMap<?, ?>) object.get(3);
+      assertEquals(2, innerStruct.get("a"));
+      toStructVector.close();
+    }
   }
 
   @Test
@@ -932,82 +965,85 @@ public class TestComplexWriter {
     /* initialize a SingleStructWriter with empty StructVector and then lazily
      * create all vectors with expected initialCapacity.
      */
-    NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator);
-    SingleStructWriter singleStructWriter = new SingleStructWriter(parent);
+    try (NonNullableStructVector parent = NonNullableStructVector.empty("parent", allocator)) {
+      SingleStructWriter singleStructWriter = new SingleStructWriter(parent);
 
-    int initialCapacity = 1024;
-    singleStructWriter.setInitialCapacity(initialCapacity);
+      int initialCapacity = 1024;
+      singleStructWriter.setInitialCapacity(initialCapacity);
 
-    IntWriter intWriter = singleStructWriter.integer("intField");
-    BigIntWriter bigIntWriter = singleStructWriter.bigInt("bigIntField");
-    Float4Writer float4Writer = singleStructWriter.float4("float4Field");
-    Float8Writer float8Writer = singleStructWriter.float8("float8Field");
-    ListWriter listWriter = singleStructWriter.list("listField");
+      IntWriter intWriter = singleStructWriter.integer("intField");
+      BigIntWriter bigIntWriter = singleStructWriter.bigInt("bigIntField");
+      Float4Writer float4Writer = singleStructWriter.float4("float4Field");
+      Float8Writer float8Writer = singleStructWriter.float8("float8Field");
+      ListWriter listWriter = singleStructWriter.list("listField");
 
-    int intValue = 100;
-    long bigIntValue = 10000;
-    float float4Value = 100.5f;
-    double float8Value = 100.375;
+      int intValue = 100;
+      long bigIntValue = 10000;
+      float float4Value = 100.5f;
+      double float8Value = 100.375;
 
-    for (int i = 0; i < initialCapacity; i++) {
-      singleStructWriter.start();
+      for (int i = 0; i < initialCapacity; i++) {
+        singleStructWriter.start();
 
-      intWriter.writeInt(intValue + i);
-      bigIntWriter.writeBigInt(bigIntValue + (long)i);
-      float4Writer.writeFloat4(float4Value + (float)i);
-      float8Writer.writeFloat8(float8Value + (double)i);
+        intWriter.writeInt(intValue + i);
+        bigIntWriter.writeBigInt(bigIntValue + (long)i);
+        float4Writer.writeFloat4(float4Value + (float)i);
+        float8Writer.writeFloat8(float8Value + (double)i);
 
-      listWriter.setPosition(i);
-      listWriter.startList();
-      listWriter.integer().writeInt(intValue + i);
-      listWriter.integer().writeInt(intValue + i + 1);
-      listWriter.integer().writeInt(intValue + i + 2);
-      listWriter.integer().writeInt(intValue + i + 3);
-      listWriter.endList();
+        listWriter.setPosition(i);
+        listWriter.startList();
+        listWriter.integer().writeInt(intValue + i);
+        listWriter.integer().writeInt(intValue + i + 1);
+        listWriter.integer().writeInt(intValue + i + 2);
+        listWriter.integer().writeInt(intValue + i + 3);
+        listWriter.endList();
 
-      singleStructWriter.end();
-    }
+        singleStructWriter.end();
+      }
 
-    IntVector intVector = (IntVector)parent.getChild("intField");
-    BigIntVector bigIntVector = (BigIntVector)parent.getChild("bigIntField");
-    Float4Vector float4Vector = (Float4Vector)parent.getChild("float4Field");
-    Float8Vector float8Vector = (Float8Vector)parent.getChild("float8Field");
+      IntVector intVector = (IntVector)parent.getChild("intField");
+      BigIntVector bigIntVector = (BigIntVector)parent.getChild("bigIntField");
+      Float4Vector float4Vector = (Float4Vector)parent.getChild("float4Field");
+      Float8Vector float8Vector = (Float8Vector)parent.getChild("float8Field");
 
-    int capacity = singleStructWriter.getValueCapacity();
-    assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
-    capacity = intVector.getValueCapacity();
-    assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
-    capacity = bigIntVector.getValueCapacity();
-    assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
-    capacity = float4Vector.getValueCapacity();
-    assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
-    capacity = float8Vector.getValueCapacity();
-    assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
+      int capacity = singleStructWriter.getValueCapacity();
+      assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
+      capacity = intVector.getValueCapacity();
+      assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
+      capacity = bigIntVector.getValueCapacity();
+      assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
+      capacity = float4Vector.getValueCapacity();
+      assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
+      capacity = float8Vector.getValueCapacity();
+      assertTrue(capacity >= initialCapacity && capacity <  initialCapacity * 2);
 
-    StructReader singleStructReader = new SingleStructReaderImpl(parent);
+      StructReader singleStructReader = new SingleStructReaderImpl(parent);
 
-    IntReader intReader = singleStructReader.reader("intField");
-    BigIntReader bigIntReader = singleStructReader.reader("bigIntField");
-    Float4Reader float4Reader = singleStructReader.reader("float4Field");
-    Float8Reader float8Reader = singleStructReader.reader("float8Field");
-    UnionListReader listReader = (UnionListReader)singleStructReader.reader("listField");
+      IntReader intReader = singleStructReader.reader("intField");
+      BigIntReader bigIntReader = singleStructReader.reader("bigIntField");
+      Float4Reader float4Reader = singleStructReader.reader("float4Field");
+      Float8Reader float8Reader = singleStructReader.reader("float8Field");
+      UnionListReader listReader = (UnionListReader)singleStructReader.reader("listField");
 
-    for (int i = 0; i < initialCapacity; i++) {
-      intReader.setPosition(i);
-      bigIntReader.setPosition(i);
-      float4Reader.setPosition(i);
-      float8Reader.setPosition(i);
-      listReader.setPosition(i);
+      for (int i = 0; i < initialCapacity; i++) {
+        intReader.setPosition(i);
+        bigIntReader.setPosition(i);
+        float4Reader.setPosition(i);
+        float8Reader.setPosition(i);
+        listReader.setPosition(i);
 
-      assertEquals(intValue + i, intReader.readInteger().intValue());
-      assertEquals(bigIntValue + (long)i, bigIntReader.readLong().longValue());
-      assertEquals(float4Value + (float)i, float4Reader.readFloat().floatValue(), 0);
-      assertEquals(float8Value + (double)i, float8Reader.readDouble().doubleValue(), 0);
+        assertEquals(intValue + i, intReader.readInteger().intValue());
+        assertEquals(bigIntValue + (long)i, bigIntReader.readLong().longValue());
+        assertEquals(float4Value + (float)i, float4Reader.readFloat().floatValue(), 0);
+        assertEquals(float8Value + (double)i, float8Reader.readDouble().doubleValue(), 0);
 
-      for (int j = 0; j < 4; j++) {
-        listReader.next();
-        assertEquals(intValue + i + j, listReader.reader().readInteger().intValue());
+        for (int j = 0; j < 4; j++) {
+          listReader.next();
+          assertEquals(intValue + i + j, listReader.reader().readInteger().intValue());
+        }
       }
     }
+
+
   }
 }


### PR DESCRIPTION
Related to [ARROW-6898](https://issues.apache.org/jira/browse/ARROW-6898).

ARROW-6040 fixed the problem that dictionary entries are required in IPC streams even when empty, which only writes dictionaries when there are at least one batch. In this way, if we write empty stream and invoke ArrowWriter#close, the dictionaries are not closed leading to memory leak (they are closed after the write operation), and it’s really hard to debug, this problem was found by TestArrowReaderWriter#testEmptyStreamInStreamingIPC when I tried to close allocator after the test. 

Besides, there are several test classes have potential memory leak without closing allocator/vector/buf etc.

