### PR TITLE
ARROW-7164: [CI] Dev cron github action is failing every 15 minutes

### DIFF
--- a/.github/workflows/dev_cron.yml
+++ b/.github/workflows/dev_cron.yml
@@ -34,7 +34,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const require = global.process.mainModule.constructor._load;
             const fs = require("fs");
             const path = ".github/workflows/dev_cron/jira_link.js";
             const script = fs.readFileSync(path).toString();
@@ -50,7 +49,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const require = global.process.mainModule.constructor._load;
             const fs = require("fs");
             const path = ".github/workflows/dev_cron/title_check.js";
             const script = fs.readFileSync(path).toString();

--- a/.github/workflows/dev_cron/title_check.js
+++ b/.github/workflows/dev_cron/title_check.js
@@ -17,7 +17,8 @@
 
 console.log("title-check");
 
-const fs = require("fs");
+// This is set outside this script
+// const fs = require("fs");
 
 const {owner: owner, repo: repo} = context.repo;
 

--- a/.github/workflows/dev_cron/title_check.js
+++ b/.github/workflows/dev_cron/title_check.js
@@ -17,8 +17,7 @@
 
 console.log("title-check");
 
-// This is set outside this script
-// const fs = require("fs");
+const fs = require("fs");
 
 const {owner: owner, repo: repo} = context.repo;
 


### PR DESCRIPTION
See https://github.com/apache/arrow/actions?query=workflow%3A%22Dev+Cron%22. I noticed because it's spamming me every 15 minutes on my fork. [The error message](https://github.com/apache/arrow/commit/c7ae2e7514c0b5c89bf418a1ebc2257e28de7d5c/checks?check_suite_id=310205854#step:3:12) suggests that the problem is that we're calling require twice.

The cause was a fix in the 0.3.0 release of `github-script`, which made one of our workarounds redundant: https://github.com/actions/github-script/commit/71fcc9050d59a28dc237c70b7b2f8874d72501bf

This patch removes the workaround.
