### PR TITLE
ARROW-7085: Custom column builder for CSV reader

### DIFF
--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -19,11 +19,14 @@
 #define ARROW_CSV_OPTIONS_H
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include "arrow/csv/column_builder.h"
+#include "arrow/util/task_group.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -67,7 +70,16 @@ struct ARROW_EXPORT ConvertOptions {
   bool check_utf8 = true;
   /// Optional per-column types (disabling type inference on those columns)
   std::unordered_map<std::string, std::shared_ptr<DataType>> column_types;
-  /// Recognized spellings for null values
+
+  /// Optional per-column fabrics for custom column builders
+  std::unordered_map<
+      std::string,
+      std::function<Status(MemoryPool* pool, const std::shared_ptr<DataType>& type,
+                           int32_t col_index, const ConvertOptions& options,
+                           const std::shared_ptr<internal::TaskGroup>& task_group,
+                           std::shared_ptr<ColumnBuilder>* out)>>
+      column_builder_fabrics;
+  // Recognized spellings for null values
   std::vector<std::string> null_values;
   /// Recognized spellings for boolean true values
   std::vector<std::string> true_values;

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -225,6 +225,12 @@ class BaseTableReader : public csv::TableReader {
     if (it == convert_options_.column_types.end()) {
       return ColumnBuilder::Make(pool_, col_index, convert_options_, task_group_, out);
     } else {
+      auto builder_fabric =
+          convert_options_.column_builder_fabrics.find(col_name);
+      if (builder_fabric != convert_options_.column_builder_fabrics.end()) {
+        return builder_fabric->second(pool_, it->second, col_index, convert_options_,
+                                      task_group_, out);
+      }
       return ColumnBuilder::Make(pool_, it->second, col_index, convert_options_,
                                  task_group_, out);
     }


### PR DESCRIPTION
As discussed in [ARROW-7085](https://issues.apache.org/jira/browse/ARROW-7085), I've implemented one of the ways to provide custom column builder to a column. 
However, it doesn't look like final solution for me. Hope to hear your thought about possible implementation. 