### PR TITLE
ARROW-7898: [Python] Reduce the number docstring violations using numpydoc

### DIFF
--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -209,19 +209,3 @@ class NumpyDoc:
                     self.traverse(callback, obj, from_package=from_package)
 
         return results
-
-
-# import pyarrow as pa
-
-# print(inspect_signature(pa.array))
-
-# n = NumpyDoc()
-# with n._apply_patches():
-#     print(pa.array.__doc__)
-
-#     s = pa.array.__doc__.splitlines()[0]
-
-#     print(repr(inspect.signature(pa.array)))
-
-# import sys
-# sys.exit(0)

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -17,6 +17,8 @@
 
 import importlib
 import inspect
+import tokenize
+import itertools
 from contextlib import contextmanager
 
 try:
@@ -207,3 +209,19 @@ class NumpyDoc:
                     self.traverse(callback, obj, from_package=from_package)
 
         return results
+
+
+# import pyarrow as pa
+
+# print(inspect_signature(pa.array))
+
+# n = NumpyDoc()
+# with n._apply_patches():
+#     print(pa.array.__doc__)
+
+#     s = pa.array.__doc__.splitlines()[0]
+
+#     print(repr(inspect.signature(pa.array)))
+
+# import sys
+# sys.exit(0)

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import importlib
 import inspect
 import tokenize
 from contextlib import contextmanager

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -18,7 +18,6 @@
 import importlib
 import inspect
 import tokenize
-import itertools
 from contextlib import contextmanager
 
 try:

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import importlib
+import inspect
 from contextlib import contextmanager
 
 try:

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -15,8 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import inspect
-import tokenize
+import importlib
 from contextlib import contextmanager
 
 try:

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -17,6 +17,17 @@
 
 # flake8: noqa
 
+"""
+PyArrow is the python implementation of Apache Arrow.
+
+Apache Arrow is a cross-language development platform for in-memory data.
+It specifies a standardized language-independent columnar memory format for
+flat and hierarchical data, organized for efficient analytic operations on
+modern hardware. It also provides computational libraries and zero-copy
+streaming messaging and interprocess communication.
+
+For more information see the official page at https://arrow.apache.org
+"""
 
 import os as _os
 import sys as _sys

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1040,7 +1040,7 @@ cdef class Scanner:
         partition information or internal metadata found in the data
         source, e.g. Parquet statistics. Otherwise filters the loaded
         RecordBatches before yielding them.
-    use_threads : boolean, default True
+    use_threads : bool, default True
         If enabled, then maximum paralellism will be used determined by
         the number of available CPU cores.
     batch_size : int, default 32K

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -57,7 +57,9 @@ def _normalize_path(FileSystem filesystem, path):
 
 
 cdef class FileInfo:
-    """FileSystem entry info"""
+    """
+    FileSystem entry info.
+    """
 
     def __init__(self):
         raise TypeError("FileInfo cannot be instantiated directly, use "
@@ -87,7 +89,8 @@ cdef class FileInfo:
 
     @property
     def type(self):
-        """Type of the file
+        """
+        Type of the file.
 
         The returned enum values can be the following:
 
@@ -106,12 +109,15 @@ cdef class FileInfo:
 
     @property
     def path(self):
-        """The full file path in the filesystem."""
+        """
+        The full file path in the filesystem.
+        """
         return frombytes(self.info.path())
 
     @property
     def base_name(self):
-        """The file base name
+        """
+        The file base name.
 
         Component after the last directory separator.
         """
@@ -119,7 +125,8 @@ cdef class FileInfo:
 
     @property
     def size(self):
-        """The size in bytes, if available
+        """
+        The size in bytes, if available.
 
         Only regular files are guaranteed to have a size.
         """
@@ -129,12 +136,15 @@ cdef class FileInfo:
 
     @property
     def extension(self):
-        """The file extension"""
+        """
+        The file extension.
+        """
         return frombytes(self.info.extension())
 
     @property
     def mtime(self):
-        """The time of last modification, if available.
+        """
+        The time of last modification, if available.
 
         Returns
         -------
@@ -146,7 +156,8 @@ cdef class FileInfo:
 
 
 cdef class FileSelector:
-    """File and directory selector.
+    """
+    File and directory selector.
 
     It contains a set of options that describes how to search for files and
     directories.
@@ -203,7 +214,9 @@ cdef class FileSelector:
 
 
 cdef class FileSystem:
-    """Abstract file system API"""
+    """
+    Abstract file system API.
+    """
 
     def __init__(self):
         raise TypeError("FileSystem is an abstract class, instantiate one of "
@@ -212,7 +225,8 @@ cdef class FileSystem:
 
     @staticmethod
     def from_uri(uri):
-        """Create a new FileSystem from URI or Path
+        """
+        Create a new FileSystem from URI or Path.
 
         Recognized URI schemes are "file", "mock", "s3fs", "hdfs" and "viewfs".
         In addition, the argument can be a pathlib.Path object, or a string
@@ -221,7 +235,7 @@ cdef class FileSystem:
         Parameters
         ----------
         uri : string
-            URI-based path, for example: file:///some/local/path
+            URI-based path, for example: file:///some/local/path.
 
         Returns
         -------
@@ -270,7 +284,8 @@ cdef class FileSystem:
         return self.wrapped
 
     def get_file_info(self, paths_or_selector):
-        """Get info for the given files.
+        """
+        Get info for the given files.
 
         Any symlink is automatically dereferenced, recursively. A non-existing
         or unreachable file returns a FileStat object and has a FileType of
@@ -307,7 +322,8 @@ cdef class FileSystem:
         return [FileInfo.wrap(info) for info in infos]
 
     def create_dir(self, path, *, bint recursive=True):
-        """Create a directory and subdirectories.
+        """
+        Create a directory and subdirectories.
 
         This function succeeds if the directory already exists.
 
@@ -335,7 +351,8 @@ cdef class FileSystem:
             check_status(self.fs.DeleteDir(directory))
 
     def move(self, src, dest):
-        """Move / rename a file or directory.
+        """
+        Move / rename a file or directory.
 
         If the destination exists:
         - if it is a non-empty directory, an error is returned
@@ -356,7 +373,8 @@ cdef class FileSystem:
             check_status(self.fs.Move(source, destination))
 
     def copy_file(self, src, dest):
-        """Copy a file.
+        """
+        Copy a file.
 
         If the destination exists and is a directory, an error is returned.
         Otherwise, it is replaced.
@@ -375,7 +393,8 @@ cdef class FileSystem:
             check_status(self.fs.CopyFile(source, destination))
 
     def delete_file(self, path):
-        """Delete a file.
+        """
+        Delete a file.
 
         Parameters
         ----------
@@ -405,7 +424,8 @@ cdef class FileSystem:
         return stream
 
     def open_input_file(self, path):
-        """Open an input file for random access reading.
+        """
+        Open an input file for random access reading.
 
         Parameters
         ----------
@@ -429,7 +449,8 @@ cdef class FileSystem:
         return stream
 
     def open_input_stream(self, path, compression='detect', buffer_size=None):
-        """Open an input stream for sequential reading.
+        """
+        Open an input stream for sequential reading.
 
         Parameters
         ----------
@@ -465,7 +486,8 @@ cdef class FileSystem:
         )
 
     def open_output_stream(self, path, compression='detect', buffer_size=None):
-        """Open an output stream for sequential writing.
+        """
+        Open an output stream for sequential writing.
 
         If the target already exists, existing data is truncated.
 
@@ -503,7 +525,8 @@ cdef class FileSystem:
         )
 
     def open_append_stream(self, path, compression='detect', buffer_size=None):
-        """Open an output stream for appending.
+        """
+        Open an output stream for appending.
 
         If the target doesn't exist, a new empty file is created.
 
@@ -542,7 +565,8 @@ cdef class FileSystem:
 
 
 cdef class LocalFileSystemOptions:
-    """Options for LocalFileSystemOptions.
+    """
+    Options for LocalFileSystemOptions.
 
     Parameters
     ----------
@@ -575,7 +599,8 @@ cdef class LocalFileSystemOptions:
 
 
 cdef class LocalFileSystem(FileSystem):
-    """A FileSystem implementation accessing files on the local machine.
+    """
+    A FileSystem implementation accessing files on the local machine.
 
     Details such as symlinks are abstracted away (symlinks are always followed,
     except when deleting an entry).
@@ -605,7 +630,8 @@ cdef class LocalFileSystem(FileSystem):
 
 
 cdef class SubTreeFileSystem(FileSystem):
-    """Delegates to another implementation after prepending a fixed base path.
+    """
+    Delegates to another implementation after prepending a fixed base path.
 
     This is useful to expose a logical view of a subtree of a filesystem,
     for example a directory in a LocalFileSystem.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -124,7 +124,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
     type : pyarrow.DataType
         Explicit type to attempt to coerce to, otherwise will be inferred from
         the data.
-    mask : array (boolean), optional
+    mask : array[bool], optional
         Indicate which values are null (True) or not null (False).
     size : int64, optional
         Size of the elements. If the imput is larger than size bail at this
@@ -144,6 +144,14 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
     memory_pool : pyarrow.MemoryPool, optional
         If not passed, will allocate memory from the currently-set default
         memory pool.
+
+    Returns
+    -------
+    array : pyarrow.Array or pyarrow.ChunkedArray
+        A ChunkedArray instead of an Array is returned if:
+        - the object data overflowed binary storage.
+        - the object's ``__arrow_array__`` protocol method returned a chunked
+          array.
 
     Notes
     -----
@@ -170,15 +178,6 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
       1,
       null
     ]
-
-    Returns
-    -------
-    array : pyarrow.Array or pyarrow.ChunkedArray
-        A ChunkedArray instead of an Array is returned if:
-
-        - the object data overflowed binary storage.
-        - the object's ``__arrow_array__`` protocol method returned a chunked
-          array.
     """
     cdef:
         CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
@@ -529,7 +528,7 @@ cdef class _PandasConvertible:
             data in a pandas DataFrame or Series (e.g. timestamps are always
             stored as nanoseconds in pandas). This option controls whether it
             is a safe cast or not.
-        split_blocks : boolean, default False
+        split_blocks : bool, default False
             If True, generate one internal "block" for each column when
             creating a pandas.DataFrame from a RecordBatch or Table. While this
             can temporarily reduce memory note that various pandas operations

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -132,14 +132,14 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
         will be treated as a "max size", but will involve an initial allocation
         of size followed by a resize to the actual size (so if you know the
         exact size specifying it correctly will give you better performance).
-    from_pandas : boolean, default None
+    from_pandas : bool, default None
         Use pandas's semantics for inferring nulls from values in
         ndarray-like data. If passed, the mask tasks precendence, but
         if a value is unmasked (not-null), but still null according to
         pandas semantics, then it is null. Defaults to False if not
         passed explicitly by user, or True if a pandas object is
         passed in.
-    safe : boolean, default True
+    safe : bool, default True
         Check for overflows or other unsafe conversions.
     memory_pool : pyarrow.MemoryPool, optional
         If not passed, will allocate memory from the currently-set default
@@ -307,7 +307,7 @@ def infer_type(values, mask=None, from_pandas=False):
         Sequence to infer type from.
     mask : ndarray (bool type), optional
         Optional exclusion mask where True marks null, False non-null.
-    from_pandas : boolean, default False
+    from_pandas : bool, default False
         Use pandas's NA/null sentinel values for type inference.
 
     Returns
@@ -504,27 +504,27 @@ cdef class _PandasConvertible:
         memory_pool : MemoryPool, default None
             Arrow MemoryPool to use for allocations. Uses the default memory
             pool is not passed.
-        strings_to_categorical : boolean, default False
+        strings_to_categorical : bool, default False
             Encode string (UTF8) and binary types to pandas.Categorical.
         categories: list, default empty
             List of fields that should be returned as pandas.Categorical. Only
             applies to table-like data structures.
-        zero_copy_only : boolean, default False
+        zero_copy_only : bool, default False
             Raise an ArrowException if this function call would require copying
             the underlying data.
-        integer_object_nulls : boolean, default False
+        integer_object_nulls : bool, default False
             Cast integers with nulls to objects
-        date_as_object : boolean, default True
+        date_as_object : bool, default True
             Cast dates to objects. If False, convert to datetime64[ns] dtype.
-        use_threads: boolean, default True
+        use_threads: bool, default True
             Whether to parallelize the conversion using multiple threads.
-        deduplicate_objects : boolean, default False
+        deduplicate_objects : bool, default False
             Do not create multiple copies Python objects when created, to save
             on memory use. Conversion will be slower.
-        ignore_metadata : boolean, default False
+        ignore_metadata : bool, default False
             If True, do not use the 'pandas' metadata to reconstruct the
             DataFrame index, if present
-        safe : boolean default True
+        safe : bool, default True
             For certain data types, a cast is needed in order to store the
             data in a pandas DataFrame or Series (e.g. timestamps are always
             stored as nanoseconds in pandas). This option controls whether it
@@ -534,7 +534,7 @@ cdef class _PandasConvertible:
             creating a pandas.DataFrame from a RecordBatch or Table. While this
             can temporarily reduce memory note that various pandas operations
             can trigger "consolidation" which may balloon memory use.
-        self_destruct : boolean, default False
+        self_destruct : bool, default False
             EXPERIMENTAL: If True, attempt to deallocate the originating Arrow
             memory while converting the Arrow object to pandas. If you use the
             object after calling to_pandas with this option it will crash your
@@ -659,7 +659,7 @@ cdef class Array(_PandasConvertible):
         ----------
         target_type : DataType
             Type to cast to
-        safe : boolean, default True
+        safe : bool, default True
             Check for overflows or other unsafe conversions
 
         Returns
@@ -765,7 +765,7 @@ cdef class Array(_PandasConvertible):
         type : pyarrow.DataType
             Explicit type to attempt to coerce to, otherwise will be inferred
             from the data.
-        safe : boolean, default True
+        safe : bool, default True
             Check for overflows or other unsafe conversions.
         memory_pool : pyarrow.MemoryPool, optional
             If not passed, will allocate memory from the currently-set default
@@ -1856,12 +1856,12 @@ cdef class DictionaryArray(Array):
             A closed set of values referenced by the indices.
         mask : ndarray or pandas.Series, bool type
             True values indicate that indices are actually null.
-        from_pandas : boolean, default False
+        from_pandas : bool, default False
             If True, the indices should be treated as though they originated in
             a pandas.Categorical (null encoded as -1).
-        ordered : boolean, default False
+        ordered : bool, default False
             Set to True if the category values are ordered.
-        safe : boolean, default True
+        safe : bool, default True
             If True, check that the dictionary indices are in range.
         memory_pool : MemoryPool, default None
             For memory allocations, if required, otherwise uses default pool.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -114,16 +114,16 @@ def _handle_arrow_array_protocol(obj, type, mask, size):
 def array(object obj, type=None, mask=None, size=None, from_pandas=None,
           bint safe=True, MemoryPool memory_pool=None):
     """
-    Create pyarrow.Array instance from a Python object
+    Create pyarrow.Array instance from a Python object.
 
     Parameters
     ----------
     obj : sequence, iterable, ndarray or Series
         If both type and size are specified may be a single use iterable. If
-        not strongly-typed, Arrow type will be inferred for resulting array
+        not strongly-typed, Arrow type will be inferred for resulting array.
     type : pyarrow.DataType
         Explicit type to attempt to coerce to, otherwise will be inferred from
-        the data
+        the data.
     mask : array (boolean), optional
         Indicate which values are null (True) or not null (False).
     size : int64, optional
@@ -138,12 +138,12 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
         if a value is unmasked (not-null), but still null according to
         pandas semantics, then it is null. Defaults to False if not
         passed explicitly by user, or True if a pandas object is
-        passed in
+        passed in.
     safe : boolean, default True
-        Check for overflows or other unsafe conversions
+        Check for overflows or other unsafe conversions.
     memory_pool : pyarrow.MemoryPool, optional
         If not passed, will allocate memory from the currently-set default
-        memory pool
+        memory pool.
 
     Notes
     -----
@@ -272,8 +272,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
 
 def asarray(values, type=None):
     """
-    Convert to pyarrow.Array, inferring type if not provided. Attempt to cast
-    if indicated type is different
+    Convert to pyarrow.Array, inferring type if not provided.
 
     Parameters
     ----------
@@ -282,6 +281,8 @@ def asarray(values, type=None):
         pyarrow.ChunkedArray. If a ChunkedArray is passed, the output will be
         a ChunkedArray, otherwise the output will be a Array.
     type : string or DataType
+        Explicitly construct the array with this type. Attempt to cast if
+        indicated type is different.
 
     Returns
     -------
@@ -290,7 +291,6 @@ def asarray(values, type=None):
     if isinstance(values, (Array, ChunkedArray)):
         if type is not None and not values.type.equals(type):
             values = values.cast(type)
-
         return values
     else:
         return array(values, type=type)
@@ -304,11 +304,11 @@ def infer_type(values, mask=None, from_pandas=False):
     Parameters
     ----------
     values : array-like
-        Sequence to infer type from
+        Sequence to infer type from.
     mask : ndarray (bool type), optional
-        Optional exclusion mask where True marks null, False non-null
+        Optional exclusion mask where True marks null, False non-null.
     from_pandas : boolean, default False
-        Use pandas's NA/null sentinel values for type inference
+        Use pandas's NA/null sentinel values for type inference.
 
     Returns
     -------
@@ -503,24 +503,24 @@ cdef class _PandasConvertible:
         ----------
         memory_pool : MemoryPool, default None
             Arrow MemoryPool to use for allocations. Uses the default memory
-            pool is not passed
+            pool is not passed.
         strings_to_categorical : boolean, default False
-            Encode string (UTF8) and binary types to pandas.Categorical
+            Encode string (UTF8) and binary types to pandas.Categorical.
         categories: list, default empty
             List of fields that should be returned as pandas.Categorical. Only
-            applies to table-like data structures
+            applies to table-like data structures.
         zero_copy_only : boolean, default False
             Raise an ArrowException if this function call would require copying
-            the underlying data
+            the underlying data.
         integer_object_nulls : boolean, default False
             Cast integers with nulls to objects
         date_as_object : boolean, default True
             Cast dates to objects. If False, convert to datetime64[ns] dtype.
         use_threads: boolean, default True
-            Whether to parallelize the conversion using multiple threads
+            Whether to parallelize the conversion using multiple threads.
         deduplicate_objects : boolean, default False
             Do not create multiple copies Python objects when created, to save
-            on memory use. Conversion will be slower
+            on memory use. Conversion will be slower.
         ignore_metadata : boolean, default False
             If True, do not use the 'pandas' metadata to reconstruct the
             DataFrame index, if present
@@ -533,12 +533,12 @@ cdef class _PandasConvertible:
             If True, generate one internal "block" for each column when
             creating a pandas.DataFrame from a RecordBatch or Table. While this
             can temporarily reduce memory note that various pandas operations
-            can trigger "consolidation" which may balloon memory use
+            can trigger "consolidation" which may balloon memory use.
         self_destruct : boolean, default False
             EXPERIMENTAL: If True, attempt to deallocate the originating Arrow
             memory while converting the Arrow object to pandas. If you use the
             object after calling to_pandas with this option it will crash your
-            program
+            program.
         types_mapper : function, default None
             A function mapping a pyarrow DataType to a pandas ExtensionDtype.
             This can be used to override the default pandas type for conversion
@@ -609,8 +609,10 @@ cdef class Array(_PandasConvertible):
 
     def diff(self, Array other):
         """
