### PR TITLE
ARROW-6758: [Developer] Install local NodeJS via nvm when running release verification

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -361,6 +361,14 @@ test_glib() {
 
 test_js() {
   pushd js
+
+  export NVM_DIR="`pwd`/.nvm"
+  mkdir -p $NVM_DIR
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.34.0/install.sh | bash
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+
+  nvm install node
+
   npm install
   # clean, lint, and build JS source
   npx run-s clean:all lint build


### PR DESCRIPTION
This will allow developers to verify JS and run the integration tests without having NodeJS installed previously