### PR TITLE
ARROW-7796: [R] write_* functions should invisibly return their inputs

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -21,7 +21,7 @@
 
 
 * `write_feather`, `write_arrow` and `write_parquet` now return their input
-similar to `write_*` functions from `readr` (#7796 @boshek)
+similar to `write_*` functions from `readr` (#6387, @boshek)
 * Dataset filtering is now correctly supported for all Arrow date/time/timestamp column types.
 
 # arrow 0.16.0

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -19,6 +19,9 @@
 
 # arrow 0.16.0.9000
 
+* `write_feather`, `write_arrow` and `write_parquet` now return their input
+similar to `write_*` functions from `readr` (#7796 @boshek)
+
 # arrow 0.16.0
 
 ## Multi-file datasets

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -20,6 +20,8 @@
 #' @param x `data.frame` or RecordBatch
 #' @param sink A file path or an OutputStream
 #'
+#' @return the input `x` invisibly.
+#'
 #' @export
 #' @examples
 #' \donttest{

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -45,7 +45,7 @@ write_feather <- function(x, sink) {
   writer <- FeatherTableWriter$create(sink)
   ipc___TableWriter__RecordBatch__WriteFeather(writer, x)
 
-  x_out
+  invisible(x_out)
 }
 
 #' @title FeatherTableWriter class

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -29,6 +29,8 @@
 #' }
 #' @include arrow-package.R
 write_feather <- function(x, sink) {
+  x_out <- x
+
   if (is.data.frame(x)) {
     x <- record_batch(x)
   }
@@ -42,6 +44,8 @@ write_feather <- function(x, sink) {
 
   writer <- FeatherTableWriter$create(sink)
   ipc___TableWriter__RecordBatch__WriteFeather(writer, x)
+
+  x_out
 }
 
 #' @title FeatherTableWriter class

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -99,7 +99,7 @@ read_parquet <- function(file,
 #' disable compression, set `compression = "uncompressed"`.
 #' Note that "uncompressed" columns may still have dictionary encoding.
 #'
-#' @return `NULL`, invisibly
+#' @return the input `x` invisibly.
 #'
 #' @examples
 #' \donttest{

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -145,6 +145,7 @@ write_parquet <- function(x,
     allow_truncated_timestamps = allow_truncated_timestamps
   )
 ) {
+  x_out <- x
   x <- to_arrow(x)
 
   if (is.character(sink)) {
@@ -164,6 +165,8 @@ write_parquet <- function(x,
   writer <- ParquetFileWriter$create(schema, sink, properties = properties, arrow_properties = arrow_properties)
   writer$WriteTable(x, chunk_size = chunk_size %||% x$num_rows)
   writer$Close()
+
+  invisible(x_out)
 }
 
 

--- a/r/R/write-arrow.R
+++ b/r/R/write-arrow.R
@@ -49,6 +49,7 @@ to_arrow.data.frame <- function(x) Table$create(!!!x)
 #' `write_arrow` is a convenience function, the classes [arrow::RecordBatchFileWriter][RecordBatchFileWriter]
 #' and [arrow::RecordBatchStreamWriter][RecordBatchStreamWriter] can be used for more flexibility.
 #'
+#' @return the input `x` invisibly.
 #' @export
 write_arrow <- function(x, sink, ...) {
   UseMethod("write_arrow", sink)

--- a/r/R/write-arrow.R
+++ b/r/R/write-arrow.R
@@ -76,7 +76,7 @@ write_arrow.character <- function(x, sink, ...) {
   # on.exit(file_writer$close(), add = TRUE, after = FALSE)
   write_arrow(x, file_writer, ...)
 
-  x_out
+  invisible(x_out)
 }
 
 #' @export

--- a/r/R/write-arrow.R
+++ b/r/R/write-arrow.R
@@ -61,6 +61,7 @@ write_arrow.RecordBatchWriter <- function(x, sink, ...){
 
 #' @export
 write_arrow.character <- function(x, sink, ...) {
+  x_out <- x
   assert_that(length(sink) == 1L)
   x <- to_arrow(x)
   file_stream <- FileOutputStream$create(sink)
@@ -74,6 +75,8 @@ write_arrow.character <- function(x, sink, ...) {
   # Available on R >= 3.5
   # on.exit(file_writer$close(), add = TRUE, after = FALSE)
   write_arrow(x, file_writer, ...)
+
+  x_out
 }
 
 #' @export

--- a/r/man/write_arrow.Rd
+++ b/r/man/write_arrow.Rd
@@ -27,6 +27,9 @@ dispatch). \code{x} is serialized using the streaming format, i.e. using the
 \code{write_arrow} is a convenience function, the classes \link[=RecordBatchFileWriter]{arrow::RecordBatchFileWriter}
 and \link[=RecordBatchStreamWriter]{arrow::RecordBatchStreamWriter} can be used for more flexibility.}
 }
+\value{
+the input \code{x} invisibly.
+}
 \description{
 Write Arrow formatted data
 }

--- a/r/man/write_feather.Rd
+++ b/r/man/write_feather.Rd
@@ -11,6 +11,9 @@ write_feather(x, sink)
 
 \item{sink}{A file path or an OutputStream}
 }
+\value{
+the input \code{x} invisibly.
+}
 \description{
 Write data in the Feather format
 }

--- a/r/man/write_parquet.Rd
+++ b/r/man/write_parquet.Rd
@@ -66,7 +66,7 @@ You should not specify any of these arguments if you also provide a \code{proper
 argument, as they will be ignored.}
 }
 \value{
-\code{NULL}, invisibly
+the input \code{x} invisibly.
 }
 \description{
 \href{https://parquet.apache.org/}{Parquet} is a columnar storage file format.

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -25,7 +25,7 @@ test_that("Write a feather file", {
   expect_true(file.exists(feather_file))
 })
 
-test_that("write_feather() returns it's input", {
+test_that("write_feather() returns its input", {
   tib_out <- write_feather(tib, feather_file)
   expect_identical(tib_out, tib)
 })

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -25,6 +25,11 @@ test_that("Write a feather file", {
   expect_true(file.exists(feather_file))
 })
 
+test_that("write_feather() returns it's input", {
+  tib_out <- write_feather(tib, feather_file)
+  expect_identical(tib_out, tib)
+})
+
 test_that("feather read/write round trip", {
   tf2 <- normalizePath(tempfile(), mustWork = FALSE)
   write_feather(tib, tf2)

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -131,7 +131,7 @@ test_that("write_parquet() to stream", {
   expect_equal(read_parquet(tf), df)
 })
 
-test_that("write_parquet() returns it's input", {
+test_that("write_parquet() returns its input", {
   df <- tibble::tibble(x = 1:5)
   tf <- tempfile()
   on.exit(unlink(tf))

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -130,3 +130,11 @@ test_that("write_parquet() to stream", {
   con$close()
   expect_equal(read_parquet(tf), df)
 })
+
+test_that("write_parquet() returns it's input", {
+  df <- tibble::tibble(x = 1:5)
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  df_out <- write_parquet(df, tf)
+  expect_identical(df, df_out)
+})

--- a/r/tests/testthat/test-read-write.R
+++ b/r/tests/testthat/test-read-write.R
@@ -112,3 +112,12 @@ test_that("table round trip handles NA in integer and numeric", {
   expect_true(is.na(res$dbl[10]))
   unlink(tf)
 })
+
+
+test_that("write_arrow() returns it's input", {
+  df <- tibble::tibble(x = 1:5)
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  df_out <- write_arrow(df, tf)
+  expect_identical(df, df_out)
+})

--- a/r/tests/testthat/test-read-write.R
+++ b/r/tests/testthat/test-read-write.R
@@ -114,7 +114,7 @@ test_that("table round trip handles NA in integer and numeric", {
 })
 
 
-test_that("write_arrow() returns it's input", {
+test_that("write_arrow() returns its input", {
   df <- tibble::tibble(x = 1:5)
   tf <- tempfile()
   on.exit(unlink(tf))


### PR DESCRIPTION
I had some trouble building from source on Windows but I thought the changes were simple enough that I just went ahead. Tests and documentation also updated. 