### PR TITLE
ARROW-7377: [C++][Dataset] Add ScanOptions::MaterializedFields

### DIFF
--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -46,6 +46,20 @@ ScanOptionsPtr ScanOptions::ReplaceSchema(std::shared_ptr<Schema> schema) const 
   return copy;
 }
 
+std::vector<std::string> ScanOptions::MaterializedFields() const {
+  std::vector<std::string> fields;
+
+  for (const auto& f : schema()->fields()) {
+    fields.push_back(f->name());
+  }
+
+  for (auto&& name : FieldsInExpression(filter)) {
+    fields.push_back(std::move(name));
+  }
+
+  return fields;
+}
+
 Result<RecordBatchIterator> SimpleScanTask::Execute() {
   return MakeVectorIterator(record_batches_);
 }

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -72,6 +73,22 @@ class ARROW_DS_EXPORT ScanOptions {
 
   // Projector for reconciling the final RecordBatch to the requested schema.
   RecordBatchProjector projector;
+
+  // Return a vector of fields that requires materialization.
+  //
+  // This is usually the union of the fields referenced in the projection and the
+  // filter expression. Examples:
+  //
+  // - `SELECT a, b WHERE a < 2 && c > 1` => ["a", "b", "a", "c"]
+  // - `SELECT a + b < 3 WHERE a > 1` => ["a", "b"]
+  //
+  // This is needed for expression where a field may not be directly
+  // used in the final projection but is still required to evaluate the
+  // expression.
+  //
+  // This is used by DataFragments implementation to apply the column
+  // sub-selection optimization.
+  std::vector<std::string> MaterializedFields() const;
 
  private:
   explicit ScanOptions(std::shared_ptr<Schema> schema);

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -388,10 +388,10 @@ class Result : public util::EqualityComparable<Result<T>> {
   arrow::util::variant<T, Status, const char*> variant_;
 };
 
-#define ARROW_ASSIGN_OR_RAISE_IMPL(status_name, lhs, rexpr) \
-  auto status_name = (rexpr);                               \
-  ARROW_RETURN_NOT_OK(status_name.status());                \
-  lhs = std::move(status_name).ValueOrDie();
+#define ARROW_ASSIGN_OR_RAISE_IMPL(result_name, lhs, rexpr) \
+  auto result_name = (rexpr);                               \
+  ARROW_RETURN_NOT_OK((result_name).status());              \
+  lhs = std::move(result_name).ValueOrDie();
 
 #define ARROW_ASSIGN_OR_RAISE_NAME(x, y) ARROW_CONCAT(x, y)
 
@@ -405,7 +405,7 @@ class Result : public util::EqualityComparable<Result<T>> {
 //   ValueType value;
 //   ARROW_ASSIGN_OR_RAISE(value, MaybeGetValue(arg));
 //
-// WARNING: ASSIGN_OR_RAISE expands into multiple statements; it cannot be used
+// WARNING: ARROW_ASSIGN_OR_RAISE expands into multiple statements; it cannot be used
 //  in a single statement (e.g. as the body of an if statement without {})!
 #define ARROW_ASSIGN_OR_RAISE(lhs, rexpr)                                              \
   ARROW_ASSIGN_OR_RAISE_IMPL(ARROW_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), \


### PR DESCRIPTION
A small utility used to simplify parquet's implementation. Will be useful for other file formats.