### PR TITLE
ARROW-7020: [Java] Fix the bugs when calculating vector hash code

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -598,7 +598,11 @@ public class UnionVector implements FieldVector {
     }
 
     public boolean isNull(int index) {
-      return (typeBuffer.getByte(index * TYPE_WIDTH) == 0);
+      ValueVector vec = getVector(index);
+      if (vec == null) {
+        return true;
+      }
+      return vec.isNull(index);
     }
 
     @Override
@@ -693,10 +697,11 @@ public class UnionVector implements FieldVector {
 
     @Override
     public int hashCode(int index, ArrowBufHasher hasher) {
-      if (isNull(index)) {
+      ValueVector vec = getVector(index);
+      if (vec == null) {
         return 0;
       }
-      return getVector(index).hashCode(index, hasher);
+      return vec.hashCode(index, hasher);
     }
 
     @Override

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -693,6 +693,9 @@ public class UnionVector implements FieldVector {
 
     @Override
     public int hashCode(int index, ArrowBufHasher hasher) {
+      if (isNull(index)) {
+        return 0;
+      }
       return getVector(index).hashCode(index, hasher);
     }
 

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -49,6 +49,7 @@ import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.ValueVectorUtility;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.util.OversizedAllocationException;
@@ -699,7 +700,7 @@ public class UnionVector implements FieldVector {
     public int hashCode(int index, ArrowBufHasher hasher) {
       ValueVector vec = getVector(index);
       if (vec == null) {
-        return 0;
+        return ArrowBufPointer.NULL_HASH_CODE;
       }
       return vec.hashCode(index, hasher);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -885,6 +885,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
 
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
+    if (isNull(index)) {
+      return 0;
+    }
     int start = typeWidth * index;
     int end = typeWidth * (index + 1);
     return ByteFunctionHelpers.hash(hasher, this.getDataBuffer(), start, end);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -886,7 +886,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isNull(index)) {
-      return 0;
+      return ArrowBufPointer.NULL_HASH_CODE;
     }
     int start = typeWidth * index;
     int end = typeWidth * (index + 1);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -1373,6 +1373,9 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
 
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
+    if (isNull(index)) {
+      return 0;
+    }
     final int start = getStartOffset(index);
     final int end = getStartOffset(index + 1);
     return ByteFunctionHelpers.hash(hasher, this.getDataBuffer(), start, end);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -1374,7 +1374,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isNull(index)) {
-      return 0;
+      return ArrowBufPointer.NULL_HASH_CODE;
     }
     final int start = getStartOffset(index);
     final int end = getStartOffset(index + 1);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.TransferPair;
@@ -57,7 +58,7 @@ public final class ZeroVector extends NullVector {
 
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
-    return 0;
+    return ArrowBufPointer.NULL_HASH_CODE;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
+import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
@@ -535,7 +536,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
-      return 0;
+      return ArrowBufPointer.NULL_HASH_CODE;
     }
     int hash = 0;
     for (int i = 0; i < listSize; i++) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
+import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
@@ -426,7 +427,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
-      return 0;
+      return ArrowBufPointer.NULL_HASH_CODE;
     }
     int hash = 0;
     final int start = offsetBuffer.getInt(index * OFFSET_WIDTH);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseValueVector;
@@ -489,7 +490,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
-      return 0;
+      return ArrowBufPointer.NULL_HASH_CODE;
     } else {
       return super.hashCode(index, hasher);
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
@@ -390,6 +390,28 @@ public class TestUnionVector {
     }
   }
 
+  @Test
+  public void testSetGetNull() {
+    try (UnionVector srcVector = new UnionVector(EMPTY_SCHEMA_PATH, allocator, null)) {
+      srcVector.allocateNew();
+
+      final NullableIntHolder holder = new NullableIntHolder();
+      holder.isSet = 1;
+      holder.value = 5;
+
+      // write some data
+      srcVector.setType(0, MinorType.INT);
+      srcVector.setSafe(0, holder);
+
+      assertFalse(srcVector.isNull(0));
+
+      holder.isSet = 0;
+      srcVector.setSafe(0, holder);
+
+      assertTrue(srcVector.isNull(0));
+    }
+  }
+
   private static NullableIntHolder newIntHolder(int value) {
     final NullableIntHolder holder = new NullableIntHolder();
     holder.isSet = 1;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2643,6 +2643,26 @@ public class TestValueVector {
   }
 
   @Test
+  public void testNullHashCode() {
+    try (IntVector intVec = new IntVector("int vector", allocator);
+    VarCharVector varChVec = new VarCharVector("var char vector", allocator)) {
+      intVec.allocateNew(1);
+      intVec.setValueCount(1);
+      varChVec.allocateNew(100, 1);
+      varChVec.setValueCount(1);
+
+      intVec.set(0, 100);
+      varChVec.set(0, "abc".getBytes());
+
+      intVec.setNull(0);
+      varChVec.setNull(0);
+
+      assertEquals(0, intVec.hashCode(0));
+      assertEquals(0, varChVec.hashCode(0));
+    }
+  }
+
+  @Test
   public void testToString() {
     try (final IntVector intVector = new IntVector("intVector", allocator);
          final ListVector listVector = ListVector.empty("listVector", allocator);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2643,22 +2643,44 @@ public class TestValueVector {
   }
 
   @Test
-  public void testNullHashCode() {
-    try (IntVector intVec = new IntVector("int vector", allocator);
-    VarCharVector varChVec = new VarCharVector("var char vector", allocator)) {
+  public void testFixedWidthVectorNullHashCode() {
+    try (IntVector intVec = new IntVector("int vector", allocator)) {
       intVec.allocateNew(1);
       intVec.setValueCount(1);
+
+      intVec.set(0, 100);
+      intVec.setNull(0);
+
+      assertEquals(0, intVec.hashCode(0));
+    }
+  }
+
+  @Test
+  public void testVariableWidthVectorNullHashCode() {
+    try (VarCharVector varChVec = new VarCharVector("var char vector", allocator)) {
       varChVec.allocateNew(100, 1);
       varChVec.setValueCount(1);
 
-      intVec.set(0, 100);
       varChVec.set(0, "abc".getBytes());
-
-      intVec.setNull(0);
       varChVec.setNull(0);
 
-      assertEquals(0, intVec.hashCode(0));
       assertEquals(0, varChVec.hashCode(0));
+    }
+  }
+
+  @Test
+  public void testUnionNullHashCode() {
+    try (UnionVector srcVector = new UnionVector(EMPTY_SCHEMA_PATH, allocator, null)) {
+      srcVector.allocateNew();
+
+      final NullableIntHolder holder = new NullableIntHolder();
+      holder.isSet = 0;
+
+      // write some data
+      srcVector.setType(0, MinorType.INT);
+      srcVector.setSafe(0, holder);
+
+      assertEquals(0, srcVector.hashCode(0));
     }
   }
 


### PR DESCRIPTION
When calculating the hash code for a value in the vector, the validity bit must be taken into account.