### PR TITLE
ARROW-8105: [Python] Fix segfault when shrunken masked array is passed to pyarrow.array

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -208,7 +208,8 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 raise ValueError("Cannot pass a numpy masked array and "
                                  "specify a mask at the same time")
             else:
-                mask = values.mask
+                # don't use shrunken masks
+                mask = None if values.mask is np.ma.nomask else values.mask
                 values = values.data
 
         if hasattr(values, '__arrow_array__'):

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1655,6 +1655,12 @@ def test_array_from_masked():
     with pytest.raises(ValueError, match="Cannot pass a numpy masked array"):
         pa.array(ma, mask=np.array([True, False, False, False]))
 
+def test_array_from_shrunken_masked():
+    ma = np.ma.array([0])
+    result = pa.array(ma)
+    expected = pa.array([0], type='int64')
+    assert expected.equals(result)
+
 
 def test_array_from_invalid_dim_raises():
     msg = "only handle 1-dimensional arrays"

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1657,7 +1657,7 @@ def test_array_from_masked():
 
 
 def test_array_from_shrunken_masked():
-    ma = np.ma.array([0])
+    ma = np.ma.array([0], dtype='int64')
     result = pa.array(ma)
     expected = pa.array([0], type='int64')
     assert expected.equals(result)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1655,6 +1655,7 @@ def test_array_from_masked():
     with pytest.raises(ValueError, match="Cannot pass a numpy masked array"):
         pa.array(ma, mask=np.array([True, False, False, False]))
 
+
 def test_array_from_shrunken_masked():
     ma = np.ma.array([0])
     result = pa.array(ma)


### PR DESCRIPTION
Needed to validate that the mask of the masked array wasn't equal to the nomask
constant which indicates that the masked array was shrunk