### PR TITLE
ARROW-7323: [CI][Rust] Use the same toolchain

### DIFF
--- a/ci/docker/debian-10-rust.dockerfile
+++ b/ci/docker/debian-10-rust.dockerfile
@@ -37,7 +37,7 @@ RUN wget -q -O - https://github.com/google/flatbuffers/archive/v${flatbuffers}.t
 # dependencies without building the library itself
 ARG rust=nightly-2019-11-14
 RUN rustup default ${rust}
-RUN rustup component add rustfmt --toolchain nightly-2019-11-14-x86_64-unknown-linux-gnu
+RUN rustup component add rustfmt --toolchain ${rust}-x86_64-unknown-linux-gnu
 
 # TODO(kszucs):
 # 1. add the files required to install the dependencies to .dockeignore

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -104,7 +104,7 @@ groups:
     - test-conda-r-3.6
     - test-ubuntu-18.04-r-sanitizer
     - test-debian-10-go-1.12
-    - test-debian-10-rust-nightly-2019-09-25
+    - test-debian-10-rust-nightly-2019-11-14
     - test-ubuntu-18.04-docs
     - test-ubuntu-fuzzit-fuzzing
     - test-ubuntu-fuzzit-regression
@@ -145,7 +145,7 @@ groups:
     - test-conda-r-3.6
     - test-ubuntu-18.04-r-sanitizer
     - test-debian-10-go-1.12
-    - test-debian-10-rust-nightly-2019-09-25
+    - test-debian-10-rust-nightly-2019-11-14
     - test-ubuntu-18.04-docs
 
   cpp:
@@ -255,7 +255,7 @@ groups:
     - test-conda-r-3.6
     # - test-ubuntu-18.04-r-sanitizer # ARROW-6957
     - test-debian-10-go-1.12
-    - test-debian-10-rust-nightly-2019-09-25
+    - test-debian-10-rust-nightly-2019-11-14
     - test-ubuntu-18.04-docs
     - test-ubuntu-fuzzit-fuzzing
     - test-ubuntu-fuzzit-regression
@@ -1787,13 +1787,13 @@ tasks:
         - docker-compose build debian-go
         - docker-compose run debian-go
 
-  test-debian-10-rust-nightly-2019-09-25:
+  test-debian-10-rust-nightly-2019-11-14:
     ci: circle
     platform: linux
     template: docker-tests/circle.linux.yml
     params:
       commands:
-        - export RUST=nightly-2019-09-25
+        - export RUST=nightly-2019-11-14
         - docker-compose pull --ignore-pull-failures debian-rust
         - docker-compose build debian-rust
         - docker-compose run debian-rust

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -641,6 +641,7 @@ services:
     volumes: *debian-volumes
     command: &rust-command >
       /bin/bash -c "
+        echo ${RUST} > /arrow/rust/rust-toolchain &&
         /arrow/ci/scripts/rust_build.sh /arrow /build/rust &&
         /arrow/ci/scripts/rust_test.sh /arrow /build/rust"
 


### PR DESCRIPTION
It fixes nightly CI failure:
https://circleci.com/gh/ursa-labs/crossbow/5685

    Step 8/8 : RUN rustup component add rustfmt --toolchain nightly-2019-11-14-x86_64-unknown-linux-gnu
     ---> Running in b28e33fbf36d
    error: toolchain 'nightly-2019-11-14-x86_64-unknown-linux-gnu' is not installed
    ERROR: Service 'debian-rust' failed to build: The command '/bin/sh -c rustup component add rustfmt --toolchain nightly-2019-11-14-x86_64-unknown-linux-gnu' returned a non-zero code: 1