### PR TITLE
ARROW-7157: [R] Add validation, helpful error message to Object$new()

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -67,7 +67,14 @@ Object <- R6Class("Object",
 
     pointer = function() self$`.:xp:.`,
     `.:xp:.` = NULL,
-    set_pointer = function(xp){
+    set_pointer = function(xp) {
+      if (!inherits(xp, "externalptr")) {
+        stop(
+          class(self)[1], "$new() requires a pointer as input: ",
+          "did you mean $create() instead?",
+          call. = FALSE
+        )
+      }
       self$`.:xp:.` <- xp
     },
     print = function(...){

--- a/r/tests/testthat/test-arrow.R
+++ b/r/tests/testthat/test-arrow.R
@@ -23,6 +23,14 @@ if (identical(Sys.getenv("TEST_R_WITH_ARROW"), "TRUE")) {
   })
 }
 
+test_that("Can't $new() an object with anything other than a pointer", {
+  expect_error(
+    Array$new(1:5),
+    "Array$new() requires a pointer as input: did you mean $create() instead?",
+    fixed = TRUE
+  )
+})
+
 r_only({
   test_that("assert_is", {
     x <- 42


### PR DESCRIPTION
The original report turned out to be user error, but it revealed that we could have better validation, and a helpful error message (rather than a segfault) could help folks self-correct.