### PR TITLE
ARROW-7437: [Java] ReadChannel#readFully does not set writer index correctly

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/ReadChannel.java
@@ -53,11 +53,14 @@ public class ReadChannel implements AutoCloseable {
    * @throws IOException if nit enough bytes left to read
    */
   public int readFully(ByteBuffer buffer) throws IOException {
-    LOGGER.debug("Reading buffer with size: {}", buffer.remaining());
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Reading buffer with size: {}", buffer.remaining());
+    }
     int totalRead = 0;
     while (buffer.remaining() != 0) {
       int read = in.read(buffer);
-      if (read < 0) {
+      if (read == -1) {
+        this.bytesRead += totalRead;
         return totalRead;
       }
       totalRead += read;
@@ -79,7 +82,7 @@ public class ReadChannel implements AutoCloseable {
    */
   public int readFully(ArrowBuf buffer, int l) throws IOException {
     int n = readFully(buffer.nioBuffer(buffer.writerIndex(), l));
-    buffer.writerIndex(n);
+    buffer.writerIndex(buffer.writerIndex() + n);
     return n;
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -29,6 +29,8 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.Channels;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,6 +71,8 @@ import org.apache.arrow.vector.util.DictionaryUtility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
 
 import io.netty.buffer.ArrowBuf;
 
@@ -524,5 +528,45 @@ public class TestArrowReaderWriter {
 
     batch.close();
     vector.close();
+  }
+
+  @Test
+  public void testChannelReadFully() throws IOException {
+    final ByteBuffer buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+    buf.putInt(200);
+    buf.rewind();
+
+    try (ReadChannel channel = new ReadChannel(Channels.newChannel(new ByteBufferBackedInputStream(buf)));
+         ArrowBuf arrBuf = allocator.buffer(8)) {
+      arrBuf.setInt(0, 100);
+      arrBuf.writerIndex(4);
+      assertEquals(4, arrBuf.writerIndex());
+
+      int n = channel.readFully(arrBuf, 4);
+      assertEquals(4, n);
+      assertEquals(8, arrBuf.writerIndex());
+
+      assertEquals(100, arrBuf.getInt(0));
+      assertEquals(200, arrBuf.getInt(4));
+    }
+  }
+
+  @Test
+  public void testChannelReadFullyEos() throws IOException {
+    final ByteBuffer buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+    buf.putInt(10);
+    buf.rewind();
+
+    try (ReadChannel channel = new ReadChannel(Channels.newChannel(new ByteBufferBackedInputStream(buf)));
+         ArrowBuf arrBuf = allocator.buffer(8)) {
+      int n = channel.readFully(arrBuf.nioBuffer(0, 8));
+      assertEquals(4, n);
+
+      // the input has only 4 bytes, so the number of bytes read should be 4
+      assertEquals(4, channel.bytesRead());
+
+      // the first 4 bytes have been read successfully.
+      assertEquals(10, arrBuf.getInt(0));
+    }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -72,8 +72,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.util.ByteBufferBackedInputStream;
-
 import io.netty.buffer.ArrowBuf;
 
 public class TestArrowReaderWriter {
@@ -536,7 +534,7 @@ public class TestArrowReaderWriter {
     buf.putInt(200);
     buf.rewind();
 
-    try (ReadChannel channel = new ReadChannel(Channels.newChannel(new ByteBufferBackedInputStream(buf)));
+    try (ReadChannel channel = new ReadChannel(Channels.newChannel(new ByteArrayInputStream(buf.array())));
          ArrowBuf arrBuf = allocator.buffer(8)) {
       arrBuf.setInt(0, 100);
       arrBuf.writerIndex(4);
@@ -557,7 +555,7 @@ public class TestArrowReaderWriter {
     buf.putInt(10);
     buf.rewind();
 
-    try (ReadChannel channel = new ReadChannel(Channels.newChannel(new ByteBufferBackedInputStream(buf)));
+    try (ReadChannel channel = new ReadChannel(Channels.newChannel(new ByteArrayInputStream(buf.array())));
          ArrowBuf arrBuf = allocator.buffer(8)) {
       int n = channel.readFully(arrBuf.nioBuffer(0, 8));
       assertEquals(4, n);


### PR DESCRIPTION
1. The writer index should be incremented by the amount of data actually read.
2. When EOS is encounterned, the number of bytes read should be incremented before returning.