### PR TITLE
ARROW-6951: [C++][Dataset] Column projection in ParquetFragment

### DIFF
--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -212,35 +212,6 @@ static inline DataFragmentIterator GetFragmentsFromSources(
   return MakeFlattenIterator(std::move(fragments_it));
 }
 
-/// \brief Return a schema with the union of fields in schemas.
-/// If fields in two schemas share a name they must be identical.
-/// TODO(bkietz) loosen this to "be convertible"
-inline Result<std::shared_ptr<Schema>> MergeSchemas(
-    const std::vector<std::shared_ptr<Schema>>& schemas) {
-  std::unordered_map<std::string, int> field_names;
-  std::vector<std::shared_ptr<Field>> fields;
-
-  for (const auto& schema : schemas) {
-    for (const auto& field : schema->fields()) {
-      auto it = field_names.find(field->name());
-      if (it == field_names.end()) {
-        // new field name
-        field_names.emplace(field->name(), static_cast<int>(fields.size()));
-        fields.push_back(field);
-        continue;
-      }
-
-      // ensure fields with the same name are identical
-      const auto& matching_field = fields[it->second];
-      if (!matching_field->Equals(field)) {
-        return Status::TypeError("Non identical fields with the same name: ",
-                                 field->ToString(), " vs ", matching_field->ToString());
-      }
-    }
-  }
-  return schema(fields);
-}
-
 inline std::shared_ptr<Schema> SchemaFromColumnNames(
     const std::shared_ptr<Schema>& input, const std::vector<std::string>& column_names) {
   std::vector<std::shared_ptr<Field>> columns;

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -43,12 +43,12 @@ using parquet::arrow::StatisticsAsScalars;
 /// \brief A ScanTask backed by a parquet file and a RowGroup within a parquet file.
 class ParquetScanTask : public ScanTask {
  public:
-  ParquetScanTask(int row_group, std::vector<int> columns_projection,
+  ParquetScanTask(int row_group, std::vector<int> column_projection,
                   std::shared_ptr<parquet::arrow::FileReader> reader,
                   std::shared_ptr<ScanOptions> options,
                   std::shared_ptr<ScanContext> context)
       : row_group_(row_group),
-        columns_projection_(std::move(columns_projection)),
+        column_projection_(std::move(column_projection)),
         reader_(reader),
         options_(std::move(options)),
         context_(std::move(context)) {}
@@ -61,7 +61,7 @@ class ParquetScanTask : public ScanTask {
     // Thus the memory incurred by the RecordBatchReader is allocated when
     // Scan is called.
     std::unique_ptr<RecordBatchReader> record_batch_reader;
-    auto status = reader_->GetRecordBatchReader({row_group_}, columns_projection_,
+    auto status = reader_->GetRecordBatchReader({row_group_}, column_projection_,
                                                 &record_batch_reader);
     // Propagate the previous error as an error iterator.
     if (!status.ok()) {
@@ -73,7 +73,7 @@ class ParquetScanTask : public ScanTask {
 
  private:
   int row_group_;
-  std::vector<int> columns_projection_;
+  std::vector<int> column_projection_;
   // The ScanTask _must_ hold a reference to reader_ because there's no
   // guarantee the producing ParquetScanTaskIterator is still alive. This is a
   // contract required by record_batch_reader_
@@ -139,16 +139,15 @@ class ParquetScanTaskIterator {
                      ScanTaskIterator* out) {
     auto metadata = reader->metadata();
 
-    std::vector<int> columns_projection;
-    RETURN_NOT_OK(InferColumnProjection(*metadata, options, &columns_projection));
+    auto column_projection = InferColumnProjection(*metadata, options);
 
     std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
     RETURN_NOT_OK(parquet::arrow::FileReader::Make(context->pool, std::move(reader),
                                                    &arrow_reader));
 
     *out = ScanTaskIterator(ParquetScanTaskIterator(
-        std::move(options), std::move(context), std::move(columns_projection), metadata,
-        std::move(arrow_reader)));
+        std::move(options), std::move(context), std::move(column_projection),
+        std::move(metadata), std::move(arrow_reader)));
     return Status::OK();
   }
 
@@ -162,73 +161,78 @@ class ParquetScanTaskIterator {
     }
 
     task->reset(
-        new ParquetScanTask(row_group, columns_projection_, reader_, options_, context_));
+        new ParquetScanTask(row_group, column_projection_, reader_, options_, context_));
 
     return Status::OK();
   }
 
  private:
   // Compute the column projection out of an optional arrow::Schema
-  static Status InferColumnProjection(const parquet::FileMetaData& metadata,
-                                      const std::shared_ptr<ScanOptions>& options,
-                                      std::vector<int>* out) {
-    // fall back to no push down projection
-    auto fall_back = [&] {
-      *out = internal::Iota(metadata.num_columns());
-      return Status::OK();
-    };
-
-    if (options->projector == nullptr) return fall_back();
-
-    // get column indices
-    out->clear();
-    auto filter_fields = FieldsInExpression(options->filter);
+  static std::vector<int> InferColumnProjection(
+      const parquet::FileMetaData& metadata,
+      const std::shared_ptr<ScanOptions>& options) {
+    if (options->projector == nullptr) {
+      // fall back to no push down projection
+      return internal::Iota(metadata.num_columns());
+    }
 
     SchemaManifest manifest;
     if (!SchemaManifest::Make(metadata.schema(), nullptr,
                               parquet::default_arrow_reader_properties(), &manifest)
-             .ok())
-      return fall_back();
+             .ok()) {
+      return internal::Iota(metadata.num_columns());
+    }
+
+    // get column indices
+    auto filter_fields = FieldsInExpression(options->filter);
+
+    std::vector<int> column_projection;
 
     for (const auto& schema_field : manifest.schema_fields) {
-      auto field = schema_field.field;
-      auto parquet_column_index = schema_field.column_index;
+      auto field_name = schema_field.field->name();
 
-      // Ignore nested fields.
-      if (field->type()->num_children() != 0 || parquet_column_index == -1) {
-        continue;
-      }
-
-      if (options->projector->schema()->GetFieldIndex(field->name()) != -1) {
+      if (options->projector->schema()->GetFieldIndex(field_name) != -1) {
         // add explicitly projected field
-        out->push_back(parquet_column_index);
+        AddColumnIndices(schema_field, &column_projection);
         continue;
       }
 
-      if (std::find(filter_fields.begin(), filter_fields.end(), field->name()) !=
+      if (std::find(filter_fields.begin(), filter_fields.end(), field_name) !=
           filter_fields.end()) {
         // add field referenced by filter
-        out->push_back(parquet_column_index);
+        AddColumnIndices(schema_field, &column_projection);
       }
     }
 
-    return Status::OK();
+    return column_projection;
+  }
+
+  static void AddColumnIndices(const SchemaField& schema_field,
+                               std::vector<int>* column_projection) {
+    if (schema_field.column_index != -1) {
+      column_projection->push_back(schema_field.column_index);
+      return;
+    }
+
+    for (const auto& child : schema_field.children) {
+      AddColumnIndices(child, column_projection);
+    }
   }
 
   ParquetScanTaskIterator(std::shared_ptr<ScanOptions> options,
                           std::shared_ptr<ScanContext> context,
-                          std::vector<int> columns_projection,
+                          std::vector<int> column_projection,
                           std::shared_ptr<parquet::FileMetaData> metadata,
                           std::unique_ptr<parquet::arrow::FileReader> reader)
       : options_(std::move(options)),
         context_(std::move(context)),
-        columns_projection_(std::move(columns_projection)),
+        column_projection_(std::move(column_projection)),
         skipper_(std::move(metadata), options_->filter),
         reader_(std::move(reader)) {}
 
   std::shared_ptr<ScanOptions> options_;
   std::shared_ptr<ScanContext> context_;
-  std::vector<int> columns_projection_;
+  std::vector<int> column_projection_;
   RowGroupSkipper skipper_;
   std::shared_ptr<parquet::arrow::FileReader> reader_;
 };

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -99,16 +99,22 @@ Status WriteRecordBatchReader(
 
 class ArrowParquetWriterMixin : public ::testing::Test {
  public:
-  std::shared_ptr<Buffer> Write(RecordBatchReader* reader) {
+  std::shared_ptr<Buffer> Write(std::vector<RecordBatchReader*> readers) {
     auto pool = ::arrow::default_memory_pool();
 
     std::shared_ptr<Buffer> out;
     auto sink = CreateOutputStream(pool);
 
-    ABORT_NOT_OK(WriteRecordBatchReader(reader, pool, sink));
-    ABORT_NOT_OK(sink->Finish(&out));
+    for (auto reader : readers) {
+      ARROW_EXPECT_OK(WriteRecordBatchReader(reader, pool, sink));
+    }
+    ARROW_EXPECT_OK(sink->Finish(&out));
 
     return out;
+  }
+
+  std::shared_ptr<Buffer> Write(RecordBatchReader* reader) {
+    return Write(std::vector<RecordBatchReader*>{reader});
   }
 
   std::shared_ptr<Buffer> Write(const Table& table) {
@@ -128,6 +134,11 @@ class ParquetBufferFixtureMixin : public ArrowParquetWriterMixin {
  public:
   std::unique_ptr<FileSource> GetFileSource(RecordBatchReader* reader) {
     auto buffer = Write(reader);
+    return internal::make_unique<FileSource>(std::move(buffer));
+  }
+
+  std::unique_ptr<FileSource> GetFileSource(std::vector<RecordBatchReader*> readers) {
+    auto buffer = Write(std::move(readers));
     return internal::make_unique<FileSource>(std::move(buffer));
   }
 
@@ -156,17 +167,17 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   auto source = GetFileSource(reader.get());
   auto fragment = std::make_shared<ParquetFragment>(*source, opts_);
 
-  ScanTaskIterator it;
-  ASSERT_OK(fragment->Scan(ctx_, &it));
+  ScanTaskIterator scan_task_it;
+  ASSERT_OK(fragment->Scan(ctx_, &scan_task_it));
   int64_t row_count = 0;
 
-  ASSERT_OK(it.Visit([&row_count](std::unique_ptr<ScanTask> task) -> Status {
-    auto batch_it = task->Scan();
-    return batch_it.Visit([&row_count](std::shared_ptr<RecordBatch> batch) -> Status {
+  for (auto maybe_task : scan_task_it) {
+    ASSERT_OK_AND_ASSIGN(auto task, std::move(maybe_task));
+    for (auto maybe_batch : task->Scan()) {
+      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
       row_count += batch->num_rows();
-      return Status::OK();
-    });
-  }));
+    }
+  }
 
   ASSERT_EQ(row_count, kNumRows);
 }
@@ -204,20 +215,59 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjected) {
   auto source = GetFileSource(reader.get());
   auto fragment = std::make_shared<ParquetFragment>(*source, opts_);
 
-  ScanTaskIterator it;
-  ASSERT_OK(fragment->Scan(ctx_, &it));
+  ScanTaskIterator scan_task_it;
+  ASSERT_OK(fragment->Scan(ctx_, &scan_task_it));
   int64_t row_count = 0;
 
-  ASSERT_OK(
-      it.Visit([&row_count, &expected_schema](std::unique_ptr<ScanTask> task) -> Status {
-        auto batch_it = task->Scan();
-        return batch_it.Visit(
-            [&row_count, &expected_schema](std::shared_ptr<RecordBatch> batch) -> Status {
-              row_count += batch->num_rows();
-              EXPECT_EQ(*batch->schema(), *expected_schema);
-              return Status::OK();
-            });
-      }));
+  for (auto maybe_task : scan_task_it) {
+    ASSERT_OK_AND_ASSIGN(auto task, std::move(maybe_task));
+    for (auto maybe_batch : task->Scan()) {
+      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+      row_count += batch->num_rows();
+      ASSERT_EQ(*batch->schema(), *expected_schema);
+    }
+  }
+
+  ASSERT_EQ(row_count, kNumRows);
+}
+
+TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjectedMissingCols) {
+  schema_ =
+      schema({field("f64", float64()), field("i64", int64()), field("f32", float32())});
+  auto reader_without_i32 = GetRecordBatchReader();
+
+  schema_ =
+      schema({field("i64", int64()), field("f32", float32()), field("i32", int32())});
+  auto reader_without_f64 = GetRecordBatchReader();
+
+  schema_ = schema({field("f64", float64()), field("i64", int64()),
+                    field("f32", float32()), field("i32", int32())});
+  auto reader = GetRecordBatchReader();
+
+  opts_->schema = schema_;
+  opts_->projector = std::make_shared<RecordBatchProjector>(
+      default_memory_pool(), SchemaFromColumnNames(schema_, {"f64"}));
+  opts_->filter = equal(field_ref("i32"), scalar(3));
+
+  // NB: projector is applied by the scanner; ParquetFragment does not evaluate it so
+  // we will not drop "i32" even though it is not in the projector's schema
+  auto expected_schema = schema({field("f64", float64()), field("i32", int32())});
+
+  auto source =
+      GetFileSource({reader.get(), reader_without_i32.get(), reader_without_f64.get()});
+  auto fragment = std::make_shared<ParquetFragment>(*source, opts_);
+
+  ScanTaskIterator scan_task_it;
+  ASSERT_OK(fragment->Scan(ctx_, &scan_task_it));
+  int64_t row_count = 0;
+
+  for (auto maybe_task : scan_task_it) {
+    ASSERT_OK_AND_ASSIGN(auto task, std::move(maybe_task));
+    for (auto maybe_batch : task->Scan()) {
+      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+      row_count += batch->num_rows();
+    }
+  }
 
   ASSERT_EQ(row_count, kNumRows);
 }

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -196,6 +196,8 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjected) {
       default_memory_pool(), SchemaFromColumnNames(schema_, {"f64"}));
   opts_->filter = equal(field_ref("i32"), scalar(3));
 
+  // NB: projector is applied by the scanner; ParquetFragment does not evaluate it so
+  // we will not drop "i32" even though it is not in the projector's schema
   auto expected_schema = schema({field("f64", float64()), field("i32", int32())});
 
   auto reader = GetRecordBatchReader();

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -205,7 +205,7 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjected) {
   opts_->schema = schema_;
   opts_->projector = std::make_shared<RecordBatchProjector>(
       default_memory_pool(), SchemaFromColumnNames(schema_, {"f64"}));
-  opts_->filter = equal(field_ref("i32"), scalar(3));
+  opts_->filter = equal(field_ref("i32"), scalar(0));
 
   // NB: projector is applied by the scanner; ParquetFragment does not evaluate it so
   // we will not drop "i32" even though it is not in the projector's schema
@@ -247,7 +247,7 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjectedMissingCols) {
   opts_->schema = schema_;
   opts_->projector = std::make_shared<RecordBatchProjector>(
       default_memory_pool(), SchemaFromColumnNames(schema_, {"f64"}));
-  opts_->filter = equal(field_ref("i32"), scalar(3));
+  opts_->filter = equal(field_ref("i32"), scalar(0));
 
   // NB: projector is applied by the scanner; ParquetFragment does not evaluate it so
   // we will not drop "i32" even though it is not in the projector's schema

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -62,8 +62,7 @@ class ExpressionsTest : public ::testing::Test {
     auto simplified = expr.Assume(given);
     ASSERT_EQ(E{simplified}, E{expected})
         << "  simplification of: " << expr.ToString() << std::endl
-        << "              given: " << given.ToString() << std::endl
-        << "           expected: " << expected.ToString() << std::endl;
+        << "              given: " << given.ToString() << std::endl;
   }
 
   void AssertSimplifiesTo(const Expression& expr, const Expression& given,

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -128,16 +128,6 @@ Status ScannerBuilder::Filter(std::shared_ptr<Expression> filter) {
 
 Status ScannerBuilder::Filter(const Expression& filter) { return Filter(filter.Copy()); }
 
-std::shared_ptr<Schema> SchemaFromColumnNames(
-    const std::shared_ptr<Schema>& input, const std::vector<std::string>& column_names) {
-  std::vector<std::shared_ptr<Field>> columns;
-  for (const auto& name : column_names) {
-    columns.push_back(input->GetFieldByName(name));
-  }
-
-  return std::make_shared<Schema>(columns);
-}
-
 Status ScannerBuilder::UseThreads(bool use_threads) {
   scan_options_->use_threads = use_threads;
   return Status::OK();

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1306,7 +1306,9 @@ class ARROW_EXPORT DictionaryUnifier {
 /// \class Schema
 /// \brief Sequence of arrow::Field objects describing the columns of a record
 /// batch or table data structure
-class ARROW_EXPORT Schema : public detail::Fingerprintable {
+class ARROW_EXPORT Schema : public detail::Fingerprintable,
+                            public util::EqualityComparable<Schema>,
+                            public util::ToStringOstreamable<Schema> {
  public:
   explicit Schema(const std::vector<std::shared_ptr<Field>>& fields,
                   const std::shared_ptr<const KeyValueMetadata>& metadata = NULLPTR);
@@ -1320,7 +1322,6 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable {
 
   /// Returns true if all of the schema fields are equal
   bool Equals(const Schema& other, bool check_metadata = true) const;
-  bool operator==(const Schema& other) const { return Equals(other); }
 
   /// \brief Return the number of fields (columns) in the schema
   int num_fields() const;

--- a/cpp/src/parquet/arrow/schema.h
+++ b/cpp/src/parquet/arrow/schema.h
@@ -140,8 +140,8 @@ struct PARQUET_EXPORT SchemaManifest {
   }
 
   bool GetFieldIndices(const std::vector<int>& column_indices, std::vector<int>* out) {
-    // Coalesce a list of schema fields indices which are the roots of the
-    // columns referred by a list of column indices
+    // Coalesce a list of schema field indices which are the roots of the
+    // columns referred to by a list of column indices
     const schema::GroupNode* group = descr->group_node();
     std::unordered_set<int> already_added;
     out->clear();


### PR DESCRIPTION
Extract the indices of columns excluding those which need not be loaded (neither projected nor referenced by the filter expression) so that the parquet reader can avoid unnecessary IO.