### PR TITLE
ARROW-8039: [Python] Use dataset API in existing parquet readers and tests

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1191,7 +1191,8 @@ cdef class FileSystemDatasetFactory(DatasetFactory):
                     c_options
                 )
         else:
-            raise TypeError('Must pass either paths or a FileSelector')
+            raise TypeError('Must pass either paths or a FileSelector, but '
+                            'passed {}'.format(type(paths_or_selector)))
 
         self.init(GetResultValue(result))
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -623,7 +623,7 @@ cdef class ParquetReadOptions:
     buffer_size : int, default 8192
         Size of buffered stream, if enabled. Default is 8KB.
     dictionary_columns : list of string, default None
-        Names of columns which should be read as dictionaries.
+        Names of columns which should be read as dictionary type.
     """
 
     cdef public:
@@ -632,9 +632,11 @@ cdef class ParquetReadOptions:
         set dictionary_columns
 
     def __init__(self, bint use_buffered_stream=False,
-                 uint32_t buffer_size=8192,
+                 buffer_size=8192,
                  dictionary_columns=None):
         self.use_buffered_stream = use_buffered_stream
+        if buffer_size <= 0:
+            raise ValueError("Buffer size must be larger than zero")
         self.buffer_size = buffer_size
         self.dictionary_columns = set(dictionary_columns or set())
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -623,7 +623,8 @@ cdef class ParquetReadOptions:
     buffer_size : int, default 8192
         Size of buffered stream, if enabled. Default is 8KB.
     dictionary_columns : list of string, default None
-        Names of columns which should be read as dictionary type.
+        Names of columns which should be dictionary encoded as
+        they are read.
     """
 
     cdef public:

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -77,7 +77,7 @@ def _check_contains_null(val):
     return False
 
 
-def _check_filters(filters):
+def _check_filters(filters, check_null_strings=True):
     """
     Check if filters are well-formed.
     """
@@ -89,17 +89,18 @@ def _check_filters(filters):
             # too few:
             #   We have [(,,), ..] instead of [[(,,), ..]]
             filters = [filters]
-        for conjunction in filters:
-            for col, op, val in conjunction:
-                if (
-                    isinstance(val, list)
-                    and all(_check_contains_null(v) for v in val)
-                    or _check_contains_null(val)
-                ):
-                    raise NotImplementedError(
-                        "Null-terminated binary strings are not supported as"
-                        " filter values."
-                    )
+        if check_null_strings:
+            for conjunction in filters:
+                for col, op, val in conjunction:
+                    if (
+                        isinstance(val, list)
+                        and all(_check_contains_null(v) for v in val)
+                        or _check_contains_null(val)
+                    ):
+                        raise NotImplementedError(
+                            "Null-terminated binary strings are not supported "
+                            "as filter values."
+                        )
     return filters
 
 
