### PR TITLE
ARROW-7666: [Packaging][deb] Always use Ninja to reduce build time

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -21,15 +21,10 @@ override_dh_auto_configure:
 	  ARROW_CUDA=OFF;					\
 	  ARROW_PLASMA=OFF;					\
 	fi;							\
-	if dpkg -l libprotobuf-dev > /dev/null 2>&1; then	\
-	  cpp_build_system=cmake+ninja;				\
-	else							\
-	  cpp_build_system=cmake;				\
-	fi;							\
 	dh_auto_configure					\
 	  --sourcedirectory=cpp					\
 	  --builddirectory=cpp_build				\
-	  --buildsystem=$${cpp_build_system}			\
+	  --buildsystem=cmake+ninja				\
 	  --							\
 	  -DARROW_CUDA=$${ARROW_CUDA}				\
 	  -DARROW_FLIGHT=ON					\


### PR DESCRIPTION
debhelper 11.2 or later supports `cmake+ninja`: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=895044
We require debhelper 12 or later in `debian/control`.
So we can always use `cmake+ninja`.