### PR TITLE
ARROW-7361: [Rust] Build directory is not passed to ci/scripts/rust_test.sh

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -90,7 +90,6 @@ jobs:
   macos:
     name: AMD64 MacOS 10.15 Rust ${{ matrix.rust }}
     runs-on: macos-latest
-    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,10 +22,12 @@ on:
     paths:
       - 'ci/**'
       - 'rust/**'
+      - '.github/workflows/rust.yml'
   pull_request:
     paths:
       - 'ci/**'
       - 'rust/**'
+      - '.github/workflows/rust.yml'
 
 jobs:
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,7 +83,7 @@ jobs:
         run: ci/scripts/rust_build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash
-        run: ci/scripts/rust_test.sh $(pwd)
+        run: ci/scripts/rust_test.sh $(pwd) $(pwd)/build
 
   macos:
     name: AMD64 MacOS 10.15 Rust ${{ matrix.rust }}
@@ -111,4 +111,4 @@ jobs:
         run: ci/scripts/rust_build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash
-        run: ci/scripts/rust_test.sh $(pwd)
+        run: ci/scripts/rust_test.sh $(pwd) $(pwd)/build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -679,6 +679,8 @@ services:
         arch: ${ARCH}
         rust: ${RUST}
     shm_size: *shm-size
+    environment:
+      CARGO_HOME: /build/cargo
     volumes: *debian-volumes
     command: &rust-command >
       /bin/bash -c "


### PR DESCRIPTION
- preserve cargo crates between docker invocations
- cache cargo dependencies
- run macOS build on pull requests