@@ -116,7 +117,7 @@ def _filters_to_expression(filters):
     """
     import pyarrow.dataset as ds
 
-    filters = _check_filters(filters)
+    filters = _check_filters(filters, check_null_strings=False)
 
     def convert_single_predicate(col, op, val):
         field = ds.field(col)

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1120,8 +1120,8 @@ metadata_nthreads: int, default 1
     def __new__(cls, path_or_paths=None, filesystem=None, schema=None,
                 metadata=None, split_row_groups=False, validate_schema=True,
                 filters=None, metadata_nthreads=1, read_dictionary=None,
-                memory_map=False, buffer_size=0, use_dataset=False):
-        if use_dataset:
+                memory_map=False, buffer_size=0, use_legacy_dataset=True):
+        if not use_legacy_dataset:
             # TODO raise warning on unsupported keywords
             return _ParquetDatasetV2(path_or_paths, filesystem=filesystem,
                                      filters=filters,
@@ -1133,7 +1133,7 @@ metadata_nthreads: int, default 1
     def __init__(self, path_or_paths, filesystem=None, schema=None,
                  metadata=None, split_row_groups=False, validate_schema=True,
                  filters=None, metadata_nthreads=1, read_dictionary=None,
-                 memory_map=False, buffer_size=0, use_dataset=False):
+                 memory_map=False, buffer_size=0, use_legacy_dataset=True):
         self._metadata = _ParquetDatasetMetadata()
         a_path = path_or_paths
         if isinstance(a_path, list):
@@ -1451,8 +1451,8 @@ Returns
 def read_table(source, columns=None, use_threads=True, metadata=None,
                use_pandas_metadata=False, memory_map=False,
                read_dictionary=None, filesystem=None, filters=None,
-               buffer_size=0, use_dataset=False):
-    if use_dataset:
+               buffer_size=0, use_legacy_dataset=True):
+    if not use_legacy_dataset:
         import pyarrow.dataset as ds
         dataset = _dataset_from_legacy_args(
             source, filesystem=filesystem, read_dictionary=read_dictionary,
@@ -1498,7 +1498,8 @@ read_table.__doc__ = _read_table_docstring.format(
 
 
 def read_pandas(source, columns=None, use_threads=True, memory_map=False,
-                metadata=None, filters=None, buffer_size=0, use_dataset=False):
+                metadata=None, filters=None, buffer_size=0,
+                use_legacy_dataset=True):
     return read_table(
         source,
         columns=columns,
@@ -1508,7 +1509,7 @@ def read_pandas(source, columns=None, use_threads=True, memory_map=False,
         memory_map=memory_map,
         buffer_size=buffer_size,
         use_pandas_metadata=True,
-        use_dataset=use_dataset,
+        use_legacy_dataset=use_legacy_dataset,
     )
 
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1057,8 +1057,8 @@ buffer_size : int, default 0
     column chunks. Otherwise IO calls are unbuffered.
 use_legacy_dataset : bool, default True
     Set to False to enable the new code path (experimental, using the
-    new Arrow Dataset API). This allows to pass `filters` for all columns
-    and not only the partition keys."""
+    new Arrow Dataset API). Among other things, this allows to pass
+    `filters` for all columns and not only the partition keys."""
 
 
 class ParquetDataset:
@@ -1374,13 +1374,11 @@ class _ParquetDatasetV2:
             read_options.update(use_buffered_stream=True,
                                 buffer_size=buffer_size)
         if read_dictionary is not None:
-            read_options.update(dict_columns=read_dictionary)
+            read_options.update(dictionary_columns=read_dictionary)
         parquet_format = ds.ParquetFileFormat(read_options=read_options)
 
-        dataset = ds.dataset(path_or_paths, filesystem=filesystem,
-                             format=parquet_format, partitioning="hive")
-
-        self._dataset = dataset
+        self._dataset = ds.dataset(path_or_paths, filesystem=filesystem,
+                                   format=parquet_format, partitioning="hive")
         self._filters = filters
         if filters is not None:
             self._filter_expression = _filters_to_expression(filters)

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1496,18 +1496,8 @@ def read_table(source, columns=None, use_threads=True, metadata=None,
             # unsupported keywords
             metadata=metadata
         )
-        table = dataset.read(columns=columns, use_threads=use_threads,
-                             use_pandas_metadata=use_pandas_metadata)
-
-        # remove ARROW:schema metadata, current parquet version doesn't
-        # preserve this
-        metadata = table.schema.metadata
-        if metadata:
-            metadata.pop(b"ARROW:schema", None)
-            if len(metadata) == 0:
-                metadata = None
-            table = table.replace_schema_metadata(metadata)
-        return table
+        return dataset.read(columns=columns, use_threads=use_threads,
+                            use_pandas_metadata=use_pandas_metadata)
 
     if _is_path_like(source):
         pf = ParquetDataset(source, metadata=metadata, memory_map=memory_map,

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -152,16 +152,19 @@ def _filters_to_expression(filters):
         and_exprs = []
         for col, op, val in conjunction:
             and_exprs.append(convert_single_predicate(col, op, val))
+
+        expr = and_exprs[0]
         if len(and_exprs) > 1:
-            expr = ds.AndExpression(*and_exprs)
-        else:
-            expr = and_exprs[0]
+            for and_expr in and_exprs[1:]:
+                expr = ds.AndExpression(expr, and_expr)
+
         or_exprs.append(expr)
 
+    expr = or_exprs[0]
     if len(or_exprs) > 1:
         expr = ds.OrExpression(*or_exprs)
-    else:
-        expr = or_exprs[0]
+        for or_expr in or_exprs[1:]:
+            expr = ds.OrExpression(expr, or_expr)
 
     return expr
 
@@ -1043,7 +1046,11 @@ memory_map : bool, default False
     improve performance in some environments.
 buffer_size : int, default 0
     If positive, perform read buffering when deserializing individual
-    column chunks. Otherwise IO calls are unbuffered."""
+    column chunks. Otherwise IO calls are unbuffered.
+use_legacy_dataset : bool, default True
+    Set to False to enable the new code path (experimental, using the
+    new Arrow Dataset API). This allows to pass `filters` for all columns
+    and not only the partition keys."""
 
 
 class ParquetDataset:

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -108,12 +108,17 @@ def _filters_to_expression(filters):
     """
     Check if filters are well-formed.
 
