### PR TITLE
ARROW-7481: [C#] fix typo

### DIFF
--- a/csharp/.gitignore
+++ b/csharp/.gitignore
@@ -159,7 +159,7 @@ PublishScripts/
 !**/packages/build/
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/packages/repositories.config
-# NuGet v3's project.json files produces more ignoreable files
+# NuGet v3's project.json files produces more ignorable files
 *.nuget.props
 *.nuget.targets
 

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -154,7 +154,7 @@ Which will build the final/stable package.
 NOTE: When building the officially released version, ensure that your `git` repository has the `origin` remote set to `https://github.com/apache/arrow.git`, which will ensure Source Link is set correctly. See https://github.com/dotnet/sourcelink/blob/master/docs/README.md for more information.
 
 There are two output artifacts:
-1. `Apache.Arrow.<version>.nupkg` - this contains the exectuable assemblies
+1. `Apache.Arrow.<version>.nupkg` - this contains the executable assemblies
 2. `Apache.Arrow.<version>.snupkg` - this contains the debug symbols files
 
 Both of these artifacts can then be uploaded to https://www.nuget.org/packages/manage/upload.

--- a/csharp/src/Apache.Arrow/Flatbuf/FlatBuffers/ByteBuffer.cs
+++ b/csharp/src/Apache.Arrow/Flatbuf/FlatBuffers/ByteBuffer.cs
@@ -214,7 +214,7 @@ namespace FlatBuffers
         }
 
         /// <summary>
-        /// Get the wire-size (in bytes) of an typed array
+        /// Get the wire-size (in bytes) of a typed array
         /// </summary>
         /// <typeparam name="T">The type of the array</typeparam>
         /// <param name="x">The array to get the size of</param>
@@ -289,7 +289,7 @@ namespace FlatBuffers
 #endif
 
 #if !UNSAFE_BYTEBUFFER
-        // Pre-allocated helper arrays for convertion.
+        // Pre-allocated helper arrays for conversion.
         private float[] floathelper = new[] { 0.0f };
         private int[] inthelper = new[] { 0 };
         private double[] doublehelper = new[] { 0.0 };

--- a/csharp/src/Apache.Arrow/Flatbuf/FlatBuffers/FlatBufferBuilder.cs
+++ b/csharp/src/Apache.Arrow/Flatbuf/FlatBuffers/FlatBufferBuilder.cs
@@ -387,7 +387,7 @@ namespace FlatBuffers
             return EndVector();
         }
 
-        /// @cond FLATBUFFERS_INTENRAL
+        /// @cond FLATBUFFERS_INTERNAL
         public void Nested(int obj)
         {
             // Structs are always stored inline, so need to be created right

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
@@ -72,9 +72,9 @@ namespace Apache.Arrow.Ipc
 
             await ArrayPool<byte>.Shared.RentReturnAsync(footerLength, async (buffer) =>
             {
-                long footerStartPostion = GetFooterLengthPosition() - footerLength;
+                long footerStartPosition = GetFooterLengthPosition() - footerLength;
 
-                BaseStream.Position = footerStartPostion;
+                BaseStream.Position = footerStartPosition;
 
                 int bytesRead = await BaseStream.ReadFullBufferAsync(buffer).ConfigureAwait(false);
                 EnsureFullRead(buffer, bytesRead);
@@ -105,9 +105,9 @@ namespace Apache.Arrow.Ipc
 
             ArrayPool<byte>.Shared.RentReturn(footerLength, (buffer) =>
             {
-                long footerStartPostion = GetFooterLengthPosition() - footerLength;
+                long footerStartPosition = GetFooterLengthPosition() - footerLength;
 
-                BaseStream.Position = footerStartPostion;
+                BaseStream.Position = footerStartPosition;
 
                 int bytesRead = BaseStream.ReadFullBuffer(buffer);
                 EnsureFullRead(buffer, bytesRead);

--- a/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
+++ b/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
@@ -74,8 +74,8 @@ namespace Apache.Arrow.Ipc
                     var intMetaData = field.Type<Flatbuf.Int>().Value;
                     return MessageSerializer.GetNumberType(intMetaData.BitWidth, intMetaData.IsSigned);
                 case Flatbuf.Type.FloatingPoint:
-                    var floatingPointTypeMetadta = field.Type<Flatbuf.FloatingPoint>().Value;
-                    switch (floatingPointTypeMetadta.Precision)
+                    var floatingPointTypeMetadata = field.Type<Flatbuf.FloatingPoint>().Value;
+                    switch (floatingPointTypeMetadata.Precision)
                     {
                         case Flatbuf.Precision.SINGLE:
                             return Types.FloatType.Default;


### PR DESCRIPTION
This PR fixes typos in files under `csharp` directory