### PR TITLE
PARQUET-458: [C++][Parquet] Add support for reading/writing DataPageV2 format

### DIFF
--- a/cpp/src/parquet/column_page.h
+++ b/cpp/src/parquet/column_page.h
@@ -62,19 +62,24 @@ class DataPage : public Page {
  public:
   int32_t num_values() const { return num_values_; }
   Encoding::type encoding() const { return encoding_; }
+  int64_t uncompressed_size() const { return uncompressed_size_; }
   const EncodedStatistics& statistics() const { return statistics_; }
+
+  virtual ~DataPage() = default;
 
  protected:
   DataPage(PageType::type type, const std::shared_ptr<Buffer>& buffer, int32_t num_values,
-           Encoding::type encoding,
+           Encoding::type encoding, int64_t uncompressed_size,
            const EncodedStatistics& statistics = EncodedStatistics())
       : Page(buffer, type),
         num_values_(num_values),
         encoding_(encoding),
+        uncompressed_size_(uncompressed_size),
         statistics_(statistics) {}
 
   int32_t num_values_;
   Encoding::type encoding_;
+  int64_t uncompressed_size_;
   EncodedStatistics statistics_;
 };
 
@@ -82,9 +87,10 @@ class DataPageV1 : public DataPage {
  public:
   DataPageV1(const std::shared_ptr<Buffer>& buffer, int32_t num_values,
              Encoding::type encoding, Encoding::type definition_level_encoding,
-             Encoding::type repetition_level_encoding,
+             Encoding::type repetition_level_encoding, int64_t uncompressed_size,
              const EncodedStatistics& statistics = EncodedStatistics())
-      : DataPage(PageType::DATA_PAGE, buffer, num_values, encoding, statistics),
+      : DataPage(PageType::DATA_PAGE, buffer, num_values, encoding, uncompressed_size,
+                 statistics),
         definition_level_encoding_(definition_level_encoding),
         repetition_level_encoding_(repetition_level_encoding) {}
 
@@ -97,29 +103,15 @@ class DataPageV1 : public DataPage {
   Encoding::type repetition_level_encoding_;
 };
 
-class CompressedDataPage : public DataPageV1 {
- public:
-  CompressedDataPage(const std::shared_ptr<Buffer>& buffer, int32_t num_values,
-                     Encoding::type encoding, Encoding::type definition_level_encoding,
-                     Encoding::type repetition_level_encoding, int64_t uncompressed_size,
-                     const EncodedStatistics& statistics = EncodedStatistics())
-      : DataPageV1(buffer, num_values, encoding, definition_level_encoding,
-                   repetition_level_encoding, statistics),
-        uncompressed_size_(uncompressed_size) {}
-
-  int64_t uncompressed_size() const { return uncompressed_size_; }
-
- private:
-  int64_t uncompressed_size_;
-};
-
 class DataPageV2 : public DataPage {
  public:
   DataPageV2(const std::shared_ptr<Buffer>& buffer, int32_t num_values, int32_t num_nulls,
              int32_t num_rows, Encoding::type encoding,
              int32_t definition_levels_byte_length, int32_t repetition_levels_byte_length,
-             bool is_compressed = false)
-      : DataPage(PageType::DATA_PAGE_V2, buffer, num_values, encoding),
+             int64_t uncompressed_size, bool is_compressed = false,
+             const EncodedStatistics& statistics = EncodedStatistics())
+      : DataPage(PageType::DATA_PAGE_V2, buffer, num_values, encoding, uncompressed_size,
+                 statistics),
         num_nulls_(num_nulls),
         num_rows_(num_rows),
         definition_levels_byte_length_(definition_levels_byte_length),
@@ -142,8 +134,6 @@ class DataPageV2 : public DataPage {
   int32_t definition_levels_byte_length_;
   int32_t repetition_levels_byte_length_;
   bool is_compressed_;
-
-  // TODO(wesm): format::DataPageHeaderV2.statistics
 };
 
 class DictionaryPage : public Page {

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -631,9 +631,7 @@ class ColumnReaderImplBase {
                                           static_cast<int>(num_buffered_values_), buffer);
     }
 
-    int64_t levels_byte_size =
-        page.repetition_levels_byte_length() + page.definition_levels_byte_length();
-    return levels_byte_size;
+    return page.repetition_levels_byte_length() + page.definition_levels_byte_length();
   }
 
   // Get a decoder object for this page or create a new decoder if this is the

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -353,10 +353,11 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
       EncodedStatistics page_statistics = ExtractStatsFromHeader(header);
       seen_num_rows_ += header.num_values;
 
