### PR TITLE
ARROW-8059: [Python] Make FileSystem objects serializable

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -299,6 +299,10 @@ SlowFileSystem::SlowFileSystem(std::shared_ptr<FileSystem> base_fs,
                                double average_latency, int32_t seed)
     : base_fs_(base_fs), latencies_(io::LatencyGenerator::Make(average_latency, seed)) {}
 
+bool SlowFileSystem::Equals(const FileSystem& other) const {
+  return this == &other;
+}
+
 Result<FileInfo> SlowFileSystem::GetFileInfo(const std::string& path) {
   latencies_->Sleep();
   return base_fs_->GetFileInfo(path);

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -32,6 +32,7 @@
 #include "arrow/io/slow.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/uri.h"
@@ -158,8 +159,8 @@ bool SubTreeFileSystem::Equals(const FileSystem& other) const {
   if (other.type_name() != type_name()) {
     return false;
   }
-  const auto& subtreefs = static_cast<const SubTreeFileSystem&>(other);
-  return base_path_ == subtreefs.base_path_ && base_fs_->Equals(subtreefs.base_fs_);
+  const auto& subfs = ::arrow::internal::checked_cast<const SubTreeFileSystem&>(other);
+  return base_path_ == subfs.base_path_ && base_fs_->Equals(subfs.base_fs_);
 }
 
 std::string SubTreeFileSystem::PrependBase(const std::string& s) const {

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -151,6 +151,17 @@ Result<std::string> SubTreeFileSystem::NormalizeBasePath(
   return EnsureTrailingSlash(std::move(base_path));
 }
 
+bool SubTreeFileSystem::Equals(const FileSystem& other) const {
+  if (this == &other) {
+    return true;
+  }
+  if (other.type_name() != type_name()) {
+    return false;
+  }
+  const auto& subtreefs = static_cast<const SubTreeFileSystem&>(other);
+  return base_path_ == subtreefs.base_path_ && base_fs_->Equals(subtreefs.base_fs_);
+}
+
 std::string SubTreeFileSystem::PrependBase(const std::string& s) const {
   if (s.empty()) {
     return base_path_;

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -299,9 +299,7 @@ SlowFileSystem::SlowFileSystem(std::shared_ptr<FileSystem> base_fs,
                                double average_latency, int32_t seed)
     : base_fs_(base_fs), latencies_(io::LatencyGenerator::Make(average_latency, seed)) {}
 
-bool SlowFileSystem::Equals(const FileSystem& other) const {
-  return this == &other;
-}
+bool SlowFileSystem::Equals(const FileSystem& other) const { return this == &other; }
 
 Result<FileInfo> SlowFileSystem::GetFileInfo(const std::string& path) {
   latencies_->Sleep();

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -168,6 +168,10 @@ class ARROW_EXPORT FileSystem {
   /// may allow normalizing irregular path forms (such as Windows local paths).
   virtual Result<std::string> NormalizePath(std::string path);
 
+  virtual bool Equals(const FileSystem& other) const { return this == &other; }
+
+  virtual bool Equals(std::shared_ptr<FileSystem> other) const { return Equals(*other); }
+
   /// Get info for the given target.
   ///
   /// Any symlink is automatically dereferenced, recursively.
@@ -262,6 +266,8 @@ class ARROW_EXPORT SubTreeFileSystem : public FileSystem {
   std::shared_ptr<FileSystem> base_fs() const { return base_fs_; }
 
   Result<std::string> NormalizePath(std::string path) override;
+
+  bool Equals(const FileSystem& other) const override;
 
   /// \cond FALSE
   using FileSystem::GetFileInfo;

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -168,7 +168,7 @@ class ARROW_EXPORT FileSystem {
   /// may allow normalizing irregular path forms (such as Windows local paths).
   virtual Result<std::string> NormalizePath(std::string path);
 
-  virtual bool Equals(const FileSystem& other) const { return this == &other; }
+  virtual bool Equals(const FileSystem& other) const = 0;
 
   virtual bool Equals(std::shared_ptr<FileSystem> other) const { return Equals(*other); }
 
@@ -321,6 +321,7 @@ class ARROW_EXPORT SlowFileSystem : public FileSystem {
                  int32_t seed);
 
   std::string type_name() const override { return "slow"; }
+  bool Equals(const FileSystem& other) const override;
 
   using FileSystem::GetFileInfo;
   Result<FileInfo> GetFileInfo(const std::string& path) override;

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -258,6 +258,8 @@ class ARROW_EXPORT SubTreeFileSystem : public FileSystem {
   ~SubTreeFileSystem() override;
 
   std::string type_name() const override { return "subtree"; }
+  std::string base_path() const { return base_path_; }
+  std::shared_ptr<FileSystem> base_fs() const { return base_fs_; }
 
   Result<std::string> NormalizePath(std::string path) override;
 

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -170,7 +170,9 @@ class ARROW_EXPORT FileSystem {
 
   virtual bool Equals(const FileSystem& other) const = 0;
 
-  virtual bool Equals(std::shared_ptr<FileSystem> other) const { return Equals(*other); }
+  virtual bool Equals(const std::shared_ptr<FileSystem>& other) const {
+    return Equals(*other);
+  }
 
   /// Get info for the given target.
   ///

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -24,6 +24,7 @@
 #include "arrow/filesystem/path_util.h"
 #include "arrow/io/hdfs.h"
 #include "arrow/io/hdfs_internal.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/parsing.h"
 #include "arrow/util/windows_fixup.h"
@@ -380,7 +381,8 @@ bool HadoopFileSystem::Equals(const FileSystem& other) const {
   if (other.type_name() != type_name()) {
     return false;
   }
-  return options().Equals(static_cast<const HadoopFileSystem&>(other).options());
+  const auto& hdfs = ::arrow::internal::checked_cast<const HadoopFileSystem&>(other);
+  return options().Equals(hdfs.options());
 }
 
 Result<std::vector<FileInfo>> HadoopFileSystem::GetFileInfo(const FileSelector& select) {

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -308,11 +308,11 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   if (it != options_map.end()) {
     const auto& v = it->second;
     ::arrow::internal::StringConverter<Int16Type> converter;
-    int16_t reps;
-    if (!converter(v.data(), v.size(), &reps)) {
+    int16_t replication;
+    if (!converter(v.data(), v.size(), &replication)) {
       return Status::Invalid("Invalid value for option 'replication': '", v, "'");
     }
-    options.ConfigureHdfsReplication(reps);
+    options.ConfigureHdfsReplication(replication);
   }
 
   // configure buffer_size
@@ -320,11 +320,11 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   if (it != options_map.end()) {
     const auto& v = it->second;
     ::arrow::internal::StringConverter<Int32Type> converter;
-    int32_t reps;
-    if (!converter(v.data(), v.size(), &reps)) {
+    int32_t buffer_size;
+    if (!converter(v.data(), v.size(), &buffer_size)) {
       return Status::Invalid("Invalid value for option 'buffer_size': '", v, "'");
     }
-    options.ConfigureHdfsBufferSize(reps);
+    options.ConfigureHdfsBufferSize(buffer_size);
   }
 
   // configure default_block_size
@@ -332,18 +332,18 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   if (it != options_map.end()) {
     const auto& v = it->second;
     ::arrow::internal::StringConverter<Int64Type> converter;
-    int64_t reps;
-    if (!converter(v.data(), v.size(), &reps)) {
+    int64_t default_block_size;
+    if (!converter(v.data(), v.size(), &default_block_size)) {
       return Status::Invalid("Invalid value for option 'default_block_size': '", v, "'");
     }
-    options.ConfigureHdfsBlockSize(reps);
+    options.ConfigureHdfsBlockSize(default_block_size);
   }
 
   // configure user
   it = options_map.find("user");
   if (it != options_map.end()) {
-    const auto& v = it->second;
-    options.ConfigureHdfsUser(v);
+    const auto& user = it->second;
+    options.ConfigureHdfsUser(user);
   }
 
   return options;

--- a/cpp/src/arrow/filesystem/hdfs.h
+++ b/cpp/src/arrow/filesystem/hdfs.h
@@ -47,6 +47,8 @@ struct ARROW_EXPORT HdfsOptions {
   void ConfigureHdfsBufferSize(int32_t buffer_size);
   void ConfigureHdfsBlockSize(int64_t default_block_size);
 
+  bool Equals(const HdfsOptions& other) const;
+
   static Result<HdfsOptions> FromUri(const ::arrow::internal::Uri& uri);
   static Result<HdfsOptions> FromUri(const std::string& uri);
 };
@@ -60,6 +62,7 @@ class ARROW_EXPORT HadoopFileSystem : public FileSystem {
   ~HadoopFileSystem() override;
 
   std::string type_name() const override { return "hdfs"; }
+  bool Equals(const FileSystem& other) const override;
 
   /// \cond FALSE
   using FileSystem::GetFileInfo;
@@ -96,6 +99,8 @@ class ARROW_EXPORT HadoopFileSystem : public FileSystem {
 
   class Impl;
   std::unique_ptr<Impl> impl_;
+
+  HdfsOptions options_;
 };
 
 }  // namespace fs

--- a/cpp/src/arrow/filesystem/hdfs.h
+++ b/cpp/src/arrow/filesystem/hdfs.h
@@ -62,6 +62,7 @@ class ARROW_EXPORT HadoopFileSystem : public FileSystem {
   ~HadoopFileSystem() override;
 
   std::string type_name() const override { return "hdfs"; }
+  HdfsOptions options() const;
   bool Equals(const FileSystem& other) const override;
 
   /// \cond FALSE
@@ -99,8 +100,6 @@ class ARROW_EXPORT HadoopFileSystem : public FileSystem {
 
   class Impl;
   std::unique_ptr<Impl> impl_;
-
-  HdfsOptions options_;
 };
 
 }  // namespace fs

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -233,6 +233,10 @@ LocalFileSystemOptions LocalFileSystemOptions::Defaults() {
   return LocalFileSystemOptions();
 }
 
+bool LocalFileSystemOptions::Equals(const LocalFileSystemOptions& other) const {
+  return use_mmap == other.use_mmap;
+}
+
 LocalFileSystem::LocalFileSystem() : options_(LocalFileSystemOptions::Defaults()) {}
 
 LocalFileSystem::LocalFileSystem(const LocalFileSystemOptions& options)
@@ -243,6 +247,14 @@ LocalFileSystem::~LocalFileSystem() {}
 Result<std::string> LocalFileSystem::NormalizePath(std::string path) {
   ARROW_ASSIGN_OR_RAISE(auto fn, PlatformFilename::FromString(path));
   return fn.ToString();
+}
+
+bool LocalFileSystem::Equals(const FileSystem& other) const {
+  if (other.type_name() != type_name()) {
+    return false;
+  } else {
+    return options_.Equals(static_cast<const LocalFileSystem&>(other).options_);
+  }
 }
 
 Result<FileInfo> LocalFileSystem::GetFileInfo(const std::string& path) {

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -253,7 +253,8 @@ bool LocalFileSystem::Equals(const FileSystem& other) const {
   if (other.type_name() != type_name()) {
     return false;
   } else {
-    return options_.Equals(static_cast<const LocalFileSystem&>(other).options_);
+    const auto& localfs = ::arrow::internal::checked_cast<const LocalFileSystem&>(other);
+    return options_.Equals(localfs.options());
   }
 }
 

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -34,6 +34,8 @@ struct ARROW_EXPORT LocalFileSystemOptions {
 
   /// \brief Initialize with defaults
   static LocalFileSystemOptions Defaults();
+
+  bool Equals(const LocalFileSystemOptions& other) const;
 };
 
 /// \brief A FileSystem implementation accessing files on the local machine.
@@ -51,6 +53,8 @@ class ARROW_EXPORT LocalFileSystem : public FileSystem {
   std::string type_name() const override { return "local"; }
 
   Result<std::string> NormalizePath(std::string path) override;
+
+  bool Equals(const FileSystem& other) const override;
 
   LocalFileSystemOptions options() const { return options_; }
 

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -52,6 +52,8 @@ class ARROW_EXPORT LocalFileSystem : public FileSystem {
 
   Result<std::string> NormalizePath(std::string path) override;
 
+  LocalFileSystemOptions options() const { return options_; }
+
   /// \cond FALSE
   using FileSystem::GetFileInfo;
   /// \endcond

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -383,6 +383,10 @@ MockFileSystem::MockFileSystem(TimePoint current_time) {
   impl_ = std::unique_ptr<Impl>(new Impl(current_time));
 }
 
+bool MockFileSystem::Equals(const FileSystem& other) const {
+  return this == &other;
+}
+
 Status MockFileSystem::CreateDir(const std::string& path, bool recursive) {
   auto parts = SplitAbstractPath(path);
   RETURN_NOT_OK(ValidateAbstractPathParts(parts));

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -383,9 +383,7 @@ MockFileSystem::MockFileSystem(TimePoint current_time) {
   impl_ = std::unique_ptr<Impl>(new Impl(current_time));
 }
 
-bool MockFileSystem::Equals(const FileSystem& other) const {
-  return this == &other;
-}
+bool MockFileSystem::Equals(const FileSystem& other) const { return this == &other; }
 
 Status MockFileSystem::CreateDir(const std::string& path, bool recursive) {
   auto parts = SplitAbstractPath(path);

--- a/cpp/src/arrow/filesystem/mockfs.h
+++ b/cpp/src/arrow/filesystem/mockfs.h
@@ -63,6 +63,8 @@ class ARROW_EXPORT MockFileSystem : public FileSystem {
 
   std::string type_name() const override { return "mock"; }
 
+  bool Equals(const FileSystem& other) const override;
+
   // XXX It's not very practical to have to explicitly declare inheritance
   // of default overrides.
   using FileSystem::GetFileInfo;

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -254,7 +254,7 @@ bool S3Options::Equals(const S3Options& other) const {
   return (region == other.region && endpoint_override == other.endpoint_override &&
           scheme == other.scheme && background_writes == other.background_writes &&
           GetAccessKey() == other.GetAccessKey() &&
-          GetSecretKey() == other.GetAccessKey());
+          GetSecretKey() == other.GetSecretKey());
 }
 
 namespace {
@@ -853,6 +853,8 @@ class S3FileSystem::Impl {
     return Status::OK();
   }
 
+  S3Options options() const { return options_; }
+
   // Create a bucket.  Successful if bucket already exists.
   Status CreateBucket(const std::string& bucket) {
     S3Model::CreateBucketConfiguration config;
@@ -1214,8 +1216,10 @@ bool S3FileSystem::Equals(const FileSystem& other) const {
   if (other.type_name() != type_name()) {
     return false;
   }
-  return options_.Equals(static_cast<const S3FileSystem&>(other).options_);
+  return options().Equals(static_cast<const S3FileSystem&>(other).options());
 }
+
+S3Options S3FileSystem::options() const { return impl_->options(); }
 
 Result<FileInfo> S3FileSystem::GetFileInfo(const std::string& s) {
   S3Path path;

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -69,6 +69,7 @@
 #include "arrow/io/util_internal.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/windows_fixup.h"
 
@@ -1216,7 +1217,8 @@ bool S3FileSystem::Equals(const FileSystem& other) const {
   if (other.type_name() != type_name()) {
     return false;
   }
-  return options().Equals(static_cast<const S3FileSystem&>(other).options());
+  const auto& s3fs = ::arrow::internal::checked_cast<const S3FileSystem&>(other);
+  return options().Equals(s3fs.options());
 }
 
 S3Options S3FileSystem::options() const { return impl_->options(); }

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -61,6 +61,11 @@ struct ARROW_EXPORT S3Options {
   /// Configure with explicit access and secret key.
   void ConfigureAccessKey(const std::string& access_key, const std::string& secret_key);
 
+  std::string GetAccessKey() const;
+  std::string GetSecretKey() const;
+
+  bool Equals(const S3Options& other) const;
+
   /// \brief Initialize with default credentials provider chain
   ///
   /// This is recommended if you use the standard AWS environment variables
@@ -87,6 +92,8 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
 
   std::string type_name() const override { return "s3"; }
   S3Options options() const { return options_; }
+
+  bool Equals(const FileSystem& other) const override;
 
   /// \cond FALSE
   using FileSystem::GetFileInfo;

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -91,7 +91,7 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   ~S3FileSystem() override;
 
   std::string type_name() const override { return "s3"; }
-  S3Options options() const { return options_; }
+  S3Options options() const;
 
   bool Equals(const FileSystem& other) const override;
 
@@ -146,8 +146,6 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
 
   class Impl;
   std::unique_ptr<Impl> impl_;
-
-  S3Options options_;
 };
 
 enum class S3LogLevel : int8_t { Off, Fatal, Error, Warn, Info, Debug, Trace };

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -86,6 +86,7 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   ~S3FileSystem() override;
 
   std::string type_name() const override { return "s3"; }
+  S3Options options() const { return options_; }
 
   /// \cond FALSE
   using FileSystem::GetFileInfo;
@@ -138,6 +139,8 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
 
   class Impl;
   std::unique_ptr<Impl> impl_;
+
+  S3Options options_;
 };
 
 enum class S3LogLevel : int8_t { Off, Fatal, Error, Warn, Info, Debug, Trace };

--- a/python/pyarrow/_fs.pxd
+++ b/python/pyarrow/_fs.pxd
@@ -57,7 +57,7 @@ cdef class FileSystem:
     cdef init(self, const shared_ptr[CFileSystem]& wrapped)
 
     @staticmethod
-    cdef wrap(shared_ptr[CFileSystem]& sp)
+    cdef wrap(const shared_ptr[CFileSystem]& sp)
 
     cdef inline shared_ptr[CFileSystem] unwrap(self) nogil
 

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -258,7 +258,7 @@ cdef class FileSystem:
         self.fs = wrapped.get()
 
     @staticmethod
-    cdef wrap(shared_ptr[CFileSystem]& sp):
+    cdef wrap(const shared_ptr[CFileSystem]& sp):
         cdef FileSystem self
 
         typ = frombytes(sp.get().type_name())
@@ -564,40 +564,6 @@ cdef class FileSystem:
         )
 
 
-cdef class LocalFileSystemOptions:
-    """
-    Options for LocalFileSystemOptions.
-
-    Parameters
-    ----------
-    use_mmap: bool, default False
-        Whether open_input_stream and open_input_file should return
-        a mmap'ed file or a regular file.
-    """
-    cdef:
-        CLocalFileSystemOptions options
-
-    # Avoid mistakingly creating attributes
-    __slots__ = ()
-
-    def __init__(self, use_mmap=None):
-        self.options = CLocalFileSystemOptions.Defaults()
-        if use_mmap is not None:
-            self.use_mmap = use_mmap
-
-    @property
-    def use_mmap(self):
-        """
-        Whether open_input_stream and open_input_file should return
-        a mmap'ed file or a regular file.
-        """
-        return self.options.use_mmap
-
-    @use_mmap.setter
-    def use_mmap(self, value):
-        self.options.use_mmap = value
-
-
 cdef class LocalFileSystem(FileSystem):
     """
     A FileSystem implementation accessing files on the local machine.
@@ -607,26 +573,29 @@ cdef class LocalFileSystem(FileSystem):
 
     Parameters
     ----------
-    options: LocalFileSystemOptions, default None
-    kwargs: individual named options, for convenience
-
+    use_mmap: bool, default False
+        Whether open_input_stream and open_input_file should return
+        a mmap'ed file or a regular file.
     """
 
-    def __init__(self, LocalFileSystemOptions options=None, **kwargs):
+    def __init__(self, use_mmap=False):
         cdef:
-            CLocalFileSystemOptions c_options
-            shared_ptr[CLocalFileSystem] c_fs
+            CLocalFileSystemOptions opts
+            shared_ptr[CLocalFileSystem] fs
 
-        options = options or LocalFileSystemOptions()
-        for k, v in kwargs.items():
-            setattr(options, k, v)
-        c_options = options.options
-        c_fs = make_shared[CLocalFileSystem](c_options)
-        self.init(<shared_ptr[CFileSystem]> c_fs)
+        opts = CLocalFileSystemOptions.Defaults()
+        opts.use_mmap = use_mmap
+
+        fs = make_shared[CLocalFileSystem](opts)
+        self.init(<shared_ptr[CFileSystem]> fs)
 
     cdef init(self, const shared_ptr[CFileSystem]& c_fs):
         FileSystem.init(self, c_fs)
         self.localfs = <CLocalFileSystem*> c_fs.get()
+
+    def __reduce__(self):
+        cdef CLocalFileSystemOptions opts = self.localfs.options()
+        return LocalFileSystem, (opts.use_mmap,)
 
 
 cdef class SubTreeFileSystem(FileSystem):
@@ -662,6 +631,11 @@ cdef class SubTreeFileSystem(FileSystem):
         FileSystem.init(self, wrapped)
         self.subtreefs = <CSubTreeFileSystem*> wrapped.get()
 
+    def __reduce__(self):
+        return SubTreeFileSystem, (
+            frombytes(self.subtreefs.base_path()),
+            FileSystem.wrap(self.subtreefs.base_fs())
+        )
 
 cdef class _MockFileSystem(FileSystem):
 
@@ -678,3 +652,6 @@ cdef class _MockFileSystem(FileSystem):
     cdef init(self, const shared_ptr[CFileSystem]& wrapped):
         FileSystem.init(self, wrapped)
         self.mockfs = <CMockFileSystem*> wrapped.get()
+
+    def __reduce__(self):
+        return _MockFileSystem, tuple()

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -283,6 +283,15 @@ cdef class FileSystem:
     cdef inline shared_ptr[CFileSystem] unwrap(self) nogil:
         return self.wrapped
 
+    def equals(self, FileSystem other):
+        return self.fs.Equals(other.unwrap())
+
+    def __eq__(self, other):
+        try:
+            return self.equals(other)
+        except TypeError:
+            return NotImplemented
+
     def get_file_info(self, paths_or_selector):
         """
         Get info for the given files.

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -661,6 +661,3 @@ cdef class _MockFileSystem(FileSystem):
     cdef init(self, const shared_ptr[CFileSystem]& wrapped):
         FileSystem.init(self, wrapped)
         self.mockfs = <CMockFileSystem*> wrapped.get()
-
-    def __reduce__(self):
-        return _MockFileSystem, tuple()

--- a/python/pyarrow/_hdfs.pyx
+++ b/python/pyarrow/_hdfs.pyx
@@ -50,12 +50,12 @@ cdef class HadoopFileSystem(FileSystem):
 
     def __init__(self, str host, int port=8020, str user=None,
                  int replication=3, int buffer_size=0,
-                 int default_block_size=0):
+                 int default_block_size=None):
         cdef:
             CHdfsOptions options
             shared_ptr[CHadoopFileSystem] wrapped
 
-        if not host.startswith('hdfs://'):
+        if not host.startswith(('hdfs://', 'viewfs://')):
             # TODO(kszucs): do more sanitization
             host = 'hdfs://{}'.format(host)
 

--- a/python/pyarrow/_hdfs.pyx
+++ b/python/pyarrow/_hdfs.pyx
@@ -50,7 +50,7 @@ cdef class HadoopFileSystem(FileSystem):
 
     def __init__(self, str host, int port=8020, str user=None,
                  int replication=3, int buffer_size=0,
-                 int default_block_size=None):
+                 default_block_size=None):
         cdef:
             CHdfsOptions options
             shared_ptr[CHadoopFileSystem] wrapped

--- a/python/pyarrow/_hdfs.pyx
+++ b/python/pyarrow/_hdfs.pyx
@@ -25,137 +25,101 @@ from pyarrow.includes.libarrow_fs cimport *
 from pyarrow._fs cimport FileSystem
 
 
-cdef class HdfsOptions:
-    """Options for HadoopFileSystem.
+cdef class HadoopFileSystem(FileSystem):
+    """
+    HDFS backed FileSystem implementation
 
     Parameters
     ----------
-    endpoint : tuple of (host, port) pair
-        For example ('localhost', 8020).
+    host : str
+        HDFS host to connect to.
+    port : int, default 8020
+        HDFS port to connect to.
     replication : int, default 3
         Number of copies each block will have.
     buffer_size : int, default 0
         If 0, no buffering will happen otherwise the size of the temporary read
         and write buffer.
-    default_block_size : int, default None
-        None means the default configuration for HDFS, a typical block size is
+    default_block_size : int, default 0
+        0 means the default configuration for HDFS, a typical block size is
         128 MB.
-    """
-    cdef:
-        CHdfsOptions options
-
-    # Avoid mistakingly creating attributes
-    __slots__ = ()
-
-    def __init__(self, endpoint=None, replication=None,
-                 user=None, buffer_size=None, default_block_size=None):
-        if endpoint is not None:
-            self.endpoint = endpoint
-        if replication is not None:
-            self.replication = replication
-        if user is not None:
-            self.user = user
-        if buffer_size is not None:
-            self.buffer_size = buffer_size
-        if default_block_size is not None:
-            self.default_block_size = default_block_size
-
-    @staticmethod
-    cdef wrap(CHdfsOptions wrapped):
-        cdef HdfsOptions self = HdfsOptions.__new__(HdfsOptions)
-        self.options = wrapped
-        return self
-
-    cdef inline CHdfsOptions unwrap(self) nogil:
-        return self.options
-
-    @staticmethod
-    def from_uri(uri):
-        cdef CResult[CHdfsOptions] result
-        result = CHdfsOptions.FromUriString(tobytes(uri))
-        return HdfsOptions.wrap(GetResultValue(result))
-
-    @property
-    def endpoint(self):
-        return (
-            frombytes(self.options.connection_config.host),
-            self.options.connection_config.port
-        )
-
-    @endpoint.setter
-    def endpoint(self, value):
-        if not isinstance(value, tuple) or len(value) != 2:
-            raise TypeError('Endpoint must be a tuple of host port pair')
-        self.options.connection_config.host = tobytes(value[0])
-        self.options.connection_config.port = int(value[1])
-
-    @property
-    def user(self):
-        return frombytes(self.options.connection_config.user)
-
-    @user.setter
-    def user(self, value):
-        self.options.connection_config.user = tobytes(value)
-
-    @property
-    def replication(self):
-        return self.options.replication
-
-    @replication.setter
-    def replication(self, int value):
-        self.options.replication = value
-
-    @property
-    def buffer_size(self):
-        return self.options.buffer_size
-
-    @buffer_size.setter
-    def buffer_size(self, int value):
-        self.options.buffer_size = value
-
-    @property
-    def default_block_size(self):
-        return self.options.default_block_size
-
-    @default_block_size.setter
-    def default_block_size(self, int value):
-        self.options.default_block_size = value
-
-
-cdef class HadoopFileSystem(FileSystem):
-    """HDFS backed FileSystem implementation
-
-    Parameters
-    ----------
-    options_or_uri: HdfsOptions or str, default None
-        Either an options object or a string URI describing the connection to
-        HDFS. HdfsOptions(endpoint=('localhost', 8020), user='test') and
-        'hdfs://localhost:8020/?user=test' are equivalent.
-        In order to change the used driver, replication, buffer_size or
-        default_block_size use the HdfsOptions object.
     """
 
     cdef:
         CHadoopFileSystem* hdfs
 
-    def __init__(self, options_or_uri=None):
+    def __init__(self, str host, int port=8020, str user=None,
+                 int replication=3, int buffer_size=0,
+                 int default_block_size=0):
         cdef:
-            HdfsOptions options
+            CHdfsOptions options
             shared_ptr[CHadoopFileSystem] wrapped
 
-        if isinstance(options_or_uri, str):
-            options = HdfsOptions.from_uri(options_or_uri)
-        elif isinstance(options_or_uri, HdfsOptions):
-            options = options_or_uri
-        elif options_or_uri is None:
-            options = HdfsOptions()
-        else:
-            raise TypeError('Must pass either a string or HdfsOptions')
+        if not host.startswith('hdfs://'):
+            # TODO(kszucs): do more sanitization
+            host = 'hdfs://{}'.format(host)
+        options.ConfigureEndPoint(tobytes(host), int(port))
+
+        if user is not None:
+            options.connection_config.user = tobytes(user)
+
+        options.replication = replication
+        options.buffer_size = buffer_size
+        options.default_block_size = default_block_size
 
         with nogil:
-            wrapped = GetResultValue(CHadoopFileSystem.Make(options.unwrap()))
+            wrapped = GetResultValue(CHadoopFileSystem.Make(options))
         self.init(<shared_ptr[CFileSystem]> wrapped)
 
     cdef init(self, const shared_ptr[CFileSystem]& wrapped):
         FileSystem.init(self, wrapped)
         self.hdfs = <CHadoopFileSystem*> wrapped.get()
+
+    @staticmethod
+    def from_uri(uri):
+        """
+        Instantiate HadoopFileSystem object from an URI string.
+
+        The following two calls are equivalent:
+
+        HadoopFileSystem.from_uri(
+            'hdfs://localhost:8020/?user=test&replication=1'
+        )
+
+        HadoopFileSystem('localhost', port=8020, user='test', replication=1)
+
+        Parameters
+        ----------
+        uri : str
+            A string URI describing the connection to HDFS.
+            In order to change the user, replication, buffer_size or
+            default_block_size pass the values as query parts.
+
+        Returns
+        -------
+        HadoopFileSystem
+        """
+        cdef:
+            HadoopFileSystem self = HadoopFileSystem.__new__(HadoopFileSystem)
+            shared_ptr[CHadoopFileSystem] wrapped
+            CHdfsOptions options
+
+        options = GetResultValue(CHdfsOptions.FromUriString(tobytes(uri)))
+        with nogil:
+            wrapped = GetResultValue(CHadoopFileSystem.Make(options))
+
+        self.init(<shared_ptr[CFileSystem]> wrapped)
+        return self
+
+    def __reduce__(self):
+        cdef CHdfsOptions opts = self.hdfs.options()
+        return (
+            HadoopFileSystem, (
+                frombytes(opts.connection_config.host),
+                opts.connection_config.port,
+                frombytes(opts.connection_config.user),
+                opts.replication,
+                opts.buffer_size,
+                opts.default_block_size,
+            )
+        )

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -126,8 +126,8 @@ cdef class S3FileSystem(FileSystem):
         cdef CS3Options opts = self.s3fs.options()
         return (
             S3FileSystem, (
-                None,  # frombytes(opts.GetAccessKey()),
-                None,  # frombytes(opts.GetSecretKey()),
+                frombytes(opts.GetAccessKey()),
+                frombytes(opts.GetSecretKey()),
                 frombytes(opts.region),
                 frombytes(opts.scheme),
                 frombytes(opts.endpoint_override),

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -126,8 +126,8 @@ cdef class S3FileSystem(FileSystem):
         cdef CS3Options opts = self.s3fs.options()
         return (
             S3FileSystem, (
-                None,  # frombytes(opts.access_key),
-                None,  # frombytes(opts.secret_key),
+                None,  # frombytes(opts.GetAccessKey()),
+                None,  # frombytes(opts.GetSecretKey()),
                 frombytes(opts.region),
                 frombytes(opts.scheme),
                 frombytes(opts.endpoint_override),

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -45,12 +45,15 @@ def finalize_s3():
     check_status(CFinalizeS3())
 
 
-cdef class S3Options:
-    """Options for S3FileSystem.
+cdef class S3FileSystem(FileSystem):
+    """S3-backed FileSystem implementation
 
     If neither access_key nor secret_key are provided then attempts to
     initialize from AWS environment variables, otherwise both access_key and
     secret_key must be provided.
+
+    Note: S3 buckets are special and the operations available on them may be
+    limited or more expensive than desired.
 
     Parameters
     ----------
@@ -70,14 +73,17 @@ cdef class S3Options:
         Whether OutputStream writes will be issued in the background, without
         blocking.
     """
-    cdef:
-        CS3Options options
 
-    # Avoid mistakingly creating attributes
-    __slots__ = ()
+    cdef:
+        CS3FileSystem* s3fs
 
     def __init__(self, access_key=None, secret_key=None, region=None,
-                 scheme=None, endpoint_override=None, background_writes=None):
+                 scheme=None, endpoint_override=None,
+                 bint background_writes=True):
+        cdef:
+            CS3Options options
+            shared_ptr[CS3FileSystem] wrapped
+
         if access_key is not None and secret_key is None:
             raise ValueError(
                 'In order to initialize with explicit credentials both '
@@ -91,85 +97,40 @@ cdef class S3Options:
                 '`access_key` is not set.'
             )
         elif access_key is not None or secret_key is not None:
-            self.options = CS3Options.FromAccessKey(
+            options = CS3Options.FromAccessKey(
                 tobytes(access_key),
                 tobytes(secret_key)
             )
         else:
-            self.options = CS3Options.Defaults()
+            options = CS3Options.Defaults()
 
         if region is not None:
-            self.region = region
+            options.region = tobytes(region)
         if scheme is not None:
-            self.scheme = scheme
+            options.scheme = tobytes(scheme)
         if endpoint_override is not None:
-            self.endpoint_override = endpoint_override
+            options.endpoint_override = tobytes(endpoint_override)
         if background_writes is not None:
-            self.background_writes = background_writes
+            options.background_writes = background_writes
 
-    cdef inline CS3Options unwrap(self) nogil:
-        return self.options
-
-    @property
-    def region(self):
-        """AWS region to connect to."""
-        return frombytes(self.options.region)
-
-    @region.setter
-    def region(self, value):
-        self.options.region = tobytes(value)
-
-    @property
-    def scheme(self):
-        """S3 connection transport scheme."""
-        return frombytes(self.options.scheme)
-
-    @scheme.setter
-    def scheme(self, value):
-        self.options.scheme = tobytes(value)
-
-    @property
-    def endpoint_override(self):
-        """Override region with a connect string such as localhost:9000"""
-        return frombytes(self.options.endpoint_override)
-
-    @endpoint_override.setter
-    def endpoint_override(self, value):
-        self.options.endpoint_override = tobytes(value)
-
-    @property
-    def background_writes(self):
-        """OutputStream writes will be issued in the background"""
-        return self.options.background_writes
-
-    @background_writes.setter
-    def background_writes(self, bint value):
-        self.options.background_writes = value
-
-
-cdef class S3FileSystem(FileSystem):
-    """S3-backed FileSystem implementation
-
-    Note: S3 buckets are special and the operations available on them may be
-    limited or more expensive than desired.
-
-    Parameters
-    ----------
-    options: S3Options, default None
-        Options for connecting to S3. If None is passed then attempts to
-        initialize the connection from AWS environment variables.
-    """
-
-    cdef:
-        CS3FileSystem* s3fs
-
-    def __init__(self, S3Options options=None):
-        cdef shared_ptr[CS3FileSystem] wrapped
-        options = options or S3Options()
         with nogil:
-            wrapped = GetResultValue(CS3FileSystem.Make(options.unwrap()))
+            wrapped = GetResultValue(CS3FileSystem.Make(options))
+
         self.init(<shared_ptr[CFileSystem]> wrapped)
 
     cdef init(self, const shared_ptr[CFileSystem]& wrapped):
         FileSystem.init(self, wrapped)
         self.s3fs = <CS3FileSystem*> wrapped.get()
+
+    def __reduce__(self):
+        cdef CS3Options opts = self.s3fs.options()
+        return (
+            S3FileSystem, (
+                None,  # frombytes(opts.access_key),
+                None,  # frombytes(opts.secret_key),
+                frombytes(opts.region),
+                frombytes(opts.scheme),
+                frombytes(opts.endpoint_override),
+                opts.background_writes
+            )
+        )

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -25,7 +25,6 @@ from pyarrow._fs import (  # noqa
     FileInfo,
     FileSystem,
     LocalFileSystem,
-    LocalFileSystemOptions,
     SubTreeFileSystem,
     _MockFileSystem,
     _normalize_path

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -39,12 +39,7 @@ except ImportError:
     pass
 
 try:
-    from pyarrow._s3fs import (  # noqa
-        initialize_s3,
-        finalize_s3,
-        S3Options,
-        S3FileSystem
-    )
+    from pyarrow._s3fs import initialize_s3, finalize_s3, S3FileSystem  # noqa
 except ImportError:
     pass
 else:

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -34,12 +34,12 @@ from pyarrow._fs import (  # noqa
 FileStats = FileInfo
 
 try:
-    from pyarrow._hdfs import HdfsOptions, HadoopFileSystem  # noqa
+    from pyarrow._hdfs import HadoopFileSystem  # noqa
 except ImportError:
     pass
 
 try:
-    from pyarrow._s3fs import initialize_s3, finalize_s3, S3FileSystem  # noqa
+    from pyarrow._s3fs import S3FileSystem, initialize_s3, finalize_s3  # noqa
 except ImportError:
     pass
 else:

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -134,6 +134,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
     cdef cppclass CS3FileSystem "arrow::fs::S3FileSystem"(CFileSystem):
         @staticmethod
         CResult[shared_ptr[CS3FileSystem]] Make(const CS3Options& options)
+        CS3Options options()
 
     cdef CStatus CInitializeS3 "arrow::fs::InitializeS3"(
         const CS3GlobalOptions& options)

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -166,6 +166,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         @staticmethod
         CResult[shared_ptr[CHadoopFileSystem]] Make(
             const CHdfsOptions& options)
+        CHdfsOptions options()
 
     cdef cppclass CMockFileSystem "arrow::fs::internal::MockFileSystem"(
             CFileSystem):

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -95,11 +95,14 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
     cdef cppclass CLocalFileSystem "arrow::fs::LocalFileSystem"(CFileSystem):
         CLocalFileSystem()
         CLocalFileSystem(CLocalFileSystemOptions)
+        CLocalFileSystemOptions options()
 
     cdef cppclass CSubTreeFileSystem \
             "arrow::fs::SubTreeFileSystem"(CFileSystem):
         CSubTreeFileSystem(const c_string& base_path,
                            shared_ptr[CFileSystem] base_fs)
+        c_string base_path()
+        shared_ptr[CFileSystem] base_fs()
 
     ctypedef enum CS3LogLevel "arrow::fs::S3LogLevel":
         CS3LogLevel_Off "arrow::fs::S3LogLevel::Off"

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -79,6 +79,8 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
             const c_string& path)
         CResult[shared_ptr[COutputStream]] OpenAppendStream(
             const c_string& path)
+        c_bool Equals(const CFileSystem& other)
+        c_bool Equals(shared_ptr[CFileSystem] other)
 
     CResult[shared_ptr[CFileSystem]] CFileSystemFromUri \
         "arrow::fs::FileSystemFromUri"(const c_string& uri, c_string* out_path)
@@ -91,6 +93,8 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
 
         @staticmethod
         CLocalFileSystemOptions Defaults()
+
+        c_bool Equals(const CLocalFileSystemOptions& other)
 
     cdef cppclass CLocalFileSystem "arrow::fs::LocalFileSystem"(CFileSystem):
         CLocalFileSystem()
@@ -124,6 +128,9 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         void ConfigureDefaultCredentials()
         void ConfigureAccessKey(const c_string& access_key,
                                 const c_string& secret_key)
+        c_string GetAccessKey()
+        c_string GetSecretKey()
+        c_bool Equals(const CS3Options& other)
 
         @staticmethod
         CS3Options Defaults()

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -229,7 +229,7 @@ def datadir():
 
 @pytest.mark.hdfs
 @pytest.fixture(scope='session')
-def hdfs_server():
+def hdfs_connection():
     host = os.environ.get('ARROW_HDFS_TEST_HOST', 'default')
     port = int(os.environ.get('ARROW_HDFS_TEST_PORT', 0))
     user = os.environ.get('ARROW_HDFS_TEST_USER', 'hdfs')
@@ -238,9 +238,15 @@ def hdfs_server():
 
 @pytest.mark.s3
 @pytest.fixture(scope='session')
-def minio_server():
+def s3_connection():
     host, port = 'localhost', find_free_port()
     access_key, secret_key = 'arrow', 'apachearrow'
+    return host, port, access_key, secret_key
+
+
+@pytest.fixture(scope='session')
+def s3_server(s3_connection):
+    host, port, access_key, secret_key = s3_connection
 
     address = '{}:{}'.format(host, port)
     env = os.environ.copy()
@@ -258,7 +264,7 @@ def minio_server():
         except OSError:
             pytest.skip('`minio` command cannot be located')
         else:
-            yield address, access_key, secret_key
+            yield proc
         finally:
             if proc is not None:
                 proc.kill()

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -18,7 +18,6 @@
 import contextlib
 import operator
 import os
-import urllib
 
 import numpy as np
 import pytest
@@ -769,14 +768,16 @@ def test_open_dataset_from_source_additional_kwargs(multisourcefs):
 
 @pytest.mark.parquet
 @pytest.mark.s3
-def test_open_dataset_from_uri_s3(minio_server):
+def test_open_dataset_from_uri_s3(s3_connection, s3_server):
     # open dataset from non-localfs string path
     from pyarrow.fs import FileSystem
     import pyarrow.parquet as pq
 
-    address, access_key, secret_key = minio_server
-    uri = "s3://{}:{}@mybucket/data.parquet?scheme=http&endpoint_override={}" \
-        .format(access_key, secret_key, urllib.parse.quote(address))
+    host, port, access_key, secret_key = s3_connection
+    uri = (
+        "s3://{}:{}@mybucket/data.parquet?scheme=http&endpoint_override={}:{}"
+        .format(access_key, secret_key, host, port)
+    )
 
     fs, path = FileSystem.from_uri(uri)
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -196,11 +196,37 @@ def test_cannot_instantiate_base_filesystem():
         FileSystem()
 
 
+def test_filesystem_equals():
+    fs0 = LocalFileSystem()
+    fs1 = LocalFileSystem()
+    fs2 = _MockFileSystem()
+
+    assert fs0.equals(fs0)
+    assert fs0.equals(fs1)
+    with pytest.raises(TypeError):
+        fs0.equals('string')
+    assert fs0 == fs0 == fs1
+    assert fs0 != 4
+
+    assert fs2 == fs2
+    assert fs2 != _MockFileSystem()
+
+    assert SubTreeFileSystem('/base', fs0) == SubTreeFileSystem('/base', fs0)
+    assert SubTreeFileSystem('/base', fs0) != SubTreeFileSystem('/base', fs2)
+    assert SubTreeFileSystem('/base', fs0) != SubTreeFileSystem('/other', fs0)
+
+
 def test_filesystem_pickling(fs):
     restored = pickle.loads(pickle.dumps(fs))
     assert isinstance(restored, FileSystem)
-    # TODO(kszucs): implement Equals
-    # assert restored == fs
+    # assert restored.equals(fs)
+
+
+# TODO(kszucs): test that the filesystem objects are functional after pickling
+#               especially S3 and HDFS
+# TODO(kszucs): convert hdfs options to kwargs
+# TODO(kszucs): create a fixture which returns the defined objects without
+#               any service integration, e.g. s3 without minio running
 
 
 def test_non_path_like_input_raises(fs):

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -18,6 +18,7 @@
 from datetime import datetime
 import gzip
 import pathlib
+import pickle
 import urllib.parse
 import sys
 
@@ -26,7 +27,7 @@ import pytest
 import pyarrow as pa
 from pyarrow.tests.test_io import assert_file_not_found
 from pyarrow.fs import (FileType, FileSelector, FileSystem, LocalFileSystem,
-                        LocalFileSystemOptions, SubTreeFileSystem,
+                        SubTreeFileSystem,
                         _MockFileSystem)
 
 
@@ -193,6 +194,13 @@ def allow_append_to_file(request, filesystem_config):
 def test_cannot_instantiate_base_filesystem():
     with pytest.raises(TypeError):
         FileSystem()
+
+
+def test_filesystem_pickling(fs):
+    restored = pickle.loads(pickle.dumps(fs))
+    assert isinstance(restored, FileSystem)
+    # TODO(kszucs): implement Equals
+    # assert restored == fs
 
 
 def test_non_path_like_input_raises(fs):
@@ -473,22 +481,10 @@ def test_open_append_stream(fs, pathfn, compression, buffer_size, compressor,
 
 
 def test_localfs_options():
-    options = LocalFileSystemOptions()
-    assert options.use_mmap is False
-    options.use_mmap = True
-    assert options.use_mmap is True
-
-    with pytest.raises(AttributeError):
-        options.xxx = True
-
-    options = LocalFileSystemOptions(use_mmap=True)
-    assert options.use_mmap is True
-
     # LocalFileSystem instantiation
-    LocalFileSystem(LocalFileSystemOptions(use_mmap=True))
     LocalFileSystem(use_mmap=False)
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(TypeError):
         LocalFileSystem(xxx=False)
 
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -227,18 +227,17 @@ def test_filesystem_is_functional_after_pickling(fs, pathfn):
     if isinstance(fs, _MockFileSystem):
         pytest.xfail(reason='MockFileSystem is not serializable')
 
-    restored = pickle.loads(pickle.dumps(fs))
-
     aaa = pathfn('a/aa/aaa/')
     bb = pathfn('a/bb')
     c = pathfn('c.txt')
 
-    restored.create_dir(aaa)
-    with restored.open_output_stream(bb):
+    fs.create_dir(aaa)
+    with fs.open_output_stream(bb):
         pass  # touch
-    with restored.open_output_stream(c) as fp:
+    with fs.open_output_stream(c) as fp:
         fp.write(b'test')
 
+    restored = pickle.loads(pickle.dumps(fs))
     aaa_info, bb_info, c_info = restored.get_file_info([aaa, bb, c])
     assert aaa_info.type == FileType.Directory
     assert bb_info.type == FileType.File

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -1878,14 +1878,14 @@ def test_filters_read_table(tempdir):
 
 
 @pytest.fixture
-def s3_bucket(request, minio_server):
+def s3_bucket(request, s3_connection, s3_server):
     boto3 = pytest.importorskip('boto3')
     botocore = pytest.importorskip('botocore')
 
-    address, access_key, secret_key = minio_server
+    host, port, access_key, secret_key = s3_connection
     s3 = boto3.resource(
         's3',
-        endpoint_url='http://{}'.format(address),
+        endpoint_url='http://{}:{}'.format(host, port),
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
         config=botocore.client.Config(signature_version='s3v4'),
@@ -1897,15 +1897,15 @@ def s3_bucket(request, minio_server):
 
 
 @pytest.fixture
-def s3_example(minio_server, s3_bucket):
+def s3_example(s3_connection, s3_server, s3_bucket):
     s3fs = pytest.importorskip('s3fs')
 
-    address, access_key, secret_key = minio_server
+    host, port, access_key, secret_key = s3_connection
     fs = s3fs.S3FileSystem(
         key=access_key,
         secret=secret_key,
         client_kwargs={
-            'endpoint_url': 'http://{}'.format(address)
+            'endpoint_url': 'http://{}:{}'.format(host, port)
         }
     )
 


### PR DESCRIPTION
Also:
- implemented Equals on the filesystem objects
- removed the *Options objects in favor of keyword arguments
- support passing more options as query parameters when instantiating hdfs filesystem from an URI
- exposed more properties of S3FS, SubtreeFS and HDFS