### PR TITLE
ARROW-7729: [Python][CI] Pin pandas version to 0.25 in the dask integration test

### DIFF
--- a/ci/docker/conda-python-dask.dockerfile
+++ b/ci/docker/conda-python-dask.dockerfile
@@ -23,3 +23,6 @@ FROM ${repo}:${arch}-conda-python-${python}
 ARG dask=latest
 COPY ci/scripts/install_dask.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_dask.sh ${dask}
+
+# The Spark tests currently break with pandas >= 1.0
+RUN conda install pandas=0.25.3

--- a/ci/docker/conda-python-dask.dockerfile
+++ b/ci/docker/conda-python-dask.dockerfile
@@ -25,4 +25,4 @@ COPY ci/scripts/install_dask.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_dask.sh ${dask}
 
 # The Spark tests currently break with pandas >= 1.0
-RUN conda install pandas=0.25.3
+RUN if [ ${dask} == "latest" ]; then conda install pandas=0.25.3; fi


### PR DESCRIPTION
Additionally test agains dask's latest release not just the master revision.