### PR TITLE
ARROW-7060: [R] Post-0.15.1 cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -287,6 +287,7 @@ matrix:
     - if [ $ARROW_CI_R_AFFECTED != "1" ]; then exit; fi
     - source ci/travis/before-install.sh
     # First check that it builds without libarrow
+    - sudo apt-get install devscripts # For checkbashisms
     - pushd ${TRAVIS_BUILD_DIR}/r
     - R -e 'install.packages("remotes"); remotes::install_deps(dep = TRUE)'
     - R CMD build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -269,6 +269,7 @@ matrix:
   # -------------------------------------------------------------------------
   - name: R (with and without libarrow)
     language: r
+    r: devel
     cache:
       directories:
         - $HOME/.ccache
@@ -279,6 +280,7 @@ matrix:
     - ARROW_TRAVIS_PARQUET_ENCRYPTION=1
     - ARROW_TRAVIS_USE_SYSTEM=1
     - ARROW_TRAVIS_MIMALLOC=1
+    - _R_CHECK_BASHISMS_=true
     before_install:
     # Have to copy-paste this here because of how R's build steps work
     - eval `python $TRAVIS_BUILD_DIR/ci/detect-changes.py`

--- a/.travis.yml
+++ b/.travis.yml
@@ -280,7 +280,6 @@ matrix:
     - ARROW_TRAVIS_PARQUET_ENCRYPTION=1
     - ARROW_TRAVIS_USE_SYSTEM=1
     - ARROW_TRAVIS_MIMALLOC=1
-    - _R_CHECK_BASHISMS_=true
     before_install:
     # Have to copy-paste this here because of how R's build steps work
     - eval `python $TRAVIS_BUILD_DIR/ci/detect-changes.py`
@@ -291,7 +290,7 @@ matrix:
     - pushd ${TRAVIS_BUILD_DIR}/r
     - R -e 'install.packages("remotes"); remotes::install_deps(dep = TRUE)'
     - R CMD build .
-    - R CMD check arrow_*tar.gz
+    - R CMD check --as-cran arrow_*tar.gz
     - rm arrow_*tar.gz
     - popd
     # Now, proceed to install the c++ lib and the rest of the job

--- a/ci/PKGBUILD
+++ b/ci/PKGBUILD
@@ -18,7 +18,7 @@
 _realname=arrow
 pkgbase=mingw-w64-${_realname}
 pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
-pkgver=0.15.0.9000
+pkgver=0.15.1.9000
 pkgrel=8000
 pkgdesc="Apache Arrow is a cross-language development platform for in-memory data (mingw-w64)"
 arch=("any")

--- a/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
@@ -19,7 +19,7 @@
 class ApacheArrow < Formula
   desc "Columnar in-memory analytics layer designed to accelerate big data"
   homepage "https://arrow.apache.org/"
-  url "https://www.apache.org/dyn/closer.cgi?path=arrow/arrow-0.15.0.9000/apache-arrow-0.15.0.9000.tar.gz"
+  url "https://www.apache.org/dyn/closer.cgi?path=arrow/arrow-0.15.1.9000/apache-arrow-0.15.1.9000.tar.gz"
   sha256 "9948ddb6d4798b51552d0dca3252dd6e3a7d0f9702714fc6f5a1b59397ce1d28"
   head "https://github.com/apache/arrow.git"
 

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -42,7 +42,6 @@ VignetteBuilder: knitr
 Suggests:
     covr,
     dplyr,
-    fs,
     hms,
     knitr,
     lubridate,

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: arrow
 Title: Integration to 'Apache' 'Arrow'
