### PR TITLE
ARROW-7889: [Rust] Add support to datafusion-cli for parquet files.

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -92,7 +92,11 @@ impl ExecutionContext {
                 FileType::CSV => {
                     self.register_csv(name, location, schema, *header_row);
                     Ok(vec![])
-                }
+                },
+                FileType::Parquet => {
+                    self.register_parquet(name, location)?;
+                    Ok(vec![])
+                },
                 _ => Err(ExecutionError::ExecutionError(format!(
                     "Unsupported file type {:?}.",
                     file_type

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -92,11 +92,11 @@ impl ExecutionContext {
                 FileType::CSV => {
                     self.register_csv(name, location, schema, *header_row);
                     Ok(vec![])
-                },
+                }
                 FileType::Parquet => {
                     self.register_parquet(name, location)?;
                     Ok(vec![])
-                },
+                }
                 _ => Err(ExecutionError::ExecutionError(format!(
                     "Unsupported file type {:?}.",
                     file_type


### PR DESCRIPTION
At present, using datafusion-cli with a parquet file results in an error that Parquet is unsupported.

This change allows the registration of parquet files with `CREATE EXTERNAL TABLE`.