### PR TITLE
ARROW-7788: [C++][Parquet] Enable Arrow Schema to Parquet Schema for missing types

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -1334,7 +1334,7 @@ class NullArrayFactory {
     }
 
     template <typename T>
-    enable_if_var_length_list<T, Status> Visit(const T&) {
+    enable_if_var_size_list<T, Status> Visit(const T&) {
       // values array may be empty, but there must be at least one offset of 0
       return MaxOf(sizeof(typename T::offset_type) * (length_ + 1));
     }
@@ -1439,7 +1439,7 @@ class NullArrayFactory {
   }
 
   template <typename T>
-  enable_if_var_length_list<T, Status> Visit(const T& type) {
+  enable_if_var_size_list<T, Status> Visit(const T& type) {
     (*out_)->buffers.resize(2, buffer_);
     return CreateChild(0, length_, &(*out_)->child_data[0]);
   }

--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -1334,7 +1334,7 @@ class NullArrayFactory {
     }
 
     template <typename T>
-    enable_if_base_list<T, Status> Visit(const T&) {
+    enable_if_var_length_list<T, Status> Visit(const T&) {
       // values array may be empty, but there must be at least one offset of 0
       return MaxOf(sizeof(typename T::offset_type) * (length_ + 1));
     }
@@ -1439,7 +1439,7 @@ class NullArrayFactory {
   }
 
   template <typename T>
-  enable_if_base_list<T, Status> Visit(const T& type) {
+  enable_if_var_length_list<T, Status> Visit(const T& type) {
     (*out_)->buffers.resize(2, buffer_);
     return CreateChild(0, length_, &(*out_)->child_data[0]);
   }

--- a/cpp/src/arrow/ipc/json_internal.cc
+++ b/cpp/src/arrow/ipc/json_internal.cc
@@ -568,7 +568,7 @@ class ArrayWriter {
   }
 
   template <typename ArrayType>
-  enable_if_var_length_list<typename ArrayType::TypeClass, Status> Visit(
+  enable_if_var_size_list<typename ArrayType::TypeClass, Status> Visit(
       const ArrayType& array) {
     WriteValidityField(array);
     WriteIntegerField("OFFSET", array.raw_value_offsets(), array.length() + 1);
@@ -1281,7 +1281,7 @@ class ArrayReader {
   }
 
   template <typename T>
-  enable_if_var_length_list<T, Status> Visit(const T& type) {
+  enable_if_var_size_list<T, Status> Visit(const T& type) {
     return CreateList<T>(type_, &result_);
   }
 

--- a/cpp/src/arrow/ipc/json_internal.cc
+++ b/cpp/src/arrow/ipc/json_internal.cc
@@ -568,7 +568,7 @@ class ArrayWriter {
   }
 
   template <typename ArrayType>
-  enable_if_base_list<typename ArrayType::TypeClass, Status> Visit(
+  enable_if_var_length_list<typename ArrayType::TypeClass, Status> Visit(
       const ArrayType& array) {
     WriteValidityField(array);
     WriteIntegerField("OFFSET", array.raw_value_offsets(), array.length() + 1);
@@ -1281,7 +1281,7 @@ class ArrayReader {
   }
 
   template <typename T>
-  enable_if_base_list<T, Status> Visit(const T& type) {
+  enable_if_var_length_list<T, Status> Visit(const T& type) {
     return CreateList<T>(type_, &result_);
   }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -278,7 +278,7 @@ class ArrayLoader {
   }
 
   template <typename T>
-  enable_if_base_list<T, Status> Visit(const T& type) {
+  enable_if_var_length_list<T, Status> Visit(const T& type) {
     return LoadList(type);
   }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -278,7 +278,7 @@ class ArrayLoader {
   }
 
   template <typename T>
-  enable_if_var_length_list<T, Status> Visit(const T& type) {
+  enable_if_var_size_list<T, Status> Visit(const T& type) {
     return LoadList(type);
   }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -219,11 +219,13 @@ std::string LargeListType::ToString() const {
 
 MapType::MapType(const std::shared_ptr<DataType>& key_type,
                  const std::shared_ptr<DataType>& item_type, bool keys_sorted)
+    : MapType(key_type, std::make_shared<Field>("value", item_type), keys_sorted) {}
+
+MapType::MapType(const std::shared_ptr<DataType>& key_type,
+                 const std::shared_ptr<Field>& item_field, bool keys_sorted)
     : ListType(std::make_shared<Field>(
           "entries",
-          struct_({std::make_shared<Field>("key", key_type, false),
-                   std::make_shared<Field>("value", item_type)}),
-          false)),
+          struct_({std::make_shared<Field>("key", key_type, false), item_field}), false)),
       keys_sorted_(keys_sorted) {
   id_ = type_id;
 }
@@ -1404,9 +1406,15 @@ std::shared_ptr<DataType> large_list(const std::shared_ptr<Field>& value_field) 
 }
 
 std::shared_ptr<DataType> map(const std::shared_ptr<DataType>& key_type,
-                              const std::shared_ptr<DataType>& value_type,
+                              const std::shared_ptr<DataType>& item_type,
                               bool keys_sorted) {
-  return std::make_shared<MapType>(key_type, value_type, keys_sorted);
+  return std::make_shared<MapType>(key_type, item_type, keys_sorted);
+}
+
+std::shared_ptr<DataType> map(const std::shared_ptr<DataType>& key_type,
+                              const std::shared_ptr<Field>& item_field,
+                              bool keys_sorted) {
+  return std::make_shared<MapType>(key_type, item_field, keys_sorted);
 }
 
 std::shared_ptr<DataType> fixed_size_list(const std::shared_ptr<DataType>& value_type,

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -219,11 +219,11 @@ std::string LargeListType::ToString() const {
 
 MapType::MapType(const std::shared_ptr<DataType>& key_type,
                  const std::shared_ptr<DataType>& item_type, bool keys_sorted)
-    : MapType(key_type, std::make_shared<Field>("value", item_type), keys_sorted) {}
+    : MapType(key_type, field("value", item_type), keys_sorted) {}
 
 MapType::MapType(const std::shared_ptr<DataType>& key_type,
                  const std::shared_ptr<Field>& item_field, bool keys_sorted)
-    : ListType(std::make_shared<Field>(
+    : ListType(field(
           "entries",
           struct_({std::make_shared<Field>("key", key_type, false), item_field}), false)),
       keys_sorted_(keys_sorted) {

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -513,15 +513,15 @@ using is_var_length_list_type =
                                      std::is_base_of<ListType, T>::value>;
 
 template <typename T, typename R = void>
-using enable_if_var_length_list = enable_if_t<is_var_length_list_type<T>::value, R>;
+using enable_if_var_size_list = enable_if_t<is_var_length_list_type<T>::value, R>;
 
 // DEPRECATED use is_var_length_list_type.
 template <typename T>
 using is_base_list_type = is_var_length_list_type<T>;
 
-// DEPRECATED use enable_if_var_length_list
+// DEPRECATED use enable_if_var_size_list
 template <typename T, typename R = void>
-using enable_if_base_list = enable_if_var_length_list<T, R>;
+using enable_if_base_list = enable_if_var_size_list<T, R>;
 
 template <typename T>
 using is_fixed_size_list_type = std::is_same<FixedSizeListType, T>;

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -508,17 +508,20 @@ template <typename T, typename R = void>
 using enable_if_nested = enable_if_t<is_nested_type<T>::value, R>;
 
 template <typename T>
-using is_var_length_list_type = std::integral_constant(std::is_base_of<LargeListType, T>::value || std::is_base_of(ListType, T>::value>;
+using is_var_length_list_type =
+    std::integral_constant<bool, std::is_base_of<LargeListType, T>::value ||
+                                     std::is_base_of<ListType, T>::value>;
+
+template <typename T, typename R = void>
+using enable_if_var_length_list = enable_if_t<is_var_length_list_type<T>::value, R>;
 
 // DEPRECATED use is_var_length_list_type.
 template <typename T>
-using is_base_list_type = is_var_length_list_type;
-
-using enable_if_var_length_list = enable_if_t<is_var_length_list_type<T>::value, R>;
+using is_base_list_type = is_var_length_list_type<T>;
 
 // DEPRECATED use enable_if_var_length_list
 template <typename T, typename R = void>
-using enable_if_base_list = enable_if_var_length_list;
+using enable_if_base_list = enable_if_var_length_list<T, R>;
 
 template <typename T>
 using is_fixed_size_list_type = std::is_same<FixedSizeListType, T>;

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -508,10 +508,17 @@ template <typename T, typename R = void>
 using enable_if_nested = enable_if_t<is_nested_type<T>::value, R>;
 
 template <typename T>
-using is_base_list_type = std::is_base_of<BaseListType, T>;
+using is_var_length_list_type = std::integral_constant(std::is_base_of<LargeListType, T>::value || std::is_base_of(ListType, T>::value>;
 
+// DEPRECATED use is_var_length_list_type.
+template <typename T>
+using is_base_list_type = is_var_length_list_type;
+
+using enable_if_var_length_list = enable_if_t<is_var_length_list_type<T>::value, R>;
+
+// DEPRECATED use enable_if_var_length_list
 template <typename T, typename R = void>
-using enable_if_base_list = enable_if_t<is_base_list_type<T>::value, R>;
+using enable_if_base_list = enable_if_var_length_list;
 
 template <typename T>
 using is_fixed_size_list_type = std::is_same<FixedSizeListType, T>;

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -658,15 +658,24 @@ class TestConvertArrowSchema : public ::testing::Test {
     for (int i = 0; i < expected_schema_node->field_count(); i++) {
       auto lhs = result_schema_node->field(i);
       auto rhs = expected_schema_node->field(i);
-      EXPECT_TRUE(lhs->Equals(rhs.get()));
+      SchemaDescriptor lhs_d, rhs_d;
+      lhs_d.Init(lhs);
+      rhs_d.Init(rhs);
+      EXPECT_TRUE(lhs->Equals(rhs.get()))
+          << "result(i=" << i << "): actual: \n"
+          << lhs_d.ToString() << "\n expected: \n  " << rhs_d.ToString();
     }
   }
 
-  ::arrow::Status ConvertSchema(const std::vector<std::shared_ptr<Field>>& fields) {
+  ::arrow::Status ConvertSchema(
+      const std::vector<std::shared_ptr<Field>>& fields,
+      std::shared_ptr<::parquet::ArrowWriterProperties> arrow_properties =
+          ::parquet::default_arrow_writer_properties()) {
     arrow_schema_ = ::arrow::schema(fields);
     std::shared_ptr<::parquet::WriterProperties> properties =
         ::parquet::default_writer_properties();
-    return ToParquetSchema(arrow_schema_.get(), *properties.get(), &result_schema_);
+    return ToParquetSchema(arrow_schema_.get(), *properties.get(), *arrow_properties,
+                           &result_schema_);
   }
 
  protected:
@@ -743,6 +752,8 @@ TEST_F(TestConvertArrowSchema, ArrowFields) {
   std::vector<FieldConstructionArguments> cases = {
       {"boolean", ::arrow::boolean(), LogicalType::None(), ParquetType::BOOLEAN, -1},
       {"binary", ::arrow::binary(), LogicalType::None(), ParquetType::BYTE_ARRAY, -1},
+      {"large_binary", ::arrow::large_binary(), LogicalType::None(),
+       ParquetType::BYTE_ARRAY, -1},
       {"fixed_size_binary", ::arrow::fixed_size_binary(64), LogicalType::None(),
        ParquetType::FIXED_LEN_BYTE_ARRAY, 64},
       {"uint8", ::arrow::uint8(), LogicalType::Int(8, false), ParquetType::INT32, -1},
@@ -757,6 +768,8 @@ TEST_F(TestConvertArrowSchema, ArrowFields) {
       {"float32", ::arrow::float32(), LogicalType::None(), ParquetType::FLOAT, -1},
       {"float64", ::arrow::float64(), LogicalType::None(), ParquetType::DOUBLE, -1},
       {"utf8", ::arrow::utf8(), LogicalType::String(), ParquetType::BYTE_ARRAY, -1},
+      {"large_utf8", ::arrow::large_utf8(), LogicalType::String(),
+       ParquetType::BYTE_ARRAY, -1},
       {"decimal(1, 0)", ::arrow::decimal(1, 0), LogicalType::Decimal(1, 0),
        ParquetType::FIXED_LEN_BYTE_ARRAY, 1},
       {"decimal(8, 2)", ::arrow::decimal(8, 2), LogicalType::Decimal(8, 2),
@@ -929,6 +942,128 @@ TEST_F(TestConvertArrowSchema, ParquetLists) {
   }
 
   ASSERT_OK(ConvertSchema(arrow_fields));
+
+  ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
+}
+
+TEST_F(TestConvertArrowSchema, ParquetMaps) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  //  optional group my_map (MAP) {
+  //      repeated group key_value {
+  //          required binary key (UTF8);
+  //          optional binary value (UTF8);
+  //	}
+  //  }
+  {
+    auto key = PrimitiveNode::Make("key", Repetition::REQUIRED, ParquetType::BYTE_ARRAY,
+                                   ConvertedType::UTF8);
+    auto value = PrimitiveNode::Make("value", Repetition::OPTIONAL,
+                                     ParquetType::BYTE_ARRAY, ConvertedType::UTF8);
+
+    auto list = GroupNode::Make("key_value", Repetition::REPEATED, {key, value});
+    parquet_fields.push_back(
+        GroupNode::Make("my_map", Repetition::OPTIONAL, {list}, ConvertedType::MAP));
+    auto arrow_key = ::arrow::field("string", UTF8, /*nullable=*/false);
+    auto arrow_value = ::arrow::field("other_string", UTF8, /*nullable=*/true);
+    auto arrow_map = ::arrow::map(arrow_key->type(), arrow_value, /*nullable=*/false);
+    arrow_fields.push_back(::arrow::field("my_map", arrow_map, /*nullable=*/true));
+  }
+
+  //  required group my_map (MAP) {
+  //      repeated group key_value {
+  //          required binary key (UTF8);
+  //          required binary value (UTF8);
+  //	}
+  //  }
+  {
+    auto key = PrimitiveNode::Make("key", Repetition::REQUIRED, ParquetType::BYTE_ARRAY,
+                                   ConvertedType::UTF8);
+    auto value = PrimitiveNode::Make("value", Repetition::REQUIRED,
+                                     ParquetType::BYTE_ARRAY, ConvertedType::UTF8);
+
+    auto list = GroupNode::Make("key_value", Repetition::REPEATED, {key, value});
+    parquet_fields.push_back(
+        GroupNode::Make("my_map", Repetition::REQUIRED, {list}, ConvertedType::MAP));
+    auto arrow_key = ::arrow::field("string", UTF8, /*nullable=*/false);
+    auto arrow_value = ::arrow::field("other_string", UTF8, /*nullable=*/false);
+    auto arrow_map = ::arrow::map(arrow_key->type(), arrow_value);
+    arrow_fields.push_back(::arrow::field("my_map", arrow_map, /*nullable=*/false));
+    ARROW_LOG(INFO) << arrow_fields.back()->ToString();
+  }
+
+  ASSERT_OK(ConvertSchema(arrow_fields));
+
+  ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
+}
+
+TEST_F(TestConvertArrowSchema, ParquetOtherLists) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  // parquet_arrow will always generate 3-level LIST encodings
+
+  // // List<String> (list non-null, elements nullable)
+  // required group my_list (LIST) {
+  //   repeated group list {
+  //     optional binary element (UTF8);
+  //   }
+  // }
+  {
+    auto element = PrimitiveNode::Make("string", Repetition::OPTIONAL,
+                                       ParquetType::BYTE_ARRAY, ConvertedType::UTF8);
+    auto list = GroupNode::Make("list", Repetition::REPEATED, {element});
+    parquet_fields.push_back(
+        GroupNode::Make("my_list", Repetition::REQUIRED, {list}, ConvertedType::LIST));
+    auto arrow_element = ::arrow::field("string", UTF8, true);
+    auto arrow_list = ::arrow::large_list(arrow_element);
+    arrow_fields.push_back(::arrow::field("my_list", arrow_list, false));
+  }
+  {
+    auto element = PrimitiveNode::Make("string", Repetition::OPTIONAL,
+                                       ParquetType::BYTE_ARRAY, ConvertedType::UTF8);
+    auto list = GroupNode::Make("list", Repetition::REPEATED, {element});
+    parquet_fields.push_back(
+        GroupNode::Make("my_list", Repetition::REQUIRED, {list}, ConvertedType::LIST));
+    auto arrow_element = ::arrow::field("string", UTF8, true);
+    auto arrow_list = ::arrow::fixed_size_list(arrow_element, 10);
+    arrow_fields.push_back(::arrow::field("my_list", arrow_list, false));
+  }
+
+  ASSERT_OK(ConvertSchema(arrow_fields));
+
+  ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
+}
+
+TEST_F(TestConvertArrowSchema, ParquetNestedComplianceEnabled) {
+  std::vector<NodePtr> parquet_fields;
+  std::vector<std::shared_ptr<Field>> arrow_fields;
+
+  // parquet_arrow will always generate 3-level LIST encodings
+
+  // // List<String> (list non-null, elements nullable)
+  // required group my_list (LIST) {
+  //   repeated group list {
+  //     optional binary element (UTF8);
+  //   }
+  // }
+  {
+    auto element = PrimitiveNode::Make("element", Repetition::OPTIONAL,
+                                       ParquetType::BYTE_ARRAY, ConvertedType::UTF8);
+    auto list = GroupNode::Make("list", Repetition::REPEATED, {element});
+    parquet_fields.push_back(
+        GroupNode::Make("my_list", Repetition::REQUIRED, {list}, ConvertedType::LIST));
+    auto arrow_element = ::arrow::field("string", UTF8, true);
+    auto arrow_list = ::arrow::large_list(arrow_element);
+    arrow_fields.push_back(::arrow::field("my_list", arrow_list, false));
+  }
+
+  ArrowWriterProperties::Builder builder;
+  builder.enable_compliant_nested_types();
+  auto arrow_properties = builder.build();
+
+  ASSERT_OK(ConvertSchema(arrow_fields, arrow_properties));
 
   ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
 }

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -658,12 +658,7 @@ class TestConvertArrowSchema : public ::testing::Test {
     for (int i = 0; i < expected_schema_node->field_count(); i++) {
       auto lhs = result_schema_node->field(i);
       auto rhs = expected_schema_node->field(i);
-      SchemaDescriptor lhs_d, rhs_d;
-      lhs_d.Init(lhs);
-      rhs_d.Init(rhs);
-      EXPECT_TRUE(lhs->Equals(rhs.get()))
-          << "result(i=" << i << "): actual: \n"
-          << lhs_d.ToString() << "\n expected: \n  " << rhs_d.ToString();
+      EXPECT_TRUE(lhs->Equals(rhs.get()));
     }
   }
 

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -58,16 +58,44 @@ namespace arrow {
 // ----------------------------------------------------------------------
 // Parquet to Arrow schema conversion
 
-Status ListToNode(const std::shared_ptr<::arrow::ListType>& type, const std::string& name,
-                  bool nullable, const WriterProperties& properties,
+namespace {
+Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
+                   const WriterProperties& properties,
+                   const ArrowWriterProperties& arrow_properties, NodePtr* out);
+
+Status ListToNode(const std::shared_ptr<::arrow::BaseListType>& type,
+                  const std::string& name, bool nullable,
+                  const WriterProperties& properties,
                   const ArrowWriterProperties& arrow_properties, NodePtr* out) {
   Repetition::type repetition = nullable ? Repetition::OPTIONAL : Repetition::REQUIRED;
 
   NodePtr element;
-  RETURN_NOT_OK(FieldToNode(type->value_field(), properties, arrow_properties, &element));
+  std::string value_name =
+      arrow_properties.compliant_nested_types() ? "element" : type->value_field()->name();
+  RETURN_NOT_OK(FieldToNode(value_name, type->value_field(), properties, arrow_properties,
+                            &element));
 
   NodePtr list = GroupNode::Make("list", Repetition::REPEATED, {element});
   *out = GroupNode::Make(name, repetition, {list}, LogicalType::List());
+  return Status::OK();
+}
+
+Status MapToNode(const std::shared_ptr<::arrow::MapType>& type, const std::string& name,
+                 bool nullable, const WriterProperties& properties,
+                 const ArrowWriterProperties& arrow_properties, NodePtr* out) {
+  // TODO: Should we offer non-compliant moe that forwards the type names?
+  NodePtr key_node;
+  RETURN_NOT_OK(
+      FieldToNode("key", type->key_field(), properties, arrow_properties, &key_node));
+
+  NodePtr value_node;
+  RETURN_NOT_OK(FieldToNode("value", type->item_field(), properties, arrow_properties,
+                            &value_node));
+
+  NodePtr key_value =
+      GroupNode::Make("key_value", Repetition::REPEATED, {key_node, value_node});
+  Repetition::type repetition = nullable ? Repetition::OPTIONAL : Repetition::REQUIRED;
+  *out = GroupNode::Make(name, repetition, {key_value}, LogicalType::Map());
   return Status::OK();
 }
 
@@ -79,8 +107,8 @@ Status StructToNode(const std::shared_ptr<::arrow::StructType>& type,
 
   std::vector<NodePtr> children(type->num_children());
   for (int i = 0; i < type->num_children(); i++) {
-    RETURN_NOT_OK(
-        FieldToNode(type->child(i), properties, arrow_properties, &children[i]));
+    RETURN_NOT_OK(FieldToNode(type->child(i)->name(), type->child(i), properties,
+                              arrow_properties, &children[i]));
   }
 
   *out = GroupNode::Make(name, repetition, children);
@@ -185,7 +213,7 @@ static Status GetTimestampMetadata(const ::arrow::TimestampType& type,
   return Status::OK();
 }
 
-Status FieldToNode(const std::shared_ptr<Field>& field,
+Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
                    const WriterProperties& properties,
                    const ArrowWriterProperties& arrow_properties, NodePtr* out) {
   std::shared_ptr<const LogicalType> logical_type = LogicalType::None();
@@ -245,10 +273,12 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
     case ArrowTypeId::DOUBLE:
       type = ParquetType::DOUBLE;
       break;
+    case ArrowTypeId::LARGE_STRING:
     case ArrowTypeId::STRING:
       type = ParquetType::BYTE_ARRAY;
       logical_type = LogicalType::String();
       break;
+    case ArrowTypeId::LARGE_BINARY:
     case ArrowTypeId::BINARY:
       type = ParquetType::BYTE_ARRAY;
       break;
@@ -298,13 +328,15 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
     } break;
     case ArrowTypeId::STRUCT: {
       auto struct_type = std::static_pointer_cast<::arrow::StructType>(field->type());
-      return StructToNode(struct_type, field->name(), field->nullable(), properties,
+      return StructToNode(struct_type, name, field->nullable(), properties,
                           arrow_properties, out);
     }
+    case ArrowTypeId::FIXED_SIZE_LIST:
+    case ArrowTypeId::LARGE_LIST:
     case ArrowTypeId::LIST: {
-      auto list_type = std::static_pointer_cast<::arrow::ListType>(field->type());
-      return ListToNode(list_type, field->name(), field->nullable(), properties,
-                        arrow_properties, out);
+      auto list_type = std::static_pointer_cast<::arrow::BaseListType>(field->type());
+      return ListToNode(list_type, name, field->nullable(), properties, arrow_properties,
+                        out);
     }
     case ArrowTypeId::DICTIONARY: {
       // Parquet has no Dictionary type, dictionary-encoded is handled on
@@ -312,15 +344,21 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
       const ::arrow::DictionaryType& dict_type =
           static_cast<const ::arrow::DictionaryType&>(*field->type());
       std::shared_ptr<::arrow::Field> unpacked_field = ::arrow::field(
-          field->name(), dict_type.value_type(), field->nullable(), field->metadata());
-      return FieldToNode(unpacked_field, properties, arrow_properties, out);
+          name, dict_type.value_type(), field->nullable(), field->metadata());
+      return FieldToNode(name, unpacked_field, properties, arrow_properties, out);
     }
     case ArrowTypeId::EXTENSION: {
       auto ext_type = std::static_pointer_cast<::arrow::ExtensionType>(field->type());
       std::shared_ptr<::arrow::Field> storage_field = ::arrow::field(
-          field->name(), ext_type->storage_type(), field->nullable(), field->metadata());
-      return FieldToNode(storage_field, properties, arrow_properties, out);
+          name, ext_type->storage_type(), field->nullable(), field->metadata());
+      return FieldToNode(name, storage_field, properties, arrow_properties, out);
     }
+    case ArrowTypeId::MAP: {
+      auto map_type = std::static_pointer_cast<::arrow::MapType>(field->type());
+      return MapToNode(map_type, name, field->nullable(), properties, arrow_properties,
+                       out);
+    }
+
     default: {
       // TODO: DENSE_UNION, SPARE_UNION, JSON_SCALAR, DECIMAL_TEXT, VARCHAR
       return Status::NotImplemented(
@@ -329,10 +367,18 @@ Status FieldToNode(const std::shared_ptr<Field>& field,
     }
   }
 
-  PARQUET_CATCH_NOT_OK(*out = PrimitiveNode::Make(field->name(), repetition, logical_type,
-                                                  type, length));
+  PARQUET_CATCH_NOT_OK(*out = PrimitiveNode::Make(name, repetition, logical_type, type,
+                                                  length));
 
   return Status::OK();
+}
+
+}  // namespace
+
+Status FieldToNode(const std::shared_ptr<Field>& field,
+                   const WriterProperties& properties,
+                   const ArrowWriterProperties& arrow_properties, NodePtr* out) {
+  return FieldToNode(field->name(), field, properties, arrow_properties, out);
 }
 
 Status ToParquetSchema(const ::arrow::Schema* arrow_schema,

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -585,7 +585,9 @@ class PARQUET_EXPORT ArrowWriterProperties {
           coerce_timestamps_enabled_(false),
           coerce_timestamps_unit_(::arrow::TimeUnit::SECOND),
           truncated_timestamps_allowed_(false),
-          store_schema_(false) {}
+          store_schema_(false),
+          // TODO: At some point we should flip this.
+          compliant_nested_types_(false) {}
     virtual ~Builder() {}
 
     Builder* disable_deprecated_int96_timestamps() {
@@ -622,10 +624,20 @@ class PARQUET_EXPORT ArrowWriterProperties {
       return this;
     }
 
+    Builder* enable_compliant_nested_types() {
+      compliant_nested_types_ = true;
+      return this;
+    }
+
+    Builder* disable_compliant_nested_types() {
+      compliant_nested_types_ = false;
+      return this;
+    }
+
     std::shared_ptr<ArrowWriterProperties> build() {
       return std::shared_ptr<ArrowWriterProperties>(new ArrowWriterProperties(
           write_timestamps_as_int96_, coerce_timestamps_enabled_, coerce_timestamps_unit_,
-          truncated_timestamps_allowed_, store_schema_));
+          truncated_timestamps_allowed_, store_schema_, compliant_nested_types_));
     }
 
    private:
@@ -636,6 +648,7 @@ class PARQUET_EXPORT ArrowWriterProperties {
     bool truncated_timestamps_allowed_;
 
     bool store_schema_;
+    bool compliant_nested_types_;
   };
 
   bool support_deprecated_int96_timestamps() const { return write_timestamps_as_int96_; }
@@ -649,22 +662,32 @@ class PARQUET_EXPORT ArrowWriterProperties {
 
   bool store_schema() const { return store_schema_; }
 
+  /// \brief Enable nested type naming according to the parquet specification.
+  ///
+  /// Older versions of arrow wrote out field names for nested lists based on the name
+  /// of the field.  According to the parquet specification they should always be
+  /// "element".
+  bool compliant_nested_types() const { return compliant_nested_types_; }
+
  private:
   explicit ArrowWriterProperties(bool write_nanos_as_int96,
                                  bool coerce_timestamps_enabled,
                                  ::arrow::TimeUnit::type coerce_timestamps_unit,
-                                 bool truncated_timestamps_allowed, bool store_schema)
+                                 bool truncated_timestamps_allowed, bool store_schema,
+                                 bool compliant_nested_types)
       : write_timestamps_as_int96_(write_nanos_as_int96),
         coerce_timestamps_enabled_(coerce_timestamps_enabled),
         coerce_timestamps_unit_(coerce_timestamps_unit),
         truncated_timestamps_allowed_(truncated_timestamps_allowed),
-        store_schema_(store_schema) {}
+        store_schema_(store_schema),
+        compliant_nested_types_(compliant_nested_types) {}
 
   const bool write_timestamps_as_int96_;
   const bool coerce_timestamps_enabled_;
   const ::arrow::TimeUnit::type coerce_timestamps_unit_;
   const bool truncated_timestamps_allowed_;
   const bool store_schema_;
+  const bool compliant_nested_types_;
 };
 
 /// \brief State object used for writing Arrow data directly to a Parquet


### PR DESCRIPTION

*  Moves common methods for ListTypes to BaseList type and make FixedListType extend
   the same base class so they can mapped
*  Enable Large* types and FixedListType by adding them to the appropriate enum cases
*  Add implementation to Maps
*  Expose constructor/static factory to MapType that can take a field as a value
*  For list type expose a configuration parameter to make the parquet schema
   conform to the required naming.