### PR TITLE
ARROW-6650: [Rust] [Integration] Compare integration JSON with schema & batch

### DIFF
--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -579,7 +579,7 @@ impl DataType {
                     };
                     match map.get("bitWidth") {
                         Some(p) if p == "32" => Ok(DataType::Time32(unit?)),
-                        Some(p) if p == "64" => Ok(DataType::Time32(unit?)),
+                        Some(p) if p == "64" => Ok(DataType::Time64(unit?)),
                         _ => Err(ArrowError::ParseError(
                             "time bitWidth missing or invalid".to_string(),
                         )),
@@ -629,20 +629,19 @@ impl DataType {
                         "int signed missing or invalid".to_string(),
                     )),
                 },
+                Some(s) if s == "list" => {
+                    // return a list with any type as its child isn't defined in the map
+                    Ok(DataType::List(Box::new(DataType::Boolean)))
+                }
+                Some(s) if s == "struct" => {
+                    // return an empty `struct` type as its children aren't defined in the map
+                    Ok(DataType::Struct(vec![]))
+                }
                 Some(other) => Err(ArrowError::ParseError(format!(
-                    "invalid type name: {}",
-                    other
+                    "invalid or unsupported type name: {} in {:?}",
+                    other, json
                 ))),
-                None => match map.get("fields") {
-                    Some(&Value::Array(ref fields_array)) => {
-                        let fields = fields_array
-                            .iter()
-                            .map(|f| Field::from(f))
-                            .collect::<Result<Vec<Field>>>();
-                        Ok(DataType::Struct(fields?))
-                    }
-                    _ => Err(ArrowError::ParseError("empty type".to_string())),
-                },
+                None => Err(ArrowError::ParseError("type name missing".to_string())),
             },
             _ => Err(ArrowError::ParseError(
                 "invalid json value type".to_string(),
@@ -666,16 +665,8 @@ impl DataType {
             DataType::Float32 => json!({"name": "floatingpoint", "precision": "SINGLE"}),
             DataType::Float64 => json!({"name": "floatingpoint", "precision": "DOUBLE"}),
             DataType::Utf8 => json!({"name": "utf8"}),
-            DataType::Struct(ref fields) => {
-                let field_json_array = Value::Array(
-                    fields.iter().map(|f| f.to_json()).collect::<Vec<Value>>(),
-                );
-                json!({ "fields": field_json_array })
-            }
-            DataType::List(ref t) => {
-                let child_json = t.to_json();
-                json!({ "name": "list", "children": child_json })
-            }
+            DataType::Struct(_) => json!({"name": "struct"}),
+            DataType::List(_) => json!({ "name": "list"}),
             DataType::Time32(unit) => {
                 json!({"name": "time", "bitWidth": "32", "unit": match unit {
                     TimeUnit::Second => "SECOND",
@@ -752,6 +743,7 @@ impl Field {
                 let nullable = match map.get("nullable") {
                     Some(&Value::Bool(b)) => b,
                     _ => {
+                        println!("error field: {:?}", map);
                         return Err(ArrowError::ParseError(
                             "Field missing 'nullable' attribute".to_string(),
                         ));
@@ -764,6 +756,48 @@ impl Field {
                             "Field missing 'type' attribute".to_string(),
                         ));
                     }
+                };
+                // if data_type is a struct or list, get its children
+                let data_type = match data_type {
+                    DataType::List(_) => match map.get("children") {
+                        Some(Value::Array(values)) => {
+                            if values.len() != 1 {
+                                return Err(ArrowError::ParseError(
+                                    "Field 'children' must have one element for a list data type".to_string(),
+                                ));
+                            }
+                            DataType::List(Box::new(Self::from(&values[0])?.data_type))
+                        }
+                        Some(_) => {
+                            return Err(ArrowError::ParseError(
+                                "Field 'children' must be an array".to_string(),
+                            ))
+                        }
+                        None => {
+                            return Err(ArrowError::ParseError(
+                                "Field missing 'children' attribute".to_string(),
+                            ));
+                        }
+                    },
+                    DataType::Struct(mut fields) => match map.get("children") {
+                        Some(Value::Array(values)) => {
+                            let mut struct_fields =
+                                values.iter().map(|v| Field::from(v).unwrap()).collect();
+                            fields.append(&mut struct_fields);
+                            DataType::Struct(fields)
+                        }
+                        Some(_) => {
+                            return Err(ArrowError::ParseError(
+                                "Field 'children' must be an array".to_string(),
+                            ))
+                        }
+                        None => {
+                            return Err(ArrowError::ParseError(
+                                "Field missing 'children' attribute".to_string(),
+                            ));
+                        }
+                    },
+                    _ => data_type,
                 };
                 Ok(Field {
                     name,
@@ -779,10 +813,19 @@ impl Field {
 
     /// Generate a JSON representation of the `Field`
     pub fn to_json(&self) -> Value {
+        let children: Vec<Value> = match self.data_type() {
+            DataType::Struct(fields) => fields.iter().map(|f| f.to_json()).collect(),
+            DataType::List(dtype) => {
+                let item = Field::new("item", *dtype.clone(), self.nullable);
+                vec![item.to_json()]
+            }
+            _ => vec![],
+        };
         json!({
             "name": self.name,
             "nullable": self.nullable,
             "type": self.data_type.to_json(),
+            "children": children
         })
     }
 
@@ -849,11 +892,31 @@ impl Schema {
             .find(|&(_, c)| c.name == name)
     }
 
-    /// Generate a JSON representation of the `Field`
+    /// Generate a JSON representation of the `Schema`
     pub fn to_json(&self) -> Value {
         json!({
             "fields": self.fields.iter().map(|field| field.to_json()).collect::<Vec<Value>>(),
         })
+    }
+
+    /// Parse a `Schema` definition from a JSON representation
+    pub fn from(json: &Value) -> Result<Self> {
+        match *json {
+            Value::Object(ref schema) => {
+                if let Some(Value::Array(fields)) = schema.get("fields") {
+                    let fields: Result<Vec<Field>> =
+                        fields.iter().map(|f| Field::from(f)).collect();
+                    Ok(Schema::new(fields?))
+                } else {
+                    return Err(ArrowError::ParseError(
+                        "Schema fields should be an array".to_string(),
+                    ));
+                }
+            }
+            _ => Err(ArrowError::ParseError(
+                "Invalid json value type for schema".to_string(),
+            )),
+        }
     }
 }
 
@@ -943,9 +1006,9 @@ mod tests {
             false,
         );
         assert_eq!(
-            "{\"name\":\"address\",\"nullable\":false,\"type\":{\"fields\":[\
-            {\"name\":\"street\",\"nullable\":false,\"type\":{\"name\":\"utf8\"}},\
-            {\"name\":\"zip\",\"nullable\":false,\"type\":{\"name\":\"int\",\"bitWidth\":16,\"isSigned\":false}}]}}",
+            "{\"name\":\"address\",\"nullable\":false,\"type\":{\"name\":\"struct\"},\"children\":[\
+            {\"name\":\"street\",\"nullable\":false,\"type\":{\"name\":\"utf8\"},\"children\":[]},\
+            {\"name\":\"zip\",\"nullable\":false,\"type\":{\"name\":\"int\",\"bitWidth\":16,\"isSigned\":false},\"children\":[]}]}",
             f.to_json().to_string()
         );
     }
@@ -954,15 +1017,41 @@ mod tests {
     fn primitive_field_to_json() {
         let f = Field::new("first_name", DataType::Utf8, false);
         assert_eq!(
-            "{\"name\":\"first_name\",\"nullable\":false,\"type\":{\"name\":\"utf8\"}}",
+            "{\"name\":\"first_name\",\"nullable\":false,\"type\":{\"name\":\"utf8\"},\"children\":[]}",
             f.to_json().to_string()
         );
     }
     #[test]
     fn parse_struct_from_json() {
-        let json = "{\"name\":\"address\",\"nullable\":false,\"type\":{\"fields\":[\
-        {\"name\":\"street\",\"nullable\":false,\"type\":{\"name\":\"utf8\"}},\
-        {\"name\":\"zip\",\"nullable\":false,\"type\":{\"bitWidth\":16,\"isSigned\":false,\"name\":\"int\"}}]}}";
+        let json = r#"
+        {
+            "name": "address",
+            "type": {
+                "name": "struct"
+            },
+            "nullable": false,
+            "children": [
+                {
+                    "name": "street",
+                    "type": {
+                    "name": "utf8"
+                    },
+                    "nullable": false,
+                    "children": []
+                },
+                {
+                    "name": "zip",
+                    "type": {
+                    "name": "int",
+                    "isSigned": false,
+                    "bitWidth": 16
+                    },
+                    "nullable": false,
+                    "children": []
+                }
+            ]
+        }
+        "#;
         let value: Value = serde_json::from_str(json).unwrap();
         let dt = Field::from(&value).unwrap();
 
@@ -998,8 +1087,9 @@ mod tests {
     fn schema_json() {
         let schema = Schema::new(vec![
             Field::new("c1", DataType::Utf8, false),
-            Field::new("c2", DataType::Date32(DateUnit::Day), false),
-            Field::new("c3", DataType::Date64(DateUnit::Millisecond), false),
+            Field::new("c2", DataType::Boolean, false),
+            Field::new("c3", DataType::Date32(DateUnit::Day), false),
+            Field::new("c4", DataType::Date64(DateUnit::Millisecond), false),
             Field::new("c7", DataType::Time32(TimeUnit::Second), false),
             Field::new("c8", DataType::Time32(TimeUnit::Millisecond), false),
             Field::new("c9", DataType::Time32(TimeUnit::Microsecond), false),
@@ -1014,8 +1104,16 @@ mod tests {
             Field::new("c18", DataType::Timestamp(TimeUnit::Nanosecond), false),
             Field::new("c19", DataType::Interval(IntervalUnit::DayTime), false),
             Field::new("c20", DataType::Interval(IntervalUnit::YearMonth), false),
+            Field::new("c21", DataType::List(Box::new(DataType::Boolean)), false),
             Field::new(
-                "c21",
+                "c22",
+                DataType::List(Box::new(DataType::List(Box::new(DataType::Struct(
+                    vec![],
+                ))))),
+                true,
+            ),
+            Field::new(
+                "c23",
                 DataType::Struct(vec![
                     Field::new("a", DataType::Utf8, false),
                     Field::new("b", DataType::UInt16, false),
@@ -1025,37 +1123,38 @@ mod tests {
         ]);
 
         let json = schema.to_json().to_string();
-        assert_eq!(json, "{\"fields\":[{\"name\":\"c1\",\"nullable\":false,\"type\":{\"name\":\"utf8\"}},\
-        {\"name\":\"c2\",\"nullable\":false,\"type\":{\"name\":\"date\",\"unit\":\"DAY\"}},\
-        {\"name\":\"c3\",\"nullable\":false,\"type\":{\"name\":\"date\",\"unit\":\"MILLISECOND\"}},\
-        {\"name\":\"c7\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"SECOND\"}},\
-        {\"name\":\"c8\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"MILLISECOND\"}},\
-        {\"name\":\"c9\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"MICROSECOND\"}},\
-        {\"name\":\"c10\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"NANOSECOND\"}},\
-        {\"name\":\"c11\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"SECOND\"}},\
-        {\"name\":\"c12\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"MILLISECOND\"}},\
-        {\"name\":\"c13\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"MICROSECOND\"}},\
-        {\"name\":\"c14\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"NANOSECOND\"}},\
-        {\"name\":\"c15\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"SECOND\"}},\
-        {\"name\":\"c16\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"MILLISECOND\"}},\
-        {\"name\":\"c17\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"MICROSECOND\"}},\
-        {\"name\":\"c18\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"NANOSECOND\"}},\
-        {\"name\":\"c19\",\"nullable\":false,\"type\":{\"name\":\"interval\",\"unit\":\"DAY_TIME\"}},\
-        {\"name\":\"c20\",\"nullable\":false,\"type\":{\"name\":\"interval\",\"unit\":\"YEAR_MONTH\"}},\
-        {\"name\":\"c21\",\"nullable\":false,\"type\":{\"fields\":[\
-        {\"name\":\"a\",\"nullable\":false,\"type\":{\"name\":\"utf8\"}},\
-        {\"name\":\"b\",\"nullable\":false,\"type\":{\"name\":\"int\",\"bitWidth\":16,\"isSigned\":false}}]}}]}");
+        assert_eq!(json, "{\"fields\":[{\"name\":\"c1\",\"nullable\":false,\"type\":{\"name\":\"utf8\"},\"children\":[]},\
+        {\"name\":\"c2\",\"nullable\":false,\"type\":{\"name\":\"bool\"},\"children\":[]},\
+        {\"name\":\"c3\",\"nullable\":false,\"type\":{\"name\":\"date\",\"unit\":\"DAY\"},\"children\":[]},\
+        {\"name\":\"c4\",\"nullable\":false,\"type\":{\"name\":\"date\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
+        {\"name\":\"c7\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"SECOND\"},\"children\":[]},\
+        {\"name\":\"c8\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
+        {\"name\":\"c9\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"MICROSECOND\"},\"children\":[]},\
+        {\"name\":\"c10\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"NANOSECOND\"},\"children\":[]},\
+        {\"name\":\"c11\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"SECOND\"},\"children\":[]},\
+        {\"name\":\"c12\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
+        {\"name\":\"c13\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"MICROSECOND\"},\"children\":[]},\
+        {\"name\":\"c14\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"NANOSECOND\"},\"children\":[]},\
+        {\"name\":\"c15\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"SECOND\"},\"children\":[]},\
+        {\"name\":\"c16\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
+        {\"name\":\"c17\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"MICROSECOND\"},\"children\":[]},\
+        {\"name\":\"c18\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"NANOSECOND\"},\"children\":[]},\
+        {\"name\":\"c19\",\"nullable\":false,\"type\":{\"name\":\"interval\",\"unit\":\"DAY_TIME\"},\"children\":[]},\
+        {\"name\":\"c20\",\"nullable\":false,\"type\":{\"name\":\"interval\",\"unit\":\"YEAR_MONTH\"},\"children\":[]},\
+        {\"name\":\"c21\",\"nullable\":false,\"type\":{\"name\":\"list\"},\"children\":[\
+        {\"name\":\"item\",\"nullable\":false,\"type\":{\"name\":\"bool\"},\"children\":[]}]},\
+        {\"name\":\"c22\",\"nullable\":true,\"type\":{\"name\":\"list\"},\"children\":[\
+        {\"name\":\"item\",\"nullable\":true,\"type\":{\"name\":\"list\"},\"children\":[\
+        {\"name\":\"item\",\"nullable\":true,\"type\":{\"name\":\"struct\"},\"children\":[]}]}]},\
+        {\"name\":\"c23\",\"nullable\":false,\"type\":{\"name\":\"struct\"},\"children\":[\
+        {\"name\":\"a\",\"nullable\":false,\"type\":{\"name\":\"utf8\"},\"children\":[]},\
+        {\"name\":\"b\",\"nullable\":false,\"type\":{\"name\":\"int\",\"bitWidth\":16,\"isSigned\":false},\"children\":[]}]}]}");
 
         // convert back to a schema
         let value: Value = serde_json::from_str(&json).unwrap();
-        let schema2 = DataType::from(&value).unwrap();
+        let schema2 = Schema::from(&value).unwrap();
 
-        match schema2 {
-            DataType::Struct(fields) => {
-                assert_eq!(schema.fields().len(), fields.len());
-            }
-            _ => panic!(),
-        }
+        assert_eq!(schema, schema2);
     }
 
     #[test]

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -780,9 +780,9 @@ impl Field {
                     },
                     DataType::Struct(mut fields) => match map.get("children") {
                         Some(Value::Array(values)) => {
-                            let mut struct_fields =
-                                values.iter().map(|v| Field::from(v).unwrap()).collect();
-                            fields.append(&mut struct_fields);
+                            let struct_fields: Result<Vec<Field>> =
+                                values.iter().map(|v| Field::from(v)).collect();
+                            fields.append(&mut struct_fields?);
                             DataType::Struct(fields)
                         }
                         Some(_) => {

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1004,21 +1004,54 @@ mod tests {
             ]),
             false,
         );
-        assert_eq!(
-            "{\"name\":\"address\",\"nullable\":false,\"type\":{\"name\":\"struct\"},\"children\":[\
-            {\"name\":\"street\",\"nullable\":false,\"type\":{\"name\":\"utf8\"},\"children\":[]},\
-            {\"name\":\"zip\",\"nullable\":false,\"type\":{\"name\":\"int\",\"bitWidth\":16,\"isSigned\":false},\"children\":[]}]}",
-            f.to_json().to_string()
-        );
+        let value: Value = serde_json::from_str(
+            r#"{
+                "name": "address",
+                "nullable": false,
+                "type": {
+                    "name": "struct"
+                },
+                "children": [
+                    {
+                        "name": "street",
+                        "nullable": false,
+                        "type": {
+                            "name": "utf8"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "zip",
+                        "nullable": false,
+                        "type": {
+                            "name": "int",
+                            "bitWidth": 16,
+                            "isSigned": false
+                        },
+                        "children": []
+                    }
+                ]
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(value, f.to_json());
     }
 
     #[test]
     fn primitive_field_to_json() {
         let f = Field::new("first_name", DataType::Utf8, false);
-        assert_eq!(
-            "{\"name\":\"first_name\",\"nullable\":false,\"type\":{\"name\":\"utf8\"},\"children\":[]}",
-            f.to_json().to_string()
-        );
+        let value: Value = serde_json::from_str(
+            r#"{
+                "name": "first_name",
+                "nullable": false,
+                "type": {
+                    "name": "utf8"
+                },
+                "children": []
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(value, f.to_json());
     }
     #[test]
     fn parse_struct_from_json() {
@@ -1121,33 +1154,251 @@ mod tests {
             ),
         ]);
 
-        let json = schema.to_json().to_string();
-        assert_eq!(json, "{\"fields\":[{\"name\":\"c1\",\"nullable\":false,\"type\":{\"name\":\"utf8\"},\"children\":[]},\
-        {\"name\":\"c2\",\"nullable\":false,\"type\":{\"name\":\"bool\"},\"children\":[]},\
-        {\"name\":\"c3\",\"nullable\":false,\"type\":{\"name\":\"date\",\"unit\":\"DAY\"},\"children\":[]},\
-        {\"name\":\"c4\",\"nullable\":false,\"type\":{\"name\":\"date\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
-        {\"name\":\"c7\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":32,\"unit\":\"SECOND\"},\"children\":[]},\
-        {\"name\":\"c8\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":32,\"unit\":\"MILLISECOND\"},\"children\":[]},\
-        {\"name\":\"c9\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":32,\"unit\":\"MICROSECOND\"},\"children\":[]},\
-        {\"name\":\"c10\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":32,\"unit\":\"NANOSECOND\"},\"children\":[]},\
-        {\"name\":\"c11\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":64,\"unit\":\"SECOND\"},\"children\":[]},\
-        {\"name\":\"c12\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":64,\"unit\":\"MILLISECOND\"},\"children\":[]},\
-        {\"name\":\"c13\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":64,\"unit\":\"MICROSECOND\"},\"children\":[]},\
-        {\"name\":\"c14\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":64,\"unit\":\"NANOSECOND\"},\"children\":[]},\
-        {\"name\":\"c15\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"SECOND\"},\"children\":[]},\
-        {\"name\":\"c16\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
-        {\"name\":\"c17\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"MICROSECOND\"},\"children\":[]},\
-        {\"name\":\"c18\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"NANOSECOND\"},\"children\":[]},\
-        {\"name\":\"c19\",\"nullable\":false,\"type\":{\"name\":\"interval\",\"unit\":\"DAY_TIME\"},\"children\":[]},\
-        {\"name\":\"c20\",\"nullable\":false,\"type\":{\"name\":\"interval\",\"unit\":\"YEAR_MONTH\"},\"children\":[]},\
-        {\"name\":\"c21\",\"nullable\":false,\"type\":{\"name\":\"list\"},\"children\":[\
-        {\"name\":\"item\",\"nullable\":false,\"type\":{\"name\":\"bool\"},\"children\":[]}]},\
-        {\"name\":\"c22\",\"nullable\":true,\"type\":{\"name\":\"list\"},\"children\":[\
-        {\"name\":\"item\",\"nullable\":true,\"type\":{\"name\":\"list\"},\"children\":[\
-        {\"name\":\"item\",\"nullable\":true,\"type\":{\"name\":\"struct\"},\"children\":[]}]}]},\
-        {\"name\":\"c23\",\"nullable\":false,\"type\":{\"name\":\"struct\"},\"children\":[\
-        {\"name\":\"a\",\"nullable\":false,\"type\":{\"name\":\"utf8\"},\"children\":[]},\
-        {\"name\":\"b\",\"nullable\":false,\"type\":{\"name\":\"int\",\"bitWidth\":16,\"isSigned\":false},\"children\":[]}]}]}");
+        let expected = schema.to_json();
+        let json = r#"{
+                "fields": [
+                    {
+                        "name": "c1",
+                        "nullable": false,
+                        "type": {
+                            "name": "utf8"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c2",
+                        "nullable": false,
+                        "type": {
+                            "name": "bool"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c3",
+                        "nullable": false,
+                        "type": {
+                            "name": "date",
+                            "unit": "DAY"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c4",
+                        "nullable": false,
+                        "type": {
+                            "name": "date",
+                            "unit": "MILLISECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c7",
+                        "nullable": false,
+                        "type": {
+                            "name": "time",
+                            "bitWidth": 32,
+                            "unit": "SECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c8",
+                        "nullable": false,
+                        "type": {
+                            "name": "time",
+                            "bitWidth": 32,
+                            "unit": "MILLISECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c9",
+                        "nullable": false,
+                        "type": {
+                            "name": "time",
+                            "bitWidth": 32,
+                            "unit": "MICROSECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c10",
+                        "nullable": false,
+                        "type": {
+                            "name": "time",
+                            "bitWidth": 32,
+                            "unit": "NANOSECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c11",
+                        "nullable": false,
+                        "type": {
+                            "name": "time",
+                            "bitWidth": 64,
+                            "unit": "SECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c12",
+                        "nullable": false,
+                        "type": {
+                            "name": "time",
+                            "bitWidth": 64,
+                            "unit": "MILLISECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c13",
+                        "nullable": false,
+                        "type": {
+                            "name": "time",
+                            "bitWidth": 64,
+                            "unit": "MICROSECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c14",
+                        "nullable": false,
+                        "type": {
+                            "name": "time",
+                            "bitWidth": 64,
+                            "unit": "NANOSECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c15",
+                        "nullable": false,
+                        "type": {
+                            "name": "timestamp",
+                            "unit": "SECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c16",
+                        "nullable": false,
+                        "type": {
+                            "name": "timestamp",
+                            "unit": "MILLISECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c17",
+                        "nullable": false,
+                        "type": {
+                            "name": "timestamp",
+                            "unit": "MICROSECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c18",
+                        "nullable": false,
+                        "type": {
+                            "name": "timestamp",
+                            "unit": "NANOSECOND"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c19",
+                        "nullable": false,
+                        "type": {
+                            "name": "interval",
+                            "unit": "DAY_TIME"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c20",
+                        "nullable": false,
+                        "type": {
+                            "name": "interval",
+                            "unit": "YEAR_MONTH"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c21",
+                        "nullable": false,
+                        "type": {
+                            "name": "list"
+                        },
+                        "children": [
+                            {
+                                "name": "item",
+                                "nullable": false,
+                                "type": {
+                                    "name": "bool"
+                                },
+                                "children": []
+                            }
+                        ]
+                    },
+                    {
+                        "name": "c22",
+                        "nullable": true,
+                        "type": {
+                            "name": "list"
+                        },
+                        "children": [
+                            {
+                                "name": "item",
+                                "nullable": true,
+                                "type": {
+                                    "name": "list"
+                                },
+                                "children": [
+                                    {
+                                        "name": "item",
+                                        "nullable": true,
+                                        "type": {
+                                            "name": "struct"
+                                        },
+                                        "children": []
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "name": "c23",
+                        "nullable": false,
+                        "type": {
+                            "name": "struct"
+                        },
+                        "children": [
+                            {
+                                "name": "a",
+                                "nullable": false,
+                                "type": {
+                                    "name": "utf8"
+                                },
+                                "children": []
+                            },
+                            {
+                                "name": "b",
+                                "nullable": false,
+                                "type": {
+                                    "name": "int",
+                                    "bitWidth": 16,
+                                    "isSigned": false
+                                },
+                                "children": []
+                            }
+                        ]
+                    }
+                ]
+            }"#;
+        let value: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(expected, value);
 
         // convert back to a schema
         let value: Value = serde_json::from_str(&json).unwrap();

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -578,8 +578,8 @@ impl DataType {
                         )),
                     };
                     match map.get("bitWidth") {
-                        Some(p) if p == "32" => Ok(DataType::Time32(unit?)),
-                        Some(p) if p == "64" => Ok(DataType::Time64(unit?)),
+                        Some(p) if p == 32 => Ok(DataType::Time32(unit?)),
+                        Some(p) if p == 64 => Ok(DataType::Time64(unit?)),
                         _ => Err(ArrowError::ParseError(
                             "time bitWidth missing or invalid".to_string(),
                         )),
@@ -668,7 +668,7 @@ impl DataType {
             DataType::Struct(_) => json!({"name": "struct"}),
             DataType::List(_) => json!({ "name": "list"}),
             DataType::Time32(unit) => {
-                json!({"name": "time", "bitWidth": "32", "unit": match unit {
+                json!({"name": "time", "bitWidth": 32, "unit": match unit {
                     TimeUnit::Second => "SECOND",
                     TimeUnit::Millisecond => "MILLISECOND",
                     TimeUnit::Microsecond => "MICROSECOND",
@@ -676,7 +676,7 @@ impl DataType {
                 }})
             }
             DataType::Time64(unit) => {
-                json!({"name": "time", "bitWidth": "64", "unit": match unit {
+                json!({"name": "time", "bitWidth": 64, "unit": match unit {
                     TimeUnit::Second => "SECOND",
                     TimeUnit::Millisecond => "MILLISECOND",
                     TimeUnit::Microsecond => "MICROSECOND",
@@ -743,7 +743,6 @@ impl Field {
                 let nullable = match map.get("nullable") {
                     Some(&Value::Bool(b)) => b,
                     _ => {
-                        println!("error field: {:?}", map);
                         return Err(ArrowError::ParseError(
                             "Field missing 'nullable' attribute".to_string(),
                         ));
@@ -1127,14 +1126,14 @@ mod tests {
         {\"name\":\"c2\",\"nullable\":false,\"type\":{\"name\":\"bool\"},\"children\":[]},\
         {\"name\":\"c3\",\"nullable\":false,\"type\":{\"name\":\"date\",\"unit\":\"DAY\"},\"children\":[]},\
         {\"name\":\"c4\",\"nullable\":false,\"type\":{\"name\":\"date\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
-        {\"name\":\"c7\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"SECOND\"},\"children\":[]},\
-        {\"name\":\"c8\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
-        {\"name\":\"c9\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"MICROSECOND\"},\"children\":[]},\
-        {\"name\":\"c10\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"32\",\"unit\":\"NANOSECOND\"},\"children\":[]},\
-        {\"name\":\"c11\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"SECOND\"},\"children\":[]},\
-        {\"name\":\"c12\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
-        {\"name\":\"c13\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"MICROSECOND\"},\"children\":[]},\
-        {\"name\":\"c14\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":\"64\",\"unit\":\"NANOSECOND\"},\"children\":[]},\
+        {\"name\":\"c7\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":32,\"unit\":\"SECOND\"},\"children\":[]},\
+        {\"name\":\"c8\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":32,\"unit\":\"MILLISECOND\"},\"children\":[]},\
+        {\"name\":\"c9\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":32,\"unit\":\"MICROSECOND\"},\"children\":[]},\
+        {\"name\":\"c10\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":32,\"unit\":\"NANOSECOND\"},\"children\":[]},\
+        {\"name\":\"c11\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":64,\"unit\":\"SECOND\"},\"children\":[]},\
+        {\"name\":\"c12\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":64,\"unit\":\"MILLISECOND\"},\"children\":[]},\
+        {\"name\":\"c13\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":64,\"unit\":\"MICROSECOND\"},\"children\":[]},\
+        {\"name\":\"c14\",\"nullable\":false,\"type\":{\"name\":\"time\",\"bitWidth\":64,\"unit\":\"NANOSECOND\"},\"children\":[]},\
         {\"name\":\"c15\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"SECOND\"},\"children\":[]},\
         {\"name\":\"c16\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"MILLISECOND\"},\"children\":[]},\
         {\"name\":\"c17\",\"nullable\":false,\"type\":{\"name\":\"timestamp\",\"unit\":\"MICROSECOND\"},\"children\":[]},\

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -95,8 +95,8 @@ impl RecordBatch {
     }
 
     /// Get a reference to all columns
-    pub fn columns(&self) -> &Vec<ArrayRef> {
-        &self.columns
+    pub fn columns(&self) -> &[ArrayRef] {
+        &self.columns[..]
     }
 }
 

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -93,6 +93,11 @@ impl RecordBatch {
     pub fn column(&self, i: usize) -> &ArrayRef {
         &self.columns[i]
     }
+
+    /// Get a reference to all columns
+    pub fn columns(&self) -> &Vec<ArrayRef> {
+        &self.columns
+    }
 }
 
 impl From<&StructArray> for RecordBatch {

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -112,12 +112,15 @@ impl ArrowJsonBatch {
                         let arr = arr.as_any().downcast_ref::<Int16Array>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
-                    DataType::Int32 => {
-                        let arr = arr.as_any().downcast_ref::<Int32Array>().unwrap();
+                    DataType::Int32 | DataType::Date32(_) | DataType::Time32(_) => {
+                        let arr = Int32Array::from(arr.data());
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
-                    DataType::Int64 => {
-                        let arr = arr.as_any().downcast_ref::<Int64Array>().unwrap();
+                    DataType::Int64
+                    | DataType::Date64(_)
+                    | DataType::Time64(_)
+                    | DataType::Timestamp(_) => {
+                        let arr = Int64Array::from(arr.data());
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
                     DataType::UInt8 => {
@@ -324,6 +327,24 @@ mod tests {
             Field::new("uint64s", DataType::UInt64, true),
             Field::new("float32s", DataType::Float32, true),
             Field::new("float64s", DataType::Float64, true),
+            Field::new("date_days", DataType::Date32(DateUnit::Day), true),
+            Field::new("date_millis", DataType::Date64(DateUnit::Millisecond), true),
+            Field::new("time_secs", DataType::Time32(TimeUnit::Second), true),
+            Field::new("time_millis", DataType::Time32(TimeUnit::Millisecond), true),
+            Field::new("time_micros", DataType::Time64(TimeUnit::Microsecond), true),
+            Field::new("time_nanos", DataType::Time64(TimeUnit::Nanosecond), true),
+            Field::new("ts_secs", DataType::Timestamp(TimeUnit::Second), true),
+            Field::new(
+                "ts_millis",
+                DataType::Timestamp(TimeUnit::Millisecond),
+                true,
+            ),
+            Field::new(
+                "ts_micros",
+                DataType::Timestamp(TimeUnit::Microsecond),
+                true,
+            ),
+            Field::new("ts_nanos", DataType::Timestamp(TimeUnit::Nanosecond), true),
             Field::new("utf8s", DataType::Utf8, true),
             Field::new("lists", DataType::List(Box::new(DataType::Int32)), true),
             Field::new(
@@ -347,6 +368,35 @@ mod tests {
         let uint64s = UInt64Array::from(vec![Some(1), None, Some(3)]);
         let float32s = Float32Array::from(vec![Some(1.0), None, Some(3.0)]);
         let float64s = Float64Array::from(vec![Some(1.0), None, Some(3.0)]);
+        let date_days = Date32Array::from(vec![Some(1196848), None, None]);
+        let date_millis = Date64Array::from(vec![
+            Some(167903550396207),
+            Some(29923997007884),
+            Some(30612271819236),
+        ]);
+        let time_secs =
+            Time32SecondArray::from(vec![Some(27974), Some(78592), Some(43207)]);
+        let time_millis = Time32MillisecondArray::from(vec![
+            Some(6613125),
+            Some(74667230),
+            Some(52260079),
+        ]);
+        let time_micros =
+            Time64MicrosecondArray::from(vec![Some(62522958593), None, None]);
+        let time_nanos = Time64NanosecondArray::from(vec![
+            Some(73380123595985),
+            None,
+            Some(16584393546415),
+        ]);
+        let ts_secs = TimestampSecondArray::from(vec![None, Some(193438817552), None]);
+        let ts_millis = TimestampMillisecondArray::from(vec![
+            None,
+            Some(38606916383008),
+            Some(58113709376587),
+        ]);
+        let ts_micros = TimestampMicrosecondArray::from(vec![None, None, None]);
+        let ts_nanos =
+            TimestampNanosecondArray::from(vec![None, None, Some(-6473623571954960143)]);
         let utf8s = BinaryArray::try_from(vec![Some("aa"), None, Some("bbb")]).unwrap();
 
         let value_data = Int32Array::from(vec![None, Some(2), None, None]);
@@ -387,6 +437,16 @@ mod tests {
                 Arc::new(uint64s),
                 Arc::new(float32s),
                 Arc::new(float64s),
+                Arc::new(date_days),
+                Arc::new(date_millis),
+                Arc::new(time_secs),
+                Arc::new(time_millis),
+                Arc::new(time_micros),
+                Arc::new(time_nanos),
+                Arc::new(ts_secs),
+                Arc::new(ts_millis),
+                Arc::new(ts_micros),
+                Arc::new(ts_nanos),
                 Arc::new(utf8s),
                 Arc::new(lists),
                 Arc::new(structs),

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -1,0 +1,405 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Utils for JSON integration testing
+//!
+//! These utilities define structs that read the integration JSON format for integration testing purposes.
+
+use serde_derive::Deserialize;
+use serde_json::Value;
+
+use crate::array::*;
+use crate::datatypes::*;
+use crate::record_batch::RecordBatch;
+
+/// A struct that represents an Arrow file with a schema and record batches
+#[derive(Deserialize)]
+struct ArrowJson {
+    schema: ArrowJsonSchema,
+    batches: Vec<ArrowJsonBatch>,
+}
+
+/// A struct that partially reads the Arrow JSON schema.
+///
+/// Fields are left as JSON `Value` as they vary by `DataType`
+#[derive(Deserialize)]
+struct ArrowJsonSchema {
+    fields: Vec<Value>,
+}
+
+/// A struct that partially reads the Arrow JSON record batch
+#[derive(Deserialize)]
+struct ArrowJsonBatch {
+    count: usize,
+    columns: Vec<ArrowJsonColumn>,
+}
+
+/// A struct that partially reads the Arrow JSON column/array
+#[derive(Deserialize, Clone, Debug)]
+struct ArrowJsonColumn {
+    name: String,
+    count: usize,
+    #[serde(rename = "VALIDITY")]
+    validity: Vec<u8>,
+    #[serde(rename = "DATA")]
+    data: Option<Vec<Value>>,
+    #[serde(rename = "OFFSET")]
+    offset: Option<Vec<Value>>, // leaving as Value as 64-bit offsets are strings
+    children: Option<Vec<ArrowJsonColumn>>,
+}
+
+impl ArrowJsonSchema {
+    /// Compare the Arrow JSON schema with the Arrow `Schema`
+    fn equals_schema(&self, schema: &Schema) -> bool {
+        let field_len = self.fields.len();
+        if field_len != schema.fields().len() {
+            return false;
+        }
+        for i in 0..field_len {
+            let json_field = &self.fields[i];
+            let field = schema.field(i);
+            assert_eq!(json_field, &field.to_json());
+        }
+        true
+    }
+}
+
+impl ArrowJsonBatch {
+    /// Comapre the Arrow JSON record batch with a `RecordBatch`
+    fn equals_batch(&self, batch: &RecordBatch) -> bool {
+        if self.count != batch.num_rows() {
+            return false;
+        }
+        let num_columns = self.columns.len();
+        if num_columns != batch.num_columns() {
+            return false;
+        }
+        let schema = batch.schema();
+        self.columns
+            .iter()
+            .zip(batch.columns())
+            .zip(schema.fields())
+            .all(|((col, arr), field)| {
+                // compare each column based on its type
+                if &col.name != field.name() {
+                    return false;
+                }
+                let json_array: Vec<Value> = json_from_col(&col, field.data_type());
+                match field.data_type() {
+                    DataType::Boolean => {
+                        let arr = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::Int8 => {
+                        let arr = arr.as_any().downcast_ref::<Int8Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::Int16 => {
+                        let arr = arr.as_any().downcast_ref::<Int16Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::Int32 => {
+                        let arr = arr.as_any().downcast_ref::<Int32Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::Int64 => {
+                        let arr = arr.as_any().downcast_ref::<Int64Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::UInt8 => {
+                        let arr = arr.as_any().downcast_ref::<UInt8Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::UInt16 => {
+                        let arr = arr.as_any().downcast_ref::<UInt16Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::UInt32 => {
+                        let arr = arr.as_any().downcast_ref::<UInt32Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::UInt64 => {
+                        let arr = arr.as_any().downcast_ref::<UInt64Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::Float32 => {
+                        let arr = arr.as_any().downcast_ref::<Float32Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::Float64 => {
+                        let arr = arr.as_any().downcast_ref::<Float64Array>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::Utf8 => {
+                        let arr = arr.as_any().downcast_ref::<BinaryArray>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::List(_) => {
+                        let arr = arr.as_any().downcast_ref::<ListArray>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    DataType::Struct(_) => {
+                        let arr = arr.as_any().downcast_ref::<StructArray>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
+                    t @ _ => panic!("Unsupported comparison for {:?}", t),
+                }
+            })
+    }
+}
+
+/// Convert an Arrow JSON column/array into a vector of `Value`
+fn json_from_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value> {
+    match data_type {
+        DataType::List(dt) => json_from_list_col(col, &**dt),
+        DataType::Struct(fields) => json_from_struct_col(col, fields),
+        _ => merge_json_array(&col.validity, &col.data.clone().unwrap()),
+    }
+}
+
+/// Merge VALIDITY and DATA vectors from a primitive data type into a `Value` vector with nulls
+fn merge_json_array(validity: &Vec<u8>, data: &Vec<Value>) -> Vec<Value> {
+    validity
+        .iter()
+        .zip(data)
+        .map(|(v, d)| match v {
+            0 => Value::Null,
+            1 => d.clone(),
+            _ => panic!("Validity data should be 0 or 1"),
+        })
+        .collect()
+}
+
+/// Convert an Arrow JSON column/array of a `DataType::Struct` into a vector of `Value`
+fn json_from_struct_col(col: &ArrowJsonColumn, fields: &Vec<Field>) -> Vec<Value> {
+    let mut values = Vec::with_capacity(col.count);
+
+    let children: Vec<Vec<Value>> = col
+        .children
+        .clone()
+        .unwrap()
+        .iter()
+        .zip(fields)
+        .map(|(child, field)| json_from_col(child, field.data_type()))
+        .collect();
+
+    // create a struct from children
+    for j in 0..col.count {
+        let mut map = serde_json::map::Map::new();
+        for i in 0..children.len() {
+            map.insert(fields[i].name().to_string(), children[i][j].clone());
+        }
+        values.push(Value::Object(map));
+    }
+
+    values
+}
+
+/// Convert an Arrow JSON column/array of a `DataType::List` into a vector of `Value`
+fn json_from_list_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value> {
+    let mut values = Vec::with_capacity(col.count);
+
+    // get the inner array
+    let child = &col.children.clone().expect("list type must have children")[0];
+    let offsets: Vec<usize> = col
+        .offset
+        .clone()
+        .unwrap()
+        .iter()
+        .map(|o| match o {
+            Value::String(s) => *&s.parse::<usize>().unwrap(),
+            Value::Number(n) => n.as_u64().unwrap() as usize,
+            _ => panic!(
+                "Offsets should be numbers or strings that are convertible to numbers"
+            ),
+        })
+        .collect();
+    let inner = match data_type {
+        DataType::List(ref dt) => json_from_col(child, &**dt),
+        DataType::Struct(fields) => json_from_struct_col(col, fields),
+        _ => merge_json_array(&child.validity, &child.data.clone().unwrap()),
+    };
+
+    for i in 0..col.count {
+        match col.validity[i] {
+            0 => values.push(Value::Null),
+            1 => values.push(Value::Array(inner[offsets[i]..offsets[i + 1]].to_vec())),
+            _ => panic!("Validity data should be 0 or 1"),
+        }
+    }
+
+    values
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::convert::TryFrom;
+    use std::fs::File;
+    use std::io::Read;
+    use std::sync::Arc;
+
+    use crate::buffer::Buffer;
+
+    #[test]
+    fn test_schema_equality() {
+        let json = r#"
+        {
+            "fields": [
+                {
+                    "name": "c1",
+                    "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+                    "nullable": true,
+                    "children": []
+                },
+                {
+                    "name": "c2",
+                    "type": {"name": "floatingpoint", "precision": "DOUBLE"},
+                    "nullable": true,
+                    "children": []
+                },
+                {
+                    "name": "c3",
+                    "type": {"name": "utf8"},
+                    "nullable": true,
+                    "children": []
+                },
+                {
+                    "name": "c4",
+                    "type": {
+                        "name": "list"
+                    },
+                    "nullable": true,
+                    "children": [
+                        {
+                            "name": "item",
+                            "type": {
+                                "name": "int",
+                                "isSigned": true,
+                                "bitWidth": 32
+                            },
+                            "nullable": true,
+                            "children": []
+                        }
+                    ]
+                }
+            ]
+        }"#;
+        let json_schema: ArrowJsonSchema = serde_json::from_str(json).unwrap();
+        let schema = Schema::new(vec![
+            Field::new("c1", DataType::Int32, true),
+            Field::new("c2", DataType::Float64, true),
+            Field::new("c3", DataType::Utf8, true),
+            Field::new("c4", DataType::List(Box::new(DataType::Int32)), true),
+        ]);
+        assert!(json_schema.equals_schema(&schema));
+    }
+
+    #[test]
+    fn test_arrow_data_equality() {
+        let schema = Schema::new(vec![
+            Field::new("bools", DataType::Boolean, true),
+            Field::new("int8s", DataType::Int8, true),
+            Field::new("int16s", DataType::Int16, true),
+            Field::new("int32s", DataType::Int32, true),
+            Field::new("int64s", DataType::Int64, true),
+            Field::new("uint8s", DataType::UInt8, true),
+            Field::new("uint16s", DataType::UInt16, true),
+            Field::new("uint32s", DataType::UInt32, true),
+            Field::new("uint64s", DataType::UInt64, true),
+            Field::new("float32s", DataType::Float32, true),
+            Field::new("float64s", DataType::Float64, true),
+            Field::new("utf8s", DataType::Utf8, true),
+            Field::new("lists", DataType::List(Box::new(DataType::Int32)), true),
+            Field::new(
+                "structs",
+                DataType::Struct(vec![
+                    Field::new("int32s", DataType::Int32, true),
+                    Field::new("utf8s", DataType::Utf8, true),
+                ]),
+                true,
+            ),
+        ]);
+
+        let bools = BooleanArray::from(vec![Some(true), None, Some(false)]);
+        let int8s = Int8Array::from(vec![Some(1), None, Some(3)]);
+        let int16s = Int16Array::from(vec![Some(1), None, Some(3)]);
+        let int32s = Int32Array::from(vec![Some(1), None, Some(3)]);
+        let int64s = Int64Array::from(vec![Some(1), None, Some(3)]);
+        let uint8s = UInt8Array::from(vec![Some(1), None, Some(3)]);
+        let uint16s = UInt16Array::from(vec![Some(1), None, Some(3)]);
+        let uint32s = UInt32Array::from(vec![Some(1), None, Some(3)]);
+        let uint64s = UInt64Array::from(vec![Some(1), None, Some(3)]);
+        let float32s = Float32Array::from(vec![Some(1.0), None, Some(3.0)]);
+        let float64s = Float64Array::from(vec![Some(1.0), None, Some(3.0)]);
+        let utf8s = BinaryArray::try_from(vec![Some("aa"), None, Some("bbb")]).unwrap();
+
+        let value_data = Int32Array::from(vec![None, Some(2), None, None]);
+        let value_offsets = Buffer::from(&[0, 3, 4, 4].to_byte_slice());
+        let list_data_type = DataType::List(Box::new(DataType::Int32));
+        let list_data = ArrayData::builder(list_data_type)
+            .len(3)
+            .add_buffer(value_offsets)
+            .add_child_data(value_data.data())
+            .build();
+        let lists = ListArray::from(list_data);
+
+        let structs_int32s = Int32Array::from(vec![None, Some(-2), None]);
+        let structs_utf8s =
+            BinaryArray::try_from(vec![None, None, Some("aaaaaa")]).unwrap();
+        let structs = StructArray::from(vec![
+            (
+                Field::new("int32s", DataType::Int32, true),
+                Arc::new(structs_int32s) as ArrayRef,
+            ),
+            (
+                Field::new("utf8s", DataType::Utf8, true),
+                Arc::new(structs_utf8s) as ArrayRef,
+            ),
+        ]);
+
+        let record_batch = RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(bools),
+                Arc::new(int8s),
+                Arc::new(int16s),
+                Arc::new(int32s),
+                Arc::new(int64s),
+                Arc::new(uint8s),
+                Arc::new(uint16s),
+                Arc::new(uint32s),
+                Arc::new(uint64s),
+                Arc::new(float32s),
+                Arc::new(float64s),
+                Arc::new(utf8s),
+                Arc::new(lists),
+                Arc::new(structs),
+            ],
+        )
+        .unwrap();
+        let mut file = File::open("test/data/integration.json").unwrap();
+        let mut json = String::new();
+        file.read_to_string(&mut json).unwrap();
+        let arrow_json: ArrowJson = serde_json::from_str(&json).unwrap();
+        // test schemas
+        assert!(arrow_json.schema.equals_schema(&schema));
+        // test record batch
+        assert!(arrow_json.batches[0].equals_batch(&record_batch));
+    }
+}

--- a/rust/arrow/src/util/mod.rs
+++ b/rust/arrow/src/util/mod.rs
@@ -16,5 +16,6 @@
 // under the License.
 
 pub mod bit_util;
+pub(crate) mod integration_util;
 pub mod string_writer;
 pub mod test_util;

--- a/rust/arrow/test/data/integration.json
+++ b/rust/arrow/test/data/integration.json
@@ -108,6 +108,100 @@
         "children": []
       },
       {
+        "name": "date_days",
+        "type": {
+          "name": "date",
+          "unit": "DAY"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "date_millis",
+        "type": {
+          "name": "date",
+          "unit": "MILLISECOND"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "time_secs",
+        "type": {
+          "name": "time",
+          "unit": "SECOND",
+          "bitWidth": 32
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "time_millis",
+        "type": {
+          "name": "time",
+          "unit": "MILLISECOND",
+          "bitWidth": 32
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "time_micros",
+        "type": {
+          "name": "time",
+          "unit": "MICROSECOND",
+          "bitWidth": 64
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "time_nanos",
+        "type": {
+          "name": "time",
+          "unit": "NANOSECOND",
+          "bitWidth": 64
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "ts_secs",
+        "type": {
+          "name": "timestamp",
+          "unit": "SECOND"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "ts_millis",
+        "type": {
+          "name": "timestamp",
+          "unit": "MILLISECOND"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "ts_micros",
+        "type": {
+          "name": "timestamp",
+          "unit": "MICROSECOND"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "ts_nanos",
+        "type": {
+          "name": "timestamp",
+          "unit": "NANOSECOND"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
         "name": "utf8s",
         "type": {
           "name": "utf8"
@@ -319,6 +413,146 @@
             1.0,
             2.0,
             3.0
+          ]
+        },
+        {
+          "name": "date_days",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            0
+          ],
+          "DATA": [
+            1196848,
+            2319603,
+            2755982
+          ]
+        },
+        {
+          "name": "date_millis",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            1,
+            1
+          ],
+          "DATA": [
+            167903550396207,
+            29923997007884,
+            30612271819236
+          ]
+        },
+        {
+          "name": "time_secs",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            1,
+            1
+          ],
+          "DATA": [
+            27974,
+            78592,
+            43207
+          ]
+        },
+        {
+          "name": "time_millis",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            1,
+            1
+          ],
+          "DATA": [
+            6613125,
+            74667230,
+            52260079
+          ]
+        },
+        {
+          "name": "time_micros",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            0
+          ],
+          "DATA": [
+            62522958593,
+            13470380050,
+            50797036705
+          ]
+        },
+        {
+          "name": "time_nanos",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            73380123595985,
+            52520995325145,
+            16584393546415
+          ]
+        },
+        {
+          "name": "ts_secs",
+          "count": 3,
+          "VALIDITY": [
+            0,
+            1,
+            0
+          ],
+          "DATA": [
+            209869064422,
+            193438817552,
+            51757838205
+          ]
+        },
+        {
+          "name": "ts_millis",
+          "count": 3,
+          "VALIDITY": [
+            0,
+            1,
+            1
+          ],
+          "DATA": [
+            228315043570185,
+            38606916383008,
+            58113709376587
+          ]
+        },
+        {
+          "name": "ts_micros",
+          "count": 3,
+          "VALIDITY": [
+            0,
+            0,
+            0
+          ],
+          "DATA": [
+            133457416537791415,
+            129522736067409280,
+            177110451066832967
+          ]
+        },
+        {
+          "name": "ts_nanos",
+          "count": 3,
+          "VALIDITY": [
+            0,
+            0,
+            1
+          ],
+          "DATA": [
+            -804525722984600007,
+            8166038652634779458,
+            -6473623571954960143
           ]
         },
         {

--- a/rust/arrow/test/data/integration.json
+++ b/rust/arrow/test/data/integration.json
@@ -1,0 +1,425 @@
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "bools",
+        "type": {
+          "name": "bool"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "int8s",
+        "type": {
+          "name": "int",
+          "isSigned": true,
+          "bitWidth": 8
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "int16s",
+        "type": {
+          "name": "int",
+          "isSigned": true,
+          "bitWidth": 16
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "int32s",
+        "type": {
+          "name": "int",
+          "isSigned": true,
+          "bitWidth": 32
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "int64s",
+        "type": {
+          "name": "int",
+          "isSigned": true,
+          "bitWidth": 64
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "uint8s",
+        "type": {
+          "name": "int",
+          "isSigned": false,
+          "bitWidth": 8
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "uint16s",
+        "type": {
+          "name": "int",
+          "isSigned": false,
+          "bitWidth": 16
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "uint32s",
+        "type": {
+          "name": "int",
+          "isSigned": false,
+          "bitWidth": 32
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "uint64s",
+        "type": {
+          "name": "int",
+          "isSigned": false,
+          "bitWidth": 64
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "float32s",
+        "type": {
+          "name": "floatingpoint",
+          "precision": "SINGLE"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "float64s",
+        "type": {
+          "name": "floatingpoint",
+          "precision": "DOUBLE"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "utf8s",
+        "type": {
+          "name": "utf8"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "lists",
+        "type": {
+          "name": "list"
+        },
+        "nullable": true,
+        "children": [
+          {
+            "name": "item",
+            "type": {
+              "name": "int",
+              "isSigned": true,
+              "bitWidth": 32
+            },
+            "nullable": true,
+            "children": []
+          }
+        ]
+      },
+      {
+        "name": "structs",
+        "type": {
+          "name": "struct"
+        },
+        "nullable": true,
+        "children": [
+          {
+            "name": "int32s",
+            "type": {
+              "name": "int",
+              "isSigned": true,
+              "bitWidth": 32
+            },
+            "nullable": true,
+            "children": []
+          },
+          {
+            "name": "utf8s",
+            "type": {
+              "name": "utf8"
+            },
+            "nullable": true,
+            "children": []
+          }
+        ]
+      }
+    ]
+  },
+  "batches": [
+    {
+      "count": 3,
+      "columns": [
+        {
+          "name": "bools",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            true,
+            true,
+            false
+          ]
+        },
+        {
+          "name": "int8s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "name": "int16s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "name": "int32s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "name": "int64s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "name": "uint8s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "name": "uint16s",
+          "count": 5,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "name": "uint32s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "name": "uint64s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1,
+            2,
+            3
+          ]
+        },
+        {
+          "name": "float32s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1.0,
+            2.0,
+            3.0
+          ]
+        },
+        {
+          "name": "float64s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "DATA": [
+            1.0,
+            2.0,
+            3.0
+          ]
+        },
+        {
+          "name": "utf8s",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            0,
+            1
+          ],
+          "OFFSET": [
+            0,
+            2,
+            2,
+            5
+          ],
+          "DATA": [
+            "aa",
+            "",
+            "bbb"
+          ]
+        },
+        {
+          "name": "lists",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            1,
+            0
+          ],
+          "OFFSET": [
+            0,
+            3,
+            4,
+            4
+          ],
+          "children": [
+            {
+              "name": "item",
+              "count": 4,
+              "VALIDITY": [
+                0,
+                1,
+                0,
+                0
+              ],
+              "DATA": [
+                1,
+                2,
+                3,
+                4
+              ]
+            }
+          ]
+        },
+        {
+          "name": "structs",
+          "count": 3,
+          "VALIDITY": [
+            1,
+            1,
+            0
+          ],
+          "children": [
+            {
+              "name": "int32s",
+              "count": 3,
+              "VALIDITY": [
+                0,
+                1,
+                0
+              ],
+              "DATA": [
+                -1,
+                -2,
+                -3
+              ]
+            },
+            {
+              "name": "utf8s",
+              "count": 3,
+              "VALIDITY": [
+                0,
+                0,
+                1
+              ],
+              "OFFSET": [
+                0,
+                0,
+                0,
+                7
+              ],
+              "DATA": [
+                "",
+                "",
+                "aaaaaa"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -326,7 +326,9 @@ impl ExecutionContext {
                 match expr {
                     &Expr::Literal(ref scalar_value) => {
                         let limit: usize = match scalar_value {
-                            ScalarValue::Int8(limit) if *limit >= 0 => Ok(*limit as usize),
+                            ScalarValue::Int8(limit) if *limit >= 0 => {
+                                Ok(*limit as usize)
+                            }
                             ScalarValue::Int16(limit) if *limit >= 0 => {
                                 Ok(*limit as usize)
                             }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -326,9 +326,7 @@ impl ExecutionContext {
                 match expr {
                     &Expr::Literal(ref scalar_value) => {
                         let limit: usize = match scalar_value {
-                            ScalarValue::Int8(limit) if *limit >= 0 => {
-                                Ok(*limit as usize)
-                            }
+                            ScalarValue::Int8(limit) if *limit >= 0 => Ok(*limit as usize),
                             ScalarValue::Int16(limit) if *limit >= 0 => {
                                 Ok(*limit as usize)
                             }


### PR DESCRIPTION
This creates the ability to compare a schema and batch against the JSON rep used in integration testing.
The PR:

- fixes and aligns the JSON fns in datatypes to align to the Arrow spec
- adds fns to partially read an integration JSON file
- compares record batches with the JSON data, leveraging JSON equality checks

After this PR, it should be possible to add Rust to integration tests