### PR TITLE
ARROW-8186: [Python] Fix dataset expression operation with invalid scalar

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1165,20 +1165,12 @@ cdef class Scanner:
 def _binop(fn, left, right):
     # cython doesn't support reverse operands like __radd__ just passes the
     # arguments in the same order as the binary operator called
-
     if isinstance(left, Expression) and isinstance(right, Expression):
         pass
     elif isinstance(left, Expression):
-        try:
-            right = ScalarExpression(right)
-        except TypeError:
-            return NotImplemented
-
+        right = ScalarExpression(right)
     elif isinstance(right, Expression):
-        try:
-            left = ScalarExpression(left)
-        except TypeError:
-            return NotImplemented
+        left = ScalarExpression(left)
     else:
         raise TypeError('Neither left nor right arguments are Expressions')
 
@@ -1282,10 +1274,7 @@ cdef class Expression:
         }
 
         if not isinstance(other, Expression):
-            try:
-                other = ScalarExpression(other)
-            except TypeError:
-                return NotImplemented
+            other = ScalarExpression(other)
 
         return ComparisonExpression(operator_mapping[op], self, other)
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -444,6 +444,19 @@ def test_expression_ergonomics():
     with pytest.raises(TypeError):
         field.isin(1)
 
+    # operations with non-scalar values
+    with pytest.raises(TypeError):
+        field == [1]
+
+    with pytest.raises(TypeError):
+        field != {1}
+
+    with pytest.raises(TypeError):
+        field & [1]
+
+    with pytest.raises(TypeError):
+        field | [1]
+
 
 @pytest.mark.parametrize('paths_or_selector', [
     fs.FileSelector('subdir', recursive=True),


### PR DESCRIPTION
When the expression operation is invalid, we should raise an error rather than returning a non-expression object.