### PR TITLE
ARROW-7074: [C++] ASSERT_OK_AND_ASSIGN should use ASSERT_OK instead of EXPE…

### DIFF
--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -140,7 +140,7 @@ class FilterTest : public ::testing::Test {
       *expected_mask = checked_pointer_cast<BooleanArray>(batch->GetColumnByName("in"));
     }
 
-    ASSERT_OK_AND_ASSIGN(auto expr_type, expr.Validate(*batch->schema()));
+    ARROW_ASSIGN_OR_RAISE(auto expr_type, expr.Validate(*batch->schema()));
     EXPECT_TRUE(expr_type->Equals(boolean()));
 
     return evaluator_->Evaluate(expr, *batch);

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -339,6 +339,9 @@ class Result : public util::EqualityComparable<Result<T>> {
 // Executes an expression that returns a Result, extracting its value
 // into the variable defined by lhs (or returning on error).
 //
+// Example: Assigning to a new value
+//   ARROW_ASSIGN_OR_RAISE(auto value, MaybeGetValue(arg));
+//
 // Example: Assigning to an existing value
 //   ValueType value;
 //   ARROW_ASSIGN_OR_RAISE(value, MaybeGetValue(arg));

--- a/cpp/src/arrow/testing/generator.cc
+++ b/cpp/src/arrow/testing/generator.cc
@@ -39,8 +39,7 @@ template <typename ArrowType, typename CType = typename TypeTraits<ArrowType>::C
 static inline std::shared_ptr<Array> ConstantArray(int64_t size, CType value = 0) {
   auto type = TypeTraits<ArrowType>::type_singleton();
   auto builder_fn = [](BuilderType* builder) { builder->UnsafeAppend(CType(0)); };
-  ASSERT_OK_AND_ASSIGN(auto array, ArrayFromBuilderVisitor(type, size, builder_fn));
-  return array;
+  return ArrayFromBuilderVisitor(type, size, builder_fn).ValueOrDie();
 }
 
 std::shared_ptr<arrow::Array> ConstantArrayGenerator::Boolean(int64_t size, bool value) {

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -115,7 +115,7 @@ inline Status GenericToStatus(const Result<T>& res) {
 
 #define ASSERT_OK_AND_ASSIGN_IMPL(status_name, lhs, rexpr) \
   auto status_name = (rexpr);                              \
-  ARROW_EXPECT_OK(status_name.status());                   \
+  ASSERT_OK(status_name.status());                         \
   lhs = std::move(status_name).ValueOrDie();
 
 #define ASSERT_OK_AND_ASSIGN(lhs, rexpr)                                              \


### PR DESCRIPTION
…CT_OK

There is no point of using EXPECT_OK in ASSERT_OK_AND_ASSIGN since ValueOrDie will terminate afterward. Using ASSERT_OK ensure gtest doesn't crash but move to the next tests.