### PR TITLE
ARROW-7400: [Java] Avoid the worst case for quick sort

### DIFF
--- a/java/algorithm/pom.xml
+++ b/java/algorithm/pom.xml
@@ -29,6 +29,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
       <artifactId>arrow-memory</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthInPlaceVectorSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/FixedWidthInPlaceVectorSorter.java
@@ -31,6 +31,8 @@ public class FixedWidthInPlaceVectorSorter<V extends BaseFixedWidthVector> imple
    */
   public static final int CHANGE_ALGORITHM_THRESHOLD = 15;
 
+  static final int STOP_CHOOSING_PIVOT_THRESHOLD = 3;
+
   VectorValueComparator<V> comparator;
 
   /**
@@ -102,7 +104,7 @@ public class FixedWidthInPlaceVectorSorter<V extends BaseFixedWidthVector> imple
    */
   void choosePivot(int low, int high) {
     // we need at least 3 items
-    if (high - low < 3) {
+    if (high - low + 1 < STOP_CHOOSING_PIVOT_THRESHOLD) {
       pivotBuffer.copyFrom(low, 0, vec);
       return;
     }
@@ -113,23 +115,23 @@ public class FixedWidthInPlaceVectorSorter<V extends BaseFixedWidthVector> imple
     // find the median by at most 3 comparisons
     int medianIdx;
     if (comparator.compare(low, mid) < 0) {
-      if (comparator.compare(mid, high - 1) < 0) {
+      if (comparator.compare(mid, high) < 0) {
         medianIdx = mid;
       } else {
-        if (comparator.compare(low, high - 1) < 0) {
-          medianIdx = high - 1;
+        if (comparator.compare(low, high) < 0) {
+          medianIdx = high;
         } else {
           medianIdx = low;
         }
       }
     } else {
-      if (comparator.compare(mid, high - 1) > 0) {
+      if (comparator.compare(mid, high) > 0) {
         medianIdx = mid;
       } else {
-        if (comparator.compare(low, high - 1) < 0) {
+        if (comparator.compare(low, high) < 0) {
           medianIdx = low;
         } else {
-          medianIdx = high - 1;
+          medianIdx = high;
         }
       }
     }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/IndexSorter.java
@@ -106,7 +106,7 @@ public class IndexSorter<V extends ValueVector> {
   static <T extends ValueVector> int choosePivot(
           int low, int high, IntVector indices, VectorValueComparator<T> comparator) {
     // we need at least 3 items
-    if (high - low < 3) {
+    if (high - low + 1 < FixedWidthInPlaceVectorSorter.STOP_CHOOSING_PIVOT_THRESHOLD) {
       return indices.get(low);
     }
 
@@ -115,23 +115,23 @@ public class IndexSorter<V extends ValueVector> {
     // find the median by at most 3 comparisons
     int medianIdx;
     if (comparator.compare(indices.get(low), indices.get(mid)) < 0) {
-      if (comparator.compare(indices.get(mid), indices.get(high - 1)) < 0) {
+      if (comparator.compare(indices.get(mid), indices.get(high)) < 0) {
         medianIdx = mid;
       } else {
-        if (comparator.compare(indices.get(low), indices.get(high - 1)) < 0) {
-          medianIdx = high - 1;
+        if (comparator.compare(indices.get(low), indices.get(high)) < 0) {
+          medianIdx = high;
         } else {
           medianIdx = low;
         }
       }
     } else {
-      if (comparator.compare(indices.get(mid), indices.get(high - 1)) > 0) {
+      if (comparator.compare(indices.get(mid), indices.get(high)) > 0) {
         medianIdx = mid;
       } else {
-        if (comparator.compare(indices.get(low), indices.get(high - 1)) < 0) {
+        if (comparator.compare(indices.get(low), indices.get(high)) < 0) {
           medianIdx = low;
         } else {
-          medianIdx = high - 1;
+          medianIdx = high;
         }
       }
     }

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/InsertionSorter.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/InsertionSorter.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.sort;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.ValueVector;
+
+/**
+ * Insertion sorter.
+ */
+class InsertionSorter {
+
+  /**
+   * Sorts the range of a vector by insertion sort.
+   *
+   * @param vector     the vector to be sorted.
+   * @param startIdx   the start index of the range (inclusive).
+   * @param endIdx     the end index of the range (inclusive).
+   * @param buffer     an extra buffer with capacity 1 to hold the current key.
+   * @param comparator the criteria for vector element comparison.
+   * @param <V>        the vector type.
+   */
+  static <V extends BaseFixedWidthVector> void insertionSort(
+      V vector, int startIdx, int endIdx, VectorValueComparator<V> comparator, V buffer) {
+    comparator.attachVectors(vector, buffer);
+    for (int i = startIdx; i <= endIdx; i++) {
+      buffer.copyFrom(i, 0, vector);
+      int j = i - 1;
+      while (j >= startIdx && comparator.compare(j, 0) > 0) {
+        vector.copyFrom(j, j + 1, vector);
+        j = j - 1;
+      }
+      vector.copyFrom(0, j + 1, buffer);
+    }
+  }
+
+  /**
+   * Sorts the range of vector indices by insertion sort.
+   *
+   * @param indices    the vector  indices.
+   * @param startIdx   the start index of the range (inclusive).
+   * @param endIdx     the end index of the range (inclusive).
+   * @param comparator the criteria for vector element comparison.
+   * @param <V>        the vector type.
+   */
+  static <V extends ValueVector> void insertionSort(
+      IntVector indices, int startIdx, int endIdx, VectorValueComparator<V> comparator) {
+    for (int i = startIdx; i <= endIdx; i++) {
+      int key = indices.get(i);
+      int j = i - 1;
+      while (j >= startIdx && comparator.compare(indices.get(j), key) > 0) {
+        indices.set(j + 1, indices.get(j));
+        j = j - 1;
+      }
+      indices.set(j + 1, key);
+    }
+  }
+}

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestFixedWidthInPlaceVectorSorter.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestFixedWidthInPlaceVectorSorter.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -140,9 +141,9 @@ public class TestFixedWidthInPlaceVectorSorter {
         comparator.attachVectors(vec, pivotBuffer);
 
         int low = 5;
-        int high = 7;
+        int high = 6;
         int pivotValue = vec.get(low);
-        assertTrue(high - low < 3);
+        assertTrue(high - low + 1 < FixedWidthInPlaceVectorSorter.STOP_CHOOSING_PIVOT_THRESHOLD);
 
         // the range is small enough, so the pivot is simply selected as the low value
         sorter.choosePivot(low, high);
@@ -151,11 +152,60 @@ public class TestFixedWidthInPlaceVectorSorter {
         low = 30;
         high = 80;
         pivotValue = vec.get((low + high) / 2);
-        assertTrue(high - low >= 3);
+        assertTrue(high - low + 1 >= FixedWidthInPlaceVectorSorter.STOP_CHOOSING_PIVOT_THRESHOLD);
 
         // the range is large enough, so the median is selected as the pivot
         sorter.choosePivot(low, high);
         assertEquals(pivotValue, vec.get(low));
+      }
+    }
+  }
+
+  /**
+   * Evaluates choosing pivot for all possible permutations of 3 numbers.
+   */
+  @Test
+  public void testChoosePivotAllPermutes() {
+    try (IntVector vec = new IntVector("", allocator)) {
+      vec.allocateNew(3);
+
+      FixedWidthInPlaceVectorSorter sorter = new FixedWidthInPlaceVectorSorter();
+      VectorValueComparator<IntVector> comparator = DefaultVectorComparators.createDefaultComparator(vec);
+
+      try (IntVector pivotBuffer = (IntVector) vec.getField().createVector(allocator)) {
+        // setup internal data structures
+        pivotBuffer.allocateNew(1);
+        sorter.pivotBuffer = pivotBuffer;
+        sorter.comparator = comparator;
+        sorter.vec = vec;
+        comparator.attachVectors(vec, pivotBuffer);
+
+        int low = 0;
+        int high = 2;
+
+        ValueVectorDataPopulator.setVector(vec, 11, 22, 33);
+        sorter.choosePivot(low, high);
+        assertEquals(22, vec.get(0));
+
+        ValueVectorDataPopulator.setVector(vec, 11, 33, 22);
+        sorter.choosePivot(low, high);
+        assertEquals(22, vec.get(0));
+
+        ValueVectorDataPopulator.setVector(vec, 22, 11, 33);
+        sorter.choosePivot(low, high);
+        assertEquals(22, vec.get(0));
+
+        ValueVectorDataPopulator.setVector(vec, 22, 33, 11);
+        sorter.choosePivot(low, high);
+        assertEquals(22, vec.get(0));
+
+        ValueVectorDataPopulator.setVector(vec, 33, 11, 22);
+        sorter.choosePivot(low, high);
+        assertEquals(22, vec.get(0));
+
+        ValueVectorDataPopulator.setVector(vec, 33, 22, 11);
+        sorter.choosePivot(low, high);
+        assertEquals(22, vec.get(0));
       }
     }
   }

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestFixedWidthInPlaceVectorSorter.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestFixedWidthInPlaceVectorSorter.java
@@ -140,9 +140,9 @@ public class TestFixedWidthInPlaceVectorSorter {
         comparator.attachVectors(vec, pivotBuffer);
 
         int low = 5;
-        int high = 10;
+        int high = 7;
         int pivotValue = vec.get(low);
-        assertTrue(high - low < FixedWidthInPlaceVectorSorter.PIVOT_SELECTION_THRESHOLD);
+        assertTrue(high - low < 3);
 
         // the range is small enough, so the pivot is simply selected as the low value
         sorter.choosePivot(low, high);
@@ -151,7 +151,7 @@ public class TestFixedWidthInPlaceVectorSorter {
         low = 30;
         high = 80;
         pivotValue = vec.get((low + high) / 2);
-        assertTrue(high - low >= FixedWidthInPlaceVectorSorter.PIVOT_SELECTION_THRESHOLD);
+        assertTrue(high - low >= 3);
 
         // the range is large enough, so the median is selected as the pivot
         sorter.choosePivot(low, high);

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestIndexSorter.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestIndexSorter.java
@@ -136,16 +136,17 @@ public class TestIndexSorter {
       comparator.attachVector(vec);
 
       int low = 5;
-      int high = 10;
-      assertTrue(high - low < FixedWidthInPlaceVectorSorter.PIVOT_SELECTION_THRESHOLD);
+      int high = 7;
+      assertTrue(high - low < 3);
 
       // the range is small enough, so the pivot is simply selected as the low value
       int pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);
+      assertEquals(pivotIndex, low);
       assertEquals(pivotIndex, indices.get(low));
 
       low = 30;
       high = 80;
-      assertTrue(high - low >= FixedWidthInPlaceVectorSorter.PIVOT_SELECTION_THRESHOLD);
+      assertTrue(high - low >= 3);
 
       // the range is large enough, so the median is selected as the pivot
       pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestIndexSorter.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestIndexSorter.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,16 +52,7 @@ public class TestIndexSorter {
       vec.setValueCount(10);
 
       // fill data to sort
-      vec.set(0, 11);
-      vec.set(1, 8);
-      vec.set(2, 33);
-      vec.set(3, 10);
-      vec.set(4, 12);
-      vec.set(5, 17);
-      vec.setNull(6);
-      vec.set(7, 23);
-      vec.set(8, 35);
-      vec.set(9, 2);
+      ValueVectorDataPopulator.setVector(vec, 11, 8, 33, 10, 12, 17, null, 23, 35, 2);
 
       // sort the index
       IndexSorter<IntVector> indexSorter = new IndexSorter<>();
@@ -136,8 +128,8 @@ public class TestIndexSorter {
       comparator.attachVector(vec);
 
       int low = 5;
-      int high = 7;
-      assertTrue(high - low < 3);
+      int high = 6;
+      assertTrue(high - low + 1 < FixedWidthInPlaceVectorSorter.STOP_CHOOSING_PIVOT_THRESHOLD);
 
       // the range is small enough, so the pivot is simply selected as the low value
       int pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);
@@ -146,12 +138,68 @@ public class TestIndexSorter {
 
       low = 30;
       high = 80;
-      assertTrue(high - low >= 3);
+      assertTrue(high - low + 1 >= FixedWidthInPlaceVectorSorter.STOP_CHOOSING_PIVOT_THRESHOLD);
 
       // the range is large enough, so the median is selected as the pivot
       pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);
       assertEquals(pivotIndex, (low + high) / 2);
       assertEquals(pivotIndex, indices.get(low));
+    }
+  }
+
+  /**
+   * Evaluates choosing pivot for all possible permutations of 3 numbers.
+   */
+  @Test
+  public void testChoosePivotAllPermutes() {
+    try (IntVector vec = new IntVector("vector", allocator);
+         IntVector indices = new IntVector("indices", allocator)) {
+      vec.allocateNew();
+      indices.allocateNew();
+
+      VectorValueComparator<IntVector> comparator = DefaultVectorComparators.createDefaultComparator(vec);
+
+      // setup internal data structures
+      comparator.attachVector(vec);
+      int low = 0;
+      int high = 2;
+
+      // test all the 6 permutations of 3 numbers
+      ValueVectorDataPopulator.setVector(indices, 0, 1, 2);
+      ValueVectorDataPopulator.setVector(vec, 11, 22, 33);
+      int pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);
+      assertEquals(1, pivotIndex);
+      assertEquals(1, indices.get(low));
+
+      ValueVectorDataPopulator.setVector(indices, 0, 1, 2);
+      ValueVectorDataPopulator.setVector(vec, 11, 33, 22);
+      pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);
+      assertEquals(2, pivotIndex);
+      assertEquals(2, indices.get(low));
+
+      ValueVectorDataPopulator.setVector(indices, 0, 1, 2);
+      ValueVectorDataPopulator.setVector(vec, 22, 11, 33);
+      pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);
+      assertEquals(0, pivotIndex);
+      assertEquals(0, indices.get(low));
+
+      ValueVectorDataPopulator.setVector(indices, 0, 1, 2);
+      ValueVectorDataPopulator.setVector(vec, 22, 33, 11);
+      pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);
+      assertEquals(0, pivotIndex);
+      assertEquals(0, indices.get(low));
+
+      ValueVectorDataPopulator.setVector(indices, 0, 1, 2);
+      ValueVectorDataPopulator.setVector(vec, 33, 11, 22);
+      pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);
+      assertEquals(2, pivotIndex);
+      assertEquals(2, indices.get(low));
+
+      ValueVectorDataPopulator.setVector(indices, 0, 1, 2);
+      ValueVectorDataPopulator.setVector(vec, 33, 22, 11);
+      pivotIndex = IndexSorter.choosePivot(low, high, indices, comparator);
+      assertEquals(1, pivotIndex);
+      assertEquals(1, indices.get(low));
     }
   }
 }

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestInsertionSorter.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestInsertionSorter.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.sort;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link InsertionSorter}.
+ */
+public class TestInsertionSorter {
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void prepare() {
+    allocator = new RootAllocator(1024 * 1024);
+  }
+
+  @After
+  public void shutdown() {
+    allocator.close();
+  }
+
+  private void testSortIntVectorRange(int start, int end, int vectorLength) {
+    try (IntVector vector = new IntVector("vector", allocator);
+         IntVector buffer = new IntVector("buffer", allocator)) {
+
+      vector.allocateNew(vectorLength);
+      buffer.allocateNew(1);
+
+      for (int i = 0; i < vectorLength; i++) {
+        // place values in reverse order
+        vector.set(i, vectorLength - i - 1);
+      }
+
+      VectorValueComparator<IntVector> comparator =
+          DefaultVectorComparators.createDefaultComparator(vector);
+      InsertionSorter.insertionSort(vector, start, end, comparator, buffer);
+
+      // verify results
+      for (int i = start, expected = vectorLength - end - 1; i < end; i++, expected++) {
+        assertEquals(expected, vector.get(i));
+      }
+    }
+  }
+
+  @Test
+  public void testSortIntVector() {
+    testSortIntVectorRange(0, 99, 100);
+    testSortIntVectorRange(15, 30, 100);
+    testSortIntVectorRange(50, 50, 100);
+    testSortIntVectorRange(50, 51, 100);
+    testSortIntVectorRange(0, 30, 100);
+    testSortIntVectorRange(72, 99, 100);
+  }
+
+  private void testSortIndicesRange(int start, int end, int vectorLength) {
+    try (IntVector vector = new IntVector("vector", allocator);
+         IntVector indices = new IntVector("indices", allocator)) {
+
+      vector.allocateNew(vectorLength);
+      indices.allocateNew(vectorLength);
+
+      for (int i = 0; i < vectorLength; i++) {
+        // place values in reverse order
+        vector.set(i, (vectorLength - i - 1) * 10);
+        indices.set(i, i);
+      }
+
+      VectorValueComparator<IntVector> comparator =
+          DefaultVectorComparators.createDefaultComparator(vector);
+      comparator.attachVector(vector);
+
+      InsertionSorter.insertionSort(indices, start, end, comparator);
+
+      // verify results
+      for (int i = start, expected = vectorLength - end - 1; i < end; i++, expected++) {
+        assertEquals(expected, indices.get(i));
+      }
+    }
+  }
+
+  @Test
+  public void testSortIndices() {
+    testSortIntVectorRange(0, 99, 100);
+    testSortIntVectorRange(15, 30, 100);
+    testSortIntVectorRange(50, 50, 100);
+    testSortIntVectorRange(50, 51, 100);
+    testSortIntVectorRange(0, 30, 100);
+    testSortIntVectorRange(72, 99, 100);
+  }
+}

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestInsertionSorter.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/sort/TestInsertionSorter.java
@@ -17,11 +17,13 @@
 
 package org.apache.arrow.algorithm.sort;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,51 +45,49 @@ public class TestInsertionSorter {
     allocator.close();
   }
 
-  private void testSortIntVectorRange(int start, int end, int vectorLength) {
+  private static final int VECTOR_LENGTH = 10;
+
+  private void testSortIntVectorRange(int start, int end, int[] expected) {
     try (IntVector vector = new IntVector("vector", allocator);
          IntVector buffer = new IntVector("buffer", allocator)) {
 
-      vector.allocateNew(vectorLength);
       buffer.allocateNew(1);
 
-      for (int i = 0; i < vectorLength; i++) {
-        // place values in reverse order
-        vector.set(i, vectorLength - i - 1);
-      }
+      ValueVectorDataPopulator.setVector(vector, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+      assertEquals(VECTOR_LENGTH, vector.getValueCount());
 
       VectorValueComparator<IntVector> comparator =
           DefaultVectorComparators.createDefaultComparator(vector);
       InsertionSorter.insertionSort(vector, start, end, comparator, buffer);
 
-      // verify results
-      for (int i = start, expected = vectorLength - end - 1; i < end; i++, expected++) {
-        assertEquals(expected, vector.get(i));
+      assertEquals(VECTOR_LENGTH, expected.length);
+      for (int i = 0; i < VECTOR_LENGTH; i++) {
+        assertFalse(vector.isNull(i));
+        assertEquals(expected[i], vector.get(i));
       }
     }
   }
 
   @Test
   public void testSortIntVector() {
-    testSortIntVectorRange(0, 99, 100);
-    testSortIntVectorRange(15, 30, 100);
-    testSortIntVectorRange(50, 50, 100);
-    testSortIntVectorRange(50, 51, 100);
-    testSortIntVectorRange(0, 30, 100);
-    testSortIntVectorRange(72, 99, 100);
+    testSortIntVectorRange(2, 5, new int[] {9, 8, 4, 5, 6, 7, 3, 2, 1, 0});
+    testSortIntVectorRange(3, 7, new int[] {9, 8, 7, 2, 3, 4, 5, 6, 1, 0});
+    testSortIntVectorRange(3, 4, new int[] {9, 8, 7, 5, 6, 4, 3, 2, 1, 0});
+    testSortIntVectorRange(7, 7, new int[] {9, 8, 7, 6, 5, 4, 3, 2, 1, 0});
+    testSortIntVectorRange(0, 5, new int[] {4, 5, 6, 7, 8, 9, 3, 2, 1, 0});
+    testSortIntVectorRange(8, 9, new int[] {9, 8, 7, 6, 5, 4, 3, 2, 0, 1});
+    testSortIntVectorRange(0, 9, new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
   }
 
-  private void testSortIndicesRange(int start, int end, int vectorLength) {
+  private void testSortIndicesRange(int start, int end, int[] expectedIndices) {
     try (IntVector vector = new IntVector("vector", allocator);
          IntVector indices = new IntVector("indices", allocator)) {
 
-      vector.allocateNew(vectorLength);
-      indices.allocateNew(vectorLength);
+      ValueVectorDataPopulator.setVector(vector, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
+      ValueVectorDataPopulator.setVector(indices, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-      for (int i = 0; i < vectorLength; i++) {
-        // place values in reverse order
-        vector.set(i, (vectorLength - i - 1) * 10);
-        indices.set(i, i);
-      }
+      assertEquals(VECTOR_LENGTH, vector.getValueCount());
+      assertEquals(VECTOR_LENGTH, indices.getValueCount());
 
       VectorValueComparator<IntVector> comparator =
           DefaultVectorComparators.createDefaultComparator(vector);
@@ -96,19 +96,22 @@ public class TestInsertionSorter {
       InsertionSorter.insertionSort(indices, start, end, comparator);
 
       // verify results
-      for (int i = start, expected = vectorLength - end - 1; i < end; i++, expected++) {
-        assertEquals(expected, indices.get(i));
+      assertEquals(VECTOR_LENGTH, expectedIndices.length);
+      for (int i = 0; i < VECTOR_LENGTH; i++) {
+        assertFalse(indices.isNull(i));
+        assertEquals(expectedIndices[i], indices.get(i));
       }
     }
   }
 
   @Test
   public void testSortIndices() {
-    testSortIntVectorRange(0, 99, 100);
-    testSortIntVectorRange(15, 30, 100);
-    testSortIntVectorRange(50, 50, 100);
-    testSortIntVectorRange(50, 51, 100);
-    testSortIntVectorRange(0, 30, 100);
-    testSortIntVectorRange(72, 99, 100);
+    testSortIndicesRange(2, 5, new int[] {0, 1, 5, 4, 3, 2, 6, 7, 8, 9});
+    testSortIndicesRange(3, 7, new int[] {0, 1, 2, 7, 6, 5, 4, 3, 8, 9});
+    testSortIndicesRange(3, 4, new int[] {0, 1, 2, 4, 3, 5, 6, 7, 8, 9});
+    testSortIndicesRange(7, 7, new int[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+    testSortIndicesRange(0, 5, new int[] {5, 4, 3, 2, 1, 0, 6, 7, 8, 9});
+    testSortIndicesRange(8, 9, new int[] {0, 1, 2, 3, 4, 5, 6, 7, 9, 8});
+    testSortIndicesRange(0, 9, new int[] {9, 8, 7, 6, 5, 4, 3, 2, 1, 0});
   }
 }


### PR DESCRIPTION
This issue is in response of a discussion in: https://github.com/apache/arrow/pull/5540#discussion_r329487232.

The quick sort algorithm can degenerate to an O(n^2) algorithm, if the pivot is selected poorly. This is an important problem, as the worst case can happen, if the input vector is alrady sorted, which is frequently encountered in practice.

After some investigation, we solve the problem with a simple but effective approach: take 3 samples and choose the median (with at most 3 comparisons) as the pivot. This sorts the vector which is already sorted in O(nlogn) time.