### PR TITLE
ARROW-8218: [C++] Decompress record batch messages in parallel at field level. Only allow LZ4_FRAME, ZSTD compression

### DIFF
--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -39,7 +39,11 @@ Result<std::shared_ptr<ipc::RecordBatchFileReader>> OpenReader(
   }
 
   std::shared_ptr<ipc::RecordBatchFileReader> reader;
-  auto status = ipc::RecordBatchFileReader::Open(std::move(input)).Value(&reader);
+  auto options = ipc::IpcReadOptions::Defaults();
+  options.use_threads = false;
+
+  auto status =
+      ipc::RecordBatchFileReader::Open(std::move(input), options).Value(&reader);
   if (!status.ok()) {
     return status.WithMessage("Could not open IPC input source '", source.path(),
                               "': ", status.message());

--- a/cpp/src/arrow/ipc/options.cc
+++ b/cpp/src/arrow/ipc/options.cc
@@ -24,5 +24,16 @@ IpcWriteOptions IpcWriteOptions::Defaults() { return IpcWriteOptions(); }
 
 IpcReadOptions IpcReadOptions::Defaults() { return IpcReadOptions(); }
 
+namespace internal {
+
+Status CheckCompressionSupported(Compression::type codec) {
+  if (!(codec == Compression::LZ4_FRAME || codec == Compression::ZSTD)) {
+    return Status::Invalid("Only LZ4_FRAME and ZSTD compression allowed");
+  }
+  return Status::OK();
+}
+
+}  // namespace internal
+
 }  // namespace ipc
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -57,7 +57,8 @@ struct ARROW_EXPORT IpcWriteOptions {
 
   /// \brief EXPERIMENTAL: Codec to use for compressing and decompressing
   /// record batch body buffers. This is not part of the Arrow IPC protocol and
-  /// only for internal use (e.g. Feather files)
+  /// only for internal use (e.g. Feather files). May only be LZ4_FRAME and
+  /// ZSTD
   Compression::type compression = Compression::UNCOMPRESSED;
   int compression_level = Compression::kUseDefaultCompressionLevel;
 
@@ -78,6 +79,10 @@ struct ARROW_EXPORT IpcReadOptions {
   /// \brief EXPERIMENTAL: Top-level schema fields to include when
   /// deserializing RecordBatch. If null, return all deserialized fields
   util::optional<std::vector<int>> included_fields;
+
+  /// \brief Use global CPU thread pool to parallelize any computational tasks
+  /// like decompression
+  bool use_threads = true;
 
   static IpcReadOptions Defaults();
 };

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -62,6 +62,10 @@ struct ARROW_EXPORT IpcWriteOptions {
   Compression::type compression = Compression::UNCOMPRESSED;
   int compression_level = Compression::kUseDefaultCompressionLevel;
 
+  /// \brief Use global CPU thread pool to parallelize any computational tasks
+  /// like compression
+  bool use_threads = true;
+
   static IpcWriteOptions Defaults();
 };
 
@@ -87,5 +91,10 @@ struct ARROW_EXPORT IpcReadOptions {
   static IpcReadOptions Defaults();
 };
 
+namespace internal {
+
+Status CheckCompressionSupported(Compression::type codec);
+
+}  // namespace internal
 }  // namespace ipc
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -295,20 +295,19 @@ class IpcTestFixture : public io::MemoryMapFixture {
     ASSERT_EQ(out_memo->num_fields(), in_memo.num_fields());
   }
 
