### PR TITLE
ARROW-7640: [C++][Dataset][Parquet] Detect missing compression support

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -230,6 +230,8 @@ Result<bool> ParquetFileFormat::IsSupported(const FileSource& source) const {
   try {
     ARROW_ASSIGN_OR_RAISE(auto input, source.Open());
     auto reader = parquet::ParquetFileReader::Open(input);
+    auto metadata = reader->metadata();
+    return metadata != nullptr && metadata->can_decompress();
   } catch (const ::parquet::ParquetInvalidOrCorruptedFileException& e) {
     ARROW_UNUSED(e);
     return false;

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -698,6 +698,8 @@ Status StructReader::NextBatch(int64_t records_to_read,
 
 Status GetReader(const SchemaField& field, const std::shared_ptr<ReaderContext>& ctx,
                  std::unique_ptr<ColumnReaderImpl>* out) {
+  BEGIN_PARQUET_CATCH_EXCEPTIONS
+
   auto type_id = field.field->type()->id();
   if (field.children.size() == 0) {
     std::unique_ptr<FileColumnIterator> input(
@@ -754,6 +756,8 @@ Status GetReader(const SchemaField& field, const std::shared_ptr<ReaderContext>&
     return Status::Invalid("Unsupported nested type: ", field.field->ToString());
   }
   return Status::OK();
+
+  END_PARQUET_CATCH_EXCEPTIONS
 }
 
 Status FileReaderImpl::GetRecordBatchReader(const std::vector<int>& row_group_indices,

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -144,7 +144,12 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   std::shared_ptr<schema::ColumnPath> path_in_schema() const;
   bool is_stats_set() const;
   std::shared_ptr<Statistics> statistics() const;
+
   Compression::type compression() const;
+  // Indicate if the ColumnChunk compression is supported by the current
+  // compiled parquet library.
+  bool can_decompress() const;
+
   const std::vector<Encoding::type>& encodings() const;
   bool has_dictionary_page() const;
   int64_t dictionary_page_offset() const;
@@ -181,6 +186,8 @@ class PARQUET_EXPORT RowGroupMetaData {
   int64_t total_byte_size() const;
   // Return const-pointer to make it clear that this object is not to be copied
   const SchemaDescriptor* schema() const;
+  // Indicate if all of the RowGroup's ColumnChunks can be decompressed.
+  bool can_decompress() const;
 
   std::unique_ptr<ColumnChunkMetaData> ColumnChunk(int i) const;
 
@@ -224,6 +231,8 @@ class PARQUET_EXPORT FileMetaData {
   int num_schema_elements() const;
   std::unique_ptr<RowGroupMetaData> RowGroup(int i) const;
   const ApplicationVersion& writer_version() const;
+  // Indicate if all of the FileMetadata's RowGroups can be decompressed.
+  bool can_decompress() const;
 
   bool is_encryption_algorithm_set() const;
   EncryptionAlgorithm encryption_algorithm() const;


### PR DESCRIPTION
The following patch ensures that reading a dataset with parquet files where the compression code is not compiled in does not crash. It also skips such file, instead of failing mid-scan. If any of the file's ColumnChunk compression is not supported, the whole file is ignored.

Also fix an uncaught exception in parquet::arrow::reader::GetReader.