### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -78,9 +78,9 @@ jobs:
           pip install cython setuptools pytest jira
           wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
           sudo dpkg -i packages-microsoft-prod.deb
-          sudo apt-get install apt-transport-https
+          sudo apt-get --no-install-recommends install apt-transport-https
           sudo apt-get update
-          sudo apt-get install dotnet-sdk-2.2
+          sudo apt-get --no-install-recommends install dotnet-sdk-2.2
       - name: Run Release Test
         shell: bash
         run: |

--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -129,7 +129,7 @@ to build Arrow GLib. You can install them by the followings:
 On Debian GNU/Linux or Ubuntu:
 
 ```console
-% sudo apt install -y -V gtk-doc-tools autoconf-archive libgirepository1.0-dev meson ninja-build
+% sudo apt-get --no-install-recommends install -y -V gtk-doc-tools autoconf-archive libgirepository1.0-dev meson ninja-build
 ```
 
 On CentOS 7 or later:
@@ -225,7 +225,7 @@ You can install them by the followings:
 On Debian GNU/Linux or Ubuntu:
 
 ```console
-% sudo apt install -y -V ruby-dev
+% sudo apt-get --no-install-recommends install -y -V ruby-dev
 % sudo gem install bundler
 % (cd c_glib && bundle install)
 ```

--- a/c_glib/example/lua/README.md
+++ b/c_glib/example/lua/README.md
@@ -29,7 +29,7 @@ Arrow GLib based bindings.
 Here are command lines to install LGI on Debian GNU/Linux and Ubuntu:
 
 ```text
-% sudo apt install -y luarocks
+% sudo apt-get --no-install-recommends install -y luarocks
 % sudo luarocks install lgi
 ```
 

--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -25,7 +25,7 @@ ARG prefix=/opt/conda
 # install build essentials
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y -q && \
-    apt-get install -y -q wget tzdata libc6-dbg \
+    apt-get --no-install-recommends install -y -q wget tzdata libc6-dbg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/conda-python-turbodbc.dockerfile
+++ b/ci/docker/conda-python-turbodbc.dockerfile
@@ -22,7 +22,7 @@ FROM ${repo}:${arch}-conda-python-${python}
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q --no-install-recommends \
         odbc-postgresql \
         postgresql \
         sudo && \

--- a/ci/docker/conda-r.dockerfile
+++ b/ci/docker/conda-r.dockerfile
@@ -21,7 +21,7 @@ FROM ${repo}:${arch}-conda-cpp
 
 # Need locales so we can set UTF-8
 RUN apt-get update -y && \
-    apt-get install -y locales && \
+    apt-get --no-install-recommends install -y locales && \
     locale-gen en_US.UTF-8 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/cuda-10.0-cpp.dockerfile
+++ b/ci/docker/cuda-10.0-cpp.dockerfile
@@ -24,13 +24,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q --no-install-recommends \
       wget software-properties-common gpg-agent && \
       apt-get clean && rm -rf /var/lib/apt/lists*
 
 # Installs C++ toolchain and dependencies
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q --no-install-recommends \
       autoconf \
       ca-certificates \
       ccache \

--- a/ci/docker/cuda-10.1-cpp.dockerfile
+++ b/ci/docker/cuda-10.1-cpp.dockerfile
@@ -24,13 +24,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q --no-install-recommends \
       wget software-properties-common gpg-agent && \
       apt-get clean && rm -rf /var/lib/apt/lists*
 
 # Installs C++ toolchain and dependencies
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q --no-install-recommends \
       autoconf \
       ca-certificates \
       ccache \

--- a/ci/docker/cuda-9.1-cpp.dockerfile
+++ b/ci/docker/cuda-9.1-cpp.dockerfile
@@ -24,13 +24,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q --no-install-recommends \
       wget software-properties-common && \
       apt-get clean && rm -rf /var/lib/apt/lists*
 
 # Installs C++ toolchain and dependencies
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q --no-install-recommends \
       autoconf \
       ca-certificates \
       ccache \

