### PR TITLE
ARROW-7063: [C++][Python] Add metadata output and toggle in PrettyPrint, add pyarrow.Schema.to_string, disable metadata output by default

### DIFF
--- a/cpp/src/arrow/pretty_print.h
+++ b/cpp/src/arrow/pretty_print.h
@@ -33,13 +33,15 @@ class Status;
 class Table;
 
 struct PrettyPrintOptions {
-  PrettyPrintOptions(int indent_arg, int window_arg = 10, int indent_size_arg = 2,
-                     std::string null_rep_arg = "null", bool skip_new_lines_arg = false)
+  PrettyPrintOptions(int indent_arg = 0, int window_arg = 10, int indent_size_arg = 2,
+                     std::string null_rep_arg = "null", bool skip_new_lines_arg = false,
+                     bool show_metadata = false)
       : indent(indent_arg),
         indent_size(indent_size_arg),
         window(window_arg),
         null_rep(null_rep_arg),
-        skip_new_lines(skip_new_lines_arg) {}
+        skip_new_lines(skip_new_lines_arg),
+        show_metadata(show_metadata) {}
 
   /// Number of spaces to shift entire formatted object to the right
   int indent;
@@ -55,6 +57,9 @@ struct PrettyPrintOptions {
 
   /// Skip new lines between elements, defaults to false
   bool skip_new_lines;
+
+  /// Show Schema and Field-level KeyValueMetadata
+  bool show_metadata;
 };
 
 /// \brief Print human-readable representation of RecordBatch

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -177,13 +177,13 @@ bool Field::IsCompatibleWith(const std::shared_ptr<Field>& other) const {
   return IsCompatibleWith(*other);
 }
 
-std::string Field::ToString(bool print_metadata) const {
+std::string Field::ToString(bool show_metadata) const {
   std::stringstream ss;
   ss << name_ << ": " << type_->ToString();
   if (!nullable_) {
     ss << " not null";
   }
-  if (print_metadata && metadata_) {
+  if (show_metadata && metadata_) {
     ss << metadata_->ToString();
   }
   return ss.str();
@@ -798,7 +798,7 @@ Status Schema::RemoveField(int i, std::shared_ptr<Schema>* out) const {
   return Status::OK();
 }
 
-std::string Schema::ToString(bool print_metadata) const {
+std::string Schema::ToString(bool show_metadata) const {
   std::stringstream buffer;
 
   int i = 0;
@@ -810,7 +810,7 @@ std::string Schema::ToString(bool print_metadata) const {
     ++i;
   }
 
-  if (print_metadata && HasMetadata()) {
+  if (show_metadata && HasMetadata()) {
     buffer << impl_->metadata_->ToString();
   }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -430,7 +430,9 @@ class ARROW_EXPORT Field : public detail::Fingerprintable {
   bool IsCompatibleWith(const std::shared_ptr<Field>& other) const;
 
   /// \brief Return a string representation ot the field
-  std::string ToString(bool print_metadata = false) const;
+  /// \param[in] show_metadata when true, if KeyValueMetadata is non-empty,
+  /// print keys and values in the output
+  std::string ToString(bool show_metadata = false) const;
 
   /// \brief Return the field name
   const std::string& name() const { return name_; }
@@ -1452,7 +1454,9 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   std::shared_ptr<const KeyValueMetadata> metadata() const;
 
   /// \brief Render a string representation of the schema suitable for debugging
-  std::string ToString(bool print_metadata = false) const;
+  /// \param[in] show_metadata when true, if KeyValueMetadata is non-empty,
+  /// print keys and values in the output
+  std::string ToString(bool show_metadata = false) const;
 
   Status AddField(int i, const std::shared_ptr<Field>& field,
                   std::shared_ptr<Schema>* out) const;

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -401,10 +401,15 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         shared_ptr[CSchema] RemoveMetadata()
 
     cdef cppclass PrettyPrintOptions:
+        PrettyPrintOptions()
         PrettyPrintOptions(int indent_arg)
         PrettyPrintOptions(int indent_arg, int window_arg)
         int indent
+        int indent_size
         int window
+        c_string null_rep
+        c_bool skip_new_lines
+        c_bool show_metadata
 
     CStatus PrettyPrint(const CArray& schema,
                         const PrettyPrintOptions& options,

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -234,6 +234,20 @@ baz: list<item: int8>
         pa.schema([None])
 
 
+def test_schema_to_string_with_metadata():
+    # ARROW-7063
+    my_schema = pa.schema([pa.field("foo", "int32", False,
+                                    metadata={"key1": "value1"})],
+                          metadata={"key2": "value2"})
+
+    assert my_schema.to_string(show_metadata=True) == """\
+foo: int32 not null
+  -- metadata --
+  key1: value1
+-- metadata --
+key2: value2"""
+
+
 def test_schema_from_tuples():
     fields = [
         ('foo', pa.int32()),

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1304,26 +1304,39 @@ cdef class Schema:
             new_schema = self.schema.RemoveMetadata()
         return pyarrow_wrap_schema(new_schema)
 
-    def __str__(self):
+    def to_string(self, bint show_metadata=False):
+        """
+        Return human-readable representation of Schema
+
+        Parameters
+        ----------
+        show_metadata : boolean, default False
+            If True, and there is non-empty metadata, it will be printed after
+            the column names and types
+
+        Returns
+        -------
+        str : the formatted output
+        """
         cdef:
             c_string result
+            PrettyPrintOptions options
 
         with nogil:
+            options.indent = 0
+            options.show_metadata = show_metadata
             check_status(
                 PrettyPrint(
                     deref(self.schema),
-                    PrettyPrintOptions(0),
+                    options,
                     &result
                 )
             )
 
-        printed = frombytes(result)
-        if self.metadata is not None:
-            import pprint
-            metadata_formatted = pprint.pformat(self.metadata)
-            printed += '\nmetadata\n--------\n' + metadata_formatted
+        return frombytes(result)
 
-        return printed
+    def __str__(self):
+        return self.to_string(show_metadata=False)
 
     def __repr__(self):
         return self.__str__()


### PR DESCRIPTION
There was a temporary hack to suppress outputting the metadata in ARROW-7080 so this is a more complete working over, and adding metadata output. I disabled the default metadata output in Python (which is often more of a distraction than anything) since it seems several others agreed that was the way to go