### PR TITLE
ARROW-7019: [Java] Improve the performance of loading validity buffers

### DIFF
--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -1166,6 +1166,21 @@ public final class ArrowBuf implements AutoCloseable {
   }
 
   /**
+   * Sets all bits to one in the specified range.
+   * @param index index index (0 based relative to the portion of memory
+   *              this ArrowBuf has access to)
+   * @param length length of bytes to set.
+   * @return this ArrowBuf
+   */
+  public ArrowBuf setOne(int index, int length) {
+    if (length != 0) {
+      this.checkIndex(index, length);
+      PlatformDependent.setMemory(this.addr + index, length, (byte) 0xff);
+    }
+    return this;
+  }
+
+  /**
    * Returns <code>this</code> if size is less then {@link #capacity()}, otherwise
    * delegates to {@link BufferManager#replace(ArrowBuf, int)} to get a new buffer.
    */

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -500,10 +500,8 @@ public final class BitVector extends BaseFixedWidthVector {
       }
 
       // fill in one full byte at a time
-      for (int i = startByteIndex; i < endByteIndex; i++) {
-        validityBuffer.setByte(i, 0xFF);
-        valueBuffer.setByte(i, 0xFF);
-      }
+      validityBuffer.setOne(startByteIndex, endByteIndex - startByteIndex);
+      valueBuffer.setOne(startByteIndex, endByteIndex - startByteIndex);
 
       // fill in the last byte (if it's not full)
       if (endBytebitIndex != 0) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -288,9 +288,7 @@ public class BitVectorHelper {
       }
       /* all non-NULLs */
       int fullBytesCount = valueCount / 8;
-      for (int i = 0; i < fullBytesCount; ++i) {
-        newBuffer.setByte(i, 0xFF);
-      }
+      newBuffer.setOne(0, fullBytesCount);
       int remainder = valueCount % 8;
       if (remainder > 0) {
         byte bitMask = (byte) (0xFFL >>> ((8 - remainder) & 7));


### PR DESCRIPTION
At the receiver side of flighting, loading validity buffer is an important operation, as each vector has a validity buffer.

For non-nullable vectors, the current implementation of loading the validity buffer is inefficient. We improve the performance of this operation by efficiently setting the bits of a memory region to 1.

Benchmark results show that the changes leads to a 35% performance improvement:

Before:
BitVectorHelperBenchmarks.loadValidityBufferAllOne avgt 5 748.916 ± 23.290 ns/op

After:
BitVectorHelperBenchmarks.loadValidityBufferAllOne avgt 5 487.352 ± 15.046 ns/op