### PR TITLE
ARROW-7197: [Ruby] Suppress keyword argument related warnings with Ruby 2.7

### DIFF
--- a/ruby/red-arrow/lib/arrow/table-loader.rb
+++ b/ruby/red-arrow/lib/arrow/table-loader.rb
@@ -147,9 +147,9 @@ module Arrow
       options = @options.dup
       options.delete(:format)
       if @input.is_a?(Buffer)
-        CSVLoader.load(@input.data.to_s, options)
+        CSVLoader.load(@input.data.to_s, **options)
       else
-        CSVLoader.load(Pathname.new(@input), options)
+        CSVLoader.load(Pathname.new(@input), **options)
       end
     end
 

--- a/ruby/red-arrow/test/test-csv-loader.rb
+++ b/ruby/red-arrow/test/test-csv-loader.rb
@@ -117,8 +117,8 @@ class CSVLoaderTest < Test::Unit::TestCase
   end
 
   sub_test_case("CSVReader") do
-    def load_csv(data, options)
-      Arrow::CSVLoader.load(data, options)
+    def load_csv(data, **options)
+      Arrow::CSVLoader.load(data, **options)
     end
 
     sub_test_case(":headers") do


### PR DESCRIPTION
    ruby/red-arrow/test/test-csv-loader.rb:121: warning: The last argument is used as the keyword parameter
    ruby/red-arrow/lib/arrow/csv-loader.rb:25: warning: for `load' defined here