### PR TITLE
ARROW-7397: [C++][JSON]Fix white space length detection error

### DIFF
--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -46,7 +46,7 @@ static size_t ConsumeWhitespace(string_view view) {
 #else
   auto ws_count = view.find_first_not_of(" \t\r\n");
   if (ws_count == string_view::npos) {
-    return 0;
+    return view.size();
   } else {
     return ws_count;
   }


### PR DESCRIPTION
Commit 21ca13a5cd [1] introduces a bug in ConsumeWhitespace() function.
When all chars in a string are white spaces, it should return string
length. But current code returns 0. It's not noticed because x86 goes
rapidjson simd code path which is okay. Arm64 now goes the buggy code
path and triggers json unit test failure.

[1] https://github.com/apache/arrow/commit/21ca13a5cd9c1478d64370732fcfae72d52350dd#diff-664e724274fbe0ff1e03745aa452b4d6R48

Signed-off-by: Yibo Cai <yibo.cai@arm.com>