### PR TITLE
ARROW-7405: [Java] ListVector isEmpty API is incorrect

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -735,7 +735,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   @Override
   public boolean isEmpty(int index) {
     if (isNull(index)) {
-      return false;
+      return true;
     } else {
       final int start = offsetBuffer.getInt(index * OFFSET_WIDTH);
       final int end = offsetBuffer.getInt((index + 1) * OFFSET_WIDTH);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -730,7 +730,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   /**
    * Check if element at given index is empty list.
    * @param index position of element
-   * @return true if element at given index is empty list, false otherwise
+   * @return true if element at given index is empty list or NULL, false otherwise
    */
   @Override
   public boolean isEmpty(int index) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -719,12 +719,27 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   /**
    * Check if element at given index is null.
    *
-   * @param index  position of element
+   * @param index position of element
    * @return true if element at given index is null, false otherwise
    */
   @Override
   public boolean isNull(int index) {
     return (isSet(index) == 0);
+  }
+
+  /**
+   * Check if element at given index is empty list.
+   * @param index position of element
+   * @return true if element at given index is empty list, false otherwise
+   */
+  public boolean isEmpty(int index) {
+    if (isSet(index) == 0) {
+      return false;
+    } else {
+      final int start = offsetBuffer.getInt(index * OFFSET_WIDTH);
+      final int end = offsetBuffer.getInt((index + 1) * OFFSET_WIDTH);
+      return start == end;
+    }
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -732,8 +732,9 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
    * @param index position of element
    * @return true if element at given index is empty list, false otherwise
    */
+  @Override
   public boolean isEmpty(int index) {
-    if (isSet(index) == 0) {
+    if (isNull(index)) {
       return false;
     } else {
       final int start = offsetBuffer.getInt(index * OFFSET_WIDTH);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -965,7 +965,7 @@ public class TestListVector {
       writer.setValueCount(4);
 
       assertTrue(vector.isNull(1));
-      assertFalse(vector.isEmpty(1));
+      assertTrue(vector.isEmpty(1));
 
       assertFalse(vector.isNull(2));
       assertTrue(vector.isEmpty(2));

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -953,7 +953,6 @@ public class TestListVector {
   @Test
   public void testIsEmpty() {
     try (final ListVector vector = ListVector.empty("list", allocator)) {
-
       UnionListWriter writer = vector.getWriter();
       writer.allocate();
 
@@ -964,18 +963,14 @@ public class TestListVector {
       writeIntValues(writer, new int[] {5, 6});
       writer.setValueCount(4);
 
+      assertFalse(vector.isEmpty(0));
       assertTrue(vector.isNull(1));
       assertTrue(vector.isEmpty(1));
-
       assertFalse(vector.isNull(2));
       assertTrue(vector.isEmpty(2));
-
-      assertFalse(vector.isEmpty(0));
       assertFalse(vector.isEmpty(3));
-
     }
   }
-
 
   private void writeIntValues(UnionListWriter writer, int[] values) {
     writer.startList();

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -950,6 +950,33 @@ public class TestListVector {
     }
   }
 
+  @Test
+  public void testIsEmpty() {
+    try (final ListVector vector = ListVector.empty("list", allocator)) {
+
+      UnionListWriter writer = vector.getWriter();
+      writer.allocate();
+
+      // set values [1,2], null, [], [5,6]
+      writeIntValues(writer, new int[] {1, 2});
+      writer.setPosition(2);
+      writeIntValues(writer, new int[] {});
+      writeIntValues(writer, new int[] {5, 6});
+      writer.setValueCount(4);
+
+      assertTrue(vector.isNull(1));
+      assertFalse(vector.isEmpty(1));
+
+      assertFalse(vector.isNull(2));
+      assertTrue(vector.isEmpty(2));
+
+      assertFalse(vector.isEmpty(0));
+      assertFalse(vector.isEmpty(3));
+
+    }
+  }
+
+
   private void writeIntValues(UnionListWriter writer, int[] values) {
     writer.startList();
     for (int v: values) {


### PR DESCRIPTION
Related to [ARROW-7405](https://issues.apache.org/jira/browse/ARROW-7405).

Currently isEmpty API is always return false in BaseRepeatedValueVector, and its subclass ListVector did not overwrite this method.
This will lead to incorrect result, for example, a ListVector with data [1,2], null, [], [5,6] should get [false, false, true, false] with this API, but now it would return [false, false, false, false].

This change implements `isEmpty(int index)` for a `ListVector` that will return `true` if the index is an empty list or a null value, and `false` otherwise.