### PR TITLE
ARROW-8121: [Java] Enhance code style checking for Java code (add spaces after commas, semi-colons and type casts)

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -753,7 +753,7 @@ public class AvroToArrowUtils {
 
   private static Map<String, String> getMetaData(Schema schema) {
     Map<String, String> metadata = new HashMap<>();
-    schema.getObjectProps().forEach((k,v) -> metadata.put(k, v.toString()));
+    schema.getObjectProps().forEach((k, v) -> metadata.put(k, v.toString()));
     return metadata;
   }
 

--- a/java/adapter/avro/src/test/java/org/apache/arrow/AvroSkipFieldTest.java
+++ b/java/adapter/avro/src/test/java/org/apache/arrow/AvroSkipFieldTest.java
@@ -362,9 +362,9 @@ public class AvroSkipFieldTest extends AvroTestBase {
       GenericRecord record = new GenericData.Record(schema);
       record.put(0, i % 2 == 0);
       record.put(1, i);
-      record.put(2, (long)i);
-      record.put(3, (float)i);
-      record.put(4, (double)i);
+      record.put(2, (long) i);
+      record.put(3, (float) i);
+      record.put(4, (double) i);
       data.add(record);
 
       GenericRecord expectedRecord = new GenericData.Record(expectedSchema);
@@ -395,9 +395,9 @@ public class AvroSkipFieldTest extends AvroTestBase {
       GenericRecord record = new GenericData.Record(schema);
       record.put(0, i % 2 == 0);
       record.put(1, i);
-      record.put(2, (long)i);
-      record.put(3, (float)i);
-      record.put(4, (double)i);
+      record.put(2, (long) i);
+      record.put(3, (float) i);
+      record.put(4, (double) i);
       data.add(record);
 
       GenericRecord expectedRecord = new GenericData.Record(expectedSchema);
@@ -428,9 +428,9 @@ public class AvroSkipFieldTest extends AvroTestBase {
       GenericRecord record = new GenericData.Record(schema);
       record.put(0, i % 2 == 0);
       record.put(1, i);
-      record.put(2, (long)i);
-      record.put(3, (float)i);
-      record.put(4, (double)i);
+      record.put(2, (long) i);
+      record.put(3, (float) i);
+      record.put(4, (double) i);
       data.add(record);
 
       GenericRecord expectedRecord = new GenericData.Record(expectedSchema);
@@ -461,9 +461,9 @@ public class AvroSkipFieldTest extends AvroTestBase {
       GenericRecord record = new GenericData.Record(schema);
       record.put(0, i % 2 == 0);
       record.put(1, i);
-      record.put(2, (long)i);
-      record.put(3, (float)i);
-      record.put(4, (double)i);
+      record.put(2, (long) i);
+      record.put(3, (float) i);
+      record.put(4, (double) i);
       data.add(record);
 
       GenericRecord expectedRecord = new GenericData.Record(expectedSchema);
@@ -494,9 +494,9 @@ public class AvroSkipFieldTest extends AvroTestBase {
       GenericRecord record = new GenericData.Record(schema);
       record.put(0, i % 2 == 0);
       record.put(1, i);
-      record.put(2, (long)i);
-      record.put(3, (float)i);
-      record.put(4, (double)i);
+      record.put(2, (long) i);
+      record.put(3, (float) i);
+      record.put(4, (double) i);
       data.add(record);
 
       GenericRecord expectedRecord = new GenericData.Record(expectedSchema);

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -427,7 +427,7 @@ public class JdbcToArrowUtils {
           throw new IllegalArgumentException("Column " + columnIndex + " is an array of unknown type.");
         }
         JdbcConsumer delegate = getConsumer(resultSet, JDBC_ARRAY_VALUE_COLUMN,
-            fieldInfo.getJdbcType(), ((ListVector)vector).getDataVector(), config);
+            fieldInfo.getJdbcType(), ((ListVector) vector).getDataVector(), config);
         return ArrayConsumer.createConsumer((ListVector) vector, delegate, columnIndex, nullable);
       case Types.CLOB:
         return ClobConsumer.createConsumer((VarCharVector) vector, columnIndex, nullable);

--- a/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
+++ b/java/adapter/orc/src/main/java/org/apache/arrow/adapter/orc/OrcStripeReader.java
@@ -65,7 +65,7 @@ public class OrcStripeReader extends ArrowReader {
       buffers.add(new ArrowBuf(
               new OrcReferenceManager(buffer),
               null,
-              (int)buffer.getSize(),
+              (int) buffer.getSize(),
               buffer.getMemoryAddress(),
               false));
     }

--- a/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
+++ b/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
@@ -88,8 +88,8 @@ public class OrcReaderTest {
     List<FieldVector> fields = schemaRoot.getFieldVectors();
     assertEquals(2, fields.size());
 
-    IntVector intVector = (IntVector)fields.get(0);
-    VarCharVector varCharVector = (VarCharVector)fields.get(1);
+    IntVector intVector = (IntVector) fields.get(0);
+    VarCharVector varCharVector = (VarCharVector) fields.get(1);
     for (int i = 0; i < 1024; ++i) {
       assertEquals(i, intVector.get(i));
       assertEquals("Last-" + (i * 3), new String(varCharVector.get(i), StandardCharsets.UTF_8));

--- a/java/dev/checkstyle/checkstyle.xml
+++ b/java/dev/checkstyle/checkstyle.xml
@@ -96,6 +96,9 @@
              <message key="ws.notPreceded"
              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
         </module>
+        <module name="WhitespaceAfter">
+            <property name="tokens" value="COMMA, SEMI, TYPECAST"/>
+        </module>
         <module name="OneStatementPerLine"/>
         <module name="MultipleVariableDeclarations"/>
         <module name="ArrayTypeStyle"/>

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
@@ -344,7 +344,7 @@ class ArrowMessage implements AutoCloseable {
         size += b.readableBytes();
         // [ARROW-4213] These buffers must be aligned to an 8-byte boundary in order to be readable from C++.
         if (b.readableBytes() % 8 != 0) {
-          int paddingBytes = (int)(8 - (b.readableBytes() % 8));
+          int paddingBytes = (int) (8 - (b.readableBytes() % 8));
           assert paddingBytes > 0 && paddingBytes < 8;
           size += paddingBytes;
           allBufs.add(PADDING_BUFFERS.get(paddingBytes).retain());

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/ExpressionRegistry.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/ExpressionRegistry.java
@@ -175,7 +175,7 @@ public class ExpressionRegistry {
       case GandivaType.NONE_VALUE:
         return new ArrowType.Null();
       case GandivaType.DECIMAL_VALUE:
-        return new ArrowType.Decimal(0,0);
+        return new ArrowType.Decimal(0, 0);
       case GandivaType.INTERVAL_VALUE:
         return new ArrowType.Interval(mapArrowIntervalUnit(type.getIntervalType()));
       case GandivaType.FIXED_SIZE_BINARY_VALUE:

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/Projector.java
@@ -258,7 +258,7 @@ public class Projector {
         hasVariableWidthColumns = true;
 
         // save vector to allow for resizing.
-        resizableVectors[outColumnIdx] = (BaseVariableWidthVector)valueVector;
+        resizableVectors[outColumnIdx] = (BaseVariableWidthVector) valueVector;
       }
       outAddrs[idx] = valueVector.getDataBuffer().memoryAddress();
       outSizes[idx++] = valueVector.getDataBuffer().capacity();

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt16.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/evaluator/SelectionVectorInt16.java
@@ -44,6 +44,6 @@ public class SelectionVectorInt16 extends SelectionVector {
     checkReadBounds(index);
 
     char value = getBuffer().getChar(index * getRecordSize());
-    return (int)value;
+    return (int) value;
   }
 }

--- a/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/InNode.java
+++ b/java/gandiva/src/main/java/org/apache/arrow/gandiva/expression/InNode.java
@@ -48,19 +48,19 @@ public class InNode implements TreeNode {
   }
 
   public static InNode makeIntInExpr(Field field, Set<Integer> intValues) {
-    return new InNode(intValues, null, null, null ,field);
+    return new InNode(intValues, null, null, null, field);
   }
 
   public static InNode makeLongInExpr(Field field, Set<Long> longValues) {
-    return new InNode(null, longValues, null, null ,field);
+    return new InNode(null, longValues, null, null, field);
   }
 
   public static InNode makeStringInExpr(Field field, Set<String> stringValues) {
-    return new InNode(null, null, stringValues, null ,field);
+    return new InNode(null, null, stringValues, null, field);
   }
 
   public static InNode makeBinaryInExpr(Field field, Set<byte[]> binaryValues) {
-    return new InNode(null, null, null, binaryValues ,field);
+    return new InNode(null, null, null, binaryValues, field);
   }
 
   @Override

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorDecimalTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorDecimalTest.java
@@ -73,8 +73,8 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
 
     int numRows = 4;
     byte[] validity = new byte[]{(byte) 255};
-    String[] aValues = new String[]{"1.12345678","2.12345678","3.12345678","4.12345678"};
-    String[] bValues = new String[]{"2.12345678","3.12345678","4.12345678","5.12345678"};
+    String[] aValues = new String[]{"1.12345678", "2.12345678", "3.12345678", "4.12345678"};
+    String[] bValues = new String[]{"2.12345678", "3.12345678", "4.12345678", "5.12345678"};
 
     DecimalVector valuesa = decimalVector(aValues, precision, scale);
     DecimalVector valuesb = decimalVector(bValues, precision, scale);
@@ -186,8 +186,8 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
 
     int numRows = 4;
     byte[] validity = new byte[]{(byte) 255};
-    String[] aValues = new String[]{"1.12345678","2.12345678","3.12345678", "999999999999.99999999"};
-    String[] bValues = new String[]{"2.12345678","3.12345678","4.12345678", "999999999999.99999999"};
+    String[] aValues = new String[]{"1.12345678", "2.12345678", "3.12345678", "999999999999.99999999"};
+    String[] bValues = new String[]{"2.12345678", "3.12345678", "4.12345678", "999999999999.99999999"};
 
     DecimalVector valuesa = decimalVector(aValues, precision, scale);
     DecimalVector valuesb = decimalVector(bValues, precision, scale);
@@ -742,7 +742,7 @@ public class ProjectorDecimalTest extends org.apache.arrow.gandiva.evaluator.Bas
             "field " + resultVector.getField().getName() +
             " for row " + i +
             " expected " + expected[i] +
-            ", got " + resultVector.getObject(i),expected[i].compareTo(resultVector.getObject(i)) == 0);
+            ", got " + resultVector.getObject(i), expected[i].compareTo(resultVector.getObject(i)) == 0);
       }
     } finally {
       // free buffers

--- a/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
+++ b/java/gandiva/src/test/java/org/apache/arrow/gandiva/evaluator/ProjectorTest.java
@@ -1182,7 +1182,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
     Field c1 = Field.nullable("c1", int32);
 
     TreeNode inExpr =
-            TreeBuilder.makeInExpressionInt32(c1, Sets.newHashSet(1,2,3,4,5,15,16));
+            TreeBuilder.makeInExpressionInt32(c1, Sets.newHashSet(1, 2, 3, 4, 5, 15, 16));
     ExpressionTree expr = TreeBuilder.makeExpression(inExpr, Field.nullable("result", boolType));
     Schema schema = new Schema(Lists.newArrayList(c1));
     Projector eval = Projector.make(schema, Lists.newArrayList(expr));
@@ -1246,7 +1246,7 @@ public class ProjectorTest extends BaseEvaluatorTest {
             new ArrowRecordBatch(
                     numRows,
                     Lists.newArrayList(fieldNode, fieldNode),
-                    Lists.newArrayList(c1Validity, dataBufsX.get(0),dataBufsX.get(1), c2Validity));
+                    Lists.newArrayList(c1Validity, dataBufsX.get(0), dataBufsX.get(1), c2Validity));
 
     BitVector bitVector = new BitVector(EMPTY_SCHEMA_PATH, allocator);
     bitVector.allocateNew(numRows);

--- a/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/NettyArrowBuf.java
@@ -58,7 +58,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
       final int length) {
     super(length);
     this.arrowBuf = arrowBuf;
-    this.arrowByteBufAllocator = (ArrowByteBufAllocator)arrowByteBufAllocator;
+    this.arrowByteBufAllocator = (ArrowByteBufAllocator) arrowByteBufAllocator;
     this.length = length;
     this.address = arrowBuf.memoryAddress();
   }
@@ -208,7 +208,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
   public ByteBuffer internalNioBuffer(int index, int length) {
     ByteBuffer nioBuf = getDirectBuffer(index);
     // Follows convention from other ByteBuf implementations.
-    return (ByteBuffer)nioBuf.clear().limit(length);
+    return (ByteBuffer) nioBuf.clear().limit(length);
   }
 
   @Override
@@ -303,11 +303,11 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
     } else {
       final long srcAddress = addr(index);
       if (dst.hasMemoryAddress()) {
-        final long dstAddress = dst.memoryAddress() + (long)dstIndex;
-        PlatformDependent.copyMemory(srcAddress, dstAddress, (long)length);
+        final long dstAddress = dst.memoryAddress() + (long) dstIndex;
+        PlatformDependent.copyMemory(srcAddress, dstAddress, (long) length);
       } else if (dst.hasArray()) {
         dstIndex += dst.arrayOffset();
-        PlatformDependent.copyMemory(srcAddress, dst.array(), dstIndex, (long)length);
+        PlatformDependent.copyMemory(srcAddress, dst.array(), dstIndex, (long) length);
       } else {
         dst.setBytes(dstIndex, this, index, length);
       }
@@ -325,11 +325,11 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
       if (length != 0) {
         final long dstAddress = addr(index);
         if (src.hasMemoryAddress()) {
-          final long srcAddress = src.memoryAddress() + (long)srcIndex;
-          PlatformDependent.copyMemory(srcAddress, dstAddress, (long)length);
+          final long srcAddress = src.memoryAddress() + (long) srcIndex;
+          PlatformDependent.copyMemory(srcAddress, dstAddress, (long) length);
         } else if (src.hasArray()) {
           srcIndex += src.arrayOffset();
-          PlatformDependent.copyMemory(src.array(), srcIndex, dstAddress, (long)length);
+          PlatformDependent.copyMemory(src.array(), srcIndex, dstAddress, (long) length);
         } else {
           src.getBytes(srcIndex, this, index, length);
         }
@@ -495,7 +495,7 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
   @Override
   protected void _setShortLE(int index, int value) {
     this.chk(index, 2);
-    PlatformDependent.putShort(this.addr(index), Short.reverseBytes((short)value));
+    PlatformDependent.putShort(this.addr(index), Short.reverseBytes((short) value));
   }
 
   @Override
@@ -543,8 +543,8 @@ public class NettyArrowBuf extends AbstractByteBuf implements AutoCloseable {
   protected void _setMediumLE(int index, int value) {
     this.chk(index, 3);
     long addr = this.addr(index);
-    PlatformDependent.putByte(addr, (byte)value);
-    PlatformDependent.putShort(addr + 1L, Short.reverseBytes((short)(value >>> 8)));
+    PlatformDependent.putByte(addr, (byte) value);
+    PlatformDependent.putShort(addr + 1L, Short.reverseBytes((short) (value >>> 8)));
   }
 
   @Override

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
@@ -133,7 +133,7 @@ public abstract class AllocationManager {
    * calling ReferenceManager drops to 0.
    */
   void release(final BufferLedger ledger) {
-    final BaseAllocator allocator = (BaseAllocator)ledger.getAllocator();
+    final BaseAllocator allocator = (BaseAllocator) ledger.getAllocator();
     allocator.assertOpen();
 
     // remove the <BaseAllocator, BufferLedger> mapping for the allocator
@@ -144,7 +144,7 @@ public abstract class AllocationManager {
 
     // needed for debug only: tell the allocator that AllocationManager is removing a
     // reference manager associated with this particular allocator
-    ((BaseAllocator)oldLedger.getAllocator()).dissociateLedger(oldLedger);
+    ((BaseAllocator) oldLedger.getAllocator()).dissociateLedger(oldLedger);
 
     if (oldLedger == owningLedger) {
       // the release call was made by the owning reference manager
@@ -152,10 +152,10 @@ public abstract class AllocationManager {
         // the only <allocator, reference manager> mapping was for the owner
         // which now has been removed, it implies we can safely destroy the
         // underlying memory chunk as it is no longer being referenced
-        ((BaseAllocator)oldLedger.getAllocator()).releaseBytes(getSize());
+        ((BaseAllocator) oldLedger.getAllocator()).releaseBytes(getSize());
         // free the memory chunk associated with the allocation manager
         release0();
-        ((BaseAllocator)oldLedger.getAllocator()).getListener().onRelease(getSize());
+        ((BaseAllocator) oldLedger.getAllocator()).getListener().onRelease(getSize());
         amDestructionTime = System.nanoTime();
         owningLedger = null;
       } else {

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcomeDetails.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationOutcomeDetails.java
@@ -50,7 +50,7 @@ public class AllocationOutcomeDetails {
   public BufferAllocator getFailedAllocator() {
     Entry top = allocEntries.peekLast();
     if (top != null && top.allocationFailed && (top.accountant instanceof BufferAllocator)) {
-      return (BufferAllocator)top.accountant;
+      return (BufferAllocator) top.accountant;
     } else {
       return null;
     }

--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -472,7 +472,7 @@ public final class ArrowBuf implements AutoCloseable {
    * @param value value to write
    */
   public void setShort(long index, int value) {
-    setShort(index, (short)value);
+    setShort(index, (short) value);
   }
 
   /**
@@ -609,7 +609,7 @@ public final class ArrowBuf implements AutoCloseable {
    */
   public void writeByte(int value) {
     ensureWritable(1);
-    MemoryUtil.UNSAFE.putByte(addr(writerIndex), (byte)value);
+    MemoryUtil.UNSAFE.putByte(addr(writerIndex), (byte) value);
     ++writerIndex;
   }
 
@@ -941,7 +941,7 @@ public final class ArrowBuf implements AutoCloseable {
       // address srcAddress into dst ArrowBuf starting at address
       // dstAddress
       final long srcAddress = addr(index);
-      final long dstAddress = dst.memoryAddress() + (long)dstIndex;
+      final long dstAddress = dst.memoryAddress() + (long) dstIndex;
       MemoryUtil.UNSAFE.copyMemory(null, srcAddress, null, dstAddress, length);
     }
   }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -323,7 +323,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
     // alternatively, if there was already a mapping for <buffer allocator, ref manager> in
     // allocation manager, the ref count of the new buffer will be targetrefmanager.refcount() + 1
     // and this will be true for all the existing buffers currently managed by targetrefmanager
-    final BufferLedger targetRefManager = allocationManager.associate((BaseAllocator)target);
+    final BufferLedger targetRefManager = allocationManager.associate((BaseAllocator) target);
     // create a new ArrowBuf to associate with new allocator and target ref manager
     final long targetBufLength = srcBuffer.capacity();
     ArrowBuf targetArrowBuf = targetRefManager.deriveBuffer(srcBuffer, 0, targetBufLength);
@@ -342,7 +342,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
   boolean transferBalance(final ReferenceManager targetReferenceManager) {
     Preconditions.checkArgument(targetReferenceManager != null,
         "Expecting valid target reference manager");
-    final BaseAllocator targetAllocator = (BaseAllocator)targetReferenceManager.getAllocator();
+    final BaseAllocator targetAllocator = (BaseAllocator) targetReferenceManager.getAllocator();
     Preconditions.checkArgument(allocator.root == targetAllocator.root,
         "You can only transfer between two allocators that share the same root.");
 
@@ -375,7 +375,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
       // since the transfer can only happen from the owning reference manager,
       // we need to set the target ref manager as the new owning ref manager
       // for the chunk of memory in allocation manager
-      allocationManager.setOwningLedger((BufferLedger)targetReferenceManager);
+      allocationManager.setOwningLedger((BufferLedger) targetReferenceManager);
       return overlimit;
     }
   }
@@ -420,7 +420,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
     // alternatively, if there was already a mapping for <buffer allocator, ref manager> in
     // allocation manager, the ref count of the new buffer will be targetrefmanager.refcount() + 1
     // and this will be true for all the existing buffers currently managed by targetrefmanager
-    final BufferLedger targetRefManager = allocationManager.associate((BaseAllocator)target);
+    final BufferLedger targetRefManager = allocationManager.associate((BaseAllocator) target);
     // create a new ArrowBuf to associate with new allocator and target ref manager
     final long targetBufLength = srcBuffer.capacity();
     final ArrowBuf targetArrowBuf = targetRefManager.deriveBuffer(srcBuffer, 0, targetBufLength);

--- a/java/memory/src/main/java/org/apache/arrow/memory/LowCostIdentityHashMap.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/LowCostIdentityHashMap.java
@@ -124,7 +124,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
     Preconditions.checkNotNull(key);
 
     int index = findIndex(key, elementData);
-    return (elementData[index] == null) ? false : ((V)elementData[index]).getKey() == key;
+    return (elementData[index] == null) ? false : ((V) elementData[index]).getKey() == key;
   }
 
   /**
@@ -158,7 +158,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
     int index = findIndex(key, elementData);
 
     return (elementData[index] == null) ? null :
-      (((V)elementData[index]).getKey() == key) ? (V)elementData[index] : null;
+      (((V) elementData[index]).getKey() == key) ? (V) elementData[index] : null;
   }
 
   /**
@@ -171,7 +171,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
     int index = getModuloHash(key, length);
     int last = (index + length - 1) % length;
     while (index != last) {
-      if ((array[index] == null) || ((V)array[index]).getKey() == key) {
+      if ((array[index] == null) || ((V) array[index]).getKey() == key) {
         /*
          * Found the key, or the next empty spot (which means key is not
          * in the table)
@@ -203,7 +203,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
     int index = findIndex(key, elementData);
 
     // if the key doesn't exist in the table
-    if (elementData[index] == null || ((V)elementData[index]).getKey() != key) {
+    if (elementData[index] == null || ((V) elementData[index]).getKey() != key) {
       if (++size > threshold) {
         rehash();
         index = findIndex(key, elementData);
@@ -228,7 +228,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
     }
     Object[] newData = newElementArray(newlength);
     for (int i = 0; i < elementData.length; i++) {
-      Object key = (elementData[i] == null) ? null : ((V)elementData[i]).getKey();
+      Object key = (elementData[i] == null) ? null : ((V) elementData[i]).getKey();
       if (key != null) {
         // if not empty
         int index = findIndex(key, newData);
@@ -261,7 +261,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
     Object object;
     index = next = findIndex(key, elementData);
 
-    if (elementData[index] == null || ((V)elementData[index]).getKey() != key) {
+    if (elementData[index] == null || ((V) elementData[index]).getKey() != key) {
       return null;
     }
 
@@ -281,7 +281,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
         break;
       }
 
-      hash = getModuloHash(((V)object).getKey(), length);
+      hash = getModuloHash(((V) object).getKey(), length);
       hashedOk = hash > index;
       if (next < index) {
         hashedOk = hashedOk || (hash <= next);
@@ -328,7 +328,7 @@ public class LowCostIdentityHashMap<K, V extends ValueWithKeyIncluded<K>> {
   public V getNextValue() {
     for (int i = 0; i < elementData.length; i++) {
       if (elementData[i] != null) {
-        return (V)elementData[i];
+        return (V) elementData[i];
       }
     }
     return null;

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/LargeMemoryUtil.java
@@ -41,6 +41,6 @@ public final class LargeMemoryUtil {
    * Returns a min(Integer.MAX_VALUE, length).
    */
   public static int capAtMaxInt(long length) {
-    return (int)Math.min(length, Integer.MAX_VALUE);
+    return (int) Math.min(length, Integer.MAX_VALUE);
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
@@ -143,7 +143,7 @@ public class MurmurHasher implements ArrowBufHasher {
    * @return the finalized hash code.
    */
   public static int finalizeHashCode(int hashCode, long length) {
-    hashCode = hashCode ^ (int)length;
+    hashCode = hashCode ^ (int) length;
 
     hashCode = hashCode ^ (hashCode >>> 16);
     hashCode = hashCode * 0x85ebca6b;

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -48,7 +48,7 @@ public class TestNettyArrowBuf {
          ArrowBuf buf = allocator.buffer(20);
     ) {
       NettyArrowBuf nettyBuf = buf.asNettyBuffer();
-      ByteBuffer byteBuffer = nettyBuf.nioBuffer(4 ,6);
+      ByteBuffer byteBuffer = nettyBuf.nioBuffer(4, 6);
       // Nio Buffers should always be 0 indexed
       Assert.assertEquals(0, byteBuffer.position());
       Assert.assertEquals(6, byteBuffer.limit());

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestLowCostIdentityHashMap.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestLowCostIdentityHashMap.java
@@ -47,11 +47,11 @@ public class TestLowCostIdentityHashMap {
 
     assertEquals(4, hashMap.size());
 
-    assertEquals(obj4,hashMap.get("s1key"));
+    assertEquals(obj4, hashMap.get("s1key"));
 
     assertNull(hashMap.remove("abc"));
 
-    assertEquals(obj3,hashMap.remove("s3key"));
+    assertEquals(obj3, hashMap.remove("s3key"));
 
     assertEquals(3, hashMap.size());
 
@@ -68,7 +68,7 @@ public class TestLowCostIdentityHashMap {
     assertTrue(hashMap.containsValue(obj2));
     assertTrue(hashMap.containsValue(obj5));
 
-    assertEquals(obj4,hashMap.remove("s1key"));
+    assertEquals(obj4, hashMap.remove("s1key"));
 
     nextValue = hashMap.getNextValue();
 
@@ -78,8 +78,8 @@ public class TestLowCostIdentityHashMap {
 
     assertEquals(2, hashMap.size());
 
-    assertEquals(obj2,hashMap.remove("s2key"));
-    assertEquals(obj5,hashMap.remove("s5key"));
+    assertEquals(obj2, hashMap.remove("s2key"));
+    assertEquals(obj5, hashMap.remove("s5key"));
 
     assertEquals(0, hashMap.size());
 

--- a/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/BitVectorHelperBenchmarks.java
@@ -66,7 +66,7 @@ public class BitVectorHelperBenchmarks {
       allocator = new RootAllocator(ALLOCATOR_CAPACITY);
       validityBuffer = allocator.buffer(VALIDITY_BUFFER_CAPACITY / 8);
 
-      for (int i = 0;i < VALIDITY_BUFFER_CAPACITY; i++) {
+      for (int i = 0; i < VALIDITY_BUFFER_CAPACITY; i++) {
         if (i % 7 == 0) {
           BitVectorHelper.setBit(validityBuffer, i);
         } else {

--- a/java/performance/src/test/java/org/apache/arrow/vector/Float8Benchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/Float8Benchmarks.java
@@ -63,7 +63,7 @@ public class Float8Benchmarks {
     fromVector = new Float8Vector("vector", allocator);
     fromVector.allocateNew(VECTOR_LENGTH);
 
-    for (int i = 0;i < VECTOR_LENGTH; i++) {
+    for (int i = 0; i < VECTOR_LENGTH; i++) {
       if (i % 3 == 0) {
         fromVector.setNull(i);
       } else {

--- a/java/performance/src/test/java/org/apache/arrow/vector/VarCharBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/vector/VarCharBenchmarks.java
@@ -62,7 +62,7 @@ public class VarCharBenchmarks {
     fromVector = new VarCharVector("vector", allocator);
     fromVector.allocateNew(ALLOCATOR_CAPACITY / 4, VECTOR_LENGTH);
 
-    for (int i = 0;i < VECTOR_LENGTH; i++) {
+    for (int i = 0; i < VECTOR_LENGTH; i++) {
       if (i % 3 == 0) {
         fromVector.setNull(i);
       } else {

--- a/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
+++ b/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java
@@ -125,15 +125,15 @@ public class PlasmaClientTest {
     System.out.println("Start test.");
     int timeoutMs = 3000;
     byte[] id1 = new byte[20];
-    Arrays.fill(id1, (byte)1);
+    Arrays.fill(id1, (byte) 1);
     byte[] value1 = new byte[20];
-    Arrays.fill(value1, (byte)11);
+    Arrays.fill(value1, (byte) 11);
     pLink.put(id1, value1, null);
 
     byte[] id2 = new byte[20];
-    Arrays.fill(id2, (byte)2);
+    Arrays.fill(id2, (byte) 2);
     byte[] value2 = new byte[20];
-    Arrays.fill(value2, (byte)12);
+    Arrays.fill(value2, (byte) 12);
     pLink.put(id2, value2, null);
     System.out.println("Plasma java client put test success.");
     byte[] getValue1 = pLink.get(id1, timeoutMs, false);
@@ -160,16 +160,16 @@ public class PlasmaClientTest {
     boolean exist = pLink.contains(id2);
     assert exist;
     byte[] id3 = new byte[20];
-    Arrays.fill(id3, (byte)3);
+    Arrays.fill(id3, (byte) 3);
     boolean notExist = pLink.contains(id3);
     assert !notExist;
     System.out.println("Plasma java client contains test success.");
 
     byte[] id4 = new byte[20];
-    Arrays.fill(id4, (byte)4);
+    Arrays.fill(id4, (byte) 4);
     byte[] value4 = new byte[20];
     byte[] meta4 = "META4".getBytes();
-    Arrays.fill(value4, (byte)14);
+    Arrays.fill(value4, (byte) 14);
     pLink.put(id4, value4, meta4);
 
     List<byte[]> existIds = Arrays.asList(id1, id2, id3, id4);
@@ -187,10 +187,10 @@ public class PlasmaClientTest {
     System.out.println("Plasma java client list test success.");
 
     byte[] id5 = new byte[20];
-    Arrays.fill(id5, (byte)5);
+    Arrays.fill(id5, (byte) 5);
     byte[] value5 = new byte[20];
     byte[] meta5 = "META5".getBytes();
-    Arrays.fill(value5, (byte)15);
+    Arrays.fill(value5, (byte) 15);
     pLink.put(id5, value5, meta5);
 
     byte[] getMeta4 = pLink.get(id4, timeoutMs, true);
@@ -235,7 +235,7 @@ public class PlasmaClientTest {
 
     try {
       byte[] idNone = new byte[20];
-      Arrays.fill(idNone, (byte)987);
+      Arrays.fill(idNone, (byte) 987);
       pLink.get(idNone, timeoutMs, false);
       Assert.fail("Fail to throw PlasmaClientException when get an object " +
                   "when object store shutdown.");
@@ -254,9 +254,9 @@ public class PlasmaClientTest {
 
   public void doByteBufferTest() {
     System.out.println("Start ByteBuffer test.");
-    PlasmaClient client = (PlasmaClient)pLink;
+    PlasmaClient client = (PlasmaClient) pLink;
     byte[] id = new byte[20];
-    Arrays.fill(id, (byte)10);
+    Arrays.fill(id, (byte) 10);
     ByteBuffer buf = client.create(id, 100, null);
     assert buf.isDirect();
     for (int i = 0; i < 10; i++) {

--- a/java/vector/src/main/java/org/apache/arrow/util/Collections2.java
+++ b/java/vector/src/main/java/org/apache/arrow/util/Collections2.java
@@ -50,8 +50,8 @@ public class Collections2 {
   }
 
   /** Copies the elements of <code>map</code> to a new unmodifiable map. */
-  public static <K,V> Map<K, V> immutableMapCopy(Map<K, V> map) {
-    Map<K,V> newMap = new HashMap<>();
+  public static <K, V> Map<K, V> immutableMapCopy(Map<K, V> map) {
+    Map<K, V> newMap = new HashMap<>();
     newMap.putAll(map);
     return java.util.Collections.unmodifiableMap(newMap);
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -183,7 +183,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
    */
   @Override
   public void setInitialCapacity(int valueCount, double density) {
-    long size = Math.max((long)(valueCount * density), 1L);
+    long size = Math.max((long) (valueCount * density), 1L);
     checkDataBufferSize(size);
     computeAndCheckOffsetsBufferSize(valueCount);
     lastValueAllocationSizeInBytes = (int) size;

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -79,7 +79,7 @@ public final class BitVector extends BaseFixedWidthVector {
    * @param allocator allocator for memory management.
    */
   public BitVector(Field field, BufferAllocator allocator) {
-    super(field, allocator,0);
+    super(field, allocator, 0);
     reader = new BitReaderImpl(BitVector.this);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DecimalVector.java
@@ -228,7 +228,7 @@ public final class DecimalVector extends BaseFixedWidthVector {
     }
 
     if (length == 0) {
-      PlatformDependent.setMemory(outAddress, DecimalVector.TYPE_WIDTH, (byte)0);
+      PlatformDependent.setMemory(outAddress, DecimalVector.TYPE_WIDTH, (byte) 0);
     } else if (length < TYPE_WIDTH) {
       // sign extend
       final byte pad = (byte) (value[0] < 0 ? 0xFF : 0x00);

--- a/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
@@ -68,7 +68,7 @@ public final class DurationVector extends BaseFixedWidthVector {
   public DurationVector(Field field, BufferAllocator allocator) {
     super(field, allocator, TYPE_WIDTH);
     reader = new DurationReaderImpl(DurationVector.this);
-    this.unit = ((ArrowType.Duration)field.getFieldType().getType()).getUnit();
+    this.unit = ((ArrowType.Duration) field.getFieldType().getType()).getUnit();
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/UInt1Vector.java
@@ -83,7 +83,7 @@ public final class UInt1Vector extends BaseFixedWidthVector implements BaseIntVe
    */
   public static short getNoOverflow(final ArrowBuf buffer, final int index) {
     byte b = buffer.getByte(index * TYPE_WIDTH);
-    return (short)(0xFF & b);
+    return (short) (0xFF & b);
   }
 
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -121,7 +121,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
 
     long newAllocationSize = baseSize * 2L;
     newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
-    newAllocationSize = Math.min(newAllocationSize, (long)(OFFSET_WIDTH) * Integer.MAX_VALUE);
+    newAllocationSize = Math.min(newAllocationSize, (long) (OFFSET_WIDTH) * Integer.MAX_VALUE);
     assert newAllocationSize >= 1;
 
     if (newAllocationSize > MAX_ALLOCATION_SIZE || newAllocationSize <= baseSize) {
@@ -188,10 +188,10 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
 
     offsetAllocationSizeInBytes = (numRecords + 1) * OFFSET_WIDTH;
 
-    int innerValueCapacity = Math.max((int)(numRecords * density), 1);
+    int innerValueCapacity = Math.max((int) (numRecords * density), 1);
 
     if (vector instanceof DensityAwareVector) {
-      ((DensityAwareVector)vector).setInitialCapacity(innerValueCapacity, density);
+      ((DensityAwareVector) vector).setInitialCapacity(innerValueCapacity, density);
     } else {
       vector.setInitialCapacity(innerValueCapacity);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/EmptyValuePopulator.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/EmptyValuePopulator.java
@@ -41,7 +41,7 @@ public class EmptyValuePopulator {
       throw new IndexOutOfBoundsException("index cannot be negative");
     }
     final int lastSet = Math.max(offsets.getValueCount() - 1, 0);
-    final int previousEnd = offsets.get(lastSet);//0 ? 0 : accessor.get(lastSet);
+    final int previousEnd = offsets.get(lastSet); //0 ? 0 : accessor.get(lastSet);
     for (int i = lastSet; i < lastIndex; i++) {
       offsets.setSafe(i + 1, previousEnd);
     }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/MapVector.java
@@ -112,7 +112,7 @@ public class MapVector extends ListVector {
     if (reader == null) {
       reader = new UnionMapReader(this);
     }
-    return (UnionMapReader)reader;
+    return (UnionMapReader) reader;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/NonNullableStructVector.java
@@ -129,7 +129,7 @@ public class NonNullableStructVector extends AbstractStructVector {
   public void setInitialCapacity(int valueCount, double density) {
     for (final ValueVector vector : this) {
       if (vector instanceof DensityAwareVector) {
-        ((DensityAwareVector)vector).setInitialCapacity(valueCount, density);
+        ((DensityAwareVector) vector).setInitialCapacity(valueCount, density);
       } else {
         vector.setInitialCapacity(valueCount);
       }

--- a/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/dictionary/ListSubfieldEncoder.java
@@ -81,7 +81,7 @@ public class ListSubfieldEncoder {
 
     FieldType indexFieldType = new FieldType(vector.getField().isNullable(),
         dictionary.getEncoding().getIndexType(), dictionary.getEncoding(), vector.getField().getMetadata());
-    Field valueField = new Field(vector.getField().getName(), indexFieldType,null);
+    Field valueField = new Field(vector.getField().getName(), indexFieldType, null);
 
     // clone list vector and initialize data vector
     BaseListVector encoded = cloneVector(vector);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -364,7 +364,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
 
         for (int i = 0; i < count; i++) {
           parser.nextToken();
-          buf.writeInt((int)parser.getLongValue());
+          buf.writeInt((int) parser.getLongValue());
         }
 
         return buf;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/WriteChannel.java
@@ -129,7 +129,7 @@ public class WriteChannel implements AutoCloseable {
   public void write(ArrowBuf buffer) throws IOException {
     long bytesWritten = 0;
     while (bytesWritten < buffer.readableBytes()) {
-      int bytesToWrite = (int)Math.min(Integer.MAX_VALUE, buffer.readableBytes() - bytesWritten);
+      int bytesToWrite = (int) Math.min(Integer.MAX_VALUE, buffer.readableBytes() - bytesWritten);
       ByteBuffer nioBuffer = buffer.nioBuffer(buffer.readerIndex() + bytesWritten,
            bytesToWrite);
       write(nioBuffer);

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/ArrowRecordBatch.java
@@ -222,7 +222,7 @@ public class ArrowRecordBatch implements ArrowMessage {
 
       long readableBytes = buffer.readableBytes();
       while (readableBytes > 0) {
-        int nextRead = (int)Math.min(readableBytes, Integer.MAX_VALUE);
+        int nextRead = (int) Math.min(readableBytes, Integer.MAX_VALUE);
         ByteBuffer nioBuffer =
             buffer.nioBuffer(buffer.readerIndex(), nextRead);
         readableBytes -= nextRead;

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/DecimalUtility.java
@@ -32,8 +32,8 @@ public class DecimalUtility {
   private DecimalUtility() {}
 
   public static final int DECIMAL_BYTE_LENGTH = 16;
-  public static final byte [] zeroes = new byte[] {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
-  public static final byte [] minus_one = new byte[] {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1};
+  public static final byte [] zeroes = new byte[] {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  public static final byte [] minus_one = new byte[] {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1};
 
   /**
    * Read an ArrowType.Decimal at the given value index in the ArrowBuf and convert to a BigDecimal

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVector.java
@@ -205,7 +205,7 @@ public class TestBitVector {
       try (final BitVector toVector = new BitVector("toVector", allocator)) {
         final TransferPair transferPair = sourceVector.makeTransferPair(toVector);
 
-        final int[][] transferLengths = {{5,22}, {5,24}, {5,25}, {5,27}, {0,31}, {5,7}, {2,3}};
+        final int[][] transferLengths = {{5, 22}, {5, 24}, {5, 25}, {5, 27}, {0, 31}, {5, 7}, {2, 3}};
 
         for (final int[] transferLength : transferLengths) {
           final int start = transferLength[0];
@@ -285,7 +285,7 @@ public class TestBitVector {
       /* now transfer the vector */
       TransferPair transferPair = vector.getTransferPair(allocator);
       transferPair.transfer();
-      final BitVector toVector = (BitVector)transferPair.getTo();
+      final BitVector toVector = (BitVector) transferPair.getTo();
 
       assertEquals(valueCapacity * 4, toVector.getValueCapacity());
 
@@ -369,7 +369,7 @@ public class TestBitVector {
       /* now transfer the vector */
       TransferPair transferPair = vector.getTransferPair(allocator);
       transferPair.transfer();
-      final BitVector toVector = (BitVector)transferPair.getTo();
+      final BitVector toVector = (BitVector) transferPair.getTo();
 
       assertEquals(valueCapacity * 4, toVector.getValueCapacity());
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestBitVectorHelper.java
@@ -34,7 +34,7 @@ public class TestBitVectorHelper {
   public void testGetNullCount() throws Exception {
     // test case 1, 1 null value for 0b110
     ArrowBuf validityBuffer = new ArrowBuf(
-        ReferenceManager.NO_OP, null,3, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
+        ReferenceManager.NO_OP, null, 3, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
     // we set validity buffer to be 0b10110, but only have 3 items with 1st item is null
     validityBuffer.setByte(0, 0b10110);
 
@@ -44,7 +44,7 @@ public class TestBitVectorHelper {
 
     // test case 2, no null value for 0xFF
     validityBuffer = new ArrowBuf(
-        ReferenceManager.NO_OP, null,8, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
+        ReferenceManager.NO_OP, null, 8, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
     validityBuffer.setByte(0, 0xFF);
 
     count = BitVectorHelper.getNullCount(validityBuffer, 8);
@@ -60,7 +60,7 @@ public class TestBitVectorHelper {
 
     // test case 4, validity buffer has multiple bytes, 11 items
     validityBuffer = new ArrowBuf(
-        ReferenceManager.NO_OP, null,11, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
+        ReferenceManager.NO_OP, null, 11, new PooledByteBufAllocatorL().empty.memoryAddress(), true);
     validityBuffer.setByte(0, 0b10101010);
     validityBuffer.setByte(1, 0b01010101);
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDecimalVector.java
@@ -330,7 +330,7 @@ public class TestDecimalVector {
             new ArrowType.Decimal(5, 2), allocator);
          ArrowBuf buf = allocator.buffer(9);) {
       BigDecimal [] expectedValues = new BigDecimal[] {BigDecimal.valueOf(705.32), BigDecimal
-              .valueOf(-705.32),BigDecimal.valueOf(705.32)};
+              .valueOf(-705.32), BigDecimal.valueOf(705.32)};
       verifyWritingArrowBufWithBigEndianBytes(decimalVector, buf, expectedValues, 3);
     }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDictionaryVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDictionaryVector.java
@@ -186,7 +186,7 @@ public class TestDictionaryVector {
         // verify indices
         assertEquals(IntVector.class, encoded.getClass());
 
-        IntVector index = ((IntVector)encoded);
+        IntVector index = ((IntVector) encoded);
         assertEquals(6, index.getValueCount());
         assertEquals(0, index.get(0));
         assertEquals(0, index.get(1));
@@ -245,7 +245,7 @@ public class TestDictionaryVector {
         // verify indices
         assertEquals(IntVector.class, encoded.getClass());
 
-        IntVector index = ((IntVector)encoded);
+        IntVector index = ((IntVector) encoded);
         assertEquals(7, index.getValueCount());
         assertEquals(0, index.get(0));
         assertEquals(0, index.get(1));
@@ -282,7 +282,7 @@ public class TestDictionaryVector {
         // verify indices
         assertEquals(IntVector.class, encoded.getClass());
 
-        IntVector index = ((IntVector)encoded);
+        IntVector index = ((IntVector) encoded);
         assertEquals(5, index.getValueCount());
         assertEquals(0, index.get(0));
         assertEquals(1, index.get(1));
@@ -356,7 +356,7 @@ public class TestDictionaryVector {
         // verify indices
         assertEquals(IntVector.class, encoded.getClass());
 
-        IntVector index = ((IntVector)encoded);
+        IntVector index = ((IntVector) encoded);
         assertEquals(5, index.getValueCount());
         assertEquals(0, index.get(0));
         assertEquals(1, index.get(1));
@@ -653,17 +653,17 @@ public class TestDictionaryVector {
 
         assertEquals(6, encoded.getValueCount());
         int[] realValue1 = convertListToIntArray((JsonStringArrayList) encoded.getObject(0));
-        assertTrue(Arrays.equals(new int[] {0,1}, realValue1));
+        assertTrue(Arrays.equals(new int[] {0, 1}, realValue1));
         int[] realValue2 = convertListToIntArray((JsonStringArrayList) encoded.getObject(1));
-        assertTrue(Arrays.equals(new int[] {0,1}, realValue2));
+        assertTrue(Arrays.equals(new int[] {0, 1}, realValue2));
         int[] realValue3 = convertListToIntArray((JsonStringArrayList) encoded.getObject(2));
-        assertTrue(Arrays.equals(new int[] {0,1}, realValue3));
+        assertTrue(Arrays.equals(new int[] {0, 1}, realValue3));
         int[] realValue4 = convertListToIntArray((JsonStringArrayList) encoded.getObject(3));
-        assertTrue(Arrays.equals(new int[] {2,3,4}, realValue4));
+        assertTrue(Arrays.equals(new int[] {2, 3, 4}, realValue4));
         int[] realValue5 = convertListToIntArray((JsonStringArrayList) encoded.getObject(4));
-        assertTrue(Arrays.equals(new int[] {2,3,4}, realValue5));
+        assertTrue(Arrays.equals(new int[] {2, 3, 4}, realValue5));
         int[] realValue6 = convertListToIntArray((JsonStringArrayList) encoded.getObject(5));
-        assertTrue(Arrays.equals(new int[] {0,1}, realValue6));
+        assertTrue(Arrays.equals(new int[] {0, 1}, realValue6));
 
         // now run through the decoder and verify we get the original back
         try (ValueVector decoded = encoder.decodeListSubField(encoded)) {
@@ -731,13 +731,13 @@ public class TestDictionaryVector {
 
         assertEquals(4, encoded.getValueCount());
         int[] realValue1 = convertListToIntArray((JsonStringArrayList) encoded.getObject(0));
-        assertTrue(Arrays.equals(new int[] {0,1}, realValue1));
+        assertTrue(Arrays.equals(new int[] {0, 1}, realValue1));
         int[] realValue2 = convertListToIntArray((JsonStringArrayList) encoded.getObject(1));
-        assertTrue(Arrays.equals(new int[] {0,1}, realValue2));
+        assertTrue(Arrays.equals(new int[] {0, 1}, realValue2));
         int[] realValue3 = convertListToIntArray((JsonStringArrayList) encoded.getObject(2));
-        assertTrue(Arrays.equals(new int[] {2,3}, realValue3));
+        assertTrue(Arrays.equals(new int[] {2, 3}, realValue3));
         int[] realValue4 = convertListToIntArray((JsonStringArrayList) encoded.getObject(3));
-        assertTrue(Arrays.equals(new int[] {0,1}, realValue4));
+        assertTrue(Arrays.equals(new int[] {0, 1}, realValue4));
 
         // now run through the decoder and verify we get the original back
         try (ValueVector decoded = encoder.decodeListSubField(encoded)) {
@@ -798,15 +798,15 @@ public class TestDictionaryVector {
 
         assertEquals(5, encoded.getValueCount());
         Object[] realValue1 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(0));
-        assertTrue(Arrays.equals(new Object[] {0,1}, realValue1));
+        assertTrue(Arrays.equals(new Object[] {0, 1}, realValue1));
         Object[] realValue2 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(1));
-        assertTrue(Arrays.equals(new Object[] {1,2}, realValue2));
+        assertTrue(Arrays.equals(new Object[] {1, 2}, realValue2));
         Object[] realValue3 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(2));
-        assertTrue(Arrays.equals(new Object[] {2,0}, realValue3));
+        assertTrue(Arrays.equals(new Object[] {2, 0}, realValue3));
         Object[] realValue4 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(3));
-        assertTrue(Arrays.equals(new Object[] {0,0}, realValue4));
+        assertTrue(Arrays.equals(new Object[] {0, 0}, realValue4));
         Object[] realValue5 = convertMapValuesToArray((JsonStringHashMap) encoded.getObject(4));
-        assertTrue(Arrays.equals(new Object[] {3,0}, realValue5));
+        assertTrue(Arrays.equals(new Object[] {3, 0}, realValue5));
 
         // now run through the decoder and verify we get the original back
         try (ValueVector decoded = encoder.decode(encoded)) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestListVector.java
@@ -574,22 +574,22 @@ public class TestListVector {
 
       listVector.addOrGetVector(FieldType.nullable(listType.getType()));
 
-      ListVector innerList1 = (ListVector)listVector.getDataVector();
+      ListVector innerList1 = (ListVector) listVector.getDataVector();
       innerList1.addOrGetVector(FieldType.nullable(listType.getType()));
 
-      ListVector innerList2 = (ListVector)innerList1.getDataVector();
+      ListVector innerList2 = (ListVector) innerList1.getDataVector();
       innerList2.addOrGetVector(FieldType.nullable(listType.getType()));
 
-      ListVector innerList3 = (ListVector)innerList2.getDataVector();
+      ListVector innerList3 = (ListVector) innerList2.getDataVector();
       innerList3.addOrGetVector(FieldType.nullable(listType.getType()));
 
-      ListVector innerList4 = (ListVector)innerList3.getDataVector();
+      ListVector innerList4 = (ListVector) innerList3.getDataVector();
       innerList4.addOrGetVector(FieldType.nullable(listType.getType()));
 
-      ListVector innerList5 = (ListVector)innerList4.getDataVector();
+      ListVector innerList5 = (ListVector) innerList4.getDataVector();
       innerList5.addOrGetVector(FieldType.nullable(listType.getType()));
 
-      ListVector innerList6 = (ListVector)innerList5.getDataVector();
+      ListVector innerList6 = (ListVector) innerList5.getDataVector();
       innerList6.addOrGetVector(FieldType.nullable(scalarType.getType()));
 
       listVector.setInitialCapacity(128);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -85,8 +85,8 @@ public class TestValueVector {
   private static final byte[] STR5 = "EEE5".getBytes(utf8Charset);
   private static final byte[] STR6 = "FFFFF6".getBytes(utf8Charset);
   private static final int MAX_VALUE_COUNT =
-      (int)(Integer.getInteger("arrow.vector.max_allocation_bytes", Integer.MAX_VALUE) / 7);
-  private static final int MAX_VALUE_COUNT_8BYTE = (int)(MAX_VALUE_COUNT / 2);
+      (int) (Integer.getInteger("arrow.vector.max_allocation_bytes", Integer.MAX_VALUE) / 7);
+  private static final int MAX_VALUE_COUNT_8BYTE = (int) (MAX_VALUE_COUNT / 2);
 
   @After
   public void terminate() throws Exception {
@@ -985,7 +985,7 @@ public class TestValueVector {
       double baseValue = 100.375;
 
       for (int i = 0; i < initialCapacity; i++) {
-        vector.setSafe(i, baseValue + (double)i);
+        vector.setSafe(i, baseValue + (double) i);
       }
 
       /* the above setSafe calls should not have triggered a realloc as
@@ -995,35 +995,35 @@ public class TestValueVector {
 
       for (int i = 0; i < initialCapacity; i++) {
         double value = vector.get(i);
-        assertEquals(baseValue + (double)i, value, 0);
+        assertEquals(baseValue + (double) i, value, 0);
       }
 
       /* this should trigger a realloc */
-      vector.setSafe(initialCapacity, baseValue + (double)initialCapacity);
+      vector.setSafe(initialCapacity, baseValue + (double) initialCapacity);
       assertTrue(vector.getValueCapacity() >= initialCapacity * 2);
       int capacityAfterRealloc1 = vector.getValueCapacity();
 
       for (int i = initialCapacity + 1; i < capacityAfterRealloc1; i++) {
-        vector.setSafe(i, baseValue + (double)i);
+        vector.setSafe(i, baseValue + (double) i);
       }
 
       for (int i = 0; i < capacityAfterRealloc1; i++) {
         double value = vector.get(i);
-        assertEquals(baseValue + (double)i, value, 0);
+        assertEquals(baseValue + (double) i, value, 0);
       }
 
       /* this should trigger a realloc */
-      vector.setSafe(capacityAfterRealloc1, baseValue + (double)(capacityAfterRealloc1));
+      vector.setSafe(capacityAfterRealloc1, baseValue + (double) (capacityAfterRealloc1));
       assertTrue(vector.getValueCapacity() >= initialCapacity * 4);
       int capacityAfterRealloc2 = vector.getValueCapacity();
 
       for (int i = capacityAfterRealloc1 + 1; i < capacityAfterRealloc2; i++) {
-        vector.setSafe(i, baseValue + (double)i);
+        vector.setSafe(i, baseValue + (double) i);
       }
 
       for (int i = 0; i < capacityAfterRealloc2; i++) {
         double value = vector.get(i);
-        assertEquals(baseValue + (double)i, value, 0);
+        assertEquals(baseValue + (double) i, value, 0);
       }
 
       /* at this point we are working with a 128KB buffer data for this
@@ -1033,7 +1033,7 @@ public class TestValueVector {
       TransferPair transferPair = vector.getTransferPair(allocator);
       transferPair.transfer();
 
-      Float8Vector toVector = (Float8Vector)transferPair.getTo();
+      Float8Vector toVector = (Float8Vector) transferPair.getTo();
 
       /* now let's realloc the toVector */
       toVector.reAlloc();
@@ -1041,7 +1041,7 @@ public class TestValueVector {
 
       for (int i = 0; i < toVector.getValueCapacity(); i++) {
         if (i < capacityAfterRealloc2) {
-          assertEquals(baseValue + (double)i, toVector.get(i), 0);
+          assertEquals(baseValue + (double) i, toVector.get(i), 0);
         } else {
           assertTrue(toVector.isNull(i));
         }
@@ -1064,7 +1064,7 @@ public class TestValueVector {
       double baseValue = 100.375;
 
       for (int i = 0; i < initialCapacity; i++) {
-        vector.setSafe(i, baseValue + (double)i);
+        vector.setSafe(i, baseValue + (double) i);
       }
 
       /* the above setSafe calls should not have triggered a realloc as
@@ -1074,35 +1074,35 @@ public class TestValueVector {
 
       for (int i = 0; i < initialCapacity; i++) {
         double value = vector.get(i);
-        assertEquals(baseValue + (double)i, value, 0);
+        assertEquals(baseValue + (double) i, value, 0);
       }
 
       /* this should trigger a realloc */
-      vector.setSafe(initialCapacity, baseValue + (double)initialCapacity);
+      vector.setSafe(initialCapacity, baseValue + (double) initialCapacity);
       assertTrue(vector.getValueCapacity() >= initialCapacity * 2);
       int capacityAfterRealloc1 = vector.getValueCapacity();
 
       for (int i = initialCapacity + 1; i < capacityAfterRealloc1; i++) {
-        vector.setSafe(i, baseValue + (double)i);
+        vector.setSafe(i, baseValue + (double) i);
       }
 
       for (int i = 0; i < capacityAfterRealloc1; i++) {
         double value = vector.get(i);
-        assertEquals(baseValue + (double)i, value, 0);
+        assertEquals(baseValue + (double) i, value, 0);
       }
 
       /* this should trigger a realloc */
-      vector.setSafe(capacityAfterRealloc1, baseValue + (double)(capacityAfterRealloc1));
+      vector.setSafe(capacityAfterRealloc1, baseValue + (double) (capacityAfterRealloc1));
       assertTrue(vector.getValueCapacity() >= initialCapacity * 4);
       int capacityAfterRealloc2 = vector.getValueCapacity();
 
       for (int i = capacityAfterRealloc1 + 1; i < capacityAfterRealloc2; i++) {
-        vector.setSafe(i, baseValue + (double)i);
+        vector.setSafe(i, baseValue + (double) i);
       }
 
       for (int i = 0; i < capacityAfterRealloc2; i++) {
         double value = vector.get(i);
-        assertEquals(baseValue + (double)i, value, 0);
+        assertEquals(baseValue + (double) i, value, 0);
       }
 
       /* at this point we are working with a 128KB buffer data for this
@@ -1112,13 +1112,13 @@ public class TestValueVector {
       TransferPair transferPair = vector.getTransferPair(allocator);
       transferPair.transfer();
 
-      Float8Vector toVector = (Float8Vector)transferPair.getTo();
+      Float8Vector toVector = (Float8Vector) transferPair.getTo();
 
       /* check toVector contents before realloc */
       for (int i = 0; i < toVector.getValueCapacity(); i++) {
         assertFalse("unexpected null value at index: " + i, toVector.isNull(i));
         double value = toVector.get(i);
-        assertEquals("unexpected value at index: " + i, baseValue + (double)i, value, 0);
+        assertEquals("unexpected value at index: " + i, baseValue + (double) i, value, 0);
       }
 
       /* now let's realloc the toVector and check contents again */
@@ -1129,7 +1129,7 @@ public class TestValueVector {
         if (i < capacityAfterRealloc2) {
           assertFalse("unexpected null value at index: " + i, toVector.isNull(i));
           double value = toVector.get(i);
-          assertEquals("unexpected value at index: " + i, baseValue + (double)i, value, 0);
+          assertEquals("unexpected value at index: " + i, baseValue + (double) i, value, 0);
         } else {
           assertTrue("unexpected non-null value at index: " + i, toVector.isNull(i));
         }
@@ -1223,7 +1223,7 @@ public class TestValueVector {
 
       TransferPair transferPair = vector.getTransferPair(allocator);
       transferPair.transfer();
-      VarCharVector toVector = (VarCharVector)transferPair.getTo();
+      VarCharVector toVector = (VarCharVector) transferPair.getTo();
       valueCapacity = toVector.getValueCapacity();
 
       for (int i = 0; i < valueCapacity; i++) {
@@ -1312,7 +1312,7 @@ public class TestValueVector {
 
       TransferPair transferPair = vector.getTransferPair(allocator);
       transferPair.transfer();
-      IntVector toVector = (IntVector)transferPair.getTo();
+      IntVector toVector = (IntVector) transferPair.getTo();
       /* value capacity of source and target vectors should be same after
        * the transfer.
        */
@@ -1971,12 +1971,12 @@ public class TestValueVector {
       vector.setInitialCapacity(defaultCapacity, 0.1);
       vector.allocateNew();
       assertEquals(defaultCapacity, vector.getValueCapacity());
-      assertEquals(BaseAllocator.nextPowerOfTwo((int)(defaultCapacity * 0.1)), vector.getDataBuffer().capacity());
+      assertEquals(BaseAllocator.nextPowerOfTwo((int) (defaultCapacity * 0.1)), vector.getDataBuffer().capacity());
 
       vector.setInitialCapacity(defaultCapacity, 0.01);
       vector.allocateNew();
       assertEquals(defaultCapacity, vector.getValueCapacity());
-      assertEquals(BaseAllocator.nextPowerOfTwo((int)(defaultCapacity * 0.01)), vector.getDataBuffer().capacity());
+      assertEquals(BaseAllocator.nextPowerOfTwo((int) (defaultCapacity * 0.01)), vector.getDataBuffer().capacity());
 
       vector.setInitialCapacity(5, 0.01);
       vector.allocateNew();

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharListVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVarCharListVector.java
@@ -46,7 +46,7 @@ public class TestVarCharListVector {
   public void testVarCharListWithNulls() {
     byte[] bytes = "a".getBytes();
     try (ListVector vector = new ListVector("VarList", allocator, FieldType.nullable(Types
-            .MinorType.VARCHAR.getType()),null);
+            .MinorType.VARCHAR.getType()), null);
          ArrowBuf tempBuf = allocator.buffer(bytes.length)) {
       UnionListWriter writer = vector.getWriter();
       writer.allocate();

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorUnloadLoad.java
@@ -219,7 +219,7 @@ public class TestVectorUnloadLoad {
 
         buf2.setInt(j * 4, j);
       }
-      buf1.writerIndex((int)Math.ceil(count / 8));
+      buf1.writerIndex((int) Math.ceil(count / 8));
       buf2.writerIndex(count * 4);
     }
 
@@ -290,7 +290,7 @@ public class TestVectorUnloadLoad {
         FieldVector vector = field.createVector(originalVectorsAllocator);
         vector.allocateNew();
         sources.add(vector);
-        IntVector intVector = (IntVector)vector;
+        IntVector intVector = (IntVector) vector;
         for (int i = 0; i < count; i++) {
           intVector.set(i, i);
         }

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -1031,9 +1031,9 @@ public class TestComplexWriter {
         singleStructWriter.start();
 
         intWriter.writeInt(intValue + i);
-        bigIntWriter.writeBigInt(bigIntValue + (long)i);
-        float4Writer.writeFloat4(float4Value + (float)i);
-        float8Writer.writeFloat8(float8Value + (double)i);
+        bigIntWriter.writeBigInt(bigIntValue + (long) i);
+        float4Writer.writeFloat4(float4Value + (float) i);
+        float8Writer.writeFloat8(float8Value + (double) i);
 
         listWriter.setPosition(i);
         listWriter.startList();
@@ -1046,10 +1046,10 @@ public class TestComplexWriter {
         singleStructWriter.end();
       }
 
-      IntVector intVector = (IntVector)parent.getChild("intField");
-      BigIntVector bigIntVector = (BigIntVector)parent.getChild("bigIntField");
-      Float4Vector float4Vector = (Float4Vector)parent.getChild("float4Field");
-      Float8Vector float8Vector = (Float8Vector)parent.getChild("float8Field");
+      IntVector intVector = (IntVector) parent.getChild("intField");
+      BigIntVector bigIntVector = (BigIntVector) parent.getChild("bigIntField");
+      Float4Vector float4Vector = (Float4Vector) parent.getChild("float4Field");
+      Float8Vector float8Vector = (Float8Vector) parent.getChild("float8Field");
 
       int capacity = singleStructWriter.getValueCapacity();
       assertTrue(capacity >= initialCapacity && capacity < initialCapacity * 2);
@@ -1068,7 +1068,7 @@ public class TestComplexWriter {
       BigIntReader bigIntReader = singleStructReader.reader("bigIntField");
       Float4Reader float4Reader = singleStructReader.reader("float4Field");
       Float8Reader float8Reader = singleStructReader.reader("float8Field");
-      UnionListReader listReader = (UnionListReader)singleStructReader.reader("listField");
+      UnionListReader listReader = (UnionListReader) singleStructReader.reader("listField");
 
       for (int i = 0; i < initialCapacity; i++) {
         intReader.setPosition(i);
@@ -1078,9 +1078,9 @@ public class TestComplexWriter {
         listReader.setPosition(i);
 
         assertEquals(intValue + i, intReader.readInteger().intValue());
-        assertEquals(bigIntValue + (long)i, bigIntReader.readLong().longValue());
-        assertEquals(float4Value + (float)i, float4Reader.readFloat().floatValue(), 0);
-        assertEquals(float8Value + (double)i, float8Reader.readDouble().doubleValue(), 0);
+        assertEquals(bigIntValue + (long) i, bigIntReader.readLong().longValue());
+        assertEquals(float4Value + (float) i, float4Reader.readFloat().floatValue(), 0);
+        assertEquals(float8Value + (double) i, float8Reader.readDouble().doubleValue(), 0);
 
         for (int j = 0; j < 4; j++) {
           listReader.next();

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/BaseFileTest.java
@@ -132,11 +132,11 @@ public class BaseFileTest {
       uint1Writer.setPosition(i);
       // TODO: Fix add safe write methods on uint methods.
       uint1Writer.setPosition(i);
-      uint1Writer.writeUInt1((byte)uint1Values[i % uint1Values.length] );
+      uint1Writer.writeUInt1((byte) uint1Values[i % uint1Values.length] );
       uint2Writer.setPosition(i);
-      uint2Writer.writeUInt2((char)uint2Values[i % uint2Values.length] );
+      uint2Writer.writeUInt2((char) uint2Values[i % uint2Values.length] );
       uint4Writer.setPosition(i);
-      uint4Writer.writeUInt4((int)uint4Values[i % uint4Values.length] );
+      uint4Writer.writeUInt4((int) uint4Values[i % uint4Values.length] );
       uint8Writer.setPosition(i);
       uint8Writer.writeUInt8(uint8Values[i % uint8Values.length].longValue());
       bigIntWriter.setPosition(i);
@@ -151,14 +151,14 @@ public class BaseFileTest {
   protected void validateContent(int count, VectorSchemaRoot root) {
     for (int i = 0; i < count; i++) {
       Assert.assertEquals(i, root.getVector("int").getObject(i));
-      Assert.assertEquals((Short)uint1Values[i % uint1Values.length],
-          ((UInt1Vector)root.getVector("uint1")).getObjectNoOverflow(i));
-      Assert.assertEquals("Failed for index: " + i, (Character)uint2Values[i % uint2Values.length],
-          (Character)((UInt2Vector)root.getVector("uint2")).get(i));
-      Assert.assertEquals("Failed for index: " + i, (Long)uint4Values[i % uint4Values.length],
-          ((UInt4Vector)root.getVector("uint4")).getObjectNoOverflow(i));
+      Assert.assertEquals((Short) uint1Values[i % uint1Values.length],
+          ((UInt1Vector) root.getVector("uint1")).getObjectNoOverflow(i));
+      Assert.assertEquals("Failed for index: " + i, (Character) uint2Values[i % uint2Values.length],
+          (Character) ((UInt2Vector) root.getVector("uint2")).get(i));
+      Assert.assertEquals("Failed for index: " + i, (Long) uint4Values[i % uint4Values.length],
+          ((UInt4Vector) root.getVector("uint4")).getObjectNoOverflow(i));
       Assert.assertEquals("Failed for index: " + i, uint8Values[i % uint8Values.length],
-          ((UInt8Vector)root.getVector("uint8")).getObjectNoOverflow(i));
+          ((UInt8Vector) root.getVector("uint8")).getObjectNoOverflow(i));
       Assert.assertEquals(Long.valueOf(i), root.getVector("bigInt").getObject(i));
       Assert.assertEquals(i == 0 ? Float.NaN : i, root.getVector("float").getObject(i));
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
@@ -91,7 +91,7 @@ public class TestArrowStream extends BaseFileTest {
       int numBatches = 1;
 
       root.getFieldVectors().get(0).allocateNew();
-      TinyIntVector vector = (TinyIntVector)root.getFieldVectors().get(0);
+      TinyIntVector vector = (TinyIntVector) root.getFieldVectors().get(0);
       for (int i = 0; i < 16; i++) {
         vector.set(i, i < 8 ? 1 : 0, (byte) (i + 1));
       }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestJSONFile.java
@@ -450,7 +450,7 @@ public class TestJSONFile extends BaseFileTest {
       uInt1Vector.setValueCount(3);
       for (int i = 0; i < byteValues.length; i++) {
         uInt1Vector.set(i, byteValues[i]);
-        byte actualValue = (byte) UInt1Vector.getNoOverflow(uInt1Vector.getDataBuffer(),i);
+        byte actualValue = (byte) UInt1Vector.getNoOverflow(uInt1Vector.getDataBuffer(), i);
         assertEquals(byteValues[i], actualValue);
       }
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/testing/TestValueVectorPopulator.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/testing/TestValueVectorPopulator.java
@@ -209,7 +209,7 @@ public class TestValueVectorPopulator {
       }
       vector1.setValueCount(10);
 
-      setVector(vector2,null, "test1".getBytes(), null, "test3".getBytes(), null, "test5".getBytes(), null,
+      setVector(vector2, null, "test1".getBytes(), null, "test3".getBytes(), null, "test5".getBytes(), null,
           "test7".getBytes(), null, "test9".getBytes());
       assertTrue(VectorEqualsVisitor.vectorEquals(vector1, vector2));
     }
@@ -288,8 +288,8 @@ public class TestValueVectorPopulator {
       }
       vector1.setValueCount(10);
 
-      ValueVectorDataPopulator.setVector(vector2, null, (short)1, null, (short)3, null, (short)5,
-          null, (short)7, null, (short)9);
+      ValueVectorDataPopulator.setVector(vector2, null, (short) 1, null, (short) 3, null, (short) 5,
+          null, (short) 7, null, (short) 9);
       assertTrue(VectorEqualsVisitor.vectorEquals(vector1, vector2));
     }
   }
@@ -480,7 +480,7 @@ public class TestValueVectorPopulator {
         }
       }
       vector1.setValueCount(10);
-      setVector(vector2, null, (byte)1, null, (byte)3, null, (byte)5, null, (byte)7, null, (byte)9);
+      setVector(vector2, null, (byte) 1, null, (byte) 3, null, (byte) 5, null, (byte) 7, null, (byte) 9);
       assertTrue(VectorEqualsVisitor.vectorEquals(vector1, vector2));
     }
   }
@@ -499,7 +499,7 @@ public class TestValueVectorPopulator {
         }
       }
       vector1.setValueCount(10);
-      setVector(vector2, null, (byte)1, null, (byte)3, null, (byte)5, null, (byte)7, null, (byte)9);
+      setVector(vector2, null, (byte) 1, null, (byte) 3, null, (byte) 5, null, (byte) 7, null, (byte) 9);
       assertTrue(VectorEqualsVisitor.vectorEquals(vector1, vector2));
     }
   }
@@ -518,7 +518,7 @@ public class TestValueVectorPopulator {
         }
       }
       vector1.setValueCount(10);
-      setVector(vector2, null, (char)1, null, (char)3, null, (char)5, null, (char)7, null, (char)9);
+      setVector(vector2, null, (char) 1, null, (char) 3, null, (char) 5, null, (char) 7, null, (char) 9);
       assertTrue(VectorEqualsVisitor.vectorEquals(vector1, vector2));
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorVisitor.java
@@ -98,7 +98,7 @@ public class TestValidateVectorVisitor {
   public void testListVector() {
     try (final ListVector vector = ListVector.empty("v", allocator)) {
       validate(vector);
-      setVector(vector, Arrays.asList(1,2,3), Arrays.asList(4, 5));
+      setVector(vector, Arrays.asList(1, 2, 3), Arrays.asList(4, 5));
       validate(vector);
 
       vector.getDataVector().setValueCount(3);
@@ -113,7 +113,7 @@ public class TestValidateVectorVisitor {
   public void testFixedSizeListVector() {
     try (final FixedSizeListVector vector = FixedSizeListVector.empty("v", 3, allocator)) {
       validate(vector);
-      setVector(vector, Arrays.asList(1,2,3), Arrays.asList(4, 5, 6));
+      setVector(vector, Arrays.asList(1, 2, 3), Arrays.asList(4, 5, 6));
       validate(vector);
 
       vector.getDataVector().setValueCount(3);


### PR DESCRIPTION
This is in response to a discussion in https://github.com/apache/arrow/pull/6039#discussion_r375161992

We found the current style checking for Java code is not sufficient. So we want to enhace it in a series of "small" steps, in order to avoid having to change too many files at once.

In this issue, we add spaces after commas, semi-colons and type casts.