+        Compare contents of this array against another one.
+
         Return string containing the result of arrow::Diff comparing contents
-        of this array against the other array
+        of this array against the other array.
         """
         cdef c_string result
         with nogil:
@@ -676,13 +678,15 @@ cdef class Array(_PandasConvertible):
         return pyarrow_wrap_array(result)
 
     def view(self, object target_type):
-        """Return zero-copy "view" of array as another data type. The data
-        types must have compatible columnar buffer layouts
+        """
+        Return zero-copy "view" of array as another data type.
+
+        The data types must have compatible columnar buffer layouts
 
         Parameters
         ----------
         target_type : DataType
-            Type to construct view as
+            Type to construct view as.
 
         Returns
         -------
@@ -707,7 +711,7 @@ cdef class Array(_PandasConvertible):
 
     def unique(self):
         """
-        Compute distinct elements in array
+        Compute distinct elements in array.
         """
         cdef shared_ptr[CArray] result
 
@@ -718,7 +722,7 @@ cdef class Array(_PandasConvertible):
 
     def dictionary_encode(self):
         """
-        Compute dictionary-encoded representation of array
+        Compute dictionary-encoded representation of array.
         """
         cdef CDatum out
 
@@ -747,34 +751,36 @@ cdef class Array(_PandasConvertible):
     def from_pandas(obj, mask=None, type=None, bint safe=True,
                     MemoryPool memory_pool=None):
         """
-        Convert pandas.Series to an Arrow Array, using pandas's semantics about
-        what values indicate nulls. See pyarrow.array for more general
-        conversion from arrays or sequences to Arrow arrays.
+        Convert pandas.Series to an Arrow Array.
+
+        The method is using pandas's semantics about what values indicate
+        nulls. See pyarrow.array for more general conversion from arrays or
+        sequences to Arrow arrays.
 
         Parameters
         ----------
         sequence : ndarray, pandas.Series, array-like
         mask : array (boolean), optional
-            Indicate which values are null (True) or not null (False)
+            Indicate which values are null (True) or not null (False).
         type : pyarrow.DataType
             Explicit type to attempt to coerce to, otherwise will be inferred
-            from the data
+            from the data.
         safe : boolean, default True
-            Check for overflows or other unsafe conversions
+            Check for overflows or other unsafe conversions.
         memory_pool : pyarrow.MemoryPool, optional
             If not passed, will allocate memory from the currently-set default
-            memory pool
+            memory pool.
 
         Notes
         -----
         Localized timestamps will currently be returned as UTC (pandas's native
-        representation).  Timezone-naive data will be implicitly interpreted as
+        representation). Timezone-naive data will be implicitly interpreted as
         UTC.
 
         Returns
         -------
-        array : pyarrow.Array or pyarrow.ChunkedArray (if object data
-        overflows binary buffer)
+        array : pyarrow.Array or pyarrow.ChunkedArray
+            ChunkedArray is returned if object data overflows binary buffer.
         """
         return array(obj, mask=mask, type=type, safe=safe, from_pandas=True,
                      memory_pool=memory_pool)
@@ -787,23 +793,26 @@ cdef class Array(_PandasConvertible):
     def from_buffers(DataType type, length, buffers, null_count=-1, offset=0,
                      children=None):
         """
-        Construct an Array from a sequence of buffers. The concrete type
-        returned depends on the datatype.
+        Construct an Array from a sequence of buffers.
+
+        The concrete type returned depends on the datatype.
 
         Parameters
         ----------
         type : DataType
-            The value type of the array
+            The value type of the array.
         length : int
-            The number of values in the array
-        buffers: List[Buffer]
-            The buffers backing this array
+            The number of values in the array.
+        buffers : List[Buffer]
+            The buffers backing this array.
         null_count : int, default -1
+            The number of null entries in the array. Negative value means that
+            the null count is not known.
         offset : int, default 0
             The array's logical offset (in values, not in bytes) from the
-            start of each buffer
+            start of each buffer.
         children : List[Array], default None
-            Nested type children with length matching type.num_children
+            Nested type children with length matching type.num_children.
 
         Returns
         -------
@@ -848,7 +857,9 @@ cdef class Array(_PandasConvertible):
 
     @property
     def nbytes(self):
-        """Total number of bytes consumed by the elements of the array."""
+        """
+        Total number of bytes consumed by the elements of the array.
+        """
         size = 0
         for buf in self.buffers():
             if buf is not None:
@@ -917,15 +928,15 @@ cdef class Array(_PandasConvertible):
 
     def slice(self, offset=0, length=None):
         """
-        Compute zero-copy slice of this array
+        Compute zero-copy slice of this array.
 
         Parameters
         ----------
         offset : int, default 0
-            Offset from start of array to slice
+            Offset from start of array to slice.
         length : int, default None
             Length of slice (default is until end of Array starting from
-            offset)
+            offset).
 
         Returns
         -------
@@ -1119,9 +1130,11 @@ cdef class Array(_PandasConvertible):
     @property
     def offset(self):
         """
-        A relative position into another array's data, to enable zero-copy
-        slicing. This value defaults to zero but must be applied on all
-        operations with the physical storage buffers.
+        A relative position into another array's data.
+
+        The purpose is to enable zero-copy slicing. This value defaults to zero
+        but must be applied on all operations with the physical storage
+        buffers.
         """
         return self.sp_array.get().offset()
 
@@ -1389,7 +1402,7 @@ cdef class ListArray(Array):
     @staticmethod
     def from_arrays(offsets, values, MemoryPool pool=None):
         """
-        Construct ListArray from arrays of int32 offsets and values
+        Construct ListArray from arrays of int32 offsets and values.
 
         Parameters
         ----------
@@ -1431,7 +1444,7 @@ cdef class ListArray(Array):
 
     def flatten(self, MemoryPool memory_pool=None):
         """
-        Unnest this ListArray by one level
+        Unnest this ListArray by one level.
 
         The returned Array is logically a concatenation of all the sub-lists
         in this Array.
@@ -1463,14 +1476,15 @@ cdef class ListArray(Array):
 
 cdef class LargeListArray(Array):
     """
-    Concrete class for Arrow arrays of a large list data type
-    (like ListArray, but 64-bit offsets).
+    Concrete class for Arrow arrays of a large list data type.
+
+    Identical to ListArray, but 64-bit offsets.
     """
 
     @staticmethod
     def from_arrays(offsets, values, MemoryPool pool=None):
         """
-        Construct LargeListArray from arrays of int64 offsets and values
+        Construct LargeListArray from arrays of int64 offsets and values.
 
         Parameters
         ----------
@@ -1526,7 +1540,7 @@ cdef class LargeListArray(Array):
         ----------
         memory_pool : pyarrow.MemoryPool, optional
             If not passed, will allocate memory from the currently-set default
-            memory pool
+            memory pool.
 
         Returns
         -------
@@ -1551,7 +1565,7 @@ cdef class MapArray(Array):
     @staticmethod
     def from_arrays(offsets, keys, items, MemoryPool pool=None):
         """
-        Construct MapArray from arrays of int32 offsets and key, item arrays
+        Construct MapArray from arrays of int32 offsets and key, item arrays.
 
         Parameters
         ----------
@@ -1831,24 +1845,26 @@ cdef class DictionaryArray(Array):
                     bint from_pandas=False, bint safe=True,
                     MemoryPool memory_pool=None):
         """
-        Construct Arrow DictionaryArray from array of indices (must be
-        non-negative integers) and corresponding array of dictionary values
+        Construct a DictionaryArray from indices and the referencable values.
 
         Parameters
         ----------
-        indices : ndarray or pandas.Series, integer type
-        dictionary : ndarray or pandas.Series
-        mask : ndarray or pandas.Series, boolean type
-            True values indicate that indices are actually null
+        indices : pyarrow.Array, numpy.ndarray or pandas.Series, int type
+            Non-negative integers referencing the dictionary values by zero
+            based index.
+        dictionary : pyarrow.Array, ndarray or pandas.Series
+            A closed set of values referenced by the indices.
+        mask : ndarray or pandas.Series, bool type
+            True values indicate that indices are actually null.
         from_pandas : boolean, default False
             If True, the indices should be treated as though they originated in
-            a pandas.Categorical (null encoded as -1)
+            a pandas.Categorical (null encoded as -1).
         ordered : boolean, default False
-            Set to True if the category values are ordered
+            Set to True if the category values are ordered.
         safe : boolean, default True
-            If True, check that the dictionary indices are in range
+            If True, check that the dictionary indices are in range.
         memory_pool : MemoryPool, default None
-            For memory allocations, if required, otherwise uses default pool
+            For memory allocations, if required, otherwise uses default pool.
 
         Returns
         -------
@@ -1906,12 +1922,12 @@ cdef class StructArray(Array):
 
     def field(self, index):
         """
-        Retrieves the child array belonging to field
+        Retrieves the child array belonging to field.
 
         Parameters
         ----------
         index : Union[int, str]
-            Index / position or name of the field
+            Index / position or name of the field.
 
         Returns
         -------
@@ -1935,13 +1951,12 @@ cdef class StructArray(Array):
 
     def flatten(self, MemoryPool memory_pool=None):
         """
-        Flatten this StructArray, returning one individual array for each
-        field in the struct.
+        Return one individual array for each field in the struct.
 
         Parameters
         ----------
         memory_pool : MemoryPool, default None
-            For memory allocations, if required, otherwise use default pool
+            For memory allocations, if required, otherwise use default pool.
 
         Returns
         -------
@@ -1969,9 +1984,9 @@ cdef class StructArray(Array):
         ----------
         arrays : sequence of Array
         names : List[str] (optional)
-            Field names for each struct child
+            Field names for each struct child.
         fields : List[Field] (optional)
-            Field instances for each struct child
+            Field instances for each struct child.
 
         Returns
         -------
@@ -2074,7 +2089,11 @@ cdef class ExtensionArray(Array):
 
     def to_numpy(self, **kwargs):
         """
-        See Array.to_numpy
+        Converts extension array to a numpy ndarray.
+
+        See Also
+        --------
+        Array.to_numpy
         """
         return self.storage.to_numpy(**kwargs)
 
@@ -2132,13 +2151,18 @@ cdef object get_values(object obj, bint* is_series):
 
 def concat_arrays(arrays, MemoryPool memory_pool=None):
     """
-    Returns a concatenation of the given arrays. The contents of those arrays
-    are copied into the returned array. Raises exception if all of the arrays
-    are not of the same type.
+    Returns a concatenation of the given arrays.
+
+    The contents of those arrays are copied into the returned array.
+
+    Raises
+    ------
+    ArrowInvalid : if any of the arrays is not of the same type.
 
     Parameters
     ----------
-    arrays : iterable of pyarrow.Array objects
+    arrays : iterable of pyarrow.Array
+        Arrays to concatenate, the arrays must be identically typed.
     memory_pool : MemoryPool, default None
         For memory allocations. If None, the default pool is used.
     """

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -752,7 +752,7 @@ cdef class Array(_PandasConvertible):
         """
         Convert pandas.Series to an Arrow Array.
 
-        The method is using pandas's semantics about what values indicate
+        This method uses Pandas semantics about what values indicate
         nulls. See pyarrow.array for more general conversion from arrays or
         sequences to Arrow arrays.
 
@@ -1844,7 +1844,7 @@ cdef class DictionaryArray(Array):
                     bint from_pandas=False, bint safe=True,
                     MemoryPool memory_pool=None):
         """
-        Construct a DictionaryArray from indices and the referencable values.
+        Construct a DictionaryArray from indices and values.
 
         Parameters
         ----------
@@ -1852,7 +1852,7 @@ cdef class DictionaryArray(Array):
             Non-negative integers referencing the dictionary values by zero
             based index.
         dictionary : pyarrow.Array, ndarray or pandas.Series
-            A closed set of values referenced by the indices.
+            The array of values referenced by the indices.
         mask : ndarray or pandas.Series, bool type
             True values indicate that indices are actually null.
         from_pandas : bool, default False
@@ -2088,7 +2088,7 @@ cdef class ExtensionArray(Array):
 
     def to_numpy(self, **kwargs):
         """
-        Converts extension array to a numpy ndarray.
+        Convert extension array to a numpy ndarray.
 
         See Also
         --------
@@ -2150,18 +2150,18 @@ cdef object get_values(object obj, bint* is_series):
 
 def concat_arrays(arrays, MemoryPool memory_pool=None):
     """
-    Returns a concatenation of the given arrays.
+    Concatenate the given arrays.
 
-    The contents of those arrays are copied into the returned array.
+    The contents of the input arrays are copied into the returned array.
 
     Raises
     ------
-    ArrowInvalid : if any of the arrays is not of the same type.
+    ArrowInvalid : if not all of the arrays have the same type.
 
     Parameters
     ----------
     arrays : iterable of pyarrow.Array
-        Arrays to concatenate, the arrays must be identically typed.
+        Arrays to concatenate, must be identically typed.
     memory_pool : MemoryPool, default None
         For memory allocations. If None, the default pool is used.
     """

--- a/python/pyarrow/builder.pxi
+++ b/python/pyarrow/builder.pxi
@@ -20,9 +20,10 @@ from pyarrow.compat import tobytes
 
 cdef class StringBuilder:
     """
-    Builder class for UTF8 strings. This class exposes facilities for
-    incrementally adding string values and building the null bitmap
-    for a pyarrow.Array (type='string').
+    Builder class for UTF8 strings.
+
+    This class exposes facilities for incrementally adding string values and
+    building the null bitmap for a pyarrow.Array (type='string').
     """
     cdef:
         unique_ptr[CStringBuilder] builder
@@ -33,13 +34,15 @@ cdef class StringBuilder:
 
     def append(self, value):
         """
-        Append a single value to the builder. The value can either be a
-        string/bytes object or a null value (np.nan or None).
+        Append a single value to the builder.
+
+        The value can either be a string/bytes object or a null value
+        (np.nan or None).
 
         Parameters
         ----------
         value : string/bytes or np.nan/None
-            The value to append to the string array builder
+            The value to append to the string array builder.
         """
         if value is None or value is np.nan:
             self.builder.get().AppendNull()
@@ -50,13 +53,12 @@ cdef class StringBuilder:
 
     def append_values(self, values):
         """
-        Append all the values in an iterable to the string array builder
-        object.
+        Append all the values from an iterable.
 
         Parameters
         ----------
         values : iterable of string/bytes or np.nan/None values
-            The values to append to the string array builder
+            The values to append to the string array builder.
         """
         for value in values:
             self.append(value)

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -105,7 +105,7 @@ class FeatherDataset:
     ----------
     path_or_paths : List[str]
         A list of file names
-    validate_schema : boolean, default True
+    validate_schema : bool, default True
         Check that individual file schemas are all the same / compatible
     """
     def __init__(self, path_or_paths, validate_schema=True):
@@ -153,7 +153,7 @@ class FeatherDataset:
         ----------
         columns : List[str]
             Names of columns to read from the file
-        use_threads : boolean, default True
+        use_threads : bool, default True
             Use multiple threads when converting to pandas
 
         Returns
@@ -173,7 +173,7 @@ def write_feather(df, dest):
     ----------
     df : pandas.DataFrame
         Dataframe to write out as feather format.
-    dest : string
+    dest : str
         Local destination path.
     """
     writer = FeatherWriter(dest)
@@ -198,7 +198,7 @@ def read_feather(source, columns=None, use_threads=True):
 
     Parameters
     ----------
-    source : string file path, or file-like object
+    source : str file path, or file-like object
 
     columns : sequence, optional
         Only read a specific set of columns. If not provided, all columns are
@@ -220,7 +220,7 @@ def read_table(source, columns=None):
 
     Parameters
     ----------
-    source : string file path, or file-like object
+    source : str file path, or file-like object
     columns : sequence, optional
         Only read a specific set of columns. If not provided, all columns are
         read.

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -167,13 +167,14 @@ class FeatherDataset:
 
 def write_feather(df, dest):
     """
-    Write a pandas.DataFrame to Feather format
+    Write a pandas.DataFrame to Feather format.
 
     Parameters
     ----------
     df : pandas.DataFrame
+        Dataframe to write out as feather format.
     dest : string
-        Local file path
+        Local destination path.
     """
     writer = FeatherWriter(dest)
     try:
@@ -193,16 +194,17 @@ def write_feather(df, dest):
 
 def read_feather(source, columns=None, use_threads=True):
     """
-    Read a pandas.DataFrame from Feather format
+    Read a pandas.DataFrame from Feather format.
 
     Parameters
     ----------
     source : string file path, or file-like object
+
     columns : sequence, optional
         Only read a specific set of columns. If not provided, all columns are
-        read
+        read.
     use_threads: bool, default True
-        Whether to parallelize reading using multiple threads
+        Whether to parallelize reading using multiple threads.
 
     Returns
     -------
@@ -221,7 +223,7 @@ def read_table(source, columns=None):
     source : string file path, or file-like object
     columns : sequence, optional
         Only read a specific set of columns. If not provided, all columns are
-        read
+        read.
 
     Returns
     -------

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -67,7 +67,7 @@ class FileSystem:
         ----------
         path : str
             Path to delete.
-        recursive : boolean, default False
+        recursive : bool, default False
             If True, also delete child paths for directories.
         """
         raise NotImplementedError
@@ -200,17 +200,17 @@ class FileSystem:
         path : str
             Single file path or directory
         columns : List[str], optional
-            Subset of columns to read
+            Subset of columns to read.
         metadata : pyarrow.parquet.FileMetaData
-            Known metadata to validate files against
+            Known metadata to validate files against.
         schema : pyarrow.parquet.Schema
             Known schema to validate files against. Alternative to metadata
-            argument
-        use_threads : boolean, default True
-            Perform multi-threaded column reads
-        use_pandas_metadata : boolean, default False
+            argument.
+        use_threads : bool, default True
+            Perform multi-threaded column reads.
+        use_pandas_metadata : bool, default False
             If True and file has custom pandas schema metadata, ensure that
-            index columns are also loaded
+            index columns are also loaded.
 
         Returns
         -------

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -29,11 +29,17 @@ from pyarrow.util import implements, _stringify_path, _is_path_like
 
 class FileSystem:
     """
