### PR TITLE
ARROW-7168: [Python] Respect the specified dictionary type for pd.Categorical conversion

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3212,9 +3212,31 @@ def test_variable_dictionary_to_pandas():
     tm.assert_series_equal(result_dense, expected_dense)
 
 
+def test_dictionary_from_pandas():
+    cat = pd.Categorical(['a', 'b', 'a'])
+    expected_type = pa.dictionary(pa.int8(), pa.string())
+
+    result = pa.array(cat)
+    assert result.to_pylist() == ['a', 'b', 'a']
+    assert result.type.equals(expected_type)
+
+    # with missing values in categorical
+    cat = pd.Categorical(['a', 'b', None, 'a'])
+
+    result = pa.array(cat)
+    assert result.to_pylist() == ['a', 'b', None, 'a']
+    assert result.type.equals(expected_type)
+
+    # with additional mask
+    result = pa.array(cat, mask=np.array([False, False, False, True]))
+    assert result.to_pylist() == ['a', 'b', None, None]
+    assert result.type.equals(expected_type)
+
+
 def test_dictionary_from_pandas_specified_type():
-    # ARROW-7168
-    # the same as cat = pd.Categorical(['a', 'b'])
+    # ARROW-7168 - ensure specified type is always respected
+
+    # the same as cat = pd.Categorical(['a', 'b']) but explicit about dtypes
     cat = pd.Categorical.from_codes(
         np.array([0, 1], dtype='int8'), np.array(['a', 'b'], dtype=object))
 
@@ -3223,6 +3245,7 @@ def test_dictionary_from_pandas_specified_type():
     typ = pa.dictionary(index_type=pa.int16(), value_type=pa.string())
     result = pa.array(cat, type=typ)
     assert result.type.equals(typ)
+    assert result.to_pylist() == ['a', 'b']
 
     # mismatching values type -> raise error
     typ = pa.dictionary(index_type=pa.int8(), value_type=pa.int64())
@@ -3235,21 +3258,30 @@ def test_dictionary_from_pandas_specified_type():
     with pytest.raises(ValueError):
         pa.array(cat, type=typ)
 
+    # with mask
+    typ = pa.dictionary(index_type=pa.int16(), value_type=pa.string())
+    result = pa.array(cat, type=typ, mask=np.array([False, True]))
+    assert result.type.equals(typ)
+    assert result.to_pylist() == ['a', None]
+
     # empty categorical -> be flexible in values type to allow
     cat = pd.Categorical([])
 
     typ = pa.dictionary(index_type=pa.int8(), value_type=pa.string())
     result = pa.array(cat, type=typ)
     assert result.type.equals(typ)
+    assert result.to_pylist() == []
     typ = pa.dictionary(index_type=pa.int8(), value_type=pa.int64())
     result = pa.array(cat, type=typ)
     assert result.type.equals(typ)
+    assert result.to_pylist() == []
 
     # passing non-dictionary type
     cat = pd.Categorical(['a', 'b'])
     result = pa.array(cat, type=pa.string())
     expected = pa.array(['a', 'b'], type=pa.string())
     assert result.equals(expected)
+    assert result.to_pylist() == ['a', 'b']
 
 
 # ----------------------------------------------------------------------

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3247,16 +3247,18 @@ def test_dictionary_from_pandas_specified_type():
     assert result.type.equals(typ)
     assert result.to_pylist() == ['a', 'b']
 
-    # mismatching values type -> raise error
+    # mismatching values type -> raise error (for now a deprecation warning)
     typ = pa.dictionary(index_type=pa.int8(), value_type=pa.int64())
-    with pytest.raises(TypeError):
-        pa.array(cat, type=typ)
+    with pytest.warns(FutureWarning):
+        result = pa.array(cat, type=typ)
+    assert result.to_pylist() == ['a', 'b']
 
-    # mismatching order -> raise error
+    # mismatching order -> raise error (for now a deprecation warning)
     typ = pa.dictionary(
         index_type=pa.int8(), value_type=pa.string(), ordered=True)
-    with pytest.raises(ValueError):
-        pa.array(cat, type=typ)
+    with pytest.warns(FutureWarning, match="The 'ordered' flag of the passed"):
+        result = pa.array(cat, type=typ)
+    assert result.to_pylist() == ['a', 'b']
 
     # with mask
     typ = pa.dictionary(index_type=pa.int16(), value_type=pa.string())

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3213,7 +3213,7 @@ def test_variable_dictionary_to_pandas():
 
 
 def test_dictionary_from_pandas():
-    cat = pd.Categorical(['a', 'b', 'a'])
+    cat = pd.Categorical([u'a', u'b', u'a'])
     expected_type = pa.dictionary(pa.int8(), pa.string())
 
     result = pa.array(cat)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3221,7 +3221,7 @@ def test_dictionary_from_pandas():
     assert result.type.equals(expected_type)
 
     # with missing values in categorical
-    cat = pd.Categorical(['a', 'b', None, 'a'])
+    cat = pd.Categorical([u'a', u'b', None, u'a'])
 
     result = pa.array(cat)
     assert result.to_pylist() == ['a', 'b', None, 'a']


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-7168

This change ensures that if you specify a `type` in `pa.array`, we ensure the output actually has this type when converting to dictionary array (as we also do for other types).

The PR now implements this change, but we might want to do this with a deprecation first, as this can break people's code.