### PR TITLE
ARROW-7037: [C++ ] Compile error on the combination of protobuf >= 3.9 and clang

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2304,6 +2304,9 @@ macro(build_orc)
       set(ORC_CMAKE_CXX_FLAGS " -Wno-zero-as-null-pointer-constant \
 -Wno-inconsistent-missing-destructor-override -Wno-error=undef ")
     endif()
+    if("${Protobuf_VERSION}" VERSION_GREATER_EQUAL "3.9.0")
+      set(ORC_CMAKE_CXX_FLAGS "${ORC_CMAKE_CXX_FLAGS} -Wno-comma ")
+    endif()
   endif()
 
   set(ORC_CMAKE_CXX_FLAGS "${EP_CXX_FLAGS} ${ORC_CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
I encountered the following compile error on the combination of protobuf 3.10.0 and clang (Xcode 11).

```
[13/26] Building CXX object c++/src/CMakeFiles/orc.dir/wrap/orc-proto-wrapper.cc.o
FAILED: c++/src/CMakeFiles/orc.dir/wrap/orc-proto-wrapper.cc.o
/Applications/Xcode_11.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++   -Ic++/include -I/Users/mrkn/src/github.com/apache/arrow/cpp/build.debug/orc_ep-prefix/src/orc_ep/c++/include -I/Users/mrkn/src/github.com/apache/arrow/cpp/build.debug/orc_ep-prefix/src/orc_ep/c++/src -Ic++/src -isystem c++/libs/thirdparty/zlib_ep-install/include -isystem c++/libs/thirdparty/lz4_ep-install/include -Qunused-arguments -fcolor-diagnostics -ggdb -O0 -g -fPIC  -Wno-zero-as-null-pointer-constant -Wno-inconsistent-missing-destructor-override -Wno-error=undef -std=c++11 -Weverything -Wno-c++98-compat -Wno-missing-prototypes -Wno-c++98-compat-pedantic -Wno-padded -Wno-covered-switch-default -Wno-missing-noreturn -Wno-unknown-pragmas -Wno-gnu-zero-variadic-macro-arguments -Wconversion -Wno-c++2a-compat -Werror -std=c++11 -Weverything -Wno-c++98-compat -Wno-missing-prototypes -Wno-c++98-compat-pedantic -Wno-padded -Wno-covered-switch-default -Wno-missing-noreturn -Wno-unknown-pragmas -Wno-gnu-zero-variadic-macro-arguments -Wconversion -Wno-c++2a-compat -Werror -O0 -g -MD -MT c++/src/CMakeFiles/orc.dir/wrap/orc-proto-wrapper.cc.o -MF c++/src/CMakeFiles/orc.dir/wrap/orc-proto-wrapper.cc.o.d -o c++/src/CMakeFiles/orc.dir/wrap/orc-proto-wrapper.cc.o -c /Users/mrkn/src/github.com/apache/arrow/cpp/build.debug/orc_ep-prefix/src/orc_ep/c++/src/wrap/orc-proto-wrapper.cc
In file included from /Users/mrkn/src/github.com/apache/arrow/cpp/build.debug/orc_ep-prefix/src/orc_ep/c++/src/wrap/orc-proto-wrapper.cc:44:
c++/src/orc_proto.pb.cc:959:145: error: possible misuse of comma operator here [-Werror,-Wcomma]
static bool dynamic_init_dummy_orc_5fproto_2eproto = (  ::PROTOBUF_NAMESPACE_ID::internal::AddDescriptors(&descriptor_table_orc_5fproto_2eproto), true);
                                                                                                                                                ^
c++/src/orc_proto.pb.cc:959:57: note: cast expression to void to silence warning
static bool dynamic_init_dummy_orc_5fproto_2eproto = (  ::PROTOBUF_NAMESPACE_ID::internal::AddDescriptors(&descriptor_table_orc_5fproto_2eproto), true);
                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                        static_cast<void>(                                                                      )
1 error generated.
```

I'd like to put `-Wno-comma` in `ORG_CMAKE_CXX_FLAGS` when the version of protobuf >= 3.9.

This is the related issue on protobuf: https://github.com/protocolbuffers/protobuf/issues/6619