### PR TITLE
ARROW-7644: [Doc][Install] Add vcpkg installation instructions

### DIFF
--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -99,7 +99,7 @@ The final output is located under ``docs/_build/html``.
 Building with Vcpkg
 -------------------
 
-You can download and install arrow using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+You can download and install arrow using the `vcpkg <https://github.com/Microsoft/vcpkg>`_ dependency manager:
 
 .. code-block:: shell
 
@@ -109,4 +109,4 @@ You can download and install arrow using the [vcpkg](https://github.com/Microsof
     ./vcpkg integrate install
     ./vcpkg install arrow
 
-The arrow port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The arrow port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`_ on the vcpkg repository.

--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -93,3 +93,20 @@ You can use Docker to build the documentation:
   make -f Makefile.docker docs
 
 The final output is located under ``docs/_build/html``.
+
+.. _building-vcpkg:
+
+Building with Vcpkg
+-------------------
+
+You can download and install arrow using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+.. code-block:: shell
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install arrow
+
+The arrow port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.


### PR DESCRIPTION
arrow is available as a port in vcpkg, a C++ library manager that simplifies installation for arrow and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build arrow, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/arrow/portfile.cmake). We try to keep the library maintained as close as possible to the original library.