### PR TITLE
ARROW-7059: [C++][Parquet] Mostly fix performance regression when reading Parquet file with many columns

### DIFF
--- a/cpp/src/parquet/arrow/reader_internal.h
+++ b/cpp/src/parquet/arrow/reader_internal.h
@@ -119,8 +119,10 @@ struct ReaderContext {
   std::shared_ptr<std::unordered_set<int>> included_leaves;
 
   bool IncludesLeaf(int leaf_index) const {
-    const auto& to_search = *included_leaves;
-    return (!this->filter_leaves || (to_search.find(leaf_index) != to_search.end()));
+    if (this->filter_leaves) {
+      return this->included_leaves->find(leaf_index) != this->included_leaves->end();
+    }
+    return true;
   }
 };
 

--- a/cpp/src/parquet/arrow/reader_internal.h
+++ b/cpp/src/parquet/arrow/reader_internal.h
@@ -116,11 +116,11 @@ struct ReaderContext {
   ::arrow::MemoryPool* pool;
   FileColumnIteratorFactory iterator_factory;
   bool filter_leaves;
-  std::unordered_set<int> included_leaves;
+  std::shared_ptr<std::unordered_set<int>> included_leaves;
 
   bool IncludesLeaf(int leaf_index) const {
-    return (!this->filter_leaves ||
-            (included_leaves.find(leaf_index) != included_leaves.end()));
+    const auto& to_search = *included_leaves;
+    return (!this->filter_leaves || (to_search.find(leaf_index) != to_search.end()));
   }
 };
 


### PR DESCRIPTION
This fixes a quadratic growth issue where an unordered set containing a list of all the column indices is constructed for each column. This code still seems a bit messy but we have a benchmark already to keep an eye on this (if we would actually run and track the benchmarks though...) 

Without patch
Elapsed: 61.533573419999996 seconds

With patch
Elapsed: 2.484871 seconds

With 0.14.1
Elapsed: 1.6306039680000002 seconds