### PR TITLE
PARQUET-1770: [C++][CI] Add fuzz target for reading Parquet files

### DIFF
--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -30,6 +30,10 @@ CORPUS_DIR=/tmp/corpus
 ARROW=$(cd $(dirname $BASH_SOURCE)/../..; pwd)
 OUT=$1
 
+# NOTE: name of seed corpus output file should be "<FUZZ TARGET>-seed_corpus.zip"
+# where "<FUZZ TARGET>" is the exact name of the fuzz target executable the
+# seed corpus is generated for.
+
 rm -rf ${CORPUS_DIR}
 ${OUT}/arrow-ipc-generate-fuzz-corpus -stream ${CORPUS_DIR}
 ${ARROW}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-stream-fuzz_seed_corpus.zip
@@ -37,3 +41,7 @@ ${ARROW}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-str
 rm -rf ${CORPUS_DIR}
 ${OUT}/arrow-ipc-generate-fuzz-corpus -file ${CORPUS_DIR}
 ${ARROW}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-file-fuzz_seed_corpus.zip
+
+rm -rf ${CORPUS_DIR}
+${OUT}/parquet-arrow-generate-fuzz-corpus ${CORPUS_DIR}
+${ARROW}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/parquet-arrow-fuzz_seed_corpus.zip

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -687,17 +687,17 @@ endfunction()
 #
 # Fuzzing
 #
-# Add new fuzzing test executable.
+# Add new fuzz target executable.
 #
 # The single source file must define a function:
 #   extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 #
 # No main function must be present within the source file!
 #
-function(ADD_ARROW_FUZZING REL_FUZZING_NAME)
+function(ADD_FUZZ_TARGET REL_FUZZING_NAME)
   set(options)
-  set(one_value_args)
-  set(multi_value_args PREFIX)
+  set(one_value_args PREFIX)
+  set(multi_value_args LINK_LIBS)
   cmake_parse_arguments(ARG
                         "${options}"
                         "${one_value_args}"
@@ -720,12 +720,6 @@ function(ADD_ARROW_FUZZING REL_FUZZING_NAME)
     set(FUZZING_NAME "${ARG_PREFIX}-${FUZZING_NAME}")
   endif()
 
-  if(ARROW_BUILD_STATIC)
-    set(FUZZ_LINK_LIBS arrow_static)
-  else()
-    set(FUZZ_LINK_LIBS arrow_shared)
-  endif()
-
   # For OSS-Fuzz
   # (https://google.github.io/oss-fuzz/advanced-topics/ideal-integration/)
   if(DEFINED ENV{LIB_FUZZING_ENGINE})
@@ -735,7 +729,7 @@ function(ADD_ARROW_FUZZING REL_FUZZING_NAME)
   endif()
 
   add_executable(${FUZZING_NAME} "${REL_FUZZING_NAME}.cc")
-  target_link_libraries(${FUZZING_NAME} ${FUZZ_LINK_LIBS})
+  target_link_libraries(${FUZZING_NAME} ${LINK_LIBS})
   target_compile_options(${FUZZING_NAME} PRIVATE ${FUZZ_LDFLAGS})
   set_target_properties(${FUZZING_NAME}
                         PROPERTIES LINK_FLAGS ${FUZZ_LDFLAGS} LABELS "fuzzing")

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -57,6 +57,35 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
                 ${ARG_UNPARSED_ARGUMENTS})
 endfunction()
 
+function(ADD_ARROW_FUZZ_TARGET REL_FUZZING_NAME)
+  set(options)
+  set(one_value_args PREFIX)
+  set(multi_value_args)
+  cmake_parse_arguments(ARG
+                        "${options}"
+                        "${one_value_args}"
+                        "${multi_value_args}"
+                        ${ARGN})
+
+  if(ARG_PREFIX)
+    set(PREFIX ${ARG_PREFIX})
+  else()
+    set(PREFIX "arrow")
+  endif()
+
+  if(ARROW_BUILD_STATIC)
+    set(LINK_LIBS arrow_static)
+  else()
+    set(LINK_LIBS arrow_shared)
+  endif()
+  add_fuzz_target(${REL_FUZZING_NAME}
+                  PREFIX
+                  ${PREFIX}
+                  LINK_LIBS
+                  ${LINK_LIBS}
+                  ${ARG_UNPARSED_ARGUMENTS})
+endfunction()
+
 function(ADD_ARROW_BENCHMARK REL_TEST_NAME)
   set(options)
   set(one_value_args PREFIX)

