### PR TITLE
ARROW-7332: [C++][Python] Propagate Arrow Status through Parquet errors

### DIFF
--- a/cpp/src/parquet/exception.h
+++ b/cpp/src/parquet/exception.h
@@ -33,18 +33,22 @@
 
 // Parquet exception to Arrow Status
 
-#define PARQUET_CATCH_NOT_OK(s)                    \
-  try {                                            \
-    (s);                                           \
-  } catch (const ::parquet::ParquetException& e) { \
-    return ::arrow::Status::IOError(e.what());     \
+#define PARQUET_CATCH_NOT_OK(s)                          \
+  try {                                                  \
+    (s);                                                 \
+  } catch (const ::parquet::ParquetStatusException& e) { \
+    return e.status();                                   \
+  } catch (const ::parquet::ParquetException& e) {       \
+    return ::arrow::Status::IOError(e.what());           \
   }
 
-#define PARQUET_CATCH_AND_RETURN(s)                \
-  try {                                            \
-    return (s);                                    \
-  } catch (const ::parquet::ParquetException& e) { \
-    return ::arrow::Status::IOError(e.what());     \
+#define PARQUET_CATCH_AND_RETURN(s)                      \
+  try {                                                  \
+    return (s);                                          \
+  } catch (const ::parquet::ParquetStatusException& e) { \
+    return e.status();                                   \
+  } catch (const ::parquet::ParquetException& e) {       \
+    return ::arrow::Status::IOError(e.what());           \
   }
 
 // Arrow Status to Parquet exception

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1312,7 +1312,8 @@ cdef class ParquetWriter:
                 raise ValueError("Unsupported Parquet format version: {0}"
                                  .format(self.version))
 
-    cdef void _set_compression_props(self, WriterProperties.Builder* props):
+    cdef void _set_compression_props(self, WriterProperties.Builder* props) \
+            except *:
         if isinstance(self.compression, basestring):
             check_compression_name(self.compression)
             props.compression(compression_from_name(self.compression))
@@ -1325,9 +1326,10 @@ cdef class ParquetWriter:
             props.compression_level(self.compression_level)
         elif self.compression_level is not None:
             for column, level in self.compression_level.iteritems():
-                props.compression_level(column, level)
+                props.compression_level(tobytes(column), level)
 
-    cdef void _set_dictionary_props(self, WriterProperties.Builder* props):
+    cdef void _set_dictionary_props(self, WriterProperties.Builder* props) \
+            except *:
         if isinstance(self.use_dictionary, bool):
             if self.use_dictionary:
                 props.enable_dictionary()
@@ -1337,18 +1339,20 @@ cdef class ParquetWriter:
             # Deactivate dictionary encoding by default
             props.disable_dictionary()
             for column in self.use_dictionary:
-                props.enable_dictionary(column)
+                props.enable_dictionary(tobytes(column))
 
     cdef void _set_byte_stream_split_props(
-            self, WriterProperties.Builder* props):
+            self, WriterProperties.Builder* props) except *:
         if isinstance(self.use_byte_stream_split, bool):
             if self.use_byte_stream_split:
                 props.encoding(ParquetEncoding_BYTE_STREAM_SPLIT)
         elif self.use_byte_stream_split is not None:
             for column in self.use_byte_stream_split:
-                props.encoding(column, ParquetEncoding_BYTE_STREAM_SPLIT)
+                props.encoding(tobytes(column),
+                               ParquetEncoding_BYTE_STREAM_SPLIT)
 
-    cdef void _set_statistics_props(self, WriterProperties.Builder* props):
+    cdef void _set_statistics_props(self, WriterProperties.Builder* props) \
+            except *:
         if isinstance(self.write_statistics, bool):
             if self.write_statistics:
                 props.enable_statistics()

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -690,7 +690,7 @@ def test_compression_level():
 
     # Check that the user can provide a compression level per column
     _check_roundtrip(table, expected=table, compression="gzip",
-                     compression_level=[{'a': 2, 'b': 3}])
+                     compression_level={'a': 2, 'b': 3})
 
     # Check that specifying a compression level for a codec which does allow
     # specifying one, results into an error.
@@ -702,7 +702,7 @@ def test_compression_level():
                             ("None", 444), ("lzo", 14)]
     buf = io.BytesIO()
     for (codec, level) in invalid_combinations:
-        with pytest.raises(IOError):
+        with pytest.raises((ValueError, OSError)):
             _write_table(table, buf, compression=codec,
                          compression_level=level)
 
@@ -3241,13 +3241,13 @@ def test_dataset_metadata(tempdir):
 
 def test_parquet_file_too_small(tempdir):
     path = str(tempdir / "test.parquet")
-    with pytest.raises(pa.ArrowIOError,
+    with pytest.raises(pa.ArrowInvalid,
                        match='size is 0 bytes'):
         with open(path, 'wb') as f:
             pass
         pq.read_table(path)
 
-    with pytest.raises(pa.ArrowIOError,
+    with pytest.raises(pa.ArrowInvalid,
                        match='size is 4 bytes'):
         with open(path, 'wb') as f:
             f.write(b'ffff')


### PR DESCRIPTION
Also fix the input handling and error reporting of ParquetWriter properties.