### PR TITLE
ARROW-7105: [CI][Crossbow] Nightly homebrew-cpp job fails

### DIFF
--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -6,7 +6,7 @@ class ApacheArrow < Formula
   head "https://github.com/apache/arrow.git"
 
   depends_on "cmake" => :build
-  depends_on "aws-sdk-cpp"
+  # depends_on "aws-sdk-cpp" # Re-enable this and -DARROW_S3=ON in ARROW-6437
   depends_on "boost"
   depends_on "brotli"
   depends_on "flatbuffers"
@@ -40,7 +40,6 @@ class ApacheArrow < Formula
       -DARROW_INSTALL_NAME_RPATH=OFF
       -DPYTHON_EXECUTABLE=#{Formula["python"].bin/"python3"}
     ]
-    # Re-enable -DARROW_S3=ON in ARROW-6437
 
     mkdir "build"
     cd "build" do

--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -6,7 +6,6 @@ class ApacheArrow < Formula
   head "https://github.com/apache/arrow.git"
 
   depends_on "cmake" => :build
-  depends_on "aws-sdk-cpp"
   depends_on "boost"
   depends_on "brotli"
   depends_on "flatbuffers"
@@ -40,7 +39,7 @@ class ApacheArrow < Formula
       -DARROW_INSTALL_NAME_RPATH=OFF
       -DPYTHON_EXECUTABLE=#{Formula["python"].bin/"python3"}
     ]
-    # Re-enable -DARROW_S3=ON in ARROW-6437
+    # Re-enable -DARROW_S3=ON and add back aws-sdk-cpp to depends_on in ARROW-6437
 
     mkdir "build"
     cd "build" do

--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -6,7 +6,7 @@ class ApacheArrow < Formula
   head "https://github.com/apache/arrow.git"
 
   depends_on "cmake" => :build
-  # depends_on "aws-sdk-cpp" # Re-enable this and -DARROW_S3=ON in ARROW-6437
+  depends_on "aws-sdk-cpp"
   depends_on "boost"
   depends_on "brotli"
   depends_on "flatbuffers"
@@ -40,6 +40,7 @@ class ApacheArrow < Formula
       -DARROW_INSTALL_NAME_RPATH=OFF
       -DPYTHON_EXECUTABLE=#{Formula["python"].bin/"python3"}
     ]
+    # Re-enable -DARROW_S3=ON in ARROW-6437
 
     mkdir "build"
     cd "build" do

--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -31,7 +31,6 @@ class ApacheArrow < Formula
       -DARROW_PLASMA=ON
       -DARROW_PROTOBUF_USE_SHARED=ON
       -DARROW_PYTHON=ON
-      -DARROW_S3=ON
       -DARROW_WITH_BZ2=ON
       -DARROW_WITH_ZLIB=ON
       -DARROW_WITH_ZSTD=ON
@@ -41,6 +40,7 @@ class ApacheArrow < Formula
       -DARROW_INSTALL_NAME_RPATH=OFF
       -DPYTHON_EXECUTABLE=#{Formula["python"].bin/"python3"}
     ]
+    # Re-enable -DARROW_S3=ON in ARROW-6437
 
     mkdir "build"
     cd "build" do


### PR DESCRIPTION
This turns off ARROW_S3, which seems to be the cause of the failure.