### PR TITLE
PARQUET-1810: [C++] Fix undefined behaviour on invalid enum values (OSS-Fuzz)

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -211,12 +211,12 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
         }
       }
     }
-    for (auto encoding : column_metadata_->encodings) {
-      encodings_.push_back(FromThrift(encoding));
+    for (const auto& encoding : column_metadata_->encodings) {
+      encodings_.push_back(LoadEnumSafe(&encoding));
     }
     for (auto encoding_stats : column_metadata_->encoding_stats) {
-      encoding_stats_.push_back({FromThrift(encoding_stats.page_type),
-                                 FromThrift(encoding_stats.encoding),
+      encoding_stats_.push_back({LoadEnumSafe(&encoding_stats.page_type),
+                                 LoadEnumSafe(&encoding_stats.encoding),
                                  encoding_stats.count});
     }
     possible_stats_ = nullptr;
@@ -225,7 +225,7 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
   inline int64_t file_offset() const { return column_->file_offset; }
   inline const std::string& file_path() const { return column_->file_path; }
 
-  inline Type::type type() const { return FromThrift(column_metadata_->type); }
+  inline Type::type type() const { return LoadEnumSafe(&column_metadata_->type); }
 
   inline int64_t num_values() const { return column_metadata_->num_values; }
 
@@ -257,7 +257,7 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
   }
 
   inline Compression::type compression() const {
-    return FromThrift(column_metadata_->codec);
+    return LoadEnumSafe(&column_metadata_->codec);
   }
 
   const std::vector<Encoding::type>& encodings() const { return encodings_; }

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -400,70 +400,18 @@ std::unique_ptr<Node> GroupNode::FromParquet(const void* opaque_element,
   if (element->__isset.logicalType) {
     // updated writer with logical type present
     group_node = std::unique_ptr<GroupNode>(
-        new GroupNode(element->name, FromThrift(element->repetition_type), fields,
+        new GroupNode(element->name, LoadEnumSafe(&element->repetition_type), fields,
                       LogicalType::FromThrift(element->logicalType), field_id));
   } else {
     group_node = std::unique_ptr<GroupNode>(new GroupNode(
-        element->name, FromThrift(element->repetition_type), fields,
-        (element->__isset.converted_type ? FromThrift(element->converted_type)
+        element->name, LoadEnumSafe(&element->repetition_type), fields,
+        (element->__isset.converted_type ? LoadEnumSafe(&element->converted_type)
                                          : ConvertedType::NONE),
         field_id));
   }
 
   return std::unique_ptr<Node>(group_node.release());
 }
-
-namespace {
-
-// If the parquet file is corrupted it is possible the type value decoded
-// will not be in the range of format::Type::type, which is undefined behavior.
-// This method prevents this by loading the value as the underlying type and checking
-// to make sure it is in range.
-template <typename ApiType>
-struct SafeLoader {
-  using ApiTypeEnum = typename ApiType::type;
-  using ApiTypeRawEnum = typename std::underlying_type<ApiTypeEnum>::type;
-
-  template <typename ThriftType>
-  inline static ApiTypeRawEnum LoadRaw(ThriftType* in) {
-    static_assert(
-        sizeof(ApiTypeEnum) >= sizeof(ThriftType),
-        "parquet type should always be the same size of larger then thrift type");
-    typename std::underlying_type<ThriftType>::type raw_value;
-    memcpy(&raw_value, in, sizeof(ThriftType));
-    return static_cast<ApiTypeRawEnum>(raw_value);
-  }
-
-  template <typename ThriftType, bool IsUnsigned = true>
-  inline static ApiTypeEnum LoadChecked(
-      typename std::enable_if<IsUnsigned, ThriftType>::type* in) {
-    auto raw_value = LoadRaw(in);
-    if (ARROW_PREDICT_FALSE(raw_value >=
-                            static_cast<ApiTypeRawEnum>(ApiType::UNDEFINED))) {
-      return ApiType::UNDEFINED;
-    }
-    return FromThrift(static_cast<ThriftType>(raw_value));
-  }
-
-  template <typename ThriftType, bool IsUnsigned = false>
-  inline static ApiTypeEnum LoadChecked(
-      typename std::enable_if<!IsUnsigned, ThriftType>::type* in) {
-    auto raw_value = LoadRaw(in);
-    if (ARROW_PREDICT_FALSE(raw_value >=
-                                static_cast<ApiTypeRawEnum>(ApiType::UNDEFINED) ||
-                            raw_value < 0)) {
-      return ApiType::UNDEFINED;
-    }
-    return FromThrift(static_cast<ThriftType>(raw_value));
-  }
-
-  template <typename ThriftType>
-  inline static ApiTypeEnum Load(ThriftType* in) {
-    return LoadChecked<ThriftType, std::is_unsigned<ApiTypeRawEnum>::value>(in);
-  }
-};
-
-}  // namespace
 
 std::unique_ptr<Node> PrimitiveNode::FromParquet(const void* opaque_element,
                                                  int field_id) {
@@ -477,23 +425,21 @@ std::unique_ptr<Node> PrimitiveNode::FromParquet(const void* opaque_element,
   std::unique_ptr<PrimitiveNode> primitive_node;
   if (element->__isset.logicalType) {
     // updated writer with logical type present
-    primitive_node = std::unique_ptr<PrimitiveNode>(new PrimitiveNode(
-        element->name, SafeLoader<Repetition>::Load(&(element->repetition_type)),
-        LogicalType::FromThrift(element->logicalType),
-        SafeLoader<Type>::Load(&(element->type)), element->type_length, field_id));
+    primitive_node = std::unique_ptr<PrimitiveNode>(
+        new PrimitiveNode(element->name, LoadEnumSafe(&element->repetition_type),
+                          LogicalType::FromThrift(element->logicalType),
+                          LoadEnumSafe(&element->type), element->type_length, field_id));
   } else if (element->__isset.converted_type) {
     // legacy writer with logical type present
     primitive_node = std::unique_ptr<PrimitiveNode>(new PrimitiveNode(
-        element->name, SafeLoader<Repetition>::Load(&(element->repetition_type)),
-        SafeLoader<Type>::Load(&(element->type)),
-        SafeLoader<ConvertedType>::Load(&(element->converted_type)), element->type_length,
-        element->precision, element->scale, field_id));
+        element->name, LoadEnumSafe(&element->repetition_type),
+        LoadEnumSafe(&element->type), LoadEnumSafe(&element->converted_type),
+        element->type_length, element->precision, element->scale, field_id));
   } else {
     // logical type not present
     primitive_node = std::unique_ptr<PrimitiveNode>(new PrimitiveNode(
-        element->name, SafeLoader<Repetition>::Load(&(element->repetition_type)),
-        NoLogicalType::Make(), SafeLoader<Type>::Load(&(element->type)),
-        element->type_length, field_id));
+        element->name, LoadEnumSafe(&element->repetition_type), NoLogicalType::Make(),
+        LoadEnumSafe(&element->type), element->type_length, field_id));
   }
 
   // Return as unique_ptr to the base type

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -453,6 +453,8 @@ struct Encoding {
     DELTA_BYTE_ARRAY = 7,
     RLE_DICTIONARY = 8,
     BYTE_STREAM_SPLIT = 9,
+    // Should always be last element (except UNKNOWN)
+    UNDEFINED = 10,
     UNKNOWN = 999
   };
 };
@@ -484,7 +486,14 @@ struct EncryptionAlgorithm {
 
 // parquet::PageType
 struct PageType {
-  enum type { DATA_PAGE, INDEX_PAGE, DICTIONARY_PAGE, DATA_PAGE_V2 };
+  enum type {
+    DATA_PAGE,
+    INDEX_PAGE,
+    DICTIONARY_PAGE,
+    DATA_PAGE_V2,
+    // Should always be last element
+    UNDEFINED
+  };
 };
 
 class ColumnOrder {


### PR DESCRIPTION
Should fix the following issues:
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20686
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20696
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20733
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20849
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21010
