### PR TITLE
ARROW-7620: [Rust] Remove call to flatc

### DIFF
--- a/ci/scripts/rust_build.sh
+++ b/ci/scripts/rust_build.sh
@@ -36,11 +36,17 @@ pushd ${source_dir}
 
 # flatbuffer codegen
 echo "Generating IPC"
+pwd
+
+echo "generating from fbs files:"
+ls ../format/*.fbs
+
 flatc --rust -o arrow/src/ipc/gen/ ../format/*.fbs
 
 # work around some bugs in flatbuffers
-find arrow/src/ipc/gen/ -name "*.rs"
-find arrow/src/ipc/gen/ -name "*_generated.rs" -exec sed -i 's/type__type/type_type/g' {} \; 2>/dev/null
+find arrow/src/ipc/gen/
+
+#find arrow/src/ipc/gen/ -name "*_generated.rs" -exec sed -i 's/type__type/type_type/g' {} \; 2>/dev/null
 
 # build entire project
 RUSTFLAGS="-D warnings" cargo build --all-targets

--- a/ci/scripts/rust_build.sh
+++ b/ci/scripts/rust_build.sh
@@ -34,13 +34,6 @@ mkdir -p ${build_dir}
 
 pushd ${source_dir}
 
-# flatbuffer codegen
-echo "Generating IPC"
-flatc --rust -o arrow/src/ipc/gen/ ../format/*.fbs
-
-# work around some bugs in flatbuffers
-#find arrow/src/ipc/gen/ -name "*_generated.rs" -exec sed -i 's/type__type/type_type/g' {} \;
-
 # build entire project
 RUSTFLAGS="-D warnings" cargo build --all-targets
 

--- a/ci/scripts/rust_build.sh
+++ b/ci/scripts/rust_build.sh
@@ -36,17 +36,10 @@ pushd ${source_dir}
 
 # flatbuffer codegen
 echo "Generating IPC"
-pwd
-
-echo "generating from fbs files:"
-ls ../format/*.fbs
-
 flatc --rust -o arrow/src/ipc/gen/ ../format/*.fbs
 
 # work around some bugs in flatbuffers
-find arrow/src/ipc/gen/
-
-#find arrow/src/ipc/gen/ -name "*_generated.rs" -exec sed -i 's/type__type/type_type/g' {} \; 2>/dev/null
+#find arrow/src/ipc/gen/ -name "*_generated.rs" -exec sed -i 's/type__type/type_type/g' {} \;
 
 # build entire project
 RUSTFLAGS="-D warnings" cargo build --all-targets

--- a/ci/scripts/rust_build.sh
+++ b/ci/scripts/rust_build.sh
@@ -39,7 +39,8 @@ echo "Generating IPC"
 flatc --rust -o arrow/src/ipc/gen/ ../format/*.fbs
 
 # work around some bugs in flatbuffers
-find arrow/src/ipc/gen/ -name "*_generated.rs" -exec sed -i 's/type__type/type_type/g' {} \;
+find arrow/src/ipc/gen/ -name "*.rs"
+find arrow/src/ipc/gen/ -name "*_generated.rs" -exec sed -i 's/type__type/type_type/g' {} \; 2>/dev/null
 
 # build entire project
 RUSTFLAGS="-D warnings" cargo build --all-targets


### PR DESCRIPTION
The Rust build was calling `rustc` to generate code from the flatbuffers files, and this recently stopped working on Windows (about a week ago) and I'm not sure why.

This was a work-in-progress anyway that was never completed. To generate working code we would have to follow the steps in https://github.com/apache/arrow/blob/master/rust/arrow/regen.sh to add the necessary imports to the generated code.

I suggest we just remove this for now since the generated code doesn't have any impact on the project (the files had the `_generated` suffix and were not referenced in any `mod.rs`).
