### PR TITLE
ARROW-7463 : [Doc] fix a broken link and typo

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -29,7 +29,7 @@ This document is intended to provide adequate detail to create a new
 implementation of the columnar format without the aid of an existing
 implementation. We utilize Google's `Flatbuffers`_ project for
 metadata serialization, so it will be necessary to refer to the
-project's `Flatbuffers protocol definition files <FlatbuffersFiles>`_
+project's `Flatbuffers protocol definition files`_
 while reading this document.
 
 The columnar format has some key features:
@@ -112,7 +112,7 @@ the different physical layouts defined by Arrow:
   encoding.
 * **Struct**: a nested layout consisting of a collection of named
   child **fields** each having the same length but possibly different
-  types
+  types.
 * **Sparse** and **Dense Union**: a nested layout representing a
   sequence of values, each of which can have type chosen from a
   collection of child array types.
@@ -187,7 +187,7 @@ each array slot.
 Whether any array slot is valid (non-null) is encoded in the respective bits of
 this bitmap. A 1 (set bit) for index ``j`` indicates that the value is not null,
 while a 0 (bit not set) indicates that it is null. Bitmaps are to be
-initialized to be all unset at allocation time (this includes padding).::
+initialized to be all unset at allocation time (this includes padding): ::
 
     is_valid[j] -> bitmap[j / 8] & (1 << (j % 8))
 
@@ -284,7 +284,7 @@ Variable-size Binary Layout
 
 Each value in this layout consists of 0 or more bytes. While primitive
 arrays have a single values buffer, variable-size binary have an
-**offsets** buffer and **data** buffer
+**offsets** buffer and **data** buffer.
 
 The offsets buffer contains `length + 1` signed integers (either
 32-bit or 64-bit, depending on the logical type), which encode the
@@ -577,9 +577,9 @@ having the values: ``[{f=1.2}, null, {f=3.4}, {i=5}]``
 
     * Offset buffer:
 
-      |Byte 0-3 | Byte 4-7    | Byte 8-11 | Byte 12-15 | Bytes 16-63 |
-      |---------|-------------|-----------|------------|-------------|
-      | 0       | unspecified | 1         | 0          | unspecified |
+      |Bytes 0-3 | Bytes 4-7   | Bytes 8-11 | Bytes 12-15 | Bytes 16-63 |
+      |----------|-------------|------------|-------------|-------------|
+      | 0        | unspecified | 1          | 0           | unspecified |
 
     * Children arrays:
       * Field-0 array (f: float):
@@ -1037,7 +1037,7 @@ batches, each having a single field. The complete semantic schema for a
 sequence of record batches, therefore, consists of the schema along with all of
 the dictionaries. The dictionary types are found in the schema, so it is
 necessary to read the schema to first determine the dictionary types so that
-the dictionaries can be properly interpreted. ::
+the dictionaries can be properly interpreted: ::
 
     table DictionaryBatch {
       id: long;
@@ -1201,7 +1201,7 @@ References
 * Apache Drill Documentation - `Value Vectors`_
 
 .. _Flatbuffers: http://github.com/google/flatbuffers
-.. _FlatbuffersFiles: https://github.com/apache/arrow/tree/master/format
+.. _Flatbuffers protocol definition files: https://github.com/apache/arrow/tree/master/format
 .. _Schema.fbs: https://github.com/apache/arrow/blob/master/format/Schema.fbs
 .. _Message.fbs: https://github.com/apache/arrow/blob/master/format/Message.fbs
 .. _least-significant bit (LSB) numbering: https://en.wikipedia.org/wiki/Bit_numbering

--- a/docs/source/format/Integration.rst
+++ b/docs/source/format/Integration.rst
@@ -23,7 +23,7 @@ Integration Testing
 A JSON representation of Arrow columnar data is provided for
 cross-language integration testing purposes.
 
-The high level structure of a JSON integration test files is as follows
+The high level structure of a JSON integration test files is as follows:
 
 **Data file** ::
 

--- a/docs/source/format/Other.rst
+++ b/docs/source/format/Other.rst
@@ -35,7 +35,7 @@ multidimensional array of fixed-size values (such as a NumPy ndarray).
 When writing a standalone encapsulated tensor message, we use the
 encapsulated IPC format defined in the :ref:`Columnar Specification
 <format_columnar>`, but additionally align the starting offset of the
-tensor body to be a multiple of 64 bytes.::
+tensor body to be a multiple of 64 bytes: ::
 
     <metadata prefix and metadata>
     <PADDING>

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -259,5 +259,5 @@ pandas ``ExtensionArray``. This method should have the following signature::
         def __from_arrow__(self, array: pyarrow.Array/ChunkedArray) -> pandas.ExtensionArray:
             ...
 
-This way, you can control the conversion of an pyarrow ``Array`` of your pyarrow
+This way, you can control the conversion of a pyarrow ``Array`` of your pyarrow
 extension type to a pandas ``ExtensionArray`` that can be stored in a DataFrame.

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -25,7 +25,7 @@ namespace org.apache.arrow.flatbuf;
 /// ----------------------------------------------------------------------
 /// EXPERIMENTAL: Data structures for sparse tensors
 
-/// Coodinate (COO) format of sparse tensor index.
+/// Coordinate (COO) format of sparse tensor index.
 ///
 /// COO's index list are represented as a NxM matrix,
 /// where N is the number of non-zero values,


### PR DESCRIPTION
This PR fixes a broken link, typos, and missing periods under `docs` directory.
