### PR TITLE
ARROW-6912: [Java] Extract a common base class for avro converter consumers

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroArraysConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroArraysConsumer.java
@@ -19,7 +19,6 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.avro.io.Decoder;
 
@@ -27,18 +26,15 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume array type values from avro decoder.
  * Write the data to {@link ListVector}.
  */
-public class AvroArraysConsumer implements Consumer<ListVector> {
+public class AvroArraysConsumer extends BaseAvroConsumer<ListVector> {
 
-  private ListVector vector;
   private final Consumer delegate;
-
-  private int currentIndex = 0;
 
   /**
    * Instantiate a ArrayConsumer.
    */
   public AvroArraysConsumer(ListVector vector, Consumer delegate) {
-    this.vector = vector;
+    super(vector);
     this.delegate = delegate;
   }
 
@@ -58,31 +54,14 @@ public class AvroArraysConsumer implements Consumer<ListVector> {
   }
 
   @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return this.vector;
-  }
-
-  @Override
   public void close() throws Exception {
-    vector.close();
+    super.close();
     delegate.close();
   }
 
   @Override
   public boolean resetValueVector(ListVector vector) {
-    this.currentIndex = 0;
-    this.vector = vector;
     this.delegate.resetValueVector(vector.getDataVector());
-    return true;
+    return super.resetValueVector(vector);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
@@ -20,55 +20,24 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 
 import org.apache.arrow.vector.BitVector;
-import org.apache.arrow.vector.FieldVector;
 import org.apache.avro.io.Decoder;
 
 /**
  * Consumer which consume boolean type values from avro decoder.
  * Write the data to {@link BitVector}.
  */
-public class AvroBooleanConsumer implements Consumer<BitVector> {
-
-  private BitVector vector;
-  private int currentIndex = 0;
+public class AvroBooleanConsumer extends BaseAvroConsumer<BitVector> {
 
   /**
    * Instantiate a AvroBooleanConsumer.
    */
   public AvroBooleanConsumer(BitVector vector) {
-    this.vector = vector;
+    super(vector);
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
     vector.setSafe(currentIndex, decoder.readBoolean() ? 1 : 0);
     currentIndex++;
-  }
-
-  @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return this.vector;
-  }
-
-  @Override
-  public void close() throws Exception {
-    vector.close();
-  }
-
-  @Override
-  public boolean resetValueVector(BitVector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
-    return true;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBytesConsumer.java
@@ -20,7 +20,6 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.avro.io.Decoder;
 
@@ -28,18 +27,15 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume bytes type values from avro decoder.
  * Write the data to {@link VarBinaryVector}.
  */
-public class AvroBytesConsumer implements Consumer<VarBinaryVector> {
+public class AvroBytesConsumer extends BaseAvroConsumer<VarBinaryVector> {
 
-  private VarBinaryVector vector;
   private ByteBuffer cacheBuffer;
-
-  private int currentIndex;
 
   /**
    * Instantiate a AvroBytesConsumer.
    */
   public AvroBytesConsumer(VarBinaryVector vector) {
-    this.vector = vector;
+    super(vector);
   }
 
   @Override
@@ -49,32 +45,5 @@ public class AvroBytesConsumer implements Consumer<VarBinaryVector> {
     cacheBuffer = decoder.readBytes(cacheBuffer);
     vector.setSafe(currentIndex, cacheBuffer, 0, cacheBuffer.limit());
     currentIndex++;
-  }
-
-  @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return vector;
-  }
-
-  @Override
-  public void close() throws Exception {
-    vector.close();
-  }
-
-  @Override
-  public boolean resetValueVector(VarBinaryVector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
-    return true;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
@@ -19,7 +19,6 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.avro.io.Decoder;
 
@@ -27,48 +26,17 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume double type values from avro decoder.
  * Write the data to {@link Float8Vector}.
  */
-public class AvroDoubleConsumer implements Consumer<Float8Vector> {
-
-  private Float8Vector vector;
-
-  private int currentIndex;
+public class AvroDoubleConsumer extends BaseAvroConsumer<Float8Vector> {
 
   /**
    * Instantiate a AvroDoubleConsumer.
    */
   public AvroDoubleConsumer(Float8Vector vector) {
-    this.vector = vector;
+    super(vector);
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
     vector.setSafe(currentIndex++, decoder.readDouble());
-  }
-
-  @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return vector;
-  }
-
-  @Override
-  public void close() throws Exception {
-    vector.close();
-  }
-
-  @Override
-  public boolean resetValueVector(Float8Vector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
-    return true;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroEnumConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroEnumConsumer.java
@@ -20,7 +20,6 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 
 import org.apache.arrow.vector.BaseIntVector;
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.avro.io.Decoder;
 
@@ -28,48 +27,17 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume enum type values from avro decoder.
  * Write the data to {@link IntVector}.
  */
-public class AvroEnumConsumer implements Consumer<BaseIntVector> {
-
-  private BaseIntVector vector;
-
-  private int currentIndex;
+public class AvroEnumConsumer extends BaseAvroConsumer<BaseIntVector> {
 
   /**
    * Instantiate a AvroEnumConsumer.
    */
   public AvroEnumConsumer(BaseIntVector vector) {
-    this.vector = vector;
+    super(vector);
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
     vector.setWithPossibleTruncate(currentIndex++, decoder.readEnum());
-  }
-
-  @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return this.vector;
-  }
-
-  @Override
-  public void close() throws Exception {
-    vector.close();
-  }
-
-  @Override
-  public boolean resetValueVector(BaseIntVector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
-    return true;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFixedConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFixedConsumer.java
@@ -19,7 +19,6 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.avro.io.Decoder;
 
@@ -27,18 +26,15 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume fixed type values from avro decoder.
  * Write the data to {@link org.apache.arrow.vector.FixedSizeBinaryVector}.
  */
-public class AvroFixedConsumer implements Consumer<FixedSizeBinaryVector> {
+public class AvroFixedConsumer extends BaseAvroConsumer<FixedSizeBinaryVector> {
 
-  private FixedSizeBinaryVector vector;
   private final byte[] reuseBytes;
-
-  private int currentIndex;
 
   /**
    * Instantiate a AvroFixedConsumer.
    */
   public AvroFixedConsumer(FixedSizeBinaryVector vector, int size) {
-    this.vector = vector;
+    super(vector);
     reuseBytes = new byte[size];
   }
 
@@ -46,32 +42,5 @@ public class AvroFixedConsumer implements Consumer<FixedSizeBinaryVector> {
   public void consume(Decoder decoder) throws IOException {
     decoder.readFixed(reuseBytes);
     vector.setSafe(currentIndex++, reuseBytes);
-  }
-
-  @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return vector;
-  }
-
-  @Override
-  public void close() throws Exception {
-    vector.close();
-  }
-
-  @Override
-  public boolean resetValueVector(FixedSizeBinaryVector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
-    return true;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -19,7 +19,6 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.avro.io.Decoder;
 
@@ -27,48 +26,17 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume float type values from avro decoder.
  * Write the data to {@link Float4Vector}.
  */
-public class AvroFloatConsumer implements Consumer<Float4Vector> {
-
-  private Float4Vector vector;
-
-  private int currentIndex;
+public class AvroFloatConsumer extends BaseAvroConsumer<Float4Vector> {
 
   /**
    * Instantiate a AvroFloatConsumer.
    */
   public AvroFloatConsumer(Float4Vector vector) {
-    this.vector = vector;
+    super(vector);
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
     vector.setSafe(currentIndex++, decoder.readFloat());
-  }
-
-  @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return this.vector;
-  }
-
-  @Override
-  public void close() throws Exception {
-    vector.close();
-  }
-
-  @Override
-  public boolean resetValueVector(Float4Vector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
-    return true;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -20,55 +20,23 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 
 import org.apache.arrow.vector.BigIntVector;
-import org.apache.arrow.vector.FieldVector;
 import org.apache.avro.io.Decoder;
 
 /**
  * Consumer which consume long type values from avro decoder.
  * Write the data to {@link BigIntVector}.
  */
-public class AvroLongConsumer implements Consumer<BigIntVector> {
-
-  private BigIntVector vector;
-
-  private int currentIndex;
+public class AvroLongConsumer extends BaseAvroConsumer<BigIntVector> {
 
   /**
    * Instantiate a AvroLongConsumer.
    */
   public AvroLongConsumer(BigIntVector vector) {
-    this.vector = vector;
+    super(vector);
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
     vector.setSafe(currentIndex++, decoder.readLong());
-  }
-
-  @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return this.vector;
-  }
-
-  @Override
-  public void close() throws Exception {
-    vector.close();
-  }
-
-  @Override
-  public boolean resetValueVector(BigIntVector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
-    return true;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroMapConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroMapConsumer.java
@@ -19,7 +19,6 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.avro.io.Decoder;
 
@@ -27,18 +26,15 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume map type values from avro decoder.
  * Write the data to {@link MapVector}.
  */
-public class AvroMapConsumer implements Consumer<MapVector> {
+public class AvroMapConsumer extends BaseAvroConsumer<MapVector> {
 
-  private MapVector vector;
   private final Consumer delegate;
-
-  private int currentIndex;
 
   /**
    * Instantiate a AvroMapConsumer.
    */
   public AvroMapConsumer(MapVector vector, Consumer delegate) {
-    this.vector = vector;
+    super(vector);
     this.delegate = delegate;
   }
 
@@ -58,31 +54,14 @@ public class AvroMapConsumer implements Consumer<MapVector> {
   }
 
   @Override
-  public void addNull() {
-    vector.setValueCount(vector.getValueCount() + 1);
-  }
-
-  @Override
-  public void setPosition(int index) {
-    this.currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return this.vector;
-  }
-
-  @Override
   public void close() throws Exception {
-    vector.close();
+    super.close();
     delegate.close();
   }
 
   @Override
   public boolean resetValueVector(MapVector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
     this.delegate.resetValueVector(vector.getDataVector());
-    return true;
+    return super.resetValueVector(vector);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroNullConsumer.java
@@ -19,46 +19,21 @@ package org.apache.arrow.consumers;
 
 import java.io.IOException;
 
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.NullVector;
 import org.apache.avro.io.Decoder;
 
 /**
  * Consumer which consume null type values from avro decoder.
- * Corresponding to {@link org.apache.arrow.vector.ZeroVector}.
+ * Corresponding to {@link org.apache.arrow.vector.NullVector}.
  */
-public class AvroNullConsumer implements Consumer<NullVector> {
-
-  private NullVector vector;
+public class AvroNullConsumer extends BaseAvroConsumer<NullVector> {
 
   public AvroNullConsumer(NullVector vector) {
-    this.vector = vector;
+    super(vector);
   }
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setValueCount(vector.getValueCount() + 1);
-  }
-
-  @Override
-  public void addNull() {}
-
-  @Override
-  public void setPosition(int index) {}
-
-  @Override
-  public FieldVector getVector() {
-    return this.vector;
-  }
-
-  @Override
-  public void close() {
-    vector.close();
-  }
-
-  @Override
-  public boolean resetValueVector(NullVector vector) {
-    this.vector = vector;
-    return true;
+    currentIndex++;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStringConsumer.java
@@ -20,7 +20,6 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.avro.io.Decoder;
 
@@ -28,17 +27,15 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume string type values from avro decoder.
  * Write the data to {@link VarCharVector}.
  */
-public class AvroStringConsumer implements Consumer<VarCharVector> {
+public class AvroStringConsumer extends BaseAvroConsumer<VarCharVector> {
 
-  private VarCharVector vector;
   private ByteBuffer cacheBuffer;
-  private int currentIndex;
 
   /**
    * Instantiate a AvroStringConsumer.
    */
   public AvroStringConsumer(VarCharVector vector) {
-    this.vector = vector;
+    super(vector);
   }
 
   @Override
@@ -47,32 +44,5 @@ public class AvroStringConsumer implements Consumer<VarCharVector> {
     // if its capacity < size to read, decoder will create a new one with new capacity.
     cacheBuffer = decoder.readBytes(cacheBuffer);
     vector.setSafe(currentIndex++, cacheBuffer, 0, cacheBuffer.limit());
-  }
-
-  @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    return this.vector;
-  }
-
-  @Override
-  public void close() throws Exception {
-    vector.close();
-  }
-
-  @Override
-  public boolean resetValueVector(VarCharVector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
-    return true;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStructConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroStructConsumer.java
@@ -20,7 +20,6 @@ package org.apache.arrow.consumers;
 import java.io.IOException;
 
 import org.apache.arrow.util.AutoCloseables;
-import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.avro.io.Decoder;
 
@@ -28,18 +27,15 @@ import org.apache.avro.io.Decoder;
  * Consumer which consume nested record type values from avro decoder.
  * Write the data to {@link org.apache.arrow.vector.complex.StructVector}.
  */
-public class AvroStructConsumer implements Consumer<StructVector> {
+public class AvroStructConsumer extends BaseAvroConsumer<StructVector> {
 
   private final Consumer[] delegates;
-  private StructVector vector;
-
-  private int currentIndex;
 
   /**
    * Instantiate a AvroStructConsumer.
    */
   public AvroStructConsumer(StructVector vector, Consumer[] delegates) {
-    this.vector = vector;
+    super(vector);
     this.delegates = delegates;
   }
 
@@ -55,34 +51,16 @@ public class AvroStructConsumer implements Consumer<StructVector> {
   }
 
   @Override
-  public void addNull() {
-    currentIndex++;
-  }
-
-  @Override
-  public void setPosition(int index) {
-    currentIndex = index;
-  }
-
-  @Override
-  public FieldVector getVector() {
-    vector.setValueCount(currentIndex);
-    return this.vector;
-  }
-
-  @Override
   public void close() throws Exception {
-    vector.close();
+    super.close();
     AutoCloseables.close(delegates);
   }
 
   @Override
   public boolean resetValueVector(StructVector vector) {
-    this.vector = vector;
-    this.currentIndex = 0;
     for (int i = 0; i < delegates.length; i++) {
       delegates[i].resetValueVector(vector.getChildrenFromFields().get(i));
     }
-    return true;
+    return super.resetValueVector(vector);
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/BaseAvroConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/BaseAvroConsumer.java
@@ -17,26 +17,49 @@
 
 package org.apache.arrow.consumers;
 
-import java.io.IOException;
-
-import org.apache.arrow.vector.IntVector;
-import org.apache.avro.io.Decoder;
+import org.apache.arrow.vector.FieldVector;
 
 /**
- * Consumer which consume int type values from avro decoder.
- * Write the data to {@link IntVector}.
+ * Base class for all avro consumers.
+ * @param <T> vector type.
  */
-public class AvroIntConsumer extends BaseAvroConsumer<IntVector> {
+public abstract class BaseAvroConsumer<T extends FieldVector> implements Consumer<T> {
+
+  protected T vector;
+  protected int currentIndex;
 
   /**
-   * Instantiate a AvroIntConsumer.
+   * Constructs a base avro consumer.
+   * @param vector the vector to consume.
    */
-  public AvroIntConsumer(IntVector vector) {
-    super(vector);
+  public BaseAvroConsumer(T vector) {
+    this.vector = vector;
   }
 
   @Override
-  public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readInt());
+  public void addNull() {
+    currentIndex++;
+  }
+
+  @Override
+  public void setPosition(int index) {
+    currentIndex = index;
+  }
+
+  @Override
+  public FieldVector getVector() {
+    return vector;
+  }
+
+  @Override
+  public void close() throws Exception {
+    vector.close();
+  }
+
+  @Override
+  public boolean resetValueVector(T vector) {
+    this.vector = vector;
+    this.currentIndex = 0;
+    return true;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/BaseAvroConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/BaseAvroConsumer.java
@@ -20,7 +20,7 @@ package org.apache.arrow.consumers;
 import org.apache.arrow.vector.FieldVector;
 
 /**
- * Base class for all avro consumers.
+ * Base class for non-skippable avro consumers.
  * @param <T> vector type.
  */
 public abstract class BaseAvroConsumer<T extends FieldVector> implements Consumer<T> {

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/CompositeAvroConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/CompositeAvroConsumer.java
@@ -55,8 +55,7 @@ public class CompositeAvroConsumer implements AutoCloseable {
   public void resetConsumerVectors(VectorSchemaRoot root) {
     int index = 0;
     for (Consumer consumer : consumers) {
-      boolean resetResult = consumer.resetValueVector(root.getFieldVectors().get(index));
-      if (resetResult) {
+      if (consumer.resetValueVector(root.getFieldVectors().get(index))) {
         index++;
       }
     }


### PR DESCRIPTION
Related to [ARROW-6912](https://issues.apache.org/jira/browse/ARROW-6912).

Currently Avro converter consumers have some common variables and methods which could be eliminated by extracting a common class.