### PR TITLE
ARROW-6286: [GLib] Add support for LargeList type

### DIFF
--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -3940,9 +3940,6 @@ garrow_list_array_builder_dispose(GObject *object)
   priv = GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(object);
 
   if (priv->value_builder) {
-    GArrowArrayBuilderPrivate *value_builder_priv;
-    value_builder_priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(priv->value_builder);
-    value_builder_priv->array_builder = nullptr;
     g_object_unref(priv->value_builder);
     priv->value_builder = NULL;
   }
@@ -4139,6 +4136,7 @@ garrow_list_array_builder_get_value_builder(GArrowListArrayBuilder *builder)
         garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
     auto arrow_value_builder = arrow_builder->value_builder();
     priv->value_builder = garrow_array_builder_new_raw(arrow_value_builder);
+    garrow_array_builder_release_ownership(priv->value_builder);
   }
   return priv->value_builder;
 }
@@ -4163,8 +4161,6 @@ garrow_large_list_array_builder_dispose(GObject *object)
   auto priv = GARROW_LARGE_LIST_ARRAY_BUILDER_GET_PRIVATE(object);
 
   if (priv->value_builder) {
-    auto value_builder_priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(priv->value_builder);
-    value_builder_priv->array_builder = nullptr;
     g_object_unref(priv->value_builder);
     priv->value_builder = NULL;
   }
@@ -4280,6 +4276,7 @@ garrow_large_list_array_builder_get_value_builder(GArrowLargeListArrayBuilder *b
         garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
     auto arrow_value_builder = arrow_builder->value_builder();
     priv->value_builder = garrow_array_builder_new_raw(arrow_value_builder);
+    garrow_array_builder_release_ownership(priv->value_builder);
   }
   return priv->value_builder;
 }

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -304,6 +304,9 @@ G_BEGIN_DECLS
  * #GArrowListArrayBuilder is the class to create a new
  * #GArrowListArray.
  *
+ * #GArrowLargeListArrayBuilder is the class to create a new
+ * #GArrowLargeListArray.
+ *
  * #GArrowStructArrayBuilder is the class to create a new
  * #GArrowStructArray.
  *
@@ -4141,6 +4144,147 @@ garrow_list_array_builder_get_value_builder(GArrowListArrayBuilder *builder)
 }
 
 
