### PR TITLE
ARROW-6910: [C++][Python] Set jemalloc default configuration to release dirty pages more aggressively back to the OS dirty_decay_ms and muzzy_decay_ms to 0 by default, add C++ / Python option to configure this

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,8 +50,6 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_lint.sh
     - $TRAVIS_BUILD_DIR/ci/travis_release_test.sh
 
-  # -------------------------------------------------------------------------
-  # Separating Valgrind and C++ coverage makes individual jobs shorter
   - name: "C++ unit tests w/ conda-forge toolchain, coverage"
     compiler: gcc
     language: cpp
@@ -88,13 +86,12 @@ matrix:
     - $TRAVIS_BUILD_DIR/ci/travis_upload_cpp_coverage.sh || travis_terminate 1
 
   # -------------------------------------------------------------------------
-  - name: "Python 3.6 unit tests w/ Valgrind, conda-forge toolchain, coverage"
+  - name: "Python 3.6 unit tests, conda-forge toolchain, coverage"
     compiler: gcc
     language: cpp
     os: linux
     jdk: openjdk8
     env:
-    # Valgrind is needed for the Plasma store tests
     - ARROW_BUILD_WARNING_LEVEL=CHECKIN
     - ARROW_TRAVIS_COVERAGE=1
     - ARROW_TRAVIS_FLIGHT=1
@@ -103,7 +100,6 @@ matrix:
     - ARROW_TRAVIS_PYTHON_JVM=1
     - ARROW_TRAVIS_USE_SYSTEM_JAVA=1
     - ARROW_TRAVIS_USE_TOOLCHAIN=1
-    - ARROW_TRAVIS_VALGRIND=1
     - ARROW_TRAVIS_S3=1
     # TODO(wesm): Run the benchmarks outside of Travis
     # - ARROW_TRAVIS_PYTHON_BENCHMARKS=1
@@ -116,9 +112,6 @@ matrix:
     script:
     - $TRAVIS_BUILD_DIR/ci/travis_script_java.sh || travis_terminate 1
     - export ARROW_TRAVIS_PYTHON_GANDIVA=1
-    # Only run Plasma tests with valgrind in one of the Python builds because
-    # they are slow
-    - export PLASMA_VALGRIND=1
     - $TRAVIS_BUILD_DIR/ci/travis_script_python.sh 3.6
     - $TRAVIS_BUILD_DIR/ci/travis_upload_cpp_coverage.sh
 

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -138,19 +138,7 @@ if("${BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
     # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-by-compiler-version
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /W3 /wd4365 /wd4267 /wd4838")
   elseif("${COMPILER_FAMILY}" STREQUAL "clang")
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Weverything -Wdocumentation \
--Wno-c++98-compat \
--Wno-c++98-compat-pedantic -Wno-deprecated -Wno-weak-vtables -Wno-padded \
--Wno-comma -Wno-unused-macros -Wno-unused-parameter -Wno-unused-template -Wno-undef \
--Wno-shadow -Wno-switch-enum -Wno-exit-time-destructors \
--Wno-global-constructors -Wno-weak-template-vtables -Wno-undefined-reinterpret-cast \
--Wno-implicit-fallthrough -Wno-unreachable-code -Wno-unreachable-code-return \
--Wno-float-equal -Wno-missing-prototypes -Wno-documentation-unknown-command \
--Wno-old-style-cast -Wno-covered-switch-default \
--Wno-cast-align -Wno-vla-extension -Wno-shift-sign-overflow \
--Wno-used-but-marked-unused -Wno-missing-variable-declarations \
--Wno-gnu-zero-variadic-macro-arguments -Wno-conversion -Wno-sign-conversion \
--Wno-disabled-macro-expansion -Wno-format-nonliteral -Wno-missing-noreturn")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Weverything -Wdocumentation")
 
     # Version numbers where warnings are introduced
     if("${COMPILER_VERSION}" VERSION_GREATER "3.3")
