### PR TITLE
ARROW-6799: [WIP][Plasma] Fix plasma_java build

### DIFF
--- a/cpp/src/plasma/CMakeLists.txt
+++ b/cpp/src/plasma/CMakeLists.txt
@@ -190,17 +190,11 @@ if(ARROW_PLASMA_JAVA_CLIENT)
                           plasma_shared
                           ${PLASMA_LINK_LIBS}
                           "-undefined dynamic_lookup"
-                          -Wl,-force_load,flatbuffers::flatbuffers
-                          flatbuffers::flatbuffers
                           ${PTHREAD_LIBRARY})
   else(APPLE)
     target_link_libraries(plasma_java
                           plasma_shared
                           ${PLASMA_LINK_LIBS}
-                          -Wl,--whole-archive
-                          flatbuffers::flatbuffers
-                          -Wl,--no-whole-archive
-                          flatbuffers::flatbuffers
                           ${PTHREAD_LIBRARY})
   endif(APPLE)
 endif()

--- a/java/plasma/test.sh
+++ b/java/plasma/test.sh
@@ -31,7 +31,7 @@ pushd ../../cpp
       mkdir release
     fi
     pushd release
-        cmake -DCMAKE_BUILD_TYPE=Release \
+        sudo cmake -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_FLAGS="-g -O3" \
             -DCMAKE_CXX_FLAGS="-g -O3" \
             -DARROW_BUILD_TESTS=off \
@@ -47,10 +47,10 @@ pushd ../../cpp
             -DARROW_WITH_ZSTD=off \
             -DARROW_PLASMA_JAVA_CLIENT=on \
             ..
-        make VERBOSE=1 -j$PARALLEL
+        sudo make VERBOSE=1 -j$PARALLEL
     popd
 popd
 
 mvn clean install
-export PLASMA_STORE=$ROOT_DIR/../../cpp/release/release/plasma_store_server
-java -cp target/test-classes:target/classes -Djava.library.path=$ROOT_DIR/../../cpp/release/release/ org.apache.arrow.plasma.PlasmaClientTest
+export PLASMA_STORE=$CONDA_PREFIX/tmp/arrow/cpp/release/release/plasma-store-server
+java -cp target/test-classes:target/classes -Djava.library.path=$CONDA_PREFIX/tmp/arrow/cpp/release/release/ org.apache.arrow.plasma.PlasmaClientTest


### PR DESCRIPTION
# What does this PR do ?
It removes the unused flatbuffers linked lib from the `arrow/cpp/src/plasma/CMakeList.txt` file.
It fixes var naming into the `arrow/java/plasma/test.sh` file that prevented java from finding the built binaries 