### PR TITLE
ARROW-8321: [CI] Use bundled thrift in Fedora 30 build

### DIFF
--- a/ci/docker/fedora-30-cpp.dockerfile
+++ b/ci/docker/fedora-30-cpp.dockerfile
@@ -50,7 +50,6 @@ RUN dnf update -y && \
         rapidjson-devel \
         re2-devel \
         snappy-devel \
-        thrift-devel \
         zlib-devel
 
 # * c-ares cmake config is not installed on Fedora but gRPC needs it
@@ -80,4 +79,5 @@ ENV ARROW_BUILD_TESTS=ON \
     PARQUET_BUILD_EXECUTABLES=ON \
     PARQUET_BUILD_EXAMPLES=ON \
     PATH=/usr/lib/ccache/:$PATH \
-    Protobuf_SOURCE=BUNDLED
+    Protobuf_SOURCE=BUNDLED \
+    Thrift_SOURCE=BUNDLED


### PR DESCRIPTION
After unsetting Thrift_SOURCE from AUTO it surfaced that the thrift available on Fedora 30 is older 0.10 than the minimal required version 0.11.
Build thrift_ep instead.