### PR TITLE
ARROW-6666: [Rust] Datafusion parquet string literal support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ docker_cache
 .gdb_history
 .DS_Store
 *.orig
+.*.swp
+.*.swo
 
 site/
 

--- a/rust/arrow/benches/comparison_kernels.rs
+++ b/rust/arrow/benches/comparison_kernels.rs
@@ -39,37 +39,37 @@ fn create_array(size: usize) -> Float32Array {
 pub fn eq_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a == b).unwrap());
+    criterion::black_box(no_simd_compare_op(&arr_a, &arr_b, |a, b| a == b).unwrap());
 }
 
 pub fn neq_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a != b).unwrap());
+    criterion::black_box(no_simd_compare_op(&arr_a, &arr_b, |a, b| a != b).unwrap());
 }
 
 pub fn lt_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a < b).unwrap());
+    criterion::black_box(no_simd_compare_op(&arr_a, &arr_b, |a, b| a < b).unwrap());
 }
 
 fn lt_eq_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a <= b).unwrap());
+    criterion::black_box(no_simd_compare_op(&arr_a, &arr_b, |a, b| a <= b).unwrap());
 }
 
 pub fn gt_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a > b).unwrap());
+    criterion::black_box(no_simd_compare_op(&arr_a, &arr_b, |a, b| a > b).unwrap());
 }
 
 fn gt_eq_no_simd(size: usize) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
-    criterion::black_box(compare_op(&arr_a, &arr_b, |a, b| a >= b).unwrap());
+    criterion::black_box(no_simd_compare_op(&arr_a, &arr_b, |a, b| a >= b).unwrap());
 }
 
 fn eq_simd(size: usize) {

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1120,6 +1120,7 @@ impl StringArray {
                 self.value_data.get().offset(pos as isize),
                 (self.value_offset_at(offset + 1) - pos) as usize,
             );
+
             std::str::from_utf8_unchecked(slice)
         }
     }

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -22,25 +22,77 @@
 //! `RUSTFLAGS="-C target-feature=+avx2"` for example.  See the documentation
 //! [here](https://doc.rust-lang.org/stable/core/arch/) for more information.
 
+use regex::Regex;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::array::*;
-use crate::buffer::Buffer;
 use crate::compute::util::apply_bin_op_to_option_bitmap;
-use crate::datatypes::{ArrowNumericType, BooleanType, DataType, ToByteSlice};
+use crate::datatypes::{ArrowNumericType, BooleanType, DataType};
 use crate::error::{ArrowError, Result};
 
 /// Helper function to perform boolean lambda function on values from two arrays, this
 /// version does not attempt to use SIMD.