-Version: 0.15.0.9000
+Version: 0.15.1.9000
 Authors@R: c(
     person("Romain", "Fran\u00e7ois", email = "romain@rstudio.com", role = c("aut"), comment = c(ORCID = "0000-0002-2444-4226")),
     person("Jeroen", "Ooms", email = "jeroen@berkeley.edu", role = c("aut")),

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -17,11 +17,20 @@
   under the License.
 -->
 
-# arrow 0.15.0.9000
+# arrow 0.15.1.9000
+
+## Data exploration
+
+* Tables and RecordBatches now have `dplyr` methods, conditionally loaded if you have `dplyr` available. You can `select()`, `filter()`, etc. and work will be done where possible in Arrow memory. When necessary, data is pulled into R for further computation.
+* For exploration without `dplyr`, `[` methods for Tables, RecordBatches, Arrays, and ChunkedArrays now support natural row extraction operations. These use the C++ `Filter`, `Slice`, and `Take` methods for efficient access, depending on the type of selection vector.
+* An experimental, lazily evaluated `array_expression` class has also been added, enabling among other things the ability to filter a Table with some function of Arrays, such as `arrow_table[arrow_table$var1 > 5, ]` without having to pull everything into R first.
+
+## Compression
 
 * `write_parquet()` now supports compression
+* `codec_is_available()` returns `TRUE` or `FALSE` whether the Arrow C++ library was built with support for a given compression library (e.g. gzip, lz4, snappy)
 
-# arrow 0.15.0
+# arrow 0.15.1
 
 * This patch release includes bugfixes in the C++ library around dictionary types and Parquet reading.
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -23,6 +23,10 @@
 
 # arrow 0.15.0
 
+* This patch release includes bugfixes in the C++ library around dictionary types and Parquet reading.
+
+# arrow 0.15.0
+
 ## Breaking changes
 
 * The R6 classes that wrap the C++ classes are now documented and exported and have been renamed to be more R-friendly. Users of the high-level R interface in this package are not affected. Those who want to interact with the Arrow C++ API more directly should work with these objects and methods. As part of this change, many functions that instantiated these R6 objects have been removed in favor of `Class$create()` methods. Notably, `arrow::array()` and `arrow::table()` have been removed in favor of `Array$create()` and `Table$create()`, eliminating the package startup message about masking `base` functions. For more information, see the new `vignette("arrow")`.

--- a/r/configure
+++ b/r/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/r/configure
+++ b/r/configure
@@ -34,12 +34,14 @@ PKG_TEST_HEADER="<arrow/api.h>"
 PKG_LIBS="-larrow -lparquet"
 
 # generate code
-if [ "$ARROW_R_DEV" == "TRUE" ]; then
+if [ "$ARROW_R_DEV" = "TRUE" ]; then
   echo "*** Generating code with data-raw/codegen.R"
   ${R_HOME}/bin/Rscript data-raw/codegen.R
 fi
 
-if [ "$LOCAL_AUTOBREW" == "TRUE" ]; then
+UNAME=$(uname -s)
+
+if [ "$LOCAL_AUTOBREW" = "TRUE" ]; then
   # LOCAL_AUTOBREW means use the script in tools/
   # If you want to use a local apache-arrow.rb formula, do:
   # $ cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb tools/apache-arrow.rb
@@ -68,7 +70,7 @@ else
     PKG_CFLAGS="$PKGCONFIG_CFLAGS"
     PKG_LIBS=${PKGCONFIG_LIBS}
   else
-    if [[ "$OSTYPE" == "darwin"* ]]; then
+    if [ "$UNAME" = "Darwin" ]; then
       if [ "$FORCE_AUTOBREW" != "TRUE" ] && [ "$(command -v brew)" ] && [ "$(brew ls --versions ${PKG_BREW_NAME})" != "" ]; then
         echo "Using Homebrew ${PKG_BREW_NAME}"
         BREWDIR=$(brew --prefix)
@@ -82,7 +84,7 @@ else
             echo "Failed to download manifest for ${PKG_BREW_NAME}"
           fi
         fi
-        source autobrew
+        . autobrew
         if [ $? -ne 0 ]; then
           echo "Failed to retrieve binary for ${PKG_BREW_NAME}"
         fi
@@ -108,13 +110,13 @@ fi
 TEST_CMD="${CXXCPP} ${CPPFLAGS} ${PKG_CFLAGS} ${CXX11FLAGS} ${CXX11STD} -xc++ -"
 echo "#include $PKG_TEST_HEADER" | ${TEST_CMD} >/dev/null 2>&1
 
-if [ $? -eq 0 ] || [[ "$OSTYPE" == "darwin"* ]]; then
+if [ $? -eq 0 ] || [ "$UNAME" = "Darwin" ]; then
   # Always build with arrow on macOS
   PKG_CFLAGS="$PKG_CFLAGS -DARROW_R_WITH_ARROW"
   echo "PKG_CFLAGS=$PKG_CFLAGS"
   echo "PKG_LIBS=$PKG_LIBS"
 else
-  if [[ "$OSTYPE" == "darwin"* ]]; then
+  if [ "$UNAME" = "Darwin" ]; then
     # Just for debugging: is this possible?
     echo "Test to load header failed. Command:"
     echo "$TEST_CMD"

--- a/r/configure
+++ b/r/configure
@@ -71,9 +71,9 @@ else
     PKG_LIBS=${PKGCONFIG_LIBS}
   else
     if [ "$UNAME" = "Darwin" ]; then
-      if [ "$FORCE_AUTOBREW" != "TRUE" ] && [ "$(command -v brew)" ] && [ "$(brew ls --versions ${PKG_BREW_NAME})" != "" ]; then
+      if [ "$FORCE_AUTOBREW" != "TRUE" ] && [ "`command -v brew`" ] && [ "`brew ls --versions ${PKG_BREW_NAME}`" != "" ]; then
         echo "Using Homebrew ${PKG_BREW_NAME}"
-        BREWDIR=$(brew --prefix)
+        BREWDIR=`brew --prefix`
       else
         echo "Downloading ${PKG_BREW_NAME}"
         if [ -f "autobrew" ]; then

--- a/r/configure
+++ b/r/configure
@@ -39,7 +39,7 @@ if [ "$ARROW_R_DEV" = "TRUE" ]; then
   ${R_HOME}/bin/Rscript data-raw/codegen.R
 fi
 
-UNAME=$(uname -s)
+UNAME=`uname -s`
 
 if [ "$LOCAL_AUTOBREW" = "TRUE" ]; then
   # LOCAL_AUTOBREW means use the script in tools/
@@ -96,10 +96,10 @@ else
 fi
 
 # Find compiler
-CXXCPP="$(${R_HOME}/bin/R CMD config CXX11) -E"
-CXX11FLAGS=$("${R_HOME}"/bin/R CMD config CXX11FLAGS)
-CXX11STD=$("${R_HOME}"/bin/R CMD config CXX11STD)
-CPPFLAGS=$("${R_HOME}"/bin/R CMD config CPPFLAGS)
+CXXCPP="`${R_HOME}/bin/R CMD config CXX11` -E"
+CXX11FLAGS=`"${R_HOME}"/bin/R CMD config CXX11FLAGS`
+CXX11STD=`"${R_HOME}"/bin/R CMD config CXX11STD`
+CPPFLAGS=`"${R_HOME}"/bin/R CMD config CPPFLAGS`
 
 # If libarrow uses the old GLIBCXX ABI, so we have to use it too
 if [ "$ARROW_USE_OLD_CXXABI" ]; then

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -31,7 +31,7 @@ test_that("read_table handles various input streams (ARROW-3450, ARROW-3505)", {
   bytes <- write_arrow(tab, raw())
 
   tab1 <- read_table(tf)
-  tab2 <- read_table(fs::path_abs(tf))
+  tab2 <- read_table(normalizePath(tf))
 
   readable_file <- ReadableFile$create(tf)
   file_reader1 <- RecordBatchFileReader$create(readable_file)

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -22,19 +22,19 @@ tib <- tibble::tibble(x = 1:10, y = rnorm(10), z = letters[1:10])
 
 test_that("Write a feather file", {
   write_feather(tib, feather_file)
-  expect_true(fs::file_exists(feather_file))
+  expect_true(file.exists(feather_file))
 })
 
 test_that("feather read/write round trip", {
-  tf2 <- fs::path_abs(tempfile())
+  tf2 <- normalizePath(tempfile(), mustWork = FALSE)
   write_feather(tib, tf2)
-  expect_true(fs::file_exists(tf2))
+  expect_true(file.exists(tf2))
 
   tf3 <- tempfile()
   stream <- FileOutputStream$create(tf3)
   write_feather(tib, stream)
   stream$close()
-  expect_true(fs::file_exists(tf3))
+  expect_true(file.exists(tf3))
 
   tab1 <- read_feather(feather_file)
   expect_is(tab1, "data.frame")


### PR DESCRIPTION
The most substantive change here is revisions to `r/configure` based on a recently added CRAN check for bashisms. We could have caught that change earlier if we were running R tests on Travis with the latest development version of R, so this patch fixes that as well (even though we may not be using Travis for much longer). 

There is also some backfilling of `r/NEWS.md` since I was already in the file.

Leaving this as a draft PR until the CRAN submission is accepted, in case we need to revise further.