### PR TITLE
ARROW-8058: [Dataset] Relax DatasetFactory discovery validation

### DIFF
--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -343,7 +343,10 @@ TEST_F(TestEndToEnd, EndToEndSingleDataset) {
   // schema evolved by adding/renaming columns. In this case, the schema is
   // passed to the dataset constructor.
   // The inspected_schema may optionally be modified before being finalized.
-  ASSERT_OK_AND_ASSIGN(auto inspected_schema, factory->Inspect());
+  InspectOptions inspect_options;
+  inspect_options.depth = InspectOptions::kInspectAllFragments;
+  inspect_options.with_partition_inspection = true;
+  ASSERT_OK_AND_ASSIGN(auto inspected_schema, factory->Inspect(inspect_options));
   EXPECT_EQ(*schema_, *inspected_schema);
 
   // Build the Dataset where partitions are attached to fragments (files).

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -344,8 +344,7 @@ TEST_F(TestEndToEnd, EndToEndSingleDataset) {
   // passed to the dataset constructor.
   // The inspected_schema may optionally be modified before being finalized.
   InspectOptions inspect_options;
-  inspect_options.depth = InspectOptions::kInspectAllFragments;
-  inspect_options.with_partition_inspection = true;
+  inspect_options.fragments = InspectOptions::kInspectAllFragments;
   ASSERT_OK_AND_ASSIGN(auto inspected_schema, factory->Inspect(inspect_options));
   EXPECT_EQ(*schema_, *inspected_schema);
 

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -41,16 +41,17 @@ struct InspectOptions {
   /// See `fragments` property.
   static constexpr int kInspectAllFragments = -1;
 
-  /// Indicate how many fragments' schema should be inspected. This limits the
-  /// number of fragment accessed to inquire their schemas, thus improving the
-  /// latency of the discovery process when dealing with a high number of fragment
-  /// and/or high latency file systems.
+  /// Indicate how many fragments should be inspected to infer the unified dataset
+  /// schema. Limiting the number of fragments accessed improves the latency of
+  /// the discovery process when dealing with a high number of fragments and/or
+  /// high latency file systems.
   ///
-  /// The default value of `1` inspect the schema of the first fragment only,
-  /// in no particular order. If the dataset has a uniform schema for all fragments,
-  /// this default is the optimal value. In order to inspect all fragments, set
-  /// this option to `kInspectAllFragments`. A value of `0` disable inspection
-  /// of fragments.
+  /// The default value of `1` inspects the schema of the first (in no particular
+  /// order) fragment only. If the dataset has a uniform schema for all fragments,
+  /// this default is the optimal value. In order to inspect all fragments and
+  /// robustly unify their potentially varying schemas, set this option to
+  /// `kInspectAllFragments`. A value of `0` disables inspection of fragments
+  /// altogether so only the partitioning schema will be inspected.
   int fragments = 1;
 };
 
@@ -64,7 +65,7 @@ struct FinishOptions {
   /// following options to `DatasetDiscovery::Inspect`.
   InspectOptions inspect_options{};
 
-  /// Indicate if the given Schema (when inferred), should be validated against
+  /// Indicate if the given Schema (when specified), should be validated against
   /// the fragments' schemas. `inspect_options` will control how many fragments
   /// are checked.
   bool validate_fragments = false;
@@ -114,6 +115,10 @@ class ARROW_DS_EXPORT UnionDatasetFactory : public DatasetFactory {
   }
 
   /// \brief Get the schemas of the Datasets.
+  ///
+  /// Instead of applying options globally, it applies at each child factory.
+  /// This will not respect `options.fragments` exactly, but will respect the
+  /// spirit of peeking the first fragments or all of them.
   Result<std::vector<std::shared_ptr<Schema>>> InspectSchemas(
       InspectOptions options) override;
 

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -190,7 +190,7 @@ TEST_F(FileSystemDatasetFactoryTest, ExplicitPartition) {
   MakeFactory({fs::File(a_1)});
 
   InspectOptions options;
-  // Should inspect the Schema even if no files are inspected.
+  // Should inspect the partition's Schema even if no files are inspected.
   options.fragments = 0;
   AssertInspect(schema({part_field}), options);
   AssertFinishWithPaths({a_1}, nullptr, options);

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -724,8 +724,9 @@ cdef class DatasetFactory:
 
     def inspect_schemas(self):
         cdef CResult[vector[shared_ptr[CSchema]]] result
+        cdef CInspectOptions options
         with nogil:
-            result = self.factory.InspectSchemas()
+            result = self.factory.InspectSchemas(options)
 
         schemas = []
         for s in GetResultValue(result):
@@ -741,8 +742,9 @@ cdef class DatasetFactory:
         Schema
         """
         cdef CResult[shared_ptr[CSchema]] result
+        cdef CInspectOptions options
         with nogil:
-            result = self.factory.Inspect()
+            result = self.factory.Inspect(options)
         return pyarrow_wrap_schema(GetResultValue(result))
 
     def finish(self, Schema schema=None):

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -181,9 +181,17 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[shared_ptr[CUnionDataset]] Make(shared_ptr[CSchema] schema,
                                                 CDatasetVector children)
 
+    cdef cppclass CInspectOptions "arrow::dataset::InspectOptions":
+        int fragments
+
+    cdef cppclass CFinishOptions "arrow::dataset::FinishOptions":
+        shared_ptr[CSchema] schema
+        CInspectOptions inspect_options
+        c_bool validate_fragments
+
     cdef cppclass CDatasetFactory "arrow::dataset::DatasetFactory":
-        CResult[vector[shared_ptr[CSchema]]] InspectSchemas()
-        CResult[shared_ptr[CSchema]] Inspect()
+        CResult[vector[shared_ptr[CSchema]]] InspectSchemas(CInspectOptions)
+        CResult[shared_ptr[CSchema]] Inspect(CInspectOptions)
         CResult[shared_ptr[CDataset]] FinishWithSchema "Finish"(
             const shared_ptr[CSchema] & schema)
         CResult[shared_ptr[CDataset]] Finish()

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -482,7 +482,7 @@ def test_filesystem_factory(mockfs, paths_or_selector):
     )
     assert options.partition_base_dir == 'subdir'
     assert options.ignore_prefixes == ['.', '_']
-    assert options.exclude_invalid_files is True
+    assert options.exclude_invalid_files is False
 
     factory = ds.FileSystemDatasetFactory(
         mockfs, paths_or_selector, format, options


### PR DESCRIPTION
This PR aims to improve the latency of the discovery process. Notably, it selects "fast" defaults over "safe" defaults.

- Add `InspectOptions` which limits the number of fragments inspected to infer the schema, it defaults to one fragment.
- Add `FinishOptions` which toggles if validation of the optional schema and also controls the number of fragments it validates with. It defaults to disabling validation.

This gives a noticeable speedup when the fragments have a uniform schema.