### PR TITLE
ARROW-7521: [Rust] Remove tuple on FixedSizeList

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -161,7 +161,7 @@ pub fn make_array(data: ArrayDataRef) -> ArrayRef {
         DataType::Utf8 => Arc::new(StringArray::from(data)) as ArrayRef,
         DataType::List(_) => Arc::new(ListArray::from(data)) as ArrayRef,
         DataType::Struct(_) => Arc::new(StructArray::from(data)) as ArrayRef,
-        DataType::FixedSizeList(_) => {
+        DataType::FixedSizeList(_, _) => {
             Arc::new(FixedSizeListArray::from(data)) as ArrayRef
         }
         dt => panic!("Unexpected data type {:?}", dt),
@@ -999,7 +999,7 @@ impl From<ArrayDataRef> for FixedSizeListArray {
         );
         let values = make_array(data.child_data()[0].clone());
         let length = match data.data_type() {
-            DataType::FixedSizeList((_, len)) => {
+            DataType::FixedSizeList(_, len) => {
                 // check that child data is multiple of length
                 assert_eq!(
                     values.len() % *len as usize,
@@ -2108,7 +2108,7 @@ mod tests {
             .build();
 
         // Construct a list array from the above two
-        let list_data_type = DataType::FixedSizeList((Box::new(DataType::Int32), 3));
+        let list_data_type = DataType::FixedSizeList(Box::new(DataType::Int32), 3);
         let list_data = ArrayData::builder(list_data_type.clone())
             .len(3)
             .add_child_data(value_data.clone())
@@ -2156,7 +2156,7 @@ mod tests {
             .build();
 
         // Construct a list array from the above two
-        let list_data_type = DataType::FixedSizeList((Box::new(DataType::Int32), 3));
+        let list_data_type = DataType::FixedSizeList(Box::new(DataType::Int32), 3);
         let list_data = ArrayData::builder(list_data_type.clone())
             .len(3)
             .add_child_data(value_data.clone())
@@ -2247,7 +2247,7 @@ mod tests {
         bit_util::set_bit(&mut null_bits, 4);
 
         // Construct a fixed size list array from the above two
-        let list_data_type = DataType::FixedSizeList((Box::new(DataType::Int32), 2));
+        let list_data_type = DataType::FixedSizeList(Box::new(DataType::Int32), 2);
         let list_data = ArrayData::builder(list_data_type.clone())
             .len(5)
             .add_child_data(value_data.clone())
@@ -2552,7 +2552,7 @@ mod tests {
             .build();
 
         let array_data =
-            ArrayData::builder(DataType::FixedSizeList((Box::new(DataType::Binary), 4)))
+            ArrayData::builder(DataType::FixedSizeList(Box::new(DataType::Binary), 4))
                 .len(3)
                 .add_child_data(values_data)
                 .build();

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -525,10 +525,10 @@ where
         );
 
         let null_bit_buffer = self.bitmap_builder.finish();
-        let data = ArrayData::builder(DataType::FixedSizeList((
+        let data = ArrayData::builder(DataType::FixedSizeList(
             Box::new(values_data.data_type().clone()),
             self.list_len,
-        )))
+        ))
         .len(len)
         .null_count(len - bit_util::count_set_bits(null_bit_buffer.data()))
         .add_child_data(values_data)

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -216,10 +216,7 @@ fn get_data_type(field: ipc::Field) -> DataType {
             }
             let child_field = children.get(0);
             let fsl = field.type_as_fixed_size_list().unwrap();
-            DataType::FixedSizeList((
-                Box::new(get_data_type(child_field)),
-                fsl.listSize(),
-            ))
+            DataType::FixedSizeList(Box::new(get_data_type(child_field)), fsl.listSize())
         }
         ipc::Type::Struct_ => {
             let mut fields = vec![];

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -108,7 +108,7 @@ fn create_array(
 
             create_list_array(list_node, data_type, &list_buffers[..], triple.0)
         }
-        FixedSizeList((ref list_data_type, _)) => {
+        FixedSizeList(ref list_data_type, _) => {
             let list_node = &nodes[node_index];
             let list_buffers: Vec<Buffer> = buffers[buffer_index..buffer_index + 1]
                 .iter()
@@ -331,7 +331,7 @@ fn create_list_array(
                 .null_bit_buffer(buffers[0].clone())
         }
         make_array(builder.build())
-    } else if let &DataType::FixedSizeList(_) = data_type {
+    } else if let &DataType::FixedSizeList(_, _) = data_type {
         let null_count = field_node.null_count() as usize;
         let mut builder = ArrayData::builder(data_type.clone())
             .len(field_node.length() as usize)

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -218,7 +218,7 @@ impl ArrowJsonBatch {
                         let arr = arr.as_any().downcast_ref::<ListArray>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
                     }
-                    DataType::FixedSizeList(_) => {
+                    DataType::FixedSizeList(_, _) => {
                         let arr =
                             arr.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
@@ -237,7 +237,7 @@ impl ArrowJsonBatch {
 fn json_from_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value> {
     match data_type {
         DataType::List(dt) => json_from_list_col(col, &**dt),
-        DataType::FixedSizeList((dt, list_size)) => {
+        DataType::FixedSizeList(dt, list_size) => {
             json_from_fixed_size_list_col(col, &**dt, *list_size as usize)
         }
         DataType::Struct(fields) => json_from_struct_col(col, fields),
@@ -331,7 +331,7 @@ fn json_from_fixed_size_list_col(
     let child = &col.children.clone().expect("list type must have children")[0];
     let inner = match data_type {
         DataType::List(ref dt) => json_from_col(child, &**dt),
-        DataType::FixedSizeList((ref dt, _)) => json_from_col(child, &**dt),
+        DataType::FixedSizeList(ref dt, _) => json_from_col(child, &**dt),
         DataType::Struct(fields) => json_from_struct_col(col, fields),
         _ => merge_json_array(&child.validity, &child.data.clone().unwrap()),
     };


### PR DESCRIPTION
This changes `FixedSizeList((Box<DataType>, i32))` to `DataType::FixedSizeList(Box<DataType>, i32)`