### PR TITLE
ARROW-7495: [Java] Remove "empty" concept from ArrowBuf, replace with custom referencemanager

### DIFF
--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcReferenceManager.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcReferenceManager.java
@@ -93,8 +93,8 @@ public class OrcReferenceManager implements ReferenceManager {
             this,
             null,
             length, // length (in bytes) in the underlying memory chunk for this new ArrowBuf
-            derivedBufferAddress, // starting byte address in the underlying memory for this new ArrowBuf,
-            false);
+            derivedBufferAddress // starting byte address in the underlying memory for this new ArrowBuf,
+            );
 
     return derivedBuf;
   }

--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
@@ -66,8 +66,7 @@ public class OrcStripeReader extends ArrowReader {
               new OrcReferenceManager(buffer),
               null,
               (int) buffer.getSize(),
-              buffer.getMemoryAddress(),
-              false));
+              buffer.getMemoryAddress()));
     }
 
     loadRecordBatch(new ArrowRecordBatch(

--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -1245,6 +1245,6 @@ public final class ArrowBuf implements AutoCloseable {
    * Create an empty ArrowBuf with length.
    */
   public static ArrowBuf empty(long length) {
-    return new ArrowBuf(ReferenceManager.NO_OP, null,length, new PooledByteBufAllocatorL().empty.memoryAddress());
+    return new ArrowBuf(ReferenceManager.NO_OP, null, length, new PooledByteBufAllocatorL().empty.memoryAddress());
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -1239,4 +1239,11 @@ public final class ArrowBuf implements AutoCloseable {
        "(expected:0 <= readerIndex <= writerIndex <= capacity(%d))", readerIndex, writerIndex, this.capacity()));
     }
   }
+
+  /**
+   * Create an empty ArrowBuf with length.
+   */
+  public static ArrowBuf empty(long length) {
+    return new ArrowBuf(ReferenceManager.NO_OP, null,length, new PooledByteBufAllocatorL().empty.memoryAddress());
+  }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -33,6 +33,7 @@ import org.apache.arrow.memory.util.MemoryUtil;
 import org.apache.arrow.util.Preconditions;
 
 import io.netty.buffer.NettyArrowBuf;
+import io.netty.buffer.PooledByteBufAllocatorL;
 
 /**
  * ArrowBuf serves as a facade over underlying memory by providing

--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -70,7 +70,6 @@ public final class ArrowBuf implements AutoCloseable {
   private final ReferenceManager referenceManager;
   private final BufferManager bufferManager;
   private final long addr;
-  private final boolean isEmpty;
   private long readerIndex;
   private long writerIndex;
   private final HistoricalLog historicalLog = BaseAllocator.DEBUG ?
@@ -82,17 +81,14 @@ public final class ArrowBuf implements AutoCloseable {
    *
    * @param referenceManager The memory manager to track memory usage and reference count of this buffer
    * @param length The  byte length of this buffer
-   * @param isEmpty  Indicates if this buffer is empty which enables some optimizations.
    */
   public ArrowBuf(
       final ReferenceManager referenceManager,
       final BufferManager bufferManager,
       final long length,
-      final long memoryAddress,
-      boolean isEmpty) {
+      final long memoryAddress) {
     this.referenceManager = referenceManager;
     this.bufferManager = bufferManager;
-    this.isEmpty = isEmpty;
     this.addr = memoryAddress;
     this.length = length;
     this.readerIndex = 0;
@@ -103,7 +99,7 @@ public final class ArrowBuf implements AutoCloseable {
   }
 
   public int refCnt() {
-    return isEmpty ? 1 : referenceManager.getRefCount();
+    return referenceManager.getRefCount();
   }
 
   /**
@@ -140,7 +136,7 @@ public final class ArrowBuf implements AutoCloseable {
 
     final NettyArrowBuf nettyArrowBuf = new NettyArrowBuf(
             this,
-            isEmpty ? null : referenceManager.getAllocator().getAsByteBufAllocator(),
+            referenceManager.getAllocator().getAsByteBufAllocator(),
             checkedCastToInt(length));
     nettyArrowBuf.readerIndex(checkedCastToInt(readerIndex));
     nettyArrowBuf.writerIndex(checkedCastToInt(writerIndex));
@@ -153,10 +149,6 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public ReferenceManager getReferenceManager() {
     return referenceManager;
-  }
-
-  public boolean isEmpty() {
-    return isEmpty;
   }
 
   public long capacity() {
@@ -218,9 +210,6 @@ public final class ArrowBuf implements AutoCloseable {
    *  Returns a slice (view) starting at <code>index</code> with the given <code>length</code>.
    */
   public ArrowBuf slice(long index, long length) {
-    if (isEmpty) {
-      return this;
-    }
 
     Preconditions.checkPositionIndex(index, this.length);
     Preconditions.checkPositionIndex(index + length, this.length);
@@ -236,11 +225,11 @@ public final class ArrowBuf implements AutoCloseable {
   }
 
   public ByteBuffer nioBuffer() {
-    return isEmpty ? ByteBuffer.allocateDirect(0) : asNettyBuffer().nioBuffer();
+    return asNettyBuffer().nioBuffer();
   }
 
   public ByteBuffer nioBuffer(long index, int length) {
-    return isEmpty ? ByteBuffer.allocateDirect(0) : asNettyBuffer().nioBuffer(index, length);
+    return asNettyBuffer().nioBuffer(index, length);
   }
 
   public long memoryAddress() {
@@ -1056,7 +1045,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @return Size in bytes.
    */
   public long getPossibleMemoryConsumed() {
-    return isEmpty ? 0 : referenceManager.getSize();
+    return referenceManager.getSize();
   }
 
   /**
@@ -1065,7 +1054,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @return Size in bytes.
    */
   public long getActualMemoryConsumed() {
-    return isEmpty ? 0 : referenceManager.getAccountedSize();
+    return referenceManager.getAccountedSize();
   }
 
   /**
@@ -1114,7 +1103,7 @@ public final class ArrowBuf implements AutoCloseable {
   public void print(StringBuilder sb, int indent, Verbosity verbosity) {
     BaseAllocator.indent(sb, indent).append(toString());
 
-    if (BaseAllocator.DEBUG && !isEmpty && verbosity.includeHistoricalLog) {
+    if (BaseAllocator.DEBUG && verbosity.includeHistoricalLog) {
       sb.append("\n");
       historicalLog.buildHistory(sb, indent + 1, verbosity.includeStackTraces);
     }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -279,7 +279,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
   }
 
   private ArrowBuf createEmpty() {
-    return new ArrowBuf(ReferenceManager.NO_OP, null, 0, NettyAllocationManager.EMPTY.memoryAddress(), true);
+    return new ArrowBuf(ReferenceManager.NO_OP, null, 0, NettyAllocationManager.EMPTY.memoryAddress());
   }
 
   @Override

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -232,8 +232,8 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
             this,
             null,
             length, // length (in bytes) in the underlying memory chunk for this new ArrowBuf
-            derivedBufferAddress, // starting byte address in the underlying memory for this new ArrowBuf,
-            false);
+            derivedBufferAddress // starting byte address in the underlying memory for this new ArrowBuf
+            );
 
     // logging
     if (BaseAllocator.DEBUG) {
@@ -271,7 +271,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
     final long startAddress = allocationManager.memoryAddress();
 
     // create ArrowBuf
-    final ArrowBuf buf = new ArrowBuf(this, manager, length, startAddress, false);
+    final ArrowBuf buf = new ArrowBuf(this, manager, length, startAddress);
 
     // logging
     if (BaseAllocator.DEBUG) {
@@ -308,9 +308,6 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
    */
   @Override
   public ArrowBuf retain(final ArrowBuf srcBuffer, BufferAllocator target) {
-    if (srcBuffer.isEmpty()) {
-      return srcBuffer;
-    }
 
     if (BaseAllocator.DEBUG) {
       historicalLog.recordEvent("retain(%s)", target.getName());
@@ -410,9 +407,6 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
    */
   @Override
   public TransferResult transferOwnership(final ArrowBuf srcBuffer, final BufferAllocator target) {
-    if (srcBuffer.isEmpty()) {
-      return new TransferResult(true, srcBuffer);
-    }
     // the call to associate will return the corresponding reference manager (buffer ledger) for
     // the target allocator. if the allocation manager didn't already have a mapping
     // for the target allocator, it will create one and return the new reference manager with a

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
@@ -134,6 +134,9 @@ public class TestArrowBuf {
     assertEquals(3, buf.capacity());
     assertEquals(1, buf.getReferenceManager().getRefCount());
     buf.close();
+
+    ArrowBuf buf2 = ArrowBuf.empty(10);
+    assertEquals(10, buf2.capacity());
   }
 
 }

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
@@ -30,6 +30,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import io.netty.buffer.PooledByteBufAllocatorL;
+
 public class TestArrowBuf {
 
   private static final int MAX_ALLOCATION = 8 * 1024;

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
@@ -128,7 +128,7 @@ public class TestArrowBuf {
 
   @Test
   public void testEmptyArrowBuf() {
-    ArrowBuf buf = new ArrowBuf(ReferenceManager.NO_OP, null,3, new PooledByteBufAllocatorL().empty.memoryAddress());
+    ArrowBuf buf = new ArrowBuf(ReferenceManager.NO_OP, null, 3, new PooledByteBufAllocatorL().empty.memoryAddress());
     buf.getReferenceManager().retain(8);
     assertEquals(3, buf.capacity());
     assertEquals(1, buf.getReferenceManager().getRefCount());

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
@@ -24,6 +24,7 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.ReferenceManager;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -124,6 +125,15 @@ public class TestArrowBuf {
       buf.getBytes(0, actual);
       assertArrayEquals(expected, actual);
     }
+  }
+
+  @Test
+  public void testEmptyArrowBuf() {
+    ArrowBuf buf = new ArrowBuf(ReferenceManager.NO_OP, null,3, new PooledByteBufAllocatorL().empty.memoryAddress());
+    buf.getReferenceManager().retain(8);
+    assertEquals(3, buf.capacity());
+    assertEquals(1, buf.getReferenceManager().getRefCount());
+    buf.close();
   }
 
 }

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
@@ -23,9 +23,6 @@ import static org.junit.Assert.assertEquals;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import org.apache.arrow.memory.BufferAllocator;
-import org.apache.arrow.memory.ReferenceManager;
-import org.apache.arrow.memory.RootAllocator;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -34,7 +34,7 @@ public class TestBitVectorHelper {
   public void testGetNullCount() throws Exception {
     // test case 1, 1 null value for 0b110
     ArrowBuf validityBuffer = new ArrowBuf(
-        ReferenceManager.NO_OP, null, 3, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
+        ReferenceManager.NO_OP, null, 3, new PooledByteBufAllocatorL().empty.memoryAddress());
     // we set validity buffer to be 0b10110, but only have 3 items with 1st item is null
     validityBuffer.setByte(0, 0b10110);
 
@@ -44,7 +44,7 @@ public class TestBitVectorHelper {
 
     // test case 2, no null value for 0xFF
     validityBuffer = new ArrowBuf(
-        ReferenceManager.NO_OP, null, 8, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
+        ReferenceManager.NO_OP, null, 8, new PooledByteBufAllocatorL().empty.memoryAddress());
     validityBuffer.setByte(0, 0xFF);
 
     count = BitVectorHelper.getNullCount(validityBuffer, 8);
@@ -52,7 +52,7 @@ public class TestBitVectorHelper {
 
     // test case 3, 1 null value for 0x7F
     validityBuffer = new ArrowBuf(
-        ReferenceManager.NO_OP, null, 8, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
+        ReferenceManager.NO_OP, null, 8, new PooledByteBufAllocatorL().empty.memoryAddress());
     validityBuffer.setByte(0, 0x7F);
 
     count = BitVectorHelper.getNullCount(validityBuffer, 8);
@@ -60,7 +60,7 @@ public class TestBitVectorHelper {
 
     // test case 4, validity buffer has multiple bytes, 11 items
     validityBuffer = new ArrowBuf(
-        ReferenceManager.NO_OP, null, 11, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
+        ReferenceManager.NO_OP, null, 11, new PooledByteBufAllocatorL().empty.memoryAddress());
     validityBuffer.setByte(0, 0b10101010);
     validityBuffer.setByte(1, 0b01010101);
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -43,6 +43,8 @@ import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
 import org.apache.arrow.vector.compare.VectorEqualsVisitor;
+import org.apache.arrow.vector.complex.DenseUnionVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
@@ -2722,6 +2724,137 @@ public class TestValueVector {
       assertEquals(STR1.length + STR2.length, vector2.getEndOffset(1));
       assertEquals(STR1.length + STR2.length, vector2.getStartOffset(2));
       assertEquals(STR1.length + STR2.length + STR3.length, vector2.getEndOffset(2));
+    }
+  }
+
+  @Test
+  public void testEmptyBufBehavior() {
+    final int valueCount = 10;
+
+    try (final IntVector vector = new IntVector("v", allocator)) {
+      assertEquals(1, vector.getDataBuffer().refCnt());
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(0, vector.getDataBuffer().capacity());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+
+      vector.allocateNew(valueCount);
+      assertEquals(2, vector.getDataBuffer().refCnt());
+      assertEquals(2, vector.getValidityBuffer().refCnt());
+      assertEquals(56, vector.getDataBuffer().capacity());
+      assertEquals(8, vector.getValidityBuffer().capacity());
+
+      vector.close();
+      assertEquals(1, vector.getDataBuffer().refCnt());
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(0, vector.getDataBuffer().capacity());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+    }
+
+    try (final VarCharVector vector = new VarCharVector("v", allocator)) {
+      assertEquals(1, vector.getDataBuffer().refCnt());
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getOffsetBuffer().refCnt());
+      assertEquals(0, vector.getDataBuffer().capacity());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(0, vector.getOffsetBuffer().capacity());
+
+      vector.allocateNew(valueCount);
+      assertEquals(1, vector.getDataBuffer().refCnt());
+      assertEquals(2, vector.getValidityBuffer().refCnt());
+      assertEquals(2, vector.getOffsetBuffer().refCnt());
+      assertEquals(32768, vector.getDataBuffer().capacity());
+      assertEquals(8, vector.getValidityBuffer().capacity());
+      assertEquals(56, vector.getOffsetBuffer().capacity());
+
+      vector.close();
+      assertEquals(1, vector.getDataBuffer().refCnt());
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getOffsetBuffer().refCnt());
+      assertEquals(0, vector.getDataBuffer().capacity());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(0, vector.getOffsetBuffer().capacity());
+    }
+
+    try (final ListVector vector = ListVector.empty("v", allocator)) {
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getOffsetBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(0, vector.getOffsetBuffer().capacity());
+
+      vector.setValueCount(valueCount);
+      vector.allocateNewSafe();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getOffsetBuffer().refCnt());
+      assertEquals(1024, vector.getValidityBuffer().capacity());
+      assertEquals(32768, vector.getOffsetBuffer().capacity());
+
+      vector.close();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getOffsetBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(0, vector.getOffsetBuffer().capacity());
+    }
+
+    try (final FixedSizeListVector vector = FixedSizeListVector.empty("v", 2, allocator)) {
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+
+      vector.setValueCount(10);
+      vector.allocateNewSafe();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1024, vector.getValidityBuffer().capacity());
+
+      vector.close();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+    }
+
+    try (final StructVector vector = StructVector.empty("v", allocator)) {
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+
+      vector.setValueCount(valueCount);
+      vector.allocateNewSafe();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1024, vector.getValidityBuffer().capacity());
+
+      vector.close();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+    }
+
+    try (final UnionVector vector = UnionVector.empty("v", allocator)) {
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+
+      vector.setValueCount(10);
+      vector.allocateNewSafe();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(8192, vector.getValidityBuffer().capacity());
+
+      vector.close();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+    }
+
+    try (final DenseUnionVector vector = DenseUnionVector.empty("v", allocator)) {
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getOffsetBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(0, vector.getOffsetBuffer().capacity());
+
+      vector.setValueCount(valueCount);
+      vector.allocateNew();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getOffsetBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(32768, vector.getOffsetBuffer().capacity());
+
+      vector.close();
+      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getOffsetBuffer().refCnt());
+      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(0, vector.getOffsetBuffer().capacity());
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2785,8 +2785,8 @@ public class TestValueVector {
       vector.allocateNewSafe();
       assertEquals(1, vector.getValidityBuffer().refCnt());
       assertEquals(1, vector.getOffsetBuffer().refCnt());
-      assertEquals(1024, vector.getValidityBuffer().capacity());
-      assertEquals(32768, vector.getOffsetBuffer().capacity());
+      assertEquals(512, vector.getValidityBuffer().capacity());
+      assertEquals(16384, vector.getOffsetBuffer().capacity());
 
       vector.close();
       assertEquals(1, vector.getValidityBuffer().refCnt());
@@ -2802,7 +2802,7 @@ public class TestValueVector {
       vector.setValueCount(10);
       vector.allocateNewSafe();
       assertEquals(1, vector.getValidityBuffer().refCnt());
-      assertEquals(1024, vector.getValidityBuffer().capacity());
+      assertEquals(512, vector.getValidityBuffer().capacity());
 
       vector.close();
       assertEquals(1, vector.getValidityBuffer().refCnt());
@@ -2816,7 +2816,7 @@ public class TestValueVector {
       vector.setValueCount(valueCount);
       vector.allocateNewSafe();
       assertEquals(1, vector.getValidityBuffer().refCnt());
-      assertEquals(1024, vector.getValidityBuffer().capacity());
+      assertEquals(512, vector.getValidityBuffer().capacity());
 
       vector.close();
       assertEquals(1, vector.getValidityBuffer().refCnt());
@@ -2830,7 +2830,7 @@ public class TestValueVector {
       vector.setValueCount(10);
       vector.allocateNewSafe();
       assertEquals(1, vector.getValidityBuffer().refCnt());
-      assertEquals(8192, vector.getValidityBuffer().capacity());
+      assertEquals(4096, vector.getValidityBuffer().capacity());
 
       vector.close();
       assertEquals(1, vector.getValidityBuffer().refCnt());
@@ -2848,7 +2848,7 @@ public class TestValueVector {
       assertEquals(1, vector.getValidityBuffer().refCnt());
       assertEquals(1, vector.getOffsetBuffer().refCnt());
       assertEquals(0, vector.getValidityBuffer().capacity());
-      assertEquals(32768, vector.getOffsetBuffer().capacity());
+      assertEquals(16384, vector.getOffsetBuffer().capacity());
 
       vector.close();
       assertEquals(1, vector.getValidityBuffer().refCnt());


### PR DESCRIPTION
Related to [ARROW-7495](https://issues.apache.org/jira/browse/ARROW-7495).

With the introduction of ReferenceManager in the codebase, the need for a separate ArrowBuf is no longer necessary. Instead, once can create a new reference manager that is used for the empty ArrowBuf. For reminder/review, empty arrowbufs have a special behavior in that they don't actually have any reference counting semantics and always stay at one. This allow us to better troubleshoot unallocated memory than what would otherwise be an NPE after calling ValueVector.clear()