### PR TITLE
ARROW-7464: [C++] Refine CpuInfo singleton with std::call_once

### DIFF
--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -183,14 +183,11 @@ bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name) {
 CpuInfo::CpuInfo() : hardware_flags_(0), num_cores_(1), model_name_("unknown") {}
 
 std::unique_ptr<CpuInfo> g_cpu_info;
-static std::mutex cpuinfo_mutex;
+static std::once_flag cpuinfo_once;
 
 CpuInfo* CpuInfo::GetInstance() {
-  std::lock_guard<std::mutex> lock(cpuinfo_mutex);
-  if (!g_cpu_info) {
-    g_cpu_info.reset(new CpuInfo);
-    g_cpu_info->Init();
-  }
+  std::call_once(cpuinfo_once,
+                 [](){ g_cpu_info.reset(new CpuInfo); g_cpu_info->Init(); });
   return g_cpu_info.get();
 }
 

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -186,8 +186,10 @@ std::unique_ptr<CpuInfo> g_cpu_info;
 static std::once_flag cpuinfo_once;
 
 CpuInfo* CpuInfo::GetInstance() {
-  std::call_once(cpuinfo_once,
-                 [](){ g_cpu_info.reset(new CpuInfo); g_cpu_info->Init(); });
+  std::call_once(cpuinfo_once, []() {
+    g_cpu_info.reset(new CpuInfo);
+    g_cpu_info->Init();
+  });
   return g_cpu_info.get();
 }
 

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -183,10 +183,10 @@ bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name) {
 CpuInfo::CpuInfo() : hardware_flags_(0), num_cores_(1), model_name_("unknown") {}
 
 std::unique_ptr<CpuInfo> g_cpu_info;
-static std::once_flag cpuinfo_once;
+static std::once_flag cpuinfo_initialized;
 
 CpuInfo* CpuInfo::GetInstance() {
-  std::call_once(cpuinfo_once, []() {
+  std::call_once(cpuinfo_initialized, []() {
     g_cpu_info.reset(new CpuInfo);
     g_cpu_info->Init();
   });


### PR DESCRIPTION
CpuInfo singleton is created and initialized on first invocation of
[CpuInfo::GetInstance()](https://github.com/apache/arrow/blob/master/cpp/src/arrow/util/cpu_info.cc#L188-L195). All calls afterwards return reference to the
same instance. Current code uses std::mutex to make sure that CpuInfo
is created only once, but it introduces unnecessary overhead for later
calls. Concurrent threads getting the created instance should not block
each other.

Replace std::mutex with std::call_once to fix this issue.

References:
[1] https://en.cppreference.com/w/cpp/thread/call_once
[2] http://www.modernescpp.com/index.php/thread-safe-initialization-of-data