### PR TITLE
ARROW-7699: [Java] Support concating dense union vectors in batch

### DIFF
--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -150,7 +150,7 @@ public class DenseUnionVector implements FieldVector {
 
   @Override
   public MinorType getMinorType() {
-    return MinorType.UNION;
+    return MinorType.DENSEUNION;
   }
 
   @Override
@@ -259,6 +259,8 @@ public class DenseUnionVector implements FieldVector {
 
   @Override
   public ArrowBuf getOffsetBuffer() { return offsetBuffer; }
+
+  public ArrowBuf getTypeBuffer() { return typeBuffer; }
 
   @Override
   public ArrowBuf getDataBuffer() { throw new UnsupportedOperationException(); }
@@ -671,7 +673,6 @@ public class DenseUnionVector implements FieldVector {
           typeStarts[typeId] = offsetBuffer.getInt(i * OFFSET_WIDTH);
         }
       }
-      to.setValueCount(length);
 
       // transfer vector values
       for (int i = 0; i < nextTypeId; i++) {
@@ -680,6 +681,8 @@ public class DenseUnionVector implements FieldVector {
           to.childVectors[i] = internalTransferPairs[i].getTo();
         }
       }
+
+      to.setValueCount(length);
     }
 
     @Override
@@ -802,7 +805,20 @@ public class DenseUnionVector implements FieldVector {
       reallocTypeBuffer();
       reallocOffsetBuffer();
     }
-    internalStruct.setValueCount(valueCount);
+    setChildVectorValueCounts();
+  }
+
+  private void setChildVectorValueCounts() {
+    int [] counts = new int[nextTypeId];
+    for (int i = 0; i < this.valueCount; i++) {
+      if (!isNull(i)) {
+        byte typeId = getTypeId(i);
+        counts[typeId] += 1;
+      }
+    }
+    for (int i = 0; i < nextTypeId; i++) {
+      childVectors[i].setValueCount(counts[i]);
+    }
   }
 
   public void setSafe(int index, DenseUnionHolder holder) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDenseUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDenseUnionVector.java
@@ -30,11 +30,13 @@ import java.util.Map;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.holders.NullableBigIntHolder;
 import org.apache.arrow.vector.holders.NullableBitHolder;
 import org.apache.arrow.vector.holders.NullableFloat4Holder;
 import org.apache.arrow.vector.holders.NullableIntHolder;
 import org.apache.arrow.vector.holders.NullableUInt4Holder;
 import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
