### PR TITLE
ARROW-8101: [FlightRPC][Java] Fix null arrays in Flight with no buffers

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -958,6 +958,14 @@ def generate_null_case(batch_sizes):
     return _generate_file('null', fields, batch_sizes)
 
 
+def generate_null_trivial_case(batch_sizes):
+    # Generate a case with no buffers
+    fields = [
+        NullType(name='f0'),
+    ]
+    return _generate_file('null_trivial', fields, batch_sizes)
+
+
 def generate_decimal_case():
     fields = [
         DecimalType(name='f{}'.format(i), precision=precision, scale=2)
@@ -1097,6 +1105,10 @@ def get_generated_json_files(tempdir=None, flight=False):
         generate_primitive_case([0, 0, 0], name='primitive_zerolength'),
 
         generate_null_case([10, 0])
+        .skip_category('JS')   # TODO(ARROW-7900)
+        .skip_category('Go'),  # TODO(ARROW-7901)
+
+        generate_null_trivial_case([0, 0])
         .skip_category('JS')   # TODO(ARROW-7900)
         .skip_category('Go'),  # TODO(ARROW-7901)
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
@@ -291,7 +291,7 @@ class ArrowMessage implements AutoCloseable {
 
       Preconditions.checkArgument(getMessageType() == HeaderType.RECORD_BATCH ||
           getMessageType() == HeaderType.DICTIONARY_BATCH);
-      Preconditions.checkArgument(!bufs.isEmpty());
+      // There may be no buffers in the case that we write only a null array
       Preconditions.checkArgument(descriptor == null, "Descriptor should only be included in the schema message.");
 
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -326,7 +326,8 @@ class ArrowMessage implements AutoCloseable {
 
       ArrowBuf initialBuf = allocator.buffer(baos.size());
       initialBuf.writeBytes(baos.toByteArray());
-      final CompositeByteBuf bb = new CompositeByteBuf(allocator.getAsByteBufAllocator(), true, bufs.size() + 1,
+      final CompositeByteBuf bb = new CompositeByteBuf(allocator.getAsByteBufAllocator(), true,
+          Math.max(2, bufs.size() + 1),
           ImmutableList.<ByteBuf>builder().add(initialBuf.asNettyBuffer()).addAll(allBufs).build());
       final ByteBufInputStream is = new DrainableByteBufInputStream(bb);
       return is;


### PR DESCRIPTION
Java assumes that at least one buffer is always written, but this is not the case when you have an empty null array.