### PR TITLE
ARROW-7802: [C++][Python]  Support LargeBinary and LargeString in the hash kernel

### DIFF
--- a/cpp/src/arrow/array/dict_internal.h
+++ b/cpp/src/arrow/array/dict_internal.h
@@ -125,16 +125,17 @@ struct DictionaryTraits<T, enable_if_base_binary<T>> {
                                        const MemoTableType& memo_table,
                                        int64_t start_offset,
                                        std::shared_ptr<ArrayData>* out) {
+    using offset_type = typename T::offset_type;
     std::shared_ptr<Buffer> dict_offsets;
     std::shared_ptr<Buffer> dict_data;
 
     // Create the offsets buffer
     auto dict_length = static_cast<int64_t>(memo_table.size() - start_offset);
     if (dict_length > 0) {
-      RETURN_NOT_OK(AllocateBuffer(
-          pool, TypeTraits<Int32Type>::bytes_required(dict_length + 1), &dict_offsets));
-      auto raw_offsets = reinterpret_cast<int32_t*>(dict_offsets->mutable_data());
-      memo_table.CopyOffsets(static_cast<int32_t>(start_offset), raw_offsets);
+      RETURN_NOT_OK(
+          AllocateBuffer(pool, sizeof(offset_type) * (dict_length + 1), &dict_offsets));
+      auto raw_offsets = reinterpret_cast<offset_type*>(dict_offsets->mutable_data());
+      memo_table.CopyOffsets(static_cast<offset_type>(start_offset), raw_offsets);
     }
 
     // Create the data buffer

--- a/cpp/src/arrow/array/dict_internal.h
+++ b/cpp/src/arrow/array/dict_internal.h
@@ -135,7 +135,7 @@ struct DictionaryTraits<T, enable_if_base_binary<T>> {
       RETURN_NOT_OK(
           AllocateBuffer(pool, sizeof(offset_type) * (dict_length + 1), &dict_offsets));
       auto raw_offsets = reinterpret_cast<offset_type*>(dict_offsets->mutable_data());
-      memo_table.CopyOffsets(static_cast<offset_type>(start_offset), raw_offsets);
+      memo_table.CopyOffsets(static_cast<int32_t>(start_offset), raw_offsets);
     }
 
     // Create the data buffer

--- a/cpp/src/arrow/compute/kernels/hash.cc
+++ b/cpp/src/arrow/compute/kernels/hash.cc
@@ -460,7 +460,9 @@ struct HashKernelTraits<Type, Action, with_error_status, with_memo_visit_null,
   PROCESS(Time64Type)                         \
   PROCESS(TimestampType)                      \
   PROCESS(BinaryType)                         \
+  PROCESS(LargeBinaryType)                    \
   PROCESS(StringType)                         \
+  PROCESS(LargeStringType)                    \
   PROCESS(FixedSizeBinaryType)                \
   PROCESS(Decimal128Type)
 

--- a/cpp/src/arrow/compute/kernels/hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_test.cc
@@ -618,7 +618,6 @@ TEST_F(TestHashKernel, ChunkedArrayZeroChunk) {
 
   AssertChunkedEqual(*std::make_shared<ChunkedArray>(ArrayVector{}, dict_type),
                      *result_datum.chunked_array());
-  std::unique_ptr<int> a;
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_test.cc
@@ -699,6 +699,7 @@ TEST_F(TestHashKernel, ChunkedArrayZeroChunk) {
 
   AssertChunkedEqual(*std::make_shared<ChunkedArray>(ArrayVector{}, dict_type),
                      *result_datum.chunked_array());
+  std::unique_ptr<int> a;
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/util/hashing_test.cc
+++ b/cpp/src/arrow/util/hashing_test.cc
@@ -380,7 +380,7 @@ TEST(BinaryMemoTable, Basics) {
   F += '\0';
   F += "trailing";
 
-  BinaryMemoTable table(default_memory_pool(), 0);
+  BinaryMemoTable<BinaryBuilder> table(default_memory_pool(), 0);
   ASSERT_EQ(table.size(), 0);
   AssertGet(table, A, kKeyNotFound);
   AssertGetNull(table, kKeyNotFound);
@@ -458,7 +458,7 @@ TEST(BinaryMemoTable, Stress) {
 
   const auto values = MakeDistinctStrings(n_values);
 
-  BinaryMemoTable table(default_memory_pool(), 0);
+  BinaryMemoTable<BinaryBuilder> table(default_memory_pool(), 0);
   std::unordered_map<std::string, int32_t> map;
 
   for (int32_t i = 0; i < n_repeats; ++i) {

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -436,12 +436,12 @@ struct DictEncoderTraits {
 
 template <>
 struct DictEncoderTraits<ByteArrayType> {
-  using MemoTableType = arrow::internal::BinaryMemoTable;
+  using MemoTableType = arrow::internal::BinaryMemoTable<arrow::BinaryBuilder>;
 };
 
 template <>
 struct DictEncoderTraits<FLBAType> {
-  using MemoTableType = arrow::internal::BinaryMemoTable;
+  using MemoTableType = arrow::internal::BinaryMemoTable<arrow::BinaryBuilder>;
 };
 
 // Initially 1024 elements

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -727,6 +727,21 @@ cdef class Array(_PandasConvertible):
 
         return wrap_datum(out)
 
+    def value_counts(self):
+        """
+        Compute counts of unique elements in array
+
+        Returns
+        -------
+        An array of  <input type "Values", int64_t "Counts"> structs
+        """
+        cdef shared_ptr[CArray] result
+
+        with nogil:
+            check_status(ValueCounts(_context(), CDatum(self.sp_array),
+                                     &result))
+        return pyarrow_wrap_array(result)
+
     @staticmethod
     def from_pandas(obj, mask=None, type=None, bint safe=True,
                     MemoryPool memory_pool=None):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -729,7 +729,7 @@ cdef class Array(_PandasConvertible):
 
     def value_counts(self):
         """
-        Compute counts of unique elements in array
+        Compute counts of unique elements in array.
 
         Returns
         -------

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1446,6 +1446,9 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
     CStatus DictionaryEncode(CFunctionContext* context, const CDatum& value,
                              CDatum* out)
 
+    CStatus ValueCounts(CFunctionContext* context, const CDatum& value,
+                        shared_ptr[CArray]* out)
+
     CStatus Sum(CFunctionContext* context, const CDatum& value, CDatum* out)
 
     CStatus Take(CFunctionContext* context, const CDatum& values,

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -299,6 +299,21 @@ cdef class ChunkedArray(_PandasConvertible):
 
         return pyarrow_wrap_array(result)
 
+    def value_counts(self):
+        """
+        Compute counts of unique elements in array
+
+        Returns
+        -------
+        An array of  <input type "Values", int64_t "Counts"> structs
+        """
+        cdef shared_ptr[CArray] result
+
+        with nogil:
+            check_status(ValueCounts(_context(), CDatum(self.sp_chunked_array),
+                                     &result))
+        return pyarrow_wrap_array(result)
+
     def slice(self, offset=0, length=None):
         """
         Compute zero-copy slice of this ChunkedArray

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -301,7 +301,7 @@ cdef class ChunkedArray(_PandasConvertible):
 
     def value_counts(self):
         """
-        Compute counts of unique elements in array
+        Compute counts of unique elements in array.
 
         Returns
         -------

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1083,12 +1083,13 @@ def test_value_counts_simple():
          pa.array([2, 1, 1], type=pa.int64())),
     ]
     for arr, expected_values, expected_counts in cases:
-      for arr_in in (arr, pa.chunked_array([arr])):
-        result = arr_in.value_counts()
-        assert result.type.equals(
-            pa.struct([pa.field("values", arr.type), pa.field("counts", pa.int64())]))
-        assert result.field("values").equals(expected_values)
-        assert result.field("counts").equals(expected_counts)
+        for arr_in in (arr, pa.chunked_array([arr])):
+            result = arr_in.value_counts()
+            assert result.type.equals(
+                pa.struct([pa.field("values", arr.type),
+                           pa.field("counts", pa.int64())]))
+            assert result.field("values").equals(expected_values)
+            assert result.field("counts").equals(expected_counts)
 
 
 def test_dictionary_encode_simple():
@@ -1127,7 +1128,8 @@ def test_dictionary_encode_sliced():
          pa.DictionaryArray.from_arrays(
              pa.array([0, 1, 0], type='int32'),
              ['foo', 'bar'])),
-        (pa.array([None, 'foo', 'bar', 'foo', 'xyzzy'], type=pa.large_string())[1:-1],
+        (pa.array([None, 'foo', 'bar', 'foo', 'xyzzy'],
+                  type=pa.large_string())[1:-1],
          pa.DictionaryArray.from_arrays(
              pa.array([0, 1, 0], type='int32'),
              pa.array(['foo', 'bar'], type=pa.large_string()))),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1059,13 +1059,36 @@ def test_unique_simple():
     cases = [
         (pa.array([1, 2, 3, 1, 2, 3]), pa.array([1, 2, 3])),
         (pa.array(['foo', None, 'bar', 'foo']),
-         pa.array(['foo', None, 'bar']))
+         pa.array(['foo', None, 'bar'])),
+        (pa.array(['foo', None, 'bar', 'foo'], pa.large_binary()),
+         pa.array(['foo', None, 'bar'], pa.large_binary())),
     ]
     for arr, expected in cases:
         result = arr.unique()
         assert result.equals(expected)
         result = pa.chunked_array([arr]).unique()
         assert result.equals(expected)
+
+
+def test_value_counts_simple():
+    cases = [
+        (pa.array([1, 2, 3, 1, 2, 3]),
+         pa.array([1, 2, 3]),
+         pa.array([2, 2, 2], type=pa.int64())),
+        (pa.array(['foo', None, 'bar', 'foo']),
+         pa.array(['foo', None, 'bar']),
+         pa.array([2, 1, 1], type=pa.int64())),
+        (pa.array(['foo', None, 'bar', 'foo'], pa.large_binary()),
+         pa.array(['foo', None, 'bar'], pa.large_binary()),
+         pa.array([2, 1, 1], type=pa.int64())),
+    ]
+    for arr, expected_values, expected_counts in cases:
+      for arr_in in (arr, pa.chunked_array([arr])):
+        result = arr_in.value_counts()
+        assert result.type.equals(
+            pa.struct([pa.field("values", arr.type), pa.field("counts", pa.int64())]))
+        assert result.field("values").equals(expected_values)
+        assert result.field("counts").equals(expected_counts)
 
 
 def test_dictionary_encode_simple():
@@ -1077,7 +1100,11 @@ def test_dictionary_encode_simple():
         (pa.array(['foo', None, 'bar', 'foo']),
          pa.DictionaryArray.from_arrays(
              pa.array([0, None, 1, 0], type='int32'),
-             ['foo', 'bar']))
+             ['foo', 'bar'])),
+        (pa.array(['foo', None, 'bar', 'foo'], type=pa.large_binary()),
+         pa.DictionaryArray.from_arrays(
+             pa.array([0, None, 1, 0], type='int32'),
+             pa.array(['foo', 'bar'], type=pa.large_binary()))),
     ]
     for arr, expected in cases:
         result = arr.dictionary_encode()
@@ -1099,7 +1126,11 @@ def test_dictionary_encode_sliced():
         (pa.array([None, 'foo', 'bar', 'foo', 'xyzzy'])[1:-1],
          pa.DictionaryArray.from_arrays(
              pa.array([0, 1, 0], type='int32'),
-             ['foo', 'bar']))
+             ['foo', 'bar'])),
+        (pa.array([None, 'foo', 'bar', 'foo', 'xyzzy'], type=pa.large_string())[1:-1],
+         pa.DictionaryArray.from_arrays(
+             pa.array([0, 1, 0], type='int32'),
+             pa.array(['foo', 'bar'], type=pa.large_string()))),
     ]
     for arr, expected in cases:
         result = arr.dictionary_encode()


### PR DESCRIPTION
templatized BinaryMemoTable so that it can hold either a BinaryBuilder or a LargeBinaryBuilder.

Also added Python binding for ValueCounts().