### PR TITLE
ARROW-7775: Don't let safe code arbitrarily transmute readers and writers

### DIFF
--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -65,7 +65,7 @@ impl RecordBatch {
             }
             if columns[i].data_type() != schema.field(i).data_type() {
                 return Err(ArrowError::InvalidArgumentError(format!(
-                    "column types must match schema types, expected {:?} but found {:?} at column index {}", 
+                    "column types must match schema types, expected {:?} but found {:?} at column index {}",
                     schema.field(i).data_type(),
                     columns[i].data_type(),
                     i)));
@@ -129,9 +129,6 @@ impl Into<StructArray> for RecordBatch {
             .into()
     }
 }
-
-unsafe impl Send for RecordBatch {}
-unsafe impl Sync for RecordBatch {}
 
 /// Definition of record batch reader.
 pub trait RecordBatchReader {

--- a/rust/parquet/src/column/reader.rs
+++ b/rust/parquet/src/column/reader.rs
@@ -20,7 +20,6 @@
 use std::{
     cmp::{max, min},
     collections::HashMap,
-    mem,
 };
 
 use super::page::{Page, PageReader};
@@ -90,21 +89,11 @@ pub fn get_column_reader(
 /// Gets a typed column reader for the specific type `T`, by "up-casting" `col_reader` of
 /// non-generic type to a generic column reader type `ColumnReaderImpl`.
 ///
-/// NOTE: the caller MUST guarantee that the actual enum value for `col_reader` matches
-/// the type `T`. Otherwise, disastrous consequence could happen.
+/// Panics if actual enum value for `col_reader` does not match the type `T`.
 pub fn get_typed_column_reader<T: DataType>(
     col_reader: ColumnReader,
 ) -> ColumnReaderImpl<T> {
-    match col_reader {
-        ColumnReader::BoolColumnReader(r) => unsafe { mem::transmute(r) },
-        ColumnReader::Int32ColumnReader(r) => unsafe { mem::transmute(r) },
-        ColumnReader::Int64ColumnReader(r) => unsafe { mem::transmute(r) },
-        ColumnReader::Int96ColumnReader(r) => unsafe { mem::transmute(r) },
-        ColumnReader::FloatColumnReader(r) => unsafe { mem::transmute(r) },
-        ColumnReader::DoubleColumnReader(r) => unsafe { mem::transmute(r) },
-        ColumnReader::ByteArrayColumnReader(r) => unsafe { mem::transmute(r) },
-        ColumnReader::FixedLenByteArrayColumnReader(r) => unsafe { mem::transmute(r) },
-    }
+    T::get_column_reader(col_reader).expect("Column type mismatch")
 }
 
 /// Typed value reader for a particular primitive column.

--- a/rust/parquet/src/column/reader.rs
+++ b/rust/parquet/src/column/reader.rs
@@ -93,7 +93,12 @@ pub fn get_column_reader(
 pub fn get_typed_column_reader<T: DataType>(
     col_reader: ColumnReader,
 ) -> ColumnReaderImpl<T> {
-    T::get_column_reader(col_reader).expect("Column type mismatch")
+    T::get_column_reader(col_reader).unwrap_or_else(|| {
+        panic!(
+            "Failed to convert column reader into a typed column reader for `{}` typ",
+            T::get_physical_type()
+        )
+    })
 }
 
 /// Typed value reader for a particular primitive column.

--- a/rust/parquet/src/column/reader.rs
+++ b/rust/parquet/src/column/reader.rs
@@ -95,7 +95,7 @@ pub fn get_typed_column_reader<T: DataType>(
 ) -> ColumnReaderImpl<T> {
     T::get_column_reader(col_reader).unwrap_or_else(|| {
         panic!(
-            "Failed to convert column reader into a typed column reader for `{}` typ",
+            "Failed to convert column reader into a typed column reader for `{}` type",
             T::get_physical_type()
         )
     })

--- a/rust/parquet/src/column/writer.rs
+++ b/rust/parquet/src/column/writer.rs
@@ -17,7 +17,7 @@
 
 //! Contains column writer API.
 
-use std::{cmp, collections::VecDeque, mem, rc::Rc};
+use std::{cmp, collections::VecDeque, rc::Rc};
 
 use crate::basic::{Compression, Encoding, PageType, Type};
 use crate::column::page::{CompressedPage, Page, PageWriteSpec, PageWriter};
@@ -98,57 +98,25 @@ pub fn get_column_writer(
 /// Gets a typed column writer for the specific type `T`, by "up-casting" `col_writer` of
 /// non-generic type to a generic column writer type `ColumnWriterImpl`.
 ///
-/// NOTE: the caller MUST guarantee that the actual enum value for `col_writer` matches
-/// the type `T`. Otherwise, disastrous consequence could happen.
+/// Panics if actual enum value for `col_writer` does not match the type `T`.
 pub fn get_typed_column_writer<T: DataType>(
     col_writer: ColumnWriter,
 ) -> ColumnWriterImpl<T> {
-    match col_writer {
-        ColumnWriter::BoolColumnWriter(r) => unsafe { mem::transmute(r) },
-        ColumnWriter::Int32ColumnWriter(r) => unsafe { mem::transmute(r) },
-        ColumnWriter::Int64ColumnWriter(r) => unsafe { mem::transmute(r) },
-        ColumnWriter::Int96ColumnWriter(r) => unsafe { mem::transmute(r) },
-        ColumnWriter::FloatColumnWriter(r) => unsafe { mem::transmute(r) },
-        ColumnWriter::DoubleColumnWriter(r) => unsafe { mem::transmute(r) },
-        ColumnWriter::ByteArrayColumnWriter(r) => unsafe { mem::transmute(r) },
-        ColumnWriter::FixedLenByteArrayColumnWriter(r) => unsafe { mem::transmute(r) },
-    }
+    T::get_column_writer(col_writer).expect("Column type mismatch")
 }
 
 /// Similar to `get_typed_column_writer` but returns a reference.
 pub fn get_typed_column_writer_ref<T: DataType>(
     col_writer: &ColumnWriter,
 ) -> &ColumnWriterImpl<T> {
-    match col_writer {
-        ColumnWriter::BoolColumnWriter(ref r) => unsafe { mem::transmute(r) },
-        ColumnWriter::Int32ColumnWriter(ref r) => unsafe { mem::transmute(r) },
-        ColumnWriter::Int64ColumnWriter(ref r) => unsafe { mem::transmute(r) },
-        ColumnWriter::Int96ColumnWriter(ref r) => unsafe { mem::transmute(r) },
-        ColumnWriter::FloatColumnWriter(ref r) => unsafe { mem::transmute(r) },
-        ColumnWriter::DoubleColumnWriter(ref r) => unsafe { mem::transmute(r) },
-        ColumnWriter::ByteArrayColumnWriter(ref r) => unsafe { mem::transmute(r) },
-        ColumnWriter::FixedLenByteArrayColumnWriter(ref r) => unsafe {
-            mem::transmute(r)
-        },
-    }
+    T::get_column_writer_ref(col_writer).expect("Column type mismatch")
 }
 
 /// Similar to `get_typed_column_writer` but returns a reference.
 pub fn get_typed_column_writer_mut<T: DataType>(
     col_writer: &mut ColumnWriter,
 ) -> &mut ColumnWriterImpl<T> {
-    match col_writer {
-        ColumnWriter::BoolColumnWriter(ref mut r) => unsafe { mem::transmute(r) },
-        ColumnWriter::Int32ColumnWriter(ref mut r) => unsafe { mem::transmute(r) },
-        ColumnWriter::Int64ColumnWriter(ref mut r) => unsafe { mem::transmute(r) },
-        ColumnWriter::Int96ColumnWriter(ref mut r) => unsafe { mem::transmute(r) },
-        ColumnWriter::FloatColumnWriter(ref mut r) => unsafe { mem::transmute(r) },
-        ColumnWriter::DoubleColumnWriter(ref mut r) => unsafe { mem::transmute(r) },
-        ColumnWriter::ByteArrayColumnWriter(ref mut r) => unsafe { mem::transmute(r) },
-        ColumnWriter::FixedLenByteArrayColumnWriter(ref mut r) => unsafe {
-            mem::transmute(r)
-        },
-    }
+    T::get_column_writer_mut(col_writer).expect("Column type mismatch")
 }
 
 /// Typed column writer for a primitive column.

--- a/rust/parquet/src/column/writer.rs
+++ b/rust/parquet/src/column/writer.rs
@@ -104,7 +104,7 @@ pub fn get_typed_column_writer<T: DataType>(
 ) -> ColumnWriterImpl<T> {
     T::get_column_writer(col_writer).unwrap_or_else(|| {
         panic!(
-            "Failed to convert column writer into a typed column writer for `{}` typ",
+            "Failed to convert column writer into a typed column writer for `{}` type",
             T::get_physical_type()
         )
     })
@@ -116,7 +116,7 @@ pub fn get_typed_column_writer_ref<T: DataType>(
 ) -> &ColumnWriterImpl<T> {
     T::get_column_writer_ref(col_writer).unwrap_or_else(|| {
         panic!(
-            "Failed to convert column writer into a typed column writer for `{}` typ",
+            "Failed to convert column writer into a typed column writer for `{}` type",
             T::get_physical_type()
         )
     })
@@ -128,7 +128,7 @@ pub fn get_typed_column_writer_mut<T: DataType>(
 ) -> &mut ColumnWriterImpl<T> {
     T::get_column_writer_mut(col_writer).unwrap_or_else(|| {
         panic!(
-            "Failed to convert column writer into a typed column writer for `{}` typ",
+            "Failed to convert column writer into a typed column writer for `{}` type",
             T::get_physical_type()
         )
     })

--- a/rust/parquet/src/column/writer.rs
+++ b/rust/parquet/src/column/writer.rs
@@ -102,21 +102,36 @@ pub fn get_column_writer(
 pub fn get_typed_column_writer<T: DataType>(
     col_writer: ColumnWriter,
 ) -> ColumnWriterImpl<T> {
-    T::get_column_writer(col_writer).expect("Column type mismatch")
+    T::get_column_writer(col_writer).unwrap_or_else(|| {
+        panic!(
+            "Failed to convert column writer into a typed column writer for `{}` typ",
+            T::get_physical_type()
+        )
+    })
 }
 
 /// Similar to `get_typed_column_writer` but returns a reference.
 pub fn get_typed_column_writer_ref<T: DataType>(
     col_writer: &ColumnWriter,
 ) -> &ColumnWriterImpl<T> {
-    T::get_column_writer_ref(col_writer).expect("Column type mismatch")
+    T::get_column_writer_ref(col_writer).unwrap_or_else(|| {
+        panic!(
+            "Failed to convert column writer into a typed column writer for `{}` typ",
+            T::get_physical_type()
+        )
+    })
 }
 
 /// Similar to `get_typed_column_writer` but returns a reference.
 pub fn get_typed_column_writer_mut<T: DataType>(
     col_writer: &mut ColumnWriter,
 ) -> &mut ColumnWriterImpl<T> {
-    T::get_column_writer_mut(col_writer).expect("Column type mismatch")
+    T::get_column_writer_mut(col_writer).unwrap_or_else(|| {
+        panic!(
+            "Failed to convert column writer into a typed column writer for `{}` typ",
+            T::get_physical_type()
+        )
+    })
 }
 
 /// Typed column writer for a primitive column.


### PR DESCRIPTION
This code were quite clearly unsafe (which seems to be known, judging
from the comment about it). As the functions appeared to callable
indirectly from other public functions I changed these to just panic
instead to keep the API.