### PR TITLE
ARROW-7246: [CI][Python] Use Python 3 for docker-compose

### DIFF
--- a/dev/tasks/python-wheels/travis.linux.yml
+++ b/dev/tasks/python-wheels/travis.linux.yml
@@ -16,14 +16,12 @@
 
 os: linux
 
+dist: bionic
+
+language: python
+
 services:
   - docker
-
-# Update docker to support newer docker-compose versions
-addons:
-  apt:
-    packages:
-      - docker-ce
 
 # don't build twice
 if: tag IS blank
@@ -32,9 +30,6 @@ env:
   global:
     - PLAT=x86_64
     - TRAVIS_TAG={{ task.tag }}
-
-before_script:
-  - sudo pip install -U docker-compose
 
 script:
   - git clone --no-checkout {{ arrow.remote }} arrow


### PR DESCRIPTION
We get the following error when we use Python 2:

    $ docker-compose pull $BUILD_IMAGE
    Traceback (most recent call last):
      File "/usr/local/bin/docker-compose", line 6, in <module>
        from compose.cli.main import main
      File "/usr/local/lib/python2.7/dist-packages/compose/cli/main.py", line 18, in <module>
        import docker
      File "/usr/local/lib/python2.7/dist-packages/docker/__init__.py", line 2, in <module>
        from .api import APIClient
      File "/usr/local/lib/python2.7/dist-packages/docker/api/__init__.py", line 2, in <module>
        from .client import APIClient
      File "/usr/local/lib/python2.7/dist-packages/docker/api/client.py", line 5, in <module>
        import requests
      File "/usr/local/lib/python2.7/dist-packages/requests/__init__.py", line 95, in <module>
        from urllib3.contrib import pyopenssl
      File "/usr/local/lib/python2.7/dist-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
        import OpenSSL.SSL
      File "/usr/lib/python2.7/dist-packages/OpenSSL/__init__.py", line 8, in <module>
        from OpenSSL import rand, crypto, SSL
      File "/usr/lib/python2.7/dist-packages/OpenSSL/SSL.py", line 118, in <module>
        SSL_ST_INIT = _lib.SSL_ST_INIT
    AttributeError: 'module' object has no attribute 'SSL_ST_INIT'