### PR TITLE
ARROW-7027: [Python] Correctly raise error in pa.table(..) on invalid input

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1635,7 +1635,8 @@ def table(data, names=None, schema=None, metadata=None):
                 "passing a pandas DataFrame")
         return Table.from_pandas(data, schema=schema)
     else:
-        return TypeError("Expected pandas DataFrame or python dictionary")
+        raise TypeError(
+            "Expected pandas DataFrame, python dictionary or list of arrays")
 
 
 def concat_tables(tables):

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -1183,6 +1183,11 @@ def test_table_factory_function_args_pandas():
     assert table.column('a').type == pa.int32()
 
 
+def test_table_factory_function_invalid_input():
+    with pytest.raises(TypeError, match="Expected pandas DataFrame, python"):
+        pa.table("invalid input")
+
+
 def test_table_function_unicode_schema():
     col_a = "äääh"
     col_b = "öööf"


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-7027