### PR TITLE
ARROW-7503: [Rust] [Parquet] Fix build failures

### DIFF
--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -30,7 +30,7 @@ edition = "2018"
 
 [dependencies]
 parquet-format = "~2.6"
-quick-error = "1.2.2"
+quick-error = "1.2"
 byteorder = "1"
 thrift = "0.12"
 snap = "0.2"

--- a/rust/parquet/src/column/writer.rs
+++ b/rust/parquet/src/column/writer.rs
@@ -890,7 +890,7 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.to_string(),
+                format!("{}", err),
                 "Parquet error: Inconsistent length of definition and repetition levels: 3 != 2"
             );
         }
@@ -905,7 +905,7 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.to_string(),
+                format!("{}", err),
                 "Parquet error: Definition levels are required, because max definition level = 1"
             );
         }
@@ -920,7 +920,7 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.to_string(),
+                format!("{}", err),
                 "Parquet error: Repetition levels are required, because max repetition level = 1"
             );
         }
@@ -935,7 +935,7 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.to_string(),
+                format!("{}", err),
                 "Parquet error: Expected to write 4 values, but have only 2"
             );
         }
@@ -968,7 +968,7 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.to_string(),
+                format!("{}", err),
                 "Parquet error: Dictionary encoder is not set"
             );
         }

--- a/rust/parquet/src/column/writer.rs
+++ b/rust/parquet/src/column/writer.rs
@@ -865,8 +865,6 @@ impl EncodingWriteSupport for ColumnWriterImpl<FixedLenByteArrayType> {
 mod tests {
     use super::*;
 
-    use std::error::Error;
-
     use rand::distributions::range::SampleRange;
 
     use crate::column::{
@@ -892,8 +890,8 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.description(),
-                "Inconsistent length of definition and repetition levels: 3 != 2"
+                err.to_string(),
+                "Parquet error: Inconsistent length of definition and repetition levels: 3 != 2"
             );
         }
     }
@@ -907,8 +905,8 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.description(),
-                "Definition levels are required, because max definition level = 1"
+                err.to_string(),
+                "Parquet error: Definition levels are required, because max definition level = 1"
             );
         }
     }
@@ -922,8 +920,8 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.description(),
-                "Repetition levels are required, because max repetition level = 1"
+                err.to_string(),
+                "Parquet error: Repetition levels are required, because max repetition level = 1"
             );
         }
     }
@@ -937,8 +935,8 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.description(),
-                "Expected to write 4 values, but have only 2"
+                err.to_string(),
+                "Parquet error: Expected to write 4 values, but have only 2"
             );
         }
     }
@@ -969,7 +967,10 @@ mod tests {
         let res = writer.write_dictionary_page();
         assert!(res.is_err());
         if let Err(err) = res {
-            assert_eq!(err.description(), "Dictionary encoder is not set");
+            assert_eq!(
+                err.to_string(),
+                "Parquet error: Dictionary encoder is not set"
+            );
         }
     }
 

