### PR TITLE
ARROW-8178: [C++] Update to Flatbuffers 1.12.0

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -677,8 +677,7 @@ class FieldToFlatbufferVisitor {
       type_ids.push_back(code);
     }
 
-    auto fb_type_ids =
-        fbb_.CreateVector(util::MakeNonNull(type_ids.data()), type_ids.size());
+    auto fb_type_ids = fbb_.CreateVector(type_ids.data(), type_ids.size());
 
     type_offset_ = flatbuf::CreateUnion(fbb_, mode, fb_type_ids).Union();
     return Status::OK();
@@ -701,8 +700,7 @@ class FieldToFlatbufferVisitor {
   Status GetResult(const std::shared_ptr<Field>& field, FieldOffset* offset) {
     auto fb_name = fbb_.CreateString(field->name());
     RETURN_NOT_OK(VisitType(*field->type()));
-    auto fb_children =
-        fbb_.CreateVector(util::MakeNonNull(children_.data()), children_.size());
+    auto fb_children = fbb_.CreateVector(children_.data(), children_.size());
 
     DictionaryOffset dictionary = 0;
     if (field->type()->id() == Type::DICTIONARY) {
@@ -855,7 +853,7 @@ static Status WriteFieldNodes(FBB& fbb, const std::vector<FieldMetadata>& nodes,
     }
     fb_nodes.emplace_back(node.length, node.null_count);
   }
-  *out = fbb.CreateVectorOfStructs(util::MakeNonNull(fb_nodes.data()), fb_nodes.size());
+  *out = fbb.CreateVectorOfStructs(fb_nodes.data(), fb_nodes.size());
   return Status::OK();
 }
 
@@ -868,8 +866,7 @@ static Status WriteBuffers(FBB& fbb, const std::vector<BufferMetadata>& buffers,
     const BufferMetadata& buffer = buffers[i];
     fb_buffers.emplace_back(buffer.offset, buffer.length);
   }
-  *out =
-      fbb.CreateVectorOfStructs(util::MakeNonNull(fb_buffers.data()), fb_buffers.size());
+  *out = fbb.CreateVectorOfStructs(fb_buffers.data(), fb_buffers.size());
 
   return Status::OK();
 }
