### PR TITLE
ARROW-7622: [Format] Mark Tensor and SparseTensor fields required

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -1233,7 +1233,7 @@ Status GetTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>* type
     }
   }
 
-  if (tensor->strides()->size() > 0) {
+  if (tensor->strides() && tensor->strides()->size() > 0) {
     for (int i = 0; i < ndim; ++i) {
       strides->push_back(tensor->strides()->Get(i));
     }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -869,6 +869,7 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
     const flatbuf::SparseTensor* sparse_tensor, const std::vector<int64_t>& shape,
     int64_t non_zero_length, io::RandomAccessFile* file) {
   auto* sparse_index = sparse_tensor->sparseIndex_as_SparseTensorIndexCOO();
+  const auto ndim = static_cast<int64_t>(shape.size());
 
   std::shared_ptr<DataType> indices_type;
   RETURN_NOT_OK(internal::GetSparseCOOIndexMetadata(sparse_index, &indices_type));
@@ -878,8 +879,7 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
   auto* indices_buffer = sparse_index->indicesBuffer();
   ARROW_ASSIGN_OR_RAISE(auto indices_data,
                         file->ReadAt(indices_buffer->offset(), indices_buffer->length()));
-  std::vector<int64_t> indices_shape(
-      {non_zero_length, static_cast<int64_t>(shape.size())});
+  std::vector<int64_t> indices_shape({non_zero_length, ndim});
   auto* indices_strides = sparse_index->indicesStrides();
   std::vector<int64_t> strides(2);
   if (indices_strides && indices_strides->size() > 0) {
@@ -889,9 +889,9 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
     strides[0] = indices_strides->Get(0);
     strides[1] = indices_strides->Get(1);
   } else {
-    // Column-major by default
-    strides[0] = indices_elsize;
-    strides[1] = indices_elsize * non_zero_length;
+    // Row-major by default
+    strides[0] = indices_elsize * ndim;
+    strides[1] = indices_elsize;
   }
   return std::make_shared<SparseCOOIndex>(
       std::make_shared<Tensor>(indices_type, indices_data, indices_shape, strides));

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -47,11 +47,12 @@
 #include "generated/Message_generated.h"
 #include "generated/Schema_generated.h"
 
-using arrow::internal::checked_pointer_cast;
-
 namespace arrow {
 
 namespace flatbuf = org::apache::arrow::flatbuf;
+
+using internal::checked_cast;
+using internal::checked_pointer_cast;
 
 namespace ipc {
 
@@ -871,6 +872,8 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
 
   std::shared_ptr<DataType> indices_type;
   RETURN_NOT_OK(internal::GetSparseCOOIndexMetadata(sparse_index, &indices_type));
+  const int64_t indices_elsize =
+      checked_cast<const IntegerType&>(*indices_type).bit_width() / 8;
 
   auto* indices_buffer = sparse_index->indicesBuffer();
   ARROW_ASSIGN_OR_RAISE(auto indices_data,
@@ -878,10 +881,18 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
   std::vector<int64_t> indices_shape(
       {non_zero_length, static_cast<int64_t>(shape.size())});
   auto* indices_strides = sparse_index->indicesStrides();
-  std::vector<int64_t> strides;
-  // Assume indices_strides is a 2-length array.
-  strides.push_back(indices_strides->Get(0));
-  strides.push_back(indices_strides->Get(1));
+  std::vector<int64_t> strides(2);
+  if (indices_strides && indices_strides->size() > 0) {
+    if (indices_strides->size() != 2) {
+      return Status::Invalid("Wrong size for indicesStrides in SparseCOOIndex");
+    }
+    strides[0] = indices_strides->Get(0);
+    strides[1] = indices_strides->Get(1);
+  } else {
+    // Column-major by default
+    strides[0] = indices_elsize;
+    strides[1] = indices_elsize * non_zero_length;
+  }
   return std::make_shared<SparseCOOIndex>(
       std::make_shared<Tensor>(indices_type, indices_data, indices_shape, strides));
 }

--- a/cpp/src/arrow/python/serialize.h
+++ b/cpp/src/arrow/python/serialize.h
@@ -103,14 +103,6 @@ Status SerializeObject(PyObject* context, PyObject* sequence, SerializedPyObject
 ARROW_PYTHON_EXPORT
 Status SerializeTensor(std::shared_ptr<Tensor> tensor, py::SerializedPyObject* out);
 
-/// \brief Serialize an Arrow SparseCOOTensor as a SerializedPyObject.
-/// \param[in] sparse_tensor SparseCOOTensor to be serialized
-/// \param[out] out The serialized representation
-/// \return Status
-ARROW_PYTHON_EXPORT
-Status SerializeSparseTensor(std::shared_ptr<SparseTensor> sparse_tensor,
-                             py::SerializedPyObject* out);
-
 /// \brief Write the Tensor metadata header to an OutputStream.
 /// \param[in] dtype DataType of the Tensor
 /// \param[in] shape The shape of the tensor

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -101,6 +101,9 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
       const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data);
 
   /// \brief Make SparseCOOIndex from sparse tensor's shape properties and data
+  ///
+  /// The indices_data should be in row-major (C-like) order.  If not,
+  /// use the raw properties constructor.
   static Result<std::shared_ptr<SparseCOOIndex>> Make(
       const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
       int64_t non_zero_length, std::shared_ptr<Buffer> indices_data);
@@ -110,10 +113,10 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
 
   /// \brief Return a tensor that has the coordinates of the non-zero values
   ///
-  /// The returned tensor is a Nx3 tensor where N is the number of non-zero
-  /// values.  Each 3-element column has the form `{row, column, index}`,
-  /// indicating that the value for the logical element at `{row, column}`
-  /// should be found at the given physical index.
+  /// The returned tensor is a N x D tensor where N is the number of non-zero
+  /// values and D is the number of dimensions in the logical data.
+  /// The column at index `i` is a D-tuple of coordinates indicating that the
+  /// logical value at those coordinates should be found at physical index `i`.
   const std::shared_ptr<Tensor>& indices() const { return coords_; }
 
   /// \brief Return a string representation of the sparse index
@@ -378,12 +381,16 @@ class ARROW_EXPORT SparseTensor {
   bool Equals(const SparseTensor& other) const;
 
   /// \brief Return dense representation of sparse tensor as tensor
+  ///
+  /// The returned Tensor has row-major order (C-like).
   Status ToTensor(std::shared_ptr<Tensor>* out) const {
     return ToTensor(default_memory_pool(), out);
   }
 
   /// \brief Return dense representation of sparse tensor as tensor
   /// using specified memory pool
+  ///
+  /// The returned Tensor has row-major order (C-like).
   Status ToTensor(MemoryPool* pool, std::shared_ptr<Tensor>* out) const;
 
  protected:

--- a/cpp/src/generated/SparseTensor_generated.h
+++ b/cpp/src/generated/SparseTensor_generated.h
@@ -139,7 +139,7 @@ struct SparseTensorIndexCOO FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     return GetPointer<const Int *>(VT_INDICESTYPE);
   }
   /// Non-negative byte offsets to advance one value cell along each dimension
-  /// If omitted, default to column-major order (Fortran-like).
+  /// If omitted, default to row-major order (C-like).
   const flatbuffers::Vector<int64_t> *indicesStrides() const {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_INDICESSTRIDES);
   }

--- a/cpp/src/generated/SparseTensor_generated.h
+++ b/cpp/src/generated/SparseTensor_generated.h
@@ -139,6 +139,7 @@ struct SparseTensorIndexCOO FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     return GetPointer<const Int *>(VT_INDICESTYPE);
   }
   /// Non-negative byte offsets to advance one value cell along each dimension
+  /// If omitted, default to column-major order (Fortran-like).
   const flatbuffers::Vector<int64_t> *indicesStrides() const {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_INDICESSTRIDES);
   }
@@ -148,11 +149,11 @@ struct SparseTensorIndexCOO FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
-           VerifyOffset(verifier, VT_INDICESTYPE) &&
+           VerifyOffsetRequired(verifier, VT_INDICESTYPE) &&
            verifier.VerifyTable(indicesType()) &&
            VerifyOffset(verifier, VT_INDICESSTRIDES) &&
            verifier.VerifyVector(indicesStrides()) &&
-           VerifyField<Buffer>(verifier, VT_INDICESBUFFER) &&
+           VerifyFieldRequired<Buffer>(verifier, VT_INDICESBUFFER) &&
            verifier.EndTable();
   }
 };
