### PR TITLE
ARROW-7418: [C++] Fix build error on Ubuntu 16.04

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu: [18.04]
+        ubuntu: [16.04, 18.04]
     env:
       UBUNTU: ${{ matrix.ubuntu }}
     steps:

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -524,10 +524,10 @@ TEST_F(TestSchemaUnification, SelectStar) {
 
   using TupleType = std::tuple<i32, i32, i32, i32, i32, i32>;
   std::vector<TupleType> rows = {
-      {111, 211, nullopt, nullopt, 1, 1},
-      {nullopt, 212, 312, nullopt, 1, 2},
-      {nullopt, nullopt, 321, 421, 2, 1},
-      {nullopt, 222, nullopt, 422, 2, 2},
+      TupleType(111, 211, nullopt, nullopt, 1, 1),
+      TupleType(nullopt, 212, 312, nullopt, 1, 2),
+      TupleType(nullopt, nullopt, 321, 421, 2, 1),
+      TupleType(nullopt, 222, nullopt, 422, 2, 2),
   };
 
   AssertBuilderEquals(scan_builder, rows);
@@ -540,10 +540,10 @@ TEST_F(TestSchemaUnification, SelectPhysicalColumns) {
 
   using TupleType = std::tuple<i32, i32, i32, i32>;
   std::vector<TupleType> rows = {
-      {111, 211, nullopt, nullopt},
-      {nullopt, 212, 312, nullopt},
-      {nullopt, nullopt, 321, 421},
-      {nullopt, 222, nullopt, 422},
+      TupleType(111, 211, nullopt, nullopt),
+      TupleType(nullopt, 212, 312, nullopt),
+      TupleType(nullopt, nullopt, 321, 421),
+      TupleType(nullopt, 222, nullopt, 422),
   };
 
   AssertBuilderEquals(scan_builder, rows);
@@ -556,10 +556,10 @@ TEST_F(TestSchemaUnification, SelectSomeReorderedPhysicalColumns) {
 
   using TupleType = std::tuple<i32, i32, i32>;
   std::vector<TupleType> rows = {
-      {211, 111, nullopt},
-      {212, nullopt, nullopt},
-      {nullopt, nullopt, 421},
-      {222, nullopt, 422},
+      TupleType(211, 111, nullopt),
+      TupleType(212, nullopt, nullopt),
+      TupleType(nullopt, nullopt, 421),
+      TupleType(222, nullopt, 422),
   };
 
   AssertBuilderEquals(scan_builder, rows);
@@ -578,8 +578,8 @@ TEST_F(TestSchemaUnification, SelectPhysicalColumnsFilterPartitionColumn) {
 
   using TupleType = std::tuple<i32, i32, i32>;
   std::vector<TupleType> rows = {
-      {211, nullopt, nullopt},
-      {nullopt, 321, 421},
+      TupleType(211, nullopt, nullopt),
+      TupleType(nullopt, 321, 421),
   };
 
   AssertBuilderEquals(scan_builder, rows);
@@ -594,10 +594,10 @@ TEST_F(TestSchemaUnification, SelectPartitionColumns) {
   ASSERT_OK(scan_builder->Project({"part_ds", "part_df"}));
   using TupleType = std::tuple<i32, i32>;
   std::vector<TupleType> rows = {
-      {1, 1},
-      {1, 2},
-      {2, 1},
-      {2, 2},
+      TupleType(1, 1),
+      TupleType(1, 2),
+      TupleType(2, 1),
+      TupleType(2, 2),
   };
   AssertBuilderEquals(scan_builder, rows);
 }
@@ -610,7 +610,7 @@ TEST_F(TestSchemaUnification, SelectPartitionColumnsFilterPhysicalColumn) {
   ASSERT_OK(scan_builder->Project({"part_df", "part_ds"}));
   using TupleType = std::tuple<i32, i32>;
   std::vector<TupleType> rows = {
-      {1, 1},
+      TupleType(1, 1),
   };
   AssertBuilderEquals(scan_builder, rows);
 }
@@ -624,8 +624,8 @@ TEST_F(TestSchemaUnification, SelectMixedColumnsAndFilter) {
 
   using TupleType = std::tuple<i32, i32, i32, i32>;
   std::vector<TupleType> rows = {
-      {2, 312, 1, nullopt},
-      {2, nullopt, 2, nullopt},
+      TupleType(2, 312, 1, nullopt),
+      TupleType(2, nullopt, 2, nullopt),
   };
   AssertBuilderEquals(scan_builder, rows);
 }


### PR DESCRIPTION
Formatted error message:

    FAILED: /usr/bin/ccache /usr/lib/ccache/g++ \
      -DARROW_JEMALLOC \
      -DARROW_JEMALLOC_INCLUDE_DIR="" \
      -DARROW_USE_GLOG \
      -DARROW_USE_SIMD \
      -DARROW_WITH_BOOST_FILESYSTEM \
      -DARROW_WITH_BROTLI \
      -DARROW_WITH_BZ2 \
      -DARROW_WITH_LZ4 \
      -DARROW_WITH_SNAPPY \
      -DARROW_WITH_ZLIB \
      -DGTEST_LINKED_AS_SHARED_LIBRARY=1 \
      -DURI_STATIC_BUILD \
      -isystem /arrow/cpp/thirdparty/flatbuffers/include \
      -isystem boost_ep-prefix/src/boost_ep \
      -isystem thrift_ep/src/thrift_ep-install/include \
      -isystem /arrow/cpp/thirdparty/protobuf_ep-install/include \
      -isystem jemalloc_ep-prefix/src \
      -isystem googletest_ep-prefix/src/googletest_ep/include \
      -isystem rapidjson_ep/src/rapidjson_ep-install/include \
      -isystem /arrow/cpp/thirdparty/hadoop/include \
      -Isrc \
      -I/arrow/cpp/src \
      -I/arrow/cpp/src/generated \
      -fdiagnostics-color=always \
      -ggdb \
      -O0 \
      -Wall \
      -Wno-conversion \
      -Wno-sign-conversion \
      -Wno-unused-variable \
      -Werror \
      -Wno-attributes \
      -msse4.2 \
      -g \
      -fPIE \
      -pthread \
      -std=gnu++11 \
      -MMD \
      -MT src/arrow/dataset/CMakeFiles/arrow-dataset-dataset-test.dir/dataset_test.cc.o \
      -MF src/arrow/dataset/CMakeFiles/arrow-dataset-dataset-test.dir/dataset_test.cc.o.d \
      -o src/arrow/dataset/CMakeFiles/arrow-dataset-dataset-test.dir/dataset_test.cc.o \
      -c /arrow/cpp/src/arrow/dataset/dataset_test.cc
    /arrow/cpp/src/arrow/dataset/dataset_test.cc: In member function
      'virtual void arrow::dataset::TestSchemaUnification_SelectStar_Test::TestBody()':
    /arrow/cpp/src/arrow/dataset/dataset_test.cc:531:3: error:
      converting to '
        std::tuple<nonstd::optional_lite::optional<int>,
                   nonstd::optional_lite::optional<int>,
                   nonstd::optional_lite::optional<int>,
                   nonstd::optional_lite::optional<int>,
                   nonstd::optional_lite::optional<int>,
                   nonstd::optional_lite::optional<int> >'
      from initializer list would use explicit constructor '
        constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...)
          [with
           _UElements = {
             int,
             int,
             const nonstd::optional_lite::nullopt_t&,
             const nonstd::optional_lite::nullopt_t&,
             int,
             int
           };
           <template-parameter-2-2> = void;
           _Elements = {
             nonstd::optional_lite::optional<int>,
             nonstd::optional_lite::optional<int>,
             nonstd::optional_lite::optional<int>,
             nonstd::optional_lite::optional<int>,
             nonstd::optional_lite::optional<int>,
             nonstd::optional_lite::optional<int>
           }]'
       };
       ^

Full log: https://circleci.com/gh/ursa-labs/crossbow/6109