### PR TITLE
ARROW-7368: [Ruby] Use :arrow_file and :arrow_streaming for format name

### DIFF
--- a/ruby/red-arrow/lib/arrow/table-loader.rb
+++ b/ruby/red-arrow/lib/arrow/table-loader.rb
@@ -41,6 +41,8 @@ module Arrow
             available_formats << match_data.post_match
           end
         end
+        deprecated_formats = ["batch", "stream"]
+        available_formats -= deprecated_formats
         message = "Arrow::Table load format must be one of ["
         message << available_formats.join(", ")
         message << "]: #{format.inspect}"
@@ -119,16 +121,28 @@ module Arrow
       load_raw(input, reader)
     end
 
-    def load_as_batch
+    # @since 1.0.0
+    def load_as_arrow_file
       input = open_input_stream
       reader = RecordBatchFileReader.new(input)
       load_raw(input, reader)
     end
 
-    def load_as_stream
+    # @deprecated Use `format: :arrow_file` instead.
+    def load_as_batch
+      load_as_arrow_file
+    end
+
+    # @since 1.0.0
+    def load_as_arrow_streaming
       input = open_input_stream
       reader = RecordBatchStreamReader.new(input)
       load_raw(input, reader)
+    end
+
+    # @deprecated Use `format: :arrow_streaming` instead.
+    def load_as_stream
+      load_as_arrow_streaming
     end
 
     if Arrow.const_defined?(:ORCFileReader)

--- a/ruby/red-arrow/lib/arrow/table-saver.rb
+++ b/ruby/red-arrow/lib/arrow/table-saver.rb
@@ -42,6 +42,8 @@ module Arrow
             available_formats << match_data.post_match
           end
         end
+        deprecated_formats = ["batch", "stream"]
+        available_formats -= deprecated_formats
         message = "Arrow::Table save format must be one of ["
         message << available_formats.join(", ")
         message << "]: #{format.inspect}"
@@ -110,15 +112,27 @@ module Arrow
     end
 
     def save_as_arrow
-      save_as_batch
+      save_as_arrow_file
     end
 
-    def save_as_batch
+    # @since 1.0.0
+    def save_as_arrow_file
       save_raw(RecordBatchFileWriter)
     end
 
-    def save_as_stream
+    # @deprecated Use `format: :arrow_batch` instead.
+    def save_as_batch
+      save_as_arrow_file
+    end
+
+    # @since 1.0.0
+    def save_as_arrow_streaming
       save_raw(RecordBatchStreamWriter)
+    end
+
+    # @deprecated Use `format: :arrow_streaming` instead.
+    def save_as_stream
+      save_as_arrow_streaming
     end
 
     def save_as_csv

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -438,10 +438,22 @@ class TableTest < Test::Unit::TestCase
         assert_equal(@table, Arrow::Table.load(output))
       end
 
+      def test_arrow_file
+        output = create_output(".arrow")
+        @table.save(output, format: :arrow_file)
+        assert_equal(@table, Arrow::Table.load(output, format: :arrow_file))
+      end
+
       def test_batch
         output = create_output(".arrow")
         @table.save(output, format: :batch)
         assert_equal(@table, Arrow::Table.load(output, format: :batch))
+      end
+
+      def test_arrow_streaming
+        output = create_output(".arrow")
+        @table.save(output, format: :arrow_streaming)
+        assert_equal(@table, Arrow::Table.load(output, format: :arrow_streaming))
       end
 
       def test_stream
@@ -503,15 +515,15 @@ class TableTest < Test::Unit::TestCase
         end
 
         sub_test_case("load: auto detect") do
-          test("batch") do
+          test("arrow: file") do
             output = create_output(".arrow")
-            @table.save(output, format: :batch)
+            @table.save(output, format: :arrow_file)
             assert_equal(@table, Arrow::Table.load(output))
           end
 
-          test("stream") do
+          test("arrow: streaming") do
             output = create_output(".arrow")
-            @table.save(output, format: :stream)
+            @table.save(output, format: :arrow_streaming)
             assert_equal(@table, Arrow::Table.load(output))
           end
 


### PR DESCRIPTION
:batch isn't suitable because we use "Apache Arrow IPC File Format" as
format name.

:stream is ambiguous.