### PR TITLE
ARROW-6944: [Rust] Add String, FixedSizeBinary types

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -48,6 +48,7 @@ lazy_static = "1.2"
 packed_simd = { version = "0.3.1", optional = true }
 chrono = "0.4"
 flatbuffers = "0.6.0"
+hex = "0.4"
 
 [features]
 simd = ["packed_simd"]

--- a/rust/arrow/benches/csv_writer.rs
+++ b/rust/arrow/benches/csv_writer.rs
@@ -35,7 +35,7 @@ fn record_batches_to_csv() {
         Field::new("c3", DataType::Boolean, true),
     ]);
 
-    let c1 = BinaryArray::from(vec![
+    let c1 = StringArray::from(vec![
         "Lorem ipsum dolor sit amet",
         "consectetur adipiscing elit",
         "sed do eiusmod tempor",

--- a/rust/arrow/examples/builders.rs
+++ b/rust/arrow/examples/builders.rs
@@ -21,8 +21,8 @@ extern crate arrow;
 use std::sync::Arc;
 
 use arrow::array::{
-    Array, ArrayData, BinaryArray, BooleanArray, Int32Array, Int32Builder, ListArray,
-    PrimitiveArray, StructArray,
+    Array, ArrayData, BooleanArray, Int32Array, Int32Builder, ListArray, PrimitiveArray,
+    StringArray, StructArray,
 };
 use arrow::buffer::Buffer;
 use arrow::datatypes::{DataType, Date64Type, Field, Time64NanosecondType, ToByteSlice};
@@ -83,7 +83,7 @@ fn main() {
         .add_buffer(Buffer::from(&values[..]))
         .null_bit_buffer(Buffer::from([0b00000101]))
         .build();
-    let binary_array = BinaryArray::from(array_data);
+    let binary_array = StringArray::from(array_data);
     println!("{:?}", binary_array);
 
     // ListArrays are similar to ByteArrays: they are arrays of other

--- a/rust/arrow/examples/dynamic_types.rs
+++ b/rust/arrow/examples/dynamic_types.rs
@@ -46,7 +46,7 @@ fn main() -> Result<()> {
     let nested = StructArray::from(vec![
         (
             Field::new("a", DataType::Utf8, false),
-            Arc::new(BinaryArray::from(vec!["a", "b", "c", "d", "e"])) as Arc<dyn Array>,
+            Arc::new(StringArray::from(vec!["a", "b", "c", "d", "e"])) as Arc<dyn Array>,
         ),
         (
             Field::new("b", DataType::Float64, false),

--- a/rust/arrow/examples/read_csv.rs
+++ b/rust/arrow/examples/read_csv.rs
@@ -59,11 +59,9 @@ fn main() {
         .unwrap();
 
     for i in 0..batch.num_rows() {
-        let city_name: String = String::from_utf8(city.value(i).to_vec()).unwrap();
-
         println!(
             "City: {}, Latitude: {}, Longitude: {}",
-            city_name,
+            city.value(i),
             lat.value(i),
             lng.value(i)
         );

--- a/rust/arrow/examples/read_csv.rs
+++ b/rust/arrow/examples/read_csv.rs
@@ -20,7 +20,7 @@ extern crate arrow;
 use std::fs::File;
 use std::sync::Arc;
 
-use arrow::array::{BinaryArray, Float64Array};
+use arrow::array::{Float64Array, StringArray};
 use arrow::csv;
 use arrow::datatypes::{DataType, Field, Schema};
 
@@ -45,7 +45,7 @@ fn main() {
     let city = batch
         .column(0)
         .as_any()
-        .downcast_ref::<BinaryArray>()
+        .downcast_ref::<StringArray>()
         .unwrap();
     let lat = batch
         .column(1)

--- a/rust/arrow/examples/read_csv_infer_schema.rs
+++ b/rust/arrow/examples/read_csv_infer_schema.rs
@@ -17,7 +17,7 @@
 
 extern crate arrow;
 
-use arrow::array::{BinaryArray, Float64Array};
+use arrow::array::{Float64Array, StringArray};
 use arrow::csv;
 use std::fs::File;
 
@@ -40,7 +40,7 @@ fn main() {
     let city = batch
         .column(0)
         .as_any()
-        .downcast_ref::<BinaryArray>()
+        .downcast_ref::<StringArray>()
         .unwrap();
     let lat = batch
         .column(1)

--- a/rust/arrow/examples/read_csv_infer_schema.rs
+++ b/rust/arrow/examples/read_csv_infer_schema.rs
@@ -54,11 +54,9 @@ fn main() {
         .unwrap();
 
     for i in 0..batch.num_rows() {
-        let city_name: String = String::from_utf8(city.value(i).to_vec()).unwrap();
-
         println!(
             "City: {}, Latitude: {}, Longitude: {}",
-            city_name,
+            city.value(i),
             lat.value(i),
             lng.value(i)
         );

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -499,7 +499,7 @@ impl PrimitiveArray<BooleanType> {
 
     /// Returns the boolean value at index `i`.
     pub fn value(&self, i: usize) -> bool {
-        assert!(i + self.offset() < self.data.len());
+        assert!(i < self.data.len());
         let offset = i + self.offset();
         unsafe { bit_util::get_bit_raw(self.raw_values.get() as *const u8, offset) }
     }
@@ -1145,6 +1145,10 @@ impl From<ArrayDataRef> for BinaryArray {
             "BinaryArray data should contain 2 buffers only (offsets and values)"
         );
         let raw_value_offsets = data.buffers()[0].raw_data();
+        assert!(
+            memory::is_aligned(raw_value_offsets, mem::align_of::<i32>()),
+            "memory is not aligned"
+        );
         let value_data = data.buffers()[1].raw_data();
         Self {
             data: data.clone(),
@@ -1162,6 +1166,10 @@ impl From<ArrayDataRef> for StringArray {
             "StringArray data should contain 2 buffers only (offsets and values)"
         );
         let raw_value_offsets = data.buffers()[0].raw_data();
+        assert!(
+            memory::is_aligned(raw_value_offsets, mem::align_of::<i32>()),
+            "memory is not aligned"
+        );
         let value_data = data.buffers()[1].raw_data();
         Self {
             data: data.clone(),
@@ -2669,7 +2677,7 @@ mod tests {
 
         let values: [u8; 12] = [0; 12];
 
-        let array_data = ArrayData::builder(DataType::Utf8)
+        let array_data = ArrayData::builder(DataType::Binary)
             .add_buffer(buf2)
             .add_buffer(Buffer::from(&values[..]))
             .build();

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -921,7 +921,7 @@ impl JsonEqual for StringArray {
         }
 
         (0..self.len()).all(|i| match json[i] {
-            JString(s) => self.is_valid(i) && s.as_str().as_bytes() == self.value(i),
+            JString(s) => self.is_valid(i) && s.as_str() == self.value(i),
             JNull => self.is_null(i),
             _ => false,
         })
@@ -1965,7 +1965,7 @@ mod tests {
         let string_builder = builder.field_builder::<StringBuilder>(0).unwrap();
         for v in first.as_ref() {
             if let Some(s) = v {
-                string_builder.append_string(s)?;
+                string_builder.append_value(s)?;
             } else {
                 string_builder.append_null()?;
             }

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -18,6 +18,7 @@
 use super::*;
 use crate::datatypes::*;
 use crate::util::bit_util;
+use hex::FromHex;
 use serde_json::value::Value::{Null as JNull, Object, String as JString};
 use serde_json::Value;
 
@@ -381,6 +382,220 @@ impl ArrayEqual for BinaryArray {
     }
 }
 
+impl ArrayEqual for StringArray {
+    fn equals(&self, other: &dyn Array) -> bool {
+        if !base_equal(&self.data(), &other.data()) {
+            return false;
+        }
+
+        let other = other.as_any().downcast_ref::<StringArray>().unwrap();
+
+        if !value_offset_equal(self, other) {
+            return false;
+        }
+
+        // TODO: handle null & length == 0 case?
+
+        let value_buf = self.value_data();
+        let other_value_buf = other.value_data();
+        let value_data = value_buf.data();
+        let other_value_data = other_value_buf.data();
+
+        if self.null_count() == 0 {
+            // No offset in both - just do memcmp
+            if self.offset() == 0 && other.offset() == 0 {
+                let len = self.value_offset(self.len()) as usize;
+                return value_data[..len] == other_value_data[..len];
+            } else {
+                let start = self.value_offset(0) as usize;
+                let other_start = other.value_offset(0) as usize;
+                let len = (self.value_offset(self.len()) - self.value_offset(0)) as usize;
+                return value_data[start..(start + len)]
+                    == other_value_data[other_start..(other_start + len)];
+            }
+        } else {
+            for i in 0..self.len() {
+                if self.is_null(i) {
+                    continue;
+                }
+
+                let start = self.value_offset(i) as usize;
+                let other_start = other.value_offset(i) as usize;
+                let len = self.value_length(i) as usize;
+                if value_data[start..(start + len)]
+                    != other_value_data[other_start..(other_start + len)]
+                {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn range_equals(
+        &self,
+        other: &dyn Array,
+        start_idx: usize,
+        end_idx: usize,
+        other_start_idx: usize,
+    ) -> bool {
+        assert!(other_start_idx + (end_idx - start_idx) <= other.len());
+        let other = other.as_any().downcast_ref::<StringArray>().unwrap();
+
+        let mut j = other_start_idx;
+        for i in start_idx..end_idx {
+            let is_null = self.is_null(i);
+            let other_is_null = other.is_null(j);
+
+            if is_null != other_is_null {
+                return false;
+            }
+
+            if is_null {
+                continue;
+            }
+
+            let start_offset = self.value_offset(i) as usize;
+            let end_offset = self.value_offset(i + 1) as usize;
+            let other_start_offset = other.value_offset(j) as usize;
+            let other_end_offset = other.value_offset(j + 1) as usize;
+
+            if end_offset - start_offset != other_end_offset - other_start_offset {
+                return false;
+            }
+
+            let value_buf = self.value_data();
+            let other_value_buf = other.value_data();
+            let value_data = value_buf.data();
+            let other_value_data = other_value_buf.data();
+
+            if end_offset - start_offset > 0 {
+                let len = end_offset - start_offset;
+                if value_data[start_offset..(start_offset + len)]
+                    != other_value_data[other_start_offset..(other_start_offset + len)]
+                {
+                    return false;
+                }
+            }
+
+            j += 1;
+        }
+
+        true
+    }
+}
+
+impl ArrayEqual for FixedSizeBinaryArray {
+    fn equals(&self, other: &dyn Array) -> bool {
+        if !base_equal(&self.data(), &other.data()) {
+            return false;
+        }
+
+        let other = other
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+
+        if !value_offset_equal(self, other) {
+            return false;
+        }
+
+        // TODO: handle null & length == 0 case?
+
+        let value_buf = self.value_data();
+        let other_value_buf = other.value_data();
+        let value_data = value_buf.data();
+        let other_value_data = other_value_buf.data();
+
+        if self.null_count() == 0 {
+            // No offset in both - just do memcmp
+            if self.offset() == 0 && other.offset() == 0 {
+                let len = self.value_offset(self.len()) as usize;
+                return value_data[..len] == other_value_data[..len];
+            } else {
+                let start = self.value_offset(0) as usize;
+                let other_start = other.value_offset(0) as usize;
+                let len = (self.value_offset(self.len()) - self.value_offset(0)) as usize;
+                return value_data[start..(start + len)]
+                    == other_value_data[other_start..(other_start + len)];
+            }
+        } else {
+            for i in 0..self.len() {
+                if self.is_null(i) {
+                    continue;
+                }
+
+                let start = self.value_offset(i) as usize;
+                let other_start = other.value_offset(i) as usize;
+                let len = self.value_length() as usize;
+                if value_data[start..(start + len)]
+                    != other_value_data[other_start..(other_start + len)]
+                {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    fn range_equals(
+        &self,
+        other: &dyn Array,
+        start_idx: usize,
+        end_idx: usize,
+        other_start_idx: usize,
+    ) -> bool {
+        assert!(other_start_idx + (end_idx - start_idx) <= other.len());
+        let other = other
+            .as_any()
+            .downcast_ref::<FixedSizeBinaryArray>()
+            .unwrap();
+
+        let mut j = other_start_idx;
+        for i in start_idx..end_idx {
+            let is_null = self.is_null(i);
+            let other_is_null = other.is_null(j);
+
+            if is_null != other_is_null {
+                return false;
+            }
+
+            if is_null {
+                continue;
+            }
+
+            let start_offset = self.value_offset(i) as usize;
+            let end_offset = self.value_offset(i + 1) as usize;
+            let other_start_offset = other.value_offset(j) as usize;
+            let other_end_offset = other.value_offset(j + 1) as usize;
+
+            if end_offset - start_offset != other_end_offset - other_start_offset {
+                return false;
+            }
+
+            let value_buf = self.value_data();
+            let other_value_buf = other.value_data();
+            let value_data = value_buf.data();
+            let other_value_data = other_value_buf.data();
+
+            if end_offset - start_offset > 0 {
+                let len = end_offset - start_offset;
+                if value_data[start_offset..(start_offset + len)]
+                    != other_value_data[other_start_offset..(other_start_offset + len)]
+                {
+                    return false;
+                }
+            }
+
+            j += 1;
+        }
+
+        true
+    }
+}
+
 impl ArrayEqual for StructArray {
     fn equals(&self, other: &dyn Array) -> bool {
         if !base_equal(&self.data(), &other.data()) {
@@ -668,7 +883,10 @@ impl JsonEqual for BinaryArray {
         }
 
         (0..self.len()).all(|i| match json[i] {
-            JString(s) => self.is_valid(i) && s.as_str().as_bytes() == self.value(i),
+            JString(s) => {
+                self.is_valid(i)
+                    && Vec::from_hex(s.as_str()) == Ok(self.value(i).to_vec())
+            }
             JNull => self.is_null(i),
             _ => false,
         })
@@ -686,6 +904,73 @@ impl PartialEq<Value> for BinaryArray {
 
 impl PartialEq<BinaryArray> for Value {
     fn eq(&self, arrow: &BinaryArray) -> bool {
+        match self {
+            Value::Array(json_array) => arrow.equals_json_values(&json_array),
+            _ => false,
+        }
+    }
+}
+
+impl JsonEqual for StringArray {
+    fn equals_json(&self, json: &[&Value]) -> bool {
+        if self.len() != json.len() {
+            return false;
+        }
+
+        (0..self.len()).all(|i| match json[i] {
+            JString(s) => self.is_valid(i) && s.as_str().as_bytes() == self.value(i),
+            JNull => self.is_null(i),
+            _ => false,
+        })
+    }
+}
+
+impl PartialEq<Value> for StringArray {
+    fn eq(&self, json: &Value) -> bool {
+        match json {
+            Value::Array(json_array) => self.equals_json_values(&json_array),
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<StringArray> for Value {
+    fn eq(&self, arrow: &StringArray) -> bool {
+        match self {
+            Value::Array(json_array) => arrow.equals_json_values(&json_array),
+            _ => false,
+        }
+    }
+}
+
+impl JsonEqual for FixedSizeBinaryArray {
+    fn equals_json(&self, json: &[&Value]) -> bool {
+        if self.len() != json.len() {
+            return false;
+        }
+
+        (0..self.len()).all(|i| match json[i] {
+            JString(s) => {
+                self.is_valid(i)
+                    && Vec::from_hex(s.as_str()) == Ok(self.value(i).to_vec())
+            }
+            JNull => self.is_null(i),
+            _ => false,
+        })
+    }
+}
+
+impl PartialEq<Value> for FixedSizeBinaryArray {
+    fn eq(&self, json: &Value) -> bool {
+        match json {
+            Value::Array(json_array) => self.equals_json_values(&json_array),
+            _ => false,
+        }
+    }
+}
+
+impl PartialEq<FixedSizeBinaryArray> for Value {
+    fn eq(&self, arrow: &FixedSizeBinaryArray) -> bool {
         match self {
             Value::Array(json_array) => arrow.equals_json_values(&json_array),
             _ => false,
@@ -937,19 +1222,19 @@ mod tests {
     }
 
     #[test]
-    fn test_binary_equal() {
-        let a = BinaryArray::from(vec!["hello", "world"]);
-        let b = BinaryArray::from(vec!["hello", "world"]);
+    fn test_string_equal() {
+        let a = StringArray::from(vec!["hello", "world"]);
+        let b = StringArray::from(vec!["hello", "world"]);
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        let b = BinaryArray::from(vec!["hello", "arrow"]);
+        let b = StringArray::from(vec!["hello", "arrow"]);
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
         // Test the case where null_count > 0
 
-        let a = BinaryArray::try_from(vec![
+        let a = StringArray::try_from(vec![
             Some("hello"),
             None,
             None,
@@ -959,7 +1244,7 @@ mod tests {
         ])
         .unwrap();
 
-        let b = BinaryArray::try_from(vec![
+        let b = StringArray::try_from(vec![
             Some("hello"),
             None,
             None,
@@ -971,7 +1256,7 @@ mod tests {
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        let b = BinaryArray::try_from(vec![
+        let b = StringArray::try_from(vec![
             Some("hello"),
             Some("foo"),
             None,
@@ -983,7 +1268,7 @@ mod tests {
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
-        let b = BinaryArray::try_from(vec![
+        let b = StringArray::try_from(vec![
             Some("hello"),
             None,
             None,
@@ -1015,7 +1300,7 @@ mod tests {
 
     #[test]
     fn test_struct_equal() {
-        let string_builder = BinaryBuilder::new(5);
+        let string_builder = StringBuilder::new(5);
         let int_builder = Int32Builder::new(5);
 
         let mut fields = Vec::new();
@@ -1252,9 +1537,9 @@ mod tests {
     }
 
     #[test]
-    fn test_binary_json_equal() {
+    fn test_string_json_equal() {
         // Test the equal case
-        let arrow_array = BinaryArray::try_from(vec![
+        let arrow_array = StringArray::try_from(vec![
             Some("hello"),
             None,
             None,
@@ -1280,7 +1565,7 @@ mod tests {
         assert!(json_array.eq(&arrow_array));
 
         // Test unequal case
-        let arrow_array = BinaryArray::try_from(vec![
+        let arrow_array = StringArray::try_from(vec![
             Some("hello"),
             None,
             None,
@@ -1307,7 +1592,7 @@ mod tests {
 
         // Test unequal length case
         let arrow_array =
-            BinaryArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
+            StringArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
                 .unwrap();
         let json_array: Value = serde_json::from_str(
             r#"
@@ -1327,7 +1612,7 @@ mod tests {
 
         // Test incorrect type case
         let arrow_array =
-            BinaryArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
+            StringArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
                 .unwrap();
         let json_array: Value = serde_json::from_str(
             r#"
@@ -1342,7 +1627,7 @@ mod tests {
 
         // Test incorrect value type case
         let arrow_array =
-            BinaryArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
+            StringArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
                 .unwrap();
         let json_array: Value = serde_json::from_str(
             r#"
@@ -1364,7 +1649,7 @@ mod tests {
     #[test]
     fn test_struct_json_equal() {
         // Test equal case
-        let string_builder = BinaryBuilder::new(5);
+        let string_builder = StringBuilder::new(5);
         let int_builder = Int32Builder::new(5);
 
         let mut fields = Vec::new();
@@ -1479,7 +1764,7 @@ mod tests {
         second: U,
         is_valid: V,
     ) -> Result<StructArray> {
-        let string_builder = builder.field_builder::<BinaryBuilder>(0).unwrap();
+        let string_builder = builder.field_builder::<StringBuilder>(0).unwrap();
         for v in first.as_ref() {
             if let Some(s) = v {
                 string_builder.append_string(s)?;

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -70,9 +70,11 @@ pub use self::data::ArrayDataBuilder;
 pub use self::data::ArrayDataRef;
 
 pub use self::array::BinaryArray;
+pub use self::array::FixedSizeBinaryArray;
 pub use self::array::FixedSizeListArray;
 pub use self::array::ListArray;
 pub use self::array::PrimitiveArray;
+pub use self::array::StringArray;
 pub use self::array::StructArray;
 
 pub(crate) use self::array::make_array;
@@ -134,9 +136,11 @@ pub type Time64NanosecondBufferBuilder = BufferBuilder<Time64NanosecondType>;
 
 pub use self::builder::ArrayBuilder;
 pub use self::builder::BinaryBuilder;
+pub use self::builder::FixedSizeBinaryBuilder;
 pub use self::builder::FixedSizeListBuilder;
 pub use self::builder::ListBuilder;
 pub use self::builder::PrimitiveBuilder;
+pub use self::builder::StringBuilder;
 pub use self::builder::StructBuilder;
 
 pub type BooleanBuilder = PrimitiveBuilder<BooleanType>;

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -161,7 +161,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
                     if array.is_null(i) {
                         b.append(false)?;
                     } else {
-                        b.append_string(match from.value(i) {
+                        b.append_value(match from.value(i) {
                             true => "1",
                             false => "0",
                         })?;
@@ -634,7 +634,7 @@ where
         if from.is_null(i) {
             b.append(false)?;
         } else {
-            b.append_string(from.value(i).to_string().as_str())?;
+            b.append_value(&from.value(i).to_string())?;
         }
     }
 
@@ -664,10 +664,7 @@ where
         if from.is_null(i) {
             b.append_null()?;
         } else {
-            match std::str::from_utf8(from.value(i))
-                .unwrap_or("")
-                .parse::<T::Native>()
-            {
+            match from.value(i).parse::<T::Native>() {
                 Ok(v) => b.append_value(v)?,
                 _ => b.append_null()?,
             };

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -156,7 +156,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
             Float64 => cast_bool_to_numeric::<Float64Type>(array),
             Utf8 => {
                 let from = array.as_any().downcast_ref::<BooleanArray>().unwrap();
-                let mut b = BinaryBuilder::new(array.len());
+                let mut b = StringBuilder::new(array.len());
                 for i in 0..array.len() {
                     if array.is_null(i) {
                         b.append(false)?;
@@ -623,12 +623,12 @@ where
     }
 }
 
-fn numeric_to_string_cast<T>(from: &PrimitiveArray<T>) -> Result<BinaryArray>
+fn numeric_to_string_cast<T>(from: &PrimitiveArray<T>) -> Result<StringArray>
 where
     T: ArrowPrimitiveType + ArrowNumericType,
     T::Native: ::std::string::ToString,
 {
-    let mut b = BinaryBuilder::new(from.len());
+    let mut b = StringBuilder::new(from.len());
 
     for i in 0..from.len() {
         if from.is_null(i) {
@@ -647,17 +647,16 @@ where
     TO: ArrowNumericType,
 {
     match string_to_numeric_cast::<TO>(
-        from.as_any().downcast_ref::<BinaryArray>().unwrap(),
+        from.as_any().downcast_ref::<StringArray>().unwrap(),
     ) {
         Ok(to) => Ok(Arc::new(to) as ArrayRef),
         Err(e) => Err(e),
     }
 }
 
-fn string_to_numeric_cast<T>(from: &BinaryArray) -> Result<PrimitiveArray<T>>
+fn string_to_numeric_cast<T>(from: &StringArray) -> Result<PrimitiveArray<T>>
 where
     T: ArrowNumericType,
-    // T::Native: ::std::string::ToString,
 {
     let mut b = PrimitiveBuilder::<T>::new(from.len());
 
@@ -901,8 +900,8 @@ mod tests {
     }
 
     #[test]
-    fn test_cast_utf_to_i32() {
-        let a = BinaryArray::from(vec!["5", "6", "seven", "8", "9.1"]);
+    fn test_cast_utf8_to_i32() {
+        let a = StringArray::from(vec!["5", "6", "seven", "8", "9.1"]);
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Int32).unwrap();
         let c = b.as_any().downcast_ref::<Int32Array>().unwrap();

--- a/rust/arrow/src/compute/kernels/limit.rs
+++ b/rust/arrow/src/compute/kernels/limit.rs
@@ -53,13 +53,13 @@ mod tests {
     }
 
     #[test]
-    fn test_limit_binary_array() {
-        let a: ArrayRef = Arc::new(BinaryArray::from(vec!["hello", " ", "world", "!"]));
+    fn test_limit_string_array() {
+        let a: ArrayRef = Arc::new(StringArray::from(vec!["hello", " ", "world", "!"]));
         let b = limit(&a, 2).unwrap();
-        let c = b.as_ref().as_any().downcast_ref::<BinaryArray>().unwrap();
+        let c = b.as_ref().as_any().downcast_ref::<StringArray>().unwrap();
         assert_eq!(2, c.len());
-        assert_eq!("hello", c.get_string(0));
-        assert_eq!(" ", c.get_string(1));
+        assert_eq!("hello", c.value(0));
+        assert_eq!(" ", c.value(1));
     }
 
     #[test]

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -321,19 +321,19 @@ mod tests {
     fn test_take_string() {
         let index = UInt32Array::from(vec![Some(3), None, Some(1), Some(3), Some(4)]);
         let mut builder: StringBuilder = StringBuilder::new(6);
-        builder.append_string("one").unwrap();
+        builder.append_value("one").unwrap();
         builder.append_null().unwrap();
-        builder.append_string("three").unwrap();
-        builder.append_string("four").unwrap();
-        builder.append_string("five").unwrap();
+        builder.append_value("three").unwrap();
+        builder.append_value("four").unwrap();
+        builder.append_value("five").unwrap();
         let array = Arc::new(builder.finish()) as ArrayRef;
         let a = take(&array, &index, None).unwrap();
         assert_eq!(a.len(), index.len());
-        builder.append_string("four").unwrap();
+        builder.append_value("four").unwrap();
         builder.append_null().unwrap();
         builder.append_null().unwrap();
-        builder.append_string("four").unwrap();
-        builder.append_string("five").unwrap();
+        builder.append_value("four").unwrap();
+        builder.append_value("five").unwrap();
         let b = builder.finish();
         assert_eq!(a.data(), b.data());
     }

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -88,7 +88,7 @@ pub fn take(
         DataType::Timestamp(Nanosecond) => {
             take_primitive::<TimestampNanosecondType>(values, indices)
         }
-        DataType::Utf8 => take_binary(values, indices),
+        DataType::Utf8 => take_string(values, indices),
         DataType::List(_) => take_list(values, indices),
         DataType::Struct(fields) => {
             let struct_: &StructArray =
@@ -156,10 +156,10 @@ where
     Ok(Arc::new(builder.finish()) as ArrayRef)
 }
 
-/// `take` implementation for binary arrays
-fn take_binary(values: &ArrayRef, indices: &UInt32Array) -> Result<ArrayRef> {
-    let mut builder = BinaryBuilder::new(indices.len());
-    let a = values.as_any().downcast_ref::<BinaryArray>().unwrap();
+/// `take` implementation for string arrays
+fn take_string(values: &ArrayRef, indices: &UInt32Array) -> Result<ArrayRef> {
+    let mut builder = StringBuilder::new(indices.len());
+    let a = values.as_any().downcast_ref::<StringArray>().unwrap();
     for i in 0..indices.len() {
         if indices.is_null(i) {
             builder.append(false)?;
@@ -318,9 +318,9 @@ mod tests {
     }
 
     #[test]
-    fn test_take_binary() {
+    fn test_take_string() {
         let index = UInt32Array::from(vec![Some(3), None, Some(1), Some(3), Some(4)]);
-        let mut builder: BinaryBuilder = BinaryBuilder::new(6);
+        let mut builder: StringBuilder = StringBuilder::new(6);
         builder.append_string("one").unwrap();
         builder.append_null().unwrap();
         builder.append_string("three").unwrap();

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -324,7 +324,7 @@ impl<R: Read> Reader<R> {
                         let mut builder = StringBuilder::new(rows.len());
                         for row_index in 0..rows.len() {
                             match rows[row_index].get(*i) {
-                                Some(s) => builder.append_string(s).unwrap(),
+                                Some(s) => builder.append_value(s).unwrap(),
                                 _ => builder.append(false).unwrap(),
                             }
                         }
@@ -571,9 +571,7 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
 
-        let city_name: String = String::from_utf8(city.value(13).to_vec()).unwrap();
-
-        assert_eq!("Aberdeen, Aberdeen City, UK", city_name);
+        assert_eq!("Aberdeen, Aberdeen City, UK", city.value(13));
     }
 
     #[test]
@@ -634,9 +632,7 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
 
-        let city_name: String = String::from_utf8(city.value(13).to_vec()).unwrap();
-
-        assert_eq!("Aberdeen, Aberdeen City, UK", city_name);
+        assert_eq!("Aberdeen, Aberdeen City, UK", city.value(13));
     }
 
     #[test]
@@ -674,9 +670,7 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
 
-        let city_name: String = String::from_utf8(city.value(13).to_vec()).unwrap();
-
-        assert_eq!("Aberdeen, Aberdeen City, UK", city_name);
+        assert_eq!("Aberdeen, Aberdeen City, UK", city.value(13));
     }
 
     #[test]

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -48,7 +48,7 @@ use std::sync::Arc;
 
 use csv as csv_crate;
 
-use crate::array::{ArrayRef, BinaryBuilder, PrimitiveBuilder};
+use crate::array::{ArrayRef, PrimitiveBuilder, StringBuilder};
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::record_batch::RecordBatch;
@@ -321,7 +321,7 @@ impl<R: Read> Reader<R> {
                         self.build_primitive_array::<Float64Type>(rows, i)
                     }
                     &DataType::Utf8 => {
-                        let mut builder = BinaryBuilder::new(rows.len());
+                        let mut builder = StringBuilder::new(rows.len());
                         for row_index in 0..rows.len() {
                             match rows[row_index].get(*i) {
                                 Some(s) => builder.append_string(s).unwrap(),
@@ -568,7 +568,7 @@ mod tests {
         let city = batch
             .column(0)
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap();
 
         let city_name: String = String::from_utf8(city.value(13).to_vec()).unwrap();
@@ -631,7 +631,7 @@ mod tests {
         let city = batch
             .column(0)
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap();
 
         let city_name: String = String::from_utf8(city.value(13).to_vec()).unwrap();
@@ -671,7 +671,7 @@ mod tests {
         let city = batch
             .column(0)
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap();
 
         let city_name: String = String::from_utf8(city.value(13).to_vec()).unwrap();

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -150,7 +150,7 @@ where
                 }
                 DataType::Utf8 => {
                     let c = col.as_any().downcast_ref::<StringArray>().unwrap();
-                    String::from_utf8(c.value(row_index).to_vec())?
+                    c.value(row_index).to_owned()
                 }
                 DataType::Date32(DateUnit::Day) => {
                     let c = col.as_any().downcast_ref::<Date32Array>().unwrap();

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -37,7 +37,7 @@
 //!     Field::new("c3", DataType::UInt32, false),
 //!     Field::new("c3", DataType::Boolean, true),
 //! ]);
-//! let c1 = BinaryArray::from(vec![
+//! let c1 = StringArray::from(vec![
 //!     "Lorem ipsum dolor sit amet",
 //!     "consectetur adipiscing elit",
 //!     "sed do eiusmod tempor",
@@ -149,7 +149,7 @@ where
                     c.value(row_index).to_string()
                 }
                 DataType::Utf8 => {
-                    let c = col.as_any().downcast_ref::<BinaryArray>().unwrap();
+                    let c = col.as_any().downcast_ref::<StringArray>().unwrap();
                     String::from_utf8(c.value(row_index).to_vec())?
                 }
                 DataType::Date32(DateUnit::Day) => {
@@ -397,7 +397,7 @@ mod tests {
             Field::new("c6", DataType::Time32(TimeUnit::Second), false),
         ]);
 
-        let c1 = BinaryArray::from(vec![
+        let c1 = StringArray::from(vec![
             "Lorem ipsum dolor sit amet",
             "consectetur adipiscing elit",
             "sed do eiusmod tempor",
@@ -465,7 +465,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
             Field::new("c6", DataType::Time32(TimeUnit::Second), false),
         ]);
 
-        let c1 = BinaryArray::from(vec![
+        let c1 = StringArray::from(vec![
             "Lorem ipsum dolor sit amet",
             "consectetur adipiscing elit",
             "sed do eiusmod tempor",
@@ -526,7 +526,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
             Field::new("c6", DataType::Time32(TimeUnit::Second), false),
         ]);
 
-        let c1 = BinaryArray::from(vec![
+        let c1 = StringArray::from(vec![
             "Lorem ipsum dolor sit amet",
             "consectetur adipiscing elit",
             "sed do eiusmod tempor",

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -693,14 +693,10 @@ impl DataType {
             DataType::Float64 => json!({"name": "floatingpoint", "precision": "DOUBLE"}),
             DataType::Utf8 => json!({"name": "utf8"}),
             DataType::Binary => json!({"name": "binary"}),
-            DataType::FixedSizeBinary(byte_width) => {
-                json!({"name": "fixedsizebinary", "byteWidth": byte_width})
-            }
+            DataType::FixedSizeBinary(byte_width) => json!({"name": "fixedsizebinary", "byteWidth": byte_width}),
             DataType::Struct(_) => json!({"name": "struct"}),
             DataType::List(_) => json!({ "name": "list"}),
-            DataType::FixedSizeList((_, length)) => {
-                json!({"name":"fixedsizelist", "listSize": length})
-            }
+            DataType::FixedSizeList((_, length)) => json!({"name":"fixedsizelist", "listSize": length}),
             DataType::Time32(unit) => {
                 json!({"name": "time", "bitWidth": 32, "unit": match unit {
                     TimeUnit::Second => "SECOND",

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1168,9 +1168,11 @@ mod tests {
     fn schema_json() {
         let schema = Schema::new(vec![
             Field::new("c1", DataType::Utf8, false),
-            Field::new("c2", DataType::Boolean, false),
-            Field::new("c3", DataType::Date32(DateUnit::Day), false),
-            Field::new("c4", DataType::Date64(DateUnit::Millisecond), false),
+            Field::new("c2", DataType::Binary, false),
+            Field::new("c3", DataType::FixedSizeBinary(3), false),
+            Field::new("c4", DataType::Boolean, false),
+            Field::new("c5", DataType::Date32(DateUnit::Day), false),
+            Field::new("c6", DataType::Date64(DateUnit::Millisecond), false),
             Field::new("c7", DataType::Time32(TimeUnit::Second), false),
             Field::new("c8", DataType::Time32(TimeUnit::Millisecond), false),
             Field::new("c9", DataType::Time32(TimeUnit::Microsecond), false),
@@ -1223,12 +1225,29 @@ mod tests {
                         "name": "c2",
                         "nullable": false,
                         "type": {
-                            "name": "bool"
+                            "name": "binary"
                         },
                         "children": []
                     },
                     {
                         "name": "c3",
+                        "nullable": false,
+                        "type": {
+                            "name": "fixedsizebinary",
+                            "byteWidth": 3
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c4",
+                        "nullable": false,
+                        "type": {
+                            "name": "bool"
+                        },
+                        "children": []
+                    },
+                    {
+                        "name": "c5",
                         "nullable": false,
                         "type": {
                             "name": "date",
@@ -1237,7 +1256,7 @@ mod tests {
                         "children": []
                     },
                     {
-                        "name": "c4",
+                        "name": "c6",
                         "nullable": false,
                         "type": {
                             "name": "date",

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -418,7 +418,7 @@ impl<R: Read> Reader<R> {
                     }
                     DataType::UInt8 => self.build_primitive_array::<UInt8Type>(rows, field.name()),
                     DataType::Utf8 => {
-                        let mut builder = BinaryBuilder::new(rows.len());
+                        let mut builder = StringBuilder::new(rows.len());
                         for row_index in 0..rows.len() {
                             match rows[row_index].get(field.name()) {
                                 Some(value) => {
@@ -446,7 +446,7 @@ impl<R: Read> Reader<R> {
                         DataType::Float64 => self.build_list_array::<Float64Type>(rows, field.name()),
                         DataType::Boolean => self.build_boolean_list_array(rows, field.name()),
                         DataType::Utf8 => {
-                            let values_builder = BinaryBuilder::new(rows.len() * 5);
+                            let values_builder = StringBuilder::new(rows.len() * 5);
                             let mut builder = ListBuilder::new(values_builder);
                             for row_index in 0..rows.len() {
                                 match rows[row_index].get(field.name()) {
@@ -805,7 +805,7 @@ mod tests {
         let dd = batch
             .column(d.0)
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap();
         assert_eq!("4", String::from_utf8(dd.value(0).to_vec()).unwrap());
         assert_eq!("text", String::from_utf8(dd.value(8).to_vec()).unwrap());
@@ -862,7 +862,7 @@ mod tests {
         let dd = batch
             .column(d.0)
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap();
         assert_eq!(false, dd.is_valid(0));
         assert_eq!(true, dd.is_valid(1));
@@ -1111,7 +1111,7 @@ mod tests {
             .downcast_ref::<ListArray>()
             .unwrap();
         let dd = dd.values();
-        let dd = dd.as_any().downcast_ref::<BinaryArray>().unwrap();
+        let dd = dd.as_any().downcast_ref::<StringArray>().unwrap();
         assert_eq!(7, dd.len());
         assert_eq!(false, dd.is_valid(1));
         assert_eq!("text", &String::from_utf8(dd.value(2).to_vec()).unwrap());

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -423,7 +423,7 @@ impl<R: Read> Reader<R> {
                             match rows[row_index].get(field.name()) {
                                 Some(value) => {
                                     match value.as_str() {
-                                        Some(v) => builder.append_string(v)?,
+                                        Some(v) => builder.append_value(v)?,
                                         // TODO: value might exist as something else, coerce so we don't lose it
                                         None => builder.append(false)?,
                                     }
@@ -477,7 +477,7 @@ impl<R: Read> Reader<R> {
                                         };
                                         for i in 0..vals.len() {
                                             match &vals[i] {
-                                                Some(v) => builder.values().append_string(&v)?,
+                                                Some(v) => builder.values().append_value(&v)?,
                                                 None => builder.values().append_null()?,
                                             };
                                         }
@@ -807,8 +807,8 @@ mod tests {
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap();
-        assert_eq!("4", String::from_utf8(dd.value(0).to_vec()).unwrap());
-        assert_eq!("text", String::from_utf8(dd.value(8).to_vec()).unwrap());
+        assert_eq!("4", dd.value(0));
+        assert_eq!("text", dd.value(8));
     }
 
     #[test]
@@ -1114,10 +1114,10 @@ mod tests {
         let dd = dd.as_any().downcast_ref::<StringArray>().unwrap();
         assert_eq!(7, dd.len());
         assert_eq!(false, dd.is_valid(1));
-        assert_eq!("text", &String::from_utf8(dd.value(2).to_vec()).unwrap());
-        assert_eq!("1", &String::from_utf8(dd.value(3).to_vec()).unwrap());
-        assert_eq!("false", &String::from_utf8(dd.value(4).to_vec()).unwrap());
-        assert_eq!("array", &String::from_utf8(dd.value(5).to_vec()).unwrap());
-        assert_eq!("2.4", &String::from_utf8(dd.value(6).to_vec()).unwrap());
+        assert_eq!("text", dd.value(2));
+        assert_eq!("1", dd.value(3));
+        assert_eq!("false", dd.value(4));
+        assert_eq!("array", dd.value(5));
+        assert_eq!("2.4", dd.value(6));
     }
 }

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -24,11 +24,11 @@ use serde_json::Value;
 
 use crate::array::*;
 use crate::datatypes::*;
-use crate::record_batch::{RecordBatch, RecordBatchReader};
+use crate::record_batch::RecordBatch;
 
 /// A struct that represents an Arrow file with a schema and record batches
 #[derive(Deserialize)]
-pub(crate) struct ArrowJson {
+struct ArrowJson {
     schema: ArrowJsonSchema,
     batches: Vec<ArrowJsonBatch>,
 }
@@ -60,22 +60,6 @@ struct ArrowJsonColumn {
     #[serde(rename = "OFFSET")]
     offset: Option<Vec<Value>>, // leaving as Value as 64-bit offsets are strings
     children: Option<Vec<ArrowJsonColumn>>,
-}
-
-impl ArrowJson {
-    // Compare the Arrow JSON with a record batch reader
-    pub fn equals_reader(&self, reader: &mut RecordBatchReader) -> bool {
-        if !self.schema.equals_schema(&reader.schema()) {
-            return false;
-        }
-        self.batches.iter().all(|col| {
-            let batch = reader.next_batch();
-            match batch {
-                Ok(Some(batch)) => col.equals_batch(&batch),
-                _ => false,
-            }
-        })
-    }
 }
 
 impl ArrowJsonSchema {
@@ -174,16 +158,10 @@ impl ArrowJsonBatch {
                     DataType::FixedSizeBinary(_) => {
                         let arr =
                             arr.as_any().downcast_ref::<FixedSizeBinaryArray>().unwrap();
-                        println!("fixed size bin json: {:?}", json_array);
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
                     DataType::List(_) => {
                         let arr = arr.as_any().downcast_ref::<ListArray>().unwrap();
-                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
-                    }
-                    DataType::FixedSizeList(_) => {
-                        let arr =
-                            arr.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
                     DataType::Struct(_) => {
@@ -200,9 +178,6 @@ impl ArrowJsonBatch {
 fn json_from_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value> {
     match data_type {
         DataType::List(dt) => json_from_list_col(col, &**dt),
-        DataType::FixedSizeList((dt, list_size)) => {
-            json_from_fixed_size_list_col(col, &**dt, *list_size as usize)
-        }
         DataType::Struct(fields) => json_from_struct_col(col, fields),
         _ => merge_json_array(&col.validity, &col.data.clone().unwrap()),
     }
@@ -275,36 +250,6 @@ fn json_from_list_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value>
         match col.validity[i] {
             0 => values.push(Value::Null),
             1 => values.push(Value::Array(inner[offsets[i]..offsets[i + 1]].to_vec())),
-            _ => panic!("Validity data should be 0 or 1"),
-        }
-    }
-
-    values
-}
-
-/// Convert an Arrow JSON column/array of a `DataType::List` into a vector of `Value`
-fn json_from_fixed_size_list_col(
-    col: &ArrowJsonColumn,
-    data_type: &DataType,
-    list_size: usize,
-) -> Vec<Value> {
-    let mut values = Vec::with_capacity(col.count);
-
-    // get the inner array
-    let child = &col.children.clone().expect("list type must have children")[0];
-    let inner = match data_type {
-        DataType::List(ref dt) => json_from_col(child, &**dt),
-        DataType::FixedSizeList((ref dt, _)) => json_from_col(child, &**dt),
-        DataType::Struct(fields) => json_from_struct_col(col, fields),
-        _ => merge_json_array(&child.validity, &child.data.clone().unwrap()),
-    };
-
-    for i in 0..col.count {
-        match col.validity[i] {
-            0 => values.push(Value::Null),
-            1 => values.push(Value::Array(
-                inner[(list_size * i)..(list_size * (i + 1))].to_vec(),
-            )),
             _ => panic!("Validity data should be 0 or 1"),
         }
     }

--- a/rust/arrow/src/util/string_writer.rs
+++ b/rust/arrow/src/util/string_writer.rs
@@ -36,7 +36,7 @@
 //!     Field::new("c3", DataType::UInt32, false),
 //!     Field::new("c3", DataType::Boolean, true),
 //! ]);
-//! let c1 = BinaryArray::from(vec![
+//! let c1 = StringArray::from(vec![
 //!     "Lorem ipsum dolor sit amet",
 //!     "consectetur adipiscing elit",
 //!     "sed do eiusmod tempor",

--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -142,7 +142,7 @@ fn main() {
         let c1 = batch
             .column(0)
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap();
 
         let min = batch

--- a/rust/datafusion/examples/csv_sql.rs
+++ b/rust/datafusion/examples/csv_sql.rs
@@ -97,9 +97,12 @@ fn main() -> Result<()> {
             .unwrap();
 
         for i in 0..batch.num_rows() {
-            let c1_value: String = String::from_utf8(c1.value(i).to_vec()).unwrap();
-
-            println!("{}, Min: {}, Max: {}", c1_value, min.value(i), max.value(i),);
+            println!(
+                "{}, Min: {}, Max: {}",
+                c1.value(i),
+                min.value(i),
+                max.value(i),
+            );
         }
     });
 

--- a/rust/datafusion/examples/csv_sql.rs
+++ b/rust/datafusion/examples/csv_sql.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 extern crate arrow;
 extern crate datafusion;
 
-use arrow::array::{BinaryArray, Float64Array};
+use arrow::array::{Float64Array, StringArray};
 use arrow::datatypes::{DataType, Field, Schema};
 
 use datafusion::error::Result;
@@ -81,7 +81,7 @@ fn main() -> Result<()> {
         let c1 = batch
             .column(0)
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap();
 
         let min = batch

--- a/rust/datafusion/examples/parquet_sql.rs
+++ b/rust/datafusion/examples/parquet_sql.rs
@@ -18,7 +18,7 @@
 extern crate arrow;
 extern crate datafusion;
 
-use arrow::array::{BinaryArray, Float64Array, Int32Array};
+use arrow::array::{Float64Array, Int32Array, StringArray};
 
 use datafusion::error::Result;
 use datafusion::execution::context::ExecutionContext;
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
         let date = batch
             .column(2)
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap();
 
         for i in 0..batch.num_rows() {

--- a/rust/datafusion/examples/parquet_sql.rs
+++ b/rust/datafusion/examples/parquet_sql.rs
@@ -76,11 +76,9 @@ fn main() -> Result<()> {
             .unwrap();
 
         for i in 0..batch.num_rows() {
-            let date_value: String = String::from_utf8(date.value(i).to_vec()).unwrap();
-
             println!(
                 "Date: {}, Int: {}, Double: {}",
-                date_value,
+                date.value(i),
                 int.value(i),
                 double.value(i)
             );

--- a/rust/datafusion/src/bin/repl.rs
+++ b/rust/datafusion/src/bin/repl.rs
@@ -160,7 +160,8 @@ fn str_value(column: ArrayRef, row: usize) -> Result<String> {
             .as_any()
             .downcast_ref::<StringArray>()
             .unwrap()
-            .get_string(row)),
+            .value(row)
+            .to_string()),
         DataType::Boolean => make_string!(BooleanArray, column, row),
         DataType::Int16 => make_string!(Int16Array, column, row),
         DataType::Int32 => make_string!(Int32Array, column, row),

--- a/rust/datafusion/src/bin/repl.rs
+++ b/rust/datafusion/src/bin/repl.rs
@@ -158,7 +158,7 @@ fn str_value(column: ArrayRef, row: usize) -> Result<String> {
     match column.data_type() {
         DataType::Utf8 => Ok(column
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap()
             .get_string(row)),
         DataType::Boolean => make_string!(BooleanArray, column, row),

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -190,7 +190,7 @@ macro_rules! read_binary_column {
         let mut value_index = 0;
         for i in 0..levels_read {
             if def_levels[i] > 0 {
-                builder.append_string(
+                builder.append_value(
                     &String::from_utf8(read_buffer[value_index].data().to_vec()).unwrap(),
                 )?;
                 value_index += 1;
@@ -762,8 +762,7 @@ mod tests {
             .unwrap();
         let mut values: Vec<String> = vec![];
         for i in 0..batch.num_rows() {
-            let str: String = String::from_utf8(array.value(i).to_vec()).unwrap();
-            values.push(str);
+            values.push(array.value(i).to_string());
         }
 
         assert_eq!(

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -25,7 +25,7 @@ use std::thread;
 use crossbeam::channel::{unbounded, Receiver, Sender};
 
 use arrow::array::{
-    Array, BinaryBuilder, PrimitiveArray, PrimitiveBuilder, TimestampNanosecondBuilder,
+    Array, PrimitiveArray, PrimitiveBuilder, StringBuilder, TimestampNanosecondBuilder,
 };
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
@@ -186,7 +186,7 @@ macro_rules! read_binary_column {
             None,
             &mut read_buffer,
         )?;
-        let mut builder = BinaryBuilder::new(levels_read);
+        let mut builder = StringBuilder::new(levels_read);
         let mut value_index = 0;
         for i in 0..levels_read {
             if def_levels[i] > 0 {
@@ -550,7 +550,7 @@ impl ParquetFile {
 mod tests {
     use super::*;
     use arrow::array::{
-        BinaryArray, BooleanArray, Float32Array, Float64Array, Int32Array,
+        BooleanArray, Float32Array, Float64Array, Int32Array, StringArray,
         TimestampNanosecondArray,
     };
     use std::env;
@@ -758,7 +758,7 @@ mod tests {
         let array = batch
             .column(0)
             .as_any()
-            .downcast_ref::<BinaryArray>()
+            .downcast_ref::<StringArray>()
             .unwrap();
         let mut values: Vec<String> = vec![];
         for i in 0..batch.num_rows() {

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -326,7 +326,9 @@ impl ExecutionContext {
                 match expr {
                     &Expr::Literal(ref scalar_value) => {
                         let limit: usize = match scalar_value {
-                            ScalarValue::Int8(limit) if *limit >= 0 => Ok(*limit as usize),
+                            ScalarValue::Int8(limit) if *limit >= 0 => {
+                                Ok(*limit as usize)
+                            }
                             ScalarValue::Int16(limit) if *limit >= 0 => {
                                 Ok(*limit as usize)
                             }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -326,9 +326,7 @@ impl ExecutionContext {
                 match expr {
                     &Expr::Literal(ref scalar_value) => {
                         let limit: usize = match scalar_value {
-                            ScalarValue::Int8(limit) if *limit >= 0 => {
-                                Ok(*limit as usize)
-                            }
+                            ScalarValue::Int8(limit) if *limit >= 0 => Ok(*limit as usize),
                             ScalarValue::Int16(limit) if *limit >= 0 => {
                                 Ok(*limit as usize)
                             }

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -1245,7 +1245,7 @@ mod tests {
             .as_any()
             .downcast_ref::<StringArray>()
             .expect("failed to downcast to StringArray");
-        assert_eq!(result.value(0), "1".as_bytes());
+        assert_eq!(result.value(0), "1");
 
         Ok(())
     }

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -1123,7 +1123,7 @@ mod tests {
     use super::*;
     use crate::error::Result;
     use crate::execution::physical_plan::common::get_scalar_value;
-    use arrow::array::{BinaryArray, PrimitiveArray};
+    use arrow::array::{PrimitiveArray, StringArray};
     use arrow::datatypes::*;
 
     #[test]
@@ -1243,8 +1243,8 @@ mod tests {
 
         let result = result
             .as_any()
-            .downcast_ref::<BinaryArray>()
-            .expect("failed to downcast to BinaryArray");
+            .downcast_ref::<StringArray>()
+            .expect("failed to downcast to StringArray");
         assert_eq!(result.value(0), "1".as_bytes());
 
         Ok(())

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -28,12 +28,13 @@ use crate::execution::physical_plan::{
 };
 
 use arrow::array::{
-    ArrayRef, BinaryArray, Float32Array, Float64Array, Int16Array, Int32Array,
-    Int64Array, Int8Array, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    ArrayRef, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+    StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
 };
 use arrow::array::{
-    BinaryBuilder, Float32Builder, Float64Builder, Int16Builder, Int32Builder,
-    Int64Builder, Int8Builder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
+    Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder,
+    Int8Builder, StringBuilder, UInt16Builder, UInt32Builder, UInt64Builder,
+    UInt8Builder,
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
@@ -468,7 +469,7 @@ impl BatchIterator for GroupedHashAggregateIterator {
                     group_array_from_map_entries!(Int64Builder, Int64, map, i)
                 }
                 DataType::Utf8 => {
-                    let mut builder = BinaryBuilder::new(1);
+                    let mut builder = StringBuilder::new(1);
                     for k in map.keys() {
                         match &k[i] {
                             GroupByScalar::Utf8(s) => builder.append_string(&s).unwrap(),
@@ -704,7 +705,7 @@ fn create_key(
                 vec[i] = GroupByScalar::Int64(array.value(row))
             }
             DataType::Utf8 => {
-                let array = col.as_any().downcast_ref::<BinaryArray>().unwrap();
+                let array = col.as_any().downcast_ref::<StringArray>().unwrap();
                 vec[i] = GroupByScalar::Utf8(String::from(
                     str::from_utf8(array.value(row)).unwrap(),
                 ))

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -19,7 +19,6 @@
 
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::str;
 use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};
@@ -472,7 +471,7 @@ impl BatchIterator for GroupedHashAggregateIterator {
                     let mut builder = StringBuilder::new(1);
                     for k in map.keys() {
                         match &k[i] {
-                            GroupByScalar::Utf8(s) => builder.append_string(&s).unwrap(),
+                            GroupByScalar::Utf8(s) => builder.append_value(&s).unwrap(),
                             _ => {
                                 return Err(ExecutionError::ExecutionError(
                                     "Unexpected value for Utf8 group column".to_string(),
@@ -706,9 +705,7 @@ fn create_key(
             }
             DataType::Utf8 => {
                 let array = col.as_any().downcast_ref::<StringArray>().unwrap();
-                vec[i] = GroupByScalar::Utf8(String::from(
-                    str::from_utf8(array.value(row)).unwrap(),
-                ))
+                vec[i] = GroupByScalar::Utf8(String::from(array.value(row)))
             }
             _ => {
                 return Err(ExecutionError::ExecutionError(

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -456,7 +456,7 @@ fn result_str(results: &Vec<RecordBatch>) -> Vec<String> {
                     }
                     DataType::Utf8 => {
                         let array =
-                            column.as_any().downcast_ref::<BinaryArray>().unwrap();
+                            column.as_any().downcast_ref::<StringArray>().unwrap();
                         let s =
                             String::from_utf8(array.value(row_index).to_vec()).unwrap();
 

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -457,8 +457,7 @@ fn result_str(results: &Vec<RecordBatch>) -> Vec<String> {
                     DataType::Utf8 => {
                         let array =
                             column.as_any().downcast_ref::<StringArray>().unwrap();
-                        let s =
-                            String::from_utf8(array.value(row_index).to_vec()).unwrap();
+                        let s = array.value(row_index);
 
                         str.push_str(&format!("{:?}", s));
                     }


### PR DESCRIPTION
This PR creates a `StringArray` which behaves exactly like the current `BinaryArray`, then restricts the `BinaryArray` to dealing with binary data only. It also adds a `FixedSizeBinaryArray` which is backed by a `FixedSizeListArray`. 