--- a/ci/docker/debian-10-cpp.dockerfile
+++ b/ci/docker/debian-10-cpp.dockerfile
@@ -21,7 +21,7 @@ FROM ${arch}/debian:10
 # install build essentials
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q --no-install-recommends \
         autoconf \
         ca-certificates \
         ccache \

--- a/ci/docker/debian-10-rust.dockerfile
+++ b/ci/docker/debian-10-rust.dockerfile
@@ -20,7 +20,7 @@ FROM ${arch}/rust
 
 # install pre-requisites for building flatbuffers
 RUN apt-get update -y && \
-    apt-get install -y build-essential cmake && \
+    apt-get --no-install-recommends install -y build-essential cmake && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/linux-apt-c-glib.dockerfile
+++ b/ci/docker/linux-apt-c-glib.dockerfile
@@ -19,7 +19,7 @@ ARG base
 FROM ${base}
 
 RUN apt-get update -y -q && \
-    apt-get install -y -q \
+    apt-get --no-install-recommends install -y -q \
         python3 \
         python3-pip \
         gtk-doc-tools \

--- a/ci/docker/linux-apt-cmake.dockerfile
+++ b/ci/docker/linux-apt-cmake.dockerfile
@@ -19,7 +19,7 @@ ARG base
 FROM ${base}
 
 RUN apt-get update && \
-    apt-get install -y -q \
+    apt-get --no-install-recommends install -y -q \
         libidn11 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -22,7 +22,7 @@ ARG r=3.6
 ARG jdk=8
 
 RUN apt-get update -y && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
         dirmngr \
         apt-transport-https \
         software-properties-common && \
@@ -30,7 +30,7 @@ RUN apt-get update -y && \
         --keyserver keyserver.ubuntu.com \
         --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
     add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu '$(lsb_release -cs)'-cran35/' && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
         autoconf-archive \
         automake \
         doxygen \
@@ -58,7 +58,7 @@ ENV PATH=/opt/apache-maven-${maven}/bin:$PATH
 
 ARG node=11
 RUN wget -q -O - https://deb.nodesource.com/setup_${node}.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get --no-install-recommends install -y nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/linux-apt-jni.dockerfile
+++ b/ci/docker/linux-apt-jni.dockerfile
@@ -21,7 +21,7 @@ FROM ${base}
 # install build essentials
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q \
         ca-certificates \
         ccache \
         clang-7 \

--- a/ci/docker/linux-apt-lint.dockerfile
+++ b/ci/docker/linux-apt-lint.dockerfile
@@ -20,7 +20,7 @@ FROM hadolint/hadolint:v1.17.2 AS hadolint
 FROM ${base}
 
 RUN apt-get update && \
-    apt-get install -y -q \
+    apt-get --no-install-recommends install -y -q \
         clang-7 \
         clang-format-7 \
         clang-tidy-7 \

--- a/ci/docker/linux-apt-python-3.dockerfile
+++ b/ci/docker/linux-apt-python-3.dockerfile
@@ -19,7 +19,7 @@ ARG base
 FROM ${base}
 
 RUN apt-get update -y -q && \
-    apt-get install -y -q \
+    apt-get --no-install-recommends install -y -q \
         python3 \
         python3-pip \
         python3-dev && \

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -23,7 +23,7 @@ FROM ${base}
 # [2] https://linuxize.com/post/how-to-install-r-on-ubuntu-18-04/#installing-r-packages-from-cran
 ARG r=3.6
 RUN apt-get update -y && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
         dirmngr \
         apt-transport-https \
         software-properties-common && \
@@ -34,7 +34,7 @@ RUN apt-get update -y && \
     # R 3.2, 3.3, 3.4 are available without the suffix but only for trusty and xenial
     # TODO: make sure OS version and R version are valid together and conditionally set repo suffix
     add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu '$(lsb_release -cs)'-cran35/' && \
-    apt-get install -y \
+    apt-get --no-install-recommends install -y \
         r-base=${r}* \
         # system libs needed by core R packages
         libxml2-dev \

