### PR TITLE
PARQUET-1689: [C++] Stream API: Allow for columns/rows to be skipped when reading

### DIFF
--- a/cpp/src/parquet/stream_reader.cc
+++ b/cpp/src/parquet/stream_reader.cc
@@ -22,7 +22,7 @@
 namespace parquet {
 
 StreamReader::StreamReader(std::unique_ptr<ParquetFileReader> reader)
-    : file_reader_{std::move(reader)} {
+    : file_reader_{std::move(reader)}, eof_{false} {
   file_metadata_ = file_reader_->metadata();
 
   auto schema = file_metadata_->schema();
@@ -34,6 +34,20 @@ StreamReader::StreamReader(std::unique_ptr<ParquetFileReader> reader)
     nodes_[i] = std::static_pointer_cast<schema::PrimitiveNode>(group_node->field(i));
   }
   NextRowGroup();
+}
+
+int StreamReader::num_columns() const {
+  if (file_metadata_) {
+    return file_metadata_->num_columns();
+  }
+  return 0;
+}
+
+int64_t StreamReader::num_rows() const {
+  if (file_metadata_) {
+    return file_metadata_->num_rows();
+  }
+  return 0;
 }
 
 StreamReader& StreamReader::operator>>(bool& v) {
@@ -183,11 +197,11 @@ void StreamReader::EndRow() {
                            " of " + std::to_string(nodes_.size()) + " columns read");
   }
   column_index_ = 0;
+  ++current_row_;
 
-  if (column_readers_[0]->HasNext()) {
-    return;
+  if (!column_readers_[0]->HasNext()) {
+    NextRowGroup();
   }
-  NextRowGroup();
 }
 
 void StreamReader::NextRowGroup() {
@@ -202,23 +216,106 @@ void StreamReader::NextRowGroup() {
       column_readers_[i] = row_group_reader_->Column(i);
     }
     if (column_readers_[0]->HasNext()) {
+      row_group_row_offset_ = current_row_;
       return;
     }
   }
   // No more row groups found.
+  SetEof();
+}
+
+void StreamReader::SetEof() {
+  // Do not reset file_metadata_ to ensure queries on the number of
+  // rows/columns still function.
   eof_ = true;
   file_reader_.reset();
-  file_metadata_.reset();
   row_group_reader_.reset();
   column_readers_.clear();
   nodes_.clear();
+}
+
+int64_t StreamReader::SkipRows(int64_t num_rows_to_skip) {
+  if (0 != column_index_) {
+    throw ParquetException("Must finish reading current row before skipping rows.");
+  }
+  int64_t num_rows_remaining_to_skip = num_rows_to_skip;
+
+  while (!eof_ && (num_rows_remaining_to_skip > 0)) {
+    int64_t num_rows_in_row_group = row_group_reader_->metadata()->num_rows();
+    int64_t num_rows_remaining_in_row_group =
+        num_rows_in_row_group - current_row_ - row_group_row_offset_;
+
+    if (num_rows_remaining_in_row_group > num_rows_remaining_to_skip) {
+      for (auto reader : column_readers_) {
+        SkipRowsInColumn(reader.get(), num_rows_remaining_to_skip);
+      }
+      current_row_ += num_rows_remaining_to_skip;
+      num_rows_remaining_to_skip = 0;
+    } else {
+      num_rows_remaining_to_skip -= num_rows_remaining_in_row_group;
+      current_row_ += num_rows_remaining_in_row_group;
+      NextRowGroup();
+    }
+  }
+  return num_rows_to_skip - num_rows_remaining_to_skip;
+}
+
+int64_t StreamReader::SkipColumns(int64_t num_columns_to_skip) {
+  int64_t num_columns_skipped = 0;
+
+  if (!eof_) {
+    for (; (num_columns_to_skip > num_columns_skipped) &&
+           static_cast<std::size_t>(column_index_) < nodes_.size();
+         ++column_index_) {
+      SkipRowsInColumn(column_readers_[column_index_].get(), 1);
+      ++num_columns_skipped;
+    }
+  }
+  return num_columns_skipped;
+}
+
+void StreamReader::SkipRowsInColumn(ColumnReader* reader, int64_t num_rows_to_skip) {
+  int64_t num_skipped = 0;
+
+  switch (reader->type()) {
+    case Type::BOOLEAN:
+      num_skipped = static_cast<BoolReader*>(reader)->Skip(num_rows_to_skip);
+      break;
+    case Type::INT32:
+      num_skipped = static_cast<Int32Reader*>(reader)->Skip(num_rows_to_skip);
+      break;
+    case Type::INT64:
+      num_skipped = static_cast<Int64Reader*>(reader)->Skip(num_rows_to_skip);
+      break;
+    case Type::BYTE_ARRAY:
+      num_skipped = static_cast<ByteArrayReader*>(reader)->Skip(num_rows_to_skip);
+      break;
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      num_skipped = static_cast<FixedLenByteArrayReader*>(reader)->Skip(num_rows_to_skip);
+      break;
+    case Type::FLOAT:
+      num_skipped = static_cast<FloatReader*>(reader)->Skip(num_rows_to_skip);
+      break;
+    case Type::DOUBLE:
+      num_skipped = static_cast<DoubleReader*>(reader)->Skip(num_rows_to_skip);
+      break;
+    case Type::INT96:
+    case Type::UNDEFINED:
+      throw ParquetException("Unexpected type: " + TypeToString(reader->type()));
+      break;
+  }
+  if (num_rows_to_skip != num_skipped) {
+    throw ParquetException("Skipped " + std::to_string(num_skipped) + "/" +
+                           std::to_string(num_rows_to_skip) + " rows in column " +
+                           reader->descr()->name());
+  }
 }
 
 void StreamReader::CheckColumn(Type::type physical_type,
                                ConvertedType::type converted_type, int length) {
   if (static_cast<std::size_t>(column_index_) >= nodes_.size()) {
     if (eof_) {
-      throw ParquetException("EOF reached");
+      ParquetException::EofException();
     }
     throw ParquetException("Column index out-of-bounds.  Index " +
                            std::to_string(column_index_) + " is invalid for " +

--- a/cpp/src/parquet/stream_reader.cc
+++ b/cpp/src/parquet/stream_reader.cc
@@ -37,6 +37,7 @@ StreamReader::StreamReader(std::unique_ptr<ParquetFileReader> reader)
 }
 
 int StreamReader::num_columns() const {
+  // Check for file metadata i.e. object is not default constructed.
   if (file_metadata_) {
     return file_metadata_->num_columns();
   }
@@ -44,6 +45,7 @@ int StreamReader::num_columns() const {
 }
 
 int64_t StreamReader::num_rows() const {
+  // Check for file metadata i.e. object is not default constructed.
   if (file_metadata_) {
     return file_metadata_->num_rows();
   }

--- a/cpp/src/parquet/stream_reader_test.cc
+++ b/cpp/src/parquet/stream_reader_test.cc
@@ -176,6 +176,18 @@ TEST_F(TestStreamReader, DefaultConstructed) {
   ASSERT_THROW(os >> i, ParquetException);
   ASSERT_THROW(os >> s, ParquetException);
   ASSERT_THROW(os >> EndRow, ParquetException);
+
+  ASSERT_EQ(true, os.eof());
+  ASSERT_EQ(0, os.current_column());
+  ASSERT_EQ(0, os.current_row());
+
+  ASSERT_EQ(0, os.num_columns());
+  ASSERT_EQ(0, os.num_rows());
+
+  // Skipping columns and rows is allowed.
+  //
+  ASSERT_EQ(0, os.SkipColumns(100));
+  ASSERT_EQ(0, os.SkipRows(100));
 }
 
 TEST_F(TestStreamReader, TypeChecking) {
@@ -236,6 +248,8 @@ TEST_F(TestStreamReader, ValueChecking) {
   int i;
 
   for (i = 0; !reader_.eof(); ++i) {
+    ASSERT_EQ(i, reader_.current_row());
+
     reader_ >> b;
     reader_ >> s;
     reader_ >> c;
@@ -261,7 +275,194 @@ TEST_F(TestStreamReader, ValueChecking) {
     ASSERT_FLOAT_EQ(f, TestData::GetFloat(i));
     ASSERT_DOUBLE_EQ(d, TestData::GetDouble(i));
   }
+  ASSERT_EQ(reader_.current_row(), TestData::num_rows);
   ASSERT_EQ(i, TestData::num_rows);
+}
+
+TEST_F(TestStreamReader, SkipRows) {
+  bool b;
+  std::string s;
+  std::array<char, 4> char_array;
+  char c;
+  int8_t int8;
+  uint16_t uint16;
+  int32_t int32;
+  uint64_t uint64;
+  std::chrono::microseconds ts_us;
+  float f;
+  double d;
+  std::string str;
+
+  const int num_rows_to_read = 3;
+  const int num_rows_to_skip = 13;
+  int num_rows_read = 0;
+  int i = 0;
+
+  // Skipping zero and negative number of rows is ok.
+  //
+  ASSERT_EQ(0, reader_.SkipRows(0));
+  ASSERT_EQ(0, reader_.SkipRows(-100));
+
+  ASSERT_EQ(false, reader_.eof());
+  ASSERT_EQ(0, reader_.current_row());
+  ASSERT_EQ(TestData::num_rows, reader_.num_rows());
+
+  while (!reader_.eof()) {
+    // Each iteration of this loop reads some rows (num_rows_to_read
+    // are read) and then skips some rows (num_rows_to_skip will be
+    // skipped).
+    // The loop variable i is the current row being read.
+    // Loop variable j is used just to count the number of rows to
+    // read.
+    for (int j = 0; !reader_.eof() && (j < num_rows_to_read); ++i, ++j) {
+      ASSERT_EQ(i, reader_.current_row());
+
+      reader_ >> b;
+      reader_ >> s;
+      reader_ >> c;
+      reader_ >> char_array;
+      reader_ >> int8;
+      reader_ >> uint16;
+
+      // Not allowed to skip row once reading columns has started.
+      ASSERT_THROW(reader_.SkipRows(1), ParquetException);
+
+      reader_ >> int32;
+      reader_ >> uint64;
+      reader_ >> ts_us;
+      reader_ >> f;
+      reader_ >> d;
+      reader_ >> EndRow;
+      num_rows_read += 1;
+
+      ASSERT_EQ(b, TestData::GetBool(i));
+      ASSERT_EQ(s, TestData::GetString(i));
+      ASSERT_EQ(c, TestData::GetChar(i));
+      ASSERT_EQ(char_array, TestData::GetCharArray(i));
+      ASSERT_EQ(int8, TestData::GetInt8(i));
+      ASSERT_EQ(uint16, TestData::GetUInt16(i));
+      ASSERT_EQ(int32, TestData::GetInt32(i));
+      ASSERT_EQ(uint64, TestData::GetUInt64(i));
+      ASSERT_EQ(ts_us, TestData::GetChronoMicroseconds(i));
+      ASSERT_FLOAT_EQ(f, TestData::GetFloat(i));
+      ASSERT_DOUBLE_EQ(d, TestData::GetDouble(i));
+    }
+    ASSERT_EQ(num_rows_to_skip, reader_.SkipRows(num_rows_to_skip));
+    i += num_rows_to_skip;
+  }
+  ASSERT_EQ(TestData::num_rows, reader_.current_row());
+
+  ASSERT_EQ(num_rows_read, num_rows_to_read * TestData::num_rows /
+                               (num_rows_to_read + num_rows_to_skip));
+
+  // Skipping rows at eof is allowed.
+  //
+  ASSERT_EQ(0, reader_.SkipRows(100));
+}
+
+TEST_F(TestStreamReader, SkipAllRows) {
+  ASSERT_EQ(false, reader_.eof());
+  ASSERT_EQ(0, reader_.current_row());
+
+  ASSERT_EQ(reader_.num_rows(), reader_.SkipRows(2 * reader_.num_rows()));
+
+  ASSERT_EQ(true, reader_.eof());
+  ASSERT_EQ(reader_.num_rows(), reader_.current_row());
+}
+
+TEST_F(TestStreamReader, SkipColumns) {
+  bool b;
+  std::string s;
+  std::array<char, 4> char_array;
+  char c;
+  int8_t int8;
+  uint16_t uint16;
+  int32_t int32;
+  uint64_t uint64;
+  std::chrono::microseconds ts_us;
+  float f;
+  double d;
+  std::string str;
+
+  int i;
+
+  // Skipping zero and negative number of columns is ok.
+  //
+  ASSERT_EQ(0, reader_.SkipColumns(0));
+  ASSERT_EQ(0, reader_.SkipColumns(-100));
+
+  for (i = 0; !reader_.eof(); ++i) {
+    ASSERT_EQ(i, reader_.current_row());
+    ASSERT_EQ(0, reader_.current_column());
+
+    // Skip all columns every 31 rows.
+    if (i % 31 == 0) {
+      ASSERT_EQ(reader_.num_columns(), reader_.SkipColumns(reader_.num_columns()));
+      ASSERT_EQ(reader_.num_columns(), reader_.current_column());
+      reader_ >> EndRow;
+      continue;
+    }
+    reader_ >> b;
+    ASSERT_EQ(b, TestData::GetBool(i));
+    ASSERT_EQ(1, reader_.current_column());
+
+    // Skip the next column every 3 rows.
+    if (i % 3 == 0) {
+      ASSERT_EQ(1, reader_.SkipColumns(1));
+    } else {
+      reader_ >> s;
+      ASSERT_EQ(s, TestData::GetString(i));
+    }
+    ASSERT_EQ(2, reader_.current_column());
+
+    reader_ >> c;
+    ASSERT_EQ(c, TestData::GetChar(i));
+    ASSERT_EQ(3, reader_.current_column());
+    reader_ >> char_array;
+    ASSERT_EQ(char_array, TestData::GetCharArray(i));
+    ASSERT_EQ(4, reader_.current_column());
+    reader_ >> int8;
+    ASSERT_EQ(int8, TestData::GetInt8(i));
+    ASSERT_EQ(5, reader_.current_column());
+
+    // Skip the next 3 columns every 7 rows.
+    if (i % 7 == 0) {
+      ASSERT_EQ(3, reader_.SkipColumns(3));
+    } else {
+      reader_ >> uint16;
+      ASSERT_EQ(uint16, TestData::GetUInt16(i));
+      ASSERT_EQ(6, reader_.current_column());
+      reader_ >> int32;
+      ASSERT_EQ(int32, TestData::GetInt32(i));
+      ASSERT_EQ(7, reader_.current_column());
+      reader_ >> uint64;
+      ASSERT_EQ(uint64, TestData::GetUInt64(i));
+    }
+    ASSERT_EQ(8, reader_.current_column());
+
+    reader_ >> ts_us;
+    ASSERT_EQ(ts_us, TestData::GetChronoMicroseconds(i));
+    ASSERT_EQ(9, reader_.current_column());
+
+    // Skip 301 columns (i.e. all remaining) every 11 rows.
+    if (i % 11 == 0) {
+      ASSERT_EQ(2, reader_.SkipColumns(301));
+    } else {
+      reader_ >> f;
+      ASSERT_FLOAT_EQ(f, TestData::GetFloat(i));
+      ASSERT_EQ(10, reader_.current_column());
+      reader_ >> d;
+      ASSERT_DOUBLE_EQ(d, TestData::GetDouble(i));
+    }
+    ASSERT_EQ(11, reader_.current_column());
+    reader_ >> EndRow;
+  }
+  ASSERT_EQ(i, TestData::num_rows);
+  ASSERT_EQ(reader_.current_row(), TestData::num_rows);
+
+  // Skipping columns at eof is allowed.
+  //
+  ASSERT_EQ(0, reader_.SkipColumns(100));
 }
 
 }  // namespace test

--- a/cpp/src/parquet/stream_reader_test.cc
+++ b/cpp/src/parquet/stream_reader_test.cc
@@ -280,24 +280,6 @@ TEST_F(TestStreamReader, ValueChecking) {
 }
 
 TEST_F(TestStreamReader, SkipRows) {
-  bool b;
-  std::string s;
-  std::array<char, 4> char_array;
-  char c;
-  int8_t int8;
-  uint16_t uint16;
-  int32_t int32;
-  uint64_t uint64;
-  std::chrono::microseconds ts_us;
-  float f;
-  double d;
-  std::string str;
-
-  const int num_rows_to_read = 3;
-  const int num_rows_to_skip = 13;
-  int num_rows_read = 0;
-  int i = 0;
-
   // Skipping zero and negative number of rows is ok.
   //
   ASSERT_EQ(0, reader_.SkipRows(0));
@@ -307,14 +289,33 @@ TEST_F(TestStreamReader, SkipRows) {
   ASSERT_EQ(0, reader_.current_row());
   ASSERT_EQ(TestData::num_rows, reader_.num_rows());
 
-  while (!reader_.eof()) {
-    // Each iteration of this loop reads some rows (num_rows_to_read
-    // are read) and then skips some rows (num_rows_to_skip will be
+  const int iter_num_rows_to_read = 3;
+  const int iter_num_rows_to_skip = 13;
+  int num_rows_read = 0;
+  int i = 0;
+  int num_iterations;
+
+  for (num_iterations = 0; !reader_.eof(); ++num_iterations) {
+    // Each iteration of this loop reads some rows (iter_num_rows_to_read
+    // are read) and then skips some rows (iter_num_rows_to_skip will be
     // skipped).
     // The loop variable i is the current row being read.
     // Loop variable j is used just to count the number of rows to
     // read.
-    for (int j = 0; !reader_.eof() && (j < num_rows_to_read); ++i, ++j) {
+    bool b;
+    std::string s;
+    std::array<char, 4> char_array;
+    char c;
+    int8_t int8;
+    uint16_t uint16;
+    int32_t int32;
+    uint64_t uint64;
+    std::chrono::microseconds ts_us;
+    float f;
+    double d;
+    std::string str;
+
+    for (int j = 0; !reader_.eof() && (j < iter_num_rows_to_read); ++i, ++j) {
       ASSERT_EQ(i, reader_.current_row());
 
       reader_ >> b;
@@ -347,13 +348,12 @@ TEST_F(TestStreamReader, SkipRows) {
       ASSERT_FLOAT_EQ(f, TestData::GetFloat(i));
       ASSERT_DOUBLE_EQ(d, TestData::GetDouble(i));
     }
-    ASSERT_EQ(num_rows_to_skip, reader_.SkipRows(num_rows_to_skip));
-    i += num_rows_to_skip;
+    ASSERT_EQ(iter_num_rows_to_skip, reader_.SkipRows(iter_num_rows_to_skip));
+    i += iter_num_rows_to_skip;
   }
   ASSERT_EQ(TestData::num_rows, reader_.current_row());
 
-  ASSERT_EQ(num_rows_read, num_rows_to_read * TestData::num_rows /
-                               (num_rows_to_read + num_rows_to_skip));
+  ASSERT_EQ(num_rows_read, num_iterations * iter_num_rows_to_read);
 
   // Skipping rows at eof is allowed.
   //


### PR DESCRIPTION
Add methods to the StreamReader class to allow for columns and rows of
data to be skipped.

Also add helper methods for finding out:
- total number of columns
- total number of rows
- current row
- current column