### PR TITLE
ARROW-7181: [C++] Fix an Arrow module search bug with pkg-config

### DIFF
--- a/cpp/cmake_modules/FindArrow.cmake
+++ b/cpp/cmake_modules/FindArrow.cmake
@@ -275,6 +275,7 @@ macro(arrow_find_package_pkg_config)
                                      "${rest_shared_lib_paths}"
                                      IMPORTED_LOCATION
                                      "${first_shared_lib_path}")
+    get_target_property(shared_lib ${target_shared} IMPORTED_LOCATION)
 
     find_library(${prefix}_static_lib
                  NAMES "${static_lib_name}"


### PR DESCRIPTION
If an Arrow module has only shared library and pkg-config is used to
find the module, FindArrow.cmake can't find directory that has the
shared library.