### PR TITLE
ARROW-7264: [Java] RangeEqualsVisitor type check is not correct

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/deduplicate/DeduplicationUtils.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/deduplicate/DeduplicationUtils.java
@@ -44,7 +44,7 @@ class DeduplicationUtils {
     runStarts.setZero(0, bufSize);
 
     BitVectorHelper.setBit(runStarts, 0);
-    RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector, vector, false);
+    RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector, vector, null);
     Range range = new Range(0, 0, 1);
     for (int i = 1; i < vector.getValueCount(); i++) {
       range.setLeftStart(i).setRightStart(i - 1);

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/LinearDictionaryEncoder.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/LinearDictionaryEncoder.java
@@ -68,7 +68,7 @@ public class LinearDictionaryEncoder<E extends BaseIntVector, D extends ValueVec
     this.encodeNull = encodeNull;
 
     // temporarily set left and right vectors to dictionary
-    equalizer = new RangeEqualsVisitor(dictionary, dictionary, false);
+    equalizer = new RangeEqualsVisitor(dictionary, dictionary, null);
     range = new Range(0, 0, 1);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -69,7 +69,7 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
   public ApproxEqualsVisitor(ValueVector left, ValueVector right,
                              VectorValueEqualizer<Float4Vector> floatDiffFunction,
                              VectorValueEqualizer<Float8Vector> doubleDiffFunction) {
-    this (left, right, floatDiffFunction, doubleDiffFunction, true, new TypeEqualsVisitor(right));
+    this (left, right, floatDiffFunction, doubleDiffFunction, new TypeEqualsVisitor(right));
   }
 
   /**
@@ -78,15 +78,13 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
    * @param right the right vector.
    * @param floatDiffFunction the equalizer for float values.
    * @param doubleDiffFunction the equalizer for double values.
-   * @param checkType whether need check type equals
-   * @param typeVisitor type visitor to compare vector fields
+   * @param typeVisitor type visitor to compare vector fields, null indicates no need to check type
    */
   public ApproxEqualsVisitor(ValueVector left, ValueVector right,
       VectorValueEqualizer<Float4Vector> floatDiffFunction,
       VectorValueEqualizer<Float8Vector> doubleDiffFunction,
-      boolean checkType,
       TypeEqualsVisitor typeVisitor) {
-    super(left, right, checkType, typeVisitor);
+    super(left, right, typeVisitor);
     this.floatDiffFunction = floatDiffFunction;
     this.doubleDiffFunction = doubleDiffFunction;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.vector.compare;
 
+import java.util.function.BiFunction;
+
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
@@ -69,7 +71,7 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
   public ApproxEqualsVisitor(ValueVector left, ValueVector right,
                              VectorValueEqualizer<Float4Vector> floatDiffFunction,
                              VectorValueEqualizer<Float8Vector> doubleDiffFunction) {
-    this (left, right, floatDiffFunction, doubleDiffFunction, new TypeEqualsVisitor(right));
+    this (left, right, floatDiffFunction, doubleDiffFunction, DEFAULT_TYPE_COMPARATOR);
   }
 
   /**
@@ -78,13 +80,13 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
    * @param right the right vector.
    * @param floatDiffFunction the equalizer for float values.
    * @param doubleDiffFunction the equalizer for double values.
-   * @param typeVisitor type visitor to compare vector fields, null indicates no need to check type
+   * @param typeComparator type comparator to compare vector type.
    */
   public ApproxEqualsVisitor(ValueVector left, ValueVector right,
       VectorValueEqualizer<Float4Vector> floatDiffFunction,
       VectorValueEqualizer<Float8Vector> doubleDiffFunction,
-      TypeEqualsVisitor typeVisitor) {
-    super(left, right, typeVisitor);
+      BiFunction<ValueVector, ValueVector, Boolean> typeComparator) {
+    super(left, right, typeComparator);
     this.floatDiffFunction = floatDiffFunction;
     this.doubleDiffFunction = doubleDiffFunction;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -69,7 +69,7 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
   public ApproxEqualsVisitor(ValueVector left, ValueVector right,
                              VectorValueEqualizer<Float4Vector> floatDiffFunction,
                              VectorValueEqualizer<Float8Vector> doubleDiffFunction) {
-    this (left, right, floatDiffFunction, doubleDiffFunction, new TypeEqualsVisitor(right));
+    this (left, right, floatDiffFunction, doubleDiffFunction, true, new TypeEqualsVisitor(right));
   }
 
   /**
@@ -78,13 +78,15 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
    * @param right the right vector.
    * @param floatDiffFunction the equalizer for float values.
    * @param doubleDiffFunction the equalizer for double values.
+   * @param checkType whether need check type equals
    * @param typeVisitor type visitor to compare vector fields
    */
   public ApproxEqualsVisitor(ValueVector left, ValueVector right,
       VectorValueEqualizer<Float4Vector> floatDiffFunction,
       VectorValueEqualizer<Float8Vector> doubleDiffFunction,
+      boolean checkType,
       TypeEqualsVisitor typeVisitor) {
-    super(left, right, true, typeVisitor);
+    super(left, right, checkType, typeVisitor);
     this.floatDiffFunction = floatDiffFunction;
     this.doubleDiffFunction = doubleDiffFunction;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/ApproxEqualsVisitor.java
@@ -58,10 +58,18 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
    * @param doubleEpsilon difference for double values
    */
   public ApproxEqualsVisitor(ValueVector left, ValueVector right, float floatEpsilon, double doubleEpsilon) {
-    super(left, right, true);
+    this (left, right,
+        new ValueEpsilonEqualizers.Float4EpsilonEqualizer(floatEpsilon),
+        new ValueEpsilonEqualizers.Float8EpsilonEqualizer(doubleEpsilon));
+  }
 
-    floatDiffFunction = new ValueEpsilonEqualizers.Float4EpsilonEqualizer(floatEpsilon);
-    doubleDiffFunction = new ValueEpsilonEqualizers.Float8EpsilonEqualizer(doubleEpsilon);
+  /**
+   * Constructs a new instance.
+   */
+  public ApproxEqualsVisitor(ValueVector left, ValueVector right,
+                             VectorValueEqualizer<Float4Vector> floatDiffFunction,
+                             VectorValueEqualizer<Float8Vector> doubleDiffFunction) {
+    this (left, right, floatDiffFunction, doubleDiffFunction, new TypeEqualsVisitor(right));
   }
 
   /**
@@ -70,11 +78,13 @@ public class ApproxEqualsVisitor extends RangeEqualsVisitor {
    * @param right the right vector.
    * @param floatDiffFunction the equalizer for float values.
    * @param doubleDiffFunction the equalizer for double values.
+   * @param typeVisitor type visitor to compare vector fields
    */
   public ApproxEqualsVisitor(ValueVector left, ValueVector right,
-                             VectorValueEqualizer<Float4Vector> floatDiffFunction,
-                             VectorValueEqualizer<Float8Vector> doubleDiffFunction) {
-    super(left, right, true);
+      VectorValueEqualizer<Float4Vector> floatDiffFunction,
+      VectorValueEqualizer<Float8Vector> doubleDiffFunction,
+      TypeEqualsVisitor typeVisitor) {
+    super(left, right, true, typeVisitor);
     this.floatDiffFunction = floatDiffFunction;
     this.doubleDiffFunction = doubleDiffFunction;
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
@@ -59,17 +59,6 @@ public class TypeEqualsVisitor implements VectorVisitor<Boolean, Void> {
     this.checkMetadata = checkMetadata;
   }
 
-  public ValueVector getRight() {
-    return right;
-  }
-
-  /**
-   * Return a new visitor with the given right vector, other params are same.
-   */
-  public TypeEqualsVisitor newVisitor(ValueVector right) {
-    return new TypeEqualsVisitor(right, checkName, checkMetadata);
-  }
-
   /**
    * Check type equals without passing IN param in VectorVisitor.
    */

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/TypeEqualsVisitor.java
@@ -59,6 +59,17 @@ public class TypeEqualsVisitor implements VectorVisitor<Boolean, Void> {
     this.checkMetadata = checkMetadata;
   }
 
+  public ValueVector getRight() {
+    return right;
+  }
+
+  /**
+   * Return a new visitor with the given right vector, other params are same.
+   */
+  public TypeEqualsVisitor newVisitor(ValueVector right) {
+    return new TypeEqualsVisitor(right, checkName, checkMetadata);
+  }
+
   /**
    * Check type equals without passing IN param in VectorVisitor.
    */

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorEqualsVisitor.java
@@ -17,6 +17,10 @@
 
 package org.apache.arrow.vector.compare;
 
+import static org.apache.arrow.vector.compare.RangeEqualsVisitor.DEFAULT_TYPE_COMPARATOR;
+
+import java.util.function.BiFunction;
+
 import org.apache.arrow.vector.ValueVector;
 
 /**
@@ -31,26 +35,26 @@ public class VectorEqualsVisitor {
    * @return true if the vectors are equal, and false otherwise.
    */
   public static boolean vectorEquals(ValueVector left, ValueVector right) {
-    return vectorEquals(left, right, new TypeEqualsVisitor(right));
+    return vectorEquals(left, right, DEFAULT_TYPE_COMPARATOR);
   }
 
   /**
    * Checks if two vectors are equals.
    * @param left the left vector to compare.
    * @param right the right vector to compare.
-   * @param typeVisitor type visitor to compare vector fields, null indicates no need to check type.
+   * @param typeComparator type comparator to compare vector type.
    * @return true if the vectors are equal, and false otherwise.
    */
   public static boolean vectorEquals(
       ValueVector left,
       ValueVector right,
-      TypeEqualsVisitor typeVisitor) {
+      BiFunction<ValueVector, ValueVector, Boolean> typeComparator) {
 
     if (left.getValueCount() != right.getValueCount()) {
       return false;
     }
 
-    RangeEqualsVisitor visitor = new RangeEqualsVisitor(left, right, typeVisitor);
+    RangeEqualsVisitor visitor = new RangeEqualsVisitor(left, right, typeComparator);
     return visitor.rangeEquals(new Range(0, 0, left.getValueCount()));
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorEqualsVisitor.java
@@ -25,41 +25,32 @@ import org.apache.arrow.vector.ValueVector;
 public class VectorEqualsVisitor {
 
   /**
-   * Checks if two vectors are equals.
+   * Checks if two vectors are equals with default type visitor.
    * @param left the left vector to compare.
    * @param right the right vector to compare.
    * @return true if the vectors are equal, and false otherwise.
    */
   public static boolean vectorEquals(ValueVector left, ValueVector right) {
-    return vectorEquals(left, right, true);
-  }
-
-  /**
-   * Checks if two vectors are equals.
-   */
-  public static boolean vectorEquals(ValueVector left, ValueVector right, boolean checkType) {
-    return vectorEquals(left, right, checkType, new TypeEqualsVisitor(right));
+    return vectorEquals(left, right, new TypeEqualsVisitor(right));
   }
 
   /**
    * Checks if two vectors are equals.
    * @param left the left vector to compare.
    * @param right the right vector to compare.
-   * @param checkType whether need check equality of types
-   * @param typeVisitor type visitor to compare vector fields
+   * @param typeVisitor type visitor to compare vector fields, null indicates no need to check type.
    * @return true if the vectors are equal, and false otherwise.
    */
   public static boolean vectorEquals(
       ValueVector left,
       ValueVector right,
-      boolean checkType,
       TypeEqualsVisitor typeVisitor) {
 
     if (left.getValueCount() != right.getValueCount()) {
       return false;
     }
 
-    RangeEqualsVisitor visitor = new RangeEqualsVisitor(left, right, checkType, typeVisitor);
+    RangeEqualsVisitor visitor = new RangeEqualsVisitor(left, right, typeVisitor);
     return visitor.rangeEquals(new Range(0, 0, left.getValueCount()));
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorEqualsVisitor.java
@@ -36,17 +36,30 @@ public class VectorEqualsVisitor {
 
   /**
    * Checks if two vectors are equals.
+   */
+  public static boolean vectorEquals(ValueVector left, ValueVector right, boolean checkType) {
+    return vectorEquals(left, right, checkType, new TypeEqualsVisitor(right));
+  }
+
+  /**
+   * Checks if two vectors are equals.
    * @param left the left vector to compare.
    * @param right the right vector to compare.
-   * @param isTypeCheckNeeded check equality of types
+   * @param checkType whether need check equality of types
+   * @param typeVisitor type visitor to compare vector fields
    * @return true if the vectors are equal, and false otherwise.
    */
-  public static boolean vectorEquals(ValueVector left, ValueVector right, boolean isTypeCheckNeeded) {
+  public static boolean vectorEquals(
+      ValueVector left,
+      ValueVector right,
+      boolean checkType,
+      TypeEqualsVisitor typeVisitor) {
+
     if (left.getValueCount() != right.getValueCount()) {
       return false;
     }
 
-    RangeEqualsVisitor visitor = new RangeEqualsVisitor(left, right, isTypeCheckNeeded);
+    RangeEqualsVisitor visitor = new RangeEqualsVisitor(left, right, checkType, typeVisitor);
     return visitor.rangeEquals(new Range(0, 0, left.getValueCount()));
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorEqualsVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/compare/VectorEqualsVisitor.java
@@ -29,7 +29,7 @@ import org.apache.arrow.vector.ValueVector;
 public class VectorEqualsVisitor {
 
   /**
-   * Checks if two vectors are equals with default type visitor.
+   * Checks if two vectors are equals with default type comparator.
    * @param left the left vector to compare.
    * @param right the right vector to compare.
    * @return true if the vectors are equal, and false otherwise.

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/DictionaryHashTable.java
@@ -148,7 +148,7 @@ public class DictionaryHashTable {
     int hash = toEncode.hashCode(indexInArray, this.hasher);
     int index = indexFor(hash, table.length);
 
-    RangeEqualsVisitor equalVisitor = new RangeEqualsVisitor(dictionary, toEncode, false);
+    RangeEqualsVisitor equalVisitor = new RangeEqualsVisitor(dictionary, toEncode, null);
     Range range = new Range(0, 0, 1);
 
     for (DictionaryHashTable.Entry e = table[index]; e != null ; e = e.next) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -288,8 +288,8 @@ public class TestRangeEqualsVisitor {
     try (final IntVector intVector = new IntVector("int", allocator);
          final ZeroVector zeroVector = new ZeroVector()) {
 
-      assertTrue(VectorEqualsVisitor.vectorEquals(intVector, zeroVector, false));
-      assertTrue(VectorEqualsVisitor.vectorEquals(zeroVector, intVector, false));
+      assertTrue(VectorEqualsVisitor.vectorEquals(intVector, zeroVector, null));
+      assertTrue(VectorEqualsVisitor.vectorEquals(zeroVector, intVector, null));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.nio.charset.Charset;
+import java.util.Arrays;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
@@ -45,6 +46,7 @@ import org.apache.arrow.vector.holders.NullableUInt4Holder;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.junit.After;
 import org.junit.Before;
@@ -84,9 +86,9 @@ public class TestRangeEqualsVisitor {
 
   @Test
   public void testEqualsWithTypeChange() {
-    try (final IntVector vector1 = new IntVector("intVector1", allocator);
-         final IntVector vector2 = new IntVector("intVector2", allocator);
-         final BigIntVector vector3 = new BigIntVector("bigIntVector", allocator)) {
+    try (final IntVector vector1 = new IntVector("vector", allocator);
+         final IntVector vector2 = new IntVector("vector", allocator);
+         final BigIntVector vector3 = new BigIntVector("vector", allocator)) {
 
       setVector(vector1, 1, 2);
       setVector(vector2, 1, 2);
@@ -122,6 +124,24 @@ public class TestRangeEqualsVisitor {
 
       RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector1, vector2);
       assertTrue(visitor.rangeEquals(new Range(1, 1, 3)));
+    }
+  }
+
+  @Test
+  public void testListVectorWithDifferentChild() {
+    try (final ListVector vector1 = ListVector.empty("list", allocator);
+         final ListVector vector2 = ListVector.empty("list", allocator);) {
+
+      vector1.allocateNew();
+      vector1.initializeChildrenFromFields(
+          Arrays.asList(Field.nullable("child", new ArrowType.Int(32, true))));
+
+      vector2.allocateNew();
+      vector2.initializeChildrenFromFields(
+          Arrays.asList(Field.nullable("child", new ArrowType.Int(64, true))));
+
+      RangeEqualsVisitor visitor = new RangeEqualsVisitor(vector1, vector2);
+      assertFalse(visitor.rangeEquals(new Range(0, 0, 0)));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -20,8 +20,11 @@ package org.apache.arrow.vector.complex.impl;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.function.BiFunction;
+
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.compare.VectorEqualsVisitor;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.MapVector;
@@ -38,6 +41,9 @@ public class TestComplexCopier {
   private BufferAllocator allocator;
 
   private static final int COUNT = 100;
+
+  private static final BiFunction<ValueVector, ValueVector, Boolean> TYPE_COMPARATOR =
+      (v1, v2) -> v1.getField().getType().equals(v2.getField().getType());
 
   @Before
   public void init() {
@@ -79,7 +85,7 @@ public class TestComplexCopier {
       }
 
       // validate equals
-      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to, TYPE_COMPARATOR));
 
     }
   }
@@ -148,7 +154,7 @@ public class TestComplexCopier {
       to.setValueCount(COUNT);
 
       // validate equals
-      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to, TYPE_COMPARATOR));
 
     }
   }


### PR DESCRIPTION
Related to [ARROW-7264](https://issues.apache.org/jira/browse/ARROW-7264).

Currently RangeEqualsVisitor generally only checks type once and keep the result to avoid repeated type checking, see
>typeCompareResult = left.getField().getType().equals(right.getField().getType());

This only compares ArrowType and for complex type, this may cause unexpected behavior, for example List<Int> and List<BigInt> would be type equals which not consider their child field.

We should compare Field here instead and to make it more extendable, we use TypeEqualsVisitor to compare Field, in this way, one could choose whether checks names or metadata either.

Also provide a test for ListVector to validate this change.