### PR TITLE
ARROW-7334: [CI][Python] Use Python 3 on macOS

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -160,6 +160,7 @@ jobs:
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
+      CMAKE_ARGS: "-DPYTHON_EXECUTABLE=/usr/local/bin/python3"
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v1
@@ -170,12 +171,13 @@ jobs:
         run: |
           brew bundle --file=cpp/Brewfile
           brew install coreutils python
-          pip install -r python/requirements.txt \
-                      -r python/requirements-test.txt \
-                      cython
+          pip3 install -r python/requirements.txt \
+                       -r python/requirements-test.txt \
+                       cython
       - name: Build
         shell: bash
         run: |
+          export PYTHON=python3
           ci/scripts/cpp_build.sh $(pwd)
           ci/scripts/python_build.sh $(pwd)
       - name: Test

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -39,8 +39,9 @@ pushd ${source_dir}
 relative_build_dir=$(realpath --relative-to=. $build_dir)
 
 # not nice, but prevents mutating the mounted the source directory for docker
-python setup.py build --build-base $build_dir \
-                install --single-version-externally-managed \
-                        --record $relative_build_dir/record.txt
+${PYTHON:-python} \
+  setup.py build --build-base $build_dir \
+           install --single-version-externally-managed \
+                   --record $relative_build_dir/record.txt
 
 popd

--- a/python/pyarrow/tests/test_plasma.py
+++ b/python/pyarrow/tests/test_plasma.py
@@ -1086,8 +1086,8 @@ def test_plasma_list():
 @pytest.mark.plasma
 def test_object_id_randomness():
     cmd = "from pyarrow import plasma; print(plasma.ObjectID.from_random())"
-    first_object_id = subprocess.check_output(["python", "-c", cmd])
-    second_object_id = subprocess.check_output(["python", "-c", cmd])
+    first_object_id = subprocess.check_output([sys.executable, "-c", cmd])
+    second_object_id = subprocess.check_output([sys.executable, "-c", cmd])
     assert first_object_id != second_object_id
 
 

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -917,7 +917,7 @@ def test_deserialize_components_in_different_process():
     subprocess_env = test_util.get_modified_env_with_pythonpath()
     print("** sys.path =", sys.path)
     print("** setting PYTHONPATH to:", subprocess_env['PYTHONPATH'])
-    subprocess.check_call(["python", "-c", code], env=subprocess_env)
+    subprocess.check_call([sys.executable, "-c", code], env=subprocess_env)
 
 
 def test_serialize_read_concatenated_records():


### PR DESCRIPTION
Currently, Python 2 is used.