### PR TITLE
ARROW-7315: [Python] Remove unused cmake flag from wheel scripts 

### DIFF
--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -147,7 +147,6 @@ function build_wheel {
           -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
           -DLLVM_SOURCE=SYSTEM \
           -DMAKE=make \
-          -DOPENSSL_USE_STATIC_LIBS=ON \
           -DProtobuf_SOURCE=SYSTEM \
           -DgRPC_SOURCE=SYSTEM \
           ..

--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -114,7 +114,6 @@ cmake -DCMAKE_BUILD_TYPE=Release \
     -DARROW_GANDIVA_JAVA=OFF \
     -DBoost_NAMESPACE=arrow_boost \
     -DBOOST_ROOT=/arrow_boost_dist \
-    -DOPENSSL_USE_STATIC_LIBS=ON \
     -GNinja /arrow/cpp
 ninja
 ninja install

--- a/python/manylinux2010/build_arrow.sh
+++ b/python/manylinux2010/build_arrow.sh
@@ -115,7 +115,6 @@ PATH="${CPYTHON_PATH}/bin:${PATH}" cmake -DCMAKE_BUILD_TYPE=Release \
     -DARROW_GANDIVA_JAVA=OFF \
     -DBoost_NAMESPACE=arrow_boost \
     -DBOOST_ROOT=/arrow_boost_dist \
-    -DOPENSSL_USE_STATIC_LIBS=ON \
     -GNinja /arrow/cpp
 ninja install
 popd


### PR DESCRIPTION
Aside: why is the macos wheel script under `dev/tasks` but manylinux* are under `python/`?