### PR TITLE
ARROW-7690 [R] Cannot write parquet to OutputStream

### DIFF
--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -150,7 +150,7 @@ write_parquet <- function(x,
   if (is.character(sink)) {
     sink <- FileOutputStream$create(sink)
     on.exit(sink$close())
-  } else if (!inherits(sink, OutputStream)) {
+  } else if (!inherits(sink, "OutputStream")) {
     abort("sink must be a file path or an OutputStream")
   }
 

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -120,3 +120,13 @@ test_that("Factors are preserved when writing/reading from Parquet", {
   df_read <- read_parquet(pq_tmp_file)
   expect_identical(df, df_read)
 })
+
+test_that("write_parquet() to stream", {
+  df <- tibble::tibble(x = 1:5)
+  tf <- tempfile()
+  con <- FileOutputStream$create(tf)
+  on.exit(unlink(tf))
+  write_parquet(df, con)
+  con$close()
+  expect_equal(read_parquet(tf), df)
+})


### PR DESCRIPTION
The second parameter for inherits expects a character vector.