-      return std::make_shared<DataPageV1>(
-          page_buffer, header.num_values, LoadEnumSafe(&header.encoding),
-          LoadEnumSafe(&header.definition_level_encoding),
-          LoadEnumSafe(&header.repetition_level_encoding), uncompressed_len, page_statistics);
+      return std::make_shared<DataPageV1>(page_buffer, header.num_values,
+                                          LoadEnumSafe(&header.encoding),
+                                          LoadEnumSafe(&header.definition_level_encoding),
+                                          LoadEnumSafe(&header.repetition_level_encoding),
+                                          uncompressed_len, page_statistics);
     } else if (page_type == PageType::DATA_PAGE_V2) {
       ++page_ordinal_;
       const format::DataPageHeaderV2& header = current_page_header_.data_page_header_v2;

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -613,25 +613,23 @@ class ColumnReaderImplBase {
 
     // Have not decoded any values from the data page yet
     num_decoded_values_ = 0;
-
-    int64_t levels_byte_size = 0;
+    const uint8_t* buffer = page.data();
 
     if (max_rep_level_ > 0) {
-      repetition_level_decoder_.SetDataV2(
-          page.repetition_levels_byte_length(), max_rep_level_,
-          static_cast<int>(num_buffered_values_), page.data());
-
-      levels_byte_size += page.repetition_levels_byte_length();
+      repetition_level_decoder_.SetDataV2(page.repetition_levels_byte_length(),
+                                          max_rep_level_,
+                                          static_cast<int>(num_buffered_values_), buffer);
+      buffer += page.repetition_levels_byte_length();
     }
 
     if (max_def_level_ > 0) {
-      definition_level_decoder_.SetDataV2(
-          page.definition_levels_byte_length(), max_def_level_,
-          static_cast<int>(num_buffered_values_), page.data());
-
-      levels_byte_size += page.definition_levels_byte_length();
+      definition_level_decoder_.SetDataV2(page.definition_levels_byte_length(),
+                                          max_def_level_,
+                                          static_cast<int>(num_buffered_values_), buffer);
     }
 
+    int64_t levels_byte_size =
+        page.repetition_levels_byte_length() + page.definition_levels_byte_length();
     return levels_byte_size;
   }
 

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -617,17 +617,17 @@ class ColumnReaderImplBase {
     int64_t levels_byte_size = 0;
 
     if (max_rep_level_ > 0) {
-      repetition_level_decoder_.SetDataV2(page.repetition_levels_byte_length(),
-                                          max_rep_level_, num_buffered_values_,
-                                          page.data());
+      repetition_level_decoder_.SetDataV2(
+          page.repetition_levels_byte_length(), max_rep_level_,
+          static_cast<int>(num_buffered_values_), page.data());
 
       levels_byte_size += page.repetition_levels_byte_length();
     }
 
     if (max_def_level_ > 0) {
-      definition_level_decoder_.SetDataV2(page.definition_levels_byte_length(),
-                                          max_def_level_, num_buffered_values_,
-                                          page.data());
+      definition_level_decoder_.SetDataV2(
+          page.definition_levels_byte_length(), max_def_level_,
+          static_cast<int>(num_buffered_values_), page.data());
 
       levels_byte_size += page.definition_levels_byte_length();
     }

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -98,6 +98,21 @@ int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
   return -1;
 }
 
+void LevelDecoder::SetDataV2(int32_t num_bytes, int16_t max_level,
+                             int num_buffered_values, const uint8_t* data) {
+  // Repetition and definition levels always uses RLE encoding
+  // in the DataPageV2 format.
+  encoding_ = Encoding::RLE;
+  num_values_remaining_ = num_buffered_values;
+  bit_width_ = BitUtil::Log2(max_level + 1);
+
+  if (!rle_decoder_) {
+    rle_decoder_.reset(new ::arrow::util::RleDecoder(data, num_bytes, bit_width_));
+  } else {
+    rle_decoder_->Reset(data, num_bytes, bit_width_);
+  }
+}
+
 int LevelDecoder::Decode(int batch_size, int16_t* levels) {
   int num_decoded = 0;
 
@@ -114,6 +129,29 @@ int LevelDecoder::Decode(int batch_size, int16_t* levels) {
 ReaderProperties default_reader_properties() {
   static ReaderProperties default_reader_properties;
   return default_reader_properties;
+}
+
+// Extracts encoded statistics from V1 and V2 data page headers
+template <typename H>
+EncodedStatistics ExtractStatsFromHeader(H header) {
+  EncodedStatistics page_statistics;
+  if (!header.__isset.statistics) {
+    return page_statistics;
+  }
+  const format::Statistics& stats = header.statistics;
+  if (stats.__isset.max) {
+    page_statistics.set_max(stats.max);
+  }
+  if (stats.__isset.min) {
+    page_statistics.set_min(stats.min);
+  }
+  if (stats.__isset.null_count) {
+    page_statistics.set_null_count(stats.null_count);
+  }
+  if (stats.__isset.distinct_count) {
+    page_statistics.set_distinct_count(stats.distinct_count);
+  }
+  return page_statistics;
 }
 
 // ----------------------------------------------------------------------
@@ -152,6 +190,9 @@ class SerializedPageReader : public PageReader {
                         const std::string& page_aad);
 
   void InitDecryption();
+
+  void DecompressPage(int compressed_len, int uncompressed_len,
+                      std::shared_ptr<Buffer>& page_buffer);
 
   std::shared_ptr<ArrowInputStream> stream_;
 
@@ -291,14 +332,7 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
     }
     // Uncompress it if we need to
     if (decompressor_ != nullptr) {
-      // Grow the uncompressed buffer if we need to.
-      if (uncompressed_len > static_cast<int>(decompression_buffer_->size())) {
-        PARQUET_THROW_NOT_OK(decompression_buffer_->Resize(uncompressed_len, false));
-      }
-      PARQUET_THROW_NOT_OK(
-          decompressor_->Decompress(compressed_len, page_buffer->data(), uncompressed_len,
-                                    decompression_buffer_->mutable_data()));
-      page_buffer = decompression_buffer_;
+      DecompressPage(compressed_len, uncompressed_len, page_buffer);
     }
 
     const PageType::type page_type = LoadEnumSafe(&current_page_header_.type);
@@ -316,41 +350,25 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
     } else if (page_type == PageType::DATA_PAGE) {
       ++page_ordinal_;
       const format::DataPageHeader& header = current_page_header_.data_page_header;
-
-      EncodedStatistics page_statistics;
-      if (header.__isset.statistics) {
-        const format::Statistics& stats = header.statistics;
-        if (stats.__isset.max) {
-          page_statistics.set_max(stats.max);
-        }
-        if (stats.__isset.min) {
-          page_statistics.set_min(stats.min);
-        }
-        if (stats.__isset.null_count) {
-          page_statistics.set_null_count(stats.null_count);
-        }
-        if (stats.__isset.distinct_count) {
-          page_statistics.set_distinct_count(stats.distinct_count);
-        }
-      }
-
+      EncodedStatistics page_statistics = ExtractStatsFromHeader(header);
       seen_num_rows_ += header.num_values;
 
       return std::make_shared<DataPageV1>(
           page_buffer, header.num_values, LoadEnumSafe(&header.encoding),
           LoadEnumSafe(&header.definition_level_encoding),
-          LoadEnumSafe(&header.repetition_level_encoding), page_statistics);
+          LoadEnumSafe(&header.repetition_level_encoding), uncompressed_len, page_statistics);
     } else if (page_type == PageType::DATA_PAGE_V2) {
       ++page_ordinal_;
       const format::DataPageHeaderV2& header = current_page_header_.data_page_header_v2;
       bool is_compressed = header.__isset.is_compressed ? header.is_compressed : false;
-
+      EncodedStatistics page_statistics = ExtractStatsFromHeader(header);
       seen_num_rows_ += header.num_values;
 
       return std::make_shared<DataPageV2>(
           page_buffer, header.num_values, header.num_nulls, header.num_rows,
           LoadEnumSafe(&header.encoding), header.definition_levels_byte_length,
-          header.repetition_levels_byte_length, is_compressed);
+          header.repetition_levels_byte_length, uncompressed_len, is_compressed,
+          page_statistics);
     } else {
       // We don't know what this page type is. We're allowed to skip non-data
       // pages.
@@ -358,6 +376,35 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
     }
   }
   return std::shared_ptr<Page>(nullptr);
