### PR TITLE
ARROW-7941: [Rust] [DataFusion] Add support for named columns in logical plan

### DIFF
--- a/rust/datafusion/src/optimizer/mod.rs
+++ b/rust/datafusion/src/optimizer/mod.rs
@@ -20,5 +20,6 @@
 
 pub mod optimizer;
 pub mod projection_push_down;
+pub mod resolve_columns;
 pub mod type_coercion;
 pub mod utils;

--- a/rust/datafusion/src/optimizer/optimizer.rs
+++ b/rust/datafusion/src/optimizer/optimizer.rs
@@ -19,11 +19,10 @@
 
 use crate::error::Result;
 use crate::logicalplan::LogicalPlan;
-use std::sync::Arc;
 
 /// An optimizer rules performs a transformation on a logical plan to produce an optimized
 /// logical plan.
 pub trait OptimizerRule {
     /// Perform optimizations on the plan
-    fn optimize(&mut self, plan: &LogicalPlan) -> Result<Arc<LogicalPlan>>;
+    fn optimize(&mut self, plan: &LogicalPlan) -> Result<LogicalPlan>;
 }

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -19,8 +19,8 @@
 //! loaded into memory
 
 use crate::error::{ExecutionError, Result};
-use crate::logicalplan::Expr;
 use crate::logicalplan::LogicalPlan;
+use crate::logicalplan::{Expr, LogicalPlanBuilder};
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
 use arrow::datatypes::{Field, Schema};
