### PR TITLE
ARROW-7751: [Release] macOS wheel verification also needs arrow-testing

### DIFF
--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -454,7 +454,8 @@ Status TestClientBasicAuthHandler::GetToken(std::string* token) {
 Status GetTestResourceRoot(std::string* out) {
   const char* c_root = std::getenv("ARROW_TEST_DATA");
   if (!c_root) {
-    return Status::IOError("Test resources not found, set ARROW_TEST_DATA to <repo root>/testing/data");
+    return Status::IOError(
+        "Test resources not found, set ARROW_TEST_DATA to <repo root>/testing/data");
   }
   *out = std::string(c_root);
   return Status::OK();

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -454,7 +454,7 @@ Status TestClientBasicAuthHandler::GetToken(std::string* token) {
 Status GetTestResourceRoot(std::string* out) {
   const char* c_root = std::getenv("ARROW_TEST_DATA");
   if (!c_root) {
-    return Status::IOError("Test resources not found, set ARROW_TEST_DATA");
+    return Status::IOError("Test resources not found, set ARROW_TEST_DATA to <repo root>/testing/data");
   }
   *out = std::string(c_root);
   return Status::OK();

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -637,10 +637,6 @@ test_linux_wheels() {
 
 test_macos_wheels() {
   local py_arches="2.7m 3.5m 3.6m 3.7m 3.8"
-  if [ ! -d "arrow-testing" ]; then
-    git clone https://github.com/apache/arrow-testing.git
-  fi
-  export ARROW_TEST_DATA=$PWD/arrow-testing/data
 
   for py_arch in ${py_arches}; do
     local env=_verify_wheel-${py_arch}
@@ -672,6 +668,11 @@ test_macos_wheels() {
 }
 
 test_wheels() {
+  if [ ! -d "arrow-testing" ]; then
+    git clone https://github.com/apache/arrow-testing.git
+  fi
+  export ARROW_TEST_DATA=$PWD/arrow-testing/data
+  
   local download_dir=binaries
   mkdir -p ${download_dir}
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -637,6 +637,10 @@ test_linux_wheels() {
 
 test_macos_wheels() {
   local py_arches="2.7m 3.5m 3.6m 3.7m 3.8"
+  if [ ! -d "arrow-testing" ]; then
+    git clone https://github.com/apache/arrow-testing.git
+  fi
+  export ARROW_TEST_DATA=$PWD/arrow-testing/data
 
   for py_arch in ${py_arches}; do
     local env=_verify_wheel-${py_arch}

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -522,6 +522,18 @@ test_integration() {
               $INTEGRATION_TEST_ARGS
 }
 
+clone_testing_repositories() {
+  # Clone testing repositories if not cloned already
+  if [ ! -d "arrow-testing" ]; then
+    git clone https://github.com/apache/arrow-testing.git
+  fi
+  if [ ! -d "parquet-testing" ]; then
+    git clone https://github.com/apache/parquet-testing.git
+  fi
+  export ARROW_TEST_DATA=$PWD/arrow-testing/data
+  export PARQUET_TEST_DATA=$PWD/parquet-testing/data
+}
+
 test_source_distribution() {
   export ARROW_HOME=$TMPDIR/install
   export PARQUET_HOME=$TMPDIR/install
@@ -534,15 +546,7 @@ test_source_distribution() {
     NPROC=$(nproc)
   fi
 
-  # Clone testing repositories if not cloned already
-  if [ ! -d "arrow-testing" ]; then
-    git clone https://github.com/apache/arrow-testing.git
-  fi
-  if [ ! -d "parquet-testing" ]; then
-    git clone https://github.com/apache/parquet-testing.git
-  fi
-  export ARROW_TEST_DATA=$PWD/arrow-testing/data
-  export PARQUET_TEST_DATA=$PWD/parquet-testing/data
+  clone_testing_repositories
 
   if [ ${TEST_JAVA} -gt 0 ]; then
     test_package_java
@@ -668,11 +672,8 @@ test_macos_wheels() {
 }
 
 test_wheels() {
-  if [ ! -d "arrow-testing" ]; then
-    git clone https://github.com/apache/arrow-testing.git
-  fi
-  export ARROW_TEST_DATA=$PWD/arrow-testing/data
-  
+  clone_testing_repositories
+
   local download_dir=binaries
   mkdir -p ${download_dir}
 

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -60,7 +60,7 @@ def resource_root():
     """Get the path to the test resources directory."""
     if not os.environ.get("ARROW_TEST_DATA"):
         raise RuntimeError("Test resources not found; set "
-                           "ARROW_TEST_DATA to <repo root>/testing")
+                           "ARROW_TEST_DATA to <repo root>/testing/data")
     return pathlib.Path(os.environ["ARROW_TEST_DATA"]) / "flight"
 
 


### PR DESCRIPTION
This addition follows the pattern of `test_source_distribution` (as it is in #6344). There are also two error message patches to make them consistent with everywhere else that references this env var (though FWIW `testing/data` is still not correct in the verification script, it's `arrow-testing/data` 🤷‍♂).