### PR TITLE
ARROW-7311: [Python] Return filesystem and path from URI

### DIFF
--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -190,6 +190,12 @@ cdef class FileSystem:
                         "the subclasses instead: LocalFileSystem or "
                         "SubTreeFileSystem")
 
+    @staticmethod
+    def from_uri(uri):
+        cdef CResult[shared_ptr[CFileSystem]] result
+        result = CFileSystemFromUri(tobytes(uri))
+        return FileSystem.wrap(GetResultValue(result))
+
     cdef init(self, const shared_ptr[CFileSystem]& wrapped):
         self.wrapped = wrapped
         self.fs = wrapped.get()

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -192,9 +192,26 @@ cdef class FileSystem:
 
     @staticmethod
     def from_uri(uri):
-        cdef CResult[shared_ptr[CFileSystem]] result
-        result = CFileSystemFromUri(tobytes(uri))
-        return FileSystem.wrap(GetResultValue(result))
+        """Create a new FileSystem from by URI
+
+        A scheme-less URI is considered a local filesystem path.
+        Recognized schemes are "file", "mock", "hdfs" and "viewfs".
+
+        Parameters
+        ----------
+        uri : string
+            URI-based path, for example: file:///some/local/path
+
+        Returns
+        -------
+        With (filesystem, path) tuple where path is the abtract path inside the
+        FileSystem instance.
+        """
+        cdef:
+            c_string path
+            CResult[shared_ptr[CFileSystem]] result
+        result = CFileSystemFromUri(tobytes(uri), &path)
+        return FileSystem.wrap(GetResultValue(result)), frombytes(path)
 
     cdef init(self, const shared_ptr[CFileSystem]& wrapped):
         self.wrapped = wrapped

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -79,6 +79,9 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         CResult[shared_ptr[COutputStream]] OpenAppendStream(
             const c_string& path)
 
+    CResult[shared_ptr[CFileSystem]] CFileSystemFromUri \
+        "arrow::fs::FileSystemFromUri"(const c_string& uri)
+
     cdef cppclass CLocalFileSystemOptions "arrow::fs::LocalFileSystemOptions":
         c_bool use_mmap
 

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -80,7 +80,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
             const c_string& path)
 
     CResult[shared_ptr[CFileSystem]] CFileSystemFromUri \
-        "arrow::fs::FileSystemFromUri"(const c_string& uri)
+        "arrow::fs::FileSystemFromUri"(const c_string& uri, c_string* out_path)
 
     cdef cppclass CLocalFileSystemOptions "arrow::fs::LocalFileSystemOptions":
         c_bool use_mmap

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -600,9 +600,11 @@ def test_hdfs_options(hdfs_server):
     ('mock:/foo/bar', _MockFileSystem, 'foo/bar'),
     ('mock:///foo/bar', _MockFileSystem, 'foo/bar'),
     ('file:', LocalFileSystem, ''),
+    ('file:foo/bar', LocalFileSystem, 'foo/bar'),
     ('file:/foo/bar', LocalFileSystem, '/foo/bar'),
     ('file:///foo/bar', LocalFileSystem, '/foo/bar'),
     ('', LocalFileSystem, ''),
+    ('foo/bar', LocalFileSystem, 'foo/bar'),
     ('/foo/bar', LocalFileSystem, '/foo/bar'),
 ])
 def test_filesystem_from_uri(uri, expected_klass, expected_path):

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -590,3 +590,19 @@ def test_hdfs_options(hdfs_server):
     uri = "hdfs://{}:{}/?user={}".format(host, port, user)
     fs = HadoopFileSystem(uri)
     assert fs.get_target_stats(FileSelector('/'))
+
+
+@pytest.mark.parametrize(('scheme', 'klass'), [
+    ('mock', _MockFileSystem),
+    ('local', LocalFileSystem)
+])
+def test_filesystem_from_uri(scheme, klass):
+    uris = [
+        "{scheme}:",
+        "{scheme}:foo/bar",
+        "{scheme}:/foo/bar",
+        "{scheme}:///foo/bar",
+    ]
+    for uri in uris:
+        fs = FileSystem.from_uri(uri.format(scheme=scheme))
+        assert isinstance(fs, klass)


### PR DESCRIPTION
This should supersede https://github.com/apache/arrow/pull/5977