### PR TITLE
ARROW-7895: [Python] Remove more python 2.7 cruft

### DIFF
--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -20,19 +20,14 @@
 import re
 import sys
 
-try:
-    import argparse
-    import concurrent.futures as cf
-    import functools
-    import hashlib
-    import json
-    import os
-    import subprocess
-    import urllib.request
-except ImportError:
-    if sys.version_info.major < 3:
-        raise Exception("Please use Python 3 to run this script")
-    raise
+import argparse
+import concurrent.futures as cf
+import functools
+import hashlib
+import json
+import os
+import subprocess
+import urllib.request
 
 
 BINTRAY_API_ROOT = "https://bintray.com/api/v1"

--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -18,7 +18,6 @@
 #
 
 import re
-import sys
 
 import argparse
 import concurrent.futures as cf

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -614,7 +614,7 @@ check_python_imports() {
 }
 
 test_linux_wheels() {
-  local py_arches="2.7mu 3.5m 3.6m 3.7m 3.8"
+  local py_arches="3.5m 3.6m 3.7m 3.8"
   local manylinuxes="1 2010 2014"
 
   for py_arch in ${py_arches}; do
@@ -623,11 +623,6 @@ test_linux_wheels() {
     conda activate ${env}
 
     for ml_spec in ${manylinuxes}; do
-      if [[ "$py_arch" = "2.7mu" && "$ml_spec" = "2014" ]]; then
-        # manylinux2014 does not support py2.7, so skip that one
-        continue
-      fi
-
       # check the mandatory and optional imports
       pip install python-rc/${VERSION}-rc${RC_NUMBER}/pyarrow-${VERSION}-cp${py_arch//[mu.]/}-cp${py_arch//./}-manylinux${ml_spec}_x86_64.whl
       check_python_imports py_arch
@@ -644,7 +639,7 @@ test_linux_wheels() {
 }
 
 test_macos_wheels() {
-  local py_arches="2.7m 3.5m 3.6m 3.7m 3.8"
+  local py_arches="3.5m 3.6m 3.7m 3.8"
 
   for py_arch in ${py_arches}; do
     local env=_verify_wheel-${py_arch}

--- a/dev/tasks/gandiva-jars/build-cpp-linux.sh
+++ b/dev/tasks/gandiva-jars/build-cpp-linux.sh
@@ -22,8 +22,8 @@ source /multibuild/manylinux_utils.sh
 # Quit on failure
 set -e
 
-PYTHON_VERSION=2.7
-CPYTHON_PATH="$(cpython_path ${PYTHON_VERSION} 16)"
+PYTHON_VERSION=3.6
+CPYTHON_PATH="$(cpython_path ${PYTHON_VERSION})"
 PYTHON_INTERPRETER="${CPYTHON_PATH}/bin/python"
 PIP="${CPYTHON_PATH}/bin/pip"
 
@@ -69,4 +69,3 @@ popd
 
 # copy the library to distribution
 cp -L  /arrow-dist/lib/libgandiva_jni.so /io/dist
-

--- a/dev/tasks/python-wheels/manylinux-test.sh
+++ b/dev/tasks/python-wheels/manylinux-test.sh
@@ -37,7 +37,6 @@ fi
 
 # Test import and optional dependencies
 python -c "
-import sys
 import pyarrow
 import pyarrow.parquet
 import pyarrow.plasma

--- a/dev/tasks/python-wheels/manylinux-test.sh
+++ b/dev/tasks/python-wheels/manylinux-test.sh
@@ -43,9 +43,7 @@ import pyarrow.parquet
 import pyarrow.plasma
 import pyarrow.fs
 import pyarrow._hdfs
-
-if sys.version_info.major > 2:
-    import pyarrow.dataset
-    import pyarrow.flight
-    import pyarrow.gandiva
+import pyarrow.dataset
+import pyarrow.flight
+import pyarrow.gandiva
 "

--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -104,14 +104,8 @@ function build_wheel {
 
     pip install $(pip_opts) -r python/requirements-wheel.txt cython
 
-    if [ ${MB_PYTHON_VERSION} != "2.7" ]; then
-      # Gandiva is not supported on Python 2.7
-      export PYARROW_WITH_GANDIVA=1
-      export BUILD_ARROW_GANDIVA=ON
-    else
-      export PYARROW_WITH_GANDIVA=0
-      export BUILD_ARROW_GANDIVA=OFF
-    fi
+    export PYARROW_WITH_GANDIVA=1
+    export BUILD_ARROW_GANDIVA=ON
 
     git submodule update --init
     export ARROW_TEST_DATA=`pwd`/testing/data
@@ -223,10 +217,8 @@ import pyarrow.parquet
 import pyarrow.plasma
 import pyarrow.fs
 import pyarrow._hdfs
-
-if sys.version_info.major > 2:
-    import pyarrow.dataset
-    import pyarrow.flight
-    import pyarrow.gandiva
+import pyarrow.dataset
+import pyarrow.flight
+import pyarrow.gandiva
 "
 }

--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -211,7 +211,6 @@ function run_unit_tests {
 function run_import_tests {
     # Test optional dependencies
     python -c "
-import sys
 import pyarrow
 import pyarrow.parquet
 import pyarrow.plasma

--- a/dev/tasks/python-wheels/win-build.bat
+++ b/dev/tasks/python-wheels/win-build.bat
@@ -72,8 +72,6 @@ popd
 
 set PYARROW_BUILD_TYPE=Release
 set PYARROW_PARALLEL=8
-@rem Flight, Gandiva and Dataset are not supported on Python 2.7,
-@rem but we don't build 2.7 wheels for Windows.
 set PYARROW_WITH_DATASET=1
 set PYARROW_WITH_FLIGHT=1
 set PYARROW_WITH_GANDIVA=1

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -97,7 +97,6 @@ groups:
     - test-ubuntu-c-glib
     - test-debian-ruby
     - test-ubuntu-ruby
-    - test-conda-python-2.7
     - test-conda-python-3.6
     - test-conda-python-3.7
     - test-conda-python-3.8
@@ -115,8 +114,6 @@ groups:
     - test-ubuntu-18.04-r-sanitizer
     - test-debian-10-go-1.12
     - test-ubuntu-18.04-docs
-    - test-conda-python-2.7-pandas-latest
-    - test-conda-python-2.7-pandas-master
     - test-conda-python-3.7-pandas-latest
     - test-conda-python-3.7-pandas-master
     - test-conda-python-3.8-pandas-latest
@@ -141,7 +138,6 @@ groups:
     - test-ubuntu-c-glib
     - test-debian-ruby
     - test-ubuntu-ruby
-    - test-conda-python-2.7
     - test-conda-python-3.6
     - test-conda-python-3.7
     - test-conda-python-3.8
@@ -175,7 +171,6 @@ groups:
     - test-ubuntu-c-glib
 
   python:
-    - test-conda-python-2.7
     - test-conda-python-3.6
     - test-conda-python-3.7
     - test-conda-python-3.8
@@ -199,8 +194,6 @@ groups:
     - test-ubuntu-ruby
 
   integration:
-    - test-conda-python-2.7-pandas-latest
-    - test-conda-python-2.7-pandas-master
     - test-conda-python-3.7-pandas-latest
     - test-conda-python-3.7-pandas-master
     - test-conda-python-3.8-pandas-latest
@@ -269,7 +262,6 @@ groups:
     - test-ubuntu-c-glib
     - test-debian-ruby
     - test-ubuntu-ruby
-    - test-conda-python-2.7
     - test-conda-python-3.6
     - test-conda-python-3.7
     - test-debian-10-python-3
@@ -285,7 +277,6 @@ groups:
     - test-ubuntu-18.04-r-sanitizer
     - test-debian-10-go-1.12
     - test-ubuntu-18.04-docs
-    - test-conda-python-2.7-pandas-latest
     - test-conda-python-3.7-pandas-latest
     - test-conda-python-3.7-pandas-master
     - test-conda-python-3.8-pandas-latest
@@ -1756,19 +1747,6 @@ tasks:
         - docker-compose build ubuntu-ruby
         - docker-compose run ubuntu-ruby
 
-  test-conda-python-2.7:
-    ci: circle
-    platform: linux
-    template: docker-tests/circle.linux.yml
-    params:
-      commands:
-        - export PYTHON=2.7
-        - docker-compose pull --ignore-pull-failures conda-cpp
-        - docker-compose pull --ignore-pull-failures conda-python
-        - docker-compose build conda-cpp
-        - docker-compose build conda-python
-        - docker-compose run conda-python
-
   test-conda-python-3.6:
     ci: circle
     platform: linux
@@ -1964,20 +1942,6 @@ tasks:
         - docker-compose run ubuntu-docs
 
   ############################## Integration tests ############################
-
-  test-conda-python-2.7-pandas-latest:
-    ci: circle
-    platform: linux
-    template: docker-tests/circle.linux.yml
-    params:
-      commands:
-        - export PYTHON=2.7 PANDAS=latest
-        - docker-compose pull --ignore-pull-failures conda-cpp
-        - docker-compose pull --ignore-pull-failures conda-python
-        - docker-compose build conda-cpp
-        - docker-compose build conda-python
-        - docker-compose build --no-cache conda-python-pandas
-        - docker-compose run conda-python-pandas
 
   test-conda-python-3.7-pandas-latest:
     ci: circle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -411,7 +411,7 @@ services:
     #   docker-compose run --rm conda-python
     # Parameters:
     #   ARCH: amd64, arm32v7
-    #   PYTHON: 2.7, 3.6, 3.7, 3.8
+    #   PYTHON: 3.6, 3.7, 3.8
     image: ${REPO}:${ARCH}-conda-python-${PYTHON}
     build:
       context: .

--- a/python/manylinux1/scripts/build_llvm.sh
+++ b/python/manylinux1/scripts/build_llvm.sh
@@ -37,7 +37,7 @@ cmake -DCMAKE_INSTALL_PREFIX=$PREFIX \
     -DLLVM_ENABLE_RTTI=ON \
     -DLLVM_ENABLE_OCAMLDOC=OFF \
     -DLLVM_USE_INTEL_JITEVENTS=ON \
-    -DPYTHON_EXECUTABLE="$(cpython_path 2.7 32)/bin/python" \
+    -DPYTHON_EXECUTABLE="$(cpython_path 3.6)/bin/python" \
     -GNinja \
     ..
 ninja install

--- a/python/manylinux1/scripts/build_python.sh
+++ b/python/manylinux1/scripts/build_python.sh
@@ -25,7 +25,7 @@
 # (https://github.com/pypa/manylinux/).
 
 PYTHON_DOWNLOAD_URL=https://www.python.org/ftp/python
-CPYTHON_VERSIONS="2.7.15 3.4.9 3.5.6 3.6.8 3.7.2"
+CPYTHON_VERSIONS="3.5.6 3.6.8 3.7.2"
 
 # openssl version to build, with expected sha256 hash of .tar.gz
 # archive.

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -210,9 +210,7 @@ def _has_pkg_config(pkgname):
     try:
         return subprocess.call([_get_pkg_config_executable(),
                                 '--exists', pkgname]) == 0
-    except OSError:
-        # TODO: replace with FileNotFoundError once we ditch 2.7
-        # Update: we have ditched 2.7
+    except FileNotFoundError:
         return False
 
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -212,6 +212,7 @@ def _has_pkg_config(pkgname):
                                 '--exists', pkgname]) == 0
     except OSError:
         # TODO: replace with FileNotFoundError once we ditch 2.7
+        # Update: we have ditched 2.7
         return False
 
 


### PR DESCRIPTION
I noticed we had some failing nightly builds using python 2.7 so I searched for more places we could remove 2.7.