### PR TITLE
ARROW-7378: [C++][Gandiva] Fix loop vectorization in gandiva

### DIFF
--- a/cpp/src/gandiva/annotator.h
+++ b/cpp/src/gandiva/annotator.h
@@ -52,6 +52,8 @@ class GANDIVA_EXPORT Annotator {
   EvalBatchPtr PrepareEvalBatch(const arrow::RecordBatch& record_batch,
                                 const ArrayDataVector& out_vector);
 
+  int buffer_count() { return buffer_count_; }
+
  private:
   /// Annotate a field and return the descriptor.
   FieldDescriptorPtr MakeDesc(FieldPtr field, bool is_output);

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -189,7 +189,7 @@ Status Engine::RemoveUnusedFunctions() {
 }
 
 // Optimise and compile the module.
-Status Engine::FinalizeModule(bool optimise_ir, bool dump_ir) {
+Status Engine::FinalizeModule(bool optimise_ir, bool dump_ir, std::string* final_ir) {
   auto status = RemoveUnusedFunctions();
   ARROW_RETURN_NOT_OK(status);
 
@@ -225,7 +225,10 @@ Status Engine::FinalizeModule(bool optimise_ir, bool dump_ir) {
       DumpIR("After optimise");
     }
   }
-
+  if (final_ir != nullptr) {
+    llvm::raw_string_ostream stream(*final_ir);
+    module_->print(stream, nullptr);
+  }
   ARROW_RETURN_IF(llvm::verifyModule(*module_, &llvm::errs()),
                   Status::CodeGenError("Module verification failed after optimizer"));
 

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -59,7 +59,7 @@ class GANDIVA_EXPORT Engine {
   }
 
   /// Optimise and compile the module.
-  Status FinalizeModule(bool optimise_ir, bool dump_ir, std::string* final_ir = nullptr);
+  Status FinalizeModule(bool optimise_ir, bool dump_ir, std::string* final_ir = NULLPTR);
 
   /// Get the compiled function corresponding to the irfunction.
   void* CompiledFunction(llvm::Function* irFunction);

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -59,7 +59,7 @@ class GANDIVA_EXPORT Engine {
   }
 
   /// Optimise and compile the module.
-  Status FinalizeModule(bool optimise_ir, bool dump_ir);
+  Status FinalizeModule(bool optimise_ir, bool dump_ir, std::string* final_ir = nullptr);
 
   /// Get the compiled function corresponding to the irfunction.
   void* CompiledFunction(llvm::Function* irFunction);

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -90,7 +90,7 @@ class GANDIVA_EXPORT LLVMGenerator {
    public:
     Visitor(LLVMGenerator* generator, llvm::Function* function,
             llvm::BasicBlock* entry_block, llvm::Value* arg_addrs,
-            llvm::Value* arg_addr_offsets, llvm::Value* arg_local_bitmaps,
+            llvm::Value* arg_local_bitmaps, std::vector<llvm::Value*> slice_offsets,
             llvm::Value* arg_context_ptr, llvm::Value* loop_var);
 
     void Visit(const VectorReadValidityDex& dex) override;
@@ -146,8 +146,8 @@ class GANDIVA_EXPORT LLVMGenerator {
     // Switch to the entry_block and get reference of the validity/value/offsets buffer
     llvm::Value* GetBufferReference(int idx, BufferType buffer_type, FieldPtr field);
 
-    // Get offset of the validity/value/offsets buffer
-    llvm::Value* GetBufferOffset(int idx, FieldPtr field);
+    // Get the slice offset of the validity/value/offsets buffer
+    llvm::Value* GetSliceOffset(int idx);
 
     // Switch to the entry_block and get reference to the local bitmap.
     llvm::Value* GetLocalBitMapReference(int idx);
@@ -160,8 +160,8 @@ class GANDIVA_EXPORT LLVMGenerator {
     llvm::Function* function_;
     llvm::BasicBlock* entry_block_;
     llvm::Value* arg_addrs_;
-    llvm::Value* arg_addr_offsets_;
     llvm::Value* arg_local_bitmaps_;
+    std::vector<llvm::Value*> slice_offsets_;
     llvm::Value* arg_context_ptr_;
     llvm::Value* loop_var_;
     bool has_arena_allocs_;
@@ -188,8 +188,8 @@ class GANDIVA_EXPORT LLVMGenerator {
   llvm::Value* GetDataBufferPtrReference(llvm::Value* arg_addrs, int idx, FieldPtr field);
 
   /// Generate code for the value array of one expression.
-  Status CodeGenExprValue(DexPtr value_expr, FieldDescriptorPtr output, int suffix_idx,
-                          llvm::Function** fn,
+  Status CodeGenExprValue(DexPtr value_expr, int num_buffers, FieldDescriptorPtr output,
+                          int suffix_idx, llvm::Function** fn,
                           SelectionVector::Mode selection_vector_mode);
 
   /// Generate code to load the local bitmap specified index and cast it as bitmap.

--- a/cpp/src/gandiva/llvm_generator_test.cc
+++ b/cpp/src/gandiva/llvm_generator_test.cc
@@ -86,12 +86,15 @@ TEST_F(TestLLVMGenerator, TestAdd) {
 
   llvm::Function* ir_func = nullptr;
 
-  status = generator->CodeGenExprValue(func_dex, desc_sum, 0, &ir_func,
+  status = generator->CodeGenExprValue(func_dex, 4, desc_sum, 0, &ir_func,
                                        SelectionVector::MODE_NONE);
   EXPECT_TRUE(status.ok()) << status.message();
 
-  status = generator->engine_->FinalizeModule(true, false);
+  std::string final_ir;
+  status = generator->engine_->FinalizeModule(true, false, &final_ir);
   EXPECT_TRUE(status.ok()) << status.message();
+  EXPECT_TRUE(final_ir.find("vector.body") != std::string::npos)
+      << "missing vectorization: " << final_ir;
 
   EvalFunc eval_func = (EvalFunc)generator->engine_->CompiledFunction(ir_func);
 


### PR DESCRIPTION
- for slice offsets, use local variables instead of memory references.
  The memory references make it harder for the loop vectorization to happen.
- added a test to verify loop vectorization is happening.