### PR TITLE
ARROW-7631: [C++][Gandiva] return zero if there is an overflow while downscaling a decimal

### DIFF
--- a/cpp/src/gandiva/function_registry_arithmetic.cc
+++ b/cpp/src/gandiva/function_registry_arithmetic.cc
@@ -56,6 +56,10 @@ std::vector<NativeFunction> GetArithmeticFunctionRegistry() {
       UNARY_SAFE_NULL_IF_NULL(castDECIMAL, {}, decimal128, decimal128),
       UNARY_UNSAFE_NULL_IF_NULL(castDECIMAL, {}, utf8, decimal128),
 
+      NativeFunction("castDECIMALNullOnOverflow", {}, DataTypeVector{decimal128()},
+                     decimal128(), kResultNullInternal,
+                     "castDECIMALNullOnOverflow_decimal128"),
+
       UNARY_SAFE_NULL_IF_NULL(castDATE, {}, int64, date64),
 
       // add/sub/multiply/divide/mod

--- a/cpp/src/gandiva/precompiled/decimal_ops.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops.cc
@@ -544,7 +544,10 @@ static BasicDecimal128 ModifyScaleAndPrecision(const BasicDecimalScalar128& x,
     return x.value().IncreaseScaleBy(delta_scale);
   } else {
     // Do not do any rounding, that is handled by the caller.
-    return x.value().ReduceScaleBy(-delta_scale, false);
+    auto result = x.value().ReduceScaleBy(-delta_scale, false);
+    DECIMAL_OVERFLOW_IF(BasicDecimal128::Abs(result) > GetMaxValue(out_precision),
+                        overflow);
+    return result;
   }
 }
 

--- a/cpp/src/gandiva/precompiled/decimal_ops.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops.cc
@@ -617,6 +617,10 @@ static BasicDecimal128 RoundWithPositiveScale(const BasicDecimalScalar128& x,
   DCHECK_GE(out_scale, 0);
 
   auto scaled = ModifyScaleAndPrecision(x, out_precision, out_scale, overflow);
+  if (*overflow) {
+    return 0;
+  }
+
   auto delta = ComputeRoundingDelta(x.value(), x.scale(), out_scale, round_type);
   if (delta == 0) {
     return scaled;

--- a/cpp/src/gandiva/precompiled/decimal_wrapper.cc
+++ b/cpp/src/gandiva/precompiled/decimal_wrapper.cc
@@ -228,15 +228,43 @@ void castDECIMAL_float32(float in, int32_t x_precision, int32_t x_scale,
   castDECIMAL_float64(in, x_precision, x_scale, out_high, out_low);
 }
 
-FORCE_INLINE
-void castDECIMAL_decimal128(int64_t x_high, uint64_t x_low, int32_t x_precision,
-                            int32_t x_scale, int32_t out_precision, int32_t out_scale,
-                            int64_t* out_high, int64_t* out_low) {
+boolean castDecimal_return_overflow(int64_t x_high, uint64_t x_low, int32_t x_precision,
+                                    int32_t x_scale, int32_t out_precision,
+                                    int32_t out_scale, int64_t* out_high,
+                                    int64_t* out_low) {
   gandiva::BasicDecimalScalar128 x({x_high, x_low}, x_precision, x_scale);
   bool overflow = false;
   auto out = gandiva::decimalops::Convert(x, out_precision, out_scale, &overflow);
   *out_high = out.high_bits();
   *out_low = out.low_bits();
+  return overflow;
+}
+
+FORCE_INLINE
+void castDECIMAL_decimal128(int64_t x_high, uint64_t x_low, int32_t x_precision,
+                            int32_t x_scale, int32_t out_precision, int32_t out_scale,
+                            int64_t* out_high, int64_t* out_low) {
+  castDecimal_return_overflow(x_high, x_low, x_precision, x_scale, out_precision,
+                              out_scale, out_high, out_low);
+}
+
+FORCE_INLINE
+void castDECIMALNullOnOverflow_decimal128(int64_t x_high, uint64_t x_low,
+                                          int32_t x_precision, int32_t x_scale,
+                                          boolean x_isvalid, bool* out_valid,
+                                          int32_t out_precision, int32_t out_scale,
+                                          int64_t* out_high, int64_t* out_low) {
+  *out_valid = true;
+
+  if (!x_isvalid) {
+    *out_valid = false;
+    return;
+  }
+
+  if (castDecimal_return_overflow(x_high, x_low, x_precision, x_scale, out_precision,
+                                  out_scale, out_high, out_low)) {
+    *out_valid = false;
+  }
 }
 
 FORCE_INLINE

--- a/cpp/src/gandiva/precompiled/decimal_wrapper.cc
+++ b/cpp/src/gandiva/precompiled/decimal_wrapper.cc
@@ -228,6 +228,7 @@ void castDECIMAL_float32(float in, int32_t x_precision, int32_t x_scale,
   castDECIMAL_float64(in, x_precision, x_scale, out_high, out_low);
 }
 
+FORCE_INLINE
 boolean castDecimal_return_overflow(int64_t x_high, uint64_t x_low, int32_t x_precision,
                                     int32_t x_scale, int32_t out_precision,
                                     int32_t out_scale, int64_t* out_high,

--- a/cpp/src/gandiva/precompiled/decimal_wrapper.cc
+++ b/cpp/src/gandiva/precompiled/decimal_wrapper.cc
@@ -229,10 +229,9 @@ void castDECIMAL_float32(float in, int32_t x_precision, int32_t x_scale,
 }
 
 FORCE_INLINE
-boolean castDecimal_return_overflow(int64_t x_high, uint64_t x_low, int32_t x_precision,
-                                    int32_t x_scale, int32_t out_precision,
-                                    int32_t out_scale, int64_t* out_high,
-                                    int64_t* out_low) {
+boolean castDecimal_internal(int64_t x_high, uint64_t x_low, int32_t x_precision,
+                             int32_t x_scale, int32_t out_precision, int32_t out_scale,
+                             int64_t* out_high, int64_t* out_low) {
   gandiva::BasicDecimalScalar128 x({x_high, x_low}, x_precision, x_scale);
   bool overflow = false;
   auto out = gandiva::decimalops::Convert(x, out_precision, out_scale, &overflow);
@@ -245,8 +244,8 @@ FORCE_INLINE
 void castDECIMAL_decimal128(int64_t x_high, uint64_t x_low, int32_t x_precision,
                             int32_t x_scale, int32_t out_precision, int32_t out_scale,
                             int64_t* out_high, int64_t* out_low) {
-  castDecimal_return_overflow(x_high, x_low, x_precision, x_scale, out_precision,
-                              out_scale, out_high, out_low);
+  castDecimal_internal(x_high, x_low, x_precision, x_scale, out_precision, out_scale,
+                       out_high, out_low);
 }
 
 FORCE_INLINE
@@ -262,8 +261,8 @@ void castDECIMALNullOnOverflow_decimal128(int64_t x_high, uint64_t x_low,
     return;
   }
 
-  if (castDecimal_return_overflow(x_high, x_low, x_precision, x_scale, out_precision,
-                                  out_scale, out_high, out_low)) {
+  if (castDecimal_internal(x_high, x_low, x_precision, x_scale, out_precision, out_scale,
+                           out_high, out_low)) {
     *out_valid = false;
   }
 }


### PR DESCRIPTION
  - also add castDecimalNullOnOverflow function