### PR TITLE
ARROW-4225: [Format][C++] Add CSC sparse matrix support

### DIFF
--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1189,6 +1189,13 @@ inline bool SparseTensorEqualsImplDispatch(const SparseTensorImpl<SparseIndexTyp
                                                                               right_csr);
     }
 
+    case SparseTensorFormat::CSC: {
+      const auto& right_csc =
+          checked_cast<const SparseTensorImpl<SparseCSCIndex>&>(right);
+      return SparseTensorEqualsImpl<SparseIndexType, SparseCSCIndex>::Compare(left,
+                                                                              right_csc);
+    }
+
     default:
       return false;
   }
@@ -1218,6 +1225,11 @@ bool SparseTensorEquals(const SparseTensor& left, const SparseTensor& right) {
     case SparseTensorFormat::CSR: {
       const auto& left_csr = checked_cast<const SparseTensorImpl<SparseCSRIndex>&>(left);
       return SparseTensorEqualsImplDispatch(left_csr, right);
+    }
+
+    case SparseTensorFormat::CSC: {
+      const auto& left_csc = checked_cast<const SparseTensorImpl<SparseCSCIndex>&>(left);
+      return SparseTensorEqualsImplDispatch(left_csc, right);
     }
 
     default:

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -112,7 +112,7 @@ Status GetSparseCOOIndexMetadata(const flatbuf::SparseTensorIndexCOO* sparse_ind
                                  std::shared_ptr<DataType>* indices_type);
 
 // EXPERIMENTAL: Extracting metadata of a SparseCSRIndex from the message
-Status GetSparseCSRIndexMetadata(const flatbuf::SparseMatrixIndexCSR* sparse_index,
+Status GetSparseCSXIndexMetadata(const flatbuf::SparseMatrixIndexCSX* sparse_index,
                                  std::shared_ptr<DataType>* indptr_type,
                                  std::shared_ptr<DataType>* indices_type);
 

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -111,7 +111,7 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
 Status GetSparseCOOIndexMetadata(const flatbuf::SparseTensorIndexCOO* sparse_index,
                                  std::shared_ptr<DataType>* indices_type);
 
-// EXPERIMENTAL: Extracting metadata of a SparseCSRIndex from the message
+// EXPERIMENTAL: Extracting metadata of a SparseCSXIndex from the message
 Status GetSparseCSXIndexMetadata(const flatbuf::SparseMatrixIndexCSX* sparse_index,
                                  std::shared_ptr<DataType>* indptr_type,
                                  std::shared_ptr<DataType>* indices_type);

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1144,6 +1144,7 @@ class TestSparseTensorRoundTrip : public ::testing::Test, public IpcTestFixture 
 
   void CheckSparseTensorRoundTrip(const SparseCOOTensor& sparse_tensor);
   void CheckSparseTensorRoundTrip(const SparseCSRMatrix& sparse_tensor);
+  void CheckSparseTensorRoundTrip(const SparseCSCMatrix& sparse_tensor);
 
  protected:
   std::shared_ptr<SparseCOOIndex> MakeSparseCOOIndex(
@@ -1195,6 +1196,7 @@ void TestSparseTensorRoundTrip<IndexValueType>::CheckSparseTensorRoundTrip(
 
   std::shared_ptr<SparseTensor> result;
   ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
+  ASSERT_EQ(SparseTensorFormat::COO, result->format_id());
 
   const auto& resulted_sparse_index =
       checked_cast<const SparseCOOIndex&>(*result->sparse_index());
@@ -1233,9 +1235,50 @@ void TestSparseTensorRoundTrip<IndexValueType>::CheckSparseTensorRoundTrip(
 
   std::shared_ptr<SparseTensor> result;
   ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
+  ASSERT_EQ(SparseTensorFormat::CSR, result->format_id());
 
   const auto& resulted_sparse_index =
       checked_cast<const SparseCSRIndex&>(*result->sparse_index());
+  ASSERT_EQ(resulted_sparse_index.indptr()->data()->size(), indptr_length);
+  ASSERT_EQ(resulted_sparse_index.indices()->data()->size(), indices_length);
+  ASSERT_EQ(result->data()->size(), data_length);
+  ASSERT_TRUE(result->Equals(sparse_tensor));
+}
+
+template <typename IndexValueType>
+void TestSparseTensorRoundTrip<IndexValueType>::CheckSparseTensorRoundTrip(
+    const SparseCSCMatrix& sparse_tensor) {
+  const auto& type = checked_cast<const FixedWidthType&>(*sparse_tensor.type());
+  const int elem_size = type.bit_width() / 8;
+  const int index_elem_size = sizeof(typename IndexValueType::c_type);
+
+  int32_t metadata_length;
+  int64_t body_length;
+
+  ASSERT_OK(mmap_->Seek(0));
+
+  ASSERT_OK(
+      WriteSparseTensor(sparse_tensor, mmap_.get(), &metadata_length, &body_length));
+
+  const auto& sparse_index =
+      checked_cast<const SparseCSCIndex&>(*sparse_tensor.sparse_index());
+  const int64_t indptr_length =
+      BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indptr()->size());
+  const int64_t indices_length =
+      BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indices()->size());
+  const int64_t data_length =
+      BitUtil::RoundUpToMultipleOf8(elem_size * sparse_tensor.non_zero_length());
+  const int64_t expected_body_length = indptr_length + indices_length + data_length;
+  ASSERT_EQ(expected_body_length, body_length);
+
+  ASSERT_OK(mmap_->Seek(0));
+
+  std::shared_ptr<SparseTensor> result;
+  ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
+  ASSERT_EQ(SparseTensorFormat::CSC, result->format_id());
+
+  const auto& resulted_sparse_index =
+      checked_cast<const SparseCSCIndex&>(*result->sparse_index());
   ASSERT_EQ(resulted_sparse_index.indptr()->data()->size(), indptr_length);
   ASSERT_EQ(resulted_sparse_index.indices()->data()->size(), indices_length);
   ASSERT_EQ(result->data()->size(), data_length);
@@ -1360,8 +1403,31 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSRIndex) {
   this->CheckSparseTensorRoundTrip(*st);
 }
 
+TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSCIndex) {
+  using IndexValueType = TypeParam;
+
+  std::string path = "test-write-sparse-csc-matrix";
+  constexpr int64_t kBufferSize = 1 << 20;
+  ASSERT_OK_AND_ASSIGN(this->mmap_,
+                       io::MemoryMapFixture::InitMemoryMap(kBufferSize, path));
+
+  std::vector<int64_t> shape = {4, 6};
+  std::vector<std::string> dim_names = {"foo", "bar", "baz"};
+  std::vector<int64_t> values = {1, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
+                                 0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
+
+  auto data = Buffer::Wrap(values);
+  NumericTensor<Int64Type> t(data, shape, {}, dim_names);
+  std::shared_ptr<SparseCSCMatrix> st;
+  ASSERT_OK_AND_ASSIGN(
+      st, SparseCSCMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton()));
+
+  this->CheckSparseTensorRoundTrip(*st);
+}
+
 REGISTER_TYPED_TEST_CASE_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor,
-                           WithSparseCOOIndexColumnMajor, WithSparseCSRIndex);
+                           WithSparseCOOIndexColumnMajor, WithSparseCSRIndex,
+                           WithSparseCSCIndex);
 
 INSTANTIATE_TYPED_TEST_CASE_P(TestInt8, TestSparseTensorRoundTrip, Int8Type);
 INSTANTIATE_TYPED_TEST_CASE_P(TestUInt8, TestSparseTensorRoundTrip, UInt8Type);

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1142,9 +1142,88 @@ class TestSparseTensorRoundTrip : public ::testing::Test, public IpcTestFixture 
   void SetUp() { IpcTestFixture::SetUp(); }
   void TearDown() { IpcTestFixture::TearDown(); }
 
