### PR TITLE
ARROW-6508: [C++] Add Tensor and SparseTensor factory function with validations

### DIFF
--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1288,7 +1288,8 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor) {
   std::shared_ptr<SparseCOOIndex> si;
   ASSERT_OK(SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
                                  {sizeof_index_value * 3, sizeof_index_value},
-                                 Buffer::Wrap(coords_values), &si));
+                                 Buffer::Wrap(coords_values))
+                .Value(&si));
 
   std::vector<int64_t> shape = {2, 3, 4};
   std::vector<std::string> dim_names = {"foo", "bar", "baz"};
@@ -1333,7 +1334,8 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
   std::shared_ptr<SparseCOOIndex> si;
   ASSERT_OK(SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
                                  {sizeof_index_value, sizeof_index_value * 12},
-                                 Buffer::Wrap(coords_values), &si));
+                                 Buffer::Wrap(coords_values))
+                .Value(&si));
 
   std::vector<int64_t> shape = {2, 3, 4};
   std::vector<std::string> dim_names = {"foo", "bar", "baz"};
@@ -1358,7 +1360,8 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSRIndex) {
   auto data = Buffer::Wrap(values);
   NumericTensor<Int64Type> t(data, shape, {}, dim_names);
   std::shared_ptr<SparseCSRMatrix> st;
-  ASSERT_OK(SparseCSRMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton(), &st));
+  ASSERT_OK(
+      SparseCSRMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton()).Value(&st));
 
   this->CheckSparseTensorRoundTrip(*st);
 }

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1286,10 +1286,10 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor) {
                                                    1, 1, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3};
   const int sizeof_index_value = sizeof(c_index_value_type);
   std::shared_ptr<SparseCOOIndex> si;
-  ASSERT_OK(SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
-                                 {sizeof_index_value * 3, sizeof_index_value},
-                                 Buffer::Wrap(coords_values))
-                .Value(&si));
+  ASSERT_OK_AND_ASSIGN(
+      si, SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
+                               {sizeof_index_value * 3, sizeof_index_value},
+                               Buffer::Wrap(coords_values)));
 
   std::vector<int64_t> shape = {2, 3, 4};
   std::vector<std::string> dim_names = {"foo", "bar", "baz"};
@@ -1332,10 +1332,10 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
                                                    0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3};
   const int sizeof_index_value = sizeof(c_index_value_type);
   std::shared_ptr<SparseCOOIndex> si;
-  ASSERT_OK(SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
-                                 {sizeof_index_value, sizeof_index_value * 12},
-                                 Buffer::Wrap(coords_values))
-                .Value(&si));
+  ASSERT_OK_AND_ASSIGN(
+      si, SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
+                               {sizeof_index_value, sizeof_index_value * 12},
+                               Buffer::Wrap(coords_values)));
 
   std::vector<int64_t> shape = {2, 3, 4};
   std::vector<std::string> dim_names = {"foo", "bar", "baz"};
@@ -1360,8 +1360,8 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSRIndex) {
   auto data = Buffer::Wrap(values);
   NumericTensor<Int64Type> t(data, shape, {}, dim_names);
   std::shared_ptr<SparseCSRMatrix> st;
-  ASSERT_OK(
-      SparseCSRMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton()).Value(&st));
+  ASSERT_OK_AND_ASSIGN(
+      st, SparseCSRMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton()));
 
   this->CheckSparseTensorRoundTrip(*st);
 }

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1286,9 +1286,9 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor) {
                                                    1, 1, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3};
   const int sizeof_index_value = sizeof(c_index_value_type);
   std::shared_ptr<SparseCOOIndex> si;
-  ASSERT_OK(SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
-                                 {sizeof_index_value * 3, sizeof_index_value},
-                                 Buffer::Wrap(coords_values))
+  ASSERT_OK(SparseCOOIndex::MakeSafe(
+                TypeTraits<IndexValueType>::type_singleton(), {12, 3},
+                {sizeof_index_value * 3, sizeof_index_value}, Buffer::Wrap(coords_values))
                 .Value(&si));
 
   std::vector<int64_t> shape = {2, 3, 4};
@@ -1332,9 +1332,10 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
                                                    0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3};
   const int sizeof_index_value = sizeof(c_index_value_type);
   std::shared_ptr<SparseCOOIndex> si;
-  ASSERT_OK(SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
-                                 {sizeof_index_value, sizeof_index_value * 12},
-                                 Buffer::Wrap(coords_values))
+  ASSERT_OK(SparseCOOIndex::MakeSafe(TypeTraits<IndexValueType>::type_singleton(),
+                                     {12, 3},
+                                     {sizeof_index_value, sizeof_index_value * 12},
+                                     Buffer::Wrap(coords_values))
                 .Value(&si));
 
   std::vector<int64_t> shape = {2, 3, 4};
@@ -1360,8 +1361,8 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSRIndex) {
   auto data = Buffer::Wrap(values);
   NumericTensor<Int64Type> t(data, shape, {}, dim_names);
   std::shared_ptr<SparseCSRMatrix> st;
-  ASSERT_OK(
-      SparseCSRMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton()).Value(&st));
+  ASSERT_OK(SparseCSRMatrix::MakeSafe(t, TypeTraits<IndexValueType>::type_singleton())
+                .Value(&st));
 
   this->CheckSparseTensorRoundTrip(*st);
 }

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1286,9 +1286,9 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor) {
                                                    1, 1, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3};
   const int sizeof_index_value = sizeof(c_index_value_type);
   std::shared_ptr<SparseCOOIndex> si;
-  ASSERT_OK(SparseCOOIndex::MakeSafe(
-                TypeTraits<IndexValueType>::type_singleton(), {12, 3},
-                {sizeof_index_value * 3, sizeof_index_value}, Buffer::Wrap(coords_values))
+  ASSERT_OK(SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
+                                 {sizeof_index_value * 3, sizeof_index_value},
+                                 Buffer::Wrap(coords_values))
                 .Value(&si));
 
   std::vector<int64_t> shape = {2, 3, 4};
@@ -1332,10 +1332,9 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
                                                    0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3};
   const int sizeof_index_value = sizeof(c_index_value_type);
   std::shared_ptr<SparseCOOIndex> si;
-  ASSERT_OK(SparseCOOIndex::MakeSafe(TypeTraits<IndexValueType>::type_singleton(),
-                                     {12, 3},
-                                     {sizeof_index_value, sizeof_index_value * 12},
-                                     Buffer::Wrap(coords_values))
+  ASSERT_OK(SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
+                                 {sizeof_index_value, sizeof_index_value * 12},
+                                 Buffer::Wrap(coords_values))
                 .Value(&si));
 
   std::vector<int64_t> shape = {2, 3, 4};