@@ -177,6 +178,8 @@ struct SparseTensorIndexCOOBuilder {
   flatbuffers::Offset<SparseTensorIndexCOO> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<SparseTensorIndexCOO>(end);
+    fbb_.Required(o, SparseTensorIndexCOO::VT_INDICESTYPE);
+    fbb_.Required(o, SparseTensorIndexCOO::VT_INDICESBUFFER);
     return o;
   }
 };
@@ -267,12 +270,12 @@ struct SparseMatrixIndexCSX FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<int16_t>(verifier, VT_COMPRESSEDAXIS) &&
-           VerifyOffset(verifier, VT_INDPTRTYPE) &&
+           VerifyOffsetRequired(verifier, VT_INDPTRTYPE) &&
            verifier.VerifyTable(indptrType()) &&
-           VerifyField<Buffer>(verifier, VT_INDPTRBUFFER) &&
-           VerifyOffset(verifier, VT_INDICESTYPE) &&
+           VerifyFieldRequired<Buffer>(verifier, VT_INDPTRBUFFER) &&
+           VerifyOffsetRequired(verifier, VT_INDICESTYPE) &&
            verifier.VerifyTable(indicesType()) &&
-           VerifyField<Buffer>(verifier, VT_INDICESBUFFER) &&
+           VerifyFieldRequired<Buffer>(verifier, VT_INDICESBUFFER) &&
            verifier.EndTable();
   }
 };
