### PR TITLE
ARROW-7289: [C#] ListType constructor argument is redundant

### DIFF
--- a/csharp/src/Apache.Arrow/Types/ListType.cs
+++ b/csharp/src/Apache.Arrow/Types/ListType.cs
@@ -25,10 +25,16 @@ namespace Apache.Arrow.Types
         public Field ValueField { get; }
         public IArrowType ValueDataType { get; }
 
-        public ListType(Field valueField, IArrowType valueDataType)
+        public ListType(Field valueField)
         {
             ValueField = valueField ?? throw new ArgumentNullException(nameof(valueField));
+            ValueDataType = ValueField.DataType;
+        }
+
+        public ListType(IArrowType valueDataType)
+        {
             ValueDataType = valueDataType ?? NullType.Default;
+            ValueField = new Field("item", ValueDataType, true);
         }
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);

--- a/csharp/src/Apache.Arrow/Types/ListType.cs
+++ b/csharp/src/Apache.Arrow/Types/ListType.cs
@@ -31,11 +31,8 @@ namespace Apache.Arrow.Types
             ValueDataType = ValueField.DataType;
         }
 
-        public ListType(IArrowType valueDataType)
-        {
-            ValueDataType = valueDataType ?? NullType.Default;
-            ValueField = new Field("item", ValueDataType, true);
-        }
+        public ListType(IArrowType valueDataType) 
+            : this(new Field("item", valueDataType, true)) { }
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);
     }

--- a/csharp/test/Apache.Arrow.Tests/TypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/TypeTests.cs
@@ -96,6 +96,23 @@ namespace Apache.Arrow.Tests
             Assert.True(struct_type.GetFieldByName("not_found") == null);
         }
 
+        [Fact]
+        public void TestListTypeConstructor()
+        {
+            var stringField = new Field.Builder().Name("item").DataType(StringType.Default).Build();
+            var stringType1 = new ListType(stringField);
+            var stringType2 = new ListType(StringType.Default);
+
+            var int64Field = new Field.Builder().Name("item").DataType(Int64Type.Default).Build();
+            var int64Type1 = new ListType(int64Field);
+            var int64Type2 = new ListType(Int64Type.Default);
+
+            Assert.True(FieldComparer.Equals(stringType1.ValueField, stringType2.ValueField));
+            Assert.True(FieldComparer.Equals(int64Type1.ValueField, int64Type2.ValueField));
+            Assert.Equal(stringType1.ValueDataType.TypeId, stringType2.ValueDataType.TypeId);
+            Assert.Equal(int64Type1.ValueDataType.TypeId, int64Type2.ValueDataType.TypeId);
+        }
+
         // Todo: StructType::GetFieldIndexDuplicate test
 
 

--- a/csharp/test/Apache.Arrow.Tests/TypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/TypeTests.cs
@@ -103,14 +103,8 @@ namespace Apache.Arrow.Tests
             var stringType1 = new ListType(stringField);
             var stringType2 = new ListType(StringType.Default);
 
-            var int64Field = new Field.Builder().Name("item").DataType(Int64Type.Default).Build();
-            var int64Type1 = new ListType(int64Field);
-            var int64Type2 = new ListType(Int64Type.Default);
-
             Assert.True(FieldComparer.Equals(stringType1.ValueField, stringType2.ValueField));
-            Assert.True(FieldComparer.Equals(int64Type1.ValueField, int64Type2.ValueField));
             Assert.Equal(stringType1.ValueDataType.TypeId, stringType2.ValueDataType.TypeId);
-            Assert.Equal(int64Type1.ValueDataType.TypeId, int64Type2.ValueDataType.TypeId);
         }
 
         // Todo: StructType::GetFieldIndexDuplicate test


### PR DESCRIPTION
ListType constructor is redundant and should be seperated.