### PR TITLE
ARROW-8193: [C++] Fix gcc 4.8 compilation error with non-copyable types in Iterator<T>::ToVector

### DIFF
--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -156,7 +156,9 @@ class Iterator : public util::EqualityComparable<Iterator<T>> {
       ARROW_ASSIGN_OR_RAISE(auto element, std::move(maybe_element));
       out.push_back(std::move(element));
     }
-    return out;
+    // ARROW-8193: On gcc-4.8 without the explicit move it tries to use the
+    // copy constructor, which may be deleted on the elements of type T
+    return std::move(out);
   }
 
  private:


### PR DESCRIPTION
This fixes the failure for me in arrow/util/future_test.cc. 