### PR TITLE
ARROW-8060: [Python] Make dataset Expression objects serializable

### DIFF
--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -607,6 +607,14 @@ std::shared_ptr<Expression> CastExpression::Assume(const Expression& given) cons
   return std::make_shared<CastExpression>(std::move(operand), std::move(like), options_);
 }
 
+std::shared_ptr<DataType> CastExpression::to_type() const {
+  if (arrow::util::holds_alternative<std::shared_ptr<DataType>>(to_)) {
+    return arrow::util::get<std::shared_ptr<DataType>>(to_);
+  } else {
+    return std::shared_ptr<DataType>(nullptr);
+  }
+}
+
 std::string FieldExpression::ToString() const { return name_; }
 
 std::string OperatorName(compute::CompareOperator op) {

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -607,12 +607,20 @@ std::shared_ptr<Expression> CastExpression::Assume(const Expression& given) cons
   return std::make_shared<CastExpression>(std::move(operand), std::move(like), options_);
 }
 
-std::shared_ptr<DataType> CastExpression::to_type() const {
+const std::shared_ptr<DataType>& CastExpression::to_type() const {
   if (arrow::util::holds_alternative<std::shared_ptr<DataType>>(to_)) {
     return arrow::util::get<std::shared_ptr<DataType>>(to_);
-  } else {
-    return std::shared_ptr<DataType>(nullptr);
   }
+  static std::shared_ptr<DataType> null;
+  return null;
+}
+
+const std::shared_ptr<Expression>& CastExpression::like_expr() const {
+  if (arrow::util::holds_alternative<std::shared_ptr<Expression>>(to_)) {
+    return arrow::util::get<std::shared_ptr<Expression>>(to_);
+  }
+  static std::shared_ptr<Expression> null;
+  return null;
 }
 
 std::string FieldExpression::ToString() const { return name_; }

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -377,6 +377,7 @@ class ARROW_DS_EXPORT CastExpression final
 
   const compute::CastOptions& options() const { return options_; }
 
+  /// Try to return with the DataType variant of the cast target.
   std::shared_ptr<DataType> to_type() const;
 
  private:

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -377,6 +377,8 @@ class ARROW_DS_EXPORT CastExpression final
 
   const compute::CastOptions& options() const { return options_; }
 
+  std::shared_ptr<DataType> to_type() const;
+
  private:
   util::variant<std::shared_ptr<DataType>, std::shared_ptr<Expression>> to_;
   compute::CastOptions options_;

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -377,8 +377,13 @@ class ARROW_DS_EXPORT CastExpression final
 
   const compute::CastOptions& options() const { return options_; }
 
-  /// Try to return with the DataType variant of the cast target.
-  std::shared_ptr<DataType> to_type() const;
+  /// Return the target type of this CastTo expression, or nullptr if this is a
+  /// CastLike expression.
+  const std::shared_ptr<DataType>& to_type() const;
+
+  /// Return the target expression of this CastLike expression, or nullptr if
+  /// this is a CastTo expression.
+  const std::shared_ptr<Expression>& like_expr() const;
 
  private:
   util::variant<std::shared_ptr<DataType>, std::shared_ptr<Expression>> to_;

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1472,13 +1472,10 @@ cdef class CastExpression(UnaryExpression):
         -------
         DataType or Expression
         """
-        cdef:
-            shared_ptr[CDataType] typ = self.cast.to_type()
-            shared_ptr[CExpression] expr = self.cast.like_expr()
+        cdef shared_ptr[CDataType] typ = self.cast.to_type()
+
         if typ.get() != nullptr:
             return pyarrow_wrap_data_type(typ)
-        elif expr.get() != nullptr:
-            return Expression.wrap(expr)
         else:
             raise TypeError(
                 'Cannot determine the target type of the cast expression'

--- a/python/pyarrow/compute.pxi
+++ b/python/pyarrow/compute.pxi
@@ -48,6 +48,15 @@ cdef class CastOptions:
     def unsafe():
         return CastOptions.wrap(CCastOptions.Unsafe())
 
+    def is_safe(self):
+        return not (
+            self.options.allow_int_overflow or
+            self.options.allow_time_truncate or
+            self.options.allow_time_overflow or
+            self.options.allow_float_truncate or
+            self.options.allow_invalid_utf8
+        )
+
     cdef inline CCastOptions unwrap(self) nogil:
         return self.options
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -819,6 +819,9 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
     cdef cppclass CNullScalar" arrow::NullScalar"(CScalar):
         CNullScalar()
 
+    cdef cppclass CBooleanScalar" arrow::BooleanScalar"(CScalar):
+        c_bool value
+
     cdef cppclass CInt8Scalar" arrow::Int8Scalar"(CScalar):
         int8_t value
 
@@ -850,7 +853,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         double value
 
     cdef cppclass CStringScalar" arrow::StringScalar"(CScalar):
-        pass
+        shared_ptr[CBuffer] value
 
     shared_ptr[CScalar] MakeScalar[Value](Value value)
     shared_ptr[CScalar] MakeStringScalar" arrow::MakeScalar"(c_string value)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -814,6 +814,10 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
     cdef cppclass CScalar" arrow::Scalar":
         shared_ptr[CDataType] type
         c_bool is_valid
+        c_string ToString() const
+
+    cdef cppclass CNullScalar" arrow::NullScalar"(CScalar):
+        CNullScalar()
 
     cdef cppclass CInt8Scalar" arrow::Int8Scalar"(CScalar):
         int8_t value

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -114,6 +114,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
                         CCastOptions options)
         const CCastOptions& options() const
         const shared_ptr[CDataType]& to_type() const
+        const shared_ptr[CExpression]& like_expr() const
 
     cdef cppclass CInExpression "arrow::dataset::InExpression"(
             CUnaryExpression):

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -49,13 +49,13 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CExpression "arrow::dataset::Expression":
         CExpression(CExpressionType type)
-        c_bool Equals(const CExpression & other) const
-        c_bool Equals(const shared_ptr[CExpression] & other) const
+        c_bool Equals(const CExpression& other) const
+        c_bool Equals(const shared_ptr[CExpression]& other) const
         c_bool IsNull() const
-        CResult[shared_ptr[CDataType]] Validate(const CSchema & schema) const
-        shared_ptr[CExpression] Assume(const CExpression & given) const
+        CResult[shared_ptr[CDataType]] Validate(const CSchema& schema) const
+        shared_ptr[CExpression] Assume(const CExpression& given) const
         shared_ptr[CExpression] Assume(
-            const shared_ptr[CExpression] & given) const
+            const shared_ptr[CExpression]& given) const
         c_string ToString() const
         CExpressionType type() const
         shared_ptr[CExpression] Copy() const
@@ -65,17 +65,17 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CUnaryExpression "arrow::dataset::UnaryExpression"(
             CExpression):
-        const shared_ptr[CExpression] & operand() const
+        const shared_ptr[CExpression]& operand() const
 
     cdef cppclass CBinaryExpression "arrow::dataset::BinaryExpression"(
             CExpression):
-        const shared_ptr[CExpression] & left_operand() const
-        const shared_ptr[CExpression] & right_operand() const
+        const shared_ptr[CExpression]& left_operand() const
+        const shared_ptr[CExpression]& right_operand() const
 
     cdef cppclass CScalarExpression "arrow::dataset::ScalarExpression"(
             CExpression):
-        CScalarExpression(const shared_ptr[CScalar] & value)
-        const shared_ptr[CScalar] & value() const
+        CScalarExpression(const shared_ptr[CScalar]& value)
+        const shared_ptr[CScalar]& value() const
 
     cdef cppclass CFieldExpression "arrow::dataset::FieldExpression"(
             CExpression):
@@ -91,11 +91,13 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CAndExpression "arrow::dataset::AndExpression"(
             CBinaryExpression):
-        pass
+        CAndExpression(shared_ptr[CExpression] left_operand,
+                       shared_ptr[CExpression] right_operand)
 
     cdef cppclass COrExpression "arrow::dataset::OrExpression"(
             CBinaryExpression):
-        pass
+        COrExpression(shared_ptr[CExpression] left_operand,
+                      shared_ptr[CExpression] right_operand)
 
     cdef cppclass CNotExpression "arrow::dataset::NotExpression"(
             CUnaryExpression):
@@ -110,17 +112,20 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CCastExpression(shared_ptr[CExpression] operand,
                         shared_ptr[CDataType] to,
                         CCastOptions options)
+        const CCastOptions& options() const
+        const shared_ptr[CDataType]& to_type() const
 
     cdef cppclass CInExpression "arrow::dataset::InExpression"(
             CUnaryExpression):
         CInExpression(shared_ptr[CExpression] operand, shared_ptr[CArray] set)
+        const shared_ptr[CArray]& set() const
 
     cdef shared_ptr[CNotExpression] CMakeNotExpression "arrow::dataset::not_"(
         shared_ptr[CExpression] operand)
     cdef shared_ptr[CExpression] CMakeAndExpression "arrow::dataset::and_"(
-        const CExpressionVector & subexpressions)
+        const CExpressionVector& subexpressions)
     cdef shared_ptr[CExpression] CMakeOrExpression "arrow::dataset::or_"(
-        const CExpressionVector & subexpressions)
+        const CExpressionVector& subexpressions)
 
     cdef CResult[shared_ptr[CExpression]] CInsertImplicitCasts \
         "arrow::dataset::InsertImplicitCasts"(
@@ -155,8 +160,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
     cdef cppclass CScannerBuilder "arrow::dataset::ScannerBuilder":
         CScannerBuilder(shared_ptr[CDataset],
                         shared_ptr[CScanContext] scan_context)
-        CStatus Project(const vector[c_string] & columns)
-        CStatus Filter(const CExpression & filter)
+        CStatus Project(const vector[c_string]& columns)
+        CStatus Filter(const CExpression& filter)
         CStatus Filter(shared_ptr[CExpression] filter)
         CStatus UseThreads(c_bool use_threads)
         CStatus BatchSize(int64_t batch_size)
@@ -185,7 +190,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[vector[shared_ptr[CSchema]]] InspectSchemas()
         CResult[shared_ptr[CSchema]] Inspect()
         CResult[shared_ptr[CDataset]] FinishWithSchema "Finish"(
-            const shared_ptr[CSchema] & schema)
+            const shared_ptr[CSchema]& schema)
         CResult[shared_ptr[CDataset]] Finish()
         const shared_ptr[CExpression]& root_partition()
         CStatus SetRootPartition(shared_ptr[CExpression] partition)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -19,7 +19,6 @@ import contextlib
 import operator
 import os
 import pickle
-import urllib
 
 import numpy as np
 import pytest

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -354,9 +354,15 @@ def test_expression():
     or_ = ds.OrExpression(a, b)
     not_ = ds.NotExpression(ds.OrExpression(a, b))
     is_valid = ds.IsValidExpression(a)
-    cast_unsafe = ds.CastExpression(a, pa.int32())
-    cast_safe = ds.CastExpression(a, pa.int32(), safe=True)
+    cast_safe = ds.CastExpression(a, pa.int32())
+    cast_unsafe = ds.CastExpression(a, pa.int32(), safe=False)
     in_ = ds.InExpression(a, pa.array([1, 2, 3]))
+
+    assert is_valid.operand == a
+    assert in_.set_.equals(pa.array([1, 2, 3]))
+    assert cast_unsafe.to == pa.int32()
+    assert cast_unsafe.safe is False
+    assert cast_safe.safe is True
 
     condition = ds.ComparisonExpression(
         ds.CompareOperator.Greater,

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -18,6 +18,8 @@
 import contextlib
 import operator
 import os
+import pickle
+import urllib
 
 import numpy as np
 import pytest
@@ -337,9 +339,11 @@ def test_expression():
     b = ds.ScalarExpression(1.1)
     c = ds.ScalarExpression(True)
     d = ds.ScalarExpression("string")
+    e = ds.ScalarExpression(None)
 
     equal = ds.ComparisonExpression(ds.CompareOperator.Equal, a, b)
-    assert equal.op() == ds.CompareOperator.Equal
+    greater = a > b
+    assert equal.op == ds.CompareOperator.Equal
 
     and_ = ds.AndExpression(a, b)
     assert and_.left_operand.equals(a)
@@ -347,14 +351,12 @@ def test_expression():
     assert and_.equals(ds.AndExpression(a, b))
     assert and_.equals(and_)
 
-    ds.AndExpression(a, b, c)
-    ds.OrExpression(a, b)
-    ds.OrExpression(a, b, c, d)
-    ds.NotExpression(ds.OrExpression(a, b, c))
-    ds.IsValidExpression(a)
-    ds.CastExpression(a, pa.int32())
-    ds.CastExpression(a, pa.int32(), safe=True)
-    ds.InExpression(a, pa.array([1, 2, 3]))
+    or_ = ds.OrExpression(a, b)
+    not_ = ds.NotExpression(ds.OrExpression(a, b))
+    is_valid = ds.IsValidExpression(a)
+    cast_unsafe = ds.CastExpression(a, pa.int32())
+    cast_safe = ds.CastExpression(a, pa.int32(), safe=True)
+    in_ = ds.InExpression(a, pa.array([1, 2, 3]))
 
     condition = ds.ComparisonExpression(
         ds.CompareOperator.Greater,
@@ -381,6 +383,12 @@ def test_expression():
     assert condition.assume(i64_is_7).equals(ds.ScalarExpression(True))
     assert str(condition) == "(i64 > 5:int64)"
     assert "(i64 > 5:int64)" in repr(condition)
+
+    all_exprs = [a, b, c, d, e, equal, greater, and_, or_, not_, is_valid,
+                 cast_unsafe, cast_safe, in_, condition, i64_is_5, i64_is_7]
+    for expr in all_exprs:
+        restored = pickle.loads(pickle.dumps(expr))
+        assert expr.equals(restored)
 
 
 def test_expression_ergonomics():


### PR DESCRIPTION
The Scalar are not properly exposed yet and the C++ implementation will change soon so while the serialization will work, we need to refactor this code.