### PR TITLE
ARROW-7180: [CI] Java builds are not triggered on the master branch

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -21,7 +21,7 @@ on:
   push:
     paths:
       - 'ci/**'
-      - 'cpp/**'
+      - 'java/**'
   pull_request:
     paths:
       - 'ci/**'


### PR DESCRIPTION
The path selector was misconfigured for the push events.