### PR TITLE
ARROW-7466: [CI] Disable gandiva OSX jar deploy

### DIFF
--- a/dev/tasks/gandiva-jars/travis.osx.yml
+++ b/dev/tasks/gandiva-jars/travis.osx.yml
@@ -53,14 +53,15 @@ script:
   - dev/tasks/gandiva-jars/build-cpp-osx.sh || travis_terminate 1
   - dev/tasks/gandiva-jars/build-java.sh || travis_terminate 1
 
-deploy:
-  provider: releases
-  api_key: $CROSSBOW_GITHUB_TOKEN
-  file_glob: true
-  file: dist/*.jar
-  skip_cleanup: true
-  on:
-    tags: true
+# ARROW-7466
+# deploy:
+#   provider: releases
+#   api_key: $CROSSBOW_GITHUB_TOKEN
+#   file_glob: true
+#   file: dist/*.jar
+#   skip_cleanup: true
+#   on:
+#     tags: true
 
 notifications:
   email:


### PR DESCRIPTION
This has been failing for months, disabling as it seems no one is affected. The build is still tested, only the jars are not deployed anymore.