### PR TITLE
ARROW-7539: [Java] FieldVector getFieldBuffers API should not set reader/writer indices

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -159,7 +159,6 @@ public class UnionVector implements FieldVector {
   @Override
   public List<ArrowBuf> getFieldBuffers() {
     List<ArrowBuf> result = new ArrayList<>(1);
-    setReaderAndWriterIndex();
     result.add(typeBuffer);
 
     return result;
@@ -534,10 +533,8 @@ public class UnionVector implements FieldVector {
   public ArrowBuf[] getBuffers(boolean clear) {
     List<ArrowBuf> list = new java.util.ArrayList<>();
     setReaderAndWriterIndex();
-    if (getBufferSize() != 0) {
-      list.add(typeBuffer);
-      list.addAll(java.util.Arrays.asList(internalStruct.getBuffers(clear)));
-    }
+    list.add(typeBuffer);
+    list.addAll(java.util.Arrays.asList(internalStruct.getBuffers(clear)));
     if (clear) {
       valueCount = 0;
       typeBuffer.getReferenceManager().retain();

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -396,13 +396,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   public ArrowBuf[] getBuffers(boolean clear) {
     final ArrowBuf[] buffers;
     setReaderAndWriterIndex();
-    if (getBufferSize() == 0) {
-      buffers = new ArrowBuf[0];
-    } else {
-      buffers = new ArrowBuf[2];
-      buffers[0] = validityBuffer;
-      buffers[1] = valueBuffer;
-    }
+    buffers = new ArrowBuf[2];
+    buffers[0] = validityBuffer;
+    buffers[1] = valueBuffer;
     if (clear) {
       for (final ArrowBuf buffer : buffers) {
         buffer.getReferenceManager().retain(1);
@@ -503,7 +499,6 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    */
   public List<ArrowBuf> getFieldBuffers() {
     List<ArrowBuf> result = new ArrayList<>(2);
-    setReaderAndWriterIndex();
     result.add(validityBuffer);
     result.add(valueBuffer);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -337,7 +337,6 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     fillHoles(valueCount);
 
     List<ArrowBuf> result = new ArrayList<>(3);
-    setReaderAndWriterIndex();
     result.add(validityBuffer);
     result.add(offsetBuffer);
     result.add(valueBuffer);
@@ -638,15 +637,12 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   @Override
   public ArrowBuf[] getBuffers(boolean clear) {
     final ArrowBuf[] buffers;
+    fillHoles(valueCount);
     setReaderAndWriterIndex();
-    if (getBufferSize() == 0) {
-      buffers = new ArrowBuf[0];
-    } else {
-      buffers = new ArrowBuf[3];
-      buffers[0] = validityBuffer;
-      buffers[1] = offsetBuffer;
-      buffers[2] = valueBuffer;
-    }
+    buffers = new ArrowBuf[3];
+    buffers[0] = validityBuffer;
+    buffers[1] = offsetBuffer;
+    buffers[2] = valueBuffer;
     if (clear) {
       for (final ArrowBuf buffer : buffers) {
         buffer.getReferenceManager().retain();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -253,14 +253,10 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
   @Override
   public ArrowBuf[] getBuffers(boolean clear) {
     final ArrowBuf[] buffers;
-    if (getBufferSize() == 0) {
-      buffers = new ArrowBuf[0];
-    } else {
-      List<ArrowBuf> list = new ArrayList<>();
-      list.add(offsetBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(false)));
-      buffers = list.toArray(new ArrowBuf[list.size()]);
-    }
+    List<ArrowBuf> list = new ArrayList<>();
+    list.add(offsetBuffer);
+    list.addAll(Arrays.asList(vector.getBuffers(false)));
+    buffers = list.toArray(new ArrowBuf[list.size()]);
     if (clear) {
       for (ArrowBuf buffer : buffers) {
         buffer.getReferenceManager().retain();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -173,7 +173,6 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
   @Override
   public List<ArrowBuf> getFieldBuffers() {
     List<ArrowBuf> result = new ArrayList<>(1);
-    setReaderAndWriterIndex();
     result.add(validityBuffer);
 
     return result;
@@ -348,14 +347,10 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
   public ArrowBuf[] getBuffers(boolean clear) {
     setReaderAndWriterIndex();
     final ArrowBuf[] buffers;
-    if (getBufferSize() == 0) {
-      buffers = new ArrowBuf[0];
-    } else {
-      List<ArrowBuf> list = new ArrayList<>();
-      list.add(validityBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(false)));
-      buffers = list.toArray(new ArrowBuf[list.size()]);
-    }
+    List<ArrowBuf> list = new ArrayList<>();
+    list.add(validityBuffer);
+    list.addAll(Arrays.asList(vector.getBuffers(false)));
+    buffers = list.toArray(new ArrowBuf[list.size()]);
     if (clear) {
       for (ArrowBuf buffer : buffers) {
         buffer.getReferenceManager().retain();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -225,7 +225,6 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   @Override
   public List<ArrowBuf> getFieldBuffers() {
     List<ArrowBuf> result = new ArrayList<>(2);
-    setReaderAndWriterIndex();
     result.add(validityBuffer);
     result.add(offsetBuffer);
 
@@ -662,15 +661,11 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   public ArrowBuf[] getBuffers(boolean clear) {
     setReaderAndWriterIndex();
     final ArrowBuf[] buffers;
-    if (getBufferSize() == 0) {
-      buffers = new ArrowBuf[0];
-    } else {
-      List<ArrowBuf> list = new ArrayList<>();
-      list.add(offsetBuffer);
-      list.add(validityBuffer);
-      list.addAll(Arrays.asList(vector.getBuffers(false)));
-      buffers = list.toArray(new ArrowBuf[list.size()]);
-    }
+    List<ArrowBuf> list = new ArrayList<>();
+    list.add(validityBuffer);
+    list.add(offsetBuffer);
+    list.addAll(Arrays.asList(vector.getBuffers(false)));
+    buffers = list.toArray(new ArrowBuf[list.size()]);
     if (clear) {
       for (ArrowBuf buffer : buffers) {
         buffer.getReferenceManager().retain();

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -118,7 +118,6 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   @Override
   public List<ArrowBuf> getFieldBuffers() {
     List<ArrowBuf> result = new ArrayList<>(1);
-    setReaderAndWriterIndex();
     result.add(validityBuffer);
 
     return result;
@@ -296,14 +295,10 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   public ArrowBuf[] getBuffers(boolean clear) {
     setReaderAndWriterIndex();
     final ArrowBuf[] buffers;
-    if (getBufferSize() == 0) {
-      buffers = new ArrowBuf[0];
-    } else {
-      List<ArrowBuf> list = new ArrayList<>();
-      list.add(validityBuffer);
-      list.addAll(Arrays.asList(super.getBuffers(false)));
-      buffers = list.toArray(new ArrowBuf[list.size()]);
-    }
+    List<ArrowBuf> list = new ArrayList<>();
+    list.add(validityBuffer);
+    list.addAll(Arrays.asList(super.getBuffers(false)));
+    buffers = list.toArray(new ArrowBuf[list.size()]);
     if (clear) {
       for (ArrowBuf buffer : buffers) {
         buffer.getReferenceManager().retain();

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2673,11 +2673,11 @@ public class TestValueVector {
 
       varCharVector.set(0, "abcd".getBytes());
 
-      List<ArrowBuf> bufs = varCharVector.getFieldBuffers();
-      assertEquals(3, bufs.size());
+      ArrowBuf[] bufs = varCharVector.getBuffers(false);
+      assertEquals(3, bufs.length);
 
-      ArrowBuf offsetBuf = bufs.get(1);
-      ArrowBuf dataBuf = bufs.get(2);
+      ArrowBuf offsetBuf = bufs[1];
+      ArrowBuf dataBuf = bufs[2];
 
       assertEquals(12, offsetBuf.writerIndex());
       assertEquals(4, offsetBuf.getInt(4));


### PR DESCRIPTION
Related to [ARROW-7539](https://issues.apache.org/jira/browse/ARROW-7539).

Per discussion https://github.com/apache/arrow/pull/6133#discussion_r364906302.

The fact that we have reader/writer settings in getFieldBuffers is wrong. To clarify, getFieldBuffers is distinct from getBuffers. The former should be for getting access to underlying data for higher-performance algorithms. The latter is for sending the data over the wire. Seems we've mixed up use of both.
Currently in VectorUnloader, we used getFieldBuffers to create ArrowRecordBatch that’s why we keep writer/reader indices in getFieldBuffers, we should use getBuffers instead.
