### PR TITLE
ARROW-7844: [R] Converter_List is not thread-safe

### DIFF
--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -593,6 +593,8 @@ class Converter_List : public Converter {
 
     return Status::OK();
   }
+
+  bool Parallel() const { return false; }
 };
 
 class Converter_Int64 : public Converter {


### PR DESCRIPTION
This would trigger issues such as this:

```
Parquet file reading/writing: .........S..............Warning: stack imbalance in '.Call', 145 then 144
Warning: stack imbalance in '{', 141 then 140
Warning: stack imbalance in '{', 134 then 133
1..

══ Skipped ═════════════════════════════════════════════════════════════════════
1. write_parquet() handles various compression_level= specs (@test-parquet.R#66) - Reason: Arrow C++ not built with support for gzip

══ Failed ══════════════════════════════════════════════════════════════════════
── 1. Failure: Lists are preserved when writing/reading from Parquet (@test-parq
`object` not equivalent to `expected`.
Component “int”: Component 3: Numeric: lengths (4, 2) differ
```