### PR TITLE
ARROW-7058: [C++] FileSystemDataSourceDiscovery should apply partition schemes relative to its base dir

### DIFF
--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -89,10 +89,6 @@ class ARROW_DS_EXPORT DataSourceDiscovery {
 /// of fs::FileStats or a fs::Selector.
 class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery {
  public:
-  static Status Make(fs::FileSystem* filesystem, std::vector<fs::FileStats> files,
-                     std::shared_ptr<FileFormat> format,
-                     std::shared_ptr<DataSourceDiscovery>* out);
-
   static Status Make(fs::FileSystem* filesystem, fs::Selector selector,
                      std::shared_ptr<FileFormat> format,
                      std::shared_ptr<DataSourceDiscovery>* out);
@@ -102,11 +98,12 @@ class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery
   Status Finish(std::shared_ptr<DataSource>* out) override;
 
  protected:
-  FileSystemDataSourceDiscovery(fs::FileSystem* filesystem,
+  FileSystemDataSourceDiscovery(fs::FileSystem* filesystem, fs::Selector selector,
                                 std::vector<fs::FileStats> files,
                                 std::shared_ptr<FileFormat> format);
 
   fs::FileSystem* fs_;
+  fs::Selector selector_;
   std::vector<fs::FileStats> files_;
   std::shared_ptr<FileFormat> format_;
 };

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -89,6 +89,14 @@ class ARROW_DS_EXPORT DataSourceDiscovery {
 /// of fs::FileStats or a fs::Selector.
 class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery {
  public:
+  static Status Make(fs::FileSystem* filesystem, std::string base_dir,
+                     std::vector<fs::FileStats> files, std::shared_ptr<FileFormat> format,
+                     std::shared_ptr<DataSourceDiscovery>* out);
+
+  static Status Make(fs::FileSystem* filesystem, std::vector<fs::FileStats> files,
+                     std::shared_ptr<FileFormat> format,
+                     std::shared_ptr<DataSourceDiscovery>* out);
+
   static Status Make(fs::FileSystem* filesystem, fs::Selector selector,
                      std::shared_ptr<FileFormat> format,
                      std::shared_ptr<DataSourceDiscovery>* out);
@@ -98,12 +106,12 @@ class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery
   Status Finish(std::shared_ptr<DataSource>* out) override;
 
  protected:
-  FileSystemDataSourceDiscovery(fs::FileSystem* filesystem, fs::Selector selector,
+  FileSystemDataSourceDiscovery(fs::FileSystem* filesystem, std::string base_dir,
                                 std::vector<fs::FileStats> files,
                                 std::shared_ptr<FileFormat> format);
 
   fs::FileSystem* fs_;
-  fs::Selector selector_;
+  std::string base_dir_;
   std::vector<fs::FileStats> files_;
   std::shared_ptr<FileFormat> format_;
 };

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -88,16 +88,20 @@ Result<std::shared_ptr<Expression>> HivePartitionScheme::Parse(
   return ConvertPartitionKeys(GetUnconvertedKeys(path), *schema_);
 }
 
-Status ApplyPartitionScheme(const PartitionScheme& scheme, const fs::Selector& selector,
+Status ApplyPartitionScheme(const PartitionScheme& scheme,
+                            std::vector<fs::FileStats> files, PathPartitions* out) {
+  return ApplyPartitionScheme(scheme, "", std::move(files), out);
+}
+
+Status ApplyPartitionScheme(const PartitionScheme& scheme, const std::string& base_dir,
                             std::vector<fs::FileStats> files, PathPartitions* out) {
   for (const auto& file : files) {
-    // XXX is this the right way to drop the base dir?
-    DCHECK(std::equal(selector.base_dir.begin(), selector.base_dir.end(),
-                      file.path().begin()));
-    const auto& path = file.path().substr(selector.base_dir.size());
+    if (file.path().substr(0, base_dir.size()) != base_dir) continue;
+    auto path = file.path().substr(base_dir.size());
+
     std::shared_ptr<Expression> partition;
     RETURN_NOT_OK(scheme.Parse(path, &partition));
-    out->emplace(path, std::move(partition));
+    out->emplace(std::move(path), std::move(partition));
   }
 
   return Status::OK();

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -88,10 +88,10 @@ Result<std::shared_ptr<Expression>> HivePartitionScheme::Parse(
   return ConvertPartitionKeys(GetUnconvertedKeys(path), *schema_);
 }
 
-Status ApplyPartitionScheme(const PartitionScheme& scheme,
+Status ApplyPartitionScheme(const PartitionScheme& scheme, const fs::Selector& selector,
                             std::vector<fs::FileStats> files, PathPartitions* out) {
   for (const auto& file : files) {
-    const auto& path = file.path();
+    const auto& path = file.path().substr(selector.base_dir.size());
     std::shared_ptr<Expression> partition;
     RETURN_NOT_OK(scheme.Parse(path, &partition));
     out->emplace(path, std::move(partition));

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -91,6 +91,9 @@ Result<std::shared_ptr<Expression>> HivePartitionScheme::Parse(
 Status ApplyPartitionScheme(const PartitionScheme& scheme, const fs::Selector& selector,
                             std::vector<fs::FileStats> files, PathPartitions* out) {
   for (const auto& file : files) {
+    // XXX is this the right way to drop the base dir?
+    DCHECK(std::equal(selector.base_dir.begin(), selector.base_dir.end(),
+                      file.path().begin()));
     const auto& path = file.path().substr(selector.base_dir.size());
     std::shared_ptr<Expression> partition;
     RETURN_NOT_OK(scheme.Parse(path, &partition));

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -34,7 +34,8 @@ namespace arrow {
 
 namespace fs {
 struct FileStats;
-}
+struct Selector;
+}  // namespace fs
 
 namespace dataset {
 
@@ -168,7 +169,7 @@ class ARROW_DS_EXPORT FunctionPartitionScheme : public PartitionScheme {
 /// \brief Mapping from path to partition expressions.
 using PathPartitions = std::unordered_map<std::string, std::shared_ptr<Expression>>;
 
-Status ApplyPartitionScheme(const PartitionScheme& scheme,
+Status ApplyPartitionScheme(const PartitionScheme& scheme, const fs::Selector& selector,
                             std::vector<fs::FileStats> files, PathPartitions* out);
 
 // TODO(bkietz) use RE2 and named groups to provide RegexpPartitionScheme

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -169,7 +169,10 @@ class ARROW_DS_EXPORT FunctionPartitionScheme : public PartitionScheme {
 /// \brief Mapping from path to partition expressions.
 using PathPartitions = std::unordered_map<std::string, std::shared_ptr<Expression>>;
 
-Status ApplyPartitionScheme(const PartitionScheme& scheme, const fs::Selector& selector,
+Status ApplyPartitionScheme(const PartitionScheme& scheme,
+                            std::vector<fs::FileStats> files, PathPartitions* out);
+
+Status ApplyPartitionScheme(const PartitionScheme& scheme, const std::string& base_dir,
                             std::vector<fs::FileStats> files, PathPartitions* out);
 
 // TODO(bkietz) use RE2 and named groups to provide RegexpPartitionScheme

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -91,7 +91,7 @@ struct ARROW_EXPORT FileStats {
   void set_type(FileType type) { type_ = type; }
 
   /// The full file path in the filesystem
-  std::string path() const { return path_; }
+  const std::string& path() const { return path_; }
   void set_path(const std::string& path) { path_ = path; }
 
   /// The file base name (component after the last directory separator)


### PR DESCRIPTION
@nealrichardson 