### PR TITLE
ARROW-6898: [Java][hotfix] fix ArrowWriter memory leak

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ArrowWriter.java
@@ -162,11 +162,15 @@ public abstract class ArrowWriter implements AutoCloseable {
     if (!dictWritten) {
       dictWritten = true;
       // write out any dictionaries
-      for (ArrowDictionaryBatch batch : dictionaries) {
-        try {
+      try {
+        for (ArrowDictionaryBatch batch : dictionaries) {
           writeDictionaryBatch(batch);
-        } finally {
-          batch.close();
+        }
+      } finally {
+        try {
+          AutoCloseables.close(dictionaries);
+        } catch (Exception e) {
+          throw new RuntimeException("Error occurred while closing dictionaries.", e);
         }
       }
     }


### PR DESCRIPTION
Related to [ARROW-6898](https://issues.apache.org/jira/browse/ARROW-6898).
hotfix for potential memory leak in ArrowWriter.