### PR TITLE
ARROW-6977: [C++] Disable jemalloc background_thread on macOS

### DIFF
--- a/.github/workflows/windows-msvc-cpp.yml
+++ b/.github/workflows/windows-msvc-cpp.yml
@@ -36,6 +36,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: CMake
+        shell: cmd
         run: |
           mkdir build\cpp
           cmake ^
@@ -48,5 +49,6 @@ jobs:
             -S cpp ^
             -B build\cpp
       - name: Install
+        shell: cmd
         run: |
           cmake --build build\cpp --config Debug --target Install


### PR DESCRIPTION
The option isn't always available, perhaps based on the macOS version
or configured SDK version.