### PR TITLE
ARROW-7605: [C++] Bundle private jemalloc symbols into static library libarrow.a

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1986,3 +1986,31 @@ SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
 FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+The file cpp/cmake_modules/BuildUtils.cmake contains code from
+
+https://gist.github.com/cristianadam/ef920342939a89fae3e8a85ca9459b49
+
+which is made available under the MIT license
+
+Copyright (c) 2019 Cristian Adam
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -626,10 +626,6 @@ endif()
 #
 
 # TODO: Also rework how these libs work
-set(ARROW_LINK_LIBS)
-set(ARROW_SHARED_INSTALL_INTERFACE_LIBS)
-set(ARROW_STATIC_INSTALL_INTERFACE_LIBS)
-
 # Libraries to link statically with libarrow.so
 set(ARROW_LINK_LIBS)
 set(ARROW_STATIC_LINK_LIBS)

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -128,6 +128,8 @@ function(REUSE_PRECOMPILED_HEADER_LIB TARGET_NAME LIB_NAME)
   endif()
 endfunction()
 
+# Based on MIT-licensed
+# https://gist.github.com/cristianadam/ef920342939a89fae3e8a85ca9459b49
 function(create_merged_static_lib output_target)
   set(options)
   set(one_value_args NAME ROOT)

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -150,10 +150,15 @@ function(create_merged_static_lib output_target)
   foreach(lib ${ARG_TO_MERGE})
     list(APPEND all_library_paths $<TARGET_FILE:${lib}>)
   endforeach()
-  
+
   if(APPLE)
-    set(BUNDLE_COMMAND "libtool" "-no_warning_for_no_symbols" "-static" "-o" 
-      ${output_lib_path} ${all_library_paths})
+    set(BUNDLE_COMMAND
+        "libtool"
+        "-no_warning_for_no_symbols"
+        "-static"
+        "-o"
+        ${output_lib_path}
+        ${all_library_paths})
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "^(Clang|GNU)$")
     set(ar_script_path ${CMAKE_BINARY_DIR}/${ARG_NAME}.ar)
 
@@ -171,24 +176,25 @@ function(create_merged_static_lib output_target)
     if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
       set(ar_tool ${CMAKE_CXX_COMPILER_AR})
     endif()
-    
+
     set(BUNDLE_COMMAND ${ar_tool} -M < ${ar_script_path})
 
-    elseif(MSVC)
-      if(NOT CMAKE_LIBTOOL)
-        find_program(lib_tool lib HINTS "${CMAKE_CXX_COMPILER}/..")
-        if("${lib_tool}" STREQUAL "lib_tool-NOTFOUND")
-          message(FATAL_ERROR "Cannot locate libtool to bundle libraries")
-        endif()
-      else()
-        set(${lib_tool} ${CMAKE_LIBTOOL})
+  elseif(MSVC)
+    if(NOT CMAKE_LIBTOOL)
+      find_program(lib_tool lib HINTS "${CMAKE_CXX_COMPILER}/..")
+      if("${lib_tool}" STREQUAL "lib_tool-NOTFOUND")
+        message(FATAL_ERROR "Cannot locate libtool to bundle libraries")
       endif()
-      set(BUNDLE_TOOL ${lib_tool})
-      set(BUNDLE_COMMAND ${BUNDLE_TOOL} /NOLOGO /OUT:${output_lib_path} ${all_library_paths})
     else()
-      message(FATAL_ERROR "Unknown bundle scenario!")
+      set(${lib_tool} ${CMAKE_LIBTOOL})
+    endif()
+    set(BUNDLE_TOOL ${lib_tool})
+    set(BUNDLE_COMMAND ${BUNDLE_TOOL} /NOLOGO /OUT:${output_lib_path}
+                       ${all_library_paths})
+  else()
+    message(FATAL_ERROR "Unknown bundle scenario!")
   endif()
-  
+
   add_custom_command(COMMAND ${BUNDLE_COMMAND}
                      OUTPUT ${output_lib_path}
                      COMMENT "Bundling ${output_lib_path}"
@@ -196,13 +202,7 @@ function(create_merged_static_lib output_target)
 
   add_custom_target(${output_target} ALL DEPENDS ${output_lib_path})
   add_dependencies(${output_target} ${ARG_ROOT} ${ARG_TO_MERGE})
-
-  add_library(${output_target}_lib STATIC IMPORTED)
-  set_target_properties(${output_target}_lib
-        PROPERTIES
-            IMPORTED_LOCATION ${bundled_tgt_full_name}
-            INTERFACE_INCLUDE_DIRECTORIES $<TARGET_PROPERTY:${tgt_name},INTERFACE_INCLUDE_DIRECTORIES>)
-    add_dependencies(${bundled_tgt_name} ${tgt_name})
+  install(FILES ${output_lib_path} DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endfunction()
 
 # \arg OUTPUTS list to append built targets to

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -437,6 +437,8 @@ add_arrow_lib(arrow
               ${ARROW_SHARED_PRIVATE_LINK_LIBS}
               STATIC_LINK_LIBS
               ${ARROW_STATIC_LINK_LIBS}
+              BUNDLE_STATIC_LIBS
+              ${ARROW_BUNDLE_STATIC_LIBS}
               SHARED_INSTALL_INTERFACE_LIBS
               ${ARROW_SHARED_INSTALL_INTERFACE_LIBS}
               STATIC_INSTALL_INTERFACE_LIBS

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -416,6 +416,14 @@ endif()
 
 set(ARROW_ALL_SRCS ${ARROW_SRCS} ${ARROW_C_SRCS})
 
+if(ARROW_JEMALLOC)
+  set(ARROW_BUNDLE_STATIC_LIBS jemalloc::jemalloc)
+endif()
+
+if(ARROW_MIMALLOC)
+  set(ARROW_BUNDLE_STATIC_LIBS mimalloc::mimalloc)
+endif()
+
 add_arrow_lib(arrow
               CMAKE_PACKAGE_NAME
               Arrow

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -416,12 +416,16 @@ endif()
 
 set(ARROW_ALL_SRCS ${ARROW_SRCS} ${ARROW_C_SRCS})
 
+# We bundle some private static dependencies into the Arrow static library,
+# for convenience.
+set(ARROW_BUNDLE_STATIC_LIBS)
+
 if(ARROW_JEMALLOC)
-  set(ARROW_BUNDLE_STATIC_LIBS jemalloc::jemalloc)
+  list(APPEND ARROW_BUNDLE_STATIC_LIBS jemalloc::jemalloc)
 endif()
 
 if(ARROW_MIMALLOC)
-  set(ARROW_BUNDLE_STATIC_LIBS mimalloc::mimalloc)
+  list(APPEND ARROW_BUNDLE_STATIC_LIBS mimalloc::mimalloc)
 endif()
 
 add_arrow_lib(arrow


### PR DESCRIPTION
If something like this is not done, then `libarrow.a` cannot be used without obtaining the exact `libjemalloc_pic.a` that we build privately. 

Open questions I need help with

* Does this break any packaging builds?
* How does this affect the `INSTALL` CMake commands (and `ArrowTargets.cmake`, etc.)? Ideally we want people to be able to use Arrow as a dependency in other CMake projects and for things to Just Work 
* Test with ARROW_MIMALLOC=ON on Windows