### PR TITLE
ARROW-7257: [CI] Fix Homebrew formula audit error by openssl

### DIFF
--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -13,7 +13,7 @@ class ApacheArrow < Formula
   depends_on "grpc"
   depends_on "lz4"
   depends_on "numpy"
-  depends_on "openssl"
+  depends_on "openssl@1.1"
   depends_on "protobuf"
   depends_on "python"
   depends_on "rapidjson"


### PR DESCRIPTION
https://travis-ci.org/ursa-labs/crossbow/builds/616575964#L3501

    Error: 2 problems in 1 formula detected
    apache-arrow:
      * Dependency 'openssl' is an alias; use the canonical name 'openssl@1.1'.
    The command "brew audit $ARROW_FORMULA" failed and exited with 1 during .