### PR TITLE
ARROW-7336: [C++][Compute] fix minmax kernel options

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -385,6 +385,25 @@ class TestNumericMinMaxKernel : public ComputeFixture, public TestBase {
     ASSERT_EQ(max->value, static_cast<c_type>(expected_max));
   }
 
+  void AssertMinMaxIsNull(std::string array_json, const MinMaxOptions& options) {
+    auto array = ArrayFromJSON(Traits::type_singleton(), array_json);
+    Datum out, out_min, out_max;
+    ASSERT_OK(MinMax(&this->ctx_, options, *array, &out));
+
+    ASSERT_TRUE(out.is_collection());
+    auto col = out.collection();
+
+    out_min = col[0];
+    ASSERT_TRUE(out_min.is_scalar());
+    auto min = checked_pointer_cast<ScalarType>(out_min.scalar());
+    ASSERT_EQ(min->value, static_cast<c_type>(NULL));
+
+    out_max = col[1];
+    ASSERT_TRUE(out_max.is_scalar());
+    auto max = checked_pointer_cast<ScalarType>(out_max.scalar());
+    ASSERT_EQ(max->value, static_cast<c_type>(NULL));
+  }
+
   template <typename Min, typename Max>
   void AssertMinMaxIs(std::vector<std::string>& json, Min expected_min, Max expected_max,
                       const MinMaxOptions& options) {
@@ -404,6 +423,25 @@ class TestNumericMinMaxKernel : public ComputeFixture, public TestBase {
     ASSERT_TRUE(out_max.is_scalar());
     auto max = checked_pointer_cast<ScalarType>(out_max.scalar());
     ASSERT_EQ(max->value, static_cast<c_type>(expected_max));
+  }
+
+  void AssertMinMaxIsNull(std::vector<std::string>& json, const MinMaxOptions& options) {
+    auto array = ChunkedArrayFromJSON(Traits::type_singleton(), json);
+    Datum out, out_min, out_max;
+    ASSERT_OK(MinMax(&this->ctx_, options, Datum(array), &out));
+
+    ASSERT_TRUE(out.is_collection());
+    auto col = out.collection();
+
+    out_min = col[0];
+    ASSERT_TRUE(out_min.is_scalar());
+    auto min = checked_pointer_cast<ScalarType>(out_min.scalar());
+    ASSERT_EQ(min->value, static_cast<c_type>(NULL));
+
+    out_max = col[1];
+    ASSERT_TRUE(out_max.is_scalar());
+    auto max = checked_pointer_cast<ScalarType>(out_max.scalar());
+    ASSERT_EQ(max->value, static_cast<c_type>(NULL));
   }
 };
 
@@ -426,11 +464,11 @@ TYPED_TEST(TestNumericMinMaxKernel, Basics) {
   options = MinMaxOptions(MinMaxOptions::OUTPUT_NULL);
   this->AssertMinMaxIs("[5, 1, 2, 3, 4]", 1, 5, options);
   // output null
-  this->AssertMinMaxIs("[5, null, 2, 3, 4]", 0, 0, options);
+  this->AssertMinMaxIsNull("[5, null, 2, 3, 4]", options);
   // output null
-  this->AssertMinMaxIs(chunked_input1, 0, 0, options);
-  this->AssertMinMaxIs(chunked_input2, 0, 0, options);
-  this->AssertMinMaxIs(chunked_input3, 0, 0, options);
+  this->AssertMinMaxIsNull(chunked_input1, options);
+  this->AssertMinMaxIsNull(chunked_input2, options);
+  this->AssertMinMaxIsNull(chunked_input3, options);
 }
 
 TYPED_TEST_SUITE(TestFloatingMinMaxKernel, RealArrowTypes);
