### PR TITLE
ARROW-6757: [Release] Use same CMake generator for C++ and Python when verifying RC, remove Python 3.5 from wheel verification

### DIFF
--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -25,16 +25,13 @@
 @echo on
 
 set _CURRENT_DIR=%CD%
-set _VERIFICATION_DIR=C:\tmp\arrow-verify-release
+set _VERIFICATION_DIR=C:\tmp\arrow-verify-release-wheels
 
 if not exist "C:\tmp\" mkdir C:\tmp
 if exist %_VERIFICATION_DIR% rd %_VERIFICATION_DIR% /s /q
 if not exist %_VERIFICATION_DIR% mkdir %_VERIFICATION_DIR%
 
 cd %_VERIFICATION_DIR%
-
-CALL :verify_wheel 3.5 %1 %2
-if errorlevel 1 GOTO error
 
 CALL :verify_wheel 3.6 %1 %2
 if errorlevel 1 GOTO error
@@ -62,7 +59,7 @@ set ARROW_VERSION=%2
 set RC_NUMBER=%3
 set PY_VERSION_NO_PERIOD=%PY_VERSION:.=%
 
-set CONDA_ENV_PATH=C:\tmp\arrow-verify-release\_verify-wheel-%PY_VERSION%
+set CONDA_ENV_PATH=%_VERIFICATION_DIR%\_verify-wheel-%PY_VERSION%
 call conda create -p %CONDA_ENV_PATH% ^
     --no-shortcuts -f -q -y python=%PY_VERSION% ^
     || EXIT /B 1

--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -71,7 +71,10 @@ pushd %ARROW_SOURCE%\cpp\build
 @rem This is the path for Visual Studio Community 2017
 call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64
 
-cmake -G "Ninja" ^
+@rem NOTE(wesm): not using Ninja for now to be able to more easily control the
+@rem generator used
+
+cmake -G "%GENERATOR%" ^
       -DCMAKE_INSTALL_PREFIX=%ARROW_HOME% ^
       -DARROW_BUILD_STATIC=OFF ^
       -DARROW_BOOST_USE_SHARED=ON ^
@@ -90,11 +93,13 @@ cmake -G "Ninja" ^
       -DARROW_PARQUET=ON ^
       ..  || exit /B
 
+cmake --build . --target INSTALL --config Release
+
 @rem NOTE(wesm): Building googletest is flaky for me with ninja. Building it
 @rem first fixes the problem
-ninja googletest_ep || exit /B
 
-ninja install || exit /B
+@rem ninja googletest_ep || exit /B
+@rem ninja install || exit /B
 
 @rem Get testing datasets for Parquet unit tests
 git clone https://github.com/apache/parquet-testing.git %_VERIFICATION_DIR%\parquet-testing
@@ -112,6 +117,7 @@ popd
 @rem Build and import pyarrow
 pushd %ARROW_SOURCE%\python
 
+set PYARROW_CMAKE_GENERATOR=%GENERATOR%
 set PYARROW_WITH_FLIGHT=1
 set PYARROW_WITH_PARQUET=1
 python setup.py build_ext --inplace --bundle-arrow-cpp bdist_wheel  || exit /B


### PR DESCRIPTION
This resolves the issues I was having as described in ARROW-6757. This does not fix the Python 3.8 wheel, though