### PR TITLE
ARROW-8200: [GLib] Rename garrow_file_system_target_info{,s}() to ..._file_info{,s}()

### DIFF
--- a/c_glib/arrow-glib/file-system.cpp
+++ b/c_glib/arrow-glib/file-system.cpp
@@ -636,7 +636,7 @@ garrow_file_system_get_type_name(GArrowFileSystem *file_system)
 }
 
 /**
- * garrow_file_system_get_target_info:
+ * garrow_file_system_get_file_info:
  * @file_system: A #GArrowFileSystem.
  * @path: The path of the target.
  * @error: (nullable): Return location for a #GError or %NULL.
@@ -654,13 +654,13 @@ garrow_file_system_get_type_name(GArrowFileSystem *file_system)
  * Since: 1.0.0
  */
 GArrowFileInfo *
-garrow_file_system_get_target_info(GArrowFileSystem *file_system,
-                                   const gchar *path,
-                                   GError **error)
+garrow_file_system_get_file_info(GArrowFileSystem *file_system,
+                                 const gchar *path,
+                                 GError **error)
 {
   auto arrow_file_system = garrow_file_system_get_raw(file_system);
   auto arrow_result = arrow_file_system->GetFileInfo(path);
-  if (garrow::check(error, arrow_result, "[file-system][get-target-info]")) {
+  if (garrow::check(error, arrow_result, "[file-system][get-file-info]")) {
     const auto &arrow_file_info = *arrow_result;
     return garrow_file_info_new_raw(arrow_file_info);
   } else {
@@ -687,13 +687,13 @@ garrow_file_infos_new(arrow::Result<std::vector<arrow::fs::FileInfo>>&& arrow_re
 }
 
 /**
- * garrow_file_system_get_target_infos_paths:
+ * garrow_file_system_get_file_infos_paths:
  * @file_system: A #GArrowFileSystem.
  * @paths: (array length=n_paths): The paths of the targets.
  * @n_paths: The number of items in @paths.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
- * Get information same as garrow_file_system_get_target_info()
+ * Get information same as garrow_file_system_get_file_info()
  * for the given many targets at once.
  *
  * Returns: (element-type GArrowFileInfo) (transfer full):
@@ -702,10 +702,10 @@ garrow_file_infos_new(arrow::Result<std::vector<arrow::fs::FileInfo>>&& arrow_re
  * Since: 1.0.0
  */
 GList *
-garrow_file_system_get_target_infos_paths(GArrowFileSystem *file_system,
-                                          const gchar **paths,
-                                          gsize n_paths,
-                                          GError **error)
+garrow_file_system_get_file_infos_paths(GArrowFileSystem *file_system,
+                                        const gchar **paths,
+                                        gsize n_paths,
+                                        GError **error)
 {
   auto arrow_file_system = garrow_file_system_get_raw(file_system);
   std::vector<std::string> arrow_paths;
@@ -714,16 +714,16 @@ garrow_file_system_get_target_infos_paths(GArrowFileSystem *file_system,
   }
   return garrow_file_infos_new(arrow_file_system->GetFileInfo(arrow_paths),
                                error,
-                               "[file-system][get-target-infos][paths]");
+                               "[file-system][get-file-infos][paths]");
 }
 
 /**
- * garrow_file_system_get_target_infos_selector:
+ * garrow_file_system_get_file_infos_selector:
  * @file_system: A #GArrowFileSystem.
  * @file_selector: A #GArrowFileSelector.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
- * Get information same as garrow_file_system_get_target_info()
+ * Get information same as garrow_file_system_get_file_info()
  * according to a selector.
  *
  * The selector's base directory will not be part of the results,
@@ -735,16 +735,16 @@ garrow_file_system_get_target_infos_paths(GArrowFileSystem *file_system,
  * Since: 1.0.0
  */
 GList *
-garrow_file_system_get_target_infos_selector(GArrowFileSystem *file_system,
-                                             GArrowFileSelector *file_selector,
-                                             GError **error)
+garrow_file_system_get_file_infos_selector(GArrowFileSystem *file_system,
+                                           GArrowFileSelector *file_selector,
+                                           GError **error)
 {
   auto arrow_file_system = garrow_file_system_get_raw(file_system);
   const auto &arrow_file_selector =
     GARROW_FILE_SELECTOR_GET_PRIVATE(file_selector)->file_selector;
   return garrow_file_infos_new(arrow_file_system->GetFileInfo(arrow_file_selector),
                                error,
-                               "[file-system][get-target-infos][selector]");
+                               "[file-system][get-file-infos][selector]");
 }
 
 /**

--- a/c_glib/arrow-glib/file-system.h
+++ b/c_glib/arrow-glib/file-system.h
@@ -109,21 +109,21 @@ gchar *garrow_file_system_get_type_name(GArrowFileSystem *file_system);
 
 GARROW_AVAILABLE_IN_1_0
 GArrowFileInfo *
-garrow_file_system_get_target_info(GArrowFileSystem *file_system,
-                                   const gchar *path,
-                                   GError **error);
+garrow_file_system_get_file_info(GArrowFileSystem *file_system,
+                                 const gchar *path,
+                                 GError **error);
 
 GARROW_AVAILABLE_IN_1_0
-GList *garrow_file_system_get_target_infos_paths(GArrowFileSystem *file_system,
-                                                 const gchar **paths,
-                                                 gsize n_paths,
-                                                 GError **error);
+GList *garrow_file_system_get_file_infos_paths(GArrowFileSystem *file_system,
+                                               const gchar **paths,
+                                               gsize n_paths,
+                                               GError **error);
 
 GARROW_AVAILABLE_IN_1_0
 GList *
-garrow_file_system_get_target_infos_selector(GArrowFileSystem *file_system,
-                                             GArrowFileSelector *file_selector,
-                                             GError **error);
+garrow_file_system_get_file_infos_selector(GArrowFileSystem *file_system,
+                                           GArrowFileSelector *file_selector,
+                                           GError **error);
 
 GARROW_AVAILABLE_IN_1_0
 gboolean garrow_file_system_create_dir(GArrowFileSystem *file_system,

--- a/c_glib/test/file-system-tests.rb
+++ b/c_glib/test/file-system-tests.rb
@@ -20,7 +20,7 @@ module FileSystemTests
     selector = Arrow::FileSelector.new
     selector.base_dir = ""
     selector.recursive = true
-    infos = @fs.get_target_infos_selector(selector)
+    infos = @fs.get_file_infos_selector(selector)
     infos.map {|info| [info.path, info.type.nick.to_sym]}.to_h
   end
 
@@ -36,21 +36,21 @@ module FileSystemTests
 
   private def read_file(path)
     stream = @fs.open_input_stream(path)
-    size = @fs.get_target_info(path).size
+    size = @fs.get_file_info(path).size
     bytes = stream.read_bytes(size)
     stream.close
     bytes.to_s
   end
 
   private def file?(path)
-    info = @fs.get_target_info(path)
+    info = @fs.get_file_info(path)
     info.file?
   rescue Arrow::Error::Io
     false
   end
 
   private def directory?(path)
-    info = @fs.get_target_info(path)
+    info = @fs.get_file_info(path)
     info.dir?
   rescue Arrow::Error::Io
     false
@@ -240,11 +240,11 @@ module FileSystemTests
                  read_file("def"))
   end
 
-  def test_get_target_info
+  def test_get_file_info
     mkpath("AB/CD")
     create_file("AB/CD/ghi", "some data")
 
-    info = @fs.get_target_info("AB")
+    info = @fs.get_file_info("AB")
     assert_equal(Arrow::FileType::DIR,
                  info.type)
     assert_equal("AB",
@@ -255,7 +255,7 @@ module FileSystemTests
       info.mtime > 0
     end
 
-    info = @fs.get_target_info("AB/CD/ghi")
+    info = @fs.get_file_info("AB/CD/ghi")
     assert_equal(Arrow::FileType::FILE,
                  info.type)
     assert_equal("ghi",
@@ -267,11 +267,11 @@ module FileSystemTests
     end
   end
 
-  def test_get_target_infos_paths
+  def test_get_file_infos_paths
     mkpath("AB/CD")
     create_file("AB/CD/ghi", "some data")
 
-    infos = @fs.get_target_infos_paths(["AB", "AB/CD/ghi"])
+    infos = @fs.get_file_infos_paths(["AB", "AB/CD/ghi"])
     assert_equal({
                    "AB" => -1,
                    "AB/CD/ghi" => 9
@@ -279,14 +279,14 @@ module FileSystemTests
                  infos.map {|info| [info.path, info.size]}.to_h)
   end
 
-  def test_get_target_infos_selector
+  def test_get_file_infos_selector
     mkpath("AB/CD")
     create_file("abc", "data")
     create_file("AB/def", "some data")
     create_file("AB/CD/ghi", "some other data")
 
     selector = Arrow::FileSelector.new
-    infos = @fs.get_target_infos_selector(selector)
+    infos = @fs.get_file_infos_selector(selector)
     assert_equal({
                    "AB" => -1,
                    "abc" => 4
@@ -294,7 +294,7 @@ module FileSystemTests
                  infos.map {|info| [info.path, info.size]}.to_h)
 
     selector.base_dir = "AB"
-    infos = @fs.get_target_infos_selector(selector)
+    infos = @fs.get_file_infos_selector(selector)
     assert_equal({
                    "AB/CD" => -1,
                    "AB/def" => 9
@@ -302,7 +302,7 @@ module FileSystemTests
                  infos.map {|info| [info.path, info.size]}.to_h)
   end
 
-  def test_get_target_infos_selector_with_recursion
+  def test_get_file_infos_selector_with_recursion
     mkpath("AB/CD")
     create_file("abc", "data")
     create_file("AB/def", "some data")
@@ -310,7 +310,7 @@ module FileSystemTests
 
     selector = Arrow::FileSelector.new
     selector.recursive = true
-    infos = @fs.get_target_infos_selector(selector)
+    infos = @fs.get_file_infos_selector(selector)
     assert_equal({
                    "AB" => -1,
                    "AB/CD" => -1,


### PR DESCRIPTION
Because C++ renamed them by ARROW-8145.