### PR TITLE
ARROW-8140: [Dev] Follow class name change

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1036,7 +1036,7 @@ def generate_null_case(batch_sizes):
 def generate_null_trivial_case(batch_sizes):
     # Generate a case with no buffers
     fields = [
-        NullType(name='f0'),
+        NullField(name='f0'),
     ]
     return _generate_file('null_trivial', fields, batch_sizes)
 


### PR DESCRIPTION
NullType was renamed to NullField by 963ac4f330f8dba27672f091eb4706f24707a876.