### PR TITLE
ARROW-7171: [Ruby] Pass Array<Boolean> for Arrow::Table#filter

### DIFF
--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -306,13 +306,13 @@ module Arrow
         end
       end
 
-      ranges = []
+      sliced_tables = []
       slicers.each do |slicer|
         slicer = slicer.evaluate if slicer.respond_to?(:evaluate)
         case slicer
         when Integer
           slicer += n_rows if slicer < 0
-          ranges << [slicer, n_rows - 1]
+          sliced_tables << slice_by_range(slicer, n_rows - 1)
         when Range
           original_from = from = slicer.first
           to = slicer.last
@@ -325,20 +325,9 @@ module Arrow
             raise ArgumentError, message
           end
           to += n_rows if to < 0
-          ranges << [from, to]
-        when ::Array
-          slicer.map! { |value| value.nil? ? false : value }
-          return filter(slicer)
-        when ChunkedArray
-          chunks = []
-          slicer.each_chunk do |array|
-            chunks << array.map { |value| value.nil? ? false : value }
-          end
-          return filter(chunks.flatten)
-        when BooleanArray
-          slicer = slicer.to_a
-          slicer.map! { |value| value.nil? ? false : value }
-          return filter(slicer)
+          sliced_tables << slice_by_range(from, to)
+        when ::Array, BooleanArray, ChunkedArray
+          sliced_tables << filter(slicer)
         else
           message = "slicer must be Integer, Range, (from, to), " +
             "Arrow::ChunkedArray of Arrow::BooleanArray, " +
@@ -346,7 +335,11 @@ module Arrow
           raise ArgumentError, message
         end
       end
-      slice_by_ranges(ranges)
+      if sliced_tables.size > 1
+        sliced_tables[0].concatenate(sliced_tables[1..-1])
+      else
+        sliced_tables[0]
+      end
     end
 
     # TODO
@@ -520,45 +513,17 @@ module Arrow
     def filter(array)
       case array
       when ::Array
-        filter_raw(Arrow::BooleanArray.new(array))
+        filter_raw(BooleanArray.new(array))
+      when ChunkedArray
+        filter_chunked_array(array)
       else
         filter_raw(array)
       end
     end
 
     private
-    def boolean_array_to_slice_ranges(array, offset, ranges)
-      in_target = false
-      target_start = nil
-      array.each_with_index do |is_target, i|
-        if is_target
-          unless in_target
-            target_start = offset + i
-            in_target = true
-          end
-        else
-          if in_target
-            ranges << [target_start, offset + i - 1]
-            target_start = nil
-            in_target = false
-          end
-        end
-      end
-      if in_target
-        ranges << [target_start, offset + array.length - 1]
-      end
-    end
-
-    def slice_by_ranges(ranges)
-      sliced_table = []
-      ranges.each do |from, to|
-        sliced_table << slice_raw(from, to - from + 1)
-      end
-      if sliced_table.size > 1
-        sliced_table[0].concatenate(sliced_table[1..-1])
-      else
-        sliced_table[0]
-      end
+    def slice_by_range(from, to)
+      slice_raw(from, to - from + 1)
     end
 
     def ensure_raw_column(name, data)

--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -513,6 +513,16 @@ module Arrow
       super
     end
 
+    alias_method :filter_raw, :filter
+    def filter(array)
+      case array
+      when ::Array
+        filter_raw(Arrow::BooleanArray.new(array))
+      else
+        filter_raw(array)
+      end
+    end
+
     private
     def boolean_array_to_slice_ranges(array, offset, ranges)
       in_target = false

--- a/ruby/red-arrow/lib/arrow/table.rb
+++ b/ruby/red-arrow/lib/arrow/table.rb
@@ -327,15 +327,18 @@ module Arrow
           to += n_rows if to < 0
           ranges << [from, to]
         when ::Array
-          boolean_array_to_slice_ranges(slicer, 0, ranges)
+          slicer.map! { |value| value.nil? ? false : value }
+          return filter(slicer)
         when ChunkedArray
-          offset = 0
+          chunks = []
           slicer.each_chunk do |array|
-            boolean_array_to_slice_ranges(array, offset, ranges)
-            offset += array.length
+            chunks << array.map { |value| value.nil? ? false : value }
           end
+          return filter(chunks.flatten)
         when BooleanArray
