### PR TITLE
ARROW-7791: [C++][Parquet] Fix building error "cannot bind lvalue"

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2897,7 +2897,7 @@ class TestArrowReadDictionary : public ::testing::TestWithParam<double> {
     RETURN_NOT_OK(builder.Open(std::make_shared<BufferReader>(buffer_)));
     RETURN_NOT_OK(builder.properties(properties_)->Build(&reader));
 
-    return reader;
+    return std::move(reader);
   }
 };
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-7791