### PR TITLE
ARROW-7551: [FlightRPC][C++] Flight test on macOS fails due to Homebrew gRPC

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -116,6 +116,10 @@ jobs:
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: ON
+      # ARROW-7551: for now, build without Homebrew gRPC, as gRPC
+      # 1.26.0 is broken. https://github.com/grpc/grpc/pull/21662
+      gRPC_SOURCE: BUNDLED
+      Protobuf_SOURCE: BUNDLED
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v1
@@ -124,6 +128,11 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: brew bundle --file=cpp/Brewfile
+        # ARROW-7551: for now, build without Homebrew gRPC, as gRPC
+        # 1.26.0 is broken. https://github.com/grpc/grpc/pull/21662
+      - name: Uninstall Problematic Homebrew Dependencies
+        shell: bash
+        run: brew uninstall grpc protobuf
       - name: Build
         shell: bash
         run: ci/scripts/cpp_build.sh $(pwd) $(pwd)/build

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2049,6 +2049,15 @@ macro(build_grpc)
   # ZLIB is never vendored
   set(GRPC_CMAKE_PREFIX "${GRPC_CMAKE_PREFIX};${ZLIB_ROOT}")
 
+  if(APPLE)
+    # gRPC on MacOS will fail to build due to thread local variables.
+    # While the issue is for Bazel builds, CMake is also affected.
+    # https://github.com/grpc/grpc/issues/13856
+    set(GRPC_CMAKE_CXX_FLAGS "${EP_CXX_FLAGS} -DGRPC_BAZEL_BUILD")
+  else()
+    set(GRPC_CMAKE_CXX_FLAGS "${EP_CXX_FLAGS}")
+  endif()
+
   if(RAPIDJSON_VENDORED)
     add_dependencies(grpc_dependencies rapidjson_ep)
   endif()
@@ -2064,7 +2073,7 @@ macro(build_grpc)
       -DgRPC_PROTOBUF_PROVIDER=package
       -DgRPC_SSL_PROVIDER=package
       -DgRPC_ZLIB_PROVIDER=package
-      -DCMAKE_CXX_FLAGS=${EP_CXX_FLAGS}
+      -DCMAKE_CXX_FLAGS=${GRPC_CMAKE_CXX_FLAGS}
       -DCMAKE_C_FLAGS=${EP_C_FLAGS}
       -DCMAKE_INSTALL_PREFIX=${GRPC_PREFIX}
       -DCMAKE_INSTALL_LIBDIR=lib


### PR DESCRIPTION
This test is consistently flaky on MacOS, but I can't reproduce it locally.