### PR TITLE
ARROW-7959: [Ruby] Add support for Ruby 2.3 again

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           docker login -u ${{ secrets.DOCKERHUB_USER }} \
                        -p ${{ secrets.DOCKERHUB_TOKEN }}
-          docker-compose push ubuntu-cpp
+          docker-compose push ubuntu-cpp-sanitizer
 
   macos:
     name: AMD64 MacOS 10.15 C++

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,7 +41,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ubuntu: [18.04]
+        ubuntu:
+          - 16.04
+          - 18.04
     env:
       UBUNTU: ${{ matrix.ubuntu }}
     steps:
@@ -71,6 +73,7 @@ jobs:
         run: |
           docker login -u ${{ secrets.DOCKERHUB_USER }} \
                        -p ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-compose push ubuntu-c-glib
           docker-compose push ubuntu-ruby
 
   macos:

--- a/c_glib/test/test-numeric-array.rb
+++ b/c_glib/test/test-numeric-array.rb
@@ -20,7 +20,7 @@ class TestNumericArray < Test::Unit::TestCase
 
   def test_mean
     array = build_double_array([1.1, 2.2, nil])
-    assert_in_delta(array.values.sum / 2,
+    assert_in_delta(array.values.inject(&:+) / 2,
                     array.mean)
   end
 end

--- a/ruby/red-arrow/lib/arrow/generic-filterable.rb
+++ b/ruby/red-arrow/lib/arrow/generic-filterable.rb
@@ -19,8 +19,8 @@ module Arrow
   module GenericFilterable
     class << self
       def included(base)
-        base.alias_method :filter_raw, :filter
-        base.alias_method :filter, :filter_generic
+        base.__send__(:alias_method, :filter_raw, :filter)
+        base.__send__(:alias_method, :filter, :filter_generic)
       end
     end
 

--- a/ruby/red-arrow/lib/arrow/generic-takeable.rb
+++ b/ruby/red-arrow/lib/arrow/generic-takeable.rb
@@ -19,8 +19,8 @@ module Arrow
   module GenericTakeable
     class << self
       def included(base)
-        base.alias_method :take_raw, :take
-        base.alias_method :take, :take_generic
+        base.__send__(:alias_method, :take_raw, :take)
+        base.__send__(:alias_method, :take, :take_generic)
       end
     end
 

--- a/ruby/red-arrow/lib/arrow/null-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/null-array-builder.rb
@@ -19,7 +19,7 @@ module Arrow
   class NullArrayBuilder
     class << self
       def buildable?(args)
-        super and args.collect(&:class) != [Integer]
+        super and not (args.size == 1 and args[0].is_a?(Integer))
       end
     end
   end


### PR DESCRIPTION
Ruby 2.3 reached EOL but Ubuntu 16.04 LTS ships Ruby 2.3. So
supporting Ruby 2.3 again is valuable.

Note that Red Arrow 0.15.1 works with Ruby 2.3.