### PR TITLE
ARROW-7764: [C++] Don't keep a null bitmap in ArrayData if null_count == 0

### DIFF
--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -92,50 +92,38 @@ struct ARROW_EXPORT ArrayData {
       : type(type), length(length), null_count(null_count), offset(offset) {}
 
   ArrayData(const std::shared_ptr<DataType>& type, int64_t length,
-            const std::vector<std::shared_ptr<Buffer>>& buffers,
-            int64_t null_count = kUnknownNullCount, int64_t offset = 0)
-      : ArrayData(type, length, null_count, offset) {
-    this->buffers = buffers;
-  }
-
-  ArrayData(const std::shared_ptr<DataType>& type, int64_t length,
-            const std::vector<std::shared_ptr<Buffer>>& buffers,
-            const std::vector<std::shared_ptr<ArrayData>>& child_data,
-            int64_t null_count = kUnknownNullCount, int64_t offset = 0)
-      : ArrayData(type, length, null_count, offset) {
-    this->buffers = buffers;
-    this->child_data = child_data;
-  }
-
-  ArrayData(const std::shared_ptr<DataType>& type, int64_t length,
-            std::vector<std::shared_ptr<Buffer>>&& buffers,
+            std::vector<std::shared_ptr<Buffer>> buffers,
             int64_t null_count = kUnknownNullCount, int64_t offset = 0)
       : ArrayData(type, length, null_count, offset) {
     this->buffers = std::move(buffers);
   }
 
+  ArrayData(const std::shared_ptr<DataType>& type, int64_t length,
+            std::vector<std::shared_ptr<Buffer>> buffers,
+            std::vector<std::shared_ptr<ArrayData>> child_data,
+            int64_t null_count = kUnknownNullCount, int64_t offset = 0)
+      : ArrayData(type, length, null_count, offset) {
+    this->buffers = std::move(buffers);
+    this->child_data = std::move(child_data);
+  }
+
   static std::shared_ptr<ArrayData> Make(const std::shared_ptr<DataType>& type,
                                          int64_t length,
-                                         std::vector<std::shared_ptr<Buffer>>&& buffers,
+                                         std::vector<std::shared_ptr<Buffer>> buffers,
                                          int64_t null_count = kUnknownNullCount,
                                          int64_t offset = 0);
 
   static std::shared_ptr<ArrayData> Make(
       const std::shared_ptr<DataType>& type, int64_t length,
-      const std::vector<std::shared_ptr<Buffer>>& buffers,
+      std::vector<std::shared_ptr<Buffer>> buffers,
+      std::vector<std::shared_ptr<ArrayData>> child_data,
       int64_t null_count = kUnknownNullCount, int64_t offset = 0);
 
   static std::shared_ptr<ArrayData> Make(
       const std::shared_ptr<DataType>& type, int64_t length,
-      const std::vector<std::shared_ptr<Buffer>>& buffers,
-      const std::vector<std::shared_ptr<ArrayData>>& child_data,
-      int64_t null_count = kUnknownNullCount, int64_t offset = 0);
-
-  static std::shared_ptr<ArrayData> Make(
-      const std::shared_ptr<DataType>& type, int64_t length,
-      const std::vector<std::shared_ptr<Buffer>>& buffers,
-      const std::vector<std::shared_ptr<ArrayData>>& child_data,
-      const std::shared_ptr<Array>& dictionary, int64_t null_count = kUnknownNullCount,
+      std::vector<std::shared_ptr<Buffer>> buffers,
+      std::vector<std::shared_ptr<ArrayData>> child_data,
+      std::shared_ptr<Array> dictionary, int64_t null_count = kUnknownNullCount,
       int64_t offset = 0);
 
   static std::shared_ptr<ArrayData> Make(const std::shared_ptr<DataType>& type,

--- a/cpp/src/arrow/array/dict_internal.cc
+++ b/cpp/src/arrow/array/dict_internal.cc
@@ -204,7 +204,7 @@ Status DictionaryArray::Transpose(MemoryPool* pool, const std::shared_ptr<DataTy
 
   // Shift null buffer if the original offset is non-zero
   std::shared_ptr<Buffer> null_bitmap;
-  if (data_->offset != 0) {
+  if (data_->offset != 0 && data_->null_count != 0) {
     ARROW_ASSIGN_OR_RAISE(
         null_bitmap, CopyBitmap(pool, null_bitmap_data_, data_->offset, data_->length));
   } else {

--- a/cpp/src/arrow/array_test.cc
+++ b/cpp/src/arrow/array_test.cc
@@ -594,7 +594,11 @@ void TestPrimitiveBuilder<PBoolean>::Check(const std::unique_ptr<BooleanBuilder>
   AssertArraysEqual(*result, *expected);
 
   // buffers are correctly sized
-  ASSERT_EQ(result->data()->buffers[0]->size(), BitUtil::BytesForBits(size));
+  if (result->data()->buffers[0]) {
+    ASSERT_EQ(result->data()->buffers[0]->size(), BitUtil::BytesForBits(size));
+  } else {
+    ASSERT_EQ(result->data()->null_count, 0);
+  }
   ASSERT_EQ(result->data()->buffers[1]->size(), BitUtil::BytesForBits(size));
 
   // Builder is now reset

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -60,16 +60,25 @@ static SumResult<ArrowType> NaiveSumPartial(const Array& array) {
   ResultType result;
 
   auto data = array.data();
-  internal::BitmapReader reader(array.null_bitmap_data(), array.offset(), array.length());
   const auto& array_numeric = reinterpret_cast<const ArrayType&>(array);
   const auto values = array_numeric.raw_values();
-  for (int64_t i = 0; i < array.length(); i++) {
-    if (reader.IsSet()) {
+
+  if (array.null_count() != 0) {
+    internal::BitmapReader reader(array.null_bitmap_data(), array.offset(),
+                                  array.length());
+    for (int64_t i = 0; i < array.length(); i++) {
+      if (reader.IsSet()) {
+        result.first += values[i];
+        result.second++;
+      }
+
+      reader.Next();
+    }
+  } else {
+    for (int64_t i = 0; i < array.length(); i++) {
       result.first += values[i];
       result.second++;
     }
-
-    reader.Next();
   }
 
   return result;

--- a/cpp/src/arrow/json/parser_test.cc
+++ b/cpp/src/arrow/json/parser_test.cc
@@ -51,7 +51,10 @@ void AssertUnconvertedArraysEqual(const Array& expected, const Array& actual) {
     }
     case Type::LIST: {
       ASSERT_EQ(expected.type_id(), Type::LIST);
-      AssertBufferEqual(*expected.null_bitmap(), *actual.null_bitmap());
+      ASSERT_EQ(expected.null_count(), actual.null_count());
+      if (expected.null_count() != 0) {
+        AssertBufferEqual(*expected.null_bitmap(), *actual.null_bitmap());
+      }
       const auto& expected_offsets = expected.data()->buffers[1];
       const auto& actual_offsets = actual.data()->buffers[1];
       AssertBufferEqual(*expected_offsets, *actual_offsets);

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1429,13 +1429,6 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
     return result;
   }
 
-  int DecodeArrowNonNull(int num_values,
-                         arrow::BinaryDictionary32Builder* builder) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, builder, &result));
-    return result;
-  }
-
   // ----------------------------------------------------------------------
   // Optimized dense binary read paths
 
@@ -1449,13 +1442,6 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
       PARQUET_THROW_NOT_OK(DecodeArrowDense(num_values, null_count, valid_bits,
                                             valid_bits_offset, out, &result));
     }
-    return result;
-  }
-
-  int DecodeArrowNonNull(
-      int num_values, typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowDenseNonNull(num_values, out, &result));
     return result;
   }
 
@@ -2019,13 +2005,6 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType>,
     return result;
   }
 
-  int DecodeArrowNonNull(int num_values,
-                         arrow::BinaryDictionary32Builder* builder) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, builder, &result));
-    return result;
-  }
-
   int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
                   int64_t valid_bits_offset,
                   typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
