### PR TITLE
ARROW-8309: [CI] C++/Java/Rust workflows should trigger on changes to Flight.proto

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -23,11 +23,13 @@ on:
       - '.github/workflows/cpp.yml'
       - 'ci/**'
       - 'cpp/**'
+      - 'format/Flight.proto'
   pull_request:
     paths:
       - '.github/workflows/cpp.yml'
       - 'ci/**'
       - 'cpp/**'
+      - 'format/Flight.proto'
 
 env:
   ARROW_ENABLE_TIMING_TESTS: OFF

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -21,12 +21,18 @@ on:
   push:
     paths:
       - '.github/workflows/java.yml'
-      - 'ci/**'
+      - 'ci/docker/*java*'
+      - 'ci/scripts/java*.sh'
+      - 'ci/scripts/util_*.sh'
+      - 'format/Flight.proto'
       - 'java/**'
   pull_request:
     paths:
       - '.github/workflows/java.yml'
-      - 'ci/**'
+      - 'ci/docker/*java*'
+      - 'ci/scripts/java*.sh'
+      - 'ci/scripts/util_*.sh'
+      - 'format/Flight.proto'
       - 'java/**'
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,13 +21,19 @@ on:
   push:
     paths:
       - '.github/workflows/rust.yml'
-      - 'ci/**'
+      - 'ci/docker/*rust*'
+      - 'ci/scripts/rust_*.sh'
+      - 'ci/scripts/util_*.sh'
       - 'rust/**'
+      - 'format/Flight.proto'
   pull_request:
     paths:
       - '.github/workflows/rust.yml'
-      - 'ci/**'
+      - 'ci/docker/*rust*'
+      - 'ci/scripts/rust_*.sh'
+      - 'ci/scripts/util_*.sh'
       - 'rust/**'
+      - 'format/Flight.proto'
 
 jobs:
 


### PR DESCRIPTION
This also narrows the scope of the triggers on changes to the `ci/` directory (cc @kszucs )