### PR TITLE
ARROW-8128: [C#] NestedType children serialized on wrong length

### DIFF
--- a/csharp/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
@@ -216,8 +216,8 @@ namespace Apache.Arrow.Ipc
             var children = new ArrayData[childrenCount];
             for (var index = 0; index < childrenCount; index++)
             {
-                Flatbuf.FieldNode childFieldNode = recordBatchEnumerator.CurrentNode;
                 recordBatchEnumerator.MoveNextNode();
+                Flatbuf.FieldNode childFieldNode = recordBatchEnumerator.CurrentNode;
 
                 var childField = type.Children[index];
                 var child = childField.DataType.IsFixedPrimitive()

--- a/csharp/test/Apache.Arrow.Tests/TestData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestData.cs
@@ -187,13 +187,15 @@ namespace Apache.Arrow.Tests
                 var builder = new ListArray.Builder(type.ValueField).Reserve(Length);
 
                 //Todo : Support various types
-                var valueBuilder = (Int64Array.Builder)builder.ValueBuilder.Reserve(Length);
+                var valueBuilder = (Int64Array.Builder)builder.ValueBuilder.Reserve(Length + 1);
 
                 for (var i = 0; i < Length; i++)
                 {
                     builder.Append();
                     valueBuilder.Append(i);
                 }
+                //Add a value to check if Values.Length can exceed ListArray.Length
+                valueBuilder.Append(0);
 
                 Array = builder.Build();
 


### PR DESCRIPTION
Move MoveNextMode to the correct line.


Background:

Each node of NestedType children is serialized on a previous node Length and NullCount.
This causes wrong data access at ListArray.GetValueOffset and so on.