### PR TITLE
ARROW-8009: [Java] Fix the hash code methods for BitVector

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -22,6 +22,7 @@ import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.impl.BitReaderImpl;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -41,6 +42,11 @@ import io.netty.buffer.ArrowBuf;
  * to a single bit in the underlying data stream backing the vector.
  */
 public final class BitVector extends BaseFixedWidthVector {
+
+  private static final int HASH_CODE_FOR_ZERO = 17;
+
+  private static final int HASH_CODE_FOR_ONE = 19;
+
   private final FieldReader reader;
 
   /**
@@ -471,6 +477,24 @@ public final class BitVector extends BaseFixedWidthVector {
   @Override
   public ArrowBufPointer getDataPointer(int index, ArrowBufPointer reuse) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int hashCode(int index) {
+    if (isNull(index)) {
+      return ArrowBufPointer.NULL_HASH_CODE;
+    } else {
+      if (get(index) == 0) {
+        return HASH_CODE_FOR_ZERO;
+      } else {
+        return HASH_CODE_FOR_ONE;
+      }
+    }
+  }
+
+  @Override
+  public int hashCode(int index, ArrowBufHasher hasher) {
+    return hashCode(index);
   }
 
   /**


### PR DESCRIPTION
The current hash code methods of BitVector are based on implementations in BaseFixedWidthVector, which rely on the type width of the vector.
For BitVector, the type width is 0, so the underlying data is not actually used when computing the hash code. That means, the hash code will always be 0, no matter if the underlying data is null or not, and no matter if the underlying bit is 0 or 1.

We fix this by overriding the methods in BitVector.