### PR TITLE
ARROW-7100: [C++][HDFS] Fix search directories for libjvm.so

### DIFF
--- a/cpp/src/arrow/io/hdfs_internal.cc
+++ b/cpp/src/arrow/io/hdfs_internal.cc
@@ -217,7 +217,7 @@ static std::vector<fs::path> get_potential_libjvm_paths() {
       "/usr/lib/jvm/default",                     // alt centos
       "/usr/java/latest",                         // alt centos
   };
-  search_suffixes = {"", "/jre/lib/amd64/server", "/lib/amd64/server"};
+  search_suffixes = {"", "/jre/lib/amd64/server", "/lib/amd64/server", "/lib/server"};
   file_name = "libjvm.so";
 #endif
   // From direct environment variable


### PR DESCRIPTION
Added "/lib/server" to search_suffices to deal with recent installs of java on ubuntu systems.