### PR TITLE
ARROW-7987: [CI][R] Fix for verbose nightly builds

### DIFF
--- a/.env
+++ b/.env
@@ -38,6 +38,7 @@ HDFS=2.9.2
 SPARK=master
 DOTNET=2.1
 R=3.6
+ARROW_R_DEV=TRUE
 # These correspond to images on Docker Hub that contain R, e.g. rhub/ubuntu-gcc-release:latest
 R_ORG=rhub
 R_IMAGE=ubuntu-gcc-release

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -24,6 +24,8 @@ source_dir=${1}/r
 
 pushd ${source_dir}
 
+printenv
+
 if [ "$ARROW_USE_PKG_CONFIG" != "false" ]; then
   export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
   export R_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -19,6 +19,7 @@
 set -ex
 
 : ${R_BIN:=R}
+: ${ARROW_R_DEV:=TRUE}
 
 source_dir=${1}/r
 
@@ -28,11 +29,10 @@ if [ "$ARROW_USE_PKG_CONFIG" != "false" ]; then
   export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
   export R_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
 fi
-if [ "$ARROW_R_CXXFLAGS" != "" ]; then
+if [ "$ARROW_R_CXXFLAGS" != "" ] || [ "$ARROW_R_DEV" != "TRUE" ]; then
   export _R_CHECK_COMPILATION_FLAGS_=FALSE
 fi
 export TEST_R_WITH_ARROW=TRUE
