### PR TITLE
ARROW-7299: [GLib] Use Result instead of Status

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -87,6 +87,7 @@ jobs:
       ARROW_WITH_LZ4: ON
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_ZLIB: ON
+      XML_CATALOG_FILES: /usr/local/etc/xml/catalog
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: C Glib & Ruby
+name: C GLib & Ruby
 
 on:
   push:
@@ -34,7 +34,7 @@ on:
 jobs:
 
   ubuntu:
-    name: AMD64 Ubuntu ${{ matrix.ubuntu }} Glib & Ruby
+    name: AMD64 Ubuntu ${{ matrix.ubuntu }} GLib & Ruby
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -72,7 +72,7 @@ jobs:
           docker-compose push ubuntu-ruby
 
   macos:
-    name: AMD64 MacOS 10.15 Glib & Ruby
+    name: AMD64 MacOS 10.15 GLib & Ruby
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -103,7 +103,7 @@ jobs:
         run: |
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/cpp/build
           ci/scripts/c_glib_build.sh $(pwd) $(pwd)/c_glib/build
-      - name: Test Glib
+      - name: Test GLib
         shell: bash
         run: ci/scripts/c_glib_test.sh $(pwd) $(pwd)/c_glib/build
       - name: Test Ruby

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -77,14 +77,16 @@ jobs:
     strategy:
       fail-fast: false
     env:
+      ARROW_BUILD_TESTS: ON
+      ARROW_GLIB_DEVELOPMENT_MODE: true
+      ARROW_GLIB_GTK_DOC: true
       ARROW_HOME: /usr/local
-      ARROW_ORC: OFF
       ARROW_JEMALLOC: OFF
+      ARROW_ORC: OFF
       ARROW_WITH_BROTLI: ON
       ARROW_WITH_LZ4: ON
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_ZLIB: ON
-      ARROW_BUILD_TESTS: ON
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v1

