### PR TITLE
ARROW-7227: [Python] Added a python wrapper for ConcatenateTablesWithPromotions

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -122,7 +122,8 @@ from pyarrow.lib import (HdfsFile, NativeFile, PythonFile,
                          MockOutputStream, input_stream, output_stream)
 
 from pyarrow.lib import (ChunkedArray, RecordBatch, Table,
-                         concat_arrays, concat_tables)
+                         concat_arrays, concat_tables,
+                         concat_tables_with_promotion)
 
 # Exceptions
 from pyarrow.lib import (ArrowException,

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -122,8 +122,7 @@ from pyarrow.lib import (HdfsFile, NativeFile, PythonFile,
                          MockOutputStream, input_stream, output_stream)
 
 from pyarrow.lib import (ChunkedArray, RecordBatch, Table,
-                         concat_arrays, concat_tables,
-                         concat_tables_with_promotion)
+                         concat_arrays, concat_tables)
 
 # Exceptions
 from pyarrow.lib import (ArrowException,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -743,6 +743,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
     CStatus ConcatenateTables(const vector[shared_ptr[CTable]]& tables,
                               shared_ptr[CTable]* result)
 
+    CResult[shared_ptr[CTable]] ConcatenateTablesWithPromotion(
+        const vector[shared_ptr[CTable]]& tables, CMemoryPool* pool)
+
 cdef extern from "arrow/builder.h" namespace "arrow" nogil:
 
     cdef cppclass CArrayBuilder" arrow::ArrayBuilder":

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1696,7 +1696,6 @@ def concat_tables(tables, promote=False, MemoryPool memory_pool=None):
     """
     cdef:
         vector[shared_ptr[CTable]] c_tables
-        CResult[shared_ptr[CTable]] c_result
         shared_ptr[CTable] c_result_table
         CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
         Table table
@@ -1706,8 +1705,8 @@ def concat_tables(tables, promote=False, MemoryPool memory_pool=None):
 
     if promote:
         with nogil:
-            c_result = ConcatenateTablesWithPromotion(c_tables, pool)
-        c_result_table = GetResultValue(c_result)
+            c_result_table = GetResultValue(
+                ConcatenateTablesWithPromotion(c_tables, pool))
     else:
         with nogil:
             check_status(ConcatenateTables(c_tables, &c_result_table))

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1669,7 +1669,7 @@ def table(data, names=None, schema=None, metadata=None):
             "Expected pandas DataFrame, python dictionary or list of arrays")
 
 
-def concat_tables(tables, promote=False, MemoryPool memory_pool=None):
+def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
     """
     Perform zero-copy concatenation of pyarrow.Table objects.
 
@@ -1702,13 +1702,11 @@ def concat_tables(tables, promote=False, MemoryPool memory_pool=None):
 
     for table in tables:
         c_tables.push_back(table.sp_table)
-
-    if promote:
-        with nogil:
+    with nogil:
+        if promote:
             c_result_table = GetResultValue(
                 ConcatenateTablesWithPromotion(c_tables, pool))
-    else:
-        with nogil:
+        else:
             check_status(ConcatenateTables(c_tables, &c_result_table))
 
     return pyarrow_wrap_table(c_result_table)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1671,26 +1671,26 @@ def table(data, names=None, schema=None, metadata=None):
 
 def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
     """
-    Perform zero-copy concatenation of pyarrow.Table objects.
+    Concatenate pyarrow.Table objects.
 
-    If promote==False, the schemas of all the Tables must be the same
-    (except the metadata), otherwise an exception will be raised. The result
-    Table will share the metadata with the first table.
+    If promote==False, a zero-copy concatenation will be performed. The schemas
+    of all the Tables must be the same (except the metadata), otherwise an
+    exception will be raised. The result Table will share the metadata with the
+    first table.
 
-    If promote==True, columns of the same name will be concatenated.
-    They should be of the same type, or be of type NULL, in which case it will
-    be promoted to the type of other corresponding columns with null values
-    filled.  If a table is missing a particular field, null values of the
-    appropriate type will be generated to take the place of the missing field.
-    The new schema will share the metadata with the first table. Each field in
-    the new schema will share the metadata with the first table which has the
-    field defined.
+    If promote==True, any null type arrays will be casted to the type of other
+    arrays in the column of the same name. If a table is missing a particular
+    field, null values of the appropriate type will be generated to take the
+    place of the missing field. The new schema will share the metadata with the
+    first table. Each field in the new schema will share the metadata with the
+    first table which has the field defined. Note that type promotions may
+    involve additional allocations on the given ``memory_pool``.
 
     Parameters
     ----------
     tables : iterable of pyarrow.Table objects
     promote: bool, default False
-        If True, concatenate tables with null-filling and type promotion.
+        If True, concatenate tables with null-filling and null type promotion.
     memory_pool : MemoryPool, default None
         For memory allocations, if required, otherwise use default pool
     """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1674,7 +1674,7 @@ def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
     Perform zero-copy concatenation of pyarrow.Table objects.
 
     If promote==False, the schemas of all the Tables must be the same
-    (modulo the metadata), otherwise an exception will be raised. The result
+    (except the metadata), otherwise an exception will be raised. The result
     Table will share the metadata with the first table.
 
     If promote==True, columns of the same name will be concatenated.
@@ -1690,7 +1690,7 @@ def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
     ----------
     tables : iterable of pyarrow.Table objects
     promote: bool, default False
-        if True, concatenate tables with null-filling and type promotion.
+        If True, concatenate tables with null-filling and type promotion.
     memory_pool : MemoryPool, default None
         For memory allocations, if required, otherwise use default pool
     """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1669,15 +1669,15 @@ def table(data, names=None, schema=None, metadata=None):
             "Expected pandas DataFrame, python dictionary or list of arrays")
 
 
-def concat_tables(tables, with_promotion=False, MemoryPool memory_pool=None):
+def concat_tables(tables, promote=False, MemoryPool memory_pool=None):
     """
     Perform zero-copy concatenation of pyarrow.Table objects.
 
-    If with_promotion==False, the schemas of all the Tables must be the same
+    If promote==False, the schemas of all the Tables must be the same
     (modulo the metadata), otherwise an exception will be raised. The result
     Table will share the metadata with the first table.
 
-    If with_promotion==True, columns of the same name will be concatenated.
+    If promote==True, columns of the same name will be concatenated.
     They should be of the same type, or be of type NULL, in which case it will
     be promoted to the type of other corresponding columns with null values
     filled.  If a table is missing a particular field, null values of the
@@ -1689,7 +1689,7 @@ def concat_tables(tables, with_promotion=False, MemoryPool memory_pool=None):
     Parameters
     ----------
     tables : iterable of pyarrow.Table objects
-    with_promotion: bool, default False
+    promote: bool, default False
         if True, concatenate tables with null-filling and type promotion.
     memory_pool : MemoryPool, default None
         For memory allocations, if required, otherwise use default pool
@@ -1704,13 +1704,12 @@ def concat_tables(tables, with_promotion=False, MemoryPool memory_pool=None):
     for table in tables:
         c_tables.push_back(table.sp_table)
 
-    if with_promotion:
-      with nogil:
-        c_result = ConcatenateTablesWithPromotion(c_tables, pool)
-      c_result_table = GetResultValue(c_result)
+    if promote:
+        with nogil:
+            c_result = ConcatenateTablesWithPromotion(c_tables, pool)
+        c_result_table = GetResultValue(c_result)
     else:
-      with nogil:
-          check_status(ConcatenateTables(c_tables, &c_result_table))
+        with nogil:
+            check_status(ConcatenateTables(c_tables, &c_result_table))
 
     return pyarrow_wrap_table(c_result_table)
-

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1672,7 +1672,12 @@ def table(data, names=None, schema=None, metadata=None):
 def concat_tables(tables, with_promotion=False, MemoryPool memory_pool=None):
     """
     Perform zero-copy concatenation of pyarrow.Table objects.
-    if with_promotion==True, Columns of the same name will be concatenated.
+
+    If with_promotion==False, the schemas of all the Tables must be the same
+    (modulo the metadata), otherwise an exception will be raised. The result
+    Table will share the metadata with the first table.
+
+    If with_promotion==True, columns of the same name will be concatenated.
     They should be of the same type, or be of type NULL, in which case it will
     be promoted to the type of other corresponding columns with null values
     filled.  If a table is missing a particular field, null values of the
@@ -1680,16 +1685,14 @@ def concat_tables(tables, with_promotion=False, MemoryPool memory_pool=None):
     The new schema will share the metadata with the first table. Each field in
     the new schema will share the metadata with the first table which has the
     field defined.
-    if with_promotion==False, the schemas of all the Tables must be the same,
-    otherwise an exception will be raised.
 
     Parameters
     ----------
     tables : iterable of pyarrow.Table objects
-    with_promotion: if True, concatenate tables with null-filling and type
-      promotion.
+    with_promotion: bool, default False
+        if True, concatenate tables with null-filling and type promotion.
     memory_pool : MemoryPool, default None
-      For memory allocations, if required, otherwise use default pool
+        For memory allocations, if required, otherwise use default pool
     """
     cdef:
         vector[shared_ptr[CTable]] c_tables

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -825,7 +825,7 @@ def test_concat_tables_with_promotion():
     t2 = pa.Table.from_arrays(
         [pa.array([1.0, 2.0], type=pa.float32())], ["float_field"])
 
-    result = pa.concat_tables_with_promotion([t1, t2])
+    result = pa.concat_tables([t1, t2], with_promotion=True)
 
     assert result.equals(pa.Table.from_arrays([
         pa.array([1, 2, None, None], type=pa.int64()),
@@ -840,7 +840,7 @@ def test_concat_tables_with_promotion_error():
         [pa.array([1, 2], type=pa.float32())], ["f"])
 
     with pytest.raises(pa.ArrowInvalid):
-        pa.concat_tables_with_promotion([t1, t2])
+        pa.concat_tables([t1, t2], with_promotion=True)
 
 
 def test_table_negative_indexing():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -819,6 +819,30 @@ def test_concat_tables_with_different_schema_metadata():
     assert table2.schema.equals(table3.schema, check_metadata=False)
 
 
+def test_concat_tables_with_promotion():
+    t1 = pa.Table.from_arrays(
+        [pa.array([1, 2], type=pa.int64())], ["int64_field"])
+    t2 = pa.Table.from_arrays(
+        [pa.array([1.0, 2.0], type=pa.float32())], ["float_field"])
+
+    result = pa.concat_tables_with_promotion([t1, t2])
+
+    assert result.equals(pa.Table.from_arrays([
+        pa.array([1, 2, None, None], type=pa.int64()),
+        pa.array([None, None, 1.0, 2.0], type=pa.float32()),
+    ], ["int64_field", "float_field"]))
+
+
+def test_concat_tables_with_promotion_error():
+    t1 = pa.Table.from_arrays(
+        [pa.array([1, 2], type=pa.int64())], ["f"])
+    t2 = pa.Table.from_arrays(
+        [pa.array([1, 2], type=pa.float32())], ["f"])
+
+    with pytest.raises(pa.ArrowInvalid):
+        pa.concat_tables_with_promotion([t1, t2])
+
+
 def test_table_negative_indexing():
     data = [
         pa.array(range(5)),

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -825,7 +825,7 @@ def test_concat_tables_with_promotion():
     t2 = pa.Table.from_arrays(
         [pa.array([1.0, 2.0], type=pa.float32())], ["float_field"])
 
-    result = pa.concat_tables([t1, t2], with_promotion=True)
+    result = pa.concat_tables([t1, t2], promote=True)
 
     assert result.equals(pa.Table.from_arrays([
         pa.array([1, 2, None, None], type=pa.int64()),
@@ -840,7 +840,7 @@ def test_concat_tables_with_promotion_error():
         [pa.array([1, 2], type=pa.float32())], ["f"])
 
     with pytest.raises(pa.ArrowInvalid):
-        pa.concat_tables([t1, t2], with_promotion=True)
+        pa.concat_tables([t1, t2], promote=True)
 
 
 def test_table_negative_indexing():


### PR DESCRIPTION
@wesm 
I'd also like to seek advice on consolidating Concat*() APIs with ConcatenateOptions: do we want to consolidate ConcatenateTables and ConcatenateTablesWithPromotions? I can imagine at the beginning the ConcatenateOptions contains only a "with_promotion" field.
