### PR TITLE
ARROW-7932: [Rust] implement array_reader for temporal types

### DIFF
--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -31,7 +31,7 @@ use arrow::array::{
     Int16BufferBuilder, StructArray,
 };
 use arrow::buffer::{Buffer, MutableBuffer};
-use arrow::datatypes::{DataType as ArrowType, Field};
+use arrow::datatypes::{DataType as ArrowType, Field, IntervalUnit};
 
 use crate::arrow::converter::{
     BinaryConverter, BoolConverter, Converter, Float32Converter, Float64Converter,
@@ -215,6 +215,54 @@ impl<T: DataType> ArrayReader for PrimitiveArrayReader<T> {
                 Float64Converter::convert(transmute::<
                     &mut RecordReader<T>,
                     &mut RecordReader<DoubleType>,
+                >(&mut self.record_reader))
+            },
+            (ArrowType::Timestamp(_, _), PhysicalType::INT64) => unsafe {
+                UInt64Converter::convert(transmute::<
+                    &mut RecordReader<T>,
+                    &mut RecordReader<Int64Type>,
+                >(&mut self.record_reader))
+            },
+            (ArrowType::Date32(_), PhysicalType::INT32) => unsafe {
+                UInt32Converter::convert(transmute::<
+                    &mut RecordReader<T>,
+                    &mut RecordReader<Int32Type>,
+                >(&mut self.record_reader))
+            },
+            (ArrowType::Date64(_), PhysicalType::INT64) => unsafe {
+                UInt64Converter::convert(transmute::<
+                    &mut RecordReader<T>,
+                    &mut RecordReader<Int64Type>,
+                >(&mut self.record_reader))
+            },
+            (ArrowType::Time32(_), PhysicalType::INT32) => unsafe {
+                UInt32Converter::convert(transmute::<
+                    &mut RecordReader<T>,
+                    &mut RecordReader<Int32Type>,
+                >(&mut self.record_reader))
+            },
+            (ArrowType::Time64(_), PhysicalType::INT64) => unsafe {
+                UInt64Converter::convert(transmute::<
+                    &mut RecordReader<T>,
+                    &mut RecordReader<Int64Type>,
+                >(&mut self.record_reader))
+            },
+            (ArrowType::Interval(IntervalUnit::YearMonth), PhysicalType::INT32) => unsafe {
+                UInt32Converter::convert(transmute::<
+                    &mut RecordReader<T>,
+                    &mut RecordReader<Int32Type>,
+                >(&mut self.record_reader))
+            },
+            (ArrowType::Interval(IntervalUnit::DayTime), PhysicalType::INT64) => unsafe {
+                UInt64Converter::convert(transmute::<
+                    &mut RecordReader<T>,
+                    &mut RecordReader<Int64Type>,
+                >(&mut self.record_reader))
+            },
+            (ArrowType::Duration(_), PhysicalType::INT64) => unsafe {
+                UInt64Converter::convert(transmute::<
+                    &mut RecordReader<T>,
+                    &mut RecordReader<Int64Type>,
                 >(&mut self.record_reader))
             },
             (arrow_type, physical_type) => Err(general_err!(

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -95,7 +95,7 @@ impl<T: DataType> PrimitiveArrayReader<T> {
         column_desc: ColumnDescPtr,
     ) -> Result<Self> {
         let data_type = parquet_to_arrow_field(column_desc.as_ref())?
-            .data_type() //TO DO: this is type ArrowType NOT DataType --> is this a deeper bug? HOW DOES THIS COMPILE?
+            .data_type()
             .clone();
 
         let mut record_reader = RecordReader::<T>::new(column_desc.clone());
@@ -1106,7 +1106,7 @@ mod tests {
             let message_type = format!(
                 "
             message test_schema {{
-              REQUIRED {:?} leaf {};
+              REQUIRED {:?} leaf ({});
           }}
             ",
                 $physical_type, $logical_type_str
@@ -1170,35 +1170,35 @@ mod tests {
         test_primitive_array_reader_one_type!(
             Int32Type,
             PhysicalType::INT32,
-            "(DATE)",
+            "DATE",
             ArrowUInt32,
             u32
         );
         test_primitive_array_reader_one_type!(
             Int32Type,
             PhysicalType::INT32,
-            "(TIME_MILLIS)",
+            "TIME_MILLIS",
             ArrowUInt32,
             u32
         );
         test_primitive_array_reader_one_type!(
             Int64Type,
             PhysicalType::INT64,
-            "(TIME_MICROS)",
+            "TIME_MICROS",
             ArrowUInt64,
             u64
         );
         test_primitive_array_reader_one_type!(
             Int64Type,
             PhysicalType::INT64,
-            "(TIMESTAMP_MILLIS)",
+            "TIMESTAMP_MILLIS",
             ArrowUInt64,
             u64
         );
         test_primitive_array_reader_one_type!(
             Int64Type,
             PhysicalType::INT64,
-            "(TIMESTAMP_MICROS)",
+            "TIMESTAMP_MICROS",
             ArrowUInt64,
             u64
         );
@@ -1293,7 +1293,6 @@ mod tests {
     }
 
     /// Array reader for test.
-    #[derive(Clone)]
     struct InMemoryArrayReader {
         data_type: ArrowType,
         array: ArrayRef,

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -960,7 +960,10 @@ mod tests {
     use crate::util::test_common::page_util::InMemoryPageIterator;
     use crate::util::test_common::{get_test_file, make_pages};
     use arrow::array::{Array, ArrayRef, PrimitiveArray, StructArray};
-    use arrow::datatypes::{DataType as ArrowType, Field, Int32Type as ArrowInt32, UInt32Type as ArrowUInt32, UInt64Type as ArrowUInt64};
+    use arrow::datatypes::{
+        DataType as ArrowType, Field, Int32Type as ArrowInt32, UInt32Type as ArrowUInt32,
+        UInt64Type as ArrowUInt64,
+    };
     use rand::distributions::range::SampleRange;
     use std::any::Any;
     use std::collections::VecDeque;
@@ -1100,11 +1103,14 @@ mod tests {
 
     macro_rules! test_primitive_array_reader_one_type {
         ($arrow_parquet_type:ty, $physical_type:expr, $logical_type_str:expr, $result_arrow_type:ty, $result_primitive_type:ty) => {{
-            let message_type = format!("
+            let message_type = format!(
+                "
             message test_schema {{
               REQUIRED {:?} leaf {};
           }}
-            ", $physical_type, $logical_type_str);
+            ",
+                $physical_type, $logical_type_str
+            );
             let schema = parse_message_type(&message_type)
                 .map(|t| Rc::new(SchemaDescriptor::new(Rc::new(t))))
                 .unwrap();
@@ -1148,7 +1154,10 @@ mod tests {
 
                 assert_eq!(
                     &PrimitiveArray::<$result_arrow_type>::from(
-                        data[0..50].iter().map(|x| *x as $result_primitive_type).collect::<Vec<$result_primitive_type>>()
+                        data[0..50]
+                            .iter()
+                            .map(|x| *x as $result_primitive_type)
+                            .collect::<Vec<$result_primitive_type>>()
                     ),
                     array
                 );
@@ -1158,11 +1167,41 @@ mod tests {
 
     #[test]
     fn test_primitive_array_reader_temporal_types() {
-        test_primitive_array_reader_one_type!(Int32Type, PhysicalType::INT32, "(DATE)", ArrowUInt32, u32);
-        test_primitive_array_reader_one_type!(Int32Type, PhysicalType::INT32, "(TIME_MILLIS)", ArrowUInt32, u32);
-        test_primitive_array_reader_one_type!(Int64Type, PhysicalType::INT64, "(TIME_MICROS)", ArrowUInt64, u64);
-        test_primitive_array_reader_one_type!(Int64Type, PhysicalType::INT64, "(TIMESTAMP_MILLIS)", ArrowUInt64, u64);
-        test_primitive_array_reader_one_type!(Int64Type, PhysicalType::INT64, "(TIMESTAMP_MICROS)", ArrowUInt64, u64);
+        test_primitive_array_reader_one_type!(
+            Int32Type,
+            PhysicalType::INT32,
+            "(DATE)",
+            ArrowUInt32,
+            u32
+        );
+        test_primitive_array_reader_one_type!(
+            Int32Type,
+            PhysicalType::INT32,
+            "(TIME_MILLIS)",
+            ArrowUInt32,
+            u32
+        );
+        test_primitive_array_reader_one_type!(
+            Int64Type,
+            PhysicalType::INT64,
+            "(TIME_MICROS)",
+            ArrowUInt64,
+            u64
+        );
+        test_primitive_array_reader_one_type!(
+            Int64Type,
+            PhysicalType::INT64,
+            "(TIMESTAMP_MILLIS)",
+            ArrowUInt64,
+            u64
+        );
+        test_primitive_array_reader_one_type!(
+            Int64Type,
+            PhysicalType::INT64,
+            "(TIMESTAMP_MICROS)",
+            ArrowUInt64,
+            u64
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add date/time/timestamp/interval/duration LogicalType support to array_reader