### PR TITLE
ARROW-8122: [Python] Empty numpy arrays with shape cannot be deserialized

### DIFF
--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -117,6 +117,9 @@ Status CheckTensorStridesValidity(const std::shared_ptr<Buffer>& data,
   if (strides.size() != shape.size()) {
     return Status::Invalid("strides must have the same length as shape");
   }
+  if (data->size() == 0 && std::find(shape.begin(), shape.end(), 0) != shape.end()) {
+    return Status::OK();
+  }
 
   std::vector<int64_t> last_index(shape);
   const int64_t n = static_cast<int64_t>(shape.size());

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2613,6 +2613,12 @@ def test_serialize_deserialize_pandas():
     _check_serialize_components_roundtrip(df)
 
 
+def test_serialize_deserialize_empty_pandas():
+    # ARROW-7996, serialize and deserialize empty pandas
+    df = pd.DataFrame({'col1': [], 'col2': [], 'col3': []})
+    _check_serialize_components_roundtrip(df)
+
+
 def _pytime_from_micros(val):
     microseconds = val % 1000000
     val //= 1000000

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2595,13 +2595,16 @@ def test_roundtrip_with_bytes_unicode(columns):
     assert table1.schema.metadata == table2.schema.metadata
 
 
-def _check_serialize_components_roundtrip(df):
+def _check_serialize_components_roundtrip(pd_obj):
     ctx = pa.default_serialization_context()
 
-    components = ctx.serialize(df).to_components()
+    components = ctx.serialize(pd_obj).to_components()
     deserialized = ctx.deserialize_components(components)
 
-    tm.assert_frame_equal(df, deserialized)
+    if isinstance(pd_obj, pd.DataFrame):
+        tm.assert_frame_equal(pd_obj, deserialized)
+    else:
+        tm.assert_series_equal(pd_obj, deserialized)
 
 
 @pytest.mark.skipif(LooseVersion(np.__version__) >= '0.16',
@@ -2614,9 +2617,12 @@ def test_serialize_deserialize_pandas():
 
 
 def test_serialize_deserialize_empty_pandas():
-    # ARROW-7996, serialize and deserialize empty pandas
+    # ARROW-7996, serialize and deserialize empty pandas objects
     df = pd.DataFrame({'col1': [], 'col2': [], 'col3': []})
     _check_serialize_components_roundtrip(df)
+
+    series = pd.Series([], dtype=np.float32, name='col')
+    _check_serialize_components_roundtrip(series)
 
 
 def _pytime_from_micros(val):

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -1093,6 +1093,17 @@ def test_tensor_alignment():
         assert y.ctypes.data % 64 == 0
 
 
+def test_empty_tensor():
+    # ARROW-8122, serialize and deserialize empty tensors
+    x = np.array([], dtype=np.float64)
+    y = pa.deserialize(pa.serialize(x).to_buffer())
+    np.testing.assert_array_equal(x, y)
+
+    x = np.array([[], [], []], dtype=np.float64)
+    y = pa.deserialize(pa.serialize(x).to_buffer())
+    np.testing.assert_array_equal(x, y)
+
+
 def test_serialization_determinism():
     for obj in COMPLEX_OBJECTS:
         buf1 = pa.serialize(obj).to_buffer()

--- a/python/pyarrow/tests/test_serialization.py
+++ b/python/pyarrow/tests/test_serialization.py
@@ -1103,6 +1103,10 @@ def test_empty_tensor():
     y = pa.deserialize(pa.serialize(x).to_buffer())
     np.testing.assert_array_equal(x, y)
 
+    x = np.array([[], [], []], dtype=np.float64).T
+    y = pa.deserialize(pa.serialize(x).to_buffer())
+    np.testing.assert_array_equal(x, y)
+
 
 def test_serialization_determinism():
     for obj in COMPLEX_OBJECTS:


### PR DESCRIPTION
When checking tensor validity with ``CheckTensorStridesValidity`` in ``tensor.cc``, and one of the dimensions is zero, ``last_offset`` and ``data->size()`` are both 0, and ``last_offset >= data->size()`` will be true, which causes a false Status::Invalid, and such empty numpy arrays fails to deserialize.