### PR TITLE
ARROW-7781: [C++] Improve message when referencing a missing field

### DIFF
--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -1004,6 +1004,7 @@ struct InsertImplicitCastsImpl {
 
 Result<std::shared_ptr<Expression>> InsertImplicitCasts(const Expression& expr,
                                                         const Schema& schema) {
+  RETURN_NOT_OK(schema.CanReferenceFieldsByNames(FieldsInExpression(expr)));
   return VisitExpression(expr, InsertImplicitCastsImpl{schema});
 }
 

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -353,7 +353,9 @@ TEST_F(ExpressionsTest, ImplicitCast) {
   auto set_int32 = ArrayFromJSON(int32(), R"([1, 2, 3])");
   ASSERT_EQ(E{filter}, E{"a"_.In(set_int32)});
 
-  ASSERT_RAISES(Invalid, InsertImplicitCasts("nope"_ == 0.0, *schema_));
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
+                                  testing::HasSubstr("Field named 'nope' not found"),
+                                  InsertImplicitCasts("nope"_ == 0.0, *schema_));
 }
 
 TEST_F(FilterTest, ImplicitCast) {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -700,6 +700,17 @@ std::vector<int> Schema::GetAllFieldIndices(const std::string& name) const {
   return result;
 }
 
+Status Schema::CanReferenceFieldsByNames(const std::vector<std::string>& names) const {
+  for (const auto& name : names) {
+    if (GetFieldByName(name) == nullptr) {
+      return Status::Invalid("Field named '", name,
+                             "' not found or not unique in the schema.");
+    }
+  }
+
+  return Status::OK();
+}
+
 std::vector<std::shared_ptr<Field>> Schema::GetAllFieldsByName(
     const std::string& name) const {
   std::vector<std::shared_ptr<Field>> result;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1442,6 +1442,9 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   /// Return the indices of all fields having this name
   std::vector<int> GetAllFieldIndices(const std::string& name) const;
 
+  /// Indicate if fields named `names` can be found unambiguously in the schema.
+  Status CanReferenceFieldsByNames(const std::vector<std::string>& names) const;
+
   /// \brief The custom key-value metadata, if any
   ///
   /// \return metadata may be null

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -403,6 +403,27 @@ TEST_F(TestSchema, GetFieldDuplicates) {
   ASSERT_EQ(results.size(), 0);
 }
 
+TEST_F(TestSchema, CanReferenceFieldsByNames) {
+  auto f0 = field("f0", int32());
+  auto f1 = field("f1", uint8(), false);
+  auto f2 = field("f2", utf8());
+  auto f3 = field("f1", list(int16()));
+
+  auto schema = ::arrow::schema({f0, f1, f2, f3});
+
+  ASSERT_OK(schema->CanReferenceFieldsByNames({"f0", "f2"}));
+  ASSERT_OK(schema->CanReferenceFieldsByNames({"f2", "f0"}));
+
+  // Not found
+  ASSERT_RAISES(Invalid, schema->CanReferenceFieldsByNames({"nope"}));
+  ASSERT_RAISES(Invalid, schema->CanReferenceFieldsByNames({"f0", "nope"}));
+  // Duplicates
+  ASSERT_RAISES(Invalid, schema->CanReferenceFieldsByNames({"f1"}));
+  ASSERT_RAISES(Invalid, schema->CanReferenceFieldsByNames({"f0", "f1"}));
+  // Both
+  ASSERT_RAISES(Invalid, schema->CanReferenceFieldsByNames({"f0", "f1", "nope"}));
+}
+
 TEST_F(TestSchema, TestMetadataConstruction) {
   auto metadata0 = key_value_metadata({{"foo", "bar"}, {"bizz", "buzz"}});
   auto metadata1 = key_value_metadata({{"foo", "baz"}});


### PR DESCRIPTION
- The failure now indicate which field name is causing the issue.
- Add the `CanReferenceFieldsByNames` in Schema and relevant tests.