--- a/ci/docker/ubuntu-14.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-14.04-cpp.dockerfile
@@ -22,8 +22,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends wget software-properties-common && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q wget software-properties-common && \
+    apt-get --no-install-recommends install -y -q \
         autoconf \
         ca-certificates \
         ccache \

--- a/ci/docker/ubuntu-16.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-16.04-cpp.dockerfile
@@ -22,14 +22,14 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q \
         apt-transport-https \
         software-properties-common \
         wget && \
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-add-repository -y "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" && \
     apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q \
         autoconf \
         ca-certificates \
         ccache \

--- a/ci/docker/ubuntu-18.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-18.04-cpp.dockerfile
@@ -25,7 +25,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q \
         wget \
         software-properties-common \
         gpg-agent && \
@@ -42,7 +42,7 @@ ARG llvm_apt_url="http://apt.llvm.org/bionic/"
 ARG llvm_apt_arch="llvm-toolchain-bionic-${llvm_version}"
 RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-add-repository -y --update "deb ${llvm_apt_url} ${llvm_apt_arch} main" && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q \
         clang-${llvm_version} \
         clang-format-${llvm_version} \
         clang-tidy-${llvm_version} \
@@ -52,7 +52,7 @@ RUN wget -q -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
 
 # Installs C++ toolchain and dependencies
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q \
         autoconf \
         ca-certificates \
         ccache \

--- a/ci/docker/ubuntu-18.04-r-sanitizer.dockerfile
+++ b/ci/docker/ubuntu-18.04-r-sanitizer.dockerfile
@@ -19,7 +19,7 @@ FROM wch1/r-debug:latest
 
 # Installs C++ toolchain and dependencies
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q \
       autoconf \
       ca-certificates \
       ccache \

--- a/cpp/examples/minimal_build/Dockerfile
+++ b/cpp/examples/minimal_build/Dockerfile
@@ -20,7 +20,7 @@ FROM ubuntu:bionic
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y -q && \
-    apt-get install -y -q --no-install-recommends \
+    apt-get --no-install-recommends install -y -q \
       build-essential \
       cmake && \
       apt-get clean && rm -rf /var/lib/apt/lists*

--- a/dev/release/VERIFY.md
+++ b/dev/release/VERIFY.md
@@ -43,7 +43,7 @@ You need the followings to verify C GLib build:
 You can install them by the followings on Debian GNU/Linux and Ubuntu:
 
 ```console
-% sudo apt install -y -V libgirepository1.0-dev ruby-dev
+% sudo apt-get --no-install-recommends install -y -V libgirepository1.0-dev ruby-dev
 % sudo gem install gobject-introspection test-unit
 ```
 

--- a/dev/release/binary/Dockerfile
+++ b/dev/release/binary/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     apt-utils \
     createrepo \
     devscripts \

--- a/dev/release/source/Dockerfile
+++ b/dev/release/source/Dockerfile
@@ -20,7 +20,7 @@ FROM debian:buster
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt update && \
-  apt install -y -V \
+  apt-get --no-install-recommends install -y -V \
     autoconf-archive \
     gtk-doc-tools \
     libgirepository1.0-dev \

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -37,7 +37,7 @@ deb_version="${VERSION}-1"
 export DEBIAN_FRONTEND=noninteractive
 
 apt update
-apt install -y -V \
+apt-get --no-install-recommends install -y -V \
   curl \
   lsb-release
 
@@ -87,7 +87,7 @@ keyring_archive_base_name="apache-arrow-archive-keyring-latest-${code_name}.deb"
 curl \
   --output "${keyring_archive_base_name}" \
   "${bintray_base_url}/${keyring_archive_base_name}"
-apt install -y -V "./${keyring_archive_base_name}"
+apt-get --no-install-recommends install -y -V "./${keyring_archive_base_name}"
 if [ "${BINTRAY_REPOSITORY}" = "apache/arrow" ]; then
   if [ "${IS_RC}" = "yes" ]; then
     sed \
