### PR TITLE
ARROW-7526: [C++][Compute] Optimize small integer sorting

### DIFF
--- a/cpp/src/arrow/compute/kernels/sort_to_indices.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices.cc
@@ -71,11 +71,79 @@ bool CompareViews(const ArrayType& array, uint64_t lhs, uint64_t rhs) {
 }
 
 template <typename ArrowType, typename Comparator>
+class CompareSorter {
+  using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
+
+ public:
+  explicit CompareSorter(Comparator compare) : compare_(compare) {}
+
+  void Sort(int64_t* indices_begin, int64_t* indices_end, const ArrayType& values) {
+    std::iota(indices_begin, indices_end, 0);
+
+    auto nulls_begin = indices_end;
+    if (values.null_count()) {
+      nulls_begin =
+          std::stable_partition(indices_begin, indices_end,
+                                [&values](uint64_t ind) { return !values.IsNull(ind); });
+    }
+    std::stable_sort(indices_begin, nulls_begin,
+                     [&values, this](uint64_t left, uint64_t right) {
+                       return compare_(values, left, right);
+                     });
+  }
+
+ private:
+  Comparator compare_;
+};
+
+template <typename ArrowType>
+class CountSorter {
+  using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
+
+ public:
+  explicit CountSorter(int min, int max) : min_(min), max_(max) {}
+
+  void Sort(int64_t *indices_begin, int64_t *indices_end, const ArrayType& values) {
+    // 32bit counter performs much better than 64bit one
+    if (values.length() < (1LL << 32)) {
+        SortInternal<uint32_t>(indices_begin, indices_end, values);
+    } else {
+        SortInternal<uint64_t>(indices_begin, indices_end, values);
+    }
+  }
+
+ private:
+  const int min_, max_;
+
+  template <typename CounterType>
+  void SortInternal(int64_t *indices_begin, int64_t *indices_end, const ArrayType& values) {
+    const size_t value_range = max_ - min_ + 1;
+
+    // first slot reserved for prefix sum, last slot for null value
+    std::vector<CounterType> count(1 + value_range + 1);
+
+    for (int64_t i = 0; i < values.length(); ++i) {
+      auto v = values.IsNull(i) ? value_range : (values.Value(i) - min_);
+      ++count[v+1];
+    }
+
+    for (size_t i = 1; i <= value_range; ++i) {
+      count[i] += count[i-1];
+    }
+
+    for (int64_t i = 0; i < values.length(); ++i) {
+        auto v = values.IsNull(i) ? value_range : (values.Value(i) - min_);
+        indices_begin[count[v]++] = i;
+    }
+  }
+};
+
+template <typename ArrowType, typename Sorter>
 class SortToIndicesKernelImpl : public SortToIndicesKernel {
   using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
 
  public:
-  explicit SortToIndicesKernelImpl(Comparator compare) : compare_(compare) {}
+  explicit SortToIndicesKernelImpl(Sorter sorter) : sorter_(sorter) {}
 
   Status SortToIndices(FunctionContext* ctx, const std::shared_ptr<Array>& values,
                        std::shared_ptr<Array>* offsets) {
@@ -96,7 +164,7 @@ class SortToIndicesKernelImpl : public SortToIndicesKernel {
   std::shared_ptr<DataType> out_type() const { return type_; }
 
  private:
-  Comparator compare_;
+  Sorter sorter_;
 
   Status SortToIndicesImpl(FunctionContext* ctx, const std::shared_ptr<ArrayType>& values,
                            std::shared_ptr<Array>* offsets) {
@@ -107,26 +175,22 @@ class SortToIndicesKernelImpl : public SortToIndicesKernel {
     int64_t* indices_begin = reinterpret_cast<int64_t*>(indices_buf->mutable_data());
     int64_t* indices_end = indices_begin + values->length();
 
-    std::iota(indices_begin, indices_end, 0);
-    auto nulls_begin = indices_end;
-    if (values->null_count()) {
-      nulls_begin =
-          std::stable_partition(indices_begin, indices_end,
-                                [&values](uint64_t ind) { return !values->IsNull(ind); });
-    }
-    std::stable_sort(indices_begin, nulls_begin,
-                     [&values, this](uint64_t left, uint64_t right) {
-                       return compare_(*values, left, right);
-                     });
+    sorter_.Sort(indices_begin, indices_end, *values.get());
     *offsets = std::make_shared<UInt64Array>(values->length(), indices_buf);
     return Status::OK();
   }
 };
 
-template <typename ArrowType, typename Comparator>
-SortToIndicesKernelImpl<ArrowType, Comparator>* MakeSortToIndicesKernelImpl(
+template <typename ArrowType, typename Comparator, typename Sorter = CompareSorter<ArrowType, Comparator>>
+SortToIndicesKernelImpl<ArrowType, Sorter>* MakeSortToIndicesKernelImpl(
     Comparator comparator) {
-  return new SortToIndicesKernelImpl<ArrowType, Comparator>(comparator);
+  return new SortToIndicesKernelImpl<ArrowType, Sorter>(Sorter(comparator));
+}
+
+template <typename ArrowType, typename Sorter = CountSorter<ArrowType>>
+SortToIndicesKernelImpl<ArrowType, Sorter>* MakeSortToIndicesKernelImpl(
+    int min, int max) {
+  return new SortToIndicesKernelImpl<ArrowType, Sorter>(Sorter(min, max));
 }
 
 Status SortToIndicesKernel::Make(const std::shared_ptr<DataType>& value_type,
@@ -134,10 +198,10 @@ Status SortToIndicesKernel::Make(const std::shared_ptr<DataType>& value_type,
   SortToIndicesKernel* kernel;
   switch (value_type->id()) {
     case Type::UINT8:
-      kernel = MakeSortToIndicesKernelImpl<UInt8Type>(CompareValues<UInt8Array>);
+      kernel = MakeSortToIndicesKernelImpl<UInt8Type>(0, 255);
       break;
     case Type::INT8:
-      kernel = MakeSortToIndicesKernelImpl<Int8Type>(CompareValues<Int8Array>);
+      kernel = MakeSortToIndicesKernelImpl<Int8Type>(-128, 127);
       break;
     case Type::UINT16:
       kernel = MakeSortToIndicesKernelImpl<UInt16Type>(CompareValues<UInt16Array>);

--- a/cpp/src/arrow/compute/kernels/sort_to_indices.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices.cc
@@ -184,14 +184,13 @@ class SortToIndicesKernelImpl : public SortToIndicesKernel {
 
 template <typename ArrowType, typename Comparator,
           typename Sorter = CompareSorter<ArrowType, Comparator>>
-SortToIndicesKernelImpl<ArrowType, Sorter>* MakeSortToIndicesKernelImpl(
+SortToIndicesKernelImpl<ArrowType, Sorter>* MakeSortToIndicesWithComparator(
     Comparator comparator) {
   return new SortToIndicesKernelImpl<ArrowType, Sorter>(Sorter(comparator));
 }
 
 template <typename ArrowType, typename Sorter = CountSorter<ArrowType>>
-SortToIndicesKernelImpl<ArrowType, Sorter>* MakeSortToIndicesKernelImpl(int min,
-                                                                        int max) {
+SortToIndicesKernelImpl<ArrowType, Sorter>* MakeSortToIndicesCounting(int min, int max) {
   return new SortToIndicesKernelImpl<ArrowType, Sorter>(Sorter(min, max));
 }
 
@@ -200,40 +199,40 @@ Status SortToIndicesKernel::Make(const std::shared_ptr<DataType>& value_type,
   SortToIndicesKernel* kernel;
   switch (value_type->id()) {
     case Type::UINT8:
-      kernel = MakeSortToIndicesKernelImpl<UInt8Type>(0, 255);
+      kernel = MakeSortToIndicesCounting<UInt8Type>(0, 255);
       break;
     case Type::INT8:
-      kernel = MakeSortToIndicesKernelImpl<Int8Type>(-128, 127);
+      kernel = MakeSortToIndicesCounting<Int8Type>(-128, 127);
       break;
     case Type::UINT16:
-      kernel = MakeSortToIndicesKernelImpl<UInt16Type>(CompareValues<UInt16Array>);
+      kernel = MakeSortToIndicesWithComparator<UInt16Type>(CompareValues<UInt16Array>);
       break;
     case Type::INT16:
-      kernel = MakeSortToIndicesKernelImpl<Int16Type>(CompareValues<Int16Array>);
+      kernel = MakeSortToIndicesWithComparator<Int16Type>(CompareValues<Int16Array>);
       break;
     case Type::UINT32:
-      kernel = MakeSortToIndicesKernelImpl<UInt32Type>(CompareValues<UInt32Array>);
+      kernel = MakeSortToIndicesWithComparator<UInt32Type>(CompareValues<UInt32Array>);
       break;
     case Type::INT32:
-      kernel = MakeSortToIndicesKernelImpl<Int32Type>(CompareValues<Int32Array>);
+      kernel = MakeSortToIndicesWithComparator<Int32Type>(CompareValues<Int32Array>);
       break;
     case Type::UINT64:
-      kernel = MakeSortToIndicesKernelImpl<UInt64Type>(CompareValues<UInt64Array>);
+      kernel = MakeSortToIndicesWithComparator<UInt64Type>(CompareValues<UInt64Array>);
       break;
     case Type::INT64:
-      kernel = MakeSortToIndicesKernelImpl<Int64Type>(CompareValues<Int64Array>);
+      kernel = MakeSortToIndicesWithComparator<Int64Type>(CompareValues<Int64Array>);
       break;
     case Type::FLOAT:
-      kernel = MakeSortToIndicesKernelImpl<FloatType>(CompareValues<FloatArray>);
+      kernel = MakeSortToIndicesWithComparator<FloatType>(CompareValues<FloatArray>);
       break;
     case Type::DOUBLE:
-      kernel = MakeSortToIndicesKernelImpl<DoubleType>(CompareValues<DoubleArray>);
+      kernel = MakeSortToIndicesWithComparator<DoubleType>(CompareValues<DoubleArray>);
       break;
     case Type::BINARY:
-      kernel = MakeSortToIndicesKernelImpl<BinaryType>(CompareViews<BinaryArray>);
+      kernel = MakeSortToIndicesWithComparator<BinaryType>(CompareViews<BinaryArray>);
       break;
     case Type::STRING:
-      kernel = MakeSortToIndicesKernelImpl<StringType>(CompareViews<StringArray>);
+      kernel = MakeSortToIndicesWithComparator<StringType>(CompareViews<StringArray>);
       break;
     default:
       return Status::NotImplemented("Sorting of ", *value_type, " arrays");

--- a/cpp/src/arrow/compute/kernels/sort_to_indices_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices_benchmark.cc
@@ -49,10 +49,31 @@ static void SortToIndicesInt64(benchmark::State& state) {
   SortToIndicesBenchmark(state, values);
 }
 
+static void SortToIndicesInt8(benchmark::State& state) {
+  RegressionArgs args(state);
+
+  const int64_t array_size = args.size / sizeof(int8_t);
+  auto rand = random::RandomArrayGenerator(kSeed);
+
+  auto values = rand.Int8(array_size, -100, 100, args.null_proportion);
+
+  SortToIndicesBenchmark(state, values);
+}
+
 BENCHMARK(SortToIndicesInt64)
     ->Apply(RegressionSetArgs)
     ->Args({1 << 20, 1})
     ->Args({1 << 23, 1})
+    ->MinTime(1.0)
+    ->Unit(benchmark::TimeUnit::kNanosecond);
+
+BENCHMARK(SortToIndicesInt8)
+    ->Apply(RegressionSetArgs)
+    ->Args({1 << 20, 1})
+    ->Args({1 << 23, 1})
+    ->Args({1 << 23, 50})
+    ->Args({1 << 23, 80})
+    ->Args({1 << 23, 99})
     ->MinTime(1.0)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/sort_to_indices_test.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices_test.cc
@@ -115,7 +115,7 @@ TYPED_TEST(TestSortToIndicesKernelForUInt8, SortUInt8) {
 }
 
 TYPED_TEST(TestSortToIndicesKernelForInt8, SortInt8) {
-  this->AssertSortToIndices("[null, 10, 127, 0, -128, -128, null, 0]", "[4,5,3,7,1,2,0,6]");
+  this->AssertSortToIndices("[null, 10, 127, 0, -128, -128, null]", "[4,5,3,1,2,0,6]");
 }
 
 template <typename ArrowType>

--- a/cpp/src/arrow/compute/kernels/sort_to_indices_test.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices_test.cc
@@ -103,6 +103,22 @@ TYPED_TEST(TestSortToIndicesKernelForStrings, SortStrings) {
 }
 
 template <typename ArrowType>
+class TestSortToIndicesKernelForUInt8 : public TestSortToIndicesKernel<ArrowType> {};
+TYPED_TEST_CASE(TestSortToIndicesKernelForUInt8, UInt8Type);
+
+template <typename ArrowType>
+class TestSortToIndicesKernelForInt8 : public TestSortToIndicesKernel<ArrowType> {};
+TYPED_TEST_CASE(TestSortToIndicesKernelForInt8, Int8Type);
+
+TYPED_TEST(TestSortToIndicesKernelForUInt8, SortUInt8) {
+  this->AssertSortToIndices("[255, null, 0, 255, 10, null, 128, 0]", "[2,7,4,6,0,3,1,5]");
+}
+
+TYPED_TEST(TestSortToIndicesKernelForInt8, SortInt8) {
+  this->AssertSortToIndices("[null, 10, 127, 0, -128, -128, null, 0]", "[4,5,3,7,1,2,0,6]");
+}
+
+template <typename ArrowType>
 class TestSortToIndicesKernelRandom : public ComputeFixture, public TestBase {};
 
 using SortToIndicesableTypes =


### PR DESCRIPTION
Current sorting kernel handles all data types with stl stable_sort.
It is suboptimal for small integers with small value range.

This patch leverages counting sort for Int8 and UInt8 sorting. Up to
10x performance improvement is observed on x86, and above 20x on Arm.

Benchmark
=========
- Tested on Intel E5-2650 and Arm64 CPU
- Data collected by running "arrow-compute-sort-to-indices-benchmark"
- No performance regression is found for Int64 benchmark
- Int8 benchmark is added, result shows big performance boost

Int8 sorting benchmark on E5-2650
---------------------------------
| current    | this patch  | uplift | test case                     |
| -------    | ----------  | ------ | ---------                     |
| 10.0461M/s | 75.2091M/s  | 7.5x   | null_percent=0  size=32.768k  |
| 9.99244M/s | 75.0697M/s  | 7.5x   | null_percent=1  size=32.768k  |
| 10.8323M/s | 71.1796M/s  | 6.6x   | null_percent=10 size=32.768k  |
| 16.9689M/s | 58.756M/s   | 3.5x   | null_percent=50 size=32.768k  |
| 8.25916M/s | 74.9076M/s  | 9.1x   | null_percent=1  size=1048.58k |
| 6.8773M/s  | 73.1168M/s  | 10.6x  | null_percent=1  size=8.38861M |
| 11.9212M/s | 57.5259M/s  | 4.8x   | null_percent=50 size=8.38861M |
| 28.6507M/s | 109.871M/s  | 3.8x   | null_percent=80 size=8.38861M |
| 119.498M/s | 192.564M/s  | 1.6x   | null_percent=99 size=8.38861M |

One interesting finding is current code performs better with more null
values, while this patch performs worst at 50% null values. It's
because current code partitions null values and sort only valid ones,
while this patch treats null as largest value and sort as normal ones.
Branch prediction for null testing works badly if half values are null.
For the extreme case with 99% null values, this patch is 1.6x faster
than current code.

NOTES
=====
Counting sort is not friendly to short arrays. I benchmarked very short
Int8 arrays. Though the test result is very noisy, it does show a bit
performance drops for arrays with fewer than 32 elements on my test bed.

| bytes | current | this patch | uplift |
| ----- | ------- | ---------- | ------ |
| 16    | 16.5M/s | 15.4M/s    | -6%    |
| 32    | 25.4M/s | 25.3M/s    |  0%    |
| 64    | 32.5M/s | 37.9M/s    | +17%   |

It's possible to fallback to stl stable_sort when sorting very short
Int8 arrays. I think it's not necessary as the absolute sorting time
is too short to influence a real world application.