### PR TITLE
ARROW-7061: [C++][Dataset] Add ignore file options to FileSystemDataSourceDiscovery

### DIFF
--- a/cpp/examples/arrow/dataset-parquet-scan-example.cc
+++ b/cpp/examples/arrow/dataset-parquet-scan-example.cc
@@ -73,8 +73,11 @@ std::shared_ptr<ds::Dataset> GetDatasetFromPath(fs::FileSystem* fs,
   s.base_dir = path;
   s.recursive = true;
 
+  ds::FileSystemDiscoveryOptions options;
+
   std::shared_ptr<ds::DataSourceDiscovery> discovery;
-  ABORT_ON_FAILURE(ds::FileSystemDataSourceDiscovery::Make(fs, s, format, &discovery));
+  ABORT_ON_FAILURE(
+      ds::FileSystemDataSourceDiscovery::Make(fs, s, format, options, &discovery));
 
   std::shared_ptr<Schema> inspect_schema;
   ABORT_ON_FAILURE(discovery->Inspect(&inspect_schema));

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -323,7 +323,9 @@ TEST_F(TestEndToEnd, EndToEndSingleSource) {
   s.base_dir = "/dataset";
   s.recursive = true;
 
-  // Further options can be given to the discovery mechanism.
+  // Further options can be given to the discovery mechanism via the
+  // FileSystemDiscoveryOptions configuration class. See the docstring for more
+  // information.
   FileSystemDiscoveryOptions options;
   options.ignore_prefixes = {"."};
 

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -248,30 +248,33 @@ class TestEndToEnd : public TestDataset {
     });
 
     using PathAndContent = std::vector<std::pair<std::string, std::string>>;
-    auto files = PathAndContent{{"/2018/01/US.json", R"([
+    auto files = PathAndContent{
+        {"/dataset/2018/01/US.json", R"([
         {"country": "US", "region": "NY", "year": 2018, "model": "3", "sales": 742},
         {"country": "US", "region": "NY", "year": 2018, "model": "S", "sales": 304},
         {"country": "US", "region": "NY", "year": 2018, "model": "X", "sales": 136},
         {"country": "US", "region": "NY", "year": 2018, "model": "Y", "sales": 27}
       ])"},
-                                {"/2018/01/CA.json", R"([
+        {"/dataset/2018/01/CA.json", R"([
         {"country": "US", "region": "CA", "year": 2018, "model": "3", "sales": 512},
         {"country": "US", "region": "CA", "year": 2018, "model": "S", "sales": 978},
         {"country": "US", "region": "CA", "year": 2018, "model": "X", "sales": 1},
         {"country": "US", "region": "CA", "year": 2018, "model": "Y", "sales": 69}
       ])"},
-                                {"/2019/01/US.json", R"([
+        {"/dataset/2019/01/US.json", R"([
         {"country": "CA", "region": "QC", "year": 2019, "model": "3", "sales": 273},
         {"country": "CA", "region": "QC", "year": 2019, "model": "S", "sales": 13},
         {"country": "CA", "region": "QC", "year": 2019, "model": "X", "sales": 54},
         {"country": "CA", "region": "QC", "year": 2019, "model": "Y", "sales": 21}
       ])"},
-                                {"/2019/01/CA.json", R"([
+        {"/dataset/2019/01/CA.json", R"([
         {"country": "CA", "region": "QC", "year": 2019, "model": "3", "sales": 152},
         {"country": "CA", "region": "QC", "year": 2019, "model": "S", "sales": 10},
         {"country": "CA", "region": "QC", "year": 2019, "model": "X", "sales": 42},
         {"country": "CA", "region": "QC", "year": 2019, "model": "Y", "sales": 37}
-      ])"}};
+      ])"},
+        {"/dataset/.pesky", "garbage content"},
+    };
 
     auto mock_fs = std::make_shared<fs::internal::MockFileSystem>(fs::kNoTime);
     for (const auto& f : files) {
@@ -317,9 +320,15 @@ TEST_F(TestEndToEnd, EndToEndSingleSource) {
   // FileSystemDataSourceDiscovery class also supports an explicit list of
   // fs::FileStats instead of the selector.
   fs::Selector s;
-  s.base_dir = "/";
+  s.base_dir = "/dataset";
   s.recursive = true;
-  ASSERT_OK(FileSystemDataSourceDiscovery::Make(fs_.get(), s, format, &discovery));
+
+  // Further options can be given to the discovery mechanism.
+  FileSystemDiscoveryOptions options;
+  options.ignore_prefixes = {"."};
+
+  ASSERT_OK(
+      FileSystemDataSourceDiscovery::Make(fs_.get(), s, format, options, &discovery));
 
   // DataFragments might have compatible but slightly different schemas, e.g.
   // schema evolved by adding/renaming columns. In this case, the schema is

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -56,6 +56,9 @@ class ARROW_DS_EXPORT DataSourceDiscovery {
   /// \brief Get the schema for the resulting DataSource.
   virtual Status Inspect(std::shared_ptr<Schema>* out) = 0;
 
+  /// \brief Create a DataSource with a given partition.
+  virtual Status Finish(std::shared_ptr<DataSource>* out) = 0;
+
   std::shared_ptr<Schema> schema() const { return schema_; }
   Status SetSchema(std::shared_ptr<Schema> schema) {
     schema_ = schema;
@@ -74,9 +77,6 @@ class ARROW_DS_EXPORT DataSourceDiscovery {
     return Status::OK();
   }
 
-  /// \brief Create a DataSource with a given partition.
-  virtual Status Finish(std::shared_ptr<DataSource>* out) = 0;
-
   virtual ~DataSourceDiscovery() = default;
 
  protected:
@@ -85,35 +85,94 @@ class ARROW_DS_EXPORT DataSourceDiscovery {
   std::shared_ptr<Expression> root_partition_;
 };
 
-/// \brief FileSystemDataSourceFactory creates a DataSource from a vector
-/// of fs::FileStats or a fs::Selector.
+struct FileSystemDiscoveryOptions {
+  // For the purposes of applying the partition scheme, files will be stripped
+  // of the partition_base_dir. Files not matching the partition_base_dir
+  // prefix will be skipped for partition discovery. The ignored files will still
+  // be part of the DataSource, but will not have partition information.
+  //
+  // Example:
+  // partition_base_dir = "/dataset";
+  //
+  // - "/dataset/US/sales.csv" -> "US/sales.csv" will be given to the partition
+  //                              scheme
+  //
+  // - "/home/john/late_sales.csv" -> Will be ignored for partition discovery.
+  //
+  // This is useful for partition schemes which parses directory when ordering
+  // is important, e.g. SchemaPartitionScheme.
+  std::string partition_base_dir;
+
+  // Files matching one of the following prefix will be ignored by the
+  // discovery process. This is matched to the basename of a path.
+  //
+  // Example:
+  // ignore_prefixes = {"_", ".DS_STORE" };
+  //
+  // - "/dataset/data.csv" -> not ignored
+  // - "/dataset/_metadata" -> ignored
+  // - "/dataset/.DS_STORE" -> ignored
+  std::vector<std::string> ignore_prefixes = {
+      ".",
+      "_",
+      // HDFS stamp files. A full match is also a valid prefix match.
+      "_$folder$",
+      "_SUCCESS",
+  };
+};
+
+/// \brief FileSystemDataSourceFactory creates a DataSource from a vector of
+/// fs::FileStats or a fs::Selector.
 class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery {
  public:
-  static Status Make(fs::FileSystem* filesystem, std::string base_dir,
-                     std::vector<fs::FileStats> files, std::shared_ptr<FileFormat> format,
-                     std::shared_ptr<DataSourceDiscovery>* out);
-
-  static Status Make(fs::FileSystem* filesystem, std::vector<fs::FileStats> files,
+  /// \brief Build a FileSystemDataSourceDiscovery from an explicit list of
+  /// fs::FileStats.
+  ///
+  /// \param[in] filesystem passed to FileSystemDataSource
+  /// \param[in] stats passed to FileSystemDataSource
+  /// \param[in] format passed to FileSystemDataSource
+  /// \param[in] options see @FileSystemDiscoveryOptions for more information.
+  /// \param[out] discovery output pointer
+  static Status Make(fs::FileSystem* filesystem, std::vector<fs::FileStats> stats,
                      std::shared_ptr<FileFormat> format,
-                     std::shared_ptr<DataSourceDiscovery>* out);
+                     FileSystemDiscoveryOptions options,
+                     std::shared_ptr<DataSourceDiscovery>* discovery);
 
+  /// \brief Build a FileSystemDataSourceDiscovery from a fs::Selector.
+  ///
+  /// The selector will expand to a vector of FileStats. The expansion/crawling
+  /// is performed in this function call. Thus, the finalized DataSource is
+  /// working with a snapshot of the filesystem.
+  //
+  /// If options.partition_base_dir is not provided, it will be overwritten
+  /// with selector.base_dir.
+  ///
+  /// \param[in] filesystem passed to FileSystemDataSource
+  /// \param[in] selector
+  /// \param[in] format passed to FileSystemDataSource
+  /// \param[in] format to pass to FileSystemDataSource
+  /// \param[in] options see @FileSystemDiscoveryOptions for more information.
+  /// \param[out] discovery output pointer
   static Status Make(fs::FileSystem* filesystem, fs::Selector selector,
                      std::shared_ptr<FileFormat> format,
-                     std::shared_ptr<DataSourceDiscovery>* out);
+                     FileSystemDiscoveryOptions options,
+                     std::shared_ptr<DataSourceDiscovery>* discovery);
 
   Status Inspect(std::shared_ptr<Schema>* out) override;
 
   Status Finish(std::shared_ptr<DataSource>* out) override;
 
  protected:
-  FileSystemDataSourceDiscovery(fs::FileSystem* filesystem, std::string base_dir,
+  FileSystemDataSourceDiscovery(fs::FileSystem* filesystem,
                                 std::vector<fs::FileStats> files,
-                                std::shared_ptr<FileFormat> format);
+                                std::shared_ptr<FileFormat> format,
+                                FileSystemDiscoveryOptions options);
 
   fs::FileSystem* fs_;
-  std::string base_dir_;
   std::vector<fs::FileStats> files_;
   std::shared_ptr<FileFormat> format_;
+
+  FileSystemDiscoveryOptions options_;
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -103,11 +103,12 @@ struct FileSystemDiscoveryOptions {
   // is important, e.g. SchemaPartitionScheme.
   std::string partition_base_dir;
 
-  // Files given (via selector or explicitly) will be filtered via the
-  // FileFormat::IsSupported method.  This will incur IO for each files in a
-  // serial and single threaded fashion. Disabling this feature will skip the
-  // IO, but bubble failure later down the chain.
-  bool filter_supported_files = true;
+  // Invalid files (via selector or explicitly) will be excluded by checking
+  // with the FileFormat::IsSupported method.  This will incur IO for each files
+  // in a serial and single threaded fashion. Disabling this feature will skip the
+  // IO, but unsupported files may will be present in the DataSource
+  // (resulting in an error at scan time).
+  bool exclude_invalid_files = true;
 
   // Files matching one of the following prefix will be ignored by the
   // discovery process. This is matched to the basename of a path.

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -134,7 +134,7 @@ class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery
   /// \param[in] filesystem passed to FileSystemDataSource
   /// \param[in] stats passed to FileSystemDataSource
   /// \param[in] format passed to FileSystemDataSource
-  /// \param[in] options see @FileSystemDiscoveryOptions for more information.
+  /// \param[in] options see FileSystemDiscoveryOptions for more information.
   /// \param[out] discovery output pointer
   static Status Make(fs::FileSystem* filesystem, std::vector<fs::FileStats> stats,
                      std::shared_ptr<FileFormat> format,

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -55,10 +55,17 @@ TEST_F(FileSystemDataSourceDiscoveryTest, Basic) {
 
 TEST_F(FileSystemDataSourceDiscoveryTest, Selector) {
   selector_.base_dir = "A";
-  MakeDiscovery({fs::File("0"), fs::File("A/a")});
+  selector_.recursive = true;
 
+  MakeDiscovery({fs::File("0"), fs::File("A/a"), fs::File("A/A/a")});
   // "0" doesn't match selector, so it has been dropped:
-  AssertFinishWithPaths({"A/a"});
+  AssertFinishWithPaths({"A/a", "A/A/a"});
+
+  discovery_options_.partition_base_dir = "A/A";
+  MakeDiscovery({fs::File("0"), fs::File("A/a"), fs::File("A/A/a")});
+  // partition_base_dir should not affect filtered files, ony the applied
+  // partition scheme.
+  AssertFinishWithPaths({"A/a", "A/A/a"});
 }
 
 TEST_F(FileSystemDataSourceDiscoveryTest, Partition) {

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -31,12 +31,18 @@ class FileSystemDataSourceDiscoveryTest : public TestFileSystemBasedDataSource {
  public:
   void MakeDiscovery(const std::vector<fs::FileStats>& files) {
     MakeFileSystem(files);
-    ASSERT_OK(
-        FileSystemDataSourceDiscovery::Make(fs_.get(), selector_, format_, &discovery_));
+    ASSERT_OK(FileSystemDataSourceDiscovery::Make(fs_.get(), selector_, format_,
+                                                  fs_options_, &discovery_));
+  }
+
+  void AssertFinishWithPaths(std::vector<std::string> paths) {
+    ASSERT_OK(discovery_->Finish(&source_));
+    AssertFragmentsAreFromPath(source_->GetFragments(options_), paths);
   }
 
  protected:
   fs::Selector selector_;
+  FileSystemDiscoveryOptions fs_options_;
   std::shared_ptr<DataSourceDiscovery> discovery_;
   std::shared_ptr<FileFormat> format_ = std::make_shared<DummyFileFormat>();
 };
@@ -44,17 +50,15 @@ class FileSystemDataSourceDiscoveryTest : public TestFileSystemBasedDataSource {
 TEST_F(FileSystemDataSourceDiscoveryTest, Basic) {
   MakeDiscovery({fs::File("a"), fs::File("b")});
 
-  ASSERT_OK(discovery_->Finish(&source_));
-  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"a", "b"});
+  AssertFinishWithPaths({"a", "b"});
 }
 
 TEST_F(FileSystemDataSourceDiscoveryTest, Selector) {
   selector_.base_dir = "A";
   MakeDiscovery({fs::File("0"), fs::File("A/a")});
 
-  ASSERT_OK(discovery_->Finish(&source_));
   // "0" doesn't match selector, so it has been dropped:
-  AssertFragmentsAreFromPath(source_->GetFragments(options_), {"A/a"});
+  AssertFinishWithPaths({"A/a"});
 }
 
 TEST_F(FileSystemDataSourceDiscoveryTest, Partition) {
@@ -64,12 +68,34 @@ TEST_F(FileSystemDataSourceDiscoveryTest, Partition) {
 
   auto partition_scheme =
       std::make_shared<HivePartitionScheme>(schema({field("a", int32())}));
-
   ASSERT_OK(discovery_->SetPartitionScheme(partition_scheme));
-  ASSERT_OK(discovery_->Finish(&source_));
 
-  AssertFragmentsAreFromPath(source_->GetFragments(options_),
-                             {selector_.base_dir + "/a=1", selector_.base_dir + "/a=2"});
+  AssertFinishWithPaths({selector_.base_dir + "/a=1", selector_.base_dir + "/a=2"});
+}
+
+TEST_F(FileSystemDataSourceDiscoveryTest, OptionsIgnoredDefaultPrefixes) {
+  MakeDiscovery({
+      fs::File("."),
+      fs::File("_"),
+      fs::File("_$folder$"),
+      fs::File("_SUCCESS"),
+      fs::File("not_ignored_by_default"),
+  });
+
+  AssertFinishWithPaths({"not_ignored_by_default"});
+}
+
+TEST_F(FileSystemDataSourceDiscoveryTest, OptionsIgnoredCustomPrefixes) {
+  fs_options_.ignore_prefixes = {"not_ignored"};
+  MakeDiscovery({
+      fs::File("."),
+      fs::File("_"),
+      fs::File("_$folder$"),
+      fs::File("_SUCCESS"),
+      fs::File("not_ignored_by_default"),
+  });
+
+  AssertFinishWithPaths({".", "_", "_$folder$", "_SUCCESS"});
 }
 
 TEST_F(FileSystemDataSourceDiscoveryTest, Inspect) {

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -32,7 +32,7 @@ class FileSystemDataSourceDiscoveryTest : public TestFileSystemBasedDataSource {
   void MakeDiscovery(const std::vector<fs::FileStats>& files) {
     MakeFileSystem(files);
     ASSERT_OK(FileSystemDataSourceDiscovery::Make(fs_.get(), selector_, format_,
-                                                  fs_options_, &discovery_));
+                                                  discovery_options_, &discovery_));
   }
 
   void AssertFinishWithPaths(std::vector<std::string> paths) {
@@ -42,7 +42,7 @@ class FileSystemDataSourceDiscoveryTest : public TestFileSystemBasedDataSource {
 
  protected:
   fs::Selector selector_;
-  FileSystemDiscoveryOptions fs_options_;
+  FileSystemDiscoveryOptions discovery_options_;
   std::shared_ptr<DataSourceDiscovery> discovery_;
   std::shared_ptr<FileFormat> format_ = std::make_shared<DummyFileFormat>();
 };
@@ -86,7 +86,7 @@ TEST_F(FileSystemDataSourceDiscoveryTest, OptionsIgnoredDefaultPrefixes) {
 }
 
 TEST_F(FileSystemDataSourceDiscoveryTest, OptionsIgnoredCustomPrefixes) {
-  fs_options_.ignore_prefixes = {"not_ignored"};
+  discovery_options_.ignore_prefixes = {"not_ignored"};
   MakeDiscovery({
       fs::File("."),
       fs::File("_"),

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -133,8 +133,8 @@ class ARROW_DS_EXPORT FileFormat {
 
   virtual std::string name() const = 0;
 
-  /// \brief Return true if the given file extension
-  virtual bool IsKnownExtension(const std::string& ext) const = 0;
+  /// \brief Indicate if the FileSource is supported/readable by this format.
+  virtual Status IsSupported(const FileSource& source, bool* supported) const = 0;
 
   /// \brief Return the schema of the file if possible.
   virtual Status Inspect(const FileSource& source,

--- a/cpp/src/arrow/dataset/file_csv.h
+++ b/cpp/src/arrow/dataset/file_csv.h
@@ -56,8 +56,8 @@ class ARROW_DS_EXPORT CsvFileFormat : public FileFormat {
  public:
   std::string name() const override;
 
-  /// \brief Return true if the given file extension
-  bool IsKnownExtension(const std::string& ext) const override;
+  /// \brief Indicate if the FileSource is supported/readable by this format.
+  Status IsSupported(const FileSource& source, bool* supported) const override;
 
   /// \brief Open a file for scanning
   Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,

--- a/cpp/src/arrow/dataset/file_feather.h
+++ b/cpp/src/arrow/dataset/file_feather.h
@@ -43,8 +43,8 @@ class ARROW_DS_EXPORT FeatherFileFormat : public FileFormat {
  public:
   std::string name() const override;
 
-  /// \brief Return true if the given file extension
-  bool IsKnownExtension(const std::string& ext) const override;
+  /// \brief Indicate if the FileSource is supported/readable by this format.
+  Status IsSupported(const FileSource& source, bool* supported) const override;
 
   /// \brief Open a file for scanning
   Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,

--- a/cpp/src/arrow/dataset/file_json.h
+++ b/cpp/src/arrow/dataset/file_json.h
@@ -48,8 +48,8 @@ class ARROW_DS_EXPORT JsonFileFormat : public FileFormat {
  public:
   std::string name() const override;
 
-  /// \brief Return true if the given file extension
-  bool IsKnownExtension(const std::string& ext) const override;
+  /// \brief Indicate if the FileSource is supported/readable by this format.
+  Status IsSupported(const FileSource& source, bool* supported) const override;
 
   /// \brief Open a file for scanning
   Status ScanFile(const FileSource& source, std::shared_ptr<ScanOptions> scan_options,

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -243,6 +243,7 @@ Status ParquetFileFormat::IsSupported(const FileSource& source, bool* supported)
     RETURN_NOT_OK(source.Open(&input));
     auto reader = parquet::ParquetFileReader::Open(input);
   } catch (const ::parquet::ParquetInvalidOrCorruptedFileException& e) {
+    ARROW_UNUSED(e);
     *supported = false;
     return Status::OK();
   } catch (const ::parquet::ParquetException& e) {

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -47,10 +47,7 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
  public:
   std::string name() const override { return "parquet"; }
 
-  /// \brief Return true if the given file extension
-  bool IsKnownExtension(const std::string& ext) const override {
-    return ext == "par" || ext == "parq" || ext == name();
-  }
+  Status IsSupported(const FileSource& source, bool* supported) const override;
 
   /// \brief Return the schema of the file if possible.
   Status Inspect(const FileSource& source, std::shared_ptr<Schema>* out) const override;

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -188,13 +188,13 @@ TEST_F(TestParquetFileFormat, OpenFailureWithRelevantError) {
   std::shared_ptr<Schema> dont_care;
 
   std::shared_ptr<Buffer> buf = std::make_shared<Buffer>(util::string_view(""));
-  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("<Buffer>"),
+  EXPECT_RAISES_WITH_MESSAGE_THAT(IOError, testing::HasSubstr("<Buffer>"),
                                   format.Inspect({buf}, &dont_care));
 
   constexpr auto file_name = "herp/derp";
   ASSERT_OK_AND_ASSIGN(
       auto fs, fs::internal::MockFileSystem::Make(fs::kNoTime, {fs::File(file_name)}));
-  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr(file_name),
+  EXPECT_RAISES_WITH_MESSAGE_THAT(IOError, testing::HasSubstr(file_name),
                                   format.Inspect({file_name, fs.get()}, &dont_care));
 }
 

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -194,8 +194,10 @@ class DummyFileFormat : public FileFormat {
 
   std::string name() const override { return "dummy"; }
 
-  /// \brief Return true if the given file extension
-  bool IsKnownExtension(const std::string& ext) const override { return ext == name(); }
+  Status IsSupported(const FileSource& source, bool* supported) const override {
+    *supported = true;
+    return Status::OK();
+  }
 
   Status Inspect(const FileSource& source, std::shared_ptr<Schema>* out) const override {
     *out = schema_;
@@ -241,7 +243,10 @@ class JSONRecordBatchFileFormat : public FileFormat {
   std::string name() const override { return "json_record_batch"; }
 
   /// \brief Return true if the given file extension
-  bool IsKnownExtension(const std::string& ext) const override { return ext == name(); }
+  Status IsSupported(const FileSource& source, bool* supported) const override {
+    *supported = true;
+    return Status::OK();
+  }
 
   Status Inspect(const FileSource& source, std::shared_ptr<Schema>* out) const override {
     *out = schema_;

--- a/cpp/src/parquet/exception.h
+++ b/cpp/src/parquet/exception.h
@@ -44,14 +44,12 @@
     ARROW_UNUSED(_s);            \
   } while (0)
 
-#define PARQUET_THROW_NOT_OK(s)                    \
-  do {                                             \
-    ::arrow::Status _s = (s);                      \
-    if (!_s.ok()) {                                \
-      std::stringstream ss;                        \
-      ss << "Arrow error: " << _s.ToString();      \
-      throw ::parquet::ParquetException(ss.str()); \
-    }                                              \
+#define PARQUET_THROW_NOT_OK(s)                               \
+  do {                                                        \
+    ::arrow::Status _s = (s);                                 \
+    if (!_s.ok()) {                                           \
+      throw ::parquet::ParquetStatusException(std::move(_s)); \
+    }                                                         \
   } while (0)
 
 namespace parquet {
@@ -92,106 +90,18 @@ class ParquetStatusException : public ParquetException {
   explicit ParquetStatusException(::arrow::Status status)
       : ParquetException(status.ToString()), status_(std::move(status)) {}
 
-  /// Return an error status for out-of-memory conditions
-  template <typename... Args>
-  PARQUET_NORETURN static void OutOfMemory(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::OutOfMemory(std::forward<Args>(args)...));
-  }
-
-  /// Return an error status for failed key lookups (e.g. column name in a table)
-  template <typename... Args>
-  PARQUET_NORETURN static void KeyError(Args&&... args) {
-    throw ParquetStatusException(::arrow::Status::KeyError(std::forward<Args>(args)...));
-  }
-
-  /// Return an error status for type errors (such as mismatching data types)
-  template <typename... Args>
-  PARQUET_NORETURN static void TypeError(Args&&... args) {
-    throw ParquetStatusException(::arrow::Status::TypeError(std::forward<Args>(args)...));
-  }
-
-  /// Return an error status for unknown errors
-  template <typename... Args>
-  PARQUET_NORETURN static void UnknownError(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::UnknownError(std::forward<Args>(args)...));
-  }
-
-  /// Return an error status when an operation or a combination of operation and
-  /// data types is unimplemented
-  template <typename... Args>
-  PARQUET_NORETURN static void NotImplemented(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::NotImplemented(std::forward<Args>(args)...));
-  }
-
-  /// Return an error status for invalid data (for example a string that fails parsing)
-  template <typename... Args>
-  PARQUET_NORETURN static void Invalid(Args&&... args) {
-    throw ParquetStatusException(::arrow::Status::Invalid(std::forward<Args>(args)...));
-  }
-
-  /// Return an error status when an index is out of bounds
-  template <typename... Args>
-  PARQUET_NORETURN static void IndexError(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::IndexError(std::forward<Args>(args)...));
-  }
-
-  /// Return an error status when a container's capacity would exceed its limits
-  template <typename... Args>
-  PARQUET_NORETURN static void CapacityError(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::CapacityError(std::forward<Args>(args)...));
-  }
-
-  /// Return an error status when some IO-related operation failed
-  template <typename... Args>
-  PARQUET_NORETURN static void IOError(Args&&... args) {
-    throw ParquetStatusException(::arrow::Status::IOError(std::forward<Args>(args)...));
-  }
-
-  /// Return an error status when some (de)serialization operation failed
-  template <typename... Args>
-  PARQUET_NORETURN static void SerializationError(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::SerializationError(std::forward<Args>(args)...));
-  }
-
-  template <typename... Args>
-  PARQUET_NORETURN static void RError(Args&&... args) {
-    throw ParquetStatusException(::arrow::Status::RError(std::forward<Args>(args)...));
-  }
-
-  template <typename... Args>
-  PARQUET_NORETURN static void CodeGenError(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::CodeGenError(std::forward<Args>(args)...));
-  }
-
-  template <typename... Args>
-  PARQUET_NORETURN static void ExpressionValidationError(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::ExpressionValidationError(std::forward<Args>(args)...));
-  }
-
-  template <typename... Args>
-  PARQUET_NORETURN static void ExecutionError(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::ExecutionError(std::forward<Args>(args)...));
-  }
-
-  template <typename... Args>
-  PARQUET_NORETURN static void AlreadyExists(Args&&... args) {
-    throw ParquetStatusException(
-        ::arrow::Status::AlreadyExists(std::forward<Args>(args)...));
-  }
-
   const ::arrow::Status& status() const { return status_; }
 
  private:
   ::arrow::Status status_;
+};
+
+// This class exists for the purpose of detecting an invalid or corrupted file.
+class ParquetInvalidOrCorruptedFileException : public ParquetStatusException {
+ public:
+  template <typename... Args>
+  explicit ParquetInvalidOrCorruptedFileException(Args&&... args)
+      : ParquetStatusException(::arrow::Status::Invalid(std::forward<Args>(args)...)) {}
 };
 
 template <typename StatusReturnBlock>

--- a/cpp/src/parquet/exception.h
+++ b/cpp/src/parquet/exception.h
@@ -21,6 +21,7 @@
 #include <exception>
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include "arrow/status.h"
 #include "parquet/platform.h"
@@ -84,6 +85,113 @@ class ParquetException : public std::exception {
 
  private:
   std::string msg_;
+};
+
+class ParquetStatusException : public ParquetException {
+ public:
+  explicit ParquetStatusException(::arrow::Status status)
+      : ParquetException(status.ToString()), status_(std::move(status)) {}
+
+  /// Return an error status for out-of-memory conditions
+  template <typename... Args>
+  PARQUET_NORETURN static void OutOfMemory(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::OutOfMemory(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status for failed key lookups (e.g. column name in a table)
+  template <typename... Args>
+  PARQUET_NORETURN static void KeyError(Args&&... args) {
+    throw ParquetStatusException(::arrow::Status::KeyError(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status for type errors (such as mismatching data types)
+  template <typename... Args>
+  PARQUET_NORETURN static void TypeError(Args&&... args) {
+    throw ParquetStatusException(::arrow::Status::TypeError(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status for unknown errors
+  template <typename... Args>
+  PARQUET_NORETURN static void UnknownError(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::UnknownError(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status when an operation or a combination of operation and
+  /// data types is unimplemented
+  template <typename... Args>
+  PARQUET_NORETURN static void NotImplemented(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::NotImplemented(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status for invalid data (for example a string that fails parsing)
+  template <typename... Args>
+  PARQUET_NORETURN static void Invalid(Args&&... args) {
+    throw ParquetStatusException(::arrow::Status::Invalid(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status when an index is out of bounds
+  template <typename... Args>
+  PARQUET_NORETURN static void IndexError(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::IndexError(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status when a container's capacity would exceed its limits
+  template <typename... Args>
+  PARQUET_NORETURN static void CapacityError(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::CapacityError(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status when some IO-related operation failed
+  template <typename... Args>
+  PARQUET_NORETURN static void IOError(Args&&... args) {
+    throw ParquetStatusException(::arrow::Status::IOError(std::forward<Args>(args)...));
+  }
+
+  /// Return an error status when some (de)serialization operation failed
+  template <typename... Args>
+  PARQUET_NORETURN static void SerializationError(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::SerializationError(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  PARQUET_NORETURN static void RError(Args&&... args) {
+    throw ParquetStatusException(::arrow::Status::RError(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  PARQUET_NORETURN static void CodeGenError(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::CodeGenError(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  PARQUET_NORETURN static void ExpressionValidationError(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::ExpressionValidationError(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  PARQUET_NORETURN static void ExecutionError(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::ExecutionError(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  PARQUET_NORETURN static void AlreadyExists(Args&&... args) {
+    throw ParquetStatusException(
+        ::arrow::Status::AlreadyExists(std::forward<Args>(args)...));
+  }
+
+  const ::arrow::Status& status() const { return status_; }
+
+ private:
+  ::arrow::Status status_;
 };
 
 template <typename StatusReturnBlock>

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -212,12 +212,11 @@ class SerializedFile : public ParquetFileReader::Contents {
     PARQUET_THROW_NOT_OK(source_->GetSize(&file_size));
 
     if (file_size == 0) {
-      throw ParquetException("Invalid Parquet file size is 0 bytes");
+      ParquetStatusException::Invalid("Parquet file size is 0 bytes");
     } else if (file_size < kFooterSize) {
-      std::stringstream ss;
-      ss << "Invalid Parquet file size is " << file_size
-         << " bytes, smaller than standard file footer (" << kFooterSize << " bytes)";
-      throw ParquetException(ss.str());
+      ParquetStatusException::Invalid("Parquet file size is ", file_size,
+                                      " bytes, smaller than the minimum file footer (",
+                                      kFooterSize, " bytes)");
     }
 
     std::shared_ptr<Buffer> footer_buffer;
@@ -229,7 +228,9 @@ class SerializedFile : public ParquetFileReader::Contents {
     if (footer_buffer->size() != footer_read_size ||
         (memcmp(footer_buffer->data() + footer_read_size - 4, kParquetMagic, 4) != 0 &&
          memcmp(footer_buffer->data() + footer_read_size - 4, kParquetEMagic, 4) != 0)) {
-      throw ParquetException("Invalid parquet file. Corrupt footer.");
+      ParquetStatusException::Invalid(
+          "Parquet magic bytes not found in footer. Either the file is corrupted or this "
+          "is not a parquet file.");
     }
 
     if (memcmp(footer_buffer->data() + footer_read_size - 4, kParquetEMagic, 4) == 0) {
@@ -293,9 +294,9 @@ void SerializedFile::ParseUnencryptedFileMetadata(
       kFooterSize);
   int64_t metadata_start = file_size - kFooterSize - *metadata_len;
   if (kFooterSize + *metadata_len > file_size) {
-    throw ParquetException(
-        "Invalid parquet file. File is less than "
-        "file metadata size.");
+    ParquetStatusException::Invalid(
+        "Parquet file size is ", file_size,
+        " bytes, smaller than the size reported by metadata (", metadata_len, "bytes)");
   }
 
   // Check if the footer_buffer contains the entire metadata
@@ -305,7 +306,9 @@ void SerializedFile::ParseUnencryptedFileMetadata(
   } else {
     PARQUET_THROW_NOT_OK(source_->ReadAt(metadata_start, *metadata_len, metadata_buffer));
     if ((*metadata_buffer)->size() != *metadata_len) {
-      throw ParquetException("Invalid parquet file. Could not read metadata bytes.");
+      ParquetStatusException::IOError("Failed reading metadata buffer (requested ",
+                                      *metadata_len, " bytes but got ",
+                                      (*metadata_buffer)->size(), " bytes)");
     }
   }
 
@@ -323,9 +326,9 @@ void SerializedFile::ParseMetaDataOfEncryptedFileWithEncryptedFooter(
       kFooterSize);
   int64_t crypto_metadata_start = file_size - kFooterSize - footer_len;
   if (kFooterSize + footer_len > file_size) {
-    throw ParquetException(
-        "Invalid parquet file. File is less than "
-        "file metadata size.");
+    ParquetStatusException::Invalid(
+        "Parquet file size is ", file_size,
+        " bytes, smaller than the size reported by footer's (", footer_len, "bytes)");
   }
   std::shared_ptr<Buffer> crypto_metadata_buffer;
   // Check if the footer_buffer contains the entire metadata
@@ -336,14 +339,15 @@ void SerializedFile::ParseMetaDataOfEncryptedFileWithEncryptedFooter(
     PARQUET_THROW_NOT_OK(
         source_->ReadAt(crypto_metadata_start, footer_len, &crypto_metadata_buffer));
     if (crypto_metadata_buffer->size() != footer_len) {
-      throw ParquetException("Invalid parquet file. Could not read metadata bytes.");
+      ParquetStatusException::IOError(
+          "Failed reading encrypted metadata buffer (requested ", footer_len,
+          " bytes but got ", crypto_metadata_buffer->size(), " bytes)");
     }
   }
   auto file_decryption_properties = properties_.file_decryption_properties();
   if (file_decryption_properties == nullptr) {
-    throw ParquetException(
-        "No decryption properties are provided. Could not read "
-        "encrypted footer metadata");
+    ParquetStatusException::ExecutionError(
+        "Could not read encrypted metadata, no decryption found in reader's properties");
   }
   uint32_t crypto_metadata_len = footer_len;
   std::shared_ptr<FileCryptoMetaData> file_crypto_metadata =
@@ -359,9 +363,9 @@ void SerializedFile::ParseMetaDataOfEncryptedFileWithEncryptedFooter(
   std::shared_ptr<Buffer> metadata_buffer;
   PARQUET_THROW_NOT_OK(source_->ReadAt(metadata_offset, metadata_len, &metadata_buffer));
   if (metadata_buffer->size() != metadata_len) {
-    throw ParquetException(
-        "Invalid encrypted parquet file. "
-        "Could not read footer metadata bytes.");
+    ParquetStatusException::IOError("Failed reading metadata buffer (requested ",
+                                    metadata_len, " bytes but got ",
+                                    metadata_buffer->size(), " bytes)");
   }
 
   auto footer_decryptor = file_decryptor_->GetFooterDecryptor();
@@ -386,15 +390,15 @@ void SerializedFile::ParseMetaDataOfEncryptedFileWithPlaintextFooter(
     if (file_decryption_properties->check_plaintext_footer_integrity()) {
       if (metadata_len - read_metadata_len !=
           (parquet::encryption::kGcmTagLength + parquet::encryption::kNonceLength)) {
-        throw ParquetException(
-            "Invalid parquet file. Cannot verify plaintext mode footer.");
+        ParquetStatusException::Invalid(
+            "Failed reading metadata for encryption signature (requested ",
+            parquet::encryption::kGcmTagLength + parquet::encryption::kNonceLength,
+            " bytes but have ", metadata_len - read_metadata_len, " bytes)");
       }
 
       if (!file_metadata_->VerifySignature(file_decryptor_.get(),
                                            metadata_buffer->data() + read_metadata_len)) {
-        throw ParquetException(
-            "Invalid parquet file. Could not verify plaintext "
-            "footer metadata");
+        ParquetStatusException::Invalid("Parquet crypto signature verification failed");
       }
     }
   }

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -26,9 +26,11 @@ std::shared_ptr<arrow::dataset::DataSourceDiscovery> dataset___FSDSDiscovery__Ma
   std::shared_ptr<arrow::dataset::DataSourceDiscovery> discovery;
   // TODO(npr): add format as an argument, don't hard-code Parquet
   auto format = std::make_shared<arrow::dataset::ParquetFileFormat>();
+  // TODO(fsaintjacques): Make options configurable
+  auto options = arrow::dataset::FileSystemDiscoveryOptions{};
 
-  STOP_IF_NOT_OK(arrow::dataset::FileSystemDataSourceDiscovery::Make(fs.get(), *selector,
-                                                                     format, &discovery));
+  STOP_IF_NOT_OK(arrow::dataset::FileSystemDataSourceDiscovery::Make(
+      fs.get(), *selector, format, std::move(options), &discovery));
   return discovery;
 }
 


### PR DESCRIPTION
The FileSystemDataSource implementation requires that only files supported by it's FileFormat are given. The following patch provides a way to filter files in the FileSystemDataSourceDiscovery by two options:

- A list of ignore prefixes, configurable via `FileSystemDiscoveryOptions.ignore_prefixes`
- The automatic filtering of files not recognized by the fomat, configurable via `FileSystemDiscoveryOptions.filter_supported_files`

By default all files prefixed by `.` (hidden files on Posix systems) and `_` (metadata files in HDFS/S3) will be ignored and the discovery process will ignore files not supported by the format.