### PR TITLE
ARROW-7726: [CI] [C++] Use boost binaries on Windows GHA build

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -175,10 +175,15 @@ jobs:
       ARROW_BUILD_STATIC: OFF
       ARROW_BOOST_USE_SHARED: OFF
       ARROW_VERBOSE_THIRDPARTY_BUILD: OFF
-      BOOST_SOURCE: BUNDLED
+      BOOST_ROOT: C:\local\boost_1_67_0
+      BOOST_LIBRARYDIR: C:\local\boost_1_67_0\lib64-msvc-14.1\
     steps:
       - name: Disable Crash Dialogs
         run: reg add "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" /v DontShowUI /t REG_DWORD /d 1 /f
+      - name: Installed Packages
+        run: choco list -l
+      - name: Install Boost
+        run: choco install -y boost-msvc-14.1
       - name: Checkout Arrow
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -190,11 +190,7 @@ jobs:
           submodules: true
       - name: Build
         shell: bash
-        run: |
-          export BOOST_ROOT="$(ls -1 /c/local/boost_* | tail -n1)"
-          export BOOST_LIBRARYDIR="${BOOST_ROOT}\\lib64-msvc-14.1"
-          echo "BOOST_ROOT: ${BOOST_ROOT}"
-          ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
+        run: ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash
         run: ci/scripts/cpp_test.sh $(pwd) $(pwd)/build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -190,7 +190,11 @@ jobs:
           submodules: true
       - name: Build
         shell: bash
-        run: ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
+        run: |
+          export BOOST_ROOT="$(ls -1 /c/local/boost_* | tail -n1)"
+          export BOOST_LIBRARYDIR="${BOOST_ROOT}\\lib64-msvc-14.1"
+          echo "BOOST_ROOT: ${BOOST_ROOT}"
+          ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash
         run: ci/scripts/cpp_test.sh $(pwd) $(pwd)/build


### PR DESCRIPTION
The binaries are installed using Chocolatey, which takes a bit of time (it's a 2+GB install...), but less so than recompiling Boost from scratch during the CMake build.

[skip appveyor]