### PR TITLE
ARROW-7543 [R] Fixes R arrow::write_parquet() documentation code examples

### DIFF
--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -104,11 +104,11 @@ read_parquet <- function(file,
 #' @examples
 #' \donttest{
 #' tf1 <- tempfile(fileext = ".parquet")
-#' write_parquet(data.frame(x = 1:5), tf2)
+#' write_parquet(data.frame(x = 1:5), tf1)
 #'
 #' # using compression
 #' tf2 <- tempfile(fileext = ".gz.parquet")
-#' write_parquet(data.frame(x = 1:5), compression = "gzip", compression_level = 5)
+#' write_parquet(data.frame(x = 1:5), tf2, compression = "gzip", compression_level = 5)
 #'
 #' }
 #' @export

--- a/r/man/write_parquet.Rd
+++ b/r/man/write_parquet.Rd
@@ -96,11 +96,11 @@ Note that "uncompressed" columns may still have dictionary encoding.
 \examples{
 \donttest{
 tf1 <- tempfile(fileext = ".parquet")
-write_parquet(data.frame(x = 1:5), tf2)
+write_parquet(data.frame(x = 1:5), tf1)
 
 # using compression
 tf2 <- tempfile(fileext = ".gz.parquet")
-write_parquet(data.frame(x = 1:5), compression = "gzip", compression_level = 5)
+write_parquet(data.frame(x = 1:5), tf2, compression = "gzip", compression_level = 5)
 
 }
 }


### PR DESCRIPTION
Fixes broken code examples in the docs for the R `arrow::write_parquet()` method.