### PR TITLE
ARROW-6952: [C++][Dataset] Implement predicate pushdown with ParqueFileFragment

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -26,6 +26,7 @@
 
 namespace parquet {
 class ParquetFileReader;
+class RowGroupMetaData;
 }  // namespace parquet
 
 namespace arrow {
@@ -74,6 +75,9 @@ class ARROW_DS_EXPORT ParquetFragment : public FileBasedDataFragment {
 
   bool splittable() const override { return true; }
 };
+
+Result<std::shared_ptr<Expression>> RowGroupStatisticsAsExpression(
+    const parquet::RowGroupMetaData& metadata);
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -104,8 +104,8 @@ class ArrowParquetWriterMixin : public ::testing::Test {
     std::shared_ptr<Buffer> out;
     auto sink = CreateOutputStream(pool);
 
-    ARROW_EXPECT_OK(WriteRecordBatchReader(reader, pool, sink));
-    ARROW_EXPECT_OK(sink->Finish(&out));
+    ABORT_NOT_OK(WriteRecordBatchReader(reader, pool, sink));
+    ABORT_NOT_OK(sink->Finish(&out));
 
     return out;
   }
@@ -145,12 +145,9 @@ class ParquetBufferFixtureMixin : public ArrowParquetWriterMixin {
 };
 
 class TestParquetFileFormat : public ParquetBufferFixtureMixin {
- public:
-  TestParquetFileFormat() : ctx_(std::make_shared<ScanContext>()) {}
-
  protected:
   std::shared_ptr<ScanOptions> opts_ = ScanOptions::Defaults();
-  std::shared_ptr<ScanContext> ctx_;
+  std::shared_ptr<ScanContext> ctx_ = std::make_shared<ScanContext>();
 };
 
 TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
@@ -181,6 +178,97 @@ TEST_F(TestParquetFileFormat, Inspect) {
   std::shared_ptr<Schema> actual;
   ASSERT_OK(format.Inspect(*source.get(), &actual));
   EXPECT_EQ(*actual, *schema_);
+}
+
+void CountRowsInScan(ScanTaskIterator& it, int64_t expected_rows,
+                     int64_t expected_batches) {
+  int64_t actual_rows = 0;
+  int64_t actual_batches = 0;
+
+  for (auto maybe_scan_task : it) {
+    ASSERT_OK_AND_ASSIGN(auto scan_task, std::move(maybe_scan_task));
+    for (auto maybe_record_batch : scan_task->Scan()) {
+      ASSERT_OK_AND_ASSIGN(auto record_batch, std::move(maybe_record_batch));
+      actual_rows += record_batch->num_rows();
+      actual_batches++;
+    }
+  }
+
+  EXPECT_EQ(actual_rows, expected_rows);
+  EXPECT_EQ(actual_batches, expected_batches);
+}
+
+class TestParquetFileFormatPushDown : public TestParquetFileFormat {
+ public:
+  void CountRowsAndBatchesInScan(DataFragment& fragment, int64_t expected_rows,
+                                 int64_t expected_batches) {
+    int64_t actual_rows = 0;
+    int64_t actual_batches = 0;
+
+    ScanTaskIterator it;
+    ASSERT_OK(fragment.Scan(ctx_, &it));
+    for (auto maybe_scan_task : it) {
+      ASSERT_OK_AND_ASSIGN(auto scan_task, std::move(maybe_scan_task));
+      for (auto maybe_record_batch : scan_task->Scan()) {
+        ASSERT_OK_AND_ASSIGN(auto record_batch, std::move(maybe_record_batch));
+        actual_rows += record_batch->num_rows();
+        actual_batches++;
+      }
+    }
+
+    EXPECT_EQ(actual_rows, expected_rows);
+    EXPECT_EQ(actual_batches, expected_batches);
+  }
+};
+
+TEST_F(TestParquetFileFormatPushDown, Basic) {
+  // Given a number `n`, the arithmetic dataset creates n RecordBatches where
+  // each RecordBatch is keyed by a unique integer in [1, n]. Let `rb_i` denote
+  // the record batch keyed by `i`. `rb_i` is composed of `i` rows where all
+  // values are a variant of `i`, e.g. {"i64": i, "u8": i, ... }.
+  //
+  // Thus the ArithmeticDataset(n) has n RecordBatches and the total number of
+  // rows is n(n+1)/2.
+  //
+  // This test uses the DataFragment directly, and so no post-filtering is
+  // applied via ScanOptions' evaluator. Thus, counting the number of returned
+  // rows and returned row groups is a good enough proxy to check if pushdown
+  // predicate is working.
+  constexpr int64_t kNumRowGroups = 16;
+  constexpr int64_t kTotalNumRows = kNumRowGroups * (kNumRowGroups + 1) / 2;
+
+  auto reader = ArithmeticDatasetFixture::GetRecordBatchReader(kNumRowGroups);
+  auto source = GetFileSource(reader.get());
+  auto fragment = std::make_shared<ParquetFragment>(*source, opts_);
+
+  opts_->filter = scalar(true);
+  CountRowsAndBatchesInScan(*fragment, kTotalNumRows, kNumRowGroups);
+
+  for (int64_t i = 1; i <= kNumRowGroups; i++) {
+    opts_->filter = ("i64"_ == int64_t(i)).Copy();
+    CountRowsAndBatchesInScan(*fragment, i, 1);
+  }
+
+  /* Out of bound filters should skip all RowGroups. */
+  opts_->filter = scalar(false);
+  CountRowsAndBatchesInScan(*fragment, 0, 0);
+  opts_->filter = ("i64"_ == int64_t(kNumRowGroups + 1)).Copy();
+  CountRowsAndBatchesInScan(*fragment, 0, 0);
+  opts_->filter = ("i64"_ == int64_t(-1)).Copy();
+  CountRowsAndBatchesInScan(*fragment, 0, 0);
+  // No rows match 1 and 2.
+  opts_->filter = ("i64"_ == int64_t(1) and "u8"_ == uint8_t(2)).Copy();
+  CountRowsAndBatchesInScan(*fragment, 0, 0);
+
+  opts_->filter = ("i64"_ == int64_t(2) or "i64"_ == int64_t(4)).Copy();
+  CountRowsAndBatchesInScan(*fragment, 2 + 4, 2);
+
+  opts_->filter = ("i64"_ < int64_t(6)).Copy();
+  CountRowsAndBatchesInScan(*fragment, 5 * (5 + 1) / 2, 5);
+
+  opts_->filter = ("i64"_ >= int64_t(6)).Copy();
+  CountRowsAndBatchesInScan(*fragment, kTotalNumRows - (5 * (5 + 1) / 2),
+                            kNumRowGroups - 5);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -179,6 +179,10 @@ class ARROW_DS_EXPORT Expression {
     return Copy();
   }
 
+  std::shared_ptr<Expression> Assume(const std::shared_ptr<Expression>& given) const {
+    return Assume(*given);
+  }
+
   /// returns a debug string representing this expression
   virtual std::string ToString() const = 0;
 

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -62,7 +62,13 @@ class ExpressionsTest : public ::testing::Test {
     auto simplified = expr.Assume(given);
     ASSERT_EQ(E{simplified}, E{expected})
         << "  simplification of: " << expr.ToString() << std::endl
-        << "              given: " << given.ToString() << std::endl;
+        << "              given: " << given.ToString() << std::endl
+        << "           expected: " << expected.ToString() << std::endl;
+  }
+
+  void AssertSimplifiesTo(const Expression& expr, const Expression& given,
+                          const std::shared_ptr<Expression>& expected) {
+    AssertSimplifiesTo(expr, given, *expected);
   }
 
   std::shared_ptr<Schema> schema_ =

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -123,9 +123,11 @@ TEST_F(TestSimpleScanner, ToTable) {
       std::make_shared<SimpleDataSource>(fragments),
   };
 
+  options_->schema = s;
   auto scanner = std::make_shared<SimpleScanner>(sources, options_, ctx_);
   std::shared_ptr<Table> actual;
 
+  options_->use_threads = false;
   ASSERT_OK(scanner->ToTable(&actual));
   AssertTablesEqual(*expected, *actual);
 

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -32,7 +32,6 @@
 
 using arrow::ArrayFromVector;
 using arrow::Field;
-using arrow::Scalar;
 using arrow::TimeUnit;
 
 using ParquetType = parquet::Type;

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -32,6 +32,7 @@
 
 using arrow::ArrayFromVector;
 using arrow::Field;
+using arrow::Scalar;
 using arrow::TimeUnit;
 
 using ParquetType = parquet::Type;

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -326,9 +326,9 @@ PARQUET_EXPORT
 /// @}
 
 PARQUET_EXPORT
-::arrow::Status FromParquetStatistics(const std::shared_ptr<Statistics>& Statistics,
-                                      std::shared_ptr<::arrow::Scalar>* min,
-                                      std::shared_ptr<::arrow::Scalar>* max);
+::arrow::Status StatisticsAsScalars(const Statistics& Statistics,
+                                    std::shared_ptr<::arrow::Scalar>* min,
+                                    std::shared_ptr<::arrow::Scalar>* max);
 
 }  // namespace arrow
 }  // namespace parquet

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -326,23 +326,6 @@ PARQUET_EXPORT
 /// @}
 
 PARQUET_EXPORT
