### PR TITLE
PARQUET-1785: [C++] Implement ByteStreamSplitDecoder::DecodeArrow and refactor tests

### DIFF
--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -16,13 +16,13 @@
 // under the License.
 
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <utility>
 #include <vector>
-#include <algorithm>
 
 #include "arrow/array.h"
 #include "arrow/compute/api.h"

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -22,6 +22,7 @@
 #include <limits>
 #include <utility>
 #include <vector>
+#include <algorithm>
 
 #include "arrow/array.h"
 #include "arrow/compute/api.h"

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -942,12 +942,12 @@ class TestByteStreamSplitEncoding : public TestEncodingBase<Type> {
       std::vector<T> expected_filtered_output;
       const int every_nth = 5;
       expected_filtered_output.reserve((num_values_ + every_nth - 1) / every_nth);
-      arrow::internal::BitmapWriter writer { valid_bits.data(), 0, num_values_ };
+      arrow::internal::BitmapWriter writer{valid_bits.data(), 0, num_values_};
       // Set every fifth bit.
       for (int i = 0; i < num_values_; ++i) {
         if (i % every_nth == 0) {
-            writer.Set();
-            expected_filtered_output.push_back(draws_[i]);
+          writer.Set();
+          expected_filtered_output.push_back(draws_[i]);
         }
         writer.Next();
       }
@@ -960,7 +960,8 @@ class TestByteStreamSplitEncoding : public TestEncodingBase<Type> {
                        static_cast<int>(encode_buffer_->size()));
       int values_decoded = decoder->Decode(decode_buf_, num_values_);
       ASSERT_EQ(expected_size, values_decoded);
-      ASSERT_NO_FATAL_FAILURE(VerifyResults<T>(decode_buf_, expected_filtered_output.data(), expected_size));
+      ASSERT_NO_FATAL_FAILURE(
+          VerifyResults<T>(decode_buf_, expected_filtered_output.data(), expected_size));
     }
   }
 
