### PR TITLE
ARROW-7351: [Developer] Only suggest cpp-* versions by default for PARQUET issues in merge tool

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -156,9 +156,7 @@ class JiraIssue(object):
         unreleased_versions = sorted(unreleased_versions,
                                      key=lambda x: x.name, reverse=True)
 
-        mainline_version_regex = re.compile(r'\d.*')
-        mainline_versions = [x for x in unreleased_versions
-                             if mainline_version_regex.match(x.name)]
+        mainline_versions = self._filter_mainline_versions(unreleased_versions)
 
         mainline_non_patch_versions = []
         for v in mainline_versions:
@@ -175,6 +173,14 @@ class JiraIssue(object):
             for x in merge_branches]
 
         return all_versions, default_fix_versions
+
+    def _filter_mainline_versions(self, versions):
+        if self.project == 'PARQUET':
+            mainline_regex = re.compile(r'cpp-\d.*')
+        else:
+            mainline_regex = re.compile(r'\d.*')
+
+        return [x for x in versions if mainline_regex.match(x.name)]
 
     def resolve(self, fix_versions, comment):
         fields = self.issue.fields

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -123,6 +123,27 @@ def test_jira_no_suggest_patch_release():
     assert default_versions == ['0.12.0']
 
 
+def test_jira_parquet_no_suggest_non_cpp():
+    # ARROW-7351
+    versions_json = [
+        {'version': 'cpp-1.5.0', 'released': True},
+        {'version': 'cpp-1.6.0', 'released': False},
+        {'version': 'cpp-1.7.0', 'released': False},
+        {'version': '1.11.0', 'released': False},
+        {'version': '1.12.0', 'released': False}
+    ]
+
+    versions = [FakeProjectVersion(raw['version'], raw)
+                for raw in versions_json]
+
+    jira = FakeJIRA(project_versions=versions, transitions=TRANSITIONS)
+    issue = merge_arrow_pr.JiraIssue(jira, 'PARQUET-1713', 'PARQUET',
+                                     FakeCLI())
+    all_versions, default_versions = issue.get_candidate_fix_versions()
+    assert all_versions == versions
+    assert default_versions == ['cpp-1.6.0']
+
+
 def test_jira_invalid_issue():
     class Mock:
 


### PR DESCRIPTION
The Java version is being suggested by default, requiring committers to know to type in something like "cpp-1.6.0"