+import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
 import org.apache.arrow.vector.types.UnionMode;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -202,6 +204,7 @@ public class TestDenseUnionVector {
       assertEquals(50, sourceVector.getObject(9));
 
       try (DenseUnionVector toVector = new DenseUnionVector(EMPTY_SCHEMA_PATH, allocator, null, null)) {
+        toVector.registerNewTypeId(Field.nullable("", MinorType.INT.getType()));
 
         final TransferPair transferPair = sourceVector.makeTransferPair(toVector);
 
@@ -295,6 +298,8 @@ public class TestDenseUnionVector {
       assertEquals(30.5f, sourceVector.getObject(9));
 
       try (DenseUnionVector toVector = new DenseUnionVector(EMPTY_SCHEMA_PATH, allocator, null, null)) {
+        toVector.registerNewTypeId(Field.nullable("", MinorType.INT.getType()));
+        toVector.registerNewTypeId(Field.nullable("", MinorType.FLOAT4.getType()));
 
         final TransferPair transferPair = sourceVector.makeTransferPair(toVector);
 
@@ -337,7 +342,7 @@ public class TestDenseUnionVector {
             /*dictionary=*/null, metadata);
     final Field field = new Field("union", fieldType, children);
 
-    MinorType minorType = MinorType.UNION;
+    MinorType minorType = MinorType.DENSEUNION;
     DenseUnionVector vector = (DenseUnionVector) minorType.getNewVector(field, allocator, null);
     vector.initializeChildrenFromFields(children);
 
@@ -448,7 +453,10 @@ public class TestDenseUnionVector {
       // add two struct vectors to union vector
       unionVector.addVector(typeId1, structVector1);
       unionVector.addVector(typeId2, structVector2);
-      unionVector.setValueCount(3);
+
+      while (unionVector.getValueCapacity() < 3) {
+        unionVector.reAlloc();
+      }
 
       ArrowBuf offsetBuf = unionVector.getOffsetBuffer();
 
@@ -463,6 +471,8 @@ public class TestDenseUnionVector {
       unionVector.setTypeId(2, typeId1);
       offsetBuf.setInt(DenseUnionVector.OFFSET_WIDTH * 2, 1);
       BitVectorHelper.setBit(unionVector.getValidityBuffer(), 2);
+
+      unionVector.setValueCount(3);
 
       Map<String, Integer> value0 = new JsonStringHashMap<>();
       value0.put("sub11", 0);
@@ -489,7 +499,6 @@ public class TestDenseUnionVector {
    */
   @Test
   public void testMultipleVarChars() {
-    FieldType type = new FieldType(true, ArrowType.Struct.INSTANCE, null, null);
     try (VarCharVector childVector1 = new VarCharVector("child1", allocator);
          VarCharVector childVector2 = new VarCharVector("child2", allocator);
          DenseUnionVector unionVector = DenseUnionVector.empty("union", allocator)) {
@@ -505,7 +514,9 @@ public class TestDenseUnionVector {
       assertEquals(typeId1, 0);
       assertEquals(typeId2, 1);
 
-      unionVector.setValueCount(5);
+      while (unionVector.getValueCapacity() < 5) {
+        unionVector.reAlloc();
+      }
 
       // add two struct vectors to union vector
       unionVector.addVector(typeId1, childVector1);
@@ -536,11 +547,70 @@ public class TestDenseUnionVector {
       offsetBuf.setInt(DenseUnionVector.OFFSET_WIDTH * 4, 1);
       BitVectorHelper.setBit(unionVector.getValidityBuffer(), 4);
 
+      unionVector.setValueCount(5);
+
       assertEquals(new Text("a0"), unionVector.getObject(0));
       assertEquals(new Text("b1"), unionVector.getObject(1));
       assertEquals(new Text("b2"), unionVector.getObject(2));
       assertNull(unionVector.getObject(3));
       assertEquals(new Text("a4"), unionVector.getObject(4));
+    }
+  }
+
+  @Test
+  public void testChildVectorValueCounts() {
+    final NullableIntHolder intHolder = new NullableIntHolder();
+    intHolder.isSet = 1;
+
+    final NullableBigIntHolder longHolder = new NullableBigIntHolder();
+    longHolder.isSet = 1;
+
+    final NullableFloat4Holder floatHolder = new NullableFloat4Holder();
+    floatHolder.isSet = 1;
+
+    try (DenseUnionVector vector = new DenseUnionVector("vector", allocator, null, null)) {
+      vector.allocateNew();
+
+      // populate the delta vector with values {7, null, 8L, 9.0f, 10, 12L}
+      while (vector.getValueCapacity() < 6) {
+        vector.reAlloc();
+      }
+      byte intTypeId = vector.registerNewTypeId(Field.nullable("", Types.MinorType.INT.getType()));
+      vector.setTypeId(0, intTypeId);
+      intHolder.value = 7;
+      vector.setSafe(0, intHolder);
+      byte longTypeId = vector.registerNewTypeId(Field.nullable("", Types.MinorType.BIGINT.getType()));
+      vector.setTypeId(2, longTypeId);
+      longHolder.value = 8L;
+      vector.setSafe(2, longHolder);
+      byte floatTypeId = vector.registerNewTypeId(Field.nullable("", Types.MinorType.FLOAT4.getType()));
+      vector.setTypeId(3, floatTypeId);
+      floatHolder.value = 9.0f;
+      vector.setSafe(3, floatHolder);
+
+      vector.setTypeId(4, intTypeId);
+      intHolder.value = 10;
+      vector.setSafe(4, intHolder);
+      vector.setTypeId(5, longTypeId);
+      longHolder.value = 12L;
+      vector.setSafe(5, longHolder);
+
+      vector.setValueCount(6);
+
+      // verify results
+      IntVector intVector = (IntVector) vector.getVectorByType(intTypeId);
+      assertEquals(2, intVector.getValueCount());
+      assertEquals(7, intVector.get(0));
+      assertEquals(10, intVector.get(1));
+
+      BigIntVector longVector = (BigIntVector) vector.getVectorByType(longTypeId);
+      assertEquals(2, longVector.getValueCount());
+      assertEquals(8L, longVector.get(0));
+      assertEquals(12L, longVector.get(1));
+
+      Float4Vector floagVector = (Float4Vector) vector.getVectorByType(floatTypeId);
+      assertEquals(1, floagVector.getValueCount());
+      assertEquals(9.0f, floagVector.get(0), 0);
     }
   }
 


### PR DESCRIPTION
After supporting the dense union vector, we need to support concating dense union vectors in batch.

In addition, since we have supported 64-bit buffers, we need to adjust other append methods to avoid integer overflow. 