### PR TITLE
PARQUET-1678: [C++] Provide classes for reading/writing using input/output operators

### DIFF
--- a/cpp/examples/parquet/CMakeLists.txt
+++ b/cpp/examples/parquet/CMakeLists.txt
@@ -18,6 +18,7 @@
 add_executable(parquet-low-level-example low-level-api/reader-writer.cc)
 add_executable(parquet-low-level-example2 low-level-api/reader-writer2.cc)
 add_executable(parquet-arrow-example parquet-arrow/reader-writer.cc)
+add_executable(parquet-stream-api-example parquet-stream-api/stream-reader-writer.cc)
 target_include_directories(parquet-low-level-example PRIVATE low-level-api/)
 target_include_directories(parquet-low-level-example2 PRIVATE low-level-api/)
 
@@ -40,11 +41,13 @@ endif()
 target_link_libraries(parquet-arrow-example ${PARQUET_EXAMPLE_LINK_LIBS})
 target_link_libraries(parquet-low-level-example ${PARQUET_EXAMPLE_LINK_LIBS})
 target_link_libraries(parquet-low-level-example2 ${PARQUET_EXAMPLE_LINK_LIBS})
+target_link_libraries(parquet-stream-api-example ${PARQUET_EXAMPLE_LINK_LIBS})
 
 add_dependencies(parquet
   parquet-low-level-example
   parquet-low-level-example2
-  parquet-arrow-example)
+  parquet-arrow-example
+  parquet-stream-api-example)
 
 if (PARQUET_REQUIRE_ENCRYPTION)
   add_dependencies(parquet

--- a/cpp/examples/parquet/parquet-stream-api/stream-reader-writer.cc
+++ b/cpp/examples/parquet/parquet-stream-api/stream-reader-writer.cc
@@ -1,0 +1,299 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements. See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership. The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <utility>
+
+#include "arrow/io/file.h"
+#include "parquet/exception.h"
+#include "parquet/stream_reader.h"
+#include "parquet/stream_writer.h"
+
+// This file gives an example of how to use the parquet::StreamWriter
+// and parquet::StreamReader classes.
+// It shows writing/reading of the supported types as well as how a
+// user-defined type can be handled.
+
+// Example of a user-defined type to be written to/read from Parquet
+// using C++ input/output operators.
+class UserTimestamp {
+ public:
+  UserTimestamp() = default;
+
+  UserTimestamp(const std::chrono::microseconds v) : ts_{v} {}
+
+  bool operator==(const UserTimestamp& x) const { return ts_ == x.ts_; }
+
+  void dump(std::ostream& os) const {
+    std::time_t t{std::chrono::duration_cast<std::chrono::seconds>(ts_).count()};
+    os << std::put_time(std::gmtime(&t), "%Y%m%d-%H%M%S");
+  }
+
+  void dump(parquet::StreamWriter& os) const { os << ts_; }
+
+ private:
+  std::chrono::microseconds ts_;
+};
+
+std::ostream& operator<<(std::ostream& os, const UserTimestamp& v) {
+  v.dump(os);
+  return os;
+}
+
+parquet::StreamWriter& operator<<(parquet::StreamWriter& os, const UserTimestamp& v) {
+  v.dump(os);
+  return os;
+}
+
+parquet::StreamReader& operator>>(parquet::StreamReader& os, UserTimestamp& v) {
+  std::chrono::microseconds ts;
+
+  os >> ts;
+  v = UserTimestamp{ts};
+
+  return os;
+}
+
+std::shared_ptr<parquet::schema::GroupNode> GetSchema() {
+  parquet::schema::NodeVector fields;
+
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "string_field", parquet::Repetition::REQUIRED, parquet::Type::BYTE_ARRAY,
+      parquet::ConvertedType::UTF8));
+
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "char_field", parquet::Repetition::REQUIRED, parquet::Type::FIXED_LEN_BYTE_ARRAY,
+      parquet::ConvertedType::NONE, 1));
+
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "char[4]_field", parquet::Repetition::REQUIRED, parquet::Type::FIXED_LEN_BYTE_ARRAY,
+      parquet::ConvertedType::NONE, 4));
+
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "int8_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
+      parquet::ConvertedType::INT_8));
+
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "uint16_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
+      parquet::ConvertedType::UINT_16));
+
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "int32_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
+      parquet::ConvertedType::INT_32));
+
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "uint64_field", parquet::Repetition::REQUIRED, parquet::Type::INT64,
+      parquet::ConvertedType::UINT_64));
+
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "double_field", parquet::Repetition::REQUIRED, parquet::Type::DOUBLE,
+      parquet::ConvertedType::NONE));
+
+  // User defined timestamp type.
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "timestamp_field", parquet::Repetition::REQUIRED, parquet::Type::INT64,
+      parquet::ConvertedType::TIMESTAMP_MICROS));
+
+  fields.push_back(parquet::schema::PrimitiveNode::Make(
+      "chrono_milliseconds_field", parquet::Repetition::REQUIRED, parquet::Type::INT64,
+      parquet::ConvertedType::TIMESTAMP_MILLIS));
+
+  return std::static_pointer_cast<parquet::schema::GroupNode>(
+      parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED, fields));
+}
+
+struct TestData {
+  static const int num_rows = 2000;
+
+  static void init() { std::time(&ts_offset_); }
+
+  static std::string GetString(const int i) { return "Str #" + std::to_string(i); }
+  static arrow::util::string_view GetStringView(const int i) {
+    string_ = "StringView #" + std::to_string(i);
+    return arrow::util::string_view(string_);
+  }
+  static const char* GetCharPtr(const int i) {
+    string_ = "CharPtr #" + std::to_string(i);
+    return string_.c_str();
+  }
+  static char GetChar(const int i) { return i & 1 ? 'M' : 'F'; }
+  static int8_t GetInt8(const int i) { return static_cast<int8_t>((i % 256) - 128); }
+  static uint16_t GetUInt16(const int i) { return static_cast<uint16_t>(i); }
+  static int32_t GetInt32(const int i) { return 3 * i - 17; }
+  static uint64_t GetUInt64(const int i) { return (1ull << 40) + i * i + 101; }
+  static double GetDouble(const int i) { return 6.62607004e-34 * 3e8 * i; }
+  static UserTimestamp GetUserTimestamp(const int i) {
+    return UserTimestamp{std::chrono::microseconds{(ts_offset_ + 3 * i) * 1000000 + i}};
+  }
+  static std::chrono::milliseconds GetChronoMilliseconds(const int i) {
+    return std::chrono::milliseconds{(ts_offset_ + 3 * i) * 1000ull + i};
+  }
+
+  static char char4_array[4];
+
+ private:
+  static std::time_t ts_offset_;
+  static std::string string_;
+};
+
+char TestData::char4_array[] = "XYZ";
+std::time_t TestData::ts_offset_;
+std::string TestData::string_;
+
+void WriteParquetFile() {
+  std::shared_ptr<arrow::io::FileOutputStream> outfile;
+
+  PARQUET_THROW_NOT_OK(
+      arrow::io::FileOutputStream::Open("parquet-stream-api-example.parquet", &outfile));
+
+  parquet::WriterProperties::Builder builder;
+
+  builder.compression(parquet::Compression::BROTLI);
+
+  auto file_writer =
+      parquet::ParquetFileWriter::Open(outfile, GetSchema(), builder.build());
+
+  parquet::StreamWriter os{std::move(file_writer)};
+
+  os.SetMaxRowGroupSize(1000);
+
+  for (auto i = 0; i < TestData::num_rows; ++i) {
+    // Output string using 3 different types: std::string, arrow::util::string_view and
+    // const char *.
+    switch (i % 3) {
+      case 0:
+        os << TestData::GetString(i);
+        break;
+      case 1:
+        os << TestData::GetStringView(i);
+        break;
+      case 2:
+        os << TestData::GetCharPtr(i);
+        break;
+    }
+    os << TestData::GetChar(i);
+    switch (i % 2) {
+      case 0:
+        os << TestData::char4_array;
+        break;
+      case 1:
+        os << parquet::StreamWriter::FixedStringView{TestData::GetCharPtr(i), 4};
+        break;
+    }
+    os << TestData::GetInt8(i);
+    os << TestData::GetUInt16(i);
+    os << TestData::GetInt32(i);
+    os << TestData::GetUInt64(i);
+    os << TestData::GetDouble(i);
+    os << TestData::GetUserTimestamp(i);
+    os << TestData::GetChronoMilliseconds(i);
+    os << parquet::EndRow;
+
+    if (i == TestData::num_rows / 2) {
+      os << parquet::EndRowGroup;
+    }
+  }
+  std::cout << "Parquet Stream Writing complete." << std::endl;
+}
+
+void ReadParquetFile() {
+  std::shared_ptr<arrow::io::ReadableFile> infile;
+
+  PARQUET_THROW_NOT_OK(
+      arrow::io::ReadableFile::Open("parquet-stream-api-example.parquet", &infile));
+
+  auto file_reader = parquet::ParquetFileReader::Open(infile);
+
+  parquet::StreamReader os{std::move(file_reader)};
+
+  std::string s;
+  char ch;
+  char char_array[4];
+  int8_t int8;
+  uint16_t uint16;
+  int32_t int32;
+  uint64_t uint64;
+  double d;
+  UserTimestamp ts_user;
+  std::chrono::milliseconds ts_ms;
+  int i;
+
+  for (i = 0; !os.eof(); ++i) {
+    os >> s;
+    os >> ch;
+    os >> char_array;
+    os >> int8;
+    os >> uint16;
+    os >> int32;
+    os >> uint64;
+    os >> d;
+    os >> ts_user;
+    os >> ts_ms;
+    os >> parquet::EndRow;
+
+    if (0) {
+      // For debugging.
+      std::cout << s << ' ' << ch << ' ' << char_array << ' ' << int(int8) << ' '
+                << uint16 << ' ' << int32 << ' ' << uint64 << ' ' << d << ' ' << ts_user
+                << ' ' << ts_ms.count() << std::endl;
+    }
+    // Check data.
+    switch (i % 3) {
+      case 0:
+        assert(s == TestData::GetString(i));
+        break;
+      case 1:
+        assert(s == TestData::GetStringView(i));
+        break;
+      case 2:
+        assert(s == TestData::GetCharPtr(i));
+        break;
+    }
+    assert(ch == TestData::GetChar(i));
+    switch (i % 2) {
+      case 0:
+        assert(0 == std::memcmp(char_array, TestData::char4_array, sizeof(char_array)));
+        break;
+      case 1:
+        assert(0 == std::memcmp(char_array, TestData::GetCharPtr(i), sizeof(char_array)));
+        break;
+    }
+    assert(int8 == TestData::GetInt8(i));
+    assert(uint16 == TestData::GetUInt16(i));
+    assert(int32 == TestData::GetInt32(i));
+    assert(uint64 == TestData::GetUInt64(i));
+    assert(std::abs(d - TestData::GetDouble(i)) < 1e-6);
+    assert(ts_user == TestData::GetUserTimestamp(i));
+    assert(ts_ms == TestData::GetChronoMilliseconds(i));
+  }
+  assert(TestData::num_rows == i);
+
+  std::cout << "Parquet Stream Reading complete." << std::endl;
+}
+
+int main() {
+  WriteParquetFile();
+  ReadParquetFile();
+
+  return 0;
+}

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -169,6 +169,8 @@ set(PARQUET_SRCS
     properties.cc
     schema.cc
     statistics.cc
+    stream_reader.cc
+    stream_writer.cc
     types.cc)
 
 if(PARQUET_REQUIRE_ENCRYPTION)
