### PR TITLE
ARROW-7177: [Java] Provide a utility to improve the performance of vector loading/unloading

### DIFF
--- a/java/performance/src/test/java/org/apache/arrow/vector/VectorLoaderBenchmark.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/VectorLoaderBenchmark.java
@@ -37,70 +37,78 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
- * Benchmarks for {@link VectorUnloader}.
+ * Benchmarks for {@link VectorLoader}.
  */
-@State(Scope.Benchmark)
-public class VectorUnloaderBenchmark {
+public class VectorLoaderBenchmark {
 
   private static final int ALLOCATOR_CAPACITY = 1024 * 1024;
 
   private static final int VECTOR_COUNT = 10;
 
-  private BufferAllocator allocator;
-
-  private VarCharVector [] vectors;
-
-  private VectorUnloader unloader;
-
-  private ArrowRecordBatch recordBatch;
-
   /**
-   * Setup benchmarks.
+   * State for vector load benchmark.
    */
-  @Setup(Level.Trial)
-  public void prepare() {
-    allocator = new RootAllocator(ALLOCATOR_CAPACITY);
-  }
+  @State(Scope.Benchmark)
+  public static class LoadState {
 
-  @Setup(Level.Invocation)
-  public void prepareInvoke() {
-    vectors = new VarCharVector[VECTOR_COUNT];
-    for (int i = 0; i < VECTOR_COUNT; i++) {
-      vectors[i] = new VarCharVector("vector", allocator);
-      vectors[i].allocateNew(100, 10);
+    private BufferAllocator allocator;
+
+    private VarCharVector[] vectors;
+
+    private ArrowRecordBatch recordBatch;
+
+    private VectorSchemaRoot root;
+
+    private VectorLoader loader;
+
+    /**
+     * Setup benchmarks.
+     */
+    @Setup(Level.Trial)
+    public void prepare() {
+      allocator = new RootAllocator(ALLOCATOR_CAPACITY);
     }
 
-    unloader = new VectorUnloader(VectorSchemaRoot.of(vectors));
-  }
+    @Setup(Level.Invocation)
+    public void prepareInvoke() {
+      vectors = new VarCharVector[VECTOR_COUNT];
+      for (int i = 0; i < VECTOR_COUNT; i++) {
+        vectors[i] = new VarCharVector("vector", allocator);
+        vectors[i].allocateNew(100, 10);
+      }
 
-  @TearDown(Level.Invocation)
-  public void tearDownInvoke() {
-    if (recordBatch != null) {
+      root = VectorSchemaRoot.of(vectors);
+      VectorUnloader unloader = new VectorUnloader(root);
+      recordBatch = unloader.getRecordBatch();
+
+      loader = new VectorLoader(root);
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDownInvoke() {
       recordBatch.close();
+      root.close();
     }
-    for (int i = 0; i < VECTOR_COUNT; i++) {
-      vectors[i].close();
-    }
-  }
 
-  /**
-   * Tear down benchmarks.
-   */
-  @TearDown(Level.Trial)
-  public void tearDown() {
-    allocator.close();
+    /**
+     * Tear down benchmarks.
+     */
+    @TearDown(Level.Trial)
+    public void tearDown() {
+      allocator.close();
+    }
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
-  public void unloadBenchmark() {
-    recordBatch = unloader.getRecordBatch();
+  public void loadBenchmark(LoadState state) {
+    state.loader.load(state.recordBatch);
   }
 
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-            .include(VectorUnloaderBenchmark.class.getSimpleName())
+            .include(VectorLoaderBenchmark.class.getSimpleName())
             .forks(1)
             .build();
 

--- a/java/performance/src/test/java/org/apache/arrow/vector/VectorUnloaderBenchmark.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/VectorUnloaderBenchmark.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Benchmarks for {@link VectorUnloader}.
+ */
+@State(Scope.Benchmark)
+public class VectorUnloaderBenchmark {
+
+  private static final int ALLOCATOR_CAPACITY = 1024 * 1024;
+
+  private static final int VECTOR_COUNT = 10;
+
+  private BufferAllocator allocator;
+
+  private VarCharVector [] vectors;
+
+  private VectorUnloader unloader;
+
+  private ArrowRecordBatch recordBatch;
+
+  /**
+   * Setup benchmarks.
+   */
+  @Setup(Level.Trial)
+  public void prepare() {
+    allocator = new RootAllocator(ALLOCATOR_CAPACITY);
+
+  }
+
+  @Setup(Level.Invocation)
+  public void prepareInvoke() {
+    vectors = new VarCharVector[VECTOR_COUNT];
+    for (int i = 0; i < VECTOR_COUNT; i++) {
+      vectors[i] = new VarCharVector("vector", allocator);
+      vectors[i].allocateNew(100, 10);
+    }
+
+    unloader = new VectorUnloader(VectorSchemaRoot.of(vectors));
+  }
+
+  @TearDown(Level.Invocation)
+  public void tearDownInvoke() {
+    recordBatch.close();
+    for (int i = 0; i < VECTOR_COUNT; i++) {
+      vectors[i].close();
+    }
+  }
+
+  /**
+   * Tear down benchmarks.
+   */
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    allocator.close();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void unloadBenchmark() {
+    recordBatch = unloader.getRecordBatch();
+  }
+
+  @Test
+  public void evaluate() throws RunnerException {
+    Options opt = new OptionsBuilder()
+            .include(VectorUnloaderBenchmark.class.getSimpleName())
+            .forks(1)
+            .build();
+
+    new Runner(opt).run();
+  }
+}

--- a/java/performance/src/test/java/org/apache/arrow/vector/VectorUnloaderBenchmark.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/VectorUnloaderBenchmark.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -77,7 +76,9 @@ public class VectorUnloaderBenchmark {
 
   @TearDown(Level.Invocation)
   public void tearDownInvoke() {
-    recordBatch.close();
+    if (recordBatch != null) {
+      recordBatch.close();
+    }
     for (int i = 0; i < VECTOR_COUNT; i++) {
       vectors[i].close();
     }
@@ -98,8 +99,7 @@ public class VectorUnloaderBenchmark {
     recordBatch = unloader.getRecordBatch();
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
             .include(VectorUnloaderBenchmark.class.getSimpleName())
             .forks(1)

--- a/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
@@ -225,6 +225,117 @@ public class TypeLayout {
     return layout;
   }
 
+  /**
+   * Gets the number of {@link BufferLayout}s for the given <code>arrowType</code>.
+   */
+  public static int getTypeBufferCount(final ArrowType arrowType) {
+    return  arrowType.accept(new ArrowTypeVisitor<Integer>() {
+
+      static final int FIXED_WIDTH_BUFFER_COUNT = 2;
+
+      static final int VARIABLE_WIDTH_BUFFER_COUNT = 3;
+
+      @Override
+      public Integer visit(Int type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Union type) {
+        switch (type.getMode()) {
+          case Dense:
+            // TODO: validate this
+            return 3;
+          case Sparse:
+            return 1;
+          default:
+            throw new UnsupportedOperationException("Unsupported Union Mode: " + type.getMode());
+        }
+      }
+
+      @Override
+      public Integer visit(Struct type) {
+        return 1;
+      }
+
+      @Override
+      public Integer visit(Timestamp type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(org.apache.arrow.vector.types.pojo.ArrowType.List type) {
+        return 2;
+      }
+
+      @Override
+      public Integer visit(FixedSizeList type) {
+        return 1;
+      }
+
+      @Override
+      public Integer visit(Map type) {
+        return 2;
+      }
+
+      @Override
+      public Integer visit(FloatingPoint type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Decimal type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(FixedSizeBinary type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Bool type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Binary type) {
+        return VARIABLE_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Utf8 type) {
+        return VARIABLE_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Null type) {
+        return 0;
+      }
+
+      @Override
+      public Integer visit(Date type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Time type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Interval type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+      @Override
+      public Integer visit(Duration type) {
+        return FIXED_WIDTH_BUFFER_COUNT;
+      }
+
+    });
+  }
+
   private final List<BufferLayout> bufferLayouts;
 
   public TypeLayout(List<BufferLayout> bufferLayouts) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
@@ -231,8 +231,15 @@ public class TypeLayout {
   public static int getTypeBufferCount(final ArrowType arrowType) {
     return  arrowType.accept(new ArrowTypeVisitor<Integer>() {
 
+      /**
+       * All fixed width vectors have a common number of buffers 2: one validity buffer, plus a data buffer.
+       */
       static final int FIXED_WIDTH_BUFFER_COUNT = 2;
 
+      /**
+       * All variable width vectors have a common number of buffers 3: a validity buffer,
+       * an offset buffer, and a data buffer.
+       */
       static final int VARIABLE_WIDTH_BUFFER_COUNT = 3;
 
       @Override
@@ -247,6 +254,7 @@ public class TypeLayout {
             // TODO: validate this
             return 3;
           case Sparse:
+            // type buffer
             return 1;
           default:
             throw new UnsupportedOperationException("Unsupported Union Mode: " + type.getMode());
@@ -255,6 +263,7 @@ public class TypeLayout {
 
       @Override
       public Integer visit(Struct type) {
+        // validity buffer
         return 1;
       }
 
@@ -265,16 +274,19 @@ public class TypeLayout {
 
       @Override
       public Integer visit(org.apache.arrow.vector.types.pojo.ArrowType.List type) {
+        // validity buffer + offset buffer
         return 2;
       }
 
       @Override
       public Integer visit(FixedSizeList type) {
+        // validity buffer
         return 1;
       }
 
       @Override
       public Integer visit(Map type) {
+        // validity buffer + offset buffer
         return 2;
       }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -73,9 +73,9 @@ public class VectorLoader {
     checkArgument(nodes.hasNext(),
         "no more field nodes for for field " + field + " and vector " + vector);
     ArrowFieldNode fieldNode = nodes.next();
-    List<BufferLayout> bufferLayouts = TypeLayout.getTypeLayout(field.getType()).getBufferLayouts();
-    List<ArrowBuf> ownBuffers = new ArrayList<>(bufferLayouts.size());
-    for (int j = 0; j < bufferLayouts.size(); j++) {
+    int bufferLayoutCount = TypeLayout.getTypeBufferCount(field.getType());
+    List<ArrowBuf> ownBuffers = new ArrayList<>(bufferLayoutCount);
+    for (int j = 0; j < bufferLayoutCount; j++) {
       ownBuffers.add(buffers.next());
     }
     try {

--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorUnloader.java
@@ -20,7 +20,6 @@ package org.apache.arrow.vector;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.arrow.vector.BufferLayout.BufferType;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 
@@ -72,8 +71,8 @@ public class VectorUnloader {
   private void appendNodes(FieldVector vector, List<ArrowFieldNode> nodes, List<ArrowBuf> buffers) {
     nodes.add(new ArrowFieldNode(vector.getValueCount(), includeNullCount ? vector.getNullCount() : -1));
     List<ArrowBuf> fieldBuffers = vector.getFieldBuffers();
-    List<BufferType> expectedBuffers = TypeLayout.getTypeLayout(vector.getField().getType()).getBufferTypes();
-    if (fieldBuffers.size() != expectedBuffers.size()) {
+    int expectedBufferCount = TypeLayout.getTypeBufferCount(vector.getField().getType());
+    if (fieldBuffers.size() != expectedBufferCount) {
       throw new IllegalArgumentException(String.format(
           "wrong number of buffers for field %s in vector %s. found: %s",
           vector.getField(), vector.getClass().getSimpleName(), fieldBuffers));

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -78,7 +78,9 @@ public class ArrowRecordBatch implements ArrowMessage {
       arrowBuf.getReferenceManager().retain();
       long size = arrowBuf.readableBytes();
       arrowBuffers.add(new ArrowBuffer(offset, size));
-      LOGGER.debug("Buffer in RecordBatch at {}, length: {}", offset, size);
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Buffer in RecordBatch at {}, length: {}", offset, size);
+      }
       offset += size;
       if (alignBuffers) { // align on 8 byte boundaries
         offset = DataSizeRoundingUtil.roundUpTo8Multiple(offset);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.IntervalUnit;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.UnionMode;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.junit.Test;
+
+public class TestTypeLayout {
+
+  @Test
+  public void testTypeBufferCount() {
+    ArrowType type = new ArrowType.Int(8, true);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Union(UnionMode.Sparse, new int[3]);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Union(UnionMode.Dense, new int[1]);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Struct();
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Timestamp(TimeUnit.MILLISECOND, null);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.List();
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.FixedSizeList(5);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Map(false);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Decimal(10, 10);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.FixedSizeBinary(5);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Bool();
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Binary();
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Utf8();
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Null();
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Date(DateUnit.DAY);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Time(TimeUnit.MILLISECOND, 32);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Interval(IntervalUnit.DAY_TIME);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+
+    type = new ArrowType.Duration(TimeUnit.MILLISECOND);
+    assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
+  }
+}


### PR DESCRIPTION
Vector loading/unloading transforms a set of vectors to and from a set of buffers with meta data. It is heavily used in flight/IPC.

In the loading/unloading operations, only the number of type buffers are really needed. However, the current code logic gets a copy of the type buffers, which is not necessary.

In this issue, we provide a utility to get the number of type buffers, given an arrow type. It improves the performance because it removes the following overhead:

1. creating type buffer objects unnecessarily.
2. creating a list and copying list contents (in TypeLayout#getBufferTypes) for vector unloading.