### PR TITLE
ARROW-7425: [Java] PromotableWriter support writing FixedSizeList type data

### DIFF
--- a/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -116,6 +116,12 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
   }
 
   @Override
+  public ListWriter fixedSizeList(int listSize) {
+    fail("FixedSizeList");
+    return null;
+  }
+
+  @Override
   public StructWriter struct(String name) {
     fail("Struct");
     return null;

--- a/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
@@ -51,6 +51,16 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
    */
   abstract protected FieldWriter getWriter();
 
+  /**
+   * Set the arrowType for fixed list writer.
+   */
+  abstract protected void setFixedListArrowType(ArrowType arrowType);
+
+  /**
+   * Get the list type, MinorType.List or MinorType.FixedSizeList
+   */
+  abstract protected Types.MinorType getListType();
+
   @Override
   public void start() {
     getWriter(MinorType.STRUCT).start();
@@ -64,12 +74,12 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
 
   @Override
   public void startList() {
-    getWriter(MinorType.LIST).startList();
+    getWriter(getListType()).startList();
   }
 
   @Override
   public void endList() {
-    getWriter(MinorType.LIST).endList();
+    getWriter(getListType()).endList();
     setPosition(idx() + 1);
   }
 
@@ -101,7 +111,14 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
 
   @Override
   public ListWriter list() {
+    this.setFixedListArrowType(null);
     return getWriter(MinorType.LIST).list();
+  }
+
+  @Override
+  public ListWriter fixedSizeList(int listSize) {
+    this.setFixedListArrowType(new ArrowType.FixedSizeList(listSize));
+    return getWriter(MinorType.FIXED_SIZE_LIST).list();
   }
 
   @Override
@@ -134,7 +151,7 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
 
   @Override
   public ${capName}Writer ${lowerName}() {
-    return getWriter(MinorType.LIST).${lowerName}();
+    return getWriter(getListType()).${lowerName}();
   }
 
   </#list></#list>

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -70,6 +70,7 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     void endList();
     StructWriter struct();
     ListWriter list();
+    ListWriter fixedSizeList(int listSize);
     void copyReader(FieldReader reader);
 
     <#list vv.types as type><#list type.minor as minor>

--- a/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
@@ -16,8 +16,10 @@
  */
 
 import io.netty.buffer.ArrowBuf;
+import org.apache.arrow.vector.complex.writer.BaseWriter;
 import org.apache.arrow.vector.complex.writer.DecimalWriter;
 import org.apache.arrow.vector.holders.DecimalHolder;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 
 import java.lang.UnsupportedOperationException;
 import java.math.BigDecimal;
@@ -135,6 +137,13 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
 
   @Override
   public ListWriter list() {
+    writer.setFixedListArrowType(null);
+    return writer;
+  }
+
+  @Override
+  public BaseWriter.ListWriter fixedSizeList(int listSize) {
+    writer.setFixedListArrowType(new ArrowType.FixedSizeList(listSize));
     return writer;
   }
 

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -16,8 +16,10 @@
  */
 
 import io.netty.buffer.ArrowBuf;
+import org.apache.arrow.vector.complex.writer.BaseWriter;
 import org.apache.arrow.vector.complex.writer.DecimalWriter;
 import org.apache.arrow.vector.holders.DecimalHolder;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 
 import java.lang.UnsupportedOperationException;
 import java.math.BigDecimal;
@@ -134,6 +136,13 @@ public class UnionListWriter extends AbstractFieldWriter {
 
   @Override
   public ListWriter list() {
+    writer.setFixedListArrowType(null);
+    return writer;
+  }
+
+  @Override
+  public BaseWriter.ListWriter fixedSizeList(int listSize) {
+    writer.setFixedListArrowType(new ArrowType.FixedSizeList(listSize));
     return writer;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/PromotableWriter.java
@@ -29,6 +29,7 @@ import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 import org.apache.arrow.vector.holders.DecimalHolder;
+import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -53,6 +54,8 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
   private final NullableStructWriterFactory nullableStructWriterFactory;
   private int position;
   private static final int MAX_DECIMAL_PRECISION = 38;
+
+  private ArrowType fixedListType;
 
   private enum State {
     UNTYPED, SINGLE, UNION
@@ -206,7 +209,7 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
   }
 
   protected FieldWriter getWriter(MinorType type) {
-    return getWriter(type, null);
+    return getWriter(type, type == MinorType.FIXED_SIZE_LIST ? fixedListType : null);
   }
 
   protected FieldWriter getWriter(MinorType type, ArrowType arrowType) {
@@ -240,6 +243,14 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
 
   protected FieldWriter getWriter() {
     return writer;
+  }
+
+  protected void setFixedListArrowType(ArrowType arrowType) {
+    this.fixedListType = arrowType;
+  }
+
+  protected Types.MinorType getListType() {
+    return fixedListType == null ? MinorType.LIST : MinorType.FIXED_SIZE_LIST;
   }
 
   private FieldWriter promoteToUnion() {

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -94,6 +94,7 @@ import org.apache.arrow.vector.complex.impl.UInt1WriterImpl;
 import org.apache.arrow.vector.complex.impl.UInt2WriterImpl;
 import org.apache.arrow.vector.complex.impl.UInt4WriterImpl;
 import org.apache.arrow.vector.complex.impl.UInt8WriterImpl;
+import org.apache.arrow.vector.complex.impl.UnionFixedSizeListWriter;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
 import org.apache.arrow.vector.complex.impl.UnionWriter;
 import org.apache.arrow.vector.complex.impl.VarBinaryWriterImpl;
@@ -584,8 +585,7 @@ public class Types {
 
       @Override
       public FieldWriter getNewFieldWriter(ValueVector vector) {
-        throw new UnsupportedOperationException("FieldWriter not implemented for FixedSizeList " +
-          "type");
+        return new UnionFixedSizeListWriter((FixedSizeListVector) vector);
       }
     },
     UNION(new Union(Sparse, null)) {


### PR DESCRIPTION
Related to [ARROW-7425](https://issues.apache.org/jira/browse/ARROW-7425).

We have introduced writer API for FixedSizeListVector via ARROW-6079, but PromotableWriter’s support for it is incomplete.

For example, using UnionListWriter we could simply write List\<List\> type data, but for List\<FixedSizeList\> or FixedSizeList\<FixedSizeList\> it doesn’t work.

This issue is about to enhance the PromotableWriter support for FixedSizeList type and add tests to verify the cases mentioned above.