### PR TITLE
ARROW-7362: [Python][C++] Added ListArray.Flatten() that properly flattens a ListArray

### DIFF
--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -27,6 +27,9 @@ with_docs=${3:-false}
 
 # TODO(kszucs): consider to move these to CMake
 if [ ! -z "${CONDA_PREFIX}" ]; then
+  echo -e "===\n=== Conda environment for build\n==="
+  conda list
+
   export CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_AR=${AR} -DCMAKE_RANLIB=${RANLIB}"
   export ARROW_GANDIVA_PC_CXX_FLAGS=$(echo | ${CXX} -E -Wp,-v -xc++ - 2>&1 | grep '^ ' | awk '{print "-isystem;" substr($1, 1)}' | tr '\n' ';')
 elif [ -x "$(command -v xcrun)" ]; then

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -22,6 +22,11 @@ set -ex
 source_dir=${1}/python
 build_dir=${2}/python
 
+if [ ! -z "${CONDA_PREFIX}" ]; then
+  echo -e "===\n=== Conda environment for build\n==="
+  conda list
+fi
+
 export PYARROW_CMAKE_GENERATOR=${CMAKE_GENERATOR:-Ninja}
 export PYARROW_BUILD_TYPE=${CMAKE_BUILD_TYPE:-debug}
 export PYARROW_WITH_S3=${ARROW_S3:-OFF}

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -305,8 +305,8 @@ Status ListArrayFromArrays(const Array& offsets, const Array& values, MemoryPool
   return Status::OK();
 }
 