-pub fn compare_op<T, F>(
-    left: &PrimitiveArray<T>,
-    right: &PrimitiveArray<T>,
-    op: F,
-) -> Result<BooleanArray>
-where
-    T: ArrowNumericType,
-    F: Fn(T::Native, T::Native) -> bool,
-{
+macro_rules! compare_op {
+    ($left: expr, $right:expr, $op:expr) => {{
+        if $left.len() != $right.len() {
+            return Err(ArrowError::ComputeError(
+                "Cannot perform math operation on arrays of different length".to_string(),
+            ));
+        }
+
+        let null_bit_buffer = apply_bin_op_to_option_bitmap(
+            $left.data().null_bitmap(),
+            $right.data().null_bitmap(),
+            |a, b| a & b,
+        )?;
+
+        let mut result = BooleanBufferBuilder::new($left.len());
+        for i in 0..$left.len() {
+            result.append($op($left.value(i), $right.value(i)))?;
+        }
+
+        let data = ArrayData::new(
+            DataType::Boolean,
+            $left.len(),
+            None,
+            null_bit_buffer,
+            $left.offset(),
+            vec![result.finish()],
+            vec![],
+        );
+        Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+    }};
+}
+
+struct RegexCache<'a> {
+    map: HashMap<&'a str, Regex>,
+}
+
+impl<'a> RegexCache<'a> {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    fn match_str(&'a mut self, a: &str, pat: &'a str) -> bool {
+        let re = if let Some(ref regex) = self.map.get(pat) {
+            regex
+        } else {
+            let re_pattern = pat.replace("%", ".*").replace("_", ".");
+            let re = Regex::new(&re_pattern).unwrap();
+            self.map.insert(pat, re);
+
+            self.map.get(pat).unwrap()
+        };
+
+        re.is_match(a)
+    }
+}
+
+pub fn like_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
+    let mut map = HashMap::new();
     if left.len() != right.len() {
         return Err(ArrowError::ComputeError(
             "Cannot perform math operation on arrays of different length".to_string(),
@@ -53,9 +105,20 @@ where
         |a, b| a & b,
     )?;
 
-    let mut values = Vec::with_capacity(left.len());
+    let mut result = BooleanBufferBuilder::new(left.len());
     for i in 0..left.len() {
-        values.push(op(left.value(i), right.value(i)));
+        let haystack = left.value(i);
+        let pat = right.value(i);
+        let re = if let Some(ref regex) = map.get(pat) {
+            regex
+        } else {
+            let re_pattern = pat.replace("%", ".*").replace("_", ".");
+            let re = Regex::new(&re_pattern).unwrap();
+            map.insert(pat, re);
+            map.get(pat).unwrap()
+        };
+
+        result.append(re.is_match(haystack))?;
     }
 
     let data = ArrayData::new(
@@ -64,10 +127,76 @@ where
         None,
         null_bit_buffer,
         left.offset(),
-        vec![Buffer::from(values.to_byte_slice())],
+        vec![result.finish()],
         vec![],
     );
     Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+}
+
+pub fn nlike_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
+    let mut map = HashMap::new();
+    if left.len() != right.len() {
+        return Err(ArrowError::ComputeError(
+            "Cannot perform math operation on arrays of different length".to_string(),
+        ));
+    }
+
+    let null_bit_buffer = apply_bin_op_to_option_bitmap(
+        left.data().null_bitmap(),
+        right.data().null_bitmap(),
+        |a, b| a & b,
+    )?;
+
+    let mut result = BooleanBufferBuilder::new(left.len());
+    for i in 0..left.len() {
+        let haystack = left.value(i);
+        let pat = right.value(i);
+        let re = if let Some(ref regex) = map.get(pat) {
+            regex
+        } else {
+            let re_pattern = pat.replace("%", ".*").replace("_", ".");
+            let re = Regex::new(&re_pattern).unwrap();
+            map.insert(pat, re);
+            map.get(pat).unwrap()
+        };
+
+        result.append(!re.is_match(haystack))?;
+    }
+
+    let data = ArrayData::new(
+        DataType::Boolean,
+        left.len(),
+        None,
+        null_bit_buffer,
+        left.offset(),
+        vec![result.finish()],
+        vec![],
+    );
+    Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
+}
+
+pub fn eq_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
+    compare_op!(left, right, |a, b| a == b)
+}
+
+pub fn neq_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
+    compare_op!(left, right, |a, b| a != b)
+}
+
+pub fn lt_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
+    compare_op!(left, right, |a, b| a < b)
+}
+
+pub fn lt_eq_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
+    compare_op!(left, right, |a, b| a <= b)
+}
+
+pub fn gt_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
+    compare_op!(left, right, |a, b| a > b)
+}
+
+pub fn gt_eq_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
+    compare_op!(left, right, |a, b| a >= b)
 }
 
 /// Helper function to perform boolean lambda function on values from two arrays using
@@ -126,8 +255,11 @@ where
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
     return simd_compare_op(left, right, |a, b| T::eq(a, b));
 
-    #[allow(unreachable_code)]
-    compare_op(left, right, |a, b| a == b)
+    #[cfg(any(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        not(feature = "simd")
+    ))]
+    compare_op!(left, right, |a, b| a == b)
 }
 
 /// Perform `left != right` operation on two arrays.
@@ -138,8 +270,11 @@ where
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
     return simd_compare_op(left, right, |a, b| T::ne(a, b));
 
-    #[allow(unreachable_code)]
-    compare_op(left, right, |a, b| a != b)
+    #[cfg(any(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        not(feature = "simd")
+    ))]
+    compare_op!(left, right, |a, b| a != b)
 }
 
 /// Perform `left < right` operation on two arrays. Null values are less than non-null
