### PR TITLE
ARROW-7045: [R] Preserve factor in Parquet roundtrip

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1080,10 +1080,6 @@ parquet___arrow___FileReader__ReadTable2 <- function(reader, column_indices){
     .Call(`_arrow_parquet___arrow___FileReader__ReadTable2` , reader, column_indices)
 }
 
-parquet___default_arrow_writer_properties <- function(){
-    .Call(`_arrow_parquet___default_arrow_writer_properties` )
-}
-
 parquet___ArrowWriterProperties___Builder__create <- function(){
     .Call(`_arrow_parquet___ArrowWriterProperties___Builder__create` )
 }

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -205,16 +205,12 @@ ParquetArrowWriterPropertiesBuilder <- R6Class("ParquetArrowWriterPropertiesBuil
 ParquetArrowWriterProperties <- R6Class("ParquetArrowWriterProperties", inherit = Object)
 
 ParquetArrowWriterProperties$create <- function(use_deprecated_int96_timestamps = FALSE, coerce_timestamps = NULL, allow_truncated_timestamps = FALSE) {
-  if (!use_deprecated_int96_timestamps && is.null(coerce_timestamps) && !allow_truncated_timestamps) {
-    shared_ptr(ParquetArrowWriterProperties, parquet___default_arrow_writer_properties())
-  } else {
-    builder <- shared_ptr(ParquetArrowWriterPropertiesBuilder, parquet___ArrowWriterProperties___Builder__create())
-    builder$store_schema()
-    builder$set_int96_support(use_deprecated_int96_timestamps)
-    builder$set_coerce_timestamps(coerce_timestamps)
-    builder$set_allow_truncated_timestamps(allow_truncated_timestamps)
-    shared_ptr(ParquetArrowWriterProperties, parquet___ArrowWriterProperties___Builder__build(builder))
-  }
+  builder <- shared_ptr(ParquetArrowWriterPropertiesBuilder, parquet___ArrowWriterProperties___Builder__create())
+  builder$store_schema()
+  builder$set_int96_support(use_deprecated_int96_timestamps)
+  builder$set_coerce_timestamps(coerce_timestamps)
+  builder$set_allow_truncated_timestamps(allow_truncated_timestamps)
+  shared_ptr(ParquetArrowWriterProperties, parquet___ArrowWriterProperties___Builder__build(builder))
 }
 
 valid_parquet_version <- c(

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -4202,20 +4202,6 @@ RcppExport SEXP _arrow_parquet___arrow___FileReader__ReadTable2(SEXP reader_sexp
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<parquet::ArrowWriterProperties> parquet___default_arrow_writer_properties();
-RcppExport SEXP _arrow_parquet___default_arrow_writer_properties(){
-BEGIN_RCPP
-	return Rcpp::wrap(parquet___default_arrow_writer_properties());
-END_RCPP
-}
-#else
-RcppExport SEXP _arrow_parquet___default_arrow_writer_properties(){
-	Rf_error("Cannot call parquet___default_arrow_writer_properties(). Please use arrow::install_arrow() to install required runtime libraries. ");
-}
-#endif
-
-// parquet.cpp
-#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<parquet::ArrowWriterProperties::Builder> parquet___ArrowWriterProperties___Builder__create();
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__create(){
 BEGIN_RCPP
@@ -5799,7 +5785,6 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_parquet___arrow___FileReader__OpenFile", (DL_FUNC) &_arrow_parquet___arrow___FileReader__OpenFile, 2}, 
 		{ "_arrow_parquet___arrow___FileReader__ReadTable1", (DL_FUNC) &_arrow_parquet___arrow___FileReader__ReadTable1, 1}, 
 		{ "_arrow_parquet___arrow___FileReader__ReadTable2", (DL_FUNC) &_arrow_parquet___arrow___FileReader__ReadTable2, 2}, 
-		{ "_arrow_parquet___default_arrow_writer_properties", (DL_FUNC) &_arrow_parquet___default_arrow_writer_properties, 0}, 
 		{ "_arrow_parquet___ArrowWriterProperties___Builder__create", (DL_FUNC) &_arrow_parquet___ArrowWriterProperties___Builder__create, 0}, 
 		{ "_arrow_parquet___ArrowWriterProperties___Builder__store_schema", (DL_FUNC) &_arrow_parquet___ArrowWriterProperties___Builder__store_schema, 1}, 
 		{ "_arrow_parquet___ArrowWriterProperties___Builder__enable_deprecated_int96_timestamps", (DL_FUNC) &_arrow_parquet___ArrowWriterProperties___Builder__enable_deprecated_int96_timestamps, 1}, 

--- a/r/src/parquet.cpp
+++ b/r/src/parquet.cpp
@@ -83,12 +83,6 @@ std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable2(
 }
 
 // [[arrow::export]]
-std::shared_ptr<parquet::ArrowWriterProperties>
-parquet___default_arrow_writer_properties() {
-  return parquet::default_arrow_writer_properties();
-}
-
-// [[arrow::export]]
 std::shared_ptr<parquet::ArrowWriterProperties::Builder>
 parquet___ArrowWriterProperties___Builder__create() {
   return std::make_shared<parquet::ArrowWriterProperties::Builder>();

--- a/r/tests/testthat/helper-parquet.R
+++ b/r/tests/testthat/helper-parquet.R
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-expect_parquet_roundtrip <- function(tab, ...) {
+expect_parquet_roundtrip <- function(tab, ..., as_data_frame = FALSE) {
   tf <- tempfile()
   on.exit(unlink(tf))
 
   write_parquet(tab, tf, ...)
-  expect_equal(read_parquet(tf, as_data_frame = FALSE), tab)
+  expect_equal(read_parquet(tf, as_data_frame = as_data_frame), tab)
 }

--- a/r/tests/testthat/helper-parquet.R
+++ b/r/tests/testthat/helper-parquet.R
@@ -15,10 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
-expect_parquet_roundtrip <- function(tab, ..., as_data_frame = FALSE) {
+expect_parquet_roundtrip <- function(tab, ...) {
   tf <- tempfile()
   on.exit(unlink(tf))
 
   write_parquet(tab, tf, ...)
-  expect_equal(read_parquet(tf, as_data_frame = as_data_frame), tab)
+  expect_equal(read_parquet(tf, as_data_frame = FALSE), tab)
 }

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -106,3 +106,13 @@ test_that("write_parquet() defaults to snappy compression", {
   write_parquet(mtcars, tmp2, compression = "snappy")
   expect_equal(file.size(tmp1), file.size(tmp2))
 })
+
+test_that("Factors are preserved when writing/reading from Parquet", {
+  fct <- factor(c("a", "b"), levels = c("c", "a", "b"))
+  ord <- factor(c("a", "b"), levels = c("c", "a", "b"), ordered = TRUE)
+  chr <- c("a", "b")
+  df <- tibble::tibble(fct = fct, ord = ord, chr = chr)
+
+  expect_parquet_roundtrip(df)
+  expect_parquet_roundtrip(df, as_data_frame = FALSE)
+})

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -113,6 +113,10 @@ test_that("Factors are preserved when writing/reading from Parquet", {
   chr <- c("a", "b")
   df <- tibble::tibble(fct = fct, ord = ord, chr = chr)
 
-  expect_parquet_roundtrip(df)
-  expect_parquet_roundtrip(df, as_data_frame = FALSE)
+  pq_tmp_file <- tempfile()
+  on.exit(unlink(pq_tmp_file))
+
+  write_parquet(df, pq_tmp_file)
+  df_read <- read_parquet(pq_tmp_file)
+  expect_identical(df, df_read)
 })


### PR DESCRIPTION
The ability to preserve categorical values was introduced in https://github.com/apache/arrow/pull/5077 as the convention of storing a special `ARROW:schema` key in the metadata. To invoke this, we need to call `ArrowWriterProperties::store_schema()`.

The R binding is already ready for this, but calls `store_schema()` only conditionally and uses `parquet___default_arrow_writer_properties()` by default. Though I don't see the motivation to implement as such in #5451, considering [the Python binding always calls `store_schema()`](https://github.com/apache/arrow/blob/dbe708c7527a4aa6b63df7722cd57db4e0bd2dc7/python/pyarrow/_parquet.pyx#L1269), I guess the R code can do the same.