### PR TITLE
ARROW-6901: [Rust] [Parquet] Increment total_num_rows when closing a row group

### DIFF
--- a/rust/parquet/src/file/writer.rs
+++ b/rust/parquet/src/file/writer.rs
@@ -122,7 +122,7 @@ pub struct SerializedFileWriter {
     schema: TypePtr,
     descr: SchemaDescPtr,
     props: WriterPropertiesPtr,
-    total_num_rows: u64,
+    total_num_rows: i64,
     row_groups: Vec<RowGroupMetaDataPtr>,
     previous_writer_closed: bool,
     is_closed: bool,
@@ -160,6 +160,7 @@ impl SerializedFileWriter {
         mut row_group_writer: Box<RowGroupWriter>,
     ) -> Result<()> {
         let row_group_metadata = row_group_writer.close()?;
+        self.total_num_rows += row_group_metadata.num_rows();
         self.row_groups.push(row_group_metadata);
         Ok(())
     }

--- a/rust/parquet/src/file/writer.rs
+++ b/rust/parquet/src/file/writer.rs
@@ -930,7 +930,8 @@ mod tests {
             if let Some(mut writer) = col_writer {
                 match writer {
                     ColumnWriter::Int32ColumnWriter(ref mut typed) => {
-                        rows += typed.write_batch(&subset[..], None, None).unwrap() as i64;
+                        rows +=
+                            typed.write_batch(&subset[..], None, None).unwrap() as i64;
                     }
                     _ => {
                         unimplemented!();
@@ -945,7 +946,11 @@ mod tests {
 
         let reader = SerializedFileReader::new(file).unwrap();
         assert_eq!(reader.num_row_groups(), data.len());
-        assert_eq!(reader.metadata().file_metadata().num_rows(), rows, "row count in metadata not equal to number of rows written");
+        assert_eq!(
+            reader.metadata().file_metadata().num_rows(),
+            rows,
+            "row count in metadata not equal to number of rows written"
+        );
         for i in 0..reader.num_row_groups() {
             let row_group_reader = reader.get_row_group(i).unwrap();
             let iter = row_group_reader.get_row_iter(None).unwrap();


### PR DESCRIPTION
This means that the total_num_rows written to the file will accurately reflect the row groups that were successfully written.