### PR TITLE
ARROW-6869: [C++] Do not return invalid arrays from DictionaryBuilder::Finish when reusing builder. Add "FinishDelta" method and "ResetFull" method

### DIFF
--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -89,11 +89,7 @@ class ARROW_EXPORT DictionaryMemoTable {
 /// dense array
 ///
 /// Unlike other builders, dictionary builder does not completely
-/// reset the state on Finish calls. The arrays built after the
-/// initial Finish call will reuse the previously created encoding and
-/// build a delta dictionary when new terms occur.
-///
-/// data
+/// reset the state on Finish calls.
 template <typename BuilderType, typename T>
 class DictionaryBuilderBase : public ArrayBuilder {
  public:
@@ -230,10 +226,16 @@ class DictionaryBuilderBase : public ArrayBuilder {
   }
 
   void Reset() override {
+    // Perform a partial reset. Also call ResetDictionary to reset the
+    // accumulated dictionary values
     ArrayBuilder::Reset();
     indices_builder_.Reset();
+  }
+
+  /// \brief Reset and also clear accumulated dictionary values in memo table
+  void ResetFull() {
+    Reset();
     memo_table_.reset(new internal::DictionaryMemoTable(value_type_));
-    delta_offset_ = 0;
   }
 
   Status Resize(int64_t capacity) override {
@@ -244,28 +246,26 @@ class DictionaryBuilderBase : public ArrayBuilder {
     return Status::OK();
   }
 
+  /// \brief Return dictionary indices and a delta dictionary since the last
+  /// time that Finish or FinishDelta were called, and reset state of builder
+  /// (except the memo table)
+  Status FinishDelta(std::shared_ptr<Array>* out_indices,
+                     std::shared_ptr<Array>* out_delta) {
+    std::shared_ptr<Array> dictionary;
+    std::shared_ptr<ArrayData> indices_data;
+    ARROW_RETURN_NOT_OK(FinishWithDictOffset(delta_offset_, &indices_data, out_delta));
+
+    *out_indices = MakeArray(indices_data);
+    return Status::OK();
+  }
+
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override {
-    // Finalize indices array
-    ARROW_RETURN_NOT_OK(indices_builder_.FinishInternal(out));
-
-    // Generate dictionary array from hash table contents
-    std::shared_ptr<ArrayData> dictionary_data;
-
-    ARROW_RETURN_NOT_OK(
-        memo_table_->GetArrayData(pool_, delta_offset_, &dictionary_data));
+    std::shared_ptr<Array> dictionary;
+    ARROW_RETURN_NOT_OK(FinishWithDictOffset(/*offset=*/0, out, &dictionary));
 
     // Set type of array data to the right dictionary type
     (*out)->type = type();
-    (*out)->dictionary = MakeArray(dictionary_data);
-
-    // Update internals for further uses of this DictionaryBuilder
-    delta_offset_ = memo_table_->size();
-
-    // ARROW-6861: Manually set capacity/length/null count until we can fix up
-    // Reset to not reset the memo table in ARROW-6869
-    capacity_ = length_ = null_count_ = 0;
-    indices_builder_.Reset();
-
+    (*out)->dictionary = dictionary;
     return Status::OK();
   }
 
@@ -275,17 +275,35 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
 
-  /// is the dictionary builder in the delta building mode
-  bool is_building_delta() { return delta_offset_ > 0; }
-
   std::shared_ptr<DataType> type() const override {
     return ::arrow::dictionary(indices_builder_.type(), value_type_);
   }
 
  protected:
+  Status FinishWithDictOffset(int64_t dict_offset,
+                              std::shared_ptr<ArrayData>* out_indices,
+                              std::shared_ptr<Array>* out_dictionary) {
+    // Finalize indices array
+    ARROW_RETURN_NOT_OK(indices_builder_.FinishInternal(out_indices));
+
+    // Generate dictionary array from hash table contents
+    std::shared_ptr<ArrayData> dictionary_data;
+    ARROW_RETURN_NOT_OK(memo_table_->GetArrayData(pool_, dict_offset, &dictionary_data));
+
+    *out_dictionary = MakeArray(dictionary_data);
+    delta_offset_ = memo_table_->size();
+
+    // Update internals for further uses of this DictionaryBuilder
+    ArrayBuilder::Reset();
+    return Status::OK();
+  }
+
   std::unique_ptr<DictionaryMemoTable> memo_table_;
 
+  // The size of the dictionary memo at last invocation of Finish, to use in
+  // FinishDelta for computing dictionary deltas
   int32_t delta_offset_;
+
   // Only used for FixedSizeBinaryType
   int32_t byte_width_;
 

--- a/cpp/src/arrow/array_dict_test.cc
+++ b/cpp/src/arrow/array_dict_test.cc
@@ -342,14 +342,17 @@ TYPED_TEST(TestDictionaryBuilder, ResetFull) {
   ASSERT_OK(builder.Finish(&result));
 
   // Dictionary expanded
+  const auto& dict_result = static_cast<const DictionaryArray&>(*result);
+  AssertArraysEqual(*ArrayFromJSON(int32(), "[2]"), *dict_result.indices());
   AssertArraysEqual(*ArrayFromJSON(type, "[1, 2, 3]"),
                     *static_cast<const DictionaryArray&>(*result).dictionary());
 
   builder.ResetFull();
   ASSERT_OK(builder.Append(static_cast<c_type>(4)));
   ASSERT_OK(builder.Finish(&result));
-  AssertArraysEqual(*ArrayFromJSON(type, "[4]"),
-                    *static_cast<const DictionaryArray&>(*result).dictionary());
+  const auto& dict_result2 = static_cast<const DictionaryArray&>(*result);
+  AssertArraysEqual(*ArrayFromJSON(int32(), "[0]"), *dict_result2.indices());
+  AssertArraysEqual(*ArrayFromJSON(type, "[4]"), *dict_result2.dictionary());
 }
 
 TEST(TestDictionaryBuilderAdHoc, AppendIndicesUpdateCapacity) {

--- a/cpp/src/arrow/array_dict_test.cc
+++ b/cpp/src/arrow/array_dict_test.cc
@@ -342,12 +342,14 @@ TYPED_TEST(TestDictionaryBuilder, ResetFull) {
   ASSERT_OK(builder.Finish(&result));
 
   // Dictionary expanded
-  ASSERT_EQ(3, static_cast<const DictionaryArray&>(*result).dictionary()->length());
+  AssertArraysEqual(*ArrayFromJSON(type, "[1, 2, 3]"),
+                    *static_cast<const DictionaryArray&>(*result).dictionary());
 
   builder.ResetFull();
   ASSERT_OK(builder.Append(static_cast<c_type>(4)));
   ASSERT_OK(builder.Finish(&result));
-  ASSERT_EQ(1, static_cast<const DictionaryArray&>(*result).dictionary()->length());
+  AssertArraysEqual(*ArrayFromJSON(type, "[4]"),
+                    *static_cast<const DictionaryArray&>(*result).dictionary());
 }
 
 TEST(TestDictionaryBuilderAdHoc, AppendIndicesUpdateCapacity) {

--- a/cpp/src/arrow/array_dict_test.cc
+++ b/cpp/src/arrow/array_dict_test.cc
@@ -217,16 +217,10 @@ TYPED_TEST(TestDictionaryBuilder, DeltaDictionary) {
   ASSERT_OK(builder.Append(static_cast<c_type>(1)));
   ASSERT_OK(builder.Append(static_cast<c_type>(3)));
 
-  std::shared_ptr<Array> result_delta;
-  ASSERT_OK(builder.Finish(&result_delta));
-
-  // Build expected data for the delta dictionary
-  auto ex_dict2 = ArrayFromJSON(type, "[3]");
-  auto dict_type2 = dictionary(int8(), type);
-  DictionaryArray expected_delta(dict_type2, ArrayFromJSON(int8(), "[1, 2, 2, 0, 2]"),
-                                 ex_dict2);
-
-  ASSERT_TRUE(expected_delta.Equals(result_delta));
+  std::shared_ptr<Array> result_indices, result_delta;
+  ASSERT_OK(builder.FinishDelta(&result_indices, &result_delta));
+  AssertArraysEqual(*ArrayFromJSON(int8(), "[1, 2, 2, 0, 2]"), *result_indices);
+  AssertArraysEqual(*ArrayFromJSON(type, "[3]"), *result_delta);
 }
 
 TYPED_TEST(TestDictionaryBuilder, DoubleDeltaDictionary) {
@@ -256,15 +250,10 @@ TYPED_TEST(TestDictionaryBuilder, DoubleDeltaDictionary) {
   ASSERT_OK(builder.Append(static_cast<c_type>(1)));
   ASSERT_OK(builder.Append(static_cast<c_type>(3)));
 
-  std::shared_ptr<Array> result_delta1;
-  ASSERT_OK(builder.Finish(&result_delta1));
-
-  // Build expected data for the delta dictionary
-  auto ex_dict2 = ArrayFromJSON(type, "[3]");
-  DictionaryArray expected_delta1(dict_type, ArrayFromJSON(int8(), "[1, 2, 2, 0, 2]"),
-                                  ex_dict2);
-
-  ASSERT_TRUE(expected_delta1.Equals(result_delta1));
+  std::shared_ptr<Array> result_indices1, result_delta1;
+  ASSERT_OK(builder.FinishDelta(&result_indices1, &result_delta1));
+  AssertArraysEqual(*ArrayFromJSON(int8(), "[1, 2, 2, 0, 2]"), *result_indices1);
+  AssertArraysEqual(*ArrayFromJSON(type, "[3]"), *result_delta1);
 
   // extend the dictionary builder with new data again
   ASSERT_OK(builder.Append(static_cast<c_type>(1)));
@@ -273,15 +262,10 @@ TYPED_TEST(TestDictionaryBuilder, DoubleDeltaDictionary) {
   ASSERT_OK(builder.Append(static_cast<c_type>(4)));
   ASSERT_OK(builder.Append(static_cast<c_type>(5)));
 
-  std::shared_ptr<Array> result_delta2;
-  ASSERT_OK(builder.Finish(&result_delta2));
-
-  // Build expected data for the delta dictionary again
-  auto ex_dict3 = ArrayFromJSON(type, "[4, 5]");
-  DictionaryArray expected_delta2(dict_type, ArrayFromJSON(int8(), "[0, 1, 2, 3, 4]"),
-                                  ex_dict3);
-
-  ASSERT_TRUE(expected_delta2.Equals(result_delta2));
+  std::shared_ptr<Array> result_indices2, result_delta2;
+  ASSERT_OK(builder.FinishDelta(&result_indices2, &result_delta2));
+  AssertArraysEqual(*ArrayFromJSON(int8(), "[0, 1, 2, 3, 4]"), *result_indices2);
+  AssertArraysEqual(*ArrayFromJSON(type, "[4, 5]"), *result_delta2);
 }
 
 TYPED_TEST(TestDictionaryBuilder, Dictionary32_BasicPrimitive) {
@@ -336,7 +320,7 @@ TYPED_TEST(TestDictionaryBuilder, FinishResetBehavior) {
 
   ASSERT_OK(builder.Finish(&result));
 
-  // Dictionary has 4 elements because the dictionary memo was not reset. This
+  // Dictionary has 2 elements because the dictionary memo was not reset. This
   // behavior will change after ARROW-6869
   ASSERT_EQ(2, static_cast<const DictionaryArray&>(*result).dictionary()->length());
 }
@@ -533,14 +517,12 @@ TEST(TestStringDictionaryBuilder, DeltaDictionary) {
   ASSERT_OK(builder.Append("test3"));
   ASSERT_OK(builder.Append("test2"));
 
-  std::shared_ptr<Array> result_delta;
-  FinishAndCheckPadding(&builder, &result_delta);
+  std::shared_ptr<Array> result_indices, result_delta;
+  ASSERT_OK(builder.FinishDelta(&result_indices, &result_delta));
 
   // Build expected data
-  DictionaryArray expected_delta(dtype, ArrayFromJSON(int8(), "[1, 2, 1]"),
-                                 ArrayFromJSON(utf8(), "[\"test3\"]"));
-
-  ASSERT_TRUE(expected_delta.Equals(result_delta));
+  AssertArraysEqual(*ArrayFromJSON(int8(), "[1, 2, 1]"), *result_indices);
+  AssertArraysEqual(*ArrayFromJSON(utf8(), "[\"test3\"]"), *result_delta);
 }
 
 TEST(TestStringDictionaryBuilder, BigDeltaDictionary) {
@@ -588,18 +570,17 @@ TEST(TestStringDictionaryBuilder, BigDeltaDictionary) {
   }
   ASSERT_OK(str_builder2.Append("test_new_value1"));
 
-  std::shared_ptr<Array> result2;
-  ASSERT_OK(builder.Finish(&result2));
+  std::shared_ptr<Array> indices2, delta2;
+  ASSERT_OK(builder.FinishDelta(&indices2, &delta2));
 
   std::shared_ptr<Array> str_array2;
   ASSERT_OK(str_builder2.Finish(&str_array2));
-  auto dtype2 = dictionary(int16(), utf8());
 
   std::shared_ptr<Array> int_array2;
   ASSERT_OK(int_builder2.Finish(&int_array2));
 
-  DictionaryArray expected2(dtype2, int_array2, str_array2);
-  ASSERT_TRUE(expected2.Equals(result2));
+  AssertArraysEqual(*int_array2, *indices2);
+  AssertArraysEqual(*str_array2, *delta2);
 
   // build delta 2
   StringBuilder str_builder3;
@@ -616,18 +597,17 @@ TEST(TestStringDictionaryBuilder, BigDeltaDictionary) {
   }
   ASSERT_OK(str_builder3.Append("test_new_value2"));
 
-  std::shared_ptr<Array> result3;
-  ASSERT_OK(builder.Finish(&result3));
+  std::shared_ptr<Array> indices3, delta3;
+  ASSERT_OK(builder.FinishDelta(&indices3, &delta3));
 
   std::shared_ptr<Array> str_array3;
   ASSERT_OK(str_builder3.Finish(&str_array3));
-  auto dtype3 = dictionary(int16(), utf8());
 
   std::shared_ptr<Array> int_array3;
   ASSERT_OK(int_builder3.Finish(&int_array3));
 
-  DictionaryArray expected3(dtype3, int_array3, str_array3);
-  ASSERT_TRUE(expected3.Equals(result3));
+  AssertArraysEqual(*int_array3, *indices3);
+  AssertArraysEqual(*str_array3, *delta3);
 }
 
 TEST(TestFixedSizeBinaryDictionaryBuilder, Basic) {
@@ -744,8 +724,8 @@ TEST(TestFixedSizeBinaryDictionaryBuilder, DeltaDictionary) {
   ASSERT_OK(builder.Append(test2.data()));
   ASSERT_OK(builder.Append(test3.data()));
 
-  std::shared_ptr<Array> result2;
-  FinishAndCheckPadding(&builder, &result2);
+  std::shared_ptr<Array> indices2, delta2;
+  ASSERT_OK(builder.FinishDelta(&indices2, &delta2));
 
   // Build expected data
   FixedSizeBinaryBuilder fsb_builder2(value_type);
@@ -757,11 +737,12 @@ TEST(TestFixedSizeBinaryDictionaryBuilder, DeltaDictionary) {
   ASSERT_OK(int_builder2.Append(0));
   ASSERT_OK(int_builder2.Append(1));
   ASSERT_OK(int_builder2.Append(2));
+
   std::shared_ptr<Array> int_array2;
   ASSERT_OK(int_builder2.Finish(&int_array2));
 
-  DictionaryArray expected2(dict_type, int_array2, fsb_array2);
-  ASSERT_TRUE(expected2.Equals(result2));
+  AssertArraysEqual(*int_array2, *indices2);
+  AssertArraysEqual(*fsb_array2, *delta2);
 }
 
 TEST(TestFixedSizeBinaryDictionaryBuilder, DoubleTableSize) {

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -1270,8 +1270,8 @@ class ByteArrayDictionaryRecordReader : public TypedRecordReader<ByteArrayType>,
       PARQUET_THROW_NOT_OK(builder_.Finish(&chunk));
       result_chunks_.emplace_back(std::move(chunk));
 
-      // Reset clears the dictionary memo table
-      builder_.Reset();
+      // Also clears the dictionary memo table
+      builder_.ResetFull();
     }
   }
 


### PR DESCRIPTION
The current behavior is "wrong enough" that adding this to 0.15.1 might not be a bad idea, but we could always leave it for the next major release