### PR TITLE
ARROW-8322: [CI] Fix C# workflow file syntax

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -61,7 +61,7 @@ jobs:
   windows:
     name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
     runs-on: windows-latest
-    if: !contains(github.event.pull_request.title, 'WIP')
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:
@@ -88,7 +88,7 @@ jobs:
   macos:
     name: AMD64 MacOS 10.15 C# ${{ matrix.dotnet }}
     runs-on: macos-latest
-    if: !contains(github.event.pull_request.title, 'WIP')
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The github actions expression requires the enclosing `${{ }}`