@@ -32,7 +32,7 @@ use std::sync::Arc;
 pub struct ProjectionPushDown {}
 
 impl OptimizerRule for ProjectionPushDown {
-    fn optimize(&mut self, plan: &LogicalPlan) -> Result<Arc<LogicalPlan>> {
+    fn optimize(&mut self, plan: &LogicalPlan) -> Result<LogicalPlan> {
         let mut accum: HashSet<usize> = HashSet::new();
         let mut mapping: HashMap<usize, usize> = HashMap::new();
         self.optimize_plan(plan, &mut accum, &mut mapping)
@@ -50,92 +50,52 @@ impl ProjectionPushDown {
         plan: &LogicalPlan,
         accum: &mut HashSet<usize>,
         mapping: &mut HashMap<usize, usize>,
-    ) -> Result<Arc<LogicalPlan>> {
+    ) -> Result<LogicalPlan> {
         match plan {
-            LogicalPlan::Projection {
-                expr,
-                input,
-                schema,
-            } => {
+            LogicalPlan::Projection { expr, input, .. } => {
                 // collect all columns referenced by projection expressions
                 utils::exprlist_to_column_indices(&expr, accum)?;
 
-                // push projection down
-                let input = self.optimize_plan(&input, accum, mapping)?;
-
-                // rewrite projection expressions to use new column indexes
-                let new_expr = self.rewrite_exprs(expr, mapping)?;
-
-                Ok(Arc::new(LogicalPlan::Projection {
-                    expr: new_expr,
-                    input,
-                    schema: schema.clone(),
-                }))
+                LogicalPlanBuilder::from(&self.optimize_plan(&input, accum, mapping)?)
+                    .project(self.rewrite_expr_list(expr, mapping)?)?
+                    .build()
             }
             LogicalPlan::Selection { expr, input } => {
                 // collect all columns referenced by filter expression
                 utils::expr_to_column_indices(expr, accum)?;
 
-                // push projection down
-                let input = self.optimize_plan(&input, accum, mapping)?;
-
-                // rewrite filter expression to use new column indexes
-                let new_expr = self.rewrite_expr(expr, mapping)?;
-
-                Ok(Arc::new(LogicalPlan::Selection {
-                    expr: new_expr,
-                    input,
-                }))
+                LogicalPlanBuilder::from(&self.optimize_plan(&input, accum, mapping)?)
+                    .filter(self.rewrite_expr(expr, mapping)?)?
+                    .build()
             }
             LogicalPlan::Aggregate {
                 input,
                 group_expr,
                 aggr_expr,
-                schema,
+                ..
             } => {
                 // collect all columns referenced by grouping and aggregate expressions
                 utils::exprlist_to_column_indices(&group_expr, accum)?;
                 utils::exprlist_to_column_indices(&aggr_expr, accum)?;
 
-                // push projection down
-                let input = self.optimize_plan(&input, accum, mapping)?;
-
-                // rewrite expressions to use new column indexes
-                let new_group_expr = self.rewrite_exprs(group_expr, mapping)?;
-                let new_aggr_expr = self.rewrite_exprs(aggr_expr, mapping)?;
-
-                Ok(Arc::new(LogicalPlan::Aggregate {
-                    input,
-                    group_expr: new_group_expr,
-                    aggr_expr: new_aggr_expr,
-                    schema: schema.clone(),
-                }))
+                LogicalPlanBuilder::from(&self.optimize_plan(&input, accum, mapping)?)
+                    .aggregate(
+                        self.rewrite_expr_list(group_expr, mapping)?,
+                        self.rewrite_expr_list(aggr_expr, mapping)?,
+                    )?
+                    .build()
             }
-            LogicalPlan::Sort {
-                expr,
-                input,
-                schema,
-            } => {
+            LogicalPlan::Sort { expr, input, .. } => {
                 // collect all columns referenced by sort expressions
                 utils::exprlist_to_column_indices(&expr, accum)?;
 
-                // push projection down
-                let input = self.optimize_plan(&input, accum, mapping)?;
-
-                // rewrite sort expressions to use new column indexes
-                let new_expr = self.rewrite_exprs(expr, mapping)?;
-
-                Ok(Arc::new(LogicalPlan::Sort {
-                    expr: new_expr,
-                    input,
-                    schema: schema.clone(),
-                }))
+                LogicalPlanBuilder::from(&self.optimize_plan(&input, accum, mapping)?)
+                    .sort(self.rewrite_expr_list(expr, mapping)?)?
+                    .build()
             }
-            LogicalPlan::EmptyRelation { schema } => {
-                Ok(Arc::new(LogicalPlan::EmptyRelation {
-                    schema: schema.clone(),
-                }))
-            }
+            LogicalPlan::EmptyRelation { schema } => Ok(LogicalPlan::EmptyRelation {
+                schema: schema.clone(),
+            }),
             LogicalPlan::TableScan {
                 schema_name,
                 table_name,
@@ -183,40 +143,40 @@ impl ProjectionPushDown {
                 }
 
                 // return the table scan with projection
-                Ok(Arc::new(LogicalPlan::TableScan {
+                Ok(LogicalPlan::TableScan {
                     schema_name: schema_name.to_string(),
                     table_name: table_name.to_string(),
                     table_schema: table_schema.clone(),
                     projected_schema: Arc::new(projected_schema),
                     projection: Some(projection),
-                }))
+                })
             }
             LogicalPlan::Limit {
                 expr,
                 input,
                 schema,
-            } => Ok(Arc::new(LogicalPlan::Limit {
+            } => Ok(LogicalPlan::Limit {
                 expr: expr.clone(),
                 input: input.clone(),
                 schema: schema.clone(),
-            })),
+            }),
             LogicalPlan::CreateExternalTable {
                 schema,
                 name,
                 location,
                 file_type,
                 header_row,
-            } => Ok(Arc::new(LogicalPlan::CreateExternalTable {
+            } => Ok(LogicalPlan::CreateExternalTable {
                 schema: schema.clone(),
                 name: name.to_string(),
                 location: location.to_string(),
                 file_type: file_type.clone(),
                 header_row: *header_row,
-            })),
+            }),
         }
     }
 
-    fn rewrite_exprs(
+    fn rewrite_expr_list(
         &self,
         expr: &Vec<Expr>,
         mapping: &HashMap<usize, usize>,
@@ -234,6 +194,9 @@ impl ProjectionPushDown {
                 name.clone(),
             )),
             Expr::Column(i) => Ok(Expr::Column(self.new_index(mapping, i)?)),
+            Expr::UnresolvedColumn(_) => Err(ExecutionError::ExecutionError(
+                "Columns need to be resolved before this rule can run".to_owned(),
+            )),
             Expr::Literal(_) => Ok(expr.clone()),
             Expr::Not(e) => Ok(Expr::Not(Arc::new(self.rewrite_expr(e, mapping)?))),
             Expr::IsNull(e) => Ok(Expr::IsNull(Arc::new(self.rewrite_expr(e, mapping)?))),
@@ -259,7 +222,7 @@ impl ProjectionPushDown {
                 return_type,
             } => Ok(Expr::AggregateFunction {
                 name: name.to_string(),
-                args: self.rewrite_exprs(args, mapping)?,
+                args: self.rewrite_expr_list(args, mapping)?,
                 return_type: return_type.clone(),
             }),
             Expr::ScalarFunction {
@@ -268,7 +231,7 @@ impl ProjectionPushDown {
                 return_type,
             } => Ok(Expr::ScalarFunction {
                 name: name.to_string(),
-                args: self.rewrite_exprs(args, mapping)?,
+                args: self.rewrite_expr_list(args, mapping)?,
                 return_type: return_type.clone(),
             }),
             Expr::Wildcard => Err(ExecutionError::General(
@@ -292,147 +255,107 @@ mod tests {
 
     use super::*;
     use crate::logicalplan::Expr::*;
-    use crate::logicalplan::LogicalPlan::*;
-    use arrow::datatypes::{DataType, Field, Schema};
-    use std::borrow::Borrow;
+    use crate::test::*;
+    use arrow::datatypes::DataType;
     use std::sync::Arc;
 
     #[test]
-    fn aggregate_no_group_by() {
-        let table_scan = test_table_scan();
+    fn aggregate_no_group_by() -> Result<()> {
+        let table_scan = test_table_scan()?;
 
-        let aggregate = Aggregate {
-            group_expr: vec![],
-            aggr_expr: vec![Column(1)],
-            schema: Arc::new(Schema::new(vec![Field::new(
-                "MAX(b)",
-                DataType::UInt32,
-                false,
-            )])),
-            input: Arc::new(table_scan),
-        };
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .aggregate(vec![], vec![max(Column(1))])?
+            .build()?;
 
-        assert_optimized_plan_eq(&aggregate, "Aggregate: groupBy=[[]], aggr=[[#0]]\n  TableScan: test projection=Some([1])");
+        let expected = "Aggregate: groupBy=[[]], aggr=[[MAX(#0)]]\
+        \n  TableScan: test projection=Some([1])";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
     }
 
     #[test]
-    fn aggregate_group_by() {
-        let table_scan = test_table_scan();
+    fn aggregate_group_by() -> Result<()> {
+        let table_scan = test_table_scan()?;
 
-        let aggregate = Aggregate {
-            group_expr: vec![Column(2)],
-            aggr_expr: vec![Column(1)],
-            schema: Arc::new(Schema::new(vec![
-                Field::new("c", DataType::UInt32, false),
-                Field::new("MAX(b)", DataType::UInt32, false),
-            ])),
-            input: Arc::new(table_scan),
-        };
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .aggregate(vec![Column(2)], vec![max(Column(1))])?
+            .build()?;
 
-        assert_optimized_plan_eq(&aggregate, "Aggregate: groupBy=[[#1]], aggr=[[#0]]\n  TableScan: test projection=Some([1, 2])");
+        let expected = "Aggregate: groupBy=[[#1]], aggr=[[MAX(#0)]]\
+        \n  TableScan: test projection=Some([1, 2])";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
     }
 
     #[test]
-    fn aggregate_no_group_by_with_selection() {
-        let table_scan = test_table_scan();
+    fn aggregate_no_group_by_with_selection() -> Result<()> {
+        let table_scan = test_table_scan()?;
 
-        let selection = Selection {
-            expr: Column(2),
-            input: Arc::new(table_scan),
-        };
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .filter(Column(2))?
+            .aggregate(vec![], vec![max(Column(1))])?
+            .build()?;
 
-        let aggregate = Aggregate {
-            group_expr: vec![],
-            aggr_expr: vec![Column(1)],
-            schema: Arc::new(Schema::new(vec![Field::new(
-                "MAX(b)",
-                DataType::UInt32,
-                false,
-            )])),
-            input: Arc::new(selection),
-        };
+        let expected = "Aggregate: groupBy=[[]], aggr=[[MAX(#0)]]\
+        \n  Selection: #1\
+        \n    TableScan: test projection=Some([1, 2])";
 
-        assert_optimized_plan_eq(&aggregate, "Aggregate: groupBy=[[]], aggr=[[#0]]\n  Selection: #1\n    TableScan: test projection=Some([1, 2])");
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
     }
 
     #[test]
-    fn cast() {
-        let table_scan = test_table_scan();
+    fn cast() -> Result<()> {
+        let table_scan = test_table_scan()?;
 
-        let projection = Projection {
-            expr: vec![Cast {
+        let projection = LogicalPlanBuilder::from(&table_scan)
+            .project(vec![Cast {
                 expr: Arc::new(Column(2)),
                 data_type: DataType::Float64,
-            }],
-            input: Arc::new(table_scan),
-            schema: Arc::new(Schema::new(vec![Field::new(
-                "CAST(c AS float)",
-                DataType::Float64,
-                false,
-            )])),
-        };
+            }])?
+            .build()?;
 
-        assert_optimized_plan_eq(
-            &projection,
-            "Projection: CAST(#0 AS Float64)\n  TableScan: test projection=Some([2])",
-        );
+        let expected = "Projection: CAST(#0 AS Float64)\
+        \n  TableScan: test projection=Some([2])";
+
+        assert_optimized_plan_eq(&projection, expected);
+
+        Ok(())
     }
 
     #[test]
-    fn table_scan_projected_schema() {
-        let table_scan = test_table_scan();
+    fn table_scan_projected_schema() -> Result<()> {
+        let table_scan = test_table_scan()?;
         assert_eq!(3, table_scan.schema().fields().len());
+        assert_fields_eq(&table_scan, vec!["a", "b", "c"]);
 
-        let projection = Projection {
-            expr: vec![Column(0), Column(1)],
-            input: Arc::new(table_scan),
-            schema: Arc::new(Schema::new(vec![
-                Field::new("a", DataType::UInt32, false),
-                Field::new("b", DataType::UInt32, false),
-            ])),
-        };
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .project(vec![Column(0), Column(1)])?
+            .build()?;
 
-        let optimized_plan = optimize(&projection);
+        assert_fields_eq(&plan, vec!["a", "b"]);
 
-        // check that table scan schema now contains 2 columns
-        match optimized_plan.as_ref().borrow() {
-            LogicalPlan::Projection { input, .. } => match input.as_ref().borrow() {
-                LogicalPlan::TableScan {
-                    ref projected_schema,
-                    ..
-                } => {
-                    assert_eq!(2, projected_schema.fields().len());
-                }
-                _ => assert!(false),
-            },
-            _ => assert!(false),
-        }
+        let expected = "Projection: #0, #1\
+        \n  TableScan: test projection=Some([0, 1])";
+
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
     }
 
     fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
-        let optimized_plan = optimize(plan);
+        let optimized_plan = optimize(plan).expect("failed to optimize plan");
         let formatted_plan = format!("{:?}", optimized_plan);
         assert_eq!(formatted_plan, expected);
     }
 
-    fn optimize(plan: &LogicalPlan) -> Arc<LogicalPlan> {
+    fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
         let mut rule = ProjectionPushDown::new();
-        rule.optimize(plan).unwrap()
-    }
-
-    /// all tests share a common table
-    fn test_table_scan() -> LogicalPlan {
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("a", DataType::UInt32, false),
-            Field::new("b", DataType::UInt32, false),
-            Field::new("c", DataType::UInt32, false),
-        ]));
-        TableScan {
-            schema_name: "default".to_string(),
-            table_name: "test".to_string(),
-            table_schema: schema.clone(),
-            projected_schema: schema,
-            projection: None,
-        }
+        rule.optimize(plan)
     }
 }

--- a/rust/datafusion/src/optimizer/resolve_columns.rs
+++ b/rust/datafusion/src/optimizer/resolve_columns.rs
@@ -1,0 +1,152 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Optimizer rule to replace UnresolvedColumns with Columns
+
+use crate::error::Result;
+use crate::logicalplan::LogicalPlan;
+use crate::logicalplan::{Expr, LogicalPlanBuilder};
+use crate::optimizer::optimizer::OptimizerRule;
+use arrow::datatypes::Schema;
+use std::sync::Arc;
+
+/// Replace UnresolvedColumns with Columns
+pub struct ResolveColumnsRule {}
+
+impl ResolveColumnsRule {
+    #[allow(missing_docs)]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl OptimizerRule for ResolveColumnsRule {
+    fn optimize(&mut self, plan: &LogicalPlan) -> Result<LogicalPlan> {
+        match plan {
+            LogicalPlan::Projection { input, expr, .. } => {
+                Ok(LogicalPlanBuilder::from(&self.optimize(input.as_ref())?)
+                    .project(rewrite_expr_list(expr, &input.schema())?)?
+                    .build()?)
+            }
+            LogicalPlan::Selection { expr, input } => Ok(LogicalPlanBuilder::from(input)
+                .filter(rewrite_expr(expr, &input.schema())?)?
+                .build()?),
+            LogicalPlan::Aggregate {
+                input,
+                group_expr,
+                aggr_expr,
+                ..
+            } => Ok(LogicalPlanBuilder::from(input)
+                .aggregate(
+                    rewrite_expr_list(group_expr, &input.schema())?,
+                    rewrite_expr_list(aggr_expr, &input.schema())?,
+                )?
+                .build()?),
+            LogicalPlan::Sort { input, expr, .. } => Ok(LogicalPlanBuilder::from(input)
+                .sort(rewrite_expr_list(expr, &input.schema())?)?
+                .build()?),
+            _ => Ok(plan.clone()),
+        }
+    }
+}
+fn rewrite_expr_list(expr: &Vec<Expr>, schema: &Schema) -> Result<Vec<Expr>> {
+    Ok(expr
+        .iter()
+        .map(|e| rewrite_expr(e, schema))
+        .collect::<Result<Vec<_>>>()?)
+}
+
+fn rewrite_expr(expr: &Expr, schema: &Schema) -> Result<Expr> {
+    match expr {
+        Expr::Alias(expr, alias) => Ok(rewrite_expr(&expr, schema)?.alias(&alias)),
+        Expr::UnresolvedColumn(name) => Ok(Expr::Column(schema.index_of(&name)?)),
+        Expr::BinaryExpr { left, op, right } => Ok(Expr::BinaryExpr {
+            left: Arc::new(rewrite_expr(&left, schema)?),
+            op: op.clone(),
+            right: Arc::new(rewrite_expr(&right, schema)?),
+        }),
+        Expr::Not(expr) => Ok(Expr::Not(Arc::new(rewrite_expr(&expr, schema)?))),
+        Expr::IsNotNull(expr) => {
+            Ok(Expr::IsNotNull(Arc::new(rewrite_expr(&expr, schema)?)))
+        }
+        Expr::IsNull(expr) => Ok(Expr::IsNull(Arc::new(rewrite_expr(&expr, schema)?))),
+        Expr::Cast { expr, data_type } => Ok(Expr::Cast {
+            expr: Arc::new(rewrite_expr(&expr, schema)?),
+            data_type: data_type.clone(),
+        }),
+        Expr::Sort { expr, asc } => Ok(Expr::Sort {
+            expr: Arc::new(rewrite_expr(&expr, schema)?),
+            asc: asc.clone(),
+        }),
+        Expr::ScalarFunction {
+            name,
+            args,
+            return_type,
+        } => Ok(Expr::ScalarFunction {
+            name: name.clone(),
+            args: rewrite_expr_list(args, schema)?,
+            return_type: return_type.clone(),
+        }),
+        Expr::AggregateFunction {
+            name,
+            args,
+            return_type,
+        } => Ok(Expr::AggregateFunction {
+            name: name.clone(),
+            args: rewrite_expr_list(args, schema)?,
+            return_type: return_type.clone(),
+        }),
+        _ => Ok(expr.clone()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::logicalplan::col;
+    use crate::test::*;
+
+    #[test]
+    fn aggregate_no_group_by() -> Result<()> {
+        let table_scan = test_table_scan()?;
+
+        let plan = LogicalPlanBuilder::from(&table_scan)
+            .aggregate(vec![col("a")], vec![max(col("b"))])?
+            .build()?;
+
+        // plan has unresolve columns
+        let expected = "Aggregate: groupBy=[[#a]], aggr=[[MAX(#b)]]\n  TableScan: test projection=None";
+        assert_eq!(format!("{:?}", plan), expected);
+
+        // optimized plan has resolved columns
+        let expected = "Aggregate: groupBy=[[#0]], aggr=[[MAX(#1)]]\n  TableScan: test projection=None";
+        assert_optimized_plan_eq(&plan, expected);
+
+        Ok(())
+    }
+
+    fn assert_optimized_plan_eq(plan: &LogicalPlan, expected: &str) {
+        let optimized_plan = optimize(plan).expect("failed to optimize plan");
+        let formatted_plan = format!("{:?}", optimized_plan);
+        assert_eq!(formatted_plan, expected);
+    }
+
+    fn optimize(plan: &LogicalPlan) -> Result<LogicalPlan> {
+        let mut rule = ResolveColumnsRule::new();
+        rule.optimize(plan)
+    }
+}

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -45,6 +45,9 @@ pub fn expr_to_column_indices(expr: &Expr, accum: &mut HashSet<usize>) -> Result
             accum.insert(*i);
             Ok(())
         }
+        Expr::UnresolvedColumn(_) => Err(ExecutionError::ExecutionError(
+            "Columns need to be resolved before this rule can run".to_owned(),
+        )),
         Expr::Literal(_) => {
             // not needed
             Ok(())
@@ -73,6 +76,7 @@ pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
         Expr::Alias(expr, name) => {
             Ok(Field::new(name, expr.get_type(input_schema)?, true))
         }
+        Expr::UnresolvedColumn(name) => Ok(input_schema.field_with_name(&name)?.clone()),
         Expr::Column(i) => {
             let input_schema_field_count = input_schema.fields().len();
             if *i < input_schema_field_count {

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -20,6 +20,7 @@
 use crate::error::Result;
 use crate::execution::context::ExecutionContext;
 use crate::execution::physical_plan::ExecutionPlan;
+use crate::logicalplan::{Expr, LogicalPlan, LogicalPlanBuilder};
 use arrow::array;
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
@@ -201,4 +202,32 @@ pub fn format_batch(batch: &RecordBatch) -> Vec<String> {
         rows.push(s);
     }
     rows
+}
+
+/// all tests share a common table
+pub fn test_table_scan() -> Result<LogicalPlan> {
+    let schema = Schema::new(vec![
+        Field::new("a", DataType::UInt32, false),
+        Field::new("b", DataType::UInt32, false),
+        Field::new("c", DataType::UInt32, false),
+    ]);
+    LogicalPlanBuilder::scan("default", "test", &schema, None)?.build()
+}
+
+pub fn assert_fields_eq(plan: &LogicalPlan, expected: Vec<&str>) {
+    let actual: Vec<String> = plan
+        .schema()
+        .fields()
+        .iter()
+        .map(|f| f.name().clone())
+        .collect();
+    assert_eq!(actual, expected);
+}
+
+pub fn max(expr: Expr) -> Expr {
+    Expr::AggregateFunction {
+        name: "MAX".to_owned(),
+        args: vec![expr],
+        return_type: DataType::Float64,
+    }
 }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -64,7 +64,7 @@ fn nyc() -> Result<()> {
 
     let optimized_plan = ctx.optimize(&logical_plan)?;
 
-    match optimized_plan.as_ref() {
+    match &optimized_plan {
         LogicalPlan::Aggregate { input, .. } => match input.as_ref() {
             LogicalPlan::TableScan {
                 ref projected_schema,


### PR DESCRIPTION
This PR adds support for unresolved columns in the logical plan so that users can add columns by name rather than index. There is a new optimizer rule that will resolve these columns and replace them with indices in the plan.

This PR also:

- Removes pointless `Arc`s from the optimizer rules
- Optimizer rules now leverage `LogicalPlanBuilder` for much more concise and readable code
