### PR TITLE
ARROW-7399: [C++][Gandiva] set Mcpu based on host cpu

### DIFF
--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -105,6 +105,7 @@ Status Engine::Make(std::shared_ptr<Configuration> config,
   engine_obj->module_ = cg_module.get();
 
   llvm::EngineBuilder engineBuilder(std::move(cg_module));
+  engineBuilder.setMCPU(llvm::sys::getHostCPUName());
   engineBuilder.setEngineKind(llvm::EngineKind::JIT);
   engineBuilder.setOptLevel(llvm::CodeGenOpt::Aggressive);
   engineBuilder.setErrorStr(&(engine_obj->llvm_error_));

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -92,6 +92,7 @@ void Engine::InitOnce() {
 /// factory method to construct the engine.
 Status Engine::Make(std::shared_ptr<Configuration> config,
                     std::unique_ptr<Engine>* engine) {
+  static auto host_cpu_name = llvm::sys::getHostCPUName();
   std::unique_ptr<Engine> engine_obj(new Engine());
 
   std::call_once(init_once_flag, [&engine_obj] { engine_obj->InitOnce(); });
@@ -105,7 +106,7 @@ Status Engine::Make(std::shared_ptr<Configuration> config,
   engine_obj->module_ = cg_module.get();
 
   llvm::EngineBuilder engineBuilder(std::move(cg_module));
-  engineBuilder.setMCPU(llvm::sys::getHostCPUName());
+  engineBuilder.setMCPU(host_cpu_name);
   engineBuilder.setEngineKind(llvm::EngineKind::JIT);
   engineBuilder.setOptLevel(llvm::CodeGenOpt::Aggressive);
   engineBuilder.setErrorStr(&(engine_obj->llvm_error_));


### PR DESCRIPTION
- llvm doesn't auto detect cpu features based on host cpu. so,
  explicitly set the same in EngineBuilder.