### PR TITLE
ARROW-7022, ARROW-7023: [Python] fix handling of pandas Index and Period/Interval extension arrays in pa.array

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -204,9 +204,6 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
             if pandas_api.have_pandas:
                 values, type = pandas_api.compat.get_datetimetz_type(
                     values, obj.dtype, type)
-            if not isinstance(values, np.ndarray):
-                # e.g. pandas extension array that has no __arrow_array__
-                values = np.asarray(values)
             return _ndarray_to_array(values, mask, type, c_from_pandas, safe,
                                      pool)
     else:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1726,8 +1726,8 @@ cdef dict _array_classes = {
 
 
 cdef object get_series_values(object obj, bint* is_series):
-    if pandas_api.is_series(obj):
-        result = obj.values
+    if pandas_api.is_series(obj) or pandas_api.is_index(obj):
+        result = pandas_api.get_values(obj)
         is_series[0] = True
     elif isinstance(obj, np.ndarray):
         result = obj

--- a/python/pyarrow/pandas-shim.pxi
+++ b/python/pyarrow/pandas-shim.pxi
@@ -33,6 +33,7 @@ cdef class _PandasAPIShim(object):
         object _datetimetz_type, _extension_array
         object _array_like_types
         bint has_sparse
+        bint _pd024
 
     def __init__(self):
         self._tried_importing_pandas = False
@@ -86,6 +87,8 @@ cdef class _PandasAPIShim(object):
             self.has_sparse = False
         else:
             self.has_sparse = True
+
+        self._pd024 = self._loose_version >= LooseVersion('0.24')
 
     cdef inline _check_import(self, bint raise_=True):
         if self._tried_importing_pandas:
@@ -182,6 +185,28 @@ cdef class _PandasAPIShim(object):
             return isinstance(obj, self._series)
         else:
             return False
+
+    cpdef is_index(self, obj):
+        if self._have_pandas_internal():
+            return isinstance(obj, self._index)
+        else:
+            return False
+
+    cpdef get_values(self, obj):
+        """
+        Get the underlying array values of a pandas Series or Index in the
+        format (np.ndarray or pandas ExtensionArray) as we need them.
+
+        Assumes obj is a pandas Series or Index.
+        """
+        self._check_import()
+        if isinstance(obj.dtype, (self.pd.api.types.IntervalDtype,
+                                  self.pd.api.types.PeriodDtype)):
+            if self._pd024:
+                # only since pandas 0.24, interval and period are stored as
+                # such in Series
+                return obj.array
+        return obj.values
 
     def assert_frame_equal(self, *args, **kwargs):
         self._check_import()

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1203,6 +1203,17 @@ def test_pandas_null_sentinels_raise_error():
         assert result.null_count == (1 if ty != 'null' else 2)
 
 
+@pytest.mark.pandas
+def test_pandas_null_sentinels_index():
+    # ARROW-7023 - ensure that when passing a pandas Index, "from_pandas"
+    # semantics are used
+    import pandas as pd
+    idx = pd.Index([1, 2, np.nan], dtype=object)
+    result = pa.array(idx)
+    expected = pa.array([1, 2, np.nan], from_pandas=True)
+    assert result.equals(expected)
+
+
 def test_array_from_numpy_datetimeD():
     arr = np.array([None, datetime.date(2017, 4, 4)], dtype='datetime64[D]')
 

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -542,7 +542,7 @@ class TestFeatherReader(unittest.TestCase):
 
         # period
         df = pd.DataFrame({'a': pd.period_range('2013', freq='M', periods=3)})
-        self._assert_error_on_write(df, ValueError)
+        self._assert_error_on_write(df, TypeError)
 
         # non-strings
         df = pd.DataFrame({'a': ['a', 1, 2.0]})

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3232,8 +3232,8 @@ class DummyExtensionType(pa.PyExtensionType):
 
 
 def PandasArray__arrow_array__(self, type=None):
-    # harcode dummy return - we only want to check that this method is
-    # correctly called
+    # harcode dummy return regardless of self - we only want to check that
+    # this method is correctly called
     storage = pa.array([1, 2, 3], type=pa.int64())
     return pa.ExtensionArray.from_storage(DummyExtensionType(), storage)
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2576,7 +2576,7 @@ def test_convert_unsupported_type_error_message():
     })
 
     expected_msg = 'Conversion failed for column a with type period'
-    with pytest.raises(pa.ArrowInvalid, match=expected_msg):
+    with pytest.raises(TypeError, match=expected_msg):
         pa.Table.from_pandas(df)
 
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3222,6 +3222,47 @@ def test_array_protocol():
         assert result.equals(expected2)
 
 
+class DummyExtensionType(pa.PyExtensionType):
+
+    def __init__(self):
+        pa.PyExtensionType.__init__(self, pa.int64())
+
+    def __reduce__(self):
+        return DummyExtensionType, ()
+
+
+def PandasArray__arrow_array__(self, type=None):
+    # harcode dummy return - we only want to check that this method is
+    # correctly called
+    storage = pa.array([1, 2, 3], type=pa.int64())
+    return pa.ExtensionArray.from_storage(DummyExtensionType(), storage)
+
+
+def test_array_protocol_pandas_extension_types(monkeypatch):
+    # ARROW-7022 - ensure protocol works for Period / Interval extension dtypes
+
+    if LooseVersion(pd.__version__) < '0.24.0':
+        pytest.skip(reason='Period/IntervalArray only introduced in 0.24')
+
+    storage = pa.array([1, 2, 3], type=pa.int64())
+    expected = pa.ExtensionArray.from_storage(DummyExtensionType(), storage)
+
+    monkeypatch.setattr(pd.arrays.PeriodArray, "__arrow_array__",
+                        PandasArray__arrow_array__, raising=False)
+    monkeypatch.setattr(pd.arrays.IntervalArray, "__arrow_array__",
+                        PandasArray__arrow_array__, raising=False)
+    for arr in [pd.period_range("2012-01-01", periods=3, freq="D").array,
+                pd.interval_range(1, 4).array]:
+        result = pa.array(arr)
+        assert result.equals(expected)
+        result = pa.array(pd.Series(arr))
+        assert result.equals(expected)
+        result = pa.array(pd.Index(arr))
+        assert result.equals(expected)
+        result = pa.table(pd.DataFrame({'a': arr})).column('a').chunk(0)
+        assert result.equals(expected)
+
+
 # ----------------------------------------------------------------------
 # Pandas ExtensionArray support
 


### PR DESCRIPTION
Fixes https://issues.apache.org/jira/browse/ARROW-7022, and while doing this noticed another bug this is fixing (for which I opened https://issues.apache.org/jira/browse/ARROW-7023)