### PR TITLE
ARROW-7216: [Java] Improve the performance of setting/clearing individual bits

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BinaryConsumer.java
@@ -85,7 +85,7 @@ public abstract class BinaryConsumer implements JdbcConsumer<VarBinaryVector> {
         totalBytes += read;
       }
       offsetBuffer.setInt((currentIndex + 1) * 4, startIndex + totalBytes);
-      BitVectorHelper.setValidityBitToOne(vector.getValidityBuffer(), currentIndex);
+      BitVectorHelper.setBit(vector.getValidityBuffer(), currentIndex);
       vector.setLastSet(currentIndex);
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ClobConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ClobConsumer.java
@@ -115,7 +115,7 @@ public abstract class ClobConsumer implements JdbcConsumer<VarCharVector> {
             read += readSize;
           }
           offsetBuffer.setInt((currentIndex + 1) * 4, startIndex + totalBytes);
-          BitVectorHelper.setValidityBitToOne(vector.getValidityBuffer(), currentIndex);
+          BitVectorHelper.setBit(vector.getValidityBuffer(), currentIndex);
           vector.setLastSet(currentIndex);
         }
       }
@@ -162,7 +162,7 @@ public abstract class ClobConsumer implements JdbcConsumer<VarCharVector> {
           read += readSize;
         }
         offsetBuffer.setInt((currentIndex + 1) * 4, startIndex + totalBytes);
-        BitVectorHelper.setValidityBitToOne(vector.getValidityBuffer(), currentIndex);
+        BitVectorHelper.setBit(vector.getValidityBuffer(), currentIndex);
         vector.setLastSet(currentIndex);
       }
     

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/deduplicate/DeduplicationUtils.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/deduplicate/DeduplicationUtils.java
@@ -43,13 +43,13 @@ class DeduplicationUtils {
     Preconditions.checkArgument(runStarts.capacity() >= bufSize);
     runStarts.setZero(0, bufSize);
 
-    BitVectorHelper.setValidityBitToOne(runStarts, 0);
+    BitVectorHelper.setBit(runStarts, 0);
     RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector, vector, false);
     Range range = new Range(0, 0, 1);
     for (int i = 1; i < vector.getValueCount(); i++) {
       range.setLeftStart(i).setRightStart(i - 1);
       if (!visitor.rangeEquals(range)) {
-        BitVectorHelper.setValidityBitToOne(runStarts, i);
+        BitVectorHelper.setBit(runStarts, i);
       }
     }
   }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthOutOfPlaceVectorSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthOutOfPlaceVectorSorter.java
