### PR TITLE
ARROW-7797: [Release][Rust] Fix arrow-flight's version in datafusion crate

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -61,7 +61,7 @@ prost = "0.6"
 tokio = { version = "0.2", features = ["macros"] }
 tonic = "0.1"
 flatbuffers = "0.6.0"
-arrow-flight = { path = "../arrow-flight", version = "0.16.0-SNAPSHOT" }
+arrow-flight = { path = "../arrow-flight", version = "1.0.0-SNAPSHOT" }
 
 [[bench]]
 name = "aggregate_query_sql"


### PR DESCRIPTION
After the release the version number got bumped except this one.