### PR TITLE
ARROW-8026: [Python] Support memoryview as a value type for creating binary-like arrays

### DIFF
--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -78,7 +78,7 @@ ARROW_PYTHON_EXPORT
 bool PyFloat_IsNaN(PyObject* obj);
 
 inline bool IsPyBinary(PyObject* obj) {
-  return PyBytes_Check(obj) || PyByteArray_Check(obj);
+  return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj);
 }
 
 // \brief Convert a Python integer into a C integer

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -712,15 +712,16 @@ def test_large_binary_value(ty):
 def test_sequence_bytes():
     u1 = b'ma\xc3\xb1ana'
     data = [b'foo',
+            memoryview(b'data'),
             u1.decode('utf-8'),  # unicode gets encoded,
             bytearray(b'bar'),
             None]
     for ty in [None, pa.binary(), pa.large_binary()]:
         arr = pa.array(data, type=ty)
-        assert len(arr) == 4
+        assert len(arr) == 5
         assert arr.null_count == 1
         assert arr.type == ty or pa.binary()
-        assert arr.to_pylist() == [b'foo', u1, b'bar', None]
+        assert arr.to_pylist() == [b'foo', b'data', u1, b'bar', None]
 
 
 @pytest.mark.parametrize("ty", [pa.string(), pa.large_string()])

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -711,17 +711,19 @@ def test_large_binary_value(ty):
 
 def test_sequence_bytes():
     u1 = b'ma\xc3\xb1ana'
+
     data = [b'foo',
-            memoryview(b'data'),
+            memoryview(b'dada'),
+            memoryview(b'd-a-t-a')[::2],  # non-contiguous is made contiguous
             u1.decode('utf-8'),  # unicode gets encoded,
             bytearray(b'bar'),
             None]
     for ty in [None, pa.binary(), pa.large_binary()]:
         arr = pa.array(data, type=ty)
-        assert len(arr) == 5
+        assert len(arr) == 6
         assert arr.null_count == 1
         assert arr.type == ty or pa.binary()
-        assert arr.to_pylist() == [b'foo', b'data', u1, b'bar', None]
+        assert arr.to_pylist() == [b'foo', b'dada', b'data', u1, b'bar', None]
 
 
 @pytest.mark.parametrize("ty", [pa.string(), pa.large_string()])


### PR DESCRIPTION
This also handles non-contiguous memory views. 