### PR TITLE
ARROW-7096: [C++] Unified ConcatenateTables APIs

### DIFF
--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -552,7 +552,6 @@ garrow_table_concatenate(GArrowTable *table,
     auto arrow_other_table = garrow_table_get_raw(GARROW_TABLE(node->data));
     arrow_tables.push_back(arrow_other_table);
   }
-  std::shared_ptr<arrow::Table> arrow_concatenated_table;
   auto arrow_concatenated_table = arrow::ConcatenateTables(arrow_tables);
   if (garrow::check(error, arrow_concatenated_table, "[table][concatenate]")) {
     return garrow_table_new_raw(&arrow_concatenated_table.ValueOrDie());

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -553,9 +553,9 @@ garrow_table_concatenate(GArrowTable *table,
     arrow_tables.push_back(arrow_other_table);
   }
   std::shared_ptr<arrow::Table> arrow_concatenated_table;
-  auto status = arrow::ConcatenateTables(arrow_tables, &arrow_concatenated_table);
-  if (garrow_error_check(error, status, "[table][concatenate]")) {
-    return garrow_table_new_raw(&arrow_concatenated_table);
+  auto arrow_concatenated_table = arrow::ConcatenateTables(arrow_tables);
+  if (garrow::check(error, arrow_concatenated_table, "[table][concatenate]")) {
+    return garrow_table_new_raw(&arrow_concatenated_table.ValueOrDie());
   } else {
     return NULL;
   }

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -94,11 +94,14 @@ Result<std::shared_ptr<Field>> Field::MergeWith(const Field& other,
                            other.name());
   }
 
-  if (type()->Equals(other.type())) {
+  if (Equals(other, /*check_metadata=*/false)) {
     return Copy();
   }
 
   if (options.promote_nullability) {
+    if (type()->Equals(other.type())) {
+      return Copy()->WithNullable(nullable() || other.nullable());
+    }
     std::shared_ptr<Field> promoted = MaybePromoteNullTypes(*this, other);
     if (promoted) return promoted;
   }

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -98,7 +98,7 @@ Result<std::shared_ptr<Field>> Field::MergeWith(const Field& other,
     return Copy();
   }
 
-  if (options.promote_null_type) {
+  if (options.promote_nullability) {
     std::shared_ptr<Field> promoted = MaybePromoteNullTypes(*this, other);
     if (promoted) return promoted;
   }

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -40,8 +40,25 @@
 #include "arrow/visitor_inline.h"
 
 namespace arrow {
-
+namespace {
 using internal::checked_cast;
+
+// Merges `existing` and `other` if one of them is of NullType, otherwise
+// returns nullptr.
+//   - if `other` if of NullType or is nullable, the unified field will be nullable.
+//   - if `existing` is of NullType but other is not, the unified field will
+//     have `other`'s type and will be nullable
+std::shared_ptr<Field> MaybePromoteNullTypes(const Field& existing, const Field& other) {
+  if (existing.type()->id() != Type::NA && other.type()->id() != Type::NA) {
+    return nullptr;
+  }
+  if (existing.type()->id() == Type::NA) {
+    return other.WithNullable(true)->WithMetadata(existing.metadata());
+  }
+  // `other` must be null.
+  return existing.WithNullable(true);
+}
+}  // namespace
 
 Field::~Field() {}
 
@@ -70,30 +87,31 @@ std::shared_ptr<Field> Field::WithNullable(const bool nullable) const {
   return std::make_shared<Field>(name_, type_, nullable, metadata_);
 }
 
-Result<std::shared_ptr<Field>> Field::MergeWith(const Field& other) const {
+Result<std::shared_ptr<Field>> Field::MergeWith(const Field& other,
+                                                MergeOptions options) const {
   if (name() != other.name()) {
     return Status::Invalid("Field ", name(), " doesn't have the same name as ",
                            other.name());
   }
-  if (type()->id() == Type::NA) {
-    return other.WithNullable(true)->WithMetadata(metadata());
+
+  if (type()->Equals(other.type())) {
+    return Copy();
   }
-  if (other.type()->id() != Type::NA && !type()->Equals(other.type())) {
-    return Status::Invalid("Field ", name(),
-                           " has incompatible types: ", type()->ToString(), " vs ",
-                           other.type()->ToString());
+
+  if (options.promote_null_type) {
+    std::shared_ptr<Field> promoted = MaybePromoteNullTypes(*this, other);
+    if (promoted) return promoted;
   }
-  // At least one field is nullable thus the unified field should also be nullable.
-  if (other.type()->id() == Type::NA || other.nullable() != nullable()) {
-    return WithNullable(true);
-  }
-  return Copy();
+
+  return Status::Invalid("Unable to merge: Field ", name(),
+                         " has incompatible types: ", type()->ToString(), " vs ",
+                         other.type()->ToString());
 }
 
-Result<std::shared_ptr<Field>> Field::MergeWith(
-    const std::shared_ptr<Field>& other) const {
+Result<std::shared_ptr<Field>> Field::MergeWith(const std::shared_ptr<Field>& other,
+                                                MergeOptions options) const {
   DCHECK_NE(other, nullptr);
-  return MergeWith(*other);
+  return MergeWith(*other, options);
 }
 
 std::vector<std::shared_ptr<Field>> Field::Flatten() const {
@@ -759,14 +777,17 @@ std::vector<std::string> Schema::field_names() const {
 class SchemaBuilder::Impl {
  public:
   friend class SchemaBuilder;
-  Impl(ConflictPolicy policy) : policy_(policy) {}
+  Impl(ConflictPolicy policy, Field::MergeOptions field_merge_options)
+      : policy_(policy), field_merge_options_(field_merge_options) {}
 
   Impl(std::vector<std::shared_ptr<Field>> fields,
-       std::shared_ptr<const KeyValueMetadata> metadata, ConflictPolicy conflict_policy)
+       std::shared_ptr<const KeyValueMetadata> metadata, ConflictPolicy conflict_policy,
+       Field::MergeOptions field_merge_options)
       : fields_(std::move(fields)),
         name_to_index_(CreateNameToIndexMap(fields_)),
         metadata_(std::move(metadata)),
-        policy_(conflict_policy) {}
+        policy_(conflict_policy),
+        field_merge_options_(field_merge_options) {}
 
   Status AddField(const std::shared_ptr<Field>& field) {
     DCHECK_NE(field, nullptr);
@@ -830,28 +851,33 @@ class SchemaBuilder::Impl {
   std::unordered_multimap<std::string, int> name_to_index_;
   std::shared_ptr<const KeyValueMetadata> metadata_;
   ConflictPolicy policy_;
+  Field::MergeOptions field_merge_options_;
 };
 
-SchemaBuilder::SchemaBuilder(ConflictPolicy policy) {
-  impl_ = internal::make_unique<Impl>(policy);
+SchemaBuilder::SchemaBuilder(ConflictPolicy policy,
+                             Field::MergeOptions field_merge_options) {
+  impl_ = internal::make_unique<Impl>(policy, field_merge_options);
 }
 
 SchemaBuilder::SchemaBuilder(std::vector<std::shared_ptr<Field>> fields,
-                             ConflictPolicy policy) {
-  impl_ = internal::make_unique<Impl>(std::move(fields), nullptr, policy);
+                             ConflictPolicy policy,
+                             Field::MergeOptions field_merge_options) {
+  impl_ = internal::make_unique<Impl>(std::move(fields), nullptr, policy,
+                                      field_merge_options);
 }
 
-SchemaBuilder::~SchemaBuilder() {}
-
-SchemaBuilder::SchemaBuilder(const std::shared_ptr<Schema>& schema,
-                             ConflictPolicy policy) {
+SchemaBuilder::SchemaBuilder(const std::shared_ptr<Schema>& schema, ConflictPolicy policy,
+                             Field::MergeOptions field_merge_options) {
   std::shared_ptr<const KeyValueMetadata> metadata;
   if (schema->HasMetadata()) {
     metadata = schema->metadata()->Copy();
   }
 
-  impl_ = internal::make_unique<Impl>(schema->fields(), std::move(metadata), policy);
+  impl_ = internal::make_unique<Impl>(schema->fields(), std::move(metadata), policy,
+                                      field_merge_options);
 }
+
+SchemaBuilder::~SchemaBuilder() {}
 
 SchemaBuilder::ConflictPolicy SchemaBuilder::policy() const { return impl_->policy_; }
 
@@ -918,7 +944,8 @@ std::shared_ptr<Schema> schema(std::vector<std::shared_ptr<Field>>&& fields,
 }
 
 Result<std::shared_ptr<Schema>> UnifySchemas(
-    const std::vector<std::shared_ptr<Schema>>& schemas) {
+    const std::vector<std::shared_ptr<Schema>>& schemas,
+    const Field::MergeOptions field_merge_options) {
   if (schemas.empty()) {
     return Status::Invalid("Must provide at least one schema to unify.");
   }
@@ -927,7 +954,7 @@ Result<std::shared_ptr<Schema>> UnifySchemas(
     return Status::Invalid("Can't unify schema with duplicate field names.");
   }
 
-  SchemaBuilder builder{schemas[0], SchemaBuilder::CONFLICT_MERGE};
+  SchemaBuilder builder{schemas[0], SchemaBuilder::CONFLICT_MERGE, field_merge_options};
 
   for (size_t i = 1; i < schemas.size(); i++) {
     const auto& schema = schemas[i];

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -366,7 +366,7 @@ class ARROW_EXPORT Field : public detail::Fingerprintable {
     /// The unified field will be of the other type and become nullable.
     /// Nullability will be promoted to the looser option (nullable if one is not
     /// nullable).
-    bool promote_null_type = true;
+    bool promote_nullability = true;
 
     static MergeOptions Defaults() { return MergeOptions(); }
   };

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -358,21 +358,33 @@ class ARROW_EXPORT Field : public detail::Fingerprintable {
   /// \brief Return a copy of this field with the replaced nullability.
   std::shared_ptr<Field> WithNullable(bool nullable) const;
 
+  /// \brief Options that control the behavior of `MergeWith`.
+  /// Options are to be added to allow type conversions, including integer
+  /// widening, promotion from integer to float, or conversion to or from boolean.
+  struct MergeOptions {
+    /// If true, a Field of NullType can be unified with a Field of another type.
+    /// The unified field will be of the other type and become nullable.
+    /// Nullability will be promoted to the looser option (nullable if one is not
+    /// nullable).
+    bool promote_null_type = true;
+
+    static MergeOptions Defaults() { return MergeOptions(); }
+  };
+
   /// \brief Merge the current field with a field of the same name.
   ///
   /// The two fields must be compatible, i.e:
   ///   - have the same name
-  ///   - have the same type, or one or both are NullType
+  ///   - have the same type, or of compatible types according to `options`.
   ///
-  /// Nullability will be promoted to the looser option (nullable if one is not
-  /// nullable). This method does _not_ accommodate type conversion minus
-  /// nullability. This includes integer widening, promotion from integer to
-  /// float, or conversion to or from boolean.
   ///
   /// The metadata of the current field is preserved; the metadata of the other
   /// field is discarded.
-  Result<std::shared_ptr<Field>> MergeWith(const Field& other) const;
-  Result<std::shared_ptr<Field>> MergeWith(const std::shared_ptr<Field>& other) const;
+  Result<std::shared_ptr<Field>> MergeWith(
+      const Field& other, MergeOptions options = MergeOptions::Defaults()) const;
+  Result<std::shared_ptr<Field>> MergeWith(
+      const std::shared_ptr<Field>& other,
+      MergeOptions options = MergeOptions::Defaults()) const;
 
   std::vector<std::shared_ptr<Field>> Flatten() const;
 
@@ -1607,20 +1619,30 @@ class ARROW_EXPORT SchemaBuilder {
     CONFLICT_IGNORE,
     // Replace the existing field with the newer one.
     CONFLICT_REPLACE,
-    // Merge the fields. See documentation of `Field::MergeWith`.
+    // Merge the fields. The merging behavior can be controlled by `Field::MergeOptions`
+    // specified at construction time. Also see documentation of `Field::MergeWith`.
     CONFLICT_MERGE,
     // Refuse the new field and error out.
     CONFLICT_ERROR
   };
 
   /// \brief Construct an empty SchemaBuilder
-  explicit SchemaBuilder(ConflictPolicy conflict_policy = CONFLICT_APPEND);
+  /// `field_merge_options` is only effecitive when `conflict_policy` == `CONFLICT_MERGE`.
+  SchemaBuilder(
+      ConflictPolicy conflict_policy = CONFLICT_APPEND,
+      Field::MergeOptions field_merge_options = Field::MergeOptions::Defaults());
   /// \brief Construct a SchemaBuilder from a list of fields
-  SchemaBuilder(std::vector<std::shared_ptr<Field>> fields,
-                ConflictPolicy conflict_policy = CONFLICT_APPEND);
+  /// `field_merge_options` is only effecitive when `conflict_policy` == `CONFLICT_MERGE`.
+  SchemaBuilder(
+      std::vector<std::shared_ptr<Field>> fields,
+      ConflictPolicy conflict_policy = CONFLICT_APPEND,
+      Field::MergeOptions field_merge_options = Field::MergeOptions::Defaults());
   /// \brief Construct a SchemaBuilder from a schema, preserving the metadata
-  SchemaBuilder(const std::shared_ptr<Schema>& schema,
-                ConflictPolicy conflict_policy = CONFLICT_APPEND);
+  /// `field_merge_options` is only effecitive when `conflict_policy` == `CONFLICT_MERGE`.
+  SchemaBuilder(
+      const std::shared_ptr<Schema>& schema,
+      ConflictPolicy conflict_policy = CONFLICT_APPEND,
+      Field::MergeOptions field_merge_options = Field::MergeOptions::Defaults());
 
   /// \brief Return the conflict resolution method.
   ConflictPolicy policy() const;
@@ -1683,12 +1705,13 @@ class ARROW_EXPORT SchemaBuilder {
   Status AppendField(const std::shared_ptr<Field>& field);
 };
 
-/// \brief Unifies schemas by unifying fields by name and promoting Null fields.
+/// \brief Unifies schemas by merging fields by name.
+///
+/// The behavior of field merging can be controlled via `Field::MergeOptions`.
 ///
 /// The resulting schema will contain the union of fields from all schemas.
-/// Fields with the same name will be unified:
-/// - They are expected to be of the same type, or of Null type. The unified
-///   field will be of that same type.
+/// Fields with the same name will be merged. See `Field::MergeOptions`.
+/// - They are expected to be mergeable under provided `field_merge_options`.
 /// - The unified field will inherit the metadata from the schema where
 ///   that field is first defined.
 /// - The first N fields in the schema will be ordered the same as the
@@ -1696,10 +1719,12 @@ class ARROW_EXPORT SchemaBuilder {
 /// The resulting schema will inherit its metadata from the first input schema.
 /// Returns an error if:
 /// - Any input schema contains fields with duplicate names.
-/// - Fields of the same name are of incompatible types.
+/// - Fields of the same name are not mergeable.
 ARROW_EXPORT
 Result<std::shared_ptr<Schema>> UnifySchemas(
-    const std::vector<std::shared_ptr<Schema>>& schemas);
+    const std::vector<std::shared_ptr<Schema>>& schemas,
+    Field::MergeOptions field_merge_options = Field::MergeOptions::Defaults());
+
 }  // namespace arrow
 
 #endif  // ARROW_TYPE_H

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1905,12 +1905,12 @@ TEST(TestArrowReadWrite, ReadSingleRowGroup) {
 
   std::shared_ptr<Table> concatenated;
 
-  ASSERT_OK_AND_ASSIGN(concatenated, ConcatenateTables({r1, r2}));
+  ASSERT_OK_AND_ASSIGN(concatenated, ::arrow::ConcatenateTables({r1, r2}));
   AssertTablesEqual(*concatenated, *table, /*same_chunk_layout=*/false);
 
   ASSERT_TRUE(table->Equals(*r3));
   ASSERT_TRUE(r2->Equals(*r4));
-  ASSERT_OK_AND_ASSIGN(concatenated, ConcatenateTables({r1, r4}));
+  ASSERT_OK_AND_ASSIGN(concatenated, ::arrow::ConcatenateTables({r1, r4}));
   ASSERT_TRUE(table->Equals(*concatenated));
 }
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1905,12 +1905,12 @@ TEST(TestArrowReadWrite, ReadSingleRowGroup) {
 
   std::shared_ptr<Table> concatenated;
 
-  ASSERT_OK(ConcatenateTables({r1, r2}, &concatenated));
+  ASSERT_OK_AND_ASSIGN(concatenated, ConcatenateTables({r1, r2}));
   AssertTablesEqual(*concatenated, *table, /*same_chunk_layout=*/false);
 
   ASSERT_TRUE(table->Equals(*r3));
   ASSERT_TRUE(r2->Equals(*r4));
-  ASSERT_OK(ConcatenateTables({r1, r4}, &concatenated));
+  ASSERT_OK_AND_ASSIGN(concatenated, ConcatenateTables({r1, r4}));
   ASSERT_TRUE(table->Equals(*concatenated));
 }
 

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -227,7 +227,7 @@ static void BM_ReadIndividualRowGroups(::benchmark::State& state) {
     }
 
     std::shared_ptr<::arrow::Table> final_table;
-    EXIT_NOT_OK(ConcatenateTables(tables, &final_table));
+    PARQUET_ASSIGN_OR_THROW(final_table, ConcatenateTables(tables));
   }
   SetBytesProcessed<true, Int64Type>(state);
 }

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -318,6 +318,12 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int scale()
 
     cdef cppclass CField" arrow::Field":
+        cppclass CMergeOptions "arrow::Field::MergeOptions":
+            c_bool promote_null_type
+
+            @staticmethod
+            CMergeOptions Defaults()
+
         const c_string& name()
         shared_ptr[CDataType] type()
         c_bool nullable()
@@ -796,11 +802,17 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     shared_ptr[CScalar] MakeScalar[Value](Value value)
 
-    CStatus ConcatenateTables(const vector[shared_ptr[CTable]]& tables,
-                              shared_ptr[CTable]* result)
+    cdef cppclass CConcatenateTablesOptions" arrow::ConcatenateTablesOptions":
+        c_bool unify_schemas
+        CField.CMergeOptions field_merge_options
 
-    CResult[shared_ptr[CTable]] ConcatenateTablesWithPromotion(
-        const vector[shared_ptr[CTable]]& tables, CMemoryPool* pool)
+        @staticmethod
+        CConcatenateTablesOptions Defaults()
+
+    CResult[shared_ptr[CTable]] ConcatenateTables(
+        const vector[shared_ptr[CTable]]& tables,
+        CConcatenateTablesOptions options,
+        CMemoryPool* memory_pool)
 
 cdef extern from "arrow/builder.h" namespace "arrow" nogil:
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -319,7 +319,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
     cdef cppclass CField" arrow::Field":
         cppclass CMergeOptions "arrow::Field::MergeOptions":
-            c_bool promote_null_type
+            c_bool promote_nullability
 
             @staticmethod
             CMergeOptions Defaults()

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1773,14 +1773,15 @@ def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
         shared_ptr[CTable] c_result_table
         CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
         Table table
+        CConcatenateTablesOptions options = (
+            CConcatenateTablesOptions.Defaults())
 
     for table in tables:
         c_tables.push_back(table.sp_table)
+
     with nogil:
-        if promote:
-            c_result_table = GetResultValue(
-                ConcatenateTablesWithPromotion(c_tables, pool))
-        else:
-            check_status(ConcatenateTables(c_tables, &c_result_table))
+        options.unify_schemas = promote
+        c_result_table = GetResultValue(
+            ConcatenateTables(c_tables, options, pool))
 
     return pyarrow_wrap_table(c_result_table)


### PR DESCRIPTION
* Introduced a UnifySchemasOptions.
  - Currently the only option is to control whether to promote a Null
    column to a non-Null. (If turned off, UnifySchemas will only union the
    columns and raise an error on any mismatched types).
  - We can introduce more switches to control whether to promote
    integers, floats, etc (through casting).
  - We can also allow strategy of metadata merging to be specified.
* Introduced a ConcatenateTablesOptions.
  - Currently the only option is to control whether to unify schemas.
* For now PromoteTableToSchema won't accept any options. I'm not sure if
  this is desirable. But my vision is to make it do the best effort to
  cast the columns to the types specified in the desired schema. It's
  the caller's responsibility to make sure the desired schema is "safe"
  (or not).

Tests have not been updated fully. Test cases need to be added for UnifySchemas where promote_null == false. The ConcatenateTables test cases and ContenateTablesWithPromotion  test caes may need to be merged (i.e. using the same test fixture).

The python APIs / tests have not been changed.  (do we want to introduce the counter-part of those options class in the python API?)