--- a/rust/parquet/src/errors.rs
+++ b/rust/parquet/src/errors.rs
@@ -32,7 +32,6 @@ quick_error! {
       /// Returned when code violates normal workflow of working with Parquet files.
       General(message: String) {
           display("Parquet error: {}", message)
-              display(message)
               from(e: io::Error) -> (format!("underlying IO error: {}", e))
               from(e: snap::Error) -> (format!("underlying snap error: {}", e))
               from(e: thrift::Error) -> (format!("underlying Thrift error: {}", e))
@@ -43,25 +42,21 @@ quick_error! {
       /// Returned when functionality is not yet available.
       NYI(message: String) {
           display("NYI: {}", message)
-              display(message)
       }
       /// "End of file" Parquet error.
       /// Returned when IO related failures occur, e.g. when there are not enough bytes to
       /// decode.
       EOF(message: String) {
           display("EOF: {}", message)
-              display(message)
       }
       /// Arrow error.
       /// Returned when reading into arrow or writing from arrow.
       ArrowError(message:  String) {
           display("Arrow: {}", message)
-              display(message)
               from(e: ArrowError) -> (format!("underlying Arrow error: {:?}", e))
       }
       IndexOutOfBound(index: usize, bound: usize) {
           display("Index {} out of bound: {}", index, bound)
-              display("Index out of bound error")
       }
   }
 }
@@ -104,6 +99,6 @@ macro_rules! eof_err {
 
 impl Into<ArrowError> for ParquetError {
     fn into(self) -> ArrowError {
-        ArrowError::ParquetError(self.to_string())
+        ArrowError::ParquetError(format!("{}", self))
     }
 }

--- a/rust/parquet/src/errors.rs
+++ b/rust/parquet/src/errors.rs
@@ -22,7 +22,6 @@ use std::{cell, convert, io, result, str};
 use arrow::error::ArrowError;
 use quick_error::quick_error;
 use snap;
-use std::error::Error;
 use thrift;
 
 quick_error! {
@@ -33,7 +32,7 @@ quick_error! {
       /// Returned when code violates normal workflow of working with Parquet files.
       General(message: String) {
           display("Parquet error: {}", message)
-              description(message)
+              display(message)
               from(e: io::Error) -> (format!("underlying IO error: {}", e))
               from(e: snap::Error) -> (format!("underlying snap error: {}", e))
               from(e: thrift::Error) -> (format!("underlying Thrift error: {}", e))
@@ -44,25 +43,25 @@ quick_error! {
       /// Returned when functionality is not yet available.
       NYI(message: String) {
           display("NYI: {}", message)
-              description(message)
+              display(message)
       }
       /// "End of file" Parquet error.
       /// Returned when IO related failures occur, e.g. when there are not enough bytes to
       /// decode.
       EOF(message: String) {
           display("EOF: {}", message)
-              description(message)
+              display(message)
       }
       /// Arrow error.
       /// Returned when reading into arrow or writing from arrow.
       ArrowError(message:  String) {
           display("Arrow: {}", message)
-              description(message)
+              display(message)
               from(e: ArrowError) -> (format!("underlying Arrow error: {:?}", e))
       }
       IndexOutOfBound(index: usize, bound: usize) {
           display("Index {} out of bound: {}", index, bound)
-              description("Index out of bound error")
+              display("Index out of bound error")
       }
   }
 }
@@ -105,6 +104,6 @@ macro_rules! eof_err {
 
 impl Into<ArrowError> for ParquetError {
     fn into(self) -> ArrowError {
-        ArrowError::ParquetError(self.description().to_string())
+        ArrowError::ParquetError(self.to_string())
     }
 }

--- a/rust/parquet/src/file/metadata.rs
+++ b/rust/parquet/src/file/metadata.rs
@@ -669,7 +669,7 @@ mod tests {
         assert!(row_group_meta.is_err());
         if let Err(e) = row_group_meta {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: Column length mismatch: 2 != 0"
             );
         }

--- a/rust/parquet/src/file/writer.rs
+++ b/rust/parquet/src/file/writer.rs
@@ -524,7 +524,7 @@ impl<T: Write + Position> PageWriter for SerializedPageWriter<T> {
 mod tests {
     use super::*;
 
-    use std::{error::Error, fs::File, io::Cursor};
+    use std::{fs::File, io::Cursor};
 
     use crate::basic::{Compression, Encoding, Repetition, Type};
     use crate::column::page::PageReader;
@@ -548,14 +548,14 @@ mod tests {
             let res = writer.next_row_group();
             assert!(res.is_err());
             if let Err(err) = res {
-                assert_eq!(err.description(), "File writer is closed");
+                assert_eq!(err.to_string(), "Parquet error: File writer is closed");
             }
         }
         {
             let res = writer.close();
             assert!(res.is_err());
             if let Err(err) = res {
-                assert_eq!(err.description(), "File writer is closed");
+                assert_eq!(err.to_string(), "Parquet error: File writer is closed");
             }
         }
     }
@@ -572,7 +572,7 @@ mod tests {
         let res = row_group_writer.next_column();
         assert!(res.is_err());
         if let Err(err) = res {
-            assert_eq!(err.description(), "Row group writer is closed");
+            assert_eq!(err.to_string(), "Parquet error: Row group writer is closed");
         }
     }
 
@@ -596,7 +596,10 @@ mod tests {
         let res = row_group_writer.close();
         assert!(res.is_err());
         if let Err(err) = res {
-            assert_eq!(err.description(), "Column length mismatch: 1 != 0");
+            assert_eq!(
+                err.to_string(),
+                "Parquet error: Column length mismatch: 1 != 0"
+            );
         }
     }
 
@@ -641,8 +644,8 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.description(),
-                "Incorrect number of rows, expected 3 != 2 rows"
+                err.to_string(),
+                "Parquet error: Incorrect number of rows, expected 3 != 2 rows"
             );
         }
     }

--- a/rust/parquet/src/file/writer.rs
+++ b/rust/parquet/src/file/writer.rs
@@ -548,14 +548,14 @@ mod tests {
             let res = writer.next_row_group();
             assert!(res.is_err());
             if let Err(err) = res {
-                assert_eq!(err.to_string(), "Parquet error: File writer is closed");
+                assert_eq!(format!("{}", err), "Parquet error: File writer is closed");
             }
         }
         {
             let res = writer.close();
             assert!(res.is_err());
             if let Err(err) = res {
-                assert_eq!(err.to_string(), "Parquet error: File writer is closed");
+                assert_eq!(format!("{}", err), "Parquet error: File writer is closed");
             }
         }
     }
@@ -572,7 +572,10 @@ mod tests {
         let res = row_group_writer.next_column();
         assert!(res.is_err());
         if let Err(err) = res {
-            assert_eq!(err.to_string(), "Parquet error: Row group writer is closed");
+            assert_eq!(
+                format!("{}", err),
+                "Parquet error: Row group writer is closed"
+            );
         }
     }
 
@@ -597,7 +600,7 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.to_string(),
+                format!("{}", err),
                 "Parquet error: Column length mismatch: 1 != 0"
             );
         }
