### PR TITLE
ARROW-8243: [Rust] [DataFusion] Fix inconsistency in LogicalPlanBuilder api

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -745,7 +745,7 @@ mod tests {
             vec![col(0)],
             vec![aggregate_expr("SUM", col(1), DataType::Int32)],
         )?
-        .project(&vec![col(0), col(1).alias("total_salary")])?
+        .project(vec![col(0), col(1).alias("total_salary")])?
         .build()?;
 
         let physical_plan = ctx.create_physical_plan(&Arc::new(plan), 1024)?;

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -702,7 +702,7 @@ impl LogicalPlanBuilder {
     }
 
     /// Apply a projection
-    pub fn project(&self, expr: &Vec<Expr>) -> Result<Self> {
+    pub fn project(&self, expr: Vec<Expr>) -> Result<Self> {
         let input_schema = self.plan.schema();
         let projected_expr = if expr.contains(&Expr::Wildcard) {
             let mut expr_vec = vec![];
@@ -792,7 +792,7 @@ mod tests {
             Some(vec![0, 3]),
         )?
         .filter(col(1).eq(&lit_str("CO")))?
-        .project(&vec![col(0)])?
+        .project(vec![col(0)])?
         .build()?;
 
         // prove that a plan can be passed to a thread
@@ -813,7 +813,7 @@ mod tests {
             Some(vec![0, 3]),
         )?
         .filter(col(1).eq(&lit_str("CO")))?
-        .project(&vec![col(0)])?
+        .project(vec![col(0)])?
         .build()?;
 
         let expected = "Projection: #0\n  \
@@ -837,7 +837,7 @@ mod tests {
             vec![col(0)],
             vec![aggregate_expr("SUM", col(1), DataType::Int32)],
         )?
-        .project(&vec![col(0), col(1).alias("total_salary")])?
+        .project(vec![col(0), col(1).alias("total_salary")])?
         .build()?;
 
         let expected = "Projection: #0, #1 AS total_salary\

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -92,7 +92,7 @@ impl<S: SchemaProvider> SqlToRel<S> {
                 let plan = if group_by.is_some() || aggr_expr.len() > 0 {
                     self.aggregate(&plan, projection_expr, group_by, aggr_expr)?
                 } else {
-                    self.project(&plan, &projection_expr)?
+                    self.project(&plan, projection_expr)?
                 };
 
                 // apply ORDER BY
@@ -140,7 +140,7 @@ impl<S: SchemaProvider> SqlToRel<S> {
     }
 
     /// Wrap a plan in a projection
-    fn project(&self, input: &LogicalPlan, expr: &Vec<Expr>) -> Result<LogicalPlan> {
+    fn project(&self, input: &LogicalPlan, expr: Vec<Expr>) -> Result<LogicalPlan> {
         LogicalPlanBuilder::from(input).project(expr)?.build()
     }
 
@@ -200,7 +200,7 @@ impl<S: SchemaProvider> SqlToRel<S> {
         if projection_needed {
             self.project(
                 &plan,
-                &projected_fields.iter().map(|i| Expr::Column(*i)).collect(),
+                projected_fields.iter().map(|i| Expr::Column(*i)).collect(),
             )
         } else {
             Ok(plan)


### PR DESCRIPTION
LogicalPlanBuilder project method takes a &Vec whereas other methods take a Vec. It makes sense to take Vec and take ownership of these inputs since they are being used to build the plan.