### PR TITLE
ARROW-1900: [C++] Add kernel for min / max

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -244,6 +244,7 @@ if(ARROW_COMPUTE)
               compute/kernels/hash.cc
               compute/kernels/filter.cc
               compute/kernels/mean.cc
+              compute/kernels/minmax.cc
               compute/kernels/sort_to_indices.cc
               compute/kernels/sum.cc
               compute/kernels/add.cc

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -191,6 +191,8 @@ struct ARROW_EXPORT Datum {
 
   bool is_scalar() const { return this->kind() == Datum::SCALAR; }
 
+  bool is_collection() const { return this->kind() == Datum::COLLECTION; }
+
   /// \brief The value type of the variant, if any
   ///
   /// \return nullptr if no type

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -324,8 +324,8 @@ class TestNumericMinMaxKernel : public ComputeFixture, public TestBase {
   using ScalarType = typename Traits::ScalarType;
 
  public:
-  template <typename T>
-  void AssertMinMaxIs(std::string array_json, T expected_min, T expected_max,
+  template <typename Min, typename Max>
+  void AssertMinMaxIs(std::string array_json, Min expected_min, Max expected_max,
                       const MinMaxOptions& options) {
     auto array = ArrayFromJSON(Traits::type_singleton(), array_json);
     Datum out, out_min, out_max;
@@ -361,9 +361,9 @@ TYPED_TEST(TestFloatingMinMaxKernel, Floats) {
   MinMaxOptions options;
   this->AssertMinMaxIs("[5, 1, 2, 3, 4]", 1, 5, options);
   this->AssertMinMaxIs("[5, null, 2, 3, 4]", 2, 5, options);
-  // this->AssertMinMaxIs("[5, Inf, 2, 3, 4]", 2.0, INFINITY, options);
+  this->AssertMinMaxIs("[5, Inf, 2, 3, 4]", 2.0, INFINITY, options);
   this->AssertMinMaxIs("[5, NaN, 2, 3, 4]", 2, 5, options);
-  // this->AssertMinMaxIs("[5, -Inf, 2, 3, 4]", -INFINITY, 5, options);
+  this->AssertMinMaxIs("[5, -Inf, 2, 3, 4]", -INFINITY, 5, options);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/minmax.cc
+++ b/cpp/src/arrow/compute/kernels/minmax.cc
@@ -108,7 +108,7 @@ class MinMaxAggregateFunction final
   }
 
   Status Finalize(const StateType& src, Datum* output) const override {
-    *output = Datum(src.min);
+    *output = Datum({Datum(src.min), Datum(src.max)});
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/kernels/minmax.cc
+++ b/cpp/src/arrow/compute/kernels/minmax.cc
@@ -1,0 +1,182 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// returnGegarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+
+#include "arrow/compute/kernels/aggregate.h"
+#include "arrow/compute/kernels/minmax.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/checked_cast.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+
+namespace compute {
+
+template <typename ArrowType, typename Enable = void>
+struct MinMaxState {};
+
+template <typename ArrowType>
+struct MinMaxState<ArrowType,
+                   typename std::enable_if<is_integer_type<ArrowType>::value>::type> {
+  using ThisType = MinMaxState<ArrowType>;
+  using c_type = typename ArrowType::c_type;
+
+  ThisType& operator+=(const ThisType& rhs) {
+    this->min = std::min(this->min, rhs.min);
+    this->max = std::max(this->max, rhs.max);
+    return *this;
+  }
+
+  void MergeOne(c_type value) {
+    this->min = std::min(this->min, value);
+    this->max = std::max(this->max, value);
+  }
+
+  c_type min = std::numeric_limits<c_type>::max();
+  c_type max = std::numeric_limits<c_type>::min();
+};
+
+template <typename ArrowType>
+struct MinMaxState<ArrowType,
+                   typename std::enable_if<is_floating_type<ArrowType>::value>::type> {
+  using ThisType = MinMaxState<ArrowType>;
+  using c_type = typename ArrowType::c_type;
+
+  ThisType& operator+=(const ThisType& rhs) {
+    this->min = std::fmin(this->min, rhs.min);
+    this->max = std::fmax(this->max, rhs.max);
+    return *this;
+  }
+
+  void MergeOne(c_type value) {
+    this->min = std::fmin(this->min, value);
+    this->max = std::fmax(this->max, value);
+  }
+
+  c_type min = std::numeric_limits<c_type>::infinity();
+  c_type max = -std::numeric_limits<c_type>::infinity();
+};
+
+template <typename ArrowType>
+class MinMaxAggregateFunction final
+    : public AggregateFunctionStaticState<MinMaxState<ArrowType>> {
+ public:
+  using StateType = MinMaxState<ArrowType>;
+
+  explicit MinMaxAggregateFunction(const MinMaxOptions& options) : options_(options) {}
+
+  Status Consume(const Array& array, StateType* state) const override {
+    StateType local;
+
+    internal::BitmapReader reader(array.null_bitmap_data(), array.offset(),
+                                  array.length());
+    const auto values =
+        checked_cast<const typename TypeTraits<ArrowType>::ArrayType&>(array)
+            .raw_values();
+    for (int64_t i = 0; i < array.length(); i++) {
+      if (reader.IsSet()) {
+        local.MergeOne(values[i]);
+      }
+      reader.Next();
+    }
+    *state = local;
+
+    return Status::OK();
+  }
+
+  Status Merge(const StateType& src, StateType* dst) const override {
+    *dst += src;
+    return Status::OK();
+  }
+
+  Status Finalize(const StateType& src, Datum* output) const override {
+    *output = Datum(src.min);
+    return Status::OK();
+  }
+
+  std::shared_ptr<DataType> out_type() const override {
+    return TypeTraits<ArrowType>::type_singleton();
+  }
+
+ private:
+  MinMaxOptions options_;
+};
+
+#define MINMAX_AGG_FN_CASE(T)                           \
+  case T::type_id:                                      \
+    return std::static_pointer_cast<AggregateFunction>( \
+        std::make_shared<MinMaxAggregateFunction<T>>(options));
+
+std::shared_ptr<AggregateFunction> MakeMinMaxAggregateFunction(
+    const DataType& type, FunctionContext* ctx, const MinMaxOptions& options) {
+  switch (type.id()) {
+    MINMAX_AGG_FN_CASE(UInt8Type);
+    MINMAX_AGG_FN_CASE(Int8Type);
+    MINMAX_AGG_FN_CASE(UInt16Type);
+    MINMAX_AGG_FN_CASE(Int16Type);
+    MINMAX_AGG_FN_CASE(UInt32Type);
+    MINMAX_AGG_FN_CASE(Int32Type);
+    MINMAX_AGG_FN_CASE(UInt64Type);
+    MINMAX_AGG_FN_CASE(Int64Type);
+    MINMAX_AGG_FN_CASE(FloatType);
+    MINMAX_AGG_FN_CASE(DoubleType);
+    default:
+      return nullptr;
+  }
+
+#undef MINMAX_AGG_FN_CASE
+}
+
+static Status GetMinMaxKernel(FunctionContext* ctx, const DataType& type,
+                              const MinMaxOptions& options,
+                              std::shared_ptr<AggregateUnaryKernel>& kernel) {
+  std::shared_ptr<AggregateFunction> aggregate =
+      MakeMinMaxAggregateFunction(type, ctx, options);
+  if (!aggregate) return Status::Invalid("No min/max for type ", type);
+
+  kernel = std::make_shared<AggregateUnaryKernel>(aggregate);
+
+  return Status::OK();
+}
+
+Status MinMax(FunctionContext* ctx, const MinMaxOptions& options, const Datum& value,
+              Datum* min) {
+  std::shared_ptr<AggregateUnaryKernel> kernel;
+
+  auto data_type = value.type();
+  if (data_type == nullptr) {
+    return Status::Invalid("Datum must be array-like");
+  } else if (!is_integer(data_type->id()) && !is_floating(data_type->id())) {
+    return Status::Invalid("Datum must contain a NumericType");
+  }
+
+  RETURN_NOT_OK(GetMinMaxKernel(ctx, *data_type, options, kernel));
+
+  return kernel->Call(ctx, value, min);
+}
+
+Status MinMax(FunctionContext* ctx, const MinMaxOptions& options, const Array& array,
+              Datum* min) {
+  return MinMax(ctx, options, array.data(), min);
+}
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/minmax.cc
+++ b/cpp/src/arrow/compute/kernels/minmax.cc
@@ -158,7 +158,7 @@ static Status GetMinMaxKernel(FunctionContext* ctx, const DataType& type,
 }
 
 Status MinMax(FunctionContext* ctx, const MinMaxOptions& options, const Datum& value,
-              Datum* min) {
+              Datum* out) {
   std::shared_ptr<AggregateUnaryKernel> kernel;
 
   auto data_type = value.type();
@@ -170,12 +170,12 @@ Status MinMax(FunctionContext* ctx, const MinMaxOptions& options, const Datum& v
 
   RETURN_NOT_OK(GetMinMaxKernel(ctx, *data_type, options, kernel));
 
-  return kernel->Call(ctx, value, min);
+  return kernel->Call(ctx, value, out);
 }
 
 Status MinMax(FunctionContext* ctx, const MinMaxOptions& options, const Array& array,
-              Datum* min) {
-  return MinMax(ctx, options, array.data(), min);
+              Datum* out) {
+  return MinMax(ctx, options, array.data(), out);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/minmax.h
+++ b/cpp/src/arrow/compute/kernels/minmax.h
@@ -57,10 +57,13 @@ std::shared_ptr<AggregateFunction> MakeMinMaxAggregateFunction(
 
 /// \brief Calculate the min / max of a numeric array
 ///
+/// This function returns both the min and max as a collection. The resulting
+/// datum thus consists of two scalar datums: {Datum(min), Datum(max)}
+///
 /// \param[in] ctx the FunctionContext
 /// \param[in] options, see MinMaxOptions for more information
 /// \param[in] value input datum, expecting Array or ChunkedArray
-/// \param[out] out resulting datum
+/// \param[out] out resulting datum containing a {min, max} collection
 ///
 /// \since 1.0.0
 /// \note API not yet finalized
@@ -70,10 +73,13 @@ Status MinMax(FunctionContext* ctx, const MinMaxOptions& options, const Datum& v
 
 /// \brief Calculate the min / max of a numeric array.
 ///
+/// This function returns both the min and max as a collection. The resulting
+/// datum thus consists of two scalar datums: {Datum(min), Datum(max)}
+///
 /// \param[in] ctx the FunctionContext
 /// \param[in] options, see MinMaxOptions for more information
 /// \param[in] array input array
-/// \param[out] out resulting datum
+/// \param[out] out resulting datum containing a {min, max} collection
 ///
 /// \since 1.0.0
 /// \note API not yet finalized

--- a/cpp/src/arrow/compute/kernels/minmax.h
+++ b/cpp/src/arrow/compute/kernels/minmax.h
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/util/visibility.h"
+
+namespace arrow {
+
+class Array;
+class DataType;
+class Status;
+
+namespace compute {
+
+struct Datum;
+class FunctionContext;
+class AggregateFunction;
+
+/// \class MinMaxOptions
+///
+/// The user can control the MinMax kernel behavior with this class. By default,
+/// it will return null if there is a null value present.
+struct ARROW_EXPORT MinMaxOptions {
+  //   MinMaxOptions() : skip_nulls(false) {}
+
+  //   bool skip_nulls;
+};
+
+/// \brief Return a Min/Max Kernel
+///
+/// \param[in] type required to specialize the kernel
+/// \param[in] context the FunctionContext
+/// \param[in] options, see MinMaxOptions for more information
+///
+/// \since 1.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+std::shared_ptr<AggregateFunction> MakeMinMaxAggregateFunction(
+    const DataType& type, FunctionContext* ctx, const MinMaxOptions& options);
+
+/// \brief Calculate the min / max of a numeric array
+///
+/// \param[in] context the FunctionContext
+/// \param[in] options, see MinMaxOptions for more information
+/// \param[in] input value datum, expecting Array or ChunkedArray
+/// \param[out] out resulting datum
+///
+/// \since 1.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Status MinMax(FunctionContext* context, const MinMaxOptions& options, const Datum& value,
+              Datum* min);
+
+/// \brief Calculate the min / max of a numeric array.
+///
+/// \param[in] context the FunctionContext
+/// \param[in] options, see MinMaxOptions for more information
+/// \param[in] input array
+/// \param[out] out resulting datum
+///
+/// \since 1.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Status MinMax(FunctionContext* context, const MinMaxOptions& options, const Array& array,
+              Datum* min);
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/minmax.h
+++ b/cpp/src/arrow/compute/kernels/minmax.h
@@ -46,7 +46,7 @@ struct ARROW_EXPORT MinMaxOptions {
 /// \brief Return a Min/Max Kernel
 ///
 /// \param[in] type required to specialize the kernel
-/// \param[in] context the FunctionContext
+/// \param[in] ctx the FunctionContext
 /// \param[in] options, see MinMaxOptions for more information
 ///
 /// \since 1.0.0
@@ -57,29 +57,29 @@ std::shared_ptr<AggregateFunction> MakeMinMaxAggregateFunction(
 
 /// \brief Calculate the min / max of a numeric array
 ///
-/// \param[in] context the FunctionContext
+/// \param[in] ctx the FunctionContext
 /// \param[in] options, see MinMaxOptions for more information
-/// \param[in] input value datum, expecting Array or ChunkedArray
+/// \param[in] value input datum, expecting Array or ChunkedArray
 /// \param[out] out resulting datum
 ///
 /// \since 1.0.0
 /// \note API not yet finalized
 ARROW_EXPORT
-Status MinMax(FunctionContext* context, const MinMaxOptions& options, const Datum& value,
-              Datum* min);
+Status MinMax(FunctionContext* ctx, const MinMaxOptions& options, const Datum& value,
+              Datum* out);
 
 /// \brief Calculate the min / max of a numeric array.
 ///
-/// \param[in] context the FunctionContext
+/// \param[in] ctx the FunctionContext
 /// \param[in] options, see MinMaxOptions for more information
-/// \param[in] input array
+/// \param[in] array input array
 /// \param[out] out resulting datum
 ///
 /// \since 1.0.0
 /// \note API not yet finalized
 ARROW_EXPORT
-Status MinMax(FunctionContext* context, const MinMaxOptions& options, const Array& array,
-              Datum* min);
+Status MinMax(FunctionContext* ctx, const MinMaxOptions& options, const Array& array,
+              Datum* out);
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/minmax.h
+++ b/cpp/src/arrow/compute/kernels/minmax.h
@@ -47,7 +47,7 @@ struct ARROW_EXPORT MinMaxOptions {
 ///
 /// \param[in] type required to specialize the kernel
 /// \param[in] ctx the FunctionContext
-/// \param[in] options, see MinMaxOptions for more information
+/// \param[in] options see MinMaxOptions for more information
 ///
 /// \since 1.0.0
 /// \note API not yet finalized
@@ -61,7 +61,7 @@ std::shared_ptr<AggregateFunction> MakeMinMaxAggregateFunction(
 /// datum thus consists of two scalar datums: {Datum(min), Datum(max)}
 ///
 /// \param[in] ctx the FunctionContext
-/// \param[in] options, see MinMaxOptions for more information
+/// \param[in] options see MinMaxOptions for more information
 /// \param[in] value input datum, expecting Array or ChunkedArray
 /// \param[out] out resulting datum containing a {min, max} collection
 ///
@@ -77,7 +77,7 @@ Status MinMax(FunctionContext* ctx, const MinMaxOptions& options, const Datum& v
 /// datum thus consists of two scalar datums: {Datum(min), Datum(max)}
 ///
 /// \param[in] ctx the FunctionContext
-/// \param[in] options, see MinMaxOptions for more information
+/// \param[in] options see MinMaxOptions for more information
 /// \param[in] array input array
 /// \param[out] out resulting datum containing a {min, max} collection
 ///


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-1900

Some to do's:

- ~~Return min and/or max (should we always return both, or return one of both specified through an option?)~~
- Option to not skip nulls?
- How to handle NaN for floating point? Currently (determined by `std:fmin`) it is ignored, but we should maybe rather propagate it?
- Corner cases such as zero-length array