### PR TITLE
ARROW-7691: [C++] Check non-scalar Flatbuffers fields are not null

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -31,19 +31,15 @@
 #include "arrow/buffer.h"
 #include "arrow/ipc/dictionary.h"  // IYWU pragma: keep
 #include "arrow/ipc/message.h"
-#include "arrow/memory_pool.h"
 #include "arrow/sparse_tensor.h"
 #include "arrow/status.h"
+#include "arrow/type_fwd.h"
+#include "arrow/util/macros.h"
 
 #include "generated/Message_generated.h"
 #include "generated/Schema_generated.h"
 
 namespace arrow {
-
-class DataType;
-class Schema;
-class Tensor;
-class SparseTensor;
 
 namespace flatbuf = org::apache::arrow::flatbuf;
 
@@ -91,6 +87,21 @@ struct FileBlock {
   int32_t metadata_length;
   int64_t body_length;
 };
+
+// Low-level utilities to help with reading Flatbuffers data.
+
+#define CHECK_FLATBUFFERS_NOT_NULL(fb_value, name)             \
+  if ((fb_value) == NULLPTR) {                                 \
+    return Status::IOError("Unexpected null field ", name,     \
+                           " in flatbuffer-encoded metadata"); \
+  }
+
+#define FLATBUFFERS_VECTOR_SIZE(fb_vector) \
+  ((fb_vector == NULLPTR) ? 0 : fb_vector->size())
+
+inline std::string StringFromFlatbuffers(const flatbuffers::String* s) {
+  return (s == NULLPTR) ? "" : s->str();
+}
 
 // Read interface classes. We do not fully deserialize the flatbuffers so that
 // individual fields metadata can be retrieved from very large schema without

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -96,8 +96,10 @@ struct FileBlock {
                            " in flatbuffer-encoded metadata"); \
   }
 
-#define FLATBUFFERS_VECTOR_SIZE(fb_vector) \
-  ((fb_vector == NULLPTR) ? 0 : fb_vector->size())
+template <typename T>
+inline uint32_t FlatBuffersVectorSize(const flatbuffers::Vector<T>* vec) {
+  return (vec == NULLPTR) ? 0 : vec->size();
+}
 
 inline std::string StringFromFlatbuffers(const flatbuffers::String* s) {
   return (s == NULLPTR) ? "" : s->str();

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -657,11 +657,11 @@ class RecordBatchFileReader::RecordBatchFileReaderImpl {
   }
 
   int num_dictionaries() const {
-    return FLATBUFFERS_VECTOR_SIZE(footer_->dictionaries());
+    return static_cast<int>(internal::FlatBuffersVectorSize(footer_->dictionaries()));
   }
 
   int num_record_batches() const {
-    return FLATBUFFERS_VECTOR_SIZE(footer_->recordBatches());
+    return static_cast<int>(internal::FlatBuffersVectorSize(footer_->recordBatches()));
   }
 
   MetadataVersion version() const {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -102,10 +102,7 @@ class IpcComponentSource {
 
   Status GetBuffer(int buffer_index, std::shared_ptr<Buffer>* out) {
     auto buffers = metadata_->buffers();
-    if (buffers == nullptr) {
-      return Status::IOError(
-          "Buffers-pointer of flatbuffer-encoded RecordBatch is null.");
-    }
+    CHECK_FLATBUFFERS_NOT_NULL(buffers, "RecordBatch.buffers");
     if (buffer_index >= static_cast<int>(buffers->size())) {
       return Status::IOError("buffer_index out of range.");
     }
@@ -127,9 +124,7 @@ class IpcComponentSource {
 
   Status GetFieldMetadata(int field_index, ArrayData* out) {
     auto nodes = metadata_->nodes();
-    if (nodes == nullptr) {
-      return Status::IOError("Nodes-pointer of flatbuffer-encoded Table is null.");
-    }
+    CHECK_FLATBUFFERS_NOT_NULL(nodes, "Table.nodes");
     // pop off a field
     if (field_index >= static_cast<int>(nodes->size())) {
       return Status::Invalid("Ran out of field metadata, likely malformed");
@@ -441,6 +436,7 @@ Status ReadDictionary(const Buffer& metadata, DictionaryMemo* dictionary_memo,
   // The dictionary is embedded in a record batch with a single column
   std::shared_ptr<RecordBatch> batch;
   auto batch_meta = dictionary_batch->data();
+  CHECK_FLATBUFFERS_NOT_NULL(batch_meta, "DictionaryBatch.data");
   RETURN_NOT_OK(ReadRecordBatch(batch_meta, ::arrow::schema({value_field}),
                                 dictionary_memo, options, file, &batch));
   if (batch->num_columns() != 1) {
@@ -475,9 +471,6 @@ class RecordBatchStreamReader::RecordBatchStreamReaderImpl {
     }
     CHECK_MESSAGE_TYPE(Message::SCHEMA, message->type());
     CHECK_HAS_NO_BODY(*message);
-    if (message->header() == nullptr) {
-      return Status::IOError("Header-pointer of flatbuffer-encoded Message is null.");
-    }
     return internal::GetSchema(message->header(), &dictionary_memo_, &schema_);
   }
 
@@ -663,9 +656,13 @@ class RecordBatchFileReader::RecordBatchFileReaderImpl {
     return Status::OK();
   }
 
-  int num_dictionaries() const { return footer_->dictionaries()->size(); }
+  int num_dictionaries() const {
+    return FLATBUFFERS_VECTOR_SIZE(footer_->dictionaries());
+  }
 
-  int num_record_batches() const { return footer_->recordBatches()->size(); }
+  int num_record_batches() const {
+    return FLATBUFFERS_VECTOR_SIZE(footer_->recordBatches());
+  }
 
   MetadataVersion version() const {
     return internal::GetMetadataVersion(footer_->version());


### PR DESCRIPTION
We're discussing whether to make those fields required in the schema definitions (which would make validation automatic by the flatbuffers generated verifier), but in the meantime we can check those fields manually.

This should fix a bunch of issues detected by OSS-Fuzz.