### PR TITLE
ARROW-7872: [C++/Python] Support conversion of list of structs to pandas

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -152,6 +152,7 @@ static inline bool ListTypeSupported(const DataType& type) {
     case Type::STRING:
     case Type::DATE32:
     case Type::DATE64:
+    case Type::STRUCT:
     case Type::TIME32:
     case Type::TIME64:
     case Type::TIMESTAMP:

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1953,6 +1953,22 @@ class TestConvertListTypes:
 
         _check_pandas_roundtrip(df, expected_schema=expected_schema)
 
+    def test_to_list_of_structs_pandas(self):
+        ints = pa.array([1, 2, 3], pa.int32())
+        strings = pa.array([['a', 'b'], ['c', 'd'], ['e', 'f']],
+                           pa.list_(pa.string()))
+        structs = pa.StructArray.from_arrays([ints, strings], ['f1', 'f2'])
+        data = pa.ListArray.from_arrays([0, 1, 3], structs)
+
+        expected = pd.Series([
+            [{'f1': 1, 'f2': ['a', 'b']}],
+            [{'f1': 2, 'f2': ['c', 'd']},
+             {'f1': 3, 'f2': ['e', 'f']}]
+        ])
+
+        series = pd.Series(data.to_pandas())
+        tm.assert_series_equal(series, expected)
+
     @pytest.mark.parametrize('t,data,expected', [
         (
             pa.int64,


### PR DESCRIPTION
It appears that all the code exists to to the conversion but struct wasn't included in the list.  Is there a way to ensure, this doesn't cause a python memory leak or some other weird gotcha?