### PR TITLE
ARROW-5859: [Python] Support ExtensionArray.to_numpy using storage array

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -2177,10 +2177,8 @@ class ArrowDeserializer {
     ArrayVector out_chunks(data_->num_chunks());
     for (int i = 0; i < data_->num_chunks(); i++) {
       auto chunk = data_->chunk(i);
-      auto ext_data = chunk->data()->Copy();
-      ext_data->type = storage_type;
-      auto storage_result = MakeArray(ext_data);
-      out_chunks[i] = storage_result;
+      auto storage_data = checked_cast<const ExtensionArray&>(*chunk).storage();
+      out_chunks[i] = storage_data;
     }
 
     data_ = std::make_shared<ChunkedArray>(out_chunks);

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -18,6 +18,7 @@
 import pickle
 import weakref
 
+import numpy as np
 import pyarrow as pa
 
 import pytest
@@ -388,3 +389,16 @@ def test_parquet(tmpdir, registered_period_type):
     pa.unregister_extension_type(period_type.extension_name)
     result = pq.read_table(filename)
     assert result.column("ext").type == pa.int64()
+
+
+def test_to_numpy():
+    period_type = PeriodType('D')
+    storage = pa.array([1, 2, 3, 4], pa.int64())
+    arr = pa.ExtensionArray.from_storage(period_type, storage)
+
+    result = arr.to_numpy()
+    expected = storage.to_numpy()
+    np.testing.assert_array_equal(result, expected)
+
+    result = np.asarray(arr)
+    np.testing.assert_array_equal(result, expected)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -402,3 +402,9 @@ def test_to_numpy():
 
     result = np.asarray(arr)
     np.testing.assert_array_equal(result, expected)
+
+    # chunked array
+    charr = pa.chunked_array([arr])
+
+    result = np.asarray(charr)
+    np.testing.assert_array_equal(result, expected)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -396,9 +396,11 @@ def test_to_numpy():
     storage = pa.array([1, 2, 3, 4], pa.int64())
     arr = pa.ExtensionArray.from_storage(period_type, storage)
 
-    result = arr.to_numpy()
     expected = storage.to_numpy()
-    np.testing.assert_array_equal(result, expected)
+
+    # TODO waiting on ARROW-6749 PR to enable to_numpy
+    # result = arr.to_numpy()
+    # np.testing.assert_array_equal(result, expected)
 
     result = np.asarray(arr)
     np.testing.assert_array_equal(result, expected)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -397,10 +397,8 @@ def test_to_numpy():
     arr = pa.ExtensionArray.from_storage(period_type, storage)
 
     expected = storage.to_numpy()
-
-    # TODO waiting on ARROW-6749 PR to enable to_numpy
-    # result = arr.to_numpy()
-    # np.testing.assert_array_equal(result, expected)
+    result = arr.to_numpy()
+    np.testing.assert_array_equal(result, expected)
 
     result = np.asarray(arr)
     np.testing.assert_array_equal(result, expected)


### PR DESCRIPTION
xref https://issues.apache.org/jira/browse/ARROW-5859

This makes `to_numpy` (and np.(as)array) work on pyarrow arrays with an ExtensionType by falling back to the storage type for conversion to numpy. 
(previously this raised "ArrowNotImplementedError: extension")