### PR TITLE
ARROW-7523: [Developer] Relax clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,google-*,modernize-*,readability-*'
+Checks: 'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,google-*,modernize-*,-modernize-use-trailing-return-type'
 # produce HeaderFilterRegex from cpp/build-support/lint_exclusions.txt with:
 # echo -n '^('; sed -e 's/*/\.*/g' cpp/build-support/lint_exclusions.txt | tr '\n' '|'; echo ')$'
 HeaderFilterRegex: '^(.*codegen.*|.*_generated.*|.*windows_compatibility.h|.*pyarrow_api.h|.*pyarrow_lib.h|.*python/config.h|.*python/platform.h|.*thirdparty/ae/.*|.*vendored/.*|.*RcppExports.cpp.*|)$'


### PR DESCRIPTION
The following checks are removed due to verbosity

- modernize-use-trailing-return-type
- readability-*