### PR TITLE
ARROW-7389: [Python][Packaging] Remove pyarrow.s3fs import check from the recipe

### DIFF
--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -25,8 +25,6 @@ requirements:
     - brotli
     - bzip2
     - c-ares
-    - double-conversion
-    - flatbuffers
     - gflags
     - glog
     - grpc-cpp
@@ -41,16 +39,15 @@ requirements:
     - re2
     - snappy
     - thrift-cpp >=0.11
-    - uriparser
     - zlib
     - zstd
 
   run:
     - {{ pin_compatible('numpy', lower_bound='1.16') }}
+    - aws-sdk-cpp
     - boost-cpp
     - brotli
     - c-ares
-    - double-conversion
     - gflags
     - glog
     - grpc-cpp
@@ -58,7 +55,6 @@ requirements:
     - python
     - re2
     - snappy
-    - uriparser
     - zlib
     - zstd
 

--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -23,7 +23,10 @@ requirements:
     - aws-sdk-cpp
     - boost-cpp
     - brotli
+    - bzip2
     - c-ares
+    - double-conversion
+    - flatbuffers
     - gflags
     - glog
     - grpc-cpp
@@ -31,22 +34,23 @@ requirements:
     - clangdev 7.*
     - llvmdev 7.*
     - lz4-c
-    - numpy 1.14.*
+    - numpy 1.16.*
     - orc  # [unix]
     - python
     - rapidjson
     - re2
     - snappy
     - thrift-cpp >=0.11
+    - uriparser
     - zlib
     - zstd
 
   run:
-    - {{ pin_compatible('numpy', lower_bound='1.14') }}
-    - aws-sdk-cpp
+    - {{ pin_compatible('numpy', lower_bound='1.16') }}
     - boost-cpp
     - brotli
     - c-ares
+    - double-conversion
     - gflags
     - glog
     - grpc-cpp
@@ -54,6 +58,7 @@ requirements:
     - python
     - re2
     - snappy
+    - uriparser
     - zlib
     - zstd
 

--- a/dev/tasks/conda-recipes/pyarrow/meta.yaml
+++ b/dev/tasks/conda-recipes/pyarrow/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - arrow-cpp {{ ARROW_VERSION }}
     - boost-cpp
     - cython
-    - numpy 1.14.*
+    - numpy 1.16.*
     - python
     - setuptools
     - setuptools_scm

--- a/dev/tasks/conda-recipes/pyarrow/meta.yaml
+++ b/dev/tasks/conda-recipes/pyarrow/meta.yaml
@@ -45,7 +45,6 @@ test:
   imports:
     - pyarrow
     - pyarrow.fs
-    - pyarrow.s3fs
     - pyarrow.flight   # [not py==27]
     - pyarrow.gandiva  # [not py==27]
     - pyarrow.orc      # [unix]


### PR DESCRIPTION
`s3fs` module has been removed recently.