### PR TITLE
ARROW-7460: [Rust] Improve some kernel performance

### DIFF
--- a/rust/arrow-flight/Cargo.toml
+++ b/rust/arrow-flight/Cargo.toml
@@ -26,16 +26,15 @@ repository = "https://github.com/apache/arrow"
 license = "Apache-2.0"
 
 [dependencies]
-tonic = "0.1.0-alpha.6"
+tonic = "0.1.0-beta.1"
 bytes = "0.4"
 prost = "0.5"
 prost-derive = "0.5"
-tokio = "=0.2.0-alpha.6"
-futures-preview = { version = "=0.3.0-alpha.19", default-features = false, features = ["alloc"]}
-async-stream = "0.1.2"
+tokio = {version = "0.2", features = ["macros"]}
+futures = { version = "0.3", default-features = false, features = ["alloc"]}
 
 [build-dependencies]
-tonic-build = "0.1.0-alpha.6"
+tonic-build = "0.1.0-beta.1"
 
 [lib]
 name = "flight"

--- a/rust/arrow-flight/examples/server.rs
+++ b/rust/arrow-flight/examples/server.rs
@@ -15,14 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use tokio::sync::mpsc;
+use std::pin::Pin;
+
+use futures::Stream;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 
 use flight::{
-    server::FlightService, server::FlightServiceServer, Action, ActionType, Criteria,
-    Empty, FlightData, FlightDescriptor, FlightInfo, HandshakeRequest, HandshakeResponse,
-    PutResult, SchemaResult, Ticket,
+    flight_service_server::FlightService, flight_service_server::FlightServiceServer,
+    Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
+    HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
 };
 
 #[derive(Clone)]
@@ -30,12 +32,20 @@ pub struct FlightServiceImpl {}
 
 #[tonic::async_trait]
 impl FlightService for FlightServiceImpl {
-    type HandshakeStream = mpsc::Receiver<Result<HandshakeResponse, Status>>;
-    type ListFlightsStream = mpsc::Receiver<Result<FlightInfo, Status>>;
-    type DoGetStream = mpsc::Receiver<Result<FlightData, Status>>;
-    type DoPutStream = mpsc::Receiver<Result<PutResult, Status>>;
-    type DoActionStream = mpsc::Receiver<Result<flight::Result, Status>>;
-    type ListActionsStream = mpsc::Receiver<Result<ActionType, Status>>;
+    type HandshakeStream = Pin<
+        Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send + Sync + 'static>,
+    >;
+    type ListFlightsStream =
+        Pin<Box<dyn Stream<Item = Result<FlightInfo, Status>> + Send + Sync + 'static>>;
+    type DoGetStream =
+        Pin<Box<dyn Stream<Item = Result<FlightData, Status>> + Send + Sync + 'static>>;
+    type DoPutStream =
+        Pin<Box<dyn Stream<Item = Result<PutResult, Status>> + Send + Sync + 'static>>;
+    type DoActionStream = Pin<
+        Box<dyn Stream<Item = Result<flight::Result, Status>> + Send + Sync + 'static>,
+    >;
+    type ListActionsStream =
+        Pin<Box<dyn Stream<Item = Result<ActionType, Status>> + Send + Sync + 'static>>;
 
     async fn handshake(
         &self,

--- a/rust/arrow/benches/comparison_kernels.rs
+++ b/rust/arrow/benches/comparison_kernels.rs
@@ -51,57 +51,25 @@ pub fn neq_no_simd(size: usize) {
 pub fn lt_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(
-        compare_op(&arr_a, &arr_b, |a, b| match (a, b) {
-            (None, None) => false,
-            (None, _) => true,
-            (_, None) => false,
-            (Some(aa), Some(bb)) => aa < bb,
-        })
-        .unwrap(),
-    );
+    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a < b).unwrap());
 }
 
 fn lt_eq_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(
-        compare_op(&arr_a, &arr_b, |a, b| match (a, b) {
-            (None, None) => true,
-            (None, _) => true,
-            (_, None) => false,
-            (Some(aa), Some(bb)) => aa <= bb,
-        })
-        .unwrap(),
-    );
+    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a <= b).unwrap());
 }
 
 pub fn gt_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(
-        compare_op(&arr_a, &arr_b, |a, b| match (a, b) {
-            (None, None) => false,
-            (None, _) => false,
-            (_, None) => true,
-            (Some(aa), Some(bb)) => aa > bb,
-        })
-        .unwrap(),
-    );
+    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a > b).unwrap());
 }
 
 fn gt_eq_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(
-        compare_op(&arr_a, &arr_b, |a, b| match (a, b) {
-            (None, None) => true,
-            (None, _) => false,
-            (_, None) => true,
-            (Some(aa), Some(bb)) => aa >= bb,
-        })
-        .unwrap(),
-    );
+    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a >= b).unwrap());
 }
 
 fn eq_simd(size: usize) {

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -35,11 +35,13 @@ use num::{One, Zero};
 use crate::array::*;
 #[cfg(feature = "simd")]
 use crate::bitmap::Bitmap;
+use crate::buffer::Buffer;
 #[cfg(feature = "simd")]
 use crate::buffer::MutableBuffer;
 #[cfg(feature = "simd")]
 use crate::compute::util::{apply_bin_op_to_option_bitmap, simd_load_set_invalid};
 use crate::datatypes;
+use crate::datatypes::ToByteSlice;
 use crate::error::{ArrowError, Result};
 
 /// Helper function to perform math lambda function on values from two arrays. If either
@@ -59,16 +61,28 @@ where
             "Cannot perform math operation on arrays of different length".to_string(),
         ));
     }
