### PR TITLE
ARROW-7282: [Python] IO functions should raise the right exceptions

### DIFF
--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <cerrno>
 #include <chrono>
 #include <memory>
 #include <string>

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -593,7 +593,8 @@ class MemoryMappedFile::MemoryMap
     void* result = mmap(nullptr, mmap_length, prot_flags_, map_mode_, file_->fd(),
                         static_cast<off_t>(offset));
     if (result == MAP_FAILED) {
-      return Status::IOError("Memory mapping file failed: ", std::strerror(errno));
+      return Status::IOError("Memory mapping file failed: ",
+                             ::arrow::internal::ErrnoMessage(errno));
     }
     map_len_ = mmap_length;
     offset_ = offset;

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -161,101 +161,103 @@ class ARROW_EXPORT Status : public util::EqualityComparable<Status>,
   /// Return a success status
   static Status OK() { return Status(); }
 
+  template <typename... Args>
+  static Status FromArgs(StatusCode code, Args&&... args) {
+    return Status(code, util::StringBuilder(std::forward<Args>(args)...));
+  }
+
+  template <typename... Args>
+  static Status FromDetailAndArgs(StatusCode code, std::shared_ptr<StatusDetail> detail,
+                                  Args&&... args) {
+    return Status(code, util::StringBuilder(std::forward<Args>(args)...),
+                  std::move(detail));
+  }
+
   /// Return an error status for out-of-memory conditions
   template <typename... Args>
   static Status OutOfMemory(Args&&... args) {
-    return Status(StatusCode::OutOfMemory,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::OutOfMemory, std::forward<Args>(args)...);
   }
 
   /// Return an error status for failed key lookups (e.g. column name in a table)
   template <typename... Args>
   static Status KeyError(Args&&... args) {
-    return Status(StatusCode::KeyError, util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::KeyError, std::forward<Args>(args)...);
   }
 
   /// Return an error status for type errors (such as mismatching data types)
   template <typename... Args>
   static Status TypeError(Args&&... args) {
-    return Status(StatusCode::TypeError,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::TypeError, std::forward<Args>(args)...);
   }
 
   /// Return an error status for unknown errors
   template <typename... Args>
   static Status UnknownError(Args&&... args) {
-    return Status(StatusCode::UnknownError,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::UnknownError, std::forward<Args>(args)...);
   }
 
   /// Return an error status when an operation or a combination of operation and
   /// data types is unimplemented
   template <typename... Args>
   static Status NotImplemented(Args&&... args) {
-    return Status(StatusCode::NotImplemented,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::NotImplemented, std::forward<Args>(args)...);
   }
 
   /// Return an error status for invalid data (for example a string that fails parsing)
   template <typename... Args>
   static Status Invalid(Args&&... args) {
-    return Status(StatusCode::Invalid, util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::Invalid, std::forward<Args>(args)...);
   }
 
   /// Return an error status when an index is out of bounds
   template <typename... Args>
   static Status IndexError(Args&&... args) {
-    return Status(StatusCode::IndexError,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::IndexError, std::forward<Args>(args)...);
   }
 
   /// Return an error status when a container's capacity would exceed its limits
   template <typename... Args>
   static Status CapacityError(Args&&... args) {
-    return Status(StatusCode::CapacityError,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::CapacityError, std::forward<Args>(args)...);
   }
 
   /// Return an error status when some IO-related operation failed
   template <typename... Args>
   static Status IOError(Args&&... args) {
-    return Status(StatusCode::IOError, util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::IOError, std::forward<Args>(args)...);
   }
 
   /// Return an error status when some (de)serialization operation failed
   template <typename... Args>
   static Status SerializationError(Args&&... args) {
-    return Status(StatusCode::SerializationError,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::SerializationError, std::forward<Args>(args)...);
   }
 
   template <typename... Args>
   static Status RError(Args&&... args) {
-    return Status(StatusCode::RError, util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::RError, std::forward<Args>(args)...);
   }
 
   template <typename... Args>
   static Status CodeGenError(Args&&... args) {
-    return Status(StatusCode::CodeGenError,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::CodeGenError, std::forward<Args>(args)...);
   }
 
   template <typename... Args>
   static Status ExpressionValidationError(Args&&... args) {
-    return Status(StatusCode::ExpressionValidationError,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::ExpressionValidationError,
+                            std::forward<Args>(args)...);
   }
 
   template <typename... Args>
   static Status ExecutionError(Args&&... args) {
-    return Status(StatusCode::ExecutionError,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::ExecutionError, std::forward<Args>(args)...);
   }
 
   template <typename... Args>
   static Status AlreadyExists(Args&&... args) {
-    return Status(StatusCode::AlreadyExists,
-                  util::StringBuilder(std::forward<Args>(args)...));
+    return Status::FromArgs(StatusCode::AlreadyExists, std::forward<Args>(args)...);
   }
 
   /// Return true iff the status indicates success.

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -253,7 +253,7 @@ cdef class FileSystem:
 
         return [FileStats.wrap(stat) for stat in stats]
 
