### PR TITLE
ARROW-7716: [Packaging][APT] Use the "main" component for Ubuntu 19.10

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1016,7 +1016,7 @@ class BinaryTask
       ["ubuntu", "xenial", "main"],
       ["ubuntu", "bionic", "main"],
       ["ubuntu", "disco", "main"],
-      ["ubuntu", "eoan", "universe"],
+      ["ubuntu", "eoan", "main"],
     ]
   end
 


### PR DESCRIPTION
Because we always use the "main" component in
apache-arrow-archive-keyring.