### PR TITLE
ARROW-7940: [C++] Remove ARROW_USE_CLCACHE handling

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -361,16 +361,6 @@ if(ARROW_TEST_MEMCHECK)
   add_definitions(-DARROW_VALGRIND)
 endif()
 
-if(MSVC
-   AND ARROW_USE_CLCACHE
-   AND (("${CMAKE_GENERATOR}" STREQUAL "NMake Makefiles")
-        OR ("${CMAKE_GENERATOR}" STREQUAL "Ninja")))
-  find_program(CLCACHE_FOUND clcache)
-  if(CLCACHE_FOUND)
-    set(CMAKE_CXX_COMPILER ${CLCACHE_FOUND})
-  endif(CLCACHE_FOUND)
-endif()
-
 #
 # Compiler flags
 #

--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -286,8 +286,6 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
                   "Pass verbose linking options when linking libraries and executables"
                   OFF)
 
-    define_option(ARROW_USE_CLCACHE "Use clcache if available" ON)
-
     define_option_string(BROTLI_MSVC_STATIC_LIB_SUFFIX
                          "Brotli static lib suffix used on Windows with MSVC" "-static")
 

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -139,9 +139,26 @@ do an out of source build by generating Ninja files:
    cd cpp
    mkdir build
    cd build
-   cmake -G "Ninja" -DARROW_BUILD_TESTS=ON ^
+   cmake -G "Ninja" ^
+         -DCMAKE_C_COMPILER=clcache ^
+         -DCMAKE_CXX_COMPILER=clcache ^
+         -DARROW_BUILD_TESTS=ON ^
          -DGTest_SOURCE=BUNDLED ..
    cmake --build . --config Release
+
+Setting ``CMAKE_C_COMPILER`` and ``CMAKE_CXX_COMPILER`` in the command line 
+of ``cmake`` is the preferred method of using ``clcache``. Alternatively, you 
+can set ``CC`` and ``CXX`` environment variables before calling ``cmake``:
+
+.. code-block:: shell
+
+   ...
+   set CC=clcache
+   set CXX=clcache
+   cmake -G "Ninja" ^
+   ...
+
+
 
 Building with NMake
 ===================


### PR DESCRIPTION
The recommended way to enable `clcache` is to pass the `CMAKE_CXX_COMPILER` option to CMake, or to set the `CXX` environment variable.