### PR TITLE
ARROW-7506: [Java] JMH benchmarks should be called from main methods

### DIFF
--- a/java/performance/src/test/java/io/netty/buffer/ArrowBufBenchmarks.java
+++ b/java/performance/src/test/java/io/netty/buffer/ArrowBufBenchmarks.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -74,8 +73,7 @@ public class ArrowBufBenchmarks {
     buffer.setZero(0, BUFFER_CAPACITY);
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
             .include(ArrowBufBenchmarks.class.getSimpleName())
             .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/adapter/AvroAdapterBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/adapter/AvroAdapterBenchmarks.java
@@ -39,7 +39,6 @@ import org.apache.avro.io.DatumWriter;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -131,8 +130,7 @@ public class AvroAdapterBenchmarks {
     return sum;
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
         .include(AvroAdapterBenchmarks.class.getSimpleName())
         .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
@@ -36,7 +36,6 @@ import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -348,8 +347,7 @@ public class JdbcAdapterBenchmarks {
     }
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
         .include(JdbcAdapterBenchmarks.class.getSimpleName())
         .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/memory/AllocatorBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/memory/AllocatorBenchmarks.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.memory.rounding.RoundingPolicy;
 import org.apache.arrow.memory.rounding.SegmentRoundingPolicy;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -86,8 +85,7 @@ public class AllocatorBenchmarks {
     }
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
             .include(AllocatorBenchmarks.class.getSimpleName())
             .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/memory/util/ByteFunctionHelpersBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/memory/util/ByteFunctionHelpersBenchmarks.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -129,8 +128,7 @@ public class ByteFunctionHelpersBenchmarks {
             state.buffer2, 0, ArrowArrayEqualState.BUFFER_CAPACITY);
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
         .include(ByteFunctionHelpersBenchmarks.class.getSimpleName())
         .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/vector/BaseValueVectorBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/BaseValueVectorBenchmarks.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -83,8 +82,7 @@ public class BaseValueVectorBenchmarks {
     return totalSize;
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String [] args) throws RunnerException {
     Options opt = new OptionsBuilder()
         .include(BaseValueVectorBenchmarks.class.getSimpleName())
         .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
@@ -219,7 +219,6 @@ public class BitVectorHelperBenchmarks {
     }
   }
 
-  //@Test
   public static void main(String [] args) throws RunnerException {
     Options opt = new OptionsBuilder()
             .include(BitVectorHelperBenchmarks.class.getSimpleName())

--- a/java/performance/src/test/java/org/apache/arrow/vector/DecimalVectorBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/DecimalVectorBenchmarks.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -112,8 +111,7 @@ public class DecimalVectorBenchmarks {
     }
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String [] args) throws RunnerException {
     Options opt = new OptionsBuilder()
         .include(DecimalVectorBenchmarks.class.getSimpleName())
         .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/vector/Float8Benchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/Float8Benchmarks.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.arrow.memory.BoundsChecking;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -112,8 +111,7 @@ public class Float8Benchmarks {
     }
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String [] args) throws RunnerException {
     Options opt = new OptionsBuilder()
             .include(Float8Benchmarks.class.getSimpleName())
             .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/vector/VarCharBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/VarCharBenchmarks.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -92,8 +91,7 @@ public class VarCharBenchmarks {
     }
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String [] args) throws RunnerException {
     Options opt = new OptionsBuilder()
             .include(VarCharBenchmarks.class.getSimpleName())
             .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/vector/VariableWidthVectorBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/VariableWidthVectorBenchmarks.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -81,8 +80,7 @@ public class VariableWidthVectorBenchmarks {
     return vector.getValueCapacity();
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String [] args) throws RunnerException {
     Options opt = new OptionsBuilder()
             .include(VariableWidthVectorBenchmarks.class.getSimpleName())
             .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/vector/dictionary/DictionaryEncoderBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/dictionary/DictionaryEncoderBenchmarks.java
@@ -28,7 +28,6 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -137,8 +136,7 @@ public class DictionaryEncoderBenchmarks {
     return sb.toString();
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
         .include(DictionaryEncoderBenchmarks.class.getSimpleName())
         .forks(1)

--- a/java/performance/src/test/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatchBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatchBenchmarks.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VarCharVector;
-import org.junit.Test;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -88,8 +87,7 @@ public class ArrowRecordBatchBenchmarks {
     }
   }
 
-  @Test
-  public void evaluate() throws RunnerException {
+  public static void main(String [] args) throws RunnerException {
     Options opt = new OptionsBuilder()
             .include(ArrowRecordBatchBenchmarks.class.getSimpleName())
             .forks(1)


### PR DESCRIPTION
Some benchmarks are called as unit tests in our current code base. They should be called from main methods, because:

1. This is the recommended way of writing JMH benchmarks. The automatically generated benchmarks are called from main, and sample benchmarks provided by JMH [1] are also called from main.

2. Some compiler does not support calling JMH as unit test. For example, the "javac with error prone" reports the following error:

Error:(100, 15) java: [JUnit4TearDownNotRun] tearDown() method will not be run; please add JUnit's @After annotation
(see https://errorprone.info/bugpattern/JUnit4TearDownNotRun)
Did you mean '@After'?

3. When run as a unit test, enable assert flag will be turned on by default, so some test/debug operations will be performed. This will distort the benchmark result data. For example, a related discussion can be found in [2].

[1] https://hg.openjdk.java.net/code-tools/jmh/file/tip/jmh-samples/src/main/java/org/openjdk/jmh/samples/
[2] https://github.com/apache/arrow/pull/5842#issuecomment-558082914