### PR TITLE
ARROW-7290: [C#] Implement ListArray Builder

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/ArrowArrayBuilderFactory.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrowArrayBuilderFactory.cs
@@ -18,9 +18,9 @@ using System;
 
 namespace Apache.Arrow
 {
-    public static class ArrowArrayBuilderFactory
+    static class ArrowArrayBuilderFactory
     {
-        public static IArrowArrayBuilder<IArrowArray, IArrowArrayBuilder<IArrowArray>> BuildBuilder(IArrowType dataType)
+        internal static IArrowArrayBuilder<IArrowArray, IArrowArrayBuilder<IArrowArray>> BuildBuilder(IArrowType dataType)
         {
             switch (dataType.TypeId)
             {

--- a/csharp/src/Apache.Arrow/Arrays/ArrowArrayBuilderFactory.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrowArrayBuilderFactory.cs
@@ -20,7 +20,7 @@ namespace Apache.Arrow
 {
     static class ArrowArrayBuilderFactory
     {
-        internal static IArrowArrayBuilder<IArrowArray, IArrowArrayBuilder<IArrowArray>> BuildBuilder(IArrowType dataType)
+        internal static IArrowArrayBuilder<IArrowArray, IArrowArrayBuilder<IArrowArray>> Build(IArrowType dataType)
         {
             switch (dataType.TypeId)
             {

--- a/csharp/src/Apache.Arrow/Arrays/ArrowArrayBuilderFactory.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ArrowArrayBuilderFactory.cs
@@ -1,0 +1,76 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Apache.Arrow.Types;
+using System;
+
+namespace Apache.Arrow
+{
+    public static class ArrowArrayBuilderFactory
+    {
+        public static IArrowArrayBuilder<IArrowArray, IArrowArrayBuilder<IArrowArray>> BuildBuilder(IArrowType dataType)
+        {
+            switch (dataType.TypeId)
+            {
+                case ArrowTypeId.Boolean:
+                    return new BooleanArray.Builder();
+                case ArrowTypeId.UInt8:
+                    return new UInt8Array.Builder();
+                case ArrowTypeId.Int8:
+                    return new Int8Array.Builder();
+                case ArrowTypeId.UInt16:
+                    return new UInt16Array.Builder();
+                case ArrowTypeId.Int16:
+                    return new Int16Array.Builder();
+                case ArrowTypeId.UInt32:
+                    return new UInt32Array.Builder();
+                case ArrowTypeId.Int32:
+                    return new Int32Array.Builder();
+                case ArrowTypeId.UInt64:
+                    return new UInt64Array.Builder();
+                case ArrowTypeId.Int64:
+                    return new Int64Array.Builder();
+                case ArrowTypeId.Float:
+                    return new FloatArray.Builder();
+                case ArrowTypeId.Double:
+                    return new DoubleArray.Builder();
+                case ArrowTypeId.String:
+                    return new StringArray.Builder();
+                case ArrowTypeId.Binary:
+                    return new BinaryArray.Builder();
+                case ArrowTypeId.Timestamp:
+                    return new TimestampArray.Builder();
+                case ArrowTypeId.Date64:
+                    return new Date64Array.Builder();
+                case ArrowTypeId.Date32:
+                    return new Date32Array.Builder();
+                case ArrowTypeId.List:
+                    return new ListArray.Builder(dataType as ListType);
+                case ArrowTypeId.Struct:
+                case ArrowTypeId.Union:
+                case ArrowTypeId.Decimal:
+                case ArrowTypeId.Dictionary:
+                case ArrowTypeId.FixedSizedBinary:
+                case ArrowTypeId.HalfFloat:
+                case ArrowTypeId.Interval:
+                case ArrowTypeId.Map:
+                case ArrowTypeId.Time32:
+                case ArrowTypeId.Time64:
+                default:
+                    throw new NotSupportedException($"An ArrowArrayBuilder cannot be built for type {dataType.TypeId}.");
+            }
+        }
+    }
+}

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -67,6 +67,8 @@ namespace Apache.Arrow
 
             protected abstract TArray Build(ArrayData data);
 
+            public int Length => ValueOffsets.Length;
+
             public TArray Build(MemoryAllocator allocator = default)
             {
                 ValueOffsets.Append(Offset);

--- a/csharp/src/Apache.Arrow/Arrays/ListArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ListArray.cs
@@ -142,7 +142,6 @@ namespace Apache.Arrow
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            //TODO: Use IArrowArray.Slice
             if (!(Values is Array array))
             {
                 return default;

--- a/csharp/src/Apache.Arrow/Arrays/ListArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ListArray.cs
@@ -14,12 +14,77 @@
 // limitations under the License.
 
 using System;
+using Apache.Arrow.Memory;
 using Apache.Arrow.Types;
 
 namespace Apache.Arrow
 {
     public class ListArray : Array
     {
+
+
+        public class Builder : IArrowArrayBuilder<ListArray, Builder>
+        {
+            // TODO: Implement support for null values (null bitmaps)
+
+            public IArrowArrayBuilder<IArrowArray, IArrowArrayBuilder<IArrowArray>> ValueBuilder { get; }
+
+            public int Length => ValueOffsetsBufferBuilder.Length;
+
+            private ArrowBuffer.Builder<int> ValueOffsetsBufferBuilder { get; }
+
+            private IArrowType DataType { get; }
+
+            public Builder(ListType dataType)
+            {
+                ValueBuilder = ArrowArrayBuilderFactory.BuildBuilder(dataType.ValueDataType);
+                ValueOffsetsBufferBuilder = new ArrowBuffer.Builder<int>();
+                DataType = dataType;
+            }
+
+            /// <summary>
+            /// Start a new variable-length list slot
+            ///
+            /// This function should be called before beginning to append elements to the
+            /// value builder
+            /// </summary>
+            /// <returns></returns>
+            public Builder Append()
+            {
+                ValueOffsetsBufferBuilder.Append(ValueBuilder.Length);
+                return this;
+            }
+
+            public ListArray Build(MemoryAllocator allocator = default)
+            {
+                Append();
+
+                return new ListArray(DataType, Length - 1,
+                    ValueOffsetsBufferBuilder.Build(allocator), ValueBuilder.Build(allocator),
+                    new ArrowBuffer(), 0, 0);
+            }
+
+            public Builder Reserve(int capacity)
+            {
+                ValueOffsetsBufferBuilder.Reserve(capacity + 1);
+                return this;
+            }
+
+            public Builder Resize(int length)
+            {
+                ValueOffsetsBufferBuilder.Resize(length + 1);
+                return this;
+            }
+
+            public Builder Clear()
+            {
+                ValueOffsetsBufferBuilder.Clear();
+                ValueBuilder.Clear();
+                return this;
+            }
+
+        }
+
         public IArrowArray Values { get; }
 
         public ArrowBuffer ValueOffsetsBuffer => Data.Buffers[1];
@@ -49,15 +114,41 @@ namespace Apache.Arrow
 
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
 
+
+        [Obsolete]
         public int GetValueOffset(int index)
         {
+            if (index < 0 || index > Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
             return ValueOffsets[index];
         }
 
         public int GetValueLength(int index)
         {
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
             var offsets = ValueOffsets;
             return offsets[index + 1] - offsets[index];
+        }
+
+        public IArrowArray GetSlicedValues(int index)
+        {
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            //TODO: Use IArrowArray.Slice
+            if (!(Values is Array array))
+            {
+                return default;
+            }
+
+            return array.Slice(ValueOffsets[index], GetValueLength(index));
         }
 
         protected override void Dispose(bool disposing)

--- a/csharp/src/Apache.Arrow/Arrays/ListArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ListArray.cs
@@ -37,7 +37,7 @@ namespace Apache.Arrow
 
             public Builder(ListType dataType)
             {
-                ValueBuilder = ArrowArrayBuilderFactory.BuildBuilder(dataType.ValueDataType);
+                ValueBuilder = ArrowArrayBuilderFactory.Build(dataType.ValueDataType);
                 ValueOffsetsBufferBuilder = new ArrowBuffer.Builder<int>();
                 DataType = dataType;
             }

--- a/csharp/src/Apache.Arrow/Arrays/ListArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ListArray.cs
@@ -35,7 +35,15 @@ namespace Apache.Arrow
 
             private IArrowType DataType { get; }
 
-            public Builder(ListType dataType)
+            public Builder(IArrowType valueDataType) : this(new ListType(valueDataType))
+            {
+            }
+
+            public Builder(Field valueField) : this(new ListType(valueField))
+            {
+            }
+
+            internal Builder(ListType dataType)
             {
                 ValueBuilder = ArrowArrayBuilderFactory.Build(dataType.ValueDataType);
                 ValueOffsetsBufferBuilder = new ArrowBuffer.Builder<int>();

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArrayBuilder.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArrayBuilder.cs
@@ -20,15 +20,17 @@ using System.Linq;
 
 namespace Apache.Arrow
 {
-    public abstract class PrimitiveArrayBuilder<TFrom, TTo, TArray, TBuilder> : IArrowArrayBuilder<TFrom, TArray>
-        where TTo: struct
-        where TArray: IArrowArray
-        where TBuilder: class, IArrowArrayBuilder<TArray>
+    public abstract class PrimitiveArrayBuilder<TFrom, TTo, TArray, TBuilder> : IArrowArrayBuilder<TArray, TBuilder>
+        where TTo : struct
+        where TArray : IArrowArray
+        where TBuilder : class, IArrowArrayBuilder<TArray>
     {
         protected TBuilder Instance => this as TBuilder;
-        protected IArrowArrayBuilder<TTo, TArray, IArrowArrayBuilder<TTo, TArray>> ArrayBuilder { get; }
+        protected IArrowArrayBuilder<TTo, TArray, IArrowArrayBuilder<TArray>> ArrayBuilder { get; }
 
-        internal PrimitiveArrayBuilder(IArrowArrayBuilder<TTo, TArray, IArrowArrayBuilder<TTo, TArray>> builder)
+        public int Length => ArrayBuilder.Length;
+
+        internal PrimitiveArrayBuilder(IArrowArrayBuilder<TTo, TArray, IArrowArrayBuilder<TArray>> builder)
         {
             ArrayBuilder = builder ?? throw new ArgumentNullException(nameof(builder));
         }
@@ -91,12 +93,14 @@ namespace Apache.Arrow
     }
 
     public abstract class PrimitiveArrayBuilder<T, TArray, TBuilder> : IArrowArrayBuilder<T, TArray, TBuilder>
-        where T: struct
+        where T : struct
         where TArray : IArrowArray
-        where TBuilder : class, IArrowArrayBuilder<T, TArray>
+        where TBuilder : class, IArrowArrayBuilder<TArray>
     {
         protected TBuilder Instance => this as TBuilder;
         protected ArrowBuffer.Builder<T> ValueBuffer { get; }
+
+        public int Length => ValueBuffer.Length;
 
         // TODO: Implement support for null values (null bitmaps)
 

--- a/csharp/src/Apache.Arrow/Interfaces/IArrowArrayBuilder.cs
+++ b/csharp/src/Apache.Arrow/Interfaces/IArrowArrayBuilder.cs
@@ -19,28 +19,35 @@ using System.Collections.Generic;
 
 namespace Apache.Arrow
 {
-    public interface IArrowArrayBuilder { }
+    public interface IArrowArrayBuilder
+    {
+        int Length { get; }
+    }
 
     public interface IArrowArrayBuilder<out TArray> : IArrowArrayBuilder
-        where TArray: IArrowArray
-    {
+        where TArray : IArrowArray
+    { 
         TArray Build(MemoryAllocator allocator);
     }
 
-    public interface IArrowArrayBuilder<T, out TArray> : IArrowArrayBuilder<TArray>
-        where TArray: IArrowArray { }
+    public interface IArrowArrayBuilder<out TArray, out TBuilder> : IArrowArrayBuilder<TArray>
+        where TArray : IArrowArray
+        where TBuilder : IArrowArrayBuilder<TArray>
+    {
+        TBuilder Reserve(int capacity);
+        TBuilder Resize(int length);
+        TBuilder Clear();
+    }
 
-    public interface IArrowArrayBuilder<T, out TArray, out TBuilder> : IArrowArrayBuilder<T, TArray>
+
+    public interface IArrowArrayBuilder<T, out TArray, out TBuilder> : IArrowArrayBuilder<TArray, TBuilder>
         where TArray : IArrowArray
         where TBuilder : IArrowArrayBuilder<TArray>
     {
         TBuilder Append(T value);
         TBuilder Append(ReadOnlySpan<T> span);
         TBuilder AppendRange(IEnumerable<T> values);
-        TBuilder Reserve(int capacity);
-        TBuilder Resize(int length);
         TBuilder Swap(int i, int j);
         TBuilder Set(int index, T value);
-        TBuilder Clear();
     }
 }

--- a/csharp/test/Apache.Arrow.Benchmarks/ArrowWriterBenchmark.cs
+++ b/csharp/test/Apache.Arrow.Benchmarks/ArrowWriterBenchmark.cs
@@ -28,7 +28,7 @@ namespace Apache.Arrow.Benchmarks
         [Params(10_000, 1_000_000)]
         public int BatchLength{ get; set; }
 
-        [Params(10, 20)]
+        [Params(10, 25)]
         public int ColumnSetCount { get; set; }
 
         private MemoryStream _memoryStream;

--- a/csharp/test/Apache.Arrow.Benchmarks/ArrowWriterBenchmark.cs
+++ b/csharp/test/Apache.Arrow.Benchmarks/ArrowWriterBenchmark.cs
@@ -28,7 +28,7 @@ namespace Apache.Arrow.Benchmarks
         [Params(10_000, 1_000_000)]
         public int BatchLength{ get; set; }
 
-        [Params(10, 25)]
+        [Params(10, 20)]
         public int ColumnSetCount { get; set; }
 
         private MemoryStream _memoryStream;

--- a/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
@@ -43,7 +43,18 @@ namespace Apache.Arrow.Tests
         [Fact]
         public void ListArrayBuilder()
         {
-            var list = CreateList();
+            var stringField = new Field("item", StringType.Default, true);
+            var listBuilder = new ListArray.Builder(new ListType(stringField));
+            var valueBuilder = listBuilder.ValueBuilder as StringArray.Builder;
+            Assert.NotNull(valueBuilder);
+            listBuilder.Append();
+            valueBuilder.Append("1");
+            listBuilder.Append();
+            valueBuilder.Append("22").Append("33");
+            listBuilder.Append();
+            valueBuilder.Append("444").Append("555").Append("666");
+
+            var list = listBuilder.Build();
 
             Assert.Equal(
                 new List<string> { "1" },
@@ -54,22 +65,6 @@ namespace Apache.Arrow.Tests
             Assert.Equal(
                 new List<string> { "444", "555", "666" },
                 ConvertStringArrayToList(list.GetSlicedValues(2) as StringArray));
-
-            ListArray CreateList()
-            {
-                var stringField = new Field("item", StringType.Default, true);
-                var listBuilder = new ListArray.Builder(new ListType(stringField));
-                var valueBuilder = listBuilder.ValueBuilder as StringArray.Builder;
-                Assert.NotNull(valueBuilder);
-                listBuilder.Append();
-                valueBuilder.Append("1");
-                listBuilder.Append();
-                valueBuilder.Append("22").Append("33");
-                listBuilder.Append();
-                valueBuilder.Append("444").Append("555").Append("666");
-
-                return listBuilder.Build();
-            }
 
             List<string> ConvertStringArrayToList(StringArray array)
             {
@@ -86,7 +81,29 @@ namespace Apache.Arrow.Tests
         [Fact]
         public void NestedListArrayBuilder()
         {
-            var parentList = CreateList();
+            var int64Field = new Field("item", Int64Type.Default, true);
+            var childListType = new ListType(int64Field);
+            var parentListType = new ListType(childListType);
+            var parentListBuilder = new ListArray.Builder(parentListType);
+            var childListBuilder = parentListBuilder.ValueBuilder as ListArray.Builder;
+            Assert.NotNull(childListBuilder);
+            var valueBuilder = childListBuilder.ValueBuilder as Int64Array.Builder;
+            Assert.NotNull(valueBuilder);
+
+            parentListBuilder.Append();
+            childListBuilder.Append();
+            valueBuilder.Append(1);
+            childListBuilder.Append();
+            valueBuilder.Append(2).Append(3);
+            parentListBuilder.Append();
+            childListBuilder.Append();
+            valueBuilder.Append(4).Append(5).Append(6).Append(7);
+            parentListBuilder.Append();
+            childListBuilder.Append();
+            valueBuilder.Append(8).Append(9).Append(10).Append(11).Append(12);
+
+            var parentList = parentListBuilder.Build();
+
             var childList1 = (ListArray)parentList.GetSlicedValues(0);
             var childList2 = (ListArray)parentList.GetSlicedValues(1);
             var childList3 = (ListArray)parentList.GetSlicedValues(2);
@@ -106,32 +123,6 @@ namespace Apache.Arrow.Tests
             Assert.Equal(
                 new List<long?> { 8, 9, 10, 11, 12 },
                 ((Int64Array)childList3.GetSlicedValues(0)).ToList());
-
-            ListArray CreateList()
-            {
-                var int64Field = new Field("item", Int64Type.Default, true);
-                var childListType = new ListType(int64Field);
-                var parentListType = new ListType(childListType);
-                var parentListBuilder = new ListArray.Builder(parentListType);
-                var childListBuilder = parentListBuilder.ValueBuilder as ListArray.Builder;
-                Assert.NotNull(childListBuilder);
-                var valueBuilder = childListBuilder.ValueBuilder as Int64Array.Builder;
-                Assert.NotNull(valueBuilder);
-
-                parentListBuilder.Append();
-                childListBuilder.Append();
-                valueBuilder.Append(1);
-                childListBuilder.Append();
-                valueBuilder.Append(2).Append(3);
-                parentListBuilder.Append();
-                childListBuilder.Append();
-                valueBuilder.Append(4).Append(5).Append(6).Append(7);
-                parentListBuilder.Append();
-                childListBuilder.Append();
-                valueBuilder.Append(8).Append(9).Append(10).Append(11).Append(12);
-
-                return parentListBuilder.Build();
-            }
         }
 
         public class TimestampArrayBuilder

--- a/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
@@ -15,6 +15,7 @@
 
 using Apache.Arrow.Types;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Apache.Arrow.Tests
@@ -38,6 +39,101 @@ namespace Apache.Arrow.Tests
             TestArrayBuilder<DoubleArray, DoubleArray.Builder>(x => x.Append(10).Append(20).Append(30));
         }
 
+
+        [Fact]
+        public void ListArrayBuilder()
+        {
+            var list = CreateList();
+
+            Assert.Equal(
+                new List<string> { "1" },
+                ConvertStringArrayToList(list.GetSlicedValues(0) as StringArray));
+            Assert.Equal(
+                new List<string> { "22", "33" },
+                ConvertStringArrayToList(list.GetSlicedValues(1) as StringArray));
+            Assert.Equal(
+                new List<string> { "444", "555", "666" },
+                ConvertStringArrayToList(list.GetSlicedValues(2) as StringArray));
+
+            ListArray CreateList()
+            {
+                var stringField = new Field("item", StringType.Default, true);
+                var listBuilder = new ListArray.Builder(new ListType(stringField));
+                var valueBuilder = listBuilder.ValueBuilder as StringArray.Builder;
+                Assert.NotNull(valueBuilder);
+                listBuilder.Append();
+                valueBuilder.Append("1");
+                listBuilder.Append();
+                valueBuilder.Append("22").Append("33");
+                listBuilder.Append();
+                valueBuilder.Append("444").Append("555").Append("666");
+
+                return listBuilder.Build();
+            }
+
+            List<string> ConvertStringArrayToList(StringArray array)
+            {
+                var length = array.Length;
+                var resultList = new List<string>(length);
+                for (var index = 0; index < length; index++)
+                {
+                    resultList.Add(array.GetString(index));
+                }
+                return resultList;
+            }
+        }
+
+        [Fact]
+        public void NestedListArrayBuilder()
+        {
+            var parentList = CreateList();
+            var childList1 = (ListArray)parentList.GetSlicedValues(0);
+            var childList2 = (ListArray)parentList.GetSlicedValues(1);
+            var childList3 = (ListArray)parentList.GetSlicedValues(2);
+
+            Assert.Equal(2, childList1.Length);
+            Assert.Equal(1, childList2.Length);
+            Assert.Equal(1, childList3.Length);
+            Assert.Equal(
+                new List<long?> { 1 },
+                ((Int64Array)childList1.GetSlicedValues(0)).ToList());
+            Assert.Equal(
+                new List<long?> { 2, 3 },
+                ((Int64Array)childList1.GetSlicedValues(1)).ToList());
+            Assert.Equal(
+                new List<long?> { 4, 5, 6, 7 },
+                ((Int64Array)childList2.GetSlicedValues(0)).ToList());
+            Assert.Equal(
+                new List<long?> { 8, 9, 10, 11, 12 },
+                ((Int64Array)childList3.GetSlicedValues(0)).ToList());
+
+            ListArray CreateList()
+            {
+                var int64Field = new Field("item", Int64Type.Default, true);
+                var childListType = new ListType(int64Field);
+                var parentListType = new ListType(childListType);
+                var parentListBuilder = new ListArray.Builder(parentListType);
+                var childListBuilder = parentListBuilder.ValueBuilder as ListArray.Builder;
+                Assert.NotNull(childListBuilder);
+                var valueBuilder = childListBuilder.ValueBuilder as Int64Array.Builder;
+                Assert.NotNull(valueBuilder);
+
+                parentListBuilder.Append();
+                childListBuilder.Append();
+                valueBuilder.Append(1);
+                childListBuilder.Append();
+                valueBuilder.Append(2).Append(3);
+                parentListBuilder.Append();
+                childListBuilder.Append();
+                valueBuilder.Append(4).Append(5).Append(6).Append(7);
+                parentListBuilder.Append();
+                childListBuilder.Append();
+                valueBuilder.Append(8).Append(9).Append(10).Append(11).Append(12);
+
+                return parentListBuilder.Build();
+            }
+        }
+
         public class TimestampArrayBuilder
         {
             [Fact]
@@ -56,8 +152,8 @@ namespace Apache.Arrow.Tests
         }
 
         private static void TestArrayBuilder<TArray, TArrayBuilder>(Action<TArrayBuilder> action)
-            where TArray: IArrowArray
-            where TArrayBuilder: IArrowArrayBuilder<TArray>, new()
+            where TArray : IArrowArray
+            where TArrayBuilder : IArrowArrayBuilder<TArray>, new()
         {
             var builder = new TArrayBuilder();
             action(builder);
@@ -68,6 +164,6 @@ namespace Apache.Arrow.Tests
             Assert.Equal(3, array.Length);
             Assert.Equal(0, array.NullCount);
         }
-        
+
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrayBuilderTests.cs
@@ -43,8 +43,7 @@ namespace Apache.Arrow.Tests
         [Fact]
         public void ListArrayBuilder()
         {
-            var stringField = new Field("item", StringType.Default, true);
-            var listBuilder = new ListArray.Builder(new ListType(stringField));
+            var listBuilder = new ListArray.Builder(StringType.Default);
             var valueBuilder = listBuilder.ValueBuilder as StringArray.Builder;
             Assert.NotNull(valueBuilder);
             listBuilder.Append();
@@ -81,10 +80,8 @@ namespace Apache.Arrow.Tests
         [Fact]
         public void NestedListArrayBuilder()
         {
-            var int64Field = new Field("item", Int64Type.Default, true);
-            var childListType = new ListType(int64Field);
-            var parentListType = new ListType(childListType);
-            var parentListBuilder = new ListArray.Builder(parentListType);
+            var childListType = new ListType(Int64Type.Default);
+            var parentListBuilder = new ListArray.Builder(childListType);
             var childListBuilder = parentListBuilder.ValueBuilder as ListArray.Builder;
             Assert.NotNull(childListBuilder);
             var valueBuilder = childListBuilder.ValueBuilder as Int64Array.Builder;

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -181,17 +181,19 @@ namespace Apache.Arrow.Tests
 
             public void Visit(ListType type)
             {
-                //Todo : Use ListArray.Builder
-                var children = new [] { CreateArray(type.ValueField, Length).Data };
-                ArrowBuffer.Builder<int> builder = new ArrowBuffer.Builder<int>(Length);
-                for (int i = 0; i < Length; i++)
+                var builder = new ListArray.Builder(type).Reserve(Length);
+
+                //Todo : Support various types
+                var valueBuilder = (Int64Array.Builder)builder.ValueBuilder.Reserve(Length);
+
+                for (var i = 0; i < Length; i++)
                 {
-                    builder.Append(i);
+                    builder.Append();
+                    valueBuilder.Append(i);
                 }
 
-                var valueOffsetsBuffer = builder.Build();
-                Array = new ListArray(new ArrayData(type, Length, 0, 0,
-                    new[] { ArrowBuffer.Empty, valueOffsetsBuffer }, children));
+                Array = builder.Build();
+
             }
 
             private void GenerateArray<T, TArray, TArrayBuilder>(IArrowArrayBuilder<T, TArray, TArrayBuilder> builder, Func<int, T> generator)

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -185,7 +185,7 @@ namespace Apache.Arrow.Tests
 
             public void Visit(ListType type)
             {
-                var builder = new ListArray.Builder(type).Reserve(Length);
+                var builder = new ListArray.Builder(type.ValueField).Reserve(Length);
 
                 //Todo : Support various types
                 var valueBuilder = (Int64Array.Builder)builder.ValueBuilder.Reserve(Length);

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -172,7 +172,7 @@ namespace Apache.Arrow.Tests
 
             public void Visit(StringType type)
             {
-                var str = "helloworld";
+                var str = "hello";
                 var builder = new StringArray.Builder();
 
                 for (var i = 0; i < Length; i++)


### PR DESCRIPTION
* Add ListArray.Builder
* Add ArrowArrayBuilderFactory
* Change IArrowArrayBuilder
Some builders like ListArray.Builder need not specify a value on Append. To support such builders, I added IArrowArrayBuilder<TArray, TBuilder>> and changed IArrowArrayBuilder<T, TArray, TBuilder>> to inherit it.
