### PR TITLE
ARROW-7379: [C++] Introduce SchemaBuilder companion class and Field::IsCompatibleWith

### DIFF
--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -182,7 +182,38 @@ ARROW_EXPORT void AssertBufferEqual(const Buffer& buffer,
                                     const std::vector<uint8_t>& expected);
 ARROW_EXPORT void AssertBufferEqual(const Buffer& buffer, const std::string& expected);
 ARROW_EXPORT void AssertBufferEqual(const Buffer& buffer, const Buffer& expected);
-ARROW_EXPORT void AssertSchemaEqual(const Schema& lhs, const Schema& rhs);
+
+ARROW_EXPORT void AssertTypeEqual(const DataType& lhs, const DataType& rhs,
+                                  bool check_metadata = true);
+ARROW_EXPORT void AssertTypeEqual(const std::shared_ptr<DataType>& lhs,
+                                  const std::shared_ptr<DataType>& rhs,
+                                  bool check_metadata = true);
+ARROW_EXPORT void AssertFieldEqual(const Field& lhs, const Field& rhs,
+                                   bool check_metadata = true);
+ARROW_EXPORT void AssertFieldEqual(const std::shared_ptr<Field>& lhs,
+                                   const std::shared_ptr<Field>& rhs,
+                                   bool check_metadata = true);
+ARROW_EXPORT void AssertSchemaEqual(const Schema& lhs, const Schema& rhs,
+                                    bool check_metadata = true);
+ARROW_EXPORT void AssertSchemaEqual(const std::shared_ptr<Schema>& lhs,
+                                    const std::shared_ptr<Schema>& rhs,
+                                    bool check_metadata = true);
+
+ARROW_EXPORT void AssertTypeNotEqual(const DataType& lhs, const DataType& rhs,
+                                     bool check_metadata = true);
+ARROW_EXPORT void AssertTypeNotEqual(const std::shared_ptr<DataType>& lhs,
+                                     const std::shared_ptr<DataType>& rhs,
+                                     bool check_metadata = true);
+ARROW_EXPORT void AssertFieldNotEqual(const Field& lhs, const Field& rhs,
+                                      bool check_metadata = true);
+ARROW_EXPORT void AssertFieldNotEqual(const std::shared_ptr<Field>& lhs,
+                                      const std::shared_ptr<Field>& rhs,
+                                      bool check_metadata = true);
+ARROW_EXPORT void AssertSchemaNotEqual(const Schema& lhs, const Schema& rhs,
+                                       bool check_metadata = true);
+ARROW_EXPORT void AssertSchemaNotEqual(const std::shared_ptr<Schema>& lhs,
+                                       const std::shared_ptr<Schema>& rhs,
+                                       bool check_metadata = true);
 
 ARROW_EXPORT void AssertTablesEqual(const Table& expected, const Table& actual,
                                     bool same_chunk_layout = true, bool flatten = false);

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -24,6 +24,7 @@
 #include <sstream>  // IWYU pragma: keep
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -68,6 +69,32 @@ std::shared_ptr<Field> Field::WithNullable(const bool nullable) const {
   return std::make_shared<Field>(name_, type_, nullable, metadata_);
 }
 
