### PR TITLE
ARROW-7069:[C++][Dataset] Replace ConstantPS with PrefixDictPS

### DIFF
--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -28,6 +28,7 @@
 #include "arrow/scalar.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/stl.h"
+#include "arrow/util/string_view.h"
 
 namespace arrow {
 namespace dataset {
@@ -50,9 +51,14 @@ Result<std::shared_ptr<Expression>> ConvertPartitionKeys(
   return and_(subexpressions);
 }
 
-Result<std::shared_ptr<Expression>> ConstantPartitionScheme::Parse(
+Result<std::shared_ptr<Expression>> PrefixDictionaryPartitionScheme::Parse(
     const std::string& path) const {
-  return expression_;
+  for (const auto& prefix_expr : dict_) {
+    if (util::string_view(path).starts_with(prefix_expr.first)) {
+      return prefix_expr.second;
+    }
+  }
+  return scalar(true);
 }
 
 Result<std::shared_ptr<Expression>> SchemaPartitionScheme::Parse(

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -87,17 +87,18 @@ class ARROW_DS_EXPORT PartitionScheme {
 };
 
 /// \brief Trivial partition scheme which yields an expression provided on construction.
-class ARROW_DS_EXPORT ConstantPartitionScheme : public PartitionScheme {
+class ARROW_DS_EXPORT PrefixDictionaryPartitionScheme : public PartitionScheme {
  public:
-  explicit ConstantPartitionScheme(std::shared_ptr<Expression> expr)
-      : expression_(std::move(expr)) {}
+  explicit PrefixDictionaryPartitionScheme(
+      std::vector<std::pair<std::string, std::shared_ptr<Expression>>> dict)
+      : dict_(std::move(dict)) {}
 
   std::string name() const override { return "constant_partition_scheme"; }
 
   Result<std::shared_ptr<Expression>> Parse(const std::string& path) const override;
 
  private:
-  std::shared_ptr<Expression> expression_;
+  std::vector<std::pair<std::string, std::shared_ptr<Expression>>> dict_;
 };
 
 /// \brief SchemaPartitionScheme parses one segment of a path for each field in its

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -86,7 +86,9 @@ class ARROW_DS_EXPORT PartitionScheme {
   }
 };
 
-/// \brief Trivial partition scheme which yields an expression provided on construction.
+/// \brief Partition scheme which checks paths against a dictionary of prefixes provided
+/// on construction. The expression corresponding to the first prefix which matches a path
+/// will be returned, or scalar(true) if no prefix matches.
 class ARROW_DS_EXPORT PrefixDictionaryPartitionScheme : public PartitionScheme {
  public:
   explicit PrefixDictionaryPartitionScheme(

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -56,10 +56,15 @@ class TestPartitionScheme : public ::testing::Test {
   std::shared_ptr<PartitionScheme> scheme_;
 };
 
-TEST_F(TestPartitionScheme, Simple) {
-  auto expr = equal(field_ref("alpha"), scalar<int16_t>(3));
-  scheme_ = std::make_shared<ConstantPartitionScheme>(expr);
-  AssertParse("/hello/world", expr);
+TEST_F(TestPartitionScheme, PrefixDictionary) {
+  auto alpha_is_three = equal(field_ref("alpha"), scalar<int16_t>(3));
+  auto beta_is_two = equal(field_ref("beta"), scalar<int16_t>(2));
+  scheme_.reset(new PrefixDictionaryPartitionScheme(
+      {{"/alpha_is_three", alpha_is_three}, {"/beta_is_two", beta_is_two}}));
+
+  AssertParse("/misc/ancient.dat", scalar(true));
+  AssertParse("/alpha_is_three/last_year.dat", alpha_is_three);
+  AssertParse("/beta_is_two/current.dat", beta_is_two);
 }
 
 TEST_F(TestPartitionScheme, Schema) {


### PR DESCRIPTION
ConstantPartitionScheme only yields a single expression regardless of path.

PrefixDictionaryPartitionScheme will be more useful; it checks paths against a dictionary of prefixes. If it doesn't find a match, `scalar(true)` will be returned