### PR TITLE
PARQUET-1720: [C++] JSONPrint not showing version correctly

### DIFF
--- a/cpp/src/parquet/printer.cc
+++ b/cpp/src/parquet/printer.cc
@@ -187,7 +187,7 @@ void ParquetFilePrinter::JSONPrint(std::ostream& stream, std::list<int> selected
   const FileMetaData* file_metadata = fileReader->metadata().get();
   stream << "{\n";
   stream << "  \"FileName\": \"" << filename << "\",\n";
-  stream << "  \"Version\": \"" << file_metadata->version() << "\",\n";
+  stream << "  \"Version\": \"" << ParquetVersionToString(file_metadata->version()) << "\",\n";
   stream << "  \"CreatedBy\": \"" << file_metadata->created_by() << "\",\n";
   stream << "  \"TotalRows\": \"" << file_metadata->num_rows() << "\",\n";
   stream << "  \"NumberOfRowGroups\": \"" << file_metadata->num_row_groups() << "\",\n";

--- a/cpp/src/parquet/printer.cc
+++ b/cpp/src/parquet/printer.cc
@@ -188,7 +188,7 @@ void ParquetFilePrinter::JSONPrint(std::ostream& stream, std::list<int> selected
   stream << "{\n";
   stream << "  \"FileName\": \"" << filename << "\",\n";
   stream << "  \"Version\": \"" << ParquetVersionToString(file_metadata->version())
-	 << "\",\n";
+         << "\",\n";
   stream << "  \"CreatedBy\": \"" << file_metadata->created_by() << "\",\n";
   stream << "  \"TotalRows\": \"" << file_metadata->num_rows() << "\",\n";
   stream << "  \"NumberOfRowGroups\": \"" << file_metadata->num_row_groups() << "\",\n";

--- a/cpp/src/parquet/printer.cc
+++ b/cpp/src/parquet/printer.cc
@@ -187,7 +187,8 @@ void ParquetFilePrinter::JSONPrint(std::ostream& stream, std::list<int> selected
   const FileMetaData* file_metadata = fileReader->metadata().get();
   stream << "{\n";
   stream << "  \"FileName\": \"" << filename << "\",\n";
-  stream << "  \"Version\": \"" << ParquetVersionToString(file_metadata->version()) << "\",\n";
+  stream << "  \"Version\": \"" << ParquetVersionToString(file_metadata->version())
+	 << "\",\n";
   stream << "  \"CreatedBy\": \"" << file_metadata->created_by() << "\",\n";
   stream << "  \"TotalRows\": \"" << file_metadata->num_rows() << "\",\n";
   stream << "  \"NumberOfRowGroups\": \"" << file_metadata->num_row_groups() << "\",\n";

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -328,7 +328,7 @@ Column 1
 TEST(TestJSONWithLocalFile, JSONOutput) {
   std::string json_output = R"###({
   "FileName": "alltypes_plain.parquet",
-  "Version": "0",
+  "Version": "1.0",
   "CreatedBy": "impala version 1.3.0-INTERNAL (build 8a48ddb1eff84592b3fc06bc6f51ec120e1fffc9)",
   "TotalRows": "8",
   "NumberOfRowGroups": "1",


### PR DESCRIPTION
Parquet JSONPrint not showing version correctly