### PR TITLE
ARROW-7749: [C++] Link more tests together

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -305,6 +305,8 @@ if(ARROW_CSV)
               csv/options.cc
               csv/parser.cc
               csv/reader.cc)
+
+  list(APPEND ARROW_TESTING_SRCS csv/test_common.cc)
 endif()
 
 if(ARROW_COMPUTE)
@@ -515,8 +517,13 @@ if(ARROW_IPC)
   add_arrow_test(extension_type_test)
 endif()
 
-add_arrow_test(memory_pool_test)
-add_arrow_test(pretty_print_test)
+add_arrow_test(misc_test
+               SOURCES
+               memory_pool_test.cc
+               result_test.cc
+               pretty_print_test.cc
+               status_test.cc)
+
 add_arrow_test(public_api_test)
 
 set_source_files_properties(public_api_test.cc
@@ -526,12 +533,11 @@ set_source_files_properties(public_api_test.cc
                             SKIP_UNITY_BUILD_INCLUSION
                             ON)
 
-add_arrow_test(result_test)
 add_arrow_test(scalar_test)
-add_arrow_test(status_test)
 add_arrow_test(type_test)
-add_arrow_test(table_test)
-add_arrow_test(table_builder_test)
+
+add_arrow_test(table_test SOURCES table_test.cc table_builder_test.cc)
+
 add_arrow_test(tensor_test)
 add_arrow_test(sparse_tensor_test)
 

--- a/cpp/src/arrow/csv/CMakeLists.txt
+++ b/cpp/src/arrow/csv/CMakeLists.txt
@@ -15,10 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
-add_arrow_test(chunker_test PREFIX "arrow-csv")
-add_arrow_test(column_builder_test PREFIX "arrow-csv")
-add_arrow_test(converter_test PREFIX "arrow-csv")
-add_arrow_test(parser_test PREFIX "arrow-csv")
+add_arrow_test(csv-test
+               SOURCES
+               chunker_test.cc
+               column_builder_test.cc
+               converter_test.cc
+               parser_test.cc)
 
 add_arrow_benchmark(converter_benchmark PREFIX "arrow-csv")
 add_arrow_benchmark(parser_benchmark PREFIX "arrow-csv")

--- a/cpp/src/arrow/csv/column_builder_test.cc
+++ b/cpp/src/arrow/csv/column_builder_test.cc
@@ -26,6 +26,7 @@
 #include "arrow/csv/test_common.h"
 #include "arrow/memory_pool.h"
 #include "arrow/table.h"
+#include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"

--- a/cpp/src/arrow/csv/test_common.cc
+++ b/cpp/src/arrow/csv/test_common.cc
@@ -1,0 +1,65 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/csv/test_common.h"
+#include "arrow/testing/gtest_util.h"
+
+namespace arrow {
+namespace csv {
+
+std::string MakeCSVData(std::vector<std::string> lines) {
+  std::string s;
+  for (const auto& line : lines) {
+    s += line;
+  }
+  return s;
+}
+
+void MakeCSVParser(std::vector<std::string> lines, ParseOptions options, int32_t num_cols,
+                   std::shared_ptr<BlockParser>* out) {
+  auto csv = MakeCSVData(lines);
+  auto parser = std::make_shared<BlockParser>(options, num_cols);
+  uint32_t out_size;
+  ASSERT_OK(parser->Parse(util::string_view(csv), &out_size));
+  ASSERT_EQ(out_size, csv.size()) << "trailing CSV data not parsed";
+  *out = parser;
+}
+
+void MakeCSVParser(std::vector<std::string> lines, ParseOptions options,
+                   std::shared_ptr<BlockParser>* out) {
+  return MakeCSVParser(lines, options, -1, out);
+}
+
+void MakeCSVParser(std::vector<std::string> lines, std::shared_ptr<BlockParser>* out) {
+  MakeCSVParser(lines, ParseOptions::Defaults(), out);
+}
+
+void MakeColumnParser(std::vector<std::string> items, std::shared_ptr<BlockParser>* out) {
+  auto options = ParseOptions::Defaults();
+  // Need this to test for null (empty) values
+  options.ignore_empty_lines = false;
+  std::vector<std::string> lines;
+  for (const auto& item : items) {
+    lines.push_back(item + '\n');
+  }
+  MakeCSVParser(lines, options, 1, out);
+  ASSERT_EQ((*out)->num_cols(), 1) << "Should have seen only 1 CSV column";
+  ASSERT_EQ((*out)->num_rows(), items.size());
+}
+
+}  // namespace csv
+}  // namespace arrow

--- a/cpp/src/arrow/csv/test_common.h
+++ b/cpp/src/arrow/csv/test_common.h
@@ -15,62 +15,36 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#ifndef ARROW_CSV_TEST_COMMON_H
-#define ARROW_CSV_TEST_COMMON_H
+#pragma once
 
 #include <memory>
 #include <string>
 #include <vector>
 
 #include "arrow/csv/parser.h"
-#include "arrow/testing/gtest_util.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow {
 namespace csv {
 
-std::string MakeCSVData(std::vector<std::string> lines) {
-  std::string s;
-  for (const auto& line : lines) {
-    s += line;
-  }
-  return s;
-}
+ARROW_EXPORT
+std::string MakeCSVData(std::vector<std::string> lines);
 
 // Make a BlockParser from a vector of lines representing a CSV file
+ARROW_EXPORT
 void MakeCSVParser(std::vector<std::string> lines, ParseOptions options, int32_t num_cols,
-                   std::shared_ptr<BlockParser>* out) {
-  auto csv = MakeCSVData(lines);
-  auto parser = std::make_shared<BlockParser>(options, num_cols);
-  uint32_t out_size;
-  ASSERT_OK(parser->Parse(util::string_view(csv), &out_size));
-  ASSERT_EQ(out_size, csv.size()) << "trailing CSV data not parsed";
-  *out = parser;
-}
+                   std::shared_ptr<BlockParser>* out);
 
+ARROW_EXPORT
 void MakeCSVParser(std::vector<std::string> lines, ParseOptions options,
-                   std::shared_ptr<BlockParser>* out) {
-  return MakeCSVParser(lines, options, -1, out);
-}
+                   std::shared_ptr<BlockParser>* out);
 