@@ -303,6 +306,10 @@ struct SparseMatrixIndexCSXBuilder {
   flatbuffers::Offset<SparseMatrixIndexCSX> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<SparseMatrixIndexCSX>(end);
+    fbb_.Required(o, SparseMatrixIndexCSX::VT_INDPTRTYPE);
+    fbb_.Required(o, SparseMatrixIndexCSX::VT_INDPTRBUFFER);
+    fbb_.Required(o, SparseMatrixIndexCSX::VT_INDICESTYPE);
+    fbb_.Required(o, SparseMatrixIndexCSX::VT_INDICESBUFFER);
     return o;
   }
 };
@@ -435,16 +442,16 @@ struct SparseTensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_TYPE_TYPE) &&
-           VerifyOffset(verifier, VT_TYPE) &&
+           VerifyOffsetRequired(verifier, VT_TYPE) &&
            VerifyType(verifier, type(), type_type()) &&
-           VerifyOffset(verifier, VT_SHAPE) &&
+           VerifyOffsetRequired(verifier, VT_SHAPE) &&
            verifier.VerifyVector(shape()) &&
            verifier.VerifyVectorOfTables(shape()) &&
            VerifyField<int64_t>(verifier, VT_NON_ZERO_LENGTH) &&
            VerifyField<uint8_t>(verifier, VT_SPARSEINDEX_TYPE) &&
-           VerifyOffset(verifier, VT_SPARSEINDEX) &&
+           VerifyOffsetRequired(verifier, VT_SPARSEINDEX) &&
            VerifySparseTensorIndex(verifier, sparseIndex(), sparseIndex_type()) &&
-           VerifyField<Buffer>(verifier, VT_DATA) &&
+           VerifyFieldRequired<Buffer>(verifier, VT_DATA) &&
            verifier.EndTable();
   }
 };