-  void CheckSparseTensorRoundTrip(const SparseCOOTensor& sparse_tensor);
-  void CheckSparseTensorRoundTrip(const SparseCSRMatrix& sparse_tensor);
-  void CheckSparseTensorRoundTrip(const SparseCSCMatrix& sparse_tensor);
+  void CheckSparseCOOTensorRoundTrip(const SparseCOOTensor& sparse_tensor) {
+    const auto& type = checked_cast<const FixedWidthType&>(*sparse_tensor.type());
+    const int elem_size = type.bit_width() / 8;
+    const int index_elem_size = sizeof(typename IndexValueType::c_type);
+
+    int32_t metadata_length;
+    int64_t body_length;
+
+    ASSERT_OK(mmap_->Seek(0));
+
+    ASSERT_OK(
+        WriteSparseTensor(sparse_tensor, mmap_.get(), &metadata_length, &body_length));
+
+    const auto& sparse_index =
+        checked_cast<const SparseCOOIndex&>(*sparse_tensor.sparse_index());
+    const int64_t indices_length =
+        BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indices()->size());
+    const int64_t data_length =
+        BitUtil::RoundUpToMultipleOf8(elem_size * sparse_tensor.non_zero_length());
+    const int64_t expected_body_length = indices_length + data_length;
+    ASSERT_EQ(expected_body_length, body_length);
+
+    ASSERT_OK(mmap_->Seek(0));
+
+    std::shared_ptr<SparseTensor> result;
+    ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
+    ASSERT_EQ(SparseTensorFormat::COO, result->format_id());
+
+    const auto& resulted_sparse_index =
+        checked_cast<const SparseCOOIndex&>(*result->sparse_index());
+    ASSERT_EQ(resulted_sparse_index.indices()->data()->size(), indices_length);
+    ASSERT_EQ(result->data()->size(), data_length);
+    ASSERT_TRUE(result->Equals(sparse_tensor));
+  }
+
+  template <typename SparseIndexType>
+  void CheckSparseCSXMatrixRoundTrip(
+      const SparseTensorImpl<SparseIndexType>& sparse_tensor) {
+    static_assert(std::is_same<SparseIndexType, SparseCSRIndex>::value ||
+                      std::is_same<SparseIndexType, SparseCSCIndex>::value,
+                  "SparseIndexType must be either SparseCSRIndex or SparseCSCIndex");
+
+    const auto& type = checked_cast<const FixedWidthType&>(*sparse_tensor.type());
+    const int elem_size = type.bit_width() / 8;
+    const int index_elem_size = sizeof(typename IndexValueType::c_type);
+
+    int32_t metadata_length;
+    int64_t body_length;
+
+    ASSERT_OK(mmap_->Seek(0));
+
+    ASSERT_OK(
+        WriteSparseTensor(sparse_tensor, mmap_.get(), &metadata_length, &body_length));
+
+    const auto& sparse_index =
+        checked_cast<const SparseIndexType&>(*sparse_tensor.sparse_index());
+    const int64_t indptr_length =
+        BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indptr()->size());
+    const int64_t indices_length =
+        BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indices()->size());
+    const int64_t data_length =
+        BitUtil::RoundUpToMultipleOf8(elem_size * sparse_tensor.non_zero_length());
+    const int64_t expected_body_length = indptr_length + indices_length + data_length;
+    ASSERT_EQ(expected_body_length, body_length);
+
+    ASSERT_OK(mmap_->Seek(0));
+
+    std::shared_ptr<SparseTensor> result;
+    ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
+
+    constexpr auto expected_format_id =
+        std::is_same<SparseIndexType, SparseCSRIndex>::value ? SparseTensorFormat::CSR
+                                                             : SparseTensorFormat::CSC;
+    ASSERT_EQ(expected_format_id, result->format_id());
+
+    const auto& resulted_sparse_index =
+        checked_cast<const SparseIndexType&>(*result->sparse_index());
+    ASSERT_EQ(resulted_sparse_index.indptr()->data()->size(), indptr_length);
+    ASSERT_EQ(resulted_sparse_index.indices()->data()->size(), indices_length);
+    ASSERT_EQ(result->data()->size(), data_length);
+    ASSERT_TRUE(result->Equals(sparse_tensor));
+  }
 
  protected:
   std::shared_ptr<SparseCOOIndex> MakeSparseCOOIndex(
@@ -1167,123 +1246,6 @@ class TestSparseTensorRoundTrip : public ::testing::Test, public IpcTestFixture 
                                              data, shape, dim_names);
   }
 };