@@ -644,7 +647,7 @@ mod tests {
         assert!(res.is_err());
         if let Err(err) = res {
             assert_eq!(
-                err.to_string(),
+                format!("{}", err),
                 "Parquet error: Incorrect number of rows, expected 3 != 2 rows"
             );
         }

--- a/rust/parquet/src/schema/types.rs
+++ b/rust/parquet/src/schema/types.rs
@@ -1096,7 +1096,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: BSON can only annotate BYTE_ARRAY fields"
             );
         }
@@ -1110,7 +1110,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: DECIMAL can only annotate INT32, INT64, BYTE_ARRAY and FIXED"
             );
         }
@@ -1124,7 +1124,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: Invalid DECIMAL precision: -1"
             );
         }
@@ -1137,7 +1137,10 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.to_string(), "Parquet error: Invalid DECIMAL precision: 0");
+            assert_eq!(
+                format!("{}", e),
+                "Parquet error: Invalid DECIMAL precision: 0"
+            );
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
@@ -1148,7 +1151,7 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.to_string(), "Parquet error: Invalid DECIMAL scale: -1");
+            assert_eq!(format!("{}", e), "Parquet error: Invalid DECIMAL scale: -1");
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
@@ -1160,7 +1163,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: Invalid DECIMAL: scale (2) cannot be greater than or equal to precision (1)"
             );
         }
@@ -1174,7 +1177,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: Cannot represent INT32 as DECIMAL with precision 18"
             );
         }
@@ -1188,7 +1191,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: Cannot represent INT64 as DECIMAL with precision 32"
             );
         }
@@ -1203,7 +1206,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: Cannot represent FIXED_LEN_BYTE_ARRAY as DECIMAL with length 5 and precision 12"
             );
         }
@@ -1215,7 +1218,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: UINT_8 can only annotate INT32"
             );
         }
@@ -1227,7 +1230,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: TIME_MICROS can only annotate INT64"
             );
         }
@@ -1239,7 +1242,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: INTERVAL can only annotate FIXED_LEN_BYTE_ARRAY(12)"
             );
         }
@@ -1252,7 +1255,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: INTERVAL can only annotate FIXED_LEN_BYTE_ARRAY(12)"
             );
         }
@@ -1264,7 +1267,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: ENUM can only annotate BYTE_ARRAY fields"
             );
         }
@@ -1276,7 +1279,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: MAP cannot be applied to a primitive type"
             );
         }
@@ -1289,7 +1292,7 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: Invalid FIXED_LEN_BYTE_ARRAY length: -1"
             );
         }
@@ -1777,7 +1780,7 @@ mod tests {
         assert!(thrift_schema.is_err());
         if let Err(e) = thrift_schema {
             assert_eq!(
-                e.to_string(),
+                format!("{}", e),
                 "Parquet error: Root schema must be Group type"
             );
         }

--- a/rust/parquet/src/schema/types.rs
+++ b/rust/parquet/src/schema/types.rs
@@ -1063,8 +1063,6 @@ fn to_thrift_helper(schema: &Type, elements: &mut Vec<SchemaElement>) {
 mod tests {
     use super::*;
 
-    use std::error::Error;
-
     use crate::schema::parser::parse_message_type;
 
     #[test]
@@ -1097,7 +1095,10 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.description(), "BSON can only annotate BYTE_ARRAY fields");
+            assert_eq!(
+                e.to_string(),
+                "Parquet error: BSON can only annotate BYTE_ARRAY fields"
+            );
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT96)
@@ -1109,8 +1110,8 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.description(),
-                "DECIMAL can only annotate INT32, INT64, BYTE_ARRAY and FIXED"
+                e.to_string(),
+                "Parquet error: DECIMAL can only annotate INT32, INT64, BYTE_ARRAY and FIXED"
             );
         }
 
