### PR TITLE
ARROW-7801: [R][CI] Add lint and doc GitHub Action workflows

### DIFF
--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -31,15 +31,12 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up git remote for pushing to
         run: |
-          OWNER=$(jq --raw-output .pull_request.head.user.login ${GITHUB_EVENT_PATH})
-          echo "::set-env name=OWNER::${OWNER}"
-          REPO=$(jq --raw-output .pull_request.head.repo.name ${GITHUB_EVENT_PATH})
-          if [ "$OWNER" != "apache" ]; then
+          if [ "${{ github.repository }}" != "apache/arrow" ]; then
             git config user.name "$(git log -1 --pretty=format:%an)"
             git config user.email "$(git log -1 --pretty=format:%ae)"
-            git remote add deploy https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPO}.git
+            git remote add deploy https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
             git fetch deploy
-            git checkout --track deploy/${{ github.head_ref }}
+            git checkout --track deploy/${{ github.ref }}
           fi
       - uses: r-lib/actions/setup-r@v1
       - name: Install dependencies
@@ -50,7 +47,7 @@ jobs:
           Rscript -e 'roxygen2::roxygenize()'
       - name: Commit results
         run: |
-          if [ "$OWNER" != "apache" ]; then
+          if [ "${{ github.repository }}" != "apache/arrow" ]; then
             git commit -a -m 'Update docs' || echo "No changes to commit"
-            git push deploy ${{ github.head_ref }} || echo "No changes to commit"
+            git push deploy ${{ github.ef }} || echo "No changes to commit"
           fi

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -22,8 +22,8 @@ on:
     paths:
       - '.github/workflows/r_docs.yml'
       - 'r/R/*.R'
-    # branches:
-    #   - '!master'
+    branches-ignore:
+      - master
 
 jobs:
   roxygen:

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -38,6 +38,7 @@ jobs:
           Rscript -e 'roxygen2::roxygenize()'
       - name: Commit results
         run: |
-          git add .
-          git commit -m 'Update docs' || echo "No changes to commit"
-          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to commit"
+          OWNER=$(jq --raw-output .pull_request.head.user.login ${GITHUB_EVENT_PATH})
+          REPO=$(jq --raw-output .pull_request.head.repo.name ${GITHUB_EVENT_PATH})
+          git commit -a -m 'Update docs' || echo "No changes to commit"
+          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${OWNER}/${REPO}.git HEAD:${{ github.ref }} || echo "No changes to commit"

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -18,7 +18,7 @@
 name: R documentation
 
 on:
-  pull_request:
+  push:
     paths:
       - '.github/workflows/r_docs.yml'
       - 'r/R/*.R'
@@ -31,14 +31,16 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up git remote for pushing to
         run: |
-          git config user.name "$(git log -1 --pretty=format:%an)"
-          git config user.email "$(git log -1 --pretty=format:%ae)"
           OWNER=$(jq --raw-output .pull_request.head.user.login ${GITHUB_EVENT_PATH})
+          echo "::set-env name=OWNER::${OWNER}"
           REPO=$(jq --raw-output .pull_request.head.repo.name ${GITHUB_EVENT_PATH})
-          git remote add deploy \
-            https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPO}.git
-          git fetch deploy
-          git checkout --track deploy/${{ github.head_ref }}
+          if [ "$OWNER" != "apache" ]; then
+            git config user.name "$(git log -1 --pretty=format:%an)"
+            git config user.email "$(git log -1 --pretty=format:%ae)"
+            git remote add deploy https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPO}.git
+            git fetch deploy
+            git checkout --track deploy/${{ github.head_ref }}
+          fi
       - uses: r-lib/actions/setup-r@v1
       - name: Install dependencies
         run: Rscript -e 'source("ci/etc/rprofile"); install.packages(c("remotes", "roxygen2")); remotes::install_deps("r")'
@@ -48,5 +50,7 @@ jobs:
           Rscript -e 'roxygen2::roxygenize()'
       - name: Commit results
         run: |
-          git commit -a -m 'Update docs' || echo "No changes to commit"
-          git push deploy ${{ github.head_ref }} || echo "No changes to commit"
+          if [ "$OWNER" != "apache" ]; then
+            git commit -a -m 'Update docs' || echo "No changes to commit"
+            git push deploy ${{ github.head_ref }} || echo "No changes to commit"
+          fi

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -42,5 +42,9 @@ jobs:
           git config user.email "$(git log -1 --pretty=format:%ae)"
           OWNER=$(jq --raw-output .pull_request.head.user.login ${GITHUB_EVENT_PATH})
           REPO=$(jq --raw-output .pull_request.head.repo.name ${GITHUB_EVENT_PATH})
