### PR TITLE
ARROW-7390: [C++][Dataset] Fix RecordBatchProjector race

### DIFF
--- a/cpp/src/arrow/dataset/projector.cc
+++ b/cpp/src/arrow/dataset/projector.cc
@@ -63,7 +63,7 @@ Status RecordBatchProjector::SetDefaultValue(FieldRef ref,
 
 Result<std::shared_ptr<RecordBatch>> RecordBatchProjector::Project(
     const RecordBatch& batch, MemoryPool* pool) {
-  if (from_ == nullptr || !batch.schema()->Equals(*from_)) {
+  if (from_ == nullptr || !batch.schema()->Equals(*from_, /*check_metadata=*/false)) {
     RETURN_NOT_OK(SetInputSchema(batch.schema(), pool));
   }
 
@@ -103,7 +103,7 @@ Status RecordBatchProjector::SetInputSchema(std::shared_ptr<Schema> from,
       RETURN_NOT_OK(ref.CheckNonMultiple(matches, *from_));
       int matching_index = matches[0][0];
 
-      if (!from_->field(matching_index)->Equals(field)) {
+      if (!from_->field(matching_index)->Equals(field, /*check_metadata=*/false)) {
         return Status::TypeError("fields had matching names but were not equivalent ",
                                  from_->field(matching_index)->ToString(), " vs ",
                                  field->ToString());

--- a/cpp/src/arrow/dataset/scanner_internal.h
+++ b/cpp/src/arrow/dataset/scanner_internal.h
@@ -44,7 +44,13 @@ static inline RecordBatchIterator ProjectRecordBatch(RecordBatchIterator it,
                                                      RecordBatchProjector* projector,
                                                      MemoryPool* pool) {
   return MakeMaybeMapIterator(
-      [=](std::shared_ptr<RecordBatch> in) { return projector->Project(*in, pool); },
+      [=](std::shared_ptr<RecordBatch> in) {
+        // The RecordBatchProjector is shared accross ScanTasks of the same
+        // Fragment. The resize operation of missing columns is not thread safe.
+        // Ensure that each ScanTask gets his own projector.
+        RecordBatchProjector local_projector{*projector};
+        return local_projector.Project(*in, pool);
+      },
       std::move(it));
 }
 


### PR DESCRIPTION
The RecordBatchProjector is shared accross ScanTasks of the same Fragment. The resize operation of missing columns is not thread safe. This change ensure that each ScanTask gets his own projector. The copy should not be costly since it's copying empty vectors and one shared pointer.