### PR TITLE
ARROW-7450: [C++] Also link boost_filesystem when using static test linkage

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -696,7 +696,12 @@ if(NOT MSVC)
   list(APPEND ARROW_SHARED_INSTALL_INTERFACE_LIBS ${CMAKE_DL_LIBS})
 endif()
 
-set(ARROW_TEST_LINK_TOOLCHAIN GTest::Main GTest::GTest GTest::GMock)
+set(ARROW_TEST_LINK_TOOLCHAIN
+    GTest::Main
+    GTest::GTest
+    GTest::GMock
+    ${BOOST_FILESYSTEM_LIBRARY}
+    ${BOOST_SYSTEM_LIBRARY})
 
 if(ARROW_BUILD_TESTS)
   add_dependencies(arrow_test_dependencies ${ARROW_TEST_LINK_TOOLCHAIN})
@@ -711,13 +716,8 @@ endif()
 set(ARROW_TEST_STATIC_LINK_LIBS arrow_testing_static arrow_static ${ARROW_LINK_LIBS}
                                 ${ARROW_TEST_LINK_TOOLCHAIN})
 
-set(ARROW_TEST_SHARED_LINK_LIBS
-    arrow_testing_shared
-    arrow_shared
-    ${ARROW_LINK_LIBS}
-    ${BOOST_FILESYSTEM_LIBRARY}
-    ${BOOST_SYSTEM_LIBRARY}
-    ${ARROW_TEST_LINK_TOOLCHAIN})
+set(ARROW_TEST_SHARED_LINK_LIBS arrow_testing_shared arrow_shared ${ARROW_LINK_LIBS}
+                                ${ARROW_TEST_LINK_TOOLCHAIN})
 
 if(NOT MSVC)
   set(ARROW_TEST_SHARED_LINK_LIBS ${ARROW_TEST_SHARED_LINK_LIBS} ${CMAKE_DL_LIBS})

--- a/cpp/src/arrow/io/hdfs_test.cc
+++ b/cpp/src/arrow/io/hdfs_test.cc
@@ -95,6 +95,7 @@ class TestHadoopFileSystem : public ::testing::Test {
     internal::LibHdfsShim* driver_shim;
 
     client_ = nullptr;
+
     scratch_dir_ =
         boost::filesystem::unique_path(boost::filesystem::temp_directory_path() /
                                        "arrow-hdfs/scratch-%%%%")

--- a/cpp/src/arrow/io/hdfs_test.cc
+++ b/cpp/src/arrow/io/hdfs_test.cc
@@ -95,7 +95,6 @@ class TestHadoopFileSystem : public ::testing::Test {
     internal::LibHdfsShim* driver_shim;
 
     client_ = nullptr;
-
     scratch_dir_ =
         boost::filesystem::unique_path(boost::filesystem::temp_directory_path() /
                                        "arrow-hdfs/scratch-%%%%")


### PR DESCRIPTION
The nightly test-ubuntu-18.04-cpp-static has been failing due to a missing Boost link dependency in the unit tests