--- a/cpp/src/arrow/ipc/CMakeLists.txt
+++ b/cpp/src/arrow/ipc/CMakeLists.txt
@@ -67,5 +67,5 @@ if(ARROW_FUZZING)
                         ${ARROW_TEST_LINK_LIBS})
 endif()
 
-add_arrow_fuzzing(file_fuzz PREFIX "arrow-ipc")
-add_arrow_fuzzing(stream_fuzz PREFIX "arrow-ipc")
+add_arrow_fuzz_target(file_fuzz PREFIX "arrow-ipc")
+add_arrow_fuzz_target(stream_fuzz PREFIX "arrow-ipc")

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -49,8 +49,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> Boolean(int64_t size, double probability,
-                                        double null_probability = 0);
+  std::shared_ptr<Array> Boolean(int64_t size, double probability,
+                                 double null_probability = 0);
 
   /// \brief Generates a random UInt8Array
   ///
@@ -60,8 +60,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> UInt8(int64_t size, uint8_t min, uint8_t max,
-                                      double null_probability = 0);
+  std::shared_ptr<Array> UInt8(int64_t size, uint8_t min, uint8_t max,
+                               double null_probability = 0);
 
   /// \brief Generates a random Int8Array
   ///
@@ -71,8 +71,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> Int8(int64_t size, int8_t min, int8_t max,
-                                     double null_probability = 0);
+  std::shared_ptr<Array> Int8(int64_t size, int8_t min, int8_t max,
+                              double null_probability = 0);
 
   /// \brief Generates a random UInt16Array
   ///
@@ -82,8 +82,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> UInt16(int64_t size, uint16_t min, uint16_t max,
-                                       double null_probability = 0);
+  std::shared_ptr<Array> UInt16(int64_t size, uint16_t min, uint16_t max,
+                                double null_probability = 0);
 
   /// \brief Generates a random Int16Array
   ///
@@ -93,8 +93,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> Int16(int64_t size, int16_t min, int16_t max,
-                                      double null_probability = 0);
+  std::shared_ptr<Array> Int16(int64_t size, int16_t min, int16_t max,
+                               double null_probability = 0);
 
   /// \brief Generates a random UInt32Array
   ///
@@ -104,8 +104,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> UInt32(int64_t size, uint32_t min, uint32_t max,
-                                       double null_probability = 0);
+  std::shared_ptr<Array> UInt32(int64_t size, uint32_t min, uint32_t max,
+                                double null_probability = 0);
 
   /// \brief Generates a random Int32Array
   ///
@@ -115,8 +115,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> Int32(int64_t size, int32_t min, int32_t max,
-                                      double null_probability = 0);
+  std::shared_ptr<Array> Int32(int64_t size, int32_t min, int32_t max,
+                               double null_probability = 0);
 
   /// \brief Generates a random UInt64Array
   ///
@@ -126,8 +126,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> UInt64(int64_t size, uint64_t min, uint64_t max,
-                                       double null_probability = 0);
+  std::shared_ptr<Array> UInt64(int64_t size, uint64_t min, uint64_t max,
+                                double null_probability = 0);
 
   /// \brief Generates a random Int64Array
   ///
@@ -137,8 +137,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> Int64(int64_t size, int64_t min, int64_t max,
-                                      double null_probability = 0);
+  std::shared_ptr<Array> Int64(int64_t size, int64_t min, int64_t max,
+                               double null_probability = 0);
 
   /// \brief Generates a random FloatArray
   ///
@@ -148,8 +148,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> Float32(int64_t size, float min, float max,
-                                        double null_probability = 0);
+  std::shared_ptr<Array> Float32(int64_t size, float min, float max,
+                                 double null_probability = 0);
 
   /// \brief Generates a random DoubleArray
   ///
@@ -159,12 +159,12 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> Float64(int64_t size, double min, double max,
-                                        double null_probability = 0);
+  std::shared_ptr<Array> Float64(int64_t size, double min, double max,
+                                 double null_probability = 0);
 
   template <typename ArrowType, typename CType = typename ArrowType::c_type>