+          git remote add deploy \
+            https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPO}.git
+          git fetch deploy
+          git checkout --track deploy/${{ github.ref }}
           git commit -a -m 'Update docs' || echo "No changes to commit"
-          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${OWNER}/${REPO}.git HEAD:${{ github.ref }} || echo "No changes to commit"
+          git push deploy ${{ github.ref }} || echo "No changes to commit"

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -29,15 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Set up git remote for pushing to
-        run: |
-          if [ "${{ github.repository }}" != "apache/arrow" ]; then
-            git config user.name "$(git log -1 --pretty=format:%an)"
-            git config user.email "$(git log -1 --pretty=format:%ae)"
-            git remote add deploy https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
-            git fetch deploy
-            git checkout --track deploy/${{ github.ref }}
-          fi
       - uses: r-lib/actions/setup-r@v1
       - name: Install dependencies
         run: Rscript -e 'source("ci/etc/rprofile"); install.packages(c("remotes", "roxygen2")); remotes::install_deps("r")'
@@ -49,5 +40,5 @@ jobs:
         run: |
           if [ "${{ github.repository }}" != "apache/arrow" ]; then
             git commit -a -m 'Update docs' || echo "No changes to commit"
-            git push deploy ${{ github.ef }} || echo "No changes to commit"
+            git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to commit"
           fi

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -38,6 +38,8 @@ jobs:
           Rscript -e 'roxygen2::roxygenize()'
       - name: Commit results
         run: |
+          git config user.name "$(git log -1 --pretty=format:%an)"
+          git config user.email "$(git log -1 --pretty=format:%ae)"
           OWNER=$(jq --raw-output .pull_request.head.user.login ${GITHUB_EVENT_PATH})
           REPO=$(jq --raw-output .pull_request.head.repo.name ${GITHUB_EVENT_PATH})
           git commit -a -m 'Update docs' || echo "No changes to commit"

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: R documentation
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/r_docs.yml'
+      - 'r/R/*.R'
+
+jobs:
+  roxygen:
+    name: Build and Push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: r-lib/actions/setup-r@v1
+      - name: Install dependencies
+        run: Rscript -e 'source("ci/etc/rprofile"); install.packages(c("remotes", "roxygen2")); remotes::install_deps("r")'
+      - name: Render docs
+        run: |
+          cd r
+          Rscript -e 'roxygen2::roxygenize()'
+      - name: Commit results
+        run: |
+          git add .
+          git commit -m 'Update docs' || echo "No changes to commit"
+          git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to commit"

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -22,8 +22,8 @@ on:
     paths:
       - '.github/workflows/r_docs.yml'
       - 'r/R/*.R'
-    branches:
-      - '!master'
+    # branches:
+    #   - '!master'
 
 jobs:
   roxygen:

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -22,25 +22,24 @@ on:
     paths:
       - '.github/workflows/r_docs.yml'
       - 'r/R/*.R'
+    branches:
+      - '!master'
 
 jobs:
   roxygen:
     name: Build and Push
     runs-on: ubuntu-latest
+    if: github.repository != 'apache/arrow'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v1
       - name: Install dependencies
         run: Rscript -e 'source("ci/etc/rprofile"); install.packages(c("remotes", "roxygen2")); remotes::install_deps("r")'
       - name: Render docs
-        run: |
-          cd r
-          Rscript -e 'roxygen2::roxygenize()'
+        run: Rscript -e 'roxygen2::roxygenize("r")'
       - name: Commit results
         run: |
-          if [ "${{ github.repository }}" != "apache/arrow" ]; then
-            git config user.name "$(git log -1 --pretty=format:%an)"
-            git config user.email "$(git log -1 --pretty=format:%ae)"
-            git commit -a -m 'Update docs' || echo "No changes to commit"
-            git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to commit"
-          fi
+          git config user.name "$(git log -1 --pretty=format:%an)"
+          git config user.email "$(git log -1 --pretty=format:%ae)"
+          git commit -a -m 'Update docs [automated commit]' || echo "No changes to commit"
+          git push origin ${{ github.ref }} || echo "No changes to commit"

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -29,6 +29,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Set up git remote for pushing to
+        run: |
+          git config user.name "$(git log -1 --pretty=format:%an)"
+          git config user.email "$(git log -1 --pretty=format:%ae)"
+          OWNER=$(jq --raw-output .pull_request.head.user.login ${GITHUB_EVENT_PATH})
+          REPO=$(jq --raw-output .pull_request.head.repo.name ${GITHUB_EVENT_PATH})
+          git remote add deploy \
+            https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPO}.git
+          git fetch deploy
+          git checkout --track deploy/${{ github.head_ref }}
       - uses: r-lib/actions/setup-r@v1
       - name: Install dependencies
         run: Rscript -e 'source("ci/etc/rprofile"); install.packages(c("remotes", "roxygen2")); remotes::install_deps("r")'
