### PR TITLE
ARROW-7857: [Python] Revert temporary changes to pandas extension array tests

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3634,14 +3634,11 @@ def test_conversion_extensiontype_to_extensionarray(monkeypatch):
     arr = pa.ExtensionArray.from_storage(MyCustomIntegerType(), storage)
     table = pa.table({'a': arr})
 
-    # TODO TEMP use our monkeypatched method for all pandas versions because
-    #   latest pandas release / master fails to cast extension type to int64
-    #   type (see ARROW-7857)
-    # if LooseVersion(pd.__version__) < "0.26.0.dev":
-    # ensure pandas Int64Dtype has the protocol method (for older pandas)
-    monkeypatch.setattr(
-        pd.Int64Dtype, '__from_arrow__', _Int64Dtype__from_arrow__,
-        raising=False)
+    if LooseVersion(pd.__version__) < "0.26.0.dev":
+        # ensure pandas Int64Dtype has the protocol method (for older pandas)
+        monkeypatch.setattr(
+            pd.Int64Dtype, '__from_arrow__', _Int64Dtype__from_arrow__,
+            raising=False)
 
     # extension type points to Int64Dtype, which knows how to create a
     # pandas ExtensionArray
@@ -3652,11 +3649,9 @@ def test_conversion_extensiontype_to_extensionarray(monkeypatch):
 
     # monkeypatch pandas Int64Dtype to *not* have the protocol method
     # (remove the version added above and the actual version for recent pandas)
-    # TODO TEMP see above
-    # if LooseVersion(pd.__version__) < "0.26.0.dev":
-    monkeypatch.delattr(pd.Int64Dtype, "__from_arrow__")
-    # else:
-    if LooseVersion(pd.__version__) >= "0.26.0.dev":
+    if LooseVersion(pd.__version__) < "0.26.0.dev":
+        monkeypatch.delattr(pd.Int64Dtype, "__from_arrow__")
+    else:
         monkeypatch.delattr(
             pd.core.arrays.integer._IntegerDtype, "__from_arrow__",
             raising=False)


### PR DESCRIPTION
Reverts https://github.com/apache/arrow/pull/6614, now ARROW-7858 (casting extension type based on its storage type) is implemented.