### PR TITLE
ARROW-7003: [Rust] Generate flatbuffers files in docker build image

### DIFF
--- a/ci/docker_build_rust.sh
+++ b/ci/docker_build_rust.sh
@@ -26,6 +26,13 @@ rustup show
 # clean first
 cargo clean
 
+# flatbuffer codegen
+echo Generating IPC
+flatc --rust -o arrow/src/ipc/gen/ ../format/*.fbs
+
+# work around some bugs in flatbuffers
+find arrow/src/ipc/gen/ -name "*_generated.rs" -exec sed -i 's/type__type/type_type/g' {} \;
+
 # raises on any formatting errors
 echo "Running formatting checks ..."
 cargo +stable fmt --all -- --check

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -30,6 +30,17 @@ RUN rustup default "$(cat /tmp/rust-toolchain)"
 # Enable stable rustfmt for nightly Rust
 RUN rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
 
+# Install pre-requisites for building flatbuffers
+RUN apt update && \
+    apt install -y build-essential cmake
+
+# Install flatbuffers
+RUN wget https://github.com/google/flatbuffers/archive/v1.11.0.tar.gz && \
+    tar xzf v1.11.0.tar.gz && \
+    cd flatbuffers-1.11.0 && \
+    cmake -G "Unix Makefiles" && \
+    make install
+
 # Set environment variables for location of test data required by unit and integration tests
 ENV ARROW_TEST_DATA=/arrow/testing/data
 ENV PARQUET_TEST_DATA=/arrow/cpp/submodules/parquet-testing/data

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -45,6 +45,8 @@ WORKDIR flatbuffers-1.11.0
 RUN cmake -G "Unix Makefiles" \
     && make install
 
+WORKDIR /
+
 # Set environment variables for location of test data required by unit and integration tests
 ENV ARROW_TEST_DATA=/arrow/testing/data
 ENV PARQUET_TEST_DATA=/arrow/cpp/submodules/parquet-testing/data

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -40,7 +40,7 @@ RUN apt-get update \
 RUN wget https://github.com/google/flatbuffers/archive/v1.11.0.tar.gz \
     && tar xzf v1.11.0.tar.gz
 
-WORKDIR flatbuffers-1.11.0
+WORKDIR /flatbuffers-1.11.0
 
 RUN cmake -G "Unix Makefiles" \
     && make install

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -31,15 +31,19 @@ RUN rustup default "$(cat /tmp/rust-toolchain)"
 RUN rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
 
 # Install pre-requisites for building flatbuffers
-RUN apt-get update && \
-    apt-get install -y build-essential cmake
+RUN apt-get update \
+    && apt-get install -y build-essential cmake \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Install flatbuffers
-RUN wget https://github.com/google/flatbuffers/archive/v1.11.0.tar.gz && \
-    tar xzf v1.11.0.tar.gz && \
-    cd flatbuffers-1.11.0 && \
-    cmake -G "Unix Makefiles" && \
-    make install
+RUN wget https://github.com/google/flatbuffers/archive/v1.11.0.tar.gz \
+    && tar xzf v1.11.0.tar.gz
+
+WORKDIR flatbuffers-1.11.0
+
+RUN cmake -G "Unix Makefiles" \
+    && make install
 
 # Set environment variables for location of test data required by unit and integration tests
 ENV ARROW_TEST_DATA=/arrow/testing/data

--- a/rust/Dockerfile
+++ b/rust/Dockerfile
@@ -31,8 +31,8 @@ RUN rustup default "$(cat /tmp/rust-toolchain)"
 RUN rustup component add rustfmt --toolchain stable-x86_64-unknown-linux-gnu
 
 # Install pre-requisites for building flatbuffers
-RUN apt update && \
-    apt install -y build-essential cmake
+RUN apt-get update && \
+    apt-get install -y build-essential cmake
 
 # Install flatbuffers
 RUN wget https://github.com/google/flatbuffers/archive/v1.11.0.tar.gz && \

--- a/rust/README.md
+++ b/rust/README.md
@@ -65,3 +65,19 @@ and check for lint issues:
 ```bash
 cargo +stable fmt --all -- --check
 ```
+
+## CI and Dockerized builds
+
+There are currently multiple CI systems that build the project and they all use the same docker image. It is possible to run the same build locally.
+
+From the root of the Arrow project, run the following command to build the Docker image that the CI system uses to build the project.
+
+```bash
+docker-compose build rust
+```
+
+Run the following command to build the project in the same way that the CI system will build the project. Note that this currently does cause some files to be written to your local workspace.
+
+```bash
+docker run -v `pwd`:/arrow -it arrowdev/arrow-rust
+```

--- a/rust/rustfmt.toml
+++ b/rust/rustfmt.toml
@@ -16,3 +16,8 @@
 # under the License.
 
 max_width = 90
+
+# ignore generated files
+ignore = [
+    "arrow/src/ipc/gen",
+]


### PR DESCRIPTION
This PR updates the build docker image to generate IPC source based on the flatbuffer specification.

Note that the generated files are currently not used in the build (the generated files have a `_generated.rs` suffix so don't overwrite the checked in versions of the files).

We cannot fully automate this until https://github.com/google/flatbuffers/issues/5589 is resolved, or we figure out a workaround, but I suggest we merge this current PR since it lays the groundwork.