### PR TITLE
ARROW-6724: [C++] Allow simpler BufferOutputStream creation

### DIFF
--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -34,7 +34,6 @@
 namespace arrow {
 namespace dataset {
 
-constexpr int64_t kDefaultOutputStreamSize = 1024;
 constexpr int64_t kBatchSize = 1UL << 12;
 constexpr int64_t kBatchRepetitions = 1 << 5;
 constexpr int64_t kNumRows = kBatchSize * kBatchRepetitions;
@@ -42,8 +41,7 @@ constexpr int64_t kNumRows = kBatchSize * kBatchRepetitions;
 class ArrowIpcWriterMixin : public ::testing::Test {
  public:
   std::shared_ptr<Buffer> Write(std::vector<RecordBatchReader*> readers) {
-    EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create(
-                                        kDefaultOutputStreamSize, default_memory_pool()));
+    EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create());
     auto writer_schema = readers[0]->schema();
 
     EXPECT_OK_AND_ASSIGN(auto writer,
@@ -69,8 +67,7 @@ class ArrowIpcWriterMixin : public ::testing::Test {
   }
 
   std::shared_ptr<Buffer> Write(const Table& table) {
-    EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create(
-                                        kDefaultOutputStreamSize, default_memory_pool()));
+    EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create());
 
     EXPECT_OK_AND_ASSIGN(auto writer,
                          ipc::RecordBatchFileWriter::Open(sink.get(), table.schema()));

--- a/cpp/src/arrow/extension_type_test.cc
+++ b/cpp/src/arrow/extension_type_test.cc
@@ -217,7 +217,7 @@ TEST_F(TestExtensionType, ExtensionTypeTest) {
 
 auto RoundtripBatch = [](const std::shared_ptr<RecordBatch>& batch,
                          std::shared_ptr<RecordBatch>* out) {
-  ASSERT_OK_AND_ASSIGN(auto out_stream, io::BufferOutputStream::Create(1024));
+  ASSERT_OK_AND_ASSIGN(auto out_stream, io::BufferOutputStream::Create());
   ASSERT_OK(ipc::WriteRecordBatchStream({batch}, ipc::IpcOptions::Defaults(),
                                         out_stream.get()));
 
@@ -255,7 +255,7 @@ TEST_F(TestExtensionType, UnrecognizedExtension) {
 
   // Write full IPC stream including schema, then unregister type, then read
   // and ensure that a plain instance of the storage type is created
-  ASSERT_OK_AND_ASSIGN(auto out_stream, io::BufferOutputStream::Create(1024));
+  ASSERT_OK_AND_ASSIGN(auto out_stream, io::BufferOutputStream::Create());
   ASSERT_OK(ipc::WriteRecordBatchStream({batch}, ipc::IpcOptions::Defaults(),
                                         out_stream.get()));
 

--- a/cpp/src/arrow/io/compressed_test.cc
+++ b/cpp/src/arrow/io/compressed_test.cc
@@ -127,7 +127,7 @@ void CheckCompressedInputStream(Codec* codec, const std::vector<uint8_t>& data) 
 void CheckCompressedOutputStream(Codec* codec, const std::vector<uint8_t>& data,
                                  bool do_flush) {
   // Create compressed output stream
-  ASSERT_OK_AND_ASSIGN(auto buffer_writer, BufferOutputStream::Create(1024));
+  ASSERT_OK_AND_ASSIGN(auto buffer_writer, BufferOutputStream::Create());
   ASSERT_OK_AND_ASSIGN(auto stream, CompressedOutputStream::Make(codec, buffer_writer));
   ASSERT_OK_AND_EQ(0, stream->Tell());
 

--- a/cpp/src/arrow/io/memory.h
+++ b/cpp/src/arrow/io/memory.h
@@ -46,7 +46,7 @@ class ARROW_EXPORT BufferOutputStream : public OutputStream {
   /// \param[in,out] pool a MemoryPool to use for allocations
   /// \return the created stream
   static Result<std::shared_ptr<BufferOutputStream>> Create(
-      int64_t initial_capacity, MemoryPool* pool = default_memory_pool());
+      int64_t initial_capacity = 4096, MemoryPool* pool = default_memory_pool());
 
   ARROW_DEPRECATED("Use Result-returning overload")
   static Status Create(int64_t initial_capacity, MemoryPool* pool,

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -281,7 +281,7 @@ void CheckBatches(const RecordBatch& expected, const RecordBatch& result) {
 class TestTableReader : public ::testing::Test {
  public:
   void SetUp() {
-    ASSERT_OK_AND_ASSIGN(stream_, io::BufferOutputStream::Create(1024));
+    ASSERT_OK_AND_ASSIGN(stream_, io::BufferOutputStream::Create());
     ASSERT_OK(TableWriter::Open(stream_, &writer_));
   }
 
@@ -356,7 +356,7 @@ TEST_F(TestTableReader, ReadNames) {
 class TestTableWriter : public ::testing::Test {
  public:
   void SetUp() {
-    ASSERT_OK_AND_ASSIGN(stream_, io::BufferOutputStream::Create(1024));
+    ASSERT_OK_AND_ASSIGN(stream_, io::BufferOutputStream::Create());
     ASSERT_OK(TableWriter::Open(stream_, &writer_));
   }
 

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -412,7 +412,7 @@ TEST(TestFileReader, BufferedReads) {
   std::shared_ptr<WriterProperties> writer_props =
       WriterProperties::Builder().write_batch_size(64)->data_pagesize(128)->build();
 
-  ASSERT_OK_AND_ASSIGN(auto out_file, arrow::io::BufferOutputStream::Create(1024));
+  ASSERT_OK_AND_ASSIGN(auto out_file, arrow::io::BufferOutputStream::Create());
   std::shared_ptr<ParquetFileWriter> file_writer =
       ParquetFileWriter::Open(out_file, schema, writer_props);
 


### PR DESCRIPTION
Make the initial capacity argument optional.