### PR TITLE
ARROW-1581: [Packaging] Tooling to make nightly wheels available for install

### DIFF
--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -1094,9 +1094,9 @@ class GithubPage:
         self.jobs = list(jobs)
 
     def _generate_page(self, links):
-        links = ['<a href="{}">{}</a>'.format(url, name)
+        links = ['<li><a href="{}">{}</a></li>'.format(url, name)
                  for name, url in sorted(links.items())]
-        return '<html><body>{}</body></html>'.format('<br>'.join(links))
+        return '<html><body><ul>{}</ul></body></html>'.format(''.join(links))
 
     def _generate_toc(self, files):
         result, links = {}, {}

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -66,6 +66,7 @@ def md(template, *args, **kwargs):
 
 
 def unflatten(mapping):
+    """Converts a flat tuple => object mapping to hierarchical one"""
     result = {}
     for path, value in mapping.items():
         parents, leaf = path[:-1], path[-1]
@@ -81,6 +82,25 @@ def unflatten(mapping):
 
 
 def unflatten_tree(files):
+    """Converts a flat path => object mapping to a hierarchical directories
+
+    Input:
+        {
+            'path/to/file.a': a_content,
+            'path/to/file.b': b_content,
+            'path/file.c': c_content
+        }
+    Output:
+        {
+            'path': {
+                'to': {
+                    'file.a': a_content,
+                    'file.b': b_content
+                },
+                'file.c': c_content
+            }
+        }
+    """
     files = toolz.keymap(lambda path: tuple(path.split('/')), files)
     return unflatten(files)
 
@@ -891,7 +911,7 @@ class Job(Serializable):
             with concurrent.futures.ThreadPoolExecutor(max_workers) as pool:
                 for task_name, task in sorted(self.tasks.items()):
                     # HACK: spare some queries because of the rate limit, and
-                    # don't query tasks with specieid prefig, e.g. "test-"
+                    # don't query tasks with specified prefix, e.g. "test-"
                     if (ignore_prefix is not None and
                             task_name.startswith(ignore_prefix)):
                         continue

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -433,7 +433,7 @@ class Repo:
         if self._github_repo is None:
             username, reponame = self._parse_github_user_repo()
             gh = github3.login(token=self.github_token)
-            return gh.repository(username, reponame)
+            self._github_repo = gh.repository(username, reponame)
         return self._github_repo
 
     def github_commit_status(self, commit):
@@ -1115,13 +1115,11 @@ class GithubPage:
     def _is_failed(self, status, task_name):
         # for showing task statuses during the rendering procedure
         if status.state == 'success':
-            msg = click.style('[  OK] {}'.format(task_name),
-                                fg='green')
+            msg = click.style('[  OK] {}'.format(task_name), fg='green')
             failed = False
             click.echo(msg)
         else:
-            msg = click.style('[FAIL] {}'.format(task_name),
-                                fg='yellow')
+            msg = click.style('[FAIL] {}'.format(task_name), fg='yellow')
             failed = True
 
         click.echo(msg)
@@ -1427,7 +1425,7 @@ def generate_github_page(ctx, n, gh_branch, job_prefix, dry_run):
     # $ at the end of the pattern is important because we're only looking for
     # branches belonging to jobs not branches belonging to tasks
     # the branches we're looking for are like 2020-01-01-0
-    jobs = queue.jobs(pattern="^nightly-(\d{4})-(\d{2})-(\d{2})-(\d+)$")
+    jobs = queue.jobs(pattern=r"^nightly-(\d{4})-(\d{2})-(\d{2})-(\d+)$")
     page = GithubPage(toolz.take(n, jobs))
     files = page.render()
     files.update(unflatten_tree(_default_tree))
@@ -1444,7 +1442,7 @@ def generate_github_page(ctx, n, gh_branch, job_prefix, dry_run):
     commit = queue.create_commit(files, parents=[head.id], message=message,
                                  reference_name=refname)
     click.echo('Updated `{}` branch\'s head to `{}`'
-                .format(branch.branch_name, commit.id))
+               .format(branch.branch_name, commit.id))
     queue.push([refname])
 
 

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -890,7 +890,7 @@ class Job(Serializable):
             self._assets = []
             with concurrent.futures.ThreadPoolExecutor(max_workers) as pool:
                 for task_name, task in sorted(self.tasks.items()):
-                    # HACK: spare some queires because of the rate limit, and
+                    # HACK: spare some queries because of the rate limit, and
                     # don't query tasks with specieid prefig, e.g. "test-"
                     if (ignore_prefix is not None and
                             task_name.startswith(ignore_prefix)):
@@ -1429,7 +1429,7 @@ def github_page(ctx):
 def generate_github_page(ctx, n, gh_branch, job_prefix, dry_run,
                          github_push_token):
     queue = ctx.obj['queue']
-    # queue.fetch()
+    queue.fetch()
 
     # fail early if the requested branch is not available in the local checkout
     remote = 'origin'


### PR DESCRIPTION
Generates a GitHub page to a specific crossbow branch (typically gh-pages). 

It creates two directories:

- [nightly](https://ursalabs.org/crossbow/nightly/): containing links for the nightly artifacts grouped by day and task, also creates a "latest" directory for the most recent nightly artifacts

- [pypi/pyarrow](https://ursalabs.org/crossbow/pypi/pyarrow/): compatible with the [simple PyPI repository specification](https://www.python.org/dev/peps/pep-0503/) so lets user install PyArrow with 
    ```bash
    pip install -v --extra-index-url https://ursalabs.org/crossbow/pypi/ pyarrow==0.15.0.dev718
    ```

Gotchas:
- API rate limit: the script uses the GitHub API extensively so it can consume the rate limit pretty quickly 
- GitHub API doesn't provide a checksum for the assets, so we cannot include them in the links

Follow-up work:
Run this on a daily bases, the simplest would be to execute after the nightly report via [ursabot](https://github.com/ursa-labs/ursabot/blob/master/projects/arrow/arrow/crossbow.py#L81)