### PR TITLE
ARROW-843: [C++][Dataset] Ensure Schemas are unified in DataSourceDiscovery

### DIFF
--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -53,8 +53,11 @@ namespace dataset {
 ///   return Dataset(sources, common_schema)
 class ARROW_DS_EXPORT DataSourceDiscovery {
  public:
-  /// \brief Get the schema for the resulting DataSource.
-  virtual Result<std::shared_ptr<Schema>> Inspect() = 0;
+  /// \brief Get the schemas of the DataFragments and PartitionScheme.
+  virtual Result<std::vector<std::shared_ptr<Schema>>> InspectSchemas() = 0;
+
+  /// \brief Get unified schema for the resulting DataSource.
+  virtual Result<std::shared_ptr<Schema>> Inspect();
 
   /// \brief Create a DataSource with a given partition.
   virtual Result<DataSourcePtr> Finish() = 0;
@@ -160,7 +163,7 @@ class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery
                                              fs::Selector selector, FileFormatPtr format,
                                              FileSystemDiscoveryOptions options);
 
-  Result<std::shared_ptr<Schema>> Inspect() override;
+  Result<std::vector<std::shared_ptr<Schema>>> InspectSchemas() override;
 
   Result<DataSourcePtr> Finish() override;
 

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -17,6 +17,8 @@
 
 #include "arrow/dataset/discovery.h"
 
+#include <utility>
+
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
@@ -27,7 +29,114 @@
 namespace arrow {
 namespace dataset {
 
-class FileSystemDataSourceDiscoveryTest : public TestFileSystemDataSource {
+class DataSourceDiscoveryTest : public TestFileSystemDataSource {
+ public:
+  void AssertInspect(std::shared_ptr<Schema> schema) {
+    ASSERT_OK_AND_ASSIGN(auto actual, discovery_->Inspect());
+    EXPECT_EQ(*actual, *schema);
+  }
+
+  void AssertInspect(const std::vector<std::shared_ptr<Field>>& expected_fields) {
+    AssertInspect(schema(expected_fields));
+  }
+
+  void AssertInspectSchemas(std::vector<std::shared_ptr<Schema>> expected) {
+    ASSERT_OK_AND_ASSIGN(auto actual, discovery_->InspectSchemas());
+
+    EXPECT_EQ(actual.size(), expected.size());
+    for (size_t i = 0; i < actual.size(); i++) {
+      EXPECT_EQ(*actual[i], *expected[i]);
+    }
+  }
+
+ protected:
+  DataSourceDiscoveryPtr discovery_;
+};
+
+class MockDataSourceDiscovery : public DataSourceDiscovery {
+ public:
+  explicit MockDataSourceDiscovery(std::vector<std::shared_ptr<Schema>> schemas)
+      : schemas_(std::move(schemas)) {}
+
+  Result<std::vector<std::shared_ptr<Schema>>> InspectSchemas() override {
+    return schemas_;
+  }
+
+  Result<DataSourcePtr> Finish() override {
+    return std::make_shared<SimpleDataSource>(std::vector<DataFragmentPtr>{});
+  }
+
+ protected:
+  std::vector<std::shared_ptr<Schema>> schemas_;
+};
+
+class MockPartitionScheme : public PartitionScheme {
+ public:
+  explicit MockPartitionScheme(std::shared_ptr<Schema> schema)
+      : PartitionScheme(std::move(schema)) {}
+
+  Result<ExpressionPtr> Parse(const std::string& segment, int i) const override {
+    return nullptr;
+  }
+
+  std::string type_name() const override { return "mock_partition_scheme"; }
+};
+
+class MockDataSourceDiscoveryTest : public DataSourceDiscoveryTest {
+ public:
+  void MakeDiscovery(std::vector<std::shared_ptr<Schema>> schemas) {
+    discovery_ = std::make_shared<MockDataSourceDiscovery>(schemas);
+  }
+
+ protected:
+  std::shared_ptr<Field> i32 = field("i32", int32());
+  std::shared_ptr<Field> i64 = field("i64", int64());
+  std::shared_ptr<Field> f32 = field("f32", float64());
+  std::shared_ptr<Field> f64 = field("f64", float64());
+  // Non-nullable
+  std::shared_ptr<Field> i32_req = field("i32", int32(), false);
+  // bad type with name `i32`
+  std::shared_ptr<Field> i32_fake = field("i32", boolean());
+};
+
+TEST_F(MockDataSourceDiscoveryTest, UnifySchemas) {
+  MakeDiscovery({});
+  AssertInspect(schema({}));
+
+  MakeDiscovery({schema({i32}), schema({i32})});
+  AssertInspect(schema({i32}));
+
+  MakeDiscovery({schema({i32}), schema({i64})});
+  AssertInspect(schema({i32, i64}));
+
+  MakeDiscovery({schema({i32}), schema({i64})});
+  AssertInspect(schema({i32, i64}));
+
+  MakeDiscovery({schema({i32}), schema({i32_req})});
+  AssertInspect(schema({i32}));
+
+  MakeDiscovery({schema({i32, f64}), schema({i32_req, i64})});
+  AssertInspect(schema({i32, f64, i64}));
+
+  MakeDiscovery({schema({i32, f64}), schema({f64, i32_fake})});
+  // Unification fails when fields with the same name have clashing types.
+  ASSERT_RAISES(Invalid, discovery_->Inspect());
+  // Return the individual schema for closer inspection should not fail.
+  AssertInspectSchemas({schema({i32, f64}), schema({f64, i32_fake})});
+
+  // Partition Scheme's schema should be taken into account
+  MakeDiscovery({schema({i64, f64})});
+  auto partition_scheme = std::make_shared<MockPartitionScheme>(schema({i32}));
+  ASSERT_OK(discovery_->SetPartitionScheme(partition_scheme));
+  AssertInspect(schema({i64, f64, i32}));
+
+  // Partition scheme with an existing column should be fine.
+  partition_scheme = std::make_shared<MockPartitionScheme>(schema({i64}));
+  ASSERT_OK(discovery_->SetPartitionScheme(partition_scheme));
+  AssertInspect(schema({i64, f64}));
+}
+
+class FileSystemDataSourceDiscoveryTest : public DataSourceDiscoveryTest {
  public:
   void MakeDiscovery(const std::vector<fs::FileStats>& files) {
     MakeFileSystem(files);
@@ -41,15 +150,9 @@ class FileSystemDataSourceDiscoveryTest : public TestFileSystemDataSource {
     AssertFragmentsAreFromPath(source_->GetFragments(options_), paths);
   }
 
-  void AssertInspect(const std::vector<std::shared_ptr<Field>>& expected_fields) {
-    ASSERT_OK_AND_ASSIGN(auto actual, discovery_->Inspect());
-    ASSERT_EQ(*actual, Schema(expected_fields));
-  }
-
  protected:
   fs::Selector selector_;
   FileSystemDiscoveryOptions discovery_options_;
-  DataSourceDiscoveryPtr discovery_;
   FileFormatPtr format_ = std::make_shared<DummyFileFormat>(schema({}));
 };
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -259,6 +259,16 @@ cdef class DataSourceDiscovery:
     def root_partition(self, Expression expr):
         check_status(self.discovery.SetRootPartition(expr.unwrap()))
 
+    def inspect_schemas(self):
+        cdef CResult[vector[shared_ptr[CSchema]]] result
+        with nogil:
+            result = self.discovery.InspectSchemas()
+
+        schemas = []
+        for s in GetResultValue(result):
+            schemas.append(pyarrow_wrap_schema(s))
+        return schemas
+
     def inspect(self):
         cdef CResult[shared_ptr[CSchema]] result
         with nogil:

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -331,6 +331,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         vector[c_string] ignore_prefixes
 
     cdef cppclass CDataSourceDiscovery "arrow::dataset::DataSourceDiscovery":
+        CResult[vector[shared_ptr[CSchema]]] InspectSchemas()
         CResult[shared_ptr[CSchema]] Inspect()
         CResult[CDataSourcePtr] Finish()
         shared_ptr[CSchema] schema()

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -315,6 +315,7 @@ def test_file_system_discovery(mockfs, paths_or_selector):
         mockfs, paths_or_selector, format, options
     )
     assert isinstance(discovery.inspect(), pa.Schema)
+    assert isinstance(discovery.inspect_schemas(), list)
     assert isinstance(discovery.finish(), ds.FileSystemDataSource)
     assert isinstance(discovery.partition_scheme, ds.DefaultPartitionScheme)
     assert discovery.root_partition.equals(ds.ScalarExpression(True))


### PR DESCRIPTION
The `DataSourceDiscovery::InspectSchemas` was added such that if `Inspect()` fails to unify, the caller can inspect each schemas (including the partition scheme's schema).