### PR TITLE
ARROW-5949: [Rust] Implement Dictionary Array

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1679,7 +1679,7 @@ impl From<(Vec<(Field, ArrayRef)>, Buffer, usize)> for StructArray {
 ///     use arrow::datatypes::Int8Type;
 ///     let test = vec!["a", "a", "b", "c"];
 ///     let array : DictionaryArray<Int8Type> = test.iter().map(|&x| if x == "b" {None} else {Some(x)}).collect();
-///     assert_eq!(array.keys().collect::<Vec<Option<i8>>>(), vec![Some(1), Some(1), Some(0), Some(2)]);
+///     assert_eq!(array.keys().collect::<Vec<Option<i8>>>(), vec![Some(0), Some(0), None, Some(1)]);
 /// ```
 ///
 /// Example without nullable data:
@@ -1819,8 +1819,7 @@ impl<T: ArrowPrimitiveType> FromIterator<Option<&'static str>> for DictionaryArr
         let (lower, _) = iter.size_hint();
         let key_builder = PrimitiveBuilder::<T>::new(lower);
         let value_builder = StringBuilder::new(256);
-        // Note: "true" here reserves one value element for null.
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder, true);
+        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         for i in iter {
             if let Some(i) = i {
                 // Note: impl ... for Result<DictionaryArray<T>> fails with
@@ -1842,8 +1841,7 @@ impl<T: ArrowPrimitiveType> FromIterator<&'static str> for DictionaryArray<T> {
         let (lower, _) = iter.size_hint();
         let key_builder = PrimitiveBuilder::<T>::new(lower);
         let value_builder = StringBuilder::new(256);
-        // Note: "true" here reserves one value element for null.
-        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder, false);
+        let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         for i in iter {
             builder.append(i).expect("Unable to append a value to a dictionary array.");
         }
@@ -3247,7 +3245,7 @@ mod tests {
             .map(|&x| if x == "b" { None } else { Some(x) })
             .collect();
         assert_eq!(
-            "DictionaryArray {keys: [Some(1), Some(1), Some(0), Some(2)] values: StringArray\n[\n  null,\n  \"a\",\n  \"c\",\n]}\n",
+            "DictionaryArray {keys: [Some(0), Some(0), None, Some(1)] values: StringArray\n[\n  \"a\",\n  \"c\",\n]}\n",
             format!("{:?}", array)
         );
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1722,7 +1722,7 @@ impl DictionaryArray {
         1
     }
 
-    // Get a key for various primitive types.
+    /// Get a key for various primitive types.
     fn key<T: Copy>(&self, i: usize) -> T {
         unsafe {
             let ptr: *const T = mem::transmute(self.raw_values.get());

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1731,7 +1731,7 @@ impl DictionaryArray {
         }
     }
 
-    // Get a zero-copy slice of keys for various primitive types.
+    /// Get a zero-copy slice of keys for various primitive types.
     fn key_slice<T>(&self) -> &[T] {
         let raw = unsafe {
             let ptr: *const T = mem::transmute(self.raw_values.get());

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -2366,7 +2366,7 @@ mod tests {
         // Construct a buffer for value offsets, for the nested array:
         let keys = Buffer::from(&[2_i16, 3, 4].to_byte_slice());
 
-        // Construct a list array from the above two
+        // Construct a dictionary array from the above two
         let key_type = DataType::Int16;
         let value_type = DataType::Int8;
         let dict_data_type =

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1825,9 +1825,9 @@ impl<T: ArrowPrimitiveType> FromIterator<Option<&'static str>> for DictionaryArr
             if let Some(i) = i {
                 // Note: impl ... for Result<DictionaryArray<T>> fails with
                 // error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
-                builder.append(i).unwrap();
+                builder.append(i).expect("Unable to append a value to a dictionary array.");
             } else {
-                builder.append_null().unwrap();
+                builder.append_null().expect("Unable to append a null value to a dictionary array.");
             }
         }
 
@@ -1845,7 +1845,7 @@ impl<T: ArrowPrimitiveType> FromIterator<&'static str> for DictionaryArray<T> {
         // Note: "true" here reserves one value element for null.
         let mut builder = StringDictionaryBuilder::new(key_builder, value_builder, false);
         for i in iter {
-            builder.append(i).unwrap();
+            builder.append(i).expect("Unable to append a value to a dictionary array.");
         }
 
         builder.finish()

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -164,7 +164,7 @@ pub fn make_array(data: ArrayDataRef) -> ArrayRef {
         DataType::FixedSizeList(_, _) => {
             Arc::new(FixedSizeListArray::from(data)) as ArrayRef
         }
-        DataType::Dictionary((ref key_type, _)) => match key_type.as_ref() {
+        DataType::Dictionary(ref key_type, _) => match key_type.as_ref() {
             DataType::Int8 => {
                 Arc::new(DictionaryArray::<Int8Type>::from(data)) as ArrayRef
             }
@@ -1794,7 +1794,7 @@ impl<T: ArrowPrimitiveType> From<ArrayDataRef> for DictionaryArray<T> {
         let raw_values = data.buffers()[0].raw_data();
         let dtype: &DataType = data.data_type();
         let values = make_array(data.child_data()[0].clone());
-        if let DataType::Dictionary(_) = dtype {
+        if let DataType::Dictionary(_, _) = dtype {
             Self {
                 data: data,
                 raw_values: RawPtrBox::new(raw_values as *const T::Native),
@@ -2332,7 +2332,7 @@ mod tests {
         let key_type = DataType::Int16;
         let value_type = DataType::Int8;
         let dict_data_type =
-            DataType::Dictionary((Box::new(key_type), Box::new(value_type)));
+            DataType::Dictionary(Box::new(key_type), Box::new(value_type));
         let dict_data = ArrayData::builder(dict_data_type.clone())
             .len(3)
             .add_buffer(keys.clone())

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1823,15 +1823,17 @@ impl<T: ArrowPrimitiveType> Array for DictionaryArray<T> {
 
 impl<T: ArrowPrimitiveType> fmt::Debug for DictionaryArray<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        const MAX_LEN : usize = 10;
-        let keys : Vec<_> = self.iter_keys().take(MAX_LEN).collect();
-        let elipsis = if self.iter_keys().count() > MAX_LEN {"..."} else {""};
+        const MAX_LEN: usize = 10;
+        let keys: Vec<_> = self.iter_keys().take(MAX_LEN).collect();
+        let elipsis = if self.iter_keys().count() > MAX_LEN {
+            "..."
+        } else {
+            ""
+        };
         write!(
             f,
             "DictionaryArray {{keys: {:?}{} values: {:?}}}\n",
-            keys,
-            elipsis,
-            self.values
+            keys, elipsis, self.values
         )
     }
 }
@@ -3186,5 +3188,4 @@ mod tests {
             format!("{:?}", array)
         );
     }
-
 }

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1813,7 +1813,7 @@ impl<T: ArrowPrimitiveType> From<ArrayDataRef> for DictionaryArray<T> {
 }
 
 /// Constructs a `DictionaryArray` from an iterator of optional strings.
-impl<T: ArrowPrimitiveType> FromIterator<Option<&'static str>> for DictionaryArray<T> {
+impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'static str>> for DictionaryArray<T> {
     fn from_iter<I: IntoIterator<Item = Option<&'static str>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();
@@ -1835,7 +1835,7 @@ impl<T: ArrowPrimitiveType> FromIterator<Option<&'static str>> for DictionaryArr
 }
 
 /// Constructs a `DictionaryArray` from an iterator of strings.
-impl<T: ArrowPrimitiveType> FromIterator<&'static str> for DictionaryArray<T> {
+impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<&'static str> for DictionaryArray<T> {
     fn from_iter<I: IntoIterator<Item = &'static str>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -164,19 +164,33 @@ pub fn make_array(data: ArrayDataRef) -> ArrayRef {
         DataType::FixedSizeList(_, _) => {
             Arc::new(FixedSizeListArray::from(data)) as ArrayRef
         }
-        DataType::Dictionary((ref key_type, _)) => {
-            match key_type.as_ref() {
-                DataType::Int8 => Arc::new(DictionaryArray::<Int8Type>::from(data)) as ArrayRef,
-                DataType::Int16 => Arc::new(DictionaryArray::<Int16Type>::from(data)) as ArrayRef,
-                DataType::Int32 => Arc::new(DictionaryArray::<Int32Type>::from(data)) as ArrayRef,
-                DataType::Int64 => Arc::new(DictionaryArray::<Int64Type>::from(data)) as ArrayRef,
-                DataType::UInt8 => Arc::new(DictionaryArray::<UInt8Type>::from(data)) as ArrayRef,
-                DataType::UInt16 => Arc::new(DictionaryArray::<UInt16Type>::from(data)) as ArrayRef,
-                DataType::UInt32 => Arc::new(DictionaryArray::<UInt32Type>::from(data)) as ArrayRef,
-                DataType::UInt64 => Arc::new(DictionaryArray::<UInt64Type>::from(data)) as ArrayRef,
-                dt => panic!("Unexpected dictionary key type {:?}", dt),
+        DataType::Dictionary((ref key_type, _)) => match key_type.as_ref() {
+            DataType::Int8 => {
+                Arc::new(DictionaryArray::<Int8Type>::from(data)) as ArrayRef
             }
-        }
+            DataType::Int16 => {
+                Arc::new(DictionaryArray::<Int16Type>::from(data)) as ArrayRef
+            }
+            DataType::Int32 => {
+                Arc::new(DictionaryArray::<Int32Type>::from(data)) as ArrayRef
+            }
+            DataType::Int64 => {
+                Arc::new(DictionaryArray::<Int64Type>::from(data)) as ArrayRef
+            }
+            DataType::UInt8 => {
+                Arc::new(DictionaryArray::<UInt8Type>::from(data)) as ArrayRef
+            }
+            DataType::UInt16 => {
+                Arc::new(DictionaryArray::<UInt16Type>::from(data)) as ArrayRef
+            }
+            DataType::UInt32 => {
+                Arc::new(DictionaryArray::<UInt32Type>::from(data)) as ArrayRef
+            }
+            DataType::UInt64 => {
+                Arc::new(DictionaryArray::<UInt64Type>::from(data)) as ArrayRef
+            }
+            dt => panic!("Unexpected dictionary key type {:?}", dt),
+        },
         dt => panic!("Unexpected data type {:?}", dt),
     }
 }
@@ -1724,7 +1738,11 @@ impl<T: ArrowPrimitiveType> Array for DictionaryArray<T> {
 
 impl<T: ArrowPrimitiveType> fmt::Debug for DictionaryArray<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "DictionaryArray {{keys: {:?} values: {:?}}}\n", self.keys, self.values)
+        write!(
+            f,
+            "DictionaryArray {{keys: {:?} values: {:?}}}\n",
+            self.keys, self.values
+        )
     }
 }
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1813,7 +1813,9 @@ impl<T: ArrowPrimitiveType> From<ArrayDataRef> for DictionaryArray<T> {
 }
 
 /// Constructs a `DictionaryArray` from an iterator of optional strings.
-impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'static str>> for DictionaryArray<T> {
+impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'static str>>
+    for DictionaryArray<T>
+{
     fn from_iter<I: IntoIterator<Item = Option<&'static str>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();
@@ -1824,9 +1826,13 @@ impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'stati
             if let Some(i) = i {
                 // Note: impl ... for Result<DictionaryArray<T>> fails with
                 // error[E0117]: only traits defined in the current crate can be implemented for arbitrary types
-                builder.append(i).expect("Unable to append a value to a dictionary array.");
+                builder
+                    .append(i)
+                    .expect("Unable to append a value to a dictionary array.");
             } else {
-                builder.append_null().expect("Unable to append a null value to a dictionary array.");
+                builder
+                    .append_null()
+                    .expect("Unable to append a null value to a dictionary array.");
             }
         }
 
@@ -1835,7 +1841,9 @@ impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'stati
 }
 
 /// Constructs a `DictionaryArray` from an iterator of strings.
-impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<&'static str> for DictionaryArray<T> {
+impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<&'static str>
+    for DictionaryArray<T>
+{
     fn from_iter<I: IntoIterator<Item = &'static str>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (lower, _) = iter.size_hint();
@@ -1843,7 +1851,9 @@ impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<&'static str> 
         let value_builder = StringBuilder::new(256);
         let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         for i in iter {
-            builder.append(i).expect("Unable to append a value to a dictionary array.");
+            builder
+                .append(i)
+                .expect("Unable to append a value to a dictionary array.");
         }
 
         builder.finish()

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1705,9 +1705,7 @@ where
             Some(None)
         } else {
             self.i += 1;
-            unsafe {
-                Some(Some((&*self.ptr.offset(i as isize)).clone()))
-            }
+            unsafe { Some(Some((&*self.ptr.offset(i as isize)).clone())) }
         }
     }
 
@@ -1725,9 +1723,7 @@ where
             Some(None)
         } else {
             self.i += n + 1;
-            unsafe {
-                Some(Some((&*self.ptr.offset((i+n) as isize)).clone()))
-            }
+            unsafe { Some(Some((&*self.ptr.offset((i + n) as isize)).clone())) }
         }
     }
 }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1062,7 +1062,7 @@ where
     K: ArrowPrimitiveType,
     V: ArrowPrimitiveType,
 {
-    /// Append a primive value to the array. Return an existing index
+    /// Append a primitive value to the array. Return an existing index
     /// if already present in the values array or a new index if the
     /// value is appended to the values array.
     pub fn append(&mut self, value: V::Native) -> Result<K::Native> {

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1098,7 +1098,7 @@ where
 /// arrays or result in an ordered dictionary.
 pub struct StringDictionaryBuilder<K>
 where
-    K: ArrowPrimitiveType
+    K: ArrowPrimitiveType,
 {
     keys_builder: PrimitiveBuilder<K>,
     values_builder: StringBuilder,
@@ -1108,14 +1108,14 @@ where
 
 impl<K> StringDictionaryBuilder<K>
 where
-    K: ArrowPrimitiveType
+    K: ArrowPrimitiveType,
 {
     /// Creates a new `StringDictionaryBuilder` from a keys builder and a value builder.
     /// Set null_is_zero if you want zero to be the null value (recommended).
     pub fn new(
         keys_builder: PrimitiveBuilder<K>,
         mut values_builder: StringBuilder,
-        null_is_zero : bool,
+        null_is_zero: bool,
     ) -> Self {
         if null_is_zero {
             values_builder.append_null().unwrap();
@@ -1124,14 +1124,14 @@ where
             keys_builder,
             values_builder,
             map: HashMap::new(),
-            null_is_zero
+            null_is_zero,
         }
     }
 }
 
 impl<K> ArrayBuilder for StringDictionaryBuilder<K>
 where
-    K: ArrowPrimitiveType
+    K: ArrowPrimitiveType,
 {
     /// Returns the builder as an non-mutable `Any` reference.
     fn as_any(&self) -> &Any {
@@ -1161,7 +1161,7 @@ where
 
 impl<K> StringDictionaryBuilder<K>
 where
-    K: ArrowPrimitiveType
+    K: ArrowPrimitiveType,
 {
     /// Append a primitive value to the array. Return an existing index
     /// if already present in the values array or a new index if the
@@ -1184,7 +1184,8 @@ where
 
     pub fn append_null(&mut self) -> Result<()> {
         if self.null_is_zero {
-            self.keys_builder.append_value(K::Native::from_usize(0).unwrap())
+            self.keys_builder
+                .append_value(K::Native::from_usize(0).unwrap())
         } else {
             self.keys_builder.append_null()
         }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1110,10 +1110,7 @@ where
     K: ArrowDictionaryKeyType,
 {
     /// Creates a new `StringDictionaryBuilder` from a keys builder and a value builder.
-    pub fn new(
-        keys_builder: PrimitiveBuilder<K>,
-        values_builder: StringBuilder,
-    ) -> Self {
+    pub fn new(keys_builder: PrimitiveBuilder<K>, values_builder: StringBuilder) -> Self {
         Self {
             keys_builder,
             values_builder,

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1005,7 +1005,7 @@ where
 {
     keys_builder: PrimitiveBuilder<K>,
     values_builder: PrimitiveBuilder<V>,
-    map: HashMap<&'static [u8], K::Native>,
+    map: HashMap<Box<[u8]>, K::Native>,
 }
 
 impl<K, V> PrimitiveDictionaryBuilder<K, V>
@@ -1065,8 +1065,6 @@ where
     /// Append a primive value to the array. Return an existing index
     /// if already present in the values array or a new index if the
     /// value is appended to the values array.
-    /// ```
-    /// ```
     pub fn append(&mut self, value: V::Native) -> Result<K::Native> {
         if let Some(&key) = self.map.get(value.to_byte_slice()) {
             // Append existing value.
@@ -1078,6 +1076,7 @@ where
                 .ok_or(ArrowError::DictionaryKeyOverflowError)?;
             self.values_builder.append_value(value)?;
             self.keys_builder.append_value(key as K::Native)?;
+            self.map.insert(value.to_byte_slice().into(), key);
             Ok(key)
         }
     }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1940,7 +1940,7 @@ mod tests {
         let array = builder.finish();
 
         // Keys are strongly typed.
-        let aks : Vec<_> = array.keys().collect();
+        let aks: Vec<_> = array.keys().collect();
 
         // Values are polymorphic and so require a downcast.
         let av = array.values();

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1098,7 +1098,7 @@ where
 /// arrays or result in an ordered dictionary.
 pub struct StringDictionaryBuilder<K>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
 {
     keys_builder: PrimitiveBuilder<K>,
     values_builder: StringBuilder,
@@ -1107,7 +1107,7 @@ where
 
 impl<K> StringDictionaryBuilder<K>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
 {
     /// Creates a new `StringDictionaryBuilder` from a keys builder and a value builder.
     pub fn new(
@@ -1124,7 +1124,7 @@ where
 
 impl<K> ArrayBuilder for StringDictionaryBuilder<K>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
 {
     /// Returns the builder as an non-mutable `Any` reference.
     fn as_any(&self) -> &Any {
@@ -1154,7 +1154,7 @@ where
 
 impl<K> StringDictionaryBuilder<K>
 where
-    K: ArrowPrimitiveType,
+    K: ArrowDictionaryKeyType,
 {
     /// Append a primitive value to the array. Return an existing index
     /// if already present in the values array or a new index if the
@@ -2051,7 +2051,7 @@ mod tests {
 
     #[test]
     fn test_string_dictionary_builder() {
-        let key_builder = PrimitiveBuilder::<UInt8Type>::new(5);
+        let key_builder = PrimitiveBuilder::<Int8Type>::new(5);
         let value_builder = StringBuilder::new(2);
         let mut builder = StringDictionaryBuilder::new(key_builder, value_builder);
         builder.append("abc").unwrap();

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -333,10 +333,10 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
         let len = self.len();
         let null_bit_buffer = self.bitmap_builder.finish();
         let null_count = len - bit_util::count_set_bits(null_bit_buffer.data());
-        let data_type = DataType::Dictionary((
+        let data_type = DataType::Dictionary(
             Box::new(T::get_data_type()),
             Box::new(values.data_type().clone()),
-        ));
+        );
         let mut builder = ArrayData::builder(data_type)
             .len(len)
             .add_buffer(self.values_builder.finish());

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -19,6 +19,7 @@
 //! internal buffer in an `ArrayData` object.
 
 use std::any::Any;
+use std::collections::HashMap;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::mem;
@@ -325,6 +326,27 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
         }
         let data = builder.build();
         PrimitiveArray::<T>::from(data)
+    }
+
+    /// Builds the `DictionaryArray` and reset this builder.
+    pub fn finish_dict(&mut self, values: ArrayRef) -> DictionaryArray<T> {
+        let len = self.len();
+        let null_bit_buffer = self.bitmap_builder.finish();
+        let null_count = len - bit_util::count_set_bits(null_bit_buffer.data());
+        let data_type = DataType::Dictionary((
+            Box::new(T::get_data_type()),
+            Box::new(values.data_type().clone()),
+        ));
+        let mut builder = ArrayData::builder(data_type)
+            .len(len)
+            .add_buffer(self.values_builder.finish());
+        if null_count > 0 {
+            builder = builder
+                .null_count(null_count)
+                .null_bit_buffer(null_bit_buffer);
+        }
+        builder = builder.add_child_data(values.data());
+        DictionaryArray::<T>::from(builder.build())
     }
 }
 
@@ -970,6 +992,105 @@ impl Drop for StructBuilder {
         // To avoid double drop on the field array builders.
         let builders = std::mem::replace(&mut self.field_builders, Vec::new());
         std::mem::forget(builders);
+    }
+}
+
+/// Array builder for `DictionaryArray`. For example to map a set of byte indices
+/// to f32 values. Note that the use of a `HashMap` here will not scale to very large
+/// arrays or result in an ordered dictionary.
+pub struct PrimitiveDictionaryBuilder<K, V>
+where
+    K: ArrowPrimitiveType,
+    V: ArrowPrimitiveType,
+{
+    keys_builder: PrimitiveBuilder<K>,
+    values_builder: PrimitiveBuilder<V>,
+    map: HashMap<&'static [u8], K::Native>,
+}
+
+impl<K, V> PrimitiveDictionaryBuilder<K, V>
+where
+    K: ArrowPrimitiveType,
+    V: ArrowPrimitiveType,
+{
+    /// Creates a new `PrimitiveDictionaryBuilder` from a keys builder and a value builder.
+    pub fn new(
+        keys_builder: PrimitiveBuilder<K>,
+        values_builder: PrimitiveBuilder<V>,
+    ) -> Self {
+        Self {
+            keys_builder: keys_builder,
+            values_builder: values_builder,
+            map: HashMap::new(),
+        }
+    }
+}
+
+impl<K, V> ArrayBuilder for PrimitiveDictionaryBuilder<K, V>
+where
+    K: ArrowPrimitiveType,
+    V: ArrowPrimitiveType,
+{
+    /// Returns the builder as an non-mutable `Any` reference.
+    fn as_any(&self) -> &Any {
+        self
+    }
+
+    /// Returns the builder as an mutable `Any` reference.
+    fn as_any_mut(&mut self) -> &mut Any {
+        self
+    }
+
+    /// Returns the boxed builder as a box of `Any`.
+    fn into_box_any(self: Box<Self>) -> Box<Any> {
+        self
+    }
+
+    /// Returns the number of array slots in the builder
+    fn len(&self) -> usize {
+        self.keys_builder.len()
+    }
+
+    /// Builds the array and reset this builder.
+    fn finish(&mut self) -> ArrayRef {
+        Arc::new(self.finish())
+    }
+}
+
+impl<K, V> PrimitiveDictionaryBuilder<K, V>
+where
+    K: ArrowPrimitiveType,
+    V: ArrowPrimitiveType,
+{
+    /// Append a primive value to the array. Return an existing index
+    /// if already present in the values array or a new index if the
+    /// value is appended to the values array.
+    /// ```
+    /// ```
+    pub fn append(&mut self, value: V::Native) -> Result<K::Native> {
+        if let Some(&key) = self.map.get(value.to_byte_slice()) {
+            // Append existing value.
+            self.keys_builder.append_value(key)?;
+            Ok(key)
+        } else {
+            // Append new value.
+            let key = K::Native::from_usize(self.values_builder.len())
+                .ok_or(ArrowError::DictionaryKeyOverflowError)?;
+            self.values_builder.append_value(value)?;
+            self.keys_builder.append_value(key as K::Native)?;
+            Ok(key)
+        }
+    }
+
+    pub fn append_null(&mut self) -> Result<()> {
+        self.keys_builder.append_null()
+    }
+
+    /// Builds the `DictionaryArray` and reset this builder.
+    pub fn finish(&mut self) -> DictionaryArray<K> {
+        self.map.clear();
+        let value_ref: ArrayRef = Arc::new(self.values_builder.finish());
+        self.keys_builder.finish_dict(value_ref)
     }
 }
 
@@ -1807,5 +1928,47 @@ mod tests {
 
         let mut builder = StructBuilder::new(fields, field_builders);
         assert!(builder.field_builder::<BinaryBuilder>(0).is_none());
+    }
+
+    #[test]
+    fn test_primitive_dictionary_builder() {
+        let key_builder = PrimitiveBuilder::<UInt8Type>::new(3);
+        let value_builder = PrimitiveBuilder::<UInt32Type>::new(2);
+        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        builder.append(12345678).unwrap();
+        builder.append_null().unwrap();
+        builder.append(22345678).unwrap();
+        let array = builder.finish();
+
+        // Keys are strongly typed.
+        let aks = array.keys();
+
+        // Values are polymorphic and so require a downcast.
+        let av = array.values();
+        let ava: &UInt32Array = av.as_any().downcast_ref::<UInt32Array>().unwrap();
+        let avs: &[u32] = ava.value_slice(0, array.values().len());
+
+        assert_eq!(array.is_null(0), false);
+        assert_eq!(array.is_null(1), true);
+        assert_eq!(array.is_null(2), false);
+        assert_eq!(aks[0], 0);
+        assert_eq!(aks[2], 1);
+        assert_eq!(avs, &[12345678, 22345678]);
+    }
+
+    #[test]
+    fn test_primitive_dictionary_overflow() {
+        let key_builder = PrimitiveBuilder::<UInt8Type>::new(257);
+        let value_builder = PrimitiveBuilder::<UInt32Type>::new(257);
+        let mut builder = PrimitiveDictionaryBuilder::new(key_builder, value_builder);
+        // 256 unique keys.
+        for i in 0..256 {
+            builder.append(i + 1000).unwrap();
+        }
+        // Special error if the key overflows (256th entry)
+        assert_eq!(
+            builder.append(1257),
+            Err(ArrowError::DictionaryKeyOverflowError)
+        );
     }
 }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1940,7 +1940,7 @@ mod tests {
         let array = builder.finish();
 
         // Keys are strongly typed.
-        let aks = array.keys();
+        let aks : Vec<_> = array.keys().collect();
 
         // Values are polymorphic and so require a downcast.
         let av = array.values();
@@ -1950,8 +1950,8 @@ mod tests {
         assert_eq!(array.is_null(0), false);
         assert_eq!(array.is_null(1), true);
         assert_eq!(array.is_null(2), false);
-        assert_eq!(aks[0], 0);
-        assert_eq!(aks[2], 1);
+
+        assert_eq!(aks, vec![Some(0), None, Some(1)]);
         assert_eq!(avs, &[12345678, 22345678]);
     }
 

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -231,8 +231,8 @@ impl<T: ArrowPrimitiveType> ArrayEqual for DictionaryArray<T> {
         assert!(other_start_idx + (end_idx - start_idx) <= other.len());
         let other = other.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
 
-        let iter_a = self.iter_keys().take(end_idx).skip(start_idx);
-        let iter_b = other.iter_keys().skip(other_start_idx);
+        let iter_a = self.keys().take(end_idx).skip(start_idx);
+        let iter_b = other.keys().skip(other_start_idx);
 
         // For now, all the values must be the same
         iter_a.eq(iter_b)
@@ -824,7 +824,7 @@ impl PartialEq<ListArray> for Value {
 
 impl<T: ArrowPrimitiveType> JsonEqual for DictionaryArray<T> {
     fn equals_json(&self, json: &[&Value]) -> bool {
-        self.iter_keys().zip(json.iter()).all(|aj| match aj {
+        self.keys().zip(json.iter()).all(|aj| match aj {
             (None, Value::Null) => true,
             (Some(a), Value::Number(j)) => {
                 a.to_usize().unwrap() as u64 == j.as_u64().unwrap()

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -220,7 +220,9 @@ impl<T: ArrowPrimitiveType> ArrayEqual for DictionaryArray<T> {
     fn equals(&self, other: &dyn Array) -> bool {
         let other = other.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
         self.keys().equals(other.keys())
-            && self.values().range_equals(&*other.values(), 0, other.values().len(), 0)
+            && self
+                .values()
+                .range_equals(&*other.values(), 0, other.values().len(), 0)
     }
 
     fn range_equals(
@@ -231,8 +233,11 @@ impl<T: ArrowPrimitiveType> ArrayEqual for DictionaryArray<T> {
         other_start_idx: usize,
     ) -> bool {
         let other = other.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
-        self.keys().range_equals(other, start_idx, end_idx, other_start_idx)
-            && self.values().range_equals(&*other.values(), 0, other.values().len(), 0)
+        self.keys()
+            .range_equals(other, start_idx, end_idx, other_start_idx)
+            && self
+                .values()
+                .range_equals(&*other.values(), 0, other.values().len(), 0)
     }
 }
 
@@ -816,13 +821,13 @@ impl PartialEq<ListArray> for Value {
     }
 }
 
-impl<T:ArrowPrimitiveType> JsonEqual for DictionaryArray<T> {
+impl<T: ArrowPrimitiveType> JsonEqual for DictionaryArray<T> {
     fn equals_json(&self, json: &[&Value]) -> bool {
         self.keys().equals_json(json)
     }
 }
 
-impl<T:ArrowPrimitiveType> PartialEq<Value> for DictionaryArray<T> {
+impl<T: ArrowPrimitiveType> PartialEq<Value> for DictionaryArray<T> {
     fn eq(&self, json: &Value) -> bool {
         match json {
             Value::Array(json_array) => self.equals_json_values(json_array),
@@ -831,7 +836,7 @@ impl<T:ArrowPrimitiveType> PartialEq<Value> for DictionaryArray<T> {
     }
 }
 
-impl<T:ArrowPrimitiveType> PartialEq<DictionaryArray<T>> for Value {
+impl<T: ArrowPrimitiveType> PartialEq<DictionaryArray<T>> for Value {
     fn eq(&self, arrow: &DictionaryArray<T>) -> bool {
         match self {
             Value::Array(json_array) => arrow.equals_json_values(json_array),

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -70,6 +70,7 @@ pub use self::data::ArrayDataBuilder;
 pub use self::data::ArrayDataRef;
 
 pub use self::array::BinaryArray;
+pub use self::array::DictionaryArray;
 pub use self::array::FixedSizeBinaryArray;
 pub use self::array::FixedSizeListArray;
 pub use self::array::ListArray;

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -92,6 +92,15 @@ pub type UInt64Array = PrimitiveArray<UInt64Type>;
 pub type Float32Array = PrimitiveArray<Float32Type>;
 pub type Float64Array = PrimitiveArray<Float64Type>;
 
+pub type Int8DictionaryArray = DictionaryArray<Int8Type>;
+pub type Int16DictionaryArray = DictionaryArray<Int16Type>;
+pub type Int32DictionaryArray = DictionaryArray<Int32Type>;
+pub type Int64DictionaryArray = DictionaryArray<Int64Type>;
+pub type UInt8DictionaryArray = DictionaryArray<UInt8Type>;
+pub type UInt16DictionaryArray = DictionaryArray<UInt16Type>;
+pub type UInt32DictionaryArray = DictionaryArray<UInt32Type>;
+pub type UInt64DictionaryArray = DictionaryArray<UInt64Type>;
+
 pub type TimestampSecondArray = PrimitiveArray<TimestampSecondType>;
 pub type TimestampMillisecondArray = PrimitiveArray<TimestampMillisecondType>;
 pub type TimestampMicrosecondArray = PrimitiveArray<TimestampMicrosecondType>;

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -161,6 +161,7 @@ pub use self::builder::FixedSizeBinaryBuilder;
 pub use self::builder::FixedSizeListBuilder;
 pub use self::builder::ListBuilder;
 pub use self::builder::PrimitiveBuilder;
+pub use self::builder::PrimitiveDictionaryBuilder;
 pub use self::builder::StringBuilder;
 pub use self::builder::StructBuilder;
 

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1065,7 +1065,7 @@ impl Field {
                             Some(t) => DataType::from(t)?,
                             _ => {
                                 return Err(ArrowError::ParseError(
-                                    "Field missing 'type' attribute".to_string(),
+                                    "Field missing 'indexType' attribute".to_string(),
                                 ));
                             }
                         };
@@ -1081,7 +1081,7 @@ impl Field {
                             Some(&Value::Bool(n)) => n,
                             _ => {
                                 return Err(ArrowError::ParseError(
-                                    "Field missing 'id' attribute".to_string(),
+                                    "Field missing 'isOrdered' attribute".to_string(),
                                 ));
                             }
                         };

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -419,20 +419,15 @@ make_type!(
 
 /// A subtype of primitive type that represents legal dictionary keys.
 /// See https://arrow.apache.org/docs/format/Columnar.html
-pub trait ArrowDictionaryKeyType: ArrowPrimitiveType {
-}
+pub trait ArrowDictionaryKeyType: ArrowPrimitiveType {}
 
-impl ArrowDictionaryKeyType for Int8Type {
-}
+impl ArrowDictionaryKeyType for Int8Type {}
 
-impl ArrowDictionaryKeyType for Int16Type {
-}
+impl ArrowDictionaryKeyType for Int16Type {}
 
-impl ArrowDictionaryKeyType for Int32Type {
-}
+impl ArrowDictionaryKeyType for Int32Type {}
 
-impl ArrowDictionaryKeyType for Int64Type {
-}
+impl ArrowDictionaryKeyType for Int64Type {}
 
 /// A subtype of primitive type that represents numeric values.
 ///

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -417,6 +417,23 @@ make_type!(
     0i64
 );
 
+/// A subtype of primitive type that represents legal dictionary keys.
+/// See https://arrow.apache.org/docs/format/Columnar.html
+pub trait ArrowDictionaryKeyType: ArrowPrimitiveType {
+}
+
+impl ArrowDictionaryKeyType for Int8Type {
+}
+
+impl ArrowDictionaryKeyType for Int16Type {
+}
+
+impl ArrowDictionaryKeyType for Int32Type {
+}
+
+impl ArrowDictionaryKeyType for Int64Type {
+}
+
 /// A subtype of primitive type that represents numeric values.
 ///
 /// SIMD operations are defined in this trait if available on the target system.

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1474,16 +1474,14 @@ mod tests {
                     ]),
                     false,
                 ),
-<<<<<<< HEAD
                 Field::new("c25", DataType::Interval(IntervalUnit::YearMonth), true),
                 Field::new("c26", DataType::Interval(IntervalUnit::DayTime), true),
                 Field::new("c27", DataType::Duration(TimeUnit::Second), false),
                 Field::new("c28", DataType::Duration(TimeUnit::Millisecond), false),
                 Field::new("c29", DataType::Duration(TimeUnit::Microsecond), false),
                 Field::new("c30", DataType::Duration(TimeUnit::Nanosecond), false),
-=======
                 Field::new_dict(
-                    "c25",
+                    "c31",
                     DataType::Dictionary((
                         Box::new(DataType::Int32),
                         Box::new(DataType::Utf8),
@@ -1492,7 +1490,6 @@ mod tests {
                     123,
                     true,
                 ),
->>>>>>> fixing merge
             ],
             metadata,
         );
@@ -1777,7 +1774,6 @@ mod tests {
                     },
                     {
                         "name": "c25",
-<<<<<<< HEAD
                         "nullable": true,
                         "type": {
                             "name": "interval",
@@ -1829,12 +1825,14 @@ mod tests {
                             "unit": "NANOSECOND"
                         },
                         "children": []
-=======
+                    },
+                    {
+                        "name": "c31",
+                        "nullable": true,
+                        "children": [],
                         "type": {
                           "name": "utf8"
                         },
-                        "nullable": true,
-                        "children": [],
                         "dictionary": {
                           "id": 123,
                           "indexType": {
@@ -1844,7 +1842,6 @@ mod tests {
                           },
                           "isOrdered": true
                         }
->>>>>>> fixing merge
                     }
                 ],
                 "metadata" : {

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -78,7 +78,7 @@ pub enum DataType {
     List(Box<DataType>),
     FixedSizeList(Box<DataType>, i32),
     Struct(Vec<Field>),
-    Dictionary((Box<DataType>, Box<DataType>)),
+    Dictionary(Box<DataType>, Box<DataType>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -909,7 +909,7 @@ impl DataType {
                 TimeUnit::Microsecond => "MICROSECOND",
                 TimeUnit::Nanosecond => "NANOSECOND",
             }}),
-            DataType::Dictionary(_) => json!({ "name": "dictionary"}),
+            DataType::Dictionary(_, _) => json!({ "name": "dictionary"}),
         }
     }
 }
@@ -1073,7 +1073,7 @@ impl Field {
                                 ));
                             }
                         };
-                        DataType::Dictionary((Box::new(index_type), Box::new(data_type)))
+                        DataType::Dictionary(Box::new(index_type), Box::new(data_type))
                     }
                     _ => data_type,
                 };
@@ -1106,7 +1106,7 @@ impl Field {
             _ => vec![],
         };
         match self.data_type() {
-            DataType::Dictionary((ref index_type, ref value_type)) => json!({
+            DataType::Dictionary(ref index_type, ref value_type) => json!({
                 "name": self.name,
                 "nullable": self.nullable,
                 "type": value_type.to_json(),
@@ -1556,10 +1556,10 @@ mod tests {
                 Field::new("c30", DataType::Duration(TimeUnit::Nanosecond), false),
                 Field::new_dict(
                     "c31",
-                    DataType::Dictionary((
+                    DataType::Dictionary(
                         Box::new(DataType::Int32),
                         Box::new(DataType::Utf8),
-                    )),
+                    ),
                     true,
                     123,
                     true,

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -117,6 +117,16 @@ pub trait ArrowNativeType:
     fmt::Debug + Send + Sync + Copy + PartialOrd + FromStr + 'static
 {
     fn into_json_value(self) -> Option<Value>;
+
+    /// Convert native type from usize.
+    fn from_usize(_: usize) -> Option<Self> {
+        None
+    }
+
+    /// Convert native type to usize.
+    fn to_usize(&self) -> Option<usize> {
+        None
+    }
 }
 
 /// Trait indicating a primitive fixed-width type (bool, ints and floats).
@@ -146,11 +156,27 @@ impl ArrowNativeType for i8 {
     fn into_json_value(self) -> Option<Value> {
         Some(VNumber(Number::from(self)))
     }
+
+    fn from_usize(v: usize) -> Option<Self> {
+        num::FromPrimitive::from_usize(v)
+    }
+
+    fn to_usize(&self) -> Option<usize> {
+        num::ToPrimitive::to_usize(self)
+    }
 }
 
 impl ArrowNativeType for i16 {
     fn into_json_value(self) -> Option<Value> {
         Some(VNumber(Number::from(self)))
+    }
+
+    fn from_usize(v: usize) -> Option<Self> {
+        num::FromPrimitive::from_usize(v)
+    }
+
+    fn to_usize(&self) -> Option<usize> {
+        num::ToPrimitive::to_usize(self)
     }
 }
 
@@ -158,11 +184,27 @@ impl ArrowNativeType for i32 {
     fn into_json_value(self) -> Option<Value> {
         Some(VNumber(Number::from(self)))
     }
+
+    fn from_usize(v: usize) -> Option<Self> {
+        num::FromPrimitive::from_usize(v)
+    }
+
+    fn to_usize(&self) -> Option<usize> {
+        num::ToPrimitive::to_usize(self)
+    }
 }
 
 impl ArrowNativeType for i64 {
     fn into_json_value(self) -> Option<Value> {
         Some(VNumber(Number::from(self)))
+    }
+
+    fn from_usize(v: usize) -> Option<Self> {
+        num::FromPrimitive::from_usize(v)
+    }
+
+    fn to_usize(&self) -> Option<usize> {
+        num::ToPrimitive::to_usize(self)
     }
 }
 
@@ -170,11 +212,27 @@ impl ArrowNativeType for u8 {
     fn into_json_value(self) -> Option<Value> {
         Some(VNumber(Number::from(self)))
     }
+
+    fn from_usize(v: usize) -> Option<Self> {
+        num::FromPrimitive::from_usize(v)
+    }
+
+    fn to_usize(&self) -> Option<usize> {
+        num::ToPrimitive::to_usize(self)
+    }
 }
 
 impl ArrowNativeType for u16 {
     fn into_json_value(self) -> Option<Value> {
         Some(VNumber(Number::from(self)))
+    }
+
+    fn from_usize(v: usize) -> Option<Self> {
+        num::FromPrimitive::from_usize(v)
+    }
+
+    fn to_usize(&self) -> Option<usize> {
+        num::ToPrimitive::to_usize(self)
     }
 }
 
@@ -182,11 +240,27 @@ impl ArrowNativeType for u32 {
     fn into_json_value(self) -> Option<Value> {
         Some(VNumber(Number::from(self)))
     }
+
+    fn from_usize(v: usize) -> Option<Self> {
+        num::FromPrimitive::from_usize(v)
+    }
+
+    fn to_usize(&self) -> Option<usize> {
+        num::ToPrimitive::to_usize(self)
+    }
 }
 
 impl ArrowNativeType for u64 {
     fn into_json_value(self) -> Option<Value> {
         Some(VNumber(Number::from(self)))
+    }
+
+    fn from_usize(v: usize) -> Option<Self> {
+        num::FromPrimitive::from_usize(v)
+    }
+
+    fn to_usize(&self) -> Option<usize> {
+        num::ToPrimitive::to_usize(self)
     }
 }
 

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -17,7 +17,6 @@
 
 //! Defines `ArrowError` for representing failures in various Arrow operations
 use std::error::Error;
-use std::fmt::{Display, Formatter};
 
 use csv as csv_crate;
 
@@ -71,6 +70,7 @@ impl From<::std::string::FromUtf8Error> for ArrowError {
     }
 }
 
+<<<<<<< HEAD
 impl Display for ArrowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -94,3 +94,6 @@ impl Display for ArrowError {
 impl Error for ArrowError {}
 
 pub type Result<T> = std::result::Result<T, ArrowError>;
+=======
+pub type Result<T> = ::std::result::Result<T, ArrowError>;
+>>>>>>> Rebase master

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -72,10 +72,6 @@ impl From<::std::string::FromUtf8Error> for ArrowError {
     }
 }
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> ARROW-7312: [Rust] Implement std::error::Error for ArrowError.
 impl Display for ArrowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -101,10 +97,4 @@ impl Display for ArrowError {
 
 impl Error for ArrowError {}
 
-<<<<<<< HEAD
 pub type Result<T> = std::result::Result<T, ArrowError>;
-=======
-=======
->>>>>>> ARROW-7312: [Rust] Implement std::error::Error for ArrowError.
-pub type Result<T> = ::std::result::Result<T, ArrowError>;
->>>>>>> Rebase master

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -92,6 +92,9 @@ impl Display for ArrowError {
             &ArrowError::ParquetError(ref desc) => {
                 write!(f, "Parquet argument error: {}", desc)
             }
+            &ArrowError::DictionaryKeyOverflowError => {
+                write!(f, "Dictionary key bigger than the key type")
+            }
         }
     }
 }

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -32,6 +32,7 @@ pub enum ArrowError {
     IoError(String),
     InvalidArgumentError(String),
     ParquetError(String),
+    DictionaryKeyOverflowError,
 }
 
 impl From<::std::io::Error> for ArrowError {

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -17,6 +17,7 @@
 
 //! Defines `ArrowError` for representing failures in various Arrow operations
 use std::error::Error;
+use std::fmt::{Display, Formatter};
 
 use csv as csv_crate;
 
@@ -72,6 +73,9 @@ impl From<::std::string::FromUtf8Error> for ArrowError {
 }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> ARROW-7312: [Rust] Implement std::error::Error for ArrowError.
 impl Display for ArrowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -94,7 +98,10 @@ impl Display for ArrowError {
 
 impl Error for ArrowError {}
 
+<<<<<<< HEAD
 pub type Result<T> = std::result::Result<T, ArrowError>;
 =======
+=======
+>>>>>>> ARROW-7312: [Rust] Implement std::error::Error for ArrowError.
 pub type Result<T> = ::std::result::Result<T, ArrowError>;
 >>>>>>> Rebase master

--- a/rust/arrow/src/flight/mod.rs
+++ b/rust/arrow/src/flight/mod.rs
@@ -72,12 +72,13 @@ pub fn flight_data_to_batch(
 ) -> Result<Option<RecordBatch>> {
     // check that the data_header is a record batch message
     let message = crate::ipc::get_root_as_message(&data.data_header[..]);
+    let dictionaries_by_field = Vec::new();
     let batch_header = message
         .header_as_record_batch()
         .ok_or(ArrowError::ParseError(
             "Unable to convert flight data header to a record batch".to_string(),
         ))?;
-    reader::read_record_batch(&data.data_body, batch_header, schema)
+    reader::read_record_batch(&data.data_body, batch_header, schema, &dictionaries_by_field)
 }
 
 // TODO: add more explicit conversion that expoess flight descriptor and metadata options

--- a/rust/arrow/src/flight/mod.rs
+++ b/rust/arrow/src/flight/mod.rs
@@ -78,7 +78,12 @@ pub fn flight_data_to_batch(
         .ok_or(ArrowError::ParseError(
             "Unable to convert flight data header to a record batch".to_string(),
         ))?;
-    reader::read_record_batch(&data.data_body, batch_header, schema, &dictionaries_by_field)
+    reader::read_record_batch(
+        &data.data_body,
+        batch_header,
+        schema,
+        &dictionaries_by_field,
+    )
 }
 
 // TODO: add more explicit conversion that expoess flight descriptor and metadata options

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -119,11 +119,21 @@ pub(crate) fn schema_to_fb_offset<'a: 'b, 'b>(
 /// Convert an IPC Field to Arrow Field
 impl<'a> From<ipc::Field<'a>> for Field {
     fn from(field: ipc::Field) -> Field {
-        Field::new(
-            field.name().unwrap(),
-            get_data_type(field),
-            field.nullable(),
-        )
+        if let Some(dictionary) = field.dictionary() {
+            Field::new_dict(
+                field.name().unwrap(),
+                get_data_type(field, true),
+                field.nullable(),
+                dictionary.id(),
+                dictionary.isOrdered(),
+            )
+        } else {
+            Field::new(
+                field.name().unwrap(),
+                get_data_type(field, true),
+                field.nullable(),
+            )
+        }
     }
 }
 
@@ -159,7 +169,32 @@ pub(crate) fn schema_from_bytes(bytes: &[u8]) -> Option<Schema> {
 }
 
 /// Get the Arrow data type from the flatbuffer Field table
+<<<<<<< HEAD
 pub(crate) fn get_data_type(field: ipc::Field) -> DataType {
+=======
+fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataType {
+    if let Some(dictionary) = field.dictionary() {
+        if may_be_dictionary {
+            let int = dictionary.indexType().unwrap();
+            let index_type = match (int.bitWidth(), int.is_signed()) {
+                (8, true) => DataType::Int8,
+                (8, false) => DataType::UInt8,
+                (16, true) => DataType::Int16,
+                (16, false) => DataType::UInt16,
+                (32, true) => DataType::Int32,
+                (32, false) => DataType::UInt32,
+                (64, true) => DataType::Int64,
+                (64, false) => DataType::UInt64,
+                _ => panic!("Unexpected bitwidth and signed"),
+            };
+            return DataType::Dictionary((
+                Box::new(index_type),
+                Box::new(get_data_type(field, false)),
+            ));
+        }
+    }
+
+>>>>>>> Rebase master
     match field.type_type() {
         ipc::Type::Bool => DataType::Boolean,
         ipc::Type::Int => {
@@ -256,7 +291,7 @@ pub(crate) fn get_data_type(field: ipc::Field) -> DataType {
             }
             let child_field = children.get(0);
             // returning int16 for now, to test, not sure how to get data type
-            DataType::List(Box::new(get_data_type(child_field)))
+            DataType::List(Box::new(get_data_type(child_field, false)))
         }
         ipc::Type::FixedSizeList => {
             let children = field.children().unwrap();
@@ -265,7 +300,10 @@ pub(crate) fn get_data_type(field: ipc::Field) -> DataType {
             }
             let child_field = children.get(0);
             let fsl = field.type_as_fixed_size_list().unwrap();
-            DataType::FixedSizeList(Box::new(get_data_type(child_field)), fsl.listSize())
+            DataType::FixedSizeList((
+                Box::new(get_data_type(child_field, false)),
+                fsl.listSize(),
+            ))
         }
         ipc::Type::Struct_ => {
             let mut fields = vec![];

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -583,6 +583,7 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                 Some(children),
             )
         }
+        t @ _ => unimplemented!("Type {:?} not supported", t),
     }
 }
 

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -300,10 +300,10 @@ fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataType {
             }
             let child_field = children.get(0);
             let fsl = field.type_as_fixed_size_list().unwrap();
-            DataType::FixedSizeList((
+            DataType::FixedSizeList(
                 Box::new(get_data_type(child_field, false)),
                 fsl.listSize(),
-            ))
+            )
         }
         ipc::Type::Struct_ => {
             let mut fields = vec![];

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -187,10 +187,10 @@ fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataType {
                 (64, false) => DataType::UInt64,
                 _ => panic!("Unexpected bitwidth and signed"),
             };
-            return DataType::Dictionary((
+            return DataType::Dictionary(
                 Box::new(index_type),
                 Box::new(get_data_type(field, false)),
-            ));
+            );
         }
     }
 

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -169,10 +169,7 @@ pub(crate) fn schema_from_bytes(bytes: &[u8]) -> Option<Schema> {
 }
 
 /// Get the Arrow data type from the flatbuffer Field table
-<<<<<<< HEAD
-pub(crate) fn get_data_type(field: ipc::Field) -> DataType {
-=======
-fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataType {
+pub(crate) fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataType {
     if let Some(dictionary) = field.dictionary() {
         if may_be_dictionary {
             let int = dictionary.indexType().unwrap();
@@ -194,7 +191,6 @@ fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataType {
         }
     }
 
->>>>>>> Rebase master
     match field.type_type() {
         ipc::Type::Bool => DataType::Boolean,
         ipc::Type::Int => {

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -370,7 +370,7 @@ fn create_list_array(
     }
 }
 
-/// Reads the correct number of buffers based on list type an null_count, and creates a
+/// Reads the correct number of buffers based on list type and null_count, and creates a
 /// list array ref
 fn create_dictionary_array(
     field_node: &ipc::FieldNode,

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use crate::array::*;
 use crate::buffer::Buffer;
 use crate::compute::cast;
-use crate::datatypes::{DataType, IntervalUnit, Schema, SchemaRef, Field};
+use crate::datatypes::{DataType, Field, IntervalUnit, Schema, SchemaRef};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
 use crate::record_batch::{RecordBatch, RecordBatchReader};

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -20,13 +20,14 @@
 //! The `FileReader` and `StreamReader` have similar interfaces,
 //! however the `FileReader` expects a reader that supports `Seek`ing
 
+use std::collections::HashMap;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 use crate::array::*;
 use crate::buffer::Buffer;
 use crate::compute::cast;
-use crate::datatypes::{DataType, IntervalUnit, Schema, SchemaRef};
+use crate::datatypes::{DataType, IntervalUnit, Schema, SchemaRef, Field};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
 use crate::record_batch::{RecordBatch, RecordBatchReader};
@@ -54,6 +55,7 @@ fn create_array(
     data_type: &DataType,
     data: &Vec<u8>,
     buffers: &[ipc::Buffer],
+    dictionaries: &Vec<Option<ArrayRef>>,
     mut node_index: usize,
     mut buffer_index: usize,
 ) -> (ArrayRef, usize, usize) {
@@ -98,6 +100,7 @@ fn create_array(
                 list_data_type,
                 data,
                 buffers,
+                dictionaries,
                 node_index,
                 buffer_index,
             );
@@ -119,6 +122,7 @@ fn create_array(
                 list_data_type,
                 data,
                 buffers,
+                dictionaries,
                 node_index,
                 buffer_index,
             );
@@ -143,6 +147,7 @@ fn create_array(
                     struct_field.data_type(),
                     data,
                     buffers,
+                    dictionaries,
                     node_index,
                     buffer_index,
                 );
@@ -162,6 +167,24 @@ fn create_array(
                 StructArray::from(struct_arrays)
             };
             Arc::new(struct_array)
+        }
+        // Create dictionary array from RecordBatch
+        Dictionary(_) => {
+            let index_node = &nodes[node_index];
+            let index_buffers: Vec<Buffer> = buffers[buffer_index..buffer_index + 2]
+                .iter()
+                .map(|buf| read_buffer(buf, data))
+                .collect();
+            let value_array = dictionaries[node_index].clone().unwrap();
+            node_index = node_index + 1;
+            buffer_index = buffer_index + 2;
+
+            create_dictionary_array(
+                index_node,
+                data_type,
+                &index_buffers[..],
+                value_array,
+            )
         }
         _ => {
             let array = create_primitive_array(
@@ -347,11 +370,38 @@ fn create_list_array(
     }
 }
 
+/// Reads the correct number of buffers based on list type an null_count, and creates a
+/// list array ref
+fn create_dictionary_array(
+    field_node: &ipc::FieldNode,
+    data_type: &DataType,
+    buffers: &[Buffer],
+    value_array: ArrayRef,
+) -> ArrayRef {
+    if let &DataType::Dictionary(_) = data_type {
+        let null_count = field_node.null_count() as usize;
+        let mut builder = ArrayData::builder(data_type.clone())
+            .len(field_node.length() as usize)
+            .buffers(buffers[1..2].to_vec())
+            .offset(0)
+            .child_data(vec![value_array.data()]);
+        if null_count > 0 {
+            builder = builder
+                .null_count(null_count)
+                .null_bit_buffer(buffers[0].clone())
+        }
+        make_array(builder.build())
+    } else {
+        panic!("Cannot create dictionary array from {:?}", data_type)
+    }
+}
+
 /// Creates a record batch from binary data using the `ipc::RecordBatch` indexes and the `Schema`
 pub(crate) fn read_record_batch(
     buf: &Vec<u8>,
     batch: ipc::RecordBatch,
     schema: Arc<Schema>,
+    dictionaries: &Vec<Option<ArrayRef>>,
 ) -> Result<Option<RecordBatch>> {
     let buffers = batch.buffers().ok_or(ArrowError::IoError(
         "Unable to get buffers from IPC RecordBatch".to_string(),
@@ -371,6 +421,7 @@ pub(crate) fn read_record_batch(
             field.data_type(),
             &buf,
             buffers,
+            dictionaries,
             node_index,
             buffer_index,
         );
@@ -382,20 +433,43 @@ pub(crate) fn read_record_batch(
     RecordBatch::try_new(schema.clone(), arrays).map(|batch| Some(batch))
 }
 
+// Linear search for the first dictionary field with a dictionary id.
+fn find_dictionary_field(ipc_schema: &ipc::Schema, id: i64) -> Option<usize> {
+    let fields = ipc_schema.fields().unwrap();
+    for i in 0..fields.len() {
+        let field: ipc::Field = fields.get(i);
+        if let Some(dictionary) = field.dictionary() {
+            if dictionary.id() == id {
+                return Some(i);
+            }
+        }
+    }
+    None
+}
+
 /// Arrow File reader
 pub struct FileReader<R: Read + Seek> {
     /// Buffered file reader that supports reading and seeking
     reader: BufReader<R>,
+
     /// The schema that is read from the file header
     schema: Arc<Schema>,
+
     /// The blocks in the file
     ///
     /// A block indicates the regions in the file to read to get data
     blocks: Vec<ipc::Block>,
+
     /// A counter to keep track of the current block that should be read
     current_block: usize,
+
     /// The total number of blocks, which may contain record batches and other types
     total_blocks: usize,
+
+    /// Optional dictionaries for each schema field.
+    ///
+    /// Dictionaries may be appended to in the streaming format.
+    dictionaries_by_field: Vec<Option<ArrayRef>>,
 }
 
 impl<R: Read + Seek> FileReader<R> {
@@ -420,24 +494,6 @@ impl<R: Read + Seek> FileReader<R> {
                 "Arrow file does not contain correct footer".to_string(),
             ));
         }
-        reader.seek(SeekFrom::Start(8))?;
-        // determine metadata length
-        let mut meta_size: [u8; 4] = [0; 4];
-        reader.read_exact(&mut meta_size)?;
-        let meta_len = u32::from_le_bytes(meta_size);
-
-        let mut meta_buffer = vec![0; meta_len as usize];
-        reader.seek(SeekFrom::Start(12))?;
-        reader.read_exact(&mut meta_buffer)?;
-
-        let vecs = &meta_buffer.to_vec();
-        let message = ipc::get_root_as_message(vecs);
-        // message header is a Schema, so read it
-        let ipc_schema: ipc::Schema =
-            message.header_as_schema().ok_or(ArrowError::IoError(
-                "Unable to Unable to read IPC message as schema".to_string(),
-            ))?;
-        let schema = ipc::convert::fb_to_schema(ipc_schema);
 
         // what does the footer contain?
         let mut footer_size: [u8; 4] = [0; 4];
@@ -457,12 +513,96 @@ impl<R: Read + Seek> FileReader<R> {
 
         let total_blocks = blocks.len();
 
+        let ipc_schema = footer.schema().unwrap();
+        let schema = ipc::convert::fb_to_schema(ipc_schema);
+
+        // Create an array of optional dictionary value arrays, one per field.
+        let mut dictionaries_by_field = vec![None; schema.fields().len()];
+        for block in footer.dictionaries().unwrap() {
+            // read length from end of offset
+            let meta_len = block.metaDataLength() - 4;
+
+            let mut block_data = vec![0; meta_len as usize];
+            reader.seek(SeekFrom::Start(block.offset() as u64 + 4))?;
+            reader.read_exact(&mut block_data)?;
+
+            let message = ipc::get_root_as_message(&block_data[..]);
+
+            match message.header_type() {
+                ipc::MessageHeader::DictionaryBatch => {
+                    let batch = message.header_as_dictionary_batch().unwrap();
+
+                    // read the block that makes up the dictionary batch into a buffer
+                    let mut buf = vec![0; block.bodyLength() as usize];
+                    reader.seek(SeekFrom::Start(
+                        block.offset() as u64 + block.metaDataLength() as u64,
+                    ))?;
+                    reader.read_exact(&mut buf)?;
+
+                    if batch.isDelta() {
+                        panic!("delta dictionary batches not supported");
+                    }
+
+                    let id = batch.id();
+
+                    // As the dictionary batch does not contain the type of the
+                    let first_field = find_dictionary_field(&ipc_schema, id)
+                        .expect("dictionary id not found in shchema");
+
+                    // Get an array representing this dictionary's values.
+                    let dictionary_values: ArrayRef =
+                        match schema.field(first_field).data_type() {
+                            DataType::Dictionary((_, ref value_type)) => {
+                                // Make a fake schema for the dictionary batch.
+                                let schema = Schema {
+                                    fields: vec![Field::new(
+                                        "",
+                                        value_type.as_ref().clone(),
+                                        false,
+                                    )],
+                                    metadata: HashMap::new(),
+                                };
+                                // Read a single column
+                                let record_batch = read_record_batch(
+                                    &buf,
+                                    batch.data().unwrap(),
+                                    Arc::new(schema),
+                                    &dictionaries_by_field,
+                                )?
+                                .unwrap();
+                                Some(record_batch.column(0).clone())
+                            }
+                            _ => None,
+                        }
+                        .expect("dictionary id not found in schema");
+
+                    // for all fields with this dictionary id, update the dictionaries vector
+                    // in the reader. Note that a dictionary batch may be shared between many fields.
+                    // We don't currently record the isOrdered field. This could be general
+                    // attributes of arrays.
+                    let fields = ipc_schema.fields().unwrap();
+                    for i in 0..fields.len() {
+                        let field: ipc::Field = fields.get(i);
+                        if let Some(dictionary) = field.dictionary() {
+                            if dictionary.id() == id {
+                                // Add (possibly multiple) array refs to the dictionaries array.
+                                dictionaries_by_field[i] =
+                                    Some(dictionary_values.clone());
+                            }
+                        }
+                    }
+                }
+                _ => panic!("Expecting DictionaryBatch in dictionary blocks."),
+            };
+        }
+
         Ok(Self {
             reader,
             schema: Arc::new(schema),
             blocks: blocks.to_vec(),
             current_block: 0,
             total_blocks,
+            dictionaries_by_field,
         })
     }
 
@@ -511,7 +651,12 @@ impl<R: Read + Seek> FileReader<R> {
                     ))?;
                     self.reader.read_exact(&mut buf)?;
 
-                    read_record_batch(&buf, batch, self.schema())
+                    read_record_batch(
+                        &buf,
+                        batch,
+                        self.schema(),
+                        &self.dictionaries_by_field,
+                    )
                 }
                 _ => {
                     return Err(ArrowError::IoError(
@@ -680,6 +825,7 @@ mod tests {
         let paths = vec![
             "generated_interval",
             "generated_datetime",
+            "generated_dictionary",
             "generated_nested",
             "generated_primitive_no_batches",
             "generated_primitive_zerolength",

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -169,7 +169,7 @@ fn create_array(
             Arc::new(struct_array)
         }
         // Create dictionary array from RecordBatch
-        Dictionary(_) => {
+        Dictionary(_, _) => {
             let index_node = &nodes[node_index];
             let index_buffers: Vec<Buffer> = buffers[buffer_index..buffer_index + 2]
                 .iter()
@@ -378,7 +378,7 @@ fn create_dictionary_array(
     buffers: &[Buffer],
     value_array: ArrayRef,
 ) -> ArrayRef {
-    if let &DataType::Dictionary(_) = data_type {
+    if let &DataType::Dictionary(_, _) = data_type {
         let null_count = field_node.null_count() as usize;
         let mut builder = ArrayData::builder(data_type.clone())
             .len(field_node.length() as usize)
@@ -553,7 +553,7 @@ impl<R: Read + Seek> FileReader<R> {
                     // Get an array representing this dictionary's values.
                     let dictionary_values: ArrayRef =
                         match schema.field(first_field).data_type() {
-                            DataType::Dictionary((_, ref value_type)) => {
+                            DataType::Dictionary(_, ref value_type) => {
                                 // Make a fake schema for the dictionary batch.
                                 let schema = Schema {
                                     fields: vec![Field::new(

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -546,6 +546,7 @@ impl<R: Read + Seek> FileReader<R> {
                     let id = batch.id();
 
                     // As the dictionary batch does not contain the type of the
+                    // values array, we need to retieve this from the schema.
                     let first_field = find_dictionary_field(&ipc_schema, id)
                         .expect("dictionary id not found in shchema");
 

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -392,7 +392,7 @@ fn create_dictionary_array(
         }
         make_array(builder.build())
     } else {
-        panic!("Cannot create dictionary array from {:?}", data_type)
+        unreachable!("Cannot create dictionary array from {:?}", data_type)
     }
 }
 

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -242,7 +242,7 @@ impl ArrowJsonBatch {
                                 .as_any()
                                 .downcast_ref::<Int8DictionaryArray>()
                                 .unwrap();
-                            arr.keys().equals_json(
+                            arr.equals_json(
                                 &json_array.iter().collect::<Vec<&Value>>()[..],
                             )
                         }
@@ -251,7 +251,7 @@ impl ArrowJsonBatch {
                                 .as_any()
                                 .downcast_ref::<Int16DictionaryArray>()
                                 .unwrap();
-                            arr.keys().equals_json(
+                            arr.equals_json(
                                 &json_array.iter().collect::<Vec<&Value>>()[..],
                             )
                         }
@@ -260,7 +260,7 @@ impl ArrowJsonBatch {
                                 .as_any()
                                 .downcast_ref::<Int32DictionaryArray>()
                                 .unwrap();
-                            arr.keys().equals_json(
+                            arr.equals_json(
                                 &json_array.iter().collect::<Vec<&Value>>()[..],
                             )
                         }
@@ -269,7 +269,7 @@ impl ArrowJsonBatch {
                                 .as_any()
                                 .downcast_ref::<Int64DictionaryArray>()
                                 .unwrap();
-                            arr.keys().equals_json(
+                            arr.equals_json(
                                 &json_array.iter().collect::<Vec<&Value>>()[..],
                             )
                         }
@@ -278,7 +278,7 @@ impl ArrowJsonBatch {
                                 .as_any()
                                 .downcast_ref::<UInt8DictionaryArray>()
                                 .unwrap();
-                            arr.keys().equals_json(
+                            arr.equals_json(
                                 &json_array.iter().collect::<Vec<&Value>>()[..],
                             )
                         }
@@ -287,7 +287,7 @@ impl ArrowJsonBatch {
                                 .as_any()
                                 .downcast_ref::<UInt16DictionaryArray>()
                                 .unwrap();
-                            arr.keys().equals_json(
+                            arr.equals_json(
                                 &json_array.iter().collect::<Vec<&Value>>()[..],
                             )
                         }
@@ -296,7 +296,7 @@ impl ArrowJsonBatch {
                                 .as_any()
                                 .downcast_ref::<UInt32DictionaryArray>()
                                 .unwrap();
-                            arr.keys().equals_json(
+                            arr.equals_json(
                                 &json_array.iter().collect::<Vec<&Value>>()[..],
                             )
                         }
@@ -305,7 +305,7 @@ impl ArrowJsonBatch {
                                 .as_any()
                                 .downcast_ref::<UInt64DictionaryArray>()
                                 .unwrap();
-                            arr.keys().equals_json(
+                            arr.equals_json(
                                 &json_array.iter().collect::<Vec<&Value>>()[..],
                             )
                         }

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -236,43 +236,81 @@ impl ArrowJsonBatch {
                         let arr = arr.as_any().downcast_ref::<StructArray>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
-                    DataType::Dictionary((ref key_type, _)) => {
-                        match key_type.as_ref() {
-                            DataType::Int8 => {
-                                let arr = arr.as_any().downcast_ref::<Int8DictionaryArray>().unwrap();
-                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
-                            }
-                            DataType::Int16 => {
-                                let arr = arr.as_any().downcast_ref::<Int16DictionaryArray>().unwrap();
-                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
-                            }
-                            DataType::Int32 => {
-                                let arr = arr.as_any().downcast_ref::<Int32DictionaryArray>().unwrap();
-                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
-                            }
-                            DataType::Int64 => {
-                                let arr = arr.as_any().downcast_ref::<Int64DictionaryArray>().unwrap();
-                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
-                            }
-                            DataType::UInt8 => {
-                                let arr = arr.as_any().downcast_ref::<UInt8DictionaryArray>().unwrap();
-                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
-                            }
-                            DataType::UInt16 => {
-                                let arr = arr.as_any().downcast_ref::<UInt16DictionaryArray>().unwrap();
-                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
-                            }
-                            DataType::UInt32 => {
-                                let arr = arr.as_any().downcast_ref::<UInt32DictionaryArray>().unwrap();
-                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
-                            }
-                            DataType::UInt64 => {
-                                let arr = arr.as_any().downcast_ref::<UInt64DictionaryArray>().unwrap();
-                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
-                            }
-                            t @ _ => panic!("Unsupported dictionary comparison for {:?}", t),
+                    DataType::Dictionary((ref key_type, _)) => match key_type.as_ref() {
+                        DataType::Int8 => {
+                            let arr = arr
+                                .as_any()
+                                .downcast_ref::<Int8DictionaryArray>()
+                                .unwrap();
+                            arr.keys().equals_json(
+                                &json_array.iter().collect::<Vec<&Value>>()[..],
+                            )
                         }
-                    }
+                        DataType::Int16 => {
+                            let arr = arr
+                                .as_any()
+                                .downcast_ref::<Int16DictionaryArray>()
+                                .unwrap();
+                            arr.keys().equals_json(
+                                &json_array.iter().collect::<Vec<&Value>>()[..],
+                            )
+                        }
+                        DataType::Int32 => {
+                            let arr = arr
+                                .as_any()
+                                .downcast_ref::<Int32DictionaryArray>()
+                                .unwrap();
+                            arr.keys().equals_json(
+                                &json_array.iter().collect::<Vec<&Value>>()[..],
+                            )
+                        }
+                        DataType::Int64 => {
+                            let arr = arr
+                                .as_any()
+                                .downcast_ref::<Int64DictionaryArray>()
+                                .unwrap();
+                            arr.keys().equals_json(
+                                &json_array.iter().collect::<Vec<&Value>>()[..],
+                            )
+                        }
+                        DataType::UInt8 => {
+                            let arr = arr
+                                .as_any()
+                                .downcast_ref::<UInt8DictionaryArray>()
+                                .unwrap();
+                            arr.keys().equals_json(
+                                &json_array.iter().collect::<Vec<&Value>>()[..],
+                            )
+                        }
+                        DataType::UInt16 => {
+                            let arr = arr
+                                .as_any()
+                                .downcast_ref::<UInt16DictionaryArray>()
+                                .unwrap();
+                            arr.keys().equals_json(
+                                &json_array.iter().collect::<Vec<&Value>>()[..],
+                            )
+                        }
+                        DataType::UInt32 => {
+                            let arr = arr
+                                .as_any()
+                                .downcast_ref::<UInt32DictionaryArray>()
+                                .unwrap();
+                            arr.keys().equals_json(
+                                &json_array.iter().collect::<Vec<&Value>>()[..],
+                            )
+                        }
+                        DataType::UInt64 => {
+                            let arr = arr
+                                .as_any()
+                                .downcast_ref::<UInt64DictionaryArray>()
+                                .unwrap();
+                            arr.keys().equals_json(
+                                &json_array.iter().collect::<Vec<&Value>>()[..],
+                            )
+                        }
+                        t @ _ => panic!("Unsupported dictionary comparison for {:?}", t),
+                    },
                     t @ _ => panic!("Unsupported comparison for {:?}", t),
                 }
             })

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -236,7 +236,7 @@ impl ArrowJsonBatch {
                         let arr = arr.as_any().downcast_ref::<StructArray>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
-                    DataType::Dictionary((ref key_type, _)) => match key_type.as_ref() {
+                    DataType::Dictionary(ref key_type, _) => match key_type.as_ref() {
                         DataType::Int8 => {
                             let arr = arr
                                 .as_any()

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -236,9 +236,42 @@ impl ArrowJsonBatch {
                         let arr = arr.as_any().downcast_ref::<StructArray>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
-                    DataType::Dictionary(_) => {
-                        let arr = arr.as_any().downcast_ref::<DictionaryArray>().unwrap();
-                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    DataType::Dictionary((ref key_type, _)) => {
+                        match key_type.as_ref() {
+                            DataType::Int8 => {
+                                let arr = arr.as_any().downcast_ref::<Int8DictionaryArray>().unwrap();
+                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                            }
+                            DataType::Int16 => {
+                                let arr = arr.as_any().downcast_ref::<Int16DictionaryArray>().unwrap();
+                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                            }
+                            DataType::Int32 => {
+                                let arr = arr.as_any().downcast_ref::<Int32DictionaryArray>().unwrap();
+                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                            }
+                            DataType::Int64 => {
+                                let arr = arr.as_any().downcast_ref::<Int64DictionaryArray>().unwrap();
+                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                            }
+                            DataType::UInt8 => {
+                                let arr = arr.as_any().downcast_ref::<UInt8DictionaryArray>().unwrap();
+                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                            }
+                            DataType::UInt16 => {
+                                let arr = arr.as_any().downcast_ref::<UInt16DictionaryArray>().unwrap();
+                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                            }
+                            DataType::UInt32 => {
+                                let arr = arr.as_any().downcast_ref::<UInt32DictionaryArray>().unwrap();
+                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                            }
+                            DataType::UInt64 => {
+                                let arr = arr.as_any().downcast_ref::<UInt64DictionaryArray>().unwrap();
+                                arr.keys().equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                            }
+                            t @ _ => panic!("Unsupported dictionary comparison for {:?}", t),
+                        }
                     }
                     t @ _ => panic!("Unsupported comparison for {:?}", t),
                 }

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -49,7 +49,7 @@ struct ArrowJsonBatch {
     columns: Vec<ArrowJsonColumn>,
 }
 
-/// A struct that partially reads the Arrow JSON record batch
+/// A struct that partially reads the Arrow JSON dictionary batch
 #[derive(Deserialize)]
 #[allow(non_snake_case)]
 struct ArrowJsonDictionaryBatch {


### PR DESCRIPTION
@nevi-me and @andygrove 

I've been working on the structure of the dictionary array getting the structure back into the spirit of the original design. The DictionaryArray is now typed by the key native type and could be typed by the value array type as otherwise, we can't implement value() in any meaningful way.

I've extended ArrowNativeType for use as an index (to/from usize) and added a value iterator which simplifies iteration over arrays of all kinds.