### PR TITLE
ARROW-6969: [C++][Dataset] ParquetScanTask defer memory usage

### DIFF
--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -219,6 +219,14 @@ Iterator<T> MakeEmptyIterator() {
   });
 }
 
+template <typename T>
+Iterator<T> MakeErrorIterator(Status s) {
+  return MakeFunctionIterator([s](T* out) {
+    *out = IterationTraits<T>::End();
+    return s;
+  });
+}
+
 /// \brief Simple iterator which yields the elements of a std::vector
 template <typename T>
 class VectorIterator {


### PR DESCRIPTION
The constructor (via Make) would eagerly create the RecordBatchReader which would consume memory even if the ScanTask was not consumed yet.

This creates a memory usage problem with Scanner users who collect all ScanTask before dispatching them, e.g. by using TaskGroup.

This patch defer the creation of the RecordBatchReader in the `Scan` method of the ParquetScanTask.