### PR TITLE
ARROW-7887: [Rust] Add date/time/duration/timestamp types to filter kernel

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -645,26 +645,6 @@ def_numeric_from_vec!(
     i64,
     DataType::Duration(TimeUnit::Nanosecond)
 );
-def_numeric_from_vec!(
-    TimestampSecondType,
-    i64,
-    DataType::Timestamp(TimeUnit::Second, None)
-);
-def_numeric_from_vec!(
-    TimestampMillisecondType,
-    i64,
-    DataType::Timestamp(TimeUnit::Millisecond, None)
-);
-def_numeric_from_vec!(
-    TimestampMicrosecondType,
-    i64,
-    DataType::Timestamp(TimeUnit::Microsecond, None)
-);
-def_numeric_from_vec!(
-    TimestampNanosecondType,
-    i64,
-    DataType::Timestamp(TimeUnit::Nanosecond, None)
-);
 
 impl<T: ArrowTimestampType> PrimitiveArray<T> {
     /// Construct a timestamp array from a vec of i64 values and an optional timezone
@@ -1834,37 +1814,33 @@ mod tests {
 
     #[test]
     fn test_timestamp_array_from_vec() {
-        let arr = TimestampSecondArray::from(vec![Some(1), None, Some(-5)]);
-        assert_eq!(3, arr.len());
+        let arr = TimestampSecondArray::from_vec(vec![1, -5], None);
+        assert_eq!(2, arr.len());
         assert_eq!(0, arr.offset());
-        assert_eq!(1, arr.null_count());
+        assert_eq!(0, arr.null_count());
         assert_eq!(1, arr.value(0));
-        assert!(arr.is_null(1));
-        assert_eq!(-5, arr.value(2));
+        assert_eq!(-5, arr.value(1));
 
-        let arr = TimestampMillisecondArray::from(vec![Some(1), None, Some(-5)]);
-        assert_eq!(3, arr.len());
+        let arr = TimestampMillisecondArray::from_vec(vec![1, -5], None);
+        assert_eq!(2, arr.len());
         assert_eq!(0, arr.offset());
-        assert_eq!(1, arr.null_count());
+        assert_eq!(0, arr.null_count());
         assert_eq!(1, arr.value(0));
-        assert!(arr.is_null(1));
-        assert_eq!(-5, arr.value(2));
+        assert_eq!(-5, arr.value(1));
 
-        let arr = TimestampMicrosecondArray::from(vec![Some(1), None, Some(-5)]);
-        assert_eq!(3, arr.len());
+        let arr = TimestampMicrosecondArray::from_vec(vec![1, -5], None);
+        assert_eq!(2, arr.len());
         assert_eq!(0, arr.offset());
-        assert_eq!(1, arr.null_count());
+        assert_eq!(0, arr.null_count());
         assert_eq!(1, arr.value(0));
-        assert!(arr.is_null(1));
-        assert_eq!(-5, arr.value(2));
+        assert_eq!(-5, arr.value(1));
 
-        let arr = TimestampNanosecondArray::from(vec![Some(1), None, Some(-5)]);
-        assert_eq!(3, arr.len());
+        let arr = TimestampNanosecondArray::from_vec(vec![1, -5], None);
+        assert_eq!(2, arr.len());
         assert_eq!(0, arr.offset());
-        assert_eq!(1, arr.null_count());
+        assert_eq!(0, arr.null_count());
         assert_eq!(1, arr.value(0));
-        assert!(arr.is_null(1));
-        assert_eq!(-5, arr.value(2));
+        assert_eq!(-5, arr.value(1));
     }
 
     #[test]

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -645,6 +645,26 @@ def_numeric_from_vec!(
     i64,
     DataType::Duration(TimeUnit::Nanosecond)
 );
+def_numeric_from_vec!(
+    TimestampSecondType,
+    i64,
+    DataType::Timestamp(TimeUnit::Second, None)
+);
+def_numeric_from_vec!(
+    TimestampMillisecondType,
+    i64,
+    DataType::Timestamp(TimeUnit::Millisecond, None)
+);
+def_numeric_from_vec!(
+    TimestampMicrosecondType,
+    i64,
+    DataType::Timestamp(TimeUnit::Microsecond, None)
+);
+def_numeric_from_vec!(
+    TimestampNanosecondType,
+    i64,
+    DataType::Timestamp(TimeUnit::Nanosecond, None)
+);
 
 impl<T: ArrowTimestampType> PrimitiveArray<T> {
     /// Construct a timestamp array from a vec of i64 values and an optional timezone
@@ -1804,6 +1824,41 @@ mod tests {
         assert_eq!(-5, arr.value(2));
 
         let arr = DurationNanosecondArray::from(vec![Some(1), None, Some(-5)]);
+        assert_eq!(3, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(1, arr.null_count());
+        assert_eq!(1, arr.value(0));
+        assert!(arr.is_null(1));
+        assert_eq!(-5, arr.value(2));
+    }
+
+    #[test]
+    fn test_timestamp_array_from_vec() {
+        let arr = TimestampSecondArray::from(vec![Some(1), None, Some(-5)]);
+        assert_eq!(3, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(1, arr.null_count());
+        assert_eq!(1, arr.value(0));
+        assert!(arr.is_null(1));
+        assert_eq!(-5, arr.value(2));
+
+        let arr = TimestampMillisecondArray::from(vec![Some(1), None, Some(-5)]);
+        assert_eq!(3, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(1, arr.null_count());
+        assert_eq!(1, arr.value(0));
+        assert!(arr.is_null(1));
+        assert_eq!(-5, arr.value(2));
+
+        let arr = TimestampMicrosecondArray::from(vec![Some(1), None, Some(-5)]);
+        assert_eq!(3, arr.len());
+        assert_eq!(0, arr.offset());
+        assert_eq!(1, arr.null_count());
+        assert_eq!(1, arr.value(0));
+        assert!(arr.is_null(1));
+        assert_eq!(-5, arr.value(2));
+
+        let arr = TimestampNanosecondArray::from(vec![Some(1), None, Some(-5)]);
         assert_eq!(3, arr.len());
         assert_eq!(0, arr.offset());
         assert_eq!(1, arr.null_count());

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -20,7 +20,7 @@
 use std::sync::Arc;
 
 use crate::array::*;
-use crate::datatypes::{ArrowNumericType, DataType};
+use crate::datatypes::{ArrowNumericType, DataType, TimeUnit};
 use crate::error::{ArrowError, Result};
 
 /// Helper function to perform boolean lambda function on values from two arrays.
@@ -87,7 +87,21 @@ pub fn filter(array: &Array, filter: &BooleanArray) -> Result<ArrayRef> {
         DataType::Float32 => filter_array!(array, filter, Float32Array),
         DataType::Float64 => filter_array!(array, filter, Float64Array),
         DataType::Boolean => filter_array!(array, filter, BooleanArray),
-        DataType::Binary => {
+        DataType::Date32(_) => filter_array!(array, filter, Date32Array),
+        DataType::Date64(_) => filter_array!(array, filter, Date64Array),
+        DataType::Time32(TimeUnit::Second) => filter_array!(array, filter, Time32SecondArray),
+        DataType::Time32(TimeUnit::Millisecond) => filter_array!(array, filter, Time32MillisecondArray),
+        DataType::Time64(TimeUnit::Microsecond) => filter_array!(array, filter, Time64MicrosecondArray),
+        DataType::Time64(TimeUnit::Nanosecond) => filter_array!(array, filter, Time64NanosecondArray),
+        DataType::Duration(TimeUnit::Second) => filter_array!(array, filter, DurationSecondArray),
+        DataType::Duration(TimeUnit::Millisecond) => filter_array!(array, filter, DurationMillisecondArray),
+        DataType::Duration(TimeUnit::Microsecond) => filter_array!(array, filter, DurationMicrosecondArray),
+        DataType::Duration(TimeUnit::Nanosecond) => filter_array!(array, filter, DurationNanosecondArray),
+        DataType::Timestamp(TimeUnit::Second, _) => filter_array!(array, filter, TimestampSecondArray),
+        DataType::Timestamp(TimeUnit::Millisecond, _) => filter_array!(array, filter, TimestampMillisecondArray),
+        DataType::Timestamp(TimeUnit::Microsecond, _) => filter_array!(array, filter, TimestampMicrosecondArray),
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => filter_array!(array, filter, TimestampNanosecondArray),
+        DataType::Binary => { 
             let b = array.as_any().downcast_ref::<BinaryArray>().unwrap();
             let mut values: Vec<&[u8]> = Vec::with_capacity(b.len());
             for i in 0..b.len() {

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -157,10 +157,10 @@ mod tests {
     use super::*;
 
     macro_rules! def_temporal_test {
-        ($test:ident, $array_type: ident) => {
+        ($test:ident, $array_type: ident, $data: expr) => {
             #[test]
             fn $test() {
-                let a = $array_type::from(vec![1, 2, 3, 4]);
+                let a = $data;
                 let b = BooleanArray::from(vec![true, false, true, false]);
                 let c = filter(&a, &b).unwrap();
                 let d = c.as_ref().as_any().downcast_ref::<$array_type>().unwrap();
@@ -171,20 +171,76 @@ mod tests {
         };
     }
 
-    def_temporal_test!(test_filter_date32, Date32Array);
-    def_temporal_test!(test_filter_date64, Date64Array);
-    def_temporal_test!(test_filter_time32_second, Time32SecondArray);
-    def_temporal_test!(test_filter_time32_millisecond, Time32MillisecondArray);
-    def_temporal_test!(test_filter_time64_microsecond, Time64MicrosecondArray);
-    def_temporal_test!(test_filter_time64_nanosecond, Time64NanosecondArray);
-    def_temporal_test!(test_filter_duration_second, DurationSecondArray);
-    def_temporal_test!(test_filter_duration_millisecond, DurationMillisecondArray);
-    def_temporal_test!(test_filter_duration_microsecond, DurationMicrosecondArray);
-    def_temporal_test!(test_filter_duration_nanosecond, DurationNanosecondArray);
-    def_temporal_test!(test_filter_timestamp_second, TimestampSecondArray);
-    def_temporal_test!(test_filter_timestamp_millisecond, TimestampMillisecondArray);
-    def_temporal_test!(test_filter_timestamp_microsecond, TimestampMicrosecondArray);
-    def_temporal_test!(test_filter_timestamp_nanosecond, TimestampNanosecondArray);
+    def_temporal_test!(
+        test_filter_date32,
+        Date32Array,
+        Date32Array::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_date64,
+        Date64Array,
+        Date64Array::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_time32_second,
+        Time32SecondArray,
+        Time32SecondArray::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_time32_millisecond,
+        Time32MillisecondArray,
+        Time32MillisecondArray::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_time64_microsecond,
+        Time64MicrosecondArray,
+        Time64MicrosecondArray::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_time64_nanosecond,
+        Time64NanosecondArray,
+        Time64NanosecondArray::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_duration_second,
+        DurationSecondArray,
+        DurationSecondArray::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_duration_millisecond,
+        DurationMillisecondArray,
+        DurationMillisecondArray::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_duration_microsecond,
+        DurationMicrosecondArray,
+        DurationMicrosecondArray::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_duration_nanosecond,
+        DurationNanosecondArray,
+        DurationNanosecondArray::from(vec![1, 2, 3, 4])
+    );
+    def_temporal_test!(
+        test_filter_timestamp_second,
+        TimestampSecondArray,
+        TimestampSecondArray::from_vec(vec![1, 2, 3, 4], None)
+    );
+    def_temporal_test!(
+        test_filter_timestamp_millisecond,
+        TimestampMillisecondArray,
+        TimestampMillisecondArray::from_vec(vec![1, 2, 3, 4], None)
+    );
+    def_temporal_test!(
+        test_filter_timestamp_microsecond,
+        TimestampMicrosecondArray,
+        TimestampMicrosecondArray::from_vec(vec![1, 2, 3, 4], None)
+    );
+    def_temporal_test!(
+        test_filter_timestamp_nanosecond,
+        TimestampNanosecondArray,
+        TimestampNanosecondArray::from_vec(vec![1, 2, 3, 4], None)
+    );
 
     #[test]
     fn test_filter_array() {

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -89,19 +89,43 @@ pub fn filter(array: &Array, filter: &BooleanArray) -> Result<ArrayRef> {
         DataType::Boolean => filter_array!(array, filter, BooleanArray),
         DataType::Date32(_) => filter_array!(array, filter, Date32Array),
         DataType::Date64(_) => filter_array!(array, filter, Date64Array),
-        DataType::Time32(TimeUnit::Second) => filter_array!(array, filter, Time32SecondArray),
-        DataType::Time32(TimeUnit::Millisecond) => filter_array!(array, filter, Time32MillisecondArray),
-        DataType::Time64(TimeUnit::Microsecond) => filter_array!(array, filter, Time64MicrosecondArray),
-        DataType::Time64(TimeUnit::Nanosecond) => filter_array!(array, filter, Time64NanosecondArray),
-        DataType::Duration(TimeUnit::Second) => filter_array!(array, filter, DurationSecondArray),
-        DataType::Duration(TimeUnit::Millisecond) => filter_array!(array, filter, DurationMillisecondArray),
-        DataType::Duration(TimeUnit::Microsecond) => filter_array!(array, filter, DurationMicrosecondArray),
-        DataType::Duration(TimeUnit::Nanosecond) => filter_array!(array, filter, DurationNanosecondArray),
-        DataType::Timestamp(TimeUnit::Second, _) => filter_array!(array, filter, TimestampSecondArray),
-        DataType::Timestamp(TimeUnit::Millisecond, _) => filter_array!(array, filter, TimestampMillisecondArray),
-        DataType::Timestamp(TimeUnit::Microsecond, _) => filter_array!(array, filter, TimestampMicrosecondArray),
-        DataType::Timestamp(TimeUnit::Nanosecond, _) => filter_array!(array, filter, TimestampNanosecondArray),
-        DataType::Binary => { 
+        DataType::Time32(TimeUnit::Second) => {
+            filter_array!(array, filter, Time32SecondArray)
+        }
+        DataType::Time32(TimeUnit::Millisecond) => {
+            filter_array!(array, filter, Time32MillisecondArray)
+        }
+        DataType::Time64(TimeUnit::Microsecond) => {
+            filter_array!(array, filter, Time64MicrosecondArray)
+        }
+        DataType::Time64(TimeUnit::Nanosecond) => {
+            filter_array!(array, filter, Time64NanosecondArray)
+        }
+        DataType::Duration(TimeUnit::Second) => {
+            filter_array!(array, filter, DurationSecondArray)
+        }
+        DataType::Duration(TimeUnit::Millisecond) => {
+            filter_array!(array, filter, DurationMillisecondArray)
+        }
+        DataType::Duration(TimeUnit::Microsecond) => {
+            filter_array!(array, filter, DurationMicrosecondArray)
+        }
+        DataType::Duration(TimeUnit::Nanosecond) => {
+            filter_array!(array, filter, DurationNanosecondArray)
+        }
+        DataType::Timestamp(TimeUnit::Second, _) => {
+            filter_array!(array, filter, TimestampSecondArray)
+        }
+        DataType::Timestamp(TimeUnit::Millisecond, _) => {
+            filter_array!(array, filter, TimestampMillisecondArray)
+        }
+        DataType::Timestamp(TimeUnit::Microsecond, _) => {
+            filter_array!(array, filter, TimestampMicrosecondArray)
+        }
+        DataType::Timestamp(TimeUnit::Nanosecond, _) => {
+            filter_array!(array, filter, TimestampNanosecondArray)
+        }
+        DataType::Binary => {
             let b = array.as_any().downcast_ref::<BinaryArray>().unwrap();
             let mut values: Vec<&[u8]> = Vec::with_capacity(b.len());
             for i in 0..b.len() {

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -168,7 +168,7 @@ mod tests {
                 assert_eq!(1, d.value(0));
                 assert_eq!(3, d.value(1));
             }
-        }
+        };
     }
 
     def_temporal_test!(test_filter_date32, Date32Array);

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -156,6 +156,36 @@ pub fn filter(array: &Array, filter: &BooleanArray) -> Result<ArrayRef> {
 mod tests {
     use super::*;
 
+    macro_rules! def_temporal_test {
+        ($test:ident, $array_type: ident) => {
+            #[test]
+            fn $test() {
+                let a = $array_type::from(vec![1, 2, 3, 4]);
+                let b = BooleanArray::from(vec![true, false, true, false]);
+                let c = filter(&a, &b).unwrap();
+                let d = c.as_ref().as_any().downcast_ref::<$array_type>().unwrap();
+                assert_eq!(2, d.len());
+                assert_eq!(1, d.value(0));
+                assert_eq!(3, d.value(1));
+            }
+        }
+    }
+
+    def_temporal_test!(test_filter_date32, Date32Array);
+    def_temporal_test!(test_filter_date64, Date64Array);
+    def_temporal_test!(test_filter_time32_second, Time32SecondArray);
+    def_temporal_test!(test_filter_time32_millisecond, Time32MillisecondArray);
+    def_temporal_test!(test_filter_time64_microsecond, Time64MicrosecondArray);
+    def_temporal_test!(test_filter_time64_nanosecond, Time64NanosecondArray);
+    def_temporal_test!(test_filter_duration_second, DurationSecondArray);
+    def_temporal_test!(test_filter_duration_millisecond, DurationMillisecondArray);
+    def_temporal_test!(test_filter_duration_microsecond, DurationMicrosecondArray);
+    def_temporal_test!(test_filter_duration_nanosecond, DurationNanosecondArray);
+    def_temporal_test!(test_filter_timestamp_second, TimestampSecondArray);
+    def_temporal_test!(test_filter_timestamp_millisecond, TimestampMillisecondArray);
+    def_temporal_test!(test_filter_timestamp_microsecond, TimestampMicrosecondArray);
+    def_temporal_test!(test_filter_timestamp_nanosecond, TimestampNanosecondArray);
+
     #[test]
     fn test_filter_array() {
         let a = Int32Array::from(vec![5, 6, 7, 8, 9]);


### PR DESCRIPTION
The filter kernel was missing implementations for the temporal types (ie: date / time / duration / timestamp).