@@ -301,12 +303,14 @@ add_parquet_test(reader_test
                  column_reader_test.cc
                  column_scanner_test.cc
                  reader_test.cc
+                 stream_reader_test.cc
                  test_util.cc)
 
 add_parquet_test(writer-test
                  SOURCES
                  column_writer_test.cc
                  file_serialize_test.cc
+                 stream_writer_test.cc
                  test_util.cc)
 
 add_parquet_test(arrow-test

--- a/cpp/src/parquet/stream_reader.cc
+++ b/cpp/src/parquet/stream_reader.cc
@@ -1,0 +1,253 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/stream_reader.h"
+
+#include <utility>
+
+namespace parquet {
+
+StreamReader::StreamReader(std::unique_ptr<ParquetFileReader> reader)
+    : file_reader_{std::move(reader)} {
+  file_metadata_ = file_reader_->metadata();
+
+  auto schema = file_metadata_->schema();
+  auto group_node = schema->group_node();
+
+  nodes_.resize(schema->num_columns());
+
+  for (auto i = 0; i < schema->num_columns(); ++i) {
+    nodes_[i] = std::static_pointer_cast<schema::PrimitiveNode>(group_node->field(i));
+  }
+  NextRowGroup();
+}
+
+StreamReader& StreamReader::operator>>(bool& v) {
+  CheckColumn(Type::BOOLEAN, ConvertedType::NONE);
+  Read<BoolReader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(int8_t& v) {
+  CheckColumn(Type::INT32, ConvertedType::INT_8);
+  int32_t tmp;
+  Read<Int32Reader>(&tmp);
+  v = static_cast<int8_t>(tmp);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(uint8_t& v) {
+  CheckColumn(Type::INT32, ConvertedType::UINT_8);
+  int32_t tmp;
+  Read<Int32Reader>(&tmp);
+  v = static_cast<uint8_t>(tmp);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(int16_t& v) {
+  CheckColumn(Type::INT32, ConvertedType::INT_16);
+  int32_t tmp;
+  Read<Int32Reader>(&tmp);
+  v = static_cast<int16_t>(tmp);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(uint16_t& v) {
+  CheckColumn(Type::INT32, ConvertedType::UINT_16);
+  int32_t tmp;
+  Read<Int32Reader>(&tmp);
+  v = static_cast<uint16_t>(tmp);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(int32_t& v) {
+  CheckColumn(Type::INT32, ConvertedType::INT_32);
+  Read<Int32Reader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(uint32_t& v) {
+  CheckColumn(Type::INT32, ConvertedType::UINT_32);
+  Read<Int32Reader>(reinterpret_cast<int32_t*>(&v));
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(int64_t& v) {
+  CheckColumn(Type::INT64, ConvertedType::INT_64);
+  Read<Int64Reader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(uint64_t& v) {
+  CheckColumn(Type::INT64, ConvertedType::UINT_64);
+  Read<Int64Reader>(reinterpret_cast<int64_t*>(&v));
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(std::chrono::milliseconds& v) {
+  CheckColumn(Type::INT64, ConvertedType::TIMESTAMP_MILLIS);
+  int64_t tmp;
+  Read<Int64Reader>(&tmp);
+  v = std::chrono::milliseconds{tmp};
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(std::chrono::microseconds& v) {
+  CheckColumn(Type::INT64, ConvertedType::TIMESTAMP_MICROS);
+  int64_t tmp;
+  Read<Int64Reader>(&tmp);
+  v = std::chrono::microseconds{tmp};
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(float& v) {
+  CheckColumn(Type::FLOAT, ConvertedType::NONE);
+  Read<FloatReader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(double& v) {
+  CheckColumn(Type::DOUBLE, ConvertedType::NONE);
+  Read<DoubleReader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(char& v) {
+  CheckColumn(Type::FIXED_LEN_BYTE_ARRAY, ConvertedType::NONE, 1);
+  FixedLenByteArray flba;
+  Read(&flba);
+  v = static_cast<char>(flba.ptr[0]);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(std::string& v) {
+  CheckColumn(Type::BYTE_ARRAY, ConvertedType::UTF8);
+  ByteArray ba;
+  Read(&ba);
+  v = std::string(reinterpret_cast<const char*>(ba.ptr), ba.len);
+  return *this;
+}
+
+void StreamReader::ReadFixedLength(char* ptr, int len) {
+  CheckColumn(Type::FIXED_LEN_BYTE_ARRAY, ConvertedType::NONE, len);
+  FixedLenByteArray flba;
+  Read(&flba);
+  std::memcpy(ptr, flba.ptr, len);
+}
+
+void StreamReader::Read(ByteArray* v) {
+  const auto& node = nodes_[column_index_];
+  auto reader = static_cast<ByteArrayReader*>(column_readers_[column_index_++].get());
+  int64_t values_read;
+
+  reader->ReadBatch(1, nullptr, nullptr, v, &values_read);
+
+  if (values_read != 1) {
+    throw ParquetException("Failed to read value for column '" + node->name() + "'");
+  }
+}
+
+void StreamReader::Read(FixedLenByteArray* v) {
+  const auto& node = nodes_[column_index_];
+  auto reader =
+      static_cast<FixedLenByteArrayReader*>(column_readers_[column_index_++].get());
+  int64_t values_read;
+
+  reader->ReadBatch(1, nullptr, nullptr, v, &values_read);
+
+  if (values_read != 1) {
+    throw ParquetException("Failed to read value for column '" + node->name() + "'");
+  }
+}
+
+void StreamReader::EndRow() {
+  if (!file_reader_) {
+    throw ParquetException("StreamReader not initialized");
+  }
+  if (static_cast<std::size_t>(column_index_) < nodes_.size()) {
+    throw ParquetException("Cannot end row with " + std::to_string(column_index_) +
+                           " of " + std::to_string(nodes_.size()) + " columns read");
+  }
+  column_index_ = 0;
+
+  if (column_readers_[0]->HasNext()) {
+    return;
+  }
+  NextRowGroup();
+}
+
+void StreamReader::NextRowGroup() {
+  // Find next none-empty row group
+  while (row_group_index_ < file_metadata_->num_row_groups()) {
+    row_group_reader_ = file_reader_->RowGroup(row_group_index_);
+    ++row_group_index_;
+
+    column_readers_.resize(file_metadata_->num_columns());
+
+    for (int i = 0; i < file_metadata_->num_columns(); ++i) {
+      column_readers_[i] = row_group_reader_->Column(i);
+    }
+    if (column_readers_[0]->HasNext()) {
+      return;
+    }
+  }
+  // No more row groups found.
+  eof_ = true;
+  file_reader_.reset();
+  file_metadata_.reset();
+  row_group_reader_.reset();
+  column_readers_.clear();
+  nodes_.clear();
+}
+
+void StreamReader::CheckColumn(Type::type physical_type,
+                               ConvertedType::type converted_type, int length) {
+  if (static_cast<std::size_t>(column_index_) >= nodes_.size()) {
+    if (eof_) {
+      throw ParquetException("EOF reached");
+    }
+    throw ParquetException("Column index out-of-bounds.  Index " +
+                           std::to_string(column_index_) + " is invalid for " +
+                           std::to_string(nodes_.size()) + " columns");
+  }
+  const auto& node = nodes_[column_index_];
+
+  if (physical_type != node->physical_type()) {
+    throw ParquetException("Column physical type mismatch.  Column '" + node->name() +
+                           "' has physical type '" + TypeToString(node->physical_type()) +
+                           "' not '" + TypeToString(physical_type) + "'");
+  }
+  if (converted_type != node->converted_type()) {
+    throw ParquetException("Column converted type mismatch.  Column '" + node->name() +
+                           "' has converted type '" +
+                           ConvertedTypeToString(node->converted_type()) + "' not '" +
+                           ConvertedTypeToString(converted_type) + "'");
+  }
+  // Length must be exact.
+  if (length != node->type_length()) {
+    throw ParquetException("Column length mismatch.  Column '" + node->name() +
+                           "' has length " + std::to_string(node->type_length()) +
+                           "] not " + std::to_string(length));
+  }
+}
+
+StreamReader& operator>>(StreamReader& os, EndRowType) {
+  os.EndRow();
+  return os;
+}
+
+}  // namespace parquet

--- a/cpp/src/parquet/stream_reader.h
+++ b/cpp/src/parquet/stream_reader.h
@@ -1,0 +1,162 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PARQUET_STREAM_READER_H
+#define PARQUET_STREAM_READER_H
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "parquet/column_reader.h"
+#include "parquet/file_reader.h"
+#include "parquet/stream_writer.h"
+
+namespace parquet {
+
+/// \brief A class for reading Parquet files using an output stream type API.
+///
+/// The values given must be of the correct type i.e. the type must
+/// match the file schema exactly otherwise a ParquetException will be
+/// thrown.
+///
+/// The user must explicitly advance to the next row using the
+/// EndRow() function or EndRow input manipulator.
+///
+/// Currently there is no support for optional or repeated fields.
+///
+class PARQUET_EXPORT StreamReader {
+ public:
+  // N.B. Default constructed objects are not usable.  This
+  //      constructor is provided so that the object may be move
+  //      assigned afterwards.
+  StreamReader() = default;
+
+  explicit StreamReader(std::unique_ptr<ParquetFileReader> reader);
+
+  ~StreamReader() = default;
+
+  bool eof() const { return eof_; }
+
+  // Moving is possible.
+  StreamReader(StreamReader&&) noexcept = default;
+  StreamReader& operator=(StreamReader&&) noexcept = default;
+
+  // Copying is not allowed.
+  StreamReader(const StreamReader&) = delete;
+  StreamReader& operator=(const StreamReader&) = delete;
+
+  StreamReader& operator>>(bool& v);
+
+  StreamReader& operator>>(int8_t& v);
+
+  StreamReader& operator>>(uint8_t& v);
+
+  StreamReader& operator>>(int16_t& v);
+
+  StreamReader& operator>>(uint16_t& v);
+
+  StreamReader& operator>>(int32_t& v);
+
+  StreamReader& operator>>(uint32_t& v);
+
+  StreamReader& operator>>(int64_t& v);
+
+  StreamReader& operator>>(uint64_t& v);
+
+  StreamReader& operator>>(std::chrono::milliseconds& v);
+
+  StreamReader& operator>>(std::chrono::microseconds& v);
+
+  StreamReader& operator>>(float& v);
+
+  StreamReader& operator>>(double& v);
+
+  StreamReader& operator>>(char& v);
+
+  template <int N>
+  StreamReader& operator>>(char (&v)[N]) {
+    ReadFixedLength(v, N);
+    return *this;
+  }
+
+  template <std::size_t N>
+  StreamReader& operator>>(std::array<char, N>& v) {
+    ReadFixedLength(v.data(), static_cast<int>(N));
+    return *this;
+  }
+
+  // N.B. Cannot allow for reading to a arbitrary char pointer as the
+  //      length cannot be verified.  Also it would overshadow the
+  //      char[N] input operator.
+  // StreamReader& operator>>(char * v);
+
+  StreamReader& operator>>(std::string& v);
+
+  // Terminate current row and advance to next one.
+  void EndRow();
+
+ protected:
+  template <typename ReaderType, typename T>
+  void Read(T* v) {
+    const auto& node = nodes_[column_index_];
+    auto reader = static_cast<ReaderType*>(column_readers_[column_index_++].get());
+
+    int64_t values_read;
+
+    reader->ReadBatch(1, NULLPTR, NULLPTR, v, &values_read);
+
+    if (values_read != 1) {
+      throw ParquetException("Failed to read value for column '" + node->name() + "'");
+    }
+  }
+
+  void ReadFixedLength(char* ptr, int len);
+
+  void Read(ByteArray* v);
+
+  void Read(FixedLenByteArray* v);
+
+  void NextRowGroup();
+
+  void CheckColumn(Type::type physical_type, ConvertedType::type converted_type,
+                   int length = 0);
+
+ private:
+  using node_ptr_type = std::shared_ptr<schema::PrimitiveNode>;
+
+  std::unique_ptr<ParquetFileReader> file_reader_;
+  std::shared_ptr<FileMetaData> file_metadata_;
+  std::shared_ptr<RowGroupReader> row_group_reader_;
+  std::vector<std::shared_ptr<ColumnReader>> column_readers_;
+  std::vector<node_ptr_type> nodes_;
+
+  bool eof_{false};
+  int row_group_index_{0};
+  int column_index_{0};
+};
+
+PARQUET_EXPORT
+StreamReader& operator>>(StreamReader&, EndRowType);
+
+}  // namespace parquet
+
+#endif  // PARQUET_STREAM_READER_H

--- a/cpp/src/parquet/stream_reader_test.cc
+++ b/cpp/src/parquet/stream_reader_test.cc
@@ -1,0 +1,268 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/stream_reader.h"
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <ctime>
+#include <memory>
+#include <utility>
+
+#include "arrow/io/api.h"
+#include "parquet/exception.h"
+#include "parquet/test_util.h"
+
+namespace parquet {
+namespace test {
+
+struct TestData {
+  static void init() { std::time(&ts_offset_); }
+
+  static constexpr int num_rows = 2000;
+
+  static std::string GetString(const int i) { return "Str #" + std::to_string(i); }
+  static bool GetBool(const int i) { return i % 7 < 3; }
+  static char GetChar(const int i) { return i & 1 ? 'M' : 'F'; }
+  static std::array<char, 4> GetCharArray(const int i) {
+    return {'X', 'Y', 'Z', char('A' + i % 26)};
+  }
+  static int8_t GetInt8(const int i) { return static_cast<int8_t>((i % 256) - 128); }
+  static uint16_t GetUInt16(const int i) { return static_cast<uint16_t>(i); }
+  static int32_t GetInt32(const int i) { return 3 * i - 17; }
+  static uint64_t GetUInt64(const int i) { return (1ull << 40) + i * i + 101; }
+  static float GetFloat(const int i) { return 3.1415926535897f * 2.718281828459045f; }
+  static double GetDouble(const int i) { return 6.62607004e-34 * 3e8 * i; }
+
+  static std::chrono::microseconds GetChronoMicroseconds(const int i) {
+    return std::chrono::microseconds{(ts_offset_ + 3 * i) * 1000000ull + i};
+  }
+
+ private:
+  static std::time_t ts_offset_;
+};
+
+std::time_t TestData::ts_offset_;
+constexpr int TestData::num_rows;
+
+class TestStreamReader : public ::testing::Test {
+ public:
+  TestStreamReader() { createTestFile(); }
+
+ protected:
+  const char* GetDataFile() const { return "stream_reader_test.parquet"; }
+
+  void SetUp() {
+    std::shared_ptr<arrow::io::ReadableFile> infile;
+
+    PARQUET_THROW_NOT_OK(arrow::io::ReadableFile::Open(GetDataFile(), &infile));
+
+    auto file_reader = parquet::ParquetFileReader::Open(infile);
+
+    reader_ = StreamReader{std::move(file_reader)};
+  }
+
+  void TearDown() { reader_ = StreamReader{}; }
+
+  std::shared_ptr<parquet::schema::GroupNode> GetSchema() {
+    parquet::schema::NodeVector fields;
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "bool_field", parquet::Repetition::REQUIRED, parquet::Type::BOOLEAN,
+        parquet::ConvertedType::NONE));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "string_field", parquet::Repetition::REQUIRED, parquet::Type::BYTE_ARRAY,
+        parquet::ConvertedType::UTF8));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "char_field", parquet::Repetition::REQUIRED, parquet::Type::FIXED_LEN_BYTE_ARRAY,
+        parquet::ConvertedType::NONE, 1));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "char[4]_field", parquet::Repetition::REQUIRED,
+        parquet::Type::FIXED_LEN_BYTE_ARRAY, parquet::ConvertedType::NONE, 4));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "int8_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
+        parquet::ConvertedType::INT_8));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "uint16_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
+        parquet::ConvertedType::UINT_16));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "int32_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
+        parquet::ConvertedType::INT_32));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "uint64_field", parquet::Repetition::REQUIRED, parquet::Type::INT64,
+        parquet::ConvertedType::UINT_64));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "chrono_microseconds_field", parquet::Repetition::REQUIRED, parquet::Type::INT64,
+        parquet::ConvertedType::TIMESTAMP_MICROS));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "float_field", parquet::Repetition::REQUIRED, parquet::Type::FLOAT,
+        parquet::ConvertedType::NONE));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "double_field", parquet::Repetition::REQUIRED, parquet::Type::DOUBLE,
+        parquet::ConvertedType::NONE));
+
+    return std::static_pointer_cast<parquet::schema::GroupNode>(
+        parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED,
+                                         fields));
+  }
+
+  void createTestFile() {
+    std::shared_ptr<arrow::io::FileOutputStream> outfile;
+
+    PARQUET_THROW_NOT_OK(arrow::io::FileOutputStream::Open(GetDataFile(), &outfile));
+
+    parquet::WriterProperties::Builder builder;
+
+    builder.compression(parquet::Compression::BROTLI);
+
+    auto file_writer =
+        parquet::ParquetFileWriter::Open(outfile, GetSchema(), builder.build());
+
+    parquet::StreamWriter os{std::move(file_writer)};
+
+    TestData::init();
+
+    for (auto i = 0; i < TestData::num_rows; ++i) {
+      os << TestData::GetBool(i);
+      os << TestData::GetString(i);
+      os << TestData::GetChar(i);
+      os << TestData::GetCharArray(i);
+      os << TestData::GetInt8(i);
+      os << TestData::GetUInt16(i);
+      os << TestData::GetInt32(i);
+      os << TestData::GetUInt64(i);
+      os << TestData::GetChronoMicroseconds(i);
+      os << TestData::GetFloat(i);
+      os << TestData::GetDouble(i);
+      os << parquet::EndRow;
+    }
+  }
+
+  StreamReader reader_;
+};
+
+TEST_F(TestStreamReader, DefaultConstructed) {
+  StreamReader os;
+  int i;
+  std::string s;
+
+  // N.B. Default constructor objects are not usable.
+  ASSERT_THROW(os >> i, ParquetException);
+  ASSERT_THROW(os >> s, ParquetException);
+  ASSERT_THROW(os >> EndRow, ParquetException);
+}
+
+TEST_F(TestStreamReader, TypeChecking) {
+  bool b;
+  std::string s;
+  std::array<char, 4> char_array;
+  char c;
+  int8_t int8;
+  int16_t int16;
+  uint16_t uint16;
+  int32_t int32;
+  int64_t int64;
+  uint64_t uint64;
+  std::chrono::microseconds ts_us;
+  float f;
+  double d;
+  std::string str;
+
+  ASSERT_THROW(reader_ >> int8, ParquetException);
+  ASSERT_NO_THROW(reader_ >> b);
+  ASSERT_THROW(reader_ >> c, ParquetException);
+  ASSERT_NO_THROW(reader_ >> s);
+  ASSERT_THROW(reader_ >> s, ParquetException);
+  ASSERT_NO_THROW(reader_ >> c);
+  ASSERT_THROW(reader_ >> s, ParquetException);
+  ASSERT_NO_THROW(reader_ >> char_array);
+  ASSERT_THROW(reader_ >> int16, ParquetException);
+  ASSERT_NO_THROW(reader_ >> int8);
+  ASSERT_THROW(reader_ >> int16, ParquetException);
+  ASSERT_NO_THROW(reader_ >> uint16);
+  ASSERT_THROW(reader_ >> int64, ParquetException);
+  ASSERT_NO_THROW(reader_ >> int32);
+  ASSERT_THROW(reader_ >> int64, ParquetException);
+  ASSERT_NO_THROW(reader_ >> uint64);
+  ASSERT_THROW(reader_ >> uint64, ParquetException);
+  ASSERT_NO_THROW(reader_ >> ts_us);
+  ASSERT_THROW(reader_ >> d, ParquetException);
+  ASSERT_NO_THROW(reader_ >> f);
+  ASSERT_THROW(reader_ >> f, ParquetException);
+  ASSERT_NO_THROW(reader_ >> d);
+  ASSERT_NO_THROW(reader_ >> EndRow);
+}
+
+TEST_F(TestStreamReader, ValueChecking) {
+  bool b;
+  std::string s;
+  std::array<char, 4> char_array;
+  char c;
+  int8_t int8;
+  uint16_t uint16;
+  int32_t int32;
+  uint64_t uint64;
+  std::chrono::microseconds ts_us;
+  float f;
+  double d;
+  std::string str;
+
+  int i;
+
+  for (i = 0; !reader_.eof(); ++i) {
+    reader_ >> b;
+    reader_ >> s;
+    reader_ >> c;
+    reader_ >> char_array;
+    reader_ >> int8;
+    reader_ >> uint16;
+    reader_ >> int32;
+    reader_ >> uint64;
+    reader_ >> ts_us;
+    reader_ >> f;
+    reader_ >> d;
+    reader_ >> EndRow;
+
+    ASSERT_EQ(b, TestData::GetBool(i));
+    ASSERT_EQ(s, TestData::GetString(i));
+    ASSERT_EQ(c, TestData::GetChar(i));
+    ASSERT_EQ(char_array, TestData::GetCharArray(i));
+    ASSERT_EQ(int8, TestData::GetInt8(i));
+    ASSERT_EQ(uint16, TestData::GetUInt16(i));
+    ASSERT_EQ(int32, TestData::GetInt32(i));
+    ASSERT_EQ(uint64, TestData::GetUInt64(i));
+    ASSERT_EQ(ts_us, TestData::GetChronoMicroseconds(i));
+    ASSERT_FLOAT_EQ(f, TestData::GetFloat(i));
+    ASSERT_DOUBLE_EQ(d, TestData::GetDouble(i));
+  }
+  ASSERT_EQ(i, TestData::num_rows);
+}
+
+}  // namespace test
+}  // namespace parquet

