### PR TITLE
ARROW-8305: [Java] ExtensionTypeVector should make sure underlyingVector not null

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ExtensionTypeVector.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
+import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.reader.FieldReader;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
@@ -50,6 +51,7 @@ public abstract class ExtensionTypeVector<T extends BaseValueVector & FieldVecto
    */
   public ExtensionTypeVector(String name, BufferAllocator allocator, T underlyingVector) {
     super(allocator);
+    Preconditions.checkNotNull(underlyingVector, "underlyingVector can not be null.");
     this.name = name;
     this.underlyingVector = underlyingVector;
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -17,6 +17,9 @@
 
 package org.apache.arrow.vector.types.pojo;
 
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -153,6 +156,19 @@ public class TestExtensionType {
         }
       }
     }
+  }
+
+  @Test
+  public void testNullCheck() {
+    NullPointerException e = assertThrows(NullPointerException.class,
+        () -> {
+          try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
+               final ExtensionTypeVector vector = new UuidVector("uuid", allocator, null)) {
+            vector.getField();
+            vector.allocateNewSafe();
+          }
+        });
+    assertTrue(e.getMessage().contains("underlyingVector can not be null."));
   }
 
   static class UuidType extends ExtensionType {

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -17,7 +17,7 @@
 
 package org.apache.arrow.vector.types.pojo;
 
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;


### PR DESCRIPTION
Related to [ARROW-8305](https://issues.apache.org/jira/browse/ARROW-8305).

In ExtensionTypeVector seems not check nullability for underlyingVector, and it will throw exception when it is null in some api like accept/reset/getField etc.

it's better to do null check when create ExtensionTypeVector rather than when really use it.