-
-template <typename IndexValueType>
-void TestSparseTensorRoundTrip<IndexValueType>::CheckSparseTensorRoundTrip(
-    const SparseCOOTensor& sparse_tensor) {
-  const auto& type = checked_cast<const FixedWidthType&>(*sparse_tensor.type());
-  const int elem_size = type.bit_width() / 8;
-  const int index_elem_size = sizeof(typename IndexValueType::c_type);
-
-  int32_t metadata_length;
-  int64_t body_length;
-
-  ASSERT_OK(mmap_->Seek(0));
-
-  ASSERT_OK(
-      WriteSparseTensor(sparse_tensor, mmap_.get(), &metadata_length, &body_length));
-
-  const auto& sparse_index =
-      checked_cast<const SparseCOOIndex&>(*sparse_tensor.sparse_index());
-  const int64_t indices_length =
-      BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indices()->size());
-  const int64_t data_length =
-      BitUtil::RoundUpToMultipleOf8(elem_size * sparse_tensor.non_zero_length());
-  const int64_t expected_body_length = indices_length + data_length;
-  ASSERT_EQ(expected_body_length, body_length);
-
-  ASSERT_OK(mmap_->Seek(0));
-
-  std::shared_ptr<SparseTensor> result;
-  ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
-  ASSERT_EQ(SparseTensorFormat::COO, result->format_id());
-
-  const auto& resulted_sparse_index =
-      checked_cast<const SparseCOOIndex&>(*result->sparse_index());
-  ASSERT_EQ(resulted_sparse_index.indices()->data()->size(), indices_length);
-  ASSERT_EQ(result->data()->size(), data_length);
-  ASSERT_TRUE(result->Equals(sparse_tensor));
-}
-
-template <typename IndexValueType>
-void TestSparseTensorRoundTrip<IndexValueType>::CheckSparseTensorRoundTrip(
-    const SparseCSRMatrix& sparse_tensor) {
-  const auto& type = checked_cast<const FixedWidthType&>(*sparse_tensor.type());
-  const int elem_size = type.bit_width() / 8;
-  const int index_elem_size = sizeof(typename IndexValueType::c_type);
-
-  int32_t metadata_length;
-  int64_t body_length;
-
-  ASSERT_OK(mmap_->Seek(0));
-
-  ASSERT_OK(
-      WriteSparseTensor(sparse_tensor, mmap_.get(), &metadata_length, &body_length));
-
-  const auto& sparse_index =
-      checked_cast<const SparseCSRIndex&>(*sparse_tensor.sparse_index());
-  const int64_t indptr_length =
-      BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indptr()->size());
-  const int64_t indices_length =
-      BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indices()->size());
-  const int64_t data_length =
-      BitUtil::RoundUpToMultipleOf8(elem_size * sparse_tensor.non_zero_length());
-  const int64_t expected_body_length = indptr_length + indices_length + data_length;
-  ASSERT_EQ(expected_body_length, body_length);
-
-  ASSERT_OK(mmap_->Seek(0));
-
-  std::shared_ptr<SparseTensor> result;
-  ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
-  ASSERT_EQ(SparseTensorFormat::CSR, result->format_id());
-
-  const auto& resulted_sparse_index =
-      checked_cast<const SparseCSRIndex&>(*result->sparse_index());
-  ASSERT_EQ(resulted_sparse_index.indptr()->data()->size(), indptr_length);
-  ASSERT_EQ(resulted_sparse_index.indices()->data()->size(), indices_length);
-  ASSERT_EQ(result->data()->size(), data_length);
-  ASSERT_TRUE(result->Equals(sparse_tensor));
-}
-
-template <typename IndexValueType>
-void TestSparseTensorRoundTrip<IndexValueType>::CheckSparseTensorRoundTrip(
-    const SparseCSCMatrix& sparse_tensor) {
-  const auto& type = checked_cast<const FixedWidthType&>(*sparse_tensor.type());
-  const int elem_size = type.bit_width() / 8;
-  const int index_elem_size = sizeof(typename IndexValueType::c_type);
-
-  int32_t metadata_length;
-  int64_t body_length;
-
-  ASSERT_OK(mmap_->Seek(0));
-
-  ASSERT_OK(
-      WriteSparseTensor(sparse_tensor, mmap_.get(), &metadata_length, &body_length));
-
-  const auto& sparse_index =
-      checked_cast<const SparseCSCIndex&>(*sparse_tensor.sparse_index());
-  const int64_t indptr_length =
-      BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indptr()->size());
-  const int64_t indices_length =
-      BitUtil::RoundUpToMultipleOf8(index_elem_size * sparse_index.indices()->size());
-  const int64_t data_length =
-      BitUtil::RoundUpToMultipleOf8(elem_size * sparse_tensor.non_zero_length());
-  const int64_t expected_body_length = indptr_length + indices_length + data_length;
-  ASSERT_EQ(expected_body_length, body_length);
-
-  ASSERT_OK(mmap_->Seek(0));
-
-  std::shared_ptr<SparseTensor> result;
-  ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
-  ASSERT_EQ(SparseTensorFormat::CSC, result->format_id());
-
-  const auto& resulted_sparse_index =
-      checked_cast<const SparseCSCIndex&>(*result->sparse_index());
-  ASSERT_EQ(resulted_sparse_index.indptr()->data()->size(), indptr_length);
-  ASSERT_EQ(resulted_sparse_index.indices()->data()->size(), indices_length);
-  ASSERT_EQ(result->data()->size(), data_length);
-  ASSERT_TRUE(result->Equals(sparse_tensor));
-}
 
 TYPED_TEST_CASE_P(TestSparseTensorRoundTrip);
 
@@ -1331,7 +1293,7 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor) {
   std::vector<int64_t> values = {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16};
   auto st = this->MakeSparseCOOTensor(si, values, shape, dim_names);
 
-  this->CheckSparseTensorRoundTrip(*st);
+  this->CheckSparseCOOTensorRoundTrip(*st);
 }
 
 TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
@@ -1378,7 +1340,7 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
   std::vector<int64_t> values = {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16};
   auto st = this->MakeSparseCOOTensor(si, values, shape, dim_names);
 
-  this->CheckSparseTensorRoundTrip(*st);
+  this->CheckSparseCOOTensorRoundTrip(*st);
 }
 
 TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSRIndex) {
@@ -1400,7 +1362,7 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSRIndex) {
   ASSERT_OK_AND_ASSIGN(
       st, SparseCSRMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton()));
 
-  this->CheckSparseTensorRoundTrip(*st);
+  this->CheckSparseCSXMatrixRoundTrip(*st);
 }
 
 TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSCIndex) {
@@ -1422,7 +1384,7 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCSCIndex) {
   ASSERT_OK_AND_ASSIGN(
       st, SparseCSCMatrix::Make(t, TypeTraits<IndexValueType>::type_singleton()));
 
-  this->CheckSparseTensorRoundTrip(*st);
+  this->CheckSparseCSXMatrixRoundTrip(*st);
 }
 
 REGISTER_TYPED_TEST_CASE_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor,

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -746,6 +746,11 @@ class SparseTensorSerializer {
             VisitSparseCSRIndex(checked_cast<const SparseCSRIndex&>(sparse_index)));
         break;
 
+      case SparseTensorFormat::CSC:
+        RETURN_NOT_OK(
+            VisitSparseCSCIndex(checked_cast<const SparseCSCIndex&>(sparse_index)));
+        break;
+
       default:
         std::stringstream ss;
         ss << "Unable to convert type: " << sparse_index.ToString() << std::endl;
@@ -793,6 +798,12 @@ class SparseTensorSerializer {
   }
 
   Status VisitSparseCSRIndex(const SparseCSRIndex& sparse_index) {
+    out_->body_buffers.emplace_back(sparse_index.indptr()->data());
+    out_->body_buffers.emplace_back(sparse_index.indices()->data());
+    return Status::OK();
+  }
+
+  Status VisitSparseCSCIndex(const SparseCSCIndex& sparse_index) {
     out_->body_buffers.emplace_back(sparse_index.indptr()->data());
     out_->body_buffers.emplace_back(sparse_index.indices()->data());
     return Status::OK();

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -663,6 +663,9 @@ Status CountSparseTensors(
       case SparseTensorFormat::CSR:
         ++num_csr;
         break;
+      case SparseTensorFormat::CSC:
+        // TODO(mrkn): support csc
+        break;
     }
   }
 

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -164,7 +164,7 @@ class SparseTensorConverter<TYPE, SparseCOOIndex>
       ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(CALL_TYPE_SPECIFIC_CONVERT);
       // LCOV_EXCL_START: The following invalid causes program failure.
       default:
-        return Status::Invalid("Unsupported SparseTensor index value type");
+        return Status::TypeError("Unsupported SparseTensor index value type");
         // LCOV_EXCL_STOP
     }
   }
