### PR TITLE
ARROW-1571: [C++][Compute] Optimize sorting integers in small value range

### DIFF
--- a/cpp/src/arrow/compute/kernels/sort_to_indices.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices.cc
@@ -18,6 +18,7 @@
 #include "arrow/compute/kernels/sort_to_indices.h"
 
 #include <algorithm>
+#include <limits>
 #include <numeric>
 #include <vector>
 
@@ -104,9 +105,7 @@ class CountSorter {
  public:
   CountSorter() = default;
 
-  explicit CountSorter(c_type min, c_type max) {
-    SetMinMax(min, max);
-  }
+  explicit CountSorter(c_type min, c_type max) { SetMinMax(min, max); }
 
   // Assume: max >= min && (max - min) < 4Gi
   void SetMinMax(c_type min, c_type max) {
@@ -124,8 +123,8 @@ class CountSorter {
   }
 
  private:
-  c_type min_ { 0 };
-  uint32_t value_range_ { 0 };
+  c_type min_{0};
+  uint32_t value_range_{0};
 
   template <typename CounterType>
   void SortInternal(int64_t* indices_begin, int64_t* indices_end,

--- a/cpp/src/arrow/compute/kernels/sort_to_indices_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices_benchmark.cc
@@ -75,5 +75,6 @@ BENCHMARK(SortToIndicesInt64Compare)
     ->Args({1 << 23, 1})
     ->MinTime(1.0)
     ->Unit(benchmark::TimeUnit::kNanosecond);
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/sort_to_indices_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices_benchmark.cc
@@ -38,7 +38,7 @@ static void SortToIndicesBenchmark(benchmark::State& state,
   }
 }
 
-static void SortToIndicesInt64(benchmark::State& state) {
+static void SortToIndicesInt64Count(benchmark::State& state) {
   RegressionArgs args(state);
 
   const int64_t array_size = args.size / sizeof(int64_t);
@@ -49,31 +49,30 @@ static void SortToIndicesInt64(benchmark::State& state) {
   SortToIndicesBenchmark(state, values);
 }
 
-static void SortToIndicesInt8(benchmark::State& state) {
+static void SortToIndicesInt64Compare(benchmark::State& state) {
   RegressionArgs args(state);
 
-  const int64_t array_size = args.size / sizeof(int8_t);
+  const int64_t array_size = args.size / sizeof(int64_t);
   auto rand = random::RandomArrayGenerator(kSeed);
 
-  auto values = rand.Int8(array_size, -100, 100, args.null_proportion);
+  auto min = std::numeric_limits<int64_t>::min();
+  auto max = std::numeric_limits<int64_t>::max();
+  auto values = rand.Int64(array_size, min, max, args.null_proportion);
 
   SortToIndicesBenchmark(state, values);
 }
 
-BENCHMARK(SortToIndicesInt64)
+BENCHMARK(SortToIndicesInt64Count)
     ->Apply(RegressionSetArgs)
     ->Args({1 << 20, 1})
     ->Args({1 << 23, 1})
     ->MinTime(1.0)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 
-BENCHMARK(SortToIndicesInt8)
+BENCHMARK(SortToIndicesInt64Compare)
     ->Apply(RegressionSetArgs)
     ->Args({1 << 20, 1})
     ->Args({1 << 23, 1})
-    ->Args({1 << 23, 50})
-    ->Args({1 << 23, 80})
-    ->Args({1 << 23, 99})
     ->MinTime(1.0)
     ->Unit(benchmark::TimeUnit::kNanosecond);
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/sort_to_indices_test.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices_test.cc
@@ -211,7 +211,7 @@ class RandomRange : public RandomImpl {
     CType min = std::numeric_limits<CType>::min();
     CType max = min + range;
     if (sizeof(CType) < 4 && (range + min) > std::numeric_limits<CType>::max()) {
-        max = std::numeric_limits<CType>::max();
+      max = std::numeric_limits<CType>::max();
     }
     return generator.Numeric<ArrowType>(count, min, max, null_prob);
   }

--- a/cpp/src/arrow/compute/kernels/sort_to_indices_test.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices_test.cc
@@ -121,9 +121,19 @@ TYPED_TEST(TestSortToIndicesKernelForInt8, SortInt8) {
 template <typename ArrowType>
 class TestSortToIndicesKernelRandom : public ComputeFixture, public TestBase {};
 
+template <typename ArrowType>
+class TestSortToIndicesKernelRandomCount : public ComputeFixture, public TestBase {};
+
+template <typename ArrowType>
+class TestSortToIndicesKernelRandomCompare : public ComputeFixture, public TestBase {};
+
 using SortToIndicesableTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
                      Int32Type, Int64Type, FloatType, DoubleType, StringType>;
+
+using SortToIndicesIntegerTypes =
+    ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
+                     Int32Type, Int64Type>;
 
 template <typename ArrayType>
 class Comparator {
@@ -190,6 +200,23 @@ class Random<StringType> : public RandomImpl {
   }
 };
 
+template <typename ArrowType>
+class RandomRange : public RandomImpl {
+  using CType = typename TypeTraits<ArrowType>::CType;
+
+ public:
+  explicit RandomRange(random::SeedType seed) : RandomImpl(seed) {}
+
+  std::shared_ptr<Array> Generate(uint64_t count, int range, double null_prob) {
+    CType min = std::numeric_limits<CType>::min();
+    CType max = min + range;
+    if (sizeof(CType) < 4 && (range + min) > std::numeric_limits<CType>::max()) {
+        max = std::numeric_limits<CType>::max();
+    }
+    return generator.Numeric<ArrowType>(count, min, max, null_prob);
+  }
+};
+
 TYPED_TEST_CASE(TestSortToIndicesKernelRandom, SortToIndicesableTypes);
 
 TYPED_TEST(TestSortToIndicesKernelRandom, SortRandomValues) {
@@ -198,6 +225,49 @@ TYPED_TEST(TestSortToIndicesKernelRandom, SortRandomValues) {
   Random<TypeParam> rand(0x5487655);
   int times = 5;
   int length = 1000;
+  for (int test = 0; test < times; test++) {
+    for (auto null_probability : {0.0, 0.1, 0.5, 1.0}) {
+      auto array = rand.Generate(length, null_probability);
+      std::shared_ptr<Array> offsets;
+      ASSERT_OK(arrow::compute::SortToIndices(&this->ctx_, *array, &offsets));
+      ValidateSorted<ArrayType>(*std::static_pointer_cast<ArrayType>(array),
+                                *std::static_pointer_cast<UInt64Array>(offsets));
+    }
+  }
+}
+
+// Long array with small value range: counting sort
+// - length >= 1024(CountCompareSorter::countsort_min_len_)
+// - range  <= 4096(CountCompareSorter::countsort_max_range_)
+TYPED_TEST_CASE(TestSortToIndicesKernelRandomCount, SortToIndicesIntegerTypes);
+
+TYPED_TEST(TestSortToIndicesKernelRandomCount, SortRandomValuesCount) {
+  using ArrayType = typename TypeTraits<TypeParam>::ArrayType;
+
+  RandomRange<TypeParam> rand(0x5487656);
+  int times = 5;
+  int length = 4000;
+  int range = 2000;
+  for (int test = 0; test < times; test++) {
+    for (auto null_probability : {0.0, 0.1, 0.5, 1.0}) {
+      auto array = rand.Generate(length, range, null_probability);
+      std::shared_ptr<Array> offsets;
+      ASSERT_OK(arrow::compute::SortToIndices(&this->ctx_, *array, &offsets));
+      ValidateSorted<ArrayType>(*std::static_pointer_cast<ArrayType>(array),
+                                *std::static_pointer_cast<UInt64Array>(offsets));
+    }
+  }
+}
+
+// Long array with big value range: std::stable_sort
+TYPED_TEST_CASE(TestSortToIndicesKernelRandomCompare, SortToIndicesIntegerTypes);
+
+TYPED_TEST(TestSortToIndicesKernelRandomCompare, SortRandomValuesCompare) {
+  using ArrayType = typename TypeTraits<TypeParam>::ArrayType;
+
+  Random<TypeParam> rand(0x5487657);
+  int times = 5;
+  int length = 4000;
   for (int test = 0; test < times; test++) {
     for (auto null_probability : {0.0, 0.1, 0.5, 1.0}) {
       auto array = rand.Generate(length, null_probability);

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -455,6 +455,11 @@ inline Status GenericToStatus(const Result<T>& res) {
   return res.status();
 }
 
+template <typename T>
+inline Status GenericToStatus(Result<T>&& res) {
+  return std::move(res).status();
+}
+
 }  // namespace internal
 
 }  // namespace arrow

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -436,6 +436,7 @@ namespace internal {
 // Extract Status from Status or Result<T>
 // Useful for the status check macros such as RETURN_NOT_OK.
 inline Status GenericToStatus(const Status& st) { return st; }
+inline Status GenericToStatus(Status&& st) { return std::move(st); }
 
 }  // namespace internal
 


### PR DESCRIPTION
For integer array with limited value range, counting sort can be much
more efficient than comparison based algorithms. Detailed analysis in
Jira link https://issues.apache.org/jira/browse/ARROW-1571

Tested on x86 and Arm64 platforms, Arrow sorting kernel benchnmark
(values within -100 ~ +100) shows 6x to 15x performance boost.

NOTE: This approach scans for min/max values before choose appropriate
sorting algorithm. It's a waste of time if we finally find the value
range is too large to use counting sort. This time is trivial comparing
with sorting. But I see performance drop when there are many null values
in the array. Possibly due to unpredictable null value checking impacts
finding min/max values. In case of 50% null values, up to 6% performance
drop is observed in sorting big int64 arrays. Will follow up this issue.