### PR TITLE
ARROW-8191: [Packaging][APT] Fix cmake removal in Debian GNU/Linux Stretch

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
@@ -32,6 +32,9 @@ RUN sed -i'' -e 's/main$/main contrib non-free/g' /etc/apt/sources.list
 RUN \
   echo "deb http://deb.debian.org/debian stretch-backports main" > \
     /etc/apt/sources.list.d/backports.list
+RUN \
+  echo "deb http://deb.debian.org/debian stretch-backports-sloppy main" > \
+    /etc/apt/sources.list.d/backports-sloppy.list
 
 ARG DEBUG
 ARG LLVM
@@ -80,7 +83,7 @@ RUN \
     python3-wheel \
     tzdata \
     zlib1g-dev && \
-  apt install -y -V -t stretch-backports ${quiet} \
+  apt install -y -V -t stretch-backports -t stretch-backports-sloppy ${quiet} \
     debhelper \
     libgmock-dev \
     libgtest-dev \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
@@ -83,9 +83,10 @@ RUN \
     python3-wheel \
     tzdata \
     zlib1g-dev && \
-  apt install -y -V -t stretch-backports -t stretch-backports-sloppy ${quiet} \
-    debhelper && \
+  apt install -y -V -t stretch-backports-sloppy ${quiet} \
+    libarchive13 && \
   apt install -y -V -t stretch-backports ${quiet} \
+    debhelper && \
     libgmock-dev \
     libgtest-dev \
     rapidjson-dev && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
@@ -86,7 +86,7 @@ RUN \
   apt install -y -V -t stretch-backports-sloppy ${quiet} \
     libarchive13 && \
   apt install -y -V -t stretch-backports ${quiet} \
-    debhelper && \
+    debhelper \
     libgmock-dev \
     libgtest-dev \
     rapidjson-dev && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
@@ -84,7 +84,8 @@ RUN \
     tzdata \
     zlib1g-dev && \
   apt install -y -V -t stretch-backports -t stretch-backports-sloppy ${quiet} \
-    debhelper \
+    debhelper && \
+  apt install -y -V -t stretch-backports ${quiet} \
     libgmock-dev \
     libgtest-dev \
     rapidjson-dev && \


### PR DESCRIPTION
Because cmake in stretch-backports requires newer libarchive13 but
newer libarchive13 only exists in stretch-backports-sloppy.