### PR TITLE
ARROW-7488: [GLib] Fix typos and broken links

### DIFF
--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -57,7 +57,7 @@ We support two build systems, GNU Autotools and Meson. If you find problems when
 
 ### Package
 
-See [install document](../site/install.md) for details.
+See [install document](https://arrow.apache.org/install/) for details.
 
 ### How to build by users
 
@@ -192,7 +192,7 @@ You can find example codes in the `example/` directory.
 
 ### Language bindings
 
-You can use Arrow GLib with non C languages with GObject Introspection
+You can use Arrow GLib with non-C languages with GObject Introspection
 based bindings. Here are languages that support GObject Introspection:
 
   * Ruby: [red-arrow gem](https://rubygems.org/gems/red-arrow) should be used.
@@ -297,7 +297,7 @@ gobject-introspection requires libffi, and it's automatically installed with gob
 
 ### build failed - /usr/bin/ld: cannot find -larrow
 
-Arrow C++ must be installed to build Arrow GLib. Run `make install` on Arrow C++ build directory. In addtion, on linux, you may need to run `sudo ldconfig`.
+Arrow C++ must be installed to build Arrow GLib. Run `make install` on Arrow C++ build directory. In addition, on linux, you may need to run `sudo ldconfig`.
 
 ### build failed - unable to load http://docbook.sourceforge.net/release/xsl/current/html/chunk.xsl
 

--- a/c_glib/arrow-glib/tensor.cpp
+++ b/c_glib/arrow-glib/tensor.cpp
@@ -164,7 +164,7 @@ garrow_tensor_class_init(GArrowTensorClass *klass)
  * @n_strides: The number of strides.
  * @dimension_names: (array length=n_dimension_names) (nullable): A list of
  *   dimension names.
- * @n_dimention_names: The number of dimension names
+ * @n_dimension_names: The number of dimension names
  *
  * Returns: The newly created #GArrowTensor.
  *

--- a/c_glib/arrow-glib/tensor.cpp
+++ b/c_glib/arrow-glib/tensor.cpp
@@ -162,7 +162,7 @@ garrow_tensor_class_init(GArrowTensorClass *klass)
  * @strides: (array length=n_strides) (nullable): A list of the number of
  *   bytes in each dimension.
  * @n_strides: The number of strides.
- * @dimention_names: (array length=n_dimention_names) (nullable): A list of
+ * @dimension_names: (array length=n_dimension_names) (nullable): A list of
  *   dimension names.
  * @n_dimention_names: The number of dimension names
  *

--- a/c_glib/arrow-glib/tensor.h
+++ b/c_glib/arrow-glib/tensor.h
@@ -41,8 +41,8 @@ GArrowTensor   *garrow_tensor_new                (GArrowDataType *data_type,
                                                   gsize n_dimensions,
                                                   gint64 *strides,
                                                   gsize n_strides,
-                                                  gchar **dimention_names,
-                                                  gsize n_dimention_names);
+                                                  gchar **dimension_names,
+                                                  gsize n_dimension_names);
 gboolean        garrow_tensor_equal              (GArrowTensor *tensor,
                                                   GArrowTensor *other_tensor);
 GArrowDataType *garrow_tensor_get_value_data_type(GArrowTensor *tensor);

--- a/c_glib/test/test-compare.rb
+++ b/c_glib/test/test-compare.rb
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class TestComapre < Test::Unit::TestCase
+class TestCompare < Test::Unit::TestCase
   include Helper::Buildable
 
   def setup


### PR DESCRIPTION
This PR fixes typo and broken link in files under `c_glib` directory.