@@ -256,6 +244,24 @@ if("${COMPILER_FAMILY}" STREQUAL "clang")
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unknown-warning-option")
   # Add colors when paired with ninja
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
+
+  # Avoid all kinds of annoying warnings
+  set(_clang_flags "\
+    -Wno-c++98-compat \
+    -Wno-c++98-compat-pedantic -Wno-deprecated -Wno-weak-vtables -Wno-padded \
+    -Wno-comma -Wno-unused-macros -Wno-unused-parameter -Wno-unused-template -Wno-undef \
+    -Wno-shadow -Wno-switch-enum -Wno-exit-time-destructors \
+    -Wno-global-constructors -Wno-weak-template-vtables -Wno-undefined-reinterpret-cast \
+    -Wno-implicit-fallthrough -Wno-unreachable-code -Wno-unreachable-code-return \
+    -Wno-float-equal -Wno-missing-prototypes -Wno-documentation-unknown-command \
+    -Wno-old-style-cast -Wno-covered-switch-default \
+    -Wno-cast-align -Wno-vla-extension -Wno-shift-sign-overflow \
+    -Wno-used-but-marked-unused -Wno-missing-variable-declarations \
+    -Wno-gnu-zero-variadic-macro-arguments -Wno-conversion -Wno-sign-conversion \
+    -Wno-disabled-macro-expansion -Wno-format-nonliteral -Wno-missing-noreturn")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_clang_flags}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_clang_flags}")
+
 endif()
 
 # if build warning flags is set, add to CXX_COMMON_FLAGS

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -138,7 +138,19 @@ if("${BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
     # https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warnings-by-compiler-version
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} /W3 /wd4365 /wd4267 /wd4838")
   elseif("${COMPILER_FAMILY}" STREQUAL "clang")
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Weverything -Wdocumentation")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Weverything -Wdocumentation \
+-Wno-c++98-compat \
+-Wno-c++98-compat-pedantic -Wno-deprecated -Wno-weak-vtables -Wno-padded \
+-Wno-comma -Wno-unused-macros -Wno-unused-parameter -Wno-unused-template -Wno-undef \
+-Wno-shadow -Wno-switch-enum -Wno-exit-time-destructors \
+-Wno-global-constructors -Wno-weak-template-vtables -Wno-undefined-reinterpret-cast \
+-Wno-implicit-fallthrough -Wno-unreachable-code -Wno-unreachable-code-return \
+-Wno-float-equal -Wno-missing-prototypes -Wno-documentation-unknown-command \
+-Wno-old-style-cast -Wno-covered-switch-default \
+-Wno-cast-align -Wno-vla-extension -Wno-shift-sign-overflow \
+-Wno-used-but-marked-unused -Wno-missing-variable-declarations \
+-Wno-gnu-zero-variadic-macro-arguments -Wno-conversion -Wno-sign-conversion \
+-Wno-disabled-macro-expansion -Wno-format-nonliteral -Wno-missing-noreturn")
 
     # Version numbers where warnings are introduced
     if("${COMPILER_VERSION}" VERSION_GREATER "3.3")
@@ -244,24 +256,6 @@ if("${COMPILER_FAMILY}" STREQUAL "clang")
   set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unknown-warning-option")
   # Add colors when paired with ninja
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
-
-  # Avoid all kinds of annoying warnings
-  set(_clang_flags "\
-    -Wno-c++98-compat \
-    -Wno-c++98-compat-pedantic -Wno-deprecated -Wno-weak-vtables -Wno-padded \
-    -Wno-comma -Wno-unused-macros -Wno-unused-parameter -Wno-unused-template -Wno-undef \
-    -Wno-shadow -Wno-switch-enum -Wno-exit-time-destructors \
-    -Wno-global-constructors -Wno-weak-template-vtables -Wno-undefined-reinterpret-cast \
-    -Wno-implicit-fallthrough -Wno-unreachable-code -Wno-unreachable-code-return \
-    -Wno-float-equal -Wno-missing-prototypes -Wno-documentation-unknown-command \
-    -Wno-old-style-cast -Wno-covered-switch-default \
-    -Wno-cast-align -Wno-vla-extension -Wno-shift-sign-overflow \
-    -Wno-used-but-marked-unused -Wno-missing-variable-declarations \
-    -Wno-gnu-zero-variadic-macro-arguments -Wno-conversion -Wno-sign-conversion \
-    -Wno-disabled-macro-expansion -Wno-format-nonliteral -Wno-missing-noreturn")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_clang_flags}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_clang_flags}")
-
 endif()
 
 # if build warning flags is set, add to CXX_COMMON_FLAGS

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -46,10 +46,19 @@
 // See discussion in https://github.com/jemalloc/jemalloc/issues/1621
 
 #ifdef NDEBUG
-const char* je_arrow_malloc_conf = "oversize_threshold:0,dirty_decay_ms:0,muzzy_decay_ms:0";
+const char* je_arrow_malloc_conf =
+    ("oversize_threshold:0,"
+     "dirty_decay_ms:1000,"
+     "muzzy_decay_ms:1000,"
+     "background_thread:true");
 #else
 // In debug mode, add memory poisoning on alloc / free
-const char* je_arrow_malloc_conf = "oversize_threshold:0,junk:true";
+const char* je_arrow_malloc_conf =
+    ("oversize_threshold:0,"
+     "junk:true,"
+     "dirty_decay_ms:1000,"
+     "muzzy_decay_ms:1000,"
+     "background_thread:true");
 #endif
 #endif
 

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -45,6 +45,14 @@
 // building jemalloc.
 // See discussion in https://github.com/jemalloc/jemalloc/issues/1621
 
