### PR TITLE
ARROW-6895: [C++][Parquet] Do not reset dictionary in ByteArrayDictionaryRecordReader during incremental reads

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2260,14 +2260,18 @@ TEST(TestArrowReadWrite, DISABLED_CanonicalNestedRoundTrip) {
       ::arrow::ArrayFromJSON(links->type(),
                              "[{\"Backward\":[], \"Forward\":[20, 40, 60]}, "
                              "{\"Backward\":[10, 30], \"Forward\":[80]}]");
+
+  // Written without C++11 string literal because many editors don't have C++11
+  // string literals implemented properly
   auto name_array =
-      ::arrow::ArrayFromJSON(name->type(),
-                             R"([[{"Language": [{"Code": "en_us", "Country":"us"},
-                                   {"Code": "en_us", "Country": null}],
-                      "Url": "http://A"},
-                     {"Url": "http://B"},
-                     {"Language": [{"Code": "en-gb", "Country": "gb"}]}],
-                    [{"Url": "http://C"}]])");
+      ::arrow::ArrayFromJSON(
+           name->type(),
+           "([[{\"Language\": [{\"Code\": \"en_us\", \"Country\":\"us\"},"
+           "{\"Code\": \"en_us\", \"Country\": null}],"
+           "\"Url\": \"http://A\"},"
+           "{\"Url\": \"http://B\"},"
+           "{\"Language\": [{\"Code\": \"en-gb\", \"Country\": \"gb\"}]}],"
+           "[{\"Url\": \"http://C\"}]]");
   auto expected =
       ::arrow::Table::Make(schema, {doc_id_array, links_id_array, name_array});
   CheckSimpleRoundtrip(expected, 2);
@@ -2899,14 +2903,9 @@ class TestArrowReadDictionary : public ::testing::TestWithParam<double> {
   } options;
 
   void SetUp() override {
-    GenerateData(GetParam());
-
-    // Write `num_row_groups` row groups; each row group will have a different dictionary
-    ASSERT_NO_FATAL_FAILURE(
-        WriteTableToBuffer(expected_dense_, options.num_rows / options.num_row_groups,
-                           default_arrow_writer_properties(), &buffer_));
-
     properties_ = default_arrow_reader_properties();
+
+    GenerateData(GetParam());
   }
 
   void GenerateData(double null_probability) {
@@ -2919,6 +2918,13 @@ class TestArrowReadDictionary : public ::testing::TestWithParam<double> {
   }
 
   void TearDown() override {}
+
+  void WriteSimple() {
+    // Write `num_row_groups` row groups; each row group will have a different dictionary
+    ASSERT_NO_FATAL_FAILURE(
+        WriteTableToBuffer(expected_dense_, options.num_rows / options.num_row_groups,
+                           default_arrow_writer_properties(), &buffer_));
+  }
 
   void CheckReadWholeFile(const Table& expected) {
     ASSERT_OK_AND_ASSIGN(auto reader, GetReader());
@@ -2970,6 +2976,8 @@ void AsDictionary32Encoded(const Array& arr, std::shared_ptr<Array>* out) {
 TEST_P(TestArrowReadDictionary, ReadWholeFileDict) {
   properties_.set_read_dictionary(0, true);
 
+  WriteSimple();
+
   auto num_row_groups = options.num_row_groups;
   auto chunk_size = options.num_rows / num_row_groups;
 
@@ -2982,6 +2990,36 @@ TEST_P(TestArrowReadDictionary, ReadWholeFileDict) {
   CheckReadWholeFile(*ex_table);
 }
 
+TEST_P(TestArrowReadDictionary, IncrementalReads) {
+  // ARROW-6895
+
+  properties_.set_read_dictionary(0, true);
+
+  // Just write a single row group
+  ASSERT_NO_FATAL_FAILURE(
+      WriteTableToBuffer(expected_dense_, options.num_rows,
+                         default_arrow_writer_properties(), &buffer_));
+
+  // Read in one shot
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileReader> reader, GetReader());
+  std::shared_ptr<Table> expected;
+  ASSERT_OK_NO_THROW(reader->ReadTable(&expected));
+
+  ASSERT_OK_AND_ASSIGN(reader, GetReader());
+  std::unique_ptr<ColumnReader> col;
+  ASSERT_OK(reader->GetColumn(0, &col));
+
+  int num_reads = 4;
+  int batch_size = options.num_rows / num_reads;
+  for (int i = 0; i < num_reads; ++i) {
+    std::shared_ptr<ChunkedArray> chunk;
+    ASSERT_OK(col->NextBatch(batch_size, &chunk));
+    AssertChunkedEqual(*expected->column(0)->Slice(num_reads * batch_size,
+                                                   batch_size),
+                       *chunk);
+  }
+}
+
 TEST_P(TestArrowReadDictionary, StreamReadWholeFileDict) {
   // ARROW-6895 and ARROW-7545 reading a parquet file with a dictionary of
   // binary data, e.g. String, will return invalid values when using the
@@ -2992,6 +3030,7 @@ TEST_P(TestArrowReadDictionary, StreamReadWholeFileDict) {
   options.num_row_groups = 1;
   options.num_rows = 16;
   SetUp();
+  WriteSimple();
 
   // Would trigger an infinite loop when requesting a batch greater than the
   // number of available rows in a row group.
@@ -3001,6 +3040,7 @@ TEST_P(TestArrowReadDictionary, StreamReadWholeFileDict) {
 
 TEST_P(TestArrowReadDictionary, ReadWholeFileDense) {
   properties_.set_read_dictionary(0, false);
+  WriteSimple();
   CheckReadWholeFile(*expected_dense_);
 }
 

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -1462,7 +1462,7 @@ class ByteArrayDictionaryRecordReader : public TypedRecordReader<ByteArrayType>,
       result_chunks_.emplace_back(std::move(chunk));
 
       // Also clears the dictionary memo table
-      builder_.ResetFull();
+      builder_.Reset();
     }
   }
 
@@ -1471,6 +1471,7 @@ class ByteArrayDictionaryRecordReader : public TypedRecordReader<ByteArrayType>,
       /// If there is a new dictionary, we may need to flush the builder, then
       /// insert the new dictionary values
       FlushBuilder();
+      builder_.ResetFull();
       auto decoder = dynamic_cast<BinaryDictDecoder*>(this->current_decoder_);
       decoder->InsertDictionary(&builder_);
       this->new_dictionary_ = false;


### PR DESCRIPTION
Previously, ByteArrayDictionaryRecordReader would clear the dictionary
after returning a chunk. Now, it persists the dictionary in case a
future chunk needs it.

Sorry -- I feel I'm missing the expertise to write a unit test. But I can attest that in Arrow 0.16 the code snippet in ARROW-6895 segfaults on the `bad.parquet` attached to that issue; and after this patch, it works correctly.