### PR TITLE
ARROW-7210: [C++][R] Allow Numeric <-> Temporal Scalar casts

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -136,6 +136,7 @@ set(ARROW_SRCS
     util/string_builder.cc
     util/task_group.cc
     util/thread_pool.cc
+    util/time.cc
     util/trie.cc
     util/uri.cc
     util/utf8.cc

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -838,7 +838,8 @@ class ScalarEqualsVisitor {
 
   template <typename T>
   typename std::enable_if<
-      std::is_base_of<internal::PrimitiveScalar<typename T::TypeClass>, T>::value,
+      std::is_base_of<internal::PrimitiveScalar<typename T::TypeClass>, T>::value ||
+          std::is_base_of<TemporalScalar<typename T::TypeClass>, T>::value,
       Status>::type
   Visit(const T& left_) {
     const auto& right = checked_cast<const T&>(right_);

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -830,9 +830,16 @@ class ScalarEqualsVisitor {
     return Status::OK();
   }
 
+  Status Visit(const BooleanScalar& left) {
+    const auto& right = checked_cast<const BooleanScalar&>(right_);
+    result_ = left.value == right.value;
+    return Status::OK();
+  }
+
   template <typename T>
-  typename std::enable_if<std::is_base_of<internal::PrimitiveScalar, T>::value,
-                          Status>::type
+  typename std::enable_if<
+      std::is_base_of<internal::PrimitiveScalar<typename T::TypeClass>, T>::value,
+      Status>::type
   Visit(const T& left_) {
     const auto& right = checked_cast<const T&>(right_);
     result_ = right.value == left_.value;
@@ -840,19 +847,9 @@ class ScalarEqualsVisitor {
   }
 
   template <typename T>
-  typename std::enable_if<std::is_base_of<BinaryScalar, T>::value, Status>::type Visit(
-      const T& left_) {
-    const auto& left = checked_cast<const BinaryScalar&>(left_);
+  typename std::enable_if<std::is_base_of<BaseBinaryScalar, T>::value, Status>::type
+  Visit(const T& left) {
     const auto& right = checked_cast<const BinaryScalar&>(right_);
-    result_ = internal::SharedPtrEquals(left.value, right.value);
-    return Status::OK();
-  }
-
-  template <typename T>
-  typename std::enable_if<std::is_base_of<LargeBinaryScalar, T>::value, Status>::type
-  Visit(const T& left_) {
-    const auto& left = checked_cast<const LargeBinaryScalar&>(left_);
-    const auto& right = checked_cast<const LargeBinaryScalar&>(right_);
     result_ = internal::SharedPtrEquals(left.value, right.value);
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -83,7 +83,8 @@ static Datum NaiveSum(const Array& array) {
   auto result = NaiveSumPartial<ArrowType>(array);
   bool is_valid = result.second > 0;
 
-  return Datum(std::make_shared<SumScalarType>(result.first, is_valid));
+  if (!is_valid) return Datum(std::make_shared<SumScalarType>());
+  return Datum(std::make_shared<SumScalarType>(result.first));
 }
 
 template <typename ArrowType>
@@ -115,11 +116,9 @@ TYPED_TEST(TestNumericSumKernel, SimpleSum) {
   using ScalarType = typename TypeTraits<SumType>::ScalarType;
   using T = typename TypeParam::c_type;
 
-  ValidateSum<TypeParam>(&this->ctx_, "[]",
-                         Datum(std::make_shared<ScalarType>(0, false)));
+  ValidateSum<TypeParam>(&this->ctx_, "[]", Datum(std::make_shared<ScalarType>()));
 
-  ValidateSum<TypeParam>(&this->ctx_, "[null]",
-                         Datum(std::make_shared<ScalarType>(0, false)));
+  ValidateSum<TypeParam>(&this->ctx_, "[null]", Datum(std::make_shared<ScalarType>()));
 
   ValidateSum<TypeParam>(&this->ctx_, "[0, 1, 2, 3, 4, 5]",
                          Datum(std::make_shared<ScalarType>(static_cast<T>(5 * 6 / 2))));
@@ -180,7 +179,8 @@ static Datum NaiveMean(const Array& array) {
                       static_cast<double>(result.second ? result.second : 1UL);
   const bool is_valid = result.second > 0;
 
-  return Datum(std::make_shared<MeanScalarType>(mean, is_valid));
+  if (!is_valid) return Datum(std::make_shared<MeanScalarType>());
+  return Datum(std::make_shared<MeanScalarType>(mean));
 }
 
 template <typename ArrowType>
@@ -210,11 +210,9 @@ TYPED_TEST_CASE(TestMeanKernelNumeric, NumericArrowTypes);
 TYPED_TEST(TestMeanKernelNumeric, SimpleMean) {
   using ScalarType = typename TypeTraits<DoubleType>::ScalarType;
 
-  ValidateMean<TypeParam>(&this->ctx_, "[]",
-                          Datum(std::make_shared<ScalarType>(0.0, false)));
+  ValidateMean<TypeParam>(&this->ctx_, "[]", Datum(std::make_shared<ScalarType>()));
 
-  ValidateMean<TypeParam>(&this->ctx_, "[null]",
-                          Datum(std::make_shared<ScalarType>(0.0, false)));
+  ValidateMean<TypeParam>(&this->ctx_, "[null]", Datum(std::make_shared<ScalarType>()));
 
   ValidateMean<TypeParam>(&this->ctx_, "[1, null, 1]",
                           Datum(std::make_shared<ScalarType>(1.0)));

--- a/cpp/src/arrow/compute/kernels/compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/compare_test.cc
@@ -324,9 +324,8 @@ TYPED_TEST(TestNumericCompareKernel, SimpleCompareScalarArray) {
 TYPED_TEST(TestNumericCompareKernel, TestNullScalar) {
   /* Ensure that null scalar broadcast to all null results. */
   using ScalarType = typename TypeTraits<TypeParam>::ScalarType;
-  using CType = typename TypeTraits<TypeParam>::CType;
 
-  Datum null(std::make_shared<ScalarType>(CType(0), false));
+  Datum null(std::make_shared<ScalarType>());
   EXPECT_FALSE(null.scalar()->is_valid);
 
   CompareOptions eq(CompareOperator::EQUAL);

--- a/cpp/src/arrow/compute/kernels/mean.cc
+++ b/cpp/src/arrow/compute/kernels/mean.cc
@@ -47,7 +47,8 @@ struct MeanState {
     const double divisor = static_cast<double>(is_valid ? count : 1UL);
     const double mean = static_cast<double>(sum) / divisor;
 
-    return std::make_shared<ScalarType>(mean, is_valid);
+    if (!is_valid) return std::make_shared<ScalarType>();
+    return std::make_shared<ScalarType>(mean);
   }
 
   static std::shared_ptr<DataType> out_type() {

--- a/cpp/src/arrow/compute/kernels/sum.cc
+++ b/cpp/src/arrow/compute/kernels/sum.cc
@@ -42,13 +42,11 @@ struct SumState {
   std::shared_ptr<Scalar> Finalize() const {
     using ScalarType = typename TypeTraits<SumType>::ScalarType;
 
-    auto boxed = std::make_shared<ScalarType>(this->sum);
     if (count == 0) {
-      // TODO(wesm): Currently null, but fix this
-      boxed->is_valid = false;
+      return std::make_shared<ScalarType>();
     }
 
-    return std::move(boxed);
+    return MakeScalar(sum);
   }
 
   static std::shared_ptr<DataType> out_type() {

--- a/cpp/src/arrow/compute/test_util.h
+++ b/cpp/src/arrow/compute/test_util.h
@@ -97,9 +97,7 @@ struct DatumEqual<Type, enable_if_integer<Type>> {
     if (lhs.kind() == Datum::SCALAR) {
       auto left = internal::checked_cast<const ScalarType*>(lhs.scalar().get());
       auto right = internal::checked_cast<const ScalarType*>(rhs.scalar().get());
-      ASSERT_EQ(left->is_valid, right->is_valid);
-      ASSERT_EQ(left->type->id(), right->type->id());
-      ASSERT_EQ(left->value, right->value);
+      ASSERT_EQ(*left, *right);
     }
   }
 };

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -298,13 +298,7 @@ static ExpressionPtr ColumnChunkStatisticsAsExpression(
 
   // Optimize for corner case where all values are nulls
   if (statistics->num_values() == statistics->null_count()) {
-    auto null_scalar = MakeNullScalar(field->type());
-    if (null_scalar.ok()) {
-      // MakeNullScalar can fail for some nested/repeated types.
-      return scalar(true);
-    }
-
-    return equal(field_expr, scalar(*null_scalar));
+    return equal(field_expr, scalar(MakeNullScalar(field->type())));
   }
 
   std::shared_ptr<Scalar> min, max;

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -704,7 +704,7 @@ bool ComparisonExpression::Equals(const Expression& other) const {
 
 bool ScalarExpression::Equals(const Expression& other) const {
   return other.type() == ExpressionType::SCALAR &&
-         value_->Equals(checked_cast<const ScalarExpression&>(other).value_);
+         value_->Equals(*checked_cast<const ScalarExpression&>(other).value_);
 }
 
 bool FieldExpression::Equals(const Expression& other) const {
@@ -880,9 +880,7 @@ Result<std::shared_ptr<DataType>> CastExpression::Validate(const Schema& schema)
   // if the operand is a scalar leaf.
   if (operand_->type() == ExpressionType::SCALAR) {
     auto scalar_expr = checked_pointer_cast<ScalarExpression>(operand_);
-    auto result = scalar_expr->value()->CastTo(to_type);
-    // Test if the cast is implemented.
-    RETURN_NOT_OK(result.status());
+    ARROW_ASSIGN_OR_RAISE(std::ignore, scalar_expr->value()->CastTo(to_type));
     return to_type;
   }
 
@@ -1214,7 +1212,7 @@ Result<std::shared_ptr<RecordBatch>> TreeEvaluator::Filter(
                                   selection.kind(), " of type ", *selection.type());
   }
 
-  if (BooleanScalar(true).Equals(selection.scalar())) {
+  if (BooleanScalar(true).Equals(*selection.scalar())) {
     return batch;
   }
 

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -491,7 +491,7 @@ bool Expression::Equals(T&& t) const {
     return false;
   }
   auto s = MakeScalar(std::forward<T>(t));
-  return internal::checked_cast<const ScalarExpression&>(*this).value()->Equals(s);
+  return internal::checked_cast<const ScalarExpression&>(*this).value()->Equals(*s);
 }
 
 template <typename Visitor>

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -335,13 +335,16 @@ TEST_F(ExpressionsTest, ImplicitCast) {
   ASSERT_OK_AND_ASSIGN(auto filter, InsertImplicitCasts("a"_ == 0.0, *schema_));
   ASSERT_EQ(E{filter}, E{"a"_ == 0});
 
-  ASSERT_OK_AND_ASSIGN(filter, InsertImplicitCasts("ts"_ == "1990-01-03", *schema_));
-  ASSERT_EQ(E{filter}, E{"ts"_ == *MakeScalar("1990-01-03")->CastTo(ns)});
+  auto ns = timestamp(TimeUnit::NANO);
+  ASSERT_OK_AND_ASSIGN(filter,
+                       InsertImplicitCasts("ts"_ == "1990-10-23 10:23:33", *schema_));
+  ASSERT_EQ(E{filter}, E{"ts"_ == scalar("1990-10-23 10:23:33")->CastTo(ns)});
 
   ASSERT_OK_AND_ASSIGN(
-      filter, InsertImplicitCasts("ts"_ == "1990-01-03" and "b"_ == "3", *schema_));
-  ASSERT_EQ(E{filter}, E{"ts"_ == *MakeScalar("1990-01-03")->CastTo(ns) and "b"_ == 3});
-
+      filter,
+      InsertImplicitCasts("ts"_ == "1990-10-23 10:23:33" and "b"_ == "3", *schema_));
+  ASSERT_EQ(E{filter},
+            E{"a"_ == scalar("1990-10-23 10:23:33")->CastTo(ns) and "b"_ == 3});
   AssertSimplifiesTo(*filter, "b"_ == 2, *never);
   AssertSimplifiesTo(*filter, "b"_ == 3, "ts"_ == *MakeScalar("1990-01-03")->CastTo(ns));
 }

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -336,17 +336,15 @@ TEST_F(ExpressionsTest, ImplicitCast) {
   ASSERT_EQ(E{filter}, E{"a"_ == 0});
 
   auto ns = timestamp(TimeUnit::NANO);
-  ASSERT_OK_AND_ASSIGN(filter,
-                       InsertImplicitCasts("ts"_ == "1990-10-23 10:23:33", *schema_));
-  ASSERT_EQ(E{filter}, E{"ts"_ == scalar("1990-10-23 10:23:33")->CastTo(ns)});
+  auto date = "1990-10-23 10:23:33";
+  ASSERT_OK_AND_ASSIGN(filter, InsertImplicitCasts("ts"_ == date, *schema_));
+  ASSERT_EQ(E{filter}, E{"ts"_ == *MakeScalar(date)->CastTo(ns)});
 
-  ASSERT_OK_AND_ASSIGN(
-      filter,
-      InsertImplicitCasts("ts"_ == "1990-10-23 10:23:33" and "b"_ == "3", *schema_));
-  ASSERT_EQ(E{filter},
-            E{"a"_ == scalar("1990-10-23 10:23:33")->CastTo(ns) and "b"_ == 3});
+  ASSERT_OK_AND_ASSIGN(filter,
+                       InsertImplicitCasts("ts"_ == date and "b"_ == "3", *schema_));
+  ASSERT_EQ(E{filter}, E{"ts"_ == *MakeScalar(date)->CastTo(ns) and "b"_ == 3});
   AssertSimplifiesTo(*filter, "b"_ == 2, *never);
-  AssertSimplifiesTo(*filter, "b"_ == 3, "ts"_ == *MakeScalar("1990-01-03")->CastTo(ns));
+  AssertSimplifiesTo(*filter, "b"_ == 3, "ts"_ == *MakeScalar(date)->CastTo(ns));
 }
 
 TEST_F(FilterTest, ImplicitCast) {

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -39,113 +39,65 @@ using internal::checked_pointer_cast;
 
 bool Scalar::Equals(const Scalar& other) const { return ScalarEquals(*this, other); }
 
-Time32Scalar::Time32Scalar(int32_t value, const std::shared_ptr<DataType>& type,
-                           bool is_valid)
-    : internal::PrimitiveScalar{type, is_valid}, value(value) {
-  ARROW_CHECK_EQ(Type::TIME32, type->id());
-}
-
-Time64Scalar::Time64Scalar(int64_t value, const std::shared_ptr<DataType>& type,
-                           bool is_valid)
-    : internal::PrimitiveScalar{type, is_valid}, value(value) {
-  ARROW_CHECK_EQ(Type::TIME64, type->id());
-}
-
-TimestampScalar::TimestampScalar(int64_t value, const std::shared_ptr<DataType>& type,
-                                 bool is_valid)
-    : internal::PrimitiveScalar{type, is_valid}, value(value) {
-  ARROW_CHECK_EQ(Type::TIMESTAMP, type->id());
-}
-
-DurationScalar::DurationScalar(int64_t value, const std::shared_ptr<DataType>& type,
-                               bool is_valid)
-    : internal::PrimitiveScalar{type, is_valid}, value(value) {
-  DCHECK_EQ(Type::DURATION, type->id());
-}
-
-MonthIntervalScalar::MonthIntervalScalar(int32_t value, bool is_valid)
-    : internal::PrimitiveScalar{month_interval(), is_valid}, value(value) {}
-
-MonthIntervalScalar::MonthIntervalScalar(int32_t value,
-                                         const std::shared_ptr<DataType>& type,
-                                         bool is_valid)
-    : internal::PrimitiveScalar{type, is_valid}, value(value) {
-  DCHECK_EQ(Type::INTERVAL, type->id());
-  DCHECK_EQ(IntervalType::MONTHS,
-            checked_cast<IntervalType*>(type.get())->interval_type());
-}
-
-DayTimeIntervalScalar::DayTimeIntervalScalar(DayTimeIntervalType::DayMilliseconds value,
-                                             bool is_valid)
-    : internal::PrimitiveScalar{day_time_interval(), is_valid}, value(value) {}
-
-DayTimeIntervalScalar::DayTimeIntervalScalar(DayTimeIntervalType::DayMilliseconds value,
-                                             const std::shared_ptr<DataType>& type,
-                                             bool is_valid)
-    : internal::PrimitiveScalar{type, is_valid}, value(value) {
-  DCHECK_EQ(Type::INTERVAL, type->id());
-  DCHECK_EQ(IntervalType::DAY_TIME,
-            checked_cast<IntervalType*>(type.get())->interval_type());
-}
-
 StringScalar::StringScalar(std::string s)
-    : StringScalar(Buffer::FromString(std::move(s)), true) {}
+    : StringScalar(Buffer::FromString(std::move(s))) {}
 
 FixedSizeBinaryScalar::FixedSizeBinaryScalar(const std::shared_ptr<Buffer>& value,
-                                             const std::shared_ptr<DataType>& type,
-                                             bool is_valid)
-    : BinaryScalar(value, type, is_valid) {
+                                             const std::shared_ptr<DataType>& type)
+    : BinaryScalar(value, type) {
   ARROW_CHECK_EQ(checked_cast<const FixedSizeBinaryType&>(*type).byte_width(),
                  value->size());
 }
 
-Decimal128Scalar::Decimal128Scalar(const Decimal128& value,
-                                   const std::shared_ptr<DataType>& type, bool is_valid)
-    : Scalar{type, is_valid}, value(value) {}
-
 BaseListScalar::BaseListScalar(const std::shared_ptr<Array>& value,
-                               const std::shared_ptr<DataType>& type, bool is_valid)
-    : Scalar{type, is_valid}, value(value) {}
+                               const std::shared_ptr<DataType>& type)
+    : Scalar{type, true}, value(value) {}
 
-BaseListScalar::BaseListScalar(const std::shared_ptr<Array>& value, bool is_valid)
-    : BaseListScalar(value, value->type(), is_valid) {}
+BaseListScalar::BaseListScalar(const std::shared_ptr<Array>& value)
+    : BaseListScalar(value, value->type()) {}
 
 FixedSizeListScalar::FixedSizeListScalar(const std::shared_ptr<Array>& value,
-                                         const std::shared_ptr<DataType>& type,
-                                         bool is_valid)
-    : BaseListScalar(value, type, is_valid) {
+                                         const std::shared_ptr<DataType>& type)
+    : BaseListScalar(value, type) {
   ARROW_CHECK_EQ(value->length(),
                  checked_cast<const FixedSizeListType*>(type.get())->list_size());
 }
 
+template <typename T>
+using scalar_constructor_has_arrow_type =
+    std::is_constructible<typename TypeTraits<T>::ScalarType, std::shared_ptr<DataType>>;
+
+template <typename T, typename R = void>
+using enable_if_scalar_constructor_has_arrow_type =
+    typename std::enable_if<scalar_constructor_has_arrow_type<T>::value, R>::type;
+
+template <typename T, typename R = void>
+using enable_if_scalar_constructor_has_no_arrow_type =
+    typename std::enable_if<!scalar_constructor_has_arrow_type<T>::value, R>::type;
+
 // TODO(bkietz) This doesn't need a factory. Just rewrite all scalars to be generically
 // constructible (is_simple_scalar should apply to all scalars)
 struct MakeNullImpl {
-  template <typename T, typename ScalarType = typename TypeTraits<T>::ScalarType,
-            typename ValueType = typename ScalarType::ValueType,
-            typename Enable = typename std::enable_if<
-                internal::is_simple_scalar<ScalarType>::value>::type>
-  Status Visit(const T&) {
-    out_ = std::make_shared<ScalarType>(ValueType(), type_, false);
+  template <typename T, typename ScalarType = typename TypeTraits<T>::ScalarType>
+  enable_if_scalar_constructor_has_arrow_type<T, Status> Visit(const T&) {
+    out_ = std::make_shared<ScalarType>(type_);
     return Status::OK();
   }
 
-  Status Visit(const NullType&) {
-    out_ = std::make_shared<NullScalar>();
+  template <typename T, typename ScalarType = typename TypeTraits<T>::ScalarType>
+  enable_if_scalar_constructor_has_no_arrow_type<T, Status> Visit(const T&) {
+    out_ = std::make_shared<ScalarType>();
     return Status::OK();
-  }
-
-  Status Visit(const DataType& t) {
-    return Status::NotImplemented("construcing null scalars of type ", t);
   }
 
   const std::shared_ptr<DataType>& type_;
   std::shared_ptr<Scalar> out_;
 };
 
-Result<std::shared_ptr<Scalar>> MakeNullScalar(const std::shared_ptr<DataType>& type) {
-  MakeNullImpl impl = {type, nullptr};
-  RETURN_NOT_OK(VisitTypeInline(*type, &impl));
+std::shared_ptr<Scalar> MakeNullScalar(const std::shared_ptr<DataType>& type) {
+  MakeNullImpl impl = {type};
+  // Should not fail.
+  DCHECK_OK(VisitTypeInline(*type, &impl));
   return std::move(impl.out_);
 }
 
@@ -243,6 +195,26 @@ Status CastImpl(const BooleanScalar& from, NumericScalar<T>* to) {
   return Status::OK();
 }
 
+// numeric to temporal
+template <typename From, typename To>
+Status CastImpl(const NumericScalar<From>& from, TemporalScalar<To>* to) {
+  to->value = static_cast<typename To::c_type>(from.value);
+  return Status::OK();
+}
+
+// temporal to numeric
+template <typename From, typename To>
+Status CastImpl(const TemporalScalar<From>& from, NumericScalar<To>* to) {
+  to->value = static_cast<typename To::c_type>(from.value);
+  return Status::OK();
+}
+
+// timestamp to timestamp
+Status CastImpl(const TimestampScalar& from, TimestampScalar* to) {
+  to->value = from.value;
+  return Status::OK();
+}
+
 // string to any
 template <typename ScalarType>
 Status CastImpl(const StringScalar& from, ScalarType* to) {
@@ -285,8 +257,10 @@ struct FromTypeVisitor {
                     out_);
   }
 
-  // identity cast
-  Status Visit(const ToType&) {
+  // identity cast only for parameter free types
+  template <typename T1 = ToType>
+  typename std::enable_if<TypeTraits<T1>::is_parameter_free, Status>::type Visit(
+      const ToType&) {
     out_->value = checked_cast<const ToScalar&>(from_).value;
     return Status::OK();
   }
@@ -343,7 +317,7 @@ struct ToTypeVisitor {
 }  // namespace
 
 Result<std::shared_ptr<Scalar>> Scalar::CastTo(std::shared_ptr<DataType> to) const {
-  ARROW_ASSIGN_OR_RAISE(auto out, MakeNullScalar(to));
+  std::shared_ptr<Scalar> out = MakeNullScalar(to);
   if (is_valid) {
     out->is_valid = true;
     ToTypeVisitor unpack_to_type{*this, to, out.get()};

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -30,6 +30,7 @@
 #include "arrow/util/formatting.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/parsing.h"
+#include "arrow/util/time.h"
 #include "arrow/visitor_inline.h"
 
 namespace arrow {
@@ -75,8 +76,6 @@ template <typename T, typename R = void>
 using enable_if_scalar_constructor_has_no_arrow_type =
     typename std::enable_if<!scalar_constructor_has_arrow_type<T>::value, R>::type;
 
-// TODO(bkietz) This doesn't need a factory. Just rewrite all scalars to be generically
-// constructible (is_simple_scalar should apply to all scalars)
 struct MakeNullImpl {
   template <typename T, typename ScalarType = typename TypeTraits<T>::ScalarType>
   enable_if_scalar_constructor_has_arrow_type<T, Status> Visit(const T&) {
@@ -217,8 +216,7 @@ CastImpl(const TemporalScalar<From>& from, NumericScalar<To>* to) {
 
 // timestamp to timestamp
 Status CastImpl(const TimestampScalar& from, TimestampScalar* to) {
-  to->value = from.value;
-  return Status::OK();
+  return util::ConvertTimestampValue(from.type, to->type, from.value).Value(&to->value);
 }
 
 // string to any

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -94,7 +94,7 @@ struct MakeNullImpl {
 };
 
 std::shared_ptr<Scalar> MakeNullScalar(const std::shared_ptr<DataType>& type) {
-  MakeNullImpl impl = {type};
+  MakeNullImpl impl = {type, nullptr};
   // Should not fail.
   DCHECK_OK(VisitTypeInline(*type, &impl));
   return std::move(impl.out_);
@@ -217,6 +217,11 @@ CastImpl(const TemporalScalar<From>& from, NumericScalar<To>* to) {
 // timestamp to timestamp
 Status CastImpl(const TimestampScalar& from, TimestampScalar* to) {
   return util::ConvertTimestampValue(from.type, to->type, from.value).Value(&to->value);
+}
+
+Status CastImpl(const TimestampScalar& from, StringScalar* to) {
+  to->value = Buffer::FromString(std::to_string(from.value));
+  return Status::OK();
 }
 
 // string to any

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -197,14 +197,20 @@ Status CastImpl(const BooleanScalar& from, NumericScalar<T>* to) {
 
 // numeric to temporal
 template <typename From, typename To>
-Status CastImpl(const NumericScalar<From>& from, TemporalScalar<To>* to) {
+typename std::enable_if<std::is_base_of<TemporalType, To>::value &&
+                            !std::is_same<DayTimeIntervalType, To>::value,
+                        Status>::type
+CastImpl(const NumericScalar<From>& from, TemporalScalar<To>* to) {
   to->value = static_cast<typename To::c_type>(from.value);
   return Status::OK();
 }
 
 // temporal to numeric
 template <typename From, typename To>
-Status CastImpl(const TemporalScalar<From>& from, NumericScalar<To>* to) {
+typename std::enable_if<std::is_base_of<TemporalType, From>::value &&
+                            !std::is_same<DayTimeIntervalType, From>::value,
+                        Status>::type
+CastImpl(const TemporalScalar<From>& from, NumericScalar<To>* to) {
   to->value = static_cast<typename To::c_type>(from.value);
   return Status::OK();
 }

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -33,6 +33,7 @@
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/compare.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/string_view.h"
@@ -44,7 +45,7 @@ class Array;
 
 /// \brief Base class for scalar values, representing a single value occupying
 /// an array "slot"
-struct ARROW_EXPORT Scalar {
+struct ARROW_EXPORT Scalar : public util::EqualityComparable<Scalar> {
   virtual ~Scalar() = default;
 
   explicit Scalar(const std::shared_ptr<DataType>& type) : type(type), is_valid(false) {}
@@ -56,10 +57,6 @@ struct ARROW_EXPORT Scalar {
   bool is_valid = false;
 
   bool Equals(const Scalar& other) const;
-  bool Equals(const std::shared_ptr<Scalar>& other) const {
-    if (other) return Equals(*other);
-    return false;
-  }
 
   std::string ToString() const;
 
@@ -101,7 +98,7 @@ struct ARROW_EXPORT PrimitiveScalar : public Scalar {
 
   PrimitiveScalar() : Scalar(TypeTraits<T>::type_singleton()) {}
 
-  ValueType value;
+  ValueType value{};
 };
 
 }  // namespace internal

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -47,11 +47,13 @@ class Array;
 struct ARROW_EXPORT Scalar {
   virtual ~Scalar() = default;
 
+  explicit Scalar(const std::shared_ptr<DataType>& type) : Scalar(type, false) {}
+
   /// \brief The type of the scalar value
   std::shared_ptr<DataType> type;
 
   /// \brief Whether the value is valid (not null) or not
-  bool is_valid;
+  bool is_valid = false;
 
   bool Equals(const Scalar& other) const;
   bool Equals(const std::shared_ptr<Scalar>& other) const {
@@ -82,232 +84,157 @@ struct ARROW_EXPORT NullScalar : public Scalar {
 
 namespace internal {
 
-template <typename T, typename Enable = void>
-struct is_simple_scalar : std::false_type {};
-
-template <typename T>
-struct is_simple_scalar<
-    T,
-    typename std::enable_if<
-        // scalar has a single extra data member named "value" with type "ValueType"
-        std::is_same<decltype(std::declval<T>().value), typename T::ValueType>::value &&
-        // scalar is constructible from (value, type, is_valid)
-        std::is_constructible<T, typename T::ValueType, std::shared_ptr<DataType>,
-                              bool>::value>::type> : std::true_type {};
-
-template <typename T, typename R = void>
-using enable_if_simple_scalar = std::enable_if<is_simple_scalar<T>::value, R>;
-
+template <typename T, typename CType = typename T::c_type>
 struct ARROW_EXPORT PrimitiveScalar : public Scalar {
   using Scalar::Scalar;
+  using TypeClass = T;
+  using ValueType = CType;
+
+  // Non-null constructor.
+  PrimitiveScalar(ValueType value, const std::shared_ptr<DataType>& type)
+      : Scalar(type, true), value(value) {
+    ARROW_CHECK_EQ(type->id(), T::type_id);
+  }
+
+  // Non-null constructor without type's pointer if the type is parameter-free.
+  template <typename T1 = T>
+  explicit PrimitiveScalar(
+      ValueType value,
+      typename std::enable_if<TypeTraits<T1>::is_parameter_free>::type* = NULLPTR)
+      : PrimitiveScalar(value, TypeTraits<T>::type_singleton()) {}
+
+  // Null constructor without type's pointer if the type is parameter-free.
+  template <typename T1 = T>
+  PrimitiveScalar(
+      typename std::enable_if<TypeTraits<T1>::is_parameter_free>::type* = NULLPTR)
+      : Scalar(TypeTraits<T>::type_singleton()) {}
+
+  ValueType value;
 };
 
 }  // namespace internal
 
-struct ARROW_EXPORT BooleanScalar : public internal::PrimitiveScalar {
-  using TypeClass = BooleanType;
-  using ValueType = bool;
-
-  bool value;
-
-  explicit BooleanScalar(bool value, bool is_valid = true)
-      : internal::PrimitiveScalar{boolean(), is_valid}, value(value) {}
-
-  BooleanScalar() : BooleanScalar(false, false) {}
-
-  BooleanScalar(bool value, const std::shared_ptr<DataType>& type, bool is_valid = true)
-      : BooleanScalar(value, is_valid) {
-    ARROW_CHECK_EQ(type->id(), Type::BOOL);
-  }
+struct ARROW_EXPORT BooleanScalar : public internal::PrimitiveScalar<BooleanType, bool> {
+  using internal::PrimitiveScalar<BooleanType, bool>::PrimitiveScalar;
 };
 
 template <typename T>
-struct NumericScalar : public internal::PrimitiveScalar {
-  using TypeClass = T;
-  using ValueType = typename T::c_type;
-
-  ValueType value;
-
-  explicit NumericScalar(ValueType value, bool is_valid = true)
-      : internal::PrimitiveScalar(TypeTraits<T>::type_singleton(), is_valid),
-        value(value) {}
-
-  NumericScalar() : NumericScalar(0, false) {}
-
-  NumericScalar(ValueType value, const std::shared_ptr<DataType>& type,
-                bool is_valid = true)
-      : NumericScalar(value, is_valid) {
-    ARROW_CHECK_EQ(type->id(), T::type_id);
-  }
+struct ARROW_EXPORT NumericScalar : public internal::PrimitiveScalar<T> {
+  using internal::PrimitiveScalar<T>::PrimitiveScalar;
 };
 
-template <typename T>
-struct BaseBinaryScalar : public Scalar {
-  using TypeClass = T;
+struct ARROW_EXPORT BaseBinaryScalar : public Scalar {
+  using Scalar::Scalar;
   using ValueType = std::shared_ptr<Buffer>;
 
   std::shared_ptr<Buffer> value;
 
  protected:
   BaseBinaryScalar(const std::shared_ptr<Buffer>& value,
-                   const std::shared_ptr<DataType>& type, bool is_valid = true)
-      : Scalar{type, is_valid}, value(value) {}
+                   const std::shared_ptr<DataType>& type)
+      : Scalar{type, true}, value(value) {}
 };
 
-struct ARROW_EXPORT BinaryScalar : public BaseBinaryScalar<BinaryType> {
+struct ARROW_EXPORT BinaryScalar : public BaseBinaryScalar {
+  using BaseBinaryScalar::BaseBinaryScalar;
+  using TypeClass = BinaryScalar;
+
   BinaryScalar(const std::shared_ptr<Buffer>& value,
-               const std::shared_ptr<DataType>& type, bool is_valid = true)
-      : BaseBinaryScalar(value, type, is_valid) {}
+               const std::shared_ptr<DataType>& type)
+      : BaseBinaryScalar(value, type) {}
 
-  explicit BinaryScalar(const std::shared_ptr<Buffer>& value, bool is_valid = true)
-      : BinaryScalar(value, binary(), is_valid) {}
+  explicit BinaryScalar(const std::shared_ptr<Buffer>& value)
+      : BinaryScalar(value, binary()) {}
 
-  BinaryScalar() : BinaryScalar(NULLPTR, false) {}
+  BinaryScalar() : BinaryScalar(binary()) {}
 };
 
 struct ARROW_EXPORT StringScalar : public BinaryScalar {
+  using BinaryScalar::BinaryScalar;
   using TypeClass = StringType;
 
-  StringScalar(const std::shared_ptr<Buffer>& value,
-               const std::shared_ptr<DataType>& type, bool is_valid = true)
-      : BinaryScalar(value, type, is_valid) {}
-
-  explicit StringScalar(const std::shared_ptr<Buffer>& value, bool is_valid = true)
-      : StringScalar(value, utf8(), is_valid) {}
+  explicit StringScalar(const std::shared_ptr<Buffer>& value)
+      : StringScalar(value, utf8()) {}
 
   explicit StringScalar(std::string s);
 
-  StringScalar() : StringScalar(NULLPTR, false) {}
+  StringScalar() : StringScalar(utf8()) {}
 };
 
-struct ARROW_EXPORT LargeBinaryScalar : public BaseBinaryScalar<LargeBinaryType> {
+struct ARROW_EXPORT LargeBinaryScalar : public BaseBinaryScalar {
+  using BaseBinaryScalar::BaseBinaryScalar;
+  using TypeClass = LargeBinaryScalar;
+
   LargeBinaryScalar(const std::shared_ptr<Buffer>& value,
-                    const std::shared_ptr<DataType>& type, bool is_valid = true)
-      : BaseBinaryScalar(value, type, is_valid) {}
+                    const std::shared_ptr<DataType>& type)
+      : BaseBinaryScalar(value, type) {}
 
-  explicit LargeBinaryScalar(const std::shared_ptr<Buffer>& value, bool is_valid = true)
-      : LargeBinaryScalar(value, large_binary(), is_valid) {}
+  explicit LargeBinaryScalar(const std::shared_ptr<Buffer>& value)
+      : LargeBinaryScalar(value, large_binary()) {}
 
-  LargeBinaryScalar() : LargeBinaryScalar(NULLPTR, false) {}
+  LargeBinaryScalar() : LargeBinaryScalar(large_binary()) {}
 };
 
 struct ARROW_EXPORT LargeStringScalar : public LargeBinaryScalar {
-  using TypeClass = LargeStringType;
+  using LargeBinaryScalar::LargeBinaryScalar;
+  using TypeClass = LargeStringScalar;
 
-  LargeStringScalar(const std::shared_ptr<Buffer>& value,
-                    const std::shared_ptr<DataType>& type, bool is_valid = true)
-      : LargeBinaryScalar(value, type, is_valid) {}
+  explicit LargeStringScalar(const std::shared_ptr<Buffer>& value)
+      : LargeStringScalar(value, large_utf8()) {}
 
-  explicit LargeStringScalar(const std::shared_ptr<Buffer>& value, bool is_valid = true)
-      : LargeStringScalar(value, large_utf8(), is_valid) {}
-
-  LargeStringScalar() : LargeStringScalar(NULLPTR, false) {}
+  LargeStringScalar() : LargeStringScalar(large_utf8()) {}
 };
 
 struct ARROW_EXPORT FixedSizeBinaryScalar : public BinaryScalar {
   using TypeClass = FixedSizeBinaryType;
 
   FixedSizeBinaryScalar(const std::shared_ptr<Buffer>& value,
-                        const std::shared_ptr<DataType>& type, bool is_valid = true);
+                        const std::shared_ptr<DataType>& type);
+
+  explicit FixedSizeBinaryScalar(const std::shared_ptr<DataType>& type)
+      : BinaryScalar(type) {}
 };
 
-class ARROW_EXPORT Date32Scalar : public NumericScalar<Date32Type> {
- public:
-  using NumericScalar<Date32Type>::NumericScalar;
+template <typename T>
+struct ARROW_EXPORT TemporalScalar : public internal::PrimitiveScalar<T> {
+  using TypeClass = T;
+  using internal::PrimitiveScalar<T>::PrimitiveScalar;
 };
 
-class ARROW_EXPORT Date64Scalar : public NumericScalar<Date64Type> {
- public:
-  using NumericScalar<Date64Type>::NumericScalar;
+template <typename T>
+struct ARROW_EXPORT DateScalar : public TemporalScalar<T> {
+  using TemporalScalar<T>::TemporalScalar;
 };
 
-class ARROW_EXPORT Time32Scalar : public internal::PrimitiveScalar {
- public:
-  using TypeClass = Time32Type;
-  using ValueType = int32_t;
-
-  Time32Scalar(int32_t value, const std::shared_ptr<DataType>& type,
-               bool is_valid = true);
-
-  int32_t value;
+template <typename T>
+struct ARROW_EXPORT TimeScalar : public TemporalScalar<T> {
+  using TemporalScalar<T>::TemporalScalar;
 };
 
-class ARROW_EXPORT Time64Scalar : public internal::PrimitiveScalar {
- public:
-  using TypeClass = Time64Type;
-  using ValueType = int64_t;
-
-  Time64Scalar(int64_t value, const std::shared_ptr<DataType>& type,
-               bool is_valid = true);
-
-  int64_t value;
-};
-
-class ARROW_EXPORT TimestampScalar : public internal::PrimitiveScalar {
- public:
-  using TypeClass = TimestampType;
-  using ValueType = int64_t;
-
-  TimestampScalar(int64_t value, const std::shared_ptr<DataType>& type,
-                  bool is_valid = true);
-
-  int64_t value;
-};
-
-class ARROW_EXPORT DurationScalar : public internal::PrimitiveScalar {
- public:
-  using TypeClass = DurationType;
-  using ValueType = int64_t;
-
-  DurationScalar(int64_t value, const std::shared_ptr<DataType>& type,
-                 bool is_valid = true);
-
-  int64_t value;
-};
-
-class ARROW_EXPORT MonthIntervalScalar : public internal::PrimitiveScalar {
- public:
-  using TypeClass = MonthIntervalType;
-  using ValueType = int32_t;
-
-  explicit MonthIntervalScalar(int32_t value, bool is_valid = true);
-  MonthIntervalScalar(int32_t value, const std::shared_ptr<DataType>& type,
-                      bool is_valid = true);
-
-  int32_t value;
-};
-
-class ARROW_EXPORT DayTimeIntervalScalar : public internal::PrimitiveScalar {
- public:
-  using TypeClass = DayTimeIntervalType;
-  using ValueType = DayTimeIntervalType::DayMilliseconds;
-
-  explicit DayTimeIntervalScalar(DayTimeIntervalType::DayMilliseconds value,
-                                 bool is_valid = true);
-
-  DayTimeIntervalScalar(DayTimeIntervalType::DayMilliseconds value,
-                        const std::shared_ptr<DataType>& type, bool is_valid = true);
-
-  DayTimeIntervalType::DayMilliseconds value;
+template <typename T>
+struct ARROW_EXPORT IntervalScalar : public internal::PrimitiveScalar<T> {
+  using internal::PrimitiveScalar<T>::PrimitiveScalar;
 };
 
 struct ARROW_EXPORT Decimal128Scalar : public Scalar {
+  using Scalar::Scalar;
   using TypeClass = Decimal128Type;
   using ValueType = Decimal128;
 
-  Decimal128Scalar(const Decimal128& value, const std::shared_ptr<DataType>& type,
-                   bool is_valid = true);
+  Decimal128Scalar(const Decimal128& value, const std::shared_ptr<DataType>& type)
+      : Scalar(type, true), value(std::move(value)) {}
 
   Decimal128 value;
 };
 
 struct ARROW_EXPORT BaseListScalar : public Scalar {
+  using Scalar::Scalar;
   using ValueType = std::shared_ptr<Array>;
 
   BaseListScalar(const std::shared_ptr<Array>& value,
-                 const std::shared_ptr<DataType>& type, bool is_valid = true);
+                 const std::shared_ptr<DataType>& type);
 
-  BaseListScalar(const std::shared_ptr<Array>& value, bool is_valid);
+  explicit BaseListScalar(const std::shared_ptr<Array>& value);
 
   std::shared_ptr<Array> value;
 };
@@ -329,38 +256,40 @@ struct ARROW_EXPORT MapScalar : public BaseListScalar {
 
 struct ARROW_EXPORT FixedSizeListScalar : public BaseListScalar {
   using TypeClass = FixedSizeListType;
-  FixedSizeListScalar(const std::shared_ptr<Array>& value,
-                      const std::shared_ptr<DataType>& type, bool is_valid = true);
-
   using BaseListScalar::BaseListScalar;
+
+  FixedSizeListScalar(const std::shared_ptr<Array>& value,
+                      const std::shared_ptr<DataType>& type);
 };
 
 struct ARROW_EXPORT StructScalar : public Scalar {
+  using Scalar::Scalar;
   using TypeClass = StructType;
   using ValueType = std::vector<std::shared_ptr<Scalar>>;
 
   std::vector<std::shared_ptr<Scalar>> value;
 
-  StructScalar(ValueType value, std::shared_ptr<DataType> type, bool is_valid = true)
-      : Scalar(std::move(type), is_valid), value(std::move(value)) {}
+  StructScalar(ValueType value, std::shared_ptr<DataType> type)
+      : Scalar(std::move(type), true), value(std::move(value)) {}
 };
 
 class ARROW_EXPORT UnionScalar : public Scalar {
+  using Scalar::Scalar;
   using TypeClass = UnionType;
 };
 
 class ARROW_EXPORT DictionaryScalar : public Scalar {
+  using Scalar::Scalar;
   using TypeClass = DictionaryType;
 };
 
 class ARROW_EXPORT ExtensionScalar : public Scalar {
+  using Scalar::Scalar;
   using TypeClass = ExtensionType;
 };
 
-/// \param[in] type the type of scalar to produce
-/// \return output scalar with is_valid=false
 ARROW_EXPORT
-Result<std::shared_ptr<Scalar>> MakeNullScalar(const std::shared_ptr<DataType>& type);
+std::shared_ptr<Scalar> MakeNullScalar(const std::shared_ptr<DataType>& type);
 
 namespace internal {
 
@@ -368,6 +297,20 @@ inline Status CheckBufferLength(...) { return Status::OK(); }
 
 ARROW_EXPORT Status CheckBufferLength(const FixedSizeBinaryType* t,
                                       const std::shared_ptr<Buffer>* b);
+
+template <typename T, typename Enable = void>
+struct is_simple_scalar : std::false_type {};
+
+template <typename T>
+struct is_simple_scalar<
+    T,
+    typename std::enable_if<
+        // scalar has a single extra data member named "value" with type "ValueType"
+        std::is_same<decltype(std::declval<T>().value), typename T::ValueType>::value &&
+        // scalar is constructible from (value, type)
+        std::is_constructible<T, typename T::ValueType,
+                              std::shared_ptr<DataType>>::value>::type> : std::true_type {
+};
 
 };  // namespace internal
 
@@ -381,8 +324,7 @@ struct MakeScalarImpl {
           std::is_same<ValueType, typename std::decay<ValueRef>::type>::value>::type>
   Status Visit(const T& t) {
     ARROW_RETURN_NOT_OK(internal::CheckBufferLength(&t, &value_));
-    *out_ = std::make_shared<ScalarType>(ValueType(static_cast<ValueRef>(value_)), type_,
-                                         true);
+    *out_ = std::make_shared<ScalarType>(ValueType(static_cast<ValueRef>(value_)), type_);
     return Status::OK();
   }
 
@@ -408,9 +350,9 @@ Result<std::shared_ptr<Scalar>> MakeScalar(const std::shared_ptr<DataType>& type
 template <typename Value, typename Traits = CTypeTraits<typename std::decay<Value>::type>,
           typename ScalarType = typename Traits::ScalarType,
           typename Enable = decltype(ScalarType(std::declval<Value>(),
-                                                Traits::type_singleton(), true))>
+                                                Traits::type_singleton()))>
 std::shared_ptr<Scalar> MakeScalar(Value value) {
-  return std::make_shared<ScalarType>(std::move(value), Traits::type_singleton(), true);
+  return std::make_shared<ScalarType>(std::move(value), Traits::type_singleton());
 }
 
 inline std::shared_ptr<Scalar> MakeScalar(std::string value) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -68,7 +68,7 @@ TYPED_TEST(TestNumericScalar, Basics) {
   ASSERT_EQ(other_value, scalar_val->value);
   ASSERT_TRUE(scalar_other->Equals(scalar_val));
 
-  ScalarType stack_val = ScalarType(0, false);
+  ScalarType stack_val;
   ASSERT_FALSE(stack_val.is_valid);
 }
 
@@ -102,7 +102,7 @@ TEST(TestBinaryScalar, Basics) {
   base_ref = nullptr;
   ASSERT_EQ(ref_count, buf.use_count());
 
-  BinaryScalar null_value(nullptr, false);
+  BinaryScalar null_value;
   ASSERT_FALSE(null_value.is_valid);
 
   StringScalar value2(buf);
@@ -117,7 +117,7 @@ TEST(TestBinaryScalar, Basics) {
   // Same buffer, same type.
   ASSERT_TRUE(value2.Equals(value3));
 
-  StringScalar null_value2(nullptr, false);
+  StringScalar null_value2;
   ASSERT_FALSE(null_value2.is_valid);
 }
 
@@ -166,15 +166,14 @@ TEST(TestFixedSizeBinaryScalar, MakeScalar) {
 TEST(TestDateScalars, Basics) {
   int32_t i32_val = 1;
   Date32Scalar date32_val(i32_val);
-  Date32Scalar date32_null(i32_val, false);
-  ASSERT_EQ(i32_val, date32_val.value);
+  Date32Scalar date32_null;
   ASSERT_TRUE(date32_val.type->Equals(*date32()));
   ASSERT_TRUE(date32_val.is_valid);
   ASSERT_FALSE(date32_null.is_valid);
 
   int64_t i64_val = 2;
   Date64Scalar date64_val(i64_val);
-  Date64Scalar date64_null(i64_val, false);
+  Date64Scalar date64_null;
   ASSERT_EQ(i64_val, date64_val.value);
   ASSERT_TRUE(date64_val.type->Equals(*date64()));
   ASSERT_TRUE(date64_val.is_valid);
@@ -199,7 +198,7 @@ TEST(TestTimeScalars, Basics) {
 
   int32_t i32_val = 1;
   Time32Scalar time32_val(i32_val, type1);
-  Time32Scalar time32_null(i32_val, type2, false);
+  Time32Scalar time32_null(type2);
   ASSERT_EQ(i32_val, time32_val.value);
   ASSERT_TRUE(time32_val.type->Equals(*type1));
   ASSERT_TRUE(time32_val.is_valid);
@@ -208,7 +207,7 @@ TEST(TestTimeScalars, Basics) {
 
   int64_t i64_val = 2;
   Time64Scalar time64_val(i64_val, type3);
-  Time64Scalar time64_null(i64_val, type4, false);
+  Time64Scalar time64_null(type4);
   ASSERT_EQ(i64_val, time64_val.value);
   ASSERT_TRUE(time64_val.type->Equals(*type3));
   ASSERT_TRUE(time64_val.is_valid);
@@ -245,9 +244,8 @@ TEST(TestTimestampScalars, Basics) {
   int64_t val2 = 2;
   TimestampScalar ts_val1(val1, type1);
   TimestampScalar ts_val2(val2, type2);
-  TimestampScalar ts_null(val2, type1, false);
+  TimestampScalar ts_null(type1);
   ASSERT_EQ(val1, ts_val1.value);
-  ASSERT_EQ(val2, ts_null.value);
 
   ASSERT_TRUE(ts_val1.type->Equals(*type1));
   ASSERT_TRUE(ts_val2.type->Equals(*type2));
@@ -297,9 +295,8 @@ TEST(TestDurationScalars, Basics) {
   int64_t val2 = 2;
   DurationScalar ts_val1(val1, type1);
   DurationScalar ts_val2(val2, type2);
-  DurationScalar ts_null(val2, type1, false);
+  DurationScalar ts_null(type1);
   ASSERT_EQ(val1, ts_val1.value);
-  ASSERT_EQ(val2, ts_null.value);
 
   ASSERT_TRUE(ts_val1.type->Equals(*type1));
   ASSERT_TRUE(ts_val2.type->Equals(*type2));
@@ -319,9 +316,8 @@ TEST(TestMonthIntervalScalars, Basics) {
   int32_t val2 = 2;
   MonthIntervalScalar ts_val1(val1);
   MonthIntervalScalar ts_val2(val2);
-  MonthIntervalScalar ts_null(val2, false);
+  MonthIntervalScalar ts_null;
   ASSERT_EQ(val1, ts_val1.value);
-  ASSERT_EQ(val2, ts_null.value);
 
   ASSERT_TRUE(ts_val1.type->Equals(*type));
   ASSERT_TRUE(ts_val2.type->Equals(*type));
@@ -341,9 +337,8 @@ TEST(TestDayTimeIntervalScalars, Basics) {
   DayTimeIntervalType::DayMilliseconds val2 = {2, 2};
   DayTimeIntervalScalar ts_val1(val1);
   DayTimeIntervalScalar ts_val2(val2);
-  DayTimeIntervalScalar ts_null(val2, false);
+  DayTimeIntervalScalar ts_null;
   ASSERT_EQ(val1, ts_val1.value);
-  ASSERT_EQ(val2, ts_null.value);
 
   ASSERT_TRUE(ts_val1.type->Equals(*type));
   ASSERT_TRUE(ts_val2.type->Equals(*type));

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -54,7 +54,7 @@ class Schema;
 
 class DictionaryType;
 class DictionaryArray;
-class DictionaryScalar;
+struct DictionaryScalar;
 
 class NullType;
 class NullArray;
@@ -123,7 +123,7 @@ struct Decimal128Scalar;
 
 class UnionType;
 class UnionArray;
-class UnionScalar;
+struct UnionScalar;
 
 template <typename TypeClass>
 class NumericArray;
@@ -134,14 +134,11 @@ class NumericBuilder;
 template <typename TypeClass>
 class NumericTensor;
 
-template <typename TypeClass>
-struct NumericScalar;
-
 #define _NUMERIC_TYPE_DECL(KLASS)                     \
   class KLASS##Type;                                  \
   using KLASS##Array = NumericArray<KLASS##Type>;     \
   using KLASS##Builder = NumericBuilder<KLASS##Type>; \
-  using KLASS##Scalar = NumericScalar<KLASS##Type>;   \
+  struct KLASS##Scalar;                               \
   using KLASS##Tensor = NumericTensor<KLASS##Type>;
 
 _NUMERIC_TYPE_DECL(Int8)
@@ -158,61 +155,49 @@ _NUMERIC_TYPE_DECL(Double)
 
 #undef _NUMERIC_TYPE_DECL
 
-template <typename TypeClass>
-struct TemporalScalar;
-
-template <typename T>
-struct DateScalar;
-
 class Date32Type;
 using Date32Array = NumericArray<Date32Type>;
 using Date32Builder = NumericBuilder<Date32Type>;
-using Date32Scalar = DateScalar<Date32Type>;
+struct Date32Scalar;
 
 class Date64Type;
 using Date64Array = NumericArray<Date64Type>;
 using Date64Builder = NumericBuilder<Date64Type>;
-using Date64Scalar = DateScalar<Date64Type>;
-
-template <typename T>
-struct TimeScalar;
+struct Date64Scalar;
 
 class Time32Type;
 using Time32Array = NumericArray<Time32Type>;
 using Time32Builder = NumericBuilder<Time32Type>;
-using Time32Scalar = TimeScalar<Time32Type>;
+struct Time32Scalar;
 
 class Time64Type;
 using Time64Array = NumericArray<Time64Type>;
 using Time64Builder = NumericBuilder<Time64Type>;
-using Time64Scalar = TimeScalar<Time64Type>;
+struct Time64Scalar;
 
 class TimestampType;
 using TimestampArray = NumericArray<TimestampType>;
 using TimestampBuilder = NumericBuilder<TimestampType>;
-using TimestampScalar = TemporalScalar<TimestampType>;
-
-template <typename TypeClass>
-struct IntervalScalar;
+struct TimestampScalar;
 
 class MonthIntervalType;
 using MonthIntervalArray = NumericArray<MonthIntervalType>;
 using MonthIntervalBuilder = NumericBuilder<MonthIntervalType>;
-using MonthIntervalScalar = IntervalScalar<MonthIntervalType>;
+struct MonthIntervalScalar;
 
 class DayTimeIntervalType;
 class DayTimeIntervalArray;
 class DayTimeIntervalBuilder;
-using DayTimeIntervalScalar = IntervalScalar<DayTimeIntervalType>;
+struct DayTimeIntervalScalar;
 
 class DurationType;
 using DurationArray = NumericArray<DurationType>;
 using DurationBuilder = NumericBuilder<DurationType>;
-using DurationScalar = TemporalScalar<DurationType>;
+struct DurationScalar;
 
 class ExtensionType;
 class ExtensionArray;
-class ExtensionScalar;
+struct ExtensionScalar;
 
 // ----------------------------------------------------------------------
 // (parameter-free) Factory functions

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -158,45 +158,57 @@ _NUMERIC_TYPE_DECL(Double)
 
 #undef _NUMERIC_TYPE_DECL
 
-class Date64Type;
-using Date64Array = NumericArray<Date64Type>;
-using Date64Builder = NumericBuilder<Date64Type>;
-class Date64Scalar;
+template <typename TypeClass>
+struct TemporalScalar;
+
+template <typename T>
+struct DateScalar;
 
 class Date32Type;
 using Date32Array = NumericArray<Date32Type>;
 using Date32Builder = NumericBuilder<Date32Type>;
-class Date32Scalar;
+using Date32Scalar = DateScalar<Date32Type>;
+
+class Date64Type;
+using Date64Array = NumericArray<Date64Type>;
+using Date64Builder = NumericBuilder<Date64Type>;
+using Date64Scalar = DateScalar<Date64Type>;
+
+template <typename T>
+struct TimeScalar;
 
 class Time32Type;
 using Time32Array = NumericArray<Time32Type>;
 using Time32Builder = NumericBuilder<Time32Type>;
-class Time32Scalar;
+using Time32Scalar = TimeScalar<Time32Type>;
 
 class Time64Type;
 using Time64Array = NumericArray<Time64Type>;
 using Time64Builder = NumericBuilder<Time64Type>;
-class Time64Scalar;
+using Time64Scalar = TimeScalar<Time64Type>;
 
 class TimestampType;
 using TimestampArray = NumericArray<TimestampType>;
 using TimestampBuilder = NumericBuilder<TimestampType>;
-class TimestampScalar;
+using TimestampScalar = TemporalScalar<TimestampType>;
+
+template <typename TypeClass>
+struct IntervalScalar;
 
 class MonthIntervalType;
 using MonthIntervalArray = NumericArray<MonthIntervalType>;
 using MonthIntervalBuilder = NumericBuilder<MonthIntervalType>;
-class MonthIntervalScalar;
+using MonthIntervalScalar = IntervalScalar<MonthIntervalType>;
 
 class DayTimeIntervalType;
 class DayTimeIntervalArray;
 class DayTimeIntervalBuilder;
-class DayTimeIntervalScalar;
+using DayTimeIntervalScalar = IntervalScalar<DayTimeIntervalType>;
 
 class DurationType;
 using DurationArray = NumericArray<DurationType>;
 using DurationBuilder = NumericBuilder<DurationType>;
-class DurationScalar;
+using DurationScalar = TemporalScalar<DurationType>;
 
 class ExtensionType;
 class ExtensionArray;

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -40,6 +40,7 @@ add_arrow_test(utility-test
                range_test.cc
                stl_util_test.cc
                string_test.cc
+               time_test.cc
                trie_test.cc
                utf8_util_test.cc)
 

--- a/cpp/src/arrow/util/compare.h
+++ b/cpp/src/arrow/util/compare.h
@@ -46,7 +46,6 @@ class EqualityComparable {
   }
 
   bool operator==(const T& other) const { return cast().Equals(other); }
-
   bool operator!=(const T& other) const { return !(cast() == other); }
 
  private:

--- a/cpp/src/arrow/util/time.cc
+++ b/cpp/src/arrow/util/time.cc
@@ -1,0 +1,47 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/time.h"
+#include "arrow/util/checked_cast.h"
+
+namespace arrow {
+namespace util {
+
+Result<int64_t> ConvertTimestampValue(const std::shared_ptr<DataType>& in,
+                                      const std::shared_ptr<DataType>& out,
+                                      int64_t value) {
+  auto from = internal::checked_pointer_cast<TimestampType>(in)->unit();
+  auto to = internal::checked_pointer_cast<TimestampType>(out)->unit();
+
+  auto op_factor =
+      util::kTimestampConversionTable[static_cast<int>(from)][static_cast<int>(to)];
+
+  auto op = op_factor.first;
+  auto factor = op_factor.second;
+  switch (op) {
+    case MULTIPLY:
+      return value * factor;
+    case DIVIDE:
+      return value / factor;
+  }
+
+  // unreachable...
+  return 0;
+}
+
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/time.h
+++ b/cpp/src/arrow/util/time.h
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <memory>
+#include <utility>
+
+#include "arrow/result.h"
+#include "arrow/type.h"
+
+namespace arrow {
+namespace util {
+
+enum DivideOrMultiply {
+  MULTIPLY,
+  DIVIDE,
+};
+
+// TimestampType -> TimestampType
+static std::pair<DivideOrMultiply, int64_t> kTimestampConversionTable[4][4] = {
+    // TimestampType::SECOND
+    {{MULTIPLY, 1}, {MULTIPLY, 1000}, {MULTIPLY, 1000000}, {MULTIPLY, 1000000000}},
+    // TimestampType::MILLI
+    {{DIVIDE, 1000}, {MULTIPLY, 1}, {MULTIPLY, 1000}, {MULTIPLY, 1000000}},
+    // TimestampType::MICRO
+    {{DIVIDE, 1000000}, {DIVIDE, 1000}, {MULTIPLY, 1}, {MULTIPLY, 1000}},
+    // TimestampType::NANO
+    {{DIVIDE, 1000000000}, {DIVIDE, 1000000}, {DIVIDE, 1000}, {MULTIPLY, 1}},
+};
+
+// Converts a Timestamp value into another Timestamp value.
+//
+// This function takes care of properly transforming from one unit to another.
+//
+// \param[in] in, the input type. Must be TimestampType.
+// \param[in] out, the output type. Must be TimestampType.
+// \param[in] value, the input value.
+//
+// \return The converted value, or an error.
+ARROW_EXPORT Result<int64_t> ConvertTimestampValue(const std::shared_ptr<DataType>& in,
+                                                   const std::shared_ptr<DataType>& out,
+                                                   int64_t value);
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/time_test.cc
+++ b/cpp/src/arrow/util/time_test.cc
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/time.h"
+
+namespace arrow {
+namespace util {
+
+TEST(TimeTest, ConvertTimestampValue) {
+  auto convert = [](TimeUnit::type in, TimeUnit::type out, int64_t value) {
+    return ConvertTimestampValue(timestamp(in), timestamp(out), value).ValueOrDie();
+  };
+
+  auto units = {
+      TimeUnit::SECOND,
+      TimeUnit::MILLI,
+      TimeUnit::MICRO,
+      TimeUnit::NANO,
+  };
+
+  // Test for identity
+  for (auto unit : units) {
+    EXPECT_EQ(convert(unit, unit, 0), 0);
+    EXPECT_EQ(convert(unit, unit, INT64_MAX), INT64_MAX);
+    EXPECT_EQ(convert(unit, unit, INT64_MIN), INT64_MIN);
+  }
+
+  EXPECT_EQ(convert(TimeUnit::SECOND, TimeUnit::MILLI, 2), 2000);
+  EXPECT_EQ(convert(TimeUnit::SECOND, TimeUnit::MICRO, 2), 2000000);
+  EXPECT_EQ(convert(TimeUnit::SECOND, TimeUnit::NANO, 2), 2000000000);
+
+  EXPECT_EQ(convert(TimeUnit::MILLI, TimeUnit::SECOND, 7000), 7);
+  EXPECT_EQ(convert(TimeUnit::MILLI, TimeUnit::MICRO, 7), 7000);
+  EXPECT_EQ(convert(TimeUnit::MILLI, TimeUnit::NANO, 7), 7000000);
+
+  EXPECT_EQ(convert(TimeUnit::MICRO, TimeUnit::SECOND, 4000000), 4);
+  EXPECT_EQ(convert(TimeUnit::MICRO, TimeUnit::MILLI, 4000), 4);
+  EXPECT_EQ(convert(TimeUnit::MICRO, TimeUnit::SECOND, 4000000), 4);
+
+  EXPECT_EQ(convert(TimeUnit::NANO, TimeUnit::SECOND, 6000000000), 6);
+  EXPECT_EQ(convert(TimeUnit::NANO, TimeUnit::MILLI, 6000000), 6);
+  EXPECT_EQ(convert(TimeUnit::NANO, TimeUnit::MICRO, 6000), 6);
+}
+
+}  // namespace util
+}  // namespace arrow

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -25,19 +25,25 @@ dir.create(dataset_dir)
 hive_dir <- tempfile()
 dir.create(hive_dir)
 
+first_date <- lubridate::ymd_hms("2015-04-29 03:12:39")
 df1 <- tibble(
   int = 1:10,
   dbl = as.numeric(1:10),
   lgl = rep(c(TRUE, FALSE, NA, TRUE, FALSE), 2),
   chr = letters[1:10],
   fct = factor(LETTERS[1:10])
+  fct = factor(LETTERS[1:10]),
+  ts = first_date + lubridate::days(1:10)
 )
+
+second_date <- lubridate::ymd_hms("2017-03-09 07:01:02")
 df2 <- tibble(
   int = 101:110,
   dbl = as.numeric(51:60),
   lgl = rep(c(TRUE, FALSE, NA, TRUE, FALSE), 2),
   chr = letters[10:1],
-  fct = factor(LETTERS[10:1])
+  fct = factor(LETTERS[10:1]),
+  ts = second_date + lubridate::days(10:1)
 )
 
 test_that("Setup (putting data in the dir)", {
@@ -124,6 +130,18 @@ test_that("filter() with %in%", {
       # TODO: C++ In() should cast: ARROW-7204
       collect(),
     tibble(int = df1$int[c(3, 4, 6)], part = 1)
+  )
+})
+
+test_that("filter() on timestamp columns", {
+  ds <- open_dataset(dataset_dir)
+  expect_equivalent(
+    ds %>%
+      # Replace `0L` with a proper lubriate object.
+      filter(ts >= 0L , part == 1) %>%
+      select(ts) %>%
+      collect(),
+    df1[1:10, c("ts")],
   )
 })
 

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -31,7 +31,6 @@ df1 <- tibble(
   dbl = as.numeric(1:10),
   lgl = rep(c(TRUE, FALSE, NA, TRUE, FALSE), 2),
   chr = letters[1:10],
-  fct = factor(LETTERS[1:10])
   fct = factor(LETTERS[1:10]),
   ts = first_date + lubridate::days(1:10)
 )
@@ -134,7 +133,7 @@ test_that("filter() with %in%", {
 })
 
 test_that("filter() on timestamp columns", {
-  ds <- open_dataset(dataset_dir)
+  ds <- open_dataset(dataset_dir, partition = schema(part = uint8()))
   expect_equivalent(
     ds %>%
       # Replace with expression with function once ARROW-7360 is fixed

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -137,11 +137,11 @@ test_that("filter() on timestamp columns", {
   ds <- open_dataset(dataset_dir)
   expect_equivalent(
     ds %>%
-      # Replace `0L` with a proper lubriate object.
-      filter(ts >= 0L , part == 1) %>%
+      # Replace with expression with function once ARROW-7360 is fixed
+      filter(ts >= (as.integer(as.POSIXct(lubridate::ymd_hms("2015-04-29 03:12:39") + lubridate::days(5))) * 1000000), part == 1) %>%
       select(ts) %>%
       collect(),
-    df1[1:10, c("ts")],
+    df1[5:10, c("ts")],
   )
 })
 

--- a/r/tests/testthat/test-dplyr.R
+++ b/r/tests/testthat/test-dplyr.R
@@ -80,6 +80,18 @@ test_that("More complex select/filter", {
   )
 })
 
+# ARROW-7360
+# test_that("filtering with expression", {
+#   char_sym <- "b"
+#   expect_dplyr_equal(
+#     input %>%
+#       filter(chr == char_sym) %>%
+#       select(string = chr, int) %>%
+#       collect(),
+#     tbl
+#   )
+# })
+
 test_that("filter() on is.na()", {
   expect_dplyr_equal(
     input %>%


### PR DESCRIPTION
The end goal of this PR is to minimally support filtering in R on temporal columns.

- Refactor Scalar classes
  - Follow the same hierarchy as the type hierarchy.
  - Provide 2 constructor for each Scalar, one for constructing a Null value and one providing an explicit value. The is_valid flag is not required by caller anymore.
  - All scalar types provide a non failing null constructor, i.e MakeNullScalar will not fail.
  - Ensure that we can cast from a NumericScalar to a TemporalScalar

- Add R unit test