### PR TITLE
PARQUET-1701: [C++] Stream API: Add support for optional fields

### DIFF
--- a/cpp/src/parquet/stream_reader.cc
+++ b/cpp/src/parquet/stream_reader.cc
@@ -21,6 +21,8 @@
 
 namespace parquet {
 
+constexpr int64_t StreamReader::kBatchSizeOne;
+
 StreamReader::StreamReader(std::unique_ptr<ParquetFileReader> reader)
     : file_reader_{std::move(reader)}, eof_{false} {
   file_metadata_ = file_reader_->metadata();
@@ -268,7 +270,7 @@ void StreamReader::Read(ByteArray* v) {
   int16_t rep_level;
   int64_t values_read;
 
-  reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
+  reader->ReadBatch(kBatchSizeOne, &def_level, &rep_level, v, &values_read);
 
   if (values_read != 1) {
     ThrowReadFailedException(node);
@@ -282,7 +284,7 @@ bool StreamReader::ReadOptional(ByteArray* v) {
   int16_t rep_level;
   int64_t values_read;
 
-  reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
+  reader->ReadBatch(kBatchSizeOne, &def_level, &rep_level, v, &values_read);
 
   if (values_read == 1) {
     return true;
@@ -300,7 +302,7 @@ void StreamReader::Read(FixedLenByteArray* v) {
   int16_t rep_level;
   int64_t values_read;
 
-  reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
+  reader->ReadBatch(kBatchSizeOne, &def_level, &rep_level, v, &values_read);
 
   if (values_read != 1) {
     ThrowReadFailedException(node);
@@ -315,7 +317,7 @@ bool StreamReader::ReadOptional(FixedLenByteArray* v) {
   int16_t rep_level;
   int64_t values_read;
 
-  reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
+  reader->ReadBatch(kBatchSizeOne, &def_level, &rep_level, v, &values_read);
 
   if (values_read == 1) {
     return true;
@@ -479,7 +481,8 @@ void StreamReader::CheckColumn(Type::type physical_type,
   }
 }
 
-void StreamReader::ThrowReadFailedException(const node_ptr_type& node) {
+void StreamReader::ThrowReadFailedException(
+    const std::shared_ptr<schema::PrimitiveNode>& node) {
   throw ParquetException("Failed to read value for column '" + node->name() +
                          "' on row " + std::to_string(current_row_));
 }

--- a/cpp/src/parquet/stream_reader.cc
+++ b/cpp/src/parquet/stream_reader.cc
@@ -60,33 +60,25 @@ StreamReader& StreamReader::operator>>(bool& v) {
 
 StreamReader& StreamReader::operator>>(int8_t& v) {
   CheckColumn(Type::INT32, ConvertedType::INT_8);
-  int32_t tmp;
-  Read<Int32Reader>(&tmp);
-  v = static_cast<int8_t>(tmp);
+  Read<Int32Reader, int32_t>(&v);
   return *this;
 }
 
 StreamReader& StreamReader::operator>>(uint8_t& v) {
   CheckColumn(Type::INT32, ConvertedType::UINT_8);
-  int32_t tmp;
-  Read<Int32Reader>(&tmp);
-  v = static_cast<uint8_t>(tmp);
+  Read<Int32Reader, int32_t>(&v);
   return *this;
 }
 
 StreamReader& StreamReader::operator>>(int16_t& v) {
   CheckColumn(Type::INT32, ConvertedType::INT_16);
-  int32_t tmp;
-  Read<Int32Reader>(&tmp);
-  v = static_cast<int16_t>(tmp);
+  Read<Int32Reader, int32_t>(&v);
   return *this;
 }
 
 StreamReader& StreamReader::operator>>(uint16_t& v) {
   CheckColumn(Type::INT32, ConvertedType::UINT_16);
-  int32_t tmp;
-  Read<Int32Reader>(&tmp);
-  v = static_cast<uint16_t>(tmp);
+  Read<Int32Reader, int32_t>(&v);
   return *this;
 }
 
@@ -145,6 +137,7 @@ StreamReader& StreamReader::operator>>(double& v) {
 StreamReader& StreamReader::operator>>(char& v) {
   CheckColumn(Type::FIXED_LEN_BYTE_ARRAY, ConvertedType::NONE, 1);
   FixedLenByteArray flba;
+
   Read(&flba);
   v = static_cast<char>(flba.ptr[0]);
   return *this;
@@ -153,8 +146,111 @@ StreamReader& StreamReader::operator>>(char& v) {
 StreamReader& StreamReader::operator>>(std::string& v) {
   CheckColumn(Type::BYTE_ARRAY, ConvertedType::UTF8);
   ByteArray ba;
+
   Read(&ba);
   v = std::string(reinterpret_cast<const char*>(ba.ptr), ba.len);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<bool>& v) {
+  CheckColumn(Type::BOOLEAN, ConvertedType::NONE);
+  ReadOptional<BoolReader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<int8_t>& v) {
+  CheckColumn(Type::INT32, ConvertedType::INT_8);
+  ReadOptional<Int32Reader, int32_t>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<uint8_t>& v) {
+  CheckColumn(Type::INT32, ConvertedType::UINT_8);
+  ReadOptional<Int32Reader, int32_t>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<int16_t>& v) {
+  CheckColumn(Type::INT32, ConvertedType::INT_16);
+  ReadOptional<Int32Reader, int32_t>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<uint16_t>& v) {
+  CheckColumn(Type::INT32, ConvertedType::UINT_16);
+  ReadOptional<Int32Reader, int32_t>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<int32_t>& v) {
+  CheckColumn(Type::INT32, ConvertedType::INT_32);
+  ReadOptional<Int32Reader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<uint32_t>& v) {
+  CheckColumn(Type::INT32, ConvertedType::UINT_32);
+  ReadOptional<Int32Reader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<int64_t>& v) {
+  CheckColumn(Type::INT64, ConvertedType::INT_64);
+  ReadOptional<Int64Reader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<uint64_t>& v) {
+  CheckColumn(Type::INT64, ConvertedType::UINT_64);
+  ReadOptional<Int64Reader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<float>& v) {
+  CheckColumn(Type::FLOAT, ConvertedType::NONE);
+  ReadOptional<FloatReader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<double>& v) {
+  CheckColumn(Type::DOUBLE, ConvertedType::NONE);
+  ReadOptional<DoubleReader>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<std::chrono::milliseconds>& v) {
+  CheckColumn(Type::INT64, ConvertedType::TIMESTAMP_MILLIS);
+  ReadOptional<Int64Reader, int64_t>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<std::chrono::microseconds>& v) {
+  CheckColumn(Type::INT64, ConvertedType::TIMESTAMP_MICROS);
+  ReadOptional<Int64Reader, int64_t>(&v);
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<char>& v) {
+  CheckColumn(Type::FIXED_LEN_BYTE_ARRAY, ConvertedType::NONE, 1);
+  FixedLenByteArray flba;
+
+  if (ReadOptional(&flba)) {
+    v = static_cast<char>(flba.ptr[0]);
+  } else {
+    v.reset();
+  }
+  return *this;
+}
+
+StreamReader& StreamReader::operator>>(optional<std::string>& v) {
+  CheckColumn(Type::BYTE_ARRAY, ConvertedType::UTF8);
+  ByteArray ba;
+
+  if (ReadOptional(&ba)) {
+    v = std::string(reinterpret_cast<const char*>(ba.ptr), ba.len);
+  } else {
+    v.reset();
+  }
   return *this;
 }
 
@@ -168,26 +264,65 @@ void StreamReader::ReadFixedLength(char* ptr, int len) {
 void StreamReader::Read(ByteArray* v) {
   const auto& node = nodes_[column_index_];
   auto reader = static_cast<ByteArrayReader*>(column_readers_[column_index_++].get());
+  int16_t def_level;
+  int16_t rep_level;
   int64_t values_read;
 
-  reader->ReadBatch(1, nullptr, nullptr, v, &values_read);
+  reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
 
   if (values_read != 1) {
-    throw ParquetException("Failed to read value for column '" + node->name() + "'");
+    ThrowReadFailedException(node);
   }
+}
+
+bool StreamReader::ReadOptional(ByteArray* v) {
+  const auto& node = nodes_[column_index_];
+  auto reader = static_cast<ByteArrayReader*>(column_readers_[column_index_++].get());
+  int16_t def_level;
+  int16_t rep_level;
+  int64_t values_read;
+
+  reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
+
+  if (values_read == 1) {
+    return true;
+  } else if ((values_read == 0) && (def_level == 0)) {
+    return false;
+  }
+  ThrowReadFailedException(node);
 }
 
 void StreamReader::Read(FixedLenByteArray* v) {
   const auto& node = nodes_[column_index_];
   auto reader =
       static_cast<FixedLenByteArrayReader*>(column_readers_[column_index_++].get());
+  int16_t def_level;
+  int16_t rep_level;
   int64_t values_read;
 
-  reader->ReadBatch(1, nullptr, nullptr, v, &values_read);
+  reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
 
   if (values_read != 1) {
-    throw ParquetException("Failed to read value for column '" + node->name() + "'");
+    ThrowReadFailedException(node);
   }
+}
+
+bool StreamReader::ReadOptional(FixedLenByteArray* v) {
+  const auto& node = nodes_[column_index_];
+  auto reader =
+      static_cast<FixedLenByteArrayReader*>(column_readers_[column_index_++].get());
+  int16_t def_level;
+  int16_t rep_level;
+  int64_t values_read;
+
+  reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
+
+  if (values_read == 1) {
+    return true;
+  } else if ((values_read == 0) && (def_level == 0)) {
+    return false;
+  }
+  ThrowReadFailedException(node);
 }
 
 void StreamReader::EndRow() {
@@ -342,6 +477,11 @@ void StreamReader::CheckColumn(Type::type physical_type,
                            "' has length " + std::to_string(node->type_length()) +
                            "] not " + std::to_string(length));
   }
+}
+
+void StreamReader::ThrowReadFailedException(const node_ptr_type& node) {
+  throw ParquetException("Failed to read value for column '" + node->name() +
+                         "' on row " + std::to_string(current_row_));
 }
 
 StreamReader& operator>>(StreamReader& os, EndRowType) {

--- a/cpp/src/parquet/stream_reader.h
+++ b/cpp/src/parquet/stream_reader.h
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "arrow/util/optional.h"
 #include "parquet/column_reader.h"
 #include "parquet/file_reader.h"
 #include "parquet/stream_writer.h"
@@ -41,10 +42,17 @@ namespace parquet {
 /// The user must explicitly advance to the next row using the
 /// EndRow() function or EndRow input manipulator.
 ///
-/// Currently there is no support for optional or repeated fields.
+/// Required and optional fields are supported:
+/// - Required fields are read using operator>>(T)
+/// - Optional fields are read with
+///   operator>>(arrow::util::optional<T>)
+/// Currently there is no support for repeated fields.
 ///
 class PARQUET_EXPORT StreamReader {
  public:
+  template <typename T>
+  using optional = arrow::util::optional<T>;
+
   // N.B. Default constructed objects are not usable.  This
   //      constructor is provided so that the object may be move
   //      assigned afterwards.
@@ -119,7 +127,54 @@ class PARQUET_EXPORT StreamReader {
 
   StreamReader& operator>>(std::string& v);
 
-  // Terminate current row and advance to next one.
+  // Input operators for optional fields.
+
+  StreamReader& operator>>(optional<bool>& v);
+
+  StreamReader& operator>>(optional<int8_t>& v);
+
+  StreamReader& operator>>(optional<uint8_t>& v);
+
+  StreamReader& operator>>(optional<int16_t>& v);
+
+  StreamReader& operator>>(optional<uint16_t>& v);
+
+  StreamReader& operator>>(optional<int32_t>& v);
+
+  StreamReader& operator>>(optional<uint32_t>& v);
+
+  StreamReader& operator>>(optional<int64_t>& v);
+
+  StreamReader& operator>>(optional<uint64_t>& v);
+
+  StreamReader& operator>>(optional<float>& v);
+
+  StreamReader& operator>>(optional<double>& v);
+
+  StreamReader& operator>>(optional<std::chrono::milliseconds>& v);
+
+  StreamReader& operator>>(optional<std::chrono::microseconds>& v);
+
+  StreamReader& operator>>(optional<char>& v);
+
+  StreamReader& operator>>(optional<std::string>& v);
+
+  template <std::size_t N>
+  StreamReader& operator>>(optional<std::array<char, N>>& v) {
+    CheckColumn(Type::FIXED_LEN_BYTE_ARRAY, ConvertedType::NONE, N);
+    FixedLenByteArray flba;
+    if (ReadOptional(&flba)) {
+      v = std::array<char, N>{};
+      std::memcpy(v->data(), flba.ptr, N);
+    } else {
+      v.reset();
+    }
+    return *this;
+  }
+
+  /// \brief Terminate current row and advance to next one.
+  /// \throws ParquetException if all columns in the row were not
+  /// read or skipped.
   void EndRow();
 
   /// \brief Skip the data in the next columns.
@@ -140,17 +195,60 @@ class PARQUET_EXPORT StreamReader {
   int64_t SkipRows(int64_t num_rows_to_skip);
 
  protected:
+  using node_ptr_type = std::shared_ptr<schema::PrimitiveNode>;
+
+  [[noreturn]] void ThrowReadFailedException(const node_ptr_type& node);
+
   template <typename ReaderType, typename T>
   void Read(T* v) {
     const auto& node = nodes_[column_index_];
     auto reader = static_cast<ReaderType*>(column_readers_[column_index_++].get());
-
+    int16_t def_level;
+    int16_t rep_level;
     int64_t values_read;
 
-    reader->ReadBatch(1, NULLPTR, NULLPTR, v, &values_read);
+    reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
 
     if (values_read != 1) {
-      throw ParquetException("Failed to read value for column '" + node->name() + "'");
+      ThrowReadFailedException(node);
+    }
+  }
+
+  template <typename ReaderType, typename ReadType, typename T>
+  void Read(T* v) {
+    const auto& node = nodes_[column_index_];
+    auto reader = static_cast<ReaderType*>(column_readers_[column_index_++].get());
+    int16_t def_level;
+    int16_t rep_level;
+    ReadType tmp;
+    int64_t values_read;
+
+    reader->ReadBatch(1, &def_level, &rep_level, &tmp, &values_read);
+
+    if (values_read == 1) {
+      *v = tmp;
+    } else {
+      ThrowReadFailedException(node);
+    }
+  }
+
+  template <typename ReaderType, typename ReadType = typename ReaderType::T, typename T>
+  void ReadOptional(optional<T>* v) {
+    const auto& node = nodes_[column_index_];
+    auto reader = static_cast<ReaderType*>(column_readers_[column_index_++].get());
+    int16_t def_level;
+    int16_t rep_level;
+    ReadType tmp;
+    int64_t values_read;
+
+    reader->ReadBatch(1, &def_level, &rep_level, &tmp, &values_read);
+
+    if (values_read == 1) {
+      *v = T(tmp);
+    } else if ((values_read == 0) && (def_level == 0)) {
+      v->reset();
+    } else {
+      ThrowReadFailedException(node);
     }
   }
 
@@ -159,6 +257,10 @@ class PARQUET_EXPORT StreamReader {
   void Read(ByteArray* v);
 
   void Read(FixedLenByteArray* v);
+
+  bool ReadOptional(ByteArray* v);
+
+  bool ReadOptional(FixedLenByteArray* v);
 
   void NextRowGroup();
 
@@ -170,8 +272,6 @@ class PARQUET_EXPORT StreamReader {
   void SetEof();
 
  private:
-  using node_ptr_type = std::shared_ptr<schema::PrimitiveNode>;
-
   std::unique_ptr<ParquetFileReader> file_reader_;
   std::shared_ptr<FileMetaData> file_metadata_;
   std::shared_ptr<RowGroupReader> row_group_reader_;
@@ -183,7 +283,7 @@ class PARQUET_EXPORT StreamReader {
   int column_index_{0};
   int64_t current_row_{0};
   int64_t row_group_row_offset_{0};
-};
+};  // namespace parquet
 
 PARQUET_EXPORT
 StreamReader& operator>>(StreamReader&, EndRowType);

--- a/cpp/src/parquet/stream_reader.h
+++ b/cpp/src/parquet/stream_reader.h
@@ -46,6 +46,14 @@ namespace parquet {
 /// - Required fields are read using operator>>(T)
 /// - Optional fields are read with
 ///   operator>>(arrow::util::optional<T>)
+///
+/// Note that operator>>(arrow::util::optional<T>) can be used to read
+/// required fields.
+///
+/// Similarly operator>>(T) can be used to read optional fields.
+/// However, if the value is not present then a ParquetException will
+/// be raised.
+///
 /// Currently there is no support for repeated fields.
 ///
 class PARQUET_EXPORT StreamReader {

--- a/cpp/src/parquet/stream_reader.h
+++ b/cpp/src/parquet/stream_reader.h
@@ -195,9 +195,8 @@ class PARQUET_EXPORT StreamReader {
   int64_t SkipRows(int64_t num_rows_to_skip);
 
  protected:
-  using node_ptr_type = std::shared_ptr<schema::PrimitiveNode>;
-
-  [[noreturn]] void ThrowReadFailedException(const node_ptr_type& node);
+  [[noreturn]] void ThrowReadFailedException(
+      const std::shared_ptr<schema::PrimitiveNode>& node);
 
   template <typename ReaderType, typename T>
   void Read(T* v) {
@@ -207,7 +206,7 @@ class PARQUET_EXPORT StreamReader {
     int16_t rep_level;
     int64_t values_read;
 
-    reader->ReadBatch(1, &def_level, &rep_level, v, &values_read);
+    reader->ReadBatch(kBatchSizeOne, &def_level, &rep_level, v, &values_read);
 
     if (values_read != 1) {
       ThrowReadFailedException(node);
@@ -223,7 +222,7 @@ class PARQUET_EXPORT StreamReader {
     ReadType tmp;
     int64_t values_read;
 
-    reader->ReadBatch(1, &def_level, &rep_level, &tmp, &values_read);
+    reader->ReadBatch(kBatchSizeOne, &def_level, &rep_level, &tmp, &values_read);
 
     if (values_read == 1) {
       *v = tmp;
@@ -241,7 +240,7 @@ class PARQUET_EXPORT StreamReader {
     ReadType tmp;
     int64_t values_read;
 
-    reader->ReadBatch(1, &def_level, &rep_level, &tmp, &values_read);
+    reader->ReadBatch(kBatchSizeOne, &def_level, &rep_level, &tmp, &values_read);
 
     if (values_read == 1) {
       *v = T(tmp);
@@ -276,13 +275,15 @@ class PARQUET_EXPORT StreamReader {
   std::shared_ptr<FileMetaData> file_metadata_;
   std::shared_ptr<RowGroupReader> row_group_reader_;
   std::vector<std::shared_ptr<ColumnReader>> column_readers_;
-  std::vector<node_ptr_type> nodes_;
+  std::vector<std::shared_ptr<schema::PrimitiveNode>> nodes_;
 
   bool eof_{true};
   int row_group_index_{0};
   int column_index_{0};
   int64_t current_row_{0};
   int64_t row_group_row_offset_{0};
+
+  static constexpr int64_t kBatchSizeOne = 1;
 };  // namespace parquet
 
 PARQUET_EXPORT

--- a/cpp/src/parquet/stream_reader_test.cc
+++ b/cpp/src/parquet/stream_reader_test.cc
@@ -34,6 +34,7 @@ namespace test {
 
 template <typename T>
 using optional = StreamReader::optional<T>;
+using arrow::util::nullopt;
 
 struct TestData {
   static void init() { std::time(&ts_offset_); }
@@ -59,77 +60,77 @@ struct TestData {
 
   static optional<bool> GetOptBool(const int i) {
     if (i % 11 == 0) {
-      return {};
+      return nullopt;
     }
     return i % 7 < 3;
   }
 
   static optional<char> GetOptChar(const int i) {
     if ((i + 1) % 11 == 1) {
-      return {};
+      return nullopt;
     }
     return i & 1 ? 'M' : 'F';
   }
 
   static optional<std::array<char, 4>> GetOptCharArray(const int i) {
     if ((i + 2) % 11 == 1) {
-      return {};
+      return nullopt;
     }
     return std::array<char, 4>{{'X', 'Y', 'Z', char('A' + i % 26)}};
   }
 
   static optional<int8_t> GetOptInt8(const int i) {
     if ((i + 3) % 11 == 1) {
-      return {};
+      return nullopt;
     }
     return static_cast<int8_t>((i % 256) - 128);
   }
 
   static optional<uint16_t> GetOptUInt16(const int i) {
     if ((i + 4) % 11 == 1) {
-      return {};
+      return nullopt;
     }
     return static_cast<uint16_t>(i);
   }
 
   static optional<int32_t> GetOptInt32(const int i) {
     if ((i + 5) % 11 == 1) {
-      return {};
+      return nullopt;
     }
     return 3 * i - 17;
   }
 
   static optional<uint64_t> GetOptUInt64(const int i) {
     if ((i + 6) % 11 == 1) {
-      return {};
+      return nullopt;
     }
     return (1ull << 40) + i * i + 101;
   }
 
   static optional<std::string> GetOptString(const int i) {
     if (i % 5 == 0) {
-      return {};
+      return nullopt;
     }
     return "Str #" + std::to_string(i);
   }
 
   static optional<float> GetOptFloat(const int i) {
     if ((i + 1) % 3 == 0) {
-      return {};
+      return nullopt;
     }
     return 2.718281828459045f * i;
   }
 
   static optional<double> GetOptDouble(const int i) {
     if ((i + 2) % 3 == 0) {
-      return {};
+      return nullopt;
     }
     return 6.62607004e-34 * 3e8 * i;
   }
 
   static optional<std::chrono::microseconds> GetOptChronoMicroseconds(const int i) {
     if ((i + 2) % 7 == 0) {
-      return {};
+      return nullopt;
     }
     return std::chrono::microseconds{(ts_offset_ + 3 * i) * 1000000ull + i};
   }
@@ -234,21 +235,21 @@ TEST_F(TestStreamReader, DefaultConstructed) {
   std::string s;
 
   // N.B. Default constructor objects are not usable.
-  ASSERT_THROW(os >> i, ParquetException);
-  ASSERT_THROW(os >> s, ParquetException);
-  ASSERT_THROW(os >> EndRow, ParquetException);
+  EXPECT_THROW(os >> i, ParquetException);
+  EXPECT_THROW(os >> s, ParquetException);
+  EXPECT_THROW(os >> EndRow, ParquetException);
 
-  ASSERT_EQ(true, os.eof());
-  ASSERT_EQ(0, os.current_column());
-  ASSERT_EQ(0, os.current_row());
+  EXPECT_EQ(true, os.eof());
+  EXPECT_EQ(0, os.current_column());
+  EXPECT_EQ(0, os.current_row());
 
-  ASSERT_EQ(0, os.num_columns());
-  ASSERT_EQ(0, os.num_rows());
+  EXPECT_EQ(0, os.num_columns());
+  EXPECT_EQ(0, os.num_rows());
 
   // Skipping columns and rows is allowed.
   //
-  ASSERT_EQ(0, os.SkipColumns(100));
-  ASSERT_EQ(0, os.SkipRows(100));
+  EXPECT_EQ(0, os.SkipColumns(100));
+  EXPECT_EQ(0, os.SkipRows(100));
 }
 
 TEST_F(TestStreamReader, TypeChecking) {
@@ -267,29 +268,29 @@ TEST_F(TestStreamReader, TypeChecking) {
   double d;
   std::string str;
 
-  ASSERT_THROW(reader_ >> int8, ParquetException);
-  ASSERT_NO_THROW(reader_ >> b);
-  ASSERT_THROW(reader_ >> c, ParquetException);
-  ASSERT_NO_THROW(reader_ >> s);
-  ASSERT_THROW(reader_ >> s, ParquetException);
-  ASSERT_NO_THROW(reader_ >> c);
-  ASSERT_THROW(reader_ >> s, ParquetException);
-  ASSERT_NO_THROW(reader_ >> char_array);
-  ASSERT_THROW(reader_ >> int16, ParquetException);
-  ASSERT_NO_THROW(reader_ >> int8);
-  ASSERT_THROW(reader_ >> int16, ParquetException);
-  ASSERT_NO_THROW(reader_ >> uint16);
-  ASSERT_THROW(reader_ >> int64, ParquetException);
-  ASSERT_NO_THROW(reader_ >> int32);
-  ASSERT_THROW(reader_ >> int64, ParquetException);
-  ASSERT_NO_THROW(reader_ >> uint64);
-  ASSERT_THROW(reader_ >> uint64, ParquetException);
-  ASSERT_NO_THROW(reader_ >> ts_us);
-  ASSERT_THROW(reader_ >> d, ParquetException);
-  ASSERT_NO_THROW(reader_ >> f);
-  ASSERT_THROW(reader_ >> f, ParquetException);
-  ASSERT_NO_THROW(reader_ >> d);
-  ASSERT_NO_THROW(reader_ >> EndRow);
+  EXPECT_THROW(reader_ >> int8, ParquetException);
+  EXPECT_NO_THROW(reader_ >> b);
+  EXPECT_THROW(reader_ >> c, ParquetException);
+  EXPECT_NO_THROW(reader_ >> s);
+  EXPECT_THROW(reader_ >> s, ParquetException);
+  EXPECT_NO_THROW(reader_ >> c);
+  EXPECT_THROW(reader_ >> s, ParquetException);
+  EXPECT_NO_THROW(reader_ >> char_array);
+  EXPECT_THROW(reader_ >> int16, ParquetException);
+  EXPECT_NO_THROW(reader_ >> int8);
+  EXPECT_THROW(reader_ >> int16, ParquetException);
+  EXPECT_NO_THROW(reader_ >> uint16);
+  EXPECT_THROW(reader_ >> int64, ParquetException);
+  EXPECT_NO_THROW(reader_ >> int32);
+  EXPECT_THROW(reader_ >> int64, ParquetException);
+  EXPECT_NO_THROW(reader_ >> uint64);
+  EXPECT_THROW(reader_ >> uint64, ParquetException);
+  EXPECT_NO_THROW(reader_ >> ts_us);
+  EXPECT_THROW(reader_ >> d, ParquetException);
+  EXPECT_NO_THROW(reader_ >> f);
+  EXPECT_THROW(reader_ >> f, ParquetException);
+  EXPECT_NO_THROW(reader_ >> d);
+  EXPECT_NO_THROW(reader_ >> EndRow);
 }
 
 TEST_F(TestStreamReader, ValueChecking) {
@@ -308,7 +309,7 @@ TEST_F(TestStreamReader, ValueChecking) {
   int i;
 
   for (i = 0; !reader_.eof(); ++i) {
-    ASSERT_EQ(i, reader_.current_row());
+    EXPECT_EQ(i, reader_.current_row());
 
     reader_ >> b;
     reader_ >> str;
@@ -323,32 +324,32 @@ TEST_F(TestStreamReader, ValueChecking) {
     reader_ >> d;
     reader_ >> EndRow;
 
-    ASSERT_EQ(b, TestData::GetBool(i));
-    ASSERT_EQ(str, TestData::GetString(i));
-    ASSERT_EQ(c, TestData::GetChar(i));
-    ASSERT_EQ(char_array, TestData::GetCharArray(i));
-    ASSERT_EQ(int8, TestData::GetInt8(i));
-    ASSERT_EQ(uint16, TestData::GetUInt16(i));
-    ASSERT_EQ(int32, TestData::GetInt32(i));
-    ASSERT_EQ(uint64, TestData::GetUInt64(i));
-    ASSERT_EQ(ts_us, TestData::GetChronoMicroseconds(i));
-    ASSERT_FLOAT_EQ(f, TestData::GetFloat(i));
-    ASSERT_DOUBLE_EQ(d, TestData::GetDouble(i));
+    EXPECT_EQ(b, TestData::GetBool(i)) << "index: " << i;
+    EXPECT_EQ(str, TestData::GetString(i)) << "index: " << i;
+    EXPECT_EQ(c, TestData::GetChar(i)) << "index: " << i;
+    EXPECT_EQ(char_array, TestData::GetCharArray(i)) << "index: " << i;
+    EXPECT_EQ(int8, TestData::GetInt8(i)) << "index: " << i;
+    EXPECT_EQ(uint16, TestData::GetUInt16(i)) << "index: " << i;
+    EXPECT_EQ(int32, TestData::GetInt32(i)) << "index: " << i;
+    EXPECT_EQ(uint64, TestData::GetUInt64(i)) << "index: " << i;
+    EXPECT_EQ(ts_us, TestData::GetChronoMicroseconds(i)) << "index: " << i;
+    EXPECT_FLOAT_EQ(f, TestData::GetFloat(i)) << "index: " << i;
+    EXPECT_DOUBLE_EQ(d, TestData::GetDouble(i)) << "index: " << i;
   }
-  ASSERT_EQ(reader_.current_row(), TestData::num_rows);
-  ASSERT_EQ(reader_.num_rows(), TestData::num_rows);
-  ASSERT_EQ(i, TestData::num_rows);
+  EXPECT_EQ(reader_.current_row(), TestData::num_rows);
+  EXPECT_EQ(reader_.num_rows(), TestData::num_rows);
+  EXPECT_EQ(i, TestData::num_rows);
 }
 
 TEST_F(TestStreamReader, SkipRows) {
   // Skipping zero and negative number of rows is ok.
   //
-  ASSERT_EQ(0, reader_.SkipRows(0));
-  ASSERT_EQ(0, reader_.SkipRows(-100));
+  EXPECT_EQ(0, reader_.SkipRows(0));
+  EXPECT_EQ(0, reader_.SkipRows(-100));
 
-  ASSERT_EQ(false, reader_.eof());
-  ASSERT_EQ(0, reader_.current_row());
-  ASSERT_EQ(TestData::num_rows, reader_.num_rows());
+  EXPECT_EQ(false, reader_.eof());
+  EXPECT_EQ(0, reader_.current_row());
+  EXPECT_EQ(TestData::num_rows, reader_.num_rows());
 
   const int iter_num_rows_to_read = 3;
   const int iter_num_rows_to_skip = 13;
@@ -377,7 +378,7 @@ TEST_F(TestStreamReader, SkipRows) {
     std::string str;
 
     for (int j = 0; !reader_.eof() && (j < iter_num_rows_to_read); ++i, ++j) {
-      ASSERT_EQ(i, reader_.current_row());
+      EXPECT_EQ(i, reader_.current_row());
 
       reader_ >> b;
       reader_ >> s;
@@ -387,7 +388,7 @@ TEST_F(TestStreamReader, SkipRows) {
       reader_ >> uint16;
 
       // Not allowed to skip row once reading columns has started.
-      ASSERT_THROW(reader_.SkipRows(1), ParquetException);
+      EXPECT_THROW(reader_.SkipRows(1), ParquetException);
 
       reader_ >> int32;
       reader_ >> uint64;
@@ -397,38 +398,38 @@ TEST_F(TestStreamReader, SkipRows) {
       reader_ >> EndRow;
       num_rows_read += 1;
 
-      ASSERT_EQ(b, TestData::GetBool(i));
-      ASSERT_EQ(s, TestData::GetString(i));
-      ASSERT_EQ(c, TestData::GetChar(i));
-      ASSERT_EQ(char_array, TestData::GetCharArray(i));
-      ASSERT_EQ(int8, TestData::GetInt8(i));
-      ASSERT_EQ(uint16, TestData::GetUInt16(i));
-      ASSERT_EQ(int32, TestData::GetInt32(i));
-      ASSERT_EQ(uint64, TestData::GetUInt64(i));
-      ASSERT_EQ(ts_us, TestData::GetChronoMicroseconds(i));
-      ASSERT_FLOAT_EQ(f, TestData::GetFloat(i));
-      ASSERT_DOUBLE_EQ(d, TestData::GetDouble(i));
+      EXPECT_EQ(b, TestData::GetBool(i));
+      EXPECT_EQ(s, TestData::GetString(i));
+      EXPECT_EQ(c, TestData::GetChar(i));
+      EXPECT_EQ(char_array, TestData::GetCharArray(i));
+      EXPECT_EQ(int8, TestData::GetInt8(i));
+      EXPECT_EQ(uint16, TestData::GetUInt16(i));
+      EXPECT_EQ(int32, TestData::GetInt32(i));
+      EXPECT_EQ(uint64, TestData::GetUInt64(i));
+      EXPECT_EQ(ts_us, TestData::GetChronoMicroseconds(i));
+      EXPECT_FLOAT_EQ(f, TestData::GetFloat(i));
+      EXPECT_DOUBLE_EQ(d, TestData::GetDouble(i));
     }
-    ASSERT_EQ(iter_num_rows_to_skip, reader_.SkipRows(iter_num_rows_to_skip));
+    EXPECT_EQ(iter_num_rows_to_skip, reader_.SkipRows(iter_num_rows_to_skip));
     i += iter_num_rows_to_skip;
   }
-  ASSERT_EQ(TestData::num_rows, reader_.current_row());
+  EXPECT_EQ(TestData::num_rows, reader_.current_row());
 
-  ASSERT_EQ(num_rows_read, num_iterations * iter_num_rows_to_read);
+  EXPECT_EQ(num_rows_read, num_iterations * iter_num_rows_to_read);
 
   // Skipping rows at eof is allowed.
   //
-  ASSERT_EQ(0, reader_.SkipRows(100));
+  EXPECT_EQ(0, reader_.SkipRows(100));
 }
 
 TEST_F(TestStreamReader, SkipAllRows) {
-  ASSERT_EQ(false, reader_.eof());
-  ASSERT_EQ(0, reader_.current_row());
+  EXPECT_EQ(false, reader_.eof());
+  EXPECT_EQ(0, reader_.current_row());
 
-  ASSERT_EQ(reader_.num_rows(), reader_.SkipRows(2 * reader_.num_rows()));
+  EXPECT_EQ(reader_.num_rows(), reader_.SkipRows(2 * reader_.num_rows()));
 
-  ASSERT_EQ(true, reader_.eof());
-  ASSERT_EQ(reader_.num_rows(), reader_.current_row());
+  EXPECT_EQ(true, reader_.eof());
+  EXPECT_EQ(reader_.num_rows(), reader_.current_row());
 }
 
 TEST_F(TestStreamReader, SkipColumns) {
@@ -449,81 +450,82 @@ TEST_F(TestStreamReader, SkipColumns) {
 
   // Skipping zero and negative number of columns is ok.
   //
-  ASSERT_EQ(0, reader_.SkipColumns(0));
-  ASSERT_EQ(0, reader_.SkipColumns(-100));
+  EXPECT_EQ(0, reader_.SkipColumns(0));
+  EXPECT_EQ(0, reader_.SkipColumns(-100));
 
   for (i = 0; !reader_.eof(); ++i) {
-    ASSERT_EQ(i, reader_.current_row());
-    ASSERT_EQ(0, reader_.current_column());
+    EXPECT_EQ(i, reader_.current_row());
+    EXPECT_EQ(0, reader_.current_column());
 
     // Skip all columns every 31 rows.
     if (i % 31 == 0) {
-      ASSERT_EQ(reader_.num_columns(), reader_.SkipColumns(reader_.num_columns()));
-      ASSERT_EQ(reader_.num_columns(), reader_.current_column());
+      EXPECT_EQ(reader_.num_columns(), reader_.SkipColumns(reader_.num_columns()))
+          << "index: " << i;
+      EXPECT_EQ(reader_.num_columns(), reader_.current_column()) << "index: " << i;
       reader_ >> EndRow;
       continue;
     }
     reader_ >> b;
-    ASSERT_EQ(b, TestData::GetBool(i));
-    ASSERT_EQ(1, reader_.current_column());
+    EXPECT_EQ(b, TestData::GetBool(i)) << "index: " << i;
+    EXPECT_EQ(1, reader_.current_column()) << "index: " << i;
 
     // Skip the next column every 3 rows.
     if (i % 3 == 0) {
-      ASSERT_EQ(1, reader_.SkipColumns(1));
+      EXPECT_EQ(1, reader_.SkipColumns(1)) << "index: " << i;
     } else {
       reader_ >> s;
-      ASSERT_EQ(s, TestData::GetString(i));
+      EXPECT_EQ(s, TestData::GetString(i)) << "index: " << i;
     }
-    ASSERT_EQ(2, reader_.current_column());
+    EXPECT_EQ(2, reader_.current_column()) << "index: " << i;
 
     reader_ >> c;
-    ASSERT_EQ(c, TestData::GetChar(i));
-    ASSERT_EQ(3, reader_.current_column());
+    EXPECT_EQ(c, TestData::GetChar(i)) << "index: " << i;
+    EXPECT_EQ(3, reader_.current_column()) << "index: " << i;
     reader_ >> char_array;
-    ASSERT_EQ(char_array, TestData::GetCharArray(i));
-    ASSERT_EQ(4, reader_.current_column());
+    EXPECT_EQ(char_array, TestData::GetCharArray(i)) << "index: " << i;
+    EXPECT_EQ(4, reader_.current_column()) << "index: " << i;
     reader_ >> int8;
-    ASSERT_EQ(int8, TestData::GetInt8(i));
-    ASSERT_EQ(5, reader_.current_column());
+    EXPECT_EQ(int8, TestData::GetInt8(i)) << "index: " << i;
+    EXPECT_EQ(5, reader_.current_column()) << "index: " << i;
 
     // Skip the next 3 columns every 7 rows.
     if (i % 7 == 0) {
-      ASSERT_EQ(3, reader_.SkipColumns(3));
+      EXPECT_EQ(3, reader_.SkipColumns(3)) << "index: " << i;
     } else {
       reader_ >> uint16;
-      ASSERT_EQ(uint16, TestData::GetUInt16(i));
-      ASSERT_EQ(6, reader_.current_column());
+      EXPECT_EQ(uint16, TestData::GetUInt16(i)) << "index: " << i;
+      EXPECT_EQ(6, reader_.current_column()) << "index: " << i;
       reader_ >> int32;
-      ASSERT_EQ(int32, TestData::GetInt32(i));
-      ASSERT_EQ(7, reader_.current_column());
+      EXPECT_EQ(int32, TestData::GetInt32(i)) << "index: " << i;
+      EXPECT_EQ(7, reader_.current_column()) << "index: " << i;
       reader_ >> uint64;
-      ASSERT_EQ(uint64, TestData::GetUInt64(i));
+      EXPECT_EQ(uint64, TestData::GetUInt64(i)) << "index: " << i;
     }
-    ASSERT_EQ(8, reader_.current_column());
+    EXPECT_EQ(8, reader_.current_column());
 
     reader_ >> ts_us;
-    ASSERT_EQ(ts_us, TestData::GetChronoMicroseconds(i));
-    ASSERT_EQ(9, reader_.current_column());
+    EXPECT_EQ(ts_us, TestData::GetChronoMicroseconds(i)) << "index: " << i;
+    EXPECT_EQ(9, reader_.current_column()) << "index: " << i;
 
     // Skip 301 columns (i.e. all remaining) every 11 rows.
     if (i % 11 == 0) {
-      ASSERT_EQ(2, reader_.SkipColumns(301));
+      EXPECT_EQ(2, reader_.SkipColumns(301)) << "index: " << i;
     } else {
       reader_ >> f;
-      ASSERT_FLOAT_EQ(f, TestData::GetFloat(i));
-      ASSERT_EQ(10, reader_.current_column());
+      EXPECT_FLOAT_EQ(f, TestData::GetFloat(i)) << "index: " << i;
+      EXPECT_EQ(10, reader_.current_column()) << "index: " << i;
       reader_ >> d;
-      ASSERT_DOUBLE_EQ(d, TestData::GetDouble(i));
+      EXPECT_DOUBLE_EQ(d, TestData::GetDouble(i)) << "index: " << i;
     }
-    ASSERT_EQ(11, reader_.current_column());
+    EXPECT_EQ(11, reader_.current_column()) << "index: " << i;
     reader_ >> EndRow;
   }
-  ASSERT_EQ(i, TestData::num_rows);
-  ASSERT_EQ(reader_.current_row(), TestData::num_rows);
+  EXPECT_EQ(i, TestData::num_rows);
+  EXPECT_EQ(reader_.current_row(), TestData::num_rows);
 
   // Skipping columns at eof is allowed.
   //
-  ASSERT_EQ(0, reader_.SkipColumns(100));
+  EXPECT_EQ(0, reader_.SkipColumns(100));
 }
 
 class TestOptionalFields : public ::testing::Test {
@@ -629,7 +631,7 @@ TEST_F(TestOptionalFields, ValueChecking) {
   int i;
 
   for (i = 0; !reader_.eof(); ++i) {
-    ASSERT_EQ(i, reader_.current_row());
+    EXPECT_EQ(i, reader_.current_row());
 
     reader_ >> opt_bool;
     reader_ >> opt_string;
@@ -644,29 +646,130 @@ TEST_F(TestOptionalFields, ValueChecking) {
     reader_ >> opt_double;
     reader_ >> EndRow;
 
-    ASSERT_EQ(opt_bool, TestData::GetOptBool(i));
-    ASSERT_EQ(opt_string, TestData::GetOptString(i));
-    ASSERT_EQ(opt_char, TestData::GetOptChar(i));
-    ASSERT_EQ(opt_char_array, TestData::GetOptCharArray(i));
-    ASSERT_EQ(opt_int8, TestData::GetOptInt8(i));
-    ASSERT_EQ(opt_uint16, TestData::GetOptUInt16(i));
-    ASSERT_EQ(opt_int32, TestData::GetOptInt32(i));
-    ASSERT_EQ(opt_uint64, TestData::GetOptUInt64(i));
-    ASSERT_EQ(opt_ts_us, TestData::GetOptChronoMicroseconds(i));
-    if (opt_float) {
-      ASSERT_FLOAT_EQ(*opt_float, *TestData::GetOptFloat(i));
+    EXPECT_EQ(opt_bool, TestData::GetOptBool(i)) << "index: " << i;
+    EXPECT_EQ(opt_string, TestData::GetOptString(i)) << "index: " << i;
+    EXPECT_EQ(opt_char, TestData::GetOptChar(i)) << "index: " << i;
+    EXPECT_EQ(opt_char_array, TestData::GetOptCharArray(i)) << "index: " << i;
+    EXPECT_EQ(opt_int8, TestData::GetOptInt8(i)) << "index: " << i;
+    EXPECT_EQ(opt_uint16, TestData::GetOptUInt16(i)) << "index: " << i;
+    EXPECT_EQ(opt_int32, TestData::GetOptInt32(i)) << "index: " << i;
+    EXPECT_EQ(opt_uint64, TestData::GetOptUInt64(i)) << "index: " << i;
+    EXPECT_EQ(opt_ts_us, TestData::GetOptChronoMicroseconds(i)) << "index: " << i;
+    if (opt_float && TestData::GetOptFloat(i)) {
+      EXPECT_FLOAT_EQ(*opt_float, *TestData::GetOptFloat(i)) << "index: " << i;
     } else {
-      ASSERT_EQ(opt_float, TestData::GetOptFloat(i));
+      EXPECT_EQ(opt_float, TestData::GetOptFloat(i)) << "index: " << i;
     }
-    if (opt_double) {
-      ASSERT_DOUBLE_EQ(*opt_double, *TestData::GetOptDouble(i));
+    if (opt_double && TestData::GetOptDouble(i)) {
+      EXPECT_DOUBLE_EQ(*opt_double, *TestData::GetOptDouble(i)) << "index: " << i;
     } else {
-      ASSERT_EQ(opt_double, TestData::GetOptDouble(i));
+      EXPECT_EQ(opt_double, TestData::GetOptDouble(i)) << "index: " << i;
     }
   }
-  ASSERT_EQ(reader_.current_row(), TestData::num_rows);
-  ASSERT_EQ(reader_.num_rows(), TestData::num_rows);
-  ASSERT_EQ(i, TestData::num_rows);
+  EXPECT_EQ(reader_.current_row(), TestData::num_rows);
+  EXPECT_EQ(reader_.num_rows(), TestData::num_rows);
+  EXPECT_EQ(i, TestData::num_rows);
+}
+
+TEST_F(TestOptionalFields, ReadOptionalValueAsRequiredField) {
+  /* Test that optional fields can be read using non-optional types
+    _provided_ that the optional value is available.
+
+    This can be useful if a schema is changed such that a column is
+    optional in some conditions.  Applications for which the optional
+    conditions do not hold can continue reading the column as being
+    mandatory.
+
+    Of course if the optional value is not present, then the read will
+    fail by throwing an exception.  This is also tested below.
+  */
+
+  bool b;
+  std::string s;
+  std::array<char, 4> char_array;
+  char c;
+  int8_t int8;
+  uint16_t uint16;
+  int32_t int32;
+  uint64_t uint64;
+  std::chrono::microseconds ts_us;
+  float f;
+  double d;
+  std::string str;
+
+  int i;
+
+  for (i = 0; !reader_.eof(); ++i) {
+    EXPECT_EQ(i, reader_.current_row());
+
+    if (TestData::GetOptBool(i)) {
+      reader_ >> b;
+      EXPECT_EQ(b, *TestData::GetOptBool(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> b, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptString(i)) {
+      reader_ >> s;
+      EXPECT_EQ(s, *TestData::GetOptString(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> s, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptChar(i)) {
+      reader_ >> c;
+      EXPECT_EQ(c, *TestData::GetOptChar(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> c, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptCharArray(i)) {
+      reader_ >> char_array;
+      EXPECT_EQ(char_array, *TestData::GetOptCharArray(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> char_array, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptInt8(i)) {
+      reader_ >> int8;
+      EXPECT_EQ(int8, *TestData::GetOptInt8(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> int8, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptUInt16(i)) {
+      reader_ >> uint16;
+      EXPECT_EQ(uint16, *TestData::GetOptUInt16(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> uint16, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptInt32(i)) {
+      reader_ >> int32;
+      EXPECT_EQ(int32, *TestData::GetOptInt32(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> int32, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptUInt64(i)) {
+      reader_ >> uint64;
+      EXPECT_EQ(uint64, *TestData::GetOptUInt64(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> uint64, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptChronoMicroseconds(i)) {
+      reader_ >> ts_us;
+      EXPECT_EQ(ts_us, *TestData::GetOptChronoMicroseconds(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> ts_us, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptFloat(i)) {
+      reader_ >> f;
+      EXPECT_EQ(f, *TestData::GetOptFloat(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> f, ParquetException) << "index: " << i;
+    }
+    if (TestData::GetOptDouble(i)) {
+      reader_ >> d;
+      EXPECT_EQ(d, *TestData::GetOptDouble(i)) << "index: " << i;
+    } else {
+      EXPECT_THROW(reader_ >> d, ParquetException) << "index: " << i;
+    }
+    reader_ >> EndRow;
+  }
 }
 
 }  // namespace test

--- a/cpp/src/parquet/stream_writer.cc
+++ b/cpp/src/parquet/stream_writer.cc
@@ -23,6 +23,11 @@ namespace parquet {
 
 int64_t StreamWriter::default_row_group_size_{512 * 1024 * 1024};  // 512MB
 
+const int16_t StreamWriter::def_level_zero_ = 0;
+const int16_t StreamWriter::def_level_one_ = 1;
+const int16_t StreamWriter::rep_level_zero_ = 0;
+const int16_t StreamWriter::rep_level_one_ = 1;
+
 StreamWriter::FixedStringView::FixedStringView(const char* data_ptr)
     : data{data_ptr}, size{std::strlen(data_ptr)} {}
 
@@ -42,16 +47,6 @@ StreamWriter::StreamWriter(std::unique_ptr<ParquetFileWriter> writer)
   }
 }
 
-StreamWriter::~StreamWriter() {
-  if (row_group_writer_) {
-    row_group_writer_->Close();
-  }
-
-  if (file_writer_) {
-    file_writer_->Close();
-  }
-}
-
 void StreamWriter::SetDefaultMaxRowGroupSize(int64_t max_size) {
   default_row_group_size_ = max_size;
 }
@@ -59,6 +54,8 @@ void StreamWriter::SetDefaultMaxRowGroupSize(int64_t max_size) {
 void StreamWriter::SetMaxRowGroupSize(int64_t max_size) {
   max_row_group_size_ = max_size;
 }
+
+int StreamWriter::num_columns() const { return nodes_.size(); }
 
 StreamWriter& StreamWriter::operator<<(bool v) {
   CheckColumn(Type::BOOLEAN, ConvertedType::NONE);
@@ -135,6 +132,10 @@ StreamWriter& StreamWriter::operator<<(const char* v) {
   return WriteVariableLength(v, std::strlen(v));
 }
 
+StreamWriter& StreamWriter::operator<<(const std::string& v) {
+  return WriteVariableLength(v.data(), v.size());
+}
+
 StreamWriter& StreamWriter::operator<<(arrow::util::string_view v) {
   return WriteVariableLength(v.data(), v.size());
 }
@@ -145,13 +146,16 @@ StreamWriter& StreamWriter::WriteVariableLength(const char* data_ptr,
 
   auto writer = static_cast<ByteArrayWriter*>(row_group_writer_->column(column_index_++));
 
-  ByteArray ba_value;
+  if (data_ptr != nullptr) {
+    ByteArray ba_value;
 
-  ba_value.ptr = reinterpret_cast<const uint8_t*>(data_ptr);
-  ba_value.len = static_cast<uint32_t>(data_len);
+    ba_value.ptr = reinterpret_cast<const uint8_t*>(data_ptr);
+    ba_value.len = static_cast<uint32_t>(data_len);
 
-  writer->WriteBatch(1, nullptr, nullptr, &ba_value);
-
+    writer->WriteBatch(1, &def_level_one_, &rep_level_zero_, &ba_value);
+  } else {
+    writer->WriteBatch(1, &def_level_zero_, &rep_level_zero_, nullptr);
+  }
   if (max_row_group_size_ > 0) {
     row_group_size_ += writer->EstimatedBufferedValueBytes();
   }
@@ -165,12 +169,14 @@ StreamWriter& StreamWriter::WriteFixedLength(const char* data_ptr, std::size_t d
   auto writer =
       static_cast<FixedLenByteArrayWriter*>(row_group_writer_->column(column_index_++));
 
-  FixedLenByteArray flba_value;
+  if (data_ptr != nullptr) {
+    FixedLenByteArray flba_value;
 
-  flba_value.ptr = reinterpret_cast<const uint8_t*>(data_ptr);
-
-  writer->WriteBatch(1, nullptr, nullptr, &flba_value);
-
+    flba_value.ptr = reinterpret_cast<const uint8_t*>(data_ptr);
+    writer->WriteBatch(1, &def_level_one_, &rep_level_zero_, &flba_value);
+  } else {
+    writer->WriteBatch(1, &def_level_zero_, &rep_level_zero_, nullptr);
+  }
   if (max_row_group_size_ > 0) {
     row_group_size_ += writer->EstimatedBufferedValueBytes();
   }
@@ -208,6 +214,65 @@ void StreamWriter::CheckColumn(Type::type physical_type,
   }
 }
 
+int64_t StreamWriter::SkipColumns(int num_columns_to_skip) {
+  int num_columns_skipped = 0;
+
+  for (; (num_columns_to_skip > num_columns_skipped) &&
+         static_cast<std::size_t>(column_index_) < nodes_.size();
+       ++num_columns_skipped) {
+    const auto& node = nodes_[column_index_];
+
+    if (node->is_required()) {
+      throw ParquetException("Cannot skip column '" + node->name() +
+                             "' as it is required.");
+    }
+    auto writer = row_group_writer_->column(column_index_++);
+
+    switch (writer->type()) {
+      case Type::BOOLEAN:
+        static_cast<BoolWriter*>(writer)->WriteBatch(1, &def_level_zero_,
+                                                     &rep_level_zero_, nullptr);
+        break;
+      case Type::INT32:
+        static_cast<Int32Writer*>(writer)->WriteBatch(1, &def_level_zero_,
+                                                      &rep_level_zero_, nullptr);
+        break;
+      case Type::INT64:
+        static_cast<Int64Writer*>(writer)->WriteBatch(1, &def_level_zero_,
+                                                      &rep_level_zero_, nullptr);
+        break;
+      case Type::BYTE_ARRAY:
+        static_cast<ByteArrayWriter*>(writer)->WriteBatch(1, &def_level_zero_,
+                                                          &rep_level_zero_, nullptr);
+        break;
+      case Type::FIXED_LEN_BYTE_ARRAY:
+        static_cast<FixedLenByteArrayWriter*>(writer)->WriteBatch(
+            1, &def_level_zero_, &rep_level_zero_, nullptr);
+        break;
+      case Type::FLOAT:
+        static_cast<FloatWriter*>(writer)->WriteBatch(1, &def_level_zero_,
+                                                      &rep_level_zero_, nullptr);
+        break;
+      case Type::DOUBLE:
+        static_cast<DoubleWriter*>(writer)->WriteBatch(1, &def_level_zero_,
+                                                       &rep_level_zero_, nullptr);
+        break;
+      case Type::INT96:
+      case Type::UNDEFINED:
+        throw ParquetException("Unexpected type: " + TypeToString(writer->type()));
+        break;
+    }
+  }
+  return num_columns_skipped;
+}
+
+void StreamWriter::SkipOptionalColumn() {
+  if (SkipColumns(1) != 1) {
+    throw ParquetException("Failed to skip optional column at column index " +
+                           std::to_string(column_index_));
+  }
+}
+
 void StreamWriter::EndRow() {
   if (!file_writer_) {
     throw ParquetException("StreamWriter not initialized");
@@ -217,6 +282,7 @@ void StreamWriter::EndRow() {
                            " of " + std::to_string(nodes_.size()) + " columns written");
   }
   column_index_ = 0;
+  ++current_row_;
 
   if (max_row_group_size_ > 0) {
     if (row_group_size_ > max_row_group_size_) {

--- a/cpp/src/parquet/stream_writer.cc
+++ b/cpp/src/parquet/stream_writer.cc
@@ -55,7 +55,7 @@ void StreamWriter::SetMaxRowGroupSize(int64_t max_size) {
   max_row_group_size_ = max_size;
 }
 
-int StreamWriter::num_columns() const { return nodes_.size(); }
+int StreamWriter::num_columns() const { return static_cast<int>(nodes_.size()); }
 
 StreamWriter& StreamWriter::operator<<(bool v) {
   CheckColumn(Type::BOOLEAN, ConvertedType::NONE);

--- a/cpp/src/parquet/stream_writer.h
+++ b/cpp/src/parquet/stream_writer.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "arrow/util/optional.h"
 #include "arrow/util/string_view.h"
 #include "parquet/column_writer.h"
 #include "parquet/file_writer.h"
@@ -45,10 +46,18 @@ namespace parquet {
 /// user can create new row groups by calling the EndRowGroup()
 /// function or using the EndRowGroup output manipulator.
 ///
-/// Currently there is no support for optional or repeated fields.
+/// Required and optional fields are supported:
+/// - Required fields are written using operator<<(T)
+/// - Optional fields can be written as required fields (when there is
+///   a value to write) and with operator<<(arrow::util::optional<T>)
+///   when there may or may not be a value to write.
+/// Currently there is no support for repeated fields.
 ///
 class PARQUET_EXPORT StreamWriter {
  public:
+  template <typename T>
+  using optional = arrow::util::optional<T>;
+
   // N.B. Default constructed objects are not usable.  This
   //      constructor is provided so that the object may be move
   //      assigned afterwards.
@@ -56,11 +65,17 @@ class PARQUET_EXPORT StreamWriter {
 
   explicit StreamWriter(std::unique_ptr<ParquetFileWriter> writer);
 
-  ~StreamWriter();
+  ~StreamWriter() = default;
 
   static void SetDefaultMaxRowGroupSize(int64_t max_size);
 
   void SetMaxRowGroupSize(int64_t max_size);
+
+  int current_column() const { return column_index_; }
+
+  int64_t current_row() const { return current_row_; }
+
+  int num_columns() const;
 
   // Moving is possible.
   StreamWriter(StreamWriter&&) = default;
@@ -70,6 +85,8 @@ class PARQUET_EXPORT StreamWriter {
   StreamWriter(const StreamWriter&) = delete;
   StreamWriter& operator=(const StreamWriter&) = delete;
 
+  /// \brief Output operators for required fields.
+  /// These can also be used for optional fields when a value must be set.
   StreamWriter& operator<<(bool v);
 
   StreamWriter& operator<<(int8_t v);
@@ -112,7 +129,7 @@ class PARQUET_EXPORT StreamWriter {
     std::size_t size{0};
   };
 
-  // Output operators for fixed length strings.
+  /// \brief Output operators for fixed length strings.
   template <int N>
   StreamWriter& operator<<(const char (&v)[N]) {
     return WriteFixedLength(v, N);
@@ -123,14 +140,33 @@ class PARQUET_EXPORT StreamWriter {
   }
   StreamWriter& operator<<(FixedStringView v);
 
-  // Output operators for variable length strings.
+  /// \brief Output operators for variable length strings.
   StreamWriter& operator<<(const char* v);
+  StreamWriter& operator<<(const std::string& v);
   StreamWriter& operator<<(arrow::util::string_view v);
 
-  // Terminate the current row and advance to next one.
+  /// \brief Output operator for optional fields.
+  template <typename T>
+  StreamWriter& operator<<(const optional<T>& v) {
+    if (v) {
+      return operator<<(*v);
+    }
+    SkipOptionalColumn();
+    return *this;
+  }
+
+  /// \brief Skip the next N columns of optional data.
+  /// \throws ParquetException if there is an attempt to skip any
+  /// required column.
+  /// \return Number of columns actually skipped.
+  int64_t SkipColumns(int num_columns_to_skip);
+
+  /// \brief Terminate the current row and advance to next one.
+  /// \throws ParquetException if all columns in the row were not
+  /// written or skipped.
   void EndRow();
 
-  // Terminate the current row group and create new one.
+  /// \brief Terminate the current row group and create new one.
   void EndRowGroup();
 
  protected:
@@ -138,7 +174,7 @@ class PARQUET_EXPORT StreamWriter {
   StreamWriter& Write(const T v) {
     auto writer = static_cast<WriterType*>(row_group_writer_->column(column_index_++));
 
-    writer->WriteBatch(1, NULLPTR, NULLPTR, &v);
+    writer->WriteBatch(1, &def_level_one_, &rep_level_zero_, &v);
 
     if (max_row_group_size_ > 0) {
       row_group_size_ += writer->EstimatedBufferedValueBytes();
@@ -153,6 +189,8 @@ class PARQUET_EXPORT StreamWriter {
   void CheckColumn(Type::type physical_type, ConvertedType::type converted_type,
                    int length = -1);
 
+  void SkipOptionalColumn();
+
  private:
   using node_ptr_type = std::shared_ptr<schema::PrimitiveNode>;
 
@@ -160,12 +198,19 @@ class PARQUET_EXPORT StreamWriter {
     void operator()(void*) {}
   };
 
+  int32_t column_index_{0};
+  int64_t current_row_{0};
   int64_t row_group_size_{0};
   int64_t max_row_group_size_{default_row_group_size_};
-  int32_t column_index_{0};
+
   std::unique_ptr<ParquetFileWriter> file_writer_;
   std::unique_ptr<RowGroupWriter, null_deleter> row_group_writer_;
   std::vector<node_ptr_type> nodes_;
+
+  static const int16_t def_level_zero_;
+  static const int16_t def_level_one_;
+  static const int16_t rep_level_zero_;
+  static const int16_t rep_level_one_;
 
   static int64_t default_row_group_size_;
 };

--- a/cpp/src/parquet/stream_writer.h
+++ b/cpp/src/parquet/stream_writer.h
@@ -48,9 +48,16 @@ namespace parquet {
 ///
 /// Required and optional fields are supported:
 /// - Required fields are written using operator<<(T)
-/// - Optional fields can be written as required fields (when there is
-///   a value to write) and with operator<<(arrow::util::optional<T>)
-///   when there may or may not be a value to write.
+/// - Optional fields are written using
+///   operator<<(arrow::util::optional<T>).
+///
+/// Note that operator<<(T) can be used to write optional fields.
+///
+/// Similarly, operator<<(arrow::util::optional<T>) can be used to
+/// write required fields.  However if the optional parameter does not
+/// have a value (i.e. it is nullopt) then a ParquetException will be
+/// raised.
+///
 /// Currently there is no support for repeated fields.
 ///
 class PARQUET_EXPORT StreamWriter {

--- a/cpp/src/parquet/stream_writer_test.cc
+++ b/cpp/src/parquet/stream_writer_test.cc
@@ -23,73 +23,61 @@
 #include <memory>
 #include <utility>
 
-#include "arrow/io/api.h"
 #include "parquet/exception.h"
 
 namespace parquet {
 namespace test {
 
+template <typename T>
+using optional = StreamWriter::optional<T>;
+
+using char4_array_type = std::array<char, 4>;
+
 class TestStreamWriter : public ::testing::Test {
  protected:
   void SetUp() {
-    parquet::WriterProperties::Builder builder;
-
-    builder.compression(parquet::Compression::BROTLI);
-
-    auto file_writer = parquet::ParquetFileWriter::Open(CreateOutputStream(), GetSchema(),
-                                                        builder.build());
-
-    writer_ = StreamWriter{std::move(file_writer)};
+    writer_ = StreamWriter{ParquetFileWriter::Open(CreateOutputStream(), GetSchema())};
   }
 
   void TearDown() { writer_ = StreamWriter{}; }
 
-  std::shared_ptr<parquet::schema::GroupNode> GetSchema() {
-    parquet::schema::NodeVector fields;
+  std::shared_ptr<schema::GroupNode> GetSchema() {
+    schema::NodeVector fields;
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "bool_field", parquet::Repetition::REQUIRED, parquet::Type::BOOLEAN,
-        parquet::ConvertedType::NONE));
+    fields.push_back(schema::PrimitiveNode::Make("bool_field", Repetition::REQUIRED,
+                                                 Type::BOOLEAN, ConvertedType::NONE));
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "string_field", parquet::Repetition::REQUIRED, parquet::Type::BYTE_ARRAY,
-        parquet::ConvertedType::UTF8));
+    fields.push_back(schema::PrimitiveNode::Make("string_field", Repetition::REQUIRED,
+                                                 Type::BYTE_ARRAY, ConvertedType::UTF8));
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "char_field", parquet::Repetition::REQUIRED, parquet::Type::FIXED_LEN_BYTE_ARRAY,
-        parquet::ConvertedType::NONE, 1));
+    fields.push_back(schema::PrimitiveNode::Make("char_field", Repetition::REQUIRED,
+                                                 Type::FIXED_LEN_BYTE_ARRAY,
+                                                 ConvertedType::NONE, 1));
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "char[4]_field", parquet::Repetition::REQUIRED,
-        parquet::Type::FIXED_LEN_BYTE_ARRAY, parquet::ConvertedType::NONE, 4));
+    fields.push_back(schema::PrimitiveNode::Make("char[4]_field", Repetition::REQUIRED,
+                                                 Type::FIXED_LEN_BYTE_ARRAY,
+                                                 ConvertedType::NONE, 4));
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "int8_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
-        parquet::ConvertedType::INT_8));
+    fields.push_back(schema::PrimitiveNode::Make("int8_field", Repetition::REQUIRED,
+                                                 Type::INT32, ConvertedType::INT_8));
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "uint16_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
-        parquet::ConvertedType::UINT_16));
+    fields.push_back(schema::PrimitiveNode::Make("uint16_field", Repetition::REQUIRED,
+                                                 Type::INT32, ConvertedType::UINT_16));
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "int32_field", parquet::Repetition::REQUIRED, parquet::Type::INT32,
-        parquet::ConvertedType::INT_32));
+    fields.push_back(schema::PrimitiveNode::Make("int32_field", Repetition::REQUIRED,
+                                                 Type::INT32, ConvertedType::INT_32));
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "uint64_field", parquet::Repetition::REQUIRED, parquet::Type::INT64,
-        parquet::ConvertedType::UINT_64));
+    fields.push_back(schema::PrimitiveNode::Make("uint64_field", Repetition::REQUIRED,
+                                                 Type::INT64, ConvertedType::UINT_64));
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "float_field", parquet::Repetition::REQUIRED, parquet::Type::FLOAT,
-        parquet::ConvertedType::NONE));
+    fields.push_back(schema::PrimitiveNode::Make("float_field", Repetition::REQUIRED,
+                                                 Type::FLOAT, ConvertedType::NONE));
 
-    fields.push_back(parquet::schema::PrimitiveNode::Make(
-        "double_field", parquet::Repetition::REQUIRED, parquet::Type::DOUBLE,
-        parquet::ConvertedType::NONE));
+    fields.push_back(schema::PrimitiveNode::Make("double_field", Repetition::REQUIRED,
+                                                 Type::DOUBLE, ConvertedType::NONE));
 
-    return std::static_pointer_cast<parquet::schema::GroupNode>(
-        parquet::schema::GroupNode::Make("schema", parquet::Repetition::REQUIRED,
-                                         fields));
+    return std::static_pointer_cast<schema::GroupNode>(
+        schema::GroupNode::Make("schema", Repetition::REQUIRED, fields));
   }
 
   StreamWriter writer_;
@@ -98,11 +86,16 @@ class TestStreamWriter : public ::testing::Test {
 TEST_F(TestStreamWriter, DefaultConstructed) {
   StreamWriter os;
 
-  // N.B. Default constructor objects are not usable.
+  // Default constructor objects are not usable for writing data.
   ASSERT_THROW(os << 4, ParquetException);
   ASSERT_THROW(os << "bad", ParquetException);
   ASSERT_THROW(os << EndRow, ParquetException);
   ASSERT_THROW(os << EndRowGroup, ParquetException);
+
+  ASSERT_EQ(0, os.current_column());
+  ASSERT_EQ(0, os.current_row());
+  ASSERT_EQ(0, os.num_columns());
+  ASSERT_EQ(0, os.SkipColumns(10));
 }
 
 TEST_F(TestStreamWriter, TypeChecking) {
@@ -111,10 +104,12 @@ TEST_F(TestStreamWriter, TypeChecking) {
   std::array<char, 5> char5_array = {'T', 'E', 'S', 'T', '2'};
 
   // Required type: bool
+  ASSERT_EQ(0, writer_.current_column());
   ASSERT_THROW(writer_ << 4.5, ParquetException);
   ASSERT_NO_THROW(writer_ << true);
 
   // Required type: Variable length string.
+  ASSERT_EQ(1, writer_.current_column());
   ASSERT_THROW(writer_ << 5, ParquetException);
   ASSERT_THROW(writer_ << char3_array, ParquetException);
   ASSERT_THROW(writer_ << char4_array, ParquetException);
@@ -122,37 +117,93 @@ TEST_F(TestStreamWriter, TypeChecking) {
   ASSERT_NO_THROW(writer_ << "ok");
 
   // Required type: A char.
+  ASSERT_EQ(2, writer_.current_column());
   ASSERT_THROW(writer_ << "no good", ParquetException);
   ASSERT_NO_THROW(writer_ << 'K');
 
   // Required type: Fixed string of length 4
+  ASSERT_EQ(3, writer_.current_column());
   ASSERT_THROW(writer_ << "bad", ParquetException);
   ASSERT_THROW(writer_ << char3_array, ParquetException);
   ASSERT_THROW(writer_ << char5_array, ParquetException);
   ASSERT_NO_THROW(writer_ << char4_array);
 
   // Required type: int8_t
+  ASSERT_EQ(4, writer_.current_column());
   ASSERT_THROW(writer_ << false, ParquetException);
   ASSERT_NO_THROW(writer_ << int8_t(51));
 
   // Required type: uint16_t
+  ASSERT_EQ(5, writer_.current_column());
   ASSERT_THROW(writer_ << int16_t(15), ParquetException);
   ASSERT_NO_THROW(writer_ << uint16_t(15));
 
   // Required type: int32_t
+  ASSERT_EQ(6, writer_.current_column());
   ASSERT_THROW(writer_ << int16_t(99), ParquetException);
   ASSERT_NO_THROW(writer_ << int32_t(329487));
 
   // Required type: uint64_t
+  ASSERT_EQ(7, writer_.current_column());
   ASSERT_THROW(writer_ << uint32_t(9832423), ParquetException);
   ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
 
   // Required type: float
+  ASSERT_EQ(8, writer_.current_column());
   ASSERT_THROW(writer_ << 5.4, ParquetException);
   ASSERT_NO_THROW(writer_ << 5.4f);
 
   // Required type: double
+  ASSERT_EQ(9, writer_.current_column());
   ASSERT_THROW(writer_ << 5.4f, ParquetException);
+  ASSERT_NO_THROW(writer_ << 5.4);
+
+  ASSERT_EQ(0, writer_.current_row());
+  ASSERT_NO_THROW(writer_ << EndRow);
+  ASSERT_EQ(1, writer_.current_row());
+}
+
+TEST_F(TestStreamWriter, RequiredFieldChecking) {
+  char4_array_type char4_array = {'T', 'E', 'S', 'T'};
+
+  // Required field of type: bool
+  ASSERT_THROW(writer_ << optional<bool>(), ParquetException);
+  ASSERT_NO_THROW(writer_ << true);
+
+  // Required field of type: Variable length string.
+  ASSERT_THROW(writer_ << optional<std::string>(), ParquetException);
+  ASSERT_NO_THROW(writer_ << std::string("ok"));
+
+  // Required field of type: A char.
+  ASSERT_THROW(writer_ << optional<char>(), ParquetException);
+  ASSERT_NO_THROW(writer_ << 'K');
+
+  // Required field of type: Fixed string of length 4
+  ASSERT_THROW(writer_ << optional<char4_array_type>(), ParquetException);
+  ASSERT_NO_THROW(writer_ << char4_array);
+
+  // Required field of type: int8_t
+  ASSERT_THROW(writer_ << optional<int8_t>(), ParquetException);
+  ASSERT_NO_THROW(writer_ << int8_t(51));
+
+  // Required field of type: uint16_t
+  ASSERT_THROW(writer_ << optional<uint16_t>(), ParquetException);
+  ASSERT_NO_THROW(writer_ << uint16_t(15));
+
+  // Required field of type: int32_t
+  ASSERT_THROW(writer_ << optional<int32_t>(), ParquetException);
+  ASSERT_NO_THROW(writer_ << int32_t(329487));
+
+  // Required field of type: uint64_t
+  ASSERT_THROW(writer_ << optional<uint64_t>(), ParquetException);
+  ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
+
+  // Required field of type: float
+  ASSERT_THROW(writer_ << optional<float>(), ParquetException);
+  ASSERT_NO_THROW(writer_ << 5.4f);
+
+  // Required field of type: double
+  ASSERT_THROW(writer_ << optional<double>(), ParquetException);
   ASSERT_NO_THROW(writer_ << 5.4);
 
   ASSERT_NO_THROW(writer_ << EndRow);
@@ -160,23 +211,32 @@ TEST_F(TestStreamWriter, TypeChecking) {
 
 TEST_F(TestStreamWriter, EndRow) {
   // Attempt #1 to end row prematurely.
+  ASSERT_EQ(0, writer_.current_row());
   ASSERT_THROW(writer_ << EndRow, ParquetException);
+  ASSERT_EQ(0, writer_.current_row());
+
   ASSERT_NO_THROW(writer_ << true);
   ASSERT_NO_THROW(writer_ << "eschatology");
   ASSERT_NO_THROW(writer_ << 'z');
   ASSERT_NO_THROW(writer_ << StreamWriter::FixedStringView("Test", 4));
   ASSERT_NO_THROW(writer_ << int8_t(51));
   ASSERT_NO_THROW(writer_ << uint16_t(15));
+
   // Attempt #2 to end row prematurely.
   ASSERT_THROW(writer_ << EndRow, ParquetException);
+  ASSERT_EQ(0, writer_.current_row());
+
   ASSERT_NO_THROW(writer_ << int32_t(329487));
   ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
   ASSERT_NO_THROW(writer_ << 25.4f);
   ASSERT_NO_THROW(writer_ << 3.3424);
   // Correct use of end row after all fields have been output.
   ASSERT_NO_THROW(writer_ << EndRow);
+  ASSERT_EQ(1, writer_.current_row());
+
   // Attempt #3 to end row prematurely.
   ASSERT_THROW(writer_ << EndRow, ParquetException);
+  ASSERT_EQ(1, writer_.current_row());
 }
 
 TEST_F(TestStreamWriter, EndRowGroup) {
@@ -221,6 +281,115 @@ TEST_F(TestStreamWriter, EndRowGroup) {
   ASSERT_NO_THROW(writer_ << EndRowGroup);
   ASSERT_NO_THROW(writer_ << EndRowGroup);
   ASSERT_NO_THROW(writer_ << EndRowGroup);
+}
+
+TEST_F(TestStreamWriter, SkipColumns) {
+  ASSERT_EQ(0, writer_.SkipColumns(0));
+  ASSERT_THROW(writer_.SkipColumns(2), ParquetException);
+  writer_ << true << std::string("Cannot skip mandatory columns");
+  ASSERT_THROW(writer_.SkipColumns(1), ParquetException);
+  writer_ << 'x' << std::array<char, 4>{'A', 'B', 'C', 'D'} << int8_t(2) << uint16_t(3)
+          << int32_t(4) << uint64_t(5) << 6.0f << 7.0;
+  writer_ << EndRow;
+}
+
+class TestOptionalFields : public ::testing::Test {
+ protected:
+  void SetUp() {
+    writer_ = StreamWriter{ParquetFileWriter::Open(CreateOutputStream(), GetSchema())};
+  }
+
+  void TearDown() { writer_ = StreamWriter{}; }
+
+  std::shared_ptr<schema::GroupNode> GetSchema() {
+    schema::NodeVector fields;
+
+    fields.push_back(schema::PrimitiveNode::Make("bool_field", Repetition::OPTIONAL,
+                                                 Type::BOOLEAN, ConvertedType::NONE));
+
+    fields.push_back(schema::PrimitiveNode::Make("string_field", Repetition::OPTIONAL,
+                                                 Type::BYTE_ARRAY, ConvertedType::UTF8));
+
+    fields.push_back(schema::PrimitiveNode::Make("char_field", Repetition::OPTIONAL,
+                                                 Type::FIXED_LEN_BYTE_ARRAY,
+                                                 ConvertedType::NONE, 1));
+
+    fields.push_back(schema::PrimitiveNode::Make("char[4]_field", Repetition::OPTIONAL,
+                                                 Type::FIXED_LEN_BYTE_ARRAY,
+                                                 ConvertedType::NONE, 4));
+
+    fields.push_back(schema::PrimitiveNode::Make("int8_field", Repetition::OPTIONAL,
+                                                 Type::INT32, ConvertedType::INT_8));
+
+    fields.push_back(schema::PrimitiveNode::Make("uint16_field", Repetition::OPTIONAL,
+                                                 Type::INT32, ConvertedType::UINT_16));
+
+    fields.push_back(schema::PrimitiveNode::Make("int32_field", Repetition::OPTIONAL,
+                                                 Type::INT32, ConvertedType::INT_32));
+
+    fields.push_back(schema::PrimitiveNode::Make("uint64_field", Repetition::OPTIONAL,
+                                                 Type::INT64, ConvertedType::UINT_64));
+
+    fields.push_back(schema::PrimitiveNode::Make("float_field", Repetition::OPTIONAL,
+                                                 Type::FLOAT, ConvertedType::NONE));
+
+    fields.push_back(schema::PrimitiveNode::Make("double_field", Repetition::OPTIONAL,
+                                                 Type::DOUBLE, ConvertedType::NONE));
+
+    return std::static_pointer_cast<schema::GroupNode>(
+        schema::GroupNode::Make("schema", Repetition::REQUIRED, fields));
+  }
+
+  StreamWriter writer_;
+};
+
+TEST_F(TestOptionalFields, Output_operator_with_optional_T) {
+  for (auto i = 0; i < 100; ++i) {
+    // Write optional fields using operator<<(optional<T>).  Writing
+    // of a value is skipped every 9 rows by using a optional<T>
+    // object without a value.
+
+    if (i % 9 == 0) {
+      writer_ << optional<bool>() << optional<std::string>() << optional<char>()
+              << optional<char4_array_type>() << optional<int8_t>()
+              << optional<uint16_t>() << optional<int32_t>() << optional<uint64_t>()
+              << optional<float>() << optional<double>();
+    } else {
+      writer_ << bool(i & 1) << optional<std::string>("#" + std::to_string(i))
+              << optional<char>('A' + i % 26)
+              << optional<char4_array_type>{{'F', 'O', 'O', 0}} << optional<int8_t>(i)
+              << optional<uint16_t>(0xffff - i) << optional<int32_t>(0x7fffffff - 3 * i)
+              << optional<uint64_t>((1ull << 60) + i) << optional<float>(5.4f * i)
+              << optional<double>(5.1322e6 * i);
+    }
+    ASSERT_NO_THROW(writer_ << EndRow);
+  }
+}
+
+TEST_F(TestOptionalFields, Output_operator_T_and_SkipColumns) {
+  auto constexpr num_rows = 100;
+
+  ASSERT_EQ(0, writer_.current_row());
+
+  for (auto i = 0; i < num_rows; ++i) {
+    // Write optional fields using standard operator<<(T).  Writing of
+    // a value is skipped every 9 rows by using SkipColumns().
+
+    ASSERT_EQ(0, writer_.current_column());
+    ASSERT_EQ(i, writer_.current_row());
+
+    if (i % 9 == 0) {
+      ASSERT_EQ(writer_.num_columns(), writer_.SkipColumns(writer_.num_columns() + 99));
+    } else {
+      writer_ << bool(i & 1) << std::string("ok") << char('A' + i % 26)
+              << char4_array_type{{'S', 'K', 'I', 'P'}} << int8_t(i)
+              << uint16_t(0xffff - i) << int32_t(0x7fffffff - 3 * i)
+              << uint64_t((1ull << 60) + i) << 5.4f * i << 5.1322e6 * i;
+    }
+    ASSERT_EQ(writer_.num_columns(), writer_.current_column());
+    ASSERT_NO_THROW(writer_ << EndRow);
+  }
+  ASSERT_EQ(num_rows, writer_.current_row());
 }
 
 }  // namespace test

--- a/cpp/src/parquet/stream_writer_test.cc
+++ b/cpp/src/parquet/stream_writer_test.cc
@@ -343,7 +343,7 @@ class TestOptionalFields : public ::testing::Test {
   StreamWriter writer_;
 };
 
-TEST_F(TestOptionalFields, Output_operator_with_optional_T) {
+TEST_F(TestOptionalFields, OutputOperatorWithOptionalT) {
   for (int i = 0; i < 100; ++i) {
     // Write optional fields using operator<<(optional<T>).  Writing
     // of a value is skipped every 9 rows by using a optional<T>
@@ -366,7 +366,7 @@ TEST_F(TestOptionalFields, Output_operator_with_optional_T) {
   }
 }
 
-TEST_F(TestOptionalFields, Output_operator_T_and_SkipColumns) {
+TEST_F(TestOptionalFields, OutputOperatorTAndSkipColumns) {
   constexpr int num_rows = 100;
 
   EXPECT_EQ(0, writer_.current_row());

--- a/cpp/src/parquet/stream_writer_test.cc
+++ b/cpp/src/parquet/stream_writer_test.cc
@@ -87,15 +87,15 @@ TEST_F(TestStreamWriter, DefaultConstructed) {
   StreamWriter os;
 
   // Default constructor objects are not usable for writing data.
-  ASSERT_THROW(os << 4, ParquetException);
-  ASSERT_THROW(os << "bad", ParquetException);
-  ASSERT_THROW(os << EndRow, ParquetException);
-  ASSERT_THROW(os << EndRowGroup, ParquetException);
+  EXPECT_THROW(os << 4, ParquetException);
+  EXPECT_THROW(os << "bad", ParquetException);
+  EXPECT_THROW(os << EndRow, ParquetException);
+  EXPECT_THROW(os << EndRowGroup, ParquetException);
 
-  ASSERT_EQ(0, os.current_column());
-  ASSERT_EQ(0, os.current_row());
-  ASSERT_EQ(0, os.num_columns());
-  ASSERT_EQ(0, os.SkipColumns(10));
+  EXPECT_EQ(0, os.current_column());
+  EXPECT_EQ(0, os.current_row());
+  EXPECT_EQ(0, os.num_columns());
+  EXPECT_EQ(0, os.SkipColumns(10));
 }
 
 TEST_F(TestStreamWriter, TypeChecking) {
@@ -104,155 +104,155 @@ TEST_F(TestStreamWriter, TypeChecking) {
   std::array<char, 5> char5_array = {'T', 'E', 'S', 'T', '2'};
 
   // Required type: bool
-  ASSERT_EQ(0, writer_.current_column());
-  ASSERT_THROW(writer_ << 4.5, ParquetException);
-  ASSERT_NO_THROW(writer_ << true);
+  EXPECT_EQ(0, writer_.current_column());
+  EXPECT_THROW(writer_ << 4.5, ParquetException);
+  EXPECT_NO_THROW(writer_ << true);
 
   // Required type: Variable length string.
-  ASSERT_EQ(1, writer_.current_column());
-  ASSERT_THROW(writer_ << 5, ParquetException);
-  ASSERT_THROW(writer_ << char3_array, ParquetException);
-  ASSERT_THROW(writer_ << char4_array, ParquetException);
-  ASSERT_THROW(writer_ << char5_array, ParquetException);
-  ASSERT_NO_THROW(writer_ << "ok");
+  EXPECT_EQ(1, writer_.current_column());
+  EXPECT_THROW(writer_ << 5, ParquetException);
+  EXPECT_THROW(writer_ << char3_array, ParquetException);
+  EXPECT_THROW(writer_ << char4_array, ParquetException);
+  EXPECT_THROW(writer_ << char5_array, ParquetException);
+  EXPECT_NO_THROW(writer_ << "ok");
 
   // Required type: A char.
-  ASSERT_EQ(2, writer_.current_column());
-  ASSERT_THROW(writer_ << "no good", ParquetException);
-  ASSERT_NO_THROW(writer_ << 'K');
+  EXPECT_EQ(2, writer_.current_column());
+  EXPECT_THROW(writer_ << "no good", ParquetException);
+  EXPECT_NO_THROW(writer_ << 'K');
 
   // Required type: Fixed string of length 4
-  ASSERT_EQ(3, writer_.current_column());
-  ASSERT_THROW(writer_ << "bad", ParquetException);
-  ASSERT_THROW(writer_ << char3_array, ParquetException);
-  ASSERT_THROW(writer_ << char5_array, ParquetException);
-  ASSERT_NO_THROW(writer_ << char4_array);
+  EXPECT_EQ(3, writer_.current_column());
+  EXPECT_THROW(writer_ << "bad", ParquetException);
+  EXPECT_THROW(writer_ << char3_array, ParquetException);
+  EXPECT_THROW(writer_ << char5_array, ParquetException);
+  EXPECT_NO_THROW(writer_ << char4_array);
 
   // Required type: int8_t
-  ASSERT_EQ(4, writer_.current_column());
-  ASSERT_THROW(writer_ << false, ParquetException);
-  ASSERT_NO_THROW(writer_ << int8_t(51));
+  EXPECT_EQ(4, writer_.current_column());
+  EXPECT_THROW(writer_ << false, ParquetException);
+  EXPECT_NO_THROW(writer_ << int8_t(51));
 
   // Required type: uint16_t
-  ASSERT_EQ(5, writer_.current_column());
-  ASSERT_THROW(writer_ << int16_t(15), ParquetException);
-  ASSERT_NO_THROW(writer_ << uint16_t(15));
+  EXPECT_EQ(5, writer_.current_column());
+  EXPECT_THROW(writer_ << int16_t(15), ParquetException);
+  EXPECT_NO_THROW(writer_ << uint16_t(15));
 
   // Required type: int32_t
-  ASSERT_EQ(6, writer_.current_column());
-  ASSERT_THROW(writer_ << int16_t(99), ParquetException);
-  ASSERT_NO_THROW(writer_ << int32_t(329487));
+  EXPECT_EQ(6, writer_.current_column());
+  EXPECT_THROW(writer_ << int16_t(99), ParquetException);
+  EXPECT_NO_THROW(writer_ << int32_t(329487));
 
   // Required type: uint64_t
-  ASSERT_EQ(7, writer_.current_column());
-  ASSERT_THROW(writer_ << uint32_t(9832423), ParquetException);
-  ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
+  EXPECT_EQ(7, writer_.current_column());
+  EXPECT_THROW(writer_ << uint32_t(9832423), ParquetException);
+  EXPECT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
 
   // Required type: float
-  ASSERT_EQ(8, writer_.current_column());
-  ASSERT_THROW(writer_ << 5.4, ParquetException);
-  ASSERT_NO_THROW(writer_ << 5.4f);
+  EXPECT_EQ(8, writer_.current_column());
+  EXPECT_THROW(writer_ << 5.4, ParquetException);
+  EXPECT_NO_THROW(writer_ << 5.4f);
 
   // Required type: double
-  ASSERT_EQ(9, writer_.current_column());
-  ASSERT_THROW(writer_ << 5.4f, ParquetException);
-  ASSERT_NO_THROW(writer_ << 5.4);
+  EXPECT_EQ(9, writer_.current_column());
+  EXPECT_THROW(writer_ << 5.4f, ParquetException);
+  EXPECT_NO_THROW(writer_ << 5.4);
 
-  ASSERT_EQ(0, writer_.current_row());
-  ASSERT_NO_THROW(writer_ << EndRow);
-  ASSERT_EQ(1, writer_.current_row());
+  EXPECT_EQ(0, writer_.current_row());
+  EXPECT_NO_THROW(writer_ << EndRow);
+  EXPECT_EQ(1, writer_.current_row());
 }
 
 TEST_F(TestStreamWriter, RequiredFieldChecking) {
   char4_array_type char4_array = {'T', 'E', 'S', 'T'};
 
   // Required field of type: bool
-  ASSERT_THROW(writer_ << optional<bool>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << true);
+  EXPECT_THROW(writer_ << optional<bool>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << true);
 
   // Required field of type: Variable length string.
-  ASSERT_THROW(writer_ << optional<std::string>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << std::string("ok"));
+  EXPECT_THROW(writer_ << optional<std::string>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << std::string("ok"));
 
   // Required field of type: A char.
-  ASSERT_THROW(writer_ << optional<char>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << 'K');
+  EXPECT_THROW(writer_ << optional<char>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << 'K');
 
   // Required field of type: Fixed string of length 4
-  ASSERT_THROW(writer_ << optional<char4_array_type>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << char4_array);
+  EXPECT_THROW(writer_ << optional<char4_array_type>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << char4_array);
 
   // Required field of type: int8_t
-  ASSERT_THROW(writer_ << optional<int8_t>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << int8_t(51));
+  EXPECT_THROW(writer_ << optional<int8_t>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << int8_t(51));
 
   // Required field of type: uint16_t
-  ASSERT_THROW(writer_ << optional<uint16_t>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << uint16_t(15));
+  EXPECT_THROW(writer_ << optional<uint16_t>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << uint16_t(15));
 
   // Required field of type: int32_t
-  ASSERT_THROW(writer_ << optional<int32_t>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << int32_t(329487));
+  EXPECT_THROW(writer_ << optional<int32_t>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << int32_t(329487));
 
   // Required field of type: uint64_t
-  ASSERT_THROW(writer_ << optional<uint64_t>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
+  EXPECT_THROW(writer_ << optional<uint64_t>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
 
   // Required field of type: float
-  ASSERT_THROW(writer_ << optional<float>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << 5.4f);
+  EXPECT_THROW(writer_ << optional<float>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << 5.4f);
 
   // Required field of type: double
-  ASSERT_THROW(writer_ << optional<double>(), ParquetException);
-  ASSERT_NO_THROW(writer_ << 5.4);
+  EXPECT_THROW(writer_ << optional<double>(), ParquetException);
+  EXPECT_NO_THROW(writer_ << 5.4);
 
-  ASSERT_NO_THROW(writer_ << EndRow);
+  EXPECT_NO_THROW(writer_ << EndRow);
 }
 
 TEST_F(TestStreamWriter, EndRow) {
   // Attempt #1 to end row prematurely.
-  ASSERT_EQ(0, writer_.current_row());
-  ASSERT_THROW(writer_ << EndRow, ParquetException);
-  ASSERT_EQ(0, writer_.current_row());
+  EXPECT_EQ(0, writer_.current_row());
+  EXPECT_THROW(writer_ << EndRow, ParquetException);
+  EXPECT_EQ(0, writer_.current_row());
 
-  ASSERT_NO_THROW(writer_ << true);
-  ASSERT_NO_THROW(writer_ << "eschatology");
-  ASSERT_NO_THROW(writer_ << 'z');
-  ASSERT_NO_THROW(writer_ << StreamWriter::FixedStringView("Test", 4));
-  ASSERT_NO_THROW(writer_ << int8_t(51));
-  ASSERT_NO_THROW(writer_ << uint16_t(15));
+  EXPECT_NO_THROW(writer_ << true);
+  EXPECT_NO_THROW(writer_ << "eschatology");
+  EXPECT_NO_THROW(writer_ << 'z');
+  EXPECT_NO_THROW(writer_ << StreamWriter::FixedStringView("Test", 4));
+  EXPECT_NO_THROW(writer_ << int8_t(51));
+  EXPECT_NO_THROW(writer_ << uint16_t(15));
 
   // Attempt #2 to end row prematurely.
-  ASSERT_THROW(writer_ << EndRow, ParquetException);
-  ASSERT_EQ(0, writer_.current_row());
+  EXPECT_THROW(writer_ << EndRow, ParquetException);
+  EXPECT_EQ(0, writer_.current_row());
 
-  ASSERT_NO_THROW(writer_ << int32_t(329487));
-  ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
-  ASSERT_NO_THROW(writer_ << 25.4f);
-  ASSERT_NO_THROW(writer_ << 3.3424);
+  EXPECT_NO_THROW(writer_ << int32_t(329487));
+  EXPECT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
+  EXPECT_NO_THROW(writer_ << 25.4f);
+  EXPECT_NO_THROW(writer_ << 3.3424);
   // Correct use of end row after all fields have been output.
-  ASSERT_NO_THROW(writer_ << EndRow);
-  ASSERT_EQ(1, writer_.current_row());
+  EXPECT_NO_THROW(writer_ << EndRow);
+  EXPECT_EQ(1, writer_.current_row());
 
   // Attempt #3 to end row prematurely.
-  ASSERT_THROW(writer_ << EndRow, ParquetException);
-  ASSERT_EQ(1, writer_.current_row());
+  EXPECT_THROW(writer_ << EndRow, ParquetException);
+  EXPECT_EQ(1, writer_.current_row());
 }
 
 TEST_F(TestStreamWriter, EndRowGroup) {
   writer_.SetMaxRowGroupSize(0);
 
   // It's ok to end a row group multiple times.
-  ASSERT_NO_THROW(writer_ << EndRowGroup);
-  ASSERT_NO_THROW(writer_ << EndRowGroup);
-  ASSERT_NO_THROW(writer_ << EndRowGroup);
+  EXPECT_NO_THROW(writer_ << EndRowGroup);
+  EXPECT_NO_THROW(writer_ << EndRowGroup);
+  EXPECT_NO_THROW(writer_ << EndRowGroup);
 
   std::array<char, 4> char_array = {'A', 'B', 'C', 'D'};
 
-  for (auto i = 0; i < 20000; ++i) {
-    ASSERT_NO_THROW(writer_ << bool(i & 1));
-    ASSERT_NO_THROW(writer_ << std::to_string(i));
-    ASSERT_NO_THROW(writer_ << char(i % 26 + 'A'));
+  for (int i = 0; i < 20000; ++i) {
+    EXPECT_NO_THROW(writer_ << bool(i & 1)) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << std::to_string(i)) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << char(i % 26 + 'A')) << "index: " << i;
     // Rotate letters.
     {
       char tmp{char_array[0]};
@@ -261,33 +261,33 @@ TEST_F(TestStreamWriter, EndRowGroup) {
       char_array[2] = char_array[1];
       char_array[1] = tmp;
     }
-    ASSERT_NO_THROW(writer_ << char_array);
-    ASSERT_NO_THROW(writer_ << int8_t(i & 0xff));
-    ASSERT_NO_THROW(writer_ << uint16_t(7 * i));
-    ASSERT_NO_THROW(writer_ << int32_t((1 << 30) - i * i));
-    ASSERT_NO_THROW(writer_ << uint64_t((1ull << 60) - i * i));
-    ASSERT_NO_THROW(writer_ << 42325.4f / float(i + 1));
-    ASSERT_NO_THROW(writer_ << 3.2342e5 / double(i + 1));
-    ASSERT_NO_THROW(writer_ << EndRow);
+    EXPECT_NO_THROW(writer_ << char_array) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << int8_t(i & 0xff)) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << uint16_t(7 * i)) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << int32_t((1 << 30) - i * i)) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << uint64_t((1ull << 60) - i * i)) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << 42325.4f / float(i + 1)) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << 3.2342e5 / double(i + 1)) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << EndRow) << "index: " << i;
 
     if (i % 1000 == 0) {
       // It's ok to end a row group multiple times.
-      ASSERT_NO_THROW(writer_ << EndRowGroup);
-      ASSERT_NO_THROW(writer_ << EndRowGroup);
-      ASSERT_NO_THROW(writer_ << EndRowGroup);
+      EXPECT_NO_THROW(writer_ << EndRowGroup);
+      EXPECT_NO_THROW(writer_ << EndRowGroup);
+      EXPECT_NO_THROW(writer_ << EndRowGroup);
     }
   }
   // It's ok to end a row group multiple times.
-  ASSERT_NO_THROW(writer_ << EndRowGroup);
-  ASSERT_NO_THROW(writer_ << EndRowGroup);
-  ASSERT_NO_THROW(writer_ << EndRowGroup);
+  EXPECT_NO_THROW(writer_ << EndRowGroup);
+  EXPECT_NO_THROW(writer_ << EndRowGroup);
+  EXPECT_NO_THROW(writer_ << EndRowGroup);
 }
 
 TEST_F(TestStreamWriter, SkipColumns) {
-  ASSERT_EQ(0, writer_.SkipColumns(0));
-  ASSERT_THROW(writer_.SkipColumns(2), ParquetException);
+  EXPECT_EQ(0, writer_.SkipColumns(0));
+  EXPECT_THROW(writer_.SkipColumns(2), ParquetException);
   writer_ << true << std::string("Cannot skip mandatory columns");
-  ASSERT_THROW(writer_.SkipColumns(1), ParquetException);
+  EXPECT_THROW(writer_.SkipColumns(1), ParquetException);
   writer_ << 'x' << std::array<char, 4>{'A', 'B', 'C', 'D'} << int8_t(2) << uint16_t(3)
           << int32_t(4) << uint64_t(5) << 6.0f << 7.0;
   writer_ << EndRow;
@@ -344,7 +344,7 @@ class TestOptionalFields : public ::testing::Test {
 };
 
 TEST_F(TestOptionalFields, Output_operator_with_optional_T) {
-  for (auto i = 0; i < 100; ++i) {
+  for (int i = 0; i < 100; ++i) {
     // Write optional fields using operator<<(optional<T>).  Writing
     // of a value is skipped every 9 rows by using a optional<T>
     // object without a value.
@@ -362,34 +362,35 @@ TEST_F(TestOptionalFields, Output_operator_with_optional_T) {
               << optional<uint64_t>((1ull << 60) + i) << optional<float>(5.4f * i)
               << optional<double>(5.1322e6 * i);
     }
-    ASSERT_NO_THROW(writer_ << EndRow);
+    EXPECT_NO_THROW(writer_ << EndRow);
   }
 }
 
 TEST_F(TestOptionalFields, Output_operator_T_and_SkipColumns) {
-  auto constexpr num_rows = 100;
+  constexpr int num_rows = 100;
 
-  ASSERT_EQ(0, writer_.current_row());
+  EXPECT_EQ(0, writer_.current_row());
 
-  for (auto i = 0; i < num_rows; ++i) {
+  for (int i = 0; i < num_rows; ++i) {
     // Write optional fields using standard operator<<(T).  Writing of
     // a value is skipped every 9 rows by using SkipColumns().
 
-    ASSERT_EQ(0, writer_.current_column());
-    ASSERT_EQ(i, writer_.current_row());
+    EXPECT_EQ(0, writer_.current_column());
+    EXPECT_EQ(i, writer_.current_row());
 
     if (i % 9 == 0) {
-      ASSERT_EQ(writer_.num_columns(), writer_.SkipColumns(writer_.num_columns() + 99));
+      EXPECT_EQ(writer_.num_columns(), writer_.SkipColumns(writer_.num_columns() + 99))
+          << "index: " << i;
     } else {
       writer_ << bool(i & 1) << std::string("ok") << char('A' + i % 26)
               << char4_array_type{{'S', 'K', 'I', 'P'}} << int8_t(i)
               << uint16_t(0xffff - i) << int32_t(0x7fffffff - 3 * i)
               << uint64_t((1ull << 60) + i) << 5.4f * i << 5.1322e6 * i;
     }
-    ASSERT_EQ(writer_.num_columns(), writer_.current_column());
-    ASSERT_NO_THROW(writer_ << EndRow);
+    EXPECT_EQ(writer_.num_columns(), writer_.current_column()) << "index: " << i;
+    EXPECT_NO_THROW(writer_ << EndRow) << "index: " << i;
   }
-  ASSERT_EQ(num_rows, writer_.current_row());
+  EXPECT_EQ(num_rows, writer_.current_row());
 }
 
 }  // namespace test

--- a/cpp/src/parquet/stream_writer_test.cc
+++ b/cpp/src/parquet/stream_writer_test.cc
@@ -168,43 +168,43 @@ TEST_F(TestStreamWriter, RequiredFieldChecking) {
 
   // Required field of type: bool
   EXPECT_THROW(writer_ << optional<bool>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << true);
+  EXPECT_NO_THROW(writer_ << optional<bool>(true));
 
   // Required field of type: Variable length string.
   EXPECT_THROW(writer_ << optional<std::string>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << std::string("ok"));
+  EXPECT_NO_THROW(writer_ << optional<std::string>("ok"));
 
   // Required field of type: A char.
   EXPECT_THROW(writer_ << optional<char>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << 'K');
+  EXPECT_NO_THROW(writer_ << optional<char>('K'));
 
   // Required field of type: Fixed string of length 4
   EXPECT_THROW(writer_ << optional<char4_array_type>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << char4_array);
+  EXPECT_NO_THROW(writer_ << optional<char4_array_type>(char4_array));
 
   // Required field of type: int8_t
   EXPECT_THROW(writer_ << optional<int8_t>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << int8_t(51));
+  EXPECT_NO_THROW(writer_ << optional<int8_t>(51));
 
   // Required field of type: uint16_t
   EXPECT_THROW(writer_ << optional<uint16_t>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << uint16_t(15));
+  EXPECT_NO_THROW(writer_ << optional<uint16_t>(15));
 
   // Required field of type: int32_t
   EXPECT_THROW(writer_ << optional<int32_t>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << int32_t(329487));
+  EXPECT_NO_THROW(writer_ << optional<int32_t>(329487));
 
   // Required field of type: uint64_t
   EXPECT_THROW(writer_ << optional<uint64_t>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << uint64_t((1ull << 60) + 123));
+  EXPECT_NO_THROW(writer_ << optional<uint64_t>((1ull << 60) + 123));
 
   // Required field of type: float
   EXPECT_THROW(writer_ << optional<float>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << 5.4f);
+  EXPECT_NO_THROW(writer_ << optional<float>(5.4f));
 
   // Required field of type: double
   EXPECT_THROW(writer_ << optional<double>(), ParquetException);
-  EXPECT_NO_THROW(writer_ << 5.4);
+  EXPECT_NO_THROW(writer_ << optional<double>(5.4));
 
   EXPECT_NO_THROW(writer_ << EndRow);
 }


### PR DESCRIPTION
StreamReader and StreamWriter classes can now support schemata with
optional fields.

Additional input/output operators are available using the
arrow::util::optional class in order to indicate whether optional data
was present when reading, or is present when writing.