### PR TITLE
ARROW-7527: [Python] Fix pandas/feather tests for unsupported types with pandas master

### DIFF
--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -540,9 +540,12 @@ class TestFeatherReader(unittest.TestCase):
         # https://github.com/wesm/feather/issues/240
         # serializing actual python objects
 
-        # period
-        df = pd.DataFrame({'a': pd.period_range('2013', freq='M', periods=3)})
-        self._assert_error_on_write(df, TypeError)
+        # custom python objects
+        class A:
+            pass
+
+        df = pd.DataFrame({'a': [A(), A()]})
+        self._assert_error_on_write(df, ValueError)
 
         # non-strings
         df = pd.DataFrame({'a': ['a', 1, 2.0]})

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2580,14 +2580,25 @@ def _pytime_to_micros(pytime):
 def test_convert_unsupported_type_error_message():
     # ARROW-1454
 
-    # period as yet unsupported
-    df = pd.DataFrame({
-        'a': pd.period_range('2000-01-01', periods=20),
-    })
+    # custom python objects
+    class A:
+        pass
 
-    expected_msg = 'Conversion failed for column a with type period'
-    with pytest.raises(TypeError, match=expected_msg):
+    df = pd.DataFrame({'a': [A(), A()]})
+
+    expected_msg = 'Conversion failed for column a with type object'
+    with pytest.raises(ValueError, match=expected_msg):
         pa.Table.from_pandas(df)
+
+    # period unsupported for pandas <= 0.25
+    if LooseVersion(pd.__version__) <= '0.25':
+        df = pd.DataFrame({
+            'a': pd.period_range('2000-01-01', periods=20),
+        })
+
+        expected_msg = 'Conversion failed for column a with type period'
+        with pytest.raises(TypeError, match=expected_msg):
+            pa.Table.from_pandas(df)
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-7527

Period dtype is now supported in pandas <-> arrow conversions with pandas master (https://github.com/pandas-dev/pandas/pull/28371)