### PR TITLE
ARROW-6176: [Python] Allow type of ExtensionArray to be reinterpreted

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1689,6 +1689,9 @@ cdef class ExtensionArray(Array):
         result.validate()
         return result
 
+    def __getitem__(self, index):
+        return self.type.__storage_to_realized__(self.storage.__getitem__(index))
+
 
 cdef dict _array_classes = {
     _Type_NA: NullArray,

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -630,6 +630,9 @@ cdef class ExtensionType(BaseExtensionType):
         """
         return NotImplementedError
 
+    @classmethod
+    def __storage_to_realized__(cls, scalar):
+        return NotImplementedError
 
 cdef class PyExtensionType(ExtensionType):
     """


### PR DESCRIPTION
An extremely simple way to access elements of an `ExtensionArray`.  The [issue](https://issues.apache.org/jira/browse/ARROW-6176) indicated that an `ExtensionArray` subclass would be better.  I couldn't see how that would work, so I took this approach.  As this is my first PR to Arrow, some guidance would be greatly appreciated.