### PR TITLE
PARQUET-1688: [C++] StreamWriter/StreamReader can't be built with g++ 4.8.5 on CentOS 7

### DIFF
--- a/cpp/src/parquet/stream_reader.h
+++ b/cpp/src/parquet/stream_reader.h
@@ -57,8 +57,8 @@ class PARQUET_EXPORT StreamReader {
   bool eof() const { return eof_; }
 
   // Moving is possible.
-  StreamReader(StreamReader&&) noexcept = default;
-  StreamReader& operator=(StreamReader&&) noexcept = default;
+  StreamReader(StreamReader&&) = default;
+  StreamReader& operator=(StreamReader&&) = default;
 
   // Copying is not allowed.
   StreamReader(const StreamReader&) = delete;

--- a/cpp/src/parquet/stream_writer.h
+++ b/cpp/src/parquet/stream_writer.h
@@ -63,8 +63,8 @@ class PARQUET_EXPORT StreamWriter {
   void SetMaxRowGroupSize(int64_t max_size);
 
   // Moving is possible.
-  StreamWriter(StreamWriter&&) noexcept = default;
-  StreamWriter& operator=(StreamWriter&&) noexcept = default;
+  StreamWriter(StreamWriter&&) = default;
+  StreamWriter& operator=(StreamWriter&&) = default;
 
   // Copying is not allowed.
   StreamWriter(const StreamWriter&) = delete;


### PR DESCRIPTION
Move constructor and move assignment operator signatures changed to
remove 'noexcept'.