### PR TITLE
ARROW-7568: [Java] Bump Apache Avro from 1.9.0 to 1.9.1

### DIFF
--- a/java/adapter/avro/pom.xml
+++ b/java/adapter/avro/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.9.0</version>
+      <version>1.9.1</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Bumps a minor version of Avro which takes care of some minor issues.