### PR TITLE
ARROW-8158: [Java] Getting length of data buffer and base variable width vector

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -1217,7 +1217,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
     return getStartOffset(index);
   }
 
-  protected final int getStartOffset(int index) {
+  public final int getStartOffset(int index) {
     return offsetBuffer.getInt(index * OFFSET_WIDTH);
   }
 
@@ -1399,7 +1399,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   /**
    * Gets the ending offset of a record, given its index.
    */
-  protected final int getEndOffset(int index) {
+  public final int getEndOffset(int index) {
     return offsetBuffer.getInt((index + 1) * OFFSET_WIDTH);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -1395,4 +1395,11 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
   public <OUT, IN> OUT accept(VectorVisitor<OUT, IN> visitor, IN value) {
     return visitor.visit(this, value);
   }
+
+  /**
+   * Gets the ending offset of a record, given its index.
+   */
+  protected final int getEndOffset(int index) {
+    return offsetBuffer.getInt((index + 1) * OFFSET_WIDTH);
+  }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2701,4 +2701,28 @@ public class TestValueVector {
     }
     writer.endList();
   }
+
+  @Test
+  public void testVariableVectorGetEndOffset() {
+    try (final VarCharVector vector1 = new VarCharVector("v1", allocator);
+         final VarBinaryVector vector2 = new VarBinaryVector("v2", allocator)) {
+
+      setVector(vector1, STR1, null, STR2);
+      setVector(vector2, STR1, STR2, STR3);
+
+      assertEquals(0, vector1.getStartOffset(0));
+      assertEquals(6, vector1.getEndOffset(0));
+      assertEquals(6, vector1.getStartOffset(1));
+      assertEquals(6, vector1.getEndOffset(1));
+      assertEquals(6, vector1.getStartOffset(2));
+      assertEquals(16, vector1.getEndOffset(2));
+
+      assertEquals(0, vector2.getStartOffset(0));
+      assertEquals(6, vector2.getEndOffset(0));
+      assertEquals(6, vector2.getStartOffset(1));
+      assertEquals(16, vector2.getEndOffset(1));
+      assertEquals(16, vector2.getStartOffset(2));
+      assertEquals(21, vector2.getEndOffset(2));
+    }
+  }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2711,18 +2711,18 @@ public class TestValueVector {
       setVector(vector2, STR1, STR2, STR3);
 
       assertEquals(0, vector1.getStartOffset(0));
-      assertEquals(6, vector1.getEndOffset(0));
-      assertEquals(6, vector1.getStartOffset(1));
-      assertEquals(6, vector1.getEndOffset(1));
-      assertEquals(6, vector1.getStartOffset(2));
-      assertEquals(16, vector1.getEndOffset(2));
+      assertEquals(STR1.length, vector1.getEndOffset(0));
+      assertEquals(STR1.length, vector1.getStartOffset(1));
+      assertEquals(STR1.length, vector1.getEndOffset(1));
+      assertEquals(STR1.length, vector1.getStartOffset(2));
+      assertEquals(STR1.length + STR2.length, vector1.getEndOffset(2));
 
       assertEquals(0, vector2.getStartOffset(0));
-      assertEquals(6, vector2.getEndOffset(0));
-      assertEquals(6, vector2.getStartOffset(1));
-      assertEquals(16, vector2.getEndOffset(1));
-      assertEquals(16, vector2.getStartOffset(2));
-      assertEquals(21, vector2.getEndOffset(2));
+      assertEquals(STR1.length, vector2.getEndOffset(0));
+      assertEquals(STR1.length, vector2.getStartOffset(1));
+      assertEquals(STR1.length + STR2.length, vector2.getEndOffset(1));
+      assertEquals(STR1.length + STR2.length, vector2.getStartOffset(2));
+      assertEquals(STR1.length + STR2.length + STR3.length, vector2.getEndOffset(2));
     }
   }
 }


### PR DESCRIPTION
For string data buffer and base variable width vector can we have a way to get length of the data? 

For instance, in ArrowColumnVector in StringAccessor we use stringResult.start and stringResult.end, instead we would like to get length of the data through an exposed function.

Now we have getStartOffset in BaseVariableVector and getElementStartIndex/getElementEndIndex in BaseListVector. To be consistent, we add getEndOffset for BaseVariableVector.