@@ -151,8 +286,11 @@ where
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
     return simd_compare_op(left, right, |a, b| T::lt(a, b));
 
-    #[allow(unreachable_code)]
-    compare_op(left, right, |a, b| a < b)
+    #[cfg(any(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        not(feature = "simd")
+    ))]
+    compare_op!(left, right, |a, b| a < b)
 }
 
 /// Perform `left <= right` operation on two arrays. Null values are less than non-null
@@ -167,8 +305,11 @@ where
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
     return simd_compare_op(left, right, |a, b| T::le(a, b));
 
-    #[allow(unreachable_code)]
-    compare_op(left, right, |a, b| a <= b)
+    #[cfg(any(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        not(feature = "simd")
+    ))]
+    compare_op!(left, right, |a, b| a <= b)
 }
 
 /// Perform `left > right` operation on two arrays. Non-null values are greater than null
@@ -180,8 +321,11 @@ where
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
     return simd_compare_op(left, right, |a, b| T::gt(a, b));
 
-    #[allow(unreachable_code)]
-    compare_op(left, right, |a, b| a > b)
+    #[cfg(any(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        not(feature = "simd")
+    ))]
+    compare_op!(left, right, |a, b| a > b)
 }
 
 /// Perform `left >= right` operation on two arrays. Non-null values are greater than null
@@ -196,8 +340,11 @@ where
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
     return simd_compare_op(left, right, |a, b| T::ge(a, b));
 
-    #[allow(unreachable_code)]
-    compare_op(left, right, |a, b| a >= b)
+    #[cfg(any(
+        not(any(target_arch = "x86", target_arch = "x86_64")),
+        not(feature = "simd")
+    ))]
+    compare_op!(left, right, |a, b| a >= b)
 }
 
 #[cfg(test)]
@@ -316,4 +463,78 @@ mod tests {
         assert_eq!(false, c.value(1));
         assert_eq!(true, c.value(2));
     }
+
+    macro_rules! test_utf8 {
+        ($test_name:ident, $left:expr, $right:expr, $op:expr, $expected:expr) => {
+            #[test]
+            fn $test_name() {
+                let left = StringArray::from($left);
+                let right = StringArray::from($right);
+                let res = $op(&left, &right).unwrap();
+                let expected = $expected;
+                assert_eq!(expected.len(), res.len());
+                for i in 0..res.len() {
+                    let v = res.value(i);
+                    assert_eq!(v, expected[i]);
+                }
+            }
+        };
+    }
+
+    test_utf8!(
+        test_utf8_array_like,
+        vec!["arrow", "arrow", "arrow", "arrow"],
+        vec!["arrow", "ar%", "%ro%", "foo"],
+        like_utf8,
+        vec![true, true, true, false]
+    );
+    test_utf8!(
+        test_utf8_array_nlike,
+        vec!["arrow", "arrow", "arrow", "arrow"],
+        vec!["arrow", "ar%", "%ro%", "foo"],
+        nlike_utf8,
+        vec![false, false, false, true]
+    );
+    test_utf8!(
+        test_utf8_array_eq,
+        vec!["arrow", "arrow", "arrow", "arrow"],
+        vec!["arrow", "parquet", "datafusion", "flight"],
+        eq_utf8,
+        vec![true, false, false, false]
+    );
+    test_utf8!(
+        test_utf8_array_new,
+        vec!["arrow", "arrow", "arrow", "arrow"],
+        vec!["arrow", "parquet", "datafusion", "flight"],
+        neq_utf8,
+        vec![false, true, true, true]
+    );
+    test_utf8!(
+        test_utf8_array_lt,
+        vec!["arrow", "datafusion", "flight", "parquet"],
+        vec!["flight", "flight", "flight", "flight"],
+        lt_utf8,
+        vec![true, true, false, false]
+    );
+    test_utf8!(
+        test_utf8_array_lt_eq,
+        vec!["arrow", "datafusion", "flight", "parquet"],
+        vec!["flight", "flight", "flight", "flight"],
+        lt_eq_utf8,
+        vec![true, true, true, false]
+    );
+    test_utf8!(
+        test_utf8_array_gt,
+        vec!["arrow", "datafusion", "flight", "parquet"],
+        vec!["flight", "flight", "flight", "flight"],
+        gt_utf8,
+        vec![false, false, false, true]
+    );
+    test_utf8!(
+        test_utf8_array_gt_eq,
+        vec!["arrow", "datafusion", "flight", "parquet"],
+        vec!["flight", "flight", "flight", "flight"],
+        gt_eq_utf8,
+        vec![false, false, true, true]
+    );
 }

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -65,6 +65,18 @@ macro_rules! compare_op {
     }};
 }
 
