### PR TITLE
ARROW-6935: [Java] Improve the performance of comparing two blocks of heap data

### DIFF
--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightDescriptor.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightDescriptor.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.impl.Flight.FlightDescriptor.DescriptorType;
+import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.util.Preconditions;
 
 import com.google.common.base.Joiner;
@@ -160,7 +161,8 @@ public class FlightDescriptor {
       if (other.cmd != null) {
         return false;
       }
-    } else if (!Arrays.equals(cmd, other.cmd)) {
+    } else if (ByteFunctionHelpers.equal(
+            cmd, 0, cmd.length, other.cmd, 0, other.cmd.length) == 0) {
       return false;
     }
     if (isCmd != other.isCmd) {

--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightDescriptor.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightDescriptor.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.impl.Flight.FlightDescriptor.DescriptorType;
-import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.util.Preconditions;
 
 import com.google.common.base.Joiner;
@@ -161,8 +160,7 @@ public class FlightDescriptor {
       if (other.cmd != null) {
         return false;
       }
-    } else if (ByteFunctionHelpers.equal(
-            cmd, 0, cmd.length, other.cmd, 0, other.cmd.length) == 0) {
+    } else if (!Arrays.equals(cmd, other.cmd)) {
       return false;
     }
     if (isCmd != other.isCmd) {

--- a/java/performance/src/test/java/org/apache/arrow/memory/util/ByteFunctionHelpersBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/memory/util/ByteFunctionHelpersBenchmarks.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.memory.util;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -127,6 +128,43 @@ public class ByteFunctionHelpersBenchmarks {
     return ByteFunctionHelpers.compare(
             state.buffer1, 0, ArrowArrayEqualState.BUFFER_CAPACITY,
             state.buffer2, 0, ArrowArrayEqualState.BUFFER_CAPACITY);
+  }
+
+  /**
+   * State object for the {@link ByteFunctionHelpersBenchmarks#byteArrayEquals(ByteArrayEqualState)} benchmark.
+   */
+  @State(Scope.Benchmark)
+  public static class ByteArrayEqualState {
+
+    private static final int ARRAY_LENGTH = 1024;
+
+    private byte[] buffer1 = new byte[ARRAY_LENGTH];
+
+    private byte[] buffer2 = new byte[ARRAY_LENGTH];
+
+    @Setup(Level.Trial)
+    public void prepare() {
+      for (int i = 0; i < ARRAY_LENGTH; i++) {
+        buffer1[i] = (byte) i;
+        buffer2[i] = (byte) i;
+      }
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public int byteArrayEquals(ByteArrayEqualState state) {
+    return ByteFunctionHelpers.equal(
+            state.buffer1, 0, ByteArrayEqualState.ARRAY_LENGTH,
+            state.buffer2, 0, ByteArrayEqualState.ARRAY_LENGTH);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.NANOSECONDS)
+  public boolean builtInByteArrayEquals(ByteArrayEqualState state) {
+    return Arrays.equals(state.buffer1, state.buffer2);
   }
 
   @Test

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/Text.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/Text.java
@@ -31,6 +31,8 @@ import java.text.CharacterIterator;
 import java.text.StringCharacterIterator;
 import java.util.Arrays;
 
+import org.apache.arrow.memory.util.ByteFunctionHelpers;
+
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -335,14 +337,7 @@ public class Text {
       return false;
     }
 
-    // copied from Arrays.equals so we don'thave to copy the byte arrays
-    for (int i = 0; i < length; i++) {
-      if (bytes[i] != that.bytes[i]) {
-        return false;
-      }
-    }
-
-    return true;
+    return ByteFunctionHelpers.equal(bytes, 0, bytes.length, that.bytes, 0, that.bytes.length) == 1;
   }
 
   /**


### PR DESCRIPTION
Implement methods to compare data word by word, instead of byte by byte.
Benchmarks shows that there is a 4.5x performance improvement:

ByteFunctionHelpersBenchmarks.builtInByteArrayEquals avgt 5 437.504 ± 1.120 ns/op
ByteFunctionHelpersBenchmarks.byteArrayEquals avgt 5 97.700 ± 0.178 ns/op