### PR TITLE
ARROW-7935: [Java] Remove Netty dependency for BufferAllocator and ReferenceManager

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowByteBufAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowByteBufAllocator.java
@@ -30,7 +30,10 @@ import io.netty.buffer.ExpandableByteBuf;
  * the signature and the fact that this Allocator returns ExpandableByteBufs which enable
  * otherwise non-expandable
  * ArrowBufs to be expandable.
+ *
+ * @deprecated This class may be removed in a future release.
  */
+@Deprecated
 public class ArrowByteBufAllocator extends AbstractByteBufAllocator {
 
   private static final int DEFAULT_BUFFER_SIZE = 4096;

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -324,7 +324,6 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         releaseBytes(actualRequestSize);
       }
     }
-
   }
 
   /**

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -33,7 +33,6 @@ import org.apache.arrow.util.Preconditions;
 import org.immutables.value.Value;
 
 import io.netty.buffer.ArrowBuf;
-import io.netty.util.internal.OutOfDirectMemoryError;
 
 /**
  * A base-class that implements all functionality of {@linkplain BufferAllocator}s.
@@ -319,15 +318,6 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       listener.onAllocation(actualRequestSize);
       return buffer;
     } catch (OutOfMemoryError e) {
-      /*
-       * OutOfDirectMemoryError is thrown by Netty when we exceed the direct memory limit defined by
-       * -XX:MaxDirectMemorySize. OutOfMemoryError with "Direct buffer memory" message is thrown by
-       * java.nio.Bits when we exceed the direct memory limit. This should never be hit in practice
-       * as Netty is expected to throw an OutOfDirectMemoryError first.
-       */
-      if (e instanceof OutOfDirectMemoryError || "Direct buffer memory".equals(e.getMessage())) {
-        throw new OutOfMemoryException(e);
-      }
       throw e;
     } finally {
       if (!success) {

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -56,7 +56,10 @@ public interface BufferAllocator extends AutoCloseable {
    * Returns the allocator this allocator falls back to when it needs more memory.
    *
    * @return the underlying allocator used by this allocator
+   *
+   * @deprecated This method may be removed in a future release.
    */
+  @Deprecated
   ByteBufAllocator getAsByteBufAllocator();
 
   /**

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -526,7 +526,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
   /**
    * Returns the underlying {@link UnsafeDirectLittleEndian} instance used by this BufferLedger.
    *
-   * @deprecated Use #unwrap(UnsafeDirectLittleEndian.class) instead.
+   * @deprecated This method may be removed in a future release.
    */
   @Deprecated
   public UnsafeDirectLittleEndian getUnderlying() {
@@ -554,6 +554,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
       return clazz.cast(allocationManager);
     }
 
+    // TODO: remove this in a future release.
     if (clazz == UnsafeDirectLittleEndian.class) {
       Preconditions.checkState(allocationManager instanceof NettyAllocationManager,
           "Underlying memory was not allocated by Netty");


### PR DESCRIPTION
With previous work (ARROW-7329 and ARROW-7505) finished, Netty based allocation is only one of the possible implementations. So we need to revise BufferAllocator and ReferenceManager, to make them general, and independent of Netty libraries.