### PR TITLE
ARROW-6515: [C++] Clean type_traits.h definitions

### DIFF
--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -486,11 +486,10 @@ class NumericArray : public PrimitiveArray {
   // Only enable this constructor without a type argument for types without additional
   // metadata
   template <typename T1 = TYPE>
-  NumericArray(
-      typename std::enable_if<TypeTraits<T1>::is_parameter_free, int64_t>::type length,
-      const std::shared_ptr<Buffer>& data,
-      const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
-      int64_t null_count = kUnknownNullCount, int64_t offset = 0)
+  NumericArray(enable_if_parameter_free<T1, int64_t> length,
+               const std::shared_ptr<Buffer>& data,
+               const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
+               int64_t null_count = kUnknownNullCount, int64_t offset = 0)
       : PrimitiveArray(TypeTraits<T1>::type_singleton(), length, data, null_bitmap,
                        null_count, offset) {}
 

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -98,10 +98,10 @@ class DictionaryBuilderBase : public ArrayBuilder {
   // WARNING: the type given below is the value type, not the DictionaryType.
   // The DictionaryType is instantiated on the Finish() call.
   template <typename T1 = T>
-  DictionaryBuilderBase(
-      typename std::enable_if<!std::is_base_of<FixedSizeBinaryType, T1>::value,
-                              const std::shared_ptr<DataType>&>::type value_type,
-      MemoryPool* pool = default_memory_pool())
+  DictionaryBuilderBase(enable_if_t<!std::is_base_of<FixedSizeBinaryType, T1>::value,
+                                    const std::shared_ptr<DataType>&>
+                            value_type,
+                        MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(pool),
         memo_table_(new internal::DictionaryMemoTable(value_type)),
         delta_offset_(0),
@@ -111,9 +111,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
-      typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T1>::value,
-                              const std::shared_ptr<DataType>&>::type value_type,
-      MemoryPool* pool = default_memory_pool())
+      enable_if_fixed_size_binary<T1, const std::shared_ptr<DataType>&> value_type,
+      MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(pool),
         memo_table_(new internal::DictionaryMemoTable(value_type)),
         delta_offset_(0),
@@ -123,12 +122,11 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
-      typename std::enable_if<TypeTraits<T1>::is_parameter_free, MemoryPool*>::type pool =
-          default_memory_pool())
+      enable_if_parameter_free<T1, MemoryPool*> pool ARROW_MEMORY_POOL_DEFAULT)
       : DictionaryBuilderBase<BuilderType, T1>(TypeTraits<T1>::type_singleton(), pool) {}
 
   DictionaryBuilderBase(const std::shared_ptr<Array>& dictionary,
-                        MemoryPool* pool = default_memory_pool())
+                        MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(pool),
         memo_table_(new internal::DictionaryMemoTable(dictionary)),
         delta_offset_(0),
@@ -154,15 +152,13 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   /// \brief Append a fixed-width string (only for FixedSizeBinaryType)
   template <typename T1 = T>
