### PR TITLE
ARROW-8182 [Packaging] Increment the version number detected from the latest git tag

### DIFF
--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -36,6 +36,7 @@ from collections import namedtuple
 import click
 import toolz
 from setuptools_scm.git import parse as parse_git_version
+from setuptools_scm.version import guess_next_version
 from ruamel.yaml import YAML
 
 try:
@@ -758,7 +759,8 @@ def get_version(root, **kwargs):
     """
     kwargs['describe_command'] =\
         'git describe --dirty --tags --long --match "apache-arrow-[0-9].*"'
-    return parse_git_version(root, **kwargs)
+    version = parse_git_version(root, **kwargs)
+    return version.format_next_version(guess_next_version)
 
 
 class Serializable:
@@ -802,7 +804,7 @@ class Target(Serializable):
         if remote is None:
             remote = repo.remote_url
         if version is None:
-            version = get_version(repo.path).format_with('{tag}.dev{distance}')
+            version = get_version(repo.path)
         if email is None:
             email = repo.user_email
 


### PR DESCRIPTION
The packaging artifacts are tagged with the following version number format by setuptools_scm: `{latest-tag}.dev{distance}` (0.16.0.dev1, 0.16.0.dev2...)

Once we make nightly artifacts available for development purposes depending on the package manager `0.16.0` may be considered newer than `0.16.0.dev1`. For example to install a nightly wheel via pip the user must pin the exact version of the produced wheel, there are no options to prefer `0.16.0.devN` over `0.16.0`.

One way to resolve this to increment the version number's minor component, so instead of generating `0.16.0.devN` version number after the `0.16` tag, create `0.16.1.devN` version which will be considered newer than `0.16.0`.