@@ -111,25 +111,25 @@ fi
 
 apt update
 
-apt install -y -V libarrow-glib-dev=${deb_version}
-apt install -y -V libarrow-glib-doc=${deb_version}
+apt-get --no-install-recommends install -y -V libarrow-glib-dev=${deb_version}
+apt-get --no-install-recommends install -y -V libarrow-glib-doc=${deb_version}
 
 if [ "${have_flight}" = "yes" ]; then
-  apt install -y -V libarrow-flight-dev=${deb_version}
+  apt-get --no-install-recommends install -y -V libarrow-flight-dev=${deb_version}
 fi
 
-apt install -y -V libarrow-python-dev=${deb_version}
+apt-get --no-install-recommends install -y -V libarrow-python-dev=${deb_version}
 
 if [ "${have_plasma}" = "yes" ]; then
-  apt install -y -V libplasma-glib-dev=${deb_version}
-  apt install -y -V libplasma-glib-doc=${deb_version}
-  apt install -y -V plasma-store-server=${deb_version}
+  apt-get --no-install-recommends install -y -V libplasma-glib-dev=${deb_version}
+  apt-get --no-install-recommends install -y -V libplasma-glib-doc=${deb_version}
+  apt-get --no-install-recommends install -y -V plasma-store-server=${deb_version}
 fi
 
 if [ "${have_gandiva}" = "yes" ]; then
-  apt install -y -V libgandiva-glib-dev=${deb_version}
-  apt install -y -V libgandiva-glib-doc=${deb_version}
+  apt-get --no-install-recommends install -y -V libgandiva-glib-dev=${deb_version}
+  apt-get --no-install-recommends install -y -V libgandiva-glib-doc=${deb_version}
 fi
 
-apt install -y -V libparquet-glib-dev=${deb_version}
-apt install -y -V libparquet-glib-doc=${deb_version}
+apt-get --no-install-recommends install -y -V libparquet-glib-dev=${deb_version}
+apt-get --no-install-recommends install -y -V libparquet-glib-doc=${deb_version}

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/debian-buster/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/debian-buster/Dockerfile
@@ -26,7 +26,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     debhelper \
     devscripts \
     gnupg && \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/debian-stretch/Dockerfile
@@ -26,7 +26,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     debhelper \
     devscripts \
     gnupg && \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-bionic/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-bionic/Dockerfile
@@ -26,7 +26,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     debhelper \
     devscripts \
     gnupg && \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-disco/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-disco/Dockerfile
@@ -26,7 +26,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     debhelper \
     devscripts \
     gnupg && \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-eoan/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-eoan/Dockerfile
@@ -26,7 +26,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     debhelper \
     devscripts \
     gnupg && \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-xenial/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-xenial/Dockerfile
@@ -26,7 +26,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     debhelper \
     devscripts \
     gnupg && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-buster/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-buster/Dockerfile
@@ -31,7 +31,7 @@ RUN sed -i'' -e 's/main$/main contrib non-free/g' /etc/apt/sources.list
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     bison \
     build-essential \
     clang-7 \
@@ -67,7 +67,7 @@ RUN \
     tzdata \
     zlib1g-dev && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get --no-install-recommends install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \
   pip3 install --upgrade meson && \
   ln -s /usr/local/bin/meson /usr/bin/ && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
@@ -34,14 +34,14 @@ RUN \
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     gnupg \
     wget && \
   wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
   echo "deb http://apt.llvm.org/stretch/ llvm-toolchain-stretch-7 main" > \
     /etc/apt/sources.list.d/llvm.list && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     bison \
     build-essential \
     clang-7 \
@@ -72,13 +72,13 @@ RUN \
     python3-pip \
     tzdata \
     zlib1g-dev && \
-  apt install -y -V -t stretch-backports ${quiet} \
+  apt-get --no-install-recommends install -y -V -t stretch-backports ${quiet} \
     debhelper \
     libgmock-dev \
     libgtest-dev \
     rapidjson-dev && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V -t stretch-backports ${quiet} nvidia-cuda-toolkit; \