-  std::shared_ptr<arrow::Array> Numeric(int64_t size, CType min, CType max,
-                                        double null_probability = 0) {
+  std::shared_ptr<Array> Numeric(int64_t size, CType min, CType max,
+                                 double null_probability = 0) {
     switch (ArrowType::type_id) {
       case Type::UINT8:
         return UInt8(size, static_cast<uint8_t>(min), static_cast<uint8_t>(max),
@@ -201,6 +201,8 @@ class ARROW_EXPORT RandomArrayGenerator {
     }
   }
 
+  std::shared_ptr<Array> Offsets(int64_t size, int32_t first_offset, int32_t last_offset);
+
   /// \brief Generates a random StringArray
   ///
   /// \param[in] size the size of the array to generate
@@ -211,8 +213,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> String(int64_t size, int32_t min_length,
-                                       int32_t max_length, double null_probability = 0);
+  std::shared_ptr<Array> String(int64_t size, int32_t min_length, int32_t max_length,
+                                double null_probability = 0);
 
   /// \brief Generates a random LargeStringArray
   ///
@@ -224,9 +226,8 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> LargeString(int64_t size, int32_t min_length,
-                                            int32_t max_length,
-                                            double null_probability = 0);
+  std::shared_ptr<Array> LargeString(int64_t size, int32_t min_length, int32_t max_length,
+                                     double null_probability = 0);
 
   /// \brief Generates a random StringArray with repeated values
   ///
@@ -240,14 +241,14 @@ class ARROW_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<arrow::Array> StringWithRepeats(int64_t size, int64_t unique,
-                                                  int32_t min_length, int32_t max_length,
-                                                  double null_probability = 0);
+  std::shared_ptr<Array> StringWithRepeats(int64_t size, int64_t unique,
+                                           int32_t min_length, int32_t max_length,
+                                           double null_probability = 0);
 
   /// \brief Like StringWithRepeats but return BinaryArray
-  std::shared_ptr<arrow::Array> BinaryWithRepeats(int64_t size, int64_t unique,
-                                                  int32_t min_length, int32_t max_length,
-                                                  double null_probability = 0);
+  std::shared_ptr<Array> BinaryWithRepeats(int64_t size, int64_t unique,
+                                           int32_t min_length, int32_t max_length,
+                                           double null_probability = 0);
 
   SeedType seed() { return seed_distribution_(seed_rng_); }
 

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -65,6 +65,35 @@ function(ADD_PARQUET_TEST REL_TEST_NAME)
   endif()
 endfunction()
 
+function(ADD_PARQUET_FUZZ_TARGET REL_FUZZING_NAME)
+  set(options)
+  set(one_value_args PREFIX)
+  set(multi_value_args)
+  cmake_parse_arguments(ARG
+                        "${options}"
+                        "${one_value_args}"
+                        "${multi_value_args}"
+                        ${ARGN})
+
+  if(ARG_PREFIX)
+    set(PREFIX ${ARG_PREFIX})
+  else()
+    set(PREFIX "parquet")
+  endif()
+
+  if(ARROW_BUILD_STATIC)
+    set(LINK_LIBS parquet_static)
+  else()
+    set(LINK_LIBS parquet_shared)
+  endif()
+  add_fuzz_target(${REL_FUZZING_NAME}
+                  PREFIX
+                  ${PREFIX}
+                  LINK_LIBS
+                  ${LINK_LIBS}
+                  ${ARG_UNPARSED_ARGUMENTS})
+endfunction()
+
 function(ADD_PARQUET_BENCHMARK REL_TEST_NAME)
   set(options)
   set(one_value_args PREFIX)

--- a/cpp/src/parquet/arrow/CMakeLists.txt
+++ b/cpp/src/parquet/arrow/CMakeLists.txt
@@ -16,3 +16,16 @@
 # under the License.
 
 arrow_install_all_headers("parquet/arrow")
+
+if(ARROW_FUZZING)
+  add_executable(parquet-arrow-generate-fuzz-corpus generate_fuzz_corpus.cc)
+  if(ARROW_BUILD_STATIC)
+    target_link_libraries(parquet-arrow-generate-fuzz-corpus parquet_static
+                          arrow_testing_static)
+  else()
+    target_link_libraries(parquet-arrow-generate-fuzz-corpus parquet_shared
+                          arrow_testing_shared)
+  endif()
+endif()
+
+add_parquet_fuzz_target(fuzz PREFIX "parquet-arrow")

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -73,6 +73,7 @@ using arrow::random_is_valid;
 
 using ArrowId = ::arrow::Type;
 using ParquetType = parquet::Type;
+
 using parquet::arrow::FromParquetSchema;
 using parquet::schema::GroupNode;
 using parquet::schema::NodePtr;
@@ -464,7 +465,7 @@ static std::shared_ptr<GroupNode> MakeSimpleSchema(const DataType& type,
         case ::arrow::Type::DECIMAL: {
           const auto& decimal_type =
               static_cast<const ::arrow::Decimal128Type&>(values_type);
-          byte_width = internal::DecimalSize(decimal_type.precision());
+          byte_width = ::parquet::internal::DecimalSize(decimal_type.precision());
         } break;
         default:
           break;
@@ -475,7 +476,7 @@ static std::shared_ptr<GroupNode> MakeSimpleSchema(const DataType& type,
       break;
     case ::arrow::Type::DECIMAL: {
       const auto& decimal_type = static_cast<const ::arrow::Decimal128Type&>(type);
-      byte_width = internal::DecimalSize(decimal_type.precision());
+      byte_width = ::parquet::internal::DecimalSize(decimal_type.precision());
     } break;
     default:
       break;
@@ -2662,7 +2663,7 @@ TEST(TestImpalaConversion, ArrowTimestampToImpalaTimestamp) {
   Int96 calculated;
 
   Int96 expected = {{UINT32_C(632093973), UINT32_C(13871), UINT32_C(2457925)}};
-  internal::NanosecondsToImpalaTimestamp(nanoseconds, &calculated);
+  ::parquet::internal::NanosecondsToImpalaTimestamp(nanoseconds, &calculated);
   ASSERT_EQ(expected, calculated);
 }
 

--- a/cpp/src/parquet/arrow/fuzz.cc
+++ b/cpp/src/parquet/arrow/fuzz.cc
@@ -1,0 +1,25 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/status.h"
+#include "parquet/arrow/reader.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  auto status = parquet::arrow::internal::FuzzReader(data, static_cast<int64_t>(size));
+  ARROW_UNUSED(status);
+  return 0;
+}

--- a/cpp/src/parquet/arrow/generate_fuzz_corpus.cc
+++ b/cpp/src/parquet/arrow/generate_fuzz_corpus.cc
@@ -1,0 +1,118 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// A command line executable that generates a bunch of valid Parquet files
+// containing example record batches.  Those are used as fuzzing seeds
+// to make fuzzing more efficient.
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/io/file.h"
+#include "arrow/record_batch.h"
+#include "arrow/result.h"
+#include "arrow/table.h"
+#include "arrow/testing/random.h"
+#include "arrow/util/io_util.h"
+#include "parquet/arrow/writer.h"
+
+namespace arrow {
+
+using ::arrow::internal::CreateDir;
+using ::arrow::internal::PlatformFilename;
+
+static constexpr int32_t kBatchSize = 1000;
+static constexpr int32_t kChunkSize = kBatchSize * 3 / 8;
+
+Result<std::shared_ptr<RecordBatch>> ExampleBatch1() {
+  random::RandomArrayGenerator gen(42);
+  std::shared_ptr<Array> a, b, c, d;
+  a = gen.Int16(kBatchSize, -10000, 10000, /*null_probability=*/0.2);
+  b = gen.Float64(kBatchSize, -1e10, 1e10, /*null_probability=*/0.0);
+  c = gen.String(kBatchSize, 0, 30, /*null_probability=*/0.2);
+  {
+    auto values = gen.Int64(kBatchSize * 10, -10000, 10000, /*null_probability=*/0.2);
+    auto offsets = gen.Offsets(kBatchSize + 1, 0, static_cast<int32_t>(values->length()));
+    RETURN_NOT_OK(ListArray::FromArrays(*offsets, *values, default_memory_pool(), &d));
+  }
+
+  auto schema = ::arrow::schema({field("a", a->type()), field("b", b->type()),
+                                 field("c", c->type()), field("d", d->type())});
+  // TODO add metadata
+  return RecordBatch::Make(schema, kBatchSize, {a, b, c, d});
+}
+
+Result<std::vector<std::shared_ptr<RecordBatch>>> Batches() {
+  std::vector<std::shared_ptr<RecordBatch>> batches;
+  ARROW_ASSIGN_OR_RAISE(auto batch, ExampleBatch1());
+  batches.push_back(batch);
+  return batches;
+}
+
+Status DoMain(const std::string& out_dir) {
+  ARROW_ASSIGN_OR_RAISE(auto dir_fn, PlatformFilename::FromString(out_dir));
+  RETURN_NOT_OK(CreateDir(dir_fn));
+
+  int sample_num = 1;
+  auto sample_name = [&]() -> std::string {
+    return "pq-table-" + std::to_string(sample_num++);
+  };
+
+  ARROW_ASSIGN_OR_RAISE(auto batches, Batches());
+
+  for (const auto& batch : batches) {
+    RETURN_NOT_OK(batch->ValidateFull());
+    std::shared_ptr<Table> table;
+    RETURN_NOT_OK(Table::FromRecordBatches({batch}, &table));
+
+    ARROW_ASSIGN_OR_RAISE(auto sample_fn, dir_fn.Join(sample_name()));
+    std::cerr << sample_fn.ToString() << std::endl;
+    ARROW_ASSIGN_OR_RAISE(auto file, io::FileOutputStream::Open(sample_fn.ToString()));
+    RETURN_NOT_OK(
+        ::parquet::arrow::WriteTable(*table, default_memory_pool(), file, kChunkSize));
+    RETURN_NOT_OK(file->Close());
+  }
+  return Status::OK();
+}
+
+ARROW_NORETURN void Usage() {
+  std::cerr << "Usage: parquet-arrow-generate-fuzz-corpus "
+            << "<output directory>" << std::endl;
+  std::exit(2);
+}
+
+int Main(int argc, char** argv) {
+  if (argc != 2) {
+    Usage();
+  }
+  auto out_dir = std::string(argv[1]);
+
+  Status st = DoMain(out_dir);
+  if (!st.ok()) {
+    std::cerr << st.ToString() << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+}  // namespace arrow
+
+int main(int argc, char** argv) { return arrow::Main(argc, argv); }

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -158,14 +158,7 @@ class PARQUET_EXPORT FileReader {
       std::unique_ptr<::arrow::RecordBatchReader>* out) = 0;
 
   ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                       std::shared_ptr<::arrow::RecordBatchReader>* out) {
-    std::unique_ptr<::arrow::RecordBatchReader> tmp;
-
-    ARROW_RETURN_NOT_OK(GetRecordBatchReader(row_group_indices, &tmp));
-    out->reset(tmp.release());
-
-    return ::arrow::Status::OK();
-  }
+                                       std::shared_ptr<::arrow::RecordBatchReader>* out);
 
   /// \brief Return a RecordBatchReader of row groups selected from
   ///     row_group_indices, whose columns are selected by column_indices. The
@@ -176,16 +169,9 @@ class PARQUET_EXPORT FileReader {
       const std::vector<int>& row_group_indices, const std::vector<int>& column_indices,
       std::unique_ptr<::arrow::RecordBatchReader>* out) = 0;
 
-  virtual ::arrow::Status GetRecordBatchReader(
-      const std::vector<int>& row_group_indices, const std::vector<int>& column_indices,
-      std::shared_ptr<::arrow::RecordBatchReader>* out) {
-    std::unique_ptr<::arrow::RecordBatchReader> tmp;
-
-    ARROW_RETURN_NOT_OK(GetRecordBatchReader(row_group_indices, column_indices, &tmp));
-    out->reset(tmp.release());
-
-    return ::arrow::Status::OK();
-  }
+  ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
+                                       const std::vector<int>& column_indices,
+                                       std::shared_ptr<::arrow::RecordBatchReader>* out);
 
   /// Read all columns into a Table
   virtual ::arrow::Status ReadTable(std::shared_ptr<::arrow::Table>* out) = 0;
@@ -330,6 +316,12 @@ PARQUET_EXPORT
                                     std::shared_ptr<::arrow::Scalar>* min,
                                     std::shared_ptr<::arrow::Scalar>* max);
 
+namespace internal {
+
+PARQUET_EXPORT
+::arrow::Status FuzzReader(const uint8_t* data, int64_t size);
+
+}  // namespace internal
 }  // namespace arrow
 }  // namespace parquet
 

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -875,7 +875,7 @@ Status TransferDate64(RecordReader* reader, MemoryPool* pool,
 Status TransferDictionary(RecordReader* reader,
                           const std::shared_ptr<DataType>& logical_value_type,
                           std::shared_ptr<ChunkedArray>* out) {
-  auto dict_reader = checked_cast<DictionaryRecordReader*>(reader);
+  auto dict_reader = dynamic_cast<DictionaryRecordReader*>(reader);
   DCHECK(dict_reader);
   *out = dict_reader->GetResult();
   if (!logical_value_type->Equals(*(*out)->type())) {
@@ -891,7 +891,7 @@ Status TransferBinary(RecordReader* reader,
     return TransferDictionary(
         reader, ::arrow::dictionary(::arrow::int32(), logical_value_type), out);
   }
-  auto binary_reader = checked_cast<BinaryRecordReader*>(reader);
+  auto binary_reader = dynamic_cast<BinaryRecordReader*>(reader);
   DCHECK(binary_reader);
   auto chunks = binary_reader->GetBuilderChunks();
   for (const auto& chunk : chunks) {
@@ -1184,7 +1184,7 @@ Status TransferDecimal(RecordReader* reader, MemoryPool* pool,
                        const std::shared_ptr<DataType>& type, Datum* out) {
   DCHECK_EQ(type->id(), ::arrow::Type::DECIMAL);
 
-  auto binary_reader = checked_cast<BinaryRecordReader*>(reader);
+  auto binary_reader = dynamic_cast<BinaryRecordReader*>(reader);
   DCHECK(binary_reader);
   ::arrow::ArrayVector chunks = binary_reader->GetBuilderChunks();
   for (size_t i = 0; i < chunks.size(); ++i) {

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -875,7 +875,7 @@ Status TransferDate64(RecordReader* reader, MemoryPool* pool,
 Status TransferDictionary(RecordReader* reader,
                           const std::shared_ptr<DataType>& logical_value_type,
                           std::shared_ptr<ChunkedArray>* out) {
-  auto dict_reader = dynamic_cast<DictionaryRecordReader*>(reader);
+  auto dict_reader = checked_cast<DictionaryRecordReader*>(reader);
   DCHECK(dict_reader);
   *out = dict_reader->GetResult();
   if (!logical_value_type->Equals(*(*out)->type())) {
@@ -891,7 +891,7 @@ Status TransferBinary(RecordReader* reader,
     return TransferDictionary(
         reader, ::arrow::dictionary(::arrow::int32(), logical_value_type), out);
   }
-  auto binary_reader = dynamic_cast<BinaryRecordReader*>(reader);
+  auto binary_reader = checked_cast<BinaryRecordReader*>(reader);
   DCHECK(binary_reader);
   auto chunks = binary_reader->GetBuilderChunks();
   for (const auto& chunk : chunks) {
@@ -1184,7 +1184,7 @@ Status TransferDecimal(RecordReader* reader, MemoryPool* pool,
                        const std::shared_ptr<DataType>& type, Datum* out) {
   DCHECK_EQ(type->id(), ::arrow::Type::DECIMAL);
 
-  auto binary_reader = dynamic_cast<BinaryRecordReader*>(reader);
+  auto binary_reader = checked_cast<BinaryRecordReader*>(reader);
   DCHECK(binary_reader);
   ::arrow::ArrayVector chunks = binary_reader->GetBuilderChunks();
   for (size_t i = 0; i < chunks.size(); ++i) {

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -28,8 +28,6 @@ namespace arrow {
 
 class Array;
 class ChunkedArray;
-class RecordBatch;
-class RecordBatchReader;
 class Schema;
 class Table;
 

--- a/cpp/src/parquet/stream_writer.cc
+++ b/cpp/src/parquet/stream_writer.cc
@@ -104,12 +104,12 @@ StreamWriter& StreamWriter::operator<<(uint64_t v) {
 
 StreamWriter& StreamWriter::operator<<(const std::chrono::milliseconds& v) {
   CheckColumn(Type::INT64, ConvertedType::TIMESTAMP_MILLIS);
-  return Write<Int64Writer>(v.count());
+  return Write<Int64Writer>(static_cast<int64_t>(v.count()));
 }
 
 StreamWriter& StreamWriter::operator<<(const std::chrono::microseconds& v) {
   CheckColumn(Type::INT64, ConvertedType::TIMESTAMP_MICROS);
-  return Write<Int64Writer>(v.count());
+  return Write<Int64Writer>(static_cast<int64_t>(v.count()));
 }
 
 StreamWriter& StreamWriter::operator<<(float v) {

--- a/docs/source/developers/cpp/fuzzing.rst
+++ b/docs/source/developers/cpp/fuzzing.rst
@@ -24,6 +24,7 @@ fuzz testing on several parts of the Arrow C++ feature set, currently:
 
 * the IPC stream format
 * the IPC file format
+* the Parquet file format
 
 We welcome any contribution to expand the scope of fuzz testing and cover
 areas ingesting potentially invalid or malicious data.


### PR DESCRIPTION
This fuzz target goes through the Parquet Arrow file reader.
