### PR TITLE
ARROW-8110: [C#] BuildArrays fails if NestedType is included

### DIFF
--- a/csharp/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
@@ -122,10 +122,10 @@ namespace Apache.Arrow.Ipc
             }
 
             var recordBatchEnumerator = new RecordBatchEnumerator(in recordBatchMessage);
-
+            var schemaFieldIndex = 0;
             do
             {
-                var field = schema.GetFieldByIndex(recordBatchEnumerator.CurrentNodeIndex);
+                var field = schema.GetFieldByIndex(schemaFieldIndex++);
                 var fieldNode = recordBatchEnumerator.CurrentNode;
 
                 var arrayData = field.DataType.IsFixedPrimitive()

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -31,6 +31,7 @@ namespace Apache.Arrow.Tests
             Schema.Builder builder = new Schema.Builder();
             for (int i = 0; i < columnSetCount; i++)
             {
+                builder.Field(CreateField(new ListType(Int64Type.Default), i));
                 builder.Field(CreateField(BooleanType.Default, i));
                 builder.Field(CreateField(UInt8Type.Default, i));
                 builder.Field(CreateField(Int8Type.Default, i));
@@ -52,8 +53,6 @@ namespace Apache.Arrow.Tests
                 //builder.Field(CreateField(StringType.Default));
                 //builder.Field(CreateField(Time32Type.Default));
                 //builder.Field(CreateField(Time64Type.Default));
-
-                builder.Field(CreateField(new ListType(Int64Type.Default), i));
             }
 
             Schema schema = builder.Build();


### PR DESCRIPTION
Bug:
An ArgumentOutOfRange exception is thrown when using a NestedType column which is not at the end of RecordBatch columns.
(If RecordBatch columns have only one NestedType column and it is at the end of the columns, this exception is not thrown because this do-while loop breaks before executing GetFieldByIndex on a wrong index.)


- Use correct index number
- Change TestData in order to test this bug