### PR TITLE
ARROW-7321: [CI][GLib] Disable development mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,6 @@ services:
         base: ${REPO}:${ARCH}-debian-${DEBIAN}-cpp
     environment:
       ARROW_GLIB_GTK_DOC: "true"
-      ARROW_GLIB_DEVELOPMENT_MODE: "true"
     shm_size: *shm-size
     volumes: *debian-volumes
     command: &c-glib-command >
@@ -241,7 +240,6 @@ services:
         base: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-cpp
     environment:
       ARROW_GLIB_GTK_DOC: "true"
-      ARROW_GLIB_DEVELOPMENT_MODE: "true"
     shm_size: *shm-size
     volumes: *ubuntu-volumes
     command: *c-glib-command


### PR DESCRIPTION
Because GLib version is old on Debian 10 and Ubuntu 18.04 LTS.

GLib 2.58 or earlier generates a warning when we use C++ compiler. It
has been fixed in GLib 2.60.

Debian 10 ships GLib 2.58 and Ubuntu 18.04 LTS ships GLib 2.56.

This fixes CI failure https://circleci.com/gh/ursa-labs/crossbow/5681 :

    FAILED: arrow-glib/20f505c@@arrow-glib@sha/file.cpp.o
    ccache c++ -Iarrow-glib/20f505c@@arrow-glib@sha -Iarrow-glib -I../../arrow/c_glib/arrow-glib -I. -I../../arrow/c_glib/ -I/usr/local/include -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wnon-virtual-dtor -std=c++11 -g -Werror -DARROW_NO_DEPRECATED_API -fPIC -pthread -MD -MQ 'arrow-glib/20f505c@@arrow-glib@sha/file.cpp.o' -MF 'arrow-glib/20f505c@@arrow-glib@sha/file.cpp.o.d' -o 'arrow-glib/20f505c@@arrow-glib@sha/file.cpp.o' -c ../../arrow/c_glib/arrow-glib/file.cpp
    In file included from /usr/include/glib-2.0/gobject/gobject.h:24:0,
                     from /usr/include/glib-2.0/gobject/gbinding.h:29,
                     from /usr/include/glib-2.0/glib-object.h:23,
                     from ../../arrow/c_glib/arrow-glib/error.h:22,
                     from ../../arrow/c_glib/arrow-glib/error.hpp:24,
                     from ../../arrow/c_glib/arrow-glib/file.cpp:26:
    ../../arrow/c_glib/arrow-glib/file.cpp: In function 'GType garrow_file_get_type()':
    /usr/include/glib-2.0/gobject/gtype.h:219:50: error: '<<' in boolean context, did you mean '<' ? [-Werror=int-in-bool-context]
     #define G_TYPE_MAKE_FUNDAMENTAL(x) ((GType) ((x) << G_TYPE_FUNDAMENTAL_SHIFT))
                                                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/glib-2.0/gobject/gtype.h:2015:11: note: in definition of macro '_G_DEFINE_INTERFACE_EXTENDED_BEGIN'
           if (TYPE_PREREQ) \
               ^~~~~~~~~~~
    /usr/include/glib-2.0/gobject/gtype.h:1756:47: note: in expansion of macro 'G_DEFINE_INTERFACE_WITH_CODE'
     #define G_DEFINE_INTERFACE(TN, t_n, T_P)      G_DEFINE_INTERFACE_WITH_CODE(TN, t_n, T_P, ;)
                                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../../arrow/c_glib/arrow-glib/file.cpp:40:1: note: in expansion of macro 'G_DEFINE_INTERFACE'
     G_DEFINE_INTERFACE(GArrowFile,
     ^~~~~~~~~~~~~~~~~~
    /usr/include/glib-2.0/gobject/gtype.h:178:25: note: in expansion of macro 'G_TYPE_MAKE_FUNDAMENTAL'
     #define G_TYPE_OBJECT   G_TYPE_MAKE_FUNDAMENTAL (20)
                             ^~~~~~~~~~~~~~~~~~~~~~~
    ../../arrow/c_glib/arrow-glib/file.cpp:42:20: note: in expansion of macro 'G_TYPE_OBJECT'
                        G_TYPE_OBJECT)
                        ^~~~~~~~~~~~~
    cc1plus: all warnings being treated as errors