-          boolean_array_to_slice_ranges(slicer, 0, ranges)
+          slicer = slicer.to_a
+          slicer.map! { |value| value.nil? ? false : value }
+          return filter(slicer)
         else
           message = "slicer must be Integer, Range, (from, to), " +
             "Arrow::ChunkedArray of Arrow::BooleanArray, " +

--- a/ruby/red-arrow/test/test-slicer.rb
+++ b/ruby/red-arrow/test/test-slicer.rb
@@ -46,10 +46,14 @@ class SlicerTest < Test::Unit::TestCase
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
 	count	visible
-0	    1	true   
-1	    8	true   
-2	   16	true   
-3	  256	true   
+0	     	       
+1	    1	true   
+2	     	       
+3	    8	true   
+4	   16	true   
+5	     	       
+6	     	       
+7	  256	true   
       TABLE
     end
 
@@ -66,7 +70,8 @@ class SlicerTest < Test::Unit::TestCase
 4	   16	true   
 5	   32	false  
 6	   64	       
-7	  256	true   
+7	     	       
+8	  256	true   
       TABLE
     end
   end
@@ -78,8 +83,12 @@ class SlicerTest < Test::Unit::TestCase
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
 	count	visible
-0	    2	false  
-1	   32	false  
+0	     	       
+1	    2	false  
+2	     	       
+3	   32	false  
+4	     	       
+5	     	       
       TABLE
     end
 
@@ -90,6 +99,7 @@ class SlicerTest < Test::Unit::TestCase
       assert_equal(<<-TABLE, sliced_table.to_s)
 	count	visible
 0	    0	       
+1	     	       
       TABLE
     end
   end
@@ -142,10 +152,14 @@ class SlicerTest < Test::Unit::TestCase
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
 	count	visible
-0	    1	true   
-1	    8	true   
-2	   16	true   
-3	  256	true   
+0	     	       
+1	    1	true   
+2	     	       
+3	    8	true   
+4	   16	true   
+5	     	       
+6	     	       
+7	  256	true   
       TABLE
     end
   end
@@ -172,8 +186,12 @@ class SlicerTest < Test::Unit::TestCase
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
 	count	visible
-0	    2	false  
-1	   32	false  
+0	     	       
+1	    2	false  
+2	     	       
+3	   32	false  
+4	     	       
+5	     	       
       TABLE
     end
   end
@@ -200,8 +218,12 @@ class SlicerTest < Test::Unit::TestCase
       end
       assert_equal(<<-TABLE, sliced_table.to_s)
 	count	visible
-0	    2	false  
-1	   32	false  
+0	     	       
+1	    2	false  
+2	     	       
+3	   32	false  
+4	     	       
+5	     	       
       TABLE
     end
   end
@@ -217,6 +239,7 @@ class SlicerTest < Test::Unit::TestCase
 2	    2	false  
 3	    4	       
 4	    8	true   
+5	     	       
     TABLE
   end
 
@@ -229,7 +252,8 @@ class SlicerTest < Test::Unit::TestCase
 0	   16	true   
 1	   32	false  
 2	   64	       
-3	  256	true   
+3	     	       
+4	  256	true   
     TABLE
   end
 
@@ -245,6 +269,7 @@ class SlicerTest < Test::Unit::TestCase
 3	    4	       
 4	    8	true   
 5	   16	true   
+6	     	       
     TABLE
   end
 
@@ -256,7 +281,8 @@ class SlicerTest < Test::Unit::TestCase
 	count	visible
 0	   32	false  
 1	   64	       
-2	  256	true   
+2	     	       
+3	  256	true   
     TABLE
   end
 
@@ -268,7 +294,8 @@ class SlicerTest < Test::Unit::TestCase
 	count	visible
 0	   32	false  
 1	   64	       
-2	  256	true   
+2	     	       
+3	  256	true   
     TABLE
   end
 
@@ -284,6 +311,7 @@ class SlicerTest < Test::Unit::TestCase
 3	    4	       
 4	    8	true   
 5	   16	true   
+6	     	       
     TABLE
   end
 
@@ -296,7 +324,8 @@ class SlicerTest < Test::Unit::TestCase
 0	   16	true   
 1	   32	false  
 2	   64	       
-3	  256	true   
+3	     	       
+4	  256	true   
     TABLE
   end
 
@@ -311,6 +340,7 @@ class SlicerTest < Test::Unit::TestCase
 2	    2	false  
 3	    4	       
 4	    8	true   
+5	     	       
     TABLE
   end
 
@@ -324,6 +354,7 @@ class SlicerTest < Test::Unit::TestCase
 1	    4	       
 2	   16	true   
 3	   64	       
