### PR TITLE
ARROW-7021: [Java] UnionFixedSizeListWriter decimal type should check writer index

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
@@ -174,16 +174,25 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
 
   @Override
   public void write(DecimalHolder holder) {
+    if (writer.idx() >= (idx() + 1) * listSize) {
+      throw new IllegalStateException(String.format("values at index %s exceed listSize %s", idx(), listSize));
+    }
     writer.write(holder);
     writer.setPosition(writer.idx() + 1);
   }
 
   public void writeDecimal(int start, ArrowBuf buffer) {
+    if (writer.idx() >= (idx() + 1) * listSize) {
+      throw new IllegalStateException(String.format("values at index %s exceed listSize %s", idx(), listSize));
+    }
     writer.writeDecimal(start, buffer);
     writer.setPosition(writer.idx() + 1);
   }
 
   public void writeDecimal(BigDecimal value) {
+    if (writer.idx() >= (idx() + 1) * listSize) {
+      throw new IllegalStateException(String.format("values at index %s exceed listSize %s", idx(), listSize));
+    }
     writer.writeDecimal(value);
     writer.setPosition(writer.idx() + 1);
   }
@@ -197,7 +206,7 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
   @Override
   public void write${name}(<#list fields as field>${field.type} ${field.name}<#if field_has_next>, </#if></#list>) {
     if (writer.idx() >= (idx() + 1) * listSize) {
-      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
+      throw new IllegalStateException(String.format("values at index %s exceed listSize %s", idx(), listSize));
     }
     writer.write${name}(<#list fields as field>${field.name}<#if field_has_next>, </#if></#list>);
     writer.setPosition(writer.idx() + 1);

--- a/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
@@ -175,7 +175,7 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
   @Override
   public void write(DecimalHolder holder) {
     if (writer.idx() >= (idx() + 1) * listSize) {
-      throw new IllegalStateException(String.format("values at index %s exceed listSize %s", idx(), listSize));
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
     }
     writer.write(holder);
     writer.setPosition(writer.idx() + 1);
@@ -183,7 +183,7 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
 
   public void writeDecimal(int start, ArrowBuf buffer) {
     if (writer.idx() >= (idx() + 1) * listSize) {
-      throw new IllegalStateException(String.format("values at index %s exceed listSize %s", idx(), listSize));
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
     }
     writer.writeDecimal(start, buffer);
     writer.setPosition(writer.idx() + 1);
@@ -191,7 +191,7 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
 
   public void writeDecimal(BigDecimal value) {
     if (writer.idx() >= (idx() + 1) * listSize) {
-      throw new IllegalStateException(String.format("values at index %s exceed listSize %s", idx(), listSize));
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
     }
     writer.writeDecimal(value);
     writer.setPosition(writer.idx() + 1);
@@ -206,7 +206,7 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
   @Override
   public void write${name}(<#list fields as field>${field.type} ${field.name}<#if field_has_next>, </#if></#list>) {
     if (writer.idx() >= (idx() + 1) * listSize) {
-      throw new IllegalStateException(String.format("values at index %s exceed listSize %s", idx(), listSize));
+      throw new IllegalStateException(String.format("values at index %s is greater than listSize %s", idx(), listSize));
     }
     writer.write${name}(<#list fields as field>${field.name}<#if field_has_next>, </#if></#list>);
     writer.setPosition(writer.idx() + 1);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -266,6 +267,23 @@ public class TestFixedSizeListVector {
   }
 
   @Test(expected = IllegalStateException.class)
+  public void testDecimalIndexCheck() throws Exception {
+    try (final FixedSizeListVector vector1 = FixedSizeListVector.empty("vector", 3, allocator)) {
+
+      UnionFixedSizeListWriter writer1 = vector1.getWriter();
+      writer1.allocate();
+
+      writer1.startList();
+      writer1.decimal().writeDecimal(new BigDecimal(1));
+      writer1.decimal().writeDecimal(new BigDecimal(2));
+      writer1.decimal().writeDecimal(new BigDecimal(3));
+      writer1.decimal().writeDecimal(new BigDecimal(4));
+      writer1.endList();
+    }
+  }
+
+
+  @Test(expected = IllegalStateException.class)
   public void testWriteIllegalData() throws Exception {
     try (final FixedSizeListVector vector1 = FixedSizeListVector.empty("vector", 3, allocator)) {
 
@@ -285,6 +303,7 @@ public class TestFixedSizeListVector {
       assertTrue(Arrays.equals(values1, realValue1));
       int[] realValue2 = convertListToIntArray((JsonStringArrayList) vector1.getObject(1));
       assertTrue(Arrays.equals(values2, realValue2));
+      System.out.println("hehe");
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
@@ -19,6 +19,7 @@ package org.apache.arrow.vector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -266,19 +267,22 @@ public class TestFixedSizeListVector {
     }
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testDecimalIndexCheck() throws Exception {
     try (final FixedSizeListVector vector1 = FixedSizeListVector.empty("vector", 3, allocator)) {
 
       UnionFixedSizeListWriter writer1 = vector1.getWriter();
       writer1.allocate();
 
-      writer1.startList();
-      writer1.decimal().writeDecimal(new BigDecimal(1));
-      writer1.decimal().writeDecimal(new BigDecimal(2));
-      writer1.decimal().writeDecimal(new BigDecimal(3));
-      writer1.decimal().writeDecimal(new BigDecimal(4));
-      writer1.endList();
+      IllegalStateException e = assertThrows(IllegalStateException.class, () -> {
+        writer1.startList();
+        writer1.decimal().writeDecimal(new BigDecimal(1));
+        writer1.decimal().writeDecimal(new BigDecimal(2));
+        writer1.decimal().writeDecimal(new BigDecimal(3));
+        writer1.decimal().writeDecimal(new BigDecimal(4));
+        writer1.endList();
+      });
+      assertEquals("values at index 0 exceed listSize 3", e.getMessage());
     }
   }
 
@@ -303,7 +307,6 @@ public class TestFixedSizeListVector {
       assertTrue(Arrays.equals(values1, realValue1));
       int[] realValue2 = convertListToIntArray((JsonStringArrayList) vector1.getObject(1));
       assertTrue(Arrays.equals(values2, realValue2));
-      System.out.println("hehe");
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestFixedSizeListVector.java
@@ -269,7 +269,7 @@ public class TestFixedSizeListVector {
 
   @Test
   public void testDecimalIndexCheck() throws Exception {
-    try (final FixedSizeListVector vector1 = FixedSizeListVector.empty("vector", 3, allocator)) {
+    try (final FixedSizeListVector vector1 = FixedSizeListVector.empty("vector", /*listSize=*/3, allocator)) {
 
       UnionFixedSizeListWriter writer1 = vector1.getWriter();
       writer1.allocate();
@@ -282,7 +282,7 @@ public class TestFixedSizeListVector {
         writer1.decimal().writeDecimal(new BigDecimal(4));
         writer1.endList();
       });
-      assertEquals("values at index 0 exceed listSize 3", e.getMessage());
+      assertEquals("values at index 0 is greater than listSize 3", e.getMessage());
     }
   }
 


### PR DESCRIPTION
Related to [ARROW-7021](https://issues.apache.org/jira/browse/ARROW-7021).

UnionFixedSizeListWriter should check writer index for decimal type (just as other types) to ensure the values written not exceed listSize.

Otherwise, the writer may continue to write data into it’s underlying vector quietly even the the writer.idx() > listSize * index.