### PR TITLE
ARROW-8217: [R] Unskip previously failing test on Win32 in test-dataset.R from ARROW-7979

### DIFF
--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -174,9 +174,6 @@ test_that("IPC/Arrow format data", {
     dim(ds),
     "Number of rows unknown; returning NA"
   )
-  # This causes a segfault on Windows R 32-bit following ARROW-7979
-  # TODO: fix me
-  # skip_on_os("windows")
   expect_equivalent(
     ds %>%
       select(string = chr, integer = int, part) %>%

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -176,7 +176,7 @@ test_that("IPC/Arrow format data", {
   )
   # This causes a segfault on Windows R 32-bit following ARROW-7979
   # TODO: fix me
-  skip_on_os("windows")
+  # skip_on_os("windows")
   expect_equivalent(
     ds %>%
       select(string = chr, integer = int, part) %>%


### PR DESCRIPTION
Neal found that the test passed in a debug build, let's see if the test still fails on master