### PR TITLE
ARROW-7735: [Release] Add missing conda-forge channel to verify wheels

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -224,6 +224,7 @@ setup_miniconda() {
   rm -f miniconda.sh
 
   . $MINICONDA/etc/profile.d/conda.sh
+  conda config --add channels conda-forge
 }
 
 # Build and test Java (Requires newer Maven -- I used 3.3.9)


### PR DESCRIPTION
pytest-faulthandler and pytest-lazy-fixture require it.