### PR TITLE
ARROW-7936: [Python] Fix and exercise tests on python 3.5

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     env:
-      UBUNTU: 18.04
+      UBUNTU: [16.04, 18.04]
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v1

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -34,7 +34,7 @@ on:
 jobs:
 
   ubuntu:
-    name: AMD64 Ubuntu 18.04 Python 3
+    name: AMD64 Ubuntu ${{ matrix.ubuntu }} Python 3
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     strategy:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -37,8 +37,12 @@ jobs:
     name: AMD64 Ubuntu 18.04 Python 3
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu: [16.04, 18.04]
     env:
-      UBUNTU: [16.04, 18.04]
+      UBUNTU: ${{ matrix.ubuntu }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v1

--- a/ci/docker/ubuntu-16.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-16.04-cpp.dockerfile
@@ -44,7 +44,6 @@ RUN apt-get update -y -q && \
         libgoogle-glog-dev \
         liblz4-dev \
         libre2-dev \
-        libsnappy-dev \
         libssl-dev \
         llvm-7-dev \
         make \
@@ -65,8 +64,8 @@ RUN apt-get update -y -q && \
 #   unit tests, so doing vendored build by default
 ENV ARROW_BUILD_BENCHMARKS=OFF \
     ARROW_BUILD_TESTS=ON \
-    ARROW_DEPENDENCY_SOURCE=SYSTEM \
     ARROW_DATASET=ON \
+    ARROW_DEPENDENCY_SOURCE=SYSTEM \
     ARROW_GANDIVA_JAVA=OFF \
     ARROW_GANDIVA=ON \
     ARROW_HOME=/usr/local \
@@ -85,9 +84,10 @@ ENV ARROW_BUILD_BENCHMARKS=OFF \
     gRPC_SOURCE=BUNDLED \
     GTest_SOURCE=BUNDLED \
     ORC_SOURCE=BUNDLED \
-    PARQUET_BUILD_EXECUTABLES=ON \
     PARQUET_BUILD_EXAMPLES=ON \
+    PARQUET_BUILD_EXECUTABLES=ON \
     PATH=/usr/lib/ccache/:$PATH \
     Protobuf_SOURCE=BUNDLED \
     RapidJSON_SOURCE=BUNDLED \
+    Snappy_SOURCE=BUNDLED \
     Thrift_SOURCE=BUNDLED

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -120,6 +120,7 @@ cmake -G "${CMAKE_GENERATOR:-Ninja}" \
       -DProtobuf_SOURCE=${Protobuf_SOURCE:-AUTO} \
       -DRapidJSON_SOURCE=${RapidJSON_SOURCE:-AUTO} \
       -DRE2_SOURCE=${RE2_SOURCE:-AUTO} \
+      -DSnappy_SOURCE=${Snappy_SOURCE:-AUTO} \
       -DThrift_SOURCE=${Thrift_SOURCE:-AUTO} \
       -DZSTD_SOURCE=${ZSTD_SOURCE:-AUTO} \
       ${CMAKE_ARGS} \

--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -58,7 +58,6 @@ function build_wheel {
     pushd cpp
     mkdir build
     pushd build
-
     cmake -DARROW_BUILD_SHARED=ON \
           -DARROW_BUILD_TESTS=OFF \
           -DARROW_DATASET=ON \

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -105,7 +105,7 @@ from pyarrow.lib import (null, bool_,
 
 # Buffers, allocation
 from pyarrow.lib import (Buffer, ResizableBuffer, foreign_buffer, py_buffer,
-                         compress, decompress, allocate_buffer)
+                         Codec, compress, decompress, allocate_buffer)
 
 from pyarrow.lib import (MemoryPool, LoggingMemoryPool, ProxyMemoryPool,
                          total_allocated_bytes, set_memory_pool,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1694,18 +1694,21 @@ cdef extern from 'arrow/python/benchmark.h' namespace 'arrow::py::benchmark':
 
 
 cdef extern from 'arrow/util/compression.h' namespace 'arrow' nogil:
-    enum CompressionType" arrow::Compression::type":
-        CompressionType_UNCOMPRESSED" arrow::Compression::UNCOMPRESSED"
-        CompressionType_SNAPPY" arrow::Compression::SNAPPY"
-        CompressionType_GZIP" arrow::Compression::GZIP"
-        CompressionType_BROTLI" arrow::Compression::BROTLI"
-        CompressionType_ZSTD" arrow::Compression::ZSTD"
-        CompressionType_LZ4" arrow::Compression::LZ4"
-        CompressionType_BZ2" arrow::Compression::BZ2"
+    enum CCompressionType" arrow::Compression::type":
+        CCompressionType_UNCOMPRESSED" arrow::Compression::UNCOMPRESSED"
+        CCompressionType_SNAPPY" arrow::Compression::SNAPPY"
+        CCompressionType_GZIP" arrow::Compression::GZIP"
+        CCompressionType_BROTLI" arrow::Compression::BROTLI"
+        CCompressionType_ZSTD" arrow::Compression::ZSTD"
+        CCompressionType_LZ4" arrow::Compression::LZ4"
+        CCompressionType_BZ2" arrow::Compression::BZ2"
 
     cdef cppclass CCodec" arrow::util::Codec":
         @staticmethod
-        CResult[unique_ptr[CCodec]] Create(CompressionType codec)
+        CResult[unique_ptr[CCodec]] Create(CCompressionType codec)
+
+        @staticmethod
+        c_bool IsAvailable(CCompressionType codec)
 
         CResult[int64_t] Decompress(int64_t input_len, const uint8_t* input,
                                     int64_t output_len,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1713,11 +1713,10 @@ cdef extern from 'arrow/util/compression.h' namespace 'arrow' nogil:
         CResult[int64_t] Decompress(int64_t input_len, const uint8_t* input,
                                     int64_t output_len,
                                     uint8_t* output_buffer)
-
         CResult[int64_t] Compress(int64_t input_len, const uint8_t* input,
                                   int64_t output_buffer_len,
                                   uint8_t* output_buffer)
-
+        const char* name() const
         int64_t MaxCompressedLen(int64_t input_len, const uint8_t* input)
 
 

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -1192,21 +1192,16 @@ cdef class CompressedInputStream(NativeFile):
     compression : str
         The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd")
     """
-    def __init__(self, NativeFile stream, compression):
+    def __init__(self, NativeFile stream, str compression not None):
         cdef:
-            CompressionType compression_type
-            unique_ptr[CCodec] codec
+            Codec codec = Codec(compression)
             shared_ptr[CCompressedInputStream] compressed_stream
-
-        compression_type = _get_compression_type(compression)
-        if compression_type == CompressionType_UNCOMPRESSED:
-            raise ValueError('Invalid value for compression: {!r}'
-                             .format(compression))
-
-        codec = move(GetResultValue(CCodec.Create(compression_type)))
-        compressed_stream = GetResultValue(CCompressedInputStream.Make(
-            codec.get(), stream.get_input_stream()))
-
+        compressed_stream = GetResultValue(
+            CCompressedInputStream.Make(
+                codec.unwrap(),
+                stream.get_input_stream()
+            )
+        )
         self.set_input_stream(<shared_ptr[CInputStream]> compressed_stream)
         self.is_readable = True
 
@@ -1222,21 +1217,16 @@ cdef class CompressedOutputStream(NativeFile):
         The compression type ("bz2", "brotli", "gzip", "lz4" or "zstd")
     """
 
-    def __init__(self, NativeFile stream, compression):
+    def __init__(self, NativeFile stream, str compression not None):
         cdef:
-            CompressionType compression_type
-            unique_ptr[CCodec] codec
+            Codec codec = Codec(compression)
             shared_ptr[CCompressedOutputStream] compressed_stream
-
-        compression_type = _get_compression_type(compression)
-        if compression_type == CompressionType_UNCOMPRESSED:
-            raise ValueError('Invalid value for compression: {!r}'
-                             .format(compression))
-
-        codec = move(GetResultValue(CCodec.Create(compression_type)))
-        compressed_stream = GetResultValue(CCompressedOutputStream.Make(
-            codec.get(), stream.get_output_stream()))
-
+        compressed_stream = GetResultValue(
+            CCompressedOutputStream.Make(
+                codec.unwrap(),
+                stream.get_output_stream()
+            )
+        )
         self.set_output_stream(<shared_ptr[COutputStream]> compressed_stream)
         self.is_writable = True
 
@@ -1418,25 +1408,22 @@ cdef get_input_stream(object source, c_bool use_memory_map,
     """
     cdef:
         NativeFile nf
-        unique_ptr[CCodec] codec
+        Codec codec
         shared_ptr[CInputStream] input_stream
-        CompressionType compression_type
 
     try:
-        source_path = _stringify_path(source)
+        codec = Codec.detect(source)
     except TypeError:
-        compression = None
-    else:
-        compression = _detect_compression(source_path)
+        codec = None
 
-    compression_type = _get_compression_type(compression)
     nf = _get_native_file(source, use_memory_map)
     input_stream = nf.get_input_stream()
 
-    if compression_type != CompressionType_UNCOMPRESSED:
-        codec = move(GetResultValue(CCodec.Create(compression_type)))
+    # codec is None if compression can't be detected
+    if codec is not None:
         input_stream = <shared_ptr[CInputStream]> GetResultValue(
-            CCompressedInputStream.Make(codec.get(), input_stream))
+            CCompressedInputStream.Make(codec.unwrap(), input_stream)
+        )
 
     out[0] = input_stream
 
@@ -1463,24 +1450,6 @@ cdef get_writer(object source, shared_ptr[COutputStream]* writer):
 
 # ---------------------------------------------------------------------
 
-cdef CompressionType _get_compression_type(object name) except *:
-    if name is None or name == 'uncompressed':
-        return CompressionType_UNCOMPRESSED
-    elif name == 'bz2':
-        return CompressionType_BZ2
-    elif name == 'brotli':
-        return CompressionType_BROTLI
-    elif name == 'gzip':
-        return CompressionType_GZIP
-    elif name == 'lz4':
-        return CompressionType_LZ4
-    elif name == 'snappy':
-        return CompressionType_SNAPPY
-    elif name == 'zstd':
-        return CompressionType_ZSTD
-    else:
-        raise ValueError('Unrecognized compression type: {}'.format(name))
-
 
 def _detect_compression(path):
     if isinstance(path, str):
@@ -1492,6 +1461,124 @@ def _detect_compression(path):
             return 'lz4'
         elif path.endswith('.zst'):
             return 'zstd'
+
+
+cdef CCompressionType _ensure_compression(str name) except *:
+    uppercase = name.upper()
+    if uppercase == 'GZIP':
+        return CCompressionType_GZIP
+    elif uppercase == 'BZ2':
+        return CCompressionType_BZ2
+    elif uppercase == 'BROTLI':
+        return CCompressionType_BROTLI
+    elif uppercase == 'LZ4':
+        return CCompressionType_LZ4
+    elif uppercase == 'ZSTD':
+        return CCompressionType_ZSTD
+    elif uppercase == 'SNAPPY':
+        return CCompressionType_SNAPPY
+    else:
+        raise ValueError('Invalid value for compression: {!r}'.format(name))
+
+
+cdef class Codec:
+
+    def __init__(self, str compression not None):
+        cdef CCompressionType typ = _ensure_compression(compression)
+        self.wrapped = move(GetResultValue(CCodec.Create(typ)))
+
+    cdef inline CCodec* unwrap(self) nogil:
+        return self.wrapped.get()
+
+    @staticmethod
+    def detect(path):
+        return Codec(_detect_compression(path))
+
+    @staticmethod
+    def is_available(str compression not None):
+        cdef CCompressionType typ = _ensure_compression(compression)
+        return CCodec.IsAvailable(typ)
+
+    def compress(self, object buf, asbytes=False, memory_pool=None):
+        cdef:
+            shared_ptr[CBuffer] owned_buf
+            CBuffer* c_buf
+            PyObject* pyobj
+            ResizableBuffer out_buf
+            int64_t max_output_size
+            int64_t output_length
+            uint8_t* output_buffer = NULL
+
+        owned_buf = as_c_buffer(buf)
+        c_buf = owned_buf.get()
+
+        max_output_size = self.wrapped.get().MaxCompressedLen(
+            c_buf.size(), c_buf.data()
+        )
+
+        if asbytes:
+            pyobj = PyBytes_FromStringAndSizeNative(NULL, max_output_size)
+            output_buffer = <uint8_t*> cp.PyBytes_AS_STRING(<object> pyobj)
+        else:
+            out_buf = allocate_buffer(
+                max_output_size, memory_pool=memory_pool, resizable=True
+            )
+            output_buffer = out_buf.buffer.get().mutable_data()
+
+        with nogil:
+            output_length = GetResultValue(
+                self.unwrap().Compress(
+                    c_buf.size(),
+                    c_buf.data(),
+                    max_output_size,
+                    output_buffer
+                )
+            )
+
+        if asbytes:
+            cp._PyBytes_Resize(&pyobj, <Py_ssize_t> output_length)
+            return PyObject_to_object(pyobj)
+        else:
+            out_buf.resize(output_length)
+            return out_buf
+
+    def decompress(self, object buf, decompressed_size=None, asbytes=False,
+                   memory_pool=None):
+        cdef:
+            shared_ptr[CBuffer] owned_buf
+            CBuffer* c_buf
+            Buffer out_buf
+            int64_t output_size
+            uint8_t* output_buffer = NULL
+
+        owned_buf = as_c_buffer(buf)
+        c_buf = owned_buf.get()
+
+        if decompressed_size is None:
+            raise ValueError(
+                "Must pass decompressed_size for {} codec".format(self)
+            )
+
+        output_size = decompressed_size
+
+        if asbytes:
+            pybuf = cp.PyBytes_FromStringAndSize(NULL, output_size)
+            output_buffer = <uint8_t*> cp.PyBytes_AS_STRING(pybuf)
+        else:
+            out_buf = allocate_buffer(output_size, memory_pool=memory_pool)
+            output_buffer = out_buf.buffer.get().mutable_data()
+
+        with nogil:
+            GetResultValue(
+                self.unwrap().Decompress(
+                    c_buf.size(),
+                    c_buf.data(),
+                    output_size,
+                    output_buffer
+                )
+            )
+
+        return pybuf if asbytes else out_buf
 
 
 def compress(object buf, codec='lz4', asbytes=False, memory_pool=None):
@@ -1513,45 +1600,8 @@ def compress(object buf, codec='lz4', asbytes=False, memory_pool=None):
     -------
     compressed : pyarrow.Buffer or bytes (if asbytes=True)
     """
-    cdef:
-        CompressionType compression_type = _get_compression_type(codec)
-        unique_ptr[CCodec] c_codec
-        cdef shared_ptr[CBuffer] owned_buf
-        CBuffer* c_buf
-        cdef PyObject* pyobj
-        cdef ResizableBuffer out_buf
-
-    c_codec = move(GetResultValue(CCodec.Create(compression_type)))
-
-    owned_buf = as_c_buffer(buf)
-    c_buf = owned_buf.get()
-
-    cdef int64_t max_output_size = (c_codec.get()
-                                    .MaxCompressedLen(c_buf.size(),
-                                                      c_buf.data()))
-    cdef uint8_t* output_buffer = NULL
-
-    if asbytes:
-        pyobj = PyBytes_FromStringAndSizeNative(NULL, max_output_size)
-        output_buffer = <uint8_t*> cp.PyBytes_AS_STRING(<object> pyobj)
-    else:
-        out_buf = allocate_buffer(max_output_size, memory_pool=memory_pool,
-                                  resizable=True)
-        output_buffer = out_buf.buffer.get().mutable_data()
-
-    cdef int64_t output_length
-    with nogil:
-        output_length = GetResultValue(
-            c_codec.get()
-            .Compress(c_buf.size(), c_buf.data(),
-                      max_output_size, output_buffer))
-
-    if asbytes:
-        cp._PyBytes_Resize(&pyobj, <Py_ssize_t> output_length)
-        return PyObject_to_object(pyobj)
-    else:
-        out_buf.resize(output_length)
-        return out_buf
+    cdef Codec coder = Codec(codec)
+    return coder.compress(buf, asbytes=asbytes, memory_pool=memory_pool)
 
 
 def decompress(object buf, decompressed_size=None, codec='lz4',
@@ -1577,39 +1627,9 @@ def decompress(object buf, decompressed_size=None, codec='lz4',
     -------
     uncompressed : pyarrow.Buffer or bytes (if asbytes=True)
     """
-    cdef:
-        CompressionType compression_type = _get_compression_type(codec)
-        unique_ptr[CCodec] c_codec
-        cdef shared_ptr[CBuffer] owned_buf
-        cdef CBuffer* c_buf
-        cdef Buffer out_buf
-
-    c_codec = move(GetResultValue(CCodec.Create(compression_type)))
-
-    owned_buf = as_c_buffer(buf)
-    c_buf = owned_buf.get()
-
-    if decompressed_size is None:
-        raise ValueError("Must pass decompressed_size for {0} codec"
-                         .format(codec))
-
-    cdef int64_t output_size = decompressed_size
-    cdef uint8_t* output_buffer = NULL
-
-    if asbytes:
-        pybuf = cp.PyBytes_FromStringAndSize(NULL, output_size)
-        output_buffer = <uint8_t*> cp.PyBytes_AS_STRING(pybuf)
-    else:
-        out_buf = allocate_buffer(output_size, memory_pool=memory_pool)
-        output_buffer = out_buf.buffer.get().mutable_data()
-
-    with nogil:
-        check_status(c_codec.get()
-                     .Decompress(c_buf.size(), c_buf.data(),
-                                 output_size, output_buffer)
-                     .status())
-
-    return pybuf if asbytes else out_buf
+    cdef Codec decoder = Codec(codec)
+    return decoder.decompress(buf, asbytes=asbytes, memory_pool=memory_pool,
+                              decompressed_size=decompressed_size)
 
 
 def input_stream(source, compression='detect', buffer_size=None):

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -529,6 +529,13 @@ cdef class _CRecordBatchReader:
         shared_ptr[CRecordBatchReader] reader
 
 
+cdef class Codec:
+    cdef:
+        unique_ptr[CCodec] wrapped
+
+    cdef inline CCodec* unwrap(self) nogil
+
+
 cdef class CastOptions:
     cdef:
         CCastOptions options
@@ -538,8 +545,6 @@ cdef class CastOptions:
 
     cdef inline CCastOptions unwrap(self) nogil
 
-
-cdef CompressionType _get_compression_type(object name) except *
 
 cdef get_input_stream(object source, c_bool use_memory_map,
                       shared_ptr[CInputStream]* reader)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -18,8 +18,8 @@
 from datetime import datetime
 import gzip
 import pathlib
-
 import urllib.parse
+import sys
 
 import pytest
 
@@ -605,8 +605,14 @@ def test_filesystem_from_uri(uri, expected_klass, expected_path):
     assert path == expected_path
 
 
-@pytest.mark.parametrize('path',
-                         ['', '/', 'foo/bar', '/foo/bar', __file__])
+@pytest.mark.skipif(
+    sys.version_info < (3, 6),
+    reason="python 3.5 Path.resolve() checks that the path exists"
+)
+@pytest.mark.parametrize(
+    'path',
+    ['', '/', 'foo/bar', '/foo/bar', __file__]
+)
 def test_filesystem_from_path_object(path):
     p = pathlib.Path(path)
     fs, path = FileSystem.from_uri(p)

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -31,6 +31,7 @@ import weakref
 import numpy as np
 
 from pyarrow.compat import guid
+from pyarrow.lib import Codec
 import pyarrow as pa
 
 
@@ -546,32 +547,44 @@ def test_allocate_buffer_resizable():
     assert buf.size == 200
 
 
-def test_compress_decompress():
+@pytest.mark.parametrize("compression", [
+    pytest.param(
+        "bz2", marks=pytest.mark.xfail(raises=pa.lib.ArrowNotImplementedError)
+    ),
+    "brotli",
+    "gzip",
+    "lz4",
+    "zstd",
+    "snappy"
+])
+def test_compress_decompress(compression):
+    if not Codec.is_available(compression):
+        pytest.skip("{} support is not built".format(compression))
+
     INPUT_SIZE = 10000
     test_data = (np.random.randint(0, 255, size=INPUT_SIZE)
                  .astype(np.uint8)
                  .tostring())
     test_buf = pa.py_buffer(test_data)
 
-    codecs = ['lz4', 'snappy', 'gzip', 'zstd', 'brotli']
-    for codec in codecs:
-        compressed_buf = pa.compress(test_buf, codec=codec)
-        compressed_bytes = pa.compress(test_data, codec=codec, asbytes=True)
+    compressed_buf = pa.compress(test_buf, codec=compression)
+    compressed_bytes = pa.compress(test_data, codec=compression,
+                                   asbytes=True)
 
-        assert isinstance(compressed_bytes, bytes)
+    assert isinstance(compressed_bytes, bytes)
 
-        decompressed_buf = pa.decompress(compressed_buf, INPUT_SIZE,
-                                         codec=codec)
-        decompressed_bytes = pa.decompress(compressed_bytes, INPUT_SIZE,
-                                           codec=codec, asbytes=True)
+    decompressed_buf = pa.decompress(compressed_buf, INPUT_SIZE,
+                                     codec=compression)
+    decompressed_bytes = pa.decompress(compressed_bytes, INPUT_SIZE,
+                                       codec=compression, asbytes=True)
 
-        assert isinstance(decompressed_bytes, bytes)
+    assert isinstance(decompressed_bytes, bytes)
 
-        assert decompressed_buf.equals(test_buf)
-        assert decompressed_bytes == test_data
+    assert decompressed_buf.equals(test_buf)
+    assert decompressed_bytes == test_data
 
-        with pytest.raises(ValueError):
-            pa.decompress(compressed_bytes, codec=codec)
+    with pytest.raises(ValueError):
+        pa.decompress(compressed_bytes, codec=compression)
 
 
 def test_buffer_memoryview_is_immutable():
@@ -1158,7 +1171,7 @@ def test_compressed_input_invalid():
     raw = pa.BufferReader(data)
     with pytest.raises(ValueError):
         pa.CompressedInputStream(raw, "unknown_compression")
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         pa.CompressedInputStream(raw, None)
 
     with pa.CompressedInputStream(raw, "gzip") as compressed:
@@ -1201,19 +1214,26 @@ def test_compressed_output_bz2(tmpdir):
         assert got == data
 
 
-@pytest.mark.parametrize("compression",
-                         ["bz2", "brotli", "gzip", "lz4", "zstd"])
+@pytest.mark.parametrize("compression", [
+    "bz2",
+    "brotli",
+    "gzip",
+    "lz4",
+    "zstd",
+    pytest.param(
+        "snappy",
+        marks=pytest.mark.xfail(raises=pa.lib.ArrowNotImplementedError)
+    )
+])
 def test_compressed_roundtrip(compression):
+    if not Codec.is_available(compression):
+        pytest.skip("{} support is not built".format(compression))
+
     data = b"some test data\n" * 10 + b"eof\n"
     raw = pa.BufferOutputStream()
-    try:
-        with pa.CompressedOutputStream(raw, compression) as compressed:
-            compressed.write(data)
-    except NotImplementedError as e:
-        if compression == "bz2":
-            pytest.skip(str(e))
-        else:
-            raise
+    with pa.CompressedOutputStream(raw, compression) as compressed:
+        compressed.write(data)
+
     cdata = raw.getvalue()
     assert len(cdata) < len(data)
     raw = pa.BufferReader(cdata)
@@ -1222,19 +1242,18 @@ def test_compressed_roundtrip(compression):
         assert got == data
 
 
-@pytest.mark.parametrize("compression",
-                         ["bz2", "brotli", "gzip", "lz4", "zstd"])
+@pytest.mark.parametrize(
+    "compression",
+    ["bz2", "brotli", "gzip", "lz4", "zstd"]
+)
 def test_compressed_recordbatch_stream(compression):
+    if not Codec.is_available(compression):
+        pytest.skip("{} support is not built".format(compression))
+
     # ARROW-4836: roundtrip a RecordBatch through a compressed stream
     table = pa.Table.from_arrays([pa.array([1, 2, 3, 4, 5])], ['a'])
     raw = pa.BufferOutputStream()
-    try:
-        stream = pa.CompressedOutputStream(raw, compression)
-    except NotImplementedError as e:
-        if compression == "bz2":
-            pytest.skip(str(e))
-        else:
-            raise
+    stream = pa.CompressedOutputStream(raw, compression)
     writer = pa.RecordBatchStreamWriter(stream, table.schema)
     writer.write_table(table, max_chunksize=3)
     writer.close()
@@ -1474,7 +1493,7 @@ def test_output_stream_file_path_compressed(tmpdir):
         check_data(file_path, data, compression='gzip')) == data
     assert check_data(file_path, data, compression=None) == data
 
-    with pytest.raises(ValueError, match='Unrecognized compression type'):
+    with pytest.raises(ValueError, match='Invalid value for compression'):
         assert check_data(file_path, data, compression='rabbit') == data
 
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -894,7 +894,11 @@ def test_statistics_convert_logical_types(tempdir):
 
 def test_parquet_write_disable_statistics(tempdir):
     table = pa.Table.from_pydict(
-        {'a': pa.array([1, 2, 3]), 'b': pa.array(['a', 'b', 'c'])})
+        OrderedDict([
+            ('a', pa.array([1, 2, 3])),
+            ('b', pa.array(['a', 'b', 'c']))
+        ])
+    )
     _write_table(table, tempdir / 'data.parquet')
     meta = pq.read_metadata(tempdir / 'data.parquet')
     for col in [0, 1]:
@@ -912,10 +916,10 @@ def test_parquet_write_disable_statistics(tempdir):
     _write_table(table, tempdir / 'data3.parquet', write_statistics=['a'])
     meta = pq.read_metadata(tempdir / 'data3.parquet')
     cc_a = meta.row_group(0).column(0)
-    assert cc_a.is_stats_set is True
-    assert cc_a.statistics is not None
     cc_b = meta.row_group(0).column(1)
+    assert cc_a.is_stats_set is True
     assert cc_b.is_stats_set is False
+    assert cc_a.statistics is not None
     assert cc_b.statistics is None
 
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -620,6 +620,9 @@ def test_pandas_parquet_configuration_options(tempdir):
         tm.assert_frame_equal(df, df_read)
 
     for compression in ['NONE', 'SNAPPY', 'GZIP', 'LZ4', 'ZSTD']:
+        if (compression != 'NONE' and
+                not pa.lib.Codec.is_available(compression)):
+            continue
         _write_table(arrow_table, filename, version='2.0',
                      compression=compression)
         table_read = _read_table(filename)

--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -1,6 +1,8 @@
 cython
-hypothesis
-pandas
+hypothesis==5.0; python_version <= "3.5.2"
+hypothesis; python_version > "3.5.2"
+pandas==0.24; python_version <= "3.5.2"
+pandas; python_version > "3.5.2"
 pickle5; python_version == "3.6" or python_version == "3.7"
 pytest
 pytest-lazy-fixture


### PR DESCRIPTION
- added bindings for the Codec class
- support to check compiled/available compression types
- test on ubuntu 16.04 with python 3.5.2 (needs to pin dependencies because of python typing incompatibilities)
- skip the failing Filesystem.from_uri tests on python 3.5 because pathlib.Path.resolve checks that the path exists (which is not)
- run a github actions build with python 3.5.2 test for each commit

