### PR TITLE
ARROW-8179: [R] Windows build script tweaking for nightly packaging on GHA

### DIFF
--- a/ci/scripts/PKGBUILD
+++ b/ci/scripts/PKGBUILD
@@ -36,7 +36,6 @@ options=("staticlibs" "strip" "!buildflags")
 
 # For installing from a local checkout, set source_dir to . and don't include
 # a "source" param below
-: ${ARROW_HOME:="$GITHUB_WORKSPACE"}
 source_dir="$ARROW_HOME"
 # else
 # source_dir=apache-${_realname}-${pkgver}

--- a/ci/scripts/PKGBUILD
+++ b/ci/scripts/PKGBUILD
@@ -36,7 +36,8 @@ options=("staticlibs" "strip" "!buildflags")
 
 # For installing from a local checkout, set source_dir to . and don't include
 # a "source" param below
-source_dir="$GITHUB_WORKSPACE"
+: ${ARROW_HOME:="$GITHUB_WORKSPACE"}
+source_dir="$ARROW_HOME"
 # else
 # source_dir=apache-${_realname}-${pkgver}
 

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -19,6 +19,8 @@
 
 set -x
 
+: ${ARROW_HOME:=$(pwd)}
+
 pacman --sync --noconfirm ccache
 
 wget https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf
@@ -36,7 +38,7 @@ rm -f /mingw32/lib/*.dll.a
 rm -f /mingw64/lib/*.dll.a
 export PKG_CONFIG="/${MINGW_PREFIX}/bin/pkg-config --static"
 
-cp ci/scripts/PKGBUILD .
+cp $ARROW_HOME/ci/scripts/PKGBUILD .
 export PKGEXT='.pkg.tar.xz' # pacman default changed to .zst in 2020, but keep the old ext for compat
 unset BOOST_ROOT
 printenv
@@ -54,7 +56,7 @@ MSYS_LIB_DIR="D:/a/_temp/msys/msys64"
 ls $MSYS_LIB_DIR/mingw64/lib/
 ls $MSYS_LIB_DIR/mingw32/lib/
 
-VERSION=$(grep Version ../r/DESCRIPTION | cut -d " " -f 2)
+VERSION=$(grep Version $ARROW_HOME/r/DESCRIPTION | cut -d " " -f 2)
 DST_DIR="arrow-$VERSION"
 
 # Untar the two builds we made

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -20,8 +20,8 @@
 set -x
 
 : ${ARROW_HOME:=$(pwd)}
-# Make sure it is absolute and exists
-ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
+# Make sure it is absolute and exported
+export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 
 pacman --sync --noconfirm ccache
 

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -20,6 +20,8 @@
 set -x
 
 : ${ARROW_HOME:=$(pwd)}
+# Make sure it is absolute and exists
+ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 
 pacman --sync --noconfirm ccache
 

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -44,6 +44,9 @@ unset BOOST_ROOT
 printenv
 makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --cleanbuild
 
+VERSION=$(grep Version $ARROW_HOME/r/DESCRIPTION | cut -d " " -f 2)
+DST_DIR="arrow-$VERSION"
+
 # Collect the build artifacts and make the shape of zip file that rwinlib expects
 ls
 mkdir build
@@ -55,9 +58,6 @@ MSYS_LIB_DIR="D:/a/_temp/msys/msys64"
 
 ls $MSYS_LIB_DIR/mingw64/lib/
 ls $MSYS_LIB_DIR/mingw32/lib/
-
-VERSION=$(grep Version $ARROW_HOME/r/DESCRIPTION | cut -d " " -f 2)
-DST_DIR="arrow-$VERSION"
 
 # Untar the two builds we made
 ls | xargs -n 1 tar -xJf

--- a/r/tools/winlibs.R
+++ b/r/tools/winlibs.R
@@ -28,19 +28,30 @@ if(!file.exists(sprintf("windows/arrow-%s/include/arrow/api.h", VERSION))){
     file.copy(localfile, "lib.zip")
   } else {
     # Download static arrow from rwinlib
-    if(getRversion() < "3.3.0") setInternet2()
-    try(download.file(sprintf("https://github.com/rwinlib/arrow/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE), silent = TRUE)
-    if(!file.exists("lib.zip")){
+    if (getRversion() < "3.3.0") setInternet2()
+    get_file <- function(template, version) {
+      try(download.file(sprintf(template, version), "lib.zip", quiet = TRUE), silent = TRUE)
+    }
+    # URL templates
+    # TODO: don't hard-code RTools 3.5? Can we detect which toolchain we have?
+    nightly <- "https://dl.bintray.com/ursalabs/arrow-r/libarrow/bin/windows-35/arrow-%s.zip"
+    rwinlib <- "https://github.com/rwinlib/arrow/archive/v%s.zip"
+    # First look for a nightly
+    get_file(nightly, VERSION)
+    # If not found, then check rwinlib
+    if (!file.exists("lib.zip")) {
+      get_file(rwinlib, VERSION)
+    }
+    if (!file.exists("lib.zip")) {
       # Try a different version
       # First, try pruning off a dev number, i.e. go from 0.14.1.1 to 0.14.1
       VERSION <- sub("^([0-9]+\\.[0-9]+\\.[0-9]+).*$", "\\1", VERSION)
-      try(download.file(sprintf("https://github.com/rwinlib/arrow/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE), silent = TRUE)
+      get_file(rwinlib, VERSION)
     }
-    if(!file.exists("lib.zip")){
+    if (!file.exists("lib.zip")) {
       # Next, try without a patch release, i.e. go from 0.14.1 to 0.14.0
       VERSION <- sub("^([0-9]+\\.[0-9]+\\.).*$", "\\10", VERSION)
-      cat(sprintf("Downloading https://github.com/rwinlib/arrow/archive/v%s.zip\n", VERSION))
-      download.file(sprintf("https://github.com/rwinlib/arrow/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
+      get_file(rwinlib, VERSION)
     }
   }
   dir.create("windows", showWarnings = FALSE)


### PR DESCRIPTION
This patch:

* Makes ci/scripts/r_windows_build.sh executable from any directory, provided that `ARROW_HOME` is set
* Modifies r/tools/winlibs.R to look for Arrow C++ binaries on our bintray. This lets us (in the packaging jobs on ursa-labs/arrow-r-nightly) build the C++ libraries once and then pull that in for each R version we build packages for, rather than compiling everything every time. It also lets any R developers on Windows be able to download dev versions of the C++ libs.