### PR TITLE
ARROW-8319: [CI] Install thrift compiler in the debian build

### DIFF
--- a/ci/docker/debian-10-cpp.dockerfile
+++ b/ci/docker/debian-10-cpp.dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update -y -q && \
         pkg-config \
         protobuf-compiler \
         rapidjson-dev \
+        thrift-compiler \
         tzdata \
         zlib1g-dev \
         wget && \


### PR DESCRIPTION
After [setting](https://github.com/apache/arrow/commit/156d449f0a82e7ef830f8510309e6a8cdf29966f#diff-8f85d961ec4381b4cf136e3cea1b1791R124) `Thrift_SOURCE` to empty from `AUTO` the compiler cannot be found. Previously it was automatically using the bundled build az a fallback.