### PR TITLE
ARROW-6820: [Format] Update Map type child to "entries"

### DIFF
--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -59,24 +59,24 @@ table FixedSizeList {
 
 /// A Map is a logical nested type that is represented as
 ///
-/// List<entry: Struct<key: K, value: V>>
+/// List<entries: Struct<key: K, value: V>>
 ///
 /// In this layout, the keys and values are each respectively contiguous. We do
 /// not constrain the key and value types, so the application is responsible
 /// for ensuring that the keys are hashable and unique. Whether the keys are sorted
-/// may be set in the metadata for this field
+/// may be set in the metadata for this field.
 ///
-/// In a Field with Map type, the Field has a child Struct field, which then
+/// In a field with Map type, the field has a child Struct field, which then
 /// has two children: key type and the second the value type. The names of the
-/// child fields may be respectively "entry", "key", and "value", but this is
-/// not enforced
+/// child fields may be respectively "entries", "key", and "value", but this is
+/// not enforced.
 ///
 /// Map
-///   - child[0] entry: Struct
+///   - child[0] entries: Struct
 ///     - child[0] key: K
 ///     - child[1] value: V
 ///
-/// Neither the "entry" field nor the "key" field may be nullable.
+/// Neither the "entries" field nor the "key" field may be nullable.
 ///
 /// The metadata is structured so that Arrow systems without special handling
 /// for Map can make Map an alias for List. The "layout" attribute for the Map


### PR DESCRIPTION
This changes the Map type child field name from "entry" to "entries." This is more appropriate because the field is a list of key/value entries, and the C++ and Java implementations already use "entries." This name is only a recommendation for field names and specific names for Map are not enforced.