### PR TITLE
ARROW-7382: [C++][Dataset] Insert missing directories in FileSystemDataSourceDiscovery::Make

### DIFF
--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -118,7 +118,8 @@ Result<DataSourceDiscoveryPtr> FileSystemDataSourceDiscovery::Make(
       parent_path = parent.stats().path();
     }
 
-    for (auto&& path : fs::internal::GatherAncestry(parent_path, ref.stats().path())) {
+    for (auto&& path :
+         fs::internal::AncestorsFromBasePath(parent_path, ref.stats().path())) {
       ARROW_ASSIGN_OR_RAISE(auto file, filesystem->GetTargetStats(std::move(path)));
       missing.insert(std::move(file));
     }

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -135,14 +135,14 @@ struct FileSystemDiscoveryOptions {
 class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery {
  public:
   /// \brief Build a FileSystemDataSourceDiscovery from an explicit list of
-  /// fs::FileStats.
+  /// paths.
   ///
   /// \param[in] filesystem passed to FileSystemDataSource
   /// \param[in] paths passed to FileSystemDataSource
   /// \param[in] format passed to FileSystemDataSource
   /// \param[in] options see FileSystemDiscoveryOptions for more information.
   static Result<DataSourceDiscoveryPtr> Make(fs::FileSystemPtr filesystem,
-                                             fs::FileStatsVector paths,
+                                             const std::vector<std::string>& paths,
                                              FileFormatPtr format,
                                              FileSystemDiscoveryOptions options);
 
@@ -169,12 +169,15 @@ class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery
   Result<DataSourcePtr> Finish() override;
 
  protected:
-  FileSystemDataSourceDiscovery(fs::FileSystemPtr filesystem,
-                                std::vector<fs::FileStats> files, FileFormatPtr format,
-                                FileSystemDiscoveryOptions options);
+  FileSystemDataSourceDiscovery(fs::FileSystemPtr filesystem, fs::PathForest forest,
+                                FileFormatPtr format, FileSystemDiscoveryOptions options);
+
+  static Status Filter(const fs::FileSystemPtr& filesystem, const FileFormatPtr& format,
+                       const FileSystemDiscoveryOptions& options,
+                       fs::FileStatsVector* files);
 
   fs::FileSystemPtr fs_;
-  std::vector<fs::FileStats> files_;
+  fs::PathForest forest_;
   FileFormatPtr format_;
   FileSystemDiscoveryOptions options_;
 };

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -172,9 +172,10 @@ class ARROW_DS_EXPORT FileSystemDataSourceDiscovery : public DataSourceDiscovery
   FileSystemDataSourceDiscovery(fs::FileSystemPtr filesystem, fs::PathForest forest,
                                 FileFormatPtr format, FileSystemDiscoveryOptions options);
 
-  static Status Filter(const fs::FileSystemPtr& filesystem, const FileFormatPtr& format,
-                       const FileSystemDiscoveryOptions& options,
-                       fs::FileStatsVector* files);
+  static Result<fs::PathForest> Filter(const fs::FileSystemPtr& filesystem,
+                                       const FileFormatPtr& format,
+                                       const FileSystemDiscoveryOptions& options,
+                                       fs::PathForest forest);
 
   fs::FileSystemPtr fs_;
   fs::PathForest forest_;

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -159,8 +159,6 @@ class FileSystemDataSourceDiscoveryTest : public DataSourceDiscoveryTest {
 TEST_F(FileSystemDataSourceDiscoveryTest, Basic) {
   MakeDiscovery({fs::File("a"), fs::File("b")});
   AssertFinishWithPaths({"a", "b"});
-
-  // missing directory
   MakeDiscovery({fs::Dir("a"), fs::Dir("a/b"), fs::File("a/b/c")});
 }
 
@@ -189,6 +187,22 @@ TEST_F(FileSystemDataSourceDiscoveryTest, Partition) {
   ASSERT_OK(discovery_->SetPartitionScheme(partition_scheme));
   AssertInspect({field("a", int32())});
   AssertFinishWithPaths({selector_.base_dir + "/a=1", selector_.base_dir + "/a=2"});
+}
+
+TEST_F(FileSystemDataSourceDiscoveryTest, MissingDirectories) {
+  MakeFileSystem({fs::File("base_dir/a=3/b=3/dat"), fs::File("unpartitioned/ignored=3")});
+
+  discovery_options_.partition_base_dir = "base_dir";
+  ASSERT_OK_AND_ASSIGN(
+      discovery_, FileSystemDataSourceDiscovery::Make(
+                      fs_, {"base_dir/a=3/b=3/dat", "unpartitioned/ignored=3"}, format_,
+                      discovery_options_));
+  auto partition_scheme = std::make_shared<HivePartitionScheme>(
+      schema({field("a", int32()), field("b", int32())}));
+  ASSERT_OK(discovery_->SetPartitionScheme(partition_scheme));
+
+  AssertInspect({field("a", int32()), field("b", int32())});
+  AssertFinishWithPaths({"base_dir/a=3/b=3/dat", "unpartitioned/ignored=3"});
 }
 
 TEST_F(FileSystemDataSourceDiscoveryTest, OptionsIgnoredDefaultPrefixes) {

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -159,6 +159,9 @@ class FileSystemDataSourceDiscoveryTest : public DataSourceDiscoveryTest {
 TEST_F(FileSystemDataSourceDiscoveryTest, Basic) {
   MakeDiscovery({fs::File("a"), fs::File("b")});
   AssertFinishWithPaths({"a", "b"});
+
+  // missing directory
+  MakeDiscovery({fs::Dir("a"), fs::Dir("a/b"), fs::File("a/b/c")});
 }
 
 TEST_F(FileSystemDataSourceDiscoveryTest, Selector) {

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -94,7 +94,7 @@ struct ARROW_EXPORT FileStats : public util::EqualityComparable<FileStats> {
 
   /// The full file path in the filesystem
   const std::string& path() const { return path_; }
-  void set_path(const std::string& path) { path_ = path; }
+  void set_path(std::string path) { path_ = std::move(path); }
 
   /// The file base name (component after the last directory separator)
   std::string base_name() const;
@@ -124,6 +124,19 @@ struct ARROW_EXPORT FileStats : public util::EqualityComparable<FileStats> {
   }
 
   std::string ToString() const;
+
+  /// Function object implementing less-than comparison and hashing
+  /// by path, to support sorting stats, using them as keys, and other
+  /// interactions with the STL.
+  struct ByPath {
+    bool operator()(const FileStats& l, const FileStats& r) const {
+      return l.path() < r.path();
+    }
+
+    size_t operator()(const FileStats& s) const {
+      return std::hash<std::string>{}(s.path());
+    }
+  };
 
  protected:
   FileType type_ = FileType::Unknown;

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -22,6 +22,7 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/type_fwd.h"

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -210,16 +210,17 @@ TEST(PathUtil, MakeAbstractPathRelative) {
   ASSERT_RAISES(Invalid, MakeAbstractPathRelative("", "foo/bar/baz"));
 }
 
-TEST(PathUtil, GatherAncestry) {
+TEST(PathUtil, AncestorsFromBasePath) {
   using V = std::vector<std::string>;
 
   // Not relative to base
-  ASSERT_EQ(GatherAncestry("xxx", "foo/bar"), V{});
-  ASSERT_EQ(GatherAncestry("xxx", "xxxx"), V{});
+  ASSERT_EQ(AncestorsFromBasePath("xxx", "foo/bar"), V{});
+  ASSERT_EQ(AncestorsFromBasePath("xxx", "xxxx"), V{});
 
-  ASSERT_EQ(GatherAncestry("foo", "foo/bar"), V{});
-  ASSERT_EQ(GatherAncestry("foo", "foo/bar/baz"), V({"foo/bar"}));
-  ASSERT_EQ(GatherAncestry("foo", "foo/bar/baz/quux"), V({"foo/bar", "foo/bar/baz"}));
+  ASSERT_EQ(AncestorsFromBasePath("foo", "foo/bar"), V{});
+  ASSERT_EQ(AncestorsFromBasePath("foo", "foo/bar/baz"), V({"foo/bar"}));
+  ASSERT_EQ(AncestorsFromBasePath("foo", "foo/bar/baz/quux"),
+            V({"foo/bar", "foo/bar/baz"}));
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -189,8 +189,6 @@ TEST(PathUtil, RemoveLeadingSlash) {
 }
 
 TEST(PathUtil, MakeAbstractPathRelative) {
-  std::string s;
-
   ASSERT_OK_AND_EQ("", MakeAbstractPathRelative("/", "/"));
   ASSERT_OK_AND_EQ("foo/bar", MakeAbstractPathRelative("/", "/foo/bar"));
 
@@ -210,6 +208,18 @@ TEST(PathUtil, MakeAbstractPathRelative) {
   // Base is not absolute
   ASSERT_RAISES(Invalid, MakeAbstractPathRelative("foo/bar", "foo/bar/baz"));
   ASSERT_RAISES(Invalid, MakeAbstractPathRelative("", "foo/bar/baz"));
+}
+
+TEST(PathUtil, GatherAncestry) {
+  using V = std::vector<std::string>;
+
+  // Not relative to base
+  ASSERT_EQ(GatherAncestry("xxx", "foo/bar"), V{});
+  ASSERT_EQ(GatherAncestry("xxx", "xxxx"), V{});
+
+  ASSERT_EQ(GatherAncestry("foo", "foo/bar"), V{});
+  ASSERT_EQ(GatherAncestry("foo", "foo/bar/baz"), V({"foo/bar"}));
+  ASSERT_EQ(GatherAncestry("foo", "foo/bar/baz/quux"), V({"foo/bar", "foo/bar/baz"}));
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/cpp/src/arrow/filesystem/path_forest.cc
+++ b/cpp/src/arrow/filesystem/path_forest.cc
@@ -33,7 +33,7 @@
 namespace arrow {
 namespace fs {
 
-Result<PathForest> PathForest::DoMake(std::vector<FileStats> stats) {
+Result<PathForest> PathForest::MakeFromPreSorted(std::vector<FileStats> stats) {
   int size = static_cast<int>(stats.size());
   std::vector<int> descendant_counts(size, 0), parents(size, -1);
 

--- a/cpp/src/arrow/filesystem/path_forest.h
+++ b/cpp/src/arrow/filesystem/path_forest.h
@@ -95,6 +95,10 @@ class ARROW_EXPORT PathForest : public util::EqualityComparable<PathForest> {
 
   std::vector<Ref> roots() const;
 
+  const std::vector<FileStats>& stats() const& { return *stats_; }
+
+  std::vector<FileStats> stats() && { return std::move(*stats_); }
+
   enum { Continue, Prune };
   using MaybePrune = Result<decltype(Prune)>;
 

--- a/cpp/src/arrow/filesystem/path_forest.h
+++ b/cpp/src/arrow/filesystem/path_forest.h
@@ -50,21 +50,21 @@ class ARROW_EXPORT PathForest : public util::EqualityComparable<PathForest> {
   template <typename... Associated>
   static Result<PathForest> Make(std::vector<FileStats> stats,
                                  std::vector<Associated>*... associated) {
-    auto compare_paths = [](const FileStats& lhs, const FileStats& rhs) {
-      return lhs.path() < rhs.path();
-    };
-
     if (sizeof...(associated) == 0) {
-      std::sort(stats.begin(), stats.end(), compare_paths);
+      std::sort(stats.begin(), stats.end(), FileStats::ByPath{});
     } else {
-      auto indices = arrow::internal::ArgSort(stats, compare_paths);
+      auto indices = arrow::internal::ArgSort(stats, FileStats::ByPath{});
       size_t _[] = {arrow::internal::Permute(indices, &stats),
                     arrow::internal::Permute(indices, associated)...};
       static_cast<void>(_);
     }
 
-    return DoMake(std::move(stats));
+    return MakeFromPreSorted(std::move(stats));
   }
+
+  /// Make a PathForest from FileStats which are already sorted in a
+  /// depth first visitation order.
+  static Result<PathForest> MakeFromPreSorted(std::vector<FileStats> sorted_stats);
 
   /// \brief Returns the number of nodes in this forest.
   int size() const { return size_; }
@@ -95,8 +95,8 @@ class ARROW_EXPORT PathForest : public util::EqualityComparable<PathForest> {
 
   std::vector<Ref> roots() const;
 
+  std::vector<FileStats>& stats() & { return *stats_; }
   const std::vector<FileStats>& stats() const& { return *stats_; }
-
   std::vector<FileStats> stats() && { return std::move(*stats_); }
 
   enum { Continue, Prune };
@@ -120,8 +120,6 @@ class ARROW_EXPORT PathForest : public util::EqualityComparable<PathForest> {
         stats_(std::move(stats)),
         descendant_counts_(std::move(descendant_counts)),
         parents_(std::move(parents)) {}
-
-  static Result<PathForest> DoMake(std::vector<FileStats> sorted_stats);
 
   /// \brief Visit with eager pruning.
   template <typename Visitor>

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -185,10 +185,10 @@ util::optional<util::string_view> RemoveAncestor(util::string_view ancestor,
   return RemoveLeadingSlash(relative_to_ancestor);
 }
 
-std::vector<std::string> GatherAncestry(util::string_view ancestor,
-                                        util::string_view descendant) {
+std::vector<std::string> AncestorsFromBasePath(util::string_view base_path,
+                                               util::string_view descendant) {
   std::vector<std::string> ancestry;
-  if (auto relative = RemoveAncestor(ancestor, descendant)) {
+  if (auto relative = RemoveAncestor(base_path, descendant)) {
     auto relative_segments = fs::internal::SplitAbstractPath(relative->to_string());
 
     // the last segment indicates descendant
@@ -201,8 +201,8 @@ std::vector<std::string> GatherAncestry(util::string_view ancestor,
 
     for (auto&& relative_segment : relative_segments) {
       ancestry.push_back(JoinAbstractPath(
-          std::vector<std::string>{ancestor.to_string(), std::move(relative_segment)}));
-      ancestor = ancestry.back();
+          std::vector<std::string>{base_path.to_string(), std::move(relative_segment)}));
+      base_path = ancestry.back();
     }
   }
   return ancestry;

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -185,6 +185,29 @@ util::optional<util::string_view> RemoveAncestor(util::string_view ancestor,
   return RemoveLeadingSlash(relative_to_ancestor);
 }
 
+std::vector<std::string> GatherAncestry(util::string_view ancestor,
+                                        util::string_view descendant) {
+  std::vector<std::string> ancestry;
+  if (auto relative = RemoveAncestor(ancestor, descendant)) {
+    auto relative_segments = fs::internal::SplitAbstractPath(relative->to_string());
+
+    // the last segment indicates descendant
+    relative_segments.pop_back();
+
+    if (relative_segments.empty()) {
+      // no missing parent
+      return {};
+    }
+
+    for (auto&& relative_segment : relative_segments) {
+      ancestry.push_back(JoinAbstractPath(
+          std::vector<std::string>{ancestor.to_string(), std::move(relative_segment)}));
+      ancestor = ancestry.back();
+    }
+  }
+  return ancestry;
+}
+
 }  // namespace internal
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -79,6 +79,12 @@ ARROW_EXPORT
 util::optional<util::string_view> RemoveAncestor(util::string_view ancestor,
                                                  util::string_view descendant);
 
+/// Return a vector of paths which are descendants of ancestor but ancestors of descendant
+/// (not inclusive of either argument).
+ARROW_EXPORT
+std::vector<std::string> GatherAncestry(util::string_view ancestor,
+                                        util::string_view descendant);
+
 // Join the components of an abstract path.
 template <class StringIt>
 std::string JoinAbstractPath(StringIt it, StringIt end) {

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -79,11 +79,13 @@ ARROW_EXPORT
 util::optional<util::string_view> RemoveAncestor(util::string_view ancestor,
                                                  util::string_view descendant);
 
-/// Return a vector of paths which are descendants of ancestor but ancestors of descendant
-/// (not inclusive of either argument).
+/// Return a vector of ancestors between a base path and a descendant.
+/// For example,
+///
+/// AncestorsFromBasePath("a/b", "a/b/c/d/e") -> ["a/b/c", "a/b/c/d"]
 ARROW_EXPORT
-std::vector<std::string> GatherAncestry(util::string_view ancestor,
-                                        util::string_view descendant);
+std::vector<std::string> AncestorsFromBasePath(util::string_view base_path,
+                                               util::string_view descendant);
 
 // Join the components of an abstract path.
 template <class StringIt>


### PR DESCRIPTION
Previously an omitted interceding directory (providing `/a=1/b=2/data` but not `/a=1` and `/a=1/b=2`) resulted in clobbered partition information. Now if any directories are missing they will be inserted