### PR TITLE
ARROW-7467: [Java] ComplexCopier does incorrect copy for Map nullable info

### DIFF
--- a/java/vector/src/main/codegen/templates/ComplexCopier.java
+++ b/java/vector/src/main/codegen/templates/ComplexCopier.java
@@ -85,10 +85,6 @@ public class ComplexCopier {
           writer.start();
           for(String name : reader){
             FieldReader childReader = reader.reader(name);
-            if (writer instanceof UnionMapWriter) {
-              final boolean nullable = childReader.getField().isNullable();
-              ((UnionMapWriter) writer).writer.setAddVectorAsNullable(nullable);
-            }
             if(childReader.isSet()){
               writeValue(childReader, getStructWriterForReader(childReader, writer, name));
             }

--- a/java/vector/src/main/codegen/templates/ComplexCopier.java
+++ b/java/vector/src/main/codegen/templates/ComplexCopier.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import org.apache.arrow.vector.complex.impl.UnionMapWriter;
 import org.apache.arrow.vector.complex.writer.FieldWriter;
 
 <@pp.dropOutputFile />
@@ -63,6 +64,10 @@ public class ComplexCopier {
           writer.start();
           for(String name : reader){
             FieldReader childReader = reader.reader(name);
+            if (writer instanceof UnionMapWriter) {
+              final boolean nullable = childReader.getField().isNullable();
+              ((UnionMapWriter) writer).writer.setAddVectorAsNullable(nullable);
+            }
             if(childReader.isSet()){
               writeValue(childReader, getStructWriterForReader(childReader, writer, name));
             }

--- a/java/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -98,18 +98,6 @@ public class UnionMapWriter extends UnionListWriter {
     entryWriter = struct();
   }
 
-  @Override
-  public void start() {
-    writer.setAddVectorAsNullable(false);
-    writer.start();
-  }
-
-  @Override
-  public void end() {
-    writer.setAddVectorAsNullable(true);
-    super.end();
-  }
-
   /** Start writing a map that consists of 1 or more entries. */
   public void startMap() {
     startList();

--- a/java/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -98,6 +98,18 @@ public class UnionMapWriter extends UnionListWriter {
     entryWriter = struct();
   }
 
+  @Override
+  public void start() {
+    writer.setAddVectorAsNullable(false);
+    writer.start();
+  }
+
+  @Override
+  public void end() {
+    writer.setAddVectorAsNullable(true);
+    super.end();
+  }
+
   /** Start writing a map that consists of 1 or more entries. */
   public void startMap() {
     startList();

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
@@ -114,7 +114,7 @@ public class FieldType {
     if (!(obj instanceof FieldType)) {
       return false;
     }
-    Field that = (Field) obj;
+    FieldType that = (FieldType) obj;
     return Objects.equals(this.isNullable(), that.isNullable()) &&
         Objects.equals(this.getType(), that.getType()) &&
         Objects.equals(this.getDictionary(), that.getDictionary()) &&

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -17,7 +17,6 @@
 
 package org.apache.arrow.vector.complex.impl;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -156,9 +155,7 @@ public class TestComplexCopier {
       to.setValueCount(COUNT);
 
       // validate equals
-      assertTrue(VectorEqualsVisitor.vectorEquals(from, to, null));
-      assertEquals(from.getField().getFieldType(), to.getField().getFieldType());
-
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to, TYPE_COMPARATOR));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -20,11 +20,8 @@ package org.apache.arrow.vector.complex.impl;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.function.BiFunction;
-
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.compare.VectorEqualsVisitor;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -43,9 +40,6 @@ public class TestComplexCopier {
 
   private static final int COUNT = 100;
 
-  private static final BiFunction<ValueVector, ValueVector, Boolean> TYPE_COMPARATOR =
-      (v1, v2) -> v1.getField().getType().equals(v2.getField().getType());
-
   @Before
   public void init() {
     allocator = new RootAllocator(Long.MAX_VALUE);
@@ -58,8 +52,8 @@ public class TestComplexCopier {
 
   @Test
   public void testCopyFixedSizeListVector() {
-    try (FixedSizeListVector from = FixedSizeListVector.empty("from", 3, allocator);
-         FixedSizeListVector to = FixedSizeListVector.empty("to", 3, allocator)) {
+    try (FixedSizeListVector from = FixedSizeListVector.empty("v", 3, allocator);
+         FixedSizeListVector to = FixedSizeListVector.empty("v", 3, allocator)) {
 
       from.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
       to.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
@@ -86,15 +80,15 @@ public class TestComplexCopier {
       }
 
       // validate equals
-      assertTrue(VectorEqualsVisitor.vectorEquals(from, to, TYPE_COMPARATOR));
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
 
     }
   }
 
   @Test
   public void testInvalidCopyFixedSizeListVector() {
-    try (FixedSizeListVector from = FixedSizeListVector.empty("from", 3, allocator);
-         FixedSizeListVector to = FixedSizeListVector.empty("to", 2, allocator)) {
+    try (FixedSizeListVector from = FixedSizeListVector.empty("v", 3, allocator);
+         FixedSizeListVector to = FixedSizeListVector.empty("v", 2, allocator)) {
 
       from.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
       to.addOrGetVector(FieldType.nullable(Types.MinorType.INT.getType()));
@@ -122,8 +116,8 @@ public class TestComplexCopier {
 
   @Test
   public void testCopyMapVector() {
-    try (final MapVector from = MapVector.empty("from", allocator, false);
-         final MapVector to = MapVector.empty("to", allocator, false)) {
+    try (final MapVector from = MapVector.empty("v", allocator, false);
+         final MapVector to = MapVector.empty("v", allocator, false)) {
 
       from.allocateNew();
 
@@ -155,14 +149,14 @@ public class TestComplexCopier {
       to.setValueCount(COUNT);
 
       // validate equals
-      assertTrue(VectorEqualsVisitor.vectorEquals(from, to, TYPE_COMPARATOR));
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
     }
   }
 
   @Test
   public void testCopyListVector() {
-    try (ListVector from = ListVector.empty("from", allocator);
-         ListVector to = ListVector.empty("to", allocator)) {
+    try (ListVector from = ListVector.empty("v", allocator);
+         ListVector to = ListVector.empty("v", allocator)) {
 
       UnionListWriter listWriter = from.getWriter();
       listWriter.allocate();
@@ -201,7 +195,7 @@ public class TestComplexCopier {
       to.setValueCount(COUNT);
 
       // validate equals
-      assertTrue(VectorEqualsVisitor.vectorEquals(from, to, TYPE_COMPARATOR));
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
 
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.vector.complex.impl;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -155,7 +156,8 @@ public class TestComplexCopier {
       to.setValueCount(COUNT);
 
       // validate equals
-      assertTrue(VectorEqualsVisitor.vectorEquals(from, to, TYPE_COMPARATOR));
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to, null));
+      assertEquals(from.getField().getFieldType(), to.getField().getFieldType());
 
     }
   }


### PR DESCRIPTION
Related to [ARROW-7467](https://issues.apache.org/jira/browse/ARROW-7467).

The MapVector and its 'value' vector are nullable, and its structVector and 'key' vector are non-nullable.
However, the MapVector generated by ComplexCopier has all nullable fields which is not correct.