-    let mut b = PrimitiveBuilder::<T>::new(left.len());
+
+    let null_bit_buffer = apply_bin_op_to_option_bitmap(
+        left.data().null_bitmap(),
+        right.data().null_bitmap(),
+        |a, b| a & b,
+    )?;
+
+    let mut values = Vec::with_capacity(left.len());
     for i in 0..left.len() {
-        let index = i;
-        if left.is_null(i) || right.is_null(i) {
-            b.append_null()?;
-        } else {
-            b.append_value(op(left.value(index), right.value(index))?)?;
-        }
+        values.push(op(left.value(i), right.value(i))?);
     }
-    Ok(b.finish())
+
+    let data = ArrayData::new(
+        T::get_data_type(),
+        left.len(),
+        None,
+        null_bit_buffer,
+        left.offset(),
+        vec![Buffer::from(values.to_byte_slice())],
+        vec![],
+    );
+    Ok(PrimitiveArray::<T>::from(Arc::new(data)))
 }
 
 /// SIMD vectorized version of `math_op` above.

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -27,7 +27,6 @@ use std::mem;
 use std::ops::{Add, Div, Mul, Sub};
 #[cfg(feature = "simd")]
 use std::slice::from_raw_parts_mut;
-#[cfg(feature = "simd")]
 use std::sync::Arc;
 
 use num::{One, Zero};
@@ -38,8 +37,9 @@ use crate::bitmap::Bitmap;
 use crate::buffer::Buffer;
 #[cfg(feature = "simd")]
 use crate::buffer::MutableBuffer;
+use crate::compute::util::apply_bin_op_to_option_bitmap;
 #[cfg(feature = "simd")]
-use crate::compute::util::{apply_bin_op_to_option_bitmap, simd_load_set_invalid};
+use crate::compute::util::simd_load_set_invalid;
 use crate::datatypes;
 use crate::datatypes::ToByteSlice;
 use crate::error::{ArrowError, Result};

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -22,16 +22,12 @@
 //! `RUSTFLAGS="-C target-feature=+avx2"` for example.  See the documentation
 //! [here](https://doc.rust-lang.org/stable/core/arch/) for more information.
 
-#[cfg(feature = "simd")]
 use std::sync::Arc;
 
 use crate::array::*;
 use crate::buffer::Buffer;
-#[cfg(feature = "simd")]
 use crate::compute::util::apply_bin_op_to_option_bitmap;
-use crate::datatypes::{ArrowNumericType, ToByteSlice};
-#[cfg(feature = "simd")]
-use crate::datatypes::{BooleanType, DataType};
+use crate::datatypes::{ArrowNumericType, BooleanType, DataType, ToByteSlice};
 use crate::error::{ArrowError, Result};
 
 /// Helper function to perform boolean lambda function on values from two arrays, this


### PR DESCRIPTION
This removes the null checks on arithmetic and comparison kernels, in order to simplify the kernels and allow for LLVM to autovectorise the remaining simple loops.

Although `for loop`s are often slower than iterators (due to bounds checks), we do not perform bounds checking when accessing array values.
This results in performance being as good as what we might get with iterator support.

Another observation from my benchmarking is that the kernels are now as fast as their SIMD equivalents (on my 2012-13 Haswell).