### PR TITLE
ARROW-7837 [JAVA] copyFromSafe fails due to a bug in handleSafe

### DIFF
--- a/java/performance/src/test/java/org/apache/arrow/vector/VariableWidthVectorBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/VariableWidthVectorBenchmarks.java
@@ -19,7 +19,6 @@ package org.apache.arrow.vector;
 
 import java.util.concurrent.TimeUnit;
 
-import io.netty.buffer.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.holders.NullableVarCharHolder;
@@ -36,6 +35,8 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
+import io.netty.buffer.ArrowBuf;
+
 /**
  * Benchmarks for {@link BaseVariableWidthVector}.
  */
@@ -49,7 +50,7 @@ public class VariableWidthVectorBenchmarks {
   private static final int ALLOCATOR_CAPACITY = 1024 * 1024;
 
   private static byte[] bytes = VariableWidthVectorBenchmarks.class.getName().getBytes();
-  private ArrowBuf  arrowBuff;
+  private ArrowBuf arrowBuff;
 
   private BufferAllocator allocator;
 
@@ -92,7 +93,7 @@ public class VariableWidthVectorBenchmarks {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public int setSafeFromArray() {
-    for(int i =0; i < 500; ++i){
+    for (int i = 0; i < 500; ++i) {
       vector.setSafe(i * 40, bytes);
     }
     return vector.getBufferSize();
@@ -106,7 +107,7 @@ public class VariableWidthVectorBenchmarks {
     nvch.buffer = arrowBuff;
     nvch.start = 0;
     nvch.end = bytes.length;
-    for(int i =0; i < 50; ++i) {
+    for (int i = 0; i < 50; ++i) {
       nvch.isSet = 0;
       for (int j = 0; j < 9; ++j) {
         int idx = 10 * i + j;

--- a/java/performance/src/test/java/org/apache/arrow/vector/VariableWidthVectorBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/VariableWidthVectorBenchmarks.java
@@ -19,8 +19,10 @@ package org.apache.arrow.vector;
 
 import java.util.concurrent.TimeUnit;
 
+import io.netty.buffer.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.holders.NullableVarCharHolder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -46,6 +48,9 @@ public class VariableWidthVectorBenchmarks {
 
   private static final int ALLOCATOR_CAPACITY = 1024 * 1024;
 
+  private static byte[] bytes = VariableWidthVectorBenchmarks.class.getName().getBytes();
+  private ArrowBuf  arrowBuff;
+
   private BufferAllocator allocator;
 
   private VarCharVector vector;
@@ -58,6 +63,8 @@ public class VariableWidthVectorBenchmarks {
     allocator = new RootAllocator(ALLOCATOR_CAPACITY);
     vector = new VarCharVector("vector", allocator);
     vector.allocateNew(VECTOR_CAPACITY, VECTOR_LENGTH);
+    arrowBuff = allocator.buffer(VECTOR_LENGTH);
+    arrowBuff.setBytes(0, bytes, 0, bytes.length);
   }
 
   /**
@@ -65,6 +72,7 @@ public class VariableWidthVectorBenchmarks {
    */
   @TearDown
   public void tearDown() {
+    arrowBuff.close();
     vector.close();
     allocator.close();
   }
@@ -79,6 +87,37 @@ public class VariableWidthVectorBenchmarks {
   public int getValueCapacity() {
     return vector.getValueCapacity();
   }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int setSafeFromArray() {
+    for(int i =0; i < 500; ++i){
+      vector.setSafe(i * 40, bytes);
+    }
+    return vector.getBufferSize();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public int setSafeFromNullableVarcharHolder() {
+    NullableVarCharHolder nvch = new NullableVarCharHolder();
+    nvch.buffer = arrowBuff;
+    nvch.start = 0;
+    nvch.end = bytes.length;
+    for(int i =0; i < 50; ++i) {
+      nvch.isSet = 0;
+      for (int j = 0; j < 9; ++j) {
+        int idx = 10 * i + j;
+        vector.setSafe(idx, nvch);
+      }
+      nvch.isSet = 1;
+      vector.setSafe(10 * (i + 1), nvch);
+    }
+    return vector.getBufferSize();
+  }
+
 
   public static void main(String [] args) throws RunnerException {
     Options opt = new OptionsBuilder()

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -1245,7 +1245,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     while (index >= getValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
-    final int startOffset = getStartOffset(index);
+    final int startOffset = lastSet < 0 ? 0 : getStartOffset(lastSet + 1);
     while (valueBuffer.capacity() < (startOffset + dataLength)) {
       reallocDataBuffer();
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -999,8 +999,8 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   public void setSafe(int index, byte[] value) {
     assert index >= 0;
-    fillEmpties(index);
     handleSafe(index, value.length);
+    fillHoles(index);
     BitVectorHelper.setBit(validityBuffer, index);
     setBytes(index, value, 0, value.length);
     lastSet = index;
@@ -1035,8 +1035,8 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   public void setSafe(int index, byte[] value, int start, int length) {
     assert index >= 0;
-    fillEmpties(index);
     handleSafe(index, length);
+    fillHoles(index);
     BitVectorHelper.setBit(validityBuffer, index);
     setBytes(index, value, start, length);
     lastSet = index;
@@ -1073,8 +1073,8 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   public void setSafe(int index, ByteBuffer value, int start, int length) {
     assert index >= 0;
-    fillEmpties(index);
     handleSafe(index, length);
+    fillHoles(index);
     BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = getStartOffset(index);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + length);
@@ -1129,8 +1129,8 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   public void setSafe(int index, int isSet, int start, int end, ArrowBuf buffer) {
     assert index >= 0;
     final int dataLength = end - start;
-    fillEmpties(index);
     handleSafe(index, dataLength);
+    fillHoles(index);
     BitVectorHelper.setValidityBit(validityBuffer, index, isSet);
     final int startOffset = offsetBuffer.getInt(index * OFFSET_WIDTH);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + dataLength);
@@ -1170,8 +1170,8 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   public void setSafe(int index, int start, int length, ArrowBuf buffer) {
     assert index >= 0;
-    fillEmpties(index);
     handleSafe(index, length);
+    fillHoles(index);
     BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = offsetBuffer.getInt(index * OFFSET_WIDTH);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + length);

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarBinaryVector.java
@@ -184,8 +184,8 @@ public final class VarBinaryVector extends BaseVariableWidthVector {
   public void setSafe(int index, VarBinaryHolder holder) {
     assert index >= 0;
     final int dataLength = holder.end - holder.start;
-    fillEmpties(index);
     handleSafe(index, dataLength);
+    fillHoles(index);
     BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = getStartOffset(index);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + dataLength);
@@ -225,18 +225,17 @@ public final class VarBinaryVector extends BaseVariableWidthVector {
    */
   public void setSafe(int index, NullableVarBinaryHolder holder) {
     assert index >= 0;
-    fillEmpties(index);
-    BitVectorHelper.setValidityBit(validityBuffer, index, holder.isSet);
-    final int startOffset = getStartOffset(index);
     if (holder.isSet != 0) {
       final int dataLength = holder.end - holder.start;
       handleSafe(index, dataLength);
+      fillHoles(index);
+      final int startOffset = getStartOffset(index);
       offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + dataLength);
       valueBuffer.setBytes(startOffset, holder.buffer, holder.start, dataLength);
     } else {
-      handleSafe(index, 0);
-      offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset);
+      fillEmpties(index + 1);
     }
+    BitVectorHelper.setValidityBit(validityBuffer, index, holder.isSet);
     lastSet = index;
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VarCharVector.java
@@ -186,8 +186,9 @@ public final class VarCharVector extends BaseVariableWidthVector {
   public void setSafe(int index, VarCharHolder holder) {
     assert index >= 0;
     final int dataLength = holder.end - holder.start;
-    fillEmpties(index);
     handleSafe(index, dataLength);
+    fillHoles(index);
+
     BitVectorHelper.setBit(validityBuffer, index);
     final int startOffset = getStartOffset(index);
     offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + dataLength);
@@ -227,18 +228,17 @@ public final class VarCharVector extends BaseVariableWidthVector {
    */
   public void setSafe(int index, NullableVarCharHolder holder) {
     assert index >= 0;
-    fillEmpties(index);
-    BitVectorHelper.setValidityBit(validityBuffer, index, holder.isSet);
-    final int startOffset = getStartOffset(index);
     if (holder.isSet != 0) {
       final int dataLength = holder.end - holder.start;
       handleSafe(index, dataLength);
+      fillHoles(index);
+      final int startOffset = getStartOffset(index);
       offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset + dataLength);
       valueBuffer.setBytes(startOffset, holder.buffer, holder.start, dataLength);
     } else {
-      handleSafe(index, 0);
-      offsetBuffer.setInt((index + 1) * OFFSET_WIDTH, startOffset);
+      fillEmpties(index + 1);
     }
+    BitVectorHelper.setValidityBit(validityBuffer, index, holder.isSet);
     lastSet = index;
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import java.math.BigDecimal;
+import java.nio.charset.Charset;
 import java.time.Duration;
 import java.time.Period;
 
@@ -1069,4 +1070,27 @@ public class TestCopyFrom {
       }
     }
   }
+
+  @Test //https://issues.apache.org/jira/browse/ARROW-7837
+  public void testCopySafeArrow7837() {
+    try (VarCharVector vc1 = new VarCharVector("vc1", allocator);
+         VarCharVector vc2 = new VarCharVector("vc2", allocator);
+    ) {
+      vc2.setInitialCapacity(20, 0.5);
+
+      vc1.setSafe(0, "1234567890".getBytes(Charset.forName("utf-8")));
+      assertFalse(vc1.isNull(0));
+      assertEquals(vc1.getObject(0).toString(), "1234567890");
+
+      vc2.copyFromSafe(0, 0, vc1);
+      assertFalse(vc2.isNull(0));
+      assertEquals(vc2.getObject(0).toString(), "1234567890");
+
+      vc2.copyFromSafe(0, 5, vc1);
+      assertFalse(vc2.isNull(5));
+      assertEquals(vc2.getObject(5).toString(), "1234567890");
+    }
+  }
+
+
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
@@ -1078,7 +1078,8 @@ public class TestCopyFrom {
     try (VarCharVector vc1 = new VarCharVector("vc1", allocator);
          VarCharVector vc2 = new VarCharVector("vc2", allocator);
     ) {
-      vc2.setInitialCapacity(20, 0.5);
+      //initial size is carefully set in order to force the second 'copyFromSafe' operation t trigger a reallocation of the vector.
+      vc2.setInitialCapacity(/*valueCount*/20, /*density*/0.5);
 
       vc1.setSafe(0, "1234567890".getBytes(Charset.forName("utf-8")));
       assertFalse(vc1.isNull(0));
@@ -1089,6 +1090,10 @@ public class TestCopyFrom {
       assertEquals(vc2.getObject(0).toString(), "1234567890");
 
       vc2.copyFromSafe(0, 5, vc1);
+      assertTrue(vc2.isNull(1));
+      assertTrue(vc2.isNull(2));
+      assertTrue(vc2.isNull(3));
+      assertTrue(vc2.isNull(4));
       assertFalse(vc2.isNull(5));
       assertEquals(vc2.getObject(5).toString(), "1234567890");
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
@@ -1078,7 +1078,8 @@ public class TestCopyFrom {
     try (VarCharVector vc1 = new VarCharVector("vc1", allocator);
          VarCharVector vc2 = new VarCharVector("vc2", allocator);
     ) {
-      //initial size is carefully set in order to force the second 'copyFromSafe' operation t trigger a reallocation of the vector.
+      //initial size is carefully set in order to force the second 'copyFromSafe' operation
+      // to trigger a reallocation of the vector.
       vc2.setInitialCapacity(/*valueCount*/20, /*density*/0.5);
 
       vc1.setSafe(0, "1234567890".getBytes(Charset.forName("utf-8")));

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
@@ -1073,7 +1073,8 @@ public class TestCopyFrom {
 
   @Test //https://issues.apache.org/jira/browse/ARROW-7837
   public void testCopySafeArrow7837() {
-    // this test exposes a bug in `handleSafe` where it read a stale index and as a result missed a requires resize of the value vector.
+    // this test exposes a bug in `handleSafe` where
+    // it read a stale index and as a result missed a requires resize of the value vector.
     try (VarCharVector vc1 = new VarCharVector("vc1", allocator);
          VarCharVector vc2 = new VarCharVector("vc2", allocator);
     ) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
@@ -1074,7 +1074,7 @@ public class TestCopyFrom {
   @Test //https://issues.apache.org/jira/browse/ARROW-7837
   public void testCopySafeArrow7837() {
     // this test exposes a bug in `handleSafe` where
-    // it read a stale index and as a result missed a requires resize of the value vector.
+    // it reads a stale index and as a result missed a required resize of the value vector.
     try (VarCharVector vc1 = new VarCharVector("vc1", allocator);
          VarCharVector vc2 = new VarCharVector("vc2", allocator);
     ) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestCopyFrom.java
@@ -1073,6 +1073,7 @@ public class TestCopyFrom {
 
   @Test //https://issues.apache.org/jira/browse/ARROW-7837
   public void testCopySafeArrow7837() {
+    // this test exposes a bug in `handleSafe` where it read a stale index and as a result missed a requires resize of the value vector.
     try (VarCharVector vc1 = new VarCharVector("vc1", allocator);
          VarCharVector vc2 = new VarCharVector("vc2", allocator);
     ) {


### PR DESCRIPTION
this fixes [ARROW-7837](https://issues.apache.org/jira/browse/ARROW-7837).
* introduces a small test case showing how `copyFromSafe` fails on index-out-of-bounds when skipping some indices when adding values to a `VarCharVector` (probably happens to `VarBinaryVector` as well).
* root cause is a bug in `handleSafe` which loads a stale write index resulting with a failure to identify the need to resize the value buffer.
* fixed `handleSafe` to consult with the last-set index in order to properly calculate the future end offset of writing requested length to the buffer.