### PR TITLE
ARROW-6938: [Packaging][Python] Disable bz2 in Windows wheels and build ZSTD in bundled mode to triage linking issues

### DIFF
--- a/dev/tasks/python-wheels/win-build.bat
+++ b/dev/tasks/python-wheels/win-build.bat
@@ -41,6 +41,10 @@ echo %ARROW_HOME%
 mkdir %ARROW_SRC%\cpp\build
 pushd %ARROW_SRC%\cpp\build
 
+@rem ARROW-6938(wesm): bz2 and zstd are disabled on Windows because the build
+@rem currently selects the shared libs for linking, and we are not bundling
+@rem libbz2.dll and zstd.dll currentlya
+
 cmake -G "%GENERATOR%" ^
       -DCMAKE_INSTALL_PREFIX=%ARROW_HOME% ^
       -DARROW_BOOST_USE_SHARED=OFF ^
@@ -49,9 +53,9 @@ cmake -G "%GENERATOR%" ^
       -DARROW_DEPENDENCY_SOURCE=CONDA ^
       -DOPENSSL_ROOT_DIR=%CONDA_PREFIX%/Library ^
       -DARROW_CXXFLAGS="/MP" ^
-      -DARROW_WITH_BZ2=ON ^
+      -DARROW_WITH_BZ2=OFF ^
       -DARROW_WITH_ZLIB=ON ^
-      -DARROW_WITH_ZSTD=ON ^
+      -DARROW_WITH_ZSTD=OFF ^
       -DARROW_WITH_LZ4=ON ^
       -DARROW_WITH_SNAPPY=ON ^
       -DARROW_WITH_BROTLI=ON ^

--- a/dev/tasks/python-wheels/win-build.bat
+++ b/dev/tasks/python-wheels/win-build.bat
@@ -41,9 +41,10 @@ echo %ARROW_HOME%
 mkdir %ARROW_SRC%\cpp\build
 pushd %ARROW_SRC%\cpp\build
 
-@rem ARROW-6938(wesm): bz2 and zstd are disabled on Windows because the build
-@rem currently selects the shared libs for linking, and we are not bundling
-@rem libbz2.dll and zstd.dll currentlya
+@rem ARROW-6938(wesm): bz2 is disabled on Windows because the build
+@rem currently selects the shared lib for linking. Using the zstd lib from
+@rem conda-forge also results in a broken build so we use the BUNDLED
+@rem dependency resolution strategy for now
 
 cmake -G "%GENERATOR%" ^
       -DCMAKE_INSTALL_PREFIX=%ARROW_HOME% ^
@@ -55,7 +56,7 @@ cmake -G "%GENERATOR%" ^
       -DARROW_CXXFLAGS="/MP" ^
       -DARROW_WITH_BZ2=OFF ^
       -DARROW_WITH_ZLIB=ON ^
-      -DARROW_WITH_ZSTD=OFF ^
+      -DARROW_WITH_ZSTD=ON ^
       -DARROW_WITH_LZ4=ON ^
       -DARROW_WITH_SNAPPY=ON ^
       -DARROW_WITH_BROTLI=ON ^
@@ -64,6 +65,7 @@ cmake -G "%GENERATOR%" ^
       -DARROW_PARQUET=ON ^
       -DARROW_GANDIVA=ON ^
       -Duriparser_SOURCE=BUNDLED ^
+      -DZSTD_SOURCE=BUNDLED ^
       .. || exit /B
 cmake --build . --target install --config Release || exit /B
 popd


### PR DESCRIPTION
I will open a follow up issue for an enterprising developer to enable BZ2 and to see if ZSTD can be handled without building from source