### PR TITLE
ARROW-7530: [Developer] Do not include list of PR commits in commit message when using PR merge tool

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -367,9 +367,6 @@ class PullRequest(object):
             # If there is only one author, do not prompt for a lead author
             primary_author = distinct_authors[0]
 
-        commits = run_cmd(['git', 'log', 'HEAD..%s' % pr_branch_name,
-                          '--pretty=format:%h <%an> %s']).split("\n\n")
-
         merge_message_flags = []
 
         merge_message_flags += ["-m", self.title]
@@ -400,12 +397,8 @@ class PullRequest(object):
         # close the PR
         merge_message_flags += [
             "-m",
-            "Closes #%s from %s and squashes the following commits:"
+            "Closes #%s from %s"
             % (self.number, self.description)]
-        for c in commits:
-            stripped_message = strip_ci_directives(c).strip()
-            merge_message_flags += ["-m", stripped_message]
-
         merge_message_flags += ["-m", authors]
 
         if DEBUG:


### PR DESCRIPTION
We've been including these since the beginning of the project, but my sense from reading commit logs is that they add noise and little extra information to our commit log. Since the commit message links back to the original PR, if someone is interested in looking at the evolution of a PR, they can look at the PR in the GitHub UI. 

I got this from Apache Spark originally (IIRC) and Spark has also stopped including the commit messages in their merges. 