### PR TITLE
ARROW-7741: [C++] Adds parquet write support for nested types

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -105,7 +105,11 @@ ArrayData ArrayData::Slice(int64_t off, int64_t len) const {
   auto copy = *this;
   copy.length = len;
   copy.offset = off;
-  copy.null_count = null_count != 0 ? kUnknownNullCount : 0;
+  if (null_count == length) {
+    copy.null_count = len;
+  } else {
+    copy.null_count = null_count != 0 ? kUnknownNullCount : 0;
+  }
   return copy;
 }
 

--- a/cpp/src/arrow/array_test.cc
+++ b/cpp/src/arrow/array_test.cc
@@ -79,6 +79,16 @@ TEST_F(TestArray, TestNullCount) {
   ASSERT_EQ(kUnknownNullCount, arr_default_null_count->data()->null_count);
 }
 
+TEST_F(TestArray, TestSlicePreservesAllNullCount) {
+  // These are placeholders
+  auto data = std::make_shared<Buffer>(nullptr, 0);
+  auto null_bitmap = std::make_shared<Buffer>(nullptr, 0);
+
+  Int32Array arr(/*length=*/100, data, null_bitmap,
+                 /*null_count*/ 100);
+  EXPECT_EQ(arr.Slice(1, 99)->data()->null_count, arr.Slice(1, 99)->length());
+}
+
 TEST_F(TestArray, TestLength) {
   // Placeholder buffer
   auto data = std::make_shared<Buffer>(nullptr, 0);

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -874,21 +874,21 @@ class MultipathLevelBuilder::Impl {
 };
 
 // static
-::arrow::Result<std::unique_ptr<MultipathLevelBuilder>> MultipathLevelBuilder::Create(
-    const ::arrow::Array& array, bool array_nullable) {
-  auto constructor = ::arrow::internal::make_unique<PathBuilder>(array_nullable);
+::arrow::Result<std::unique_ptr<MultipathLevelBuilder>> MultipathLevelBuilder::Make(
+    const ::arrow::Array& array, bool array_field_nullable) {
+  auto constructor = ::arrow::internal::make_unique<PathBuilder>(array_field_nullable);
   RETURN_NOT_OK(VisitArrayInline(array, constructor.get()));
   return std::unique_ptr<MultipathLevelBuilder>(new MultipathLevelBuilder(
       new MultipathLevelBuilder::Impl(array.data(), std::move(constructor))));
 }
 
 // static
-Status MultipathLevelBuilder::Write(const Array& array, bool array_nullable,
+Status MultipathLevelBuilder::Write(const Array& array, bool array_field_nullable,
                                     ArrowWriteContext* context,
                                     MultipathLevelBuilder::CallbackFunction callback) {
   ARROW_ASSIGN_OR_RAISE(std::unique_ptr<MultipathLevelBuilder> builder,
-                        MultipathLevelBuilder::Create(array, array_nullable));
-  PathBuilder constructor(array_nullable);
+                        MultipathLevelBuilder::Make(array, array_field_nullable));
+  PathBuilder constructor(array_field_nullable);
   RETURN_NOT_OK(VisitArrayInline(array, &constructor));
   for (int leaf_idx = 0; leaf_idx < builder->GetLeafCount(); leaf_idx++) {
     RETURN_NOT_OK(builder->Write(leaf_idx, context, callback));

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -863,7 +863,9 @@ class MultipathLevelBuilderImpl : public MultipathLevelBuilder {
         data_(std::move(data)),
         path_builder_(std::move(path_builder)) {}
 
-  int GetLeafCount() const override { return path_builder_->paths().size(); }
+  int GetLeafCount() const override {
+    return static_cast<int>(path_builder_->paths().size());
+  }
 
   ::arrow::Status Write(int leaf_index, ArrowWriteContext* context,
                         CallbackFunction write_leaf_callback) override {

--- a/cpp/src/parquet/arrow/path_internal.h
+++ b/cpp/src/parquet/arrow/path_internal.h
@@ -131,11 +131,11 @@ class PARQUET_EXPORT MultipathLevelBuilder {
   static ::arrow::Result<std::unique_ptr<MultipathLevelBuilder>> Make(
       const ::arrow::Array& array, bool array_field_nullable);
 
-  ~MultipathLevelBuilder();
+  virtual ~MultipathLevelBuilder() = default;
 
   /// \brief Returns the number of leaf columns that need to be written
   /// to Parquet.
-  int GetLeafCount() const;
+  virtual int GetLeafCount() const = 0;
 
   /// \brief Calls write_leaf_callback with the MultipathLevelBuilderResult corresponding
   /// to |leaf_index|.
@@ -143,16 +143,8 @@ class PARQUET_EXPORT MultipathLevelBuilder {
   /// \param[in] The index of the leaf column to write.  Must be in the range [0,
   /// GetLeafCount()]. \param[in, out] context for use when allocating memory, etc.
   /// \param[out] write_leaf_callback Callback to receive the result.
-  ::arrow::Status Write(int leaf_index, ArrowWriteContext* context,
-                        CallbackFunction write_leaf_callback);
-
- private:
-  class Impl;
-  explicit MultipathLevelBuilder(Impl* impl);
-  // Not copyable.
-  MultipathLevelBuilder(const MultipathLevelBuilder&) = delete;
-  MultipathLevelBuilder& operator=(const MultipathLevelBuilder&) = delete;
-  Impl* impl_;
+  virtual ::arrow::Status Write(int leaf_index, ArrowWriteContext* context,
+                                CallbackFunction write_leaf_callback) = 0;
 };
 
 }  // namespace arrow

--- a/cpp/src/parquet/arrow/path_internal.h
+++ b/cpp/src/parquet/arrow/path_internal.h
@@ -118,7 +118,7 @@ class PARQUET_EXPORT MultipathLevelBuilder {
   /// \param[in, out] context for use when allocating memory, etc.
   /// \param[out] write_leaf_callback Callback to receive results.
   /// There will be one call to the write_leaf_callback for each leaf node.
-  static ::arrow::Status Write(const ::arrow::Array& array, bool array_nullable,
+  static ::arrow::Status Write(const ::arrow::Array& array, bool array_field_nullable,
                                ArrowWriteContext* context,
                                CallbackFunction write_leaf_callback);
 
@@ -139,9 +139,10 @@ class PARQUET_EXPORT MultipathLevelBuilder {
 
   /// \brief Calls write_leaf_callback with the MultipathLevelBuilderResult corresponding
   /// to |leaf_index|.
-
-  /// \param[in] The index of the leaf column to write.  Must be in the range [0,
-  /// GetLeafCount()]. \param[in, out] context for use when allocating memory, etc.
+  ///
+  /// \param[in] leaf_index The index of the leaf column to write.  Must be in the range
+  /// [0, GetLeafCount()].
+  /// \param[in, out] context for use when allocating memory, etc.
   /// \param[out] write_leaf_callback Callback to receive the result.
   virtual ::arrow::Status Write(int leaf_index, ArrowWriteContext* context,
                                 CallbackFunction write_leaf_callback) = 0;

--- a/cpp/src/parquet/arrow/path_internal.h
+++ b/cpp/src/parquet/arrow/path_internal.h
@@ -148,7 +148,7 @@ class PARQUET_EXPORT MultipathLevelBuilder {
 
  private:
   class Impl;
-  MultipathLevelBuilder(Impl* impl);
+  explicit MultipathLevelBuilder(Impl* impl);
   // Not copyable.
   MultipathLevelBuilder(const MultipathLevelBuilder&) = delete;
   MultipathLevelBuilder& operator=(const MultipathLevelBuilder&) = delete;

--- a/cpp/src/parquet/arrow/path_internal.h
+++ b/cpp/src/parquet/arrow/path_internal.h
@@ -112,8 +112,9 @@ class PARQUET_EXPORT MultipathLevelBuilder {
   /// first traversal-order.
   ///
   /// \param[in] array The array to process.
-  /// \param[in] array_nullable Whether the algorithm should consider
-  ///   the elements in the top level array nullable.
+  /// \param[in] array_field_nullable Whether the algorithm should consider
+  ///   the the array column as nullable (as determined by its type's parent
+  ///   field).
   /// \param[in, out] context for use when allocating memory, etc.
   /// \param[out] write_leaf_callback Callback to receive results.
   /// There will be one call to the write_leaf_callback for each leaf node.
@@ -124,10 +125,11 @@ class PARQUET_EXPORT MultipathLevelBuilder {
   /// \brief Construct a new instance of the builder.
   ///
   /// \param[in] array The array to process.
-  /// \param[in] array_nullable Whether the algorithm should consider
-  ///   the elements in the top level array nullable.
-  static ::arrow::Result<std::unique_ptr<MultipathLevelBuilder>> Create(
-      const ::arrow::Array& array, bool array_nullable);
+  /// \param[in] array_field_nullable Whether the algorithm should consider
+  ///   the the array column as nullable (as determined by its type's parent
+  ///   field).
+  static ::arrow::Result<std::unique_ptr<MultipathLevelBuilder>> Make(
+      const ::arrow::Array& array, bool array_field_nullable);
 
   ~MultipathLevelBuilder();
 

--- a/cpp/src/parquet/arrow/path_internal_test.cc
+++ b/cpp/src/parquet/arrow/path_internal_test.cc
@@ -82,6 +82,13 @@ class CapturedResult {
     EXPECT_THAT(rep_levels_, ElementsAreArray(expected_rep));
   }
 
+  friend void PrintTo(const CapturedResult& result, std::ostream* os) {
+    // This print method is to silence valgrind issues.  Whats printed
+    // is not important because all asserts happen directly on
+    // members.
+    *os << null_def_levels << " " << null_rep_levels;
+  }
+
  private:
   std::vector<int16_t> def_levels_;
   std::vector<int16_t> rep_levels_;
@@ -382,8 +389,6 @@ TEST_F(MultipathLevelBuilderTest, TripleNestedListsAllPresent) {
                          0, 3, 3, 2, 3, 3, 1, 3, 3  // first row
                      });
 }
-
-// TODO test empty.
 
 TEST_F(MultipathLevelBuilderTest, TripleNestedListsWithSomeNullsSomeEmptys) {
   auto entries = field("Entries", ::arrow::int64(), /*nullable=*/true);

--- a/cpp/src/parquet/arrow/path_internal_test.cc
+++ b/cpp/src/parquet/arrow/path_internal_test.cc
@@ -82,12 +82,13 @@ class CapturedResult {
     EXPECT_THAT(rep_levels_, ElementsAreArray(expected_rep));
   }
 
-  friend void PrintTo(const CapturedResult& result, std::ostream* os) {
+  friend std::ostream& operator<<(std::ostream& os, const CapturedResult& result) {
     // This print method is to silence valgrind issues.  Whats printed
     // is not important because all asserts happen directly on
     // members.
-    *os << "CapturedResult (null def, null_rep):" << result.null_def_levels << " "
-        << result.null_rep_levels;
+    os << "CapturedResult (null def, null_rep):" << result.null_def_levels << " "
+       << result.null_rep_levels;
+    return os;
   }
 
  private:

--- a/cpp/src/parquet/arrow/path_internal_test.cc
+++ b/cpp/src/parquet/arrow/path_internal_test.cc
@@ -86,7 +86,8 @@ class CapturedResult {
     // This print method is to silence valgrind issues.  Whats printed
     // is not important because all asserts happen directly on
     // members.
-    *os << null_def_levels << " " << null_rep_levels;
+    *os << "CapturedResult (null def, null_rep):" << result.null_def_levels << " "
+        << result.null_rep_levels;
   }
 
  private:

--- a/cpp/src/parquet/arrow/test_util.h
+++ b/cpp/src/parquet/arrow/test_util.h
@@ -402,6 +402,7 @@ Status MakeEmptyListsArray(int64_t size, std::shared_ptr<Array>* out_array) {
   array_data->child_data.push_back(child_data);
 
   *out_array = ::arrow::MakeArray(array_data);
+  (*out_array)->null_count();
   return Status::OK();
 }
 

--- a/cpp/src/parquet/arrow/test_util.h
+++ b/cpp/src/parquet/arrow/test_util.h
@@ -402,7 +402,6 @@ Status MakeEmptyListsArray(int64_t size, std::shared_ptr<Array>* out_array) {
   array_data->child_data.push_back(child_data);
 
   *out_array = ::arrow::MakeArray(array_data);
-  (*out_array)->null_count();
   return Status::OK();
 }
 

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -344,8 +344,8 @@ Status GetLeafType(const ::arrow::DataType& type, ::arrow::Type::type* leaf_type
 // supported by parquet.
 class ArrowColumnWriterV2 {
  public:
-  // Constructs a new object (use Make() method below to construct from 
-  // A ChunkedArray).  
+  // Constructs a new object (use Make() method below to construct from
+  // A ChunkedArray).
   // level_builders should contain one MultipathLevelBuilder per chunk of the
   // Arrow-column to write.
   ArrowColumnWriterV2(std::vector<std::unique_ptr<MultipathLevelBuilder>> level_builders,

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -369,7 +369,7 @@ class ArrowColumnWriterV2 {
                                                result.def_rep_level_count, *values_array,
                                                ctx);
             }));
-      };
+      }
 
       PARQUET_CATCH_NOT_OK(column_writer->Close());
     }
@@ -377,7 +377,7 @@ class ArrowColumnWriterV2 {
     return Status::OK();
   }
 
-  static ::arrow::Result<std::unique_ptr<ArrowColumnWriterV2>> Create(
+  static ::arrow::Result<std::unique_ptr<ArrowColumnWriterV2>> Make(
       const ChunkedArray& data, int64_t offset, const int64_t size,
       const SchemaManifest& schema_manifest, RowGroupWriter* row_group_writer) {
     int64_t absolute_position = 0;
@@ -442,9 +442,8 @@ class ArrowColumnWriterV2 {
       std::shared_ptr<Array> array_to_write = chunk.Slice(chunk_offset, chunk_write_size);
 
       if (array_to_write->length() > 0) {
-        ARROW_ASSIGN_OR_RAISE(
-            std::unique_ptr<MultipathLevelBuilder> builder,
-            MultipathLevelBuilder::Create(*array_to_write, is_nullable));
+        ARROW_ASSIGN_OR_RAISE(std::unique_ptr<MultipathLevelBuilder> builder,
+                              MultipathLevelBuilder::Make(*array_to_write, is_nullable));
         if (leaf_count != builder->GetLeafCount()) {
           return Status::UnknownError("data type leaf_count != builder_leaf_count",
                                       leaf_count, " ", builder->GetLeafCount());
@@ -632,8 +631,8 @@ class FileWriterImpl : public FileWriter {
     } else if (arrow_properties_->engine_version() == ArrowWriterProperties::V2) {
       ARROW_ASSIGN_OR_RAISE(
           std::unique_ptr<ArrowColumnWriterV2> writer,
-          ArrowColumnWriterV2::Create(*data, offset, size, schema_manifest_,
-                                      row_group_writer_));
+          ArrowColumnWriterV2::Make(*data, offset, size, schema_manifest_,
+                                    row_group_writer_));
       return writer->Write(&column_write_context_);
     }
     return Status::NotImplemented("Unknown engine version.");

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -31,7 +31,9 @@
 #include "arrow/table.h"
 #include "arrow/type.h"
 #include "arrow/util/base64.h"
+#include "arrow/util/make_unique.h"
 #include "arrow/visitor_inline.h"
+#include "parquet/arrow/path_internal.h"
 #include "parquet/arrow/reader_internal.h"
 #include "parquet/arrow/schema.h"
 #include "parquet/column_writer.h"
@@ -44,6 +46,7 @@ using arrow::Array;
 using arrow::BinaryArray;
 using arrow::BooleanArray;
 using arrow::ChunkedArray;
+using arrow::DataType;
 using arrow::Decimal128Array;
 using arrow::DictionaryArray;
 using arrow::Field;
@@ -67,6 +70,32 @@ namespace parquet {
 namespace arrow {
 
 namespace {
+
+int CalculateLeafCount(const DataType& type) {
+  if (type.num_children() == 0) {
+    // Primitive type.
+    return 1;
+  }
+
+  int num_leaves = 0;
+  for (std::shared_ptr<Field> field : type.children()) {
+    num_leaves += CalculateLeafCount(*(field->type()));
+  }
+  return num_leaves;
+}
+
+// Determines if the |schema_field|'s root ancestor is nullable.
+bool HasNullableRoot(const SchemaManifest& schema_manifest,
+                     const SchemaField* schema_field) {
+  DCHECK(schema_field != nullptr);
+  const SchemaField* current_field = schema_field;
+  bool nullable = schema_field->field->nullable();
+  while (current_field != nullptr) {
+    nullable = current_field->field->nullable();
+    current_field = schema_manifest.GetParent(current_field);
+  }
+  return nullable;
+}
 
 class LevelBuilder {
  public:
@@ -311,6 +340,134 @@ Status GetLeafType(const ::arrow::DataType& type, ::arrow::Type::type* leaf_type
   }
 }
 
+class ArrowColumnWriterV2 {
+ public:
+  ArrowColumnWriterV2(std::vector<std::unique_ptr<MultipathLevelBuilder>> level_builders,
+                      int leaf_count, RowGroupWriter* row_group_writer)
+      : level_builders_(std::move(level_builders)),
+        leaf_count_(leaf_count),
+        row_group_writer_(row_group_writer) {}
+
+  Status Write(ArrowWriteContext* ctx) {
+    for (int leaf_idx = 0; leaf_idx < leaf_count_; leaf_idx++) {
+      ColumnWriter* column_writer;
+      PARQUET_CATCH_NOT_OK(column_writer = row_group_writer_->NextColumn());
+      for (auto& level_builder : level_builders_) {
+        RETURN_NOT_OK(level_builder->Write(
+            leaf_idx, ctx, [&](const MultipathLevelBuilderResult& result) {
+              size_t visited_component_size = result.post_list_visited_elements.size();
+              DCHECK_GT(visited_component_size, 0);
+              if (visited_component_size != 1) {
+                return Status::NotImplemented(
+                    "Lists with non-zero length null components are not supported");
+              }
+              const ElementRange& range = result.post_list_visited_elements[0];
+              std::shared_ptr<Array> values_array =
+                  result.leaf_array->Slice(range.start, range.Size());
+
+              return column_writer->WriteArrow(result.def_levels, result.rep_levels,
+                                               result.def_rep_level_count, *values_array,
+                                               ctx);
+            }));
+      };
+
+      PARQUET_CATCH_NOT_OK(column_writer->Close());
+    }
+
+    return Status::OK();
+  }
+
+  static ::arrow::Result<std::unique_ptr<ArrowColumnWriterV2>> Create(
+      const ChunkedArray& data, int64_t offset, const int64_t size,
+      const SchemaManifest& schema_manifest, RowGroupWriter* row_group_writer) {
+    int64_t absolute_position = 0;
+    int chunk_index = 0;
+    int64_t chunk_offset = 0;
+    if (data.length() == 0) {
+      return ::arrow::internal::make_unique<ArrowColumnWriterV2>(
+          std::vector<std::unique_ptr<MultipathLevelBuilder>>{},
+          CalculateLeafCount(*data.type()), row_group_writer);
+    }
+    while (chunk_index < data.num_chunks() && absolute_position < offset) {
+      const int64_t chunk_length = data.chunk(chunk_index)->length();
+      if (absolute_position + chunk_length > offset) {
+        // Relative offset into the chunk to reach the desired start offset for
+        // writing
+        chunk_offset = offset - absolute_position;
+        break;
+      } else {
+        ++chunk_index;
+        absolute_position += chunk_length;
+      }
+    }
+
+    if (absolute_position >= data.length()) {
+      return Status::Invalid("Cannot write data at offset past end of chunked array");
+    }
+
+    int64_t values_written = 0;
+    std::vector<std::unique_ptr<MultipathLevelBuilder>> builders;
+    const int leaf_count = CalculateLeafCount(*data.type());
+    bool is_nullable;
+    // The row_group_writer hasn't been advanced yet so add 1 to the current
+    // which is the one this instance will start writing for.
+    int column_index = row_group_writer->current_column() + 1;
+    for (int leaf_offset = 0; leaf_offset < leaf_count; ++leaf_offset) {
+      const SchemaField* schema_field = nullptr;
+      RETURN_NOT_OK(
+          schema_manifest.GetColumnField(column_index + leaf_offset, &schema_field));
+      bool nullable_root = HasNullableRoot(schema_manifest, schema_field);
+      if (leaf_offset == 0) {
+        is_nullable = nullable_root;
+      }
+
+// Don't validate common ancestry for all leafs if not in debug.
+#ifndef NDEBUG
+      break;
+#else
+      if (is_nullable != nullable_root) {
+        return Status::UnknownError(
+            "Unexpected mismatched nullability between column index",
+            column_index + leaf_offset, " and ", column_index);
+      }
+#endif
+    }
+    while (values_written < size) {
+      const Array& chunk = *data.chunk(chunk_index);
+      const int64_t available_values = chunk.length() - chunk_offset;
+      const int64_t chunk_write_size = std::min(size - values_written, available_values);
+
+      // The chunk offset here will be 0 except for possibly the first chunk
+      // because of the advancing logic above
+      std::shared_ptr<Array> array_to_write = chunk.Slice(chunk_offset, chunk_write_size);
+
+      if (array_to_write->length() > 0) {
+        ARROW_ASSIGN_OR_RAISE(
+            std::unique_ptr<MultipathLevelBuilder> builder,
+            MultipathLevelBuilder::Create(*array_to_write, is_nullable));
+        if (leaf_count != builder->GetLeafCount()) {
+          return Status::UnknownError("data type leaf_count != builder_leaf_count",
+                                      leaf_count, " ", builder->GetLeafCount());
+        }
+        builders.emplace_back(std::move(builder));
+      }
+
+      if (chunk_write_size == available_values) {
+        chunk_offset = 0;
+        ++chunk_index;
+      }
+      values_written += chunk_write_size;
+    }
+    return ::arrow::internal::make_unique<ArrowColumnWriterV2>(
+        std::move(builders), leaf_count, row_group_writer);
+  }
+
+ private:
+  std::vector<std::unique_ptr<MultipathLevelBuilder>> level_builders_;
+  int leaf_count_;
+  RowGroupWriter* row_group_writer_;
+};
+
 class ArrowColumnWriter {
  public:
   ArrowColumnWriter(ArrowWriteContext* ctx, ColumnWriter* column_writer,
@@ -460,16 +617,26 @@ class FileWriterImpl : public FileWriter {
 
   Status WriteColumnChunk(const std::shared_ptr<ChunkedArray>& data, int64_t offset,
                           int64_t size) override {
-    ColumnWriter* column_writer;
-    PARQUET_CATCH_NOT_OK(column_writer = row_group_writer_->NextColumn());
+    if (arrow_properties_->engine_version() == ArrowWriterProperties::V1) {
+      ColumnWriter* column_writer;
+      PARQUET_CATCH_NOT_OK(column_writer = row_group_writer_->NextColumn());
 
-    const SchemaField* schema_field = nullptr;
-    RETURN_NOT_OK(schema_manifest_.GetColumnField(row_group_writer_->current_column(),
-                                                  &schema_field));
-    ArrowColumnWriter arrow_writer(&column_write_context_, column_writer, schema_field,
-                                   &schema_manifest_);
-    RETURN_NOT_OK(arrow_writer.Write(*data, offset, size));
-    return arrow_writer.Close();
+      const SchemaField* schema_field = nullptr;
+      RETURN_NOT_OK(schema_manifest_.GetColumnField(row_group_writer_->current_column(),
+                                                    &schema_field));
+
+      ArrowColumnWriter arrow_writer(&column_write_context_, column_writer, schema_field,
+                                     &schema_manifest_);
+      RETURN_NOT_OK(arrow_writer.Write(*data, offset, size));
+      return arrow_writer.Close();
+    } else if (arrow_properties_->engine_version() == ArrowWriterProperties::V2) {
+      ARROW_ASSIGN_OR_RAISE(
+          std::unique_ptr<ArrowColumnWriterV2> writer,
+          ArrowColumnWriterV2::Create(*data, offset, size, schema_manifest_,
+                                      row_group_writer_));
+      return writer->Write(&column_write_context_);
+    }
+    return Status::NotImplemented("Unknown engine version.");
   }
 
   Status WriteColumnChunk(const std::shared_ptr<::arrow::ChunkedArray>& data) override {

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -69,7 +69,8 @@ class PARQUET_EXPORT RowGroupWriter {
   /// directly written to the sink, once a new column is started, the contents
   /// of the previous one cannot be modified anymore.
   ColumnWriter* NextColumn();
-  /// Index of currently written column
+  /// Index of currently written column. Equal to -1 if NextColumn()
+  /// has not been called yet.
   int current_column();
   void Close();
 


### PR DESCRIPTION
1.  Keeps the old version around (without unit tests) under V1 and
    make this version (V2) a default
2.  Reworks PathInternal slightly to preserve column at a time writing
    with chunked columns.  Address @bkietz comment that the vendored
    visitor implementation for variants supports a return type.
3.  While debugging I found we don't preserve all null counts when
    slicing, so included a small patch and unit test for that.

I'll plan on adding bindings in python for the versioning in a follow-up CR that can also be toggled with a environment variable in case regressions are encountered "in the wild"