@@ -38,13 +48,5 @@ jobs:
           Rscript -e 'roxygen2::roxygenize()'
       - name: Commit results
         run: |
-          git config user.name "$(git log -1 --pretty=format:%an)"
-          git config user.email "$(git log -1 --pretty=format:%ae)"
-          OWNER=$(jq --raw-output .pull_request.head.user.login ${GITHUB_EVENT_PATH})
-          REPO=$(jq --raw-output .pull_request.head.repo.name ${GITHUB_EVENT_PATH})
-          git remote add deploy \
-            https://x-access-token:${GITHUB_TOKEN}@github.com/${OWNER}/${REPO}.git
-          git fetch deploy
-          git checkout --track deploy/${{ github.ref }}
           git commit -a -m 'Update docs' || echo "No changes to commit"
-          git push deploy ${{ github.ref }} || echo "No changes to commit"
+          git push deploy ${{ github.head_ref }} || echo "No changes to commit"

--- a/.github/workflows/r_docs.yml
+++ b/.github/workflows/r_docs.yml
@@ -39,6 +39,8 @@ jobs:
       - name: Commit results
         run: |
           if [ "${{ github.repository }}" != "apache/arrow" ]; then
+            git config user.name "$(git log -1 --pretty=format:%an)"
+            git config user.email "$(git log -1 --pretty=format:%ae)"
             git commit -a -m 'Update docs' || echo "No changes to commit"
             git push https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:${{ github.ref }} || echo "No changes to commit"
           fi

--- a/r/R/message.R
+++ b/r/R/message.R
@@ -17,7 +17,7 @@
 
 #' @include arrow-package.R
 
-#' @title class arrow::Message
+#' @title Message
 #'
 #' @usage NULL
 #' @format NULL
@@ -25,7 +25,13 @@
 #'
 #' @section Methods:
 #'
-#' TODO
+#' * `$Equals(other)`: Test for equality
+#' * `$body_length()`:
+#' * `$Verify()`:
+#' @section Active bindings:
+#' * `$type`:
+#' * `$metadata`:
+#' * `$body`:
 #'
 #' @rdname Message
 #' @name Message
@@ -74,7 +80,7 @@ MessageReader$create <- function(stream) {
 #' Read a Message from a stream
 #'
 #' @param stream an InputStream
-#'
+#' @return A [Message]
 #' @export
 read_message <- function(stream) {
   UseMethod("read_message")

--- a/r/man/Message.Rd
+++ b/r/man/Message.Rd
@@ -3,13 +3,25 @@
 \docType{class}
 \name{Message}
 \alias{Message}
-\title{class arrow::Message}
+\title{Message}
 \description{
-class arrow::Message
+Message
 }
 \section{Methods}{
 
+\itemize{
+\item \verb{$Equals(other)}: Test for equality
+\item \verb{$body_length()}:
+\item \verb{$Verify()}:
+}
+}
 
-TODO
+\section{Active bindings}{
+
+\itemize{
+\item \verb{$type}:
+\item \verb{$metadata}:
+\item \verb{$body}:
+}
 }
 

--- a/r/man/read_message.Rd
+++ b/r/man/read_message.Rd
@@ -9,6 +9,9 @@ read_message(stream)
 \arguments{
 \item{stream}{an InputStream}
 }
+\value{
+A \link{Message}
+}
 \description{
 Read a Message from a stream
 }


### PR DESCRIPTION
I'm tired of forgetting to update the rendered docs (in `r/man/`), so this workflow does it for us. It's designed to run only on your fork, not on apache/arrow. It can't just work on pull requests, IIUC, because the GITHUB_TOKEN only had read permissions on a PR.

This PR includes a change to the doclets in the .R source that triggers a rendering of the .Rd man pages. https://github.com/nealrichardson/arrow/runs/442280907?check_suite_focus=true is the workflow run that updated and pushed the changes. The subsequent push doesn't trigger the job to run again because of the path filtering.

In a different PR, I've removed `README.Rmd`, so updating that is no longer an issue. For linting, that should be handled in the main lint job. I'll look to do it there and if that's too much trouble, I'll probably add a workflow to `lint.sh --fix` the `r/src`.