### PR TITLE
ARROW-7711: [C#] Make Date32 test independent of system timezone

### DIFF
--- a/csharp/test/Apache.Arrow.Tests/Date32ArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/Date32ArrayTests.cs
@@ -28,7 +28,13 @@ namespace Apache.Arrow.Tests
                 var now = DateTimeOffset.UtcNow;
 
                 // throw away the time portion of the date time
-                var expected = new DateTime(now.Year, now.Month, now.Day);
+                var expected = new DateTime(now.Year,
+					    now.Month,
+					    now.Day,
+					    0,
+					    0,
+					    0,
+					    DateTimeKind.Utc);
 
                 var array = new Date32Array.Builder()
                     .Resize(1)


### PR DESCRIPTION
The following failure was occurred on 2020-01-29:08:47:33+09:00:

    Starting test execution, please wait...
    [xUnit.net 00:00:00.53]     Apache.Arrow.Tests.Date32ArrayTests+Set.SetAndGet [FAIL]
      X Apache.Arrow.Tests.Date32ArrayTests+Set.SetAndGet [19ms]
      Error Message:
       Assert.Equal() Failure
    Expected: 2020-01-28T00:00:00.0000000
    Actual:   2020-01-27T00:00:00.0000000
      Stack Trace:
         at Apache.Arrow.Tests.Date32ArrayTests.Set.SetAndGet() in /tmp/arrow-0.16.0.mrKfP/apache-arrow-0.16.0/csharp/test/Apache.Arrow.Tests/Date32ArrayTests.cs:line 38