### PR TITLE
ARROW-8077: [Python][Packaging] Add Windows Python 3.5 wheel build script

### DIFF
--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -48,7 +48,7 @@ build_script:
   - rd /s /q C:\OpenSSL-v111-Win32
   - rd /s /q C:\OpenSSL-v111-Win64
 
-  - call %ARROW_SRC%\dev\tasks\python-wheels\win-build.bat
+  - call %ARROW_SRC%\dev\tasks\python-wheels\{{ script }}
 
 after_build:
   # the artifacts must be uploaded from a directory relative to the build root

--- a/dev/tasks/python-wheels/win-build-3.5.bat
+++ b/dev/tasks/python-wheels/win-build-3.5.bat
@@ -78,7 +78,7 @@ conda create -n wheel-test -c conda-forge -q -y python=3.5 || exit /B
 call conda.bat activate wheel-test
 
 @rem install the built wheel
-pip install -vv --no-index --find-links=%ARROW_SRC%\python\dist\ pyarrow || exit /B
+pip install -vv %ARROW_SRC%\python\dist\pyarrow-%PYARROW_VERSION%-cp35-cp35m-win_amd64.whl || exit /B
 
 @rem test the imports
 python -c "import pyarrow; import pyarrow.parquet" || exit /B

--- a/dev/tasks/python-wheels/win-build-3.5.bat
+++ b/dev/tasks/python-wheels/win-build-3.5.bat
@@ -65,8 +65,7 @@ set PYARROW_BUNDLE_ARROW_CPP=1
 set SETUPTOOLS_SCM_PRETEND_VERSION=%PYARROW_VERSION%
 
 pushd %ARROW_SRC%\python
-python setup.py build_ext --extra-cmake-args="-DZLIB_ROOT=%CONDA_PREFIX%\Library"
-       bdist_wheel || exit /B
+python setup.py build_ext --extra-cmake-args="-DZLIB_ROOT=%CONDA_PREFIX%\Library" bdist_wheel || exit /B
 popd
 
 call conda.bat deactivate

--- a/dev/tasks/python-wheels/win-build-3.5.bat
+++ b/dev/tasks/python-wheels/win-build-3.5.bat
@@ -1,0 +1,83 @@
+@rem Licensed to the Apache Software Foundation (ASF) under one
+@rem or more contributor license agreements.  See the NOTICE file
+@rem distributed with this work for additional information
+@rem regarding copyright ownership.  The ASF licenses this file
+@rem to you under the Apache License, Version 2.0 (the
+@rem "License"); you may not use this file except in compliance
+@rem with the License.  You may obtain a copy of the License at
+@rem
+@rem   http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing,
+@rem software distributed under the License is distributed on an
+@rem "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@rem KIND, either express or implied.  See the License for the
+@rem specific language governing permissions and limitations
+@rem under the License.
+
+@echo on
+
+@rem create conda environment for compiling
+conda update --yes --quiet conda
+
+conda create -n wheel-build -q -y -c conda-forge ^
+    python=3.5 ^
+    zlib || exit /B
+
+call conda.bat activate wheel-build
+
+@rem Cannot use conda_env_python.yml here because conda-forge has
+@rem ceased providing up-to-date packages for Python 3.5
+pip install -r %ARROW_SRC%\python\requirements-wheel.txt
+
+set ARROW_HOME=%CONDA_PREFIX%\Library
+set PARQUET_HOME=%CONDA_PREFIX%\Library
+echo %ARROW_HOME%
+
+@rem Build Arrow C++ libraries
+mkdir %ARROW_SRC%\cpp\build
+pushd %ARROW_SRC%\cpp\build
+
+cmake -G "%GENERATOR%" ^
+      -DCMAKE_INSTALL_PREFIX=%ARROW_HOME% ^
+      -DARROW_BOOST_USE_SHARED=OFF ^
+      -DCMAKE_BUILD_TYPE=Release ^
+      -DARROW_DEPENDENCY_SOURCE=BUNDLED ^
+      -DZLIB_SOURCE=SYSTEM ^
+      -DZLIB_ROOT=%CONDA_PREFIX%\Library ^
+      -DARROW_CXXFLAGS="/MP" ^
+      -DARROW_WITH_ZLIB=ON ^
+      -DARROW_WITH_ZSTD=ON ^
+      -DARROW_WITH_LZ4=ON ^
+      -DARROW_WITH_SNAPPY=ON ^
+      -DARROW_WITH_BROTLI=ON ^
+      -DARROW_PYTHON=ON ^
+      -DARROW_PARQUET=ON ^
+      .. || exit /B
+cmake --build . --target install --config Release || exit /B
+popd
+
+set PYARROW_BUILD_TYPE=Release
+set PYARROW_PARALLEL=8
+set PYARROW_WITH_PARQUET=1
+set PYARROW_WITH_STATIC_BOOST=1
+set PYARROW_BUNDLE_ARROW_CPP=1
+set SETUPTOOLS_SCM_PRETEND_VERSION=%PYARROW_VERSION%
+
+pushd %ARROW_SRC%\python
+python setup.py build_ext --extra-cmake-args="-DZLIB_ROOT=%CONDA_PREFIX%\Library"
+       bdist_wheel || exit /B
+popd
+
+call conda.bat deactivate
+
+set ARROW_TEST_DATA=%ARROW_SRC%\testing\data
+
+@rem install the built wheel
+pip install -vv --no-index --find-links=%ARROW_SRC%\python\dist\ pyarrow || exit /B
+
+@rem test the imports
+python -c "import pyarrow; import pyarrow.parquet" || exit /B
+
+@rem run the python tests
+pytest -rs --pyargs pyarrow || exit /B