@@ -54,9 +54,9 @@ public class FixedWidthOutOfPlaceVectorSorter<V extends BaseFixedWidthVector> im
       for (int dstIndex = 0; dstIndex < sortedIndices.getValueCount(); dstIndex++) {
         int srcIndex = sortedIndices.get(dstIndex);
         if (srcVector.isNull(srcIndex)) {
-          BitVectorHelper.setValidityBit(dstValidityBuffer, dstIndex, 0);
+          BitVectorHelper.setValidityBitToZero(dstValidityBuffer, dstIndex);
         } else {
-          BitVectorHelper.setValidityBit(dstValidityBuffer, dstIndex, 1);
+          BitVectorHelper.setValidityBitToOne(dstValidityBuffer, dstIndex);
           PlatformDependent.copyMemory(
                   srcValueBuffer.memoryAddress() + srcIndex * valueWidth,
                   dstValueBuffer.memoryAddress() + dstIndex * valueWidth,

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthOutOfPlaceVectorSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthOutOfPlaceVectorSorter.java
@@ -54,9 +54,9 @@ public class FixedWidthOutOfPlaceVectorSorter<V extends BaseFixedWidthVector> im
       for (int dstIndex = 0; dstIndex < sortedIndices.getValueCount(); dstIndex++) {
         int srcIndex = sortedIndices.get(dstIndex);
         if (srcVector.isNull(srcIndex)) {
-          BitVectorHelper.setValidityBitToZero(dstValidityBuffer, dstIndex);
+          BitVectorHelper.unsetBit(dstValidityBuffer, dstIndex);
         } else {
-          BitVectorHelper.setValidityBitToOne(dstValidityBuffer, dstIndex);
+          BitVectorHelper.setBit(dstValidityBuffer, dstIndex);
           PlatformDependent.copyMemory(
                   srcValueBuffer.memoryAddress() + srcIndex * valueWidth,
                   dstValueBuffer.memoryAddress() + dstIndex * valueWidth,

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VariableWidthOutOfPlaceVectorSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VariableWidthOutOfPlaceVectorSorter.java
@@ -58,9 +58,9 @@ public class VariableWidthOutOfPlaceVectorSorter<V extends BaseVariableWidthVect
       for (int dstIndex = 0; dstIndex < sortedIndices.getValueCount(); dstIndex++) {
         int srcIndex = sortedIndices.get(dstIndex);
         if (srcVector.isNull(srcIndex)) {
-          BitVectorHelper.setValidityBitToZero(dstValidityBuffer, dstIndex);
+          BitVectorHelper.unsetBit(dstValidityBuffer, dstIndex);
         } else {
-          BitVectorHelper.setValidityBitToOne(dstValidityBuffer, dstIndex);
+          BitVectorHelper.setBit(dstValidityBuffer, dstIndex);
           int srcOffset = srcOffsetBuffer.getInt(srcIndex * BaseVariableWidthVector.OFFSET_WIDTH);
           int valueLength = srcOffsetBuffer.getInt((srcIndex + 1) * BaseVariableWidthVector.OFFSET_WIDTH) - srcOffset;
           PlatformDependent.copyMemory(

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VariableWidthOutOfPlaceVectorSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/VariableWidthOutOfPlaceVectorSorter.java
@@ -58,9 +58,9 @@ public class VariableWidthOutOfPlaceVectorSorter<V extends BaseVariableWidthVect
       for (int dstIndex = 0; dstIndex < sortedIndices.getValueCount(); dstIndex++) {
         int srcIndex = sortedIndices.get(dstIndex);
         if (srcVector.isNull(srcIndex)) {
-          BitVectorHelper.setValidityBit(dstValidityBuffer, dstIndex, 0);
+          BitVectorHelper.setValidityBitToZero(dstValidityBuffer, dstIndex);
         } else {
-          BitVectorHelper.setValidityBit(dstValidityBuffer, dstIndex, 1);
+          BitVectorHelper.setValidityBitToOne(dstValidityBuffer, dstIndex);
           int srcOffset = srcOffsetBuffer.getInt(srcIndex * BaseVariableWidthVector.OFFSET_WIDTH);
           int valueLength = srcOffsetBuffer.getInt((srcIndex + 1) * BaseVariableWidthVector.OFFSET_WIDTH) - srcOffset;
           PlatformDependent.copyMemory(

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/search/TestVectorSearcher.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/search/TestVectorSearcher.java
@@ -217,7 +217,7 @@ public class TestVectorSearcher {
     dataVector.setValueCount(innerCount);
 
     for (int i = 0; i < outerCount; i++) {
-      BitVectorHelper.setValidityBitToOne(listVector.getValidityBuffer(), i);
+      BitVectorHelper.setBit(listVector.getValidityBuffer(), i);
       listVector.getOffsetBuffer().setInt(i * OFFSET_WIDTH, i * listLength);
       listVector.getOffsetBuffer().setInt((i + 1) * OFFSET_WIDTH, (i + 1) * listLength);
     }
@@ -247,7 +247,7 @@ public class TestVectorSearcher {
     dataVector.setValueCount(innerCount);
 
     for (int i = 0; i < outerCount; i++) {
-      BitVectorHelper.setValidityBitToOne(listVector.getValidityBuffer(), i);
+      BitVectorHelper.setBit(listVector.getValidityBuffer(), i);
       listVector.getOffsetBuffer().setInt(i * OFFSET_WIDTH, i * listLength);
       listVector.getOffsetBuffer().setInt((i + 1) * OFFSET_WIDTH, (i + 1) * listLength);
     }

--- a/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
@@ -69,16 +69,16 @@ public class BitVectorHelperBenchmarks {
 
       for (int i = 0;i < VALIDITY_BUFFER_CAPACITY; i++) {
         if (i % 7 == 0) {
-          BitVectorHelper.setValidityBit(validityBuffer, i, (byte) 1);
+          BitVectorHelper.setValidityBitToOne(validityBuffer, i);
         } else {
-          BitVectorHelper.setValidityBit(validityBuffer, i, (byte) 0);
+          BitVectorHelper.setValidityBitToZero(validityBuffer, i);
         }
       }
 
       // only one 1 bit in the middle of the buffer
       oneBitValidityBuffer = allocator.buffer(VALIDITY_BUFFER_CAPACITY / 8);
       oneBitValidityBuffer.setZero(0, VALIDITY_BUFFER_CAPACITY / 8);
-      BitVectorHelper.setValidityBit(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY / 2, (byte) 1);
+      BitVectorHelper.setValidityBitToOne(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY / 2);
     }
 
     /**
@@ -133,8 +133,8 @@ public class BitVectorHelperBenchmarks {
       allocator = new RootAllocator(ALLOCATOR_CAPACITY);
       validityBuffer = allocator.buffer(VALIDITY_BUFFER_CAPACITY / 8);
 
-      for (int i = 0;i < VALIDITY_BUFFER_CAPACITY; i++) {
-        BitVectorHelper.setValidityBit(validityBuffer, i, (byte) 1);
+      for (int i = 0; i < VALIDITY_BUFFER_CAPACITY; i++) {
+        BitVectorHelper.setValidityBitToOne(validityBuffer, i);
       }
 
       fieldNode = new ArrowFieldNode(VALIDITY_BUFFER_CAPACITY, 0);
@@ -164,6 +164,59 @@ public class BitVectorHelperBenchmarks {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public void loadValidityBufferAllOne(NonNullableValidityBufferState state) {
     state.loadResult = BitVectorHelper.loadValidityBuffer(state.fieldNode, state.validityBuffer, state.allocator);
+  }
+
+  /**
+   * State object for {@link #setValidityBitBenchmark(ClearBitStateState)}.
+   */
+  @State(Scope.Benchmark)
+  public static class ClearBitStateState {
+
+    private static final int VALIDITY_BUFFER_CAPACITY = 1024;
+
+    private static final int ALLOCATOR_CAPACITY = 1024 * 1024;
+
+    private BufferAllocator allocator;
+
+    private ArrowBuf validityBuffer;
+
+    private int bitToSet = 0;
+
+    /**
+     * Setup benchmarks.
+     */
+    @Setup(Level.Trial)
+    public void prepare() {
+      allocator = new RootAllocator(ALLOCATOR_CAPACITY);
+      validityBuffer = allocator.buffer(VALIDITY_BUFFER_CAPACITY / 8);
+    }
+
+    /**
+     * Tear down benchmarks.
+     */
+    @TearDown(Level.Trial)
+    public void tearDown() {
+      validityBuffer.close();
+      allocator.close();
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void setValidityBitBenchmark(ClearBitStateState state) {
+    for (int i = 0; i < ClearBitStateState.VALIDITY_BUFFER_CAPACITY; i++) {
+      BitVectorHelper.setValidityBit(state.validityBuffer, i, state.bitToSet);
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public void setValidityBitToZeroBenchmark(ClearBitStateState state) {
+    for (int i = 0; i < ClearBitStateState.VALIDITY_BUFFER_CAPACITY; i++) {
+      BitVectorHelper.setValidityBitToZero(state.validityBuffer, i);
+    }
   }
 
   //@Test

--- a/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
@@ -69,16 +69,16 @@ public class BitVectorHelperBenchmarks {
 
       for (int i = 0;i < VALIDITY_BUFFER_CAPACITY; i++) {
         if (i % 7 == 0) {
-          BitVectorHelper.setValidityBitToOne(validityBuffer, i);
+          BitVectorHelper.setBit(validityBuffer, i);
         } else {
-          BitVectorHelper.setValidityBitToZero(validityBuffer, i);
+          BitVectorHelper.unsetBit(validityBuffer, i);
         }
       }
 
       // only one 1 bit in the middle of the buffer
       oneBitValidityBuffer = allocator.buffer(VALIDITY_BUFFER_CAPACITY / 8);
       oneBitValidityBuffer.setZero(0, VALIDITY_BUFFER_CAPACITY / 8);
-      BitVectorHelper.setValidityBitToOne(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY / 2);
+      BitVectorHelper.setBit(oneBitValidityBuffer, VALIDITY_BUFFER_CAPACITY / 2);
     }
 
     /**
@@ -134,7 +134,7 @@ public class BitVectorHelperBenchmarks {
       validityBuffer = allocator.buffer(VALIDITY_BUFFER_CAPACITY / 8);
 
       for (int i = 0; i < VALIDITY_BUFFER_CAPACITY; i++) {
-        BitVectorHelper.setValidityBitToOne(validityBuffer, i);
+        BitVectorHelper.setBit(validityBuffer, i);
       }
 
       fieldNode = new ArrowFieldNode(VALIDITY_BUFFER_CAPACITY, 0);
@@ -215,7 +215,7 @@ public class BitVectorHelperBenchmarks {
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   public void setValidityBitToZeroBenchmark(ClearBitStateState state) {
     for (int i = 0; i < ClearBitStateState.VALIDITY_BUFFER_CAPACITY; i++) {
-      BitVectorHelper.setValidityBitToZero(state.validityBuffer, i);
+      BitVectorHelper.unsetBit(state.validityBuffer, i);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -781,7 +781,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   @Override
   public void setIndexDefined(int index) {
     handleSafe(index);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
   }
 
   public void set(int index, byte[] value, int start, int length) {
@@ -827,9 +827,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   public void copyFrom(int fromIndex, int thisIndex, ValueVector from) {
     Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
     if (from.isNull(fromIndex)) {
-      BitVectorHelper.setValidityBitToZero(this.getValidityBuffer(), thisIndex);
+      BitVectorHelper.unsetBit(this.getValidityBuffer(), thisIndex);
     } else {
-      BitVectorHelper.setValidityBitToOne(this.getValidityBuffer(), thisIndex);
+      BitVectorHelper.setBit(this.getValidityBuffer(), thisIndex);
       PlatformDependent.copyMemory(from.getDataBuffer().memoryAddress() + fromIndex * typeWidth,
               this.getDataBuffer().memoryAddress() + thisIndex * typeWidth, typeWidth);
     }
@@ -860,7 +860,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     handleSafe(index);
     // not really needed to set the bit to 0 as long as
     // the buffer always starts from 0.
-    BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+    BitVectorHelper.unsetBit(validityBuffer, index);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -827,9 +827,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   public void copyFrom(int fromIndex, int thisIndex, ValueVector from) {
     Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
     if (from.isNull(fromIndex)) {
-      BitVectorHelper.setValidityBit(this.getValidityBuffer(), thisIndex, 0);
+      BitVectorHelper.setValidityBitToZero(this.getValidityBuffer(), thisIndex);
     } else {
-      BitVectorHelper.setValidityBit(this.getValidityBuffer(), thisIndex, 1);
+      BitVectorHelper.setValidityBitToOne(this.getValidityBuffer(), thisIndex);
       PlatformDependent.copyMemory(from.getDataBuffer().memoryAddress() + fromIndex * typeWidth,
               this.getDataBuffer().memoryAddress() + thisIndex * typeWidth, typeWidth);
     }
@@ -860,7 +860,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     handleSafe(index);
     // not really needed to set the bit to 0 as long as
     // the buffer always starts from 0.
-    BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+    BitVectorHelper.setValidityBitToZero(validityBuffer, index);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -1081,7 +1081,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     while (index >= getValidityBufferValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
-    BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+    BitVectorHelper.setValidityBitToZero(validityBuffer, index);
   }
 
   /**
@@ -1301,7 +1301,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
     if (from.isNull(fromIndex)) {
       fillHoles(thisIndex);
-      BitVectorHelper.setValidityBit(this.validityBuffer, thisIndex, 0);
+      BitVectorHelper.setValidityBitToZero(this.validityBuffer, thisIndex);
       final int copyStart = offsetBuffer.getInt(thisIndex * OFFSET_WIDTH);
       offsetBuffer.setInt((thisIndex + 1) * OFFSET_WIDTH, copyStart);
     } else {
@@ -1309,7 +1309,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
       final int end = from.getOffsetBuffer().getInt((fromIndex + 1) * OFFSET_WIDTH);
       final int length = end - start;
       fillHoles(thisIndex);
-      BitVectorHelper.setValidityBit(this.validityBuffer, thisIndex, 1);
+      BitVectorHelper.setValidityBitToOne(this.validityBuffer, thisIndex);
       final int copyStart = offsetBuffer.getInt(thisIndex * OFFSET_WIDTH);
       from.getDataBuffer().getBytes(start, this.valueBuffer, copyStart, length);
       offsetBuffer.setInt((thisIndex + 1) * OFFSET_WIDTH, copyStart + length);
@@ -1332,7 +1332,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     if (from.isNull(fromIndex)) {
       handleSafe(thisIndex, 0);
       fillHoles(thisIndex);
-      BitVectorHelper.setValidityBit(this.validityBuffer, thisIndex, 0);
+      BitVectorHelper.setValidityBitToZero(this.validityBuffer, thisIndex);
       final int copyStart = offsetBuffer.getInt(thisIndex * OFFSET_WIDTH);
       offsetBuffer.setInt((thisIndex + 1) * OFFSET_WIDTH, copyStart);
     } else {
@@ -1341,7 +1341,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
       final int length = end - start;
       handleSafe(thisIndex, length);
       fillHoles(thisIndex);
-      BitVectorHelper.setValidityBit(this.validityBuffer, thisIndex, 1);
+      BitVectorHelper.setValidityBitToOne(this.validityBuffer, thisIndex);
       final int copyStart = offsetBuffer.getInt(thisIndex * OFFSET_WIDTH);
       from.getDataBuffer().getBytes(start, this.valueBuffer, copyStart, length);
       offsetBuffer.setInt((thisIndex + 1) * OFFSET_WIDTH, copyStart + length);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -928,7 +928,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     while (index >= getValidityBufferValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
   }
 
   /**
@@ -974,7 +974,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   public void set(int index, byte[] value) {
     assert index >= 0;
     fillHoles(index);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setBytes(index, value, 0, value.length);
     lastSet = index;
   }
@@ -991,7 +991,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     assert index >= 0;
     fillEmpties(index);
     handleSafe(index, value.length);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setBytes(index, value, 0, value.length);
     lastSet = index;
   }
@@ -1008,7 +1008,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   public void set(int index, byte[] value, int start, int length) {
     assert index >= 0;
     fillHoles(index);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setBytes(index, value, start, length);
     lastSet = index;
   }
@@ -1027,7 +1027,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     assert index >= 0;
     fillEmpties(index);
     handleSafe(index, length);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setBytes(index, value, start, length);
     lastSet = index;
   }
@@ -1044,7 +1044,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   public void set(int index, ByteBuffer value, int start, int length) {
     assert index >= 0;
     fillHoles(index);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = getStartOffset(index);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + length);
     valueBuffer.setBytes(startOffset, value, start, length);
@@ -1065,7 +1065,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     assert index >= 0;
     fillEmpties(index);
     handleSafe(index, length);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = getStartOffset(index);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + length);
     valueBuffer.setBytes(startOffset, value, start, length);
@@ -1081,7 +1081,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     while (index >= getValidityBufferValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
-    BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+    BitVectorHelper.unsetBit(validityBuffer, index);
   }
 
   /**
@@ -1140,7 +1140,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   public void set(int index, int start, int length, ArrowBuf buffer) {
     assert index >= 0;
     fillHoles(index);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = offsetBuffer.getInt(index * OFFSET_WIDTH);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + length);
     final ArrowBuf bb = buffer.slice(start, length);
@@ -1162,7 +1162,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     assert index >= 0;
     fillEmpties(index);
     handleSafe(index, length);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = offsetBuffer.getInt(index * OFFSET_WIDTH);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + length);
     final ArrowBuf bb = buffer.slice(start, length);
@@ -1301,7 +1301,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
     if (from.isNull(fromIndex)) {
       fillHoles(thisIndex);
-      BitVectorHelper.setValidityBitToZero(this.validityBuffer, thisIndex);
+      BitVectorHelper.unsetBit(this.validityBuffer, thisIndex);
       final int copyStart = offsetBuffer.getInt(thisIndex * OFFSET_WIDTH);
       offsetBuffer.setInt((thisIndex + 1) * OFFSET_WIDTH, copyStart);
     } else {
@@ -1309,7 +1309,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
       final int end = from.getOffsetBuffer().getInt((fromIndex + 1) * OFFSET_WIDTH);
       final int length = end - start;
       fillHoles(thisIndex);
-      BitVectorHelper.setValidityBitToOne(this.validityBuffer, thisIndex);
+      BitVectorHelper.setBit(this.validityBuffer, thisIndex);
       final int copyStart = offsetBuffer.getInt(thisIndex * OFFSET_WIDTH);
       from.getDataBuffer().getBytes(start, this.valueBuffer, copyStart, length);
       offsetBuffer.setInt((thisIndex + 1) * OFFSET_WIDTH, copyStart + length);
@@ -1332,7 +1332,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     if (from.isNull(fromIndex)) {
       handleSafe(thisIndex, 0);
       fillHoles(thisIndex);
-      BitVectorHelper.setValidityBitToZero(this.validityBuffer, thisIndex);
+      BitVectorHelper.unsetBit(this.validityBuffer, thisIndex);
       final int copyStart = offsetBuffer.getInt(thisIndex * OFFSET_WIDTH);
       offsetBuffer.setInt((thisIndex + 1) * OFFSET_WIDTH, copyStart);
     } else {
@@ -1341,7 +1341,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
       final int length = end - start;
       handleSafe(thisIndex, length);
       fillHoles(thisIndex);
-      BitVectorHelper.setValidityBitToOne(this.validityBuffer, thisIndex);
+      BitVectorHelper.setBit(this.validityBuffer, thisIndex);
       final int copyStart = offsetBuffer.getInt(thisIndex * OFFSET_WIDTH);
       from.getDataBuffer().getBytes(start, this.valueBuffer, copyStart, length);
       offsetBuffer.setInt((thisIndex + 1) * OFFSET_WIDTH, copyStart + length);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -163,7 +163,7 @@ public final class BigIntVector extends BaseFixedWidthVector implements BaseIntV
    * @param value   value of element
    */
   public void set(int index, long value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -179,10 +179,10 @@ public final class BigIntVector extends BaseFixedWidthVector implements BaseIntV
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -193,7 +193,7 @@ public final class BigIntVector extends BaseFixedWidthVector implements BaseIntV
    * @param holder  data holder for value of element
    */
   public void set(int index, BigIntHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -247,7 +247,7 @@ public final class BigIntVector extends BaseFixedWidthVector implements BaseIntV
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BigIntVector.java
@@ -182,7 +182,7 @@ public final class BigIntVector extends BaseFixedWidthVector implements BaseIntV
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -247,7 +247,7 @@ public final class BigIntVector extends BaseFixedWidthVector implements BaseIntV
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -303,10 +303,10 @@ public final class BitVector extends BaseFixedWidthVector {
     Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
     boolean fromIsSet = BitVectorHelper.get(from.getValidityBuffer(), fromIndex) != 0;
     if (fromIsSet) {
-      BitVectorHelper.setValidityBit(validityBuffer, thisIndex, 1);
+      BitVectorHelper.setValidityBitToOne(validityBuffer, thisIndex);
       BitVectorHelper.setValidityBit(valueBuffer, thisIndex, ((BitVector) from).getBit(fromIndex));
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, thisIndex, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, thisIndex);
     }
   }
 
@@ -328,7 +328,7 @@ public final class BitVector extends BaseFixedWidthVector {
     if (value != 0) {
       BitVectorHelper.setValidityBitToOne(valueBuffer, index);
     } else {
-      BitVectorHelper.setValidityBit(valueBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(valueBuffer, index);
     }
   }
 
@@ -348,10 +348,10 @@ public final class BitVector extends BaseFixedWidthVector {
       if (holder.value != 0) {
         BitVectorHelper.setValidityBitToOne(valueBuffer, index);
       } else {
-        BitVectorHelper.setValidityBit(valueBuffer, index, 0);
+        BitVectorHelper.setValidityBitToZero(valueBuffer, index);
       }
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -366,7 +366,7 @@ public final class BitVector extends BaseFixedWidthVector {
     if (holder.value != 0) {
       BitVectorHelper.setValidityBitToOne(valueBuffer, index);
     } else {
-      BitVectorHelper.setValidityBit(valueBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(valueBuffer, index);
     }
   }
 
@@ -421,7 +421,7 @@ public final class BitVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -303,10 +303,10 @@ public final class BitVector extends BaseFixedWidthVector {
     Preconditions.checkArgument(this.getMinorType() == from.getMinorType());
     boolean fromIsSet = BitVectorHelper.get(from.getValidityBuffer(), fromIndex) != 0;
     if (fromIsSet) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, thisIndex);
+      BitVectorHelper.setBit(validityBuffer, thisIndex);
       BitVectorHelper.setValidityBit(valueBuffer, thisIndex, ((BitVector) from).getBit(fromIndex));
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, thisIndex);
+      BitVectorHelper.unsetBit(validityBuffer, thisIndex);
     }
   }
 
@@ -324,11 +324,11 @@ public final class BitVector extends BaseFixedWidthVector {
    * @param value value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     if (value != 0) {
-      BitVectorHelper.setValidityBitToOne(valueBuffer, index);
+      BitVectorHelper.setBit(valueBuffer, index);
     } else {
-      BitVectorHelper.setValidityBitToZero(valueBuffer, index);
+      BitVectorHelper.unsetBit(valueBuffer, index);
     }
   }
 
@@ -344,14 +344,14 @@ public final class BitVector extends BaseFixedWidthVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       if (holder.value != 0) {
-        BitVectorHelper.setValidityBitToOne(valueBuffer, index);
+        BitVectorHelper.setBit(valueBuffer, index);
       } else {
-        BitVectorHelper.setValidityBitToZero(valueBuffer, index);
+        BitVectorHelper.unsetBit(valueBuffer, index);
       }
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -362,11 +362,11 @@ public final class BitVector extends BaseFixedWidthVector {
    * @param holder data holder for value of element
    */
   public void set(int index, BitHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     if (holder.value != 0) {
-      BitVectorHelper.setValidityBitToOne(valueBuffer, index);
+      BitVectorHelper.setBit(valueBuffer, index);
     } else {
-      BitVectorHelper.setValidityBitToZero(valueBuffer, index);
+      BitVectorHelper.unsetBit(valueBuffer, index);
     }
   }
 
@@ -421,7 +421,7 @@ public final class BitVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -445,8 +445,8 @@ public final class BitVector extends BaseFixedWidthVector {
    * @param index position of element
    */
   public void setToOne(int index) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
-    BitVectorHelper.setValidityBitToOne(valueBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
+    BitVectorHelper.setBit(valueBuffer, index);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -55,13 +55,25 @@ public class BitVectorHelper {
    * @param validityBuffer validity buffer of the vector
    * @param index index to be set
    */
-  public static void setValidityBitToOne(ArrowBuf validityBuffer, int index) {
+  public static void setBit(ArrowBuf validityBuffer, int index) {
     final int byteIndex = byteIndex(index);
     final int bitIndex = bitIndex(index);
+
+    // the byte is promoted to an int, because according to Java specification,
+    // bytes will be promoted to ints automatically, upon expression evaluation.
+    // by promoting it manually, we avoid the unnecessary conversions.
     int currentByte = validityBuffer.getByte(byteIndex);
     final int bitMask = 1 << bitIndex;
     currentByte |= bitMask;
     validityBuffer.setByte(byteIndex, currentByte);
+  }
+
+  /**
+   * @deprecated Please use {@link BitVectorHelper#setBit(ArrowBuf, int)} instead..
+   */
+  @Deprecated
+  public static void setValidityBitToOne(ArrowBuf validityBuffer, int index) {
+    setBit(validityBuffer, index);
   }
 
   /**
@@ -70,9 +82,13 @@ public class BitVectorHelper {
    * @param validityBuffer validity buffer of the vector
    * @param index index to be set
    */
-  public static void setValidityBitToZero(ArrowBuf validityBuffer, int index) {
+  public static void unsetBit(ArrowBuf validityBuffer, int index) {
     final int byteIndex = byteIndex(index);
     final int bitIndex = bitIndex(index);
+
+    // the byte is promoted to an int, because according to Java specification,
+    // bytes will be promoted to ints automatically, upon expression evaluation.
+    // by promoting it manually, we avoid the unnecessary conversions.
     int currentByte = validityBuffer.getByte(byteIndex);
     final int bitMask = 1 << bitIndex;
     currentByte &= ~bitMask;
@@ -89,6 +105,10 @@ public class BitVectorHelper {
   public static void setValidityBit(ArrowBuf validityBuffer, int index, int value) {
     final int byteIndex = byteIndex(index);
     final int bitIndex = bitIndex(index);
+
+    // the byte is promoted to an int, because according to Java specification,
+    // bytes will be promoted to ints automatically, upon expression evaluation.
+    // by promoting it manually, we avoid the unnecessary conversions.
     int currentByte = validityBuffer.getByte(byteIndex);
     final int bitMask = 1 << bitIndex;
     if (value != 0) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -58,9 +58,24 @@ public class BitVectorHelper {
   public static void setValidityBitToOne(ArrowBuf validityBuffer, int index) {
     final int byteIndex = byteIndex(index);
     final int bitIndex = bitIndex(index);
-    byte currentByte = validityBuffer.getByte(byteIndex);
-    final byte bitMask = (byte) (1L << bitIndex);
+    int currentByte = validityBuffer.getByte(byteIndex);
+    final int bitMask = 1 << bitIndex;
     currentByte |= bitMask;
+    validityBuffer.setByte(byteIndex, currentByte);
+  }
+
+  /**
+   * Set the bit at provided index to 0.
+   *
+   * @param validityBuffer validity buffer of the vector
+   * @param index index to be set
+   */
+  public static void setValidityBitToZero(ArrowBuf validityBuffer, int index) {
+    final int byteIndex = byteIndex(index);
+    final int bitIndex = bitIndex(index);
+    int currentByte = validityBuffer.getByte(byteIndex);
+    final int bitMask = 1 << bitIndex;
+    currentByte &= ~bitMask;
     validityBuffer.setByte(byteIndex, currentByte);
   }
 
@@ -74,12 +89,12 @@ public class BitVectorHelper {
   public static void setValidityBit(ArrowBuf validityBuffer, int index, int value) {
     final int byteIndex = byteIndex(index);
     final int bitIndex = bitIndex(index);
-    byte currentByte = validityBuffer.getByte(byteIndex);
-    final byte bitMask = (byte) (1L << bitIndex);
+    int currentByte = validityBuffer.getByte(byteIndex);
+    final int bitMask = 1 << bitIndex;
     if (value != 0) {
       currentByte |= bitMask;
     } else {
-      currentByte -= (bitMask & currentByte);
+      currentByte &= ~bitMask;
     }
     validityBuffer.setByte(byteIndex, currentByte);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVectorHelper.java
@@ -56,6 +56,9 @@ public class BitVectorHelper {
    * @param index index to be set
    */
   public static void setBit(ArrowBuf validityBuffer, int index) {
+    // it can be observed that some logic is duplicate of the logic in setValidityBit.
+    // this is because JIT cannot always remove the if branch in setValidityBit,
+    // so we give a dedicated implementation for setting bits.
     final int byteIndex = byteIndex(index);
     final int bitIndex = bitIndex(index);
 
@@ -83,6 +86,9 @@ public class BitVectorHelper {
    * @param index index to be set
    */
   public static void unsetBit(ArrowBuf validityBuffer, int index) {
+    // it can be observed that some logic is duplicate of the logic in setValidityBit.
+    // this is because JIT cannot always remove the if branch in setValidityBit,
+    // so we give a dedicated implementation for unsetting bits.
     final int byteIndex = byteIndex(index);
     final int bitIndex = bitIndex(index);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
@@ -164,7 +164,7 @@ public final class DateDayVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -180,10 +180,10 @@ public final class DateDayVector extends BaseFixedWidthVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -194,7 +194,7 @@ public final class DateDayVector extends BaseFixedWidthVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, DateDayHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -249,7 +249,7 @@ public final class DateDayVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateDayVector.java
@@ -183,7 +183,7 @@ public final class DateDayVector extends BaseFixedWidthVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -249,7 +249,7 @@ public final class DateDayVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
@@ -187,7 +187,7 @@ public final class DateMilliVector extends BaseFixedWidthVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -253,7 +253,7 @@ public final class DateMilliVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DateMilliVector.java
@@ -168,7 +168,7 @@ public final class DateMilliVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, long value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -184,10 +184,10 @@ public final class DateMilliVector extends BaseFixedWidthVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -198,7 +198,7 @@ public final class DateMilliVector extends BaseFixedWidthVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, DateMilliHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -253,7 +253,7 @@ public final class DateMilliVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -185,7 +185,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
    * @param buffer   ArrowBuf containing decimal value.
    */
   public void set(int index, ArrowBuf buffer) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     valueBuffer.setBytes(index * TYPE_WIDTH, buffer, 0, TYPE_WIDTH);
   }
 
@@ -205,7 +205,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
    * @param value array of bytes containing decimal in big endian byte order.
    */
   public void setBigEndian(int index, byte[] value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     final int length = value.length;
 
     // do the bound check.
@@ -241,7 +241,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
    * @param buffer   ArrowBuf containing decimal value.
    */
   public void set(int index, int start, ArrowBuf buffer) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     valueBuffer.setBytes(index * TYPE_WIDTH, buffer, start, TYPE_WIDTH);
   }
 
@@ -254,7 +254,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
    */
   public void setSafe(int index, int start, ArrowBuf buffer, int length) {
     handleSafe(index);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
 
     // do the bound checks.
     buffer.checkBytes(start, start + length);
@@ -281,7 +281,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
    */
   public void setBigEndianSafe(int index, int start, ArrowBuf buffer, int length) {
     handleSafe(index);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
 
     // do the bound checks.
     buffer.checkBytes(start, start + length);
@@ -310,7 +310,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
    * @param value   BigDecimal containing decimal value.
    */
   public void set(int index, BigDecimal value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     DecimalUtility.checkPrecisionAndScale(value, precision, scale);
     DecimalUtility.writeBigDecimalToArrowBuf(value, valueBuffer, index);
   }
@@ -322,7 +322,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
    * @param value   long value.
    */
   public void set(int index, long value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     DecimalUtility.writeLongToArrowBuf(value, valueBuffer, index);
   }
 
@@ -338,10 +338,10 @@ public final class DecimalVector extends BaseFixedWidthVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       valueBuffer.setBytes(index * TYPE_WIDTH, holder.buffer, holder.start, TYPE_WIDTH);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -352,7 +352,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, DecimalHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     valueBuffer.setBytes(index * TYPE_WIDTH, holder.buffer, holder.start, TYPE_WIDTH);
   }
 
@@ -458,7 +458,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, start, buffer);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -341,7 +341,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       valueBuffer.setBytes(index * TYPE_WIDTH, holder.buffer, holder.start, TYPE_WIDTH);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -458,7 +458,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, start, buffer);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
@@ -206,7 +206,7 @@ public final class DurationVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, ArrowBuf value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     valueBuffer.setBytes(index * TYPE_WIDTH, value, 0, TYPE_WIDTH);
   }
 
@@ -218,7 +218,7 @@ public final class DurationVector extends BaseFixedWidthVector {
    */
   public void set(int index, long value) {
     final int offsetIndex = index * TYPE_WIDTH;
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     valueBuffer.setLong(offsetIndex, value);
   }
 
@@ -236,7 +236,7 @@ public final class DurationVector extends BaseFixedWidthVector {
     } else if (holder.isSet > 0) {
       set(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -314,7 +314,7 @@ public final class DurationVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
@@ -236,7 +236,7 @@ public final class DurationVector extends BaseFixedWidthVector {
     } else if (holder.isSet > 0) {
       set(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -314,7 +314,7 @@ public final class DurationVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
@@ -166,7 +166,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
     assert index >= 0;
     Preconditions.checkNotNull(value, "expecting a valid byte array");
     assert byteWidth <= value.length;
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     valueBuffer.setBytes(index * byteWidth, value, 0, byteWidth);
   }
 
@@ -186,7 +186,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -204,7 +204,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
   public void set(int index, ArrowBuf buffer) {
     assert index >= 0;
     assert byteWidth <= buffer.capacity();
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     valueBuffer.setBytes(index * byteWidth, buffer, 0, byteWidth);
   }
 
@@ -231,7 +231,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, buffer);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -287,7 +287,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
     } else if (holder.isSet > 0) {
       set(index, holder.buffer);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/FixedSizeBinaryVector.java
@@ -186,7 +186,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -231,7 +231,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, buffer);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -287,7 +287,7 @@ public class FixedSizeBinaryVector extends BaseFixedWidthVector {
     } else if (holder.isSet > 0) {
       set(index, holder.buffer);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
@@ -165,7 +165,7 @@ public final class Float4Vector extends BaseFixedWidthVector implements Floating
    * @param value   value of element
    */
   public void set(int index, float value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -181,10 +181,10 @@ public final class Float4Vector extends BaseFixedWidthVector implements Floating
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -195,7 +195,7 @@ public final class Float4Vector extends BaseFixedWidthVector implements Floating
    * @param holder  data holder for value of element
    */
   public void set(int index, Float4Holder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -250,7 +250,7 @@ public final class Float4Vector extends BaseFixedWidthVector implements Floating
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float4Vector.java
@@ -184,7 +184,7 @@ public final class Float4Vector extends BaseFixedWidthVector implements Floating
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -250,7 +250,7 @@ public final class Float4Vector extends BaseFixedWidthVector implements Floating
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
@@ -166,7 +166,7 @@ public final class Float8Vector extends BaseFixedWidthVector implements Floating
    * @param value   value of element
    */
   public void set(int index, double value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -182,10 +182,10 @@ public final class Float8Vector extends BaseFixedWidthVector implements Floating
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -196,7 +196,7 @@ public final class Float8Vector extends BaseFixedWidthVector implements Floating
    * @param holder  data holder for value of element
    */
   public void set(int index, Float8Holder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -251,7 +251,7 @@ public final class Float8Vector extends BaseFixedWidthVector implements Floating
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/Float8Vector.java
@@ -185,7 +185,7 @@ public final class Float8Vector extends BaseFixedWidthVector implements Floating
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -251,7 +251,7 @@ public final class Float8Vector extends BaseFixedWidthVector implements Floating
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -184,7 +184,7 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -250,7 +250,7 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -165,7 +165,7 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
    * @param value value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -181,10 +181,10 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -195,7 +195,7 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
    * @param holder data holder for value of element
    */
   public void set(int index, IntHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -250,7 +250,7 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
@@ -269,7 +269,7 @@ public final class IntervalDayVector extends BaseFixedWidthVector {
     } else if (holder.isSet > 0) {
       set(index, holder.days, holder.milliseconds);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -349,7 +349,7 @@ public final class IntervalDayVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, days, milliseconds);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalDayVector.java
@@ -237,7 +237,7 @@ public final class IntervalDayVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, ArrowBuf value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     valueBuffer.setBytes(index * TYPE_WIDTH, value, 0, TYPE_WIDTH);
   }
 
@@ -250,7 +250,7 @@ public final class IntervalDayVector extends BaseFixedWidthVector {
    */
   public void set(int index, int days, int milliseconds) {
     final int offsetIndex = index * TYPE_WIDTH;
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     valueBuffer.setInt(offsetIndex, days);
     valueBuffer.setInt((offsetIndex + MILLISECOND_OFFSET), milliseconds);
   }
@@ -269,7 +269,7 @@ public final class IntervalDayVector extends BaseFixedWidthVector {
     } else if (holder.isSet > 0) {
       set(index, holder.days, holder.milliseconds);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -349,7 +349,7 @@ public final class IntervalDayVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, days, milliseconds);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
@@ -233,7 +233,7 @@ public final class IntervalYearVector extends BaseFixedWidthVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -299,7 +299,7 @@ public final class IntervalYearVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntervalYearVector.java
@@ -214,7 +214,7 @@ public final class IntervalYearVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -230,10 +230,10 @@ public final class IntervalYearVector extends BaseFixedWidthVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -244,7 +244,7 @@ public final class IntervalYearVector extends BaseFixedWidthVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, IntervalYearHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -299,7 +299,7 @@ public final class IntervalYearVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -169,7 +169,7 @@ public final class SmallIntVector extends BaseFixedWidthVector implements BaseIn
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -180,7 +180,7 @@ public final class SmallIntVector extends BaseFixedWidthVector implements BaseIn
    * @param value   value of element
    */
   public void set(int index, short value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -196,10 +196,10 @@ public final class SmallIntVector extends BaseFixedWidthVector implements BaseIn
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -210,7 +210,7 @@ public final class SmallIntVector extends BaseFixedWidthVector implements BaseIn
    * @param holder  data holder for value of element
    */
   public void set(int index, SmallIntHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -278,7 +278,7 @@ public final class SmallIntVector extends BaseFixedWidthVector implements BaseIn
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/SmallIntVector.java
@@ -199,7 +199,7 @@ public final class SmallIntVector extends BaseFixedWidthVector implements BaseIn
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -278,7 +278,7 @@ public final class SmallIntVector extends BaseFixedWidthVector implements BaseIn
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
@@ -165,7 +165,7 @@ public final class TimeMicroVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, long value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -181,10 +181,10 @@ public final class TimeMicroVector extends BaseFixedWidthVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -195,7 +195,7 @@ public final class TimeMicroVector extends BaseFixedWidthVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeMicroHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -250,7 +250,7 @@ public final class TimeMicroVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMicroVector.java
@@ -184,7 +184,7 @@ public final class TimeMicroVector extends BaseFixedWidthVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -250,7 +250,7 @@ public final class TimeMicroVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
@@ -169,7 +169,7 @@ public final class TimeMilliVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -185,10 +185,10 @@ public final class TimeMilliVector extends BaseFixedWidthVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -199,7 +199,7 @@ public final class TimeMilliVector extends BaseFixedWidthVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeMilliHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -254,7 +254,7 @@ public final class TimeMilliVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeMilliVector.java
@@ -188,7 +188,7 @@ public final class TimeMilliVector extends BaseFixedWidthVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -254,7 +254,7 @@ public final class TimeMilliVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
@@ -166,7 +166,7 @@ public final class TimeNanoVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, long value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -182,10 +182,10 @@ public final class TimeNanoVector extends BaseFixedWidthVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -196,7 +196,7 @@ public final class TimeNanoVector extends BaseFixedWidthVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeNanoHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -251,7 +251,7 @@ public final class TimeNanoVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeNanoVector.java
@@ -185,7 +185,7 @@ public final class TimeNanoVector extends BaseFixedWidthVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -251,7 +251,7 @@ public final class TimeNanoVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
@@ -166,7 +166,7 @@ public final class TimeSecVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -182,10 +182,10 @@ public final class TimeSecVector extends BaseFixedWidthVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -196,7 +196,7 @@ public final class TimeSecVector extends BaseFixedWidthVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeSecHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -251,7 +251,7 @@ public final class TimeSecVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeSecVector.java
@@ -185,7 +185,7 @@ public final class TimeSecVector extends BaseFixedWidthVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -251,7 +251,7 @@ public final class TimeSecVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
@@ -160,7 +160,7 @@ public final class TimeStampMicroTZVector extends TimeStampVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroTZVector.java
@@ -157,10 +157,10 @@ public final class TimeStampMicroTZVector extends TimeStampVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -171,7 +171,7 @@ public final class TimeStampMicroTZVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampMicroTZHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
@@ -154,10 +154,10 @@ public final class TimeStampMicroVector extends TimeStampVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -168,7 +168,7 @@ public final class TimeStampMicroVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampMicroHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMicroVector.java
@@ -157,7 +157,7 @@ public final class TimeStampMicroVector extends TimeStampVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
@@ -160,7 +160,7 @@ public final class TimeStampMilliTZVector extends TimeStampVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliTZVector.java
@@ -157,10 +157,10 @@ public final class TimeStampMilliTZVector extends TimeStampVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -171,7 +171,7 @@ public final class TimeStampMilliTZVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampMilliTZHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
@@ -157,7 +157,7 @@ public final class TimeStampMilliVector extends TimeStampVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampMilliVector.java
@@ -154,10 +154,10 @@ public final class TimeStampMilliVector extends TimeStampVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -168,7 +168,7 @@ public final class TimeStampMilliVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampMilliHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
@@ -157,10 +157,10 @@ public final class TimeStampNanoTZVector extends TimeStampVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -171,7 +171,7 @@ public final class TimeStampNanoTZVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampNanoTZHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoTZVector.java
@@ -160,7 +160,7 @@ public final class TimeStampNanoTZVector extends TimeStampVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
@@ -157,7 +157,7 @@ public final class TimeStampNanoVector extends TimeStampVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampNanoVector.java
@@ -154,10 +154,10 @@ public final class TimeStampNanoVector extends TimeStampVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -168,7 +168,7 @@ public final class TimeStampNanoVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampNanoHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
@@ -157,10 +157,10 @@ public final class TimeStampSecTZVector extends TimeStampVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -171,7 +171,7 @@ public final class TimeStampSecTZVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampSecTZHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecTZVector.java
@@ -160,7 +160,7 @@ public final class TimeStampSecTZVector extends TimeStampVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
@@ -155,10 +155,10 @@ public final class TimeStampSecVector extends TimeStampVector {
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -169,7 +169,7 @@ public final class TimeStampSecVector extends TimeStampVector {
    * @param holder  data holder for value of element
    */
   public void set(int index, TimeStampSecHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampSecVector.java
@@ -158,7 +158,7 @@ public final class TimeStampSecVector extends TimeStampVector {
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampVector.java
@@ -125,7 +125,7 @@ public abstract class TimeStampVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TimeStampVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TimeStampVector.java
@@ -96,7 +96,7 @@ public abstract class TimeStampVector extends BaseFixedWidthVector {
    * @param value   value of element
    */
   public void set(int index, long value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -125,7 +125,7 @@ public abstract class TimeStampVector extends BaseFixedWidthVector {
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -169,7 +169,7 @@ public final class TinyIntVector extends BaseFixedWidthVector implements BaseInt
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -180,7 +180,7 @@ public final class TinyIntVector extends BaseFixedWidthVector implements BaseInt
    * @param value   value of element
    */
   public void set(int index, byte value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -196,10 +196,10 @@ public final class TinyIntVector extends BaseFixedWidthVector implements BaseInt
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -210,7 +210,7 @@ public final class TinyIntVector extends BaseFixedWidthVector implements BaseInt
    * @param holder  data holder for value of element
    */
   public void set(int index, TinyIntHolder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -278,7 +278,7 @@ public final class TinyIntVector extends BaseFixedWidthVector implements BaseInt
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TinyIntVector.java
@@ -199,7 +199,7 @@ public final class TinyIntVector extends BaseFixedWidthVector implements BaseInt
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -278,7 +278,7 @@ public final class TinyIntVector extends BaseFixedWidthVector implements BaseInt
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -169,7 +169,7 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -180,7 +180,7 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param value   value of element
    */
   public void set(int index, byte value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -196,10 +196,10 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -210,7 +210,7 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param holder  data holder for value of element
    */
   public void set(int index, UInt1Holder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -274,7 +274,7 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -199,7 +199,7 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -274,7 +274,7 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -179,7 +179,7 @@ public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVe
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -254,7 +254,7 @@ public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVe
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt2Vector.java
@@ -149,7 +149,7 @@ public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -160,7 +160,7 @@ public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param value   value of element
    */
   public void set(int index, char value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -176,10 +176,10 @@ public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVe
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -190,7 +190,7 @@ public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param holder  data holder for value of element
    */
   public void set(int index, UInt2Holder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -254,7 +254,7 @@ public final class UInt2Vector extends BaseFixedWidthVector implements BaseIntVe
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -163,7 +163,7 @@ public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param value   value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -179,10 +179,10 @@ public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVe
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -193,7 +193,7 @@ public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param holder  data holder for value of element
    */
   public void set(int index, UInt4Holder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -244,7 +244,7 @@ public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVe
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt4Vector.java
@@ -182,7 +182,7 @@ public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVe
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -244,7 +244,7 @@ public final class UInt4Vector extends BaseFixedWidthVector implements BaseIntVe
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -168,7 +168,7 @@ public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param value   value of element
    */
   public void set(int index, long value) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, value);
   }
 
@@ -184,10 +184,10 @@ public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVe
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 
@@ -198,7 +198,7 @@ public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVe
    * @param holder  data holder for value of element
    */
   public void set(int index, UInt8Holder holder) {
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     setValue(index, holder.value);
   }
 
@@ -246,7 +246,7 @@ public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVe
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+      BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt8Vector.java
@@ -187,7 +187,7 @@ public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVe
       BitVectorHelper.setValidityBitToOne(validityBuffer, index);
       setValue(index, holder.value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 
@@ -246,7 +246,7 @@ public final class UInt8Vector extends BaseFixedWidthVector implements BaseIntVe
     if (isSet > 0) {
       set(index, value);
     } else {
-      BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, index);
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
@@ -165,7 +165,7 @@ public final class VarBinaryVector extends BaseVariableWidthVector {
   public void set(int index, VarBinaryHolder holder) {
     assert index >= 0;
     fillHoles(index);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     final int dataLength = holder.end - holder.start;
     final int startOffset = getStartOffset(index);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + dataLength);
@@ -186,7 +186,7 @@ public final class VarBinaryVector extends BaseVariableWidthVector {
     final int dataLength = holder.end - holder.start;
     fillEmpties(index);
     handleSafe(index, dataLength);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = getStartOffset(index);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + dataLength);
     valueBuffer.setBytes(startOffset, holder.buffer, holder.start, dataLength);

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -167,7 +167,7 @@ public final class VarCharVector extends BaseVariableWidthVector {
   public void set(int index, VarCharHolder holder) {
     assert index >= 0;
     fillHoles(index);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     final int dataLength = holder.end - holder.start;
     final int startOffset = getStartOffset(index);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + dataLength);
@@ -188,7 +188,7 @@ public final class VarCharVector extends BaseVariableWidthVector {
     final int dataLength = holder.end - holder.start;
     fillEmpties(index);
     handleSafe(index, dataLength);
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = getStartOffset(index);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + dataLength);
     valueBuffer.setBytes(startOffset, holder.buffer, holder.start, dataLength);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -281,7 +281,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
       reallocValidityBuffer();
     }
 
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     return index * listSize;
   }
 
@@ -493,7 +493,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
     while (index >= getValidityBufferValueCapacity()) {
       reallocValidityBuffer();
     }
-    BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+    BitVectorHelper.unsetBit(validityBuffer, index);
   }
 
   /** Sets the value at index to not-null. Reallocates if index is larger than capacity. */
@@ -501,7 +501,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
     while (index >= getValidityBufferValueCapacity()) {
       reallocValidityBuffer();
     }
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -493,7 +493,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
     while (index >= getValidityBufferValueCapacity()) {
       reallocValidityBuffer();
     }
-    BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+    BitVectorHelper.setValidityBitToZero(validityBuffer, index);
   }
 
   /** Sets the value at index to not-null. Reallocates if index is larger than capacity. */

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -767,7 +767,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
     while (index >= getValidityAndOffsetValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     lastSet = index;
   }
 
@@ -785,7 +785,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
       final int currentOffset = offsetBuffer.getInt(i * OFFSET_WIDTH);
       offsetBuffer.setInt((i + 1) * OFFSET_WIDTH, currentOffset);
     }
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
     lastSet = index;
     return offsetBuffer.getInt((lastSet + 1) * OFFSET_WIDTH);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -539,7 +539,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
       /* realloc the inner buffers if needed */
       reallocValidityBuffer();
     }
-    BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+    BitVectorHelper.setBit(validityBuffer, index);
   }
 
   /**
@@ -550,7 +550,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
       /* realloc the inner buffers if needed */
       reallocValidityBuffer();
     }
-    BitVectorHelper.setValidityBitToZero(validityBuffer, index);
+    BitVectorHelper.unsetBit(validityBuffer, index);
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -550,7 +550,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
       /* realloc the inner buffers if needed */
       reallocValidityBuffer();
     }
-    BitVectorHelper.setValidityBit(validityBuffer, index, 0);
+    BitVectorHelper.setValidityBitToZero(validityBuffer, index);
   }
 
   @Override

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -83,28 +83,28 @@ public class TestBitVectorHelper {
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1025;
-      BitVectorHelper.setValidityBit(validityBuffer, 12, 1);
+      BitVectorHelper.setValidityBitToOne(validityBuffer, 12);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1025;
-      BitVectorHelper.setValidityBit(validityBuffer, 1024, 1);
+      BitVectorHelper.setValidityBitToOne(validityBuffer, 1024);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1026;
-      BitVectorHelper.setValidityBit(validityBuffer, 1024, 1);
+      BitVectorHelper.setValidityBitToOne(validityBuffer, 1024);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1027;
-      BitVectorHelper.setValidityBit(validityBuffer, 1025, 1);
+      BitVectorHelper.setValidityBitToOne(validityBuffer, 1025);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1031;
-      BitVectorHelper.setValidityBit(validityBuffer, 1029, 1);
-      BitVectorHelper.setValidityBit(validityBuffer, 1030, 1);
+      BitVectorHelper.setValidityBitToOne(validityBuffer, 1029);
+      BitVectorHelper.setValidityBitToOne(validityBuffer, 1030);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
     }
   }
@@ -124,28 +124,28 @@ public class TestBitVectorHelper {
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1025;
-      BitVectorHelper.setValidityBit(validityBuffer, 12, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, 12);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1025;
-      BitVectorHelper.setValidityBit(validityBuffer, 1024, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, 1024);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1026;
-      BitVectorHelper.setValidityBit(validityBuffer, 1024, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, 1024);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1027;
-      BitVectorHelper.setValidityBit(validityBuffer, 1025, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, 1025);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1031;
-      BitVectorHelper.setValidityBit(validityBuffer, 1029, 0);
-      BitVectorHelper.setValidityBit(validityBuffer, 1030, 0);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, 1029);
+      BitVectorHelper.setValidityBitToZero(validityBuffer, 1030);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -83,28 +83,28 @@ public class TestBitVectorHelper {
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1025;
-      BitVectorHelper.setValidityBitToOne(validityBuffer, 12);
+      BitVectorHelper.setBit(validityBuffer, 12);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1025;
-      BitVectorHelper.setValidityBitToOne(validityBuffer, 1024);
+      BitVectorHelper.setBit(validityBuffer, 1024);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1026;
-      BitVectorHelper.setValidityBitToOne(validityBuffer, 1024);
+      BitVectorHelper.setBit(validityBuffer, 1024);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1027;
-      BitVectorHelper.setValidityBitToOne(validityBuffer, 1025);
+      BitVectorHelper.setBit(validityBuffer, 1025);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
 
       validityBuffer.setZero(0, bufferLength);
       bitLength = 1031;
-      BitVectorHelper.setValidityBitToOne(validityBuffer, 1029);
-      BitVectorHelper.setValidityBitToOne(validityBuffer, 1030);
+      BitVectorHelper.setBit(validityBuffer, 1029);
+      BitVectorHelper.setBit(validityBuffer, 1030);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, false));
     }
   }
@@ -124,28 +124,28 @@ public class TestBitVectorHelper {
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1025;
-      BitVectorHelper.setValidityBitToZero(validityBuffer, 12);
+      BitVectorHelper.unsetBit(validityBuffer, 12);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1025;
-      BitVectorHelper.setValidityBitToZero(validityBuffer, 1024);
+      BitVectorHelper.unsetBit(validityBuffer, 1024);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1026;
-      BitVectorHelper.setValidityBitToZero(validityBuffer, 1024);
+      BitVectorHelper.unsetBit(validityBuffer, 1024);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1027;
-      BitVectorHelper.setValidityBitToZero(validityBuffer, 1025);
+      BitVectorHelper.unsetBit(validityBuffer, 1025);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
 
       PlatformDependent.setMemory(validityBuffer.memoryAddress(), bufferLength, (byte) -1);
       bitLength = 1031;
-      BitVectorHelper.setValidityBitToZero(validityBuffer, 1029);
-      BitVectorHelper.setValidityBitToZero(validityBuffer, 1030);
+      BitVectorHelper.unsetBit(validityBuffer, 1029);
+      BitVectorHelper.unsetBit(validityBuffer, 1030);
       assertFalse(BitVectorHelper.checkAllBitsEqualTo(validityBuffer, bitLength, true));
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -142,7 +142,7 @@ public class TestListVector {
       int offset = 0;
 
       /* write [10, 11, 12] to the list vector at index 0 */
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       dataVector.setSafe(0, 1, 10);
       dataVector.setSafe(1, 1, 11);
       dataVector.setSafe(2, 1, 12);
@@ -151,7 +151,7 @@ public class TestListVector {
       index += 1;
 
       /* write [13, 14] to the list vector at index 1 */
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       dataVector.setSafe(3, 1, 13);
       dataVector.setSafe(4, 1, 14);
       offsetBuffer.setInt((index + 1) * ListVector.OFFSET_WIDTH, 5);
@@ -159,7 +159,7 @@ public class TestListVector {
       index += 1;
 
       /* write [15, 16, 17] to the list vector at index 2 */
-      BitVectorHelper.setValidityBitToOne(validityBuffer, index);
+      BitVectorHelper.setBit(validityBuffer, index);
       dataVector.setSafe(5, 1, 15);
       dataVector.setSafe(6, 1, 16);
       dataVector.setSafe(7, 1, 17);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -1948,7 +1948,7 @@ public class TestValueVector {
   public static void setBytes(int index, byte[] bytes, VarCharVector vector) {
     final int currentOffset = vector.offsetBuffer.getInt(index * vector.OFFSET_WIDTH);
 
-    BitVectorHelper.setValidityBitToOne(vector.validityBuffer, index);
+    BitVectorHelper.setBit(vector.validityBuffer, index);
     vector.offsetBuffer.setInt((index + 1) * vector.OFFSET_WIDTH, currentOffset + bytes.length);
     vector.valueBuffer.setBytes(currentOffset, bytes, 0, bytes.length);
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
@@ -213,7 +213,7 @@ public class TestVectorUnloadLoad {
       values[i + 1] = buf2;
       for (int j = 0; j < count; j++) {
         if (i == 2) {
-          BitVectorHelper.setValidityBit(buf1, j, 0);
+          BitVectorHelper.setValidityBitToZero(buf1, j);
         } else {
           BitVectorHelper.setValidityBitToOne(buf1, j);
         }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
@@ -213,9 +213,9 @@ public class TestVectorUnloadLoad {
       values[i + 1] = buf2;
       for (int j = 0; j < count; j++) {
         if (i == 2) {
-          BitVectorHelper.setValidityBitToZero(buf1, j);
+          BitVectorHelper.unsetBit(buf1, j);
         } else {
-          BitVectorHelper.setValidityBitToOne(buf1, j);
+          BitVectorHelper.setBit(buf1, j);
         }
 
         buf2.setInt(j * 4, j);


### PR DESCRIPTION
Setting/clearing individual bits are key operations for Arrow. In this issue, we improve the performance these operations by:

1. replacing arithmetic operations with bit-wise operations
2. remove unnecessary casts between int/byte
3. provide new API to remove the if branch

Benchmark results show that for clearing a bit, the performance improve by 11%, and for general set/clear operation, the performance improve by 4.7%:

before:
BitVectorHelperBenchmarks.setValidityBitBenchmark avgt 5 4.524 ± 0.015 us/op

after:
BitVectorHelperBenchmarks.setValidityBitBenchmark avgt 5 4.313 ± 0.011 us/op
BitVectorHelperBenchmarks.setValidityBitToZeroBenchmark avgt 5 4.020 ± 0.016 us/op