### PR TITLE
ARROW-5265: [Python][CI] Add integration test with kartothek

### DIFF
--- a/.env
+++ b/.env
@@ -34,6 +34,7 @@ JDK=8
 PANDAS=latest
 DASK=latest
 TURBODBC=latest
+KARTOTHEK=latest
 HDFS=2.9.2
 SPARK=master
 DOTNET=2.1

--- a/.github/workflows/python_cron.yml
+++ b/.github/workflows/python_cron.yml
@@ -112,6 +112,7 @@ jobs:
           - dask
           - hdfs
           - turbodbc
+          - kartothek
           - pandas-master
           - pandas-0.24
         include:
@@ -121,6 +122,9 @@ jobs:
           - name: turbodbc
             library: turbodbc
             title: Turbodbc
+          - name: kartothek
+            library: kartothek
+            title: Kartothek
           - name: pandas-0.24
             library: pandas
             title: Pandas 0.24

--- a/.github/workflows/python_cron.yml
+++ b/.github/workflows/python_cron.yml
@@ -112,7 +112,7 @@ jobs:
           - dask
           - hdfs
           - turbodbc
-          - kartothek-master
+          - kartothek-latest
           - pandas-master
           - pandas-0.24
         include:
@@ -122,10 +122,10 @@ jobs:
           - name: turbodbc
             library: turbodbc
             title: Turbodbc
-          - name: kartothek-master
+          - name: kartothek-latest
             library: kartothek
-            kartothek: master
-            title: Kartothek master
+            kartothek: latest
+            title: Kartothek latest
           - name: pandas-0.24
             library: pandas
             title: Pandas 0.24

--- a/.github/workflows/python_cron.yml
+++ b/.github/workflows/python_cron.yml
@@ -112,7 +112,7 @@ jobs:
           - dask
           - hdfs
           - turbodbc
-          - kartothek
+          - kartothek-master
           - pandas-master
           - pandas-0.24
         include:
@@ -122,9 +122,10 @@ jobs:
           - name: turbodbc
             library: turbodbc
             title: Turbodbc
-          - name: kartothek
+          - name: kartothek-master
             library: kartothek
-            title: Kartothek
+            kartothek: master
+            title: Kartothek master
           - name: pandas-0.24
             library: pandas
             title: Pandas 0.24
@@ -141,7 +142,7 @@ jobs:
       DASK: latest
       TURBODBC: latest
       PANDAS: ${{ matrix.pandas || 'latest' }}