+pub fn no_simd_compare_op<T, F>(
+    left: &PrimitiveArray<T>,
+    right: &PrimitiveArray<T>,
+    op: F,
+) -> Result<BooleanArray>
+where
+    T: ArrowNumericType,
+    F: Fn(T::Native, T::Native) -> bool,
+{
+    compare_op!(left, right, op)
+}
+
 struct RegexCache<'a> {
     map: HashMap<&'a str, Regex>,
 }

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -37,7 +37,8 @@ macro_rules! compare_op {
     ($left: expr, $right:expr, $op:expr) => {{
         if $left.len() != $right.len() {
             return Err(ArrowError::ComputeError(
-                "Cannot perform math operation on arrays of different length".to_string(),
+                "Cannot perform comparison operation on arrays of different length"
+                    .to_string(),
             ));
         }
 
@@ -77,37 +78,12 @@ where
     compare_op!(left, right, op)
 }
 
-struct RegexCache<'a> {
-    map: HashMap<&'a str, Regex>,
-}
-
-impl<'a> RegexCache<'a> {
-    fn new() -> Self {
-        Self {
-            map: HashMap::new(),
-        }
-    }
-
-    fn match_str(&'a mut self, a: &str, pat: &'a str) -> bool {
-        let re = if let Some(ref regex) = self.map.get(pat) {
-            regex
-        } else {
-            let re_pattern = pat.replace("%", ".*").replace("_", ".");
-            let re = Regex::new(&re_pattern).unwrap();
-            self.map.insert(pat, re);
-
-            self.map.get(pat).unwrap()
-        };
-
-        re.is_match(a)
-    }
-}
-
 pub fn like_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray> {
     let mut map = HashMap::new();
     if left.len() != right.len() {
         return Err(ArrowError::ComputeError(
-            "Cannot perform math operation on arrays of different length".to_string(),
+            "Cannot perform comparison operation on arrays of different length"
+                .to_string(),
         ));
     }
 
@@ -125,7 +101,12 @@ pub fn like_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray
             regex
         } else {
             let re_pattern = pat.replace("%", ".*").replace("_", ".");
-            let re = Regex::new(&re_pattern).unwrap();
+            let re = Regex::new(&re_pattern).map_err(|e| {
+                ArrowError::ComputeError(format!(
+                    "Unable to build regex from LIKE pattern: {}",
+                    e
+                ))
+            })?;
             map.insert(pat, re);
             map.get(pat).unwrap()
         };
@@ -149,7 +130,8 @@ pub fn nlike_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArra
     let mut map = HashMap::new();
     if left.len() != right.len() {
         return Err(ArrowError::ComputeError(
-            "Cannot perform math operation on arrays of different length".to_string(),
+            "Cannot perform comparison operation on arrays of different length"
+                .to_string(),
         ));
     }
 
@@ -167,7 +149,12 @@ pub fn nlike_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArra
             regex
         } else {
             let re_pattern = pat.replace("%", ".*").replace("_", ".");
-            let re = Regex::new(&re_pattern).unwrap();
+            let re = Regex::new(&re_pattern).map_err(|e| {
+                ArrowError::ComputeError(format!(
+                    "Unable to build regex from LIKE pattern: {}",
+                    e
+                ))
+            })?;
             map.insert(pat, re);
             map.get(pat).unwrap()
         };
