### PR TITLE
ARROW-7983: [CI][R] Nightly builds should be more verbose when they fail

### DIFF
--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -32,6 +32,7 @@ if [ "$ARROW_R_CXXFLAGS" != "" ]; then
   export _R_CHECK_COMPILATION_FLAGS_=FALSE
 fi
 export TEST_R_WITH_ARROW=TRUE
+export ARROW_R_DEV=TRUE # For log verbosity
 export _R_CHECK_TESTS_NLINES_=0
 export _R_CHECK_CRAN_INCOMING_REMOTE_=FALSE
 export _R_CHECK_LIMIT_CORES_=FALSE

--- a/dev/tasks/r/azure.linux.yml
+++ b/dev/tasks/r/azure.linux.yml
@@ -48,3 +48,9 @@ jobs:
         R_TAG={{ r_tag }}
         docker-compose run r
       displayName: Docker run
+
+    - script: |
+        set -ex
+        cat arrow/r/check/arrow.Rcheck/00install.out
+      displayName: Dump install logs on failure
+      condition: failed()

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -220,11 +220,12 @@ test_that("support for NaN (ARROW-3615)", {
   expect_equal(y$null_count, 1L)
 })
 
-int_types <- c(int8(), int16(), int32(), int64())
-uint_types <- c(uint8(), uint16(), uint32(), uint64())
-float_types <- c(float32(), float64()) # float16() not really supported in C++ yet
-
 test_that("integer types casts (ARROW-3741)", {
+  # Defining some type groups for use here and in the following tests
+  int_types <- c(int8(), int16(), int32(), int64())
+  uint_types <- c(uint8(), uint16(), uint32(), uint64())
+  float_types <- c(float32(), float64()) # float16() not really supported in C++ yet
+
   a <- Array$create(c(1:10, NA))
   for (type in c(int_types, uint_types)) {
     casted <- a$cast(type)


### PR DESCRIPTION
We do this on GHA but not crossbow