### PR TITLE
ARROW-7722: [FlightRPC][Java] disable flaky Flight auth test

### DIFF
--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth/TestBasicAuth.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/auth/TestBasicAuth.java
@@ -41,6 +41,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -61,6 +62,8 @@ public class TestBasicAuth {
     Assert.assertTrue(ImmutableList.copyOf(client.listFlights(Criteria.ALL)).size() == 0);
   }
 
+  // ARROW-7722: this test occasionally leaks memory
+  @Ignore
   @Test
   public void asyncCall() throws Exception {
     client.authenticateBasic(USERNAME, PASSWORD);


### PR DESCRIPTION
I was unable to reproduce this one locally or with docker, so let's disable it, since it keeps failing on master.