### PR TITLE
ARROW-7974: [C++][Developer] Fix linter warnings when PYTHONDEVMODE enabled

### DIFF
--- a/cpp/build-support/run_clang_format.py
+++ b/cpp/build-support/run_clang_format.py
@@ -74,8 +74,8 @@ if __name__ == "__main__":
 
     exclude_globs = []
     if arguments.exclude_globs:
-        for line in open(arguments.exclude_globs):
-            exclude_globs.append(line.strip())
+        with open(arguments.exclude_globs) as f:
+            exclude_globs.extend(line.strip() for line in f)
 
     formatted_filenames = []
     for path in lintutils.get_sources(arguments.source_dir, exclude_globs):

--- a/cpp/build-support/run_cpplint.py
+++ b/cpp/build-support/run_cpplint.py
@@ -74,8 +74,8 @@ if __name__ == "__main__":
 
     exclude_globs = []
     if arguments.exclude_globs:
-        for line in open(arguments.exclude_globs):
-            exclude_globs.append(line.strip())
+        with open(arguments.exclude_globs) as f:
+            exclude_globs.extend(line.strip() for line in f)
 
     linted_filenames = []
     for path in lintutils.get_sources(arguments.source_dir, exclude_globs):


### PR DESCRIPTION
Also fixes ARROW-7973