### PR TITLE
ARROW-7457: [Doc] fix typos

### DIFF
--- a/docs/source/cpp/arrays.rst
+++ b/docs/source/cpp/arrays.rst
@@ -164,7 +164,7 @@ but unlike a simple array, a chunked array does not require the entire sequence
 to be physically contiguous in memory.  Also, the constituents of a chunked array
 need not have the same size, but they must all have the same data type.
 
-A chunked array is constructed by agregating any number of arrays.  Here we'll
+A chunked array is constructed by aggregating any number of arrays.  Here we'll
 build a chunked array with the same logical values as in the example above,
 but in two separate chunks::
 

--- a/docs/source/developers/cpp.rst
+++ b/docs/source/developers/cpp.rst
@@ -180,11 +180,11 @@ boolean flags to ``cmake``.
   ``ARROW_FILESYSTEM``, ``ARROW_HDFS``, and ``ARROW_JSON``.
 * ``-DARROW_S3=ON``: Support for Amazon S3-compatible filesystems
 * ``-DARROW_WITH_BZ2=ON``: Build support for BZ2 compression
-* ``-DARROW_WITH_ZLIB=ON``: Build suport for zlib (gzip) compression
-* ``-DARROW_WITH_LZ4=ON``: Build suport for lz4 compression
-* ``-DARROW_WITH_SNAPPY=ON``: Build suport for Snappy compression
-* ``-DARROW_WITH_ZSTD=ON``: Build suport for ZSTD compression
-* ``-DARROW_WITH_BROTLI=ON``: Build suport for Brotli compression
+* ``-DARROW_WITH_ZLIB=ON``: Build support for zlib (gzip) compression
+* ``-DARROW_WITH_LZ4=ON``: Build support for lz4 compression
+* ``-DARROW_WITH_SNAPPY=ON``: Build support for Snappy compression
+* ``-DARROW_WITH_ZSTD=ON``: Build support for ZSTD compression
+* ``-DARROW_WITH_BROTLI=ON``: Build support for Brotli compression
 
 Some features of the core Arrow shared library can be switched off for improved
 build times if they are not required for your application:
@@ -277,7 +277,7 @@ offline builds.
 Boost-related Options
 ~~~~~~~~~~~~~~~~~~~~~
 
-We depend on some Boost C++ libraries for cross-platform suport. In most cases,
+We depend on some Boost C++ libraries for cross-platform support. In most cases,
 the Boost version available in your package manager may be new enough, and the
 build system will find it automatically. If you have Boost installed in a
 non-standard location, you can specify it by passing
@@ -398,7 +398,7 @@ functions.
 
 When using ``clang`` and building with
 ``-DBUILD_WARNING_LEVEL=CHECKIN``, the ``-Wdocumentation`` flag is
-used which checks for some common documnetation inconsistencies, like
+used which checks for some common documentation inconsistencies, like
 documenting some, but not all function parameters with ``\param``. See
 the `LLVM documentation warnings section
 <https://releases.llvm.org/7.0.1/tools/clang/docs/DiagnosticsReference.html#wdocumentation>`_
@@ -621,7 +621,7 @@ Once the build has finished, you can generate ABI reports using:
 The above version number is freely selectable. As we want to compare versions,
 you should now ``git checkout`` the version you want to compare it to and re-run
 the above command using a different version number. Once both reports are
-generated, you can build a comparision report using
+generated, you can build a comparison report using
 
 .. code-block:: shell
 
@@ -661,7 +661,7 @@ System Setup
 ~~~~~~~~~~~~
 
 Microsoft provides the free Visual Studio Community edition. When doing
-development in the the shell, you must initialize the development
+development in the shell, you must initialize the development
 environment.
 
 For Visual Studio 2015, execute the following batch script:
@@ -900,11 +900,11 @@ tests can be made with there individual make targets).
 
    cd $EXTRACT_BOOST_DIRECTORY
    .\bootstrap.bat
-   @rem This is for static libraries needed for static_crt_build in appvyor
+   @rem This is for static libraries needed for static_crt_build in appveyor
    .\b2 link=static -with-filesystem -with-regex -with-system install
    @rem this should put libraries and headers in c:\Boost
 
