### PR TITLE
ARROW-8197: [Rust] [DataFusion] Fix schema returned by physical plan

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -35,7 +35,7 @@ use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::datasource::DatasourceExec;
 use crate::execution::physical_plan::expressions::{
-    Avg, BinaryExpr, CastExpr, Column, Count, Literal, Max, Min, Sum,
+    Alias, Avg, BinaryExpr, CastExpr, Column, Count, Literal, Max, Min, Sum,
 };
 use crate::execution::physical_plan::hash_aggregate::HashAggregateExec;
 use crate::execution::physical_plan::limit::LimitExec;
@@ -380,6 +380,10 @@ impl ExecutionContext {
         input_schema: &Schema,
     ) -> Result<Arc<dyn PhysicalExpr>> {
         match e {
+            Expr::Alias(expr, name) => {
+                let expr = self.create_physical_expr(expr, input_schema)?;
+                Ok(Arc::new(Alias::new(expr, &name)))
+            }
             Expr::Column(i) => {
                 Ok(Arc::new(Column::new(*i, &input_schema.field(*i).name())))
             }
@@ -718,6 +722,38 @@ mod tests {
         let mut rows = test::format_batch(&batch);
         rows.sort();
         assert_eq!(rows, expected);
+        Ok(())
+    }
+
+    #[test]
+    fn aggregate_with_alias() -> Result<()> {
+        let tmp_dir = TempDir::new("execute")?;
+        let mut ctx = create_ctx(&tmp_dir, 1)?;
+
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("c1", DataType::UInt32, false),
+            Field::new("c2", DataType::UInt64, false),
+        ]));
+
+        let plan = LogicalPlanBuilder::scan(
+            "default",
+            "test",
+            schema.as_ref(),
+            Some(vec![0, 1]),
+        )?
+        .aggregate(
+            vec![col(0)],
+            vec![aggregate_expr("SUM", col(1), DataType::Int32)],
+        )?
+        .project(&vec![col(0), col(1).alias("total_salary")])?
+        .build()?;
+
+        let physical_plan = ctx.create_physical_plan(&Arc::new(plan), 1024)?;
+        assert_eq!("c1", physical_plan.schema().field(0).name().as_str());
+        assert_eq!(
+            "total_salary",
+            physical_plan.schema().field(1).name().as_str()
+        );
         Ok(())
     }
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -380,7 +380,9 @@ impl ExecutionContext {
         input_schema: &Schema,
     ) -> Result<Arc<dyn PhysicalExpr>> {
         match e {
-            Expr::Column(i) => Ok(Arc::new(Column::new(*i))),
+            Expr::Column(i) => {
+                Ok(Arc::new(Column::new(*i, &input_schema.field(*i).name())))
+            }
             Expr::Literal(value) => Ok(Arc::new(Literal::new(value.clone()))),
             Expr::BinaryExpr { left, op, right } => Ok(Arc::new(BinaryExpr::new(
                 self.create_physical_expr(left, input_schema)?,

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -49,19 +49,23 @@ use arrow::record_batch::RecordBatch;
 /// Represents the column at a given index in a RecordBatch
 pub struct Column {
     index: usize,
+    name: String,
 }
 
 impl Column {
     /// Create a new column expression
-    pub fn new(index: usize) -> Self {
-        Self { index }
+    pub fn new(index: usize, name: &str) -> Self {
+        Self {
+            index,
+            name: name.to_owned(),
+        }
     }
 }
 
 impl PhysicalExpr for Column {
     /// Get the name to use in a schema to represent the result of this expression
     fn name(&self) -> String {
-        format!("c{}", self.index)
+        self.name.clone()
     }
 
     /// Get the data type of this expression, given the schema of the input
@@ -76,8 +80,8 @@ impl PhysicalExpr for Column {
 }
 
 /// Create a column expression
-pub fn col(i: usize) -> Arc<dyn PhysicalExpr> {
-    Arc::new(Column::new(i))
+pub fn col(i: usize, schema: &Schema) -> Arc<dyn PhysicalExpr> {
+    Arc::new(Column::new(i, &schema.field(i).name()))
 }
 
 /// SUM aggregate expression
@@ -123,7 +127,7 @@ impl AggregateExpr for Sum {
     }
 
     fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
-        Arc::new(Sum::new(Arc::new(Column::new(column_index))))
+        Arc::new(Sum::new(Arc::new(Column::new(column_index, "tbd"))))
     }
 }
 
@@ -324,7 +328,7 @@ impl AggregateExpr for Avg {
     }
 
     fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
-        Arc::new(Avg::new(Arc::new(Column::new(column_index))))
+        Arc::new(Avg::new(Arc::new(Column::new(column_index, "tbd"))))
     }
 }
 
@@ -437,7 +441,7 @@ impl AggregateExpr for Max {
     }
 
     fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
-        Arc::new(Max::new(Arc::new(Column::new(column_index))))
+        Arc::new(Max::new(Arc::new(Column::new(column_index, "MAX"))))
     }
 }
 
@@ -636,7 +640,7 @@ impl AggregateExpr for Min {
     }
 
     fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
-        Arc::new(Min::new(Arc::new(Column::new(column_index))))
+        Arc::new(Min::new(Arc::new(Column::new(column_index, "MIN"))))
     }
 }
 
