### PR TITLE
ARROW-7664: [C++] Rework FileSystemFromUri

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -334,8 +334,7 @@ class ARROW_EXPORT SlowFileSystem : public FileSystem {
 
 /// \brief Create a new FileSystem by URI
 ///
-/// A scheme-less URI is considered a local filesystem path.
-/// Recognized schemes are "file", "mock" and "hdfs".
+/// Recognized schemes are "file", "mock", "hdfs" and "s3fs".
 ///
 /// \param[in] uri a URI-based path, ex: file:///some/local/path
 /// \param[out] out_path (optional) Path inside the filesystem.
@@ -344,12 +343,23 @@ ARROW_EXPORT
 Result<std::shared_ptr<FileSystem>> FileSystemFromUri(const std::string& uri,
                                                       std::string* out_path = NULLPTR);
 
+/// \brief Create a new FileSystem by URI
+///
+/// Same as FileSystemFromUri, but in addition also recognize non-URIs
+/// and treat them as local filesystem paths.  The following kinds of
+/// local filesystem paths are recognized:
+/// - absolute paths starting with a slash
+/// - on Windows, absolute paths starting with a backslash
+/// - on Windows, paths starting with a local drive specification (such as "C:...")
+ARROW_EXPORT
+Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
+    const std::string& uri, std::string* out_path = NULLPTR);
+
 /// @}
 
 /// \brief Create a new FileSystem by URI
 ///
-/// A scheme-less URI is considered a local filesystem path.
-/// Recognized schemes are "file", "mock" and "hdfs".
+/// Recognized schemes are "file", "mock", "hdfs" and "s3fs".
 ///
 /// \param[in] uri a URI-based path, ex: file:///some/local/path
 /// \param[out] out_fs FileSystem instance.

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -346,11 +346,8 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUri(const std::string& uri,
 /// \brief Create a new FileSystem by URI
 ///
 /// Same as FileSystemFromUri, but in addition also recognize non-URIs
-/// and treat them as local filesystem paths.  The following kinds of
-/// local filesystem paths are recognized:
-/// - absolute paths starting with a slash
-/// - on Windows, absolute paths starting with a backslash
-/// - on Windows, paths starting with a local drive specification (such as "C:...")
+/// and treat them as local filesystem paths.  Only absolute local filesystem
+/// paths are allowed.
 ARROW_EXPORT
 Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
     const std::string& uri, std::string* out_path = NULLPTR);

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -46,6 +46,35 @@ using ::arrow::internal::IOErrorFromWinError;
 using ::arrow::internal::NativePathString;
 using ::arrow::internal::PlatformFilename;
 