@@ -900,9 +897,8 @@ Status MakeSparseTensorIndexCOO(FBB& fbb, const SparseCOOIndex& sparse_index,
   auto indices_type_offset =
       flatbuf::CreateInt(fbb, index_value_type.bit_width(), index_value_type.is_signed());
 
-  auto fb_strides =
-      fbb.CreateVector(util::MakeNonNull(sparse_index.indices()->strides().data()),
-                       sparse_index.indices()->strides().size());
+  auto fb_strides = fbb.CreateVector(sparse_index.indices()->strides().data(),
+                                     sparse_index.indices()->strides().size());
 
   const BufferMetadata& indices_metadata = buffers[0];
   flatbuf::Buffer indices(indices_metadata.offset, indices_metadata.length);
@@ -1072,11 +1068,10 @@ Result<std::shared_ptr<Buffer>> WriteTensorMessage(const Tensor& tensor,
     dims.push_back(flatbuf::CreateTensorDim(fbb, tensor.shape()[i], name));
   }
 
-  auto fb_shape = fbb.CreateVector(util::MakeNonNull(dims.data()), dims.size());
+  auto fb_shape = fbb.CreateVector(dims.data(), dims.size());
 
   flatbuffers::Offset<flatbuffers::Vector<int64_t>> fb_strides;
-  fb_strides = fbb.CreateVector(util::MakeNonNull(tensor.strides().data()),
-                                tensor.strides().size());
+  fb_strides = fbb.CreateVector(tensor.strides().data(), tensor.strides().size());
   int64_t body_length = tensor.size() * elem_size;
   flatbuf::Buffer buffer(buffer_start_offset, body_length);
 
@@ -1119,7 +1114,7 @@ FileBlocksToFlatbuffer(FBB& fbb, const std::vector<FileBlock>& blocks) {
     fb_blocks.emplace_back(block.offset, block.metadata_length, block.body_length);
   }
 
-  return fbb.CreateVectorOfStructs(util::MakeNonNull(fb_blocks.data()), fb_blocks.size());
+  return fbb.CreateVectorOfStructs(fb_blocks.data(), fb_blocks.size());
 }
 
 Status WriteFileFooter(const Schema& schema, const std::vector<FileBlock>& dictionaries,

--- a/cpp/src/generated/File_generated.h
+++ b/cpp/src/generated/File_generated.h
@@ -14,6 +14,7 @@ namespace arrow {
 namespace flatbuf {
 
 struct Footer;
+struct FooterBuilder;
 
 struct Block;
 
@@ -55,6 +56,7 @@ FLATBUFFERS_STRUCT_END(Block, 24);
 /// Arrow File metadata
 ///
 struct Footer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef FooterBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_VERSION = 4,
     VT_SCHEMA = 6,
@@ -62,21 +64,21 @@ struct Footer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_RECORDBATCHES = 10,
     VT_CUSTOM_METADATA = 12
   };
-  MetadataVersion version() const {
-    return static_cast<MetadataVersion>(GetField<int16_t>(VT_VERSION, 0));
+  org::apache::arrow::flatbuf::MetadataVersion version() const {
+    return static_cast<org::apache::arrow::flatbuf::MetadataVersion>(GetField<int16_t>(VT_VERSION, 0));
   }
-  const Schema *schema() const {
-    return GetPointer<const Schema *>(VT_SCHEMA);
+  const org::apache::arrow::flatbuf::Schema *schema() const {
+    return GetPointer<const org::apache::arrow::flatbuf::Schema *>(VT_SCHEMA);
   }
-  const flatbuffers::Vector<const Block *> *dictionaries() const {
-    return GetPointer<const flatbuffers::Vector<const Block *> *>(VT_DICTIONARIES);
+  const flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *> *dictionaries() const {
+    return GetPointer<const flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *> *>(VT_DICTIONARIES);
   }
-  const flatbuffers::Vector<const Block *> *recordBatches() const {
-    return GetPointer<const flatbuffers::Vector<const Block *> *>(VT_RECORDBATCHES);
+  const flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *> *recordBatches() const {
+    return GetPointer<const flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *> *>(VT_RECORDBATCHES);
   }
   /// User-defined metadata
-  const flatbuffers::Vector<flatbuffers::Offset<KeyValue>> *custom_metadata() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<KeyValue>> *>(VT_CUSTOM_METADATA);
+  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *>(VT_CUSTOM_METADATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -95,21 +97,22 @@ struct Footer FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct FooterBuilder {
+  typedef Footer Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_version(MetadataVersion version) {
+  void add_version(org::apache::arrow::flatbuf::MetadataVersion version) {
     fbb_.AddElement<int16_t>(Footer::VT_VERSION, static_cast<int16_t>(version), 0);
   }
-  void add_schema(flatbuffers::Offset<Schema> schema) {
+  void add_schema(flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema) {
     fbb_.AddOffset(Footer::VT_SCHEMA, schema);
   }
-  void add_dictionaries(flatbuffers::Offset<flatbuffers::Vector<const Block *>> dictionaries) {
+  void add_dictionaries(flatbuffers::Offset<flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *>> dictionaries) {
     fbb_.AddOffset(Footer::VT_DICTIONARIES, dictionaries);
   }
-  void add_recordBatches(flatbuffers::Offset<flatbuffers::Vector<const Block *>> recordBatches) {
+  void add_recordBatches(flatbuffers::Offset<flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *>> recordBatches) {
     fbb_.AddOffset(Footer::VT_RECORDBATCHES, recordBatches);
   }
-  void add_custom_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<KeyValue>>> custom_metadata) {
+  void add_custom_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata) {
     fbb_.AddOffset(Footer::VT_CUSTOM_METADATA, custom_metadata);
   }
   explicit FooterBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -126,11 +129,11 @@ struct FooterBuilder {
 
 inline flatbuffers::Offset<Footer> CreateFooter(
     flatbuffers::FlatBufferBuilder &_fbb,
-    MetadataVersion version = MetadataVersion::V1,
-    flatbuffers::Offset<Schema> schema = 0,
-    flatbuffers::Offset<flatbuffers::Vector<const Block *>> dictionaries = 0,
-    flatbuffers::Offset<flatbuffers::Vector<const Block *>> recordBatches = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<KeyValue>>> custom_metadata = 0) {
+    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion::V1,
+    flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *>> dictionaries = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *>> recordBatches = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata = 0) {
   FooterBuilder builder_(_fbb);
   builder_.add_custom_metadata(custom_metadata);
   builder_.add_recordBatches(recordBatches);
@@ -142,14 +145,14 @@ inline flatbuffers::Offset<Footer> CreateFooter(
 
 inline flatbuffers::Offset<Footer> CreateFooterDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    MetadataVersion version = MetadataVersion::V1,
-    flatbuffers::Offset<Schema> schema = 0,
-    const std::vector<Block> *dictionaries = nullptr,
-    const std::vector<Block> *recordBatches = nullptr,
-    const std::vector<flatbuffers::Offset<KeyValue>> *custom_metadata = nullptr) {
-  auto dictionaries__ = dictionaries ? _fbb.CreateVectorOfStructs<Block>(*dictionaries) : 0;
-  auto recordBatches__ = recordBatches ? _fbb.CreateVectorOfStructs<Block>(*recordBatches) : 0;
-  auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<flatbuffers::Offset<KeyValue>>(*custom_metadata) : 0;
+    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion::V1,
+    flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema = 0,
+    const std::vector<org::apache::arrow::flatbuf::Block> *dictionaries = nullptr,
+    const std::vector<org::apache::arrow::flatbuf::Block> *recordBatches = nullptr,
+    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata = nullptr) {
+  auto dictionaries__ = dictionaries ? _fbb.CreateVectorOfStructs<org::apache::arrow::flatbuf::Block>(*dictionaries) : 0;
+  auto recordBatches__ = recordBatches ? _fbb.CreateVectorOfStructs<org::apache::arrow::flatbuf::Block>(*recordBatches) : 0;
+  auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>(*custom_metadata) : 0;
   return org::apache::arrow::flatbuf::CreateFooter(
       _fbb,
       version,

--- a/cpp/src/generated/Message_generated.h
+++ b/cpp/src/generated/Message_generated.h
@@ -18,10 +18,13 @@ namespace flatbuf {
 struct FieldNode;
 
 struct RecordBatch;
+struct RecordBatchBuilder;
 
 struct DictionaryBatch;
+struct DictionaryBatchBuilder;
 
 struct Message;
+struct MessageBuilder;
 
 /// ----------------------------------------------------------------------
 /// The root Message type
@@ -55,7 +58,7 @@ inline const MessageHeader (&EnumValuesMessageHeader())[6] {
 }
 
 inline const char * const *EnumNamesMessageHeader() {
-  static const char * const names[] = {
+  static const char * const names[7] = {
     "NONE",
     "Schema",
     "DictionaryBatch",
@@ -68,7 +71,7 @@ inline const char * const *EnumNamesMessageHeader() {
 }
 
 inline const char *EnumNameMessageHeader(MessageHeader e) {
-  if (e < MessageHeader::NONE || e > MessageHeader::SparseTensor) return "";
+  if (flatbuffers::IsOutRange(e, MessageHeader::NONE, MessageHeader::SparseTensor)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesMessageHeader()[index];
 }
@@ -77,23 +80,23 @@ template<typename T> struct MessageHeaderTraits {
   static const MessageHeader enum_value = MessageHeader::NONE;
 };
 
-template<> struct MessageHeaderTraits<Schema> {
+template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::Schema> {
   static const MessageHeader enum_value = MessageHeader::Schema;
 };
 
-template<> struct MessageHeaderTraits<DictionaryBatch> {
+template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::DictionaryBatch> {
   static const MessageHeader enum_value = MessageHeader::DictionaryBatch;
 };
 
-template<> struct MessageHeaderTraits<RecordBatch> {
+template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::RecordBatch> {
   static const MessageHeader enum_value = MessageHeader::RecordBatch;
 };
 
-template<> struct MessageHeaderTraits<Tensor> {
+template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::Tensor> {
   static const MessageHeader enum_value = MessageHeader::Tensor;
 };
 
-template<> struct MessageHeaderTraits<SparseTensor> {
+template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::SparseTensor> {
   static const MessageHeader enum_value = MessageHeader::SparseTensor;
 };
 
@@ -140,6 +143,7 @@ FLATBUFFERS_STRUCT_END(FieldNode, 16);
 /// batch. Some systems call this a "row batch" internally and others a "record
 /// batch".
 struct RecordBatch FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef RecordBatchBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_LENGTH = 4,
     VT_NODES = 6,
@@ -151,8 +155,8 @@ struct RecordBatch FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return GetField<int64_t>(VT_LENGTH, 0);
   }
   /// Nodes correspond to the pre-ordered flattened logical schema
-  const flatbuffers::Vector<const FieldNode *> *nodes() const {
-    return GetPointer<const flatbuffers::Vector<const FieldNode *> *>(VT_NODES);
+  const flatbuffers::Vector<const org::apache::arrow::flatbuf::FieldNode *> *nodes() const {
+    return GetPointer<const flatbuffers::Vector<const org::apache::arrow::flatbuf::FieldNode *> *>(VT_NODES);
   }
   /// Buffers correspond to the pre-ordered flattened buffer tree
   ///
@@ -160,8 +164,8 @@ struct RecordBatch FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   /// example, most primitive arrays will have 2 buffers, 1 for the validity
   /// bitmap and 1 for the values. For struct arrays, there will only be a
   /// single buffer for the validity (nulls) bitmap
-  const flatbuffers::Vector<const Buffer *> *buffers() const {
-    return GetPointer<const flatbuffers::Vector<const Buffer *> *>(VT_BUFFERS);
+  const flatbuffers::Vector<const org::apache::arrow::flatbuf::Buffer *> *buffers() const {
+    return GetPointer<const flatbuffers::Vector<const org::apache::arrow::flatbuf::Buffer *> *>(VT_BUFFERS);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -175,15 +179,16 @@ struct RecordBatch FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct RecordBatchBuilder {
+  typedef RecordBatch Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_length(int64_t length) {
     fbb_.AddElement<int64_t>(RecordBatch::VT_LENGTH, length, 0);
   }
-  void add_nodes(flatbuffers::Offset<flatbuffers::Vector<const FieldNode *>> nodes) {
+  void add_nodes(flatbuffers::Offset<flatbuffers::Vector<const org::apache::arrow::flatbuf::FieldNode *>> nodes) {
     fbb_.AddOffset(RecordBatch::VT_NODES, nodes);
   }
-  void add_buffers(flatbuffers::Offset<flatbuffers::Vector<const Buffer *>> buffers) {
+  void add_buffers(flatbuffers::Offset<flatbuffers::Vector<const org::apache::arrow::flatbuf::Buffer *>> buffers) {
     fbb_.AddOffset(RecordBatch::VT_BUFFERS, buffers);
   }
   explicit RecordBatchBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -201,8 +206,8 @@ struct RecordBatchBuilder {
 inline flatbuffers::Offset<RecordBatch> CreateRecordBatch(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t length = 0,
-    flatbuffers::Offset<flatbuffers::Vector<const FieldNode *>> nodes = 0,
-    flatbuffers::Offset<flatbuffers::Vector<const Buffer *>> buffers = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<const org::apache::arrow::flatbuf::FieldNode *>> nodes = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const org::apache::arrow::flatbuf::Buffer *>> buffers = 0) {
   RecordBatchBuilder builder_(_fbb);
   builder_.add_length(length);
   builder_.add_buffers(buffers);
@@ -213,10 +218,10 @@ inline flatbuffers::Offset<RecordBatch> CreateRecordBatch(
 inline flatbuffers::Offset<RecordBatch> CreateRecordBatchDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t length = 0,
-    const std::vector<FieldNode> *nodes = nullptr,
-    const std::vector<Buffer> *buffers = nullptr) {
-  auto nodes__ = nodes ? _fbb.CreateVectorOfStructs<FieldNode>(*nodes) : 0;
-  auto buffers__ = buffers ? _fbb.CreateVectorOfStructs<Buffer>(*buffers) : 0;
+    const std::vector<org::apache::arrow::flatbuf::FieldNode> *nodes = nullptr,
+    const std::vector<org::apache::arrow::flatbuf::Buffer> *buffers = nullptr) {
+  auto nodes__ = nodes ? _fbb.CreateVectorOfStructs<org::apache::arrow::flatbuf::FieldNode>(*nodes) : 0;
+  auto buffers__ = buffers ? _fbb.CreateVectorOfStructs<org::apache::arrow::flatbuf::Buffer>(*buffers) : 0;
   return org::apache::arrow::flatbuf::CreateRecordBatch(
       _fbb,
       length,
@@ -231,6 +236,7 @@ inline flatbuffers::Offset<RecordBatch> CreateRecordBatchDirect(
 /// may be spread across multiple dictionary batches by using the isDelta
 /// flag
 struct DictionaryBatch FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef DictionaryBatchBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ID = 4,
     VT_DATA = 6,
@@ -239,8 +245,8 @@ struct DictionaryBatch FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int64_t id() const {
     return GetField<int64_t>(VT_ID, 0);
   }
-  const RecordBatch *data() const {
-    return GetPointer<const RecordBatch *>(VT_DATA);
+  const org::apache::arrow::flatbuf::RecordBatch *data() const {
+    return GetPointer<const org::apache::arrow::flatbuf::RecordBatch *>(VT_DATA);
   }
   /// If isDelta is true the values in the dictionary are to be appended to a
   /// dictionary with the indicated id. If isDelta is false this dictionary
@@ -259,12 +265,13 @@ struct DictionaryBatch FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct DictionaryBatchBuilder {
+  typedef DictionaryBatch Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_id(int64_t id) {
     fbb_.AddElement<int64_t>(DictionaryBatch::VT_ID, id, 0);
   }
-  void add_data(flatbuffers::Offset<RecordBatch> data) {
+  void add_data(flatbuffers::Offset<org::apache::arrow::flatbuf::RecordBatch> data) {
     fbb_.AddOffset(DictionaryBatch::VT_DATA, data);
   }
   void add_isDelta(bool isDelta) {
@@ -285,7 +292,7 @@ struct DictionaryBatchBuilder {
 inline flatbuffers::Offset<DictionaryBatch> CreateDictionaryBatch(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t id = 0,
-    flatbuffers::Offset<RecordBatch> data = 0,
+    flatbuffers::Offset<org::apache::arrow::flatbuf::RecordBatch> data = 0,
     bool isDelta = false) {
   DictionaryBatchBuilder builder_(_fbb);
   builder_.add_id(id);
@@ -295,6 +302,7 @@ inline flatbuffers::Offset<DictionaryBatch> CreateDictionaryBatch(
 }
 
 struct Message FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef MessageBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_VERSION = 4,
     VT_HEADER_TYPE = 6,
@@ -302,36 +310,36 @@ struct Message FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_BODYLENGTH = 10,
     VT_CUSTOM_METADATA = 12
   };
-  MetadataVersion version() const {
-    return static_cast<MetadataVersion>(GetField<int16_t>(VT_VERSION, 0));
+  org::apache::arrow::flatbuf::MetadataVersion version() const {
+    return static_cast<org::apache::arrow::flatbuf::MetadataVersion>(GetField<int16_t>(VT_VERSION, 0));
   }
-  MessageHeader header_type() const {
-    return static_cast<MessageHeader>(GetField<uint8_t>(VT_HEADER_TYPE, 0));
+  org::apache::arrow::flatbuf::MessageHeader header_type() const {
+    return static_cast<org::apache::arrow::flatbuf::MessageHeader>(GetField<uint8_t>(VT_HEADER_TYPE, 0));
   }
   const void *header() const {
     return GetPointer<const void *>(VT_HEADER);
   }
   template<typename T> const T *header_as() const;
-  const Schema *header_as_Schema() const {
-    return header_type() == MessageHeader::Schema ? static_cast<const Schema *>(header()) : nullptr;
+  const org::apache::arrow::flatbuf::Schema *header_as_Schema() const {
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader::Schema ? static_cast<const org::apache::arrow::flatbuf::Schema *>(header()) : nullptr;
   }
-  const DictionaryBatch *header_as_DictionaryBatch() const {
-    return header_type() == MessageHeader::DictionaryBatch ? static_cast<const DictionaryBatch *>(header()) : nullptr;
+  const org::apache::arrow::flatbuf::DictionaryBatch *header_as_DictionaryBatch() const {
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader::DictionaryBatch ? static_cast<const org::apache::arrow::flatbuf::DictionaryBatch *>(header()) : nullptr;
   }
-  const RecordBatch *header_as_RecordBatch() const {
-    return header_type() == MessageHeader::RecordBatch ? static_cast<const RecordBatch *>(header()) : nullptr;
+  const org::apache::arrow::flatbuf::RecordBatch *header_as_RecordBatch() const {
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader::RecordBatch ? static_cast<const org::apache::arrow::flatbuf::RecordBatch *>(header()) : nullptr;
   }
-  const Tensor *header_as_Tensor() const {
-    return header_type() == MessageHeader::Tensor ? static_cast<const Tensor *>(header()) : nullptr;
+  const org::apache::arrow::flatbuf::Tensor *header_as_Tensor() const {
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader::Tensor ? static_cast<const org::apache::arrow::flatbuf::Tensor *>(header()) : nullptr;
   }
-  const SparseTensor *header_as_SparseTensor() const {
-    return header_type() == MessageHeader::SparseTensor ? static_cast<const SparseTensor *>(header()) : nullptr;
+  const org::apache::arrow::flatbuf::SparseTensor *header_as_SparseTensor() const {
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader::SparseTensor ? static_cast<const org::apache::arrow::flatbuf::SparseTensor *>(header()) : nullptr;
   }
   int64_t bodyLength() const {
     return GetField<int64_t>(VT_BODYLENGTH, 0);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<KeyValue>> *custom_metadata() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<KeyValue>> *>(VT_CUSTOM_METADATA);
+  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *>(VT_CUSTOM_METADATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -347,33 +355,34 @@ struct Message FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
 };
 
-template<> inline const Schema *Message::header_as<Schema>() const {
+template<> inline const org::apache::arrow::flatbuf::Schema *Message::header_as<org::apache::arrow::flatbuf::Schema>() const {
   return header_as_Schema();
 }
 
-template<> inline const DictionaryBatch *Message::header_as<DictionaryBatch>() const {
+template<> inline const org::apache::arrow::flatbuf::DictionaryBatch *Message::header_as<org::apache::arrow::flatbuf::DictionaryBatch>() const {
   return header_as_DictionaryBatch();
 }
 
-template<> inline const RecordBatch *Message::header_as<RecordBatch>() const {
+template<> inline const org::apache::arrow::flatbuf::RecordBatch *Message::header_as<org::apache::arrow::flatbuf::RecordBatch>() const {
   return header_as_RecordBatch();
 }
 
-template<> inline const Tensor *Message::header_as<Tensor>() const {
+template<> inline const org::apache::arrow::flatbuf::Tensor *Message::header_as<org::apache::arrow::flatbuf::Tensor>() const {
   return header_as_Tensor();
 }
 
-template<> inline const SparseTensor *Message::header_as<SparseTensor>() const {
+template<> inline const org::apache::arrow::flatbuf::SparseTensor *Message::header_as<org::apache::arrow::flatbuf::SparseTensor>() const {
   return header_as_SparseTensor();
 }
 
 struct MessageBuilder {
+  typedef Message Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_version(MetadataVersion version) {
+  void add_version(org::apache::arrow::flatbuf::MetadataVersion version) {
     fbb_.AddElement<int16_t>(Message::VT_VERSION, static_cast<int16_t>(version), 0);
   }
-  void add_header_type(MessageHeader header_type) {
+  void add_header_type(org::apache::arrow::flatbuf::MessageHeader header_type) {
     fbb_.AddElement<uint8_t>(Message::VT_HEADER_TYPE, static_cast<uint8_t>(header_type), 0);
   }
   void add_header(flatbuffers::Offset<void> header) {
@@ -382,7 +391,7 @@ struct MessageBuilder {
   void add_bodyLength(int64_t bodyLength) {
     fbb_.AddElement<int64_t>(Message::VT_BODYLENGTH, bodyLength, 0);
   }
-  void add_custom_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<KeyValue>>> custom_metadata) {
+  void add_custom_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata) {
     fbb_.AddOffset(Message::VT_CUSTOM_METADATA, custom_metadata);
   }
   explicit MessageBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -399,11 +408,11 @@ struct MessageBuilder {
 
 inline flatbuffers::Offset<Message> CreateMessage(
     flatbuffers::FlatBufferBuilder &_fbb,
-    MetadataVersion version = MetadataVersion::V1,
-    MessageHeader header_type = MessageHeader::NONE,
+    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion::V1,
+    org::apache::arrow::flatbuf::MessageHeader header_type = org::apache::arrow::flatbuf::MessageHeader::NONE,
     flatbuffers::Offset<void> header = 0,
     int64_t bodyLength = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<KeyValue>>> custom_metadata = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata = 0) {
   MessageBuilder builder_(_fbb);
   builder_.add_bodyLength(bodyLength);
   builder_.add_custom_metadata(custom_metadata);
@@ -415,12 +424,12 @@ inline flatbuffers::Offset<Message> CreateMessage(
 
 inline flatbuffers::Offset<Message> CreateMessageDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    MetadataVersion version = MetadataVersion::V1,
-    MessageHeader header_type = MessageHeader::NONE,
+    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion::V1,
+    org::apache::arrow::flatbuf::MessageHeader header_type = org::apache::arrow::flatbuf::MessageHeader::NONE,
     flatbuffers::Offset<void> header = 0,
     int64_t bodyLength = 0,
-    const std::vector<flatbuffers::Offset<KeyValue>> *custom_metadata = nullptr) {
-  auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<flatbuffers::Offset<KeyValue>>(*custom_metadata) : 0;
+    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata = nullptr) {
+  auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>(*custom_metadata) : 0;
   return org::apache::arrow::flatbuf::CreateMessage(
       _fbb,
       version,
@@ -436,26 +445,26 @@ inline bool VerifyMessageHeader(flatbuffers::Verifier &verifier, const void *obj
       return true;
     }
     case MessageHeader::Schema: {
-      auto ptr = reinterpret_cast<const Schema *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Schema *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case MessageHeader::DictionaryBatch: {
-      auto ptr = reinterpret_cast<const DictionaryBatch *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::DictionaryBatch *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case MessageHeader::RecordBatch: {
-      auto ptr = reinterpret_cast<const RecordBatch *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::RecordBatch *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case MessageHeader::Tensor: {
-      auto ptr = reinterpret_cast<const Tensor *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Tensor *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case MessageHeader::SparseTensor: {
-      auto ptr = reinterpret_cast<const SparseTensor *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::SparseTensor *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    default: return false;
+    default: return true;
   }
 }
 

--- a/cpp/src/generated/Schema_generated.h
+++ b/cpp/src/generated/Schema_generated.h
@@ -12,65 +12,90 @@ namespace arrow {
 namespace flatbuf {
 
 struct Null;
+struct NullBuilder;
 
 struct Struct_;
+struct Struct_Builder;
 
 struct List;
+struct ListBuilder;
 
 struct LargeList;
+struct LargeListBuilder;
 
 struct FixedSizeList;
+struct FixedSizeListBuilder;
 
 struct Map;
+struct MapBuilder;
 
 struct Union;
+struct UnionBuilder;
 
 struct Int;
+struct IntBuilder;
 
 struct FloatingPoint;
+struct FloatingPointBuilder;
 
 struct Utf8;
+struct Utf8Builder;
 
 struct Binary;
+struct BinaryBuilder;
 
 struct LargeUtf8;
+struct LargeUtf8Builder;
 
 struct LargeBinary;
+struct LargeBinaryBuilder;
 
 struct FixedSizeBinary;
+struct FixedSizeBinaryBuilder;
 
 struct Bool;
+struct BoolBuilder;
 
 struct Decimal;
+struct DecimalBuilder;
 
 struct Date;
+struct DateBuilder;
 
 struct Time;
+struct TimeBuilder;
 
 struct Timestamp;
+struct TimestampBuilder;
 
 struct Interval;
+struct IntervalBuilder;
 
 struct Duration;
+struct DurationBuilder;
 
 struct KeyValue;
+struct KeyValueBuilder;
 
 struct DictionaryEncoding;
+struct DictionaryEncodingBuilder;
 
 struct Field;
+struct FieldBuilder;
 
 struct Buffer;
 
 struct Schema;
+struct SchemaBuilder;
 
 enum class MetadataVersion : int16_t {
   /// 0.1.0
-  V1 = 0  /// 0.2.0
-,
-  V2 = 1  /// 0.3.0 -> 0.7.1
-,
-  V3 = 2  /// >= 0.8.0
-,
+  V1 = 0,
+  /// 0.2.0
+  V2 = 1,
+  /// 0.3.0 -> 0.7.1
+  V3 = 2,
+  /// >= 0.8.0
   V4 = 3,
   MIN = V1,
   MAX = V4
@@ -87,7 +112,7 @@ inline const MetadataVersion (&EnumValuesMetadataVersion())[4] {
 }
 
 inline const char * const *EnumNamesMetadataVersion() {
-  static const char * const names[] = {
+  static const char * const names[5] = {
     "V1",
     "V2",
     "V3",
@@ -98,7 +123,7 @@ inline const char * const *EnumNamesMetadataVersion() {
 }
 
 inline const char *EnumNameMetadataVersion(MetadataVersion e) {
-  if (e < MetadataVersion::V1 || e > MetadataVersion::V4) return "";
+  if (flatbuffers::IsOutRange(e, MetadataVersion::V1, MetadataVersion::V4)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesMetadataVersion()[index];
 }
@@ -119,7 +144,7 @@ inline const UnionMode (&EnumValuesUnionMode())[2] {
 }
 
 inline const char * const *EnumNamesUnionMode() {
-  static const char * const names[] = {
+  static const char * const names[3] = {
     "Sparse",
     "Dense",
     nullptr
@@ -128,7 +153,7 @@ inline const char * const *EnumNamesUnionMode() {
 }
 
 inline const char *EnumNameUnionMode(UnionMode e) {
-  if (e < UnionMode::Sparse || e > UnionMode::Dense) return "";
+  if (flatbuffers::IsOutRange(e, UnionMode::Sparse, UnionMode::Dense)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesUnionMode()[index];
 }
@@ -151,7 +176,7 @@ inline const Precision (&EnumValuesPrecision())[3] {
 }
 
 inline const char * const *EnumNamesPrecision() {
-  static const char * const names[] = {
+  static const char * const names[4] = {
     "HALF",
     "SINGLE",
     "DOUBLE",
@@ -161,7 +186,7 @@ inline const char * const *EnumNamesPrecision() {
 }
 
 inline const char *EnumNamePrecision(Precision e) {
-  if (e < Precision::HALF || e > Precision::DOUBLE) return "";
+  if (flatbuffers::IsOutRange(e, Precision::HALF, Precision::DOUBLE)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesPrecision()[index];
 }
@@ -182,7 +207,7 @@ inline const DateUnit (&EnumValuesDateUnit())[2] {
 }
 
 inline const char * const *EnumNamesDateUnit() {
-  static const char * const names[] = {
+  static const char * const names[3] = {
     "DAY",
     "MILLISECOND",
     nullptr
@@ -191,7 +216,7 @@ inline const char * const *EnumNamesDateUnit() {
 }
 
 inline const char *EnumNameDateUnit(DateUnit e) {
-  if (e < DateUnit::DAY || e > DateUnit::MILLISECOND) return "";
+  if (flatbuffers::IsOutRange(e, DateUnit::DAY, DateUnit::MILLISECOND)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDateUnit()[index];
 }
@@ -216,7 +241,7 @@ inline const TimeUnit (&EnumValuesTimeUnit())[4] {
 }
 
 inline const char * const *EnumNamesTimeUnit() {
-  static const char * const names[] = {
+  static const char * const names[5] = {
     "SECOND",
     "MILLISECOND",
     "MICROSECOND",
@@ -227,7 +252,7 @@ inline const char * const *EnumNamesTimeUnit() {
 }
 
 inline const char *EnumNameTimeUnit(TimeUnit e) {
-  if (e < TimeUnit::SECOND || e > TimeUnit::NANOSECOND) return "";
+  if (flatbuffers::IsOutRange(e, TimeUnit::SECOND, TimeUnit::NANOSECOND)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTimeUnit()[index];
 }
@@ -248,7 +273,7 @@ inline const IntervalUnit (&EnumValuesIntervalUnit())[2] {
 }
 
 inline const char * const *EnumNamesIntervalUnit() {
-  static const char * const names[] = {
+  static const char * const names[3] = {
     "YEAR_MONTH",
     "DAY_TIME",
     nullptr
@@ -257,7 +282,7 @@ inline const char * const *EnumNamesIntervalUnit() {
 }
 
 inline const char *EnumNameIntervalUnit(IntervalUnit e) {
-  if (e < IntervalUnit::YEAR_MONTH || e > IntervalUnit::DAY_TIME) return "";
+  if (flatbuffers::IsOutRange(e, IntervalUnit::YEAR_MONTH, IntervalUnit::DAY_TIME)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesIntervalUnit()[index];
 }
@@ -321,7 +346,7 @@ inline const Type (&EnumValuesType())[22] {
 }
 
 inline const char * const *EnumNamesType() {
-  static const char * const names[] = {
+  static const char * const names[23] = {
     "NONE",
     "Null",
     "Int",
@@ -350,7 +375,7 @@ inline const char * const *EnumNamesType() {
 }
 
 inline const char *EnumNameType(Type e) {
-  if (e < Type::NONE || e > Type::LargeList) return "";
+  if (flatbuffers::IsOutRange(e, Type::NONE, Type::LargeList)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesType()[index];
 }
@@ -359,87 +384,87 @@ template<typename T> struct TypeTraits {
   static const Type enum_value = Type::NONE;
 };
 
-template<> struct TypeTraits<Null> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Null> {
   static const Type enum_value = Type::Null;
 };
 
-template<> struct TypeTraits<Int> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Int> {
   static const Type enum_value = Type::Int;
 };
 
-template<> struct TypeTraits<FloatingPoint> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::FloatingPoint> {
   static const Type enum_value = Type::FloatingPoint;
 };
 
-template<> struct TypeTraits<Binary> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Binary> {
   static const Type enum_value = Type::Binary;
 };
 
-template<> struct TypeTraits<Utf8> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Utf8> {
   static const Type enum_value = Type::Utf8;
 };
 
-template<> struct TypeTraits<Bool> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Bool> {
   static const Type enum_value = Type::Bool;
 };
 
-template<> struct TypeTraits<Decimal> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Decimal> {
   static const Type enum_value = Type::Decimal;
 };
 
-template<> struct TypeTraits<Date> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Date> {
   static const Type enum_value = Type::Date;
 };
 
-template<> struct TypeTraits<Time> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Time> {
   static const Type enum_value = Type::Time;
 };
 
-template<> struct TypeTraits<Timestamp> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Timestamp> {
   static const Type enum_value = Type::Timestamp;
 };
 
-template<> struct TypeTraits<Interval> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Interval> {
   static const Type enum_value = Type::Interval;
 };
 
-template<> struct TypeTraits<List> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::List> {
   static const Type enum_value = Type::List;
 };
 
-template<> struct TypeTraits<Struct_> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Struct_> {
   static const Type enum_value = Type::Struct_;
 };
 
-template<> struct TypeTraits<Union> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Union> {
   static const Type enum_value = Type::Union;
 };
 
-template<> struct TypeTraits<FixedSizeBinary> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::FixedSizeBinary> {
   static const Type enum_value = Type::FixedSizeBinary;
 };
 
-template<> struct TypeTraits<FixedSizeList> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::FixedSizeList> {
   static const Type enum_value = Type::FixedSizeList;
 };
 
-template<> struct TypeTraits<Map> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Map> {
   static const Type enum_value = Type::Map;
 };
 
-template<> struct TypeTraits<Duration> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::Duration> {
   static const Type enum_value = Type::Duration;
 };
 
-template<> struct TypeTraits<LargeBinary> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::LargeBinary> {
   static const Type enum_value = Type::LargeBinary;
 };
 
-template<> struct TypeTraits<LargeUtf8> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::LargeUtf8> {
   static const Type enum_value = Type::LargeUtf8;
 };
 
-template<> struct TypeTraits<LargeList> {
+template<> struct TypeTraits<org::apache::arrow::flatbuf::LargeList> {
   static const Type enum_value = Type::LargeList;
 };
 
@@ -465,7 +490,7 @@ inline const DictionaryKind (&EnumValuesDictionaryKind())[1] {
 }
 
 inline const char * const *EnumNamesDictionaryKind() {
-  static const char * const names[] = {
+  static const char * const names[2] = {
     "DenseArray",
     nullptr
   };
@@ -473,7 +498,7 @@ inline const char * const *EnumNamesDictionaryKind() {
 }
 
 inline const char *EnumNameDictionaryKind(DictionaryKind e) {
-  if (e < DictionaryKind::DenseArray || e > DictionaryKind::DenseArray) return "";
+  if (flatbuffers::IsOutRange(e, DictionaryKind::DenseArray, DictionaryKind::DenseArray)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDictionaryKind()[index];
 }
@@ -496,7 +521,7 @@ inline const Endianness (&EnumValuesEndianness())[2] {
 }
 
 inline const char * const *EnumNamesEndianness() {
-  static const char * const names[] = {
+  static const char * const names[3] = {
     "Little",
     "Big",
     nullptr
@@ -505,7 +530,7 @@ inline const char * const *EnumNamesEndianness() {
 }
 
 inline const char *EnumNameEndianness(Endianness e) {
-  if (e < Endianness::Little || e > Endianness::Big) return "";
+  if (flatbuffers::IsOutRange(e, Endianness::Little, Endianness::Big)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesEndianness()[index];
 }
@@ -543,6 +568,7 @@ FLATBUFFERS_STRUCT_END(Buffer, 16);
 
 /// These are stored in the flatbuffer in the Type union below
 struct Null FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef NullBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -550,6 +576,7 @@ struct Null FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct NullBuilder {
+  typedef Null Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit NullBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -574,6 +601,7 @@ inline flatbuffers::Offset<Null> CreateNull(
 /// (according to the physical memory layout). We used Struct_ here as
 /// Struct is a reserved word in Flatbuffers
 struct Struct_ FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef Struct_Builder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -581,6 +609,7 @@ struct Struct_ FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct Struct_Builder {
+  typedef Struct_ Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit Struct_Builder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -602,6 +631,7 @@ inline flatbuffers::Offset<Struct_> CreateStruct_(
 }
 
 struct List FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ListBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -609,6 +639,7 @@ struct List FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct ListBuilder {
+  typedef List Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit ListBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -632,6 +663,7 @@ inline flatbuffers::Offset<List> CreateList(
 /// Same as List, but with 64-bit offsets, allowing to represent
 /// extremely large data values.
 struct LargeList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef LargeListBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -639,6 +671,7 @@ struct LargeList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct LargeListBuilder {
+  typedef LargeList Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LargeListBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -660,6 +693,7 @@ inline flatbuffers::Offset<LargeList> CreateLargeList(
 }
 
 struct FixedSizeList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef FixedSizeListBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_LISTSIZE = 4
   };
@@ -675,6 +709,7 @@ struct FixedSizeList FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct FixedSizeListBuilder {
+  typedef FixedSizeList Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_listSize(int32_t listSize) {
@@ -725,6 +760,7 @@ inline flatbuffers::Offset<FixedSizeList> CreateFixedSizeList(
 /// for Map can make Map an alias for List. The "layout" attribute for the Map
 /// field must have the same contents as a List.
 struct Map FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef MapBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_KEYSSORTED = 4
   };
@@ -740,6 +776,7 @@ struct Map FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct MapBuilder {
+  typedef Map Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_keysSorted(bool keysSorted) {
@@ -770,12 +807,13 @@ inline flatbuffers::Offset<Map> CreateMap(
 /// optionally typeIds provides an indirection between the child offset and the type id
 /// for each child typeIds[offset] is the id used in the type vector
 struct Union FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef UnionBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_MODE = 4,
     VT_TYPEIDS = 6
   };
-  UnionMode mode() const {
-    return static_cast<UnionMode>(GetField<int16_t>(VT_MODE, 0));
+  org::apache::arrow::flatbuf::UnionMode mode() const {
+    return static_cast<org::apache::arrow::flatbuf::UnionMode>(GetField<int16_t>(VT_MODE, 0));
   }
   const flatbuffers::Vector<int32_t> *typeIds() const {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_TYPEIDS);
@@ -790,9 +828,10 @@ struct Union FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct UnionBuilder {
+  typedef Union Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_mode(UnionMode mode) {
+  void add_mode(org::apache::arrow::flatbuf::UnionMode mode) {
     fbb_.AddElement<int16_t>(Union::VT_MODE, static_cast<int16_t>(mode), 0);
   }
   void add_typeIds(flatbuffers::Offset<flatbuffers::Vector<int32_t>> typeIds) {
@@ -812,7 +851,7 @@ struct UnionBuilder {
 
 inline flatbuffers::Offset<Union> CreateUnion(
     flatbuffers::FlatBufferBuilder &_fbb,
-    UnionMode mode = UnionMode::Sparse,
+    org::apache::arrow::flatbuf::UnionMode mode = org::apache::arrow::flatbuf::UnionMode::Sparse,
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> typeIds = 0) {
   UnionBuilder builder_(_fbb);
   builder_.add_typeIds(typeIds);
@@ -822,7 +861,7 @@ inline flatbuffers::Offset<Union> CreateUnion(
 
 inline flatbuffers::Offset<Union> CreateUnionDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    UnionMode mode = UnionMode::Sparse,
+    org::apache::arrow::flatbuf::UnionMode mode = org::apache::arrow::flatbuf::UnionMode::Sparse,
     const std::vector<int32_t> *typeIds = nullptr) {
   auto typeIds__ = typeIds ? _fbb.CreateVector<int32_t>(*typeIds) : 0;
   return org::apache::arrow::flatbuf::CreateUnion(
@@ -832,6 +871,7 @@ inline flatbuffers::Offset<Union> CreateUnionDirect(
 }
 
 struct Int FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef IntBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_BITWIDTH = 4,
     VT_IS_SIGNED = 6
@@ -851,6 +891,7 @@ struct Int FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct IntBuilder {
+  typedef Int Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_bitWidth(int32_t bitWidth) {
@@ -882,11 +923,12 @@ inline flatbuffers::Offset<Int> CreateInt(
 }
 
 struct FloatingPoint FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef FloatingPointBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_PRECISION = 4
   };
-  Precision precision() const {
-    return static_cast<Precision>(GetField<int16_t>(VT_PRECISION, 0));
+  org::apache::arrow::flatbuf::Precision precision() const {
+    return static_cast<org::apache::arrow::flatbuf::Precision>(GetField<int16_t>(VT_PRECISION, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -896,9 +938,10 @@ struct FloatingPoint FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct FloatingPointBuilder {
+  typedef FloatingPoint Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_precision(Precision precision) {
+  void add_precision(org::apache::arrow::flatbuf::Precision precision) {
     fbb_.AddElement<int16_t>(FloatingPoint::VT_PRECISION, static_cast<int16_t>(precision), 0);
   }
   explicit FloatingPointBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -915,7 +958,7 @@ struct FloatingPointBuilder {
 
 inline flatbuffers::Offset<FloatingPoint> CreateFloatingPoint(
     flatbuffers::FlatBufferBuilder &_fbb,
-    Precision precision = Precision::HALF) {
+    org::apache::arrow::flatbuf::Precision precision = org::apache::arrow::flatbuf::Precision::HALF) {
   FloatingPointBuilder builder_(_fbb);
   builder_.add_precision(precision);
   return builder_.Finish();
@@ -923,6 +966,7 @@ inline flatbuffers::Offset<FloatingPoint> CreateFloatingPoint(
 
 /// Unicode with UTF-8 encoding
 struct Utf8 FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef Utf8Builder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -930,6 +974,7 @@ struct Utf8 FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct Utf8Builder {
+  typedef Utf8 Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit Utf8Builder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -952,6 +997,7 @@ inline flatbuffers::Offset<Utf8> CreateUtf8(
 
 /// Opaque binary data
 struct Binary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef BinaryBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -959,6 +1005,7 @@ struct Binary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct BinaryBuilder {
+  typedef Binary Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit BinaryBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -982,6 +1029,7 @@ inline flatbuffers::Offset<Binary> CreateBinary(
 /// Same as Utf8, but with 64-bit offsets, allowing to represent
 /// extremely large data values.
 struct LargeUtf8 FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef LargeUtf8Builder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -989,6 +1037,7 @@ struct LargeUtf8 FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct LargeUtf8Builder {
+  typedef LargeUtf8 Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LargeUtf8Builder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1012,6 +1061,7 @@ inline flatbuffers::Offset<LargeUtf8> CreateLargeUtf8(
 /// Same as Binary, but with 64-bit offsets, allowing to represent
 /// extremely large data values.
 struct LargeBinary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef LargeBinaryBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -1019,6 +1069,7 @@ struct LargeBinary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct LargeBinaryBuilder {
+  typedef LargeBinary Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit LargeBinaryBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1040,6 +1091,7 @@ inline flatbuffers::Offset<LargeBinary> CreateLargeBinary(
 }
 
 struct FixedSizeBinary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef FixedSizeBinaryBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_BYTEWIDTH = 4
   };
@@ -1055,6 +1107,7 @@ struct FixedSizeBinary FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct FixedSizeBinaryBuilder {
+  typedef FixedSizeBinary Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_byteWidth(int32_t byteWidth) {
@@ -1081,6 +1134,7 @@ inline flatbuffers::Offset<FixedSizeBinary> CreateFixedSizeBinary(
 }
 
 struct Bool FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef BoolBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -1088,6 +1142,7 @@ struct Bool FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct BoolBuilder {
+  typedef Bool Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit BoolBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1109,6 +1164,7 @@ inline flatbuffers::Offset<Bool> CreateBool(
 }
 
 struct Decimal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef DecimalBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_PRECISION = 4,
     VT_SCALE = 6
@@ -1130,6 +1186,7 @@ struct Decimal FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct DecimalBuilder {
+  typedef Decimal Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_precision(int32_t precision) {
@@ -1167,11 +1224,12 @@ inline flatbuffers::Offset<Decimal> CreateDecimal(
 ///   leap seconds), where the values are evenly divisible by 86400000
 /// * Days (32 bits) since the UNIX epoch
 struct Date FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef DateBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_UNIT = 4
   };
-  DateUnit unit() const {
-    return static_cast<DateUnit>(GetField<int16_t>(VT_UNIT, 1));
+  org::apache::arrow::flatbuf::DateUnit unit() const {
+    return static_cast<org::apache::arrow::flatbuf::DateUnit>(GetField<int16_t>(VT_UNIT, 1));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1181,9 +1239,10 @@ struct Date FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct DateBuilder {
+  typedef Date Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_unit(DateUnit unit) {
+  void add_unit(org::apache::arrow::flatbuf::DateUnit unit) {
     fbb_.AddElement<int16_t>(Date::VT_UNIT, static_cast<int16_t>(unit), 1);
   }
   explicit DateBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1200,7 +1259,7 @@ struct DateBuilder {
 
 inline flatbuffers::Offset<Date> CreateDate(
     flatbuffers::FlatBufferBuilder &_fbb,
-    DateUnit unit = DateUnit::MILLISECOND) {
+    org::apache::arrow::flatbuf::DateUnit unit = org::apache::arrow::flatbuf::DateUnit::MILLISECOND) {
   DateBuilder builder_(_fbb);
   builder_.add_unit(unit);
   return builder_.Finish();
@@ -1210,12 +1269,13 @@ inline flatbuffers::Offset<Date> CreateDate(
 /// - SECOND and MILLISECOND: 32 bits
 /// - MICROSECOND and NANOSECOND: 64 bits
 struct Time FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef TimeBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_UNIT = 4,
     VT_BITWIDTH = 6
   };
-  TimeUnit unit() const {
-    return static_cast<TimeUnit>(GetField<int16_t>(VT_UNIT, 1));
+  org::apache::arrow::flatbuf::TimeUnit unit() const {
+    return static_cast<org::apache::arrow::flatbuf::TimeUnit>(GetField<int16_t>(VT_UNIT, 1));
   }
   int32_t bitWidth() const {
     return GetField<int32_t>(VT_BITWIDTH, 32);
@@ -1229,9 +1289,10 @@ struct Time FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct TimeBuilder {
+  typedef Time Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_unit(TimeUnit unit) {
+  void add_unit(org::apache::arrow::flatbuf::TimeUnit unit) {
     fbb_.AddElement<int16_t>(Time::VT_UNIT, static_cast<int16_t>(unit), 1);
   }
   void add_bitWidth(int32_t bitWidth) {
@@ -1251,7 +1312,7 @@ struct TimeBuilder {
 
 inline flatbuffers::Offset<Time> CreateTime(
     flatbuffers::FlatBufferBuilder &_fbb,
-    TimeUnit unit = TimeUnit::MILLISECOND,
+    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit::MILLISECOND,
     int32_t bitWidth = 32) {
   TimeBuilder builder_(_fbb);
   builder_.add_bitWidth(bitWidth);
@@ -1266,12 +1327,13 @@ inline flatbuffers::Offset<Time> CreateTime(
 /// The Timestamp metadata supports both "time zone naive" and "time zone
 /// aware" timestamps. Read about the timezone attribute for more detail
 struct Timestamp FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef TimestampBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_UNIT = 4,
     VT_TIMEZONE = 6
   };
-  TimeUnit unit() const {
-    return static_cast<TimeUnit>(GetField<int16_t>(VT_UNIT, 0));
+  org::apache::arrow::flatbuf::TimeUnit unit() const {
+    return static_cast<org::apache::arrow::flatbuf::TimeUnit>(GetField<int16_t>(VT_UNIT, 0));
   }
   /// The time zone is a string indicating the name of a time zone, one of:
   ///
@@ -1306,9 +1368,10 @@ struct Timestamp FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct TimestampBuilder {
+  typedef Timestamp Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_unit(TimeUnit unit) {
+  void add_unit(org::apache::arrow::flatbuf::TimeUnit unit) {
     fbb_.AddElement<int16_t>(Timestamp::VT_UNIT, static_cast<int16_t>(unit), 0);
   }
   void add_timezone(flatbuffers::Offset<flatbuffers::String> timezone) {
@@ -1328,7 +1391,7 @@ struct TimestampBuilder {
 
 inline flatbuffers::Offset<Timestamp> CreateTimestamp(
     flatbuffers::FlatBufferBuilder &_fbb,
-    TimeUnit unit = TimeUnit::SECOND,
+    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit::SECOND,
     flatbuffers::Offset<flatbuffers::String> timezone = 0) {
   TimestampBuilder builder_(_fbb);
   builder_.add_timezone(timezone);
@@ -1338,7 +1401,7 @@ inline flatbuffers::Offset<Timestamp> CreateTimestamp(
 
 inline flatbuffers::Offset<Timestamp> CreateTimestampDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    TimeUnit unit = TimeUnit::SECOND,
+    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit::SECOND,
     const char *timezone = nullptr) {
   auto timezone__ = timezone ? _fbb.CreateString(timezone) : 0;
   return org::apache::arrow::flatbuf::CreateTimestamp(
@@ -1348,11 +1411,12 @@ inline flatbuffers::Offset<Timestamp> CreateTimestampDirect(
 }
 
 struct Interval FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef IntervalBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_UNIT = 4
   };
-  IntervalUnit unit() const {
-    return static_cast<IntervalUnit>(GetField<int16_t>(VT_UNIT, 0));
+  org::apache::arrow::flatbuf::IntervalUnit unit() const {
+    return static_cast<org::apache::arrow::flatbuf::IntervalUnit>(GetField<int16_t>(VT_UNIT, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1362,9 +1426,10 @@ struct Interval FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct IntervalBuilder {
+  typedef Interval Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_unit(IntervalUnit unit) {
+  void add_unit(org::apache::arrow::flatbuf::IntervalUnit unit) {
     fbb_.AddElement<int16_t>(Interval::VT_UNIT, static_cast<int16_t>(unit), 0);
   }
   explicit IntervalBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1381,18 +1446,19 @@ struct IntervalBuilder {
 
 inline flatbuffers::Offset<Interval> CreateInterval(
     flatbuffers::FlatBufferBuilder &_fbb,
-    IntervalUnit unit = IntervalUnit::YEAR_MONTH) {
+    org::apache::arrow::flatbuf::IntervalUnit unit = org::apache::arrow::flatbuf::IntervalUnit::YEAR_MONTH) {
   IntervalBuilder builder_(_fbb);
   builder_.add_unit(unit);
   return builder_.Finish();
 }
 
 struct Duration FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef DurationBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_UNIT = 4
   };
-  TimeUnit unit() const {
-    return static_cast<TimeUnit>(GetField<int16_t>(VT_UNIT, 1));
+  org::apache::arrow::flatbuf::TimeUnit unit() const {
+    return static_cast<org::apache::arrow::flatbuf::TimeUnit>(GetField<int16_t>(VT_UNIT, 1));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1402,9 +1468,10 @@ struct Duration FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct DurationBuilder {
+  typedef Duration Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_unit(TimeUnit unit) {
+  void add_unit(org::apache::arrow::flatbuf::TimeUnit unit) {
     fbb_.AddElement<int16_t>(Duration::VT_UNIT, static_cast<int16_t>(unit), 1);
   }
   explicit DurationBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1421,7 +1488,7 @@ struct DurationBuilder {
 
 inline flatbuffers::Offset<Duration> CreateDuration(
     flatbuffers::FlatBufferBuilder &_fbb,
-    TimeUnit unit = TimeUnit::MILLISECOND) {
+    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit::MILLISECOND) {
   DurationBuilder builder_(_fbb);
   builder_.add_unit(unit);
   return builder_.Finish();
@@ -1431,6 +1498,7 @@ inline flatbuffers::Offset<Duration> CreateDuration(
 /// user defined key value pairs to add custom metadata to arrow
 /// key namespacing is the responsibility of the user
 struct KeyValue FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef KeyValueBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_KEY = 4,
     VT_VALUE = 6
@@ -1452,6 +1520,7 @@ struct KeyValue FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct KeyValueBuilder {
+  typedef KeyValue Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_key(flatbuffers::Offset<flatbuffers::String> key) {
@@ -1495,6 +1564,7 @@ inline flatbuffers::Offset<KeyValue> CreateKeyValueDirect(
 }
 
 struct DictionaryEncoding FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef DictionaryEncodingBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ID = 4,
     VT_INDEXTYPE = 6,
@@ -1509,8 +1579,8 @@ struct DictionaryEncoding FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
   /// The dictionary indices are constrained to be positive integers. If this
   /// field is null, the indices must be signed int32
-  const Int *indexType() const {
-    return GetPointer<const Int *>(VT_INDEXTYPE);
+  const org::apache::arrow::flatbuf::Int *indexType() const {
+    return GetPointer<const org::apache::arrow::flatbuf::Int *>(VT_INDEXTYPE);
   }
   /// By default, dictionaries are not ordered, or the order does not have
   /// semantic meaning. In some statistical, applications, dictionary-encoding
@@ -1519,8 +1589,8 @@ struct DictionaryEncoding FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool isOrdered() const {
     return GetField<uint8_t>(VT_ISORDERED, 0) != 0;
   }
-  DictionaryKind dictionaryKind() const {
-    return static_cast<DictionaryKind>(GetField<int16_t>(VT_DICTIONARYKIND, 0));
+  org::apache::arrow::flatbuf::DictionaryKind dictionaryKind() const {
+    return static_cast<org::apache::arrow::flatbuf::DictionaryKind>(GetField<int16_t>(VT_DICTIONARYKIND, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1534,18 +1604,19 @@ struct DictionaryEncoding FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct DictionaryEncodingBuilder {
+  typedef DictionaryEncoding Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_id(int64_t id) {
     fbb_.AddElement<int64_t>(DictionaryEncoding::VT_ID, id, 0);
   }
-  void add_indexType(flatbuffers::Offset<Int> indexType) {
+  void add_indexType(flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indexType) {
     fbb_.AddOffset(DictionaryEncoding::VT_INDEXTYPE, indexType);
   }
   void add_isOrdered(bool isOrdered) {
     fbb_.AddElement<uint8_t>(DictionaryEncoding::VT_ISORDERED, static_cast<uint8_t>(isOrdered), 0);
   }
-  void add_dictionaryKind(DictionaryKind dictionaryKind) {
+  void add_dictionaryKind(org::apache::arrow::flatbuf::DictionaryKind dictionaryKind) {
     fbb_.AddElement<int16_t>(DictionaryEncoding::VT_DICTIONARYKIND, static_cast<int16_t>(dictionaryKind), 0);
   }
   explicit DictionaryEncodingBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1563,9 +1634,9 @@ struct DictionaryEncodingBuilder {
 inline flatbuffers::Offset<DictionaryEncoding> CreateDictionaryEncoding(
     flatbuffers::FlatBufferBuilder &_fbb,
     int64_t id = 0,
-    flatbuffers::Offset<Int> indexType = 0,
+    flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indexType = 0,
     bool isOrdered = false,
-    DictionaryKind dictionaryKind = DictionaryKind::DenseArray) {
+    org::apache::arrow::flatbuf::DictionaryKind dictionaryKind = org::apache::arrow::flatbuf::DictionaryKind::DenseArray) {
   DictionaryEncodingBuilder builder_(_fbb);
   builder_.add_id(id);
   builder_.add_indexType(indexType);
@@ -1578,6 +1649,7 @@ inline flatbuffers::Offset<DictionaryEncoding> CreateDictionaryEncoding(
 /// A field represents a named column in a record / row batch or child of a
 /// nested type.
 struct Field FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef FieldBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NAME = 4,
     VT_NULLABLE = 6,
@@ -1595,89 +1667,89 @@ struct Field FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   bool nullable() const {
     return GetField<uint8_t>(VT_NULLABLE, 0) != 0;
   }
-  Type type_type() const {
-    return static_cast<Type>(GetField<uint8_t>(VT_TYPE_TYPE, 0));
+  org::apache::arrow::flatbuf::Type type_type() const {
+    return static_cast<org::apache::arrow::flatbuf::Type>(GetField<uint8_t>(VT_TYPE_TYPE, 0));
   }
   /// This is the type of the decoded value if the field is dictionary encoded.
   const void *type() const {
     return GetPointer<const void *>(VT_TYPE);
   }
   template<typename T> const T *type_as() const;
-  const Null *type_as_Null() const {
-    return type_type() == Type::Null ? static_cast<const Null *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Null *type_as_Null() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Null ? static_cast<const org::apache::arrow::flatbuf::Null *>(type()) : nullptr;
   }
-  const Int *type_as_Int() const {
-    return type_type() == Type::Int ? static_cast<const Int *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Int *type_as_Int() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Int ? static_cast<const org::apache::arrow::flatbuf::Int *>(type()) : nullptr;
   }
-  const FloatingPoint *type_as_FloatingPoint() const {
-    return type_type() == Type::FloatingPoint ? static_cast<const FloatingPoint *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::FloatingPoint *type_as_FloatingPoint() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::FloatingPoint ? static_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(type()) : nullptr;
   }
-  const Binary *type_as_Binary() const {
-    return type_type() == Type::Binary ? static_cast<const Binary *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Binary *type_as_Binary() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Binary ? static_cast<const org::apache::arrow::flatbuf::Binary *>(type()) : nullptr;
   }
-  const Utf8 *type_as_Utf8() const {
-    return type_type() == Type::Utf8 ? static_cast<const Utf8 *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Utf8 *type_as_Utf8() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Utf8 ? static_cast<const org::apache::arrow::flatbuf::Utf8 *>(type()) : nullptr;
   }
-  const Bool *type_as_Bool() const {
-    return type_type() == Type::Bool ? static_cast<const Bool *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Bool *type_as_Bool() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Bool ? static_cast<const org::apache::arrow::flatbuf::Bool *>(type()) : nullptr;
   }
-  const Decimal *type_as_Decimal() const {
-    return type_type() == Type::Decimal ? static_cast<const Decimal *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Decimal *type_as_Decimal() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Decimal ? static_cast<const org::apache::arrow::flatbuf::Decimal *>(type()) : nullptr;
   }
-  const Date *type_as_Date() const {
-    return type_type() == Type::Date ? static_cast<const Date *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Date *type_as_Date() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Date ? static_cast<const org::apache::arrow::flatbuf::Date *>(type()) : nullptr;
   }
-  const Time *type_as_Time() const {
-    return type_type() == Type::Time ? static_cast<const Time *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Time *type_as_Time() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Time ? static_cast<const org::apache::arrow::flatbuf::Time *>(type()) : nullptr;
   }
-  const Timestamp *type_as_Timestamp() const {
-    return type_type() == Type::Timestamp ? static_cast<const Timestamp *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Timestamp *type_as_Timestamp() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Timestamp ? static_cast<const org::apache::arrow::flatbuf::Timestamp *>(type()) : nullptr;
   }
-  const Interval *type_as_Interval() const {
-    return type_type() == Type::Interval ? static_cast<const Interval *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Interval *type_as_Interval() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Interval ? static_cast<const org::apache::arrow::flatbuf::Interval *>(type()) : nullptr;
   }
-  const List *type_as_List() const {
-    return type_type() == Type::List ? static_cast<const List *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::List *type_as_List() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::List ? static_cast<const org::apache::arrow::flatbuf::List *>(type()) : nullptr;
   }
-  const Struct_ *type_as_Struct_() const {
-    return type_type() == Type::Struct_ ? static_cast<const Struct_ *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Struct_ *type_as_Struct_() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Struct_ ? static_cast<const org::apache::arrow::flatbuf::Struct_ *>(type()) : nullptr;
   }
-  const Union *type_as_Union() const {
-    return type_type() == Type::Union ? static_cast<const Union *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Union *type_as_Union() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Union ? static_cast<const org::apache::arrow::flatbuf::Union *>(type()) : nullptr;
   }
-  const FixedSizeBinary *type_as_FixedSizeBinary() const {
-    return type_type() == Type::FixedSizeBinary ? static_cast<const FixedSizeBinary *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::FixedSizeBinary *type_as_FixedSizeBinary() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeBinary ? static_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(type()) : nullptr;
   }
-  const FixedSizeList *type_as_FixedSizeList() const {
-    return type_type() == Type::FixedSizeList ? static_cast<const FixedSizeList *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::FixedSizeList *type_as_FixedSizeList() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeList ? static_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(type()) : nullptr;
   }
-  const Map *type_as_Map() const {
-    return type_type() == Type::Map ? static_cast<const Map *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Map *type_as_Map() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Map ? static_cast<const org::apache::arrow::flatbuf::Map *>(type()) : nullptr;
   }
-  const Duration *type_as_Duration() const {
-    return type_type() == Type::Duration ? static_cast<const Duration *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Duration *type_as_Duration() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Duration ? static_cast<const org::apache::arrow::flatbuf::Duration *>(type()) : nullptr;
   }
-  const LargeBinary *type_as_LargeBinary() const {
-    return type_type() == Type::LargeBinary ? static_cast<const LargeBinary *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::LargeBinary *type_as_LargeBinary() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::LargeBinary ? static_cast<const org::apache::arrow::flatbuf::LargeBinary *>(type()) : nullptr;
   }
-  const LargeUtf8 *type_as_LargeUtf8() const {
-    return type_type() == Type::LargeUtf8 ? static_cast<const LargeUtf8 *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::LargeUtf8 *type_as_LargeUtf8() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::LargeUtf8 ? static_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(type()) : nullptr;
   }
-  const LargeList *type_as_LargeList() const {
-    return type_type() == Type::LargeList ? static_cast<const LargeList *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::LargeList *type_as_LargeList() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::LargeList ? static_cast<const org::apache::arrow::flatbuf::LargeList *>(type()) : nullptr;
   }
   /// Present only if the field is dictionary encoded.
-  const DictionaryEncoding *dictionary() const {
-    return GetPointer<const DictionaryEncoding *>(VT_DICTIONARY);
+  const org::apache::arrow::flatbuf::DictionaryEncoding *dictionary() const {
+    return GetPointer<const org::apache::arrow::flatbuf::DictionaryEncoding *>(VT_DICTIONARY);
   }
   /// children apply only to nested data types like Struct, List and Union. For
   /// primitive types children will have length 0.
-  const flatbuffers::Vector<flatbuffers::Offset<Field>> *children() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Field>> *>(VT_CHILDREN);
+  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>> *children() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>> *>(VT_CHILDREN);
   }
   /// User-defined metadata
-  const flatbuffers::Vector<flatbuffers::Offset<KeyValue>> *custom_metadata() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<KeyValue>> *>(VT_CUSTOM_METADATA);
+  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *>(VT_CUSTOM_METADATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1699,91 +1771,92 @@ struct Field FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
 };
 
-template<> inline const Null *Field::type_as<Null>() const {
+template<> inline const org::apache::arrow::flatbuf::Null *Field::type_as<org::apache::arrow::flatbuf::Null>() const {
   return type_as_Null();
 }
 
-template<> inline const Int *Field::type_as<Int>() const {
+template<> inline const org::apache::arrow::flatbuf::Int *Field::type_as<org::apache::arrow::flatbuf::Int>() const {
   return type_as_Int();
 }
 
-template<> inline const FloatingPoint *Field::type_as<FloatingPoint>() const {
+template<> inline const org::apache::arrow::flatbuf::FloatingPoint *Field::type_as<org::apache::arrow::flatbuf::FloatingPoint>() const {
   return type_as_FloatingPoint();
 }
 
-template<> inline const Binary *Field::type_as<Binary>() const {
+template<> inline const org::apache::arrow::flatbuf::Binary *Field::type_as<org::apache::arrow::flatbuf::Binary>() const {
   return type_as_Binary();
 }
 
-template<> inline const Utf8 *Field::type_as<Utf8>() const {
+template<> inline const org::apache::arrow::flatbuf::Utf8 *Field::type_as<org::apache::arrow::flatbuf::Utf8>() const {
   return type_as_Utf8();
 }
 
-template<> inline const Bool *Field::type_as<Bool>() const {
+template<> inline const org::apache::arrow::flatbuf::Bool *Field::type_as<org::apache::arrow::flatbuf::Bool>() const {
   return type_as_Bool();
 }
 
-template<> inline const Decimal *Field::type_as<Decimal>() const {
+template<> inline const org::apache::arrow::flatbuf::Decimal *Field::type_as<org::apache::arrow::flatbuf::Decimal>() const {
   return type_as_Decimal();
 }
 
-template<> inline const Date *Field::type_as<Date>() const {
+template<> inline const org::apache::arrow::flatbuf::Date *Field::type_as<org::apache::arrow::flatbuf::Date>() const {
   return type_as_Date();
 }
 
-template<> inline const Time *Field::type_as<Time>() const {
+template<> inline const org::apache::arrow::flatbuf::Time *Field::type_as<org::apache::arrow::flatbuf::Time>() const {
   return type_as_Time();
 }
 
-template<> inline const Timestamp *Field::type_as<Timestamp>() const {
+template<> inline const org::apache::arrow::flatbuf::Timestamp *Field::type_as<org::apache::arrow::flatbuf::Timestamp>() const {
   return type_as_Timestamp();
 }
 
-template<> inline const Interval *Field::type_as<Interval>() const {
+template<> inline const org::apache::arrow::flatbuf::Interval *Field::type_as<org::apache::arrow::flatbuf::Interval>() const {
   return type_as_Interval();
 }
 
-template<> inline const List *Field::type_as<List>() const {
+template<> inline const org::apache::arrow::flatbuf::List *Field::type_as<org::apache::arrow::flatbuf::List>() const {
   return type_as_List();
 }
 
-template<> inline const Struct_ *Field::type_as<Struct_>() const {
+template<> inline const org::apache::arrow::flatbuf::Struct_ *Field::type_as<org::apache::arrow::flatbuf::Struct_>() const {
   return type_as_Struct_();
 }
 
-template<> inline const Union *Field::type_as<Union>() const {
+template<> inline const org::apache::arrow::flatbuf::Union *Field::type_as<org::apache::arrow::flatbuf::Union>() const {
   return type_as_Union();
 }
 
-template<> inline const FixedSizeBinary *Field::type_as<FixedSizeBinary>() const {
+template<> inline const org::apache::arrow::flatbuf::FixedSizeBinary *Field::type_as<org::apache::arrow::flatbuf::FixedSizeBinary>() const {
   return type_as_FixedSizeBinary();
 }
 
-template<> inline const FixedSizeList *Field::type_as<FixedSizeList>() const {
+template<> inline const org::apache::arrow::flatbuf::FixedSizeList *Field::type_as<org::apache::arrow::flatbuf::FixedSizeList>() const {
   return type_as_FixedSizeList();
 }
 
-template<> inline const Map *Field::type_as<Map>() const {
+template<> inline const org::apache::arrow::flatbuf::Map *Field::type_as<org::apache::arrow::flatbuf::Map>() const {
   return type_as_Map();
 }
 
-template<> inline const Duration *Field::type_as<Duration>() const {
+template<> inline const org::apache::arrow::flatbuf::Duration *Field::type_as<org::apache::arrow::flatbuf::Duration>() const {
   return type_as_Duration();
 }
 
-template<> inline const LargeBinary *Field::type_as<LargeBinary>() const {
+template<> inline const org::apache::arrow::flatbuf::LargeBinary *Field::type_as<org::apache::arrow::flatbuf::LargeBinary>() const {
   return type_as_LargeBinary();
 }
 
-template<> inline const LargeUtf8 *Field::type_as<LargeUtf8>() const {
+template<> inline const org::apache::arrow::flatbuf::LargeUtf8 *Field::type_as<org::apache::arrow::flatbuf::LargeUtf8>() const {
   return type_as_LargeUtf8();
 }
 
-template<> inline const LargeList *Field::type_as<LargeList>() const {
+template<> inline const org::apache::arrow::flatbuf::LargeList *Field::type_as<org::apache::arrow::flatbuf::LargeList>() const {
   return type_as_LargeList();
 }
 
 struct FieldBuilder {
+  typedef Field Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
@@ -1792,19 +1865,19 @@ struct FieldBuilder {
   void add_nullable(bool nullable) {
     fbb_.AddElement<uint8_t>(Field::VT_NULLABLE, static_cast<uint8_t>(nullable), 0);
   }
-  void add_type_type(Type type_type) {
+  void add_type_type(org::apache::arrow::flatbuf::Type type_type) {
     fbb_.AddElement<uint8_t>(Field::VT_TYPE_TYPE, static_cast<uint8_t>(type_type), 0);
   }
   void add_type(flatbuffers::Offset<void> type) {
     fbb_.AddOffset(Field::VT_TYPE, type);
   }
-  void add_dictionary(flatbuffers::Offset<DictionaryEncoding> dictionary) {
+  void add_dictionary(flatbuffers::Offset<org::apache::arrow::flatbuf::DictionaryEncoding> dictionary) {
     fbb_.AddOffset(Field::VT_DICTIONARY, dictionary);
   }
-  void add_children(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Field>>> children) {
+  void add_children(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>> children) {
     fbb_.AddOffset(Field::VT_CHILDREN, children);
   }
-  void add_custom_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<KeyValue>>> custom_metadata) {
+  void add_custom_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata) {
     fbb_.AddOffset(Field::VT_CUSTOM_METADATA, custom_metadata);
   }
   explicit FieldBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1823,11 +1896,11 @@ inline flatbuffers::Offset<Field> CreateField(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> name = 0,
     bool nullable = false,
-    Type type_type = Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
     flatbuffers::Offset<void> type = 0,
-    flatbuffers::Offset<DictionaryEncoding> dictionary = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Field>>> children = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<KeyValue>>> custom_metadata = 0) {
+    flatbuffers::Offset<org::apache::arrow::flatbuf::DictionaryEncoding> dictionary = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>> children = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata = 0) {
   FieldBuilder builder_(_fbb);
   builder_.add_custom_metadata(custom_metadata);
   builder_.add_children(children);
@@ -1843,14 +1916,14 @@ inline flatbuffers::Offset<Field> CreateFieldDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
     bool nullable = false,
-    Type type_type = Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
     flatbuffers::Offset<void> type = 0,
-    flatbuffers::Offset<DictionaryEncoding> dictionary = 0,
-    const std::vector<flatbuffers::Offset<Field>> *children = nullptr,
-    const std::vector<flatbuffers::Offset<KeyValue>> *custom_metadata = nullptr) {
+    flatbuffers::Offset<org::apache::arrow::flatbuf::DictionaryEncoding> dictionary = 0,
+    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>> *children = nullptr,
+    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
-  auto children__ = children ? _fbb.CreateVector<flatbuffers::Offset<Field>>(*children) : 0;
-  auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<flatbuffers::Offset<KeyValue>>(*custom_metadata) : 0;
+  auto children__ = children ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>(*children) : 0;
+  auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>(*custom_metadata) : 0;
   return org::apache::arrow::flatbuf::CreateField(
       _fbb,
       name__,
@@ -1865,6 +1938,7 @@ inline flatbuffers::Offset<Field> CreateFieldDirect(
 /// ----------------------------------------------------------------------
 /// A Schema describes the columns in a row batch
 struct Schema FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef SchemaBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ENDIANNESS = 4,
     VT_FIELDS = 6,
@@ -1873,14 +1947,14 @@ struct Schema FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   /// endianness of the buffer
   /// it is Little Endian by default
   /// if endianness doesn't match the underlying system then the vectors need to be converted
-  Endianness endianness() const {
-    return static_cast<Endianness>(GetField<int16_t>(VT_ENDIANNESS, 0));
+  org::apache::arrow::flatbuf::Endianness endianness() const {
+    return static_cast<org::apache::arrow::flatbuf::Endianness>(GetField<int16_t>(VT_ENDIANNESS, 0));
   }
-  const flatbuffers::Vector<flatbuffers::Offset<Field>> *fields() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Field>> *>(VT_FIELDS);
+  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>> *fields() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>> *>(VT_FIELDS);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<KeyValue>> *custom_metadata() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<KeyValue>> *>(VT_CUSTOM_METADATA);
+  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *>(VT_CUSTOM_METADATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1896,15 +1970,16 @@ struct Schema FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct SchemaBuilder {
+  typedef Schema Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_endianness(Endianness endianness) {
+  void add_endianness(org::apache::arrow::flatbuf::Endianness endianness) {
     fbb_.AddElement<int16_t>(Schema::VT_ENDIANNESS, static_cast<int16_t>(endianness), 0);
   }
-  void add_fields(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Field>>> fields) {
+  void add_fields(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>> fields) {
     fbb_.AddOffset(Schema::VT_FIELDS, fields);
   }
-  void add_custom_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<KeyValue>>> custom_metadata) {
+  void add_custom_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata) {
     fbb_.AddOffset(Schema::VT_CUSTOM_METADATA, custom_metadata);
   }
   explicit SchemaBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1921,9 +1996,9 @@ struct SchemaBuilder {
 
 inline flatbuffers::Offset<Schema> CreateSchema(
     flatbuffers::FlatBufferBuilder &_fbb,
-    Endianness endianness = Endianness::Little,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Field>>> fields = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<KeyValue>>> custom_metadata = 0) {
+    org::apache::arrow::flatbuf::Endianness endianness = org::apache::arrow::flatbuf::Endianness::Little,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>> fields = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata = 0) {
   SchemaBuilder builder_(_fbb);
   builder_.add_custom_metadata(custom_metadata);
   builder_.add_fields(fields);
@@ -1933,11 +2008,11 @@ inline flatbuffers::Offset<Schema> CreateSchema(
 
 inline flatbuffers::Offset<Schema> CreateSchemaDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    Endianness endianness = Endianness::Little,
-    const std::vector<flatbuffers::Offset<Field>> *fields = nullptr,
-    const std::vector<flatbuffers::Offset<KeyValue>> *custom_metadata = nullptr) {
-  auto fields__ = fields ? _fbb.CreateVector<flatbuffers::Offset<Field>>(*fields) : 0;
-  auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<flatbuffers::Offset<KeyValue>>(*custom_metadata) : 0;
+    org::apache::arrow::flatbuf::Endianness endianness = org::apache::arrow::flatbuf::Endianness::Little,
+    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>> *fields = nullptr,
+    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata = nullptr) {
+  auto fields__ = fields ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>(*fields) : 0;
+  auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>(*custom_metadata) : 0;
   return org::apache::arrow::flatbuf::CreateSchema(
       _fbb,
       endianness,
@@ -1951,90 +2026,90 @@ inline bool VerifyType(flatbuffers::Verifier &verifier, const void *obj, Type ty
       return true;
     }
     case Type::Null: {
-      auto ptr = reinterpret_cast<const Null *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Null *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Int: {
-      auto ptr = reinterpret_cast<const Int *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Int *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::FloatingPoint: {
-      auto ptr = reinterpret_cast<const FloatingPoint *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Binary: {
-      auto ptr = reinterpret_cast<const Binary *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Binary *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Utf8: {
-      auto ptr = reinterpret_cast<const Utf8 *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Utf8 *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Bool: {
-      auto ptr = reinterpret_cast<const Bool *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Bool *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Decimal: {
-      auto ptr = reinterpret_cast<const Decimal *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Decimal *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Date: {
-      auto ptr = reinterpret_cast<const Date *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Date *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Time: {
-      auto ptr = reinterpret_cast<const Time *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Time *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Timestamp: {
-      auto ptr = reinterpret_cast<const Timestamp *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Timestamp *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Interval: {
-      auto ptr = reinterpret_cast<const Interval *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Interval *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::List: {
-      auto ptr = reinterpret_cast<const List *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::List *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Struct_: {
-      auto ptr = reinterpret_cast<const Struct_ *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Struct_ *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Union: {
-      auto ptr = reinterpret_cast<const Union *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Union *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::FixedSizeBinary: {
-      auto ptr = reinterpret_cast<const FixedSizeBinary *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::FixedSizeList: {
-      auto ptr = reinterpret_cast<const FixedSizeList *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Map: {
-      auto ptr = reinterpret_cast<const Map *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Map *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::Duration: {
-      auto ptr = reinterpret_cast<const Duration *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Duration *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::LargeBinary: {
-      auto ptr = reinterpret_cast<const LargeBinary *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::LargeBinary *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::LargeUtf8: {
-      auto ptr = reinterpret_cast<const LargeUtf8 *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case Type::LargeList: {
-      auto ptr = reinterpret_cast<const LargeList *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::LargeList *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    default: return false;
+    default: return true;
   }
 }
 

--- a/cpp/src/generated/SparseTensor_generated.h
+++ b/cpp/src/generated/SparseTensor_generated.h
@@ -15,10 +15,13 @@ namespace arrow {
 namespace flatbuf {
 
 struct SparseTensorIndexCOO;
+struct SparseTensorIndexCOOBuilder;
 
 struct SparseMatrixIndexCSX;
+struct SparseMatrixIndexCSXBuilder;
 
 struct SparseTensor;
+struct SparseTensorBuilder;
 
 enum class SparseMatrixCompressedAxis : int16_t {
   Row = 0,
@@ -36,7 +39,7 @@ inline const SparseMatrixCompressedAxis (&EnumValuesSparseMatrixCompressedAxis()
 }
 
 inline const char * const *EnumNamesSparseMatrixCompressedAxis() {
-  static const char * const names[] = {
+  static const char * const names[3] = {
     "Row",
     "Column",
     nullptr
@@ -45,7 +48,7 @@ inline const char * const *EnumNamesSparseMatrixCompressedAxis() {
 }
 
 inline const char *EnumNameSparseMatrixCompressedAxis(SparseMatrixCompressedAxis e) {
-  if (e < SparseMatrixCompressedAxis::Row || e > SparseMatrixCompressedAxis::Column) return "";
+  if (flatbuffers::IsOutRange(e, SparseMatrixCompressedAxis::Row, SparseMatrixCompressedAxis::Column)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesSparseMatrixCompressedAxis()[index];
 }
@@ -68,7 +71,7 @@ inline const SparseTensorIndex (&EnumValuesSparseTensorIndex())[3] {
 }
 
 inline const char * const *EnumNamesSparseTensorIndex() {
-  static const char * const names[] = {
+  static const char * const names[4] = {
     "NONE",
     "SparseTensorIndexCOO",
     "SparseMatrixIndexCSX",
@@ -78,7 +81,7 @@ inline const char * const *EnumNamesSparseTensorIndex() {
 }
 
 inline const char *EnumNameSparseTensorIndex(SparseTensorIndex e) {
-  if (e < SparseTensorIndex::NONE || e > SparseTensorIndex::SparseMatrixIndexCSX) return "";
+  if (flatbuffers::IsOutRange(e, SparseTensorIndex::NONE, SparseTensorIndex::SparseMatrixIndexCSX)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesSparseTensorIndex()[index];
 }
@@ -87,11 +90,11 @@ template<typename T> struct SparseTensorIndexTraits {
   static const SparseTensorIndex enum_value = SparseTensorIndex::NONE;
 };
 
-template<> struct SparseTensorIndexTraits<SparseTensorIndexCOO> {
+template<> struct SparseTensorIndexTraits<org::apache::arrow::flatbuf::SparseTensorIndexCOO> {
   static const SparseTensorIndex enum_value = SparseTensorIndex::SparseTensorIndexCOO;
 };
 
-template<> struct SparseTensorIndexTraits<SparseMatrixIndexCSX> {
+template<> struct SparseTensorIndexTraits<org::apache::arrow::flatbuf::SparseMatrixIndexCSX> {
   static const SparseTensorIndex enum_value = SparseTensorIndex::SparseMatrixIndexCSX;
 };
 
@@ -129,14 +132,15 @@ bool VerifySparseTensorIndexVector(flatbuffers::Verifier &verifier, const flatbu
 ///
 /// Note that the indices are sorted in lexicographical order.
 struct SparseTensorIndexCOO FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef SparseTensorIndexCOOBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_INDICESTYPE = 4,
     VT_INDICESSTRIDES = 6,
     VT_INDICESBUFFER = 8
   };
   /// The type of values in indicesBuffer
-  const Int *indicesType() const {
-    return GetPointer<const Int *>(VT_INDICESTYPE);
+  const org::apache::arrow::flatbuf::Int *indicesType() const {
+    return GetPointer<const org::apache::arrow::flatbuf::Int *>(VT_INDICESTYPE);
   }
   /// Non-negative byte offsets to advance one value cell along each dimension
   /// If omitted, default to row-major order (C-like).
@@ -144,8 +148,8 @@ struct SparseTensorIndexCOO FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_INDICESSTRIDES);
   }
   /// The location and size of the indices matrix's data
-  const Buffer *indicesBuffer() const {
-    return GetStruct<const Buffer *>(VT_INDICESBUFFER);
+  const org::apache::arrow::flatbuf::Buffer *indicesBuffer() const {
+    return GetStruct<const org::apache::arrow::flatbuf::Buffer *>(VT_INDICESBUFFER);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -153,21 +157,22 @@ struct SparseTensorIndexCOO FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
            verifier.VerifyTable(indicesType()) &&
            VerifyOffset(verifier, VT_INDICESSTRIDES) &&
            verifier.VerifyVector(indicesStrides()) &&
-           VerifyFieldRequired<Buffer>(verifier, VT_INDICESBUFFER) &&
+           VerifyFieldRequired<org::apache::arrow::flatbuf::Buffer>(verifier, VT_INDICESBUFFER) &&
            verifier.EndTable();
   }
 };
 
 struct SparseTensorIndexCOOBuilder {
+  typedef SparseTensorIndexCOO Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_indicesType(flatbuffers::Offset<Int> indicesType) {
+  void add_indicesType(flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indicesType) {
     fbb_.AddOffset(SparseTensorIndexCOO::VT_INDICESTYPE, indicesType);
   }
   void add_indicesStrides(flatbuffers::Offset<flatbuffers::Vector<int64_t>> indicesStrides) {
     fbb_.AddOffset(SparseTensorIndexCOO::VT_INDICESSTRIDES, indicesStrides);
   }
-  void add_indicesBuffer(const Buffer *indicesBuffer) {
+  void add_indicesBuffer(const org::apache::arrow::flatbuf::Buffer *indicesBuffer) {
     fbb_.AddStruct(SparseTensorIndexCOO::VT_INDICESBUFFER, indicesBuffer);
   }
   explicit SparseTensorIndexCOOBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -186,9 +191,9 @@ struct SparseTensorIndexCOOBuilder {
 
 inline flatbuffers::Offset<SparseTensorIndexCOO> CreateSparseTensorIndexCOO(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<Int> indicesType = 0,
+    flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indicesType = 0,
     flatbuffers::Offset<flatbuffers::Vector<int64_t>> indicesStrides = 0,
-    const Buffer *indicesBuffer = 0) {
+    const org::apache::arrow::flatbuf::Buffer *indicesBuffer = 0) {
   SparseTensorIndexCOOBuilder builder_(_fbb);
   builder_.add_indicesBuffer(indicesBuffer);
   builder_.add_indicesStrides(indicesStrides);
@@ -198,9 +203,9 @@ inline flatbuffers::Offset<SparseTensorIndexCOO> CreateSparseTensorIndexCOO(
 
 inline flatbuffers::Offset<SparseTensorIndexCOO> CreateSparseTensorIndexCOODirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<Int> indicesType = 0,
+    flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indicesType = 0,
     const std::vector<int64_t> *indicesStrides = nullptr,
-    const Buffer *indicesBuffer = 0) {
+    const org::apache::arrow::flatbuf::Buffer *indicesBuffer = 0) {
   auto indicesStrides__ = indicesStrides ? _fbb.CreateVector<int64_t>(*indicesStrides) : 0;
   return org::apache::arrow::flatbuf::CreateSparseTensorIndexCOO(
       _fbb,
@@ -211,6 +216,7 @@ inline flatbuffers::Offset<SparseTensorIndexCOO> CreateSparseTensorIndexCOODirec
 
 /// Compressed Sparse format, that is matrix-specific.
 struct SparseMatrixIndexCSX FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef SparseMatrixIndexCSXBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_COMPRESSEDAXIS = 4,
     VT_INDPTRTYPE = 6,
@@ -219,12 +225,12 @@ struct SparseMatrixIndexCSX FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
     VT_INDICESBUFFER = 12
   };
   /// Which axis, row or column, is compressed
-  SparseMatrixCompressedAxis compressedAxis() const {
-    return static_cast<SparseMatrixCompressedAxis>(GetField<int16_t>(VT_COMPRESSEDAXIS, 0));
+  org::apache::arrow::flatbuf::SparseMatrixCompressedAxis compressedAxis() const {
+    return static_cast<org::apache::arrow::flatbuf::SparseMatrixCompressedAxis>(GetField<int16_t>(VT_COMPRESSEDAXIS, 0));
   }
   /// The type of values in indptrBuffer
-  const Int *indptrType() const {
-    return GetPointer<const Int *>(VT_INDPTRTYPE);
+  const org::apache::arrow::flatbuf::Int *indptrType() const {
+    return GetPointer<const org::apache::arrow::flatbuf::Int *>(VT_INDPTRTYPE);
   }
   /// indptrBuffer stores the location and size of indptr array that
   /// represents the range of the rows.
@@ -248,12 +254,12 @@ struct SparseMatrixIndexCSX FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   /// And the indptr of X is:
   ///
   ///   indptr(X) = [0, 2, 3, 5, 5, 8, 10].
-  const Buffer *indptrBuffer() const {
-    return GetStruct<const Buffer *>(VT_INDPTRBUFFER);
+  const org::apache::arrow::flatbuf::Buffer *indptrBuffer() const {
+    return GetStruct<const org::apache::arrow::flatbuf::Buffer *>(VT_INDPTRBUFFER);
   }
   /// The type of values in indicesBuffer
-  const Int *indicesType() const {
-    return GetPointer<const Int *>(VT_INDICESTYPE);
+  const org::apache::arrow::flatbuf::Int *indicesType() const {
+    return GetPointer<const org::apache::arrow::flatbuf::Int *>(VT_INDICESTYPE);
   }
   /// indicesBuffer stores the location and size of the array that
   /// contains the column indices of the corresponding non-zero values.
@@ -264,38 +270,39 @@ struct SparseMatrixIndexCSX FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   ///   indices(X) = [1, 2, 2, 1, 3, 0, 2, 3, 1].
   ///
   /// Note that the indices are sorted in lexicographical order for each row.
-  const Buffer *indicesBuffer() const {
-    return GetStruct<const Buffer *>(VT_INDICESBUFFER);
+  const org::apache::arrow::flatbuf::Buffer *indicesBuffer() const {
+    return GetStruct<const org::apache::arrow::flatbuf::Buffer *>(VT_INDICESBUFFER);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<int16_t>(verifier, VT_COMPRESSEDAXIS) &&
            VerifyOffsetRequired(verifier, VT_INDPTRTYPE) &&
            verifier.VerifyTable(indptrType()) &&
-           VerifyFieldRequired<Buffer>(verifier, VT_INDPTRBUFFER) &&
+           VerifyFieldRequired<org::apache::arrow::flatbuf::Buffer>(verifier, VT_INDPTRBUFFER) &&
            VerifyOffsetRequired(verifier, VT_INDICESTYPE) &&
            verifier.VerifyTable(indicesType()) &&
-           VerifyFieldRequired<Buffer>(verifier, VT_INDICESBUFFER) &&
+           VerifyFieldRequired<org::apache::arrow::flatbuf::Buffer>(verifier, VT_INDICESBUFFER) &&
            verifier.EndTable();
   }
 };
 
 struct SparseMatrixIndexCSXBuilder {
+  typedef SparseMatrixIndexCSX Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_compressedAxis(SparseMatrixCompressedAxis compressedAxis) {
+  void add_compressedAxis(org::apache::arrow::flatbuf::SparseMatrixCompressedAxis compressedAxis) {
     fbb_.AddElement<int16_t>(SparseMatrixIndexCSX::VT_COMPRESSEDAXIS, static_cast<int16_t>(compressedAxis), 0);
   }
-  void add_indptrType(flatbuffers::Offset<Int> indptrType) {
+  void add_indptrType(flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indptrType) {
     fbb_.AddOffset(SparseMatrixIndexCSX::VT_INDPTRTYPE, indptrType);
   }
-  void add_indptrBuffer(const Buffer *indptrBuffer) {
+  void add_indptrBuffer(const org::apache::arrow::flatbuf::Buffer *indptrBuffer) {
     fbb_.AddStruct(SparseMatrixIndexCSX::VT_INDPTRBUFFER, indptrBuffer);
   }
-  void add_indicesType(flatbuffers::Offset<Int> indicesType) {
+  void add_indicesType(flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indicesType) {
     fbb_.AddOffset(SparseMatrixIndexCSX::VT_INDICESTYPE, indicesType);
   }
-  void add_indicesBuffer(const Buffer *indicesBuffer) {
+  void add_indicesBuffer(const org::apache::arrow::flatbuf::Buffer *indicesBuffer) {
     fbb_.AddStruct(SparseMatrixIndexCSX::VT_INDICESBUFFER, indicesBuffer);
   }
   explicit SparseMatrixIndexCSXBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -316,11 +323,11 @@ struct SparseMatrixIndexCSXBuilder {
 
 inline flatbuffers::Offset<SparseMatrixIndexCSX> CreateSparseMatrixIndexCSX(
     flatbuffers::FlatBufferBuilder &_fbb,
-    SparseMatrixCompressedAxis compressedAxis = SparseMatrixCompressedAxis::Row,
-    flatbuffers::Offset<Int> indptrType = 0,
-    const Buffer *indptrBuffer = 0,
-    flatbuffers::Offset<Int> indicesType = 0,
-    const Buffer *indicesBuffer = 0) {
+    org::apache::arrow::flatbuf::SparseMatrixCompressedAxis compressedAxis = org::apache::arrow::flatbuf::SparseMatrixCompressedAxis::Row,
+    flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indptrType = 0,
+    const org::apache::arrow::flatbuf::Buffer *indptrBuffer = 0,
+    flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indicesType = 0,
+    const org::apache::arrow::flatbuf::Buffer *indicesBuffer = 0) {
   SparseMatrixIndexCSXBuilder builder_(_fbb);
   builder_.add_indicesBuffer(indicesBuffer);
   builder_.add_indicesType(indicesType);
@@ -331,6 +338,7 @@ inline flatbuffers::Offset<SparseMatrixIndexCSX> CreateSparseMatrixIndexCSX(
 }
 
 struct SparseTensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef SparseTensorBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_TYPE_TYPE = 4,
     VT_TYPE = 6,
@@ -340,8 +348,8 @@ struct SparseTensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_SPARSEINDEX = 14,
     VT_DATA = 16
   };
-  Type type_type() const {
-    return static_cast<Type>(GetField<uint8_t>(VT_TYPE_TYPE, 0));
+  org::apache::arrow::flatbuf::Type type_type() const {
+    return static_cast<org::apache::arrow::flatbuf::Type>(GetField<uint8_t>(VT_TYPE_TYPE, 0));
   }
   /// The type of data contained in a value cell.
   /// Currently only fixed-width value types are supported,
@@ -350,94 +358,94 @@ struct SparseTensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return GetPointer<const void *>(VT_TYPE);
   }
   template<typename T> const T *type_as() const;
-  const Null *type_as_Null() const {
-    return type_type() == Type::Null ? static_cast<const Null *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Null *type_as_Null() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Null ? static_cast<const org::apache::arrow::flatbuf::Null *>(type()) : nullptr;
   }
-  const Int *type_as_Int() const {
-    return type_type() == Type::Int ? static_cast<const Int *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Int *type_as_Int() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Int ? static_cast<const org::apache::arrow::flatbuf::Int *>(type()) : nullptr;
   }
-  const FloatingPoint *type_as_FloatingPoint() const {
-    return type_type() == Type::FloatingPoint ? static_cast<const FloatingPoint *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::FloatingPoint *type_as_FloatingPoint() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::FloatingPoint ? static_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(type()) : nullptr;
   }
-  const Binary *type_as_Binary() const {
-    return type_type() == Type::Binary ? static_cast<const Binary *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Binary *type_as_Binary() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Binary ? static_cast<const org::apache::arrow::flatbuf::Binary *>(type()) : nullptr;
   }
-  const Utf8 *type_as_Utf8() const {
-    return type_type() == Type::Utf8 ? static_cast<const Utf8 *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Utf8 *type_as_Utf8() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Utf8 ? static_cast<const org::apache::arrow::flatbuf::Utf8 *>(type()) : nullptr;
   }
-  const Bool *type_as_Bool() const {
-    return type_type() == Type::Bool ? static_cast<const Bool *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Bool *type_as_Bool() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Bool ? static_cast<const org::apache::arrow::flatbuf::Bool *>(type()) : nullptr;
   }
-  const Decimal *type_as_Decimal() const {
-    return type_type() == Type::Decimal ? static_cast<const Decimal *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Decimal *type_as_Decimal() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Decimal ? static_cast<const org::apache::arrow::flatbuf::Decimal *>(type()) : nullptr;
   }
-  const Date *type_as_Date() const {
-    return type_type() == Type::Date ? static_cast<const Date *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Date *type_as_Date() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Date ? static_cast<const org::apache::arrow::flatbuf::Date *>(type()) : nullptr;
   }
-  const Time *type_as_Time() const {
-    return type_type() == Type::Time ? static_cast<const Time *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Time *type_as_Time() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Time ? static_cast<const org::apache::arrow::flatbuf::Time *>(type()) : nullptr;
   }
-  const Timestamp *type_as_Timestamp() const {
-    return type_type() == Type::Timestamp ? static_cast<const Timestamp *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Timestamp *type_as_Timestamp() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Timestamp ? static_cast<const org::apache::arrow::flatbuf::Timestamp *>(type()) : nullptr;
   }
-  const Interval *type_as_Interval() const {
-    return type_type() == Type::Interval ? static_cast<const Interval *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Interval *type_as_Interval() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Interval ? static_cast<const org::apache::arrow::flatbuf::Interval *>(type()) : nullptr;
   }
-  const List *type_as_List() const {
-    return type_type() == Type::List ? static_cast<const List *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::List *type_as_List() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::List ? static_cast<const org::apache::arrow::flatbuf::List *>(type()) : nullptr;
   }
-  const Struct_ *type_as_Struct_() const {
-    return type_type() == Type::Struct_ ? static_cast<const Struct_ *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Struct_ *type_as_Struct_() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Struct_ ? static_cast<const org::apache::arrow::flatbuf::Struct_ *>(type()) : nullptr;
   }
-  const Union *type_as_Union() const {
-    return type_type() == Type::Union ? static_cast<const Union *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Union *type_as_Union() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Union ? static_cast<const org::apache::arrow::flatbuf::Union *>(type()) : nullptr;
   }
-  const FixedSizeBinary *type_as_FixedSizeBinary() const {
-    return type_type() == Type::FixedSizeBinary ? static_cast<const FixedSizeBinary *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::FixedSizeBinary *type_as_FixedSizeBinary() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeBinary ? static_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(type()) : nullptr;
   }
-  const FixedSizeList *type_as_FixedSizeList() const {
-    return type_type() == Type::FixedSizeList ? static_cast<const FixedSizeList *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::FixedSizeList *type_as_FixedSizeList() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeList ? static_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(type()) : nullptr;
   }
-  const Map *type_as_Map() const {
-    return type_type() == Type::Map ? static_cast<const Map *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Map *type_as_Map() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Map ? static_cast<const org::apache::arrow::flatbuf::Map *>(type()) : nullptr;
   }
-  const Duration *type_as_Duration() const {
-    return type_type() == Type::Duration ? static_cast<const Duration *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Duration *type_as_Duration() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Duration ? static_cast<const org::apache::arrow::flatbuf::Duration *>(type()) : nullptr;
   }
-  const LargeBinary *type_as_LargeBinary() const {
-    return type_type() == Type::LargeBinary ? static_cast<const LargeBinary *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::LargeBinary *type_as_LargeBinary() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::LargeBinary ? static_cast<const org::apache::arrow::flatbuf::LargeBinary *>(type()) : nullptr;
   }
-  const LargeUtf8 *type_as_LargeUtf8() const {
-    return type_type() == Type::LargeUtf8 ? static_cast<const LargeUtf8 *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::LargeUtf8 *type_as_LargeUtf8() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::LargeUtf8 ? static_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(type()) : nullptr;
   }
-  const LargeList *type_as_LargeList() const {
-    return type_type() == Type::LargeList ? static_cast<const LargeList *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::LargeList *type_as_LargeList() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::LargeList ? static_cast<const org::apache::arrow::flatbuf::LargeList *>(type()) : nullptr;
   }
   /// The dimensions of the tensor, optionally named.
-  const flatbuffers::Vector<flatbuffers::Offset<TensorDim>> *shape() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<TensorDim>> *>(VT_SHAPE);
+  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *shape() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *>(VT_SHAPE);
   }
   /// The number of non-zero values in a sparse tensor.
   int64_t non_zero_length() const {
     return GetField<int64_t>(VT_NON_ZERO_LENGTH, 0);
   }
-  SparseTensorIndex sparseIndex_type() const {
-    return static_cast<SparseTensorIndex>(GetField<uint8_t>(VT_SPARSEINDEX_TYPE, 0));
+  org::apache::arrow::flatbuf::SparseTensorIndex sparseIndex_type() const {
+    return static_cast<org::apache::arrow::flatbuf::SparseTensorIndex>(GetField<uint8_t>(VT_SPARSEINDEX_TYPE, 0));
   }
   /// Sparse tensor index
   const void *sparseIndex() const {
     return GetPointer<const void *>(VT_SPARSEINDEX);
   }
   template<typename T> const T *sparseIndex_as() const;
-  const SparseTensorIndexCOO *sparseIndex_as_SparseTensorIndexCOO() const {
-    return sparseIndex_type() == SparseTensorIndex::SparseTensorIndexCOO ? static_cast<const SparseTensorIndexCOO *>(sparseIndex()) : nullptr;
+  const org::apache::arrow::flatbuf::SparseTensorIndexCOO *sparseIndex_as_SparseTensorIndexCOO() const {
+    return sparseIndex_type() == org::apache::arrow::flatbuf::SparseTensorIndex::SparseTensorIndexCOO ? static_cast<const org::apache::arrow::flatbuf::SparseTensorIndexCOO *>(sparseIndex()) : nullptr;
   }
-  const SparseMatrixIndexCSX *sparseIndex_as_SparseMatrixIndexCSX() const {
-    return sparseIndex_type() == SparseTensorIndex::SparseMatrixIndexCSX ? static_cast<const SparseMatrixIndexCSX *>(sparseIndex()) : nullptr;
+  const org::apache::arrow::flatbuf::SparseMatrixIndexCSX *sparseIndex_as_SparseMatrixIndexCSX() const {
+    return sparseIndex_type() == org::apache::arrow::flatbuf::SparseTensorIndex::SparseMatrixIndexCSX ? static_cast<const org::apache::arrow::flatbuf::SparseMatrixIndexCSX *>(sparseIndex()) : nullptr;
   }
   /// The location and size of the tensor's data
-  const Buffer *data() const {
-    return GetStruct<const Buffer *>(VT_DATA);
+  const org::apache::arrow::flatbuf::Buffer *data() const {
+    return GetStruct<const org::apache::arrow::flatbuf::Buffer *>(VT_DATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -451,125 +459,126 @@ struct SparseTensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyField<uint8_t>(verifier, VT_SPARSEINDEX_TYPE) &&
            VerifyOffsetRequired(verifier, VT_SPARSEINDEX) &&
            VerifySparseTensorIndex(verifier, sparseIndex(), sparseIndex_type()) &&
-           VerifyFieldRequired<Buffer>(verifier, VT_DATA) &&
+           VerifyFieldRequired<org::apache::arrow::flatbuf::Buffer>(verifier, VT_DATA) &&
            verifier.EndTable();
   }
 };
 
-template<> inline const Null *SparseTensor::type_as<Null>() const {
+template<> inline const org::apache::arrow::flatbuf::Null *SparseTensor::type_as<org::apache::arrow::flatbuf::Null>() const {
   return type_as_Null();
 }
 
-template<> inline const Int *SparseTensor::type_as<Int>() const {
+template<> inline const org::apache::arrow::flatbuf::Int *SparseTensor::type_as<org::apache::arrow::flatbuf::Int>() const {
   return type_as_Int();
 }
 
-template<> inline const FloatingPoint *SparseTensor::type_as<FloatingPoint>() const {
+template<> inline const org::apache::arrow::flatbuf::FloatingPoint *SparseTensor::type_as<org::apache::arrow::flatbuf::FloatingPoint>() const {
   return type_as_FloatingPoint();
 }
 
-template<> inline const Binary *SparseTensor::type_as<Binary>() const {
+template<> inline const org::apache::arrow::flatbuf::Binary *SparseTensor::type_as<org::apache::arrow::flatbuf::Binary>() const {
   return type_as_Binary();
 }
 
-template<> inline const Utf8 *SparseTensor::type_as<Utf8>() const {
+template<> inline const org::apache::arrow::flatbuf::Utf8 *SparseTensor::type_as<org::apache::arrow::flatbuf::Utf8>() const {
   return type_as_Utf8();
 }
 
-template<> inline const Bool *SparseTensor::type_as<Bool>() const {
+template<> inline const org::apache::arrow::flatbuf::Bool *SparseTensor::type_as<org::apache::arrow::flatbuf::Bool>() const {
   return type_as_Bool();
 }
 
-template<> inline const Decimal *SparseTensor::type_as<Decimal>() const {
+template<> inline const org::apache::arrow::flatbuf::Decimal *SparseTensor::type_as<org::apache::arrow::flatbuf::Decimal>() const {
   return type_as_Decimal();
 }
 
-template<> inline const Date *SparseTensor::type_as<Date>() const {
+template<> inline const org::apache::arrow::flatbuf::Date *SparseTensor::type_as<org::apache::arrow::flatbuf::Date>() const {
   return type_as_Date();
 }
 
-template<> inline const Time *SparseTensor::type_as<Time>() const {
+template<> inline const org::apache::arrow::flatbuf::Time *SparseTensor::type_as<org::apache::arrow::flatbuf::Time>() const {
   return type_as_Time();
 }
 
-template<> inline const Timestamp *SparseTensor::type_as<Timestamp>() const {
+template<> inline const org::apache::arrow::flatbuf::Timestamp *SparseTensor::type_as<org::apache::arrow::flatbuf::Timestamp>() const {
   return type_as_Timestamp();
 }
 
-template<> inline const Interval *SparseTensor::type_as<Interval>() const {
+template<> inline const org::apache::arrow::flatbuf::Interval *SparseTensor::type_as<org::apache::arrow::flatbuf::Interval>() const {
   return type_as_Interval();
 }
 
-template<> inline const List *SparseTensor::type_as<List>() const {
+template<> inline const org::apache::arrow::flatbuf::List *SparseTensor::type_as<org::apache::arrow::flatbuf::List>() const {
   return type_as_List();
 }
 
-template<> inline const Struct_ *SparseTensor::type_as<Struct_>() const {
+template<> inline const org::apache::arrow::flatbuf::Struct_ *SparseTensor::type_as<org::apache::arrow::flatbuf::Struct_>() const {
   return type_as_Struct_();
 }
 
-template<> inline const Union *SparseTensor::type_as<Union>() const {
+template<> inline const org::apache::arrow::flatbuf::Union *SparseTensor::type_as<org::apache::arrow::flatbuf::Union>() const {
   return type_as_Union();
 }
 
-template<> inline const FixedSizeBinary *SparseTensor::type_as<FixedSizeBinary>() const {
+template<> inline const org::apache::arrow::flatbuf::FixedSizeBinary *SparseTensor::type_as<org::apache::arrow::flatbuf::FixedSizeBinary>() const {
   return type_as_FixedSizeBinary();
 }
 
-template<> inline const FixedSizeList *SparseTensor::type_as<FixedSizeList>() const {
+template<> inline const org::apache::arrow::flatbuf::FixedSizeList *SparseTensor::type_as<org::apache::arrow::flatbuf::FixedSizeList>() const {
   return type_as_FixedSizeList();
 }
 
-template<> inline const Map *SparseTensor::type_as<Map>() const {
+template<> inline const org::apache::arrow::flatbuf::Map *SparseTensor::type_as<org::apache::arrow::flatbuf::Map>() const {
   return type_as_Map();
 }
 
-template<> inline const Duration *SparseTensor::type_as<Duration>() const {
+template<> inline const org::apache::arrow::flatbuf::Duration *SparseTensor::type_as<org::apache::arrow::flatbuf::Duration>() const {
   return type_as_Duration();
 }
 
-template<> inline const LargeBinary *SparseTensor::type_as<LargeBinary>() const {
+template<> inline const org::apache::arrow::flatbuf::LargeBinary *SparseTensor::type_as<org::apache::arrow::flatbuf::LargeBinary>() const {
   return type_as_LargeBinary();
 }
 
-template<> inline const LargeUtf8 *SparseTensor::type_as<LargeUtf8>() const {
+template<> inline const org::apache::arrow::flatbuf::LargeUtf8 *SparseTensor::type_as<org::apache::arrow::flatbuf::LargeUtf8>() const {
   return type_as_LargeUtf8();
 }
 
-template<> inline const LargeList *SparseTensor::type_as<LargeList>() const {
+template<> inline const org::apache::arrow::flatbuf::LargeList *SparseTensor::type_as<org::apache::arrow::flatbuf::LargeList>() const {
   return type_as_LargeList();
 }
 
-template<> inline const SparseTensorIndexCOO *SparseTensor::sparseIndex_as<SparseTensorIndexCOO>() const {
+template<> inline const org::apache::arrow::flatbuf::SparseTensorIndexCOO *SparseTensor::sparseIndex_as<org::apache::arrow::flatbuf::SparseTensorIndexCOO>() const {
   return sparseIndex_as_SparseTensorIndexCOO();
 }
 
-template<> inline const SparseMatrixIndexCSX *SparseTensor::sparseIndex_as<SparseMatrixIndexCSX>() const {
+template<> inline const org::apache::arrow::flatbuf::SparseMatrixIndexCSX *SparseTensor::sparseIndex_as<org::apache::arrow::flatbuf::SparseMatrixIndexCSX>() const {
   return sparseIndex_as_SparseMatrixIndexCSX();
 }
 
 struct SparseTensorBuilder {
+  typedef SparseTensor Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_type_type(Type type_type) {
+  void add_type_type(org::apache::arrow::flatbuf::Type type_type) {
     fbb_.AddElement<uint8_t>(SparseTensor::VT_TYPE_TYPE, static_cast<uint8_t>(type_type), 0);
   }
   void add_type(flatbuffers::Offset<void> type) {
     fbb_.AddOffset(SparseTensor::VT_TYPE, type);
   }
-  void add_shape(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<TensorDim>>> shape) {
+  void add_shape(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>>> shape) {
     fbb_.AddOffset(SparseTensor::VT_SHAPE, shape);
   }
   void add_non_zero_length(int64_t non_zero_length) {
     fbb_.AddElement<int64_t>(SparseTensor::VT_NON_ZERO_LENGTH, non_zero_length, 0);
   }
-  void add_sparseIndex_type(SparseTensorIndex sparseIndex_type) {
+  void add_sparseIndex_type(org::apache::arrow::flatbuf::SparseTensorIndex sparseIndex_type) {
     fbb_.AddElement<uint8_t>(SparseTensor::VT_SPARSEINDEX_TYPE, static_cast<uint8_t>(sparseIndex_type), 0);
   }
   void add_sparseIndex(flatbuffers::Offset<void> sparseIndex) {
     fbb_.AddOffset(SparseTensor::VT_SPARSEINDEX, sparseIndex);
   }
-  void add_data(const Buffer *data) {
+  void add_data(const org::apache::arrow::flatbuf::Buffer *data) {
     fbb_.AddStruct(SparseTensor::VT_DATA, data);
   }
   explicit SparseTensorBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -590,13 +599,13 @@ struct SparseTensorBuilder {
 
 inline flatbuffers::Offset<SparseTensor> CreateSparseTensor(
     flatbuffers::FlatBufferBuilder &_fbb,
-    Type type_type = Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
     flatbuffers::Offset<void> type = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<TensorDim>>> shape = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>>> shape = 0,
     int64_t non_zero_length = 0,
-    SparseTensorIndex sparseIndex_type = SparseTensorIndex::NONE,
+    org::apache::arrow::flatbuf::SparseTensorIndex sparseIndex_type = org::apache::arrow::flatbuf::SparseTensorIndex::NONE,
     flatbuffers::Offset<void> sparseIndex = 0,
-    const Buffer *data = 0) {
+    const org::apache::arrow::flatbuf::Buffer *data = 0) {
   SparseTensorBuilder builder_(_fbb);
   builder_.add_non_zero_length(non_zero_length);
   builder_.add_data(data);
@@ -610,14 +619,14 @@ inline flatbuffers::Offset<SparseTensor> CreateSparseTensor(
 
 inline flatbuffers::Offset<SparseTensor> CreateSparseTensorDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    Type type_type = Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
     flatbuffers::Offset<void> type = 0,
-    const std::vector<flatbuffers::Offset<TensorDim>> *shape = nullptr,
+    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *shape = nullptr,
     int64_t non_zero_length = 0,
-    SparseTensorIndex sparseIndex_type = SparseTensorIndex::NONE,
+    org::apache::arrow::flatbuf::SparseTensorIndex sparseIndex_type = org::apache::arrow::flatbuf::SparseTensorIndex::NONE,
     flatbuffers::Offset<void> sparseIndex = 0,
-    const Buffer *data = 0) {
-  auto shape__ = shape ? _fbb.CreateVector<flatbuffers::Offset<TensorDim>>(*shape) : 0;
+    const org::apache::arrow::flatbuf::Buffer *data = 0) {
+  auto shape__ = shape ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>>(*shape) : 0;
   return org::apache::arrow::flatbuf::CreateSparseTensor(
       _fbb,
       type_type,
@@ -635,14 +644,14 @@ inline bool VerifySparseTensorIndex(flatbuffers::Verifier &verifier, const void 
       return true;
     }
     case SparseTensorIndex::SparseTensorIndexCOO: {
-      auto ptr = reinterpret_cast<const SparseTensorIndexCOO *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::SparseTensorIndexCOO *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case SparseTensorIndex::SparseMatrixIndexCSX: {
-      auto ptr = reinterpret_cast<const SparseMatrixIndexCSX *>(obj);
+      auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::SparseMatrixIndexCSX *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    default: return false;
+    default: return true;
   }
 }
 

--- a/cpp/src/generated/Tensor_generated.h
+++ b/cpp/src/generated/Tensor_generated.h
@@ -14,13 +14,16 @@ namespace arrow {
 namespace flatbuf {
 
 struct TensorDim;
+struct TensorDimBuilder;
 
 struct Tensor;
+struct TensorBuilder;
 
 /// ----------------------------------------------------------------------
 /// Data structures for dense tensors
 /// Shape data for a single axis in a tensor
 struct TensorDim FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef TensorDimBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_SIZE = 4,
     VT_NAME = 6
@@ -43,6 +46,7 @@ struct TensorDim FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct TensorDimBuilder {
+  typedef TensorDim Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_size(int64_t size) {
@@ -85,6 +89,7 @@ inline flatbuffers::Offset<TensorDim> CreateTensorDimDirect(
 }
 
 struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef TensorBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_TYPE_TYPE = 4,
     VT_TYPE = 6,
@@ -92,8 +97,8 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_STRIDES = 10,
     VT_DATA = 12
   };
-  Type type_type() const {
-    return static_cast<Type>(GetField<uint8_t>(VT_TYPE_TYPE, 0));
+  org::apache::arrow::flatbuf::Type type_type() const {
+    return static_cast<org::apache::arrow::flatbuf::Type>(GetField<uint8_t>(VT_TYPE_TYPE, 0));
   }
   /// The type of data contained in a value cell. Currently only fixed-width
   /// value types are supported, no strings or nested types
@@ -101,72 +106,72 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return GetPointer<const void *>(VT_TYPE);
   }
   template<typename T> const T *type_as() const;
-  const Null *type_as_Null() const {
-    return type_type() == Type::Null ? static_cast<const Null *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Null *type_as_Null() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Null ? static_cast<const org::apache::arrow::flatbuf::Null *>(type()) : nullptr;
   }
-  const Int *type_as_Int() const {
-    return type_type() == Type::Int ? static_cast<const Int *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Int *type_as_Int() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Int ? static_cast<const org::apache::arrow::flatbuf::Int *>(type()) : nullptr;
   }
-  const FloatingPoint *type_as_FloatingPoint() const {
-    return type_type() == Type::FloatingPoint ? static_cast<const FloatingPoint *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::FloatingPoint *type_as_FloatingPoint() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::FloatingPoint ? static_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(type()) : nullptr;
   }
-  const Binary *type_as_Binary() const {
-    return type_type() == Type::Binary ? static_cast<const Binary *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Binary *type_as_Binary() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Binary ? static_cast<const org::apache::arrow::flatbuf::Binary *>(type()) : nullptr;
   }
-  const Utf8 *type_as_Utf8() const {
-    return type_type() == Type::Utf8 ? static_cast<const Utf8 *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Utf8 *type_as_Utf8() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Utf8 ? static_cast<const org::apache::arrow::flatbuf::Utf8 *>(type()) : nullptr;
   }
-  const Bool *type_as_Bool() const {
-    return type_type() == Type::Bool ? static_cast<const Bool *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Bool *type_as_Bool() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Bool ? static_cast<const org::apache::arrow::flatbuf::Bool *>(type()) : nullptr;
   }
-  const Decimal *type_as_Decimal() const {
-    return type_type() == Type::Decimal ? static_cast<const Decimal *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Decimal *type_as_Decimal() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Decimal ? static_cast<const org::apache::arrow::flatbuf::Decimal *>(type()) : nullptr;
   }
-  const Date *type_as_Date() const {
-    return type_type() == Type::Date ? static_cast<const Date *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Date *type_as_Date() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Date ? static_cast<const org::apache::arrow::flatbuf::Date *>(type()) : nullptr;
   }
-  const Time *type_as_Time() const {
-    return type_type() == Type::Time ? static_cast<const Time *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Time *type_as_Time() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Time ? static_cast<const org::apache::arrow::flatbuf::Time *>(type()) : nullptr;
   }
-  const Timestamp *type_as_Timestamp() const {
-    return type_type() == Type::Timestamp ? static_cast<const Timestamp *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Timestamp *type_as_Timestamp() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Timestamp ? static_cast<const org::apache::arrow::flatbuf::Timestamp *>(type()) : nullptr;
   }
-  const Interval *type_as_Interval() const {
-    return type_type() == Type::Interval ? static_cast<const Interval *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Interval *type_as_Interval() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Interval ? static_cast<const org::apache::arrow::flatbuf::Interval *>(type()) : nullptr;
   }
-  const List *type_as_List() const {
-    return type_type() == Type::List ? static_cast<const List *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::List *type_as_List() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::List ? static_cast<const org::apache::arrow::flatbuf::List *>(type()) : nullptr;
   }
-  const Struct_ *type_as_Struct_() const {
-    return type_type() == Type::Struct_ ? static_cast<const Struct_ *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Struct_ *type_as_Struct_() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Struct_ ? static_cast<const org::apache::arrow::flatbuf::Struct_ *>(type()) : nullptr;
   }
-  const Union *type_as_Union() const {
-    return type_type() == Type::Union ? static_cast<const Union *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Union *type_as_Union() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Union ? static_cast<const org::apache::arrow::flatbuf::Union *>(type()) : nullptr;
   }
-  const FixedSizeBinary *type_as_FixedSizeBinary() const {
-    return type_type() == Type::FixedSizeBinary ? static_cast<const FixedSizeBinary *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::FixedSizeBinary *type_as_FixedSizeBinary() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeBinary ? static_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(type()) : nullptr;
   }
-  const FixedSizeList *type_as_FixedSizeList() const {
-    return type_type() == Type::FixedSizeList ? static_cast<const FixedSizeList *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::FixedSizeList *type_as_FixedSizeList() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeList ? static_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(type()) : nullptr;
   }
-  const Map *type_as_Map() const {
-    return type_type() == Type::Map ? static_cast<const Map *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Map *type_as_Map() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Map ? static_cast<const org::apache::arrow::flatbuf::Map *>(type()) : nullptr;
   }
-  const Duration *type_as_Duration() const {
-    return type_type() == Type::Duration ? static_cast<const Duration *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::Duration *type_as_Duration() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::Duration ? static_cast<const org::apache::arrow::flatbuf::Duration *>(type()) : nullptr;
   }
-  const LargeBinary *type_as_LargeBinary() const {
-    return type_type() == Type::LargeBinary ? static_cast<const LargeBinary *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::LargeBinary *type_as_LargeBinary() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::LargeBinary ? static_cast<const org::apache::arrow::flatbuf::LargeBinary *>(type()) : nullptr;
   }
-  const LargeUtf8 *type_as_LargeUtf8() const {
-    return type_type() == Type::LargeUtf8 ? static_cast<const LargeUtf8 *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::LargeUtf8 *type_as_LargeUtf8() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::LargeUtf8 ? static_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(type()) : nullptr;
   }
-  const LargeList *type_as_LargeList() const {
-    return type_type() == Type::LargeList ? static_cast<const LargeList *>(type()) : nullptr;
+  const org::apache::arrow::flatbuf::LargeList *type_as_LargeList() const {
+    return type_type() == org::apache::arrow::flatbuf::Type::LargeList ? static_cast<const org::apache::arrow::flatbuf::LargeList *>(type()) : nullptr;
   }
   /// The dimensions of the tensor, optionally named
-  const flatbuffers::Vector<flatbuffers::Offset<TensorDim>> *shape() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<TensorDim>> *>(VT_SHAPE);
+  const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *shape() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *>(VT_SHAPE);
   }
   /// Non-negative byte offsets to advance one value cell along each dimension
   /// If omitted, default to row-major order (C-like).
@@ -174,8 +179,8 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_STRIDES);
   }
   /// The location and size of the tensor's data
-  const Buffer *data() const {
-    return GetStruct<const Buffer *>(VT_DATA);
+  const org::apache::arrow::flatbuf::Buffer *data() const {
+    return GetStruct<const org::apache::arrow::flatbuf::Buffer *>(VT_DATA);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -187,111 +192,112 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            verifier.VerifyVectorOfTables(shape()) &&
            VerifyOffset(verifier, VT_STRIDES) &&
            verifier.VerifyVector(strides()) &&
-           VerifyFieldRequired<Buffer>(verifier, VT_DATA) &&
+           VerifyFieldRequired<org::apache::arrow::flatbuf::Buffer>(verifier, VT_DATA) &&
            verifier.EndTable();
   }
 };
 
-template<> inline const Null *Tensor::type_as<Null>() const {
+template<> inline const org::apache::arrow::flatbuf::Null *Tensor::type_as<org::apache::arrow::flatbuf::Null>() const {
   return type_as_Null();
 }
 
-template<> inline const Int *Tensor::type_as<Int>() const {
+template<> inline const org::apache::arrow::flatbuf::Int *Tensor::type_as<org::apache::arrow::flatbuf::Int>() const {
   return type_as_Int();
 }
 
-template<> inline const FloatingPoint *Tensor::type_as<FloatingPoint>() const {
+template<> inline const org::apache::arrow::flatbuf::FloatingPoint *Tensor::type_as<org::apache::arrow::flatbuf::FloatingPoint>() const {
   return type_as_FloatingPoint();
 }
 
-template<> inline const Binary *Tensor::type_as<Binary>() const {
+template<> inline const org::apache::arrow::flatbuf::Binary *Tensor::type_as<org::apache::arrow::flatbuf::Binary>() const {
   return type_as_Binary();
 }
 
-template<> inline const Utf8 *Tensor::type_as<Utf8>() const {
+template<> inline const org::apache::arrow::flatbuf::Utf8 *Tensor::type_as<org::apache::arrow::flatbuf::Utf8>() const {
   return type_as_Utf8();
 }
 
-template<> inline const Bool *Tensor::type_as<Bool>() const {
+template<> inline const org::apache::arrow::flatbuf::Bool *Tensor::type_as<org::apache::arrow::flatbuf::Bool>() const {
   return type_as_Bool();
 }
 
-template<> inline const Decimal *Tensor::type_as<Decimal>() const {
+template<> inline const org::apache::arrow::flatbuf::Decimal *Tensor::type_as<org::apache::arrow::flatbuf::Decimal>() const {
   return type_as_Decimal();
 }
 
-template<> inline const Date *Tensor::type_as<Date>() const {
+template<> inline const org::apache::arrow::flatbuf::Date *Tensor::type_as<org::apache::arrow::flatbuf::Date>() const {
   return type_as_Date();
 }
 
-template<> inline const Time *Tensor::type_as<Time>() const {
+template<> inline const org::apache::arrow::flatbuf::Time *Tensor::type_as<org::apache::arrow::flatbuf::Time>() const {
   return type_as_Time();
 }
 
-template<> inline const Timestamp *Tensor::type_as<Timestamp>() const {
+template<> inline const org::apache::arrow::flatbuf::Timestamp *Tensor::type_as<org::apache::arrow::flatbuf::Timestamp>() const {
   return type_as_Timestamp();
 }
 
-template<> inline const Interval *Tensor::type_as<Interval>() const {
+template<> inline const org::apache::arrow::flatbuf::Interval *Tensor::type_as<org::apache::arrow::flatbuf::Interval>() const {
   return type_as_Interval();
 }
 
-template<> inline const List *Tensor::type_as<List>() const {
+template<> inline const org::apache::arrow::flatbuf::List *Tensor::type_as<org::apache::arrow::flatbuf::List>() const {
   return type_as_List();
 }
 
-template<> inline const Struct_ *Tensor::type_as<Struct_>() const {
+template<> inline const org::apache::arrow::flatbuf::Struct_ *Tensor::type_as<org::apache::arrow::flatbuf::Struct_>() const {
   return type_as_Struct_();
 }
 
-template<> inline const Union *Tensor::type_as<Union>() const {
+template<> inline const org::apache::arrow::flatbuf::Union *Tensor::type_as<org::apache::arrow::flatbuf::Union>() const {
   return type_as_Union();
 }
 
-template<> inline const FixedSizeBinary *Tensor::type_as<FixedSizeBinary>() const {
+template<> inline const org::apache::arrow::flatbuf::FixedSizeBinary *Tensor::type_as<org::apache::arrow::flatbuf::FixedSizeBinary>() const {
   return type_as_FixedSizeBinary();
 }
 
-template<> inline const FixedSizeList *Tensor::type_as<FixedSizeList>() const {
+template<> inline const org::apache::arrow::flatbuf::FixedSizeList *Tensor::type_as<org::apache::arrow::flatbuf::FixedSizeList>() const {
   return type_as_FixedSizeList();
 }
 
-template<> inline const Map *Tensor::type_as<Map>() const {
+template<> inline const org::apache::arrow::flatbuf::Map *Tensor::type_as<org::apache::arrow::flatbuf::Map>() const {
   return type_as_Map();
 }
 
-template<> inline const Duration *Tensor::type_as<Duration>() const {
+template<> inline const org::apache::arrow::flatbuf::Duration *Tensor::type_as<org::apache::arrow::flatbuf::Duration>() const {
   return type_as_Duration();
 }
 
-template<> inline const LargeBinary *Tensor::type_as<LargeBinary>() const {
+template<> inline const org::apache::arrow::flatbuf::LargeBinary *Tensor::type_as<org::apache::arrow::flatbuf::LargeBinary>() const {
   return type_as_LargeBinary();
 }
 
-template<> inline const LargeUtf8 *Tensor::type_as<LargeUtf8>() const {
+template<> inline const org::apache::arrow::flatbuf::LargeUtf8 *Tensor::type_as<org::apache::arrow::flatbuf::LargeUtf8>() const {
   return type_as_LargeUtf8();
 }
 
-template<> inline const LargeList *Tensor::type_as<LargeList>() const {
+template<> inline const org::apache::arrow::flatbuf::LargeList *Tensor::type_as<org::apache::arrow::flatbuf::LargeList>() const {
   return type_as_LargeList();
 }
 
 struct TensorBuilder {
+  typedef Tensor Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_type_type(Type type_type) {
+  void add_type_type(org::apache::arrow::flatbuf::Type type_type) {
     fbb_.AddElement<uint8_t>(Tensor::VT_TYPE_TYPE, static_cast<uint8_t>(type_type), 0);
   }
   void add_type(flatbuffers::Offset<void> type) {
     fbb_.AddOffset(Tensor::VT_TYPE, type);
   }
-  void add_shape(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<TensorDim>>> shape) {
+  void add_shape(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>>> shape) {
     fbb_.AddOffset(Tensor::VT_SHAPE, shape);
   }
   void add_strides(flatbuffers::Offset<flatbuffers::Vector<int64_t>> strides) {
     fbb_.AddOffset(Tensor::VT_STRIDES, strides);
   }
-  void add_data(const Buffer *data) {
+  void add_data(const org::apache::arrow::flatbuf::Buffer *data) {
     fbb_.AddStruct(Tensor::VT_DATA, data);
   }
   explicit TensorBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -311,11 +317,11 @@ struct TensorBuilder {
 
 inline flatbuffers::Offset<Tensor> CreateTensor(
     flatbuffers::FlatBufferBuilder &_fbb,
-    Type type_type = Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
     flatbuffers::Offset<void> type = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<TensorDim>>> shape = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>>> shape = 0,
     flatbuffers::Offset<flatbuffers::Vector<int64_t>> strides = 0,
-    const Buffer *data = 0) {
+    const org::apache::arrow::flatbuf::Buffer *data = 0) {
   TensorBuilder builder_(_fbb);
   builder_.add_data(data);
   builder_.add_strides(strides);
@@ -327,12 +333,12 @@ inline flatbuffers::Offset<Tensor> CreateTensor(
 
 inline flatbuffers::Offset<Tensor> CreateTensorDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    Type type_type = Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
     flatbuffers::Offset<void> type = 0,
-    const std::vector<flatbuffers::Offset<TensorDim>> *shape = nullptr,
+    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *shape = nullptr,
     const std::vector<int64_t> *strides = nullptr,
-    const Buffer *data = 0) {
-  auto shape__ = shape ? _fbb.CreateVector<flatbuffers::Offset<TensorDim>>(*shape) : 0;
+    const org::apache::arrow::flatbuf::Buffer *data = 0) {
+  auto shape__ = shape ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>>(*shape) : 0;
   auto strides__ = strides ? _fbb.CreateVector<int64_t>(*strides) : 0;
   return org::apache::arrow::flatbuf::CreateTensor(
       _fbb,

--- a/cpp/src/generated/feather_generated.h
+++ b/cpp/src/generated/feather_generated.h
@@ -12,18 +12,25 @@ namespace feather {
 namespace fbs {
 
 struct PrimitiveArray;
+struct PrimitiveArrayBuilder;
 
 struct CategoryMetadata;
+struct CategoryMetadataBuilder;
 
 struct TimestampMetadata;
+struct TimestampMetadataBuilder;
 
 struct DateMetadata;
+struct DateMetadataBuilder;
 
 struct TimeMetadata;
+struct TimeMetadataBuilder;
 
 struct Column;
+struct ColumnBuilder;
 
 struct CTable;
+struct CTableBuilder;
 
 /// Feather is an experimental serialization format implemented using
 /// techniques from Apache Arrow. It was created as a proof-of-concept of an
@@ -81,7 +88,7 @@ inline const Type (&EnumValuesType())[19] {
 }
 
 inline const char * const *EnumNamesType() {
-  static const char * const names[] = {
+  static const char * const names[20] = {
     "BOOL",
     "INT8",
     "INT16",
@@ -107,19 +114,19 @@ inline const char * const *EnumNamesType() {
 }
 
 inline const char *EnumNameType(Type e) {
-  if (e < Type::BOOL || e > Type::LARGE_BINARY) return "";
+  if (flatbuffers::IsOutRange(e, Type::BOOL, Type::LARGE_BINARY)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesType()[index];
 }
 
 enum class Encoding : int8_t {
-  PLAIN = 0  /// Data is stored dictionary-encoded
+  PLAIN = 0,
+  /// Data is stored dictionary-encoded
   /// dictionary size: <INT32 Dictionary size>
   /// dictionary data: <TYPE primitive array>
   /// dictionary index: <INT32 primitive array>
   ///
   /// TODO: do we care about storing the index values in a smaller typeclass
-,
   DICTIONARY = 1,
   MIN = PLAIN,
   MAX = DICTIONARY
@@ -134,7 +141,7 @@ inline const Encoding (&EnumValuesEncoding())[2] {
 }
 
 inline const char * const *EnumNamesEncoding() {
-  static const char * const names[] = {
+  static const char * const names[3] = {
     "PLAIN",
     "DICTIONARY",
     nullptr
@@ -143,7 +150,7 @@ inline const char * const *EnumNamesEncoding() {
 }
 
 inline const char *EnumNameEncoding(Encoding e) {
-  if (e < Encoding::PLAIN || e > Encoding::DICTIONARY) return "";
+  if (flatbuffers::IsOutRange(e, Encoding::PLAIN, Encoding::DICTIONARY)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesEncoding()[index];
 }
@@ -168,7 +175,7 @@ inline const TimeUnit (&EnumValuesTimeUnit())[4] {
 }
 
 inline const char * const *EnumNamesTimeUnit() {
-  static const char * const names[] = {
+  static const char * const names[5] = {
     "SECOND",
     "MILLISECOND",
     "MICROSECOND",
@@ -179,7 +186,7 @@ inline const char * const *EnumNamesTimeUnit() {
 }
 
 inline const char *EnumNameTimeUnit(TimeUnit e) {
-  if (e < TimeUnit::SECOND || e > TimeUnit::NANOSECOND) return "";
+  if (flatbuffers::IsOutRange(e, TimeUnit::SECOND, TimeUnit::NANOSECOND)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTimeUnit()[index];
 }
@@ -206,7 +213,7 @@ inline const TypeMetadata (&EnumValuesTypeMetadata())[5] {
 }
 
 inline const char * const *EnumNamesTypeMetadata() {
-  static const char * const names[] = {
+  static const char * const names[6] = {
     "NONE",
     "CategoryMetadata",
     "TimestampMetadata",
@@ -218,7 +225,7 @@ inline const char * const *EnumNamesTypeMetadata() {
 }
 
 inline const char *EnumNameTypeMetadata(TypeMetadata e) {
-  if (e < TypeMetadata::NONE || e > TypeMetadata::TimeMetadata) return "";
+  if (flatbuffers::IsOutRange(e, TypeMetadata::NONE, TypeMetadata::TimeMetadata)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTypeMetadata()[index];
 }
@@ -227,19 +234,19 @@ template<typename T> struct TypeMetadataTraits {
   static const TypeMetadata enum_value = TypeMetadata::NONE;
 };
 
-template<> struct TypeMetadataTraits<CategoryMetadata> {
+template<> struct TypeMetadataTraits<arrow::ipc::feather::fbs::CategoryMetadata> {
   static const TypeMetadata enum_value = TypeMetadata::CategoryMetadata;
 };
 
-template<> struct TypeMetadataTraits<TimestampMetadata> {
+template<> struct TypeMetadataTraits<arrow::ipc::feather::fbs::TimestampMetadata> {
   static const TypeMetadata enum_value = TypeMetadata::TimestampMetadata;
 };
 
-template<> struct TypeMetadataTraits<DateMetadata> {
+template<> struct TypeMetadataTraits<arrow::ipc::feather::fbs::DateMetadata> {
   static const TypeMetadata enum_value = TypeMetadata::DateMetadata;
 };
 
-template<> struct TypeMetadataTraits<TimeMetadata> {
+template<> struct TypeMetadataTraits<arrow::ipc::feather::fbs::TimeMetadata> {
   static const TypeMetadata enum_value = TypeMetadata::TimeMetadata;
 };
 
@@ -247,6 +254,7 @@ bool VerifyTypeMetadata(flatbuffers::Verifier &verifier, const void *obj, TypeMe
 bool VerifyTypeMetadataVector(flatbuffers::Verifier &verifier, const flatbuffers::Vector<flatbuffers::Offset<void>> *values, const flatbuffers::Vector<uint8_t> *types);
 
 struct PrimitiveArray FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef PrimitiveArrayBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_TYPE = 4,
     VT_ENCODING = 6,
@@ -255,11 +263,11 @@ struct PrimitiveArray FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
     VT_NULL_COUNT = 12,
     VT_TOTAL_BYTES = 14
   };
-  Type type() const {
-    return static_cast<Type>(GetField<int8_t>(VT_TYPE, 0));
+  arrow::ipc::feather::fbs::Type type() const {
+    return static_cast<arrow::ipc::feather::fbs::Type>(GetField<int8_t>(VT_TYPE, 0));
   }
-  Encoding encoding() const {
-    return static_cast<Encoding>(GetField<int8_t>(VT_ENCODING, 0));
+  arrow::ipc::feather::fbs::Encoding encoding() const {
+    return static_cast<arrow::ipc::feather::fbs::Encoding>(GetField<int8_t>(VT_ENCODING, 0));
   }
   /// Relative memory offset of the start of the array data excluding the size
   /// of the metadata
@@ -291,12 +299,13 @@ struct PrimitiveArray FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PrimitiveArrayBuilder {
+  typedef PrimitiveArray Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_type(Type type) {
+  void add_type(arrow::ipc::feather::fbs::Type type) {
     fbb_.AddElement<int8_t>(PrimitiveArray::VT_TYPE, static_cast<int8_t>(type), 0);
   }
-  void add_encoding(Encoding encoding) {
+  void add_encoding(arrow::ipc::feather::fbs::Encoding encoding) {
     fbb_.AddElement<int8_t>(PrimitiveArray::VT_ENCODING, static_cast<int8_t>(encoding), 0);
   }
   void add_offset(int64_t offset) {
@@ -325,8 +334,8 @@ struct PrimitiveArrayBuilder {
 
 inline flatbuffers::Offset<PrimitiveArray> CreatePrimitiveArray(
     flatbuffers::FlatBufferBuilder &_fbb,
-    Type type = Type::BOOL,
-    Encoding encoding = Encoding::PLAIN,
+    arrow::ipc::feather::fbs::Type type = arrow::ipc::feather::fbs::Type::BOOL,
+    arrow::ipc::feather::fbs::Encoding encoding = arrow::ipc::feather::fbs::Encoding::PLAIN,
     int64_t offset = 0,
     int64_t length = 0,
     int64_t null_count = 0,
@@ -342,14 +351,15 @@ inline flatbuffers::Offset<PrimitiveArray> CreatePrimitiveArray(
 }
 
 struct CategoryMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef CategoryMetadataBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_LEVELS = 4,
     VT_ORDERED = 6
   };
   /// The category codes are presumed to be integers that are valid indexes into
   /// the levels array
-  const PrimitiveArray *levels() const {
-    return GetPointer<const PrimitiveArray *>(VT_LEVELS);
+  const arrow::ipc::feather::fbs::PrimitiveArray *levels() const {
+    return GetPointer<const arrow::ipc::feather::fbs::PrimitiveArray *>(VT_LEVELS);
   }
   bool ordered() const {
     return GetField<uint8_t>(VT_ORDERED, 0) != 0;
@@ -364,9 +374,10 @@ struct CategoryMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct CategoryMetadataBuilder {
+  typedef CategoryMetadata Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_levels(flatbuffers::Offset<PrimitiveArray> levels) {
+  void add_levels(flatbuffers::Offset<arrow::ipc::feather::fbs::PrimitiveArray> levels) {
     fbb_.AddOffset(CategoryMetadata::VT_LEVELS, levels);
   }
   void add_ordered(bool ordered) {
@@ -386,7 +397,7 @@ struct CategoryMetadataBuilder {
 
 inline flatbuffers::Offset<CategoryMetadata> CreateCategoryMetadata(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<PrimitiveArray> levels = 0,
+    flatbuffers::Offset<arrow::ipc::feather::fbs::PrimitiveArray> levels = 0,
     bool ordered = false) {
   CategoryMetadataBuilder builder_(_fbb);
   builder_.add_levels(levels);
@@ -395,12 +406,13 @@ inline flatbuffers::Offset<CategoryMetadata> CreateCategoryMetadata(
 }
 
 struct TimestampMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef TimestampMetadataBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_UNIT = 4,
     VT_TIMEZONE = 6
   };
-  TimeUnit unit() const {
-    return static_cast<TimeUnit>(GetField<int8_t>(VT_UNIT, 0));
+  arrow::ipc::feather::fbs::TimeUnit unit() const {
+    return static_cast<arrow::ipc::feather::fbs::TimeUnit>(GetField<int8_t>(VT_UNIT, 0));
   }
   /// Timestamp data is assumed to be UTC, but the time zone is stored here for
   /// presentation as localized
@@ -417,9 +429,10 @@ struct TimestampMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct TimestampMetadataBuilder {
+  typedef TimestampMetadata Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_unit(TimeUnit unit) {
+  void add_unit(arrow::ipc::feather::fbs::TimeUnit unit) {
     fbb_.AddElement<int8_t>(TimestampMetadata::VT_UNIT, static_cast<int8_t>(unit), 0);
   }
   void add_timezone(flatbuffers::Offset<flatbuffers::String> timezone) {
@@ -439,7 +452,7 @@ struct TimestampMetadataBuilder {
 
 inline flatbuffers::Offset<TimestampMetadata> CreateTimestampMetadata(
     flatbuffers::FlatBufferBuilder &_fbb,
-    TimeUnit unit = TimeUnit::SECOND,
+    arrow::ipc::feather::fbs::TimeUnit unit = arrow::ipc::feather::fbs::TimeUnit::SECOND,
     flatbuffers::Offset<flatbuffers::String> timezone = 0) {
   TimestampMetadataBuilder builder_(_fbb);
   builder_.add_timezone(timezone);
@@ -449,7 +462,7 @@ inline flatbuffers::Offset<TimestampMetadata> CreateTimestampMetadata(
 
 inline flatbuffers::Offset<TimestampMetadata> CreateTimestampMetadataDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    TimeUnit unit = TimeUnit::SECOND,
+    arrow::ipc::feather::fbs::TimeUnit unit = arrow::ipc::feather::fbs::TimeUnit::SECOND,
     const char *timezone = nullptr) {
   auto timezone__ = timezone ? _fbb.CreateString(timezone) : 0;
   return arrow::ipc::feather::fbs::CreateTimestampMetadata(
@@ -459,6 +472,7 @@ inline flatbuffers::Offset<TimestampMetadata> CreateTimestampMetadataDirect(
 }
 
 struct DateMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef DateMetadataBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -466,6 +480,7 @@ struct DateMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct DateMetadataBuilder {
+  typedef DateMetadata Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit DateMetadataBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -487,11 +502,12 @@ inline flatbuffers::Offset<DateMetadata> CreateDateMetadata(
 }
 
 struct TimeMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef TimeMetadataBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_UNIT = 4
   };
-  TimeUnit unit() const {
-    return static_cast<TimeUnit>(GetField<int8_t>(VT_UNIT, 0));
+  arrow::ipc::feather::fbs::TimeUnit unit() const {
+    return static_cast<arrow::ipc::feather::fbs::TimeUnit>(GetField<int8_t>(VT_UNIT, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -501,9 +517,10 @@ struct TimeMetadata FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct TimeMetadataBuilder {
+  typedef TimeMetadata Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_unit(TimeUnit unit) {
+  void add_unit(arrow::ipc::feather::fbs::TimeUnit unit) {
     fbb_.AddElement<int8_t>(TimeMetadata::VT_UNIT, static_cast<int8_t>(unit), 0);
   }
   explicit TimeMetadataBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -520,13 +537,14 @@ struct TimeMetadataBuilder {
 
 inline flatbuffers::Offset<TimeMetadata> CreateTimeMetadata(
     flatbuffers::FlatBufferBuilder &_fbb,
-    TimeUnit unit = TimeUnit::SECOND) {
+    arrow::ipc::feather::fbs::TimeUnit unit = arrow::ipc::feather::fbs::TimeUnit::SECOND) {
   TimeMetadataBuilder builder_(_fbb);
   builder_.add_unit(unit);
   return builder_.Finish();
 }
 
 struct Column FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef ColumnBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NAME = 4,
     VT_VALUES = 6,
@@ -537,27 +555,27 @@ struct Column FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::String *name() const {
     return GetPointer<const flatbuffers::String *>(VT_NAME);
   }
-  const PrimitiveArray *values() const {
-    return GetPointer<const PrimitiveArray *>(VT_VALUES);
+  const arrow::ipc::feather::fbs::PrimitiveArray *values() const {
+    return GetPointer<const arrow::ipc::feather::fbs::PrimitiveArray *>(VT_VALUES);
   }
-  TypeMetadata metadata_type() const {
-    return static_cast<TypeMetadata>(GetField<uint8_t>(VT_METADATA_TYPE, 0));
+  arrow::ipc::feather::fbs::TypeMetadata metadata_type() const {
+    return static_cast<arrow::ipc::feather::fbs::TypeMetadata>(GetField<uint8_t>(VT_METADATA_TYPE, 0));
   }
   const void *metadata() const {
     return GetPointer<const void *>(VT_METADATA);
   }
   template<typename T> const T *metadata_as() const;
-  const CategoryMetadata *metadata_as_CategoryMetadata() const {
-    return metadata_type() == TypeMetadata::CategoryMetadata ? static_cast<const CategoryMetadata *>(metadata()) : nullptr;
+  const arrow::ipc::feather::fbs::CategoryMetadata *metadata_as_CategoryMetadata() const {
+    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata::CategoryMetadata ? static_cast<const arrow::ipc::feather::fbs::CategoryMetadata *>(metadata()) : nullptr;
   }
-  const TimestampMetadata *metadata_as_TimestampMetadata() const {
-    return metadata_type() == TypeMetadata::TimestampMetadata ? static_cast<const TimestampMetadata *>(metadata()) : nullptr;
+  const arrow::ipc::feather::fbs::TimestampMetadata *metadata_as_TimestampMetadata() const {
+    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata::TimestampMetadata ? static_cast<const arrow::ipc::feather::fbs::TimestampMetadata *>(metadata()) : nullptr;
   }
-  const DateMetadata *metadata_as_DateMetadata() const {
-    return metadata_type() == TypeMetadata::DateMetadata ? static_cast<const DateMetadata *>(metadata()) : nullptr;
+  const arrow::ipc::feather::fbs::DateMetadata *metadata_as_DateMetadata() const {
+    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata::DateMetadata ? static_cast<const arrow::ipc::feather::fbs::DateMetadata *>(metadata()) : nullptr;
   }
-  const TimeMetadata *metadata_as_TimeMetadata() const {
-    return metadata_type() == TypeMetadata::TimeMetadata ? static_cast<const TimeMetadata *>(metadata()) : nullptr;
+  const arrow::ipc::feather::fbs::TimeMetadata *metadata_as_TimeMetadata() const {
+    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata::TimeMetadata ? static_cast<const arrow::ipc::feather::fbs::TimeMetadata *>(metadata()) : nullptr;
   }
   /// This should (probably) be JSON
   const flatbuffers::String *user_metadata() const {
@@ -578,32 +596,33 @@ struct Column FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   }
 };
 
-template<> inline const CategoryMetadata *Column::metadata_as<CategoryMetadata>() const {
+template<> inline const arrow::ipc::feather::fbs::CategoryMetadata *Column::metadata_as<arrow::ipc::feather::fbs::CategoryMetadata>() const {
   return metadata_as_CategoryMetadata();
 }
 
-template<> inline const TimestampMetadata *Column::metadata_as<TimestampMetadata>() const {
+template<> inline const arrow::ipc::feather::fbs::TimestampMetadata *Column::metadata_as<arrow::ipc::feather::fbs::TimestampMetadata>() const {
   return metadata_as_TimestampMetadata();
 }
 
-template<> inline const DateMetadata *Column::metadata_as<DateMetadata>() const {
+template<> inline const arrow::ipc::feather::fbs::DateMetadata *Column::metadata_as<arrow::ipc::feather::fbs::DateMetadata>() const {
   return metadata_as_DateMetadata();
 }
 
-template<> inline const TimeMetadata *Column::metadata_as<TimeMetadata>() const {
+template<> inline const arrow::ipc::feather::fbs::TimeMetadata *Column::metadata_as<arrow::ipc::feather::fbs::TimeMetadata>() const {
   return metadata_as_TimeMetadata();
 }
 
 struct ColumnBuilder {
+  typedef Column Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_name(flatbuffers::Offset<flatbuffers::String> name) {
     fbb_.AddOffset(Column::VT_NAME, name);
   }
-  void add_values(flatbuffers::Offset<PrimitiveArray> values) {
+  void add_values(flatbuffers::Offset<arrow::ipc::feather::fbs::PrimitiveArray> values) {
     fbb_.AddOffset(Column::VT_VALUES, values);
   }
-  void add_metadata_type(TypeMetadata metadata_type) {
+  void add_metadata_type(arrow::ipc::feather::fbs::TypeMetadata metadata_type) {
     fbb_.AddElement<uint8_t>(Column::VT_METADATA_TYPE, static_cast<uint8_t>(metadata_type), 0);
   }
   void add_metadata(flatbuffers::Offset<void> metadata) {
@@ -627,8 +646,8 @@ struct ColumnBuilder {
 inline flatbuffers::Offset<Column> CreateColumn(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> name = 0,
-    flatbuffers::Offset<PrimitiveArray> values = 0,
-    TypeMetadata metadata_type = TypeMetadata::NONE,
+    flatbuffers::Offset<arrow::ipc::feather::fbs::PrimitiveArray> values = 0,
+    arrow::ipc::feather::fbs::TypeMetadata metadata_type = arrow::ipc::feather::fbs::TypeMetadata::NONE,
     flatbuffers::Offset<void> metadata = 0,
     flatbuffers::Offset<flatbuffers::String> user_metadata = 0) {
   ColumnBuilder builder_(_fbb);
@@ -643,8 +662,8 @@ inline flatbuffers::Offset<Column> CreateColumn(
 inline flatbuffers::Offset<Column> CreateColumnDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
-    flatbuffers::Offset<PrimitiveArray> values = 0,
-    TypeMetadata metadata_type = TypeMetadata::NONE,
+    flatbuffers::Offset<arrow::ipc::feather::fbs::PrimitiveArray> values = 0,
+    arrow::ipc::feather::fbs::TypeMetadata metadata_type = arrow::ipc::feather::fbs::TypeMetadata::NONE,
     flatbuffers::Offset<void> metadata = 0,
     const char *user_metadata = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
@@ -659,6 +678,7 @@ inline flatbuffers::Offset<Column> CreateColumnDirect(
 }
 
 struct CTable FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
+  typedef CTableBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_DESCRIPTION = 4,
     VT_NUM_ROWS = 6,
@@ -673,8 +693,8 @@ struct CTable FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int64_t num_rows() const {
     return GetField<int64_t>(VT_NUM_ROWS, 0);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<Column>> *columns() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<Column>> *>(VT_COLUMNS);
+  const flatbuffers::Vector<flatbuffers::Offset<arrow::ipc::feather::fbs::Column>> *columns() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<arrow::ipc::feather::fbs::Column>> *>(VT_COLUMNS);
   }
   /// Version number of the Feather format
   int32_t version() const {
@@ -700,6 +720,7 @@ struct CTable FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct CTableBuilder {
+  typedef CTable Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_description(flatbuffers::Offset<flatbuffers::String> description) {
@@ -708,7 +729,7 @@ struct CTableBuilder {
   void add_num_rows(int64_t num_rows) {
     fbb_.AddElement<int64_t>(CTable::VT_NUM_ROWS, num_rows, 0);
   }
-  void add_columns(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Column>>> columns) {
+  void add_columns(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<arrow::ipc::feather::fbs::Column>>> columns) {
     fbb_.AddOffset(CTable::VT_COLUMNS, columns);
   }
   void add_version(int32_t version) {
@@ -733,7 +754,7 @@ inline flatbuffers::Offset<CTable> CreateCTable(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> description = 0,
     int64_t num_rows = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<Column>>> columns = 0,
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<arrow::ipc::feather::fbs::Column>>> columns = 0,
     int32_t version = 0,
     flatbuffers::Offset<flatbuffers::String> metadata = 0) {
   CTableBuilder builder_(_fbb);
@@ -749,11 +770,11 @@ inline flatbuffers::Offset<CTable> CreateCTableDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *description = nullptr,
     int64_t num_rows = 0,
-    const std::vector<flatbuffers::Offset<Column>> *columns = nullptr,
+    const std::vector<flatbuffers::Offset<arrow::ipc::feather::fbs::Column>> *columns = nullptr,
     int32_t version = 0,
     const char *metadata = nullptr) {
   auto description__ = description ? _fbb.CreateString(description) : 0;
-  auto columns__ = columns ? _fbb.CreateVector<flatbuffers::Offset<Column>>(*columns) : 0;
+  auto columns__ = columns ? _fbb.CreateVector<flatbuffers::Offset<arrow::ipc::feather::fbs::Column>>(*columns) : 0;
   auto metadata__ = metadata ? _fbb.CreateString(metadata) : 0;
   return arrow::ipc::feather::fbs::CreateCTable(
       _fbb,
@@ -770,22 +791,22 @@ inline bool VerifyTypeMetadata(flatbuffers::Verifier &verifier, const void *obj,
       return true;
     }
     case TypeMetadata::CategoryMetadata: {
-      auto ptr = reinterpret_cast<const CategoryMetadata *>(obj);
+      auto ptr = reinterpret_cast<const arrow::ipc::feather::fbs::CategoryMetadata *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case TypeMetadata::TimestampMetadata: {
-      auto ptr = reinterpret_cast<const TimestampMetadata *>(obj);
+      auto ptr = reinterpret_cast<const arrow::ipc::feather::fbs::TimestampMetadata *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case TypeMetadata::DateMetadata: {
-      auto ptr = reinterpret_cast<const DateMetadata *>(obj);
+      auto ptr = reinterpret_cast<const arrow::ipc::feather::fbs::DateMetadata *>(obj);
       return verifier.VerifyTable(ptr);
     }
     case TypeMetadata::TimeMetadata: {
-      auto ptr = reinterpret_cast<const TimeMetadata *>(obj);
+      auto ptr = reinterpret_cast<const arrow::ipc::feather::fbs::TimeMetadata *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    default: return false;
+    default: return true;
   }
 }
 

--- a/cpp/src/plasma/common_generated.h
+++ b/cpp/src/plasma/common_generated.h
@@ -10,6 +10,7 @@ namespace plasma {
 namespace flatbuf {
 
 struct ObjectInfo;
+struct ObjectInfoBuilder;
 struct ObjectInfoT;
 
 struct ObjectInfoT : public flatbuffers::NativeTable {
@@ -34,6 +35,7 @@ struct ObjectInfoT : public flatbuffers::NativeTable {
 
 struct ObjectInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef ObjectInfoT NativeTableType;
+  typedef ObjectInfoBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_DATA_SIZE = 6,
@@ -88,6 +90,7 @@ struct ObjectInfo FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct ObjectInfoBuilder {
+  typedef ObjectInfo Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -175,22 +178,22 @@ inline flatbuffers::Offset<ObjectInfo> CreateObjectInfoDirect(
 flatbuffers::Offset<ObjectInfo> CreateObjectInfo(flatbuffers::FlatBufferBuilder &_fbb, const ObjectInfoT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline ObjectInfoT *ObjectInfo::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new ObjectInfoT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::ObjectInfoT> _o = std::unique_ptr<plasma::flatbuf::ObjectInfoT>(new ObjectInfoT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void ObjectInfo::UnPackTo(ObjectInfoT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = data_size(); _o->data_size = _e; };
-  { auto _e = metadata_size(); _o->metadata_size = _e; };
-  { auto _e = ref_count(); _o->ref_count = _e; };
-  { auto _e = create_time(); _o->create_time = _e; };
-  { auto _e = construct_duration(); _o->construct_duration = _e; };
-  { auto _e = digest(); if (_e) _o->digest = _e->str(); };
-  { auto _e = is_deletion(); _o->is_deletion = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = data_size(); _o->data_size = _e; }
+  { auto _e = metadata_size(); _o->metadata_size = _e; }
+  { auto _e = ref_count(); _o->ref_count = _e; }
+  { auto _e = create_time(); _o->create_time = _e; }
+  { auto _e = construct_duration(); _o->construct_duration = _e; }
+  { auto _e = digest(); if (_e) _o->digest = _e->str(); }
+  { auto _e = is_deletion(); _o->is_deletion = _e; }
 }
 
 inline flatbuffers::Offset<ObjectInfo> ObjectInfo::Pack(flatbuffers::FlatBufferBuilder &_fbb, const ObjectInfoT* _o, const flatbuffers::rehasher_function_t *_rehasher) {

--- a/cpp/src/plasma/plasma_generated.h
+++ b/cpp/src/plasma/plasma_generated.h
@@ -14,147 +14,182 @@ namespace flatbuf {
 struct PlasmaObjectSpec;
 
 struct PlasmaSetOptionsRequest;
+struct PlasmaSetOptionsRequestBuilder;
 struct PlasmaSetOptionsRequestT;
 
 struct PlasmaSetOptionsReply;
+struct PlasmaSetOptionsReplyBuilder;
 struct PlasmaSetOptionsReplyT;
 
 struct PlasmaGetDebugStringRequest;
+struct PlasmaGetDebugStringRequestBuilder;
 struct PlasmaGetDebugStringRequestT;
 
 struct PlasmaGetDebugStringReply;
+struct PlasmaGetDebugStringReplyBuilder;
 struct PlasmaGetDebugStringReplyT;
 
 struct PlasmaCreateRequest;
+struct PlasmaCreateRequestBuilder;
 struct PlasmaCreateRequestT;
 
 struct CudaHandle;
+struct CudaHandleBuilder;
 struct CudaHandleT;
 
 struct PlasmaCreateReply;
+struct PlasmaCreateReplyBuilder;
 struct PlasmaCreateReplyT;
 
 struct PlasmaCreateAndSealRequest;
+struct PlasmaCreateAndSealRequestBuilder;
 struct PlasmaCreateAndSealRequestT;
 
 struct PlasmaCreateAndSealReply;
+struct PlasmaCreateAndSealReplyBuilder;
 struct PlasmaCreateAndSealReplyT;
 
 struct PlasmaCreateAndSealBatchRequest;
+struct PlasmaCreateAndSealBatchRequestBuilder;
 struct PlasmaCreateAndSealBatchRequestT;
 
 struct PlasmaCreateAndSealBatchReply;
+struct PlasmaCreateAndSealBatchReplyBuilder;
 struct PlasmaCreateAndSealBatchReplyT;
 
 struct PlasmaAbortRequest;
+struct PlasmaAbortRequestBuilder;
 struct PlasmaAbortRequestT;
 
 struct PlasmaAbortReply;
+struct PlasmaAbortReplyBuilder;
 struct PlasmaAbortReplyT;
 
 struct PlasmaSealRequest;
+struct PlasmaSealRequestBuilder;
 struct PlasmaSealRequestT;
 
 struct PlasmaSealReply;
+struct PlasmaSealReplyBuilder;
 struct PlasmaSealReplyT;
 
 struct PlasmaGetRequest;
+struct PlasmaGetRequestBuilder;
 struct PlasmaGetRequestT;
 
 struct PlasmaGetReply;
+struct PlasmaGetReplyBuilder;
 struct PlasmaGetReplyT;
 
 struct PlasmaReleaseRequest;
+struct PlasmaReleaseRequestBuilder;
 struct PlasmaReleaseRequestT;
 
 struct PlasmaReleaseReply;
+struct PlasmaReleaseReplyBuilder;
 struct PlasmaReleaseReplyT;
 
 struct PlasmaDeleteRequest;
+struct PlasmaDeleteRequestBuilder;
 struct PlasmaDeleteRequestT;
 
 struct PlasmaDeleteReply;
+struct PlasmaDeleteReplyBuilder;
 struct PlasmaDeleteReplyT;
 
 struct PlasmaContainsRequest;
+struct PlasmaContainsRequestBuilder;
 struct PlasmaContainsRequestT;
 
 struct PlasmaContainsReply;
+struct PlasmaContainsReplyBuilder;
 struct PlasmaContainsReplyT;
 
 struct PlasmaListRequest;
+struct PlasmaListRequestBuilder;
 struct PlasmaListRequestT;
 
 struct PlasmaListReply;
+struct PlasmaListReplyBuilder;
 struct PlasmaListReplyT;
 
 struct PlasmaConnectRequest;
+struct PlasmaConnectRequestBuilder;
 struct PlasmaConnectRequestT;
 
 struct PlasmaConnectReply;
+struct PlasmaConnectReplyBuilder;
 struct PlasmaConnectReplyT;
 
 struct PlasmaEvictRequest;
+struct PlasmaEvictRequestBuilder;
 struct PlasmaEvictRequestT;
 
 struct PlasmaEvictReply;
+struct PlasmaEvictReplyBuilder;
 struct PlasmaEvictReplyT;
 
 struct PlasmaSubscribeRequest;
+struct PlasmaSubscribeRequestBuilder;
 struct PlasmaSubscribeRequestT;
 
 struct PlasmaNotification;
+struct PlasmaNotificationBuilder;
 struct PlasmaNotificationT;
 
 struct PlasmaDataRequest;
+struct PlasmaDataRequestBuilder;
 struct PlasmaDataRequestT;
 
 struct PlasmaDataReply;
+struct PlasmaDataReplyBuilder;
 struct PlasmaDataReplyT;
 
 struct PlasmaRefreshLRURequest;
+struct PlasmaRefreshLRURequestBuilder;
 struct PlasmaRefreshLRURequestT;
 
 struct PlasmaRefreshLRUReply;
+struct PlasmaRefreshLRUReplyBuilder;
 struct PlasmaRefreshLRUReplyT;
 
 enum class MessageType : int64_t {
   PlasmaDisconnectClient = 0,
-  PlasmaCreateRequest = 1,
-  PlasmaCreateReply = 2,
-  PlasmaCreateAndSealRequest = 3,
-  PlasmaCreateAndSealReply = 4,
-  PlasmaAbortRequest = 5,
-  PlasmaAbortReply = 6,
-  PlasmaSealRequest = 7,
-  PlasmaSealReply = 8,
-  PlasmaGetRequest = 9,
-  PlasmaGetReply = 10,
-  PlasmaReleaseRequest = 11,
-  PlasmaReleaseReply = 12,
-  PlasmaDeleteRequest = 13,
-  PlasmaDeleteReply = 14,
-  PlasmaContainsRequest = 15,
-  PlasmaContainsReply = 16,
-  PlasmaListRequest = 17,
-  PlasmaListReply = 18,
-  PlasmaConnectRequest = 19,
-  PlasmaConnectReply = 20,
-  PlasmaEvictRequest = 21,
-  PlasmaEvictReply = 22,
-  PlasmaSubscribeRequest = 23,
-  PlasmaUnsubscribeRequest = 24,
-  PlasmaDataRequest = 25,
-  PlasmaDataReply = 26,
-  PlasmaNotification = 27,
-  PlasmaSetOptionsRequest = 28,
-  PlasmaSetOptionsReply = 29,
-  PlasmaGetDebugStringRequest = 30,
-  PlasmaGetDebugStringReply = 31,
-  PlasmaCreateAndSealBatchRequest = 32,
-  PlasmaCreateAndSealBatchReply = 33,
-  PlasmaRefreshLRURequest = 34,
-  PlasmaRefreshLRUReply = 35,
+  PlasmaCreateRequest = 1LL,
+  PlasmaCreateReply = 2LL,
+  PlasmaCreateAndSealRequest = 3LL,
+  PlasmaCreateAndSealReply = 4LL,
+  PlasmaAbortRequest = 5LL,
+  PlasmaAbortReply = 6LL,
+  PlasmaSealRequest = 7LL,
+  PlasmaSealReply = 8LL,
+  PlasmaGetRequest = 9LL,
+  PlasmaGetReply = 10LL,
+  PlasmaReleaseRequest = 11LL,
+  PlasmaReleaseReply = 12LL,
+  PlasmaDeleteRequest = 13LL,
+  PlasmaDeleteReply = 14LL,
+  PlasmaContainsRequest = 15LL,
+  PlasmaContainsReply = 16LL,
+  PlasmaListRequest = 17LL,
+  PlasmaListReply = 18LL,
+  PlasmaConnectRequest = 19LL,
+  PlasmaConnectReply = 20LL,
+  PlasmaEvictRequest = 21LL,
+  PlasmaEvictReply = 22LL,
+  PlasmaSubscribeRequest = 23LL,
+  PlasmaUnsubscribeRequest = 24LL,
+  PlasmaDataRequest = 25LL,
+  PlasmaDataReply = 26LL,
+  PlasmaNotification = 27LL,
+  PlasmaSetOptionsRequest = 28LL,
+  PlasmaSetOptionsReply = 29LL,
+  PlasmaGetDebugStringRequest = 30LL,
+  PlasmaGetDebugStringReply = 31LL,
+  PlasmaCreateAndSealBatchRequest = 32LL,
+  PlasmaCreateAndSealBatchReply = 33LL,
+  PlasmaRefreshLRURequest = 34LL,
+  PlasmaRefreshLRUReply = 35LL,
   MIN = PlasmaDisconnectClient,
   MAX = PlasmaRefreshLRUReply
 };
@@ -202,7 +237,7 @@ inline const MessageType (&EnumValuesMessageType())[36] {
 }
 
 inline const char * const *EnumNamesMessageType() {
-  static const char * const names[] = {
+  static const char * const names[37] = {
     "PlasmaDisconnectClient",
     "PlasmaCreateRequest",
     "PlasmaCreateReply",
@@ -245,7 +280,7 @@ inline const char * const *EnumNamesMessageType() {
 }
 
 inline const char *EnumNameMessageType(MessageType e) {
-  if (e < MessageType::PlasmaDisconnectClient || e > MessageType::PlasmaRefreshLRUReply) return "";
+  if (flatbuffers::IsOutRange(e, MessageType::PlasmaDisconnectClient, MessageType::PlasmaRefreshLRUReply)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesMessageType()[index];
 }
@@ -274,7 +309,7 @@ inline const PlasmaError (&EnumValuesPlasmaError())[6] {
 }
 
 inline const char * const *EnumNamesPlasmaError() {
-  static const char * const names[] = {
+  static const char * const names[7] = {
     "OK",
     "ObjectExists",
     "ObjectNonexistent",
@@ -287,7 +322,7 @@ inline const char * const *EnumNamesPlasmaError() {
 }
 
 inline const char *EnumNamePlasmaError(PlasmaError e) {
-  if (e < PlasmaError::OK || e > PlasmaError::ObjectInUse) return "";
+  if (flatbuffers::IsOutRange(e, PlasmaError::OK, PlasmaError::ObjectInUse)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesPlasmaError()[index];
 }
@@ -351,6 +386,7 @@ struct PlasmaSetOptionsRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaSetOptionsRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaSetOptionsRequestT NativeTableType;
+  typedef PlasmaSetOptionsRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_CLIENT_NAME = 4,
     VT_OUTPUT_MEMORY_QUOTA = 6
@@ -374,6 +410,7 @@ struct PlasmaSetOptionsRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Ta
 };
 
 struct PlasmaSetOptionsRequestBuilder {
+  typedef PlasmaSetOptionsRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_client_name(flatbuffers::Offset<flatbuffers::String> client_name) {
@@ -419,19 +456,20 @@ flatbuffers::Offset<PlasmaSetOptionsRequest> CreatePlasmaSetOptionsRequest(flatb
 
 struct PlasmaSetOptionsReplyT : public flatbuffers::NativeTable {
   typedef PlasmaSetOptionsReply TableType;
-  PlasmaError error;
+  plasma::flatbuf::PlasmaError error;
   PlasmaSetOptionsReplyT()
-      : error(PlasmaError::OK) {
+      : error(plasma::flatbuf::PlasmaError::OK) {
   }
 };
 
 struct PlasmaSetOptionsReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaSetOptionsReplyT NativeTableType;
+  typedef PlasmaSetOptionsReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ERROR = 4
   };
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -444,9 +482,10 @@ struct PlasmaSetOptionsReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 };
 
 struct PlasmaSetOptionsReplyBuilder {
+  typedef PlasmaSetOptionsReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaSetOptionsReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   explicit PlasmaSetOptionsReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -463,7 +502,7 @@ struct PlasmaSetOptionsReplyBuilder {
 
 inline flatbuffers::Offset<PlasmaSetOptionsReply> CreatePlasmaSetOptionsReply(
     flatbuffers::FlatBufferBuilder &_fbb,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   PlasmaSetOptionsReplyBuilder builder_(_fbb);
   builder_.add_error(error);
   return builder_.Finish();
@@ -479,6 +518,7 @@ struct PlasmaGetDebugStringRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaGetDebugStringRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaGetDebugStringRequestT NativeTableType;
+  typedef PlasmaGetDebugStringRequestBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -489,6 +529,7 @@ struct PlasmaGetDebugStringRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers
 };
 
 struct PlasmaGetDebugStringRequestBuilder {
+  typedef PlasmaGetDebugStringRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PlasmaGetDebugStringRequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -520,6 +561,7 @@ struct PlasmaGetDebugStringReplyT : public flatbuffers::NativeTable {
 
 struct PlasmaGetDebugStringReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaGetDebugStringReplyT NativeTableType;
+  typedef PlasmaGetDebugStringReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_DEBUG_STRING = 4
   };
@@ -538,6 +580,7 @@ struct PlasmaGetDebugStringReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::
 };
 
 struct PlasmaGetDebugStringReplyBuilder {
+  typedef PlasmaGetDebugStringReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_debug_string(flatbuffers::Offset<flatbuffers::String> debug_string) {
@@ -591,6 +634,7 @@ struct PlasmaCreateRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaCreateRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaCreateRequestT NativeTableType;
+  typedef PlasmaCreateRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_EVICT_IF_FULL = 6,
@@ -629,6 +673,7 @@ struct PlasmaCreateRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table 
 };
 
 struct PlasmaCreateRequestBuilder {
+  typedef PlasmaCreateRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -702,6 +747,7 @@ struct CudaHandleT : public flatbuffers::NativeTable {
 
 struct CudaHandle FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef CudaHandleT NativeTableType;
+  typedef CudaHandleBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_HANDLE = 4
   };
@@ -720,6 +766,7 @@ struct CudaHandle FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct CudaHandleBuilder {
+  typedef CudaHandle Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_handle(flatbuffers::Offset<flatbuffers::Vector<uint8_t>> handle) {
@@ -759,13 +806,13 @@ flatbuffers::Offset<CudaHandle> CreateCudaHandle(flatbuffers::FlatBufferBuilder 
 struct PlasmaCreateReplyT : public flatbuffers::NativeTable {
   typedef PlasmaCreateReply TableType;
   std::string object_id;
-  std::unique_ptr<PlasmaObjectSpec> plasma_object;
-  PlasmaError error;
+  std::unique_ptr<plasma::flatbuf::PlasmaObjectSpec> plasma_object;
+  plasma::flatbuf::PlasmaError error;
   int32_t store_fd;
   int64_t mmap_size;
-  std::unique_ptr<CudaHandleT> ipc_handle;
+  std::unique_ptr<plasma::flatbuf::CudaHandleT> ipc_handle;
   PlasmaCreateReplyT()
-      : error(PlasmaError::OK),
+      : error(plasma::flatbuf::PlasmaError::OK),
         store_fd(0),
         mmap_size(0) {
   }
@@ -773,6 +820,7 @@ struct PlasmaCreateReplyT : public flatbuffers::NativeTable {
 
 struct PlasmaCreateReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaCreateReplyT NativeTableType;
+  typedef PlasmaCreateReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_PLASMA_OBJECT = 6,
@@ -784,11 +832,11 @@ struct PlasmaCreateReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::String *object_id() const {
     return GetPointer<const flatbuffers::String *>(VT_OBJECT_ID);
   }
-  const PlasmaObjectSpec *plasma_object() const {
-    return GetStruct<const PlasmaObjectSpec *>(VT_PLASMA_OBJECT);
+  const plasma::flatbuf::PlasmaObjectSpec *plasma_object() const {
+    return GetStruct<const plasma::flatbuf::PlasmaObjectSpec *>(VT_PLASMA_OBJECT);
   }
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   int32_t store_fd() const {
     return GetField<int32_t>(VT_STORE_FD, 0);
@@ -796,14 +844,14 @@ struct PlasmaCreateReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int64_t mmap_size() const {
     return GetField<int64_t>(VT_MMAP_SIZE, 0);
   }
-  const CudaHandle *ipc_handle() const {
-    return GetPointer<const CudaHandle *>(VT_IPC_HANDLE);
+  const plasma::flatbuf::CudaHandle *ipc_handle() const {
+    return GetPointer<const plasma::flatbuf::CudaHandle *>(VT_IPC_HANDLE);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffset(verifier, VT_OBJECT_ID) &&
            verifier.VerifyString(object_id()) &&
-           VerifyField<PlasmaObjectSpec>(verifier, VT_PLASMA_OBJECT) &&
+           VerifyField<plasma::flatbuf::PlasmaObjectSpec>(verifier, VT_PLASMA_OBJECT) &&
            VerifyField<int32_t>(verifier, VT_ERROR) &&
            VerifyField<int32_t>(verifier, VT_STORE_FD) &&
            VerifyField<int64_t>(verifier, VT_MMAP_SIZE) &&
@@ -817,15 +865,16 @@ struct PlasmaCreateReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaCreateReplyBuilder {
+  typedef PlasmaCreateReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
     fbb_.AddOffset(PlasmaCreateReply::VT_OBJECT_ID, object_id);
   }
-  void add_plasma_object(const PlasmaObjectSpec *plasma_object) {
+  void add_plasma_object(const plasma::flatbuf::PlasmaObjectSpec *plasma_object) {
     fbb_.AddStruct(PlasmaCreateReply::VT_PLASMA_OBJECT, plasma_object);
   }
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaCreateReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   void add_store_fd(int32_t store_fd) {
@@ -834,7 +883,7 @@ struct PlasmaCreateReplyBuilder {
   void add_mmap_size(int64_t mmap_size) {
     fbb_.AddElement<int64_t>(PlasmaCreateReply::VT_MMAP_SIZE, mmap_size, 0);
   }
-  void add_ipc_handle(flatbuffers::Offset<CudaHandle> ipc_handle) {
+  void add_ipc_handle(flatbuffers::Offset<plasma::flatbuf::CudaHandle> ipc_handle) {
     fbb_.AddOffset(PlasmaCreateReply::VT_IPC_HANDLE, ipc_handle);
   }
   explicit PlasmaCreateReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -852,11 +901,11 @@ struct PlasmaCreateReplyBuilder {
 inline flatbuffers::Offset<PlasmaCreateReply> CreatePlasmaCreateReply(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> object_id = 0,
-    const PlasmaObjectSpec *plasma_object = 0,
-    PlasmaError error = PlasmaError::OK,
+    const plasma::flatbuf::PlasmaObjectSpec *plasma_object = 0,
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK,
     int32_t store_fd = 0,
     int64_t mmap_size = 0,
-    flatbuffers::Offset<CudaHandle> ipc_handle = 0) {
+    flatbuffers::Offset<plasma::flatbuf::CudaHandle> ipc_handle = 0) {
   PlasmaCreateReplyBuilder builder_(_fbb);
   builder_.add_mmap_size(mmap_size);
   builder_.add_ipc_handle(ipc_handle);
@@ -870,11 +919,11 @@ inline flatbuffers::Offset<PlasmaCreateReply> CreatePlasmaCreateReply(
 inline flatbuffers::Offset<PlasmaCreateReply> CreatePlasmaCreateReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *object_id = nullptr,
-    const PlasmaObjectSpec *plasma_object = 0,
-    PlasmaError error = PlasmaError::OK,
+    const plasma::flatbuf::PlasmaObjectSpec *plasma_object = 0,
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK,
     int32_t store_fd = 0,
     int64_t mmap_size = 0,
-    flatbuffers::Offset<CudaHandle> ipc_handle = 0) {
+    flatbuffers::Offset<plasma::flatbuf::CudaHandle> ipc_handle = 0) {
   auto object_id__ = object_id ? _fbb.CreateString(object_id) : 0;
   return plasma::flatbuf::CreatePlasmaCreateReply(
       _fbb,
@@ -902,6 +951,7 @@ struct PlasmaCreateAndSealRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaCreateAndSealRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaCreateAndSealRequestT NativeTableType;
+  typedef PlasmaCreateAndSealRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_EVICT_IF_FULL = 6,
@@ -943,6 +993,7 @@ struct PlasmaCreateAndSealRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers:
 };
 
 struct PlasmaCreateAndSealRequestBuilder {
+  typedef PlasmaCreateAndSealRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -1012,19 +1063,20 @@ flatbuffers::Offset<PlasmaCreateAndSealRequest> CreatePlasmaCreateAndSealRequest
 
 struct PlasmaCreateAndSealReplyT : public flatbuffers::NativeTable {
   typedef PlasmaCreateAndSealReply TableType;
-  PlasmaError error;
+  plasma::flatbuf::PlasmaError error;
   PlasmaCreateAndSealReplyT()
-      : error(PlasmaError::OK) {
+      : error(plasma::flatbuf::PlasmaError::OK) {
   }
 };
 
 struct PlasmaCreateAndSealReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaCreateAndSealReplyT NativeTableType;
+  typedef PlasmaCreateAndSealReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ERROR = 4
   };
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1037,9 +1089,10 @@ struct PlasmaCreateAndSealReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::T
 };
 
 struct PlasmaCreateAndSealReplyBuilder {
+  typedef PlasmaCreateAndSealReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaCreateAndSealReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   explicit PlasmaCreateAndSealReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1056,7 +1109,7 @@ struct PlasmaCreateAndSealReplyBuilder {
 
 inline flatbuffers::Offset<PlasmaCreateAndSealReply> CreatePlasmaCreateAndSealReply(
     flatbuffers::FlatBufferBuilder &_fbb,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   PlasmaCreateAndSealReplyBuilder builder_(_fbb);
   builder_.add_error(error);
   return builder_.Finish();
@@ -1078,6 +1131,7 @@ struct PlasmaCreateAndSealBatchRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaCreateAndSealBatchRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaCreateAndSealBatchRequestT NativeTableType;
+  typedef PlasmaCreateAndSealBatchRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_IDS = 4,
     VT_EVICT_IF_FULL = 6,
@@ -1123,6 +1177,7 @@ struct PlasmaCreateAndSealBatchRequest FLATBUFFERS_FINAL_CLASS : private flatbuf
 };
 
 struct PlasmaCreateAndSealBatchRequestBuilder {
+  typedef PlasmaCreateAndSealBatchRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_ids(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> object_ids) {
@@ -1192,19 +1247,20 @@ flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> CreatePlasmaCreateAndSealBa
 
 struct PlasmaCreateAndSealBatchReplyT : public flatbuffers::NativeTable {
   typedef PlasmaCreateAndSealBatchReply TableType;
-  PlasmaError error;
+  plasma::flatbuf::PlasmaError error;
   PlasmaCreateAndSealBatchReplyT()
-      : error(PlasmaError::OK) {
+      : error(plasma::flatbuf::PlasmaError::OK) {
   }
 };
 
 struct PlasmaCreateAndSealBatchReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaCreateAndSealBatchReplyT NativeTableType;
+  typedef PlasmaCreateAndSealBatchReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ERROR = 4
   };
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1217,9 +1273,10 @@ struct PlasmaCreateAndSealBatchReply FLATBUFFERS_FINAL_CLASS : private flatbuffe
 };
 
 struct PlasmaCreateAndSealBatchReplyBuilder {
+  typedef PlasmaCreateAndSealBatchReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaCreateAndSealBatchReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   explicit PlasmaCreateAndSealBatchReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1236,7 +1293,7 @@ struct PlasmaCreateAndSealBatchReplyBuilder {
 
 inline flatbuffers::Offset<PlasmaCreateAndSealBatchReply> CreatePlasmaCreateAndSealBatchReply(
     flatbuffers::FlatBufferBuilder &_fbb,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   PlasmaCreateAndSealBatchReplyBuilder builder_(_fbb);
   builder_.add_error(error);
   return builder_.Finish();
@@ -1253,6 +1310,7 @@ struct PlasmaAbortRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaAbortRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaAbortRequestT NativeTableType;
+  typedef PlasmaAbortRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4
   };
@@ -1271,6 +1329,7 @@ struct PlasmaAbortRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaAbortRequestBuilder {
+  typedef PlasmaAbortRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -1316,6 +1375,7 @@ struct PlasmaAbortReplyT : public flatbuffers::NativeTable {
 
 struct PlasmaAbortReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaAbortReplyT NativeTableType;
+  typedef PlasmaAbortReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4
   };
@@ -1334,6 +1394,7 @@ struct PlasmaAbortReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaAbortReplyBuilder {
+  typedef PlasmaAbortReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -1380,6 +1441,7 @@ struct PlasmaSealRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaSealRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaSealRequestT NativeTableType;
+  typedef PlasmaSealRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_DIGEST = 6
@@ -1404,6 +1466,7 @@ struct PlasmaSealRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaSealRequestBuilder {
+  typedef PlasmaSealRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -1451,14 +1514,15 @@ flatbuffers::Offset<PlasmaSealRequest> CreatePlasmaSealRequest(flatbuffers::Flat
 struct PlasmaSealReplyT : public flatbuffers::NativeTable {
   typedef PlasmaSealReply TableType;
   std::string object_id;
-  PlasmaError error;
+  plasma::flatbuf::PlasmaError error;
   PlasmaSealReplyT()
-      : error(PlasmaError::OK) {
+      : error(plasma::flatbuf::PlasmaError::OK) {
   }
 };
 
 struct PlasmaSealReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaSealReplyT NativeTableType;
+  typedef PlasmaSealReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_ERROR = 6
@@ -1466,8 +1530,8 @@ struct PlasmaSealReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::String *object_id() const {
     return GetPointer<const flatbuffers::String *>(VT_OBJECT_ID);
   }
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1482,12 +1546,13 @@ struct PlasmaSealReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaSealReplyBuilder {
+  typedef PlasmaSealReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
     fbb_.AddOffset(PlasmaSealReply::VT_OBJECT_ID, object_id);
   }
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaSealReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   explicit PlasmaSealReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1505,7 +1570,7 @@ struct PlasmaSealReplyBuilder {
 inline flatbuffers::Offset<PlasmaSealReply> CreatePlasmaSealReply(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> object_id = 0,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   PlasmaSealReplyBuilder builder_(_fbb);
   builder_.add_error(error);
   builder_.add_object_id(object_id);
@@ -1515,7 +1580,7 @@ inline flatbuffers::Offset<PlasmaSealReply> CreatePlasmaSealReply(
 inline flatbuffers::Offset<PlasmaSealReply> CreatePlasmaSealReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *object_id = nullptr,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   auto object_id__ = object_id ? _fbb.CreateString(object_id) : 0;
   return plasma::flatbuf::CreatePlasmaSealReply(
       _fbb,
@@ -1536,6 +1601,7 @@ struct PlasmaGetRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaGetRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaGetRequestT NativeTableType;
+  typedef PlasmaGetRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_IDS = 4,
     VT_TIMEOUT_MS = 6
@@ -1560,6 +1626,7 @@ struct PlasmaGetRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaGetRequestBuilder {
+  typedef PlasmaGetRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_ids(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> object_ids) {
@@ -1606,16 +1673,17 @@ flatbuffers::Offset<PlasmaGetRequest> CreatePlasmaGetRequest(flatbuffers::FlatBu
 struct PlasmaGetReplyT : public flatbuffers::NativeTable {
   typedef PlasmaGetReply TableType;
   std::vector<std::string> object_ids;
-  std::vector<PlasmaObjectSpec> plasma_objects;
+  std::vector<plasma::flatbuf::PlasmaObjectSpec> plasma_objects;
   std::vector<int32_t> store_fds;
   std::vector<int64_t> mmap_sizes;
-  std::vector<std::unique_ptr<CudaHandleT>> handles;
+  std::vector<std::unique_ptr<plasma::flatbuf::CudaHandleT>> handles;
   PlasmaGetReplyT() {
   }
 };
 
 struct PlasmaGetReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaGetReplyT NativeTableType;
+  typedef PlasmaGetReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_IDS = 4,
     VT_PLASMA_OBJECTS = 6,
@@ -1626,8 +1694,8 @@ struct PlasmaGetReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *object_ids() const {
     return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>> *>(VT_OBJECT_IDS);
   }
-  const flatbuffers::Vector<const PlasmaObjectSpec *> *plasma_objects() const {
-    return GetPointer<const flatbuffers::Vector<const PlasmaObjectSpec *> *>(VT_PLASMA_OBJECTS);
+  const flatbuffers::Vector<const plasma::flatbuf::PlasmaObjectSpec *> *plasma_objects() const {
+    return GetPointer<const flatbuffers::Vector<const plasma::flatbuf::PlasmaObjectSpec *> *>(VT_PLASMA_OBJECTS);
   }
   const flatbuffers::Vector<int32_t> *store_fds() const {
     return GetPointer<const flatbuffers::Vector<int32_t> *>(VT_STORE_FDS);
@@ -1635,8 +1703,8 @@ struct PlasmaGetReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<int64_t> *mmap_sizes() const {
     return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_MMAP_SIZES);
   }
-  const flatbuffers::Vector<flatbuffers::Offset<CudaHandle>> *handles() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<CudaHandle>> *>(VT_HANDLES);
+  const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>> *handles() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>> *>(VT_HANDLES);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1660,12 +1728,13 @@ struct PlasmaGetReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaGetReplyBuilder {
+  typedef PlasmaGetReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_ids(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> object_ids) {
     fbb_.AddOffset(PlasmaGetReply::VT_OBJECT_IDS, object_ids);
   }
-  void add_plasma_objects(flatbuffers::Offset<flatbuffers::Vector<const PlasmaObjectSpec *>> plasma_objects) {
+  void add_plasma_objects(flatbuffers::Offset<flatbuffers::Vector<const plasma::flatbuf::PlasmaObjectSpec *>> plasma_objects) {
     fbb_.AddOffset(PlasmaGetReply::VT_PLASMA_OBJECTS, plasma_objects);
   }
   void add_store_fds(flatbuffers::Offset<flatbuffers::Vector<int32_t>> store_fds) {
@@ -1674,7 +1743,7 @@ struct PlasmaGetReplyBuilder {
   void add_mmap_sizes(flatbuffers::Offset<flatbuffers::Vector<int64_t>> mmap_sizes) {
     fbb_.AddOffset(PlasmaGetReply::VT_MMAP_SIZES, mmap_sizes);
   }
-  void add_handles(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<CudaHandle>>> handles) {
+  void add_handles(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>>> handles) {
     fbb_.AddOffset(PlasmaGetReply::VT_HANDLES, handles);
   }
   explicit PlasmaGetReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1692,10 +1761,10 @@ struct PlasmaGetReplyBuilder {
 inline flatbuffers::Offset<PlasmaGetReply> CreatePlasmaGetReply(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> object_ids = 0,
-    flatbuffers::Offset<flatbuffers::Vector<const PlasmaObjectSpec *>> plasma_objects = 0,
+    flatbuffers::Offset<flatbuffers::Vector<const plasma::flatbuf::PlasmaObjectSpec *>> plasma_objects = 0,
     flatbuffers::Offset<flatbuffers::Vector<int32_t>> store_fds = 0,
     flatbuffers::Offset<flatbuffers::Vector<int64_t>> mmap_sizes = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<CudaHandle>>> handles = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>>> handles = 0) {
   PlasmaGetReplyBuilder builder_(_fbb);
   builder_.add_handles(handles);
   builder_.add_mmap_sizes(mmap_sizes);
@@ -1708,15 +1777,15 @@ inline flatbuffers::Offset<PlasmaGetReply> CreatePlasmaGetReply(
 inline flatbuffers::Offset<PlasmaGetReply> CreatePlasmaGetReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const std::vector<flatbuffers::Offset<flatbuffers::String>> *object_ids = nullptr,
-    const std::vector<PlasmaObjectSpec> *plasma_objects = nullptr,
+    const std::vector<plasma::flatbuf::PlasmaObjectSpec> *plasma_objects = nullptr,
     const std::vector<int32_t> *store_fds = nullptr,
     const std::vector<int64_t> *mmap_sizes = nullptr,
-    const std::vector<flatbuffers::Offset<CudaHandle>> *handles = nullptr) {
+    const std::vector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>> *handles = nullptr) {
   auto object_ids__ = object_ids ? _fbb.CreateVector<flatbuffers::Offset<flatbuffers::String>>(*object_ids) : 0;
-  auto plasma_objects__ = plasma_objects ? _fbb.CreateVectorOfStructs<PlasmaObjectSpec>(*plasma_objects) : 0;
+  auto plasma_objects__ = plasma_objects ? _fbb.CreateVectorOfStructs<plasma::flatbuf::PlasmaObjectSpec>(*plasma_objects) : 0;
   auto store_fds__ = store_fds ? _fbb.CreateVector<int32_t>(*store_fds) : 0;
   auto mmap_sizes__ = mmap_sizes ? _fbb.CreateVector<int64_t>(*mmap_sizes) : 0;
-  auto handles__ = handles ? _fbb.CreateVector<flatbuffers::Offset<CudaHandle>>(*handles) : 0;
+  auto handles__ = handles ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>>(*handles) : 0;
   return plasma::flatbuf::CreatePlasmaGetReply(
       _fbb,
       object_ids__,
@@ -1737,6 +1806,7 @@ struct PlasmaReleaseRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaReleaseRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaReleaseRequestT NativeTableType;
+  typedef PlasmaReleaseRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4
   };
@@ -1755,6 +1825,7 @@ struct PlasmaReleaseRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 };
 
 struct PlasmaReleaseRequestBuilder {
+  typedef PlasmaReleaseRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -1794,14 +1865,15 @@ flatbuffers::Offset<PlasmaReleaseRequest> CreatePlasmaReleaseRequest(flatbuffers
 struct PlasmaReleaseReplyT : public flatbuffers::NativeTable {
   typedef PlasmaReleaseReply TableType;
   std::string object_id;
-  PlasmaError error;
+  plasma::flatbuf::PlasmaError error;
   PlasmaReleaseReplyT()
-      : error(PlasmaError::OK) {
+      : error(plasma::flatbuf::PlasmaError::OK) {
   }
 };
 
 struct PlasmaReleaseReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaReleaseReplyT NativeTableType;
+  typedef PlasmaReleaseReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_ERROR = 6
@@ -1809,8 +1881,8 @@ struct PlasmaReleaseReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::String *object_id() const {
     return GetPointer<const flatbuffers::String *>(VT_OBJECT_ID);
   }
-  PlasmaError error() const {
-    return static_cast<PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
+  plasma::flatbuf::PlasmaError error() const {
+    return static_cast<plasma::flatbuf::PlasmaError>(GetField<int32_t>(VT_ERROR, 0));
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -1825,12 +1897,13 @@ struct PlasmaReleaseReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaReleaseReplyBuilder {
+  typedef PlasmaReleaseReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
     fbb_.AddOffset(PlasmaReleaseReply::VT_OBJECT_ID, object_id);
   }
-  void add_error(PlasmaError error) {
+  void add_error(plasma::flatbuf::PlasmaError error) {
     fbb_.AddElement<int32_t>(PlasmaReleaseReply::VT_ERROR, static_cast<int32_t>(error), 0);
   }
   explicit PlasmaReleaseReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -1848,7 +1921,7 @@ struct PlasmaReleaseReplyBuilder {
 inline flatbuffers::Offset<PlasmaReleaseReply> CreatePlasmaReleaseReply(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<flatbuffers::String> object_id = 0,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   PlasmaReleaseReplyBuilder builder_(_fbb);
   builder_.add_error(error);
   builder_.add_object_id(object_id);
@@ -1858,7 +1931,7 @@ inline flatbuffers::Offset<PlasmaReleaseReply> CreatePlasmaReleaseReply(
 inline flatbuffers::Offset<PlasmaReleaseReply> CreatePlasmaReleaseReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     const char *object_id = nullptr,
-    PlasmaError error = PlasmaError::OK) {
+    plasma::flatbuf::PlasmaError error = plasma::flatbuf::PlasmaError::OK) {
   auto object_id__ = object_id ? _fbb.CreateString(object_id) : 0;
   return plasma::flatbuf::CreatePlasmaReleaseReply(
       _fbb,
@@ -1879,6 +1952,7 @@ struct PlasmaDeleteRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaDeleteRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaDeleteRequestT NativeTableType;
+  typedef PlasmaDeleteRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_COUNT = 4,
     VT_OBJECT_IDS = 6
@@ -1903,6 +1977,7 @@ struct PlasmaDeleteRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table 
 };
 
 struct PlasmaDeleteRequestBuilder {
+  typedef PlasmaDeleteRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_count(int32_t count) {
@@ -1950,7 +2025,7 @@ struct PlasmaDeleteReplyT : public flatbuffers::NativeTable {
   typedef PlasmaDeleteReply TableType;
   int32_t count;
   std::vector<std::string> object_ids;
-  std::vector<PlasmaError> errors;
+  std::vector<plasma::flatbuf::PlasmaError> errors;
   PlasmaDeleteReplyT()
       : count(0) {
   }
@@ -1958,6 +2033,7 @@ struct PlasmaDeleteReplyT : public flatbuffers::NativeTable {
 
 struct PlasmaDeleteReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaDeleteReplyT NativeTableType;
+  typedef PlasmaDeleteReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_COUNT = 4,
     VT_OBJECT_IDS = 6,
@@ -1988,6 +2064,7 @@ struct PlasmaDeleteReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaDeleteReplyBuilder {
+  typedef PlasmaDeleteReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_count(int32_t count) {
@@ -2048,6 +2125,7 @@ struct PlasmaContainsRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaContainsRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaContainsRequestT NativeTableType;
+  typedef PlasmaContainsRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4
   };
@@ -2066,6 +2144,7 @@ struct PlasmaContainsRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 };
 
 struct PlasmaContainsRequestBuilder {
+  typedef PlasmaContainsRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -2113,6 +2192,7 @@ struct PlasmaContainsReplyT : public flatbuffers::NativeTable {
 
 struct PlasmaContainsReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaContainsReplyT NativeTableType;
+  typedef PlasmaContainsReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_HAS_OBJECT = 6
@@ -2136,6 +2216,7 @@ struct PlasmaContainsReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table 
 };
 
 struct PlasmaContainsReplyBuilder {
+  typedef PlasmaContainsReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -2187,6 +2268,7 @@ struct PlasmaListRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaListRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaListRequestT NativeTableType;
+  typedef PlasmaListRequestBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -2197,6 +2279,7 @@ struct PlasmaListRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaListRequestBuilder {
+  typedef PlasmaListRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PlasmaListRequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -2221,18 +2304,19 @@ flatbuffers::Offset<PlasmaListRequest> CreatePlasmaListRequest(flatbuffers::Flat
 
 struct PlasmaListReplyT : public flatbuffers::NativeTable {
   typedef PlasmaListReply TableType;
-  std::vector<std::unique_ptr<ObjectInfoT>> objects;
+  std::vector<std::unique_ptr<plasma::flatbuf::ObjectInfoT>> objects;
   PlasmaListReplyT() {
   }
 };
 
 struct PlasmaListReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaListReplyT NativeTableType;
+  typedef PlasmaListReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECTS = 4
   };
-  const flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>> *objects() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>> *>(VT_OBJECTS);
+  const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> *objects() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> *>(VT_OBJECTS);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -2247,9 +2331,10 @@ struct PlasmaListReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaListReplyBuilder {
+  typedef PlasmaListReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_objects(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>>> objects) {
+  void add_objects(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>>> objects) {
     fbb_.AddOffset(PlasmaListReply::VT_OBJECTS, objects);
   }
   explicit PlasmaListReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -2266,7 +2351,7 @@ struct PlasmaListReplyBuilder {
 
 inline flatbuffers::Offset<PlasmaListReply> CreatePlasmaListReply(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>>> objects = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>>> objects = 0) {
   PlasmaListReplyBuilder builder_(_fbb);
   builder_.add_objects(objects);
   return builder_.Finish();
@@ -2274,8 +2359,8 @@ inline flatbuffers::Offset<PlasmaListReply> CreatePlasmaListReply(
 
 inline flatbuffers::Offset<PlasmaListReply> CreatePlasmaListReplyDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<flatbuffers::Offset<ObjectInfo>> *objects = nullptr) {
-  auto objects__ = objects ? _fbb.CreateVector<flatbuffers::Offset<ObjectInfo>>(*objects) : 0;
+    const std::vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> *objects = nullptr) {
+  auto objects__ = objects ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>>(*objects) : 0;
   return plasma::flatbuf::CreatePlasmaListReply(
       _fbb,
       objects__);
@@ -2291,6 +2376,7 @@ struct PlasmaConnectRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaConnectRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaConnectRequestT NativeTableType;
+  typedef PlasmaConnectRequestBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -2301,6 +2387,7 @@ struct PlasmaConnectRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
 };
 
 struct PlasmaConnectRequestBuilder {
+  typedef PlasmaConnectRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PlasmaConnectRequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -2333,6 +2420,7 @@ struct PlasmaConnectReplyT : public flatbuffers::NativeTable {
 
 struct PlasmaConnectReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaConnectReplyT NativeTableType;
+  typedef PlasmaConnectReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_MEMORY_CAPACITY = 4
   };
@@ -2350,6 +2438,7 @@ struct PlasmaConnectReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaConnectReplyBuilder {
+  typedef PlasmaConnectReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_memory_capacity(int64_t memory_capacity) {
@@ -2387,6 +2476,7 @@ struct PlasmaEvictRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaEvictRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaEvictRequestT NativeTableType;
+  typedef PlasmaEvictRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NUM_BYTES = 4
   };
@@ -2404,6 +2494,7 @@ struct PlasmaEvictRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaEvictRequestBuilder {
+  typedef PlasmaEvictRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num_bytes(uint64_t num_bytes) {
@@ -2441,6 +2532,7 @@ struct PlasmaEvictReplyT : public flatbuffers::NativeTable {
 
 struct PlasmaEvictReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaEvictReplyT NativeTableType;
+  typedef PlasmaEvictReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_NUM_BYTES = 4
   };
@@ -2458,6 +2550,7 @@ struct PlasmaEvictReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaEvictReplyBuilder {
+  typedef PlasmaEvictReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_num_bytes(uint64_t num_bytes) {
@@ -2493,6 +2586,7 @@ struct PlasmaSubscribeRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaSubscribeRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaSubscribeRequestT NativeTableType;
+  typedef PlasmaSubscribeRequestBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -2503,6 +2597,7 @@ struct PlasmaSubscribeRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tab
 };
 
 struct PlasmaSubscribeRequestBuilder {
+  typedef PlasmaSubscribeRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PlasmaSubscribeRequestBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -2527,18 +2622,19 @@ flatbuffers::Offset<PlasmaSubscribeRequest> CreatePlasmaSubscribeRequest(flatbuf
 
 struct PlasmaNotificationT : public flatbuffers::NativeTable {
   typedef PlasmaNotification TableType;
-  std::vector<std::unique_ptr<ObjectInfoT>> object_info;
+  std::vector<std::unique_ptr<plasma::flatbuf::ObjectInfoT>> object_info;
   PlasmaNotificationT() {
   }
 };
 
 struct PlasmaNotification FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaNotificationT NativeTableType;
+  typedef PlasmaNotificationBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_INFO = 4
   };
-  const flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>> *object_info() const {
-    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>> *>(VT_OBJECT_INFO);
+  const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> *object_info() const {
+    return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> *>(VT_OBJECT_INFO);
   }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -2553,9 +2649,10 @@ struct PlasmaNotification FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaNotificationBuilder {
+  typedef PlasmaNotification Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
-  void add_object_info(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>>> object_info) {
+  void add_object_info(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>>> object_info) {
     fbb_.AddOffset(PlasmaNotification::VT_OBJECT_INFO, object_info);
   }
   explicit PlasmaNotificationBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -2572,7 +2669,7 @@ struct PlasmaNotificationBuilder {
 
 inline flatbuffers::Offset<PlasmaNotification> CreatePlasmaNotification(
     flatbuffers::FlatBufferBuilder &_fbb,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<ObjectInfo>>> object_info = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>>> object_info = 0) {
   PlasmaNotificationBuilder builder_(_fbb);
   builder_.add_object_info(object_info);
   return builder_.Finish();
@@ -2580,8 +2677,8 @@ inline flatbuffers::Offset<PlasmaNotification> CreatePlasmaNotification(
 
 inline flatbuffers::Offset<PlasmaNotification> CreatePlasmaNotificationDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
-    const std::vector<flatbuffers::Offset<ObjectInfo>> *object_info = nullptr) {
-  auto object_info__ = object_info ? _fbb.CreateVector<flatbuffers::Offset<ObjectInfo>>(*object_info) : 0;
+    const std::vector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> *object_info = nullptr) {
+  auto object_info__ = object_info ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>>(*object_info) : 0;
   return plasma::flatbuf::CreatePlasmaNotification(
       _fbb,
       object_info__);
@@ -2601,6 +2698,7 @@ struct PlasmaDataRequestT : public flatbuffers::NativeTable {
 
 struct PlasmaDataRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaDataRequestT NativeTableType;
+  typedef PlasmaDataRequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_ADDRESS = 6,
@@ -2630,6 +2728,7 @@ struct PlasmaDataRequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaDataRequestBuilder {
+  typedef PlasmaDataRequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -2694,6 +2793,7 @@ struct PlasmaDataReplyT : public flatbuffers::NativeTable {
 
 struct PlasmaDataReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaDataReplyT NativeTableType;
+  typedef PlasmaDataReplyBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_ID = 4,
     VT_OBJECT_SIZE = 6,
@@ -2722,6 +2822,7 @@ struct PlasmaDataReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
 };
 
 struct PlasmaDataReplyBuilder {
+  typedef PlasmaDataReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_id(flatbuffers::Offset<flatbuffers::String> object_id) {
@@ -2781,6 +2882,7 @@ struct PlasmaRefreshLRURequestT : public flatbuffers::NativeTable {
 
 struct PlasmaRefreshLRURequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaRefreshLRURequestT NativeTableType;
+  typedef PlasmaRefreshLRURequestBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_OBJECT_IDS = 4
   };
@@ -2800,6 +2902,7 @@ struct PlasmaRefreshLRURequest FLATBUFFERS_FINAL_CLASS : private flatbuffers::Ta
 };
 
 struct PlasmaRefreshLRURequestBuilder {
+  typedef PlasmaRefreshLRURequest Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   void add_object_ids(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<flatbuffers::String>>> object_ids) {
@@ -2844,6 +2947,7 @@ struct PlasmaRefreshLRUReplyT : public flatbuffers::NativeTable {
 
 struct PlasmaRefreshLRUReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   typedef PlasmaRefreshLRUReplyT NativeTableType;
+  typedef PlasmaRefreshLRUReplyBuilder Builder;
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            verifier.EndTable();
@@ -2854,6 +2958,7 @@ struct PlasmaRefreshLRUReply FLATBUFFERS_FINAL_CLASS : private flatbuffers::Tabl
 };
 
 struct PlasmaRefreshLRUReplyBuilder {
+  typedef PlasmaRefreshLRUReply Table;
   flatbuffers::FlatBufferBuilder &fbb_;
   flatbuffers::uoffset_t start_;
   explicit PlasmaRefreshLRUReplyBuilder(flatbuffers::FlatBufferBuilder &_fbb)
@@ -2877,16 +2982,16 @@ inline flatbuffers::Offset<PlasmaRefreshLRUReply> CreatePlasmaRefreshLRUReply(
 flatbuffers::Offset<PlasmaRefreshLRUReply> CreatePlasmaRefreshLRUReply(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaRefreshLRUReplyT *_o, const flatbuffers::rehasher_function_t *_rehasher = nullptr);
 
 inline PlasmaSetOptionsRequestT *PlasmaSetOptionsRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaSetOptionsRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaSetOptionsRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaSetOptionsRequestT>(new PlasmaSetOptionsRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaSetOptionsRequest::UnPackTo(PlasmaSetOptionsRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = client_name(); if (_e) _o->client_name = _e->str(); };
-  { auto _e = output_memory_quota(); _o->output_memory_quota = _e; };
+  { auto _e = client_name(); if (_e) _o->client_name = _e->str(); }
+  { auto _e = output_memory_quota(); _o->output_memory_quota = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaSetOptionsRequest> PlasmaSetOptionsRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaSetOptionsRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2906,15 +3011,15 @@ inline flatbuffers::Offset<PlasmaSetOptionsRequest> CreatePlasmaSetOptionsReques
 }
 
 inline PlasmaSetOptionsReplyT *PlasmaSetOptionsReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaSetOptionsReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaSetOptionsReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaSetOptionsReplyT>(new PlasmaSetOptionsReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaSetOptionsReply::UnPackTo(PlasmaSetOptionsReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = error(); _o->error = _e; };
+  { auto _e = error(); _o->error = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaSetOptionsReply> PlasmaSetOptionsReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaSetOptionsReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2932,9 +3037,9 @@ inline flatbuffers::Offset<PlasmaSetOptionsReply> CreatePlasmaSetOptionsReply(fl
 }
 
 inline PlasmaGetDebugStringRequestT *PlasmaGetDebugStringRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaGetDebugStringRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaGetDebugStringRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaGetDebugStringRequestT>(new PlasmaGetDebugStringRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaGetDebugStringRequest::UnPackTo(PlasmaGetDebugStringRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
@@ -2955,15 +3060,15 @@ inline flatbuffers::Offset<PlasmaGetDebugStringRequest> CreatePlasmaGetDebugStri
 }
 
 inline PlasmaGetDebugStringReplyT *PlasmaGetDebugStringReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaGetDebugStringReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaGetDebugStringReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaGetDebugStringReplyT>(new PlasmaGetDebugStringReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaGetDebugStringReply::UnPackTo(PlasmaGetDebugStringReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = debug_string(); if (_e) _o->debug_string = _e->str(); };
+  { auto _e = debug_string(); if (_e) _o->debug_string = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaGetDebugStringReply> PlasmaGetDebugStringReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaGetDebugStringReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -2981,19 +3086,19 @@ inline flatbuffers::Offset<PlasmaGetDebugStringReply> CreatePlasmaGetDebugString
 }
 
 inline PlasmaCreateRequestT *PlasmaCreateRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaCreateRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaCreateRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaCreateRequestT>(new PlasmaCreateRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaCreateRequest::UnPackTo(PlasmaCreateRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = evict_if_full(); _o->evict_if_full = _e; };
-  { auto _e = data_size(); _o->data_size = _e; };
-  { auto _e = metadata_size(); _o->metadata_size = _e; };
-  { auto _e = device_num(); _o->device_num = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = evict_if_full(); _o->evict_if_full = _e; }
+  { auto _e = data_size(); _o->data_size = _e; }
+  { auto _e = metadata_size(); _o->metadata_size = _e; }
+  { auto _e = device_num(); _o->device_num = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaCreateRequest> PlasmaCreateRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3019,15 +3124,15 @@ inline flatbuffers::Offset<PlasmaCreateRequest> CreatePlasmaCreateRequest(flatbu
 }
 
 inline CudaHandleT *CudaHandle::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new CudaHandleT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::CudaHandleT> _o = std::unique_ptr<plasma::flatbuf::CudaHandleT>(new CudaHandleT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void CudaHandle::UnPackTo(CudaHandleT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = handle(); if (_e) { _o->handle.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->handle[_i] = _e->Get(_i); } } };
+  { auto _e = handle(); if (_e) { _o->handle.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->handle[_i] = _e->Get(_i); } } }
 }
 
 inline flatbuffers::Offset<CudaHandle> CudaHandle::Pack(flatbuffers::FlatBufferBuilder &_fbb, const CudaHandleT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3045,20 +3150,20 @@ inline flatbuffers::Offset<CudaHandle> CreateCudaHandle(flatbuffers::FlatBufferB
 }
 
 inline PlasmaCreateReplyT *PlasmaCreateReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaCreateReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaCreateReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaCreateReplyT>(new PlasmaCreateReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaCreateReply::UnPackTo(PlasmaCreateReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = plasma_object(); if (_e) _o->plasma_object = std::unique_ptr<PlasmaObjectSpec>(new PlasmaObjectSpec(*_e)); };
-  { auto _e = error(); _o->error = _e; };
-  { auto _e = store_fd(); _o->store_fd = _e; };
-  { auto _e = mmap_size(); _o->mmap_size = _e; };
-  { auto _e = ipc_handle(); if (_e) _o->ipc_handle = std::unique_ptr<CudaHandleT>(_e->UnPack(_resolver)); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = plasma_object(); if (_e) _o->plasma_object = std::unique_ptr<plasma::flatbuf::PlasmaObjectSpec>(new plasma::flatbuf::PlasmaObjectSpec(*_e)); }
+  { auto _e = error(); _o->error = _e; }
+  { auto _e = store_fd(); _o->store_fd = _e; }
+  { auto _e = mmap_size(); _o->mmap_size = _e; }
+  { auto _e = ipc_handle(); if (_e) _o->ipc_handle = std::unique_ptr<plasma::flatbuf::CudaHandleT>(_e->UnPack(_resolver)); }
 }
 
 inline flatbuffers::Offset<PlasmaCreateReply> PlasmaCreateReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3086,19 +3191,19 @@ inline flatbuffers::Offset<PlasmaCreateReply> CreatePlasmaCreateReply(flatbuffer
 }
 
 inline PlasmaCreateAndSealRequestT *PlasmaCreateAndSealRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaCreateAndSealRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaCreateAndSealRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaCreateAndSealRequestT>(new PlasmaCreateAndSealRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaCreateAndSealRequest::UnPackTo(PlasmaCreateAndSealRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = evict_if_full(); _o->evict_if_full = _e; };
-  { auto _e = data(); if (_e) _o->data = _e->str(); };
-  { auto _e = metadata(); if (_e) _o->metadata = _e->str(); };
-  { auto _e = digest(); if (_e) _o->digest = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = evict_if_full(); _o->evict_if_full = _e; }
+  { auto _e = data(); if (_e) _o->data = _e->str(); }
+  { auto _e = metadata(); if (_e) _o->metadata = _e->str(); }
+  { auto _e = digest(); if (_e) _o->digest = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaCreateAndSealRequest> PlasmaCreateAndSealRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3124,15 +3229,15 @@ inline flatbuffers::Offset<PlasmaCreateAndSealRequest> CreatePlasmaCreateAndSeal
 }
 
 inline PlasmaCreateAndSealReplyT *PlasmaCreateAndSealReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaCreateAndSealReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaCreateAndSealReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaCreateAndSealReplyT>(new PlasmaCreateAndSealReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaCreateAndSealReply::UnPackTo(PlasmaCreateAndSealReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = error(); _o->error = _e; };
+  { auto _e = error(); _o->error = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaCreateAndSealReply> PlasmaCreateAndSealReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3150,19 +3255,19 @@ inline flatbuffers::Offset<PlasmaCreateAndSealReply> CreatePlasmaCreateAndSealRe
 }
 
 inline PlasmaCreateAndSealBatchRequestT *PlasmaCreateAndSealBatchRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaCreateAndSealBatchRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaCreateAndSealBatchRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaCreateAndSealBatchRequestT>(new PlasmaCreateAndSealBatchRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaCreateAndSealBatchRequest::UnPackTo(PlasmaCreateAndSealBatchRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
-  { auto _e = evict_if_full(); _o->evict_if_full = _e; };
-  { auto _e = data(); if (_e) { _o->data.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->data[_i] = _e->Get(_i)->str(); } } };
-  { auto _e = metadata(); if (_e) { _o->metadata.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->metadata[_i] = _e->Get(_i)->str(); } } };
-  { auto _e = digest(); if (_e) { _o->digest.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->digest[_i] = _e->Get(_i)->str(); } } };
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = evict_if_full(); _o->evict_if_full = _e; }
+  { auto _e = data(); if (_e) { _o->data.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->data[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = metadata(); if (_e) { _o->metadata.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->metadata[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = digest(); if (_e) { _o->digest.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->digest[_i] = _e->Get(_i)->str(); } } }
 }
 
 inline flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> PlasmaCreateAndSealBatchRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3188,15 +3293,15 @@ inline flatbuffers::Offset<PlasmaCreateAndSealBatchRequest> CreatePlasmaCreateAn
 }
 
 inline PlasmaCreateAndSealBatchReplyT *PlasmaCreateAndSealBatchReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaCreateAndSealBatchReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaCreateAndSealBatchReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaCreateAndSealBatchReplyT>(new PlasmaCreateAndSealBatchReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaCreateAndSealBatchReply::UnPackTo(PlasmaCreateAndSealBatchReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = error(); _o->error = _e; };
+  { auto _e = error(); _o->error = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaCreateAndSealBatchReply> PlasmaCreateAndSealBatchReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaCreateAndSealBatchReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3214,15 +3319,15 @@ inline flatbuffers::Offset<PlasmaCreateAndSealBatchReply> CreatePlasmaCreateAndS
 }
 
 inline PlasmaAbortRequestT *PlasmaAbortRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaAbortRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaAbortRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaAbortRequestT>(new PlasmaAbortRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaAbortRequest::UnPackTo(PlasmaAbortRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaAbortRequest> PlasmaAbortRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaAbortRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3240,15 +3345,15 @@ inline flatbuffers::Offset<PlasmaAbortRequest> CreatePlasmaAbortRequest(flatbuff
 }
 
 inline PlasmaAbortReplyT *PlasmaAbortReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaAbortReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaAbortReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaAbortReplyT>(new PlasmaAbortReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaAbortReply::UnPackTo(PlasmaAbortReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaAbortReply> PlasmaAbortReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaAbortReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3266,16 +3371,16 @@ inline flatbuffers::Offset<PlasmaAbortReply> CreatePlasmaAbortReply(flatbuffers:
 }
 
 inline PlasmaSealRequestT *PlasmaSealRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaSealRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaSealRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaSealRequestT>(new PlasmaSealRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaSealRequest::UnPackTo(PlasmaSealRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = digest(); if (_e) _o->digest = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = digest(); if (_e) _o->digest = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaSealRequest> PlasmaSealRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaSealRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3295,16 +3400,16 @@ inline flatbuffers::Offset<PlasmaSealRequest> CreatePlasmaSealRequest(flatbuffer
 }
 
 inline PlasmaSealReplyT *PlasmaSealReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaSealReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaSealReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaSealReplyT>(new PlasmaSealReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaSealReply::UnPackTo(PlasmaSealReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = error(); _o->error = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = error(); _o->error = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaSealReply> PlasmaSealReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaSealReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3324,16 +3429,16 @@ inline flatbuffers::Offset<PlasmaSealReply> CreatePlasmaSealReply(flatbuffers::F
 }
 
 inline PlasmaGetRequestT *PlasmaGetRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaGetRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaGetRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaGetRequestT>(new PlasmaGetRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaGetRequest::UnPackTo(PlasmaGetRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
-  { auto _e = timeout_ms(); _o->timeout_ms = _e; };
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = timeout_ms(); _o->timeout_ms = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaGetRequest> PlasmaGetRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaGetRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3353,19 +3458,19 @@ inline flatbuffers::Offset<PlasmaGetRequest> CreatePlasmaGetRequest(flatbuffers:
 }
 
 inline PlasmaGetReplyT *PlasmaGetReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaGetReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaGetReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaGetReplyT>(new PlasmaGetReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaGetReply::UnPackTo(PlasmaGetReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
-  { auto _e = plasma_objects(); if (_e) { _o->plasma_objects.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->plasma_objects[_i] = *_e->Get(_i); } } };
-  { auto _e = store_fds(); if (_e) { _o->store_fds.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->store_fds[_i] = _e->Get(_i); } } };
-  { auto _e = mmap_sizes(); if (_e) { _o->mmap_sizes.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->mmap_sizes[_i] = _e->Get(_i); } } };
-  { auto _e = handles(); if (_e) { _o->handles.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->handles[_i] = std::unique_ptr<CudaHandleT>(_e->Get(_i)->UnPack(_resolver)); } } };
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = plasma_objects(); if (_e) { _o->plasma_objects.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->plasma_objects[_i] = *_e->Get(_i); } } }
+  { auto _e = store_fds(); if (_e) { _o->store_fds.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->store_fds[_i] = _e->Get(_i); } } }
+  { auto _e = mmap_sizes(); if (_e) { _o->mmap_sizes.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->mmap_sizes[_i] = _e->Get(_i); } } }
+  { auto _e = handles(); if (_e) { _o->handles.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->handles[_i] = std::unique_ptr<plasma::flatbuf::CudaHandleT>(_e->Get(_i)->UnPack(_resolver)); } } }
 }
 
 inline flatbuffers::Offset<PlasmaGetReply> PlasmaGetReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaGetReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3380,7 +3485,7 @@ inline flatbuffers::Offset<PlasmaGetReply> CreatePlasmaGetReply(flatbuffers::Fla
   auto _plasma_objects = _o->plasma_objects.size() ? _fbb.CreateVectorOfStructs(_o->plasma_objects) : 0;
   auto _store_fds = _o->store_fds.size() ? _fbb.CreateVector(_o->store_fds) : 0;
   auto _mmap_sizes = _o->mmap_sizes.size() ? _fbb.CreateVector(_o->mmap_sizes) : 0;
-  auto _handles = _o->handles.size() ? _fbb.CreateVector<flatbuffers::Offset<CudaHandle>> (_o->handles.size(), [](size_t i, _VectorArgs *__va) { return CreateCudaHandle(*__va->__fbb, __va->__o->handles[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _handles = _o->handles.size() ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::CudaHandle>> (_o->handles.size(), [](size_t i, _VectorArgs *__va) { return CreateCudaHandle(*__va->__fbb, __va->__o->handles[i].get(), __va->__rehasher); }, &_va ) : 0;
   return plasma::flatbuf::CreatePlasmaGetReply(
       _fbb,
       _object_ids,
@@ -3391,15 +3496,15 @@ inline flatbuffers::Offset<PlasmaGetReply> CreatePlasmaGetReply(flatbuffers::Fla
 }
 
 inline PlasmaReleaseRequestT *PlasmaReleaseRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaReleaseRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaReleaseRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaReleaseRequestT>(new PlasmaReleaseRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaReleaseRequest::UnPackTo(PlasmaReleaseRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaReleaseRequest> PlasmaReleaseRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaReleaseRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3417,16 +3522,16 @@ inline flatbuffers::Offset<PlasmaReleaseRequest> CreatePlasmaReleaseRequest(flat
 }
 
 inline PlasmaReleaseReplyT *PlasmaReleaseReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaReleaseReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaReleaseReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaReleaseReplyT>(new PlasmaReleaseReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaReleaseReply::UnPackTo(PlasmaReleaseReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = error(); _o->error = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = error(); _o->error = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaReleaseReply> PlasmaReleaseReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaReleaseReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3446,16 +3551,16 @@ inline flatbuffers::Offset<PlasmaReleaseReply> CreatePlasmaReleaseReply(flatbuff
 }
 
 inline PlasmaDeleteRequestT *PlasmaDeleteRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaDeleteRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaDeleteRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaDeleteRequestT>(new PlasmaDeleteRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaDeleteRequest::UnPackTo(PlasmaDeleteRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = count(); _o->count = _e; };
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
+  { auto _e = count(); _o->count = _e; }
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
 }
 
 inline flatbuffers::Offset<PlasmaDeleteRequest> PlasmaDeleteRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaDeleteRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3475,17 +3580,17 @@ inline flatbuffers::Offset<PlasmaDeleteRequest> CreatePlasmaDeleteRequest(flatbu
 }
 
 inline PlasmaDeleteReplyT *PlasmaDeleteReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaDeleteReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaDeleteReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaDeleteReplyT>(new PlasmaDeleteReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaDeleteReply::UnPackTo(PlasmaDeleteReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = count(); _o->count = _e; };
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
-  { auto _e = errors(); if (_e) { _o->errors.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->errors[_i] = static_cast<PlasmaError>(_e->Get(_i)); } } };
+  { auto _e = count(); _o->count = _e; }
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
+  { auto _e = errors(); if (_e) { _o->errors.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->errors[_i] = static_cast<plasma::flatbuf::PlasmaError>(_e->Get(_i)); } } }
 }
 
 inline flatbuffers::Offset<PlasmaDeleteReply> PlasmaDeleteReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaDeleteReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3507,15 +3612,15 @@ inline flatbuffers::Offset<PlasmaDeleteReply> CreatePlasmaDeleteReply(flatbuffer
 }
 
 inline PlasmaContainsRequestT *PlasmaContainsRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaContainsRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaContainsRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaContainsRequestT>(new PlasmaContainsRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaContainsRequest::UnPackTo(PlasmaContainsRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
 }
 
 inline flatbuffers::Offset<PlasmaContainsRequest> PlasmaContainsRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaContainsRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3533,16 +3638,16 @@ inline flatbuffers::Offset<PlasmaContainsRequest> CreatePlasmaContainsRequest(fl
 }
 
 inline PlasmaContainsReplyT *PlasmaContainsReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaContainsReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaContainsReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaContainsReplyT>(new PlasmaContainsReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaContainsReply::UnPackTo(PlasmaContainsReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = has_object(); _o->has_object = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = has_object(); _o->has_object = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaContainsReply> PlasmaContainsReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaContainsReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3562,9 +3667,9 @@ inline flatbuffers::Offset<PlasmaContainsReply> CreatePlasmaContainsReply(flatbu
 }
 
 inline PlasmaListRequestT *PlasmaListRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaListRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaListRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaListRequestT>(new PlasmaListRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaListRequest::UnPackTo(PlasmaListRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
@@ -3585,15 +3690,15 @@ inline flatbuffers::Offset<PlasmaListRequest> CreatePlasmaListRequest(flatbuffer
 }
 
 inline PlasmaListReplyT *PlasmaListReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaListReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaListReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaListReplyT>(new PlasmaListReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaListReply::UnPackTo(PlasmaListReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = objects(); if (_e) { _o->objects.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->objects[_i] = std::unique_ptr<ObjectInfoT>(_e->Get(_i)->UnPack(_resolver)); } } };
+  { auto _e = objects(); if (_e) { _o->objects.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->objects[_i] = std::unique_ptr<plasma::flatbuf::ObjectInfoT>(_e->Get(_i)->UnPack(_resolver)); } } }
 }
 
 inline flatbuffers::Offset<PlasmaListReply> PlasmaListReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaListReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3604,16 +3709,16 @@ inline flatbuffers::Offset<PlasmaListReply> CreatePlasmaListReply(flatbuffers::F
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const PlasmaListReplyT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _objects = _o->objects.size() ? _fbb.CreateVector<flatbuffers::Offset<ObjectInfo>> (_o->objects.size(), [](size_t i, _VectorArgs *__va) { return CreateObjectInfo(*__va->__fbb, __va->__o->objects[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _objects = _o->objects.size() ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> (_o->objects.size(), [](size_t i, _VectorArgs *__va) { return CreateObjectInfo(*__va->__fbb, __va->__o->objects[i].get(), __va->__rehasher); }, &_va ) : 0;
   return plasma::flatbuf::CreatePlasmaListReply(
       _fbb,
       _objects);
 }
 
 inline PlasmaConnectRequestT *PlasmaConnectRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaConnectRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaConnectRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaConnectRequestT>(new PlasmaConnectRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaConnectRequest::UnPackTo(PlasmaConnectRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
@@ -3634,15 +3739,15 @@ inline flatbuffers::Offset<PlasmaConnectRequest> CreatePlasmaConnectRequest(flat
 }
 
 inline PlasmaConnectReplyT *PlasmaConnectReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaConnectReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaConnectReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaConnectReplyT>(new PlasmaConnectReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaConnectReply::UnPackTo(PlasmaConnectReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = memory_capacity(); _o->memory_capacity = _e; };
+  { auto _e = memory_capacity(); _o->memory_capacity = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaConnectReply> PlasmaConnectReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaConnectReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3660,15 +3765,15 @@ inline flatbuffers::Offset<PlasmaConnectReply> CreatePlasmaConnectReply(flatbuff
 }
 
 inline PlasmaEvictRequestT *PlasmaEvictRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaEvictRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaEvictRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaEvictRequestT>(new PlasmaEvictRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaEvictRequest::UnPackTo(PlasmaEvictRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = num_bytes(); _o->num_bytes = _e; };
+  { auto _e = num_bytes(); _o->num_bytes = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaEvictRequest> PlasmaEvictRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaEvictRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3686,15 +3791,15 @@ inline flatbuffers::Offset<PlasmaEvictRequest> CreatePlasmaEvictRequest(flatbuff
 }
 
 inline PlasmaEvictReplyT *PlasmaEvictReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaEvictReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaEvictReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaEvictReplyT>(new PlasmaEvictReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaEvictReply::UnPackTo(PlasmaEvictReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = num_bytes(); _o->num_bytes = _e; };
+  { auto _e = num_bytes(); _o->num_bytes = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaEvictReply> PlasmaEvictReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaEvictReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3712,9 +3817,9 @@ inline flatbuffers::Offset<PlasmaEvictReply> CreatePlasmaEvictReply(flatbuffers:
 }
 
 inline PlasmaSubscribeRequestT *PlasmaSubscribeRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaSubscribeRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaSubscribeRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaSubscribeRequestT>(new PlasmaSubscribeRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaSubscribeRequest::UnPackTo(PlasmaSubscribeRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
@@ -3735,15 +3840,15 @@ inline flatbuffers::Offset<PlasmaSubscribeRequest> CreatePlasmaSubscribeRequest(
 }
 
 inline PlasmaNotificationT *PlasmaNotification::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaNotificationT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaNotificationT> _o = std::unique_ptr<plasma::flatbuf::PlasmaNotificationT>(new PlasmaNotificationT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaNotification::UnPackTo(PlasmaNotificationT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_info(); if (_e) { _o->object_info.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_info[_i] = std::unique_ptr<ObjectInfoT>(_e->Get(_i)->UnPack(_resolver)); } } };
+  { auto _e = object_info(); if (_e) { _o->object_info.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_info[_i] = std::unique_ptr<plasma::flatbuf::ObjectInfoT>(_e->Get(_i)->UnPack(_resolver)); } } }
 }
 
 inline flatbuffers::Offset<PlasmaNotification> PlasmaNotification::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaNotificationT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3754,24 +3859,24 @@ inline flatbuffers::Offset<PlasmaNotification> CreatePlasmaNotification(flatbuff
   (void)_rehasher;
   (void)_o;
   struct _VectorArgs { flatbuffers::FlatBufferBuilder *__fbb; const PlasmaNotificationT* __o; const flatbuffers::rehasher_function_t *__rehasher; } _va = { &_fbb, _o, _rehasher}; (void)_va;
-  auto _object_info = _o->object_info.size() ? _fbb.CreateVector<flatbuffers::Offset<ObjectInfo>> (_o->object_info.size(), [](size_t i, _VectorArgs *__va) { return CreateObjectInfo(*__va->__fbb, __va->__o->object_info[i].get(), __va->__rehasher); }, &_va ) : 0;
+  auto _object_info = _o->object_info.size() ? _fbb.CreateVector<flatbuffers::Offset<plasma::flatbuf::ObjectInfo>> (_o->object_info.size(), [](size_t i, _VectorArgs *__va) { return CreateObjectInfo(*__va->__fbb, __va->__o->object_info[i].get(), __va->__rehasher); }, &_va ) : 0;
   return plasma::flatbuf::CreatePlasmaNotification(
       _fbb,
       _object_info);
 }
 
 inline PlasmaDataRequestT *PlasmaDataRequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaDataRequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaDataRequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaDataRequestT>(new PlasmaDataRequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaDataRequest::UnPackTo(PlasmaDataRequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = address(); if (_e) _o->address = _e->str(); };
-  { auto _e = port(); _o->port = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = address(); if (_e) _o->address = _e->str(); }
+  { auto _e = port(); _o->port = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaDataRequest> PlasmaDataRequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaDataRequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3793,17 +3898,17 @@ inline flatbuffers::Offset<PlasmaDataRequest> CreatePlasmaDataRequest(flatbuffer
 }
 
 inline PlasmaDataReplyT *PlasmaDataReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaDataReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaDataReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaDataReplyT>(new PlasmaDataReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaDataReply::UnPackTo(PlasmaDataReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); };
-  { auto _e = object_size(); _o->object_size = _e; };
-  { auto _e = metadata_size(); _o->metadata_size = _e; };
+  { auto _e = object_id(); if (_e) _o->object_id = _e->str(); }
+  { auto _e = object_size(); _o->object_size = _e; }
+  { auto _e = metadata_size(); _o->metadata_size = _e; }
 }
 
 inline flatbuffers::Offset<PlasmaDataReply> PlasmaDataReply::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaDataReplyT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3825,15 +3930,15 @@ inline flatbuffers::Offset<PlasmaDataReply> CreatePlasmaDataReply(flatbuffers::F
 }
 
 inline PlasmaRefreshLRURequestT *PlasmaRefreshLRURequest::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaRefreshLRURequestT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaRefreshLRURequestT> _o = std::unique_ptr<plasma::flatbuf::PlasmaRefreshLRURequestT>(new PlasmaRefreshLRURequestT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaRefreshLRURequest::UnPackTo(PlasmaRefreshLRURequestT *_o, const flatbuffers::resolver_function_t *_resolver) const {
   (void)_o;
   (void)_resolver;
-  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } };
+  { auto _e = object_ids(); if (_e) { _o->object_ids.resize(_e->size()); for (flatbuffers::uoffset_t _i = 0; _i < _e->size(); _i++) { _o->object_ids[_i] = _e->Get(_i)->str(); } } }
 }
 
 inline flatbuffers::Offset<PlasmaRefreshLRURequest> PlasmaRefreshLRURequest::Pack(flatbuffers::FlatBufferBuilder &_fbb, const PlasmaRefreshLRURequestT* _o, const flatbuffers::rehasher_function_t *_rehasher) {
@@ -3851,9 +3956,9 @@ inline flatbuffers::Offset<PlasmaRefreshLRURequest> CreatePlasmaRefreshLRUReques
 }
 
 inline PlasmaRefreshLRUReplyT *PlasmaRefreshLRUReply::UnPack(const flatbuffers::resolver_function_t *_resolver) const {
-  auto _o = new PlasmaRefreshLRUReplyT();
-  UnPackTo(_o, _resolver);
-  return _o;
+  std::unique_ptr<plasma::flatbuf::PlasmaRefreshLRUReplyT> _o = std::unique_ptr<plasma::flatbuf::PlasmaRefreshLRUReplyT>(new PlasmaRefreshLRUReplyT());
+  UnPackTo(_o.get(), _resolver);
+  return _o.release();
 }
 
 inline void PlasmaRefreshLRUReply::UnPackTo(PlasmaRefreshLRUReplyT *_o, const flatbuffers::resolver_function_t *_resolver) const {

--- a/cpp/thirdparty/flatbuffers/include/flatbuffers/base.h
+++ b/cpp/thirdparty/flatbuffers/include/flatbuffers/base.h
@@ -55,6 +55,10 @@
 
 #include "flatbuffers/stl_emulation.h"
 
+#if defined(__ICCARM__)
+#include <intrinsics.h>
+#endif
+
 // Note the __clang__ check is needed, because clang presents itself
 // as an older GNUC compiler (4.2).
 // Clang 3.3 and later implement all of the ISO C++ 2011 standard.
@@ -95,7 +99,7 @@
 #if !defined(__clang__) && \
     defined(__GNUC__) && \
     (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__ < 40600)
-  // Backwards compatability for g++ 4.4, and 4.5 which don't have the nullptr
+  // Backwards compatibility for g++ 4.4, and 4.5 which don't have the nullptr
   // and constexpr keywords. Note the __clang__ check is needed, because clang
   // presents itself as an older GNUC compiler.
   #ifndef nullptr_t
@@ -117,7 +121,7 @@
   #define FLATBUFFERS_LITTLEENDIAN 0
 #endif // __s390x__
 #if !defined(FLATBUFFERS_LITTLEENDIAN)
-  #if defined(__GNUC__) || defined(__clang__)
+  #if defined(__GNUC__) || defined(__clang__) || defined(__ICCARM__)
     #if (defined(__BIG_ENDIAN__) || \
          (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__))
       #define FLATBUFFERS_LITTLEENDIAN 0
@@ -136,10 +140,14 @@
 #endif // !defined(FLATBUFFERS_LITTLEENDIAN)
 
 #define FLATBUFFERS_VERSION_MAJOR 1
-#define FLATBUFFERS_VERSION_MINOR 11
+#define FLATBUFFERS_VERSION_MINOR 12
 #define FLATBUFFERS_VERSION_REVISION 0
 #define FLATBUFFERS_STRING_EXPAND(X) #X
 #define FLATBUFFERS_STRING(X) FLATBUFFERS_STRING_EXPAND(X)
+namespace flatbuffers {
+  // Returns version as string  "MAJOR.MINOR.REVISION".
+  const char* FLATBUFFERS_VERSION();
+}
 
 #if (!defined(_MSC_VER) || _MSC_VER > 1600) && \
     (!defined(__GNUC__) || (__GNUC__ * 100 + __GNUC_MINOR__ >= 407)) || \
@@ -191,7 +199,7 @@
   // to detect a header that provides an implementation
   #if defined(__has_include)
     // Check for std::string_view (in c++17)
-    #if __has_include(<string_view>) && (__cplusplus >= 201606 || _HAS_CXX17)
+    #if __has_include(<string_view>) && (__cplusplus >= 201606 || (defined(_HAS_CXX17) && _HAS_CXX17))
       #include <string_view>
       namespace flatbuffers {
         typedef std::string_view string_view;
@@ -202,6 +210,13 @@
       #include <experimental/string_view>
       namespace flatbuffers {
         typedef std::experimental::string_view string_view;
+      }
+      #define FLATBUFFERS_HAS_STRING_VIEW 1
+    // Check for absl::string_view
+    #elif __has_include("absl/strings/string_view.h")
+      #include "absl/strings/string_view.h"
+      namespace flatbuffers {
+        typedef absl::string_view string_view;
       }
       #define FLATBUFFERS_HAS_STRING_VIEW 1
     #endif
@@ -234,7 +249,7 @@
 // Suppress Undefined Behavior Sanitizer (recoverable only). Usage:
 // - __supress_ubsan__("undefined")
 // - __supress_ubsan__("signed-integer-overflow")
-#if defined(__clang__)
+#if defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >=7))
   #define __supress_ubsan__(type) __attribute__((no_sanitize(type)))
 #elif defined(__GNUC__) && (__GNUC__ * 100 + __GNUC_MINOR__ >= 409)
   #define __supress_ubsan__(type) __attribute__((no_sanitize_undefined))
@@ -288,7 +303,7 @@ typedef uint16_t voffset_t;
 typedef uintmax_t largest_scalar_t;
 
 // In 32bits, this evaluates to 2GB - 1
-#define FLATBUFFERS_MAX_BUFFER_SIZE ((1ULL << (sizeof(soffset_t) * 8 - 1)) - 1)
+#define FLATBUFFERS_MAX_BUFFER_SIZE ((1ULL << (sizeof(::flatbuffers::soffset_t) * 8 - 1)) - 1)
 
 // We support aligning the contents of buffers up to this size.
 #define FLATBUFFERS_MAX_ALIGNMENT 16
@@ -303,6 +318,11 @@ template<typename T> T EndianSwap(T t) {
     #define FLATBUFFERS_BYTESWAP16 _byteswap_ushort
     #define FLATBUFFERS_BYTESWAP32 _byteswap_ulong
     #define FLATBUFFERS_BYTESWAP64 _byteswap_uint64
+  #elif defined(__ICCARM__)
+    #define FLATBUFFERS_BYTESWAP16 __REV16
+    #define FLATBUFFERS_BYTESWAP32 __REV
+    #define FLATBUFFERS_BYTESWAP64(x) \
+       ((__REV(static_cast<uint32_t>(x >> 32U))) | (static_cast<uint64_t>(__REV(static_cast<uint32_t>(x)))) << 32U)
   #else
     #if defined(__GNUC__) && __GNUC__ * 100 + __GNUC_MINOR__ < 408 && !defined(__clang__)
       // __builtin_bswap16 was missing prior to GCC 4.8.
@@ -317,22 +337,20 @@ template<typename T> T EndianSwap(T t) {
   if (sizeof(T) == 1) {   // Compile-time if-then's.
     return t;
   } else if (sizeof(T) == 2) {
-    union { T t; uint16_t i; } u;
-    u.t = t;
+    union { T t; uint16_t i; } u = { t };
     u.i = FLATBUFFERS_BYTESWAP16(u.i);
     return u.t;
   } else if (sizeof(T) == 4) {
-    union { T t; uint32_t i; } u;
-    u.t = t;
+    union { T t; uint32_t i; } u = { t };
     u.i = FLATBUFFERS_BYTESWAP32(u.i);
     return u.t;
   } else if (sizeof(T) == 8) {
-    union { T t; uint64_t i; } u;
-    u.t = t;
+    union { T t; uint64_t i; } u = { t };
     u.i = FLATBUFFERS_BYTESWAP64(u.i);
     return u.t;
   } else {
     FLATBUFFERS_ASSERT(0);
+    return t;
   }
 }
 
@@ -371,6 +389,7 @@ template<typename T> __supress_ubsan__("alignment") void WriteScalar(void *p, Of
 // Computes how many bytes you'd have to pad to be able to write an
 // "scalar_size" scalar if the buffer had grown to "buf_size" (downwards in
 // memory).
+__supress_ubsan__("unsigned-integer-overflow")
 inline size_t PaddingBytes(size_t buf_size, size_t scalar_size) {
   return ((~buf_size) + 1) & (scalar_size - 1);
 }

--- a/cpp/thirdparty/flatbuffers/include/flatbuffers/stl_emulation.h
+++ b/cpp/thirdparty/flatbuffers/include/flatbuffers/stl_emulation.h
@@ -96,13 +96,13 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
       }
   };
 
-  template <> class numeric_limits<float> : 
+  template <> class numeric_limits<float> :
       public std::numeric_limits<float> {
     public:
       static float lowest() { return -FLT_MAX; }
   };
 
-  template <> class numeric_limits<double> : 
+  template <> class numeric_limits<double> :
       public std::numeric_limits<double> {
     public:
       static double lowest() { return -DBL_MAX; }
@@ -138,7 +138,12 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
     template <typename T, typename U> using is_same = std::is_same<T,U>;
     template <typename T> using is_floating_point = std::is_floating_point<T>;
     template <typename T> using is_unsigned = std::is_unsigned<T>;
+    template <typename T> using is_enum = std::is_enum<T>;
     template <typename T> using make_unsigned = std::make_unsigned<T>;
+    template<bool B, class T, class F>
+    using conditional = std::conditional<B, T, F>;
+    template<class T, T v>
+    using integral_constant = std::integral_constant<T, v>;
   #else
     // Map C++ TR1 templates defined by stlport.
     template <typename T> using is_scalar = std::tr1::is_scalar<T>;
@@ -146,6 +151,7 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
     template <typename T> using is_floating_point =
         std::tr1::is_floating_point<T>;
     template <typename T> using is_unsigned = std::tr1::is_unsigned<T>;
+    template <typename T> using is_enum = std::tr1::is_enum<T>;
     // Android NDK doesn't have std::make_unsigned or std::tr1::make_unsigned.
     template<typename T> struct make_unsigned {
       static_assert(is_unsigned<T>::value, "Specialization not implemented!");
@@ -157,6 +163,10 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
     template<> struct make_unsigned<long> { using type = unsigned long; };
     template<>
     struct make_unsigned<long long> { using type = unsigned long long; };
+    template<bool B, class T, class F>
+    using conditional = std::tr1::conditional<B, T, F>;
+    template<class T, T v>
+    using integral_constant = std::tr1::integral_constant<T, v>;
   #endif  // !FLATBUFFERS_CPP98_STL
 #else
   // MSVC 2010 doesn't support C++11 aliases.
@@ -165,7 +175,12 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
   template <typename T> struct is_floating_point :
         public std::is_floating_point<T> {};
   template <typename T> struct is_unsigned : public std::is_unsigned<T> {};
+  template <typename T> struct is_enum : public std::is_enum<T> {};
   template <typename T> struct make_unsigned : public std::make_unsigned<T> {};
+  template<bool B, class T, class F>
+  struct conditional : public std::conditional<B, T, F> {};
+  template<class T, T v>
+  struct integral_constant : public std::integral_constant<T, v> {};
 #endif  // defined(FLATBUFFERS_TEMPLATES_ALIASES)
 
 #ifndef FLATBUFFERS_CPP98_STL
@@ -268,6 +283,23 @@ inline void vector_emplace_back(std::vector<T> *vector, V &&data) {
   template <class T> bool operator==(const unique_ptr<T>& x, intptr_t y) {
     return reinterpret_cast<intptr_t>(x.get()) == y;
   }
+
+  template <class T> bool operator!=(const unique_ptr<T>& x, decltype(nullptr)) {
+    return !!x;
+  }
+
+  template <class T> bool operator!=(decltype(nullptr), const unique_ptr<T>& x) {
+    return !!x;
+  }
+
+  template <class T> bool operator==(const unique_ptr<T>& x, decltype(nullptr)) {
+    return !x;
+  }
+
+  template <class T> bool operator==(decltype(nullptr), const unique_ptr<T>& x) {
+    return !x;
+  }
+
 #endif  // !FLATBUFFERS_CPP98_STL
 
 }  // namespace flatbuffers


### PR DESCRIPTION
This includes some UBSAN-related fixes that make our `MakeNonNull` helper function unneeded with Flatbuffers