### PR TITLE
ARROW-7318: [C#] TimestampArray serialization failure

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
@@ -101,7 +101,7 @@ namespace Apache.Arrow
         {
             data.EnsureDataType(ArrowTypeId.Timestamp);
 
-            Debug.Assert((Data.DataType as TimestampType) != null);
+            Debug.Assert(Data.DataType is TimestampType);
         }
 
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);

--- a/csharp/src/Apache.Arrow/Extensions/TimeSpanExtensions.cs
+++ b/csharp/src/Apache.Arrow/Extensions/TimeSpanExtensions.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 
 namespace Apache.Arrow
 {

--- a/csharp/src/Apache.Arrow/Extensions/TimeSpanExtensions.cs
+++ b/csharp/src/Apache.Arrow/Extensions/TimeSpanExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Apache.Arrow
+{
+    public static class TimeSpanExtensions
+    {
+        /// <summary>
+        /// Formats a TimeSpan into an ISO 8601 compliant time offset string.
+        /// </summary>
+        /// <param name="timeSpan">timeSpan to format</param>
+        /// <returns>ISO 8601 offset string</returns>
+        public static string ToTimeZoneOffsetString(this TimeSpan timeSpan)
+        {
+            var sign = timeSpan.Hours >= 0 ? "+" : "-";
+            var hours = Math.Abs(timeSpan.Hours);
+            var minutes = Math.Abs(timeSpan.Minutes);
+            return sign + hours.ToString("00") + ":" + minutes.ToString("00");
+        }
+           
+    }
+}

--- a/csharp/src/Apache.Arrow/Ipc/ArrowTypeFlatbufferBuilder.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowTypeFlatbufferBuilder.cs
@@ -118,7 +118,7 @@ namespace Apache.Arrow.Ipc
             {  
                 StringOffset timezoneStringOffset = default;
 
-                if (string.IsNullOrWhiteSpace(type.Timezone))
+                if (!string.IsNullOrWhiteSpace(type.Timezone))
                     timezoneStringOffset = Builder.CreateString(type.Timezone);
 
                 Result = FieldType.Build(

--- a/csharp/src/Apache.Arrow/RecordBatch.Builder.cs
+++ b/csharp/src/Apache.Arrow/RecordBatch.Builder.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using Apache.Arrow.Memory;
+using Apache.Arrow.Types;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
@@ -32,32 +33,38 @@ namespace Apache.Arrow
                 _allocator = allocator;
             }
 
-            public BooleanArray Boolean(Action<BooleanArray.Builder> action) => Build<BooleanArray, BooleanArray.Builder>(action);
-            public Int8Array Int8(Action<Int8Array.Builder> action) => Build<Int8Array, Int8Array.Builder>(action);
-            public Int16Array Int16(Action<Int16Array.Builder> action) => Build<Int16Array, Int16Array.Builder>(action);
-            public Int32Array Int32(Action<Int32Array.Builder> action) => Build<Int32Array, Int32Array.Builder>(action);
-            public Int64Array Int64(Action<Int64Array.Builder> action) => Build<Int64Array, Int64Array.Builder>(action);
-            public UInt8Array UInt8(Action<UInt8Array.Builder> action) => Build<UInt8Array, UInt8Array.Builder>(action);
-            public UInt16Array UInt16(Action<UInt16Array.Builder> action) => Build<UInt16Array, UInt16Array.Builder>(action);
-            public UInt32Array UInt32(Action<UInt32Array.Builder> action) => Build<UInt32Array, UInt32Array.Builder>(action);
-            public UInt64Array UInt64(Action<UInt64Array.Builder> action) => Build<UInt64Array, UInt64Array.Builder>(action);
-            public FloatArray Float(Action<FloatArray.Builder> action) => Build<FloatArray, FloatArray.Builder>(action);
-            public DoubleArray Double(Action<DoubleArray.Builder> action) => Build<DoubleArray, DoubleArray.Builder>(action);
-            public Date32Array Date32(Action<Date32Array.Builder> action) => Build<Date32Array, Date32Array.Builder>(action);
-            public Date64Array Date64(Action<Date64Array.Builder> action) => Build<Date64Array, Date64Array.Builder>(action);
-            public BinaryArray Binary(Action<BinaryArray.Builder> action) => Build<BinaryArray, BinaryArray.Builder>(action);
-            public StringArray String(Action<StringArray.Builder> action) => Build<StringArray, StringArray.Builder>(action);
+            public BooleanArray Boolean(Action<BooleanArray.Builder> action) => Build<BooleanArray, BooleanArray.Builder>(new BooleanArray.Builder(), action);
+            public Int8Array Int8(Action<Int8Array.Builder> action) => Build<Int8Array, Int8Array.Builder>(new Int8Array.Builder(), action);
+            public Int16Array Int16(Action<Int16Array.Builder> action) => Build<Int16Array, Int16Array.Builder>(new Int16Array.Builder(), action);
+            public Int32Array Int32(Action<Int32Array.Builder> action) => Build<Int32Array, Int32Array.Builder>(new Int32Array.Builder(), action);
+            public Int64Array Int64(Action<Int64Array.Builder> action) => Build<Int64Array, Int64Array.Builder>(new Int64Array.Builder(), action);
+            public UInt8Array UInt8(Action<UInt8Array.Builder> action) => Build<UInt8Array, UInt8Array.Builder>(new UInt8Array.Builder(), action);
+            public UInt16Array UInt16(Action<UInt16Array.Builder> action) => Build<UInt16Array, UInt16Array.Builder>(new UInt16Array.Builder(), action);
+            public UInt32Array UInt32(Action<UInt32Array.Builder> action) => Build<UInt32Array, UInt32Array.Builder>(new UInt32Array.Builder(), action);
+            public UInt64Array UInt64(Action<UInt64Array.Builder> action) => Build<UInt64Array, UInt64Array.Builder>(new UInt64Array.Builder(), action);
+            public FloatArray Float(Action<FloatArray.Builder> action) => Build<FloatArray, FloatArray.Builder>(new FloatArray.Builder(), action);
+            public DoubleArray Double(Action<DoubleArray.Builder> action) => Build<DoubleArray, DoubleArray.Builder>(new DoubleArray.Builder(), action);
+            public Date32Array Date32(Action<Date32Array.Builder> action) => Build<Date32Array, Date32Array.Builder>(new Date32Array.Builder(), action);
+            public Date64Array Date64(Action<Date64Array.Builder> action) => Build<Date64Array, Date64Array.Builder>(new Date64Array.Builder(), action);
+            public BinaryArray Binary(Action<BinaryArray.Builder> action) => Build<BinaryArray, BinaryArray.Builder>(new BinaryArray.Builder(), action);
+            public StringArray String(Action<StringArray.Builder> action) => Build<StringArray, StringArray.Builder>(new StringArray.Builder(), action);
+            public TimestampArray Timestamp(Action<TimestampArray.Builder> action) => Build<TimestampArray, TimestampArray.Builder>(new TimestampArray.Builder(), action);
+            public TimestampArray Timestamp(TimestampType type, Action<TimestampArray.Builder> action) => 
+                Build<TimestampArray, TimestampArray.Builder>(
+                    new TimestampArray.Builder(type), action);
+            public TimestampArray Timestamp(TimeUnit unit, TimeZoneInfo timezone, Action<TimestampArray.Builder> action) =>
+                Build<TimestampArray, TimestampArray.Builder>(
+                    new TimestampArray.Builder(new TimestampType(unit, timezone)), action);
 
-            private TArray Build<TArray, TArrayBuilder>(Action<TArrayBuilder> action)
+            private TArray Build<TArray, TArrayBuilder>(TArrayBuilder builder, Action<TArrayBuilder> action)
                 where TArray: IArrowArray
-                where TArrayBuilder: IArrowArrayBuilder<TArray>, new()
+                where TArrayBuilder: IArrowArrayBuilder<TArray>
             {
                 if (action == null)
                 {
                     return default;
                 }
 
-                var builder = new TArrayBuilder();
                 action(builder);
 
                 return builder.Build(_allocator);

--- a/csharp/src/Apache.Arrow/Types/TimestampType.cs
+++ b/csharp/src/Apache.Arrow/Types/TimestampType.cs
@@ -14,11 +14,13 @@
 // limitations under the License.
 
 
+using System;
+
 namespace Apache.Arrow.Types
 {
     public sealed class TimestampType : FixedWidthType
     {
-        public static readonly TimestampType Default = new TimestampType(TimeUnit.Millisecond, "UTC");
+        public static readonly TimestampType Default = new TimestampType(TimeUnit.Millisecond, TimeZoneInfo.Utc.Id);
 
         public override ArrowTypeId TypeId => ArrowTypeId.Timestamp;
         public override string Name => "timestamp";
@@ -27,12 +29,29 @@ namespace Apache.Arrow.Types
         public TimeUnit Unit { get; }
         public string Timezone { get; }
 
+        public TimeZoneInfo GetTimeZoneInfo()
+        {
+            return !string.IsNullOrEmpty(Timezone)
+                ? TimeZoneInfo.FindSystemTimeZoneById(Timezone)
+                : null;
+        }
+
+        public bool IsTimeZoneAware => !string.IsNullOrWhiteSpace(Timezone);
+
         public TimestampType(
             TimeUnit unit = TimeUnit.Millisecond,
             string timezone = default)
         {
             Unit = unit;
             Timezone = timezone;
+        }
+
+        public TimestampType(
+            TimeUnit unit = TimeUnit.Millisecond,
+            TimeZoneInfo timezone = default)
+        {
+            Unit = unit;
+            Timezone = timezone?.Id;
         }
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);

--- a/csharp/src/Apache.Arrow/Types/TimestampType.cs
+++ b/csharp/src/Apache.Arrow/Types/TimestampType.cs
@@ -20,7 +20,7 @@ namespace Apache.Arrow.Types
 {
     public sealed class TimestampType : FixedWidthType
     {
-        public static readonly TimestampType Default = new TimestampType(TimeUnit.Millisecond, TimeZoneInfo.Utc.Id);
+        public static readonly TimestampType Default = new TimestampType(TimeUnit.Millisecond, "+00:00");
 
         public override ArrowTypeId TypeId => ArrowTypeId.Timestamp;
         public override string Name => "timestamp";
@@ -28,13 +28,6 @@ namespace Apache.Arrow.Types
 
         public TimeUnit Unit { get; }
         public string Timezone { get; }
-
-        public TimeZoneInfo GetTimeZoneInfo()
-        {
-            return !string.IsNullOrEmpty(Timezone)
-                ? TimeZoneInfo.FindSystemTimeZoneById(Timezone)
-                : null;
-        }
 
         public bool IsTimeZoneAware => !string.IsNullOrWhiteSpace(Timezone);
 
@@ -51,7 +44,7 @@ namespace Apache.Arrow.Types
             TimeZoneInfo timezone = default)
         {
             Unit = unit;
-            Timezone = timezone?.Id;
+            Timezone = timezone?.BaseUtcOffset.ToTimeZoneOffsetString();
         }
 
         public override void Accept(IArrowTypeVisitor visitor) => Accept(this, visitor);

--- a/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
@@ -44,7 +44,8 @@ namespace Apache.Arrow.Tests
             public void ProducesExpectedArray()
             {
                 var now = DateTimeOffset.UtcNow.ToLocalTime();
-                var array = new TimestampArray.Builder(TimeUnit.Nanosecond, TimeZoneInfo.Local.Id)
+                var timestampType = new TimestampType(TimeUnit.Nanosecond, TimeZoneInfo.Local);
+                var array = new TimestampArray.Builder(timestampType)
                     .Append(now)
                     .Build();
 

--- a/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -14,7 +14,9 @@
 // limitations under the License.
 
 using Apache.Arrow.Ipc;
+using Apache.Arrow.Types;
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -58,6 +60,79 @@ namespace Apache.Arrow.Tests
             }
         }
 
+        private class ArrayTypeComparer :
+            IArrowTypeVisitor<TimestampType>,
+            IArrowTypeVisitor<Date32Type>,
+            IArrowTypeVisitor<Date64Type>,
+            IArrowTypeVisitor<Time32Type>,
+            IArrowTypeVisitor<Time64Type>,
+            IArrowTypeVisitor<FixedSizeBinaryType>
+        {
+            private readonly IArrowType _expectedType;
+
+            public ArrayTypeComparer(IArrowType expectedType)
+            {
+                Debug.Assert(expectedType != null);
+                _expectedType = expectedType;
+            }
+
+            public void Visit(TimestampType actualType)
+            {
+                Assert.IsAssignableFrom<TimestampType>(_expectedType);
+
+                var expectedType = (TimestampType) _expectedType;
+                
+                Assert.Equal(expectedType.Timezone, actualType.Timezone);
+                Assert.Equal(expectedType.Unit, actualType.Unit);
+            }
+
+
+            public void Visit(Date32Type actualType)
+            {
+                Assert.IsAssignableFrom<Date32Type>(_expectedType);
+                var expectedType = (Date32Type)_expectedType;
+
+                Assert.Equal(expectedType.Unit, actualType.Unit);
+            }
+
+            public void Visit(Date64Type actualType)
+            {
+                Assert.IsAssignableFrom<Date64Type>(_expectedType);
+                var expectedType = (Date64Type)_expectedType;
+
+                Assert.Equal(expectedType.Unit, actualType.Unit);
+            }
+
+            public void Visit(Time32Type actualType)
+            {
+                Assert.IsAssignableFrom<Time32Type>(_expectedType);
+                var expectedType = (Time32Type)_expectedType;
+
+                Assert.Equal(expectedType.Unit, actualType.Unit);
+            }
+
+            public void Visit(Time64Type actualType)
+            {
+                Assert.IsAssignableFrom<Time64Type>(_expectedType);
+                var expectedType = (Time64Type)_expectedType;
+
+                Assert.Equal(expectedType.Unit, actualType.Unit);
+            }
+
+            public void Visit(FixedSizeBinaryType actualType)
+            {
+                Assert.IsAssignableFrom<FixedSizeBinaryType>(_expectedType);
+                var expectedType = (FixedSizeBinaryType)_expectedType;
+
+                Assert.Equal(expectedType.ByteWidth, actualType.ByteWidth);
+            }
+
+            public void Visit(IArrowType actualType)
+            {
+                Assert.IsAssignableFrom(actualType.GetType(), _expectedType);
+            }
+        }
+
         private class ArrayComparer :
             IArrowArrayVisitor<Int8Array>,
             IArrowArrayVisitor<Int16Array>,
@@ -78,10 +153,12 @@ namespace Apache.Arrow.Tests
             IArrowArrayVisitor<BinaryArray>
         {
             private readonly IArrowArray _expectedArray;
+            private readonly ArrayTypeComparer _arrayTypeComparer;
 
             public ArrayComparer(IArrowArray expectedArray)
             {
                 _expectedArray = expectedArray;
+                _arrayTypeComparer = new ArrayTypeComparer(expectedArray.Data.DataType);
             }
 
             public void Visit(Int8Array array) => CompareArrays(array);
@@ -99,15 +176,38 @@ namespace Apache.Arrow.Tests
             public void Visit(Date32Array array) => CompareArrays(array);
             public void Visit(Date64Array array) => CompareArrays(array);
             public void Visit(ListArray array) => throw new NotImplementedException();
-            public void Visit(StringArray array) => throw new NotImplementedException();
-            public void Visit(BinaryArray array) => throw new NotImplementedException();
+
+            public void Visit(StringArray array) => CompareBinaryArrays<StringArray>(array);
+
+            public void Visit(BinaryArray array) => CompareBinaryArrays<BinaryArray>(array);
+            public void Visit(FixedSizeBinaryType array) => throw new NotImplementedException();
             public void Visit(IArrowArray array) => throw new NotImplementedException();
+
+            private void CompareBinaryArrays<T>(BinaryArray actualArray)
+                where T: IArrowArray
+            {
+                Assert.IsAssignableFrom<T>(_expectedArray);
+                Assert.IsAssignableFrom<T>(actualArray);
+
+                var expectedArray = (BinaryArray)_expectedArray;
+
+                _arrayTypeComparer.Visit(actualArray.Data.DataType);
+
+                Assert.Equal(expectedArray.Length, actualArray.Length);
+                Assert.Equal(expectedArray.NullCount, actualArray.NullCount);
+                Assert.Equal(expectedArray.Offset, actualArray.Offset);
+
+                Assert.True(expectedArray.NullBitmapBuffer.Span.SequenceEqual(actualArray.NullBitmapBuffer.Span));
+                Assert.True(expectedArray.Values.Slice(0, expectedArray.Length).SequenceEqual(actualArray.Values.Slice(0, actualArray.Length)));
+            }
 
             private void CompareArrays<T>(PrimitiveArray<T> actualArray)
                 where T : struct, IEquatable<T>
             {
                 Assert.IsAssignableFrom<PrimitiveArray<T>>(_expectedArray);
                 PrimitiveArray<T> expectedArray = (PrimitiveArray<T>)_expectedArray;
+
+                _arrayTypeComparer.Visit(actualArray.Data.DataType);
 
                 Assert.Equal(expectedArray.Length, actualArray.Length);
                 Assert.Equal(expectedArray.NullCount, actualArray.NullCount);
@@ -121,6 +221,8 @@ namespace Apache.Arrow.Tests
             {
                 Assert.IsAssignableFrom<BooleanArray>(_expectedArray);
                 BooleanArray expectedArray = (BooleanArray)_expectedArray;
+
+                _arrayTypeComparer.Visit(actualArray.Data.DataType);
 
                 Assert.Equal(expectedArray.Length, actualArray.Length);
                 Assert.Equal(expectedArray.NullCount, actualArray.NullCount);

--- a/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -86,7 +86,6 @@ namespace Apache.Arrow.Tests
                 Assert.Equal(expectedType.Unit, actualType.Unit);
             }
 
-
             public void Visit(Date32Type actualType)
             {
                 Assert.IsAssignableFrom<Date32Type>(_expectedType);
@@ -198,6 +197,7 @@ namespace Apache.Arrow.Tests
                 Assert.Equal(expectedArray.Offset, actualArray.Offset);
 
                 Assert.True(expectedArray.NullBitmapBuffer.Span.SequenceEqual(actualArray.NullBitmapBuffer.Span));
+                Assert.True(expectedArray.ValueOffsetsBuffer.Span.SequenceEqual(actualArray.ValueOffsetsBuffer.Span));
                 Assert.True(expectedArray.Values.Slice(0, expectedArray.Length).SequenceEqual(actualArray.Values.Slice(0, actualArray.Length)));
             }
 
@@ -229,6 +229,7 @@ namespace Apache.Arrow.Tests
                 Assert.Equal(expectedArray.Offset, actualArray.Offset);
 
                 Assert.True(expectedArray.NullBitmapBuffer.Span.SequenceEqual(actualArray.NullBitmapBuffer.Span));
+
                 int booleanByteCount = BitUtility.ByteCount(expectedArray.Length);
                 Assert.True(expectedArray.Values.Slice(0, booleanByteCount).SequenceEqual(actualArray.Values.Slice(0, booleanByteCount)));
             }

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -44,12 +44,14 @@ namespace Apache.Arrow.Tests
                 builder.Field(CreateField(DoubleType.Default, i));
                 builder.Field(CreateField(Date32Type.Default, i));
                 builder.Field(CreateField(Date64Type.Default, i));
+                builder.Field(CreateField(TimestampType.Default, i));
+                builder.Field(CreateField(StringType.Default, i));
+                //builder.Field(CreateField(new FixedSizeBinaryType(16), i));
                 //builder.Field(CreateField(new DecimalType(19, 2)));
                 //builder.Field(CreateField(HalfFloatType.Default));
                 //builder.Field(CreateField(StringType.Default));
                 //builder.Field(CreateField(Time32Type.Default));
                 //builder.Field(CreateField(Time64Type.Default));
-                //builder.Field(CreateField(TimestampType.Default));
             }
 
             Schema schema = builder.Build();
@@ -78,16 +80,14 @@ namespace Apache.Arrow.Tests
 
         private static IArrowArray CreateArray(Field field, int length)
         {
-            var creator = new ArrayBufferCreator(length);
+            var creator = new ArrayCreator(length);
+
             field.DataType.Accept(creator);
 
-            ArrayData data = new ArrayData(field.DataType, length, 0, 0,
-                    new[] { ArrowBuffer.Empty, creator.Buffer });
-
-            return ArrowArrayFactory.BuildArray(data);
+            return creator.Array;
         }
 
-        private class ArrayBufferCreator :
+        private class ArrayCreator :
             IArrowTypeVisitor<BooleanType>,
             IArrowTypeVisitor<Date32Type>,
             IArrowTypeVisitor<Date64Type>,
@@ -100,78 +100,94 @@ namespace Apache.Arrow.Tests
             IArrowTypeVisitor<UInt32Type>,
             IArrowTypeVisitor<UInt64Type>,
             IArrowTypeVisitor<FloatType>,
-            IArrowTypeVisitor<DoubleType>
+            IArrowTypeVisitor<DoubleType>,
+            IArrowTypeVisitor<TimestampType>,
+            IArrowTypeVisitor<StringType>
         {
-            private readonly int _length;
-            public ArrowBuffer Buffer { get; private set; }
+            private int Length { get; }
+            public IArrowArray Array { get; private set; }
 
-            public ArrayBufferCreator(int length)
+            public ArrayCreator(int length)
             {
-                _length = length;
+                Length = length;
             }
 
-            public void Visit(BooleanType type)
-            {
-                ArrowBuffer.Builder<bool> builder = new ArrowBuffer.Builder<bool>(_length);
-                for (int i = 0; i < _length; i++)
-                    builder.Append(i % 2 == 0);
+            public void Visit(BooleanType type) => GenerateArray(new BooleanArray.Builder(), x => x % 2 == 0);
+            public void Visit(Int8Type type) => GenerateArray(new Int8Array.Builder(), x => (sbyte)x);
+            public void Visit(Int16Type type) => GenerateArray(new Int16Array.Builder(), x => (short)x);
+            public void Visit(Int32Type type) => GenerateArray(new Int32Array.Builder(), x => x);
+            public void Visit(Int64Type type) => GenerateArray(new Int64Array.Builder(), x => x);
+            public void Visit(UInt8Type type) => GenerateArray(new UInt8Array.Builder(), x => (byte)x);
+            public void Visit(UInt16Type type) => GenerateArray(new UInt16Array.Builder(), x => (ushort)x);
+            public void Visit(UInt32Type type) => GenerateArray(new UInt32Array.Builder(), x => (uint)x);
+            public void Visit(UInt64Type type) => GenerateArray(new UInt64Array.Builder(), x => (ulong)x);
+            public void Visit(FloatType type) => GenerateArray(new FloatArray.Builder(), x => ((float)x / Length));
+            public void Visit(DoubleType type) => GenerateArray(new DoubleArray.Builder(), x => ((double)x / Length));
 
-                Buffer = builder.Build();
+            public void Visit(Date32Type type)
+            {
+                var builder = new Date32Array.Builder().Reserve(Length);
+                var basis = DateTimeOffset.UtcNow.AddDays(-Length);
+
+                for (var i = 0; i < Length; i++)
+                {
+                    builder.Append(basis.AddDays(i));
+                }
+
+                Array = builder.Build();
             }
 
-            public void Visit(Int8Type type)
+            public void Visit(Date64Type type)
             {
-                ArrowBuffer.Builder<sbyte> builder = new ArrowBuffer.Builder<sbyte>(_length);
-                for (int i = 0; i < _length; i++)
-                    builder.Append((sbyte)i);
+                var builder = new Date64Array.Builder().Reserve(Length);
+                var basis = DateTimeOffset.UtcNow.AddSeconds(-Length);
 
-                Buffer = builder.Build();
+                for (var i = 0; i < Length; i++)
+                {
+                    builder.Append(basis.AddSeconds(i));
+                }
+
+                Array = builder.Build();
             }
 
-            public void Visit(UInt8Type type)
+            public void Visit(TimestampType type)
             {
-                ArrowBuffer.Builder<byte> builder = new ArrowBuffer.Builder<byte>(_length);
-                for (int i = 0; i < _length; i++)
-                    builder.Append((byte)i);
+                var builder = new TimestampArray.Builder().Reserve(Length);
+                var basis = DateTimeOffset.UtcNow.AddMilliseconds(-Length);
 
-                Buffer = builder.Build();
+                for (var i = 0; i < Length; i++)
+                {
+                    builder.Append(basis.AddMilliseconds(i));
+                }
+
+                Array = builder.Build();
             }
 
-            public void Visit(Int16Type type)
+            public void Visit(StringType type)
             {
-                ArrowBuffer.Builder<short> builder = new ArrowBuffer.Builder<short>(_length);
-                for (int i = 0; i < _length; i++)
-                    builder.Append((short)i);
+                var str = "helloworld";
+                var builder = new StringArray.Builder();
 
-                Buffer = builder.Build();
+                for (var i = 0; i < Length; i++)
+                {
+                    builder.Append(str);
+                }
+
+                Array = builder.Build();
             }
 
-            public void Visit(UInt16Type type)
-            {
-                ArrowBuffer.Builder<ushort> builder = new ArrowBuffer.Builder<ushort>(_length);
-                for (int i = 0; i < _length; i++)
-                    builder.Append((ushort)i);
-
-                Buffer = builder.Build();
-            }
-
-            public void Visit(Int32Type type) => CreateNumberArray<int>(type);
-            public void Visit(UInt32Type type) => CreateNumberArray<uint>(type);
-            public void Visit(Int64Type type) => CreateNumberArray<long>(type);
-            public void Visit(UInt64Type type) => CreateNumberArray<ulong>(type);
-            public void Visit(FloatType type) => CreateNumberArray<float>(type);
-            public void Visit(DoubleType type) => CreateNumberArray<double>(type);
-            public void Visit(Date32Type type) => CreateNumberArray<int>(type);
-            public void Visit(Date64Type type) => CreateNumberArray<long>(type);
-
-            private void CreateNumberArray<T>(IArrowType type)
+            private void GenerateArray<T, TArray, TArrayBuilder>(IArrowArrayBuilder<T, TArray, TArrayBuilder> builder, Func<int, T> generator)
+                where TArrayBuilder : IArrowArrayBuilder<T, TArray, TArrayBuilder>
+                where TArray : IArrowArray
                 where T : struct
             {
-                ArrowBuffer.Builder<T> builder = new ArrowBuffer.Builder<T>(_length);
-                for (int i = 0; i < _length; i++)
-                    builder.Append((T)Convert.ChangeType(i, typeof(T)));
+                for (var i = 0; i < Length; i++)
+                {
+                    var value = generator(i);
+                    builder.Append(value);
+                }
 
-                Buffer = builder.Build();
+                Array = builder.Build(default);
             }
 
             public void Visit(IArrowType type)


### PR DESCRIPTION
Fixes bug where FlatBuffer serialization of TimestampType was not serializing the time zone, resulting in the time zone not being preserved. Existing round-trip serialization tests did not catch this bug, because they were both not including a timestamp field in the test record batches, and did not include tests for comparing array types.

The test code was refactored to lift an abstraction from buffers to arrays; this both simplifies the code (we can use the fluent builder API) and offers more flexibility for comparing parametric array types like binary, string, timestamp, date/time, etc.