-    def create_dir(self, path, bint recursive=True):
+    def create_dir(self, path, *, bint recursive=True):
         """Create a directory and subdirectories.
 
         This function succeeds if the directory already exists.

--- a/python/pyarrow/includes/common.pxd
+++ b/python/pyarrow/includes/common.pxd
@@ -77,6 +77,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
         c_string ToString()
         c_string message()
+        shared_ptr[CStatusDetail] detail()
 
         c_bool ok()
         c_bool IsIOError()
@@ -88,6 +89,10 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         c_bool IsCapacityError()
         c_bool IsIndexError()
         c_bool IsSerializationError()
+
+    cdef cppclass CStatusDetail "arrow::StatusDetail":
+        c_string ToString()
+
 
 cdef extern from "arrow/result.h" namespace "arrow" nogil:
     cdef cppclass CResult "arrow::Result"[T]:

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1684,11 +1684,14 @@ cdef extern from 'arrow/util/compression.h' namespace 'arrow' nogil:
         int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input)
 
 
+cdef extern from 'arrow/util/io_util.h' namespace 'arrow::internal' nogil:
+    int ErrnoFromStatus(CStatus status)
+    int WinErrorFromStatus(CStatus status)
+
 cdef extern from 'arrow/util/iterator.h' namespace 'arrow' nogil:
     cdef cppclass CIterator" arrow::Iterator"[T]:
         CResult[T] Next()
         CStatus Visit[Visitor](Visitor&& visitor)
-
 
 cdef extern from 'arrow/util/thread_pool.h' namespace 'arrow' nogil:
     int GetCpuThreadPoolCapacity()

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -24,7 +24,8 @@ except ImportError:
 import pytest
 
 import pyarrow as pa
-from pyarrow.tests.test_io import gzip_compress, gzip_decompress
+from pyarrow.tests.test_io import (gzip_compress, gzip_decompress,
+                                   assert_file_not_found)
 from pyarrow.fs import (FileType, FileSelector, FileSystem, LocalFileSystem,
                         LocalFileSystemOptions, SubTreeFileSystem,
                         _MockFileSystem)
@@ -478,6 +479,26 @@ def test_localfs_options():
 
     with pytest.raises(AttributeError):
         LocalFileSystem(xxx=False)
+
+
+def test_localfs_errors(localfs):
+    # Local filesystem errors should raise the right Python exceptions
+    # (e.g. FileNotFoundError)
+    fs = localfs['fs']
+    with assert_file_not_found():
+        fs.open_input_stream('/non/existent/file')
+    with assert_file_not_found():
+        fs.open_output_stream('/non/existent/file')
+    with assert_file_not_found():
+        fs.create_dir('/non/existent/dir', recursive=False)
+    with assert_file_not_found():
+        fs.delete_dir('/non/existent/dir')
+    with assert_file_not_found():
+        fs.delete_file('/non/existent/dir')
+    with assert_file_not_found():
+        fs.move('/non/existent', '/xxx')
+    with assert_file_not_found():
+        fs.copy_file('/non/existent', '/xxx')
 
 
 @pytest.mark.s3

--- a/python/pyarrow/tests/test_hdfs.py
+++ b/python/pyarrow/tests/test_hdfs.py
@@ -417,6 +417,7 @@ def _get_hdfs_uri(path):
     return uri
 
 
+@pytest.mark.hdfs
 @pytest.mark.pandas
 @pytest.mark.parquet
 @pytest.mark.fastparquet

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -660,12 +660,9 @@ def test_compression_level():
                             ("None", 444), ("lzo", 14)]
     buf = io.BytesIO()
     for (codec, level) in invalid_combinations:
-        try:
+        with pytest.raises(IOError):
             _write_table(table, buf, compression=codec,
                          compression_level=level)
-            assert 0
-        except pa.ArrowException:
-            pass
 
 
 @pytest.mark.pandas


### PR DESCRIPTION
When an Arrow IO function fails, it should be turned into the appropriate
Python exception subclass, e.g. FileNotFoundError in case the requested
file or directory is missing.