### PR TITLE
ARROW-6872: [Python] Fix empty table creation from schema with dictionary field

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2155,3 +2155,16 @@ def concat_arrays(arrays, MemoryPool memory_pool=None):
         check_status(Concatenate(c_arrays, pool, &c_result))
 
     return pyarrow_wrap_array(c_result)
+
+
+def _empty_array(DataType type):
+    """
+    Create empty array of the given type.
+    """
+    if type.id == Type_DICTIONARY:
+        arr = DictionaryArray.from_arrays(
+            _empty_array(type.index_type), _empty_array(type.value_type),
+            ordered=type.ordered)
+    else:
+        arr = array([], type=type)
+    return arr

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -547,7 +547,9 @@ def test_type_schema_pickling():
 
 def test_empty_table():
     schema = pa.schema([
-        pa.field('oneField', pa.int64())
+        pa.field('f0', pa.int64()),
+        pa.field('f1', pa.dictionary(pa.int32(), pa.string())),
+        pa.field('f2', pa.list_(pa.list_(pa.int64()))),
     ])
     table = schema.empty_table()
     assert isinstance(table, pa.Table)

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1036,7 +1036,7 @@ cdef class Schema:
         arrays = []
         names = []
         for field in self:
-            arrays.append(array([], type=field.type))
+            arrays.append(_empty_array(field.type))
             names.append(field.name)
         return Table.from_arrays(
             arrays=arrays,


### PR DESCRIPTION
This is a quick fix for ARROW-6872 to handle dictionary fields. What it does not yet fix is a nested type with dictionary inside (eg list of dictionary type), which probably needs a sequence converted for dictionary type.