@@ -1361,8 +1360,8 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSRIndex) {
   auto data = Buffer::Wrap(values);
   NumericTensor<Int64Type> t(data, shape, {}, dim_names);
   std::shared_ptr<SparseCSRMatrix> st;
-  ASSERT_OK(SparseCSRMatrix::MakeSafe(t, TypeTraits<IndexValueType>::type_singleton())
-                .Value(&st));
+  ASSERT_OK(
+      SparseCSRMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton()).Value(&st));
 
   this->CheckSparseTensorRoundTrip(*st);
 }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1031,8 +1031,8 @@ Status ReadSparseTensorPayload(const IpcPayload& payload,
       std::shared_ptr<DataType> indices_type;
       RETURN_NOT_OK(internal::GetSparseCOOIndexMetadata(
           sparse_tensor->sparseIndex_as_SparseTensorIndexCOO(), &indices_type));
-      RETURN_NOT_OK(SparseCOOIndex::Make(indices_type, shape, non_zero_length,
-                                         payload.body_buffers[0])
+      RETURN_NOT_OK(SparseCOOIndex::MakeSafe(indices_type, shape, non_zero_length,
+                                             payload.body_buffers[0])
                         .Value(&sparse_index));
       return MakeSparseTensorWithSparseCOOIndex(type, shape, dim_names, sparse_index,
                                                 non_zero_length, payload.body_buffers[1],
@@ -1047,8 +1047,9 @@ Status ReadSparseTensorPayload(const IpcPayload& payload,
           sparse_tensor->sparseIndex_as_SparseMatrixIndexCSR(), &indptr_type,
           &indices_type));
       ARROW_CHECK_EQ(indptr_type, indices_type);
-      RETURN_NOT_OK(SparseCSRIndex::Make(indices_type, shape, non_zero_length,
-                                         payload.body_buffers[0], payload.body_buffers[1])
+      RETURN_NOT_OK(SparseCSRIndex::MakeSafe(indices_type, shape, non_zero_length,
+                                             payload.body_buffers[0],
+                                             payload.body_buffers[1])
                         .Value(&sparse_index));
       return MakeSparseTensorWithSparseCSRIndex(type, shape, dim_names, sparse_index,
                                                 non_zero_length, payload.body_buffers[2],

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1031,9 +1031,9 @@ Status ReadSparseTensorPayload(const IpcPayload& payload,
       std::shared_ptr<DataType> indices_type;
       RETURN_NOT_OK(internal::GetSparseCOOIndexMetadata(
           sparse_tensor->sparseIndex_as_SparseTensorIndexCOO(), &indices_type));
-      RETURN_NOT_OK(SparseCOOIndex::Make(indices_type, shape, non_zero_length,
-                                         payload.body_buffers[0])
-                        .Value(&sparse_index));
+      ARROW_ASSIGN_OR_RAISE(sparse_index,
+                            SparseCOOIndex::Make(indices_type, shape, non_zero_length,
+                                                 payload.body_buffers[0]));
       return MakeSparseTensorWithSparseCOOIndex(type, shape, dim_names, sparse_index,
                                                 non_zero_length, payload.body_buffers[1],
                                                 out);
@@ -1047,9 +1047,10 @@ Status ReadSparseTensorPayload(const IpcPayload& payload,
           sparse_tensor->sparseIndex_as_SparseMatrixIndexCSR(), &indptr_type,
           &indices_type));
       ARROW_CHECK_EQ(indptr_type, indices_type);
-      RETURN_NOT_OK(SparseCSRIndex::Make(indices_type, shape, non_zero_length,
-                                         payload.body_buffers[0], payload.body_buffers[1])
-                        .Value(&sparse_index));
+      ARROW_ASSIGN_OR_RAISE(
+          sparse_index,
+          SparseCSRIndex::Make(indices_type, shape, non_zero_length,
+                               payload.body_buffers[0], payload.body_buffers[1]));
       return MakeSparseTensorWithSparseCSRIndex(type, shape, dim_names, sparse_index,
                                                 non_zero_length, payload.body_buffers[2],
                                                 out);

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1032,7 +1032,8 @@ Status ReadSparseTensorPayload(const IpcPayload& payload,
       RETURN_NOT_OK(internal::GetSparseCOOIndexMetadata(
           sparse_tensor->sparseIndex_as_SparseTensorIndexCOO(), &indices_type));
       RETURN_NOT_OK(SparseCOOIndex::Make(indices_type, shape, non_zero_length,
-                                         payload.body_buffers[0], &sparse_index));
+                                         payload.body_buffers[0])
+                        .Value(&sparse_index));
       return MakeSparseTensorWithSparseCOOIndex(type, shape, dim_names, sparse_index,
                                                 non_zero_length, payload.body_buffers[1],
                                                 out);
@@ -1047,8 +1048,8 @@ Status ReadSparseTensorPayload(const IpcPayload& payload,
           &indices_type));
       ARROW_CHECK_EQ(indptr_type, indices_type);
       RETURN_NOT_OK(SparseCSRIndex::Make(indices_type, shape, non_zero_length,
-                                         payload.body_buffers[0], payload.body_buffers[1],
-                                         &sparse_index));
+                                         payload.body_buffers[0], payload.body_buffers[1])
+                        .Value(&sparse_index));
       return MakeSparseTensorWithSparseCSRIndex(type, shape, dim_names, sparse_index,
                                                 non_zero_length, payload.body_buffers[2],
                                                 out);

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1031,8 +1031,8 @@ Status ReadSparseTensorPayload(const IpcPayload& payload,
       std::shared_ptr<DataType> indices_type;
       RETURN_NOT_OK(internal::GetSparseCOOIndexMetadata(
           sparse_tensor->sparseIndex_as_SparseTensorIndexCOO(), &indices_type));
-      RETURN_NOT_OK(SparseCOOIndex::MakeSafe(indices_type, shape, non_zero_length,
-                                             payload.body_buffers[0])
+      RETURN_NOT_OK(SparseCOOIndex::Make(indices_type, shape, non_zero_length,
+                                         payload.body_buffers[0])
                         .Value(&sparse_index));
       return MakeSparseTensorWithSparseCOOIndex(type, shape, dim_names, sparse_index,
                                                 non_zero_length, payload.body_buffers[1],
@@ -1047,9 +1047,8 @@ Status ReadSparseTensorPayload(const IpcPayload& payload,
           sparse_tensor->sparseIndex_as_SparseMatrixIndexCSR(), &indptr_type,
           &indices_type));
       ARROW_CHECK_EQ(indptr_type, indices_type);
-      RETURN_NOT_OK(SparseCSRIndex::MakeSafe(indices_type, shape, non_zero_length,
-                                             payload.body_buffers[0],
-                                             payload.body_buffers[1])
+      RETURN_NOT_OK(SparseCSRIndex::Make(indices_type, shape, non_zero_length,
+                                         payload.body_buffers[0], payload.body_buffers[1])
                         .Value(&sparse_index));
       return MakeSparseTensorWithSparseCSRIndex(type, shape, dim_names, sparse_index,
                                                 non_zero_length, payload.body_buffers[2],

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -414,12 +414,12 @@ Status NdarraysToSparseCSRMatrix(MemoryPool* pool, PyObject* data_ao, PyObject* 
 
 Status TensorToSparseCOOTensor(const std::shared_ptr<Tensor>& tensor,
                                std::shared_ptr<SparseCOOTensor>* out) {
-  return SparseCOOTensor::Make(*tensor, out);
+  return SparseCOOTensor::Make(*tensor).Value(out);
 }
 
 Status TensorToSparseCSRMatrix(const std::shared_ptr<Tensor>& tensor,
                                std::shared_ptr<SparseCSRMatrix>* out) {
-  return SparseCSRMatrix::Make(*tensor, out);
+  return SparseCSRMatrix::Make(*tensor).Value(out);
 }
 
 }  // namespace py

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -414,12 +414,12 @@ Status NdarraysToSparseCSRMatrix(MemoryPool* pool, PyObject* data_ao, PyObject* 
 
 Status TensorToSparseCOOTensor(const std::shared_ptr<Tensor>& tensor,
                                std::shared_ptr<SparseCOOTensor>* out) {
-  return SparseCOOTensor::Make(*tensor).Value(out);
+  return SparseCOOTensor::MakeSafe(*tensor).Value(out);
 }
 
 Status TensorToSparseCSRMatrix(const std::shared_ptr<Tensor>& tensor,
                                std::shared_ptr<SparseCSRMatrix>* out) {
-  return SparseCSRMatrix::Make(*tensor).Value(out);
+  return SparseCSRMatrix::MakeSafe(*tensor).Value(out);
 }
 
 }  // namespace py

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -414,12 +414,12 @@ Status NdarraysToSparseCSRMatrix(MemoryPool* pool, PyObject* data_ao, PyObject* 
 
 Status TensorToSparseCOOTensor(const std::shared_ptr<Tensor>& tensor,
                                std::shared_ptr<SparseCOOTensor>* out) {
-  return SparseCOOTensor::MakeSafe(*tensor).Value(out);
+  return SparseCOOTensor::Make(*tensor).Value(out);
 }
 
 Status TensorToSparseCSRMatrix(const std::shared_ptr<Tensor>& tensor,
                                std::shared_ptr<SparseCSRMatrix>* out) {
-  return SparseCSRMatrix::MakeSafe(*tensor).Value(out);
+  return SparseCSRMatrix::Make(*tensor).Value(out);
 }
 
 }  // namespace py

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/sparse_tensor.h"
 
+#include <algorithm>
 #include <functional>
 #include <limits>
 #include <memory>
@@ -27,6 +28,17 @@
 #include "arrow/visitor_inline.h"
 
 namespace arrow {
+
+// ----------------------------------------------------------------------
+// SparseIndex
+
+Status SparseIndex::ValidateShape(const std::vector<int64_t>& shape) const {
+  if (!std::all_of(shape.begin(), shape.end(), [](int64_t x) { return x > 0; })) {
+    return Status::Invalid("Shape elements must be positive");
+  }
+
+  return Status::OK();
+}
 
 namespace {
 

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -557,9 +557,8 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
 // Constructor with a contiguous NumericTensor
 SparseCOOIndex::SparseCOOIndex(const std::shared_ptr<Tensor>& coords)
     : SparseIndexBase(coords->shape()[0]), coords_(coords) {
-  ARROW_CHECK(
-      CheckSparseCOOIndexValidity(coords_->type(), coords_->shape(), coords_->strides())
-          .ok());
+  ARROW_CHECK_OK(
+      CheckSparseCOOIndexValidity(coords_->type(), coords_->shape(), coords_->strides()));
 }
 
 std::string SparseCOOIndex::ToString() const { return std::string("SparseCOOIndex"); }

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -515,7 +515,7 @@ Status MakeTensorFromSparseTensor(MemoryPool* pool, const SparseTensor* sparse_t
 // ----------------------------------------------------------------------
 // SparseCOOIndex
 
-Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::MakeSafe(
     const std::shared_ptr<DataType>& indices_type,
     const std::vector<int64_t>& indices_shape,
     const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data) {
@@ -533,14 +533,14 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
       indices_type, indices_data, indices_shape, indices_strides));
 }
 
-Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::MakeSafe(
     const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
     int64_t non_zero_length, std::shared_ptr<Buffer> indices_data) {
   auto ndim = static_cast<int64_t>(shape.size());
   const int64_t elsize = sizeof(indices_type.get());
   std::vector<int64_t> indices_shape({non_zero_length, ndim});
   std::vector<int64_t> indices_strides({elsize, elsize * non_zero_length});
-  return SparseCOOIndex::Make(indices_type, indices_shape, indices_strides, indices_data);
+  return MakeSafe(indices_type, indices_shape, indices_strides, indices_data);
 }
 
 // Constructor with a contiguous NumericTensor
@@ -556,7 +556,7 @@ std::string SparseCOOIndex::ToString() const { return std::string("SparseCOOInde
 // ----------------------------------------------------------------------
 // SparseCSRIndex
 
-Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::Make(
+Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::MakeSafe(
     const std::shared_ptr<DataType>& indptr_type,
     const std::shared_ptr<DataType>& indices_type,
     const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
@@ -578,15 +578,15 @@ Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::Make(
       std::make_shared<Tensor>(indices_type, indices_data, indices_shape));
 }
 
-Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::Make(
+Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::MakeSafe(
     const std::shared_ptr<DataType>& indptr_type,
     const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
     int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
     std::shared_ptr<Buffer> indices_data) {
   std::vector<int64_t> indptr_shape({shape[0] + 1});
   std::vector<int64_t> indices_shape({non_zero_length});
-  return SparseCSRIndex::Make(indptr_type, indices_type, indptr_shape, indices_shape,
-                              indptr_data, indices_data);
+  return MakeSafe(indptr_type, indices_type, indptr_shape, indices_shape, indptr_data,
+                  indices_data);
 }
 
 // Constructor with two index vectors

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -515,17 +515,27 @@ Status MakeTensorFromSparseTensor(MemoryPool* pool, const SparseTensor* sparse_t
 // ----------------------------------------------------------------------
 // SparseCOOIndex
 
-Status SparseCOOIndex::Make(std::shared_ptr<DataType> indices_type,
+Status SparseCOOIndex::Make(const std::shared_ptr<DataType>& indices_type,
                             const std::vector<int64_t>& indices_shape,
                             const std::vector<int64_t>& indices_strides,
                             std::shared_ptr<Buffer> indices_data,
                             std::shared_ptr<SparseCOOIndex>* out) {
+  if (!is_integer(indices_type->id())) {
+    return Status::Invalid("Type of SparseCOOIndex indices must be integer");
+  }
+  if (indices_shape.size() != 2) {
+    return Status::Invalid("SparseCOOIndex indices must be a matrix");
+  }
+  if (!internal::IsTensorStridesContiguous(indices_type, indices_shape,
+                                           indices_strides)) {
+    return Status::Invalid("SparseCOOIndex indices must be contiguous");
+  }
   *out = std::make_shared<SparseCOOIndex>(std::make_shared<Tensor>(
       indices_type, indices_data, indices_shape, indices_strides));
   return Status::OK();
 }
 
-Status SparseCOOIndex::Make(std::shared_ptr<DataType> indices_type,
+Status SparseCOOIndex::Make(const std::shared_ptr<DataType>& indices_type,
                             const std::vector<int64_t>& shape, int64_t non_zero_length,
                             std::shared_ptr<Buffer> indices_data,
                             std::shared_ptr<SparseCOOIndex>* out) {
@@ -550,27 +560,41 @@ std::string SparseCOOIndex::ToString() const { return std::string("SparseCOOInde
 // ----------------------------------------------------------------------
 // SparseCSRIndex
 
-Status SparseCSRIndex::Make(const std::shared_ptr<DataType> indices_type,
+Status SparseCSRIndex::Make(const std::shared_ptr<DataType>& indptr_type,
+                            const std::shared_ptr<DataType>& indices_type,
                             const std::vector<int64_t>& indptr_shape,
                             const std::vector<int64_t>& indices_shape,
                             std::shared_ptr<Buffer> indptr_data,
                             std::shared_ptr<Buffer> indices_data,
                             std::shared_ptr<SparseCSRIndex>* out) {
+  if (!is_integer(indptr_type->id())) {
+    return Status::Invalid("Type of SparseCSRIndex indptr must be integer");
+  }
+  if (indptr_shape.size() != 1) {
+    return Status::Invalid("SparseCSRIndex indptr must be a vector");
+  }
+  if (!is_integer(indices_type->id())) {
+    return Status::Invalid("Type of SparseCSRIndex indices must be integer");
+  }
+  if (indices_shape.size() != 1) {
+    return Status::Invalid("SparseCSRIndex indices must be a vector");
+  }
   *out = std::make_shared<SparseCSRIndex>(
-      std::make_shared<Tensor>(indices_type, indptr_data, indptr_shape),
+      std::make_shared<Tensor>(indptr_type, indptr_data, indptr_shape),
       std::make_shared<Tensor>(indices_type, indices_data, indices_shape));
   return Status::OK();
 }
 
-Status SparseCSRIndex::Make(const std::shared_ptr<DataType> indices_type,
+Status SparseCSRIndex::Make(const std::shared_ptr<DataType>& indptr_type,
+                            const std::shared_ptr<DataType>& indices_type,
                             const std::vector<int64_t>& shape, int64_t non_zero_length,
                             std::shared_ptr<Buffer> indptr_data,
                             std::shared_ptr<Buffer> indices_data,
                             std::shared_ptr<SparseCSRIndex>* out) {
   std::vector<int64_t> indptr_shape({shape[0] + 1});
   std::vector<int64_t> indices_shape({non_zero_length});
-  return SparseCSRIndex::Make(indices_type, indptr_shape, indices_shape, indptr_data,
-                              indices_data, out);
+  return SparseCSRIndex::Make(indptr_type, indices_type, indptr_shape, indices_shape,
+                              indptr_data, indices_data, out);
 }
 
 // Constructor with two index vectors

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -515,11 +515,10 @@ Status MakeTensorFromSparseTensor(MemoryPool* pool, const SparseTensor* sparse_t
 // ----------------------------------------------------------------------
 // SparseCOOIndex
 
-Status SparseCOOIndex::Make(const std::shared_ptr<DataType>& indices_type,
-                            const std::vector<int64_t>& indices_shape,
-                            const std::vector<int64_t>& indices_strides,
-                            std::shared_ptr<Buffer> indices_data,
-                            std::shared_ptr<SparseCOOIndex>* out) {
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
+    const std::shared_ptr<DataType>& indices_type,
+    const std::vector<int64_t>& indices_shape,
+    const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data) {
   if (!is_integer(indices_type->id())) {
     return Status::Invalid("Type of SparseCOOIndex indices must be integer");
   }
@@ -530,21 +529,18 @@ Status SparseCOOIndex::Make(const std::shared_ptr<DataType>& indices_type,
                                            indices_strides)) {
     return Status::Invalid("SparseCOOIndex indices must be contiguous");
   }
-  *out = std::make_shared<SparseCOOIndex>(std::make_shared<Tensor>(
+  return std::make_shared<SparseCOOIndex>(std::make_shared<Tensor>(
       indices_type, indices_data, indices_shape, indices_strides));
-  return Status::OK();
 }
 
-Status SparseCOOIndex::Make(const std::shared_ptr<DataType>& indices_type,
-                            const std::vector<int64_t>& shape, int64_t non_zero_length,
-                            std::shared_ptr<Buffer> indices_data,
-                            std::shared_ptr<SparseCOOIndex>* out) {
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
+    const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
+    int64_t non_zero_length, std::shared_ptr<Buffer> indices_data) {
   auto ndim = static_cast<int64_t>(shape.size());
   const int64_t elsize = sizeof(indices_type.get());
   std::vector<int64_t> indices_shape({non_zero_length, ndim});
   std::vector<int64_t> indices_strides({elsize, elsize * non_zero_length});
-  return SparseCOOIndex::Make(indices_type, indices_shape, indices_strides, indices_data,
-                              out);
+  return SparseCOOIndex::Make(indices_type, indices_shape, indices_strides, indices_data);
 }
 
 // Constructor with a contiguous NumericTensor
@@ -560,13 +556,11 @@ std::string SparseCOOIndex::ToString() const { return std::string("SparseCOOInde
 // ----------------------------------------------------------------------
 // SparseCSRIndex
 
-Status SparseCSRIndex::Make(const std::shared_ptr<DataType>& indptr_type,
-                            const std::shared_ptr<DataType>& indices_type,
-                            const std::vector<int64_t>& indptr_shape,
-                            const std::vector<int64_t>& indices_shape,
-                            std::shared_ptr<Buffer> indptr_data,
-                            std::shared_ptr<Buffer> indices_data,
-                            std::shared_ptr<SparseCSRIndex>* out) {
+Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::Make(
+    const std::shared_ptr<DataType>& indptr_type,
+    const std::shared_ptr<DataType>& indices_type,
+    const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
+    std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data) {
   if (!is_integer(indptr_type->id())) {
     return Status::Invalid("Type of SparseCSRIndex indptr must be integer");
   }
@@ -579,22 +573,20 @@ Status SparseCSRIndex::Make(const std::shared_ptr<DataType>& indptr_type,
   if (indices_shape.size() != 1) {
     return Status::Invalid("SparseCSRIndex indices must be a vector");
   }
-  *out = std::make_shared<SparseCSRIndex>(
+  return std::make_shared<SparseCSRIndex>(
       std::make_shared<Tensor>(indptr_type, indptr_data, indptr_shape),
       std::make_shared<Tensor>(indices_type, indices_data, indices_shape));
-  return Status::OK();
 }
 
-Status SparseCSRIndex::Make(const std::shared_ptr<DataType>& indptr_type,
-                            const std::shared_ptr<DataType>& indices_type,
-                            const std::vector<int64_t>& shape, int64_t non_zero_length,
-                            std::shared_ptr<Buffer> indptr_data,
-                            std::shared_ptr<Buffer> indices_data,
-                            std::shared_ptr<SparseCSRIndex>* out) {
+Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::Make(
+    const std::shared_ptr<DataType>& indptr_type,
+    const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
+    int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
+    std::shared_ptr<Buffer> indices_data) {
   std::vector<int64_t> indptr_shape({shape[0] + 1});
   std::vector<int64_t> indices_shape({non_zero_length});
   return SparseCSRIndex::Make(indptr_type, indices_type, indptr_shape, indices_shape,
-                              indptr_data, indices_data, out);
+                              indptr_data, indices_data);
 }
 
 // Constructor with two index vectors

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -534,7 +534,7 @@ inline Status CheckSparseCOOIndexValidity(const std::shared_ptr<DataType>& type,
 
 }  // namespace
 
-Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::MakeSafe(
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
     const std::shared_ptr<DataType>& indices_type,
     const std::vector<int64_t>& indices_shape,
     const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data) {
@@ -544,14 +544,14 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::MakeSafe(
       indices_type, indices_data, indices_shape, indices_strides));
 }
 
-Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::MakeSafe(
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
     const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
     int64_t non_zero_length, std::shared_ptr<Buffer> indices_data) {
   auto ndim = static_cast<int64_t>(shape.size());
   const int64_t elsize = sizeof(indices_type.get());
   std::vector<int64_t> indices_shape({non_zero_length, ndim});
   std::vector<int64_t> indices_strides({elsize, elsize * non_zero_length});
-  return MakeSafe(indices_type, indices_shape, indices_strides, indices_data);
+  return Make(indices_type, indices_shape, indices_strides, indices_data);
 }
 
 // Constructor with a contiguous NumericTensor
@@ -590,7 +590,7 @@ inline Status CheckSparseCSRIndexValidity(const std::shared_ptr<DataType>& indpt
 
 }  // namespace
 
-Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::MakeSafe(
+Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::Make(
     const std::shared_ptr<DataType>& indptr_type,
     const std::shared_ptr<DataType>& indices_type,
     const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
@@ -602,15 +602,15 @@ Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::MakeSafe(
       std::make_shared<Tensor>(indices_type, indices_data, indices_shape));
 }
 
-Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::MakeSafe(
+Result<std::shared_ptr<SparseCSRIndex>> SparseCSRIndex::Make(
     const std::shared_ptr<DataType>& indptr_type,
     const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
     int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
     std::shared_ptr<Buffer> indices_data) {
   std::vector<int64_t> indptr_shape({shape[0] + 1});
   std::vector<int64_t> indices_shape({non_zero_length});
-  return MakeSafe(indptr_type, indices_type, indptr_shape, indices_shape, indptr_data,
-                  indices_data);
+  return Make(indptr_type, indices_type, indptr_shape, indices_shape, indptr_data,
+              indices_data);
 }
 
 // Constructor with two index vectors

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -216,7 +216,7 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
       return Status::Invalid("shape length is too long");
     }
 
-    if (shape.size() == 0 || indptr_->shape()[0] == shape[0] + 1) {
+    if (indptr_->shape()[0] == shape[0] + 1) {
       return Status::OK();
     }
 

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -340,7 +340,7 @@ class SparseTensorImpl : public SparseTensor {
       : SparseTensorImpl(NULLPTR, type, NULLPTR, shape, dim_names) {}
 
   /// \brief Create a SparseTensor with full parameters
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+  static inline Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
       const std::shared_ptr<SparseIndexType>& sparse_index,
       const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
       const std::vector<int64_t>& shape, const std::vector<std::string>& dim_names) {
@@ -360,9 +360,9 @@ class SparseTensorImpl : public SparseTensor {
   ///
   /// The dense tensor is re-encoded as a sparse index and a physical
   /// data buffer for the non-zero value.
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+  static inline Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
       const Tensor& tensor, const std::shared_ptr<DataType>& index_value_type,
-      MemoryPool* pool) {
+      MemoryPool* pool = default_memory_pool()) {
     std::shared_ptr<SparseIndex> sparse_index;
     std::shared_ptr<Buffer> data;
     ARROW_RETURN_NOT_OK(internal::MakeSparseTensorFromTensor(
@@ -373,19 +373,9 @@ class SparseTensorImpl : public SparseTensor {
         data, tensor.shape(), tensor.dim_names_);
   }
 
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
-      const Tensor& tensor, const std::shared_ptr<DataType>& index_value_type) {
-    return Make(tensor, index_value_type, default_memory_pool());
-  }
-
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
-      const Tensor& tensor, MemoryPool* pool) {
+  static inline Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+      const Tensor& tensor, MemoryPool* pool = default_memory_pool()) {
     return Make(tensor, int64(), pool);
-  }
-
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
-      const Tensor& tensor) {
-    return Make(tensor, default_memory_pool());
   }
 
   /// \brief Create a sparse tensor from a dense tensor

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -92,13 +92,13 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::COO;
 
   /// \brief Make SparseCOOIndex from raw properties
-  static Result<std::shared_ptr<SparseCOOIndex>> MakeSafe(
+  static Result<std::shared_ptr<SparseCOOIndex>> Make(
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indices_shape,
       const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCOOIndex from sparse tensor's shape properties and data
-  static Result<std::shared_ptr<SparseCOOIndex>> MakeSafe(
+  static Result<std::shared_ptr<SparseCOOIndex>> Make(
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
       int64_t non_zero_length, std::shared_ptr<Buffer> indices_data);
 
@@ -156,35 +156,35 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
 
   /// \brief Make SparseCSRIndex from raw properties
-  static Result<std::shared_ptr<SparseCSRIndex>> MakeSafe(
+  static Result<std::shared_ptr<SparseCSRIndex>> Make(
       const std::shared_ptr<DataType>& indptr_type,
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
       std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCSRIndex from raw properties
-  static Result<std::shared_ptr<SparseCSRIndex>> MakeSafe(
+  static Result<std::shared_ptr<SparseCSRIndex>> Make(
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
       std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data) {
-    return MakeSafe(indices_type, indices_type, indptr_shape, indices_shape, indptr_data,
-                    indices_data);
+    return Make(indices_type, indices_type, indptr_shape, indices_shape, indptr_data,
+                indices_data);
   }
 
   /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
-  static Result<std::shared_ptr<SparseCSRIndex>> MakeSafe(
+  static Result<std::shared_ptr<SparseCSRIndex>> Make(
       const std::shared_ptr<DataType>& indptr_type,
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
       int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
       std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
-  static Result<std::shared_ptr<SparseCSRIndex>> MakeSafe(
+  static Result<std::shared_ptr<SparseCSRIndex>> Make(
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
       int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
       std::shared_ptr<Buffer> indices_data) {
-    return MakeSafe(indices_type, indices_type, shape, non_zero_length, indptr_data,
-                    indices_data);
+    return Make(indices_type, indices_type, shape, non_zero_length, indptr_data,
+                indices_data);
   }
 
   /// \brief Construct SparseCSRIndex from two index vectors
@@ -340,7 +340,7 @@ class SparseTensorImpl : public SparseTensor {
       : SparseTensorImpl(NULLPTR, type, NULLPTR, shape, dim_names) {}
 
   /// \brief Create a SparseTensor with full parameters
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
       const std::shared_ptr<SparseIndexType>& sparse_index,
       const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
       const std::vector<int64_t>& shape, const std::vector<std::string>& dim_names) {
@@ -360,7 +360,7 @@ class SparseTensorImpl : public SparseTensor {
   ///
   /// The dense tensor is re-encoded as a sparse index and a physical
   /// data buffer for the non-zero value.
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
       const Tensor& tensor, const std::shared_ptr<DataType>& index_value_type,
       MemoryPool* pool) {
     std::shared_ptr<SparseIndex> sparse_index;
@@ -373,47 +373,47 @@ class SparseTensorImpl : public SparseTensor {
         data, tensor.shape(), tensor.dim_names_);
   }
 
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
       const Tensor& tensor, const std::shared_ptr<DataType>& index_value_type) {
-    return MakeSafe(tensor, index_value_type, default_memory_pool());
+    return Make(tensor, index_value_type, default_memory_pool());
   }
 
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
       const Tensor& tensor, MemoryPool* pool) {
-    return MakeSafe(tensor, int64(), pool);
+    return Make(tensor, int64(), pool);
   }
 
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
       const Tensor& tensor) {
-    return MakeSafe(tensor, default_memory_pool());
+    return Make(tensor, default_memory_pool());
   }
 
   /// \brief Create a sparse tensor from a dense tensor
   ///
   /// The dense tensor is re-encoded as a sparse index and a physical
   /// data buffer for the non-zero value.
-  ARROW_DEPRECATED("Use MakeSafe")
+  ARROW_DEPRECATED("Use Result-returning version")
   static Status Make(const Tensor& tensor,
                      const std::shared_ptr<DataType>& index_value_type, MemoryPool* pool,
                      std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
-    auto result = MakeSafe(tensor, index_value_type, pool);
+    auto result = Make(tensor, index_value_type, pool);
     return std::move(result).Value(out);
   }
 
-  ARROW_DEPRECATED("Use MakeSafe")
+  ARROW_DEPRECATED("Use Result-returning version")
   static Status Make(const Tensor& tensor,
                      const std::shared_ptr<DataType>& index_value_type,
                      std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
     return Make(tensor, index_value_type, default_memory_pool(), out);
   }
 
-  ARROW_DEPRECATED("Use MakeSafe")
+  ARROW_DEPRECATED("Use Result-returning version")
   static Status Make(const Tensor& tensor, MemoryPool* pool,
                      std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
     return Make(tensor, int64(), pool, out);
   }
 
-  ARROW_DEPRECATED("Use MakeSafe")
+  ARROW_DEPRECATED("Use Result-returning version")
   static Status Make(const Tensor& tensor,
                      std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
     return Make(tensor, default_memory_pool(), out);

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -121,7 +121,7 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
     return indices()->Equals(*other.indices());
   }
 
-  Status ValidateShape(const std::vector<int64_t>& shape) const override {
+  inline Status ValidateShape(const std::vector<int64_t>& shape) const override {
     ARROW_RETURN_NOT_OK(SparseIndex::ValidateShape(shape));
 
     if (static_cast<size_t>(coords_->shape()[1]) == shape.size()) {
@@ -205,7 +205,7 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
     return indptr()->Equals(*other.indptr()) && indices()->Equals(*other.indices());
   }
 
-  Status ValidateShape(const std::vector<int64_t>& shape) const override {
+  inline Status ValidateShape(const std::vector<int64_t>& shape) const override {
     ARROW_RETURN_NOT_OK(SparseIndex::ValidateShape(shape));
 
     if (shape.size() < 2) {

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -209,7 +209,7 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
     ARROW_RETURN_NOT_OK(SparseIndex::ValidateShape(shape));
 
     if (shape.size() < 2) {
-      return Status::Invalid("shape length is too long");
+      return Status::Invalid("shape length is too short");
     }
 
     if (shape.size() > 2) {
@@ -220,8 +220,7 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
       return Status::OK();
     }
 
-    return Status::Invalid(
-        "shape length is inconsistent with the coords matrix in COO index");
+    return Status::Invalid("shape length is inconsistent with the CSR index");
   }
 
  protected:

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -91,14 +91,14 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::COO;
 
   /// \brief Make SparseCOOIndex from raw properties
-  static Status Make(const std::shared_ptr<DataType> indices_type,
+  static Status Make(const std::shared_ptr<DataType>& indices_type,
                      const std::vector<int64_t>& indices_shape,
                      const std::vector<int64_t>& indices_strides,
                      std::shared_ptr<Buffer> indices_data,
                      std::shared_ptr<SparseCOOIndex>* out);
 
   /// \brief Make SparseCOOIndex from sparse tensor's shape properties and data
-  static Status Make(const std::shared_ptr<DataType> indices_type,
+  static Status Make(const std::shared_ptr<DataType>& indices_type,
                      const std::vector<int64_t>& shape, int64_t non_zero_length,
                      std::shared_ptr<Buffer> indices_data,
                      std::shared_ptr<SparseCOOIndex>* out);
@@ -157,19 +157,42 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
 
   /// \brief Make SparseCSRIndex from raw properties
-  static Status Make(const std::shared_ptr<DataType> indices_type,
+  static Status Make(const std::shared_ptr<DataType>& indptr_type,
+                     const std::shared_ptr<DataType>& indices_type,
                      const std::vector<int64_t>& indptr_shape,
                      const std::vector<int64_t>& indices_shape,
                      std::shared_ptr<Buffer> indptr_data,
                      std::shared_ptr<Buffer> indices_data,
                      std::shared_ptr<SparseCSRIndex>* out);
 
+  /// \brief Make SparseCSRIndex from raw properties
+  static Status Make(const std::shared_ptr<DataType>& indices_type,
+                     const std::vector<int64_t>& indptr_shape,
+                     const std::vector<int64_t>& indices_shape,
+                     std::shared_ptr<Buffer> indptr_data,
+                     std::shared_ptr<Buffer> indices_data,
+                     std::shared_ptr<SparseCSRIndex>* out) {
+    return Make(indices_type, indices_type, indptr_shape, indices_shape, indptr_data,
+                indices_data, out);
+  }
+
   /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
-  static Status Make(const std::shared_ptr<DataType> indices_type,
+  static Status Make(const std::shared_ptr<DataType>& indptr_type,
+                     const std::shared_ptr<DataType>& indices_type,
                      const std::vector<int64_t>& shape, int64_t non_zero_length,
                      std::shared_ptr<Buffer> indptr_data,
                      std::shared_ptr<Buffer> indices_data,
                      std::shared_ptr<SparseCSRIndex>* out);
+
+  /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
+  static Status Make(const std::shared_ptr<DataType>& indices_type,
+                     const std::vector<int64_t>& shape, int64_t non_zero_length,
+                     std::shared_ptr<Buffer> indptr_data,
+                     std::shared_ptr<Buffer> indices_data,
+                     std::shared_ptr<SparseCSRIndex>* out) {
+    return Make(indices_type, indices_type, shape, non_zero_length, indptr_data,
+                indices_data, out);
+  }
 
   /// \brief Construct SparseCSRIndex from two index vectors
   explicit SparseCSRIndex(const std::shared_ptr<Tensor>& indptr,

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -92,13 +92,13 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::COO;
 
   /// \brief Make SparseCOOIndex from raw properties
-  static Result<std::shared_ptr<SparseCOOIndex>> Make(
+  static Result<std::shared_ptr<SparseCOOIndex>> MakeSafe(
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indices_shape,
       const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCOOIndex from sparse tensor's shape properties and data
-  static Result<std::shared_ptr<SparseCOOIndex>> Make(
+  static Result<std::shared_ptr<SparseCOOIndex>> MakeSafe(
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
       int64_t non_zero_length, std::shared_ptr<Buffer> indices_data);
 
@@ -156,35 +156,35 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
 
   /// \brief Make SparseCSRIndex from raw properties
-  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+  static Result<std::shared_ptr<SparseCSRIndex>> MakeSafe(
       const std::shared_ptr<DataType>& indptr_type,
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
       std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCSRIndex from raw properties
-  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+  static Result<std::shared_ptr<SparseCSRIndex>> MakeSafe(
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
       std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data) {
-    return Make(indices_type, indices_type, indptr_shape, indices_shape, indptr_data,
-                indices_data);
+    return MakeSafe(indices_type, indices_type, indptr_shape, indices_shape, indptr_data,
+                    indices_data);
   }
 
   /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
-  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+  static Result<std::shared_ptr<SparseCSRIndex>> MakeSafe(
       const std::shared_ptr<DataType>& indptr_type,
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
       int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
       std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
-  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+  static Result<std::shared_ptr<SparseCSRIndex>> MakeSafe(
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
       int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
       std::shared_ptr<Buffer> indices_data) {
-    return Make(indices_type, indices_type, shape, non_zero_length, indptr_data,
-                indices_data);
+    return MakeSafe(indices_type, indices_type, shape, non_zero_length, indptr_data,
+                    indices_data);
   }
 
   /// \brief Construct SparseCSRIndex from two index vectors
@@ -341,7 +341,7 @@ class SparseTensorImpl : public SparseTensor {
       : SparseTensorImpl(NULLPTR, type, NULLPTR, shape, dim_names) {}
 
   /// \brief Create a SparseTensor with full parameters
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
       const std::shared_ptr<SparseIndexType>& sparse_index,
       const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
       const std::vector<int64_t>& shape, const std::vector<std::string>& dim_names) {
@@ -361,7 +361,7 @@ class SparseTensorImpl : public SparseTensor {
   ///
   /// The dense tensor is re-encoded as a sparse index and a physical
   /// data buffer for the non-zero value.
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
       const Tensor& tensor, const std::shared_ptr<DataType>& index_value_type,
       MemoryPool* pool) {
     std::shared_ptr<SparseIndex> sparse_index;
@@ -374,43 +374,47 @@ class SparseTensorImpl : public SparseTensor {
         data, tensor.shape(), tensor.dim_names_);
   }
 
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
       const Tensor& tensor, const std::shared_ptr<DataType>& index_value_type) {
-    return Make(tensor, index_value_type, default_memory_pool());
+    return MakeSafe(tensor, index_value_type, default_memory_pool());
   }
 
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
       const Tensor& tensor, MemoryPool* pool) {
-    return Make(tensor, int64(), pool);
+    return MakeSafe(tensor, int64(), pool);
   }
 
-  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> MakeSafe(
       const Tensor& tensor) {
-    return Make(tensor, default_memory_pool());
+    return MakeSafe(tensor, default_memory_pool());
   }
 
   /// \brief Create a sparse tensor from a dense tensor
   ///
   /// The dense tensor is re-encoded as a sparse index and a physical
   /// data buffer for the non-zero value.
+  ARROW_DEPRECATED("Use MakeSafe")
   static Status Make(const Tensor& tensor,
                      const std::shared_ptr<DataType>& index_value_type, MemoryPool* pool,
                      std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
-    auto result = Make(tensor, index_value_type, pool);
+    auto result = MakeSafe(tensor, index_value_type, pool);
     return std::move(result).Value(out);
   }
 
+  ARROW_DEPRECATED("Use MakeSafe")
   static Status Make(const Tensor& tensor,
                      const std::shared_ptr<DataType>& index_value_type,
                      std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
     return Make(tensor, index_value_type, default_memory_pool(), out);
   }
 
+  ARROW_DEPRECATED("Use MakeSafe")
   static Status Make(const Tensor& tensor, MemoryPool* pool,
                      std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
     return Make(tensor, int64(), pool, out);
   }
 
+  ARROW_DEPRECATED("Use MakeSafe")
   static Status Make(const Tensor& tensor,
                      std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
     return Make(tensor, default_memory_pool(), out);

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/tensor.h"
@@ -91,17 +92,15 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::COO;
 
   /// \brief Make SparseCOOIndex from raw properties
-  static Status Make(const std::shared_ptr<DataType>& indices_type,
-                     const std::vector<int64_t>& indices_shape,
-                     const std::vector<int64_t>& indices_strides,
-                     std::shared_ptr<Buffer> indices_data,
-                     std::shared_ptr<SparseCOOIndex>* out);
+  static Result<std::shared_ptr<SparseCOOIndex>> Make(
+      const std::shared_ptr<DataType>& indices_type,
+      const std::vector<int64_t>& indices_shape,
+      const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCOOIndex from sparse tensor's shape properties and data
-  static Status Make(const std::shared_ptr<DataType>& indices_type,
-                     const std::vector<int64_t>& shape, int64_t non_zero_length,
-                     std::shared_ptr<Buffer> indices_data,
-                     std::shared_ptr<SparseCOOIndex>* out);
+  static Result<std::shared_ptr<SparseCOOIndex>> Make(
+      const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
+      int64_t non_zero_length, std::shared_ptr<Buffer> indices_data);
 
   /// \brief Construct SparseCOOIndex from column-major NumericTensor
   explicit SparseCOOIndex(const std::shared_ptr<Tensor>& coords);
@@ -157,41 +156,35 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
 
   /// \brief Make SparseCSRIndex from raw properties
-  static Status Make(const std::shared_ptr<DataType>& indptr_type,
-                     const std::shared_ptr<DataType>& indices_type,
-                     const std::vector<int64_t>& indptr_shape,
-                     const std::vector<int64_t>& indices_shape,
-                     std::shared_ptr<Buffer> indptr_data,
-                     std::shared_ptr<Buffer> indices_data,
-                     std::shared_ptr<SparseCSRIndex>* out);
+  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+      const std::shared_ptr<DataType>& indptr_type,
+      const std::shared_ptr<DataType>& indices_type,
+      const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
+      std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCSRIndex from raw properties
-  static Status Make(const std::shared_ptr<DataType>& indices_type,
-                     const std::vector<int64_t>& indptr_shape,
-                     const std::vector<int64_t>& indices_shape,
-                     std::shared_ptr<Buffer> indptr_data,
-                     std::shared_ptr<Buffer> indices_data,
-                     std::shared_ptr<SparseCSRIndex>* out) {
+  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+      const std::shared_ptr<DataType>& indices_type,
+      const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
+      std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data) {
     return Make(indices_type, indices_type, indptr_shape, indices_shape, indptr_data,
-                indices_data, out);
+                indices_data);
   }
 
   /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
-  static Status Make(const std::shared_ptr<DataType>& indptr_type,
-                     const std::shared_ptr<DataType>& indices_type,
-                     const std::vector<int64_t>& shape, int64_t non_zero_length,
-                     std::shared_ptr<Buffer> indptr_data,
-                     std::shared_ptr<Buffer> indices_data,
-                     std::shared_ptr<SparseCSRIndex>* out);
+  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+      const std::shared_ptr<DataType>& indptr_type,
+      const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
+      int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
+      std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
-  static Status Make(const std::shared_ptr<DataType>& indices_type,
-                     const std::vector<int64_t>& shape, int64_t non_zero_length,
-                     std::shared_ptr<Buffer> indptr_data,
-                     std::shared_ptr<Buffer> indices_data,
-                     std::shared_ptr<SparseCSRIndex>* out) {
+  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+      const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
+      int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
+      std::shared_ptr<Buffer> indices_data) {
     return Make(indices_type, indices_type, shape, non_zero_length, indptr_data,
-                indices_data, out);
+                indices_data);
   }
 
   /// \brief Construct SparseCSRIndex from two index vectors
@@ -348,12 +341,10 @@ class SparseTensorImpl : public SparseTensor {
       : SparseTensorImpl(NULLPTR, type, NULLPTR, shape, dim_names) {}
 
   /// \brief Create a SparseTensor with full parameters
-  static Status Make(const std::shared_ptr<SparseIndexType>& sparse_index,
-                     const std::shared_ptr<DataType>& type,
-                     const std::shared_ptr<Buffer>& data,
-                     const std::vector<int64_t>& shape,
-                     const std::vector<std::string>& dim_names,
-                     std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+      const std::shared_ptr<SparseIndexType>& sparse_index,
+      const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
+      const std::vector<int64_t>& shape, const std::vector<std::string>& dim_names) {
     if (!is_tensor_supported(type->id())) {
       return Status::Invalid(type->ToString(),
                              " is not valid data type for a sparse tensor");
@@ -362,9 +353,40 @@ class SparseTensorImpl : public SparseTensor {
     if (dim_names.size() > 0 && dim_names.size() != shape.size()) {
       return Status::Invalid("dim_names length is inconsistent with shape");
     }
-    *out = std::make_shared<SparseTensorImpl<SparseIndexType>>(sparse_index, type, data,
+    return std::make_shared<SparseTensorImpl<SparseIndexType>>(sparse_index, type, data,
                                                                shape, dim_names);
-    return Status::OK();
+  }
+
+  /// \brief Create a sparse tensor from a dense tensor
+  ///
+  /// The dense tensor is re-encoded as a sparse index and a physical
+  /// data buffer for the non-zero value.
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+      const Tensor& tensor, const std::shared_ptr<DataType>& index_value_type,
+      MemoryPool* pool) {
+    std::shared_ptr<SparseIndex> sparse_index;
+    std::shared_ptr<Buffer> data;
+    ARROW_RETURN_NOT_OK(internal::MakeSparseTensorFromTensor(
+        tensor, SparseIndexType::format_id, index_value_type, pool, &sparse_index,
+        &data));
+    return std::make_shared<SparseTensorImpl<SparseIndexType>>(
+        internal::checked_pointer_cast<SparseIndexType>(sparse_index), tensor.type(),
+        data, tensor.shape(), tensor.dim_names_);
+  }
+
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+      const Tensor& tensor, const std::shared_ptr<DataType>& index_value_type) {
+    return Make(tensor, index_value_type, default_memory_pool());
+  }
+
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+      const Tensor& tensor, MemoryPool* pool) {
+    return Make(tensor, int64(), pool);
+  }
+
+  static Result<std::shared_ptr<SparseTensorImpl<SparseIndexType>>> Make(
+      const Tensor& tensor) {
+    return Make(tensor, default_memory_pool());
   }
 
   /// \brief Create a sparse tensor from a dense tensor
@@ -374,15 +396,8 @@ class SparseTensorImpl : public SparseTensor {
   static Status Make(const Tensor& tensor,
                      const std::shared_ptr<DataType>& index_value_type, MemoryPool* pool,
                      std::shared_ptr<SparseTensorImpl<SparseIndexType>>* out) {
-    std::shared_ptr<SparseIndex> sparse_index;
-    std::shared_ptr<Buffer> data;
-    ARROW_RETURN_NOT_OK(internal::MakeSparseTensorFromTensor(
-        tensor, SparseIndexType::format_id, index_value_type, pool, &sparse_index,
-        &data));
-    *out = std::make_shared<SparseTensorImpl<SparseIndexType>>(
-        internal::checked_pointer_cast<SparseIndexType>(sparse_index), tensor.type(),
-        data, tensor.shape(), tensor.dim_names_);
-    return Status::OK();
+    auto result = Make(tensor, index_value_type, pool);
+    return std::move(result).Value(out);
   }
 
   static Status Make(const Tensor& tensor,

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -287,8 +287,9 @@ TYPED_TEST_P(TestSparseCOOTensorForIndexValueType, Make) {
   ASSERT_RAISES(Invalid,
                 SparseCOOTensor::Make(si, binary(), sparse_data, this->shape_, {}, &st));
 
-  // empty shape
-  ASSERT_RAISES(Invalid, SparseCOOTensor::Make(si, int64(), sparse_data, {}, {}, &st));
+  // negative items in shape
+  ASSERT_RAISES(Invalid,
+                SparseCOOTensor::Make(si, int64(), sparse_data, {2, -3, 4}, {}, &st));
 
   // sparse index and ndim (shape length) are inconsistent
   ASSERT_RAISES(Invalid,
@@ -604,6 +605,13 @@ TYPED_TEST_P(TestSparseCSRMatrixForIndexValueType, Make) {
 
   // empty shape
   ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {}, {}, &sm));
+
+  // 1D shape
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {24}, {}, &sm));
+
+  // negative items in shape
+  ASSERT_RAISES(Invalid,
+                SparseCSRMatrix::Make(si, int64(), sparse_data, {6, -4}, {}, &sm));
 
   // sparse index and ndim (shape length) are inconsistent
   ASSERT_RAISES(Invalid,

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -123,9 +123,9 @@ class TestSparseCOOTensorBase : public ::testing::Test {
                                          0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
     auto dense_data = Buffer::Wrap(dense_values);
     NumericTensor<Int64Type> dense_tensor(dense_data, shape_, {}, dim_names_);
-    ASSERT_OK(
-        SparseCOOTensor::Make(dense_tensor, TypeTraits<IndexValueType>::type_singleton())
-            .Value(&sparse_tensor_from_dense_));
+    ASSERT_OK_AND_ASSIGN(sparse_tensor_from_dense_,
+                         SparseCOOTensor::Make(
+                             dense_tensor, TypeTraits<IndexValueType>::type_singleton()));
   }
 
  protected:
@@ -189,7 +189,7 @@ TEST_F(TestSparseCOOTensor, CreationFromNumericTensor1D) {
   NumericTensor<Int64Type> dense_vector(dense_data, dense_shape);
 
   std::shared_ptr<SparseCOOTensor> st;
-  ASSERT_OK(SparseCOOTensor::Make(dense_vector).Value(&st));
+  ASSERT_OK_AND_ASSIGN(st, SparseCOOTensor::Make(dense_vector));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -215,7 +215,7 @@ TEST_F(TestSparseCOOTensor, CreationFromTensor) {
   Tensor tensor(int64(), buffer, this->shape_, {}, this->dim_names_);
 
   std::shared_ptr<SparseCOOTensor> st;
-  ASSERT_OK(SparseCOOTensor::Make(tensor).Value(&st));
+  ASSERT_OK_AND_ASSIGN(st, SparseCOOTensor::Make(tensor));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -237,7 +237,7 @@ TEST_F(TestSparseCOOTensor, CreationFromNonContiguousTensor) {
   Tensor tensor(int64(), buffer, this->shape_, strides);
 
   std::shared_ptr<SparseCOOTensor> st;
-  ASSERT_OK(SparseCOOTensor::Make(tensor).Value(&st));
+  ASSERT_OK_AND_ASSIGN(st, SparseCOOTensor::Make(tensor));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -256,10 +256,10 @@ TEST_F(TestSparseCOOTensor, TensorEquality) {
   NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
 
   std::shared_ptr<SparseCOOTensor> st1;
-  ASSERT_OK(SparseCOOTensor::Make(tensor1).Value(&st1));
+  ASSERT_OK_AND_ASSIGN(st1, SparseCOOTensor::Make(tensor1));
 
   std::shared_ptr<SparseCOOTensor> st2;
-  ASSERT_OK(SparseCOOTensor::Make(tensor2).Value(&st2));
+  ASSERT_OK_AND_ASSIGN(st2, SparseCOOTensor::Make(tensor2));
 
   ASSERT_TRUE(st1->Equals(*this->sparse_tensor_from_dense_));
   ASSERT_FALSE(st1->Equals(*st2));
@@ -273,7 +273,7 @@ TEST_F(TestSparseCOOTensor, TestToTensor) {
   Tensor tensor(int64(), buffer, shape, {}, this->dim_names_);
 
   std::shared_ptr<SparseCOOTensor> sparse_tensor;
-  ASSERT_OK(SparseCOOTensor::Make(tensor).Value(&sparse_tensor));
+  ASSERT_OK_AND_ASSIGN(sparse_tensor, SparseCOOTensor::Make(tensor));
 
   ASSERT_EQ(5, sparse_tensor->non_zero_length());
   ASSERT_TRUE(sparse_tensor->is_mutable());
@@ -485,9 +485,9 @@ class TestSparseCSRMatrixBase : public ::testing::Test {
                                          0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
     auto dense_data = Buffer::Wrap(dense_values);
     NumericTensor<Int64Type> dense_tensor(dense_data, shape_, {}, dim_names_);
-    ASSERT_OK(
-        SparseCSRMatrix::Make(dense_tensor, TypeTraits<IndexValueType>::type_singleton())
-            .Value(&sparse_tensor_from_dense_));
+    ASSERT_OK_AND_ASSIGN(sparse_tensor_from_dense_,
+                         SparseCSRMatrix::Make(
+                             dense_tensor, TypeTraits<IndexValueType>::type_singleton()));
   }
 
  protected:
@@ -505,7 +505,7 @@ TEST_F(TestSparseCSRMatrix, CreationFromNumericTensor2D) {
   NumericTensor<Int64Type> tensor(buffer, this->shape_);
 
   std::shared_ptr<SparseCSRMatrix> st1;
-  ASSERT_OK(SparseCSRMatrix::Make(tensor).Value(&st1));
+  ASSERT_OK_AND_ASSIGN(st1, SparseCSRMatrix::Make(tensor));
 
   auto st2 = this->sparse_tensor_from_dense_;
 
@@ -557,7 +557,7 @@ TEST_F(TestSparseCSRMatrix, CreationFromNonContiguousTensor) {
   Tensor tensor(int64(), buffer, this->shape_, strides);
 
   std::shared_ptr<SparseCSRMatrix> st;
-  ASSERT_OK(SparseCSRMatrix::Make(tensor).Value(&st));
+  ASSERT_OK_AND_ASSIGN(st, SparseCSRMatrix::Make(tensor));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -599,8 +599,8 @@ TEST_F(TestSparseCSRMatrix, TensorEquality) {
   NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
 
   std::shared_ptr<SparseCSRMatrix> st1, st2;
-  ASSERT_OK(SparseCSRMatrix::Make(tensor1).Value(&st1));
-  ASSERT_OK(SparseCSRMatrix::Make(tensor2).Value(&st2));
+  ASSERT_OK_AND_ASSIGN(st1, SparseCSRMatrix::Make(tensor1));
+  ASSERT_OK_AND_ASSIGN(st2, SparseCSRMatrix::Make(tensor2));
 
   ASSERT_TRUE(st1->Equals(*this->sparse_tensor_from_dense_));
   ASSERT_FALSE(st1->Equals(*st2));
@@ -614,7 +614,7 @@ TEST_F(TestSparseCSRMatrix, TestToTensor) {
   Tensor tensor(int64(), buffer, shape, {}, this->dim_names_);
 
   std::shared_ptr<SparseCSRMatrix> sparse_tensor;
-  ASSERT_OK(SparseCSRMatrix::Make(tensor).Value(&sparse_tensor));
+  ASSERT_OK_AND_ASSIGN(sparse_tensor, SparseCSRMatrix::Make(tensor));
 
   ASSERT_EQ(7, sparse_tensor->non_zero_length());
   ASSERT_TRUE(sparse_tensor->is_mutable());
@@ -642,10 +642,10 @@ TYPED_TEST_P(TestSparseCSRMatrixForIndexValueType, Make) {
   std::vector<int64_t> indices_shape = {12};
 
   std::shared_ptr<SparseCSRIndex> si;
-  ASSERT_OK(SparseCSRIndex::Make(TypeTraits<IndexValueType>::type_singleton(),
-                                 indptr_shape, indices_shape, Buffer::Wrap(indptr_values),
-                                 Buffer::Wrap(indices_values))
-                .Value(&si));
+  ASSERT_OK_AND_ASSIGN(
+      si, SparseCSRIndex::Make(TypeTraits<IndexValueType>::type_singleton(), indptr_shape,
+                               indices_shape, Buffer::Wrap(indptr_values),
+                               Buffer::Wrap(indices_values)));
 
   std::vector<int64_t> sparse_values = {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16};
   auto sparse_data = Buffer::Wrap(sparse_values);

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -55,20 +55,20 @@ TEST(TestSparseCOOIndex, Make) {
   std::vector<int64_t> stride = {3 * sizeof(int32_t), sizeof(int32_t)};
 
   // OK
-  auto res = SparseCOOIndex::MakeSafe(int32(), shape, stride, data);
+  auto res = SparseCOOIndex::Make(int32(), shape, stride, data);
   ASSERT_OK(res);
 
   // Non-integer type
-  res = SparseCOOIndex::MakeSafe(float32(), shape, stride, data);
+  res = SparseCOOIndex::Make(float32(), shape, stride, data);
   ASSERT_RAISES(Invalid, res);
 
   // Non-matrix indices
-  res = SparseCOOIndex::MakeSafe(int32(), {4, 3, 4}, stride, data);
+  res = SparseCOOIndex::Make(int32(), {4, 3, 4}, stride, data);
   ASSERT_RAISES(Invalid, res);
 
   // Non-contiguous indices
-  res = SparseCOOIndex::MakeSafe(int32(), {6, 3},
-                                 {6 * sizeof(int32_t), 2 * sizeof(int32_t)}, data);
+  res = SparseCOOIndex::Make(int32(), {6, 3}, {6 * sizeof(int32_t), 2 * sizeof(int32_t)},
+                             data);
   ASSERT_RAISES(Invalid, res);
 }
 
@@ -81,23 +81,21 @@ TEST(TestSparseCSRIndex, Make) {
   std::vector<int64_t> indices_shape = {12};
 
   // OK
-  auto res = SparseCSRIndex::MakeSafe(int32(), indptr_shape, indices_shape, indptr_data,
-                                      indices_data);
+  auto res = SparseCSRIndex::Make(int32(), indptr_shape, indices_shape, indptr_data,
+                                  indices_data);
   ASSERT_OK(res);
 
   // Non-integer type
-  res = SparseCSRIndex::MakeSafe(float32(), indptr_shape, indices_shape, indptr_data,
-                                 indices_data);
+  res = SparseCSRIndex::Make(float32(), indptr_shape, indices_shape, indptr_data,
+                             indices_data);
   ASSERT_RAISES(Invalid, res);
 
   // Non-vector indptr shape
-  res =
-      SparseCSRIndex::MakeSafe(int32(), {1, 2}, indices_shape, indptr_data, indices_data);
+  res = SparseCSRIndex::Make(int32(), {1, 2}, indices_shape, indptr_data, indices_data);
   ASSERT_RAISES(Invalid, res);
 
   // Non-vector indices shape
-  res =
-      SparseCSRIndex::MakeSafe(int32(), indptr_shape, {1, 2}, indptr_data, indices_data);
+  res = SparseCSRIndex::Make(int32(), indptr_shape, {1, 2}, indptr_data, indices_data);
   ASSERT_RAISES(Invalid, res);
 }
 
@@ -125,9 +123,9 @@ class TestSparseCOOTensorBase : public ::testing::Test {
                                          0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
     auto dense_data = Buffer::Wrap(dense_values);
     NumericTensor<Int64Type> dense_tensor(dense_data, shape_, {}, dim_names_);
-    ASSERT_OK(SparseCOOTensor::MakeSafe(dense_tensor,
-                                        TypeTraits<IndexValueType>::type_singleton())
-                  .Value(&sparse_tensor_from_dense_));
+    ASSERT_OK(
+        SparseCOOTensor::Make(dense_tensor, TypeTraits<IndexValueType>::type_singleton())
+            .Value(&sparse_tensor_from_dense_));
   }
 
  protected:
@@ -191,7 +189,7 @@ TEST_F(TestSparseCOOTensor, CreationFromNumericTensor1D) {
   NumericTensor<Int64Type> dense_vector(dense_data, dense_shape);
 
   std::shared_ptr<SparseCOOTensor> st;
-  ASSERT_OK(SparseCOOTensor::MakeSafe(dense_vector).Value(&st));
+  ASSERT_OK(SparseCOOTensor::Make(dense_vector).Value(&st));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -217,7 +215,7 @@ TEST_F(TestSparseCOOTensor, CreationFromTensor) {
   Tensor tensor(int64(), buffer, this->shape_, {}, this->dim_names_);
 
   std::shared_ptr<SparseCOOTensor> st;
-  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor).Value(&st));
+  ASSERT_OK(SparseCOOTensor::Make(tensor).Value(&st));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -239,7 +237,7 @@ TEST_F(TestSparseCOOTensor, CreationFromNonContiguousTensor) {
   Tensor tensor(int64(), buffer, this->shape_, strides);
 
   std::shared_ptr<SparseCOOTensor> st;
-  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor).Value(&st));
+  ASSERT_OK(SparseCOOTensor::Make(tensor).Value(&st));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -258,10 +256,10 @@ TEST_F(TestSparseCOOTensor, TensorEquality) {
   NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
 
   std::shared_ptr<SparseCOOTensor> st1;
-  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor1).Value(&st1));
+  ASSERT_OK(SparseCOOTensor::Make(tensor1).Value(&st1));
 
   std::shared_ptr<SparseCOOTensor> st2;
-  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor2).Value(&st2));
+  ASSERT_OK(SparseCOOTensor::Make(tensor2).Value(&st2));
 
   ASSERT_TRUE(st1->Equals(*this->sparse_tensor_from_dense_));
   ASSERT_FALSE(st1->Equals(*st2));
@@ -275,7 +273,7 @@ TEST_F(TestSparseCOOTensor, TestToTensor) {
   Tensor tensor(int64(), buffer, shape, {}, this->dim_names_);
 
   std::shared_ptr<SparseCOOTensor> sparse_tensor;
-  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor).Value(&sparse_tensor));
+  ASSERT_OK(SparseCOOTensor::Make(tensor).Value(&sparse_tensor));
 
   ASSERT_EQ(5, sparse_tensor->non_zero_length());
   ASSERT_TRUE(sparse_tensor->is_mutable());
@@ -334,28 +332,28 @@ TYPED_TEST_P(TestSparseCOOTensorForIndexValueType, Make) {
 
   // OK
   auto res =
-      SparseCOOTensor::MakeSafe(si, int64(), sparse_data, this->shape_, this->dim_names_);
+      SparseCOOTensor::Make(si, int64(), sparse_data, this->shape_, this->dim_names_);
   ASSERT_OK(res);
 
   // OK with an empty dim_names
-  res = SparseCOOTensor::MakeSafe(si, int64(), sparse_data, this->shape_, {});
+  res = SparseCOOTensor::Make(si, int64(), sparse_data, this->shape_, {});
   ASSERT_OK(res);
 
   // invalid data type
-  res = SparseCOOTensor::MakeSafe(si, binary(), sparse_data, this->shape_, {});
+  res = SparseCOOTensor::Make(si, binary(), sparse_data, this->shape_, {});
   ASSERT_RAISES(Invalid, res);
 
   // negative items in shape
-  res = SparseCOOTensor::MakeSafe(si, int64(), sparse_data, {2, -3, 4}, {});
+  res = SparseCOOTensor::Make(si, int64(), sparse_data, {2, -3, 4}, {});
   ASSERT_RAISES(Invalid, res);
 
   // sparse index and ndim (shape length) are inconsistent
-  res = SparseCOOTensor::MakeSafe(si, int64(), sparse_data, {6, 4}, {});
+  res = SparseCOOTensor::Make(si, int64(), sparse_data, {6, 4}, {});
   ASSERT_RAISES(Invalid, res);
 
   // shape and dim_names are inconsistent
-  res = SparseCOOTensor::MakeSafe(si, int64(), sparse_data, this->shape_,
-                                  std::vector<std::string>{"foo"});
+  res = SparseCOOTensor::Make(si, int64(), sparse_data, this->shape_,
+                              std::vector<std::string>{"foo"});
   ASSERT_RAISES(Invalid, res);
 }
 
@@ -487,9 +485,9 @@ class TestSparseCSRMatrixBase : public ::testing::Test {
                                          0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
     auto dense_data = Buffer::Wrap(dense_values);
     NumericTensor<Int64Type> dense_tensor(dense_data, shape_, {}, dim_names_);
-    ASSERT_OK(SparseCSRMatrix::MakeSafe(dense_tensor,
-                                        TypeTraits<IndexValueType>::type_singleton())
-                  .Value(&sparse_tensor_from_dense_));
+    ASSERT_OK(
+        SparseCSRMatrix::Make(dense_tensor, TypeTraits<IndexValueType>::type_singleton())
+            .Value(&sparse_tensor_from_dense_));
   }
 
  protected:
@@ -507,7 +505,7 @@ TEST_F(TestSparseCSRMatrix, CreationFromNumericTensor2D) {
   NumericTensor<Int64Type> tensor(buffer, this->shape_);
 
   std::shared_ptr<SparseCSRMatrix> st1;
-  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor).Value(&st1));
+  ASSERT_OK(SparseCSRMatrix::Make(tensor).Value(&st1));
 
   auto st2 = this->sparse_tensor_from_dense_;
 
@@ -559,7 +557,7 @@ TEST_F(TestSparseCSRMatrix, CreationFromNonContiguousTensor) {
   Tensor tensor(int64(), buffer, this->shape_, strides);
 
   std::shared_ptr<SparseCSRMatrix> st;
-  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor).Value(&st));
+  ASSERT_OK(SparseCSRMatrix::Make(tensor).Value(&st));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -601,8 +599,8 @@ TEST_F(TestSparseCSRMatrix, TensorEquality) {
   NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
 
   std::shared_ptr<SparseCSRMatrix> st1, st2;
-  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor1).Value(&st1));
-  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor2).Value(&st2));
+  ASSERT_OK(SparseCSRMatrix::Make(tensor1).Value(&st1));
+  ASSERT_OK(SparseCSRMatrix::Make(tensor2).Value(&st2));
 
   ASSERT_TRUE(st1->Equals(*this->sparse_tensor_from_dense_));
   ASSERT_FALSE(st1->Equals(*st2));
@@ -616,7 +614,7 @@ TEST_F(TestSparseCSRMatrix, TestToTensor) {
   Tensor tensor(int64(), buffer, shape, {}, this->dim_names_);
 
   std::shared_ptr<SparseCSRMatrix> sparse_tensor;
-  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor).Value(&sparse_tensor));
+  ASSERT_OK(SparseCSRMatrix::Make(tensor).Value(&sparse_tensor));
 
   ASSERT_EQ(7, sparse_tensor->non_zero_length());
   ASSERT_TRUE(sparse_tensor->is_mutable());
@@ -644,9 +642,9 @@ TYPED_TEST_P(TestSparseCSRMatrixForIndexValueType, Make) {
   std::vector<int64_t> indices_shape = {12};
 
   std::shared_ptr<SparseCSRIndex> si;
-  ASSERT_OK(SparseCSRIndex::MakeSafe(
-                TypeTraits<IndexValueType>::type_singleton(), indptr_shape, indices_shape,
-                Buffer::Wrap(indptr_values), Buffer::Wrap(indices_values))
+  ASSERT_OK(SparseCSRIndex::Make(TypeTraits<IndexValueType>::type_singleton(),
+                                 indptr_shape, indices_shape, Buffer::Wrap(indptr_values),
+                                 Buffer::Wrap(indices_values))
                 .Value(&si));
 
   std::vector<int64_t> sparse_values = {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16};
@@ -655,32 +653,31 @@ TYPED_TEST_P(TestSparseCSRMatrixForIndexValueType, Make) {
   std::shared_ptr<SparseCSRMatrix> sm;
 
   // OK
-  ASSERT_OK(SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, this->shape_,
-                                      this->dim_names_));
+  ASSERT_OK(
+      SparseCSRMatrix::Make(si, int64(), sparse_data, this->shape_, this->dim_names_));
 
   // OK with an empty dim_names
-  ASSERT_OK(SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, this->shape_, {}));
+  ASSERT_OK(SparseCSRMatrix::Make(si, int64(), sparse_data, this->shape_, {}));
 
   // invalid data type
   ASSERT_RAISES(Invalid,
-                SparseCSRMatrix::MakeSafe(si, binary(), sparse_data, this->shape_, {}));
+                SparseCSRMatrix::Make(si, binary(), sparse_data, this->shape_, {}));
 
   // empty shape
-  ASSERT_RAISES(Invalid, SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, {}, {}));
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {}, {}));
 
   // 1D shape
-  ASSERT_RAISES(Invalid, SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, {24}, {}));
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {24}, {}));
 
   // negative items in shape
-  ASSERT_RAISES(Invalid,
-                SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, {6, -4}, {}));
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {6, -4}, {}));
 
   // sparse index and ndim (shape length) are inconsistent
-  ASSERT_RAISES(Invalid, SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, {4, 6}, {}));
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {4, 6}, {}));
 
   // shape and dim_names are inconsistent
-  ASSERT_RAISES(Invalid, SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, this->shape_,
-                                                   std::vector<std::string>{"foo"}));
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, this->shape_,
+                                               std::vector<std::string>{"foo"}));
 }
 
 REGISTER_TYPED_TEST_CASE_P(TestSparseCSRMatrixForIndexValueType, Make);

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -55,20 +55,20 @@ TEST(TestSparseCOOIndex, Make) {
   std::vector<int64_t> stride = {3 * sizeof(int32_t), sizeof(int32_t)};
 
   // OK
-  auto res = SparseCOOIndex::Make(int32(), shape, stride, data);
+  auto res = SparseCOOIndex::MakeSafe(int32(), shape, stride, data);
   ASSERT_OK(res);
 
   // Non-integer type
-  res = SparseCOOIndex::Make(float32(), shape, stride, data);
+  res = SparseCOOIndex::MakeSafe(float32(), shape, stride, data);
   ASSERT_RAISES(Invalid, res);
 
   // Non-matrix indices
-  res = SparseCOOIndex::Make(int32(), {4, 3, 4}, stride, data);
+  res = SparseCOOIndex::MakeSafe(int32(), {4, 3, 4}, stride, data);
   ASSERT_RAISES(Invalid, res);
 
   // Non-contiguous indices
-  res = SparseCOOIndex::Make(int32(), {6, 3}, {6 * sizeof(int32_t), 2 * sizeof(int32_t)},
-                             data);
+  res = SparseCOOIndex::MakeSafe(int32(), {6, 3},
+                                 {6 * sizeof(int32_t), 2 * sizeof(int32_t)}, data);
   ASSERT_RAISES(Invalid, res);
 }
 
@@ -81,21 +81,23 @@ TEST(TestSparseCSRIndex, Make) {
   std::vector<int64_t> indices_shape = {12};
 
   // OK
-  auto res = SparseCSRIndex::Make(int32(), indptr_shape, indices_shape, indptr_data,
-                                  indices_data);
+  auto res = SparseCSRIndex::MakeSafe(int32(), indptr_shape, indices_shape, indptr_data,
+                                      indices_data);
   ASSERT_OK(res);
 
   // Non-integer type
-  res = SparseCSRIndex::Make(float32(), indptr_shape, indices_shape, indptr_data,
-                             indices_data);
+  res = SparseCSRIndex::MakeSafe(float32(), indptr_shape, indices_shape, indptr_data,
+                                 indices_data);
   ASSERT_RAISES(Invalid, res);
 
   // Non-vector indptr shape
-  res = SparseCSRIndex::Make(int32(), {1, 2}, indices_shape, indptr_data, indices_data);
+  res =
+      SparseCSRIndex::MakeSafe(int32(), {1, 2}, indices_shape, indptr_data, indices_data);
   ASSERT_RAISES(Invalid, res);
 
   // Non-vector indices shape
-  res = SparseCSRIndex::Make(int32(), indptr_shape, {1, 2}, indptr_data, indices_data);
+  res =
+      SparseCSRIndex::MakeSafe(int32(), indptr_shape, {1, 2}, indptr_data, indices_data);
   ASSERT_RAISES(Invalid, res);
 }
 
@@ -123,9 +125,9 @@ class TestSparseCOOTensorBase : public ::testing::Test {
                                          0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
     auto dense_data = Buffer::Wrap(dense_values);
     NumericTensor<Int64Type> dense_tensor(dense_data, shape_, {}, dim_names_);
-    ASSERT_OK(
-        SparseCOOTensor::Make(dense_tensor, TypeTraits<IndexValueType>::type_singleton())
-            .Value(&sparse_tensor_from_dense_));
+    ASSERT_OK(SparseCOOTensor::MakeSafe(dense_tensor,
+                                        TypeTraits<IndexValueType>::type_singleton())
+                  .Value(&sparse_tensor_from_dense_));
   }
 
  protected:
@@ -189,7 +191,7 @@ TEST_F(TestSparseCOOTensor, CreationFromNumericTensor1D) {
   NumericTensor<Int64Type> dense_vector(dense_data, dense_shape);
 
   std::shared_ptr<SparseCOOTensor> st;
-  ASSERT_OK(SparseCOOTensor::Make(dense_vector).Value(&st));
+  ASSERT_OK(SparseCOOTensor::MakeSafe(dense_vector).Value(&st));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -215,7 +217,7 @@ TEST_F(TestSparseCOOTensor, CreationFromTensor) {
   Tensor tensor(int64(), buffer, this->shape_, {}, this->dim_names_);
 
   std::shared_ptr<SparseCOOTensor> st;
-  ASSERT_OK(SparseCOOTensor::Make(tensor).Value(&st));
+  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor).Value(&st));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -237,7 +239,7 @@ TEST_F(TestSparseCOOTensor, CreationFromNonContiguousTensor) {
   Tensor tensor(int64(), buffer, this->shape_, strides);
 
   std::shared_ptr<SparseCOOTensor> st;
-  ASSERT_OK(SparseCOOTensor::Make(tensor).Value(&st));
+  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor).Value(&st));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -256,10 +258,10 @@ TEST_F(TestSparseCOOTensor, TensorEquality) {
   NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
 
   std::shared_ptr<SparseCOOTensor> st1;
-  ASSERT_OK(SparseCOOTensor::Make(tensor1).Value(&st1));
+  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor1).Value(&st1));
 
   std::shared_ptr<SparseCOOTensor> st2;
-  ASSERT_OK(SparseCOOTensor::Make(tensor2).Value(&st2));
+  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor2).Value(&st2));
 
   ASSERT_TRUE(st1->Equals(*this->sparse_tensor_from_dense_));
   ASSERT_FALSE(st1->Equals(*st2));
@@ -273,7 +275,7 @@ TEST_F(TestSparseCOOTensor, TestToTensor) {
   Tensor tensor(int64(), buffer, shape, {}, this->dim_names_);
 
   std::shared_ptr<SparseCOOTensor> sparse_tensor;
-  ASSERT_OK(SparseCOOTensor::Make(tensor).Value(&sparse_tensor));
+  ASSERT_OK(SparseCOOTensor::MakeSafe(tensor).Value(&sparse_tensor));
 
   ASSERT_EQ(5, sparse_tensor->non_zero_length());
   ASSERT_TRUE(sparse_tensor->is_mutable());
@@ -332,28 +334,28 @@ TYPED_TEST_P(TestSparseCOOTensorForIndexValueType, Make) {
 
   // OK
   auto res =
-      SparseCOOTensor::Make(si, int64(), sparse_data, this->shape_, this->dim_names_);
+      SparseCOOTensor::MakeSafe(si, int64(), sparse_data, this->shape_, this->dim_names_);
   ASSERT_OK(res);
 
   // OK with an empty dim_names
-  res = SparseCOOTensor::Make(si, int64(), sparse_data, this->shape_, {});
+  res = SparseCOOTensor::MakeSafe(si, int64(), sparse_data, this->shape_, {});
   ASSERT_OK(res);
 
   // invalid data type
-  res = SparseCOOTensor::Make(si, binary(), sparse_data, this->shape_, {});
+  res = SparseCOOTensor::MakeSafe(si, binary(), sparse_data, this->shape_, {});
   ASSERT_RAISES(Invalid, res);
 
   // negative items in shape
-  res = SparseCOOTensor::Make(si, int64(), sparse_data, {2, -3, 4}, {});
+  res = SparseCOOTensor::MakeSafe(si, int64(), sparse_data, {2, -3, 4}, {});
   ASSERT_RAISES(Invalid, res);
 
   // sparse index and ndim (shape length) are inconsistent
-  res = SparseCOOTensor::Make(si, int64(), sparse_data, {6, 4}, {});
+  res = SparseCOOTensor::MakeSafe(si, int64(), sparse_data, {6, 4}, {});
   ASSERT_RAISES(Invalid, res);
 
   // shape and dim_names are inconsistent
-  res = SparseCOOTensor::Make(si, int64(), sparse_data, this->shape_,
-                              std::vector<std::string>{"foo"});
+  res = SparseCOOTensor::MakeSafe(si, int64(), sparse_data, this->shape_,
+                                  std::vector<std::string>{"foo"});
   ASSERT_RAISES(Invalid, res);
 }
 
@@ -485,9 +487,9 @@ class TestSparseCSRMatrixBase : public ::testing::Test {
                                          0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
     auto dense_data = Buffer::Wrap(dense_values);
     NumericTensor<Int64Type> dense_tensor(dense_data, shape_, {}, dim_names_);
-    ASSERT_OK(
-        SparseCSRMatrix::Make(dense_tensor, TypeTraits<IndexValueType>::type_singleton())
-            .Value(&sparse_tensor_from_dense_));
+    ASSERT_OK(SparseCSRMatrix::MakeSafe(dense_tensor,
+                                        TypeTraits<IndexValueType>::type_singleton())
+                  .Value(&sparse_tensor_from_dense_));
   }
 
  protected:
@@ -505,7 +507,7 @@ TEST_F(TestSparseCSRMatrix, CreationFromNumericTensor2D) {
   NumericTensor<Int64Type> tensor(buffer, this->shape_);
 
   std::shared_ptr<SparseCSRMatrix> st1;
-  ASSERT_OK(SparseCSRMatrix::Make(tensor).Value(&st1));
+  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor).Value(&st1));
 
   auto st2 = this->sparse_tensor_from_dense_;
 
@@ -557,7 +559,7 @@ TEST_F(TestSparseCSRMatrix, CreationFromNonContiguousTensor) {
   Tensor tensor(int64(), buffer, this->shape_, strides);
 
   std::shared_ptr<SparseCSRMatrix> st;
-  ASSERT_OK(SparseCSRMatrix::Make(tensor).Value(&st));
+  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor).Value(&st));
 
   ASSERT_EQ(12, st->non_zero_length());
   ASSERT_TRUE(st->is_mutable());
@@ -599,8 +601,8 @@ TEST_F(TestSparseCSRMatrix, TensorEquality) {
   NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
 
   std::shared_ptr<SparseCSRMatrix> st1, st2;
-  ASSERT_OK(SparseCSRMatrix::Make(tensor1).Value(&st1));
-  ASSERT_OK(SparseCSRMatrix::Make(tensor2).Value(&st2));
+  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor1).Value(&st1));
+  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor2).Value(&st2));
 
   ASSERT_TRUE(st1->Equals(*this->sparse_tensor_from_dense_));
   ASSERT_FALSE(st1->Equals(*st2));
@@ -614,7 +616,7 @@ TEST_F(TestSparseCSRMatrix, TestToTensor) {
   Tensor tensor(int64(), buffer, shape, {}, this->dim_names_);
 
   std::shared_ptr<SparseCSRMatrix> sparse_tensor;
-  ASSERT_OK(SparseCSRMatrix::Make(tensor).Value(&sparse_tensor));
+  ASSERT_OK(SparseCSRMatrix::MakeSafe(tensor).Value(&sparse_tensor));
 
   ASSERT_EQ(7, sparse_tensor->non_zero_length());
   ASSERT_TRUE(sparse_tensor->is_mutable());
@@ -642,9 +644,9 @@ TYPED_TEST_P(TestSparseCSRMatrixForIndexValueType, Make) {
   std::vector<int64_t> indices_shape = {12};
 
   std::shared_ptr<SparseCSRIndex> si;
-  ASSERT_OK(SparseCSRIndex::Make(TypeTraits<IndexValueType>::type_singleton(),
-                                 indptr_shape, indices_shape, Buffer::Wrap(indptr_values),
-                                 Buffer::Wrap(indices_values))
+  ASSERT_OK(SparseCSRIndex::MakeSafe(
+                TypeTraits<IndexValueType>::type_singleton(), indptr_shape, indices_shape,
+                Buffer::Wrap(indptr_values), Buffer::Wrap(indices_values))
                 .Value(&si));
 
   std::vector<int64_t> sparse_values = {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16};
@@ -653,31 +655,32 @@ TYPED_TEST_P(TestSparseCSRMatrixForIndexValueType, Make) {
   std::shared_ptr<SparseCSRMatrix> sm;
 
   // OK
-  ASSERT_OK(
-      SparseCSRMatrix::Make(si, int64(), sparse_data, this->shape_, this->dim_names_));
+  ASSERT_OK(SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, this->shape_,
+                                      this->dim_names_));
 
   // OK with an empty dim_names
-  ASSERT_OK(SparseCSRMatrix::Make(si, int64(), sparse_data, this->shape_, {}));
+  ASSERT_OK(SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, this->shape_, {}));
 
   // invalid data type
   ASSERT_RAISES(Invalid,
-                SparseCSRMatrix::Make(si, binary(), sparse_data, this->shape_, {}));
+                SparseCSRMatrix::MakeSafe(si, binary(), sparse_data, this->shape_, {}));
 
   // empty shape
-  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {}, {}));
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, {}, {}));
 
   // 1D shape
-  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {24}, {}));
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, {24}, {}));
 
   // negative items in shape
-  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {6, -4}, {}));
+  ASSERT_RAISES(Invalid,
+                SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, {6, -4}, {}));
 
   // sparse index and ndim (shape length) are inconsistent
-  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, {4, 6}, {}));
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, {4, 6}, {}));
 
   // shape and dim_names are inconsistent
-  ASSERT_RAISES(Invalid, SparseCSRMatrix::Make(si, int64(), sparse_data, this->shape_,
-                                               std::vector<std::string>{"foo"}));
+  ASSERT_RAISES(Invalid, SparseCSRMatrix::MakeSafe(si, int64(), sparse_data, this->shape_,
+                                                   std::vector<std::string>{"foo"}));
 }
 
 REGISTER_TYPED_TEST_CASE_P(TestSparseCSRMatrixForIndexValueType, Make);

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/tensor.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -88,6 +89,9 @@ inline Status CheckTensorValidity(const std::shared_ptr<DataType>& type,
   }
   if (shape.size() == 0) {
     return Status::Invalid("Empty shape is supplied");
+  }
+  if (!std::all_of(shape.begin(), shape.end(), [](int64_t x) { return x > 0; })) {
+    return Status::Invalid("Shape elements must be positive");
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -113,12 +113,13 @@ Status CheckTensorStridesValidity(const std::shared_ptr<Buffer>& data,
 
 }  // namespace
 
-Status Tensor::Make(const std::shared_ptr<DataType>& type,
-                    const std::shared_ptr<Buffer>& data,
-                    const std::vector<int64_t>& shape,
-                    const std::vector<int64_t>& strides,
-                    const std::vector<std::string>& dim_names,
-                    std::shared_ptr<Tensor>* out) {
+namespace internal {
+
+Status ValidateTensorParameters(const std::shared_ptr<DataType>& type,
+                                const std::shared_ptr<Buffer>& data,
+                                const std::vector<int64_t>& shape,
+                                const std::vector<int64_t>& strides,
+                                const std::vector<std::string>& dim_names) {
   RETURN_NOT_OK(CheckTensorValidity(type, data, shape));
   if (!strides.empty()) {
     RETURN_NOT_OK(CheckTensorStridesValidity(data, shape, strides));
@@ -126,22 +127,10 @@ Status Tensor::Make(const std::shared_ptr<DataType>& type,
   if (dim_names.size() > shape.size()) {
     return Status::Invalid("too many dim_names are supplied");
   }
-  *out = std::make_shared<Tensor>(type, data, shape, strides, dim_names);
   return Status::OK();
 }
 
-Status Tensor::Make(const std::shared_ptr<DataType>& type,
-                    const std::shared_ptr<Buffer>& data,
-                    const std::vector<int64_t>& shape,
-                    const std::vector<int64_t>& strides, std::shared_ptr<Tensor>* out) {
-  return Make(type, data, shape, strides, {}, out);
-}
-
-Status Tensor::Make(const std::shared_ptr<DataType>& type,
-                    const std::shared_ptr<Buffer>& data,
-                    const std::vector<int64_t>& shape, std::shared_ptr<Tensor>* out) {
-  return Make(type, data, shape, {}, {}, out);
-}
+}  // namespace internal
 
 /// Constructor with strides and dimension names
 Tensor::Tensor(const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -105,9 +105,6 @@ inline Status CheckTensorValidity(const std::shared_ptr<DataType>& type,
   if (!data) {
     return Status::Invalid("Null data is supplied");
   }
-  if (shape.size() == 0) {
-    return Status::Invalid("Empty shape is supplied");
-  }
   if (!std::all_of(shape.begin(), shape.end(), [](int64_t x) { return x > 0; })) {
     return Status::Invalid("Shape elements must be positive");
   }

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -219,6 +219,59 @@ class NumericTensor : public Tensor {
   using TypeClass = TYPE;
   using value_type = typename TypeClass::c_type;
 
+  /// \brief Create a NumericTensor with full parameters
+  ///
+  /// This factory function will return Status::Invalid when the parameters are
+  /// inconsistent
+  ///
+  /// \param[in] data The buffer of the tensor content
+  /// \param[in] shape The shape of the tensor
+  /// \param[in] strides The strides of the tensor
+  ///            (if this is empty, the data assumed to be row-major)
+  /// \param[in] dim_names The names of the tensor dimensions
+  /// \param[out] out The result tensor
+  static Status Make(const std::shared_ptr<Buffer>& data,
+                     const std::vector<int64_t>& shape,
+                     const std::vector<int64_t>& strides,
+                     const std::vector<std::string>& dim_names,
+                     std::shared_ptr<NumericTensor<TYPE>>* out) {
+    ARROW_RETURN_NOT_OK(internal::ValidateTensorParameters(
+        TypeTraits<TYPE>::type_singleton(), data, shape, strides, dim_names));
+    *out = std::make_shared<NumericTensor<TYPE>>(data, shape, strides, dim_names);
+    return Status::OK();
+  }
+
+  /// \brief Create a NumericTensor with full parameters with empty dim_names
+  ///
+  /// This factory function will return Status::Invalid when the parameters are
+  /// inconsistent
+  ///
+  /// \param[in] data The buffer of the tensor content
+  /// \param[in] shape The shape of the tensor
+  /// \param[in] strides The strides of the tensor
+  /// \param[out] out The result tensor
+  static Status Make(const std::shared_ptr<Buffer>& data,
+                     const std::vector<int64_t>& shape,
+                     const std::vector<int64_t>& strides,
+                     std::shared_ptr<NumericTensor<TYPE>>* out) {
+    return Make(data, shape, strides, {}, out);
+  }
+
+  /// \brief Create a NumericTensor with full parameters with empty strides and empty
+  /// dim_names, the data assumed to be row-major
+  ///
+  /// This factory function will return Status::Invalid when the parameters are
+  /// inconsistent
+  ///
+  /// \param[in] data The buffer of the tensor content
+  /// \param[in] shape The shape of the tensor
+  /// \param[out] out The result tensor
+  static Status Make(const std::shared_ptr<Buffer>& data,
+                     const std::vector<int64_t>& shape,
+                     std::shared_ptr<NumericTensor<TYPE>>* out) {
+    return Make(data, shape, {}, {}, out);
+  }
+
   /// Constructor with non-negative strides and dimension names
   NumericTensor(const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
                 const std::vector<int64_t>& strides,

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -108,25 +108,6 @@ class ARROW_EXPORT Tensor {
     return Make(type, data, shape, strides, {}, out);
   }
 
-  /// \brief Create a Tensor with full parameters with empty strides, the data assumed to
-  /// be row-major
-  ///
-  /// This factory function will return Status::Invalid when the parameters are
-  /// inconsistent
-  ///
-  /// \param[in] type The data type of the tensor values
-  /// \param[in] data The buffer of the tensor content
-  /// \param[in] shape The shape of the tensor
-  /// \param[in] dim_names The names of the tensor dimensions
-  /// \param[out] out The result tensor
-  static Status Make(const std::shared_ptr<DataType>& type,
-                     const std::shared_ptr<Buffer>& data,
-                     const std::vector<int64_t>& shape,
-                     const std::vector<std::string>& dim_names,
-                     std::shared_ptr<Tensor>* out) {
-    return Make(type, data, shape, {}, dim_names, out);
-  }
-
   /// \brief Create a Tensor with full parameters with empty dim_names, the data assumed
   /// to be row-major
   ///

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -57,13 +57,19 @@ class SparseTensorImpl;
 
 namespace internal {
 
+ARROW_EXPORT
+bool IsTensorStridesContiguous(const std::shared_ptr<DataType>& type,
+                               const std::vector<int64_t>& shape,
+                               const std::vector<int64_t>& strides);
+
+ARROW_EXPORT
 Status ValidateTensorParameters(const std::shared_ptr<DataType>& type,
                                 const std::shared_ptr<Buffer>& data,
                                 const std::vector<int64_t>& shape,
                                 const std::vector<int64_t>& strides,
                                 const std::vector<std::string>& dim_names);
 
-}
+}  // namespace internal
 
 class ARROW_EXPORT Tensor {
  public:

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -85,10 +85,11 @@ class ARROW_EXPORT Tensor {
   /// \param[in] strides The strides of the tensor
   ///            (if this is empty, the data assumed to be row-major)
   /// \param[in] dim_names The names of the tensor dimensions
-  static Result<std::shared_ptr<Tensor>> MakeSafe(
-      const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
-      const std::vector<int64_t>& shape, const std::vector<int64_t>& strides,
-      const std::vector<std::string>& dim_names) {
+  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
+                                              const std::shared_ptr<Buffer>& data,
+                                              const std::vector<int64_t>& shape,
+                                              const std::vector<int64_t>& strides,
+                                              const std::vector<std::string>& dim_names) {
     ARROW_RETURN_NOT_OK(
         internal::ValidateTensorParameters(type, data, shape, strides, dim_names));
     return std::make_shared<Tensor>(type, data, shape, strides, dim_names);
@@ -103,11 +104,11 @@ class ARROW_EXPORT Tensor {
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
   /// \param[in] strides The strides of the tensor
-  static Result<std::shared_ptr<Tensor>> MakeSafe(const std::shared_ptr<DataType>& type,
-                                                  const std::shared_ptr<Buffer>& data,
-                                                  const std::vector<int64_t>& shape,
-                                                  const std::vector<int64_t>& strides) {
-    return MakeSafe(type, data, shape, strides, {});
+  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
+                                              const std::shared_ptr<Buffer>& data,
+                                              const std::vector<int64_t>& shape,
+                                              const std::vector<int64_t>& strides) {
+    return Make(type, data, shape, strides, {});
   }
 
   /// \brief Create a Tensor with full parameters with empty dim_names, the data assumed
@@ -119,10 +120,10 @@ class ARROW_EXPORT Tensor {
   /// \param[in] type The data type of the tensor values
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
-  static Result<std::shared_ptr<Tensor>> MakeSafe(const std::shared_ptr<DataType>& type,
-                                                  const std::shared_ptr<Buffer>& data,
-                                                  const std::vector<int64_t>& shape) {
-    return MakeSafe(type, data, shape, {}, {});
+  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
+                                              const std::shared_ptr<Buffer>& data,
+                                              const std::vector<int64_t>& shape) {
+    return Make(type, data, shape, {}, {});
   }
 
   virtual ~Tensor() = default;
@@ -230,7 +231,7 @@ class NumericTensor : public Tensor {
   /// \param[in] strides The strides of the tensor
   ///            (if this is empty, the data assumed to be row-major)
   /// \param[in] dim_names The names of the tensor dimensions
-  static Result<std::shared_ptr<NumericTensor<TYPE>>> MakeSafe(
+  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
       const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
       const std::vector<int64_t>& strides, const std::vector<std::string>& dim_names) {
     ARROW_RETURN_NOT_OK(internal::ValidateTensorParameters(
@@ -246,10 +247,10 @@ class NumericTensor : public Tensor {
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
   /// \param[in] strides The strides of the tensor
-  static Result<std::shared_ptr<NumericTensor<TYPE>>> MakeSafe(
+  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
       const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
       const std::vector<int64_t>& strides) {
-    return MakeSafe(data, shape, strides, {});
+    return Make(data, shape, strides, {});
   }
 
   /// \brief Create a NumericTensor with full parameters with empty strides and empty
@@ -260,9 +261,9 @@ class NumericTensor : public Tensor {
   ///
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
-  static Result<std::shared_ptr<NumericTensor<TYPE>>> MakeSafe(
+  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
       const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape) {
-    return MakeSafe(data, shape, {}, {});
+    return Make(data, shape, {}, {});
   }
 
   /// Constructor with non-negative strides and dimension names

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -85,45 +85,13 @@ class ARROW_EXPORT Tensor {
   /// \param[in] strides The strides of the tensor
   ///            (if this is empty, the data assumed to be row-major)
   /// \param[in] dim_names The names of the tensor dimensions
-  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
-                                              const std::shared_ptr<Buffer>& data,
-                                              const std::vector<int64_t>& shape,
-                                              const std::vector<int64_t>& strides,
-                                              const std::vector<std::string>& dim_names) {
+  static inline Result<std::shared_ptr<Tensor>> Make(
+      const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
+      const std::vector<int64_t>& shape, const std::vector<int64_t>& strides = {},
+      const std::vector<std::string>& dim_names = {}) {
     ARROW_RETURN_NOT_OK(
         internal::ValidateTensorParameters(type, data, shape, strides, dim_names));
     return std::make_shared<Tensor>(type, data, shape, strides, dim_names);
-  }
-
-  /// \brief Create a Tensor with full parameters with empty dim_names
-  ///
-  /// This factory function will return Status::Invalid when the parameters are
-  /// inconsistent
-  ///
-  /// \param[in] type The data type of the tensor values
-  /// \param[in] data The buffer of the tensor content
-  /// \param[in] shape The shape of the tensor
-  /// \param[in] strides The strides of the tensor
-  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
-                                              const std::shared_ptr<Buffer>& data,
-                                              const std::vector<int64_t>& shape,
-                                              const std::vector<int64_t>& strides) {
-    return Make(type, data, shape, strides, {});
-  }
-
-  /// \brief Create a Tensor with full parameters with empty dim_names, the data assumed
-  /// to be row-major
-  ///
-  /// This factory function will return Status::Invalid when the
-  /// parameters are inconsistent
-  ///
-  /// \param[in] type The data type of the tensor values
-  /// \param[in] data The buffer of the tensor content
-  /// \param[in] shape The shape of the tensor
-  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
-                                              const std::shared_ptr<Buffer>& data,
-                                              const std::vector<int64_t>& shape) {
-    return Make(type, data, shape, {}, {});
   }
 
   virtual ~Tensor() = default;
@@ -233,37 +201,11 @@ class NumericTensor : public Tensor {
   /// \param[in] dim_names The names of the tensor dimensions
   static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
       const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
-      const std::vector<int64_t>& strides, const std::vector<std::string>& dim_names) {
+      const std::vector<int64_t>& strides = {},
+      const std::vector<std::string>& dim_names = {}) {
     ARROW_RETURN_NOT_OK(internal::ValidateTensorParameters(
         TypeTraits<TYPE>::type_singleton(), data, shape, strides, dim_names));
     return std::make_shared<NumericTensor<TYPE>>(data, shape, strides, dim_names);
-  }
-
-  /// \brief Create a NumericTensor with full parameters with empty dim_names
-  ///
-  /// This factory function will return Status::Invalid when the parameters are
-  /// inconsistent
-  ///
-  /// \param[in] data The buffer of the tensor content
-  /// \param[in] shape The shape of the tensor
-  /// \param[in] strides The strides of the tensor
-  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
-      const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
-      const std::vector<int64_t>& strides) {
-    return Make(data, shape, strides, {});
-  }
-
-  /// \brief Create a NumericTensor with full parameters with empty strides and empty
-  /// dim_names, the data assumed to be row-major
-  ///
-  /// This factory function will return Status::Invalid when the parameters are
-  /// inconsistent
-  ///
-  /// \param[in] data The buffer of the tensor content
-  /// \param[in] shape The shape of the tensor
-  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
-      const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape) {
-    return Make(data, shape, {}, {});
   }
 
   /// Constructor with non-negative strides and dimension names

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -85,11 +85,10 @@ class ARROW_EXPORT Tensor {
   /// \param[in] strides The strides of the tensor
   ///            (if this is empty, the data assumed to be row-major)
   /// \param[in] dim_names The names of the tensor dimensions
-  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
-                                              const std::shared_ptr<Buffer>& data,
-                                              const std::vector<int64_t>& shape,
-                                              const std::vector<int64_t>& strides,
-                                              const std::vector<std::string>& dim_names) {
+  static Result<std::shared_ptr<Tensor>> MakeSafe(
+      const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data,
+      const std::vector<int64_t>& shape, const std::vector<int64_t>& strides,
+      const std::vector<std::string>& dim_names) {
     ARROW_RETURN_NOT_OK(
         internal::ValidateTensorParameters(type, data, shape, strides, dim_names));
     return std::make_shared<Tensor>(type, data, shape, strides, dim_names);
@@ -104,11 +103,11 @@ class ARROW_EXPORT Tensor {
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
   /// \param[in] strides The strides of the tensor
-  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
-                                              const std::shared_ptr<Buffer>& data,
-                                              const std::vector<int64_t>& shape,
-                                              const std::vector<int64_t>& strides) {
-    return Make(type, data, shape, strides, {});
+  static Result<std::shared_ptr<Tensor>> MakeSafe(const std::shared_ptr<DataType>& type,
+                                                  const std::shared_ptr<Buffer>& data,
+                                                  const std::vector<int64_t>& shape,
+                                                  const std::vector<int64_t>& strides) {
+    return MakeSafe(type, data, shape, strides, {});
   }
 
   /// \brief Create a Tensor with full parameters with empty dim_names, the data assumed
@@ -120,10 +119,10 @@ class ARROW_EXPORT Tensor {
   /// \param[in] type The data type of the tensor values
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
-  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
-                                              const std::shared_ptr<Buffer>& data,
-                                              const std::vector<int64_t>& shape) {
-    return Make(type, data, shape, {}, {});
+  static Result<std::shared_ptr<Tensor>> MakeSafe(const std::shared_ptr<DataType>& type,
+                                                  const std::shared_ptr<Buffer>& data,
+                                                  const std::vector<int64_t>& shape) {
+    return MakeSafe(type, data, shape, {}, {});
   }
 
   virtual ~Tensor() = default;
@@ -231,7 +230,7 @@ class NumericTensor : public Tensor {
   /// \param[in] strides The strides of the tensor
   ///            (if this is empty, the data assumed to be row-major)
   /// \param[in] dim_names The names of the tensor dimensions
-  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
+  static Result<std::shared_ptr<NumericTensor<TYPE>>> MakeSafe(
       const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
       const std::vector<int64_t>& strides, const std::vector<std::string>& dim_names) {
     ARROW_RETURN_NOT_OK(internal::ValidateTensorParameters(
@@ -247,10 +246,10 @@ class NumericTensor : public Tensor {
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
   /// \param[in] strides The strides of the tensor
-  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
+  static Result<std::shared_ptr<NumericTensor<TYPE>>> MakeSafe(
       const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
       const std::vector<int64_t>& strides) {
-    return Make(data, shape, strides, {});
+    return MakeSafe(data, shape, strides, {});
   }
 
   /// \brief Create a NumericTensor with full parameters with empty strides and empty
@@ -261,9 +260,9 @@ class NumericTensor : public Tensor {
   ///
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
-  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
+  static Result<std::shared_ptr<NumericTensor<TYPE>>> MakeSafe(
       const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape) {
-    return Make(data, shape, {}, {});
+    return MakeSafe(data, shape, {}, {});
   }
 
   /// Constructor with non-negative strides and dimension names

--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -25,6 +25,7 @@
 
 #include "arrow/buffer.h"
 #include "arrow/compare.h"
+#include "arrow/result.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/macros.h"
@@ -84,17 +85,14 @@ class ARROW_EXPORT Tensor {
   /// \param[in] strides The strides of the tensor
   ///            (if this is empty, the data assumed to be row-major)
   /// \param[in] dim_names The names of the tensor dimensions
-  /// \param[out] out The result tensor
-  static Status Make(const std::shared_ptr<DataType>& type,
-                     const std::shared_ptr<Buffer>& data,
-                     const std::vector<int64_t>& shape,
-                     const std::vector<int64_t>& strides,
-                     const std::vector<std::string>& dim_names,
-                     std::shared_ptr<Tensor>* out) {
+  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
+                                              const std::shared_ptr<Buffer>& data,
+                                              const std::vector<int64_t>& shape,
+                                              const std::vector<int64_t>& strides,
+                                              const std::vector<std::string>& dim_names) {
     ARROW_RETURN_NOT_OK(
         internal::ValidateTensorParameters(type, data, shape, strides, dim_names));
-    *out = std::make_shared<Tensor>(type, data, shape, strides, dim_names);
-    return Status::OK();
+    return std::make_shared<Tensor>(type, data, shape, strides, dim_names);
   }
 
   /// \brief Create a Tensor with full parameters with empty dim_names
@@ -106,12 +104,11 @@ class ARROW_EXPORT Tensor {
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
   /// \param[in] strides The strides of the tensor
-  /// \param[out] out The result tensor
-  static Status Make(const std::shared_ptr<DataType>& type,
-                     const std::shared_ptr<Buffer>& data,
-                     const std::vector<int64_t>& shape,
-                     const std::vector<int64_t>& strides, std::shared_ptr<Tensor>* out) {
-    return Make(type, data, shape, strides, {}, out);
+  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
+                                              const std::shared_ptr<Buffer>& data,
+                                              const std::vector<int64_t>& shape,
+                                              const std::vector<int64_t>& strides) {
+    return Make(type, data, shape, strides, {});
   }
 
   /// \brief Create a Tensor with full parameters with empty dim_names, the data assumed
@@ -123,11 +120,10 @@ class ARROW_EXPORT Tensor {
   /// \param[in] type The data type of the tensor values
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
-  /// \param[out] out The result tensor
-  static Status Make(const std::shared_ptr<DataType>& type,
-                     const std::shared_ptr<Buffer>& data,
-                     const std::vector<int64_t>& shape, std::shared_ptr<Tensor>* out) {
-    return Make(type, data, shape, {}, {}, out);
+  static Result<std::shared_ptr<Tensor>> Make(const std::shared_ptr<DataType>& type,
+                                              const std::shared_ptr<Buffer>& data,
+                                              const std::vector<int64_t>& shape) {
+    return Make(type, data, shape, {}, {});
   }
 
   virtual ~Tensor() = default;
@@ -235,16 +231,12 @@ class NumericTensor : public Tensor {
   /// \param[in] strides The strides of the tensor
   ///            (if this is empty, the data assumed to be row-major)
   /// \param[in] dim_names The names of the tensor dimensions
-  /// \param[out] out The result tensor
-  static Status Make(const std::shared_ptr<Buffer>& data,
-                     const std::vector<int64_t>& shape,
-                     const std::vector<int64_t>& strides,
-                     const std::vector<std::string>& dim_names,
-                     std::shared_ptr<NumericTensor<TYPE>>* out) {
+  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
+      const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
+      const std::vector<int64_t>& strides, const std::vector<std::string>& dim_names) {
     ARROW_RETURN_NOT_OK(internal::ValidateTensorParameters(
         TypeTraits<TYPE>::type_singleton(), data, shape, strides, dim_names));
-    *out = std::make_shared<NumericTensor<TYPE>>(data, shape, strides, dim_names);
-    return Status::OK();
+    return std::make_shared<NumericTensor<TYPE>>(data, shape, strides, dim_names);
   }
 
   /// \brief Create a NumericTensor with full parameters with empty dim_names
@@ -255,12 +247,10 @@ class NumericTensor : public Tensor {
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
   /// \param[in] strides The strides of the tensor
-  /// \param[out] out The result tensor
-  static Status Make(const std::shared_ptr<Buffer>& data,
-                     const std::vector<int64_t>& shape,
-                     const std::vector<int64_t>& strides,
-                     std::shared_ptr<NumericTensor<TYPE>>* out) {
-    return Make(data, shape, strides, {}, out);
+  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
+      const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape,
+      const std::vector<int64_t>& strides) {
+    return Make(data, shape, strides, {});
   }
 
   /// \brief Create a NumericTensor with full parameters with empty strides and empty
@@ -271,11 +261,9 @@ class NumericTensor : public Tensor {
   ///
   /// \param[in] data The buffer of the tensor content
   /// \param[in] shape The shape of the tensor
-  /// \param[out] out The result tensor
-  static Status Make(const std::shared_ptr<Buffer>& data,
-                     const std::vector<int64_t>& shape,
-                     std::shared_ptr<NumericTensor<TYPE>>* out) {
-    return Make(data, shape, {}, {}, out);
+  static Result<std::shared_ptr<NumericTensor<TYPE>>> Make(
+      const std::shared_ptr<Buffer>& data, const std::vector<int64_t>& shape) {
+    return Make(data, shape, {}, {});
   }
 
   /// Constructor with non-negative strides and dimension names

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -55,7 +55,7 @@ TEST(TestTensor, Make) {
   // without strides
   std::vector<std::string> dim_names = {"foo", "bar"};
   std::shared_ptr<Tensor> tensor3;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, dim_names, &tensor3));
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, {}, dim_names, &tensor3));
   EXPECT_TRUE(tensor3->Equals(*tensor1));
   EXPECT_TRUE(tensor3->Equals(*tensor2));
 

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -38,71 +38,68 @@ void AssertCountNonZero(const Tensor& t, int64_t expected) {
   ASSERT_EQ(count, expected);
 }
 
-TEST(TestTensor, MakeSafe) {
+TEST(TestTensor, Make) {
   // without strides and dim_names
   std::vector<int64_t> shape = {3, 6};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
   std::shared_ptr<Tensor> tensor1;
-  ASSERT_OK(Tensor::MakeSafe(float64(), data, shape).Value(&tensor1));
+  ASSERT_OK(Tensor::Make(float64(), data, shape).Value(&tensor1));
 
   // without dim_names
   std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::shared_ptr<Tensor> tensor2;
-  ASSERT_OK(Tensor::MakeSafe(float64(), data, {3, 6}, strides).Value(&tensor2));
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides).Value(&tensor2));
   EXPECT_TRUE(tensor2->Equals(*tensor1));
 
   // without strides
   std::vector<std::string> dim_names = {"foo", "bar"};
   std::shared_ptr<Tensor> tensor3;
-  ASSERT_OK(Tensor::MakeSafe(float64(), data, {3, 6}, {}, dim_names).Value(&tensor3));
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, {}, dim_names).Value(&tensor3));
   EXPECT_TRUE(tensor3->Equals(*tensor1));
   EXPECT_TRUE(tensor3->Equals(*tensor2));
 
   // supply all parameters
   std::shared_ptr<Tensor> tensor4;
-  ASSERT_OK(
-      Tensor::MakeSafe(float64(), data, {3, 6}, strides, dim_names).Value(&tensor4));
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides, dim_names).Value(&tensor4));
   EXPECT_TRUE(tensor4->Equals(*tensor1));
   EXPECT_TRUE(tensor4->Equals(*tensor2));
   EXPECT_TRUE(tensor4->Equals(*tensor3));
 }
 
-TEST(TestTensor, MakeSafeFailureCases) {
+TEST(TestTensor, MakeFailureCases) {
   std::vector<int64_t> shape = {3, 6};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
 
   // null type
-  ASSERT_RAISES(Invalid, Tensor::MakeSafe(nullptr, data, shape));
+  ASSERT_RAISES(Invalid, Tensor::Make(nullptr, data, shape));
 
   // invalid type
-  ASSERT_RAISES(Invalid, Tensor::MakeSafe(binary(), data, shape));
+  ASSERT_RAISES(Invalid, Tensor::Make(binary(), data, shape));
 
   // null data
-  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), nullptr, shape));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), nullptr, shape));
 
   // empty shape
-  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, {}));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {}));
 
   // negative items in shape
-  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, {-3, 6}));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {-3, 6}));
 
   // invalid stride length
-  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, shape, {sizeof(double)}));
-  ASSERT_RAISES(Invalid,
-                Tensor::MakeSafe(float64(), data, shape,
-                                 {sizeof(double), sizeof(double), sizeof(double)}));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {sizeof(double)}));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
+                                      {sizeof(double), sizeof(double), sizeof(double)}));
 
   // invalid stride values to involve buffer over run
-  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, shape,
-                                          {sizeof(double) * 6, sizeof(double) * 2}));
-  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, shape,
-                                          {sizeof(double) * 12, sizeof(double)}));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
+                                      {sizeof(double) * 6, sizeof(double) * 2}));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
+                                      {sizeof(double) * 12, sizeof(double)}));
 
   // too many dim_names are supplied
-  ASSERT_RAISES(Invalid,
-                Tensor::MakeSafe(float64(), data, shape, {}, {"foo", "bar", "baz"}));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {}, {"foo", "bar", "baz"}));
 }
 
 TEST(TestTensor, ZeroDim) {
@@ -425,32 +422,31 @@ REGISTER_TYPED_TEST_CASE_P(TestFloatTensor, Equals);
 INSTANTIATE_TYPED_TEST_CASE_P(Float32, TestFloatTensor, FloatType);
 INSTANTIATE_TYPED_TEST_CASE_P(Float64, TestFloatTensor, DoubleType);
 
-TEST(TestNumericTensor, MakeSafe) {
+TEST(TestNumericTensor, Make) {
   // without strides and dim_names
   std::vector<int64_t> shape = {3, 6};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
   std::shared_ptr<NumericTensor<DoubleType>> tensor1;
-  ASSERT_OK(NumericTensor<DoubleType>::MakeSafe(data, shape).Value(&tensor1));
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, shape).Value(&tensor1));
 
   // without dim_names
   std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::shared_ptr<NumericTensor<DoubleType>> tensor2;
-  ASSERT_OK(NumericTensor<DoubleType>::MakeSafe(data, {3, 6}, strides).Value(&tensor2));
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, strides).Value(&tensor2));
   EXPECT_TRUE(tensor2->Equals(*tensor1));
 
   // without strides
   std::vector<std::string> dim_names = {"foo", "bar"};
   std::shared_ptr<NumericTensor<DoubleType>> tensor3;
-  ASSERT_OK(
-      NumericTensor<DoubleType>::MakeSafe(data, {3, 6}, {}, dim_names).Value(&tensor3));
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, {}, dim_names).Value(&tensor3));
   EXPECT_TRUE(tensor3->Equals(*tensor1));
   EXPECT_TRUE(tensor3->Equals(*tensor2));
 
   // supply all parameters
   std::shared_ptr<NumericTensor<DoubleType>> tensor4;
-  ASSERT_OK(NumericTensor<DoubleType>::MakeSafe(data, {3, 6}, strides, dim_names)
-                .Value(&tensor4));
+  ASSERT_OK(
+      NumericTensor<DoubleType>::Make(data, {3, 6}, strides, dim_names).Value(&tensor4));
   EXPECT_TRUE(tensor4->Equals(*tensor1));
   EXPECT_TRUE(tensor4->Equals(*tensor2));
   EXPECT_TRUE(tensor4->Equals(*tensor3));

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -38,68 +38,71 @@ void AssertCountNonZero(const Tensor& t, int64_t expected) {
   ASSERT_EQ(count, expected);
 }
 
-TEST(TestTensor, Make) {
+TEST(TestTensor, MakeSafe) {
   // without strides and dim_names
   std::vector<int64_t> shape = {3, 6};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
   std::shared_ptr<Tensor> tensor1;
-  ASSERT_OK(Tensor::Make(float64(), data, shape).Value(&tensor1));
+  ASSERT_OK(Tensor::MakeSafe(float64(), data, shape).Value(&tensor1));
 
   // without dim_names
   std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::shared_ptr<Tensor> tensor2;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides).Value(&tensor2));
+  ASSERT_OK(Tensor::MakeSafe(float64(), data, {3, 6}, strides).Value(&tensor2));
   EXPECT_TRUE(tensor2->Equals(*tensor1));
 
   // without strides
   std::vector<std::string> dim_names = {"foo", "bar"};
   std::shared_ptr<Tensor> tensor3;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, {}, dim_names).Value(&tensor3));