-::arrow::Status FromParquetSchema(
-    const SchemaDescriptor* parquet_schema, const ArrowReaderProperties& properties,
-    const std::shared_ptr<const ::arrow::KeyValueMetadata>& key_value_metadata,
-    std::shared_ptr<::arrow::Schema>* out, std::vector<int>* out_indices = NULLPTR);
-
-PARQUET_EXPORT
-::arrow::Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
-                                  const ArrowReaderProperties& properties,
-                                  std::shared_ptr<::arrow::Schema>* out,
-                                  std::vector<int>* out_indices = NULLPTR);
-
-PARQUET_EXPORT
-::arrow::Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
-                                  std::shared_ptr<::arrow::Schema>* out,
-                                  std::vector<int>* out_indices = NULLPTR);
-
-PARQUET_EXPORT
 ::arrow::Status FromParquetStatistics(const std::shared_ptr<Statistics>& Statistics,
                                       std::shared_ptr<::arrow::Scalar>* min,
                                       std::shared_ptr<::arrow::Scalar>* max);

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -31,6 +31,7 @@ namespace arrow {
 class ChunkedArray;
 class KeyValueMetadata;
 class RecordBatchReader;
+struct Scalar;
 class Schema;
 class Table;
 class RecordBatch;
@@ -328,12 +329,23 @@ PARQUET_EXPORT
 ::arrow::Status FromParquetSchema(
     const SchemaDescriptor* parquet_schema, const ArrowReaderProperties& properties,
     const std::shared_ptr<const ::arrow::KeyValueMetadata>& key_value_metadata,
-    std::shared_ptr<::arrow::Schema>* out);
+    std::shared_ptr<::arrow::Schema>* out, std::vector<int>* out_indices = NULLPTR);
 
 PARQUET_EXPORT
 ::arrow::Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
                                   const ArrowReaderProperties& properties,