+// ARROW-6910(wesm): we found that jemalloc's default behavior with respect to
+// dirty / muzzy pages (see definitions of these in the jemalloc documentation)
+// conflicted with user expectations, and would even cause memory use problems
+// in some cases. By enabling the background_thread option and reducing the
+// decay time from 10 seconds to 1 seconds, memory is released more
+// aggressively (and in the background) to the OS. This can be configured
+// further by using the arrow::jemalloc_set_decay_ms API
+
 #ifdef NDEBUG
 const char* je_arrow_malloc_conf =
     ("oversize_threshold:0,"

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -160,6 +160,16 @@ ARROW_EXPORT MemoryPool* system_memory_pool();
 /// May return NotImplemented if jemalloc is not available.
 ARROW_EXPORT Status jemalloc_memory_pool(MemoryPool** out);
 
+/// \brief Set jemalloc memory page purging behavior for future-created arenas
+/// to the indicated number of milliseconds. See dirty_decay_ms and
+/// muzzy_decay_ms options in jemalloc for a description of what these do. The
+/// default is configured to 0 which releases memory more aggressively to the
+/// operating system. If you have a long-running application that uses a lot of
+/// memory, you may wish to set this to a higher value. The jemalloc default is
+/// 10000 (10 seconds)
+ARROW_EXPORT
+Status jemalloc_set_decay_ms(int ms);
+
 /// Return a process-wide memory pool based on mimalloc.
 ///
 /// May return NotImplemented if mimalloc is not available.

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -163,10 +163,11 @@ ARROW_EXPORT Status jemalloc_memory_pool(MemoryPool** out);
 /// \brief Set jemalloc memory page purging behavior for future-created arenas
 /// to the indicated number of milliseconds. See dirty_decay_ms and
 /// muzzy_decay_ms options in jemalloc for a description of what these do. The
-/// default is configured to 0 which releases memory more aggressively to the
-/// operating system. If you have a long-running application that uses a lot of
-/// memory, you may wish to set this to a higher value. The jemalloc default is
-/// 10000 (10 seconds)
+/// default is configured to 1000 (1 second) which releases memory more
+/// aggressively to the operating system than the jemalloc default of 10
+/// seconds. If you set the value to 0, dirty / muzzy pages will be released
+/// immediately rather than with a time decay, but this may reduce application
+/// performance.
 ARROW_EXPORT
 Status jemalloc_set_decay_ms(int ms);
 

--- a/cpp/src/arrow/memory_pool_test.cc
+++ b/cpp/src/arrow/memory_pool_test.cc
@@ -143,4 +143,14 @@ TEST(ProxyMemoryPool, Logging) {
   ASSERT_EQ(0, pool->bytes_allocated());
   ASSERT_EQ(0, pp.bytes_allocated());
 }
+
+TEST(Jemalloc, SetDirtyPageDecayMillis) {
+  // ARROW-6910
+#ifdef ARROW_JEMALLOC
+  ASSERT_OK(jemalloc_set_decay_ms(0));
+#else
+  ASSERT_RAISES(Invalid, jemalloc_set_decay_ms(0));
+#endif
+}
+
 }  // namespace arrow

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -108,7 +108,8 @@ from pyarrow.lib import (Buffer, ResizableBuffer, foreign_buffer, py_buffer,
 from pyarrow.lib import (MemoryPool, LoggingMemoryPool, ProxyMemoryPool,
                          total_allocated_bytes, set_memory_pool,
                          default_memory_pool, logging_memory_pool,
-                         proxy_memory_pool, log_memory_allocations)
+                         proxy_memory_pool, log_memory_allocations,
+                         jemalloc_set_decay_ms)
 
 # I/O
 from pyarrow.lib import (HdfsFile, NativeFile, PythonFile,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -260,6 +260,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     cdef CMemoryPool* c_default_memory_pool" arrow::default_memory_pool"()
 
+    CStatus c_jemalloc_set_decay_ms" arrow::jemalloc_set_decay_ms"(int ms)
+
     cdef cppclass CListType" arrow::ListType"(CDataType):
         CListType(const shared_ptr[CDataType]& value_type)
         CListType(const shared_ptr[CField]& field)

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -151,3 +151,21 @@ def total_allocated_bytes():
     """
     cdef CMemoryPool* pool = c_get_memory_pool()
     return pool.bytes_allocated()
+
+
+def jemalloc_set_decay_ms(decay_ms):
+    """
+    Set arenas.dirty_decay_ms and arenas.muzzy_decay_ms to indicated number of
+    milliseconds. A value of 0 (the default) results in dirty / muzzy memory
+    pages being released right away to the OS, while a higher value will result
+    in a time-based decay. See the jemalloc docs for more information
+
+    It's best to set this at the start of your application.
+
+    Parameters
+    ----------
+    decay_ms : int
+        Number of milliseconds to set for jemalloc decay conf parameters. Note
+        that this change will only affect future memory arenas
+    """
+    check_status(c_jemalloc_set_decay_ms(decay_ms))


### PR DESCRIPTION
The current default behavior causes applications dealing in large datasets to hold on to a large amount of physical operating system memory. While this may improve performance in some cases, it empirically seems to be causing problems for users.

There's some discussion of this issue in some other contexts here

https://github.com/jemalloc/jemalloc/issues/1128

Here is a test script I used to check the RSS while reading a large Parquet file (~10GB in memory) in a loop (requires downloading the file http://public-parquet-test-data.s3.amazonaws.com/big.snappy.parquet)

https://gist.github.com/wesm/c75ad3b6dcd37231aaacf56a80a5e401

This patch enables jemalloc background page reclamation and reduces the time decay from 10 seconds to 1 second so that memory is returned to the OS more aggressively. 