+  ASSERT_OK(Tensor::MakeSafe(float64(), data, {3, 6}, {}, dim_names).Value(&tensor3));
   EXPECT_TRUE(tensor3->Equals(*tensor1));
   EXPECT_TRUE(tensor3->Equals(*tensor2));
 
   // supply all parameters
   std::shared_ptr<Tensor> tensor4;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides, dim_names).Value(&tensor4));
+  ASSERT_OK(
+      Tensor::MakeSafe(float64(), data, {3, 6}, strides, dim_names).Value(&tensor4));
   EXPECT_TRUE(tensor4->Equals(*tensor1));
   EXPECT_TRUE(tensor4->Equals(*tensor2));
   EXPECT_TRUE(tensor4->Equals(*tensor3));
 }
 
-TEST(TestTensor, MakeFailureCases) {
+TEST(TestTensor, MakeSafeFailureCases) {
   std::vector<int64_t> shape = {3, 6};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
 
   // null type
-  ASSERT_RAISES(Invalid, Tensor::Make(nullptr, data, shape));
+  ASSERT_RAISES(Invalid, Tensor::MakeSafe(nullptr, data, shape));
 
   // invalid type
-  ASSERT_RAISES(Invalid, Tensor::Make(binary(), data, shape));
+  ASSERT_RAISES(Invalid, Tensor::MakeSafe(binary(), data, shape));
 
   // null data
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), nullptr, shape));
+  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), nullptr, shape));
 
   // empty shape
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {}));
+  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, {}));
 
   // negative items in shape
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {-3, 6}));
+  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, {-3, 6}));
 
   // invalid stride length
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {sizeof(double)}));
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
-                                      {sizeof(double), sizeof(double), sizeof(double)}));
+  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, shape, {sizeof(double)}));
+  ASSERT_RAISES(Invalid,
+                Tensor::MakeSafe(float64(), data, shape,
+                                 {sizeof(double), sizeof(double), sizeof(double)}));
 
   // invalid stride values to involve buffer over run
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
-                                      {sizeof(double) * 6, sizeof(double) * 2}));
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
-                                      {sizeof(double) * 12, sizeof(double)}));
+  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, shape,
+                                          {sizeof(double) * 6, sizeof(double) * 2}));
+  ASSERT_RAISES(Invalid, Tensor::MakeSafe(float64(), data, shape,
+                                          {sizeof(double) * 12, sizeof(double)}));
 
   // too many dim_names are supplied
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {}, {"foo", "bar", "baz"}));
+  ASSERT_RAISES(Invalid,
+                Tensor::MakeSafe(float64(), data, shape, {}, {"foo", "bar", "baz"}));
 }
 
 TEST(TestTensor, ZeroDim) {
@@ -422,31 +425,32 @@ REGISTER_TYPED_TEST_CASE_P(TestFloatTensor, Equals);
 INSTANTIATE_TYPED_TEST_CASE_P(Float32, TestFloatTensor, FloatType);
 INSTANTIATE_TYPED_TEST_CASE_P(Float64, TestFloatTensor, DoubleType);
 
-TEST(TestNumericTensor, Make) {
+TEST(TestNumericTensor, MakeSafe) {
   // without strides and dim_names
   std::vector<int64_t> shape = {3, 6};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
   std::shared_ptr<NumericTensor<DoubleType>> tensor1;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, shape).Value(&tensor1));
+  ASSERT_OK(NumericTensor<DoubleType>::MakeSafe(data, shape).Value(&tensor1));
 
   // without dim_names
   std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::shared_ptr<NumericTensor<DoubleType>> tensor2;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, strides).Value(&tensor2));
