### PR TITLE
ARROW-7766: [Python][Packaging] Windows py38 wheels are built with wrong ABI tag

### DIFF
--- a/python/requirements-wheel.txt
+++ b/python/requirements-wheel.txt
@@ -6,7 +6,6 @@ pandas
 setuptools_scm==3.2.0
 six>=1.0.0
 # TODO: TensorFlow doesn't support Python 3.8 yet.
+# See https://github.com/tensorflow/tensorflow/issues/33374
 tensorflow; python_version >= "3.0" and python_version < "3.8"
-# pin wheel, because auditwheel is not compatible with wheel=0.32
-# TODO(kszucs): remove after auditwheel properly supports wheel>0.31
-wheel==0.31.1
+wheel


### PR DESCRIPTION
This is fixed in the latest release of `wheel` but we were pinning to an old version