+    apt-get --no-install-recommends install -y -V -t stretch-backports ${quiet} nvidia-cuda-toolkit; \
   fi && \
   pip3 install --upgrade meson && \
   ln -s /usr/local/bin/meson /usr/bin/ && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-bionic/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-bionic/Dockerfile
@@ -29,7 +29,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     bison \
     build-essential \
     clang-7 \
@@ -62,9 +62,9 @@ RUN \
     tzdata \
     zlib1g-dev && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get --no-install-recommends install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \
-  apt install -y -V -t bionic-backports ${quiet} \
+  apt-get --no-install-recommends install -y -V -t bionic-backports ${quiet} \
     debhelper && \
   pip3 install --upgrade meson && \
   ln -s /usr/local/bin/meson /usr/bin/ && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-disco/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-disco/Dockerfile
@@ -29,7 +29,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     bison \
     build-essential \
     clang-7 \
@@ -64,7 +64,7 @@ RUN \
     tzdata \
     zlib1g-dev && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get --no-install-recommends install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \
   apt clean && \
   pip3 install --upgrade meson && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-eoan/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-eoan/Dockerfile
@@ -29,7 +29,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     bison \
     build-essential \
     clang-7 \
@@ -64,7 +64,7 @@ RUN \
     tzdata \
     zlib1g-dev && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get --no-install-recommends install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \
   apt clean && \
   pip3 install --upgrade meson && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-xenial/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-xenial/Dockerfile
@@ -29,7 +29,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     apt-transport-https \
     gnupg \
     wget && \
@@ -37,7 +37,7 @@ RUN \
   echo "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" > \
     /etc/apt/sources.list.d/llvm.list && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     autoconf-archive \
     bison \
     build-essential \
@@ -69,10 +69,10 @@ RUN \
     python3-numpy \
     zlib1g-dev && \
   if apt list | grep '^clang-7/'; then \
-    apt install -y -V ${quiet} clang-7; \
+    apt-get --no-install-recommends install -y -V ${quiet} clang-7; \
   fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get --no-install-recommends install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*

--- a/dev/tasks/linux-packages/github.linux.arm64.yml
+++ b/dev/tasks/linux-packages/github.linux.arm64.yml
@@ -42,7 +42,7 @@ jobs:
       # or Ubuntu 18.10 or later.
       - name: Prepare qemu-user-static
         run: |
-          sudo apt install -y qemu-user-static unar
+          sudo apt-get --no-install-recommends install -y qemu-user-static unar
           wget http://archive.ubuntu.com/ubuntu/pool/universe/q/qemu/qemu-user-static_3.1+dfsg-2ubuntu3.7_amd64.deb
           unar *.deb
           rm *.deb

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -44,7 +44,7 @@ On Ubuntu/Debian you can install the requirements with:
 
 .. code-block:: shell
 
-   sudo apt-get install \
+   sudo apt-get --no-install-recommends install \
         build-essential \
         cmake
 

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -228,7 +228,7 @@ dependencies will be automatically built by Arrow's third-party toolchain.
 
 .. code-block:: shell
 
-   $ sudo apt-get install libjemalloc-dev libboost-dev \
+   $ sudo apt-get --no-install-recommends install libjemalloc-dev libboost-dev \
                           libboost-filesystem-dev \
                           libboost-system-dev \
                           libboost-regex-dev \

--- a/python/manylinux1/Dockerfile-x86_64_ubuntu
+++ b/python/manylinux1/Dockerfile-x86_64_ubuntu
@@ -18,7 +18,7 @@ FROM ubuntu:14.04
 
 # Install dependencies
 RUN apt update
-RUN apt install -y ccache flex wget curl build-essential git libffi-dev autoconf pkg-config
+RUN apt-get --no-install-recommends install -y ccache flex wget curl build-essential git libffi-dev autoconf pkg-config
 
 ADD scripts/build_zlib.sh /
 RUN /build_zlib.sh


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>