### PR TITLE
ARROW-7806: [Python] Support LargeListArray and list<LargeBinaryArray> conversion to pandas.

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -150,6 +150,7 @@ static inline bool ListTypeSupported(const DataType& type) {
     case Type::DECIMAL:
     case Type::BINARY:
     case Type::LARGE_BINARY:
+    case Type::STRING:
     case Type::LARGE_STRING:
     case Type::DATE32:
     case Type::DATE64:

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -163,7 +163,11 @@ static inline bool ListTypeSupported(const DataType& type) {
       // The above types are all supported.
       return true;
     case Type::LIST: {
-      const ListType& list_type = checked_cast<const ListType&>(type);
+      const auto& list_type = checked_cast<const ListType&>(type);
+      return ListTypeSupported(*list_type.value_type());
+    }
+    case Type::LARGE_LIST: {
+      const auto& list_type = checked_cast<const LargeListType&>(type);
       return ListTypeSupported(*list_type.value_type());
     }
     default:

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2000,6 +2000,14 @@ class TestConvertListTypes:
             assert result.type == field.type  # == list<scalar>
             assert result.equals(expected)
 
+    def test_nested_large_list(self):
+        s = (pa.array([[[1, 2, 3], [4]], None],
+                      type=pa.large_list(pa.large_list(pa.int64())))
+             .to_pandas())
+        tm.assert_series_equal(
+            s, pd.Series([[[1, 2, 3], [4]], None]),
+            check_names=False)
+
     def test_large_binary_list(self):
         for list_type_factory in (pa.list_, pa.large_list):
             s = (pa.array([["aa", "bb"], None, ["cc"], []],

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2000,6 +2000,21 @@ class TestConvertListTypes:
             assert result.type == field.type  # == list<scalar>
             assert result.equals(expected)
 
+    def test_large_binary_list(self):
+        for list_type_factory in (pa.list_, pa.large_list):
+            s = (pa.array([["aa", "bb"], None, ["cc"], []],
+                          type=list_type_factory(pa.large_binary()))
+                 .to_pandas())
+            tm.assert_series_equal(
+                s, pd.Series([[b"aa", b"bb"], None, [b"cc"], []]),
+                check_names=False)
+            s = (pa.array([["aa", "bb"], None, ["cc"], []],
+                          type=list_type_factory(pa.large_string()))
+                 .to_pandas())
+            tm.assert_series_equal(
+                s, pd.Series([["aa", "bb"], None, ["cc"], []]),
+                check_names=False)
+
 
 class TestConvertStructTypes:
     """


### PR DESCRIPTION
It seems to me only some wiring is missing. If that's indeed the case, I'd like to catch the next release.