### PR TITLE
ARROW-7014: [Developer][Release] Add "wheels" verification option to verify-release-candidate.sh for Linux and macOS

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -34,8 +34,9 @@ case $# in
      VERSION="$2"
      RC_NUMBER="$3"
      case $ARTIFACT in
-       source|binaries) ;;
-       *) echo "Invalid argument: '${ARTIFACT}', valid options are 'source' or 'binaries'"
+       source|binaries|wheels) ;;
+       *) echo "Invalid argument: '${ARTIFACT}', valid options are \
+'source', 'binaries', or 'wheels'"
           exit 1
           ;;
      esac
@@ -99,14 +100,7 @@ fetch_archive() {
   shasum -a 512 -c ${dist_name}.tar.gz.sha512
 }
 
-test_binary() {
-  local download_dir=binaries
-  mkdir -p ${download_dir}
-
-  python3 $SOURCE_DIR/download_rc_binaries.py $VERSION $RC_NUMBER --dest=${download_dir}
-
-  pushd ${download_dir}
-
+verify_cwd_artifact_signatures() {
   # verify the signature and the checksums of each artifact
   find . -name '*.asc' | while read sigfile; do
     artifact=${sigfile/.asc/}
@@ -122,7 +116,16 @@ test_binary() {
     shasum -a 512 -c $base_artifact.sha512 || exit 1
     popd
   done
+}
 
+test_binary() {
+  local download_dir=binaries
+  mkdir -p ${download_dir}
+
+  python3 $SOURCE_DIR/download_rc_binaries.py $VERSION $RC_NUMBER --dest=${download_dir}
+
+  pushd ${download_dir}
+  verify_cwd_artifact_signatures
   popd
 }
 
@@ -188,15 +191,6 @@ setup_miniconda() {
   rm -f miniconda.sh
 
   . $MINICONDA/etc/profile.d/conda.sh
-
-  conda create -n arrow-test -y -q -c conda-forge \
-        python=3.6 \
-        nomkl \
-        numpy \
-        pandas \
-        six \
-        cython
-  conda activate arrow-test
 }
 
 # Build and test Java (Requires newer Maven -- I used 3.3.9)
@@ -213,6 +207,15 @@ test_package_java() {
 # Build and test C++
 
 test_and_install_cpp() {
+  conda create -n arrow-test -y -q -c conda-forge \
+        python=3.6 \
+        nomkl \
+        numpy \
+        pandas \
+        six \
+        cython
+  conda activate arrow-test
+
   mkdir cpp/build
   pushd cpp/build
 
@@ -531,6 +534,56 @@ test_binary_distribution() {
   fi
 }
 
+test_linux_wheels() {
+  local py_arches="2.7mu 3.6m 3.7m"
+
+  for py_arch in ${py_arches}; do
+    local env=_verify_wheel-${py_arch}
+    conda create -yq -n ${env} python=${py_arch//[mu]/}
+    conda activate ${env}
+
+    pip install python-rc/${VERSION}-rc${RC_NUMBER}/pyarrow-${VERSION}-cp${py_arch//[mu.]/}-cp${py_arch//./}-manylinux1_x86_64.whl
+
+    python -c "import pyarrow.parquet"
+    python -c "import pyarrow.plasma"
+    python -c "import pyarrow.fs"
+
+    pip install python-rc/${VERSION}-rc${RC_NUMBER}/pyarrow-${VERSION}-cp${py_arch//[mu.]/}-cp${py_arch//./}-manylinux2010_x86_64.whl
+
+    python -c "import pyarrow.parquet"
+    python -c "import pyarrow.plasma"
+    python -c "import pyarrow.fs"
+
+    # TODO check Flight only for Python 3
+  done
+}
+
+test_wheels() {
+  local download_dir=binaries
+  mkdir -p ${download_dir}
+
+  if [ "$(uname)" == "Darwin" ]; then
+    local filter_regex=.*macosx.*
+  else
+    local filter_regex=.*manylinux.*
+  fi
+
+  python3 $SOURCE_DIR/download_rc_binaries.py $VERSION $RC_NUMBER \
+          --regex=${filter_regex} \
+          --dest=${download_dir}
+
+  pushd ${download_dir}
+  verify_cwd_artifact_signatures
+
+  if [ "$(uname)" == "Darwin" ]; then
+    test_macos_wheels
+  else
+    test_linux_wheels
+  fi
+
+  popd
+}
+
 # By default test all functionalities.
 # To deactivate one test, deactivate the test and all of its dependents
 # To explicitly select one test, set TEST_DEFAULT=0 TEST_X=1
@@ -592,6 +645,10 @@ if [ "${ARTIFACT}" == "source" ]; then
   pushd ${dist_name}
   test_source_distribution
   popd
+elif [ "${ARTIFACT}" == "wheels" ]; then
+  import_gpg_keys
+  setup_miniconda
+  test_wheels
 else
   import_gpg_keys
   test_binary_distribution

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -559,14 +559,14 @@ test_linux_wheels() {
 }
 
 test_macos_wheels() {
-  local py_arches="2.7mu 3.6m 3.7m"
+  local py_arches="2.7m 3.6m 3.7m"
 
   for py_arch in ${py_arches}; do
     local env=_verify_wheel-${py_arch}
-    conda create -yq -n ${env} python=${py_arch//[mu]/}
+    conda create -yq -n ${env} python=${py_arch//m/}
     conda activate ${env}
 
-    pip install python-rc/${VERSION}-rc${RC_NUMBER}/pyarrow-${VERSION}-cp${py_arch//[mu.]/}-cp${py_arch//./}-manylinux1_x86_64.whl
+    pip install python-rc/${VERSION}-rc${RC_NUMBER}/pyarrow-${VERSION}-cp${py_arch//[m.]/}-cp${py_arch//./}-macosx_10_6_intel.whl
 
     python -c "import pyarrow.parquet"
     python -c "import pyarrow.plasma"
@@ -585,6 +585,9 @@ test_wheels() {
   else
     local filter_regex=.*manylinux.*
   fi
+  
+  conda create -yq -n py3-base python=3.7
+  conda activate py3-base
 
   python3 $SOURCE_DIR/download_rc_binaries.py $VERSION $RC_NUMBER \
           --regex=${filter_regex} \

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -558,6 +558,24 @@ test_linux_wheels() {
   done
 }
 
+test_macos_wheels() {
+  local py_arches="2.7mu 3.6m 3.7m"
+
+  for py_arch in ${py_arches}; do
+    local env=_verify_wheel-${py_arch}
+    conda create -yq -n ${env} python=${py_arch//[mu]/}
+    conda activate ${env}
+
+    pip install python-rc/${VERSION}-rc${RC_NUMBER}/pyarrow-${VERSION}-cp${py_arch//[mu.]/}-cp${py_arch//./}-manylinux1_x86_64.whl
+
+    python -c "import pyarrow.parquet"
+    python -c "import pyarrow.plasma"
+    python -c "import pyarrow.fs"
+
+    # TODO check Flight only for Python 3
+  done
+}
+
 test_wheels() {
   local download_dir=binaries
   mkdir -p ${download_dir}

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -585,7 +585,7 @@ test_wheels() {
   else
     local filter_regex=.*manylinux.*
   fi
-  
+
   conda create -yq -n py3-base python=3.7
   conda activate py3-base
 


### PR DESCRIPTION
Creates temporary conda environments to install and check the wheels. Checking within virtualenv would be more work but give us a stronger guarantee that things are working, but this will help catch obvious brokenness / corruption

My bash fu is not strong enough to conditionally check whether Flight or Gandiva are working on Python 3 wheels, maybe someone can help me.

For 0.15.1 rc0 this passes on Linux but fails on macOS because of the issue I cited in the vote thread.