+}
+
+void SerializedPageReader::DecompressPage(int compressed_len, int uncompressed_len,
+                                          std::shared_ptr<Buffer>& page_buffer) {
+  // Grow the uncompressed buffer if we need to.
+  if (uncompressed_len > static_cast<int>(decompression_buffer_->size())) {
+    PARQUET_THROW_NOT_OK(decompression_buffer_->Resize(uncompressed_len, false));
+  }
+
+  if (current_page_header_.type != format::PageType::DATA_PAGE_V2) {
+    PARQUET_THROW_NOT_OK(
+        decompressor_->Decompress(compressed_len, page_buffer->data(), uncompressed_len,
+                                  decompression_buffer_->mutable_data()));
+  } else {
+    // The levels are not compressed in V2 format
+    const auto& header = current_page_header_.data_page_header_v2;
+    int32_t levels_length =
+        header.repetition_levels_byte_length + header.definition_levels_byte_length;
+    uint8_t* decompressed = decompression_buffer_->mutable_data();
+    memcpy(decompressed, page_buffer->data(), levels_length);
+    decompressed += levels_length;
+    const uint8_t* compressed_values = page_buffer->data() + levels_length;
+
+    // Decompress the values
+    PARQUET_THROW_NOT_OK(
+        decompressor_->Decompress(compressed_len - levels_length, compressed_values,
+                                  uncompressed_len - levels_length, decompressed));
+  }
+  page_buffer = decompression_buffer_;
 }
 
 std::unique_ptr<PageReader> PageReader::Open(std::shared_ptr<ArrowInputStream> stream,
@@ -468,10 +515,7 @@ class ColumnReaderImplBase {
         return true;
       } else if (current_page_->type() == PageType::DATA_PAGE_V2) {
         const auto page = std::static_pointer_cast<DataPageV2>(current_page_);
-        // Repetition and definition levels are always encoded using RLE encoding
-        // in the DataPageV2 format.
-        const int64_t levels_byte_size =
-            InitializeLevelDecoders(*page, Encoding::RLE, Encoding::RLE);
+        int64_t levels_byte_size = InitializeLevelDecodersV2(*page);
         InitializeDataDecoder(*page, levels_byte_size);
         return true;
       } else {
@@ -558,6 +602,34 @@ class ColumnReaderImplBase {
           static_cast<int>(num_buffered_values_), buffer, max_size);
       levels_byte_size += def_levels_bytes;
       max_size -= def_levels_bytes;
+    }
+
+    return levels_byte_size;
+  }
+
+  int64_t InitializeLevelDecodersV2(const DataPageV2& page) {
+    // Read a data page.
+    num_buffered_values_ = page.num_values();
+
+    // Have not decoded any values from the data page yet
+    num_decoded_values_ = 0;
+
+    int64_t levels_byte_size = 0;
+
+    if (max_rep_level_ > 0) {
+      repetition_level_decoder_.SetDataV2(page.repetition_levels_byte_length(),
+                                          max_rep_level_, num_buffered_values_,
+                                          page.data());
+
+      levels_byte_size += page.repetition_levels_byte_length();
+    }
+
+    if (max_def_level_ > 0) {
+      definition_level_decoder_.SetDataV2(page.definition_levels_byte_length(),
+                                          max_def_level_, num_buffered_values_,
+                                          page.data());
+
+      levels_byte_size += page.definition_levels_byte_length();
     }
 
     return levels_byte_size;

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -63,6 +63,9 @@ class PARQUET_EXPORT LevelDecoder {
   int SetData(Encoding::type encoding, int16_t max_level, int num_buffered_values,
               const uint8_t* data, int32_t data_size);
 
+  void SetDataV2(int32_t num_bytes, int16_t max_level, int num_buffered_values,
+                 const uint8_t* data);
+
   // Decodes a batch of levels into an array and returns the number of levels decoded
   int Decode(int batch_size, int16_t* levels);
 

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -834,22 +834,22 @@ void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
   // TODO: The following assumes that num_values == num_rows
   int32_t num_values = static_cast<int32_t>(num_buffered_values_);
   int32_t null_count = static_cast<int32_t>(page_stats.null_count);
+  int32_t def_levels_byte_length = static_cast<int32_t>(definition_levels_rle_size);
+  int32_t rep_levels_byte_length = static_cast<int32_t>(repetition_levels_rle_size);
 
   // Write the page to OutputStream eagerly if there is no dictionary or
   // if dictionary encoding has fallen back to PLAIN
   if (has_dictionary_ && !fallback_) {  // Save pages until end of dictionary encoding
     std::shared_ptr<Buffer> data_copy;
     PARQUET_THROW_NOT_OK(combined->Copy(0, combined->size(), allocator_, &data_copy));
-    std::unique_ptr<DataPage> page_ptr(
-        new DataPageV2(combined, num_values, null_count, num_values, encoding_,
-                       definition_levels_rle_size, repetition_levels_rle_size,
-                       uncompressed_size, pager_->has_compressor()));
+    std::unique_ptr<DataPage> page_ptr(new DataPageV2(
+        combined, num_values, null_count, num_values, encoding_, def_levels_byte_length,
+        rep_levels_byte_length, uncompressed_size, pager_->has_compressor()));
     total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
     data_page_ptrs_.push_back(std::move(page_ptr));
   } else {
     DataPageV2 page(combined, num_values, null_count, num_values, encoding_,
-                    definition_levels_rle_size, repetition_levels_rle_size,
-                    uncompressed_size);
+                    def_levels_byte_length, rep_levels_byte_length, uncompressed_size);
     WriteDataPage(page);
   }
 }

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -267,18 +267,9 @@ class SerializedPageWriter : public PageWriter {
     PARQUET_THROW_NOT_OK(dest_buffer->Resize(compressed_size, false));
   }
 
