### PR TITLE
ARROW-7404: [C++][Gandiva] Fix utf8 char length error on Arm64

### DIFF
--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -92,7 +92,7 @@ bool ends_with_utf8_utf8(const char* data, int32 data_len, const char* suffix,
 
 FORCE_INLINE
 int32 utf8_char_length(char c) {
-  if (c >= 0) {  // 1-byte char
+  if ((signed char)c >= 0) {  // 1-byte char (0x00 ~ 0x7F)
     return 1;
   } else if ((c & 0xE0) == 0xC0) {  // 2-byte char
     return 2;


### PR DESCRIPTION
Current code checks if a UTF-8 eight-bit code unit is within 0x00~0x7F
by "if (c >= 0)", where c is defined as "char". This checking assumes
char is always signed, which is not true[1]. On Arm64, char is unsigned
by default and causes some Gandiva unit tests fail.

Fix it by casting to "signed char" explicitly.

[1] Cited from https://en.cppreference.com/w/cpp/language/types
The signedness of char depends on the compiler and the target platform:
the defaults for ARM and PowerPC are typically unsigned, the defaults
for x86 and x64 are typically signed.

Signed-off-by: Yibo Cai <yibo.cai@arm.com>