### PR TITLE
ARROW-7735: [Release][Python] Use pip to install dependencies for wheel verification

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -613,7 +613,7 @@ test_linux_wheels() {
       pip install -r ${ARROW_DIR}/python/requirements-test.txt
 
       # execute the tests
-      pytest -sv --pyargs pyarrow
+      pytest --pyargs pyarrow
     done
 
     conda deactivate
@@ -646,7 +646,7 @@ test_macos_wheels() {
     pip install -r ${ARROW_DIR}/python/requirements-test.txt
 
     # execute the tests
-    pytest -sv --pyargs pyarrow
+    pytest --pyargs pyarrow
 
     conda deactivate
   done

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -609,9 +609,11 @@ test_linux_wheels() {
       pip install python-rc/${VERSION}-rc${RC_NUMBER}/pyarrow-${VERSION}-cp${py_arch//[mu.]/}-cp${py_arch//./}-manylinux${ml_spec}_x86_64.whl
       check_python_imports py_arch
 
-      # execute the python unit tests
-      conda install -y --file ${ARROW_DIR}/ci/conda_env_python.yml pandas
-      pytest --pyargs pyarrow
+      # install test requirements
+      pip install -r ${ARROW_DIR}/python/requirements-test.txt
+
+      # execute the tests
+      pytest -sv --pyargs pyarrow
     done
 
     conda deactivate
@@ -640,9 +642,11 @@ test_macos_wheels() {
     pip install python-rc/${VERSION}-rc${RC_NUMBER}/pyarrow-${VERSION}-cp${py_arch//[m.]/}-cp${py_arch//./}-${macos_suffix}.whl
     check_python_imports py_arch
 
-    # execute the python unit tests
-    conda install -y --file ${ARROW_DIR}/ci/conda_env_python.yml pandas
-    pytest --pyargs pyarrow
+    # install test requirements
+    pip install -r ${ARROW_DIR}/python/requirements-test.txt
+
+    # execute the tests
+    pytest -sv --pyargs pyarrow
 
     conda deactivate
   done


### PR DESCRIPTION
The wheel verification script fails for python 3.5. 
At the same time the wheel properly works for python 3.5 docker
images without conda environment.

Conda forge doesn't maintain packages for python 3.5 anymore
and something must have mixed with the numpy versions.

This change fixed the wheel verification locally for me.