### PR TITLE
PARQUET-1734: [C++] Fix typo 

### DIFF
--- a/cpp/examples/parquet/low-level-api/encryption-reader-writer-all-crypto-options.cc
+++ b/cpp/examples/parquet/low-level-api/encryption-reader-writer-all-crypto-options.cc
@@ -157,7 +157,7 @@ void InteropTestWriteEncryptedParquetFiles(std::string root_path) {
                          Creating a number of Encryption configurations
    **********************************************************************************/
 
-  // This vector will hold various encryption configuraions.
+  // This vector will hold various encryption configurations.
   std::vector<std::shared_ptr<parquet::FileEncryptionProperties>>
       vector_of_encryption_configurations;
 
@@ -575,7 +575,7 @@ void PrintDecryptionConfiguration(int configuration) {
   else if (configuration == 3)
     std::cout << "3: \n\nDecrypt using explicit column and footer keys." << std::endl;
   else {
-    std::cout << "Unknown configuraion" << std::endl;
+    std::cout << "Unknown configuration" << std::endl;
     exit(-1);
   }
   std::cout << std::endl;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1029,7 +1029,7 @@ TEST_F(TestInt96ParquetIO, ReadIntoTimestamp) {
 
 using TestUInt32ParquetIO = TestParquetIO<::arrow::UInt32Type>;
 
-TEST_F(TestUInt32ParquetIO, Parquet_2_0_Compability) {
+TEST_F(TestUInt32ParquetIO, Parquet_2_0_Compatibility) {
   // This also tests max_definition_level = 1
   std::shared_ptr<Array> values;
 
@@ -1047,7 +1047,7 @@ TEST_F(TestUInt32ParquetIO, Parquet_2_0_Compability) {
   ASSERT_NO_FATAL_FAILURE(this->ReadAndCheckSingleColumnTable(values));
 }
 
-TEST_F(TestUInt32ParquetIO, Parquet_1_0_Compability) {
+TEST_F(TestUInt32ParquetIO, Parquet_1_0_Compatibility) {
   // This also tests max_definition_level = 1
   std::shared_ptr<Array> arr;
   ASSERT_OK(NullableArray<::arrow::UInt32Type>(LARGE_SIZE, 100, kDefaultSeed, &arr));

--- a/cpp/src/parquet/bloom_filter_test.cc
+++ b/cpp/src/parquet/bloom_filter_test.cc
@@ -203,7 +203,7 @@ TEST(CompatibilityTest, TestBloomFilter) {
   EXPECT_TRUE((*buffer1).Equals(*buffer2));
 }
 
-// OptmialValueTest is used to test whether OptimalNumOfBits returns expected
+// OptimalValueTest is used to test whether OptimalNumOfBits returns expected
 // numbers according to formula:
 //     num_of_bits = -8.0 * ndv / log(1 - pow(fpp, 1.0 / 8.0))
 // where ndv is the number of distinct values and fpp is the false positive probability.

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -858,7 +858,7 @@ std::shared_ptr<ColumnReader> ColumnReader::Make(const ColumnDescriptor* descr,
     default:
       ParquetException::NYI("type reader not implemented");
   }
-  // Unreachable code, but supress compiler warning
+  // Unreachable code, but suppress compiler warning
   return std::shared_ptr<ColumnReader>(nullptr);
 }
 
@@ -1463,7 +1463,7 @@ std::shared_ptr<RecordReader> RecordReader::Make(const ColumnDescriptor* descr,
       throw ParquetException(ss.str());
     }
   }
-  // Unreachable code, but supress compiler warning
+  // Unreachable code, but suppress compiler warning
   return nullptr;
 }
 

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -155,7 +155,7 @@ class TypedColumnReader : public ColumnReader {
   /// column and leave spaces for null entries on the lowest level in the values
   /// buffer.
   ///
-  /// In comparision to ReadBatch the length of repetition and definition levels
+  /// In comparison to ReadBatch the length of repetition and definition levels
   /// is the same as of the number of values read for max_definition_level == 1.
   /// In the case of max_definition_level > 1, the repetition and definition
   /// levels are larger than the values but the values include the null entries

--- a/cpp/src/parquet/column_scanner.cc
+++ b/cpp/src/parquet/column_scanner.cc
@@ -49,7 +49,7 @@ std::shared_ptr<Scanner> Scanner::Make(std::shared_ptr<ColumnReader> col_reader,
     default:
       ParquetException::NYI("type reader not implemented");
   }
-  // Unreachable code, but supress compiler warning
+  // Unreachable code, but suppress compiler warning
   return std::shared_ptr<Scanner>(nullptr);
 }
 
@@ -84,7 +84,7 @@ int64_t ScanAllValues(int32_t batch_size, int16_t* def_levels, int16_t* rep_leve
     default:
       parquet::ParquetException::NYI("type reader not implemented");
   }
-  // Unreachable code, but supress compiler warning
+  // Unreachable code, but suppress compiler warning
   return 0;
 }
 

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1058,7 +1058,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
   void FallbackToPlainEncoding() {
     if (IsDictionaryEncoding(current_encoder_->encoding())) {
       WriteDictionaryPage();
-      // Serialize the buffered Dictionary Indicies
+      // Serialize the buffered Dictionary Indices
       FlushBufferedDataPages();
       fallback_ = true;
       // Only PLAIN encoding is supported for fallback in V1
@@ -1740,7 +1740,7 @@ std::shared_ptr<ColumnWriter> ColumnWriter::Make(ColumnChunkMetaDataBuilder* met
     default:
       ParquetException::NYI("type reader not implemented");
   }
-  // Unreachable code, but supress compiler warning
+  // Unreachable code, but suppress compiler warning
   return std::shared_ptr<ColumnWriter>(nullptr);
 }
 

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -129,7 +129,7 @@ class PARQUET_EXPORT ColumnWriter {
   virtual int64_t rows_written() const = 0;
 
   /// \brief The total size of the compressed pages + page headers. Some values
-  /// might be still buffered an not written to a page yet
+  /// might be still buffered and not written to a page yet
   virtual int64_t total_compressed_bytes() const = 0;
 
   /// \brief The total number of bytes written as serialized data and
@@ -175,7 +175,7 @@ class TypedColumnWriter : public ColumnWriter {
   /// also includes all values with definition_level == (max_definition_level - 1).
   ///
   /// @param num_values number of levels to write.
-  /// @param def_levels The Parquet definiton levels, length is num_values
+  /// @param def_levels The Parquet definition levels, length is num_values
   /// @param rep_levels The Parquet repetition levels, length is num_values
   /// @param valid_bits Bitmap that indicates if the row is null on the lowest nesting
   ///   level. The length is number of rows in the lowest nesting level.

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1563,7 +1563,7 @@ class DictDecoderImpl : public DecoderImpl, virtual public DictDecoder<Type> {
 
   // Arrow-style byte offsets for each dictionary value. We maintain two
   // representations of the dictionary, one as ByteArray* for non-Arrow
-  // consumers and this one for Arrow conumers. Since dictionaries are
+  // consumers and this one for Arrow consumers. Since dictionaries are
   // generally pretty small to begin with this doesn't mean too much extra
   // memory use in most cases
   std::shared_ptr<ResizableBuffer> byte_array_offsets_;
@@ -1799,7 +1799,7 @@ template <>
 void DictDecoderImpl<ByteArrayType>::InsertDictionary(arrow::ArrayBuilder* builder) {
   auto binary_builder = checked_cast<arrow::BinaryDictionary32Builder*>(builder);
 
-  // Make an BinaryArray referencing the internal dictionary data
+  // Make a BinaryArray referencing the internal dictionary data
   auto arr = std::make_shared<arrow::BinaryArray>(dictionary_length_, byte_array_offsets_,
                                                   byte_array_data_);
   PARQUET_THROW_NOT_OK(binary_builder->InsertMemoValues(*arr));

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -374,7 +374,7 @@ void SerializedFile::ParseMetaDataOfEncryptedFileWithPlaintextFooter(
     FileDecryptionProperties* file_decryption_properties,
     const std::shared_ptr<Buffer>& metadata_buffer, uint32_t metadata_len,
     uint32_t read_metadata_len) {
-  // Providing decryption properties in plaintext footer mode is not mendatory, for
+  // Providing decryption properties in plaintext footer mode is not mandatory, for
   // example when reading by legacy reader.
   if (file_decryption_properties != nullptr) {
     EncryptionAlgorithm algo = file_metadata_->encryption_algorithm();

--- a/cpp/src/parquet/internal_file_encryptor.h
+++ b/cpp/src/parquet/internal_file_encryptor.h
@@ -69,7 +69,7 @@ class PARQUET_EXPORT Encryptor {
 
 class InternalFileEncryptor {
  public:
-  explicit InternalFileEncryptor(FileEncryptionProperties* propperties,
+  explicit InternalFileEncryptor(FileEncryptionProperties* properties,
                                  ::arrow::MemoryPool* pool);
 
   std::shared_ptr<Encryptor> GetFooterEncryptor();

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -847,7 +847,7 @@ bool ApplicationVersion::VersionEq(const ApplicationVersion& other_version) cons
 
 // Reference:
 // parquet-mr/parquet-column/src/main/java/org/apache/parquet/CorruptStatistics.java
-// PARQUET-686 has more disussion on statistics
+// PARQUET-686 has more discussion on statistics
 bool ApplicationVersion::HasCorrectStatistics(Type::type col_type,
                                               EncodedStatistics& statistics,
                                               SortOrder::type sort_order) const {

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -303,7 +303,7 @@ class PARQUET_EXPORT ColumnChunkMetaDataBuilder {
   int64_t total_compressed_size() const;
   // commit the metadata
 
-  void Finish(int64_t num_values, int64_t dictonary_page_offset,
+  void Finish(int64_t num_values, int64_t dictionary_page_offset,
               int64_t index_page_offset, int64_t data_page_offset,
               int64_t compressed_size, int64_t uncompressed_size, bool has_dictionary,
               bool dictionary_fallback,

--- a/cpp/src/parquet/parquet.thrift
+++ b/cpp/src/parquet/parquet.thrift
@@ -124,7 +124,7 @@ enum ConvertedType {
   /**
    * An unsigned integer value.
    *
-   * The number describes the maximum number of meainful data bits in
+   * The number describes the maximum number of meaningful data bits in
    * the stored value. 8, 16 and 32 bit values are stored using the
    * INT32 physical type.  64 bit values are stored using the INT64
    * physical type.
@@ -138,7 +138,7 @@ enum ConvertedType {
   /**
    * A signed integer value.
    *
-   * The number describes the maximum number of meainful data bits in
+   * The number describes the maximum number of meaningful data bits in
    * the stored value. 8, 16 and 32 bit values are stored using the
    * INT32 physical type.  64 bit values are stored using the INT64
    * physical type.
@@ -857,7 +857,7 @@ struct ColumnIndex {
   3: required list<binary> max_values
 
   /**
-   * Stores whether both min_values and max_values are orderd and if so, in
+   * Stores whether both min_values and max_values are ordered and if so, in
    * which direction. This allows readers to perform binary searches in both
    * lists. Readers cannot assume that max_values[i] <= min_values[i+1], even
    * if the lists are ordered.

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -71,7 +71,7 @@ TEST(Comparison, SignedByteArray) {
   ByteArray s2ba = ByteArrayFromString(s2);
   ASSERT_TRUE(comparator->Compare(s1ba, s2ba));
 
-  // This is case where signed comparision UTF-8 (PARQUET-686) is incorrect
+  // This is case where signed comparison UTF-8 (PARQUET-686) is incorrect
   // This example is to only check signed comparison and not UTF-8.
   s1 = u8"bügeln";
   s2 = u8"braten";

--- a/cpp/src/parquet/test_util.h
+++ b/cpp/src/parquet/test_util.h
@@ -534,7 +534,7 @@ static inline int MakePages(const ColumnDescriptor* d, int num_pages, int levels
   } else {
     num_values = num_levels;
   }
-  // Create repitition levels
+  // Create repetition levels
   if (max_rep_level > 0) {
     rep_levels.resize(num_levels);
     random_numbers(num_levels, seed, zero, max_rep_level, rep_levels.data());


### PR DESCRIPTION
This PR fixes typos in files under `cpp/src/parquet` directory