### PR TITLE
ARROW-7098: [Java] Improve the performance of comparing two memory blocks

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -70,7 +70,7 @@ public class ByteFunctionHelpers {
         n -= 8;
       }
 
-      while (n > 3) {
+      if (n > 3) {
         int leftInt = PlatformDependent.getInt(lPos);
         int rightInt = PlatformDependent.getInt(rPos);
         if (leftInt != rightInt) {
@@ -147,7 +147,7 @@ public class ByteFunctionHelpers {
       n -= 8;
     }
 
-    while (n > 3) {
+    if (n > 3) {
       int leftInt = PlatformDependent.getInt(lPos);
       int rightInt = PlatformDependent.getInt(rPos);
       if (leftInt != rightInt) {
@@ -242,7 +242,7 @@ public class ByteFunctionHelpers {
       n -= 8;
     }
 
-    while (n > 3) {
+    if (n > 3) {
       int leftInt = PlatformDependent.getInt(lPos);
       int rightInt = PlatformDependent.getInt(right, rPos);
       if (leftInt != rightInt) {

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
@@ -64,7 +64,7 @@ public class SimpleHasher implements ArrowBufHasher {
       index += 8;
     }
 
-    while (index + 4 <= length) {
+    if (index + 4 <= length) {
       int intValue = getInt(address + index);
       int intHash = intValue;
       hashValue = combineHashCode(hashValue, intHash);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -158,7 +158,7 @@ public class BitVectorHelper {
       index += 8;
     }
 
-    while (index + 4 <= fullBytesCount) {
+    if (index + 4 <= fullBytesCount) {
       int intValue = validityBuffer.getInt(index);
       count += Integer.bitCount(intValue);
       index += 4;
@@ -217,7 +217,7 @@ public class BitVectorHelper {
       index += 8;
     }
 
-    while (index + 4 <= fullBytesCount) {
+    if (index + 4 <= fullBytesCount) {
       int intValue = getInt(validityBuffer.memoryAddress() + index);
       if (intValue != intToCompare) {
         return false;


### PR DESCRIPTION
We often use the 8-4-1 paradigm to compare two blocks of memory:
1. First compare by 8-byte blocks in a loop
2. Then compare by 4-byte blocks in a loop
3. Last compare by 1-byte blocks in a loop

It can be proved that the second loop runs at most once. So we can replace the loop with a if statement, which will save us a comparison and two jump operations.

According to the discussion in https://github.com/apache/arrow/pull/5508#discussion_r343973982, loops can be expensive.