### PR TITLE
ARROW-8165: [Packaging] Make nightly wheels available on a PyPI server

### DIFF
--- a/dev/tasks/conda-recipes/azure.linux.yml
+++ b/dev/tasks/conda-recipes/azure.linux.yml
@@ -55,7 +55,9 @@ jobs:
       CROSSBOW_GITHUB_TOKEN: $(CROSSBOW_GITHUB_TOKEN)
     displayName: Upload packages as a GitHub release
 
+  {% if arrow.branch == 'master' %}
   # Upload to custom anaconda channel
   - script: |
       anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload -l nightly --force build_artifacts/linux-64/*.tar.bz2
     displayName: Upload packages to Anaconda
+  {% endif %}

--- a/dev/tasks/conda-recipes/azure.osx.yml
+++ b/dev/tasks/conda-recipes/azure.osx.yml
@@ -87,6 +87,7 @@ jobs:
       CROSSBOW_GITHUB_TOKEN: $(CROSSBOW_GITHUB_TOKEN)
     displayName: Upload packages as a GitHub release
 
+  {% if arrow.branch == 'master' %}
   # Upload to custom anaconda channel
   - script: |
       source activate base
@@ -94,3 +95,4 @@ jobs:
       anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload -l nightly --force build_artifacts/osx-64/*.tar.bz2
     displayName: Upload packages to Anaconda
     workingDirectory: arrow/dev/tasks/conda-recipes
+  {% endif %}

--- a/dev/tasks/conda-recipes/azure.win.yml
+++ b/dev/tasks/conda-recipes/azure.win.yml
@@ -102,6 +102,7 @@ jobs:
         CROSSBOW_GITHUB_TOKEN: $(CROSSBOW_GITHUB_TOKEN)
       displayName: Upload packages as a GitHub release
 
+    {% if arrow.branch == 'master' %}
     # Upload to custom anaconda channel
     - script: |
         source activate base
@@ -109,3 +110,4 @@ jobs:
         anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload -l nightly --force D:\bld\win-64\*.tar.bz2
       displayName: Upload packages to Anaconda
       workingDirectory: arrow/dev/tasks/conda-recipes
+    {% endif %}

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -601,6 +601,7 @@ class Repo:
 
         command = [
             'curl',
+            '--fail',
             '-H', "Authorization: token {}".format(self.github_token),
             '-H', "Content-Type: {}".format(mime),
             '--data-binary', '@{}'.format(path),

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -56,7 +56,7 @@ after_build:
   # upload to gemfury
   - conda install -y curl
   - for /f %%i in ('dir /b wheels\*.whl') do set WHEEL_PATH=wheels\%%i
-  - curl.exe -f -F "package=@%WHEEL_PATH%" https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/ursa-labs/
+  - curl.exe -v -f -F "package=@%WHEEL_PATH%" "https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/ursa-labs/"
 
 #on_finish:
   #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -53,6 +53,10 @@ build_script:
 after_build:
   # the artifacts must be uploaded from a directory relative to the build root
   - xcopy %ARROW_SRC%\python\dist\* wheels\
+  # upload to gemfury
+  - conda install -y curl
+  - for /f %i in ('dir /b wheels\*.whl') do set PATH=%i
+  - curl.exe -F package=@%PATH% https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/%CROSSBOW_GEMFURY_ORG%/
 
 #on_finish:
   #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -53,10 +53,12 @@ build_script:
 after_build:
   # the artifacts must be uploaded from a directory relative to the build root
   - xcopy %ARROW_SRC%\python\dist\* wheels\
+{% if arrow.branch == 'master' %}
   # upload to gemfury
   - conda install -y curl
   - for /f %%i in ('dir /b wheels\*.whl') do set WHEEL_PATH=wheels\%%i
   - curl.exe -v -f -F "package=@%WHEEL_PATH%" "https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/ursa-labs/"
+{% endif %}
 
 #on_finish:
   #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -55,8 +55,8 @@ after_build:
   - xcopy %ARROW_SRC%\python\dist\* wheels\
   # upload to gemfury
   - conda install -y curl
-  - for /f %i in ('dir /b wheels\*.whl') do set PATH=%i
-  - curl.exe -F package=@%PATH% https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/%CROSSBOW_GEMFURY_ORG%/
+  - for /f %%i in ('dir /b wheels\*.whl') do set PATH=%%i
+  - curl.exe -F "package=@%PATH%" https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/ursa-labs/
 
 #on_finish:
   #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -57,7 +57,7 @@ after_build:
   # upload to gemfury
   - conda install -y curl
   - for /f %%i in ('dir /b wheels\*.whl') do set WHEEL_PATH=wheels\%%i
-  - curl.exe -v -f -F "package=@%WHEEL_PATH%" "https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/ursa-labs/"
+  - curl.exe -f -F "package=@%WHEEL_PATH%" "https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/ursa-labs/"
 {% endif %}
 
 #on_finish:

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -55,8 +55,8 @@ after_build:
   - xcopy %ARROW_SRC%\python\dist\* wheels\
   # upload to gemfury
   - conda install -y curl
-  - for /f %%i in ('dir /b wheels\*.whl') do set PATH=%%i
-  - curl.exe -F "package=@%PATH%" https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/ursa-labs/
+  - for /f %%i in ('dir /b wheels\*.whl') do set WHEEL_PATH=wheels\%%i
+  - curl.exe -f -F "package=@%WHEEL_PATH%" https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/ursa-labs/
 
 #on_finish:
   #- ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/dev/tasks/python-wheels/azure.linux.yml
+++ b/dev/tasks/python-wheels/azure.linux.yml
@@ -22,7 +22,7 @@ jobs:
   steps:
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'click github3.py jinja2 jira pygit2 ruamel.yaml setuptools_scm toolz anaconda-client'
+        packageSpecs: 'click github3.py jinja2 jira pygit2 ruamel.yaml setuptools_scm toolz'
         installOptions: '-c conda-forge'
         updateConda: false
 

--- a/dev/tasks/python-wheels/azure.linux.yml
+++ b/dev/tasks/python-wheels/azure.linux.yml
@@ -91,6 +91,7 @@ jobs:
         CROSSBOW_GITHUB_TOKEN: $(CROSSBOW_GITHUB_TOKEN)
       displayName: Upload packages as a GitHub release
 
+    {% if arrow.branch == 'master' %}
     # upload to gemfury
     - script: |
         path=$(ls arrow/python/{{ wheel_dir }}/dist/*.whl)
@@ -98,3 +99,4 @@ jobs:
       env:
         CROSSBOW_GEMFURY_TOKEN: $(CROSSBOW_GEMFURY_TOKEN)
       displayName: Upload packages to Gemfury
+    {% endif %}

--- a/dev/tasks/python-wheels/azure.linux.yml
+++ b/dev/tasks/python-wheels/azure.linux.yml
@@ -22,7 +22,7 @@ jobs:
   steps:
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'click github3.py jinja2 jira pygit2 ruamel.yaml setuptools_scm toolz'
+        packageSpecs: 'click github3.py jinja2 jira pygit2 ruamel.yaml setuptools_scm toolz anaconda-client'
         installOptions: '-c conda-forge'
         updateConda: false
 
@@ -90,3 +90,12 @@ jobs:
       env:
         CROSSBOW_GITHUB_TOKEN: $(CROSSBOW_GITHUB_TOKEN)
       displayName: Upload packages as a GitHub release
+
+    # upload to gemfury
+    - script: |
+        curl -F package=@$(ls arrow/python/{{ wheel_dir }}/dist/*) \
+            https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/${CROSSBOW_GEMFURY_ORG}/
+      env:
+        CROSSBOW_GEMFURY_ORG: $(CROSSBOW_GEMFURY_ORG)
+        CROSSBOW_GEMFURY_TOKEN: $(CROSSBOW_GEMFURY_TOKEN)
+      displayName: Upload packages to Anaconda

--- a/dev/tasks/python-wheels/azure.linux.yml
+++ b/dev/tasks/python-wheels/azure.linux.yml
@@ -93,9 +93,8 @@ jobs:
 
     # upload to gemfury
     - script: |
-        path=$(ls arrow/python/{{ wheel_dir }}/dist/*)
-        curl -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/ursa-labs/
+        path=$(ls arrow/python/{{ wheel_dir }}/dist/*.whl)
+        curl -f -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/ursa-labs/
       env:
-        CROSSBOW_GEMFURY_ORG: $(CROSSBOW_GEMFURY_ORG)
         CROSSBOW_GEMFURY_TOKEN: $(CROSSBOW_GEMFURY_TOKEN)
       displayName: Upload packages to Gemfury

--- a/dev/tasks/python-wheels/azure.linux.yml
+++ b/dev/tasks/python-wheels/azure.linux.yml
@@ -93,9 +93,9 @@ jobs:
 
     # upload to gemfury
     - script: |
-        curl -F package=@$(ls arrow/python/{{ wheel_dir }}/dist/*) \
-            https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/${CROSSBOW_GEMFURY_ORG}/
+        path=$(ls arrow/python/{{ wheel_dir }}/dist/*)
+        curl -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/ursa-labs/
       env:
         CROSSBOW_GEMFURY_ORG: $(CROSSBOW_GEMFURY_ORG)
         CROSSBOW_GEMFURY_TOKEN: $(CROSSBOW_GEMFURY_TOKEN)
-      displayName: Upload packages to Anaconda
+      displayName: Upload packages to Gemfury

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -89,7 +89,7 @@ install:
 
   # upload to gemfury pypi repository, there should be a single wheel
   - path=$(ls arrow/python/dist/*.whl)
-  - curl -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/ursa-labs/
+  - curl -f -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/ursa-labs/
 
 notifications:
   email:

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -75,10 +75,21 @@ install:
   - sudo mv $(brew --cellar){.bak,}
   # before_install activates a virtualenv but we need the system python3
   - deactivate
+
   # crossbow dependencies for deployment
   - unset MACOSX_DEPLOYMENT_TARGET
   - pip3 install click ruamel.yaml setuptools_scm github3.py toolz requests[security]
-  - python3 arrow/dev/tasks/crossbow.py --queue-path $(pwd) --queue-remote {{ queue.remote_url }} upload-artifacts --sha {{ task.branch }} --tag {{ task.tag }} --pattern "arrow/python/dist/*.whl"
+  - python3 arrow/dev/tasks/crossbow.py
+      --queue-path $(pwd)
+      --queue-remote {{ queue.remote_url }}
+      upload-artifacts
+      --sha {{ task.branch }}
+      --tag {{ task.tag }}
+      --pattern "arrow/python/dist/*.whl"
+
+  # upload to gemfury pypi repository, there should be a single wheel
+  - curl -F package=@$(ls arrow/python/dist/*.whl)
+    https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/${CROSSBOW_GEMFURY_ORG}/
 
 notifications:
   email:

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -87,9 +87,11 @@ install:
       --tag {{ task.tag }}
       --pattern "arrow/python/dist/*.whl"
 
+  {% if arrow.branch == 'master' %}
   # upload to gemfury pypi repository, there should be a single wheel
   - path=$(ls arrow/python/dist/*.whl)
   - curl -f -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/ursa-labs/
+  {% endif %}
 
 notifications:
   email:

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -88,8 +88,8 @@ install:
       --pattern "arrow/python/dist/*.whl"
 
   # upload to gemfury pypi repository, there should be a single wheel
-  - curl -F package=@$(ls arrow/python/dist/*.whl)
-    https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/${CROSSBOW_GEMFURY_ORG}/
+  - path=$(ls arrow/python/dist/*.whl)
+  - curl -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/ursa-labs/
 
 notifications:
   email:


### PR DESCRIPTION
Uploaded wheels are available at https://pypi.fury.io/ursa-labs/

Considered Bintray, but it doesn't provide any facilities for listing the wheels, although Artifactory could be a good solution, but it only has paid plans hosted on-prem at AWS.

Gemfury seems like a good solution, pros:
- it supports multiple repositories which can be relevant for us (nuget, npm, deb, rpm, gem)
- seems to be free and unlimited for public packages
- no client needed, simple curl command is enough to upload the binaries