### PR TITLE
ARROW-7459: [Python] Fix document lint error

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1359,7 +1359,7 @@ Parameters
 table : pyarrow.Table
 where: string or pyarrow.NativeFile
 row_group_size: int
-    The number of rows per rowgroup 
+    The number of rows per rowgroup
 {0}
 """.format(_parquet_writer_arg_docs)
 


### PR DESCRIPTION
This is included by e519853fbfd0241d87572d8b333a8ab34f02b401.

I missed this. Sorry.