### PR TITLE
ARROW-7558: [Packaging][deb][RPM] Use the host owner and group for artifacts

### DIFF
--- a/c_glib/Makefile.am
+++ b/c_glib/Makefile.am
@@ -28,7 +28,6 @@ SUBDIRS =					\
 
 EXTRA_DIST =					\
 	Gemfile					\
-	LICENSE.txt				\
 	README.md				\
 	autogen.sh				\
 	meson.build				\
@@ -37,5 +36,5 @@ EXTRA_DIST =					\
 
 arrow_glib_docdir = ${datarootdir}/doc/arrow-glib
 arrow_glib_doc_DATA =				\
-	LICENSE.txt				\
+	../LICENSE.txt				\
 	README.md

--- a/c_glib/Makefile.am
+++ b/c_glib/Makefile.am
@@ -28,6 +28,7 @@ SUBDIRS =					\
 
 EXTRA_DIST =					\
 	Gemfile					\
+	LICENSE.txt				\
 	README.md				\
 	autogen.sh				\
 	meson.build				\

--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -144,7 +144,8 @@ if get_option('gtk_doc')
   endif
 endif
 
-install_data('README.md',
+install_data('../LICENSE.txt',
+             'README.md',
              install_dir: join_paths(data_dir, 'doc', meson.project_name()))
 
 run_test = find_program('test/run-test.sh')

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/apache-arrow-release.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/apache-arrow-release.spec.in
@@ -1,4 +1,4 @@
-# -*- rpm -*-
+# -*- sh-shell: rpm -*-
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -1,4 +1,4 @@
-# -*- rpm -*-
+# -*- sh-shell: rpm -*-
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -211,6 +211,7 @@ This package contains the libraries for Apache Arrow C++.
 %files libs
 %defattr(-,root,root,-)
 %doc README.md LICENSE.txt NOTICE.txt
+%{_docdir}/arrow/
 %{_libdir}/libarrow.so.*
 
 %package devel

--- a/dev/tasks/linux-packages/apt/build.sh
+++ b/dev/tasks/linux-packages/apt/build.sh
@@ -77,7 +77,10 @@ else
 fi
 run cd -
 
+repositories="/host/repositories"
 package_initial=$(echo "${PACKAGE}" | sed -e 's/\(.\).*/\1/')
-pool_dir="/host/repositories/${distribution}/pool/${code_name}/${component}/${package_initial}/${PACKAGE}"
+pool_dir="${repositories}/${distribution}/pool/${code_name}/${component}/${package_initial}/${PACKAGE}"
 run mkdir -p "${pool_dir}/"
 run cp *.tar.* *.dsc *.deb "${pool_dir}/"
+
+run chown -R "$(stat --format "%u:%g" "${repositories}")" "${repositories}"

--- a/dev/tasks/linux-packages/yum/build.sh
+++ b/dev/tasks/linux-packages/yum/build.sh
@@ -62,7 +62,8 @@ EOM
   run mkdir -p ~/rpmbuild/SRPMS
 fi
 
-repository="/host/repositories/${distribution}/${distribution_version}"
+repositories="/host/repositories"
+repository="${repositories}/${distribution}/${distribution_version}"
 rpm_dir="${repository}/${architecture}/Packages"
 srpm_dir="${repository}/source/SRPMS"
 run mkdir -p "${rpm_dir}" "${srpm_dir}"
@@ -129,3 +130,5 @@ fi
 
 run mv rpmbuild/RPMS/*/* "${rpm_dir}/"
 run mv rpmbuild/SRPMS/* "${srpm_dir}/"
+
+run chown -R "$(stat --format "%u:%g" "${repositories}")" "${repositories}"


### PR DESCRIPTION
If we don't this, artifacts are owned by root. Because we use root
user in Docker.