+typedef struct GArrowLargeListArrayBuilderPrivate_ {
+  GArrowArrayBuilder *value_builder;
+} GArrowLargeListArrayBuilderPrivate;
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowLargeListArrayBuilder,
+                           garrow_large_list_array_builder,
+                           GARROW_TYPE_ARRAY_BUILDER)
+
+#define GARROW_LARGE_LIST_ARRAY_BUILDER_GET_PRIVATE(obj)        \
+  static_cast<GArrowLargeListArrayBuilderPrivate *>(            \
+     garrow_large_list_array_builder_get_instance_private(      \
+       GARROW_LARGE_LIST_ARRAY_BUILDER(obj)))
+
+static void
+garrow_large_list_array_builder_dispose(GObject *object)
+{
+  auto priv = GARROW_LARGE_LIST_ARRAY_BUILDER_GET_PRIVATE(object);
+
+  if (priv->value_builder) {
+    auto value_builder_priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(priv->value_builder);
+    value_builder_priv->array_builder = nullptr;
+    g_object_unref(priv->value_builder);
+    priv->value_builder = NULL;
+  }
+
+  G_OBJECT_CLASS(garrow_large_list_array_builder_parent_class)->dispose(object);
+}
+
+static void
+garrow_large_list_array_builder_init(GArrowLargeListArrayBuilder *builder)
+{
+}
+
+static void
+garrow_large_list_array_builder_class_init(GArrowLargeListArrayBuilderClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = garrow_large_list_array_builder_dispose;
+}
+
+/**
+ * garrow_large_list_array_builder_new:
+ * @data_type: A #GArrowLargeListDataType for value.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: A newly created #GArrowLargeListArrayBuilder.
+ *
+ * Since: 1.0.0
+ */
+GArrowLargeListArrayBuilder *
+garrow_large_list_array_builder_new(GArrowLargeListDataType *data_type,
+                                    GError **error)
+{
+  if (!GARROW_IS_LARGE_LIST_DATA_TYPE(data_type)) {
+    g_set_error(error,
+                GARROW_ERROR,
+                GARROW_ERROR_INVALID,
+                "[large-list-array-builder][new] data type must be large list data type");
+    return NULL;
+  }
+
+  auto arrow_data_type =
+    garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type));
+  auto builder = garrow_array_builder_new(arrow_data_type,
+                                          error,
+                                          "[large-list-array-builder][new]");
+  return GARROW_LARGE_LIST_ARRAY_BUILDER(builder);
+}
+
+/**
+ * garrow_large_list_array_builder_append_value:
+ * @builder: A #GArrowLargeListArrayBuilder.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * It appends a new list element. To append a new list element, you
+ * need to call this function then append list element values to
+ * `value_builder`. `value_builder` is the #GArrowArrayBuilder
+ * specified to constructor. You can get `value_builder` by
+ * garrow_large_list_array_builder_get_value_builder().
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_large_list_array_builder_append_value(GArrowLargeListArrayBuilder *builder,
+                                             GError **error)
+{
+  auto arrow_builder =
+    static_cast<arrow::LargeListBuilder *>(
+      garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
+
+  auto status = arrow_builder->Append();
+  return garrow_error_check(error, status, "[large-list-array-builder][append-value]");
+}
+
+/**
+ * garrow_large_list_array_builder_append_null:
+ * @builder: A #GArrowLargeListArrayBuilder.
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE if there was an error.
+ *
+ * It appends a new NULL element.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_large_list_array_builder_append_null(GArrowLargeListArrayBuilder *builder,
+                                            GError **error)
+{
+  return garrow_array_builder_append_null<arrow::LargeListBuilder *>
+    (GARROW_ARRAY_BUILDER(builder),
+     error,
+     "[large-list-array-builder][append-null]");
+}
+
+/**
+ * garrow_large_list_array_builder_get_value_builder:
+ * @builder: A #GArrowLargeListArrayBuilder.
+ *
+ * Returns: (transfer none): The #GArrowArrayBuilder for values.
+ *
+ * Since: 1.0.0
+ */
+GArrowArrayBuilder *
+garrow_large_list_array_builder_get_value_builder(GArrowLargeListArrayBuilder *builder)
+{
+  auto priv = GARROW_LARGE_LIST_ARRAY_BUILDER_GET_PRIVATE(builder);
+  if (!priv->value_builder) {
+    auto arrow_builder =
+      static_cast<arrow::LargeListBuilder *>(
+        garrow_array_builder_get_raw(GARROW_ARRAY_BUILDER(builder)));
+    auto arrow_value_builder = arrow_builder->value_builder();
+    priv->value_builder = garrow_array_builder_new_raw(arrow_value_builder);
+  }
+  return priv->value_builder;
+}
+
+
 typedef struct GArrowStructArrayBuilderPrivate_ {
   GList *field_builders;
 } GArrowStructArrayBuilderPrivate;
