### PR TITLE
ARROW-7374: [Dev] [C++] Fix cuda-cpp docker build

### DIFF
--- a/.env
+++ b/.env
@@ -20,7 +20,7 @@
 
 REPO=apache/arrow-dev
 ARCH=amd64
-CUDA=10.0
+CUDA=9.1
 DEBIAN=10
 UBUNTU=18.04
 FEDORA=29

--- a/ci/docker/cuda-10.0-cpp.dockerfile
+++ b/ci/docker/cuda-10.0-cpp.dockerfile
@@ -65,9 +65,6 @@ RUN apt-get update -y -q && \
       tzdata && \
       apt-get clean && rm -rf /var/lib/apt/lists*
 
-# Make sure libcuda.so and its dependencies are visible by CMake
-RUN ln -s /usr/local/cuda-10.0/compat/lib* /usr/local/cuda-10.0/lib64/
-
 # Prioritize system packages and local installation
 # The following dependencies will be downloaded due to missing/invalid packages
 # provided by the distribution:
@@ -90,6 +87,7 @@ ENV ARROW_BUILD_STATIC=OFF \
     ARROW_NO_DEPRECATED_API=ON \
     ARROW_PLASMA=ON \
     ARROW_USE_CCACHE=ON \
+    CUDA_LIB_PATH=${LIBRARY_PATH} \
     GTest_SOURCE=BUNDLED \
     ORC_SOURCE=BUNDLED \
     PATH=/usr/lib/ccache/:$PATH \

--- a/ci/docker/cuda-9.1-cpp.dockerfile
+++ b/ci/docker/cuda-9.1-cpp.dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM nvidia/cuda:10.0-devel-ubuntu18.04
+FROM nvidia/cuda:9.1-devel-ubuntu16.04
 
 # pipefail is enabled for proper error detection in the `wget | apt-key add`
 # step
@@ -25,7 +25,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
-      wget software-properties-common gpg-agent && \
+      wget software-properties-common && \
       apt-get clean && rm -rf /var/lib/apt/lists*
 
 # Installs C++ toolchain and dependencies
@@ -40,7 +40,6 @@ RUN apt-get update -y -q && \
       g++ \
       gcc \
       git \
-      libbenchmark-dev \
       libboost-filesystem-dev \
       libboost-regex-dev \
       libboost-system-dev \
@@ -64,9 +63,6 @@ RUN apt-get update -y -q && \
       thrift-compiler \
       tzdata && \
       apt-get clean && rm -rf /var/lib/apt/lists*
-
-# Make sure libcuda.so and its dependencies are visible by CMake
-RUN ln -s /usr/local/cuda-10.0/compat/lib* /usr/local/cuda-10.0/lib64/
 
 # Prioritize system packages and local installation
 # The following dependencies will be downloaded due to missing/invalid packages
@@ -93,5 +89,4 @@ ENV ARROW_BUILD_STATIC=OFF \
     GTest_SOURCE=BUNDLED \
     ORC_SOURCE=BUNDLED \
     PATH=/usr/lib/ccache/:$PATH \
-    Thrift_SOURCE=BUNDLED \
-    LD_LIBRARY_PATH=/usr/local/cuda/lib64/
+    Thrift_SOURCE=BUNDLED

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,13 +31,14 @@ volumes:
   # like ARM64v8 with debian 10, then the appropiate parametrized volume name
   # must be added the the list below: arm64v8-debian-10-cache
   amd64-conda-cache:
+  amd64-cuda-9.1-cache:
   amd64-cuda-10.0-cache:
   amd64-debian-9-cache:
   amd64-debian-10-cache:
-  amd64-ubuntu-18.04-cache:
-  amd64-ubuntu-16.04-cache:
-  amd64-ubuntu-14.04-cache:
   amd64-fedora-29-cache:
+  amd64-ubuntu-14.04-cache:
+  amd64-ubuntu-16.04-cache:
+  amd64-ubuntu-18.04-cache:
   maven-cache:
 
 x-ccache: &ccache
@@ -93,9 +94,11 @@ services:
     # Usage:
     #   docker-compose build cuda-cpp
     #   docker-compose run --rm cuda-cpp
+    # Also need to edit the host docker configuration as follows:
+    #   https://github.com/docker/compose/issues/6691#issuecomment-561504928
     # Parameters:
     #   ARCH: amd64
-    #   CUDA: 8.0, 10.0, ...
+    #   CUDA: 9.1, 10.0
     image: ${REPO}:${ARCH}-cuda-${CUDA}-cpp
     build:
       context: .


### PR DESCRIPTION
Also add a CUDA 9.1 Dockerfile for Ubuntu 18.04 hosts.
(official Ubuntu 18.04 packages don't provide CUDA 10.0, only 9.1)