### PR TITLE
ARROW-7254: [Java] BaseVariableWidthVector#setSafe appears to make value offsets inconsistent

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -329,6 +329,12 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    * @return the inner buffers.
    */
   public List<ArrowBuf> getFieldBuffers() {
+    // before flight/IPC, we must bring the vector to a consistent state.
+    // this is because, it is possible that the offset buffers of some trailing values
+    // are not updated. this may cause some data in the data buffer being lost.
+    // for details, please see TestValueVector#testUnloadVariableWidthVector.
+    fillHoles(valueCount);
+
     List<ArrowBuf> result = new ArrayList<>(3);
     setReaderAndWriterIndex();
     result.add(validityBuffer);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2665,6 +2665,28 @@ public class TestValueVector {
     }
   }
 
+  @Test
+  public void testUnloadVariableWidthVector() {
+    try (final VarCharVector varCharVector = new VarCharVector("var char", allocator)) {
+      varCharVector.allocateNew(5, 2);
+      varCharVector.setValueCount(2);
+
+      varCharVector.set(0, "abcd".getBytes());
+
+      List<ArrowBuf> bufs = varCharVector.getFieldBuffers();
+      assertEquals(3, bufs.size());
+
+      ArrowBuf offsetBuf = bufs.get(1);
+      ArrowBuf dataBuf = bufs.get(2);
+
+      assertEquals(12, offsetBuf.writerIndex());
+      assertEquals(4, offsetBuf.getInt(4));
+      assertEquals(4, offsetBuf.getInt(8));
+
+      assertEquals(4, dataBuf.writerIndex());
+    }
+  }
+
   private void writeStructVector(NullableStructWriter writer, int value1, long value2) {
     writer.start();
     writer.integer("f0").writeInt(value1);


### PR DESCRIPTION
See the discussion in ARROW-7254