### PR TITLE
ARROW-6594: [Java] Support logical type encodings from Avro

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -50,17 +50,29 @@ import org.apache.arrow.consumers.CompositeAvroConsumer;
 import org.apache.arrow.consumers.Consumer;
 import org.apache.arrow.consumers.SkipConsumer;
 import org.apache.arrow.consumers.SkipFunction;
+import org.apache.arrow.consumers.logical.AvroDateConsumer;
+import org.apache.arrow.consumers.logical.AvroDecimalConsumer;
+import org.apache.arrow.consumers.logical.AvroTimeMicroConsumer;
+import org.apache.arrow.consumers.logical.AvroTimeMillisConsumer;
+import org.apache.arrow.consumers.logical.AvroTimestampMicrosConsumer;
+import org.apache.arrow.consumers.logical.AvroTimestampMillisConsumer;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseIntVector;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -71,12 +83,16 @@ import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryEncoder;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
 import org.apache.avro.io.Decoder;
@@ -106,7 +122,13 @@ public class AvroToArrowUtils {
    *   <li>FIXED --> ArrowType.FixedSizeBinary</li>
    *   <li>RECORD --> ArrowType.Struct</li>
    *   <li>UNION --> ArrowType.Union</li>
-   *   <li>Enum--> ArrowType.Int</li>
+   *   <li>ENUM--> ArrowType.Int</li>
+   *   <li>DECIMAL --> ArrowType.Decimal</li>
+   *   <li>Date --> ArrowType.Date(DateUnit.DAY)</li>
+   *   <li>TimeMillis --> ArrowType.Time(TimeUnit.MILLISECOND, 32)</li>
+   *   <li>TimeMicros --> ArrowType.Time(TimeUnit.MICROSECOND, 64)</li>
+   *   <li>TimestampMillis --> ArrowType.Timestamp(TimeUnit.MILLISECOND, null)</li>
+   *   <li>TimestampMicros --> ArrowType.Timestamp(TimeUnit.MICROSECOND, null)</li>
    * </ul>
    */
 
@@ -137,7 +159,8 @@ public class AvroToArrowUtils {
 
     final BufferAllocator allocator = config.getAllocator();
 
-    Type type = schema.getType();
+    final Type type = schema.getType();
+    final LogicalType logicalType = schema.getLogicalType();
 
     final ArrowType arrowType;
     final FieldType fieldType;
@@ -167,16 +190,37 @@ public class AvroToArrowUtils {
         consumer =  new AvroStringConsumer((VarCharVector) vector);
         break;
       case FIXED:
-        arrowType = new ArrowType.FixedSizeBinary(schema.getFixedSize());
-        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
-        vector = createVector(consumerVector, fieldType, name, allocator);
-        consumer =  new AvroFixedConsumer((FixedSizeBinaryVector) vector, schema.getFixedSize());
+        if (logicalType instanceof LogicalTypes.Decimal) {
+          final int scala = ((LogicalTypes.Decimal) logicalType).getScale();
+          final int precision = ((LogicalTypes.Decimal) logicalType).getPrecision();
+          arrowType = new ArrowType.Decimal(precision, scala);
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer = new AvroDecimalConsumer.FixedDecimalConsumer((DecimalVector) vector, schema.getFixedSize());
+        } else {
+          arrowType = new ArrowType.FixedSizeBinary(schema.getFixedSize());
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer = new AvroFixedConsumer((FixedSizeBinaryVector) vector, schema.getFixedSize());
+        }
         break;
       case INT:
-        arrowType = new ArrowType.Int(32, /*signed=*/true);
-        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
-        vector = createVector(consumerVector, fieldType, name, allocator);
-        consumer = new AvroIntConsumer((IntVector) vector);
+        if (logicalType instanceof LogicalTypes.Date) {
+          arrowType = new ArrowType.Date(DateUnit.DAY);
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer = new AvroDateConsumer((DateDayVector) vector);
+        } else if (logicalType instanceof LogicalTypes.TimeMillis) {
+          arrowType = new ArrowType.Time(TimeUnit.MILLISECOND, 32);
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer = new AvroTimeMillisConsumer((TimeMilliVector) vector);
+        } else {
+          arrowType = new ArrowType.Int(32, /*signed=*/true);
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer = new AvroIntConsumer((IntVector) vector);
+        }
         break;
       case BOOLEAN:
         arrowType = new ArrowType.Bool();
@@ -185,10 +229,27 @@ public class AvroToArrowUtils {
         consumer = new AvroBooleanConsumer((BitVector) vector);
         break;
       case LONG:
-        arrowType = new ArrowType.Int(64, /*signed=*/true);
-        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
-        vector = createVector(consumerVector, fieldType, name, allocator);
-        consumer =  new AvroLongConsumer((BigIntVector) vector);
+        if (logicalType instanceof LogicalTypes.TimeMicros) {
+          arrowType = new ArrowType.Time(TimeUnit.MICROSECOND, 64);
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer =  new AvroTimeMicroConsumer((TimeMicroVector) vector);
+        } else if (logicalType instanceof LogicalTypes.TimestampMillis) {
+          arrowType = new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer =  new AvroTimestampMillisConsumer((TimeStampMilliVector) vector);
+        } else if (logicalType instanceof LogicalTypes.TimestampMicros) {
+          arrowType = new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer =  new AvroTimestampMicrosConsumer((TimeStampMicroVector) vector);
+        } else {
+          arrowType = new ArrowType.Int(64, /*signed=*/true);
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer =  new AvroLongConsumer((BigIntVector) vector);
+        }
         break;
       case FLOAT:
         arrowType =  new ArrowType.FloatingPoint(SINGLE);
@@ -203,10 +264,19 @@ public class AvroToArrowUtils {
         consumer = new AvroDoubleConsumer((Float8Vector) vector);
         break;
       case BYTES:
-        arrowType = new ArrowType.Binary();
-        fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
-        vector = createVector(consumerVector, fieldType, name, allocator);
-        consumer = new AvroBytesConsumer((VarBinaryVector) vector);
+        if (logicalType instanceof LogicalTypes.Decimal) {
+          final int scala = ((LogicalTypes.Decimal) logicalType).getScale();
+          final int precision = ((LogicalTypes.Decimal) logicalType).getPrecision();
+          arrowType = new ArrowType.Decimal(precision, scala);
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer = new AvroDecimalConsumer.BytesDecimalConsumer((DecimalVector) vector);
+        } else {
+          arrowType = new ArrowType.Binary();
+          fieldType =  new FieldType(nullable, arrowType, /*dictionary=*/null, getMetaData(schema));
+          vector = createVector(consumerVector, fieldType, name, allocator);
+          consumer = new AvroBytesConsumer((VarBinaryVector) vector);
+        }
         break;
       case NULL:
         arrowType = new ArrowType.Null();
@@ -340,6 +410,7 @@ public class AvroToArrowUtils {
 
   private static Field avroSchemaToField(Schema schema, String name, AvroToArrowConfig config) {
     final Type type = schema.getType();
+    final LogicalType logicalType = schema.getLogicalType();
     final ArrowType arrowType;
 
     switch (type) {
@@ -405,16 +476,36 @@ public class AvroToArrowUtils {
         arrowType = new ArrowType.Utf8();
         break;
       case FIXED:
-        arrowType = new ArrowType.FixedSizeBinary(schema.getFixedSize());
+        if (logicalType instanceof LogicalTypes.Decimal) {
+          final int scala = ((LogicalTypes.Decimal) logicalType).getScale();
+          final int precision = ((LogicalTypes.Decimal) logicalType).getPrecision();
+          arrowType = new ArrowType.Decimal(precision, scala);
+        } else {
+          arrowType = new ArrowType.FixedSizeBinary(schema.getFixedSize());
+        }
         break;
       case INT:
-        arrowType = new ArrowType.Int(32, /*signed=*/true);
+        if (logicalType instanceof LogicalTypes.Date) {
+          arrowType = new ArrowType.Date(DateUnit.DAY);
+        } else if (logicalType instanceof LogicalTypes.TimeMillis) {
+          arrowType = new ArrowType.Time(TimeUnit.MILLISECOND, 32);
+        } else {
+          arrowType = new ArrowType.Int(32, /*signed=*/true);
+        }
         break;
       case BOOLEAN:
         arrowType = new ArrowType.Bool();
         break;
       case LONG:
-        arrowType = new ArrowType.Int(64, /*signed=*/true);
+        if (logicalType instanceof LogicalTypes.TimeMicros) {
+          arrowType = new ArrowType.Time(TimeUnit.MICROSECOND, 64);
+        } else if (logicalType instanceof LogicalTypes.TimestampMillis) {
+          arrowType = new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
+        } else if (logicalType instanceof LogicalTypes.TimestampMicros) {
+          arrowType = new ArrowType.Timestamp(TimeUnit.MICROSECOND, null);
+        } else {
+          arrowType = new ArrowType.Int(64, /*signed=*/true);
+        }
         break;
       case FLOAT:
         arrowType = new ArrowType.FloatingPoint(SINGLE);
@@ -423,7 +514,14 @@ public class AvroToArrowUtils {
         arrowType = new ArrowType.FloatingPoint(DOUBLE);
         break;
       case BYTES:
-        arrowType = new ArrowType.Binary();
+        if (logicalType instanceof LogicalTypes.Decimal) {
+          final int scala = ((LogicalTypes.Decimal) logicalType).getScale();
+          final int precision = ((LogicalTypes.Decimal) logicalType).getPrecision();
+          arrowType = new ArrowType.Decimal(precision, scala);
+        } else {
+          arrowType = new ArrowType.Binary();
+        }
+
         break;
       case NULL:
         arrowType = new ArrowType.Null();

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroDateConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroDateConsumer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.consumers.logical;
+
+import java.io.IOException;
+
+import org.apache.arrow.consumers.BaseAvroConsumer;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.avro.io.Decoder;
+
+/**
+ * Consumer which consume date type values from avro decoder.
+ * Write the data to {@link DateDayVector}.
+ */
+public class AvroDateConsumer extends BaseAvroConsumer<DateDayVector> {
+
+  /**
+   * Instantiate a AvroDateConsumer.
+   */
+  public AvroDateConsumer(DateDayVector vector) {
+    super(vector);
+  }
+
+  @Override
+  public void consume(Decoder decoder) throws IOException {
+    vector.setSafe(currentIndex++, decoder.readInt());
+  }
+}

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroDecimalConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroDecimalConsumer.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.consumers.logical;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+
+import org.apache.arrow.consumers.BaseAvroConsumer;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.avro.io.Decoder;
+
+/**
+ * Consumer which consume decimal type values from avro decoder.
+ * Write the data to {@link DecimalVector}.
+ */
+public abstract class AvroDecimalConsumer extends BaseAvroConsumer<DecimalVector> {
+
+  protected int scale;
+
+  /**
+   * Instantiate a AvroDecimalConsumer.
+   */
+  public AvroDecimalConsumer(DecimalVector vector) {
+    super(vector);
+    scale = vector.getScale();
+  }
+
+  /**
+   * Consumer for decimal logical type with original bytes type.
+   */
+  public static class BytesDecimalConsumer extends AvroDecimalConsumer {
+
+    private ByteBuffer cacheBuffer;
+
+    public BytesDecimalConsumer(DecimalVector vector) {
+      super(vector);
+    }
+
+    @Override
+    public void consume(Decoder decoder) throws IOException {
+      cacheBuffer = decoder.readBytes(cacheBuffer);
+      byte[] bytes = new byte[cacheBuffer.limit()];
+      cacheBuffer.get(bytes);
+      BigDecimal decimal = new BigDecimal(new BigInteger(bytes), scale);
+      vector.setSafe(currentIndex++, decimal);
+    }
+
+  }
+
+  /**
+   * Consumer for decimal logical type with original fixed type.
+   */
+  public static class FixedDecimalConsumer extends AvroDecimalConsumer {
+
+    private byte[] reuseBytes;
+
+    public FixedDecimalConsumer(DecimalVector vector, int size) {
+      super(vector);
+      reuseBytes = new byte[size];
+    }
+
+    @Override
+    public void consume(Decoder decoder) throws IOException {
+      decoder.readFixed(reuseBytes);
+      BigDecimal decimal = new BigDecimal(new BigInteger(reuseBytes), scale);
+      vector.setSafe(currentIndex++, decimal);
+    }
+  }
+}

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimeMicroConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimeMicroConsumer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.consumers.logical;
+
+import java.io.IOException;
+
+import org.apache.arrow.consumers.BaseAvroConsumer;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.avro.io.Decoder;
+
+/**
+ * Consumer which consume date time-micro values from avro decoder.
+ * Write the data to {@link TimeMicroVector}.
+ */
+public class AvroTimeMicroConsumer extends BaseAvroConsumer<TimeMicroVector> {
+
+  /**
+   * Instantiate a AvroTimeMicroConsumer.
+   */
+  public AvroTimeMicroConsumer(TimeMicroVector vector) {
+    super(vector);
+  }
+
+  @Override
+  public void consume(Decoder decoder) throws IOException {
+    vector.setSafe(currentIndex++, decoder.readLong());
+  }
+}

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimeMillisConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimeMillisConsumer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.consumers.logical;
+
+import java.io.IOException;
+
+import org.apache.arrow.consumers.BaseAvroConsumer;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.avro.io.Decoder;
+
+/**
+ * Consumer which consume date time-millis values from avro decoder.
+ * Write the data to {@link TimeMilliVector}.
+ */
+public class AvroTimeMillisConsumer extends BaseAvroConsumer<TimeMilliVector> {
+
+  /**
+   * Instantiate a AvroTimeMilliConsumer.
+   */
+  public AvroTimeMillisConsumer(TimeMilliVector vector) {
+    super(vector);
+  }
+
+  @Override
+  public void consume(Decoder decoder) throws IOException {
+    vector.setSafe(currentIndex++, decoder.readInt());
+  }
+}

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimestampMicrosConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimestampMicrosConsumer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.consumers.logical;
+
+import java.io.IOException;
+
+import org.apache.arrow.consumers.BaseAvroConsumer;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.avro.io.Decoder;
+
+/**
+ * Consumer which consume date timestamp-micro values from avro decoder.
+ * Write the data to {@link TimeStampMicroVector}.
+ */
+public class AvroTimestampMicrosConsumer extends BaseAvroConsumer<TimeStampMicroVector> {
+
+  /**
+   * Instantiate a AvroTimestampMicroConsumer.
+   */
+  public AvroTimestampMicrosConsumer(TimeStampMicroVector vector) {
+    super(vector);
+  }
+
+  @Override
+  public void consume(Decoder decoder) throws IOException {
+    vector.setSafe(currentIndex++, decoder.readLong());
+  }
+}

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimestampMillisConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimestampMillisConsumer.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.consumers.logical;
+
+import java.io.IOException;
+
+import org.apache.arrow.consumers.BaseAvroConsumer;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.avro.io.Decoder;
+
+/**
+ * Consumer which consume date timestamp-millis values from avro decoder.
+ * Write the data to {@link TimeStampMilliVector}.
+ */
+public class AvroTimestampMillisConsumer extends BaseAvroConsumer<TimeStampMilliVector> {
+
+  /**
+   * Instantiate a AvroTimestampMillisConsumer.
+   */
+  public AvroTimestampMillisConsumer(TimeStampMilliVector vector) {
+    super(vector);
+  }
+
+  @Override
+  public void consume(Decoder decoder) throws IOException {
+    vector.setSafe(currentIndex++, decoder.readLong());
+  }
+}

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroLogicalTypesTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroLogicalTypesTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.util.DateUtility;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.junit.Test;
+
+public class AvroLogicalTypesTest extends AvroTestBase {
+
+  @Test
+  public void testTimestampMicros() throws Exception {
+    Schema schema = getSchema("logical/test_timestamp_micros.avsc");
+
+    List<Long> data = Arrays.asList(10000L, 20000L, 30000L, 40000L, 50000L);
+    List<LocalDateTime> expected = Arrays.asList(
+        DateUtility.getLocalDateTimeFromEpochMicro(10000),
+        DateUtility.getLocalDateTimeFromEpochMicro(20000),
+        DateUtility.getLocalDateTimeFromEpochMicro(30000),
+        DateUtility.getLocalDateTimeFromEpochMicro(40000),
+        DateUtility.getLocalDateTimeFromEpochMicro(50000)
+    );
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    FieldVector vector = root.getFieldVectors().get(0);
+
+    checkPrimitiveResult(expected, vector);
+  }
+
+  @Test
+  public void testTimestampMillis() throws Exception {
+    Schema schema = getSchema("logical/test_timestamp_millis.avsc");
+
+    List<Long> data = Arrays.asList(10000L, 20000L, 30000L, 40000L, 50000L);
+    List<LocalDateTime> expected = Arrays.asList(
+        DateUtility.getLocalDateTimeFromEpochMilli(10000),
+        DateUtility.getLocalDateTimeFromEpochMilli(20000),
+        DateUtility.getLocalDateTimeFromEpochMilli(30000),
+        DateUtility.getLocalDateTimeFromEpochMilli(40000),
+        DateUtility.getLocalDateTimeFromEpochMilli(50000)
+    );
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    FieldVector vector = root.getFieldVectors().get(0);
+
+    checkPrimitiveResult(expected, vector);
+  }
+
+  @Test
+  public void testTimeMicros() throws Exception {
+    Schema schema = getSchema("logical/test_time_micros.avsc");
+
+    List<Long> data = Arrays.asList(10000L, 20000L, 30000L, 40000L, 50000L);
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    FieldVector vector = root.getFieldVectors().get(0);
+
+    checkPrimitiveResult(data, vector);
+  }
+
+  @Test
+  public void testTimeMillis() throws Exception {
+    Schema schema = getSchema("logical/test_time_millis.avsc");
+
+    List<Integer> data = Arrays.asList(100, 200, 300, 400, 500);
+    List<LocalDateTime> expected = Arrays.asList(
+        DateUtility.getLocalDateTimeFromEpochMilli(100),
+        DateUtility.getLocalDateTimeFromEpochMilli(200),
+        DateUtility.getLocalDateTimeFromEpochMilli(300),
+        DateUtility.getLocalDateTimeFromEpochMilli(400),
+        DateUtility.getLocalDateTimeFromEpochMilli(500)
+    );
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    FieldVector vector = root.getFieldVectors().get(0);
+
+    checkPrimitiveResult(expected, vector);
+  }
+
+  @Test
+  public void testDate() throws Exception {
+    Schema schema = getSchema("logical/test_date.avsc");
+
+    List<Integer> data = Arrays.asList(100, 200, 300, 400, 500);
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    FieldVector vector = root.getFieldVectors().get(0);
+
+    checkPrimitiveResult(data, vector);
+  }
+
+  @Test
+  public void testDecimalWithOriginalBytes() throws Exception {
+    Schema schema = getSchema("logical/test_decimal_with_original_bytes.avsc");
+    List<ByteBuffer> data = Arrays.asList(
+        ByteBuffer.wrap(new BigDecimal("10").unscaledValue().toByteArray()),
+        ByteBuffer.wrap(new BigDecimal("1234").unscaledValue().toByteArray()),
+        ByteBuffer.wrap(new BigDecimal("123456").unscaledValue().toByteArray()),
+        ByteBuffer.wrap(new BigDecimal("111122").unscaledValue().toByteArray()));
+
+    List<BigDecimal> expected = Arrays.asList(
+        new BigDecimal(new BigInteger("10"), 2),
+        new BigDecimal(new BigInteger("1234"), 2),
+        new BigDecimal(new BigInteger("123456"), 2),
+        new BigDecimal(new BigInteger("111122"), 2));
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    FieldVector vector = root.getFieldVectors().get(0);
+    checkPrimitiveResult(expected, vector);
+  }
+
+  @Test
+  public void testDecimalWithOriginalFixed() throws Exception {
+    Schema schema = getSchema("logical/test_decimal_with_original_fixed.avsc");
+
+    List<GenericData.Fixed> data = new ArrayList<>();
+    List<BigDecimal> expected = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      BigDecimal bigDecimal = new BigDecimal(i * i).setScale(2);
+      byte fillByte = (byte) (bigDecimal.signum() < 0 ? 0xFF : 0x00);
+      byte[] unscaled = bigDecimal.unscaledValue().toByteArray();
+      byte[] bytes = new byte[schema.getFixedSize()];
+      int offset = bytes.length - unscaled.length;
+      for (int k = 0; k < bytes.length; k++) {
+        if (k < offset) {
+          bytes[k] = fillByte;
+        } else {
+          bytes[k] = unscaled[k - offset];
+        }
+      }
+      expected.add(bigDecimal);
+      GenericData.Fixed fixed = new GenericData.Fixed(schema);
+      fixed.bytes(bytes);
+      data.add(fixed);
+    }
+
+    VectorSchemaRoot root = writeAndRead(schema, data);
+    FieldVector vector = root.getFieldVectors().get(0);
+    checkPrimitiveResult(expected, vector);
+  }
+}

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroSkipFieldTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroSkipFieldTest.java
@@ -19,15 +19,11 @@ package org.apache.arrow;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -35,32 +31,10 @@ import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.types.Types;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryDecoder;
-import org.apache.avro.io.BinaryEncoder;
-import org.apache.avro.io.DatumWriter;
-import org.apache.avro.io.DecoderFactory;
-import org.apache.avro.io.EncoderFactory;
 import org.junit.Test;
 
 public class AvroSkipFieldTest extends AvroTestBase {
-
-  private VectorSchemaRoot writeAndRead(Schema schema, List data) throws Exception {
-    File dataFile = TMP.newFile();
-
-    BinaryEncoder
-        encoder = new EncoderFactory().directBinaryEncoder(new FileOutputStream(dataFile), null);
-    DatumWriter writer = new GenericDatumWriter(schema);
-    BinaryDecoder
-        decoder = new DecoderFactory().directBinaryDecoder(new FileInputStream(dataFile), null);
-
-    for (Object value : data) {
-      writer.write(value, encoder);
-    }
-
-    return AvroToArrow.avroToArrow(schema, decoder, config);
-  }
 
   @Test
   public void testSkipUnionWithOneField() throws Exception {

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowIteratorTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowIteratorTest.java
@@ -56,7 +56,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
     this.config = new AvroToArrowConfigBuilder(allocator).setTargetBatchSize(3).build();
   }
 
-  private AvroToArrowVectorIterator writeAndRead(Schema schema, List data) throws Exception {
+  private AvroToArrowVectorIterator convert(Schema schema, List data) throws Exception {
     File dataFile = TMP.newFile();
 
     BinaryEncoder
@@ -79,7 +79,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
 
     List<VectorSchemaRoot> roots = new ArrayList<>();
     List<FieldVector> vectors = new ArrayList<>();
-    try (AvroToArrowVectorIterator iterator = writeAndRead(schema, data)) {
+    try (AvroToArrowVectorIterator iterator = convert(schema, data)) {
       while (iterator.hasNext()) {
         VectorSchemaRoot root = iterator.next();
         FieldVector vector = root.getFieldVectors().get(0);
@@ -107,7 +107,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
 
     List<VectorSchemaRoot> roots = new ArrayList<>();
     List<FieldVector> vectors = new ArrayList<>();
-    try (AvroToArrowVectorIterator iterator = writeAndRead(schema, data);) {
+    try (AvroToArrowVectorIterator iterator = convert(schema, data);) {
       while (iterator.hasNext()) {
         VectorSchemaRoot root = iterator.next();
         FieldVector vector = root.getFieldVectors().get(0);
@@ -133,7 +133,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
     }
 
     List<VectorSchemaRoot> roots = new ArrayList<>();
-    try (AvroToArrowVectorIterator iterator = writeAndRead(schema, data)) {
+    try (AvroToArrowVectorIterator iterator = convert(schema, data)) {
       while (iterator.hasNext()) {
         roots.add(iterator.next());
       }
@@ -155,7 +155,7 @@ public class AvroToArrowIteratorTest extends AvroTestBase {
 
     List<VectorSchemaRoot> roots = new ArrayList<>();
     List<ListVector> vectors = new ArrayList<>();
-    try (AvroToArrowVectorIterator iterator = writeAndRead(schema, data)) {
+    try (AvroToArrowVectorIterator iterator = convert(schema, data)) {
       while (iterator.hasNext()) {
         VectorSchemaRoot root = iterator.next();
         roots.add(root);

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroToArrowTest.java
@@ -19,9 +19,6 @@ package org.apache.arrow;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -36,30 +33,10 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.BinaryDecoder;
-import org.apache.avro.io.BinaryEncoder;
-import org.apache.avro.io.DatumWriter;
-import org.apache.avro.io.DecoderFactory;
-import org.apache.avro.io.EncoderFactory;
 import org.junit.Test;
 
 public class AvroToArrowTest extends AvroTestBase {
-
-  private VectorSchemaRoot writeAndRead(Schema schema, List data) throws Exception {
-    File dataFile = TMP.newFile();
-
-    BinaryEncoder encoder = new EncoderFactory().directBinaryEncoder(new FileOutputStream(dataFile), null);
-    DatumWriter writer = new GenericDatumWriter(schema);
-    BinaryDecoder decoder = new DecoderFactory().directBinaryDecoder(new FileInputStream(dataFile), null);
-
-    for (Object value : data) {
-      writer.write(value, encoder);
-    }
-
-    return AvroToArrow.avroToArrow(schema, decoder, config);
-  }
 
   @Test
   public void testStringType() throws Exception {

--- a/java/adapter/avro/src/test/resources/schema/logical/test_date.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_date.avsc
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "int",
+ "logicalType" : "date"
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_decimal_invalid1.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_decimal_invalid1.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "bytes",
+ "logicalType" : "decimal",
+ "precision": 39,
+ "scale": 2
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_decimal_invalid2.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_decimal_invalid2.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "bytes",
+ "logicalType" : "decimal",
+ "precision": 20,
+ "scale": -1
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_decimal_invalid3.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_decimal_invalid3.avsc
@@ -18,7 +18,8 @@
 {
  "namespace": "org.apache.arrow.avro",
  "name": "test",
- "type": "fixed",
- "size" : 12,
- "logicalType" : "duration"
+ "type": "bytes",
+ "logicalType" : "decimal",
+ "precision": 20,
+ "scale": 40
 }

--- a/java/adapter/avro/src/test/resources/schema/logical/test_decimal_invalid4.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_decimal_invalid4.avsc
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "fixed",
+ "size" : 1,
+ "logicalType" : "decimal",
+ "precision": 30,
+ "scale": 2
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_decimal_with_original_bytes.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_decimal_with_original_bytes.avsc
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "bytes",
+ "logicalType" : "decimal",
+ "precision": 10,
+ "scale": 2
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_decimal_with_original_fixed.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_decimal_with_original_fixed.avsc
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "fixed",
+ "size" : 10,
+ "logicalType" : "decimal",
+ "precision": 10,
+ "scale": 2
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_duration.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_duration.avsc
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "fixed",
+ "size" : 12,
+ "logicalType" : "duration"
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_time_micros.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_time_micros.avsc
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "long",
+ "logicalType" : "time-micros"
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_time_millis.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_time_millis.avsc
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "int",
+ "logicalType" : "time-millis"
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_timestamp_micros.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_timestamp_micros.avsc
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "long",
+ "logicalType" : "timestamp-micros"
+}

--- a/java/adapter/avro/src/test/resources/schema/logical/test_timestamp_millis.avsc
+++ b/java/adapter/avro/src/test/resources/schema/logical/test_timestamp_millis.avsc
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{
+ "namespace": "org.apache.arrow.avro",
+ "name": "test",
+ "type": "long",
+ "logicalType" : "timestamp-millis"
+}


### PR DESCRIPTION
Related to [ARROW-6594](https://issues.apache.org/jira/browse/ARROW-6594).

Avro supports some logical types that overlap with Arrow logical types (http://avro.apache.org/docs/current/spec.html#Logical+Types)

For the ones that overlap, we should use the appropriate Arrow Logical type array instead of the raw values.