### PR TITLE
ARROW-7056: [Python] Fix test_fs failures when S3 not enabled

### DIFF
--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -82,10 +82,8 @@ timestamp_types = st.builds(
     unit=st.sampled_from(['s', 'ms', 'us', 'ns']),
     tz=tzst.timezones()
 )
-duration_types = st.builds(
-    pa.duration,
-    unit=st.sampled_from(['s', 'ms', 'us', 'ns'])
-)
+duration_types = st.sampled_from([
+    pa.duration(unit) for unit in ['s', 'ms', 'us', 'ns']])
 temporal_types = st.one_of(
     date_types, time_types, timestamp_types, duration_types)
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -61,9 +61,9 @@ def subtree_localfs(request, tempdir, localfs):
     )
 
 
-@pytest.mark.s3
 @pytest.fixture
 def s3fs(request, minio_server):
+    request.config.pyarrow.requires('s3')
     from pyarrow.s3fs import S3Options, S3FileSystem
 
     address, access_key, secret_key = minio_server
@@ -113,10 +113,6 @@ def subtree_s3fs(request, s3fs):
         pytest.lazy_fixture('s3fs'),
         id='S3FileSystem'
     ),
-    pytest.param(
-        pytest.lazy_fixture('subtree_s3fs'),
-        id='SubTreeFileSystem(S3FileSystem())'
-    )
 ])
 def filesystem_config(request):
     return request.param

--- a/python/setup.py
+++ b/python/setup.py
@@ -217,47 +217,31 @@ class build_ext(_build_ext):
                 static_lib_option,
             ]
 
+            def append_cmake_bool(value, varname):
+                cmake_options.append('-D{0}={1}'.format(
+                    varname, 'on' if value else 'off'))
+
             if self.cmake_generator:
                 cmake_options += ['-G', self.cmake_generator]
-            if self.with_s3:
-                cmake_options.append('-DPYARROW_BUILD_S3=on')
-            if self.with_cuda:
-                cmake_options.append('-DPYARROW_BUILD_CUDA=on')
-            if self.with_flight:
-                cmake_options.append('-DPYARROW_BUILD_FLIGHT=on')
-            if self.with_parquet:
-                cmake_options.append('-DPYARROW_BUILD_PARQUET=on')
-            if self.with_static_parquet:
-                cmake_options.append('-DPYARROW_PARQUET_USE_SHARED=off')
-            if not self.with_static_boost:
-                cmake_options.append('-DPYARROW_BOOST_USE_SHARED=on')
-            else:
-                cmake_options.append('-DPYARROW_BOOST_USE_SHARED=off')
 
-            if self.with_plasma:
-                cmake_options.append('-DPYARROW_BUILD_PLASMA=on')
-
-            if self.with_tensorflow:
-                cmake_options.append('-DPYARROW_USE_TENSORFLOW=on')
-
-            if self.with_orc:
-                cmake_options.append('-DPYARROW_BUILD_ORC=on')
-
-            if self.with_gandiva:
-                cmake_options.append('-DPYARROW_BUILD_GANDIVA=on')
-
-            if len(self.cmake_cxxflags) > 0:
-                cmake_options.append('-DPYARROW_CXXFLAGS={0}'
-                                     .format(self.cmake_cxxflags))
-
-            if self.generate_coverage:
-                cmake_options.append('-DPYARROW_GENERATE_COVERAGE=on')
-
-            if self.bundle_arrow_cpp:
-                cmake_options.append('-DPYARROW_BUNDLE_ARROW_CPP=ON')
-
-            if self.bundle_boost:
-                cmake_options.append('-DPYARROW_BUNDLE_BOOST=ON')
+            append_cmake_bool(self.with_cuda, 'PYARROW_BUILD_CUDA')
+            append_cmake_bool(self.with_flight, 'PYARROW_BUILD_FLIGHT')
+            append_cmake_bool(self.with_gandiva, 'PYARROW_BUILD_GANDIVA')
+            append_cmake_bool(self.with_orc, 'PYARROW_BUILD_ORC')
+            append_cmake_bool(self.with_parquet, 'PYARROW_BUILD_PARQUET')
+            append_cmake_bool(self.with_plasma, 'PYARROW_BUILD_PLASMA')
+            append_cmake_bool(self.with_s3, 'PYARROW_BUILD_S3')
+            append_cmake_bool(self.with_tensorflow, 'PYARROW_USE_TENSORFLOW')
+            append_cmake_bool(self.bundle_arrow_cpp,
+                              'PYARROW_BUNDLE_ARROW_CPP')
+            append_cmake_bool(self.bundle_boost,
+                              'PYARROW_BUNDLE_BOOST')
+            append_cmake_bool(self.generate_coverage,
+                              'PYARROW_GENERATE_COVERAGE')
+            append_cmake_bool(not self.with_static_boost,
+                              'PYARROW_BOOST_USE_SHARED')
+            append_cmake_bool(not self.with_static_parquet,
+                              'PYARROW_PARQUET_USE_SHARED')
 
             cmake_options.append('-DCMAKE_BUILD_TYPE={0}'
                                  .format(self.build_type.lower()))


### PR DESCRIPTION
Also improve passing options from environment variables to PyArrow cmake.
Simplify handling of custom pytest options.
Fix a hypothesis error.