### PR TITLE
ARROW-7760: [Release] Fix verify-release-candidate.sh since pip3 seems to no longer be in miniconda, install miniconda unconditionally

### DIFF
--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -227,23 +227,23 @@ def get_static_json_files():
     ]
 
 
-def run_all_tests(enable_cpp=True, enable_java=True, enable_js=True,
-                  enable_go=True, run_flight=False,
+def run_all_tests(with_cpp=True, with_java=True, with_js=True,
+                  with_go=True, run_flight=False,
                   tempdir=None, **kwargs):
     tempdir = tempdir or tempfile.mkdtemp()
 
     testers = []
 
-    if enable_cpp:
+    if with_cpp:
         testers.append(CPPTester(kwargs))
 
-    if enable_java:
+    if with_java:
         testers.append(JavaTester(kwargs))
 
-    if enable_js:
+    if with_js:
         testers.append(JSTester(kwargs))
 
-    if enable_go:
+    if with_go:
         testers.append(GoTester(kwargs))
 
     static_json_files = get_static_json_files()

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -503,7 +503,7 @@ test_integration() {
   export ARROW_JAVA_INTEGRATION_JAR=$JAVA_DIR/tools/target/arrow-tools-$VERSION-jar-with-dependencies.jar
   export ARROW_CPP_EXE_PATH=$CPP_BUILD_DIR/release
 
-  pip3 install -e dev/archery
+  pip install -e dev/archery
 
   INTEGRATION_TEST_ARGS=""
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -238,6 +238,15 @@ setup_miniconda() {
   fi
 
   . $MINICONDA/etc/profile.d/conda.sh
+
+  conda create -n arrow-test -y -q -c conda-forge \
+        python=3.6 \
+        nomkl \
+        numpy \
+        pandas \
+        six \
+        cython
+  conda activate arrow-test
 }
 
 # Build and test Java (Requires newer Maven -- I used 3.3.9)
@@ -254,15 +263,6 @@ test_package_java() {
 # Build and test C++
 
 test_and_install_cpp() {
-  conda create -n arrow-test -y -q -c conda-forge \
-        python=3.6 \
-        nomkl \
-        numpy \
-        pandas \
-        six \
-        cython
-  conda activate arrow-test
-
   mkdir -p cpp/build
   pushd cpp/build
 
@@ -764,6 +764,10 @@ if [ "${ARTIFACT}" == "source" ]; then
     tar xf ${dist_name}.tar.gz
   else
     mkdir -p ${dist_name}
+    if [ ! -f ${TEST_ARCHIVE} ]; then
+      echo "${TEST_ARCHIVE} not found, did you mean to pass TEST_SOURCE=1?"
+      exit 1
+    fi
     tar xf ${TEST_ARCHIVE} -C ${dist_name} --strip-components=1
   fi
   pushd ${dist_name}


### PR DESCRIPTION
This change was necessary for me to get the script to finish to completion.