### PR TITLE
ARROW-6479: [C++] Inline errors from externalprojects on failure

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -499,6 +499,8 @@ if(NOT ARROW_VERBOSE_THIRDPARTY_BUILD)
       LOG_INSTALL
       1
       LOG_DOWNLOAD
+      1
+      LOG_OUTPUT_ON_FAILURE
       1)
   set(Boost_DEBUG FALSE)
 else()


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/module/ExternalProject.html
```
LOG_OUTPUT_ON_FAILURE <bool>

    This option only has an effect if at least one of the other LOG_<step> options
    is enabled. If an error occurs for a step which has logging to file enabled, that
    step’s output will be printed to the console if LOG_OUTPUT_ON_FAILURE is
    set to true. For cases where a large amount of output is recorded, just the end
    of that output may be printed to the console.
```