### PR TITLE
ARROW-8139: [C++] FileSystem enum causes attributes warning

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -50,7 +50,7 @@ using TimePoint =
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>;
 
 /// \brief FileSystem entry type
-enum class ARROW_EXPORT FileType : int8_t {
+enum class FileType : int8_t {
   /// Entry does not exist
   NonExistent,
   /// Entry exists but its type is unknown


### PR DESCRIPTION
None of our other enums have this `ARROW_EXPORT` attribute