### PR TITLE
ARROW-7062: [C++][Dataset] Ensure ParquetFileFormat::Open catch parqu…

### DIFF
--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -58,6 +58,7 @@ class ARROW_DS_EXPORT FileSource {
              Compression::type compression = Compression::UNCOMPRESSED)
       : FileSource(FileSource::BUFFER, compression) {
     buffer_ = std::move(buffer);
+    path_ = "<Buffer>";
   }
 
   bool operator==(const FileSource& other) const {

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -211,7 +211,12 @@ Status ParquetFileFormat::OpenReader(
   std::shared_ptr<io::RandomAccessFile> input;
   RETURN_NOT_OK(source.Open(&input));
 
-  *out = parquet::ParquetFileReader::Open(input);
+  try {
+    *out = parquet::ParquetFileReader::Open(input);
+  } catch (const ::parquet::ParquetException& e) {
+    return ::arrow::Status::IOError("Could not open parquet input source '",
+                                    source.path(), "': ", e.what());
+  }
   return Status::OK();
 }
 

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -294,7 +294,7 @@ Status JSONRecordBatchFileFormat::MakeFragment(const FileSource& source,
 class TestFileSystemBasedDataSource : public ::testing::Test {
  public:
   void MakeFileSystem(const std::vector<fs::FileStats>& stats) {
-    ASSERT_OK(fs::internal::MockFileSystem::Make(fs::kNoTime, stats, &fs_));
+    ASSERT_OK_AND_ASSIGN(fs_, fs::internal::MockFileSystem::Make(fs::kNoTime, stats));
   }
 
   void MakeFileSystem(const std::vector<std::string>& paths) {
@@ -302,7 +302,7 @@ class TestFileSystemBasedDataSource : public ::testing::Test {
     std::transform(paths.cbegin(), paths.cend(), stats.begin(),
                    [](const std::string& p) { return fs::File(p); });
 
-    ASSERT_OK(fs::internal::MockFileSystem::Make(fs::kNoTime, stats, &fs_));
+    ASSERT_OK_AND_ASSIGN(fs_, fs::internal::MockFileSystem::Make(fs::kNoTime, stats));
   }
 
   void MakeSource(const std::vector<fs::FileStats>& stats,

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -669,8 +669,8 @@ Status MockFileSystem::CreateFile(const std::string& path, const std::string& co
   return file->Close();
 }
 
-Status MockFileSystem::Make(TimePoint current_time, const std::vector<FileStats>& stats,
-                            std::shared_ptr<FileSystem>* out) {
+Result<std::shared_ptr<FileSystem>> MockFileSystem::Make(
+    TimePoint current_time, const std::vector<FileStats>& stats) {
   auto fs = std::make_shared<MockFileSystem>(current_time);
   for (const auto& s : stats) {
     switch (s.type()) {
@@ -685,9 +685,7 @@ Status MockFileSystem::Make(TimePoint current_time, const std::vector<FileStats>
     }
   }
 
-  *out = fs;
-
-  return Status::OK();
+  return fs;
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/filesystem/mockfs.h
+++ b/cpp/src/arrow/filesystem/mockfs.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "arrow/filesystem/filesystem.h"
+#include "arrow/result.h"
 
 namespace arrow {
 namespace fs {
@@ -100,8 +101,8 @@ class ARROW_EXPORT MockFileSystem : public FileSystem {
 
   // Create a MockFileSystem out of (empty) FileStats. The content of every
   // file is empty and of size 0. All directories will be created recursively.
-  static Status Make(TimePoint current_time, const std::vector<FileStats>& stats,
-                     std::shared_ptr<FileSystem>* out);
+  static Result<std::shared_ptr<FileSystem>> Make(TimePoint current_time,
+                                                  const std::vector<FileStats>& stats);
 
   class Impl;
 

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -86,6 +86,18 @@ inline Status GenericToStatus(const Result<T>& res) {
     ASSERT_EQ((message), _st.ToString());                                             \
   } while (false)
 
+#define EXPECT_RAISES_WITH_MESSAGE_THAT(ENUM, matcher, expr)                          \
+  do {                                                                                \
+    auto _res = (expr);                                                               \
+    ::arrow::Status _st = ::arrow::internal::GenericToStatus(_res);                   \
+    if (!_st.Is##ENUM()) {                                                            \
+      FAIL() << "Expected '" ARROW_STRINGIFY(expr) "' to fail with " ARROW_STRINGIFY( \
+                    ENUM) ", but got "                                                \
+             << _st.ToString();                                                       \
+    }                                                                                 \
+    EXPECT_THAT(_st.ToString(), (matcher));                                           \
+  } while (false)
+
 #define ASSERT_OK(expr)                                                       \
   do {                                                                        \
     auto _res = (expr);                                                       \


### PR DESCRIPTION
…et's exception

It also improves the error message by pointing which file is failing.