+  ASSERT_OK(NumericTensor<DoubleType>::MakeSafe(data, {3, 6}, strides).Value(&tensor2));
   EXPECT_TRUE(tensor2->Equals(*tensor1));
 
   // without strides
   std::vector<std::string> dim_names = {"foo", "bar"};
   std::shared_ptr<NumericTensor<DoubleType>> tensor3;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, {}, dim_names).Value(&tensor3));
+  ASSERT_OK(
+      NumericTensor<DoubleType>::MakeSafe(data, {3, 6}, {}, dim_names).Value(&tensor3));
   EXPECT_TRUE(tensor3->Equals(*tensor1));
   EXPECT_TRUE(tensor3->Equals(*tensor2));
 
   // supply all parameters
   std::shared_ptr<NumericTensor<DoubleType>> tensor4;
-  ASSERT_OK(
-      NumericTensor<DoubleType>::Make(data, {3, 6}, strides, dim_names).Value(&tensor4));
+  ASSERT_OK(NumericTensor<DoubleType>::MakeSafe(data, {3, 6}, strides, dim_names)
+                .Value(&tensor4));
   EXPECT_TRUE(tensor4->Equals(*tensor1));
   EXPECT_TRUE(tensor4->Equals(*tensor2));
   EXPECT_TRUE(tensor4->Equals(*tensor3));

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -88,6 +88,20 @@ TEST(TestTensor, Make) {
   EXPECT_TRUE(tensor4->Equals(*tensor3));
 }
 
