### PR TITLE
ARROW-7420: [C++] Migrate tensor related APIs to Result-returning version

### DIFF
--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -290,11 +290,9 @@ garrow_input_stream_read_tensor(GArrowInputStream *input_stream,
 {
   auto arrow_input_stream = garrow_input_stream_get_raw(input_stream);
 
-  std::shared_ptr<arrow::Tensor> arrow_tensor;
-  auto status = arrow::ipc::ReadTensor(arrow_input_stream.get(),
-                                       &arrow_tensor);
-  if (garrow_error_check(error, status, "[input-stream][read-tensor]")) {
-    return garrow_tensor_new_raw(&arrow_tensor);
+  auto arrow_tensor = arrow::ipc::ReadTensor(arrow_input_stream.get());
+  if (garrow::check(error, arrow_tensor, "[input-stream][read-tensor]")) {
+    return garrow_tensor_new_raw(&(arrow_tensor.ValueOrDie()));
   } else {
     return NULL;
   }

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -147,12 +147,12 @@ Status WriteRecordBatchMessage(const int64_t length, const int64_t body_length,
                                const std::vector<BufferMetadata>& buffers,
                                std::shared_ptr<Buffer>* out);
 
-Status WriteTensorMessage(const Tensor& tensor, const int64_t buffer_start_offset,
-                          std::shared_ptr<Buffer>* out);
+Result<std::shared_ptr<Buffer>> WriteTensorMessage(const Tensor& tensor,
+                                                   const int64_t buffer_start_offset);
 
-Status WriteSparseTensorMessage(const SparseTensor& sparse_tensor, int64_t body_length,
-                                const std::vector<BufferMetadata>& buffers,
-                                std::shared_ptr<Buffer>* out);
+Result<std::shared_ptr<Buffer>> WriteSparseTensorMessage(
+    const SparseTensor& sparse_tensor, int64_t body_length,
+    const std::vector<BufferMetadata>& buffers);
 
 Status WriteFileFooter(const Schema& schema, const std::vector<FileBlock>& dictionaries,
                        const std::vector<FileBlock>& record_batches,
@@ -164,8 +164,8 @@ Status WriteDictionaryMessage(const int64_t id, const int64_t length,
                               const std::vector<BufferMetadata>& buffers,
                               std::shared_ptr<Buffer>* out);
 
-static inline Status WriteFlatbufferBuilder(flatbuffers::FlatBufferBuilder& fbb,
-                                            std::shared_ptr<Buffer>* out) {
+static inline Result<std::shared_ptr<Buffer>> WriteFlatbufferBuilder(
+    flatbuffers::FlatBufferBuilder& fbb) {
   int32_t size = fbb.GetSize();
 
   std::shared_ptr<Buffer> result;
@@ -173,8 +173,7 @@ static inline Status WriteFlatbufferBuilder(flatbuffers::FlatBufferBuilder& fbb,
 
   uint8_t* dst = result->mutable_data();
   memcpy(dst, fbb.GetBufferPointer(), size);
-  *out = result;
-  return Status::OK();
+  return result;
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -95,7 +95,7 @@ TEST(TestMessage, SerializeTo) {
                                     body_length));
 
   std::shared_ptr<Buffer> metadata;
-  ASSERT_OK(internal::WriteFlatbufferBuilder(fbb, &metadata));
+  ASSERT_OK_AND_ASSIGN(metadata, internal::WriteFlatbufferBuilder(fbb));
 
   std::string body = "abcdef";
 
@@ -1081,7 +1081,7 @@ class TestTensorRoundTrip : public ::testing::Test, public IpcTestFixture {
     ASSERT_OK(mmap_->Seek(0));
 
     std::shared_ptr<Tensor> result;
-    ASSERT_OK(ReadTensor(mmap_.get(), &result));
+    ASSERT_OK_AND_ASSIGN(result, ReadTensor(mmap_.get()));
 
     ASSERT_EQ(result->data()->size(), expected_body_length);
     ASSERT_TRUE(tensor.Equals(*result));
@@ -1167,7 +1167,7 @@ class TestSparseTensorRoundTrip : public ::testing::Test, public IpcTestFixture 
     ASSERT_OK(mmap_->Seek(0));
 
     std::shared_ptr<SparseTensor> result;
-    ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
+    ASSERT_OK_AND_ASSIGN(result, ReadSparseTensor(mmap_.get()));
     ASSERT_EQ(SparseTensorFormat::COO, result->format_id());
 
     const auto& resulted_sparse_index =
@@ -1210,7 +1210,7 @@ class TestSparseTensorRoundTrip : public ::testing::Test, public IpcTestFixture 
     ASSERT_OK(mmap_->Seek(0));
 
     std::shared_ptr<SparseTensor> result;
-    ASSERT_OK(ReadSparseTensor(mmap_.get(), &result));
+    ASSERT_OK_AND_ASSIGN(result, ReadSparseTensor(mmap_.get()));
 
     constexpr auto expected_format_id =
         std::is_same<SparseIndexType, SparseCSRIndex>::value ? SparseTensorFormat::CSR

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -259,34 +259,30 @@ Status ReadRecordBatch(const Buffer& metadata, const std::shared_ptr<Schema>& sc
 /// \brief Read arrow::Tensor as encapsulated IPC message in file
 ///
 /// \param[in] file an InputStream pointed at the start of the message
-/// \param[out] out the read tensor
-/// \return Status
+/// \return the read tensor
 ARROW_EXPORT
-Status ReadTensor(io::InputStream* file, std::shared_ptr<Tensor>* out);
+Result<std::shared_ptr<Tensor>> ReadTensor(io::InputStream* file);
 
 /// \brief EXPERIMENTAL: Read arrow::Tensor from IPC message
 ///
 /// \param[in] message a Message containing the tensor metadata and body
-/// \param[out] out the read tensor
-/// \return Status
+/// \return the read tensor
 ARROW_EXPORT
-Status ReadTensor(const Message& message, std::shared_ptr<Tensor>* out);
+Result<std::shared_ptr<Tensor>> ReadTensor(const Message& message);
 
 /// \brief EXPERIMETNAL: Read arrow::SparseTensor as encapsulated IPC message in file
 ///
 /// \param[in] file an InputStream pointed at the start of the message
-/// \param[out] out the read sparse tensor
-/// \return Status
+/// \return the read sparse tensor
 ARROW_EXPORT
-Status ReadSparseTensor(io::InputStream* file, std::shared_ptr<SparseTensor>* out);
+Result<std::shared_ptr<SparseTensor>> ReadSparseTensor(io::InputStream* file);
 
 /// \brief EXPERIMENTAL: Read arrow::SparseTensor from IPC message
 ///
 /// \param[in] message a Message containing the tensor metadata and body
-/// \param[out] out the read sparse tensor
-/// \return Status
+/// \return the read sparse tensor
 ARROW_EXPORT
-Status ReadSparseTensor(const Message& message, std::shared_ptr<SparseTensor>* out);
+Result<std::shared_ptr<SparseTensor>> ReadSparseTensor(const Message& message);
 
 namespace internal {
 
@@ -294,18 +290,15 @@ namespace internal {
 
 /// \brief EXPERIMENTAL: Read arrow::SparseTensorFormat::type from a metadata
 /// \param[in] metadata a Buffer containing the sparse tensor metadata
-/// \param[out] buffer_count the returned count of the body buffers
-/// \return Status
+/// \return the count of the body buffers
 ARROW_EXPORT
-Status ReadSparseTensorBodyBufferCount(const Buffer& metadata, size_t* buffer_count);
+Result<size_t> ReadSparseTensorBodyBufferCount(const Buffer& metadata);
 
 /// \brief EXPERIMENTAL: Read arrow::SparseTensor from an IpcPayload
 /// \param[in] payload a IpcPayload contains a serialized SparseTensor
-/// \param[out] out the returned SparseTensor
-/// \return Status
+/// \return the read sparse tensor
 ARROW_EXPORT
-Status ReadSparseTensorPayload(const IpcPayload& payload,
-                               std::shared_ptr<SparseTensor>* out);
+Result<std::shared_ptr<SparseTensor>> ReadSparseTensorPayload(const IpcPayload& payload);
 
 }  // namespace internal
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -625,7 +625,7 @@ namespace {
 Status WriteTensorHeader(const Tensor& tensor, io::OutputStream* dst,
                          int32_t* metadata_length) {
   std::shared_ptr<Buffer> metadata;
-  RETURN_NOT_OK(internal::WriteTensorMessage(tensor, 0, &metadata));
+  ARROW_ASSIGN_OR_RAISE(metadata, internal::WriteTensorMessage(tensor, 0));
   IpcOptions options;
   options.alignment = kTensorAlignment;
   return WriteMessage(*metadata, options, dst, metadata_length);
@@ -720,7 +720,7 @@ Status GetTensorMessage(const Tensor& tensor, MemoryPool* pool,
   }
 
   std::shared_ptr<Buffer> metadata;
-  RETURN_NOT_OK(internal::WriteTensorMessage(*tensor_to_write, 0, &metadata));
+  ARROW_ASSIGN_OR_RAISE(metadata, internal::WriteTensorMessage(*tensor_to_write, 0));
   out->reset(new Message(metadata, tensor_to_write->data()));
   return Status::OK();
 }
@@ -761,8 +761,8 @@ class SparseTensorSerializer {
   }
 
   Status SerializeMetadata(const SparseTensor& sparse_tensor) {
-    return WriteSparseTensorMessage(sparse_tensor, out_->body_length, buffer_meta_,
-                                    &out_->metadata);
+    return WriteSparseTensorMessage(sparse_tensor, out_->body_length, buffer_meta_)
+        .Value(&out_->metadata);
   }
 
   Status Assemble(const SparseTensor& sparse_tensor) {

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -33,7 +33,7 @@ namespace arrow {
 // SparseIndex
 
 Status SparseIndex::ValidateShape(const std::vector<int64_t>& shape) const {
-  if (!std::all_of(shape.begin(), shape.end(), [](int64_t x) { return x > 0; })) {
+  if (!std::all_of(shape.begin(), shape.end(), [](int64_t x) { return x >= 0; })) {
     return Status::Invalid("Shape elements must be positive");
   }
 

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -251,7 +251,7 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
       return Status::Invalid("shape length is too long");
     }
 
-    if (indptr_->shape()[0] == shape[0] + 1) {
+    if (indptr_->shape()[0] == shape[static_cast<int64_t>(kCompressedAxis)] + 1) {
       return Status::OK();
     }
 

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -105,7 +105,7 @@ inline Status CheckTensorValidity(const std::shared_ptr<DataType>& type,
   if (!data) {
     return Status::Invalid("Null data is supplied");
   }
-  if (!std::all_of(shape.begin(), shape.end(), [](int64_t x) { return x > 0; })) {
+  if (!std::all_of(shape.begin(), shape.end(), [](int64_t x) { return x >= 0; })) {
     return Status::Invalid("Shape elements must be positive");
   }
   return Status::OK();

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1211,7 +1211,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
                         int32_t* metadata_length,
                         int64_t* body_length)
 
-    CStatus ReadTensor(CInputStream* stream, shared_ptr[CTensor]* out)
+    CResult[shared_ptr[CTensor]] ReadTensor(CInputStream* stream)
 
     CStatus ReadRecordBatch(const CMessage& message,
                             const shared_ptr[CSchema]& schema,

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -529,7 +529,7 @@ def read_tensor(source):
 
     c_stream = nf.get_input_stream().get()
     with nogil:
-        check_status(ReadTensor(c_stream, &sp_tensor))
+        sp_tensor = GetResultValue(ReadTensor(c_stream))
     return pyarrow_wrap_tensor(sp_tensor)
 
 


### PR DESCRIPTION
I'd like to modify tensor-related APIs, both internal and public, to use `Result<T>` for the return values.

Moreover, I've fixed a bug of `SparseCSXIndex::ValidateShape` for CSC format.