### PR TITLE
ARROW-8327: [FlightRPC][Java] check gRPC trailers for null

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallStatus.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallStatus.java
@@ -96,6 +96,8 @@ public class CallStatus {
 
   /**
    * Metadata associated with the exception.
+   *
+   * May be null.
    */
   public ErrorFlightMetadata metadata() {
     return metadata;


### PR DESCRIPTION
This fixes a spurious error in some scenarios. Unfortunately I couldn't get a reliable test for it - the scenario I found was a server-side generated internal error, which is rather timing sensitive (the server has to end the call without getting a halfClose from the client, which a proper gRPC client wouldn't do).