--- a/c_glib/arrow-glib/codec.cpp
+++ b/c_glib/arrow-glib/codec.cpp
@@ -131,10 +131,9 @@ garrow_codec_new(GArrowCompressionType type,
                  GError **error)
 {
   auto arrow_type = garrow_compression_type_to_raw(type);
-  std::unique_ptr<arrow::util::Codec> arrow_codec;
-  auto status = arrow::util::Codec::Create(arrow_type, &arrow_codec);
-  if (garrow_error_check(error, status, "[codec][new]")) {
-    return garrow_codec_new_raw(arrow_codec.release());
+  auto arrow_codec = arrow::util::Codec::Create(arrow_type);
+  if (garrow::check(error, arrow_codec, "[codec][new]")) {
+    return garrow_codec_new_raw(arrow_codec.ValueOrDie().release());
   } else {
     return NULL;
   }

--- a/c_glib/arrow-glib/error.cpp
+++ b/c_glib/arrow-glib/error.cpp
@@ -81,22 +81,31 @@ garrow_error_code(const arrow::Status &status)
 
 G_END_DECLS
 
+namespace garrow {
+  gboolean
+  check(GError **error,
+        const arrow::Status &status,
+        const char *context) {
+    if (status.ok()) {
+      return TRUE;
+    } else {
+      g_set_error(error,
+                  GARROW_ERROR,
+                  garrow_error_code(status),
+                  "%s: %s",
+                  context,
+                  status.ToString().c_str());
+      return FALSE;
+    }
+  }
+}
+
 gboolean
 garrow_error_check(GError **error,
                    const arrow::Status &status,
                    const char *context)
 {
-  if (status.ok()) {
-    return TRUE;
-  } else {
-    g_set_error(error,
-                GARROW_ERROR,
-                garrow_error_code(status),
-                "%s: %s",
-                context,
-                status.ToString().c_str());
-    return FALSE;
-  }
+  return garrow::check(error, status, context);
 }
 
 arrow::Status

--- a/c_glib/arrow-glib/error.hpp
+++ b/c_glib/arrow-glib/error.hpp
@@ -23,6 +23,23 @@
 
 #include <arrow-glib/error.h>
 
+namespace garrow {
+  gboolean check(GError **error,
+                 const arrow::Status &status,
+                 const char *context);
+
+  template <typename TYPE>
+  gboolean check(GError **error,
+                 const arrow::Result<TYPE> &result,
+                 const char *context) {
+    if (result.ok()) {
+      return TRUE;
+    } else {
+      return check(error, result.status(), context);
+    }
+  }
+}
+
 gboolean garrow_error_check(GError **error,
                             const arrow::Status &status,
                             const char *context);

--- a/c_glib/configure.ac
+++ b/c_glib/configure.ac
@@ -105,6 +105,17 @@ if test "x$GARROW_DEBUG" != "xno"; then
     CXXFLAGS="$CXXFLAGS -O0 -g3"
   fi
 fi
+AC_ARG_ENABLE(development-mode,
+  [AS_HELP_STRING([--enable-development-mode],
+                  [Use development mode (default=no)])],
+  [GARROW_DEVELOPMENT_MODE="$enableval"],
+  [GARROW_DEVELOPMENT_MODE="no"])
+if test "x$GARROW_DEVELOPMENT_MODE" != "xno"; then
+  if test "$CLANG" = "yes" -o "$GCC" = "yes"; then
+    CFLAGS="$CFLAGS -Werror"
+    CXXFLAGS="$CXXFLAGS -Werror"
+  fi
+fi
 AC_SUBST(GARROW_CFLAGS)
 AC_SUBST(GARROW_CXXFLAGS)
 

--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -103,6 +103,17 @@ main(void)
                                       required: false)
 endif
 
+cxx = meson.get_compiler('cpp')
+cxx_flags = []
+if get_option('development_mode')
+  if cxx.get_id() == 'msvc'
+    cxx_flags += ['/WX']
+  else
+    cxx_flags += ['-Werror']
+  endif
+endif
+add_project_arguments(cxx.get_supported_arguments(cxx_flags), language: 'cpp')
+
 subdir('arrow-glib')
 if arrow_cuda.found()
   subdir('arrow-cuda-glib')

--- a/c_glib/meson_options.txt
+++ b/c_glib/meson_options.txt
@@ -17,17 +17,22 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option('gtk_doc',
-       type: 'boolean',
-       value: false,
-       description: 'Build document by GTK-Doc')
+option('arrow_cpp_build_dir',
+       type: 'string',
+       value: '',
+       description: 'Use this option to build with not installed Arrow C++')
 
 option('arrow_cpp_build_type',
        type: 'string',
        value: 'release',
        description: '-DCMAKE_BUILD_TYPE option value for Arrow C++')
 
-option('arrow_cpp_build_dir',
-       type: 'string',
-       value: '',
-       description: 'Use this option to build with not installed Arrow C++')
+option('development_mode',
+       type: 'boolean',
+       value: false,
+       description: 'Build in development mode')
+
+option('gtk_doc',
+       type: 'boolean',
+       value: false,
+       description: 'Build document by GTK-Doc')

--- a/ci/appveyor-cpp-build-mingw.bat
+++ b/ci/appveyor-cpp-build-mingw.bat
@@ -81,6 +81,7 @@ meson ^
     setup ^
     --prefix=%INSTALL_DIR% ^
     --buildtype=%MESON_BUILD_TYPE% ^
+    -Ddevelopment_mode=true ^
     %C_GLIB_BUILD_DIR% ^
     c_glib || exit /B
 sed -i'' -s 's/\r//g' %C_GLIB_BUILD_DIR%/arrow-glib/version.h || exit /B

--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -21,7 +21,8 @@ set -ex
 
 source_dir=${1}/c_glib
 build_dir=${2:-${source_dir}/build}
-with_docs=${3:-false}
+: ${ARROW_GLIB_GTK_DOC:=false}
+: ${ARROW_GLIB_DEVELOPMENT_MODE:=false}
 
 export CFLAGS="-DARROW_NO_DEPRECATED_API"
 export CXXFLAGS="-DARROW_NO_DEPRECATED_API"
@@ -31,7 +32,8 @@ mkdir -p ${build_dir}
 # Build with Meson
 meson --prefix=$ARROW_HOME \
       --libdir=lib \
-      -Dgtk_doc=${with_docs} \
+      -Ddevelopment_mode=${ARROW_GLIB_DEVELOPMENT_MODE} \
+      -Dgtk_doc=${ARROW_GLIB_GTK_DOC} \
       ${build_dir} \
       ${source_dir}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,6 +212,9 @@ services:
         - ${REPO}:${ARCH}-debian-${DEBIAN}-c-glib
       args:
         base: ${REPO}:${ARCH}-debian-${DEBIAN}-cpp
+    environment:
+      ARROW_GLIB_GTK_DOC: "true"
+      ARROW_GLIB_DEVELOPMENT_MODE: "true"
     shm_size: *shm-size
     volumes: *debian-volumes
     command: &c-glib-command >
@@ -236,6 +239,9 @@ services:
         - ${REPO}:${ARCH}-ubuntu-${UBUNTU}-c-glib
       args:
         base: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-cpp
+    environment:
+      ARROW_GLIB_GTK_DOC: "true"
+      ARROW_GLIB_DEVELOPMENT_MODE: "true"
     shm_size: *shm-size
     volumes: *ubuntu-volumes
     command: *c-glib-command


### PR DESCRIPTION
This change suppress deprecated warnings related to Result and Status.

--enable-development-mode and -Ddevelopment_mode=true are added to
build with -Werror.