-    Abstract filesystem interface
+    Abstract filesystem interface.
     """
+
     def cat(self, path):
         """
-        Return contents of file as a bytes object
+        Return contents of file as a bytes object.
+
+        Parameters
+        ----------
+        path : str
+            File path to read content from.
 
         Returns
         -------
@@ -44,30 +50,36 @@ class FileSystem:
 
     def ls(self, path):
         """
-        Return list of file paths
+        Return list of file paths.
+
+        Parameters
+        ----------
+        path : str
+            Directory to list contents from.
         """
         raise NotImplementedError
 
     def delete(self, path, recursive=False):
         """
-        Delete the indicated file or directory
+        Delete the indicated file or directory.
 
         Parameters
         ----------
-        path : string
+        path : str
+            Path to delete.
         recursive : boolean, default False
-            If True, also delete child paths for directories
+            If True, also delete child paths for directories.
         """
         raise NotImplementedError
 
     def disk_usage(self, path):
         """
-        Compute bytes used by all contents under indicated path in file tree
+        Compute bytes used by all contents under indicated path in file tree.
 
         Parameters
         ----------
-        path : string
-            Can be a file path or directory
+        path : str
+            Can be a file path or directory.
 
         Returns
         -------
@@ -91,6 +103,7 @@ class FileSystem:
 
     def stat(self, path):
         """
+        Information about a filesystem entry.
 
         Returns
         -------
@@ -100,44 +113,72 @@ class FileSystem:
 
     def rm(self, path, recursive=False):
         """
-        Alias for FileSystem.delete
+        Alias for FileSystem.delete.
         """
         return self.delete(path, recursive=recursive)
 
     def mv(self, path, new_path):
         """
-        Alias for FileSystem.rename
+        Alias for FileSystem.rename.
         """
         return self.rename(path, new_path)
 
     def rename(self, path, new_path):
         """
-        Rename file, like UNIX mv command
+        Rename file, like UNIX mv command.
 
         Parameters
         ----------
-        path : string
-            Path to alter
-        new_path : string
-            Path to move to
+        path : str
+            Path to alter.
+        new_path : str
+            Path to move to.
         """
         raise NotImplementedError('FileSystem.rename')
 
     def mkdir(self, path, create_parents=True):
+        """
+        Creates a directory.
+
+        Parameters
+        ----------
+        path : str
+            Path to the directory.
+        create_parents : bool, default True
+            If the parent directories don't exists create them as well.
+        """
         raise NotImplementedError
 
     def exists(self, path):
+        """
+        Return True if path exists.
+
+        Parameters
+        ----------
+        path : str
+            Path to check.
+        """
         raise NotImplementedError
 
     def isdir(self, path):
         """
-        Return True if path is a directory
+        Return True if path is a directory.
+
+        Parameters
+        ----------
+        path : str
+            Path to check.
         """
         raise NotImplementedError
 
     def isfile(self, path):
         """
-        Return True if path is a file
+        Return True if path is a file.
+
+        Parameters
+        ----------
+        path : str
+            Path to check.
         """
         raise NotImplementedError
 
@@ -152,7 +193,7 @@ class FileSystem:
                      use_threads=True, use_pandas_metadata=False):
         """
         Read Parquet data from path in file system. Can read from a single file
-        or a directory of files
+        or a directory of files.
 
         Parameters
         ----------
@@ -183,7 +224,7 @@ class FileSystem:
 
     def open(self, path, mode='rb'):
         """
-        Open file for reading or writing
+        Open file for reading or writing.
         """
         raise NotImplementedError
 
@@ -237,7 +278,7 @@ class LocalFileSystem(FileSystem):
     @implements(FileSystem.open)
     def open(self, path, mode='rb'):
         """
-        Open file for reading or writing
+        Open file for reading or writing.
         """
         path = _stringify_path(path)
         return open(path, mode=mode)
@@ -248,7 +289,7 @@ class LocalFileSystem(FileSystem):
 
     def walk(self, path):
         """
-        Directory tree generator, see os.walk
+        Directory tree generator, see os.walk.
         """
         path = _stringify_path(path)
         return os.walk(path)
@@ -274,7 +315,7 @@ class DaskFileSystem(FileSystem):
     def _isfilestore(self):
         """
         Object Stores like S3 and GCSFS are based on key lookups, not true
-        file-paths
+        file-paths.
         """
         return False
 
@@ -299,7 +340,7 @@ class DaskFileSystem(FileSystem):
     @implements(FileSystem.open)
     def open(self, path, mode='rb'):
         """
-        Open file for reading or writing
+        Open file for reading or writing.
         """
         path = _stringify_path(path)
         return self.fs.open(path, mode=mode)
@@ -310,7 +351,7 @@ class DaskFileSystem(FileSystem):
 
     def walk(self, path):
         """
-        Directory tree generator, like os.walk
+        Directory tree generator, like os.walk.
         """
         path = _stringify_path(path)
         return self.fs.walk(path)
@@ -341,10 +382,10 @@ class S3FSWrapper(DaskFileSystem):
 
     def walk(self, path, refresh=False):
         """
-        Directory tree generator, like os.walk
+        Directory tree generator, like os.walk.
 
         Generator version of what is in s3fs, which yields a flattened list of
-        files
+        files.
         """
         path = _sanitize_s3(_stringify_path(path))
         directories = set()

--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -138,7 +138,7 @@ class FileSystem:
 
     def mkdir(self, path, create_parents=True):
         """
