### PR TITLE
ARROW-7213: [Java] Represent a data element of a vector as a tree of ArrowBufPointer

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ArrowBufPointerNode.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ArrowBufPointerNode.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory.util;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Queue;
+
+/**
+ * A node in the tree which has ArrowBufPointers as leaf nodes.
+ */
+public final class ArrowBufPointerNode implements Comparable<ArrowBufPointerNode>, Iterable<ArrowBufPointer> {
+
+  /**
+   * A flag indicating if this is a leaf node.
+   */
+  private final boolean leafNode;
+
+  /**
+   * Reference to an ArrowBufPointer.
+   * It is valid only if it is a leaf node.
+   */
+  private final ArrowBufPointer pointer;
+
+  /**
+   * Reference to child nodes.
+   * It is valid only if it is a non-leaf node.
+   */
+  private final ArrowBufPointerNode[] children;
+
+  /**
+   * Constructor for leaf nodes.
+   * @param pointer pointer to an ArrowBufPointer.
+   */
+  public ArrowBufPointerNode(ArrowBufPointer pointer) {
+    this.leafNode = true;
+    this.pointer = pointer;
+    this.children = null;
+  }
+
+  /**
+   * Constructor for non-leaf nodes.
+   * @param children child nodes.
+   */
+  public ArrowBufPointerNode(ArrowBufPointerNode[] children) {
+    this.leafNode = false;
+    this.children = children;
+    this.pointer = null;
+  }
+
+  @Override
+  public int compareTo(ArrowBufPointerNode o) {
+    Iterator<ArrowBufPointer> iter1 = this.iterator();
+    Iterator<ArrowBufPointer> iter2 = o.iterator();
+
+    while (iter1.hasNext() && iter2.hasNext()) {
+      ArrowBufPointer pointer1 = iter1.next();
+      ArrowBufPointer pointer2 = iter2.next();
+
+      int result = pointer1.compareTo(pointer2);
+      if (result != 0) {
+        return result;
+      }
+    }
+
+    if (iter1.hasNext() || iter2.hasNext()) {
+      // the two iterators have different lengths.
+      if (iter1.hasNext()) {
+        return 1;
+      } else {
+        return -1;
+      }
+    }
+    return 0;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof ArrowBufPointerNode)) {
+      return false;
+    }
+
+    ArrowBufPointerNode other = (ArrowBufPointerNode) o;
+    if (this.leafNode != other.leafNode) {
+      return false;
+    }
+
+    if (this.leafNode) {
+      return this.pointer.equals(other.pointer);
+    } else {
+      if (this.children.length != other.children.length) {
+        return false;
+      }
+
+      for (int i = 0; i < this.children.length; i++) {
+        if (!this.children[i].equals(other.children[i])) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    if (leafNode) {
+      return pointer.hashCode();
+    } else {
+      int ret = 0;
+      for (int i = 0; i < children.length; i++) {
+        ret = ByteFunctionHelpers.combineHash(ret, children[i].hashCode());
+      }
+      return ret;
+    }
+  }
+
+  /**
+   * Checks if the node is a leaf node.
+   */
+  public boolean isLeafNode() {
+    return leafNode;
+  }
+
+  /**
+   * Gets the underlying pointer for the node.
+   * Valid only if it is a leaf node.
+   */
+  public ArrowBufPointer getArrowBufPointer() {
+    if (!leafNode) {
+      throw new UnsupportedOperationException("This is supported only for leaf nodes.");
+    }
+    return pointer;
+  }
+
+  /**
+   * Gets the child nodes.
+   * Valid only if it is a non-leaf node.
+   */
+  public ArrowBufPointerNode[] getChildNodes() {
+    if (leafNode) {
+      throw new UnsupportedOperationException("This is supported only for non-leaf nodes.");
+    }
+    return children;
+  }
+
+  @Override
+  public Iterator<ArrowBufPointer> iterator() {
+    return new ArrowBufPointerIterator();
+  }
+
+  private class ArrowBufPointerIterator implements Iterator<ArrowBufPointer> {
+
+    private ArrowBufPointer nextToReturn = null;
+
+    private Queue<ArrowBufPointerNode> nodesToCheck = new LinkedList<>();
+
+    ArrowBufPointerIterator() {
+      nodesToCheck.add(ArrowBufPointerNode.this);
+      findNext();
+    }
+
+    @Override
+    public boolean hasNext() {
+      return nextToReturn != null;
+    }
+
+    @Override
+    public ArrowBufPointer next() {
+      ArrowBufPointer ret = nextToReturn;
+
+      nextToReturn = null;
+      findNext();
+
+      return ret;
+    }
+
+    private void findNext() {
+      // traverse the tree in breadth-first order
+      while (!nodesToCheck.isEmpty()) {
+        ArrowBufPointerNode node = nodesToCheck.poll();
+        if (node.leafNode) {
+          nextToReturn = node.pointer;
+          return;
+        } else {
+          for (ArrowBufPointerNode child : node.children) {
+            nodesToCheck.add(child);
+          }
+        }
+      }
+    }
+  }
+}