-  Status DoStandardRoundTrip(const RecordBatch& batch, const IpcWriteOptions& options,
-                             DictionaryMemo* dictionary_memo,
-                             std::shared_ptr<RecordBatch>* result) {
+  Result<std::shared_ptr<RecordBatch>> DoStandardRoundTrip(
+      const RecordBatch& batch, const IpcWriteOptions& options,
+      DictionaryMemo* dictionary_memo,
+      const IpcReadOptions& read_options = IpcReadOptions::Defaults()) {
     std::shared_ptr<Buffer> serialized_batch;
     RETURN_NOT_OK(SerializeRecordBatch(batch, options, &serialized_batch));
 
     io::BufferReader buf_reader(serialized_batch);
-    return ReadRecordBatch(batch.schema(), dictionary_memo, IpcReadOptions::Defaults(),
-                           &buf_reader)
-        .Value(result);
+    return ReadRecordBatch(batch.schema(), dictionary_memo, read_options, &buf_reader);
   }
 
-  Status DoLargeRoundTrip(const RecordBatch& batch, bool zero_data,
-                          std::shared_ptr<RecordBatch>* result) {
+  Result<std::shared_ptr<RecordBatch>> DoLargeRoundTrip(const RecordBatch& batch,
+                                                        bool zero_data) {
     if (zero_data) {
       RETURN_NOT_OK(ZeroMemoryMap(mmap_.get()));
     }
@@ -327,7 +326,9 @@ class IpcTestFixture : public io::MemoryMapFixture {
     std::shared_ptr<RecordBatchFileReader> file_reader;
     ARROW_ASSIGN_OR_RAISE(file_reader, RecordBatchFileReader::Open(mmap_.get(), offset));
 
-    return file_reader->ReadRecordBatch(0, result);
+    std::shared_ptr<RecordBatch> result;
+    RETURN_NOT_OK(file_reader->ReadRecordBatch(0, &result));
+    return result;
   }
 
   void CheckReadResult(const RecordBatch& result, const RecordBatch& expected) {
@@ -343,6 +344,7 @@ class IpcTestFixture : public io::MemoryMapFixture {
 
   void CheckRoundtrip(const RecordBatch& batch,
                       IpcWriteOptions options = IpcWriteOptions::Defaults(),
+                      IpcReadOptions read_options = IpcReadOptions::Defaults(),
                       int64_t buffer_size = 1 << 20) {
     std::stringstream ss;
     ss << "test-write-row-batch-" << g_file_number++;
@@ -357,11 +359,11 @@ class IpcTestFixture : public io::MemoryMapFixture {
 
     ASSERT_OK(CollectDictionaries(batch, &dictionary_memo));
 
-    std::shared_ptr<RecordBatch> result;
-    ASSERT_OK(DoStandardRoundTrip(batch, options, &dictionary_memo, &result));
+    ASSERT_OK_AND_ASSIGN(
+        auto result, DoStandardRoundTrip(batch, options, &dictionary_memo, read_options));
     CheckReadResult(*result, batch);
 
-    ASSERT_OK(DoLargeRoundTrip(batch, /*zero_data=*/true, &result));
+    ASSERT_OK_AND_ASSIGN(result, DoLargeRoundTrip(batch, /*zero_data=*/true));
     CheckReadResult(*result, batch);
   }
   void CheckRoundtrip(const std::shared_ptr<Array>& array,
@@ -372,7 +374,7 @@ class IpcTestFixture : public io::MemoryMapFixture {
     auto schema = std::make_shared<Schema>(fields);
 
     auto batch = RecordBatch::Make(schema, 0, {array});
-    CheckRoundtrip(*batch, options, buffer_size);
+    CheckRoundtrip(*batch, options, IpcReadOptions::Defaults(), buffer_size);
   }
 
  protected:
@@ -498,16 +500,32 @@ TEST_F(TestWriteRecordBatch, WriteWithCompression) {
   auto batch =
       RecordBatch::Make(schema, length, {rg.String(500, 0, 10, 0.1), dict_array});
 
-  std::vector<Compression::type> codecs = {Compression::GZIP, Compression::LZ4_FRAME,
-                                           Compression::ZSTD, Compression::SNAPPY,
-                                           Compression::BROTLI};
+  std::vector<Compression::type> codecs = {Compression::LZ4_FRAME, Compression::ZSTD};
   for (auto codec : codecs) {
     if (!util::Codec::IsAvailable(codec)) {
-      return;
+      continue;
     }
     IpcWriteOptions options = IpcWriteOptions::Defaults();
     options.compression = codec;
     CheckRoundtrip(*batch, options);
+
+    // Check non-parallel read
+    IpcReadOptions read_options = IpcReadOptions::Defaults();
+    read_options.use_threads = false;
+    CheckRoundtrip(*batch, options, read_options);
+  }
+
+  std::vector<Compression::type> disallowed_codecs = {
+      Compression::BROTLI, Compression::BZ2, Compression::LZ4, Compression::GZIP,
+      Compression::SNAPPY};
+  for (auto codec : disallowed_codecs) {
+    if (!util::Codec::IsAvailable(codec)) {
+      continue;
+    }
+    IpcWriteOptions options = IpcWriteOptions::Defaults();
+    options.compression = codec;
+    std::shared_ptr<Buffer> buf;
+    ASSERT_RAISES(Invalid, SerializeRecordBatch(*batch, options, &buf));
   }
 }
 
@@ -526,9 +544,9 @@ TEST_F(TestWriteRecordBatch, SliceTruncatesBinaryOffsets) {
   ASSERT_OK_AND_ASSIGN(
       mmap_, io::MemoryMapFixture::InitMemoryMap(/*buffer_size=*/1 << 20, ss.str()));
   DictionaryMemo dictionary_memo;
-  std::shared_ptr<RecordBatch> result;
-  ASSERT_OK(DoStandardRoundTrip(*sliced_batch, IpcWriteOptions::Defaults(),
-                                &dictionary_memo, &result));
+  ASSERT_OK_AND_ASSIGN(
+      auto result,
+      DoStandardRoundTrip(*sliced_batch, IpcWriteOptions::Defaults(), &dictionary_memo));
   ASSERT_EQ(6 * sizeof(int32_t), result->column(0)->data()->buffers[1]->size());
 }
 
@@ -614,9 +632,9 @@ TEST_F(TestWriteRecordBatch, RoundtripPreservesBufferSizes) {
   ASSERT_OK_AND_ASSIGN(
       mmap_, io::MemoryMapFixture::InitMemoryMap(/*buffer_size=*/1 << 20, ss.str()));
   DictionaryMemo dictionary_memo;
-  std::shared_ptr<RecordBatch> result;
-  ASSERT_OK(DoStandardRoundTrip(*batch, IpcWriteOptions::Defaults(), &dictionary_memo,
-                                &result));
+  ASSERT_OK_AND_ASSIGN(
+      auto result,
+      DoStandardRoundTrip(*batch, IpcWriteOptions::Defaults(), &dictionary_memo));
 
   // Make sure that the validity bitmap is size 2 as expected
   ASSERT_EQ(2, arr->data()->buffers[0]->size());
@@ -1096,8 +1114,7 @@ TEST_F(TestIpcRoundTrip, LargeRecordBatch) {
   constexpr int64_t kBufferSize = 1 << 29;
   ASSERT_OK_AND_ASSIGN(mmap_, io::MemoryMapFixture::InitMemoryMap(kBufferSize, path));
 
-  std::shared_ptr<RecordBatch> result;
-  ASSERT_OK(DoLargeRoundTrip(*batch, false, &result));
+  ASSERT_OK_AND_ASSIGN(auto result, DoLargeRoundTrip(*batch, false));
   CheckReadResult(*result, *batch);
 
   ASSERT_EQ(length, result->num_rows());

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -505,14 +505,15 @@ TEST_F(TestWriteRecordBatch, WriteWithCompression) {
     if (!util::Codec::IsAvailable(codec)) {
       continue;
     }
-    IpcWriteOptions options = IpcWriteOptions::Defaults();
-    options.compression = codec;
-    CheckRoundtrip(*batch, options);
+    IpcWriteOptions write_options = IpcWriteOptions::Defaults();
+    write_options.compression = codec;
+    CheckRoundtrip(*batch, write_options);
 
-    // Check non-parallel read
+    // Check non-parallel read and write
     IpcReadOptions read_options = IpcReadOptions::Defaults();
+    write_options.use_threads = false;
     read_options.use_threads = false;
-    CheckRoundtrip(*batch, options, read_options);
+    CheckRoundtrip(*batch, write_options, read_options);
   }
 
   std::vector<Compression::type> disallowed_codecs = {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -46,6 +46,7 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/optional.h"
+#include "arrow/util/parallel.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/visitor_inline.h"
 
@@ -107,13 +108,10 @@ class ArrayLoader {
  public:
   explicit ArrayLoader(const flatbuf::RecordBatch* metadata,
                        const DictionaryMemo* dictionary_memo,
-                       const IpcReadOptions& options, Compression::type compression,
-                       io::RandomAccessFile* file)
+                       const IpcReadOptions& options, io::RandomAccessFile* file)
       : metadata_(metadata),
         file_(file),
         dictionary_memo_(dictionary_memo),
-        options_(options),
-        compression_(compression),
         max_recursion_depth_(options.max_recursion_depth) {}
 
   Status ReadBuffer(int64_t offset, int64_t length, std::shared_ptr<Buffer>* out) {
@@ -130,44 +128,6 @@ class ArrayLoader {
 
   Status LoadType(const DataType& type) { return VisitTypeInline(type, this); }
 
-  Status DecompressBuffers() {
-    if (skip_io_) {
-      return Status::OK();
-    }
-    std::unique_ptr<util::Codec> codec;
-    ARROW_ASSIGN_OR_RAISE(codec, util::Codec::Create(compression_));
-
-    // TODO: Consider strategies to enable columns to decompress in parallel
-    for (size_t i = 0; i < out_->buffers.size(); ++i) {
-      if (out_->buffers[i] == nullptr) {
-        continue;
-      }
-      if (out_->buffers[i]->size() == 0) {
-        continue;
-      }
-      const uint8_t* data = out_->buffers[i]->data();
-      int64_t compressed_size = out_->buffers[i]->size() - sizeof(int64_t);
-      int64_t uncompressed_size = util::SafeLoadAs<int64_t>(data);
-
-      std::shared_ptr<Buffer> uncompressed;
-      RETURN_NOT_OK(
-          AllocateBuffer(options_.memory_pool, uncompressed_size, &uncompressed));
-
-      int64_t actual_decompressed;
-      ARROW_ASSIGN_OR_RAISE(
-          actual_decompressed,
-          codec->Decompress(compressed_size, data + sizeof(int64_t), uncompressed_size,
-                            uncompressed->mutable_data()));
-      if (actual_decompressed != uncompressed_size) {
-        return Status::Invalid("Failed to fully decompress buffer, expected ",
-                               uncompressed_size, " bytes but decompressed ",
-                               actual_decompressed);
-      }
-      out_->buffers[i] = uncompressed;
-    }
-    return Status::OK();
-  }
-
   Status Load(const Field* field, ArrayData* out) {
     if (max_recursion_depth_ <= 0) {
       return Status::Invalid("Max recursion depth reached");
@@ -176,14 +136,7 @@ class ArrayLoader {
     field_ = field;
     out_ = out;
     out_->type = field_->type();
-    RETURN_NOT_OK(LoadType(*field_->type()));
-
-    // If the buffers are indicated to be compressed, instantiate the codec and
-    // decompress them
-    if (compression_ != Compression::UNCOMPRESSED) {
-      RETURN_NOT_OK(DecompressBuffers());
-    }
-    return Status::OK();
+    return LoadType(*field_->type());
   }
 
   Status SkipField(const Field* field) {
@@ -380,8 +333,6 @@ class ArrayLoader {
   const flatbuf::RecordBatch* metadata_;
   io::RandomAccessFile* file_;
   const DictionaryMemo* dictionary_memo_;
-  const IpcReadOptions& options_;
-  Compression::type compression_;
   int max_recursion_depth_;
   int buffer_index_ = 0;
   int field_index_ = 0;
@@ -391,12 +342,59 @@ class ArrayLoader {
   ArrayData* out_;
 };
 
+Status DecompressBuffers(const std::vector<std::shared_ptr<ArrayData>>& fields,
+                         Compression::type compression, const IpcReadOptions& options) {
+  std::unique_ptr<util::Codec> codec;
+  ARROW_ASSIGN_OR_RAISE(codec, util::Codec::Create(compression));
+
+  auto DecompressOne = [&](int i) {
+    ArrayData* arr = fields[i].get();
+    for (size_t i = 0; i < arr->buffers.size(); ++i) {
+      if (arr->buffers[i] == nullptr) {
+        continue;
+      }
+      if (arr->buffers[i]->size() == 0) {
+        continue;
+      }
+      const uint8_t* data = arr->buffers[i]->data();
+      int64_t compressed_size = arr->buffers[i]->size() - sizeof(int64_t);
+      int64_t uncompressed_size = util::SafeLoadAs<int64_t>(data);
+
+      std::shared_ptr<Buffer> uncompressed;
+      RETURN_NOT_OK(
+          AllocateBuffer(options.memory_pool, uncompressed_size, &uncompressed));
+
+      int64_t actual_decompressed;
+      ARROW_ASSIGN_OR_RAISE(
+          actual_decompressed,
+          codec->Decompress(compressed_size, data + sizeof(int64_t), uncompressed_size,
+                            uncompressed->mutable_data()));
+      if (actual_decompressed != uncompressed_size) {
+        return Status::Invalid("Failed to fully decompress buffer, expected ",
+                               uncompressed_size, " bytes but decompressed ",
+                               actual_decompressed);
+      }
+      arr->buffers[i] = uncompressed;
+    }
+    return Status::OK();
+  };
+
+  if (options.use_threads) {
+    return ::arrow::internal::ParallelFor(static_cast<int>(fields.size()), DecompressOne);
+  } else {
+    for (int i = 0; i < static_cast<int>(fields.size()); ++i) {
+      RETURN_NOT_OK(DecompressOne(i));
+    }
+  }
+  return Status::OK();
+}
+
 Result<std::shared_ptr<RecordBatch>> LoadRecordBatchSubset(
     const flatbuf::RecordBatch* metadata, const std::shared_ptr<Schema>& schema,
     const std::vector<bool>& inclusion_mask, const DictionaryMemo* dictionary_memo,
     const IpcReadOptions& options, Compression::type compression,
     io::RandomAccessFile* file) {
-  ArrayLoader loader(metadata, dictionary_memo, options, compression, file);
+  ArrayLoader loader(metadata, dictionary_memo, options, file);
 
   std::vector<std::shared_ptr<ArrayData>> field_data;
   std::vector<std::shared_ptr<Field>> schema_fields;
@@ -418,6 +416,10 @@ Result<std::shared_ptr<RecordBatch>> LoadRecordBatchSubset(
     }
   }
 
+  if (compression != Compression::UNCOMPRESSED) {
+    RETURN_NOT_OK(DecompressBuffers(field_data, compression, options));
+  }
+
   return RecordBatch::Make(::arrow::schema(std::move(schema_fields), schema->metadata()),
                            metadata->length(), std::move(field_data));
 }
@@ -432,7 +434,7 @@ Result<std::shared_ptr<RecordBatch>> LoadRecordBatch(
                                  options, compression, file);
   }
 
-  ArrayLoader loader(metadata, dictionary_memo, options, compression, file);
+  ArrayLoader loader(metadata, dictionary_memo, options, file);
   std::vector<std::shared_ptr<ArrayData>> arrays(schema->num_fields());
   for (int i = 0; i < schema->num_fields(); ++i) {
     auto arr = std::make_shared<ArrayData>();
@@ -441,6 +443,9 @@ Result<std::shared_ptr<RecordBatch>> LoadRecordBatch(
       return Status::IOError("Array length did not match record batch length");
     }
     arrays[i] = std::move(arr);
+  }
+  if (compression != Compression::UNCOMPRESSED) {
+    RETURN_NOT_OK(DecompressBuffers(arrays, compression, options));
   }
   return RecordBatch::Make(schema, metadata->length(), std::move(arrays));
 }
@@ -454,7 +459,7 @@ Status GetCompression(const flatbuf::Message* message, Compression::type* out) {
     // TODO: Ensure this deserialization only ever happens once
     std::shared_ptr<const KeyValueMetadata> metadata;
     RETURN_NOT_OK(internal::GetKeyValueMetadata(message->custom_metadata(), &metadata));
-    int index = metadata->FindKey("ARROW:body_compression");
+    int index = metadata->FindKey("ARROW:experimental_compression");
     if (index != -1) {
       ARROW_ASSIGN_OR_RAISE(*out,
                             util::Codec::GetCompressionType(metadata->value(index)));

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -50,6 +50,7 @@
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/make_unique.h"
+#include "arrow/util/parallel.h"
 #include "arrow/visitor_inline.h"
 
 namespace arrow {
@@ -182,10 +183,7 @@ class RecordBatchSerializer {
   Status CompressBodyBuffers() {
     std::unique_ptr<util::Codec> codec;
 
-    if (!(options_.compression == Compression::LZ4_FRAME ||
-          options_.compression == Compression::ZSTD)) {
-      return Status::Invalid("Only LZ4_FRAME and ZSTD compression allowed");
-    }
+    RETURN_NOT_OK(internal::CheckCompressionSupported(options_.compression));
 
     // TODO check allowed values for compression?
     AppendCustomMetadata("ARROW:experimental_compression",
@@ -193,14 +191,24 @@ class RecordBatchSerializer {
 
     ARROW_ASSIGN_OR_RAISE(
         codec, util::Codec::Create(options_.compression, options_.compression_level));
-    // TODO: Parallelize buffer compression
-    for (size_t i = 0; i < out_->body_buffers.size(); ++i) {
+
+    auto CompressOne = [&](size_t i) {
       if (out_->body_buffers[i]->size() > 0) {
         RETURN_NOT_OK(
             CompressBuffer(*out_->body_buffers[i], codec.get(), &out_->body_buffers[i]));
       }
+      return Status::OK();
+    };
+
+    if (options_.use_threads) {
+      return ::arrow::internal::ParallelFor(static_cast<int>(out_->body_buffers.size()),
+                                            CompressOne);
+    } else {
+      for (size_t i = 0; i < out_->body_buffers.size(); ++i) {
+        RETURN_NOT_OK(CompressOne(i));
+      }
+      return Status::OK();
     }
-    return Status::OK();
   }
 
   Status Assemble(const RecordBatch& batch) {

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -182,8 +182,13 @@ class RecordBatchSerializer {
   Status CompressBodyBuffers() {
     std::unique_ptr<util::Codec> codec;
 
+    if (!(options_.compression == Compression::LZ4_FRAME ||
+          options_.compression == Compression::ZSTD)) {
+      return Status::Invalid("Only LZ4_FRAME and ZSTD compression allowed");
+    }
+
     // TODO check allowed values for compression?
-    AppendCustomMetadata("ARROW:body_compression",
+    AppendCustomMetadata("ARROW:experimental_compression",
                          util::Codec::GetCodecAsString(options_.compression));
 
     ARROW_ASSIGN_OR_RAISE(

--- a/r/R/enums.R
+++ b/r/R/enums.R
@@ -76,7 +76,8 @@ MessageType <- enum("Message::Type",
 #' @rdname enums
 #' @export
 CompressionType <- enum("Compression::type",
-  UNCOMPRESSED = 0L, SNAPPY = 1L, GZIP = 2L, BROTLI = 3L, ZSTD = 4L, LZ4 = 5L, LZO = 6L, BZ2 = 7L
+  UNCOMPRESSED = 0L, SNAPPY = 1L, GZIP = 2L, BROTLI = 3L, ZSTD = 4L, LZ4 = 5L,
+  LZ4_FRAME = 6L, LZO = 7L, BZ2 = 8L
 )
 
 #' @export

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -83,6 +83,12 @@ write_feather <- function(x,
   }
   # Finally, add 1 to version because 2 means V1 and 3 means V2 :shrug:
   version <- version + 1L
+
+  # "lz4" is the convenience
+  if (compression == "lz4") {
+     compression <- "lz4_frame"
+  }
+
   compression <- compression_from_name(compression)
 
   x_out <- x


### PR DESCRIPTION
I also changed the metadata key to "ARROW:experimental_compression", if anyone has opinions.

Haven't run benchmarks but will do so tomorrow. 