### PR TITLE
ARROW-8127: [C++] [Parquet] Incorrect column chunk metadata for multipage batch writes

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -299,7 +299,7 @@ class SerializedPageWriter : public PageWriter {
     // TODO(PARQUET-594) crc checksum
 
     PARQUET_ASSIGN_OR_THROW(int64_t start_pos, sink_->Tell());
-    if (data_page_offset_ == 0) {
+    if (page_ordinal_ == 0) {
       data_page_offset_ = start_pos;
     }
 


### PR DESCRIPTION
For buffered column writers and non-dictionary encoded columns, Parquet column chunks that span more than one page get the wrong data_page_offset recorded in the column chunk metadata.  This causes the file to be unreadable and unscannable. (Some more info and a test case [here](https://issues.apache.org/jira/browse/ARROW-8127).)

This patch fixes the error by setting the metadata values from information in the underlying ("final") stream sink.  It reorders but retains similar logic for dictionary page offsets introduced in [PARQUET-1706](https://github.com/apache/arrow/pull/5922).