### PR TITLE
ARROW-7406: [Java] NonNullableStructVector#hashCode should pass hasher to child vectors

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -307,7 +307,7 @@ public class NonNullableStructVector extends AbstractStructVector {
     int hash = 0;
     for (FieldVector v : getChildren()) {
       if (index < v.getValueCount()) {
-        hash = ByteFunctionHelpers.combineHash(hash, v.hashCode(index));
+        hash = ByteFunctionHelpers.combineHash(hash, v.hashCode(index, hasher));
       }
     }
     return hash;


### PR DESCRIPTION
Related to [ARROW-7406](https://issues.apache.org/jira/browse/ARROW-7406).

This was introduced by ARROW-6866 making parameter hasher useless in hashCode(int index, ArrowBufHasher hasher), and the child vectors would calculate hashCode using default hasher which is not correct.

This issue should be fixed by passing hasher to child vector.