@@ -970,10 +971,8 @@ class TestByteStreamSplitEncoding : public TestEncodingBase<Type> {
  protected:
   USING_BASE_MEMBERS();
 
-  void CheckDecode(const uint8_t* encoded_data,
-                   const int64_t encoded_data_size,
-                   const T* expected_decoded_data,
-                   const int num_elements) {
+  void CheckDecode(const uint8_t* encoded_data, const int64_t encoded_data_size,
+                   const T* expected_decoded_data, const int num_elements) {
     std::unique_ptr<TypedDecoder<Type>> decoder =
         MakeTypedDecoder<Type>(Encoding::BYTE_STREAM_SPLIT);
     decoder->SetData(num_elements, encoded_data, static_cast<int>(encoded_data_size));
@@ -986,8 +985,7 @@ class TestByteStreamSplitEncoding : public TestEncodingBase<Type> {
     ASSERT_EQ(0, decoder->values_left());
   }
 
-  void CheckEncode(const T* data,
-                   const int num_elements,
+  void CheckEncode(const T* data, const int num_elements,
                    const uint8_t* expected_encoded_data,
                    const int64_t encoded_data_size) {
     std::unique_ptr<TypedEncoder<Type>> encoder =
@@ -995,7 +993,7 @@ class TestByteStreamSplitEncoding : public TestEncodingBase<Type> {
     encoder->Put(data, num_elements);
     auto encoded_data = encoder->FlushValues();
     ASSERT_EQ(encoded_data_size, encoded_data->size());
-    const uint8_t *encoded_data_raw = encoded_data->data();
+    const uint8_t* encoded_data_raw = encoded_data->data();
     for (int64_t i = 0; i < encoded_data->size(); ++i) {
       ASSERT_EQ(expected_encoded_data[i], encoded_data_raw[i]);
     }
@@ -1004,11 +1002,12 @@ class TestByteStreamSplitEncoding : public TestEncodingBase<Type> {
 
 template <>
 void TestByteStreamSplitEncoding<FloatType>::CheckDecode() {
-    const uint8_t data[] = {0x11, 0x22, 0x33, 0x44,
-                            0x55, 0x66, 0x77, 0x88,
-                            0x99, 0xAA, 0xBB, 0xCC};
-    const uint32_t expected_output[3] = {0xAA774411, 0xBB885522, 0xCC996633};
-    CheckDecode(reinterpret_cast<const uint8_t*>(data), static_cast<int64_t>(sizeof(data)), reinterpret_cast<const float*>(expected_output), static_cast<int>(sizeof(data) / sizeof(float)));
+  const uint8_t data[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66,
+                          0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC};
+  const uint32_t expected_output[3] = {0xAA774411, 0xBB885522, 0xCC996633};
+  CheckDecode(reinterpret_cast<const uint8_t*>(data), static_cast<int64_t>(sizeof(data)),
+              reinterpret_cast<const float*>(expected_output),
+              static_cast<int>(sizeof(data) / sizeof(float)));
 }
 
 template <>
@@ -1016,7 +1015,9 @@ void TestByteStreamSplitEncoding<DoubleType>::CheckDecode() {
   const uint8_t data[] = {0xDE, 0xC0, 0x37, 0x13, 0x11, 0x22, 0x33, 0x44,
                           0xAA, 0xBB, 0xCC, 0xDD, 0x55, 0x66, 0x77, 0x88};
   const uint64_t expected_output[2] = {0x7755CCAA331137DE, 0x8866DDBB442213C0};
-  CheckDecode(reinterpret_cast<const uint8_t*>(data), static_cast<int64_t>(sizeof(data)), reinterpret_cast<const double*>(expected_output), static_cast<int>(sizeof(data) / sizeof(double)));
+  CheckDecode(reinterpret_cast<const uint8_t*>(data), static_cast<int64_t>(sizeof(data)),
+              reinterpret_cast<const double*>(expected_output),
+              static_cast<int>(sizeof(data) / sizeof(double)));
 }
 
 template <>
@@ -1026,16 +1027,18 @@ void TestByteStreamSplitEncoding<DoubleType>::CheckEncode() {
       0x48, 0x08, 0xb8, 0x47, 0x07, 0xb7, 0x46, 0x06, 0xb6, 0x45, 0x05, 0xb5,
       0x44, 0x04, 0xb4, 0x43, 0x03, 0xb3, 0x42, 0x02, 0xb2, 0x41, 0x01, 0xb1,
   };
-  CheckEncode(reinterpret_cast<const double*>(expected_output), static_cast<int>(sizeof(data) / sizeof(double)), reinterpret_cast<const uint8_t*>(data), static_cast<int64_t>(sizeof(data)));
+  CheckEncode(reinterpret_cast<const double*>(expected_output),
+              static_cast<int>(sizeof(data) / sizeof(double)),
+              reinterpret_cast<const uint8_t*>(data), static_cast<int64_t>(sizeof(data)));
 }
 
 template <>
 void TestByteStreamSplitEncoding<FloatType>::CheckEncode() {
   const uint32_t data[] = {0xaabbccdd, 0x11223344};
-  const uint8_t expected_output[8] = {
-      0xdd, 0x44, 0xcc, 0x33, 0xbb, 0x22, 0xaa, 0x11
-  };
-  CheckEncode(reinterpret_cast<const float*>(expected_output), static_cast<int>(sizeof(data) / sizeof(float)), reinterpret_cast<const uint8_t*>(data), static_cast<int64_t>(sizeof(data)));
+  const uint8_t expected_output[8] = {0xdd, 0x44, 0xcc, 0x33, 0xbb, 0x22, 0xaa, 0x11};
+  CheckEncode(reinterpret_cast<const float*>(expected_output),
+              static_cast<int>(sizeof(data) / sizeof(float)),
+              reinterpret_cast<const uint8_t*>(data), static_cast<int64_t>(sizeof(data)));
 }
 
 typedef ::testing::Types<FloatType, DoubleType> ByteStreamSplitTypes;

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -2816,12 +2816,14 @@ def _assert_dataset_is_picklable(dataset, pickler):
             assert is_pickleable(metadata.row_group(i))
 
 
+@pytest.mark.pandas
 def test_builtin_pickle_dataset(tempdir, datadir):
     import pickle
     dataset = _make_dataset_for_pickling(tempdir)
     _assert_dataset_is_picklable(dataset, pickler=pickle)
 
 
+@pytest.mark.pandas
 def test_cloudpickle_dataset(tempdir, datadir):
     cp = pytest.importorskip('cloudpickle')
     dataset = _make_dataset_for_pickling(tempdir)


### PR DESCRIPTION
The patch implements ByteStreamSplitDecoder::DecodeArrow(...) and
refactors the ByteStreamSplit Encode/Encode tests to better
utilize the existing test facilities.