### PR TITLE
ARROW-8112: [FlightRPC][C++] make sure status codes round-trip through gRPC

### DIFF
--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -258,6 +258,24 @@ TEST(TestFlight, RoundtripStatus) {
       MakeFlightError(FlightStatusCode::Unavailable, "Test message"));
   ASSERT_NE(nullptr, detail);
   ASSERT_EQ(FlightStatusCode::Unavailable, detail->code());
+
+  Status status = internal::FromGrpcStatus(
+      internal::ToGrpcStatus(Status::NotImplemented("Sentinel")));
+  ASSERT_TRUE(status.IsNotImplemented());
+  ASSERT_THAT(status.message(), ::testing::HasSubstr("Sentinel"));
+
+  status = internal::FromGrpcStatus(internal::ToGrpcStatus(Status::Invalid("Sentinel")));
+  ASSERT_TRUE(status.IsInvalid());
+  ASSERT_THAT(status.message(), ::testing::HasSubstr("Sentinel"));
+
+  status = internal::FromGrpcStatus(internal::ToGrpcStatus(Status::KeyError("Sentinel")));
+  ASSERT_TRUE(status.IsKeyError());
+  ASSERT_THAT(status.message(), ::testing::HasSubstr("Sentinel"));
+
+  status =
+      internal::FromGrpcStatus(internal::ToGrpcStatus(Status::AlreadyExists("Sentinel")));
+  ASSERT_TRUE(status.IsAlreadyExists());
+  ASSERT_THAT(status.message(), ::testing::HasSubstr("Sentinel"));
 }
 
 TEST(TestFlight, GetPort) {

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -983,6 +983,13 @@ TEST_F(TestFlightClient, DoAction) {
   ASSERT_EQ(nullptr, result);
 }
 
+TEST_F(TestFlightClient, RoundTripStatus) {
+  const auto descr = FlightDescriptor::Command("status-outofmemory");
+  std::unique_ptr<FlightInfo> info;
+  const auto status = client_->GetFlightInfo(descr, &info);
+  ASSERT_RAISES(OutOfMemory, status);
+}
+
 TEST_F(TestFlightClient, Issue5095) {
   // Make sure the server-side error message is reflected to the
   // client

--- a/cpp/src/arrow/flight/internal.cc
+++ b/cpp/src/arrow/flight/internal.cc
@@ -164,6 +164,10 @@ grpc::Status ToGrpcStatus(const Status& arrow_status) {
     grpc_code = grpc::StatusCode::UNIMPLEMENTED;
   } else if (arrow_status.IsInvalid()) {
     grpc_code = grpc::StatusCode::INVALID_ARGUMENT;
+  } else if (arrow_status.IsKeyError()) {
+    grpc_code = grpc::StatusCode::NOT_FOUND;
+  } else if (arrow_status.IsAlreadyExists()) {
+    grpc_code = grpc::StatusCode::ALREADY_EXISTS;
   }
   return grpc::Status(grpc_code, message);
 }

--- a/cpp/src/arrow/flight/internal.cc
+++ b/cpp/src/arrow/flight/internal.cc
@@ -20,6 +20,7 @@
 #include "arrow/flight/protocol_internal.h"
 
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -45,12 +46,72 @@ namespace flight {
 namespace internal {
 
 const char* kGrpcAuthHeader = "auth-token-bin";
+const char* kGrpcStatusCodeHeader = "x-arrow-status";
+const char* kGrpcStatusMessageHeader = "x-arrow-status-message-bin";
+const char* kGrpcStatusDetailHeader = "x-arrow-status-detail-bin";
 
-Status FromGrpcStatus(const grpc::Status& grpc_status) {
-  if (grpc_status.ok()) {
-    return Status::OK();
+Status StatusCodeFromString(const grpc::string_ref& code_ref, StatusCode* code) {
+  // Bounce through std::string to get a proper null-terminated C string
+  const auto code_int = std::atoi(std::string(code_ref.data(), code_ref.size()).c_str());
+  switch (code_int) {
+    case static_cast<int>(StatusCode::OutOfMemory):
+    case static_cast<int>(StatusCode::KeyError):
+    case static_cast<int>(StatusCode::TypeError):
+    case static_cast<int>(StatusCode::Invalid):
+    case static_cast<int>(StatusCode::IOError):
+    case static_cast<int>(StatusCode::CapacityError):
+    case static_cast<int>(StatusCode::IndexError):
+    case static_cast<int>(StatusCode::UnknownError):
+    case static_cast<int>(StatusCode::NotImplemented):
+    case static_cast<int>(StatusCode::SerializationError):
+    case static_cast<int>(StatusCode::RError):
+    case static_cast<int>(StatusCode::CodeGenError):
+    case static_cast<int>(StatusCode::ExpressionValidationError):
+    case static_cast<int>(StatusCode::ExecutionError):
+    case static_cast<int>(StatusCode::AlreadyExists): {
+      *code = static_cast<StatusCode>(code_int);
+      return Status::OK();
+    }
+    default:
+      // Code is invalid
+      return Status::UnknownError("Unknown Arrow status code", code_ref);
+  }
+}
+
+/// Try to extract a status from gRPC trailers. If not found, return
+/// Status::OK.
+Status FromGrpcContext(const grpc::ClientContext& ctx, Status* status) {
+  const std::multimap<grpc::string_ref, grpc::string_ref>& trailers =
+      ctx.GetServerTrailingMetadata();
+  const auto code_val = trailers.find(kGrpcStatusCodeHeader);
+  if (code_val == trailers.end()) {
+    return Status::IOError("Status code header not found");
   }
 
+  const grpc::string_ref code_ref = (*code_val).second;
+  StatusCode code;
+  RETURN_NOT_OK(StatusCodeFromString(code_ref, &code));
+
+  const auto message_val = trailers.find(kGrpcStatusMessageHeader);
+  if (message_val == trailers.end()) {
+    return Status::IOError("Status message header not found");
+  }
+
+  const grpc::string_ref message_ref = (*message_val).second;
+  std::string message = std::string(message_ref.data(), message_ref.size());
+  const auto detail_val = trailers.find(kGrpcStatusDetailHeader);
+  if (detail_val != trailers.end()) {
+    const grpc::string_ref detail_ref = (*detail_val).second;
+    message += ". Detail: ";
+    message += std::string(detail_ref.data(), detail_ref.size());
+  }
+  *status = Status(code, message);
+  return Status::OK();
+}
+
+/// Convert a gRPC status to an Arrow status, ignoring any
+/// implementation-defined headers that encode further detail.
+Status FromGrpcCode(const grpc::Status& grpc_status) {
   switch (grpc_status.error_code()) {
     case grpc::StatusCode::OK:
       return Status::OK();
@@ -123,7 +184,32 @@ Status FromGrpcStatus(const grpc::Status& grpc_status) {
   }
 }
 
-grpc::Status ToGrpcStatus(const Status& arrow_status) {
+Status FromGrpcStatus(const grpc::Status& grpc_status, grpc::ClientContext* ctx) {
+  if (grpc_status.ok()) {
+    return Status::OK();
+  }
+
+  const Status status = FromGrpcCode(grpc_status);
+
+  if (ctx) {
+    Status arrow_status;
+
+    if (!FromGrpcContext(*ctx, &arrow_status).ok()) {
+      // If we fail to decode a more detailed status from the headers,
+      // proceed normally
+      return status;
+    }
+
+    if (status.detail()) {
+      return arrow_status.WithDetail(status.detail());
+    }
+    return arrow_status;
+  }
+  return status;
+}
+
+/// Convert an Arrow status to a gRPC status.
+grpc::Status ToRawGrpcStatus(const Status& arrow_status) {
   if (arrow_status.ok()) {
     return grpc::Status::OK;
   }
@@ -170,6 +256,27 @@ grpc::Status ToGrpcStatus(const Status& arrow_status) {
     grpc_code = grpc::StatusCode::ALREADY_EXISTS;
   }
   return grpc::Status(grpc_code, message);
+}
+
+/// Convert an Arrow status to a gRPC status, and add extra headers to
+/// the response to encode the original Arrow status.
+grpc::Status ToGrpcStatus(const Status& arrow_status, grpc::ServerContext* ctx) {
+  if (arrow_status.ok()) {
+    return grpc::Status::OK;
+  }
+
+  grpc::Status status = ToRawGrpcStatus(arrow_status);
+  if (ARROW_PREDICT_FALSE(!status.ok()) && ctx) {
+    const std::string code = std::to_string(static_cast<int>(arrow_status.code()));
+    ctx->AddTrailingMetadata(internal::kGrpcStatusCodeHeader, code);
+    ctx->AddTrailingMetadata(internal::kGrpcStatusMessageHeader, arrow_status.message());
+    if (arrow_status.detail()) {
+      const std::string detail_string = arrow_status.detail()->ToString();
+      ctx->AddTrailingMetadata(internal::kGrpcStatusDetailHeader, detail_string);
+    }
+  }
+
+  return status;
 }
 
 // ActionType

--- a/cpp/src/arrow/flight/internal.h
+++ b/cpp/src/arrow/flight/internal.h
@@ -67,14 +67,30 @@ namespace internal {
 ARROW_FLIGHT_EXPORT
 extern const char* kGrpcAuthHeader;
 
+/// The name of the header used to pass the exact Arrow status code.
+ARROW_FLIGHT_EXPORT
+extern const char* kGrpcStatusCodeHeader;
+
+/// The name of the header used to pass the exact Arrow status message.
+ARROW_FLIGHT_EXPORT
+extern const char* kGrpcStatusMessageHeader;
+
+/// The name of the header used to pass the exact Arrow status detail.
+ARROW_FLIGHT_EXPORT
+extern const char* kGrpcStatusDetailHeader;
+
 ARROW_FLIGHT_EXPORT
 Status SchemaToString(const Schema& schema, std::string* out);
 
+/// Convert a gRPC status to an Arrow status. Optionally, provide a
+/// ClientContext to recover the exact Arrow status if it was passed
+/// over the wire.
 ARROW_FLIGHT_EXPORT
-Status FromGrpcStatus(const grpc::Status& grpc_status);
+Status FromGrpcStatus(const grpc::Status& grpc_status,
+                      grpc::ClientContext* ctx = nullptr);
 
 ARROW_FLIGHT_EXPORT
-grpc::Status ToGrpcStatus(const Status& arrow_status);
+grpc::Status ToGrpcStatus(const Status& arrow_status, grpc::ServerContext* ctx = nullptr);
 
 // These functions depend on protobuf types which are not exported in the Flight DLL.
 

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -169,6 +169,12 @@ class FlightTestServer : public FlightServerBase {
 
   Status GetFlightInfo(const ServerCallContext& context, const FlightDescriptor& request,
                        std::unique_ptr<FlightInfo>* out) override {
+    // Test that Arrow-C++ status codes can make it through gRPC
+    if (request.type == FlightDescriptor::DescriptorType::CMD &&
+        request.cmd == "status-outofmemory") {
+      return Status::OutOfMemory("Sentinel");
+    }
+
     std::vector<FlightInfo> flights = ExampleFlightInfo();
 
     for (const auto& info : flights) {


### PR DESCRIPTION
There are still unmapped status codes, but these are the ones that correspond closely to a gRPC one. (OutOfMemory, for instance, doesn't quite line up with RESOURCE_EXHAUSTED since the latter is intended for some application-level resource like a disk quota, not an internal server error.)