### PR TITLE
ARROW-7572: [Java] Enforce Maven 3.3+ as mentioned in README

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -208,7 +208,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>[3.0.4,4)</version>
+                  <version>[3.3.0,4)</version>
                 </requireMavenVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
The docs mention Maven 3.3.0+: https://github.com/apache/arrow/blob/master/java/README.md#setup-build-environment

But the Maven plugin for checking the version requires 3.0.4+. I believe that 3.3.0+ is reasonable, and therefore I'd like to up the constraint to 3.3.0+.