@@ -271,7 +271,7 @@ class SparseTensorConverter<TYPE, SparseCSRIndex>
       ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(CALL_TYPE_SPECIFIC_CONVERT);
       // LCOV_EXCL_START: The following invalid causes program failure.
       default:
-        return Status::Invalid("Unsupported SparseTensor index value type");
+        return Status::TypeError("Unsupported SparseTensor index value type");
         // LCOV_EXCL_STOP
     }
   }
@@ -392,7 +392,7 @@ class SparseTensorConverter<TYPE, SparseCSCIndex>
       ARROW_GENERATE_FOR_ALL_INTEGER_TYPES(CALL_TYPE_SPECIFIC_CONVERT);
       // LCOV_EXCL_START: The following invalid causes program failure.
       default:
-        return Status::Invalid("Unsupported SparseTensor index value type");
+        return Status::TypeError("Unsupported SparseTensor index value type");
         // LCOV_EXCL_STOP
     }
   }
@@ -478,7 +478,7 @@ inline Status MakeSparseTensorFromTensor(
     ARROW_GENERATE_FOR_ALL_NUMERIC_TYPES(MAKE_SPARSE_TENSOR_FROM_TENSOR);
       // LCOV_EXCL_START: ignore program failure
     default:
-      return Status::Invalid("Unsupported Tensor value type");
+      return Status::TypeError("Unsupported Tensor value type");
       // LCOV_EXCL_STOP
   }
 }
@@ -675,7 +675,7 @@ inline Status CheckSparseCOOIndexValidity(const std::shared_ptr<DataType>& type,
                                           const std::vector<int64_t>& shape,
                                           const std::vector<int64_t>& strides) {
   if (!is_integer(type->id())) {
-    return Status::Invalid("Type of SparseCOOIndex indices must be integer");
+    return Status::TypeError("Type of SparseCOOIndex indices must be integer");
   }
   if (shape.size() != 2) {
     return Status::Invalid("SparseCOOIndex indices must be a matrix");
@@ -728,7 +728,7 @@ Status ValidateSparseCSXIndex(const std::shared_ptr<DataType>& indptr_type,
                               const std::vector<int64_t>& indices_shape,
                               char const* type_name) {
   if (!is_integer(indptr_type->id())) {
-    return Status::Invalid("Type of ", type_name, " indptr must be integer");
+    return Status::TypeError("Type of ", type_name, " indptr must be integer");
   }
   if (indptr_shape.size() != 1) {
     return Status::Invalid(type_name, " indptr must be a vector");

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -592,7 +592,6 @@ Status MakeTensorFromSparseTensor(MemoryPool* pool, const SparseTensor* sparse_t
       *out = std::make_shared<Tensor>(sparse_tensor->type(), values_buffer,
                                       sparse_tensor->shape());
       return Status::OK();
-      return Status::NotImplemented("CSC format is not implemented yet");
     }
   }
   return Status::NotImplemented("Unsupported SparseIndex format type");

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -36,7 +37,9 @@ struct SparseTensorFormat {
     /// Coordinate list (COO) format.
     COO,
     /// Compressed sparse row (CSR) format.
-    CSR
+    CSR,
+    /// Compressed sparse column (CSC) format.
+    CSC,
   };
 };
 
@@ -136,34 +139,57 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   std::shared_ptr<Tensor> coords_;
 };
 
-// ----------------------------------------------------------------------
-// SparseCSRIndex class
+namespace internal {
 
-/// \brief EXPERIMENTAL: The index data for a CSR sparse matrix
-///
-/// A CSR sparse index manages the location of its non-zero values by two
-/// vectors.
-///
-/// The first vector, called indptr, represents the range of the rows; the i-th
-/// row spans from indptr[i] to indptr[i+1] in the corresponding value vector.
-/// So the length of an indptr vector is the number of rows + 1.
-///
-/// The other vector, called indices, represents the column indices of the
-/// corresponding non-zero values.  So the length of an indices vector is same
-/// as the number of non-zero-values.
-class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIndex> {
+struct SparseMatrixCompressedAxis {
+  /// EXPERIMENTAL: The axis to be compressed
+  enum type {
+    /// The value for CSR matrix
+    ROW,
+    /// The value for CSC matrix
+    COLUMN
+  };
+};
+
+ARROW_EXPORT
+Status ValidateSparseCSXIndex(const std::shared_ptr<DataType>& indptr_type,
+                              const std::shared_ptr<DataType>& indices_type,
+                              const std::vector<int64_t>& indptr_shape,
+                              const std::vector<int64_t>& indices_shape,
+                              char const* type_name);
+
+ARROW_EXPORT
+void CheckSparseCSXIndexValidity(const std::shared_ptr<DataType>& indptr_type,
+                                 const std::shared_ptr<DataType>& indices_type,
+                                 const std::vector<int64_t>& indptr_shape,
+                                 const std::vector<int64_t>& indices_shape,
+                                 char const* type_name);
+
+template <typename SparseIndexType, SparseMatrixCompressedAxis::type COMPRESSED_AXIS>
+class ARROW_EXPORT SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
  public:
-  static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
+  static constexpr SparseTensorFormat::type format_id = std::conditional<
+      COMPRESSED_AXIS == SparseMatrixCompressedAxis::ROW,
+      std::integral_constant<SparseTensorFormat::type, SparseTensorFormat::CSR>,
+      std::integral_constant<SparseTensorFormat::type,
+                             SparseTensorFormat::CSC>>::type::value;
 
-  /// \brief Make SparseCSRIndex from raw properties
-  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+  /// \brief Make a subclass of SparseCSXIndex from raw properties
+  static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indptr_type,
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
-      std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data);
+      std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data) {
+    ARROW_RETURN_NOT_OK(ValidateSparseCSXIndex(indptr_type, indices_type, indptr_shape,
+                                               indices_shape,
+                                               SparseIndexType::TYPE_NAME));
+    return std::make_shared<SparseIndexType>(
+        std::make_shared<Tensor>(indptr_type, indptr_data, indptr_shape),
+        std::make_shared<Tensor>(indices_type, indices_data, indices_shape));
+  }
 
-  /// \brief Make SparseCSRIndex from raw properties
-  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+  /// \brief Make a subclass of SparseCSRIndex from raw properties
+  static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
       std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data) {
@@ -171,15 +197,22 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
                 indices_data);
   }
 
-  /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
-  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+  /// \brief Make a subclass of SparseCSXIndex from sparse tensor's shape properties and
+  /// data
+  static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indptr_type,
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
       int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
-      std::shared_ptr<Buffer> indices_data);
+      std::shared_ptr<Buffer> indices_data) {
+    std::vector<int64_t> indptr_shape({shape[0] + 1});
+    std::vector<int64_t> indices_shape({non_zero_length});
+    return Make(indptr_type, indices_type, indptr_shape, indices_shape, indptr_data,
+                indices_data);
+  }
 
-  /// \brief Make SparseCSRIndex from sparse tensor's shape properties and data
-  static Result<std::shared_ptr<SparseCSRIndex>> Make(
+  /// \brief Make a subclass of SparseCSXIndex from sparse tensor's shape properties and
+  /// data
+  static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
       int64_t non_zero_length, std::shared_ptr<Buffer> indptr_data,
       std::shared_ptr<Buffer> indices_data) {
@@ -188,8 +221,14 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
   }
 
   /// \brief Construct SparseCSRIndex from two index vectors
