### PR TITLE
ARROW-8307: [Python] Add memory_map= option to pyarrow.feather.read_table

### DIFF
--- a/cpp/src/arrow/compute/kernels/filter.h
+++ b/cpp/src/arrow/compute/kernels/filter.h
@@ -83,6 +83,7 @@ class ARROW_EXPORT FilterKernel : public BinaryKernel {
   ///
   /// \param[in] value_type constructed FilterKernel will support filtering
   ///            values of this type
+  /// \param[in] options configures null_selection_behavior
   /// \param[out] out created kernel
   static Status Make(std::shared_ptr<DataType> value_type, FilterOptions options,
                      std::unique_ptr<FilterKernel>* out);

--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -204,7 +204,7 @@ def read_feather(source, columns=None, use_threads=True):
     return read_table(source, columns=columns).to_pandas(use_threads=True)
 
 
-def read_table(source, columns=None):
+def read_table(source, columns=None, memory_map=True):
     """
     Read a pyarrow.Table from Feather format
 
@@ -214,6 +214,8 @@ def read_table(source, columns=None):
     columns : sequence, optional
         Only read a specific set of columns. If not provided, all columns are
         read.
+    memory_map : boolean, default True
+        Use memory mapping when opening file on disk
 
     Returns
     -------
@@ -221,7 +223,7 @@ def read_table(source, columns=None):
     """
     _check_pandas_version()
     reader = ext.FeatherReader()
-    reader.open(source)
+    reader.open(source, use_memory_map=memory_map)
 
     if columns is None:
         return reader.read()

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -156,7 +156,10 @@ def test_read_table(version):
     table = pa.Table.from_pandas(data)
 
     result = read_table(path)
+    assert_frame_equal(table.to_pandas(), result.to_pandas())
 
+    # Test without memory mapping
+    result = read_table(path, memory_map=False)
     assert_frame_equal(table.to_pandas(), result.to_pandas())
 
 


### PR DESCRIPTION
Having this option makes it easier to do apples-to-apples performance tests of compressed versus uncompressed files (there may be other reasons not to memory map but either way doesn't hurt to have the option)