### PR TITLE
PARQUET-1693: [C++] Fix parquet examples with compression define guards

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -349,7 +349,26 @@ add_parquet_benchmark(column_io_benchmark)
 add_parquet_benchmark(encoding_benchmark)
 add_parquet_benchmark(arrow/reader_writer_benchmark PREFIX "parquet-arrow")
 
-# Required for tests, the ExternalProject for zstd does not build on CMake < 3.7
+if(ARROW_WITH_BROTLI)
+  add_definitions(-DARROW_WITH_BROTLI)
+endif()
+
+if(ARROW_WITH_BZ2)
+  add_definitions(-DARROW_WITH_BZ2)
+endif()
+
+if(ARROW_WITH_LZ4)
+  add_definitions(-DARROW_WITH_LZ4)
+endif()
+
+if(ARROW_WITH_SNAPPY)
+  add_definitions(-DARROW_WITH_SNAPPY)
+endif()
+
+if(ARROW_WITH_ZLIB)
+  add_definitions(-DARROW_WITH_ZLIB)
+endif()
+
 if(ARROW_WITH_ZSTD)
   add_definitions(-DARROW_WITH_ZSTD)
 endif()

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -400,11 +400,24 @@ TYPED_TEST(TestPrimitiveWriter, RequiredRLEDictionary) {
 }
 */
 
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStats) {
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::UNCOMPRESSED, false, true,
+                                 LARGE_SIZE);
+}
+
+#ifdef ARROW_WITH_SNAPPY
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithSnappyCompression) {
   this->TestRequiredWithSettings(Encoding::PLAIN, Compression::SNAPPY, false, false,
                                  LARGE_SIZE);
 }
 
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndSnappyCompression) {
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::SNAPPY, false, true,
+                                 LARGE_SIZE);
+}
+#endif
+
+#ifdef ARROW_WITH_BROTLI
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithBrotliCompression) {
   this->TestRequiredWithSettings(Encoding::PLAIN, Compression::BROTLI, false, false,
                                  LARGE_SIZE);
@@ -415,6 +428,14 @@ TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithBrotliCompressionAndLevel) {
                                  LARGE_SIZE, 10);
 }
 
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndBrotliCompression) {
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::BROTLI, false, true,
+                                 LARGE_SIZE);
+}
+
+#endif
+
+#ifdef ARROW_WITH_GZIP
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithGzipCompression) {
   this->TestRequiredWithSettings(Encoding::PLAIN, Compression::GZIP, false, false,
                                  LARGE_SIZE);
@@ -425,28 +446,15 @@ TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithGzipCompressionAndLevel) {
                                  LARGE_SIZE, 10);
 }
 
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithLz4Compression) {
-  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, false,
-                                 LARGE_SIZE);
-}
-
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStats) {
-  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::UNCOMPRESSED, false, true,
-                                 LARGE_SIZE);
-}
-
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndSnappyCompression) {
-  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::SNAPPY, false, true,
-                                 LARGE_SIZE);
-}
-
-TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndBrotliCompression) {
-  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::BROTLI, false, true,
-                                 LARGE_SIZE);
-}
-
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndGzipCompression) {
   this->TestRequiredWithSettings(Encoding::PLAIN, Compression::GZIP, false, true,
+                                 LARGE_SIZE);
+}
+#endif
+
+#ifdef ARROW_WITH_LZ4
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithLz4Compression) {
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, false,
                                  LARGE_SIZE);
 }
 
@@ -454,9 +462,8 @@ TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndLz4Compression) {
   this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, true,
                                  LARGE_SIZE);
 }
+#endif
 
-// The ExternalProject for zstd does not build on CMake < 3.7, so we do not
-// require it here
 #ifdef ARROW_WITH_ZSTD
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithZstdCompression) {
   this->TestRequiredWithSettings(Encoding::PLAIN, Compression::ZSTD, false, false,

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -228,8 +228,24 @@ TEST_F(TestPageSerde, TestFailLargePageHeaders) {
 }
 
 TEST_F(TestPageSerde, Compression) {
-  std::vector<Compression::type> codec_types = {Compression::GZIP, Compression::SNAPPY,
-                                                Compression::BROTLI, Compression::LZ4};
+  std::vector<Compression::type> codec_types;
+
+#ifdef ARROW_WITH_SNAPPY
+  codec_types.push_back(Compression::SNAPPY);
+#endif
+
+#ifdef ARROW_WITH_BROTLI
+  codec_types.push_back(Compression::BROTLI);
+#endif
+
+#ifdef ARROW_WITH_GZIP
+  codec_types.push_back(Compression::GZIP);
+#endif
+
+#ifdef ARROW_WITH_LZ4
+  codec_types.push_back(Compression::LZ4);
+#endif
+
 #ifdef ARROW_WITH_ZSTD
   codec_types.push_back(Compression::ZSTD);
 #endif
@@ -280,7 +296,7 @@ TEST_F(TestPageSerde, Compression) {
 
     ResetStream();
   }
-}
+}  // namespace parquet
 
 TEST_F(TestPageSerde, LZONotSupported) {
   // Must await PARQUET-530

--- a/cpp/src/parquet/file_serialize_test.cc
+++ b/cpp/src/parquet/file_serialize_test.cc
@@ -286,21 +286,29 @@ TYPED_TEST(TestSerialize, RepeatedTooFewRows) {
   ASSERT_THROW(this->RepeatedUnequalRows(), ParquetException);
 }
 
+#ifdef ARROW_WITH_SNAPPY
 TYPED_TEST(TestSerialize, SmallFileSnappy) {
   ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::SNAPPY));
 }
+#endif
 
+#ifdef ARROW_WITH_BROTLI
 TYPED_TEST(TestSerialize, SmallFileBrotli) {
   ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::BROTLI));
 }
+#endif
 
+#ifdef ARROW_WITH_GZIP
 TYPED_TEST(TestSerialize, SmallFileGzip) {
   ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::GZIP));
 }
+#endif
 
+#ifdef ARROW_WITH_LZ4
 TYPED_TEST(TestSerialize, SmallFileLz4) {
   ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::LZ4));
 }
+#endif
 
 #ifdef ARROW_WITH_ZSTD
 TYPED_TEST(TestSerialize, SmallFileZstd) {


### PR DESCRIPTION
Tests would not account for Cmake compression build options and would fail at runtime with "compression X not supported".