### PR TITLE
ARROW-7713: [Java] TastLeak was put at the wrong location

### DIFF
--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLeak.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLeak.java
@@ -29,7 +29,6 @@ import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
-
 import org.junit.Test;
 
 /**


### PR DESCRIPTION
Related to [ARROW-7713](https://issues.apache.org/jira/browse/ARROW-7713).

Seems TestLeak.java was put at the wrong place, we should move it into flight-core.