### PR TITLE
ARROW-8021: [Python] Install test requirements including pandas in Appveyor

### DIFF
--- a/ci/cpp-msvc-build-main.bat
+++ b/ci/cpp-msvc-build-main.bat
@@ -103,7 +103,7 @@ popd
 
 pushd python
 
-pip install -r requirements-build.txt
+conda install -y --file=requirements.txt --file=requirements-test.txt
 
 set PYARROW_CXXFLAGS=%ARROW_CXXFLAGS%
 set PYARROW_CMAKE_GENERATOR=%GENERATOR%

--- a/ci/cpp-msvc-build-main.bat
+++ b/ci/cpp-msvc-build-main.bat
@@ -103,7 +103,9 @@ popd
 
 pushd python
 
-conda install -y --file=requirements.txt --file=requirements-test.txt
+conda install -y --file=requirements.txt ^
+      --file=requirements-test.txt ^
+      -c conda-forge
 
 set PYARROW_CXXFLAGS=%ARROW_CXXFLAGS%
 set PYARROW_CMAKE_GENERATOR=%GENERATOR%

--- a/ci/cpp-msvc-build-main.bat
+++ b/ci/cpp-msvc-build-main.bat
@@ -103,8 +103,8 @@ popd
 
 pushd python
 
-conda install -y --file=..\ci\conda_env_python.yml ^
-      pandas -c conda-forge
+call conda install -y --file=..\ci\conda_env_python.yml ^
+           pandas -c conda-forge
 
 set PYARROW_CXXFLAGS=%ARROW_CXXFLAGS%
 set PYARROW_CMAKE_GENERATOR=%GENERATOR%

--- a/ci/cpp-msvc-build-main.bat
+++ b/ci/cpp-msvc-build-main.bat
@@ -103,9 +103,8 @@ popd
 
 pushd python
 
-conda install -y --file=requirements.txt ^
-      --file=requirements-test.txt ^
-      -c conda-forge
+conda install -y --file=..\ci\conda_env_python.yml ^
+      pandas -c conda-forge
 
 set PYARROW_CXXFLAGS=%ARROW_CXXFLAGS%
 set PYARROW_CMAKE_GENERATOR=%GENERATOR%

--- a/ci/cpp-msvc-build-main.bat
+++ b/ci/cpp-msvc-build-main.bat
@@ -103,7 +103,7 @@ popd
 
 pushd python
 
-pip install -r requirements.txt
+pip install -r requirements-build.txt
 
 set PYARROW_CXXFLAGS=%ARROW_CXXFLAGS%
 set PYARROW_CMAKE_GENERATOR=%GENERATOR%


### PR DESCRIPTION
Many unit tests are currently being skipped in Appveyor (presumably these changes will carry over when we migrate these builds to GitHub Actions). 