@@ -2036,13 +2015,6 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType>,
       PARQUET_THROW_NOT_OK(DecodeArrowDense(num_values, null_count, valid_bits,
                                             valid_bits_offset, out, &result));
     }
-    return result;
-  }
-
-  int DecodeArrowNonNull(
-      int num_values, typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
-    int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowDenseNonNull(num_values, out, &result));
     return result;
   }
 

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -1058,15 +1058,22 @@ int PlainDecoder<DType>::DecodeArrow(
 
   PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
 
-  arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
-  for (int i = 0; i < num_values; ++i) {
-    if (bit_reader.IsSet()) {
+  if (null_count != 0) {
+    arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
+    for (int i = 0; i < num_values; ++i) {
+      if (bit_reader.IsSet()) {
+        builder->UnsafeAppend(arrow::util::SafeLoadAs<value_type>(data_));
+        data_ += sizeof(value_type);
+      } else {
+        builder->UnsafeAppendNull();
+      }
+      bit_reader.Next();
+    }
+  } else {
+    for (int i = 0; i < num_values; ++i) {
       builder->UnsafeAppend(arrow::util::SafeLoadAs<value_type>(data_));
       data_ += sizeof(value_type);
-    } else {
-      builder->UnsafeAppendNull();
     }
-    bit_reader.Next();
   }
 
   num_values_ -= values_decoded;
@@ -1088,15 +1095,22 @@ int PlainDecoder<DType>::DecodeArrow(
 
   PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
 
-  arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
-  for (int i = 0; i < num_values; ++i) {
-    if (bit_reader.IsSet()) {
+  if (null_count != 0) {
+    arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
+    for (int i = 0; i < num_values; ++i) {
+      if (bit_reader.IsSet()) {
+        PARQUET_THROW_NOT_OK(builder->Append(arrow::util::SafeLoadAs<value_type>(data_)));
+        data_ += sizeof(value_type);
+      } else {
+        PARQUET_THROW_NOT_OK(builder->AppendNull());
+      }
+      bit_reader.Next();
+    }
+  } else {
+    for (int i = 0; i < num_values; ++i) {
       PARQUET_THROW_NOT_OK(builder->Append(arrow::util::SafeLoadAs<value_type>(data_)));
       data_ += sizeof(value_type);
-    } else {
-      PARQUET_THROW_NOT_OK(builder->AppendNull());
     }
-    bit_reader.Next();
   }
 
   num_values_ -= values_decoded;
@@ -1216,16 +1230,24 @@ int PlainBooleanDecoder::DecodeArrow(
 
   PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
 
-  arrow::internal::BitmapReader valid_reader(valid_bits, valid_bits_offset, num_values);
-  for (int i = 0; i < num_values; ++i) {
-    if (valid_reader.IsSet()) {
+  if (null_count != 0) {
+    arrow::internal::BitmapReader valid_reader(valid_bits, valid_bits_offset, num_values);
+    for (int i = 0; i < num_values; ++i) {
+      if (valid_reader.IsSet()) {
+        bool value;
+        ARROW_IGNORE_EXPR(bit_reader_->GetValue(1, &value));
+        builder->UnsafeAppend(value);
+      } else {
+        builder->UnsafeAppendNull();
+      }
+      valid_reader.Next();
+    }
+  } else {
+    for (int i = 0; i < num_values; ++i) {
       bool value;
       ARROW_IGNORE_EXPR(bit_reader_->GetValue(1, &value));
       builder->UnsafeAppend(value);
-    } else {
-      builder->UnsafeAppendNull();
     }
-    valid_reader.Next();
   }
 
   num_values_ -= values_decoded;
@@ -1327,15 +1349,22 @@ inline int PlainDecoder<FLBAType>::DecodeArrow(
 
   PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
 
-  arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
-  for (int i = 0; i < num_values; ++i) {
-    if (bit_reader.IsSet()) {
+  if (null_count != 0) {
+    arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
+    for (int i = 0; i < num_values; ++i) {
+      if (bit_reader.IsSet()) {
+        builder->UnsafeAppend(data_);
+        data_ += descr_->type_length();
+      } else {
+        builder->UnsafeAppendNull();
+      }
+      bit_reader.Next();
+    }
+  } else {
+    for (int i = 0; i < num_values; ++i) {
       builder->UnsafeAppend(data_);
       data_ += descr_->type_length();
-    } else {
-      builder->UnsafeAppendNull();
     }
-    bit_reader.Next();
   }
 
   num_values_ -= values_decoded;
@@ -1354,15 +1383,22 @@ inline int PlainDecoder<FLBAType>::DecodeArrow(
 
   PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
 
-  arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
-  for (int i = 0; i < num_values; ++i) {
-    if (bit_reader.IsSet()) {
+  if (null_count != 0) {
+    arrow::internal::BitmapReader bit_reader(valid_bits, valid_bits_offset, num_values);
+    for (int i = 0; i < num_values; ++i) {
+      if (bit_reader.IsSet()) {
+        PARQUET_THROW_NOT_OK(builder->Append(data_));
+        data_ += descr_->type_length();
+      } else {
+        PARQUET_THROW_NOT_OK(builder->AppendNull());
+      }
+      bit_reader.Next();
+    }
+  } else {
+    for (int i = 0; i < num_values; ++i) {
       PARQUET_THROW_NOT_OK(builder->Append(data_));
       data_ += descr_->type_length();
-    } else {
-      PARQUET_THROW_NOT_OK(builder->AppendNull());
     }
-    bit_reader.Next();
   }
 
   num_values_ -= values_decoded;
@@ -1384,8 +1420,12 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
                   int64_t valid_bits_offset,
                   arrow::BinaryDictionary32Builder* builder) override {
     int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrow(num_values, null_count, valid_bits,
-                                     valid_bits_offset, builder, &result));
+    if (null_count == 0) {
+      PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, builder, &result));
+    } else {
+      PARQUET_THROW_NOT_OK(DecodeArrow(num_values, null_count, valid_bits,
+                                       valid_bits_offset, builder, &result));
+    }
     return result;
   }
 
@@ -1403,8 +1443,12 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
                   int64_t valid_bits_offset,
                   typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
     int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowDense(num_values, null_count, valid_bits,
-                                          valid_bits_offset, out, &result));
+    if (null_count == 0) {
+      PARQUET_THROW_NOT_OK(DecodeArrowDenseNonNull(num_values, out, &result));
+    } else {
+      PARQUET_THROW_NOT_OK(DecodeArrowDense(num_values, null_count, valid_bits,
+                                            valid_bits_offset, out, &result));
+    }
     return result;
   }
 
@@ -1831,17 +1875,27 @@ inline int DictDecoderImpl<FLBAType>::DecodeArrow(
 
   auto dict_values = reinterpret_cast<const FLBA*>(dictionary_->data());
 
-  for (int i = 0; i < num_values; ++i) {
-    bool is_valid = bit_reader.IsSet();
-    bit_reader.Next();
-    if (is_valid) {
+  if (null_count != 0) {
+    for (int i = 0; i < num_values; ++i) {
+      bool is_valid = bit_reader.IsSet();
+      bit_reader.Next();
+      if (is_valid) {
+        int32_t index;
+        if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
+          throw ParquetException("");
+        }
+        builder->UnsafeAppend(dict_values[index].ptr);
+      } else {
+        builder->UnsafeAppendNull();
+      }
+    }
+  } else {
+    for (int i = 0; i < num_values; ++i) {
       int32_t index;
       if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
         throw ParquetException("");
       }
       builder->UnsafeAppend(dict_values[index].ptr);
-    } else {
-      builder->UnsafeAppendNull();
     }
   }
 
@@ -1867,17 +1921,27 @@ int DictDecoderImpl<FLBAType>::DecodeArrow(
 
   auto dict_values = reinterpret_cast<const FLBA*>(dictionary_->data());
 
-  for (int i = 0; i < num_values; ++i) {
-    bool is_valid = bit_reader.IsSet();
-    bit_reader.Next();
-    if (is_valid) {
+  if (null_count != 0) {
+    for (int i = 0; i < num_values; ++i) {
+      bool is_valid = bit_reader.IsSet();
+      bit_reader.Next();
+      if (is_valid) {
+        int32_t index;
+        if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
+          throw ParquetException("");
+        }
+        PARQUET_THROW_NOT_OK(builder->Append(dict_values[index].ptr));
+      } else {
+        PARQUET_THROW_NOT_OK(builder->AppendNull());
+      }
+    }
+  } else {
+    for (int i = 0; i < num_values; ++i) {
       int32_t index;
       if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
         throw ParquetException("");
       }
       PARQUET_THROW_NOT_OK(builder->Append(dict_values[index].ptr));
-    } else {
-      PARQUET_THROW_NOT_OK(builder->AppendNull());
     }
   }
 
@@ -1894,17 +1958,27 @@ int DictDecoderImpl<Type>::DecodeArrow(
   using value_type = typename Type::c_type;
   auto dict_values = reinterpret_cast<const value_type*>(dictionary_->data());
 
-  for (int i = 0; i < num_values; ++i) {
-    bool is_valid = bit_reader.IsSet();
-    bit_reader.Next();
-    if (is_valid) {
+  if (null_count != 0) {
+    for (int i = 0; i < num_values; ++i) {
+      bool is_valid = bit_reader.IsSet();
+      bit_reader.Next();
+      if (is_valid) {
+        int32_t index;
+        if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
+          throw ParquetException("");
+        }
+        builder->UnsafeAppend(dict_values[index]);
+      } else {
+        builder->UnsafeAppendNull();
+      }
+    }
+  } else {
+    for (int i = 0; i < num_values; ++i) {
       int32_t index;
       if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
         throw ParquetException("");
       }
       builder->UnsafeAppend(dict_values[index]);
-    } else {
-      builder->UnsafeAppendNull();
     }
   }
 
@@ -1936,8 +2010,12 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType>,
                   int64_t valid_bits_offset,
                   arrow::BinaryDictionary32Builder* builder) override {
     int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrow(num_values, null_count, valid_bits,
-                                     valid_bits_offset, builder, &result));
+    if (null_count == 0) {
+      PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, builder, &result));
+    } else {
+      PARQUET_THROW_NOT_OK(DecodeArrow(num_values, null_count, valid_bits,
+                                       valid_bits_offset, builder, &result));
+    }
     return result;
   }
 
@@ -1952,8 +2030,12 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType>,
                   int64_t valid_bits_offset,
                   typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
     int result = 0;
-    PARQUET_THROW_NOT_OK(DecodeArrowDense(num_values, null_count, valid_bits,
-                                          valid_bits_offset, out, &result));
+    if (null_count == 0) {
+      PARQUET_THROW_NOT_OK(DecodeArrowDenseNonNull(num_values, out, &result));
+    } else {
+      PARQUET_THROW_NOT_OK(DecodeArrowDense(num_values, null_count, valid_bits,
+                                            valid_bits_offset, out, &result));
+    }
     return result;
   }
 

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -312,6 +312,12 @@ class TypedDecoder : virtual public Decoder {
 
   /// \brief Decode into an ArrayBuilder or other accumulator
   ///
+  /// This function assumes the definition levels were already decoded
+  /// as a validity bitmap in the given `valid_bits`.  `null_count`
+  /// is the number of 0s in `valid_bits`.
+  /// As a space optimization, it is allowed for `valid_bits` to be null
+  /// if `null_count` is zero.
+  ///
   /// \return number of values decoded
   virtual int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
                           int64_t valid_bits_offset,
@@ -320,13 +326,18 @@ class TypedDecoder : virtual public Decoder {
   /// \brief Decode into an ArrayBuilder or other accumulator ignoring nulls
   ///
   /// \return number of values decoded
-  virtual int DecodeArrowNonNull(int num_values,
-                                 typename EncodingTraits<DType>::Accumulator* out) {
-    const uint8_t valid_bits = 0;
-    return DecodeArrow(num_values, 0, &valid_bits, 0, out);
+  int DecodeArrowNonNull(int num_values,
+                         typename EncodingTraits<DType>::Accumulator* out) {
+    return DecodeArrow(num_values, 0, /*valid_bits=*/NULLPTR, 0, out);
   }
 
   /// \brief Decode into a DictionaryBuilder
+  ///
+  /// This function assumes the definition levels were already decoded
+  /// as a validity bitmap in the given `valid_bits`.  `null_count`
+  /// is the number of 0s in `valid_bits`.
+  /// As a space optimization, it is allowed for `valid_bits` to be null
+  /// if `null_count` is zero.
   ///
   /// \return number of values decoded
   virtual int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
@@ -336,10 +347,9 @@ class TypedDecoder : virtual public Decoder {
   /// \brief Decode into a DictionaryBuilder ignoring nulls
   ///
   /// \return number of values decoded
-  virtual int DecodeArrowNonNull(
-      int num_values, typename EncodingTraits<DType>::DictAccumulator* builder) {
-    const uint8_t valid_bits = 0;
-    return DecodeArrow(num_values, 0, &valid_bits, 0, builder);
+  int DecodeArrowNonNull(int num_values,
+                         typename EncodingTraits<DType>::DictAccumulator* builder) {
+    return DecodeArrow(num_values, 0, /*valid_bits=*/NULLPTR, 0, builder);
   }
 };
 

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -291,7 +291,7 @@ class BenchmarkDecodeArrow : public ::benchmark::Fixture {
     ::arrow::random::RandomArrayGenerator rag(0);
     input_array_ = rag.StringWithRepeats(num_values_, num_values_ / repeat_factor,
                                          min_length, max_length, /*null_probability=*/0);
-    valid_bits_ = input_array_->null_bitmap()->data();
+    valid_bits_ = input_array_->null_bitmap_data();
     total_size_ = input_array_->data()->buffers[2]->size();
 
     values_.reserve(num_values_);

--- a/r/tests/testthat/test-array-data.R
+++ b/r/tests/testthat/test-array-data.R
@@ -24,7 +24,7 @@ test_that("string vectors with only empty strings and nulls don't allocate a dat
   buffers <- a$data()$buffers
 
   # No nulls
-  expect_equal(buffers[[1]]$size, 1)
+  expect_equal(buffers[[1]], NULL)
 
   # Offsets has 2 elements
   expect_equal(buffers[[2]]$size, 8L)


### PR DESCRIPTION
This spotted a couple bugs in kernels where null bitmaps were always iterated even if null.