### PR TITLE
ARROW-6176: [Python] Basic implementation of __arrow_ext_class__, in pure Python

### DIFF
--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -235,31 +235,31 @@ a built-in :class:`ExtensionArray` object. Nevertheless, one could want to subcl
 type. Arrow allows to do so by adding a special method ``__arrow_ext_class__`` to the
 definition of the extension type.
 
-For instance, if we consider the case of a 3-dimensional vector, stored as a fixed-size
-list, where we wish to be able to extract the data as a Numpy matrix ``(N, 3)`` without
-any copy::
+For instance, let us consider the example from the `Numpy Quickstart <https://docs.scipy.org/doc/numpy-1.13.0/user/quickstart.html>`_ of points in 3D space.
+We can store these as a fixed-size list, where we wish to be able to extract
+the data as a 2-D Numpy array ``(N, 3)`` without any copy::
 
-    class Vector3dArray(pa.ExtensionArray):
-        def to_numpy_matrix(self):
+    class Point3DArray(pa.ExtensionArray):
+        def to_numpy_array(self):
             return arr.storage.flatten().to_numpy().reshape((-1, 3))
 
 
-    class Vector3dType(pa.PyExtensionType):
+    class Point3DType(pa.PyExtensionType):
         def __init__(self):
             pa.PyExtensionType.__init__(self, pa.list_(pa.float32(), 3))
 
         def __reduce__(self):
-            return Vector3dType, ()
+            return Point3DType, ()
 
         def __arrow_ext_class__(self):
-            return Vector3dArray
+            return Point3DArray
 
 Arrays built using this extension type now have the expected custom array class::
 
     >>> storage = pa.array([[1, 2, 3], [4, 5, 6]], pa.list_(pa.float32(), 3))
-    >>> arr = pa.ExtensionArray.from_storage(Vector3dType(), storage)
+    >>> arr = pa.ExtensionArray.from_storage(Point3DType(), storage)
     >>> arr
-    <__main__.Vector3dArray object at 0x7f40dea80670>
+    <__main__.Point3DArray object at 0x7f40dea80670>
     [
         [
             1,
@@ -275,7 +275,7 @@ Arrays built using this extension type now have the expected custom array class:
 
 The additional methods in the extension class are then available to the user::
 
-    >>> arr.to_numpy_matrix()
+    >>> arr.to_numpy_array()
     array([[1., 2., 3.],
        [4., 5., 6.]], dtype=float32)
 

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -230,7 +230,7 @@ Custom extension array class
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, all arrays with an extension type are constructed or deserialized into
-a built-in :class:`ExtensionArray` object. Nevertheless, one could want to sub-class
+a built-in :class:`ExtensionArray` object. Nevertheless, one could want to subclass
 :class:`ExtensionArray` in order to add some custom logic specific to the extension
 type. Arrow allows to do so by adding a special method ``__arrow_ext_class__`` to the
 definition of the extension type.

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -227,7 +227,7 @@ data type from above would look like::
 Also the storage type does not need to be fixed but can be parametrized.
 
 Custom extension array class
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, all arrays with an extension type are constructed or deserialized into
 a built-in :class:`ExtensionArray` object. Nevertheless, one could want to subclass

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2062,7 +2062,6 @@ cdef class ExtensionArray(Array):
 
         ext_array = make_shared[CExtensionArray](typ.sp_type, storage.sp_array)
         cdef Array result = pyarrow_wrap_array(<shared_ptr[CArray]> ext_array)
-
         result.validate()
         return result
 
@@ -2124,10 +2123,7 @@ cdef object get_array_class_from_type(
 
     if data_type.id() == _Type_EXTENSION:
         py_ext_data_type = pyarrow_wrap_data_type(sp_data_type)
-        py_ext_array_class = py_ext_data_type.__arrow_ext_class__()
-        if py_ext_array_class is NotImplementedError:
-            py_ext_array_class = ExtensionArray
-        return py_ext_array_class
+        return py_ext_data_type.__arrow_ext_class__()
     else:
         return _array_classes[data_type.id()]
 

--- a/python/pyarrow/public-api.pxi
+++ b/python/pyarrow/public-api.pxi
@@ -200,12 +200,7 @@ cdef api object pyarrow_wrap_array(const shared_ptr[CArray]& sp_array):
     if sp_array.get() == NULL:
         raise ValueError('Array was NULL')
 
-    cdef CDataType* data_type = sp_array.get().type().get()
-
-    if data_type == NULL:
-        raise ValueError('Array data type was NULL')
-
-    klass = _array_classes[data_type.id()]
+    klass = get_array_class_from_type(sp_array.get().type())
 
     cdef Array arr = klass.__new__(klass)
     arr.init(sp_array)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -224,6 +224,10 @@ def test_ipc_unknown_type():
     assert arr.type == ParamExtType(3)
 
 
+class PeriodArray(pa.ExtensionArray):
+    pass
+
+
 class PeriodType(pa.ExtensionType):
 
     def __init__(self, freq):
@@ -245,6 +249,9 @@ class PeriodType(pa.ExtensionType):
         assert serialized.startswith("freq=")
         freq = serialized.split('=')[1]
         return PeriodType(freq)
+
+    def __arrow_ext_class__(self):
+        return PeriodArray
 
     def __eq__(self, other):
         if isinstance(other, pa.BaseExtensionType):
@@ -284,7 +291,7 @@ def test_generic_ext_type_ipc(registered_period_type):
     batch = ipc_read_batch(buf)
 
     result = batch.column(0)
-    assert isinstance(result, pa.ExtensionArray)
+    assert isinstance(result, PeriodArray)
     assert result.type.extension_name == "pandas.period"
     assert arr.storage.to_pylist() == [1, 2, 3, 4]
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -703,6 +703,11 @@ cdef class ExtensionType(BaseExtensionType):
         """
         return NotImplementedError
 
+    def __arrow_ext_class__(self):
+        """Arrow extension array class.
+        """
+        return NotImplementedError
+
 
 cdef class PyExtensionType(ExtensionType):
     """

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -706,7 +706,7 @@ cdef class ExtensionType(BaseExtensionType):
     def __arrow_ext_class__(self):
         """Arrow extension array class.
         """
-        return NotImplementedError
+        return ExtensionArray
 
 
 cdef class PyExtensionType(ExtensionType):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -704,7 +704,12 @@ cdef class ExtensionType(BaseExtensionType):
         return NotImplementedError
 
     def __arrow_ext_class__(self):
-        """Arrow extension array class.
+        """Return an extension array class to be used for building or
+        deserializing arrays with this extension type.
+
+        This method should return a subclass of the ExtensionArray class. By
+        default, if not specialized in the extension implementation, an
+        extension type array will be a built-in ExtensionArray instance.
         """
         return ExtensionArray
 


### PR DESCRIPTION
This is a very basic implementation of what could be `__arrow_ext_class__`, i.e. allowing extension types in PyArrow to have a custom Extension Array class (useful for adding additional logic). It is an alternative to adding dynamic attributes to `ExtensionArray` (see ARROW-8131),

Of interest @kszucs @jorisvandenbossche 