### PR TITLE
ARROW-7949: [Git] Ignore macOS specific file: 'Brewfile.lock.json'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ python/doc/
 pkgs
 docker_cache
 .gdb_history
-.DS_Store
 *.orig
 .*.swp
 .*.swo
@@ -74,3 +73,7 @@ site/
 **/*.Rcheck/
 **/.Rhistory
 .Rproj.user
+
+# macOS
+cpp/Brewfile.lock.json
+.DS_Store


### PR DESCRIPTION
In the developer guides for Python, there is a suggestion for users on
macOS to use Homebrew to install all dependencies required for building
Arrow C++. This creates a 'cpp/Brewfile.lock.json' file is specific to
the system it sits on.

It would be desirable for this not to be tracked by version control. To
prevent this accidental addition, perhaps it should be ignored in the
gitignore file for the repository

Fixes [#ARROW-7949](https://issues.apache.org/jira/browse/ARROW-7949)

REF:
https://arrow.apache.org/docs/developers/python.html#building-on-linux-and-macos

	modified:   .gitignore