### PR TITLE
[Java] Revert a wrong typo fix

### DIFF
--- a/java/flight/src/main/java/org/apache/arrow/flight/FlightServerMiddleware.java
+++ b/java/flight/src/main/java/org/apache/arrow/flight/FlightServerMiddleware.java
@@ -87,7 +87,7 @@ public interface FlightServerMiddleware {
   void onCallCompleted(CallStatus status);
 
   /**
-   * Callback for when an RPC method implementation throws a uncaught exception.
+   * Callback for when an RPC method implementation throws an uncaught exception.
    *
    * <p>May be called multiple times, and may be called before or after {@link #onCallCompleted(CallStatus)}.
    * Generally, an uncaught exception will end the call with a error {@link CallStatus}, and will be reported to {@link


### PR DESCRIPTION
This is a follow-up change of ARROW-7461.
This PR reverts a part of changes in #6087 by addressing [a comment](https://github.com/apache/arrow/pull/6087#discussion_r360747158) by @liyafan82