### PR TITLE
ARROW-8088: [C++][Dataset] Support dictionary partition columns

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -1569,6 +1569,20 @@ class RepeatedArrayFactory {
     return FinishFixedWidth(value.data(), value.size());
   }
 
+  Status Visit(const DictionaryType& type) {
+    std::shared_ptr<Array> dictionary, indices;
+
+    const auto& value = checked_cast<const DictionaryScalar&>(scalar_).value;
+    RETURN_NOT_OK(MakeArrayFromScalar(pool_, *value, 1, &dictionary));
+
+    ARROW_ASSIGN_OR_RAISE(auto zero, MakeScalar(type.index_type(), 0));
+    RETURN_NOT_OK(MakeArrayFromScalar(pool_, *zero, length_, &indices));
+
+    *out_ = std::make_shared<DictionaryArray>(scalar_.type, std::move(indices),
+                                              std::move(dictionary));
+    return Status::OK();
+  }
+
   Status Visit(const DataType& type) {
     return Status::NotImplemented("construction from scalar of type ", *scalar_.type);
   }

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -35,8 +35,8 @@ class MemoryPool;
 // Helper functions
 
 struct DictionaryBuilderCase {
-  template <typename ValueType>
-  Status Visit(const ValueType&, typename ValueType::c_type* = nullptr) {
+  template <typename ValueType, typename Enable = typename ValueType::c_type>
+  Status Visit(const ValueType&) {
     return CreateFor<ValueType>();
   }
 

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -673,9 +673,7 @@ TEST(TestDictPartitionColumn, SelectPartitionColumnFilterPhysicalColumn) {
   ASSERT_OK_AND_ASSIGN(auto scanner, scan_builder->Finish());
   ASSERT_OK_AND_ASSIGN(auto table, scanner->ToTable());
   AssertArraysEqual(*table->column(0)->chunk(0),
-                    *ArrayFromJSON(partition_field->type(), R"([
-    [0, ["one"]]
-  ])"));
+                    *DictArrayFromJSON(partition_field->type(), "[0]", "[\"one\"]"));
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -403,13 +403,21 @@ TEST_F(TestEndToEnd, EndToEndSingleDataset) {
   AssertTablesEqual(*expected, *table, false, true);
 }
 
+inline std::shared_ptr<Schema> SchemaFromNames(const std::vector<std::string> names) {
+  std::vector<std::shared_ptr<Field>> fields;
+  for (const auto& name : names) {
+    fields.push_back(field(name, int32()));
+  }
+
+  return schema(fields);
+}
+
 class TestSchemaUnification : public TestDataset {
  public:
   using i32 = util::optional<int32_t>;
+  using PathAndContent = std::vector<std::pair<std::string, std::string>>;
 
-  void SetUp() {
-    using PathAndContent = std::vector<std::pair<std::string, std::string>>;
-
+  void SetUp() override {
     // The following test creates 2 sources with divergent but compatible
     // schemas. Each source have a common partitioning where the
     // fields are not materialized in the data fragments.
@@ -443,7 +451,7 @@ class TestSchemaUnification : public TestDataset {
     auto get_source =
         [this](std::string base,
                std::vector<std::string> paths) -> Result<std::shared_ptr<Dataset>> {
-      auto resolver = [this](const FileSource& source) -> std::shared_ptr<Schema> {
+      auto resolver = [](const FileSource& source) -> std::shared_ptr<Schema> {
         auto path = source.path();
         // A different schema for each data fragment.
         if (path == ds1_df1) {
@@ -486,15 +494,6 @@ class TestSchemaUnification : public TestDataset {
     };
     dataset_ =
         std::make_shared<DisparateSchemasUnionDataset>(schema_, DatasetVector{ds1, ds2});
-  }
-
-  std::shared_ptr<Schema> SchemaFromNames(const std::vector<std::string> names) {
-    std::vector<std::shared_ptr<Field>> fields;
-    for (const auto& name : names) {
-      fields.push_back(field(name, int32()));
-    }
-
-    return schema(fields);
   }
 
   template <typename TupleType>
@@ -640,6 +639,43 @@ TEST_F(TestSchemaUnification, SelectMixedColumnsAndFilter) {
       TupleType(2, nullopt, 2, nullopt),
   };
   AssertBuilderEquals(scan_builder, rows);
+}
+
+TEST(TestDictPartitionColumn, SelectPartitionColumnFilterPhysicalColumn) {
+  auto partition_field = field("part", dictionary(int32(), utf8()));
+  auto path = "/dataset/part=one/data.json";
+
+  auto mock_fs = std::make_shared<fs::internal::MockFileSystem>(fs::kNoTime);
+  ARROW_EXPECT_OK(mock_fs->CreateFile(path, R"([ {"phy_1": 111, "phy_2": 211} ])",
+                                      /* recursive */ true));
+
+  auto physical_schema = SchemaFromNames({"phy_1", "phy_2"});
+  auto format = std::make_shared<JSONRecordBatchFileFormat>(
+      [=](const FileSource&) { return physical_schema; });
+
+  FileSystemFactoryOptions options;
+  options.partition_base_dir = "/dataset";
+  options.partitioning = std::make_shared<HivePartitioning>(schema({partition_field}));
+
+  ASSERT_OK_AND_ASSIGN(auto factory,
+                       FileSystemDatasetFactory::Make(mock_fs, {path}, format, options));
+
+  ASSERT_OK_AND_ASSIGN(auto schema, factory->Inspect());
+
+  ASSERT_OK_AND_ASSIGN(auto dataset, factory->Finish(schema));
+
+  // Selects re-ordered virtual column with a filter on a physical column
+  ASSERT_OK_AND_ASSIGN(auto scan_builder, dataset->NewScan());
+  ASSERT_OK(scan_builder->Filter("phy_1"_ == 111));
+
+  ASSERT_OK(scan_builder->Project({"part"}));
+
+  ASSERT_OK_AND_ASSIGN(auto scanner, scan_builder->Finish());
+  ASSERT_OK_AND_ASSIGN(auto table, scanner->ToTable());
+  AssertArraysEqual(*table->column(0)->chunk(0),
+                    *ArrayFromJSON(partition_field->type(), R"([
+    [0, ["one"]]
+  ])"));
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -660,110 +660,6 @@ class StructConverter final : public ConcreteConverter<StructConverter> {
 };
 
 // ------------------------------------------------------------------------
-// Converter for dictionary arrays
-
-class DictionaryConverter final : public ConcreteConverter<DictionaryConverter> {
- public:
-  explicit DictionaryConverter(const std::shared_ptr<DataType>& type) { type_ = type; }
-
-  struct FixedDictionaryBuilder : ArrayBuilder {
-    using ArrayBuilder::ArrayBuilder;
-
-    Status AppendNull() override { return index_builder_->AppendNull(); }
-
-    Status AppendNulls(int64_t length) override {
-      return index_builder_->AppendNulls(length);
-    }
-
-    Status FinishInternal(std::shared_ptr<ArrayData>* out) override {
-      if (dictionary_ == nullptr) {
-        return Status::Invalid("dictionary was never supplied");
-      }
-
-      if (max_index_ >= dictionary_->length()) {
-        return Status::IndexError("An index was out of bounds: ", max_index_,
-                                  " cannot refer to an element of ",
-                                  dictionary_->ToString());
-      }
-
-      RETURN_NOT_OK(index_builder_->FinishInternal(out));
-      (*out)->type = type_;
-      (*out)->dictionary = dictionary_;
-
-      Reset();
-      return Status::OK();
-    }
-
-    void Reset() override {
-      index_builder_->Reset();
-      dictionary_ = nullptr;
-      max_index_ = 0;
-    }
-
-    std::shared_ptr<DataType> type() const override { return type_; }
-
-    void UpdateMax(const rj::Value& json_index) {
-      if (json_index.IsNull()) return;
-
-      auto index = json_index.GetInt64();
-      if (index > max_index_) max_index_ = index;
-    }
-
-    int64_t max_index_ = 0;
-    ArrayBuilder* index_builder_;
-    std::shared_ptr<DataType> type_;
-    std::shared_ptr<Array> dictionary_;
-  };
-
-  Status Init() override {
-    auto dictionary_type = checked_cast<const DictionaryType*>(type_.get());
-    RETURN_NOT_OK(GetConverter(dictionary_type->index_type(), &index_converter_));
-    RETURN_NOT_OK(GetConverter(dictionary_type->value_type(), &dictionary_converter_));
-
-    builder_.reset(new FixedDictionaryBuilder(default_memory_pool()));
-    builder_->index_builder_ = index_converter_->builder().get();
-    builder_->type_ = type_;
-
-    return Status::OK();
-  }
-
-  Status AppendNull() override { return builder_->AppendNull(); }
-
-  Status AppendValue(const rj::Value& json_obj) override {
-    if (json_obj.IsNull()) {
-      return AppendNull();
-    }
-
-    if (!json_obj.IsArray()) {
-      return JSONTypeError("array", json_obj.GetType());
-    }
-
-    if (json_obj.Size() != 1 && json_obj.Size() != 2) {
-      return Status::Invalid(
-          "Expected [index] or [index, dictionary], got array of size ", json_obj.Size());
-    }
-
-    RETURN_NOT_OK(index_converter_->AppendValue(json_obj[0]));
-    builder_->UpdateMax(json_obj[0]);
-
-    if (json_obj.Size() == 1) return Status::OK();
-
-    if (builder_->dictionary_ != nullptr) {
-      return Status::Invalid("dictionary was already specified");
-    }
-
-    RETURN_NOT_OK(dictionary_converter_->AppendValues(json_obj[1]));
-    return dictionary_converter_->Finish(&builder_->dictionary_);
-  }
-
-  std::shared_ptr<ArrayBuilder> builder() override { return builder_; }
-
- private:
-  std::shared_ptr<FixedDictionaryBuilder> builder_;
-  std::shared_ptr<Converter> index_converter_, dictionary_converter_;
-};
-
-// ------------------------------------------------------------------------
 // Converter for union arrays
 
 class UnionConverter final : public ConcreteConverter<UnionConverter> {
@@ -901,7 +797,6 @@ Status GetConverter(const std::shared_ptr<DataType>& type,
     SIMPLE_CONVERTER_CASE(Type::FIXED_SIZE_BINARY, FixedSizeBinaryConverter)
     SIMPLE_CONVERTER_CASE(Type::DECIMAL, DecimalConverter)
     SIMPLE_CONVERTER_CASE(Type::UNION, UnionConverter)
-    SIMPLE_CONVERTER_CASE(Type::DICTIONARY, DictionaryConverter)
     case Type::INTERVAL: {
       switch (checked_cast<const IntervalType&>(*type).interval_type()) {
         case IntervalType::MONTHS:
@@ -926,8 +821,8 @@ Status GetConverter(const std::shared_ptr<DataType>& type,
   return Status::OK();
 }
 
-Status ArrayFromJSON(const std::shared_ptr<DataType>& type,
-                     const util::string_view& json_string, std::shared_ptr<Array>* out) {
+Status ArrayFromJSON(const std::shared_ptr<DataType>& type, util::string_view json_string,
+                     std::shared_ptr<Array>* out) {
   std::shared_ptr<Converter> converter;
   RETURN_NOT_OK(GetConverter(type, &converter));
 
@@ -951,6 +846,24 @@ Status ArrayFromJSON(const std::shared_ptr<DataType>& type,
 Status ArrayFromJSON(const std::shared_ptr<DataType>& type, const char* json_string,
                      std::shared_ptr<Array>* out) {
   return ArrayFromJSON(type, util::string_view(json_string), out);
+}
+
+Status DictArrayFromJSON(const std::shared_ptr<DataType>& type,
+                         util::string_view indices_json,
+                         util::string_view dictionary_json, std::shared_ptr<Array>* out) {
+  if (type->id() != Type::DICTIONARY) {
+    return Status::TypeError("DictArrayFromJSON requires dictionary type, got ", *type);
+  }
+
+  const auto& dictionary_type = checked_cast<const DictionaryType&>(*type);
+
+  std::shared_ptr<Array> indices, dictionary;
+  RETURN_NOT_OK(ArrayFromJSON(dictionary_type.index_type(), indices_json, &indices));
+  RETURN_NOT_OK(
+      ArrayFromJSON(dictionary_type.value_type(), dictionary_json, &dictionary));
+
+  return DictionaryArray::FromArrays(type, std::move(indices), std::move(dictionary),
+                                     out);
 }
 
 }  // namespace json

--- a/cpp/src/arrow/ipc/json_simple.h
+++ b/cpp/src/arrow/ipc/json_simple.h
@@ -17,8 +17,7 @@
 
 // Implement a simple JSON representation format for arrays
 
-#ifndef ARROW_IPC_JSON_SIMPLE_H
-#define ARROW_IPC_JSON_SIMPLE_H
+#pragma once
 
 #include <memory>
 #include <string>
@@ -41,16 +40,18 @@ Status ArrayFromJSON(const std::shared_ptr<DataType>&, const std::string& json,
                      std::shared_ptr<Array>* out);
 
 ARROW_EXPORT
-Status ArrayFromJSON(const std::shared_ptr<DataType>&, const util::string_view& json,
+Status ArrayFromJSON(const std::shared_ptr<DataType>&, util::string_view json,
                      std::shared_ptr<Array>* out);
 
 ARROW_EXPORT
 Status ArrayFromJSON(const std::shared_ptr<DataType>&, const char* json,
                      std::shared_ptr<Array>* out);
 
+ARROW_EXPORT
+Status DictArrayFromJSON(const std::shared_ptr<DataType>&, util::string_view indices_json,
+                         util::string_view dictionary_json, std::shared_ptr<Array>* out);
+
 }  // namespace json
 }  // namespace internal
 }  // namespace ipc
 }  // namespace arrow
-
-#endif  // ARROW_IPC_JSON_SIMPLE_H

--- a/cpp/src/arrow/ipc/json_simple_test.cc
+++ b/cpp/src/arrow/ipc/json_simple_test.cc
@@ -1207,96 +1207,24 @@ TEST(TestSparseUnion, Errors) {
 
 TEST(TestDictionary, Basics) {
   auto type = dictionary(int32(), utf8());
-  auto array = ArrayFromJSON(type, R"([
-      [null, ["whiskey", "tango", "foxtrot"]],
-      [2],
-      [1],
-      [0]
-    ])");
+  auto array =
+      DictArrayFromJSON(type, "[null, 2, 1, 0]", R"(["whiskey", "tango", "foxtrot"])");
 
   auto expected_indices = ArrayFromJSON(int32(), "[null, 2, 1, 0]");
   auto expected_dictionary = ArrayFromJSON(utf8(), R"(["whiskey", "tango", "foxtrot"])");
 
-  DictionaryArray expected(type, expected_indices, expected_dictionary);
-
-  ASSERT_ARRAYS_EQUAL(expected, *array);
-}
-
-TEST(TestDictionary, Nested) {
-  auto type = dictionary(int32(), utf8());
-  auto array = ArrayFromJSON(struct_({field("dict", type)}), R"([
-      {"dict": [null, ["whiskey", "tango", "foxtrot"]]},
-      null,
-      {"dict": [2]},
-      {"dict": [1]},
-      null,
-      {"dict": [0]}
-    ])");
-
-  auto expected_indices = ArrayFromJSON(int32(), "[null, null, 2, 1, null, 0]");
-  auto expected_dictionary = ArrayFromJSON(utf8(), R"(["whiskey", "tango", "foxtrot"])");
-  auto expected_dict_array =
-      std::make_shared<DictionaryArray>(type, expected_indices, expected_dictionary);
-  ASSERT_OK_AND_ASSIGN(auto expected_null_bitmap,
-                       BitUtil::BytesToBits({1, 0, 1, 1, 0, 1}));
-
-  ASSERT_OK_AND_ASSIGN(auto expected, StructArray::Make({expected_dict_array}, {"dict"},
-                                                        expected_null_bitmap));
-
-  ASSERT_ARRAYS_EQUAL(*expected, *array);
-}
-
-TEST(TestDictionary, VeryNested) {
-  auto dict_type = dictionary(int32(), utf8());
-  auto struct_type = struct_({field("dict", dict_type)});
-  auto type = dictionary(int8(), struct_type);
-
-  auto array = ArrayFromJSON(type, R"([
-      [null, [
-        {"dict": [null, ["whiskey", "tango", "foxtrot"]]},
-        {"dict": [2]},
-        {"dict": [1]},
-        {"dict": [0]}
-      ]],
-      [0],
-      [1],
-      [2]
-    ])");
-
-  auto expected_dictionary = ArrayFromJSON(struct_type, R"([
-      {"dict": [null, ["whiskey", "tango", "foxtrot"]]},
-      {"dict": [2]},
-      {"dict": [1]},
-      {"dict": [0]}
-    ])");
-
-  auto expected_indices = ArrayFromJSON(int8(), "[null, 0, 1, 2]");
-  auto expected_dict_array =
-      std::make_shared<DictionaryArray>(type, expected_indices, expected_dictionary);
-
-  DictionaryArray expected(type, expected_indices, expected_dictionary);
-
-  ASSERT_ARRAYS_EQUAL(expected, *array);
+  ASSERT_ARRAYS_EQUAL(DictionaryArray(type, expected_indices, expected_dictionary),
+                      *array);
 }
 
 TEST(TestDictionary, Errors) {
   auto type = dictionary(int32(), utf8());
   std::shared_ptr<Array> array;
 
-  ASSERT_RAISES(Invalid, ArrayFromJSON(type, "[[\"not a valid index\"]]", &array));
   ASSERT_RAISES(Invalid,
-                ArrayFromJSON(type, "[[0, \"not a valid dictionary\"]]", &array));
-  ASSERT_RAISES(
-      Invalid, ArrayFromJSON(type, "[[0], [1], [2]]", &array));  // no dictionary supplied
-  ASSERT_RAISES(Invalid, ArrayFromJSON(type, "[[0, [\"a\"]], [0, [\"a\"]]]",
-                                       &array));  // multiple dictionaries supplied
-  ASSERT_RAISES(IndexError, ArrayFromJSON(type, "[[0, [\"a\"]], [2]]",
-                                          &array));  // index out of bounds
-
-  ASSERT_RAISES(Invalid,
-                ArrayFromJSON(type, "[\"not an index or index,dict pair\"]", &array));
-  ASSERT_RAISES(Invalid, ArrayFromJSON(type, "[[]]", &array));
-  ASSERT_RAISES(Invalid, ArrayFromJSON(type, "[[0, [\"\"], false]]", &array));
+                DictArrayFromJSON(type, "[\"not a valid index\"]", "[\"\"]", &array));
+  ASSERT_RAISES(Invalid, DictArrayFromJSON(type, "[0, 1]", "[1]",
+                                           &array));  // dict value isn't string
 }
 
 }  // namespace json

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -127,25 +127,31 @@ size_t Scalar::Hash::hash(const Scalar& scalar) { return ScalarHashImpl(scalar).
 StringScalar::StringScalar(std::string s)
     : StringScalar(Buffer::FromString(std::move(s))) {}
 
-FixedSizeBinaryScalar::FixedSizeBinaryScalar(const std::shared_ptr<Buffer>& value,
-                                             const std::shared_ptr<DataType>& type)
-    : BinaryScalar(value, type) {
-  ARROW_CHECK_EQ(checked_cast<const FixedSizeBinaryType&>(*type).byte_width(),
-                 value->size());
+FixedSizeBinaryScalar::FixedSizeBinaryScalar(std::shared_ptr<Buffer> value,
+                                             std::shared_ptr<DataType> type)
+    : BinaryScalar(std::move(value), std::move(type)) {
+  ARROW_CHECK_EQ(checked_cast<const FixedSizeBinaryType&>(*this->type).byte_width(),
+                 this->value->size());
 }
 
-BaseListScalar::BaseListScalar(const std::shared_ptr<Array>& value,
-                               const std::shared_ptr<DataType>& type)
-    : Scalar{type, true}, value(value) {}
+BaseListScalar::BaseListScalar(std::shared_ptr<Array> value,
+                               std::shared_ptr<DataType> type)
+    : Scalar{std::move(type), true}, value(std::move(value)) {}
 
-BaseListScalar::BaseListScalar(const std::shared_ptr<Array>& value)
-    : BaseListScalar(value, value->type()) {}
+BaseListScalar::BaseListScalar(std::shared_ptr<Array> value)
+    : Scalar(value->type(), true), value(std::move(value)) {}
 
-FixedSizeListScalar::FixedSizeListScalar(const std::shared_ptr<Array>& value,
-                                         const std::shared_ptr<DataType>& type)
-    : BaseListScalar(value, type) {
-  ARROW_CHECK_EQ(value->length(),
-                 checked_cast<const FixedSizeListType*>(type.get())->list_size());
+FixedSizeListScalar::FixedSizeListScalar(std::shared_ptr<Array> value,
+                                         std::shared_ptr<DataType> type)
+    : BaseListScalar(std::move(value), std::move(type)) {
+  ARROW_CHECK_EQ(this->value->length(),
+                 checked_cast<const FixedSizeListType&>(*this->type).list_size());
+}
+
+DictionaryScalar::DictionaryScalar(std::shared_ptr<DataType> type)
+    : Scalar(std::move(type)),
+      value(
+          MakeNullScalar(checked_cast<const DictionaryType&>(*this->type).value_type())) {
 }
 
 template <typename T>
@@ -173,15 +179,18 @@ struct MakeNullImpl {
     return Status::OK();
   }
 
-  const std::shared_ptr<DataType>& type_;
+  std::shared_ptr<Scalar> Finish() && {
+    // Should not fail.
+    DCHECK_OK(VisitTypeInline(*type_, this));
+    return std::move(out_);
+  }
+
+  std::shared_ptr<DataType> type_;
   std::shared_ptr<Scalar> out_;
 };
 
-std::shared_ptr<Scalar> MakeNullScalar(const std::shared_ptr<DataType>& type) {
-  MakeNullImpl impl = {type, nullptr};
-  // Should not fail.
-  DCHECK_OK(VisitTypeInline(*type, &impl));
-  return std::move(impl.out_);
+std::shared_ptr<Scalar> MakeNullScalar(std::shared_ptr<DataType> type) {
+  return MakeNullImpl{std::move(type), nullptr}.Finish();
 }
 
 std::string Scalar::ToString() const {
@@ -207,7 +216,12 @@ struct ScalarParseImpl {
 
   Status Visit(const LargeBinaryType&) { return FinishWithBuffer(); }
 
-  Status Visit(const FixedSizeBinaryType& t) { return FinishWithBuffer(); }
+  Status Visit(const FixedSizeBinaryType&) { return FinishWithBuffer(); }
+
+  Status Visit(const DictionaryType& t) {
+    ARROW_ASSIGN_OR_RAISE(auto value, Scalar::Parse(t.value_type(), s_));
+    return Finish(std::move(value));
+  }
 
   Status Visit(const DataType& t) {
     return Status::NotImplemented("parsing scalars of type ", t);
@@ -215,26 +229,27 @@ struct ScalarParseImpl {
 
   template <typename Arg>
   Status Finish(Arg&& arg) {
-    return MakeScalar(type_, std::forward<Arg>(arg)).Value(out_);
+    return MakeScalar(std::move(type_), std::forward<Arg>(arg)).Value(&out_);
   }
 
   Status FinishWithBuffer() { return Finish(Buffer::FromString(s_.to_string())); }
 
-  ScalarParseImpl(const std::shared_ptr<DataType>& type, util::string_view s,
-                  std::shared_ptr<Scalar>* out)
-      : type_(type), s_(s), out_(out) {}
+  Result<std::shared_ptr<Scalar>> Finish() && {
+    RETURN_NOT_OK(VisitTypeInline(*type_, this));
+    return std::move(out_);
+  }
 
-  const std::shared_ptr<DataType>& type_;
+  ScalarParseImpl(std::shared_ptr<DataType> type, util::string_view s)
+      : type_(std::move(type)), s_(s) {}
+
+  std::shared_ptr<DataType> type_;
   util::string_view s_;
-  std::shared_ptr<Scalar>* out_;
+  std::shared_ptr<Scalar> out_;
 };
 
 Result<std::shared_ptr<Scalar>> Scalar::Parse(const std::shared_ptr<DataType>& type,
                                               util::string_view s) {
-  std::shared_ptr<Scalar> out;
-  ScalarParseImpl impl = {type, s, &out};
-  RETURN_NOT_OK(VisitTypeInline(*type, &impl));
-  return out;
+  return ScalarParseImpl{type, s}.Finish();
 }
 
 namespace internal {

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -48,7 +48,7 @@ class Array;
 struct ARROW_EXPORT Scalar : public util::EqualityComparable<Scalar> {
   virtual ~Scalar() = default;
 
-  explicit Scalar(const std::shared_ptr<DataType>& type) : type(type), is_valid(false) {}
+  explicit Scalar(std::shared_ptr<DataType> type) : type(std::move(type)) {}
 
   /// \brief The type of the scalar value
   std::shared_ptr<DataType> type;
@@ -79,8 +79,8 @@ struct ARROW_EXPORT Scalar : public util::EqualityComparable<Scalar> {
   Result<std::shared_ptr<Scalar>> CastTo(std::shared_ptr<DataType> to) const;
 
  protected:
-  Scalar(const std::shared_ptr<DataType>& type, bool is_valid)
-      : type(type), is_valid(is_valid) {}
+  Scalar(std::shared_ptr<DataType> type, bool is_valid)
+      : type(std::move(type)), is_valid(is_valid) {}
 };
 
 /// \brief A scalar value for NullType. Never valid
@@ -100,9 +100,9 @@ struct ARROW_EXPORT PrimitiveScalar : public Scalar {
   using ValueType = CType;
 
   // Non-null constructor.
-  PrimitiveScalar(ValueType value, const std::shared_ptr<DataType>& type)
-      : Scalar(type, true), value(value) {
-    ARROW_CHECK_EQ(type->id(), T::type_id);
+  PrimitiveScalar(ValueType value, std::shared_ptr<DataType> type)
+      : Scalar(std::move(type), true), value(value) {
+    ARROW_CHECK_EQ(this->type->id(), T::type_id);
   }
 
   explicit PrimitiveScalar(ValueType value)
@@ -175,21 +175,19 @@ struct ARROW_EXPORT BaseBinaryScalar : public Scalar {
   std::shared_ptr<Buffer> value;
 
  protected:
-  BaseBinaryScalar(const std::shared_ptr<Buffer>& value,
-                   const std::shared_ptr<DataType>& type)
-      : Scalar{type, true}, value(value) {}
+  BaseBinaryScalar(std::shared_ptr<Buffer> value, std::shared_ptr<DataType> type)
+      : Scalar{std::move(type), true}, value(std::move(value)) {}
 };
 
 struct ARROW_EXPORT BinaryScalar : public BaseBinaryScalar {
   using BaseBinaryScalar::BaseBinaryScalar;
   using TypeClass = BinaryScalar;
 
-  BinaryScalar(const std::shared_ptr<Buffer>& value,
-               const std::shared_ptr<DataType>& type)
-      : BaseBinaryScalar(value, type) {}
+  BinaryScalar(std::shared_ptr<Buffer> value, std::shared_ptr<DataType> type)
+      : BaseBinaryScalar(std::move(value), std::move(type)) {}
 
-  explicit BinaryScalar(const std::shared_ptr<Buffer>& value)
-      : BinaryScalar(value, binary()) {}
+  explicit BinaryScalar(std::shared_ptr<Buffer> value)
+      : BinaryScalar(std::move(value), binary()) {}
 
   BinaryScalar() : BinaryScalar(binary()) {}
 };
@@ -198,8 +196,8 @@ struct ARROW_EXPORT StringScalar : public BinaryScalar {
   using BinaryScalar::BinaryScalar;
   using TypeClass = StringType;
 
-  explicit StringScalar(const std::shared_ptr<Buffer>& value)
-      : StringScalar(value, utf8()) {}
+  explicit StringScalar(std::shared_ptr<Buffer> value)
+      : StringScalar(std::move(value), utf8()) {}
 
   explicit StringScalar(std::string s);
 
@@ -210,12 +208,11 @@ struct ARROW_EXPORT LargeBinaryScalar : public BaseBinaryScalar {
   using BaseBinaryScalar::BaseBinaryScalar;
   using TypeClass = LargeBinaryScalar;
 
-  LargeBinaryScalar(const std::shared_ptr<Buffer>& value,
-                    const std::shared_ptr<DataType>& type)
-      : BaseBinaryScalar(value, type) {}
+  LargeBinaryScalar(std::shared_ptr<Buffer> value, std::shared_ptr<DataType> type)
+      : BaseBinaryScalar(std::move(value), std::move(type)) {}
 
-  explicit LargeBinaryScalar(const std::shared_ptr<Buffer>& value)
-      : LargeBinaryScalar(value, large_binary()) {}
+  explicit LargeBinaryScalar(std::shared_ptr<Buffer> value)
+      : LargeBinaryScalar(std::move(value), large_binary()) {}
 
   LargeBinaryScalar() : LargeBinaryScalar(large_binary()) {}
 };
@@ -224,8 +221,8 @@ struct ARROW_EXPORT LargeStringScalar : public LargeBinaryScalar {
   using LargeBinaryScalar::LargeBinaryScalar;
   using TypeClass = LargeStringType;
 
-  explicit LargeStringScalar(const std::shared_ptr<Buffer>& value)
-      : LargeStringScalar(value, large_utf8()) {}
+  explicit LargeStringScalar(std::shared_ptr<Buffer> value)
+      : LargeStringScalar(std::move(value), large_utf8()) {}
 
   LargeStringScalar() : LargeStringScalar(large_utf8()) {}
 };
@@ -233,11 +230,9 @@ struct ARROW_EXPORT LargeStringScalar : public LargeBinaryScalar {
 struct ARROW_EXPORT FixedSizeBinaryScalar : public BinaryScalar {
   using TypeClass = FixedSizeBinaryType;
 
-  FixedSizeBinaryScalar(const std::shared_ptr<Buffer>& value,
-                        const std::shared_ptr<DataType>& type);
+  FixedSizeBinaryScalar(std::shared_ptr<Buffer> value, std::shared_ptr<DataType> type);
 
-  explicit FixedSizeBinaryScalar(const std::shared_ptr<DataType>& type)
-      : BinaryScalar(type) {}
+  explicit FixedSizeBinaryScalar(std::shared_ptr<DataType> type) : BinaryScalar(type) {}
 };
 
 template <typename T>
@@ -246,10 +241,11 @@ struct ARROW_EXPORT TemporalScalar : public Scalar {
   using TypeClass = T;
   using ValueType = typename T::c_type;
 
-  TemporalScalar(ValueType value, const std::shared_ptr<DataType>& type)
-      : Scalar(type, true), value(value) {}
+  TemporalScalar(ValueType value, std::shared_ptr<DataType> type)
+      : Scalar(std::move(type), true), value(value) {}
 
-  explicit TemporalScalar(const std::shared_ptr<DataType>& type) : Scalar(type, false) {}
+  explicit TemporalScalar(std::shared_ptr<DataType> type)
+      : Scalar(std::move(type), false) {}
 
   ValueType value;
 };
@@ -260,7 +256,7 @@ struct ARROW_EXPORT DateScalar : public TemporalScalar<T> {
   using ValueType = typename TemporalScalar<T>::ValueType;
 
   explicit DateScalar(ValueType value)
-      : TemporalScalar<T>(value, TypeTraits<T>::type_singleton()) {}
+      : TemporalScalar<T>(std::move(value), TypeTraits<T>::type_singleton()) {}
   DateScalar() : TemporalScalar<T>(TypeTraits<T>::type_singleton()) {}
 };
 
@@ -316,8 +312,8 @@ struct ARROW_EXPORT Decimal128Scalar : public Scalar {
   using TypeClass = Decimal128Type;
   using ValueType = Decimal128;
 
-  Decimal128Scalar(const Decimal128& value, const std::shared_ptr<DataType>& type)
-      : Scalar(type, true), value(std::move(value)) {}
+  Decimal128Scalar(Decimal128 value, std::shared_ptr<DataType> type)
+      : Scalar(std::move(type), true), value(value) {}
 
   Decimal128 value;
 };
@@ -326,10 +322,9 @@ struct ARROW_EXPORT BaseListScalar : public Scalar {
   using Scalar::Scalar;
   using ValueType = std::shared_ptr<Array>;
 
-  BaseListScalar(const std::shared_ptr<Array>& value,
-                 const std::shared_ptr<DataType>& type);
+  BaseListScalar(std::shared_ptr<Array> value, std::shared_ptr<DataType> type);
 
-  explicit BaseListScalar(const std::shared_ptr<Array>& value);
+  explicit BaseListScalar(std::shared_ptr<Array> value);
 
   std::shared_ptr<Array> value;
 };
@@ -353,8 +348,7 @@ struct ARROW_EXPORT FixedSizeListScalar : public BaseListScalar {
   using TypeClass = FixedSizeListType;
   using BaseListScalar::BaseListScalar;
 
-  FixedSizeListScalar(const std::shared_ptr<Array>& value,
-                      const std::shared_ptr<DataType>& type);
+  FixedSizeListScalar(std::shared_ptr<Array> value, std::shared_ptr<DataType> type);
 };
 
 struct ARROW_EXPORT StructScalar : public Scalar {
@@ -363,10 +357,10 @@ struct ARROW_EXPORT StructScalar : public Scalar {
 
   std::vector<std::shared_ptr<Scalar>> value;
 
-  StructScalar(ValueType value, const std::shared_ptr<DataType>& type)
-      : Scalar(type, true), value(std::move(value)) {}
+  StructScalar(ValueType value, std::shared_ptr<DataType> type)
+      : Scalar(std::move(type), true), value(std::move(value)) {}
 
-  explicit StructScalar(const std::shared_ptr<DataType>& type) : Scalar(type) {}
+  explicit StructScalar(std::shared_ptr<DataType> type) : Scalar(std::move(type)) {}
 };
 
 struct ARROW_EXPORT UnionScalar : public Scalar {
@@ -375,8 +369,14 @@ struct ARROW_EXPORT UnionScalar : public Scalar {
 };
 
 struct ARROW_EXPORT DictionaryScalar : public Scalar {
-  using Scalar::Scalar;
   using TypeClass = DictionaryType;
+  using ValueType = std::shared_ptr<Scalar>;
+  ValueType value;
+
+  explicit DictionaryScalar(std::shared_ptr<DataType> type);
+
+  DictionaryScalar(ValueType value, std::shared_ptr<DataType> type)
+      : Scalar(std::move(type), true), value(std::move(value)) {}
 };
 
 struct ARROW_EXPORT ExtensionScalar : public Scalar {
@@ -385,7 +385,7 @@ struct ARROW_EXPORT ExtensionScalar : public Scalar {
 };
 
 ARROW_EXPORT
-std::shared_ptr<Scalar> MakeNullScalar(const std::shared_ptr<DataType>& type);
+std::shared_ptr<Scalar> MakeNullScalar(std::shared_ptr<DataType> type);
 
 namespace internal {
 
@@ -412,15 +412,15 @@ struct is_simple_scalar<
 
 template <typename ValueRef>
 struct MakeScalarImpl {
-  template <
-      typename T, typename ScalarType = typename TypeTraits<T>::ScalarType,
-      typename ValueType = typename ScalarType::ValueType,
-      typename Enable = typename std::enable_if<
-          internal::is_simple_scalar<ScalarType>::value &&
-          std::is_same<ValueType, typename std::decay<ValueRef>::type>::value>::type>
+  template <typename T, typename ScalarType = typename TypeTraits<T>::ScalarType,
+            typename ValueType = typename ScalarType::ValueType,
+            typename Enable = typename std::enable_if<
+                internal::is_simple_scalar<ScalarType>::value &&
+                std::is_constructible<ValueType, ValueRef>::value>::type>
   Status Visit(const T& t) {
     ARROW_RETURN_NOT_OK(internal::CheckBufferLength(&t, &value_));
-    *out_ = std::make_shared<ScalarType>(ValueType(static_cast<ValueRef>(value_)), type_);
+    out_ = std::make_shared<ScalarType>(ValueType(static_cast<ValueRef>(value_)),
+                                        std::move(type_));
     return Status::OK();
   }
 
@@ -428,18 +428,20 @@ struct MakeScalarImpl {
     return Status::NotImplemented("constructing scalars of type ", t, " from ", value_);
   }
 
-  const std::shared_ptr<DataType>& type_;
+  Result<std::shared_ptr<Scalar>> Finish() && {
+    ARROW_RETURN_NOT_OK(VisitTypeInline(*type_, this));
+    return std::move(out_);
+  }
+
+  std::shared_ptr<DataType> type_;
   ValueRef value_;
-  std::shared_ptr<Scalar>* out_;
+  std::shared_ptr<Scalar> out_;
 };
 
 template <typename Value>
-Result<std::shared_ptr<Scalar>> MakeScalar(const std::shared_ptr<DataType>& type,
+Result<std::shared_ptr<Scalar>> MakeScalar(std::shared_ptr<DataType> type,
                                            Value&& value) {
-  std::shared_ptr<Scalar> out;
-  MakeScalarImpl<Value&&> impl = {type, std::forward<Value>(value), &out};
-  ARROW_RETURN_NOT_OK(VisitTypeInline(*type, &impl));
-  return out;
+  return MakeScalarImpl<Value&&>{type, std::forward<Value>(value), NULLPTR}.Finish();
 }
 
 /// \brief type inferring scalar factory
@@ -452,7 +454,7 @@ std::shared_ptr<Scalar> MakeScalar(Value value) {
 }
 
 inline std::shared_ptr<Scalar> MakeScalar(std::string value) {
-  return std::make_shared<StringScalar>(value);
+  return std::make_shared<StringScalar>(std::move(value));
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -218,6 +218,15 @@ std::shared_ptr<Array> ArrayFromJSON(const std::shared_ptr<DataType>& type,
   return out;
 }
 
+std::shared_ptr<Array> DictArrayFromJSON(const std::shared_ptr<DataType>& type,
+                                         util::string_view indices_json,
+                                         util::string_view dictionary_json) {
+  std::shared_ptr<Array> out;
+  ABORT_NOT_OK(
+      ipc::internal::json::DictArrayFromJSON(type, indices_json, dictionary_json, &out));
+  return out;
+}
+
 std::shared_ptr<ChunkedArray> ChunkedArrayFromJSON(const std::shared_ptr<DataType>& type,
                                                    const std::vector<std::string>& json) {
   ArrayVector out_chunks;

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -256,8 +256,14 @@ ARROW_EXPORT
 std::shared_ptr<Array> ArrayFromJSON(const std::shared_ptr<DataType>&,
                                      util::string_view json);
 
-ARROW_EXPORT std::shared_ptr<RecordBatch> RecordBatchFromJSON(
-    const std::shared_ptr<Schema>&, util::string_view);
+ARROW_EXPORT
+std::shared_ptr<Array> DictArrayFromJSON(const std::shared_ptr<DataType>& type,
+                                         util::string_view indices_json,
+                                         util::string_view dictionary_json);
+
+ARROW_EXPORT
+std::shared_ptr<RecordBatch> RecordBatchFromJSON(const std::shared_ptr<Schema>&,
+                                                 util::string_view);
 
 ARROW_EXPORT
 std::shared_ptr<ChunkedArray> ChunkedArrayFromJSON(const std::shared_ptr<DataType>&,


### PR DESCRIPTION
This PR necessitated adding `Scalar::Parse`, `MakeArrayFromScalar`, and `ArrayFromJSON` cases for dictionary type.