### PR TITLE
ARROW-8014: [C++] Provide CMake targets exercising tests with a label

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -659,7 +659,7 @@ function(ADD_TEST_CASE REL_TEST_NAME)
 
   foreach(LABEL ${ARG_LABELS})
     # ensure there is a cmake target which exercises tests with this LABEL
-    set(LABEL_TEST_NAME "test-label-${LABEL}")
+    set(LABEL_TEST_NAME "test-${LABEL}")
     if(NOT TARGET ${LABEL_TEST_NAME})
       add_custom_target(${LABEL_TEST_NAME}
                         ctest

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -657,6 +657,21 @@ function(ADD_TEST_CASE REL_TEST_NAME)
     set(ARG_LABELS unittest)
   endif()
 
+  foreach(LABEL ${ARG_LABELS})
+    # ensure there is a cmake target which exercises tests with this LABEL
+    set(LABEL_TEST_NAME "test-label-${LABEL}")
+    if(NOT TARGET ${LABEL_TEST_NAME})
+      add_custom_target(${LABEL_TEST_NAME}
+                        ctest
+                        -L
+                        "${LABEL}"
+                        --output-on-failure
+                        USES_TERMINAL)
+    endif()
+    # ensure the test is (re)built before the LABEL test runs
+    add_dependencies(${LABEL_TEST_NAME} ${TEST_NAME})
+  endforeach()
+
   set_property(TEST ${TEST_NAME} APPEND PROPERTY LABELS ${ARG_LABELS})
 endfunction()
 

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -45,8 +45,6 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
 
   if(ARG_LABELS)
     set(LABELS ${ARG_LABELS})
-  else()
-    set(LABELS "arrow-tests")
   endif()
 
   # Because of https://gitlab.kitware.com/cmake/cmake/issues/20289,


### PR DESCRIPTION
To run a subset of the tests, use:
```shell-session
$ ninja -C ~/arrow/cpp/debug-build test-arrow_dataset
```