-                                  std::shared_ptr<::arrow::Schema>* out);
+                                  std::shared_ptr<::arrow::Schema>* out,
+                                  std::vector<int>* out_indices = NULLPTR);
+
+PARQUET_EXPORT
+::arrow::Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
+                                  std::shared_ptr<::arrow::Schema>* out,
+                                  std::vector<int>* out_indices = NULLPTR);
+
+PARQUET_EXPORT
+::arrow::Status FromParquetStatistics(const std::shared_ptr<Statistics>& Statistics,
+                                      std::shared_ptr<::arrow::Scalar>* min,
+                                      std::shared_ptr<::arrow::Scalar>* max);
 
 }  // namespace arrow
 }  // namespace parquet

--- a/cpp/src/parquet/arrow/reader_internal.h
+++ b/cpp/src/parquet/arrow/reader_internal.h
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include "parquet/arrow/schema.h"
 #include "parquet/column_reader.h"
 #include "parquet/file_reader.h"
 #include "parquet/metadata.h"
@@ -123,76 +124,8 @@ struct ReaderContext {
   }
 };
 
-struct PARQUET_EXPORT SchemaField {
-  std::shared_ptr<::arrow::Field> field;
-  std::vector<SchemaField> children;
-
-  // Only set for leaf nodes
-  int column_index = -1;
-
-  int16_t max_definition_level;
-  int16_t max_repetition_level;
-
-  bool is_leaf() const { return column_index != -1; }
-
-  Status GetReader(const std::shared_ptr<ReaderContext>& context,
-                   std::unique_ptr<ColumnReaderImpl>* out) const;
-};
-
-struct SchemaManifest {
-  const SchemaDescriptor* descr;
-  std::shared_ptr<::arrow::Schema> origin_schema;
-  std::shared_ptr<const KeyValueMetadata> schema_metadata;
-  std::vector<SchemaField> schema_fields;
-
-  std::unordered_map<int, const SchemaField*> column_index_to_field;
-  std::unordered_map<const SchemaField*, const SchemaField*> child_to_parent;
-
-  Status GetColumnField(int column_index, const SchemaField** out) const {
-    auto it = column_index_to_field.find(column_index);
-    if (it == column_index_to_field.end()) {
-      return Status::KeyError("Column index ", column_index,
-                              " not found in schema manifest, may be malformed");
-    }
-    *out = it->second;
-    return Status::OK();
-  }
-
-  const SchemaField* GetParent(const SchemaField* field) const {
-    // Returns nullptr also if not found
-    auto it = child_to_parent.find(field);
-    if (it == child_to_parent.end()) {
-      return nullptr;
-    }
-    return it->second;
-  }
-
-  bool GetFieldIndices(const std::vector<int>& column_indices, std::vector<int>* out) {
-    // Coalesce a list of schema fields indices which are the roots of the
-    // columns referred by a list of column indices
-    const schema::GroupNode* group = descr->group_node();
-    std::unordered_set<int> already_added;
-    out->clear();
-    for (auto& column_idx : column_indices) {
-      auto field_node = descr->GetColumnRoot(column_idx);
-      auto field_idx = group->FieldIndex(*field_node);
-      if (field_idx < 0) {
-        return false;
-      }
-      auto insertion = already_added.insert(field_idx);
-      if (insertion.second) {
-        out->push_back(field_idx);
-      }
-    }
-    return true;
-  }
-};
-
-PARQUET_EXPORT
-Status BuildSchemaManifest(const SchemaDescriptor* schema,
-                           const std::shared_ptr<const KeyValueMetadata>& metadata,
-                           const ArrowReaderProperties& properties,
-                           SchemaManifest* manifest);
+Status GetReader(const SchemaField& field, const std::shared_ptr<ReaderContext>& context,
+                 std::unique_ptr<ColumnReaderImpl>* out);
 
 }  // namespace arrow
 }  // namespace parquet

