### PR TITLE
ARROW-7739: [GLib] Use placement new to initialize shared_ptr object in private structs

### DIFF
--- a/c_glib/arrow-cuda-glib/cuda.cpp
+++ b/c_glib/arrow-cuda-glib/cuda.cpp
@@ -214,6 +214,8 @@ garrow_cuda_context_get_property(GObject *object,
 static void
 garrow_cuda_context_init(GArrowCUDAContext *object)
 {
+  auto priv = GARROW_CUDA_CONTEXT_GET_PRIVATE(object);
+  new(&priv->context) std::shared_ptr<arrow::cuda::CudaContext>;
 }
 
 static void

--- a/c_glib/arrow-cuda-glib/cuda.cpp
+++ b/c_glib/arrow-cuda-glib/cuda.cpp
@@ -174,7 +174,7 @@ garrow_cuda_context_finalize(GObject *object)
 {
   auto priv = GARROW_CUDA_CONTEXT_GET_PRIVATE(object);
 
-  priv->context = nullptr;
+  priv->context.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_cuda_context_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -4291,7 +4291,7 @@ garrow_struct_array_builder_dispose(GObject *object)
 {
   auto priv = GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(object);
 
-  for (GList *node = priv->field_builders; node; node = g_list_next(node)) {
+  for (auto node = priv->field_builders; node; node = g_list_next(node)) {
     auto field_builder = static_cast<GArrowArrayBuilder *>(node->data);
     GArrowArrayBuilderPrivate *field_builder_priv;
 

--- a/c_glib/arrow-glib/array-builder.cpp
+++ b/c_glib/arrow-glib/array-builder.cpp
@@ -339,9 +339,7 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GArrowArrayBuilder,
 static void
 garrow_array_builder_finalize(GObject *object)
 {
-  GArrowArrayBuilderPrivate *priv;
-
-  priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(object);
+  auto priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(object);
 
   if (priv->have_ownership) {
     delete priv->array_builder;
@@ -356,9 +354,7 @@ garrow_array_builder_set_property(GObject *object,
                                   const GValue *value,
                                   GParamSpec *pspec)
 {
-  GArrowArrayBuilderPrivate *priv;
-
-  priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(object);
+  auto priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_ARRAY_BUILDER:
@@ -387,9 +383,7 @@ garrow_array_builder_get_property(GObject *object,
 static void
 garrow_array_builder_init(GArrowArrayBuilder *builder)
 {
-  GArrowArrayBuilderPrivate *priv;
-
-  priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(builder);
+  auto priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(builder);
   priv->have_ownership = TRUE;
 }
 
@@ -438,9 +432,7 @@ garrow_array_builder_new(const std::shared_ptr<arrow::DataType> &type,
 void
 garrow_array_builder_release_ownership(GArrowArrayBuilder *builder)
 {
-  GArrowArrayBuilderPrivate *priv;
-
-  priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(builder);
+  auto priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(builder);
   priv->have_ownership = FALSE;
 }
 
@@ -3938,9 +3930,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowListArrayBuilder,
 static void
 garrow_list_array_builder_dispose(GObject *object)
 {
-  GArrowListArrayBuilderPrivate *priv;
-
-  priv = GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(object);
+  auto priv = GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(object);
 
   if (priv->value_builder) {
     g_object_unref(priv->value_builder);
@@ -4130,9 +4120,7 @@ garrow_list_array_builder_append_null(GArrowListArrayBuilder *builder,
 GArrowArrayBuilder *
 garrow_list_array_builder_get_value_builder(GArrowListArrayBuilder *builder)
 {
-  GArrowListArrayBuilderPrivate *priv;
-
-  priv = GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(builder);
+  auto priv = GARROW_LIST_ARRAY_BUILDER_GET_PRIVATE(builder);
   if (!priv->value_builder) {
     auto arrow_builder =
       static_cast<arrow::ListBuilder *>(
@@ -4301,12 +4289,9 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowStructArrayBuilder,
 static void
 garrow_struct_array_builder_dispose(GObject *object)
 {
-  GArrowStructArrayBuilderPrivate *priv;
-  GList *node;
+  auto priv = GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(object);
 
-  priv = GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(object);
-
-  for (node = priv->field_builders; node; node = g_list_next(node)) {
+  for (GList *node = priv->field_builders; node; node = g_list_next(node)) {
     auto field_builder = static_cast<GArrowArrayBuilder *>(node->data);
     GArrowArrayBuilderPrivate *field_builder_priv;
 
@@ -4468,9 +4453,7 @@ garrow_struct_array_builder_get_field_builder(GArrowStructArrayBuilder *builder,
 GList *
 garrow_struct_array_builder_get_field_builders(GArrowStructArrayBuilder *builder)
 {
-  GArrowStructArrayBuilderPrivate *priv;
-
-  priv = GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(builder);
+  auto priv = GARROW_STRUCT_ARRAY_BUILDER_GET_PRIVATE(builder);
   if (!priv->field_builders) {
     auto arrow_struct_builder =
       static_cast<arrow::StructBuilder *>(
@@ -4949,8 +4932,6 @@ garrow_array_builder_new_raw(arrow::ArrayBuilder *arrow_builder,
 arrow::ArrayBuilder *
 garrow_array_builder_get_raw(GArrowArrayBuilder *builder)
 {
-  GArrowArrayBuilderPrivate *priv;
-
-  priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(builder);
+  auto priv = GARROW_ARRAY_BUILDER_GET_PRIVATE(builder);
   return priv->array_builder;
 }

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -232,7 +232,7 @@ garrow_array_finalize(GObject *object)
 {
   auto priv = GARROW_ARRAY_GET_PRIVATE(object);
 
-  priv->array = nullptr;
+  priv->array.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_array_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -272,6 +272,8 @@ garrow_array_get_property(GObject *object,
 static void
 garrow_array_init(GArrowArray *object)
 {
+  auto priv = GARROW_ARRAY_GET_PRIVATE(object);
+  new(&priv->array) std::shared_ptr<arrow::Array>;
 }
 
 static void

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -160,6 +160,8 @@ garrow_data_type_get_property(GObject *object,
 static void
 garrow_data_type_init(GArrowDataType *object)
 {
+  auto priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
+  new(&priv->data_type) std::shared_ptr<arrow::DataType>;
 }
 
 static void

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -120,7 +120,7 @@ garrow_data_type_finalize(GObject *object)
 {
   auto priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
 
-  priv->data_type = nullptr;
+  priv->data_type.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_data_type_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -118,9 +118,7 @@ G_DEFINE_ABSTRACT_TYPE_WITH_PRIVATE(GArrowDataType,
 static void
 garrow_data_type_finalize(GObject *object)
 {
-  GArrowDataTypePrivate *priv;
-
-  priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
+  auto priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
 
   priv->data_type = nullptr;
 
@@ -133,9 +131,7 @@ garrow_data_type_set_property(GObject *object,
                               const GValue *value,
                               GParamSpec *pspec)
 {
-  GArrowDataTypePrivate *priv;
-
-  priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
+  auto priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_DATA_TYPE:
@@ -1408,8 +1404,6 @@ garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type)
 std::shared_ptr<arrow::DataType>
 garrow_data_type_get_raw(GArrowDataType *data_type)
 {
-  GArrowDataTypePrivate *priv;
-
-  priv = GARROW_DATA_TYPE_GET_PRIVATE(data_type);
+  auto priv = GARROW_DATA_TYPE_GET_PRIVATE(data_type);
   return priv->data_type;
 }

--- a/c_glib/arrow-glib/buffer.cpp
+++ b/c_glib/arrow-glib/buffer.cpp
@@ -126,6 +126,8 @@ garrow_buffer_get_property(GObject *object,
 static void
 garrow_buffer_init(GArrowBuffer *object)
 {
+  auto priv = GARROW_BUFFER_GET_PRIVATE(object);
+  new(&priv->buffer) std::shared_ptr<arrow::Buffer>;
 }
 
 static void

--- a/c_glib/arrow-glib/buffer.cpp
+++ b/c_glib/arrow-glib/buffer.cpp
@@ -84,7 +84,7 @@ garrow_buffer_finalize(GObject *object)
 {
   auto priv = GARROW_BUFFER_GET_PRIVATE(object);
 
-  priv->buffer = nullptr;
+  priv->buffer.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_buffer_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/chunked-array.cpp
+++ b/c_glib/arrow-glib/chunked-array.cpp
@@ -62,7 +62,7 @@ garrow_chunked_array_finalize(GObject *object)
 {
   auto priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(object);
 
-  priv->chunked_array = nullptr;
+  priv->chunked_array.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_chunked_array_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/chunked-array.cpp
+++ b/c_glib/arrow-glib/chunked-array.cpp
@@ -60,9 +60,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowChunkedArray,
 static void
 garrow_chunked_array_finalize(GObject *object)
 {
-  GArrowChunkedArrayPrivate *priv;
-
-  priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(object);
+  auto priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(object);
 
   priv->chunked_array = nullptr;
 
@@ -75,9 +73,7 @@ garrow_chunked_array_set_property(GObject *object,
                                   const GValue *value,
                                   GParamSpec *pspec)
 {
-  GArrowChunkedArrayPrivate *priv;
-
-  priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(object);
+  auto priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_CHUNKED_ARRAY:
@@ -354,8 +350,6 @@ garrow_chunked_array_new_raw(std::shared_ptr<arrow::ChunkedArray> *arrow_chunked
 std::shared_ptr<arrow::ChunkedArray>
 garrow_chunked_array_get_raw(GArrowChunkedArray *chunked_array)
 {
-  GArrowChunkedArrayPrivate *priv;
-
-  priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(chunked_array);
+  auto priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(chunked_array);
   return priv->chunked_array;
 }

--- a/c_glib/arrow-glib/chunked-array.cpp
+++ b/c_glib/arrow-glib/chunked-array.cpp
@@ -102,6 +102,8 @@ garrow_chunked_array_get_property(GObject *object,
 static void
 garrow_chunked_array_init(GArrowChunkedArray *object)
 {
+  auto priv = GARROW_CHUNKED_ARRAY_GET_PRIVATE(object);
+  new(&priv->chunked_array) std::shared_ptr<arrow::ChunkedArray>;
 }
 
 static void

--- a/c_glib/arrow-glib/decimal128.cpp
+++ b/c_glib/arrow-glib/decimal128.cpp
@@ -86,6 +86,8 @@ garrow_decimal128_set_property(GObject *object,
 static void
 garrow_decimal128_init(GArrowDecimal128 *object)
 {
+  auto priv = GARROW_DECIMAL128_GET_PRIVATE(object);
+  new(&priv->decimal128) std::shared_ptr<arrow::Decimal128>;
 }
 
 static void

--- a/c_glib/arrow-glib/decimal128.cpp
+++ b/c_glib/arrow-glib/decimal128.cpp
@@ -59,7 +59,7 @@ garrow_decimal128_finalize(GObject *object)
 {
   auto priv = GARROW_DECIMAL128_GET_PRIVATE(object);
 
-  priv->decimal128 = nullptr;
+  priv->decimal128.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_decimal128_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -102,6 +102,8 @@ garrow_field_set_property(GObject *object,
 static void
 garrow_field_init(GArrowField *object)
 {
+  auto priv = GARROW_FIELD_GET_PRIVATE(object);
+  new(&priv->field) std::shared_ptr<arrow::Field>;
 }
 
 static void

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -83,9 +83,7 @@ garrow_field_set_property(GObject *object,
                           const GValue *value,
                           GParamSpec *pspec)
 {
-  GArrowFieldPrivate *priv;
-
-  priv = GARROW_FIELD_GET_PRIVATE(object);
+  auto priv = GARROW_FIELD_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_FIELD:
@@ -262,8 +260,6 @@ garrow_field_new_raw(std::shared_ptr<arrow::Field> *arrow_field,
 std::shared_ptr<arrow::Field>
 garrow_field_get_raw(GArrowField *field)
 {
-  GArrowFieldPrivate *priv;
-
-  priv = GARROW_FIELD_GET_PRIVATE(field);
+  auto priv = GARROW_FIELD_GET_PRIVATE(field);
   return priv->field;
 }

--- a/c_glib/arrow-glib/field.cpp
+++ b/c_glib/arrow-glib/field.cpp
@@ -72,7 +72,7 @@ garrow_field_finalize(GObject *object)
 {
   auto priv = GARROW_FIELD_GET_PRIVATE(object);
 
-  priv->field = nullptr;
+  priv->field.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_field_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -208,6 +208,8 @@ garrow_input_stream_close(GInputStream *stream,
 static void
 garrow_input_stream_init(GArrowInputStream *object)
 {
+  auto priv = GARROW_INPUT_STREAM_GET_PRIVATE(object);
+  new(&priv->input_stream) std::shared_ptr<arrow::io::InputStream>;
 }
 
 static void

--- a/c_glib/arrow-glib/input-stream.cpp
+++ b/c_glib/arrow-glib/input-stream.cpp
@@ -117,7 +117,7 @@ garrow_input_stream_finalize(GObject *object)
 {
   auto priv = GARROW_INPUT_STREAM_GET_PRIVATE(object);
 
-  priv->input_stream = nullptr;
+  priv->input_stream.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_input_stream_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/output-stream.cpp
+++ b/c_glib/arrow-glib/output-stream.cpp
@@ -153,6 +153,8 @@ garrow_output_stream_get_property(GObject *object,
 static void
 garrow_output_stream_init(GArrowOutputStream *object)
 {
+  auto priv = GARROW_OUTPUT_STREAM_GET_PRIVATE(object);
+  new(&priv->output_stream) std::shared_ptr<arrow::io::OutputStream>;
 }
 
 static void

--- a/c_glib/arrow-glib/output-stream.cpp
+++ b/c_glib/arrow-glib/output-stream.cpp
@@ -113,7 +113,7 @@ garrow_output_stream_finalize(GObject *object)
 {
   auto priv = GARROW_OUTPUT_STREAM_GET_PRIVATE(object);
 
-  priv->output_stream = nullptr;
+  priv->output_stream.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_output_stream_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -124,6 +124,8 @@ garrow_record_batch_reader_get_property(GObject *object,
 static void
 garrow_record_batch_reader_init(GArrowRecordBatchReader *object)
 {
+  auto priv = GARROW_RECORD_BATCH_READER_GET_PRIVATE(object);
+  new(&priv->record_batch_reader) std::shared_ptr<arrow::ipc::RecordBatchReader>;
 }
 
 static void

--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -82,9 +82,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowRecordBatchReader,
 static void
 garrow_record_batch_reader_finalize(GObject *object)
 {
-  GArrowRecordBatchReaderPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_READER_GET_PRIVATE(object);
+  auto priv = GARROW_RECORD_BATCH_READER_GET_PRIVATE(object);
 
   priv->record_batch_reader = nullptr;
 
@@ -97,9 +95,7 @@ garrow_record_batch_reader_set_property(GObject *object,
                                         const GValue *value,
                                         GParamSpec *pspec)
 {
-  GArrowRecordBatchReaderPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_READER_GET_PRIVATE(object);
+  auto priv = GARROW_RECORD_BATCH_READER_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_RECORD_BATCH_READER:
@@ -334,9 +330,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowRecordBatchFileReader,
 static void
 garrow_record_batch_file_reader_finalize(GObject *object)
 {
-  GArrowRecordBatchFileReaderPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_FILE_READER_GET_PRIVATE(object);
+  auto priv = GARROW_RECORD_BATCH_FILE_READER_GET_PRIVATE(object);
 
   priv->record_batch_file_reader = nullptr;
 
@@ -349,9 +343,7 @@ garrow_record_batch_file_reader_set_property(GObject *object,
                                              const GValue *value,
                                              GParamSpec *pspec)
 {
-  GArrowRecordBatchFileReaderPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_FILE_READER_GET_PRIVATE(object);
+  auto priv = GARROW_RECORD_BATCH_FILE_READER_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_RECORD_BATCH_FILE_READER:
@@ -550,9 +542,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowFeatherFileReader,
 static void
 garrow_feather_file_reader_finalize(GObject *object)
 {
-  GArrowFeatherFileReaderPrivate *priv;
-
-  priv = GARROW_FEATHER_FILE_READER_GET_PRIVATE(object);
+  auto priv = GARROW_FEATHER_FILE_READER_GET_PRIVATE(object);
 
   delete priv->feather_table_reader;
 
@@ -565,9 +555,7 @@ garrow_feather_file_reader_set_property(GObject *object,
                                         const GValue *value,
                                         GParamSpec *pspec)
 {
-  GArrowFeatherFileReaderPrivate *priv;
-
-  priv = GARROW_FEATHER_FILE_READER_GET_PRIVATE(object);
+  auto priv = GARROW_FEATHER_FILE_READER_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_FEATHER_TABLE_READER:

--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -84,7 +84,7 @@ garrow_record_batch_reader_finalize(GObject *object)
 {
   auto priv = GARROW_RECORD_BATCH_READER_GET_PRIVATE(object);
 
-  priv->record_batch_reader = nullptr;
+  priv->record_batch_reader.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_record_batch_reader_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/record-batch.cpp
+++ b/c_glib/arrow-glib/record-batch.cpp
@@ -106,6 +106,8 @@ garrow_record_batch_get_property(GObject *object,
 static void
 garrow_record_batch_init(GArrowRecordBatch *object)
 {
+  auto priv = GARROW_RECORD_BATCH_GET_PRIVATE(object);
+  new(&priv->record_batch) std::shared_ptr<arrow::RecordBatch>;
 }
 
 static void

--- a/c_glib/arrow-glib/record-batch.cpp
+++ b/c_glib/arrow-glib/record-batch.cpp
@@ -66,7 +66,7 @@ garrow_record_batch_finalize(GObject *object)
 {
   auto priv = GARROW_RECORD_BATCH_GET_PRIVATE(object);
 
-  priv->record_batch = nullptr;
+  priv->record_batch.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_record_batch_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/record-batch.cpp
+++ b/c_glib/arrow-glib/record-batch.cpp
@@ -64,9 +64,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowRecordBatch,
 static void
 garrow_record_batch_finalize(GObject *object)
 {
-  GArrowRecordBatchPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_GET_PRIVATE(object);
+  auto priv = GARROW_RECORD_BATCH_GET_PRIVATE(object);
 
   priv->record_batch = nullptr;
 
@@ -79,9 +77,7 @@ garrow_record_batch_set_property(GObject *object,
                           const GValue *value,
                           GParamSpec *pspec)
 {
-  GArrowRecordBatchPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_GET_PRIVATE(object);
+  auto priv = GARROW_RECORD_BATCH_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_RECORD_BATCH:
@@ -398,8 +394,6 @@ garrow_record_batch_new_raw(std::shared_ptr<arrow::RecordBatch> *arrow_record_ba
 std::shared_ptr<arrow::RecordBatch>
 garrow_record_batch_get_raw(GArrowRecordBatch *record_batch)
 {
-  GArrowRecordBatchPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_GET_PRIVATE(record_batch);
+  auto priv = GARROW_RECORD_BATCH_GET_PRIVATE(record_batch);
   return priv->record_batch;
 }

--- a/c_glib/arrow-glib/schema.cpp
+++ b/c_glib/arrow-glib/schema.cpp
@@ -57,9 +57,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowSchema,
 static void
 garrow_schema_finalize(GObject *object)
 {
-  GArrowSchemaPrivate *priv;
-
-  priv = GARROW_SCHEMA_GET_PRIVATE(object);
+  auto priv = GARROW_SCHEMA_GET_PRIVATE(object);
 
   priv->schema = nullptr;
 
@@ -72,9 +70,7 @@ garrow_schema_set_property(GObject *object,
                            const GValue *value,
                            GParamSpec *pspec)
 {
-  GArrowSchemaPrivate *priv;
-
-  priv = GARROW_SCHEMA_GET_PRIVATE(object);
+  auto priv = GARROW_SCHEMA_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_SCHEMA:
@@ -360,8 +356,6 @@ garrow_schema_new_raw(std::shared_ptr<arrow::Schema> *arrow_schema)
 std::shared_ptr<arrow::Schema>
 garrow_schema_get_raw(GArrowSchema *schema)
 {
-  GArrowSchemaPrivate *priv;
-
-  priv = GARROW_SCHEMA_GET_PRIVATE(schema);
+  auto priv = GARROW_SCHEMA_GET_PRIVATE(schema);
   return priv->schema;
 }

--- a/c_glib/arrow-glib/schema.cpp
+++ b/c_glib/arrow-glib/schema.cpp
@@ -59,7 +59,7 @@ garrow_schema_finalize(GObject *object)
 {
   auto priv = GARROW_SCHEMA_GET_PRIVATE(object);
 
-  priv->schema = nullptr;
+  priv->schema.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_schema_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/schema.cpp
+++ b/c_glib/arrow-glib/schema.cpp
@@ -99,6 +99,8 @@ garrow_schema_get_property(GObject *object,
 static void
 garrow_schema_init(GArrowSchema *object)
 {
+  auto priv = GARROW_SCHEMA_GET_PRIVATE(object);
+  new(&priv->schema) std::shared_ptr<arrow::Schema>;
 }
 
 static void

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -65,7 +65,7 @@ garrow_table_dispose(GObject *object)
 {
   auto priv = GARROW_TABLE_GET_PRIVATE(object);
 
-  priv->table = nullptr;
+  priv->table.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_table_parent_class)->dispose(object);
 }

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -105,6 +105,8 @@ garrow_table_get_property(GObject *object,
 static void
 garrow_table_init(GArrowTable *object)
 {
+  auto priv = GARROW_TABLE_GET_PRIVATE(object);
+  new(&priv->table) std::shared_ptr<arrow::Table>;
 }
 
 static void

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -63,9 +63,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowTable,
 static void
 garrow_table_dispose(GObject *object)
 {
-  GArrowTablePrivate *priv;
-
-  priv = GARROW_TABLE_GET_PRIVATE(object);
+  auto priv = GARROW_TABLE_GET_PRIVATE(object);
 
   priv->table = nullptr;
 
@@ -78,9 +76,7 @@ garrow_table_set_property(GObject *object,
                           const GValue *value,
                           GParamSpec *pspec)
 {
-  GArrowTablePrivate *priv;
-
-  priv = GARROW_TABLE_GET_PRIVATE(object);
+  auto priv = GARROW_TABLE_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_TABLE:
@@ -648,8 +644,6 @@ garrow_table_new_raw(std::shared_ptr<arrow::Table> *arrow_table)
 std::shared_ptr<arrow::Table>
 garrow_table_get_raw(GArrowTable *table)
 {
-  GArrowTablePrivate *priv;
-
-  priv = GARROW_TABLE_GET_PRIVATE(table);
+  auto priv = GARROW_TABLE_GET_PRIVATE(table);
   return priv->table;
 }

--- a/c_glib/arrow-glib/tensor.cpp
+++ b/c_glib/arrow-glib/tensor.cpp
@@ -122,6 +122,8 @@ garrow_tensor_get_property(GObject *object,
 static void
 garrow_tensor_init(GArrowTensor *object)
 {
+  auto priv = GARROW_TENSOR_GET_PRIVATE(object);
+  new(&priv->tensor) std::shared_ptr<arrow::Tensor>;
 }
 
 static void

--- a/c_glib/arrow-glib/tensor.cpp
+++ b/c_glib/arrow-glib/tensor.cpp
@@ -74,7 +74,7 @@ garrow_tensor_finalize(GObject *object)
 {
   auto priv = GARROW_TENSOR_GET_PRIVATE(object);
 
-  priv->tensor = nullptr;
+  priv->tensor.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_tensor_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/writer.cpp
+++ b/c_glib/arrow-glib/writer.cpp
@@ -75,7 +75,7 @@ garrow_record_batch_writer_finalize(GObject *object)
 {
   auto priv = GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(object);
 
-  priv->record_batch_writer = nullptr;
+  priv->record_batch_writer.~shared_ptr();
 
   G_OBJECT_CLASS(garrow_record_batch_writer_parent_class)->finalize(object);
 }

--- a/c_glib/arrow-glib/writer.cpp
+++ b/c_glib/arrow-glib/writer.cpp
@@ -73,9 +73,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowRecordBatchWriter,
 static void
 garrow_record_batch_writer_finalize(GObject *object)
 {
-  GArrowRecordBatchWriterPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(object);
+  auto priv = GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(object);
 
   priv->record_batch_writer = nullptr;
 
@@ -88,9 +86,7 @@ garrow_record_batch_writer_set_property(GObject *object,
                                         const GValue *value,
                                         GParamSpec *pspec)
 {
-  GArrowRecordBatchWriterPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(object);
+  auto priv = GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_RECORD_BATCH_WRITER:
@@ -325,9 +321,7 @@ G_DEFINE_TYPE_WITH_PRIVATE(GArrowFeatherFileWriter,
 static void
 garrow_feather_file_writer_finalize(GObject *object)
 {
-  GArrowFeatherFileWriterPrivate *priv;
-
-  priv = GARROW_FEATHER_FILE_WRITER_GET_PRIVATE(object);
+  auto priv = GARROW_FEATHER_FILE_WRITER_GET_PRIVATE(object);
 
   delete priv->feather_table_writer;
 
@@ -340,9 +334,7 @@ garrow_feather_file_writer_set_property(GObject *object,
                                         const GValue *value,
                                         GParamSpec *pspec)
 {
-  GArrowFeatherFileWriterPrivate *priv;
-
-  priv = GARROW_FEATHER_FILE_WRITER_GET_PRIVATE(object);
+  auto priv = GARROW_FEATHER_FILE_WRITER_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_FEATHER_TABLE_WRITER:
@@ -530,9 +522,7 @@ garrow_record_batch_writer_new_raw(std::shared_ptr<arrow::ipc::RecordBatchWriter
 std::shared_ptr<arrow::ipc::RecordBatchWriter>
 garrow_record_batch_writer_get_raw(GArrowRecordBatchWriter *writer)
 {
-  GArrowRecordBatchWriterPrivate *priv;
-
-  priv = GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(writer);
+  auto priv = GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(writer);
   return priv->record_batch_writer;
 }
 
@@ -572,8 +562,6 @@ garrow_feather_file_writer_new_raw(arrow::ipc::feather::TableWriter *arrow_write
 arrow::ipc::feather::TableWriter *
 garrow_feather_file_writer_get_raw(GArrowFeatherFileWriter *writer)
 {
-  GArrowFeatherFileWriterPrivate *priv;
-
-  priv = GARROW_FEATHER_FILE_WRITER_GET_PRIVATE(writer);
+  auto priv = GARROW_FEATHER_FILE_WRITER_GET_PRIVATE(writer);
   return priv->feather_table_writer;
 }

--- a/c_glib/arrow-glib/writer.cpp
+++ b/c_glib/arrow-glib/writer.cpp
@@ -115,6 +115,8 @@ garrow_record_batch_writer_get_property(GObject *object,
 static void
 garrow_record_batch_writer_init(GArrowRecordBatchWriter *object)
 {
+  auto priv = GARROW_RECORD_BATCH_WRITER_GET_PRIVATE(object);
+  new(&priv->record_batch_writer) std::shared_ptr<arrow::ipc::RecordBatchWriter>;
 }
 
 static void

--- a/c_glib/gandiva-glib/expression.cpp
+++ b/c_glib/gandiva-glib/expression.cpp
@@ -83,7 +83,7 @@ ggandiva_expression_finalize(GObject *object)
 {
   auto priv = GGANDIVA_EXPRESSION_GET_PRIVATE(object);
 
-  priv->expression = nullptr;
+  priv->expression.~shared_ptr();
 
   G_OBJECT_CLASS(ggandiva_expression_parent_class)->finalize(object);
 }

--- a/c_glib/gandiva-glib/expression.cpp
+++ b/c_glib/gandiva-glib/expression.cpp
@@ -137,6 +137,8 @@ ggandiva_expression_get_property(GObject *object,
 static void
 ggandiva_expression_init(GGandivaExpression *object)
 {
+  auto priv = GGANDIVA_EXPRESSION_GET_PRIVATE(object);
+  new(&priv->expression) std::shared_ptr<gandiva::Expression>;
 }
 
 static void

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -191,6 +191,8 @@ ggandiva_node_get_property(GObject *object,
 static void
 ggandiva_node_init(GGandivaNode *object)
 {
+  auto priv = GGANDIVA_NODE_GET_PRIVATE(object);
+  new(&priv->node) std::shared_ptr<gandiva::Node>;
 }
 
 static void

--- a/c_glib/gandiva-glib/node.cpp
+++ b/c_glib/gandiva-glib/node.cpp
@@ -143,7 +143,7 @@ ggandiva_node_finalize(GObject *object)
 {
   auto priv = GGANDIVA_NODE_GET_PRIVATE(object);
 
-  priv->node = nullptr;
+  priv->node.~shared_ptr();
 
   G_OBJECT_CLASS(ggandiva_node_parent_class)->finalize(object);
 }

--- a/c_glib/gandiva-glib/projector.cpp
+++ b/c_glib/gandiva-glib/projector.cpp
@@ -65,7 +65,7 @@ ggandiva_projector_finalize(GObject *object)
 {
   auto priv = GGANDIVA_PROJECTOR_GET_PRIVATE(object);
 
-  priv->projector = nullptr;
+  priv->projector.~shared_ptr();
 
   G_OBJECT_CLASS(ggandiva_projector_parent_class)->finalize(object);
 }

--- a/c_glib/gandiva-glib/projector.cpp
+++ b/c_glib/gandiva-glib/projector.cpp
@@ -92,6 +92,8 @@ ggandiva_projector_set_property(GObject *object,
 static void
 ggandiva_projector_init(GGandivaProjector *object)
 {
+  auto priv = GGANDIVA_PROJECTOR_GET_PRIVATE(object);
+  new(&priv->projector) std::shared_ptr<gandiva::Projector>;
 }
 
 static void

--- a/c_glib/parquet-glib/arrow-file-reader.cpp
+++ b/c_glib/parquet-glib/arrow-file-reader.cpp
@@ -117,7 +117,7 @@ gparquet_arrow_file_reader_class_init(GParquetArrowFileReaderClass *klass)
 
   spec = g_param_spec_pointer("arrow-file-reader",
                               "ArrowFileReader",
-                              "The raw std::shared<parquet::arrow::FileReader> *",
+                              "The raw parquet::arrow::FileReader *",
                               static_cast<GParamFlags>(G_PARAM_WRITABLE |
                                                        G_PARAM_CONSTRUCT_ONLY));
   g_object_class_install_property(gobject_class, PROP_ARROW_FILE_READER, spec);

--- a/c_glib/parquet-glib/arrow-file-writer.cpp
+++ b/c_glib/parquet-glib/arrow-file-writer.cpp
@@ -58,7 +58,7 @@ gparquet_writer_properties_finalize(GObject *object)
 {
   auto priv = GPARQUET_WRITER_PROPERTIES_GET_PRIVATE(object);
 
-  priv->properties = nullptr;
+  priv->properties.~shared_ptr();
   delete priv->builder;
 
   G_OBJECT_CLASS(gparquet_writer_properties_parent_class)->finalize(object);

--- a/c_glib/parquet-glib/arrow-file-writer.cpp
+++ b/c_glib/parquet-glib/arrow-file-writer.cpp
@@ -68,6 +68,7 @@ static void
 gparquet_writer_properties_init(GParquetWriterProperties *object)
 {
   auto priv = GPARQUET_WRITER_PROPERTIES_GET_PRIVATE(object);
+  new(&priv->properties) std::shared_ptr<parquet::WriterProperties>;
   priv->builder = new parquet::WriterProperties::Builder();
   priv->changed = TRUE;
 }

--- a/c_glib/plasma-glib/object.cpp
+++ b/c_glib/plasma-glib/object.cpp
@@ -193,8 +193,8 @@ gplasma_object_finalize(GObject *object)
 {
   auto priv = GPLASMA_OBJECT_GET_PRIVATE(object);
 
-  priv->raw_data = nullptr;
-  priv->raw_metadata = nullptr;
+  priv->raw_data.~shared_ptr();
+  priv->raw_metadata.~shared_ptr();
 
   G_OBJECT_CLASS(gplasma_object_parent_class)->finalize(object);
 }

--- a/c_glib/plasma-glib/object.cpp
+++ b/c_glib/plasma-glib/object.cpp
@@ -277,6 +277,9 @@ gplasma_object_get_property(GObject *object,
 static void
 gplasma_object_init(GPlasmaObject *object)
 {
+  auto priv = GPLASMA_OBJECT_GET_PRIVATE(object);
+  new(&priv->raw_data) std::shared_ptr<arrow::Buffer>;
+  new(&priv->raw_metadata) std::shared_ptr<arrow::Buffer>;
 }
 
 static void


### PR DESCRIPTION
I inserted placement new for all shared pointer fields.