### PR TITLE
ARROW-7603: [Packaging][RPM] Add workaround for LLVM on CentOS 8

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-8/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-8/Dockerfile
@@ -24,6 +24,13 @@ ARG DEBUG
 
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  # CentOS 8.0.1905 provides LLVM 7 but CentOS 8.1.1911 provides only
+  # LLVM 8. We should remove this when we support LLVM 8.
+  sed -i'' \
+    -e 's/^mirrorlist/#mirrorlist/' \
+    -e 's/^#baseurl/baseurl/' \
+    -e 's/$releasever/8.0.1905/g' \
+    /etc/yum.repos.d/*.repo && \
   dnf install -y ${quiet} epel-release && \
   dnf install --enablerepo=PowerTools -y ${quiet} \
     bison \


### PR DESCRIPTION
CentOS 8.0.1905 provides LLVM 7 but CentOS 8.1.1911 provides only LLVM
8. We should support LLVM 8 instead of using CentOS 8.0.1905. So this
is just a workaround. We should remove this workaround later.