+namespace internal {
+
+#ifdef _WIN32
+static bool IsDriveLetter(char c) {
+  // Can't use locale-dependent functions from the C/C++ stdlib
+  return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+}
+#endif
+
+bool DetectAbsolutePath(const std::string& s) {
+  // Is it a /-prefixed local path?
+  if (s.length() >= 1 && s[0] == '/') {
+    return true;
+  }
+#ifdef _WIN32
+  // Is it a \-prefixed local path?
+  if (s.length() >= 1 && s[0] == '\\') {
+    return true;
+  }
+  // Does it start with a drive letter, e.g. "C:..."?
+  if (s.length() >= 2 && s[1] == ':' && IsDriveLetter(s[0])) {
+    return true;
+  }
+#endif
+  return false;
+}
+
+}  // namespace internal
+
 namespace {
 
 #ifdef _WIN32

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -65,8 +65,10 @@ bool DetectAbsolutePath(const std::string& s) {
   if (s.length() >= 1 && s[0] == '\\') {
     return true;
   }
-  // Does it start with a drive letter, e.g. "C:..."?
-  if (s.length() >= 2 && s[1] == ':' && IsDriveLetter(s[0])) {
+  // Does it start with a drive letter in addition to being /- or \-prefixed,
+  // e.g. "C:\..."?
+  if (s.length() >= 3 && s[1] == ':' && (s[2] == '/' || s[2] == '\\') &&
+      IsDriveLetter(s[0])) {
     return true;
   }
 #endif

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -80,5 +80,13 @@ class ARROW_EXPORT LocalFileSystem : public FileSystem {
   LocalFileSystemOptions options_;
 };
 
+namespace internal {
+
+// Return whether the string is detected as a local absolute path.
+ARROW_EXPORT
+bool DetectAbsolutePath(const std::string& s);
+
+}  // namespace internal
+
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -87,20 +87,18 @@ TEST(DetectAbsolutePath, Basics) {
 #else
   constexpr bool is_win32 = false;
 #endif
-  ASSERT_EQ(is_win32, DetectAbsolutePath("A:"));
-  ASSERT_EQ(is_win32, DetectAbsolutePath("Z:/"));
-  ASSERT_EQ(is_win32, DetectAbsolutePath("a:foo"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("A:/"));
   ASSERT_EQ(is_win32, DetectAbsolutePath("z:/foo"));
 
   ASSERT_EQ(is_win32, DetectAbsolutePath("\\"));
   ASSERT_EQ(is_win32, DetectAbsolutePath("\\foo"));
   ASSERT_EQ(is_win32, DetectAbsolutePath("\\foo\\bar"));
   ASSERT_EQ(is_win32, DetectAbsolutePath("\\\\foo\\bar\\baz"));
-  ASSERT_EQ(is_win32, DetectAbsolutePath("A:"));
   ASSERT_EQ(is_win32, DetectAbsolutePath("Z:\\"));
-  ASSERT_EQ(is_win32, DetectAbsolutePath("a:foo"));
   ASSERT_EQ(is_win32, DetectAbsolutePath("z:\\foo"));
 
+  ASSERT_FALSE(DetectAbsolutePath("A:"));
+  ASSERT_FALSE(DetectAbsolutePath("z:foo"));
   ASSERT_FALSE(DetectAbsolutePath(""));
   ASSERT_FALSE(DetectAbsolutePath("AB:"));
   ASSERT_FALSE(DetectAbsolutePath(":"));
@@ -271,8 +269,15 @@ TYPED_TEST(TestLocalFS, FileSystemFromUriNoScheme) {
   this->TestInvalidUri(this->local_path_);  // Not actually an URI
 
   // Variations
-  this->TestLocalUriOrPath("/foo/bar", "/foo/bar");
-  this->TestInvalidUriOrPath("foo/bar");  // Relative
+  this->TestLocalUriOrPath(this->path_formatter_("/foo/bar"), "/foo/bar");
+
+#ifdef _WIN32
+  this->TestLocalUriOrPath(this->path_formatter_("C:/foo/bar/"), "C:/foo/bar/");
+#endif
+
+  // Relative paths
+  this->TestInvalidUriOrPath("C:foo/bar");
+  this->TestInvalidUriOrPath("foo/bar");
 }
 
 TYPED_TEST(TestLocalFS, FileSystemFromUriFileBackslashes) {
@@ -295,13 +300,14 @@ TYPED_TEST(TestLocalFS, FileSystemFromUriNoSchemeBackslashes) {
   this->TestFileSystemFromUriOrPath(uri_string);
 
   // Variations
-  this->TestLocalUriOrPath(this->path_formatter_("C:foo\\bar"), "C:foo/bar");
   this->TestLocalUriOrPath(this->path_formatter_("C:\\foo\\bar"), "C:/foo/bar");
-  this->TestLocalUriOrPath(this->path_formatter_("C:bar\\"), "C:bar/");
-  this->TestInvalidUriOrPath(this->path_formatter_("foo\\bar"));  // Relative
 #else
   this->TestInvalidUri(uri_string);
 #endif
+
+  // Relative paths
+  this->TestInvalidUriOrPath("C:foo\\bar");
+  this->TestInvalidUriOrPath("foo\\bar");
 }
 
 TYPED_TEST(TestLocalFS, DirectoryMTime) {

--- a/cpp/src/arrow/filesystem/localfs_test.cc
+++ b/cpp/src/arrow/filesystem/localfs_test.cc
@@ -66,6 +66,53 @@ using PathFormatters = ::testing::Types<CommonPathFormatter, ExtendedLengthPathF
 using PathFormatters = ::testing::Types<CommonPathFormatter>;
 #endif
 
+// Non-overloaded version of FileSystemFromUri, for template resolution
+// in CheckFileSystemFromUriFunc.
+Result<std::shared_ptr<FileSystem>> FSFromUri(const std::string& uri,
+                                              std::string* out_path = NULLPTR) {
+  return FileSystemFromUri(uri, out_path);
+}
+
+////////////////////////////////////////////////////////////////////////////
+// Misc tests
+
+TEST(DetectAbsolutePath, Basics) {
+  ASSERT_TRUE(DetectAbsolutePath("/"));
+  ASSERT_TRUE(DetectAbsolutePath("/foo"));
+  ASSERT_TRUE(DetectAbsolutePath("/foo/bar.txt"));
+  ASSERT_TRUE(DetectAbsolutePath("//foo/bar/baz"));
+
+#ifdef _WIN32
+  constexpr bool is_win32 = true;
+#else
+  constexpr bool is_win32 = false;
+#endif
+  ASSERT_EQ(is_win32, DetectAbsolutePath("A:"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("Z:/"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("a:foo"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("z:/foo"));
+
+  ASSERT_EQ(is_win32, DetectAbsolutePath("\\"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("\\foo"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("\\foo\\bar"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("\\\\foo\\bar\\baz"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("A:"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("Z:\\"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("a:foo"));
+  ASSERT_EQ(is_win32, DetectAbsolutePath("z:\\foo"));
+
+  ASSERT_FALSE(DetectAbsolutePath(""));
+  ASSERT_FALSE(DetectAbsolutePath("AB:"));
+  ASSERT_FALSE(DetectAbsolutePath(":"));
+  ASSERT_FALSE(DetectAbsolutePath(""));
+  ASSERT_FALSE(DetectAbsolutePath("@:"));
+  ASSERT_FALSE(DetectAbsolutePath("à:"));
+  ASSERT_FALSE(DetectAbsolutePath("0:"));
+  ASSERT_FALSE(DetectAbsolutePath("A"));
+  ASSERT_FALSE(DetectAbsolutePath("foo/bar"));
+  ASSERT_FALSE(DetectAbsolutePath("foo\\bar"));
+}
+
 ////////////////////////////////////////////////////////////////////////////
 // Generic LocalFileSystem tests
 
@@ -117,12 +164,14 @@ class TestLocalFS : public LocalFSTestMixin {
     fs_ = std::make_shared<SubTreeFileSystem>(local_path_, local_fs_);
   }
 
-  void TestFileSystemFromUri(const std::string& uri) {
+  template <typename FileSystemFromUriFunc>
+  void CheckFileSystemFromUriFunc(const std::string& uri,
+                                  FileSystemFromUriFunc&& fs_from_uri) {
     if (!path_formatter_.supports_uri()) {
       return;  // skip
     }
     std::string path;
-    ASSERT_OK_AND_ASSIGN(fs_, FileSystemFromUri(uri, &path));
+    ASSERT_OK_AND_ASSIGN(fs_, fs_from_uri(uri, &path));
     ASSERT_EQ(path, local_path_);
 
     // Test that the right location on disk is accessed
@@ -130,15 +179,33 @@ class TestLocalFS : public LocalFSTestMixin {
     CheckConcreteFile(this->temp_dir_->path().ToString() + "abc", 9);
   }
 
-  void TestLocalUri(const std::string& uri, const std::string& expected_path) {
-    // Like TestFileSystemFromUri, but with an arbitrary non-existing path
+  void TestFileSystemFromUri(const std::string& uri) {
+    CheckFileSystemFromUriFunc(uri, FSFromUri);
+  }
+
+  void TestFileSystemFromUriOrPath(const std::string& uri) {
+    CheckFileSystemFromUriFunc(uri, FileSystemFromUriOrPath);
+  }
+
+  template <typename FileSystemFromUriFunc>
+  void CheckLocalUri(const std::string& uri, const std::string& expected_path,
+                     FileSystemFromUriFunc&& fs_from_uri) {
     if (!path_formatter_.supports_uri()) {
       return;  // skip
     }
     std::string path;
-    ASSERT_OK_AND_ASSIGN(fs_, FileSystemFromUri(uri, &path));
+    ASSERT_OK_AND_ASSIGN(fs_, fs_from_uri(uri, &path));
     ASSERT_EQ(fs_->type_name(), "local");
     ASSERT_EQ(path, expected_path);
+  }
+
+  // Like TestFileSystemFromUri, but with an arbitrary non-existing path
+  void TestLocalUri(const std::string& uri, const std::string& expected_path) {
+    CheckLocalUri(uri, expected_path, FSFromUri);
+  }
+
+  void TestLocalUriOrPath(const std::string& uri, const std::string& expected_path) {
+    CheckLocalUri(uri, expected_path, FileSystemFromUriOrPath);
   }
 
   void TestInvalidUri(const std::string& uri) {
@@ -146,6 +213,13 @@ class TestLocalFS : public LocalFSTestMixin {
       return;  // skip
     }
     ASSERT_RAISES(Invalid, FileSystemFromUri(uri));
+  }
+
+  void TestInvalidUriOrPath(const std::string& uri) {
+    if (!path_formatter_.supports_uri()) {
+      return;  // skip
+    }
+    ASSERT_RAISES(Invalid, FileSystemFromUriOrPath(uri));
   }
 
   void CheckConcreteFile(const std::string& path, int64_t expected_size) {
@@ -180,36 +254,53 @@ TYPED_TEST(TestLocalFS, CorrectPathExists) {
 }
 
 TYPED_TEST(TestLocalFS, FileSystemFromUriFile) {
-  this->TestFileSystemFromUri("file:" + this->local_path_);
+  // Concrete test with actual file
+  const auto uri_string = "file:" + this->local_path_;
+  this->TestFileSystemFromUri(uri_string);
+  this->TestFileSystemFromUriOrPath(uri_string);
+
+  // Variations
+  this->TestLocalUri("file:foo/bar", "foo/bar");
+  this->TestLocalUri("file:/foo/bar", "/foo/bar");
+  this->TestLocalUri("file:foo:bar", "foo:bar");
 }
 
 TYPED_TEST(TestLocalFS, FileSystemFromUriNoScheme) {
-  this->TestFileSystemFromUri(this->local_path_);
+  // Concrete test with actual file
+  this->TestFileSystemFromUriOrPath(this->local_path_);
+  this->TestInvalidUri(this->local_path_);  // Not actually an URI
+
+  // Variations
+  this->TestLocalUriOrPath("/foo/bar", "/foo/bar");
+  this->TestInvalidUriOrPath("foo/bar");  // Relative
 }
 
 TYPED_TEST(TestLocalFS, FileSystemFromUriFileBackslashes) {
+  const auto uri_string = ToBackslashes("file:" + this->local_path_);
 #ifdef _WIN32
-  this->TestFileSystemFromUri(ToBackslashes("file:" + this->local_path_));
+  this->TestFileSystemFromUriOrPath(uri_string);
 
   // Variations
   this->TestLocalUri("file:" + this->path_formatter_("C:foo\\bar"), "C:foo/bar");
   this->TestLocalUri("file:" + this->path_formatter_("C:\\foo\\bar"), "C:/foo/bar");
   this->TestLocalUri("file:" + this->path_formatter_("C:bar\\"), "C:bar/");
 #else
-  this->TestInvalidUri(ToBackslashes("file:" + this->local_path_));
+  this->TestInvalidUri(uri_string);
 #endif
 }
 
 TYPED_TEST(TestLocalFS, FileSystemFromUriNoSchemeBackslashes) {
+  const auto uri_string = ToBackslashes(this->local_path_);
 #ifdef _WIN32
-  this->TestFileSystemFromUri(ToBackslashes(this->local_path_));
+  this->TestFileSystemFromUriOrPath(uri_string);
 
   // Variations
-  this->TestLocalUri(this->path_formatter_("C:foo\\bar"), "C:foo/bar");
-  this->TestLocalUri(this->path_formatter_("C:\\foo\\bar"), "C:/foo/bar");
-  this->TestLocalUri(this->path_formatter_("C:bar\\"), "C:bar/");
+  this->TestLocalUriOrPath(this->path_formatter_("C:foo\\bar"), "C:foo/bar");
+  this->TestLocalUriOrPath(this->path_formatter_("C:\\foo\\bar"), "C:/foo/bar");
+  this->TestLocalUriOrPath(this->path_formatter_("C:bar\\"), "C:bar/");
+  this->TestInvalidUriOrPath(this->path_formatter_("foo\\bar"));  // Relative
 #else
-  this->TestInvalidUri(ToBackslashes(this->local_path_));
+  this->TestInvalidUri(uri_string);
 #endif
 }
 

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -198,6 +198,11 @@ Status Uri::Parse(const std::string& uri_string) {
       URI_SUCCESS) {
     return Status::Invalid("Cannot parse URI: '", uri_string, "'");
   }
+
+  if (scheme().empty()) {
+    return Status::Invalid("URI has empty scheme: '", uri_string, "'");
+  }
+
   // Parse port number
   auto port_text = TextRangeToView(impl_->uri_.portText);
   if (port_text.size()) {

--- a/cpp/src/arrow/util/uri_test.cc
+++ b/cpp/src/arrow/util/uri_test.cc
@@ -221,6 +221,12 @@ TEST(Uri, ParseError) {
   ASSERT_RAISES(Invalid, uri.Parse("http://localhost:z"));
   ASSERT_RAISES(Invalid, uri.Parse("http://localhost:-1"));
   ASSERT_RAISES(Invalid, uri.Parse("http://localhost:99999"));
+
+  // Scheme-less URIs (forbidden by RFC 3986, and ambiguous to parse)
+  ASSERT_RAISES(Invalid, uri.Parse("localhost"));
+  ASSERT_RAISES(Invalid, uri.Parse("/foo/bar"));
+  ASSERT_RAISES(Invalid, uri.Parse("foo/bar"));
+  ASSERT_RAISES(Invalid, uri.Parse(""));
 }
 
 }  // namespace internal

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -81,6 +81,9 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
 
     CResult[shared_ptr[CFileSystem]] CFileSystemFromUri \
         "arrow::fs::FileSystemFromUri"(const c_string& uri, c_string* out_path)
+    CResult[shared_ptr[CFileSystem]] CFileSystemFromUriOrPath \
+        "arrow::fs::FileSystemFromUriOrPath"(const c_string& uri,
+                                             c_string* out_path)
 
     cdef cppclass CLocalFileSystemOptions "arrow::fs::LocalFileSystemOptions":
         c_bool use_mmap

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -596,14 +596,22 @@ def test_hdfs_options(hdfs_server):
     ('file:foo/bar', LocalFileSystem, 'foo/bar'),
     ('file:/foo/bar', LocalFileSystem, '/foo/bar'),
     ('file:///foo/bar', LocalFileSystem, '/foo/bar'),
-    ('', LocalFileSystem, ''),
-    ('foo/bar', LocalFileSystem, 'foo/bar'),
+    ('/', LocalFileSystem, '/'),
     ('/foo/bar', LocalFileSystem, '/foo/bar'),
 ])
 def test_filesystem_from_uri(uri, expected_klass, expected_path):
     fs, path = FileSystem.from_uri(uri)
     assert isinstance(fs, expected_klass)
     assert path == expected_path
+
+
+@pytest.mark.parametrize('path',
+                         ['', '/', 'foo/bar', '/foo/bar', __file__])
+def test_filesystem_from_path_object(path):
+    p = pathlib.Path(path)
+    fs, path = FileSystem.from_uri(p)
+    assert isinstance(fs, LocalFileSystem)
+    assert path == p.resolve().absolute().as_posix()
 
 
 @pytest.mark.s3


### PR DESCRIPTION
FileSystemFromUri now recognizes only URIs. 
An additional function FileSystemFromUriOrPath also recognized absolute local paths (but not relative paths).