### PR TITLE
ARROW-6916: [Developer] Sort tasks by name in Crossbow e-mail report

### DIFF
--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -952,11 +952,12 @@ class EmailReport(Report):
         return '{}/branches/all?query={}'.format(repo_url, query)
 
     def listing(self, tasks):
-        entries = (
-            self.TASK.format(name=task_name, url=self.url(task.branch))
-            for task_name, task in tasks.items()
+        return '\n'.join(
+            sorted(
+                self.TASK.format(name=task_name, url=self.url(task.branch))
+                for task_name, task in tasks.items()
+            )
         )
-        return '\n'.join(entries)
 
     def header(self):
         url = self.url(self.job.branch)

--- a/docs/source/developers/crossbow.rst
+++ b/docs/source/developers/crossbow.rst
@@ -94,7 +94,8 @@ Install
    authentication. Although it overwrites the repository urls provided with ssh
    protocol, it's advisable to use the HTTPS repository URLs.
 
-4. `Create a Personal Access Token`_
+4. `Create a Personal Access Token`_ with ``repo`` permissions (other
+   permissions are not needed)
 
 5. Locally export the token as an environment variable:
 


### PR DESCRIPTION
In the current e-mail report, the names are in arbitrary (hash-table-determined) order