-  explicit SparseCSRIndex(const std::shared_ptr<Tensor>& indptr,
-                          const std::shared_ptr<Tensor>& indices);
+  explicit SparseCSXIndex(const std::shared_ptr<Tensor>& indptr,
+                          const std::shared_ptr<Tensor>& indices)
+      : SparseIndexBase<SparseIndexType>(indices->shape()[0]),
+        indptr_(indptr),
+        indices_(indices) {
+    CheckSparseCSXIndexValidity(indptr_->type(), indices_->type(), indptr_->shape(),
+                                indices_->shape(), SparseIndexType::TYPE_NAME);
+  }
 
   /// \brief Return a 1D tensor of indptr vector
   const std::shared_ptr<Tensor>& indptr() const { return indptr_; }
@@ -198,10 +237,12 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
   const std::shared_ptr<Tensor>& indices() const { return indices_; }
 
   /// \brief Return a string representation of the sparse index
-  std::string ToString() const override;
+  std::string ToString() const override {
+    return std::string(SparseIndexType::TYPE_NAME);
+  }
 
   /// \brief Return whether the CSR indices are equal
-  bool Equals(const SparseCSRIndex& other) const {
+  bool Equals(const SparseIndexType& other) const {
     return indptr()->Equals(*other.indptr()) && indices()->Equals(*other.indices());
   }
 
@@ -220,12 +261,38 @@ class ARROW_EXPORT SparseCSRIndex : public internal::SparseIndexBase<SparseCSRIn
       return Status::OK();
     }
 
-    return Status::Invalid("shape length is inconsistent with the CSR index");
+    return Status::Invalid("shape length is inconsistent with the ", ToString());
   }
 
  protected:
   std::shared_ptr<Tensor> indptr_;
   std::shared_ptr<Tensor> indices_;
+};
+
+}  // namespace internal
+
+// ----------------------------------------------------------------------
+// SparseCSRIndex class
+
+/// \brief EXPERIMENTAL: The index data for a CSR sparse matrix
+///
+/// A CSR sparse index manages the location of its non-zero values by two
+/// vectors.
+///
+/// The first vector, called indptr, represents the range of the rows; the i-th
+/// row spans from indptr[i] to indptr[i+1] in the corresponding value vector.
+/// So the length of an indptr vector is the number of rows + 1.
+///
+/// The other vector, called indices, represents the column indices of the
+/// corresponding non-zero values.  So the length of an indices vector is same
+/// as the number of non-zero-values.
+class ARROW_EXPORT SparseCSRIndex
+    : public internal::SparseCSXIndex<SparseCSRIndex,
+                                      internal::SparseMatrixCompressedAxis::ROW> {
+ public:
+  constexpr static char const* TYPE_NAME = "SparseCSRIndex";
+
+  using SparseCSXIndex::SparseCSXIndex;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -166,7 +166,7 @@ void CheckSparseCSXIndexValidity(const std::shared_ptr<DataType>& indptr_type,
                                  char const* type_name);
 
 template <typename SparseIndexType, SparseMatrixCompressedAxis::type COMPRESSED_AXIS>
-class ARROW_EXPORT SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
+class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
  public:
   static constexpr SparseTensorFormat::type format_id = std::conditional<
       COMPRESSED_AXIS == SparseMatrixCompressedAxis::ROW,
@@ -292,6 +292,32 @@ class ARROW_EXPORT SparseCSRIndex
  public:
   constexpr static char const* TYPE_NAME = "SparseCSRIndex";
 
+  using SparseCSXIndex::Make;
+  using SparseCSXIndex::SparseCSXIndex;
+};
+
+// ----------------------------------------------------------------------
+// SparseCSCIndex class
+
+/// \brief EXPERIMENTAL: The index data for a CSC sparse matrix
+///
+/// A CSC sparse index manages the location of its non-zero values by two
+/// vectors.
+///
+/// The first vector, called indptr, represents the range of the column; the i-th
+/// column spans from indptr[i] to indptr[i+1] in the corresponding value vector.
+/// So the length of an indptr vector is the number of columns + 1.
+///
+/// The other vector, called indices, represents the row indices of the
+/// corresponding non-zero values.  So the length of an indices vector is same
+/// as the number of non-zero-values.
+class ARROW_EXPORT SparseCSCIndex
+    : public internal::SparseCSXIndex<SparseCSCIndex,
+                                      internal::SparseMatrixCompressedAxis::COLUMN> {
+ public:
+  constexpr static char const* TYPE_NAME = "SparseCSCIndex";
+
+  using SparseCSXIndex::Make;
   using SparseCSXIndex::SparseCSXIndex;
 };
 
@@ -485,6 +511,9 @@ using SparseCOOTensor = SparseTensorImpl<SparseCOOIndex>;
 
 /// \brief EXPERIMENTAL: Type alias for CSR sparse matrix
 using SparseCSRMatrix = SparseTensorImpl<SparseCSRIndex>;