@@ -1122,7 +1123,10 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.description(), "Invalid DECIMAL precision: -1");
+            assert_eq!(
+                e.to_string(),
+                "Parquet error: Invalid DECIMAL precision: -1"
+            );
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
@@ -1133,7 +1137,7 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.description(), "Invalid DECIMAL precision: 0");
+            assert_eq!(e.to_string(), "Parquet error: Invalid DECIMAL precision: 0");
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
@@ -1144,7 +1148,7 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.description(), "Invalid DECIMAL scale: -1");
+            assert_eq!(e.to_string(), "Parquet error: Invalid DECIMAL scale: -1");
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
@@ -1156,8 +1160,8 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.description(),
-                "Invalid DECIMAL: scale (2) cannot be greater than or equal to precision (1)"
+                e.to_string(),
+                "Parquet error: Invalid DECIMAL: scale (2) cannot be greater than or equal to precision (1)"
             );
         }
 
@@ -1170,8 +1174,8 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.description(),
-                "Cannot represent INT32 as DECIMAL with precision 18"
+                e.to_string(),
+                "Parquet error: Cannot represent INT32 as DECIMAL with precision 18"
             );
         }
 
@@ -1184,8 +1188,8 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.description(),
-                "Cannot represent INT64 as DECIMAL with precision 32"
+                e.to_string(),
+                "Parquet error: Cannot represent INT64 as DECIMAL with precision 32"
             );
         }
 
@@ -1199,8 +1203,8 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.description(),
-                "Cannot represent FIXED_LEN_BYTE_ARRAY as DECIMAL with length 5 and precision 12"
+                e.to_string(),
+                "Parquet error: Cannot represent FIXED_LEN_BYTE_ARRAY as DECIMAL with length 5 and precision 12"
             );
         }
 
@@ -1210,7 +1214,10 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.description(), "UINT_8 can only annotate INT32");
+            assert_eq!(
+                e.to_string(),
+                "Parquet error: UINT_8 can only annotate INT32"
+            );
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT32)
@@ -1219,7 +1226,10 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.description(), "TIME_MICROS can only annotate INT64");
+            assert_eq!(
+                e.to_string(),
+                "Parquet error: TIME_MICROS can only annotate INT64"
+            );
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::BYTE_ARRAY)
@@ -1229,8 +1239,8 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.description(),
-                "INTERVAL can only annotate FIXED_LEN_BYTE_ARRAY(12)"
+                e.to_string(),
+                "Parquet error: INTERVAL can only annotate FIXED_LEN_BYTE_ARRAY(12)"
             );
         }
 
@@ -1242,8 +1252,8 @@ mod tests {
         assert!(result.is_err());
         if let Err(e) = result {
             assert_eq!(
-                e.description(),
-                "INTERVAL can only annotate FIXED_LEN_BYTE_ARRAY(12)"
+                e.to_string(),
+                "Parquet error: INTERVAL can only annotate FIXED_LEN_BYTE_ARRAY(12)"
             );
         }
 
@@ -1253,7 +1263,10 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.description(), "ENUM can only annotate BYTE_ARRAY fields");
+            assert_eq!(
+                e.to_string(),
+                "Parquet error: ENUM can only annotate BYTE_ARRAY fields"
+            );
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::INT32)
@@ -1262,7 +1275,10 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.description(), "MAP cannot be applied to a primitive type");
+            assert_eq!(
+                e.to_string(),
+                "Parquet error: MAP cannot be applied to a primitive type"
+            );
         }
 
         result = Type::primitive_type_builder("foo", PhysicalType::FIXED_LEN_BYTE_ARRAY)
@@ -1272,7 +1288,10 @@ mod tests {
             .build();
         assert!(result.is_err());
         if let Err(e) = result {
-            assert_eq!(e.description(), "Invalid FIXED_LEN_BYTE_ARRAY length: -1");
+            assert_eq!(
+                e.to_string(),
+                "Parquet error: Invalid FIXED_LEN_BYTE_ARRAY length: -1"
+            );
         }
     }
 
@@ -1757,7 +1776,10 @@ mod tests {
         let thrift_schema = to_thrift(&schema);
         assert!(thrift_schema.is_err());
         if let Err(e) = thrift_schema {
-            assert_eq!(e.description(), "Root schema must be Group type");
+            assert_eq!(
+                e.to_string(),
+                "Parquet error: Root schema must be Group type"
+            );
         }
     }
 


### PR DESCRIPTION
This replaces the deprecated `Error::description()` with a simpler ToString. I'm not familiar with the `quick-error` crate, but did my best from what I could see on the https://github.com/tailhook/quick-error/commit/b26770f47b34e5be08ecef706e82e2e474074e9e commit that addressed the deprecation warning/error.