### PR TITLE
ARROW-7943: [C++][Parquet] Add code to generate rep/def levels for nested arrays

### DIFF
--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -50,17 +50,16 @@ class ARROW_EXPORT BufferBuilder {
         capacity_(0),
         size_(0) {}
 
-  /// \brief Constructs new Builder that will reset and start using
-  /// the provided buffer until Finish/Reset are call.
+  /// \brief Constructs new Builder that will start using
+  /// the provided buffer until Finish/Reset are called.
+  /// The buffer is not resized.
   explicit BufferBuilder(std::shared_ptr<ResizableBuffer> buffer,
                          MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
       : buffer_(std::move(buffer)),
         pool_(pool),
         data_(buffer_->mutable_data()),
         capacity_(buffer_->capacity()),
-        size_(0) {
-    buffer_->Resize(/*new_size=*/0, /*shrink_to_fit*/ false);
-  }
+        size_(buffer_->size()) {}
 
   /// \brief Resize the buffer to the nearest multiple of 64 bytes
   ///

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -185,6 +185,7 @@ add_custom_command(OUTPUT ${THRIFT_OUTPUT_FILES}
 # Library config
 
 set(PARQUET_SRCS
+    arrow/path_internal.cc 
     arrow/reader.cc
     arrow/reader_internal.cc
     arrow/schema.cc
@@ -367,6 +368,7 @@ add_parquet_test(arrow-test
                  SOURCES
                  arrow/arrow_reader_writer_test.cc
                  arrow/arrow_schema_test.cc
+		 arrow/path_internal_test.cc
                  test_util.cc)
 
 if(PARQUET_REQUIRE_ENCRYPTION)

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -368,7 +368,7 @@ add_parquet_test(arrow-test
                  SOURCES
                  arrow/arrow_reader_writer_test.cc
                  arrow/arrow_schema_test.cc
-		 arrow/path_internal_test.cc
+                 arrow/path_internal_test.cc
                  test_util.cc)
 
 if(PARQUET_REQUIRE_ENCRYPTION)

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -185,7 +185,7 @@ add_custom_command(OUTPUT ${THRIFT_OUTPUT_FILES}
 # Library config
 
 set(PARQUET_SRCS
-    arrow/path_internal.cc 
+    arrow/path_internal.cc
     arrow/reader.cc
     arrow/reader_internal.cc
     arrow/schema.cc

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -140,7 +140,7 @@ struct PathWriteContext {
   PathWriteContext(::arrow::MemoryPool* pool,
                    std::shared_ptr<::arrow::ResizableBuffer> def_levels_buffer)
       : rep_levels(pool), def_levels(std::move(def_levels_buffer), pool) {}
-  IterationResult ReserveDefLevels(int16_t elements) {
+  IterationResult ReserveDefLevels(int64_t elements) {
     last_status = def_levels.Reserve(elements);
     if (ARROW_PREDICT_TRUE(last_status.ok())) {
       return kDone;

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -84,18 +84,27 @@
 
 #include "parquet/arrow/path_internal.h"
 
+#include <atomic>
+#include <cstddef>
 #include <memory>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
+#include "arrow/array.h"
 #include "arrow/buffer.h"
 #include "arrow/buffer_builder.h"
+#include "arrow/extension_type.h"
 #include "arrow/memory_pool.h"
+#include "arrow/type.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/variant.h"
 #include "arrow/visitor_inline.h"
+
+#include "parquet/properties.h"
 
 namespace parquet {
 namespace arrow {

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -17,7 +17,7 @@
 
 // Overview.
 //
-// The strategy used for this code for repeition/defition
+// The strategy used for this code for repetition/definition
 // is to dissect the top level array into a list of paths
 // from the top level array to the final primitive (possibly
 // dictionary encoded array). It then evaluates each one of

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -492,6 +492,8 @@ Status WritePath(ElementRange start_range, PathInfo* path_info,
     return writer(builder_result);
   }
   stack[0] = start_range;
+  RETURN_NOT_OK(
+      arrow_context->def_levels_buffer->Resize(/*new_size=*/0, /*shrink_to_fit*/ false));
   PathWriteContext context(arrow_context->memory_pool, arrow_context->def_levels_buffer);
 
   auto stack_base = &stack[0];

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -217,7 +217,6 @@ class AllNullsTerminalNode {
   IterationResult Run(const ElementRange& range, PathWriteContext* context) {
     int64_t size = range.Size();
     RETURN_IF_ERROR(FillRepLevels(size, rep_level_, context));
-    // pass through an empty range to force not setting the rep-level values.
     return context->AppendDefLevels(size, def_level_);
   }
 
@@ -281,12 +280,6 @@ struct NullableTerminalNode {
 //    process.
 //       this varies depending on the type of list (int32_t* offsets, int64_t* offsets of
 //       fixed.
-//    |PositionType| - For non-empty lists a strategy to fill in rep_levels.  The strategy
-//       varies dependong if the node is the last list node for the column. This used for
-//       CRTP.
-//
-// TODO(micahk): This logic currently doesn't detect lists with a null value that has
-// non-zero size but depends on this relationship for correctness.
 template <typename RangeSelector>
 class ListPathNode {
  public:

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -421,12 +421,12 @@ class NullableNode {
       // cause discontinuties.
       valid_bits_reader_ = MakeReader(*range);
     }
-    int64_t start = range->start;
+    next_range->start = range->start;
     while (!range->Empty() && !valid_bits_reader_.IsSet()) {
       ++range->start;
       valid_bits_reader_.Next();
     }
-    int64_t null_count = range->start - start;
+    int64_t null_count = range->start - next_range->start;
     if (null_count > 0) {
       RETURN_IF_ERROR(FillRepLevels(null_count, rep_level_if_null_, context));
       RETURN_IF_ERROR(context->AppendDefLevels(null_count, def_level_if_null_));

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -235,7 +235,7 @@ class AllNullsTerminalNode {
 
 // Handles the case where all remaining arrays until the leaf have no nulls
 // (and are not interrupted by lists). Unlike AllNullsTerminalNode this is
-// always the last node in a path. We don't need an analgogue to the AllNullsTerminalNode
+// always the last node in a path. We don't need an analogue to the AllNullsTerminalNode
 // because if all values are present at an itermediate array no node is added for it
 // (the def-level for the next nullable node is incremented).
 struct AllPresentTerminalNode {

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -323,7 +323,7 @@ class ListPathNode {
     }
     // Loops post-condition:
     //   * range is either empty (we are done processing at this node)
-    //     or start corresponds a non-mepty list.
+    //     or start corresponds a non-empty list.
     //   * If range is non-empty child_range contains
     //     the bounds of non-empty list.
 

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -1,0 +1,763 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Overview.
+//
+// The strategy used for this code for repeition/defition
+// is to dissect the top level array into a list of paths
+// from the top level array to the final primitive (possibly
+// dictionary encoded array). It then evaluates each one of
+// those paths to produce results for the callback iteratively.
+//
+// This approach was taken to reduce the aggregate memory required
+// if we were to build all def/rep levels in parallel as apart of
+// a tree traversal.  It also allows for straighforward parellization
+// at the path level if that is desired in the future.
+//
+// The main downside to this approach is it duplicates effort for nodes
+// that share common ancestors. This can be mitigated to some degree
+// by adding in optimizations that detect leaf arrays that share
+// the same common list ancestor and reuse the repeteition levels
+// from the first leaf encountered (only definition levels greater
+// the list ancestor need to be re-evaluated. This is left for future
+// work.
+//
+// Algorithm.
+//
+// As mentioned above this code dissects arrays into constiutent parts:
+// nullability data, and list offset data. It tries to optimize for
+// some special cases, were is known ahead of time that a step
+// can be skipped (e.g. a nullable array happens to have all of its
+// values) or batch filled (a nullable array has all null values).
+// One futher optimization that is not implemented but could be done
+// in the future is special handling for nested list arrays that
+// have a intermediate data that indicates the final array contains all
+// nulls.
+//
+// In general, the algorithm attempts to batch work at each node as much
+// as possible.  For nullability nodes this means finding runs of null
+// values and batch filling those before finding runs fo non-null values
+// to process in batch at the next column.
+//
+// Similarly for lists runs, of empty lists are all processed in one batch
+// followed by either:
+//    - A single list entry to non-terminal lists (i.e. the upper part of a nested list)
+//    - Runs of non-mepty lists for the terminal list (i.e. the lowest nested list).
+//
+// This makes use of the following observations.
+// 1.  Null values at any node on the path are terminal (repetition and definition
+//     level can be set directly at that point).
+// 2.  Empty lists share the same property as Null values.
+// 3.  In order to keep repetition/defition level populated the algorithm is lazy
+//     in assigning repetition levels. The algorithm tracks whether it is currently
+//     in the middle of a list by comparing the lengths of repetition/definition levels.
+//     If it is currently in the middle of a list the the number of repetition levels
+//     populated will be greater then definition levels (list starts require adding
+//     the first element). If there are equal number of definition and repetition levels
+//     populated this indicates a list is waiting to be started and the next list
+//     encountered will have its repetition level signify the beginning of the list.
+//
+//     Other implementation notes.
+//
+//     This code hasn't been benchmarked (or assembly analyzed) but did the following
+//     as optimizations (yes premature optimization is the root of all evil).
+//     - This code does not use recursion, instead it constructs its own stack and manages
+//       updating elements accordingly.
+//     - It tries to avoid using Status for common return states.
+//     - Avoids virtual dispatch in favor of if/else statements on a set of well known
+//     classes.
+
+#include "parquet/arrow/path_internal.h"
+
+#include "arrow/buffer_builder.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/variant.h"
+#include "arrow/visitor_inline.h"
+
+namespace parquet {
+namespace arrow {
+
+namespace {
+
+using ::arrow::Array;
+using ::arrow::Status;
+using ::arrow::util::holds_alternative;
+
+constexpr static int16_t kLevelNotSet = -1;
+
+/// \brief Simple result of a iterating over a column to determine values.
+enum IterationResult {
+  /// Processing is done at this node. Move back up the path
+  /// to continue processing.
+  kDone = -1,
+  /// Move down towards the leaf for processing.
+  kNext = 1,
+  /// An error occurred while processing.
+  kError = 2
+
+};
+
+#define RETURN_IF_ERROR(iteration_result)                  \
+  do {                                                     \
+    if (ARROW_PREDICT_FALSE(iteration_result == kError)) { \
+      return iteration_result;                             \
+    }                                                      \
+  } while (false)
+
+struct PathWriteContext {
+  PathWriteContext(::arrow::MemoryPool* pool,
+                   std::shared_ptr<::arrow::ResizableBuffer> def_levels_buffer)
+      : rep_levels(pool), def_levels(std::move(def_levels_buffer), pool) {}
+  IterationResult ReserveDefLevels(int16_t elements) {
+    last_status = def_levels.Reserve(elements);
+    if (ARROW_PREDICT_TRUE(last_status.ok())) {
+      return kDone;
+    }
+    return kError;
+  }
+
+  IterationResult AppendDefLevel(int16_t def_level) {
+    last_status = def_levels.Append(def_level);
+    last_appended_def_level = def_level;
+    if (ARROW_PREDICT_TRUE(last_status.ok())) {
+      return kDone;
+    }
+    return kError;
+  }
+
+  IterationResult AppendDefLevels(int64_t count, int16_t def_level) {
+    if (count > 0) {
+      last_appended_def_level = def_level;
+    }
+    last_status = def_levels.Append(count, def_level);
+    if (ARROW_PREDICT_TRUE(last_status.ok())) {
+      return kDone;
+    }
+    return kError;
+  }
+
+  void UnsafeAppendDefLevel(int16_t def_level) {
+    last_appended_def_level = def_level;
+    def_levels.UnsafeAppend(def_level);
+  }
+
+  IterationResult AppendRepLevel(int16_t rep_level) {
+    last_status = rep_levels.Append(rep_level);
+
+    last_appended_rep_level = rep_level;
+    if (ARROW_PREDICT_TRUE(last_status.ok())) {
+      return kDone;
+    }
+    return kError;
+  }
+
+  IterationResult AppendRepLevels(int64_t count, int16_t rep_level) {
+    if (count > 0) {
+      last_appended_rep_level = rep_level;
+    }
+    last_status = rep_levels.Append(count, rep_level);
+    if (ARROW_PREDICT_TRUE(last_status.ok())) {
+      return kDone;
+    }
+    return kError;
+  }
+
+  bool EqualRepDefLevelsLengths() const {
+    return rep_levels.length() == def_levels.length();
+  }
+
+  void RecordPostListVisit(const ElementRange& range) {
+    if (!visited_elements.empty() && range.start == visited_elements.back().end) {
+      visited_elements.back().end = range.end;
+      return;
+    }
+    visited_elements.push_back(range);
+  }
+
+  Status last_status;
+  ::arrow::TypedBufferBuilder<int16_t> rep_levels;
+  ::arrow::TypedBufferBuilder<int16_t> def_levels;
+  int16_t last_appended_rep_level = 0;
+  int16_t last_appended_def_level = 0;
+  std::vector<ElementRange> visited_elements;
+};
+
+IterationResult FillRepLevels(int64_t count, int16_t rep_level,
+                              PathWriteContext* context) {
+  if (rep_level == kLevelNotSet) {
+    return kDone;
+  }
+  int64_t fill_count = count;
+  if (!context->EqualRepDefLevelsLengths()) {
+    fill_count--;
+  }
+  return context->AppendRepLevels(fill_count, rep_level);
+}
+
+class AllNullsTerminalNode {
+ public:
+  explicit AllNullsTerminalNode(int16_t def_level, int16_t rep_level = kLevelNotSet)
+      : def_level_(def_level), rep_level_(rep_level) {}
+  void SetRepLevelIfNull(int16_t rep_level) { rep_level_ = rep_level; }
+  IterationResult Run(const ElementRange& range, PathWriteContext* context) {
+    int64_t size = range.Size();
+    RETURN_IF_ERROR(FillRepLevels(size, rep_level_, context));
+    // pass through an empty range to force not setting the rep-level values.
+    return context->AppendDefLevels(size, def_level_);
+  }
+
+ private:
+  int16_t def_level_;
+  int16_t rep_level_;
+};
+
+struct AllPresentTerminalNode {
+  IterationResult Run(const ElementRange& range, PathWriteContext* context) {
+    return context->AppendDefLevels(range.end - range.start, def_level);
+    // No need to worry about rep levels, because this state should
+    // only be applicable for after all list/repeated values
+    // have been evaluated in the path.
+  }
+  int16_t def_level;
+};
+
+struct NullableTerminalNode {
+  NullableTerminalNode();
+  NullableTerminalNode(const uint8_t* bitmap, int64_t element_offset,
+                       int16_t def_level_if_present)
+      : bitmap_(bitmap),
+        element_offset_(element_offset),
+        def_level_if_present_(def_level_if_present),
+        def_level_if_null_(def_level_if_present - 1) {}
+
+  IterationResult Run(const ElementRange& range, PathWriteContext* context) {
+    int64_t elements = range.Size();
+    RETURN_IF_ERROR(context->ReserveDefLevels(elements));
+
+    DCHECK_GT(elements, 0);
+
+    auto bit_visitor = [&](bool is_set) {
+      context->UnsafeAppendDefLevel(is_set ? def_level_if_present_ : def_level_if_null_);
+    };
+
+    if (elements > 16) {  // 16 guarantees at least one unrolled loop.
+      ::arrow::internal::VisitBitsUnrolled(bitmap_, range.start + element_offset_,
+                                           elements, bit_visitor);
+    } else {
+      ::arrow::internal::VisitBits(bitmap_, range.start + element_offset_, elements,
+                                   bit_visitor);
+    }
+    return kDone;
+  }
+  const uint8_t* bitmap_;
+  int64_t element_offset_;
+  int16_t def_level_if_present_;
+  int16_t def_level_if_null_;
+};
+
+// List nodes handle populating rep_level for Arrow Lists and dep-level for empty lists.
+// Nullability (both list and children) is handled by other Nodes. This class should not
+// be used directly instead one of its CRTP extensions should be used below. By
+// construction all list nodes will be intermediate nodes (they will always be followed by
+// at least one other node).
+//
+// Type parameters:
+//    |RangeSelector| - A strategy for determine the the range of the child node to
+//    process.
+//       this varies depending on the type of list (int32_t* offsets, int64_t* offsets of
+//       fixed.
+//    |PositionType| - For non-empty lists a strategy to fill in rep_levels.  The strategy
+//       varies dependong if the node is the last list node for the column. This used for
+//       CRTP.
+//
+// TODO(micahk): This logic currently doesn't detect lists with a null value that has
+// non-zero size but depends on this relationship for correctness.
+template <typename RangeSelector>
+class ListPathNode {
+ public:
+  ListPathNode(RangeSelector selector, int16_t rep_lev, int16_t def_level_if_empty)
+      : selector_(std::move(selector)),
+        prev_rep_level_(rep_lev - 1),
+        rep_level_(rep_lev),
+        def_level_if_empty_(def_level_if_empty) {}
+
+  int16_t rep_level() const { return rep_level_; }
+
+  IterationResult Run(ElementRange* range, ElementRange* next_range,
+                      PathWriteContext* context) {
+    if (range->Empty()) {
+      return kDone;
+    }
+
+    // Find runs of empty lists.
+    int64_t start = range->start;
+    *next_range = selector_.GetRange(range->start);
+    while (next_range->Empty() && !range->Empty()) {
+      ++range->start;
+      *next_range = selector_.GetRange(range->start);
+    }
+
+    int64_t empty_elements = range->start - start;
+    if (empty_elements > 0) {
+      RETURN_IF_ERROR(FillRepLevels(empty_elements, prev_rep_level_, context));
+      RETURN_IF_ERROR(context->AppendDefLevels(empty_elements, def_level_if_empty_));
+    }
+    if (context->EqualRepDefLevelsLengths() && !range->Empty()) {
+      RETURN_IF_ERROR(context->AppendRepLevel(prev_rep_level_));
+    }
+
+    if (range->Empty()) {
+      return kDone;
+    }
+
+    ++range->start;
+    if (is_last_) {
+      return FillForLast(range, next_range, context);
+    }
+    return kNext;
+  }
+
+  void SetLast() { is_last_ = true; }
+
+ private:
+  IterationResult FillForLast(ElementRange* range, ElementRange* next_range,
+                              PathWriteContext* context) {
+    // First fill int the remainder of the list.
+    RETURN_IF_ERROR(FillRepLevels(next_range->Size(), rep_level_, context));
+    // Once we've reached this point the following preconditions should hold:
+    // 1.  There are no more repeated path nodes to deal with.
+    // 2.  All elements in |range| represent contiguous elements in the
+    //     child array (Null values would have shortened the range to ensure
+    //     all list elements are in present (but possibly empty)).
+    // 3.  All elements of range do not span parent lists (intermediate
+    //     list nodes only handle one list entry at a time).
+    //
+    // Given these preconditions it should be safe to fill runs on non-empty
+    // lists here and expand the range in the child node accordingly.
+
+    while (!range->Empty()) {
+      ElementRange size_check = selector_.GetRange(range->start);
+      if (size_check.Empty()) {
+        // The empty range will need to be handled after we pass down the accumulated
+        // range because it affects def_level placement and we need to get the children
+        // def_levels entered first.
+        break;
+      }
+      RETURN_IF_ERROR(context->AppendRepLevel(prev_rep_level_));
+      RETURN_IF_ERROR(context->AppendRepLevels(size_check.Size() - 1, rep_level_));
+      DCHECK_EQ(size_check.start, next_range->end);
+      next_range->end = size_check.end;
+      ++range->start;
+    }
+
+    context->RecordPostListVisit(*next_range);
+    return kNext;
+  }
+
+  RangeSelector selector_;
+  int16_t prev_rep_level_;
+  int16_t rep_level_;
+  int16_t def_level_if_empty_;
+  bool is_last_ = false;
+};
+
+template <typename OffsetType>
+struct VarRangeSelector {
+  ElementRange GetRange(int64_t index) const {
+    return ElementRange{offsets[index], offsets[index + 1]};
+  };
+
+  // Either int32_t* or int64_t*.
+  const OffsetType* offsets;
+};
+
+struct FixedSizedRangeSelector {
+  ElementRange GetRange(int64_t index) const {
+    int64_t start = index * list_size;
+    return ElementRange{start, start + list_size};
+  }
+  int list_size;
+};
+
+// An intermediate node that nhandles null values.
+class NullableNode {
+ public:
+  NullableNode(const uint8_t* null_bitmap, int64_t entry_offset,
+               int16_t def_level_if_null, int16_t rep_level_if_null = kLevelNotSet)
+      : null_bitmap_(null_bitmap),
+        entry_offset_(entry_offset),
+        valid_bits_reader_(MakeReader(ElementRange{0, 0})),
+        def_level_if_null_(def_level_if_null),
+        rep_level_if_null_(rep_level_if_null),
+        new_range_(true) {}
+
+  void SetRepLevelIfNull(int16_t rep_level) { rep_level_if_null_ = rep_level; }
+
+  ::arrow::internal::BitmapReader MakeReader(const ElementRange& range) {
+    return ::arrow::internal::BitmapReader(null_bitmap_, entry_offset_ + range.start,
+                                           range.Size());
+  }
+
+  IterationResult Run(ElementRange* range, ElementRange* next_range,
+                      PathWriteContext* context) {
+    if (new_range_) {
+      // Reset the reader each time we are starting fresh on a range.
+      // We can't rely on continuity because nulls above can
+      // cause discontinuties.
+      valid_bits_reader_ = MakeReader(*range);
+    }
+    int64_t start = range->start;
+    while (!range->Empty() && !valid_bits_reader_.IsSet()) {
+      ++range->start;
+      valid_bits_reader_.Next();
+    }
+    int64_t null_count = range->start - start;
+    if (null_count > 0) {
+      RETURN_IF_ERROR(FillRepLevels(null_count, rep_level_if_null_, context));
+      RETURN_IF_ERROR(context->AppendDefLevels(null_count, def_level_if_null_));
+    }
+    if (range->Empty()) {
+      new_range_ = true;
+      return kDone;
+    }
+    next_range->end = next_range->start = range->start;
+
+    while (next_range->end != range->end && valid_bits_reader_.IsSet()) {
+      ++next_range->end;
+      valid_bits_reader_.Next();
+    }
+    DCHECK(!next_range->Empty());
+    range->start += next_range->Size();
+    new_range_ = false;
+    return kNext;
+  };
+
+  const uint8_t* null_bitmap_;
+  int64_t entry_offset_;
+  ::arrow::internal::BitmapReader valid_bits_reader_;
+  int16_t def_level_if_null_;
+  int16_t rep_level_if_null_;
+
+  // Whether the next invocation will be a new range.
+  bool new_range_ = true;
+};
+
+using ListNode = ListPathNode<VarRangeSelector<int32_t>>;
+using LargeListNode = ListPathNode<VarRangeSelector<int64_t>>;
+using FixedSizeListNode = ListPathNode<FixedSizedRangeSelector>;
+
+// Contains static information derived from traversing the schema.
+struct PathInfo {
+  // The vectors are expected to the same length info.
+
+  // Note index order matters here.
+  using Node = ::arrow::util::variant<NullableTerminalNode, ListNode, LargeListNode,
+                                      FixedSizeListNode, NullableNode,
+                                      AllPresentTerminalNode, AllNullsTerminalNode>;
+  std::vector<Node> path;
+  std::shared_ptr<Array> primitive_array;
+  int16_t max_def_level = 0;
+  int16_t max_rep_level = 0;
+  bool has_dictionary;
+};
+
+/// \brief Contains logic for writing a single leaf node to parquet.
+/// This tracks the path from root to leaf.
+Status WritePath(ElementRange start_range, PathInfo* path_info,
+                 ArrowWriteContext* arrow_context,
+                 MultipathLevelBuilder::CallbackFunction writer) {
+  std::vector<ElementRange> stack(path_info->path.size());
+  MultipathLevelBuilderResult builder_result;
+  builder_result.leaf_array = path_info->primitive_array;
+
+  if (path_info->max_def_level == 0) {
+    int64_t leaf_length = builder_result.leaf_array->length();
+    builder_result.def_rep_level_count = leaf_length;
+    builder_result.post_list_visited_elements.push_back({0, leaf_length});
+    return writer(builder_result);
+  }
+  stack[0] = start_range;
+  PathWriteContext context(arrow_context->memory_pool, arrow_context->def_levels_buffer);
+
+  auto stack_base = &stack[0];
+  auto stack_position = stack_base;
+  IterationResult result;
+  while (stack_position >= stack_base) {
+    PathInfo::Node& node = path_info->path[stack_position - stack_base];
+    // Blocks ordered roughly in likely path usage.
+    if (holds_alternative<NullableNode>(node)) {
+      result = ::arrow::util::get<NullableNode>(node).Run(stack_position,
+                                                          stack_position + 1, &context);
+    } else if (holds_alternative<ListNode>(node)) {
+      result = ::arrow::util::get<ListNode>(node).Run(stack_position, stack_position + 1,
+                                                      &context);
+    } else if (holds_alternative<NullableTerminalNode>(node)) {
+      result =
+          ::arrow::util::get<NullableTerminalNode>(node).Run(*stack_position, &context);
+    } else if (holds_alternative<FixedSizeListNode>(node)) {
+      result = ::arrow::util::get<FixedSizeListNode>(node).Run(
+          stack_position, stack_position + 1, &context);
+    } else if (holds_alternative<AllPresentTerminalNode>(node)) {
+      result =
+          ::arrow::util::get<AllPresentTerminalNode>(node).Run(*stack_position, &context);
+    } else if (holds_alternative<AllNullsTerminalNode>(node)) {
+      result =
+          ::arrow::util::get<AllNullsTerminalNode>(node).Run(*stack_position, &context);
+    } else if (holds_alternative<LargeListNode>(node)) {
+      result = ::arrow::util::get<LargeListNode>(node).Run(stack_position,
+                                                           stack_position + 1, &context);
+    } else {
+      return Status::UnknownError("should never get here.", node.index());
+    }
+    if (ARROW_PREDICT_FALSE(result == kError)) {
+      DCHECK(!context.last_status.ok());
+      return context.last_status;
+    }
+    stack_position += static_cast<int>(result);
+  }
+  RETURN_NOT_OK(context.last_status);
+  builder_result.def_rep_level_count = context.def_levels.length();
+
+  if (context.rep_levels.length() > 0) {
+    builder_result.rep_levels = context.rep_levels.data();
+    std::swap(builder_result.post_list_visited_elements, context.visited_elements);
+    if (builder_result.post_list_visited_elements.empty()) {
+      builder_result.post_list_visited_elements.push_back({0, 0});
+    }
+  } else {
+    builder_result.post_list_visited_elements.push_back(
+        {0, builder_result.leaf_array->length()});
+    builder_result.rep_levels = nullptr;
+  }
+
+  builder_result.def_levels = context.def_levels.data();
+  return writer(builder_result);
+}
+
+struct FixupVisitor {
+  int max_rep_level = -1;
+  std::vector<PathInfo::Node> cleaned_up_nodes;
+  int16_t rep_level_if_null = kLevelNotSet;
+
+  template <typename T>
+  void HandleListNode(T& arg) {
+    if (arg.rep_level() == max_rep_level) {
+      arg.SetLast();
+      // after the last list node we don't need to fill
+      // rep levels on null.
+      rep_level_if_null = kLevelNotSet;
+    } else {
+      rep_level_if_null = arg.rep_level();
+    }
+  }
+  void operator()(ListNode& node) { HandleListNode(node); }
+  void operator()(LargeListNode& node) { HandleListNode(node); }
+  void operator()(FixedSizeListNode& node) { HandleListNode(node); }
+
+  // For non-list intermediate nodes.
+  template <typename T>
+  void HandleIntermediateNode(T& arg) {
+    if (rep_level_if_null != kLevelNotSet) {
+      arg.SetRepLevelIfNull(rep_level_if_null);
+    }
+  }
+
+  void operator()(NullableNode& arg) { HandleIntermediateNode(arg); }
+
+  void operator()(AllNullsTerminalNode& arg) {
+    // Even though no processing happens past this point we
+    // still need to adjust it if a list occurred after an
+    // all null array.
+    HandleIntermediateNode(arg);
+  }
+
+  void operator()(NullableTerminalNode& arg) {}
+  void operator()(AllPresentTerminalNode& arg) {}
+};
+
+PathInfo Fixup(PathInfo info) {
+  // We only need to fixup the path if there were repeated
+  // elements on it.
+  if (info.max_rep_level == 0) {
+    return info;
+  }
+  FixupVisitor visitor;
+  visitor.max_rep_level = info.max_rep_level;
+  if (visitor.max_rep_level > 0) {
+    visitor.rep_level_if_null = 0;
+  }
+  visitor.cleaned_up_nodes.reserve(info.path.size());
+  for (size_t x = 0; x < info.path.size(); x++) {
+    ::arrow::util::visit(visitor, info.path[x]);
+  }
+  return info;
+}
+
+class PathBuilder {
+ public:
+  explicit PathBuilder(bool start_nullable) : last_nullable_(start_nullable) {}
+  template <typename T>
+  void AddTerminalInfo(const T& array) {
+    if (last_nullable_) {
+      info_.max_def_level++;
+    }
+    if (array.null_count() == 0) {
+      info_.path.push_back(AllPresentTerminalNode{info_.max_def_level});
+    } else if (array.null_count() == array.length()) {
+      info_.path.push_back(AllNullsTerminalNode(info_.max_def_level - 1));
+    } else {
+      info_.path.push_back(NullableTerminalNode(array.null_bitmap_data(), array.offset(),
+                                                info_.max_def_level));
+    }
+    info_.primitive_array = std::make_shared<T>(array.data());
+    paths_.push_back(Fixup(info_));
+  }
+
+  template <typename T>
+  ::arrow::enable_if_t<std::is_base_of<::arrow::FlatArray, T>::value, Status> Visit(
+      const T& array) {
+    AddTerminalInfo(array);
+    return Status::OK();
+  }
+
+  template <typename T>
+  ::arrow::enable_if_t<std::is_same<::arrow::ListArray, T>::value ||
+                           std::is_same<::arrow::LargeListArray, T>::value,
+                       Status>
+  Visit(const T& array) {
+    MaybeAddNullable(array);
+    // Increment necessary due to empty lists.
+    info_.max_def_level++;
+    info_.max_rep_level++;
+    ListPathNode<VarRangeSelector<typename T::offset_type>> node(
+        VarRangeSelector<typename T::offset_type>{array.raw_value_offsets() +
+                                                  array.data()->offset},
+        info_.max_rep_level, info_.max_def_level - 1);
+    info_.path.push_back(node);
+    last_nullable_ = array.list_type()->value_field()->nullable();
+    return VisitInline(*array.values());
+  }
+
+  Status Visit(const ::arrow::DictionaryArray& array) {
+    // Only currently handle DictionaryArray where the dictionary is a
+    // primitive type
+    if (array.dict_type()->value_type()->num_children() > 0) {
+      return Status::NotImplemented(
+          "Writing DictionaryArray with nested dictionary "
+          "type not yet supported");
+    }
+    if (array.dictionary()->null_count() > 0) {
+      return Status::NotImplemented(
+          "Writing DictionaryArray with null encoded in dictionary "
+          "type not yet supported");
+    }
+    AddTerminalInfo(array);
+    return Status::OK();
+  }
+
+  void MaybeAddNullable(const Array& array) {
+    if (!last_nullable_) {
+      return;
+    }
+    info_.max_def_level++;
+    if (array.null_count() == 0) {
+      // Don't add anything because there won't be any point checking
+      // null values for the array.  There will always be at least
+      // one more array to handle nullability.
+      return;
+    }
+    if (array.null_count() == array.length()) {
+      info_.path.push_back(AllNullsTerminalNode(info_.max_def_level - 1));
+      return;
+    }
+    info_.path.push_back(NullableNode(array.null_bitmap_data(), array.offset(),
+                                      /* def_level_if_null = */ info_.max_def_level - 1));
+  }
+
+  Status VisitInline(const Array& array);
+
+  Status Visit(const ::arrow::MapArray& array) {
+    return Visit(static_cast<const ::arrow::ListArray&>(array));
+  }
+
+  Status Visit(const ::arrow::StructArray& array) {
+    MaybeAddNullable(array);
+    // TODO: wide structs might make this strategy too costly.
+    PathInfo info_backup = info_;
+    for (int x = 0; x < array.num_fields(); x++) {
+      last_nullable_ = array.type()->child(x)->nullable();
+      RETURN_NOT_OK(VisitInline(*array.field(x)));
+      info_ = info_backup;
+    }
+    return Status::OK();
+  }
+
+  Status Visit(const ::arrow::FixedSizeListArray& array) {
+    MaybeAddNullable(array);
+    // Assuming no fixed size 0 length arrays, so no dep level increase.
+    info_.max_rep_level++;
+    info_.path.push_back(
+        FixedSizeListNode(FixedSizedRangeSelector{array.list_type()->list_size()},
+                          info_.max_rep_level, info_.max_def_level));
+    last_nullable_ = array.list_type()->value_field()->nullable();
+    return VisitInline(*array.values());
+  }
+
+  Status Visit(const ::arrow::ExtensionArray& array) {
+    return VisitInline(*array.storage());
+  }
+
+#define NOT_IMPLEMENTED_VISIT(ArrowTypePrefix)                             \
+  Status Visit(const ::arrow::ArrowTypePrefix##Array& array) {             \
+    return Status::NotImplemented("Level generation for " #ArrowTypePrefix \
+                                  " not supported yet");                   \
+  }
+
+  // Union types aren't supported in Parquet.
+  NOT_IMPLEMENTED_VISIT(Union)
+
+#undef NOT_IMPLEMENTED_VISIT
+  std::vector<PathInfo>& paths() { return paths_; }
+
+ private:
+  PathInfo info_;
+  std::vector<PathInfo> paths_;
+  bool last_nullable_;
+};
+
+Status PathBuilder::VisitInline(const Array& array) {
+  return ::arrow::VisitArrayInline(array, this);
+}
+
+#undef RETURN_IF_ERROR
+}  // namespace
+
+Status MultipathLevelBuilder::Write(const Array& array, bool array_nullable,
+                                    ArrowWriteContext* context,
+                                    MultipathLevelBuilder::CallbackFunction callback) {
+  PathBuilder constructor(array_nullable);
+  RETURN_NOT_OK(VisitArrayInline(array, &constructor));
+  ElementRange start_range{0, array.length()};
+  for (auto& write_path_info : constructor.paths()) {
+    RETURN_NOT_OK(WritePath(start_range, &write_path_info, context, callback));
+  }
+  return Status::OK();
+}
+
+}  // namespace arrow
+}  // namespace parquet

--- a/cpp/src/parquet/arrow/path_internal.h
+++ b/cpp/src/parquet/arrow/path_internal.h
@@ -24,6 +24,8 @@
 
 #include "arrow/status.h"
 
+#include "parquet/platform.h"
+
 namespace arrow {
 
 class Array;
@@ -92,7 +94,7 @@ struct MultipathLevelBuilderResult {
 
 /// \brief Logic for being able to write out nesting (rep/def level) data that is
 /// needed for writing to parquet.
-class MultipathLevelBuilder {
+class PARQUET_EXPORT MultipathLevelBuilder {
  public:
   /// \brief A callback function that will receive results from the call to
   /// Write(...) below.  The MultipathLevelBuilderResult passed in will

--- a/cpp/src/parquet/arrow/path_internal.h
+++ b/cpp/src/parquet/arrow/path_internal.h
@@ -39,9 +39,9 @@ struct ElementRange {
   /// Upper bound of range (exclusive)
   int64_t end;
 
-  inline bool Empty() const { return start == end; }
+  bool Empty() const { return start == end; }
 
-  inline int64_t Size() const { return end - start; }
+  int64_t Size() const { return end - start; }
 };
 
 /// \brief Result for a single leaf array when running the builder on the
@@ -66,13 +66,16 @@ struct MultipathLevelBuilderResult {
   /// \brief Contains element ranges of the required visiting on the
   /// descendants of the final list ancestor for any leaf node.
   ///
-  /// The algorithm will atempt to consolidate visited ranges into
+  /// The algorithm will attempt to consolidate visited ranges into
   /// the smallest number possible.
   ///
   /// This data is necessary to pass along because after producing
   /// def-rep levels for each leaf array it is impossible to determine
-  /// which values have to be sent to capacitor when a null list value
+  /// which values have to be sent to parquet when a null list value
   /// in a nullable ListArray is non-empty.
+  ///
+  /// This allows for the parquet writing to determine which values ultimately
+  /// needs to be written.
   std::vector<ElementRange> post_list_visited_elements;
 };
 
@@ -80,7 +83,7 @@ struct MultipathLevelBuilderResult {
 /// needed for writing to parquet.
 class MultipathLevelBuilder {
  public:
-  /// \brief A callback function that willr receive results from the call to
+  /// \brief A callback function that will receive results from the call to
   /// Write(...) below.  The MultipathLevelBuilderResult passed in will
   /// only remain valid for the function call (i.e. storing it and relying
   /// for its data to be consistent afterwards willr result in undefined

--- a/cpp/src/parquet/arrow/path_internal.h
+++ b/cpp/src/parquet/arrow/path_internal.h
@@ -14,17 +14,26 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <vector>
 
-#include "arrow/array.h"
 #include "arrow/status.h"
-#include "parquet/properties.h"
+
+namespace arrow {
+
+class Array;
+
+}  // namespace arrow
 
 namespace parquet {
+
+struct ArrowWriteContext;
+
 namespace arrow {
 
 // This files contain internal implementation details and should not be considered

--- a/cpp/src/parquet/arrow/path_internal.h
+++ b/cpp/src/parquet/arrow/path_internal.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include <functional>
+#include <memory>
+#include <vector>
 
 #include "arrow/array.h"
 #include "arrow/status.h"
@@ -86,7 +88,7 @@ class MultipathLevelBuilder {
   /// \brief A callback function that will receive results from the call to
   /// Write(...) below.  The MultipathLevelBuilderResult passed in will
   /// only remain valid for the function call (i.e. storing it and relying
-  /// for its data to be consistent afterwards willr result in undefined
+  /// for its data to be consistent afterwards will result in undefined
   /// behavior.
   using CallbackFunction =
       std::function<::arrow::Status(const MultipathLevelBuilderResult&)>;

--- a/cpp/src/parquet/arrow/path_internal.h
+++ b/cpp/src/parquet/arrow/path_internal.h
@@ -1,0 +1,115 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#pragma once
+
+#include <functional>
+
+#include "arrow/array.h"
+#include "arrow/status.h"
+#include "parquet/properties.h"
+
+namespace parquet {
+namespace arrow {
+
+// This files contain internal implementation details and should not be considered
+// part of the public API.
+
+// The MultipathLevelBuilder is intended to fully support all Arrow nested types that
+// map to parquet types (i.e. Everything but Unions).
+//
+
+/// \brief Half open range of elements in an array.
+struct ElementRange {
+  /// Upper bound of range (inclusive)
+  int64_t start;
+  /// Upper bound of range (exclusive)
+  int64_t end;
+
+  inline bool Empty() const { return start == end; }
+
+  inline int64_t Size() const { return end - start; }
+};
+
+/// \brief Result for a single leaf array when running the builder on the
+/// its root.
+struct MultipathLevelBuilderResult {
+  /// \brief The Array containing only the values to write (after all nesting has
+  /// been processed.
+  ///
+  /// No additional processing is done on this array (it is copied as is when
+  /// visited via a DFS).
+  std::shared_ptr<::arrow::Array> leaf_array;
+
+  /// \brief Might be null.
+  const int16_t* def_levels = nullptr;
+
+  /// \brief  Might be null.
+  const int16_t* rep_levels = nullptr;
+
+  /// \brief Number of items (int16_t) contained in def/rep_levels when present.
+  int64_t def_rep_level_count = 0;
+
+  /// \brief Contains element ranges of the required visiting on the
+  /// descendants of the final list ancestor for any leaf node.
+  ///
+  /// The algorithm will atempt to consolidate visited ranges into
+  /// the smallest number possible.
+  ///
+  /// This data is necessary to pass along because after producing
+  /// def-rep levels for each leaf array it is impossible to determine
+  /// which values have to be sent to capacitor when a null list value
+  /// in a nullable ListArray is non-empty.
+  std::vector<ElementRange> post_list_visited_elements;
+};
+
+/// \brief Logic for being able to write out nesting (rep/def level) data that is
+/// needed for writing to parquet.
+class MultipathLevelBuilder {
+ public:
+  /// \brief A callback function that willr receive results from the call to
+  /// Write(...) below.  The MultipathLevelBuilderResult passed in will
+  /// only remain valid for the function call (i.e. storing it and relying
+  /// for its data to be consistent afterwards willr result in undefined
+  /// behavior.
+  using CallbackFunction =
+      std::function<::arrow::Status(const MultipathLevelBuilderResult&)>;
+
+  /// \brief Determine rep/def level information for the array.
+  ///
+  /// The callback will be invoked for each leaf Array that is a
+  /// descendant of array.  Each leaf array is processed in a depth
+  /// first traversal-order.
+  ///
+  /// \param[in] array The array to process.
+  /// \param[in] array_nullable Whether the algorithm should consider
+  ///   the elements in the top level array nullable.
+  /// \param[in, out] context for use when allocating memory, etc.
+  /// \param[out] write_leaf_callback Callback to receive results.
+  /// There will be one call to the write_leaf_callback for
+  static ::arrow::Status Write(const ::arrow::Array& array, bool array_nullable,
+                               ArrowWriteContext* context,
+                               CallbackFunction write_leaf_callback);
+
+ private:
+  MultipathLevelBuilder();
+  // Not copyable.
+  MultipathLevelBuilder(const MultipathLevelBuilder&) = delete;
+  MultipathLevelBuilder& operator=(const MultipathLevelBuilder&) = delete;
+};
+
+}  // namespace arrow
+}  // namespace parquet

--- a/cpp/src/parquet/arrow/path_internal_test.cc
+++ b/cpp/src/parquet/arrow/path_internal_test.cc
@@ -21,18 +21,11 @@
 #include <utility>
 #include <vector>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
 
-#include "arrow/memory_pool.h"
-#include "arrow/record_batch.h"
 #include "arrow/testing/gtest_util.h"
-#include "arrow/testing/random.h"
-#include "arrow/testing/util.h"
-#include "arrow/type_traits.h"
-#include "arrow/util/decimal.h"
-#include "arrow/util/logging.h"
-#include "arrow/util/range.h"
+#include "arrow/type.h"
 
 #include "parquet/properties.h"
 

--- a/cpp/src/parquet/arrow/path_internal_test.cc
+++ b/cpp/src/parquet/arrow/path_internal_test.cc
@@ -411,9 +411,8 @@ TEST_F(MultipathLevelBuilderTest, TestPrimitiveNonNullable) {
 
   ASSERT_OK(
       MultipathLevelBuilder::Write(*array, /*nullable=*/false, &context_, callback_));
+ 
   ASSERT_THAT(results_, SizeIs(1));
-  // keys -  Keys are always non-null so only null maps and null empty maps
-  // count towards rep levels.
   EXPECT_TRUE(results_[0].null_rep_levels_);
   EXPECT_TRUE(results_[0].null_def_levels_);
 

--- a/cpp/src/parquet/arrow/path_internal_test.cc
+++ b/cpp/src/parquet/arrow/path_internal_test.cc
@@ -1,0 +1,427 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/arrow/path_internal.h"
+
+#include <memory>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "arrow/api.h"
+#include "arrow/memory_pool.h"
+#include "arrow/record_batch.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/testing/util.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/decimal.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/range.h"
+
+#include "parquet/properties.h"
+
+namespace parquet {
+namespace arrow {
+namespace {
+
+using ::arrow::default_memory_pool;
+using ::arrow::field;
+using ::arrow::fixed_size_list;
+using ::arrow::Status;
+using ::testing::ElementsAre;
+using ::testing::ElementsAreArray;
+using ::testing::Eq;
+using ::testing::NotNull;
+using ::testing::SizeIs;
+
+struct CapturedResult {
+  std::vector<int16_t> def_levels_;
+  std::vector<int16_t> rep_levels_;
+  bool null_rep_levels_ = false;
+  bool null_def_levels_ = false;
+
+  std::vector<ElementRange> post_list_elements;
+
+  CapturedResult(const int16_t* def_levels, const int16_t* rep_levels,
+                 int64_t def_rep_level_count,
+                 std::vector<ElementRange> post_list_visited_elements) {
+    if (def_levels != nullptr) {
+      def_levels_ = std::vector<int16_t>(def_levels, def_levels + def_rep_level_count);
+    } else {
+      null_def_levels_ = true;
+    }
+    if (rep_levels != nullptr) {
+      rep_levels_ = std::vector<int16_t>(rep_levels, rep_levels + def_rep_level_count);
+    } else {
+      null_rep_levels_ = true;
+    }
+    post_list_elements = std::move(post_list_visited_elements);
+  }
+
+  explicit CapturedResult(MultipathLevelBuilderResult result)
+      : CapturedResult(result.def_levels, result.rep_levels, result.def_rep_level_count,
+                       std::move(result.post_list_visited_elements)) {}
+
+  void CheckLevelsWithNullRepLevels(const std::vector<int16_t>& expected_def) {
+    EXPECT_TRUE(null_rep_levels_);
+    ASSERT_FALSE(null_def_levels_);
+    EXPECT_THAT(def_levels_, ElementsAreArray(expected_def));
+  }
+
+  void CheckLevels(const std::vector<int16_t>& expected_def,
+                   const std::vector<int16_t>& expected_rep) const {
+    ASSERT_FALSE(null_def_levels_);
+    ASSERT_FALSE(null_rep_levels_);
+    EXPECT_THAT(def_levels_, ElementsAreArray(expected_def));
+    EXPECT_THAT(rep_levels_, ElementsAreArray(expected_rep));
+  }
+};
+
+struct Callback {
+  Status operator()(const MultipathLevelBuilderResult& result) {
+    results->emplace_back(result);
+    return Status::OK();
+  }
+  std::vector<CapturedResult>* results;
+};
+
+class MultipathLevelBuilderTest : public testing::Test {
+ protected:
+  std::vector<CapturedResult> results_;
+  Callback callback_{&results_};
+  std::shared_ptr<ArrowWriterProperties> arrow_properties_ =
+      default_arrow_writer_properties();
+  ArrowWriteContext context_ =
+      ArrowWriteContext(default_memory_pool(), arrow_properties_.get());
+};
+
+TEST_F(MultipathLevelBuilderTest, NonNullableSingleListNonNullableEntries) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/false);
+  auto list_type = large_list(entries);
+  auto array = ::arrow::ArrayFromJSON(list_type, R"([[1], [2, 3], [4, 5, 6]])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/false, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>(/*count=*/6, 1),
+                     /*rep_levels=*/{0, 0, 1, 0, 1, 1});
+
+  ASSERT_THAT(result.post_list_elements, SizeIs(1));
+  EXPECT_THAT(result.post_list_elements[0].start, Eq(0));
+  EXPECT_THAT(result.post_list_elements[0].end, Eq(6));
+}
+
+TEST_F(MultipathLevelBuilderTest, NullableSingleListWithAllNullsLists) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/false);
+  auto list_type = list(entries);
+  auto array = ::arrow::ArrayFromJSON(list_type, R"([null, null, null, null])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>(/*count=*/4, 0),
+                     /*rep_levels=*/std::vector<int16_t>(4, 0));
+}
+
+TEST_F(MultipathLevelBuilderTest, NullableSingleListWithAllNullEntries) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_type = list(entries);
+  auto array = ::arrow::ArrayFromJSON(list_type, R"([[null], [null], [null], [null]])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>(/*count=*/4, 2),
+                     /*rep_levels=*/std::vector<int16_t>(4, 0));
+  ASSERT_THAT(result.post_list_elements, SizeIs(1));
+  EXPECT_THAT(result.post_list_elements[0].start, Eq(0));
+  EXPECT_THAT(result.post_list_elements[0].end, Eq(4));
+}
+
+TEST_F(MultipathLevelBuilderTest, NullableSingleListWithAllPresentEntries) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_type = list(entries);
+  auto array = ::arrow::ArrayFromJSON(list_type, R"([[], [], [1], [], [2, 3]])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>{1, 1, 3, 1, 3, 3},
+                     /*rep_levels=*/std::vector<int16_t>{0, 0, 0, 0, 0, 1});
+
+  ASSERT_THAT(result.post_list_elements, SizeIs(1));
+  // JSON construction appears to only create child array lazily
+  EXPECT_THAT(result.post_list_elements[0].start, Eq(0));
+  EXPECT_THAT(result.post_list_elements[0].end, Eq(3));
+}
+
+TEST_F(MultipathLevelBuilderTest, NullableSingleListWithAllEmptyEntries) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_type = list(entries);
+  auto array = ::arrow::ArrayFromJSON(list_type, R"([[], [], [], [], []])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>(/*count=*/5, 1),
+                     /*rep_levels=*/std::vector<int16_t>(/*count=*/5, 0));
+}
+
+TEST_F(MultipathLevelBuilderTest, NullableSingleListWithSomeNullEntriesAndSomeNullLists) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_type = list(entries);
+  auto array = ::arrow::ArrayFromJSON(
+      list_type, R"([null, [1 , 2, 3], [], [], null,  null, [4, 5], [null]])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+
+  result.CheckLevels(
+      /*def_levels=*/std::vector<int16_t>{0, 3, 3, 3, 1, 1, 0, 0, 3, 3, 2},
+      /*rep_levels=*/std::vector<int16_t>{0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0});
+}
+
+TEST_F(MultipathLevelBuilderTest, NestedListsWithSomeEntries) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_field = field("list", list(entries), /*nullable=*/true);
+  auto nested_list_type = list(list_field);
+
+  auto array = ::arrow::ArrayFromJSON(
+      nested_list_type, R"([null, [[1 , 2, 3], [4, 5]], [[], [], []], []])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>{0, 5, 5, 5, 5, 5, 3, 3, 3, 1},
+                     /*rep_levels=*/std::vector<int16_t>{0, 0, 2, 2, 1, 2, 0, 1, 1, 0});
+}
+
+TEST_F(MultipathLevelBuilderTest, NestedListsWithSomeNulls) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_field = field("list", list(entries), /*nullable=*/true);
+  auto nested_list_type = list(list_field);
+
+  auto array = ::arrow::ArrayFromJSON(nested_list_type,
+                                      R"([null, [[1, null, 3], null, null], [[4, 5]]])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>{0, 5, 4, 5, 2, 2, 5, 5},
+                     /*rep_levels=*/std::vector<int16_t>{0, 0, 2, 2, 1, 1, 0, 2});
+}
+
+TEST_F(MultipathLevelBuilderTest, NestedListsWithSomeNullsSomeEmptys) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_field = field("list", list(entries), /*nullable=*/true);
+  auto nested_list_type = list(list_field);
+
+  auto array = ::arrow::ArrayFromJSON(nested_list_type,
+                                      R"([null, [[1 , null, 3], [], []], [[4, 5]]])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>{0, 5, 4, 5, 3, 3, 5, 5},
+                     /*rep_levels=*/std::vector<int16_t>{0, 0, 2, 2, 1, 1, 0, 2});
+}
+
+TEST_F(MultipathLevelBuilderTest, TripleNestedListsAllPresent) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_field = field("list", list(entries), /*nullable=*/true);
+  auto nested_list_type = list(list_field);
+  auto double_nested_list_type = list(nested_list_type);
+
+  auto array = ::arrow::ArrayFromJSON(double_nested_list_type,
+                                      R"([ [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9]]] ])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>(9, 7),
+                     /*rep_levels=*/std::vector<int16_t>{
+                         0, 3, 3, 2, 3, 3, 1, 3, 3  // first row
+                     });
+}
+
+TEST_F(MultipathLevelBuilderTest, QuadNestedListsAllPresent) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_field = field("list", list(entries), /*nullable=*/true);
+  auto nested_list_type = list(list_field);
+  auto double_nested_list_type = list(nested_list_type);
+  auto triple_nested_list_type = list(double_nested_list_type);
+
+  auto array = ::arrow::ArrayFromJSON(triple_nested_list_type,
+                                      R"([ [[[[1, 2], [3, 4]], [[5]]], [[[6, 7, 8]]]], 
+					   [[[[1, 2], [3, 4]], [[5]]], [[[6, 7, 8]]]] ])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>(16, 9),
+                     /*rep_levels=*/std::vector<int16_t>{
+                         0, 4, 3, 4, 2, 1, 4, 4,  //
+                         0, 4, 3, 4, 2, 1, 4, 4   //
+                     });
+}
+
+TEST_F(MultipathLevelBuilderTest, TripleNestedListsWithSomeNullsSomeEmptys) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_field = field("list", list(entries), /*nullable=*/true);
+  auto nested_list_type = list(list_field);
+  auto double_nested_list_type = list(nested_list_type);
+
+  auto array = ::arrow::ArrayFromJSON(double_nested_list_type,
+                                      R"([
+                                           [null, [[1 , null, 3], []], []], 
+                                           [[[]], [[], [1, 2]], null, [[3]]],
+					   null, 
+ 					   []
+                                         ])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  const CapturedResult& result = results_[0];
+  result.CheckLevels(/*def_levels=*/std::vector<int16_t>{2, 7, 6, 7, 5, 3,  // first row
+                                                         5, 5, 7, 7, 2, 7,  // second row
+                                                         0,                 // third row
+                                                         1},
+                     /*rep_levels=*/std::vector<int16_t>{0, 1, 3, 3, 2, 1,  // first row
+                                                         0, 1, 2, 3, 1, 1,  // second row
+                                                         0, 0});
+}
+
+TEST_F(MultipathLevelBuilderTest, TestStruct) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);
+  auto list_field = field("list", list(entries), /*nullable=*/true);
+  auto struct_type = ::arrow::struct_({list_field, entries});
+
+  auto array = ::arrow::ArrayFromJSON(struct_type,
+                                      R"([{"Entries" : 1, "list": [2, 3]}, 
+                                          {"Entries" : 4, "list": [5, 6]},
+                                          null])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+  ASSERT_THAT(results_, SizeIs(2));
+  results_[0].CheckLevels(/*def_levels=*/std::vector<int16_t>{4, 4, 4, 4, 0},
+                          /*rep_levels=*/std::vector<int16_t>{0, 1, 0, 1, 0});
+  results_[1].CheckLevelsWithNullRepLevels(
+      /*def_levels=*/std::vector<int16_t>({2, 2, 0}));
+}
+
+TEST_F(MultipathLevelBuilderTest, TestFixedSizeList) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/false);
+  auto list_type = fixed_size_list(entries, 2);
+  auto array = ::arrow::ArrayFromJSON(list_type, R"([null, [2, 3], [4, 5], null])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+  results_[0].CheckLevels(/*def_levels=*/std::vector<int16_t>{0, 1, 1, 1, 1, 0},
+                          /*rep_levels=*/std::vector<int16_t>{0, 0, 1, 0, 1, 0});
+
+  ASSERT_THAT(results_[0].post_list_elements, SizeIs(1));
+  EXPECT_THAT(results_[0].post_list_elements[0].start, Eq(2));
+  EXPECT_THAT(results_[0].post_list_elements[0].end, Eq(6));
+}
+
+TEST_F(MultipathLevelBuilderTest, TestFixedSizeListMissingMiddleHasTwoVisitedRanges) {
+  auto entries = field("Entries", ::arrow::int64(), /*nullable=*/false);
+  auto list_type = fixed_size_list(entries, 2);
+  auto array = ::arrow::ArrayFromJSON(list_type, R"([[0, 1], null, [2, 3]])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+
+  ASSERT_THAT(results_, SizeIs(1));
+
+  ASSERT_THAT(results_[0].post_list_elements, SizeIs(2));
+  EXPECT_THAT(results_[0].post_list_elements[0].start, Eq(0));
+  EXPECT_THAT(results_[0].post_list_elements[0].end, Eq(2));
+
+  EXPECT_THAT(results_[0].post_list_elements[1].start, Eq(4));
+  EXPECT_THAT(results_[0].post_list_elements[1].end, Eq(6));
+}
+
+TEST_F(MultipathLevelBuilderTest, TestMap) {
+  auto map_type = ::arrow::map(::arrow::int64(), ::arrow::utf8());
+
+  auto array = ::arrow::ArrayFromJSON(map_type,
+                                      R"([[[1, "a"], [2, "b"]], 
+                                          [[3, "c"], [4, null]]])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/true, &context_, callback_));
+  ASSERT_THAT(results_, SizeIs(2));
+  // keys -  Keys are always non-null so only null maps and null empty maps
+  // count towards rep levels.
+  results_[0].CheckLevels(/*def_levels=*/std::vector<int16_t>{2, 2, 2, 2},
+                          /*rep_levels=*/std::vector<int16_t>{0, 1, 0, 1});
+  // entries
+  results_[1].CheckLevels(/*def_levels=*/std::vector<int16_t>{3, 3, 3, 2},
+                          /*rep_levels=*/std::vector<int16_t>{0, 1, 0, 1});
+}
+
+TEST_F(MultipathLevelBuilderTest, TestPrimitiveNonNullable) {
+  auto array = ::arrow::ArrayFromJSON(::arrow::int64(), R"([1, 2, 3, 4])");
+
+  ASSERT_OK(
+      MultipathLevelBuilder::Write(*array, /*nullable=*/false, &context_, callback_));
+  ASSERT_THAT(results_, SizeIs(1));
+  // keys -  Keys are always non-null so only null maps and null empty maps
+  // count towards rep levels.
+  EXPECT_TRUE(results_[0].null_rep_levels_);
+  EXPECT_TRUE(results_[0].null_def_levels_);
+
+  ASSERT_THAT(results_[0].post_list_elements, SizeIs(1));
+  EXPECT_THAT(results_[0].post_list_elements[0].start, Eq(0));
+  EXPECT_THAT(results_[0].post_list_elements[0].end, Eq(4));
+}
+
+}  // namespace
+}  // namespace arrow
+}  // namespace parquet


### PR DESCRIPTION
There will be follow-up code to integrate this with the
higher level writers.

This takes a slightly more OO approach then LevelBuilder in
writer.cc and also attempts to do more batching at each level
when possible. No benchmarks have been run yet.

There are likely a lot of typos given the hours that I've been
working on it (but hopefully no logic bugs).  I'm sorry.

Also allow TypedBufferBuilder/BufferBuilder to take an
initial ResizableBuffer to use so scratch can easily
be reused.