### PR TITLE
ARROW-7386: [C#] Array offset does not work properly

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Array.cs
@@ -41,7 +41,7 @@ namespace Apache.Arrow
         }
 
         public bool IsValid(int index) =>
-            NullCount == 0 || NullBitmapBuffer.IsEmpty || BitUtility.GetBit(NullBitmapBuffer.Span, index);
+            NullCount == 0 || NullBitmapBuffer.IsEmpty || BitUtility.GetBit(NullBitmapBuffer.Span, index + Offset);
 
         public bool IsNull(int index) => !IsValid(index);
 

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -171,7 +171,7 @@ namespace Apache.Arrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetValueOffset(int index)
         {
-            if (index < 0 || index >= Length)
+            if (index < 0 || index > Length)
             {
                 throw new ArgumentOutOfRangeException(nameof(index));
             }

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -171,13 +171,22 @@ namespace Apache.Arrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetValueOffset(int index)
         {
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
             return ValueOffsets[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetValueLength(int index)
         {
-            return ValueOffsets[index + 1] - ValueOffsets[index];
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+            var offsets = ValueOffsets;
+            return offsets[index + 1] - offsets[index];
         }
 
         public ReadOnlySpan<byte> GetBytes(int index)

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -21,7 +21,7 @@ using Apache.Arrow.Memory;
 
 namespace Apache.Arrow
 {
-    public class BinaryArray: Array
+    public class BinaryArray : Array
     {
         public class Builder : BuilderBase<BinaryArray, Builder>
         {
@@ -42,15 +42,15 @@ namespace Apache.Arrow
         }
 
         public BinaryArray(ArrowTypeId typeId, ArrayData data)
-            : base (data)
+            : base(data)
         {
             data.EnsureDataType(typeId);
             data.EnsureBufferCount(3);
         }
 
-        public abstract class BuilderBase<TArray, TBuilder>: IArrowArrayBuilder<byte, TArray, TBuilder>
-            where TArray: IArrowArray
-            where TBuilder: class, IArrowArrayBuilder<byte, TArray, TBuilder>
+        public abstract class BuilderBase<TArray, TBuilder> : IArrowArrayBuilder<byte, TArray, TBuilder>
+            where TArray : IArrowArray
+            where TBuilder : class, IArrowArrayBuilder<byte, TArray, TBuilder>
         {
             protected IArrowType DataType { get; }
             protected TBuilder Instance => this as TBuilder;
@@ -71,8 +71,8 @@ namespace Apache.Arrow
             {
                 ValueOffsets.Append(Offset);
 
-                var data = new ArrayData(DataType, ValueOffsets.Length - 1, 0, 0, 
-                    new [] { ArrowBuffer.Empty, ValueOffsets.Build(allocator), ValueBuffer.Build(allocator) });
+                var data = new ArrayData(DataType, ValueOffsets.Length - 1, 0, 0,
+                    new[] { ArrowBuffer.Empty, ValueOffsets.Build(allocator), ValueBuffer.Build(allocator) });
 
                 return Build(data);
             }
@@ -154,8 +154,8 @@ namespace Apache.Arrow
             ArrowBuffer dataBuffer,
             ArrowBuffer nullBitmapBuffer,
             int nullCount = 0, int offset = 0)
-        : this(new ArrayData(dataType, length, nullCount, offset, 
-            new [] { nullBitmapBuffer, valueOffsetsBuffer, dataBuffer }))
+        : this(new ArrayData(dataType, length, nullCount, offset,
+            new[] { nullBitmapBuffer, valueOffsetsBuffer, dataBuffer }))
         { }
 
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
@@ -177,17 +177,14 @@ namespace Apache.Arrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetValueLength(int index)
         {
-            var offsets = ValueOffsets;
-            var offset = index;
-
-            return offsets[offset + 1] - offsets[offset];
+            return ValueOffsets[index + 1] - ValueOffsets[index];
         }
 
         public ReadOnlySpan<byte> GetBytes(int index)
         {
             var offset = GetValueOffset(index);
             var length = GetValueLength(index);
-            
+
             return ValueBuffer.Span.Slice(offset, length);
         }
 

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -164,21 +164,21 @@ namespace Apache.Arrow
 
         public ArrowBuffer ValueBuffer => Data.Buffers[2];
 
-        public ReadOnlySpan<int> ValueOffsets => ValueOffsetsBuffer.Span.CastTo<int>().Slice(0, Length + 1);
+        public ReadOnlySpan<int> ValueOffsets => ValueOffsetsBuffer.Span.CastTo<int>().Slice(Offset, Length + 1);
 
         public ReadOnlySpan<byte> Values => ValueBuffer.Span.CastTo<byte>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetValueOffset(int index)
         {
-            return ValueOffsets[Offset + index];
+            return ValueOffsets[index];
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetValueLength(int index)
         {
             var offsets = ValueOffsets;
-            var offset = Offset + index;
+            var offset = index;
 
             return offsets[offset + 1] - offsets[offset];
         }

--- a/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
@@ -18,7 +18,7 @@ using System;
 
 namespace Apache.Arrow
 {
-    public class Date32Array: PrimitiveArray<int>
+    public class Date32Array : PrimitiveArray<int>
     {
         private const int MillisecondsPerDay = 86400000;
 
@@ -36,7 +36,7 @@ namespace Apache.Arrow
 
             protected override int ConvertTo(DateTimeOffset value)
             {
-                return (int) (value.ToUnixTimeMilliseconds() / MillisecondsPerDay);
+                return (int)(value.ToUnixTimeMilliseconds() / MillisecondsPerDay);
             }
         }
 
@@ -47,7 +47,7 @@ namespace Apache.Arrow
                 new[] { nullBitmapBuffer, valueBuffer }))
         { }
 
-        public Date32Array(ArrayData data) 
+        public Date32Array(ArrayData data)
             : base(data)
         {
             data.EnsureDataType(ArrowTypeId.Date32);
@@ -57,10 +57,10 @@ namespace Apache.Arrow
 
         public DateTimeOffset? GetDate(int index)
         {
-            var values = ValueBuffer.Span.CastTo<int>().Slice(0, Length);
-            var value = values[index];
-
-            return DateTimeOffset.FromUnixTimeMilliseconds(value * MillisecondsPerDay);
+            var value = GetValue(index);
+            return value.HasValue ?
+                    DateTimeOffset.FromUnixTimeMilliseconds(value.Value * MillisecondsPerDay) :
+                    null as DateTimeOffset?;
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
@@ -58,9 +58,13 @@ namespace Apache.Arrow
         public DateTimeOffset? GetDate(int index)
         {
             var value = GetValue(index);
-            return value.HasValue ?
-                    DateTimeOffset.FromUnixTimeMilliseconds(value.Value * MillisecondsPerDay) :
-                    null as DateTimeOffset?;
+
+            if (!value.HasValue)
+            {
+                return default;
+            }
+
+            return DateTimeOffset.FromUnixTimeMilliseconds(value.Value * MillisecondsPerDay);
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
@@ -58,9 +58,13 @@ namespace Apache.Arrow
         public DateTimeOffset? GetDate(int index)
         {
             var value = GetValue(index);
-            return value.HasValue ? 
-                DateTimeOffset.FromUnixTimeMilliseconds(value.Value) : 
-                null as DateTimeOffset?;
+
+            if (!value.HasValue)
+            {
+                return default;
+            }
+
+            return DateTimeOffset.FromUnixTimeMilliseconds(value.Value);
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
@@ -57,15 +57,10 @@ namespace Apache.Arrow
 
         public DateTimeOffset? GetDate(int index)
         {
-            if (!IsValid(index))
-            {
-                return null;
-            }
-
-            var values = ValueBuffer.Span.CastTo<long>().Slice(0, Length);
-            var value = values[index];
-
-            return DateTimeOffset.FromUnixTimeMilliseconds(value);
+            var value = GetValue(index);
+            return value.HasValue ? 
+                DateTimeOffset.FromUnixTimeMilliseconds(value.Value) : 
+                null as DateTimeOffset?;
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Arrays/ListArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ListArray.cs
@@ -24,7 +24,7 @@ namespace Apache.Arrow
 
         public ArrowBuffer ValueOffsetsBuffer => Data.Buffers[1];
 
-        public ReadOnlySpan<int> ValueOffsets => ValueOffsetsBuffer.Span.CastTo<int>().Slice(0, Length + 1);
+        public ReadOnlySpan<int> ValueOffsets => ValueOffsetsBuffer.Span.CastTo<int>().Slice(Offset, Length + 1);
 
         public ListArray(IArrowType dataType, int length,
             ArrowBuffer valueOffsetsBuffer, IArrowArray values,

--- a/csharp/src/Apache.Arrow/Arrays/ListArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ListArray.cs
@@ -30,7 +30,7 @@ namespace Apache.Arrow
             ArrowBuffer valueOffsetsBuffer, IArrowArray values,
             ArrowBuffer nullBitmapBuffer, int nullCount = 0, int offset = 0)
             : this(new ArrayData(dataType, length, nullCount, offset,
-                new[] {nullBitmapBuffer, valueOffsetsBuffer}, new[] {values.Data}))
+                new[] { nullBitmapBuffer, valueOffsetsBuffer }, new[] { values.Data }))
         {
             Values = values;
         }

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -30,7 +30,7 @@ namespace Apache.Arrow
 
         public ArrowBuffer ValueBuffer => Data.Buffers[1];
 
-        public ReadOnlySpan<T> Values => ValueBuffer.Span.CastTo<T>().Slice(0, Length);
+        public ReadOnlySpan<T> Values => ValueBuffer.Span.CastTo<T>().Slice(Offset, Length);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T? GetValue(int index)

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -35,7 +35,7 @@ namespace Apache.Arrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T? GetValue(int index)
         {
-            return IsValid(index) ? Values[index] : (T?) null;
+            return IsValid(index) ? Values[index] : (T?)null;
         }
 
         public IList<T?> ToList(bool includeNulls = false)

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -35,6 +35,10 @@ namespace Apache.Arrow
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T? GetValue(int index)
         {
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
             return IsValid(index) ? Values[index] : (T?)null;
         }
 

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -1,0 +1,107 @@
+﻿using Apache.Arrow.Tests.Fixtures;
+using Apache.Arrow.Types;
+using System;
+using System.Text;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class ArrowArrayTests
+    {
+        [Fact]
+        public void SliceArray()
+        {
+            TestSlice<Int32Array, Int32Array.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<Int8Array, Int8Array.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<Int16Array, Int16Array.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<Int64Array, Int64Array.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<UInt8Array, UInt8Array.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<UInt16Array, UInt16Array.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<UInt32Array, UInt32Array.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<UInt64Array, UInt64Array.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<FloatArray, FloatArray.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<DoubleArray, DoubleArray.Builder>(x => x.Append(10).Append(20).Append(30));
+            TestSlice<StringArray, StringArray.Builder>(x => x.Append("10").Append("20").Append("30"));
+        }
+
+        private static void TestSlice<TArray, TArrayBuilder>(Action<TArrayBuilder> action)
+            where TArray : IArrowArray
+            where TArrayBuilder : IArrowArrayBuilder<TArray>, new()
+        {
+            var builder = new TArrayBuilder();
+            action(builder);
+            var baseArray = builder.Build(default) as Array;
+            Assert.NotNull(baseArray);
+            var totalLength = baseArray.Length;
+            var validator = new ArraySliceValidator(baseArray);
+
+            //Check all offset and length
+            for (var offset = 0; offset < totalLength; offset++)
+            {
+                for(var length = 1; length + offset <= totalLength; length++)
+                {
+                    var targetArray = baseArray.Slice(offset, length);
+                    targetArray.Accept(validator);
+                }
+            }
+        }
+        
+        private class ArraySliceValidator :
+            IArrowArrayVisitor<Int8Array>,
+            IArrowArrayVisitor<Int16Array>,
+            IArrowArrayVisitor<Int32Array>,
+            IArrowArrayVisitor<Int64Array>,
+            IArrowArrayVisitor<UInt8Array>,
+            IArrowArrayVisitor<UInt16Array>,
+            IArrowArrayVisitor<UInt32Array>,
+            IArrowArrayVisitor<UInt64Array>,
+            IArrowArrayVisitor<FloatArray>,
+            IArrowArrayVisitor<DoubleArray>,
+            IArrowArrayVisitor<StringArray>
+        {
+            private readonly IArrowArray _baseArray;
+
+            public ArraySliceValidator(IArrowArray baseArray)
+            {
+                _baseArray = baseArray;
+            }
+
+            public void Visit(Int8Array array) => ValidateArrays(array);
+            public void Visit(Int16Array array) => ValidateArrays(array);
+            public void Visit(Int32Array array) => ValidateArrays(array);
+            public void Visit(Int64Array array) => ValidateArrays(array);
+            public void Visit(UInt8Array array) => ValidateArrays(array);
+            public void Visit(UInt16Array array) => ValidateArrays(array);
+            public void Visit(UInt32Array array) => ValidateArrays(array);
+            public void Visit(UInt64Array array) => ValidateArrays(array);
+            public void Visit(FloatArray array) => ValidateArrays(array);
+            public void Visit(DoubleArray array) => ValidateArrays(array);
+            public void Visit(StringArray array) => ValidateArrays(array);
+
+            public void Visit(IArrowArray array) => throw new NotImplementedException();
+
+            private void ValidateArrays<T>(PrimitiveArray<T> slicedArray)
+                where T : struct, IEquatable<T>
+            {
+                Assert.IsAssignableFrom<PrimitiveArray<T>>(_baseArray);
+                var baseArray = (PrimitiveArray<T>)_baseArray;
+
+                Assert.True(baseArray.NullBitmapBuffer.Span.SequenceEqual(slicedArray.NullBitmapBuffer.Span));
+                Assert.True(
+                    baseArray.ValueBuffer.Span.CastTo<T>().Slice(slicedArray.Offset, slicedArray.Length)
+                        .SequenceEqual(slicedArray.Values));
+            }
+
+            private void ValidateArrays(BinaryArray slicedArray)
+            {
+                Assert.IsAssignableFrom<BinaryArray>(_baseArray);
+                var baseArray = (BinaryArray)_baseArray;
+
+                Assert.True(baseArray.NullBitmapBuffer.Span.SequenceEqual(slicedArray.NullBitmapBuffer.Span));
+                Assert.True(
+                    baseArray.ValueOffsetsBuffer.Span.CastTo<int>().Slice(slicedArray.Offset, slicedArray.Length + 1)
+                        .SequenceEqual(slicedArray.ValueOffsets));
+            }
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -43,7 +43,8 @@ namespace Apache.Arrow.Tests
             Assert.Throws<ArgumentOutOfRangeException>(() => array.GetValueOffset(-1));
             Assert.Equal(0, array.GetValueOffset(0));
             Assert.Equal(1, array.GetValueOffset(1));
-            Assert.Throws<ArgumentOutOfRangeException>(() => array.GetValueOffset(2));
+            Assert.Equal(2, array.GetValueOffset(2));
+            Assert.Throws<ArgumentOutOfRangeException>(() => array.GetValueOffset(3));
 
         }
 

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -1,7 +1,19 @@
-﻿using Apache.Arrow.Tests.Fixtures;
-using Apache.Arrow.Types;
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
-using System.Text;
 using Xunit;
 
 namespace Apache.Arrow.Tests
@@ -38,14 +50,14 @@ namespace Apache.Arrow.Tests
             //Check all offset and length
             for (var offset = 0; offset < totalLength; offset++)
             {
-                for(var length = 1; length + offset <= totalLength; length++)
+                for (var length = 1; length + offset <= totalLength; length++)
                 {
                     var targetArray = baseArray.Slice(offset, length);
                     targetArray.Accept(validator);
                 }
             }
         }
-        
+
         private class ArraySliceValidator :
             IArrowArrayVisitor<Int8Array>,
             IArrowArrayVisitor<Int16Array>,


### PR DESCRIPTION
"Array.Values" always starts from first index of "ValueBuffer".
It should start from "Offset".