### PR TITLE
ARROW-7761: [C++][Python] Support S3 URIs

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -394,6 +394,7 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriReal(const FileSystemUri& f
   }
   if (fsuri.scheme == "s3") {
 #ifdef ARROW_S3
+    RETURN_NOT_OK(EnsureS3Initialized());
     ARROW_ASSIGN_OR_RAISE(auto options, S3Options::FromUri(fsuri.uri, out_path));
     ARROW_ASSIGN_OR_RAISE(auto s3fs, S3FileSystem::Make(options));
     return s3fs;

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -22,6 +22,9 @@
 #ifdef ARROW_HDFS
 #include "arrow/filesystem/hdfs.h"
 #endif
+#ifdef ARROW_S3
+#include "arrow/filesystem/s3fs.h"
+#endif
 #include "arrow/filesystem/localfs.h"
 #include "arrow/filesystem/mockfs.h"
 #include "arrow/filesystem/path_util.h"
@@ -386,7 +389,16 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriReal(const FileSystemUri& f
     ARROW_ASSIGN_OR_RAISE(auto hdfs, HadoopFileSystem::Make(options));
     return hdfs;
 #else
-    return Status::NotImplemented("Arrow compiled without HDFS support");
+    return Status::NotImplemented("Got HDFS URI but Arrow compiled without HDFS support");
+#endif
+  }
+  if (fsuri.scheme == "s3") {
+#ifdef ARROW_S3
+    ARROW_ASSIGN_OR_RAISE(auto options, S3Options::FromUri(fsuri.uri, out_path));
+    ARROW_ASSIGN_OR_RAISE(auto s3fs, S3FileSystem::Make(options));
+    return s3fs;
+#else
+    return Status::NotImplemented("Got S3 URI but Arrow compiled without S3 support");
 #endif
   }
 

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -22,6 +22,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <sstream>
+#include <unordered_map>
 #include <utility>
 
 #ifdef _WIN32
@@ -71,6 +72,9 @@
 #include "arrow/util/logging.h"
 
 namespace arrow {
+
+using internal::Uri;
+
 namespace fs {
 
 using ::Aws::Client::AWSError;
@@ -157,6 +161,65 @@ S3Options S3Options::FromAccessKey(const std::string& access_key,
   S3Options options;
   options.ConfigureAccessKey(access_key, secret_key);
   return options;
+}
+
+Result<S3Options> S3Options::FromUri(const Uri& uri, std::string* out_path) {
+  S3Options options;
+
+  const auto bucket = uri.host();
+  auto path = uri.path();
+  if (bucket.empty()) {
+    if (!path.empty()) {
+      return Status::Invalid("Missing bucket name in S3 URI");
+    }
+  } else {
+    if (path.empty()) {
+      path = bucket;
+    } else {
+      if (path[0] != '/') {
+        return Status::Invalid("S3 URI should absolute, not relative");
+      }
+      path = bucket + path;
+    }
+  }
+  if (out_path != nullptr) {
+    *out_path = std::string(internal::RemoveTrailingSlash(path));
+  }
+
+  std::unordered_map<std::string, std::string> options_map;
+  ARROW_ASSIGN_OR_RAISE(const auto options_items, uri.query_items());
+  for (const auto& kv : options_items) {
+    options_map.emplace(kv.first, kv.second);
+  }
+
+  const auto username = uri.username();
+  if (!username.empty()) {
+    options.ConfigureAccessKey(username, uri.password());
+  } else {
+    options.ConfigureDefaultCredentials();
+  }
+
+  auto it = options_map.find("region");
+  if (it != options_map.end()) {
+    options.region = it->second;
+  }
+  it = options_map.find("scheme");
+  if (it != options_map.end()) {
+    options.scheme = it->second;
+  }
+  it = options_map.find("endpoint_override");
+  if (it != options_map.end()) {
+    options.endpoint_override = it->second;
+  }
+
+  return options;
+}
+
+Result<S3Options> S3Options::FromUri(const std::string& uri_string,
+                                     std::string* out_path) {
+  Uri uri;
+  RETURN_NOT_OK(uri.Parse(uri_string));
+  return FromUri(uri, out_path);
 }
 
 namespace {

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -151,6 +151,11 @@ struct ARROW_EXPORT S3GlobalOptions {
 ARROW_EXPORT
 Status InitializeS3(const S3GlobalOptions& options);
 
+/// Ensure the S3 APIs are initialized, but only if not already done.
+/// If necessary, this will call InitializeS3() with some default options.
+ARROW_EXPORT
+Status EnsureS3Initialized();
+
 /// Shutdown the S3 APIs.
 ARROW_EXPORT
 Status FinalizeS3();

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -23,6 +23,7 @@
 
 #include "arrow/filesystem/filesystem.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/uri.h"
 
 namespace Aws {
 namespace Auth {
@@ -68,6 +69,11 @@ struct ARROW_EXPORT S3Options {
   /// \brief Initialize with explicit access and secret key
   static S3Options FromAccessKey(const std::string& access_key,
                                  const std::string& secret_key);
+
+  static Result<S3Options> FromUri(const ::arrow::internal::Uri& uri,
+                                   std::string* out_path = NULLPTR);
+  static Result<S3Options> FromUri(const std::string& uri,
+                                   std::string* out_path = NULLPTR);
 };
 
 /// S3-backed FileSystem implementation.

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -50,6 +50,16 @@ bool IsTextRangeSet(const UriTextRangeStructA& range) { return range.first != nu
 
 }  // namespace
 
+std::string UriEscape(const std::string& s) {
+  std::string escaped;
+  escaped.resize(3 * s.length());
+
+  auto end = uriEscapeExA(s.data(), s.data() + s.length(), &escaped[0],
+                          /*spaceToPlus=*/URI_FALSE, /*normalizeBreaks=*/URI_FALSE);
+  escaped.resize(end - &escaped[0]);
+  return escaped;
+}
+
 struct Uri::Impl {
   Impl() : string_rep_(""), port_(-1) { memset(&uri_, 0, sizeof(uri_)); }
 
@@ -94,6 +104,26 @@ bool Uri::has_host() const { return IsTextRangeSet(impl_->uri_.hostText); }
 std::string Uri::port_text() const { return TextRangeToString(impl_->uri_.portText); }
 
 int32_t Uri::port() const { return impl_->port_; }
+
+std::string Uri::username() const {
+  auto userpass = TextRangeToView(impl_->uri_.userInfo);
+  auto sep_pos = userpass.find_first_of(':');
+  if (sep_pos == util::string_view::npos) {
+    return std::string(userpass);
+  } else {
+    return std::string(userpass.substr(0, sep_pos));
+  }
+}
+
+std::string Uri::password() const {
+  auto userpass = TextRangeToView(impl_->uri_.userInfo);
+  auto sep_pos = userpass.find_first_of(':');
+  if (sep_pos == util::string_view::npos) {
+    return std::string();
+  } else {
+    return std::string(userpass.substr(sep_pos + 1));
+  }
+}
 
 std::string Uri::path() const {
   // Gather path segments

--- a/cpp/src/arrow/util/uri.h
+++ b/cpp/src/arrow/util/uri.h
@@ -43,6 +43,7 @@ class ARROW_EXPORT Uri {
   /// The URI scheme, such as "http", or the empty string if the URI has no
   /// explicit scheme.
   std::string scheme() const;
+
   /// Whether the URI has an explicit host name.  This may return true if
   /// the URI has an empty host (e.g. "file:///tmp/foo"), while it returns
   /// false is the URI has not host component at all (e.g. "file:/tmp/foo").
@@ -50,16 +51,25 @@ class ARROW_EXPORT Uri {
   /// The URI host name, such as "localhost", "127.0.0.1" or "::1", or the empty
   /// string is the URI does not have a host component.
   std::string host() const;
+
   /// The URI port number, as a string such as "80", or the empty string is the URI
   /// does not have a port number component.
   std::string port_text() const;
   /// The URI port parsed as an integer, or -1 if the URI does not have a port
   /// number component.
   int32_t port() const;
+
+  /// The username specified in the URI.
+  std::string username() const;
+  /// The password specified in the URI.
+  std::string password() const;
+
   /// The URI path component.
   std::string path() const;
+
   /// The URI query string
   std::string query_string() const;
+
   /// The URI query items
   ///
   /// Note this API doesn't allow differentiating between an empty value
@@ -76,6 +86,10 @@ class ARROW_EXPORT Uri {
   struct Impl;
   std::unique_ptr<Impl> impl_;
 };
+
+/// Percent-encode the input string, for use e.g. as a URI query parameter.
+ARROW_EXPORT
+std::string UriEscape(const std::string& s);
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/uri_test.cc
+++ b/cpp/src/arrow/util/uri_test.cc
@@ -29,6 +29,12 @@
 namespace arrow {
 namespace internal {
 
+TEST(UriEscape, Basics) {
+  ASSERT_EQ(UriEscape(""), "");
+  ASSERT_EQ(UriEscape("foo123"), "foo123");
+  ASSERT_EQ(UriEscape("/El Niño/"), "%2FEl%20Ni%C3%B1o%2F");
+}
+
 TEST(Uri, Empty) {
   Uri uri;
   ASSERT_EQ(uri.scheme(), "");
@@ -128,42 +134,84 @@ TEST(Uri, ParseHostPort) {
   ASSERT_EQ(uri.host(), "localhost");
   ASSERT_EQ(uri.port_text(), "80");
   ASSERT_EQ(uri.port(), 80);
+  ASSERT_EQ(uri.username(), "");
+  ASSERT_EQ(uri.password(), "");
 
   ASSERT_OK(uri.Parse("http://1.2.3.4"));
   ASSERT_EQ(uri.scheme(), "http");
   ASSERT_EQ(uri.host(), "1.2.3.4");
   ASSERT_EQ(uri.port_text(), "");
   ASSERT_EQ(uri.port(), -1);
+  ASSERT_EQ(uri.username(), "");
+  ASSERT_EQ(uri.password(), "");
 
   ASSERT_OK(uri.Parse("http://1.2.3.4:"));
   ASSERT_EQ(uri.scheme(), "http");
   ASSERT_EQ(uri.host(), "1.2.3.4");
   ASSERT_EQ(uri.port_text(), "");
   ASSERT_EQ(uri.port(), -1);
+  ASSERT_EQ(uri.username(), "");
+  ASSERT_EQ(uri.password(), "");
 
   ASSERT_OK(uri.Parse("http://1.2.3.4:80"));
   ASSERT_EQ(uri.scheme(), "http");
   ASSERT_EQ(uri.host(), "1.2.3.4");
   ASSERT_EQ(uri.port_text(), "80");
   ASSERT_EQ(uri.port(), 80);
+  ASSERT_EQ(uri.username(), "");
+  ASSERT_EQ(uri.password(), "");
 
   ASSERT_OK(uri.Parse("http://[::1]"));
   ASSERT_EQ(uri.scheme(), "http");
   ASSERT_EQ(uri.host(), "::1");
   ASSERT_EQ(uri.port_text(), "");
   ASSERT_EQ(uri.port(), -1);
+  ASSERT_EQ(uri.username(), "");
+  ASSERT_EQ(uri.password(), "");
 
   ASSERT_OK(uri.Parse("http://[::1]:"));
   ASSERT_EQ(uri.scheme(), "http");
   ASSERT_EQ(uri.host(), "::1");
   ASSERT_EQ(uri.port_text(), "");
   ASSERT_EQ(uri.port(), -1);
+  ASSERT_EQ(uri.username(), "");
+  ASSERT_EQ(uri.password(), "");
 
   ASSERT_OK(uri.Parse("http://[::1]:80"));
   ASSERT_EQ(uri.scheme(), "http");
   ASSERT_EQ(uri.host(), "::1");
   ASSERT_EQ(uri.port_text(), "80");
   ASSERT_EQ(uri.port(), 80);
+  ASSERT_EQ(uri.username(), "");
+  ASSERT_EQ(uri.password(), "");
+}
+
+TEST(Uri, ParseUserPass) {
+  Uri uri;
+
+  ASSERT_OK(uri.Parse("http://someuser@localhost:80"));
+  ASSERT_EQ(uri.scheme(), "http");
+  ASSERT_EQ(uri.host(), "localhost");
+  ASSERT_EQ(uri.username(), "someuser");
+  ASSERT_EQ(uri.password(), "");
+
+  ASSERT_OK(uri.Parse("http://someuser:@localhost:80"));
+  ASSERT_EQ(uri.scheme(), "http");
+  ASSERT_EQ(uri.host(), "localhost");
+  ASSERT_EQ(uri.username(), "someuser");
+  ASSERT_EQ(uri.password(), "");
+
+  ASSERT_OK(uri.Parse("http://someuser:somepass@localhost:80"));
+  ASSERT_EQ(uri.scheme(), "http");
+  ASSERT_EQ(uri.host(), "localhost");
+  ASSERT_EQ(uri.username(), "someuser");
+  ASSERT_EQ(uri.password(), "somepass");
+
+  ASSERT_OK(uri.Parse("http://someuser:somepass@localhost"));
+  ASSERT_EQ(uri.scheme(), "http");
+  ASSERT_EQ(uri.host(), "localhost");
+  ASSERT_EQ(uri.username(), "someuser");
+  ASSERT_EQ(uri.password(), "somepass");
 }
 
 TEST(Uri, ParseError) {


### PR DESCRIPTION
Allow instantiating an S3 filesystem instance from a `s3://user:pass@bucket/path?params...` URI.