### PR TITLE
ARROW-8315: [Python] Fix dataset tests on Python 3.5

### DIFF
--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -625,7 +625,8 @@ def _create_dataset_for_fragments(tempdir, chunk_size=None):
     import pyarrow.parquet as pq
 
     table = pa.table(
-        {'f1': range(8), 'f2': [1] * 8, 'part': ['a'] * 4 + ['b'] * 4}
+        [range(8), [1] * 8, ['a'] * 4 + ['b'] * 4],
+        names=['f1', 'f2', 'part']
     )
     # write_to_dataset currently requires pandas
     pq.write_to_dataset(table, str(tempdir / "test_parquet_dataset"),
@@ -1176,13 +1177,14 @@ def test_specified_schema(tempdir):
 
     # Specifying schema with missing column
     schema = pa.schema([('a', 'int64')])
-    expected = pa.table({'a': [1, 2, 3]})
+    expected = pa.table([[1, 2, 3]], names=['a'])
     _check_dataset(schema, expected)
 
     # Specifying schema with additional column
     schema = pa.schema([('a', 'int64'), ('c', 'int32')])
-    expected = pa.table({'a': [1, 2, 3],
-                         'c': pa.array([None, None, None], type='int32')})
+    expected = pa.table([[1, 2, 3],
+                         pa.array([None, None, None], type='int32')],
+                        names=['a', 'c'])
     _check_dataset(schema, expected)
 
     # Specifying with incompatible schema

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -261,8 +261,7 @@ sapien. Quisque pretium vestibulum urna eu vehicula."""
                                     metadata={"key1": "value1"}),
                            pa.field("bar", "string", True,
                                     metadata={"key3": "value3"})],
-                          metadata={"key2": "value2",
-                                    "lorem": lorem})
+                          metadata={"lorem": lorem})
 
     assert my_schema.to_string() == """\
 foo: int32 not null
@@ -272,7 +271,6 @@ bar: string
   -- field metadata --
   key3: 'value3'
 -- schema metadata --
-key2: 'value2'
 lorem: '""" + lorem[:65] + "' + " + str(len(lorem) - 65)
 
     # Metadata that exactly fits
@@ -292,7 +290,6 @@ bar: string
   -- field metadata --
   key3: 'value3'
 -- schema metadata --
-key2: 'value2'
 lorem: '{}'""".format(lorem)
 
     assert my_schema.to_string(truncate_metadata=False,
@@ -300,7 +297,6 @@ lorem: '{}'""".format(lorem)
 foo: int32 not null
 bar: string
 -- schema metadata --
-key2: 'value2'
 lorem: '{}'""".format(lorem)
 
     assert my_schema.to_string(truncate_metadata=False,


### PR DESCRIPTION
Do not rely on well-defined dict ordering.