### PR TITLE
PARQUET-1820: [C++] pre-buffer specified columns of row group

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -295,10 +295,8 @@ static void ParquetRead(benchmark::State& st, S3FileSystem* fs, const std::strin
 
   parquet::ArrowReaderProperties properties;
   properties.set_use_threads(true);
+  properties.set_pre_buffer(pre_buffer);
   parquet::ReaderProperties parquet_properties = parquet::default_reader_properties();
-  if (pre_buffer) {
-    parquet_properties.enable_coalesced_stream();
-  }
 
   for (auto _ : st) {
     std::shared_ptr<io::RandomAccessFile> file;

--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -36,6 +36,7 @@
 #include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
+#include "arrow/util/range.h"
 
 #include "parquet/arrow/reader.h"
 #include "parquet/arrow/writer.h"
@@ -100,7 +101,7 @@ class MinioFixture : public benchmark::Fixture {
       ASSERT_OK(MakeObject("bytes_1mib", 1024 * 1024));
       ASSERT_OK(MakeObject("bytes_100mib", 100 * 1024 * 1024));
       ASSERT_OK(MakeObject("bytes_500mib", 500 * 1024 * 1024));
-      ASSERT_OK(MakeParquetObject(bucket_ + "/pq_c100_r250k", 100, 250000));
+      ASSERT_OK(MakeParquetObject(bucket_ + "/pq_c402_r250k", 400, 250000));
     }
   }
 
@@ -141,16 +142,31 @@ class MinioFixture : public benchmark::Fixture {
   }
 
   /// Make an object with Parquet data.
+  /// Appends integer columns to the beginning (to act as indices).
   Status MakeParquetObject(const std::string& path, int num_columns, int num_rows) {
-    std::vector<std::shared_ptr<ChunkedArray>> columns(num_columns);
-    std::vector<std::shared_ptr<Field>> fields(num_columns);
-    for (int i = 0; i < num_columns; ++i) {
+    std::vector<std::shared_ptr<ChunkedArray>> columns;
+    std::vector<std::shared_ptr<Field>> fields;
+
+    {
+      arrow::random::RandomArrayGenerator generator(0);
+      std::shared_ptr<Array> values = generator.Int64(num_rows, 0, 1e10, 0);
+      columns.push_back(std::make_shared<ChunkedArray>(values));
+      fields.push_back(::arrow::field("timestamp", values->type()));
+    }
+    {
+      arrow::random::RandomArrayGenerator generator(1);
+      std::shared_ptr<Array> values = generator.Int32(num_rows, 0, 1e9, 0);
+      columns.push_back(std::make_shared<ChunkedArray>(values));
+      fields.push_back(::arrow::field("val", values->type()));
+    }
+
+    for (int i = 0; i < num_columns; i++) {
       arrow::random::RandomArrayGenerator generator(i);
       std::shared_ptr<Array> values = generator.Float64(num_rows, -1.e10, 1e10, 0);
       std::stringstream ss;
       ss << "col" << i;
-      columns[i] = std::make_shared<ChunkedArray>(values);
-      fields[i] = ::arrow::field(ss.str(), values->type());
+      columns.push_back(std::make_shared<ChunkedArray>(values));
+      fields.push_back(::arrow::field(ss.str(), values->type()));
     }
     auto schema = std::make_shared<::arrow::Schema>(fields);
 
@@ -246,7 +262,7 @@ static void CoalescedRead(benchmark::State& st, S3FileSystem* fs,
     ASSERT_OK_AND_ASSIGN(size, file->GetSize());
     total_items += 1;
 
-    io::internal::ReadRangeCache cache(file, 8192, 64 * 1024 * 1024);
+    io::internal::ReadRangeCache cache(file, io::CacheOptions{8192, 64 * 1024 * 1024});
     std::vector<io::ReadRange> ranges;
 
     int64_t offset = 0;
@@ -271,25 +287,39 @@ static void CoalescedRead(benchmark::State& st, S3FileSystem* fs,
 }
 
 /// Read a Parquet file from S3.
-static void ParquetRead(benchmark::State& st, S3FileSystem* fs, const std::string& path) {
+static void ParquetRead(benchmark::State& st, S3FileSystem* fs, const std::string& path,
+                        std::vector<int> column_indices, bool pre_buffer,
+                        std::string read_strategy) {
   int64_t total_bytes = 0;
   int total_items = 0;
+
+  parquet::ArrowReaderProperties properties;
+  properties.set_use_threads(true);
+  parquet::ReaderProperties parquet_properties = parquet::default_reader_properties();
+  if (pre_buffer) {
+    parquet_properties.enable_coalesced_stream();
+  }
+
   for (auto _ : st) {
     std::shared_ptr<io::RandomAccessFile> file;
     int64_t size = 0;
     ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(path));
     ASSERT_OK_AND_ASSIGN(size, file->GetSize());
 
-    parquet::ArrowReaderProperties properties;
-    properties.set_use_threads(true);
     std::unique_ptr<parquet::arrow::FileReader> reader;
     parquet::arrow::FileReaderBuilder builder;
-    ASSERT_OK(builder.Open(file));
+    ASSERT_OK(builder.Open(file, parquet_properties));
     ASSERT_OK(builder.properties(properties)->Build(&reader));
-    std::shared_ptr<RecordBatchReader> rb_reader;
-    ASSERT_OK(reader->GetRecordBatchReader({0}, &rb_reader));
+
     std::shared_ptr<Table> table;
-    ASSERT_OK(rb_reader->ReadAll(&table));
+
+    if (read_strategy == "ReadTable") {
+      ASSERT_OK(reader->ReadTable(column_indices, &table));
+    } else {
+      std::shared_ptr<RecordBatchReader> rb_reader;
+      ASSERT_OK(reader->GetRecordBatchReader({0}, column_indices, &rb_reader));
+      ASSERT_OK(rb_reader->ReadAll(&table));
+    }
 
     // TODO: actually measure table memory usage
     total_bytes += size;
@@ -297,7 +327,6 @@ static void ParquetRead(benchmark::State& st, S3FileSystem* fs, const std::strin
   }
   st.SetBytesProcessed(total_bytes);
   st.SetItemsProcessed(total_items);
-  std::cerr << "Read the file " << total_items << " times" << std::endl;
 }
 
 BENCHMARK_DEFINE_F(MinioFixture, ReadAll1Mib)(benchmark::State& st) {
@@ -331,10 +360,64 @@ BENCHMARK_DEFINE_F(MinioFixture, ReadCoalesced500Mib)(benchmark::State& st) {
 }
 BENCHMARK_REGISTER_F(MinioFixture, ReadCoalesced500Mib)->UseRealTime();
 
-BENCHMARK_DEFINE_F(MinioFixture, ReadParquet250K)(benchmark::State& st) {
-  ParquetRead(st, fs_.get(), bucket_ + "/pq_c100_r250k");
-}
-BENCHMARK_REGISTER_F(MinioFixture, ReadParquet250K)->UseRealTime();
+// Helpers to generate various multiple benchmarks for a given Parquet file.
+
+// NAME: the base name of the benchmark.
+// ROWS: the number of rows in the Parquet file.
+// COLS: the number of columns in the Parquet file.
+// STRATEGY: how to read the file (ReadTable or GetRecordBatchReader)
+#define PQ_BENCHMARK_IMPL(NAME, ROWS, COLS, STRATEGY)                                 \
+  BENCHMARK_DEFINE_F(MinioFixture, NAME##STRATEGY##AllNaive)(benchmark::State & st) { \
+    std::vector<int> column_indices(COLS);                                            \
+    std::iota(column_indices.begin(), column_indices.end(), 0);                       \
+    std::stringstream ss;                                                             \
+    ss << bucket_ << "/pq_c" << COLS << "_r" << ROWS << "k";                          \
+    ParquetRead(st, fs_.get(), ss.str(), column_indices, false, #STRATEGY);           \
+  }                                                                                   \
+  BENCHMARK_REGISTER_F(MinioFixture, NAME##STRATEGY##AllNaive)->UseRealTime();        \
+  BENCHMARK_DEFINE_F(MinioFixture, NAME##STRATEGY##AllCoalesced)                      \
+  (benchmark::State & st) {                                                           \
+    std::vector<int> column_indices(COLS);                                            \
+    std::iota(column_indices.begin(), column_indices.end(), 0);                       \
+    std::stringstream ss;                                                             \
+    ss << bucket_ << "/pq_c" << COLS << "_r" << ROWS << "k";                          \
+    ParquetRead(st, fs_.get(), ss.str(), column_indices, true, #STRATEGY);            \
+  }                                                                                   \
+  BENCHMARK_REGISTER_F(MinioFixture, NAME##STRATEGY##AllCoalesced)->UseRealTime();
+
+// COL_INDICES: a vector specifying a subset of column indices to read.
+#define PQ_BENCHMARK_PICK_IMPL(NAME, ROWS, COLS, COL_INDICES, STRATEGY)                \
+  BENCHMARK_DEFINE_F(MinioFixture, NAME##STRATEGY##PickNaive)(benchmark::State & st) { \
+    std::stringstream ss;                                                              \
+    ss << bucket_ << "/pq_c" << COLS << "_r" << ROWS << "k";                           \
+    ParquetRead(st, fs_.get(), ss.str(), COL_INDICES, false, #STRATEGY);               \
+  }                                                                                    \
+  BENCHMARK_REGISTER_F(MinioFixture, NAME##STRATEGY##PickNaive)->UseRealTime();        \
+  BENCHMARK_DEFINE_F(MinioFixture, NAME##STRATEGY##PickCoalesced)                      \
+  (benchmark::State & st) {                                                            \
+    std::stringstream ss;                                                              \
+    ss << bucket_ << "/pq_c" << COLS << "_r" << ROWS << "k";                           \
+    ParquetRead(st, fs_.get(), ss.str(), COL_INDICES, true, #STRATEGY);                \
+  }                                                                                    \
+  BENCHMARK_REGISTER_F(MinioFixture, NAME##STRATEGY##PickCoalesced)->UseRealTime();
+
+#define PQ_BENCHMARK(ROWS, COLS)                                   \
+  PQ_BENCHMARK_IMPL(ReadParquet_c##COLS##_r##ROWS##K_, ROWS, COLS, \
+                    GetRecordBatchReader);                         \
+  PQ_BENCHMARK_IMPL(ReadParquet_c##COLS##_r##ROWS##K_, ROWS, COLS, ReadTable);
+
+#define PQ_BENCHMARK_PICK(NAME, ROWS, COLS, COL_INDICES)                         \
+  PQ_BENCHMARK_PICK_IMPL(ReadParquet_c##COLS##_r##ROWS##K_##NAME##_, ROWS, COLS, \
+                         COL_INDICES, GetRecordBatchReader);                     \
+  PQ_BENCHMARK_PICK_IMPL(ReadParquet_c##COLS##_r##ROWS##K_##NAME##_, ROWS, COLS, \
+                         COL_INDICES, ReadTable);
+
+// Test a Parquet file with 250k rows, 402 columns.
+PQ_BENCHMARK(250, 402);
+// Scenario A: test selecting a small set of contiguous columns, and a "far" column.
+PQ_BENCHMARK_PICK(A, 250, 402, (std::vector<int>{0, 1, 2, 3, 4, 90}));
+// Scenario B: test selecting a large set of contiguous columns.
+PQ_BENCHMARK_PICK(B, 250, 402, (::arrow::internal::Iota(41)));
 
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -27,6 +27,19 @@
 
 namespace arrow {
 namespace io {
+
+struct ARROW_EXPORT CacheOptions {
+  /// /brief The maximum distance in bytes between two consecutive
+  ///   ranges; beyond this value, ranges are not combined
+  int64_t hole_size_limit;
+  /// /brief The maximum size in bytes of a combined range; if
+  ///   combining two consecutive ranges would produce a range of a
+  ///   size greater than this, they are not combined
+  int64_t range_size_limit;
+
+  static CacheOptions Defaults();
+};
+
 namespace internal {
 
 /// \brief A read cache designed to hide IO latencies when reading.
@@ -40,16 +53,12 @@ class ARROW_EXPORT ReadRangeCache {
   static constexpr int64_t kDefaultHoleSizeLimit = 8192;
   static constexpr int64_t kDefaultRangeSizeLimit = 32 * 1024 * 1024;
 
-  /// Construct a read cache
-  ///
-  /// \param[in] hole_size_limit The maximum distance in bytes between two
-  ///   consecutive ranges; beyond this value, ranges are not combined
-  /// \param[in] range_size_limit The maximum size in bytes of a combined range;
-  ///   if combining two consecutive ranges would produce a range of a size
-  ///   greater than this, they are not combined
-  explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file,
-                          int64_t hole_size_limit = kDefaultHoleSizeLimit,
-                          int64_t range_size_limit = kDefaultRangeSizeLimit);
+  /// Construct a read cache with default
+  explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file)
+      : ReadRangeCache(file, CacheOptions::Defaults()) {}
+
+  /// Construct a read cache with given options
+  explicit ReadRangeCache(std::shared_ptr<RandomAccessFile> file, CacheOptions options);
   ~ReadRangeCache();
 
   /// \brief Cache the given ranges in the background.

--- a/cpp/src/arrow/io/memory_test.cc
+++ b/cpp/src/arrow/io/memory_test.cc
@@ -454,9 +454,10 @@ TEST(RangeReadCache, Basics) {
   std::string data = "abcdefghijklmnopqrstuvwxyz";
 
   auto file = std::make_shared<BufferReader>(Buffer(data));
-  const int64_t hole_size_limit = 2;
-  const int64_t range_size_limit = 10;
-  internal::ReadRangeCache cache(file, hole_size_limit, range_size_limit);
+  CacheOptions options = CacheOptions::Defaults();
+  options.hole_size_limit = 2;
+  options.range_size_limit = 10;
+  internal::ReadRangeCache cache(file, options);
 
   ASSERT_OK(cache.Cache({{1, 2}, {3, 2}, {8, 2}, {20, 2}, {25, 0}}));
   ASSERT_OK(cache.Cache({{10, 4}, {14, 0}, {15, 4}}));

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1960,7 +1960,8 @@ TEST(TestArrowReadWrite, ReadTableManually) {
   AssertTablesEqual(*actual, *expected, /*same_chunk_layout=*/false);
 }
 
-TEST(TestArrowReadWrite, GetRecordBatchReader) {
+void TestGetRecordBatchReader(
+    ReaderProperties parquet_properties = default_reader_properties()) {
   const int num_columns = 20;
   const int num_rows = 1000;
   const int batch_size = 100;
@@ -2012,6 +2013,15 @@ TEST(TestArrowReadWrite, GetRecordBatchReader) {
   ASSERT_EQ(nullptr, actual_batch);
 }
 
+TEST(TestArrowReadWrite, GetRecordBatchReader) { TestGetRecordBatchReader(); }
+
+// Same as the test above, but using coalesced reads.
+TEST(TestArrowReadWrite, CoalescedReads) {
+  ReaderProperties parquet_properties = default_reader_properties();
+  parquet_properties.enable_coalesced_stream();
+  TestGetRecordBatchReader(parquet_properties);
+}
+
 TEST(TestArrowReadWrite, ScanContents) {
   const int num_columns = 20;
   const int num_rows = 1000;
@@ -2058,6 +2068,45 @@ TEST(TestArrowReadWrite, ReadColumnSubset) {
   auto ex_schema = ::arrow::schema(ex_fields);
   auto expected = Table::Make(ex_schema, ex_columns);
   ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*expected, *result));
+}
+
+TEST(TestArrowReadWrite, ReadCoalescedColumnSubset) {
+  const int num_columns = 20;
+  const int num_rows = 1000;
+
+  std::shared_ptr<Table> table;
+  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, num_rows / 2,
+                                             default_arrow_writer_properties(), &buffer));
+
+  std::unique_ptr<FileReader> reader;
+  FileReaderBuilder builder;
+  ReaderProperties properties = default_reader_properties();
+  properties.enable_coalesced_stream();
+  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer), properties));
+  ASSERT_OK(builder.Build(&reader));
+  reader->set_use_threads(true);
+
+  // Test multiple subsets to ensure we can read from the file multiple times
+  std::vector<std::vector<int>> column_subsets = {
+      {0, 4, 8, 10}, {0, 1, 2, 3}, {5, 17, 18, 19}};
+
+  for (std::vector<int>& column_subset : column_subsets) {
+    std::shared_ptr<Table> result;
+    ASSERT_OK(reader->ReadTable(column_subset, &result));
+
+    std::vector<std::shared_ptr<::arrow::ChunkedArray>> ex_columns;
+    std::vector<std::shared_ptr<::arrow::Field>> ex_fields;
+    for (int i : column_subset) {
+      ex_columns.push_back(table->column(i));
+      ex_fields.push_back(table->field(i));
+    }
+
+    auto ex_schema = ::arrow::schema(ex_fields);
+    auto expected = Table::Make(ex_schema, ex_columns);
+    ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*expected, *result));
+  }
 }
 
 TEST(TestArrowReadWrite, ListLargeRecords) {

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -1961,7 +1961,7 @@ TEST(TestArrowReadWrite, ReadTableManually) {
 }
 
 void TestGetRecordBatchReader(
-    ReaderProperties parquet_properties = default_reader_properties()) {
+    ArrowReaderProperties properties = default_arrow_reader_properties()) {
   const int num_columns = 20;
   const int num_rows = 1000;
   const int batch_size = 100;
@@ -1973,7 +1973,6 @@ void TestGetRecordBatchReader(
   ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, num_rows / 2,
                                              default_arrow_writer_properties(), &buffer));
 
-  ArrowReaderProperties properties = default_arrow_reader_properties();
   properties.set_batch_size(batch_size);
 
   std::unique_ptr<FileReader> reader;
@@ -2017,9 +2016,9 @@ TEST(TestArrowReadWrite, GetRecordBatchReader) { TestGetRecordBatchReader(); }
 
 // Same as the test above, but using coalesced reads.
 TEST(TestArrowReadWrite, CoalescedReads) {
-  ReaderProperties parquet_properties = default_reader_properties();
-  parquet_properties.enable_coalesced_stream();
-  TestGetRecordBatchReader(parquet_properties);
+  ArrowReaderProperties arrow_properties = default_arrow_reader_properties();
+  arrow_properties.set_pre_buffer(true);
+  TestGetRecordBatchReader(arrow_properties);
 }
 
 TEST(TestArrowReadWrite, ScanContents) {
@@ -2083,9 +2082,10 @@ TEST(TestArrowReadWrite, ReadCoalescedColumnSubset) {
   std::unique_ptr<FileReader> reader;
   FileReaderBuilder builder;
   ReaderProperties properties = default_reader_properties();
-  properties.enable_coalesced_stream();
+  ArrowReaderProperties arrow_properties = default_arrow_reader_properties();
+  arrow_properties.set_pre_buffer(true);
   ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer), properties));
-  ASSERT_OK(builder.Build(&reader));
+  ASSERT_OK(builder.properties(arrow_properties)->Build(&reader));
   reader->set_use_threads(true);
 
   // Test multiple subsets to ensure we can read from the file multiple times

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -27,6 +27,7 @@
 
 #include "arrow/io/caching.h"
 #include "arrow/io/file.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/ubsan.h"
 #include "parquet/column_reader.h"
@@ -118,7 +119,7 @@ class SerializedRowGroup : public RowGroupReader::Contents {
                      int row_group_number, const ReaderProperties& props,
                      std::shared_ptr<InternalFileDecryptor> file_decryptor = nullptr)
       : source_(std::move(source)),
-        cached_source_(cached_source ? std::move(cached_source) : nullptr),
+        cached_source_(std::move(cached_source)),
         source_size_(source_size),
         file_metadata_(file_metadata),
         properties_(props),
@@ -581,7 +582,8 @@ void ParquetFileReader::PreBuffer(const std::vector<int>& row_groups,
                                   const std::vector<int>& column_indices,
                                   const ::arrow::io::CacheOptions& options) {
   // Access private methods here
-  SerializedFile* file = static_cast<SerializedFile*>(contents_.get());
+  SerializedFile* file =
+      ::arrow::internal::checked_cast<SerializedFile*>(contents_.get());
   file->PreBuffer(row_groups, column_indices, options);
 }
 

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -25,6 +25,7 @@
 #include <string>
 #include <utility>
 
+#include "arrow/io/caching.h"
 #include "arrow/io/file.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/ubsan.h"
@@ -78,14 +79,46 @@ std::unique_ptr<PageReader> RowGroupReader::GetColumnPageReader(int i) {
 // Returns the rowgroup metadata
 const RowGroupMetaData* RowGroupReader::metadata() const { return contents_->metadata(); }
 
+/// Compute the section of the file that should be read for the given
+/// row group and column chunk.
+arrow::io::ReadRange ComputeColumnChunkRange(FileMetaData* file_metadata,
+                                             int64_t source_size, int row_group_index,
+                                             int column_index) {
+  auto row_group_metadata = file_metadata->RowGroup(row_group_index);
+  auto column_metadata = row_group_metadata->ColumnChunk(column_index);
+
+  int64_t col_start = column_metadata->data_page_offset();
+  if (column_metadata->has_dictionary_page() &&
+      column_metadata->dictionary_page_offset() > 0 &&
+      col_start > column_metadata->dictionary_page_offset()) {
+    col_start = column_metadata->dictionary_page_offset();
+  }
+
+  int64_t col_length = column_metadata->total_compressed_size();
+  // PARQUET-816 workaround for old files created by older parquet-mr
+  const ApplicationVersion& version = file_metadata->writer_version();
+  if (version.VersionLt(ApplicationVersion::PARQUET_816_FIXED_VERSION())) {
+    // The Parquet MR writer had a bug in 1.2.8 and below where it didn't include the
+    // dictionary page header size in total_compressed_size and total_uncompressed_size
+    // (see IMPALA-694). We add padding to compensate.
+    int64_t bytes_remaining = source_size - (col_start + col_length);
+    int64_t padding = std::min<int64_t>(kMaxDictHeaderSize, bytes_remaining);
+    col_length += padding;
+  }
+
+  return {col_start, col_length};
+}
+
 // RowGroupReader::Contents implementation for the Parquet file specification
 class SerializedRowGroup : public RowGroupReader::Contents {
  public:
-  SerializedRowGroup(std::shared_ptr<ArrowInputFile> source, int64_t source_size,
-                     FileMetaData* file_metadata, int row_group_number,
-                     const ReaderProperties& props,
+  SerializedRowGroup(std::shared_ptr<ArrowInputFile> source,
+                     std::shared_ptr<::arrow::io::internal::ReadRangeCache> cached_source,
+                     int64_t source_size, FileMetaData* file_metadata,
+                     int row_group_number, const ReaderProperties& props,
                      std::shared_ptr<InternalFileDecryptor> file_decryptor = nullptr)
       : source_(std::move(source)),
+        cached_source_(cached_source ? std::move(cached_source) : nullptr),
         source_size_(source_size),
         file_metadata_(file_metadata),
         properties_(props),
@@ -102,27 +135,17 @@ class SerializedRowGroup : public RowGroupReader::Contents {
     // Read column chunk from the file
     auto col = row_group_metadata_->ColumnChunk(i);
 
-    int64_t col_start = col->data_page_offset();
-    if (col->has_dictionary_page() && col->dictionary_page_offset() > 0 &&
-        col_start > col->dictionary_page_offset()) {
-      col_start = col->dictionary_page_offset();
+    arrow::io::ReadRange col_range =
+        ComputeColumnChunkRange(file_metadata_, source_size_, row_group_ordinal_, i);
+    std::shared_ptr<ArrowInputStream> stream;
+    if (cached_source_) {
+      // PARQUET-1698: if read coalescing is enabled, read from pre-buffered
+      // segments.
+      PARQUET_ASSIGN_OR_THROW(auto buffer, cached_source_->Read(col_range));
+      stream = std::make_shared<::arrow::io::BufferReader>(buffer);
+    } else {
+      stream = properties_.GetStream(source_, col_range.offset, col_range.length);
     }
-
-    int64_t col_length = col->total_compressed_size();
-
-    // PARQUET-816 workaround for old files created by older parquet-mr
-    const ApplicationVersion& version = file_metadata_->writer_version();
-    if (version.VersionLt(ApplicationVersion::PARQUET_816_FIXED_VERSION())) {
-      // The Parquet MR writer had a bug in 1.2.8 and below where it didn't include the
-      // dictionary page header size in total_compressed_size and total_uncompressed_size
-      // (see IMPALA-694). We add padding to compensate.
-      int64_t bytes_remaining = source_size_ - (col_start + col_length);
-      int64_t padding = std::min<int64_t>(kMaxDictHeaderSize, bytes_remaining);
-      col_length += padding;
-    }
-
-    std::shared_ptr<ArrowInputStream> stream =
-        properties_.GetStream(source_, col_start, col_length);
 
     std::unique_ptr<ColumnCryptoMetaData> crypto_metadata = col->crypto_metadata();
 
@@ -166,6 +189,8 @@ class SerializedRowGroup : public RowGroupReader::Contents {
 
  private:
   std::shared_ptr<ArrowInputFile> source_;
+  // Will be nullptr if read coalescing is not enabled.
+  std::shared_ptr<::arrow::io::internal::ReadRangeCache> cached_source_;
   int64_t source_size_;
   FileMetaData* file_metadata_;
   std::unique_ptr<RowGroupMetaData> row_group_metadata_;
@@ -200,9 +225,9 @@ class SerializedFile : public ParquetFileReader::Contents {
   }
 
   std::shared_ptr<RowGroupReader> GetRowGroup(int i) override {
-    std::unique_ptr<SerializedRowGroup> contents(
-        new SerializedRowGroup(source_, source_size_, file_metadata_.get(),
-                               static_cast<int16_t>(i), properties_, file_decryptor_));
+    std::unique_ptr<SerializedRowGroup> contents(new SerializedRowGroup(
+        source_, cached_source_, source_size_, file_metadata_.get(),
+        static_cast<int16_t>(i), properties_, file_decryptor_));
     return std::make_shared<RowGroupReader>(std::move(contents));
   }
 
@@ -210,6 +235,23 @@ class SerializedFile : public ParquetFileReader::Contents {
 
   void set_metadata(std::shared_ptr<FileMetaData> metadata) {
     file_metadata_ = std::move(metadata);
+  }
+
+  void PreBuffer(const std::vector<int>& row_groups,
+                 const std::vector<int>& column_indices) {
+    if (!properties_.is_coalesced_stream_enabled()) {
+      return;
+    }
+    cached_source_ = std::make_shared<arrow::io::internal::ReadRangeCache>(
+        source_, properties_.coalescing_options());
+    std::vector<arrow::io::ReadRange> ranges;
+    for (int row : row_groups) {
+      for (int col : column_indices) {
+        ranges.push_back(
+            ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col));
+      }
+    }
+    PARQUET_THROW_NOT_OK(cached_source_->Cache(ranges));
   }
 
   void ParseMetaData() {
@@ -263,6 +305,7 @@ class SerializedFile : public ParquetFileReader::Contents {
 
  private:
   std::shared_ptr<ArrowInputFile> source_;
+  std::shared_ptr<arrow::io::internal::ReadRangeCache> cached_source_;
   int64_t source_size_;
   std::shared_ptr<FileMetaData> file_metadata_;
   ReaderProperties properties_;
@@ -534,6 +577,13 @@ std::shared_ptr<RowGroupReader> ParquetFileReader::RowGroup(int i) {
       << "row groups, requested reader for: " << i;
 
   return contents_->GetRowGroup(i);
+}
+
+void ParquetFileReader::PreBuffer(const std::vector<int>& row_groups,
+                                  const std::vector<int>& column_indices) {
+  // Access private methods here
+  SerializedFile* file = static_cast<SerializedFile*>(contents_.get());
+  file->PreBuffer(row_groups, column_indices);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -117,6 +117,15 @@ class PARQUET_EXPORT ParquetFileReader {
   // Returns the file metadata. Only one instance is ever created
   std::shared_ptr<FileMetaData> metadata() const;
 
+  /// Pre-buffer the specified column indices in all row groups.
+  ///
+  /// Only has an effect if ReaderProperties.is_coalesced_stream_enabled is set;
+  /// otherwise this is a no-op. The reader internally maintains a cache which is
+  /// overwritten each time this is called. Intended to increase performance on
+  /// high-latency filesystems (e.g. Amazon S3).
+  void PreBuffer(const std::vector<int>& row_groups,
+                 const std::vector<int>& column_indices);
+
  private:
   // Holds a pointer to an instance of Contents implementation
   std::unique_ptr<Contents> contents_;

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -131,6 +131,11 @@ class PARQUET_EXPORT ParquetFileReader {
   /// readers for the a subset of the buffered regions is
   /// acceptable. This may be called again to buffer a different set
   /// of row groups/columns.
+  ///
+  /// If memory usage is a concern, note that data will remain
+  /// buffered in memory until either \a PreBuffer() is called again,
+  /// or the reader itself is destructed. Reading - and buffering -
+  /// only one row group at a time may be useful.
   void PreBuffer(const std::vector<int>& row_groups,
                  const std::vector<int>& column_indices,
                  const ::arrow::io::CacheOptions& options);

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -23,6 +23,7 @@
 #include <unordered_set>
 #include <utility>
 
+#include "arrow/io/caching.h"
 #include "arrow/type.h"
 #include "arrow/util/compression.h"
 #include "parquet/encryption.h"
@@ -40,13 +41,16 @@ struct ParquetVersion {
 
 static int64_t DEFAULT_BUFFER_SIZE = 1024;
 static bool DEFAULT_USE_BUFFERED_STREAM = false;
+static bool DEFAULT_USE_COALESCED_STREAM = false;
 
 class PARQUET_EXPORT ReaderProperties {
  public:
   explicit ReaderProperties(MemoryPool* pool = ::arrow::default_memory_pool())
       : pool_(pool) {
     buffered_stream_enabled_ = DEFAULT_USE_BUFFERED_STREAM;
+    coalesced_stream_enabled_ = DEFAULT_USE_COALESCED_STREAM;
     buffer_size_ = DEFAULT_BUFFER_SIZE;
+    coalescing_options_ = ::arrow::io::CacheOptions::Defaults();
   }
 
   MemoryPool* memory_pool() const { return pool_; }
@@ -56,9 +60,31 @@ class PARQUET_EXPORT ReaderProperties {
 
   bool is_buffered_stream_enabled() const { return buffered_stream_enabled_; }
 
+  bool is_coalesced_stream_enabled() const { return coalesced_stream_enabled_; }
+
   void enable_buffered_stream() { buffered_stream_enabled_ = true; }
 
   void disable_buffered_stream() { buffered_stream_enabled_ = false; }
+
+  /// Enable read coalescing.
+  ///
+  /// When enabled, readers can optionally call
+  /// ParquetFileReader.PreBuffer to cache the necessary slices of the
+  /// file in-memory before deserialization. Arrow readers
+  /// automatically do this. This is intended to increase performance
+  /// when reading from high-latency filesystems (e.g. Amazon S3).
+  ///
+  /// When this is enabled, it is NOT SAFE to concurrently create
+  /// RecordBatchReaders from the same file.
+  void enable_coalesced_stream() { coalesced_stream_enabled_ = true; }
+
+  void disable_coalesced_stream() { coalesced_stream_enabled_ = false; }
+
+  void coalescing_options(::arrow::io::CacheOptions options) {
+    coalescing_options_ = options;
+  }
+
+  ::arrow::io::CacheOptions coalescing_options() const { return coalescing_options_; }
 
   void set_buffer_size(int64_t buf_size) { buffer_size_ = buf_size; }
 
@@ -76,7 +102,9 @@ class PARQUET_EXPORT ReaderProperties {
   MemoryPool* pool_;
   int64_t buffer_size_;
   bool buffered_stream_enabled_;
+  bool coalesced_stream_enabled_;
   std::shared_ptr<FileDecryptionProperties> file_decryption_properties_;
+  ::arrow::io::CacheOptions coalescing_options_;
 };
 
 ReaderProperties PARQUET_EXPORT default_reader_properties();


### PR DESCRIPTION
This hooks up Antoine's read coalescing implementation to the Parquet reader; it takes into account row groups and column indices, so it should be good for both scans of the entire file and selecting a few columns out of many. It also exposes some options on the Parquet ReaderProperties to control this. (Is exposing Arrow types like that ok, or should I wrap things?)

I'll have benchmarks later. It seems a clear win locally and against remote S3, but from EC2->S3 when I initially tried it was worse. I believe it's because the "naive" read happened to be near optimal on the particular dataset tested.

Marking this WIP as I'd like to get feedback on the approach.

I believe this subsumes PARQUET-1698/#6138. This is not exposed yet to Python or Datasets.