--- a/cpp/src/parquet/arrow/schema.h
+++ b/cpp/src/parquet/arrow/schema.h
@@ -19,6 +19,9 @@
 #define PARQUET_ARROW_SCHEMA_H
 
 #include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include "parquet/platform.h"
 #include "parquet/schema.h"
@@ -27,15 +30,22 @@ namespace arrow {
 
 class Field;
 class Schema;
+class Status;
 
 }  // namespace arrow
 
 namespace parquet {
 
+class ArrowReaderProperties;
 class ArrowWriterProperties;
 class WriterProperties;
 
 namespace arrow {
+
+/// \defgroup arrow-to-parquet-schema-conversion Functions to convert an Arrow
+/// schema into a Parquet schema.
+///
+/// @{
 
 PARQUET_EXPORT
 ::arrow::Status FieldToNode(const std::shared_ptr<::arrow::Field>& field,
@@ -53,6 +63,102 @@ PARQUET_EXPORT
 ::arrow::Status ToParquetSchema(const ::arrow::Schema* arrow_schema,
                                 const WriterProperties& properties,
                                 std::shared_ptr<SchemaDescriptor>* out);
+
+/// @}
+
+/// \defgroup parquet-to-arrow-schema-conversion Functions to convert a Parquet
+/// schema into an Arrow schema.
+///
+/// @{
+
+PARQUET_EXPORT
+::arrow::Status FromParquetSchema(
+    const SchemaDescriptor* parquet_schema, const ArrowReaderProperties& properties,
+    const std::shared_ptr<const ::arrow::KeyValueMetadata>& key_value_metadata,
+    std::shared_ptr<::arrow::Schema>* out);
+
+PARQUET_EXPORT
+::arrow::Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
+                                  const ArrowReaderProperties& properties,
+                                  std::shared_ptr<::arrow::Schema>* out);
+
+PARQUET_EXPORT
+::arrow::Status FromParquetSchema(const SchemaDescriptor* parquet_schema,
+                                  std::shared_ptr<::arrow::Schema>* out);
+
+/// @}
+
+/// \brief Bridge between an arrow::Field and parquet column indices.
+struct PARQUET_EXPORT SchemaField {
+  std::shared_ptr<::arrow::Field> field;
+  std::vector<SchemaField> children;
+
+  // Only set for leaf nodes
+  int column_index = -1;
+
+  int16_t max_definition_level;
+  int16_t max_repetition_level;
+
+  bool is_leaf() const { return column_index != -1; }
+};
+
+/// \brief Bridge between a parquet Schema and an arrow Schema.
+///
+/// Expose parquet columns as a tree structure. Useful traverse and link
+/// between arrow's Schema and parquet's Schema.
+struct PARQUET_EXPORT SchemaManifest {
+  static ::arrow::Status Make(
+      const SchemaDescriptor* schema,
+      const std::shared_ptr<const ::arrow::KeyValueMetadata>& metadata,
+      const ArrowReaderProperties& properties, SchemaManifest* manifest);
+
+  const SchemaDescriptor* descr;
+  std::shared_ptr<::arrow::Schema> origin_schema;
+  std::shared_ptr<const ::arrow::KeyValueMetadata> schema_metadata;
+  std::vector<SchemaField> schema_fields;
+
+  std::unordered_map<int, const SchemaField*> column_index_to_field;
+  std::unordered_map<const SchemaField*, const SchemaField*> child_to_parent;
+
+  ::arrow::Status GetColumnField(int column_index, const SchemaField** out) const {
+    auto it = column_index_to_field.find(column_index);
+    if (it == column_index_to_field.end()) {
+      return ::arrow::Status::KeyError("Column index ", column_index,
+                                       " not found in schema manifest, may be malformed");
+    }
+    *out = it->second;
+    return ::arrow::Status::OK();
+  }
+
+  const SchemaField* GetParent(const SchemaField* field) const {
+    // Returns nullptr also if not found
+    auto it = child_to_parent.find(field);
+    if (it == child_to_parent.end()) {
+      return NULLPTR;
+    }
+    return it->second;
+  }
+
+  bool GetFieldIndices(const std::vector<int>& column_indices, std::vector<int>* out) {
+    // Coalesce a list of schema fields indices which are the roots of the
+    // columns referred by a list of column indices
+    const schema::GroupNode* group = descr->group_node();
+    std::unordered_set<int> already_added;
+    out->clear();
+    for (auto& column_idx : column_indices) {
+      auto field_node = descr->GetColumnRoot(column_idx);
+      auto field_idx = group->FieldIndex(*field_node);
+      if (field_idx < 0) {
+        return false;
+      }
+      auto insertion = already_added.insert(field_idx);
+      if (insertion.second) {
+        out->push_back(field_idx);
+      }
+    }
+    return true;
+  }
+};
 
 }  // namespace arrow
 }  // namespace parquet

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -126,6 +126,7 @@ class LevelBuilder {
                                   " not supported yet");                   \
   }
 
