### PR TITLE
ARROW-7458: [GLib] Fix incorrect build dependency in Makefile

### DIFF
--- a/c_glib/arrow-glib/Makefile.am
+++ b/c_glib/arrow-glib/Makefile.am
@@ -193,8 +193,8 @@ libarrow_glib_la_SOURCES =			\
 	$(libarrow_glib_la_cpp_internal_headers)
 
 BUILT_SOURCES =					\
-	$(libarrow_glib_la_genearted_headers)	\
-	$(libarrow_glib_la_genearted_sources)	\
+	$(libarrow_glib_la_generated_headers)	\
+	$(libarrow_glib_la_generated_sources)	\
 	stamp-enums.c				\
 	stamp-enums.h
 


### PR DESCRIPTION
This PR fixes incorrect file dependencies `$(libarrow_glib_la_genearted_headers)` and `$(libarrow_glib_la_genearted_sources)`  for BUILT_SOURCES.