### PR TITLE
ARROW-7865: [R] Test builds on latest Linux versions

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -105,6 +105,7 @@ groups:
     - test-fedora-29-python-3
     - test-r-rhub-ubuntu-gcc-release
     - test-r-rhub-debian-gcc-devel
+    - test-r-rocker-r-base-latest    
     - test-r-rstudio-r-base-3.6-bionic
     - test-r-rstudio-r-base-3.6-centos6
     - test-r-rstudio-r-base-3.6-opensuse15
@@ -147,6 +148,7 @@ groups:
     - test-fedora-29-python-3
     - test-r-rhub-ubuntu-gcc-release
     - test-r-rhub-debian-gcc-devel
+    - test-r-rocker-r-base-latest
     - test-r-rstudio-r-base-3.6-bionic
     - test-r-rstudio-r-base-3.6-centos6
     - test-r-rstudio-r-base-3.6-opensuse15
@@ -184,6 +186,7 @@ groups:
     - test-ubuntu-18.04-r-sanitizer
     - test-r-rhub-ubuntu-gcc-release
     - test-r-rhub-debian-gcc-devel
+    - test-r-rocker-r-base-latest
     - test-r-rstudio-r-base-3.6-bionic
     - test-r-rstudio-r-base-3.6-centos6
     - test-r-rstudio-r-base-3.6-opensuse15
@@ -271,6 +274,7 @@ groups:
     - test-fedora-29-python-3
     - test-r-rhub-ubuntu-gcc-release
     - test-r-rhub-debian-gcc-devel
+    - test-r-rocker-r-base-latest
     - test-r-rstudio-r-base-3.6-bionic
     - test-r-rstudio-r-base-3.6-centos6
     - test-r-rstudio-r-base-3.6-opensuse15
@@ -1845,6 +1849,16 @@ tasks:
     params:
       r_org: rhub
       r_image: ubuntu-gcc-release
+      r_tag: latest
+      verbose: "TRUE"
+
+  test-r-rocker-r-base-latest:
+    ci: azure
+    platform: linux
+    template: r/azure.linux.yml
+    params:
+      r_org: rocker
+      r_image: r-base
       r_tag: latest
       verbose: "TRUE"
 

--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -40,6 +40,8 @@ quietly <- !env_is("ARROW_R_DEV", "true")
 download_binary <- function(os = identify_os()) {
   libfile <- tempfile()
   if (!is.null(os)) {
+    # See if we can map this os-version to one we have binaries for
+    os <- find_available_binary(os)
     binary_url <- paste0(arrow_repo, "bin/", os, "/arrow-", VERSION, ".zip")
     try(
       download.file(binary_url, libfile, quiet = quietly),
@@ -84,14 +86,20 @@ identify_os <- function(os = Sys.getenv("LIBARROW_BINARY", Sys.getenv("LIBARROW_
     vals <- sub("^.*=(.*)$", "\\1", os_release)
     names(vals) <- sub("^(.*)=.*$", "\\1", os_release)
     distro <- gsub('"', '', vals["ID"])
-    if (distro == "ubuntu") {
-      # Keep major.minor version
-      version_regex <- '^"?([0-9]+\\.[0-9]+).*"?.*$'
-    } else {
-      # Only major version number
-      version_regex <- '^"?([0-9]+).*"?.*$'
+    os_version <- "unknown" # default value
+    if ("VERSION_ID" %in% names(vals)) {
+      if (distro == "ubuntu") {
+        # Keep major.minor version
+        version_regex <- '^"?([0-9]+\\.[0-9]+).*"?.*$'
+      } else {
+        # Only major version number
+        version_regex <- '^"?([0-9]+).*"?.*$'
+      }
+      os_version <- sub(version_regex, "\\1", vals["VERSION_ID"])
+    } else if ("PRETTY_NAME" %in% names(vals) && grepl("bullseye", vals["PRETTY_NAME"])) {
+      # debian unstable doesn't include a number but we can map from pretty name
+      os_version <- "11"
     }
-    os_version <- sub(version_regex, "\\1", vals["VERSION_ID"])
     os <- paste0(distro, "-", os_version)
   } else if (file.exists("/etc/system-release")) {
     # Something like "CentOS Linux release 7.7.1908 (Core)"
@@ -103,8 +111,6 @@ identify_os <- function(os = Sys.getenv("LIBARROW_BINARY", Sys.getenv("LIBARROW_
     os <- NULL
   }
 
-  # Now look to see if we can map this os-version to one we have binaries for
-  os <- find_available_binary(os)
   os
 }
 

--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -250,6 +250,8 @@ if (!file.exists(paste0(dst_dir, "/include/arrow/api.h"))) {
     if (!is.null(src_dir)) {
       cat("*** Building C++ libraries\n")
       build_libarrow(src_dir, dst_dir)
+    } else {
+      cat("*** Proceeding without C++ dependencies\n")
     }
   } else {
    cat("*** Proceeding without C++ dependencies\n")


### PR DESCRIPTION
This adds a nightly job that tests on debian bullseye (11). We already test on Ubuntu bionic (what `rocker/r-ubuntu` provides)