@@ -454,13 +492,13 @@ TYPED_TEST(TestFloatingMinMaxKernel, Floats) {
   this->AssertMinMaxIs("[5, 1, 2, 3, 4]", 1, 5, options);
   this->AssertMinMaxIs("[5, -Inf, 2, 3, 4]", -INFINITY, 5, options);
   // output null
-  this->AssertMinMaxIs("[5, null, 2, 3, 4]", 0, 0, options);
+  this->AssertMinMaxIsNull("[5, null, 2, 3, 4]", options);
   // output null
-  this->AssertMinMaxIs("[5, -Inf, null, 3, 4]", 0, 0, options);
+  this->AssertMinMaxIsNull("[5, -Inf, null, 3, 4]", options);
   // output null
-  this->AssertMinMaxIs(chunked_input1, 0, 0, options);
-  this->AssertMinMaxIs(chunked_input2, 0, 0, options);
-  this->AssertMinMaxIs(chunked_input3, 0, 0, options);
+  this->AssertMinMaxIsNull(chunked_input1, options);
+  this->AssertMinMaxIsNull(chunked_input2, options);
+  this->AssertMinMaxIsNull(chunked_input3, options);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/minmax.cc
+++ b/cpp/src/arrow/compute/kernels/minmax.cc
@@ -39,6 +39,7 @@ struct MinMaxState<ArrowType, enable_if_integer<ArrowType>> {
   using c_type = typename ArrowType::c_type;
 
   ThisType& operator+=(const ThisType& rhs) {
+    this->has_nulls |= rhs.has_nulls;
     this->min = std::min(this->min, rhs.min);
     this->max = std::max(this->max, rhs.max);
     return *this;
@@ -51,6 +52,7 @@ struct MinMaxState<ArrowType, enable_if_integer<ArrowType>> {
 
   c_type min = std::numeric_limits<c_type>::max();
   c_type max = std::numeric_limits<c_type>::min();
+  bool has_nulls = false;
 };
 
 template <typename ArrowType>
@@ -59,6 +61,7 @@ struct MinMaxState<ArrowType, enable_if_floating_point<ArrowType>> {
   using c_type = typename ArrowType::c_type;
 
   ThisType& operator+=(const ThisType& rhs) {
+    this->has_nulls |= rhs.has_nulls;
     this->min = std::fmin(this->min, rhs.min);
     this->max = std::fmax(this->max, rhs.max);
     return *this;
@@ -71,6 +74,7 @@ struct MinMaxState<ArrowType, enable_if_floating_point<ArrowType>> {
 
   c_type min = std::numeric_limits<c_type>::infinity();
   c_type max = -std::numeric_limits<c_type>::infinity();
+  bool has_nulls = false;
 };
 
 template <typename ArrowType>
@@ -83,6 +87,8 @@ class MinMaxAggregateFunction final
 
   Status Consume(const Array& array, StateType* state) const override {
     StateType local;
+
+    local.has_nulls = array.null_count() > 0;
 
     const auto values =
         checked_cast<const typename TypeTraits<ArrowType>::ArrayType&>(array)
@@ -101,6 +107,7 @@ class MinMaxAggregateFunction final
         local.MergeOne(values[i]);
       }
     }
+
     *state = local;
     return Status::OK();
   }
@@ -111,7 +118,14 @@ class MinMaxAggregateFunction final
   }
 
   Status Finalize(const StateType& src, Datum* output) const override {
-    *output = Datum({Datum(src.min), Datum(src.max)});
+    using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
+    if (src.has_nulls && options_.null_handling == MinMaxOptions::OUTPUT_NULL) {
+      *output = Datum(
+          {Datum(std::make_shared<ScalarType>()), Datum(std::make_shared<ScalarType>())});
+    } else {
+      *output = Datum({Datum(src.min), Datum(src.max)});
+    }
+
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compute/kernels/minmax.cc
+++ b/cpp/src/arrow/compute/kernels/minmax.cc
@@ -89,11 +89,15 @@ class MinMaxAggregateFunction final
     StateType local;
 
     local.has_nulls = array.null_count() > 0;
+    if (local.has_nulls && options_.null_handling == MinMaxOptions::OUTPUT_NULL) {
+      *state = local;
+      return Status::OK();
+    }
 
     const auto values =
         checked_cast<const typename TypeTraits<ArrowType>::ArrayType&>(array)
             .raw_values();
-    if (array.null_count() != 0) {
+    if (array.null_count() > 0) {
       internal::BitmapReader reader(array.null_bitmap_data(), array.offset(),
                                     array.length());
       for (int64_t i = 0; i < array.length(); i++) {

--- a/cpp/src/arrow/compute/kernels/minmax.h
+++ b/cpp/src/arrow/compute/kernels/minmax.h
@@ -36,11 +36,18 @@ class AggregateFunction;
 /// \class MinMaxOptions
 ///
 /// The user can control the MinMax kernel behavior with this class. By default,
-/// it will return null if there is a null value present.
+/// it will skip null if there is a null value present.
 struct ARROW_EXPORT MinMaxOptions {
-  //   MinMaxOptions() : skip_nulls(false) {}
+  enum mode {
+    /// skip null values
+    SKIP = 0,
+    /// any nulls will result in null output
+    OUTPUT_NULL
+  };
 
-  //   bool skip_nulls;
+  explicit MinMaxOptions(enum mode null_handling = SKIP) : null_handling(null_handling) {}
+
+  enum mode null_handling = SKIP;
 };
 
 /// \brief Return a Min/Max Kernel


### PR DESCRIPTION
minmax kernel has MinMaxOptions but not used.
This patch allows user to make use of this option

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>