### PR TITLE
ARROW-7080: [C++][Parquet] Read and write "field_id" attribute in Parquet files, propagate to Arrow field metadata. Assorted additional changes

### DIFF
--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -342,7 +342,25 @@ garrow_table_equal(GArrowTable *table, GArrowTable *other_table)
 {
   const auto arrow_table = garrow_table_get_raw(table);
   const auto arrow_other_table = garrow_table_get_raw(other_table);
-  return arrow_table->Equals(*arrow_other_table);
+  return arrow_table->Equals(*arrow_other_table, false);
+}
+
+/**
+ * garrow_table_equal_metadata:
+ * @table: A #GArrowTable.
+ * @other_table: A #GArrowTable to be compared.
+ *
+ * Returns: %TRUE if both of them have the same data including
+ *   the metadata, %FALSE otherwise.
+ *
+ * Since: 1.0.0
+ */
+gboolean
+garrow_table_equal_metadata(GArrowTable *table, GArrowTable *other_table)
+{
+  const auto arrow_table = garrow_table_get_raw(table);
+  const auto arrow_other_table = garrow_table_get_raw(other_table);
+  return arrow_table->Equals(*arrow_other_table, true);
 }
 
 /**

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -333,7 +333,7 @@ garrow_table_new_record_batches(GArrowSchema *schema,
  * @other_table: A #GArrowTable to be compared.
  *
  * Returns: %TRUE if both of them have the same data, %FALSE
- *   otherwise. Note that this function doesn't compare metadata.
+ *   otherwise.
  *
  * Since: 0.4.0
  */
@@ -342,7 +342,7 @@ garrow_table_equal(GArrowTable *table, GArrowTable *other_table)
 {
   const auto arrow_table = garrow_table_get_raw(table);
   const auto arrow_other_table = garrow_table_get_raw(other_table);
-  return arrow_table->Equals(*arrow_other_table, false);
+  return arrow_table->Equals(*arrow_other_table);
 }
 
 /**

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -349,6 +349,7 @@ garrow_table_equal(GArrowTable *table, GArrowTable *other_table)
  * garrow_table_equal_metadata:
  * @table: A #GArrowTable.
  * @other_table: A #GArrowTable to be compared.
+ * @metadata: Whether to compare metadata.
  *
  * Returns: %TRUE if both of them have the same data including
  *   the metadata, %FALSE otherwise.
@@ -356,11 +357,13 @@ garrow_table_equal(GArrowTable *table, GArrowTable *other_table)
  * Since: 1.0.0
  */
 gboolean
-garrow_table_equal_metadata(GArrowTable *table, GArrowTable *other_table)
+garrow_table_equal_metadata(GArrowTable *table,
+                            GArrowTable *other_table,
+                            gboolean metadata)
 {
   const auto arrow_table = garrow_table_get_raw(table);
   const auto arrow_other_table = garrow_table_get_raw(other_table);
-  return arrow_table->Equals(*arrow_other_table, true);
+  return arrow_table->Equals(*arrow_other_table, metadata);
 }
 
 /**

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -333,7 +333,7 @@ garrow_table_new_record_batches(GArrowSchema *schema,
  * @other_table: A #GArrowTable to be compared.
  *
  * Returns: %TRUE if both of them have the same data, %FALSE
- *   otherwise.
+ *   otherwise. Note that this function doesn't compare metadata.
  *
  * Since: 0.4.0
  */
@@ -351,8 +351,8 @@ garrow_table_equal(GArrowTable *table, GArrowTable *other_table)
  * @other_table: A #GArrowTable to be compared.
  * @metadata: Whether to compare metadata.
  *
- * Returns: %TRUE if both of them have the same data including
- *   the metadata, %FALSE otherwise.
+ * Returns: %TRUE if both of them have the same data, %FALSE
+ *   otherwise.
  *
  * Since: 1.0.0
  */

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -349,7 +349,7 @@ garrow_table_equal(GArrowTable *table, GArrowTable *other_table)
  * garrow_table_equal_metadata:
  * @table: A #GArrowTable.
  * @other_table: A #GArrowTable to be compared.
- * @metadata: Whether to compare metadata.
+ * @check_metadata: Whether to compare metadata.
  *
  * Returns: %TRUE if both of them have the same data, %FALSE
  *   otherwise.
@@ -359,11 +359,11 @@ garrow_table_equal(GArrowTable *table, GArrowTable *other_table)
 gboolean
 garrow_table_equal_metadata(GArrowTable *table,
                             GArrowTable *other_table,
-                            gboolean metadata)
+                            gboolean check_metadata)
 {
   const auto arrow_table = garrow_table_get_raw(table);
   const auto arrow_other_table = garrow_table_get_raw(other_table);
-  return arrow_table->Equals(*arrow_other_table, metadata);
+  return arrow_table->Equals(*arrow_other_table, check_metadata);
 }
 
 /**

--- a/c_glib/arrow-glib/table.h
+++ b/c_glib/arrow-glib/table.h
@@ -63,6 +63,9 @@ garrow_table_new_record_batches(GArrowSchema *schema,
 
 gboolean        garrow_table_equal         (GArrowTable *table,
                                             GArrowTable *other_table);
+GARROW_AVAILABLE_IN_1_0
+gboolean garrow_table_equal_metadata(GArrowTable *table,
+                                     GArrowTable *other_table);
 
 GArrowSchema   *garrow_table_get_schema    (GArrowTable *table);
 GARROW_AVAILABLE_IN_1_0

--- a/c_glib/arrow-glib/table.h
+++ b/c_glib/arrow-glib/table.h
@@ -67,7 +67,7 @@ GARROW_AVAILABLE_IN_1_0
 gboolean
 garrow_table_equal_metadata(GArrowTable *table,
                             GArrowTable *other_table,
-                            gboolean metadata);
+                            gboolean check_metadata);
 
 GArrowSchema   *garrow_table_get_schema    (GArrowTable *table);
 GARROW_AVAILABLE_IN_1_0

--- a/c_glib/arrow-glib/table.h
+++ b/c_glib/arrow-glib/table.h
@@ -64,8 +64,10 @@ garrow_table_new_record_batches(GArrowSchema *schema,
 gboolean        garrow_table_equal         (GArrowTable *table,
                                             GArrowTable *other_table);
 GARROW_AVAILABLE_IN_1_0
-gboolean garrow_table_equal_metadata(GArrowTable *table,
-                                     GArrowTable *other_table);
+gboolean
+garrow_table_equal_metadata(GArrowTable *table,
+                            GArrowTable *other_table,
+                            gboolean metadata);
 
 GArrowSchema   *garrow_table_get_schema    (GArrowTable *table);
 GARROW_AVAILABLE_IN_1_0

--- a/c_glib/test/parquet/test-arrow-file-reader.rb
+++ b/c_glib/test/parquet/test-arrow-file-reader.rb
@@ -35,7 +35,11 @@ class TestParquetArrowFileReader < Test::Unit::TestCase
   def test_schema
     assert_equal(<<-SCHEMA.chomp, @reader.schema.to_s)
 a: string
+-- metadata --
+PARQUET:field_id: 1
 b: int32
+-- metadata --
+PARQUET:field_id: 2
     SCHEMA
   end
 

--- a/c_glib/test/parquet/test-arrow-file-reader.rb
+++ b/c_glib/test/parquet/test-arrow-file-reader.rb
@@ -35,11 +35,7 @@ class TestParquetArrowFileReader < Test::Unit::TestCase
   def test_schema
     assert_equal(<<-SCHEMA.chomp, @reader.schema.to_s)
 a: string
--- metadata --
-PARQUET:field_id: 1
 b: int32
--- metadata --
-PARQUET:field_id: 2
     SCHEMA
   end
 

--- a/c_glib/test/parquet/test-arrow-file-writer.rb
+++ b/c_glib/test/parquet/test-arrow-file-writer.rb
@@ -36,11 +36,11 @@ class TestParquetArrowFileWriter < Test::Unit::TestCase
     reader.use_threads = true
     assert_equal([
                    enabled_values.length / chunk_size,
-                   table,
+                   true,
                  ],
                  [
                    reader.n_row_groups,
-                   reader.read_table,
+                   table.equal_metadata(reader.read_table, false),
                  ])
   end
 end

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -99,30 +99,28 @@ class TestTable < Test::Unit::TestCase
 
   sub_test_case("instance methods") do
     def setup
-      fields = [
+      @fields = [
         Arrow::Field.new("visible", Arrow::BooleanDataType.new),
         Arrow::Field.new("valid", Arrow::BooleanDataType.new),
       ]
-      schema = Arrow::Schema.new(fields)
-      columns = [
+      @schema = Arrow::Schema.new(@fields)
+      @columns = [
         build_boolean_array([true]),
         build_boolean_array([false]),
       ]
-      @table = Arrow::Table.new(schema, columns)
+      @table = Arrow::Table.new(@schema, @columns)
     end
 
     def test_equal
-      fields = [
-        Arrow::Field.new("visible", Arrow::BooleanDataType.new),
-        Arrow::Field.new("valid", Arrow::BooleanDataType.new),
-      ]
-      schema = Arrow::Schema.new(fields)
-      columns = [
-        build_boolean_array([true]),
-        build_boolean_array([false]),
-      ]
-      other_table = Arrow::Table.new(schema, columns)
+      other_table = Arrow::Table.new(@schema, @columns)
       assert_equal(@table, other_table)
+    end
+
+    def test_equal_metadata
+      other_table = Arrow::Table.new(@schema, @columns)
+      assert do
+        @table.equal_metadata(other_table)
+      end
     end
 
     def test_schema

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -119,7 +119,7 @@ class TestTable < Test::Unit::TestCase
     def test_equal_metadata
       other_table = Arrow::Table.new(@schema, @columns)
       assert do
-        @table.equal_metadata(other_table)
+        @table.equal_metadata(other_table, true)
       end
     end
 

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -226,7 +226,8 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjected) {
     for (auto maybe_batch : rb_it) {
       ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
       row_count += batch->num_rows();
-      ASSERT_EQ(*batch->schema(), *expected_schema);
+      AssertSchemaEqual(*batch->schema(), *expected_schema,
+                        /*check_metadata=*/false);
     }
   }
 
@@ -279,7 +280,7 @@ TEST_F(TestParquetFileFormat, Inspect) {
   auto format = ParquetFileFormat();
 
   ASSERT_OK_AND_ASSIGN(auto actual, format.Inspect(*source.get()));
-  EXPECT_EQ(*actual, *schema_);
+  AssertSchemaEqual(*actual, *schema_, /*check_metadata=*/false);
 }
 
 TEST_F(TestParquetFileFormat, IsSupported) {

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -73,45 +73,22 @@ bool ChunkedArray::Equals(const ChunkedArray& other) const {
     return false;
   }
   if (length_ == 0) {
-    return type_->Equals(other.type_);
+    // We cannot toggle check_metadata here yet, so we don't check it
+    return type_->Equals(*other.type_, /*check_metadata=*/false);
   }
 
   // Check contents of the underlying arrays. This checks for equality of
   // the underlying data independently of the chunk size.
-  int this_chunk_idx = 0;
-  int64_t this_start_idx = 0;
-  int other_chunk_idx = 0;
-  int64_t other_start_idx = 0;
-
-  int64_t elements_compared = 0;
-  while (elements_compared < length_) {
-    const std::shared_ptr<Array> this_array = chunks_[this_chunk_idx];
-    const std::shared_ptr<Array> other_array = other.chunk(other_chunk_idx);
-    int64_t common_length = std::min(this_array->length() - this_start_idx,
-                                     other_array->length() - other_start_idx);
-    if (!this_array->RangeEquals(this_start_idx, this_start_idx + common_length,
-                                 other_start_idx, other_array)) {
-      return false;
-    }
-
-    elements_compared += common_length;
-
-    // If we have exhausted the current chunk, proceed to the next one individually.
-    if (this_start_idx + common_length == this_array->length()) {
-      this_chunk_idx++;
-      this_start_idx = 0;
-    } else {
-      this_start_idx += common_length;
-    }
-
-    if (other_start_idx + common_length == other_array->length()) {
-      other_chunk_idx++;
-      other_start_idx = 0;
-    } else {
-      other_start_idx += common_length;
-    }
-  }
-  return true;
+  return internal::ApplyToChunkOverlaps(
+             *this, other,
+             [](const Array& left_piece, const Array& right_piece,
+                int64_t ARROW_ARG_UNUSED(position)) {
+               if (!left_piece.Equals(right_piece)) {
+                 return Status::Invalid("Unequal piece");
+               }
+               return Status::OK();
+             })
+      .ok();
 }
 
 bool ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other) const {
@@ -221,6 +198,44 @@ Status ChunkedArray::ValidateFull() const {
   }
   return Status::OK();
 }