--- a/cpp/src/parquet/stream_writer.cc
+++ b/cpp/src/parquet/stream_writer.cc
@@ -1,0 +1,254 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/stream_writer.h"
+
+#include <utility>
+
+namespace parquet {
+
+int64_t StreamWriter::default_row_group_size_{512 * 1024 * 1024};  // 512MB
+
+StreamWriter::FixedStringView::FixedStringView(const char* data_ptr)
+    : data{data_ptr}, size{std::strlen(data_ptr)} {}
+
+StreamWriter::FixedStringView::FixedStringView(const char* data_ptr, std::size_t data_len)
+    : data{data_ptr}, size{data_len} {}
+
+StreamWriter::StreamWriter(std::unique_ptr<ParquetFileWriter> writer)
+    : file_writer_{std::move(writer)},
+      row_group_writer_{file_writer_->AppendBufferedRowGroup()} {
+  auto schema = file_writer_->schema();
+  auto group_node = schema->group_node();
+
+  nodes_.resize(schema->num_columns());
+
+  for (auto i = 0; i < schema->num_columns(); ++i) {
+    nodes_[i] = std::static_pointer_cast<schema::PrimitiveNode>(group_node->field(i));
+  }
+}
+
+StreamWriter::~StreamWriter() {
+  if (row_group_writer_) {
+    row_group_writer_->Close();
+  }
+
+  if (file_writer_) {
+    file_writer_->Close();
+  }
+}
+
+void StreamWriter::SetDefaultMaxRowGroupSize(int64_t max_size) {
+  default_row_group_size_ = max_size;
+}
+
+void StreamWriter::SetMaxRowGroupSize(int64_t max_size) {
+  max_row_group_size_ = max_size;
+}
+
+StreamWriter& StreamWriter::operator<<(bool v) {
+  CheckColumn(Type::BOOLEAN, ConvertedType::NONE);
+  return Write<BoolWriter>(v);
+}
+
+StreamWriter& StreamWriter::operator<<(int8_t v) {
+  CheckColumn(Type::INT32, ConvertedType::INT_8);
+  return Write<Int32Writer>(static_cast<int32_t>(v));
+}
+
+StreamWriter& StreamWriter::operator<<(uint8_t v) {
+  CheckColumn(Type::INT32, ConvertedType::UINT_8);
+  return Write<Int32Writer>(static_cast<int32_t>(v));
+}
+
+StreamWriter& StreamWriter::operator<<(int16_t v) {
+  CheckColumn(Type::INT32, ConvertedType::INT_16);
+  return Write<Int32Writer>(static_cast<int32_t>(v));
+}
+
+StreamWriter& StreamWriter::operator<<(uint16_t v) {
+  CheckColumn(Type::INT32, ConvertedType::UINT_16);
+  return Write<Int32Writer>(static_cast<int32_t>(v));
+}
+
+StreamWriter& StreamWriter::operator<<(int32_t v) {
+  CheckColumn(Type::INT32, ConvertedType::INT_32);
+  return Write<Int32Writer>(v);
+}
+
+StreamWriter& StreamWriter::operator<<(uint32_t v) {
+  CheckColumn(Type::INT32, ConvertedType::UINT_32);
+  return Write<Int32Writer>(static_cast<int32_t>(v));
+}
+
+StreamWriter& StreamWriter::operator<<(int64_t v) {
+  CheckColumn(Type::INT64, ConvertedType::INT_64);
+  return Write<Int64Writer>(v);
+}
+
+StreamWriter& StreamWriter::operator<<(uint64_t v) {
+  CheckColumn(Type::INT64, ConvertedType::UINT_64);
+  return Write<Int64Writer>(static_cast<int64_t>(v));
+}
+
+StreamWriter& StreamWriter::operator<<(const std::chrono::milliseconds& v) {
+  CheckColumn(Type::INT64, ConvertedType::TIMESTAMP_MILLIS);
+  return Write<Int64Writer>(v.count());
+}
+
+StreamWriter& StreamWriter::operator<<(const std::chrono::microseconds& v) {
+  CheckColumn(Type::INT64, ConvertedType::TIMESTAMP_MICROS);
+  return Write<Int64Writer>(v.count());
+}
+
+StreamWriter& StreamWriter::operator<<(float v) {
+  CheckColumn(Type::FLOAT, ConvertedType::NONE);
+  return Write<FloatWriter>(v);
+}
+
+StreamWriter& StreamWriter::operator<<(double v) {
+  CheckColumn(Type::DOUBLE, ConvertedType::NONE);
+  return Write<DoubleWriter>(v);
+}
+
+StreamWriter& StreamWriter::operator<<(char v) { return WriteFixedLength(&v, 1); }
+
+StreamWriter& StreamWriter::operator<<(FixedStringView v) {
+  return WriteFixedLength(v.data, v.size);
+}
+
+StreamWriter& StreamWriter::operator<<(const char* v) {
+  return WriteVariableLength(v, std::strlen(v));
+}
+
+StreamWriter& StreamWriter::operator<<(arrow::util::string_view v) {
+  return WriteVariableLength(v.data(), v.size());
+}
+
+StreamWriter& StreamWriter::WriteVariableLength(const char* data_ptr,
+                                                std::size_t data_len) {
+  CheckColumn(Type::BYTE_ARRAY, ConvertedType::UTF8);
+
+  auto writer = static_cast<ByteArrayWriter*>(row_group_writer_->column(column_index_++));
+
+  ByteArray ba_value;
+
+  ba_value.ptr = reinterpret_cast<const uint8_t*>(data_ptr);
+  ba_value.len = static_cast<uint32_t>(data_len);
+
+  writer->WriteBatch(1, nullptr, nullptr, &ba_value);
+
+  if (max_row_group_size_ > 0) {
+    row_group_size_ += writer->EstimatedBufferedValueBytes();
+  }
+  return *this;
+}
+
+StreamWriter& StreamWriter::WriteFixedLength(const char* data_ptr, std::size_t data_len) {
+  CheckColumn(Type::FIXED_LEN_BYTE_ARRAY, ConvertedType::NONE,
+              static_cast<int>(data_len));
+
+  auto writer =
+      static_cast<FixedLenByteArrayWriter*>(row_group_writer_->column(column_index_++));
+
+  FixedLenByteArray flba_value;
+
+  flba_value.ptr = reinterpret_cast<const uint8_t*>(data_ptr);
+
+  writer->WriteBatch(1, nullptr, nullptr, &flba_value);
+
+  if (max_row_group_size_ > 0) {
+    row_group_size_ += writer->EstimatedBufferedValueBytes();
+  }
+  return *this;
+}
+
+void StreamWriter::CheckColumn(Type::type physical_type,
+                               ConvertedType::type converted_type, int length) {
+  if (static_cast<std::size_t>(column_index_) >= nodes_.size()) {
+    throw ParquetException("Column index out-of-bounds.  Index " +
+                           std::to_string(column_index_) + " is invalid for " +
+                           std::to_string(nodes_.size()) + " columns");
+  }
+  const auto& node = nodes_[column_index_];
+
+  if (physical_type != node->physical_type()) {
+    throw ParquetException("Column physical type mismatch.  Column '" + node->name() +
+                           "' has physical type '" + TypeToString(node->physical_type()) +
+                           "' not '" + TypeToString(physical_type) + "'");
+  }
+  if (converted_type != node->converted_type()) {
+    throw ParquetException("Column converted type mismatch.  Column '" + node->name() +
+                           "' has converted type[" +
+                           ConvertedTypeToString(node->converted_type()) + "] not '" +
+                           ConvertedTypeToString(converted_type) + "'");
+  }
+  // Length must be exact.
+  // A shorter length fixed array is not acceptable as it would
+  // result in array bound read errors.
+  //
+  if (length != node->type_length()) {
+    throw ParquetException("Column length mismatch.  Column '" + node->name() +
+                           "' has length " + std::to_string(node->type_length()) +
+                           " not " + std::to_string(length));
+  }
+}
+
+void StreamWriter::EndRow() {
+  if (!file_writer_) {
+    throw ParquetException("StreamWriter not initialized");
+  }
+  if (static_cast<std::size_t>(column_index_) < nodes_.size()) {
+    throw ParquetException("Cannot end row with " + std::to_string(column_index_) +
+                           " of " + std::to_string(nodes_.size()) + " columns written");
+  }
+  column_index_ = 0;
+
+  if (max_row_group_size_ > 0) {
+    if (row_group_size_ > max_row_group_size_) {
+      EndRowGroup();
+    }
+    // Initialize for each row with size already written
+    // (compressed + uncompressed).
+    //
+    row_group_size_ = row_group_writer_->total_bytes_written() +
+                      row_group_writer_->total_compressed_bytes();
+  }
+}
+
+void StreamWriter::EndRowGroup() {
+  if (!file_writer_) {
+    throw ParquetException("StreamWriter not initialized");
+  }
+  // Avoid creating empty row groups.
+  if (row_group_writer_->num_rows() > 0) {
+    row_group_writer_->Close();
+    row_group_writer_.reset(file_writer_->AppendBufferedRowGroup());
+  }
+}
+
+StreamWriter& operator<<(StreamWriter& os, EndRowType) {
+  os.EndRow();
+  return os;
+}
+
+StreamWriter& operator<<(StreamWriter& os, EndRowGroupType) {
+  os.EndRowGroup();
+  return os;
+}
+
+}  // namespace parquet