@@ -225,7 +212,8 @@ where
 {
     if left.len() != right.len() {
         return Err(ArrowError::ComputeError(
-            "Cannot perform math operation on arrays of different length".to_string(),
+            "Cannot perform comparison operation on arrays of different length"
+                .to_string(),
         ));
     }
 

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -52,6 +52,7 @@ clap = "2.33.0"
 prettytable-rs = "0.8.0"
 rustyline = {version = "4.1.0", optional = true}
 crossbeam = "0.7.1"
+paste = "0.1.6"
 
 [dev-dependencies]
 criterion = "0.2.0"

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -92,7 +92,11 @@ impl ExecutionContext {
                 FileType::CSV => {
                     self.register_csv(name, location, schema, *header_row);
                     Ok(vec![])
-                }
+                },
+                FileType::Parquet => {
+                    self.register_parquet(name, location)?;
+                    Ok(vec![])
+                },
                 _ => Err(ExecutionError::ExecutionError(format!(
                     "Unsupported file type {:?}.",
                     file_type

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -92,11 +92,11 @@ impl ExecutionContext {
                 FileType::CSV => {
                     self.register_csv(name, location, schema, *header_row);
                     Ok(vec![])
-                },
+                }
                 FileType::Parquet => {
                     self.register_parquet(name, location)?;
                     Ok(vec![])
-                },
+                }
                 _ => Err(ExecutionError::ExecutionError(format!(
                     "Unsupported file type {:?}.",
                     file_type

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -27,17 +27,22 @@ use crate::execution::physical_plan::{Accumulator, AggregateExpr, PhysicalExpr};
 use crate::logicalplan::{Operator, ScalarValue};
 use arrow::array::{
     ArrayRef, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array,
-    Int64Array, Int8Array, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    Int64Array, Int8Array, StringArray, UInt16Array, UInt32Array, UInt64Array,
+    UInt8Array,
 };
 use arrow::array::{
     Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder,
-    Int8Builder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
+    Int8Builder, StringBuilder, UInt16Builder, UInt32Builder, UInt64Builder,
+    UInt8Builder,
 };
 use arrow::compute;
 use arrow::compute::kernels::arithmetic::{add, divide, multiply, subtract};
 use arrow::compute::kernels::boolean::{and, or};
 use arrow::compute::kernels::cast::cast;
 use arrow::compute::kernels::comparison::{eq, gt, gt_eq, lt, lt_eq, neq};
+use arrow::compute::kernels::comparison::{
+    eq_utf8, gt_eq_utf8, gt_utf8, like_utf8, lt_eq_utf8, lt_utf8, neq_utf8, nlike_utf8,
+};
 use arrow::datatypes::{DataType, Schema};
 use arrow::record_batch::RecordBatch;
 
@@ -849,6 +854,21 @@ pub fn count(expr: Arc<dyn PhysicalExpr>) -> Arc<dyn AggregateExpr> {
     Arc::new(Count::new(expr))
 }
 
+/// Invoke a compute kernel on a pair of binary data arrays
+macro_rules! compute_utf8_op {
+    ($LEFT:expr, $RIGHT:expr, $OP:ident, $DT:ident) => {{
+        let ll = $LEFT
+            .as_any()
+            .downcast_ref::<$DT>()
+            .expect("compute_op failed to downcast array");
+        let rr = $RIGHT
+            .as_any()
+            .downcast_ref::<$DT>()
+            .expect("compute_op failed to downcast array");
+        Ok(Arc::new(paste::expr! {[<$OP _utf8>]}(&ll, &rr)?))
+    }};
+}
+
 /// Invoke a compute kernel on a pair of arrays
 macro_rules! compute_op {
     ($LEFT:expr, $RIGHT:expr, $OP:ident, $DT:ident) => {{
@@ -864,7 +884,44 @@ macro_rules! compute_op {
     }};
 }
 
+macro_rules! binary_string_array_op {
+    ($LEFT:expr, $RIGHT:expr, $OP:ident) => {{
+        match $LEFT.data_type() {
+            DataType::Utf8 => compute_utf8_op!($LEFT, $RIGHT, $OP, StringArray),
+            other => Err(ExecutionError::General(format!(
+                "Unsupported data type {:?}",
+                other
+            ))),
+        }
+    }};
+}
+
 /// Invoke a compute kernel on a pair of arrays
+/// The binary_primitive_array_op macro only evaluates for primitive types
+/// like integers and floats.
+macro_rules! binary_primitive_array_op {
+    ($LEFT:expr, $RIGHT:expr, $OP:ident) => {{
+        match $LEFT.data_type() {
+            DataType::Int8 => compute_op!($LEFT, $RIGHT, $OP, Int8Array),
+            DataType::Int16 => compute_op!($LEFT, $RIGHT, $OP, Int16Array),
+            DataType::Int32 => compute_op!($LEFT, $RIGHT, $OP, Int32Array),
+            DataType::Int64 => compute_op!($LEFT, $RIGHT, $OP, Int64Array),
+            DataType::UInt8 => compute_op!($LEFT, $RIGHT, $OP, UInt8Array),
+            DataType::UInt16 => compute_op!($LEFT, $RIGHT, $OP, UInt16Array),
+            DataType::UInt32 => compute_op!($LEFT, $RIGHT, $OP, UInt32Array),
+            DataType::UInt64 => compute_op!($LEFT, $RIGHT, $OP, UInt64Array),
+            DataType::Float32 => compute_op!($LEFT, $RIGHT, $OP, Float32Array),
+            DataType::Float64 => compute_op!($LEFT, $RIGHT, $OP, Float64Array),
+            other => Err(ExecutionError::General(format!(
+                "Unsupported data type {:?}",
+                other
+            ))),
+        }
+    }};
+}
+
+/// The binary_array_op macro includes types that extend beyond the primitive,
+/// such as Utf8 strings.
 macro_rules! binary_array_op {
     ($LEFT:expr, $RIGHT:expr, $OP:ident) => {{
         match $LEFT.data_type() {
@@ -878,6 +935,7 @@ macro_rules! binary_array_op {
             DataType::UInt64 => compute_op!($LEFT, $RIGHT, $OP, UInt64Array),
             DataType::Float32 => compute_op!($LEFT, $RIGHT, $OP, Float32Array),
             DataType::Float64 => compute_op!($LEFT, $RIGHT, $OP, Float64Array),
+            DataType::Utf8 => compute_utf8_op!($LEFT, $RIGHT, $OP, StringArray),
             other => Err(ExecutionError::General(format!(
                 "Unsupported data type {:?}",
                 other
@@ -939,16 +997,18 @@ impl PhysicalExpr for BinaryExpr {
             )));
         }
         match &self.op {
+            Operator::Like => binary_string_array_op!(left, right, like),
+            Operator::NotLike => binary_string_array_op!(left, right, nlike),
             Operator::Lt => binary_array_op!(left, right, lt),
             Operator::LtEq => binary_array_op!(left, right, lt_eq),
             Operator::Gt => binary_array_op!(left, right, gt),
             Operator::GtEq => binary_array_op!(left, right, gt_eq),
             Operator::Eq => binary_array_op!(left, right, eq),
             Operator::NotEq => binary_array_op!(left, right, neq),
-            Operator::Plus => binary_array_op!(left, right, add),
-            Operator::Minus => binary_array_op!(left, right, subtract),
-            Operator::Multiply => binary_array_op!(left, right, multiply),
-            Operator::Divide => binary_array_op!(left, right, divide),
+            Operator::Plus => binary_primitive_array_op!(left, right, add),
+            Operator::Minus => binary_primitive_array_op!(left, right, subtract),
+            Operator::Multiply => binary_primitive_array_op!(left, right, multiply),
+            Operator::Divide => binary_primitive_array_op!(left, right, divide),
             Operator::And => {
                 if left.data_type() == &DataType::Boolean {
                     boolean_op!(left, right, and)
@@ -1148,6 +1208,9 @@ impl PhysicalExpr for Literal {
             }
             ScalarValue::Float64(value) => {
                 build_literal_array!(batch, Float64Builder, *value)
+            }
+            ScalarValue::Utf8(value) => {
+                build_literal_array!(batch, StringBuilder, &*value)
             }
             other => Err(ExecutionError::General(format!(
                 "Unsupported literal type {:?}",


### PR DESCRIPTION
This change also required having to add comparison predicates for UTF8 strings to Arrow's comparison kernels. Included also are support for the LIKE and NOT LIKE operators.
