### PR TITLE
PARQUET-1766: [C++] Handle parquet::Statistics NaNs and -0.0f as per upstream parquet-mr

### DIFF
--- a/cpp/src/arrow/util/ubsan.h
+++ b/cpp/src/arrow/util/ubsan.h
@@ -21,6 +21,7 @@
 
 #include <cstring>
 #include <memory>
+#include <type_traits>
 
 #include "arrow/util/macros.h"
 
@@ -64,6 +65,16 @@ inline typename std::enable_if<std::is_trivial<T>::value, T>::type SafeLoad(
     const T* unaligned) {
   typename std::remove_const<T>::type ret;
   std::memcpy(&ret, unaligned, sizeof(T));
+  return ret;
+}
+
+template <typename U, typename T>
+inline typename std::enable_if<std::is_trivial<T>::value && std::is_trivial<U>::value &&
+                                   sizeof(T) == sizeof(U),
+                               U>::type
+SafeCopy(T value) {
+  typename std::remove_const<U>::type ret;
+  std::memcpy(&ret, &value, sizeof(T));
   return ret;
 }
 

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1659,6 +1659,10 @@ struct SerializeFunctor<ParquetType, ArrowType, arrow::enable_if_decimal<ArrowTy
     return Status::OK();
   }
 
+  // Parquet's Decimal are stored with FixedLength values where the length is
+  // proportional to the precision. Arrow's Decimal are always stored with 16
+  // bytes. Thus the internal FLBA pointer must be adjusted by the offset calculated
+  // here.
   int32_t Offset(const arrow::Decimal128Array& array) {
     auto decimal_type = checked_pointer_cast<::arrow::Decimal128Type>(array.type());
     return decimal_type->byte_width() - internal::DecimalSize(decimal_type->precision());

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -28,6 +28,7 @@
 #include "arrow/array.h"
 #include "arrow/buffer_builder.h"
 #include "arrow/compute/api.h"
+#include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_stream_utils.h"
@@ -1214,19 +1215,12 @@ struct SerializeFunctor {
 };
 
 template <typename ParquetType, typename ArrowType>
-inline Status SerializeData(const arrow::Array& array, ArrowWriteContext* ctx,
-                            typename ParquetType::c_type* out) {
-  using ArrayType = typename arrow::TypeTraits<ArrowType>::ArrayType;
-  SerializeFunctor<ParquetType, ArrowType> functor;
-  return functor.Serialize(checked_cast<const ArrayType&>(array), ctx, out);
-}
-
-template <typename ParquetType, typename ArrowType>
 Status WriteArrowSerialize(const arrow::Array& array, int64_t num_levels,
                            const int16_t* def_levels, const int16_t* rep_levels,
                            ArrowWriteContext* ctx,
                            TypedColumnWriter<ParquetType>* writer) {
   using ParquetCType = typename ParquetType::c_type;
+  using ArrayType = typename arrow::TypeTraits<ArrowType>::ArrayType;
 
   ParquetCType* buffer = nullptr;
   PARQUET_THROW_NOT_OK(ctx->GetScratchData<ParquetCType>(array.length(), &buffer));
@@ -1234,8 +1228,9 @@ Status WriteArrowSerialize(const arrow::Array& array, int64_t num_levels,
   bool no_nulls =
       writer->descr()->schema_node()->is_required() || (array.null_count() == 0);
 
-  Status s = SerializeData<ParquetType, ArrowType>(array, ctx, buffer);
-  RETURN_NOT_OK(s);
+  SerializeFunctor<ParquetType, ArrowType> functor;
+  RETURN_NOT_OK(functor.Serialize(checked_cast<const ArrayType&>(array), ctx, buffer));
+
   if (no_nulls) {
     PARQUET_CATCH_NOT_OK(writer->WriteBatch(num_levels, def_levels, rep_levels, buffer));
   } else {
@@ -1613,8 +1608,10 @@ Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(const int16_t* def_
 // Write Arrow to FIXED_LEN_BYTE_ARRAY
 
 template <typename ParquetType, typename ArrowType>
-struct SerializeFunctor<ParquetType, ArrowType,
-                        arrow::enable_if_fixed_size_binary<ArrowType>> {
+struct SerializeFunctor<
+    ParquetType, ArrowType,
+    arrow::enable_if_t<arrow::is_fixed_size_binary_type<ArrowType>::value &&
+                       !arrow::is_decimal_type<ArrowType>::value>> {
   Status Serialize(const arrow::FixedSizeBinaryArray& array, ArrowWriteContext*,
                    FLBA* out) {
     if (array.null_count() == 0) {
@@ -1634,55 +1631,57 @@ struct SerializeFunctor<ParquetType, ArrowType,
   }
 };
 
-template <>
-Status WriteArrowSerialize<FLBAType, arrow::Decimal128Type>(
-    const arrow::Array& array, int64_t num_levels, const int16_t* def_levels,
-    const int16_t* rep_levels, ArrowWriteContext* ctx,
-    TypedColumnWriter<FLBAType>* writer) {
-  const auto& data = static_cast<const arrow::Decimal128Array&>(array);
-  const int64_t length = data.length();
+// ----------------------------------------------------------------------
+// Write Arrow to Decimal128
 
-  FLBA* buffer;
-  RETURN_NOT_OK(ctx->GetScratchData<FLBA>(num_levels, &buffer));
+using arrow::internal::checked_pointer_cast;
 
-  const auto& decimal_type = static_cast<const arrow::Decimal128Type&>(*data.type());
-  const int32_t offset =
-      decimal_type.byte_width() - internal::DecimalSize(decimal_type.precision());
+// Requires a custom serializer because decimal128 in parquet are in big-endian
+// format. Thus, a temporary local buffer is required.
+template <typename ParquetType, typename ArrowType>
+struct SerializeFunctor<ParquetType, ArrowType, arrow::enable_if_decimal<ArrowType>> {
+  Status Serialize(const arrow::Decimal128Array& array, ArrowWriteContext* ctx,
+                   FLBA* out) {
+    AllocateScratch(array, ctx);
+    auto offset = Offset(array);
 
-  const bool does_not_have_nulls =
-      writer->descr()->schema_node()->is_required() || data.null_count() == 0;
-
-  const auto valid_value_count = static_cast<size_t>(length - data.null_count()) * 2;
-  std::vector<uint64_t> big_endian_values(valid_value_count);
-
-  // TODO(phillipc): Look into whether our compilers will perform loop unswitching so we
-  // don't have to keep writing two loops to handle the case where we know there are no
-  // nulls
-  if (does_not_have_nulls) {
-    // no nulls, just dump the data
-    // todo(advancedxy): use a writeBatch to avoid this step
-    for (int64_t i = 0, j = 0; i < length; ++i, j += 2) {
-      auto unsigned_64_bit = reinterpret_cast<const uint64_t*>(data.GetValue(i));
-      big_endian_values[j] = arrow::BitUtil::ToBigEndian(unsigned_64_bit[1]);
-      big_endian_values[j + 1] = arrow::BitUtil::ToBigEndian(unsigned_64_bit[0]);
-      buffer[i] = FixedLenByteArray(
-          reinterpret_cast<const uint8_t*>(&big_endian_values[j]) + offset);
-    }
-  } else {
-    for (int64_t i = 0, buffer_idx = 0, j = 0; i < length; ++i) {
-      if (data.IsValid(i)) {
-        auto unsigned_64_bit = reinterpret_cast<const uint64_t*>(data.GetValue(i));
-        big_endian_values[j] = arrow::BitUtil::ToBigEndian(unsigned_64_bit[1]);
-        big_endian_values[j + 1] = arrow::BitUtil::ToBigEndian(unsigned_64_bit[0]);
-        buffer[buffer_idx++] = FixedLenByteArray(
-            reinterpret_cast<const uint8_t*>(&big_endian_values[j]) + offset);
-        j += 2;
+    if (array.null_count() == 0) {
+      for (int64_t i = 0; i < array.length(); i++) {
+        out[i] = FixDecimalEndianess(array.GetValue(i), offset);
+      }
+    } else {
+      for (int64_t i = 0; i < array.length(); i++) {
+        out[i] = array.IsValid(i) ? FixDecimalEndianess(array.GetValue(i), offset)
+                                  : FixedLenByteArray();
       }
     }
+
+    return Status::OK();
   }
-  PARQUET_CATCH_NOT_OK(writer->WriteBatch(num_levels, def_levels, rep_levels, buffer));
-  return Status::OK();
-}
+
+  int32_t Offset(const arrow::Decimal128Array& array) {
+    auto decimal_type = checked_pointer_cast<::arrow::Decimal128Type>(array.type());
+    return decimal_type->byte_width() - internal::DecimalSize(decimal_type->precision());
+  }
+
+  void AllocateScratch(const arrow::Decimal128Array& array, ArrowWriteContext* ctx) {
+    int64_t non_null_count = array.length() - array.null_count();
+    int64_t size = non_null_count * 16;
+    scratch_buffer = AllocateBuffer(ctx->memory_pool, size);
+    scratch = reinterpret_cast<int64_t*>(scratch_buffer->mutable_data());
+  }
+
+  FixedLenByteArray FixDecimalEndianess(const uint8_t* in, int64_t offset) {
+    const auto* u64_in = reinterpret_cast<const int64_t*>(in);
+    auto out = reinterpret_cast<const uint8_t*>(scratch) + offset;
+    *scratch++ = arrow::BitUtil::ToBigEndian(u64_in[1]);
+    *scratch++ = arrow::BitUtil::ToBigEndian(u64_in[0]);
+    return FixedLenByteArray(out);
+  }
+
+  std::shared_ptr<ResizableBuffer> scratch_buffer;
+  int64_t* scratch;
+};
 
 template <>
 Status TypedColumnWriterImpl<FLBAType>::WriteArrowDense(const int16_t* def_levels,

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -18,12 +18,15 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <type_traits>
+#include <utility>
 
 #include "arrow/array.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/optional.h"
 
 #include "parquet/encoding.h"
 #include "parquet/exception.h"
@@ -42,17 +45,31 @@ namespace parquet {
 
 template <typename DType, bool is_signed>
 struct CompareHelper {
-  typedef typename DType::c_type T;
+  using T = typename DType::c_type;
+
+  constexpr static T DefaultMin() { return std::numeric_limits<T>::max(); }
+  constexpr static T DefaultMax() { return std::numeric_limits<T>::lowest(); }
+  static T Coalesce(T val, T fallback) { return std::isnan(val) ? fallback : val; }
+
   static inline bool Compare(int type_length, const T& a, const T& b) { return a < b; }
+
+  static T Min(int type_length, T a, T b) { return a < b ? a : b; }
+  static T Max(int type_length, T a, T b) { return a < b ? b : a; }
 };
 
 template <>
 struct CompareHelper<Int96Type, true> {
-  static inline bool Compare(int type_length, const Int96& a, const Int96& b) {
+  using T = typename Int96Type::c_type;
+
+  constexpr static T DefaultMin() { return {}; }
+  constexpr static T DefaultMax() { return {}; }
+  static T Coalesce(T val, T fallback) { return val; }
+
+  static inline bool Compare(int type_length, const T& a, const T& b) {
     // Only the MSB bit is by Signed comparison
     // For little-endian, this is the last bit of Int96 type
-    const int32_t amsb = static_cast<const int32_t>(a.value[2]);
-    const int32_t bmsb = static_cast<const int32_t>(b.value[2]);
+    const auto amsb = static_cast<const int32_t>(a.value[2]);
+    const auto bmsb = static_cast<const int32_t>(b.value[2]);
     if (amsb != bmsb) {
       return (amsb < bmsb);
     } else if (a.value[1] != b.value[1]) {
@@ -60,47 +77,23 @@ struct CompareHelper<Int96Type, true> {
     }
     return (a.value[0] < b.value[0]);
   }
-};
 
-template <>
-struct CompareHelper<ByteArrayType, true> {
-  static inline bool Compare(int type_length, const ByteArray& a, const ByteArray& b) {
-    const int8_t* aptr = reinterpret_cast<const int8_t*>(a.ptr);
-    const int8_t* bptr = reinterpret_cast<const int8_t*>(b.ptr);
-    return std::lexicographical_compare(aptr, aptr + a.len, bptr, bptr + b.len);
+  static T Min(int type_length, const T& a, const T& b) {
+    return Compare(0, a, b) ? a : b;
   }
-};
-
-template <>
-struct CompareHelper<FLBAType, true> {
-  static inline bool Compare(int type_length, const FLBA& a, const FLBA& b) {
-    const int8_t* aptr = reinterpret_cast<const int8_t*>(a.ptr);
-    const int8_t* bptr = reinterpret_cast<const int8_t*>(b.ptr);
-    return std::lexicographical_compare(aptr, aptr + type_length, bptr,
-                                        bptr + type_length);
-  }
-};
-
-template <>
-struct CompareHelper<Int32Type, false> {
-  static inline bool Compare(int type_length, int32_t a, int32_t b) {
-    const uint32_t ua = a;
-    const uint32_t ub = b;
-    return ua < ub;
-  }
-};
-
-template <>
-struct CompareHelper<Int64Type, false> {
-  static inline bool Compare(int type_length, int64_t a, int64_t b) {
-    const uint64_t ua = a;
-    const uint64_t ub = b;
-    return ua < ub;
+  static T Max(int type_length, const T& a, const T& b) {
+    return Compare(0, a, b) ? b : a;
   }
 };
 
 template <>
 struct CompareHelper<Int96Type, false> {
+  using T = typename Int96Type::c_type;
+
+  constexpr static T DefaultMin() { return {}; }
+  constexpr static T DefaultMax() { return {}; }
+  static T Coalesce(T val, T fallback) { return val; }
+
   static inline bool Compare(int type_length, const Int96& a, const Int96& b) {
     if (a.value[2] != b.value[2]) {
       return (a.value[2] < b.value[2]);
@@ -109,172 +102,275 @@ struct CompareHelper<Int96Type, false> {
     }
     return (a.value[0] < b.value[0]);
   }
-};
 
-template <>
-struct CompareHelper<ByteArrayType, false> {
-  static inline bool Compare(int type_length, const ByteArray& a, const ByteArray& b) {
-    const uint8_t* aptr = reinterpret_cast<const uint8_t*>(a.ptr);
-    const uint8_t* bptr = reinterpret_cast<const uint8_t*>(b.ptr);
-    return std::lexicographical_compare(aptr, aptr + a.len, bptr, bptr + b.len);
+  static T Min(int type_length, const T& a, const T& b) {
+    return Compare(0, a, b) ? a : b;
+  }
+  static T Max(int type_length, const T& a, const T& b) {
+    return Compare(0, a, b) ? b : a;
   }
 };
 
-template <>
-struct CompareHelper<FLBAType, false> {
-  static inline bool Compare(int type_length, const FLBA& a, const FLBA& b) {
-    const uint8_t* aptr = reinterpret_cast<const uint8_t*>(a.ptr);
-    const uint8_t* bptr = reinterpret_cast<const uint8_t*>(b.ptr);
+template <bool is_signed>
+struct CompareHelper<ByteArrayType, is_signed> {
+  using T = ByteArrayType::c_type;
+  using PtrType = typename std::conditional<is_signed, int8_t, uint8_t>::type;
+
+  static T DefaultMin() { return {}; }
+  static T DefaultMax() { return {}; }
+  static T Coalesce(T val, T fallback) { return val; }
+
+  static inline bool Compare(int type_length, const T& a, const T& b) {
+    const auto* aptr = reinterpret_cast<const PtrType*>(a.ptr);
+    const auto* bptr = reinterpret_cast<const PtrType*>(b.ptr);
+    return std::lexicographical_compare(aptr, aptr + a.len, bptr, bptr + b.len);
+  }
+
+  static T Min(int type_length, const T& a, const T& b) {
+    if (a.ptr == nullptr) return b;
+    if (b.ptr == nullptr) return a;
+    return Compare(type_length, a, b) ? a : b;
+  }
+
+  static T Max(int type_length, const T& a, const T& b) {
+    if (a.ptr == nullptr) return b;
+    if (b.ptr == nullptr) return a;
+    return Compare(type_length, a, b) ? b : a;
+  }
+};
+
+template <bool is_signed>
+struct CompareHelper<FLBAType, is_signed> {
+  using T = FLBA;
+  using PtrType = typename std::conditional<is_signed, int8_t, uint8_t>::type;
+
+  static T DefaultMin() { return {}; }
+  static T DefaultMax() { return {}; }
+  static T Coalesce(T val, T fallback) { return val; }
+
+  static inline bool Compare(int type_length, const T& a, const T& b) {
+    const auto* aptr = reinterpret_cast<const PtrType*>(a.ptr);
+    const auto* bptr = reinterpret_cast<const PtrType*>(b.ptr);
     return std::lexicographical_compare(aptr, aptr + type_length, bptr,
                                         bptr + type_length);
   }
+
+  static T Min(int type_length, const T& a, const T& b) {
+    if (a.ptr == nullptr) return b;
+    if (b.ptr == nullptr) return a;
+    return Compare(type_length, a, b) ? a : b;
+  }
+
+  static T Max(int type_length, const T& a, const T& b) {
+    if (a.ptr == nullptr) return b;
+    if (b.ptr == nullptr) return a;
+    return Compare(type_length, a, b) ? b : a;
+  }
 };
 
+template <>
+struct CompareHelper<Int32Type, false> {
+  using T = int32_t;
+  using UCType = typename std::make_unsigned<T>::type;
+
+  constexpr static T DefaultMin() { return std::numeric_limits<UCType>::max(); }
+  constexpr static T DefaultMax() { return std::numeric_limits<UCType>::lowest(); }
+  static T Coalesce(T val, T fallback) { return val; }
+
+  static inline bool Compare(int type_length, T a, T b) {
+    UCType ua = a;
+    UCType ub = b;
+    return ua < ub;
+  }
+
+  static T Min(int type_length, T a, T b) { return Compare(type_length, a, b) ? a : b; }
+  static T Max(int type_length, T a, T b) { return Compare(type_length, a, b) ? b : a; }
+};
+
+template <>
+struct CompareHelper<Int64Type, false> {
+  using T = int64_t;
+  using UCType = typename std::make_unsigned<T>::type;
+
+  constexpr static T DefaultMin() { return std::numeric_limits<UCType>::max(); }
+  constexpr static T DefaultMax() { return std::numeric_limits<UCType>::lowest(); }
+  static T Coalesce(T val, T fallback) { return val; }
+
+  static inline bool Compare(int type_length, T a, T b) {
+    UCType ua = a;
+    UCType ub = b;
+    return ua < ub;
+  }
+
+  static T Min(int type_length, T a, T b) { return Compare(type_length, a, b) ? a : b; }
+  static T Max(int type_length, T a, T b) { return Compare(type_length, a, b) ? b : a; }
+};
+
+using ::arrow::util::optional;
+
 template <typename T>
-T CleanStatistic(T val) {
-  return val;
+::arrow::enable_if_t<std::is_integral<T>::value, optional<std::pair<T, T>>>
+CleanStatistic(std::pair<T, T> min_max) {
+  return min_max;
 }
 
-template <>
-float CleanStatistic(float val) {
-  // ARROW-5562: Return positive 0 for -0 and any value within float epsilon of
-  // 0
-  return fabs(val) < 1E-7 ? 0.0f : val;
+// In case of floating point types, the following rules are applied (as per
+// upstream parquet-mr):
+// - If any of min/max is NaN, return nothing.
+// - If min is 0.0f, replace with -0.0f
+// - If max is -0.0f, replace with 0.0f
+template <typename T>
+::arrow::enable_if_t<std::is_floating_point<T>::value, optional<std::pair<T, T>>>
+CleanStatistic(std::pair<T, T> min_max) {
+  T min = min_max.first;
+  T max = min_max.second;
+
+  // Ignore if one of the value is nan.
+  if (std::isnan(min) || std::isnan(max)) {
+    return nonstd::nullopt;
+  }
+
+  if (min == std::numeric_limits<T>::max() && max == std::numeric_limits<T>::lowest()) {
+    return nonstd::nullopt;
+  }
+
+  T zero{};
+
+  if (min == zero && !std::signbit(min)) {
+    min = -min;
+  }
+
+  if (max == zero && std::signbit(max)) {
+    max = -max;
+  }
+
+  return {{min, max}};
 }
 
-template <>
-double CleanStatistic(double val) {
-  // ARROW-5562: Return positive 0 for -0 and any value within double epsilon
-  // of 0
-  return fabs(val) < 1E-13 ? 0.0 : val;
+optional<std::pair<FLBA, FLBA>> CleanStatistic(std::pair<FLBA, FLBA> min_max) {
+  if (min_max.first.ptr == nullptr || min_max.second.ptr == nullptr) {
+    return nonstd::nullopt;
+  }
+  return min_max;
+}
+
+optional<std::pair<ByteArray, ByteArray>> CleanStatistic(
+    std::pair<ByteArray, ByteArray> min_max) {
+  if (min_max.first.ptr == nullptr || min_max.second.ptr == nullptr) {
+    return nonstd::nullopt;
+  }
+  return min_max;
 }
 
 template <bool is_signed, typename DType>
 class TypedComparatorImpl : virtual public TypedComparator<DType> {
  public:
-  typedef typename DType::c_type T;
+  using T = typename DType::c_type;
+  using Helper = CompareHelper<DType, is_signed>;
 
   explicit TypedComparatorImpl(int type_length = -1) : type_length_(type_length) {}
 
   bool CompareInline(const T& a, const T& b) const {
-    return CompareHelper<DType, is_signed>::Compare(type_length_, a, b);
+    return Helper::Compare(type_length_, a, b);
   }
 
   bool Compare(const T& a, const T& b) override { return CompareInline(a, b); }
 
-  void GetMinMax(const T* values, int64_t length, T* out_min, T* out_max) override {
-    T min = values[0];
-    T max = values[0];
-    for (int64_t i = 1; i < length; i++) {
-      if (CompareInline(values[i], min)) {
-        min = values[i];
-      } else if (CompareInline(max, values[i])) {
-        max = values[i];
-      }
+  std::pair<T, T> GetMinMax(const T* values, int64_t length) override {
+    DCHECK_GT(length, 0);
+
+    T min = Helper::DefaultMin();
+    T max = Helper::DefaultMax();
+
+    for (int64_t i = 0; i < length; i++) {
+      auto val = values[i];
+      min = Helper::Min(type_length_, min, Helper::Coalesce(val, Helper::DefaultMin()));
+      max = Helper::Max(type_length_, max, Helper::Coalesce(val, Helper::DefaultMax()));
     }
-    *out_min = CleanStatistic<T>(min);
-    *out_max = CleanStatistic<T>(max);
+
+    return {min, max};
   }
 
-  void GetMinMaxSpaced(const T* values, int64_t length, const uint8_t* valid_bits,
-                       int64_t valid_bits_offset, T* out_min, T* out_max) override {
-    ::arrow::internal::BitmapReader valid_bits_reader(valid_bits, valid_bits_offset,
-                                                      length);
+  std::pair<T, T> GetMinMaxSpaced(const T* values, int64_t length,
+                                  const uint8_t* valid_bits,
+                                  int64_t valid_bits_offset) override {
+    DCHECK_GT(length, 0);
 
-    // Find the first non-null value
-    int64_t first_non_null = 0;
-    while (!valid_bits_reader.IsSet()) {
-      ++first_non_null;
-      valid_bits_reader.Next();
-    }
+    T min = Helper::DefaultMin();
+    T max = Helper::DefaultMax();
 
-    T min = values[first_non_null];
-    T max = values[first_non_null];
-    valid_bits_reader.Next();
-    for (int64_t i = first_non_null + 1; i < length; i++) {
-      if (valid_bits_reader.IsSet()) {
-        if (CompareInline(values[i], min)) {
-          min = values[i];
-        } else if (CompareInline(max, values[i])) {
-          max = values[i];
-        }
+    ::arrow::internal::BitmapReader reader(valid_bits, valid_bits_offset, length);
+    for (int64_t i = 0; i < length; i++, reader.Next()) {
+      if (reader.IsSet()) {
+        auto val = values[i];
+        min = Helper::Min(type_length_, min, Helper::Coalesce(val, Helper::DefaultMin()));
+        max = Helper::Max(type_length_, max, Helper::Coalesce(val, Helper::DefaultMax()));
       }
-      valid_bits_reader.Next();
     }
-    *out_min = CleanStatistic<T>(min);
-    *out_max = CleanStatistic<T>(max);
+
+    return {min, max};
   }
 
-  void GetMinMax(const ::arrow::Array& values, T* out_min, T* out_max) override;
+  std::pair<T, T> GetMinMax(const ::arrow::Array& values) override;
 
  private:
   int type_length_;
 };
 
 template <bool is_signed, typename DType>
-void TypedComparatorImpl<is_signed, DType>::GetMinMax(const ::arrow::Array& values,
-                                                      typename DType::c_type* out_min,
-                                                      typename DType::c_type* out_max) {
+std::pair<typename DType::c_type, typename DType::c_type>
+TypedComparatorImpl<is_signed, DType>::GetMinMax(const ::arrow::Array& values) {
   ParquetException::NYI(values.type()->ToString());
 }
 
 template <bool is_signed>
-void GetMinMaxBinaryHelper(
+std::pair<ByteArray, ByteArray> GetMinMaxBinaryHelper(
     const TypedComparatorImpl<is_signed, ByteArrayType>& comparator,
-    const ::arrow::Array& values, ByteArray* out_min, ByteArray* out_max) {
+    const ::arrow::Array& values) {
   const auto& data = checked_cast<const ::arrow::BinaryArray&>(values);
 
   ByteArray min, max;
   if (data.null_count() > 0) {
-    ::arrow::internal::BitmapReader valid_bits_reader(data.null_bitmap_data(),
-                                                      data.offset(), data.length());
-
-    int64_t first_non_null = 0;
-    while (!valid_bits_reader.IsSet()) {
-      ++first_non_null;
-      valid_bits_reader.Next();
+    ::arrow::internal::BitmapReader reader(data.null_bitmap_data(), data.offset(),
+                                           data.length());
+    int64_t i = 0;
+    while (!reader.IsSet()) {
+      ++i;
+      reader.Next();
     }
-    min = data.GetView(first_non_null);
-    max = data.GetView(first_non_null);
-    for (int64_t i = first_non_null; i < data.length(); i++) {
+
+    min = data.GetView(i);
+    max = data.GetView(i);
+    for (; i < data.length(); i++, reader.Next()) {
       ByteArray val = data.GetView(i);
-      if (valid_bits_reader.IsSet()) {
-        if (comparator.CompareInline(val, min)) {
-          min = val;
-        } else if (comparator.CompareInline(max, val)) {
-          max = val;
-        }
+      if (reader.IsSet()) {
+        min = comparator.CompareInline(val, min) ? val : min;
+        max = comparator.CompareInline(max, val) ? val : max;
       }
-      valid_bits_reader.Next();
     }
   } else {
     min = data.GetView(0);
     max = data.GetView(0);
     for (int64_t i = 0; i < data.length(); i++) {
       ByteArray val = data.GetView(i);
-      if (comparator.CompareInline(val, min)) {
-        min = val;
-      } else if (comparator.CompareInline(max, val)) {
-        max = val;
-      }
+      min = comparator.CompareInline(val, min) ? val : min;
+      max = comparator.CompareInline(max, val) ? val : max;
     }
   }
-  *out_min = min;
-  *out_max = max;
+
+  return {min, max};
 }
 
 template <>
-void TypedComparatorImpl<true, ByteArrayType>::GetMinMax(const ::arrow::Array& values,
-                                                         ByteArray* out_min,
-                                                         ByteArray* out_max) {
-  GetMinMaxBinaryHelper<true>(*this, values, out_min, out_max);
+std::pair<ByteArray, ByteArray> TypedComparatorImpl<true, ByteArrayType>::GetMinMax(
+    const ::arrow::Array& values) {
+  return GetMinMaxBinaryHelper<true>(*this, values);
 }
 
 template <>
-void TypedComparatorImpl<false, ByteArrayType>::GetMinMax(const ::arrow::Array& values,
-                                                          ByteArray* out_min,
-                                                          ByteArray* out_max) {
-  GetMinMaxBinaryHelper<false>(*this, values, out_min, out_max);
+std::pair<ByteArray, ByteArray> TypedComparatorImpl<false, ByteArrayType>::GetMinMax(
+    const ::arrow::Array& values) {
+  return GetMinMaxBinaryHelper<false>(*this, values);
 }
 
 std::shared_ptr<Comparator> Comparator::Make(Type::type physical_type,
@@ -324,61 +420,6 @@ std::shared_ptr<Comparator> Comparator::Make(Type::type physical_type,
 
 std::shared_ptr<Comparator> Comparator::Make(const ColumnDescriptor* descr) {
   return Make(descr->physical_type(), descr->sort_order(), descr->type_length());
-}
-
-// ----------------------------------------------------------------------
-
-template <typename T, typename Enable = void>
-struct StatsHelper {
-  bool CanHaveNaN() { return false; }
-
-  inline int64_t GetValueBeginOffset(const T* values, int64_t count) { return 0; }
-
-  inline int64_t GetValueEndOffset(const T* values, int64_t count) { return count; }
-
-  inline bool IsNaN(const T value) { return false; }
-};
-
-template <typename T>
-struct StatsHelper<T, ::arrow::enable_if_t<std::is_floating_point<T>::value>> {
-  bool CanHaveNaN() { return true; }
-
-  inline int64_t GetValueBeginOffset(const T* values, int64_t count) {
-    // Skip NaNs
-    for (int64_t i = 0; i < count; i++) {
-      if (!std::isnan(values[i])) {
-        return i;
-      }
-    }
-    return count;
-  }
-
-  inline int64_t GetValueEndOffset(const T* values, int64_t count) {
-    // Skip NaNs
-    for (int64_t i = (count - 1); i >= 0; i--) {
-      if (!std::isnan(values[i])) {
-        return (i + 1);
-      }
-    }
-    return 0;
-  }
-
-  inline bool IsNaN(const T value) { return std::isnan(value); }
-};
-
-template <typename T>
-void SetNaN(T* value) {
-  // no-op
-}
-
-template <>
-void SetNaN<float>(float* value) {
-  *value = std::nanf("");
-}
-
-template <>
-void SetNaN<double>(double* value) {
-  *value = std::nan("");
 }
 
 template <typename DType>
@@ -436,15 +477,24 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   }
 
   void SetMinMax(const T& arg_min, const T& arg_max) override {
+    SetMinMax({arg_min, arg_max});
+  }
+
+  void SetMinMax(std::pair<T, T> min_max) {
+    // CleanStatistic can return a nullopt in case of erronous values, e.g. NaN
+    auto maybe_min_max = CleanStatistic(min_max);
+    if (!maybe_min_max) return;
+
+    auto min = maybe_min_max.value().first;
+    auto max = maybe_min_max.value().second;
+
     if (!has_min_max_) {
       has_min_max_ = true;
-      Copy(arg_min, &min_, min_buffer_.get());
-      Copy(arg_max, &max_, max_buffer_.get());
+      Copy(min, &min_, min_buffer_.get());
+      Copy(max, &max_, max_buffer_.get());
     } else {
-      Copy(comparator_->Compare(min_, arg_min) ? min_ : arg_min, &min_,
-           min_buffer_.get());
-      Copy(comparator_->Compare(max_, arg_max) ? arg_max : max_, &max_,
-           max_buffer_.get());
+      Copy(comparator_->Compare(min_, min) ? min_ : min, &min_, min_buffer_.get());
+      Copy(comparator_->Compare(max_, max) ? max : max_, &max_, max_buffer_.get());
     }
   }
 
@@ -462,19 +512,11 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
     IncrementNullCount(values.null_count());
     IncrementNumValues(values.length() - values.null_count());
 
-    // TODO: support distinct count?
     if (values.null_count() == values.length()) {
       return;
     }
 
-    StatsHelper<T> helper;
-    if (helper.CanHaveNaN()) {
-      ParquetException::NYI("No NaN handling for Arrow arrays yet");
-    }
-
-    T batch_min, batch_max;
-    comparator_->GetMinMax(values, &batch_min, &batch_max);
-    SetMinMax(batch_min, batch_max);
+    SetMinMax(comparator_->GetMinMax(values));
   }
 
   const T& min() const override { return min_; }
@@ -573,32 +615,11 @@ void TypedStatisticsImpl<DType>::Update(const T* values, int64_t num_not_null,
 
   IncrementNullCount(num_null);
   IncrementNumValues(num_not_null);
-  // TODO: support distinct count?
+
   if (num_not_null == 0) return;
 
-  // PARQUET-1225: Handle NaNs
-  // The problem arises only if the starting/ending value(s)
-  // of the values-buffer contain NaN
-  StatsHelper<T> helper;
-  int64_t begin_offset = helper.GetValueBeginOffset(values, num_not_null);
-  int64_t end_offset = helper.GetValueEndOffset(values, num_not_null);
-
-  // All values are NaN
-  if (helper.CanHaveNaN() && end_offset < begin_offset) {
-    // Set min/max to NaNs in this case.
-    // Don't set has_min_max flag since
-    // these values must be over-written by valid stats later
-    if (!has_min_max_) {
-      SetNaN(&min_);
-      SetNaN(&max_);
-    }
-    return;
-  }
-
-  T batch_min, batch_max;
-  comparator_->GetMinMax(values + begin_offset, end_offset - begin_offset, &batch_min,
-                         &batch_max);
-  SetMinMax(batch_min, batch_max);
+  int64_t length = num_null + num_not_null;
+  SetMinMax(comparator_->GetMinMax(values, length));
 }
 
 template <typename DType>
@@ -610,42 +631,11 @@ void TypedStatisticsImpl<DType>::UpdateSpaced(const T* values, const uint8_t* va
 
   IncrementNullCount(num_null);
   IncrementNumValues(num_not_null);
-  // TODO: support distinct count?
+
   if (num_not_null == 0) return;
 
-  // Find first valid entry and use that for min/max
-  // As (num_not_null != 0) there must be one
   int64_t length = num_null + num_not_null;
-  int64_t i = 0;
-  StatsHelper<T> helper;
-  if (helper.CanHaveNaN()) {
-    ::arrow::internal::BitmapReader valid_bits_reader(valid_bits, valid_bits_offset,
-                                                      length);
-    for (; i < length; i++) {
-      // PARQUET-1225: Handle NaNs
-      if (valid_bits_reader.IsSet() && !helper.IsNaN(values[i])) {
-        break;
-      }
-      valid_bits_reader.Next();
-    }
-
-    // All are NaNs and stats are not set yet
-    if ((i == length) && helper.IsNaN(values[i - 1])) {
-      // Don't set has_min_max flag since
-      // these values must be over-written by valid stats later
-      if (!has_min_max_) {
-        SetNaN(&min_);
-        SetNaN(&max_);
-      }
-      return;
-    }
-  }
-
-  // Find min and max values from remaining non-NaN values
-  T batch_min, batch_max;
-  comparator_->GetMinMaxSpaced(values + i, length - i, valid_bits, valid_bits_offset + i,
-                               &batch_min, &batch_max);
-  SetMinMax(batch_min, batch_max);
+  SetMinMax(comparator_->GetMinMaxSpaced(values, length, valid_bits, valid_bits_offset));
 }
 
 template <typename DType>

--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <utility>
 
 #include "parquet/platform.h"
 #include "parquet/types.h"
@@ -76,12 +77,12 @@ class TypedComparator : public Comparator {
 
   /// \brief Compute maximum and minimum elements in a batch of
   /// elements without any nulls
-  virtual void GetMinMax(const T* values, int64_t length, T* out_min, T* out_max) = 0;
+  virtual std::pair<T, T> GetMinMax(const T* values, int64_t length) = 0;
 
   /// \brief Compute minimum and maximum elements from an Arrow array. Only
   /// valid for certain Parquet Type / Arrow Type combinations, like BYTE_ARRAY
   /// / arrow::BinaryArray
-  virtual void GetMinMax(const ::arrow::Array& values, T* out_min, T* out_max) = 0;
+  virtual std::pair<T, T> GetMinMax(const ::arrow::Array& values) = 0;
 
   /// \brief Compute maximum and minimum elements in a batch of
   /// elements with accompanying bitmap indicating which elements are
@@ -93,10 +94,9 @@ class TypedComparator : public Comparator {
   /// included (1) or excluded (0)
   /// \param[in] valid_bits_offset the bit offset into the bitmap of
   /// the first element in the sequence
-  /// \param[out] out_min the returned minimum element
-  /// \param[out] out_max the returned maximum element
-  virtual void GetMinMaxSpaced(const T* values, int64_t length, const uint8_t* valid_bits,
-                               int64_t valid_bits_offset, T* out_min, T* out_max) = 0;
+  virtual std::pair<T, T> GetMinMaxSpaced(const T* values, int64_t length,
+                                          const uint8_t* valid_bits,
+                                          int64_t valid_bits_offset) = 0;
 };
 
 /// \brief Typed version of Comparator::Make

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -22,6 +22,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -874,159 +875,178 @@ TEST_F(TestStatisticsSortOrderFLBA, UnknownSortOrder) {
   ASSERT_FALSE(cc_metadata->is_stats_set());
 }
 
-// PARQUET-1225: Float NaN values may lead to incorrect filtering under certain
-// circumstances
-TEST(TestStatisticsSortOrderFloatNaN, NaNValues) {
-  constexpr int NUM_VALUES = 10;
-  NodePtr node = PrimitiveNode::Make("nan_float", Repetition::OPTIONAL, Type::FLOAT);
+template <typename Stats, typename Array, typename T = typename Array::value_type>
+void AssertMinMaxAre(Stats stats, const Array& values, T expected_min, T expected_max) {
+  stats->Update(values.data(), values.size(), 0);
+  ASSERT_TRUE(stats->HasMinMax());
+  ASSERT_EQ(stats->min(), expected_min);
+  ASSERT_EQ(stats->max(), expected_max);
+}
+
+template <typename Stats, typename Array, typename T = typename Array::value_type>
+void AssertMinMaxAre(Stats stats, const Array& values, const uint8_t* valid_bitmap,
+                     T expected_min, T expected_max) {
+  auto n_values = values.size();
+  auto null_count = ::arrow::internal::CountSetBits(valid_bitmap, n_values, 0);
+  auto non_null_count = n_values - null_count;
+  stats->UpdateSpaced(values.data(), valid_bitmap, 0, non_null_count, null_count);
+  ASSERT_TRUE(stats->HasMinMax());
+  ASSERT_EQ(stats->min(), expected_min);
+  ASSERT_EQ(stats->max(), expected_max);
+}
+
+template <typename Stats, typename Array>
+void AssertUnsetMinMax(Stats stats, const Array& values) {
+  stats->Update(values.data(), values.size(), 0);
+  ASSERT_FALSE(stats->HasMinMax());
+}
+
+template <typename Stats, typename Array>
+void AssertUnsetMinMax(Stats stats, const Array& values, const uint8_t* valid_bitmap) {
+  auto n_values = values.size();
+  auto null_count = ::arrow::internal::CountSetBits(valid_bitmap, n_values, 0);
+  auto non_null_count = n_values - null_count;
+  stats->UpdateSpaced(values.data(), valid_bitmap, 0, non_null_count, null_count);
+  ASSERT_FALSE(stats->HasMinMax());
+}
+
+template <typename ParquetType, typename T = typename ParquetType::c_type>
+void CheckExtremums() {
+  using UT = typename std::make_unsigned<T>::type;
+
+  T smin = std::numeric_limits<T>::min();
+  T smax = std::numeric_limits<T>::max();
+  T umin = std::numeric_limits<UT>::min();
+  T umax = std::numeric_limits<UT>::max();
+
+  constexpr int kNumValues = 8;
+  std::array<T, kNumValues> values{0,    smin,     smax,     umin,
+                                   umax, smin - 1, smax + 1, umin - 1};
+
+  NodePtr unsigned_node = PrimitiveNode::Make(
+      "uint", Repetition::OPTIONAL,
+      LogicalType::Int(sizeof(T) * CHAR_BIT, false /*signed*/), ParquetType::type_num);
+  ColumnDescriptor unsigned_descr(unsigned_node, 1, 1);
+  NodePtr signed_node = PrimitiveNode::Make(
+      "int", Repetition::OPTIONAL,
+      LogicalType::Int(sizeof(T) * CHAR_BIT, true /*signed*/), ParquetType::type_num);
+  ColumnDescriptor signed_descr(signed_node, 1, 1);
+
+  auto unsigned_stats = MakeStatistics<ParquetType>(&unsigned_descr);
+  AssertMinMaxAre(unsigned_stats, values, umin, umax);
+
+  auto signed_stats = MakeStatistics<ParquetType>(&signed_descr);
+  AssertMinMaxAre(signed_stats, values, smin, smax);
+}
+
+TEST(TestStatistic, Int32Extremums) { CheckExtremums<Int32Type>(); }
+TEST(TestStatistic, Int64Extremums) { CheckExtremums<Int64Type>(); }
+
+// PARQUET-1225: Float NaN values may lead to incorrect min-max
+template <typename ParquetType>
+void CheckNaNs() {
+  using T = typename ParquetType::c_type;
+
+  constexpr int kNumValues = 8;
+  NodePtr node = PrimitiveNode::Make("f", Repetition::OPTIONAL, ParquetType::type_num);
   ColumnDescriptor descr(node, 1, 1);
-  float values[NUM_VALUES] = {std::nanf(""), -4.0f, -3.0f, -2.0f, -1.0f,
-                              std::nanf(""), 1.0f,  2.0f,  3.0f,  std::nanf("")};
-  float nan_values[NUM_VALUES];
-  for (int i = 0; i < NUM_VALUES; i++) {
-    nan_values[i] = std::nanf("");
-  }
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T min = -4.0f;
+  constexpr T max = 3.0f;
+
+  std::array<T, kNumValues> all_nans{nan, nan, nan, nan, nan, nan, nan, nan};
+  std::array<T, kNumValues> some_nans{nan, max, -3.0f, -1.0f, nan, 2.0f, min, nan};
+  uint8_t valid_bitmap = 0x7F;  // 0b01111111
+  // NaNs excluded
+  uint8_t valid_bitmap_no_nans = 0x6E;  // 0b01101110
 
   // Test values
-  auto nan_stats = MakeStatistics<FloatType>(&descr);
-  nan_stats->Update(&values[0], NUM_VALUES, 0);
-  float min = nan_stats->min();
-  float max = nan_stats->max();
-  ASSERT_EQ(min, -4.0f);
-  ASSERT_EQ(max, 3.0f);
+  auto some_nan_stats = MakeStatistics<ParquetType>(&descr);
+  // Ingesting only nans should not yield valid min max
+  AssertUnsetMinMax(some_nan_stats, all_nans);
+  // Ingesting a mix of NaNs and non-NaNs should not yield valid min max.
+  AssertMinMaxAre(some_nan_stats, some_nans, min, max);
+  // Ingesting only nans after a valid min/max, should have not effect
+  AssertMinMaxAre(some_nan_stats, all_nans, min, max);
 
-  // Test all NaNs
-  auto all_nan_stats = MakeStatistics<FloatType>(&descr);
-  all_nan_stats->Update(&nan_values[0], NUM_VALUES, 0);
-  min = all_nan_stats->min();
-  max = all_nan_stats->max();
-  ASSERT_TRUE(std::isnan(min));
-  ASSERT_TRUE(std::isnan(max));
-
-  // Test values followed by all NaNs
-  nan_stats->Update(&nan_values[0], NUM_VALUES, 0);
-  min = nan_stats->min();
-  max = nan_stats->max();
-  ASSERT_EQ(min, -4.0f);
-  ASSERT_EQ(max, 3.0f);
-
-  // Test all NaNs followed by values
-  all_nan_stats->Update(&values[0], NUM_VALUES, 0);
-  min = all_nan_stats->min();
-  max = all_nan_stats->max();
-  ASSERT_EQ(min, -4.0f);
-  ASSERT_EQ(max, 3.0f);
-
-  // Test values followed by all NaNs followed by values
-  nan_stats->Update(&values[0], NUM_VALUES, 0);
-  min = nan_stats->min();
-  max = nan_stats->max();
-  ASSERT_EQ(min, -4.0f);
-  ASSERT_EQ(max, 3.0f);
+  some_nan_stats = MakeStatistics<ParquetType>(&descr);
+  AssertUnsetMinMax(some_nan_stats, all_nans, &valid_bitmap);
+  // NaNs should not pollute min max when excluded via null bitmap.
+  AssertMinMaxAre(some_nan_stats, some_nans, &valid_bitmap_no_nans, min, max);
+  // Ingesting NaNs with a null bitmap should not change the result.
+  AssertMinMaxAre(some_nan_stats, some_nans, &valid_bitmap, min, max);
 }
 
-// PARQUET-1225: Float NaN values may lead to incorrect filtering under certain
-// circumstances
-TEST(TestStatisticsSortOrderFloatNaN, NaNValuesSpaced) {
-  constexpr int NUM_VALUES = 10;
+TEST(TestStatistic, NaNFloatValues) { CheckNaNs<FloatType>(); }
+
+TEST(TestStatistic, NaNDoubleValues) { CheckNaNs<DoubleType>(); }
+
+// ARROW-7376
+TEST(TestStatisticsSortOrderFloatNaN, NaNAndNullsInfiniteLoop) {
+  constexpr int kNumValues = 8;
   NodePtr node = PrimitiveNode::Make("nan_float", Repetition::OPTIONAL, Type::FLOAT);
   ColumnDescriptor descr(node, 1, 1);
-  float values[NUM_VALUES] = {std::nanf(""), -4.0f, -3.0f, -2.0f, -1.0f,
-                              std::nanf(""), 1.0f,  2.0f,  3.0f,  std::nanf("")};
-  float nan_values[NUM_VALUES];
-  for (int i = 0; i < NUM_VALUES; i++) {
-    nan_values[i] = std::nanf("");
-  }
-  std::vector<uint8_t> valid_bits(BitUtil::BytesForBits(NUM_VALUES) + 1, 255);
 
-  // Test values
-  auto nan_stats = MakeStatistics<FloatType>(&descr);
-  nan_stats->UpdateSpaced(&values[0], valid_bits.data(), 0, NUM_VALUES, 0);
-  float min = nan_stats->min();
-  float max = nan_stats->max();
-  ASSERT_EQ(min, -4.0f);
-  ASSERT_EQ(max, 3.0f);
+  constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+  std::array<float, kNumValues> nans_but_last{nan, nan, nan, nan, nan, nan, nan, 0.0f};
 
-  // Test all NaNs
-  auto all_nan_stats = MakeStatistics<FloatType>(&descr);
-  all_nan_stats->UpdateSpaced(&nan_values[0], valid_bits.data(), 0, NUM_VALUES, 0);
-  min = all_nan_stats->min();
-  max = all_nan_stats->max();
-  ASSERT_TRUE(std::isnan(min));
-  ASSERT_TRUE(std::isnan(max));
-
-  // Test values followed by all NaNs
-  nan_stats->UpdateSpaced(&nan_values[0], valid_bits.data(), 0, NUM_VALUES, 0);
-  min = nan_stats->min();
-  max = nan_stats->max();
-  ASSERT_EQ(min, -4.0f);
-  ASSERT_EQ(max, 3.0f);
-
-  // Test all NaNs followed by values
-  all_nan_stats->UpdateSpaced(&values[0], valid_bits.data(), 0, NUM_VALUES, 0);
-  min = all_nan_stats->min();
-  max = all_nan_stats->max();
-  ASSERT_EQ(min, -4.0f);
-  ASSERT_EQ(max, 3.0f);
-
-  // Test values followed by all NaNs followed by values
-  nan_stats->UpdateSpaced(&values[0], valid_bits.data(), 0, NUM_VALUES, 0);
-  min = nan_stats->min();
-  max = nan_stats->max();
-  ASSERT_EQ(min, -4.0f);
-  ASSERT_EQ(max, 3.0f);
+  uint8_t all_but_last_valid = 0x7F;  // 0b01111111
+  auto stats = MakeStatistics<FloatType>(&descr);
+  AssertUnsetMinMax(stats, nans_but_last, &all_but_last_valid);
 }
 
-// NaN double values may lead to incorrect filtering under certain circumstances
-TEST(TestStatisticsSortOrderDoubleNaN, NaNValues) {
-  constexpr int NUM_VALUES = 10;
-  NodePtr node = PrimitiveNode::Make("nan_double", Repetition::OPTIONAL, Type::DOUBLE);
-  ColumnDescriptor descr(node, 1, 1);
+template <typename Stats, typename Array, typename T = typename Array::value_type>
+void AssertMinMaxZeroesSign(Stats stats, const Array& values) {
+  stats->Update(values.data(), values.size(), 0);
+  ASSERT_TRUE(stats->HasMinMax());
 
-  auto nan_stats = MakeStatistics<DoubleType>(&descr);
-  double values[NUM_VALUES] = {std::nan(""), std::nan(""), -3.0, -2.0, -1.0,
-                               0.0,          1.0,          2.0,  3.0,  4.0};
-  nan_stats->Update(values, NUM_VALUES, 0);
-  ASSERT_EQ(nan_stats->min(), -3.0);
-  ASSERT_EQ(nan_stats->max(), 4.0);
+  T zero{};
+  ASSERT_EQ(stats->min(), zero);
+  ASSERT_TRUE(std::signbit(stats->min()));
+
+  ASSERT_EQ(stats->max(), zero);
+  ASSERT_FALSE(std::signbit(stats->max()));
 }
 
+// ARROW-5562: Ensure that -0.0f and 0.0f values are properly handled like in
+// parquet-mr
 template <typename ParquetType>
 void CheckNegativeZeroStats() {
   using T = typename ParquetType::c_type;
 
-  constexpr int NUM_VALUES = 2;
   NodePtr node = PrimitiveNode::Make("f", Repetition::OPTIONAL, ParquetType::type_num);
   ColumnDescriptor descr(node, 1, 1);
-  T zero = 0;
+  T zero{};
 
-  // Test that the min and max are always unsigned
   {
-    T values[NUM_VALUES] = {-zero, zero};
+    std::array<T, 2> values{-zero, zero};
     auto stats = MakeStatistics<ParquetType>(&descr);
-    stats->Update(values, NUM_VALUES, 0);
-    // The min and max are unsigned
-    ASSERT_FALSE(std::signbit(stats->min()));
-    ASSERT_FALSE(std::signbit(stats->max()));
+    AssertMinMaxZeroesSign(stats, values);
   }
 
   {
-    T values[NUM_VALUES] = {zero, -zero};
+    std::array<T, 2> values{zero, -zero};
     auto stats = MakeStatistics<ParquetType>(&descr);
-    stats->Update(values, NUM_VALUES, 0);
-    ASSERT_FALSE(std::signbit(stats->min()));
-    ASSERT_FALSE(std::signbit(stats->max()));
+    AssertMinMaxZeroesSign(stats, values);
+  }
+
+  {
+    std::array<T, 2> values{-zero, -zero};
+    auto stats = MakeStatistics<ParquetType>(&descr);
+    AssertMinMaxZeroesSign(stats, values);
+  }
+
+  {
+    std::array<T, 2> values{zero, zero};
+    auto stats = MakeStatistics<ParquetType>(&descr);
+    AssertMinMaxZeroesSign(stats, values);
   }
 }
 
-TEST(TestStatistics, NegativeZero) {
-  // ARROW-5562
-  CheckNegativeZeroStats<FloatType>();
-  CheckNegativeZeroStats<DoubleType>();
+TEST(TestStatistics, FloatNegativeZero) { CheckNegativeZeroStats<FloatType>(); }
 
-  // Modern computers use two's complement encoding of integers which does not
-  // allow for negative zero
-}
+TEST(TestStatistics, DoubleNegativeZero) { CheckNegativeZeroStats<DoubleType>(); }
 
 // Test statistics for binary column with UNSIGNED sort order
 TEST(TestStatisticsSortOrderMinMax, Unsigned) {
@@ -1055,5 +1075,6 @@ TEST(TestStatisticsSortOrderMinMax, Unsigned) {
   ASSERT_EQ(0x00, stats->EncodeMin()[0]);
   ASSERT_EQ(0x0b, stats->EncodeMax()[0]);
 }
+
 }  // namespace test
 }  // namespace parquet


### PR DESCRIPTION
Fix an infinite loop when handling NaN values. Refactors the handling of NaNs and other special floating values and clean the unit tests to be readable.

The fix uncovered a bug in the Decimal128 arrow-to-parquet path where it would read un-intialized values, i.e. it would always invoke WriteBatch instead of WriteBatchSpaced irregardless of the null count. Thus, the update statistics method would read invalid data.