### PR TITLE
ARROW-7819: [C++][Gandiva] Add DumpIR to Filter/Projector object

### DIFF
--- a/cpp/src/gandiva/arrow.h
+++ b/cpp/src/gandiva/arrow.h
@@ -25,7 +25,6 @@
 #include <arrow/builder.h>
 #include <arrow/pretty_print.h>
 #include <arrow/record_batch.h>
-#include <arrow/result.h>
 #include <arrow/status.h>
 #include <arrow/type.h>
 

--- a/cpp/src/gandiva/arrow.h
+++ b/cpp/src/gandiva/arrow.h
@@ -25,6 +25,7 @@
 #include <arrow/builder.h>
 #include <arrow/pretty_print.h>
 #include <arrow/record_batch.h>
+#include <arrow/result.h>
 #include <arrow/status.h>
 #include <arrow/type.h>
 
@@ -50,6 +51,9 @@ using ArrayDataVector = std::vector<ArrayDataPtr>;
 
 using Status = arrow::Status;
 using StatusCode = arrow::StatusCode;
+
+template <typename T>
+using Result = arrow::Result<T>;
 
 static inline bool is_decimal_128(DataTypePtr type) {
   if (type->id() == arrow::Type::DECIMAL) {

--- a/cpp/src/gandiva/configuration.h
+++ b/cpp/src/gandiva/configuration.h
@@ -38,6 +38,12 @@ class GANDIVA_EXPORT Configuration {
   std::size_t Hash() const;
   bool operator==(const Configuration& other) const;
   bool operator!=(const Configuration& other) const;
+
+  bool optimize() const { return optimize_; }
+  void set_optimize(bool optimize) { optimize_ = optimize; }
+
+ private:
+  bool optimize_ = true;
 };
 
 /// \brief configuration builder for gandiva

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -25,7 +25,6 @@
 
 #include "arrow/util/macros.h"
 
-#include "gandiva/arrow.h"
 #include "gandiva/configuration.h"
 #include "gandiva/llvm_includes.h"
 #include "gandiva/llvm_types.h"

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -23,9 +23,9 @@
 #include <string>
 #include <vector>
 
-#include "arrow/status.h"
 #include "arrow/util/macros.h"
 
+#include "gandiva/arrow.h"
 #include "gandiva/configuration.h"
 #include "gandiva/llvm_includes.h"
 #include "gandiva/llvm_types.h"
@@ -34,21 +34,19 @@
 
 namespace gandiva {
 
-class FunctionIRBuilder;
-
 /// \brief LLVM Execution engine wrapper.
 class GANDIVA_EXPORT Engine {
  public:
   llvm::LLVMContext* context() { return context_.get(); }
   llvm::IRBuilder<>* ir_builder() { return ir_builder_.get(); }
-  LLVMTypes* types() { return types_.get(); }
+  LLVMTypes* types() { return &types_; }
   llvm::Module* module() { return module_; }
 
   /// Factory method to create and initialize the engine object.
   ///
   /// \param[in] config the engine configuration
   /// \param[out] engine the created engine
-  static Status Make(std::shared_ptr<Configuration> config,
+  static Status Make(const std::shared_ptr<Configuration>& config,
                      std::unique_ptr<Engine>* engine);
 
   /// Add the function to the list of IR functions that need to be compiled.
@@ -59,7 +57,7 @@ class GANDIVA_EXPORT Engine {
   }
 
   /// Optimise and compile the module.
-  Status FinalizeModule(bool optimise_ir, bool dump_ir, std::string* final_ir = NULLPTR);
+  Status FinalizeModule();
 
   /// Get the compiled function corresponding to the irfunction.
   void* CompiledFunction(llvm::Function* irFunction);
@@ -68,16 +66,20 @@ class GANDIVA_EXPORT Engine {
   void AddGlobalMappingForFunc(const std::string& name, llvm::Type* ret_type,
                                const std::vector<llvm::Type*>& args, void* func);
 
+  /// Return the generated IR for the module.
+  std::string DumpIR();
+
  private:
-  /// private constructor to ensure engine is created
-  /// only through the factory.
-  Engine() : module_finalized_(false) {}
+  Engine(const std::shared_ptr<Configuration>& conf,
+         std::unique_ptr<llvm::LLVMContext> ctx,
+         std::unique_ptr<llvm::ExecutionEngine> engine, llvm::Module* module);
 
-  /// do one time inits.
+  // Post construction init. This _must_ be called after the constructor.
+  Status Init();
+
   static void InitOnce();
-  static bool init_once_done_;
 
-  llvm::ExecutionEngine& execution_engine() { return *execution_engine_.get(); }
+  llvm::ExecutionEngine& execution_engine() { return *execution_engine_; }
 
   /// load pre-compiled IR modules from precompiled_bitcode.cc and merge them into
   /// the main module.
@@ -89,23 +91,16 @@ class GANDIVA_EXPORT Engine {
   // Remove unused functions to reduce compile time.
   Status RemoveUnusedFunctions();
 
-  /// dump the IR code to stdout with the prefix string.
-  void DumpIR(std::string prefix);
-
   std::unique_ptr<llvm::LLVMContext> context_;
   std::unique_ptr<llvm::ExecutionEngine> execution_engine_;
-  std::unique_ptr<LLVMTypes> types_;
   std::unique_ptr<llvm::IRBuilder<>> ir_builder_;
-  llvm::Module* module_;  // This is owned by the execution_engine_, so doesn't need to be
-                          // explicitly deleted.
+  llvm::Module* module_;
+  LLVMTypes types_;
 
   std::vector<std::string> functions_to_compile_;
 
-  bool module_finalized_;
-  std::string llvm_error_;
-
-  static std::set<std::string> loaded_libs_;
-  static std::mutex mtx_;
+  bool optimize_ = true;
+  bool module_finalized_ = false;
 };
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/engine_llvm_test.cc
+++ b/cpp/src/gandiva/engine_llvm_test.cc
@@ -24,7 +24,7 @@
 
 namespace gandiva {
 
-typedef int64_t (*add_vector_func_t)(int64_t*, int);
+typedef int64_t (*add_vector_func_t)(int64_t* data, int n);
 
 class TestEngine : public ::testing::Test {
  protected:

--- a/cpp/src/gandiva/engine_llvm_test.cc
+++ b/cpp/src/gandiva/engine_llvm_test.cc
@@ -18,113 +18,111 @@
 #include "gandiva/engine.h"
 
 #include <gtest/gtest.h>
+#include <functional>
 #include "gandiva/llvm_types.h"
 #include "gandiva/tests/test_util.h"
 
 namespace gandiva {
 
-typedef int64_t (*add_vector_func_t)(int64_t* elements, int nelements);
+typedef int64_t (*add_vector_func_t)(int64_t*, int);
 
 class TestEngine : public ::testing::Test {
  protected:
-  llvm::Function* BuildVecAdd(Engine* engine, LLVMTypes* types);
+  llvm::Function* BuildVecAdd(Engine* engine) {
+    auto types = engine->types();
+    llvm::IRBuilder<>* builder = engine->ir_builder();
+    llvm::LLVMContext* context = engine->context();
+
+    // Create fn prototype :
+    //   int64_t add_longs(int64_t *elements, int32_t nelements)
+    std::vector<llvm::Type*> arguments;
+    arguments.push_back(types->i64_ptr_type());
+    arguments.push_back(types->i32_type());
+    llvm::FunctionType* prototype =
+        llvm::FunctionType::get(types->i64_type(), arguments, false /*isVarArg*/);
+
+    // Create fn
+    std::string func_name = "add_longs";
+    engine->AddFunctionToCompile(func_name);
+    llvm::Function* fn = llvm::Function::Create(
+        prototype, llvm::GlobalValue::ExternalLinkage, func_name, engine->module());
+    assert(fn != nullptr);
+
+    // Name the arguments
+    llvm::Function::arg_iterator args = fn->arg_begin();
+    llvm::Value* arg_elements = &*args;
+    arg_elements->setName("elements");
+    ++args;
+    llvm::Value* arg_nelements = &*args;
+    arg_nelements->setName("nelements");
+    ++args;
+
+    llvm::BasicBlock* loop_entry = llvm::BasicBlock::Create(*context, "entry", fn);
+    llvm::BasicBlock* loop_body = llvm::BasicBlock::Create(*context, "loop", fn);
+    llvm::BasicBlock* loop_exit = llvm::BasicBlock::Create(*context, "exit", fn);
+
+    // Loop entry
+    builder->SetInsertPoint(loop_entry);
+    builder->CreateBr(loop_body);
+
+    // Loop body
+    builder->SetInsertPoint(loop_body);
+
+    llvm::PHINode* loop_var = builder->CreatePHI(types->i32_type(), 2, "loop_var");
+    llvm::PHINode* sum = builder->CreatePHI(types->i64_type(), 2, "sum");
+
+    loop_var->addIncoming(types->i32_constant(0), loop_entry);
+    sum->addIncoming(types->i64_constant(0), loop_entry);
+
+    // setup loop PHI
+    llvm::Value* loop_update =
+        builder->CreateAdd(loop_var, types->i32_constant(1), "loop_var+1");
+    loop_var->addIncoming(loop_update, loop_body);
+
+    // get the current value
+    llvm::Value* offset = builder->CreateGEP(arg_elements, loop_var, "offset");
+    llvm::Value* current_value = builder->CreateLoad(offset, "value");
+
+    // setup sum PHI
+    llvm::Value* sum_update = builder->CreateAdd(sum, current_value, "sum+ith");
+    sum->addIncoming(sum_update, loop_body);
+
+    // check loop_var
+    llvm::Value* loop_var_check =
+        builder->CreateICmpSLT(loop_update, arg_nelements, "loop_var < nrec");
+    builder->CreateCondBr(loop_var_check, loop_body, loop_exit);
+
+    // Loop exit
+    builder->SetInsertPoint(loop_exit);
+    builder->CreateRet(sum_update);
+    return fn;
+  }
+
+  void BuildEngine() { ASSERT_OK(Engine::Make(TestConfiguration(), &engine)); }
+
+  std::unique_ptr<Engine> engine;
+  std::shared_ptr<Configuration> configuration = TestConfiguration();
 };
 
-llvm::Function* TestEngine::BuildVecAdd(Engine* engine, LLVMTypes* types) {
-  llvm::IRBuilder<>* builder = engine->ir_builder();
-  llvm::LLVMContext* context = engine->context();
-
-  // Create fn prototype :
-  //   int64_t add_longs(int64_t *elements, int32_t nelements)
-  std::vector<llvm::Type*> arguments;
-  arguments.push_back(types->i64_ptr_type());
-  arguments.push_back(types->i32_type());
-  llvm::FunctionType* prototype =
-      llvm::FunctionType::get(types->i64_type(), arguments, false /*isVarArg*/);
-
-  // Create fn
-  std::string func_name = "add_longs";
-  engine->AddFunctionToCompile(func_name);
-  llvm::Function* fn = llvm::Function::Create(
-      prototype, llvm::GlobalValue::ExternalLinkage, func_name, engine->module());
-  assert(fn != NULL);
-
-  // Name the arguments
-  llvm::Function::arg_iterator args = fn->arg_begin();
-  llvm::Value* arg_elements = &*args;
-  arg_elements->setName("elements");
-  ++args;
-  llvm::Value* arg_nelements = &*args;
-  arg_nelements->setName("nelements");
-  ++args;
-
-  llvm::BasicBlock* loop_entry = llvm::BasicBlock::Create(*context, "entry", fn);
-  llvm::BasicBlock* loop_body = llvm::BasicBlock::Create(*context, "loop", fn);
-  llvm::BasicBlock* loop_exit = llvm::BasicBlock::Create(*context, "exit", fn);
-
-  // Loop entry
-  builder->SetInsertPoint(loop_entry);
-  builder->CreateBr(loop_body);
-
-  // Loop body
-  builder->SetInsertPoint(loop_body);
-
-  llvm::PHINode* loop_var = builder->CreatePHI(types->i32_type(), 2, "loop_var");
-  llvm::PHINode* sum = builder->CreatePHI(types->i64_type(), 2, "sum");
-
-  loop_var->addIncoming(types->i32_constant(0), loop_entry);
-  sum->addIncoming(types->i64_constant(0), loop_entry);
-
-  // setup loop PHI
-  llvm::Value* loop_update =
-      builder->CreateAdd(loop_var, types->i32_constant(1), "loop_var+1");
-  loop_var->addIncoming(loop_update, loop_body);
-
-  // get the current value
-  llvm::Value* offset = builder->CreateGEP(arg_elements, loop_var, "offset");
-  llvm::Value* current_value = builder->CreateLoad(offset, "value");
-
-  // setup sum PHI
-  llvm::Value* sum_update = builder->CreateAdd(sum, current_value, "sum+ith");
-  sum->addIncoming(sum_update, loop_body);
-
-  // check loop_var
-  llvm::Value* loop_var_check =
-      builder->CreateICmpSLT(loop_update, arg_nelements, "loop_var < nrec");
-  builder->CreateCondBr(loop_var_check, loop_body, loop_exit);
-
-  // Loop exit
-  builder->SetInsertPoint(loop_exit);
-  builder->CreateRet(sum_update);
-  return fn;
-}
-
 TEST_F(TestEngine, TestAddUnoptimised) {
-  std::unique_ptr<Engine> engine;
-  auto status = Engine::Make(TestConfiguration(), &engine);
-  EXPECT_TRUE(status.ok()) << status.message();
-  LLVMTypes types(*engine->context());
-  llvm::Function* ir_func = BuildVecAdd(engine.get(), &types);
-  status = engine->FinalizeModule(false, false);
-  EXPECT_TRUE(status.ok()) << status.message();
-  add_vector_func_t add_func =
-      reinterpret_cast<add_vector_func_t>(engine->CompiledFunction(ir_func));
+  configuration->set_optimize(false);
+  BuildEngine();
+
+  llvm::Function* ir_func = BuildVecAdd(engine.get());
+  ASSERT_OK(engine->FinalizeModule());
+  auto add_func = reinterpret_cast<add_vector_func_t>(engine->CompiledFunction(ir_func));
 
   int64_t my_array[] = {1, 3, -5, 8, 10};
   EXPECT_EQ(add_func(my_array, 5), 17);
 }
 
 TEST_F(TestEngine, TestAddOptimised) {
-  std::unique_ptr<Engine> engine;
-  auto status = Engine::Make(TestConfiguration(), &engine);
-  EXPECT_TRUE(status.ok()) << status.message();
-  LLVMTypes types(*engine->context());
-  llvm::Function* ir_func = BuildVecAdd(engine.get(), &types);
-  status = engine->FinalizeModule(true, false);
-  EXPECT_TRUE(status.ok()) << status.message();
+  configuration->set_optimize(true);
+  BuildEngine();
 
-  add_vector_func_t add_func =
-      reinterpret_cast<add_vector_func_t>(engine->CompiledFunction(ir_func));
+  llvm::Function* ir_func = BuildVecAdd(engine.get());
+  ASSERT_OK(engine->FinalizeModule());
+  auto add_func = reinterpret_cast<add_vector_func_t>(engine->CompiledFunction(ir_func));
 
   int64_t my_array[] = {1, 3, -5, 8, 10};
   EXPECT_EQ(add_func(my_array, 5), 17);

--- a/cpp/src/gandiva/filter.cc
+++ b/cpp/src/gandiva/filter.cc
@@ -103,4 +103,6 @@ Status Filter::Evaluate(const arrow::RecordBatch& batch,
   return out_selection->PopulateFromBitMap(result, bitmap_size, num_rows - 1);
 }
 
+std::string Filter::DumpIR() { return llvm_generator_->DumpIR(); }
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/filter.h
+++ b/cpp/src/gandiva/filter.h
@@ -76,10 +76,12 @@ class GANDIVA_EXPORT Filter {
   Status Evaluate(const arrow::RecordBatch& batch,
                   std::shared_ptr<SelectionVector> out_selection);
 
+  std::string DumpIR();
+
  private:
-  const std::unique_ptr<LLVMGenerator> llvm_generator_;
-  const SchemaPtr schema_;
-  const std::shared_ptr<Configuration> configuration_;
+  std::unique_ptr<LLVMGenerator> llvm_generator_;
+  SchemaPtr schema_;
+  std::shared_ptr<Configuration> configuration_;
 };
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -74,6 +74,7 @@ class GANDIVA_EXPORT LLVMGenerator {
   SelectionVector::Mode selection_vector_mode() { return selection_vector_mode_; }
   LLVMTypes* types() { return engine_->types(); }
   llvm::Module* module() { return engine_->module(); }
+  std::string DumpIR() { return engine_->DumpIR(); }
 
  private:
   LLVMGenerator();
@@ -243,8 +244,6 @@ class GANDIVA_EXPORT LLVMGenerator {
   SelectionVector::Mode selection_vector_mode_;
 
   // used for debug
-  bool dump_ir_;
-  bool optimise_ir_;
   bool enable_ir_traces_;
   std::vector<std::string> trace_strings_;
 };

--- a/cpp/src/gandiva/llvm_types.h
+++ b/cpp/src/gandiva/llvm_types.h
@@ -33,6 +33,8 @@ class GANDIVA_EXPORT LLVMTypes {
  public:
   explicit LLVMTypes(llvm::LLVMContext& context);
 
+  llvm::Type* void_type() { return llvm::Type::getVoidTy(context_); }
+
   llvm::Type* i1_type() { return llvm::Type::getInt1Ty(context_); }
 
   llvm::Type* i8_type() { return llvm::Type::getInt8Ty(context_); }
@@ -45,68 +47,42 @@ class GANDIVA_EXPORT LLVMTypes {
 
   llvm::Type* i128_type() { return llvm::Type::getInt128Ty(context_); }
 
-  llvm::Type* float_type() { return llvm::Type::getFloatTy(context_); }
-
-  llvm::Type* double_type() { return llvm::Type::getDoubleTy(context_); }
-
-  llvm::PointerType* i8_ptr_type() { return llvm::PointerType::get(i8_type(), 0); }
-
-  llvm::PointerType* i32_ptr_type() { return llvm::PointerType::get(i32_type(), 0); }
-
-  llvm::PointerType* i64_ptr_type() { return llvm::PointerType::get(i64_type(), 0); }
-
-  llvm::PointerType* i128_ptr_type() { return llvm::PointerType::get(i128_type(), 0); }
-
   llvm::StructType* i128_split_type() {
     // struct with high/low bits (see decimal_ops.cc:DecimalSplit)
     return llvm::StructType::get(context_, {i64_type(), i64_type()}, false);
   }
 
-  llvm::Type* void_type() { return llvm::Type::getVoidTy(context_); }
+  llvm::Type* float_type() { return llvm::Type::getFloatTy(context_); }
 
-  llvm::PointerType* ptr_type(llvm::Type* base_type) {
-    return llvm::PointerType::get(base_type, 0);
+  llvm::Type* double_type() { return llvm::Type::getDoubleTy(context_); }
+
+  llvm::PointerType* ptr_type(llvm::Type* type) { return type->getPointerTo(); }
+
+  llvm::PointerType* i8_ptr_type() { return ptr_type(i8_type()); }
+
+  llvm::PointerType* i32_ptr_type() { return ptr_type(i32_type()); }
+
+  llvm::PointerType* i64_ptr_type() { return ptr_type(i64_type()); }
+
+  llvm::PointerType* i128_ptr_type() { return ptr_type(i128_type()); }
+
+  template <typename ctype, size_t N = (sizeof(ctype) * CHAR_BIT)>
+  llvm::Constant* int_constant(ctype val) {
+    return llvm::ConstantInt::get(context_, llvm::APInt(N, val));
   }
 
-  llvm::Constant* true_constant() {
-    return llvm::ConstantInt::get(context_, llvm::APInt(1, 1));
-  }
+  llvm::Constant* i1_constant(bool val) { return int_constant<bool, 1>(val); }
+  llvm::Constant* i8_constant(int8_t val) { return int_constant(val); }
+  llvm::Constant* i16_constant(int16_t val) { return int_constant(val); }
+  llvm::Constant* i32_constant(int32_t val) { return int_constant(val); }
+  llvm::Constant* i64_constant(int64_t val) { return int_constant(val); }
+  llvm::Constant* i128_constant(int64_t val) { return int_constant<int64_t, 128>(val); }
 
-  llvm::Constant* false_constant() {
-    return llvm::ConstantInt::get(context_, llvm::APInt(1, 0));
-  }
+  llvm::Constant* true_constant() { return i1_constant(true); }
+  llvm::Constant* false_constant() { return i1_constant(false); }
 
-  llvm::Constant* i1_constant(bool val) {
-    return llvm::ConstantInt::get(context_, llvm::APInt(1, val));
-  }
-
-  llvm::Constant* i8_constant(bool val) {
-    return llvm::ConstantInt::get(context_, llvm::APInt(8, val));
-  }
-
-  llvm::Constant* i16_constant(bool val) {
-    return llvm::ConstantInt::get(context_, llvm::APInt(16, val));
-  }
-
-  llvm::Constant* i32_constant(int32_t val) {
-    return llvm::ConstantInt::get(context_, llvm::APInt(32, val));
-  }
-
-  llvm::Constant* i64_constant(int64_t val) {
-    return llvm::ConstantInt::get(context_, llvm::APInt(64, val));
-  }
-
-  llvm::Constant* i128_constant(int64_t val) {
-    return llvm::ConstantInt::get(context_, llvm::APInt(128, val));
-  }
-
-  llvm::Constant* i128_zero() {
-    return llvm::ConstantInt::get(context_, llvm::APInt(128, 0));
-  }
-
-  llvm::Constant* i128_one() {
-    return llvm::ConstantInt::get(context_, llvm::APInt(128, 1));
-  }
+  llvm::Constant* i128_zero() { return i128_constant(0); }
+  llvm::Constant* i128_one() { return i128_constant(1); }
 
   llvm::Constant* float_constant(float val) {
     return llvm::ConstantFP::get(float_type(), val);

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -267,4 +267,6 @@ Status Projector::ValidateArrayDataCapacity(const arrow::ArrayData& array_data,
   return Status::OK();
 }
 
+std::string Projector::DumpIR() { return llvm_generator_->DumpIR(); }
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/projector.h
+++ b/cpp/src/gandiva/projector.h
@@ -117,6 +117,8 @@ class GANDIVA_EXPORT Projector {
   Status Evaluate(const arrow::RecordBatch& batch,
                   const SelectionVector* selection_vector, const ArrayDataVector& output);
 
+  std::string DumpIR();
+
  private:
   Projector(std::unique_ptr<LLVMGenerator> llvm_generator, SchemaPtr schema,
             const FieldVector& output_fields, std::shared_ptr<Configuration>);
@@ -132,10 +134,10 @@ class GANDIVA_EXPORT Projector {
   /// Validate the common args for Evaluate() APIs.
   Status ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch);
 
-  const std::unique_ptr<LLVMGenerator> llvm_generator_;
-  const SchemaPtr schema_;
-  const FieldVector output_fields_;
-  const std::shared_ptr<Configuration> configuration_;
+  std::unique_ptr<LLVMGenerator> llvm_generator_;
+  SchemaPtr schema_;
+  FieldVector output_fields_;
+  std::shared_ptr<Configuration> configuration_;
 };
 
 }  // namespace gandiva

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -150,7 +150,7 @@ cdef class Projector:
         return self
 
     @property
-    def ir(self):
+    def llvm_ir(self):
         return self.projector.get().DumpIR().decode()
 
     def evaluate(self, RecordBatch batch):
@@ -179,7 +179,7 @@ cdef class Filter:
         return self
 
     @property
-    def ir(self):
+    def llvm_ir(self):
         return self.filter.get().DumpIR().decode()
 
     def evaluate(self, RecordBatch batch, MemoryPool pool, dtype='int32'):

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -149,6 +149,10 @@ cdef class Projector:
         self.pool = pool
         return self
 
+    @property
+    def ir(self):
+        return self.projector.get().DumpIR().decode()
+
     def evaluate(self, RecordBatch batch):
         cdef vector[shared_ptr[CArray]] results
         check_status(self.projector.get().Evaluate(
@@ -173,6 +177,10 @@ cdef class Filter:
         cdef Filter self = Filter.__new__(Filter)
         self.filter = filter
         return self
+
+    @property
+    def ir(self):
+        return self.filter.get().DumpIR().decode()
 
     def evaluate(self, RecordBatch batch, MemoryPool pool, dtype='int32'):
         cdef:

--- a/python/pyarrow/includes/libgandiva.pxd
+++ b/python/pyarrow/includes/libgandiva.pxd
@@ -172,11 +172,6 @@ cdef extern from "gandiva/tree_expr_builder.h" namespace "gandiva" nogil:
         "gandiva::TreeExprBuilder::MakeInExpressionBinary"(
             shared_ptr[CNode] node, const c_unordered_set[c_string]& values)
 
-    cdef CStatus Projector_Make \
-        "gandiva::Projector::Make"(
-            shared_ptr[CSchema] schema, const CExpressionVector& children,
-            shared_ptr[CProjector]* projector)
-
 cdef extern from "gandiva/projector.h" namespace "gandiva" nogil:
 
     cdef cppclass CProjector" gandiva::Projector":
@@ -185,6 +180,13 @@ cdef extern from "gandiva/projector.h" namespace "gandiva" nogil:
             const CRecordBatch& batch, CMemoryPool* pool,
             const CArrayVector* output)
 
+        c_string DumpIR()
+
+    cdef CStatus Projector_Make \
+        "gandiva::Projector::Make"(
+            shared_ptr[CSchema] schema, const CExpressionVector& children,
+            shared_ptr[CProjector]* projector)
+
 cdef extern from "gandiva/filter.h" namespace "gandiva" nogil:
 
     cdef cppclass CFilter" gandiva::Filter":
@@ -192,6 +194,8 @@ cdef extern from "gandiva/filter.h" namespace "gandiva" nogil:
         CStatus Evaluate(
             const CRecordBatch& batch,
             shared_ptr[CSelectionVector] out_selection)
+
+        c_string DumpIR()
 
     cdef CStatus Filter_Make \
         "gandiva::Filter::Make"(

--- a/python/pyarrow/tests/test_gandiva.py
+++ b/python/pyarrow/tests/test_gandiva.py
@@ -46,6 +46,8 @@ def test_tree_exp_builder():
     projector = gandiva.make_projector(
         schema, [expr], pa.default_memory_pool())
 
+    assert projector.ir.find("@expr_") != -1
+
     a = pa.array([10, 12, -20, 5], type=pa.int32())
     b = pa.array([5, 15, 15, 17], type=pa.int32())
     e = pa.array([10, 15, 15, 17], type=pa.int32())
@@ -96,6 +98,7 @@ def test_filter():
     condition = builder.make_condition(cond)
 
     filter = gandiva.make_filter(table.schema, condition)
+    assert filter.ir.find("@expr_") != -1
     result = filter.evaluate(table.to_batches()[0], pa.default_memory_pool())
     assert result.to_array().equals(pa.array(range(1000), type=pa.uint32()))
 

--- a/python/pyarrow/tests/test_gandiva.py
+++ b/python/pyarrow/tests/test_gandiva.py
@@ -46,7 +46,8 @@ def test_tree_exp_builder():
     projector = gandiva.make_projector(
         schema, [expr], pa.default_memory_pool())
 
-    assert projector.ir.find("@expr_") != -1
+    # Gandiva generates compute kernel function named `@expr_X`
+    assert projector.llvm_ir.find("@expr_") != -1
 
     a = pa.array([10, 12, -20, 5], type=pa.int32())
     b = pa.array([5, 15, 15, 17], type=pa.int32())
@@ -98,7 +99,9 @@ def test_filter():
     condition = builder.make_condition(cond)
 
     filter = gandiva.make_filter(table.schema, condition)
-    assert filter.ir.find("@expr_") != -1
+    # Gandiva generates compute kernel function named `@expr_X`
+    assert filter.llvm_ir.find("@expr_") != -1
+
     result = filter.evaluate(table.to_batches()[0], pa.default_memory_pool())
     assert result.to_array().equals(pa.array(range(1000), type=pa.uint32()))
 


### PR DESCRIPTION
The following patch exposes the generated IR as a method of the objects
for further inspection. This is a breaking change for the internal
method `FinalizeModule` which doesn't take the dump_ir and optimize
flags, it receives `optimize` from Configuration now.

- Refactored Engine, notably removed dead code, organized init in a single
  function and simplified LLVMGenerator.
- Dumping IR should not write to stdout, but instead return it as a
  string in the `DumpIR` method.
- Refactored Types, fixing some bad methods type.
- Added the optimize field to `Configuration` class.
- Simplified some unit tests.

But more importantly, we can now inspect dynamically:

```python
>>> filter = gandiva.make_filter(table.schema, condition)                                                                                    
>>> print(filter.ir)
; ModuleID = 'codegen'                                                
source_filename = "codegen"                    
target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"           
target triple = "x86_64-unknown-linux-gnu"                 
                                                                      
@llvm.global_ctors = appending global [0 x { i32, void ()*, i8* }] zeroinitializer
@_ZN5arrow7BitUtilL8kBitmaskE = internal unnamed_addr constant [8 x i8] c"\01\02\04\08\10 @\80", align 1
                                                                                                                                             
; Function Attrs: norecurse nounwind                      
define i32 @expr_0_0(i64* nocapture readonly %args, i64* nocapture readonly %arg_addr_offsets, i64* nocapture readnone %local_bitmaps, i16* nocapture readnone %selection_vector, i64 %context_ptr, i64 %nrecords) local_unnamed_addr #0 {
entry:                                                                
  %0 = bitcast i64* %args to i8**                                                                                                            
  %cond_mem56 = load i8*, i8** %0, align 8                            
  %1 = getelementptr i64, i64* %arg_addr_offsets, i64 3            
  %2 = load i64, i64* %1, align 8                                                                                                            
  %a_mem_addr = getelementptr i64, i64* %args, i64 3                  
  %3 = bitcast i64* %a_mem_addr to double**            
  %a_mem7 = load double*, double** %3, align 8                        
  %scevgep = getelementptr double, double* %a_mem7, i64 %2   
  br label %loop                                            
                                                                                                                                             
loop:                                             ; preds = %loop, %entry
  %loop_var = phi i64 [ 0, %entry ], [ %"loop_var+1", %loop ]                                                                                
  %scevgep8 = getelementptr double, double* %scevgep, i64 %loop_var
  %a = load double, double* %scevgep8, align 8      
  %4 = fcmp olt double %a, 1.000000e+03                   
  %5 = sext i1 %4 to i8                             
```                                
