### PR TITLE
ARROW-6964: [C++][Dataset] Add multithread support to Scanner::ToTable

### DIFF
--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -125,8 +125,14 @@ TEST_F(TestSimpleScanner, ToTable) {
 
   auto scanner = std::make_shared<SimpleScanner>(sources, options_, ctx_);
   std::shared_ptr<Table> actual;
-  ASSERT_OK(scanner->ToTable(&actual));
 
+  ASSERT_OK(scanner->ToTable(&actual));
+  AssertTablesEqual(*expected, *actual);
+
+  // There is no guarantee on the ordering when using multiple threads, but
+  // since the RecordBatch is always the same it will pass.
+  options_->use_threads = true;
+  ASSERT_OK(scanner->ToTable(&actual));
   AssertTablesEqual(*expected, *actual);
 }
 


### PR DESCRIPTION
The caller may request a parallel construction of the table. Scanner was refactored to own the ScanOptions and ScanContext members.