### PR TITLE
ARROW-6749: [Python] Let Array.to_numpy use general conversion code with zero_copy_only=True

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1964,15 +1964,18 @@ class ArrowDeserializer {
                               std::is_base_of<DurationType, Type>::value,
                           Status>::type
   Visit(const Type& type) {
-    if (options_.zero_copy_only) {
-      return Status::Invalid("Copy Needed, but zero_copy_only was True");
-    }
-
     constexpr int TYPE = Type::type_id;
     using traits = internal::arrow_traits<TYPE>;
     using c_type = typename Type::c_type;
 
     typedef typename traits::T T;
+
+    if (data_->num_chunks() == 1 && data_->null_count() == 0) {
+      return ConvertValuesZeroCopy<TYPE>(options_, traits::npy_type, data_->chunk(0));
+    }
+    else if (options_.zero_copy_only) {
+      return Status::Invalid("Copy Needed, but zero_copy_only was True");
+    }
 
     RETURN_NOT_OK(AllocateOutput(traits::npy_type));
     auto out_values = reinterpret_cast<T*>(PyArray_DATA(arr_));

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1972,8 +1972,7 @@ class ArrowDeserializer {
 
     if (data_->num_chunks() == 1 && data_->null_count() == 0) {
       return ConvertValuesZeroCopy<TYPE>(options_, traits::npy_type, data_->chunk(0));
-    }
-    else if (options_.zero_copy_only) {
+    } else if (options_.zero_copy_only) {
       return Status::Invalid("Copy Needed, but zero_copy_only was True");
     }
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -951,34 +951,43 @@ cdef class Array(_PandasConvertible):
             return values
         return values.astype(dtype)
 
-    def to_numpy(self):
+    def to_numpy(self, zero_copy_only=True, writable=False):
         """
         Experimental: return a NumPy view of this array. Only primitive
         arrays with the same memory layout as NumPy (i.e. integers,
         floating point), without any nulls, are supported.
 
+        Parameters
+        ----------
+        zero_copy_only : bool, default True
+            If True, an exception will be raised if the conversion to a numpy
+            array would require copying the underlying data (e.g. in presence
+            of nulls, or for non-primitive types).
+        writable : bool, default False
+            For numpy arrays created with zero copy (view on the Arrow data),
+            the resulting array is not writable (Arrow data is immutable).
+            By setting this to True, a copy of the array is made to ensure
+            it is writable.
+
         Returns
         -------
         array : numpy.ndarray
         """
-        if self.null_count:
-            raise NotImplementedError('NumPy array view is only supported '
-                                      'for arrays without nulls.')
-        if not is_primitive(self.type.id) or self.type.id == _Type_BOOL:
-            raise NotImplementedError('NumPy array view is only supported '
-                                      'for primitive types.')
-
         cdef:
             PyObject* out
             PandasOptions c_options
             object values
 
-        c_options.zero_copy_only = True
+        c_options.zero_copy_only = zero_copy_only
 
         with nogil:
             check_status(ConvertArrayToPandas(c_options, self.sp_array,
                                               self, &out))
-        return PyObject_to_object(out)
+        array = PyObject_to_object(out)
+        if writable and not array.flags["WRITEABLE"]:
+            # if the conversion already needed to a copy, WRITEABLE is True
+            array = array.copy()
+        return array
 
     def to_pylist(self):
         """

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -145,6 +145,22 @@ def test_to_numpy_unsupported_types():
         null_arr.to_numpy()
 
 
+@pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
+def test_to_numpy_datetime64(unit):
+    arr = pa.array([1, 2, 3], pa.timestamp(unit))
+    expected = np.array([1, 2, 3], dtype="datetime64[{}]".format(unit))
+    np_arr = arr.to_numpy()
+    np.testing.assert_array_equal(np_arr, expected)
+
+
+@pytest.mark.parametrize('unit', ['s', 'ms', 'us', 'ns'])
+def test_to_numpy_timedelta64(unit):
+    arr = pa.array([1, 2, 3], pa.duration(unit))
+    expected = np.array([1, 2, 3], dtype="timedelta64[{}]".format(unit))
+    np_arr = arr.to_numpy()
+    np.testing.assert_array_equal(np_arr, expected)
+
+
 @pytest.mark.pandas
 def test_to_pandas_zero_copy():
     import gc

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2184,6 +2184,16 @@ class TestZeroCopyConversion(object):
         tm.assert_series_equal(pd.Series(result), pd.Series(values),
                                check_names=False)
 
+    def test_zero_copy_timestamp(self):
+        arr = np.array(['2007-07-13'], dtype='datetime64[ns]')
+        result = pa.array(arr).to_pandas(zero_copy_only=True)
+        npt.assert_array_equal(result, arr)
+
+    def test_zero_copy_duration(self):
+        arr = np.array([1], dtype='timedelta64[ns]')
+        result = pa.array(arr).to_pandas(zero_copy_only=True)
+        npt.assert_array_equal(result, arr)
+
     def check_zero_copy_failure(self, arr):
         with pytest.raises(pa.ArrowInvalid):
             arr.to_pandas(zero_copy_only=True)
@@ -2204,12 +2214,12 @@ class TestZeroCopyConversion(object):
         arr = pa.array([[1, 2], [8, 9]], type=pa.list_(pa.int64()))
         self.check_zero_copy_failure(arr)
 
-    def test_zero_copy_failure_on_timestamp_types(self):
-        arr = np.array(['2007-07-13'], dtype='datetime64[ns]')
+    def test_zero_copy_failure_on_timestamp_with_nulls(self):
+        arr = np.array([1, None], dtype='datetime64[ns]')
         self.check_zero_copy_failure(pa.array(arr))
 
-    def test_zero_copy_failure_on_duration_types(self):
-        arr = np.array([1], dtype='timedelta64[ns]')
+    def test_zero_copy_failure_on_duration_with_nulls(self):
+        arr = np.array([1, None], dtype='timedelta64[ns]')
         self.check_zero_copy_failure(pa.array(arr))
 
 


### PR DESCRIPTION
`Array.to_numpy` converts to a numpy array zero-copy. It currently does that with a custom `np.frombuffer` (although with a bug for timestamp data, which was the original report in [ARROW-6749](https://issues.apache.org/jira/browse/ARROW-6749)), while we also have the `zero_copy_only` guarantee in the arrow->python conversion code. So here I try to switch to that.

- I added a zero_copy conversion for Timestamp/Duration. I *think* this can correctly be done since the memory layout for the actual values is identical with numpy (not sure if there is a specific reason it was not done before)
- One consequence of using the conversion code is that the resulting numpy array is non-writable. While the current `to_numpy` created a writable array (and the tests actually used this property to check the zero-copy assumption, which is why tests are now failing). Are we OK with that restriction?