### PR TITLE
ARROW-8177: [rust] Make schema_to_fb_offset public because it is very useful!

### DIFF
--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -75,7 +75,7 @@ pub(crate) fn schema_to_fb(schema: &Schema) -> FlatBufferBuilder {
     fbb
 }
 
-pub(crate) fn schema_to_fb_offset<'a: 'b, 'b>(
+pub fn schema_to_fb_offset<'a: 'b, 'b>(
     mut fbb: &'a mut FlatBufferBuilder,
     schema: &Schema,
 ) -> WIPOffset<ipc::Schema<'b>> {


### PR DESCRIPTION
I need this exact function in my application and it'd be a lot easier to just use it within Arrow instead of having to copy it out or recreate it!