### PR TITLE
ARROW-7324: [Rust] Add timezone to timestamp

### DIFF
--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -96,7 +96,7 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| {
             cast_array::<TimestampNanosecondType>(
                 512,
-                DataType::Timestamp(TimeUnit::Nanosecond),
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
             )
         })
     });
@@ -104,7 +104,7 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| {
             cast_array::<TimestampMillisecondType>(
                 512,
-                DataType::Timestamp(TimeUnit::Nanosecond),
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
             )
         })
     });

--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -43,6 +43,19 @@ where
     criterion::black_box(cast(&array, &to_type).unwrap());
 }
 
+// cast timestamp array from specified primitive array type to desired data type
+fn cast_timestamp_array<FROM>(size: usize, to_type: DataType) -> ()
+where
+    FROM: ArrowTimestampType,
+    Standard: Distribution<i64>,
+{
+    let array = Arc::new(PrimitiveArray::<FROM>::from_vec(
+        vec![random::<i64>(); size],
+        None,
+    )) as ArrayRef;
+    criterion::black_box(cast(&array, &to_type).unwrap());
+}
+
 fn add_benchmark(c: &mut Criterion) {
     c.bench_function("cast int32 to int32 512", |b| {
         b.iter(|| cast_array::<Int32Type>(512, DataType::Int32))
@@ -94,7 +107,7 @@ fn add_benchmark(c: &mut Criterion) {
     });
     c.bench_function("cast timestamp_ns to timestamp_s 512", |b| {
         b.iter(|| {
-            cast_array::<TimestampNanosecondType>(
+            cast_timestamp_array::<TimestampNanosecondType>(
                 512,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
             )
@@ -102,14 +115,14 @@ fn add_benchmark(c: &mut Criterion) {
     });
     c.bench_function("cast timestamp_ms to timestamp_ns 512", |b| {
         b.iter(|| {
-            cast_array::<TimestampMillisecondType>(
+            cast_timestamp_array::<TimestampMillisecondType>(
                 512,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
             )
         })
     });
     c.bench_function("cast timestamp_ms to i64 512", |b| {
-        b.iter(|| cast_array::<TimestampMillisecondType>(512, DataType::Int64))
+        b.iter(|| cast_timestamp_array::<TimestampMillisecondType>(512, DataType::Int64))
     });
 }
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -582,26 +582,6 @@ def_numeric_from_vec!(UInt64Type, u64, DataType::UInt64);
 def_numeric_from_vec!(Float32Type, f32, DataType::Float32);
 def_numeric_from_vec!(Float64Type, f64, DataType::Float64);
 
-def_numeric_from_vec!(
-    TimestampSecondType,
-    i64,
-    DataType::Timestamp(TimeUnit::Second, None)
-);
-def_numeric_from_vec!(
-    TimestampMillisecondType,
-    i64,
-    DataType::Timestamp(TimeUnit::Millisecond, None)
-);
-def_numeric_from_vec!(
-    TimestampMicrosecondType,
-    i64,
-    DataType::Timestamp(TimeUnit::Microsecond, None)
-);
-def_numeric_from_vec!(
-    TimestampNanosecondType,
-    i64,
-    DataType::Timestamp(TimeUnit::Nanosecond, None)
-);
 def_numeric_from_vec!(Date32Type, i32, DataType::Date32(DateUnit::Day));
 def_numeric_from_vec!(Date64Type, i64, DataType::Date64(DateUnit::Millisecond));
 def_numeric_from_vec!(Time32SecondType, i32, DataType::Time32(TimeUnit::Second));
@@ -622,6 +602,7 @@ def_numeric_from_vec!(
 );
 
 impl<T: ArrowTimestampType> PrimitiveArray<T> {
+    /// Construct a timestamp array from a vec of i64 values and an optional timezone
     pub fn from_vec(data: Vec<i64>, timezone: Option<Arc<String>>) -> Self {
         let array_data =
             ArrayData::builder(DataType::Timestamp(T::get_time_unit(), timezone))
@@ -1829,7 +1810,7 @@ mod tests {
     #[test]
     fn test_timestamp_fmt_debug() {
         let arr: PrimitiveArray<TimestampMillisecondType> =
-            vec![1546214400000, 1546214400000].into();
+            TimestampMillisecondArray::from_vec(vec![1546214400000, 1546214400000], None);
         assert_eq!(
             "PrimitiveArray<Timestamp(Millisecond, None)>\n[\n  2018-12-31T00:00:00,\n  2018-12-31T00:00:00,\n]",
             format!("{:?}", arr)

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -123,16 +123,16 @@ pub fn make_array(data: ArrayDataRef) -> ArrayRef {
         DataType::Time64(TimeUnit::Nanosecond) => {
             Arc::new(Time64NanosecondArray::from(data)) as ArrayRef
         }
-        DataType::Timestamp(TimeUnit::Second) => {
+        DataType::Timestamp(TimeUnit::Second, _) => {
             Arc::new(TimestampSecondArray::from(data)) as ArrayRef
         }
-        DataType::Timestamp(TimeUnit::Millisecond) => {
+        DataType::Timestamp(TimeUnit::Millisecond, _) => {
             Arc::new(TimestampMillisecondArray::from(data)) as ArrayRef
         }
-        DataType::Timestamp(TimeUnit::Microsecond) => {
+        DataType::Timestamp(TimeUnit::Microsecond, _) => {
             Arc::new(TimestampMicrosecondArray::from(data)) as ArrayRef
         }
-        DataType::Timestamp(TimeUnit::Nanosecond) => {
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => {
             Arc::new(TimestampNanosecondArray::from(data)) as ArrayRef
         }
         DataType::Binary => Arc::new(BinaryArray::from(data)) as ArrayRef,
@@ -332,7 +332,7 @@ where
                 (v % MILLISECONDS * MICROSECONDS) as u32,
             )),
             DataType::Time32(_) | DataType::Time64(_) => None,
-            DataType::Timestamp(unit) => match unit {
+            DataType::Timestamp(unit, _) => match unit {
                 TimeUnit::Second => Some(NaiveDateTime::from_timestamp(v, 0)),
                 TimeUnit::Millisecond => Some(NaiveDateTime::from_timestamp(
                     // extract seconds from milliseconds
@@ -416,7 +416,7 @@ where
                     _ => None,
                 }
             }
-            DataType::Timestamp(_) => match self.value_as_datetime(i) {
+            DataType::Timestamp(_, _) => match self.value_as_datetime(i) {
                 Some(datetime) => Some(datetime.time()),
                 None => None,
             },
@@ -468,7 +468,7 @@ where
                     None => write!(f, "null"),
                 }
             }
-            DataType::Timestamp(_) => match array.value_as_datetime(index) {
+            DataType::Timestamp(_, _) => match array.value_as_datetime(index) {
                 Some(datetime) => write!(f, "{:?}", datetime),
                 None => write!(f, "null"),
             },
@@ -581,27 +581,26 @@ def_numeric_from_vec!(UInt32Type, u32, DataType::UInt32);
 def_numeric_from_vec!(UInt64Type, u64, DataType::UInt64);
 def_numeric_from_vec!(Float32Type, f32, DataType::Float32);
 def_numeric_from_vec!(Float64Type, f64, DataType::Float64);
-// TODO: add temporal arrays
 
 def_numeric_from_vec!(
     TimestampSecondType,
     i64,
-    DataType::Timestamp(TimeUnit::Second)
+    DataType::Timestamp(TimeUnit::Second, None)
 );
 def_numeric_from_vec!(
     TimestampMillisecondType,
     i64,
-    DataType::Timestamp(TimeUnit::Millisecond)
+    DataType::Timestamp(TimeUnit::Millisecond, None)
 );
 def_numeric_from_vec!(
     TimestampMicrosecondType,
     i64,
-    DataType::Timestamp(TimeUnit::Microsecond)
+    DataType::Timestamp(TimeUnit::Microsecond, None)
 );
 def_numeric_from_vec!(
     TimestampNanosecondType,
     i64,
-    DataType::Timestamp(TimeUnit::Nanosecond)
+    DataType::Timestamp(TimeUnit::Nanosecond, None)
 );
 def_numeric_from_vec!(Date32Type, i32, DataType::Date32(DateUnit::Day));
 def_numeric_from_vec!(Date64Type, i64, DataType::Date64(DateUnit::Millisecond));
@@ -1787,7 +1786,7 @@ mod tests {
         let arr: PrimitiveArray<TimestampMillisecondType> =
             vec![1546214400000, 1546214400000].into();
         assert_eq!(
-            "PrimitiveArray<Timestamp(Millisecond)>\n[\n  2018-12-31T00:00:00,\n  2018-12-31T00:00:00,\n]",
+            "PrimitiveArray<Timestamp(Millisecond, None)>\n[\n  2018-12-31T00:00:00,\n  2018-12-31T00:00:00,\n]",
             format!("{:?}", arr)
         );
     }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -877,16 +877,16 @@ impl StructBuilder {
             DataType::Time64(TimeUnit::Nanosecond) => {
                 Box::new(Time64NanosecondBuilder::new(capacity))
             }
-            DataType::Timestamp(TimeUnit::Second) => {
+            DataType::Timestamp(TimeUnit::Second, _) => {
                 Box::new(TimestampSecondBuilder::new(capacity))
             }
-            DataType::Timestamp(TimeUnit::Millisecond) => {
+            DataType::Timestamp(TimeUnit::Millisecond, _) => {
                 Box::new(TimestampMillisecondBuilder::new(capacity))
             }
-            DataType::Timestamp(TimeUnit::Microsecond) => {
+            DataType::Timestamp(TimeUnit::Microsecond, _) => {
                 Box::new(TimestampMicrosecondBuilder::new(capacity))
             }
-            DataType::Timestamp(TimeUnit::Nanosecond) => {
+            DataType::Timestamp(TimeUnit::Nanosecond, _) => {
                 Box::new(TimestampNanosecondBuilder::new(capacity))
             }
             DataType::Struct(fields) => {

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -1076,11 +1076,10 @@ mod tests {
 
     #[test]
     fn test_cast_timestamp_to_date64() {
-        let a = TimestampMillisecondArray::from(vec![
-            Some(864000000005),
-            Some(1545696000001),
+        let a = TimestampMillisecondArray::from_opt_vec(
+            vec![Some(864000000005), Some(1545696000001), None],
             None,
-        ]);
+        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Date64(DateUnit::Millisecond)).unwrap();
         let c = b.as_any().downcast_ref::<Date64Array>().unwrap();
@@ -1091,11 +1090,10 @@ mod tests {
 
     #[test]
     fn test_cast_timestamp_to_i64() {
-        let a = TimestampMillisecondArray::from(vec![
-            Some(864000000005),
-            Some(1545696000001),
-            None,
-        ]);
+        let a = TimestampMillisecondArray::from_opt_vec(
+            vec![Some(864000000005), Some(1545696000001), None],
+            Some(Arc::new("UTC".to_string())),
+        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Int64).unwrap();
         let c = b.as_any().downcast_ref::<Int64Array>().unwrap();
@@ -1107,11 +1105,10 @@ mod tests {
 
     #[test]
     fn test_cast_between_timestamps() {
-        let a = TimestampMillisecondArray::from(vec![
-            Some(864000003005),
-            Some(1545696002001),
+        let a = TimestampMillisecondArray::from_opt_vec(
+            vec![Some(864000003005), Some(1545696002001), None],
             None,
-        ]);
+        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Timestamp(TimeUnit::Second, None)).unwrap();
         let c = b.as_any().downcast_ref::<TimestampSecondArray>().unwrap();

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -431,8 +431,8 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
                 _ => unreachable!("array type not supported"),
             }
         }
-        (Timestamp(_), Int64) => cast_array_data::<Int64Type>(array, to_type.clone()),
-        (Int64, Timestamp(to_unit)) => {
+        (Timestamp(_, _), Int64) => cast_array_data::<Int64Type>(array, to_type.clone()),
+        (Int64, Timestamp(to_unit, _)) => {
             use TimeUnit::*;
             match to_unit {
                 Second => cast_array_data::<TimestampSecondType>(array, to_type.clone()),
@@ -447,7 +447,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
                 }
             }
         }
-        (Timestamp(from_unit), Timestamp(to_unit)) => {
+        (Timestamp(from_unit, _), Timestamp(to_unit, _)) => {
             let time_array = Int64Array::from(array.data());
             let from_size = time_unit_multiple(&from_unit);
             let to_size = time_unit_multiple(&to_unit);
@@ -484,7 +484,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
                 ),
             }
         }
-        (Timestamp(from_unit), Date32(_)) => {
+        (Timestamp(from_unit, _), Date32(_)) => {
             let time_array = Int64Array::from(array.data());
             let from_size = time_unit_multiple(&from_unit) * SECONDS_IN_DAY;
             let mut b = Date32Builder::new(array.len());
@@ -498,7 +498,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
 
             Ok(Arc::new(b.finish()) as ArrayRef)
         }
-        (Timestamp(from_unit), Date64(_)) => {
+        (Timestamp(from_unit, _), Date64(_)) => {
             let from_size = time_unit_multiple(&from_unit);
             let to_size = MILLISECONDS;
             if from_size != to_size {
@@ -933,12 +933,12 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Casting from Int32 to Timestamp(Microsecond) not supported"
+        expected = "Casting from Int32 to Timestamp(Microsecond, None) not supported"
     )]
     fn test_cast_int32_to_timestamp() {
         let a = Int32Array::from(vec![Some(2), Some(10), None]);
         let array = Arc::new(a) as ArrayRef;
-        cast(&array, &DataType::Timestamp(TimeUnit::Microsecond)).unwrap();
+        cast(&array, &DataType::Timestamp(TimeUnit::Microsecond, None)).unwrap();
     }
 
     #[test]
@@ -994,7 +994,7 @@ mod tests {
 
     #[test]
     #[should_panic(
-        expected = "Casting from Int32 to Timestamp(Microsecond) not supported"
+        expected = "Casting from Int32 to Timestamp(Microsecond, None) not supported"
     )]
     fn test_cast_list_i32_to_list_timestamp() {
         // Construct a value array
@@ -1014,7 +1014,7 @@ mod tests {
 
         cast(
             &list_array,
-            &DataType::List(Box::new(DataType::Timestamp(TimeUnit::Microsecond))),
+            &DataType::List(Box::new(DataType::Timestamp(TimeUnit::Microsecond, None))),
         )
         .unwrap();
     }
@@ -1114,7 +1114,7 @@ mod tests {
             None,
         ]);
         let array = Arc::new(a) as ArrayRef;
-        let b = cast(&array, &DataType::Timestamp(TimeUnit::Second)).unwrap();
+        let b = cast(&array, &DataType::Timestamp(TimeUnit::Second, None)).unwrap();
         let c = b.as_any().downcast_ref::<TimestampSecondArray>().unwrap();
         assert_eq!(864000003, c.value(0));
         assert_eq!(1545696002, c.value(1));

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -1062,11 +1062,10 @@ mod tests {
 
     #[test]
     fn test_cast_timestamp_to_date32() {
-        let a = TimestampMillisecondArray::from(vec![
-            Some(864000000005),
-            Some(1545696000001),
-            None,
-        ]);
+        let a = TimestampMillisecondArray::from_opt_vec(
+            vec![Some(864000000005), Some(1545696000001), None],
+            Some(Arc::new(String::from("UTC"))),
+        );
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Date32(DateUnit::Day)).unwrap();
         let c = b.as_any().downcast_ref::<Date32Array>().unwrap();

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -76,16 +76,16 @@ pub fn take(
         DataType::Time64(Nanosecond) => {
             take_primitive::<Time64NanosecondType>(values, indices)
         }
-        DataType::Timestamp(Second) => {
+        DataType::Timestamp(Second, _) => {
             take_primitive::<TimestampSecondType>(values, indices)
         }
-        DataType::Timestamp(Millisecond) => {
+        DataType::Timestamp(Millisecond, _) => {
             take_primitive::<TimestampMillisecondType>(values, indices)
         }
-        DataType::Timestamp(Microsecond) => {
+        DataType::Timestamp(Microsecond, _) => {
             take_primitive::<TimestampMicrosecondType>(values, indices)
         }
-        DataType::Timestamp(Nanosecond) => {
+        DataType::Timestamp(Nanosecond, _) => {
             take_primitive::<TimestampNanosecondType>(values, indices)
         }
         DataType::Utf8 => take_string(values, indices),

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -203,7 +203,7 @@ impl<W: Write> Writer<W> {
                         .format(&self.time_format)
                         .to_string()
                 }
-                DataType::Timestamp(time_unit) => {
+                DataType::Timestamp(time_unit, _) => {
                     use TimeUnit::*;
                     let datetime = match time_unit {
                         Second => col
@@ -394,7 +394,7 @@ mod tests {
             Field::new("c2", DataType::Float64, true),
             Field::new("c3", DataType::UInt32, false),
             Field::new("c4", DataType::Boolean, true),
-            Field::new("c5", DataType::Timestamp(TimeUnit::Millisecond), true),
+            Field::new("c5", DataType::Timestamp(TimeUnit::Millisecond, None), true),
             Field::new("c6", DataType::Time32(TimeUnit::Second), false),
         ]);
 
@@ -523,7 +523,7 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
             Field::new("c2", DataType::Float64, true),
             Field::new("c3", DataType::UInt32, false),
             Field::new("c4", DataType::Boolean, true),
-            Field::new("c5", DataType::Timestamp(TimeUnit::Millisecond), true),
+            Field::new("c5", DataType::Timestamp(TimeUnit::Millisecond, None), true),
             Field::new("c6", DataType::Time32(TimeUnit::Second), false),
         ]);
 

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -410,11 +410,10 @@ mod tests {
         ]);
         let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
         let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
-        let c5 = TimestampMillisecondArray::from(vec![
+        let c5 = TimestampMillisecondArray::from_opt_vec(
+            vec![None, Some(1555584887378), Some(1555555555555)],
             None,
-            Some(1555584887378),
-            Some(1555555555555),
-        ]);
+        );
         let c6 = Time32SecondArray::from(vec![1234, 24680, 85563]);
 
         let batch = RecordBatch::try_new(
@@ -539,11 +538,10 @@ sed do eiusmod tempor,-556132.25,1,,2019-04-18T02:45:55.555000000,23:46:03
         ]);
         let c3 = PrimitiveArray::<UInt32Type>::from(vec![3, 2, 1]);
         let c4 = PrimitiveArray::<BooleanType>::from(vec![Some(true), Some(false), None]);
-        let c5 = TimestampMillisecondArray::from(vec![
+        let c5 = TimestampMillisecondArray::from_opt_vec(
+            vec![None, Some(1555584887378), Some(1555555555555)],
             None,
-            Some(1555584887378),
-            Some(1555555555555),
-        ]);
+        );
         let c6 = Time32SecondArray::from(vec![1234, 24680, 85563]);
 
         let batch = RecordBatch::try_new(

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -423,7 +423,10 @@ mod tests {
                 ),
                 Field::new(
                     "timestamp[us]",
-                    DataType::Timestamp(TimeUnit::Microsecond, None),
+                    DataType::Timestamp(
+                        TimeUnit::Microsecond,
+                        Some(Arc::new("Africa/Johannesburg".to_string())),
+                    ),
                     false,
                 ),
                 Field::new(

--- a/rust/arrow/src/ipc/file/reader.rs
+++ b/rust/arrow/src/ipc/file/reader.rs
@@ -271,7 +271,7 @@ fn create_primitive_array(
                 builder.build()
             }
         }
-        Boolean | Int64 | UInt64 | Float64 | Time64(_) | Timestamp(_) | Date64(_) => {
+        Boolean | Int64 | UInt64 | Float64 | Time64(_) | Timestamp(_, _) | Date64(_) => {
             let mut builder = ArrayData::builder(data_type.clone())
                 .len(length)
                 .buffers(buffers[1..].to_vec())
@@ -530,7 +530,7 @@ mod tests {
         let testdata = env::var("ARROW_TEST_DATA").expect("ARROW_TEST_DATA not defined");
         // the test is repetitive, thus we can read all supported files at once
         let paths = vec![
-            // "generated_datetime",
+            "generated_datetime",
             "generated_nested",
             "generated_primitive_no_batches",
             "generated_primitive_zerolength",

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -378,6 +378,10 @@ mod tests {
 
     #[test]
     fn test_arrow_data_equality() {
+        let secs_tz = Some(Arc::new("Europe/Budapest".to_string()));
+        let millis_tz = Some(Arc::new("America/New_York".to_string()));
+        let micros_tz = Some(Arc::new("UTC".to_string()));
+        let nanos_tz = Some(Arc::new("Africa/Johannesburg".to_string()));
         let schema = Schema::new(vec![
             Field::new("bools", DataType::Boolean, true),
             Field::new("int8s", DataType::Int8, true),
@@ -410,6 +414,26 @@ mod tests {
             Field::new(
                 "ts_nanos",
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
+            Field::new(
+                "ts_secs_tz",
+                DataType::Timestamp(TimeUnit::Second, secs_tz.clone()),
+                true,
+            ),
+            Field::new(
+                "ts_millis_tz",
+                DataType::Timestamp(TimeUnit::Millisecond, millis_tz.clone()),
+                true,
+            ),
+            Field::new(
+                "ts_micros_tz",
+                DataType::Timestamp(TimeUnit::Microsecond, micros_tz.clone()),
+                true,
+            ),
+            Field::new(
+                "ts_nanos_tz",
+                DataType::Timestamp(TimeUnit::Nanosecond, nanos_tz.clone()),
                 true,
             ),
             Field::new("utf8s", DataType::Utf8, true),
@@ -464,6 +488,20 @@ mod tests {
         let ts_micros = TimestampMicrosecondArray::from(vec![None, None, None]);
         let ts_nanos =
             TimestampNanosecondArray::from(vec![None, None, Some(-6473623571954960143)]);
+        let ts_secs_tz = TimestampSecondArray::from_opt_vec(
+            vec![None, Some(193438817552), None],
+            secs_tz,
+        );
+        let ts_millis_tz = TimestampMillisecondArray::from_opt_vec(
+            vec![None, Some(38606916383008), Some(58113709376587)],
+            millis_tz,
+        );
+        let ts_micros_tz =
+            TimestampMicrosecondArray::from_opt_vec(vec![None, None, None], micros_tz);
+        let ts_nanos_tz = TimestampNanosecondArray::from_opt_vec(
+            vec![None, None, Some(-6473623571954960143)],
+            nanos_tz,
+        );
         let utf8s = StringArray::try_from(vec![Some("aa"), None, Some("bbb")]).unwrap();
 
         let value_data = Int32Array::from(vec![None, Some(2), None, None]);
@@ -514,6 +552,10 @@ mod tests {
                 Arc::new(ts_millis),
                 Arc::new(ts_micros),
                 Arc::new(ts_nanos),
+                Arc::new(ts_secs_tz),
+                Arc::new(ts_millis_tz),
+                Arc::new(ts_micros_tz),
+                Arc::new(ts_nanos_tz),
                 Arc::new(utf8s),
                 Arc::new(lists),
                 Arc::new(structs),

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -479,15 +479,20 @@ mod tests {
             None,
             Some(16584393546415),
         ]);
-        let ts_secs = TimestampSecondArray::from(vec![None, Some(193438817552), None]);
-        let ts_millis = TimestampMillisecondArray::from(vec![
+        let ts_secs = TimestampSecondArray::from_opt_vec(
+            vec![None, Some(193438817552), None],
             None,
-            Some(38606916383008),
-            Some(58113709376587),
-        ]);
-        let ts_micros = TimestampMicrosecondArray::from(vec![None, None, None]);
-        let ts_nanos =
-            TimestampNanosecondArray::from(vec![None, None, Some(-6473623571954960143)]);
+        );
+        let ts_millis = TimestampMillisecondArray::from_opt_vec(
+            vec![None, Some(38606916383008), Some(58113709376587)],
+            None,
+        );
+        let ts_micros =
+            TimestampMicrosecondArray::from_opt_vec(vec![None, None, None], None);
+        let ts_nanos = TimestampNanosecondArray::from_opt_vec(
+            vec![None, None, Some(-6473623571954960143)],
+            None,
+        );
         let ts_secs_tz = TimestampSecondArray::from_opt_vec(
             vec![None, Some(193438817552), None],
             secs_tz,

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -135,7 +135,7 @@ impl ArrowJsonBatch {
                     DataType::Int64
                     | DataType::Date64(_)
                     | DataType::Time64(_)
-                    | DataType::Timestamp(_) => {
+                    | DataType::Timestamp(_, _) => {
                         let arr = Int64Array::from(arr.data());
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
@@ -396,18 +396,22 @@ mod tests {
             Field::new("time_millis", DataType::Time32(TimeUnit::Millisecond), true),
             Field::new("time_micros", DataType::Time64(TimeUnit::Microsecond), true),
             Field::new("time_nanos", DataType::Time64(TimeUnit::Nanosecond), true),
-            Field::new("ts_secs", DataType::Timestamp(TimeUnit::Second), true),
+            Field::new("ts_secs", DataType::Timestamp(TimeUnit::Second, None), true),
             Field::new(
                 "ts_millis",
-                DataType::Timestamp(TimeUnit::Millisecond),
+                DataType::Timestamp(TimeUnit::Millisecond, None),
                 true,
             ),
             Field::new(
                 "ts_micros",
-                DataType::Timestamp(TimeUnit::Microsecond),
+                DataType::Timestamp(TimeUnit::Microsecond, None),
                 true,
             ),
-            Field::new("ts_nanos", DataType::Timestamp(TimeUnit::Nanosecond), true),
+            Field::new(
+                "ts_nanos",
+                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                true,
+            ),
             Field::new("utf8s", DataType::Utf8, true),
             Field::new("lists", DataType::List(Box::new(DataType::Int32)), true),
             Field::new(

--- a/rust/arrow/test/data/integration.json
+++ b/rust/arrow/test/data/integration.json
@@ -202,6 +202,46 @@
         "children": []
       },
       {
+        "name": "ts_secs_tz",
+        "type": {
+          "name": "timestamp",
+          "unit": "SECOND",
+          "timezone": "Europe/Budapest"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "ts_millis_tz",
+        "type": {
+          "name": "timestamp",
+          "unit": "MILLISECOND",
+          "timezone": "America/New_York"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "ts_micros_tz",
+        "type": {
+          "name": "timestamp",
+          "unit": "MICROSECOND",
+          "timezone": "UTC"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
+        "name": "ts_nanos_tz",
+        "type": {
+          "name": "timestamp",
+          "unit": "NANOSECOND",
+          "timezone": "Africa/Johannesburg"
+        },
+        "nullable": true,
+        "children": []
+      },
+      {
         "name": "utf8s",
         "type": {
           "name": "utf8"
@@ -543,6 +583,62 @@
         },
         {
           "name": "ts_nanos",
+          "count": 3,
+          "VALIDITY": [
+            0,
+            0,
+            1
+          ],
+          "DATA": [
+            -804525722984600007,
+            8166038652634779458,
+            -6473623571954960143
+          ]
+        },
+        {
+          "name": "ts_secs_tz",
+          "count": 3,
+          "VALIDITY": [
+            0,
+            1,
+            0
+          ],
+          "DATA": [
+            209869064422,
+            193438817552,
+            51757838205
+          ]
+        },
+        {
+          "name": "ts_millis_tz",
+          "count": 3,
+          "VALIDITY": [
+            0,
+            1,
+            1
+          ],
+          "DATA": [
+            228315043570185,
+            38606916383008,
+            58113709376587
+          ]
+        },
+        {
+          "name": "ts_micros_tz",
+          "count": 3,
+          "VALIDITY": [
+            0,
+            0,
+            0
+          ],
+          "DATA": [
+            133457416537791415,
+            129522736067409280,
+            177110451066832967
+          ]
+        },
+        {
+          "name": "ts_nanos_tz",
           "count": 3,
           "VALIDITY": [
             0,

--- a/rust/datafusion/src/bin/repl.rs
+++ b/rust/datafusion/src/bin/repl.rs
@@ -173,16 +173,16 @@ fn str_value(column: ArrayRef, row: usize) -> Result<String> {
         DataType::Float16 => make_string!(Float32Array, column, row),
         DataType::Float32 => make_string!(Float32Array, column, row),
         DataType::Float64 => make_string!(Float64Array, column, row),
-        DataType::Timestamp(unit) if *unit == TimeUnit::Second => {
+        DataType::Timestamp(unit, _) if *unit == TimeUnit::Second => {
             make_string!(TimestampSecondArray, column, row)
         }
-        DataType::Timestamp(unit) if *unit == TimeUnit::Millisecond => {
+        DataType::Timestamp(unit, _) if *unit == TimeUnit::Millisecond => {
             make_string!(TimestampMillisecondArray, column, row)
         }
-        DataType::Timestamp(unit) if *unit == TimeUnit::Microsecond => {
+        DataType::Timestamp(unit, _) if *unit == TimeUnit::Microsecond => {
             make_string!(TimestampMicrosecondArray, column, row)
         }
-        DataType::Timestamp(unit) if *unit == TimeUnit::Nanosecond => {
+        DataType::Timestamp(unit, _) if *unit == TimeUnit::Nanosecond => {
             make_string!(TimestampNanosecondArray, column, row)
         }
         DataType::Date32(_) => make_string!(Date32Array, column, row),

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -398,21 +398,21 @@ impl ParquetFile {
                                     is_nullable,
                                 )?
                             }
-                            DataType::Timestamp(TimeUnit::Millisecond) => {
+                            DataType::Timestamp(TimeUnit::Millisecond, None) => {
                                 ArrowReader::<TimestampMillisecondType>::read(
                                     r,
                                     self.batch_size,
                                     is_nullable,
                                 )?
                             }
-                            DataType::Timestamp(TimeUnit::Microsecond) => {
+                            DataType::Timestamp(TimeUnit::Microsecond, None) => {
                                 ArrowReader::<TimestampMicrosecondType>::read(
                                     r,
                                     self.batch_size,
                                     is_nullable,
                                 )?
                             }
-                            DataType::Timestamp(TimeUnit::Nanosecond) => {
+                            DataType::Timestamp(TimeUnit::Nanosecond, None) => {
                                 ArrowReader::<TimestampMicrosecondType>::read(
                                     r,
                                     self.batch_size,
@@ -596,7 +596,7 @@ mod tests {
              double_col: Float64\n\
              date_string_col: Utf8\n\
              string_col: Utf8\n\
-             timestamp_col: Timestamp(Nanosecond)",
+             timestamp_col: Timestamp(Nanosecond, None)",
             y
         );
 

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -191,7 +191,7 @@ impl ParquetTypeConverter {
             PhysicalType::BOOLEAN => Ok(DataType::Boolean),
             PhysicalType::INT32 => self.from_int32(),
             PhysicalType::INT64 => self.from_int64(),
-            PhysicalType::INT96 => Ok(DataType::Timestamp(TimeUnit::Nanosecond)),
+            PhysicalType::INT96 => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
             PhysicalType::FLOAT => Ok(DataType::Float32),
             PhysicalType::DOUBLE => Ok(DataType::Float64),
             PhysicalType::BYTE_ARRAY => self.from_byte_array(),
@@ -227,10 +227,10 @@ impl ParquetTypeConverter {
             LogicalType::UINT_64 => Ok(DataType::UInt64),
             LogicalType::TIME_MICROS => Ok(DataType::Time64(TimeUnit::Microsecond)),
             LogicalType::TIMESTAMP_MILLIS => {
-                Ok(DataType::Timestamp(TimeUnit::Millisecond))
+                Ok(DataType::Timestamp(TimeUnit::Millisecond, None))
             }
             LogicalType::TIMESTAMP_MICROS => {
-                Ok(DataType::Timestamp(TimeUnit::Microsecond))
+                Ok(DataType::Timestamp(TimeUnit::Microsecond, None))
             }
             other => Err(ArrowError(format!(
                 "Unable to convert parquet INT64 logical type {}",
@@ -867,10 +867,14 @@ mod tests {
             Field::new("date", DataType::Date32(DateUnit::Day), true),
             Field::new("time_milli", DataType::Time32(TimeUnit::Millisecond), true),
             Field::new("time_micro", DataType::Time64(TimeUnit::Microsecond), true),
-            Field::new("ts_milli", DataType::Timestamp(TimeUnit::Millisecond), true),
+            Field::new(
+                "ts_milli",
+                DataType::Timestamp(TimeUnit::Millisecond, None),
+                true,
+            ),
             Field::new(
                 "ts_micro",
-                DataType::Timestamp(TimeUnit::Microsecond),
+                DataType::Timestamp(TimeUnit::Microsecond, None),
                 false,
             ),
         ];


### PR DESCRIPTION
This changes `DataType::TimeStamp(TimeUnit)` to `DataType::TimeStamp(TimeUnit, Option<String>)` where the `Option<String>` is an optional timezone.

I would like some feedback on whether this option is fine. I haven't tried `Option<&str>` to avoid introducing a lifetime on the `DataType`.

The timezone support should practically only affect temporal kernels (`fn value_as_date_time()`), but I haven't done anything there. This could be a follow up PR if there's a wider need for timezones in temporal kernels (I'll likely need them, but not urgent).

Are you fine with the current proposal/implementation @andygrove @paddyhoran @sunchao @liurenjie1024 

CC @andy-thomason to keep you in the loop.