+
+namespace internal {
+
+bool MultipleChunkIterator::Next(std::shared_ptr<Array>* next_left,
+                                 std::shared_ptr<Array>* next_right) {
+  if (pos_ == length_) return false;
+
+  // Find non-empty chunk
+  std::shared_ptr<Array> chunk_left, chunk_right;
+  while (true) {
+    chunk_left = left_.chunk(chunk_idx_left_);
+    chunk_right = right_.chunk(chunk_idx_right_);
+    if (chunk_pos_left_ == chunk_left->length()) {
+      chunk_pos_left_ = 0;
+      ++chunk_idx_left_;
+      continue;
+    }
+    if (chunk_pos_right_ == chunk_right->length()) {
+      chunk_pos_right_ = 0;
+      ++chunk_idx_right_;
+      continue;
+    }
+    break;
+  }
+  // Determine how big of a section to return
+  int64_t iteration_size = std::min(chunk_left->length() - chunk_pos_left_,
+                                    chunk_right->length() - chunk_pos_right_);
+
+  *next_left = chunk_left->Slice(chunk_pos_left_, iteration_size);
+  *next_right = chunk_right->Slice(chunk_pos_right_, iteration_size);
+
+  pos_ += iteration_size;
+  chunk_pos_left_ += iteration_size;
+  chunk_pos_right_ += iteration_size;
+  return true;
+}
+
+}  // namespace internal
 
 // ----------------------------------------------------------------------
 // Table methods

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -79,7 +79,7 @@ bool ChunkedArray::Equals(const ChunkedArray& other) const {
 
   // Check contents of the underlying arrays. This checks for equality of
   // the underlying data independently of the chunk size.
-  return internal::ApplyToChunkOverlaps(
+  return internal::ApplyBinaryChunked(
              *this, other,
              [](const Array& left_piece, const Array& right_piece,
                 int64_t ARROW_ARG_UNUSED(position)) {

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -134,7 +134,7 @@ namespace internal {
 
 /// \brief EXPERIMENTAL: Utility for incremental iteration over contiguous
 /// pieces of potentially differently-chunked ChunkedArray objects
-class MultipleChunkIterator {
+class ARROW_EXPORT MultipleChunkIterator {
  public:
   MultipleChunkIterator(const ChunkedArray& left, const ChunkedArray& right)
       : left_(left),

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -130,6 +130,63 @@ class ARROW_EXPORT ChunkedArray {
   ARROW_DISALLOW_COPY_AND_ASSIGN(ChunkedArray);
 };
 
+namespace internal {
+
+/// \brief EXPERIMENTAL: Utility for incremental iteration over contiguous
+/// pieces of potentially differently-chunked ChunkedArray objects
+class MultipleChunkIterator {
+ public:
+  MultipleChunkIterator(const ChunkedArray& left, const ChunkedArray& right)
+      : left_(left),
+        right_(right),
+        pos_(0),
+        length_(left.length()),
+        chunk_idx_left_(0),
+        chunk_idx_right_(0),
+        chunk_pos_left_(0),
+        chunk_pos_right_(0) {}
+
+  bool Next(std::shared_ptr<Array>* next_left, std::shared_ptr<Array>* next_right);
+
+  int64_t position() const { return pos_; }
+
+ private:
+  const ChunkedArray& left_;
+  const ChunkedArray& right_;
+
+  // The amount of the entire ChunkedArray consumed
+  int64_t pos_;
+
+  // Length of the chunked array(s)
+  int64_t length_;
+
+  // Current left chunk
+  int chunk_idx_left_;
+
+  // Current right chunk
+  int chunk_idx_right_;
+
+  // Offset into the current left chunk
+  int64_t chunk_pos_left_;
+
+  // Offset into the current right chunk
+  int64_t chunk_pos_right_;
+};
+
+// Execute the passed function
+template <typename Action>
+Status ApplyToChunkOverlaps(const ChunkedArray& left, const ChunkedArray& right,
+                            Action&& action) {
+  MultipleChunkIterator iterator(left, right);
+  std::shared_ptr<Array> left_piece, right_piece;
+  while (iterator.Next(&left_piece, &right_piece)) {
+    ARROW_RETURN_NOT_OK(action(*left_piece, *right_piece, iterator.position()));
+  }
+  return Status::OK();
+}
+
+}  // namespace internal
+
 /// \class Table
 /// \brief Logical table as sequence of chunked arrays
 class ARROW_EXPORT Table {

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -109,7 +109,7 @@ TEST_F(TestChunkedArray, EqualsDifferingLengths) {
 TEST_F(TestChunkedArray, EqualsDifferingMetadata) {
   auto left_ty = list(field("item", int32()));
 
-  auto metadata = KeyValueMetadata::Make({"foo"}, {"bar"});
+  auto metadata = key_value_metadata({"foo"}, {"bar"});
   auto right_ty = list(field("item", int32(), true, metadata));
 
   std::vector<std::shared_ptr<Array>> left_chunks = {ArrayFromJSON(left_ty, "[[]]")};

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -106,6 +106,20 @@ TEST_F(TestChunkedArray, EqualsDifferingLengths) {
   ASSERT_TRUE(one_->Equals(*another_.get()));
 }
 
+TEST_F(TestChunkedArray, EqualsDifferingMetadata) {
+  auto left_ty = list(field("item", int32()));
+
+  auto metadata = KeyValueMetadata::Make({"foo"}, {"bar"});
+  auto right_ty = list(field("item", int32(), true, metadata));
+
+  std::vector<std::shared_ptr<Array>> left_chunks = {ArrayFromJSON(left_ty, "[[]]")};
+  std::vector<std::shared_ptr<Array>> right_chunks = {ArrayFromJSON(right_ty, "[[]]")};
+
+  ChunkedArray left(left_chunks);
+  ChunkedArray right(right_chunks);
+  ASSERT_TRUE(left.Equals(right));
+}
+
 TEST_F(TestChunkedArray, SliceEquals) {
   arrays_one_.push_back(MakeRandomArray<Int32Array>(100));
   arrays_one_.push_back(MakeRandomArray<Int32Array>(50));

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -48,16 +48,6 @@
 
 namespace arrow {
 
-static void PrintChunkedArray(const ChunkedArray& carr, std::stringstream* ss) {
-  for (int i = 0; i < carr.num_chunks(); ++i) {
-    auto c1 = carr.chunk(i);
-    *ss << "Chunk " << i << std::endl;
-    ::arrow::PrettyPrintOptions options(/*indent=*/2);
-    ARROW_EXPECT_OK(::arrow::PrettyPrint(*c1, options, ss));
-    *ss << std::endl;
-  }
-}
-
 template <typename T>
 void AssertTsEqual(const T& expected, const T& actual) {
   if (!expected.Equals(actual)) {
@@ -280,15 +270,29 @@ void AssertTablesEqual(const Table& expected, const Table& actual, bool same_chu
     }
   } else {
     std::stringstream ss;
-    if (!actual.Equals(expected)) {
-      for (int i = 0; i < expected.num_columns(); ++i) {
-        ss << "Actual column " << i << std::endl;
-        PrintChunkedArray(*actual.column(i), &ss);
+    for (int i = 0; i < actual.num_columns(); ++i) {
+      auto actual_col = actual.column(i);
+      auto expected_col = expected.column(i);
 
-        ss << "Expected column " << i << std::endl;
-        PrintChunkedArray(*expected.column(i), &ss);
+      PrettyPrintOptions options(/*indent=*/2);
+      options.window = 50;
+
+      if (!actual_col->Equals(*expected_col)) {
+        ASSERT_OK(internal::ApplyToChunkOverlaps(
+            *actual_col, *expected_col,
+            [&](const Array& left_piece, const Array& right_piece, int64_t position) {
+              std::stringstream diff;
+              if (!left_piece.Equals(right_piece, EqualOptions().diff_sink(&diff))) {
+                ss << "Unequal at absolute position " << position << "\n" << diff.str();
+                ss << "Expected:\n";
+                ARROW_EXPECT_OK(PrettyPrint(right_piece, options, &ss));
+                ss << "\nActual:\n";
+                ARROW_EXPECT_OK(PrettyPrint(left_piece, options, &ss));
+              }
+              return Status::OK();
+            }));
+        FAIL() << ss.str();
       }
-      FAIL() << ss.str();
     }
   }
 }

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -278,7 +278,7 @@ void AssertTablesEqual(const Table& expected, const Table& actual, bool same_chu
       options.window = 50;
 
       if (!actual_col->Equals(*expected_col)) {
-        ASSERT_OK(internal::ApplyToChunkOverlaps(
+        ASSERT_OK(internal::ApplyBinaryChunked(
             *actual_col, *expected_col,
             [&](const Array& left_piece, const Array& right_piece, int64_t position) {
               std::stringstream diff;

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -177,13 +177,13 @@ bool Field::IsCompatibleWith(const std::shared_ptr<Field>& other) const {
   return IsCompatibleWith(*other);
 }
 
-std::string Field::ToString() const {
+std::string Field::ToString(bool print_metadata) const {
   std::stringstream ss;
   ss << name_ << ": " << type_->ToString();
   if (!nullable_) {
     ss << " not null";
   }
-  if (metadata_) {
+  if (print_metadata && metadata_) {
     ss << metadata_->ToString();
   }
   return ss.str();
@@ -798,7 +798,7 @@ Status Schema::RemoveField(int i, std::shared_ptr<Schema>* out) const {
   return Status::OK();
 }
 
-std::string Schema::ToString() const {
+std::string Schema::ToString(bool print_metadata) const {
   std::stringstream buffer;
 
   int i = 0;
@@ -810,7 +810,7 @@ std::string Schema::ToString() const {
     ++i;
   }
 
-  if (HasMetadata()) {
+  if (print_metadata && HasMetadata()) {
     buffer << impl_->metadata_->ToString();
   }
 

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -71,6 +71,17 @@ std::shared_ptr<Field> Field::WithMetadata(
   return std::make_shared<Field>(name_, type_, nullable_, metadata);
 }
 
+std::shared_ptr<Field> Field::WithMergedMetadata(
+    const std::shared_ptr<const KeyValueMetadata>& metadata) const {
+  std::shared_ptr<const KeyValueMetadata> merged_metadata;
+  if (metadata_) {
+    merged_metadata = metadata_->Merge(*metadata);
+  } else {
+    merged_metadata = metadata;
+  }
+  return std::make_shared<Field>(name_, type_, nullable_, merged_metadata);
+}
+
 std::shared_ptr<Field> Field::RemoveMetadata() const {
   return std::make_shared<Field>(name_, type_, nullable_);
 }
@@ -168,9 +179,12 @@ bool Field::IsCompatibleWith(const std::shared_ptr<Field>& other) const {
 
 std::string Field::ToString() const {
   std::stringstream ss;
-  ss << this->name_ << ": " << this->type_->ToString();
-  if (!this->nullable_) {
+  ss << name_ << ": " << type_->ToString();
+  if (!nullable_) {
     ss << " not null";
+  }
+  if (metadata_) {
+    ss << metadata_->ToString();
   }
   return ss.str();
 }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -430,7 +430,7 @@ class ARROW_EXPORT Field : public detail::Fingerprintable {
   bool IsCompatibleWith(const std::shared_ptr<Field>& other) const;
 
   /// \brief Return a string representation ot the field
-  std::string ToString() const;
+  std::string ToString(bool print_metadata = false) const;
 
   /// \brief Return the field name
   const std::string& name() const { return name_; }
@@ -1452,7 +1452,7 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   std::shared_ptr<const KeyValueMetadata> metadata() const;
 
   /// \brief Render a string representation of the schema suitable for debugging
-  std::string ToString() const;
+  std::string ToString(bool print_metadata = false) const;
 
   Status AddField(int i, const std::shared_ptr<Field>& field,
                   std::shared_ptr<Schema>* out) const;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -360,6 +360,12 @@ class ARROW_EXPORT Field : public detail::Fingerprintable {
   std::shared_ptr<Field> WithMetadata(
       const std::shared_ptr<const KeyValueMetadata>& metadata) const;
 
+  /// \brief EXPERIMENTAL: Return a copy of this field with the given metadata
+  /// merged with existing metadata (any colliding keys will be overridden by
+  /// the passed metadata)
+  std::shared_ptr<Field> WithMergedMetadata(
+      const std::shared_ptr<const KeyValueMetadata>& metadata) const;
+
   ARROW_DEPRECATED("Use WithMetadata")
   std::shared_ptr<Field> AddMetadata(
       const std::shared_ptr<const KeyValueMetadata>& metadata) const;
@@ -394,7 +400,6 @@ class ARROW_EXPORT Field : public detail::Fingerprintable {
   /// The two fields must be compatible, i.e:
   ///   - have the same name
   ///   - have the same type, or of compatible types according to `options`.
-  ///
   ///
   /// The metadata of the current field is preserved; the metadata of the other
   /// field is discarded.

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -47,7 +47,7 @@ TEST(TestField, Basics) {
 }
 
 TEST(TestField, ToString) {
-  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto metadata = key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32(), false, metadata);
 
   std::string result = f0->ToString();
@@ -140,7 +140,7 @@ TEST(TestField, IsCompatibleWith) {
 }
 
 TEST(TestField, TestMetadataConstruction) {
-  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto metadata = key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto metadata2 = metadata->Copy();
   auto f0 = field("f0", int32(), true, metadata);
   auto f1 = field("f0", int32(), true, metadata2);
@@ -149,7 +149,7 @@ TEST(TestField, TestMetadataConstruction) {
 }
 
 TEST(TestField, TestWithMetadata) {
-  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto metadata = key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32());
   auto f1 = field("f0", int32(), true, metadata);
   std::shared_ptr<Field> f2 = f0->WithMetadata(metadata);
@@ -164,11 +164,11 @@ TEST(TestField, TestWithMetadata) {
 }
 
 TEST(TestField, TestWithMergedMetadata) {
-  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto metadata = key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32(), true, metadata);
   auto f1 = field("f0", int32());
 
-  auto metadata2 = KeyValueMetadata::Make({"bar", "baz"}, {"bozz", "bazz"});
+  auto metadata2 = key_value_metadata({"bar", "baz"}, {"bozz", "bazz"});
 
   auto f2 = f0->WithMergedMetadata(metadata2);
   auto expected = field("f0", int32(), true, metadata->Merge(*metadata2));
@@ -180,7 +180,7 @@ TEST(TestField, TestWithMergedMetadata) {
 }
 
 TEST(TestField, TestRemoveMetadata) {
-  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto metadata = key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32());
   auto f1 = field("f0", int32(), true, metadata);
   std::shared_ptr<Field> f2 = f1->RemoveMetadata();
@@ -203,7 +203,7 @@ TEST(TestField, TestEmptyMetadata) {
 }
 
 TEST(TestField, TestFlatten) {
-  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto metadata = key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32(), true /* nullable */, metadata);
   auto vec = f0->Flatten();
   ASSERT_EQ(vec.size(), 1);
@@ -229,7 +229,7 @@ TEST(TestField, TestFlatten) {
 }
 
 TEST(TestField, TestReplacement) {
-  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto metadata = key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32(), true, metadata);
   auto fzero = f0->WithType(utf8());
   auto f1 = f0->WithName("f1");
@@ -251,8 +251,8 @@ TEST(TestField, TestReplacement) {
 }
 
 TEST(TestField, TestMerge) {
-  auto metadata1 = KeyValueMetadata::Make({"foo"}, {"v"});
-  auto metadata2 = KeyValueMetadata::Make({"bar"}, {"v"});
+  auto metadata1 = key_value_metadata({"foo"}, {"v"});
+  auto metadata2 = key_value_metadata({"bar"}, {"v"});
   {
     // different name.
     ASSERT_RAISES(Invalid, field("f0", int32())->MergeWith(field("f1", int32())));
@@ -505,7 +505,7 @@ TEST_F(TestSchema, TestWithMetadata) {
   auto f1 = field("f1", uint8(), false);
   auto f2 = field("f2", utf8());
   std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
-  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto metadata = key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto schema = std::make_shared<Schema>(fields);
   std::shared_ptr<Schema> new_schema = schema->WithMetadata(metadata);
   ASSERT_TRUE(metadata->Equals(*new_schema->metadata()));
@@ -779,8 +779,8 @@ TEST_F(TestUnifySchemas, MissingField) {
   auto int32_field = field("int32_field", int32());
   auto uint8_field = field("uint8_field", uint8(), false);
   auto utf8_field = field("utf8_field", utf8());
-  auto metadata1 = KeyValueMetadata::Make({"foo"}, {"bar"});
-  auto metadata2 = KeyValueMetadata::Make({"q"}, {"42"});
+  auto metadata1 = key_value_metadata({"foo"}, {"bar"});
+  auto metadata2 = key_value_metadata({"q"}, {"42"});
 
   auto schema1 = schema({int32_field, uint8_field})->WithMetadata(metadata1);
   auto schema2 = schema({uint8_field, utf8_field->WithMetadata(metadata2)});
@@ -793,7 +793,7 @@ TEST_F(TestUnifySchemas, MissingField) {
 }
 
 TEST_F(TestUnifySchemas, PromoteNullTypeField) {
-  auto metadata = KeyValueMetadata::Make({"foo"}, {"bar"});
+  auto metadata = key_value_metadata({"foo"}, {"bar"});
   auto null_field = field("f", null());
   auto int32_field = field("f", int32(), /*nullable=*/false);
 

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -50,11 +50,15 @@ TEST(TestField, ToString) {
   auto metadata = key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32(), false, metadata);
 
-  std::string result = f0->ToString();
+  std::string result = f0->ToString(/*print_metadata=*/true);
   std::string expected = R"(f0: int32 not null
 -- metadata --
 foo: bizz
 bar: buzz)";
+  ASSERT_EQ(expected, result);
+
+  result = f0->ToString();
+  expected = "f0: int32 not null";
   ASSERT_EQ(expected, result);
 }
 
@@ -340,13 +344,24 @@ TEST_F(TestSchema, ToString) {
   auto f2 = field("f2", utf8());
   auto f3 = field("f3", list(int16()));
 
-  auto schema = ::arrow::schema({f0, f1, f2, f3});
+  auto metadata = key_value_metadata({"foo"}, {"bar"});
+  auto schema = ::arrow::schema({f0, f1, f2, f3}, metadata);
 
   std::string result = schema->ToString();
   std::string expected = R"(f0: int32
 f1: uint8 not null
 f2: string
 f3: list<item: int16>)";
+
+  ASSERT_EQ(expected, result);
+
+  result = schema->ToString(/*print_metadata=*/true);
+  expected = R"(f0: int32
+f1: uint8 not null
+f2: string
+f3: list<item: int16>
+-- metadata --
+foo: bar)";
 
   ASSERT_EQ(expected, result);
 }

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -46,6 +46,18 @@ TEST(TestField, Basics) {
   ASSERT_FALSE(f0_nn.nullable());
 }
 
+TEST(TestField, ToString) {
+  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto f0 = field("f0", int32(), false, metadata);
+
+  std::string result = f0->ToString();
+  std::string expected = R"(f0: int32 not null
+-- metadata --
+foo: bizz
+bar: buzz)";
+  ASSERT_EQ(expected, result);
+}
+
 TEST(TestField, Equals) {
   auto meta1 = key_value_metadata({{"a", "1"}, {"b", "2"}});
   // Different from meta1
@@ -128,8 +140,7 @@ TEST(TestField, IsCompatibleWith) {
 }
 
 TEST(TestField, TestMetadataConstruction) {
-  auto metadata = std::shared_ptr<KeyValueMetadata>(
-      new KeyValueMetadata({"foo", "bar"}, {"bizz", "buzz"}));
+  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
   auto metadata2 = metadata->Copy();
   auto f0 = field("f0", int32(), true, metadata);
   auto f1 = field("f0", int32(), true, metadata2);
@@ -138,8 +149,7 @@ TEST(TestField, TestMetadataConstruction) {
 }
 
 TEST(TestField, TestWithMetadata) {
-  auto metadata = std::shared_ptr<KeyValueMetadata>(
-      new KeyValueMetadata({"foo", "bar"}, {"bizz", "buzz"}));
+  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32());
   auto f1 = field("f0", int32(), true, metadata);
   std::shared_ptr<Field> f2 = f0->WithMetadata(metadata);
@@ -153,9 +163,24 @@ TEST(TestField, TestWithMetadata) {
   ASSERT_EQ(metadata.get(), f1->metadata().get());
 }
 
+TEST(TestField, TestWithMergedMetadata) {
+  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  auto f0 = field("f0", int32(), true, metadata);
+  auto f1 = field("f0", int32());
+
+  auto metadata2 = KeyValueMetadata::Make({"bar", "baz"}, {"bozz", "bazz"});
+
+  auto f2 = f0->WithMergedMetadata(metadata2);
+  auto expected = field("f0", int32(), true, metadata->Merge(*metadata2));
+  AssertFieldEqual(expected, f2);
+
+  auto f3 = f1->WithMergedMetadata(metadata2);
+  expected = field("f0", int32(), true, metadata2);
+  AssertFieldEqual(expected, f3);
+}
+
 TEST(TestField, TestRemoveMetadata) {
-  auto metadata = std::shared_ptr<KeyValueMetadata>(
-      new KeyValueMetadata({"foo", "bar"}, {"bizz", "buzz"}));
+  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32());
   auto f1 = field("f0", int32(), true, metadata);
   std::shared_ptr<Field> f2 = f1->RemoveMetadata();
@@ -178,8 +203,7 @@ TEST(TestField, TestEmptyMetadata) {
 }
 
 TEST(TestField, TestFlatten) {
-  auto metadata = std::shared_ptr<KeyValueMetadata>(
-      new KeyValueMetadata({"foo", "bar"}, {"bizz", "buzz"}));
+  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32(), true /* nullable */, metadata);
   auto vec = f0->Flatten();
   ASSERT_EQ(vec.size(), 1);
@@ -205,8 +229,7 @@ TEST(TestField, TestFlatten) {
 }
 
 TEST(TestField, TestReplacement) {
-  auto metadata = std::shared_ptr<KeyValueMetadata>(
-      new KeyValueMetadata({"foo", "bar"}, {"bizz", "buzz"}));
+  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
   auto f0 = field("f0", int32(), true, metadata);
   auto fzero = f0->WithType(utf8());
   auto f1 = f0->WithName("f1");
@@ -228,10 +251,8 @@ TEST(TestField, TestReplacement) {
 }
 
 TEST(TestField, TestMerge) {
-  auto metadata1 =
-      std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"foo"}, {"v"}));
-  auto metadata2 =
-      std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"bar"}, {"v"}));
+  auto metadata1 = KeyValueMetadata::Make({"foo"}, {"v"});
+  auto metadata2 = KeyValueMetadata::Make({"bar"}, {"v"});
   {
     // different name.
     ASSERT_RAISES(Invalid, field("f0", int32())->MergeWith(field("f1", int32())));
@@ -484,8 +505,7 @@ TEST_F(TestSchema, TestWithMetadata) {
   auto f1 = field("f1", uint8(), false);
   auto f2 = field("f2", utf8());
   std::vector<std::shared_ptr<Field>> fields = {f0, f1, f2};
-  auto metadata = std::shared_ptr<KeyValueMetadata>(
-      new KeyValueMetadata({"foo", "bar"}, {"bizz", "buzz"}));
+  auto metadata = KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
   auto schema = std::make_shared<Schema>(fields);
   std::shared_ptr<Schema> new_schema = schema->WithMetadata(metadata);
   ASSERT_TRUE(metadata->Equals(*new_schema->metadata()));
@@ -759,9 +779,8 @@ TEST_F(TestUnifySchemas, MissingField) {
   auto int32_field = field("int32_field", int32());
   auto uint8_field = field("uint8_field", uint8(), false);
   auto utf8_field = field("utf8_field", utf8());
-  auto metadata1 =
-      std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"foo"}, {"bar"}));
-  auto metadata2 = std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"q"}, {"42"}));
+  auto metadata1 = KeyValueMetadata::Make({"foo"}, {"bar"});
+  auto metadata2 = KeyValueMetadata::Make({"q"}, {"42"});
 
   auto schema1 = schema({int32_field, uint8_field})->WithMetadata(metadata1);
   auto schema2 = schema({uint8_field, utf8_field->WithMetadata(metadata2)});
@@ -774,8 +793,7 @@ TEST_F(TestUnifySchemas, MissingField) {
 }
 
 TEST_F(TestUnifySchemas, PromoteNullTypeField) {
-  auto metadata =
-      std::shared_ptr<KeyValueMetadata>(new KeyValueMetadata({"foo"}, {"bar"}));
+  auto metadata = KeyValueMetadata::Make({"foo"}, {"bar"});
   auto null_field = field("f", null());
   auto int32_field = field("f", int32(), /*nullable=*/false);
 

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -68,11 +68,6 @@ KeyValueMetadata::KeyValueMetadata(std::vector<std::string> keys,
   ARROW_CHECK_EQ(keys.size(), values.size());
 }
 
-std::shared_ptr<KeyValueMetadata> KeyValueMetadata::Make(
-    std::vector<std::string> keys, std::vector<std::string> values) {
-  return std::make_shared<KeyValueMetadata>(std::move(keys), std::move(values));
-}
-
 void KeyValueMetadata::ToUnorderedMap(
     std::unordered_map<std::string, std::string>* out) const {
   DCHECK_NE(out, nullptr);

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -61,10 +62,15 @@ KeyValueMetadata::KeyValueMetadata(
   ARROW_CHECK_EQ(keys_.size(), values_.size());
 }
 
-KeyValueMetadata::KeyValueMetadata(const std::vector<std::string>& keys,
-                                   const std::vector<std::string>& values)
-    : keys_(keys), values_(values) {
+KeyValueMetadata::KeyValueMetadata(std::vector<std::string> keys,
+                                   std::vector<std::string> values)
+    : keys_(std::move(keys)), values_(std::move(values)) {
   ARROW_CHECK_EQ(keys.size(), values.size());
+}
+
+std::shared_ptr<KeyValueMetadata> KeyValueMetadata::Make(
+    std::vector<std::string> keys, std::vector<std::string> values) {
+  return std::make_shared<KeyValueMetadata>(std::move(keys), std::move(values));
 }
 
 void KeyValueMetadata::ToUnorderedMap(
@@ -128,6 +134,37 @@ int KeyValueMetadata::FindKey(const std::string& key) const {
 
 std::shared_ptr<KeyValueMetadata> KeyValueMetadata::Copy() const {
   return std::make_shared<KeyValueMetadata>(keys_, values_);
+}
+
+std::shared_ptr<KeyValueMetadata> KeyValueMetadata::Merge(
+    const KeyValueMetadata& other) const {
+  std::unordered_set<std::string> observed_keys;
+  std::vector<std::string> result_keys;
+  std::vector<std::string> result_values;
+
+  result_keys.reserve(keys_.size());
+  result_values.reserve(keys_.size());
+
+  for (int64_t i = 0; i < other.size(); ++i) {
+    const auto& key = other.key(i);
+    auto it = observed_keys.find(key);
+    if (it == observed_keys.end()) {
+      result_keys.push_back(key);
+      result_values.push_back(other.value(i));
+      observed_keys.insert(key);
+    }
+  }
+  for (size_t i = 0; i < keys_.size(); ++i) {
+    auto it = observed_keys.find(keys_[i]);
+    if (it == observed_keys.end()) {
+      result_keys.push_back(keys_[i]);
+      result_values.push_back(values_[i]);
+      observed_keys.insert(keys_[i]);
+    }
+  }
+
+  return std::make_shared<KeyValueMetadata>(std::move(result_keys),
+                                            std::move(result_values));
 }
 
 bool KeyValueMetadata::Equals(const KeyValueMetadata& other) const {

--- a/cpp/src/arrow/util/key_value_metadata.h
+++ b/cpp/src/arrow/util/key_value_metadata.h
@@ -38,10 +38,6 @@ class ARROW_EXPORT KeyValueMetadata {
   explicit KeyValueMetadata(const std::unordered_map<std::string, std::string>& map);
   virtual ~KeyValueMetadata() = default;
 
-  /// \brief Convenience constructor
-  static std::shared_ptr<KeyValueMetadata> Make(std::vector<std::string> keys,
-                                                std::vector<std::string> values);
-
   void ToUnorderedMap(std::unordered_map<std::string, std::string>* out) const;
 
   void Append(const std::string& key, const std::string& value);

--- a/cpp/src/arrow/util/key_value_metadata.h
+++ b/cpp/src/arrow/util/key_value_metadata.h
@@ -34,10 +34,13 @@ namespace arrow {
 class ARROW_EXPORT KeyValueMetadata {
  public:
   KeyValueMetadata();
-  KeyValueMetadata(const std::vector<std::string>& keys,
-                   const std::vector<std::string>& values);
+  KeyValueMetadata(std::vector<std::string> keys, std::vector<std::string> values);
   explicit KeyValueMetadata(const std::unordered_map<std::string, std::string>& map);
   virtual ~KeyValueMetadata() = default;
+
+  /// \brief Convenience constructor
+  static std::shared_ptr<KeyValueMetadata> Make(std::vector<std::string> keys,
+                                                std::vector<std::string> values);
 
   void ToUnorderedMap(std::unordered_map<std::string, std::string>* out) const;
 
@@ -54,6 +57,11 @@ class ARROW_EXPORT KeyValueMetadata {
   int FindKey(const std::string& key) const;
 
   std::shared_ptr<KeyValueMetadata> Copy() const;
+
+  /// \brief Return a new KeyValueMetadata by combining the passed metadata
+  /// with this KeyValueMetadata. Colliding keys will be overridden by the
+  /// passed metadata. Assumes keys in both containers are unique
+  std::shared_ptr<KeyValueMetadata> Merge(const KeyValueMetadata& other) const;
 
   bool Equals(const KeyValueMetadata& other) const;
   std::string ToString() const;

--- a/cpp/src/arrow/util/key_value_metadata_test.cc
+++ b/cpp/src/arrow/util/key_value_metadata_test.cc
@@ -42,6 +42,10 @@ TEST(KeyValueMetadataTest, StringVectorConstruction) {
   ASSERT_EQ("bizz", metadata.value(0));
   ASSERT_EQ("buzz", metadata.value(1));
   ASSERT_EQ(2, metadata.size());
+
+  std::shared_ptr<KeyValueMetadata> metadata2 =
+      KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+  ASSERT_TRUE(metadata.Equals(*metadata2));
 }
 
 TEST(KeyValueMetadataTest, StringMapConstruction) {
@@ -83,6 +87,23 @@ TEST(KeyValueMetadataTest, Copy) {
   KeyValueMetadata metadata(keys, values);
   auto metadata2 = metadata.Copy();
   ASSERT_TRUE(metadata.Equals(*metadata2));
+}
+
+TEST(KeyValueMetadataTest, Merge) {
+  std::vector<std::string> keys1 = {"foo", "bar"};
+  std::vector<std::string> values1 = {"bizz", "buzz"};
+  KeyValueMetadata metadata(keys1, values1);
+
+  std::vector<std::string> keys2 = {"bar", "baz"};
+  std::vector<std::string> values2 = {"bozz", "bezz"};
+  KeyValueMetadata metadata2(keys2, values2);
+
+  std::vector<std::string> keys3 = {"foo", "bar", "baz"};
+  std::vector<std::string> values3 = {"bizz", "bozz", "bezz"};
+  KeyValueMetadata expected(keys3, values3);
+
+  auto result = metadata.Merge(metadata2);
+  ASSERT_TRUE(result->Equals(expected));
 }
 
 TEST(KeyValueMetadataTest, FindKey) {

--- a/cpp/src/arrow/util/key_value_metadata_test.cc
+++ b/cpp/src/arrow/util/key_value_metadata_test.cc
@@ -44,7 +44,7 @@ TEST(KeyValueMetadataTest, StringVectorConstruction) {
   ASSERT_EQ(2, metadata.size());
 
   std::shared_ptr<KeyValueMetadata> metadata2 =
-      KeyValueMetadata::Make({"foo", "bar"}, {"bizz", "buzz"});
+      key_value_metadata({"foo", "bar"}, {"bizz", "buzz"});
   ASSERT_TRUE(metadata.Equals(*metadata2));
 }
 

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -63,12 +63,13 @@ class TestConvertParquetSchema : public ::testing::Test {
  public:
   virtual void SetUp() {}
 
-  void CheckFlatSchema(const std::shared_ptr<::arrow::Schema>& expected_schema) {
+  void CheckFlatSchema(const std::shared_ptr<::arrow::Schema>& expected_schema,
+                       bool check_metadata = false) {
     ASSERT_EQ(expected_schema->num_fields(), result_schema_->num_fields());
     for (int i = 0; i < expected_schema->num_fields(); ++i) {
       auto result_field = result_schema_->field(i);
       auto expected_field = expected_schema->field(i);
-      EXPECT_TRUE(result_field->Equals(expected_field))
+      EXPECT_TRUE(result_field->Equals(expected_field, check_metadata))
           << "Field " << i << "\n  result: " << result_field->ToString()
           << "\n  expected: " << expected_field->ToString();
     }

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -751,8 +751,9 @@ Status GetReader(const SchemaField& field, const std::shared_ptr<ReaderContext>&
       *out = nullptr;
       return Status::OK();
     }
-    auto filtered_field = ::arrow::field(
-        field.field->name(), ::arrow::struct_(child_fields), field.field->nullable());
+    auto filtered_field =
+        ::arrow::field(field.field->name(), ::arrow::struct_(child_fields),
+                       field.field->nullable(), field.field->metadata());
     out->reset(new StructReader(ctx, field, filtered_field, std::move(child_readers)));
   } else {
     return Status::Invalid("Unsupported nested type: ", field.field->ToString());

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -380,6 +380,11 @@ bool HasStructListName(const GroupNode& node) {
   return node.name() == "array" || boost::algorithm::ends_with(node.name(), "_tuple");
 }
 
+std::shared_ptr<::arrow::KeyValueMetadata> FieldIdMetadata(int field_id) {
+  return ::arrow::KeyValueMetadata::Make({"PARQUET::field_id"},
+                                         {std::to_string(field_id)});
+}
+
 Status GroupToStruct(const GroupNode& node, int16_t max_def_level, int16_t max_rep_level,
                      SchemaTreeContext* ctx, const SchemaField* parent,
                      SchemaField* out) {
@@ -391,7 +396,8 @@ Status GroupToStruct(const GroupNode& node, int16_t max_def_level, int16_t max_r
     arrow_fields.push_back(out->children[i].field);
   }
   auto struct_type = ::arrow::struct_(arrow_fields);
-  out->field = ::arrow::field(node.name(), struct_type, node.is_optional());
+  out->field = ::arrow::field(node.name(), struct_type, node.is_optional(),
+                              FieldIdMetadata(node.field_id()));
   out->max_definition_level = max_def_level;
   out->max_repetition_level = max_rep_level;
   return Status::OK();
@@ -465,12 +471,13 @@ Status ListToSchemaField(const GroupNode& group, int16_t max_def_level,
     int column_index = ctx->schema->GetColumnIndex(primitive_node);
     std::shared_ptr<DataType> type;
     RETURN_NOT_OK(GetTypeForNode(column_index, primitive_node, ctx, &type));
-    auto item_field = ::arrow::field(list_node.name(), type, /*nullable=*/false);
+    auto item_field = ::arrow::field(list_node.name(), type, /*nullable=*/false,
+                                     FieldIdMetadata(list_node.field_id()));
     RETURN_NOT_OK(PopulateLeaf(column_index, item_field, max_def_level, max_rep_level,
                                ctx, out, child_field));
   }
   out->field = ::arrow::field(group.name(), ::arrow::list(child_field->field),
-                              group.is_optional());
+                              group.is_optional(), FieldIdMetadata(group.field_id()));
   out->max_definition_level = max_def_level;
   out->max_repetition_level = max_rep_level;
   return Status::OK();
@@ -494,7 +501,7 @@ Status GroupToSchemaField(const GroupNode& node, int16_t max_def_level,
     RETURN_NOT_OK(
         GroupToStruct(node, max_def_level, max_rep_level, ctx, out, &out->children[0]));
     out->field = ::arrow::field(node.name(), ::arrow::list(out->children[0].field),
-                                node.is_optional());
+                                node.is_optional(), FieldIdMetadata(node.field_id()));
     out->max_definition_level = max_def_level;
     out->max_repetition_level = max_rep_level;
     return Status::OK();
@@ -547,7 +554,7 @@ Status NodeToSchemaField(const Node& node, int16_t max_def_level, int16_t max_re
                                  ctx, out, &out->children[0]));
 
       out->field = ::arrow::field(node.name(), ::arrow::list(child_field),
-                                  /*nullable=*/false);
+                                  /*nullable=*/false, FieldIdMetadata(node.field_id()));
       // Is this right?
       out->max_definition_level = max_def_level;
       out->max_repetition_level = max_rep_level;
@@ -555,7 +562,8 @@ Status NodeToSchemaField(const Node& node, int16_t max_def_level, int16_t max_re
     } else {
       // A normal (required/optional) primitive node
       return PopulateLeaf(column_index,
-                          ::arrow::field(node.name(), type, node.is_optional()),
+                          ::arrow::field(node.name(), type, node.is_optional(),
+                                         FieldIdMetadata(node.field_id())),
                           max_def_level, max_rep_level, ctx, parent, out);
     }
   }
@@ -630,6 +638,10 @@ Status ApplyOriginalMetadata(std::shared_ptr<Field> field, const Field& origin_f
   // restore field metadata
   std::shared_ptr<const KeyValueMetadata> field_metadata = origin_field.metadata();
   if (field_metadata != nullptr) {
+    if (field->metadata()) {
+      // Prefer the metadata keys (like field_id) from the current metadata
+      field_metadata = field_metadata->Merge(*field->metadata());
+    }
     field = field->WithMetadata(field_metadata);
 
     // extension type
@@ -1341,6 +1353,7 @@ Status ReconstructNestedList(const std::shared_ptr<Array>& arr,
   // Walk downwards to extract nullability
   std::vector<std::string> item_names;
   std::vector<bool> nullable;
+  std::vector<std::shared_ptr<const ::arrow::KeyValueMetadata>> field_metadata;
   std::vector<std::shared_ptr<::arrow::Int32Builder>> offset_builders;
   std::vector<std::shared_ptr<::arrow::BooleanBuilder>> valid_bits_builders;
   nullable.push_back(field->nullable());
@@ -1359,6 +1372,7 @@ Status ReconstructNestedList(const std::shared_ptr<Array>& arr,
     valid_bits_builders.emplace_back(
         std::make_shared<::arrow::BooleanBuilder>(::arrow::boolean(), pool));
     nullable.push_back(field->nullable());
+    field_metadata.push_back(field->metadata());
   }
 
   int64_t list_depth = offset_builders.size();
@@ -1436,8 +1450,8 @@ Status ReconstructNestedList(const std::shared_ptr<Array>& arr,
 
   // TODO(wesm): Use passed-in field
   for (int64_t j = list_depth - 1; j >= 0; j--) {
-    auto list_type =
-        ::arrow::list(::arrow::field(item_names[j], (*out)->type(), nullable[j + 1]));
+    auto list_type = ::arrow::list(::arrow::field(item_names[j], (*out)->type(),
+                                                  nullable[j + 1], field_metadata[j]));
     *out = std::make_shared<::arrow::ListArray>(list_type, list_lengths[j], offsets[j],
                                                 *out, valid_bits[j], null_counts[j]);
   }

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -381,8 +381,7 @@ bool HasStructListName(const GroupNode& node) {
 }
 
 std::shared_ptr<::arrow::KeyValueMetadata> FieldIdMetadata(int field_id) {
-  return ::arrow::KeyValueMetadata::Make({"PARQUET::field_id"},
-                                         {std::to_string(field_id)});
+  return ::arrow::key_value_metadata({"PARQUET:field_id"}, {std::to_string(field_id)});
 }
 
 Status GroupToStruct(const GroupNode& node, int16_t max_def_level, int16_t max_rep_level,

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -631,9 +631,8 @@ class FileMetaData::FileMetaDataImpl {
   uint32_t metadata_len_;
   std::unique_ptr<format::FileMetaData> metadata_;
   void InitSchema() {
-    schema::FlatSchemaConverter converter(&metadata_->schema[0],
-                                          static_cast<int>(metadata_->schema.size()));
-    schema_.Init(converter.Convert());
+    schema_.Init(schema::Unflatten(&metadata_->schema[0],
+                                   static_cast<int>(metadata_->schema.size())));
   }
   void InitColumnOrders() {
     // update ColumnOrder
@@ -1341,10 +1340,8 @@ class FileMetaDataBuilder::FileMetaDataBuilderImpl {
       }
     }
 
-    parquet::schema::SchemaFlattener flattener(
-        static_cast<parquet::schema::GroupNode*>(schema_->schema_root().get()),
-        &metadata_->schema);
-    flattener.Flatten();
+    ToParquet(static_cast<parquet::schema::GroupNode*>(schema_->schema_root().get()),
+              &metadata_->schema);
     auto file_meta_data = std::unique_ptr<FileMetaData>(new FileMetaData());
     file_meta_data->impl_->metadata_ = std::move(metadata_);
     file_meta_data->impl_->InitSchema();

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -124,8 +124,7 @@ class PARQUET_EXPORT Node {
 
   /// \brief The field_id value for the serialized SchemaElement. If the
   /// field_id is less than 0 (e.g. -1), it will not be set when serialized to
-  /// Thrift. Note that such unassigned field_ids will be overridden and set to
-  /// a default value determined by depth-first traversal when
+  /// Thrift.
   int field_id() const { return field_id_; }
 
   PARQUET_DEPRECATED("id() is deprecated. Use field_id() instead")
@@ -204,7 +203,7 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
   // The field_id here is the default to use if it is not set in the SchemaElement
   static std::unique_ptr<Node> FromParquet(const void* opaque_element, int field_id = -1);
 
-  // A field_id -1 means to use the default next_id()
+  // A field_id -1 (or any negative value) will be serialized as null in Thrift
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
                              Type::type type,
                              ConvertedType::type converted_type = ConvertedType::NONE,
@@ -215,7 +214,7 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
   }
 
   // If no logical type, pass LogicalType::None() or nullptr
-  // A field_id -1 means to use the default next_id()
+  // A field_id -1 (or any negative value) will be serialized as null in Thrift
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
                              std::shared_ptr<const LogicalType> logical_type,
                              Type::type primitive_type, int primitive_length = -1,
@@ -271,7 +270,7 @@ class PARQUET_EXPORT GroupNode : public Node {
   static std::unique_ptr<Node> FromParquet(const void* opaque_element,
                                            NodeVector fields = {}, int field_id = -1);
 
-  // A field_id -1 means to use the default next_id()
+  // A field_id -1 (or any negative value) will be serialized as null in Thrift
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
                              const NodeVector& fields,
                              ConvertedType::type converted_type = ConvertedType::NONE,
@@ -280,7 +279,7 @@ class PARQUET_EXPORT GroupNode : public Node {
   }
 
   // If no logical type, pass nullptr
-  // A field_id -1 means to use the default next_id()
+  // A field_id -1 (or any negative value) will be serialized as null in Thrift
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
                              const NodeVector& fields,
                              std::shared_ptr<const LogicalType> logical_type,

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -18,8 +18,7 @@
 // This module contains the logical parquet-cpp types (independent of Thrift
 // structures), schema nodes, and related type tools
 
-#ifndef PARQUET_SCHEMA_TYPES_H
-#define PARQUET_SCHEMA_TYPES_H
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -99,24 +98,6 @@ class PARQUET_EXPORT Node {
  public:
   enum type { PRIMITIVE, GROUP };
 
-  Node(Node::type type, const std::string& name, Repetition::type repetition,
-       ConvertedType::type converted_type = ConvertedType::NONE, int id = -1)
-      : type_(type),
-        name_(name),
-        repetition_(repetition),
-        converted_type_(converted_type),
-        id_(id),
-        parent_(NULLPTR) {}
-
-  Node(Node::type type, const std::string& name, Repetition::type repetition,
-       std::shared_ptr<const LogicalType> logical_type, int id = -1)
-      : type_(type),
-        name_(name),
-        repetition_(repetition),
-        logical_type_(std::move(logical_type)),
-        id_(id),
-        parent_(NULLPTR) {}
-
   virtual ~Node() {}
 
   bool is_primitive() const { return type_ == Node::PRIMITIVE; }
@@ -141,7 +122,13 @@ class PARQUET_EXPORT Node {
 
   const std::shared_ptr<const LogicalType>& logical_type() const { return logical_type_; }
 
-  int id() const { return id_; }
+  /// \brief The field_id value for the serialized SchemaElement. If the
+  /// field_id is less than 0 (e.g. -1), it will not be set when serialized to
+  /// Thrift
+  int field_id() const { return field_id_; }
+
+  PARQUET_DEPRECATED("id() is deprecated. Use field_id() instead")
+  int id() const { return field_id_; }
 
   const Node* parent() const { return parent_; }
 
@@ -169,12 +156,30 @@ class PARQUET_EXPORT Node {
  protected:
   friend class GroupNode;
 
+  Node(Node::type type, const std::string& name, Repetition::type repetition,
+       ConvertedType::type converted_type = ConvertedType::NONE, int field_id = -1)
+      : type_(type),
+        name_(name),
+        repetition_(repetition),
+        converted_type_(converted_type),
+        field_id_(field_id),
+        parent_(NULLPTR) {}
+
+  Node(Node::type type, const std::string& name, Repetition::type repetition,
+       std::shared_ptr<const LogicalType> logical_type, int field_id = -1)
+      : type_(type),
+        name_(name),
+        repetition_(repetition),
+        logical_type_(std::move(logical_type)),
+        field_id_(field_id),
+        parent_(NULLPTR) {}
+
   Node::type type_;
   std::string name_;
   Repetition::type repetition_;
   ConvertedType::type converted_type_;
   std::shared_ptr<const LogicalType> logical_type_;
-  int id_;
+  int field_id_;
   // Nodes should not be shared, they have a single parent.
   const Node* parent_;
 
@@ -195,21 +200,27 @@ typedef std::vector<NodePtr> NodeVector;
 // parameters)
 class PARQUET_EXPORT PrimitiveNode : public Node {
  public:
-  static std::unique_ptr<Node> FromParquet(const void* opaque_element, int id);
+  // The field_id here is the default to use if it is not set in the SchemaElement
+  static std::unique_ptr<Node> FromParquet(const void* opaque_element, int field_id = -1);
 
+  // A field_id -1 means to use the default next_id()
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
                              Type::type type,
                              ConvertedType::type converted_type = ConvertedType::NONE,
-                             int length = -1, int precision = -1, int scale = -1) {
+                             int length = -1, int precision = -1, int scale = -1,
+                             int field_id = -1) {
     return NodePtr(new PrimitiveNode(name, repetition, type, converted_type, length,
-                                     precision, scale));
+                                     precision, scale, field_id));
   }
 
+  // If no logical type, pass LogicalType::None() or nullptr
+  // A field_id -1 means to use the default next_id()
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
                              std::shared_ptr<const LogicalType> logical_type,
-                             Type::type primitive_type, int primitive_length = -1) {
+                             Type::type primitive_type, int primitive_length = -1,
+                             int field_id = -1) {
     return NodePtr(new PrimitiveNode(name, repetition, logical_type, primitive_type,
-                                     primitive_length));
+                                     primitive_length, field_id));
   }
 
   bool Equals(const Node* other) const override;
@@ -231,11 +242,11 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
  private:
   PrimitiveNode(const std::string& name, Repetition::type repetition, Type::type type,
                 ConvertedType::type converted_type = ConvertedType::NONE, int length = -1,
-                int precision = -1, int scale = -1, int id = -1);
+                int precision = -1, int scale = -1, int field_id = -1);
 
   PrimitiveNode(const std::string& name, Repetition::type repetition,
                 std::shared_ptr<const LogicalType> logical_type,
-                Type::type primitive_type, int primitive_length = -1, int id = -1);
+                Type::type primitive_type, int primitive_length = -1, int field_id = -1);
 
   Type::type physical_type_;
   int32_t type_length_;
@@ -255,19 +266,25 @@ class PARQUET_EXPORT PrimitiveNode : public Node {
 
 class PARQUET_EXPORT GroupNode : public Node {
  public:
-  static std::unique_ptr<Node> FromParquet(const void* opaque_element, int id,
-                                           const NodeVector& fields);
+  // The field_id here is the default to use if it is not set in the SchemaElement
+  static std::unique_ptr<Node> FromParquet(const void* opaque_element,
+                                           NodeVector fields = {}, int field_id = -1);
 
+  // A field_id -1 means to use the default next_id()
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
                              const NodeVector& fields,
-                             ConvertedType::type converted_type = ConvertedType::NONE) {
-    return NodePtr(new GroupNode(name, repetition, fields, converted_type));
+                             ConvertedType::type converted_type = ConvertedType::NONE,
+                             int field_id = -1) {
+    return NodePtr(new GroupNode(name, repetition, fields, converted_type, field_id));
   }
 
+  // If no logical type, pass nullptr
+  // A field_id -1 means to use the default next_id()
   static inline NodePtr Make(const std::string& name, Repetition::type repetition,
                              const NodeVector& fields,
-                             std::shared_ptr<const LogicalType> logical_type) {
-    return NodePtr(new GroupNode(name, repetition, fields, logical_type));
+                             std::shared_ptr<const LogicalType> logical_type,
+                             int field_id = -1) {
+    return NodePtr(new GroupNode(name, repetition, fields, logical_type, field_id));
   }
 
   bool Equals(const Node* other) const override;
@@ -289,11 +306,11 @@ class PARQUET_EXPORT GroupNode : public Node {
  private:
   GroupNode(const std::string& name, Repetition::type repetition,
             const NodeVector& fields,
-            ConvertedType::type converted_type = ConvertedType::NONE, int id = -1);
+            ConvertedType::type converted_type = ConvertedType::NONE, int field_id = -1);
 
   GroupNode(const std::string& name, Repetition::type repetition,
             const NodeVector& fields, std::shared_ptr<const LogicalType> logical_type,
-            int id = -1);
+            int field_id = -1);
 
   NodeVector fields_;
   bool EqualsInternal(const GroupNode* other) const;
@@ -310,10 +327,12 @@ class PARQUET_EXPORT GroupNode : public Node {
 // ----------------------------------------------------------------------
 // Convenience primitive type factory functions
 
-#define PRIMITIVE_FACTORY(FuncName, TYPE)                                              \
-  static inline NodePtr FuncName(const std::string& name,                              \
-                                 Repetition::type repetition = Repetition::OPTIONAL) { \
-    return PrimitiveNode::Make(name, repetition, Type::TYPE);                          \
+#define PRIMITIVE_FACTORY(FuncName, TYPE)                                                \
+  static inline NodePtr FuncName(const std::string& name,                                \
+                                 Repetition::type repetition = Repetition::OPTIONAL,     \
+                                 int field_id = -1) {                                    \
+    return PrimitiveNode::Make(name, repetition, Type::TYPE, ConvertedType::NONE,        \
+                               /*length=*/-1, /*precision=*/-1, /*scale=*/-1, field_id); \
   }
 
 PRIMITIVE_FACTORY(Boolean, BOOLEAN)
@@ -467,5 +486,3 @@ class PARQUET_EXPORT SchemaDescriptor {
 };
 
 }  // namespace parquet
-
-#endif  // PARQUET_SCHEMA_TYPES_H

--- a/cpp/src/parquet/schema.h
+++ b/cpp/src/parquet/schema.h
@@ -124,7 +124,8 @@ class PARQUET_EXPORT Node {
 
   /// \brief The field_id value for the serialized SchemaElement. If the
   /// field_id is less than 0 (e.g. -1), it will not be set when serialized to
-  /// Thrift
+  /// Thrift. Note that such unassigned field_ids will be overridden and set to
+  /// a default value determined by depth-first traversal when
   int field_id() const { return field_id_; }
 
   PARQUET_DEPRECATED("id() is deprecated. Use field_id() instead")

--- a/cpp/src/parquet/schema_internal.h
+++ b/cpp/src/parquet/schema_internal.h
@@ -15,16 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// This module contains the logical parquet-cpp types (independent of Thrift
-// structures), schema nodes, and related type tools
+// Non-public Thrift schema serialization utilities
 
-#ifndef PARQUET_SCHEMA_INTERNAL_H
-#define PARQUET_SCHEMA_INTERNAL_H
+#pragma once
 
-#include <cstdint>
 #include <memory>
-#include <string>
-#include <unordered_set>
 #include <vector>
 
 #include "parquet/platform.h"
@@ -46,25 +41,8 @@ PARQUET_EXPORT
 std::shared_ptr<SchemaDescriptor> FromParquet(
     const std::vector<format::SchemaElement>& schema);
 
-class PARQUET_EXPORT FlatSchemaConverter {
- public:
-  FlatSchemaConverter(const format::SchemaElement* elements, int length)
-      : elements_(elements), length_(length), pos_(0), current_id_(0) {}
-
-  std::unique_ptr<Node> Convert();
-
- private:
-  const format::SchemaElement* elements_;
-  int length_;
-  int pos_;
-  int current_id_;
-
-  int next_id() { return current_id_++; }
-
-  const format::SchemaElement& Next();
-
-  std::unique_ptr<Node> NextNode();
-};
+PARQUET_EXPORT
+std::unique_ptr<Node> Unflatten(const format::SchemaElement* elements, int length);
 
 // ----------------------------------------------------------------------
 // Conversion to Parquet Thrift metadata
@@ -72,19 +50,5 @@ class PARQUET_EXPORT FlatSchemaConverter {
 PARQUET_EXPORT
 void ToParquet(const GroupNode* schema, std::vector<format::SchemaElement>* out);
 
-// Converts nested parquet schema back to a flat vector of Thrift structs
-class PARQUET_EXPORT SchemaFlattener {
- public:
-  SchemaFlattener(const GroupNode* schema, std::vector<format::SchemaElement>* out);
-
-  void Flatten();
-
- private:
-  const GroupNode* root_;
-  std::vector<format::SchemaElement>* elements_;
-};
-
 }  // namespace schema
 }  // namespace parquet
-
-#endif  // PARQUET_SCHEMA_INTERNAL_H

--- a/cpp/src/parquet/schema_test.cc
+++ b/cpp/src/parquet/schema_test.cc
@@ -78,7 +78,6 @@ static void CheckNodeRoundtrip(const Node& node) {
       << "Recovered node not equivalent to original node constructed "
       << "with logical type " << node.logical_type()->ToString() << " got "
       << recovered->logical_type()->ToString();
-  ASSERT_EQ(recovered->field_id(), node.field_id());
 }
 
 static void ConfirmPrimitiveNodeRoundtrip(
@@ -831,6 +830,7 @@ TEST(TestSchemaPrinter, Examples) {
                                    /*logical_type=*/nullptr, 0);
 
   std::string result = Print(schema);
+
   std::string expected = R"(repeated group field_id=0 schema {
   required int32 field_id=1 a;
   optional group field_id=2 bag {

--- a/cpp/src/parquet/schema_test.cc
+++ b/cpp/src/parquet/schema_test.cc
@@ -43,24 +43,57 @@ namespace schema {
 
 static inline SchemaElement NewPrimitive(const std::string& name,
                                          FieldRepetitionType::type repetition,
-                                         Type::type type, int id = 0) {
+                                         Type::type type, int field_id = -1) {
   SchemaElement result;
   result.__set_name(name);
   result.__set_repetition_type(repetition);
   result.__set_type(static_cast<format::Type::type>(type));
-
+  if (field_id >= 0) {
+    result.__set_field_id(field_id);
+  }
   return result;
 }
 
 static inline SchemaElement NewGroup(const std::string& name,
                                      FieldRepetitionType::type repetition,
-                                     int num_children, int id = 0) {
+                                     int num_children, int field_id = -1) {
   SchemaElement result;
   result.__set_name(name);
   result.__set_repetition_type(repetition);
   result.__set_num_children(num_children);
 
+  if (field_id >= 0) {
+    result.__set_field_id(field_id);
+  }
+
   return result;
+}
+
+template <typename NodeType>
+static void CheckNodeRoundtrip(const Node& node) {
+  format::SchemaElement serialized;
+  node.ToParquet(&serialized);
+  std::unique_ptr<Node> recovered = NodeType::FromParquet(&serialized);
+  ASSERT_TRUE(node.Equals(recovered.get()))
+      << "Recovered node not equivalent to original node constructed "
+      << "with logical type " << node.logical_type()->ToString() << " got "
+      << recovered->logical_type()->ToString();
+  ASSERT_EQ(recovered->field_id(), node.field_id());
+}
+
+static void ConfirmPrimitiveNodeRoundtrip(
+    const std::shared_ptr<const LogicalType>& logical_type, Type::type physical_type,
+    int physical_length, int field_id = -1) {
+  auto node = PrimitiveNode::Make("something", Repetition::REQUIRED, logical_type,
+                                  physical_type, physical_length, field_id);
+  CheckNodeRoundtrip<PrimitiveNode>(*node);
+}
+
+static void ConfirmGroupNodeRoundtrip(
+    std::string name, const std::shared_ptr<const LogicalType>& logical_type,
+    int field_id = -1) {
+  auto node = GroupNode::Make(name, Repetition::REQUIRED, {}, logical_type, field_id);
+  CheckNodeRoundtrip<GroupNode>(*node);
 }
 
 // ----------------------------------------------------------------------
@@ -85,11 +118,11 @@ class TestPrimitiveNode : public ::testing::Test {
  public:
   void SetUp() {
     name_ = "name";
-    id_ = 5;
+    field_id_ = 5;
   }
 
   void Convert(const format::SchemaElement* element) {
-    node_ = PrimitiveNode::FromParquet(element, id_);
+    node_ = PrimitiveNode::FromParquet(element, field_id_);
     ASSERT_TRUE(node_->is_primitive());
     prim_node_ = static_cast<const PrimitiveNode*>(node_.get());
   }
@@ -98,7 +131,7 @@ class TestPrimitiveNode : public ::testing::Test {
   std::string name_;
   const PrimitiveNode* prim_node_;
 
-  int id_;
+  int field_id_;
   std::unique_ptr<Node> node_;
 };
 
@@ -139,16 +172,17 @@ TEST_F(TestPrimitiveNode, Attrs) {
 }
 
 TEST_F(TestPrimitiveNode, FromParquet) {
-  SchemaElement elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::INT32, 0);
+  SchemaElement elt =
+      NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::INT32, field_id_);
   ASSERT_NO_FATAL_FAILURE(Convert(&elt));
   ASSERT_EQ(name_, prim_node_->name());
-  ASSERT_EQ(id_, prim_node_->id());
+  ASSERT_EQ(field_id_, prim_node_->field_id());
   ASSERT_EQ(Repetition::OPTIONAL, prim_node_->repetition());
   ASSERT_EQ(Type::INT32, prim_node_->physical_type());
   ASSERT_EQ(ConvertedType::NONE, prim_node_->converted_type());
 
   // Test a logical type
-  elt = NewPrimitive(name_, FieldRepetitionType::REQUIRED, Type::BYTE_ARRAY, 0);
+  elt = NewPrimitive(name_, FieldRepetitionType::REQUIRED, Type::BYTE_ARRAY, field_id_);
   elt.__set_converted_type(format::ConvertedType::UTF8);
 
   ASSERT_NO_FATAL_FAILURE(Convert(&elt));
@@ -157,18 +191,20 @@ TEST_F(TestPrimitiveNode, FromParquet) {
   ASSERT_EQ(ConvertedType::UTF8, prim_node_->converted_type());
 
   // FIXED_LEN_BYTE_ARRAY
-  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY, 0);
+  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
+                     field_id_);
   elt.__set_type_length(16);
 
   ASSERT_NO_FATAL_FAILURE(Convert(&elt));
   ASSERT_EQ(name_, prim_node_->name());
-  ASSERT_EQ(id_, prim_node_->id());
+  ASSERT_EQ(field_id_, prim_node_->field_id());
   ASSERT_EQ(Repetition::OPTIONAL, prim_node_->repetition());
   ASSERT_EQ(Type::FIXED_LEN_BYTE_ARRAY, prim_node_->physical_type());
   ASSERT_EQ(16, prim_node_->type_length());
 
   // format::ConvertedType::Decimal
-  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY, 0);
+  elt = NewPrimitive(name_, FieldRepetitionType::OPTIONAL, Type::FIXED_LEN_BYTE_ARRAY,
+                     field_id_);
   elt.__set_converted_type(format::ConvertedType::DECIMAL);
   elt.__set_type_length(6);
   elt.__set_scale(2);
@@ -383,8 +419,7 @@ class TestSchemaConverter : public ::testing::Test {
   void setUp() { name_ = "parquet_schema"; }
 
   void Convert(const parquet::format::SchemaElement* elements, int length) {
-    FlatSchemaConverter converter(elements, length);
-    node_ = converter.Convert();
+    node_ = Unflatten(elements, length);
     ASSERT_TRUE(node_->is_group());
     group_ = static_cast<const GroupNode*>(node_.get());
   }
@@ -415,7 +450,8 @@ bool check_for_parent_consistency(const GroupNode* node) {
 TEST_F(TestSchemaConverter, NestedExample) {
   SchemaElement elt;
   std::vector<SchemaElement> elements;
-  elements.push_back(NewGroup(name_, FieldRepetitionType::REPEATED, 2, 0));
+  elements.push_back(NewGroup(name_, FieldRepetitionType::REPEATED, /*num_children=*/2,
+                              /*field_id=*/0));
 
   // A primitive one
   elements.push_back(NewPrimitive("a", FieldRepetitionType::REQUIRED, Type::INT32, 1));
@@ -433,15 +469,18 @@ TEST_F(TestSchemaConverter, NestedExample) {
 
   // Construct the expected schema
   NodeVector fields;
-  fields.push_back(Int32("a", Repetition::REQUIRED));
+  fields.push_back(Int32("a", Repetition::REQUIRED, 1));
 
   // 3-level list encoding
-  NodePtr item = Int64("item");
-  NodePtr list(GroupNode::Make("b", Repetition::REPEATED, {item}, ConvertedType::LIST));
-  NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
+  NodePtr item = Int64("item", Repetition::OPTIONAL, 4);
+  NodePtr list(
+      GroupNode::Make("b", Repetition::REPEATED, {item}, ConvertedType::LIST, 3));
+  NodePtr bag(
+      GroupNode::Make("bag", Repetition::OPTIONAL, {list}, /*logical_type=*/nullptr, 2));
   fields.push_back(bag);
 
-  NodePtr schema = GroupNode::Make(name_, Repetition::REPEATED, fields);
+  NodePtr schema = GroupNode::Make(name_, Repetition::REPEATED, fields,
+                                   /*logical_type=*/nullptr, 0);
 
   ASSERT_TRUE(schema->Equals(group_));
 
@@ -556,15 +595,18 @@ TEST_F(TestSchemaFlatten, NestedExample) {
 
   // Construct the schema
   NodeVector fields;
-  fields.push_back(Int32("a", Repetition::REQUIRED));
+  fields.push_back(Int32("a", Repetition::REQUIRED, 1));
 
   // 3-level list encoding
-  NodePtr item = Int64("item");
-  NodePtr list(GroupNode::Make("b", Repetition::REPEATED, {item}, ConvertedType::LIST));
-  NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
+  NodePtr item = Int64("item", Repetition::OPTIONAL, 4);
+  NodePtr list(
+      GroupNode::Make("b", Repetition::REPEATED, {item}, ConvertedType::LIST, 3));
+  NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list},
+                              /*logical_type=*/nullptr, 2));
   fields.push_back(bag);
 
-  NodePtr schema = GroupNode::Make(name_, Repetition::REPEATED, fields);
+  NodePtr schema = GroupNode::Make(name_, Repetition::REPEATED, fields,
+                                   /*logical_type=*/nullptr, 0);
 
   Flatten(static_cast<GroupNode*>(schema.get()));
   ASSERT_EQ(elements_.size(), elements.size());
@@ -767,35 +809,38 @@ static std::string Print(const NodePtr& node) {
 TEST(TestSchemaPrinter, Examples) {
   // Test schema 1
   NodeVector fields;
-  fields.push_back(Int32("a", Repetition::REQUIRED));
+  fields.push_back(Int32("a", Repetition::REQUIRED, 1));
 
   // 3-level list encoding
-  NodePtr item1 = Int64("item1");
-  NodePtr item2 = Boolean("item2", Repetition::REQUIRED);
+  NodePtr item1 = Int64("item1", Repetition::OPTIONAL, 4);
+  NodePtr item2 = Boolean("item2", Repetition::REQUIRED, 5);
   NodePtr list(
-      GroupNode::Make("b", Repetition::REPEATED, {item1, item2}, ConvertedType::LIST));
-  NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
+      GroupNode::Make("b", Repetition::REPEATED, {item1, item2}, ConvertedType::LIST, 3));
+  NodePtr bag(
+      GroupNode::Make("bag", Repetition::OPTIONAL, {list}, /*logical_type=*/nullptr, 2));
   fields.push_back(bag);
 
   fields.push_back(PrimitiveNode::Make("c", Repetition::REQUIRED, Type::INT32,
-                                       ConvertedType::DECIMAL, -1, 3, 2));
+                                       ConvertedType::DECIMAL, -1, 3, 2, 6));
 
   fields.push_back(PrimitiveNode::Make("d", Repetition::REQUIRED,
-                                       DecimalLogicalType::Make(10, 5), Type::INT64, -1));
+                                       DecimalLogicalType::Make(10, 5), Type::INT64,
+                                       /*length=*/-1, 7));
 
-  NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
+  NodePtr schema = GroupNode::Make("schema", Repetition::REPEATED, fields,
+                                   /*logical_type=*/nullptr, 0);
 
   std::string result = Print(schema);
-  std::string expected = R"(message schema {
-  required int32 a;
-  optional group bag {
-    repeated group b (List) {
-      optional int64 item1;
-      required boolean item2;
+  std::string expected = R"(repeated group field_id=0 schema {
+  required int32 field_id=1 a;
+  optional group field_id=2 bag {
+    repeated group field_id=3 b (List) {
+      optional int64 field_id=4 item1;
+      required boolean field_id=5 item2;
     }
   }
-  required int32 c (Decimal(precision=3, scale=2));
-  required int64 d (Decimal(precision=10, scale=5));
+  required int32 field_id=6 c (Decimal(precision=3, scale=2));
+  required int64 field_id=7 d (Decimal(precision=10, scale=5));
 }
 )";
   ASSERT_EQ(expected, result);
@@ -2086,37 +2131,6 @@ TEST(TestLogicalTypeSerialization, SchemaElementNestedCases) {
   ASSERT_TRUE(map_elements[0].__isset.logicalType);
   ASSERT_EQ(map_elements[0].converted_type, ToThrift(ConvertedType::MAP));
   ASSERT_TRUE(map_elements[0].logicalType.__isset.MAP);
-}
-
-static void ConfirmPrimitiveNodeRoundtrip(
-    const std::shared_ptr<const LogicalType>& logical_type, Type::type physical_type,
-    int physical_length) {
-  std::shared_ptr<Node> original = PrimitiveNode::Make(
-      "something", Repetition::REQUIRED, logical_type, physical_type, physical_length);
-  format::SchemaElement intermediary;
-  original->ToParquet(&intermediary);
-  std::unique_ptr<Node> recovered = PrimitiveNode::FromParquet(&intermediary, 1);
-  ASSERT_TRUE(original->Equals(recovered.get()))
-      << "Recovered primitive node unexpectedly not equivalent to original primitive "
-         "node constructed with logical type "
-      << logical_type->ToString();
-  return;
-}
-
-static void ConfirmGroupNodeRoundtrip(
-    std::string name, const std::shared_ptr<const LogicalType>& logical_type) {
-  NodeVector node_vector;
-  std::shared_ptr<Node> original =
-      GroupNode::Make(name, Repetition::REQUIRED, node_vector, logical_type);
-  std::vector<format::SchemaElement> elements;
-  ToParquet(reinterpret_cast<GroupNode*>(original.get()), &elements);
-  std::unique_ptr<Node> recovered =
-      GroupNode::FromParquet(&(elements[0]), 1, node_vector);
-  ASSERT_TRUE(original->Equals(recovered.get()))
-      << "Recovered group node unexpectedly not equivalent to original group node "
-         "constructed with logical type "
-      << logical_type->ToString();
-  return;
 }
 
 TEST(TestLogicalTypeSerialization, Roundtrips) {

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -182,6 +182,7 @@ cdef extern from "parquet/api/schema.h" namespace "parquet" nogil:
         shared_ptr[Node] schema()
         GroupNode* group()
         c_bool Equals(const SchemaDescriptor& other)
+        c_string ToString()
         int num_columns()
 
     cdef c_string FormatStatValue(ParquetType parquet_type, c_string val)
@@ -377,6 +378,9 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
 cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
     cdef cppclass FileReader:
         FileReader(CMemoryPool* pool, unique_ptr[ParquetFileReader] reader)
+
+        CStatus GetSchema(shared_ptr[CSchema]* out)
+
         CStatus ReadColumn(int i, shared_ptr[CChunkedArray]* out)
         CStatus ReadSchemaField(int i, shared_ptr[CChunkedArray]* out)
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -161,7 +161,18 @@ class ParquetFile:
 
     @property
     def schema(self):
+        """
+        Return the Parquet schema, unconverted to Arrow types
+        """
         return self.metadata.schema
+
+    @property
+    def schema_arrow(self):
+        """
+        Return the inferred Arrow schema, converted from the whole Parquet
+        file's schema
+        """
+        return self.reader.schema_arrow
 
     @property
     def num_row_groups(self):

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -71,6 +71,10 @@ def _read_table(*args, **kwargs):
     return pq.read_table(*args, **kwargs)
 
 
+def assert_tables_equal(left, right):
+    assert left.equals(right, check_metadata=False)
+
+
 def _roundtrip_table(table, read_table_kwargs=None,
                      write_table_kwargs=None):
     read_table_kwargs = read_table_kwargs or {}
@@ -92,10 +96,10 @@ def _check_roundtrip(table, expected=None, read_table_kwargs=None,
     # intentionally check twice
     result = _roundtrip_table(table, read_table_kwargs=read_table_kwargs,
                               write_table_kwargs=write_table_kwargs)
-    assert result.equals(expected)
+    assert_tables_equal(result, expected)
     result = _roundtrip_table(result, read_table_kwargs=read_table_kwargs,
                               write_table_kwargs=write_table_kwargs)
-    assert result.equals(expected)
+    assert_tables_equal(result, expected)
 
 
 def _roundtrip_pandas_dataframe(df, write_kwargs):
@@ -218,7 +222,7 @@ def test_memory_map(tempdir):
     with open(filename, 'wb') as f:
         _write_table(table, f, version='2.0')
     table_read = pq.read_pandas(filename, memory_map=True)
-    assert table_read.equals(table)
+    assert_tables_equal(table_read, table)
 
 
 @pytest.mark.pandas
@@ -233,7 +237,7 @@ def test_enable_buffered_stream(tempdir):
     with open(filename, 'wb') as f:
         _write_table(table, f, version='2.0')
     table_read = pq.read_pandas(filename, buffer_size=4096)
-    assert table_read.equals(table)
+    assert_tables_equal(table_read, table)
 
 
 def test_special_chars_filename(tempdir):
@@ -244,7 +248,7 @@ def test_special_chars_filename(tempdir):
     _write_table(table, str(path))
     assert path.exists()
     table_read = _read_table(str(path))
-    assert table_read.equals(table)
+    assert_tables_equal(table_read, table)
 
 
 @pytest.mark.pandas
@@ -1129,7 +1133,7 @@ def test_date_time_types(tempdir):
     for i in range(3):
         assert parquet_schema.column(i).physical_type == 'INT64'
     read_table = _read_table(filename)
-    assert read_table.equals(expected)
+    assert_tables_equal(read_table, expected)
 
     t0_ns = pa.timestamp('ns')
     data0_ns = np.array(data0 * 1000000, dtype='int64')
@@ -1150,7 +1154,7 @@ def test_date_time_types(tempdir):
     for i in range(3):
         assert parquet_schema.column(i).physical_type == 'INT96'
     read_table = _read_table(filename)
-    assert read_table.equals(expected)
+    assert_tables_equal(read_table, expected)
 
     # int96 nanosecond timestamps implied by flavor 'spark'
     filename = tempdir / 'spark_int96_timestamps.parquet'
@@ -1160,7 +1164,7 @@ def test_date_time_types(tempdir):
     for i in range(3):
         assert parquet_schema.column(i).physical_type == 'INT96'
     read_table = _read_table(filename)
-    assert read_table.equals(expected)
+    assert_tables_equal(read_table, expected)
 
 
 def test_timestamp_restore_timezone():
@@ -1301,7 +1305,7 @@ def test_multithreaded_read():
     buf.seek(0)
     table2 = _read_table(buf, use_threads=False)
 
-    assert table1.equals(table2)
+    assert_tables_equal(table1, table2)
 
 
 @pytest.mark.pandas
@@ -1315,7 +1319,7 @@ def test_min_chunksize():
     buf.seek(0)
     result = _read_table(buf)
 
-    assert result.equals(table)
+    assert_tables_equal(result, table)
 
     with pytest.raises(ValueError):
         _write_table(table, buf, chunk_size=0)
@@ -1461,7 +1465,7 @@ def test_parquet_piece_read(tempdir):
     piece1 = pq.ParquetDatasetPiece(path)
 
     result = piece1.read()
-    assert result.equals(table)
+    assert_tables_equal(result, table)
 
 
 @pytest.mark.pandas
@@ -1478,7 +1482,7 @@ def test_parquet_piece_open_and_get_metadata(tempdir):
     meta1 = piece.get_metadata()
     assert isinstance(meta1, pq.FileMetaData)
 
-    assert table == table1
+    assert_tables_equal(table, table1)
 
 
 def test_parquet_piece_basics():
@@ -2097,16 +2101,16 @@ def test_read_multiple_files(tempdir):
     result = read_multiple_files(paths)
     expected = pa.concat_tables(test_data)
 
-    assert result.equals(expected)
+    assert_tables_equal(result, expected)
 
     # Read with provided metadata
     metadata = pq.read_metadata(paths[0])
 
     result2 = read_multiple_files(paths, metadata=metadata)
-    assert result2.equals(expected)
+    assert_tables_equal(result2, expected)
 
     result3 = pa.localfs.read_parquet(dirpath, schema=metadata.schema)
-    assert result3.equals(expected)
+    assert_tables_equal(result3, expected)
 
     # Read column subset
     to_read = [0, 2, 6, result.num_columns - 1]
@@ -2116,7 +2120,7 @@ def test_read_multiple_files(tempdir):
     expected = pa.Table.from_arrays([result.column(i) for i in to_read],
                                     names=col_names,
                                     metadata=result.schema.metadata)
-    assert out.equals(expected)
+    assert_tables_equal(out, expected)
 
     # Read with multiple threads
     pa.localfs.read_parquet(dirpath, use_threads=True)
@@ -2189,7 +2193,7 @@ def test_dataset_memory_map(tempdir):
     _write_table(table, path, version='2.0')
 
     dataset = pq.ParquetDataset(dirpath, memory_map=True)
-    assert dataset.pieces[0].read().equals(table)
+    assert_tables_equal(dataset.pieces[0].read(), table)
 
 
 @pytest.mark.pandas
@@ -2207,7 +2211,7 @@ def test_dataset_enable_buffered_stream(tempdir):
 
     for buffer_size in [128, 1024]:
         dataset = pq.ParquetDataset(dirpath, buffer_size=buffer_size)
-        assert dataset.pieces[0].read().equals(table)
+        assert_tables_equal(dataset.pieces[0].read(), table)
 
 
 @pytest.mark.pandas
@@ -2334,7 +2338,7 @@ def test_multiindex_duplicate_values(tempdir):
 
     _write_table(table, filename)
     result_table = _read_table(filename)
-    assert table.equals(result_table)
+    assert_tables_equal(table, result_table)
 
     result_df = result_table.to_pandas()
     tm.assert_frame_equal(result_df, df)
@@ -2382,7 +2386,7 @@ def test_noncoerced_nanoseconds_written_without_exception(tempdir):
     assert filename.exists()
 
     recovered_table = pq.read_table(filename)
-    assert tb.equals(recovered_table)
+    assert_tables_equal(tb, recovered_table)
 
     # Loss of data thru coercion (without explicit override) still an error
     filename = tempdir / 'not_written.parquet'
@@ -2580,7 +2584,7 @@ def test_byte_array_exactly_2gb():
         values = pa.chunked_array([base, pa.array(case)])
         t = pa.table([values], names=['f0'])
         result = _simple_table_roundtrip(t, use_dictionary=False)
-        assert t.equals(result)
+        assert_tables_equal(t, result)
 
 
 @pytest.mark.pandas
@@ -2603,7 +2607,7 @@ def test_binary_array_overflow_to_chunked():
     # Split up into 2GB chunks
     assert col0_data.num_chunks == 2
 
-    assert tbl.equals(read_tbl)
+    assert_tables_equal(tbl, read_tbl)
 
 
 @pytest.mark.pandas
@@ -2622,7 +2626,7 @@ def test_list_of_binary_large_cell():
     arr = pa.array(data)
     table = pa.Table.from_arrays([arr], ['chunky_cells'])
     read_table = _simple_table_roundtrip(table)
-    assert table.equals(read_table)
+    assert_tables_equal(table, read_table)
 
 
 @pytest.mark.pandas
@@ -2970,7 +2974,7 @@ def test_empty_row_groups(tempdir):
     assert reader.metadata.num_row_groups == num_groups
 
     for i in range(num_groups):
-        assert reader.read_row_group(i).equals(table)
+        assert_tables_equal(reader.read_row_group(i), table)
 
 
 @pytest.mark.pandas
@@ -3099,7 +3103,7 @@ def test_direct_read_dictionary():
 
     # Compute dictionary-encoded subfield
     expected = pa.table([table[0].dictionary_encode()], names=['f0'])
-    assert result.equals(expected)
+    assert_tables_equal(result, expected)
 
 
 @pytest.mark.pandas
@@ -3152,7 +3156,7 @@ def test_direct_read_dictionary_subfield():
     expected_arr = pa.ListArray.from_arrays(offsets, new_values)
     expected = pa.table([expected_arr], names=['f0'])
 
-    assert result.equals(expected)
+    assert_tables_equal(result, expected)
     assert result[0].num_chunks == 1
 
 
@@ -3234,6 +3238,13 @@ def test_categorical_order_survives_roundtrip():
     tm.assert_frame_equal(result, df)
 
 
+def _simple_table_write_read(table):
+    bio = pa.BufferOutputStream()
+    pq.write_table(table, bio)
+    contents = bio.getvalue()
+    return pq.read_table(pa.BufferReader(contents))
+
+
 def test_dictionary_array_automatically_read():
     # ARROW-3246
 
@@ -3252,16 +3263,50 @@ def test_dictionary_array_automatically_read():
                                                      dict_values))
 
     table = pa.table([pa.chunked_array(chunks)], names=['f0'])
+    result = _simple_table_write_read(table)
+
+    assert_tables_equal(result, table)
+
+    # The only key in the metadata was the Arrow schema key
+    assert result.schema.metadata is None
+
+
+def test_field_id_metadata():
+    # ARROW-7080
+    table = pa.table([pa.array([1], type='int32'),
+                      pa.array([[]], type=pa.list_(pa.int32())),
+                      pa.array([b'boo'], type='binary')],
+                     ['f0', 'f1', 'f2'])
 
     bio = pa.BufferOutputStream()
     pq.write_table(table, bio)
     contents = bio.getvalue()
-    result = pq.read_table(pa.BufferReader(contents))
 
-    assert result.equals(table)
+    pf = pq.ParquetFile(pa.BufferReader(contents))
+    schema = pf.schema_arrow
 
-    # The only key in the metadata was the Arrow schema key
-    assert result.schema.metadata is None
+    # Expected Parquet schema for reference
+    #
+    # required group field_id=0 schema {
+    #   optional int32 field_id=1 f0;
+    #   optional group field_id=2 f1 (List) {
+    #     repeated group field_id=3 list {
+    #       optional int32 field_id=4 item;
+    #     }
+    #   }
+    #   optional binary field_id=5 f2;
+    # }
+
+    field_name = b'PARQUET::field_id'
+    assert schema[0].metadata[field_name] == b'1'
+
+    list_field = schema[1]
+    assert list_field.metadata[field_name] == b'2'
+
+    list_item_field = list_field.type.value_field
+    assert list_item_field.metadata[field_name] == b'4'
+
+    assert schema[2].metadata[field_name] == b'5'
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -72,6 +72,9 @@ def _read_table(*args, **kwargs):
 
 
 def assert_tables_equal(left, right):
+    # This is a helper method particular to this testing module because the
+    # round trip to Parquet adds extra Field-level metadata for the Parquet
+    # field_ids
     assert left.equals(right, check_metadata=False)
 
 
@@ -3297,7 +3300,7 @@ def test_field_id_metadata():
     #   optional binary field_id=5 f2;
     # }
 
-    field_name = b'PARQUET::field_id'
+    field_name = b'PARQUET:field_id'
     assert schema[0].metadata[field_name] == b'1'
 
     list_field = schema[1]

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -248,6 +248,10 @@ cdef class ListType(DataType):
         return list_, (self.value_type,)
 
     @property
+    def value_field(self):
+        return pyarrow_wrap_field(self.list_type.value_field())
+
+    @property
     def value_type(self):
         """
         The data type of list values.

--- a/r/tests/testthat/helper-parquet.R
+++ b/r/tests/testthat/helper-parquet.R
@@ -20,5 +20,5 @@ expect_parquet_roundtrip <- function(tab, ...) {
   on.exit(unlink(tf))
 
   write_parquet(tab, tf, ...)
-  expect_equal(read_parquet(tf, as_data_frame = FALSE), tab)
+  expect_equivalent(read_parquet(tf, as_data_frame = FALSE), tab)
 }

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -34,7 +34,7 @@ test_that("simple int column roundtrip", {
 
   write_parquet(df, pq_tmp_file)
   df_read <- read_parquet(pq_tmp_file)
-  expect_identical(df, df_read)
+  expect_equivalent(df, df_read)
 })
 
 test_that("read_parquet() supports col_select", {
@@ -118,7 +118,7 @@ test_that("Factors are preserved when writing/reading from Parquet", {
 
   write_parquet(df, pq_tmp_file)
   df_read <- read_parquet(pq_tmp_file)
-  expect_identical(df, df_read)
+  expect_equivalent(df, df_read)
 })
 
 test_that("Lists are preserved when writing/reading from Parquet", {
@@ -151,5 +151,5 @@ test_that("write_parquet() returns its input", {
   tf <- tempfile()
   on.exit(unlink(tf))
   df_out <- write_parquet(df, tf)
-  expect_identical(df, df_out)
+  expect_equivalent(df, df_out)
 })

--- a/ruby/red-parquet/test/test-arrow-table.rb
+++ b/ruby/red-parquet/test/test-arrow-table.rb
@@ -41,12 +41,16 @@ class TestArrowTableReader < Test::Unit::TestCase
   def test_save_load_path
     tempfile = Tempfile.open(["red-parquet", ".parquet"])
     @table.save(tempfile.path)
-    assert_equal(@table, Arrow::Table.load(tempfile.path))
+    assert do
+      @table.equal_metadata(Arrow::Table.load(tempfile.path), false)
+    end
   end
 
   def test_save_load_buffer
     buffer = Arrow::ResizableBuffer.new(1024)
     @table.save(buffer, format: :parquet)
-    assert_equal(@table, Arrow::Table.load(buffer, format: :parquet))
+    assert do
+      @table.equal_metadata(Arrow::Table.load(buffer, format: :parquet), false)
+    end
   end
 end


### PR DESCRIPTION
The `field_id` is used for schema evolution and other things. It is surfaced in Python in the `Field.metadata` as `b'PARQUET:field_id'`

* `ChunkedArray::Equals` would fail if a child field had unequal metadata, now it does not check the metadata
* Improved diffing output in AssertTablesEqual in testing/gtest_util.h (may need some more tests around this)
* Added a generic binary ChunkedArray iterator (see `internal::MultipleChunkIterator`) and helpful applicator `internal::ApplyToChunkOverlaps`. I retrofitted `ChunkedArray::Equals` to use this (needed it to improve the diffing output in AssertTablesEqual)
* Add `KeyValueMetadata::Merge` method
* Add `Field::WithMergedMetadata` method that calls `KeyValueMetadata::Merge`
* Print metadata in `Field::ToString`
* Add `parquet.ParquetFile.schema_arrow` property to return the effective Arrow schema
* Print field_ids in `parquet::SchemaPrinter`

This also adds a flag `print_metadata` to `Field::ToString` and `Schema::ToString` with default `false` whether to print out the key value metadata, per ARROW-7063. I figure it's OK to merge this change and then decide whether we want to keep it like that before releasing the software