### PR TITLE
PARQUET-1819: [C++] Fix crashes on invalid input

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -704,6 +704,9 @@ Status GetReader(const SchemaField& field, const std::shared_ptr<ReaderContext>&
 
   auto type_id = field.field->type()->id();
   if (field.children.size() == 0) {
+    if (!field.is_leaf()) {
+      return Status::Invalid("Parquet non-leaf node has no children");
+    }
     std::unique_ptr<FileColumnIterator> input(
         ctx->iterator_factory(field.column_index, ctx->reader));
     out->reset(new LeafReader(ctx, field.field, std::move(input)));

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -94,8 +94,7 @@ using ArrayType = typename ::arrow::TypeTraits<ArrowType>::ArrayType;
 static Status MakeArrowDecimal(const LogicalType& logical_type,
                                std::shared_ptr<DataType>* out) {
   const auto& decimal = checked_cast<const DecimalLogicalType&>(logical_type);
-  *out = ::arrow::decimal(decimal.precision(), decimal.scale());
-  return Status::OK();
+  return ::arrow::Decimal128Type::Make(decimal.precision(), decimal.scale(), out);
 }
 
 static Status MakeArrowInt(const LogicalType& logical_type,

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -559,6 +559,10 @@ class ColumnReaderImplBase {
     const uint8_t* buffer = page.data() + levels_byte_size;
     const int64_t data_size = page.size() - levels_byte_size;
 
+    if (data_size < 0) {
+      throw ParquetException("Page smaller than size of encoded levels");
+    }
+
     Encoding::type encoding = page.encoding();
 
     if (IsDictionaryIndexEncoding(encoding)) {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -214,7 +214,7 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
     for (const auto& encoding : column_metadata_->encodings) {
       encodings_.push_back(LoadEnumSafe(&encoding));
     }
-    for (auto encoding_stats : column_metadata_->encoding_stats) {
+    for (const auto& encoding_stats : column_metadata_->encoding_stats) {
       encoding_stats_.push_back({LoadEnumSafe(&encoding_stats.page_type),
                                  LoadEnumSafe(&encoding_stats.encoding),
                                  encoding_stats.count});
@@ -642,10 +642,19 @@ class FileMetaData::FileMetaDataImpl {
   friend FileMetaDataBuilder;
   uint32_t metadata_len_;
   std::unique_ptr<format::FileMetaData> metadata_;
+  SchemaDescriptor schema_;
+  ApplicationVersion writer_version_;
+  std::shared_ptr<const KeyValueMetadata> key_value_metadata_;
+  std::shared_ptr<InternalFileDecryptor> file_decryptor_;
+
   void InitSchema() {
+    if (metadata_->schema.empty()) {
+      throw ParquetException("Empty file schema (no root)");
+    }
     schema_.Init(schema::Unflatten(&metadata_->schema[0],
                                    static_cast<int>(metadata_->schema.size())));
   }
+
   void InitColumnOrders() {
     // update ColumnOrder
     std::vector<parquet::ColumnOrder> column_orders;
@@ -663,8 +672,6 @@ class FileMetaData::FileMetaDataImpl {
 
     schema_.updateColumnOrders(column_orders);
   }
-  SchemaDescriptor schema_;
-  ApplicationVersion writer_version_;
 
   void InitKeyValueMetadata() {
     std::shared_ptr<KeyValueMetadata> metadata = nullptr;
@@ -676,9 +683,6 @@ class FileMetaData::FileMetaDataImpl {
     }
     key_value_metadata_ = std::move(metadata);
   }
-
-  std::shared_ptr<const KeyValueMetadata> key_value_metadata_;
-  std::shared_ptr<InternalFileDecryptor> file_decryptor_;
 };
 
 std::shared_ptr<FileMetaData> FileMetaData::Make(

--- a/cpp/src/parquet/schema.cc
+++ b/cpp/src/parquet/schema.cc
@@ -549,6 +549,9 @@ std::unique_ptr<Node> Unflatten(const format::SchemaElement* elements, int lengt
 }
 
 std::shared_ptr<SchemaDescriptor> FromParquet(const std::vector<SchemaElement>& schema) {
+  if (schema.empty()) {
+    throw ParquetException("Empty file schema (no root)");
+  }
   std::unique_ptr<Node> root = Unflatten(&schema[0], static_cast<int>(schema.size()));
   std::shared_ptr<SchemaDescriptor> descr = std::make_shared<SchemaDescriptor>();
   descr->Init(std::shared_ptr<GroupNode>(static_cast<GroupNode*>(root.release())));

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -361,6 +361,9 @@ inline void DeserializeThriftUnencryptedMsg(const uint8_t* buf, uint32_t* len,
   shared_ptr<ThriftBuffer> tmem_transport(
       new ThriftBuffer(const_cast<uint8_t*>(buf), *len));
   apache::thrift::protocol::TCompactProtocolFactoryT<ThriftBuffer> tproto_factory;
+  // Protect against CPU and memory bombs
+  tproto_factory.setStringSizeLimit(10 * 1000 * 1000);
+  tproto_factory.setContainerSizeLimit(10 * 1000 * 1000);
   shared_ptr<apache::thrift::protocol::TProtocol> tproto =  //
       tproto_factory.getProtocol(tmem_transport);
   try {


### PR DESCRIPTION
Should fix the following issues found by OSS-Fuzz:
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20667
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20707
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20896
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20897
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20937
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=20989
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21009
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21098
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21101
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21106