### PR TITLE
ARROW-7931: [C++] Fix crash on corrupt Map array input (OSS-Fuzz)

### DIFF
--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -734,6 +734,10 @@ class ARROW_EXPORT MapArray : public ListArray {
   /// \brief Return array object containing all mapped items
   std::shared_ptr<Array> items() const { return items_; }
 
+  /// Validate child data before constructing the actual MapArray.
+  static Status ValidateChildData(
+      const std::vector<std::shared_ptr<ArrayData>>& child_data);
+
  protected:
   void SetData(const std::shared_ptr<ArrayData>& data);
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -282,6 +282,11 @@ class ArrayLoader {
     return LoadList(type);
   }
 
+  Status Visit(const MapType& type) {
+    RETURN_NOT_OK(LoadList(type));
+    return MapArray::ValidateChildData(out_->child_data);
+  }
+
   Status Visit(const FixedSizeListType& type) {
     out_->buffers.resize(1);
 


### PR DESCRIPTION
Also add a map array to the IPC fuzz corpus.