### PR TITLE
ARROW-6503: [C++] Add an argument of memory pool object to SparseTensorConverter

### DIFF
--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1353,9 +1353,10 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSRIndex) {
 
   auto data = Buffer::Wrap(values);
   NumericTensor<Int64Type> t(data, shape, {}, dim_names);
-  SparseCSRMatrix st(t, TypeTraits<IndexValueType>::type_singleton());
+  std::shared_ptr<SparseCSRMatrix> st;
+  ASSERT_OK(SparseCSRMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton(), &st));
 
-  this->CheckSparseTensorRoundTrip(st);
+  this->CheckSparseTensorRoundTrip(*st);
 }
 
 REGISTER_TYPED_TEST_CASE_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor,

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -414,14 +414,12 @@ Status NdarraysToSparseCSRMatrix(MemoryPool* pool, PyObject* data_ao, PyObject* 
 
 Status TensorToSparseCOOTensor(const std::shared_ptr<Tensor>& tensor,
                                std::shared_ptr<SparseCOOTensor>* out) {
-  *out = std::make_shared<SparseCOOTensor>(*tensor);
-  return Status::OK();
+  return SparseCOOTensor::Make(*tensor, out);
 }
 
 Status TensorToSparseCSRMatrix(const std::shared_ptr<Tensor>& tensor,
                                std::shared_ptr<SparseCSRMatrix>* out) {
-  *out = std::make_shared<SparseCSRMatrix>(*tensor);
-  return Status::OK();
+  return SparseCSRMatrix::Make(*tensor, out);
 }
 
 }  // namespace py

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -55,10 +55,6 @@ struct SparseTensorConverterBase {
                             MemoryPool* pool)
       : tensor_(tensor), index_value_type_(index_value_type), pool_(pool) {}
 
-  SparseTensorConverterBase(const NumericTensor<TYPE>& tensor,
-                            const std::shared_ptr<DataType>& data_type)
-      : SparseTensorConverterBase(tensor, data_type, default_memory_pool()) {}
-
   const NumericTensorType& tensor_;
   const std::shared_ptr<DataType>& index_value_type_;
   MemoryPool* pool_;
@@ -71,10 +67,6 @@ class SparseTensorConverter<TYPE, SparseCOOIndex>
   using BaseClass = SparseTensorConverterBase<TYPE>;
   using typename BaseClass::NumericTensorType;
   using typename BaseClass::value_type;
