### PR TITLE
ARROW-8167: [CI] Add support for skipping builds with skip pattern in pull request title

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -30,6 +30,7 @@ on:
 jobs:
 
   archery:
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     name: Archery Unittests
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -39,6 +39,7 @@ jobs:
   conda:
     name: AMD64 Conda C++
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2
@@ -71,6 +72,7 @@ jobs:
   ubuntu-sanitizer:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} C++ ASAN UBSAN
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -106,6 +108,7 @@ jobs:
   macos:
     name: AMD64 MacOS 10.15 C++
     runs-on: macos-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
     env:
@@ -160,6 +163,7 @@ jobs:
   windows:
     name: AMD64 ${{ matrix.name }} C++
     runs-on: ${{ matrix.os }}
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -224,6 +228,7 @@ jobs:
   windows-mingw:
     name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} C++
     runs-on: windows-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cpp_cron.yml
+++ b/.github/workflows/cpp_cron.yml
@@ -37,6 +37,7 @@ jobs:
   debian:
     name: AMD64 Debian ${{ matrix.debian }} C++
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -75,6 +76,7 @@ jobs:
   fedora:
     name: AMD64 Fedora ${{ matrix.fedora }} C++
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -113,6 +115,7 @@ jobs:
   ubuntu:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} C++
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -144,7 +147,7 @@ jobs:
   ubuntu-cmake32:
     name: AMD64 Ubuntu 18.04 C++ CMake 3.2
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -187,6 +190,7 @@ jobs:
   oss-fuzz:
     name: OSS-Fuzz build check
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -34,6 +34,7 @@ jobs:
   ubuntu:
     name: AMD64 Ubuntu 18.04 C# ${{ matrix.dotnet }}
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -60,6 +61,7 @@ jobs:
   windows:
     name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
     runs-on: windows-latest
+    if: !contains(github.event.pull_request.title, 'WIP')
     strategy:
       fail-fast: false
       matrix:
@@ -86,7 +88,7 @@ jobs:
   macos:
     name: AMD64 MacOS 10.15 C# ${{ matrix.dotnet }}
     runs-on: macos-latest
-    if: github.event_name == 'push'
+    if: !contains(github.event.pull_request.title, 'WIP')
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,6 +27,7 @@ jobs:
   lint:
     name: Lint C++, Python, R, Rust, Docker, RAT
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2
@@ -57,6 +58,7 @@ jobs:
   release:
     name: Source Release and Merge Script
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     env:
       GIT_AUTHOR_NAME: Github Actions
       GIT_AUTHOR_EMAIL: github@actions

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,6 +34,7 @@ jobs:
   debian:
     name: AMD64 Debian 10 Go ${{ matrix.go }}
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +67,7 @@ jobs:
   windows:
     name: AMD64 Windows 2019 Go ${{ matrix.go }}
     runs-on: windows-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -92,7 +94,7 @@ jobs:
   macos:
     name: AMD64 MacOS 10.15 Go ${{ matrix.go }}
     runs-on: macos-latest
-    if: github.event_name == 'push'
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,6 +46,7 @@ jobs:
   conda-integration:
     name: AMD64 Conda Integration Test
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     env:
       MAVEN: 3.5
     steps:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -40,6 +40,7 @@ jobs:
   debian:
     name: AMD64 Debian 9 Java JDK ${{ matrix.jdk }} Maven ${{ matrix.maven }}
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -36,6 +36,7 @@ jobs:
   debian:
     name: AMD64 Debian 9 Java JNI and Plasma
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -34,6 +34,7 @@ jobs:
   debian:
     name: AMD64 Debian 10 NodeJS ${{ matrix.node }}
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -36,6 +36,7 @@ jobs:
   ubuntu:
     name: AMD64 Ubuntu 16.04 Python 3.5
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     env:
       UBUNTU: 16.04
     steps:
@@ -111,6 +112,7 @@ jobs:
   conda-pandas:
     name: AMD64 Conda Python ${{ matrix.python }} Pandas ${{ matrix.pandas }}
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -71,6 +71,7 @@ jobs:
   conda-nopandas:
     name: AMD64 Conda Python ${{ matrix.python }} Without Pandas
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -154,6 +155,7 @@ jobs:
   macos:
     name: AMD64 MacOS 10.15 Python 3.7
     runs-on: macos-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     env:
       ARROW_HOME: /usr/local
       ARROW_DATASET: ON

--- a/.github/workflows/python_cron.yml
+++ b/.github/workflows/python_cron.yml
@@ -33,6 +33,7 @@ jobs:
   debian:
     name: AMD64 Debian ${{ matrix.debian }} Python 3
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -111,6 +112,7 @@ jobs:
   fedora:
     name: AMD64 Fedora ${{ matrix.fedora }} Python 3
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -150,6 +152,7 @@ jobs:
   downstream:
     name: AMD64 Conda Python 3.7 ${{ matrix.title }}
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python_cron.yml
+++ b/.github/workflows/python_cron.yml
@@ -73,6 +73,7 @@ jobs:
   ubuntu:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} Python 3
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -43,6 +43,7 @@ jobs:
   ubuntu:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} R ${{ matrix.r }}
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -87,6 +88,7 @@ jobs:
   rstudio:
     name: "rstudio/r-base:${{ matrix.r_version }}-${{ matrix.r_image }}"
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -130,6 +132,7 @@ jobs:
   windows:
     name: AMD64 Windows RTools ${{ matrix.rtools }}
     runs-on: windows-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,6 +38,7 @@ jobs:
   ubuntu:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} GLib & Ruby
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -83,6 +84,7 @@ jobs:
   macos:
     name: AMD64 MacOS 10.15 GLib & Ruby
     runs-on: macos-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
     env:
@@ -134,6 +136,7 @@ jobs:
   windows:
     name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} GLib & Ruby
     runs-on: windows-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,7 @@ jobs:
   debian:
     name: AMD64 Debian 10 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +73,7 @@ jobs:
   windows:
     name: AMD64 Windows 2019 Rust ${{ matrix.rust }}
     runs-on: windows-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -102,6 +104,7 @@ jobs:
   macos:
     name: AMD64 MacOS 10.15 Rust ${{ matrix.rust }}
     runs-on: macos-latest
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:

--- a/ci/scripts/util_checkout.sh
+++ b/ci/scripts/util_checkout.sh
@@ -17,9 +17,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# this script is github actions specific
+# this script is github actions specific to check out the submodules and tags
 
-# checkout the submodules,
 # TODO(kszucs): remove it once the "submodules: recursive" feature is released
 auth_header="$(git config --local --get http.https://github.com/.extraheader)"
 git submodule sync --recursive

--- a/ci/scripts/util_checkout.sh
+++ b/ci/scripts/util_checkout.sh
@@ -19,8 +19,8 @@
 
 # this script is github actions specific
 
-# checkout the submodules, remove it once the "submodules: recursive" feature
-# gets released again
+# checkout the submodules,
+# TODO(kszucs): remove it once the "submodules: recursive" feature is released
 auth_header="$(git config --local --get http.https://github.com/.extraheader)"
 git submodule sync --recursive
 git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1


### PR DESCRIPTION
In certain cases, especially when someone adds a new build configuration it can be handy to disable all but that job.

Sadly the commit message is not available for the pull_request event, so we cannot have conditions on it, but we can use the pull request's title for this purpose.

Hopefully the pull request event payload will contain the head commit in the future.