### PR TITLE
ARROW-7575: [R] Linux binary packaging followup

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -37,15 +37,11 @@ Conda users on Linux and macOS can install `arrow` from conda-forge with
     conda install -c conda-forge r-arrow
 
 On macOS and Windows, installing a binary package from CRAN will handle
-Arrow’s C++ dependencies for you. On Linux, unless you use `conda`
-you’ll need to first install the C++ library. See the [Arrow project
-installation page](https://arrow.apache.org/install/) to find
-pre-compiled binary packages for some common Linux distributions,
-including Debian, Ubuntu, and CentOS. You’ll need to install
-`libparquet-dev` on Debian and Ubuntu, or `parquet-devel` on CentOS.
-This will also automatically install the Arrow C++ library as a
-dependency. Other Linux distributions must install the C++ library from
-source.
+Arrow’s C++ dependencies for you. On Linux, unless you use `conda`, the
+R package will have to compile its bindings from source and it will need
+to find or download the C++ dependencies. As of the 0.16.0 release, this
+dependency resolution is automatic on most common Linux distributions.
+See `vignette("install", package = "arrow")` for details.
 
 If you install the `arrow` package from source and the C++ library is
 not found, the R package functions will notify you that Arrow is not
@@ -122,15 +118,12 @@ Binary R packages for macOS and Windows are built daily and hosted at
 <https://dl.bintray.com/ursalabs/arrow-r/>. To install from there:
 
 ``` r
-install.packages("arrow", repos="https://dl.bintray.com/ursalabs/arrow-r")
+install.packages("arrow", repos = "https://dl.bintray.com/ursalabs/arrow-r")
 ```
 
 These daily package builds are not official Apache releases and are not
 recommended for production use. They may be useful for testing bug fixes
 and new features under active development.
-
-Linux users will need to build the Arrow C++ library from source, then
-install the R package from source, as described in the next section.
 
 ## Developing
 
@@ -202,7 +195,8 @@ Arrow C++ was put in `make install`, e.g. `export
 R_LD_LIBRARY_PATH=/usr/local/lib`, and retry installing the R package.
 
 For any other build/configuration challenges, see the [C++ developer
-guide](https://arrow.apache.org/docs/developers/cpp.html#building).
+guide](https://arrow.apache.org/docs/developers/cpp.html#building) and
+`vignette("install", package = "arrow")`.
 
 ### Editing Rcpp code
 
@@ -255,6 +249,6 @@ from the command line (`make test`, `make doc`, `make clean`, etc.)
 ### Full package validation
 
 ``` shell
-R CMD build --keep-empty-dirs .
-R CMD check arrow_*.tar.gz --as-cran --no-manual
+R CMD build .
+R CMD check arrow_*.tar.gz --as-cran
 ```

--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -90,6 +90,20 @@ identify_os <- function(os = Sys.getenv("LIBARROW_BINARY_DISTRO")) {
     # In the future, we may be able to do some mapping of distro-versions to
     # versions we built for, since there's no way we'll build for everything.
     os <- paste0(distro, "-", os_version)
+  } else if (file.exists("/etc/os-release")) {
+    os_release <- readLines("/etc/os-release")
+    vals <- sub("^.*=(.*)$", "\\1", os_release)
+    names(vals) <- sub("^(.*)=.*$", "\\1", os_release)
+    distro <- vals["ID"]
+    if (distro == "ubuntu") {
+      # Keep major.minor version
+      version_regex <- '^"?([0-9]+\\.[0-9]+).*"?.*$'
+    } else {
+      # Only major version number
+      version_regex <- '^"?([0-9]+).*"?.*$'
+    }
+    os_version <- sub(version_regex, "\\1", vals["VERSION_ID"])
+    os <- paste0(distro, "-", os_version)
   } else if (file.exists("/etc/system-release")) {
     # Something like "CentOS Linux release 7.7.1908 (Core)"
     system_release <- tolower(utils::head(readLines("/etc/system-release"), 1))

--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -94,7 +94,7 @@ identify_os <- function(os = Sys.getenv("LIBARROW_BINARY_DISTRO")) {
     os_release <- readLines("/etc/os-release")
     vals <- sub("^.*=(.*)$", "\\1", os_release)
     names(vals) <- sub("^(.*)=.*$", "\\1", os_release)
-    distro <- vals["ID"]
+    distro <- gsub('"', '', vals["ID"])
     if (distro == "ubuntu") {
       # Keep major.minor version
       version_regex <- '^"?([0-9]+\\.[0-9]+).*"?.*$'

--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -113,6 +113,23 @@ identify_os <- function(os = Sys.getenv("LIBARROW_BINARY_DISTRO")) {
     cat("*** Unable to identify current OS/version\n")
     os <- NULL
   }
+
+  # Now look to see if we can map this os-version to one we have binaries for
+  os <- find_available_binary(os)
+  os
+}
+
+find_available_binary <- function(os) {
+  # Download a csv that maps one to the other, columns "actual" and "use_this"
+  u <- "https://raw.githubusercontent.com/ursa-labs/arrow-r-nightly/master/linux/distro-map.csv"
+  lookup <- try(utils::read.csv(u, stringsAsFactors = FALSE), silent = quietly)
+  if (!inherits(lookup, "try-error") && os %in% lookup$actual) {
+    new <- lookup$use_this[lookup$actual == os]
+    if (length(new) == 1 && !is.na(new)) { # Just some sanity checking
+      cat(sprintf("*** Using %s binary for %s\n", new, os))
+      os <- new
+    }
+  }
   os
 }
 

--- a/r/vignettes/install.Rmd
+++ b/r/vignettes/install.Rmd
@@ -82,7 +82,8 @@ the R package installation script will next attempt to download
 prebuilt static Arrow C++ libraries, hosted by Ursa Labs,
 that match your both your local operating system and `arrow` R package version.
 If found, they will be downloaded and bundled when your R package compiles.
-<!-- TODO: link to bintray to show current list of supported OSes? -->
+For a list of supported distributions and versions,
+see the [arrow-r-nightly](https://github.com/ursa-labs/arrow-r-nightly/blob/master/README.md) project.
 
 If no binary is found, it will download the Arrow C++ source that matches the R package version
 (CRAN release or nightly build) and attempt to build it locally.
@@ -174,6 +175,12 @@ to a `distribution-version` that exists in the Ursa Labs repository.
 Setting `LIBARROW_BINARY_DISTRO` is also an option when there's not an exact match
 for your OS but a similar version would work,
 such as if you're on `ubuntu-18.10` and there's only a binary for `ubuntu-18.04`.
+
+If that workaround works for you, and you believe that it should work for everyone else too,
+you may propose [adding an entry to this lookup table](https://github.com/ursa-labs/arrow-r-nightly/edit/master/linux/distro-map.csv).
+This table is checked during the installation process
+and tells the script to use binaries built on a different operating system/version
+because they're known to work.
 
 <!-- If no binary found for current nightly R package version but yes for yesterday? -->
 <!-- TODO add a function to the package to update dev version from bintray? -->


### PR DESCRIPTION
CI for nightly binary packaging and testing is running at https://github.com/ursa-labs/arrow-r-nightly. https://dl.bintray.com/ursalabs/arrow-r/libarrow/bin/ shows what distribution-versions we're building for, currently 6 of them.