--- a/java/memory/src/test/java/org/apache/arrow/memory/util/TestArrowBufPointerNode.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/util/TestArrowBufPointerNode.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory.util;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.netty.buffer.ArrowBuf;
+
+public class TestArrowBufPointerNode {
+
+  private BufferAllocator allocator;
+
+  private ArrowBuf intVector;
+
+  @Before
+  public void prepare() {
+    allocator = new RootAllocator(1024 * 1024);
+    intVector = allocator.buffer(4 * 10);
+
+    for (int i = 0; i < 10; i++) {
+      intVector.setInt(i * 4, i);
+    }
+  }
+
+  @After
+  public void shutdown() {
+    intVector.close();
+    allocator.close();
+  }
+
+  private ArrowBufPointerNode createTree1() {
+    // create a tree with structure:
+    //            root
+    //            /    \
+    //     node    node
+    //     /      \    /     \
+    //    1      2  3     4
+
+    ArrowBufPointerNode leaf1 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 1 * 4, 4));
+    ArrowBufPointerNode leaf2 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 2 * 4, 4));
+    ArrowBufPointerNode leaf3 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 3 * 4, 4));
+    ArrowBufPointerNode leaf4 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 4 * 4, 4));
+
+    ArrowBufPointerNode interNode1 = new ArrowBufPointerNode(new ArrowBufPointerNode[] {leaf1, leaf2});
+    ArrowBufPointerNode interNode2 = new ArrowBufPointerNode(new ArrowBufPointerNode[] {leaf3, leaf4});
+
+    return new ArrowBufPointerNode(new ArrowBufPointerNode[] {interNode1, interNode2});
+  }
+
+  private ArrowBufPointerNode createTree2() {
+    // create a tree with structure:
+    //            root
+    //            /    \
+    //     node    node
+    //     /      \    /     \
+    //    5      6  7     8
+
+    ArrowBufPointerNode leaf5 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 5 * 4, 4));
+    ArrowBufPointerNode leaf6 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 6 * 4, 4));
+    ArrowBufPointerNode leaf7 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 7 * 4, 4));
+    ArrowBufPointerNode leaf8 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 8 * 4, 4));
+
+    ArrowBufPointerNode interNode1 = new ArrowBufPointerNode(new ArrowBufPointerNode[] {leaf5, leaf6});
+    ArrowBufPointerNode interNode2 = new ArrowBufPointerNode(new ArrowBufPointerNode[] {leaf7, leaf8});
+
+    return new ArrowBufPointerNode(new ArrowBufPointerNode[] {interNode1, interNode2});
+  }
+
+  private ArrowBufPointerNode createTree3() {
+    // create a tree with structure:
+    //            root
+    //            /    \
+    //     node    node
+    //     /      \       |
+    //    1      2     3
+
+    ArrowBufPointerNode leaf1 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 1 * 4, 4));
+    ArrowBufPointerNode leaf2 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 2 * 4, 4));
+    ArrowBufPointerNode leaf3 = new ArrowBufPointerNode(new ArrowBufPointer(intVector, 3 * 4, 4));
+
+    ArrowBufPointerNode interNode1 = new ArrowBufPointerNode(new ArrowBufPointerNode[] {leaf1, leaf2});
+    ArrowBufPointerNode interNode2 = new ArrowBufPointerNode(new ArrowBufPointerNode[] {leaf3});
+
+    return new ArrowBufPointerNode(new ArrowBufPointerNode[] {interNode1, interNode2});
+  }
+
+  @Test
+  public void testTreeStructure() {
+    ArrowBufPointerNode root = createTree1();
+
+    assertFalse(root.isLeafNode());
+    ArrowBufPointerNode[] children = root.getChildNodes();
+    assertEquals(2, children.length);
+
+    assertFalse(children[0].isLeafNode());
+    assertFalse(children[1].isLeafNode());
+
+    ArrowBufPointerNode[] grandChildren0 = children[0].getChildNodes();
+    assertEquals(2, grandChildren0.length);
+
+    assertTrue(grandChildren0[0].isLeafNode());
+    assertTrue(grandChildren0[1].isLeafNode());
+
+    assertEquals(1, grandChildren0[0].getArrowBufPointer().getBuf().getInt(
+            grandChildren0[0].getArrowBufPointer().getOffset()));
+    assertEquals(2, grandChildren0[1].getArrowBufPointer().getBuf().getInt(
+            grandChildren0[1].getArrowBufPointer().getOffset()));
+
+    ArrowBufPointerNode[] grandChildren1 = children[1].getChildNodes();
+    assertEquals(2, grandChildren1.length);
+
+    assertTrue(grandChildren1[0].isLeafNode());
+    assertTrue(grandChildren1[1].isLeafNode());
+
+    assertEquals(3, grandChildren1[0].getArrowBufPointer().getBuf().getInt(
+            grandChildren1[0].getArrowBufPointer().getOffset()));
+    assertEquals(4, grandChildren1[1].getArrowBufPointer().getBuf().getInt(
+            grandChildren1[1].getArrowBufPointer().getOffset()));
+  }
+
+  @Test
+  public void testNodeComparison() {
+    ArrowBufPointerNode tree1 = createTree1();
+    ArrowBufPointerNode tree2 = createTree2();
+    ArrowBufPointerNode tree3 = createTree3();
+
+    assertTrue(tree1.compareTo(tree2) < 0);
+    assertTrue(tree2.compareTo(tree1) > 0);
+
+    assertTrue(tree1.compareTo(tree3) > 0);
+    assertTrue(tree3.compareTo(tree1) < 0);
+
+    assertTrue(tree2.compareTo(tree3) > 0);
+    assertTrue(tree3.compareTo(tree2) < 0);
+
+    ArrowBufPointerNode tree1Copy = createTree1();
+    assertTrue(tree1.compareTo(tree1Copy) == 0);
+    assertTrue(tree1Copy.compareTo(tree1) == 0);
+  }
+
+  @Test
+  public void testNodeEquals() {
+    ArrowBufPointerNode tree1 = createTree1();
+    ArrowBufPointerNode tree2 = createTree2();
+    ArrowBufPointerNode tree3 = createTree3();
+
+    assertFalse(tree1.equals(tree2));
+    assertFalse(tree2.equals(tree1));
+
+    assertFalse(tree1.equals(tree3));
+    assertFalse(tree3.equals(tree1));
+
+    assertFalse(tree2.equals(tree3));
+    assertFalse(tree3.equals(tree2));
+
+    ArrowBufPointerNode tree1Copy = createTree1();
+    assertTrue(tree1.equals(tree1));
+    assertTrue(tree1.equals(tree1Copy));
+  }
+
+  @Test
+  public void testNodeIterator() {
+    ArrowBufPointerNode tree1 = createTree1();
+    Iterator<ArrowBufPointer> it = tree1.iterator();
+
+    List<ArrowBufPointer> pointers = new ArrayList<>();
+    it.forEachRemaining(pointers::add);
+
+    assertEquals(4, pointers.size());
+
+    ArrowBufPointer pointer1 = pointers.get(0);
+    assertNotNull(pointer1.getBuf());
+    assertEquals(1, pointer1.getBuf().getInt(pointer1.getOffset()));
+
+    ArrowBufPointer pointer2 = pointers.get(1);
+    assertNotNull(pointer2.getBuf());
+    assertEquals(2, pointer2.getBuf().getInt(pointer2.getOffset()));
+
+    ArrowBufPointer pointer3 = pointers.get(2);
+    assertNotNull(pointer3.getBuf());
+    assertEquals(3, pointer3.getBuf().getInt(pointer3.getOffset()));
+
+    ArrowBufPointer pointer4 = pointers.get(3);
+    assertNotNull(pointer4.getBuf());
+    assertEquals(4, pointer4.getBuf().getInt(pointer4.getOffset()));
+  }
+}

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -548,7 +548,7 @@ public class UnionVector implements FieldVector {
     return vectors.iterator();
   }
 
