### PR TITLE
ARROW-6987: [CI] Travis OSX failing to install sdk headers

### DIFF
--- a/ci/travis_install_osx_sdk.sh
+++ b/ci/travis_install_osx_sdk.sh
@@ -20,10 +20,7 @@
 set -ex
 
 if [ ${using_homebrew} = "yes" ]; then
-  sudo \
-    installer \
-    -pkg /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg \
-    -target /
+  export SDKROOT="$(xcrun --show-sdk-path)"
 else
   export MACOSX_DEPLOYMENT_TARGET="10.9"
   export CONDA_BUILD_SYSROOT="$(xcode-select -p)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${MACOSX_DEPLOYMENT_TARGET}.sdk"


### PR DESCRIPTION
`macOS_SDK_headers_for_macOS_10.14.pkg` is no longer provided in Xcode 11.
We shouldn't depend on it.