### PR TITLE
ARROW-6886: [C++] Fix arrow::io nvcc compiler warnings

### DIFF
--- a/cpp/src/arrow/io/compressed.h
+++ b/cpp/src/arrow/io/compressed.h
@@ -62,6 +62,9 @@ class ARROW_EXPORT CompressedOutputStream : public OutputStream {
   Status Tell(int64_t* position) const override;
 
   Status Write(const void* data, int64_t nbytes) override;
+  /// \cond FALSE
+  using Writable::Write;
+  /// \endcond
   Status Flush() override;
 
   /// \brief Return the underlying raw output stream.

--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -230,6 +230,9 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
 
   /// Write data at the current position in the file. Thread-safe
   Status Write(const void* data, int64_t nbytes) override;
+  /// \cond FALSE
+  using Writable::Write;
+  /// \endcond
 
   /// Set the size of the map to new_size.
   Status Resize(int64_t new_size);

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -104,6 +104,9 @@ class ARROW_EXPORT MockOutputStream : public OutputStream {
   bool closed() const override;
   Status Tell(int64_t* position) const override;
   Status Write(const void* data, int64_t nbytes) override;
+  /// \cond FALSE
+  using Writable::Write;
+  /// \endcond
 
   int64_t GetExtentBytesWritten() const { return extent_bytes_written_; }
 
@@ -124,6 +127,10 @@ class ARROW_EXPORT FixedSizeBufferWriter : public WritableFile {
   Status Seek(int64_t position) override;
   Status Tell(int64_t* position) const override;
   Status Write(const void* data, int64_t nbytes) override;
+  /// \cond FALSE
+  using Writable::Write;
+  /// \endcond
+
   Status WriteAt(int64_t position, const void* data, int64_t nbytes) override;
 
   void set_memcopy_threads(int num_threads);


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/ARROW-6886.

cc @pitrou: I'm not sure if these changes are right, but the Arrow tests pass for me, and the nvcc warnings are gone in the cuDF C++ build.