### PR TITLE
ARROW-7064: [R] Support null type using vctrs::unspecified()

### DIFF
--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -628,9 +628,9 @@ class Converter_Int64 : public Converter {
   }
 };
 
-class Converter_Unspecified : public Converter {
+class Converter_Null : public Converter {
  public:
-  explicit Converter_Unspecified(const ArrayVector& arrays) : Converter(arrays) {}
+  explicit Converter_Null(const ArrayVector& arrays) : Converter(arrays) {}
 
   SEXP Allocate(R_xlen_t n) const {
     Rcpp::LogicalVector data(n, NA_LOGICAL);
@@ -727,7 +727,7 @@ std::shared_ptr<Converter> Converter::Make(const ArrayVector& arrays) {
       return std::make_shared<arrow::r::Converter_List>(arrays);
 
     case Type::NA:
-      return std::make_shared<arrow::r::Converter_Unspecified>(arrays);
+      return std::make_shared<arrow::r::Converter_Null>(arrays);
 
     default:
       break;

--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -628,6 +628,25 @@ class Converter_Int64 : public Converter {
   }
 };
 
+class Converter_Unspecified : public Converter {
+ public:
+  explicit Converter_Unspecified(const ArrayVector& arrays) : Converter(arrays) {}
+
+  SEXP Allocate(R_xlen_t n) const {
+    Rcpp::LogicalVector data(n, NA_LOGICAL);
+    data.attr("class") = "vctrs_unspecified";
+    return data;
+  }
+
+  Status Ingest_all_nulls(SEXP data, R_xlen_t start, R_xlen_t n) const {
+    return Status::OK();
+  }
+
+  Status Ingest_some_nulls(SEXP data, const std::shared_ptr<arrow::Array>& array,
+                           R_xlen_t start, R_xlen_t n) const {
+    return Status::OK();
+  }
+};
 std::shared_ptr<Converter> Converter::Make(const ArrayVector& arrays) {
   switch (arrays[0]->type_id()) {
     // direct support
@@ -706,6 +725,9 @@ std::shared_ptr<Converter> Converter::Make(const ArrayVector& arrays) {
 
     case Type::LIST:
       return std::make_shared<arrow::r::Converter_List>(arrays);
+
+    case Type::NA:
+      return std::make_shared<arrow::r::Converter_Unspecified>(arrays);
 
     default:
       break;

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -70,6 +70,14 @@ test_that("Array supports NA", {
   expect_equal(Array__Mask(x_dbl), c(rep(TRUE, 10), FALSE))
 })
 
+test_that("Array support null type (ARROW-7064)", {
+  a <- Array$create(vctrs::unspecified(10))
+  expect_equal(a$type, null())
+
+  v <- a$as_vector()
+  expect_equal(v, vctrs::unspecified(10))
+})
+
 test_that("Array supports logical vectors (ARROW-3341)", {
   # with NA
   x <- sample(c(TRUE, FALSE, NA), 1000, replace = TRUE)
@@ -275,12 +283,12 @@ test_that("array supports difftime", {
   expect_equal(a$length(), 2L)
   expect_equal(a$as_vector(), c(time, time))
 
-  a <- Array$create(vctrs::vec_c(time, NA))
+  a <- Array$create(vctrs::vec_c(NA, time))
   expect_equal(a$type, time32(unit = TimeUnit$SECOND))
   expect_equal(a$length(), 2L)
-  expect_true(a$IsNull(1))
-  expect_equal(a$as_vector()[1], time)
-  expect_true(is.na(a$as_vector()[2]))
+  expect_true(a$IsNull(0))
+  expect_equal(a$as_vector()[2], time)
+  expect_true(is.na(a$as_vector()[1]))
 })
 
 test_that("support for NaN (ARROW-3615)", {

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -281,3 +281,8 @@ test_that("record_batch() only auto splice data frames", {
     regexp = "only data frames are allowed as unnamed arguments to be auto spliced"
   )
 })
+
+test_that("record_batch() handles null type (ARROW-7064)", {
+  batch <- record_batch(a = 1:10, n = vctrs::unspecified(10))
+  expect_equal(batch$schema,  schema(a = int32(), n = null()))
+})

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -249,3 +249,10 @@ test_that("==.Table", {
   expect_true(all.equal(tab1, tab2))
   expect_equal(tab1, tab2)
 })
+
+test_that("Table handles null type (ARROW-7064)", {
+  tab <- Table$create(a = 1:10, n = vctrs::unspecified(10))
+  expect_equal(tab$schema,  schema(a = int32(), n = null()))
+})
+
+


### PR DESCRIPTION
Not sure `vctrs::unspecified()` is the right concept, but e.g. 

``` r
library(arrow)
#> 
#> Attaching package: 'arrow'
#> The following object is masked from 'package:utils':
#> 
#>     timestamp

a <- Array$create(vctrs::unspecified(10))
a
#> Array
#> <null>
#> 10 nulls
a$type
#> Null
#> null
a$as_vector()
#> <unspecified> [10]

b <- record_batch(a = 1:10, n = vctrs::unspecified(10))
b$schema
#> Schema
#> a: int32
#> n: null
```

<sup>Created on 2019-12-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9000)</sup>