+TEST(TestTensor, MakeZeroDim) {
+  std::vector<int64_t> shape = {};
+  std::vector<double> values = {355 / 113.0};
+  auto data = Buffer::Wrap(values);
+  std::shared_ptr<Tensor> tensor;
+
+  ASSERT_OK_AND_ASSIGN(tensor, Tensor::Make(float64(), data, shape));
+  EXPECT_EQ(1, tensor->size());
+  EXPECT_EQ(shape, tensor->shape());
+  EXPECT_EQ(shape, tensor->strides());
+  EXPECT_EQ(data->data(), tensor->raw_data());
+  EXPECT_EQ(values[0], tensor->Value<DoubleType>({}));
+}
+
 TEST(TestTensor, MakeFailureCases) {
   std::vector<int64_t> shape = {3, 6};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
@@ -101,9 +115,6 @@ TEST(TestTensor, MakeFailureCases) {
 
   // null data
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), nullptr, shape));
-
-  // empty shape
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {}));
 
   // negative items in shape
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {-3, 6}));

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -424,6 +424,35 @@ REGISTER_TYPED_TEST_CASE_P(TestFloatTensor, Equals);
 INSTANTIATE_TYPED_TEST_CASE_P(Float32, TestFloatTensor, FloatType);
 INSTANTIATE_TYPED_TEST_CASE_P(Float64, TestFloatTensor, DoubleType);
 
