### PR TITLE
ARROW-7072: [Java] Support concating validity bits efficiently

### DIFF
--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -149,4 +149,134 @@ public class TestBitVectorHelper {
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
     }
   }
+
+  @Test
+  public void testConcatBits() {
+    try (RootAllocator allocator = new RootAllocator(1024 * 1024)) {
+      try (ArrowBuf buf1 = allocator.buffer(1024);
+           ArrowBuf buf2 = allocator.buffer(1024);
+           ArrowBuf output = allocator.buffer(1024)) {
+
+        buf1.setZero(0, buf1.capacity());
+        buf2.setZero(0, buf2.capacity());
+
+        final int count = 100;
+        for (int i = 0; i < count; i++) {
+          if (i % 3 == 0) {
+            BitVectorHelper.setValidityBitToOne(buf1, i);
+            BitVectorHelper.setValidityBitToOne(buf2, i);
+          }
+        }
+
+        BitVectorHelper.concatBits(buf1, count, buf2, count, output);
+
+        // validate results
+        for (int i = 0; i < count * 2; i++) {
+          int result = BitVectorHelper.get(output, i);
+          if (i < count) {
+            assertEquals(i % 3 == 0 ? 1 : 0, result);
+          } else {
+            assertEquals((i - count) % 3 == 0 ? 1 : 0, result);
+          }
+        }
+      }
+
+      try (ArrowBuf buf1 = allocator.buffer(1024);
+           ArrowBuf buf2 = allocator.buffer(1024);
+           ArrowBuf output = allocator.buffer(1024)) {
+
+        buf1.setZero(0, buf1.capacity());
+        buf2.setZero(0, buf2.capacity());
+
+        final int count1 = 100;
+        final int count2 = 102;
+        for (int i = 0; i < count1 || i < count2; i++) {
+          if (i % 3 != 0) {
+            if (i < count1) {
+              BitVectorHelper.setValidityBitToOne(buf1, i);
+            }
+            if (i < count2) {
+              BitVectorHelper.setValidityBitToOne(buf2, i);
+            }
+          }
+        }
+
+        BitVectorHelper.concatBits(buf1, count1, buf2, count2, output);
+
+        // validate results
+        for (int i = 0; i < count1 + count2; i++) {
+          int result = BitVectorHelper.get(output, i);
+          if (i < count1) {
+            assertEquals(i % 3 != 0 ? 1 : 0, result);
+          } else {
+            assertEquals((i - count1) % 3 != 0 ? 1 : 0, result);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testConcatBitsInPlace() {
+    try (RootAllocator allocator = new RootAllocator(1024 * 1024)) {
+      try (ArrowBuf buf1 = allocator.buffer(1024);
+           ArrowBuf buf2 = allocator.buffer(1024)) {
+
+        buf1.setZero(0, buf1.capacity());
+        buf2.setZero(0, buf2.capacity());
+
+        final int count = 100;
+        for (int i = 0; i < count; i++) {
+          if (i % 3 == 0) {
+            BitVectorHelper.setValidityBitToOne(buf1, i);
+            BitVectorHelper.setValidityBitToOne(buf2, i);
+          }
+        }
+
+        BitVectorHelper.concatBits(buf1, count, buf2, count, buf1);
+
+        // validate results
+        for (int i = 0; i < count * 2; i++) {
+          int result = BitVectorHelper.get(buf1, i);
+          if (i < count) {
+            assertEquals(i % 3 == 0 ? 1 : 0, result);
+          } else {
+            assertEquals((i - count) % 3 == 0 ? 1 : 0, result);
+          }
+        }
+      }
+
+      try (ArrowBuf buf1 = allocator.buffer(1024);
+           ArrowBuf buf2 = allocator.buffer(1024)) {
+
+        buf1.setZero(0, buf1.capacity());
+        buf2.setZero(0, buf2.capacity());
+
+        final int count1 = 99;
+        final int count2 = 102;
+        for (int i = 0; i < count1 || i < count2; i++) {
+          if (i % 3 != 0) {
+            if (i < count1) {
+              BitVectorHelper.setValidityBitToOne(buf1, i);
+            }
+            if (i < count2) {
+              BitVectorHelper.setValidityBitToOne(buf2, i);
+            }
+          }
+        }
+
+        BitVectorHelper.concatBits(buf1, count1, buf2, count2, buf1);
+
+        // validate results
+        for (int i = 0; i < count1 + count2; i++) {
+          int result = BitVectorHelper.get(buf1, i);
+          if (i < count1) {
+            assertEquals(i % 3 != 0 ? 1 : 0, result);
+          } else {
+            assertEquals((i - count1) % 3 != 0 ? 1 : 0, result);
+          }
+        }
+      }
+    }
+  }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -223,13 +223,12 @@ public class TestBitVectorHelper {
 
   private void concatAndVerify(ArrowBuf buf1, int count1, ArrowBuf buf2, int count2, ArrowBuf output) {
     BitVectorHelper.concatBits(buf1, count1, buf2, count2, output);
-    for (int i = 0; i < count1 + count2; i++) {
-      int result = BitVectorHelper.get(output, i);
-      if (i < count1) {
-        assertEquals(i % 3 == 0 ? 1 : 0, result);
-      } else {
-        assertEquals((i - count1) % 3 == 0 ? 1 : 0, result);
-      }
+    int outputIdx = 0;
+    for (int i = 0; i < count1; i++, outputIdx++) {
+      assertEquals(BitVectorHelper.get(output, outputIdx), BitVectorHelper.get(buf1, i));
+    }
+    for (int i = 0; i < count2; i++, outputIdx++) {
+      assertEquals(BitVectorHelper.get(output, outputIdx), BitVectorHelper.get(buf2, i));
     }
   }
 }


### PR DESCRIPTION
For scenarios when we need to concate vectors (like the scenario in ARROW-7048, and delta dictionary), we need a way to concat validity bits.

Currently, we have bit level API to read/write individual validity bit. However, it is not efficient , and we need a way to copy more bits at a time.