### PR TITLE
ARROW-6801: [Rust] Arrow source release tarball is missing benchmarks

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -25,6 +25,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "arrow" ]
 include = [
+    "benches/*.rs",
     "src/**/*.rs",
     "Cargo.toml",
 ]

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -25,6 +25,7 @@ authors = ["Apache Arrow <dev@arrow.apache.org>"]
 license = "Apache-2.0"
 keywords = [ "arrow", "query", "sql" ]
 include = [
+    "benches/*.rs",
     "src/**/*.rs",
     "Cargo.toml",
 ]
@@ -59,4 +60,3 @@ tempdir = "0.3.7"
 [[bench]]
 name = "aggregate_query_sql"
 harness = false
-


### PR DESCRIPTION
The Jira is vague about how a release script fails without benchmarks included, so I have no idea how to test if this is fixes the reported issue, but it's listed as a blocker for 0.16 so I figured I'd try. 

cc @andygrove @kszucs 