### PR TITLE
ARROW-7680: [Python] Remove test skipping of partitioned dataset on Windows

### DIFF
--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-import sys
 import operator
 
 import numpy as np
@@ -624,7 +623,6 @@ def test_open_dataset_list_of_files(tempdir):
         assert result.equals(table, check_metadata=False)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="fails on windows")
 @pytest.mark.parquet
 def test_open_dataset_partitioned_directory(tempdir):
     import pyarrow.parquet as pq


### PR DESCRIPTION
(to check if this is still failing)