### PR TITLE
PARQUET-1692: [C++] Don't use the same CMake variable name for thirdparty version and found version

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1119,6 +1119,7 @@ macro(build_thrift)
                                    INTERFACE_INCLUDE_DIRECTORIES "${THRIFT_INCLUDE_DIR}")
   add_dependencies(toolchain thrift_ep)
   add_dependencies(Thrift::thrift thrift_ep)
+  set(THRIFT_VERSION ${ARROW_THRIFT_BUILD_VERSION})
 endmacro()
 
 if(ARROW_WITH_THRIFT)

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -249,16 +249,16 @@ if(DEFINED ENV{ARROW_AWSSDK_URL})
   set(AWSSDK_SOURCE_URL "$ENV{ARROW_AWSSDK_URL}")
 else()
   set(AWSSDK_SOURCE_URL
-      "https://github.com/aws/aws-sdk-cpp/archive/${AWSSDK_VERSION}.tar.gz")
+      "https://github.com/aws/aws-sdk-cpp/archive/${ARROW_AWSSDK_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_BOOST_URL})
   set(BOOST_SOURCE_URL "$ENV{ARROW_BOOST_URL}")
 else()
-  string(REPLACE "." "_" BOOST_VERSION_UNDERSCORES ${BOOST_VERSION})
+  string(REPLACE "." "_" ARROW_BOOST_BUILD_VERSION_UNDERSCORES ${ARROW_BOOST_BUILD_VERSION})
   set(
     BOOST_SOURCE_URL
-    "https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_UNDERSCORES}.tar.gz"
+    "https://dl.bintray.com/boostorg/release/${ARROW_BOOST_BUILD_VERSION}/source/boost_${ARROW_BOOST_BUILD_VERSION_UNDERSCORES}.tar.gz"
     )
 endif()
 
@@ -266,46 +266,46 @@ if(DEFINED ENV{ARROW_BROTLI_URL})
   set(BROTLI_SOURCE_URL "$ENV{ARROW_BROTLI_URL}")
 else()
   set(BROTLI_SOURCE_URL
-      "https://github.com/google/brotli/archive/${BROTLI_VERSION}.tar.gz")
+      "https://github.com/google/brotli/archive/${ARROW_BROTLI_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_CARES_URL})
   set(CARES_SOURCE_URL "$ENV{ARROW_CARES_URL}")
 else()
