### PR TITLE
ARROW-7370: [C++] Fix old Protobuf with AUTO detection failure

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -646,9 +646,10 @@ if(ARROW_WITH_ZSTD)
 endif()
 
 if(ARROW_ORC)
-  list(APPEND ARROW_LINK_LIBS protobuf::libprotobuf orc::liborc)
-  list(APPEND ARROW_STATIC_LINK_LIBS protobuf::libprotobuf orc::liborc)
-  list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS protobuf::libprotobuf orc::liborc)
+  list(APPEND ARROW_LINK_LIBS ${ARROW_PROTOBUF_LIBPROTOBUF} orc::liborc)
+  list(APPEND ARROW_STATIC_LINK_LIBS ${ARROW_PROTOBUF_LIBPROTOBUF} orc::liborc)
+  list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS ${ARROW_PROTOBUF_LIBPROTOBUF}
+              orc::liborc)
 endif()
 
 if(ARROW_USE_GLOG)

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -20,7 +20,7 @@ add_custom_target(arrow_flight)
 arrow_install_all_headers("arrow/flight")
 
 set(ARROW_FLIGHT_STATIC_LINK_LIBS
-    protobuf::libprotobuf
+    ${ARROW_PROTOBUF_LIBPROTOBUF}
     gRPC::grpc++
     gRPC::grpc
     gRPC::gpr
@@ -54,13 +54,13 @@ set(FLIGHT_GENERATED_PROTO_FILES "${CMAKE_CURRENT_BINARY_DIR}/Flight.pb.cc"
                                  "${CMAKE_CURRENT_BINARY_DIR}/Flight.grpc.pb.cc"
                                  "${CMAKE_CURRENT_BINARY_DIR}/Flight.grpc.pb.h")
 
-set(PROTO_DEPENDS ${FLIGHT_PROTO} protobuf::libprotobuf gRPC::grpc)
+set(PROTO_DEPENDS ${FLIGHT_PROTO} ${ARROW_PROTOBUF_LIBPROTOBUF} gRPC::grpc)
 
 add_custom_command(OUTPUT ${FLIGHT_GENERATED_PROTO_FILES}
-                   COMMAND protobuf::protoc "-I${FLIGHT_PROTO_PATH}"
+                   COMMAND ${ARROW_PROTOBUF_PROTOC} "-I${FLIGHT_PROTO_PATH}"
                            "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}" "${FLIGHT_PROTO}"
                    DEPENDS ${PROTO_DEPENDS} ARGS
-                   COMMAND protobuf::protoc
+                   COMMAND ${ARROW_PROTOBUF_PROTOC}
                            "-I${FLIGHT_PROTO_PATH}"
                            "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
                            "--plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}"
@@ -179,7 +179,7 @@ if(ARROW_BUILD_BENCHMARKS)
                                  "${CMAKE_CURRENT_BINARY_DIR}/perf.pb.h")
 
   add_custom_command(OUTPUT ${PERF_PROTO_GENERATED_FILES}
-                     COMMAND protobuf::protoc "-I${CMAKE_CURRENT_SOURCE_DIR}"
+                     COMMAND ${ARROW_PROTOBUF_PROTOC} "-I${CMAKE_CURRENT_SOURCE_DIR}"
                              "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}" "perf.proto"
                      DEPENDS ${PROTO_DEPENDS})
 

--- a/cpp/src/gandiva/jni/CMakeLists.txt
+++ b/cpp/src/gandiva/jni/CMakeLists.txt
@@ -36,13 +36,13 @@ get_filename_component(ABS_GANDIVA_PROTO ${CMAKE_SOURCE_DIR}/src/gandiva/proto/T
                        ABSOLUTE)
 
 add_custom_command(OUTPUT ${PROTO_OUTPUT_FILES}
-                   COMMAND protobuf::protoc
+                   COMMAND ${ARROW_PROTOBUF_PROTOC}
                            --proto_path
                            ${CMAKE_SOURCE_DIR}/src/gandiva/proto
                            --cpp_out
                            ${PROTO_OUTPUT_DIR}
                            ${CMAKE_SOURCE_DIR}/src/gandiva/proto/Types.proto
-                   DEPENDS ${ABS_GANDIVA_PROTO} protobuf::libprotobuf
+                   DEPENDS ${ABS_GANDIVA_PROTO} ${ARROW_PROTOBUF_LIBPROTOBUF}
                    COMMENT "Running PROTO compiler on Types.proto"
                    VERBATIM)
 
@@ -54,7 +54,7 @@ set(PROTO_HDRS "${PROTO_OUTPUT_DIR}/Types.pb.h")
 set(JNI_HEADERS_DIR "${CMAKE_CURRENT_BINARY_DIR}/java")
 add_subdirectory(../../../../java/gandiva ./java/gandiva)
 
-set(GANDIVA_LINK_LIBS protobuf::libprotobuf gandiva_static)
+set(GANDIVA_LINK_LIBS ${ARROW_PROTOBUF_LIBPROTOBUF} gandiva_static)
 
 set(GANDIVA_JNI_SOURCES
     config_builder.cc


### PR DESCRIPTION
If old Protobuf is found, protobuf::libprotobuf CMake target is
defined. The found old Protobuf isn't used and build vendored
Protobuf. The build step tries creating protobuf::libprotobuf CMake
target. But the target is already defined by the found old Protobuf.

This change introduces ARROW_PROTOBUF_* variables and uses ${them}
instead of raw protobuf::* targets to solve this problem.

Error message:

    -- Could NOT find Protobuf: Found unsuitable version "3.6.1", but required is at least "3.7.0" (found /usr/lib/x86_64-linux-gnu/libprotobuf.so;-pthread)
    Building Protocol Buffers from source
    CMake Error at cmake_modules/ThirdpartyToolchain.cmake:1179 (add_library):
      add_library cannot create imported target "protobuf::libprotobuf" because
      another target with the same name already exists.
    Call Stack (most recent call first):
      cmake_modules/ThirdpartyToolchain.cmake:147 (build_protobuf)
      cmake_modules/ThirdpartyToolchain.cmake:178 (build_dependency)
      cmake_modules/ThirdpartyToolchain.cmake:1204 (resolve_dependency_with_version)
      CMakeLists.txt:428 (include)