### PR TITLE
ARROW-7472: [Java] Fix some incorrect behavior in UnionListWriter

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
@@ -43,7 +43,6 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
   protected PromotableWriter writer;
   private boolean inStruct = false;
   private String structName;
-  private int lastIndex = 0;
   private final int listSize;
 
   public UnionFixedSizeListWriter(FixedSizeListVector vector) {
@@ -72,7 +71,7 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
 
   @Override
   public Field getField() {
-    return null;
+    return vector.getField();
   }
 
   public void setValueCount(int count) {
@@ -86,7 +85,7 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
 
   @Override
   public void close() throws Exception {
-
+    vector.close();
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
@@ -86,6 +86,7 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
   @Override
   public void close() throws Exception {
     vector.close();
+    writer.close();
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -43,7 +43,6 @@ public class UnionListWriter extends AbstractFieldWriter {
   protected PromotableWriter writer;
   private boolean inStruct = false;
   private String structName;
-  private int lastIndex = 0;
   private static final int OFFSET_WIDTH = 4;
 
   public UnionListWriter(ListVector vector) {
@@ -71,7 +70,7 @@ public class UnionListWriter extends AbstractFieldWriter {
 
   @Override
   public Field getField() {
-    return null;
+    return vector.getField();
   }
 
   public void setValueCount(int count) {
@@ -85,7 +84,7 @@ public class UnionListWriter extends AbstractFieldWriter {
 
   @Override
   public void close() throws Exception {
-
+    vector.close();
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -85,6 +85,7 @@ public class UnionListWriter extends AbstractFieldWriter {
   @Override
   public void close() throws Exception {
     vector.close();
+    writer.close();
   }
 
   @Override

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.arrow.memory.BufferAllocator;
@@ -31,6 +32,8 @@ import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.junit.After;
@@ -870,6 +873,29 @@ public class TestListVector {
       result = vector.getObject(1);
       resultSet = (ArrayList<Long>) result;
       assertEquals(new Long(8), resultSet.get(0));
+    }
+  }
+
+  @Test
+  public void testWriterGetField() {
+    try (final ListVector vector = ListVector.empty("list", allocator)) {
+
+      UnionListWriter writer = vector.getWriter();
+      writer.allocate();
+
+      //set some values
+      writer.startList();
+      writer.integer().writeInt(1);
+      writer.integer().writeInt(2);
+      writer.endList();
+      vector.setValueCount(2);
+
+      Field expectedDataField = new Field(BaseRepeatedValueVector.DATA_VECTOR_NAME,
+          FieldType.nullable(new ArrowType.Int(32, true)), null);
+      Field expectedField = new Field(vector.getName(), FieldType.nullable(ArrowType.List.INSTANCE),
+          Arrays.asList(expectedDataField));
+
+      assertEquals(expectedField, writer.getField());
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -900,6 +900,29 @@ public class TestListVector {
   }
 
   @Test
+  public void testClose() throws Exception {
+    try (final ListVector vector = ListVector.empty("list", allocator)) {
+
+      UnionListWriter writer = vector.getWriter();
+      writer.allocate();
+
+      //set some values
+      writer.startList();
+      writer.integer().writeInt(1);
+      writer.integer().writeInt(2);
+      writer.endList();
+      vector.setValueCount(2);
+
+      assertTrue(vector.getBufferSize() > 0);
+      assertTrue(vector.getDataVector().getBufferSize() > 0);
+
+      writer.close();
+      assertEquals(0, vector.getBufferSize());
+      assertEquals(0, vector.getDataVector().getBufferSize());
+    }
+  }
+
+  @Test
   public void testGetBufferSizeFor() {
     try (final ListVector vector = ListVector.empty("list", allocator)) {
 


### PR DESCRIPTION
Related to [ARROW-7472](https://issues.apache.org/jira/browse/ARROW-7472).
Currently the UnionListWriter/UnionFixedSizeListWriter getField/close APIs seems incorrect.