### PR TITLE
ARROW-7975: [C++] Preserve intended buffer size by default when writing to IPC format

### DIFF
--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -190,7 +190,7 @@ class RecordBatchSerializer : public ArrayVisitor {
         padding = BitUtil::RoundUpToMultipleOf8(size) - size;
       }
 
-      buffer_meta_.push_back({offset, size + padding});
+      buffer_meta_.push_back({offset, size});
       offset += size + padding;
     }
 


### PR DESCRIPTION
I stumbled into this tangentially. While padding to a minimum of an 8-byte multiple is a requirement of the binary protocol, including the padding in the metadata causes buffer sizes to be modified. In some cases, the intention of the writer is for the receiver to receive padded buffers, but including the padding unconditionally leaves no possibility of recovering the buffer size prior to producing the IPC message. I think it would be better to give the writer the option of what to do. I opened ARROW-7976 about adding an option to make this behavior configurable. 

Another possibility of course is to implement an option and have "include padding" turned on by default

To be clear in case there is concern, this change has no backward or forward compatibility implications.