-  int64_t WriteDataPage(const CompressedDataPage& page) override {
+  int64_t WriteDataPage(const DataPage& page) override {
     int64_t uncompressed_size = page.uncompressed_size();
     std::shared_ptr<Buffer> compressed_data = page.buffer();
-    format::DataPageHeader data_page_header;
-    data_page_header.__set_num_values(page.num_values());
-    data_page_header.__set_encoding(ToThrift(page.encoding()));
-    data_page_header.__set_definition_level_encoding(
-        ToThrift(page.definition_level_encoding()));
-    data_page_header.__set_repetition_level_encoding(
-        ToThrift(page.repetition_level_encoding()));
-    data_page_header.__set_statistics(ToThrift(page.statistics()));
-
     const uint8_t* output_data_buffer = compressed_data->data();
     int32_t output_data_len = static_cast<int32_t>(compressed_data->size());
 
@@ -292,11 +283,19 @@ class SerializedPageWriter : public PageWriter {
     }
 
     format::PageHeader page_header;
-    page_header.__set_type(format::PageType::DATA_PAGE);
     page_header.__set_uncompressed_page_size(static_cast<int32_t>(uncompressed_size));
     page_header.__set_compressed_page_size(static_cast<int32_t>(output_data_len));
-    page_header.__set_data_page_header(data_page_header);
     // TODO(PARQUET-594) crc checksum
+
+    if (page.type() == PageType::DATA_PAGE) {
+      const DataPageV1& v1_page = dynamic_cast<const DataPageV1&>(page);
+      SetDataPageHeader(page_header, v1_page);
+    } else if (page.type() == PageType::DATA_PAGE_V2) {
+      const DataPageV2& v2_page = dynamic_cast<const DataPageV2&>(page);
+      SetDataPageV2Header(page_header, v2_page);
+    } else {
+      throw ParquetException("Unexpected page type");
+    }
 
     PARQUET_ASSIGN_OR_THROW(int64_t start_pos, sink_->Tell());
     if (page_ordinal_ == 0) {
@@ -317,6 +316,39 @@ class SerializedPageWriter : public PageWriter {
     ++page_ordinal_;
     PARQUET_ASSIGN_OR_THROW(int64_t current_pos, sink_->Tell());
     return current_pos - start_pos;
+  }
+
+  void SetDataPageHeader(format::PageHeader& page_header, const DataPageV1& page) {
+    format::DataPageHeader data_page_header;
+    data_page_header.__set_num_values(page.num_values());
+    data_page_header.__set_encoding(ToThrift(page.encoding()));
+    data_page_header.__set_definition_level_encoding(
+        ToThrift(page.definition_level_encoding()));
+    data_page_header.__set_repetition_level_encoding(
+        ToThrift(page.repetition_level_encoding()));
+    data_page_header.__set_statistics(ToThrift(page.statistics()));
+
+    page_header.__set_type(format::PageType::DATA_PAGE);
+    page_header.__set_data_page_header(data_page_header);
+  }
+
+  void SetDataPageV2Header(format::PageHeader& page_header, const DataPageV2 page) {
+    format::DataPageHeaderV2 data_page_header;
+    data_page_header.__set_num_values(page.num_values());
+    data_page_header.__set_num_nulls(page.num_nulls());
+    data_page_header.__set_num_rows(page.num_rows());
+    data_page_header.__set_encoding(ToThrift(page.encoding()));
+
+    data_page_header.__set_definition_levels_byte_length(
+        page.definition_levels_byte_length());
+    data_page_header.__set_repetition_levels_byte_length(
+        page.repetition_levels_byte_length());
+
+    data_page_header.__set_is_compressed(page.is_compressed());
+    data_page_header.__set_statistics(ToThrift(page.statistics()));
+
+    page_header.__set_type(format::PageType::DATA_PAGE_V2);
+    page_header.__set_data_page_header_v2(data_page_header);
   }
 
   bool has_compressor() override { return (compressor_ != nullptr); }
@@ -458,7 +490,7 @@ class BufferedPageWriter : public PageWriter {
     PARQUET_THROW_NOT_OK(final_sink_->Write(buffer));
   }
 
-  int64_t WriteDataPage(const CompressedDataPage& page) override {
+  int64_t WriteDataPage(const DataPage& page) override {
     return pager_->WriteDataPage(page);
   }
 
@@ -560,8 +592,15 @@ class ColumnWriterImpl {
   // Serializes the Data Pages in other encoding modes
   void AddDataPage();
 
+  void BuildDataPageV1(int64_t definition_levels_rle_size,
+                       int64_t repetition_levels_rle_size, int64_t uncompressed_size,
+                       const std::shared_ptr<Buffer>& values);
+  void BuildDataPageV2(int64_t definition_levels_rle_size,
+                       int64_t repetition_levels_rle_size, int64_t uncompressed_size,
+                       const std::shared_ptr<Buffer>& values);
+
   // Serializes Data Pages
-  void WriteDataPage(const CompressedDataPage& page) {
+  void WriteDataPage(const DataPage& page) {
     total_bytes_written_ += pager_->WriteDataPage(page);
   }
 
@@ -581,7 +620,7 @@ class ColumnWriterImpl {
 
   // RLE encode the src_buffer into dest_buffer and return the encoded size
   int64_t RleEncodeLevels(const void* src_buffer, ResizableBuffer* dest_buffer,
-                          int16_t max_level);
+                          int16_t max_level, bool include_length_prefix = true);
 
   // Serialize the buffered Data Pages
   void FlushBufferedDataPages();
@@ -635,36 +674,54 @@ class ColumnWriterImpl {
   std::shared_ptr<ResizableBuffer> uncompressed_data_;
   std::shared_ptr<ResizableBuffer> compressed_data_;
 
-  std::vector<CompressedDataPage> data_pages_;
+  std::vector<std::unique_ptr<DataPage>> data_page_ptrs_;
 
  private:
   void InitSinks() {
     definition_levels_sink_.Rewind(0);
     repetition_levels_sink_.Rewind(0);
   }
+
+  // Concatenate the encoded levels and values into one buffer
+  void ConcatenateBuffers(int64_t definition_levels_rle_size,
+                          int64_t repetition_levels_rle_size,
+                          const std::shared_ptr<Buffer>& values, uint8_t* combined) {
+    memcpy(combined, repetition_levels_rle_->data(), repetition_levels_rle_size);
+    combined += repetition_levels_rle_size;
+    memcpy(combined, definition_levels_rle_->data(), definition_levels_rle_size);
+    combined += definition_levels_rle_size;
+    memcpy(combined, values->data(), values->size());
+  }
 };
 
 // return the size of the encoded buffer
 int64_t ColumnWriterImpl::RleEncodeLevels(const void* src_buffer,
-                                          ResizableBuffer* dest_buffer,
-                                          int16_t max_level) {
+                                          ResizableBuffer* dest_buffer, int16_t max_level,
+                                          bool include_length_prefix) {
+  // V1 DataPage includes the length of the RLE level as a prefix.
+  int32_t prefix_size = include_length_prefix ? sizeof(int32_t) : 0;
+
   // TODO: This only works with due to some RLE specifics
   int64_t rle_size = LevelEncoder::MaxBufferSize(Encoding::RLE, max_level,
                                                  static_cast<int>(num_buffered_values_)) +
-                     sizeof(int32_t);
+                     prefix_size;
 
   // Use Arrow::Buffer::shrink_to_fit = false
   // underlying buffer only keeps growing. Resize to a smaller size does not reallocate.
   PARQUET_THROW_NOT_OK(dest_buffer->Resize(rle_size, false));
 
   level_encoder_.Init(Encoding::RLE, max_level, static_cast<int>(num_buffered_values_),
-                      dest_buffer->mutable_data() + sizeof(int32_t),
-                      static_cast<int>(dest_buffer->size() - sizeof(int32_t)));
+                      dest_buffer->mutable_data() + prefix_size,
+                      static_cast<int>(dest_buffer->size() - prefix_size));
   int encoded = level_encoder_.Encode(static_cast<int>(num_buffered_values_),
                                       reinterpret_cast<const int16_t*>(src_buffer));
   DCHECK_EQ(encoded, num_buffered_values_);
-  reinterpret_cast<int32_t*>(dest_buffer->mutable_data())[0] = level_encoder_.len();
-  int64_t encoded_size = level_encoder_.len() + sizeof(int32_t);
+
+  if (include_length_prefix) {
+    reinterpret_cast<int32_t*>(dest_buffer->mutable_data())[0] = level_encoder_.len();
+  }
+
+  int64_t encoded_size = level_encoder_.len() + prefix_size;
   return encoded_size;
 }
 
@@ -673,33 +730,46 @@ void ColumnWriterImpl::AddDataPage() {
   int64_t repetition_levels_rle_size = 0;
 
   std::shared_ptr<Buffer> values = GetValuesBuffer();
+  bool is_v1 = properties_->version() == ParquetVersion::PARQUET_1_0;
 
   if (descr_->max_definition_level() > 0) {
     definition_levels_rle_size =
         RleEncodeLevels(definition_levels_sink_.data(), definition_levels_rle_.get(),
-                        descr_->max_definition_level());
+                        descr_->max_definition_level(), is_v1);
   }
 
   if (descr_->max_repetition_level() > 0) {
     repetition_levels_rle_size =
         RleEncodeLevels(repetition_levels_sink_.data(), repetition_levels_rle_.get(),
-                        descr_->max_repetition_level());
+                        descr_->max_repetition_level(), is_v1);
   }
 
   int64_t uncompressed_size =
       definition_levels_rle_size + repetition_levels_rle_size + values->size();
 
+  if (is_v1) {
+    BuildDataPageV1(definition_levels_rle_size, repetition_levels_rle_size,
+                    uncompressed_size, values);
+  } else {
+    BuildDataPageV2(definition_levels_rle_size, repetition_levels_rle_size,
+                    uncompressed_size, values);
+  }
+
+  // Re-initialize the sinks for next Page.
+  InitSinks();
+  num_buffered_values_ = 0;
+  num_buffered_encoded_values_ = 0;
+}
+
+void ColumnWriterImpl::BuildDataPageV1(int64_t definition_levels_rle_size,
+                                       int64_t repetition_levels_rle_size,
+                                       int64_t uncompressed_size,
+                                       const std::shared_ptr<Buffer>& values) {
   // Use Arrow::Buffer::shrink_to_fit = false
   // underlying buffer only keeps growing. Resize to a smaller size does not reallocate.
   PARQUET_THROW_NOT_OK(uncompressed_data_->Resize(uncompressed_size, false));
-
-  // Concatenate data into a single buffer
-  uint8_t* uncompressed_ptr = uncompressed_data_->mutable_data();
-  memcpy(uncompressed_ptr, repetition_levels_rle_->data(), repetition_levels_rle_size);
-  uncompressed_ptr += repetition_levels_rle_size;
-  memcpy(uncompressed_ptr, definition_levels_rle_->data(), definition_levels_rle_size);
-  uncompressed_ptr += definition_levels_rle_size;
-  memcpy(uncompressed_ptr, values->data(), values->size());
+  ConcatenateBuffers(definition_levels_rle_size, repetition_levels_rle_size, values,
+                     uncompressed_data_->mutable_data());
 
   EncodedStatistics page_stats = GetPageStatistics();
   page_stats.ApplyStatSizeLimits(properties_->max_statistics_size(descr_->path()));
@@ -720,22 +790,68 @@ void ColumnWriterImpl::AddDataPage() {
     std::shared_ptr<Buffer> compressed_data_copy;
     PARQUET_THROW_NOT_OK(compressed_data->Copy(0, compressed_data->size(), allocator_,
                                                &compressed_data_copy));
-    CompressedDataPage page(compressed_data_copy,
-                            static_cast<int32_t>(num_buffered_values_), encoding_,
-                            Encoding::RLE, Encoding::RLE, uncompressed_size, page_stats);
-    total_compressed_bytes_ += page.size() + sizeof(format::PageHeader);
-    data_pages_.push_back(std::move(page));
+    std::unique_ptr<DataPage> page_ptr(new DataPageV1(
+        compressed_data_copy, static_cast<int32_t>(num_buffered_values_), encoding_,
+        Encoding::RLE, Encoding::RLE, uncompressed_size, page_stats));
+    total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
+
+    data_page_ptrs_.push_back(std::move(page_ptr));
   } else {  // Eagerly write pages
-    CompressedDataPage page(compressed_data, static_cast<int32_t>(num_buffered_values_),
-                            encoding_, Encoding::RLE, Encoding::RLE, uncompressed_size,
-                            page_stats);
+    DataPageV1 page(compressed_data, static_cast<int32_t>(num_buffered_values_),
+                    encoding_, Encoding::RLE, Encoding::RLE, uncompressed_size,
+                    page_stats);
     WriteDataPage(page);
   }
+}
 
-  // Re-initialize the sinks for next Page.
-  InitSinks();
-  num_buffered_values_ = 0;
-  num_buffered_encoded_values_ = 0;
+void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
+                                       int64_t repetition_levels_rle_size,
+                                       int64_t uncompressed_size,
+                                       const std::shared_ptr<Buffer>& values) {
+  // Compress the values if needed. Repetition and definition levels are uncompressed in
+  // V2.
+  std::shared_ptr<Buffer> compressed_values;
+  if (pager_->has_compressor()) {
+    pager_->Compress(*(values.get()), compressed_data_.get());
+    compressed_values = compressed_data_;
+  } else {
+    compressed_values = values;
+  }
+
+  // Concatenate uncompressed levels and the possibly compressed values
+  int64_t combined_size =
+      definition_levels_rle_size + repetition_levels_rle_size + compressed_values->size();
+  std::shared_ptr<ResizableBuffer> combined = AllocateBuffer(allocator_, combined_size);
+
+  ConcatenateBuffers(definition_levels_rle_size, repetition_levels_rle_size,
+                     compressed_values, combined->mutable_data());
+
+  EncodedStatistics page_stats = GetPageStatistics();
+  page_stats.ApplyStatSizeLimits(properties_->max_statistics_size(descr_->path()));
+  page_stats.set_is_signed(SortOrder::SIGNED == descr_->sort_order());
+  ResetPageStatistics();
+
+  // TODO: The following assumes that num_values == num_rows
+  int32_t num_values = static_cast<int32_t>(num_buffered_values_);
+  int32_t null_count = static_cast<int32_t>(page_stats.null_count);
+
+  // Write the page to OutputStream eagerly if there is no dictionary or
+  // if dictionary encoding has fallen back to PLAIN
+  if (has_dictionary_ && !fallback_) {  // Save pages until end of dictionary encoding
+    std::shared_ptr<Buffer> data_copy;
+    PARQUET_THROW_NOT_OK(combined->Copy(0, combined->size(), allocator_, &data_copy));
+    std::unique_ptr<DataPage> page_ptr(
+        new DataPageV2(combined, num_values, null_count, num_values, encoding_,
+                       definition_levels_rle_size, repetition_levels_rle_size,
+                       uncompressed_size, pager_->has_compressor()));
+    total_compressed_bytes_ += page_ptr->size() + sizeof(format::PageHeader);
+    data_page_ptrs_.push_back(std::move(page_ptr));
+  } else {
+    DataPageV2 page(combined, num_values, null_count, num_values, encoding_,
+                    definition_levels_rle_size, repetition_levels_rle_size,
+                    uncompressed_size);
+    WriteDataPage(page);
+  }
 }
 
 int64_t ColumnWriterImpl::Close() {
@@ -767,10 +883,10 @@ void ColumnWriterImpl::FlushBufferedDataPages() {
   if (num_buffered_values_ > 0) {
     AddDataPage();
   }
-  for (size_t i = 0; i < data_pages_.size(); i++) {
-    WriteDataPage(data_pages_[i]);
+  for (auto& page_ptr : data_page_ptrs_) {
+    WriteDataPage(*page_ptr);
   }
-  data_pages_.clear();
+  data_page_ptrs_.clear();
   total_compressed_bytes_ = 0;
 }
 

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -883,7 +883,7 @@ void ColumnWriterImpl::FlushBufferedDataPages() {
   if (num_buffered_values_ > 0) {
     AddDataPage();
   }
-  for (auto& page_ptr : data_page_ptrs_) {
+  for (const auto& page_ptr : data_page_ptrs_) {
     WriteDataPage(*page_ptr);
   }
   data_page_ptrs_.clear();

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -831,7 +831,6 @@ void ColumnWriterImpl::BuildDataPageV2(int64_t definition_levels_rle_size,
   page_stats.set_is_signed(SortOrder::SIGNED == descr_->sort_order());
   ResetPageStatistics();
 
-  // TODO: The following assumes that num_values == num_rows
   int32_t num_values = static_cast<int32_t>(num_buffered_values_);
   int32_t null_count = static_cast<int32_t>(page_stats.null_count);
   int32_t def_levels_byte_length = static_cast<int32_t>(definition_levels_rle_size);

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -43,7 +43,7 @@ namespace parquet {
 
 struct ArrowWriteContext;
 class ColumnDescriptor;
-class CompressedDataPage;
+class DataPage;
 class DictionaryPage;
 class ColumnChunkMetaDataBuilder;
 class Encryptor;
@@ -97,7 +97,7 @@ class PARQUET_EXPORT PageWriter {
   // page limit
   virtual void Close(bool has_dictionary, bool fallback) = 0;
 
-  virtual int64_t WriteDataPage(const CompressedDataPage& page) = 0;
+  virtual int64_t WriteDataPage(const DataPage& page) = 0;
 
   virtual int64_t WriteDictionaryPage(const DictionaryPage& page) = 0;
 

--- a/cpp/src/parquet/test_util.h
+++ b/cpp/src/parquet/test_util.h
@@ -342,7 +342,7 @@ static std::shared_ptr<DataPageV1> MakeDataPage(
 
   return std::make_shared<DataPageV1>(buffer, num_values, encoding,
                                       page_builder.def_level_encoding(),
-                                      page_builder.rep_level_encoding());
+                                      page_builder.rep_level_encoding(), buffer->size());
 }
 
 template <typename TYPE>


### PR DESCRIPTION
This patch adds support for reading and writing the Parquet DataPageV2 format.  Currently, this change will make all V2 Parquet files use the DataPageV2 format.  I'm still working on some basic unittests and would welcome any feedback on this in the meantime.