-    Predicates are expressed in disjunctive normal form (DNF). This means
-    that the innermost tuple describe a single column predicate. These
-    inner predicate make are all combined with a conjunction (AND) into a
-    larger predicate. The most outer list then combines all filters
-    with a disjunction (OR). By this, we should be able to express all
-    kinds of filters that are possible using boolean logic.
+    Predicates are expressed in disjunctive normal form (DNF), like 
+    ``[[('x', '=', 0), ...], ...]``. DNF allows
+    arbitrary boolean logical combinations of single column predicates. The
+    innermost tuples each describe a single column predicate. The list
+    of inner predicates is interpreted as a conjunction (AND), forming a
+    more selective and multiple column predicate. Finally, the most outer
+    list combines these filters as a disjunction (OR).
+
+    Predicates may also be passed as List[Tuple]. This form is interpreted
+    as a single conjunction. To express OR in predicates, one must
+    use the (preferred) List[List[Tuple]] notation.
     """
     import pyarrow.dataset as ds
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1400,12 +1400,8 @@ class _ParquetDatasetV2:
         metadata = self._dataset.schema.metadata
         if columns is not None and use_pandas_metadata:
             if metadata and b'pandas' in metadata:
-                index_columns = _get_pandas_index_columns(metadata)
-
-            columns = list(columns)
-            for index_col in index_columns:
-                if index_col not in columns:
-                    columns += [index_col]
+                index_columns = set(_get_pandas_index_columns(metadata))
+                columns = columns + list(index_columns - set(columns))
 
         table = self._dataset.to_table(
             columns=columns, filter=self._filter_expression,

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1428,7 +1428,8 @@ def read_table(source, columns=None, use_threads=True, metadata=None,
                              format=parquat_format, partitioning="hive")
         if filters is not None and not isinstance(filters, ds.Expression):
             filters = _filters_to_expression(filters)
-        table = dataset.to_table(columns=columns, filter=filters)
+        table = dataset.to_table(columns=columns, filter=filters,
+                                 use_threads=use_threads)
 
         # remove ARROW:schema metadata, current parquet version doesn't
         # preserve this

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -2505,10 +2505,12 @@ def test_ignore_private_directories(tempdir, dir_prefix, use_legacy_dataset):
     (dirpath / '{}staging'.format(dir_prefix)).mkdir()
 
     dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
+
     if use_legacy_dataset:
         assert set(map(str, paths)) == {x.path for x in dataset.pieces}
     else:
-        assert set(map(str, paths)) == set(dataset._dataset.files)
+        paths = [str(path.as_posix()) for path in paths]
+        assert set(paths) == set(dataset._dataset.files)
 
 
 @pytest.mark.pandas
@@ -2527,10 +2529,12 @@ def test_ignore_hidden_files_dot(tempdir, use_legacy_dataset):
         f.write(b'gibberish')
 
     dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
+
     if use_legacy_dataset:
         assert set(map(str, paths)) == {x.path for x in dataset.pieces}
     else:
-        assert set(map(str, paths)) == set(dataset._dataset.files)
+        paths = [str(path.as_posix()) for path in paths]
+        assert set(paths) == set(dataset._dataset.files)
 
 
 @pytest.mark.pandas
@@ -2549,10 +2553,12 @@ def test_ignore_hidden_files_underscore(tempdir, use_legacy_dataset):
         f.write(b'abcd')
 
     dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
+
     if use_legacy_dataset:
         assert set(map(str, paths)) == {x.path for x in dataset.pieces}
     else:
-        assert set(map(str, paths)) == set(dataset._dataset.files)
+        paths = [str(path.as_posix()) for path in paths]
+        assert set(paths) == set(dataset._dataset.files)
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -561,7 +561,7 @@ def _test_dataframe(size=10000, seed=0):
     return df
 
 
-# TODO NativeFile support
+# TODO(ARROW-8074) NativeFile support
 @pytest.mark.pandas
 @parametrize_legacy_dataset_skip_buffer
 def test_pandas_parquet_native_file_roundtrip(tempdir, use_legacy_dataset):

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -192,7 +192,11 @@ def test_pandas_parquet_2_0_roundtrip(tempdir, chunk_size, use_legacy_dataset):
         use_threads=use_threads)
     assert table_read.schema.pandas_metadata is not None
 
-    assert arrow_table.schema.metadata == table_read.schema.metadata
+    read_metadata = table_read.schema.metadata
+    if not use_legacy_dataset:
+        read_metadata.pop(b"ARROW:schema")
+
+    assert arrow_table.schema.metadata == read_metadata
 
     df_read = table_read.to_pandas()
     tm.assert_frame_equal(df, df_read)
@@ -426,7 +430,11 @@ def test_pandas_parquet_2_0_roundtrip_read_pandas_no_index_written(
     js = table_read.schema.pandas_metadata
     assert not js['index_columns']
 
-    assert arrow_table.schema.metadata == table_read.schema.metadata
+    read_metadata = table_read.schema.metadata
+    if not use_legacy_dataset:
+        read_metadata.pop(b"ARROW:schema")
+
+    assert arrow_table.schema.metadata == read_metadata
 
     df_read = table_read.to_pandas()
     tm.assert_frame_equal(df, df_read)

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -56,7 +56,8 @@ def datadir(datadir):
     return datadir / 'parquet'
 
 
-parametrize_use_dataset = pytest.mark.parametrize("use_dataset", [False, True])
+parametrize_use_dataset = pytest.mark.parametrize(
+    "use_dataset", [False, pytest.param(True, marks=pytest.mark.dataset)])
 parametrize_use_dataset_not_supported = pytest.mark.parametrize(
     "use_dataset", [False, pytest.param(True, marks=pytest.mark.skip)])
 parametrize_use_dataset_skip_buffer = pytest.mark.parametrize(

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -2673,7 +2673,7 @@ def _test_write_to_dataset_with_partitions(base_path,
     if use_legacy_dataset:
         dataset_cols = set(dataset.schema.to_arrow_schema().names)
     else:
-        # TODO(dataset) schema property is an arrow and not parquet schema
+        # NB schema property is an arrow and not parquet schema
         dataset_cols = set(dataset.schema.names)
 
     assert dataset_cols == set(output_table.schema.names)
@@ -2813,7 +2813,7 @@ def test_large_table_int32_overflow():
     _write_table(table, f)
 
 
-# TODO buffer support
+# TODO(ARROW-8074) buffer support
 def _simple_table_roundtrip(table, **write_kwargs):
     stream = pa.BufferOutputStream()
     _write_table(table, stream, **write_kwargs)

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1988,7 +1988,7 @@ def test_invalid_pred_op(tempdir, use_legacy_dataset):
                                     use_legacy_dataset=use_legacy_dataset)
         assert dataset.read().num_rows == 0
 
-    with pytest.raises((ValueError, TypeError)):
+    with pytest.raises(ValueError if use_legacy_dataset else TypeError):
         # dataset API returns TypeError when trying create invalid comparison
         pq.ParquetDataset(base_path,
                           filesystem=fs,

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1897,8 +1897,6 @@ def test_invalid_pred_op(tempdir):
                           ])
 
 
-# TODO implement filters
-@pytest.mark.skip
 @pytest.mark.pandas
 def test_filters_read_table(tempdir):
     # test that filters keyword is passed through in read_table


### PR DESCRIPTION
This is testing to optionally use the dataset API in the pyarrow parquet reader implementation (`read_table` and `ParquetDataset().read()`). 
Currently, it is enabled by passing `use_legacy_dataset=False` (mechanism to opt in to be discussed), which allows to run our existing parquet tests with this (the approach I now took is to parametrize the existing tests for use_legacy_dataset True/False).

This allows users to do:

```
table = pq.read_table("my_parquet_file_or_dir", columns=.., filters=.., use_legacy_dataset=False)
```

or 

```
dataset = pq.ParquetDataset("my_parquet_dir/", use_legacy_dataset=False)
table = table.read(...)
```

and with the idea that at some point, the default for `use_legacy_dataset` would switch from `True` to `False`.

Long term, I think we certainly want to keep `pq.read_table` (and I think we will also be able to support most of its keywords). 

The future for `pq.ParquetDataset` is less clear (it has a lot of API that is tied to the python implementation, eg the ParquetDatasetPiece, PartitionSet, ParquetPartitions, .. classes). We probably want to move people towards a "new" ParquetDataset that is more consistent with the new general datasets API. Therefore, right now the `ParquetDataset(use_legacy_dataset=False)` does not yet try to provide all those features, but just the `read()` method. We can later see which extra features we add and how advanced users of ParquetDataset can move to the new API.