### PR TITLE
ARROW-8267: [CI][GLib] Fix build error on Ubuntu 16.04

### DIFF
--- a/ci/docker/linux-apt-c-glib.dockerfile
+++ b/ci/docker/linux-apt-c-glib.dockerfile
@@ -28,6 +28,10 @@ RUN apt-get update -y -q && \
         luarocks \
         pkg-config \
         ruby-dev && \
+    if [ "$(lsb_release --codename --short)" = "xenial" ]; then \
+      apt-get install -y -q --no-install-recommends -t xenial-backports \
+        ninja-build; \
+    fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Because Meson 0.54.0 requires Ninja 1.7 but Ubuntu 16.04 provides
Ninja 1.5.1 by default.