### PR TITLE
ARROW-7087: [Python] Metadata disappear from pandas dataset

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -22,6 +22,7 @@ import json
 import operator
 import re
 import warnings
+from copy import deepcopy
 
 import numpy as np
 
@@ -587,9 +588,11 @@ def dataframe_to_arrays(df, schema, preserve_index, nthreads=1, columns=None,
             fields.append(pa.field(name, type_))
         schema = pa.schema(fields)
 
-    metadata = construct_metadata(df, column_names, index_columns,
-                                  index_descriptors, preserve_index,
-                                  types)
+    pandas_metadata = construct_metadata(df, column_names, index_columns,
+                                         index_descriptors, preserve_index,
+                                         types)
+    metadata = deepcopy(schema.metadata) if schema.metadata else dict()
+    metadata.update(pandas_metadata)
     schema = schema.with_metadata(metadata)
 
     return arrays, schema

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2904,6 +2904,14 @@ def test_table_from_pandas_schema_index_columns__unnamed_index():
     assert table.schema.remove_metadata().equals(expected_schema)
 
 
+def test_table_from_pandas_schema_with_custom_metadata():
+    # ARROW-7087 - metadata disappear from pandas
+    df = pd.DataFrame()
+    schema = pa.Schema.from_pandas(df).with_metadata({'meta': 'True'})
+    table = pa.Table.from_pandas(df, schema=schema)
+    assert table.schema.metadata.get(b'meta') == b'True'
+
+
 # ----------------------------------------------------------------------
 # RecordBatch, Table
 


### PR DESCRIPTION
Related to [ARROW-7087](https://issues.apache.org/jira/browse/ARROW-7087)

There is an unexpected behavior when we write a table from pandas dataset which contains metadata. They are replaced by pandas metadata.

Therefore, I concatenated schema metadata and pandas metadata before return the schema.