-void MakeCSVParser(std::vector<std::string> lines, std::shared_ptr<BlockParser>* out) {
-  MakeCSVParser(lines, ParseOptions::Defaults(), out);
-}
+ARROW_EXPORT
+void MakeCSVParser(std::vector<std::string> lines, std::shared_ptr<BlockParser>* out);
 
 // Make a BlockParser from a vector of strings representing a single CSV column
-void MakeColumnParser(std::vector<std::string> items, std::shared_ptr<BlockParser>* out) {
-  auto options = ParseOptions::Defaults();
-  // Need this to test for null (empty) values
-  options.ignore_empty_lines = false;
-  std::vector<std::string> lines;
-  for (const auto& item : items) {
-    lines.push_back(item + '\n');
-  }
-  MakeCSVParser(lines, options, 1, out);
-  ASSERT_EQ((*out)->num_cols(), 1) << "Should have seen only 1 CSV column";
-  ASSERT_EQ((*out)->num_rows(), items.size());
-}
+ARROW_EXPORT
+void MakeColumnParser(std::vector<std::string> items, std::shared_ptr<BlockParser>* out);
 
 }  // namespace csv
 }  // namespace arrow
-
-#endif  // ARROW_CSV_TEST_COMMON_H

--- a/cpp/src/arrow/filesystem/CMakeLists.txt
+++ b/cpp/src/arrow/filesystem/CMakeLists.txt
@@ -21,9 +21,11 @@ arrow_install_all_headers("arrow/filesystem")
 # pkg-config support
 arrow_add_pkg_config("arrow-filesystem")
 