--- a/cpp/src/parquet/stream_writer.h
+++ b/cpp/src/parquet/stream_writer.h
@@ -1,0 +1,187 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef PARQUET_STREAM_WRITER_H
+#define PARQUET_STREAM_WRITER_H
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/util/string_view.h"
+#include "parquet/column_writer.h"
+#include "parquet/file_writer.h"
+
+namespace parquet {
+
+/// \brief A class for writing Parquet files using an output stream type API.
+///
+/// The values given must be of the correct type i.e. the type must
+/// match the file schema exactly otherwise a ParquetException will be
+/// thrown.
+///
+/// The user must explicitly indicate the end of the row using the
+/// EndRow() function or EndRow output manipulator.
+///
+/// A maximum row group size can be configured, the default size is
+/// 512MB.  Alternatively the row group size can be set to zero and the
+/// user can create new row groups by calling the EndRowGroup()
+/// function or using the EndRowGroup output manipulator.
+///
+/// Currently there is no support for optional or repeated fields.
+///
+class PARQUET_EXPORT StreamWriter {
+ public:
+  // N.B. Default constructed objects are not usable.  This
+  //      constructor is provided so that the object may be move
+  //      assigned afterwards.
+  StreamWriter() = default;
+
+  explicit StreamWriter(std::unique_ptr<ParquetFileWriter> writer);
+
+  ~StreamWriter();
+
+  static void SetDefaultMaxRowGroupSize(int64_t max_size);
+
+  void SetMaxRowGroupSize(int64_t max_size);
+
+  // Moving is possible.
+  StreamWriter(StreamWriter&&) noexcept = default;
+  StreamWriter& operator=(StreamWriter&&) noexcept = default;
+
+  // Copying is not allowed.
+  StreamWriter(const StreamWriter&) = delete;
+  StreamWriter& operator=(const StreamWriter&) = delete;
+
+  StreamWriter& operator<<(bool v);
+
+  StreamWriter& operator<<(int8_t v);
+
+  StreamWriter& operator<<(uint8_t v);
+
+  StreamWriter& operator<<(int16_t v);
+
+  StreamWriter& operator<<(uint16_t v);
+
+  StreamWriter& operator<<(int32_t v);
+
+  StreamWriter& operator<<(uint32_t v);
+
+  StreamWriter& operator<<(int64_t v);
+
+  StreamWriter& operator<<(uint64_t v);
+
+  StreamWriter& operator<<(const std::chrono::milliseconds& v);
+
+  StreamWriter& operator<<(const std::chrono::microseconds& v);
+
+  StreamWriter& operator<<(float v);
+
+  StreamWriter& operator<<(double v);
+
+  StreamWriter& operator<<(char v);
+
+  /// \brief Helper class to write fixed length strings.
+  /// This is useful as the standard string view (such as
+  /// arrow::util::string_view) is for variable length data.
+  struct PARQUET_EXPORT FixedStringView {
+    FixedStringView() = default;
+
+    explicit FixedStringView(const char* data_ptr);
+
+    FixedStringView(const char* data_ptr, std::size_t data_len);
+
+    const char* data{NULLPTR};
+    std::size_t size{0};
+  };
+
+  // Output operators for fixed length strings.
+  template <int N>
+  StreamWriter& operator<<(const char (&v)[N]) {
+    return WriteFixedLength(v, N);
+  }
+  template <std::size_t N>
+  StreamWriter& operator<<(const std::array<char, N>& v) {
+    return WriteFixedLength(v.data(), N);
+  }
+  StreamWriter& operator<<(FixedStringView v);
+
+  // Output operators for variable length strings.
+  StreamWriter& operator<<(const char* v);
+  StreamWriter& operator<<(arrow::util::string_view v);
+
+  // Terminate the current row and advance to next one.
+  void EndRow();
+
+  // Terminate the current row group and create new one.
+  void EndRowGroup();
+
+ protected:
+  template <typename WriterType, typename T>
+  StreamWriter& Write(const T v) {
+    auto writer = static_cast<WriterType*>(row_group_writer_->column(column_index_++));
+
+    writer->WriteBatch(1, NULLPTR, NULLPTR, &v);
+
+    if (max_row_group_size_ > 0) {
+      row_group_size_ += writer->EstimatedBufferedValueBytes();
+    }
+    return *this;
+  }
+
+  StreamWriter& WriteVariableLength(const char* data_ptr, std::size_t data_len);
+
+  StreamWriter& WriteFixedLength(const char* data_ptr, std::size_t data_len);
+
+  void CheckColumn(Type::type physical_type, ConvertedType::type converted_type,
+                   int length = -1);
+
+ private:
+  using node_ptr_type = std::shared_ptr<schema::PrimitiveNode>;
+
+  struct null_deleter {
+    void operator()(void*) {}
+  };
+
+  int64_t row_group_size_{0};
+  int64_t max_row_group_size_{default_row_group_size_};
+  int32_t column_index_{0};
+  std::unique_ptr<ParquetFileWriter> file_writer_;
+  std::unique_ptr<RowGroupWriter, null_deleter> row_group_writer_;
+  std::vector<node_ptr_type> nodes_;
+
+  static int64_t default_row_group_size_;
+};
+
+struct PARQUET_EXPORT EndRowType {};
+constexpr EndRowType EndRow;
+
+struct PARQUET_EXPORT EndRowGroupType {};
+constexpr EndRowGroupType EndRowGroup;
+
+PARQUET_EXPORT
+StreamWriter& operator<<(StreamWriter&, EndRowType);
+
+PARQUET_EXPORT
+StreamWriter& operator<<(StreamWriter&, EndRowGroupType);
+
+}  // namespace parquet
+
+#endif  // PARQUET_STREAM_WRITER_H

