### PR TITLE
ARROW-7505: [Java] Remove Netty dependency for ArrowBuf

### DIFF
--- a/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ArrowBuf.java
@@ -35,9 +35,8 @@ import org.apache.arrow.memory.BufferLedger;
 import org.apache.arrow.memory.BufferManager;
 import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.memory.util.HistoricalLog;
+import org.apache.arrow.memory.util.MemoryUtil;
 import org.apache.arrow.util.Preconditions;
-
-import io.netty.util.internal.PlatformDependent;
 
 /**
  * ArrowBuf serves as a facade over underlying memory by providing
@@ -349,7 +348,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public long getLong(long index) {
     chk(index, LONG_SIZE);
-    return PlatformDependent.getLong(addr(index));
+    return MemoryUtil.UNSAFE.getLong(addr(index));
   }
 
   /**
@@ -361,7 +360,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void setLong(long index, long value) {
     chk(index, LONG_SIZE);
-    PlatformDependent.putLong(addr(index), value);
+    MemoryUtil.UNSAFE.putLong(addr(index), value);
   }
 
   /**
@@ -384,7 +383,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void setFloat(long index, float value) {
     chk(index, FLOAT_SIZE);
-    PlatformDependent.putInt(addr(index), Float.floatToRawIntBits(value));
+    MemoryUtil.UNSAFE.putInt(addr(index), Float.floatToRawIntBits(value));
   }
 
   /**
@@ -407,7 +406,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void setDouble(long index, double value) {
     chk(index, DOUBLE_SIZE);
-    PlatformDependent.putLong(addr(index), Double.doubleToRawLongBits(value));
+    MemoryUtil.UNSAFE.putLong(addr(index), Double.doubleToRawLongBits(value));
   }
 
   /**
@@ -430,7 +429,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void setChar(long index, int value) {
     chk(index, SHORT_SIZE);
-    PlatformDependent.putShort(addr(index), (short) value);
+    MemoryUtil.UNSAFE.putShort(addr(index), (short) value);
   }
 
   /**
@@ -442,7 +441,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public int getInt(long index) {
     chk(index, INT_SIZE);
-    return PlatformDependent.getInt(addr(index));
+    return MemoryUtil.UNSAFE.getInt(addr(index));
   }
 
   /**
@@ -454,7 +453,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void setInt(long index, int value) {
     chk(index, INT_SIZE);
-    PlatformDependent.putInt(addr(index), value);
+    MemoryUtil.UNSAFE.putInt(addr(index), value);
   }
 
   /**
@@ -466,7 +465,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public short getShort(long index) {
     chk(index, SHORT_SIZE);
-    return PlatformDependent.getShort(addr(index));
+    return MemoryUtil.UNSAFE.getShort(addr(index));
   }
 
   /**
@@ -489,7 +488,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void setShort(long index, short value) {
     chk(index, SHORT_SIZE);
-    PlatformDependent.putShort(addr(index), value);
+    MemoryUtil.UNSAFE.putShort(addr(index), value);
   }
 
   /**
@@ -501,7 +500,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void setByte(long index, int value) {
     chk(index, 1);
-    PlatformDependent.putByte(addr(index), (byte) value);
+    MemoryUtil.UNSAFE.putByte(addr(index), (byte) value);
   }
 
   /**
@@ -513,7 +512,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void setByte(long index, byte value) {
     chk(index, 1);
-    PlatformDependent.putByte(addr(index), value);
+    MemoryUtil.UNSAFE.putByte(addr(index), value);
   }
 
   /**
@@ -525,7 +524,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public byte getByte(long index) {
     chk(index, 1);
-    return PlatformDependent.getByte(addr(index));
+    return MemoryUtil.UNSAFE.getByte(addr(index));
   }
 
 
@@ -603,7 +602,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void writeByte(byte value) {
     ensureWritable(1);
-    PlatformDependent.putByte(addr(writerIndex), value);
+    MemoryUtil.UNSAFE.putByte(addr(writerIndex), value);
     ++writerIndex;
   }
 
@@ -614,7 +613,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void writeByte(int value) {
     ensureWritable(1);
-    PlatformDependent.putByte(addr(writerIndex), (byte)value);
+    MemoryUtil.UNSAFE.putByte(addr(writerIndex), (byte)value);
     ++writerIndex;
   }
 
@@ -647,7 +646,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void writeShort(int value) {
     ensureWritable(SHORT_SIZE);
-    PlatformDependent.putShort(addr(writerIndex), (short) value);
+    MemoryUtil.UNSAFE.putShort(addr(writerIndex), (short) value);
     writerIndex += SHORT_SIZE;
   }
 
@@ -657,7 +656,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void writeInt(int value) {
     ensureWritable(INT_SIZE);
-    PlatformDependent.putInt(addr(writerIndex), value);
+    MemoryUtil.UNSAFE.putInt(addr(writerIndex), value);
     writerIndex += INT_SIZE;
   }
 
@@ -667,7 +666,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void writeLong(long value) {
     ensureWritable(LONG_SIZE);
-    PlatformDependent.putLong(addr(writerIndex), value);
+    MemoryUtil.UNSAFE.putLong(addr(writerIndex), value);
     writerIndex += LONG_SIZE;
   }
 
@@ -677,7 +676,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void writeFloat(float value) {
     ensureWritable(FLOAT_SIZE);
-    PlatformDependent.putInt(addr(writerIndex), Float.floatToRawIntBits(value));
+    MemoryUtil.UNSAFE.putInt(addr(writerIndex), Float.floatToRawIntBits(value));
     writerIndex += FLOAT_SIZE;
   }
 
@@ -687,7 +686,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void writeDouble(double value) {
     ensureWritable(DOUBLE_SIZE);
-    PlatformDependent.putLong(addr(writerIndex), Double.doubleToRawLongBits(value));
+    MemoryUtil.UNSAFE.putLong(addr(writerIndex), Double.doubleToRawLongBits(value));
     writerIndex += DOUBLE_SIZE;
   }
 
@@ -753,7 +752,7 @@ public final class ArrowBuf implements AutoCloseable {
     if (length != 0) {
       // copy "length" bytes from this ArrowBuf starting at addr(index) address
       // into dst byte array at dstIndex onwards
-      PlatformDependent.copyMemory(addr(index), dst, dstIndex, (long)length);
+      MemoryUtil.UNSAFE.copyMemory(null, addr(index), dst, MemoryUtil.BYTE_ARRAY_BASE_OFFSET + dstIndex, length);
     }
   }
 
@@ -790,7 +789,7 @@ public final class ArrowBuf implements AutoCloseable {
     if (length > 0) {
       // copy "length" bytes from src byte array at the starting index (srcIndex)
       // into this ArrowBuf starting at address "addr(index)"
-      PlatformDependent.copyMemory(src, srcIndex, addr(index), length);
+      MemoryUtil.UNSAFE.copyMemory(src, MemoryUtil.BYTE_ARRAY_BASE_OFFSET + srcIndex, null, addr(index), length);
     }
   }
 
@@ -815,8 +814,8 @@ public final class ArrowBuf implements AutoCloseable {
         // copy dst.remaining() bytes of data from this ArrowBuf starting
         // at address srcAddress into the dst ByteBuffer starting at
         // address dstAddress
-        final long dstAddress = PlatformDependent.directBufferAddress(dst) + (long)dst.position();
-        PlatformDependent.copyMemory(srcAddress, dstAddress, (long)dst.remaining());
+        final long dstAddress = MemoryUtil.getByteBufferAddress(dst) + dst.position();
+        MemoryUtil.UNSAFE.copyMemory(null, srcAddress, null, dstAddress, dst.remaining());
         // after copy, bump the next write position for the dst ByteBuffer
         dst.position(dst.position() + dst.remaining());
       } else if (dst.hasArray()) {
@@ -824,7 +823,8 @@ public final class ArrowBuf implements AutoCloseable {
         // at address srcAddress into the dst ByteBuffer starting at
         // index dstIndex
         final int dstIndex = dst.arrayOffset() + dst.position();
-        PlatformDependent.copyMemory(srcAddress, dst.array(), dstIndex, (long)dst.remaining());
+        MemoryUtil.UNSAFE.copyMemory(
+                null, srcAddress, dst.array(), MemoryUtil.BYTE_ARRAY_BASE_OFFSET + dstIndex, dst.remaining());
         // after copy, bump the next write position for the dst ByteBuffer
         dst.position(dst.position() + dst.remaining());
       } else {
@@ -851,34 +851,35 @@ public final class ArrowBuf implements AutoCloseable {
       if (src.isDirect()) {
         // copy src.remaining() bytes of data from src ByteBuffer starting at
         // address srcAddress into this ArrowBuf starting at address dstAddress
-        final long srcAddress = PlatformDependent.directBufferAddress(src) + (long)src.position();
-        PlatformDependent.copyMemory(srcAddress, dstAddress, (long)length);
+        final long srcAddress = MemoryUtil.getByteBufferAddress(src) + src.position();
+        MemoryUtil.UNSAFE.copyMemory(null, srcAddress, null, dstAddress, length);
         // after copy, bump the next read position for the src ByteBuffer
         src.position(src.position() + length);
       } else if (src.hasArray()) {
         // copy src.remaining() bytes of data from src ByteBuffer starting at
         // index srcIndex into this ArrowBuf starting at address dstAddress
         final int srcIndex = src.arrayOffset() + src.position();
-        PlatformDependent.copyMemory(src.array(), srcIndex, dstAddress, (long)length);
+        MemoryUtil.UNSAFE.copyMemory(
+                src.array(), MemoryUtil.BYTE_ARRAY_BASE_OFFSET + srcIndex, null, dstAddress, length);
         // after copy, bump the next read position for the src ByteBuffer
         src.position(src.position() + length);
       } else {
         // copy word at a time
         while (length - 128 >= LONG_SIZE) {
           for (int x = 0; x < 16; x++) {
-            PlatformDependent.putLong(dstAddress, src.getLong());
+            MemoryUtil.UNSAFE.putLong(dstAddress, src.getLong());
             length -= LONG_SIZE;
             dstAddress += LONG_SIZE;
           }
         }
         while (length >= LONG_SIZE) {
-          PlatformDependent.putLong(dstAddress, src.getLong());
+          MemoryUtil.UNSAFE.putLong(dstAddress, src.getLong());
           length -= LONG_SIZE;
           dstAddress += LONG_SIZE;
         }
         // copy last byte
         while (length > 0) {
-          PlatformDependent.putByte(dstAddress, src.get());
+          MemoryUtil.UNSAFE.putByte(dstAddress, src.get());
           --length;
           ++dstAddress;
         }
@@ -903,9 +904,9 @@ public final class ArrowBuf implements AutoCloseable {
     if (src.isDirect()) {
       // copy length bytes of data from src ByteBuffer starting at address
       // srcAddress into this ArrowBuf at address dstAddress
-      final long srcAddress = PlatformDependent.directBufferAddress(src) + srcIndex;
+      final long srcAddress = MemoryUtil.getByteBufferAddress(src) + srcIndex;
       final long dstAddress = addr(index);
-      PlatformDependent.copyMemory(srcAddress, dstAddress, length);
+      MemoryUtil.UNSAFE.copyMemory(null, srcAddress, null, dstAddress, length);
     } else {
       if (srcIndex == 0 && src.capacity() == length) {
         // copy the entire ByteBuffer from start to end of length
@@ -945,7 +946,7 @@ public final class ArrowBuf implements AutoCloseable {
       // dstAddress
       final long srcAddress = addr(index);
       final long dstAddress = dst.memoryAddress() + (long)dstIndex;
-      PlatformDependent.copyMemory(srcAddress, dstAddress, (long)length);
+      MemoryUtil.UNSAFE.copyMemory(null, srcAddress, null, dstAddress, length);
     }
   }
 
@@ -975,7 +976,7 @@ public final class ArrowBuf implements AutoCloseable {
       // dstAddress
       final long srcAddress = src.memoryAddress() + srcIndex;
       final long dstAddress = addr(index);
-      PlatformDependent.copyMemory(srcAddress, dstAddress, length);
+      MemoryUtil.UNSAFE.copyMemory(null, srcAddress, null, dstAddress, length);
     }
   }
 
@@ -995,7 +996,7 @@ public final class ArrowBuf implements AutoCloseable {
     checkIndex(index, length);
     final long srcAddress = src.memoryAddress() + src.readerIndex;
     final long dstAddress = addr(index);
-    PlatformDependent.copyMemory(srcAddress, dstAddress, length);
+    MemoryUtil.UNSAFE.copyMemory(null, srcAddress, null, dstAddress, length);
     src.readerIndex(src.readerIndex + length);
   }
 
@@ -1020,7 +1021,7 @@ public final class ArrowBuf implements AutoCloseable {
       if (readBytes > 0) {
         // copy readBytes length of data from the tmp byte array starting
         // at srcIndex 0 into this ArrowBuf starting at address addr(index)
-        PlatformDependent.copyMemory(tmp, 0, addr(index), readBytes);
+        MemoryUtil.UNSAFE.copyMemory(tmp, MemoryUtil.BYTE_ARRAY_BASE_OFFSET, null, addr(index), readBytes);
       }
     }
     return readBytes;
@@ -1042,7 +1043,7 @@ public final class ArrowBuf implements AutoCloseable {
       // copy length bytes of data from this ArrowBuf starting at
       // address addr(index) into the tmp byte array starting at index 0
       byte[] tmp = new byte[length];
-      PlatformDependent.copyMemory(addr(index), tmp, 0, length);
+      MemoryUtil.UNSAFE.copyMemory(null, addr(index), tmp, MemoryUtil.BYTE_ARRAY_BASE_OFFSET, length);
       // write the copied data to output stream
       out.write(tmp);
     }
@@ -1170,7 +1171,7 @@ public final class ArrowBuf implements AutoCloseable {
   public ArrowBuf setZero(long index, long length) {
     if (length != 0) {
       this.checkIndex(index, length);
-      PlatformDependent.setMemory(this.addr + index, length, (byte) 0);
+      MemoryUtil.UNSAFE.setMemory(this.addr + index, length, (byte) 0);
     }
     return this;
   }
@@ -1185,7 +1186,7 @@ public final class ArrowBuf implements AutoCloseable {
   public ArrowBuf setOne(int index, int length) {
     if (length != 0) {
       this.checkIndex(index, length);
-      PlatformDependent.setMemory(this.addr + index, length, (byte) 0xff);
+      MemoryUtil.UNSAFE.setMemory(this.addr + index, length, (byte) 0xff);
     }
     return this;
   }

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/MemoryUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory.util;
+
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+
+import io.netty.buffer.ByteBuf;
+import sun.misc.Unsafe;
+
+/**
+ * Utilities for memory related operations.
+ */
+public class MemoryUtil {
+
+  /**
+   * The unsafe object from which to access the off-heap memory.
+   */
+  public static final Unsafe UNSAFE;
+
+  /**
+   * The start offset of array data relative to the start address of the array object.
+   */
+  public static final long BYTE_ARRAY_BASE_OFFSET;
+
+  /**
+   * The offset of the address field with the {@link java.nio.ByteBuffer} object.
+   */
+  static final long BYTE_BUFFER_ADDRESS_OFFSET;
+
+  static {
+    // get the unsafe object
+    try {
+      Field unsafeField = sun.misc.Unsafe.class.getDeclaredField("theUnsafe");
+      unsafeField.setAccessible(true);
+      UNSAFE = (Unsafe) unsafeField.get(null);
+    } catch (Throwable e) {
+      throw new Error("Failed to get the unsafe object.", e);
+    }
+
+    BYTE_ARRAY_BASE_OFFSET = UNSAFE.arrayBaseOffset(byte[].class);
+
+    try {
+      Field addressField = java.nio.Buffer.class.getDeclaredField("address");
+      addressField.setAccessible(true);
+      BYTE_BUFFER_ADDRESS_OFFSET = UNSAFE.objectFieldOffset(addressField);
+    } catch (NoSuchFieldException e) {
+      throw new Error("Failed to get java.nio.Buffer#address field.", e);
+    }
+  }
+
+  /**
+   * Given a {@link ByteBuf}, gets the address the underlying memory space.
+   *
+   * @param buf the byte buffer.
+   * @return address of the underlying memory.
+   */
+  public static long getByteBufferAddress(ByteBuffer buf) {
+    return UNSAFE.getLong(buf, BYTE_BUFFER_ADDRESS_OFFSET);
+  }
+
+  private MemoryUtil() {
+  }
+}


### PR DESCRIPTION
This is part of the first step of issue ARROW-4526.
In this step, we remove netty dependency for ArrowBuf, BufferAllocator and ReferenceManager.

In this issue, we remove the dependency for ArrowBuf.
The task for BufferAllocator and ReferenceManager will not start until ARROW-7329 is finished.