### PR TITLE
ARROW-7117: [C++][CI] Fix the hanging C++ tests in Windows 2019

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -152,12 +152,13 @@ jobs:
       ARROW_WITH_BROTLI: OFF
       ARROW_USE_GLOG: OFF
       ARROW_BUILD_TESTS: ON
-      ARROW_TEST_LINKAGE: static
+      ARROW_BUILD_SHARED: ON
+      ARROW_BUILD_STATIC: OFF
       ARROW_BOOST_USE_SHARED: OFF
-      ARROW_BUILD_SHARED: OFF
-      ARROW_USE_STATIC_CRT: ON
       ARROW_VERBOSE_THIRDPARTY_BUILD: OFF
     steps:
+      - name: Disable Crash Dialogs
+        run: reg add "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" /v DontShowUI /t REG_DWORD /d 1 /f
       - name: Checkout Arrow
         uses: actions/checkout@v1
         with:
@@ -165,7 +166,6 @@ jobs:
       - name: Build
         shell: bash
         run: ci/scripts/cpp_build.sh $(pwd) $(pwd)/cpp/build
-      # FIXME(kszucs): tests are hanging
-      # - name: Test
-      #   shell: bash
-      #   run: ci/scripts/cpp_test.sh $(pwd) $(pwd)/cpp/build
+      - name: Test
+        shell: bash
+        run: ci/scripts/cpp_test.sh $(pwd) $(pwd)/cpp/build

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -28,7 +28,5 @@ export PARQUET_TEST_DATA=${source_dir}/submodules/parquet-testing/data
 export LD_LIBRARY_PATH=${ARROW_HOME}/${CMAKE_INSTALL_LIBDIR:-lib}:${LD_LIBRARY_PATH}
 
 pushd ${build_dir}
-
 ctest --output-on-failure -j$(nproc)
-
 popd


### PR DESCRIPTION
The fix is simply to use normal shared linking.