### PR TITLE
PARQUET-1823: [C++] Invalid RowGroup returned by parquet::arrow::FileReader

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -783,7 +783,7 @@ Status FileReaderImpl::GetColumn(int i, FileColumnIteratorFactory iterator_facto
   auto ctx = std::make_shared<ReaderContext>();
   ctx->reader = reader_.get();
   ctx->pool = pool_;
-  ctx->iterator_factory = AllRowGroupsFactory();
+  ctx->iterator_factory = iterator_factory;
   ctx->filter_leaves = false;
   std::unique_ptr<ColumnReaderImpl> result;
   RETURN_NOT_OK(GetReader(manifest_.schema_fields[i], ctx, &result));


### PR DESCRIPTION
As reported by Feng Tian, the FileReader::RowGroup(i)::Column(j) method was not returning the correct row group and instead always returned the first row group of the file. The root cause was an ignored `factory_iterator` parameter in the `FileReaderImpl::GetColumn` method.