+  // See ARROW-1644
   NOT_IMPLEMENTED_VISIT(LargeList)
   NOT_IMPLEMENTED_VISIT(Map)
   NOT_IMPLEMENTED_VISIT(FixedSizeList)

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -427,8 +427,8 @@ class FileWriterImpl : public FileWriter {
         closed_(false) {}
 
   Status Init() {
-    return BuildSchemaManifest(writer_->schema(), /*schema_metadata=*/nullptr,
-                               default_arrow_reader_properties(), &schema_manifest_);
+    return SchemaManifest::Make(writer_->schema(), /*schema_metadata=*/nullptr,
+                                default_arrow_reader_properties(), &schema_manifest_);
   }
 
   Status NewRowGroup(int64_t chunk_size) override {


### PR DESCRIPTION
The proposed change can be divided in 3 parts:

- Implement the `StatisticsAsScalars(Statistics& stats, Scalar* min, Scalar* max)`
  function to convert `parquet::Statistic`s min and max as `arrow::Scalar`s.

- Implement the `RowGroupStatisticsAsExpression(RowGroupMetadata& meta, Expression* out)`
  function to represents the RowGroup's statistics as an expression of
  conjunction, e.g. `(a_min <= a AND a <= a_max) AND (b_min <= b AND b <= b_max) AND ...`

- Modifies ParquetScanTaskIterator to skip RowGroups by checking the
  expression derived from the metadata with the filter expression.