@@ -573,6 +580,10 @@ struct SparseTensorBuilder {
   flatbuffers::Offset<SparseTensor> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<SparseTensor>(end);
+    fbb_.Required(o, SparseTensor::VT_TYPE);
+    fbb_.Required(o, SparseTensor::VT_SHAPE);
+    fbb_.Required(o, SparseTensor::VT_SPARSEINDEX);
+    fbb_.Required(o, SparseTensor::VT_DATA);
     return o;
   }
 };

--- a/cpp/src/generated/Tensor_generated.h
+++ b/cpp/src/generated/Tensor_generated.h
@@ -169,6 +169,7 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<TensorDim>> *>(VT_SHAPE);
   }
   /// Non-negative byte offsets to advance one value cell along each dimension
+  /// If omitted, default to row-major order (C-like).
   const flatbuffers::Vector<int64_t> *strides() const {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_STRIDES);
   }
@@ -179,14 +180,14 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<uint8_t>(verifier, VT_TYPE_TYPE) &&
-           VerifyOffset(verifier, VT_TYPE) &&
+           VerifyOffsetRequired(verifier, VT_TYPE) &&
            VerifyType(verifier, type(), type_type()) &&
-           VerifyOffset(verifier, VT_SHAPE) &&
+           VerifyOffsetRequired(verifier, VT_SHAPE) &&
            verifier.VerifyVector(shape()) &&
            verifier.VerifyVectorOfTables(shape()) &&
            VerifyOffset(verifier, VT_STRIDES) &&
            verifier.VerifyVector(strides()) &&
-           VerifyField<Buffer>(verifier, VT_DATA) &&
+           VerifyFieldRequired<Buffer>(verifier, VT_DATA) &&
            verifier.EndTable();
   }
 };
@@ -301,6 +302,9 @@ struct TensorBuilder {
   flatbuffers::Offset<Tensor> Finish() {
     const auto end = fbb_.EndTable(start_);
     auto o = flatbuffers::Offset<Tensor>(end);
+    fbb_.Required(o, Tensor::VT_TYPE);
+    fbb_.Required(o, Tensor::VT_SHAPE);
+    fbb_.Required(o, Tensor::VT_DATA);
     return o;
   }
 };

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -55,13 +55,14 @@ namespace org.apache.arrow.flatbuf;
 /// Note that the indices are sorted in lexicographical order.
 table SparseTensorIndexCOO {
   /// The type of values in indicesBuffer
-  indicesType: Int;
+  indicesType: Int (required);
 
   /// Non-negative byte offsets to advance one value cell along each dimension
+  /// If omitted, default to column-major order (Fortran-like).
   indicesStrides: [long];
 
   /// The location and size of the indices matrix's data
-  indicesBuffer: Buffer;
+  indicesBuffer: Buffer (required);
 }
 
 enum SparseMatrixCompressedAxis: short { Row, Column }