-export ARROW_R_DEV=TRUE # For log verbosity
 export _R_CHECK_TESTS_NLINES_=0
 export _R_CHECK_CRAN_INCOMING_REMOTE_=FALSE
 export _R_CHECK_LIMIT_CORES_=FALSE

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -43,7 +43,9 @@ export VERSION=$(grep ^Version DESCRIPTION | sed s/Version:\ //)
 # Make sure we aren't writing to the home dir (CRAN _hates_ this but there is no official check)
 BEFORE=$(ls -alh ~/)
 
-${R_BIN} -e "rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', '--as-cran', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check')"
+# Conditionally run --as-cran because crossbow jobs aren't using _R_CHECK_COMPILATION_FLAGS_KNOWN_
+# (maybe an R version thing, needs 3.6.2?)
+${R_BIN} -e "rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', if (identical(Sys.getenv('ARROW_R_DEV'), 'TRUE')) '--as-cran', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check')"
 
 AFTER=$(ls -alh ~/)
 if [ "$BEFORE" != "$AFTER" ]; then

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -45,7 +45,7 @@ BEFORE=$(ls -alh ~/)
 
 # Conditionally run --as-cran because crossbow jobs aren't using _R_CHECK_COMPILATION_FLAGS_KNOWN_
 # (maybe an R version thing, needs 3.6.2?)
-${R_BIN} -e "rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', if (identical(Sys.getenv('ARROW_R_DEV'), 'TRUE')) '--as-cran', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check')"
+${R_BIN} -e "rcmdcheck::rcmdcheck(build_args = '--no-build-vignettes', args = c('--no-manual', if (!identical(Sys.getenv('ARROW_R_DEV'), 'TRUE')) '--as-cran', '--ignore-vignettes', '--run-donttest'), error_on = 'warning', check_dir = 'check')"
 
 AFTER=$(ls -alh ~/)
 if [ "$BEFORE" != "$AFTER" ]; then

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -29,7 +29,7 @@ if [ "$ARROW_USE_PKG_CONFIG" != "false" ]; then
   export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
   export R_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
 fi
-if [ "$ARROW_R_CXXFLAGS" != "" ] || [ "$ARROW_R_DEV" != "TRUE" ]; then
+if [ "$ARROW_R_CXXFLAGS" != "" ] || [ "$ARROW_R_DEV" = "TRUE" ]; then
   export _R_CHECK_COMPILATION_FLAGS_=FALSE
 fi
 export TEST_R_WITH_ARROW=TRUE

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -19,7 +19,6 @@
 set -ex
 
 : ${R_BIN:=R}
-: ${ARROW_R_DEV:=TRUE}
 
 source_dir=${1}/r
 

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -29,8 +29,10 @@ if [ "$ARROW_USE_PKG_CONFIG" != "false" ]; then
   export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
   export R_LD_LIBRARY_PATH=${LD_LIBRARY_PATH}
 fi
-if [ "$ARROW_R_CXXFLAGS" != "" ] || [ "$ARROW_R_DEV" = "TRUE" ]; then
-  export _R_CHECK_COMPILATION_FLAGS_=FALSE
+export _R_CHECK_COMPILATION_FLAGS_KNOWN_=${ARROW_R_CXXFLAGS}
+if [ "$ARROW_R_DEV" = "TRUE" ]; then
+  # These are used in the Arrow C++ build and are not a problem
+  export _R_CHECK_COMPILATION_FLAGS_KNOWN_="${_R_CHECK_COMPILATION_FLAGS_KNOWN_} -Wno-attributes -msse4.2"
 fi
 export TEST_R_WITH_ARROW=TRUE
 export _R_CHECK_TESTS_NLINES_=0

--- a/dev/tasks/r/azure.linux.yml
+++ b/dev/tasks/r/azure.linux.yml
@@ -46,7 +46,8 @@ jobs:
         R_ORG={{ r_org }}
         R_IMAGE={{ r_image }}
         R_TAG={{ r_tag }}
-        ARROW_R_DEV={{ verbose }}
+        # we have to export this (right?) because we need it in the build env
+        export ARROW_R_DEV={{ verbose }}
         docker-compose run r
       displayName: Docker run
 

--- a/dev/tasks/r/azure.linux.yml
+++ b/dev/tasks/r/azure.linux.yml
@@ -46,6 +46,7 @@ jobs:
         R_ORG={{ r_org }}
         R_IMAGE={{ r_image }}
         R_TAG={{ r_tag }}
+        ARROW_R_DEV={{ verbose }}
         docker-compose run r
       displayName: Docker run
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1836,6 +1836,7 @@ tasks:
       r_org: rhub
       r_image: debian-gcc-devel
       r_tag: latest
+      verbose: TRUE
 
   test-r-rhub-ubuntu-gcc-release:
     ci: azure
@@ -1845,6 +1846,7 @@ tasks:
       r_org: rhub
       r_image: ubuntu-gcc-release
       r_tag: latest
+      verbose: TRUE
 
   test-r-rstudio-r-base-3.6-bionic:
     ci: azure
@@ -1875,6 +1877,7 @@ tasks:
       r_org: rstudio
       r_image: r-base
       r_tag: 3.6-opensuse15
+      verbose: TRUE
 
   test-r-rstudio-r-base-3.6-opensuse42:
     ci: azure
@@ -1884,6 +1887,7 @@ tasks:
       r_org: rstudio
       r_image: r-base
       r_tag: 3.6-opensuse24
+      verbose: TRUE
 
   test-ubuntu-18.04-r-3.6:
     ci: circle

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1854,6 +1854,8 @@ tasks:
       r_org: rstudio
       r_image: r-base
       r_tag: 3.6-bionic
+      # Turn off verbosity on some tests in order to check compiler flags
+      verbose: FALSE
 
   test-r-rstudio-r-base-3.6-centos6:
     ci: azure
@@ -1863,6 +1865,7 @@ tasks:
       r_org: rstudio
       r_image: r-base
       r_tag: 3.6-centos6
+      verbose: FALSE
 
   test-r-rstudio-r-base-3.6-opensuse15:
     ci: azure

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1836,7 +1836,7 @@ tasks:
       r_org: rhub
       r_image: debian-gcc-devel
       r_tag: latest
-      verbose: TRUE
+      verbose: "TRUE"
 
   test-r-rhub-ubuntu-gcc-release:
     ci: azure
@@ -1846,7 +1846,7 @@ tasks:
       r_org: rhub
       r_image: ubuntu-gcc-release
       r_tag: latest
-      verbose: TRUE
+      verbose: "TRUE"
 
   test-r-rstudio-r-base-3.6-bionic:
     ci: azure
@@ -1857,7 +1857,7 @@ tasks:
       r_image: r-base
       r_tag: 3.6-bionic
       # Turn off verbosity on some tests in order to check compiler flags
-      verbose: FALSE
+      verbose: "FALSE"
 
   test-r-rstudio-r-base-3.6-centos6:
     ci: azure
@@ -1867,7 +1867,7 @@ tasks:
       r_org: rstudio
       r_image: r-base
       r_tag: 3.6-centos6
-      verbose: FALSE
+      verbose: "FALSE"
 
   test-r-rstudio-r-base-3.6-opensuse15:
     ci: azure
@@ -1877,7 +1877,7 @@ tasks:
       r_org: rstudio
       r_image: r-base
       r_tag: 3.6-opensuse15
-      verbose: TRUE
+      verbose: "TRUE"
 
   test-r-rstudio-r-base-3.6-opensuse42:
     ci: azure
@@ -1887,7 +1887,7 @@ tasks:
       r_org: rstudio
       r_image: r-base
       r_tag: 3.6-opensuse24
-      verbose: TRUE
+      verbose: "TRUE"
 
   test-ubuntu-18.04-r-3.6:
     ci: circle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -791,11 +791,11 @@ services:
       LIBARROW_DOWNLOAD: "false"
       ARROW_HOME: "/arrow"
       ARROW_USE_PKG_CONFIG: "false"
-      ARROW_R_DEV: ${ARROW_R_DEV}
     volumes:
       - .:/arrow:delegated
     command: >
       /bin/bash -c "
+        export ARROW_R_DEV=${ARROW_R_DEV} &&
         /arrow/ci/scripts/r_test.sh /arrow"
 
   ubuntu-r-sanitizer:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -791,6 +791,7 @@ services:
       LIBARROW_DOWNLOAD: "false"
       ARROW_HOME: "/arrow"
       ARROW_USE_PKG_CONFIG: "false"
+      ARROW_R_DEV: ${ARROW_R_DEV}
     volumes:
       - .:/arrow:delegated
     command: >


### PR DESCRIPTION
Verbose builds trigger a compiler flag check to fail, so make sure that we don't run that check if building verbosely. And make sure we can test both ways: it's important that at least one nightly check the flags, but verbosity is otherwise more useful for debugging build failures.