### PR TITLE
ARROW-3543: [R] Better support for timestamp format and time zones in R

### DIFF
--- a/r/R/array.R
+++ b/r/R/array.R
@@ -175,6 +175,9 @@ DictionaryArray <- R6Class("DictionaryArray", inherit = Array,
   public = list(
     indices = function() Array$create(DictionaryArray__indices(self)),
     dictionary = function() Array$create(DictionaryArray__dictionary(self))
+  ),
+  active = list(
+    ordered = function() self$type$ordered
   )
 )
 DictionaryArray$create <- function(x, dict = NULL) {
@@ -225,6 +228,15 @@ ListArray <- R6Class("ListArray", inherit = Array,
 
 #' @export
 length.Array <- function(x) x$length()
+
+#' @export
+is.na.Array <- function(x) {
+  if (x$type == null()) {
+    rep(TRUE, length(x))
+  } else {
+    !Array__Mask(x)
+  }
+}
 
 #' @export
 as.vector.Array <- function(x, mode) x$as_vector()

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -536,12 +536,8 @@ FixedSizeBinary__initialize <- function(byte_width){
     .Call(`_arrow_FixedSizeBinary__initialize` , byte_width)
 }
 
-Timestamp__initialize1 <- function(unit){
-    .Call(`_arrow_Timestamp__initialize1` , unit)
-}
-
-Timestamp__initialize2 <- function(unit, timezone){
-    .Call(`_arrow_Timestamp__initialize2` , unit, timezone)
+Timestamp__initialize <- function(unit, timezone){
+    .Call(`_arrow_Timestamp__initialize` , unit, timezone)
 }
 
 Time32__initialize <- function(unit){

--- a/r/R/expression.R
+++ b/r/R/expression.R
@@ -31,13 +31,10 @@ Ops.ChunkedArray <- Ops.Array
 Ops.array_expression <- Ops.Array
 
 #' @export
-is.na.Array <- function(x) array_expression("is.na", x)
+is.na.ChunkedArray <- function(x) array_expression("is.na", x)
 
 #' @export
-is.na.ChunkedArray <- is.na.Array
-
-#' @export
-is.na.array_expression <- is.na.Array
+is.na.array_expression <- function(x) array_expression("is.na", x)
 
 #' @export
 as.vector.array_expression <- function(x, ...) {

--- a/r/R/type.R
+++ b/r/R/type.R
@@ -344,17 +344,13 @@ null <- function() shared_ptr(Null, Null__initialize())
 
 #' @rdname data-type
 #' @export
-timestamp <- function(unit = c("s", "ms", "us", "ns"), timezone) {
+timestamp <- function(unit = c("s", "ms", "us", "ns"), timezone = "") {
   if (is.character(unit)) {
     unit <- match.arg(unit)
   }
   unit <- make_valid_time_unit(unit, c(valid_time64_units, valid_time32_units))
-  if (missing(timezone)) {
-    shared_ptr(Timestamp, Timestamp__initialize1(unit))
-  } else {
-    assert_that(is.character(timezone), length(timezone) == 1)
-    shared_ptr(Timestamp, Timestamp__initialize2(unit, timezone))
-  }
+  assert_that(is.character(timezone), length(timezone) == 1)
+  shared_ptr(Timestamp, Timestamp__initialize(unit, timezone))
 }
 
 #' @rdname data-type

--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -953,7 +953,14 @@ std::shared_ptr<arrow::DataType> InferArrowTypeFromVector<INTSXP>(SEXP x) {
   } else if (Rf_inherits(x, "Date")) {
     return date32();
   } else if (Rf_inherits(x, "POSIXct")) {
-    return timestamp(TimeUnit::MICRO, "GMT");
+    std::string tzone;
+    auto tzone_sexp = Rf_getAttrib(x, symbols::tzone);
+    if (Rf_isNull(tzone_sexp)) {
+      tzone = "";
+    } else {
+      tzone = CHAR(STRING_ELT(tzone_sexp, 0));
+    }
+    return timestamp(TimeUnit::MICRO, tzone);
   }
   return int32();
 }
@@ -964,7 +971,14 @@ std::shared_ptr<arrow::DataType> InferArrowTypeFromVector<REALSXP>(SEXP x) {
     return date32();
   }
   if (Rf_inherits(x, "POSIXct")) {
-    return timestamp(TimeUnit::MICRO, "GMT");
+    std::string tzone;
+    auto tzone_sexp = Rf_getAttrib(x, symbols::tzone);
+    if (Rf_isNull(tzone_sexp)) {
+      tzone = "";
+    } else {
+      tzone = CHAR(STRING_ELT(tzone_sexp, 0));
+    }
+    return timestamp(TimeUnit::MICRO, tzone);
   }
   if (Rf_inherits(x, "integer64")) {
     return int64();

--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -516,8 +516,8 @@ class Converter_Timestamp : public Converter_Time<value_type, TimestampType> {
   SEXP Allocate(R_xlen_t n) const {
     Rcpp::NumericVector data(no_init(n));
     Rf_classgets(data, arrow::r::data::classes_POSIXct);
-    auto array = static_cast<TimestampArray*>(Converter::arrays_[0].get());
-    auto array_type = static_cast<const TimestampType*>(array->type().get());
+    auto array = internal::checked_cast<TimestampArray*>(Converter::arrays_[0].get());
+    auto array_type = internal::checked_cast<const TimestampType*>(array->type().get());
     data.attr("tzone") = array_type->timezone();
     return data;
   }

--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -516,6 +516,9 @@ class Converter_Timestamp : public Converter_Time<value_type, TimestampType> {
   SEXP Allocate(R_xlen_t n) const {
     Rcpp::NumericVector data(no_init(n));
     Rf_classgets(data, arrow::r::data::classes_POSIXct);
+    auto array = static_cast<TimestampArray*>(Converter::arrays_[0].get());
+    auto array_type = static_cast<const TimestampType*>(array->type().get());
+    data.attr("tzone") = array_type->timezone();
     return data;
   }
 };

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -2080,32 +2080,17 @@ RcppExport SEXP _arrow_FixedSizeBinary__initialize(SEXP byte_width_sexp){
 
 // datatype.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<arrow::DataType> Timestamp__initialize1(arrow::TimeUnit::type unit);
-RcppExport SEXP _arrow_Timestamp__initialize1(SEXP unit_sexp){
-BEGIN_RCPP
-	Rcpp::traits::input_parameter<arrow::TimeUnit::type>::type unit(unit_sexp);
-	return Rcpp::wrap(Timestamp__initialize1(unit));
-END_RCPP
-}
-#else
-RcppExport SEXP _arrow_Timestamp__initialize1(SEXP unit_sexp){
-	Rf_error("Cannot call Timestamp__initialize1(). Please use arrow::install_arrow() to install required runtime libraries. ");
-}
-#endif
-
-// datatype.cpp
-#if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<arrow::DataType> Timestamp__initialize2(arrow::TimeUnit::type unit, const std::string& timezone);
-RcppExport SEXP _arrow_Timestamp__initialize2(SEXP unit_sexp, SEXP timezone_sexp){
+std::shared_ptr<arrow::DataType> Timestamp__initialize(arrow::TimeUnit::type unit, const std::string& timezone);
+RcppExport SEXP _arrow_Timestamp__initialize(SEXP unit_sexp, SEXP timezone_sexp){
 BEGIN_RCPP
 	Rcpp::traits::input_parameter<arrow::TimeUnit::type>::type unit(unit_sexp);
 	Rcpp::traits::input_parameter<const std::string&>::type timezone(timezone_sexp);
-	return Rcpp::wrap(Timestamp__initialize2(unit, timezone));
+	return Rcpp::wrap(Timestamp__initialize(unit, timezone));
 END_RCPP
 }
 #else
-RcppExport SEXP _arrow_Timestamp__initialize2(SEXP unit_sexp, SEXP timezone_sexp){
-	Rf_error("Cannot call Timestamp__initialize2(). Please use arrow::install_arrow() to install required runtime libraries. ");
+RcppExport SEXP _arrow_Timestamp__initialize(SEXP unit_sexp, SEXP timezone_sexp){
+	Rf_error("Cannot call Timestamp__initialize(). Please use arrow::install_arrow() to install required runtime libraries. ");
 }
 #endif
 
@@ -5885,8 +5870,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_Null__initialize", (DL_FUNC) &_arrow_Null__initialize, 0}, 
 		{ "_arrow_Decimal128Type__initialize", (DL_FUNC) &_arrow_Decimal128Type__initialize, 2}, 
 		{ "_arrow_FixedSizeBinary__initialize", (DL_FUNC) &_arrow_FixedSizeBinary__initialize, 1}, 
-		{ "_arrow_Timestamp__initialize1", (DL_FUNC) &_arrow_Timestamp__initialize1, 1}, 
-		{ "_arrow_Timestamp__initialize2", (DL_FUNC) &_arrow_Timestamp__initialize2, 2}, 
+		{ "_arrow_Timestamp__initialize", (DL_FUNC) &_arrow_Timestamp__initialize, 2}, 
 		{ "_arrow_Time32__initialize", (DL_FUNC) &_arrow_Time32__initialize, 1}, 
 		{ "_arrow_Time64__initialize", (DL_FUNC) &_arrow_Time64__initialize, 1}, 
 		{ "_arrow_list__", (DL_FUNC) &_arrow_list__, 1}, 

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -29,6 +29,7 @@ namespace arrow {
 namespace r {
 struct symbols {
   static SEXP units;
+  static SEXP tzone;
   static SEXP xp;
   static SEXP dot_Internal;
   static SEXP inspect;

--- a/r/src/datatype.cpp
+++ b/r/src/datatype.cpp
@@ -94,13 +94,8 @@ std::shared_ptr<arrow::DataType> FixedSizeBinary__initialize(int32_t byte_width)
 }
 
 // [[arrow::export]]
-std::shared_ptr<arrow::DataType> Timestamp__initialize1(arrow::TimeUnit::type unit) {
-  return arrow::timestamp(unit);
-}
-
-// [[arrow::export]]
-std::shared_ptr<arrow::DataType> Timestamp__initialize2(arrow::TimeUnit::type unit,
-                                                        const std::string& timezone) {
+std::shared_ptr<arrow::DataType> Timestamp__initialize(arrow::TimeUnit::type unit,
+                                                       const std::string& timezone) {
   return arrow::timestamp(unit, timezone);
 }
 

--- a/r/src/symbols.cpp
+++ b/r/src/symbols.cpp
@@ -20,6 +20,7 @@
 namespace arrow {
 namespace r {
 SEXP symbols::units = Rf_install("units");
+SEXP symbols::tzone = Rf_install("tzone");
 SEXP symbols::xp = Rf_install(".:xp:.");
 SEXP symbols::dot_Internal = Rf_install(".Internal");
 SEXP symbols::inspect = Rf_install("inspect");

--- a/r/tests/testthat/helper-expectation.R
+++ b/r/tests/testthat/helper-expectation.R
@@ -35,3 +35,8 @@ expect_equivalent <- function(object, expected, ...) {
   }
   testthat::expect_equivalent(object, expected, ...)
 }
+
+# expect_equal but for DataTypes, so the error prints better
+expect_type_equal <- function(object, expected, ...) {
+  expect_equal(object, expected, ..., label = object$ToString(), expected.label = expected$ToString())
+}

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -22,7 +22,9 @@ expect_array_roundtrip <- function(x, type) {
   expect_equal(a$type, type)
   expect_identical(length(a), length(x))
   if (!inherits(type, "ListType")) {
-    # TODO: is this a bug that these aren't equal?
+    # TODO: revisit how missingness works with ListArrays
+    # R list objects don't handle missingness the same way as other vectors.
+    # Is there some vctrs thing we should do on the roundtrip back to R?
     expect_identical(is.na(a), is.na(x))
   }
   expect_equal(as.vector(a), x)

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -166,6 +166,10 @@ test_that("array supports POSIXct (ARROW-3340)", {
 })
 
 test_that("array supports POSIXlt and without timezone", {
+  # Make sure timezone is not set
+  tz <- Sys.getenv("TZ")
+  Sys.setenv(TZ = "")
+  on.exit(Sys.setenv(TZ = tz))
   times <- strptime("2019-02-03 12:34:56", format="%Y-%m-%d %H:%M:%S") + 1:10
   expect_array_roundtrip(times, timestamp("us", ""))
 

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -19,7 +19,7 @@ context("Array")
 
 expect_array_roundtrip <- function(x, type) {
   a <- Array$create(x)
-  expect_equal(a$type, type)
+  expect_type_equal(a$type, type)
   expect_identical(length(a), length(x))
   if (!inherits(type, "ListType")) {
     # TODO: revisit how missingness works with ListArrays
@@ -32,7 +32,7 @@ expect_array_roundtrip <- function(x, type) {
   if (length(x)) {
     a_sliced <- a$Slice(1)
     x_sliced <- x[-1]
-    expect_equal(a_sliced$type, type)
+    expect_type_equal(a_sliced$type, type)
     expect_identical(length(a_sliced), length(x_sliced))
     if (!inherits(type, "ListType")) {
       expect_identical(is.na(a_sliced), is.na(x_sliced))

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -17,11 +17,32 @@
 
 context("Array")
 
-test_that("Array", {
-  x <- Array$create(c(1:10, 1:10, 1:5))
-  expect_equal(x$type, int32())
-  expect_equal(length(x), 25L)
-  expect_equal(x$as_vector(), c(1:10, 1:10, 1:5))
+expect_array_roundtrip <- function(x, type) {
+  a <- Array$create(x)
+  expect_equal(a$type, type)
+  expect_identical(length(a), length(x))
+  if (!inherits(type, "ListType")) {
+    # TODO: is this a bug that these aren't equal?
+    expect_identical(is.na(a), is.na(x))
+  }
+  expect_equal(as.vector(a), x)
+
+  if (length(x)) {
+    a_sliced <- a$Slice(1)
+    x_sliced <- x[-1]
+    expect_equal(a_sliced$type, type)
+    expect_identical(length(a_sliced), length(x_sliced))
+    if (!inherits(type, "ListType")) {
+      expect_identical(is.na(a_sliced), is.na(x_sliced))
+    }
+    expect_equal(as.vector(a_sliced), x_sliced)
+  }
+  invisible(a)
+}
+
+test_that("Integer Array", {
+  ints <- c(1:10, 1:10, 1:5)
+  x <- expect_array_roundtrip(ints, int32())
 
   y <- x$Slice(10)
   expect_equal(y$type, int32())
@@ -34,22 +55,11 @@ test_that("Array", {
   expect_equal(z$length(), 5L)
   expect_vector(z, c(1:5))
   expect_true(x$RangeEquals(z, 10, 15, 0))
+})
 
-  x_dbl <- Array$create(c(1,2,3,4,5,6))
-  expect_equal(x_dbl$type, float64())
-  expect_equal(x_dbl$length(), 6L)
-  expect_equal(x_dbl$as_vector(), as.numeric(1:6))
-
-  y_dbl <- x_dbl$Slice(3)
-  expect_equal(y_dbl$type, float64())
-  expect_equal(y_dbl$length(), 3L)
-  expect_equal(y_dbl$offset, 3L)
-  expect_equal(y_dbl$as_vector(), as.numeric(4:6))
-
-  z_dbl <- x_dbl$Slice(3, 2)
-  expect_equal(z_dbl$type, float64())
-  expect_equal(z_dbl$length(), 2L)
-  expect_equal(z_dbl$as_vector(), as.numeric(4:5))
+test_that("Double Array", {
+  dbls <- c(1, 2, 3, 4, 5, 6)
+  x_dbl <- expect_array_roundtrip(dbls, float64())
 })
 
 test_that("Array print method includes type", {
@@ -65,230 +75,104 @@ test_that("Array supports NA", {
   expect_true(x_int$IsNull(10L))
   expect_true(x_dbl$IsNull(10L))
 
-  # this is not part of Array api
-  expect_equal(Array__Mask(x_int), c(rep(TRUE, 10), FALSE))
-  expect_equal(Array__Mask(x_dbl), c(rep(TRUE, 10), FALSE))
+  expect_equal(is.na(x_int), c(rep(FALSE, 10), TRUE))
+  expect_equal(is.na(x_dbl), c(rep(FALSE, 10), TRUE))
 })
 
 test_that("Array support null type (ARROW-7064)", {
-  a <- Array$create(vctrs::unspecified(10))
-  expect_equal(a$type, null())
-
-  v <- a$as_vector()
-  expect_equal(v, vctrs::unspecified(10))
+  expect_array_roundtrip(vctrs::unspecified(10), null())
 })
 
 test_that("Array supports logical vectors (ARROW-3341)", {
   # with NA
   x <- sample(c(TRUE, FALSE, NA), 1000, replace = TRUE)
-  arr_lgl <- Array$create(x)
-  expect_identical(x, arr_lgl$as_vector())
+  expect_array_roundtrip(x, bool())
 
   # without NA
   x <- sample(c(TRUE, FALSE), 1000, replace = TRUE)
-  arr_lgl <- Array$create(x)
-  expect_identical(x, arr_lgl$as_vector())
+  expect_array_roundtrip(x, bool())
 })
 
 test_that("Array supports character vectors (ARROW-3339)", {
-  # with NA
-  x <- c("itsy", NA, "spider")
-  arr_chr <- Array$create(x)
-  expect_equal(arr_chr$length(), 3L)
-  expect_identical(arr_chr$as_vector(), x)
-  expect_true(arr_chr$IsValid(0))
-  expect_true(arr_chr$IsNull(1))
-  expect_true(arr_chr$IsValid(2))
-
-  sl <- arr_chr$Slice(1)
-  expect_equal(sl$as_vector(), x[2:3])
-
   # without NA
-  x <- c("itsy", "bitsy", "spider")
-  arr_chr <- Array$create(x)
-  expect_equal(arr_chr$length(), 3L)
-  expect_identical(arr_chr$as_vector(), x)
+  expect_array_roundtrip(c("itsy", "bitsy", "spider"), utf8())
+  # with NA
+  expect_array_roundtrip(c("itsy", NA, "spider"), utf8())
 })
 
 test_that("empty arrays are supported", {
-  x <- character()
-  expect_equal(Array$create(x)$as_vector(), x)
-
-  x <- integer()
-  expect_equal(Array$create(x)$as_vector(), x)
-
-  x <- numeric()
-  expect_equal(Array$create(x)$as_vector(), x)
-
-  x <- factor(character())
-  expect_equal(Array$create(x)$as_vector(), x)
-
-  x <- logical()
-  expect_equal(Array$create(x)$as_vector(), x)
+  expect_array_roundtrip(character(), utf8())
+  expect_array_roundtrip(integer(), int32())
+  expect_array_roundtrip(numeric(), float64())
+  expect_array_roundtrip(factor(character()), dictionary(int8(), utf8()))
+  expect_array_roundtrip(logical(), bool())
 })
 
 test_that("array with all nulls are supported", {
   nas <- c(NA, NA)
-
-  x <- as.logical(nas)
-  expect_equal(Array$create(x)$as_vector(), x)
-
-  x <- as.integer(nas)
-  expect_equal(Array$create(x)$as_vector(), x)
-
-  x <- as.numeric(nas)
-  expect_equal(Array$create(x)$as_vector(), x)
-
-  x <- as.character(nas)
-  expect_equal(Array$create(x)$as_vector(), x)
-
-  x <- as.factor(nas)
-  expect_equal(Array$create(x)$as_vector(), x)
+  expect_array_roundtrip(as.character(nas), utf8())
+  expect_array_roundtrip(as.integer(nas), int32())
+  expect_array_roundtrip(as.numeric(nas), float64())
+  expect_array_roundtrip(as.factor(nas), dictionary(int8(), utf8()))
+  expect_array_roundtrip(as.logical(nas), bool())
 })
 
 test_that("Array supports unordered factors (ARROW-3355)", {
   # without NA
   f <- factor(c("itsy", "bitsy", "spider", "spider"))
-  arr_fac <- Array$create(f)
-  expect_equal(arr_fac$length(), 4L)
-  expect_equal(arr_fac$type$index_type, int8())
-  expect_identical(arr_fac$as_vector(), f)
-  expect_true(arr_fac$IsValid(0))
-  expect_true(arr_fac$IsValid(1))
-  expect_true(arr_fac$IsValid(2))
-  expect_true(arr_fac$IsValid(3))
-
-  sl <- arr_fac$Slice(1)
-  expect_equal(sl$length(), 3L)
-  expect_equal(arr_fac$type$index_type, int8())
-  expect_equal(sl$as_vector(), f[2:4])
+  expect_array_roundtrip(f, dictionary(int8(), utf8()))
 
   # with NA
   f <- factor(c("itsy", "bitsy", NA, "spider", "spider"))
-  arr_fac <- Array$create(f)
-  expect_equal(arr_fac$length(), 5L)
-  expect_equal(arr_fac$type$index_type, int8())
-  expect_identical(arr_fac$as_vector(), f)
-  expect_true(arr_fac$IsValid(0))
-  expect_true(arr_fac$IsValid(1))
-  expect_true(arr_fac$IsNull(2))
-  expect_true(arr_fac$IsValid(3))
-  expect_true(arr_fac$IsValid(4))
-
-  sl <- arr_fac$Slice(1)
-  expect_equal(sl$length(), 4L)
-  expect_equal(arr_fac$type$index_type, int8())
-  expect_equal(sl$as_vector(), f[2:5])
+  expect_array_roundtrip(f, dictionary(int8(), utf8()))
 })
 
 test_that("Array supports ordered factors (ARROW-3355)", {
   # without NA
   f <- ordered(c("itsy", "bitsy", "spider", "spider"))
-  arr_fac <- Array$create(f)
-  expect_equal(arr_fac$length(), 4L)
-  expect_equal(arr_fac$type$index_type, int8())
-  expect_identical(arr_fac$as_vector(), f)
-  expect_true(arr_fac$IsValid(0))
-  expect_true(arr_fac$IsValid(1))
-  expect_true(arr_fac$IsValid(2))
-  expect_true(arr_fac$IsValid(3))
-
-  sl <- arr_fac$Slice(1)
-  expect_equal(sl$length(), 3L)
-  expect_equal(arr_fac$type$index_type, int8())
-  expect_equal(sl$as_vector(), f[2:4])
+  arr_fac <- expect_array_roundtrip(f, dictionary(int8(), utf8(), ordered = TRUE))
+  expect_true(arr_fac$ordered)
 
   # with NA
   f <- ordered(c("itsy", "bitsy", NA, "spider", "spider"))
-  arr_fac <- Array$create(f)
-  expect_equal(arr_fac$length(), 5L)
-  expect_equal(arr_fac$type$index_type, int8())
-  expect_identical(arr_fac$as_vector(), f)
-  expect_true(arr_fac$IsValid(0))
-  expect_true(arr_fac$IsValid(1))
-  expect_true(arr_fac$IsNull(2))
-  expect_true(arr_fac$IsValid(3))
-  expect_true(arr_fac$IsValid(4))
-
-  sl <- arr_fac$Slice(1)
-  expect_equal(sl$length(), 4L)
-  expect_equal(arr_fac$type$index_type, int8())
-  expect_equal(sl$as_vector(), f[2:5])
+  expect_array_roundtrip(f, dictionary(int8(), utf8(), ordered = TRUE))
 })
 
 test_that("array supports Date (ARROW-3340)", {
   d <- Sys.Date() + 1:10
-  a <- Array$create(d)
-  expect_equal(a$type, date32())
-  expect_equal(a$length(), 10L)
-  expect_equal(a$as_vector(), d)
+  expect_array_roundtrip(d, date32())
 
   d[5] <- NA
-  a <- Array$create(d)
-  expect_equal(a$type, date32())
-  expect_equal(a$length(), 10L)
-  expect_equal(a$as_vector(), d)
-  expect_true(a$IsNull(4))
+  expect_array_roundtrip(d, date32())
 
   d2 <- d + .5
-  a <- Array$create(d2)
-  expect_equal(a$type, date32())
-  expect_equal(a$length(), 10L)
-  expect_equal(a$as_vector(), d)
-  expect_true(a$IsNull(4))
+  skip("Mean relative difference: 2.729026e-05")
+  expect_array_roundtrip(d2, date32())
 })
 
 test_that("array supports POSIXct (ARROW-3340)", {
   times <- lubridate::ymd_hms("2018-10-07 19:04:05") + 1:10
-  a <- Array$create(times)
-  expect_equal(a$type$name, "timestamp")
-  expect_equal(a$type$unit(), unclass(TimeUnit$MICRO))
-  expect_equal(a$length(), 10L)
-  expect_equal(as.numeric(a$as_vector()), as.numeric(times))
+  expect_array_roundtrip(times, timestamp("us", "GMT"))
 
   times[5] <- NA
-  a <- Array$create(times)
-  expect_equal(a$type$name, "timestamp")
-  expect_equal(a$type$unit(), unclass(TimeUnit$MICRO))
-  expect_equal(a$length(), 10L)
-  expect_equal(as.numeric(a$as_vector()), as.numeric(times))
-  expect_true(a$IsNull(4))
+  expect_array_roundtrip(times, timestamp("us", "GMT"))
 })
 
 test_that("array supports integer64", {
   x <- bit64::as.integer64(1:10)
-  a <- Array$create(x)
-  expect_equal(a$type, int64())
-  expect_equal(a$length(), 10L)
-  expect_equal(a$as_vector(), x)
+  expect_array_roundtrip(x, int64())
 
   x[4] <- NA
-  a <- Array$create(x)
-  expect_equal(a$type, int64())
-  expect_equal(a$length(), 10L)
-  expect_equal(a$as_vector(), x)
-  expect_true(a$IsNull(3L))
-})
+  expect_array_roundtrip(x, int64())
 
-test_that("array$as_vector() correctly handles all NA int64 (ARROW-3795)", {
-  x <- bit64::as.integer64(NA)
-  a <- Array$create(x)
-  expect_true(is.na(a$as_vector()))
+  # all NA int64 (ARROW-3795)
+  expect_array_roundtrip(bit64::as.integer64(NA), int64())
 })
 
 test_that("array supports difftime", {
   time <- hms::hms(56, 34, 12)
-  a <- Array$create(c(time, time))
-  expect_equal(a$type, time32(unit = TimeUnit$SECOND))
-  expect_equal(a$length(), 2L)
-  expect_equal(a$as_vector(), c(time, time))
-
-  a <- Array$create(vctrs::vec_c(NA, time))
-  expect_equal(a$type, time32(unit = TimeUnit$SECOND))
-  expect_equal(a$length(), 2L)
-  expect_true(a$IsNull(0))
-  expect_equal(a$as_vector()[2], time)
-  expect_true(is.na(a$as_vector()[1]))
+  expect_array_roundtrip(c(time, time), time32("s"))
+  expect_array_roundtrip(vctrs::vec_c(NA, time), time32("s"))
 })
 
 test_that("support for NaN (ARROW-3615)", {
@@ -298,64 +182,36 @@ test_that("support for NaN (ARROW-3615)", {
   expect_equal(y$null_count, 1L)
 })
 
+int_types <- c(int8(), int16(), int32(), int64())
+uint_types <- c(uint8(), uint16(), uint32(), uint64())
+float_types <- c(float32(), float64()) # float16() not really supported in C++ yet
+
 test_that("integer types casts (ARROW-3741)", {
   a <- Array$create(c(1:10, NA))
-  a_int8 <- a$cast(int8())
-  a_int16 <- a$cast(int16())
-  a_int32 <- a$cast(int32())
-  a_int64 <- a$cast(int64())
-
-  expect_equal(a_int8$type, int8())
-  expect_equal(a_int16$type, int16())
-  expect_equal(a_int32$type, int32())
-  expect_equal(a_int64$type, int64())
-  expect_true(a_int8$IsNull(10L))
-  expect_true(a_int16$IsNull(10L))
-  expect_true(a_int32$IsNull(10L))
-  expect_true(a_int64$IsNull(10L))
-
-  a_uint8 <- a$cast(uint8())
-  a_uint16 <- a$cast(uint16())
-  a_uint32 <- a$cast(uint32())
-  a_uint64 <- a$cast(uint64())
-
-  expect_equal(a_uint8$type, uint8())
-  expect_equal(a_uint16$type, uint16())
-  expect_equal(a_uint32$type, uint32())
-  expect_equal(a_uint64$type, uint64())
-  expect_true(a_uint8$IsNull(10L))
-  expect_true(a_uint16$IsNull(10L))
-  expect_true(a_uint32$IsNull(10L))
-  expect_true(a_uint64$IsNull(10L))
+  for (type in c(int_types, uint_types)) {
+    casted <- a$cast(type)
+    expect_equal(casted$type, type)
+    expect_identical(is.na(casted), c(rep(FALSE, 10), TRUE))
+  }
 })
 
 test_that("integer types cast safety (ARROW-3741, ARROW-5541)", {
   a <- Array$create(-(1:10))
-  expect_error(a$cast(uint8()), regexp = "Integer value out of bounds")
-  expect_error(a$cast(uint16()), regexp = "Integer value out of bounds")
-  expect_error(a$cast(uint32()), regexp = "Integer value out of bounds")
-  expect_error(a$cast(uint64()), regexp = "Integer value out of bounds")
-
-  expect_error(a$cast(uint8(), safe = FALSE), NA)
-  expect_error(a$cast(uint16(), safe = FALSE), NA)
-  expect_error(a$cast(uint32(), safe = FALSE), NA)
-  expect_error(a$cast(uint64(), safe = FALSE), NA)
+  for (type in uint_types) {
+    expect_error(a$cast(type), regexp = "Integer value out of bounds")
+    expect_error(a$cast(type, safe = FALSE), NA)
+  }
 })
 
 test_that("float types casts (ARROW-3741)", {
   x <- c(1, 2, 3, NA)
   a <- Array$create(x)
-  a_f32 <- a$cast(float32())
-  a_f64 <- a$cast(float64())
-
-  expect_equal(a_f32$type, float32())
-  expect_equal(a_f64$type, float64())
-
-  expect_true(a_f32$IsNull(3L))
-  expect_true(a_f64$IsNull(3L))
-
-  expect_equal(a_f32$as_vector(), x)
-  expect_equal(a_f64$as_vector(), x)
+  for (type in float_types) {
+    casted <- a$cast(type)
+    expect_equal(casted$type, type)
+    expect_identical(is.na(casted), c(rep(FALSE, 3), TRUE))
+    expect_identical(as.vector(casted), x)
+  }
 })
 
 test_that("cast to half float works", {
@@ -374,10 +230,10 @@ test_that("Array$create() supports the type= argument. conversion from INTSXP an
   num_int32 <- 12L
   num_int64 <- bit64::as.integer64(10)
 
-  types <- list(
-    int8(), int16(), int32(), int64(),
-    uint8(), uint16(), uint32(), uint64(),
-    float32(), float64(),
+  types <- c(
+    int_types,
+    uint_types,
+    float_types,
     double() # not actually a type, a base R function but should be alias for float64
   )
   for (type in types) {
@@ -393,31 +249,28 @@ test_that("Array$create() supports the type= argument. conversion from INTSXP an
 })
 
 test_that("Array$create() aborts on overflow", {
-  expect_error(Array$create(128L, type = int8())$type, "Invalid.*Value is too large")
-  expect_error(Array$create(-129L, type = int8())$type, "Invalid.*Value is too large")
+  msg <- "Invalid.*Value is too large"
+  expect_error(Array$create(128L, type = int8()), msg)
+  expect_error(Array$create(-129L, type = int8()), msg)
+  
+  expect_error(Array$create(256L, type = uint8()), msg)
+  expect_error(Array$create(-1L, type = uint8()), msg)
 
-  expect_error(Array$create(256L, type = uint8())$type, "Invalid.*Value is too large")
-  expect_error(Array$create(-1L, type = uint8())$type, "Invalid.*Value is too large")
+  expect_error(Array$create(32768L, type = int16()), msg)
+  expect_error(Array$create(-32769L, type = int16()), msg)
 
-  expect_error(Array$create(32768L, type = int16())$type, "Invalid.*Value is too large")
-  expect_error(Array$create(-32769L, type = int16())$type, "Invalid.*Value is too large")
+  expect_error(Array$create(65536L, type = uint16()), msg)
+  expect_error(Array$create(-1L, type = uint16()), msg)
 
-  expect_error(Array$create(65536L, type = uint16())$type, "Invalid.*Value is too large")
-  expect_error(Array$create(-1L, type = uint16())$type, "Invalid.*Value is too large")
+  expect_error(Array$create(65536L, type = uint16()), msg)
+  expect_error(Array$create(-1L, type = uint16()), msg)
 
-  expect_error(Array$create(65536L, type = uint16())$type, "Invalid.*Value is too large")
-  expect_error(Array$create(-1L, type = uint16())$type, "Invalid.*Value is too large")
-
-  expect_error(Array$create(bit64::as.integer64(2^31), type = int32()), "Invalid.*Value is too large")
-  expect_error(Array$create(bit64::as.integer64(2^32), type = uint32()), "Invalid.*Value is too large")
+  expect_error(Array$create(bit64::as.integer64(2^31), type = int32()), msg)
+  expect_error(Array$create(bit64::as.integer64(2^32), type = uint32()), msg)
 })
 
 test_that("Array$create() does not convert doubles to integer", {
-  types <- list(
-    int8(), int16(), int32(), int64(),
-    uint8(), uint16(), uint32(), uint64()
-  )
-  for(type in types) {
+  for (type in c(int_types, uint_types)) {
     a <- Array$create(10, type = type)
     expect_equal(a$type, type)
 
@@ -472,38 +325,32 @@ test_that("Array$create() can handle data frame with custom struct type (not inf
 })
 
 test_that("Array$create() handles vector -> list arrays (ARROW-7662)", {
-  expect_list_array <- function(v, type) {
-    a <- Array$create(v)
-    expect_equal(a$type, list_of(type))
-    expect_equivalent(a$as_vector(), v)
-  }
-
   # Should be able to create an empty list with a type hint.
-  Array$create(list(), list_of(bool()))
+  expect_is(Array$create(list(), list_of(bool())), "ListArray")
 
   # logical
-  expect_list_array(list(NA), bool())
-  expect_list_array(list(logical(0)), bool())
-  expect_list_array(list(c(TRUE), c(FALSE), c(FALSE, TRUE)), bool())
-  expect_list_array(list(c(TRUE), c(FALSE), NA, logical(0), c(FALSE, NA, TRUE)), bool())
+  expect_array_roundtrip(list(NA), list_of(bool()))
+  expect_array_roundtrip(list(logical(0)), list_of(bool()))
+  expect_array_roundtrip(list(c(TRUE), c(FALSE), c(FALSE, TRUE)), list_of(bool()))
+  expect_array_roundtrip(list(c(TRUE), c(FALSE), NA, logical(0), c(FALSE, NA, TRUE)), list_of(bool()))
 
   # integer
-  expect_list_array(list(NA_integer_), int32())
-  expect_list_array(list(integer(0)), int32())
-  expect_list_array(list(1:2, 3:4, 12:18), int32())
-  expect_list_array(list(c(1:2), NA_integer_, integer(0), c(12:18, NA_integer_)), int32())
+  expect_array_roundtrip(list(NA_integer_), list_of(int32()))
+  expect_array_roundtrip(list(integer(0)), list_of(int32()))
+  expect_array_roundtrip(list(1:2, 3:4, 12:18), list_of(int32()))
+  expect_array_roundtrip(list(c(1:2), NA_integer_, integer(0), c(12:18, NA_integer_)), list_of(int32()))
 
   # numeric
-  expect_list_array(list(NA_real_), float64())
-  expect_list_array(list(numeric(0)), float64())
-  expect_list_array(list(1, c(2, 3), 4), float64())
-  expect_list_array(list(1, numeric(0), c(2, 3, NA_real_), 4), float64())
+  expect_array_roundtrip(list(NA_real_), list_of(float64()))
+  expect_array_roundtrip(list(numeric(0)), list_of(float64()))
+  expect_array_roundtrip(list(1, c(2, 3), 4), list_of(float64()))
+  expect_array_roundtrip(list(1, numeric(0), c(2, 3, NA_real_), 4), list_of(float64()))
 
   # character
-  expect_list_array(list(NA_character_), utf8())
-  expect_list_array(list(character(0)), utf8())
-  expect_list_array(list("itsy", c("bitsy", "spider"), c("is")), utf8())
-  expect_list_array(list("itsy", character(0), c("bitsy", "spider", NA_character_), c("is")), utf8())
+  expect_array_roundtrip(list(NA_character_), list_of(utf8()))
+  expect_array_roundtrip(list(character(0)), list_of(utf8()))
+  expect_array_roundtrip(list("itsy", c("bitsy", "spider"), c("is")), list_of(utf8()))
+  expect_array_roundtrip(list("itsy", character(0), c("bitsy", "spider", NA_character_), c("is")), list_of(utf8()))
 })
 
 test_that("Array$create() should have helpful error on lists with type hint", {
@@ -521,15 +368,22 @@ test_that("Array$create() should refuse heterogeneous lists", {
   num <- numeric(0)
   char <- character(0)
 
-  expect_error(Array$create(list()),
-               regexp = "Requires at least one element to infer the values'")
-
-  expect_error(Array$create(list(lgl, lgl, int)),
-               regexp = "List vector expecting elements vector of type")
-  expect_error(Array$create(list(char, num, char)),
-               regexp = "List vector expecting elements vector of type")
-  expect_error(Array$create(list(int, int, num)),
-               regexp = "List vector expecting elements vector of type")
+  expect_error(
+    Array$create(list()),
+    regexp = "Requires at least one element to infer the values'"
+  )
+  expect_error(
+    Array$create(list(lgl, lgl, int)),
+    regexp = "List vector expecting elements vector of type"
+  )
+  expect_error(
+    Array$create(list(char, num, char)),
+    regexp = "List vector expecting elements vector of type"
+  )
+  expect_error(
+    Array$create(list(int, int, num)),
+    regexp = "List vector expecting elements vector of type"
+  )
 })
 
 test_that("Array$View() (ARROW-6542)", {

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -318,7 +318,7 @@ test_that("Dataset and query print methods", {
       "lgl: bool",
       "chr: string",
       "fct: dictionary<values=string, indices=int32>",
-      "ts: timestamp[us, tz=GMT]",
+      "ts: timestamp[us, tz=UTC]",
       "group: int32",
       "other: string",
       "",

--- a/r/tests/testthat/test-type.R
+++ b/r/tests/testthat/test-type.R
@@ -19,33 +19,33 @@ context("test-type")
 
 test_that("type() gets the right type for arrow::Array", {
   a <- Array$create(1:10)
-  expect_equal(type(a), a$type)
+  expect_type_equal(type(a), a$type)
 })
 
 test_that("type() gets the right type for ChunkedArray", {
   a <- chunked_array(1:10, 1:10)
-  expect_equal(type(a), a$type)
+  expect_type_equal(type(a), a$type)
 })
 
 test_that("type() infers from R type", {
-  expect_equal(type(1:10), int32())
-  expect_equal(type(1), float64())
-  expect_equal(type(TRUE), boolean())
-  expect_equal(type(raw()), int8())
-  expect_equal(type(""), utf8())
-  expect_equal(
+  expect_type_equal(type(1:10), int32())
+  expect_type_equal(type(1), float64())
+  expect_type_equal(type(TRUE), boolean())
+  expect_type_equal(type(raw()), int8())
+  expect_type_equal(type(""), utf8())
+  expect_type_equal(
     type(iris$Species),
     dictionary(int8(), utf8(), FALSE)
   )
-  expect_equal(
+  expect_type_equal(
     type(lubridate::ymd_hms("2019-02-14 13:55:05")),
     timestamp(TimeUnit$MICRO, "UTC")
   )
-  expect_equal(
+  expect_type_equal(
     type(hms::hms(56, 34, 12)),
     time32(unit = TimeUnit$SECOND)
   )
-  expect_equal(
+  expect_type_equal(
     type(bit64::integer64()),
     int64()
   )
@@ -53,7 +53,7 @@ test_that("type() infers from R type", {
 
 test_that("type() can infer struct types from data frames", {
   df <- tibble::tibble(x = 1:10, y = rnorm(10), z = letters[1:10])
-  expect_equal(type(df), struct(x = int32(), y = float64(), z = utf8()))
+  expect_type_equal(type(df), struct(x = int32(), y = float64(), z = utf8()))
 })
 
 test_that("DataType$Equals", {
@@ -65,5 +65,6 @@ test_that("DataType$Equals", {
   expect_false(a == z)
   expect_equal(a, b)
   expect_failure(expect_equal(a, z))
+  expect_failure(expect_type_equal(a, z), "int32 not equal to double")
   expect_false(a$Equals(32L))
 })

--- a/r/tests/testthat/test-type.R
+++ b/r/tests/testthat/test-type.R
@@ -39,7 +39,7 @@ test_that("type() infers from R type", {
   )
   expect_equal(
     type(lubridate::ymd_hms("2019-02-14 13:55:05")),
-    timestamp(TimeUnit$MICRO, "GMT")
+    timestamp(TimeUnit$MICRO, "UTC")
   )
   expect_equal(
     type(hms::hms(56, 34, 12)),


### PR DESCRIPTION
Most of this patch is test refactoring in test-Array.R, with the purpose of making sure that our R <--> Arrow roundtrips are faithful. In the process this uncovered a few issues we weren't handling correctly, and in fixing the timezone handling for timestamps, I realized that this longstanding bug might also be fixed. https://github.com/apache/arrow/commit/507762fa51d17e61f08d36d3626ab8b8df716198 is the commit with the bugfix.