### PR TITLE
ARROW-8125: [C++] Restore link between tests created with add_arrow_test and arrow-tests target

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -45,6 +45,8 @@ function(ADD_ARROW_TEST REL_TEST_NAME)
 
   if(ARG_LABELS)
     set(LABELS ${ARG_LABELS})
+  else()
+    set(LABELS "arrow-tests")
   endif()
 
   # Because of https://gitlab.kitware.com/cmake/cmake/issues/20289,


### PR DESCRIPTION
I'm not sure why this was removed but I originally set up the `arrow-tests`, `parquet-tests`, etc. labels to make it easy to build a subset of unit tests of interest. The feature introduced in ARROW-8014 I don't think is affected by this