### PR TITLE
ARROW-7113: [Rust] Add unowned buffer.

### DIFF
--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -99,20 +99,21 @@ impl Debug for BufferData {
 impl Buffer {
     /// Creates a buffer from an existing memory region (must already be byte-aligned), and this
     /// buffer will free this piece of memory when dropped.
-    #[deprecated(since = "1.0.0", note = "Please use from_owned_raw_parts instead")]
+    ///
+    /// This method is the same as `from_owned`.
     pub fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
         Buffer::build_with_arguments(ptr, len, true)
     }
 
     /// Creates a buffer from an existing memory region (must already be byte-aligned), and this
     /// buffer will free this piece of memory when dropped.
-    pub fn from_owned_raw_parts(ptr: *const u8, len: usize) -> Self {
+    pub fn from_owned(ptr: *const u8, len: usize) -> Self {
         Buffer::build_with_arguments(ptr, len, true)
     }
 
     /// Creates a buffer from an existing memory region (must already be byte-aligned), and this
     /// buffers doesn't free this piece of memory when dropped.
-    pub fn from_unowned_raw_parts(ptr: *const u8, len: usize) -> Self {
+    pub fn from_unowned(ptr: *const u8, len: usize) -> Self {
         Buffer::build_with_arguments(ptr, len, false)
     }
 

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -99,15 +99,7 @@ impl Debug for BufferData {
 impl Buffer {
     /// Creates a buffer from an existing memory region (must already be byte-aligned), and this
     /// buffer will free this piece of memory when dropped.
-    ///
-    /// This method is the same as `from_owned`.
     pub fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
-        Buffer::build_with_arguments(ptr, len, true)
-    }
-
-    /// Creates a buffer from an existing memory region (must already be byte-aligned), and this
-    /// buffer will free this piece of memory when dropped.
-    pub fn from_owned(ptr: *const u8, len: usize) -> Self {
         Buffer::build_with_arguments(ptr, len, true)
     }
 

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -55,7 +55,7 @@ struct BufferData {
 
     /// The length (num of bytes) of the buffer
     len: usize,
-  
+
     /// Whether this piece of memory is owned by this object
     owned: bool,
 }
@@ -99,10 +99,9 @@ impl Debug for BufferData {
 impl Buffer {
     /// Creates a buffer from an existing memory region (must already be byte-aligned)
     pub fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
-      Buffer::from_raw_parts_owned(ptr, len, true)
+        Buffer::from_raw_parts_owned(ptr, len, true)
     }
-    
-    
+
     /// Creates a buffer from an existing memory region (must already be byte-aligned)
     /// This differs from `from_raw_parts` in that user can provide an argument to indicate
     /// whether this piece of memory is owned by this buffer.

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -97,15 +97,34 @@ impl Debug for BufferData {
 }
 
 impl Buffer {
-    /// Creates a buffer from an existing memory region (must already be byte-aligned)
+    /// Creates a buffer from an existing memory region (must already be byte-aligned), and this
+    /// buffer will free this piece of memory when dropped.
+    #[deprecated(since = "1.0.0", note = "Please use from_owned_raw_parts instead")]
     pub fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
-        Buffer::from_raw_parts_owned(ptr, len, true)
+        Buffer::build_with_arguments(ptr, len, true)
+    }
+
+    /// Creates a buffer from an existing memory region (must already be byte-aligned), and this
+    /// buffer will free this piece of memory when dropped.
+    pub fn from_owned_raw_parts(ptr: *const u8, len: usize) -> Self {
+        Buffer::build_with_arguments(ptr, len, true)
+    }
+
+    /// Creates a buffer from an existing memory region (must already be byte-aligned), and this
+    /// buffers doesn't free this piece of memory when dropped.
+    pub fn from_unowned_raw_parts(ptr: *const u8, len: usize) -> Self {
+        Buffer::build_with_arguments(ptr, len, false)
     }
 
     /// Creates a buffer from an existing memory region (must already be byte-aligned)
-    /// This differs from `from_raw_parts` in that user can provide an argument to indicate
-    /// whether this piece of memory is owned by this buffer.
-    pub fn from_raw_parts_owned(ptr: *const u8, len: usize, owned: bool) -> Self {
+    ///
+    /// # Arguments
+    ///
+    /// * `ptr` - Pointer to raw parts.
+    /// * `len` - Length of raw parts in bytes
+    /// * `owned` - Whether the raw parts is owned by this buffer. If true, this buffer will free
+    /// this memory when dropped, otherwise it will skip freeing the raw parts.
+    fn build_with_arguments(ptr: *const u8, len: usize, owned: bool) -> Self {
         assert!(
             memory::is_aligned(ptr, memory::ALIGNMENT),
             "memory not aligned"

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -462,6 +462,7 @@ impl MutableBuffer {
         let buffer_data = BufferData {
             ptr: self.data,
             len: self.len,
+            owned: true,
         };
         ::std::mem::forget(self);
         Buffer {


### PR DESCRIPTION
Currently rust Buffer always assume that the memory passed to it is owned by itself, and frees the memory when Buffer is dropped. This is inconvenient when used in cross language environments such as jni. 