### PR TITLE
ARROW-7403: [C++][JSON] Enable Rapidjson on Arm64 Neon

### DIFF
--- a/cpp/src/arrow/json/rapidjson_defs.h
+++ b/cpp/src/arrow/json/rapidjson_defs.h
@@ -30,6 +30,7 @@
   }                             \
   }
 
+#include "arrow/util/neon_util.h"
 #include "arrow/util/sse_util.h"
 
 // enable SIMD whitespace skipping, if available
@@ -40,5 +41,10 @@
 
 #if defined(ARROW_HAVE_SSE4_2)
 #define RAPIDJSON_SSE42 1
+#define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
+#endif
+
+#if defined(ARROW_HAVE_NEON)
+#define RAPIDJSON_NEON 1
 #define ARROW_RAPIDJSON_SKIP_WHITESPACE_SIMD 1
 #endif

--- a/cpp/src/arrow/util/neon_util.h
+++ b/cpp/src/arrow/util/neon_util.h
@@ -21,6 +21,8 @@ namespace arrow {
 
 #if defined(__aarch64__) || defined(__AARCH64__)
 
+#define ARROW_HAVE_NEON 1
+
 #ifdef __ARM_FEATURE_CRC32
 #define ARROW_HAVE_ARM_CRC
 #include <arm_acle.h>


### PR DESCRIPTION
Rapidjson supports Arm64 Neon, but it's not enabled in Arrow now. We need to define macro RAPIDJSON_NEON to build Rapidjson with Neon support.