### PR TITLE
ARROW-7592: [C++] Fix crashes on corrupt IPC input

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -117,6 +117,9 @@ class PoolBuffer : public ResizableBuffer {
   }
 
   Status Reserve(const int64_t capacity) override {
+    if (capacity < 0) {
+      return Status::Invalid("Negative buffer capacity: ", capacity);
+    }
     if (!mutable_data_ || capacity > capacity_) {
       uint8_t* new_data;
       int64_t new_capacity = BitUtil::RoundUpToMultipleOf64(capacity);
@@ -133,6 +136,9 @@ class PoolBuffer : public ResizableBuffer {
   }
 
   Status Resize(const int64_t new_size, bool shrink_to_fit = true) override {
+    if (new_size < 0) {
+      return Status::Invalid("Negative buffer resize: ", new_size);
+    }
     if (mutable_data_ && shrink_to_fit && new_size <= size_) {
       // Buffer is non-null and is not growing, so shrink to the requested size without
       // excess space.

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -226,6 +226,35 @@ void CloseFromDestructor(FileInterface* file) {
   }
 }
 
+Result<int64_t> ValidateReadRegion(int64_t offset, int64_t size, int64_t file_size) {
+  if (offset < 0 || size < 0) {
+    return Status::Invalid("Invalid read (offset = ", offset, ", size = ", size, ")");
+  }
+  if (offset > file_size) {
+    return Status::IOError("Read out of bounds (offset = ", offset, ", size = ", size,
+                           ") in file of size ", file_size);
+  }
+  return std::min(size, file_size - offset);
+}
+
+Status ValidateWriteRegion(int64_t offset, int64_t size, int64_t file_size) {
+  if (offset < 0 || size < 0) {
+    return Status::Invalid("Invalid write (offset = ", offset, ", size = ", size, ")");
+  }
+  if (offset + size > file_size) {
+    return Status::IOError("Write out of bounds (offset = ", offset, ", size = ", size,
+                           ") in file of size ", file_size);
+  }
+  return Status::OK();
+}
+
+Status ValidateRegion(int64_t offset, int64_t size) {
+  if (offset < 0 || size < 0) {
+    return Status::Invalid("Invalid IO (offset = ", offset, ", size = ", size, ")");
+  }
+  return Status::OK();
+}
+
 #ifndef NDEBUG
 
 // Debug mode concurrency checking

--- a/cpp/src/arrow/io/memory_test.cc
+++ b/cpp/src/arrow/io/memory_test.cc
@@ -135,6 +135,16 @@ TEST(TestFixedSizeBufferWriter, Basics) {
   ASSERT_OK(writer.Close());
 }
 
+TEST(TestFixedSizeBufferWriter, InvalidWrites) {
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_OK(AllocateBuffer(1024, &buffer));
+
+  FixedSizeBufferWriter writer(buffer);
+  const uint8_t data[10]{};
+  ASSERT_RAISES(Invalid, writer.WriteAt(-1, data, 1));
+  ASSERT_RAISES(Invalid, writer.WriteAt(1, data, -1));
+}
+
 TEST(TestBufferReader, FromStrings) {
   // ARROW-3291: construct BufferReader from std::string or
   // arrow::util::string_view
@@ -185,6 +195,17 @@ TEST(TestBufferReader, Peek) {
   ASSERT_OK_AND_ASSIGN(view, reader.Peek(20));
   ASSERT_EQ(data.size(), view.size());
   ASSERT_EQ(data, view.to_string());
+}
+
+TEST(TestBufferReader, InvalidReads) {
+  std::string data = "data123456";
+  BufferReader reader(std::make_shared<Buffer>(data));
+  uint8_t buffer[10];
+
+  ASSERT_RAISES(Invalid, reader.ReadAt(-1, 1));
+  ASSERT_RAISES(Invalid, reader.ReadAt(1, -1));
+  ASSERT_RAISES(Invalid, reader.ReadAt(-1, 1, buffer));
+  ASSERT_RAISES(Invalid, reader.ReadAt(1, -1, buffer));
 }
 
 TEST(TestBufferReader, RetainParentReference) {

--- a/cpp/src/arrow/io/util_internal.h
+++ b/cpp/src/arrow/io/util_internal.h
@@ -26,6 +26,18 @@ namespace internal {
 
 ARROW_EXPORT void CloseFromDestructor(FileInterface* file);
 
+// Validate a (offset, size) region (as given to ReadAt) against
+// the file size.  Return the actual read size.
+ARROW_EXPORT Result<int64_t> ValidateReadRegion(int64_t offset, int64_t size,
+                                                int64_t file_size);
+// Validate a (offset, size) region (as given to WriteAt) against
+// the file size.  Short writes are not allowed.
+ARROW_EXPORT Status ValidateWriteRegion(int64_t offset, int64_t size, int64_t file_size);
+
+// Validate a (offset, size) region (as given to ReadAt or WriteAt), without
+// knowing the file size.
+ARROW_EXPORT Status ValidateRegion(int64_t offset, int64_t size);
+
 }  // namespace internal
 }  // namespace io
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -275,9 +275,7 @@ Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile
   }
 
   if (flatbuffer_length == 0) {
-    // EOS
-    *message = nullptr;
-    return Status::OK();
+    return Status::Invalid("Unexpected empty message in IPC file format");
   }
 
   if (flatbuffer_length + prefix_size != metadata_length) {

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -799,7 +799,8 @@ Status FieldFromFlatbuffer(const flatbuf::Field* field, DictionaryMemo* dictiona
           "is null.");
     }
     RETURN_NOT_OK(IntFromFlatbuffer(int_data, &index_type));
-    type = ::arrow::dictionary(index_type, type, encoding->isOrdered());
+    ARROW_ASSIGN_OR_RAISE(type,
+                          DictionaryType::Make(index_type, type, encoding->isOrdered()));
     *out = ::arrow::field(field->name()->str(), type, field->nullable(), metadata);
     RETURN_NOT_OK(dictionary_memo->AddField(encoding->id(), *out));
   } else {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -696,6 +696,7 @@ class RecordBatchFileReader::RecordBatchFileReaderImpl {
       std::unique_ptr<Message> message;
       RETURN_NOT_OK(ReadMessageFromBlock(GetDictionaryBlock(i), &message));
 
+      CHECK_HAS_BODY(*message);
       io::BufferReader reader(message->body());
       RETURN_NOT_OK(ReadDictionary(*message->metadata(), &dictionary_memo_, &reader));
     }
@@ -714,6 +715,7 @@ class RecordBatchFileReader::RecordBatchFileReaderImpl {
     std::unique_ptr<Message> message;
     RETURN_NOT_OK(ReadMessageFromBlock(GetRecordBatchBlock(i), &message));
 
+    CHECK_HAS_BODY(*message);
     io::BufferReader reader(message->body());
     return ::arrow::ipc::ReadRecordBatch(*message->metadata(), schema_, &dictionary_memo_,
                                          &reader, batch);
@@ -835,6 +837,7 @@ Status ReadRecordBatch(const std::shared_ptr<Schema>& schema,
   auto options = IpcOptions::Defaults();
   std::unique_ptr<Message> message;
   RETURN_NOT_OK(ReadContiguousPayload(file, &message));
+  CHECK_HAS_BODY(*message);
   io::BufferReader buffer_reader(message->body());
   return ReadRecordBatch(*message->metadata(), schema, dictionary_memo, options,
                          &buffer_reader, out);
@@ -851,6 +854,7 @@ Result<std::shared_ptr<Tensor>> ReadTensor(const Message& message) {
   std::vector<int64_t> shape;
   std::vector<int64_t> strides;
   std::vector<std::string> dim_names;
+  CHECK_HAS_BODY(message);
   RETURN_NOT_OK(internal::GetTensorMetadata(*message.metadata(), &type, &shape, &strides,
                                             &dim_names));
   return Tensor::Make(type, message.body(), shape, strides, dim_names);
@@ -1133,6 +1137,7 @@ Result<std::shared_ptr<SparseTensor>> ReadSparseTensor(const Buffer& metadata,
 }
 
 Result<std::shared_ptr<SparseTensor>> ReadSparseTensor(const Message& message) {
+  CHECK_HAS_BODY(message);
   io::BufferReader buffer_reader(message.body());
   return ReadSparseTensor(*message.metadata(), &buffer_reader);
 }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1276,6 +1276,11 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
   DictionaryType(const std::shared_ptr<DataType>& index_type,
                  const std::shared_ptr<DataType>& value_type, bool ordered = false);
 
+  // A constructor variant that validates its input parameters
+  static Result<std::shared_ptr<DataType>> Make(
+      const std::shared_ptr<DataType>& index_type,
+      const std::shared_ptr<DataType>& value_type, bool ordered = false);
+
   std::string ToString() const override;
   std::string name() const override { return "dictionary"; }
 
@@ -1287,6 +1292,9 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
   std::shared_ptr<DataType> value_type() const { return value_type_; }
 
   bool ordered() const { return ordered_; }
+
+  static Status ValidateParameters(const DataType& index_type,
+                                   const DataType& value_type);
 
  protected:
   std::string ComputeFingerprint() const override;

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -721,7 +721,8 @@ def sample_disk_data(request, tmpdir):
     return path, data
 
 
-def _check_native_file_reader(FACTORY, sample_data):
+def _check_native_file_reader(FACTORY, sample_data,
+                              allow_read_out_of_bounds=True):
     path, data = sample_data
 
     f = FACTORY(path, mode='r')
@@ -738,9 +739,10 @@ def _check_native_file_reader(FACTORY, sample_data):
     assert f.tell() == 0
 
     # Seeking past end of file not supported in memory maps
-    f.seek(len(data) + 1)
-    assert f.tell() == len(data) + 1
-    assert f.read(5) == b''
+    if allow_read_out_of_bounds:
+        f.seek(len(data) + 1)
+        assert f.tell() == len(data) + 1
+        assert f.read(5) == b''
 
     # Test whence argument of seek, ARROW-1287
     assert f.seek(3) == 3
@@ -753,7 +755,8 @@ def _check_native_file_reader(FACTORY, sample_data):
 
 
 def test_memory_map_reader(sample_disk_data):
-    _check_native_file_reader(pa.memory_map, sample_disk_data)
+    _check_native_file_reader(pa.memory_map, sample_disk_data,
+                              allow_read_out_of_bounds=False)
 
 
 def test_memory_map_retain_buffer_reference(sample_disk_data):


### PR DESCRIPTION
Fix the following issues spotted by OSS-Fuzz:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20115
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20117
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20124
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20126
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20127
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20133
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20135
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20139

Those are basic missing sanity checks when reading an IPC file.