### PR TITLE
ARROW-7915: [CI][Python] Enable development mode in tests

### DIFF
--- a/ci/cpp-msvc-build-main.bat
+++ b/ci/cpp-msvc-build-main.bat
@@ -129,6 +129,8 @@ set PARQUET_HOME=%CONDA_PREFIX%\Library
 
 python setup.py develop -q || exit /B
 
+set PYTHONDEVMODE=1
+
 py.test -r sxX --durations=15 --pyargs pyarrow.tests || exit /B
 
 @rem

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -25,4 +25,7 @@ export ARROW_TEST_DATA=${arrow_dir}/testing/data
 export PARQUET_TEST_DATA=${arrow_dir}/cpp/submodules/parquet-testing/data
 export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 
+# Enable some checks inside Python itself
+export PYTHONDEVMODE=1
+
 pytest -r s --pyargs pyarrow


### PR DESCRIPTION
Python's "development mode" enables some runtime checks and warnings
that help developers spot errors in their code (such as resource leaks).