@@ -4515,6 +4659,9 @@ garrow_array_builder_new_raw(arrow::ArrayBuilder *arrow_builder,
       break;
     case arrow::Type::type::LIST:
       type = GARROW_TYPE_LIST_ARRAY_BUILDER;
+      break;
+    case arrow::Type::type::LARGE_LIST:
+      type = GARROW_TYPE_LARGE_LIST_ARRAY_BUILDER;
       break;
     case arrow::Type::type::STRUCT:
       type = GARROW_TYPE_STRUCT_ARRAY_BUILDER;

--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -915,6 +915,30 @@ gboolean garrow_list_array_builder_append_null(GArrowListArrayBuilder *builder,
 GArrowArrayBuilder *garrow_list_array_builder_get_value_builder(GArrowListArrayBuilder *builder);
 
 
+#define GARROW_TYPE_LARGE_LIST_ARRAY_BUILDER (garrow_large_list_array_builder_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowLargeListArrayBuilder,
+                         garrow_large_list_array_builder,
+                         GARROW,
+                         LARGE_LIST_ARRAY_BUILDER,
+                         GArrowArrayBuilder)
+struct _GArrowLargeListArrayBuilderClass
+{
+  GArrowArrayBuilderClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_1_0
+GArrowLargeListArrayBuilder *garrow_large_list_array_builder_new(GArrowLargeListDataType *data_type,
+                                                                 GError **error);
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_large_list_array_builder_append_value(GArrowLargeListArrayBuilder *builder,
+                                                      GError **error);
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_large_list_array_builder_append_null(GArrowLargeListArrayBuilder *builder,
+                                                     GError **error);
+GARROW_AVAILABLE_IN_1_0
+GArrowArrayBuilder *garrow_large_list_array_builder_get_value_builder(GArrowLargeListArrayBuilder *builder);
+
+
 #define GARROW_TYPE_STRUCT_ARRAY_BUILDER        \
   (garrow_struct_array_builder_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowStructArrayBuilder,

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -2385,6 +2385,9 @@ garrow_array_new_raw(std::shared_ptr<arrow::Array> *arrow_array)
   case arrow::Type::type::LIST:
     type = GARROW_TYPE_LIST_ARRAY;
     break;
+  case arrow::Type::type::LARGE_LIST:
+    type = GARROW_TYPE_LARGE_LIST_ARRAY;
+    break;
   case arrow::Type::type::STRUCT:
     type = GARROW_TYPE_STRUCT_ARRAY;
     break;

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -1372,6 +1372,9 @@ garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type)
   case arrow::Type::type::LIST:
     type = GARROW_TYPE_LIST_DATA_TYPE;
     break;
+  case arrow::Type::type::LARGE_LIST:
+    type = GARROW_TYPE_LARGE_LIST_DATA_TYPE;
+    break;
   case arrow::Type::type::STRUCT:
     type = GARROW_TYPE_STRUCT_DATA_TYPE;
     break;

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -245,8 +245,7 @@ garrow_large_list_array_get_value(GArrowLargeListArray *array,
   auto arrow_large_list_array =
     static_cast<arrow::LargeListArray *>(arrow_array.get());
   auto arrow_large_list =
-    arrow_large_list_array->values()->Slice(arrow_large_list_array->value_offset(i),
-                                            arrow_large_list_array->value_length(i));
+    arrow_large_list_array->value_slice(i);
   return garrow_array_new_raw(&arrow_large_list);
 }
 

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -40,6 +40,10 @@ G_BEGIN_DECLS
  * more list data. If you don't have Arrow format data, you need to
  * use #GArrowListArrayBuilder to create a new array.
  *
+ * #GArrowLargeListArray is a class for 64-bit offsets list array.
+ * It can store zero or more list data. If you don't have Arrow format data,
+ * you need to use #GArrowLargeListArrayBuilder to create a new array.
+ *
  * #GArrowStructArray is a class for struct array. It can store zero
  * or more structs. One struct has one or more fields. If you don't
  * have Arrow format data, you need to use #GArrowStructArrayBuilder
@@ -148,6 +152,102 @@ garrow_list_array_get_value(GArrowListArray *array,
     arrow_list_array->values()->Slice(arrow_list_array->value_offset(i),
                                       arrow_list_array->value_length(i));
   return garrow_array_new_raw(&arrow_list);
+}
+
+
+G_DEFINE_TYPE(GArrowLargeListArray,
+              garrow_large_list_array,
+              GARROW_TYPE_ARRAY)
+
+static void
+garrow_large_list_array_init(GArrowLargeListArray *object)
+{
+}
+
+static void
+garrow_large_list_array_class_init(GArrowLargeListArrayClass *klass)
+{
+}
+
+/**
+ * garrow_large_list_array_new:
+ * @data_type: The data type of the list.
+ * @length: The number of elements.
+ * @value_offsets: The offsets of @values in Arrow format.
+ * @values: The values as #GArrowArray.
+ * @null_bitmap: (nullable): The bitmap that shows null elements. The
+ *   N-th element is null when the N-th bit is 0, not null otherwise.
+ *   If the array has no null elements, the bitmap must be %NULL and
+ *   @n_nulls is 0.
+ * @n_nulls: The number of null elements. If -1 is specified, the
+ *   number of nulls are computed from @null_bitmap.
+ *
+ * Returns: A newly created #GArrowLargeListArray.
+ *
+ * Since: 1.0.0
+ */
+GArrowLargeListArray *
+garrow_large_list_array_new(GArrowDataType *data_type,
+                            gint64 length,
+                            GArrowBuffer *value_offsets,
+                            GArrowArray *values,
+                            GArrowBuffer *null_bitmap,
+                            gint64 n_nulls)
+{
+  const auto arrow_data_type = garrow_data_type_get_raw(data_type);
+  const auto arrow_value_offsets = garrow_buffer_get_raw(value_offsets);
+  const auto arrow_values = garrow_array_get_raw(values);
+  const auto arrow_bitmap = garrow_buffer_get_raw(null_bitmap);
+  auto arrow_large_list_array =
+    std::make_shared<arrow::LargeListArray>(arrow_data_type,
+                                            length,
+                                            arrow_value_offsets,
+                                            arrow_values,
+                                            arrow_bitmap,
+                                            n_nulls);
+  auto arrow_array =
+    std::static_pointer_cast<arrow::Array>(arrow_large_list_array);
+  return GARROW_LARGE_LIST_ARRAY(garrow_array_new_raw(&arrow_array));
+}
+
+/**
+ * garrow_large_list_array_get_value_type:
+ * @array: A #GArrowLargeListArray.
+ *
+ * Returns: (transfer full): The data type of value in each list.
+ *
+ * Since: 1.0.0
+ */
+GArrowDataType *
+garrow_large_list_array_get_value_type(GArrowLargeListArray *array)
+{
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto arrow_large_list_array =
+    static_cast<arrow::LargeListArray *>(arrow_array.get());
+  auto arrow_value_type = arrow_large_list_array->value_type();
+  return garrow_data_type_new_raw(&arrow_value_type);
+}
+
+/**
+ * garrow_large_list_array_get_value:
+ * @array: A #GArrowLargeListArray.
+ * @i: The index of the target value.
+ *
+ * Returns: (transfer full): The @i-th list.
+ *
+ * Since: 1.0.0
+ */
+GArrowArray *
+garrow_large_list_array_get_value(GArrowLargeListArray *array,
+                                  gint64 i)
+{
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto arrow_large_list_array =
+    static_cast<arrow::LargeListArray *>(arrow_array.get());
+  auto arrow_large_list =
+    arrow_large_list_array->values()->Slice(arrow_large_list_array->value_offset(i),
+                                            arrow_large_list_array->value_length(i));
+  return garrow_array_new_raw(&arrow_large_list);
 }
 
 

--- a/c_glib/arrow-glib/composite-array.h
+++ b/c_glib/arrow-glib/composite-array.h
@@ -49,6 +49,32 @@ GArrowArray *garrow_list_array_get_value(GArrowListArray *array,
                                          gint64 i);
 
 
+#define GARROW_TYPE_LARGE_LIST_ARRAY (garrow_large_list_array_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowLargeListArray,
+                         garrow_large_list_array,
+                         GARROW,
+                         LARGE_LIST_ARRAY,
+                         GArrowArray)
+struct _GArrowLargeListArrayClass
+{
+  GArrowArrayClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_1_0
+GArrowLargeListArray *garrow_large_list_array_new(GArrowDataType *data_type,
+                                                  gint64 length,
+                                                  GArrowBuffer *value_offsets,
+                                                  GArrowArray *values,
+                                                  GArrowBuffer *null_bitmap,
+                                                  gint64 n_nulls);
+
+GARROW_AVAILABLE_IN_1_0
+GArrowDataType *garrow_large_list_array_get_value_type(GArrowLargeListArray *array);
+GARROW_AVAILABLE_IN_1_0
+GArrowArray *garrow_large_list_array_get_value(GArrowLargeListArray *array,
+                                               gint64 i);
+
+
 #define GARROW_TYPE_STRUCT_ARRAY (garrow_struct_array_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowStructArray,
                          garrow_struct_array,

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -38,6 +38,8 @@ G_BEGIN_DECLS
  *
  * #GArrowListDataType is a class for list data type.
  *
+ * #GArrowLargeListDataType is a class for 64-bit offsets list data type.
+ *
  * #GArrowStructDataType is a class for struct data type.
  *
  * #GArrowUnionDataType is a base class for union data types.
@@ -115,6 +117,63 @@ garrow_list_data_type_get_field(GArrowListDataType *list_data_type)
     static_cast<arrow::ListType *>(arrow_data_type.get());
 
   auto arrow_field = arrow_list_data_type->value_field();
+  return garrow_field_new_raw(&arrow_field, nullptr);
+}
+
+
+G_DEFINE_TYPE(GArrowLargeListDataType,
+              garrow_large_list_data_type,
+              GARROW_TYPE_DATA_TYPE)
+
+static void
+garrow_large_list_data_type_init(GArrowLargeListDataType *object)
+{
+}
+
+static void
+garrow_large_list_data_type_class_init(GArrowLargeListDataTypeClass *klass)
+{
+}
+
+/**
+ * garrow_large_list_data_type_new:
+ * @field: The field of elements
+ *
+ * Returns: The newly created large list data type.
+ *
+ * Since: 1.0.0
+ */
+GArrowLargeListDataType *
+garrow_large_list_data_type_new(GArrowField *field)
+{
+  auto arrow_field = garrow_field_get_raw(field);
+  auto arrow_data_type =
+    std::make_shared<arrow::LargeListType>(arrow_field);
+
+  GArrowLargeListDataType *data_type =
+    GARROW_LARGE_LIST_DATA_TYPE(g_object_new(GARROW_TYPE_LARGE_LIST_DATA_TYPE,
+                                             "data-type", &arrow_data_type,
+                                             NULL));
+  return data_type;
+}
+
+/**
+ * garrow_large_list_data_type_get_field:
+ * @large_list_data_type: A #GArrowLargeListDataType.
+ *
+ * Returns: (transfer full): The field of value.
+ *
+ * Since: 1.0.0
+ */
+GArrowField *
+garrow_large_list_data_type_get_field(GArrowLargeListDataType *large_list_data_type)
+{
+  auto data_type = GARROW_DATA_TYPE(large_list_data_type);
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
+  auto arrow_large_list_data_type =
+    static_cast<arrow::LargeListType *>(arrow_data_type.get());
+
+  auto arrow_field = arrow_large_list_data_type->value_field();
   return garrow_field_new_raw(&arrow_field, nullptr);
 }
 

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -46,6 +46,23 @@ GARROW_AVAILABLE_IN_0_13
 GArrowField *garrow_list_data_type_get_field (GArrowListDataType *list_data_type);
 
 
+#define GARROW_TYPE_LARGE_LIST_DATA_TYPE (garrow_large_list_data_type_get_type())
+G_DECLARE_DERIVABLE_TYPE(GArrowLargeListDataType,
+                         garrow_large_list_data_type,
+                         GARROW,
+                         LARGE_LIST_DATA_TYPE,
+                         GArrowDataType)
+struct _GArrowLargeListDataTypeClass
+{
+  GArrowDataTypeClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_1_0
+GArrowLargeListDataType *garrow_large_list_data_type_new(GArrowField *field);
+GARROW_AVAILABLE_IN_1_0
+GArrowField *garrow_large_list_data_type_get_field(GArrowLargeListDataType *large_list_data_type);
+
+
 #define GARROW_TYPE_STRUCT_DATA_TYPE (garrow_struct_data_type_get_type())
 G_DECLARE_DERIVABLE_TYPE(GArrowStructDataType,
                          garrow_struct_data_type,

--- a/c_glib/arrow-glib/type.cpp
+++ b/c_glib/arrow-glib/type.cpp
@@ -88,6 +88,8 @@ garrow_type_from_raw(arrow::Type::type type)
     return GARROW_TYPE_DECIMAL;
   case arrow::Type::type::LIST:
     return GARROW_TYPE_LIST;
+  case arrow::Type::type::LARGE_LIST:
+    return GARROW_TYPE_LARGE_LIST;
   case arrow::Type::type::STRUCT:
     return GARROW_TYPE_STRUCT;
   case arrow::Type::type::UNION:

--- a/c_glib/arrow-glib/type.h
+++ b/c_glib/arrow-glib/type.h
@@ -62,6 +62,7 @@ G_BEGIN_DECLS
  *   milliseconds, microseconds or nanoseconds.
  * @GARROW_TYPE_LARGE_STRING: 64bit offsets UTF-8 variable-length string.
  * @GARROW_TYPE_LARGE_BINARY: 64bit offsets Variable-length bytes (no guarantee of UTF-8-ness).
+ * @GARROW_TYPE_LARGE_LIST: A list of some logical data type with 64-bit offsets.
  *
  * They are corresponding to `arrow::Type::type` values.
  */
@@ -98,7 +99,8 @@ typedef enum {
   GARROW_TYPE_FIXED_SIZE_LIST,
   GARROW_TYPE_DURATION,
   GARROW_TYPE_LARGE_STRING,
-  GARROW_TYPE_LARGE_BINARY
+  GARROW_TYPE_LARGE_BINARY,
+  GARROW_TYPE_LARGE_LIST
 } GArrowType;
 
 /**

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -127,6 +127,20 @@ module Helper
       builder.finish
     end
 
+    def build_large_list_array(value_data_type, values_list, field_name: "value")
+      value_field = Arrow::Field.new(field_name, value_data_type)
+      data_type = Arrow::LargeListDataType.new(value_field)
+      builder = Arrow::LargeListArrayBuilder.new(data_type)
+      values_list.each do |values|
+        if values.nil?
+          builder.append_null
+        else
+          append_to_builder(builder, values)
+        end
+      end
+      builder.finish
+    end
+
     def build_struct_array(fields, structs)
       data_type = Arrow::StructDataType.new(fields)
       builder = Arrow::StructArrayBuilder.new(data_type)
@@ -146,7 +160,7 @@ module Helper
       else
         data_type = builder.value_data_type
         case data_type
-        when Arrow::ListDataType
+        when Arrow::ListDataType, Arrow::LargeListDataType
           builder.append_value
           value_builder = builder.value_builder
           value.each do |v|

--- a/c_glib/test/test-large-list-array.rb
+++ b/c_glib/test/test-large-list-array.rb
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestLargeListArray < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def test_new
+    field = Arrow::Field.new("value", Arrow::Int64DataType.new)
+    data_type = Arrow::LargeListDataType.new(field)
+    value_offsets = Arrow::Buffer.new([0, 2, 5, 5].pack("q*"))
+    data = Arrow::Buffer.new([1, 2, 3, 4, 5].pack("q*"))
+    nulls = Arrow::Buffer.new([0b11111].pack("C*"))
+    values = Arrow::Int64Array.new(5, data, nulls, 0)
+    assert_equal(build_large_list_array(Arrow::Int64DataType.new,
+                                        [[1, 2], [3, 4, 5], nil]),
+                 Arrow::LargeListArray.new(data_type,
+                                           3,
+                                           value_offsets,
+                                           values,
+                                           Arrow::Buffer.new([0b011].pack("C*")),
+                                           -1))
+  end
+
+  def test_value
+    field = Arrow::Field.new("value", Arrow::Int64DataType.new)
+    data_type = Arrow::LargeListDataType.new(field)
+    builder = Arrow::LargeListArrayBuilder.new(data_type)
+    value_builder = builder.value_builder
+
+    builder.append_value
+    value_builder.append_value(-29)
+    value_builder.append_value(29)
+
+    builder.append_value
+    value_builder.append_value(-1)
+    value_builder.append_value(0)
+    value_builder.append_value(1)
+
+    array = builder.finish
+    value = array.get_value(1)
+    assert_equal([-1, 0, 1],
+                 value.length.times.collect {|i| value.get_value(i)})
+  end
+
+  def test_value_type
+    field = Arrow::Field.new("value", Arrow::Int64DataType.new)
+    data_type = Arrow::LargeListDataType.new(field)
+    builder = Arrow::LargeListArrayBuilder.new(data_type)
+    array = builder.finish
+    assert_equal(Arrow::Int64DataType.new, array.value_type)
+  end
+end

--- a/c_glib/test/test-large-list-data-type.rb
+++ b/c_glib/test/test-large-list-data-type.rb
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestLargeListDataType < Test::Unit::TestCase
+  def setup
+    @field_data_type = Arrow::BooleanDataType.new
+    @field = Arrow::Field.new("enabled", @field_data_type)
+    @data_type = Arrow::LargeListDataType.new(@field)
+  end
+
+  def test_type
+    assert_equal(Arrow::Type::LARGE_LIST, @data_type.id)
+  end
+
+  def test_to_s
+    assert_equal("large_list<enabled: bool>", @data_type.to_s)
+  end
+
+  def test_field
+    assert_equal([
+                   @field,
+                   @field_data_type,
+                 ],
+                 [
+                   @data_type.field,
+                   @data_type.field.data_type,
+                 ])
+  end
+end


### PR DESCRIPTION
This PR add support for `GArrowLargeListArrayBuilder`, `GArrowLargeListArray`, and `GArrowLargeListDataType`.