+
+/// \brief EXPERIMENTAL: Type alias for CSC sparse matrix
+using SparseCSCMatrix = SparseTensorImpl<SparseCSCIndex>;
 
 }  // namespace arrow
 

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -168,6 +168,8 @@ void CheckSparseCSXIndexValidity(const std::shared_ptr<DataType>& indptr_type,
 template <typename SparseIndexType, SparseMatrixCompressedAxis::type COMPRESSED_AXIS>
 class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
  public:
+  static constexpr SparseMatrixCompressedAxis::type kCompressedAxis = COMPRESSED_AXIS;
+
   /// \brief Make a subclass of SparseCSXIndex from raw properties
   static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indptr_type,
@@ -284,9 +286,13 @@ class ARROW_EXPORT SparseCSRIndex
     : public internal::SparseCSXIndex<SparseCSRIndex,
                                       internal::SparseMatrixCompressedAxis::ROW> {
  public:
+  using BaseClass =
+      internal::SparseCSXIndex<SparseCSRIndex, internal::SparseMatrixCompressedAxis::ROW>;
+
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
   static constexpr char const* kTypeName = "SparseCSRIndex";
 
+  using SparseCSXIndex::kCompressedAxis;
   using SparseCSXIndex::Make;
   using SparseCSXIndex::SparseCSXIndex;
 };
@@ -310,9 +316,14 @@ class ARROW_EXPORT SparseCSCIndex
     : public internal::SparseCSXIndex<SparseCSCIndex,
                                       internal::SparseMatrixCompressedAxis::COLUMN> {
  public:
+  using BaseClass =
+      internal::SparseCSXIndex<SparseCSCIndex,
+                               internal::SparseMatrixCompressedAxis::COLUMN>;
+
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSC;
   static constexpr char const* kTypeName = "SparseCSCIndex";
 
+  using SparseCSXIndex::kCompressedAxis;
   using SparseCSXIndex::Make;
   using SparseCSXIndex::SparseCSXIndex;
 };

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -168,12 +168,6 @@ void CheckSparseCSXIndexValidity(const std::shared_ptr<DataType>& indptr_type,
 template <typename SparseIndexType, SparseMatrixCompressedAxis::type COMPRESSED_AXIS>
 class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
  public:
-  static constexpr SparseTensorFormat::type format_id = std::conditional<
-      COMPRESSED_AXIS == SparseMatrixCompressedAxis::ROW,
-      std::integral_constant<SparseTensorFormat::type, SparseTensorFormat::CSR>,
-      std::integral_constant<SparseTensorFormat::type,
-                             SparseTensorFormat::CSC>>::type::value;
-
   /// \brief Make a subclass of SparseCSXIndex from raw properties
   static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indptr_type,
@@ -290,6 +284,7 @@ class ARROW_EXPORT SparseCSRIndex
     : public internal::SparseCSXIndex<SparseCSRIndex,
                                       internal::SparseMatrixCompressedAxis::ROW> {
  public:
+  static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
   constexpr static char const* TYPE_NAME = "SparseCSRIndex";
 
   using SparseCSXIndex::Make;
@@ -315,6 +310,7 @@ class ARROW_EXPORT SparseCSCIndex
     : public internal::SparseCSXIndex<SparseCSCIndex,
                                       internal::SparseMatrixCompressedAxis::COLUMN> {
  public:
+  static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSC;
   constexpr static char const* TYPE_NAME = "SparseCSCIndex";
 
   using SparseCSXIndex::Make;

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -141,14 +141,12 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
 
 namespace internal {
 
-struct SparseMatrixCompressedAxis {
-  /// EXPERIMENTAL: The axis to be compressed
-  enum type {
-    /// The value for CSR matrix
-    ROW,
-    /// The value for CSC matrix
-    COLUMN
-  };
+/// EXPERIMENTAL: The axis to be compressed
+enum class SparseMatrixCompressedAxis : char {
+  /// The value for CSR matrix
+  ROW,
+  /// The value for CSC matrix
+  COLUMN
 };
 
 ARROW_EXPORT
@@ -165,10 +163,10 @@ void CheckSparseCSXIndexValidity(const std::shared_ptr<DataType>& indptr_type,
                                  const std::vector<int64_t>& indices_shape,
                                  char const* type_name);
 
-template <typename SparseIndexType, SparseMatrixCompressedAxis::type COMPRESSED_AXIS>
+template <typename SparseIndexType, SparseMatrixCompressedAxis COMPRESSED_AXIS>
 class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
  public:
-  static constexpr SparseMatrixCompressedAxis::type kCompressedAxis = COMPRESSED_AXIS;
+  static constexpr SparseMatrixCompressedAxis kCompressedAxis = COMPRESSED_AXIS;
 
   /// \brief Make a subclass of SparseCSXIndex from raw properties
   static Result<std::shared_ptr<SparseIndexType>> Make(

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -176,7 +176,7 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
       std::shared_ptr<Buffer> indptr_data, std::shared_ptr<Buffer> indices_data) {
     ARROW_RETURN_NOT_OK(ValidateSparseCSXIndex(indptr_type, indices_type, indptr_shape,
                                                indices_shape,
-                                               SparseIndexType::TYPE_NAME));
+                                               SparseIndexType::kTypeName));
     return std::make_shared<SparseIndexType>(
         std::make_shared<Tensor>(indptr_type, indptr_data, indptr_shape),
         std::make_shared<Tensor>(indices_type, indices_data, indices_shape));
@@ -221,7 +221,7 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
         indptr_(indptr),
         indices_(indices) {
     CheckSparseCSXIndexValidity(indptr_->type(), indices_->type(), indptr_->shape(),
-                                indices_->shape(), SparseIndexType::TYPE_NAME);
+                                indices_->shape(), SparseIndexType::kTypeName);
   }
 
   /// \brief Return a 1D tensor of indptr vector
@@ -232,7 +232,7 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
 
   /// \brief Return a string representation of the sparse index
   std::string ToString() const override {
-    return std::string(SparseIndexType::TYPE_NAME);
+    return std::string(SparseIndexType::kTypeName);
   }
 
   /// \brief Return whether the CSR indices are equal
@@ -285,7 +285,7 @@ class ARROW_EXPORT SparseCSRIndex
                                       internal::SparseMatrixCompressedAxis::ROW> {
  public:
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
-  constexpr static char const* TYPE_NAME = "SparseCSRIndex";
+  static constexpr char const* kTypeName = "SparseCSRIndex";
 
   using SparseCSXIndex::Make;
   using SparseCSXIndex::SparseCSXIndex;
@@ -311,7 +311,7 @@ class ARROW_EXPORT SparseCSCIndex
                                       internal::SparseMatrixCompressedAxis::COLUMN> {
  public:
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSC;
-  constexpr static char const* TYPE_NAME = "SparseCSCIndex";
+  static constexpr char const* kTypeName = "SparseCSCIndex";
 
   using SparseCSXIndex::Make;
   using SparseCSXIndex::SparseCSXIndex;

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -184,7 +184,7 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
         std::make_shared<Tensor>(indices_type, indices_data, indices_shape));
   }
 
-  /// \brief Make a subclass of SparseCSRIndex from raw properties
+  /// \brief Make a subclass of SparseCSXIndex from raw properties
   static Result<std::shared_ptr<SparseIndexType>> Make(
       const std::shared_ptr<DataType>& indices_type,
       const std::vector<int64_t>& indptr_shape, const std::vector<int64_t>& indices_shape,
@@ -216,7 +216,7 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
                 indices_data);
   }
 
-  /// \brief Construct SparseCSRIndex from two index vectors
+  /// \brief Construct SparseCSXIndex from two index vectors
   explicit SparseCSXIndex(const std::shared_ptr<Tensor>& indptr,
                           const std::shared_ptr<Tensor>& indices)
       : SparseIndexBase<SparseIndexType>(indices->shape()[0]),

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -91,6 +91,7 @@ TEST(TestSparseCSRIndex, Make) {
   ASSERT_EQ(indptr_data->data(), si->indptr()->raw_data());
   ASSERT_EQ(indices_shape, si->indices()->shape());
   ASSERT_EQ(indices_data->data(), si->indices()->raw_data());
+  ASSERT_EQ(std::string("SparseCSRIndex"), si->ToString());
 
   // Non-integer type
   auto res = SparseCSRIndex::Make(float32(), indptr_shape, indices_shape, indptr_data,
@@ -98,12 +99,43 @@ TEST(TestSparseCSRIndex, Make) {
   ASSERT_RAISES(Invalid, res);
 
   // Non-vector indptr shape
-  res = SparseCSRIndex::Make(int32(), {1, 2}, indices_shape, indptr_data, indices_data);
-  ASSERT_RAISES(Invalid, res);
+  ASSERT_RAISES(Invalid, SparseCSRIndex::Make(int32(), {1, 2}, indices_shape, indptr_data,
+                                              indices_data));
 
   // Non-vector indices shape
-  res = SparseCSRIndex::Make(int32(), indptr_shape, {1, 2}, indptr_data, indices_data);
-  ASSERT_RAISES(Invalid, res);
+  ASSERT_RAISES(Invalid, SparseCSRIndex::Make(int32(), indptr_shape, {1, 2}, indptr_data,
+                                              indices_data));
+}
+
+TEST(TestSparseCSCIndex, Make) {
+  std::vector<int32_t> indptr_values = {0, 2, 4, 6, 8, 10, 12};
+  std::vector<int32_t> indices_values = {0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3};
+  auto indptr_data = Buffer::Wrap(indptr_values);
+  auto indices_data = Buffer::Wrap(indices_values);
+  std::vector<int64_t> indptr_shape = {7};
+  std::vector<int64_t> indices_shape = {12};
+
+  // OK
+  std::shared_ptr<SparseCSCIndex> si;
+  ASSERT_OK_AND_ASSIGN(si, SparseCSCIndex::Make(int32(), indptr_shape, indices_shape,
+                                                indptr_data, indices_data));
+  ASSERT_EQ(indptr_shape, si->indptr()->shape());
+  ASSERT_EQ(indptr_data->data(), si->indptr()->raw_data());
+  ASSERT_EQ(indices_shape, si->indices()->shape());
+  ASSERT_EQ(indices_data->data(), si->indices()->raw_data());
+  ASSERT_EQ(std::string("SparseCSCIndex"), si->ToString());
+
+  // Non-integer type
+  ASSERT_RAISES(Invalid, SparseCSCIndex::Make(float32(), indptr_shape, indices_shape,
+                                              indptr_data, indices_data));
+
+  // Non-vector indptr shape
+  ASSERT_RAISES(Invalid, SparseCSCIndex::Make(int32(), {1, 2}, indices_shape, indptr_data,
+                                              indices_data));
+
+  // Non-vector indices shape
+  ASSERT_RAISES(Invalid, SparseCSCIndex::Make(int32(), indptr_shape, {1, 2}, indptr_data,
+                                              indices_data));
 }
 
 template <typename IndexValueType>
@@ -711,5 +743,164 @@ INSTANTIATE_TYPED_TEST_CASE_P(TestUInt32, TestSparseCSRMatrixForIndexValueType,
 INSTANTIATE_TYPED_TEST_CASE_P(TestInt64, TestSparseCSRMatrixForIndexValueType, Int64Type);
 INSTANTIATE_TYPED_TEST_CASE_P(TestUInt64, TestSparseCSRMatrixForIndexValueType,
                               UInt64Type);
+
+template <typename IndexValueType>
+class TestSparseCSCMatrixBase : public ::testing::Test {
+ public:
+  void SetUp() {
+    shape_ = {6, 4};
+    dim_names_ = {"foo", "bar"};
+
+    // Dense representation:
+    // [
+    //    1  0  2  0
+    //    0  3  0  4
+    //    5  0  6  0
+    //    0 11  0 12
+    //   13  0 14  0
+    //    0 15  0 16
+    // ]
+    std::vector<int64_t> dense_values = {1, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
+                                         0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
+    auto dense_data = Buffer::Wrap(dense_values);
+    NumericTensor<Int64Type> dense_tensor(dense_data, shape_, {}, dim_names_);
+    ASSERT_OK_AND_ASSIGN(sparse_tensor_from_dense_,
+                         SparseCSCMatrix::Make(
+                             dense_tensor, TypeTraits<IndexValueType>::type_singleton()));
+  }
+
+ protected:
+  std::vector<int64_t> shape_;
+  std::vector<std::string> dim_names_;
+  std::shared_ptr<SparseCSCMatrix> sparse_tensor_from_dense_;
+};
+
+class TestSparseCSCMatrix : public TestSparseCSCMatrixBase<Int64Type> {};
+
+TEST_F(TestSparseCSCMatrix, CreationFromNumericTensor2D) {
+  std::vector<int64_t> values = {1, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
+                                 0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
+  std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
+  NumericTensor<Int64Type> tensor(buffer, this->shape_);
+
+  std::shared_ptr<SparseCSCMatrix> st1;
+  ASSERT_OK_AND_ASSIGN(st1, SparseCSCMatrix::Make(tensor));
+
+  auto st2 = this->sparse_tensor_from_dense_;
+
+  CheckSparseIndexFormatType(SparseTensorFormat::CSC, *st1);
+
+  ASSERT_EQ(12, st1->non_zero_length());
+  ASSERT_TRUE(st1->is_mutable());
+
+  ASSERT_EQ(std::vector<std::string>({"foo", "bar"}), st2->dim_names());
+  ASSERT_EQ("foo", st2->dim_name(0));
+  ASSERT_EQ("bar", st2->dim_name(1));
+
+  ASSERT_EQ(std::vector<std::string>({}), st1->dim_names());
+  ASSERT_EQ("", st1->dim_name(0));
+  ASSERT_EQ("", st1->dim_name(1));
+  ASSERT_EQ("", st1->dim_name(2));
+
+  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st1->raw_data());
+  AssertNumericDataEqual(raw_data, {1, 5, 13, 3, 11, 15, 2, 6, 14, 4, 12, 16});
+
+  auto si = internal::checked_pointer_cast<SparseCSCIndex>(st1->sparse_index());
+  ASSERT_EQ(std::string("SparseCSCIndex"), si->ToString());
+  ASSERT_EQ(1, si->indptr()->ndim());
+  ASSERT_EQ(1, si->indices()->ndim());
+
+  const int64_t* indptr_begin =
+      reinterpret_cast<const int64_t*>(si->indptr()->raw_data());
+  std::vector<int64_t> indptr_values(indptr_begin,
+                                     indptr_begin + si->indptr()->shape()[0]);
+
+  ASSERT_EQ(5, indptr_values.size());
+  ASSERT_EQ(std::vector<int64_t>({0, 3, 6, 9, 12}), indptr_values);
+
+  const int64_t* indices_begin =
+      reinterpret_cast<const int64_t*>(si->indices()->raw_data());
+  std::vector<int64_t> indices_values(indices_begin,
+                                      indices_begin + si->indices()->shape()[0]);
+
+  ASSERT_EQ(12, indices_values.size());
+  ASSERT_EQ(std::vector<int64_t>({0, 2, 4, 1, 3, 5, 0, 2, 4, 1, 3, 5}), indices_values);
+}
+
+TEST_F(TestSparseCSCMatrix, CreationFromNonContiguousTensor) {
+  std::vector<int64_t> values = {1,  0, 0, 0, 2,  0, 0, 0, 0, 0, 3,  0, 0, 0, 4,  0,
+                                 5,  0, 0, 0, 6,  0, 0, 0, 0, 0, 11, 0, 0, 0, 12, 0,
+                                 13, 0, 0, 0, 14, 0, 0, 0, 0, 0, 15, 0, 0, 0, 16, 0};
+  std::vector<int64_t> strides = {64, 16};
+  std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
+  Tensor tensor(int64(), buffer, this->shape_, strides);
+
+  std::shared_ptr<SparseCSCMatrix> st;
+  ASSERT_OK_AND_ASSIGN(st, SparseCSCMatrix::Make(tensor));
+
+  ASSERT_EQ(12, st->non_zero_length());
+  ASSERT_TRUE(st->is_mutable());
+
+  const int64_t* raw_data = reinterpret_cast<const int64_t*>(st->raw_data());
+  AssertNumericDataEqual(raw_data, {1, 5, 13, 3, 11, 15, 2, 6, 14, 4, 12, 16});
+
+  auto si = internal::checked_pointer_cast<SparseCSCIndex>(st->sparse_index());
+  ASSERT_EQ(1, si->indptr()->ndim());
+  ASSERT_EQ(1, si->indices()->ndim());
+
+  const int64_t* indptr_begin =
+      reinterpret_cast<const int64_t*>(si->indptr()->raw_data());
+  std::vector<int64_t> indptr_values(indptr_begin,
+                                     indptr_begin + si->indptr()->shape()[0]);
+
+  ASSERT_EQ(5, indptr_values.size());
+  ASSERT_EQ(std::vector<int64_t>({0, 3, 6, 9, 12}), indptr_values);
+
+  const int64_t* indices_begin =
+      reinterpret_cast<const int64_t*>(si->indices()->raw_data());
+  std::vector<int64_t> indices_values(indices_begin,
+                                      indices_begin + si->indices()->shape()[0]);
+
+  ASSERT_EQ(12, indices_values.size());
+  ASSERT_EQ(std::vector<int64_t>({0, 2, 4, 1, 3, 5, 0, 2, 4, 1, 3, 5}), indices_values);
+
+  ASSERT_TRUE(st->Equals(*this->sparse_tensor_from_dense_));
+}
+
+TEST_F(TestSparseCSCMatrix, TensorEquality) {
+  std::vector<int64_t> values1 = {1, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
+                                  0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
+  std::vector<int64_t> values2 = {9, 0,  2, 0,  0,  3, 0,  4, 5, 0,  6, 0,
+                                  0, 11, 0, 12, 13, 0, 14, 0, 0, 15, 0, 16};
+  std::shared_ptr<Buffer> buffer1 = Buffer::Wrap(values1);
+  std::shared_ptr<Buffer> buffer2 = Buffer::Wrap(values2);
+  NumericTensor<Int64Type> tensor1(buffer1, this->shape_);
+  NumericTensor<Int64Type> tensor2(buffer2, this->shape_);
+
+  std::shared_ptr<SparseCSCMatrix> st1, st2;
+  ASSERT_OK_AND_ASSIGN(st1, SparseCSCMatrix::Make(tensor1));
+  ASSERT_OK_AND_ASSIGN(st2, SparseCSCMatrix::Make(tensor2));
+
+  ASSERT_TRUE(st1->Equals(*this->sparse_tensor_from_dense_));
+  ASSERT_FALSE(st1->Equals(*st2));
+}
+
+TEST_F(TestSparseCSCMatrix, TestToTensor) {
+  std::vector<int64_t> values = {1, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0, 1,
+                                 0, 2, 0, 0, 0, 0, 0, 3, 0, 0, 0, 1};
+  std::vector<int64_t> shape({6, 4});
+  std::shared_ptr<Buffer> buffer = Buffer::Wrap(values);
+  Tensor tensor(int64(), buffer, shape, {}, this->dim_names_);
+
+  std::shared_ptr<SparseCSCMatrix> sparse_tensor;
+  ASSERT_OK_AND_ASSIGN(sparse_tensor, SparseCSCMatrix::Make(tensor));
+
+  ASSERT_EQ(7, sparse_tensor->non_zero_length());
+  ASSERT_TRUE(sparse_tensor->is_mutable());
+
+  std::shared_ptr<Tensor> dense_tensor;
+  ASSERT_OK(sparse_tensor->ToTensor(&dense_tensor));
+  ASSERT_TRUE(tensor.Equals(*dense_tensor));
+}
 
 }  // namespace arrow

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -63,7 +63,7 @@ TEST(TestSparseCOOIndex, Make) {
 
   // Non-integer type
   auto res = SparseCOOIndex::Make(float32(), shape, strides, data);
-  ASSERT_RAISES(Invalid, res);
+  ASSERT_RAISES(TypeError, res);
 
   // Non-matrix indices
   res = SparseCOOIndex::Make(int32(), {4, 3, 4}, strides, data);
@@ -96,7 +96,7 @@ TEST(TestSparseCSRIndex, Make) {
   // Non-integer type
   auto res = SparseCSRIndex::Make(float32(), indptr_shape, indices_shape, indptr_data,
                                   indices_data);
-  ASSERT_RAISES(Invalid, res);
+  ASSERT_RAISES(TypeError, res);
 
   // Non-vector indptr shape
   ASSERT_RAISES(Invalid, SparseCSRIndex::Make(int32(), {1, 2}, indices_shape, indptr_data,
@@ -126,8 +126,8 @@ TEST(TestSparseCSCIndex, Make) {
   ASSERT_EQ(std::string("SparseCSCIndex"), si->ToString());
 
   // Non-integer type
-  ASSERT_RAISES(Invalid, SparseCSCIndex::Make(float32(), indptr_shape, indices_shape,
-                                              indptr_data, indices_data));
+  ASSERT_RAISES(TypeError, SparseCSCIndex::Make(float32(), indptr_shape, indices_shape,
+                                                indptr_data, indices_data));
 
   // Non-vector indptr shape
   ASSERT_RAISES(Invalid, SparseCSCIndex::Make(int32(), {1, 2}, indices_shape, indptr_data,

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -64,8 +64,13 @@ table SparseTensorIndexCOO {
   indicesBuffer: Buffer;
 }
 
-/// Compressed Sparse Row format, that is matrix-specific.
-table SparseMatrixIndexCSR {
+enum SparseMatrixCompressedAxis: short { Row, Column }
+
+/// Compressed Sparse format, that is matrix-specific.
+table SparseMatrixIndexCSX {
+  /// Which axis, row or column, is compressed
+  compressedAxis: SparseMatrixCompressedAxis;
+
   /// The type of values in indptrBuffer
   indptrType: Int;
 
@@ -110,7 +115,7 @@ table SparseMatrixIndexCSR {
 
 union SparseTensorIndex {
   SparseTensorIndexCOO,
-  SparseMatrixIndexCSR
+  SparseMatrixIndexCSX,
 }
 
 table SparseTensor {


### PR DESCRIPTION
I'd like to add CSC sparse matrix support in format and C++ API.

This pull-request changes both format and C++ API.

The changes in format are below:

- The new field `compressedAxis` is added to `SparseMatrixIndexCSR` table; this field used to distinguish CSR and CSC
- `SparseMatrixIndexCSR` is renamed to `SparseMatrixIndexCSX`

The changes in C++ API are below:

- `SparseCSCIndex` class is added as a subclass of `internal::SparseCSXIndex`
- `internal::SparseCSXIndex` class is added as a superclass of `SparseCSRIndex` and `SparseCSCIndex` classes
- `SparseCSCMatrix` class is added as an alias to `SparseTensorImpl<SparseCSCIndex>` class
- `ReadSparseTensor` supports reading `SparseCSCMatrix` class