-  Status Append(typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T1>::value,
-                                        const uint8_t*>::type value) {
+  enable_if_fixed_size_binary<T1, Status> Append(const uint8_t* value) {
     return Append(util::string_view(reinterpret_cast<const char*>(value), byte_width_));
   }
 
   /// \brief Append a fixed-width string (only for FixedSizeBinaryType)
   template <typename T1 = T>
-  Status Append(typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T1>::value,
-                                        const char*>::type value) {
+  enable_if_fixed_size_binary<T1, Status> Append(const char* value) {
     return Append(util::string_view(value, byte_width_));
   }
 
@@ -192,9 +188,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   /// \brief Append a whole dense array to the builder
   template <typename T1 = T>
-  Status AppendArray(
-      typename std::enable_if<!std::is_base_of<FixedSizeBinaryType, T1>::value,
-                              const Array&>::type array) {
+  enable_if_t<!is_fixed_size_binary_type<T1>::value, Status> AppendArray(
+      const Array& array) {
     using ArrayType = typename TypeTraits<T>::ArrayType;
 
     const auto& concrete_array = static_cast<const ArrayType&>(array);
@@ -209,9 +204,7 @@ class DictionaryBuilderBase : public ArrayBuilder {
   }
 
   template <typename T1 = T>
-  Status AppendArray(
-      typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T1>::value,
-                              const Array&>::type array) {
+  enable_if_fixed_size_binary<T1, Status> AppendArray(const Array& array) {
     if (!value_type_->Equals(*array.type())) {
       return Status::Invalid(
           "Cannot append FixedSizeBinary array with non-matching type");
@@ -316,14 +309,14 @@ template <typename BuilderType>
 class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
  public:
   DictionaryBuilderBase(const std::shared_ptr<DataType>& value_type,
-                        MemoryPool* pool = default_memory_pool())
+                        MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(pool), indices_builder_(pool) {}
 
-  explicit DictionaryBuilderBase(MemoryPool* pool = default_memory_pool())
+  explicit DictionaryBuilderBase(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(pool), indices_builder_(pool) {}
 
   DictionaryBuilderBase(const std::shared_ptr<Array>& dictionary,
-                        MemoryPool* pool = default_memory_pool())
+                        MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(pool), indices_builder_(pool) {}
 
   /// \brief Append a scalar null value

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -101,7 +101,7 @@ class DictionaryBuilderBase : public ArrayBuilder {
   DictionaryBuilderBase(enable_if_t<!std::is_base_of<FixedSizeBinaryType, T1>::value,
                                     const std::shared_ptr<DataType>&>
                             value_type,
-                        MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+                        MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool),
         memo_table_(new internal::DictionaryMemoTable(value_type)),
         delta_offset_(0),
@@ -112,7 +112,7 @@ class DictionaryBuilderBase : public ArrayBuilder {
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
       enable_if_fixed_size_binary<T1, const std::shared_ptr<DataType>&> value_type,
-      MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+      MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool),
         memo_table_(new internal::DictionaryMemoTable(value_type)),
         delta_offset_(0),
@@ -122,11 +122,11 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   template <typename T1 = T>
   explicit DictionaryBuilderBase(
-      enable_if_parameter_free<T1, MemoryPool*> pool ARROW_MEMORY_POOL_DEFAULT)
+      enable_if_parameter_free<T1, MemoryPool*> pool = default_memory_pool())
       : DictionaryBuilderBase<BuilderType, T1>(TypeTraits<T1>::type_singleton(), pool) {}
 
   DictionaryBuilderBase(const std::shared_ptr<Array>& dictionary,
-                        MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+                        MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool),
         memo_table_(new internal::DictionaryMemoTable(dictionary)),
         delta_offset_(0),
@@ -309,14 +309,14 @@ template <typename BuilderType>
 class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
  public:
   DictionaryBuilderBase(const std::shared_ptr<DataType>& value_type,
-                        MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+                        MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool), indices_builder_(pool) {}
 
-  explicit DictionaryBuilderBase(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit DictionaryBuilderBase(MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool), indices_builder_(pool) {}
 
   DictionaryBuilderBase(const std::shared_ptr<Array>& dictionary,
-                        MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+                        MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool), indices_builder_(pool) {}
 
   /// \brief Append a scalar null value

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -65,8 +65,7 @@ class NumericBuilder : public ArrayBuilder {
 
   template <typename T1 = T>
   explicit NumericBuilder(
-      typename std::enable_if<TypeTraits<T1>::is_parameter_free, MemoryPool*>::type pool
-          ARROW_MEMORY_POOL_DEFAULT)
+      enable_if_parameter_free<T1, MemoryPool*> pool ARROW_MEMORY_POOL_DEFAULT)
       : ArrayBuilder(pool), type_(TypeTraits<T>::type_singleton()) {}
 
   NumericBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
@@ -197,7 +196,7 @@ class NumericBuilder : public ArrayBuilder {
   ///  or null(0) values.
   /// \return Status
   template <typename ValuesIter, typename ValidIter>
-  typename std::enable_if<!std::is_pointer<ValidIter>::value, Status>::type AppendValues(
+  enable_if_t<!std::is_pointer<ValidIter>::value, Status> AppendValues(
       ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
     static_assert(!internal::is_null_pointer<ValidIter>::value,
                   "Don't pass a NULLPTR directly as valid_begin, use the 2-argument "
@@ -214,7 +213,7 @@ class NumericBuilder : public ArrayBuilder {
 
   // Same as above, with a pointer type ValidIter
   template <typename ValuesIter, typename ValidIter>
-  typename std::enable_if<std::is_pointer<ValidIter>::value, Status>::type AppendValues(
+  enable_if_t<std::is_pointer<ValidIter>::value, Status> AppendValues(
       ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
     ARROW_RETURN_NOT_OK(Reserve(length));
@@ -382,7 +381,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   ///  or null(0) values
   /// \return Status
   template <typename ValuesIter, typename ValidIter>
-  typename std::enable_if<!std::is_pointer<ValidIter>::value, Status>::type AppendValues(
+  enable_if_t<!std::is_pointer<ValidIter>::value, Status> AppendValues(
       ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
     static_assert(!internal::is_null_pointer<ValidIter>::value,
                   "Don't pass a NULLPTR directly as valid_begin, use the 2-argument "
@@ -401,7 +400,7 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
 
   // Same as above, for a pointer type ValidIter
   template <typename ValuesIter, typename ValidIter>
-  typename std::enable_if<std::is_pointer<ValidIter>::value, Status>::type AppendValues(
+  enable_if_t<std::is_pointer<ValidIter>::value, Status> AppendValues(
       ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
     ARROW_RETURN_NOT_OK(Reserve(length));

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -29,7 +29,7 @@ namespace arrow {
 
 class ARROW_EXPORT NullBuilder : public ArrayBuilder {
  public:
-  explicit NullBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT) : ArrayBuilder(pool) {}
+  explicit NullBuilder(MemoryPool* pool = default_memory_pool()) : ArrayBuilder(pool) {}
 
   /// \brief Append the specified number of null elements
   Status AppendNulls(int64_t length) final {
@@ -65,7 +65,7 @@ class NumericBuilder : public ArrayBuilder {
 
   template <typename T1 = T>
   explicit NumericBuilder(
-      enable_if_parameter_free<T1, MemoryPool*> pool ARROW_MEMORY_POOL_DEFAULT)
+      enable_if_parameter_free<T1, MemoryPool*> pool = default_memory_pool())
       : ArrayBuilder(pool), type_(TypeTraits<T>::type_singleton()) {}
 
   NumericBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
@@ -274,10 +274,10 @@ class ARROW_EXPORT BooleanBuilder : public ArrayBuilder {
   using TypeClass = BooleanType;
   using value_type = bool;
 
-  explicit BooleanBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+  explicit BooleanBuilder(MemoryPool* pool = default_memory_pool());
 
   BooleanBuilder(const std::shared_ptr<DataType>& type,
-                 MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+                 MemoryPool* pool = default_memory_pool());
 
   /// Write nulls as uint8_t* (0 value indicates null) into pre-allocated memory
   Status AppendNulls(int64_t length) final {

--- a/cpp/src/arrow/array/dict_internal.h
+++ b/cpp/src/arrow/array/dict_internal.h
@@ -45,14 +45,14 @@ struct DictionaryTraits {
 }  // namespace internal
 
 template <typename T, typename Out = void>
-using enable_if_memoize = typename std::enable_if<
+using enable_if_memoize = enable_if_t<
     !std::is_same<typename internal::DictionaryTraits<T>::MemoTableType, void>::value,
-    Out>::type;
+    Out>;
 
 template <typename T, typename Out = void>
-using enable_if_no_memoize = typename std::enable_if<
+using enable_if_no_memoize = enable_if_t<
     std::is_same<typename internal::DictionaryTraits<T>::MemoTableType, void>::value,
-    Out>::type;
+    Out>;
 
 namespace internal {
 
@@ -116,7 +116,7 @@ struct DictionaryTraits<T, enable_if_has_c_type<T>> {
 };
 
 template <typename T>
-struct DictionaryTraits<T, enable_if_binary<T>> {
+struct DictionaryTraits<T, enable_if_base_binary<T>> {
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
   static Status GetDictionaryArrayData(MemoryPool* pool,

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -63,9 +63,7 @@ struct Slice {
 };
 
 template <typename ArrayType, typename T = typename ArrayType::TypeClass,
-          typename =
-              typename std::enable_if<std::is_base_of<BaseListType, T>::value ||
-                                      std::is_base_of<FixedSizeListType, T>::value>::type>
+          typename = enable_if_list_like<T>>
 static Slice GetView(const ArrayType& array, int64_t index) {
   return Slice{array.values().get(), array.value_offset(index),
                array.value_length(index)};
@@ -470,9 +468,7 @@ class MakeFormatterImpl {
 
   // format Numerics with std::ostream defaults
   template <typename T>
-  typename std::enable_if<
-      is_number_type<T>::value && !is_date<T>::value && !is_time<T>::value, Status>::type
-  Visit(const T&) {
+  enable_if_number<T, Status> Visit(const T&) {
     impl_ = [](const Array& array, int64_t index, std::ostream* os) {
       const auto& numeric = checked_cast<const NumericArray<T>&>(array);
       if (sizeof(decltype(numeric.Value(index))) == sizeof(char)) {
@@ -520,21 +516,22 @@ class MakeFormatterImpl {
     return Status::OK();
   }
 
-  // format Binary and FixedSizeBinary in hexadecimal
+  // format Binary, LargeBinary and FixedSizeBinary in hexadecimal
   template <typename T>
   enable_if_binary_like<T, Status> Visit(const T&) {
+    using ArrayType = typename TypeTraits<T>::ArrayType;
     impl_ = [](const Array& array, int64_t index, std::ostream* os) {
-      *os << HexEncode(
-          checked_cast<const typename TypeTraits<T>::ArrayType&>(array).GetView(index));
+      *os << HexEncode(checked_cast<const ArrayType&>(array).GetView(index));
     };
     return Status::OK();
   }
 
   // format Strings with \"\n\r\t\\ escaped
-  Status Visit(const StringType&) {
+  template <typename T>
+  enable_if_string_like<T, Status> Visit(const T&) {
+    using ArrayType = typename TypeTraits<T>::ArrayType;
     impl_ = [](const Array& array, int64_t index, std::ostream* os) {
-      *os << "\"" << Escape(checked_cast<const StringArray&>(array).GetView(index))
-          << "\"";
+      *os << "\"" << Escape(checked_cast<const ArrayType&>(array).GetView(index)) << "\"";
     };
     return Status::OK();
   }
@@ -547,12 +544,14 @@ class MakeFormatterImpl {
     return Status::OK();
   }
 
-  Status Visit(const ListType& t) {
+  template <typename T>
+  enable_if_list_like<T, Status> Visit(const T& t) {
     struct ListImpl {
       explicit ListImpl(Formatter f) : values_formatter_(std::move(f)) {}
 
       void operator()(const Array& array, int64_t index, std::ostream* os) {
-        const auto& list_array = checked_cast<const ListArray&>(array);
+        const auto& list_array =
+            checked_cast<const typename TypeTraits<T>::ArrayType&>(array);
         *os << "[";
         for (int32_t i = 0; i < list_array.value_length(index); ++i) {
           if (i != 0) {
@@ -664,7 +663,23 @@ class MakeFormatterImpl {
     return Status::OK();
   }
 
-  Status Visit(const DataType& t) {
+  Status Visit(const NullType& t) {
+    return Status::NotImplemented("formatting diffs between arrays of type ", t);
+  }
+
+  Status Visit(const DictionaryType& t) {
+    return Status::NotImplemented("formatting diffs between arrays of type ", t);
+  }
+
+  Status Visit(const ExtensionType& t) {
+    return Status::NotImplemented("formatting diffs between arrays of type ", t);
+  }
+
+  Status Visit(const DurationType& t) {
+    return Status::NotImplemented("formatting diffs between arrays of type ", t);
+  }
+
+  Status Visit(const MonthIntervalType& t) {
     return Status::NotImplemented("formatting diffs between arrays of type ", t);
   }
 

--- a/cpp/src/arrow/array_test.cc
+++ b/cpp/src/arrow/array_test.cc
@@ -427,8 +427,7 @@ class TestPrimitiveBuilder : public TestBuilder {
 
 /// \brief uint8_t isn't a valid template parameter to uniform_int_distribution, so
 /// we use SampleType to determine which kind of integer to use to sample.
-template <typename T,
-          typename = typename std::enable_if<std::is_integral<T>::value, T>::type>
+template <typename T, typename = enable_if_t<std::is_integral<T>::value, T>>
 struct UniformIntSampleType {
   using type = T;
 };

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -731,27 +731,25 @@ class TypeEqualsVisitor {
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<NoExtraMeta, T>::value ||
-                              std::is_base_of<PrimitiveCType, T>::value,
-                          Status>::type
+  enable_if_t<is_null_type<T>::value || is_primitive_ctype<T>::value ||
+                  is_base_binary_type<T>::value,
+              Status>
   Visit(const T&) {
     result_ = true;
     return Status::OK();
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<IntervalType, T>::value, Status>::type Visit(
-      const T& left) {
+  enable_if_interval<T, Status> Visit(const T& left) {
     const auto& right = checked_cast<const IntervalType&>(right_);
     result_ = right.interval_type() == left.interval_type();
     return Status::OK();
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<TimeType, T>::value ||
-                              std::is_base_of<DateType, T>::value ||
-                              std::is_base_of<DurationType, T>::value,
-                          Status>::type
+  enable_if_t<is_time_type<T>::value || is_date_type<T>::value ||
+                  is_duration_type<T>::value,
+              Status>
   Visit(const T& left) {
     const auto& right = checked_cast<const T&>(right_);
     result_ = left.unit() == right.unit();
@@ -776,9 +774,11 @@ class TypeEqualsVisitor {
     return Status::OK();
   }
 
-  Status Visit(const ListType& left) { return VisitChildren(left); }
-
-  Status Visit(const LargeListType& left) { return VisitChildren(left); }
+  template <typename T>
+  enable_if_t<is_list_like_type<T>::value || is_struct_type<T>::value, Status> Visit(
+      const T& left) {
+    return VisitChildren(left);
+  }
 
   Status Visit(const MapType& left) {
     const auto& right = checked_cast<const MapType&>(right_);
@@ -788,10 +788,6 @@ class TypeEqualsVisitor {
     }
     return VisitChildren(left);
   }
-
-  Status Visit(const FixedSizeListType& left) { return VisitChildren(left); }
-
-  Status Visit(const StructType& left) { return VisitChildren(left); }
 
   Status Visit(const UnionType& left) {
     const auto& right = checked_cast<const UnionType&>(right_);

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -99,8 +99,7 @@ struct ARROW_EXPORT Datum {
       : value(value) {}
 
   // Cast from subtypes of Array to Datum
-  template <typename T,
-            typename = typename std::enable_if<std::is_base_of<Array, T>::value>::type>
+  template <typename T, typename = enable_if_t<std::is_base_of<Array, T>::value>>
   Datum(const std::shared_ptr<T>& value)  // NOLINT implicit conversion
       : Datum(std::shared_ptr<Array>(value)) {}
 

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -269,9 +269,6 @@ class HashKernelImpl : public HashKernel {
 // Base class for all "regular" hash kernel implementations
 // (NullType has a separate implementation)
 
-template <bool B, typename T = void>
-using enable_if_t = typename std::enable_if<B, T>::type;
-
 template <typename Type, typename Scalar, typename Action, bool with_error_status = false,
           bool with_memo_visit_null = true>
 class RegularHashKernelImpl : public HashKernelImpl {
@@ -331,8 +328,7 @@ class RegularHashKernelImpl : public HashKernelImpl {
   }
 
   template <typename Enable = Status>
-  auto VisitValue(const Scalar& value) ->
-      typename std::enable_if<!with_error_status, Enable>::type {
+  auto VisitValue(const Scalar& value) -> enable_if_t<!with_error_status, Enable> {
     auto on_found = [this](int32_t memo_index) { action_.ObserveFound(memo_index); };
     auto on_not_found = [this](int32_t memo_index) {
       action_.ObserveNotFound(memo_index);
@@ -343,8 +339,7 @@ class RegularHashKernelImpl : public HashKernelImpl {
   }
 
   template <typename Enable = Status>
-  auto VisitValue(const Scalar& value) ->
-      typename std::enable_if<with_error_status, Enable>::type {
+  auto VisitValue(const Scalar& value) -> enable_if_t<with_error_status, Enable> {
     Status s = Status::OK();
     auto on_found = [this](int32_t memo_index) { action_.ObserveFound(memo_index); };
     auto on_not_found = [this, &s](int32_t memo_index) {
@@ -431,23 +426,7 @@ struct HashKernelTraits<Type, Action, with_error_status, with_memo_visit_null,
 template <typename Type, typename Action, bool with_error_status,
           bool with_memo_visit_null>
 struct HashKernelTraits<Type, Action, with_error_status, with_memo_visit_null,
-                        enable_if_boolean<Type>> {
-  using HashKernelImpl =
-      RegularHashKernelImpl<Type, bool, Action, with_error_status, with_memo_visit_null>;
-};
-
-template <typename Type, typename Action, bool with_error_status,
-          bool with_memo_visit_null>
-struct HashKernelTraits<Type, Action, with_error_status, with_memo_visit_null,
-                        enable_if_binary<Type>> {
-  using HashKernelImpl = RegularHashKernelImpl<Type, util::string_view, Action,
-                                               with_error_status, with_memo_visit_null>;
-};
-
-template <typename Type, typename Action, bool with_error_status,
-          bool with_memo_visit_null>
-struct HashKernelTraits<Type, Action, with_error_status, with_memo_visit_null,
-                        enable_if_fixed_size_binary<Type>> {
+                        enable_if_has_string_view<Type>> {
   using HashKernelImpl = RegularHashKernelImpl<Type, util::string_view, Action,
                                                with_error_status, with_memo_visit_null>;
 };

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -295,8 +295,8 @@ class RegularHashKernelImpl : public HashKernelImpl {
                                                           0 /* start_offset */, out);
   }
 
-  template <typename Enable = Status>
-  auto VisitNull() -> enable_if_t<!with_error_status, Enable> {
+  template <bool HasError = with_error_status>
+  enable_if_t<!HasError, Status> VisitNull() {
     auto on_found = [this](int32_t memo_index) { action_.ObserveNullFound(memo_index); };
     auto on_not_found = [this](int32_t memo_index) {
       action_.ObserveNullNotFound(memo_index);
@@ -310,8 +310,8 @@ class RegularHashKernelImpl : public HashKernelImpl {
     return Status::OK();
   }
 
-  template <typename Enable = Status>
-  auto VisitNull() -> enable_if_t<with_error_status, Enable> {
+  template <bool HasError = with_error_status>
+  enable_if_t<HasError, Status> VisitNull() {
     Status s = Status::OK();
     auto on_found = [this](int32_t memo_index) { action_.ObserveFound(memo_index); };
     auto on_not_found = [this, &s](int32_t memo_index) {
@@ -327,8 +327,8 @@ class RegularHashKernelImpl : public HashKernelImpl {
     return s;
   }
 
-  template <typename Enable = Status>
-  auto VisitValue(const Scalar& value) -> enable_if_t<!with_error_status, Enable> {
+  template <bool HasError = with_error_status>
+  enable_if_t<!HasError, Status> VisitValue(const Scalar& value) {
     auto on_found = [this](int32_t memo_index) { action_.ObserveFound(memo_index); };
     auto on_not_found = [this](int32_t memo_index) {
       action_.ObserveNotFound(memo_index);
@@ -338,8 +338,8 @@ class RegularHashKernelImpl : public HashKernelImpl {
     return Status::OK();
   }
 
-  template <typename Enable = Status>
-  auto VisitValue(const Scalar& value) -> enable_if_t<with_error_status, Enable> {
+  template <bool HasError = with_error_status>
+  enable_if_t<HasError, Status> VisitValue(const Scalar& value) {
     Status s = Status::OK();
     auto on_found = [this](int32_t memo_index) { action_.ObserveFound(memo_index); };
     auto on_not_found = [this, &s](int32_t memo_index) {

--- a/cpp/src/arrow/compute/kernels/isin.cc
+++ b/cpp/src/arrow/compute/kernels/isin.cc
@@ -250,17 +250,7 @@ struct IsInKernelTraits<Type, enable_if_has_c_type<Type>> {
 };
 
 template <typename Type>
-struct IsInKernelTraits<Type, enable_if_boolean<Type>> {
-  using IsInKernelImpl = IsInKernel<Type, bool>;
-};
-
-template <typename Type>
-struct IsInKernelTraits<Type, enable_if_binary<Type>> {
-  using IsInKernelImpl = IsInKernel<Type, util::string_view>;
-};
-
-template <typename Type>
-struct IsInKernelTraits<Type, enable_if_fixed_size_binary<Type>> {
+struct IsInKernelTraits<Type, enable_if_has_string_view<Type>> {
   using IsInKernelImpl = IsInKernel<Type, util::string_view>;
 };
 

--- a/cpp/src/arrow/compute/kernels/minmax.cc
+++ b/cpp/src/arrow/compute/kernels/minmax.cc
@@ -34,8 +34,7 @@ template <typename ArrowType, typename Enable = void>
 struct MinMaxState {};
 
 template <typename ArrowType>
-struct MinMaxState<ArrowType,
-                   typename std::enable_if<is_integer_type<ArrowType>::value>::type> {
+struct MinMaxState<ArrowType, enable_if_integer<ArrowType>> {
   using ThisType = MinMaxState<ArrowType>;
   using c_type = typename ArrowType::c_type;
 
@@ -55,8 +54,7 @@ struct MinMaxState<ArrowType,
 };
 
 template <typename ArrowType>
-struct MinMaxState<ArrowType,
-                   typename std::enable_if<is_floating_type<ArrowType>::value>::type> {
+struct MinMaxState<ArrowType, enable_if_floating_point<ArrowType>> {
   using ThisType = MinMaxState<ArrowType>;
   using c_type = typename ArrowType::c_type;
 

--- a/cpp/src/arrow/compute/kernels/take_internal.h
+++ b/cpp/src/arrow/compute/kernels/take_internal.h
@@ -38,11 +38,14 @@ namespace compute {
 using internal::checked_cast;
 using internal::checked_pointer_cast;
 
+template <typename T, typename R = void>
+using enable_if_not_base_binary =
+    enable_if_t<!std::is_base_of<BaseBinaryType, T>::value, R>;
+
 // For non-binary builders, use regular value append
 template <typename Builder, typename Scalar>
-static typename std::enable_if<
-    !std::is_base_of<BaseBinaryType, typename Builder::TypeClass>::value, Status>::type
-UnsafeAppend(Builder* builder, Scalar&& value) {
+static enable_if_not_base_binary<typename Builder::TypeClass, Status> UnsafeAppend(
+    Builder* builder, Scalar&& value) {
   builder->UnsafeAppend(std::forward<Scalar>(value));
   return Status::OK();
 }

--- a/cpp/src/arrow/compute/test_util.h
+++ b/cpp/src/arrow/compute/test_util.h
@@ -73,7 +73,7 @@ template <typename Type, typename Enable = void>
 struct DatumEqual {};
 
 template <typename Type>
-struct DatumEqual<Type, typename std::enable_if<IsFloatingPoint<Type>::value>::type> {
+struct DatumEqual<Type, enable_if_floating_point<Type>> {
   static constexpr double kArbitraryDoubleErrorBound = 1.0;
   using ScalarType = typename TypeTraits<Type>::ScalarType;
 
@@ -90,7 +90,7 @@ struct DatumEqual<Type, typename std::enable_if<IsFloatingPoint<Type>::value>::t
 };
 
 template <typename Type>
-struct DatumEqual<Type, typename std::enable_if<!IsFloatingPoint<Type>::value>::type> {
+struct DatumEqual<Type, enable_if_integer<Type>> {
   using ScalarType = typename TypeTraits<Type>::ScalarType;
   static void EnsureEqual(const Datum& lhs, const Datum& rhs) {
     ASSERT_EQ(lhs.kind(), rhs.kind());

--- a/cpp/src/arrow/ipc/json_internal.cc
+++ b/cpp/src/arrow/ipc/json_internal.cc
@@ -164,10 +164,8 @@ class SchemaWriter {
   Status VisitType(const DataType& type);
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<NoExtraMeta, T>::value ||
-                              std::is_base_of<BaseListType, T>::value ||
-                              std::is_base_of<StructType, T>::value,
-                          void>::type
+  enable_if_t<has_no_extra_meta<T>::value || is_base_list_type<T>::value ||
+              is_struct_type<T>::value>
   WriteTypeMetadata(const T& type) {}
 
   void WriteTypeMetadata(const MapType& type) {
@@ -361,8 +359,7 @@ class SchemaWriter {
 
   Status Visit(const DictionaryType& type) { return VisitType(*type.value_type()); }
 
-  // Default case
-  Status Visit(const DataType& type) { return Status::NotImplemented(type.name()); }
+  Status Visit(const ExtensionType& type) { return Status::NotImplemented(type.name()); }
 
  private:
   const Schema& schema_;
@@ -397,37 +394,34 @@ class ArrayWriter {
     return Status::OK();
   }
 
-  template <typename T>
-  typename std::enable_if<IsSignedInt<T>::value, void>::type WriteDataValues(
-      const T& arr) {
+  template <typename T, bool IsSigned = std::is_signed<typename T::value_type>::value>
+  void WriteIntegerDataValues(const T& arr) {
     static const char null_string[] = "0";
     const auto data = arr.raw_values();
     for (int64_t i = 0; i < arr.length(); ++i) {
       if (arr.IsValid(i)) {
-        writer_->Int64(data[i]);
+        IsSigned ? writer_->Int64(data[i]) : writer_->Uint64(data[i]);
       } else {
         writer_->RawNumber(null_string, sizeof(null_string));
       }
     }
   }
 
-  template <typename T>
-  typename std::enable_if<IsUnsignedInt<T>::value, void>::type WriteDataValues(
-      const T& arr) {
-    static const char null_string[] = "0";
-    const auto data = arr.raw_values();
-    for (int64_t i = 0; i < arr.length(); ++i) {
-      if (arr.IsValid(i)) {
-        writer_->Uint64(data[i]);
-      } else {
-        writer_->RawNumber(null_string, sizeof(null_string));
-      }
-    }
+  template <typename ArrayType>
+  enable_if_physical_signed_integer<typename ArrayType::TypeClass> WriteDataValues(
+      const ArrayType& arr) {
+    WriteIntegerDataValues<ArrayType>(arr);
   }
 
-  template <typename T>
-  typename std::enable_if<IsFloatingPoint<T>::value, void>::type WriteDataValues(
-      const T& arr) {
+  template <typename ArrayType>
+  enable_if_physical_unsigned_integer<typename ArrayType::TypeClass> WriteDataValues(
+      const ArrayType& arr) {
+    WriteIntegerDataValues<ArrayType>(arr);
+  }
+
+  template <typename ArrayType>
+  enable_if_physical_floating_point<typename ArrayType::TypeClass> WriteDataValues(
+      const ArrayType& arr) {
     static const char null_string[] = "0.";
     const auto data = arr.raw_values();
     for (int64_t i = 0; i < arr.length(); ++i) {
@@ -440,35 +434,21 @@ class ArrayWriter {
   }
 
   // Binary, encode to hexadecimal.
-  template <typename T>
-  typename std::enable_if<std::is_same<BinaryArray, T>::value ||
-                              std::is_same<LargeBinaryArray, T>::value,
-                          void>::type
-  WriteDataValues(const T& arr) {
+  template <typename ArrayType>
+  enable_if_binary_like<typename ArrayType::TypeClass> WriteDataValues(
+      const ArrayType& arr) {
     for (int64_t i = 0; i < arr.length(); ++i) {
       writer_->String(HexEncode(arr.GetView(i)));
     }
   }
 
   // UTF8 string, write as is
-  template <typename T>
-  typename std::enable_if<std::is_same<StringArray, T>::value ||
-                              std::is_same<LargeStringArray, T>::value,
-                          void>::type
-  WriteDataValues(const T& arr) {
+  template <typename ArrayType>
+  enable_if_string_like<typename ArrayType::TypeClass> WriteDataValues(
+      const ArrayType& arr) {
     for (int64_t i = 0; i < arr.length(); ++i) {
       auto view = arr.GetView(i);
       writer_->String(view.data(), static_cast<rj::SizeType>(view.size()));
-    }
-  }
-
-  void WriteDataValues(const FixedSizeBinaryArray& arr) {
-    const int32_t width = arr.byte_width();
-
-    for (int64_t i = 0; i < arr.length(); ++i) {
-      const uint8_t* buf = arr.GetValue(i);
-      std::string encoded = HexEncode(buf, width);
-      writer_->String(encoded);
     }
   }
 
@@ -563,20 +543,18 @@ class ArrayWriter {
     return Status::OK();
   }
 
-  template <typename T>
-  typename std::enable_if<std::is_base_of<PrimitiveArray, T>::value, Status>::type Visit(
-      const T& array) {
+  template <typename ArrayType>
+  enable_if_t<std::is_base_of<PrimitiveArray, ArrayType>::value, Status> Visit(
+      const ArrayType& array) {
     WriteValidityField(array);
     WriteDataField(array);
     SetNoChildren();
     return Status::OK();
   }
 
-  template <typename T>
-  typename std::enable_if<std::is_base_of<BinaryArray, T>::value ||
-                              std::is_base_of<LargeBinaryArray, T>::value,
-                          Status>::type
-  Visit(const T& array) {
+  template <typename ArrayType>
+  enable_if_base_binary<typename ArrayType::TypeClass, Status> Visit(
+      const ArrayType& array) {
     WriteValidityField(array);
     WriteIntegerField("OFFSET", array.raw_value_offsets(), array.length() + 1);
     WriteDataField(array);
@@ -588,11 +566,9 @@ class ArrayWriter {
     return VisitArrayValues(*array.indices());
   }
 
-  template <typename T>
-  typename std::enable_if<std::is_base_of<ListArray, T>::value ||
-                              std::is_base_of<LargeListArray, T>::value,
-                          Status>::type
-  Visit(const T& array) {
+  template <typename ArrayType>
+  enable_if_base_list<typename ArrayType::TypeClass, Status> Visit(
+      const ArrayType& array) {
     WriteValidityField(array);
     WriteIntegerField("OFFSET", array.raw_value_offsets(), array.length() + 1);
     return WriteChildren(array.type()->children(), {array.values()});
@@ -1055,31 +1031,30 @@ static Status GetField(const rj::Value& obj, DictionaryMemo* dictionary_memo,
 }
 
 template <typename T>
-inline typename std::enable_if<IsSignedInt<T>::value, typename T::c_type>::type
-UnboxValue(const rj::Value& val) {
+enable_if_boolean<T, bool> UnboxValue(const rj::Value& val) {
+  DCHECK(val.IsBool());
+  return val.GetBool();
+}
+
+template <typename T>
+enable_if_physical_signed_integer<T, typename T::c_type> UnboxValue(
+    const rj::Value& val) {
   DCHECK(val.IsInt64());
   return static_cast<typename T::c_type>(val.GetInt64());
 }
 
 template <typename T>
-inline typename std::enable_if<IsUnsignedInt<T>::value, typename T::c_type>::type
-UnboxValue(const rj::Value& val) {
+enable_if_physical_unsigned_integer<T, typename T::c_type> UnboxValue(
+    const rj::Value& val) {
   DCHECK(val.IsUint());
   return static_cast<typename T::c_type>(val.GetUint64());
 }
 
 template <typename T>
-inline typename std::enable_if<IsFloatingPoint<T>::value, typename T::c_type>::type
-UnboxValue(const rj::Value& val) {
+enable_if_physical_floating_point<T, typename T::c_type> UnboxValue(
+    const rj::Value& val) {
   DCHECK(val.IsFloat());
   return static_cast<typename T::c_type>(val.GetDouble());
-}
-
-template <typename T>
-inline typename std::enable_if<std::is_base_of<BooleanType, T>::value, bool>::type
-UnboxValue(const rj::Value& val) {
-  DCHECK(val.IsBool());
-  return val.GetBool();
 }
 
 class ArrayReader {
@@ -1093,11 +1068,7 @@ class ArrayReader {
         dictionary_memo_(dictionary_memo) {}
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<PrimitiveCType, T>::value ||
-                              is_temporal_type<T>::value ||
-                              std::is_base_of<BooleanType, T>::value,
-                          Status>::type
-  Visit(const T& type) {
+  enable_if_has_c_type<T, Status> Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(type_, pool_);
 
     const auto& json_data = obj_.FindMember(kData);
@@ -1120,8 +1091,7 @@ class ArrayReader {
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<BaseBinaryType, T>::value, Status>::type Visit(
-      const T& type) {
+  enable_if_base_binary<T, Status> Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(pool_);
     using offset_type = typename T::offset_type;
 
@@ -1195,9 +1165,7 @@ class ArrayReader {
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T>::value &&
-                              !std::is_base_of<Decimal128Type, T>::value,
-                          Status>::type
+  enable_if_t<is_fixed_size_binary_type<T>::value && !is_decimal_type<T>::value, Status>
   Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(type_, pool_);
 
@@ -1238,8 +1206,7 @@ class ArrayReader {
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<Decimal128Type, T>::value, Status>::type Visit(
-      const T& type) {
+  enable_if_decimal<T, Status> Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(type_, pool_);
 
     const auto& json_data = obj_.FindMember(kData);
@@ -1312,10 +1279,9 @@ class ArrayReader {
     return Status::OK();
   }
 
-  Status Visit(const ListType& type) { return CreateList<ListType>(type_, &result_); }
-
-  Status Visit(const LargeListType& type) {
-    return CreateList<LargeListType>(type_, &result_);
+  template <typename T>
+  enable_if_base_list<T, Status> Visit(const T& type) {
+    return CreateList<T>(type_, &result_);
   }
 
   Status Visit(const MapType& type) {
@@ -1414,8 +1380,7 @@ class ArrayReader {
     return Status::OK();
   }
 
-  // Default case
-  Status Visit(const DataType& type) { return Status::NotImplemented(type.name()); }
+  Status Visit(const ExtensionType& type) { return Status::NotImplemented(type.name()); }
 
   Status GetValidityBuffer(const std::vector<bool>& is_valid, int32_t* null_count,
                            std::shared_ptr<Buffer>* validity_buffer) {

--- a/cpp/src/arrow/ipc/json_internal.cc
+++ b/cpp/src/arrow/ipc/json_internal.cc
@@ -164,7 +164,8 @@ class SchemaWriter {
   Status VisitType(const DataType& type);
 
   template <typename T>
-  enable_if_t<has_no_extra_meta<T>::value || is_base_list_type<T>::value ||
+  enable_if_t<is_null_type<T>::value || is_primitive_ctype<T>::value ||
+              is_base_binary_type<T>::value || is_base_list_type<T>::value ||
               is_struct_type<T>::value>
   WriteTypeMetadata(const T& type) {}
 

--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -154,10 +154,8 @@ class BooleanConverter final : public ConcreteConverter<BooleanConverter> {
 
 // Convert single signed integer value (also {Date,Time}{32,64} and Timestamp)
 template <typename T>
-typename std::enable_if<is_signed_integer<T>::value || is_date<T>::value ||
-                            is_time<T>::value || is_timestamp<T>::value,
-                        Status>::type
-ConvertNumber(const rj::Value& json_obj, typename T::c_type* out) {
+enable_if_physical_signed_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
+                                                           typename T::c_type* out) {
   if (json_obj.IsInt64()) {
     int64_t v64 = json_obj.GetInt64();
     *out = static_cast<typename T::c_type>(v64);
@@ -175,8 +173,8 @@ ConvertNumber(const rj::Value& json_obj, typename T::c_type* out) {
 
 // Convert single unsigned integer value
 template <typename T>
-enable_if_unsigned_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
-                                                    typename T::c_type* out) {
+enable_if_physical_unsigned_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
+                                                             typename T::c_type* out) {
   if (json_obj.IsUint64()) {
     uint64_t v64 = json_obj.GetUint64();
     *out = static_cast<typename T::c_type>(v64);
@@ -194,8 +192,8 @@ enable_if_unsigned_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
 
 // Convert single floating point value
 template <typename T>
-enable_if_floating_point<T, Status> ConvertNumber(const rj::Value& json_obj,
-                                                  typename T::c_type* out) {
+enable_if_physical_floating_point<T, Status> ConvertNumber(const rj::Value& json_obj,
+                                                           typename T::c_type* out) {
   if (json_obj.IsNumber()) {
     *out = static_cast<typename T::c_type>(json_obj.GetDouble());
     return Status::OK();
@@ -736,6 +734,7 @@ Status GetConverter(const std::shared_ptr<DataType>& type,
     SIMPLE_CONVERTER_CASE(Type::UINT64, IntegerConverter<UInt64Type>)
     SIMPLE_CONVERTER_CASE(Type::NA, NullConverter)
     SIMPLE_CONVERTER_CASE(Type::BOOL, BooleanConverter)
+    SIMPLE_CONVERTER_CASE(Type::HALF_FLOAT, IntegerConverter<HalfFloatType>)
     SIMPLE_CONVERTER_CASE(Type::FLOAT, FloatConverter<FloatType>)
     SIMPLE_CONVERTER_CASE(Type::DOUBLE, FloatConverter<DoubleType>)
     SIMPLE_CONVERTER_CASE(Type::LIST, ListConverter<ListType>)

--- a/cpp/src/arrow/ipc/json_simple_test.cc
+++ b/cpp/src/arrow/ipc/json_simple_test.cc
@@ -208,6 +208,7 @@ INSTANTIATE_TYPED_TEST_CASE_P(TestUInt8, TestIntegers, UInt8Type);
 INSTANTIATE_TYPED_TEST_CASE_P(TestUInt16, TestIntegers, UInt16Type);
 INSTANTIATE_TYPED_TEST_CASE_P(TestUInt32, TestIntegers, UInt32Type);
 INSTANTIATE_TYPED_TEST_CASE_P(TestUInt64, TestIntegers, UInt64Type);
+INSTANTIATE_TYPED_TEST_CASE_P(TestHalfFloat, TestIntegers, HalfFloatType);
 
 TEST(TestNull, Basics) {
   std::shared_ptr<DataType> type = null();

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -515,8 +515,9 @@ class FieldToFlatbufferVisitor {
   }
 
   template <typename T>
-  typename std::enable_if<IsInteger<T>::value, Status>::type Visit(const T& type) {
-    return Visit<sizeof(typename T::c_type) * 8, IsSignedInt<T>::value>(type);
+  enable_if_integer<T, Status> Visit(const T& type) {
+    constexpr bool is_signed = is_signed_integer_type<T>::value;
+    return Visit<sizeof(typename T::c_type) * 8, is_signed>(type);
   }
 
   Status Visit(const HalfFloatType& type) {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -262,19 +262,16 @@ class ArrayLoader {
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<FixedWidthType, T>::value &&
-                              !std::is_base_of<FixedSizeBinaryType, T>::value &&
-                              !std::is_base_of<DictionaryType, T>::value,
-                          Status>::type
+  enable_if_t<std::is_base_of<FixedWidthType, T>::value &&
+                  !std::is_base_of<FixedSizeBinaryType, T>::value &&
+                  !std::is_base_of<DictionaryType, T>::value,
+              Status>
   Visit(const T& type) {
     return LoadPrimitive<T>();
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<BinaryType, T>::value ||
-                              std::is_base_of<LargeBinaryType, T>::value,
-                          Status>::type
-  Visit(const T& type) {
+  enable_if_base_binary<T, Status> Visit(const T& type) {
     return LoadBinary<T>();
   }
 

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -394,8 +394,7 @@ class RawBuilderSet {
 
   /// Retrieve a pointer to a builder from a BuilderPtr
   template <Kind::type kind>
-  typename std::enable_if<kind != Kind::kNull, RawArrayBuilder<kind>*>::type Cast(
-      BuilderPtr builder) {
+  enable_if_t<kind != Kind::kNull, RawArrayBuilder<kind>*> Cast(BuilderPtr builder) {
     DCHECK_EQ(builder.kind, kind);
     return arena<kind>().data() + builder.index;
   }
@@ -579,8 +578,7 @@ class HandlerBase : public BlockParser,
 
   /// Retrieve a pointer to a builder from a BuilderPtr
   template <Kind::type kind>
-  typename std::enable_if<kind != Kind::kNull, RawArrayBuilder<kind>*>::type Cast(
-      BuilderPtr builder) {
+  enable_if_t<kind != Kind::kNull, RawArrayBuilder<kind>*> Cast(BuilderPtr builder) {
     return builder_set_.Cast<kind>(builder);
   }
 

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -2182,17 +2182,15 @@ class ArrowDeserializer {
     return Status::OK();
   }
 
-  // Default case
-  Status Visit(const FixedSizeListType& type) {
-    return Status::NotImplemented(type.name());
-  }
-  Status Visit(const LargeListType& type) { return Status::NotImplemented(type.name()); }
-  Status Visit(const UnionType& type) { return Status::NotImplemented(type.name()); }
-  Status Visit(const DayTimeIntervalType& type) {
-    return Status::NotImplemented(type.name());
-  }
-  Status Visit(const MonthIntervalType& type) {
-    return Status::NotImplemented(type.name());
+  Status Visit(const FixedSizeListType& type) { return NotImplemented(type); }
+  Status Visit(const LargeListType& type) { return NotImplemented(type); }
+  Status Visit(const UnionType& type) { return NotImplemented(type); }
+  Status Visit(const DayTimeIntervalType& type) { return NotImplemented(type); }
+  Status Visit(const MonthIntervalType& type) { return NotImplemented(type); }
+
+  Status NotImplemented(const DataType& type) {
+    return Status::NotImplemented(
+        "Convertion from arrow to pandas is not implemented for type ", type.name());
   }
 
   Status Convert(PyObject** out) {

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -498,7 +498,7 @@ struct MemoizationTraits {
 };
 
 template <typename T>
-struct MemoizationTraits<T, enable_if_binary_like<T>> {
+struct MemoizationTraits<T, enable_if_has_string_view<T>> {
   // For binary, we memoize string_view as a scalar value to avoid having to
   // unnecessarily copy the memory into the memo table data structure
   using Scalar = util::string_view;
@@ -1937,8 +1937,7 @@ class ArrowDeserializer {
   // types
 
   template <typename Type>
-  typename std::enable_if<is_floating_type<Type>::value, Status>::type Visit(
-      const Type& type) {
+  enable_if_t<is_floating_type<Type>::value, Status> Visit(const Type& type) {
     constexpr int TYPE = Type::type_id;
     using traits = internal::arrow_traits<TYPE>;
 
@@ -1960,9 +1959,7 @@ class ArrowDeserializer {
   }
 
   template <typename Type>
-  typename std::enable_if<std::is_base_of<TimestampType, Type>::value ||
-                              std::is_base_of<DurationType, Type>::value,
-                          Status>::type
+  enable_if_t<is_timestamp_type<Type>::value || is_duration_type<Type>::value, Status>
   Visit(const Type& type) {
     constexpr int TYPE = Type::type_id;
     using traits = internal::arrow_traits<TYPE>;
@@ -1994,8 +1991,7 @@ class ArrowDeserializer {
   }
 
   template <typename Type>
-  typename std::enable_if<std::is_base_of<DateType, Type>::value, Status>::type Visit(
-      const Type& type) {
+  enable_if_date<Type, Status> Visit(const Type& type) {
     if (options_.zero_copy_only) {
       return Status::Invalid("Copy Needed, but zero_copy_only was True");
     }
@@ -2027,15 +2023,13 @@ class ArrowDeserializer {
   }
 
   template <typename Type>
-  typename std::enable_if<std::is_base_of<TimeType, Type>::value, Status>::type Visit(
-      const Type& type) {
+  enable_if_time<Type, Status> Visit(const Type& type) {
     return Status::NotImplemented("Don't know how to serialize Arrow time type to NumPy");
   }
 
   // Integer specialization
   template <typename Type>
-  typename std::enable_if<is_integer_type<Type>::value, Status>::type Visit(
-      const Type& type) {
+  enable_if_integer<Type, Status> Visit(const Type& type) {
     constexpr int TYPE = Type::type_id;
     using traits = internal::arrow_traits<TYPE>;
 
@@ -2077,8 +2071,7 @@ class ArrowDeserializer {
 
   // Strings and binary
   template <typename Type>
-  typename std::enable_if<std::is_base_of<BaseBinaryType, Type>::value, Status>::type
-  Visit(const Type& type) {
+  enable_if_base_binary<Type, Status> Visit(const Type& type) {
     return VisitObjects(ConvertBinaryLike<Type>);
   }
 
@@ -2190,7 +2183,17 @@ class ArrowDeserializer {
   }
 
   // Default case
-  Status Visit(const DataType& type) { return Status::NotImplemented(type.name()); }
+  Status Visit(const FixedSizeListType& type) {
+    return Status::NotImplemented(type.name());
+  }
+  Status Visit(const LargeListType& type) { return Status::NotImplemented(type.name()); }
+  Status Visit(const UnionType& type) { return Status::NotImplemented(type.name()); }
+  Status Visit(const DayTimeIntervalType& type) {
+    return Status::NotImplemented(type.name());
+  }
+  Status Visit(const MonthIntervalType& type) {
+    return Status::NotImplemented(type.name());
+  }
 
   Status Convert(PyObject** out) {
     RETURN_NOT_OK(VisitTypeInline(*data_->type(), this));

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -171,8 +171,7 @@ Status IntegerOverflowStatus(PyObject* obj, const std::string& overflow_message)
 }
 
 // Extract C signed int from Python object
-template <typename Int,
-          typename std::enable_if<std::is_signed<Int>::value, Int>::type = 0>
+template <typename Int, enable_if_t<std::is_signed<Int>::value, Int> = 0>
 Status CIntFromPythonImpl(PyObject* obj, Int* out, const std::string& overflow_message) {
   static_assert(sizeof(Int) <= sizeof(long long),  // NOLINT
                 "integer type larger than long long");
@@ -202,8 +201,7 @@ Status CIntFromPythonImpl(PyObject* obj, Int* out, const std::string& overflow_m
 }
 
 // Extract C unsigned int from Python object
-template <typename Int,
-          typename std::enable_if<std::is_unsigned<Int>::value, Int>::type = 0>
+template <typename Int, enable_if_t<std::is_unsigned<Int>::value, Int> = 0>
 Status CIntFromPythonImpl(PyObject* obj, Int* out, const std::string& overflow_message) {
   static_assert(sizeof(Int) <= sizeof(unsigned long long),  // NOLINT
                 "integer type larger than unsigned long long");

--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -204,10 +204,7 @@ class NumPyConverter {
   const ArrayVector& result() const { return out_arrays_; }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<PrimitiveCType, T>::value ||
-                              std::is_same<BooleanType, T>::value,
-                          Status>::type
-  Visit(const T& type) {
+  enable_if_primitive_ctype<T, Status> Visit(const T& type) {
     return VisitNative<T>();
   }
 

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -171,17 +171,14 @@ struct NonZeroCounter {
       : tensor_(tensor), result_(result) {}
 
   template <typename TYPE>
-  typename std::enable_if<!is_number_type<TYPE>::value, Status>::type Visit(
-      const TYPE& type) {
-    ARROW_CHECK(!is_tensor_supported(type.id()));
-    return Status::NotImplemented("Tensor of ", type.ToString(), " is not implemented");
-  }
-
-  template <typename TYPE>
-  typename std::enable_if<is_number_type<TYPE>::value, Status>::type Visit(
-      const TYPE& type) {
+  enable_if_number<TYPE, Status> Visit(const TYPE& type) {
     *result_ = TensorCountNonZero<TYPE>(tensor_);
     return Status::OK();
+  }
+
+  Status Visit(const DataType& type) {
+    ARROW_CHECK(!is_tensor_supported(type.id()));
+    return Status::NotImplemented("Tensor of ", type.ToString(), " is not implemented");
   }
 
   const Tensor& tensor_;

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -137,8 +137,6 @@ std::ostream& operator<<(std::ostream& os, const DataType& type) {
   return os;
 }
 
-std::string BooleanType::ToString() const { return name(); }
-
 FloatingPointType::Precision HalfFloatType::precision() const {
   return FloatingPointType::HALF;
 }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -314,8 +314,6 @@ class ARROW_EXPORT NestedType : public DataType, public ParametricType {
   using DataType::DataType;
 };
 
-class NoExtraMeta {};
-
 /// \brief The combination of a field name and data type, with optional metadata
 ///
 /// Fields are used to describe the individual constituents of a
@@ -425,7 +423,7 @@ class IntegerTypeImpl : public detail::CTypeImpl<DERIVED, IntegerType, TYPE_ID, 
 }  // namespace detail
 
 /// Concrete type class for always-null data
-class ARROW_EXPORT NullType : public DataType, public NoExtraMeta {
+class ARROW_EXPORT NullType : public DataType {
  public:
   static constexpr Type::type type_id = Type::NA;
 
@@ -447,8 +445,7 @@ class ARROW_EXPORT NullType : public DataType, public NoExtraMeta {
 
 /// Concrete type class for boolean data
 class ARROW_EXPORT BooleanType
-    : public detail::CTypeImpl<BooleanType, PrimitiveCType, Type::BOOL, bool>,
-      public NoExtraMeta {
+    : public detail::CTypeImpl<BooleanType, PrimitiveCType, Type::BOOL, bool> {
  public:
   static constexpr const char* type_name() { return "bool"; }
 
@@ -714,7 +711,7 @@ class ARROW_EXPORT FixedSizeListType : public NestedType {
 };
 
 /// \brief Base class for all variable-size binary data types
-class ARROW_EXPORT BaseBinaryType : public DataType, public NoExtraMeta {
+class ARROW_EXPORT BaseBinaryType : public DataType {
  public:
   using DataType::DataType;
 };

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -389,193 +389,258 @@ using void_t = typename make_void<Ts...>::type;
 // Useful type predicates
 //
 
+// only in C++14
+template <bool B, typename T = void>
+using enable_if_t = typename std::enable_if<B, T>::type;
+
+template <typename T>
+using is_null_type = std::is_same<NullType, T>;
+
+template <typename T, typename R = void>
+using enable_if_null = enable_if_t<is_null_type<T>::value, R>;
+
+template <typename T>
+using is_boolean_type = std::is_same<BooleanType, T>;
+
+template <typename T, typename R = void>
+using enable_if_boolean = enable_if_t<is_boolean_type<T>::value, R>;
+
 template <typename T>
 using is_number_type = std::is_base_of<NumberType, T>;
+
+template <typename T, typename R = void>
+using enable_if_number = enable_if_t<is_number_type<T>::value, R>;
 
 template <typename T>
 using is_integer_type = std::is_base_of<IntegerType, T>;
 
-template <typename T>
-using is_floating_type = std::is_base_of<FloatingPointType, T>;
-
-template <typename T>
-using is_temporal_type = std::is_base_of<TemporalType, T>;
-
-template <typename T>
-struct has_c_type {
-  static constexpr bool value =
-      (std::is_base_of<PrimitiveCType, T>::value || std::is_base_of<DateType, T>::value ||
-       std::is_base_of<TimeType, T>::value || std::is_base_of<TimestampType, T>::value ||
-       std::is_base_of<IntervalType, T>::value ||
-       std::is_base_of<DurationType, T>::value);
-};
-
-template <typename T>
-struct is_8bit_int {
-  static constexpr bool value =
-      (std::is_same<UInt8Type, T>::value || std::is_same<Int8Type, T>::value);
-};
-
-template <typename T>
-struct is_any_string_type {
-  static constexpr bool value =
-      std::is_same<StringType, T>::value || std::is_same<LargeStringType, T>::value;
-};
-
 template <typename T, typename R = void>
-using enable_if_8bit_int = typename std::enable_if<is_8bit_int<T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_primitive_ctype =
-    typename std::enable_if<std::is_base_of<PrimitiveCType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_integer = typename std::enable_if<is_integer_type<T>::value, R>::type;
+using enable_if_integer = enable_if_t<is_integer_type<T>::value, R>;
 
 template <typename T>
-using is_signed_integer =
+using is_signed_integer_type =
     std::integral_constant<bool, is_integer_type<T>::value &&
                                      std::is_signed<typename T::c_type>::value>;
 
 template <typename T, typename R = void>
-using enable_if_signed_integer =
-    typename std::enable_if<is_signed_integer<T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_unsigned_integer = typename std::enable_if<
-    is_integer_type<T>::value && std::is_unsigned<typename T::c_type>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_floating_point =
-    typename std::enable_if<is_floating_type<T>::value, R>::type;
+using enable_if_signed_integer = enable_if_t<is_signed_integer_type<T>::value, R>;
 
 template <typename T>
-using is_date = std::is_base_of<DateType, T>;
+using is_unsigned_integer_type =
+    std::integral_constant<bool, is_integer_type<T>::value &&
+                                     std::is_unsigned<typename T::c_type>::value>;
 
 template <typename T, typename R = void>
-using enable_if_date = typename std::enable_if<is_date<T>::value, R>::type;
+using enable_if_unsigned_integer = enable_if_t<is_unsigned_integer_type<T>::value, R>;
+
+// Note this will also include HalfFloatType which is represented by a
+// non-floating point primitive (uint16_t).
+template <typename T>
+using is_floating_type = std::is_base_of<FloatingPointType, T>;
+
+template <typename T, typename R = void>
+using enable_if_floating_point = enable_if_t<is_floating_type<T>::value, R>;
+
+// Half floats are special in that they behave physically like an unsigned
+// integer.
+template <typename T>
+using is_half_float_type = std::is_same<HalfFloatType, T>;
+
+template <typename T, typename R = void>
+using enable_if_half_float = enable_if_t<is_half_float_type<T>::value, R>;
+
+// Binary Types
+
+// Base binary refers to Binary/LargeBinary/String/LargeString
+template <typename T>
+using is_base_binary_type = std::is_base_of<BaseBinaryType, T>;
+
+template <typename T, typename R = void>
+using enable_if_base_binary = enable_if_t<is_base_binary_type<T>::value, R>;
+
+// Any binary excludes string from Base binary
+template <typename T>
+using is_any_binary_type =
+    std::integral_constant<bool, std::is_same<BinaryType, T>::value ||
+                                     std::is_same<LargeBinaryType, T>::value>;
+
+template <typename T, typename R = void>
+using enable_if_any_binary = enable_if_t<is_any_binary_type<T>::value, R>;
 
 template <typename T>
-using is_time = std::is_base_of<TimeType, T>;
+using is_string_like_type =
+    std::integral_constant<bool, is_base_binary_type<T>::value && T::is_utf8>;
 
 template <typename T, typename R = void>
-using enable_if_time = typename std::enable_if<is_time<T>::value, R>::type;
+using enable_if_string_like = enable_if_t<is_string_like_type<T>::value, R>;
+
+// Note that this also includes DecimalType
+template <typename T>
+using is_fixed_size_binary_type = std::is_base_of<FixedSizeBinaryType, T>;
+
+template <typename T, typename R = void>
+using enable_if_fixed_size_binary = enable_if_t<is_fixed_size_binary_type<T>::value, R>;
 
 template <typename T>
-using is_timestamp = std::is_base_of<TimestampType, T>;
+using is_binary_like_type =
+    std::integral_constant<bool, (is_base_binary_type<T>::value &&
+                                  !is_string_like_type<T>::value) ||
+                                     is_fixed_size_binary_type<T>::value>;
 
 template <typename T, typename R = void>
-using enable_if_timestamp = typename std::enable_if<is_timestamp<T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_has_c_type = typename std::enable_if<has_c_type<T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_null = typename std::enable_if<std::is_same<NullType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_base_binary =
-    typename std::enable_if<std::is_base_of<BaseBinaryType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_binary =
-    typename std::enable_if<std::is_base_of<BinaryType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_large_binary =
-    typename std::enable_if<std::is_base_of<LargeBinaryType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_boolean =
-    typename std::enable_if<std::is_same<BooleanType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_binary_like =
-    typename std::enable_if<std::is_base_of<BaseBinaryType, T>::value ||
-                                std::is_base_of<FixedSizeBinaryType, T>::value,
-                            R>::type;
-
-template <typename T, typename R = void>
-using enable_if_fixed_size_binary =
-    typename std::enable_if<std::is_base_of<FixedSizeBinaryType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_base_list =
-    typename std::enable_if<std::is_base_of<BaseListType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_list =
-    typename std::enable_if<std::is_base_of<ListType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_large_list =
-    typename std::enable_if<std::is_base_of<LargeListType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_fixed_size_list =
-    typename std::enable_if<std::is_base_of<FixedSizeListType, T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_number = typename std::enable_if<is_number_type<T>::value, R>::type;
-
-namespace internal {
-
-// The partial specialization will match if T has the ATTR_NAME member
-#define GET_ATTR(ATTR_NAME, DEFAULT)                             \
-  template <typename T, typename Enable = void>                  \
-  struct GetAttr_##ATTR_NAME {                                   \
-    using type = DEFAULT;                                        \
-  };                                                             \
-                                                                 \
-  template <typename T>                                          \
-  struct GetAttr_##ATTR_NAME<T, void_t<typename T::ATTR_NAME>> { \
-    using type = typename T::ATTR_NAME;                          \
-  };
-
-GET_ATTR(c_type, void)
-GET_ATTR(TypeClass, void)
-
-#undef GET_ATTR
-
-}  // namespace internal
-
-#define PRIMITIVE_TRAITS(T)                                                           \
-  using TypeClass =                                                                   \
-      typename std::conditional<std::is_base_of<DataType, T>::value, T,               \
-                                typename internal::GetAttr_TypeClass<T>::type>::type; \
-  using c_type = typename internal::GetAttr_c_type<TypeClass>::type
+using enable_if_binary_like = enable_if_t<is_binary_like_type<T>::value, R>;
 
 template <typename T>
-struct IsUnsignedInt {
-  PRIMITIVE_TRAITS(T);
-  static constexpr bool value =
-      std::is_integral<c_type>::value && std::is_unsigned<c_type>::value;
-};
+using is_decimal_type = std::is_base_of<DecimalType, T>;
+
+template <typename T, typename R = void>
+using enable_if_decimal = enable_if_t<is_decimal_type<T>::value, R>;
+
+// Nested Types
 
 template <typename T>
-struct IsSignedInt {
-  PRIMITIVE_TRAITS(T);
-  static constexpr bool value =
-      std::is_integral<c_type>::value && std::is_signed<c_type>::value;
-};
+using is_nested_type = std::is_base_of<NestedType, T>;
+
+template <typename T, typename R = void>
+using enable_if_nested = enable_if_t<is_nested_type<T>::value, R>;
 
 template <typename T>
-struct IsInteger {
-  PRIMITIVE_TRAITS(T);
-  static constexpr bool value = std::is_integral<c_type>::value;
-};
+using is_base_list_type = std::is_base_of<BaseListType, T>;
+
+template <typename T, typename R = void>
+using enable_if_base_list = enable_if_t<is_base_list_type<T>::value, R>;
 
 template <typename T>
-struct IsFloatingPoint {
-  PRIMITIVE_TRAITS(T);
-  static constexpr bool value = std::is_floating_point<c_type>::value;
-};
+using is_fixed_size_list_type = std::is_same<FixedSizeListType, T>;
+
+template <typename T, typename R = void>
+using enable_if_fixed_size_list = enable_if_t<is_fixed_size_list_type<T>::value, R>;
 
 template <typename T>
-struct IsNumeric {
-  PRIMITIVE_TRAITS(T);
-  static constexpr bool value = std::is_arithmetic<c_type>::value;
-};
+using is_list_like_type =
+    std::integral_constant<bool, is_base_list_type<T>::value ||
+                                     is_fixed_size_list_type<T>::value>;
+
+template <typename T, typename R = void>
+using enable_if_list_like = enable_if_t<is_list_like_type<T>::value, R>;
+
+template <typename T>
+using is_struct_type = std::is_base_of<StructType, T>;
+
+template <typename T, typename R = void>
+using enable_if_struct = enable_if_t<is_struct_type<T>::value, R>;
+
+template <typename T>
+using is_union_type = std::is_base_of<UnionType, T>;
+
+template <typename T, typename R = void>
+using enable_if_union = enable_if_t<is_union_type<T>::value, R>;
+
+// TemporalTypes
+
+template <typename T>
+using is_temporal_type = std::is_base_of<TemporalType, T>;
+
+template <typename T, typename R = void>
+using enable_if_temporal = enable_if_t<is_temporal_type<T>::value, R>;
+
+template <typename T>
+using is_date_type = std::is_base_of<DateType, T>;
+
+template <typename T, typename R = void>
+using enable_if_date = enable_if_t<is_date_type<T>::value, R>;
+
+template <typename T>
+using is_time_type = std::is_base_of<TimeType, T>;
+
+template <typename T, typename R = void>
+using enable_if_time = enable_if_t<is_time_type<T>::value, R>;
+
+template <typename T>
+using is_timestamp_type = std::is_base_of<TimestampType, T>;
+
+template <typename T, typename R = void>
+using enable_if_timestamp = enable_if_t<is_timestamp_type<T>::value, R>;
+
+template <typename T>
+using is_duration_type = std::is_base_of<DurationType, T>;
+
+template <typename T, typename R = void>
+using enable_if_duration = enable_if_t<is_duration_type<T>::value, R>;
+
+// Attribute differentiation
+
+template <typename T>
+using is_primitive_ctype = std::is_base_of<PrimitiveCType, T>;
+
+template <typename T, typename R = void>
+using enable_if_primitive_ctype = enable_if_t<is_primitive_ctype<T>::value, R>;
+
+template <typename T>
+using has_c_type = std::integral_constant<bool, is_primitive_ctype<T>::value ||
+                                                    is_temporal_type<T>::value>;
+
+template <typename T, typename R = void>
+using enable_if_has_c_type = enable_if_t<has_c_type<T>::value, R>;
+
+template <typename T>
+using has_string_view = std::integral_constant<bool, is_binary_like_type<T>::value ||
+                                                         is_string_like_type<T>::value>;
+
+template <typename T, typename R = void>
+using enable_if_has_string_view = enable_if_t<has_string_view<T>::value, R>;
+
+template <typename T>
+using has_no_extra_meta = std::is_base_of<NoExtraMeta, T>;
+
+template <typename T, typename R = void>
+using enable_if_has_no_extra_meta = enable_if_t<has_no_extra_meta<T>::value, R>;
+
+template <typename T>
+using is_8bit_int = std::integral_constant<bool, std::is_same<UInt8Type, T>::value ||
+                                                     std::is_same<Int8Type, T>::value>;
+
+template <typename T, typename R = void>
+using enable_if_8bit_int = enable_if_t<is_8bit_int<T>::value, R>;
+
+template <typename T>
+using is_paramater_free_type =
+    std::integral_constant<bool, TypeTraits<T>::is_parameter_free>;
+
+template <typename T, typename R = void>
+using enable_if_parameter_free = enable_if_t<is_paramater_free_type<T>::value, R>;
+
+// Physical representation quirks
+
+template <typename T>
+using is_physical_signed_integer_type =
+    std::integral_constant<bool,
+                           is_signed_integer_type<T>::value ||
+                               (is_temporal_type<T>::value && has_c_type<T>::value)>;
+
+template <typename T, typename R = void>
+using enable_if_physical_signed_integer =
+    enable_if_t<is_physical_signed_integer_type<T>::value, R>;
+
+template <typename T>
+using is_physical_unsigned_integer_type =
+    std::integral_constant<bool, is_unsigned_integer_type<T>::value ||
+                                     is_half_float_type<T>::value>;
+
+template <typename T, typename R = void>
+using enable_if_physical_unsigned_integer =
+    enable_if_t<is_physical_unsigned_integer_type<T>::value, R>;
+
+// Like is_floating_type but excluding half-floats which don't have a
+// float-like c type.
+template <typename T>
+using is_physical_floating_type =
+    std::integral_constant<bool,
+                           is_floating_type<T>::value && !is_half_float_type<T>::value>;
+
+template <typename T, typename R = void>
+using enable_if_physical_floating_point =
+    enable_if_t<is_physical_floating_type<T>::value, R>;
 
 static inline bool is_integer(Type::type type_id) {
   switch (type_id) {

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -568,6 +568,12 @@ using is_duration_type = std::is_base_of<DurationType, T>;
 template <typename T, typename R = void>
 using enable_if_duration = enable_if_t<is_duration_type<T>::value, R>;
 
+template <typename T>
+using is_interval_type = std::is_base_of<IntervalType, T>;
+
+template <typename T, typename R = void>
+using enable_if_interval = enable_if_t<is_interval_type<T>::value, R>;
+
 // Attribute differentiation
 
 template <typename T>
@@ -589,12 +595,6 @@ using has_string_view = std::integral_constant<bool, is_binary_like_type<T>::val
 
 template <typename T, typename R = void>
 using enable_if_has_string_view = enable_if_t<has_string_view<T>::value, R>;
-
-template <typename T>
-using has_no_extra_meta = std::is_base_of<NoExtraMeta, T>;
-
-template <typename T, typename R = void>
-using enable_if_has_no_extra_meta = enable_if_t<has_no_extra_meta<T>::value, R>;
 
 template <typename T>
 using is_8bit_int = std::integral_constant<bool, std::is_same<UInt8Type, T>::value ||

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -81,8 +81,7 @@ template <typename Scalar, uint64_t AlgNum = 0, typename Enable = void>
 struct ScalarHelper : public ScalarHelperBase<Scalar, AlgNum> {};
 
 template <typename Scalar, uint64_t AlgNum>
-struct ScalarHelper<Scalar, AlgNum,
-                    typename std::enable_if<std::is_integral<Scalar>::value>::type>
+struct ScalarHelper<Scalar, AlgNum, enable_if_t<std::is_integral<Scalar>::value>>
     : public ScalarHelperBase<Scalar, AlgNum> {
   // ScalarHelper specialization for integers
 
@@ -103,9 +102,8 @@ struct ScalarHelper<Scalar, AlgNum,
 };
 
 template <typename Scalar, uint64_t AlgNum>
-struct ScalarHelper<
-    Scalar, AlgNum,
-    typename std::enable_if<std::is_same<util::string_view, Scalar>::value>::type>
+struct ScalarHelper<Scalar, AlgNum,
+                    enable_if_t<std::is_same<util::string_view, Scalar>::value>>
     : public ScalarHelperBase<Scalar, AlgNum> {
   // ScalarHelper specialization for util::string_view
 
@@ -115,8 +113,7 @@ struct ScalarHelper<
 };
 
 template <typename Scalar, uint64_t AlgNum>
-struct ScalarHelper<Scalar, AlgNum,
-                    typename std::enable_if<std::is_floating_point<Scalar>::value>::type>
+struct ScalarHelper<Scalar, AlgNum, enable_if_t<std::is_floating_point<Scalar>::value>>
     : public ScalarHelperBase<Scalar, AlgNum> {
   // ScalarHelper specialization for reals
 
@@ -494,8 +491,7 @@ struct SmallScalarTraits<bool> {
 };
 
 template <typename Scalar>
-struct SmallScalarTraits<Scalar,
-                         typename std::enable_if<std::is_integral<Scalar>::value>::type> {
+struct SmallScalarTraits<Scalar, enable_if_t<std::is_integral<Scalar>::value>> {
   using Unsigned = typename std::make_unsigned<Scalar>::type;
 
   static constexpr int32_t cardinality = 1U + std::numeric_limits<Unsigned>::max();
@@ -828,19 +824,13 @@ struct HashTraits<T, enable_if_8bit_int<T>> {
 };
 
 template <typename T>
-struct HashTraits<
-    T, typename std::enable_if<has_c_type<T>::value && !is_8bit_int<T>::value>::type> {
+struct HashTraits<T, enable_if_t<has_c_type<T>::value && !is_8bit_int<T>::value>> {
   using c_type = typename T::c_type;
   using MemoTableType = ScalarMemoTable<c_type, HashTable>;
 };
 
 template <typename T>
-struct HashTraits<T, enable_if_binary<T>> {
-  using MemoTableType = BinaryMemoTable;
-};
-
-template <typename T>
-struct HashTraits<T, enable_if_fixed_size_binary<T>> {
+struct HashTraits<T, enable_if_has_string_view<T>> {
   using MemoTableType = BinaryMemoTable;
 };
 

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -1122,10 +1122,10 @@ Status ConvertToDecimal128<ByteArrayType>(const Array& array,
 /// The parquet spec allows systems to write decimals in int32, int64 if the values are
 /// small enough to fit in less 4 bytes or less than 8 bytes, respectively.
 /// This function implements the conversion from int32 and int64 arrays to decimal arrays.
-template <typename ParquetIntegerType,
-          typename = typename std::enable_if<
-              std::is_same<ParquetIntegerType, Int32Type>::value ||
-              std::is_same<ParquetIntegerType, Int64Type>::value>::type>
+template <
+    typename ParquetIntegerType,
+    typename = ::arrow::enable_if_t<std::is_same<ParquetIntegerType, Int32Type>::value ||
+                                    std::is_same<ParquetIntegerType, Int64Type>::value>>
 static Status DecimalIntegerTransfer(RecordReader* reader, MemoryPool* pool,
                                      const std::shared_ptr<DataType>& type, Datum* out) {
   DCHECK_EQ(type->id(), ::arrow::Type::DECIMAL);

--- a/cpp/src/parquet/arrow/test_util.h
+++ b/cpp/src/parquet/arrow/test_util.h
@@ -52,29 +52,8 @@ struct DecimalWithPrecisionAndScale {
   static constexpr int32_t scale = PRECISION - 1;
 };
 
-template <typename ArrowType>
-using is_arrow_float = std::is_floating_point<typename ArrowType::c_type>;
-
-template <typename ArrowType>
-using is_arrow_int = std::is_integral<typename ArrowType::c_type>;
-
-template <typename ArrowType>
-using is_arrow_date = std::is_same<ArrowType, ::arrow::Date64Type>;
-
-template <typename ArrowType>
-using is_arrow_string = std::is_same<ArrowType, ::arrow::StringType>;
-
-template <typename ArrowType>
-using is_arrow_binary = std::is_same<ArrowType, ::arrow::BinaryType>;
-
-template <typename ArrowType>
-using is_arrow_fixed_size_binary = std::is_same<ArrowType, ::arrow::FixedSizeBinaryType>;
-
-template <typename ArrowType>
-using is_arrow_bool = std::is_same<ArrowType, ::arrow::BooleanType>;
-
 template <class ArrowType>
-typename std::enable_if<is_arrow_float<ArrowType>::value, Status>::type NonNullArray(
+::arrow::enable_if_floating_point<ArrowType, Status> NonNullArray(
     size_t size, std::shared_ptr<Array>* out) {
   using c_type = typename ArrowType::c_type;
   std::vector<c_type> values;
@@ -85,9 +64,8 @@ typename std::enable_if<is_arrow_float<ArrowType>::value, Status>::type NonNullA
 }
 
 template <class ArrowType>
-typename std::enable_if<
-    is_arrow_int<ArrowType>::value && !is_arrow_date<ArrowType>::value, Status>::type
-NonNullArray(size_t size, std::shared_ptr<Array>* out) {
+::arrow::enable_if_integer<ArrowType, Status> NonNullArray(size_t size,
+                                                           std::shared_ptr<Array>* out) {
   std::vector<typename ArrowType::c_type> values;
   ::arrow::randint(size, 0, 64, &values);
 
@@ -99,8 +77,8 @@ NonNullArray(size_t size, std::shared_ptr<Array>* out) {
 }
 
 template <class ArrowType>
-typename std::enable_if<is_arrow_date<ArrowType>::value, Status>::type NonNullArray(
-    size_t size, std::shared_ptr<Array>* out) {
+::arrow::enable_if_date<ArrowType, Status> NonNullArray(size_t size,
+                                                        std::shared_ptr<Array>* out) {
   std::vector<typename ArrowType::c_type> values;
   ::arrow::randint(size, 0, 64, &values);
   for (size_t i = 0; i < size; i++) {
@@ -110,14 +88,13 @@ typename std::enable_if<is_arrow_date<ArrowType>::value, Status>::type NonNullAr
   // Passing data type so this will work with TimestampType too
   ::arrow::NumericBuilder<ArrowType> builder(std::make_shared<ArrowType>(),
                                              ::arrow::default_memory_pool());
-  builder.AppendValues(values.data(), values.size());
+  RETURN_NOT_OK(builder.AppendValues(values.data(), values.size()));
   return builder.Finish(out);
 }
 
 template <class ArrowType>
-typename std::enable_if<
-    is_arrow_string<ArrowType>::value || is_arrow_binary<ArrowType>::value, Status>::type
-NonNullArray(size_t size, std::shared_ptr<Array>* out) {
+::arrow::enable_if_base_binary<ArrowType, Status> NonNullArray(
+    size_t size, std::shared_ptr<Array>* out) {
   using BuilderType = typename ::arrow::TypeTraits<ArrowType>::BuilderType;
   BuilderType builder;
   for (size_t i = 0; i < size; i++) {
@@ -127,8 +104,8 @@ NonNullArray(size_t size, std::shared_ptr<Array>* out) {
 }
 
 template <typename ArrowType>
-typename std::enable_if<is_arrow_fixed_size_binary<ArrowType>::value, Status>::type
-NonNullArray(size_t size, std::shared_ptr<Array>* out) {
+::arrow::enable_if_fixed_size_binary<ArrowType, Status> NonNullArray(
+    size_t size, std::shared_ptr<Array>* out) {
   using BuilderType = typename ::arrow::TypeTraits<ArrowType>::BuilderType;
   // set byte_width to the length of "fixed": 5
   // todo: find a way to generate test data with more diversity.
@@ -160,8 +137,8 @@ static inline void random_decimals(int64_t n, uint32_t seed, int32_t precision,
 }
 
 template <typename ArrowType, int32_t precision = ArrowType::precision>
-typename std::enable_if<
-    std::is_same<ArrowType, DecimalWithPrecisionAndScale<precision>>::value, Status>::type
+::arrow::enable_if_t<
+    std::is_same<ArrowType, DecimalWithPrecisionAndScale<precision>>::value, Status>
 NonNullArray(size_t size, std::shared_ptr<Array>* out) {
   constexpr int32_t kDecimalPrecision = precision;
   constexpr int32_t kDecimalScale = DecimalWithPrecisionAndScale<precision>::scale;
@@ -183,8 +160,8 @@ NonNullArray(size_t size, std::shared_ptr<Array>* out) {
 }
 
 template <class ArrowType>
-typename std::enable_if<is_arrow_bool<ArrowType>::value, Status>::type NonNullArray(
-    size_t size, std::shared_ptr<Array>* out) {
+::arrow::enable_if_boolean<ArrowType, Status> NonNullArray(size_t size,
+                                                           std::shared_ptr<Array>* out) {
   std::vector<uint8_t> values;
   ::arrow::randint(size, 0, 1, &values);
   ::arrow::BooleanBuilder builder;
@@ -194,7 +171,7 @@ typename std::enable_if<is_arrow_bool<ArrowType>::value, Status>::type NonNullAr
 
 // This helper function only supports (size/2) nulls.
 template <typename ArrowType>
-typename std::enable_if<is_arrow_float<ArrowType>::value, Status>::type NullableArray(
+::arrow::enable_if_floating_point<ArrowType, Status> NullableArray(
     size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<Array>* out) {
   using c_type = typename ArrowType::c_type;
   std::vector<c_type> values;
@@ -213,9 +190,9 @@ typename std::enable_if<is_arrow_float<ArrowType>::value, Status>::type Nullable
 
 // This helper function only supports (size/2) nulls.
 template <typename ArrowType>
-typename std::enable_if<
-    is_arrow_int<ArrowType>::value && !is_arrow_date<ArrowType>::value, Status>::type
-NullableArray(size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<Array>* out) {
+::arrow::enable_if_integer<ArrowType, Status> NullableArray(size_t size, size_t num_nulls,
+                                                            uint32_t seed,
+                                                            std::shared_ptr<Array>* out) {
   std::vector<typename ArrowType::c_type> values;
 
   // Seed is random in Arrow right now
@@ -235,8 +212,9 @@ NullableArray(size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<Arra
 }
 
 template <typename ArrowType>
-typename std::enable_if<is_arrow_date<ArrowType>::value, Status>::type NullableArray(
-    size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<Array>* out) {
+::arrow::enable_if_date<ArrowType, Status> NullableArray(size_t size, size_t num_nulls,
+                                                         uint32_t seed,
+                                                         std::shared_ptr<Array>* out) {
   std::vector<typename ArrowType::c_type> values;
 
   // Seed is random in Arrow right now
@@ -254,16 +232,14 @@ typename std::enable_if<is_arrow_date<ArrowType>::value, Status>::type NullableA
   // Passing data type so this will work with TimestampType too
   ::arrow::NumericBuilder<ArrowType> builder(std::make_shared<ArrowType>(),
                                              ::arrow::default_memory_pool());
-  builder.AppendValues(values.data(), values.size(), valid_bytes.data());
+  RETURN_NOT_OK(builder.AppendValues(values.data(), values.size(), valid_bytes.data()));
   return builder.Finish(out);
 }
 
 // This helper function only supports (size/2) nulls yet.
 template <typename ArrowType>
-typename std::enable_if<
-    is_arrow_string<ArrowType>::value || is_arrow_binary<ArrowType>::value, Status>::type
-NullableArray(size_t size, size_t num_nulls, uint32_t seed,
-              std::shared_ptr<::arrow::Array>* out) {
+::arrow::enable_if_base_binary<ArrowType, Status> NullableArray(
+    size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<::arrow::Array>* out) {
   std::vector<uint8_t> valid_bytes(size, 1);
 
   for (size_t i = 0; i < num_nulls; i++) {
@@ -289,9 +265,8 @@ NullableArray(size_t size, size_t num_nulls, uint32_t seed,
 // This helper function only supports (size/2) nulls yet,
 // same as NullableArray<String|Binary>(..)
 template <typename ArrowType>
-typename std::enable_if<is_arrow_fixed_size_binary<ArrowType>::value, Status>::type
-NullableArray(size_t size, size_t num_nulls, uint32_t seed,
-              std::shared_ptr<::arrow::Array>* out) {
+::arrow::enable_if_fixed_size_binary<ArrowType, Status> NullableArray(
+    size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<::arrow::Array>* out) {
   std::vector<uint8_t> valid_bytes(size, 1);
 
   for (size_t i = 0; i < num_nulls; i++) {
@@ -316,8 +291,8 @@ NullableArray(size_t size, size_t num_nulls, uint32_t seed,
 }
 
 template <typename ArrowType, int32_t precision = ArrowType::precision>
-typename std::enable_if<
-    std::is_same<ArrowType, DecimalWithPrecisionAndScale<precision>>::value, Status>::type
+::arrow::enable_if_t<
+    std::is_same<ArrowType, DecimalWithPrecisionAndScale<precision>>::value, Status>
 NullableArray(size_t size, size_t num_nulls, uint32_t seed,
               std::shared_ptr<::arrow::Array>* out) {
   std::vector<uint8_t> valid_bytes(size, '\1');
@@ -345,8 +320,9 @@ NullableArray(size_t size, size_t num_nulls, uint32_t seed,
 
 // This helper function only supports (size/2) nulls yet.
 template <class ArrowType>
-typename std::enable_if<is_arrow_bool<ArrowType>::value, Status>::type NullableArray(
-    size_t size, size_t num_nulls, uint32_t seed, std::shared_ptr<Array>* out) {
+::arrow::enable_if_boolean<ArrowType, Status> NullableArray(size_t size, size_t num_nulls,
+                                                            uint32_t seed,
+                                                            std::shared_ptr<Array>* out) {
   std::vector<uint8_t> values;
 
   // Seed is random in Arrow right now

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -81,8 +81,8 @@ class LevelBuilder {
   Status VisitInline(const Array& array);
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<::arrow::FlatArray, T>::value, Status>::type
-  Visit(const T& array) {
+  ::arrow::enable_if_t<std::is_base_of<::arrow::FlatArray, T>::value, Status> Visit(
+      const T& array) {
     array_offsets_.push_back(static_cast<int32_t>(array.offset()));
     valid_bitmaps_.push_back(array.null_bitmap_data());
     null_counts_.push_back(array.null_count());

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -340,7 +340,7 @@ struct StatsHelper {
 };
 
 template <typename T>
-struct StatsHelper<T, typename std::enable_if<std::is_floating_point<T>::value>::type> {
+struct StatsHelper<T, ::arrow::enable_if_t<std::is_floating_point<T>::value>> {
   bool CanHaveNaN() { return true; }
 
   inline int64_t GetValueBeginOffset(const T* values, int64_t count) {


### PR DESCRIPTION
The goal of this PR is to uniformize the usage of type traits and pattern matching on static type information.

- Introduce `arrow::enable_if_t` since we're still on C++11. This   removes a small amount of boilerplate, e.g. `typename (expr)::type`. Refactor most code to use this, except where type_traits was not included.
- Major overhaul of `type_traits.h` by exporting a uniformized (as much as I could) aliases, i.e. `is_X_type` and the accompanying `enable_if_X`.
- Removed old struct type traits, e.g. `IsSigned...`.
- Removed catch-all-visitor method and replaced them with explicits missing visitor. This will help the implementation of new types to error missing implementation at compile time instead of runtime.
- Uniformize usage of `enable_if` with methods, by using the return-place form instead of parameter-place (except when in the constructor).
- Fixed some missing implementation when trivial.
- Added c_type to BooleanType