### PR TITLE
PARQUET-1772: [C++] ParquetFileWriter: Data overwritten in append mode

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -103,13 +103,14 @@ class ArrowParquetWriterMixin : public ::testing::Test {
     auto pool = ::arrow::default_memory_pool();
 
     std::shared_ptr<Buffer> out;
-    auto sink = CreateOutputStream(pool);
 
     for (auto reader : readers) {
+      auto sink = CreateOutputStream(pool);
+
       ARROW_EXPECT_OK(WriteRecordBatchReader(reader, pool, sink));
+      // XXX the rest of the test may crash if this fails, since out will be nullptr
+      EXPECT_OK_AND_ASSIGN(out, sink->Finish());
     }
-    // XXX the rest of the test may crash if this fails, since out will be nullptr
-    EXPECT_OK_AND_ASSIGN(out, sink->Finish());
     return out;
   }
 

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -604,8 +604,10 @@ Status FileWriter::Open(const ::arrow::Schema& schema, ::arrow::MemoryPool* pool
   std::shared_ptr<const KeyValueMetadata> metadata;
   RETURN_NOT_OK(GetSchemaMetadata(schema, pool, *arrow_properties, &metadata));
 
-  std::unique_ptr<ParquetFileWriter> base_writer = ParquetFileWriter::Open(
-      std::move(sink), schema_node, std::move(properties), std::move(metadata));
+  std::unique_ptr<ParquetFileWriter> base_writer;
+  PARQUET_CATCH_NOT_OK(base_writer = ParquetFileWriter::Open(std::move(sink), schema_node,
+                                                             std::move(properties),
+                                                             std::move(metadata)));
 
   auto schema_ptr = std::make_shared<::arrow::Schema>(schema);
   return Make(pool, std::move(base_writer), std::move(schema_ptr),

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -342,7 +342,11 @@ class FileSerializer : public ParquetFileWriter::Contents {
         num_row_groups_(0),
         num_rows_(0),
         metadata_(FileMetaDataBuilder::Make(&schema_, properties_, key_value_metadata_)) {
-    StartFile();
+    if (sink_->Tell().ValueOrDie() == 0) {
+      StartFile();
+    } else {
+      throw ParquetException("Appending to file not implemented.");
+    }
   }
 
   void CloseEncryptedFile(FileEncryptionProperties* file_encryption_properties) {


### PR DESCRIPTION
Detect when the output stream provided is in append mode and raise an
exception.  This is done to prevent existing data being overwritten as
Parquet does not yet support appending data to existing files.