### PR TITLE
ARROW-8146: [C++] Add per-filesystem facility to sanitize a path

### DIFF
--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -240,6 +240,11 @@ LocalFileSystem::LocalFileSystem(const LocalFileSystemOptions& options)
 
 LocalFileSystem::~LocalFileSystem() {}
 
+Result<std::string> LocalFileSystem::NormalizePath(std::string path) {
+  ARROW_ASSIGN_OR_RAISE(auto fn, PlatformFilename::FromString(path));
+  return fn.ToString();
+}
+
 Result<FileInfo> LocalFileSystem::GetTargetInfo(const std::string& path) {
   ARROW_ASSIGN_OR_RAISE(auto fn, PlatformFilename::FromString(path));
   return StatFile(fn.ToNative());

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -50,6 +50,8 @@ class ARROW_EXPORT LocalFileSystem : public FileSystem {
 
   std::string type_name() const override { return "local"; }
 
+  Result<std::string> NormalizePath(std::string path) override;
+
   /// \cond FALSE
   using FileSystem::GetTargetInfo;
   using FileSystem::GetTargetInfos;

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -172,6 +172,12 @@ void GenericFileSystemTest::TestEmpty(FileSystem* fs) {
   ASSERT_EQ(files.size(), 0);
 }
 
+void GenericFileSystemTest::TestNormalizePath(FileSystem* fs) {
+  // Canonical abstract paths should go through unchanged
+  ASSERT_OK_AND_EQ("AB", fs->NormalizePath("AB"));
+  ASSERT_OK_AND_EQ("AB/CD/efg", fs->NormalizePath("AB/CD/efg"));
+}
+
 void GenericFileSystemTest::TestCreateDir(FileSystem* fs) {
   ASSERT_OK(fs->CreateDir("AB"));
   ASSERT_OK(fs->CreateDir("AB/CD/EF"));  // Recursive
@@ -845,6 +851,7 @@ void GenericFileSystemTest::TestOpenInputFile(FileSystem* fs) {
   void GenericFileSystemTest::FUNC_NAME() { FUNC_NAME(GetEmptyFileSystem().get()); }
 
 GENERIC_FS_TEST_DEFINE(TestEmpty)
+GENERIC_FS_TEST_DEFINE(TestNormalizePath)
 GENERIC_FS_TEST_DEFINE(TestCreateDir)
 GENERIC_FS_TEST_DEFINE(TestDeleteDir)
 GENERIC_FS_TEST_DEFINE(TestDeleteDirContents)

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -99,6 +99,7 @@ class ARROW_EXPORT GenericFileSystemTest {
   virtual ~GenericFileSystemTest();
 
   void TestEmpty();
+  void TestNormalizePath();
   void TestCreateDir();
   void TestDeleteDir();
   void TestDeleteDirContents();
@@ -136,6 +137,7 @@ class ARROW_EXPORT GenericFileSystemTest {
   virtual bool have_flaky_directory_tree_deletion() const { return false; }
 
   void TestEmpty(FileSystem* fs);
+  void TestNormalizePath(FileSystem* fs);
   void TestCreateDir(FileSystem* fs);
   void TestDeleteDir(FileSystem* fs);
   void TestDeleteDirContents(FileSystem* fs);
@@ -159,6 +161,7 @@ class ARROW_EXPORT GenericFileSystemTest {
 
 #define GENERIC_FS_TEST_FUNCTIONS_MACROS(TEST_MACRO, TEST_CLASS)                        \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, Empty)                               \
+  GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, NormalizePath)                       \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, CreateDir)                           \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, DeleteDir)                           \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, DeleteDirContents)                   \


### PR DESCRIPTION
Some filesystem types (e.g. local filesystem on Windows) might allow slightly different semantics for paths on the user side.  This function allows bridging the gap (but it has to be called explicitly).