### PR TITLE
ARROW-7596: [Python] Only permit zero-copy DataFrame block construction when split_blocks=True

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.h
+++ b/cpp/src/arrow/python/arrow_to_pandas.h
@@ -67,6 +67,11 @@ struct PandasOptions {
   /// memory-constrained situation.
   bool split_blocks = false;
 
+  /// \brief If true, allow non-writable zero-copy views to be created for
+  /// single column blocks. This option is also used to provide zero copy for
+  /// Series data
+  bool allow_zero_copy_blocks = false;
+
   /// \brief If true, attempt to deallocate buffers in passed Arrow object if
   /// it is the only remaining shared_ptr copy of it. See ARROW-3789 for
   /// original context for this feature. Only currently implemented for Table

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3041,7 +3041,14 @@ def test_array_uses_memory_pool():
 def test_singleton_blocks_zero_copy():
     # Part of ARROW-3789
     t = pa.table([pa.array(np.arange(1000, dtype=np.int64))], ['f0'])
-    _check_to_pandas_memory_unchanged(t)
+
+    # Zero copy if split_blocks=True
+    _check_to_pandas_memory_unchanged(t, split_blocks=True)
+
+    prior_allocation = pa.total_allocated_bytes()
+    result = t.to_pandas()
+    assert result['f0'].values.flags.writeable
+    assert pa.total_allocated_bytes() > prior_allocation
 
 
 def _check_to_pandas_memory_unchanged(obj, **kwargs):


### PR DESCRIPTION
We found that some code in the wild assumed that the arrays inside the DataFrame resulting from `to_pandas` are always writable, i.e. the result of new memory being allocated. So we only apply the zero copy optimizations for the split blocks case (which presumably will be used by memory-conscious users who will be okay with this)