### PR TITLE
ARROW-7720: [C++][Python] Add check_metadata argument to Table.equals

### DIFF
--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -666,11 +666,11 @@ Result<std::shared_ptr<Table>> PromoteTableToSchema(const std::shared_ptr<Table>
   return Table::Make(schema, std::move(columns));
 }
 
-bool Table::Equals(const Table& other) const {
+bool Table::Equals(const Table& other, bool check_metadata) const {
   if (this == &other) {
     return true;
   }
-  if (!schema_->Equals(*other.schema())) {
+  if (!schema_->Equals(*other.schema(), check_metadata)) {
     return false;
   }
   if (this->num_columns() != other.num_columns()) {

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -284,7 +284,7 @@ class ARROW_EXPORT Table {
   ///
   /// Two tables can be equal only if they have equal schemas.
   /// However, they may be equal even if they have different chunkings.
-  bool Equals(const Table& other) const;
+  bool Equals(const Table& other, bool check_metadata = true) const;
 
   /// \brief Make a new table by combining the chunks this table has.
   ///

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -319,6 +319,12 @@ TEST_F(TestTable, Equals) {
 
   other = Table::Make(schema_, other_columns);
   ASSERT_FALSE(table_->Equals(*other));
+
+  // Differring schema metadata
+  other_schema = schema_->WithMetadata(::arrow::key_value_metadata({"key"}, {"value"}));
+  other = Table::Make(other_schema, columns_);
+  ASSERT_FALSE(table_->Equals(*other));
+  ASSERT_TRUE(table_->Equals(*other, /*check_metadata=*/false));
 }
 
 TEST_F(TestTable, FromRecordBatches) {

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -676,7 +676,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int num_columns()
         int64_t num_rows()
 
-        c_bool Equals(const CTable& other)
+        c_bool Equals(const CTable& other, c_bool check_metadata)
 
         shared_ptr[CSchema] schema()
         shared_ptr[CChunkedArray] column(int i)

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1058,7 +1058,7 @@ cdef class Table(_PandasConvertible):
         except TypeError:
             return NotImplemented
 
-    def equals(self, Table other):
+    def equals(self, Table other, bint check_metadata=True):
         """
         Check if contents of two tables are equal
 
@@ -1079,7 +1079,7 @@ cdef class Table(_PandasConvertible):
             return False
 
         with nogil:
-            result = this_table.Equals(deref(other_table))
+            result = this_table.Equals(deref(other_table), check_metadata)
 
         return result
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1065,6 +1065,8 @@ cdef class Table(_PandasConvertible):
         Parameters
         ----------
         other : pyarrow.Table
+        check_metadata : bool, default True
+            Whether metadata equality should be checked as well.
 
         Returns
         -------

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -568,19 +568,19 @@ def _check_dataset_from_path(path, table, **kwargs):
     dataset = ds.dataset(ds.source(path, **kwargs))
     assert dataset.schema.equals(table.schema, check_metadata=False)
     result = dataset.to_table(use_threads=False)  # deterministic row order
-    assert result.replace_schema_metadata().equals(table)
+    assert result.equals(table, check_metadata=False)
 
     # string path
     dataset = ds.dataset(ds.source(str(path), **kwargs))
     assert dataset.schema.equals(table.schema, check_metadata=False)
     result = dataset.to_table(use_threads=False)  # deterministic row order
-    assert result.replace_schema_metadata().equals(table)
+    assert result.equals(table, check_matadata=False)
 
     # passing directly to dataset
     dataset = ds.dataset(str(path), **kwargs)
     assert dataset.schema.equals(table.schema, check_metadata=False)
     result = dataset.to_table(use_threads=False)  # deterministic row order
-    assert result.replace_schema_metadata().equals(table)
+    assert result.equals(table, check_metadata=False)
 
 
 @pytest.mark.parquet
@@ -608,7 +608,7 @@ def test_open_dataset_list_of_files(tempdir):
             ds.dataset(ds.source([str(path1), str(path2)]))]:
         assert dataset.schema.equals(table.schema, check_metadata=False)
         result = dataset.to_table(use_threads=False)  # deterministic row order
-        assert result.replace_schema_metadata().equals(table)
+        assert result.equals(table, check_metadata=False)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fails on windows")
@@ -646,7 +646,7 @@ def test_open_dataset_partitioned_directory(tempdir):
     result = dataset.to_table(use_threads=False)
     expected = full_table.append_column(
         "part", pa.array(np.repeat([0, 1, 2], 9), type=pa.int8()))
-    assert result.replace_schema_metadata().equals(expected)
+    assert result.equals(expected, check_metadata=False)
 
 
 @pytest.mark.parquet

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -574,7 +574,7 @@ def _check_dataset_from_path(path, table, **kwargs):
     dataset = ds.dataset(ds.source(str(path), **kwargs))
     assert dataset.schema.equals(table.schema, check_metadata=False)
     result = dataset.to_table(use_threads=False)  # deterministic row order
-    assert result.equals(table, check_matadata=False)
+    assert result.equals(table, check_metadata=False)
 
     # passing directly to dataset
     dataset = ds.dataset(str(path), **kwargs)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -480,6 +480,10 @@ def test_table_equals():
     # ARROW-4822
     assert not table.equals(None)
 
+    other = pa.Table.from_arrays([], names=[], metadata={'key': 'value'})
+    assert not table.equals(other)
+    assert table.equals(other, check_metadata=False)
+
 
 def test_table_from_batches_and_schema():
     schema = pa.schema([

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1432,8 +1432,8 @@ Table__Slice2 <- function(table, offset, length){
     .Call(`_arrow_Table__Slice2` , table, offset, length)
 }
 
-Table__Equals <- function(lhs, rhs){
-    .Call(`_arrow_Table__Equals` , lhs, rhs)
+Table__Equals <- function(lhs, rhs, check_metadata){
+    .Call(`_arrow_Table__Equals` , lhs, rhs, check_metadata)
 }
 
 Table__GetColumnByName <- function(table, name){

--- a/r/R/table.R
+++ b/r/R/table.R
@@ -162,8 +162,8 @@ Table <- R6Class("Table", inherit = Object,
       shared_ptr(Table, Table__Filter(self, i))
     },
 
-    Equals = function(other) {
-      Table__Equals(self, other)
+    Equals = function(other, check_metadata = TRUE) {
+      Table__Equals(self, other, isTRUE(check_metadata))
     }
   ),
 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -5595,16 +5595,17 @@ RcppExport SEXP _arrow_Table__Slice2(SEXP table_sexp, SEXP offset_sexp, SEXP len
 
 // table.cpp
 #if defined(ARROW_R_WITH_ARROW)
-bool Table__Equals(const std::shared_ptr<arrow::Table>& lhs, const std::shared_ptr<arrow::Table>& rhs);
-RcppExport SEXP _arrow_Table__Equals(SEXP lhs_sexp, SEXP rhs_sexp){
+bool Table__Equals(const std::shared_ptr<arrow::Table>& lhs, const std::shared_ptr<arrow::Table>& rhs, bool check_metadata);
+RcppExport SEXP _arrow_Table__Equals(SEXP lhs_sexp, SEXP rhs_sexp, SEXP check_metadata_sexp){
 BEGIN_RCPP
 	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::Table>&>::type lhs(lhs_sexp);
 	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::Table>&>::type rhs(rhs_sexp);
-	return Rcpp::wrap(Table__Equals(lhs, rhs));
+	Rcpp::traits::input_parameter<bool>::type check_metadata(check_metadata_sexp);
+	return Rcpp::wrap(Table__Equals(lhs, rhs, check_metadata));
 END_RCPP
 }
 #else
-RcppExport SEXP _arrow_Table__Equals(SEXP lhs_sexp, SEXP rhs_sexp){
+RcppExport SEXP _arrow_Table__Equals(SEXP lhs_sexp, SEXP rhs_sexp, SEXP check_metadata_sexp){
 	Rf_error("Cannot call Table__Equals(). Please use arrow::install_arrow() to install required runtime libraries. ");
 }
 #endif
@@ -6058,7 +6059,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_Table__ColumnNames", (DL_FUNC) &_arrow_Table__ColumnNames, 1}, 
 		{ "_arrow_Table__Slice1", (DL_FUNC) &_arrow_Table__Slice1, 2}, 
 		{ "_arrow_Table__Slice2", (DL_FUNC) &_arrow_Table__Slice2, 3}, 
-		{ "_arrow_Table__Equals", (DL_FUNC) &_arrow_Table__Equals, 2}, 
+		{ "_arrow_Table__Equals", (DL_FUNC) &_arrow_Table__Equals, 3}, 
 		{ "_arrow_Table__GetColumnByName", (DL_FUNC) &_arrow_Table__GetColumnByName, 2}, 
 		{ "_arrow_Table__select", (DL_FUNC) &_arrow_Table__select, 2}, 
 		{ "_arrow_Table__from_dots", (DL_FUNC) &_arrow_Table__from_dots, 2}, 

--- a/r/src/table.cpp
+++ b/r/src/table.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<arrow::Table> Table__Slice2(const std::shared_ptr<arrow::Table>&
 
 // [[arrow::export]]
 bool Table__Equals(const std::shared_ptr<arrow::Table>& lhs,
-                   const std::shared_ptr<arrow::Table>& rhs) {
+                   const std::shared_ptr<arrow::Table>& rhs, bool check_metadata) {
   return lhs->Equals(*rhs.get());
 }
 


### PR DESCRIPTION
Use 

```py
table.equals(other, check_metadata=False)
``` 

instead of

```py
table.replace_schema_metadata().equals(other)
```