-    private ValueVector getVector(int index) {
+    public ValueVector getVector(int index) {
       int type = typeBuffer.getByte(index * TYPE_WIDTH);
       switch (MinorType.values()[type]) {
         case NULL:

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ArrowBufPointerTreeGenerator.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ArrowBufPointerTreeGenerator.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.util;
+
+import java.util.List;
+
+import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.memory.util.ArrowBufPointerNode;
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.compare.VectorVisitor;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.UnionVector;
+
+/**
+ * Given a vector and an index, generates a tree representation of the underlying values.
+ */
+public class ArrowBufPointerTreeGenerator implements VectorVisitor<ArrowBufPointerNode, Integer> {
+
+  @Override
+  public ArrowBufPointerNode visit(BaseFixedWidthVector vector, Integer index) {
+    return new ArrowBufPointerNode(vector.getDataPointer(index));
+  }
+
+  @Override
+  public ArrowBufPointerNode visit(BaseVariableWidthVector vector, Integer index) {
+    return new ArrowBufPointerNode(vector.getDataPointer(index));
+  }
+
+  @Override
+  public ArrowBufPointerNode visit(ListVector vector, Integer index) {
+    if (vector.isNull(index)) {
+      return new ArrowBufPointerNode(new ArrowBufPointer());
+    }
+
+    int startIdx = vector.getOffsetBuffer().getInt(index * ListVector.OFFSET_WIDTH);
+    int endIdx = vector.getOffsetBuffer().getInt((index + 1) * ListVector.OFFSET_WIDTH);
+
+    ArrowBufPointerNode[] children = new ArrowBufPointerNode[endIdx - startIdx];
+    FieldVector childVector = vector.getDataVector();
+    for (int i = startIdx; i < endIdx; i++) {
+      children[i - startIdx] = childVector.accept(this, i);
+    }
+    return new ArrowBufPointerNode(children);
+  }
+
+  @Override
+  public ArrowBufPointerNode visit(FixedSizeListVector vector, Integer index) {
+    if (vector.isNull(index)) {
+      return new ArrowBufPointerNode(new ArrowBufPointer());
+    }
+
+    int listLength = vector.getListSize();
+
+    int startIdx = index * listLength;
+    int endIdx = (index + 1) * listLength;
+
+    ArrowBufPointerNode[] children = new ArrowBufPointerNode[endIdx - startIdx];
+    FieldVector childVector = vector.getDataVector();
+    for (int i = startIdx; i < endIdx; i++) {
+      children[i - startIdx] = childVector.accept(this, i);
+    }
+    return new ArrowBufPointerNode(children);
+  }
+
+  @Override
+  public ArrowBufPointerNode visit(NonNullableStructVector vector, Integer index) {
+    if (vector.isNull(index)) {
+      return new ArrowBufPointerNode(new ArrowBufPointer());
+    }
+
+    List<FieldVector> childVectors = vector.getChildrenFromFields();
+    ArrowBufPointerNode[] children = new ArrowBufPointerNode[childVectors.size()];
+
+    for (int i = 0; i < children.length; i++) {
+      children[i] = childVectors.get(i).accept(this, index);
+    }
+    return new ArrowBufPointerNode(children);
+  }
+
+  @Override
+  public ArrowBufPointerNode visit(UnionVector vector, Integer index) {
+    if (vector.isNull(index)) {
+      return new ArrowBufPointerNode(new ArrowBufPointer());
+    }
+
+    return vector.getVector(index).accept(this, index);
+  }
+
+  @Override
+  public ArrowBufPointerNode visit(NullVector vector, Integer index) {
+    return new ArrowBufPointerNode(new ArrowBufPointer());
+  }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/util/TestArrowBufPointerGenerator.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/util/TestArrowBufPointerGenerator.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.util;
+
+import static junit.framework.TestCase.assertNull;
+import static junit.framework.TestCase.assertTrue;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.memory.util.ArrowBufPointerNode;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.complex.UnionVector;
+import org.apache.arrow.vector.complex.impl.UnionListWriter;
+import org.apache.arrow.vector.complex.impl.UnionMapWriter;
+import org.apache.arrow.vector.holders.NullableUInt4Holder;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link ArrowBufPointerTreeGenerator}.
+ */
+public class TestArrowBufPointerGenerator {
+  ;
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void prepare() {
+    allocator = new RootAllocator(1024 * 1024);
+  }
+
+  @After
+  public void shutdown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testFixedWidthVector() {
+    try (IntVector intVector = new IntVector("", allocator)) {
+      intVector.allocateNew(2);
+      intVector.setValueCount(2);
+
+      intVector.set(0, 100);
+      intVector.setNull(1);
+
+      ArrowBufPointerTreeGenerator generator = new ArrowBufPointerTreeGenerator();
+
+      ArrowBufPointerNode root = intVector.accept(generator, 0);
+
+      assertTrue(root.isLeafNode());
+      ArrowBufPointer pointer = root.getArrowBufPointer();
+      assertNotNull(pointer.getBuf());
+      assertEquals(0, pointer.getOffset());
+      assertEquals(4, pointer.getLength());
+      assertEquals(100, pointer.getBuf().getInt(pointer.getOffset()));
+
+      root = intVector.accept(generator, 1);
+
+      assertTrue(root.isLeafNode());
+      pointer = root.getArrowBufPointer();
+      assertNull(pointer.getBuf());
+    }
+  }
+
+  @Test
+  public void testVariableWidthVector() {
+    try (VarCharVector vector = new VarCharVector("", allocator)) {
+      vector.allocateNew(10, 2);
+      vector.setValueCount(2);
+
+      vector.set(0, "abcdefg".getBytes());
+      vector.setNull(1);
+
+      ArrowBufPointerTreeGenerator generator = new ArrowBufPointerTreeGenerator();
+
+      ArrowBufPointerNode root = vector.accept(generator, 0);
+
+      assertTrue(root.isLeafNode());
+      ArrowBufPointer pointer = root.getArrowBufPointer();
+      assertNotNull(pointer.getBuf());
+      assertEquals(0, pointer.getOffset());
+      assertEquals(7, pointer.getLength());
+      byte[] actual = new byte[7];
+      pointer.getBuf().getBytes(pointer.getOffset(), actual);
+      assertEquals("abcdefg", new String(actual));
+
+      root = vector.accept(generator, 1);
+
+      assertTrue(root.isLeafNode());
+      pointer = root.getArrowBufPointer();
+      assertNull(pointer.getBuf());
+    }
+  }
+
+  @Test
+  public void testListVector() {
+    try (ListVector vector = ListVector.empty("input", allocator);) {
+      UnionListWriter writer = vector.getWriter();
+      writer.allocate();
+
+      // populate list vector with the following records
+      // [0, 1, 2]
+      // null
+      writer.setPosition(0); // optional
+      writer.startList();
+      for (int i = 0; i < 3; i++) {
+        writer.integer().writeInt(i);
+      }
+      writer.endList();
+
+      writer.setPosition(2);
+      writer.startList();
+      writer.endList();
+
+      writer.setValueCount(2);
+
+      ArrowBufPointerTreeGenerator generator = new ArrowBufPointerTreeGenerator();
+
+      ArrowBufPointerNode root = vector.accept(generator, 0);
+
+      assertFalse(root.isLeafNode());
+      ArrowBufPointerNode[] children = root.getChildNodes();
+      assertEquals(3, children.length);
+      for (int i = 0; i < children.length; i++) {
+        assertTrue(children[i].isLeafNode());
+
+        ArrowBufPointer pointer = children[i].getArrowBufPointer();
+        assertNotNull(pointer.getBuf());
+        assertEquals(i * 4, pointer.getOffset());
+        assertEquals(4, pointer.getLength());
+        assertEquals(i, pointer.getBuf().getInt(pointer.getOffset()));
+      }
+
+      root = vector.accept(generator, 1);
+
+      assertTrue(root.isLeafNode());
+      ArrowBufPointer pointer = root.getArrowBufPointer();
+      assertNull(pointer.getBuf());
+    }
+  }
+
+  @Test
+  public void testFixedSizeListVector() {
+    final int listElementLength = 5;
+    try (FixedSizeListVector vector = FixedSizeListVector.empty("list", listElementLength, allocator)) {
+      IntVector nested =
+              (IntVector) vector.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType())).getVector();
+      vector.allocateNew();
+
+      // populate list vector with the following records
+      // [10, 20, 30, 40, 50]
+      // null
+      vector.setNotNull(0);
+      for (int i = 0; i < listElementLength; i++) {
+        nested.set(i, (i + 1) * 10);
+      }
+      vector.setNull(1);
+      vector.setValueCount(2);
+
+      ArrowBufPointerTreeGenerator generator = new ArrowBufPointerTreeGenerator();
+
+      ArrowBufPointerNode root = vector.accept(generator, 0);
+
+      assertFalse(root.isLeafNode());
+      ArrowBufPointerNode[] children = root.getChildNodes();
+      assertEquals(listElementLength, children.length);
+      for (int i = 0; i < children.length; i++) {
+        assertTrue(children[i].isLeafNode());
+
+        ArrowBufPointer pointer = children[i].getArrowBufPointer();
+        assertNotNull(pointer.getBuf());
+        assertEquals(i * 4, pointer.getOffset());
+        assertEquals(4, pointer.getLength());
+        assertEquals((i + 1) * 10, pointer.getBuf().getInt(pointer.getOffset()));
+      }
+
+      root = vector.accept(generator, 1);
+
+      assertTrue(root.isLeafNode());
+      ArrowBufPointer pointer = root.getArrowBufPointer();
+      assertNull(pointer.getBuf());
+    }
+  }
+
+  @Test
+  public void testStructVector() {
+    try (final StructVector vector = StructVector.empty("vector", allocator)) {
+      IntVector child1 = vector.addOrGet(
+              "child1", FieldType.nullable(Types.MinorType.INT.getType()), IntVector.class);
+      child1.allocateNew(1);
+      child1.setValueCount(1);
+      BigIntVector child2 = vector.addOrGet(
+              "child2", FieldType.nullable(Types.MinorType.BIGINT.getType()), BigIntVector.class);
+      child2.allocateNew(1);
+      child2.setValueCount(1);
+
+      vector.setIndexDefined(0);
+      child1.set(0, 10);
+      child2.set(0, 20L);
+
+      vector.setNull(1);
+      vector.setValueCount(2);
+
+      ArrowBufPointerTreeGenerator generator = new ArrowBufPointerTreeGenerator();
+
+      ArrowBufPointerNode root = vector.accept(generator, 0);
+
+      assertFalse(root.isLeafNode());
+      ArrowBufPointerNode[] children = root.getChildNodes();
+      assertEquals(2, children.length);
+
+      assertTrue(children[0].isLeafNode());
+      ArrowBufPointer pointer0 = children[0].getArrowBufPointer();
+      assertNotNull(pointer0.getBuf());
+      assertEquals(0, pointer0.getOffset());
+      assertEquals(4, pointer0.getLength());
+      assertEquals(10, pointer0.getBuf().getInt(pointer0.getOffset()));
+
+      assertTrue(children[1].isLeafNode());
+      ArrowBufPointer pointer1 = children[1].getArrowBufPointer();
+      assertNotNull(pointer1.getBuf());
+      assertEquals(0, pointer1.getOffset());
+      assertEquals(8, pointer1.getLength());
+      assertEquals(20L, pointer1.getBuf().getLong(pointer1.getOffset()));
+
+      root = vector.accept(generator, 1);
+
+      assertTrue(root.isLeafNode());
+      ArrowBufPointer pointer = root.getArrowBufPointer();
+      assertNull(pointer.getBuf());
+    }
+  }
+
+  @Test
+  public void testUnionVector() {
+    final NullableUInt4Holder uInt4Holder = new NullableUInt4Holder();
+    uInt4Holder.value = 100;
+    uInt4Holder.isSet = 1;
+
+    try (UnionVector vector = UnionVector.empty("vector", allocator)) {
+      vector.allocateNew();
+
+      // write some data
+      vector.setType(0, Types.MinorType.UINT4);
+      vector.setSafe(0, uInt4Holder);
+      vector.setValueCount(2);
+
+      ArrowBufPointerTreeGenerator generator = new ArrowBufPointerTreeGenerator();
+
+      ArrowBufPointerNode root = vector.accept(generator, 0);
+
+      assertTrue(root.isLeafNode());
+      ArrowBufPointer pointer = root.getArrowBufPointer();
+      assertNotNull(pointer.getBuf());
+      assertEquals(0, pointer.getOffset());
+      assertEquals(4, pointer.getLength());
+      assertEquals(100, pointer.getBuf().getInt(pointer.getOffset()));
+
+      root = vector.accept(generator, 1);
+
+      assertTrue(root.isLeafNode());
+      pointer = root.getArrowBufPointer();
+      assertNull(pointer.getBuf());
+    }
+  }
+
+  /**
+   * Map vector is a case for testing nested complex vector.
+   */
+  @Test
+  public void testMapVector() {
+    int count = 5;
+    try (MapVector mapVector = MapVector.empty("map", allocator, false)) {
+      mapVector.allocateNew();
+
+      UnionMapWriter mapWriter = mapVector.getWriter();
+      mapWriter.startMap();
+      for (int i = 0; i < count; i++) {
+        mapWriter.startEntry();
+        mapWriter.key().bigInt().writeBigInt(i);
+        mapWriter.value().integer().writeInt(i);
+        mapWriter.endEntry();
+      }
+      mapWriter.endMap();
+
+      mapWriter.startMap();
+      mapWriter.endMap();
+
+      mapVector.setValueCount(2);
+
+      ArrowBufPointerTreeGenerator generator = new ArrowBufPointerTreeGenerator();
+
+      ArrowBufPointerNode root = mapVector.accept(generator, 0);
+
+      assertFalse(root.isLeafNode());
+      ArrowBufPointerNode[] children = root.getChildNodes();
+      assertEquals(count, children.length);
+
+      for (int i = 0; i < count; i++) {
+        assertFalse(children[i].isLeafNode());
+        ArrowBufPointerNode[] grandChildren = children[i].getChildNodes();
+        assertEquals(2, grandChildren.length);
+
+        assertTrue(grandChildren[0].isLeafNode());
+        ArrowBufPointer keyPointer = grandChildren[0].getArrowBufPointer();
+        assertNotNull(keyPointer.getBuf());
+        assertEquals(i * 8, keyPointer.getOffset());
+        assertEquals(8, keyPointer.getLength());
+        assertEquals(i, keyPointer.getBuf().getLong(keyPointer.getOffset()));
+
+        assertTrue(grandChildren[1].isLeafNode());
+        ArrowBufPointer valuePointer = grandChildren[1].getArrowBufPointer();
+        assertNotNull(valuePointer.getBuf());
+        assertEquals(i * 4, valuePointer.getOffset());
+        assertEquals(4, valuePointer.getLength());
+        assertEquals(i, valuePointer.getBuf().getInt(valuePointer.getOffset()));
+      }
+    }
+  }
+
+  @Test
+  public void testNullVector() {
+    try (NullVector vector = new NullVector()) {
+      ArrowBufPointerTreeGenerator generator = new ArrowBufPointerTreeGenerator();
+      ArrowBufPointerNode node = vector.accept(generator, 0);
+      assertTrue(node.isLeafNode());
+      assertNull(node.getArrowBufPointer().getBuf());
+    }
+  }
+}


### PR DESCRIPTION
For a fixed/variable width vector, each of its data element can be represented as an ArrowBufPointer object, which represents a contiguous memory segment. This makes many tasks easier and more efficient (without memory copy): calculating hash code, comparing values, etc.

This cannot be achieved for complex vectors, because their values often reside in more than one contiguous memory regions. However, it can be seen that the contiguous memory regions for each data element forms a tree-like structure, whose leaf nodes are the contiguous memory regions. For example, a data element for a struct vector forms a tree, whose root corresponds to the struct vector, while the child vectors corresponds to the child nodes of the tree root.

In this issue, we provide a data structure that represents each data element of a vector as a tree, whose leaf nodes are ArrowBufPointers, representing contiguous memory regions for the data element.

With this data structure, many tasks also becomes easier and more efficient: calculating hash code, comparing vector elements (ordering & equality). In addition, we can do something that could not have been done in the past, like placing data elements into a hash table/hash set, etc.