### PR TITLE
ARROW-8184: [Packaging] Use arrow-nightlies organization name on Anaconda and Gemfury to host the nightlies

### DIFF
--- a/dev/tasks/conda-recipes/azure.linux.yml
+++ b/dev/tasks/conda-recipes/azure.linux.yml
@@ -58,6 +58,6 @@ jobs:
   {% if arrow.branch == 'master' %}
   # Upload to custom anaconda channel
   - script: |
-      anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload -l nightly --force build_artifacts/linux-64/*.tar.bz2
+      anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload --force build_artifacts/linux-64/*.tar.bz2
     displayName: Upload packages to Anaconda
   {% endif %}

--- a/dev/tasks/conda-recipes/azure.osx.yml
+++ b/dev/tasks/conda-recipes/azure.osx.yml
@@ -92,7 +92,7 @@ jobs:
   - script: |
       source activate base
       conda install -y anaconda-client
-      anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload -l nightly --force build_artifacts/osx-64/*.tar.bz2
+      anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload --force build_artifacts/osx-64/*.tar.bz2
     displayName: Upload packages to Anaconda
     workingDirectory: arrow/dev/tasks/conda-recipes
   {% endif %}

--- a/dev/tasks/conda-recipes/azure.win.yml
+++ b/dev/tasks/conda-recipes/azure.win.yml
@@ -107,7 +107,7 @@ jobs:
     - script: |
         source activate base
         conda install -y anaconda-client
-        anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload -l nightly --force D:\bld\win-64\*.tar.bz2
+        anaconda -t $(CROSSBOW_ANACONDA_TOKEN) upload --force D:\bld\win-64\*.tar.bz2
       displayName: Upload packages to Anaconda
       workingDirectory: arrow/dev/tasks/conda-recipes
     {% endif %}

--- a/dev/tasks/python-wheels/appveyor.yml
+++ b/dev/tasks/python-wheels/appveyor.yml
@@ -57,7 +57,7 @@ after_build:
   # upload to gemfury
   - conda install -y curl
   - for /f %%i in ('dir /b wheels\*.whl') do set WHEEL_PATH=wheels\%%i
-  - curl.exe -f -F "package=@%WHEEL_PATH%" "https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/ursa-labs/"
+  - curl.exe -f -F "package=@%WHEEL_PATH%" "https://%CROSSBOW_GEMFURY_TOKEN%@push.fury.io/%CROSSBOW_GEMFURY_ORG%/"
 {% endif %}
 
 #on_finish:

--- a/dev/tasks/python-wheels/azure.linux.yml
+++ b/dev/tasks/python-wheels/azure.linux.yml
@@ -95,8 +95,9 @@ jobs:
     # upload to gemfury
     - script: |
         path=$(ls arrow/python/{{ wheel_dir }}/dist/*.whl)
-        curl -f -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/ursa-labs/
+        curl -f -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/${CROSSBOW_GEMFURY_ORG}/
       env:
         CROSSBOW_GEMFURY_TOKEN: $(CROSSBOW_GEMFURY_TOKEN)
+        CROSSBOW_GEMFURY_ORG: $(CROSSBOW_GEMFURY_ORG)
       displayName: Upload packages to Gemfury
     {% endif %}

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -90,7 +90,7 @@ install:
   {% if arrow.branch == 'master' %}
   # upload to gemfury pypi repository, there should be a single wheel
   - path=$(ls arrow/python/dist/*.whl)
-  - curl -f -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/ursa-labs/
+  - curl -f -F "package=@${path}" https://${CROSSBOW_GEMFURY_TOKEN}@push.fury.io/${CROSSBOW_GEMFURY_ORG}/
   {% endif %}
 
 notifications:

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -39,7 +39,6 @@ before_install:
   - git -C arrow checkout FETCH_HEAD
 
   - brew update
-  - brew unlink python@2
   - travis_wait 30 brew bundle --file=arrow/cpp/Brewfile
   # Install tools to build bundled Thrift
   - brew install


### PR DESCRIPTION
- [x] update the credentials for anaconda 
- [x] update the credentials for gemfury

The packages are only uploaded from the master branch, so I've triggered the crossbow tasks on from my fork's master: [build-779](https://github.com/ursa-labs/crossbow/branches/all?query=build-779)

The produced packages are available at:
- Anaconda: https://anaconda.org/arrow-nightlies/pyarrow
- Gemfury: https://pypi.fury.io/arrow-nightlies/pyarrow

Installation instuctions:

Conda: 
```bash
conda install -c arrow-nightlies pyarrow 
```

Pip: 
```bash
pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ --pre pyarrow
```

Adding it to the developer documentation in a follow-up PR.