-  set(CARES_SOURCE_URL "https://c-ares.haxx.se/download/c-ares-${CARES_VERSION}.tar.gz")
+  set(CARES_SOURCE_URL "https://c-ares.haxx.se/download/c-ares-${ARROW_CARES_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_GBENCHMARK_URL})
   set(GBENCHMARK_SOURCE_URL "$ENV{ARROW_GBENCHMARK_URL}")
 else()
   set(GBENCHMARK_SOURCE_URL
-      "https://github.com/google/benchmark/archive/${GBENCHMARK_VERSION}.tar.gz")
+      "https://github.com/google/benchmark/archive/${ARROW_GBENCHMARK_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_GFLAGS_URL})
   set(GFLAGS_SOURCE_URL "$ENV{ARROW_GFLAGS_URL}")
 else()
   set(GFLAGS_SOURCE_URL
-      "https://github.com/gflags/gflags/archive/${GFLAGS_VERSION}.tar.gz")
+      "https://github.com/gflags/gflags/archive/${ARROW_GFLAGS_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_GLOG_URL})
   set(GLOG_SOURCE_URL "$ENV{ARROW_GLOG_URL}")
 else()
-  set(GLOG_SOURCE_URL "https://github.com/google/glog/archive/${GLOG_VERSION}.tar.gz")
+  set(GLOG_SOURCE_URL "https://github.com/google/glog/archive/${ARROW_GLOG_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_GRPC_URL})
   set(GRPC_SOURCE_URL "$ENV{ARROW_GRPC_URL}")
 else()
-  set(GRPC_SOURCE_URL "https://github.com/grpc/grpc/archive/${GRPC_VERSION}.tar.gz")
+  set(GRPC_SOURCE_URL "https://github.com/grpc/grpc/archive/${ARROW_GRPC_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_GTEST_URL})
   set(GTEST_SOURCE_URL "$ENV{ARROW_GTEST_URL}")
 else()
   set(GTEST_SOURCE_URL
-      "https://github.com/google/googletest/archive/release-${GTEST_VERSION}.tar.gz")
+      "https://github.com/google/googletest/archive/release-${ARROW_GTEST_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_JEMALLOC_URL})
@@ -313,7 +313,7 @@ if(DEFINED ENV{ARROW_JEMALLOC_URL})
 else()
   set(
     JEMALLOC_SOURCE_URL
-    "https://github.com/jemalloc/jemalloc/releases/download/${JEMALLOC_VERSION}/jemalloc-${JEMALLOC_VERSION}.tar.bz2"
+    "https://github.com/jemalloc/jemalloc/releases/download/${ARROW_JEMALLOC_BUILD_VERSION}/jemalloc-${ARROW_JEMALLOC_BUILD_VERSION}.tar.bz2"
     )
 endif()
 
@@ -321,51 +321,51 @@ if(DEFINED ENV{ARROW_MIMALLOC_URL})
   set(MIMALLOC_SOURCE_URL "$ENV{ARROW_MIMALLOC_URL}")
 else()
   set(MIMALLOC_SOURCE_URL
-      "https://github.com/microsoft/mimalloc/archive/${MIMALLOC_VERSION}.tar.gz")
+      "https://github.com/microsoft/mimalloc/archive/${ARROW_MIMALLOC_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_LZ4_URL})
   set(LZ4_SOURCE_URL "$ENV{ARROW_LZ4_URL}")
 else()
-  set(LZ4_SOURCE_URL "https://github.com/lz4/lz4/archive/${LZ4_VERSION}.tar.gz")
+  set(LZ4_SOURCE_URL "https://github.com/lz4/lz4/archive/${ARROW_LZ4_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_ORC_URL})
   set(ORC_SOURCE_URL "$ENV{ARROW_ORC_URL}")
 else()
   set(ORC_SOURCE_URL
-      "https://github.com/apache/orc/archive/rel/release-${ORC_VERSION}.tar.gz")
+      "https://github.com/apache/orc/archive/rel/release-${ARROW_ORC_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_PROTOBUF_URL})
   set(PROTOBUF_SOURCE_URL "$ENV{ARROW_PROTOBUF_URL}")
 else()
-  string(SUBSTRING ${PROTOBUF_VERSION} 1 -1 STRIPPED_PROTOBUF_VERSION)
+  string(SUBSTRING ${ARROW_PROTOBUF_BUILD_VERSION} 1 -1 ARROW_PROTOBUF_STRIPPED_BUILD_VERSION)
   # strip the leading `v`
   set(
     PROTOBUF_SOURCE_URL
-    "https://github.com/protocolbuffers/protobuf/releases/download/${PROTOBUF_VERSION}/protobuf-all-${STRIPPED_PROTOBUF_VERSION}.tar.gz"
+    "https://github.com/protocolbuffers/protobuf/releases/download/${ARROW_PROTOBUF_BUILD_VERSION}/protobuf-all-${ARROW_PROTOBUF_STRIPPED_BUILD_VERSION}.tar.gz"
     )
 endif()
 
 if(DEFINED ENV{ARROW_RE2_URL})
   set(RE2_SOURCE_URL "$ENV{ARROW_RE2_URL}")
 else()
-  set(RE2_SOURCE_URL "https://github.com/google/re2/archive/${RE2_VERSION}.tar.gz")
+  set(RE2_SOURCE_URL "https://github.com/google/re2/archive/${ARROW_RE2_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_RAPIDJSON_URL})
   set(RAPIDJSON_SOURCE_URL "$ENV{ARROW_RAPIDJSON_URL}")
 else()
   set(RAPIDJSON_SOURCE_URL
-      "https://github.com/miloyip/rapidjson/archive/${RAPIDJSON_VERSION}.tar.gz")
+      "https://github.com/miloyip/rapidjson/archive/${ARROW_RAPIDJSON_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_SNAPPY_URL})
   set(SNAPPY_SOURCE_URL "$ENV{ARROW_SNAPPY_URL}")
 else()
   set(SNAPPY_SOURCE_URL
-      "https://github.com/google/snappy/archive/${SNAPPY_VERSION}.tar.gz")
+      "https://github.com/google/snappy/archive/${ARROW_SNAPPY_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_THRIFT_URL})
@@ -377,19 +377,19 @@ endif()
 if(DEFINED ENV{ARROW_ZLIB_URL})
   set(ZLIB_SOURCE_URL "$ENV{ARROW_ZLIB_URL}")
 else()
-  set(ZLIB_SOURCE_URL "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz")
+  set(ZLIB_SOURCE_URL "https://zlib.net/fossils/zlib-${ARROW_ZLIB_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_ZSTD_URL})
   set(ZSTD_SOURCE_URL "$ENV{ARROW_ZSTD_URL}")
 else()
-  set(ZSTD_SOURCE_URL "https://github.com/facebook/zstd/archive/${ZSTD_VERSION}.tar.gz")
+  set(ZSTD_SOURCE_URL "https://github.com/facebook/zstd/archive/${ARROW_ZSTD_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{BZIP2_SOURCE_URL})
   set(BZIP2_SOURCE_URL "$ENV{BZIP2_SOURCE_URL}")
 else()
-  set(BZIP2_SOURCE_URL "https://sourceware.org/pub/bzip2/bzip2-${BZIP2_VERSION}.tar.gz")
+  set(BZIP2_SOURCE_URL "https://sourceware.org/pub/bzip2/bzip2-${ARROW_BZIP2_BUILD_VERSION}.tar.gz")
 endif()
 
 # ----------------------------------------------------------------------
@@ -484,9 +484,9 @@ macro(build_boost)
   if(MSVC)
     string(REGEX
            REPLACE "^([0-9]+)\\.([0-9]+)\\.[0-9]+$" "\\1_\\2"
-                   BOOST_VERSION_NO_MICRO_UNDERSCORE ${BOOST_VERSION})
+                   ARROW_BOOST_BUILD_VERSION_NO_MICRO_UNDERSCORE ${ARROW_BOOST_BUILD_VERSION})
     set(BOOST_LIBRARY_SUFFIX
-        "-vc${MSVC_TOOLSET_VERSION}-mt-x64-${BOOST_VERSION_NO_MICRO_UNDERSCORE}")
+        "-vc${MSVC_TOOLSET_VERSION}-mt-x64-${ARROW_BOOST_BUILD_VERSION_NO_MICRO_UNDERSCORE}")
   else()
     set(BOOST_LIBRARY_SUFFIX "")
   endif()
@@ -1072,14 +1072,14 @@ macro(build_thrift)
   if("${THRIFT_SOURCE_URL}" STREQUAL "FROM-APACHE-MIRROR")
     get_apache_mirror()
     set(THRIFT_SOURCE_URL
-        "${APACHE_MIRROR}/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz")
+        "${APACHE_MIRROR}/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz")
   endif()
 
   message("Downloading Apache Thrift from ${THRIFT_SOURCE_URL}")
 
   externalproject_add(thrift_ep
                       URL ${THRIFT_SOURCE_URL}
-                      URL_HASH "MD5=${THRIFT_MD5_CHECKSUM}"
+                      URL_HASH "MD5=${ARROW_THRIFT_BUILD_MD5_CHECKSUM}"
                       BUILD_BYPRODUCTS "${THRIFT_STATIC_LIB}" "${THRIFT_COMPILER}"
                       CMAKE_ARGS ${THRIFT_CMAKE_ARGS}
                       DEPENDS ${THRIFT_DEPENDENCIES} ${EP_LOG_OPTIONS})

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -231,18 +231,18 @@ foreach(_VERSION_ENTRY ${TOOLCHAIN_VERSIONS_TXT})
     continue()
   endif()
 
-  string(REGEX MATCH "^[^=]*" _LIB_NAME ${_VERSION_ENTRY})
-  string(REPLACE "${_LIB_NAME}=" "" _LIB_VERSION ${_VERSION_ENTRY})
+  string(REGEX MATCH "^[^=]*" _VARIABLE_NAME ${_VERSION_ENTRY})
+  string(REPLACE "${_VARIABLE_NAME}=" "" _VARIABLE_VALUE ${_VERSION_ENTRY})
 
   # Skip blank or malformed lines
-  if(${_LIB_VERSION} STREQUAL "")
+  if(_VARIABLE_VALUE STREQUAL "")
     continue()
   endif()
 
   # For debugging
-  message(STATUS "${_LIB_NAME}: ${_LIB_VERSION}")
+  message(STATUS "${_VARIABLE_NAME}: ${_VARIABLE_VALUE}")
 
-  set(${_LIB_NAME} "${_LIB_VERSION}")
+  set(${_VARIABLE_NAME} ${_VARIABLE_VALUE})
 endforeach()
 
 if(DEFINED ENV{ARROW_AWSSDK_URL})

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -255,7 +255,8 @@ endif()
 if(DEFINED ENV{ARROW_BOOST_URL})
   set(BOOST_SOURCE_URL "$ENV{ARROW_BOOST_URL}")
 else()
-  string(REPLACE "." "_" ARROW_BOOST_BUILD_VERSION_UNDERSCORES ${ARROW_BOOST_BUILD_VERSION})
+  string(REPLACE "." "_" ARROW_BOOST_BUILD_VERSION_UNDERSCORES
+                 ${ARROW_BOOST_BUILD_VERSION})
   set(
     BOOST_SOURCE_URL
     "https://dl.bintray.com/boostorg/release/${ARROW_BOOST_BUILD_VERSION}/source/boost_${ARROW_BOOST_BUILD_VERSION_UNDERSCORES}.tar.gz"
@@ -272,14 +273,18 @@ endif()
 if(DEFINED ENV{ARROW_CARES_URL})
   set(CARES_SOURCE_URL "$ENV{ARROW_CARES_URL}")
 else()
-  set(CARES_SOURCE_URL "https://c-ares.haxx.se/download/c-ares-${ARROW_CARES_BUILD_VERSION}.tar.gz")
+  set(CARES_SOURCE_URL
+      "https://c-ares.haxx.se/download/c-ares-${ARROW_CARES_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_GBENCHMARK_URL})
   set(GBENCHMARK_SOURCE_URL "$ENV{ARROW_GBENCHMARK_URL}")
 else()
-  set(GBENCHMARK_SOURCE_URL
-      "https://github.com/google/benchmark/archive/${ARROW_GBENCHMARK_BUILD_VERSION}.tar.gz")
+  set(
+    GBENCHMARK_SOURCE_URL
+
+    "https://github.com/google/benchmark/archive/${ARROW_GBENCHMARK_BUILD_VERSION}.tar.gz"
+    )
 endif()
 
 if(DEFINED ENV{ARROW_GFLAGS_URL})
@@ -292,20 +297,24 @@ endif()
 if(DEFINED ENV{ARROW_GLOG_URL})
   set(GLOG_SOURCE_URL "$ENV{ARROW_GLOG_URL}")
 else()
-  set(GLOG_SOURCE_URL "https://github.com/google/glog/archive/${ARROW_GLOG_BUILD_VERSION}.tar.gz")
+  set(GLOG_SOURCE_URL
+      "https://github.com/google/glog/archive/${ARROW_GLOG_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_GRPC_URL})
   set(GRPC_SOURCE_URL "$ENV{ARROW_GRPC_URL}")
 else()
-  set(GRPC_SOURCE_URL "https://github.com/grpc/grpc/archive/${ARROW_GRPC_BUILD_VERSION}.tar.gz")
+  set(GRPC_SOURCE_URL
+      "https://github.com/grpc/grpc/archive/${ARROW_GRPC_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_GTEST_URL})
   set(GTEST_SOURCE_URL "$ENV{ARROW_GTEST_URL}")
 else()
-  set(GTEST_SOURCE_URL
-      "https://github.com/google/googletest/archive/release-${ARROW_GTEST_BUILD_VERSION}.tar.gz")
+  set(
+    GTEST_SOURCE_URL
+    "https://github.com/google/googletest/archive/release-${ARROW_GTEST_BUILD_VERSION}.tar.gz"
+    )
 endif()
 
 if(DEFINED ENV{ARROW_JEMALLOC_URL})
@@ -320,27 +329,33 @@ endif()
 if(DEFINED ENV{ARROW_MIMALLOC_URL})
   set(MIMALLOC_SOURCE_URL "$ENV{ARROW_MIMALLOC_URL}")
 else()
-  set(MIMALLOC_SOURCE_URL
-      "https://github.com/microsoft/mimalloc/archive/${ARROW_MIMALLOC_BUILD_VERSION}.tar.gz")
+  set(
+    MIMALLOC_SOURCE_URL
+
+    "https://github.com/microsoft/mimalloc/archive/${ARROW_MIMALLOC_BUILD_VERSION}.tar.gz"
+    )
 endif()
 
 if(DEFINED ENV{ARROW_LZ4_URL})
   set(LZ4_SOURCE_URL "$ENV{ARROW_LZ4_URL}")
 else()
-  set(LZ4_SOURCE_URL "https://github.com/lz4/lz4/archive/${ARROW_LZ4_BUILD_VERSION}.tar.gz")
+  set(LZ4_SOURCE_URL
+      "https://github.com/lz4/lz4/archive/${ARROW_LZ4_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_ORC_URL})
   set(ORC_SOURCE_URL "$ENV{ARROW_ORC_URL}")
 else()
-  set(ORC_SOURCE_URL
-      "https://github.com/apache/orc/archive/rel/release-${ARROW_ORC_BUILD_VERSION}.tar.gz")
+  set(
+    ORC_SOURCE_URL
+    "https://github.com/apache/orc/archive/rel/release-${ARROW_ORC_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_PROTOBUF_URL})
   set(PROTOBUF_SOURCE_URL "$ENV{ARROW_PROTOBUF_URL}")
 else()
-  string(SUBSTRING ${ARROW_PROTOBUF_BUILD_VERSION} 1 -1 ARROW_PROTOBUF_STRIPPED_BUILD_VERSION)
+  string(SUBSTRING ${ARROW_PROTOBUF_BUILD_VERSION} 1 -1
+                   ARROW_PROTOBUF_STRIPPED_BUILD_VERSION)
   # strip the leading `v`
   set(
     PROTOBUF_SOURCE_URL
@@ -351,14 +366,18 @@ endif()
 if(DEFINED ENV{ARROW_RE2_URL})
   set(RE2_SOURCE_URL "$ENV{ARROW_RE2_URL}")
 else()
-  set(RE2_SOURCE_URL "https://github.com/google/re2/archive/${ARROW_RE2_BUILD_VERSION}.tar.gz")
+  set(RE2_SOURCE_URL
+      "https://github.com/google/re2/archive/${ARROW_RE2_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{ARROW_RAPIDJSON_URL})
   set(RAPIDJSON_SOURCE_URL "$ENV{ARROW_RAPIDJSON_URL}")
 else()
-  set(RAPIDJSON_SOURCE_URL
-      "https://github.com/miloyip/rapidjson/archive/${ARROW_RAPIDJSON_BUILD_VERSION}.tar.gz")
+  set(
+    RAPIDJSON_SOURCE_URL
+
+    "https://github.com/miloyip/rapidjson/archive/${ARROW_RAPIDJSON_BUILD_VERSION}.tar.gz"
+    )
 endif()
 
 if(DEFINED ENV{ARROW_SNAPPY_URL})
@@ -383,13 +402,15 @@ endif()
 if(DEFINED ENV{ARROW_ZSTD_URL})
   set(ZSTD_SOURCE_URL "$ENV{ARROW_ZSTD_URL}")
 else()
-  set(ZSTD_SOURCE_URL "https://github.com/facebook/zstd/archive/${ARROW_ZSTD_BUILD_VERSION}.tar.gz")
+  set(ZSTD_SOURCE_URL
+      "https://github.com/facebook/zstd/archive/${ARROW_ZSTD_BUILD_VERSION}.tar.gz")
 endif()
 
 if(DEFINED ENV{BZIP2_SOURCE_URL})
   set(BZIP2_SOURCE_URL "$ENV{BZIP2_SOURCE_URL}")
 else()
-  set(BZIP2_SOURCE_URL "https://sourceware.org/pub/bzip2/bzip2-${ARROW_BZIP2_BUILD_VERSION}.tar.gz")
+  set(BZIP2_SOURCE_URL
+      "https://sourceware.org/pub/bzip2/bzip2-${ARROW_BZIP2_BUILD_VERSION}.tar.gz")
 endif()
 
 # ----------------------------------------------------------------------
@@ -484,9 +505,13 @@ macro(build_boost)
   if(MSVC)
     string(REGEX
            REPLACE "^([0-9]+)\\.([0-9]+)\\.[0-9]+$" "\\1_\\2"
-                   ARROW_BOOST_BUILD_VERSION_NO_MICRO_UNDERSCORE ${ARROW_BOOST_BUILD_VERSION})
-    set(BOOST_LIBRARY_SUFFIX
-        "-vc${MSVC_TOOLSET_VERSION}-mt-x64-${ARROW_BOOST_BUILD_VERSION_NO_MICRO_UNDERSCORE}")
+                   ARROW_BOOST_BUILD_VERSION_NO_MICRO_UNDERSCORE
+                   ${ARROW_BOOST_BUILD_VERSION})
+    set(
+      BOOST_LIBRARY_SUFFIX
+
+      "-vc${MSVC_TOOLSET_VERSION}-mt-x64-${ARROW_BOOST_BUILD_VERSION_NO_MICRO_UNDERSCORE}"
+      )
   else()
     set(BOOST_LIBRARY_SUFFIX "")
   endif()
@@ -1071,8 +1096,10 @@ macro(build_thrift)
 
   if("${THRIFT_SOURCE_URL}" STREQUAL "FROM-APACHE-MIRROR")
     get_apache_mirror()
-    set(THRIFT_SOURCE_URL
-        "${APACHE_MIRROR}/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz")
+    set(
+      THRIFT_SOURCE_URL
+      "${APACHE_MIRROR}/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
+      )
   endif()
 
   message("Downloading Apache Thrift from ${THRIFT_SOURCE_URL}")

--- a/cpp/thirdparty/versions.txt
+++ b/cpp/thirdparty/versions.txt
@@ -23,61 +23,61 @@
 # `DEPENDENCIES` array (see the comment on top of the declaration for the
 # format).
 
-AWSSDK_VERSION=1.7.160
-BOOST_VERSION=1.67.0
-BROTLI_VERSION=v1.0.7
-BZIP2_VERSION=1.0.8
-CARES_VERSION=1.15.0
-GBENCHMARK_VERSION=v1.5.0
-GFLAGS_VERSION=v2.2.0
-GLOG_VERSION=v0.3.5
-GRPC_VERSION=v1.24.3
-GTEST_VERSION=1.8.1
-JEMALLOC_VERSION=5.2.1
-LZ4_VERSION=v1.9.2
+ARROW_AWSSDK_BUILD_VERSION=1.7.160
+ARROW_BOOST_BUILD_VERSION=1.67.0
+ARROW_BROTLI_BUILD_VERSION=v1.0.7
+ARROW_BZIP2_BUILD_VERSION=1.0.8
+ARROW_CARES_BUILD_VERSION=1.15.0
+ARROW_GBENCHMARK_BUILD_VERSION=v1.5.0
+ARROW_GFLAGS_BUILD_VERSION=v2.2.0
+ARROW_GLOG_BUILD_VERSION=v0.3.5
+ARROW_GRPC_BUILD_VERSION=v1.24.3
+ARROW_GTEST_BUILD_VERSION=1.8.1
+ARROW_JEMALLOC_BUILD_VERSION=5.2.1
+ARROW_LZ4_BUILD_VERSION=v1.9.2
 # Need post-v1.0.6 version for https://github.com/microsoft/mimalloc/pull/140,
 # https://github.com/microsoft/mimalloc/pull/145 and
 # https://github.com/microsoft/mimalloc/pull/148
-MIMALLOC_VERSION=270e765454f98e8bab9d42609b153425f749fff6
-ORC_VERSION=1.5.7
-PROTOBUF_VERSION=v3.7.1
+ARROW_MIMALLOC_BUILD_VERSION=270e765454f98e8bab9d42609b153425f749fff6
+ARROW_ORC_BUILD_VERSION=1.5.7
+ARROW_PROTOBUF_BUILD_VERSION=v3.7.1
 # Because of https://github.com/Tencent/rapidjson/pull/1323, we require
 # a pre-release version of RapidJSON to build with GCC 8 without
 # warnings.
-RAPIDJSON_VERSION=2bbd33b33217ff4a73434ebf10cdac41e2ef5e34
-RE2_VERSION=2019-08-01
-SNAPPY_VERSION=1.1.7
-THRIFT_VERSION=0.12.0
-THRIFT_MD5_CHECKSUM=3deebbb4d1ca77dd9c9e009a1ea02183
-ZLIB_VERSION=1.2.11
-ZSTD_VERSION=v1.4.3
+ARROW_RAPIDJSON_BUILD_VERSION=2bbd33b33217ff4a73434ebf10cdac41e2ef5e34
+ARROW_RE2_BUILD_VERSION=2019-08-01
+ARROW_SNAPPY_BUILD_VERSION=1.1.7
+ARROW_THRIFT_BUILD_VERSION=0.12.0
+ARROW_THRIFT_BUILD_MD5_CHECKSUM=3deebbb4d1ca77dd9c9e009a1ea02183
+ARROW_ZLIB_BUILD_VERSION=1.2.11
+ARROW_ZSTD_BUILD_VERSION=v1.4.3
 
 # The first field is the name of the environment variable expected by cmake.
 # This _must_ match what is defined. The second field is the name of the
 # generated archive file. The third field is the url of the project for the
 # given version.
 DEPENDENCIES=(
-  "ARROW_AWSSDK_URL aws-sdk-cpp-${AWSSDK_VERSION}.tar.gz https://github.com/aws/aws-sdk-cpp/archive/${AWSSDK_VERSION}.tar.gz"
-  "ARROW_BOOST_URL boost-${BOOST_VERSION}.tar.gz https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION//./_}.tar.gz"
-  "ARROW_BROTLI_URL brotli-${BROTLI_VERSION}.tar.gz https://github.com/google/brotli/archive/${BROTLI_VERSION}.tar.gz"
-  "ARROW_BZIP2_URL bzip2-${BZIP2_VERSION}.tar.gz https://sourceware.org/pub/bzip2/bzip2-${BZIP2_VERSION}.tar.gz"
-  "ARROW_CARES_URL cares-${CARES_VERSION}.tar.gz https://c-ares.haxx.se/download/c-ares-$CARES_VERSION.tar.gz"
-  "ARROW_GBENCHMARK_URL gbenchmark-${GBENCHMARK_VERSION}.tar.gz https://github.com/google/benchmark/archive/${GBENCHMARK_VERSION}.tar.gz"
-  "ARROW_GFLAGS_URL gflags-${GFLAGS_VERSION}.tar.gz https://github.com/gflags/gflags/archive/${GFLAGS_VERSION}.tar.gz"
-  "ARROW_GLOG_URL glog-${GLOG_VERSION}.tar.gz https://github.com/google/glog/archive/${GLOG_VERSION}.tar.gz"
-  "ARROW_GRPC_URL grpc-${GRPC_VERSION}.tar.gz https://github.com/grpc/grpc/archive/${GRPC_VERSION}.tar.gz"
-  "ARROW_GTEST_URL gtest-${GTEST_VERSION}.tar.gz https://github.com/google/googletest/archive/release-${GTEST_VERSION}.tar.gz"
-  "ARROW_JEMALLOC_URL jemalloc-${JEMALLOC_VERSION}.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/${JEMALLOC_VERSION}/jemalloc-${JEMALLOC_VERSION}.tar.bz2"
-  "ARROW_LZ4_URL lz4-${LZ4_VERSION}.tar.gz https://github.com/lz4/lz4/archive/${LZ4_VERSION}.tar.gz"
-  "ARROW_MIMALLOC_URL mimalloc-${MIMALLOC_VERSION}.tar.gz https://github.com/microsoft/mimalloc/archive/${MIMALLOC_VERSION}.tar.gz"
-  "ARROW_ORC_URL orc-${ORC_VERSION}.tar.gz https://github.com/apache/orc/archive/rel/release-${ORC_VERSION}.tar.gz"
-  "ARROW_PROTOBUF_URL protobuf-${PROTOBUF_VERSION}.tar.gz https://github.com/google/protobuf/releases/download/${PROTOBUF_VERSION}/protobuf-all-${PROTOBUF_VERSION:1}.tar.gz"
-  "ARROW_RAPIDJSON_URL rapidjson-${RAPIDJSON_VERSION}.tar.gz https://github.com/miloyip/rapidjson/archive/${RAPIDJSON_VERSION}.tar.gz"
-  "ARROW_RE2_URL re2-${RE2_VERSION}.tar.gz https://github.com/google/re2/archive/${RE2_VERSION}.tar.gz"
-  "ARROW_SNAPPY_URL snappy-${SNAPPY_VERSION}.tar.gz https://github.com/google/snappy/archive/${SNAPPY_VERSION}.tar.gz"
-  "ARROW_THRIFT_URL thrift-${THRIFT_VERSION}.tar.gz https://archive.apache.org/dist/thrift/${THRIFT_VERSION}/thrift-${THRIFT_VERSION}.tar.gz"
-  "ARROW_ZLIB_URL zlib-${ZLIB_VERSION}.tar.gz https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
-  "ARROW_ZSTD_URL zstd-${ZSTD_VERSION}.tar.gz https://github.com/facebook/zstd/archive/${ZSTD_VERSION}.tar.gz"
+  "ARROW_AWSSDK_URL aws-sdk-cpp-${ARROW_AWSSDK_BUILD_VERSION}.tar.gz https://github.com/aws/aws-sdk-cpp/archive/${ARROW_AWSSDK_BUILD_VERSION}.tar.gz"
+  "ARROW_BOOST_URL boost-${ARROW_BOOST_BUILD_VERSION}.tar.gz https://dl.bintray.com/boostorg/release/${ARROW_BOOST_BUILD_VERSION}/source/boost_${ARROW_BOOST_BUILD_VERSION//./_}.tar.gz"
+  "ARROW_BROTLI_URL brotli-${ARROW_BROTLI_BUILD_VERSION}.tar.gz https://github.com/google/brotli/archive/${ARROW_BROTLI_BUILD_VERSION}.tar.gz"
+  "ARROW_BZIP2_URL bzip2-${ARROW_BZIP2_BUILD_VERSION}.tar.gz https://sourceware.org/pub/bzip2/bzip2-${ARROW_BZIP2_BUILD_VERSION}.tar.gz"
+  "ARROW_CARES_URL cares-${ARROW_CARES_BUILD_VERSION}.tar.gz https://c-ares.haxx.se/download/c-ares-${ARROW_CARES_BUILD_VERSION}.tar.gz"
+  "ARROW_GBENCHMARK_URL gbenchmark-${ARROW_GBENCHMARK_BUILD_VERSION}.tar.gz https://github.com/google/benchmark/archive/${ARROW_GBENCHMARK_BUILD_VERSION}.tar.gz"
+  "ARROW_GFLAGS_URL gflags-${ARROW_GFLAGS_BUILD_VERSION}.tar.gz https://github.com/gflags/gflags/archive/${ARROW_GFLAGS_BUILD_VERSION}.tar.gz"
+  "ARROW_GLOG_URL glog-${ARROW_GLOG_BUILD_VERSION}.tar.gz https://github.com/google/glog/archive/${ARROW_GLOG_BUILD_VERSION}.tar.gz"
+  "ARROW_GRPC_URL grpc-${ARROW_GRPC_BUILD_VERSION}.tar.gz https://github.com/grpc/grpc/archive/${ARROW_GRPC_BUILD_VERSION}.tar.gz"
+  "ARROW_GTEST_URL gtest-${ARROW_GTEST_BUILD_VERSION}.tar.gz https://github.com/google/googletest/archive/release-${ARROW_GTEST_BUILD_VERSION}.tar.gz"
+  "ARROW_JEMALLOC_URL jemalloc-${ARROW_JEMALLOC_BUILD_VERSION}.tar.bz2 https://github.com/jemalloc/jemalloc/releases/download/${ARROW_JEMALLOC_BUILD_VERSION}/jemalloc-${ARROW_JEMALLOC_BUILD_VERSION}.tar.bz2"
+  "ARROW_LZ4_URL lz4-${ARROW_LZ4_BUILD_VERSION}.tar.gz https://github.com/lz4/lz4/archive/${ARROW_LZ4_BUILD_VERSION}.tar.gz"
+  "ARROW_MIMALLOC_URL mimalloc-${ARROW_MIMALLOC_BUILD_VERSION}.tar.gz https://github.com/microsoft/mimalloc/archive/${ARROW_MIMALLOC_BUILD_VERSION}.tar.gz"
+  "ARROW_ORC_URL orc-${ARROW_ORC_BUILD_VERSION}.tar.gz https://github.com/apache/orc/archive/rel/release-${ARROW_ORC_BUILD_VERSION}.tar.gz"
+  "ARROW_PROTOBUF_URL protobuf-${ARROW_PROTOBUF_BUILD_VERSION}.tar.gz https://github.com/google/protobuf/releases/download/${ARROW_PROTOBUF_BUILD_VERSION}/protobuf-all-${ARROW_PROTOBUF_BUILD_VERSION:1}.tar.gz"
+  "ARROW_RAPIDJSON_URL rapidjson-${ARROW_RAPIDJSON_BUILD_VERSION}.tar.gz https://github.com/miloyip/rapidjson/archive/${ARROW_RAPIDJSON_BUILD_VERSION}.tar.gz"
+  "ARROW_RE2_URL re2-${ARROW_RE2_BUILD_VERSION}.tar.gz https://github.com/google/re2/archive/${ARROW_RE2_BUILD_VERSION}.tar.gz"
+  "ARROW_SNAPPY_URL snappy-${ARROW_SNAPPY_BUILD_VERSION}.tar.gz https://github.com/google/snappy/archive/${ARROW_SNAPPY_BUILD_VERSION}.tar.gz"
+  "ARROW_THRIFT_URL thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz https://archive.apache.org/dist/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz"
+  "ARROW_ZLIB_URL zlib-${ARROW_ZLIB_BUILD_VERSION}.tar.gz https://zlib.net/fossils/zlib-${ARROW_ZLIB_BUILD_VERSION}.tar.gz"
+  "ARROW_ZSTD_URL zstd-${ARROW_ZSTD_BUILD_VERSION}.tar.gz https://github.com/facebook/zstd/archive/${ARROW_ZSTD_BUILD_VERSION}.tar.gz"
 )
 
 # vim: set filetype=sh:


### PR DESCRIPTION
https://github.com/apache/arrow/pull/5900 introduced a new problem.
If Thrift is found but found Thrift is old, `THRIFT_VERSION` in `FindThrift.cmake` overrides our `THRIFT_VERSION` in `versions.txt`.

https://github.com/apache/arrow/pull/5946 tried to fix this problem by using another variable name, `FOUND_THRIFT_VERSION` in `FindThrift.cmake`. This can fix this but the root cause of this problem is using the same variable name for found library version and build target library version.

This change uses `ARROW_${LIBRARY_NAME}_BUILD_VERSION` for build target library version and `${LIBRARY_NAME}_VERSION` for found library version (no change). This avoids variable conflicts.

I choose `ARROW_${LIBRARY_NAME}_BUILD_VERSION` because we already use `ARROW_${LIBRARY_NAME}_REQUIRED_VERSION` such as `ARROW_BOOST_REQUIRED_VERSION`.