### PR TITLE
ARROW-7741: [C++] Add a enum to control parquet engine version

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -104,6 +104,11 @@ class FileReaderImpl : public FileReader {
       : pool_(pool), reader_(std::move(reader)), reader_properties_(properties) {}
 
   Status Init() {
+    if (reader_properties_.engine() != ArrowEngineVersion::kDefault) {
+      return Status::NotImplemented("Engine version '", (int)reader_properties_.engine(),
+                                    "' not implemented.");
+    }
+
     return SchemaManifest::Make(reader_->metadata()->schema(),
                                 reader_->metadata()->key_value_metadata(),
                                 reader_properties_, &manifest_);

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -104,7 +104,7 @@ class FileReaderImpl : public FileReader {
       : pool_(pool), reader_(std::move(reader)), reader_properties_(properties) {}
 
   Status Init() {
-    if (reader_properties_.engine() != ArrowEngineVersion::kDefault) {
+    if (reader_properties_.engine() != ArrowEngineVersion::V1) {
       return Status::NotImplemented("Engine version '", (int)reader_properties_.engine(),
                                     "' not implemented.");
     }

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -427,6 +427,10 @@ class FileWriterImpl : public FileWriter {
         closed_(false) {}
 
   Status Init() {
+    if (arrow_properties_->engine() != ArrowEngineVersion::kDefault) {
+      return Status::NotImplemented("Engine version '", (int)arrow_properties_->engine(),
+                                    "' not implemented.");
+    }
     return SchemaManifest::Make(writer_->schema(), /*schema_metadata=*/nullptr,
                                 default_arrow_reader_properties(), &schema_manifest_);
   }

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -427,7 +427,7 @@ class FileWriterImpl : public FileWriter {
         closed_(false) {}
 
   Status Init() {
-    if (arrow_properties_->engine() != ArrowEngineVersion::kDefault) {
+    if (arrow_properties_->engine() != ArrowEngineVersion::V1) {
       return Status::NotImplemented("Engine version '", (int)arrow_properties_->engine(),
                                     "' not implemented.");
     }

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -541,11 +541,11 @@ static constexpr int64_t kArrowDefaultBatchSize = 64 * 1024;
 enum class ArrowEngineVersion {
   // The current default engine. This doesn't support mixed
   // struct list date.
-  kDefault = 0,
+  V1 = 0,
 
   // Not fully implemented.  When done this will support reading/
   // writing all forms of nested data.
-  kNextGen = 1
+  V2 = 1
 };
 
 /// EXPERIMENTAL: Properties for configuring FileReader behavior.
@@ -588,7 +588,7 @@ class PARQUET_EXPORT ArrowReaderProperties {
   bool use_threads_;
   std::unordered_set<int> read_dict_indices_;
   int64_t batch_size_;
-  ArrowEngineVersion engine_ = ArrowEngineVersion::kDefault;
+  ArrowEngineVersion engine_ = ArrowEngineVersion::V1;
 };
 
 /// EXPERIMENTAL: Constructs the default ArrowReaderProperties
@@ -657,7 +657,7 @@ class PARQUET_EXPORT ArrowWriterProperties {
 
     bool coerce_timestamps_enabled_;
     ::arrow::TimeUnit::type coerce_timestamps_unit_;
-    ArrowEngineVersion engine_ = ArrowEngineVersion::kDefault;
+    ArrowEngineVersion engine_ = ArrowEngineVersion::V1;
     bool truncated_timestamps_allowed_;
 
     bool store_schema_;


### PR DESCRIPTION
There are going to be code paths added to read/write nested data.
Until these are fully validated we should have a flag to switch
the code on/off (new code to be implemented in future PRs)