### PR TITLE
ARROW-7998: [C++][Plasma] Make Seal requests synchronous

### DIFF
--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -859,6 +859,11 @@ Status PlasmaClient::Impl::Seal(const ObjectID& object_id) {
   RETURN_NOT_OK(Hash(object_id, &digest[0]));
   RETURN_NOT_OK(
       SendSealRequest(store_conn_, object_id, std::string(digest.begin(), digest.end())));
+  std::vector<uint8_t> buffer;
+  RETURN_NOT_OK(PlasmaReceive(store_conn_, MessageType::PlasmaSealReply, &buffer));
+  ObjectID sealed_id;
+  RETURN_NOT_OK(ReadSealReply(buffer.data(), buffer.size(), &sealed_id));
+  ARROW_CHECK(sealed_id == object_id);
   // We call PlasmaClient::Release to decrement the number of instances of this
   // object
   // that are currently being used by this client. The corresponding increment


### PR DESCRIPTION
When handling a `Seal` request to create an object and make it visible to other clients, the plasma store does not wait until the seal is complete before responding to the requesting client. This makes the interface hard to use, since the client is not guaranteed that the object is visible yet and would have to use an additional IPC round-trip to determine when the object is ready.

This improvement would require the plasma store to wait until the object has been created before responding to the client.