### PR TITLE
ARROW-7776: [C++][Conda] Missing abseil-cpp transitive dependency of grpc-cpp

### DIFF
--- a/ci/conda_env_cpp.yml
+++ b/ci/conda_env_cpp.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+abseil-cpp
 aws-sdk-cpp
 benchmark=1.4.1
 boost-cpp>=1.68.0

--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
+    - abseil-cpp
     - aws-sdk-cpp
     - boost-cpp
     - brotli


### PR DESCRIPTION
With the recent grpc-cpp-feedstock [update](https://github.com/conda-forge/grpc-cpp-feedstock/pull/45) our builds require abseil-cpp as a transitive dependency otherwise we get link errors, see [build log](https://ci.appveyor.com/project/Ursa-Labs/crossbow/builds/30596560).