### PR TITLE
ARROW-8108: [Java] Extract a common interface for dictionary encoders

### DIFF
--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/DictionaryEncoder.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/DictionaryEncoder.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.algorithm.dictionary;
+
+import org.apache.arrow.vector.BaseIntVector;
+import org.apache.arrow.vector.ValueVector;
+
+/**
+ * A dictionary encoder translates one vector into another one based on a dictionary vector.
+ * According to Arrow specification, the encoded vector must be an integer based vector, which
+ * is the index of the original vector element in the dictionary.
+ * @param <E> type of the encoded vector.
+ * @param <D> type of the vector to encode. It is also the type of the dictionary vector.
+ */
+public interface DictionaryEncoder<E extends BaseIntVector, D extends ValueVector> {
+
+  /**
+   * Translates an input vector into an output vector.
+   * @param input the input vector.
+   * @param output the output vector. Note that it must be in a fresh state. At least,
+   *     all its validity bits should be clear.
+   */
+  void encode(D input, E output);
+}

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/HashTableDictionaryEncoder.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/HashTableDictionaryEncoder.java
@@ -30,7 +30,8 @@ import org.apache.arrow.vector.ElementAddressableVector;
  * @param <E> encoded vector type.
  * @param <D> decoded vector type, which is also the dictionary type.
  */
-public class HashTableDictionaryEncoder<E extends BaseIntVector, D extends ElementAddressableVector> {
+public class HashTableDictionaryEncoder<E extends BaseIntVector, D extends ElementAddressableVector>
+    implements DictionaryEncoder<E, D> {
 
   /**
    * The dictionary for encoding/decoding.
@@ -125,6 +126,7 @@ public class HashTableDictionaryEncoder<E extends BaseIntVector, D extends Eleme
    * @param input  the input vector.
    * @param output the output vector.
    **/
+  @Override
   public void encode(D input, E output) {
     for (int i = 0; i < input.getValueCount(); i++) {
       if (!encodeNull && input.isNull(i)) {

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/LinearDictionaryEncoder.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/LinearDictionaryEncoder.java
@@ -27,7 +27,8 @@ import org.apache.arrow.vector.compare.RangeEqualsVisitor;
  * @param <E> encoded vector type.
  * @param <D> decoded vector type, which is also the dictionary type.
  */
-public class LinearDictionaryEncoder<E extends BaseIntVector, D extends ValueVector> {
+public class LinearDictionaryEncoder<E extends BaseIntVector, D extends ValueVector>
+    implements DictionaryEncoder<E, D> {
 
   /**
    * The dictionary for encoding.
@@ -80,6 +81,7 @@ public class LinearDictionaryEncoder<E extends BaseIntVector, D extends ValueVec
    * @param output the output vector. Note that it must be in a fresh state. At least,
    *     all its validity bits should be clear.
    */
+  @Override
   public void encode(D input, E output) {
     for (int i = 0; i < input.getValueCount(); i++) {
       if (!encodeNull && input.isNull(i)) {

--- a/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/SearchDictionaryEncoder.java
+++ b/java/algorithm/src/main/java/org/apache/arrow/algorithm/dictionary/SearchDictionaryEncoder.java
@@ -27,7 +27,8 @@ import org.apache.arrow.vector.ValueVector;
  * @param <E> encoded vector type.
  * @param <D> decoded vector type, which is also the dictionary type.
  */
-public class SearchDictionaryEncoder<E extends BaseIntVector, D extends ValueVector> {
+public class SearchDictionaryEncoder<E extends BaseIntVector, D extends ValueVector>
+    implements DictionaryEncoder<E, D> {
 
   /**
    * The dictionary for encoding/decoding.
@@ -79,6 +80,7 @@ public class SearchDictionaryEncoder<E extends BaseIntVector, D extends ValueVec
    * @param output the output vector. Note that it must be in a fresh state. At least,
    *     all its validity bits should be clear.
    */
+  @Override
   public void encode(D input, E output) {
     for (int i = 0; i < input.getValueCount(); i++) {
       if (!encodeNull && input.isNull(i)) {


### PR DESCRIPTION
In this issue, we extract a common interfaces from existing dictionary encoders. This can be useful for scenarios when the client does not care about the encoder implementations.