-add_arrow_test(filesystem_test)
-add_arrow_test(localfs_test)
-add_arrow_test(path_forest_test)
+add_arrow_test(filesystem-test
+               SOURCES
+               filesystem_test.cc
+               localfs_test.cc
+               path_forest_test.cc)
 
 if(ARROW_S3)
   add_arrow_test(s3fs_test)

--- a/cpp/src/arrow/memory_pool_test.cc
+++ b/cpp/src/arrow/memory_pool_test.cc
@@ -107,26 +107,27 @@ TEST(DefaultMemoryPoolDeathTest, MaxMemory) {
 #endif  // ARROW_VALGRIND
 
 TEST(LoggingMemoryPool, Logging) {
-  MemoryPool* pool = default_memory_pool();
+  auto pool = MemoryPool::CreateDefault();
 
-  LoggingMemoryPool lp(pool);
+  LoggingMemoryPool lp(pool.get());
 
   uint8_t* data;
-  ASSERT_OK(pool->Allocate(100, &data));
+  ASSERT_OK(lp.Allocate(100, &data));
 
   uint8_t* data2;
-  ASSERT_OK(pool->Allocate(100, &data2));
+  ASSERT_OK(lp.Allocate(100, &data2));
 
-  pool->Free(data, 100);
-  pool->Free(data2, 100);
+  lp.Free(data, 100);
+  lp.Free(data2, 100);
 
+  ASSERT_EQ(200, lp.max_memory());
   ASSERT_EQ(200, pool->max_memory());
 }
 
 TEST(ProxyMemoryPool, Logging) {
-  MemoryPool* pool = default_memory_pool();
+  auto pool = MemoryPool::CreateDefault();
 
-  ProxyMemoryPool pp(pool);
+  ProxyMemoryPool pp(pool.get());
 
   uint8_t* data;
   ASSERT_OK(pool->Allocate(100, &data));

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -25,6 +25,7 @@
 #endif
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -34,6 +35,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "arrow/array.h"
@@ -369,6 +371,11 @@ void TestInitialized(const Array& array) {
       throw_away = total;
     }
   }
+}
+
+void SleepFor(double seconds) {
+  std::this_thread::sleep_for(
+      std::chrono::nanoseconds(static_cast<int64_t>(seconds * 1e9)));
 }
 
 ///////////////////////////////////////////////////////////////////////////

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -405,6 +405,9 @@ void AssertSortedEquals(std::vector<T> u, std::vector<T> v) {
   ASSERT_EQ(u, v);
 }
 
+ARROW_EXPORT
+void SleepFor(double seconds);
+
 // A RAII-style object that switches to a new locale, and switches back
 // to the old locale when going out of scope.  Doesn't do anything if the
 // new locale doesn't exist on the local machine.

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -29,29 +29,28 @@ arrow_install_all_headers("arrow/util")
 add_arrow_test(utility-test
                SOURCES
                align_util_test.cc
+               bit_util_test.cc
                checked_cast_test.cc
+               compression_test.cc
+               decimal_test.cc
                formatting_util_test.cc
                key_value_metadata_test.cc
                hashing_test.cc
                int_util_test.cc
                io_util_test.cc
                iterator_test.cc
+               logging_test.cc
                parsing_util_test.cc
                range_test.cc
+               rle_encoding_test.cc
                stl_util_test.cc
                string_test.cc
                time_test.cc
                trie_test.cc
+               uri_test.cc
                utf8_util_test.cc)
 
-add_arrow_test(bit_util_test)
-add_arrow_test(compression_test)
-add_arrow_test(decimal_test)
-add_arrow_test(logging_test)
-add_arrow_test(rle_encoding_test)
-add_arrow_test(task_group_test)
-add_arrow_test(thread_pool_test)
-add_arrow_test(uri_test)
+add_arrow_test(threading-utility-test SOURCES task_group_test thread_pool_test)
 
 add_arrow_benchmark(bit_util_benchmark)
 add_arrow_benchmark(compression_benchmark)

--- a/cpp/src/arrow/util/logging_test.cc
+++ b/cpp/src/arrow/util/logging_test.cc
@@ -68,45 +68,6 @@ TEST(PrintLogTest, LogTestWithInit) {
   ArrowLog::ShutDownArrowLog();
 }
 
