### PR TITLE
ARROW-7170: [C++] Fix linking with bundled ORC

### DIFF
--- a/cpp/src/arrow/adapters/orc/CMakeLists.txt
+++ b/cpp/src/arrow/adapters/orc/CMakeLists.txt
@@ -25,7 +25,12 @@ install(FILES adapter.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/adapters/
 # pkg-config support
 arrow_add_pkg_config("arrow-orc")
 
-set(ORC_MIN_TEST_LIBS GTest::Main GTest::GTest)
+set(ORC_MIN_TEST_LIBS
+    GTest::Main
+    GTest::GTest
+    Snappy::snappy
+    LZ4::lz4
+    ZLIB::ZLIB)
 
 if(ARROW_BUILD_STATIC)
   set(ARROW_LIBRARIES_FOR_STATIC_TESTS arrow_testing_static arrow_static)
@@ -44,6 +49,6 @@ set(ORC_STATIC_TEST_LINK_LIBS ${ORC_MIN_TEST_LIBS} ${ARROW_LIBRARIES_FOR_STATIC_
 
 add_arrow_test(adapter_test
                PREFIX
-               "orc"
+               "arrow-orc"
                STATIC_LINK_LIBS
                ${ORC_STATIC_TEST_LINK_LIBS})


### PR DESCRIPTION
Note I still get an error later:
```
[libprotobuf ERROR google/protobuf/descriptor_database.cc:120] File already exists in database: orc_proto.proto
[libprotobuf FATAL google/protobuf/descriptor.cc:1359] CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
terminate called after throwing an instance of 'google::protobuf::FatalException'
  what():  CHECK failed: GeneratedDatabase()->Add(encoded_file_descriptor, size):
Abandon
```