### PR TITLE
ARROW-8092: [CI][Crossbow] OSX wheels fail on bundled bzip2

### DIFF
--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -38,7 +38,7 @@ function build_wheel {
     pushd $1
 
     # For bzip_ep to find the osx SDK headers
-    export CFLAGS="-isysroot $(xcrun --show-sdk-path)"
+    export SDKROOT="$(xcrun --show-sdk-path)"
 
     # Arrow is 64-bit-only at the moment
     export CFLAGS="-fPIC -arch x86_64 ${CFLAGS//"-arch i386"/}"

--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -37,6 +37,9 @@ function build_wheel {
 
     pushd $1
 
+    # For bzip_ep to find the osx SDK headers
+    export CFLAGS="-isysroot $(xcrun --show-sdk-path)"
+
     # Arrow is 64-bit-only at the moment
     export CFLAGS="-fPIC -arch x86_64 ${CFLAGS//"-arch i386"/}"
     export CXXFLAGS="-fPIC -arch x86_64 ${CXXFLAGS//"-arch i386"} -std=c++11"

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 os: osx
-osx_image: xcode11.2
+osx_image: xcode11.3
 language: generic
 
 # don't build twice


### PR DESCRIPTION
The root cause that the macos sdk headers are no longer installed, don't know why wasn't it an issue previously (perhaps travis has changed something or we changed something in the build config), investigating it.