-#ifdef ARROW_WITH_TIMING_TESTS
-
-// This test will output large amount of logs to stderr, should be disabled in travis.
-TEST(LogPerfTest, PerfTest) {
-  ArrowLog::StartArrowLog("/fake/path/to/appdire/LogPerfTest", ArrowLogLevel::ARROW_ERROR,
-                          "/tmp/");
-  int rounds = 10000;
-
-  int64_t start_time = current_time_ms();
-  for (int i = 0; i < rounds; ++i) {
-    ARROW_LOG(DEBUG) << "This is the "
-                     << "ARROW_DEBUG message";
-  }
-  int64_t elapsed = current_time_ms() - start_time;
-  std::cout << "Testing DEBUG log for " << rounds << " rounds takes " << elapsed << " ms."
-            << std::endl;
-
-  start_time = current_time_ms();
-  for (int i = 0; i < rounds; ++i) {
-    ARROW_LOG(ERROR) << "This is the "
-                     << "RARROW_ERROR message";
-  }
-  elapsed = current_time_ms() - start_time;
-  std::cout << "Testing ARROW_ERROR log for " << rounds << " rounds takes " << elapsed
-            << " ms." << std::endl;
-
-  start_time = current_time_ms();
-  for (int i = 0; i < rounds; ++i) {
-    ARROW_CHECK(i >= 0) << "This is a ARROW_CHECK "
-                        << "message but it won't show up";
-  }
-  elapsed = current_time_ms() - start_time;
-  std::cout << "Testing ARROW_CHECK(true) for " << rounds << " rounds takes " << elapsed
-            << " ms." << std::endl;
-  ArrowLog::ShutDownArrowLog();
-}
-
-#endif
-
 }  // namespace util
 
 TEST(DcheckMacros, DoNotEvaluateReleaseMode) {

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -43,15 +43,10 @@
 namespace arrow {
 namespace internal {
 
-static void sleep_for(double seconds) {
-  std::this_thread::sleep_for(
-      std::chrono::nanoseconds(static_cast<int64_t>(seconds * 1e9)));
-}
-
 static void busy_wait(double seconds, std::function<bool()> predicate) {
   const double period = 0.001;
   for (int i = 0; !predicate() && i * period < seconds; ++i) {
-    sleep_for(period);
+    SleepFor(period);
   }
 }
 
@@ -62,7 +57,7 @@ static void task_add(T x, T y, T* out) {
 
 template <typename T>
 static void task_slow_add(double seconds, T x, T y, T* out) {
-  sleep_for(seconds);
+  SleepFor(seconds);
   *out = x + y;
 }
 
@@ -75,7 +70,7 @@ static T add(T x, T y) {
 
 template <typename T>
 static T slow_add(double seconds, T x, T y) {
-  sleep_for(seconds);
+  SleepFor(seconds);
   return x + y;
 }
 
@@ -253,7 +248,7 @@ TEST_F(TestThreadPool, SetCapacity) {
 
   // Downsize while tasks are pending
   for (int i = 0; i < 10; ++i) {
-    ASSERT_OK(pool->Spawn(std::bind(sleep_for, 0.01 /* seconds */)));
+    ASSERT_OK(pool->Spawn(std::bind(SleepFor, 0.01 /* seconds */)));
   }
   ASSERT_OK(pool->SetCapacity(2));
   ASSERT_EQ(pool->GetCapacity(), 2);
@@ -290,7 +285,7 @@ TEST_F(TestThreadPool, Submit) {
   }
   {
     // `void` return type
-    ASSERT_OK_AND_ASSIGN(auto fut, pool->Submit(sleep_for, 0.001));
+    ASSERT_OK_AND_ASSIGN(auto fut, pool->Submit(SleepFor, 0.001));
     fut.get();
   }
 }


### PR DESCRIPTION
This should make unity builds slightly faster, by allowing CMake to coalesce
more source files and save on header file parsing.