### PR TITLE
ARROW-7648: [C++] Sanitize local paths on Windows

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -223,6 +223,22 @@ TEST(PathUtil, AncestorsFromBasePath) {
             V({"foo/bar", "foo/bar/baz"}));
 }
 
+TEST(PathUtil, ToBackslashes) {
+  ASSERT_EQ(ToBackslashes("foo/bar"), "foo\\bar");
+  ASSERT_EQ(ToBackslashes("//foo/bar/"), "\\\\foo\\bar\\");
+  ASSERT_EQ(ToBackslashes("foo\\bar"), "foo\\bar");
+}
+
+TEST(PathUtil, ToSlashes) {
+#ifdef _WIN32
+  ASSERT_EQ(ToSlashes("foo\\bar"), "foo/bar");
+  ASSERT_EQ(ToSlashes("\\\\foo\\bar\\"), "//foo/bar/");
+#else
+  ASSERT_EQ(ToSlashes("foo\\bar"), "foo\\bar");
+  ASSERT_EQ(ToSlashes("\\\\foo\\bar\\"), "\\\\foo\\bar\\");
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // Generic MockFileSystem tests
 

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -208,6 +208,28 @@ std::vector<std::string> AncestorsFromBasePath(util::string_view base_path,
   return ancestry;
 }
 
+std::string ToBackslashes(util::string_view v) {
+  std::string s(v);
+  for (auto& c : s) {
+    if (c == '/') {
+      c = '\\';
+    }
+  }
+  return s;
+}
+
+std::string ToSlashes(util::string_view v) {
+  std::string s(v);
+#ifdef _WIN32
+  for (auto& c : s) {
+    if (c == '\\') {
+      c = '/';
+    }
+  }
+#endif
+  return s;
+}
+
 }  // namespace internal
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -105,6 +105,15 @@ std::string JoinAbstractPath(const StringRange& range) {
   return JoinAbstractPath(range.begin(), range.end());
 }
 
+/// Convert slashes to backslashes, on all platforms.  Mostly useful for testing.
+ARROW_EXPORT
+std::string ToBackslashes(util::string_view s);
+
+/// Ensure a local path is abstract, by converting backslashes to regular slashes
+/// on Windows.  Return the path unchanged on other systems.
+ARROW_EXPORT
+std::string ToSlashes(util::string_view s);
+
 }  // namespace internal
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -78,6 +78,13 @@ Uri::Uri() : impl_(new Impl) {}
 
 Uri::~Uri() {}
 
+Uri::Uri(Uri&& u) : impl_(std::move(u.impl_)) {}
+
+Uri& Uri::operator=(Uri&& u) {
+  impl_ = std::move(u.impl_);
+  return *this;
+}
+
 std::string Uri::scheme() const { return TextRangeToString(impl_->uri_.scheme); }
 
 std::string Uri::host() const { return TextRangeToString(impl_->uri_.hostText); }

--- a/cpp/src/arrow/util/uri.h
+++ b/cpp/src/arrow/util/uri.h
@@ -34,6 +34,8 @@ class ARROW_EXPORT Uri {
  public:
   Uri();
   ~Uri();
+  Uri(Uri&&);
+  Uri& operator=(Uri&&);
 
   // XXX Should we use util::string_view instead?  These functions are
   // not performance-critical.


### PR DESCRIPTION
FileSystemFromUri() now tries to convert backslashes to slashes if the original URI fails to parse.