### PR TITLE
ARROW-8016: [Developer] Fix jira-python deprecation warning in merge_arrow_pr.py

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -518,7 +518,7 @@ def get_credentials(cmd):
 
 def connect_jira(cmd):
     try:
-        return jira.client.JIRA({'server': JIRA_API_BASE},
+        return jira.client.JIRA(options={'server': JIRA_API_BASE},
                                 basic_auth=get_credentials(cmd))
     except jira.exceptions.JIRAError as e:
         if "CAPTCHA_CHALLENGE" in e.text:


### PR DESCRIPTION
This squelches the warning for me. I merged a PR using this revision