-        Creates a directory.
+        Create a directory.
 
         Parameters
         ----------

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+"""
+FileSystem abstraction to interact with various local and remote filesystems.
+"""
 
 from pyarrow._fs import (  # noqa
     FileSelector,

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -17,7 +17,6 @@
 
 # cython: profile=False
 # distutils: language = c++
-# cython: embedsignature = True
 # cython: language_level = 3
 
 from libcpp cimport bool as c_bool, nullptr

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -18,6 +18,7 @@
 # cython: profile=False
 # distutils: language = c++
 # cython: language_level = 3
+# cython: embedsignature = True
 
 from libcpp cimport bool as c_bool, nullptr
 from libcpp.memory cimport shared_ptr, unique_ptr, make_shared

--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -27,8 +27,9 @@ import pyarrow.lib as lib
 
 class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
     """
-    FileSystem interface for HDFS cluster. See pyarrow.hdfs.connect for full
-    connection details
+    FileSystem interface for HDFS cluster.
+
+    See pyarrow.hdfs.connect for full connection details
     """
 
     def __init__(self, host="default", port=0, user=None, kerb_ticket=None,
@@ -44,8 +45,7 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
 
     def _isfilestore(self):
         """
-        Returns True if this FileSystem is a unix-style file store with
-        directories.
+        Returns True if this is a unix-style file store with directories.
         """
         return True
 
@@ -63,12 +63,12 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
 
     def mkdir(self, path, **kwargs):
         """
-        Create directory in HDFS
+        Create directory in HDFS.
 
         Parameters
         ----------
-        path : string
-            Directory path to create, including any parent directories
+        path : str
+            Directory path to create, including any parent directories.
 
         Notes
         -----

--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -90,9 +90,10 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
 
         Parameters
         ----------
-        path : HDFS path
-        detail : boolean, default False
-            If False, only return list of paths
+        path : str
+            HDFS path to retrieve contents of.
+        detail : bool, default False
+            If False, only return list of paths.
 
         Returns
         -------
@@ -102,12 +103,12 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
 
     def walk(self, top_path):
         """
-        Directory tree generator for HDFS, like os.walk
+        Directory tree generator for HDFS, like os.walk.
 
         Parameters
         ----------
-        top_path : string
-            Root directory for tree traversal
+        top_path : str
+            Root directory for tree traversal.
 
         Returns
         -------

--- a/python/pyarrow/hdfs.py
+++ b/python/pyarrow/hdfs.py
@@ -45,7 +45,7 @@ class HadoopFileSystem(lib.HadoopFileSystem, FileSystem):
 
     def _isfilestore(self):
         """
-        Returns True if this is a unix-style file store with directories.
+        Return True if this is a Unix-style file store with directories.
         """
         return True
 

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1344,8 +1344,8 @@ def foreign_buffer(address, size, base=None):
     """
     Construct an Arrow buffer with the given *address* and *size*.
 
-    Optionally backed by the Python *base* object. The *base* object, if given,
-    will be kept alive as long as this buffer is alive, including across
+    The buffer will be optionally backed by the Python *base* object, if given.
+    The *base* object will be kept alive as long as this buffer is alive, including across
     language boundaries (for example if the buffer is referenced by C++ code).
     """
     cdef:

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -764,11 +764,11 @@ cdef class MemoryMappedFile(NativeFile):
 
 def memory_map(path, mode='r'):
     """
-    Open memory map at file path. Size of the memory map cannot change
+    Open memory map at file path. Size of the memory map cannot change.
 
     Parameters
     ----------
-    path : string
+    path : str
     mode : {'r', 'r+', 'w'}, default 'r'
         Whether the file is opened for reading ('r+'), writing ('w')
         or both ('r+').
@@ -788,7 +788,7 @@ def create_memory_map(path, size):
 
     Parameters
     ----------
-    path : string
+    path : str
         The file path to create, on the local filesystem.
     size : int
         The file size to create.
@@ -961,10 +961,10 @@ cdef class Buffer:
         Parameters
         ----------
         offset : int, default 0
-            Offset from start of buffer to slice
+            Offset from start of buffer to slice.
         length : int, default None
             Length of slice (default is until end of Buffer starting from
-            offset)
+            offset).
 
         Returns
         -------
@@ -1014,7 +1014,7 @@ cdef class Buffer:
 
     def to_pybytes(self):
         """
-        Return this buffer as a Python bytes object.  Memory is copied.
+        Return this buffer as a Python bytes object. Memory is copied.
         """
         return cp.PyBytes_FromStringAndSize(
             <const char*>self.buffer.get().data(),
@@ -1076,7 +1076,7 @@ cdef class ResizableBuffer(Buffer):
         Parameters
         ----------
         new_size : int
-            New size of buffer (padding may be added internally)
+            New size of buffer (padding may be added internally).
         shrink_to_fit : boolean, default False
             If this is true, the buffer is shrunk when new_size is less
             than the current size.
@@ -1166,7 +1166,7 @@ cdef class MockOutputStream(NativeFile):
 
 cdef class BufferReader(NativeFile):
     """
-    Zero-copy reader from objects convertible to Arrow buffer
+    Zero-copy reader from objects convertible to Arrow buffer.
 
     Parameters
     ----------
@@ -1189,8 +1189,9 @@ cdef class CompressedInputStream(NativeFile):
     Parameters
     ----------
     stream : pa.NativeFile
+        Input stream object to wrap with the compression.
     compression : str
-        The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd")
+        The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd").
     """
     def __init__(self, NativeFile stream, str compression not None):
         cdef:
@@ -1213,8 +1214,9 @@ cdef class CompressedOutputStream(NativeFile):
     Parameters
     ----------
     stream : pa.NativeFile
+        Input stream object to wrap with the compression.
     compression : str
-        The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd")
+        The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd").
     """
 
     def __init__(self, NativeFile stream, str compression not None):
@@ -1309,7 +1311,7 @@ cdef class BufferedOutputStream(NativeFile):
         Returns
         -------
         raw : NativeFile
-            The underlying raw output stream
+            The underlying raw output stream.
         """
         cdef:
             shared_ptr[COutputStream] c_raw
@@ -1340,12 +1342,11 @@ def py_buffer(object obj):
 
 def foreign_buffer(address, size, base=None):
     """
-    Construct an Arrow buffer with the given *address* and *size*,
-    optionally backed by the Python *base* object.
+    Construct an Arrow buffer with the given *address* and *size*.
 
-    The *base* object, if given, will be kept alive as long as this buffer
-    is alive, including across language boundaries (for example if the
-    buffer is referenced by C++ code).
+    Optionally backed by the Python *base* object. The *base* object, if given,
+    will be kept alive as long as this buffer is alive, including across
+    language boundaries (for example if the buffer is referenced by C++ code).
     """
     cdef:
         intptr_t c_addr = address
@@ -1671,7 +1672,7 @@ def compress(object buf, codec='lz4', asbytes=False, memory_pool=None):
     Parameters
     ----------
     buf : pyarrow.Buffer, bytes, or other object supporting buffer protocol
-    codec : string, default 'lz4'
+    codec : str, default 'lz4'
         Compression codec.
         Supported types: {'brotli, 'gzip', 'lz4', 'snappy', 'zstd'}
     asbytes : boolean, default False
@@ -1695,16 +1696,17 @@ def decompress(object buf, decompressed_size=None, codec='lz4',
     Parameters
     ----------
     buf : pyarrow.Buffer, bytes, or memoryview-compatible object
+        Input object to decompress data from.
     decompressed_size : int64_t, default None
         If not specified, will be computed if the codec is able to determine
-        the uncompressed buffer size
-    codec : string, default 'lz4'
+        the uncompressed buffer size.
+    codec : str, default 'lz4'
         Compression codec.
         Supported types: {'brotli, 'gzip', 'lz4', 'snappy', 'zstd'}
-    asbytes : boolean, default False
-        Return result as Python bytes object, otherwise Buffer
+    asbytes : bool, default False
+        Return result as Python bytes object, otherwise Buffer.
     memory_pool : MemoryPool, default None
-        Memory pool to use for buffer allocations, if any
+        Memory pool to use for buffer allocations, if any.
 
     Returns
     -------
@@ -1722,15 +1724,15 @@ def input_stream(source, compression='detect', buffer_size=None):
     Parameters
     ----------
     source: str, Path, buffer, file-like object, ...
-        The source to open for reading
+        The source to open for reading.
     compression: str optional, default 'detect'
         The compression algorithm to use for on-the-fly decompression.
         If "detect" and source is a file path, then compression will be
         chosen based on the file extension.
         If None, no compression will be applied.
-        Otherwise, a well-known algorithm name must be supplied (e.g. "gzip")
+        Otherwise, a well-known algorithm name must be supplied (e.g. "gzip").
     buffer_size: int, default None
-        If None or 0, no buffering will happen.  Otherwise the size of the
+        If None or 0, no buffering will happen. Otherwise the size of the
         temporary read buffer.
     """
     cdef NativeFile stream
@@ -1774,15 +1776,15 @@ def output_stream(source, compression='detect', buffer_size=None):
     Parameters
     ----------
     source: str, Path, buffer, file-like object, ...
-        The source to open for writing
+        The source to open for writing.
     compression: str optional, default 'detect'
         The compression algorithm to use for on-the-fly compression.
         If "detect" and source is a file path, then compression will be
         chosen based on the file extension.
         If None, no compression will be applied.
-        Otherwise, a well-known algorithm name must be supplied (e.g. "gzip")
+        Otherwise, a well-known algorithm name must be supplied (e.g. "gzip").
     buffer_size: int, default None
-        If None or 0, no buffering will happen.  Otherwise the size of the
+        If None or 0, no buffering will happen. Otherwise the size of the
         temporary write buffer.
     """
     cdef NativeFile stream

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1345,8 +1345,9 @@ def foreign_buffer(address, size, base=None):
     Construct an Arrow buffer with the given *address* and *size*.
 
     The buffer will be optionally backed by the Python *base* object, if given.
-    The *base* object will be kept alive as long as this buffer is alive, including across
-    language boundaries (for example if the buffer is referenced by C++ code).
+    The *base* object will be kept alive as long as this buffer is alive,
+    including across language boundaries (for example if the buffer is
+    referenced by C++ code).
     """
     cdef:
         intptr_t c_addr = address
@@ -1775,7 +1776,7 @@ def output_stream(source, compression='detect', buffer_size=None):
 
     Parameters
     ----------
-    source: str, pathlib.Path, buffer, file-like object, ...
+    source: str, Path, buffer, file-like object, ...
         The source to open for writing.
     compression: str optional, default 'detect'
         The compression algorithm to use for on-the-fly compression.

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1077,7 +1077,7 @@ cdef class ResizableBuffer(Buffer):
         ----------
         new_size : int
             New size of buffer (padding may be added internally).
-        shrink_to_fit : boolean, default False
+        shrink_to_fit : bool, default False
             If this is true, the buffer is shrunk when new_size is less
             than the current size.
             If this is false, the buffer is never shrunk.
@@ -1107,7 +1107,7 @@ def allocate_buffer(int64_t size, MemoryPool memory_pool=None,
     memory_pool : MemoryPool, optional
         The pool to allocate memory from.
         If not given, the default memory pool is used.
-    resizable : boolean, default False
+    resizable : bool, default False
         If true, the returned buffer is resizable.
 
     Returns
@@ -1675,7 +1675,7 @@ def compress(object buf, codec='lz4', asbytes=False, memory_pool=None):
     codec : str, default 'lz4'
         Compression codec.
         Supported types: {'brotli, 'gzip', 'lz4', 'snappy', 'zstd'}
-    asbytes : boolean, default False
+    asbytes : bool, default False
         Return result as Python bytes object, otherwise Buffer.
     memory_pool : MemoryPool, default None
         Memory pool to use for buffer allocations, if any.
@@ -1775,7 +1775,7 @@ def output_stream(source, compression='detect', buffer_size=None):
 
     Parameters
     ----------
-    source: str, Path, buffer, file-like object, ...
+    source: str, pathlib.Path, buffer, file-like object, ...
         The source to open for writing.
     compression: str optional, default 'detect'
         The compression algorithm to use for on-the-fly compression.

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -155,8 +155,11 @@ cdef class MessageReader:
 
     def read_next_message(self):
         """
-        Read next Message from the stream. Raises StopIteration at end of
-        stream
+        Read next Message from the stream.
+
+        Raises
+        ------
+        StopIteration : at end of stream
         """
         cdef Message result = Message.__new__(Message)
 
@@ -182,7 +185,7 @@ cdef class _CRecordBatchWriter:
 
     def write(self, table_or_batch):
         """
-        Write RecordBatch or Table to stream
+        Write RecordBatch or Table to stream.
 
         Parameters
         ----------
@@ -197,7 +200,7 @@ cdef class _CRecordBatchWriter:
 
     def write_batch(self, RecordBatch batch):
         """
-        Write RecordBatch to stream
+        Write RecordBatch to stream.
 
         Parameters
         ----------
@@ -209,15 +212,14 @@ cdef class _CRecordBatchWriter:
 
     def write_table(self, Table table, max_chunksize=None, **kwargs):
         """
-        Write Table to stream in (contiguous) RecordBatch objects, with maximum
-        chunk size
+        Write Table to stream in (contiguous) RecordBatch objects.
 
         Parameters
         ----------
         table : Table
         max_chunksize : int, default None
             Maximum size for RecordBatch chunks. Individual chunks may be
-            smaller depending on the chunk layout of individual columns
+            smaller depending on the chunk layout of individual columns.
         """
         cdef:
             # max_chunksize must be > 0 to have any impact
@@ -239,7 +241,7 @@ cdef class _CRecordBatchWriter:
 
     def close(self):
         """
-        Close stream and write end-of-stream 0 marker
+        Close stream and write end-of-stream 0 marker.
         """
         with nogil:
             check_status(self.writer.get().Close())
@@ -307,8 +309,12 @@ cdef class _CRecordBatchReader:
 
     def read_next_batch(self):
         """
-        Read next RecordBatch from the stream. Raises StopIteration at end of
-        stream
+        Read next RecordBatch from the stream.
+
+        Raises
+        ------
+        StopIteration:
+            At end of stream.
         """
         cdef shared_ptr[CRecordBatch] batch
 
@@ -322,7 +328,7 @@ cdef class _CRecordBatchReader:
 
     def read_all(self):
         """
-        Read all record batches as a pyarrow.Table
+        Read all record batches as a pyarrow.Table.
         """
         cdef shared_ptr[CTable] table
         with nogil:
@@ -448,7 +454,7 @@ cdef class _RecordBatchFileReader:
 
 def get_tensor_size(Tensor tensor):
     """
-    Return total size of serialized Tensor including metadata and padding
+    Return total size of serialized Tensor including metadata and padding.
     """
     cdef int64_t size
     with nogil:
@@ -458,7 +464,7 @@ def get_tensor_size(Tensor tensor):
 
 def get_record_batch_size(RecordBatch batch):
     """
-    Return total size of serialized RecordBatch including metadata and padding
+    Return total size of serialized RecordBatch including metadata and padding.
     """
     cdef int64_t size
     with nogil:
@@ -468,7 +474,7 @@ def get_record_batch_size(RecordBatch batch):
 
 def write_tensor(Tensor tensor, NativeFile dest):
     """
-    Write pyarrow.Tensor to pyarrow.NativeFile object its current position
+    Write pyarrow.Tensor to pyarrow.NativeFile object its current position.
 
     Parameters
     ----------

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -69,7 +69,7 @@ sink : str, pyarrow.NativeFile, or file-like Python object
     Either a file path, or a writable file object.
 schema : pyarrow.Schema
     The Arrow schema for data to be written to the file.
-use_legacy_format : boolean, default None
+use_legacy_format : bool, default None
     If None, False will be used unless this default is overridden by
     setting the environment variable ARROW_PRE_0_15_IPC_FORMAT=1"""
 
@@ -166,7 +166,7 @@ def serialize_pandas(df, nthreads=None, preserve_index=None):
     df : pandas.DataFrame
     nthreads : int, default None
         Number of threads to use for conversion to Arrow, default all CPUs.
-    preserve_index : boolean, default None
+    preserve_index : bool, default None
         The default of None will store the index as a column, except for
         RangeIndex which is stored as metadata only. If True, always
         preserve the pandas index data as a column. If False, no index
@@ -192,7 +192,7 @@ def deserialize_pandas(buf, use_threads=True):
     ----------
     buf : buffer
         An object compatible with the buffer protocol.
-    use_threads: boolean, default True
+    use_threads: bool, default True
         Whether to parallelize the conversion using multiple threads.
 
     Returns

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -31,8 +31,10 @@ class _ReadPandasOption:
 
     def read_pandas(self, **options):
         """
-        Read contents of stream and convert to pandas.DataFrame using
-        Table.to_pandas
+        Read contents of stream to a pandas.DataFrame.
+
+        Read all record batches as a pyarrow.Table then convert it to a
+        pandas.DataFrame using Table.to_pandas.
 
         Parameters
         ----------
@@ -48,12 +50,12 @@ class _ReadPandasOption:
 
 class RecordBatchStreamReader(lib._RecordBatchStreamReader, _ReadPandasOption):
     """
-    Reader for the Arrow streaming binary format
+    Reader for the Arrow streaming binary format.
 
     Parameters
     ----------
     source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
-        Either an in-memory buffer, or a readable file object
+        Either an in-memory buffer, or a readable file object.
     """
 
     def __init__(self, source):
@@ -64,9 +66,9 @@ _ipc_writer_class_doc = """\
 Parameters
 ----------
 sink : str, pyarrow.NativeFile, or file-like Python object
-    Either a file path, or a writable file object
+    Either a file path, or a writable file object.
 schema : pyarrow.Schema
-    The Arrow schema for data to be written to the file
+    The Arrow schema for data to be written to the file.
 use_legacy_format : boolean, default None
     If None, False will be used unless this default is overridden by
     setting the environment variable ARROW_PRE_0_15_IPC_FORMAT=1"""
@@ -119,15 +121,15 @@ def _get_legacy_format_default(use_legacy_format):
 
 def open_stream(source):
     """
-    Create reader for Arrow streaming format
+    Create reader for Arrow streaming format.
 
     Parameters
     ----------
     source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
-        Either an in-memory buffer, or a readable file object
+        Either an in-memory buffer, or a readable file object.
     footer_offset : int, default None
         If the file is embedded in some larger file, this is the byte offset to
-        the very end of the file data
+        the very end of the file data.
 
     Returns
     -------
@@ -138,15 +140,15 @@ def open_stream(source):
 
 def open_file(source, footer_offset=None):
     """
-    Create reader for Arrow file format
+    Create reader for Arrow file format.
 
     Parameters
     ----------
     source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
-        Either an in-memory buffer, or a readable file object
+        Either an in-memory buffer, or a readable file object.
     footer_offset : int, default None
         If the file is embedded in some larger file, this is the byte offset to
-        the very end of the file data
+        the very end of the file data.
 
     Returns
     -------
@@ -156,13 +158,14 @@ def open_file(source, footer_offset=None):
 
 
 def serialize_pandas(df, nthreads=None, preserve_index=None):
-    """Serialize a pandas DataFrame into a buffer protocol compatible object.
+    """
+    Serialize a pandas DataFrame into a buffer protocol compatible object.
 
     Parameters
     ----------
     df : pandas.DataFrame
     nthreads : int, default None
-        Number of threads to use for conversion to Arrow, default all CPUs
+        Number of threads to use for conversion to Arrow, default all CPUs.
     preserve_index : boolean, default None
         The default of None will store the index as a column, except for
         RangeIndex which is stored as metadata only. If True, always
@@ -172,7 +175,7 @@ def serialize_pandas(df, nthreads=None, preserve_index=None):
     Returns
     -------
     buf : buffer
-        An object compatible with the buffer protocol
+        An object compatible with the buffer protocol.
     """
     batch = pa.RecordBatch.from_pandas(df, nthreads=nthreads,
                                        preserve_index=preserve_index)
@@ -188,9 +191,9 @@ def deserialize_pandas(buf, use_threads=True):
     Parameters
     ----------
     buf : buffer
-        An object compatible with the buffer protocol
+        An object compatible with the buffer protocol.
     use_threads: boolean, default True
-        Whether to parallelize the conversion using multiple threads
+        Whether to parallelize the conversion using multiple threads.
 
     Returns
     -------

--- a/python/pyarrow/jvm.py
+++ b/python/pyarrow/jvm.py
@@ -40,7 +40,7 @@ def jvm_buffer(arrowbuf):
 
     Returns
     -------
-    pyarrow.Buffer :
+    pyarrow.Buffer
         Python Buffer that references the JVM memory.
     """
     address = arrowbuf.memoryAddress()

--- a/python/pyarrow/jvm.py
+++ b/python/pyarrow/jvm.py
@@ -36,12 +36,12 @@ def jvm_buffer(arrowbuf):
     ----------
 
     arrowbuf: io.netty.buffer.ArrowBuf
-        Arrow Buffer representation on the JVM
+        Arrow Buffer representation on the JVM.
 
     Returns
     -------
-    pyarrow.Buffer
-        Python Buffer that references the JVM memory
+    pyarrow.Buffer :
+        Python Buffer that references the JVM memory.
     """
     address = arrowbuf.memoryAddress()
     size = arrowbuf.capacity()
@@ -54,11 +54,11 @@ def _from_jvm_int_type(jvm_type):
 
     Parameters
     ----------
-    jvm_type: org.apache.arrow.vector.types.pojo.ArrowType$Int
+    jvm_type : org.apache.arrow.vector.types.pojo.ArrowType$Int
 
     Returns
     -------
-    typ: pyarrow.DataType
+    typ : pyarrow.DataType
     """
 
     bit_width = jvm_type.getBitWidth()

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -48,7 +48,7 @@ def cpu_count():
     The number of threads is determined at startup by inspecting the
     ``OMP_NUM_THREADS`` and ``OMP_THREAD_LIMIT`` environment variables.
     If neither is present, it will default to the number of hardware threads
-    on the system.  It can be modified at runtime by calling
+    on the system. It can be modified at runtime by calling
     :func:`set_cpu_count()`.
     """
     return GetCpuThreadPoolCapacity()

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# cython: profile=False
+# distutils: language = c++
+# cython: embedsignature = True
+
 
 cdef class MemoryPool:
     """
@@ -131,7 +135,7 @@ def log_memory_allocations(enable=True):
 
     Parameters
     ----------
-    enable : boolean, default True
+    enable : bool, default True
         Pass False to disable logging
     """
     if enable:

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -15,10 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# cython: profile=False
-# distutils: language = c++
-# cython: embedsignature = True
-
 
 cdef class MemoryPool:
     """

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -108,21 +108,21 @@ def _check_filters(filters):
 
 class ParquetFile:
     """
-    Reader interface for a single Parquet file
+    Reader interface for a single Parquet file.
 
     Parameters
     ----------
     source : str, pathlib.Path, pyarrow.NativeFile, or file-like object
         Readable source. For passing bytes or buffer-like file containing a
-        Parquet file, use pyarrow.BufferReader
+        Parquet file, use pyarrow.BufferReader.
     metadata : FileMetaData, default None
         Use existing metadata object, rather than reading from file.
     common_metadata : FileMetaData, default None
         Will be used in reads for pandas schema metadata if not found in the
-        main file's metadata, no other uses at the moment
+        main file's metadata, no other uses at the moment.
     memory_map : bool, default False
         If the source is a file path, use a memory map to read file, which can
-        improve performance in some environments
+        improve performance in some environments.
     buffer_size : int, default 0
         If positive, perform read buffering when deserializing individual
         column chunks. Otherwise IO calls are unbuffered.
@@ -181,19 +181,19 @@ class ParquetFile:
     def read_row_group(self, i, columns=None, use_threads=True,
                        use_pandas_metadata=False):
         """
-        Read a single row group from a Parquet file
+        Read a single row group from a Parquet file.
 
         Parameters
         ----------
         columns: list
             If not None, only these columns will be read from the row group. A
             column name may be a prefix of a nested field, e.g. 'a' will select
-            'a.b', 'a.c', and 'a.d.e'
+            'a.b', 'a.c', and 'a.d.e'.
         use_threads : bool, default True
-            Perform multi-threaded column reads
+            Perform multi-threaded column reads.
         use_pandas_metadata : bool, default False
             If True and file has custom pandas schema metadata, ensure that
-            index columns are also loaded
+            index columns are also loaded.
 
         Returns
         -------
@@ -208,7 +208,7 @@ class ParquetFile:
     def read_row_groups(self, row_groups, columns=None, use_threads=True,
                         use_pandas_metadata=False):
         """
-        Read a multiple row groups from a Parquet file
+        Read a multiple row groups from a Parquet file.
 
         Parameters
         ----------
@@ -217,17 +217,17 @@ class ParquetFile:
         columns: list
             If not None, only these columns will be read from the row group. A
             column name may be a prefix of a nested field, e.g. 'a' will select
-            'a.b', 'a.c', and 'a.d.e'
+            'a.b', 'a.c', and 'a.d.e'.
         use_threads : bool, default True
-            Perform multi-threaded column reads
+            Perform multi-threaded column reads.
         use_pandas_metadata : bool, default False
             If True and file has custom pandas schema metadata, ensure that
-            index columns are also loaded
+            index columns are also loaded.
 
         Returns
         -------
         pyarrow.table.Table
-            Content of the row groups as a table (of columns)
+            Content of the row groups as a table (of columns).
         """
         column_indices = self._get_column_indices(
             columns, use_pandas_metadata=use_pandas_metadata)
@@ -237,24 +237,24 @@ class ParquetFile:
 
     def read(self, columns=None, use_threads=True, use_pandas_metadata=False):
         """
-        Read a Table from Parquet format
+        Read a Table from Parquet format,
 
         Parameters
         ----------
         columns: list
             If not None, only these columns will be read from the file. A
             column name may be a prefix of a nested field, e.g. 'a' will select
-            'a.b', 'a.c', and 'a.d.e'
+            'a.b', 'a.c', and 'a.d.e'.
         use_threads : bool, default True
-            Perform multi-threaded column reads
+            Perform multi-threaded column reads.
         use_pandas_metadata : bool, default False
             If True and file has custom pandas schema metadata, ensure that
-            index columns are also loaded
+            index columns are also loaded.
 
         Returns
         -------
         pyarrow.table.Table
-            Content of the file as a table (of columns)
+            Content of the file as a table (of columns).
         """
         column_indices = self._get_column_indices(
             columns, use_pandas_metadata=use_pandas_metadata)
@@ -263,16 +263,19 @@ class ParquetFile:
 
     def scan_contents(self, columns=None, batch_size=65536):
         """
-        Read contents of file with a single thread for indicated columns and
-        batch size. Number of rows in file is returned. This function is used
-        for benchmarking
+        Read contents of file and return the number of rows read.
+
+        Notes
+        -----
+        This function's primary purpose is benchmarking.
+        The scan is executed on a single thread.
 
         Parameters
         ----------
         columns : list of integers, default None
-            If None, scan all columns
+            Select columns to read, if None scan all columns.
         batch_size : int, default 64K
-            Number of rows to read at a time internally
+            Number of rows to read at a time internally.
 
         Returns
         -------
@@ -354,7 +357,7 @@ def _sanitize_table(table, new_schema, flavor):
 
 
 _parquet_writer_arg_docs = """version : {"1.0", "2.0"}, default "1.0"
-    The Parquet format version, defaults to 1.0
+    The Parquet format version, defaults to 1.0.
 use_dictionary : bool or list
     Specify if we should use dictionary encoding in general or only for
     some columns.
@@ -371,16 +374,16 @@ data_page_size : int, default None
 allow_truncated_timestamps : bool, default False
     Allow loss of data when coercing timestamps to a particular
     resolution. E.g. if microsecond or nanosecond data is lost when coercing to
-    'ms', do not raise an exception
+    'ms', do not raise an exception.
 compression : str or dict
     Specify the compression codec, either on a general basis or per-column.
-    Valid values: {'NONE', 'SNAPPY', 'GZIP', 'LZO', 'BROTLI', 'LZ4', 'ZSTD'}
+    Valid values: {'NONE', 'SNAPPY', 'GZIP', 'LZO', 'BROTLI', 'LZ4', 'ZSTD'}.
 write_statistics : bool or list
     Specify if we should write statistics in general (default is True) or only
     for some columns.
 flavor : {'spark'}, default None
     Sanitize schema or set other compatibility options to work with
-    various target systems
+    various target systems.
 filesystem : FileSystem, default None
     If nothing passed, will be inferred from `where` if path-like, else
     `where` is already a file-like object so no filesystem is needed.
@@ -403,7 +406,7 @@ use_byte_stream_split: bool or list, default False
 class ParquetWriter:
 
     __doc__ = """
-Class for incrementally building a Parquet file for Arrow tables
+Class for incrementally building a Parquet file for Arrow tables.
 
 Parameters
 ----------
@@ -512,20 +515,21 @@ def _get_pandas_index_columns(keyvalues):
 
 class ParquetDatasetPiece:
     """
-    A single chunk of a potentially larger Parquet dataset to read. The
-    arguments will indicate to read either a single row group or all row
-    groups, and whether to add partition keys to the resulting pyarrow.Table
+    A single chunk of a potentially larger Parquet dataset to read.
+
+    The arguments will indicate to read either a single row group or all row
+    groups, and whether to add partition keys to the resulting pyarrow.Table.
 
     Parameters
     ----------
     path : str or pathlib.Path
-        Path to file in the file system where this piece is located
+        Path to file in the file system where this piece is located.
     open_file_func : callable
-        Function to use for obtaining file handle to dataset piece
+        Function to use for obtaining file handle to dataset piece.
     partition_keys : list of tuples
-      [(column name, ordinal index)]
+        In the following structure: [(column name, ordinal index)].
     row_group : int, default None
-        Row group to load. By default, reads all row groups
+        Row group to load. By default, reads all row groups.
     """
     def __init__(self, path, open_file_func=partial(open, mode='rb'),
                  file_options=None, row_group=None, partition_keys=None):
@@ -565,7 +569,7 @@ class ParquetDatasetPiece:
 
     def get_metadata(self):
         """
-        Returns the file's metadata
+        Returns the file's metadata.
 
         Returns
         -------
@@ -576,7 +580,7 @@ class ParquetDatasetPiece:
 
     def open(self):
         """
-        Returns instance of ParquetFile
+        Returns instance of ParquetFile.
         """
         reader = self.open_file_func(self.path)
         if not isinstance(reader, ParquetFile):
@@ -586,16 +590,16 @@ class ParquetDatasetPiece:
     def read(self, columns=None, use_threads=True, partitions=None,
              file=None, use_pandas_metadata=False):
         """
-        Read this piece as a pyarrow.Table
+        Read this piece as a pyarrow.Table.
 
         Parameters
         ----------
         columns : list of column names, default None
         use_threads : bool, default True
-            Perform multi-threaded column reads
+            Perform multi-threaded column reads.
         partitions : ParquetPartitions, default None
         file : file-like object
-            passed to ParquetFile
+            Passed to ParquetFile.
 
         Returns
         -------
@@ -648,7 +652,8 @@ class ParquetDatasetPiece:
 
 
 class PartitionSet:
-    """A data structure for cataloguing the observed Parquet partitions at a
+    """
+    A data structure for cataloguing the observed Parquet partitions at a
     particular level. So if we have
 
     /foo=a/bar=0
@@ -733,7 +738,9 @@ class ParquetPartitions:
     def get_index(self, level, name, key):
         """
         Record a partition value at a particular level, returning the distinct
-        code for that value at that level. Example:
+        code for that value at that level.
+
+        Example:
 
         partitions.get_index(1, 'foo', 'a') returns 0
         partitions.get_index(1, 'foo', 'b') returns 1
@@ -804,9 +811,7 @@ class ParquetPartitions:
 
 
 class ParquetManifest:
-    """
 
-    """
     def __init__(self, dirpath, open_file_func=None, filesystem=None,
                  pathsep='/', partition_scheme='hive', metadata_nthreads=1):
         filesystem, dirpath = _get_filesystem_and_path(filesystem, dirpath)
@@ -962,7 +967,7 @@ read_dictionary : list, default None
     file's schema to obtain the paths.
 memory_map : bool, default False
     If the source is a file path, use a memory map to read file, which can
-    improve performance in some environments
+    improve performance in some environments.
 buffer_size : int, default 0
     If positive, perform read buffering when deserializing individual
     column chunks. Otherwise IO calls are unbuffered."""
@@ -972,24 +977,24 @@ class ParquetDataset:
 
     __doc__ = """
 Encapsulates details of reading a complete Parquet dataset possibly
-consisting of multiple files and partitions in subdirectories
+consisting of multiple files and partitions in subdirectories.
 
 Parameters
 ----------
 path_or_paths : str or List[str]
-    A directory name, single file name, or list of file names
+    A directory name, single file name, or list of file names.
 filesystem : FileSystem, default None
     If nothing passed, paths assumed to be found in the local on-disk
-    filesystem
+    filesystem.
 metadata : pyarrow.parquet.FileMetaData
-    Use metadata obtained elsewhere to validate file schemas
+    Use metadata obtained elsewhere to validate file schemas.
 schema : pyarrow.parquet.Schema
     Use schema obtained elsewhere to validate file schemas. Alternative to
-    metadata parameter
+    metadata parameter.
 split_row_groups : bool, default False
-    Divide files into pieces for each row group in the file
+    Divide files into pieces for each row group in the file.
 validate_schema : bool, default True
-    Check that individual file schemas are all the same / compatible
+    Check that individual file schemas are all the same / compatible.
 filters : List[Tuple] or List[List[Tuple]] or None (default)
     List of filters to apply, like ``[[('x', '=', 0), ...], ...]``. This
     implements partition-level (hive) filtering only, i.e., to prevent the
@@ -1119,21 +1124,21 @@ metadata_nthreads: int, default 1
 
     def read(self, columns=None, use_threads=True, use_pandas_metadata=False):
         """
-        Read multiple Parquet files as a single pyarrow.Table
+        Read multiple Parquet files as a single pyarrow.Table.
 
         Parameters
         ----------
         columns : List[str]
-            Names of columns to read from the file
+            Names of columns to read from the file.
         use_threads : bool, default True
             Perform multi-threaded column reads
         use_pandas_metadata : bool, default False
-            Passed through to each dataset piece
+            Passed through to each dataset piece.
 
         Returns
         -------
         pyarrow.Table
-            Content of the file as a table (of columns)
+            Content of the file as a table (of columns).
         """
         tables = []
         for piece in self.pieces:
@@ -1160,12 +1165,12 @@ metadata_nthreads: int, default 1
     def read_pandas(self, **kwargs):
         """
         Read dataset including pandas metadata, if any. Other arguments passed
-        through to ParquetDataset.read, see docstring for further details
+        through to ParquetDataset.read, see docstring for further details.
 
         Returns
         -------
         pyarrow.Table
-            Content of the file as a table (of columns)
+            Content of the file as a table (of columns).
         """
         return self.read(use_pandas_metadata=True, **kwargs)
 
@@ -1246,13 +1251,13 @@ Parameters
 source: str, pyarrow.NativeFile, or file-like object
     If a string passed, can be a single file name or directory name. For
     file-like objects, only read a single file. Use pyarrow.BufferReader to
-    read a file contained in a bytes or buffer-like object
+    read a file contained in a bytes or buffer-like object.
 columns: list
     If not None, only these columns will be read from the file. A column
     name may be a prefix of a nested field, e.g. 'a' will select 'a.b',
-    'a.c', and 'a.d.e'
+    'a.c', and 'a.d.e'.
 use_threads : bool, default True
-    Perform multi-threaded column reads
+    Perform multi-threaded column reads.
 metadata : FileMetaData
     If separately computed
 {1}
@@ -1359,7 +1364,7 @@ def write_table(table, where, row_group_size=None, version='1.0',
 
 
 write_table.__doc__ = """
-Write a Table to Parquet format
+Write a Table to Parquet format.
 
 Parameters
 ----------
@@ -1471,22 +1476,22 @@ def write_metadata(schema, where, version='1.0',
                    use_deprecated_int96_timestamps=False,
                    coerce_timestamps=None):
     """
-    Write metadata-only Parquet file from schema
+    Write metadata-only Parquet file from schema.
 
     Parameters
     ----------
     schema : pyarrow.Schema
     where: string or pyarrow.NativeFile
     version : {"1.0", "2.0"}, default "1.0"
-        The Parquet format version, defaults to 1.0
+        The Parquet format version, defaults to 1.0.
     use_deprecated_int96_timestamps : bool, default False
-        Write nanosecond resolution timestamps to INT96 Parquet format
+        Write nanosecond resolution timestamps to INT96 Parquet format.
     coerce_timestamps : str, default None
         Cast timestamps a particular resolution.
-        Valid values: {None, 'ms', 'us'}
+        Valid values: {None, 'ms', 'us'}.
     filesystem : FileSystem, default None
         If nothing passed, paths assumed to be found in the local on-disk
-        filesystem
+        filesystem.
     """
     writer = ParquetWriter(
         where, schema, version=version,
@@ -1497,13 +1502,13 @@ def write_metadata(schema, where, version='1.0',
 
 def read_metadata(where, memory_map=False):
     """
-    Read FileMetadata from footer of a single Parquet file
+    Read FileMetadata from footer of a single Parquet file.
 
     Parameters
     ----------
     where : str (filepath) or file-like object
     memory_map : bool, default False
-        Create memory map when the source is a file path
+        Create memory map when the source is a file path.
 
     Returns
     -------
@@ -1514,13 +1519,13 @@ def read_metadata(where, memory_map=False):
 
 def read_schema(where, memory_map=False):
     """
-    Read effective Arrow schema from Parquet file metadata
+    Read effective Arrow schema from Parquet file metadata.
 
     Parameters
     ----------
     where : str (filepath) or file-like object
     memory_map : bool, default False
-        Create memory map when the source is a file path
+        Create memory map when the source is a file path.
 
     Returns
     -------

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -263,7 +263,7 @@ class ParquetFile:
 
     def scan_contents(self, columns=None, batch_size=65536):
         """
-        Read contents of file and return the number of rows read.
+        Read contents of file for the given columns and batch size.
 
         Notes
         -----
@@ -527,7 +527,7 @@ class ParquetDatasetPiece:
     open_file_func : callable
         Function to use for obtaining file handle to dataset piece.
     partition_keys : list of tuples
-        In the following structure: [(column name, ordinal index)].
+        Two-element tuples of ``(column name, ordinal index)``.
     row_group : int, default None
         Row group to load. By default, reads all row groups.
     """
@@ -569,7 +569,7 @@ class ParquetDatasetPiece:
 
     def get_metadata(self):
         """
-        Returns the file's metadata.
+        Return the file's metadata.
 
         Returns
         -------
@@ -580,7 +580,7 @@ class ParquetDatasetPiece:
 
     def open(self):
         """
-        Returns instance of ParquetFile.
+        Return instance of ParquetFile.
         """
         reader = self.open_file_func(self.path)
         if not isinstance(reader, ParquetFile):

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -120,7 +120,7 @@ class ParquetFile:
     common_metadata : FileMetaData, default None
         Will be used in reads for pandas schema metadata if not found in the
         main file's metadata, no other uses at the moment
-    memory_map : boolean, default False
+    memory_map : bool, default False
         If the source is a file path, use a memory map to read file, which can
         improve performance in some environments
     buffer_size : int, default 0
@@ -189,9 +189,9 @@ class ParquetFile:
             If not None, only these columns will be read from the row group. A
             column name may be a prefix of a nested field, e.g. 'a' will select
             'a.b', 'a.c', and 'a.d.e'
-        use_threads : boolean, default True
+        use_threads : bool, default True
             Perform multi-threaded column reads
-        use_pandas_metadata : boolean, default False
+        use_pandas_metadata : bool, default False
             If True and file has custom pandas schema metadata, ensure that
             index columns are also loaded
 
@@ -218,9 +218,9 @@ class ParquetFile:
             If not None, only these columns will be read from the row group. A
             column name may be a prefix of a nested field, e.g. 'a' will select
             'a.b', 'a.c', and 'a.d.e'
-        use_threads : boolean, default True
+        use_threads : bool, default True
             Perform multi-threaded column reads
-        use_pandas_metadata : boolean, default False
+        use_pandas_metadata : bool, default False
             If True and file has custom pandas schema metadata, ensure that
             index columns are also loaded
 
@@ -245,9 +245,9 @@ class ParquetFile:
             If not None, only these columns will be read from the file. A
             column name may be a prefix of a nested field, e.g. 'a' will select
             'a.b', 'a.c', and 'a.d.e'
-        use_threads : boolean, default True
+        use_threads : bool, default True
             Perform multi-threaded column reads
-        use_pandas_metadata : boolean, default False
+        use_pandas_metadata : bool, default False
             If True and file has custom pandas schema metadata, ensure that
             index columns are also loaded
 
@@ -358,17 +358,17 @@ _parquet_writer_arg_docs = """version : {"1.0", "2.0"}, default "1.0"
 use_dictionary : bool or list
     Specify if we should use dictionary encoding in general or only for
     some columns.
-use_deprecated_int96_timestamps : boolean, default None
+use_deprecated_int96_timestamps : bool, default None
     Write timestamps to INT96 Parquet format. Defaults to False unless enabled
     by flavor argument. This take priority over the coerce_timestamps option.
-coerce_timestamps : string, default None
+coerce_timestamps : str, default None
     Cast timestamps a particular resolution.
     Valid values: {None, 'ms', 'us'}
 data_page_size : int, default None
     Set a target threshold for the approximate encoded size of data
     pages within a column chunk (in bytes). If None, use the default data page
     size of 1MByte.
-allow_truncated_timestamps : boolean, default False
+allow_truncated_timestamps : bool, default False
     Allow loss of data when coercing timestamps to a particular
     resolution. E.g. if microsecond or nanosecond data is lost when coercing to
     'ms', do not raise an exception
@@ -591,7 +591,7 @@ class ParquetDatasetPiece:
         Parameters
         ----------
         columns : list of column names, default None
-        use_threads : boolean, default True
+        use_threads : bool, default True
             Perform multi-threaded column reads
         partitions : ParquetPartitions, default None
         file : file-like object
@@ -744,9 +744,9 @@ class ParquetPartitions:
         ----------
         level : int
             The nesting level of the partition we are observing
-        name : string
+        name : str
             The partition name
-        key : string or int
+        key : str or int
             The partition value
         """
         if level == len(self.levels):
@@ -960,7 +960,7 @@ read_dictionary : list, default None
     nested types, you must pass the full column "path", which could be
     something like level1.level2.list.item. Refer to the Parquet
     file's schema to obtain the paths.
-memory_map : boolean, default False
+memory_map : bool, default False
     If the source is a file path, use a memory map to read file, which can
     improve performance in some environments
 buffer_size : int, default 0
@@ -986,9 +986,9 @@ metadata : pyarrow.parquet.FileMetaData
 schema : pyarrow.parquet.Schema
     Use schema obtained elsewhere to validate file schemas. Alternative to
     metadata parameter
-split_row_groups : boolean, default False
+split_row_groups : bool, default False
     Divide files into pieces for each row group in the file
-validate_schema : boolean, default True
+validate_schema : bool, default True
     Check that individual file schemas are all the same / compatible
 filters : List[Tuple] or List[List[Tuple]] or None (default)
     List of filters to apply, like ``[[('x', '=', 0), ...], ...]``. This
@@ -1125,7 +1125,7 @@ metadata_nthreads: int, default 1
         ----------
         columns : List[str]
             Names of columns to read from the file
-        use_threads : boolean, default True
+        use_threads : bool, default True
             Perform multi-threaded column reads
         use_pandas_metadata : bool, default False
             Passed through to each dataset piece
@@ -1251,7 +1251,7 @@ columns: list
     If not None, only these columns will be read from the file. A column
     name may be a prefix of a nested field, e.g. 'a' will select 'a.b',
     'a.c', and 'a.d.e'
-use_threads : boolean, default True
+use_threads : bool, default True
     Perform multi-threaded column reads
 metadata : FileMetaData
     If separately computed
@@ -1289,7 +1289,7 @@ def read_table(source, columns=None, use_threads=True, metadata=None,
 read_table.__doc__ = _read_table_docstring.format(
     'Read a Table from Parquet format',
     "\n".join((_read_docstring_common,
-               """use_pandas_metadata : boolean, default False
+               """use_pandas_metadata : bool, default False
     If True and file has custom pandas schema metadata, ensure that
     index columns are also loaded""")),
     """pyarrow.Table
@@ -1402,7 +1402,7 @@ def write_to_dataset(table, root_path, partition_cols=None,
     Parameters
     ----------
     table : pyarrow.Table
-    root_path : string,
+    root_path : str,
         The root directory of the dataset
     filesystem : FileSystem, default None
         If nothing passed, paths assumed to be found in the local on-disk
@@ -1479,9 +1479,9 @@ def write_metadata(schema, where, version='1.0',
     where: string or pyarrow.NativeFile
     version : {"1.0", "2.0"}, default "1.0"
         The Parquet format version, defaults to 1.0
-    use_deprecated_int96_timestamps : boolean, default False
+    use_deprecated_int96_timestamps : bool, default False
         Write nanosecond resolution timestamps to INT96 Parquet format
-    coerce_timestamps : string, default None
+    coerce_timestamps : str, default None
         Cast timestamps a particular resolution.
         Valid values: {None, 'ms', 'us'}
     filesystem : FileSystem, default None
@@ -1501,8 +1501,8 @@ def read_metadata(where, memory_map=False):
 
     Parameters
     ----------
-    where : string (filepath) or file-like object
-    memory_map : boolean, default False
+    where : str (filepath) or file-like object
+    memory_map : bool, default False
         Create memory map when the source is a file path
 
     Returns
@@ -1518,8 +1518,8 @@ def read_schema(where, memory_map=False):
 
     Parameters
     ----------
-    where : string (filepath) or file-like object
-    memory_map : boolean, default False
+    where : str (filepath) or file-like object
+    memory_map : bool, default False
         Create memory map when the source is a file path
 
     Returns

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -21,7 +21,9 @@ from pyarrow.compat import frombytes, pickle
 
 
 def is_named_tuple(cls):
-    """Return True if cls is a namedtuple and False otherwise."""
+    """
+    Return True if cls is a namedtuple and False otherwise.
+    """
     b = cls.__bases__
     if len(b) != 1 or b[0] != tuple:
         return False
@@ -80,7 +82,7 @@ cdef class SerializationContext:
 
     def clone(self):
         """
-        Return copy of this SerializationContext
+        Return copy of this SerializationContext.
 
         Returns
         -------
@@ -99,7 +101,8 @@ cdef class SerializationContext:
 
     def register_type(self, type_, type_id, pickle=False,
                       custom_serializer=None, custom_deserializer=None):
-        r"""EXPERIMENTAL: Add type to the list of types we can serialize.
+        r"""
+        EXPERIMENTAL: Add type to the list of types we can serialize.
 
         Parameters
         ----------
@@ -194,25 +197,25 @@ cdef class SerializationContext:
 
     def serialize(self, obj):
         """
-        Call pyarrow.serialize and pass this SerializationContext
+        Call pyarrow.serialize and pass this SerializationContext.
         """
         return serialize(obj, context=self)
 
     def serialize_to(self, object value, sink):
         """
-        Call pyarrow.serialize_to and pass this SerializationContext
+        Call pyarrow.serialize_to and pass this SerializationContext.
         """
         return serialize_to(value, sink, context=self)
 
     def deserialize(self, what):
         """
-        Call pyarrow.deserialize and pass this SerializationContext
+        Call pyarrow.deserialize and pass this SerializationContext.
         """
         return deserialize(what, context=self)
 
     def deserialize_components(self, what):
         """
-        Call pyarrow.deserialize_components and pass this SerializationContext
+        Call pyarrow.deserialize_components and pass this SerializationContext.
         """
         return deserialize_components(what, context=self)
 
@@ -232,7 +235,7 @@ def _get_default_context():
 
 cdef class SerializedPyObject:
     """
-    Arrow-serialized representation of Python object
+    Arrow-serialized representation of Python object.
     """
     cdef:
         CSerializedPyObject data
@@ -250,7 +253,7 @@ cdef class SerializedPyObject:
 
     def write_to(self, sink):
         """
-        Write serialized object to a sink
+        Write serialized object to a sink.
         """
         cdef shared_ptr[COutputStream] stream
         get_writer(sink, &stream)
@@ -262,7 +265,7 @@ cdef class SerializedPyObject:
 
     def deserialize(self, SerializationContext context=None):
         """
-        Convert back to Python object
+        Convert back to Python object.
         """
         cdef PyObject* result
 
@@ -279,7 +282,7 @@ cdef class SerializedPyObject:
 
     def to_buffer(self, nthreads=1):
         """
-        Write serialized data as Buffer
+        Write serialized data as Buffer.
         """
         cdef Buffer output = allocate_buffer(self.total_bytes)
         sink = FixedSizeBufferWriter(output)
@@ -292,7 +295,7 @@ cdef class SerializedPyObject:
     def from_components(components):
         """
         Reconstruct SerializedPyObject from output of
-        SerializedPyObject.to_components
+        SerializedPyObject.to_components.
         """
         cdef:
             int num_tensors = components['num_tensors']
@@ -319,12 +322,12 @@ cdef class SerializedPyObject:
         """
         Return the decomposed dict representation of the serialized object
         containing a collection of Buffer objects which maximize opportunities
-        for zero-copy
+        for zero-copy.
 
         Parameters
         ----------
         memory_pool : MemoryPool default None
-            Pool to use for necessary allocations
+            Pool to use for necessary allocations.
 
         Returns
 
@@ -339,11 +342,15 @@ cdef class SerializedPyObject:
 
 
 def serialize(object value, SerializationContext context=None):
-    """EXPERIMENTAL: Serialize a general Python sequence for transient storage
-    and transport. This may have better performance and memory efficiency than
-    Python pickle.
+    """
+    EXPERIMENTAL: Serialize a general Python sequence for transient storage
+    and transport.
 
-    Note: this function produces data that is incompatible with the standard
+    This may have better performance and memory efficiency than Python pickle.
+
+    Notes
+    -----
+    This function produces data that is incompatible with the standard
     Arrow IPC binary protocol, i.e. it cannot be used with ipc.open_stream or
     ipc.open_file. You can use deserialize, deserialize_from, or
     deserialize_components to read it.
@@ -354,7 +361,7 @@ def serialize(object value, SerializationContext context=None):
         Python object for the sequence that is to be serialized.
     context : SerializationContext
         Custom serialization and deserialization context, uses a default
-        context with some standard type handlers if not specified
+        context with some standard type handlers if not specified.
 
     Returns
     -------
@@ -373,7 +380,8 @@ def serialize(object value, SerializationContext context=None):
 
 
 def serialize_to(object value, sink, SerializationContext context=None):
-    """EXPERIMENTAL: Serialize a Python sequence to a file.
+    """
+    EXPERIMENTAL: Serialize a Python sequence to a file.
 
     Parameters
     ----------
@@ -383,14 +391,15 @@ def serialize_to(object value, sink, SerializationContext context=None):
         File the sequence will be written to.
     context : SerializationContext
         Custom serialization and deserialization context, uses a default
-        context with some standard type handlers if not specified
+        context with some standard type handlers if not specified.
     """
     serialized = serialize(value, context)
     serialized.write_to(sink)
 
 
 def read_serialized(source, base=None):
-    """EXPERIMENTAL: Read serialized Python sequence from file-like object
+    """
+    EXPERIMENTAL: Read serialized Python sequence from file-like object.
 
     Parameters
     ----------
@@ -416,8 +425,11 @@ def read_serialized(source, base=None):
 
 
 def deserialize_from(source, object base, SerializationContext context=None):
-    """EXPERIMENTAL: Deserialize a Python sequence from a file. This only can
-    interact with data produced by pyarrow.serialize or pyarrow.serialize_to
+    """
+    EXPERIMENTAL: Deserialize a Python sequence from a file.
+
+    This only can interact with data produced by pyarrow.serialize or
+    pyarrow.serialize_to.
 
     Parameters
     ----------
@@ -427,7 +439,7 @@ def deserialize_from(source, object base, SerializationContext context=None):
         This object will be the base object of all the numpy arrays
         contained in the sequence.
     context : SerializationContext
-        Custom serialization and deserialization context
+        Custom serialization and deserialization context.
 
     Returns
     -------
@@ -440,7 +452,7 @@ def deserialize_from(source, object base, SerializationContext context=None):
 
 def deserialize_components(components, SerializationContext context=None):
     """
-    Reconstruct Python object from output of SerializedPyObject.to_components
+    Reconstruct Python object from output of SerializedPyObject.to_components.
 
     Parameters
     ----------
@@ -457,15 +469,18 @@ def deserialize_components(components, SerializationContext context=None):
 
 
 def deserialize(obj, SerializationContext context=None):
-    """EXPERIMENTAL: Deserialize Python object from Buffer or other Python
-    object supporting the buffer protocol. This only can interact with data
-    produced by pyarrow.serialize or pyarrow.serialize_to
+    """
+    EXPERIMENTAL: Deserialize Python object from Buffer or other Python
+    object supporting the buffer protocol.
+
+    This only can interact with data produced by pyarrow.serialize or
+    pyarrow.serialize_to.
 
     Parameters
     ----------
     obj : pyarrow.Buffer or Python object supporting buffer protocol
     context : SerializationContext
-        Custom serialization and deserialization context
+        Custom serialization and deserialization context.
 
     Returns
     -------

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1520,7 +1520,7 @@ cdef class Table(_PandasConvertible):
         Parameters
         ----------
         i : int
-            The index of the columns to retrieve.
+            The index of the column to retrieve.
 
         Returns
         -------
@@ -1609,7 +1609,10 @@ cdef class Table(_PandasConvertible):
 
     def add_column(self, int i, field_, column):
         """
-        Add column to Table at position. Returns new table.
+        Add column to Table at position.
+        
+        A new table is returned with the column added, the original
+        table object is left unchanged.
 
         Parameters
         ----------

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -22,8 +22,8 @@ cdef class ChunkedArray(_PandasConvertible):
     """
     An array-like composed from a (possibly empty) collection of pyarrow.Arrays
 
-    Warning
-    -------
+    Warns
+    -----
     Do not call this class's constructor directly.
     """
 
@@ -395,9 +395,9 @@ def chunked_array(arrays, type=None):
     Parameters
     ----------
     arrays : Array, list of Array, or values coercible to arrays
-        Must all be the same data type. Can be empty only if type also
-        passed
+        Must all be the same data type. Can be empty only if type also passed.
     type : DataType or string coercible to DataType
+
 
     Returns
     -------
@@ -511,8 +511,8 @@ cdef class RecordBatch(_PandasConvertible):
     """
     Batch of rows of columns of equal length
 
-    Warning
-    -------
+    Warns
+    -----
     Do not call this class's constructor directly, use one of the
     ``RecordBatch.from_*`` functions instead.
     """
@@ -670,7 +670,7 @@ cdef class RecordBatch(_PandasConvertible):
 
     def serialize(self, memory_pool=None):
         """
-        Write RecordBatch to Buffer as encapsulated IPC message
+        Write RecordBatch to Buffer as encapsulated IPC message.
 
         Parameters
         ----------
@@ -849,7 +849,8 @@ cdef class RecordBatch(_PandasConvertible):
 
         Parameters
         ----------
-        struct_array: a StructArray.
+        struct_array : StructArray
+            Array to construct the record batch from.
 
         Returns
         -------
@@ -1353,14 +1354,14 @@ cdef class Table(_PandasConvertible):
     @staticmethod
     def from_batches(batches, Schema schema=None):
         """
-        Construct a Table from a sequence or iterator of Arrow RecordBatches
+        Construct a Table from a sequence or iterator of Arrow RecordBatches.
 
         Parameters
         ----------
         batches : sequence or iterator of RecordBatch
-            Sequence of RecordBatch to be converted, all schemas must be equal
+            Sequence of RecordBatch to be converted, all schemas must be equal.
         schema : Schema, default None
-            If not passed, will be inferred from the first RecordBatch
+            If not passed, will be inferred from the first RecordBatch.
 
         Returns
         -------
@@ -1391,14 +1392,13 @@ cdef class Table(_PandasConvertible):
 
     def to_batches(self, max_chunksize=None, **kwargs):
         """
-        Convert Table to list of (contiguous) RecordBatch objects, with maximum
-        chunk size
+        Convert Table to list of (contiguous) RecordBatch objects.
 
         Parameters
         ----------
         max_chunksize : int, default None
             Maximum size for RecordBatch chunks. Individual chunks may be
-            smaller depending on the chunk layout of individual columns
+            smaller depending on the chunk layout of individual columns.
 
         Returns
         -------
@@ -1466,7 +1466,7 @@ cdef class Table(_PandasConvertible):
     @property
     def schema(self):
         """
-        Schema of the table and its columns
+        Schema of the table and its columns.
 
         Returns
         -------
@@ -1481,6 +1481,7 @@ cdef class Table(_PandasConvertible):
         Parameters
         ----------
         i : int or string
+            The index or name of the field to retrieve.
 
         Returns
         -------
@@ -1495,6 +1496,7 @@ cdef class Table(_PandasConvertible):
         Parameters
         ----------
         i : int or string
+            The index or name of the column to retrieve.
 
         Returns
         -------
@@ -1518,6 +1520,7 @@ cdef class Table(_PandasConvertible):
         Parameters
         ----------
         i : int
+            The index of the columns to retrieve.
 
         Returns
         -------
@@ -1531,7 +1534,11 @@ cdef class Table(_PandasConvertible):
 
     def itercolumns(self):
         """
-        Iterator over all columns in their numerical order
+        Iterator over all columns in their numerical order.
+
+        Yields
+        ------
+        pyarrow.ChunkedArray
         """
         for i in range(self.num_columns):
             yield self._column(i)
@@ -1539,7 +1546,7 @@ cdef class Table(_PandasConvertible):
     @property
     def columns(self):
         """
-        List of all columns in numerical order
+        List of all columns in numerical order.
 
         Returns
         -------
@@ -1550,7 +1557,7 @@ cdef class Table(_PandasConvertible):
     @property
     def num_columns(self):
         """
-        Number of columns in this table
+        Number of columns in this table.
 
         Returns
         -------
@@ -1578,11 +1585,12 @@ cdef class Table(_PandasConvertible):
     @property
     def shape(self):
         """
-        Dimensions of the table: (#rows, #columns)
+        Dimensions of the table: (#rows, #columns).
 
         Returns
         -------
         (int, int)
+            Number of rows and number of columns.
         """
         return (self.num_rows, self.num_columns)
 
@@ -1601,7 +1609,22 @@ cdef class Table(_PandasConvertible):
 
     def add_column(self, int i, field_, column):
         """
-        Add column to Table at position. Returns new table
+        Add column to Table at position. Returns new table.
+
+        Parameters
+        ----------
+        i : int
+            Index to place the column at.
+        field_ : str or Field
+            If a string is passed then the type is deduced from the column
+            data.
+        column : Array, list of Array, or values coercible to arrays
+            Column data.
+
+        Returns
+        -------
+        pyarrow.Table :
+            New table with the passed column added.
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -1627,13 +1650,36 @@ cdef class Table(_PandasConvertible):
 
     def append_column(self, field_, column):
         """
-        Append column at end of columns. Returns new table
+        Append column at end of columns.
+
+        Parameters
+        ----------
+        field_ : str or Field
+            If a string is passed then the type is deduced from the column
+            data.
+        column : Array, list of Array, or values coercible to arrays
+            Column data.
+
+        Returns
+        -------
+        pyarrow.Table :
+            New table with the passed column added.
         """
         return self.add_column(self.num_columns, field_, column)
 
     def remove_column(self, int i):
         """
-        Create new Table with the indicated column removed
+        Create new Table with the indicated column removed.
+
+        Parameters
+        ----------
+        i : int
+            Index of column to remove.
+
+        Returns
+        -------
+        pyarrow.Table :
+            New table without the column.
         """
         cdef shared_ptr[CTable] c_table
 
@@ -1644,7 +1690,22 @@ cdef class Table(_PandasConvertible):
 
     def set_column(self, int i, field_, column):
         """
-        Replace column in Table at position. Returns new table
+        Replace column in Table at position.
+
+        Parameters
+        ----------
+        i : int
+            Index to place the column at.
+        field_ : str or Field
+            If a string is passed then the type is deduced from the column
+            data.
+        column : Array, list of Array, or values coercible to arrays
+            Column data.
+
+        Returns
+        -------
+        pyarrow.Table :
+            New table with the passed column set.
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -1678,7 +1739,7 @@ cdef class Table(_PandasConvertible):
 
     def rename_columns(self, names):
         """
-        Create new table with columns renamed to provided names
+        Create new table with columns renamed to provided names.
         """
         cdef:
             shared_ptr[CTable] c_table
@@ -1696,9 +1757,19 @@ cdef class Table(_PandasConvertible):
         """
         Drop one or more columns and return a new table.
 
-        columns: list of str
+        Parameters
+        ----------
+        columns : list of str
+            List of field names referencing existing columns.
 
-        Returns pa.Table
+        Raises
+        ------
+        KeyError : if any of the passed columns name are not existing.
+
+        Returns
+        -------
+        pyarrow.Table :
+            New table without the columns.
         """
         indices = []
         for col in columns:
@@ -1727,7 +1798,7 @@ def _reconstruct_table(arrays, schema):
 def record_batch(data, names=None, schema=None, metadata=None):
     """
     Create a pyarrow.RecordBatch from another Python data structure or sequence
-    of arrays
+    of arrays.
 
     Parameters
     ----------
@@ -1735,10 +1806,10 @@ def record_batch(data, names=None, schema=None, metadata=None):
         A DataFrame or list of arrays or chunked arrays.
     names : list, default None
         Column names if list of arrays passed as data. Mutually exclusive with
-        'schema' argument
+        'schema' argument.
     schema : Schema, default None
         The expected schema of the RecordBatch. If not passed, will be inferred
-        from the data. Mutually exclusive with 'names' argument
+        from the data. Mutually exclusive with 'names' argument.
     metadata : dict or Mapping, default None
         Optional metadata for the schema (if schema not passed).
 
@@ -1766,8 +1837,7 @@ def record_batch(data, names=None, schema=None, metadata=None):
 
 def table(data, names=None, schema=None, metadata=None):
     """
-    Create a pyarrow.Table from another Python data structure or sequence of
-    arrays
+    Create a pyarrow.Table from a Python data structure or sequence of arrays.
 
     Parameters
     ----------
@@ -1841,7 +1911,7 @@ def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
     promote: bool, default False
         If True, concatenate tables with null-filling and null type promotion.
     memory_pool : MemoryPool, default None
-        For memory allocations, if required, otherwise use default pool
+        For memory allocations, if required, otherwise use default pool.
     """
     cdef:
         vector[shared_ptr[CTable]] c_tables

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -167,7 +167,7 @@ cdef class ChunkedArray(_PandasConvertible):
 
         Returns
         -------
-        are_equal : boolean
+        are_equal : bool
         """
         cdef:
             CChunkedArray* this_arr = self.chunked_array
@@ -223,7 +223,7 @@ cdef class ChunkedArray(_PandasConvertible):
         ----------
         target_type : DataType
             Type to cast to
-        safe : boolean, default True
+        safe : bool, default True
             Check for overflows or other unsafe conversions
 
         Returns
@@ -1142,7 +1142,7 @@ cdef class Table(_PandasConvertible):
 
         Returns
         -------
-        are_equal : boolean
+        are_equal : bool
         """
         cdef:
             CTable* this_table = self.table
@@ -1165,7 +1165,7 @@ cdef class Table(_PandasConvertible):
         ----------
         target_schema : Schema
             Schema to cast to, the names and order of fields must match
-        safe : boolean, default True
+        safe : bool, default True
             Check for overflows or other unsafe conversions
 
         Returns
@@ -1228,7 +1228,7 @@ cdef class Table(_PandasConvertible):
             indicated number of threads
         columns : list, optional
            List of column to be converted. If None, use all columns.
-        safe : boolean, default True
+        safe : bool, default True
            Check for overflows or other unsafe conversions
 
         Returns
@@ -1908,6 +1908,7 @@ def concat_tables(tables, c_bool promote=False, MemoryPool memory_pool=None):
     Parameters
     ----------
     tables : iterable of pyarrow.Table objects
+        Pyarrow tables to concatenate into a single Table.
     promote: bool, default False
         If True, concatenate tables with null-filling and null type promotion.
     memory_pool : MemoryPool, default None

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -22,8 +22,8 @@ cdef class ChunkedArray(_PandasConvertible):
     """
     An array-like composed from a (possibly empty) collection of pyarrow.Arrays
 
-    Warns
-    -----
+    Warnings
+    --------
     Do not call this class's constructor directly.
     """
 
@@ -159,11 +159,12 @@ cdef class ChunkedArray(_PandasConvertible):
 
     def equals(self, ChunkedArray other):
         """
-        Return whether the contents of two chunked arrays are equal
+        Return whether the contents of two chunked arrays are equal.
 
         Parameters
         ----------
         other : pyarrow.ChunkedArray
+            Chunked array to compare against.
 
         Returns
         -------
@@ -511,8 +512,8 @@ cdef class RecordBatch(_PandasConvertible):
     """
     Batch of rows of columns of equal length
 
-    Warns
-    -----
+    Warnings
+    --------
     Do not call this class's constructor directly, use one of the
     ``RecordBatch.from_*`` functions instead.
     """
@@ -1132,11 +1133,12 @@ cdef class Table(_PandasConvertible):
 
     def equals(self, Table other, bint check_metadata=False):
         """
-        Check if contents of two tables are equal
+        Check if contents of two tables are equal.
 
         Parameters
         ----------
         other : pyarrow.Table
+            Table to compare against.
         check_metadata : bool, default False
             Whether schema metadata equality should be checked as well.
 
@@ -1610,9 +1612,9 @@ cdef class Table(_PandasConvertible):
     def add_column(self, int i, field_, column):
         """
         Add column to Table at position.
-        
-        A new table is returned with the column added, the original
-        table object is left unchanged.
+
+        A new table is returned with the column added, the original table
+        object is left unchanged.
 
         Parameters
         ----------
@@ -1626,8 +1628,7 @@ cdef class Table(_PandasConvertible):
 
         Returns
         -------
-        pyarrow.Table :
-            New table with the passed column added.
+        pyarrow.Table : New table with the passed column added.
         """
         cdef:
             shared_ptr[CTable] c_table

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -210,7 +210,7 @@ shape: {0.shape}""".format(self)
     @staticmethod
     def from_pydata_sparse(obj, dim_names=None):
         """
-        Convert pydata/sparse.COO to arrow::SparseCOOTensor
+        Convert pydata/sparse.COO to arrow::SparseCOOTensor.
         """
         import sparse
         if not isinstance(obj, sparse.COO):
@@ -237,7 +237,7 @@ shape: {0.shape}""".format(self)
     @staticmethod
     def from_tensor(obj):
         """
-        Convert arrow::Tensor to arrow::SparseCOOTensor
+        Convert arrow::Tensor to arrow::SparseCOOTensor.
         """
         cdef shared_ptr[CSparseCOOTensor] csparse_tensor
         cdef shared_ptr[CTensor] ctensor = pyarrow_unwrap_tensor(obj)
@@ -249,7 +249,7 @@ shape: {0.shape}""".format(self)
 
     def to_numpy(self):
         """
-        Convert arrow::SparseCOOTensor to numpy.ndarrays with zero copy
+        Convert arrow::SparseCOOTensor to numpy.ndarrays with zero copy.
         """
         cdef PyObject* out_data
         cdef PyObject* out_coords
@@ -260,7 +260,7 @@ shape: {0.shape}""".format(self)
 
     def to_scipy(self):
         """
-        Convert arrow::SparseCOOTensor to scipy.sparse.coo_matrix
+        Convert arrow::SparseCOOTensor to scipy.sparse.coo_matrix.
         """
         from scipy.sparse import coo_matrix
         cdef PyObject* out_data
@@ -276,7 +276,7 @@ shape: {0.shape}""".format(self)
 
     def to_pydata_sparse(self):
         """
-        Convert arrow::SparseCOOTensor to pydata/sparse.COO
+        Convert arrow::SparseCOOTensor to pydata/sparse.COO.
         """
         from sparse import COO
         cdef PyObject* out_data
@@ -291,7 +291,7 @@ shape: {0.shape}""".format(self)
 
     def to_tensor(self):
         """
-        Convert arrow::SparseCOOTensor to arrow::Tensor
+        Convert arrow::SparseCOOTensor to arrow::Tensor.
         """
 
         cdef shared_ptr[CTensor] ctensor
@@ -301,7 +301,7 @@ shape: {0.shape}""".format(self)
 
     def equals(self, SparseCOOTensor other):
         """
-        Return true if sparse tensors contains exactly equal data
+        Return true if sparse tensors contains exactly equal data.
         """
         return self.stp.Equals(deref(other.stp))
 
@@ -400,7 +400,7 @@ shape: {0.shape}""".format(self)
     @staticmethod
     def from_scipy(obj, dim_names=None):
         """
-        Convert scipy.sparse.csr_matrix to arrow::SparseCSRMatrix
+        Convert scipy.sparse.csr_matrix to arrow::SparseCSRMatrix.
         """
         import scipy.sparse
         if not isinstance(obj, scipy.sparse.csr_matrix):
@@ -430,7 +430,7 @@ shape: {0.shape}""".format(self)
     @staticmethod
     def from_tensor(obj):
         """
-        Convert arrow::Tensor to arrow::SparseCSRMatrix
+        Convert arrow::Tensor to arrow::SparseCSRMatrix.
         """
         cdef shared_ptr[CSparseCSRMatrix] csparse_tensor
         cdef shared_ptr[CTensor] ctensor = pyarrow_unwrap_tensor(obj)
@@ -442,7 +442,7 @@ shape: {0.shape}""".format(self)
 
     def to_numpy(self):
         """
-        Convert arrow::SparseCSRMatrix to numpy.ndarrays with zero copy
+        Convert arrow::SparseCSRMatrix to numpy.ndarrays with zero copy.
         """
         cdef PyObject* out_data
         cdef PyObject* out_indptr
@@ -456,7 +456,7 @@ shape: {0.shape}""".format(self)
 
     def to_scipy(self):
         """
-        Convert arrow::SparseCSRMatrix to scipy.sparse.csr_matrix
+        Convert arrow::SparseCSRMatrix to scipy.sparse.csr_matrix.
         """
         from scipy.sparse import csr_matrix
         cdef PyObject* out_data
@@ -475,9 +475,8 @@ shape: {0.shape}""".format(self)
 
     def to_tensor(self):
         """
-        Convert arrow::SparseCSRMatrix to arrow::Tensor
+        Convert arrow::SparseCSRMatrix to arrow::Tensor.
         """
-
         cdef shared_ptr[CTensor] ctensor
         with nogil:
             check_status(self.stp.ToTensor(&ctensor))
@@ -486,7 +485,7 @@ shape: {0.shape}""".format(self)
 
     def equals(self, SparseCSRMatrix other):
         """
-        Return true if sparse tensors contains exactly equal data
+        Return true if sparse tensors contains exactly equal data.
         """
         return self.stp.Equals(deref(other.stp))
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1594,9 +1594,9 @@ def tzinfo_to_string(tz):
 
 def string_to_tzinfo(name):
     """
-    Converts a time zone name into a time zone object.
+    Convert a time zone name into a time zone object.
 
-    Supported formats:
+    Supported input strings are:
     * As used in the Olson time zone database (the "tz database" or
       "tzdata"), such as "America/New_York"
     * An absolute time zone offset of the form +XX:XX or -XX:XX, such as +07:30

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1411,10 +1411,14 @@ def field(name, type, bint nullable=True, metadata=None):
     Parameters
     ----------
     name : string or bytes
+        Name of the field.
     type : pyarrow.DataType
+        Arrow datatype of the field.
     nullable : boolean, default True
+        Whether the field's values are nullable.
     metadata : dict, default None
-        Keys and values must be coercible to bytes.
+        Optional field metadata, the keys and values must be coercible to
+        bytes.
 
     Returns
     -------
@@ -2033,26 +2037,31 @@ def struct(fields):
     """
     Create StructType instance from fields.
 
+    A struct is a nested type parameterized by an ordered sequence of types
+    (which can all be distinct), called its fields.
+
     Parameters
     ----------
     fields : iterable of Fields or tuples, or mapping of strings to DataTypes
+        Each field must have a UTF8-encoded name, and these field names are
+        part of the type metadata.
 
     Examples
     --------
-    ::
-
-        import pyarrow as pa
-        fields = [
-            ('f1', pa.int32()),
-            ('f2', pa.string()),
-        ]
-        struct_type = pa.struct(fields)
-
-        fields = [
-            pa.field('f1', pa.int32()),
-            pa.field('f2', pa.string(), nullable=false),
-        ]
-        struct_type = pa.struct(fields)
+    >>> import pyarrow as pa
+    >>> fields = [
+    ...     ('f1', pa.int32()),
+    ...     ('f2', pa.string()),
+    ... ]
+    >>> struct_type = pa.struct(fields)
+    >>> struct_type
+    StructType(struct<f1: int32, f2: string>)
+    >>> fields = [
+    ...     pa.field('f1', pa.int32()),
+    ...     pa.field('f2', pa.string(), nullable=False),
+    ... ]
+    >>> pa.struct(fields)
+    StructType(struct<f1: int32, f2: string not null>)
 
     Returns
     -------
@@ -2081,11 +2090,16 @@ def union(children_fields, mode, type_codes=None):
     """
     Create UnionType from children fields.
 
+    A union is defined by an ordered sequence of types; each slot in the union
+    can have a value chosen from these types.
+
     Parameters
     ----------
     fields : sequence of Field values
+        Each field must have a UTF8-encoded name, and these field names are
+        part of the type metadata.
     mode : str
-        'dense' or 'sparse'
+        Either 'dense' or 'sparse'.
     type_codes : list of integers, default None
 
     Returns
@@ -2230,14 +2244,19 @@ def schema(fields, metadata=None):
 
     Examples
     --------
-    ::
-
-        import pyarrow as pa
-        fields = [
-            ('some_int', pa.int32()),
-            ('some_string', pa.string()),
-        ]
-        schema = pa.schema(fields)
+    >>> import pyarrow as pa
+    >>> pa.schema([
+    ...     ('some_int', pa.int32()),
+    ...     ('some_string', pa.string())
+    ... ])
+    some_int: int32
+    some_string: string
+    >>> pa.schema([
+    ...     pa.field('some_int', pa.int32()),
+    ...     pa.field('some_string', pa.string())
+    ... ])
+    some_int: int32
+    some_string: string
 
     Returns
     -------

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -172,7 +172,7 @@ cdef class DataType:
 
         Returns
         -------
-        is_equal : boolean
+        is_equal : bool
         """
         cdef DataType other_type
 
@@ -840,7 +840,7 @@ cdef class Field:
 
         Returns
         -------
-        is_equal : boolean
+        is_equal : bool
         """
         return self.field.Equals(deref(other.field), check_metadata)
 
@@ -1057,7 +1057,7 @@ cdef class Schema:
 
         Returns
         -------
-        is_equal : boolean
+        is_equal : bool
         """
         return self.sp_schema.get().Equals(deref(other.schema),
                                            check_metadata)
@@ -1410,11 +1410,11 @@ def field(name, type, bint nullable=True, metadata=None):
 
     Parameters
     ----------
-    name : string or bytes
+    name : str or bytes
         Name of the field.
     type : pyarrow.DataType
         Arrow datatype of the field.
-    nullable : boolean, default True
+    nullable : bool, default True
         Whether the field's values are nullable.
     metadata : dict, default None
         Optional field metadata, the keys and values must be coercible to
@@ -1561,7 +1561,7 @@ def tzinfo_to_string(tz):
 
     Returns
     -------
-      name : string
+      name : str
         Time zone name
     """
     import pytz
@@ -1626,10 +1626,10 @@ def timestamp(unit, tz=None):
 
     Parameters
     ----------
-    unit : string
+    unit : str
         one of 's' [second], 'ms' [millisecond], 'us' [microsecond], or 'ns'
         [nanosecond]
-    tz : string, default None
+    tz : str, default None
         Time zone name. None indicates time zone naive
 
     Examples
@@ -1681,7 +1681,7 @@ def time32(unit):
 
     Parameters
     ----------
-    unit : string
+    unit : str
         one of 's' [second], or 'ms' [millisecond]
 
     Examples
@@ -1719,7 +1719,7 @@ def time64(unit):
 
     Parameters
     ----------
-    unit : string
+    unit : str
         one of 'us' [microsecond], or 'ns' [nanosecond]
 
     Examples
@@ -1757,7 +1757,7 @@ def duration(unit):
 
     Parameters
     ----------
-    unit : string
+    unit : str
         one of 's' [second], 'ms' [millisecond], 'us' [microsecond], or 'ns'
         [nanosecond]
 
@@ -1986,7 +1986,7 @@ cpdef MapType map_(key_type, item_type, keys_sorted=False):
     ----------
     key_type : DataType
     item_type : DataType
-    keys_sorted : boolean
+    keys_sorted : bool
 
     Returns
     -------
@@ -2012,7 +2012,7 @@ cpdef DictionaryType dictionary(index_type, value_type, bint ordered=False):
     ----------
     index_type : DataType
     value_type : DataType
-    ordered : boolean
+    ordered : bool
 
     Returns
     -------

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1594,16 +1594,17 @@ def tzinfo_to_string(tz):
 
 def string_to_tzinfo(name):
     """
-    Converts a string indicating the name of a time zone into a time zone
-    object, one of:
+    Converts a time zone name into a time zone object.
+
+    Supported formats:
     * As used in the Olson time zone database (the "tz database" or
       "tzdata"), such as "America/New_York"
     * An absolute time zone offset of the form +XX:XX or -XX:XX, such as +07:30
 
     Parameters
     ----------
-      name: string
-        Time zone name
+      name: str
+        Time zone name.
 
     Returns
     -------
@@ -1634,10 +1635,13 @@ def timestamp(unit, tz=None):
 
     Examples
     --------
-    ::
-
-        t1 = pa.timestamp('us')
-        t2 = pa.timestamp('s', tz='America/New_York')
+    >>> import pyarrow as pa
+    >>> pa.timestamp('us')
+    TimestampType(timestamp[us])
+    >>> pa.timestamp('s', tz='America/New_York')
+    TimestampType(timestamp[s, tz=America/New_York])
+    >>> pa.timestamp('s', tz='+07:30')
+    TimestampType(timestamp[s, tz=+07:30])
 
     Returns
     -------
@@ -1684,12 +1688,17 @@ def time32(unit):
     unit : str
         one of 's' [second], or 'ms' [millisecond]
 
+    Returns
+    -------
+    type : pyarrow.Time32Type
+
     Examples
     --------
-    ::
-
-        t1 = pa.time32('s')
-        t2 = pa.time32('ms')
+    >>> import pyarrow as pa
+    >>> pa.time32('s')
+    Time32Type(time32[s])
+    >>> pa.time32('ms')
+    Time32Type(time32[ms])
     """
     cdef:
         TimeUnit unit_code
@@ -1720,14 +1729,19 @@ def time64(unit):
     Parameters
     ----------
     unit : str
-        one of 'us' [microsecond], or 'ns' [nanosecond]
+        One of 'us' [microsecond], or 'ns' [nanosecond].
+
+    Returns
+    -------
+    type : pyarrow.Time64Type
 
     Examples
     --------
-    ::
-
-        t1 = pa.time64('us')
-        t2 = pa.time64('ns')
+    >>> import pyarrow as pa
+    >>> pa.time64('us')
+    Time64Type(time64[us])
+    >>> pa.time64('ns')
+    Time64Type(time64[ns])
     """
     cdef:
         TimeUnit unit_code
@@ -1758,15 +1772,20 @@ def duration(unit):
     Parameters
     ----------
     unit : str
-        one of 's' [second], 'ms' [millisecond], 'us' [microsecond], or 'ns'
-        [nanosecond]
+        One of 's' [second], 'ms' [millisecond], 'us' [microsecond], or
+        'ns' [nanosecond].
+
+    Returns
+    -------
+    type : pyarrow.DurationType
 
     Examples
     --------
-    ::
-
-        t1 = pa.duration('us')
-        t2 = pa.duration('s')
+    >>> import pyarrow as pa
+    >>> pa.duration('us')
+    DurationType(duration[us])
+    >>> pa.duration('s')
+    DurationType(duration[s])
     """
     cdef:
         TimeUnit unit_code

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -140,7 +140,7 @@ cdef class DataType:
     def num_buffers(self):
         """
         Number of data buffers required to construct Array type
-        excluding children
+        excluding children.
         """
         return self.type.layout().buffers.size()
 
@@ -164,7 +164,7 @@ cdef class DataType:
 
     def equals(self, other):
         """
-        Return true if type is equivalent to passed value
+        Return true if type is equivalent to passed value.
 
         Parameters
         ----------
@@ -212,7 +212,7 @@ cdef class DataType:
 
 cdef class DictionaryMemo:
     """
-    Tracking container for dictionary-encoded fields
+    Tracking container for dictionary-encoded fields.
     """
     def __cinit__(self):
         self.sp_memo.reset(new CDictionaryMemo())
@@ -249,8 +249,9 @@ cdef class DictionaryType(DataType):
     @property
     def value_type(self):
         """
-        The dictionary value type. The dictionary values are found in an
-        instance of DictionaryArray
+        The dictionary value type.
+
+        The dictionary values are found in an instance of DictionaryArray.
         """
         return pyarrow_wrap_data_type(self.dict_type.value_type())
 
@@ -444,7 +445,7 @@ cdef class UnionType(DataType):
 
     def __len__(self):
         """
-        Like num_children()
+        Like num_children().
         """
         return self.type.num_children()
 
@@ -1405,7 +1406,7 @@ cdef DataType primitive_type(Type type):
 
 def field(name, type, bint nullable=True, metadata=None):
     """
-    Create a pyarrow.Field instance
+    Create a pyarrow.Field instance.
 
     Parameters
     ----------
@@ -1413,7 +1414,7 @@ def field(name, type, bint nullable=True, metadata=None):
     type : pyarrow.DataType
     nullable : boolean, default True
     metadata : dict, default None
-        Keys and values must be coercible to bytes
+        Keys and values must be coercible to bytes.
 
     Returns
     -------
@@ -1454,70 +1455,70 @@ cdef set PRIMITIVE_TYPES = set([
 
 def null():
     """
-    Create instance of null type
+    Create instance of null type.
     """
     return primitive_type(_Type_NA)
 
 
 def bool_():
     """
-    Create instance of boolean type
+    Create instance of boolean type.
     """
     return primitive_type(_Type_BOOL)
 
 
 def uint8():
     """
-    Create instance of unsigned int8 type
+    Create instance of unsigned int8 type.
     """
     return primitive_type(_Type_UINT8)
 
 
 def int8():
     """
-    Create instance of signed int8 type
+    Create instance of signed int8 type.
     """
     return primitive_type(_Type_INT8)
 
 
 def uint16():
     """
-    Create instance of unsigned uint16 type
+    Create instance of unsigned uint16 type.
     """
     return primitive_type(_Type_UINT16)
 
 
 def int16():
     """
-    Create instance of signed int16 type
+    Create instance of signed int16 type.
     """
     return primitive_type(_Type_INT16)
 
 
 def uint32():
     """
-    Create instance of unsigned uint32 type
+    Create instance of unsigned uint32 type.
     """
     return primitive_type(_Type_UINT32)
 
 
 def int32():
     """
-    Create instance of signed int32 type
+    Create instance of signed int32 type.
     """
     return primitive_type(_Type_INT32)
 
 
 def uint64():
     """
-    Create instance of unsigned uint64 type
+    Create instance of unsigned uint64 type.
     """
     return primitive_type(_Type_UINT64)
 
 
 def int64():
     """
-    Create instance of signed int64 type
+    Create instance of signed int64 type.
     """
     return primitive_type(_Type_INT64)
 
@@ -1617,7 +1618,7 @@ def string_to_tzinfo(name):
 
 def timestamp(unit, tz=None):
     """
-    Create instance of timestamp type with resolution and optional time zone
+    Create instance of timestamp type with resolution and optional time zone.
 
     Parameters
     ----------
@@ -1672,7 +1673,7 @@ def timestamp(unit, tz=None):
 
 def time32(unit):
     """
-    Create instance of 32-bit time (time of day) type with unit resolution
+    Create instance of 32-bit time (time of day) type with unit resolution.
 
     Parameters
     ----------
@@ -1710,7 +1711,7 @@ def time32(unit):
 
 def time64(unit):
     """
-    Create instance of 64-bit time (time of day) type with unit resolution
+    Create instance of 64-bit time (time of day) type with unit resolution.
 
     Parameters
     ----------
@@ -1790,42 +1791,42 @@ def duration(unit):
 
 def date32():
     """
-    Create instance of 32-bit date (days since UNIX epoch 1970-01-01)
+    Create instance of 32-bit date (days since UNIX epoch 1970-01-01).
     """
     return primitive_type(_Type_DATE32)
 
 
 def date64():
     """
-    Create instance of 64-bit date (milliseconds since UNIX epoch 1970-01-01)
+    Create instance of 64-bit date (milliseconds since UNIX epoch 1970-01-01).
     """
     return primitive_type(_Type_DATE64)
 
 
 def float16():
     """
-    Create half-precision floating point type
+    Create half-precision floating point type.
     """
     return primitive_type(_Type_HALF_FLOAT)
 
 
 def float32():
     """
-    Create single-precision floating point type
+    Create single-precision floating point type.
     """
     return primitive_type(_Type_FLOAT)
 
 
 def float64():
     """
-    Create double-precision floating point type
+    Create double-precision floating point type.
     """
     return primitive_type(_Type_DOUBLE)
 
 
 cpdef DataType decimal128(int precision, int scale=0):
     """
-    Create decimal type with precision and scale and 128bit width
+    Create decimal type with precision and scale and 128bit width.
 
     Parameters
     ----------
@@ -1845,21 +1846,21 @@ cpdef DataType decimal128(int precision, int scale=0):
 
 def string():
     """
-    Create UTF8 variable-length string type
+    Create UTF8 variable-length string type.
     """
     return primitive_type(_Type_STRING)
 
 
 def utf8():
     """
-    Alias for string()
+    Alias for string().
     """
     return string()
 
 
 def binary(int length=-1):
     """
-    Create variable-length binary type
+    Create variable-length binary type.
 
     Parameters
     ----------
@@ -1878,7 +1879,7 @@ def binary(int length=-1):
 
 def large_binary():
     """
-    Create large variable-length binary type
+    Create large variable-length binary type.
 
     This data type may not be supported by all Arrow implementations.  Unless
     you need to represent data larger than 2GB, you should prefer binary().
@@ -1888,7 +1889,7 @@ def large_binary():
 
 def large_string():
     """
-    Create large UTF8 variable-length string type
+    Create large UTF8 variable-length string type.
 
     This data type may not be supported by all Arrow implementations.  Unless
     you need to represent data larger than 2GB, you should prefer string().
@@ -1898,14 +1899,14 @@ def large_string():
 
 def large_utf8():
     """
-    Alias for large_string()
+    Alias for large_string().
     """
     return large_string()
 
 
 def list_(value_type, int list_size=-1):
     """
-    Create ListType instance from child data type or field
+    Create ListType instance from child data type or field.
 
     Parameters
     ----------
@@ -1941,7 +1942,7 @@ def list_(value_type, int list_size=-1):
 
 cpdef LargeListType large_list(value_type):
     """
-    Create LargeListType instance from child data type or field
+    Create LargeListType instance from child data type or field.
 
     This data type may not be supported by all Arrow implementations.
     Unless you need to represent data larger than 2**31 elements, you should
@@ -1975,7 +1976,7 @@ cpdef LargeListType large_list(value_type):
 
 cpdef MapType map_(key_type, item_type, keys_sorted=False):
     """
-    Create MapType instance from key and item data types
+    Create MapType instance from key and item data types.
 
     Parameters
     ----------
@@ -2001,7 +2002,7 @@ cpdef MapType map_(key_type, item_type, keys_sorted=False):
 
 cpdef DictionaryType dictionary(index_type, value_type, bint ordered=False):
     """
-    Dictionary (categorical, or simply encoded) type
+    Dictionary (categorical, or simply encoded) type.
 
     Parameters
     ----------
@@ -2030,7 +2031,7 @@ cpdef DictionaryType dictionary(index_type, value_type, bint ordered=False):
 
 def struct(fields):
     """
-    Create StructType instance from fields
+    Create StructType instance from fields.
 
     Parameters
     ----------
@@ -2189,7 +2190,7 @@ cdef dict _type_aliases = {
 
 def type_for_alias(name):
     """
-    Return DataType given a string alias if one exists
+    Return DataType given a string alias if one exists.
 
     Returns
     -------
@@ -2219,13 +2220,13 @@ cdef DataType ensure_type(object ty, c_bool allow_none=False):
 
 def schema(fields, metadata=None):
     """
-    Construct pyarrow.Schema from collection of fields
+    Construct pyarrow.Schema from collection of fields.
 
     Parameters
     ----------
     field : iterable of Fields or tuples, or mapping of strings to DataTypes
     metadata : dict, default None
-        Keys and values must be coercible to bytes
+        Keys and values must be coercible to bytes.
 
     Examples
     --------
@@ -2275,7 +2276,7 @@ def schema(fields, metadata=None):
 
 def from_numpy_dtype(object dtype):
     """
-    Convert NumPy dtype to pyarrow.DataType
+    Convert NumPy dtype to pyarrow.DataType.
     """
     cdef shared_ptr[CDataType] c_type
     dtype = np.dtype(dtype)

--- a/python/pyarrow/types.py
+++ b/python/pyarrow/types.py
@@ -41,294 +41,295 @@ _NESTED_TYPES = {lib.Type_LIST, lib.Type_LARGE_LIST, lib.Type_STRUCT,
 
 def is_null(t):
     """
-    Check that True if value is an instance of a null type.
+    Return True if value is an instance of a null type.
     """
     return t.id == lib.Type_NA
 
 
 def is_boolean(t):
     """
-    Check that the value is an instance of a boolean type.
+    Return True if value is an instance of a boolean type.
     """
     return t.id == lib.Type_BOOL
 
 
 def is_integer(t):
     """
-    Check that the value is an instance of any integer type.
+    Return True if value is an instance of any integer type.
     """
     return t.id in _INTEGER_TYPES
 
 
 def is_signed_integer(t):
     """
-    Check that the value is an instance of any signed integer type.
+    Return True if value is an instance of any signed integer type.
     """
     return t.id in _SIGNED_INTEGER_TYPES
 
 
 def is_unsigned_integer(t):
     """
-    Check that the value is an instance of any unsigned integer type.
+    Return True if value is an instance of any unsigned integer type.
     """
     return t.id in _UNSIGNED_INTEGER_TYPES
 
 
 def is_int8(t):
     """
-    Check that the value is an instance of an int8 type.
+    Return True if value is an instance of an int8 type.
     """
     return t.id == lib.Type_INT8
 
 
 def is_int16(t):
     """
-    Check that the value is an instance of an int16 type.
+    Return True if value is an instance of an int16 type.
     """
     return t.id == lib.Type_INT16
 
 
 def is_int32(t):
     """
-    Check that the value is an instance of an int32 type.
+    Return True if value is an instance of an int32 type.
     """
     return t.id == lib.Type_INT32
 
 
 def is_int64(t):
     """
-    Check that the value is an instance of an int64 type.
+    Return True if value is an instance of an int64 type.
     """
     return t.id == lib.Type_INT64
 
 
 def is_uint8(t):
     """
-    Check that the value is an instance of an uint8 type.
+    Return True if value is an instance of an uint8 type.
     """
     return t.id == lib.Type_UINT8
 
 
 def is_uint16(t):
     """
-    Check that the value is an instance of an uint16 type.
+    Return True if value is an instance of an uint16 type.
     """
     return t.id == lib.Type_UINT16
 
 
 def is_uint32(t):
     """
-    Check that the value is an instance of an uint32 type.
+    Return True if value is an instance of an uint32 type.
     """
     return t.id == lib.Type_UINT32
 
 
 def is_uint64(t):
     """
-    Check that the value is an instance of an uint64 type.
+    Return True if value is an instance of an uint64 type.
     """
     return t.id == lib.Type_UINT64
 
 
 def is_floating(t):
     """
-    Check that the value is an instance of a floating point numeric type.
+    Return True if value is an instance of a floating point numeric type.
     """
     return t.id in _FLOATING_TYPES
 
 
 def is_float16(t):
     """
-    Check that the value is an instance of a float16 (half-precision) type.
+    Return True if value is an instance of a float16 (half-precision) type.
     """
     return t.id == lib.Type_HALF_FLOAT
 
 
 def is_float32(t):
     """
-    Check that the value is an instance of a float32 (single precision) type.
+    Return True if value is an instance of a float32 (single precision) type.
     """
     return t.id == lib.Type_FLOAT
 
 
 def is_float64(t):
     """
-    Check that the value is an instance of a float64 (double precision) type.
+    Return True if value is an instance of a float64 (double precision) type.
     """
     return t.id == lib.Type_DOUBLE
 
 
 def is_list(t):
     """
-    Check that the value is an instance of a list type.
+    Return True if value is an instance of a list type.
     """
     return t.id == lib.Type_LIST
 
 
 def is_large_list(t):
     """
-    Check that the value is an instance of a large list type.
+    Return True if value is an instance of a large list type.
     """
     return t.id == lib.Type_LARGE_LIST
 
 
 def is_fixed_size_list(t):
     """
-    Check that the value is an instance of a fixed size list type.
+    Return True if value is an instance of a fixed size list type.
     """
     return t.id == lib.Type_FIXED_SIZE_LIST
 
 
 def is_struct(t):
     """
-    Check that the value is an instance of a struct type.
+    Return True if value is an instance of a struct type.
     """
     return t.id == lib.Type_STRUCT
 
 
 def is_union(t):
     """
-    Check that the value is an instance of a union type.
+    Return True if value is an instance of a union type.
     """
     return t.id == lib.Type_UNION
 
 
 def is_nested(t):
     """
-    Check that the value is an instance of a nested type.
+    Return True if value is an instance of a nested type.
     """
     return t.id in _NESTED_TYPES
 
 
 def is_temporal(t):
     """
-    Check that the value is an instance of a date, time, timestamp or duration.
+    Return True if value is an instance of date, time, timestamp or duration.
     """
     return t.id in _TEMPORAL_TYPES
 
 
 def is_timestamp(t):
     """
-    Check that the value is an instance of a timestamp type.
+    Return True if value is an instance of a timestamp type.
     """
     return t.id == lib.Type_TIMESTAMP
 
 
 def is_duration(t):
     """
-    Check that the value is an instance of a duration type.
+    Return True if value is an instance of a duration type.
     """
     return t.id == lib.Type_DURATION
 
 
 def is_time(t):
     """
-    Check that the value is an instance of a time type.
+    Return True if value is an instance of a time type.
     """
     return t.id in _TIME_TYPES
 
 
 def is_time32(t):
     """
-    Check that the value is an instance of a time32 type.
+    Return True if value is an instance of a time32 type.
     """
     return t.id == lib.Type_TIME32
 
 
 def is_time64(t):
     """
-    Check that the value is an instance of a time64 type.
+    Return True if value is an instance of a time64 type.
     """
     return t.id == lib.Type_TIME64
 
 
 def is_binary(t):
     """
-    Check that the value is an instance of a variable-length binary type.
+    Return True if value is an instance of a variable-length binary type.
     """
     return t.id == lib.Type_BINARY
 
 
 def is_large_binary(t):
     """
-    Check that the value is an instance of a large variable-length binary type.
+    Return True if value is an instance of a large variable-length
+    binary type.
     """
     return t.id == lib.Type_LARGE_BINARY
 
 
 def is_unicode(t):
     """
-    Alias for is_string
+    Alias for is_string.
     """
     return is_string(t)
 
 
 def is_string(t):
     """
-    Check that the value is an instance of string (utf8 unicode) type.
+    Return True if value is an instance of string (utf8 unicode) type.
     """
     return t.id == lib.Type_STRING
 
 
 def is_large_unicode(t):
     """
-    Alias for is_large_string
+    Alias for is_large_string.
     """
     return is_large_string(t)
 
 
 def is_large_string(t):
     """
-    Check that the value is an instance of large string (utf8 unicode) type.
+    Return True if value is an instance of large string (utf8 unicode) type.
     """
     return t.id == lib.Type_LARGE_STRING
 
 
 def is_fixed_size_binary(t):
     """
-    Check that the value is an instance of a fixed size binary type.
+    Return True if value is an instance of a fixed size binary type.
     """
     return t.id == lib.Type_FIXED_SIZE_BINARY
 
 
 def is_date(t):
     """
-    Check that the value is an instance of a date type.
+    Return True if value is an instance of a date type.
     """
     return t.id in _DATE_TYPES
 
 
 def is_date32(t):
     """
-    Check that the value is an instance of a date32 (days) type.
+    Return True if value is an instance of a date32 (days) type.
     """
     return t.id == lib.Type_DATE32
 
 
 def is_date64(t):
     """
-    Check that the value is an instance of a date64 (milliseconds) type.
+    Return True if value is an instance of a date64 (milliseconds) type.
     """
     return t.id == lib.Type_DATE64
 
 
 def is_map(t):
     """
-    Check that the value is an instance of a map logical type.
+    Return True if value is an instance of a map logical type.
     """
     return t.id == lib.Type_MAP
 
 
 def is_decimal(t):
     """
-    Check that the value is an instance of a decimal type.
+    Return True if value is an instance of a decimal type.
     """
     return t.id == lib.Type_DECIMAL
 
 
 def is_dictionary(t):
     """
-    Check that the value is an instance of a dictionary-encoded type.
+    Return True if value is an instance of a dictionary-encoded type.
     """
     return t.id == lib.Type_DICTIONARY
 

--- a/python/pyarrow/types.py
+++ b/python/pyarrow/types.py
@@ -41,219 +41,217 @@ _NESTED_TYPES = {lib.Type_LIST, lib.Type_LARGE_LIST, lib.Type_STRUCT,
 
 def is_null(t):
     """
-    Return True if value is an instance of a null type
+    Check that True if value is an instance of a null type.
     """
     return t.id == lib.Type_NA
 
 
 def is_boolean(t):
     """
-    Return True if value is an instance of a boolean type
+    Check that the value is an instance of a boolean type.
     """
     return t.id == lib.Type_BOOL
 
 
 def is_integer(t):
     """
-    Return True if value is an instance of any integer type
+    Check that the value is an instance of any integer type.
     """
     return t.id in _INTEGER_TYPES
 
 
 def is_signed_integer(t):
     """
-    Return True if value is an instance of any signed integer type
+    Check that the value is an instance of any signed integer type.
     """
     return t.id in _SIGNED_INTEGER_TYPES
 
 
 def is_unsigned_integer(t):
     """
-    Return True if value is an instance of any unsigned integer type
+    Check that the value is an instance of any unsigned integer type.
     """
     return t.id in _UNSIGNED_INTEGER_TYPES
 
 
 def is_int8(t):
     """
-    Return True if value is an instance of an int8 type
+    Check that the value is an instance of an int8 type.
     """
     return t.id == lib.Type_INT8
 
 
 def is_int16(t):
     """
-    Return True if value is an instance of an int16 type
+    Check that the value is an instance of an int16 type.
     """
     return t.id == lib.Type_INT16
 
 
 def is_int32(t):
     """
-    Return True if value is an instance of an int32 type
+    Check that the value is an instance of an int32 type.
     """
     return t.id == lib.Type_INT32
 
 
 def is_int64(t):
     """
-    Return True if value is an instance of an int64 type
+    Check that the value is an instance of an int64 type.
     """
     return t.id == lib.Type_INT64
 
 
 def is_uint8(t):
     """
-    Return True if value is an instance of an uint8 type
+    Check that the value is an instance of an uint8 type.
     """
     return t.id == lib.Type_UINT8
 
 
 def is_uint16(t):
     """
-    Return True if value is an instance of an uint16 type
+    Check that the value is an instance of an uint16 type.
     """
     return t.id == lib.Type_UINT16
 
 
 def is_uint32(t):
     """
-    Return True if value is an instance of an uint32 type
+    Check that the value is an instance of an uint32 type.
     """
     return t.id == lib.Type_UINT32
 
 
 def is_uint64(t):
     """
-    Return True if value is an instance of an uint64 type
+    Check that the value is an instance of an uint64 type.
     """
     return t.id == lib.Type_UINT64
 
 
 def is_floating(t):
     """
-    Return True if value is an instance of a floating point numeric type
+    Check that the value is an instance of a floating point numeric type.
     """
     return t.id in _FLOATING_TYPES
 
 
 def is_float16(t):
     """
-    Return True if value is an instance of a float16 (half-precision) type
+    Check that the value is an instance of a float16 (half-precision) type.
     """
     return t.id == lib.Type_HALF_FLOAT
 
 
 def is_float32(t):
     """
-    Return True if value is an instance of a float32 (single precision) type
+    Check that the value is an instance of a float32 (single precision) type.
     """
     return t.id == lib.Type_FLOAT
 
 
 def is_float64(t):
     """
-    Return True if value is an instance of a float64 (double precision) type
+    Check that the value is an instance of a float64 (double precision) type.
     """
     return t.id == lib.Type_DOUBLE
 
 
 def is_list(t):
     """
-    Return True if value is an instance of a list type
+    Check that the value is an instance of a list type.
     """
     return t.id == lib.Type_LIST
 
 
 def is_large_list(t):
     """
-    Return True if value is an instance of a large list type
+    Check that the value is an instance of a large list type.
     """
     return t.id == lib.Type_LARGE_LIST
 
 
 def is_fixed_size_list(t):
     """
-    Return True if value is an instance of a fixed size list type
+    Check that the value is an instance of a fixed size list type.
     """
     return t.id == lib.Type_FIXED_SIZE_LIST
 
 
 def is_struct(t):
     """
-    Return True if value is an instance of a struct type
+    Check that the value is an instance of a struct type.
     """
     return t.id == lib.Type_STRUCT
 
 
 def is_union(t):
     """
-    Return True if value is an instance of a union type
+    Check that the value is an instance of a union type.
     """
     return t.id == lib.Type_UNION
 
 
 def is_nested(t):
     """
-    Return True if value is an instance of a nested type
+    Check that the value is an instance of a nested type.
     """
     return t.id in _NESTED_TYPES
 
 
 def is_temporal(t):
     """
-    Return True if value is an instance of a temporal (date, time, timestamp)
-    type
+    Check that the value is an instance of a date, time, timestamp or duration.
     """
     return t.id in _TEMPORAL_TYPES
 
 
 def is_timestamp(t):
     """
-    Return True if value is an instance of a timestamp type
+    Check that the value is an instance of a timestamp type.
     """
     return t.id == lib.Type_TIMESTAMP
 
 
 def is_duration(t):
     """
-    Return True if value is an instance of a duration type
+    Check that the value is an instance of a duration type.
     """
     return t.id == lib.Type_DURATION
 
 
 def is_time(t):
     """
-    Return True if value is an instance of a time type
+    Check that the value is an instance of a time type.
     """
     return t.id in _TIME_TYPES
 
 
 def is_time32(t):
     """
-    Return True if value is an instance of a time32 type
+    Check that the value is an instance of a time32 type.
     """
     return t.id == lib.Type_TIME32
 
 
 def is_time64(t):
     """
-    Return True if value is an instance of a time64 type
+    Check that the value is an instance of a time64 type.
     """
     return t.id == lib.Type_TIME64
 
 
 def is_binary(t):
     """
-    Return True if value is an instance of a variable-length binary type
+    Check that the value is an instance of a variable-length binary type.
     """
     return t.id == lib.Type_BINARY
 
 
 def is_large_binary(t):
     """
-    Return True if value is an instance of a large variable-length
-    binary type
+    Check that the value is an instance of a large variable-length binary type.
     """
     return t.id == lib.Type_LARGE_BINARY
 
@@ -267,7 +265,7 @@ def is_unicode(t):
 
 def is_string(t):
     """
-    Return True if value is an instance of string (utf8 unicode) type
+    Check that the value is an instance of string (utf8 unicode) type.
     """
     return t.id == lib.Type_STRING
 
@@ -281,62 +279,62 @@ def is_large_unicode(t):
 
 def is_large_string(t):
     """
-    Return True if value is an instance of large string (utf8 unicode) type
+    Check that the value is an instance of large string (utf8 unicode) type.
     """
     return t.id == lib.Type_LARGE_STRING
 
 
 def is_fixed_size_binary(t):
     """
-    Return True if value is an instance of a fixed size binary type
+    Check that the value is an instance of a fixed size binary type.
     """
     return t.id == lib.Type_FIXED_SIZE_BINARY
 
 
 def is_date(t):
     """
-    Return True if value is an instance of a date type
+    Check that the value is an instance of a date type.
     """
     return t.id in _DATE_TYPES
 
 
 def is_date32(t):
     """
-    Return True if value is an instance of a date32 (days) type
+    Check that the value is an instance of a date32 (days) type.
     """
     return t.id == lib.Type_DATE32
 
 
 def is_date64(t):
     """
-    Return True if value is an instance of a date64 (milliseconds) type
+    Check that the value is an instance of a date64 (milliseconds) type.
     """
     return t.id == lib.Type_DATE64
 
 
 def is_map(t):
     """
-    Return True if value is an instance of a map logical type
+    Check that the value is an instance of a map logical type.
     """
     return t.id == lib.Type_MAP
 
 
 def is_decimal(t):
     """
-    Return True if value is an instance of a decimal type
+    Check that the value is an instance of a decimal type.
     """
     return t.id == lib.Type_DECIMAL
 
 
 def is_dictionary(t):
     """
-    Return True if value is an instance of a dictionary-encoded type
+    Check that the value is an instance of a dictionary-encoded type.
     """
     return t.id == lib.Type_DICTIONARY
 
 
 def is_primitive(t):
     """
-    Return True if the value is an instance of a primitive type
+    Return True if the value is an instance of a primitive type.
     """
     return lib._is_primitive(t.id)


### PR DESCRIPTION
Depends on #6420. 

Reduces the number of docstring violations from 1335 to 793 (fixes 542).

This is going to require more patches, but we need to start somewhere.