+4	     	       
     TABLE
   end
 
@@ -337,7 +368,8 @@ class SlicerTest < Test::Unit::TestCase
 1	    2	false  
 2	    8	true   
 3	   32	false  
-4	  256	true   
+4	     	       
+5	  256	true   
     TABLE
   end
 
@@ -347,8 +379,12 @@ class SlicerTest < Test::Unit::TestCase
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
 	count	visible
-0	   16	true   
-1	  256	true   
+0	     	       
+1	     	       
+2	   16	true   
+3	     	       
+4	     	       
+5	  256	true   
     TABLE
   end
 
@@ -358,11 +394,15 @@ class SlicerTest < Test::Unit::TestCase
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
 	count	visible
-0	    1	true   
-1	    8	true   
-2	   16	true   
-3	   32	false  
-4	  256	true   
+0	     	       
+1	    1	true   
+2	     	       
+3	    8	true   
+4	   16	true   
+5	   32	false  
+6	     	       
+7	     	       
+8	  256	true   
     TABLE
   end
 
@@ -372,9 +412,13 @@ class SlicerTest < Test::Unit::TestCase
     end
     assert_equal(<<-TABLE, sliced_table.to_s)
 	count	visible
-0	    1	true   
-1	    8	true   
-2	   32	false  
+0	     	       
+1	    1	true   
+2	     	       
+3	    8	true   
+4	   32	false  
+5	     	       
+6	     	       
     TABLE
   end
 

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -54,11 +54,12 @@ class TableTest < Test::Unit::TestCase
       target_rows = Arrow::BooleanArray.new(target_rows_raw)
       assert_equal(<<-TABLE, @table.slice(target_rows).to_s)
 	count	visible
-0	    2	false  
-1	    4	       
-2	   16	true   
-3	   64	       
-4	  128	       
+0	     	       
+1	    2	false  
+2	    4	       
+3	   16	true   
+4	   64	       
+5	  128	       
       TABLE
     end
 
@@ -66,11 +67,12 @@ class TableTest < Test::Unit::TestCase
       target_rows_raw = [nil, true, true, false, true, false, true, true]
       assert_equal(<<-TABLE, @table.slice(target_rows_raw).to_s)
 	count	visible
-0	    2	false  
-1	    4	       
-2	   16	true   
-3	   64	       
-4	  128	       
+0	     	       
+1	    2	false  
+2	    4	       
+3	   16	true   
+4	   64	       
+5	  128	       
       TABLE
     end
 
@@ -664,6 +666,24 @@ visible: false
     test("Arrow::BooleanArray") do
       array = [nil, true, true, false, true, false, true, true]
       filter = Arrow::BooleanArray.new(array)
+      assert_equal(<<-TABLE, @table.filter(filter).to_s)
+	count	visible
+0	     	       
+1	    2	false  
+2	    4	       
+3	   16	true   
+4	   64	       
+5	  128	       
+      TABLE
+    end
+
+    test("Arrow::ChunkedArray") do
+      filter_chunks = [
+        Arrow::BooleanArray.new([nil, true, true]),
+        Arrow::BooleanArray.new([false, true, false]),
+        Arrow::BooleanArray.new([true, true]),
+      ]
+      filter = Arrow::ChunkedArray.new(filter_chunks)
       assert_equal(<<-TABLE, @table.filter(filter).to_s)
 	count	visible
 0	     	       

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -646,4 +646,33 @@ visible: false
       end
     end
   end
+
+  sub_test_case("#filter") do
+    test("Array: boolean") do
+      filter = [nil, true, true, false, true, false, true, true]
+      assert_equal(<<-TABLE, @table.filter(filter).to_s)
+	count	visible
+0	     	       
+1	    2	false  
+2	    4	       
+3	   16	true   
+4	   64	       
+5	  128	       
+      TABLE
+    end
+
+    test("Arrow::BooleanArray") do
+      array = [nil, true, true, false, true, false, true, true]
+      filter = Arrow::BooleanArray.new(array)
+      assert_equal(<<-TABLE, @table.filter(filter).to_s)
+	count	visible
+0	     	       
+1	    2	false  
+2	    4	       
+3	   16	true   
+4	   64	       
+5	  128	       
+      TABLE
+    end
+  end
 end


### PR DESCRIPTION
This PR includes the following changes.
- Support `Arrow::Table#filter(Array<Boolean>)`.
- Refactor `Arrow::Table#slice` using `Arrow::Table#filter`.
