### PR TITLE
ARROW-7772: [R][C++][Dataset] Unable to filter on date32 object with date64 scalar

### DIFF
--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -352,6 +352,8 @@ TEST_F(ExpressionsTest, ImplicitCast) {
   ASSERT_OK_AND_ASSIGN(filter, InsertImplicitCasts("a"_.In(set_double), *schema_));
   auto set_int32 = ArrayFromJSON(int32(), R"([1, 2, 3])");
   ASSERT_EQ(E{filter}, E{"a"_.In(set_int32)});
+
+  ASSERT_RAISES(Invalid, InsertImplicitCasts("nope"_ == 0.0, *schema_));
 }
 
 TEST_F(FilterTest, ImplicitCast) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -305,6 +305,19 @@ TEST(TestTimestampScalars, Cast) {
 
   EXPECT_EQ(convert(TimeUnit::NANO, TimeUnit::MICRO, 1234), 1);
   EXPECT_EQ(convert(TimeUnit::MICRO, TimeUnit::MILLI, 4567), 4);
+
+  ASSERT_OK_AND_ASSIGN(auto str,
+                       TimestampScalar(1024, timestamp(TimeUnit::MILLI)).CastTo(utf8()));
+  EXPECT_EQ(*str, StringScalar("1024"));
+  ASSERT_OK_AND_ASSIGN(auto i64,
+                       TimestampScalar(1024, timestamp(TimeUnit::MILLI)).CastTo(int64()));
+  EXPECT_EQ(*i64, Int64Scalar(1024));
+
+  constexpr int64_t kMillisecondsInDay = 86400000;
+  ASSERT_OK_AND_ASSIGN(
+      auto d64, TimestampScalar(1024 * kMillisecondsInDay + 3, timestamp(TimeUnit::MILLI))
+                    .CastTo(date64()));
+  EXPECT_EQ(*d64, Date64Scalar(1024 * kMillisecondsInDay));
 }
 
 TEST(TestDurationScalars, Basics) {

--- a/cpp/src/arrow/util/time.h
+++ b/cpp/src/arrow/util/time.h
@@ -45,9 +45,9 @@ static std::pair<DivideOrMultiply, int64_t> kTimestampConversionTable[4][4] = {
 //
 // This function takes care of properly transforming from one unit to another.
 //
-// \param[in] in, the input type. Must be TimestampType.
-// \param[in] out, the output type. Must be TimestampType.
-// \param[in] value, the input value.
+// \param[in] in the input type. Must be TimestampType.
+// \param[in] out the output type. Must be TimestampType.
+// \param[in] value the input value.
 //
 // \return The converted value, or an error.
 ARROW_EXPORT Result<int64_t> ConvertTimestampValue(const std::shared_ptr<DataType>& in,

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -19,6 +19,8 @@
 
 # arrow 0.16.0.9000
 
+* Dataset filtering is now correctly supported for all Arrow date/time/timestamp column types.
+
 # arrow 0.16.0
 
 ## Multi-file datasets

--- a/r/src/expression.cpp
+++ b/r/src/expression.cpp
@@ -108,9 +108,8 @@ std::shared_ptr<ds::ScalarExpression> dataset___expr__scalar(SEXP x) {
       return ds::scalar(Rf_asLogical(x));
     case REALSXP:
       if (Rf_inherits(x, "Date")) {
-        constexpr static int64_t kMillisecondsPerDay = 86400000;
         return std::make_shared<ds::ScalarExpression>(
-            std::make_shared<arrow::Date64Scalar>(REAL(x)[0] * kMillisecondsPerDay));
+            std::make_shared<arrow::Date32Scalar>(REAL(x)[0]));
       } else if (Rf_inherits(x, "POSIXct")) {
         return std::make_shared<ds::ScalarExpression>(
             std::make_shared<arrow::TimestampScalar>(

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -227,6 +227,14 @@ test_that("filter() on date32 columns", {
       nrow(),
     1L
   )
+
+  expect_equal(
+    open_dataset(tmp) %>%
+      filter(date > lubridate::ymd_hms("2020-02-02 00:00:00")) %>%
+      collect() %>%
+      nrow(),
+    1L
+  )
 })
 
 test_that("collect() on Dataset works (if fits in memory)", {

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -212,6 +212,26 @@ test_that("filter() on timestamp columns", {
       collect(),
     df1[5:10, c("ts")],
   )
+
+  # Now with Date
+  expect_equivalent(
+    ds %>%
+      filter(ts >= as.Date("2015-05-04")) %>%
+      filter(part == 1) %>%
+      select(ts) %>%
+      collect(),
+    df1[5:10, c("ts")],
+  )
+
+  # Now with bare string date
+  expect_equivalent(
+    ds %>%
+      filter(ts >= "2015-05-04") %>%
+      filter(part == 1) %>%
+      select(ts) %>%
+      collect(),
+    df1[5:10, c("ts")],
+  )
 })
 
 test_that("filter() on date32 columns", {
@@ -228,12 +248,22 @@ test_that("filter() on date32 columns", {
     1L
   )
 
+  # Also with timestamp scalar
   expect_equal(
     open_dataset(tmp) %>%
       filter(date > lubridate::ymd_hms("2020-02-02 00:00:00")) %>%
       collect() %>%
       nrow(),
     1L
+  )
+})
+
+test_that("filter scalar validation doesn't crash (ARROW-7772)", {
+  expect_error(
+    ds %>%
+      filter(int == "fff", part == 1) %>%
+      collect(),
+    "error parsing 'fff' as scalar of type int32"
   )
 })
 

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -214,6 +214,21 @@ test_that("filter() on timestamp columns", {
   )
 })
 
+test_that("filter() on date32 columns", {
+  tmp <- tempfile()
+  dir.create(tmp)
+  df <- data.frame(date = as.Date(c("2020-02-02", "2020-02-03")))
+  write_parquet(df, file.path(tmp, "file.parquet"))
+
+  expect_equal(
+    open_dataset(tmp) %>%
+      filter(date > as.Date("2020-02-02")) %>%
+      collect() %>%
+      nrow(),
+    1L
+  )
+})
+
 test_that("collect() on Dataset works (if fits in memory)", {
   expect_equal(
     collect(open_dataset(dataset_dir)),


### PR DESCRIPTION
I fixed the issue in the R bindings that triggered @stephhazlitt's report. Then I added another test that still causes the crash. 

The crash message points at this line: https://github.com/apache/arrow/blob/master/cpp/src/arrow/scalar.cc#L333

```
/Users/enpiar/Documents/ursa/arrow/cpp/src/arrow/dataset/filter.cc:929:  Check failed: _s.ok() Operation failed: maybe_value.status()
Bad status: NotImplemented: casting scalars of type timestamp[s] to type date32[day]
In /Users/enpiar/Documents/ursa/arrow/cpp/src/arrow/scalar.cc, line 333, code: VisitTypeInline(*to, &unpack_to_type)
```

@bkietz over to you to catch that crash and also hopefully to support this cast. 