-std::shared_ptr<Array> SliceArrayWithOffsets(const Array& array, int64_t begin,
-                                             int64_t end) {
+static std::shared_ptr<Array> SliceArrayWithOffsets(const Array& array, int64_t begin,
+                                                    int64_t end) {
   return array.Slice(begin, end - begin);
 }
 
@@ -349,9 +349,9 @@ Result<std::shared_ptr<Array>> FlattenListArray(const ListArrayT& list_array,
     return non_null_fragments[0];
   }
 
-  std::shared_ptr<Array> result;
-  RETURN_NOT_OK(Concatenate(non_null_fragments, memory_pool, &result));
-  return result;
+  std::shared_ptr<Array> flattened;
+  RETURN_NOT_OK(Concatenate(non_null_fragments, memory_pool, &flattened));
+  return flattened;
 }
 
 }  // namespace

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -551,6 +551,17 @@ class BaseListArray : public Array {
   /// \brief Return array object containing the list's values
   std::shared_ptr<Array> values() const { return values_; }
 
+  /// \brief Return an Array that is a concatenation of the lists in this array.
+  ///
+  /// Note that it's different from `values()` in that it takes into
+  /// consideration of this array's offsets and slices its child Array
+  /// accordingly.
+  std::shared_ptr<Array> Flatten() const {
+    const offset_type begin_offset = value_offset(0);
+    const offset_type end_offset = value_offset(length());
+    return values()->Slice(begin_offset, end_offset - begin_offset);
+  }
+
   /// Note that this buffer does not account for any slice offset
   std::shared_ptr<Buffer> value_offsets() const { return data_->buffers[1]; }
 

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -551,17 +551,6 @@ class BaseListArray : public Array {
   /// \brief Return array object containing the list's values
   std::shared_ptr<Array> values() const { return values_; }
 
-  /// \brief Return an Array that is a concatenation of the lists in this array.
-  ///
-  /// Note that it's different from `values()` in that it takes into
-  /// consideration of this array's offsets and slices its child Array
-  /// accordingly.
-  std::shared_ptr<Array> Flatten() const {
-    const offset_type begin_offset = value_offset(0);
-    const offset_type end_offset = value_offset(length());
-    return values()->Slice(begin_offset, end_offset - begin_offset);
-  }
-
   /// Note that this buffer does not account for any slice offset
   std::shared_ptr<Buffer> value_offsets() const { return data_->buffers[1]; }
 
@@ -617,6 +606,14 @@ class ARROW_EXPORT ListArray : public BaseListArray<ListType> {
   static Status FromArrays(const Array& offsets, const Array& values, MemoryPool* pool,
                            std::shared_ptr<Array>* out);
 
+  /// \brief Return an Array that is a concatenation of the lists in this array.
+  ///
+  /// Note that it's different from `values()` in that it takes into
+  /// consideration of this array's offsets as well as null elements backed
+  /// by non-empty lists (they are skipped, thus copying may be needed).
+  Result<std::shared_ptr<Array>> Flatten(
+      MemoryPool* memory_pool = default_memory_pool()) const;
+
  protected:
   // This constructor defers SetData to a derived array class
   ListArray() = default;
@@ -650,6 +647,14 @@ class ARROW_EXPORT LargeListArray : public BaseListArray<LargeListType> {
   /// \param[out] out Will have length equal to offsets.length() - 1
   static Status FromArrays(const Array& offsets, const Array& values, MemoryPool* pool,
                            std::shared_ptr<Array>* out);
+
+  /// \brief Return an Array that is a concatenation of the lists in this array.
+  ///
+  /// Note that it's different from `values()` in that it takes into
+  /// consideration of this array's offsets as well as null elements backed
+  /// by non-empty lists (they are skipped, thus copying may be needed).
+  Result<std::shared_ptr<Array>> Flatten(
+      MemoryPool* memory_pool = default_memory_pool()) const;
 
  protected:
   void SetData(const std::shared_ptr<ArrayData>& data);

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -407,15 +407,9 @@ struct ValidateArrayDataVisitor {
     auto prev_offset = array.value_offset(0);
     for (int64_t i = 1; i <= array.length(); ++i) {
       auto current_offset = array.value_offset(i);
-      if (array.IsNull(i - 1) && current_offset != prev_offset) {
-        return Status::Invalid("Offset invariant failure at: ", i,
-                               " inconsistent value_offsets for null slot",
-                               current_offset, "!=", prev_offset);
-      }
       if (current_offset < prev_offset) {
-        return Status::Invalid("Offset invariant failure: ", i,
-                               " inconsistent offset for non-null slot: ", current_offset,
-                               "<", prev_offset);
+        return Status::Invalid("Offset invariant failure: inconsistent offset for slot ",
+                               i, ": ", current_offset, "<", prev_offset);
       }
       prev_offset = current_offset;
     }

--- a/cpp/src/arrow/array_list_test.cc
+++ b/cpp/src/arrow/array_list_test.cc
@@ -347,6 +347,34 @@ class TestListArray : public TestBuilder {
     ASSERT_EQ("counts", type.value_field()->name());
   }
 
+  void TestFlattenZeroLength() {
+    Done();
+    auto flattened = result_->Flatten();
+    ASSERT_OK(flattened->ValidateFull());
+    ASSERT_EQ(0, flattened->length());
+  }
+
+  void TestFlatten() {
+    auto type = std::make_shared<T>(int32());
+    auto list_array = std::dynamic_pointer_cast<ArrayType>(
+        ArrayFromJSON(type, "[[1, 2], [3], [4], null, [5], [], [6]]"));
+    auto flattened = list_array->Flatten();
+    ASSERT_OK(flattened->ValidateFull());
+    EXPECT_TRUE(
+        list_array->Flatten()->Equals(ArrayFromJSON(int32(), "[1, 2, 3, 4, 5, 6]")));
+    EXPECT_TRUE(
+        list_array->values()->Equals(ArrayFromJSON(int32(), "[1, 2, 3, 4, 5, 6]")));
+
+    auto sliced_list_array =
+        std::dynamic_pointer_cast<ArrayType>(list_array->Slice(3, 4));
+    auto sliced_flattened = sliced_list_array->Flatten();
+    ASSERT_OK(sliced_flattened->ValidateFull());
+    // Note the difference between values() and Flatten().
+    EXPECT_TRUE(sliced_flattened->Equals(ArrayFromJSON(int32(), "[5, 6]")));
+    EXPECT_TRUE(sliced_list_array->values()->Equals(
+        ArrayFromJSON(int32(), "[1, 2, 3, 4, 5, 6]")));
+  }
+
  protected:
   std::shared_ptr<DataType> value_type_;
 
@@ -377,6 +405,9 @@ TYPED_TEST(TestListArray, ZeroLength) { this->TestZeroLength(); }
 TYPED_TEST(TestListArray, BuilderPreserveFieldName) {
   this->TestBuilderPreserveFieldName();
 }
+
+TYPED_TEST(TestListArray, Flatten) { this->TestFlatten(); }
+TYPED_TEST(TestListArray, FlattenZeroLength) { this->TestFlattenZeroLength(); }
 
 // ----------------------------------------------------------------------
 // Map tests

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1308,7 +1308,8 @@ cdef class ListArray(Array):
 
     @property
     def values(self):
-        return self.flatten()
+        cdef CListArray* arr = <CListArray*> self.ap
+        return pyarrow_wrap_array(arr.values())
 
     @property
     def offsets(self):
@@ -1328,7 +1329,7 @@ cdef class ListArray(Array):
         result : Array
         """
         cdef CListArray* arr = <CListArray*> self.ap
-        return pyarrow_wrap_array(arr.values())
+        return pyarrow_wrap_array(arr.Flatten())
 
 
 cdef class LargeListArray(Array):
@@ -1369,7 +1370,8 @@ cdef class LargeListArray(Array):
 
     @property
     def values(self):
-        return self.flatten()
+        cdef CLargeListArray* arr = <CLargeListArray*> self.ap
+        return pyarrow_wrap_array(arr.values())
 
     @property
     def offsets(self):
@@ -1389,7 +1391,7 @@ cdef class LargeListArray(Array):
         result : Array
         """
         cdef CLargeListArray* arr = <CLargeListArray*> self.ap
-        return pyarrow_wrap_array(arr.values())
+        return pyarrow_wrap_array(arr.Flatten())
 
 
 cdef class MapArray(Array):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1327,9 +1327,9 @@ cdef class ListArray(Array):
         The returned Array is logically a concatenation of all the sub-lists
         in this Array.
 
-        Note that is different from ``self.values()`` in that it takes care of
-        the slicing offset as well as null elements backed by non-empty
-        sub-lists.
+        Note that this method is different from ``self.values()`` in that
+        it takes care of the slicing offset as well as null elements backed
+        by non-empty sub-lists.
 
         Parameters
         ----------
@@ -1409,9 +1409,9 @@ cdef class LargeListArray(Array):
         The returned Array is logically a concatenation of all the sub-lists
         in this Array.
 
-        Note that is different from ``self.values()`` in that it takes care of
-        the slicing offset as well as null elements backed by non-empty
-        sub-lists.
+        Note that this method is different from ``self.values()`` in that
+        it takes care of the slicing offset as well as null elements backed
+        by non-empty sub-lists.
 
         Parameters
         ----------

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1320,16 +1320,36 @@ cdef class ListArray(Array):
             int32(), len(self) + 1, [None, self.buffers()[1]],
             offset=self.offset)
 
-    def flatten(self):
+    def flatten(self, MemoryPool memory_pool=None):
         """
         Unnest this ListArray by one level
+
+        The returned Array is logically a concatenation of all the sub-lists
+        in this Array.
+
+        Note that is different from ``self.values()`` in that it takes care of
+        the slicing offset as well as null elements backed by non-empty
+        sub-lists.
+
+        Parameters
+        ----------
+        memory_pool : pyarrow.MemoryPool, optional
+            If not passed, will allocate memory from the currently-set default
+            memory pool
 
         Returns
         -------
         result : Array
         """
-        cdef CListArray* arr = <CListArray*> self.ap
-        return pyarrow_wrap_array(arr.Flatten())
+        cdef:
+            shared_ptr[CArray] c_result_array
+            CMemoryPool* cpool = maybe_unbox_memory_pool(memory_pool)
+            CListArray* arr = <CListArray*> self.ap
+
+        with nogil:
+            c_result_array = GetResultValue(arr.Flatten(cpool))
+
+        return pyarrow_wrap_array(c_result_array)
 
 
 cdef class LargeListArray(Array):
@@ -1382,16 +1402,36 @@ cdef class LargeListArray(Array):
             int64(), len(self) + 1, [None, self.buffers()[1]],
             offset=self.offset)
 
-    def flatten(self):
+    def flatten(self, MemoryPool memory_pool=None):
         """
-        Unnest this LargeListArray by one level
+        Unnest this ListArray by one level.
+
+        The returned Array is logically a concatenation of all the sub-lists
+        in this Array.
+
+        Note that is different from ``self.values()`` in that it takes care of
+        the slicing offset as well as null elements backed by non-empty
+        sub-lists.
+
+        Parameters
+        ----------
+        memory_pool : pyarrow.MemoryPool, optional
+            If not passed, will allocate memory from the currently-set default
+            memory pool
 
         Returns
         -------
         result : Array
         """
-        cdef CLargeListArray* arr = <CLargeListArray*> self.ap
-        return pyarrow_wrap_array(arr.Flatten())
+        cdef:
+            shared_ptr[CArray] c_result_array
+            CMemoryPool* cpool = maybe_unbox_memory_pool(memory_pool)
+            CLargeListArray* arr = <CLargeListArray*> self.ap
+
+        with nogil:
+            c_result_array = GetResultValue(arr.Flatten(cpool))
+
+        return pyarrow_wrap_array(c_result_array)
 
 
 cdef class MapArray(Array):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1404,7 +1404,7 @@ cdef class LargeListArray(Array):
 
     def flatten(self, MemoryPool memory_pool=None):
         """
-        Unnest this ListArray by one level.
+        Unnest this LargeListArray by one level.
 
         The returned Array is logically a concatenation of all the sub-lists
         in this Array.

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -486,6 +486,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int64_t value_offset(int i)
         int64_t value_length(int i)
         shared_ptr[CArray] values()
+        CResult[shared_ptr[CArray]] Flatten(CMemoryPool* memory_pool)
         shared_ptr[CDataType] value_type()
 
     cdef cppclass CFixedSizeListArray" arrow::FixedSizeListArray"(CArray):
@@ -496,7 +497,6 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int64_t value_offset(int i)
         int64_t value_length(int i)
         shared_ptr[CArray] values()
-        CResult[shared_ptr[CArray]] Flatten(CMemoryPool* memory_pool)
         shared_ptr[CDataType] value_type()
 
     cdef cppclass CMapArray" arrow::MapArray"(CArray):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -475,7 +475,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int32_t value_offset(int i)
         int32_t value_length(int i)
         shared_ptr[CArray] values()
-        shared_ptr[CArray] Flatten()
+        CResult[shared_ptr[CArray]] Flatten(CMemoryPool* memory_pool)
         shared_ptr[CDataType] value_type()
 
     cdef cppclass CLargeListArray" arrow::LargeListArray"(CArray):
@@ -496,7 +496,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int64_t value_offset(int i)
         int64_t value_length(int i)
         shared_ptr[CArray] values()
-        shared_ptr[CArray] Flatten()
+        CResult[shared_ptr[CArray]] Flatten(CMemoryPool* memory_pool)
         shared_ptr[CDataType] value_type()
 
     cdef cppclass CMapArray" arrow::MapArray"(CArray):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -475,6 +475,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int32_t value_offset(int i)
         int32_t value_length(int i)
         shared_ptr[CArray] values()
+        shared_ptr[CArray] Flatten()
         shared_ptr[CDataType] value_type()
 
     cdef cppclass CLargeListArray" arrow::LargeListArray"(CArray):
@@ -495,6 +496,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int64_t value_offset(int i)
         int64_t value_length(int i)
         shared_ptr[CArray] values()
+        shared_ptr[CArray] Flatten()
         shared_ptr[CDataType] value_type()
 
     cdef cppclass CMapArray" arrow::MapArray"(CArray):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1710,10 +1710,11 @@ def test_invalid_tensor_construction():
     with pytest.raises(TypeError):
         pa.Tensor()
 
-
-def test_list_array_flatten():
-    typ2 = pa.list_(
-        pa.list_(
+@pytest.mark.parametrize(('offset_type', 'list_type_factory'),
+                         [(pa.int32(), pa.list_), (pa.int64(), pa.large_list)])
+def test_list_array_flatten(offset_type, list_type_factory):
+    typ2 = list_type_factory(
+        list_type_factory(
             pa.int64()
         )
     )
@@ -1733,66 +1734,10 @@ def test_list_array_flatten():
         [
             [7, 8]
         ]
-    ])
-    offsets2 = pa.array([0, 0, 3, 3, 6, 7], type=pa.int32())
-    assert arr2.type.equals(typ2)
-
-    typ1 = pa.list_(pa.int64())
-    arr1 = pa.array([
-        [1, None, 2],
-        None,
-        [3, 4],
-        [],
-        [5, 6],
-        None,
-        [7, 8]
-    ])
-    offsets1 = pa.array([0, 3, 3, 5, 5, 7, 7, 9], type=pa.int32())
-    assert arr1.type.equals(typ1)
-
-    typ0 = pa.int64()
-    arr0 = pa.array([
-        1, None, 2,
-        3, 4,
-        5, 6,
-        7, 8
-    ])
-    assert arr0.type.equals(typ0)
-
-    assert arr2.flatten().equals(arr1)
-    assert arr2.offsets.equals(offsets2)
-    assert arr1.flatten().equals(arr0)
-    assert arr1.offsets.equals(offsets1)
-    assert arr2.flatten().flatten().equals(arr0)
-
-
-def test_large_list_array_flatten():
-    typ2 = pa.large_list(
-        pa.large_list(
-            pa.int16()
-        )
-    )
-    arr2 = pa.array([
-        None,
-        [
-            [1, None, 2],
-            None,
-            [3, 4]
-        ],
-        [],
-        [
-            [],
-            [5, 6],
-            None
-        ],
-        [
-            [7, 8]
-        ]
     ], type=typ2)
-    offsets2 = pa.array([0, 0, 3, 3, 6, 7], type=pa.int64())
+    offsets2 = pa.array([0, 0, 3, 3, 6, 7], type=offset_type)
 
-    typ1 = pa.large_list(pa.int16())
-    assert typ1 == typ2.value_type
+    typ1 = list_type_factory(pa.int64())
     arr1 = pa.array([
         [1, None, 2],
         None,
@@ -1802,9 +1747,20 @@ def test_large_list_array_flatten():
         None,
         [7, 8]
     ], type=typ1)
+    offsets1 = pa.array([0, 3, 3, 5, 5, 7, 7, 9], type=offset_type)
+
+    arr0 = pa.array([
+        1, None, 2,
+        3, 4,
+        5, 6,
+        7, 8
+    ], type=pa.int64())
 
     assert arr2.flatten().equals(arr1)
     assert arr2.offsets.equals(offsets2)
+    assert arr1.flatten().equals(arr0)
+    assert arr1.offsets.equals(offsets1)
+    assert arr2.flatten().flatten().equals(arr0)
 
 
 @pytest.mark.parametrize('klass', [pa.ListArray, pa.LargeListArray])
@@ -1816,9 +1772,11 @@ def test_list_array_values_offsets_sliced(klass):
 
     # sliced -> values keeps referring to full values buffer, but offsets is
     # sliced as well so the offsets correctly point into the full values array
+    # sliced -> flatten() will return the sliced value array.
     arr2 = arr[1:]
     assert arr2.values.to_pylist() == [1, 2, 3, 4, 5, 6]
     assert arr2.offsets.to_pylist() == [3, 4, 6]
+    assert arr2.flatten().to_pylist() == [4, 5, 6]
     i = arr2.offsets[0].as_py()
     j = arr2.offsets[1].as_py()
     assert arr2[0].as_py() == arr2.values[i:j].to_pylist() == [4]


### PR DESCRIPTION
Currently ListArray.flatten() simply returns the child array. If a ListArray is a slice of another ListArray, they will share the same child array, however the expected behavior (I think) of flatten() should be returning an Array that's a concatenation of all the sub-lists in the ListArray, so the slicing offset should be taken into account.

For example:
```python
a = pa.array([[1], [2], [3]])

assert a.flatten().equals(pa.array([1,2,3]))

# expected:
a.slice(1).flatten().equals(pa.array([2, 3]))
```