### PR TITLE
ARROW-7031: [Python] Correct LargeListArray.offsets attribute

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1255,12 +1255,17 @@ cdef class LargeListArray(Array):
         return result
 
     @property
+    def values(self):
+        return self.flatten()
+
+    @property
     def offsets(self):
         """
         Return the offsets as an int64 array.
         """
         return Array.from_buffers(
-            int64(), len(self) + 1, [None, self.buffers()[1]])
+            int64(), len(self) + 1, [None, self.buffers()[1]],
+            offset=self.offset)
 
     def flatten(self):
         """

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1619,10 +1619,10 @@ def test_large_list_array_flatten():
     assert arr2.offsets.equals(offsets2)
 
 
-def test_list_array_values_offsets_sliced():
+@pytest.mark.parametrize('klass', [pa.ListArray, pa.LargeListArray])
+def test_list_array_values_offsets_sliced(klass):
     # ARROW-7301
-    arr = pa.ListArray.from_arrays(offsets=[0, 3, 4, 6],
-                                   values=[1, 2, 3, 4, 5, 6])
+    arr = klass.from_arrays(offsets=[0, 3, 4, 6], values=[1, 2, 3, 4, 5, 6])
     assert arr.values.to_pylist() == [1, 2, 3, 4, 5, 6]
     assert arr.offsets.to_pylist() == [0, 3, 4, 6]
 


### PR DESCRIPTION
Follow-up on https://github.com/apache/arrow/pull/5759, which was apparently merged too quickly (I only now saw that I did the slicing behaviour only for ListArray, and not yet updated LargeListArray).

Also added the LargeListArray.values attribute which was missing (compared to ListArray)