### PR TITLE
ARROW-7884: [C++] Relax concurrency rules around GetSize()

### DIFF
--- a/cpp/src/arrow/io/concurrency.h
+++ b/cpp/src/arrow/io/concurrency.h
@@ -197,7 +197,7 @@ class ARROW_EXPORT RandomAccessFileConcurrencyWrapper : public RandomAccessFile 
   }
 
   Result<int64_t> GetSize() final {
-    auto guard = lock_.exclusive_guard();
+    auto guard = lock_.shared_guard();
     return derived()->DoGetSize();
   }
 

--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -215,7 +215,10 @@ class ARROW_EXPORT RandomAccessFile : public InputStream, public Seekable {
   static std::shared_ptr<InputStream> GetStream(std::shared_ptr<RandomAccessFile> file,
                                                 int64_t file_offset, int64_t nbytes);
 
-  /// Return the total file size in bytes.
+  /// \brief Return the total file size in bytes.
+  ///
+  /// This method does not read or move the current file position, so is safe
+  /// to call concurrently with e.g. ReadAt().
   virtual Result<int64_t> GetSize() = 0;
 
   /// \brief Read data from given file position.

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -81,10 +81,12 @@ const RowGroupMetaData* RowGroupReader::metadata() const { return contents_->met
 // RowGroupReader::Contents implementation for the Parquet file specification
 class SerializedRowGroup : public RowGroupReader::Contents {
  public:
-  SerializedRowGroup(std::shared_ptr<ArrowInputFile> source, FileMetaData* file_metadata,
-                     int row_group_number, const ReaderProperties& props,
+  SerializedRowGroup(std::shared_ptr<ArrowInputFile> source, int64_t source_size,
+                     FileMetaData* file_metadata, int row_group_number,
+                     const ReaderProperties& props,
                      std::shared_ptr<InternalFileDecryptor> file_decryptor = nullptr)
       : source_(std::move(source)),
+        source_size_(source_size),
         file_metadata_(file_metadata),
         properties_(props),
         row_group_ordinal_(row_group_number),
@@ -114,8 +116,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
       // The Parquet MR writer had a bug in 1.2.8 and below where it didn't include the
       // dictionary page header size in total_compressed_size and total_uncompressed_size
       // (see IMPALA-694). We add padding to compensate.
-      PARQUET_ASSIGN_OR_THROW(int64_t size, source_->GetSize());
-      int64_t bytes_remaining = size - (col_start + col_length);
+      int64_t bytes_remaining = source_size_ - (col_start + col_length);
       int64_t padding = std::min<int64_t>(kMaxDictHeaderSize, bytes_remaining);
       col_length += padding;
     }
@@ -161,6 +162,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
 
  private:
   std::shared_ptr<ArrowInputFile> source_;
+  int64_t source_size_;
   FileMetaData* file_metadata_;
   std::unique_ptr<RowGroupMetaData> row_group_metadata_;
   ReaderProperties properties_;
@@ -178,7 +180,9 @@ class SerializedFile : public ParquetFileReader::Contents {
  public:
   SerializedFile(std::shared_ptr<ArrowInputFile> source,
                  const ReaderProperties& props = default_reader_properties())
-      : source_(std::move(source)), properties_(props) {}
+      : source_(std::move(source)), properties_(props) {
+    PARQUET_ASSIGN_OR_THROW(source_size_, source_->GetSize());
+  }
 
   ~SerializedFile() override {
     try {
@@ -193,8 +197,8 @@ class SerializedFile : public ParquetFileReader::Contents {
 
   std::shared_ptr<RowGroupReader> GetRowGroup(int i) override {
     std::unique_ptr<SerializedRowGroup> contents(
-        new SerializedRowGroup(source_, file_metadata_.get(), static_cast<int16_t>(i),
-                               properties_, file_decryptor_));
+        new SerializedRowGroup(source_, source_size_, file_metadata_.get(),
+                               static_cast<int16_t>(i), properties_, file_decryptor_));
     return std::make_shared<RowGroupReader>(std::move(contents));
   }
 
@@ -205,20 +209,18 @@ class SerializedFile : public ParquetFileReader::Contents {
   }
 
   void ParseMetaData() {
-    PARQUET_ASSIGN_OR_THROW(int64_t file_size, source_->GetSize());
-
-    if (file_size == 0) {
+    if (source_size_ == 0) {
       throw ParquetInvalidOrCorruptedFileException("Parquet file size is 0 bytes");
-    } else if (file_size < kFooterSize) {
+    } else if (source_size_ < kFooterSize) {
       throw ParquetInvalidOrCorruptedFileException(
-          "Parquet file size is ", file_size,
+          "Parquet file size is ", source_size_,
           " bytes, smaller than the minimum file footer (", kFooterSize, " bytes)");
     }
 
-    int64_t footer_read_size = std::min(file_size, kDefaultFooterReadSize);
+    int64_t footer_read_size = std::min(source_size_, kDefaultFooterReadSize);
     PARQUET_ASSIGN_OR_THROW(
         auto footer_buffer,
-        source_->ReadAt(file_size - footer_read_size, footer_read_size));
+        source_->ReadAt(source_size_ - footer_read_size, footer_read_size));
 
     // Check if all bytes are read. Check if last 4 bytes read have the magic bits
     if (footer_buffer->size() != footer_read_size ||
@@ -231,16 +233,15 @@ class SerializedFile : public ParquetFileReader::Contents {
 
     if (memcmp(footer_buffer->data() + footer_read_size - 4, kParquetEMagic, 4) == 0) {
       // Encrypted file with Encrypted footer.
-      ParseMetaDataOfEncryptedFileWithEncryptedFooter(footer_buffer, footer_read_size,
-                                                      file_size);
+      ParseMetaDataOfEncryptedFileWithEncryptedFooter(footer_buffer, footer_read_size);
       return;
     }
 
     // No encryption or encryption with plaintext footer mode.
     std::shared_ptr<Buffer> metadata_buffer;
     uint32_t metadata_len, read_metadata_len;
-    ParseUnencryptedFileMetadata(footer_buffer, footer_read_size, file_size,
-                                 &metadata_buffer, &metadata_len, &read_metadata_len);
+    ParseUnencryptedFileMetadata(footer_buffer, footer_read_size, &metadata_buffer,
+                                 &metadata_len, &read_metadata_len);
 
     auto file_decryption_properties = properties_.file_decryption_properties();
     if (!file_metadata_->is_encryption_algorithm_set()) {  // Non encrypted file.
@@ -258,13 +259,14 @@ class SerializedFile : public ParquetFileReader::Contents {
 
  private:
   std::shared_ptr<ArrowInputFile> source_;
+  int64_t source_size_;
   std::shared_ptr<FileMetaData> file_metadata_;
   ReaderProperties properties_;
 
   std::shared_ptr<InternalFileDecryptor> file_decryptor_;
 
   void ParseUnencryptedFileMetadata(const std::shared_ptr<Buffer>& footer_buffer,
-                                    int64_t footer_read_size, int64_t file_size,
+                                    int64_t footer_read_size,
                                     std::shared_ptr<Buffer>* metadata_buffer,
                                     uint32_t* metadata_len, uint32_t* read_metadata_len);
 
@@ -277,21 +279,20 @@ class SerializedFile : public ParquetFileReader::Contents {
       uint32_t read_metadata_len);
 
   void ParseMetaDataOfEncryptedFileWithEncryptedFooter(
-      const std::shared_ptr<Buffer>& footer_buffer, int64_t footer_read_size,
-      int64_t file_size);
+      const std::shared_ptr<Buffer>& footer_buffer, int64_t footer_read_size);
 };
 
 void SerializedFile::ParseUnencryptedFileMetadata(
     const std::shared_ptr<Buffer>& footer_buffer, int64_t footer_read_size,
-    int64_t file_size, std::shared_ptr<Buffer>* metadata_buffer, uint32_t* metadata_len,
+    std::shared_ptr<Buffer>* metadata_buffer, uint32_t* metadata_len,
     uint32_t* read_metadata_len) {
   *metadata_len = arrow::util::SafeLoadAs<uint32_t>(
       reinterpret_cast<const uint8_t*>(footer_buffer->data()) + footer_read_size -
       kFooterSize);
-  int64_t metadata_start = file_size - kFooterSize - *metadata_len;
-  if (kFooterSize + *metadata_len > file_size) {
+  int64_t metadata_start = source_size_ - kFooterSize - *metadata_len;
+  if (kFooterSize + *metadata_len > source_size_) {
     throw ParquetInvalidOrCorruptedFileException(
-        "Parquet file size is ", file_size,
+        "Parquet file size is ", source_size_,
         " bytes, smaller than the size reported by metadata (", metadata_len, "bytes)");
   }
 
@@ -314,17 +315,16 @@ void SerializedFile::ParseUnencryptedFileMetadata(
 }
 
 void SerializedFile::ParseMetaDataOfEncryptedFileWithEncryptedFooter(
-    const std::shared_ptr<Buffer>& footer_buffer, int64_t footer_read_size,
-    int64_t file_size) {
+    const std::shared_ptr<Buffer>& footer_buffer, int64_t footer_read_size) {
   // encryption with encrypted footer
   // both metadata & crypto metadata length
   uint32_t footer_len = arrow::util::SafeLoadAs<uint32_t>(
       reinterpret_cast<const uint8_t*>(footer_buffer->data()) + footer_read_size -
       kFooterSize);
-  int64_t crypto_metadata_start = file_size - kFooterSize - footer_len;
-  if (kFooterSize + footer_len > file_size) {
+  int64_t crypto_metadata_start = source_size_ - kFooterSize - footer_len;
+  if (kFooterSize + footer_len > source_size_) {
     throw ParquetInvalidOrCorruptedFileException(
-        "Parquet file size is ", file_size,
+        "Parquet file size is ", source_size_,
         " bytes, smaller than the size reported by footer's (", footer_len, "bytes)");
   }
   std::shared_ptr<Buffer> crypto_metadata_buffer;
@@ -356,7 +356,7 @@ void SerializedFile::ParseMetaDataOfEncryptedFileWithEncryptedFooter(
       file_decryption_properties, file_aad, algo.algorithm,
       file_crypto_metadata->key_metadata(), properties_.memory_pool());
 
-  int64_t metadata_offset = file_size - kFooterSize - footer_len + crypto_metadata_len;
+  int64_t metadata_offset = source_size_ - kFooterSize - footer_len + crypto_metadata_len;
   uint32_t metadata_len = footer_len - crypto_metadata_len;
   PARQUET_ASSIGN_OR_THROW(auto metadata_buffer,
                           source_->ReadAt(metadata_offset, metadata_len));


### PR DESCRIPTION
RandomAccessFile::GetSize() implementations don't (and shouldn't) move or read the file pointer,
so allow issuing GetSize() calls concurrently.

This should fix a crash (in debug mode only) when reading certain types of malformed
Parquet files.