### PR TITLE
ARROW-7510: [C++] Make ArrayData::null_count thread-safe

### DIFF
--- a/cpp/src/arrow/compute/kernels/util_internal.h
+++ b/cpp/src/arrow/compute/kernels/util_internal.h
@@ -36,7 +36,7 @@ class FunctionContext;
 // the type.
 static inline void ZeroCopyData(const ArrayData& input, ArrayData* output) {
   output->length = input.length;
-  output->null_count = input.null_count;
+  output->SetNullCount(input.null_count);
   output->buffers = input.buffers;
   output->offset = input.offset;
   output->child_data = input.child_data;

--- a/cpp/src/arrow/compute/kernels/util_internal_test.cc
+++ b/cpp/src/arrow/compute/kernels/util_internal_test.cc
@@ -55,7 +55,7 @@ TEST(PropagateNulls, UnknownNullCountWithNullsZeroCopies) {
   ASSERT_OK(PropagateNulls(&ctx, input, &output));
 
   ASSERT_THAT(output.buffers, ElementsAre(Eq(nulls)));
-  ASSERT_THAT(output.null_count, 9);
+  ASSERT_EQ(output.null_count, 9);
 }
 
 TEST(PropagateNulls, UnknownNullCountWithoutNullsLeavesNullptr) {
@@ -68,7 +68,7 @@ TEST(PropagateNulls, UnknownNullCountWithoutNullsLeavesNullptr) {
 
   ASSERT_OK(PropagateNulls(&ctx, input, &output));
 
-  EXPECT_THAT(output.null_count, Eq(0));
+  EXPECT_EQ(output.null_count, 0);
   EXPECT_THAT(output.buffers, ElementsAre(IsNull())) << output.buffers[0]->data()[0];
 }
 
@@ -125,12 +125,12 @@ TEST(AssignNullIntersection, ZeroCopyWhenZeroNullsOnOneInput) {
 
   ASSERT_OK(AssignNullIntersection(&ctx, some_nulls, no_nulls, &output));
   ASSERT_THAT(output.buffers, ElementsAre(Eq(nulls)));
-  ASSERT_THAT(output.null_count, 9);
+  ASSERT_EQ(output.null_count, 9);
 
   output.buffers[0] = nullptr;
   ASSERT_OK(AssignNullIntersection(&ctx, no_nulls, some_nulls, &output));
   ASSERT_THAT(output.buffers, ElementsAre(Eq(nulls)));
-  ASSERT_THAT(output.null_count, 9);
+  ASSERT_EQ(output.null_count, 9);
 }
 
 TEST(AssignNullIntersection, IntersectsNullsWhenSomeOnBoth) {
@@ -151,7 +151,7 @@ TEST(AssignNullIntersection, IntersectsNullsWhenSomeOnBoth) {
 
   ASSERT_OK(AssignNullIntersection(&ctx, left, right, &output));
 
-  EXPECT_THAT(output.null_count, 10);
+  EXPECT_EQ(output.null_count, 10);
   ASSERT_THAT(output.buffers, ElementsAre(NotNull()));
   const auto& output_buffer = *output.buffers[0];
   EXPECT_THAT(std::vector<uint8_t>(output_buffer.data(),


### PR DESCRIPTION
This is a minor API break.  ArrayData::null_count still converts implicitly to int64_t.