### PR TITLE
ARROW-8129: [C++][Compute] Refine compare sort kernel

### DIFF
--- a/cpp/src/arrow/compute/kernels/nth_to_indices_test.cc
+++ b/cpp/src/arrow/compute/kernels/nth_to_indices_test.cc
@@ -41,16 +41,6 @@ class Comparator {
   bool operator()(const ArrayType& array, uint64_t lhs, uint64_t rhs) {
     if (array.IsNull(rhs)) return true;
     if (array.IsNull(lhs)) return false;
-    return array.Value(lhs) <= array.Value(rhs);
-  }
-};
-
-template <>
-class Comparator<StringArray> {
- public:
-  bool operator()(const BinaryArray& array, uint64_t lhs, uint64_t rhs) {
-    if (array.IsNull(rhs)) return true;
-    if (array.IsNull(lhs)) return false;
     return array.GetView(lhs) <= array.GetView(rhs);
   }
 };


### PR DESCRIPTION
Sorting kernel implements two comparison functions, CompareValues uses
array.Value() for numerical data and CompareViews uses array.GetView()
for non-numerical ones. It can be simplified by using GetView() only
as all data types support GetView(). This patch also refines unit test.

This change improves about 40% performance.