### PR TITLE
ARROW-7988: [R] Fix on.exit calls in reticulate bindings

### DIFF
--- a/r/R/py-to-r.R
+++ b/r/R/py-to-r.R
@@ -17,9 +17,11 @@
 
 py_to_r.pyarrow.lib.Array <- function(x, ...) {
   schema_ptr <- allocate_arrow_schema()
-  on.exit(delete_arrow_schema(schema_ptr))
   array_ptr <- allocate_arrow_array()
-  on.exit(delete_arrow_array(array_ptr))
+  on.exit({
+    delete_arrow_schema(schema_ptr)
+    delete_arrow_array(array_ptr)
+  })
 
   x$`_export_to_c`(array_ptr, schema_ptr)
   Array$create(ImportArray(array_ptr, schema_ptr))
@@ -27,9 +29,11 @@ py_to_r.pyarrow.lib.Array <- function(x, ...) {
 
 r_to_py.Array <- function(x, convert = FALSE) {
   schema_ptr <- allocate_arrow_schema()
-  on.exit(delete_arrow_schema(schema_ptr))
   array_ptr <- allocate_arrow_array()
-  on.exit(delete_arrow_array(array_ptr))
+  on.exit({
+    delete_arrow_schema(schema_ptr)
+    delete_arrow_array(array_ptr)
+  })
 
   pa <- reticulate::import("pyarrow", convert = convert)
   ExportArray(x, array_ptr, schema_ptr)
@@ -38,9 +42,11 @@ r_to_py.Array <- function(x, convert = FALSE) {
 
 py_to_r.pyarrow.lib.RecordBatch <- function(x, ...) {
   schema_ptr <- allocate_arrow_schema()
-  on.exit(delete_arrow_schema(schema_ptr))
   array_ptr <- allocate_arrow_array()
-  on.exit(delete_arrow_array(array_ptr))
+  on.exit({
+    delete_arrow_schema(schema_ptr)
+    delete_arrow_array(array_ptr)
+  })
 
   x$`_export_to_c`(array_ptr, schema_ptr)
   shared_ptr(RecordBatch, ImportRecordBatch(array_ptr, schema_ptr))
@@ -48,10 +54,12 @@ py_to_r.pyarrow.lib.RecordBatch <- function(x, ...) {
 
 r_to_py.RecordBatch <- function(x, convert = FALSE) {
   schema_ptr <- allocate_arrow_schema()
-  on.exit(delete_arrow_schema(schema_ptr))
   array_ptr <- allocate_arrow_array()
-  on.exit(delete_arrow_array(array_ptr))
-
+  on.exit({
+    delete_arrow_schema(schema_ptr)
+    delete_arrow_array(array_ptr)
+  })
+  
   pa <- reticulate::import("pyarrow", convert = convert)
   ExportRecordBatch(x, array_ptr, schema_ptr)
   pa$RecordBatch$`_import_from_c`(array_ptr, schema_ptr)


### PR DESCRIPTION
I missed this/didn't closely review after the refactoring that pulled the schema out of the array object. `on.exit()` overwrites the existing finalizer (more recent versions of R have added an `add = TRUE` argument that lets you append, but we still support older versions) so we should only call it once in each function. As the code currently stands, we wouldn't actually be calling `delete_arrow_schema(schema_ptr)`.