### PR TITLE
ARROW-7740: [C++] Fix StructArray::Flatten corruption

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -796,7 +796,9 @@ Status StructArray::Flatten(MemoryPool* pool, ArrayVector* out) const {
   flattened.reserve(data_->child_data.size());
   std::shared_ptr<Buffer> null_bitmap = data_->buffers[0];
 
-  for (auto& child_data : data_->child_data) {
+  for (const auto& child_data_ptr : data_->child_data) {
+    auto child_data = child_data_ptr->Copy();
+
     std::shared_ptr<Buffer> flattened_null_bitmap;
     int64_t flattened_null_count = kUnknownNullCount;
 

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -1448,6 +1448,14 @@ Table__Equals <- function(lhs, rhs, check_metadata){
     .Call(`_arrow_Table__Equals` , lhs, rhs, check_metadata)
 }
 
+Table__Validate <- function(table){
+    .Call(`_arrow_Table__Validate` , table)
+}
+
+Table__ValidateFull <- function(table){
+    .Call(`_arrow_Table__ValidateFull` , table)
+}
+
 Table__GetColumnByName <- function(table, name){
     .Call(`_arrow_Table__GetColumnByName` , table, name)
 }

--- a/r/R/json.R
+++ b/r/R/json.R
@@ -38,8 +38,6 @@
 read_json_arrow <- function(file, col_select = NULL, as_data_frame = TRUE, ...) {
   tab <- JsonTableReader$create(file, ...)$Read()$select(!!enquo(col_select))
 
-  tab$ValidateFull()
-
   if (isTRUE(as_data_frame)) {
     tab <- as.data.frame(tab)
   }

--- a/r/R/json.R
+++ b/r/R/json.R
@@ -38,6 +38,8 @@
 read_json_arrow <- function(file, col_select = NULL, as_data_frame = TRUE, ...) {
   tab <- JsonTableReader$create(file, ...)$Read()$select(!!enquo(col_select))
 
+  tab$ValidateFull()
+
   if (isTRUE(as_data_frame)) {
     tab <- as.data.frame(tab)
   }

--- a/r/R/table.R
+++ b/r/R/table.R
@@ -163,6 +163,14 @@ Table <- R6Class("Table", inherit = ArrowObject,
 
     Equals = function(other, check_metadata = TRUE, ...) {
       inherits(other, "Table") && Table__Equals(self, other, isTRUE(check_metadata))
+    },
+
+    Validate = function() {
+      Table__Validate(self)
+    },
+
+    ValidateFull = function() {
+      Table__ValidateFull(self)
     }
   ),
 

--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -574,21 +574,9 @@ class Converter_List : public Converter {
     auto list_array = checked_cast<arrow::ListArray*>(array.get());
     auto values_array = list_array->values();
 
-    for (const auto& array : arrays_) {
-      Status s = array->Validate();
-      if (!s.ok()) {
-        STOP_IF_NOT_OK(s);
-      }
-    }
-
     auto ingest_one = [&](R_xlen_t i) {
-      auto slice =
-          values_array->Slice(list_array->value_offset(i), list_array->value_length(i));
-      STOP_IF_NOT_OK(slice->Validate());
-      STOP_IF_NOT_OK(values_array->Validate());
+      auto slice = list_array->value_slice(i);
       SET_VECTOR_ELT(data, i + start, Array__as_vector(slice));
-      STOP_IF_NOT_OK(values_array->Validate());
-      STOP_IF_NOT_OK(slice->Validate());
     };
 
     if (array->null_count()) {

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -5667,6 +5667,36 @@ RcppExport SEXP _arrow_Table__Equals(SEXP lhs_sexp, SEXP rhs_sexp, SEXP check_me
 
 // table.cpp
 #if defined(ARROW_R_WITH_ARROW)
+bool Table__Validate(const std::shared_ptr<arrow::Table>& table);
+RcppExport SEXP _arrow_Table__Validate(SEXP table_sexp){
+BEGIN_RCPP
+	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::Table>&>::type table(table_sexp);
+	return Rcpp::wrap(Table__Validate(table));
+END_RCPP
+}
+#else
+RcppExport SEXP _arrow_Table__Validate(SEXP table_sexp){
+	Rf_error("Cannot call Table__Validate(). Please use arrow::install_arrow() to install required runtime libraries. ");
+}
+#endif
+
+// table.cpp
+#if defined(ARROW_R_WITH_ARROW)
+bool Table__ValidateFull(const std::shared_ptr<arrow::Table>& table);
+RcppExport SEXP _arrow_Table__ValidateFull(SEXP table_sexp){
+BEGIN_RCPP
+	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::Table>&>::type table(table_sexp);
+	return Rcpp::wrap(Table__ValidateFull(table));
+END_RCPP
+}
+#else
+RcppExport SEXP _arrow_Table__ValidateFull(SEXP table_sexp){
+	Rf_error("Cannot call Table__ValidateFull(). Please use arrow::install_arrow() to install required runtime libraries. ");
+}
+#endif
+
+// table.cpp
+#if defined(ARROW_R_WITH_ARROW)
 std::shared_ptr<arrow::ChunkedArray> Table__GetColumnByName(const std::shared_ptr<arrow::Table>& table, const std::string& name);
 RcppExport SEXP _arrow_Table__GetColumnByName(SEXP table_sexp, SEXP name_sexp){
 BEGIN_RCPP
@@ -6118,6 +6148,8 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_Table__Slice1", (DL_FUNC) &_arrow_Table__Slice1, 2}, 
 		{ "_arrow_Table__Slice2", (DL_FUNC) &_arrow_Table__Slice2, 3}, 
 		{ "_arrow_Table__Equals", (DL_FUNC) &_arrow_Table__Equals, 3}, 
+		{ "_arrow_Table__Validate", (DL_FUNC) &_arrow_Table__Validate, 1}, 
+		{ "_arrow_Table__ValidateFull", (DL_FUNC) &_arrow_Table__ValidateFull, 1}, 
 		{ "_arrow_Table__GetColumnByName", (DL_FUNC) &_arrow_Table__GetColumnByName, 2}, 
 		{ "_arrow_Table__select", (DL_FUNC) &_arrow_Table__select, 2}, 
 		{ "_arrow_Table__from_dots", (DL_FUNC) &_arrow_Table__from_dots, 2}, 

--- a/r/src/table.cpp
+++ b/r/src/table.cpp
@@ -98,6 +98,18 @@ bool Table__Equals(const std::shared_ptr<arrow::Table>& lhs,
 }
 
 // [[arrow::export]]
+bool Table__Validate(const std::shared_ptr<arrow::Table>& table) {
+  STOP_IF_NOT_OK(table->Validate());
+  return true;
+}
+
+// [[arrow::export]]
+bool Table__ValidateFull(const std::shared_ptr<arrow::Table>& table) {
+  STOP_IF_NOT_OK(table->ValidateFull());
+  return true;
+}
+
+// [[arrow::export]]
 std::shared_ptr<arrow::ChunkedArray> Table__GetColumnByName(
     const std::shared_ptr<arrow::Table>& table, const std::string& name) {
   return table->GetColumnByName(name);

--- a/r/tests/testthat/test-json.R
+++ b/r/tests/testthat/test-json.R
@@ -147,3 +147,16 @@ test_that("Can read json file with nested columns (ARROW-5503)", {
     )
   )
 })
+
+test_that("Can read json file with list<struct<T...>> nested columns (ARROW-7740)", {
+  tf <- tempfile()
+  on.exit(unlink(tf))
+  writeLines('
+    {"a":[{"b":1.0},{"b":2.0}]}
+    {"a":[{"b":1.0},{"b":2.0}]}
+  ', tf)
+
+  one <- tibble::tibble(b = c(1, 2))
+  expected <- tibble::tibble(a = c(list(one), list(one)))
+  expect_equivalent(arrow::read_json_arrow(tf), expected)
+})


### PR DESCRIPTION
Flatten would modify in-place the data_->child_data ArrayData if the currently flattened array is a slice. The parent's child_data values would also be modified (and corrupted with wrong offset/length).