+TEST(TestNumericTensor, Make) {
+  // without strides and dim_names
+  std::vector<int64_t> shape = {3, 6};
+  std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  auto data = Buffer::Wrap(values);
+  std::shared_ptr<NumericTensor<DoubleType>> tensor1;
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, shape, &tensor1));
+
+  // without dim_names
+  std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
+  std::shared_ptr<NumericTensor<DoubleType>> tensor2;
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, strides, &tensor2));
+  EXPECT_TRUE(tensor2->Equals(*tensor1));
+
+  // without strides
+  std::vector<std::string> dim_names = {"foo", "bar"};
+  std::shared_ptr<NumericTensor<DoubleType>> tensor3;
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, {}, dim_names, &tensor3));
+  EXPECT_TRUE(tensor3->Equals(*tensor1));
+  EXPECT_TRUE(tensor3->Equals(*tensor2));
+
+  // supply all parameters
+  std::shared_ptr<NumericTensor<DoubleType>> tensor4;
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, strides, dim_names, &tensor4));
+  EXPECT_TRUE(tensor4->Equals(*tensor1));
+  EXPECT_TRUE(tensor4->Equals(*tensor2));
+  EXPECT_TRUE(tensor4->Equals(*tensor3));
+}
+
 TEST(TestNumericTensor, ElementAccessWithRowMajorStrides) {
   std::vector<int64_t> shape = {3, 4};
 

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -44,24 +44,24 @@ TEST(TestTensor, Make) {
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
   std::shared_ptr<Tensor> tensor1;
-  ASSERT_OK(Tensor::Make(float64(), data, shape, &tensor1));
+  ASSERT_OK(Tensor::Make(float64(), data, shape).Value(&tensor1));
 
   // without dim_names
   std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::shared_ptr<Tensor> tensor2;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides, &tensor2));
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides).Value(&tensor2));
   EXPECT_TRUE(tensor2->Equals(*tensor1));
 
   // without strides
   std::vector<std::string> dim_names = {"foo", "bar"};
   std::shared_ptr<Tensor> tensor3;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, {}, dim_names, &tensor3));
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, {}, dim_names).Value(&tensor3));
   EXPECT_TRUE(tensor3->Equals(*tensor1));
   EXPECT_TRUE(tensor3->Equals(*tensor2));
 
   // supply all parameters
   std::shared_ptr<Tensor> tensor4;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides, dim_names, &tensor4));
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides, dim_names).Value(&tensor4));
   EXPECT_TRUE(tensor4->Equals(*tensor1));
   EXPECT_TRUE(tensor4->Equals(*tensor2));
   EXPECT_TRUE(tensor4->Equals(*tensor3));