--- a/dev/tasks/python-wheels/win-build-3.5.bat
+++ b/dev/tasks/python-wheels/win-build-3.5.bat
@@ -72,6 +72,11 @@ call conda.bat deactivate
 
 set ARROW_TEST_DATA=%ARROW_SRC%\testing\data
 
+@rem test the wheel
+@rem TODO For maximum reliability, we should test in a plain virtualenv instead.
+conda create -n wheel-test -c conda-forge -q -y python=3.5 || exit /B
+call conda.bat activate wheel-test
+
 @rem install the built wheel
 pip install -vv --no-index --find-links=%ARROW_SRC%\python\dist\ pyarrow || exit /B
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -627,11 +627,22 @@ tasks:
 
   ############################## Wheel Windows ################################
 
+  wheel-win-cp35m:
+    ci: appveyor
+    platform: win
+    template: python-wheels/appveyor.yml
+    params:
+      script: win-build-3.5.bat
+      python_version: 3.5
+    artifacts:
+      - pyarrow-{no_rc_version}-cp35-cp35m-win_amd64.whl
+
   wheel-win-cp36m:
     ci: appveyor
     platform: win
     template: python-wheels/appveyor.yml
     params:
+      script: win-build.bat
       python_version: 3.6
     artifacts:
       - pyarrow-{no_rc_version}-cp36-cp36m-win_amd64.whl
@@ -641,6 +652,7 @@ tasks:
     platform: win
     template: python-wheels/appveyor.yml
     params:
+      script: win-build.bat
       python_version: 3.7
     artifacts:
       - pyarrow-{no_rc_version}-cp37-cp37m-win_amd64.whl
@@ -650,6 +662,7 @@ tasks:
     platform: win
     template: python-wheels/appveyor.yml
     params:
+      script: win-build.bat
       python_version: 3.8
     artifacts:
       - pyarrow-{no_rc_version}-cp38-cp38-win_amd64.whl


### PR DESCRIPTION
This is my best guess of what will work once ARROW-8067 is fixed (this problem arose after 0.16.0 in https://github.com/apache/arrow/commit/c707d8b121172ecb1ab5ffa65e80cb8f846a83b1). @kszucs can you assist with the Crossbow setup? @pitrou may need your help fixing ARROW-8067