-4. Activate ananaconda/miniconda:
+4. Activate anaconda/miniconda:
 
 .. code-block:: shell
 

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -63,7 +63,7 @@ These two steps are mandatory and must be executed in order.
 
    .. note::
 
-      This step requires the the pyarrow library is installed
+      This step requires the pyarrow library is installed
       in your python environment.  One way to accomplish
       this is to follow the build instructions at :ref:`python-development`
       and then run ``python setup.py install`` in arrow/python

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -376,7 +376,7 @@ To debug the C++ libraries with gdb while running the Python unit
    gdb --args python -m pytest pyarrow/tests/test_to_run.py -k $TEST_TO_MATCH
 
 To set a breakpoint, use the same gdb syntax that you would when
-debugging a C++ unitttest, for example:
+debugging a C++ unittest, for example:
 
 .. code-block:: shell
 

--- a/docs/source/format/Other.rst
+++ b/docs/source/format/Other.rst
@@ -33,7 +33,7 @@ The ``Tensor`` message types provides a way to write a
 multidimensional array of fixed-size values (such as a NumPy ndarray).
 
 When writing a standalone encapsulated tensor message, we use the
-encapulated IPC format defined in the :ref:`Columnar Specification
+encapsulated IPC format defined in the :ref:`Columnar Specification
 <format_columnar>`, but additionally align the starting offset of the
 tensor body to be a multiple of 64 bytes.::
 
@@ -48,7 +48,7 @@ Sparse Tensor
 are generally almost all zeros.
 
 When writing a standalone encapsulated sparse tensor message, we use
-the encapulated IPC format defined in the :ref:`Columnar Specification
+the encapsulated IPC format defined in the :ref:`Columnar Specification
 <format_columnar>`, but additionally align the starting offsets of the
 sparse index and the sparse tensor body (if writing to a shared memory
 region) to be multiples of 64 bytes: ::

--- a/docs/source/python/extending.rst
+++ b/docs/source/python/extending.rst
@@ -218,7 +218,7 @@ Cython API
 
 The Cython API more or less mirrors the C++ API, but the calling convention
 can be different as required by Cython.  In Cython, you don't need to
-initialize the API as that will be handled automaticalled by the ``cimport``
+initialize the API as that will be handled automatically by the ``cimport``
 directive.
 
 .. note::

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -51,7 +51,7 @@ Defining extension types ("user-defined types")
 -----------------------------------------------
 
 Arrow has the notion of extension types in the metadata specification as a
-possiblity to extend the built-in types. This is done by annotating any of the
+possibility to extend the built-in types. This is done by annotating any of the
 built-in Arrow logical types (the "storage type") with a custom type name and
 optional serialized representation ("ARROW:extension:name" and
 "ARROW:extension:metadata" keys in the Field’s custom_metadata of an IPC
@@ -249,7 +249,7 @@ Using the pandas period type from above as example, this would look like::
 
 Secondly, the pandas ``ExtensionDtype`` on its turn needs to have the
 ``__from_arrow__`` method implemented: a method that given a pyarrow Array
-or ChunkedArray of the extesion type can construct the corresponding
+or ChunkedArray of the extension type can construct the corresponding
 pandas ``ExtensionArray``. This method should have the following signature::
 
 

--- a/docs/source/python/timestamps.rst
+++ b/docs/source/python/timestamps.rst
@@ -24,7 +24,7 @@ Arrow/Pandas Timestamps
 
 Arrow timestamps are stored as a 64-bit integer with column metadata to
 associate a time unit (e.g. milliseconds, microseconds, or nanoseconds), and an
-optional time zone.  Pandas (`Timestamp`) uses a 64-bit integer represesenting
+optional time zone.  Pandas (`Timestamp`) uses a 64-bit integer representing
 nanoseconds and an optional time zone.
 Python/Pandas timestamp types without a associated time zone are referred to as
 "Time Zone Naive".  Python/Pandas timestamp types with an associated time zone are


### PR DESCRIPTION
This PR fixes typos in files under `docs` directory.