### PR TITLE
ARROW-7858: [C++][Python] Support casting from ExtensionArray

### DIFF
--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -1278,6 +1278,9 @@ Status GetCastFunction(const DataType& in_type, std::shared_ptr<DataType> out_ty
   if (in_type.id() == Type::NA) {
     kernel->reset(new FromNullCastKernel(std::move(out_type)));
     return Status::OK();
+  } else if (in_type.id() == Type::EXTENSION) {
+    auto storage_type = dynamic_cast<const ExtensionType&>(in_type).storage_type();
+    return GetCastFunction(*storage_type, out_type, options, kernel);
   }
 
   std::unique_ptr<CastKernelBase> cast_kernel;

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -1159,10 +1159,11 @@ class ExtensionCastKernel : public CastKernelBase {
     }
 
     // validate: type is the same as the type the kernel was constructed with
-    auto& input_type = checked_cast<const ExtensionType&>(*input.type());
+    const auto& input_type = checked_cast<const ExtensionType&>(*input.type());
     if (input_type.extension_name() != extension_name_) {
       return Status::TypeError(
-          "The cast kernel was constructed with a differently named extension type");
+          "The cast kernel was constructed to cast from the extension type named '", extension_name_, 
+          "' but input has named extension type name '", input_type.extension_name(), "'");
     }
     if (!input_type.storage_type()->Equals(storage_type_)) {
       return Status::TypeError(

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -1162,8 +1162,9 @@ class ExtensionCastKernel : public CastKernelBase {
     const auto& input_type = checked_cast<const ExtensionType&>(*input.type());
     if (input_type.extension_name() != extension_name_) {
       return Status::TypeError(
-          "The cast kernel was constructed to cast from the extension type named '", extension_name_, 
-          "' but input has named extension type name '", input_type.extension_name(), "'");
+          "The cast kernel was constructed to cast from the extension type named '",
+          extension_name_, "' but input has extension type named '",
+          input_type.extension_name(), "'");
     }
     if (!input_type.storage_type()->Equals(storage_type_)) {
       return Status::TypeError(

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -1161,10 +1161,12 @@ class ExtensionCastKernel : public CastKernelBase {
     // validate: type is the same as the type the kernel was constructed with
     auto& input_type = checked_cast<const ExtensionType&>(*input.type());
     if (input_type.extension_name() != extension_name_) {
-      return Status::TypeError("EEEE");
+      return Status::TypeError(
+          "The cast kernel was constructed with a differently named extension type");
     }
     if (!input_type.storage_type()->Equals(storage_type_)) {
-      return Status::TypeError("FFF");
+      return Status::TypeError(
+          "The cast kernel was constructed with a different extension type");
     }
 
     // construct an ArrayData object with the underlying storage type

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -22,6 +22,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/cpp/src/arrow/compute/kernels/cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/cast_test.cc
@@ -26,9 +26,11 @@
 
 #include "arrow/array.h"
 #include "arrow/buffer.h"
+#include "arrow/extension_type.h"
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
 #include "arrow/table.h"
+#include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_common.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
@@ -1479,6 +1481,51 @@ TYPED_TEST(TestDictionaryCast, OutTypeError) {
 
   this->CheckPass(*plain_array, *dict_array, dict_array->type(), options);
 }*/
+
+std::shared_ptr<Array> SmallintArrayFromJSON(const std::string& json_data) {
+  auto arr = ArrayFromJSON(int16(), json_data);
+  auto ext_data = arr->data()->Copy();
+  ext_data->type = smallint();
+  return MakeArray(ext_data);
+}
+
+TEST_F(TestCast, ExtensionTypeToIntDowncast) {
+  auto smallint = std::make_shared<SmallintType>();
+  ASSERT_OK(RegisterExtensionType(smallint));
+
+  CastOptions options;
+  options.allow_int_overflow = false;
+
+  std::shared_ptr<Array> result;
+  std::vector<bool> is_valid = {true, false, true, true, true};
+
+  // Smallint(int16) to uint8, no overflow/underrun
+  auto v1 = SmallintArrayFromJSON("[0, 100, 200, 1, 2]");
+  auto e1 = ArrayFromJSON(uint8(), "[0, 100, 200, 1, 2]");
+  CheckPass(*v1, *e1, uint8(), options);
+
+  // Smallint(int16) to uint8, with overflow
+  auto v2 = SmallintArrayFromJSON("[0, null, 256, 1, 3]");
+  auto e2 = ArrayFromJSON(uint8(), "[0, null, 0, 1, 3]");
+  // allow overflow
+  options.allow_int_overflow = true;
+  CheckPass(*v2, *e2, uint8(), options);
+  // disallow overflow
+  options.allow_int_overflow = false;
+  ASSERT_RAISES(Invalid, Cast(&ctx_, *v2, uint8(), options, &result));
+
+  // Smallint(int16) to uint8, with underflow
+  auto v3 = SmallintArrayFromJSON("[0, null, -1, 1, 0]");
+  auto e3 = ArrayFromJSON(uint8(), "[0, null, 255, 1, 0]");
+  // allow overflow
+  options.allow_int_overflow = true;
+  CheckPass(*v3, *e3, uint8(), options);
+  // disallow overflow
+  options.allow_int_overflow = false;
+  ASSERT_RAISES(Invalid, Cast(&ctx_, *v3, uint8(), options, &result));
+
+  ASSERT_OK(UnregisterExtensionType("smallint"));
+}
 
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/cast_test.cc
@@ -1499,6 +1499,10 @@ TEST_F(TestCast, ExtensionTypeToIntDowncast) {
   std::shared_ptr<Array> result;
   std::vector<bool> is_valid = {true, false, true, true, true};
 
+  // Smallint(int16) to int16
+  auto v0 = SmallintArrayFromJSON("[0, 100, 200, 1, 2]");
+  CheckZeroCopy(*v0, int16());
+
   // Smallint(int16) to uint8, no overflow/underrun
   auto v1 = SmallintArrayFromJSON("[0, 100, 200, 1, 2]");
   auto e1 = ArrayFromJSON(uint8(), "[0, 100, 200, 1, 2]");

--- a/cpp/src/arrow/testing/extension_type.h
+++ b/cpp/src/arrow/testing/extension_type.h
@@ -48,10 +48,38 @@ class ARROW_EXPORT UUIDType : public ExtensionType {
   std::string Serialize() const override { return "uuid-type-unique-code"; }
 };
 
+class ARROW_EXPORT SmallintArray : public ExtensionArray {
+ public:
+  using ExtensionArray::ExtensionArray;
+};
+
+class ARROW_EXPORT SmallintType : public ExtensionType {
+ public:
+  SmallintType() : ExtensionType(int16()) {}
+
+  std::string extension_name() const override { return "smallint"; }
+
+  bool ExtensionEquals(const ExtensionType& other) const override;
+
+  std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override;
+
+  Status Deserialize(std::shared_ptr<DataType> storage_type,
+                     const std::string& serialized,
+                     std::shared_ptr<DataType>* out) const override;
+
+  std::string Serialize() const override { return "smallint"; }
+};
+
 ARROW_EXPORT
 std::shared_ptr<DataType> uuid();
 
 ARROW_EXPORT
+std::shared_ptr<DataType> smallint();
+
+ARROW_EXPORT
 std::shared_ptr<Array> ExampleUUID();
+
+ARROW_EXPORT
+std::shared_ptr<Array> ExampleSmallint();
 
 }  // namespace arrow

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -182,6 +182,11 @@ def test_cast_kernel_on_extension_arrays():
     storage = pa.array([1, 2, 3, 4], pa.int64())
     arr = pa.ExtensionArray.from_storage(IntegerType(), storage)
 
+    # test that no allocation happens during identity cast
+    allocated_before_cast = pa.total_allocated_bytes()
+    casted = arr.cast(pa.int64())
+    assert pa.total_allocated_bytes() == allocated_before_cast
+
     cases = [
         (pa.int64(), pa.Int64Array),
         (pa.int32(), pa.Int32Array),

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -181,11 +181,31 @@ def test_cast_kernel_on_extension_arrays():
     # test array casting
     storage = pa.array([1, 2, 3, 4], pa.int64())
     arr = pa.ExtensionArray.from_storage(IntegerType(), storage)
-    assert arr.cast(pa.int32()).type == pa.int32()
+
+    cases = [
+        (pa.int64(), pa.Int64Array),
+        (pa.int32(), pa.Int32Array),
+        (pa.int16(), pa.Int16Array),
+        (pa.uint64(), pa.UInt64Array),
+        (pa.uint32(), pa.UInt32Array),
+        (pa.uint16(), pa.UInt16Array)
+    ]
+    for typ, klass in cases:
+        casted = arr.cast(typ)
+        assert casted.type == typ
+        assert isinstance(casted, klass)
 
     # test chunked array casting
     arr = pa.chunked_array([arr, arr])
-    assert arr.cast(pa.int16()).type == pa.int16()
+    casted = arr.cast(pa.int16())
+    assert casted.type == pa.int16()
+    assert isinstance(casted, pa.ChunkedArray)
+
+
+def test_casting_to_extension_type_raises():
+    arr = pa.array([1, 2, 3, 4], pa.int64())
+    with pytest.raises(pa.ArrowNotImplementedError):
+        arr.cast(IntegerType())
 
 
 def example_batch():


### PR DESCRIPTION
This add support for casting from ExtensionType. We should probably add support for converting to an ExtensionType, but we can handle it in a follow-up.