### PR TITLE
ARROW-6310: [C++] IPC json should use strings for 64 bit ints

### DIFF
--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -415,6 +415,11 @@ struct CTypeTraits<Optional, enable_if_optional_like<Optional>> {
 //
 
 template <typename T>
+struct as_void {
+  using type = void;
+};
+
+template <typename T>
 using is_number_type = std::is_base_of<NumberType, T>;
 
 template <typename T>
@@ -441,6 +446,16 @@ struct is_8bit_int {
       (std::is_same<UInt8Type, T>::value || std::is_same<Int8Type, T>::value);
 };
 
+template <typename T, typename CType = void>
+struct is_integer_repr_type : std::false_type {};
+
+template <>
+struct is_integer_repr_type<HalfFloatType> : std::false_type {};
+
+template <typename T>
+struct is_integer_repr_type<T, typename as_void<typename T::c_type>::type>
+    : std::is_integral<typename T::c_type> {};
+
 template <typename T>
 struct is_any_string_type {
   static constexpr bool value =
@@ -456,6 +471,10 @@ using enable_if_primitive_ctype =
 
 template <typename T, typename R = void>
 using enable_if_integer = typename std::enable_if<is_integer_type<T>::value, R>::type;
+
+template <typename T, typename R = void>
+using enable_if_integer_repr =
+    typename std::enable_if<is_integer_repr_type<T>::value, R>::type;
 
 template <typename T>
 using is_signed_integer =

--- a/integration/integration_test.py
+++ b/integration/integration_test.py
@@ -179,6 +179,16 @@ class PrimitiveColumn(Column):
         ]
 
 
+class IntegerColumn(PrimitiveColumn):
+
+    def __init__(self, name, count, is_valid, values, bit_width):
+        super(IntegerColumn, self).__init__(name, count, is_valid, values)
+        self.bit_width = bit_width
+
+    def _encode_value(self, x):
+        return x if self.bit_width < 64 else str(x)
+
+
 TEST_INT_MAX = 2 ** 31 - 1
 TEST_INT_MIN = ~TEST_INT_MAX
 
@@ -225,7 +235,7 @@ class IntegerType(PrimitiveType):
 
         if name is None:
             name = self.name
-        return PrimitiveColumn(name, size, is_valid, values)
+        return IntegerColumn(name, size, is_valid, values, self.bit_width)
 
 
 class DateType(IntegerType):


### PR DESCRIPTION
JS can't represent all 64 bit integers as numbers (which are doubles), so store them in the JSON IPC as strings instead.Closes #5267 from bkietz/6310-Write-64-bit-integers-as- and squashes the following commits:

09b6a9492 <Benjamin Kietzman> de-nest IntegerColumn
8318e9e58 <Benjamin Kietzman> rewrite integration/integration_test.py to generate int64 cols as strings
121dee160 <Benjamin Kietzman> use std::to_string
a5cd719c1 <Benjamin Kietzman> ipc json should use strings for 64 bit ints

Authored-by: Benjamin Kietzman <bengilgit@gmail.com>
Signed-off-by: Wes McKinney <wesm+git@apache.org>