### PR TITLE
ARROW-7187: [C++][Doc] doxygen broken on master because of @ 

### DIFF
--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -154,7 +154,7 @@ class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery
   /// \param[in] filesystem passed to FileSystemDataSource
   /// \param[in] selector used to crawl and search files
   /// \param[in] format passed to FileSystemDataSource
-  /// \param[in] options see @FileSystemDiscoveryOptions for more information.
+  /// \param[in] options see FileSystemDiscoveryOptions for more information.
   /// \param[out] discovery output pointer
   static Status Make(fs::FileSystem* filesystem, fs::Selector selector,
                      std::shared_ptr<FileFormat> format,


### PR DESCRIPTION
https://github.com/apache/arrow/runs/305621760#step:5:985

```
/arrow/cpp/src/arrow/dataset/discovery.h:159: error: Found unknown command `\FileSystemDiscoveryOptions' (warning treated as error, aborting now)
```