### PR TITLE
ARROW-7485: [C++][Prasma] Fix typos

### DIFF
--- a/cpp/src/plasma/fling.h
+++ b/cpp/src/plasma/fling.h
@@ -29,7 +29,7 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-// This is neccessary for Mac OS X, see http://www.apuebook.com/faqs2e.html
+// This is necessary for Mac OS X, see http://www.apuebook.com/faqs2e.html
 // (10).
 #if !defined(CMSG_SPACE) && !defined(CMSG_LEN)
 #define CMSG_SPACE(len) (__DARWIN_ALIGN32(sizeof(struct cmsghdr)) + __DARWIN_ALIGN32(len))

--- a/cpp/src/plasma/io.h
+++ b/cpp/src/plasma/io.h
@@ -40,7 +40,7 @@ enum class MessageType : int64_t;
 }  // namespace flatbuf
 
 // TODO(pcm): Replace our own custom message header (message type,
-// message length, plasma protocol verion) with one that is serialized
+// message length, plasma protocol version) with one that is serialized
 // using flatbuffers.
 constexpr int64_t kPlasmaProtocolVersion = 0x0000000000000000;
 

--- a/cpp/src/plasma/protocol.h
+++ b/cpp/src/plasma/protocol.h
@@ -174,7 +174,7 @@ Status SendDeleteReply(int sock, const std::vector<ObjectID>& object_ids,
 Status ReadDeleteReply(uint8_t* data, size_t size, std::vector<ObjectID>* object_ids,
                        std::vector<PlasmaError>* errors);
 
-/* Plasma Constains message functions. */
+/* Plasma Contains message functions. */
 
 Status SendContainsRequest(int sock, ObjectID object_id);
 

--- a/cpp/src/plasma/store.cc
+++ b/cpp/src/plasma/store.cc
@@ -221,7 +221,7 @@ PlasmaError PlasmaStore::CreateObject(const ObjectID& object_id, int64_t data_si
   auto entry = GetObjectTableEntry(&store_info_, object_id);
   if (entry != nullptr) {
     // There is already an object with the same ID in the Plasma Store, so
-    // ignore this requst.
+    // ignore this request.
     return PlasmaError::ObjectExists;
   }
 
@@ -465,7 +465,7 @@ void PlasmaStore::ProcessGetRequest(Client* client,
         evicted_ids.push_back(object_id);
         evicted_entries.push_back(entry);
       } else {
-        // We are out of memory an cannot allocate memory for this object.
+        // We are out of memory and cannot allocate memory for this object.
         // Change the state of the object back to PLASMA_EVICTED so some
         // other request can try again.
         entry->state = ObjectState::PLASMA_EVICTED;

--- a/cpp/src/plasma/store.h
+++ b/cpp/src/plasma/store.h
@@ -102,7 +102,7 @@ class PlasmaStore {
   /// @return 1 if the abort succeeds, else 0.
   int AbortObject(const ObjectID& object_id, Client* client);
 
-  /// Delete an specific object by object_id that have been created in the hash table.
+  /// Delete a specific object by object_id that have been created in the hash table.
   ///
   /// @param object_id Object ID of the object to be deleted.
   /// @return One of the following error codes:

--- a/cpp/src/plasma/test/client_tests.cc
+++ b/cpp/src/plasma/test/client_tests.cc
@@ -503,7 +503,7 @@ TEST_F(TestPlasmaStore, RefreshLRUTest) {
 TEST_F(TestPlasmaStore, DeleteTest) {
   ObjectID object_id = random_object_id();
 
-  // Test for deleting non-existance object.
+  // Test for deleting non-existence object.
   Status result = client_.Delete(object_id);
   ARROW_CHECK_OK(result);
 
@@ -533,7 +533,7 @@ TEST_F(TestPlasmaStore, DeleteObjectsTest) {
   ObjectID object_id1 = random_object_id();
   ObjectID object_id2 = random_object_id();
 
-  // Test for deleting non-existance object.
+  // Test for deleting non-existence object.
   Status result = client_.Delete(std::vector<ObjectID>{object_id1, object_id2});
   ARROW_CHECK_OK(result);
   // Test for the object being in local Plasma store.
@@ -928,7 +928,7 @@ TEST_F(TestPlasmaStore, DeleteObjectsGPUTest) {
   ObjectID object_id1 = random_object_id();
   ObjectID object_id2 = random_object_id();
 
-  // Test for deleting non-existance object.
+  // Test for deleting non-existence object.
   Status result = client_.Delete(std::vector<ObjectID>{object_id1, object_id2});
   ARROW_CHECK_OK(result);
   // Test for the object being in local Plasma store.

--- a/cpp/src/plasma/thirdparty/ae/ae_evport.c
+++ b/cpp/src/plasma/thirdparty/ae/ae_evport.c
@@ -232,7 +232,7 @@ static void aeApiDelEvent(aeEventLoop *eventLoop, int fd, int mask) {
         /*
          * ENOMEM is a potentially transient condition, but the kernel won't
          * generally return it unless things are really bad.  EAGAIN indicates
-         * we've reached an resource limit, for which it doesn't make sense to
+         * we've reached a resource limit, for which it doesn't make sense to
          * retry (counter-intuitively).  All other errors indicate a bug.  In any
          * of these cases, the best we can do is to abort.
          */

--- a/cpp/src/plasma/thirdparty/dlmalloc.c
+++ b/cpp/src/plasma/thirdparty/dlmalloc.c
@@ -1163,7 +1163,7 @@ DLMALLOC_EXPORT void** dlindependent_calloc(size_t, size_t, void**);
   Each element must be freed when it is no longer needed. This can be
   done all at once using bulk_free.
 
-  independent_comallac differs from independent_calloc in that each
+  independent_comalloc differs from independent_calloc in that each
   element may have a different size, and also that it does not
   automatically clear elements.
 
@@ -1689,7 +1689,7 @@ static FORCEINLINE void* win32direct_mmap(size_t size) {
   return (ptr != 0)? ptr: MFAIL;
 }
 
-/* This function supports releasing coalesed segments */
+/* This function supports releasing coalesced segments */
 static FORCEINLINE int win32munmap(void* ptr, size_t size) {
   MEMORY_BASIC_INFORMATION minfo;
   char* cptr = (char*)ptr;
@@ -1777,7 +1777,7 @@ static FORCEINLINE int win32munmap(void* ptr, size_t size) {
     #define CALL_MREMAP(addr, osz, nsz, mv)     MFAIL
 #endif /* HAVE_MMAP && HAVE_MREMAP */
 
-/* mstate bit set if continguous morecore disabled or failed */
+/* mstate bit set if contiguous morecore disabled or failed */
 #define USE_NONCONTIGUOUS_BIT (4U)
 
 /* segment bit set in create_mspace_with_base */


### PR DESCRIPTION
This PR fixes typos in files under `cpp/src/prasma` directory