### PR TITLE
ARROW-7349: [C++] Fix the bug of parsing string hex values

### DIFF
--- a/cpp/src/arrow/util/string.cc
+++ b/cpp/src/arrow/util/string.cc
@@ -80,7 +80,7 @@ Status ParseHexValue(const char* data, uint8_t* out) {
   const char* pos2 = std::lower_bound(kAsciiTable, kAsciiTableEnd, c2);
 
   // Error checking
-  if (pos1 == kAsciiTableEnd || pos2 == kAsciiTableEnd) {
+  if (pos1 == kAsciiTableEnd || pos2 == kAsciiTableEnd || *pos1 != c1 || *pos2 != c2) {
     return Status::Invalid("Encountered non-hex digit");
   }
 

--- a/cpp/src/arrow/util/string.cc
+++ b/cpp/src/arrow/util/string.cc
@@ -75,11 +75,12 @@ Status ParseHexValue(const char* data, uint8_t* out) {
   char c1 = data[0];
   char c2 = data[1];
 
-  const char* pos1 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c1);
-  const char* pos2 = std::lower_bound(kAsciiTable, kAsciiTable + 16, c2);
+  const char* kAsciiTableEnd = kAsciiTable + 16;
+  const char* pos1 = std::lower_bound(kAsciiTable, kAsciiTableEnd, c1);
+  const char* pos2 = std::lower_bound(kAsciiTable, kAsciiTableEnd, c2);
 
   // Error checking
-  if (*pos1 != c1 || *pos2 != c2) {
+  if (pos1 == kAsciiTableEnd || pos2 == kAsciiTableEnd) {
     return Status::Invalid("Encountered non-hex digit");
   }
 

--- a/cpp/src/arrow/util/string_test.cc
+++ b/cpp/src/arrow/util/string_test.cc
@@ -37,10 +37,38 @@ TEST(Trim, Basics) {
   }
 }
 
-TEST(ParseHexValue, Invalid) {
-  std::string input = "xy";
+TEST(ParseHexValue, Valid) {
   uint8_t output;
-  
+
+  // evaluate valid letters
+  std::string input = "AB";
+  ASSERT_OK(ParseHexValue(input.c_str(), &output));
+  EXPECT_EQ(171, output);
+
+  // evaluate valid numbers
+  input = "12";
+  ASSERT_OK(ParseHexValue(input.c_str(), &output));
+  EXPECT_EQ(18, output);
+
+  // evaluate mixed hex numbers
+  input = "B1";
+  ASSERT_OK(ParseHexValue(input.c_str(), &output));
+  EXPECT_EQ(177, output);
+}
+
+TEST(ParseHexValue, Invalid) {
+  uint8_t output;
+
+  // evaluate invalid letters
+  std::string input = "XY";
+  ASSERT_RAISES(Invalid, ParseHexValue(input.c_str(), &output));
+
+  // evaluate invalid signs
+  input = "@?";
+  ASSERT_RAISES(Invalid, ParseHexValue(input.c_str(), &output));
+
+  // evaluate lower-case letters
+  input = "ab";
   ASSERT_RAISES(Invalid, ParseHexValue(input.c_str(), &output));
 }
 

--- a/cpp/src/arrow/util/string_test.cc
+++ b/cpp/src/arrow/util/string_test.cc
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include "arrow/status.h"
+#include "arrow/testing/gtest_util.h"
 #include "arrow/util/string.h"
 
 namespace arrow {
@@ -33,6 +35,13 @@ TEST(Trim, Basics) {
   for (auto case_ : test_cases) {
     EXPECT_EQ(case_.second, TrimString(case_.first));
   }
+}
+
+TEST(ParseHexValue, Invalid) {
+  std::string input = "xy";
+  uint8_t output;
+  
+  ASSERT_RAISES(Invalid, ParseHexValue(input.c_str(), &output));
 }
 
 }  // namespace internal


### PR DESCRIPTION
std::lower_bound returns the end of the search range, when failing to find a match.

The end of the search range is one position after the last valid position. So the value in this position is undefined, and we should not reference the value here to compare it with the target value.