### PR TITLE
ARROW-7008: [C++] Check binary offsets and data buffers for nullness in validation. Produce valid arrays in DictionaryEncode on zero-length arrays

### DIFF
--- a/cpp/src/arrow/array/dict_internal.h
+++ b/cpp/src/arrow/array/dict_internal.h
@@ -133,17 +133,15 @@ struct DictionaryTraits<T, enable_if_base_binary<T>> {
 
     // Create the offsets buffer
     auto dict_length = static_cast<int64_t>(memo_table.size() - start_offset);
-    if (dict_length > 0) {
-      RETURN_NOT_OK(
-          AllocateBuffer(pool, sizeof(offset_type) * (dict_length + 1), &dict_offsets));
-      auto raw_offsets = reinterpret_cast<offset_type*>(dict_offsets->mutable_data());
-      memo_table.CopyOffsets(static_cast<int32_t>(start_offset), raw_offsets);
-    }
+    RETURN_NOT_OK(
+        AllocateBuffer(pool, sizeof(offset_type) * (dict_length + 1), &dict_offsets));
+    auto raw_offsets = reinterpret_cast<offset_type*>(dict_offsets->mutable_data());
+    memo_table.CopyOffsets(static_cast<int32_t>(start_offset), raw_offsets);
 
     // Create the data buffer
     auto values_size = memo_table.values_size();
+    RETURN_NOT_OK(AllocateBuffer(pool, values_size, &dict_data));
     if (values_size > 0) {
-      RETURN_NOT_OK(AllocateBuffer(pool, values_size, &dict_data));
       memo_table.CopyValues(static_cast<int32_t>(start_offset), dict_data->size(),
                             dict_data->mutable_data());
     }

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -207,6 +207,9 @@ struct ValidateArrayVisitor {
     if (array.data()->buffers.size() != 3) {
       return Status::Invalid("number of buffers is != 3");
     }
+    if (array.value_data() == nullptr) {
+      return Status::Invalid("value data buffer is null");
+    }
     return ValidateOffsets(array);
   }
 
@@ -457,7 +460,7 @@ struct ValidateArrayDataVisitor {
     if (!indices_status.ok()) {
       return Status::Invalid("Dictionary indices invalid: ", indices_status.ToString());
     }
-    return Status::OK();
+    return ValidateArrayData(*array.dictionary());
   }
 
   Status Visit(const ExtensionArray& array) {
@@ -467,6 +470,9 @@ struct ValidateArrayDataVisitor {
  protected:
   template <typename BinaryArrayType>
   Status ValidateBinaryArray(const BinaryArrayType& array) {
+    if (array.value_data() == nullptr) {
+      return Status::Invalid("value data buffer is null");
+    }
     return ValidateOffsets(array, array.value_data()->size());
   }
 

--- a/cpp/src/arrow/array_dict_test.cc
+++ b/cpp/src/arrow/array_dict_test.cc
@@ -980,6 +980,21 @@ TEST(TestDictionary, Validate) {
   // Only checking index type for now
   ASSERT_OK(arr->ValidateFull());
 
+  // ARROW-7008: Invalid dict was not being validated
+  std::vector<std::shared_ptr<Buffer>> buffers = {nullptr, nullptr, nullptr};
+  auto invalid_data = std::make_shared<ArrayData>(utf8(), 0, buffers);
+
+  indices = ArrayFromJSON(int16(), "[]");
+  arr = std::make_shared<DictionaryArray>(dict_type, indices, MakeArray(invalid_data));
+  ASSERT_RAISES(Invalid, arr->Validate());
+  ASSERT_RAISES(Invalid, arr->ValidateFull());
+
+  // Make the data buffer non-null
+  ASSERT_OK(AllocateBuffer(0, &buffers[2]));
+  arr = std::make_shared<DictionaryArray>(dict_type, indices, MakeArray(invalid_data));
+  ASSERT_RAISES(Invalid, arr->Validate());
+  ASSERT_RAISES(Invalid, arr->ValidateFull());
+
   ASSERT_DEATH(
       {
         std::shared_ptr<Array> null_dict_arr =

--- a/cpp/src/arrow/array_dict_test.cc
+++ b/cpp/src/arrow/array_dict_test.cc
@@ -986,13 +986,11 @@ TEST(TestDictionary, Validate) {
 
   indices = ArrayFromJSON(int16(), "[]");
   arr = std::make_shared<DictionaryArray>(dict_type, indices, MakeArray(invalid_data));
-  ASSERT_RAISES(Invalid, arr->Validate());
   ASSERT_RAISES(Invalid, arr->ValidateFull());
 
   // Make the data buffer non-null
   ASSERT_OK(AllocateBuffer(0, &buffers[2]));
   arr = std::make_shared<DictionaryArray>(dict_type, indices, MakeArray(invalid_data));
-  ASSERT_RAISES(Invalid, arr->Validate());
   ASSERT_RAISES(Invalid, arr->ValidateFull());
 
   ASSERT_DEATH(

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1168,6 +1168,15 @@ def test_dictionary_encode_sliced():
         assert result.type == expected.type
 
 
+def test_dictionary_encode_zero_length():
+    # User-facing experience of ARROW-7008
+    arr = pa.array([], type=pa.string())
+    encoded = arr.dictionary_encode()
+    assert len(encoded.dictionary) == 0
+    encoded.validate()
+    encoded.validate(full=True)
+
+
 def test_cast_time32_to_int():
     arr = pa.array(np.array([0, 1, 2], dtype='int32'),
                    type=pa.time32('s'))

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1173,7 +1173,6 @@ def test_dictionary_encode_zero_length():
     arr = pa.array([], type=pa.string())
     encoded = arr.dictionary_encode()
     assert len(encoded.dictionary) == 0
-    encoded.validate()
     encoded.validate(full=True)
 
 


### PR DESCRIPTION
A couple of related issues:

* Validate() and ValidateFull() did not check the offsets and data buffers of BinaryArray for nullness. We might relax the requirements of the columnar format docs to allow them to be null, but that should be a separate matter
* DictionaryEncode (and other hash kernels) were producing invalid dictionaries for zero-length BinaryArray input