-      KARTOTHEK: master
+      KARTOTHEK: ${{ matrix.kartothek || 'latest' }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v1

--- a/.github/workflows/python_cron.yml
+++ b/.github/workflows/python_cron.yml
@@ -141,6 +141,7 @@ jobs:
       DASK: latest
       TURBODBC: latest
       PANDAS: ${{ matrix.pandas || 'latest' }}
+      KARTOTHEK: master
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v1

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -29,7 +29,7 @@ DEPENDS_ON_CPP = build-c_glib build-python build-r
 DEPENDS_ON_CPP_ALPINE = build-python-alpine
 DEPENDS_ON_PYTHON = build-lint build-docs build-dask build-hdfs-integration \
                     build-spark-integration build-python-nopandas \
-                    build-turbodbc-integration
+                    build-turbodbc-integration build-kartothek-integration
 DEPENDS_ON_LINT = build-iwyu build-clang-format
 
 SERVICES = $(LANGUAGES) $(MISC) $(TESTS)

--- a/ci/docker/conda-python-kartothek.dockerfile
+++ b/ci/docker/conda-python-kartothek.dockerfile
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG repo
+ARG arch=amd64
+ARG python=3.6
+FROM ${repo}:${arch}-conda-python-${python}
+
+# install kartothek dependencies from conda-forge
+RUN conda install -c conda-forge -q \
+        decorator \
+        pytest-xdist \
+        dask \
+        msgpack-python \
+        simplejson \
+        simplekv \
+        storefact \
+        toolz \
+        urlquote \
+        zstandard && \
+    conda clean --all
+
+ARG kartothek=latest
+COPY ci/scripts/install_kartothek.sh /arrow/ci/scripts/
+RUN /arrow/ci/scripts/install_kartothek.sh ${kartothek} /kartothek
+

--- a/ci/docker/conda-python-kartothek.dockerfile
+++ b/ci/docker/conda-python-kartothek.dockerfile
@@ -37,4 +37,3 @@ RUN conda install -c conda-forge -q \
 ARG kartothek=latest
 COPY ci/scripts/install_kartothek.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_kartothek.sh ${kartothek} /kartothek
-

--- a/ci/docker/conda-python-kartothek.dockerfile
+++ b/ci/docker/conda-python-kartothek.dockerfile
@@ -22,10 +22,11 @@ FROM ${repo}:${arch}-conda-python-${python}
 
 # install kartothek dependencies from conda-forge
 RUN conda install -c conda-forge -q \
-        decorator \
-        pytest-xdist \
         dask \
+        decorator \
         msgpack-python \
+        pytest-mock \
+        pytest-xdist \
         simplejson \
         simplekv \
         storefact \

--- a/ci/scripts/install_kartothek.sh
+++ b/ci/scripts/install_kartothek.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <kartothek version> <target directory>"
+  exit 1
+fi
+
+karthothek=$1
+target=$2
+
+git clone --recurse-submodules https://github.com/JDASoftwareGroup/kartothek "${target}"
+if [ "${kartothek}" = "master" ]; then
+  git -C "${target}" checkout master;
+elif [ "${kartothek}" = "latest" ]; then
+  git -C "${target}" checkout $(git describe --tags);
+else
+  git -C "${target}" checkout ${kartothek};
+fi
+
+pushd "${target}"
+pip install --no-deps .
+popd

--- a/ci/scripts/integration_kartothek.sh
+++ b/ci/scripts/integration_kartothek.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+# check that optional pyarrow modules are available
+# because pytest would just skip the pyarrow tests
+python -c "import pyarrow.parquet"
+
+# check that kartothek is correctly installed
+python -c "import kartothek"
+
+pushd /kartothek
+pytest -n0

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -121,6 +121,8 @@ groups:
     - test-conda-python-3.8-dask-master
     - test-conda-python-3.7-turbodbc-latest
     - test-conda-python-3.7-turbodbc-master
+    - test-conda-python-3.7-kartothek-latest
+    - test-conda-python-3.7-kartothek-master
     - test-conda-python-3.7-hdfs-2.9.2
     - test-conda-python-3.7-spark-master
     - test-conda-python-3.8-jpype
@@ -202,6 +204,8 @@ groups:
     - test-conda-python-3.8-dask-master
     - test-conda-python-3.7-turbodbc-latest
     - test-conda-python-3.7-turbodbc-master
+    - test-conda-python-3.7-kartothek-latest
+    - test-conda-python-3.7-kartothek-master
     - test-conda-python-3.7-hdfs-2.9.2
     - test-conda-python-3.7-spark-master
     - test-conda-python-3.8-jpype
@@ -286,6 +290,8 @@ groups:
     - test-conda-python-3.8-dask-master
     - test-conda-python-3.7-turbodbc-latest
     - test-conda-python-3.7-turbodbc-master
+    - test-conda-python-3.7-kartothek-latest
+    - test-conda-python-3.7-kartothek-master
     - test-conda-python-3.7-hdfs-2.9.2
     - test-conda-python-3.7-spark-master
     - test-conda-python-3.8-jpype
@@ -2064,6 +2070,34 @@ tasks:
         - docker-compose build conda-python
         - docker-compose build --no-cache conda-python-turbodbc
         - docker-compose run conda-python-turbodbc
+
+  test-conda-python-3.7-kartothek-latest:
+    ci: circle
+    platform: linux
+    template: docker-tests/circle.linux.yml
+    params:
+      commands:
+        - export PYTHON=3.7 KARTOTHEK=latest
+        - docker-compose pull --ignore-pull-failures conda-cpp
+        - docker-compose pull --ignore-pull-failures conda-python
+        - docker-compose build conda-cpp
+        - docker-compose build conda-python
+        - docker-compose build --no-cache conda-python-kartothek
+        - docker-compose run conda-python-kartothek
+
+  test-conda-python-3.7-kartothek-master:
+    ci: circle
+    platform: linux
+    template: docker-tests/circle.linux.yml
+    params:
+      commands:
+        - export PYTHON=3.7 TURBODBC=master
+        - docker-compose pull --ignore-pull-failures conda-cpp
+        - docker-compose pull --ignore-pull-failures conda-python
+        - docker-compose build conda-cpp
+        - docker-compose build conda-python
+        - docker-compose build --no-cache conda-python-kartothek
+        - docker-compose run conda-python-kartothek
 
   test-conda-python-3.7-hdfs-2.9.2:
     ci: circle

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -667,7 +667,7 @@ services:
         /arrow/ci/scripts/integration_turbodbc.sh /turbodbc /build"]
 
   conda-python-kartothek:
-    # Possible $TURBODBC parameters:
+    # Possible $KARTOTHEK parameters:
     #  - `latest`: latest release
     #  - `master`: git master branch, use `docker-compose run --no-cache`
     #  - `<version>`: specific version available under github releases
@@ -676,17 +676,17 @@ services:
     #   docker-compose build conda-python
     #   docker-compose build conda-python-kartothek
     #   docker-compose run --rm conda-python-kartothek
-    image: ${REPO}:${ARCH}-conda-python-${PYTHON}-kartothek-${TURBODBC}
+    image: ${REPO}:${ARCH}-conda-python-${PYTHON}-kartothek-${KARTOTHEK}
     build:
       context: .
       dockerfile: ci/docker/conda-python-kartothek.dockerfile
       cache_from:
-        - ${REPO}:${ARCH}-conda-python-${PYTHON}-kartothek-${TURBODBC}
+        - ${REPO}:${ARCH}-conda-python-${PYTHON}-kartothek-${KARTOTHEK}
       args:
         repo: ${REPO}
         arch: ${ARCH}
         python: ${PYTHON}
-        kartothek: ${TURBODBC}
+        kartothek: ${KARTOTHEK}
     shm_size: *shm-size
     environment:
       <<: *ccache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -637,7 +637,7 @@ services:
         /arrow/ci/scripts/python_test.sh /arrow"]
 
   conda-python-turbodbc:
-    # Possible $DASK parameters:
+    # Possible $TURBODBC parameters:
     #  - `latest`: latest release
     #  - `master`: git master branch, use `docker-compose run --no-cache`
     #  - `<version>`: specific version available under github releases
@@ -665,6 +665,36 @@ services:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         /arrow/ci/scripts/integration_turbodbc.sh /turbodbc /build"]
+
+  conda-python-kartothek:
+    # Possible $TURBODBC parameters:
+    #  - `latest`: latest release
+    #  - `master`: git master branch, use `docker-compose run --no-cache`
+    #  - `<version>`: specific version available under github releases
+    # Usage:
+    #   docker-compose build conda-cpp
+    #   docker-compose build conda-python
+    #   docker-compose build conda-python-kartothek
+    #   docker-compose run --rm conda-python-kartothek
+    image: ${REPO}:${ARCH}-conda-python-${PYTHON}-kartothek-${TURBODBC}
+    build:
+      context: .
+      dockerfile: ci/docker/conda-python-kartothek.dockerfile
+      cache_from:
+        - ${REPO}:${ARCH}-conda-python-${PYTHON}-kartothek-${TURBODBC}
+      args:
+        repo: ${REPO}
+        arch: ${ARCH}
+        python: ${PYTHON}
+        kartothek: ${TURBODBC}
+    shm_size: *shm-size
+    environment:
+      <<: *ccache
+    volumes: *conda-volumes
+    command:
+      ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
+        /arrow/ci/scripts/python_build.sh /arrow /build &&
+        /arrow/ci/scripts/integration_kartothek.sh /kartothek /build"]
 
   ########################## Python Wheels ####################################
 


### PR DESCRIPTION
Kartothek broke again with the latest Arrow master branch (e.g. https://issues.apache.org/jira/browse/ARROW-8057) thus I finally took the time and wrote the integration test. This will be failing until we have a workaround implement in kartothek for ARROW-8057.

cc @fjetter 