### PR TITLE
ARROW-7514: [C#] Make GetValueOffset Obsolete

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -171,7 +171,7 @@ namespace Apache.Arrow
         public ReadOnlySpan<byte> Values => ValueBuffer.Span.CastTo<byte>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [Obsolete]
+        [Obsolete("This method has been deprecated. Please use ValueOffsets instead.")]
         public int GetValueOffset(int index)
         {
             if (index < 0 || index > Length)

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -171,7 +171,7 @@ namespace Apache.Arrow
         public ReadOnlySpan<byte> Values => ValueBuffer.Span.CastTo<byte>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        [Obsolete("This method has been deprecated. Please use ValueOffsets instead.")]
+        [Obsolete("This method has been deprecated. Please use ValueOffsets[index] instead.")]
         public int GetValueOffset(int index)
         {
             if (index < 0 || index > Length)

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -171,6 +171,7 @@ namespace Apache.Arrow
         public ReadOnlySpan<byte> Values => ValueBuffer.Span.CastTo<byte>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        [Obsolete]
         public int GetValueOffset(int index)
         {
             if (index < 0 || index > Length)
@@ -193,10 +194,12 @@ namespace Apache.Arrow
 
         public ReadOnlySpan<byte> GetBytes(int index)
         {
-            var offset = GetValueOffset(index);
-            var length = GetValueLength(index);
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
 
-            return ValueBuffer.Span.Slice(offset, length);
+            return ValueBuffer.Span.Slice(ValueOffsets[index], GetValueLength(index));
         }
 
     }

--- a/csharp/src/Apache.Arrow/Arrays/ListArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ListArray.cs
@@ -123,7 +123,7 @@ namespace Apache.Arrow
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
 
 
-        [Obsolete("This method has been deprecated. Please use ValueOffsets instead.")]
+        [Obsolete("This method has been deprecated. Please use ValueOffsets[index] instead.")]
         public int GetValueOffset(int index)
         {
             if (index < 0 || index > Length)

--- a/csharp/src/Apache.Arrow/Arrays/ListArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ListArray.cs
@@ -123,7 +123,7 @@ namespace Apache.Arrow
         public override void Accept(IArrowArrayVisitor visitor) => Accept(this, visitor);
 
 
-        [Obsolete]
+        [Obsolete("This method has been deprecated. Please use ValueOffsets instead.")]
         public int GetValueOffset(int index)
         {
             if (index < 0 || index > Length)

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -46,6 +46,12 @@ namespace Apache.Arrow.Tests
             Assert.Equal(2, array.GetValueOffset(2));
             Assert.Throws<ArgumentOutOfRangeException>(() => array.GetValueOffset(3));
 
+            Assert.Throws<IndexOutOfRangeException>(() => array.ValueOffsets[-1]);
+            Assert.Equal(0, array.ValueOffsets[0]);
+            Assert.Equal(1, array.ValueOffsets[1]);
+            Assert.Equal(2, array.ValueOffsets[2]);
+            Assert.Throws<IndexOutOfRangeException>(() => array.ValueOffsets[3]);
+
         }
 
         [Fact]

--- a/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowArrayTests.cs
@@ -40,11 +40,13 @@ namespace Apache.Arrow.Tests
             Assert.Equal(1, array.GetValueLength(1));
             Assert.Throws<ArgumentOutOfRangeException>(() => array.GetValueLength(2));
 
+#pragma warning disable 618
             Assert.Throws<ArgumentOutOfRangeException>(() => array.GetValueOffset(-1));
             Assert.Equal(0, array.GetValueOffset(0));
             Assert.Equal(1, array.GetValueOffset(1));
             Assert.Equal(2, array.GetValueOffset(2));
             Assert.Throws<ArgumentOutOfRangeException>(() => array.GetValueOffset(3));
+#pragma warning restore 618
 
             Assert.Throws<IndexOutOfRangeException>(() => array.ValueOffsets[-1]);
             Assert.Equal(0, array.ValueOffsets[0]);


### PR DESCRIPTION
* Add an [Obsolete] attribute to `BinaryArray.GetValueOffset`
  * `ListArray.GetValueOffset` already has the [Obsolete] attribute, so it is not changed
* Avoid using `GetValueOffset` in the product source code

As a precaution, I added tests for `ValueOffsets` and left tests for `GetValueOffset`.