@@ -72,7 +73,7 @@ table SparseMatrixIndexCSX {
   compressedAxis: SparseMatrixCompressedAxis;
 
   /// The type of values in indptrBuffer
-  indptrType: Int;
+  indptrType: Int (required);
 
   /// indptrBuffer stores the location and size of indptr array that
   /// represents the range of the rows.
@@ -96,10 +97,10 @@ table SparseMatrixIndexCSX {
   /// And the indptr of X is:
   ///
   ///   indptr(X) = [0, 2, 3, 5, 5, 8, 10].
-  indptrBuffer: Buffer;
+  indptrBuffer: Buffer (required);
 
   /// The type of values in indicesBuffer
-  indicesType: Int;
+  indicesType: Int (required);
 
   /// indicesBuffer stores the location and size of the array that
   /// contains the column indices of the corresponding non-zero values.
@@ -110,7 +111,7 @@ table SparseMatrixIndexCSX {
   ///   indices(X) = [1, 2, 2, 1, 3, 0, 2, 3, 1].
   ///
   /// Note that the indices are sorted in lexicographical order for each row.
-  indicesBuffer: Buffer;
+  indicesBuffer: Buffer (required);
 }
 
 union SparseTensorIndex {
@@ -122,19 +123,19 @@ table SparseTensor {
   /// The type of data contained in a value cell.
   /// Currently only fixed-width value types are supported,
   /// no strings or nested types.
-  type: Type;
+  type: Type (required);
 
   /// The dimensions of the tensor, optionally named.
-  shape: [TensorDim];
+  shape: [TensorDim] (required);
 
   /// The number of non-zero values in a sparse tensor.
   non_zero_length: long;
 
   /// Sparse tensor index
-  sparseIndex: SparseTensorIndex;
+  sparseIndex: SparseTensorIndex (required);
 
   /// The location and size of the tensor's data
-  data: Buffer;
+  data: Buffer (required);
 }
 
 root_type SparseTensor;

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -58,7 +58,7 @@ table SparseTensorIndexCOO {
   indicesType: Int (required);
 
   /// Non-negative byte offsets to advance one value cell along each dimension
-  /// If omitted, default to column-major order (Fortran-like).
+  /// If omitted, default to row-major order (C-like).
   indicesStrides: [long];
 
   /// The location and size of the indices matrix's data

--- a/format/Tensor.fbs
+++ b/format/Tensor.fbs
@@ -38,16 +38,17 @@ table TensorDim {
 table Tensor {
   /// The type of data contained in a value cell. Currently only fixed-width
   /// value types are supported, no strings or nested types
-  type: Type;
+  type: Type (required);
 
   /// The dimensions of the tensor, optionally named
-  shape: [TensorDim];
+  shape: [TensorDim] (required);
 
   /// Non-negative byte offsets to advance one value cell along each dimension
+  /// If omitted, default to row-major order (C-like).
   strides: [long];
 
   /// The location and size of the tensor's data
-  data: Buffer;
+  data: Buffer (required);
 }
 
 root_type Tensor;

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -169,7 +169,7 @@ shape: {0.shape}""".format(self)
                 c_dim_names.push_back(tobytes(x))
 
         # Enforce precondition for SparseCOOTensor indices
-        coords = np.require(coords, dtype='i8', requirements='F')
+        coords = np.require(coords, dtype='i8', requirements='C')
         if coords.ndim != 2:
             raise ValueError("Expected 2-dimensional array for "
                              "SparseCOOTensor indices")
@@ -200,7 +200,7 @@ shape: {0.shape}""".format(self)
                 c_dim_names.push_back(tobytes(x))
 
         coords = np.vstack([obj.row, obj.col]).T
-        coords = np.require(coords, dtype='i8', requirements='F')
+        coords = np.require(coords, dtype='i8', requirements='C')
 
         check_status(NdarraysToSparseCOOTensor(c_default_memory_pool(),
                      obj.data, coords, c_shape, c_dim_names,
@@ -227,7 +227,7 @@ shape: {0.shape}""".format(self)
             for x in dim_names:
                 c_dim_names.push_back(tobytes(x))
 
-        coords = np.require(obj.coords.T, dtype='i8', requirements='F')
+        coords = np.require(obj.coords.T, dtype='i8', requirements='C')
 
         check_status(NdarraysToSparseCOOTensor(c_default_memory_pool(),
                      obj.data, coords, c_shape, c_dim_names,

--- a/python/pyarrow/tests/test_sparse_tensor.py
+++ b/python/pyarrow/tests/test_sparse_tensor.py
@@ -91,7 +91,7 @@ def test_sparse_coo_tensor_base_object():
     sparse_tensor = None
     assert np.array_equal(expected_data, result_data)
     assert np.array_equal(expected_coords, result_coords)
-    assert result_coords.flags.f_contiguous  # column-major
+    assert result_coords.flags.c_contiguous  # row-major
 
 
 def test_sparse_csr_matrix_base_object():


### PR DESCRIPTION
Also make sparse COO indices row-major by default, both by consistency with tensors and because it packs related coordinates sequentially.