### PR TITLE
ARROW-7927: [C++] Fix 'cpu_info.cc' compilation warning.

### DIFF
--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -377,7 +377,7 @@ int CpuInfo::num_cores() { return num_cores_; }
 std::string CpuInfo::model_name() { return model_name_; }
 
 void CpuInfo::SetDefaultCacheSize() {
-#ifdef _SC_LEVEL1_DCACHE_SIZE
+#if defined(_SC_LEVEL1_DCACHE_SIZE) && !defined(__aarch64__)
   // Call sysconf to query for the cache sizes
   cache_sizes_[0] = sysconf(_SC_LEVEL1_DCACHE_SIZE);
   cache_sizes_[1] = sysconf(_SC_LEVEL2_CACHE_SIZE);


### PR DESCRIPTION
On some aarch64 platform, '_SC_LEVEL1_DCACHE_SIZE' would be defined
but sysconf(_SC_LEVEL1_DCACHE_SIZE) doesn't work, always return 0;
