### PR TITLE
ARROW-8303: [Python] Fix test failure on Python 3.5 caused by non-deterministic dict key ordering

### DIFF
--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -454,9 +454,9 @@ def test_read_columns(version):
     data = {'foo': [1, 2, 3, 4],
             'boo': [5, 6, 7, 8],
             'woo': [1, 3, 5, 7]}
-    columns = list(data.keys())[1:3]
+    columns = ['boo', 'woo']
     df = pd.DataFrame(data)
-    expected = pd.DataFrame({c: data[c] for c in columns})
+    expected = pd.DataFrame({c: data[c] for c in columns}, columns=columns)
     _check_pandas_roundtrip(df, expected, version=version, columns=columns)
 
 


### PR DESCRIPTION
See failure for example https://github.com/apache/arrow/runs/550556785