### PR TITLE
ARROW-6915: [Developer] Do not overwrite point release fix versions with merge tool

### DIFF
--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -579,7 +579,7 @@ def cli():
     cmd.continue_maybe("Proceed with merging pull request #%s?" % pr_num)
 
     # merged hash not used
-    # pr.merge()
+    pr.merge()
 
     cmd.continue_maybe("Would you like to update the associated JIRA?")
     jira_comment = (

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -30,19 +30,18 @@ FakeFields = namedtuple('fields', ['status', 'summary', 'assignee',
 FakeAssignee = namedtuple('assignee', ['displayName'])
 FakeStatus = namedtuple('status', ['name'])
 FakeComponent = namedtuple('component', ['name'])
-FakeFixVersion = namedtuple('fixVersion', ['name'])
-FakeProjectVersion = namedtuple('version', ['name', 'raw'])
+FakeVersion = namedtuple('version', ['name', 'raw'])
 
 RAW_VERSION_JSON = [
-    {'version': 'JS-0.4.0', 'released': False},
-    {'version': '0.11.0', 'released': False},
-    {'version': '0.12.0', 'released': False},
-    {'version': '0.10.0', 'released': True},
-    {'version': '0.9.0', 'released': True}
+    {'name': 'JS-0.4.0', 'released': False},
+    {'name': '0.11.0', 'released': False},
+    {'name': '0.12.0', 'released': False},
+    {'name': '0.10.0', 'released': True},
+    {'name': '0.9.0', 'released': True}
 ]
 
 
-SOURCE_VERSIONS = [FakeProjectVersion(raw['version'], raw)
+SOURCE_VERSIONS = [FakeVersion(raw['name'], raw)
                    for raw in RAW_VERSION_JSON]
 
 TRANSITIONS = [{'name': 'Resolve Issue', 'id': 1}]
@@ -112,12 +111,11 @@ def test_jira_fix_versions():
 
 def test_jira_no_suggest_patch_release():
     versions_json = [
-        {'version': '0.11.1', 'released': False},
-        {'version': '0.12.0', 'released': False},
+        {'name': '0.11.1', 'released': False},
+        {'name': '0.12.0', 'released': False},
     ]
 
-    versions = [FakeProjectVersion(raw['version'], raw)
-                for raw in versions_json]
+    versions = [FakeVersion(raw['name'], raw) for raw in versions_json]
 
     jira = FakeJIRA(project_versions=versions, transitions=TRANSITIONS)
     issue = merge_arrow_pr.JiraIssue(jira, 'ARROW-1234', 'ARROW', FakeCLI())
@@ -129,14 +127,14 @@ def test_jira_no_suggest_patch_release():
 def test_jira_parquet_no_suggest_non_cpp():
     # ARROW-7351
     versions_json = [
-        {'version': 'cpp-1.5.0', 'released': True},
-        {'version': 'cpp-1.6.0', 'released': False},
-        {'version': 'cpp-1.7.0', 'released': False},
-        {'version': '1.11.0', 'released': False},
-        {'version': '1.12.0', 'released': False}
+        {'name': 'cpp-1.5.0', 'released': True},
+        {'name': 'cpp-1.6.0', 'released': False},
+        {'name': 'cpp-1.7.0', 'released': False},
+        {'name': '1.11.0', 'released': False},
+        {'name': '1.12.0', 'released': False}
     ]
 
-    versions = [FakeProjectVersion(raw['version'], raw)
+    versions = [FakeVersion(raw['name'], raw)
                 for raw in versions_json]
 
     jira = FakeJIRA(project_versions=versions, transitions=TRANSITIONS)
@@ -254,24 +252,41 @@ def test_no_unset_point_release_fix_version():
     # having their fix versions overwritten by the merge tool. This verifies
     # that existing patch release versions are carried over
     status = FakeStatus('In Progress')
+
+    versions_json = {
+        '0.14.2': {'name': '0.14.2', 'id': 1},
+        '0.15.1': {'name': '0.15.1', 'id': 2},
+        '0.16.0': {'name': '0.16.0', 'id': 3},
+        '0.17.0': {'name': '0.17.0', 'id': 4}
+    }
+
     fields = FakeFields(status, 'summary', FakeAssignee('someone'),
                         [FakeComponent('Java')],
-                        [FakeFixVersion('0.17.0'),
-                         FakeFixVersion('0.15.1'),
-                         FakeFixVersion('0.14.2')])
+                        [FakeVersion(v, versions_json[v])
+                         for v in ['0.17.0', '0.15.1', '0.14.2']])
     issue = FakeIssue(fields)
 
     jira = FakeJIRA(issue=issue, project_versions=SOURCE_VERSIONS,
                     transitions=TRANSITIONS)
 
     issue = merge_arrow_pr.JiraIssue(jira, 'ARROW-1234', 'ARROW', FakeCLI())
-    issue.resolve(['0.16.0'], "a comment")
+    issue.resolve([versions_json['0.16.0']], "a comment")
 
     assert jira.captured_transition == {
         'jira_id': 'ARROW-1234',
         'transition_id': 1,
         'comment': 'a comment',
-        'fixVersions': ['0.16.0', '0.15.1', '0.14.2']
+        'fixVersions': [versions_json[v]
+                        for v in ['0.16.0', '0.15.1', '0.14.2']]
+    }
+
+    issue.resolve([versions_json['0.15.1']], "a comment")
+
+    assert jira.captured_transition == {
+        'jira_id': 'ARROW-1234',
+        'transition_id': 1,
+        'comment': 'a comment',
+        'fixVersions': [versions_json[v] for v in ['0.15.1', '0.14.2']]
     }
 
 


### PR DESCRIPTION
Many times it has happened that a manually set Fix Version for a patch release got overwritten by the default behavior of the merge tool (which sets the Fix Version to the next major / non-patch release by default), and someone has had to go back and manually add the patch release version again. This ensure that the merge tool does not do this to save maintainers time and effort