### PR TITLE
ARROW-7916: [C++] Project IPC batches to materialized fields only

### DIFF
--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -38,16 +38,21 @@ class ARROW_DS_EXPORT Fragment {
  public:
   /// \brief Scan returns an iterator of ScanTasks, each of which yields
   /// RecordBatches from this Fragment.
+  ///
+  /// Note that batches yielded using this method will not be filtered and may not align
+  /// with the Fragment's schema. In particular, note that columns referenced by the
+  /// filter may be present in yielded batches even if they are not projected (so that
+  /// they are available when a filter is applied). Additionally, explicitly projected
+  /// columns may be absent if they were not present in this fragment.
+  ///
+  /// To receive a record batch stream which is fully filtered and projected, use Scanner.
   virtual Result<ScanTaskIterator> Scan(std::shared_ptr<ScanContext> context) = 0;
 
-  /// \brief Return true if the fragment can benefit from parallel
-  /// scanning
+  /// \brief Return true if the fragment can benefit from parallel scanning.
   virtual bool splittable() const = 0;
 
   /// \brief Filtering, schema reconciliation, and partition options to use when
-  /// scanning this fragment. May be nullptr, which indicates that no filtering
-  /// or schema reconciliation will be performed and all partitions will be
-  /// scanned.
+  /// scanning this fragment.
   const std::shared_ptr<ScanOptions>& scan_options() const { return scan_options_; }
 
   const std::shared_ptr<Schema>& schema() const;
@@ -55,7 +60,7 @@ class ARROW_DS_EXPORT Fragment {
   virtual ~Fragment() = default;
 
   /// \brief An expression which evaluates to true for all data viewed by this
-  /// Fragment. May be null, which indicates no information is available.
+  /// Fragment.
   const std::shared_ptr<Expression>& partition_expression() const {
     return partition_expression_;
   }

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -55,8 +55,7 @@ inline std::shared_ptr<Schema> SchemaFromColumnNames(
     const std::shared_ptr<Schema>& input, const std::vector<std::string>& column_names) {
   std::vector<std::shared_ptr<Field>> columns;
   for (const auto& name : column_names) {
-    auto field = input->GetFieldByName(name);
-    if (field != nullptr) {
+    if (auto field = input->GetFieldByName(name)) {
       columns.push_back(std::move(field));
     }
   }

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -61,7 +61,7 @@ inline std::shared_ptr<Schema> SchemaFromColumnNames(
     }
   }
 
-  return std::make_shared<Schema>(columns);
+  return schema(std::move(columns));
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/dataset/file_ipc.h"
 
+#include <algorithm>
 #include <memory>
 #include <unordered_set>
 #include <utility>
@@ -57,7 +58,17 @@ class IpcScanTask : public ScanTask {
       : ScanTask(std::move(options), std::move(context)), source_(std::move(source)) {}
 
   Result<RecordBatchIterator> Execute() override {
-    struct {
+    struct Impl {
+      static Result<Impl> Make(const FileSource& source,
+                               const std::vector<std::string>& materialized_fields,
+                               MemoryPool* pool) {
+        ARROW_ASSIGN_OR_RAISE(auto reader, OpenReader(source));
+        auto materialized_schema =
+            SchemaFromColumnNames(reader->schema(), materialized_fields);
+        return Impl{std::move(reader),
+                    RecordBatchProjector(std::move(materialized_schema)), pool, 0};
+      }
+
       Result<std::shared_ptr<RecordBatch>> Next() {
         if (i_ == reader_->num_record_batches()) {
           return nullptr;
@@ -65,14 +76,22 @@ class IpcScanTask : public ScanTask {
 
         std::shared_ptr<RecordBatch> batch;
         RETURN_NOT_OK(reader_->ReadRecordBatch(i_++, &batch));
-        return batch;
+        return projector_.Project(*batch, pool_);
       }
 
       std::shared_ptr<ipc::RecordBatchFileReader> reader_;
-      int i_ = 0;
-    } batch_it;
+      RecordBatchProjector projector_;
+      MemoryPool* pool_;
+      int i_;
+    };
 
-    ARROW_ASSIGN_OR_RAISE(batch_it.reader_, OpenReader(source_));
+    // get names of fields explicitly projected or referenced by filter
+    auto fields = options_->MaterializedFields();
+    std::sort(fields.begin(), fields.end());
+    auto unique_end = std::unique(fields.begin(), fields.end());
+    fields.erase(unique_end, fields.end());
+
+    ARROW_ASSIGN_OR_RAISE(auto batch_it, Impl::Make(source_, fields, context_->pool));
 
     return RecordBatchIterator(std::move(batch_it));
   }

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -85,9 +85,13 @@ class IpcScanTask : public ScanTask {
       int i_;
     };
 
-    ARROW_ASSIGN_OR_RAISE(
-        auto batch_it,
-        Impl::Make(source_, options_->MaterializedFields(), context_->pool));
+    // get names of fields explicitly projected or referenced by filter
+    auto fields = options_->MaterializedFields();
+    std::sort(fields.begin(), fields.end());
+    auto unique_end = std::unique(fields.begin(), fields.end());
+    fields.erase(unique_end, fields.end());
+
+    ARROW_ASSIGN_OR_RAISE(auto batch_it, Impl::Make(source_, fields, context_->pool));
 
     return RecordBatchIterator(std::move(batch_it));
   }

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -85,13 +85,9 @@ class IpcScanTask : public ScanTask {
       int i_;
     };
 
-    // get names of fields explicitly projected or referenced by filter
-    auto fields = options_->MaterializedFields();
-    std::sort(fields.begin(), fields.end());
-    auto unique_end = std::unique(fields.begin(), fields.end());
-    fields.erase(unique_end, fields.end());
-
-    ARROW_ASSIGN_OR_RAISE(auto batch_it, Impl::Make(source_, fields, context_->pool));
+    ARROW_ASSIGN_OR_RAISE(
+        auto batch_it,
+        Impl::Make(source_, options_->MaterializedFields(), context_->pool));
 
     return RecordBatchIterator(std::move(batch_it));
   }

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -40,30 +40,22 @@ constexpr int64_t kNumRows = kBatchSize * kBatchRepetitions;
 
 class ArrowIpcWriterMixin : public ::testing::Test {
  public:
-  std::shared_ptr<Buffer> Write(std::vector<RecordBatchReader*> readers) {
+  std::shared_ptr<Buffer> Write(RecordBatchReader* reader) {
     EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create());
-    auto writer_schema = readers[0]->schema();
 
     EXPECT_OK_AND_ASSIGN(auto writer,
-                         ipc::RecordBatchFileWriter::Open(sink.get(), writer_schema));
+                         ipc::RecordBatchFileWriter::Open(sink.get(), reader->schema()));
 
-    for (auto reader : readers) {
-      std::vector<std::shared_ptr<RecordBatch>> batches;
-      ARROW_EXPECT_OK(reader->ReadAll(&batches));
-      for (auto batch : batches) {
-        AssertSchemaEqual(batch->schema(), writer_schema);
-        ARROW_EXPECT_OK(writer->WriteRecordBatch(*batch));
-      }
+    std::vector<std::shared_ptr<RecordBatch>> batches;
+    ARROW_EXPECT_OK(reader->ReadAll(&batches));
+    for (auto batch : batches) {
+      ARROW_EXPECT_OK(writer->WriteRecordBatch(*batch));
     }
 
     ARROW_EXPECT_OK(writer->Close());
 
     EXPECT_OK_AND_ASSIGN(auto out, sink->Finish());
     return out;
-  }
-
-  std::shared_ptr<Buffer> Write(RecordBatchReader* reader) {
-    return Write(std::vector<RecordBatchReader*>{reader});
   }
 
   std::shared_ptr<Buffer> Write(const Table& table) {
@@ -88,11 +80,6 @@ class IpcBufferFixtureMixin : public ArrowIpcWriterMixin {
     return internal::make_unique<FileSource>(std::move(buffer));
   }
 
-  std::unique_ptr<FileSource> GetFileSource(std::vector<RecordBatchReader*> readers) {
-    auto buffer = Write(std::move(readers));
-    return internal::make_unique<FileSource>(std::move(buffer));
-  }
-
   std::unique_ptr<RecordBatchReader> GetRecordBatchReader() {
     auto batch = ConstantArrayGenerator::Zeroes(kBatchSize, schema_);
     int64_t i = 0;
@@ -108,6 +95,18 @@ class IpcBufferFixtureMixin : public ArrowIpcWriterMixin {
 };
 
 class TestIpcFileFormat : public IpcBufferFixtureMixin {
+ public:
+  RecordBatchIterator Batches(ScanTaskIterator scan_task_it) {
+    return MakeFlattenIterator(MakeMaybeMapIterator(
+        [](std::shared_ptr<ScanTask> scan_task) { return scan_task->Execute(); },
+        std::move(scan_task_it)));
+  }
+
+  RecordBatchIterator Batches(Fragment* fragment) {
+    EXPECT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(ctx_));
+    return Batches(std::move(scan_task_it));
+  }
+
  protected:
   std::shared_ptr<ScanOptions> opts_;
   std::shared_ptr<ScanContext> ctx_ = std::make_shared<ScanContext>();
@@ -120,16 +119,11 @@ TEST_F(TestIpcFileFormat, ScanRecordBatchReader) {
   opts_ = ScanOptions::Make(reader->schema());
   auto fragment = std::make_shared<IpcFragment>(*source, opts_);
 
-  ASSERT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(ctx_));
   int64_t row_count = 0;
 
-  for (auto maybe_task : scan_task_it) {
-    ASSERT_OK_AND_ASSIGN(auto task, std::move(maybe_task));
-    ASSERT_OK_AND_ASSIGN(auto rb_it, task->Execute());
-    for (auto maybe_batch : rb_it) {
-      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
-      row_count += batch->num_rows();
-    }
+  for (auto maybe_batch : Batches(fragment.get())) {
+    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    row_count += batch->num_rows();
   }
 
   ASSERT_EQ(row_count, kNumRows);
@@ -151,9 +145,80 @@ TEST_F(TestIpcFileFormat, OpenFailureWithRelevantError) {
                                   result.status());
 }
 
-// TODO(bkietz) extend IpcFileFormat to support projection pushdown
-// TEST_F(TestIpcFileFormat, ScanRecordBatchReaderProjected)
-// TEST_F(TestIpcFileFormat, ScanRecordBatchReaderProjectedMissingCols)
+TEST_F(TestIpcFileFormat, ScanRecordBatchReaderProjected) {
+  schema_ = schema({field("f64", float64()), field("i64", int64()),
+                    field("f32", float32()), field("i32", int32())});
+
+  opts_ = ScanOptions::Make(schema_);
+  opts_->projector = RecordBatchProjector(SchemaFromColumnNames(schema_, {"f64"}));
+  opts_->filter = equal(field_ref("i32"), scalar(0));
+
+  // NB: projector is applied by the scanner; IpcFragment does not evaluate it so
+  // we will not drop "i32" even though it is not in the projector's schema
+  auto expected_schema = schema({field("f64", float64()), field("i32", int32())});
+
+  auto reader = GetRecordBatchReader();
+  auto source = GetFileSource(reader.get());
+  auto fragment = std::make_shared<IpcFragment>(*source, opts_);
+
+  int64_t row_count = 0;
+
+  for (auto maybe_batch : Batches(fragment.get())) {
+    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    row_count += batch->num_rows();
+    AssertSchemaEqual(*batch->schema(), *expected_schema,
+                      /*check_metadata=*/false);
+  }
+
+  ASSERT_EQ(row_count, kNumRows);
+}
+
+TEST_F(TestIpcFileFormat, ScanRecordBatchReaderProjectedMissingCols) {
+  schema_ =
+      schema({field("f64", float64()), field("i64", int64()), field("f32", float32())});
+  auto reader_without_i32 = GetRecordBatchReader();
+
+  schema_ =
+      schema({field("i64", int64()), field("f32", float32()), field("i32", int32())});
+  auto reader_without_f64 = GetRecordBatchReader();
+
+  schema_ = schema({field("f64", float64()), field("i64", int64()),
+                    field("f32", float32()), field("i32", int32())});
+  auto reader = GetRecordBatchReader();
+
+  opts_ = ScanOptions::Make(schema_);
+  opts_->projector = RecordBatchProjector(SchemaFromColumnNames(schema_, {"f64"}));
+  opts_->filter = equal(field_ref("i32"), scalar(0));
+
+  for (auto reader : {reader.get(), reader_without_i32.get(), reader_without_f64.get()}) {
+    auto source = GetFileSource(reader);
+    auto fragment = std::make_shared<IpcFragment>(*source, opts_);
+
+    int64_t row_count = 0;
+
+    for (auto maybe_batch : Batches(fragment.get())) {
+      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+      row_count += batch->num_rows();
+      // NB: projector is applied by the scanner; ParquetFragment does not evaluate it.
+      // We will not drop "i32" even though it is not in the projector's schema.
+      //
+      // in the case where a file doesn't contain a referenced field, we won't
+      // materialize it (the filter/projector will populate it with nulls later)
+      std::shared_ptr<Schema> expected_schema;
+      if (reader == reader_without_i32.get()) {
+        expected_schema = schema({field("f64", float64())});
+      } else if (reader == reader_without_f64.get()) {
+        expected_schema = schema({field("i32", int32())});
+      } else {
+        expected_schema = schema({field("f64", float64()), field("i32", int32())});
+      }
+      AssertSchemaEqual(*batch->schema(), *expected_schema,
+                        /*check_metadata=*/false);
+    }
+
+    ASSERT_EQ(row_count, kNumRows);
+  }
+}
 
 TEST_F(TestIpcFileFormat, Inspect) {
   auto reader = GetRecordBatchReader();

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -99,23 +99,18 @@ Status WriteRecordBatchReader(
 
 class ArrowParquetWriterMixin : public ::testing::Test {
  public:
-  std::shared_ptr<Buffer> Write(std::vector<RecordBatchReader*> readers) {
+  std::shared_ptr<Buffer> Write(RecordBatchReader* reader) {
     auto pool = ::arrow::default_memory_pool();
 
     std::shared_ptr<Buffer> out;
 
-    for (auto reader : readers) {
-      auto sink = CreateOutputStream(pool);
+    auto sink = CreateOutputStream(pool);
 
-      ARROW_EXPECT_OK(WriteRecordBatchReader(reader, pool, sink));
-      // XXX the rest of the test may crash if this fails, since out will be nullptr
-      EXPECT_OK_AND_ASSIGN(out, sink->Finish());
-    }
+    ARROW_EXPECT_OK(WriteRecordBatchReader(reader, pool, sink));
+    // XXX the rest of the test may crash if this fails, since out will be nullptr
+    EXPECT_OK_AND_ASSIGN(out, sink->Finish());
+
     return out;
-  }
-
-  std::shared_ptr<Buffer> Write(RecordBatchReader* reader) {
-    return Write(std::vector<RecordBatchReader*>{reader});
   }
 
   std::shared_ptr<Buffer> Write(const Table& table) {
@@ -138,11 +133,6 @@ class ParquetBufferFixtureMixin : public ArrowParquetWriterMixin {
     return internal::make_unique<FileSource>(std::move(buffer));
   }
 
-  std::unique_ptr<FileSource> GetFileSource(std::vector<RecordBatchReader*> readers) {
-    auto buffer = Write(std::move(readers));
-    return internal::make_unique<FileSource>(std::move(buffer));
-  }
-
   std::unique_ptr<RecordBatchReader> GetRecordBatchReader() {
     auto batch = ConstantArrayGenerator::Zeroes(kBatchSize, schema_);
     int64_t i = 0;
@@ -162,6 +152,32 @@ class TestParquetFileFormat : public ParquetBufferFixtureMixin {
   std::shared_ptr<ParquetFileFormat> format_ = std::make_shared<ParquetFileFormat>();
   std::shared_ptr<ScanOptions> opts_;
   std::shared_ptr<ScanContext> ctx_ = std::make_shared<ScanContext>();
+
+  RecordBatchIterator Batches(ScanTaskIterator scan_task_it) {
+    return MakeFlattenIterator(MakeMaybeMapIterator(
+        [](std::shared_ptr<ScanTask> scan_task) { return scan_task->Execute(); },
+        std::move(scan_task_it)));
+  }
+
+  RecordBatchIterator Batches(Fragment* fragment) {
+    EXPECT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(ctx_));
+    return Batches(std::move(scan_task_it));
+  }
+
+  void CountRowsAndBatchesInScan(Fragment* fragment, int64_t expected_rows,
+                                 int64_t expected_batches) {
+    int64_t actual_rows = 0;
+    int64_t actual_batches = 0;
+
+    for (auto maybe_batch : Batches(fragment)) {
+      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+      actual_rows += batch->num_rows();
+      ++actual_batches;
+    }
+
+    EXPECT_EQ(actual_rows, expected_rows);
+    EXPECT_EQ(actual_batches, expected_batches);
+  }
 };
 
 TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
@@ -171,16 +187,11 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   opts_ = ScanOptions::Make(reader->schema());
   auto fragment = std::make_shared<ParquetFragment>(*source, format_, opts_);
 
-  ASSERT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(ctx_));
   int64_t row_count = 0;
 
-  for (auto maybe_task : scan_task_it) {
-    ASSERT_OK_AND_ASSIGN(auto task, std::move(maybe_task));
-    ASSERT_OK_AND_ASSIGN(auto rb_it, task->Execute());
-    for (auto maybe_batch : rb_it) {
-      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
-      row_count += batch->num_rows();
-    }
+  for (auto maybe_batch : Batches(fragment.get())) {
+    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    row_count += batch->num_rows();
   }
 
   ASSERT_EQ(row_count, kNumRows);
@@ -245,18 +256,13 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjected) {
   auto source = GetFileSource(reader.get());
   auto fragment = std::make_shared<ParquetFragment>(*source, format_, opts_);
 
-  ASSERT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(ctx_));
   int64_t row_count = 0;
 
-  for (auto maybe_task : scan_task_it) {
-    ASSERT_OK_AND_ASSIGN(auto task, std::move(maybe_task));
-    ASSERT_OK_AND_ASSIGN(auto rb_it, task->Execute());
-    for (auto maybe_batch : rb_it) {
-      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
-      row_count += batch->num_rows();
-      AssertSchemaEqual(*batch->schema(), *expected_schema,
-                        /*check_metadata=*/false);
-    }
+  for (auto maybe_batch : Batches(fragment.get())) {
+    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    row_count += batch->num_rows();
+    AssertSchemaEqual(*batch->schema(), *expected_schema,
+                      /*check_metadata=*/false);
   }
 
   ASSERT_EQ(row_count, kNumRows);
@@ -279,27 +285,34 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjectedMissingCols) {
   opts_->projector = RecordBatchProjector(SchemaFromColumnNames(schema_, {"f64"}));
   opts_->filter = equal(field_ref("i32"), scalar(0));
 
-  // NB: projector is applied by the scanner; ParquetFragment does not evaluate it so
-  // we will not drop "i32" even though it is not in the projector's schema
-  auto expected_schema = schema({field("f64", float64()), field("i32", int32())});
+  for (auto reader : {reader.get(), reader_without_i32.get(), reader_without_f64.get()}) {
+    auto source = GetFileSource(reader);
+    auto fragment = std::make_shared<ParquetFragment>(*source, format_, opts_);
 
-  auto source =
-      GetFileSource({reader.get(), reader_without_i32.get(), reader_without_f64.get()});
-  auto fragment = std::make_shared<ParquetFragment>(*source, format_, opts_);
+    int64_t row_count = 0;
 
-  ASSERT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(ctx_));
-  int64_t row_count = 0;
-
-  for (auto maybe_task : scan_task_it) {
-    ASSERT_OK_AND_ASSIGN(auto task, std::move(maybe_task));
-    ASSERT_OK_AND_ASSIGN(auto rb_it, task->Execute());
-    for (auto maybe_batch : rb_it) {
+    for (auto maybe_batch : Batches(fragment.get())) {
       ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
       row_count += batch->num_rows();
+      // NB: projector is applied by the scanner; ParquetFragment does not evaluate it.
+      // We will not drop "i32" even though it is not in the projector's schema.
+      //
+      // in the case where a file doesn't contain a referenced field, we won't
+      // materialize it (the filter/projector will populate it with nulls later)
+      std::shared_ptr<Schema> expected_schema;
+      if (reader == reader_without_i32.get()) {
+        expected_schema = schema({field("f64", float64())});
+      } else if (reader == reader_without_f64.get()) {
+        expected_schema = schema({field("i32", int32())});
+      } else {
+        expected_schema = schema({field("f64", float64()), field("i32", int32())});
+      }
+      AssertSchemaEqual(*batch->schema(), *expected_schema,
+                        /*check_metadata=*/false);
     }
-  }
 
-  ASSERT_EQ(row_count, kNumRows);
+    ASSERT_EQ(row_count, kNumRows);
+  }
 }
 
 TEST_F(TestParquetFileFormat, Inspect) {
@@ -341,49 +354,7 @@ TEST_F(TestParquetFileFormat, IsSupported) {
   EXPECT_EQ(supported, true);
 }
 
-void CountRowsInScan(ScanTaskIterator& it, int64_t expected_rows,
-                     int64_t expected_batches) {
-  int64_t actual_rows = 0;
-  int64_t actual_batches = 0;
-
-  for (auto maybe_scan_task : it) {
-    ASSERT_OK_AND_ASSIGN(auto scan_task, std::move(maybe_scan_task));
-    ASSERT_OK_AND_ASSIGN(auto rb_it, scan_task->Execute());
-    for (auto maybe_record_batch : rb_it) {
-      ASSERT_OK_AND_ASSIGN(auto record_batch, std::move(maybe_record_batch));
-      actual_rows += record_batch->num_rows();
-      actual_batches++;
-    }
-  }
-
-  EXPECT_EQ(actual_rows, expected_rows);
-  EXPECT_EQ(actual_batches, expected_batches);
-}
-
-class TestParquetFileFormatPushDown : public TestParquetFileFormat {
- public:
-  void CountRowsAndBatchesInScan(const std::shared_ptr<Fragment>& fragment,
-                                 int64_t expected_rows, int64_t expected_batches) {
-    int64_t actual_rows = 0;
-    int64_t actual_batches = 0;
-
-    ASSERT_OK_AND_ASSIGN(auto it, fragment->Scan(ctx_));
-    for (auto maybe_scan_task : it) {
-      ASSERT_OK_AND_ASSIGN(auto scan_task, std::move(maybe_scan_task));
-      ASSERT_OK_AND_ASSIGN(auto rb_it, scan_task->Execute());
-      for (auto maybe_record_batch : rb_it) {
-        ASSERT_OK_AND_ASSIGN(auto record_batch, std::move(maybe_record_batch));
-        actual_rows += record_batch->num_rows();
-        actual_batches++;
-      }
-    }
-
-    EXPECT_EQ(actual_rows, expected_rows);
-    EXPECT_EQ(actual_batches, expected_batches);
-  }
-};
-
-TEST_F(TestParquetFileFormatPushDown, Basic) {
+TEST_F(TestParquetFileFormat, PredicatePushdown) {
   // Given a number `n`, the arithmetic dataset creates n RecordBatches where
   // each RecordBatch is keyed by a unique integer in [1, n]. Let `rb_i` denote
   // the record batch keyed by `i`. `rb_i` is composed of `i` rows where all
@@ -406,32 +377,32 @@ TEST_F(TestParquetFileFormatPushDown, Basic) {
   auto fragment = std::make_shared<ParquetFragment>(*source, format_, opts_);
 
   opts_->filter = scalar(true);
-  CountRowsAndBatchesInScan(fragment, kTotalNumRows, kNumRowGroups);
+  CountRowsAndBatchesInScan(fragment.get(), kTotalNumRows, kNumRowGroups);
 
   for (int64_t i = 1; i <= kNumRowGroups; i++) {
     opts_->filter = ("i64"_ == int64_t(i)).Copy();
-    CountRowsAndBatchesInScan(fragment, i, 1);
+    CountRowsAndBatchesInScan(fragment.get(), i, 1);
   }
 
   /* Out of bound filters should skip all RowGroups. */
   opts_->filter = scalar(false);
-  CountRowsAndBatchesInScan(fragment, 0, 0);
+  CountRowsAndBatchesInScan(fragment.get(), 0, 0);
   opts_->filter = ("i64"_ == int64_t(kNumRowGroups + 1)).Copy();
-  CountRowsAndBatchesInScan(fragment, 0, 0);
+  CountRowsAndBatchesInScan(fragment.get(), 0, 0);
   opts_->filter = ("i64"_ == int64_t(-1)).Copy();
-  CountRowsAndBatchesInScan(fragment, 0, 0);
+  CountRowsAndBatchesInScan(fragment.get(), 0, 0);
   // No rows match 1 and 2.
   opts_->filter = ("i64"_ == int64_t(1) and "u8"_ == uint8_t(2)).Copy();
-  CountRowsAndBatchesInScan(fragment, 0, 0);
+  CountRowsAndBatchesInScan(fragment.get(), 0, 0);
 
   opts_->filter = ("i64"_ == int64_t(2) or "i64"_ == int64_t(4)).Copy();
-  CountRowsAndBatchesInScan(fragment, 2 + 4, 2);
+  CountRowsAndBatchesInScan(fragment.get(), 2 + 4, 2);
 
   opts_->filter = ("i64"_ < int64_t(6)).Copy();
-  CountRowsAndBatchesInScan(fragment, 5 * (5 + 1) / 2, 5);
+  CountRowsAndBatchesInScan(fragment.get(), 5 * (5 + 1) / 2, 5);
 
   opts_->filter = ("i64"_ >= int64_t(6)).Copy();
-  CountRowsAndBatchesInScan(fragment, kTotalNumRows - (5 * (5 + 1) / 2),
+  CountRowsAndBatchesInScan(fragment.get(), kTotalNumRows - (5 * (5 + 1) / 2),
                             kNumRowGroups - 5);
 }
 


### PR DESCRIPTION
This is an optimization where if both a filter and a projection are given, we apply the -pre-projection before the filter such that columns not referenced by the final projection are not copied.