### PR TITLE
ARROW-8005: [Tools] Update apache mirror links

### DIFF
--- a/dev/release/post-03-website.sh
+++ b/dev/release/post-03-website.sh
@@ -214,6 +214,8 @@ popd
 # Update versions.yml
 pinned_version=$(echo ${version} | sed -e 's/\.[^.]*$/.*/')
 
+apache_download_url=https://downloads.apache.org
+
 cat <<YAML > "${versions_yml}"
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -243,9 +245,9 @@ current:
   tarball_name: 'apache-arrow-${version}.tar.gz'
   mirrors-tar: 'https://www.apache.org/dyn/closer.lua/arrow/arrow-${version}/apache-arrow-${version}.tar.gz'
   java-artifacts: 'http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.arrow%22%20AND%20v%3A%22${version}%22'
-  asc: 'https://www.apache.org/dist/arrow/arrow-${version}/apache-arrow-${version}.tar.gz.asc'
-  sha256: 'https://www.apache.org/dist/arrow/arrow-${version}/apache-arrow-${version}.tar.gz.sha256'
-  sha512: 'https://www.apache.org/dist/arrow/arrow-${version}/apache-arrow-${version}.tar.gz.sha512'
+  asc: '${apache_download_url}/arrow/arrow-${version}/apache-arrow-${version}.tar.gz.asc'
+  sha256: '${apache_download_url}/arrow/arrow-${version}/apache-arrow-${version}.tar.gz.sha256'
+  sha512: '${apache_download_url}/dist/arrow/arrow-${version}/apache-arrow-${version}.tar.gz.sha512'
 YAML
 git add "${versions_yml}"
 

--- a/dev/release/post-04-ruby.sh
+++ b/dev/release/post-04-ruby.sh
@@ -36,7 +36,7 @@ rm -f ${tar_gz}
 curl \
   --remote-name \
   --fail \
-  https://www-us.apache.org/dist/arrow/arrow-${version}/${tar_gz}
+  https://downloads.apache.org/arrow/arrow-${version}/${tar_gz}
 rm -rf ${archive_name}
 tar xf ${tar_gz}
 modules=()

--- a/dev/release/post-05-js.sh
+++ b/dev/release/post-05-js.sh
@@ -35,7 +35,7 @@ rm -f ${tar_gz}
 curl \
   --remote-name \
   --fail \
-  https://www-us.apache.org/dist/arrow/arrow-${version}/${tar_gz}
+  https://downloads.apache.org/arrow/arrow-${version}/${tar_gz}
 rm -rf ${archive_name}
 tar xf ${tar_gz}
 pushd ${archive_name}/js

--- a/dev/release/post-06-csharp.sh
+++ b/dev/release/post-06-csharp.sh
@@ -40,7 +40,7 @@ rm -f ${tar_gz}
 curl \
   --remote-name \
   --fail \
-  https://www-us.apache.org/dist/arrow/arrow-${version}/${tar_gz}
+  https://downloads.apache.org/arrow/arrow-${version}/${tar_gz}
 rm -rf ${archive_name}
 tar xf ${tar_gz}
 pushd ${archive_name}/csharp

--- a/dev/release/post-07-rust.sh
+++ b/dev/release/post-07-rust.sh
@@ -49,7 +49,7 @@ rm -f ${tar_gz}
 curl \
   --remote-name \
   --fail \
-  https://www-us.apache.org/dist/arrow/arrow-${version}/${tar_gz}
+  https://downloads.apache.org/arrow/arrow-${version}/${tar_gz}
 rm -rf ${archive_name}
 tar xf ${tar_gz}
 modules=()


### PR DESCRIPTION
Change urls from `www*.apache.org/dist` to `downloads.apache.org`.