### PR TITLE
ARROW-7734: [C++] check status details for nullptr in equality

### DIFF
--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -292,6 +292,7 @@ class ARROW_EXPORT Status : public util::EqualityComparable<Status>,
   }
 
   bool IsExecutionError() const { return code() == StatusCode::ExecutionError; }
+  bool IsAlreadyExists() const { return code() == StatusCode::AlreadyExists; }
 
   /// \brief Return a string representation of this status suitable for printing.
   ///
@@ -385,8 +386,11 @@ bool Status::Equals(const Status& s) const {
     return false;
   }
 
-  if (detail() != s.detail() && !(*detail() == *s.detail())) {
-    return false;
+  if (detail() != s.detail()) {
+    if ((detail() && !s.detail()) || (!detail() && s.detail())) {
+      return false;
+    }
+    return *detail() == *s.detail();
   }
 
   return code() == s.code() && message() == s.message();

--- a/cpp/src/arrow/status_test.cc
+++ b/cpp/src/arrow/status_test.cc
@@ -114,4 +114,17 @@ TEST(StatusTest, TestEquality) {
   ASSERT_NE(Status::Invalid("error"), Status::Invalid("other error"));
 }
 
+TEST(StatusTest, TestDetailEquality) {
+  const auto status_with_detail =
+      arrow::Status(StatusCode::IOError, "", std::make_shared<TestStatusDetail>());
+  const auto status_with_detail2 =
+      arrow::Status(StatusCode::IOError, "", std::make_shared<TestStatusDetail>());
+  const auto status_without_detail = arrow::Status::IOError("");
+
+  ASSERT_EQ(*status_with_detail.detail(), *status_with_detail2.detail());
+  ASSERT_EQ(status_with_detail, status_with_detail2);
+  ASSERT_NE(status_with_detail, status_without_detail);
+  ASSERT_NE(status_without_detail, status_with_detail);
+}
+
 }  // namespace arrow


### PR DESCRIPTION
When checking statuses for equality, check to make sure that both have status detail objects before proceeding to compare those objects.