### PR TITLE
ARROW-7693: [CI] Fix test name for Spark integration, add new tests

### DIFF
--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -49,10 +49,12 @@ pushd ${spark_dir}
   # Run pyarrow related Python tests only
   spark_python_tests=(
     "pyspark.sql.tests.test_arrow"
+    "pyspark.sql.tests.test_pandas_map"
+    "pyspark.sql.tests.test_pandas_cogrouped_map"
+    "pyspark.sql.tests.test_pandas_grouped_map"
     "pyspark.sql.tests.test_pandas_udf"
     "pyspark.sql.tests.test_pandas_udf_scalar"
     "pyspark.sql.tests.test_pandas_udf_grouped_agg"
-    "pyspark.sql.tests.test_pandas_udf_grouped_map"
     "pyspark.sql.tests.test_pandas_udf_window")
 
   (echo "Testing PySpark:"; IFS=$'\n'; echo "${spark_python_tests[*]}")


### PR DESCRIPTION
Spark master renamed some Pandas/Arrow tests, this updates the tests names and adds some new tests to nightly CI.