### PR TITLE
ARROW-7284: [Java] ensure java implementation meets clarified dictionary spec

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
@@ -32,6 +32,7 @@ public class ArrowDictionaryBatch implements ArrowMessage {
   private final ArrowRecordBatch dictionary;
   private final boolean isDelta;
 
+  @Deprecated
   public ArrowDictionaryBatch(long dictionaryId, ArrowRecordBatch dictionary) {
     this (dictionaryId, dictionary, false);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowDictionaryBatch.java
@@ -30,10 +30,23 @@ public class ArrowDictionaryBatch implements ArrowMessage {
 
   private final long dictionaryId;
   private final ArrowRecordBatch dictionary;
+  private final boolean isDelta;
 
   public ArrowDictionaryBatch(long dictionaryId, ArrowRecordBatch dictionary) {
+    this (dictionaryId, dictionary, false);
+  }
+
+  /**
+   * Constructs new instance.
+   */
+  public ArrowDictionaryBatch(long dictionaryId, ArrowRecordBatch dictionary, boolean isDelta) {
     this.dictionaryId = dictionaryId;
     this.dictionary = dictionary;
+    this.isDelta = isDelta;
+  }
+
+  public boolean isDelta() {
+    return isDelta;
   }
 
   public byte getMessageType() {
@@ -54,6 +67,7 @@ public class ArrowDictionaryBatch implements ArrowMessage {
     DictionaryBatch.startDictionaryBatch(builder);
     DictionaryBatch.addId(builder, dictionaryId);
     DictionaryBatch.addData(builder, dataOffset);
+    DictionaryBatch.addIsDelta(builder, isDelta);
     return DictionaryBatch.endDictionaryBatch(builder);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
@@ -491,7 +491,7 @@ public class MessageSerializer {
       throws IOException {
     DictionaryBatch dictionaryBatchFB = (DictionaryBatch) message.header(new DictionaryBatch());
     ArrowRecordBatch recordBatch = deserializeRecordBatch(dictionaryBatchFB.data(), bodyBuffer);
-    return new ArrowDictionaryBatch(dictionaryBatchFB.id(), recordBatch);
+    return new ArrowDictionaryBatch(dictionaryBatchFB.id(), recordBatch, dictionaryBatchFB.isDelta());
   }
 
   /**
@@ -570,7 +570,7 @@ public class MessageSerializer {
     final ArrowBuf body = buffer.slice(block.getMetadataLength(),
         (int) totalLen - block.getMetadataLength());
     ArrowRecordBatch recordBatch = deserializeRecordBatch(dictionaryBatchFB.data(), body);
-    return new ArrowDictionaryBatch(dictionaryBatchFB.id(), recordBatch);
+    return new ArrowDictionaryBatch(dictionaryBatchFB.id(), recordBatch, dictionaryBatchFB.isDelta());
   }
 
   /**

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -35,12 +35,14 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.arrow.flatbuf.FieldNode;
 import org.apache.arrow.flatbuf.Message;
 import org.apache.arrow.flatbuf.RecordBatch;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.util.Collections2;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
@@ -50,6 +52,7 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorLoader;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.VectorUnloader;
+import org.apache.arrow.vector.compare.VectorEqualsVisitor;
 import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryEncoder;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
@@ -76,8 +79,13 @@ public class TestArrowReaderWriter {
 
   private BufferAllocator allocator;
 
-  private Dictionary dictionary;
+  private VarCharVector dictionaryVector1;
+  private VarCharVector dictionaryVector2;
+  private VarCharVector dictionaryVector3;
+
+  private Dictionary dictionary1;
   private Dictionary dictionary2;
+  private Dictionary dictionary3;
 
   private Schema schema;
   private Schema encodedSchema;
@@ -86,29 +94,43 @@ public class TestArrowReaderWriter {
   public void init() {
     allocator = new RootAllocator(Long.MAX_VALUE);
 
-    VarCharVector dictionary1Vector = newVarCharVector("D1", allocator);
-    dictionary1Vector.allocateNewSafe();
-    dictionary1Vector.set(0, "foo".getBytes(StandardCharsets.UTF_8));
-    dictionary1Vector.set(1, "bar".getBytes(StandardCharsets.UTF_8));
-    dictionary1Vector.set(2, "baz".getBytes(StandardCharsets.UTF_8));
-    dictionary1Vector.setValueCount(3);
+    dictionaryVector1 = newVarCharVector("D1", allocator);
+    dictionaryVector1.allocateNewSafe();
+    dictionaryVector1.set(0, "foo".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector1.set(1, "bar".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector1.set(2, "baz".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector1.setValueCount(3);
 
-    dictionary = new Dictionary(dictionary1Vector, new DictionaryEncoding(1L, false, null));
+    dictionaryVector2 = newVarCharVector("D2", allocator);
+    dictionaryVector2.allocateNewSafe();
+    dictionaryVector2.set(0, "aa".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector2.set(1, "bb".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector2.set(2, "cc".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector2.setValueCount(3);
 
-    VarCharVector dictionary2Vector = newVarCharVector("D2", allocator);
-    dictionary2Vector.allocateNewSafe();
-    dictionary2Vector.set(0, "aa".getBytes(StandardCharsets.UTF_8));
-    dictionary2Vector.set(1, "bb".getBytes(StandardCharsets.UTF_8));
-    dictionary2Vector.set(2, "cc".getBytes(StandardCharsets.UTF_8));
-    dictionary2Vector.setValueCount(3);
+    dictionaryVector3 = newVarCharVector("D3", allocator);
+    dictionaryVector3.allocateNewSafe();
+    dictionaryVector3.set(0, "foo".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector3.set(1, "bar".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector3.set(2, "baz".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector3.set(3, "aa".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector3.set(4, "bb".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector3.set(5, "cc".getBytes(StandardCharsets.UTF_8));
+    dictionaryVector3.setValueCount(6);
 
-    dictionary2 = new Dictionary(dictionary2Vector, new DictionaryEncoding(2L, false, null));
+    dictionary1 =
+        new Dictionary(dictionaryVector1, new DictionaryEncoding(1L, false, null));
+    dictionary2 =
+        new Dictionary(dictionaryVector2, new DictionaryEncoding(2L, false, null));
+    dictionary3 =
+        new Dictionary(dictionaryVector3, new DictionaryEncoding(1L, false, null));
   }
 
   @After
   public void terminate() throws Exception {
-    dictionary.getVector().close();
-    dictionary2.getVector().close();
+    dictionaryVector1.close();
+    dictionaryVector2.close();
+    dictionaryVector3.close();
     allocator.close();
   }
 
@@ -232,7 +254,7 @@ public class TestArrowReaderWriter {
   @Test
   public void testWriteReadWithDictionaries() throws IOException {
     DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
-    provider.put(dictionary);
+    provider.put(dictionary1);
 
     VarCharVector vector1 = newVarCharVector("varchar1", allocator);
     vector1.allocateNewSafe();
@@ -242,7 +264,7 @@ public class TestArrowReaderWriter {
     vector1.set(4, "bar".getBytes(StandardCharsets.UTF_8));
     vector1.set(5, "baz".getBytes(StandardCharsets.UTF_8));
     vector1.setValueCount(6);
-    FieldVector encodedVector1 = (FieldVector) DictionaryEncoder.encode(vector1, dictionary);
+    FieldVector encodedVector1 = (FieldVector) DictionaryEncoder.encode(vector1, dictionary1);
     vector1.close();
 
     VarCharVector vector2 = newVarCharVector("varchar2", allocator);
@@ -254,7 +276,7 @@ public class TestArrowReaderWriter {
     vector2.set(4, "foo".getBytes(StandardCharsets.UTF_8));
     vector2.set(5, "bar".getBytes(StandardCharsets.UTF_8));
     vector2.setValueCount(6);
-    FieldVector encodedVector2 = (FieldVector) DictionaryEncoder.encode(vector2, dictionary);
+    FieldVector encodedVector2 = (FieldVector) DictionaryEncoder.encode(vector2, dictionary1);
     vector2.close();
 
     List<Field> fields = Arrays.asList(encodedVector1.getField(), encodedVector2.getField());
@@ -285,7 +307,7 @@ public class TestArrowReaderWriter {
   public void testEmptyStreamInFileIPC() throws IOException {
 
     DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
-    provider.put(dictionary);
+    provider.put(dictionary1);
 
     VarCharVector vector = newVarCharVector("varchar", allocator);
     vector.allocateNewSafe();
@@ -296,7 +318,7 @@ public class TestArrowReaderWriter {
     vector.set(5, "baz".getBytes(StandardCharsets.UTF_8));
     vector.setValueCount(6);
 
-    FieldVector encodedVector1A = (FieldVector) DictionaryEncoder.encode(vector, dictionary);
+    FieldVector encodedVector1A = (FieldVector) DictionaryEncoder.encode(vector, dictionary1);
     vector.close();
 
     List<Field> fields = Arrays.asList(encodedVector1A.getField());
@@ -326,7 +348,7 @@ public class TestArrowReaderWriter {
   public void testEmptyStreamInStreamingIPC() throws IOException {
 
     DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
-    provider.put(dictionary);
+    provider.put(dictionary1);
 
     VarCharVector vector = newVarCharVector("varchar", allocator);
     vector.allocateNewSafe();
@@ -337,7 +359,7 @@ public class TestArrowReaderWriter {
     vector.set(5, "baz".getBytes(StandardCharsets.UTF_8));
     vector.setValueCount(6);
 
-    FieldVector encodedVector = (FieldVector) DictionaryEncoder.encode(vector, dictionary);
+    FieldVector encodedVector = (FieldVector) DictionaryEncoder.encode(vector, dictionary1);
     vector.close();
 
     List<Field> fields = Arrays.asList(encodedVector.getField());
@@ -362,6 +384,174 @@ public class TestArrowReaderWriter {
   }
 
   @Test
+  public void testDictionaryReplacement() throws Exception {
+    VarCharVector vector1 = newVarCharVector("varchar1", allocator);
+    vector1.allocateNewSafe();
+    vector1.set(0, "foo".getBytes(StandardCharsets.UTF_8));
+    vector1.set(1, "bar".getBytes(StandardCharsets.UTF_8));
+    vector1.set(2, "baz".getBytes(StandardCharsets.UTF_8));
+    vector1.set(3, "bar".getBytes(StandardCharsets.UTF_8));
+    vector1.setValueCount(4);
+
+    FieldVector encodedVector1 = (FieldVector) DictionaryEncoder.encode(vector1, dictionary1);
+
+    VarCharVector vector2 = newVarCharVector("varchar2", allocator);
+    vector2.allocateNewSafe();
+    vector2.set(0, "foo".getBytes(StandardCharsets.UTF_8));
+    vector2.set(1, "foo".getBytes(StandardCharsets.UTF_8));
+    vector2.set(2, "foo".getBytes(StandardCharsets.UTF_8));
+    vector2.set(3, "foo".getBytes(StandardCharsets.UTF_8));
+    vector2.setValueCount(4);
+
+    FieldVector encodedVector2 = (FieldVector) DictionaryEncoder.encode(vector2, dictionary1);
+
+    DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
+    provider.put(dictionary1);
+    List<Field> schemaFields = new ArrayList<>();
+    schemaFields.add(DictionaryUtility.toMessageFormat(encodedVector1.getField(), provider, new HashSet<>()));
+    schemaFields.add(DictionaryUtility.toMessageFormat(encodedVector2.getField(), provider, new HashSet<>()));
+    Schema schema = new Schema(schemaFields);
+
+    ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    WriteChannel out = new WriteChannel(newChannel(outStream));
+
+    // write schema
+    MessageSerializer.serialize(out, schema);
+
+    List<AutoCloseable> closeableList = new ArrayList<>();
+
+    // write non-delta dictionary with id=1
+    serializeDictionaryBatch(out, dictionary3, false, closeableList);
+
+    // write non-delta dictionary with id=1
+    serializeDictionaryBatch(out, dictionary1, false, closeableList);
+
+    // write recordBatch2
+    serializeRecordBatch(out, Arrays.asList(encodedVector1, encodedVector2), closeableList);
+
+    // write eos
+    out.writeIntLittleEndian(0);
+
+    try (ArrowStreamReader reader = new ArrowStreamReader(
+        new ByteArrayReadableSeekableByteChannel(outStream.toByteArray()), allocator)) {
+      assertEquals(1, reader.getDictionaryVectors().size());
+      assertTrue(reader.loadNextBatch());
+      FieldVector dictionaryVector = reader.getDictionaryVectors().get(1L).getVector();
+      // make sure the delta dictionary is concatenated.
+      assertTrue(VectorEqualsVisitor.vectorEquals(dictionaryVector, dictionaryVector1));
+      assertFalse(reader.loadNextBatch());
+    }
+
+    vector1.close();
+    vector2.close();
+    AutoCloseables.close(closeableList);
+  }
+
+  @Test
+  public void testDeltaDictionary() throws Exception {
+    VarCharVector vector1 = newVarCharVector("varchar1", allocator);
+    vector1.allocateNewSafe();
+    vector1.set(0, "foo".getBytes(StandardCharsets.UTF_8));
+    vector1.set(1, "bar".getBytes(StandardCharsets.UTF_8));
+    vector1.set(2, "baz".getBytes(StandardCharsets.UTF_8));
+    vector1.set(3, "bar".getBytes(StandardCharsets.UTF_8));
+    vector1.setValueCount(4);
+
+    FieldVector encodedVector1 = (FieldVector) DictionaryEncoder.encode(vector1, dictionary1);
+
+    VarCharVector vector2 = newVarCharVector("varchar2", allocator);
+    vector2.allocateNewSafe();
+    vector2.set(0, "foo".getBytes(StandardCharsets.UTF_8));
+    vector2.set(1, "aa".getBytes(StandardCharsets.UTF_8));
+    vector2.set(2, "bb".getBytes(StandardCharsets.UTF_8));
+    vector2.set(3, "cc".getBytes(StandardCharsets.UTF_8));
+    vector2.setValueCount(4);
+
+    FieldVector encodedVector2 = (FieldVector) DictionaryEncoder.encode(vector2, dictionary3);
+
+    DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
+    provider.put(dictionary1);
+    provider.put(dictionary3);
+    List<Field> schemaFields = new ArrayList<>();
+    schemaFields.add(DictionaryUtility.toMessageFormat(encodedVector1.getField(), provider, new HashSet<>()));
+    schemaFields.add(DictionaryUtility.toMessageFormat(encodedVector2.getField(), provider, new HashSet<>()));
+    Schema schema = new Schema(schemaFields);
+
+    ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    WriteChannel out = new WriteChannel(newChannel(outStream));
+
+    // write schema
+    MessageSerializer.serialize(out, schema);
+
+    List<AutoCloseable> closeableList = new ArrayList<>();
+
+    // write non-delta dictionary with id=1
+    serializeDictionaryBatch(out, dictionary1, false, closeableList);
+
+    // write delta dictionary with id=1
+    Dictionary deltaDictionary =
+        new Dictionary(dictionaryVector2, new DictionaryEncoding(1L, false, null));
+    serializeDictionaryBatch(out, deltaDictionary, true, closeableList);
+    deltaDictionary.getVector().close();
+
+    // write recordBatch2
+    serializeRecordBatch(out, Arrays.asList(encodedVector1, encodedVector2), closeableList);
+
+    // write eos
+    out.writeIntLittleEndian(0);
+
+    try (ArrowStreamReader reader = new ArrowStreamReader(
+        new ByteArrayReadableSeekableByteChannel(outStream.toByteArray()), allocator)) {
+      assertEquals(1, reader.getDictionaryVectors().size());
+      assertTrue(reader.loadNextBatch());
+      FieldVector dictionaryVector = reader.getDictionaryVectors().get(1L).getVector();
+      // make sure the delta dictionary is concatenated.
+      assertTrue(VectorEqualsVisitor.vectorEquals(dictionaryVector, dictionaryVector3));
+      assertFalse(reader.loadNextBatch());
+    }
+
+    vector1.close();
+    vector2.close();
+    AutoCloseables.close(closeableList);
+
+  }
+
+  private void serializeDictionaryBatch(
+      WriteChannel out,
+      Dictionary dictionary,
+      boolean isDelta,
+      List<AutoCloseable> closeables) throws IOException {
+
+    FieldVector dictVector = dictionary.getVector();
+    VectorSchemaRoot root = new VectorSchemaRoot(
+        Collections.singletonList(dictVector.getField()),
+        Collections.singletonList(dictVector),
+        dictVector.getValueCount());
+    ArrowDictionaryBatch batch =
+        new ArrowDictionaryBatch(dictionary.getEncoding().getId(), new VectorUnloader(root).getRecordBatch(), isDelta);
+    MessageSerializer.serialize(out, batch);
+    closeables.add(batch);
+    closeables.add(root);
+  }
+
+  private void serializeRecordBatch(
+      WriteChannel out,
+      List<FieldVector> vectors,
+      List<AutoCloseable> closeables) throws IOException {
+
+    List<Field> fields = vectors.stream().map(v -> v.getField()).collect(Collectors.toList());
+    VectorSchemaRoot root = new VectorSchemaRoot(
+        fields,
+        vectors,
+        vectors.get(0).getValueCount());
+    VectorUnloader unloader = new VectorUnloader(root);
+    ArrowRecordBatch batch = unloader.getRecordBatch();
+    MessageSerializer.serialize(out, batch);
+    closeables.add(batch);
+    closeables.add(root);
+  }
+
+  @Test
   public void testReadInterleavedData() throws IOException {
     List<ArrowRecordBatch> batches = createRecordBatches();
 
@@ -372,7 +562,7 @@ public class TestArrowReaderWriter {
     MessageSerializer.serialize(out, schema);
 
     // write dictionary1
-    FieldVector dictVector1 = dictionary.getVector();
+    FieldVector dictVector1 = dictionary1.getVector();
     VectorSchemaRoot dictRoot1 = new VectorSchemaRoot(
         Collections.singletonList(dictVector1.getField()),
         Collections.singletonList(dictVector1),
@@ -421,7 +611,7 @@ public class TestArrowReaderWriter {
     List<ArrowRecordBatch> batches = new ArrayList<>();
 
     DictionaryProvider.MapDictionaryProvider provider = new DictionaryProvider.MapDictionaryProvider();
-    provider.put(dictionary);
+    provider.put(dictionary1);
     provider.put(dictionary2);
 
     VarCharVector vectorA1 = newVarCharVector("varcharA1", allocator);
@@ -435,7 +625,7 @@ public class TestArrowReaderWriter {
 
     VarCharVector vectorA2 = newVarCharVector("varcharA2", allocator);
     vectorA2.setValueCount(6);
-    FieldVector encodedVectorA1 = (FieldVector) DictionaryEncoder.encode(vectorA1, dictionary);
+    FieldVector encodedVectorA1 = (FieldVector) DictionaryEncoder.encode(vectorA1, dictionary1);
     vectorA1.close();
     FieldVector encodedVectorA2 = (FieldVector) DictionaryEncoder.encode(vectorA1, dictionary2);
     vectorA2.close();
@@ -459,7 +649,7 @@ public class TestArrowReaderWriter {
     vectorB2.set(4, "bb".getBytes(StandardCharsets.UTF_8));
     vectorB2.set(5, "cc".getBytes(StandardCharsets.UTF_8));
     vectorB2.setValueCount(6);
-    FieldVector encodedVectorB1 = (FieldVector) DictionaryEncoder.encode(vectorB1, dictionary);
+    FieldVector encodedVectorB1 = (FieldVector) DictionaryEncoder.encode(vectorB1, dictionary1);
     vectorB1.close();
     FieldVector encodedVectorB2 = (FieldVector) DictionaryEncoder.encode(vectorB2, dictionary2);
     vectorB2.close();

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector.ipc;
 import static java.nio.channels.Channels.newChannel;
 import static java.util.Arrays.asList;
 import static org.apache.arrow.vector.TestUtils.newVarCharVector;
+import static org.apache.arrow.vector.testing.ValueVectorDataPopulator.setVector;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -95,35 +96,32 @@ public class TestArrowReaderWriter {
     allocator = new RootAllocator(Long.MAX_VALUE);
 
     dictionaryVector1 = newVarCharVector("D1", allocator);
-    dictionaryVector1.allocateNewSafe();
-    dictionaryVector1.set(0, "foo".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector1.set(1, "bar".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector1.set(2, "baz".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector1.setValueCount(3);
+    setVector(dictionaryVector1,
+        "foo".getBytes(StandardCharsets.UTF_8),
+        "bar".getBytes(StandardCharsets.UTF_8),
+        "baz".getBytes(StandardCharsets.UTF_8));
 
     dictionaryVector2 = newVarCharVector("D2", allocator);
-    dictionaryVector2.allocateNewSafe();
-    dictionaryVector2.set(0, "aa".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector2.set(1, "bb".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector2.set(2, "cc".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector2.setValueCount(3);
+    setVector(dictionaryVector2,
+        "aa".getBytes(StandardCharsets.UTF_8),
+        "bb".getBytes(StandardCharsets.UTF_8),
+        "cc".getBytes(StandardCharsets.UTF_8));
 
     dictionaryVector3 = newVarCharVector("D3", allocator);
-    dictionaryVector3.allocateNewSafe();
-    dictionaryVector3.set(0, "foo".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector3.set(1, "bar".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector3.set(2, "baz".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector3.set(3, "aa".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector3.set(4, "bb".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector3.set(5, "cc".getBytes(StandardCharsets.UTF_8));
-    dictionaryVector3.setValueCount(6);
+    setVector(dictionaryVector3,
+        "foo".getBytes(StandardCharsets.UTF_8),
+        "bar".getBytes(StandardCharsets.UTF_8),
+        "baz".getBytes(StandardCharsets.UTF_8),
+        "aa".getBytes(StandardCharsets.UTF_8),
+        "bb".getBytes(StandardCharsets.UTF_8),
+        "cc".getBytes(StandardCharsets.UTF_8));
 
-    dictionary1 =
-        new Dictionary(dictionaryVector1, new DictionaryEncoding(1L, false, null));
-    dictionary2 =
-        new Dictionary(dictionaryVector2, new DictionaryEncoding(2L, false, null));
-    dictionary3 =
-        new Dictionary(dictionaryVector3, new DictionaryEncoding(1L, false, null));
+    dictionary1 = new Dictionary(dictionaryVector1,
+        new DictionaryEncoding(/*id=*/1L, /*ordered=*/false, /*indexType=*/null));
+    dictionary2 = new Dictionary(dictionaryVector2,
+        new DictionaryEncoding(/*id=*/2L, /*ordered=*/false, /*indexType=*/null));
+    dictionary3 = new Dictionary(dictionaryVector3,
+        new DictionaryEncoding(/*id=*/1L, /*ordered=*/false, /*indexType=*/null));
   }
 
   @After
@@ -386,22 +384,20 @@ public class TestArrowReaderWriter {
   @Test
   public void testDictionaryReplacement() throws Exception {
     VarCharVector vector1 = newVarCharVector("varchar1", allocator);
-    vector1.allocateNewSafe();
-    vector1.set(0, "foo".getBytes(StandardCharsets.UTF_8));
-    vector1.set(1, "bar".getBytes(StandardCharsets.UTF_8));
-    vector1.set(2, "baz".getBytes(StandardCharsets.UTF_8));
-    vector1.set(3, "bar".getBytes(StandardCharsets.UTF_8));
-    vector1.setValueCount(4);
+    setVector(vector1,
+        "foo".getBytes(StandardCharsets.UTF_8),
+        "bar".getBytes(StandardCharsets.UTF_8),
+        "baz".getBytes(StandardCharsets.UTF_8),
+        "bar".getBytes(StandardCharsets.UTF_8));
 
     FieldVector encodedVector1 = (FieldVector) DictionaryEncoder.encode(vector1, dictionary1);
 
     VarCharVector vector2 = newVarCharVector("varchar2", allocator);
-    vector2.allocateNewSafe();
-    vector2.set(0, "foo".getBytes(StandardCharsets.UTF_8));
-    vector2.set(1, "foo".getBytes(StandardCharsets.UTF_8));
-    vector2.set(2, "foo".getBytes(StandardCharsets.UTF_8));
-    vector2.set(3, "foo".getBytes(StandardCharsets.UTF_8));
-    vector2.setValueCount(4);
+    setVector(vector2,
+        "foo".getBytes(StandardCharsets.UTF_8),
+        "foo".getBytes(StandardCharsets.UTF_8),
+        "foo".getBytes(StandardCharsets.UTF_8),
+        "foo".getBytes(StandardCharsets.UTF_8));
 
     FieldVector encodedVector2 = (FieldVector) DictionaryEncoder.encode(vector2, dictionary1);
 
@@ -450,22 +446,20 @@ public class TestArrowReaderWriter {
   @Test
   public void testDeltaDictionary() throws Exception {
     VarCharVector vector1 = newVarCharVector("varchar1", allocator);
-    vector1.allocateNewSafe();
-    vector1.set(0, "foo".getBytes(StandardCharsets.UTF_8));
-    vector1.set(1, "bar".getBytes(StandardCharsets.UTF_8));
-    vector1.set(2, "baz".getBytes(StandardCharsets.UTF_8));
-    vector1.set(3, "bar".getBytes(StandardCharsets.UTF_8));
-    vector1.setValueCount(4);
+    setVector(vector1,
+        "foo".getBytes(StandardCharsets.UTF_8),
+        "bar".getBytes(StandardCharsets.UTF_8),
+        "baz".getBytes(StandardCharsets.UTF_8),
+        "bar".getBytes(StandardCharsets.UTF_8));
 
     FieldVector encodedVector1 = (FieldVector) DictionaryEncoder.encode(vector1, dictionary1);
 
     VarCharVector vector2 = newVarCharVector("varchar2", allocator);
-    vector2.allocateNewSafe();
-    vector2.set(0, "foo".getBytes(StandardCharsets.UTF_8));
-    vector2.set(1, "aa".getBytes(StandardCharsets.UTF_8));
-    vector2.set(2, "bb".getBytes(StandardCharsets.UTF_8));
-    vector2.set(3, "cc".getBytes(StandardCharsets.UTF_8));
-    vector2.setValueCount(4);
+    setVector(vector2,
+        "foo".getBytes(StandardCharsets.UTF_8),
+        "aa".getBytes(StandardCharsets.UTF_8),
+        "bb".getBytes(StandardCharsets.UTF_8),
+        "cc".getBytes(StandardCharsets.UTF_8));
 
     FieldVector encodedVector2 = (FieldVector) DictionaryEncoder.encode(vector2, dictionary3);
 


### PR DESCRIPTION
Related to [ARROW-7284](https://issues.apache.org/jira/browse/ARROW-7284). 
As discussed on [[link](https://lists.apache.org/thread.html/d0f137e9db0abfcfde2ef879ca517a710f620e5be4dd749923d22c37@%3Cdev.arrow.apache.org%3E)]. This is the java side implementation.
1.  It is not required that all dictionary batches occur at the beginning
of the IPC stream format (if a the first record batch has an all null
dictionary encoded column, the null column's dictionary might not be sent
until later in the stream).

2.  A second dictionary batch for the same ID that is not a "delta batch"
in an IPC stream indicates the dictionary should be replaced.

3.  Clarifies that the file format, can only contain 1 "NON-delta"
dictionary batch and multiple "delta" dictionary batches.

4.  Add an enum to dictionary metadata for possible future changes in what
format dictionary batches can be sent. (the most likely would be an array
Map<Int, Value>).  An enum is needed as a place holder to allow for forward
compatibility past the release 1.0.0.