### PR TITLE
ARROW-8169: [Java] Improve the performance of JDBC adapter by allocating memory proactively

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
@@ -220,6 +220,7 @@ public class JdbcToArrow {
 
     VectorSchemaRoot root = VectorSchemaRoot.create(
         JdbcToArrowUtils.jdbcToArrowSchema(resultSet.getMetaData(), config), config.getAllocator());
+    ArrowVectorIterator.preAllocate(root, config);
     JdbcToArrowUtils.jdbcToArrowVectors(resultSet, root, config);
     return root;
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
@@ -220,7 +220,9 @@ public class JdbcToArrow {
 
     VectorSchemaRoot root = VectorSchemaRoot.create(
         JdbcToArrowUtils.jdbcToArrowSchema(resultSet.getMetaData(), config), config.getAllocator());
-    ArrowVectorIterator.preAllocate(root, config);
+    if (config.getTargetBatchSize() != JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE) {
+      ArrowVectorIterator.preAllocate(root, config);
+    }
     JdbcToArrowUtils.jdbcToArrowVectors(resultSet, root, config);
     return root;
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.adapter.jdbc;
 
+import static org.apache.arrow.adapter.jdbc.JdbcToArrowConfig.DEFAULT_TARGET_BATCH_SIZE;
+
 import java.util.Calendar;
 import java.util.Map;
 
@@ -71,6 +73,7 @@ public class JdbcToArrowConfigBuilder {
     this.allocator = allocator;
     this.calendar = calendar;
     this.includeMetadata = false;
+    this.targetBatchSize = DEFAULT_TARGET_BATCH_SIZE;
   }
 
   /**

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -355,10 +355,19 @@ public class JdbcToArrowUtils {
     try {
       compositeConsumer = new CompositeJdbcConsumer(consumers);
       int readRowCount = 0;
-      while (rs.next()) {
-        compositeConsumer.consume(rs);
-        readRowCount++;
+      if (config.getTargetBatchSize() == JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE) {
+        while (rs.next()) {
+          ArrowVectorIterator.ensureCapacity(root, readRowCount + 1);
+          compositeConsumer.consume(rs);
+          readRowCount++;
+        }
+      } else {
+        while (rs.next() && readRowCount < config.getTargetBatchSize()) {
+          compositeConsumer.consume(rs);
+          readRowCount++;
+        }
       }
+
       root.setRowCount(readRowCount);
     } catch (Exception e) {
       // error occurs and clean up resources.

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -365,6 +365,7 @@ public class JdbcToArrowUtils {
       if (compositeConsumer != null) {
         compositeConsumer.close();
       }
+      throw e;
     }
   }
 

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
@@ -55,6 +55,8 @@ public class BigIntConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       long value = resultSet.getLong(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, value);
       }
       currentIndex++;
@@ -76,6 +78,8 @@ public class BigIntConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       long value = resultSet.getLong(columnIndexInResultSet);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, value);
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BigIntConsumer.java
@@ -55,7 +55,7 @@ public class BigIntConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       long value = resultSet.getLong(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, value);
+        vector.set(currentIndex, value);
       }
       currentIndex++;
     }
@@ -76,7 +76,7 @@ public class BigIntConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       long value = resultSet.getLong(columnIndexInResultSet);
-      vector.setSafe(currentIndex, value);
+      vector.set(currentIndex, value);
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
@@ -55,6 +55,8 @@ public class BitConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       boolean value = resultSet.getBoolean(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, value ? 1 : 0);
       }
       currentIndex++;
@@ -76,6 +78,8 @@ public class BitConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       boolean value = resultSet.getBoolean(columnIndexInResultSet);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, value ? 1 : 0);
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BitConsumer.java
@@ -55,7 +55,7 @@ public class BitConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       boolean value = resultSet.getBoolean(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, value ? 1 : 0);
+        vector.set(currentIndex, value ? 1 : 0);
       }
       currentIndex++;
     }
@@ -76,7 +76,7 @@ public class BitConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       boolean value = resultSet.getBoolean(columnIndexInResultSet);
-      vector.setSafe(currentIndex, value ? 1 : 0);
+      vector.set(currentIndex, value ? 1 : 0);
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
@@ -89,6 +89,8 @@ public class DateConsumer {
         if (day < 0 || day > MAX_DAY) {
           throw new IllegalArgumentException("Day overflow: " + day);
         }
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, day);
       }
       currentIndex++;
@@ -125,6 +127,8 @@ public class DateConsumer {
       if (day < 0 || day > MAX_DAY) {
         throw new IllegalArgumentException("Day overflow: " + day);
       }
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, day);
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DateConsumer.java
@@ -89,7 +89,7 @@ public class DateConsumer {
         if (day < 0 || day > MAX_DAY) {
           throw new IllegalArgumentException("Day overflow: " + day);
         }
-        vector.setSafe(currentIndex, day);
+        vector.set(currentIndex, day);
       }
       currentIndex++;
     }
@@ -125,7 +125,7 @@ public class DateConsumer {
       if (day < 0 || day > MAX_DAY) {
         throw new IllegalArgumentException("Day overflow: " + day);
       }
-      vector.setSafe(currentIndex, day);
+      vector.set(currentIndex, day);
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
@@ -56,6 +56,8 @@ public class DecimalConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       BigDecimal value = resultSet.getBigDecimal(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, value);
       }
       currentIndex++;
@@ -77,6 +79,8 @@ public class DecimalConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       BigDecimal value = resultSet.getBigDecimal(columnIndexInResultSet);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, value);
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DecimalConsumer.java
@@ -56,7 +56,7 @@ public class DecimalConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       BigDecimal value = resultSet.getBigDecimal(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, value);
+        vector.set(currentIndex, value);
       }
       currentIndex++;
     }
@@ -77,7 +77,7 @@ public class DecimalConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       BigDecimal value = resultSet.getBigDecimal(columnIndexInResultSet);
-      vector.setSafe(currentIndex, value);
+      vector.set(currentIndex, value);
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
@@ -55,7 +55,7 @@ public class DoubleConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       double value = resultSet.getDouble(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, value);
+        vector.set(currentIndex, value);
       }
       currentIndex++;
     }
@@ -76,7 +76,7 @@ public class DoubleConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       double value = resultSet.getDouble(columnIndexInResultSet);
-      vector.setSafe(currentIndex, value);
+      vector.set(currentIndex, value);
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/DoubleConsumer.java
@@ -55,6 +55,8 @@ public class DoubleConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       double value = resultSet.getDouble(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, value);
       }
       currentIndex++;
@@ -76,6 +78,8 @@ public class DoubleConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       double value = resultSet.getDouble(columnIndexInResultSet);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, value);
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
@@ -55,7 +55,7 @@ public class FloatConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       float value = resultSet.getFloat(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, value);
+        vector.set(currentIndex, value);
       }
       currentIndex++;
     }
@@ -76,7 +76,7 @@ public class FloatConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       float value = resultSet.getFloat(columnIndexInResultSet);
-      vector.setSafe(currentIndex, value);
+      vector.set(currentIndex, value);
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/FloatConsumer.java
@@ -55,6 +55,8 @@ public class FloatConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       float value = resultSet.getFloat(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, value);
       }
       currentIndex++;
@@ -76,6 +78,8 @@ public class FloatConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       float value = resultSet.getFloat(columnIndexInResultSet);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, value);
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
@@ -55,6 +55,8 @@ public class IntConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       int value = resultSet.getInt(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, value);
       }
       currentIndex++;
@@ -76,6 +78,8 @@ public class IntConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       int value = resultSet.getInt(columnIndexInResultSet);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, value);
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/IntConsumer.java
@@ -55,7 +55,7 @@ public class IntConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       int value = resultSet.getInt(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, value);
+        vector.set(currentIndex, value);
       }
       currentIndex++;
     }
@@ -76,7 +76,7 @@ public class IntConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       int value = resultSet.getInt(columnIndexInResultSet);
-      vector.setSafe(currentIndex, value);
+      vector.set(currentIndex, value);
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
@@ -55,6 +55,8 @@ public class SmallIntConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       short value = resultSet.getShort(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, value);
       }
       currentIndex++;
@@ -76,6 +78,8 @@ public class SmallIntConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       short value = resultSet.getShort(columnIndexInResultSet);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, value);
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/SmallIntConsumer.java
@@ -55,7 +55,7 @@ public class SmallIntConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       short value = resultSet.getShort(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, value);
+        vector.set(currentIndex, value);
       }
       currentIndex++;
     }
@@ -76,7 +76,7 @@ public class SmallIntConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       short value = resultSet.getShort(columnIndexInResultSet);
-      vector.setSafe(currentIndex, value);
+      vector.set(currentIndex, value);
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
@@ -69,7 +69,7 @@ public abstract class TimeConsumer {
       Time time = calendar == null ? resultSet.getTime(columnIndexInResultSet) :
           resultSet.getTime(columnIndexInResultSet, calendar);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, (int) time.getTime());
+        vector.set(currentIndex, (int) time.getTime());
       }
       currentIndex++;
     }
@@ -101,7 +101,7 @@ public abstract class TimeConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       Time time = calendar == null ? resultSet.getTime(columnIndexInResultSet) :
           resultSet.getTime(columnIndexInResultSet, calendar);
-      vector.setSafe(currentIndex, (int) time.getTime());
+      vector.set(currentIndex, (int) time.getTime());
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimeConsumer.java
@@ -69,6 +69,8 @@ public abstract class TimeConsumer {
       Time time = calendar == null ? resultSet.getTime(columnIndexInResultSet) :
           resultSet.getTime(columnIndexInResultSet, calendar);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, (int) time.getTime());
       }
       currentIndex++;
@@ -101,6 +103,8 @@ public abstract class TimeConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       Time time = calendar == null ? resultSet.getTime(columnIndexInResultSet) :
           resultSet.getTime(columnIndexInResultSet, calendar);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, (int) time.getTime());
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
@@ -69,6 +69,8 @@ public abstract class TimestampConsumer {
       Timestamp timestamp = calendar == null ? resultSet.getTimestamp(columnIndexInResultSet) :
           resultSet.getTimestamp(columnIndexInResultSet, calendar);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, timestamp.getTime());
       }
       currentIndex++;
@@ -101,6 +103,8 @@ public abstract class TimestampConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       Timestamp timestamp = calendar == null ? resultSet.getTimestamp(columnIndexInResultSet) :
           resultSet.getTimestamp(columnIndexInResultSet, calendar);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, timestamp.getTime());
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TimestampConsumer.java
@@ -69,7 +69,7 @@ public abstract class TimestampConsumer {
       Timestamp timestamp = calendar == null ? resultSet.getTimestamp(columnIndexInResultSet) :
           resultSet.getTimestamp(columnIndexInResultSet, calendar);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, timestamp.getTime());
+        vector.set(currentIndex, timestamp.getTime());
       }
       currentIndex++;
     }
@@ -101,7 +101,7 @@ public abstract class TimestampConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       Timestamp timestamp = calendar == null ? resultSet.getTimestamp(columnIndexInResultSet) :
           resultSet.getTimestamp(columnIndexInResultSet, calendar);
-      vector.setSafe(currentIndex, timestamp.getTime());
+      vector.set(currentIndex, timestamp.getTime());
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
@@ -55,6 +55,8 @@ public abstract class TinyIntConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       byte value = resultSet.getByte(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
+        // for fixed width vectors, we have allocated enough memory proactively,
+        // so there is no need to call the setSafe method here.
         vector.set(currentIndex, value);
       }
       currentIndex++;
@@ -76,6 +78,8 @@ public abstract class TinyIntConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       byte value = resultSet.getByte(columnIndexInResultSet);
+      // for fixed width vectors, we have allocated enough memory proactively,
+      // so there is no need to call the setSafe method here.
       vector.set(currentIndex, value);
       currentIndex++;
     }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/TinyIntConsumer.java
@@ -55,7 +55,7 @@ public abstract class TinyIntConsumer {
     public void consume(ResultSet resultSet) throws SQLException {
       byte value = resultSet.getByte(columnIndexInResultSet);
       if (!resultSet.wasNull()) {
-        vector.setSafe(currentIndex, value);
+        vector.set(currentIndex, value);
       }
       currentIndex++;
     }
@@ -76,7 +76,7 @@ public abstract class TinyIntConsumer {
     @Override
     public void consume(ResultSet resultSet) throws SQLException {
       byte value = resultSet.getByte(columnIndexInResultSet);
-      vector.setSafe(currentIndex, value);
+      vector.set(currentIndex, value);
       currentIndex++;
     }
   }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -80,6 +80,18 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
     validate(iterator);
   }
 
+  @Test
+  public void testJdbcToArrowValuesNoLimit() throws SQLException, IOException {
+
+    JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
+        Calendar.getInstance()).setTargetBatchSize(JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE).build();
+
+    ArrowVectorIterator iterator =
+        JdbcToArrow.sqlToArrowVectorIterator(conn.createStatement().executeQuery(table.getQuery()), config);
+
+    validate(iterator);
+  }
+
   private void validate(ArrowVectorIterator iterator) throws SQLException, IOException {
 
     List<BigIntVector> bigIntVectors = new ArrayList<>();

--- a/java/performance/src/test/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
@@ -255,7 +255,7 @@ public class JdbcAdapterBenchmarks {
     @Setup(Level.Trial)
     public void prepareState() throws Exception {
       allocator = new RootAllocator(Integer.MAX_VALUE);
-      config = new JdbcToArrowConfigBuilder().setAllocator(allocator).setTargetBatchSize(1024).build();
+      config = new JdbcToArrowConfigBuilder().setAllocator(allocator).setTargetBatchSize(VALUE_COUNT).build();
       Class.forName(DRIVER);
       conn = DriverManager.getConnection(URL);
 


### PR DESCRIPTION
The current implementation use setSafe methods to dynamically allocate memory if necessary. For fixed width vectors (which are frequently used in JDBC), however, we can allocate memory proactively, since the vector size is known as a configuration parameter. So for fixed width vectors, we can use set methods instead.

This change leads to two benefits:
1. When processing each value, we no longer have to check vector capacity and reallocate memroy if needed. This leads to better performance.
2. If we allow the memory to expand automatically (each time by 2x), the amount of memory usually ends up being more than necessary. By allocating memory by the configuration parameter, we allocate no more, or no less.

Benchmark results show notable performance improvements:

Before:

Benchmark Mode Cnt Score Error Units
JdbcAdapterBenchmarks.consumeBenchmark avgt 5 521.700 ± 4.837 us/op

After:

Benchmark Mode Cnt Score Error Units
JdbcAdapterBenchmarks.consumeBenchmark avgt 5 430.523 ± 9.932 us/op