@@ -823,7 +827,7 @@ impl AggregateExpr for Count {
     }
 
     fn create_reducer(&self, column_index: usize) -> Arc<dyn AggregateExpr> {
-        Arc::new(Sum::new(Arc::new(Column::new(column_index))))
+        Arc::new(Sum::new(Arc::new(Column::new(column_index, "COUNT"))))
     }
 }
 
@@ -1252,7 +1256,7 @@ mod tests {
         )?;
 
         // expression: "a < b"
-        let lt = binary(col(0), Operator::Lt, col(1));
+        let lt = binary(col(0, &schema), Operator::Lt, col(1, &schema));
         let result = lt.evaluate(&batch)?;
         assert_eq!(result.len(), 5);
 
@@ -1283,9 +1287,9 @@ mod tests {
 
         // expression: "a < b OR a == b"
         let expr = binary(
-            binary(col(0), Operator::Lt, col(1)),
+            binary(col(0, &schema), Operator::Lt, col(1, &schema)),
             Operator::Or,
-            binary(col(0), Operator::Eq, col(1)),
+            binary(col(0, &schema), Operator::Eq, col(1, &schema)),
         );
         let result = expr.evaluate(&batch)?;
         assert_eq!(result.len(), 5);
@@ -1330,7 +1334,7 @@ mod tests {
         let a = Int32Array::from(vec![1, 2, 3, 4, 5]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
 
-        let cast = CastExpr::try_new(col(0), &schema, DataType::UInt32)?;
+        let cast = CastExpr::try_new(col(0, &schema), &schema, DataType::UInt32)?;
         let result = cast.evaluate(&batch)?;
         assert_eq!(result.len(), 5);
 
@@ -1349,7 +1353,7 @@ mod tests {
         let a = Int32Array::from(vec![1, 2, 3, 4, 5]);
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
 
-        let cast = CastExpr::try_new(col(0), &schema, DataType::Utf8)?;
+        let cast = CastExpr::try_new(col(0, &schema), &schema, DataType::Utf8)?;
         let result = cast.evaluate(&batch)?;
         assert_eq!(result.len(), 5);
 
@@ -1369,7 +1373,7 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
 
         let cast = CastExpr::try_new(
-            col(0),
+            col(0, &schema),
             &schema,
             DataType::Timestamp(TimeUnit::Nanosecond, None),
         )?;
@@ -1388,7 +1392,7 @@ mod tests {
     #[test]
     fn invalid_cast() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Utf8, false)]);
-        match CastExpr::try_new(col(0), &schema, DataType::Int32) {
+        match CastExpr::try_new(col(0, &schema), &schema, DataType::Int32) {
             Err(ExecutionError::General(ref str)) => {
                 assert_eq!(str, "Invalid CAST from Utf8 to Int32");
                 Ok(())
@@ -1401,7 +1405,7 @@ mod tests {
     fn sum_contract() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 
-        let sum = sum(col(0));
+        let sum = sum(col(0, &schema));
         assert_eq!("SUM".to_string(), sum.name());
         assert_eq!(DataType::Int64, sum.data_type(&schema)?);
 
@@ -1416,7 +1420,7 @@ mod tests {
     fn max_contract() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 
-        let max = max(col(0));
+        let max = max(col(0, &schema));
         assert_eq!("MAX".to_string(), max.name());
         assert_eq!(DataType::Int64, max.data_type(&schema)?);
 
@@ -1431,7 +1435,7 @@ mod tests {
     fn min_contract() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 
-        let min = min(col(0));
+        let min = min(col(0, &schema));
         assert_eq!("MIN".to_string(), min.name());
         assert_eq!(DataType::Int64, min.data_type(&schema)?);
 
@@ -1445,7 +1449,7 @@ mod tests {
     fn avg_contract() -> Result<()> {
         let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
 
-        let avg = avg(col(0));
+        let avg = avg(col(0, &schema));
         assert_eq!("AVG".to_string(), avg.name());
         assert_eq!(DataType::Float64, avg.data_type(&schema)?);
 
@@ -1781,7 +1785,7 @@ mod tests {
     }
 
     fn do_sum(batch: &RecordBatch) -> Result<Option<ScalarValue>> {
-        let sum = sum(col(0));
+        let sum = sum(col(0, &batch.schema()));
         let accum = sum.create_accumulator();
         let input = sum.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
@@ -1792,7 +1796,7 @@ mod tests {
     }
 
     fn do_max(batch: &RecordBatch) -> Result<Option<ScalarValue>> {
-        let max = max(col(0));
+        let max = max(col(0, &batch.schema()));
         let accum = max.create_accumulator();
         let input = max.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
@@ -1803,7 +1807,7 @@ mod tests {
     }
 
     fn do_min(batch: &RecordBatch) -> Result<Option<ScalarValue>> {
-        let min = min(col(0));
+        let min = min(col(0, &batch.schema()));
         let accum = min.create_accumulator();
         let input = min.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
@@ -1814,7 +1818,7 @@ mod tests {
     }
 
     fn do_count(batch: &RecordBatch) -> Result<Option<ScalarValue>> {
-        let count = count(col(0));
+        let count = count(col(0, &batch.schema()));
         let accum = count.create_accumulator();
         let input = count.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
@@ -1825,7 +1829,7 @@ mod tests {
     }
 
     fn do_avg(batch: &RecordBatch) -> Result<Option<ScalarValue>> {
-        let avg = avg(col(0));
+        let avg = avg(col(0, &batch.schema()));
         let accum = avg.create_accumulator();
         let input = avg.evaluate_input(batch)?;
         let mut accum = accum.borrow_mut();
@@ -1925,9 +1929,9 @@ mod tests {
         op: Operator,
         expected: PrimitiveArray<T>,
     ) -> Result<()> {
-        let batch = RecordBatch::try_new(schema, data)?;
+        let batch = RecordBatch::try_new(schema.clone(), data)?;
 
-        let arithmetic_op = binary(col(0), op, col(1));
+        let arithmetic_op = binary(col(0, schema.as_ref()), op, col(1, schema.as_ref()));
         let result = arithmetic_op.evaluate(&batch)?;
 
         assert_array_eq::<T>(expected, result);
@@ -1956,7 +1960,7 @@ mod tests {
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), vec![Arc::new(a)])?;
 
         // expression: "!a"
-        let lt = not(col(0));
+        let lt = not(col(0, &schema));
         let result = lt.evaluate(&batch)?;
         assert_eq!(result.len(), 2);
 

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -157,6 +157,8 @@ mod tests {
             Arc::new(csv),
         )?;
 
+        assert_eq!("c1", projection.schema.field(0).name().as_str());
+
         let mut partition_count = 0;
         let mut row_count = 0;
         for partition in projection.partitions()? {

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -150,10 +150,12 @@ mod tests {
         let partitions = 4;
         let path = test::create_partitioned_csv("aggregate_test_100.csv", partitions)?;
 
-        let csv = CsvExec::try_new(&path, schema, true, None, 1024)?;
+        let csv = CsvExec::try_new(&path, schema.clone(), true, None, 1024)?;
 
-        let projection =
-            ProjectionExec::try_new(vec![Arc::new(Column::new(0))], Arc::new(csv))?;
+        let projection = ProjectionExec::try_new(
+            vec![Arc::new(Column::new(0, &schema.as_ref().field(0).name()))],
+            Arc::new(csv),
+        )?;
 
         let mut partition_count = 0;
         let mut row_count = 0;

--- a/rust/datafusion/src/execution/physical_plan/selection.rs
+++ b/rust/datafusion/src/execution/physical_plan/selection.rs
@@ -159,12 +159,20 @@ mod tests {
         let partitions = 4;
         let path = test::create_partitioned_csv("aggregate_test_100.csv", partitions)?;
 
-        let csv = CsvExec::try_new(&path, schema, true, None, 1024)?;
+        let csv = CsvExec::try_new(&path, schema.clone(), true, None, 1024)?;
 
         let predicate: Arc<dyn PhysicalExpr> = binary(
-            binary(col(1), Operator::Gt, lit(ScalarValue::UInt32(1))),
+            binary(
+                col(1, schema.as_ref()),
+                Operator::Gt,
+                lit(ScalarValue::UInt32(1)),
+            ),
             Operator::And,
-            binary(col(1), Operator::Lt, lit(ScalarValue::UInt32(4))),
+            binary(
+                col(1, schema.as_ref()),
+                Operator::Lt,
+                lit(ScalarValue::UInt32(4)),
+            ),
         );
 
         let selection: Arc<dyn ExecutionPlan> =

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -229,6 +229,10 @@ impl ProjectionPushDown {
 
     fn rewrite_expr(&self, expr: &Expr, mapping: &HashMap<usize, usize>) -> Result<Expr> {
         match expr {
+            Expr::Alias(expr, name) => Ok(Expr::Alias(
+                Arc::new(self.rewrite_expr(expr, mapping)?),
+                name.clone(),
+            )),
             Expr::Column(i) => Ok(Expr::Column(self.new_index(mapping, i)?)),
             Expr::Literal(_) => Ok(expr.clone()),
             Expr::Not(e) => Ok(Expr::Not(Arc::new(self.rewrite_expr(e, mapping)?))),

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -34,6 +34,7 @@ pub fn exprlist_to_column_indices(expr: &Vec<Expr>, accum: &mut HashSet<usize>) 
 /// referenced in the expression
 pub fn expr_to_column_indices(expr: &Expr, accum: &mut HashSet<usize>) {
     match expr {
+        Expr::Alias(expr, _) => expr_to_column_indices(expr, accum),
         Expr::Column(i) => {
             accum.insert(*i);
         }
@@ -55,6 +56,9 @@ pub fn expr_to_column_indices(expr: &Expr, accum: &mut HashSet<usize>) {
 /// Create field meta-data from an expression, for use in a result set schema
 pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
     match e {
+        Expr::Alias(expr, name) => {
+            Ok(Field::new(name, expr.get_type(input_schema), true))
+        }
         Expr::Column(i) => {
             let input_schema_field_count = input_schema.fields().len();
             if *i < input_schema_field_count {


### PR DESCRIPTION
This PR fixes a bug in the physical plan where schemas always had columns named c0, c1, ... and now returns the actual name of the expression used to create the result column. Because this could be a breaking change, especially for aggregate queries where the default column names are currently MIN, MAX, etc, I also added support for aliased expressions in both the logical and physical query plans so that it is possible to alias aggregate columns to avoid duplicate column names in a schema.

I have filed https://issues.apache.org/jira/browse/ARROW-8204 to add support for aliased expressions in SQL.

I also filed https://issues.apache.org/jira/browse/ARROW-8205 to add validation to enforce that schemas have unique field names.


