### PR TITLE
ARROW-7309: [Python] Support HDFS federation viewfs

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -366,7 +366,7 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUri(const std::string& uri_str
     return std::make_shared<LocalFileSystem>();
   }
 
-  if (scheme == "hdfs") {
+  if (scheme == "hdfs" || scheme == "viewfs") {
 #ifdef ARROW_HDFS
     ARROW_ASSIGN_OR_RAISE(auto options, HdfsOptions::FromUri(uri));
     ARROW_ASSIGN_OR_RAISE(auto hdfs, HadoopFileSystem::Make(options));

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -320,9 +320,8 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   std::string host;
   if (useHdfs3) {
     host = uri.host();
-  }
-  else {
-    host = uri.scheme() + "://" + uri.host();    
+  } else {
+    host = uri.scheme() + "://" + uri.host();
   }
 
   const auto port = uri.port();

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -317,8 +317,10 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
 
   std::string host;
   if (useHdfs3) {
-    ARROW_LOG(WARNING)
-        << "viewfs://namenode resolves to hdfs://namenode with hdfs3 driver.";
+    if (uri.scheme() == "viewfs") {
+      ARROW_LOG(WARNING)
+          << "viewfs://namenode resolves to hdfs://namenode with hdfs3 driver.";
+    }
     host = uri.host();
   } else {
     host = uri.scheme() + "://" + uri.host();

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -46,8 +46,6 @@ using internal::GetAbstractPathParent;
 using internal::MakeAbstractPathRelative;
 using internal::RemoveLeadingSlash;
 
-static constexpr int32_t kDefaultHdfsPort = 0;
-
 class HadoopFileSystem::Impl {
  public:
   explicit Impl(HdfsOptions options) : options_(std::move(options)) {}
@@ -268,7 +266,7 @@ void HdfsOptions::ConfigureEndPoint(const std::string& host, int port) {
   connection_config.port = port;
 }
 
-void HdfsOptions::ConfigureHdfs3Driver(bool use_hdfs3) {
+void HdfsOptions::ConfigureHdfsDriver(bool use_hdfs3) {
   if (use_hdfs3) {
     connection_config.driver = ::arrow::io::HdfsDriver::LIBHDFS3;
   } else {
@@ -306,10 +304,10 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   if (it != options_map.end()) {
     const auto& v = it->second;
     if (v == "1") {
-      options.ConfigureHdfs3Driver(true);
+      options.ConfigureHdfsDriver(true);
       useHdfs3 = true;
     } else if (v == "0") {
-      options.ConfigureHdfs3Driver(false);
+      options.ConfigureHdfsDriver(false);
     } else {
       return Status::Invalid(
           "Invalid value for option 'use_hdfs3' (allowed values are '0' and '1'): '", v,
@@ -326,7 +324,8 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
 
   const auto port = uri.port();
   if (port == -1) {
-    options.ConfigureEndPoint(host, kDefaultHdfsPort);
+    // default port will be determined by hdfs FileSystem impl
+    options.ConfigureEndPoint(host, 0);
   } else {
     options.ConfigureEndPoint(host, port);
   }

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -317,7 +317,8 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
 
   std::string host;
   if (useHdfs3) {
-    ARROW_LOG(WARNING) << "viewfs://namenode resolves to hdfs://namenode with hdfs3 driver.";
+    ARROW_LOG(WARNING)
+        << "viewfs://namenode resolves to hdfs://namenode with hdfs3 driver.";
     host = uri.host();
   } else {
     host = uri.scheme() + "://" + uri.host();

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -331,7 +331,6 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
     options.ConfigureEndPoint(host, port);
   }
 
-
   it = options_map.find("replication");
   if (it != options_map.end()) {
     const auto& v = it->second;

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -317,6 +317,7 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
 
   std::string host;
   if (useHdfs3) {
+    ARROW_LOG(WARNING) << "viewfs://namenode resolves to hdfs://namenode with hdfs3 driver.";
     host = uri.host();
   } else {
     host = uri.scheme() + "://" + uri.host();

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -46,7 +46,7 @@ using internal::GetAbstractPathParent;
 using internal::MakeAbstractPathRelative;
 using internal::RemoveLeadingSlash;
 
-static constexpr int32_t kDefaultHdfsPort = 8020;
+static constexpr int32_t kDefaultHdfsPort = 0;
 
 class HadoopFileSystem::Impl {
  public:
@@ -268,7 +268,7 @@ void HdfsOptions::ConfigureEndPoint(const std::string& host, int port) {
   connection_config.port = port;
 }
 
-void HdfsOptions::ConfigureHdfsDriver(bool use_hdfs3) {
+void HdfsOptions::ConfigureHdfs3Driver(bool use_hdfs3) {
   if (use_hdfs3) {
     connection_config.driver = ::arrow::io::HdfsDriver::LIBHDFS3;
   } else {
@@ -312,9 +312,9 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   if (it != options_map.end()) {
     const auto& v = it->second;
     if (v == "1") {
-      options.ConfigureHdfsDriver(true);
+      options.ConfigureHdfs3Driver(true);
     } else if (v == "0") {
-      options.ConfigureHdfsDriver(false);
+      options.ConfigureHdfs3Driver(false);
     } else {
       return Status::Invalid(
           "Invalid value for option 'use_hdfs3' (allowed values are '0' and '1'): '", v,

--- a/cpp/src/arrow/filesystem/hdfs.h
+++ b/cpp/src/arrow/filesystem/hdfs.h
@@ -43,7 +43,7 @@ struct ARROW_EXPORT HdfsOptions {
 
   void ConfigureEndPoint(const std::string& host, int port);
   /// Be cautious that libhdfs3 is a unmaintained project
-  void ConfigureHdfsDriver(bool use_hdfs3);
+  void ConfigureHdfs3Driver(bool use_hdfs3);
   void ConfigureHdfsReplication(int16_t replication);
   void ConfigureHdfsUser(const std::string& user_name);
   void ConfigureHdfsBufferSize(int32_t buffer_size);

--- a/cpp/src/arrow/filesystem/hdfs.h
+++ b/cpp/src/arrow/filesystem/hdfs.h
@@ -43,7 +43,7 @@ struct ARROW_EXPORT HdfsOptions {
 
   void ConfigureEndPoint(const std::string& host, int port);
   /// Be cautious that libhdfs3 is a unmaintained project
-  void ConfigureHdfs3Driver(bool use_hdfs3);
+  void ConfigureHdfsDriver(bool use_hdfs3);
   void ConfigureHdfsReplication(int16_t replication);
   void ConfigureHdfsUser(const std::string& user_name);
   void ConfigureHdfsBufferSize(int32_t buffer_size);

--- a/cpp/src/arrow/filesystem/hdfs_test.cc
+++ b/cpp/src/arrow/filesystem/hdfs_test.cc
@@ -91,7 +91,7 @@ class TestHadoopFileSystem : public ::testing::Test {
 
     options_.ConfigureEndPoint(hdfs_host, hdfs_port);
     options_.ConfigureHdfsUser(hdfs_user);
-    options_.ConfigureHdfsDriver(use_hdfs3_);
+    options_.ConfigureHdfs3Driver(use_hdfs3_);
     options_.ConfigureHdfsReplication(0);
 
     auto result = HadoopFileSystem::Make(options_);

--- a/cpp/src/arrow/filesystem/hdfs_test.cc
+++ b/cpp/src/arrow/filesystem/hdfs_test.cc
@@ -98,7 +98,7 @@ class TestHadoopFileSystem : public ::testing::Test {
 
     options_.ConfigureEndPoint(hdfs_host, hdfs_port);
     options_.ConfigureHdfsUser(hdfs_user);
-    options_.ConfigureHdfs3Driver(use_hdfs3_);
+    options_.ConfigureHdfsDriver(use_hdfs3_);
     options_.ConfigureHdfsReplication(0);
 
     auto result = HadoopFileSystem::Make(options_);

--- a/cpp/src/arrow/filesystem/hdfs_test.cc
+++ b/cpp/src/arrow/filesystem/hdfs_test.cc
@@ -61,6 +61,13 @@ TEST(TestHdfsOptions, FromUri) {
   ASSERT_EQ(options.connection_config.port, 9999);
   ASSERT_EQ(options.connection_config.user, "stevereich");
   ASSERT_EQ(options.connection_config.driver, HdfsDriver::LIBHDFS3);
+
+  ASSERT_OK(uri.Parse("viewfs://other-nn/mypath/myfile"));
+  ASSERT_OK_AND_ASSIGN(options, HdfsOptions::FromUri(uri));
+  ASSERT_EQ(options.connection_config.host, "viewfs://other-nn");
+  ASSERT_EQ(options.connection_config.port, 0);
+  ASSERT_EQ(options.connection_config.user, "");
+  ASSERT_EQ(options.connection_config.driver, HdfsDriver::LIBHDFS);
 }
 
 struct JNIDriver {

--- a/cpp/src/arrow/filesystem/hdfs_test.cc
+++ b/cpp/src/arrow/filesystem/hdfs_test.cc
@@ -42,7 +42,7 @@ TEST(TestHdfsOptions, FromUri) {
   ASSERT_OK_AND_ASSIGN(options, HdfsOptions::FromUri(uri));
   ASSERT_EQ(options.replication, 3);
   ASSERT_EQ(options.connection_config.host, "localhost");
-  ASSERT_EQ(options.connection_config.port, 8020);
+  ASSERT_EQ(options.connection_config.port, 0);
   ASSERT_EQ(options.connection_config.user, "");
   ASSERT_EQ(options.connection_config.driver, HdfsDriver::LIBHDFS);
 

--- a/cpp/src/arrow/filesystem/hdfs_test.cc
+++ b/cpp/src/arrow/filesystem/hdfs_test.cc
@@ -41,7 +41,7 @@ TEST(TestHdfsOptions, FromUri) {
   ASSERT_OK(uri.Parse("hdfs://localhost"));
   ASSERT_OK_AND_ASSIGN(options, HdfsOptions::FromUri(uri));
   ASSERT_EQ(options.replication, 3);
-  ASSERT_EQ(options.connection_config.host, "localhost");
+  ASSERT_EQ(options.connection_config.host, "hdfs://localhost");
   ASSERT_EQ(options.connection_config.port, 0);
   ASSERT_EQ(options.connection_config.user, "");
   ASSERT_EQ(options.connection_config.driver, HdfsDriver::LIBHDFS);
@@ -49,7 +49,7 @@ TEST(TestHdfsOptions, FromUri) {
   ASSERT_OK(uri.Parse("hdfs://otherhost:9999/?use_hdfs3=0&replication=2"));
   ASSERT_OK_AND_ASSIGN(options, HdfsOptions::FromUri(uri));
   ASSERT_EQ(options.replication, 2);
-  ASSERT_EQ(options.connection_config.host, "otherhost");
+  ASSERT_EQ(options.connection_config.host, "hdfs://otherhost");
   ASSERT_EQ(options.connection_config.port, 9999);
   ASSERT_EQ(options.connection_config.user, "");
   ASSERT_EQ(options.connection_config.driver, HdfsDriver::LIBHDFS);

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -416,12 +416,14 @@ def resolve_filesystem_and_path(where, filesystem=None):
         return _ensure_filesystem(filesystem), path
 
     parsed_uri = urlparse(path)
-    if parsed_uri.scheme == 'hdfs':
+    if parsed_uri.scheme == 'hdfs' or parsed_uri.scheme == 'viewfs':
         # Input is hdfs URI such as hdfs://host:port/myfile.parquet
         netloc_split = parsed_uri.netloc.split(':')
         host = netloc_split[0]
         if host == '':
             host = 'default'
+        else:
+            host = parsed_uri.scheme + "://" + host
         port = 0
         if len(netloc_split) == 2 and netloc_split[1].isnumeric():
             port = int(netloc_split[1])

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -583,7 +583,7 @@ def test_hdfs_options(hdfs_server):
     assert options.buffer_size == 64*1024
 
     options = HdfsOptions.from_uri('hdfs://localhost:8080/?user=test')
-    assert options.endpoint == ('localhost', 8080)
+    assert options.endpoint == ('hdfs://localhost', 8080)
     assert options.user == 'test'
 
     host, port, user = hdfs_server


### PR DESCRIPTION
- libhdfs already supports injecting the scheme and will automatically resolve federation in
`fs = FileSystem#get(URI, conf, ugi)`
- works with Hadoop 2/3

see:
https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c#L770
https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/hdfs.c#L637