### PR TITLE
ARROW-7681: [Rust] Explicitly seeking kills BufRead performance.

### DIFF
--- a/rust/parquet/src/lib.rs
+++ b/rust/parquet/src/lib.rs
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![feature(bufreader_seek_relative)]
+#![feature(seek_convenience)]
 #![feature(specialization)]
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]

--- a/rust/parquet/src/util/io.rs
+++ b/rust/parquet/src/util/io.rs
@@ -47,8 +47,7 @@ pub struct FileSource<R: ParquetReader> {
 impl<R: ParquetReader> FileSource<R> {
     /// Creates new file reader with start and length from a file handle
     pub fn new(fd: &R, start: u64, length: usize) -> Self {
-        let mut reader = BufReader::new(fd.try_clone().unwrap());
-        reader.seek(SeekFrom::Start(start as u64)).unwrap();
+        let reader = BufReader::new(fd.try_clone().unwrap());
 
         Self {
             reader: Mutex::new(reader),
@@ -68,6 +67,14 @@ impl<R: ParquetReader> Read for FileSource<R> {
         let bytes_to_read = cmp::min(buf.len(), (self.end - self.start) as usize);
         let buf = &mut buf[0..bytes_to_read];
 
+        let pos = reader.stream_position()?;
+        let seek_offset = self.start as i64 - pos as i64;
+        if seek_offset != 0 {
+            // BufReader::seek will discard its internal buffer on every seek.
+            // Using seek_relative will retain the buffer if the seek position
+            // lands within the buffer bounds.
+            reader.seek_relative(seek_offset)?;
+        }
         let res = reader.read(buf);
         if let Ok(bytes_read) = res {
             self.start += bytes_read as u64;


### PR DESCRIPTION
BufRead will discard its internal buffer when seek() is called. This
kills much of the performance of a buffered reader, especially when many
tiny (1-byte) reads are performed.