@@ -71,40 +71,35 @@ TEST(TestTensor, MakeFailureCases) {
   std::vector<int64_t> shape = {3, 6};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
-  std::shared_ptr<Tensor> tensor1;
 
   // null type
-  ASSERT_RAISES(Invalid, Tensor::Make(nullptr, data, shape, &tensor1));
+  ASSERT_RAISES(Invalid, Tensor::Make(nullptr, data, shape));
 
   // invalid type
-  ASSERT_RAISES(Invalid, Tensor::Make(binary(), data, shape, &tensor1));
+  ASSERT_RAISES(Invalid, Tensor::Make(binary(), data, shape));
 
   // null data
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), nullptr, shape, &tensor1));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), nullptr, shape));
 
   // empty shape
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {}, &tensor1));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {}));
 
   // negative items in shape
-  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {-3, 6}, &tensor1));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {-3, 6}));
 
   // invalid stride length
-  ASSERT_RAISES(Invalid,
-                Tensor::Make(float64(), data, shape, {sizeof(double)}, &tensor1));
-  ASSERT_RAISES(Invalid,
-                Tensor::Make(float64(), data, shape,
-                             {sizeof(double), sizeof(double), sizeof(double)}, &tensor1));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {sizeof(double)}));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
+                                      {sizeof(double), sizeof(double), sizeof(double)}));
 
   // invalid stride values to involve buffer over run
