### PR TITLE
ARROW-7047: [C++] Insert implicit casts in ScannerBuilder::Finish

### DIFF
--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -402,7 +402,7 @@ TEST_F(TestEndToEnd, EndToEndSingleSource) {
   //
   // Note that `sales` is double, so `100` below will be implicitly cast from integer.
   auto filter = ("year"_ == 2019 && "sales"_ > 100);
-  ASSERT_OK(scanner_builder->Filter(filter));
+  ASSERT_OK(scanner_builder->Filter(filter, /* implicit_casts = */ true));
 
   std::unique_ptr<Scanner> scanner;
   ASSERT_OK(scanner_builder->Finish(&scanner));

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -244,31 +244,31 @@ class TestEndToEnd : public TestDataset {
         field("region", utf8(), nullable),
         field("model", utf8(), nullable),
         field("year", int32(), nullable),
-        field("sales", int32(), nullable),
+        field("sales", float64(), nullable),
     });
 
     using PathAndContent = std::vector<std::pair<std::string, std::string>>;
     auto files = PathAndContent{
-        {"/dataset/2018/01/US.json", R"([
-        {"country": "US", "region": "NY", "year": 2018, "model": "3", "sales": 742},
-        {"country": "US", "region": "NY", "year": 2018, "model": "S", "sales": 304},
-        {"country": "US", "region": "NY", "year": 2018, "model": "X", "sales": 136},
-        {"country": "US", "region": "NY", "year": 2018, "model": "Y", "sales": 27}
+        {"/2018/01/US.json", R"([
+        {"country": "US", "region": "NY", "year": 2018, "model": "3", "sales": 742.0},
+        {"country": "US", "region": "NY", "year": 2018, "model": "S", "sales": 304.125},
+        {"country": "US", "region": "NY", "year": 2018, "model": "X", "sales": 136.25},
+        {"country": "US", "region": "NY", "year": 2018, "model": "Y", "sales": 27.5}
       ])"},
         {"/dataset/2018/01/CA.json", R"([
         {"country": "US", "region": "CA", "year": 2018, "model": "3", "sales": 512},
         {"country": "US", "region": "CA", "year": 2018, "model": "S", "sales": 978},
-        {"country": "US", "region": "CA", "year": 2018, "model": "X", "sales": 1},
+        {"country": "US", "region": "CA", "year": 2018, "model": "X", "sales": 1.0},
         {"country": "US", "region": "CA", "year": 2018, "model": "Y", "sales": 69}
       ])"},
         {"/dataset/2019/01/US.json", R"([
-        {"country": "CA", "region": "QC", "year": 2019, "model": "3", "sales": 273},
+        {"country": "CA", "region": "QC", "year": 2019, "model": "3", "sales": 273.5},
         {"country": "CA", "region": "QC", "year": 2019, "model": "S", "sales": 13},
         {"country": "CA", "region": "QC", "year": 2019, "model": "X", "sales": 54},
         {"country": "CA", "region": "QC", "year": 2019, "model": "Y", "sales": 21}
       ])"},
         {"/dataset/2019/01/CA.json", R"([
-        {"country": "CA", "region": "QC", "year": 2019, "model": "3", "sales": 152},
+        {"country": "CA", "region": "QC", "year": 2019, "model": "3", "sales": 152.25},
         {"country": "CA", "region": "QC", "year": 2019, "model": "S", "sales": 10},
         {"country": "CA", "region": "QC", "year": 2019, "model": "X", "sales": 42},
         {"country": "CA", "region": "QC", "year": 2019, "model": "Y", "sales": 37}
@@ -399,6 +399,8 @@ TEST_F(TestEndToEnd, EndToEndSingleSource) {
   // The following filter tests both predicate pushdown and post filtering
   // without partition information because `year` is a partition and `sales` is
   // not.
+  //
+  // Note that `sales` is double, so `100` below will be implicitly cast from integer.
   auto filter = ("year"_ == 2019 && "sales"_ > 100);
   ASSERT_OK(scanner_builder->Filter(filter));
 
@@ -409,10 +411,10 @@ TEST_F(TestEndToEnd, EndToEndSingleSource) {
   std::shared_ptr<Table> table;
   ASSERT_OK(scanner->ToTable(&table));
 
-  using row_type = std::tuple<int32_t, std::string>;
+  using row_type = std::tuple<double, std::string>;
   std::vector<row_type> rows{
-      row_type{152, "3"},
-      row_type{273, "3"},
+      row_type{152.25, "3"},
+      row_type{273.5, "3"},
   };
   std::shared_ptr<Table> expected;
   ASSERT_OK(stl::TableFromTupleRange(default_memory_pool(), rows, columns, &expected));

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -566,7 +566,12 @@ std::shared_ptr<Expression> IsValidExpression::Assume(const Expression& given) c
 }
 
 std::shared_ptr<Expression> CastExpression::Assume(const Expression& given) const {
-  return std::make_shared<CastExpression>(operand_->Assume(given), to_, options_);
+  auto operand = operand_->Assume(given);
+  if (to_ != nullptr) {
+    return std::make_shared<CastExpression>(std::move(operand), to_, options_);
+  }
+  auto like = like_->Assume(given);
+  return std::make_shared<CastExpression>(std::move(operand), std::move(like), options_);
 }
 
 std::string FieldExpression::ToString() const {

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -1126,8 +1126,7 @@ Result<Datum> TreeEvaluator::Evaluate(const CastExpression& expr,
 
   ARROW_ASSIGN_OR_RAISE(auto to_cast, Evaluate(*expr.operand(), batch));
   if (to_cast.is_scalar()) {
-    // FIXME(bkietz) implement this in Scalar::As
-    return NullDatum();
+    return to_cast.scalar()->CastTo(to_type);
   }
 
   DCHECK(to_cast.is_array());

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -870,81 +870,81 @@ Result<std::shared_ptr<DataType>> FieldExpression::Validate(const Schema& schema
   return null();
 }
 
-Result<std::shared_ptr<Expression>> InsertImplicitCasts(const Expression& expr,
-                                                        const Schema& schema) {
-  struct {
-    struct Validated {
-      std::shared_ptr<Expression> expr;
-      std::shared_ptr<DataType> type;
-    };
+struct InsertImplicitCastsImpl {
+  struct Validated {
+    std::shared_ptr<Expression> expr;
+    std::shared_ptr<DataType> type;
+  };
 
-    Result<Validated> Validate(const Expression& expr) {
-      Validated out;
-      ARROW_ASSIGN_OR_RAISE(out.expr, InsertImplicitCasts(expr, schema_));
-      ARROW_ASSIGN_OR_RAISE(out.type, out.expr->Validate(schema_));
-      return std::move(out);
+  Result<Validated> Validate(const Expression& expr) {
+    Validated out;
+    ARROW_ASSIGN_OR_RAISE(out.expr, InsertImplicitCasts(expr, schema_));
+    ARROW_ASSIGN_OR_RAISE(out.type, out.expr->Validate(schema_));
+    return std::move(out);
+  }
+
+  Result<std::shared_ptr<Expression>> operator()(const NotExpression& expr) {
+    ARROW_ASSIGN_OR_RAISE(auto op, Validate(*expr.operand()));
+
+    if (op.type->id() != Type::BOOL) {
+      op.expr = op.expr->CastTo(boolean()).Copy();
     }
+    return not_(std::move(op.expr));
+  }
 
-    Result<std::shared_ptr<Expression>> operator()(const NotExpression& expr) {
-      ARROW_ASSIGN_OR_RAISE(auto op, Validate(*expr.operand()));
+  Result<std::shared_ptr<Expression>> operator()(const AndExpression& expr) {
+    ARROW_ASSIGN_OR_RAISE(auto lhs, Validate(*expr.left_operand()));
+    ARROW_ASSIGN_OR_RAISE(auto rhs, Validate(*expr.right_operand()));
 
-      if (op.type->id() != Type::BOOL) {
-        op.expr = op.expr->CastTo(boolean()).Copy();
-      }
-      return not_(std::move(op.expr));
+    if (lhs.type->id() != Type::BOOL) {
+      lhs.expr = lhs.expr->CastTo(boolean()).Copy();
     }
-
-    Result<std::shared_ptr<Expression>> operator()(const AndExpression& expr) {
-      ARROW_ASSIGN_OR_RAISE(auto lhs, Validate(*expr.left_operand()));
-      ARROW_ASSIGN_OR_RAISE(auto rhs, Validate(*expr.right_operand()));
-
-      if (lhs.type->id() != Type::BOOL) {
-        lhs.expr = lhs.expr->CastTo(boolean()).Copy();
-      }
-      if (rhs.type->id() != Type::BOOL) {
-        rhs.expr = rhs.expr->CastTo(boolean()).Copy();
-      }
-      return and_(std::move(lhs.expr), std::move(rhs.expr));
+    if (rhs.type->id() != Type::BOOL) {
+      rhs.expr = rhs.expr->CastTo(boolean()).Copy();
     }
+    return and_(std::move(lhs.expr), std::move(rhs.expr));
+  }
 
-    Result<std::shared_ptr<Expression>> operator()(const OrExpression& expr) {
-      ARROW_ASSIGN_OR_RAISE(auto lhs, Validate(*expr.left_operand()));
-      ARROW_ASSIGN_OR_RAISE(auto rhs, Validate(*expr.right_operand()));
+  Result<std::shared_ptr<Expression>> operator()(const OrExpression& expr) {
+    ARROW_ASSIGN_OR_RAISE(auto lhs, Validate(*expr.left_operand()));
+    ARROW_ASSIGN_OR_RAISE(auto rhs, Validate(*expr.right_operand()));
 
-      if (lhs.type->id() != Type::BOOL) {
-        lhs.expr = lhs.expr->CastTo(boolean()).Copy();
-      }
-      if (rhs.type->id() != Type::BOOL) {
-        rhs.expr = rhs.expr->CastTo(boolean()).Copy();
-      }
-      return or_(std::move(lhs.expr), std::move(rhs.expr));
+    if (lhs.type->id() != Type::BOOL) {
+      lhs.expr = lhs.expr->CastTo(boolean()).Copy();
     }
-
-    Result<std::shared_ptr<Expression>> operator()(const ComparisonExpression& expr) {
-      ARROW_ASSIGN_OR_RAISE(auto lhs, Validate(*expr.left_operand()));
-      ARROW_ASSIGN_OR_RAISE(auto rhs, Validate(*expr.right_operand()));
-
-      if (lhs.type->Equals(rhs.type)) {
-        return expr.Copy();
-      }
-
-      if (lhs.expr->type() == ExpressionType::SCALAR) {
-        lhs.expr = lhs.expr->CastTo(rhs.type).Copy();
-      } else {
-        rhs.expr = rhs.expr->CastTo(lhs.type).Copy();
-      }
-      return std::make_shared<ComparisonExpression>(expr.op(), std::move(lhs.expr),
-                                                    std::move(rhs.expr));
+    if (rhs.type->id() != Type::BOOL) {
+      rhs.expr = rhs.expr->CastTo(boolean()).Copy();
     }
+    return or_(std::move(lhs.expr), std::move(rhs.expr));
+  }
 
-    Result<std::shared_ptr<Expression>> operator()(const Expression& expr) const {
+  Result<std::shared_ptr<Expression>> operator()(const ComparisonExpression& expr) {
+    ARROW_ASSIGN_OR_RAISE(auto lhs, Validate(*expr.left_operand()));
+    ARROW_ASSIGN_OR_RAISE(auto rhs, Validate(*expr.right_operand()));
+
+    if (lhs.type->Equals(rhs.type)) {
       return expr.Copy();
     }
 
-    const Schema& schema_;
-  } visitor = {schema};
+    if (lhs.expr->type() == ExpressionType::SCALAR) {
+      lhs.expr = lhs.expr->CastTo(rhs.type).Copy();
+    } else {
+      rhs.expr = rhs.expr->CastTo(lhs.type).Copy();
+    }
+    return std::make_shared<ComparisonExpression>(expr.op(), std::move(lhs.expr),
+                                                  std::move(rhs.expr));
+  }
 
-  return VisitExpression(expr, visitor);
+  Result<std::shared_ptr<Expression>> operator()(const Expression& expr) const {
+    return expr.Copy();
+  }
+
+  const Schema& schema_;
+};
+
+Result<std::shared_ptr<Expression>> InsertImplicitCasts(const Expression& expr,
+                                                        const Schema& schema) {
+  return VisitExpression(expr, InsertImplicitCastsImpl{schema});
 }
 
 std::vector<std::string> FieldsInExpression(const Expression& expr) {

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -599,46 +599,12 @@ std::string OperatorName(compute::CompareOperator op) {
   return "";
 }
 
-// TODO(bkietz) extract this to Scalar::ToString()
-struct ScalarExpressionToString {
-  Status Visit(const BooleanType&) {
-    return Finish(CastValue<BooleanType>().value ? "true" : "false");
-  }
-
-  template <typename T>
-  enable_if_number<T, Status> Visit(const T&) {
-    return Finish(std::to_string(CastValue<T>().value));
-  }
-
-  Status Visit(const StringType&) {
-    return Finish(CastValue<StringType>().value->ToString());
-  }
-
-  Status Visit(const DataType&) { return Finish("TODO(bkietz)"); }
-
-  Status Finish(std::string repr) {
-    *repr_ = std::move(repr);
-    return Status::OK();
-  }
-
-  template <typename T>
-  const typename TypeTraits<T>::ScalarType& CastValue() {
-    return checked_cast<const typename TypeTraits<T>::ScalarType&>(value_);
-  }
-
-  const Scalar& value_;
-  std::string* repr_;
-};
-
 std::string ScalarExpression::ToString() const {
   if (!value_->is_valid) {
     return "scalar<" + value_->type->ToString() + ", null>()";
   }
 
-  std::string repr;
-  ScalarExpressionToString impl{*value_, &repr};
-  DCHECK_OK(VisitTypeInline(*value_->type, &impl));
-  return "scalar<" + value_->type->ToString() + ">(" + repr + ")";
+  return "scalar<" + value_->type->ToString() + ">(" + value_->ToString() + ")";
 }
 
 static std::string EulerNotation(std::string fn, const ExpressionVector& operands) {

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -363,6 +363,8 @@ class ARROW_DS_EXPORT CastExpression final
         to_(std::move(to)),
         options_(std::move(options)) {}
 
+  /// The operand will be cast to whatever type `like` would evaluate to, given the same
+  /// schema.
   CastExpression(std::shared_ptr<Expression> operand, std::shared_ptr<Expression> like,
                  compute::CastOptions options)
       : ExpressionImpl(std::move(operand)),

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -543,6 +543,10 @@ auto VisitExpression(const Expression& expr, Visitor&& visitor)
   return visitor(expr);
 }
 
+/// \brief Insert CastExpressions where necessary to make a valid expression.
+ARROW_DS_EXPORT Result<std::shared_ptr<Expression>> InsertImplicitCasts(
+    const Expression& expr, const Schema& schema);
+
 /// \brief Returns field names referenced in the expression.
 ARROW_DS_EXPORT std::vector<std::string> FieldsInExpression(const Expression& expr);
 

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -33,6 +33,7 @@
 #include "arrow/scalar.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/variant.h"
 
 namespace arrow {
 namespace dataset {
@@ -368,7 +369,7 @@ class ARROW_DS_EXPORT CastExpression final
   CastExpression(std::shared_ptr<Expression> operand, std::shared_ptr<Expression> like,
                  compute::CastOptions options)
       : ExpressionImpl(std::move(operand)),
-        like_(std::move(like)),
+        to_(std::move(like)),
         options_(std::move(options)) {}
 
   std::string ToString() const override;
@@ -380,8 +381,7 @@ class ARROW_DS_EXPORT CastExpression final
   const compute::CastOptions& options() const { return options_; }
 
  private:
-  std::shared_ptr<DataType> to_;
-  std::shared_ptr<Expression> like_;
+  util::variant<std::shared_ptr<DataType>, std::shared_ptr<Expression>> to_;
   compute::CastOptions options_;
 };
 

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -604,48 +604,11 @@ class ARROW_DS_EXPORT TreeEvaluator : public ExpressionEvaluator {
   Result<compute::Datum> Evaluate(const Expression& expr,
                                   const RecordBatch& batch) const override;
 
-  Result<compute::Datum> DoEvaluate(const ScalarExpression& expr,
-                                    const RecordBatch& batch) const;
-
-  Result<compute::Datum> DoEvaluate(const FieldExpression& expr,
-                                    const RecordBatch& batch) const;
-
-  Result<compute::Datum> DoEvaluate(const AndExpression& expr,
-                                    const RecordBatch& batch) const;
-
-  Result<compute::Datum> DoEvaluate(const OrExpression& expr,
-                                    const RecordBatch& batch) const;
-
-  Result<compute::Datum> Evaluate(const InExpression& expr,
-                                  const RecordBatch& batch) const;
-
-  Result<compute::Datum> Evaluate(const IsValidExpression& expr,
-                                  const RecordBatch& batch) const;
-
-  Result<compute::Datum> Evaluate(const NotExpression& expr,
-                                  const RecordBatch& batch) const;
-
-  Result<compute::Datum> DoEvaluate(const CastExpression& expr,
-                                    const RecordBatch& batch) const;
-
-  Result<compute::Datum> DoEvaluate(const ComparisonExpression& expr,
-                                    const RecordBatch& batch) const;
-
-  virtual Result<compute::Datum> DoEvaluate(const CustomExpression& expr,
-                                            const RecordBatch& batch) const {
-    return Status::NotImplemented("evaluation of ", expr.ToString());
-  }
-
   Result<std::shared_ptr<RecordBatch>> Filter(
       const compute::Datum& selection,
       const std::shared_ptr<RecordBatch>& batch) const override;
 
  protected:
-  Result<compute::Datum> DoEvaluate(
-      const BinaryExpression& boolean, const RecordBatch& batch,
-      Status kernel(compute::FunctionContext* context, const compute::Datum& left,
-                    const compute::Datum& right, compute::Datum* out)) const;
-
   struct Impl;
   MemoryPool* pool_;
 };

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -535,12 +535,10 @@ auto VisitExpression(const Expression& expr, Visitor&& visitor)
       return visitor(internal::checked_cast<const ComparisonExpression&>(expr));
 
     case ExpressionType::CUSTOM:
-      return visitor(internal::checked_cast<const CustomExpression&>(expr));
-
     default:
       break;
   }
-  return visitor(expr);
+  return visitor(internal::checked_cast<const CustomExpression&>(expr));
 }
 
 /// \brief Insert CastExpressions where necessary to make a valid expression.
@@ -604,17 +602,17 @@ class ARROW_DS_EXPORT TreeEvaluator : public ExpressionEvaluator {
   Result<compute::Datum> Evaluate(const Expression& expr,
                                   const RecordBatch& batch) const override;
 
-  Result<compute::Datum> Evaluate(const ScalarExpression& expr,
-                                  const RecordBatch& batch) const;
+  Result<compute::Datum> DoEvaluate(const ScalarExpression& expr,
+                                    const RecordBatch& batch) const;
 
-  Result<compute::Datum> Evaluate(const FieldExpression& expr,
-                                  const RecordBatch& batch) const;
+  Result<compute::Datum> DoEvaluate(const FieldExpression& expr,
+                                    const RecordBatch& batch) const;
 
-  Result<compute::Datum> Evaluate(const AndExpression& expr,
-                                  const RecordBatch& batch) const;
+  Result<compute::Datum> DoEvaluate(const AndExpression& expr,
+                                    const RecordBatch& batch) const;
 
-  Result<compute::Datum> Evaluate(const OrExpression& expr,
-                                  const RecordBatch& batch) const;
+  Result<compute::Datum> DoEvaluate(const OrExpression& expr,
+                                    const RecordBatch& batch) const;
 
   Result<compute::Datum> Evaluate(const InExpression& expr,
                                   const RecordBatch& batch) const;
@@ -625,14 +623,14 @@ class ARROW_DS_EXPORT TreeEvaluator : public ExpressionEvaluator {
   Result<compute::Datum> Evaluate(const NotExpression& expr,
                                   const RecordBatch& batch) const;
 
-  Result<compute::Datum> Evaluate(const CastExpression& expr,
-                                  const RecordBatch& batch) const;
+  Result<compute::Datum> DoEvaluate(const CastExpression& expr,
+                                    const RecordBatch& batch) const;
 
-  Result<compute::Datum> Evaluate(const ComparisonExpression& expr,
-                                  const RecordBatch& batch) const;
+  Result<compute::Datum> DoEvaluate(const ComparisonExpression& expr,
+                                    const RecordBatch& batch) const;
 
-  virtual Result<compute::Datum> Evaluate(const CustomExpression& expr,
-                                          const RecordBatch& batch) const {
+  virtual Result<compute::Datum> DoEvaluate(const CustomExpression& expr,
+                                            const RecordBatch& batch) const {
     return Status::NotImplemented("evaluation of ", expr.ToString());
   }
 
@@ -641,6 +639,11 @@ class ARROW_DS_EXPORT TreeEvaluator : public ExpressionEvaluator {
       const std::shared_ptr<RecordBatch>& batch) const override;
 
  protected:
+  Result<compute::Datum> DoEvaluate(
+      const BinaryExpression& boolean, const RecordBatch& batch,
+      Status kernel(compute::FunctionContext* context, const compute::Datum& left,
+                    const compute::Datum& right, compute::Datum* out)) const;
+
   struct Impl;
   MemoryPool* pool_;
 };

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -297,6 +297,17 @@ TEST_F(FilterTest, Cast) {
       {"a": 1, "b":  1.0, "in": 1}
   ])");
 
+  AssertFilter("a"_ == scalar(0.6)->CastLike("a"_),
+               {field("a", int32()), field("b", float64())}, R"([
+      {"a": 0, "b": -0.1, "in": 1},
+      {"a": 0, "b":  0.3, "in": 1},
+      {"a": 1, "b":  0.2, "in": 0},
+      {"a": 2, "b": -0.1, "in": 0},
+      {"a": 0, "b":  0.1, "in": 1},
+      {"a": 0, "b": null, "in": 1},
+      {"a": 1, "b":  1.0, "in": 0}
+  ])");
+
   AssertFilter("a"_.CastLike("b"_) == "b"_, {field("a", int32()), field("b", float64())},
                R"([
       {"a": 0, "b": -0.1, "in": 0},

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -422,9 +422,17 @@ class TakeExpression : public CustomExpression {
 
     using TreeEvaluator::Evaluate;
 
-    Result<compute::Datum> DoEvaluate(const CustomExpression& expr,
-                                      const RecordBatch& batch) const override {
-      const auto& take_expr = checked_cast<const TakeExpression&>(expr);
+    Result<compute::Datum> Evaluate(const Expression& expr,
+                                    const RecordBatch& batch) const override {
+      if (expr.type() == ExpressionType::CUSTOM) {
+        const auto& take_expr = checked_cast<const TakeExpression&>(expr);
+        return EvaluateTake(take_expr, batch);
+      }
+      return TreeEvaluator::Evaluate(expr, batch);
+    }
+
+    Result<compute::Datum> EvaluateTake(const TakeExpression& take_expr,
+                                        const RecordBatch& batch) const {
       ARROW_ASSIGN_OR_RAISE(auto indices, Evaluate(*take_expr.operand_, batch));
 
       if (indices.kind() == Datum::SCALAR) {

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -356,18 +356,17 @@ TEST_F(FilterTest, ImplicitCast) {
 TEST_F(FilterTest, ConditionOnAbsentColumn) {
   AssertFilter("a"_ == 0 and "b"_ > 0.0 and "b"_ < 1.0 and "absent"_ == 0,
                {field("a", int32()), field("b", float64())}, R"([
-      {"a": 0, "b": -0.1, "in": null},
+      {"a": 0, "b": -0.1, "in": false},
       {"a": 0, "b":  0.3, "in": null},
-      {"a": 1, "b":  0.2, "in": null},
-      {"a": 2, "b": -0.1, "in": null},
+      {"a": 1, "b":  0.2, "in": false},
+      {"a": 2, "b": -0.1, "in": false},
       {"a": 0, "b":  0.1, "in": null},
       {"a": 0, "b": null, "in": null},
-      {"a": 0, "b":  1.0, "in": null}
+      {"a": 0, "b":  1.0, "in": false}
   ])");
 }
 
 TEST_F(FilterTest, KleeneTruthTables) {
-  // TODO(bkietz) also test various ranks against each other
   AssertFilter("a"_ and "b"_, {field("a", boolean()), field("b", boolean())}, R"([
     {"a":null,  "b":null,  "in":null},
     {"a":null,  "b":true,  "in":null},
@@ -423,8 +422,8 @@ class TakeExpression : public CustomExpression {
 
     using TreeEvaluator::Evaluate;
 
-    Result<compute::Datum> Evaluate(const CustomExpression& expr,
-                                    const RecordBatch& batch) const override {
+    Result<compute::Datum> DoEvaluate(const CustomExpression& expr,
+                                      const RecordBatch& batch) const override {
       const auto& take_expr = checked_cast<const TakeExpression&>(expr);
       ARROW_ASSIGN_OR_RAISE(auto indices, Evaluate(*take_expr.operand_, batch));
 

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -120,13 +120,19 @@ Status ScannerBuilder::Project(const std::vector<std::string>& columns) {
   return Status::OK();
 }
 
-Status ScannerBuilder::Filter(std::shared_ptr<Expression> filter) {
+Status ScannerBuilder::Filter(std::shared_ptr<Expression> filter, bool implicit_casts) {
   RETURN_NOT_OK(EnsureColumnsInSchema(schema(), FieldsInExpression(*filter)));
-  scan_options_->filter = std::move(filter);
+  if (implicit_casts) {
+    ARROW_ASSIGN_OR_RAISE(scan_options_->filter, InsertImplicitCasts(*filter, *schema()));
+  } else {
+    scan_options_->filter = std::move(filter);
+  }
   return Status::OK();
 }
 
-Status ScannerBuilder::Filter(const Expression& filter) { return Filter(filter.Copy()); }
+Status ScannerBuilder::Filter(const Expression& filter, bool implicit_casts) {
+  return Filter(filter.Copy(), implicit_casts);
+}
 
 Status ScannerBuilder::UseThreads(bool use_threads) {
   scan_options_->use_threads = use_threads;
@@ -141,9 +147,6 @@ Status ScannerBuilder::Finish(std::unique_ptr<Scanner>* out) const {
     scan_options_->projector =
         std::make_shared<RecordBatchProjector>(scan_context_->pool, projected_schema);
   }
-
-  ARROW_ASSIGN_OR_RAISE(scan_options_->filter,
-                        InsertImplicitCasts(*scan_options_->filter, *dataset_->schema()));
 
   if (scan_options_->filter->Equals(true)) {
     scan_options_->evaluator = ExpressionEvaluator::Null();

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -142,6 +142,10 @@ Status ScannerBuilder::Finish(std::unique_ptr<Scanner>* out) const {
         std::make_shared<RecordBatchProjector>(scan_context_->pool, projected_schema);
   }
 
+  ARROW_ASSIGN_OR_RAISE(
+      scan_options_->filter,
+      InsertImplicitCasts(*scan_options_->filter, *scan_options_->schema));
+
   if (scan_options_->filter->Equals(true)) {
     scan_options_->evaluator = ExpressionEvaluator::Null();
   } else {

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -142,9 +142,8 @@ Status ScannerBuilder::Finish(std::unique_ptr<Scanner>* out) const {
         std::make_shared<RecordBatchProjector>(scan_context_->pool, projected_schema);
   }
 
-  ARROW_ASSIGN_OR_RAISE(
-      scan_options_->filter,
-      InsertImplicitCasts(*scan_options_->filter, *scan_options_->schema));
+  ARROW_ASSIGN_OR_RAISE(scan_options_->filter,
+                        InsertImplicitCasts(*scan_options_->filter, *dataset_->schema()));
 
   if (scan_options_->filter->Equals(true)) {
     scan_options_->evaluator = ExpressionEvaluator::Null();

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -204,8 +204,8 @@ class ARROW_DS_EXPORT ScannerBuilder {
   ///
   /// \return Failure if any referenced columns does not exist in the dataset's
   ///         Schema.
-  Status Filter(std::shared_ptr<Expression> filter);
-  Status Filter(const Expression& filter);
+  Status Filter(std::shared_ptr<Expression> filter, bool implicit_casts = false);
+  Status Filter(const Expression& filter, bool implicit_casts = false);
 
   /// \brief Indicate if the Scanner should make use of the available
   ///        ThreadPool found in ScanContext;

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -357,6 +357,10 @@ struct TestExpression : util::EqualityComparable<TestExpression>,
   }
 
   std::string ToString() const { return expression->ToString(); }
+
+  friend void PrintTo(const TestExpression& expr, std::ostream* os) {
+    *os << expr.ToString();
+  }
 };
 
 struct ArithmeticDatasetFixture {

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -60,6 +60,7 @@ class IsValidExpression;
 class AndExpression;
 class OrExpression;
 class NotExpression;
+class CastExpression;
 class ScalarExpression;
 class FieldReferenceExpression;
 using ExpressionVector = std::vector<std::shared_ptr<Expression>>;

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -34,6 +34,7 @@
 namespace arrow {
 
 using internal::checked_cast;
+using internal::checked_pointer_cast;
 
 bool Scalar::Equals(const Scalar& other) const { return ScalarEquals(*this, other); }
 
@@ -193,5 +194,139 @@ Status CheckBufferLength(const FixedSizeBinaryType* t, const std::shared_ptr<Buf
                                *t);
 }
 }  // namespace internal
+
+// CastImpl(...) assumes `to` points to a non null scalar of the correct type with
+// uninitialized value
+
+// error fallback
+Status CastImpl(const Scalar& from, Scalar* to) {
+  return Status::NotImplemented("casting scalars of type ", *from.type, " to_type type ",
+                                *to->type);
+}
+
+// numeric to numeric
+template <typename From, typename To>
+Status CastImpl(const NumericScalar<From>& from, NumericScalar<To>* to) {
+  to->value = static_cast<typename To::c_type>(from.value);
+  return Status::OK();
+}
+
+// numeric to boolean
+template <typename T>
+Status CastImpl(const NumericScalar<T>& from, BooleanScalar* to) {
+  constexpr auto zero = static_cast<typename T::c_type>(0);
+  to->value = from.value != zero;
+  return Status::OK();
+}
+
+// boolean to numeric
+template <typename T>
+Status CastImpl(const BooleanScalar& from, NumericScalar<T>* to) {
+  to->value = static_cast<typename T::c_type>(from.value);
+  return Status::OK();
+}
+
+// string to any
+template <typename ScalarType>
+Status CastImpl(const StringScalar& from, ScalarType* to) {
+  std::shared_ptr<Scalar> out;
+  RETURN_NOT_OK(Scalar::Parse(to->type, util::string_view(*from.value), &out));
+  to->value = std::move(checked_cast<ScalarType&>(*out).value);
+  return Status::OK();
+}
+
+// binary to string
+template <typename T>
+Status CastImpl(const BinaryScalar& from, StringScalar* to) {
+  to->value = from.value;
+  return Status::OK();
+}
+
+// numeric to string
+template <typename T>
+Status CastImpl(const NumericScalar<T>& from, StringScalar* to) {
+  to->value = Buffer::FromString(std::to_string(from.value));
+  return Status::OK();
+}
+
+// boolean to string
+Status CastImpl(const BooleanScalar& from, StringScalar* to) {
+  to->value = Buffer::FromString(from.value ? "true" : "false");
+  return Status::OK();
+}
+
+template <typename ToType>
+struct UnpackFromType {
+  using ToScalar = typename TypeTraits<ToType>::ScalarType;
+
+  template <typename FromType>
+  Status Visit(const FromType&) {
+    return CastImpl(checked_cast<const typename TypeTraits<FromType>::ScalarType&>(from_),
+                    out_);
+  }
+
+  // identity cast
+  Status Visit(const ToType&) {
+    out_->value = checked_cast<const ToScalar&>(from_).value;
+    return Status::OK();
+  }
+
+  // null to any
+  Status Visit(const NullType&) { return Status::Invalid(""); }
+
+  Status Visit(const UnionType&) { return Status::NotImplemented("cast to ", *to_type_); }
+  Status Visit(const DictionaryType&) {
+    return Status::NotImplemented("cast to ", *to_type_);
+  }
+  Status Visit(const ExtensionType&) {
+    return Status::NotImplemented("cast to ", *to_type_);
+  }
+
+  const Scalar& from_;
+  const std::shared_ptr<DataType>& to_type_;
+  ToScalar* out_;
+};
+
+struct UnpackToType {
+  template <typename ToType>
+  Status Visit(const ToType&) {
+    using ToScalar = typename TypeTraits<ToType>::ScalarType;
+    UnpackFromType<ToType> unpack_from_type{from_, to_type_,
+                                            checked_cast<ToScalar*>(out_)};
+    return VisitTypeInline(*from_.type, &unpack_from_type);
+  }
+
+  Status Visit(const NullType&) {
+    if (from_.is_valid) {
+      return Status::Invalid("attempting to cast non-null scalar to NullScalar");
+    }
+    return Status::OK();
+  }
+
+  Status Visit(const UnionType&) {
+    return Status::NotImplemented("cast from ", *from_.type);
+  }
+  Status Visit(const DictionaryType&) {
+    return Status::NotImplemented("cast from ", *from_.type);
+  }
+  Status Visit(const ExtensionType&) {
+    return Status::NotImplemented("cast from ", *from_.type);
+  }
+
+  const Scalar& from_;
+  const std::shared_ptr<DataType>& to_type_;
+  Scalar* out_;
+};
+
+Result<std::shared_ptr<Scalar>> Scalar::CastTo(std::shared_ptr<DataType> to) {
+  std::shared_ptr<Scalar> out;
+  RETURN_NOT_OK(MakeNullScalar(to, &out));
+  if (is_valid) {
+    out->is_valid = true;
+    UnpackToType unpack_to_type{*this, to, out.get()};
+    RETURN_NOT_OK(VisitTypeInline(*to, &unpack_to_type));
+  }
+  return std::move(out);
+}
 
 }  // namespace arrow

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -129,6 +129,11 @@ struct MakeNullImpl {
     return Status::OK();
   }
 
+  Status Visit(const NullType&) {
+    *out_ = std::make_shared<NullScalar>();
+    return Status::OK();
+  }
+
   Status Visit(const DataType& t) {
     return Status::NotImplemented("construcing null scalars of type ", t);
   }

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -64,7 +64,7 @@ struct ARROW_EXPORT Scalar {
                       std::shared_ptr<Scalar>* out);
 
   // TODO(bkietz) add compute::CastOptions
-  Result<std::shared_ptr<Scalar>> CastTo(std::shared_ptr<DataType> to);
+  Result<std::shared_ptr<Scalar>> CastTo(std::shared_ptr<DataType> to) const;
 
  protected:
   Scalar(const std::shared_ptr<DataType>& type, bool is_valid)
@@ -74,6 +74,8 @@ struct ARROW_EXPORT Scalar {
 /// \brief A scalar value for NullType. Never valid
 struct ARROW_EXPORT NullScalar : public Scalar {
  public:
+  using TypeClass = NullType;
+
   NullScalar() : Scalar{null(), false} {}
 };
 
@@ -102,6 +104,7 @@ struct ARROW_EXPORT PrimitiveScalar : public Scalar {
 }  // namespace internal
 
 struct ARROW_EXPORT BooleanScalar : public internal::PrimitiveScalar {
+  using TypeClass = BooleanType;
   using ValueType = bool;
 
   bool value;
@@ -119,6 +122,7 @@ struct ARROW_EXPORT BooleanScalar : public internal::PrimitiveScalar {
 
 template <typename T>
 struct NumericScalar : public internal::PrimitiveScalar {
+  using TypeClass = T;
   using ValueType = typename T::c_type;
 
   ValueType value;
@@ -138,6 +142,7 @@ struct NumericScalar : public internal::PrimitiveScalar {
 
 template <typename T>
 struct BaseBinaryScalar : public Scalar {
+  using TypeClass = T;
   using ValueType = std::shared_ptr<Buffer>;
 
   std::shared_ptr<Buffer> value;
@@ -160,6 +165,8 @@ struct ARROW_EXPORT BinaryScalar : public BaseBinaryScalar<BinaryType> {
 };
 
 struct ARROW_EXPORT StringScalar : public BinaryScalar {
+  using TypeClass = StringType;
+
   StringScalar(const std::shared_ptr<Buffer>& value,
                const std::shared_ptr<DataType>& type, bool is_valid = true)
       : BinaryScalar(value, type, is_valid) {}
@@ -184,6 +191,8 @@ struct ARROW_EXPORT LargeBinaryScalar : public BaseBinaryScalar<LargeBinaryType>
 };
 
 struct ARROW_EXPORT LargeStringScalar : public LargeBinaryScalar {
+  using TypeClass = LargeStringType;
+
   LargeStringScalar(const std::shared_ptr<Buffer>& value,
                     const std::shared_ptr<DataType>& type, bool is_valid = true)
       : LargeBinaryScalar(value, type, is_valid) {}
@@ -195,6 +204,8 @@ struct ARROW_EXPORT LargeStringScalar : public LargeBinaryScalar {
 };
 
 struct ARROW_EXPORT FixedSizeBinaryScalar : public BinaryScalar {
+  using TypeClass = FixedSizeBinaryType;
+
   FixedSizeBinaryScalar(const std::shared_ptr<Buffer>& value,
                         const std::shared_ptr<DataType>& type, bool is_valid = true);
 };
@@ -211,6 +222,7 @@ class ARROW_EXPORT Date64Scalar : public NumericScalar<Date64Type> {
 
 class ARROW_EXPORT Time32Scalar : public internal::PrimitiveScalar {
  public:
+  using TypeClass = Time32Type;
   using ValueType = int32_t;
 
   Time32Scalar(int32_t value, const std::shared_ptr<DataType>& type,
@@ -221,6 +233,7 @@ class ARROW_EXPORT Time32Scalar : public internal::PrimitiveScalar {
 
 class ARROW_EXPORT Time64Scalar : public internal::PrimitiveScalar {
  public:
+  using TypeClass = Time64Type;
   using ValueType = int64_t;
 
   Time64Scalar(int64_t value, const std::shared_ptr<DataType>& type,
@@ -231,6 +244,7 @@ class ARROW_EXPORT Time64Scalar : public internal::PrimitiveScalar {
 
 class ARROW_EXPORT TimestampScalar : public internal::PrimitiveScalar {
  public:
+  using TypeClass = TimestampType;
   using ValueType = int64_t;
 
   TimestampScalar(int64_t value, const std::shared_ptr<DataType>& type,
@@ -241,6 +255,7 @@ class ARROW_EXPORT TimestampScalar : public internal::PrimitiveScalar {
 
 class ARROW_EXPORT DurationScalar : public internal::PrimitiveScalar {
  public:
+  using TypeClass = DurationType;
   using ValueType = int64_t;
 
   DurationScalar(int64_t value, const std::shared_ptr<DataType>& type,
@@ -251,6 +266,7 @@ class ARROW_EXPORT DurationScalar : public internal::PrimitiveScalar {
 
 class ARROW_EXPORT MonthIntervalScalar : public internal::PrimitiveScalar {
  public:
+  using TypeClass = MonthIntervalType;
   using ValueType = int32_t;
 
   explicit MonthIntervalScalar(int32_t value, bool is_valid = true);
@@ -262,6 +278,7 @@ class ARROW_EXPORT MonthIntervalScalar : public internal::PrimitiveScalar {
 
 class ARROW_EXPORT DayTimeIntervalScalar : public internal::PrimitiveScalar {
  public:
+  using TypeClass = DayTimeIntervalType;
   using ValueType = DayTimeIntervalType::DayMilliseconds;
 
   explicit DayTimeIntervalScalar(DayTimeIntervalType::DayMilliseconds value,
@@ -274,6 +291,7 @@ class ARROW_EXPORT DayTimeIntervalScalar : public internal::PrimitiveScalar {
 };
 
 struct ARROW_EXPORT Decimal128Scalar : public Scalar {
+  using TypeClass = Decimal128Type;
   using ValueType = Decimal128;
 
   Decimal128Scalar(const Decimal128& value, const std::shared_ptr<DataType>& type,
@@ -294,18 +312,22 @@ struct ARROW_EXPORT BaseListScalar : public Scalar {
 };
 
 struct ARROW_EXPORT ListScalar : public BaseListScalar {
+  using TypeClass = ListType;
   using BaseListScalar::BaseListScalar;
 };
 
 struct ARROW_EXPORT LargeListScalar : public BaseListScalar {
+  using TypeClass = LargeListType;
   using BaseListScalar::BaseListScalar;
 };
 
 struct ARROW_EXPORT MapScalar : public BaseListScalar {
+  using TypeClass = MapType;
   using BaseListScalar::BaseListScalar;
 };
 
 struct ARROW_EXPORT FixedSizeListScalar : public BaseListScalar {
+  using TypeClass = FixedSizeListType;
   FixedSizeListScalar(const std::shared_ptr<Array>& value,
                       const std::shared_ptr<DataType>& type, bool is_valid = true);
 
@@ -313,16 +335,26 @@ struct ARROW_EXPORT FixedSizeListScalar : public BaseListScalar {
 };
 
 struct ARROW_EXPORT StructScalar : public Scalar {
+  using TypeClass = StructType;
   using ValueType = std::vector<std::shared_ptr<Scalar>>;
+
   std::vector<std::shared_ptr<Scalar>> value;
 
   StructScalar(ValueType value, std::shared_ptr<DataType> type, bool is_valid = true)
       : Scalar(std::move(type), is_valid), value(std::move(value)) {}
 };
 
-class ARROW_EXPORT UnionScalar : public Scalar {};
-class ARROW_EXPORT DictionaryScalar : public Scalar {};
-class ARROW_EXPORT ExtensionScalar : public Scalar {};
+class ARROW_EXPORT UnionScalar : public Scalar {
+  using TypeClass = UnionType;
+};
+
+class ARROW_EXPORT DictionaryScalar : public Scalar {
+  using TypeClass = DictionaryType;
+};
+
+class ARROW_EXPORT ExtensionScalar : public Scalar {
+  using TypeClass = ExtensionType;
+};
 
 /// \param[in] type the type of scalar to produce
 /// \param[out] null output scalar with is_valid=false

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -58,6 +58,8 @@ struct ARROW_EXPORT Scalar {
     return false;
   }
 
+  std::string ToString() const;
+
   static Status Parse(const std::shared_ptr<DataType>& type, util::string_view s,
                       std::shared_ptr<Scalar>* out);
 

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -28,6 +28,7 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/result.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
@@ -59,6 +60,9 @@ struct ARROW_EXPORT Scalar {
 
   static Status Parse(const std::shared_ptr<DataType>& type, util::string_view s,
                       std::shared_ptr<Scalar>* out);
+
+  // TODO(bkietz) add compute::CastOptions
+  Result<std::shared_ptr<Scalar>> CastTo(std::shared_ptr<DataType> to);
 
  protected:
   Scalar(const std::shared_ptr<DataType>& type, bool is_valid)
@@ -309,6 +313,9 @@ struct ARROW_EXPORT FixedSizeListScalar : public BaseListScalar {
 struct ARROW_EXPORT StructScalar : public Scalar {
   using ValueType = std::vector<std::shared_ptr<Scalar>>;
   std::vector<std::shared_ptr<Scalar>> value;
+
+  StructScalar(ValueType value, std::shared_ptr<DataType> type, bool is_valid = true)
+      : Scalar(std::move(type), is_valid), value(std::move(value)) {}
 };
 
 class ARROW_EXPORT UnionScalar : public Scalar {};

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -355,6 +355,7 @@ struct TypeTraits<StructType> {
 template <>
 struct TypeTraits<UnionType> {
   using ArrayType = UnionArray;
+  using ScalarType = UnionScalar;
   constexpr static bool is_parameter_free = false;
 };
 
@@ -368,6 +369,7 @@ struct TypeTraits<DictionaryType> {
 template <>
 struct TypeTraits<ExtensionType> {
   using ArrayType = ExtensionArray;
+  using ScalarType = ExtensionScalar;
   constexpr static bool is_parameter_free = false;
 };
 

--- a/r/tests/testthat/test-expression.R
+++ b/r/tests/testthat/test-expression.R
@@ -55,7 +55,7 @@ test_that("C++ expressions", {
   expect_output(
     print(f > 4),
     # We can do better than this right?
-    'ComparisonExpression\nGREATER(field(f), scalar<double>(4.000000))',
+    'ComparisonExpression\nGREATER(field(f), scalar<double>(4))',
     fixed = TRUE
   )
 })


### PR DESCRIPTION
This allows type mismatches between scalars in filter expressions and the fields to which they are compared.