### PR TITLE
ARROW-8057: [Python] Do not compare schema metadata in Schema.equals and Table.equals by default

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -335,7 +335,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         c_bool nullable()
 
         c_string ToString()
-        c_bool Equals(const CField& other)
+        c_bool Equals(const CField& other, c_bool check_metadata)
 
         shared_ptr[const CKeyValueMetadata] metadata()
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1113,15 +1113,15 @@ cdef class Table(_PandasConvertible):
         except TypeError:
             return NotImplemented
 
-    def equals(self, Table other, bint check_metadata=True):
+    def equals(self, Table other, bint check_metadata=False):
         """
         Check if contents of two tables are equal
 
         Parameters
         ----------
         other : pyarrow.Table
-        check_metadata : bool, default True
-            Whether metadata equality should be checked as well.
+        check_metadata : bool, default False
+            Whether schema metadata equality should be checked as well.
 
         Returns
         -------

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -510,7 +510,7 @@ def test_partitioning_factory(mockfs):
         ("group", pa.int32()),
         ("key", pa.string()),
     ])
-    assert inspected_schema.equals(expected_schema, check_metadata=False)
+    assert inspected_schema.equals(expected_schema)
 
     hive_partitioning_factory = ds.HivePartitioning.discover()
     assert isinstance(hive_partitioning_factory, ds.PartitioningFactory)
@@ -577,21 +577,21 @@ def _check_dataset_from_path(path, table, **kwargs):
     # pathlib object
     assert isinstance(path, pathlib.Path)
     dataset = ds.dataset(ds.factory(path, **kwargs))
-    assert dataset.schema.equals(table.schema, check_metadata=False)
+    assert dataset.schema.equals(table.schema)
     result = dataset.to_table(use_threads=False)  # deterministic row order
-    assert result.equals(table, check_metadata=False)
+    assert result.equals(table)
 
     # string path
     dataset = ds.dataset(ds.factory(str(path), **kwargs))
-    assert dataset.schema.equals(table.schema, check_metadata=False)
+    assert dataset.schema.equals(table.schema)
     result = dataset.to_table(use_threads=False)  # deterministic row order
-    assert result.equals(table, check_metadata=False)
+    assert result.equals(table)
 
     # passing directly to dataset
     dataset = ds.dataset(str(path), **kwargs)
-    assert dataset.schema.equals(table.schema, check_metadata=False)
+    assert dataset.schema.equals(table.schema)
     result = dataset.to_table(use_threads=False)  # deterministic row order
-    assert result.equals(table, check_metadata=False)
+    assert result.equals(table)
 
 
 @pytest.mark.parquet
@@ -619,9 +619,9 @@ def test_open_dataset_list_of_files(tempdir):
         ds.dataset(ds.factory([str(path1), str(path2)]))
     ]
     for dataset in datasets:
-        assert dataset.schema.equals(table.schema, check_metadata=False)
+        assert dataset.schema.equals(table.schema)
         result = dataset.to_table(use_threads=False)  # deterministic row order
-        assert result.equals(table, check_metadata=False)
+        assert result.equals(table)
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="fails on windows")
@@ -642,11 +642,11 @@ def test_open_dataset_partitioned_directory(tempdir):
     dataset = ds.dataset(
         str(tempdir), partitioning=ds.partitioning(flavor="hive"))
     expected_schema = table.schema.append(pa.field("part", pa.int32()))
-    assert dataset.schema.equals(expected_schema, check_metadata=False)
+    assert dataset.schema.equals(expected_schema)
 
     # specify partition scheme with string short-cut
     dataset = ds.dataset(str(tempdir), partitioning="hive")
-    assert dataset.schema.equals(expected_schema, check_metadata=False)
+    assert dataset.schema.equals(expected_schema)
 
     # specify partition scheme with explicit scheme
     dataset = ds.dataset(
@@ -654,12 +654,12 @@ def test_open_dataset_partitioned_directory(tempdir):
         partitioning=ds.partitioning(
             pa.schema([("part", pa.int8())]), flavor="hive"))
     expected_schema = table.schema.append(pa.field("part", pa.int8()))
-    assert dataset.schema.equals(expected_schema, check_metadata=False)
+    assert dataset.schema.equals(expected_schema)
 
     result = dataset.to_table(use_threads=False)
     expected = full_table.append_column(
         "part", pa.array(np.repeat([0, 1, 2], 9), type=pa.int8()))
-    assert result.equals(expected, check_metadata=False)
+    assert result.equals(expected)
 
 
 @pytest.mark.parquet
@@ -669,11 +669,11 @@ def test_open_dataset_filesystem(tempdir):
 
     # filesystem inferred from path
     dataset1 = ds.dataset(str(path))
-    assert dataset1.schema.equals(table.schema, check_metadata=False)
+    assert dataset1.schema.equals(table.schema)
 
     # filesystem specified
     dataset2 = ds.dataset(str(path), filesystem=fs.LocalFileSystem())
-    assert dataset2.schema.equals(table.schema, check_metadata=False)
+    assert dataset2.schema.equals(table.schema)
 
     # passing different filesystem
     with pytest.raises(FileNotFoundError):
@@ -749,7 +749,7 @@ def test_multiple_factories(multisourcefs):
         ('month', pa.int32()),
         ('year', pa.int32()),
     ])
-    assert assembled.schema.equals(expected_schema, check_metadata=False)
+    assert assembled.schema.equals(expected_schema)
 
 
 def test_multiple_factories_with_selectors(multisourcefs):
@@ -762,7 +762,7 @@ def test_multiple_factories_with_selectors(multisourcefs):
         ('value', pa.float64()),
         ('color', pa.string())
     ])
-    assert dataset.schema.equals(expected_schema, check_metadata=False)
+    assert dataset.schema.equals(expected_schema)
 
     # with hive partitioning for two hive sources
     dataset = ds.dataset(['/hive', '/hive_color'], filesystem=multisourcefs,
@@ -775,7 +775,7 @@ def test_multiple_factories_with_selectors(multisourcefs):
         ('month', pa.int32()),
         ('year', pa.int32())
     ])
-    assert dataset.schema.equals(expected_schema, check_metadata=False)
+    assert dataset.schema.equals(expected_schema)
 
 
 def test_ipc_format(tempdir):

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -87,7 +87,7 @@ def _check_pandas_roundtrip(df, expected=None, use_threads=False,
     if expected_schema:
         # all occurrences of _check_pandas_roundtrip passes expected_schema
         # without the pandas generated key-value metadata
-        assert table.schema.equals(expected_schema, check_metadata=False)
+        assert table.schema.equals(expected_schema)
 
     if expected is None:
         expected = df
@@ -458,7 +458,7 @@ class TestConvertMetadata:
         expected = (table.cast(table.schema.remove_metadata())
                     .to_pandas())
 
-        assert result.equals(expected)
+        tm.assert_frame_equal(result, expected)
 
     def test_list_metadata(self):
         df = pd.DataFrame({'data': [[1], [2, 3, 4], [5] * 7]})
@@ -2771,8 +2771,8 @@ def test_table_from_pandas_keeps_column_order_of_dataframe():
     table1 = pa.Table.from_pandas(df1, preserve_index=False)
     table2 = pa.Table.from_pandas(df2, preserve_index=False)
 
-    assert table1.schema.equals(schema1, check_metadata=False)
-    assert table2.schema.equals(schema2, check_metadata=False)
+    assert table1.schema.equals(schema1)
+    assert table2.schema.equals(schema2)
 
 
 def test_table_from_pandas_keeps_column_order_of_schema():
@@ -2795,8 +2795,8 @@ def test_table_from_pandas_keeps_column_order_of_schema():
     table1 = pa.Table.from_pandas(df1, schema=schema, preserve_index=False)
     table2 = pa.Table.from_pandas(df2, schema=schema, preserve_index=False)
 
-    assert table1.schema.equals(schema, check_metadata=False)
-    assert table1.schema.equals(table2.schema, check_metadata=False)
+    assert table1.schema.equals(schema)
+    assert table1.schema.equals(table2.schema)
 
 
 def test_table_from_pandas_columns_argument_only_does_filtering():
@@ -2822,8 +2822,8 @@ def test_table_from_pandas_columns_argument_only_does_filtering():
     table1 = pa.Table.from_pandas(df, columns=columns1, preserve_index=False)
     table2 = pa.Table.from_pandas(df, columns=columns2, preserve_index=False)
 
-    assert table1.schema.equals(schema1, check_metadata=False)
-    assert table2.schema.equals(schema2, check_metadata=False)
+    assert table1.schema.equals(schema1)
+    assert table2.schema.equals(schema2)
 
 
 def test_table_from_pandas_columns_and_schema_are_mutually_exclusive():

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -71,13 +71,6 @@ def _read_table(*args, **kwargs):
     return pq.read_table(*args, **kwargs)
 
 
-def assert_tables_equal(left, right):
-    # This is a helper method particular to this testing module because the
-    # round trip to Parquet adds extra Field-level metadata for the Parquet
-    # field_ids
-    assert left.equals(right, check_metadata=False)
-
-
 def _roundtrip_table(table, read_table_kwargs=None,
                      write_table_kwargs=None):
     read_table_kwargs = read_table_kwargs or {}
@@ -99,10 +92,10 @@ def _check_roundtrip(table, expected=None, read_table_kwargs=None,
     # intentionally check twice
     result = _roundtrip_table(table, read_table_kwargs=read_table_kwargs,
                               write_table_kwargs=write_table_kwargs)
-    assert_tables_equal(result, expected)
+    assert result.equals(expected)
     result = _roundtrip_table(result, read_table_kwargs=read_table_kwargs,
                               write_table_kwargs=write_table_kwargs)
-    assert_tables_equal(result, expected)
+    assert result.equals(expected)
 
 
 def _roundtrip_pandas_dataframe(df, write_kwargs):
@@ -225,7 +218,7 @@ def test_memory_map(tempdir):
     with open(filename, 'wb') as f:
         _write_table(table, f, version='2.0')
     table_read = pq.read_pandas(filename, memory_map=True)
-    assert_tables_equal(table_read, table)
+    assert table_read.equals(table)
 
 
 @pytest.mark.pandas
@@ -240,7 +233,7 @@ def test_enable_buffered_stream(tempdir):
     with open(filename, 'wb') as f:
         _write_table(table, f, version='2.0')
     table_read = pq.read_pandas(filename, buffer_size=4096)
-    assert_tables_equal(table_read, table)
+    assert table_read.equals(table)
 
 
 def test_special_chars_filename(tempdir):
@@ -251,7 +244,7 @@ def test_special_chars_filename(tempdir):
     _write_table(table, str(path))
     assert path.exists()
     table_read = _read_table(str(path))
-    assert_tables_equal(table_read, table)
+    assert table_read.equals(table)
 
 
 @pytest.mark.pandas
@@ -1143,7 +1136,7 @@ def test_date_time_types(tempdir):
     for i in range(3):
         assert parquet_schema.column(i).physical_type == 'INT64'
     read_table = _read_table(filename)
-    assert_tables_equal(read_table, expected)
+    assert read_table.equals(expected)
 
     t0_ns = pa.timestamp('ns')
     data0_ns = np.array(data0 * 1000000, dtype='int64')
@@ -1164,7 +1157,7 @@ def test_date_time_types(tempdir):
     for i in range(3):
         assert parquet_schema.column(i).physical_type == 'INT96'
     read_table = _read_table(filename)
-    assert_tables_equal(read_table, expected)
+    assert read_table.equals(expected)
 
     # int96 nanosecond timestamps implied by flavor 'spark'
     filename = tempdir / 'spark_int96_timestamps.parquet'
@@ -1174,7 +1167,7 @@ def test_date_time_types(tempdir):
     for i in range(3):
         assert parquet_schema.column(i).physical_type == 'INT96'
     read_table = _read_table(filename)
-    assert_tables_equal(read_table, expected)
+    assert read_table.equals(expected)
 
 
 def test_timestamp_restore_timezone():
@@ -1315,7 +1308,7 @@ def test_multithreaded_read():
     buf.seek(0)
     table2 = _read_table(buf, use_threads=False)
 
-    assert_tables_equal(table1, table2)
+    assert table1.equals(table2)
 
 
 @pytest.mark.pandas
@@ -1329,7 +1322,7 @@ def test_min_chunksize():
     buf.seek(0)
     result = _read_table(buf)
 
-    assert_tables_equal(result, table)
+    assert result.equals(table)
 
     with pytest.raises(ValueError):
         _write_table(table, buf, chunk_size=0)
@@ -1475,7 +1468,7 @@ def test_parquet_piece_read(tempdir):
     piece1 = pq.ParquetDatasetPiece(path)
 
     result = piece1.read()
-    assert_tables_equal(result, table)
+    assert result.equals(table)
 
 
 @pytest.mark.pandas
@@ -1492,7 +1485,7 @@ def test_parquet_piece_open_and_get_metadata(tempdir):
     meta1 = piece.get_metadata()
     assert isinstance(meta1, pq.FileMetaData)
 
-    assert_tables_equal(table, table1)
+    assert table.equals(table1)
 
 
 def test_parquet_piece_basics():
@@ -2055,8 +2048,8 @@ def test_read_schema(tempdir):
 
     read1 = pq.read_schema(data_path)
     read2 = pq.read_schema(data_path, memory_map=True)
-    assert table.schema.equals(read1, check_metadata=False)
-    assert table.schema.equals(read2, check_metadata=False)
+    assert table.schema.equals(read1)
+    assert table.schema.equals(read2)
 
     assert table.schema.metadata[b'pandas'] == read1.metadata[b'pandas']
 
@@ -2111,16 +2104,16 @@ def test_read_multiple_files(tempdir):
     result = read_multiple_files(paths)
     expected = pa.concat_tables(test_data)
 
-    assert_tables_equal(result, expected)
+    assert result.equals(expected)
 
     # Read with provided metadata
     metadata = pq.read_metadata(paths[0])
 
     result2 = read_multiple_files(paths, metadata=metadata)
-    assert_tables_equal(result2, expected)
+    assert result2.equals(expected)
 
     result3 = pa.localfs.read_parquet(dirpath, schema=metadata.schema)
-    assert_tables_equal(result3, expected)
+    assert result3.equals(expected)
 
     # Read column subset
     to_read = [0, 2, 6, result.num_columns - 1]
@@ -2130,7 +2123,7 @@ def test_read_multiple_files(tempdir):
     expected = pa.Table.from_arrays([result.column(i) for i in to_read],
                                     names=col_names,
                                     metadata=result.schema.metadata)
-    assert_tables_equal(out, expected)
+    assert out.equals(expected)
 
     # Read with multiple threads
     pa.localfs.read_parquet(dirpath, use_threads=True)
@@ -2203,7 +2196,7 @@ def test_dataset_memory_map(tempdir):
     _write_table(table, path, version='2.0')
 
     dataset = pq.ParquetDataset(dirpath, memory_map=True)
-    assert_tables_equal(dataset.pieces[0].read(), table)
+    assert dataset.pieces[0].read().equals(table)
 
 
 @pytest.mark.pandas
@@ -2221,7 +2214,7 @@ def test_dataset_enable_buffered_stream(tempdir):
 
     for buffer_size in [128, 1024]:
         dataset = pq.ParquetDataset(dirpath, buffer_size=buffer_size)
-        assert_tables_equal(dataset.pieces[0].read(), table)
+        assert dataset.pieces[0].read().equals(table)
 
 
 @pytest.mark.pandas
@@ -2348,7 +2341,7 @@ def test_multiindex_duplicate_values(tempdir):
 
     _write_table(table, filename)
     result_table = _read_table(filename)
-    assert_tables_equal(table, result_table)
+    assert table.equals(result_table)
 
     result_df = result_table.to_pandas()
     tm.assert_frame_equal(result_df, df)
@@ -2396,7 +2389,7 @@ def test_noncoerced_nanoseconds_written_without_exception(tempdir):
     assert filename.exists()
 
     recovered_table = pq.read_table(filename)
-    assert_tables_equal(tb, recovered_table)
+    assert tb.equals(recovered_table)
 
     # Loss of data thru coercion (without explicit override) still an error
     filename = tempdir / 'not_written.parquet'
@@ -2594,7 +2587,7 @@ def test_byte_array_exactly_2gb():
         values = pa.chunked_array([base, pa.array(case)])
         t = pa.table([values], names=['f0'])
         result = _simple_table_roundtrip(t, use_dictionary=False)
-        assert_tables_equal(t, result)
+        assert t.equals(result)
 
 
 @pytest.mark.pandas
@@ -2617,7 +2610,7 @@ def test_binary_array_overflow_to_chunked():
     # Split up into 2GB chunks
     assert col0_data.num_chunks == 2
 
-    assert_tables_equal(tbl, read_tbl)
+    assert tbl.equals(read_tbl)
 
 
 @pytest.mark.pandas
@@ -2636,7 +2629,7 @@ def test_list_of_binary_large_cell():
     arr = pa.array(data)
     table = pa.Table.from_arrays([arr], ['chunky_cells'])
     read_table = _simple_table_roundtrip(table)
-    assert_tables_equal(table, read_table)
+    assert table.equals(read_table)
 
 
 @pytest.mark.pandas
@@ -2968,8 +2961,8 @@ def test_merging_parquet_tables_with_different_pandas_metadata(tempdir):
     table1 = pa.Table.from_pandas(df1, schema=schema, preserve_index=False)
     table2 = pa.Table.from_pandas(df2, schema=schema, preserve_index=False)
 
-    assert not table1.schema.equals(table2.schema)
-    assert table1.schema.equals(table2.schema, check_metadata=False)
+    assert not table1.schema.equals(table2.schema, check_metadata=True)
+    assert table1.schema.equals(table2.schema)
 
     writer = pq.ParquetWriter(tempdir / 'merged.parquet', schema=schema)
     writer.write_table(table1)
@@ -2991,7 +2984,7 @@ def test_empty_row_groups(tempdir):
     assert reader.metadata.num_row_groups == num_groups
 
     for i in range(num_groups):
-        assert_tables_equal(reader.read_row_group(i), table)
+        assert reader.read_row_group(i).equals(table)
 
 
 @pytest.mark.pandas
@@ -3120,7 +3113,7 @@ def test_direct_read_dictionary():
 
     # Compute dictionary-encoded subfield
     expected = pa.table([table[0].dictionary_encode()], names=['f0'])
-    assert_tables_equal(result, expected)
+    assert result.equals(expected)
 
 
 @pytest.mark.pandas
@@ -3173,7 +3166,7 @@ def test_direct_read_dictionary_subfield():
     expected_arr = pa.ListArray.from_arrays(offsets, new_values)
     expected = pa.table([expected_arr], names=['f0'])
 
-    assert_tables_equal(result, expected)
+    assert result.equals(expected)
     assert result[0].num_chunks == 1
 
 
@@ -3282,7 +3275,7 @@ def test_dictionary_array_automatically_read():
     table = pa.table([pa.chunked_array(chunks)], names=['f0'])
     result = _simple_table_write_read(table)
 
-    assert_tables_equal(result, table)
+    assert result.equals(table)
 
     # The only key in the metadata was the Arrow schema key
     assert result.schema.metadata is None

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -380,11 +380,11 @@ def test_schema_equals():
     sch3 = pa.schema(fields, metadata=metadata)
     sch4 = pa.schema(fields, metadata=metadata)
 
-    assert sch1.equals(sch2)
-    assert sch3.equals(sch4)
-    assert sch1.equals(sch3, check_metadata=False)
+    assert sch1.equals(sch2, check_metadata=True)
+    assert sch3.equals(sch4, check_metadata=True)
+    assert sch1.equals(sch3)
     assert not sch1.equals(sch3, check_metadata=True)
-    assert not sch1.equals(sch3)
+    assert not sch1.equals(sch3, check_metadata=True)
 
     del fields[-1]
     sch3 = pa.schema(fields)
@@ -401,8 +401,8 @@ def test_schema_equals_propagates_check_metadata():
         pa.field('foo', pa.int32()),
         pa.field('bar', pa.string(), metadata={'a': 'alpha'}),
     ])
-    assert not schema1.equals(schema2)
-    assert schema1.equals(schema2, check_metadata=False)
+    assert not schema1.equals(schema2, check_metadata=True)
+    assert schema1.equals(schema2)
 
 
 def test_schema_equals_invalid_type():
@@ -429,8 +429,12 @@ def test_schema_equality_operators():
 
     assert sch1 == sch2
     assert sch3 == sch4
-    assert sch1 != sch3
-    assert sch2 != sch4
+
+    # __eq__ and __ne__ do not check metadata
+    assert sch1 == sch3
+    assert not sch1 != sch3
+
+    assert sch2 == sch4
 
     # comparison with other types doesn't raise
     assert sch1 != []

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -481,8 +481,8 @@ def test_table_equals():
     assert not table.equals(None)
 
     other = pa.Table.from_arrays([], names=[], metadata={'key': 'value'})
-    assert not table.equals(other)
-    assert table.equals(other, check_metadata=False)
+    assert not table.equals(other, check_metadata=True)
+    assert table.equals(other)
 
 
 def test_table_from_batches_and_schema():
@@ -857,12 +857,12 @@ def test_concat_tables_with_different_schema_metadata():
 
     table1 = pa.Table.from_pandas(df1, schema=schema, preserve_index=False)
     table2 = pa.Table.from_pandas(df2, schema=schema, preserve_index=False)
-    assert table1.schema.equals(table2.schema, check_metadata=False)
+    assert table1.schema.equals(table2.schema)
     assert not table1.schema.equals(table2.schema, check_metadata=True)
 
     table3 = pa.concat_tables([table1, table2])
     assert table1.schema.equals(table3.schema, check_metadata=True)
-    assert table2.schema.equals(table3.schema, check_metadata=False)
+    assert table2.schema.equals(table3.schema)
 
 
 def test_concat_tables_with_promotion():

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -599,9 +599,16 @@ def test_field_equals():
     assert not f1.equals(f3)
     assert not f1.equals(f4)
     assert not f3.equals(f4)
-    assert not f1.equals(f6)
     assert not f4.equals(f5)
-    assert not f7.equals(f8)
+
+    # No metadata in f1, but metadata in f6
+    assert f1.equals(f6)
+    assert not f1.equals(f6, check_metadata=True)
+
+    # Different metadata
+    assert f6.equals(f7)
+    assert f7.equals(f8)
+    assert not f7.equals(f8, check_metadata=True)
 
 
 def test_field_equality_operators():

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1042,7 +1042,7 @@ cdef class Schema:
             metadata=self.metadata
         )
 
-    def equals(self, Schema other not None, bint check_metadata=True):
+    def equals(self, Schema other not None, bint check_metadata=False):
         """
         Test if this schema is equal to the other
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -827,19 +827,21 @@ cdef class Field:
         self.field = field.get()
         self.type = pyarrow_wrap_data_type(field.get().type())
 
-    def equals(self, Field other):
+    def equals(self, Field other, bint check_metadata=False):
         """
         Test if this field is equal to the other
 
         Parameters
         ----------
         other : pyarrow.Field
+        check_metadata : bool, default False
+            Whether Field metadata equality should be checked as well.
 
         Returns
         -------
         is_equal : boolean
         """
-        return self.field.Equals(deref(other.field))
+        return self.field.Equals(deref(other.field), check_metadata)
 
     def __eq__(self, other):
         try:


### PR DESCRIPTION
It seems that in practice checking for metadata equality is the less predominant mode when comparing schemas, as evidenced by the proliferation of `check_metadata=False` in our test suite and the issue reported in ARROW-8057 after the introduction of Parquet field_id metadata in ARROW-7080. While this is an API change I don't think it will affect very many people