### PR TITLE
ARROW-7259: [Java] Support subfield encoder use different hasher

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
@@ -20,6 +20,8 @@ package org.apache.arrow.vector.dictionary;
 import java.util.Collections;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
+import org.apache.arrow.memory.util.hash.SimpleHasher;
 import org.apache.arrow.vector.BaseIntVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.ValueVector;
@@ -38,14 +40,18 @@ public class ListSubfieldEncoder {
   private final Dictionary dictionary;
   private final BufferAllocator allocator;
 
+  public ListSubfieldEncoder(Dictionary dictionary, BufferAllocator allocator) {
+    this (dictionary, allocator, SimpleHasher.INSTANCE);
+  }
+
   /**
    * Construct an instance.
    */
-  public ListSubfieldEncoder(Dictionary dictionary, BufferAllocator allocator) {
+  public ListSubfieldEncoder(Dictionary dictionary, BufferAllocator allocator, ArrowBufHasher hasher) {
     this.dictionary = dictionary;
     this.allocator = allocator;
     BaseListVector dictVector = (BaseListVector) dictionary.getVector();
-    hashTable = new DictionaryHashTable(getDataVector(dictVector));
+    hashTable = new DictionaryHashTable(getDataVector(dictVector), hasher);
   }
 
   private FieldVector getDataVector(BaseListVector vector) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/StructSubfieldEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/StructSubfieldEncoder.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
+import org.apache.arrow.memory.util.hash.SimpleHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseIntVector;
 import org.apache.arrow.vector.FieldVector;
@@ -47,9 +49,17 @@ public class StructSubfieldEncoder {
   /**
    * Construct an instance.
    */
+  public StructSubfieldEncoder(BufferAllocator allocator, DictionaryProvider.MapDictionaryProvider provider) {
+    this (allocator, provider, SimpleHasher.INSTANCE);
+  }
+
+  /**
+   * Construct an instance.
+   */
   public StructSubfieldEncoder(
       BufferAllocator allocator,
-      DictionaryProvider.MapDictionaryProvider provider) {
+      DictionaryProvider.MapDictionaryProvider provider,
+      ArrowBufHasher hasher) {
 
     this.allocator = allocator;
     this.provider = provider;
@@ -57,7 +67,7 @@ public class StructSubfieldEncoder {
     this.dictionaryIdToHashTable = new HashMap<>();
 
     provider.getDictionaryIds().forEach(id ->
-        dictionaryIdToHashTable.put(id, new DictionaryHashTable(provider.lookup(id).getVector())));
+        dictionaryIdToHashTable.put(id, new DictionaryHashTable(provider.lookup(id).getVector(), hasher)));
   }
 
   private FieldVector getChildVector(StructVector vector, int index) {


### PR DESCRIPTION
Related to [ARROW-7259](https://issues.apache.org/jira/browse/ARROW-7259).

Currently ListSubFieldEncoder/StructSubFieldEncoder use default hasher for calculating hashCode.
This issue enables them to use different hasher or even user-defined hasher for their own use cases just like DictionaryEncoder does.