### PR TITLE
ARROW-8123: [Rust] [DataFusion] Add LogicalPlanBuilder

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -71,7 +71,7 @@ impl ExecutionContext {
     pub fn sql(&mut self, sql: &str, batch_size: usize) -> Result<Vec<RecordBatch>> {
         let plan = self.create_logical_plan(sql)?;
 
-        return self.collect_plan(plan.as_ref(), batch_size);
+        return self.collect_plan(&plan, batch_size);
     }
 
     /// Executes a logical plan and produce a Relation (a schema-aware iterator over a series
@@ -112,7 +112,7 @@ impl ExecutionContext {
     }
 
     /// Creates a logical plan
-    pub fn create_logical_plan(&mut self, sql: &str) -> Result<Arc<LogicalPlan>> {
+    pub fn create_logical_plan(&mut self, sql: &str) -> Result<LogicalPlan> {
         let ast = DFParser::parse_sql(String::from(sql))?;
 
         match ast {
@@ -138,13 +138,13 @@ impl ExecutionContext {
             } => {
                 let schema = Arc::new(self.build_schema(columns)?);
 
-                Ok(Arc::new(LogicalPlan::CreateExternalTable {
+                Ok(LogicalPlan::CreateExternalTable {
                     schema,
                     name,
                     location,
                     file_type,
                     header_row,
-                }))
+                })
             }
         }
     }

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -1216,9 +1216,7 @@ impl PhysicalExpr for Literal {
             ScalarValue::Float64(value) => {
                 build_literal_array!(batch, Float64Builder, *value)
             }
-            ScalarValue::Utf8(value) => {
-                build_literal_array!(batch, StringBuilder, value)
-            }
+            ScalarValue::Utf8(value) => build_literal_array!(batch, StringBuilder, value),
             other => Err(ExecutionError::General(format!(
                 "Unsupported literal type {:?}",
                 other

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -1217,7 +1217,7 @@ impl PhysicalExpr for Literal {
                 build_literal_array!(batch, Float64Builder, *value)
             }
             ScalarValue::Utf8(value) => {
-                build_literal_array!(batch, StringBuilder, &*value)
+                build_literal_array!(batch, StringBuilder, value)
             }
             other => Err(ExecutionError::General(format!(
                 "Unsupported literal type {:?}",

--- a/rust/datafusion/src/execution/table_impl.rs
+++ b/rust/datafusion/src/execution/table_impl.rs
@@ -303,7 +303,7 @@ mod tests {
     }
 
     /// Create a logical plan from a SQL query
-    fn create_plan(sql: &str) -> Result<Arc<LogicalPlan>> {
+    fn create_plan(sql: &str) -> Result<LogicalPlan> {
         let mut ctx = ExecutionContext::new();
         register_aggregate_csv(&mut ctx);
         ctx.create_logical_plan(sql)

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -675,7 +675,7 @@ impl LogicalPlanBuilder {
         let projected_schema = projection.clone().map(|p| {
             Schema::new(p.iter().map(|i| table_schema.field(*i).clone()).collect())
         });
-        Ok(Self::from(            &LogicalPlan::TableScan {
+        Ok(Self::from(&LogicalPlan::TableScan {
             schema_name: schema_name.to_owned(),
             table_name: table_name.to_owned(),
             table_schema: Arc::new(table_schema.clone()),

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -150,7 +150,7 @@ pub enum ScalarValue {
     /// unsigned 64bit int
     UInt64(u64),
     /// utf-8 encoded string
-    Utf8(Arc<String>),
+    Utf8(String),
     /// List of scalars packed as a struct
     Struct(Vec<ScalarValue>),
 }
@@ -350,7 +350,7 @@ pub fn col(index: usize) -> Expr {
 
 /// Create a literal string expression
 pub fn lit_str(str: &str) -> Expr {
-    Expr::Literal(ScalarValue::Utf8(Arc::new(str.to_owned())))
+    Expr::Literal(ScalarValue::Utf8(str.to_owned()))
 }
 
 /// Create an aggregate expression

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -687,14 +687,14 @@ impl LogicalPlanBuilder {
     }
 
     /// Apply a projection
-    pub fn project(&self, expr: Vec<Expr>) -> Result<Self> {
+    pub fn project(&self, expr: &Vec<Expr>) -> Result<Self> {
         let input_schema = self.plan.schema();
 
         let schema =
             Schema::new(utils::exprlist_to_fields(&expr, input_schema.as_ref())?);
 
         Ok(Self::from(&LogicalPlan::Projection {
-            expr,
+            expr: expr.clone(),
             input: Arc::new(self.plan.clone()),
             schema: Arc::new(schema),
         }))
@@ -726,7 +726,7 @@ impl LogicalPlanBuilder {
         }))
     }
 
-    /// Apply a aggregate
+    /// Apply an aggregate
     pub fn aggregate(&self, group_expr: Vec<Expr>, aggr_expr: Vec<Expr>) -> Result<Self> {
         let mut all_fields: Vec<Expr> = group_expr.clone();
         aggr_expr.iter().for_each(|x| all_fields.push(x.clone()));
@@ -762,7 +762,7 @@ mod tests {
             Some(vec![0, 3]),
         )?
         .filter(col(1).eq(&lit_str("CO")))?
-        .project(vec![col(0)])?
+        .project(&vec![col(0)])?
         .build()?;
 
         // prove that a plan can be passed to a thread
@@ -783,7 +783,7 @@ mod tests {
             Some(vec![0, 3]),
         )?
         .filter(col(1).eq(&lit_str("CO")))?
-        .project(vec![col(0)])?
+        .project(&vec![col(0)])?
         .build()?;
 
         let expected = "Projection: #0\n  \

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -654,13 +654,13 @@ pub struct LogicalPlanBuilder {
 
 impl LogicalPlanBuilder {
     /// Create a builder from an existing plan
-    pub fn from(plan: LogicalPlan) -> Self {
-        Self { plan }
+    pub fn from(plan: &LogicalPlan) -> Self {
+        Self { plan: plan.clone() }
     }
 
     /// Create an empty relation
     pub fn empty() -> Self {
-        Self::from(LogicalPlan::EmptyRelation {
+        Self::from(&LogicalPlan::EmptyRelation {
             schema: Arc::new(Schema::empty()),
         })
     }
@@ -675,7 +675,7 @@ impl LogicalPlanBuilder {
         let projected_schema = projection.clone().map(|p| {
             Schema::new(p.iter().map(|i| table_schema.field(*i).clone()).collect())
         });
-        Ok(Self::from(LogicalPlan::TableScan {
+        Ok(Self::from(            &LogicalPlan::TableScan {
             schema_name: schema_name.to_owned(),
             table_name: table_name.to_owned(),
             table_schema: Arc::new(table_schema.clone()),
@@ -693,7 +693,7 @@ impl LogicalPlanBuilder {
         let schema =
             Schema::new(utils::exprlist_to_fields(&expr, input_schema.as_ref())?);
 
-        Ok(Self::from(LogicalPlan::Projection {
+        Ok(Self::from(&LogicalPlan::Projection {
             expr,
             input: Arc::new(self.plan.clone()),
             schema: Arc::new(schema),
@@ -702,7 +702,7 @@ impl LogicalPlanBuilder {
 
     /// Apply a filter
     pub fn filter(&self, expr: Expr) -> Result<Self> {
-        Ok(Self::from(LogicalPlan::Selection {
+        Ok(Self::from(&LogicalPlan::Selection {
             expr,
             input: Arc::new(self.plan.clone()),
         }))
@@ -710,7 +710,7 @@ impl LogicalPlanBuilder {
 
     /// Apply a limit
     pub fn limit(&self, expr: Expr) -> Result<Self> {
-        Ok(Self::from(LogicalPlan::Limit {
+        Ok(Self::from(&LogicalPlan::Limit {
             expr,
             input: Arc::new(self.plan.clone()),
             schema: self.plan.schema().clone(),
@@ -719,7 +719,7 @@ impl LogicalPlanBuilder {
 
     /// Apply a sort
     pub fn sort(&self, expr: Vec<Expr>) -> Result<Self> {
-        Ok(Self::from(LogicalPlan::Sort {
+        Ok(Self::from(&LogicalPlan::Sort {
             expr,
             input: Arc::new(self.plan.clone()),
             schema: self.plan.schema().clone(),
@@ -734,7 +734,7 @@ impl LogicalPlanBuilder {
         let aggr_schema =
             Schema::new(utils::exprlist_to_fields(&all_fields, self.plan.schema())?);
 
-        Ok(Self::from(LogicalPlan::Aggregate {
+        Ok(Self::from(&LogicalPlan::Aggregate {
             input: Arc::new(self.plan.clone()),
             group_expr,
             aggr_expr,

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -343,6 +343,25 @@ impl Expr {
     }
 }
 
+/// Create a column expression
+pub fn col(index: usize) -> Expr {
+    Expr::Column(index)
+}
+
+/// Create a literal string expression
+pub fn lit_str(str: &str) -> Expr {
+    Expr::Literal(ScalarValue::Utf8(Arc::new(str.to_owned())))
+}
+
+/// Create an aggregate expression
+pub fn aggregate_expr(name: &str, expr: Expr, return_type: DataType) -> Expr {
+    Expr::AggregateFunction {
+        name: name.to_owned(),
+        args: vec![expr],
+        return_type,
+    }
+}
+
 impl fmt::Debug for Expr {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
@@ -628,26 +647,183 @@ pub fn can_coerce_from(type_into: &DataType, type_from: &DataType) -> bool {
     }
 }
 
+/// Builder for logical plans
+pub struct LogicalPlanBuilder {
+    plan: LogicalPlan,
+}
+
+impl LogicalPlanBuilder {
+    /// Create a builder from an existing plan
+    pub fn from(plan: LogicalPlan) -> Self {
+        Self { plan }
+    }
+
+    /// Create an empty relation
+    pub fn empty() -> Self {
+        Self::from(LogicalPlan::EmptyRelation {
+            schema: Arc::new(Schema::empty()),
+        })
+    }
+
+    /// Scan a data source
+    pub fn scan(
+        schema_name: &str,
+        table_name: &str,
+        table_schema: &Schema,
+        projection: Option<Vec<usize>>,
+    ) -> Result<Self> {
+        let projected_schema = projection.clone().map(|p| {
+            Schema::new(p.iter().map(|i| table_schema.field(*i).clone()).collect())
+        });
+        Ok(Self::from(LogicalPlan::TableScan {
+            schema_name: schema_name.to_owned(),
+            table_name: table_name.to_owned(),
+            table_schema: Arc::new(table_schema.clone()),
+            projected_schema: Arc::new(
+                projected_schema.or(Some(table_schema.clone())).unwrap(),
+            ),
+            projection,
+        }))
+    }
+
+    /// Apply a projection
+    pub fn project(&self, expr: Vec<Expr>) -> Result<Self> {
+        let input_schema = self.plan.schema();
+
+        let schema =
+            Schema::new(utils::exprlist_to_fields(&expr, input_schema.as_ref())?);
+
+        Ok(Self::from(LogicalPlan::Projection {
+            expr,
+            input: Arc::new(self.plan.clone()),
+            schema: Arc::new(schema),
+        }))
+    }
+
+    /// Apply a filter
+    pub fn filter(&self, expr: Expr) -> Result<Self> {
+        Ok(Self::from(LogicalPlan::Selection {
+            expr,
+            input: Arc::new(self.plan.clone()),
+        }))
+    }
+
+    /// Apply a limit
+    pub fn limit(&self, expr: Expr) -> Result<Self> {
+        Ok(Self::from(LogicalPlan::Limit {
+            expr,
+            input: Arc::new(self.plan.clone()),
+            schema: self.plan.schema().clone(),
+        }))
+    }
+
+    /// Apply a sort
+    pub fn sort(&self, expr: Vec<Expr>) -> Result<Self> {
+        Ok(Self::from(LogicalPlan::Sort {
+            expr,
+            input: Arc::new(self.plan.clone()),
+            schema: self.plan.schema().clone(),
+        }))
+    }
+
+    /// Apply a aggregate
+    pub fn aggregate(&self, group_expr: Vec<Expr>, aggr_expr: Vec<Expr>) -> Result<Self> {
+        let mut all_fields: Vec<Expr> = group_expr.clone();
+        aggr_expr.iter().for_each(|x| all_fields.push(x.clone()));
+
+        let aggr_schema =
+            Schema::new(utils::exprlist_to_fields(&all_fields, self.plan.schema())?);
+
+        Ok(Self::from(LogicalPlan::Aggregate {
+            input: Arc::new(self.plan.clone()),
+            group_expr,
+            aggr_expr,
+            schema: Arc::new(aggr_schema),
+        }))
+    }
+
+    /// Build the plan
+    pub fn build(&self) -> Result<LogicalPlan> {
+        Ok(self.plan.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::thread;
 
     #[test]
-    fn logical_plan_can_be_shared_between_threads() {
-        let schema = Schema::new(vec![]);
-        let plan = Arc::new(LogicalPlan::TableScan {
-            schema_name: "".to_string(),
-            table_name: "people".to_string(),
-            table_schema: Arc::new(schema.clone()),
-            projected_schema: Arc::new(schema),
-            projection: Some(vec![0, 1, 4]),
-        });
+    fn logical_plan_can_be_shared_between_threads() -> Result<()> {
+        let plan = LogicalPlanBuilder::scan(
+            "default",
+            "employee.csv",
+            &employee_schema(),
+            Some(vec![0, 3]),
+        )?
+        .filter(col(1).eq(&lit_str("CO")))?
+        .project(vec![col(0)])?
+        .build()?;
 
         // prove that a plan can be passed to a thread
         let plan1 = plan.clone();
         thread::spawn(move || {
             println!("plan: {:?}", plan1);
         });
+
+        Ok(())
+    }
+
+    #[test]
+    fn plan_builder_simple() -> Result<()> {
+        let plan = LogicalPlanBuilder::scan(
+            "default",
+            "employee.csv",
+            &employee_schema(),
+            Some(vec![0, 3]),
+        )?
+        .filter(col(1).eq(&lit_str("CO")))?
+        .project(vec![col(0)])?
+        .build()?;
+
+        let expected = "Projection: #0\n  \
+                        Selection: #1 Eq Utf8(\"CO\")\n    \
+                        TableScan: employee.csv projection=Some([0, 3])";
+
+        assert_eq!(expected, format!("{:?}", plan));
+
+        Ok(())
+    }
+
+    #[test]
+    fn plan_builder_aggregate() -> Result<()> {
+        let plan = LogicalPlanBuilder::scan(
+            "default",
+            "employee.csv",
+            &employee_schema(),
+            Some(vec![3, 4]),
+        )?
+        .aggregate(
+            vec![col(0)],
+            vec![aggregate_expr("SUM", col(1), DataType::Int32)],
+        )?
+        .build()?;
+
+        let expected = "Aggregate: groupBy=[[#0]], aggr=[[SUM(#1)]]\n  \
+                        TableScan: employee.csv projection=Some([3, 4])";
+
+        assert_eq!(expected, format!("{:?}", plan));
+
+        Ok(())
+    }
+
+    fn employee_schema() -> Schema {
+        Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("first_name", DataType::Utf8, false),
+            Field::new("last_name", DataType::Utf8, false),
+            Field::new("state", DataType::Utf8, false),
+            Field::new("salary", DataType::Int32, false),
+        ])
     }
 }

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -60,9 +60,12 @@ pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
             if *i < input_schema_field_count {
                 Ok(input_schema.fields()[*i].clone())
             } else {
-                Err(ExecutionError::General(format!("Column index {} out of bounds for input schema with {} field(s)", *i, input_schema_field_count)))
+                Err(ExecutionError::General(format!(
+                    "Column index {} out of bounds for input schema with {} field(s)",
+                    *i, input_schema_field_count
+                )))
             }
-        },
+        }
         Expr::Literal(ref lit) => Ok(Field::new("lit", lit.get_datatype(), true)),
         Expr::ScalarFunction {
             ref name,

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -55,7 +55,14 @@ pub fn expr_to_column_indices(expr: &Expr, accum: &mut HashSet<usize>) {
 /// Create field meta-data from an expression, for use in a result set schema
 pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
     match e {
-        Expr::Column(i) => Ok(input_schema.fields()[*i].clone()),
+        Expr::Column(i) => {
+            let input_schema_field_count = input_schema.fields().len();
+            if *i < input_schema_field_count {
+                Ok(input_schema.fields()[*i].clone())
+            } else {
+                Err(ExecutionError::General(format!("Column index {} out of bounds for input schema with {} field(s)", *i, input_schema_field_count)))
+            }
+        },
         Expr::Literal(ref lit) => Ok(Field::new("lit", lit.get_datatype(), true)),
         Expr::ScalarFunction {
             ref name,

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -262,7 +262,7 @@ impl<S: SchemaProvider> SqlToRel<S> {
                 Ok(Expr::Literal(ScalarValue::Float64(n)))
             }
             ASTNode::SQLValue(sqlparser::sqlast::Value::SingleQuotedString(ref s)) => {
-                Ok(Expr::Literal(ScalarValue::Utf8(Arc::new(s.clone()))))
+                Ok(Expr::Literal(ScalarValue::Utf8(s.clone())))
             }
 
             ASTNode::SQLIdentifier(ref id) => {

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -673,6 +673,21 @@ mod tests {
                         false,
                     ),
                 ]))),
+                "aggregate_test_100" => Some(Arc::new(Schema::new(vec![
+                    Field::new("c1", DataType::Utf8, false),
+                    Field::new("c2", DataType::UInt32, false),
+                    Field::new("c3", DataType::Int8, false),
+                    Field::new("c4", DataType::Int16, false),
+                    Field::new("c5", DataType::Int32, false),
+                    Field::new("c6", DataType::Int64, false),
+                    Field::new("c7", DataType::UInt8, false),
+                    Field::new("c8", DataType::UInt16, false),
+                    Field::new("c9", DataType::UInt32, false),
+                    Field::new("c10", DataType::UInt64, false),
+                    Field::new("c11", DataType::Float32, false),
+                    Field::new("c12", DataType::Float64, false),
+                    Field::new("c13", DataType::Utf8, false),
+                ]))),
                 _ => None,
             }
         }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -168,18 +168,9 @@ impl<S: SchemaProvider> SqlToRel<S> {
                                 .map(|e| self.sql_to_rex(&e, &input_schema))
                                 .collect::<Result<Vec<Expr>>>()?;
 
-                            /*TODO
                             LogicalPlanBuilder::from(projection)
-                              .aggregate(group_by_rex, vec![])?
-                              .build()?
-                              */
-
-                            LogicalPlan::Aggregate {
-                                input: Arc::new(projection),
-                                group_expr: group_by_rex,
-                                aggr_expr: vec![],
-                                schema: input_schema.clone(), //TODO this is wrong!
-                            }
+                                .aggregate(group_by_rex, vec![])?
+                                .build()?
                         }
                         _ => projection,
                     };


### PR DESCRIPTION
This PR introduces a LogicalPlanBuilder to make it easier to build logical plans. It also updates the SQL planner to use the LogicalPlanBuilder instead of constructing the logical plans directly, which simplifies the SQL planning logic.

Here is an example of the usage of the new builder.

```rust
        let plan = LogicalPlanBuilder::scan(
            "default",
            "employee.csv",
            &employee_schema(),
            Some(vec![0, 3]),
        )?
        .filter(col(1).eq(&lit_str("CO")))?
        .project(vec![col(0)])?
        .build()?;
```