-
-  SparseTensorConverter(const NumericTensorType& tensor,
-                        const std::shared_ptr<DataType>& index_value_type)
-      : BaseClass(tensor, index_value_type) {}
 
   SparseTensorConverter(const NumericTensorType& tensor,
                         const std::shared_ptr<DataType>& index_value_type,
@@ -186,10 +178,6 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
   using BaseClass = SparseTensorConverterBase<TYPE>;
   using NumericTensorType = typename BaseClass::NumericTensorType;
   using value_type = typename BaseClass::value_type;
-
-  SparseTensorConverter(const NumericTensorType& tensor,
-                        const std::shared_ptr<DataType>& index_value_type)
-      : BaseClass(tensor, index_value_type) {}
 
   SparseTensorConverter(const NumericTensorType& tensor,
                         const std::shared_ptr<DataType>& index_value_type,

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -36,8 +36,8 @@ namespace {
 template <typename TYPE, typename SparseIndexType>
 class SparseTensorConverter {
  public:
-  explicit SparseTensorConverter(const NumericTensor<TYPE>&,
-                                 const std::shared_ptr<DataType>&) {}
+  SparseTensorConverter(const NumericTensor<TYPE>&, const std::shared_ptr<DataType>&,
+                        MemoryPool*) {}
 
   Status Convert() { return Status::Invalid("Unsupported sparse index"); }
 };
@@ -50,12 +50,18 @@ struct SparseTensorConverterBase {
   using NumericTensorType = NumericTensor<TYPE>;
   using value_type = typename NumericTensorType::value_type;
 
-  explicit SparseTensorConverterBase(const NumericTensorType& tensor,
-                                     const std::shared_ptr<DataType>& index_value_type)
-      : tensor_(tensor), index_value_type_(index_value_type) {}
+  SparseTensorConverterBase(const NumericTensorType& tensor,
+                            const std::shared_ptr<DataType>& index_value_type,
+                            MemoryPool* pool)
+      : tensor_(tensor), index_value_type_(index_value_type), pool_(pool) {}
+
+  SparseTensorConverterBase(const NumericTensor<TYPE>& tensor,
+                            const std::shared_ptr<DataType>& data_type)
+      : SparseTensorConverterBase(tensor, data_type, default_memory_pool()) {}
 
   const NumericTensorType& tensor_;
   const std::shared_ptr<DataType>& index_value_type_;
+  MemoryPool* pool_;
 };
 
 template <typename TYPE>
@@ -66,9 +72,14 @@ class SparseTensorConverter<TYPE, SparseCOOIndex>
   using typename BaseClass::NumericTensorType;
   using typename BaseClass::value_type;
 
-  explicit SparseTensorConverter(const NumericTensorType& tensor,
-                                 const std::shared_ptr<DataType>& index_value_type)
+  SparseTensorConverter(const NumericTensorType& tensor,
+                        const std::shared_ptr<DataType>& index_value_type)
       : BaseClass(tensor, index_value_type) {}
+
+  SparseTensorConverter(const NumericTensorType& tensor,
+                        const std::shared_ptr<DataType>& index_value_type,
+                        MemoryPool* pool)
+      : BaseClass(tensor, index_value_type, pool) {}
 
   template <typename IndexValueType>
   Status Convert() {
@@ -80,12 +91,14 @@ class SparseTensorConverter<TYPE, SparseCOOIndex>
     RETURN_NOT_OK(tensor_.CountNonZero(&nonzero_count));
 
     std::shared_ptr<Buffer> indices_buffer;
-    RETURN_NOT_OK(AllocateBuffer(indices_elsize * ndim * nonzero_count, &indices_buffer));
+    RETURN_NOT_OK(
+        AllocateBuffer(pool_, indices_elsize * ndim * nonzero_count, &indices_buffer));
     c_index_value_type* indices =
         reinterpret_cast<c_index_value_type*>(indices_buffer->mutable_data());
 
     std::shared_ptr<Buffer> values_buffer;
-    RETURN_NOT_OK(AllocateBuffer(sizeof(value_type) * nonzero_count, &values_buffer));
+    RETURN_NOT_OK(
+        AllocateBuffer(pool_, sizeof(value_type) * nonzero_count, &values_buffer));
     value_type* values = reinterpret_cast<value_type*>(values_buffer->mutable_data());
 
     if (ndim <= 1) {
@@ -159,6 +172,7 @@ class SparseTensorConverter<TYPE, SparseCOOIndex>
 
  private:
   using BaseClass::index_value_type_;
+  using BaseClass::pool_;
   using BaseClass::tensor_;
 };
 
@@ -173,9 +187,14 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
   using NumericTensorType = typename BaseClass::NumericTensorType;
   using value_type = typename BaseClass::value_type;
 
-  explicit SparseTensorConverter(const NumericTensorType& tensor,
-                                 const std::shared_ptr<DataType>& index_value_type)
+  SparseTensorConverter(const NumericTensorType& tensor,
+                        const std::shared_ptr<DataType>& index_value_type)
       : BaseClass(tensor, index_value_type) {}
+
+  SparseTensorConverter(const NumericTensorType& tensor,
+                        const std::shared_ptr<DataType>& index_value_type,
+                        MemoryPool* pool)
+      : BaseClass(tensor, index_value_type, pool) {}
 
   template <typename IndexValueType>
   Status Convert() {
@@ -199,16 +218,18 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
     std::shared_ptr<Buffer> indices_buffer;
 
     std::shared_ptr<Buffer> values_buffer;
-    RETURN_NOT_OK(AllocateBuffer(sizeof(value_type) * nonzero_count, &values_buffer));
+    RETURN_NOT_OK(
+        AllocateBuffer(pool_, sizeof(value_type) * nonzero_count, &values_buffer));
     value_type* values = reinterpret_cast<value_type*>(values_buffer->mutable_data());
 
     if (ndim <= 1) {
       return Status::NotImplemented("TODO for ndim <= 1");
     } else {
-      RETURN_NOT_OK(AllocateBuffer(indices_elsize * (nr + 1), &indptr_buffer));
+      RETURN_NOT_OK(AllocateBuffer(pool_, indices_elsize * (nr + 1), &indptr_buffer));
       auto* indptr = reinterpret_cast<c_index_value_type*>(indptr_buffer->mutable_data());
 
-      RETURN_NOT_OK(AllocateBuffer(indices_elsize * nonzero_count, &indices_buffer));
+      RETURN_NOT_OK(
+          AllocateBuffer(pool_, indices_elsize * nonzero_count, &indices_buffer));
       auto* indices =
           reinterpret_cast<c_index_value_type*>(indices_buffer->mutable_data());
 
@@ -262,6 +283,7 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
 
  private:
   using BaseClass::index_value_type_;
+  using BaseClass::pool_;
   using BaseClass::tensor_;
 
   template <typename c_value_type>
@@ -305,35 +327,36 @@ namespace internal {
 namespace {
 
 template <typename TYPE, typename SparseIndexType>
-void MakeSparseTensorFromTensor(const Tensor& tensor,
-                                const std::shared_ptr<DataType>& index_value_type,
-                                std::shared_ptr<SparseIndex>* sparse_index,
-                                std::shared_ptr<Buffer>* data) {
+Status MakeSparseTensorFromTensor(const Tensor& tensor,
+                                  const std::shared_ptr<DataType>& index_value_type,
+                                  MemoryPool* pool,
+                                  std::shared_ptr<SparseIndex>* out_sparse_index,
+                                  std::shared_ptr<Buffer>* out_data) {
   NumericTensor<TYPE> numeric_tensor(tensor.data(), tensor.shape(), tensor.strides());
-  SparseTensorConverter<TYPE, SparseIndexType> converter(numeric_tensor,
-                                                         index_value_type);
-  ARROW_CHECK_OK(converter.Convert());
-  *sparse_index = converter.sparse_index;
-  *data = converter.data;
+  SparseTensorConverter<TYPE, SparseIndexType> converter(numeric_tensor, index_value_type,
+                                                         pool);
+  RETURN_NOT_OK(converter.Convert());
+
+  *out_sparse_index = converter.sparse_index;
+  *out_data = converter.data;
+  return Status::OK();
 }
 
-#define MAKE_SPARSE_TENSOR_FROM_TENSOR(TYPE_CLASS)                 \
-  case TYPE_CLASS##Type::type_id:                                  \
-    MakeSparseTensorFromTensor<TYPE_CLASS##Type, SparseIndexType>( \
-        tensor, index_value_type, sparse_index, data);             \
-    break;
+#define MAKE_SPARSE_TENSOR_FROM_TENSOR(TYPE_CLASS)                        \
+  case TYPE_CLASS##Type::type_id:                                         \
+    return MakeSparseTensorFromTensor<TYPE_CLASS##Type, SparseIndexType>( \
+        tensor, index_value_type, pool, out_sparse_index, out_data);
 
 template <typename SparseIndexType>
-inline void MakeSparseTensorFromTensor(const Tensor& tensor,
-                                       const std::shared_ptr<DataType>& index_value_type,
-                                       std::shared_ptr<SparseIndex>* sparse_index,
-                                       std::shared_ptr<Buffer>* data) {
+inline Status MakeSparseTensorFromTensor(
+    const Tensor& tensor, const std::shared_ptr<DataType>& index_value_type,
+    MemoryPool* pool, std::shared_ptr<SparseIndex>* out_sparse_index,
+    std::shared_ptr<Buffer>* out_data) {
   switch (tensor.type()->id()) {
     ARROW_GENERATE_FOR_ALL_NUMERIC_TYPES(MAKE_SPARSE_TENSOR_FROM_TENSOR);
-    // LCOV_EXCL_START: ignore program failure
+      // LCOV_EXCL_START: ignore program failure
     default:
-      ARROW_LOG(FATAL) << "Unsupported Tensor value type";
-      break;
+      return Status::Invalid("Unsupported Tensor value type");
       // LCOV_EXCL_STOP
   }
 }
@@ -342,24 +365,22 @@ inline void MakeSparseTensorFromTensor(const Tensor& tensor,
 
 }  // namespace
 
-void MakeSparseTensorFromTensor(const Tensor& tensor,
-                                SparseTensorFormat::type sparse_format_id,
-                                const std::shared_ptr<DataType>& index_value_type,
-                                std::shared_ptr<SparseIndex>* sparse_index,
-                                std::shared_ptr<Buffer>* data) {
+Status MakeSparseTensorFromTensor(const Tensor& tensor,
+                                  SparseTensorFormat::type sparse_format_id,
+                                  const std::shared_ptr<DataType>& index_value_type,
+                                  MemoryPool* pool,
+                                  std::shared_ptr<SparseIndex>* out_sparse_index,
+                                  std::shared_ptr<Buffer>* out_data) {
   switch (sparse_format_id) {
     case SparseTensorFormat::COO:
-      MakeSparseTensorFromTensor<SparseCOOIndex>(tensor, index_value_type, sparse_index,
-                                                 data);
-      break;
+      return MakeSparseTensorFromTensor<SparseCOOIndex>(tensor, index_value_type, pool,
+                                                        out_sparse_index, out_data);
     case SparseTensorFormat::CSR:
-      MakeSparseTensorFromTensor<SparseCSRIndex>(tensor, index_value_type, sparse_index,
-                                                 data);
-      break;
+      return MakeSparseTensorFromTensor<SparseCSRIndex>(tensor, index_value_type, pool,
+                                                        out_sparse_index, out_data);
     // LCOV_EXCL_START: ignore program failure
     default:
-      ARROW_LOG(FATAL) << "Invalid sparse tensor format ID";
-      break;
+      return Status::Invalid("Invalid sparse tensor format");
       // LCOV_EXCL_STOP
   }
 }

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -114,10 +114,10 @@ TEST_F(TestSparseCOOTensor, CreationFromNumericTensor) {
   auto* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
-  const auto& si = internal::checked_cast<const SparseCOOIndex&>(*st.sparse_index());
-  ASSERT_EQ(std::string("SparseCOOIndex"), si.ToString());
+  auto si = internal::checked_pointer_cast<SparseCOOIndex>(st.sparse_index());
+  ASSERT_EQ(std::string("SparseCOOIndex"), si->ToString());
 
-  std::shared_ptr<Tensor> sidx = si.indices();
+  std::shared_ptr<Tensor> sidx = si->indices();
   ASSERT_EQ(std::vector<int64_t>({12, 3}), sidx->shape());
   ASSERT_TRUE(sidx->is_column_major());
 
@@ -142,8 +142,8 @@ TEST_F(TestSparseCOOTensor, CreationFromNumericTensor1D) {
   auto* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
-  const auto& si = internal::checked_cast<const SparseCOOIndex&>(*st.sparse_index());
-  auto sidx = si.indices();
+  auto si = internal::checked_pointer_cast<SparseCOOIndex>(st.sparse_index());
+  auto sidx = si->indices();
   ASSERT_EQ(std::vector<int64_t>({12, 1}), sidx->shape());
 
   AssertCOOIndex(sidx, 0, {0});
@@ -410,22 +410,23 @@ TEST_F(TestSparseCSRMatrix, CreationFromNumericTensor2D) {
   const int64_t* raw_data = reinterpret_cast<const int64_t*>(st1.raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
-  const auto& si = internal::checked_cast<const SparseCSRIndex&>(*st1.sparse_index());
-  ASSERT_EQ(std::string("SparseCSRIndex"), si.ToString());
-  ASSERT_EQ(1, si.indptr()->ndim());
-  ASSERT_EQ(1, si.indices()->ndim());
+  auto si = internal::checked_pointer_cast<SparseCSRIndex>(st1.sparse_index());
+  ASSERT_EQ(std::string("SparseCSRIndex"), si->ToString());
+  ASSERT_EQ(1, si->indptr()->ndim());
+  ASSERT_EQ(1, si->indices()->ndim());
 
-  const int64_t* indptr_begin = reinterpret_cast<const int64_t*>(si.indptr()->raw_data());
+  const int64_t* indptr_begin =
+      reinterpret_cast<const int64_t*>(si->indptr()->raw_data());
   std::vector<int64_t> indptr_values(indptr_begin,
-                                     indptr_begin + si.indptr()->shape()[0]);
+                                     indptr_begin + si->indptr()->shape()[0]);
 
   ASSERT_EQ(7, indptr_values.size());
   ASSERT_EQ(std::vector<int64_t>({0, 2, 4, 6, 8, 10, 12}), indptr_values);
 
   const int64_t* indices_begin =
-      reinterpret_cast<const int64_t*>(si.indices()->raw_data());
+      reinterpret_cast<const int64_t*>(si->indices()->raw_data());
   std::vector<int64_t> indices_values(indices_begin,
-                                      indices_begin + si.indices()->shape()[0]);
+                                      indices_begin + si->indices()->shape()[0]);
 
   ASSERT_EQ(12, indices_values.size());
   ASSERT_EQ(std::vector<int64_t>({0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3}), indices_values);
@@ -446,21 +447,22 @@ TEST_F(TestSparseCSRMatrix, CreationFromNonContiguousTensor) {
   const int64_t* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
-  const auto& si = internal::checked_cast<const SparseCSRIndex&>(*st.sparse_index());
-  ASSERT_EQ(1, si.indptr()->ndim());
-  ASSERT_EQ(1, si.indices()->ndim());
+  auto si = internal::checked_pointer_cast<SparseCSRIndex>(st.sparse_index());
+  ASSERT_EQ(1, si->indptr()->ndim());
+  ASSERT_EQ(1, si->indices()->ndim());
 
-  const int64_t* indptr_begin = reinterpret_cast<const int64_t*>(si.indptr()->raw_data());
+  const int64_t* indptr_begin =
+      reinterpret_cast<const int64_t*>(si->indptr()->raw_data());
   std::vector<int64_t> indptr_values(indptr_begin,
-                                     indptr_begin + si.indptr()->shape()[0]);
+                                     indptr_begin + si->indptr()->shape()[0]);
 
   ASSERT_EQ(7, indptr_values.size());
   ASSERT_EQ(std::vector<int64_t>({0, 2, 4, 6, 8, 10, 12}), indptr_values);
 
   const int64_t* indices_begin =
-      reinterpret_cast<const int64_t*>(si.indices()->raw_data());
+      reinterpret_cast<const int64_t*>(si->indices()->raw_data());
   std::vector<int64_t> indices_values(indices_begin,
-                                      indices_begin + si.indices()->shape()[0]);
+                                      indices_begin + si->indices()->shape()[0]);
 
   ASSERT_EQ(12, indices_values.size());
   ASSERT_EQ(std::vector<int64_t>({0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3}), indices_values);

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -71,8 +71,9 @@ class TestSparseCOOTensorBase : public ::testing::Test {
                                          0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
     auto dense_data = Buffer::Wrap(dense_values);
     NumericTensor<Int64Type> dense_tensor(dense_data, shape_, {}, dim_names_);
-    sparse_tensor_from_dense_ = std::make_shared<SparseCOOTensor>(
-        dense_tensor, TypeTraits<IndexValueType>::type_singleton());
+    ASSERT_OK(SparseCOOTensor::Make(dense_tensor,
+                                    TypeTraits<IndexValueType>::type_singleton(),
+                                    &sparse_tensor_from_dense_));
   }
 
  protected:
@@ -105,16 +106,16 @@ TEST_F(TestSparseCOOTensor, CreationEmptyTensor) {
 }
 
 TEST_F(TestSparseCOOTensor, CreationFromNumericTensor) {
-  auto& st = *this->sparse_tensor_from_dense_;
-  CheckSparseIndexFormatType(SparseTensorFormat::COO, st);
+  auto st = this->sparse_tensor_from_dense_;
+  CheckSparseIndexFormatType(SparseTensorFormat::COO, *st);
 
-  ASSERT_EQ(12, st.non_zero_length());
-  ASSERT_TRUE(st.is_mutable());
+  ASSERT_EQ(12, st->non_zero_length());
+  ASSERT_TRUE(st->is_mutable());
 
-  auto* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
+  auto* raw_data = reinterpret_cast<const int64_t*>(st->raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
-  auto si = internal::checked_pointer_cast<SparseCOOIndex>(st.sparse_index());
+  auto si = internal::checked_pointer_cast<SparseCOOIndex>(st->sparse_index());
   ASSERT_EQ(std::string("SparseCOOIndex"), si->ToString());
 
   std::shared_ptr<Tensor> sidx = si->indices();
@@ -134,15 +135,17 @@ TEST_F(TestSparseCOOTensor, CreationFromNumericTensor1D) {
   auto dense_data = Buffer::Wrap(dense_values);
   std::vector<int64_t> dense_shape({static_cast<int64_t>(dense_values.size())});
   NumericTensor<Int64Type> dense_vector(dense_data, dense_shape);
-  SparseCOOTensor st(dense_vector);
 
-  ASSERT_EQ(12, st.non_zero_length());
-  ASSERT_TRUE(st.is_mutable());
+  std::shared_ptr<SparseCOOTensor> st;
+  ASSERT_OK(SparseCOOTensor::Make(dense_vector, &st));
 
-  auto* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
+  ASSERT_EQ(12, st->non_zero_length());
+  ASSERT_TRUE(st->is_mutable());
+
+  auto* raw_data = reinterpret_cast<const int64_t*>(st->raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
-  auto si = internal::checked_pointer_cast<SparseCOOIndex>(st.sparse_index());
+  auto si = internal::checked_pointer_cast<SparseCOOIndex>(st->sparse_index());
   auto sidx = si->indices();
   ASSERT_EQ(std::vector<int64_t>({12, 1}), sidx->shape());
 
@@ -158,17 +161,19 @@ TEST_F(TestSparseCOOTensor, CreationFromTensor) {
                                  0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
   std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
   Tensor tensor(int64(), buffer, this->shape_, {}, this->dim_names_);
-  SparseCOOTensor st(tensor);
 
-  ASSERT_EQ(12, st.non_zero_length());
-  ASSERT_TRUE(st.is_mutable());
+  std::shared_ptr<SparseCOOTensor> st;
+  ASSERT_OK(SparseCOOTensor::Make(tensor, &st));
 
-  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st.dim_names());
-  ASSERT_EQ("foo", st.dim_name(0));
-  ASSERT_EQ("bar", st.dim_name(1));
-  ASSERT_EQ("baz", st.dim_name(2));
+  ASSERT_EQ(12, st->non_zero_length());
+  ASSERT_TRUE(st->is_mutable());
 
-  ASSERT_TRUE(st.Equals(*this->sparse_tensor_from_dense_));
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar", "baz"}), st->dim_names());
+  ASSERT_EQ("foo", st->dim_name(0));
+  ASSERT_EQ("bar", st->dim_name(1));
+  ASSERT_EQ("baz", st->dim_name(2));
+
+  ASSERT_TRUE(st->Equals(*this->sparse_tensor_from_dense_));
 }
 
 TEST_F(TestSparseCOOTensor, CreationFromNonContiguousTensor) {
@@ -178,12 +183,14 @@ TEST_F(TestSparseCOOTensor, CreationFromNonContiguousTensor) {
   std::vector<int64_t> strides = {192, 64, 16};
   std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
   Tensor tensor(int64(), buffer, this->shape_, strides);
-  SparseCOOTensor st(tensor);
 
-  ASSERT_EQ(12, st.non_zero_length());
-  ASSERT_TRUE(st.is_mutable());
+  std::shared_ptr<SparseCOOTensor> st;
+  ASSERT_OK(SparseCOOTensor::Make(tensor, &st));
 
-  ASSERT_TRUE(st.Equals(*this->sparse_tensor_from_dense_));
+  ASSERT_EQ(12, st->non_zero_length());
+  ASSERT_TRUE(st->is_mutable());
+
+  ASSERT_TRUE(st->Equals(*this->sparse_tensor_from_dense_));
 }
 
 TEST_F(TestSparseCOOTensor, TensorEquality) {
@@ -195,11 +202,13 @@ TEST_F(TestSparseCOOTensor, TensorEquality) {
   std::shared_ptr<Buffer> buffer2 = Buffer::Wrap(values2);
   NumericTensor<Int64Type> tensor1(buffer1, this->shape_);
   NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
-  SparseCOOTensor st1(tensor1);
-  SparseCOOTensor st2(tensor2);
 
-  ASSERT_TRUE(st1.Equals(*this->sparse_tensor_from_dense_));
-  ASSERT_FALSE(st1.Equals(st2));
+  std::shared_ptr<SparseCOOTensor> st1, st2;
+  ASSERT_OK(SparseCOOTensor::Make(tensor1, &st1));
+  ASSERT_OK(SparseCOOTensor::Make(tensor2, &st2));
+
+  ASSERT_TRUE(st1->Equals(*this->sparse_tensor_from_dense_));
+  ASSERT_FALSE(st1->Equals(*st2));
 }
 
 TEST_F(TestSparseCOOTensor, TestToTensor) {
@@ -208,12 +217,14 @@ TEST_F(TestSparseCOOTensor, TestToTensor) {
   std::vector<int64_t> shape({4, 3, 2, 1});
   std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
   Tensor tensor(int64(), buffer, shape, {}, this->dim_names_);
-  SparseTensorImpl<SparseCOOIndex> sparse_tensor(tensor);
 
-  ASSERT_EQ(5, sparse_tensor.non_zero_length());
-  ASSERT_TRUE(sparse_tensor.is_mutable());
+  std::shared_ptr<SparseCOOTensor> sparse_tensor;
+  ASSERT_OK(SparseCOOTensor::Make(tensor, &sparse_tensor));
+
+  ASSERT_EQ(5, sparse_tensor->non_zero_length());
+  ASSERT_TRUE(sparse_tensor->is_mutable());
   std::shared_ptr<Tensor> dense_tensor;
-  ASSERT_OK(sparse_tensor.ToTensor(&dense_tensor));
+  ASSERT_OK(sparse_tensor->ToTensor(&dense_tensor));
   ASSERT_TRUE(tensor.Equals(*dense_tensor));
 }
 
@@ -372,8 +383,9 @@ class TestSparseCSRMatrixBase : public ::testing::Test {
                                          0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
     auto dense_data = Buffer::Wrap(dense_values);
     NumericTensor<Int64Type> dense_tensor(dense_data, shape_, {}, dim_names_);
-    sparse_tensor_from_dense_ = std::make_shared<SparseCSRMatrix>(
-        dense_tensor, TypeTraits<IndexValueType>::type_singleton());
+    ASSERT_OK(SparseCSRMatrix::Make(dense_tensor,
+                                    TypeTraits<IndexValueType>::type_singleton(),
+                                    &sparse_tensor_from_dense_));
   }
 
  protected:
@@ -390,27 +402,28 @@ TEST_F(TestSparseCSRMatrix, CreationFromNumericTensor2D) {
   std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
   NumericTensor<Int64Type> tensor(buffer, this->shape_);
 
-  SparseCSRMatrix st1(tensor);
-  SparseCSRMatrix& st2 = *this->sparse_tensor_from_dense_;
+  std::shared_ptr<SparseCSRMatrix> st1;
+  ASSERT_OK(SparseCSRMatrix::Make(tensor, &st1));
+  auto st2 = this->sparse_tensor_from_dense_;
 
-  CheckSparseIndexFormatType(SparseTensorFormat::CSR, st1);
+  CheckSparseIndexFormatType(SparseTensorFormat::CSR, *st1);
 
-  ASSERT_EQ(12, st1.non_zero_length());
-  ASSERT_TRUE(st1.is_mutable());
+  ASSERT_EQ(12, st1->non_zero_length());
+  ASSERT_TRUE(st1->is_mutable());
 
-  ASSERT_EQ(std::vector<std::string>({"foo", "bar"}), st2.dim_names());
-  ASSERT_EQ("foo", st2.dim_name(0));
-  ASSERT_EQ("bar", st2.dim_name(1));
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar"}), st2->dim_names());
+  ASSERT_EQ("foo", st2->dim_name(0));
+  ASSERT_EQ("bar", st2->dim_name(1));
 
-  ASSERT_EQ(std::vector<std::string>({}), st1.dim_names());
-  ASSERT_EQ("", st1.dim_name(0));
-  ASSERT_EQ("", st1.dim_name(1));
-  ASSERT_EQ("", st1.dim_name(2));
+  ASSERT_EQ(std::vector<std::string>({}), st1->dim_names());
+  ASSERT_EQ("", st1->dim_name(0));
+  ASSERT_EQ("", st1->dim_name(1));
+  ASSERT_EQ("", st1->dim_name(2));
 
-  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st1.raw_data());
+  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st1->raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
-  auto si = internal::checked_pointer_cast<SparseCSRIndex>(st1.sparse_index());
+  auto si = internal::checked_pointer_cast<SparseCSRIndex>(st1->sparse_index());
   ASSERT_EQ(std::string("SparseCSRIndex"), si->ToString());
   ASSERT_EQ(1, si->indptr()->ndim());
   ASSERT_EQ(1, si->indices()->ndim());
@@ -439,15 +452,17 @@ TEST_F(TestSparseCSRMatrix, CreationFromNonContiguousTensor) {
   std::vector<int64_t> strides = {64, 16};
   std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
   Tensor tensor(int64(), buffer, this->shape_, strides);
-  SparseCSRMatrix st(tensor);
 
-  ASSERT_EQ(12, st.non_zero_length());
-  ASSERT_TRUE(st.is_mutable());
+  std::shared_ptr<SparseCSRMatrix> st;
+  ASSERT_OK(SparseCSRMatrix::Make(tensor, &st));
 
-  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st.raw_data());
+  ASSERT_EQ(12, st->non_zero_length());
+  ASSERT_TRUE(st->is_mutable());
+
+  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st->raw_data());
   AssertNumericDataEqual(raw_data, {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16});
 
-  auto si = internal::checked_pointer_cast<SparseCSRIndex>(st.sparse_index());
+  auto si = internal::checked_pointer_cast<SparseCSRIndex>(st->sparse_index());
   ASSERT_EQ(1, si->indptr()->ndim());
   ASSERT_EQ(1, si->indices()->ndim());
 
@@ -467,7 +482,7 @@ TEST_F(TestSparseCSRMatrix, CreationFromNonContiguousTensor) {
   ASSERT_EQ(12, indices_values.size());
   ASSERT_EQ(std::vector<int64_t>({0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3}), indices_values);
 
-  ASSERT_TRUE(st.Equals(*this->sparse_tensor_from_dense_));
+  ASSERT_TRUE(st->Equals(*this->sparse_tensor_from_dense_));
 }
 
 TEST_F(TestSparseCSRMatrix, TensorEquality) {
@@ -479,11 +494,13 @@ TEST_F(TestSparseCSRMatrix, TensorEquality) {
   std::shared_ptr<Buffer> buffer2 = Buffer::Wrap(values2);
   NumericTensor<Int64Type> tensor1(buffer1, this->shape_);
   NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
-  SparseCSRMatrix st1(tensor1);
-  SparseCSRMatrix st2(tensor2);
 
-  ASSERT_TRUE(st1.Equals(*this->sparse_tensor_from_dense_));
-  ASSERT_FALSE(st1.Equals(st2));
+  std::shared_ptr<SparseCSRMatrix> st1, st2;
+  ASSERT_OK(SparseCSRMatrix::Make(tensor1, &st1));
+  ASSERT_OK(SparseCSRMatrix::Make(tensor2, &st2));
+
+  ASSERT_TRUE(st1->Equals(*this->sparse_tensor_from_dense_));
+  ASSERT_FALSE(st1->Equals(*st2));
 }
 
 TEST_F(TestSparseCSRMatrix, TestToTensor) {
@@ -492,12 +509,14 @@ TEST_F(TestSparseCSRMatrix, TestToTensor) {
   std::vector<int64_t> shape({6, 4});
   std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
   Tensor tensor(int64(), buffer, shape, {}, this->dim_names_);
-  SparseTensorImpl<SparseCSRIndex> sparse_tensor(tensor);
 
-  ASSERT_EQ(7, sparse_tensor.non_zero_length());
-  ASSERT_TRUE(sparse_tensor.is_mutable());
+  std::shared_ptr<SparseCSRMatrix> sparse_tensor;
+  ASSERT_OK(SparseCSRMatrix::Make(tensor, &sparse_tensor));
+  ASSERT_EQ(7, sparse_tensor->non_zero_length());
+  ASSERT_TRUE(sparse_tensor->is_mutable());
+
   std::shared_ptr<Tensor> dense_tensor;
-  ASSERT_OK(sparse_tensor.ToTensor(&dense_tensor));
+  ASSERT_OK(sparse_tensor->ToTensor(&dense_tensor));
   ASSERT_TRUE(tensor.Equals(*dense_tensor));
 }
 }  // namespace arrow


### PR DESCRIPTION
In this pull-request, I'd like to add an argument of MemoryPool to SparseTensorConverter, and replace SparseTensorImpl's constructors from Tensor with static factory functions.