-  ASSERT_RAISES(Invalid,
-                Tensor::Make(float64(), data, shape,
-                             {sizeof(double) * 6, sizeof(double) * 2}, &tensor1));
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
-                                      {sizeof(double) * 12, sizeof(double)}, &tensor1));
+                                      {sizeof(double) * 6, sizeof(double) * 2}));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
+                                      {sizeof(double) * 12, sizeof(double)}));
 
   // too many dim_names are supplied
-  ASSERT_RAISES(
-      Invalid, Tensor::Make(float64(), data, shape, {}, {"foo", "bar", "baz"}, &tensor1));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape, {}, {"foo", "bar", "baz"}));
 }
 
 TEST(TestTensor, ZeroDim) {
@@ -433,24 +428,25 @@ TEST(TestNumericTensor, Make) {
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
   std::shared_ptr<NumericTensor<DoubleType>> tensor1;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, shape, &tensor1));
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, shape).Value(&tensor1));
 
   // without dim_names
   std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::shared_ptr<NumericTensor<DoubleType>> tensor2;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, strides, &tensor2));
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, strides).Value(&tensor2));
   EXPECT_TRUE(tensor2->Equals(*tensor1));
 
   // without strides
   std::vector<std::string> dim_names = {"foo", "bar"};
   std::shared_ptr<NumericTensor<DoubleType>> tensor3;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, {}, dim_names, &tensor3));
+  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, {}, dim_names).Value(&tensor3));
   EXPECT_TRUE(tensor3->Equals(*tensor1));
   EXPECT_TRUE(tensor3->Equals(*tensor2));
 
   // supply all parameters
   std::shared_ptr<NumericTensor<DoubleType>> tensor4;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, strides, dim_names, &tensor4));
+  ASSERT_OK(
+      NumericTensor<DoubleType>::Make(data, {3, 6}, strides, dim_names).Value(&tensor4));
   EXPECT_TRUE(tensor4->Equals(*tensor1));
   EXPECT_TRUE(tensor4->Equals(*tensor2));
   EXPECT_TRUE(tensor4->Equals(*tensor3));

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -39,29 +39,50 @@ void AssertCountNonZero(const Tensor& t, int64_t expected) {
 }
 
 TEST(TestTensor, Make) {
-  // without strides and dim_names
   std::vector<int64_t> shape = {3, 6};
+  std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
+
+  // without strides and dim_names
   std::shared_ptr<Tensor> tensor1;
-  ASSERT_OK(Tensor::Make(float64(), data, shape).Value(&tensor1));
+  ASSERT_OK_AND_ASSIGN(tensor1, Tensor::Make(float64(), data, shape));
+  EXPECT_EQ(float64(), tensor1->type());
+  EXPECT_EQ(shape, tensor1->shape());
+  EXPECT_EQ(strides, tensor1->strides());
+  EXPECT_EQ(std::vector<std::string>{}, tensor1->dim_names());
+  EXPECT_EQ(data->data(), tensor1->raw_data());
 
   // without dim_names
-  std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::shared_ptr<Tensor> tensor2;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides).Value(&tensor2));
+  ASSERT_OK_AND_ASSIGN(tensor2, Tensor::Make(float64(), data, shape, strides));
+  EXPECT_EQ(float64(), tensor2->type());
+  EXPECT_EQ(shape, tensor2->shape());
+  EXPECT_EQ(strides, tensor2->strides());
+  EXPECT_EQ(std::vector<std::string>{}, tensor2->dim_names());
+  EXPECT_EQ(data->data(), tensor2->raw_data());
   EXPECT_TRUE(tensor2->Equals(*tensor1));
 
   // without strides
   std::vector<std::string> dim_names = {"foo", "bar"};
   std::shared_ptr<Tensor> tensor3;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, {}, dim_names).Value(&tensor3));
+  ASSERT_OK_AND_ASSIGN(tensor3, Tensor::Make(float64(), data, shape, {}, dim_names));
+  EXPECT_EQ(float64(), tensor3->type());
+  EXPECT_EQ(shape, tensor3->shape());
+  EXPECT_EQ(strides, tensor3->strides());
+  EXPECT_EQ(dim_names, tensor3->dim_names());
+  EXPECT_EQ(data->data(), tensor3->raw_data());
   EXPECT_TRUE(tensor3->Equals(*tensor1));
   EXPECT_TRUE(tensor3->Equals(*tensor2));
 
   // supply all parameters
   std::shared_ptr<Tensor> tensor4;
-  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides, dim_names).Value(&tensor4));
+  ASSERT_OK_AND_ASSIGN(tensor4, Tensor::Make(float64(), data, shape, strides, dim_names));
+  EXPECT_EQ(float64(), tensor4->type());
+  EXPECT_EQ(shape, tensor4->shape());
+  EXPECT_EQ(strides, tensor4->strides());
+  EXPECT_EQ(dim_names, tensor4->dim_names());
+  EXPECT_EQ(data->data(), tensor4->raw_data());
   EXPECT_TRUE(tensor4->Equals(*tensor1));
   EXPECT_TRUE(tensor4->Equals(*tensor2));
   EXPECT_TRUE(tensor4->Equals(*tensor3));
@@ -423,30 +444,52 @@ INSTANTIATE_TYPED_TEST_CASE_P(Float32, TestFloatTensor, FloatType);
 INSTANTIATE_TYPED_TEST_CASE_P(Float64, TestFloatTensor, DoubleType);
 
 TEST(TestNumericTensor, Make) {
-  // without strides and dim_names
   std::vector<int64_t> shape = {3, 6};
+  std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto data = Buffer::Wrap(values);
+
+  // without strides and dim_names
   std::shared_ptr<NumericTensor<DoubleType>> tensor1;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, shape).Value(&tensor1));
+  ASSERT_OK_AND_ASSIGN(tensor1, NumericTensor<DoubleType>::Make(data, shape));
+  EXPECT_EQ(float64(), tensor1->type());
+  EXPECT_EQ(shape, tensor1->shape());
+  EXPECT_EQ(strides, tensor1->strides());
+  EXPECT_EQ(data->data(), tensor1->raw_data());
+  EXPECT_EQ(std::vector<std::string>{}, tensor1->dim_names());
 
   // without dim_names
-  std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
   std::shared_ptr<NumericTensor<DoubleType>> tensor2;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, strides).Value(&tensor2));
+  ASSERT_OK_AND_ASSIGN(tensor2, NumericTensor<DoubleType>::Make(data, shape, strides));
+  EXPECT_EQ(float64(), tensor2->type());
+  EXPECT_EQ(shape, tensor2->shape());
+  EXPECT_EQ(strides, tensor2->strides());
+  EXPECT_EQ(std::vector<std::string>{}, tensor2->dim_names());
+  EXPECT_EQ(data->data(), tensor2->raw_data());
   EXPECT_TRUE(tensor2->Equals(*tensor1));
 
   // without strides
   std::vector<std::string> dim_names = {"foo", "bar"};
   std::shared_ptr<NumericTensor<DoubleType>> tensor3;
-  ASSERT_OK(NumericTensor<DoubleType>::Make(data, {3, 6}, {}, dim_names).Value(&tensor3));
+  ASSERT_OK_AND_ASSIGN(tensor3,
+                       NumericTensor<DoubleType>::Make(data, shape, {}, dim_names));
+  EXPECT_EQ(float64(), tensor3->type());
+  EXPECT_EQ(shape, tensor3->shape());
+  EXPECT_EQ(strides, tensor3->strides());
+  EXPECT_EQ(dim_names, tensor3->dim_names());
+  EXPECT_EQ(data->data(), tensor3->raw_data());
   EXPECT_TRUE(tensor3->Equals(*tensor1));
   EXPECT_TRUE(tensor3->Equals(*tensor2));
 
   // supply all parameters
   std::shared_ptr<NumericTensor<DoubleType>> tensor4;
-  ASSERT_OK(
-      NumericTensor<DoubleType>::Make(data, {3, 6}, strides, dim_names).Value(&tensor4));
+  ASSERT_OK_AND_ASSIGN(tensor4,
+                       NumericTensor<DoubleType>::Make(data, shape, strides, dim_names));
+  EXPECT_EQ(float64(), tensor4->type());
+  EXPECT_EQ(shape, tensor4->shape());
+  EXPECT_EQ(strides, tensor4->strides());
+  EXPECT_EQ(dim_names, tensor4->dim_names());
+  EXPECT_EQ(data->data(), tensor4->raw_data());
   EXPECT_TRUE(tensor4->Equals(*tensor1));
   EXPECT_TRUE(tensor4->Equals(*tensor2));
   EXPECT_TRUE(tensor4->Equals(*tensor3));

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -38,6 +38,72 @@ void AssertCountNonZero(const Tensor& t, int64_t expected) {
   ASSERT_EQ(count, expected);
 }
 
+TEST(TestTensor, Make) {
+  // without strides and dim_names
+  std::vector<int64_t> shape = {3, 6};
+  std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  auto data = Buffer::Wrap(values);
+  std::shared_ptr<Tensor> tensor1;
+  ASSERT_OK(Tensor::Make(float64(), data, shape, &tensor1));
+
+  // without dim_names
+  std::vector<int64_t> strides = {sizeof(double) * 6, sizeof(double)};
+  std::shared_ptr<Tensor> tensor2;
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides, &tensor2));
+  EXPECT_TRUE(tensor2->Equals(*tensor1));
+
+  // without strides
+  std::vector<std::string> dim_names = {"foo", "bar"};
+  std::shared_ptr<Tensor> tensor3;
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, dim_names, &tensor3));
+  EXPECT_TRUE(tensor3->Equals(*tensor1));
+  EXPECT_TRUE(tensor3->Equals(*tensor2));
+
+  // supply all parameters
+  std::shared_ptr<Tensor> tensor4;
+  ASSERT_OK(Tensor::Make(float64(), data, {3, 6}, strides, dim_names, &tensor4));
+  EXPECT_TRUE(tensor4->Equals(*tensor1));
+  EXPECT_TRUE(tensor4->Equals(*tensor2));
+  EXPECT_TRUE(tensor4->Equals(*tensor3));
+}
+
+TEST(TestTensor, MakeFailureCases) {
+  std::vector<int64_t> shape = {3, 6};
+  std::vector<double> values = {1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  auto data = Buffer::Wrap(values);
+  std::shared_ptr<Tensor> tensor1;
+
+  // null type
+  ASSERT_RAISES(Invalid, Tensor::Make(nullptr, data, shape, &tensor1));
+
+  // invalid type
+  ASSERT_RAISES(Invalid, Tensor::Make(binary(), data, shape, &tensor1));
+
+  // null data
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), nullptr, shape, &tensor1));
+
+  // empty shape
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {}, &tensor1));
+
+  // invalid stride length
+  ASSERT_RAISES(Invalid,
+                Tensor::Make(float64(), data, shape, {sizeof(double)}, &tensor1));
+  ASSERT_RAISES(Invalid,
+                Tensor::Make(float64(), data, shape,
+                             {sizeof(double), sizeof(double), sizeof(double)}, &tensor1));
+
+  // invalid stride values to involve buffer over run
+  ASSERT_RAISES(Invalid,
+                Tensor::Make(float64(), data, shape,
+                             {sizeof(double) * 6, sizeof(double) * 2}, &tensor1));
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, shape,
+                                      {sizeof(double) * 12, sizeof(double)}, &tensor1));
+
+  // too many dim_names are supplied
+  ASSERT_RAISES(
+      Invalid, Tensor::Make(float64(), data, shape, {}, {"foo", "bar", "baz"}, &tensor1));
+}
+
 TEST(TestTensor, ZeroDim) {
   const int64_t values = 1;
   std::vector<int64_t> shape = {};

--- a/cpp/src/arrow/tensor_test.cc
+++ b/cpp/src/arrow/tensor_test.cc
@@ -85,6 +85,9 @@ TEST(TestTensor, MakeFailureCases) {
   // empty shape
   ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {}, &tensor1));
 
+  // negative items in shape
+  ASSERT_RAISES(Invalid, Tensor::Make(float64(), data, {-3, 6}, &tensor1));
+
   // invalid stride length
   ASSERT_RAISES(Invalid,
                 Tensor::Make(float64(), data, shape, {sizeof(double)}, &tensor1));


### PR DESCRIPTION
I'd like to add `Make` factory functions in `Tensor` and `SparseTensor`.  These functions validate the given parameters.

The following validations run in `Tensor::Make`:

- Data type (non-null and `is_tensor_supported`)
- `data` pointer
- the size of `shape`
- elements of `shape` are all positive
- the consistency of `shape` and `strides`
- the consistency of `strides` and the size of `data`
- the consistency of the size of `dim_names` and `shape`

The following validations run in `SparseTensor::Make`:

- Data type
- the consistency of the sparse index and `shape`
- the consistency of the size of `dim_names` and `shape`

---

## TODO:

- [x] Use `Result<T>` as return types.