--- a/cpp/src/parquet/stream_writer_test.cc
+++ b/cpp/src/parquet/stream_writer_test.cc
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/stream_writer.h"
+
+#include <fcntl.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <utility>
+
+#include "arrow/io/api.h"
+#include "parquet/exception.h"
+
+namespace parquet {
+namespace test {
+
+class TestStreamWriter : public ::testing::Test {
+ protected:
+  void SetUp() {
+    parquet::WriterProperties::Builder builder;
+
+    builder.compression(parquet::Compression::BROTLI);
+
+    auto file_writer = parquet::ParquetFileWriter::Open(CreateOutputStream(), GetSchema(),
+                                                        builder.build());
+
+    writer_ = StreamWriter{std::move(file_writer)};
+  }
+
+  void TearDown() { writer_ = StreamWriter{}; }
+
+  std::shared_ptr<parquet::schema::GroupNode> GetSchema() {
+    parquet::schema::NodeVector fields;
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "bool_field", parquet::Repetition::REQUIRED, parquet::Type::BOOLEAN,
+        parquet::ConvertedType::NONE));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "string_field", parquet::Repetition::REQUIRED, parquet::Type::BYTE_ARRAY,
+        parquet::ConvertedType::UTF8));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "char_field", parquet::Repetition::REQUIRED, parquet::Type::FIXED_LEN_BYTE_ARRAY,
+        parquet::ConvertedType::NONE, 1));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "char[4]_field", parquet::Repetition::REQUIRED,
+        parquet::Type::FIXED_LEN_BYTE_ARRAY, parquet::ConvertedType::NONE, 4));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "int8_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
+        parquet::ConvertedType::INT_8));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "uint16_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
+        parquet::ConvertedType::UINT_16));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "int32_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
+        parquet::ConvertedType::INT_32));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "uint64_field", parquet::Repetition::REQUIRED, parquet::Type::INT64,
+        parquet::ConvertedType::UINT_64));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "float_field", parquet::Repetition::REQUIRED, parquet::Type::FLOAT,
+        parquet::ConvertedType::NONE));
+
+    fields.push_back(parquet::schema::PrimitiveNode::Make(
+        "double_field", parquet::Repetition::REQUIRED, parquet::Type::DOUBLE,
+        parquet::ConvertedType::NONE));
+
+    return std::static_pointer_cast<parquet::schema::GroupNode>(
+        parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED,
+                                         fields));
+  }
+
+  StreamWriter writer_;
+};
+
+TEST_F(TestStreamWriter, DefaultConstructed) {
+  StreamWriter os;
+
+  // N.B. Default constructor objects are not usable.
+  ASSERT_THROW(os << 4, ParquetException);
+  ASSERT_THROW(os << "bad", ParquetException);
+  ASSERT_THROW(os << EndRow, ParquetException);
+  ASSERT_THROW(os << EndRowGroup, ParquetException);
+}
+
+TEST_F(TestStreamWriter, TypeChecking) {
+  std::array<char, 3> char3_array = {'T', 'S', 'T'};
+  std::array<char, 4> char4_array = {'T', 'E', 'S', 'T'};
+  std::array<char, 5> char5_array = {'T', 'E', 'S', 'T', '2'};
+
+  // Required type: bool
+  ASSERT_THROW(writer_ << 4.5, ParquetException);
+  ASSERT_NO_THROW(writer_ << true);
+
+  // Required type: Variable length string.
+  ASSERT_THROW(writer_ << 5, ParquetException);
+  ASSERT_THROW(writer_ << char3_array, ParquetException);
+  ASSERT_THROW(writer_ << char4_array, ParquetException);
+  ASSERT_THROW(writer_ << char5_array, ParquetException);
+  ASSERT_NO_THROW(writer_ << "ok");
+
+  // Required type: A char.
+  ASSERT_THROW(writer_ << "no good", ParquetException);
+  ASSERT_NO_THROW(writer_ << 'K');
+
+  // Required type: Fixed string of length 4
+  ASSERT_THROW(writer_ << "bad", ParquetException);
+  ASSERT_THROW(writer_ << char3_array, ParquetException);
+  ASSERT_THROW(writer_ << char5_array, ParquetException);
+  ASSERT_NO_THROW(writer_ << char4_array);
+
+  // Required type: int8_t
+  ASSERT_THROW(writer_ << false, ParquetException);
+  ASSERT_NO_THROW(writer_ << int8_t(51));
+
+  // Required type: uint16_t
+  ASSERT_THROW(writer_ << int16_t(15), ParquetException);
+  ASSERT_NO_THROW(writer_ << uint16_t(15));
+
+  // Required type: int32_t
+  ASSERT_THROW(writer_ << int16_t(99), ParquetException);
+  ASSERT_NO_THROW(writer_ << int32_t(329487));
+
+  // Required type: uint64_t
+  ASSERT_THROW(writer_ << uint32_t(9832423), ParquetException);
+  ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
+
+  // Required type: float
+  ASSERT_THROW(writer_ << 5.4, ParquetException);
+  ASSERT_NO_THROW(writer_ << 5.4f);
+
+  // Required type: double
+  ASSERT_THROW(writer_ << 5.4f, ParquetException);
+  ASSERT_NO_THROW(writer_ << 5.4);
+
+  ASSERT_NO_THROW(writer_ << EndRow);
+}
+
+TEST_F(TestStreamWriter, EndRow) {
+  // Attempt #1 to end row prematurely.
+  ASSERT_THROW(writer_ << EndRow, ParquetException);
+  ASSERT_NO_THROW(writer_ << true);
+  ASSERT_NO_THROW(writer_ << "eschatology");
+  ASSERT_NO_THROW(writer_ << 'z');
+  ASSERT_NO_THROW(writer_ << StreamWriter::FixedStringView("Test", 4));
+  ASSERT_NO_THROW(writer_ << int8_t(51));
+  ASSERT_NO_THROW(writer_ << uint16_t(15));
+  // Attempt #2 to end row prematurely.
+  ASSERT_THROW(writer_ << EndRow, ParquetException);
+  ASSERT_NO_THROW(writer_ << int32_t(329487));
+  ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
+  ASSERT_NO_THROW(writer_ << 25.4f);
+  ASSERT_NO_THROW(writer_ << 3.3424);
+  // Correct use of end row after all fields have been output.
+  ASSERT_NO_THROW(writer_ << EndRow);
+  // Attempt #3 to end row prematurely.
+  ASSERT_THROW(writer_ << EndRow, ParquetException);
+}
+
+TEST_F(TestStreamWriter, EndRowGroup) {
+  writer_.SetMaxRowGroupSize(0);
+
+  // It's ok to end a row group multiple times.
+  ASSERT_NO_THROW(writer_ << EndRowGroup);
+  ASSERT_NO_THROW(writer_ << EndRowGroup);
+  ASSERT_NO_THROW(writer_ << EndRowGroup);
+
+  std::array<char, 4> char_array = {'A', 'B', 'C', 'D'};
+
+  for (auto i = 0; i < 20000; ++i) {
+    ASSERT_NO_THROW(writer_ << bool(i & 1));
+    ASSERT_NO_THROW(writer_ << std::to_string(i));
+    ASSERT_NO_THROW(writer_ << char(i % 26 + 'A'));
+    // Rotate letters.
+    {
+      char tmp{char_array[0]};
+      char_array[0] = char_array[3];
+      char_array[3] = char_array[2];
+      char_array[2] = char_array[1];
+      char_array[1] = tmp;
+    }
+    ASSERT_NO_THROW(writer_ << char_array);
+    ASSERT_NO_THROW(writer_ << int8_t(i & 0xff));
+    ASSERT_NO_THROW(writer_ << uint16_t(7 * i));
+    ASSERT_NO_THROW(writer_ << int32_t((1 << 30) - i * i));
+    ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) - i * i));
+    ASSERT_NO_THROW(writer_ << 42325.4f / float(i + 1));
+    ASSERT_NO_THROW(writer_ << 3.2342e5 / double(i + 1));
+    ASSERT_NO_THROW(writer_ << EndRow);
+
+    if (i % 1000 == 0) {
+      // It's ok to end a row group multiple times.
+      ASSERT_NO_THROW(writer_ << EndRowGroup);
+      ASSERT_NO_THROW(writer_ << EndRowGroup);
+      ASSERT_NO_THROW(writer_ << EndRowGroup);
+    }
+  }
+  // It's ok to end a row group multiple times.
+  ASSERT_NO_THROW(writer_ << EndRowGroup);
+  ASSERT_NO_THROW(writer_ << EndRowGroup);
+  ASSERT_NO_THROW(writer_ << EndRowGroup);
+}
+
+}  // namespace test
+}  // namespace parquet


### PR DESCRIPTION
This commit adds two classes to the parquet namespace:
- StreamReader
- StreamWriter

These classes can be used to read/write values to Parquet data files
using a stream based approach using C++ input/output operators.

The goal is to make it easy to read/write data for applications which
deal with streams of data i.e. they do not have all data available in
order to create each complete column of data.

Checks are done at runtime to ensure that the types of variables
supplied when reading/writing match the schema.  Any difference
detected will result in a ParquetException being thrown.

Please see the
examples/parquet/parquet-stream-api/stream-reader-writer.cc file to
see how these classes can be used.