### PR TITLE
ARROW-7533: [Java] Move ArrowBufPointer out of the java the memory package

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/pointer/ArrowBufPointer.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/pointer/ArrowBufPointer.java
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-package org.apache.arrow.memory.util;
+package org.apache.arrow.algorithm.pointer;
 
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.memory.util.hash.SimpleHasher;
 import org.apache.arrow.util.Preconditions;
@@ -29,15 +30,20 @@ import org.apache.arrow.util.Preconditions;
 public final class ArrowBufPointer {
 
   /**
+   * An immutable pointer with buffer set to null.
+   */
+  public static final ArrowBufPointer NULL_POINTER = new ArrowBufPointer();
+
+  /**
    * The hash code when the arrow buffer is null.
    */
   public static final int NULL_HASH_CODE = 0;
 
-  private ArrowBuf buf;
+  ArrowBuf buf;
 
-  private long offset;
+  long offset;
 
-  private long length;
+  long length;
 
   private int hashCode = NULL_HASH_CODE;
 

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/pointer/ArrowBufPointerGenerator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/pointer/ArrowBufPointerGenerator.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.pointer;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseLargeVariableWidthVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.compare.VectorVisitor;
+import org.apache.arrow.vector.complex.DenseUnionVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.LargeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.UnionVector;
+
+/**
+ * Vector visitor for generating {@link ArrowBufPointer}s, given a vector and index.
+ * This only works for {@link org.apache.arrow.vector.ElementAddressableVector}s.
+ */
+public class ArrowBufPointerGenerator implements VectorVisitor<ArrowBufPointer, Integer> {
+
+  @Override
+  public ArrowBufPointer visit(BaseFixedWidthVector vector, Integer index) {
+    if (vector instanceof BitVector) {
+      throw new UnsupportedOperationException();
+    }
+    if (vector.isNull(index)) {
+      return ArrowBufPointer.NULL_POINTER;
+    }
+    return new ArrowBufPointer(vector.getDataBuffer(), (long) index * vector.getTypeWidth(), vector.getTypeWidth());
+  }
+
+  @Override
+  public ArrowBufPointer visit(BaseVariableWidthVector vector, Integer index) {
+    if (vector.isNull(index)) {
+      return ArrowBufPointer.NULL_POINTER;
+    }
+
+    int startIdx = vector.getOffsetBuffer().getInt(index * BaseVariableWidthVector.OFFSET_WIDTH);
+    int endIdx = vector.getOffsetBuffer().getInt((index + 1) * BaseVariableWidthVector.OFFSET_WIDTH);
+    return new ArrowBufPointer(vector.getDataBuffer(), startIdx, endIdx - startIdx);
+  }
+
+  @Override
+  public ArrowBufPointer visit(BaseLargeVariableWidthVector vector, Integer index) {
+    if (vector.isNull(index)) {
+      return ArrowBufPointer.NULL_POINTER;
+    }
+
+    long startIdx = vector.getOffsetBuffer().getLong((long) index * BaseLargeVariableWidthVector.OFFSET_WIDTH);
+    long endIdx = vector.getOffsetBuffer().getLong((long) (index + 1) * BaseLargeVariableWidthVector.OFFSET_WIDTH);
+    return new ArrowBufPointer(vector.getDataBuffer(), startIdx, endIdx - startIdx);
+  }
+
+  @Override
+  public ArrowBufPointer visit(ListVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ArrowBufPointer visit(FixedSizeListVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ArrowBufPointer visit(LargeListVector left, Integer value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ArrowBufPointer visit(NonNullableStructVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ArrowBufPointer visit(UnionVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ArrowBufPointer visit(DenseUnionVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ArrowBufPointer visit(NullVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/pointer/ArrowBufPointerPopulator.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/pointer/ArrowBufPointerPopulator.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.pointer;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseLargeVariableWidthVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.compare.VectorVisitor;
+import org.apache.arrow.vector.complex.DenseUnionVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.LargeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.UnionVector;
+
+/**
+ * Vector visitor for populating {@link ArrowBufPointer}s, given a vector and index.
+ * This only works for {@link org.apache.arrow.vector.ElementAddressableVector}s.
+ */
+public class ArrowBufPointerPopulator implements VectorVisitor<Void, Integer> {
+
+  private ArrowBufPointer pointer;
+
+  /**
+   * Constructs a new instance.
+   * @param pointer the {@link ArrowBufPointer} to populate.
+   */
+  public ArrowBufPointerPopulator(ArrowBufPointer pointer) {
+    this.pointer = pointer;
+  }
+
+  /**
+   * Gets the underlying pointer to populate.
+   */
+  public ArrowBufPointer getPointer() {
+    return pointer;
+  }
+
+  /**
+   * Sets the pointer to populate.
+   */
+  public void setPointer(ArrowBufPointer pointer) {
+    this.pointer = pointer;
+  }
+
+  @Override
+  public Void visit(BaseFixedWidthVector vector, Integer index) {
+    if (vector instanceof BitVector) {
+      throw new UnsupportedOperationException();
+    }
+
+    if (vector.isNull(index)) {
+      pointer.buf = null;
+      return null;
+    }
+
+    pointer.buf = vector.getDataBuffer();
+    pointer.offset = (long) index * vector.getTypeWidth();
+    pointer.length = vector.getTypeWidth();
+    return null;
+  }
+
+  @Override
+  public Void visit(BaseVariableWidthVector vector, Integer index) {
+    if (vector.isNull(index)) {
+      pointer.buf = null;
+      return null;
+    }
+
+    int startIdx = vector.getOffsetBuffer().getInt(index * BaseVariableWidthVector.OFFSET_WIDTH);
+    int endIdx = vector.getOffsetBuffer().getInt((index + 1) * BaseVariableWidthVector.OFFSET_WIDTH);
+
+    pointer.buf = vector.getDataBuffer();
+    pointer.offset = startIdx;
+    pointer.length = endIdx - startIdx;
+    return null;
+  }
+
+  @Override
+  public Void visit(BaseLargeVariableWidthVector vector, Integer index) {
+    if (vector.isNull(index)) {
+      pointer.buf = null;
+      return null;
+    }
+
+    long startIdx = vector.getOffsetBuffer().getLong((long) index * BaseLargeVariableWidthVector.OFFSET_WIDTH);
+    long endIdx = vector.getOffsetBuffer().getLong((long) (index + 1) * BaseLargeVariableWidthVector.OFFSET_WIDTH);
+
+    pointer.buf = vector.getDataBuffer();
+    pointer.offset = startIdx;
+    pointer.length = endIdx - startIdx;
+    return null;
+  }
+
+  @Override
+  public Void visit(ListVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Void visit(FixedSizeListVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Void visit(LargeListVector left, Integer value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Void visit(NonNullableStructVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Void visit(UnionVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Void visit(DenseUnionVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Void visit(NullVector vector, Integer index) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/sort/DefaultVectorComparators.java
@@ -19,7 +19,8 @@ package org.apache.arrow.algorithm.sort;
 
 import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.OFFSET_WIDTH;
 
-import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.algorithm.pointer.ArrowBufPointer;
+import org.apache.arrow.algorithm.pointer.ArrowBufPointerPopulator;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseVariableWidthVector;
@@ -351,21 +352,31 @@ public class DefaultVectorComparators {
    */
   public static class VariableWidthComparator extends VectorValueComparator<BaseVariableWidthVector> {
 
-    private ArrowBufPointer reusablePointer1 = new ArrowBufPointer();
+    private final ArrowBufPointerPopulator pointerPopulator = new ArrowBufPointerPopulator(null);
 
-    private ArrowBufPointer reusablePointer2 = new ArrowBufPointer();
+    private final ArrowBufPointer reusablePointer1 = new ArrowBufPointer();
+
+    private final ArrowBufPointer reusablePointer2 = new ArrowBufPointer();
 
     @Override
     public int compare(int index1, int index2) {
-      vector1.getDataPointer(index1, reusablePointer1);
-      vector2.getDataPointer(index2, reusablePointer2);
+      pointerPopulator.setPointer(reusablePointer1);
+      vector1.accept(pointerPopulator, index1);
+
+      pointerPopulator.setPointer(reusablePointer2);
+      vector2.accept(pointerPopulator, index2);
+
       return reusablePointer1.compareTo(reusablePointer2);
     }
 
     @Override
     public int compareNotNull(int index1, int index2) {
-      vector1.getDataPointer(index1, reusablePointer1);
-      vector2.getDataPointer(index2, reusablePointer2);
+      pointerPopulator.setPointer(reusablePointer1);
+      vector1.accept(pointerPopulator, index1);
+
+      pointerPopulator.setPointer(reusablePointer2);
+      vector2.accept(pointerPopulator, index2);
+
       return reusablePointer1.compareTo(reusablePointer2);
     }
 

--- a/java/algorithm/src/test/java/org/apache/arrow/algorithm/pointer/TestElementAddressableVectorIterator.java
+++ b/java/algorithm/src/test/java/org/apache/arrow/algorithm/pointer/TestElementAddressableVectorIterator.java
@@ -15,14 +15,13 @@
  * limitations under the License.
  */
 
-package org.apache.arrow.vector.util;
+package org.apache.arrow.algorithm.pointer;
 
 import static junit.framework.TestCase.assertNull;
 import static org.junit.Assert.assertEquals;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.junit.After;

--- a/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/hash/ArrowBufHasher.java
+++ b/java/memory/memory-core/src/main/java/org/apache/arrow/memory/util/hash/ArrowBufHasher.java
@@ -29,6 +29,11 @@ import org.apache.arrow.memory.ArrowBuf;
 public interface ArrowBufHasher {
 
   /**
+   * The hash code for null.
+   */
+  int NULL_HASH_CODE = 0;
+
+  /**
    * Calculates the hash code for a memory region.
    * @param address start address of the memory region.
    * @param length length of the memory region.

--- a/java/performance/src/test/java/org/apache/arrow/util/ArrowBufPointerBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/util/ArrowBufPointerBenchmarks.java
@@ -15,10 +15,11 @@
  * limitations under the License.
  */
 
-package org.apache.arrow.memory.util;
+package org.apache.arrow.util;
 
 import java.util.concurrent.TimeUnit;
 
+import org.apache.arrow.algorithm.pointer.ArrowBufPointer;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -58,7 +58,7 @@ import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.util.DataSizeRoundingUtil;
 import org.apache.arrow.vector.util.ValueVectorUtility;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
-import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.util.OversizedAllocationException;
@@ -779,7 +779,7 @@ public class UnionVector implements FieldVector {
     public int hashCode(int index, ArrowBufHasher hasher) {
       ValueVector vec = getVector(index);
       if (vec == null) {
-        return ArrowBufPointer.NULL_HASH_CODE;
+        return ArrowBufHasher.NULL_HASH_CODE;
       }
       return vec.hashCode(index, hasher);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
@@ -869,21 +868,6 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   }
 
   @Override
-  public ArrowBufPointer getDataPointer(int index) {
-    return getDataPointer(index, new ArrowBufPointer());
-  }
-
-  @Override
-  public ArrowBufPointer getDataPointer(int index, ArrowBufPointer reuse) {
-    if (isNull(index)) {
-      reuse.set(null, 0, 0);
-    } else {
-      reuse.set(valueBuffer, (long) index * typeWidth, typeWidth);
-    }
-    return reuse;
-  }
-
-  @Override
   public int hashCode(int index) {
     return hashCode(index, null);
   }
@@ -891,7 +875,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isNull(index)) {
-      return ArrowBufPointer.NULL_HASH_CODE;
+      return ArrowBufHasher.NULL_HASH_CODE;
     }
     long start = (long) typeWidth * index;
     long end = (long) typeWidth * (index + 1);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
@@ -27,7 +27,6 @@ import java.util.List;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
@@ -611,7 +610,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
    *
    * @param clear Whether to clear vector before returning; the buffers will still be refcounted
    *              but the returned array will be the only reference to them
-   * @return The underlying {@link io.netty.buffer.ArrowBuf buffers} that is used by this
+   * @return The underlying {@link ArrowBuf buffers} that is used by this
    *         vector instance.
    */
   @Override
@@ -1322,23 +1321,6 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
   }
 
   @Override
-  public ArrowBufPointer getDataPointer(int index) {
-    return getDataPointer(index, new ArrowBufPointer());
-  }
-
-  @Override
-  public ArrowBufPointer getDataPointer(int index, ArrowBufPointer reuse) {
-    if (isNull(index)) {
-      reuse.set(null, 0, 0);
-    } else {
-      long offset = offsetBuffer.getLong((long) index * OFFSET_WIDTH);
-      int length = (int) (offsetBuffer.getLong((long) (index + 1) * OFFSET_WIDTH) - offset);
-      reuse.set(valueBuffer, offset, length);
-    }
-    return reuse;
-  }
-
-  @Override
   public int hashCode(int index) {
     return hashCode(index, null);
   }
@@ -1346,7 +1328,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isNull(index)) {
-      return ArrowBufPointer.NULL_HASH_CODE;
+      return ArrowBufHasher.NULL_HASH_CODE;
     }
     final long start = getStartOffset(index);
     final long end = getStartOffset(index + 1);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -27,7 +27,6 @@ import java.util.List;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
@@ -1357,23 +1356,6 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   }
 
   @Override
-  public ArrowBufPointer getDataPointer(int index) {
-    return getDataPointer(index, new ArrowBufPointer());
-  }
-
-  @Override
-  public ArrowBufPointer getDataPointer(int index, ArrowBufPointer reuse) {
-    if (isNull(index)) {
-      reuse.set(null, 0, 0);
-    } else {
-      int offset = offsetBuffer.getInt((long) index * OFFSET_WIDTH);
-      int length = offsetBuffer.getInt((long) (index + 1) * OFFSET_WIDTH) - offset;
-      reuse.set(valueBuffer, offset, length);
-    }
-    return reuse;
-  }
-
-  @Override
   public int hashCode(int index) {
     return hashCode(index, null);
   }
@@ -1381,7 +1363,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isNull(index)) {
-      return ArrowBufPointer.NULL_HASH_CODE;
+      return ArrowBufHasher.NULL_HASH_CODE;
     }
     final int start = getStartOffset(index);
     final int end = getStartOffset(index + 1);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -22,7 +22,6 @@ import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.BitReaderImpl;
@@ -467,19 +466,9 @@ public final class BitVector extends BaseFixedWidthVector {
   }
 
   @Override
-  public ArrowBufPointer getDataPointer(int index) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public ArrowBufPointer getDataPointer(int index, ArrowBufPointer reuse) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public int hashCode(int index) {
     if (isNull(index)) {
-      return ArrowBufPointer.NULL_HASH_CODE;
+      return ArrowBufHasher.NULL_HASH_CODE;
     } else {
       if (get(index) == 0) {
         return HASH_CODE_FOR_ZERO;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ElementAddressableVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ElementAddressableVector.java
@@ -17,26 +17,9 @@
 
 package org.apache.arrow.vector;
 
-import org.apache.arrow.memory.util.ArrowBufPointer;
-
 /**
- * Vector for which each data element resides in a continuous memory region,
- * so it can be pointed to by an {@link org.apache.arrow.memory.util.ArrowBufPointer}.
+ * Vector for which each data element resides in a continuous memory region.
  */
 public interface ElementAddressableVector extends ValueVector {
 
-  /**
-   * Gets the pointer for the data at the given index.
-   * @param index the index for the data.
-   * @return the pointer to the data.
-   */
-  ArrowBufPointer getDataPointer(int index);
-
-  /**
-   * Gets the pointer for the data at the given index.
-   * @param index the index for the data.
-   * @param reuse the data pointer to fill, this avoids creating a new pointer object.
-   * @return the pointer to the data, it should be the same one as the input parameter
-   */
-  ArrowBufPointer getDataPointer(int index, ArrowBufPointer reuse);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ZeroVector.java
@@ -18,7 +18,6 @@
 package org.apache.arrow.vector;
 
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.TransferPair;
@@ -58,7 +57,7 @@ public final class ZeroVector extends NullVector {
 
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
-    return ArrowBufPointer.NULL_HASH_CODE;
+    return ArrowBufHasher.NULL_HASH_CODE;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -32,7 +32,6 @@ import java.util.Objects;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
@@ -541,7 +540,7 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
-      return ArrowBufPointer.NULL_HASH_CODE;
+      return ArrowBufHasher.NULL_HASH_CODE;
     }
     int hash = 0;
     for (int i = 0; i < listSize; i++) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/LargeListVector.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
@@ -514,7 +513,7 @@ public class LargeListVector extends BaseValueVector implements RepeatedValueVec
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
-      return ArrowBufPointer.NULL_HASH_CODE;
+      return ArrowBufHasher.NULL_HASH_CODE;
     }
     int hash = 0;
     final long start = offsetBuffer.getLong((long) index * OFFSET_WIDTH);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
 import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
@@ -433,7 +432,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
-      return ArrowBufPointer.NULL_HASH_CODE;
+      return ArrowBufHasher.NULL_HASH_CODE;
     }
     int hash = 0;
     final int start = offsetBuffer.getInt(index * OFFSET_WIDTH);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -26,7 +26,6 @@ import java.util.List;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
@@ -523,7 +522,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
   @Override
   public int hashCode(int index, ArrowBufHasher hasher) {
     if (isSet(index) == 0) {
-      return ArrowBufPointer.NULL_HASH_CODE;
+      return ArrowBufHasher.NULL_HASH_CODE;
     } else {
       return super.hashCode(index, hasher);
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -38,7 +38,6 @@ import java.util.List;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
@@ -2135,76 +2134,6 @@ public class TestValueVector {
       assertTrue(vector.isNull(1));
 
       buf.close();
-    }
-  }
-
-  @Test
-  public void testGetPointerFixedWidth() {
-    final int vectorLength = 100;
-    try (IntVector vec1 = new IntVector("vec1", allocator);
-         IntVector vec2 = new IntVector("vec2", allocator)) {
-      vec1.allocateNew(vectorLength);
-      vec2.allocateNew(vectorLength);
-
-      for (int i = 0; i < vectorLength; i++) {
-        if (i % 10 == 0) {
-          vec1.setNull(i);
-          vec2.setNull(i);
-        } else {
-          vec1.set(i, i * 1234);
-          vec2.set(i, i * 1234);
-        }
-      }
-
-      ArrowBufPointer ptr1 = new ArrowBufPointer();
-      ArrowBufPointer ptr2 = new ArrowBufPointer();
-
-      for (int i = 0; i < vectorLength; i++) {
-        vec1.getDataPointer(i, ptr1);
-        vec2.getDataPointer(i, ptr2);
-
-        if (i % 10 == 0) {
-          assertNull(ptr1.getBuf());
-          assertNull(ptr2.getBuf());
-        }
-
-        assertTrue(ptr1.equals(ptr2));
-        assertTrue(ptr2.equals(ptr2));
-      }
-    }
-  }
-
-  @Test
-  public void testGetPointerVariableWidth() {
-    final String[] sampleData = new String[]{
-      "abc", "123", "def", null, "hello", "aaaaa", "world", "2019", null, "0717"};
-
-    try (VarCharVector vec1 = new VarCharVector("vec1", allocator);
-         VarCharVector vec2 = new VarCharVector("vec2", allocator)) {
-      vec1.allocateNew(sampleData.length * 10, sampleData.length);
-      vec2.allocateNew(sampleData.length * 10, sampleData.length);
-
-      for (int i = 0; i < sampleData.length; i++) {
-        String str = sampleData[i];
-        if (str != null) {
-          vec1.set(i, sampleData[i].getBytes());
-          vec2.set(i, sampleData[i].getBytes());
-        } else {
-          vec1.setNull(i);
-          vec2.setNull(i);
-        }
-      }
-
-      ArrowBufPointer ptr1 = new ArrowBufPointer();
-      ArrowBufPointer ptr2 = new ArrowBufPointer();
-
-      for (int i = 0; i < sampleData.length; i++) {
-        vec1.getDataPointer(i, ptr1);
-        vec2.getDataPointer(i, ptr2);
-
-        assertTrue(ptr1.equals(ptr2));
-        assertTrue(ptr2.equals(ptr2));
-      }
     }
   }
 


### PR DESCRIPTION
The memory package is focused on memory access and management. ArrowBufPointer should be moved out as it isn't core to the Arrow memory management primitives. 