+Result<std::shared_ptr<Field>> Field::WithField(const Field& other) const {
+  if (name() != other.name()) {
+    return Status::Invalid("Field ", name(), " doesn't have the same name as ",
+                           other.name());
+  }
+  if (type()->id() == Type::NA) {
+    return other.WithNullable(true)->WithMetadata(metadata());
+  }
+  if (other.type()->id() != Type::NA && !type()->Equals(other.type())) {
+    return Status::Invalid("Field ", name(),
+                           " has incompatible types: ", type()->ToString(), " vs ",
+                           other.type()->ToString());
+  }
+  // At least one field is nullable thus the unified field should also be nullable.
+  if (other.type()->id() == Type::NA || other.nullable() != nullable()) {
+    return WithNullable(true);
+  }
+  return Copy();
+}
+
+Result<std::shared_ptr<Field>> Field::WithField(
+    const std::shared_ptr<Field>& other) const {
+  DCHECK_NE(other, nullptr);
+  return WithField(*other);
+}
+
 std::vector<std::shared_ptr<Field>> Field::Flatten() const {
   std::vector<std::shared_ptr<Field>> flattened;
   if (type_->id() == Type::STRUCT) {
@@ -108,6 +135,13 @@ bool Field::Equals(const Field& other, bool check_metadata) const {
 
 bool Field::Equals(const std::shared_ptr<Field>& other, bool check_metadata) const {
   return Equals(*other.get(), check_metadata);
+}
+
+bool Field::IsCompatibleWith(const Field& other) const { return WithField(other).ok(); }
+
+bool Field::IsCompatibleWith(const std::shared_ptr<Field>& other) const {
+  DCHECK_NE(other, nullptr);
+  return IsCompatibleWith(*other);
 }
 
 std::string Field::ToString() const {
@@ -354,18 +388,19 @@ std::unordered_multimap<std::string, int> CreateNameToIndexMap(
   return name_to_index;
 }
 
+template <int NotFoundValue = -1, int DuplicateFoundValue = -1>
 int LookupNameIndex(const std::unordered_multimap<std::string, int>& name_to_index,
                     const std::string& name) {
   auto p = name_to_index.equal_range(name);
   auto it = p.first;
   if (it == p.second) {
     // Not found
-    return -1;
+    return NotFoundValue;
   }
   auto index = it->second;
   if (++it != p.second) {
     // Duplicate field name
-    return -1;
+    return DuplicateFoundValue;
   }
   return index;
 }
@@ -502,31 +537,6 @@ std::string NullType::ToString() const { return name(); }
 // ----------------------------------------------------------------------
 // Schema implementation
 
-namespace {
-// Unifies `other` with `existing`. The unified field will have the metadata of
-// `existing` and:
-//   - if `other` if of NullType or is nullable, the unified field will be nullable.
-//   - if `existing` is of NullType but other is not, the unified field will
-//     have `other`'s type and will be nullable.
-Result<std::shared_ptr<Field>> UnifyFields(const std::shared_ptr<Field>& existing,
-                                           const std::shared_ptr<Field>& other) {
-  if (existing->type()->id() == Type::NA) {
-    return other->WithNullable(true)->WithMetadata(existing->metadata());
-  }
-  if (other->type()->id() != Type::NA && !existing->type()->Equals(other->type())) {
-    return Status::Invalid("Field ", existing->name(),
-                           " has incompatible types: ", existing->type()->ToString(),
-                           " vs ", other->type()->ToString());
-  }
-  // At least one field is nullable thus the unified field should also be nullable.
-  if (other->type()->id() == Type::NA || other->nullable() != existing->nullable()) {
-    return existing->WithNullable(true);
-  }
-  return existing;
-}
-
-}  // namespace
-
 class Schema::Impl {
  public:
   Impl(const std::vector<std::shared_ptr<Field>>& fields,
@@ -606,6 +616,14 @@ bool Schema::Equals(const Schema& other, bool check_metadata) const {
   return true;
 }
 
+bool Schema::Equals(const std::shared_ptr<Schema>& other, bool check_metadata) const {
+  if (other == nullptr) {
+    return false;
+  }
+
+  return Equals(*other, check_metadata);
+}
+
 std::shared_ptr<Field> Schema::GetFieldByName(const std::string& name) const {
   int i = GetFieldIndex(name);
   return i == -1 ? nullptr : impl_->fields_[i];
@@ -658,6 +676,12 @@ Status Schema::SetField(int i, const std::shared_ptr<Field>& field,
 
 bool Schema::HasMetadata() const {
   return (impl_->metadata_ != nullptr) && (impl_->metadata_->size() > 0);
+}
+
+bool Schema::HasUniqueFieldNames() const {
+  auto fields = field_names();
+  std::unordered_set<std::string> names{fields.cbegin(), fields.cend()};
+  return names.size() == fields.size();
 }
 
 std::shared_ptr<Schema> Schema::WithMetadata(
@@ -716,6 +740,111 @@ std::vector<std::string> Schema::field_names() const {
   return names;
 }
 
+SchemaBuilder::SchemaBuilder(ConflictPolicy policy) : policy_(policy) {}
+
+SchemaBuilder::SchemaBuilder(std::vector<std::shared_ptr<Field>> fields,
+                             ConflictPolicy policy)
+    : fields_(std::move(fields)),
+      name_to_index_(CreateNameToIndexMap(fields_)),
+      policy_(policy) {}
+
+SchemaBuilder::SchemaBuilder(const std::shared_ptr<Schema>& schema,
+                             ConflictPolicy conflict_resolution)
+    : fields_(std::move(schema->fields())),
+      name_to_index_(CreateNameToIndexMap(fields_)),
+      policy_(conflict_resolution) {
+  if (schema->HasMetadata()) {
+    metadata_ = schema->metadata()->Copy();
+  }
+}
+
+Status SchemaBuilder::WithField(const std::shared_ptr<Field>& field) {
+  DCHECK_NE(field, nullptr);
+
+  // Short-circuit, no lookup needed.
+  if (policy_ == APPEND) {
+    return AppendField(field);
+  }
+
+  auto name = field->name();
+  constexpr int kNotFound = -1;
+  constexpr int kDuplicateFound = -2;
+  auto i = LookupNameIndex<kNotFound, kDuplicateFound>(name_to_index_, name);
+
+  if (i == kNotFound) {
+    return AppendField(field);
+  }
+
+  if (i == kDuplicateFound || policy_ == ERROR) {
+    return Status::Invalid("Cannot merge field ", name,
+                           " more than one field with same name exists");
+  }
+
+  DCHECK_GE(i, 0);
+
+  if (policy_ == REPLACE) {
+    fields_[i] = field;
+  } else if (policy_ == MERGE) {
+    ARROW_ASSIGN_OR_RAISE(fields_[i], fields_[i]->WithField(field));
+  }
+
+  return Status::OK();
+}
+
+Status SchemaBuilder::WithFields(const std::vector<std::shared_ptr<Field>>& fields) {
+  for (const auto& field : fields) {
+    RETURN_NOT_OK(WithField(field));
+  }
+
+  return Status::OK();
+}
+
+Status SchemaBuilder::WithSchema(const std::shared_ptr<Schema>& schema) {
+  DCHECK_NE(schema, nullptr);
+  return WithFields(schema->fields());
+}
+
+Status SchemaBuilder::WithSchemas(const std::vector<std::shared_ptr<Schema>>& schemas) {
+  for (const auto& schema : schemas) {
+    RETURN_NOT_OK(WithSchema(schema));
+  }
+
+  return Status::OK();
+}
+
+Status SchemaBuilder::WithMetadata(const KeyValueMetadata& metadata) {
+  metadata_ = metadata.Copy();
+  return Status::OK();
+}
+
+Result<std::shared_ptr<Schema>> SchemaBuilder::Finish() const {
+  return schema(fields_, metadata_);
+}
+
+void SchemaBuilder::Reset() {
+  fields_.clear();
+  name_to_index_.clear();
+  metadata_.reset();
+}
+
+Status SchemaBuilder::AppendField(const std::shared_ptr<Field>& field) {
+  name_to_index_.emplace(field->name(), fields_.size());
+  fields_.push_back(field);
+  return Status::OK();
+}
+
+Result<std::shared_ptr<Schema>> SchemaBuilder::Merge(
+    const std::vector<std::shared_ptr<Schema>>& schemas, ConflictPolicy policy) {
+  SchemaBuilder builder{policy};
+  RETURN_NOT_OK(builder.WithSchemas(schemas));
+  return builder.Finish();
+}
+
+Status SchemaBuilder::AreCompatible(const std::vector<std::shared_ptr<Schema>>& schemas,
+                                    ConflictPolicy policy) {
+  return Merge(schemas, policy).status();
+}
+
 std::shared_ptr<Schema> schema(const std::vector<std::shared_ptr<Field>>& fields,
                                const std::shared_ptr<const KeyValueMetadata>& metadata) {
   return std::make_shared<Schema>(fields, metadata);
@@ -732,43 +861,22 @@ Result<std::shared_ptr<Schema>> UnifySchemas(
     return Status::Invalid("Must provide at least one schema to unify.");
   }
 
-  std::vector<std::shared_ptr<Field>> fields = schemas[0]->fields();
-  std::unordered_map<std::string, size_t> field_name_to_index;
-  for (size_t i = 0; i < fields.size(); ++i) {
-    if (!field_name_to_index.emplace(fields[i]->name(), i).second) {
-      return Status::Invalid(
-          "UnifySchemas does not support duplicate field names in the schema: ",
-          fields[i]->name());
-    }
+  if (!schemas[0]->HasUniqueFieldNames()) {
+    return Status::Invalid("Can't unify schema with duplicate field names.");
   }
 
-  for (auto schema_iter = schemas.begin() + 1; schema_iter != schemas.end();
-       ++schema_iter) {
-    const std::shared_ptr<Schema>& schema = *schema_iter;
-    for (const std::string& field_name : schema->field_names()) {
-      const std::vector<std::shared_ptr<Field>> current_fields =
-          schema->GetAllFieldsByName(field_name);
-      if (current_fields.size() != 1) {
-        return Status::Invalid(
-            "UnifySchemas does not support duplicate field names in the schema: ",
-            field_name);
-      }
-      auto insertion_result = field_name_to_index.emplace(field_name, fields.size());
-      const auto& current_field = current_fields[0];
-      if (insertion_result.second) {
-        // This field is not in the first schema. So it will become nullable.
-        fields.push_back(current_field->WithNullable(true));
-      } else {
-        const size_t existing_field_index = insertion_result.first->second;
-        auto& existing_field = fields[existing_field_index];
-        ARROW_ASSIGN_OR_RAISE(existing_field,
-                              UnifyFields(existing_field, current_fields[0]));
-      }
+  SchemaBuilder builder{schemas[0], SchemaBuilder::MERGE};
+
+  for (size_t i = 1; i < schemas.size(); i++) {
+    const auto& schema = schemas[i];
+    if (!schema->HasUniqueFieldNames()) {
+      return Status::Invalid("Can't unify schema with duplicate field names.");
     }
+    RETURN_NOT_OK(builder.WithSchema(schema));
   }
 
-  return schema(std::move(fields))->WithMetadata(schemas[0]->metadata());
-}
+  return builder.Finish();
+}  // namespace arrow
 
 // ----------------------------------------------------------------------
 // Fingerprint computations

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -24,6 +24,7 @@
 #include <iosfwd>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "arrow/type_fwd.h"  // IWYU pragma: export
@@ -358,10 +359,40 @@ class ARROW_EXPORT Field : public detail::Fingerprintable {
   /// \brief Return a copy of this field with the replaced nullability.
   std::shared_ptr<Field> WithNullable(bool nullable) const;
 
+  /// \brief Merge the current field with a field of the same name.
+  ///
+  /// The two fields must be compatible, i.e:
+  ///   - have the same name
+  ///   - have the same type, or one or both are NullType
+  ///
+  /// Nullability will be promoted to the looser option (nullable if one is not
+  /// nullable). This method does _not_ accommodate type conversion minus
+  /// nullability. This includes integer widening, promotion from integer to
+  /// float, or conversion to or from boolean.
+  ///
+  /// The metadata of the current field is preserved.
+  Result<std::shared_ptr<Field>> WithField(const Field& other) const;
+  Result<std::shared_ptr<Field>> WithField(const std::shared_ptr<Field>& other) const;
+
   std::vector<std::shared_ptr<Field>> Flatten() const;
 
+  /// \brief Indicate if fields are equals.
+  ///
+  /// \param[in] other field to check equality with.
+  /// \param[in] check_metadata controls if it should check for metadata
+  ///            equality.
+  ///
+  /// \return true if fields are equal, false otherwise.
   bool Equals(const Field& other, bool check_metadata = true) const;
   bool Equals(const std::shared_ptr<Field>& other, bool check_metadata = true) const;
+
+  /// \brief Indicate if fields are compatibles.
+  ///
+  /// See the criteria of WithField.
+  ///
+  /// \return true if fields are compatible, false otherwise.
+  bool IsCompatibleWith(const Field& other) const;
+  bool IsCompatibleWith(const std::shared_ptr<Field>& other) const;
 
   /// \brief Return a string representation ot the field
   std::string ToString() const;
@@ -1319,6 +1350,7 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
 
   /// Returns true if all of the schema fields are equal
   bool Equals(const Schema& other, bool check_metadata = true) const;
+  bool Equals(const std::shared_ptr<Schema>& other, bool check_metadata = true) const;
 
   /// \brief Return the number of fields (columns) in the schema
   int num_fields() const;
@@ -1370,8 +1402,11 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   /// \brief Return copy of Schema without the KeyValueMetadata
   std::shared_ptr<Schema> RemoveMetadata() const;
 
-  /// \brief Indicates that Schema has non-empty KevValueMetadata
+  /// \brief Indicate that the Schema has non-empty KevValueMetadata
   bool HasMetadata() const;
+
+  /// \brief Indicate that the Schema has unique field names.
+  bool HasUniqueFieldNames() const;
 
  protected:
   std::string ComputeFingerprint() const override;
@@ -1546,6 +1581,97 @@ std::shared_ptr<Schema> schema(
 
 /// @}
 
+/// \brief Convenience class to incrementally construct/merge schemas.
+///
+/// This class amortizes the cost of validating field name conflicts by
+/// maintaining the mapping. The caller also controls the conflict resolution
+/// scheme.
+class SchemaBuilder {
+ public:
+  // Indicate how field conflict(s) should be resolved when building a schema. A
+  // conflict arise when a field is added to the builder and one or more field(s)
+  // with the same name already exists.
+  enum ConflictPolicy {
+    // Ignore the conflict and append the field. This is the default behavior of the
+    // Schema constructor and the `arrow::schema` factory function.
+    APPEND = 0,
+    // Replace the existing field with the newer one.
+    REPLACE,
+    // Merge the fields. See documentation of `Field::WithField`.
+    MERGE,
+    // Refuse the new field and error out.
+    ERROR,
+  };
+
+  /// \brief Construct an empty SchemaBuilder
+  explicit SchemaBuilder(ConflictPolicy conflict_policy = APPEND);
+  /// \brief Construct an SchemaBuilder from a list of fields
+  SchemaBuilder(std::vector<std::shared_ptr<Field>> fields,
+                ConflictPolicy conflict_policy = APPEND);
+  /// \brief Construct an SchemaBuilder from a schema, preserving the metadata
+  SchemaBuilder(const std::shared_ptr<Schema>& schema,
+                ConflictPolicy conflict_policy = APPEND);
+
+  /// \brief Return the conflict resolution method.
+  ConflictPolicy policy() const { return policy_; }
+
+  /// \brief Set the conflict resolution method.
+  void SetPolicy(ConflictPolicy resolution) { policy_ = resolution; }
+
+  /// \brief Add a field to the constructed schema.
+  ///
+  /// \param[in] field to add to the constructed Schema.
+  /// \return A failure if encountered.
+  Status WithField(const std::shared_ptr<Field>& field);
+
+  /// \brief Add multiple fields to the constructed schema.
+  ///
+  /// \param[in] fields to add to the constructed Schema.
+  /// \return The first failure encountered, if any.
+  Status WithFields(const std::vector<std::shared_ptr<Field>>& fields);
+
+  /// \brief Add fields of a Schema to the constructed Schema.
+  ///
+  /// \param[in] schema to take fields to add to the constructed Schema.
+  /// \return The first failure encountered, if any.
+  Status WithSchema(const std::shared_ptr<Schema>& schema);
+
+  /// \brief Add fields of multiple Schemas to the constructed Schema.
+  ///
+  /// \param[in] schemas to take fields to add to the constructed Schema.
+  /// \return The first failure encountered, if any.
+  Status WithSchemas(const std::vector<std::shared_ptr<Schema>>& schemas);
+
+  Status WithMetadata(const KeyValueMetadata& metadata);
+
+  /// \brief Return the constructed Schema.
+  ///
+  /// The builder internal state is not affected by invoking this method, i.e.
+  /// a single builder can yield multiple incrementally constructed schemas.
+  ///
+  /// \return the constructed schema.
+  Result<std::shared_ptr<Schema>> Finish() const;
+
+  /// \brief Merge schemas in a unified schema according to policy.
+  static Result<std::shared_ptr<Schema>> Merge(
+      const std::vector<std::shared_ptr<Schema>>& schemas, ConflictPolicy policy = MERGE);
+
+  /// \brief Indicate if schemas are compatbile to merge according to policy.
+  static Status AreCompatible(const std::vector<std::shared_ptr<Schema>>& schemas,
+                              ConflictPolicy policy = MERGE);
+
+  /// \brief Reset internal state with an empty schema (and metadata).
+  void Reset();
+
+ private:
+  std::vector<std::shared_ptr<Field>> fields_;
+  std::unordered_multimap<std::string, int> name_to_index_;
+  std::shared_ptr<KeyValueMetadata> metadata_;
+  ConflictPolicy policy_ = ConflictPolicy::APPEND;
+
+  Status AppendField(const std::shared_ptr<Field>& field);
+};
+
 /// \brief Unifies schemas by unifying fields by name and promoting Null fields.
 ///
 /// The resulting schema will contain the union of fields from all schemas.
@@ -1560,10 +1686,8 @@ std::shared_ptr<Schema> schema(
 /// Returns an error if:
 /// - Any input schema contains fields with duplicate names.
 /// - Fields of the same name are of incompatible types.
-ARROW_EXPORT
-Result<std::shared_ptr<Schema>> UnifySchemas(
+ARROW_EXPORT Result<std::shared_ptr<Schema>> UnifySchemas(
     const std::vector<std::shared_ptr<Schema>>& schemas);
-
 }  // namespace arrow
 
 #endif  // ARROW_TYPE_H


### PR DESCRIPTION
The SchemaBuilder class is introduced to merge/unify schemas in a controlled fashion.