### PR TITLE
ARROW-8331: [C++] Fix filter_benchmark.cc compilation

### DIFF
--- a/cpp/src/arrow/compute/kernels/filter.h
+++ b/cpp/src/arrow/compute/kernels/filter.h
@@ -83,6 +83,7 @@ class ARROW_EXPORT FilterKernel : public BinaryKernel {
   ///
   /// \param[in] value_type constructed FilterKernel will support filtering
   ///            values of this type
+  /// \param[in] options configures null_selection_behavior
   /// \param[out] out created kernel
   static Status Make(std::shared_ptr<DataType> value_type, FilterOptions options,
                      std::unique_ptr<FilterKernel>* out);

--- a/cpp/src/arrow/compute/kernels/filter_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/filter_benchmark.cc
@@ -39,10 +39,11 @@ static void FilterInt64(benchmark::State& state) {
   auto filter = std::static_pointer_cast<BooleanArray>(
       rand.Boolean(array_size, 0.75, args.null_proportion));
 
+  FilterOptions options;
   FunctionContext ctx;
   for (auto _ : state) {
     Datum out;
-    ABORT_NOT_OK(Filter(&ctx, Datum(array), Datum(filter), &out));
+    ABORT_NOT_OK(Filter(&ctx, Datum(array), Datum(filter), options, &out));
     benchmark::DoNotOptimize(out);
   }
 }
@@ -60,10 +61,11 @@ static void FilterFixedSizeList1Int64(benchmark::State& state) {
   auto filter = std::static_pointer_cast<BooleanArray>(
       rand.Boolean(array_size, 0.75, args.null_proportion));
 
+  FilterOptions options;
   FunctionContext ctx;
   for (auto _ : state) {
     Datum out;
-    ABORT_NOT_OK(Filter(&ctx, Datum(array), Datum(filter), &out));
+    ABORT_NOT_OK(Filter(&ctx, Datum(array), Datum(filter), options, &out));
     benchmark::DoNotOptimize(out);
   }
 }
@@ -84,10 +86,11 @@ static void FilterString(benchmark::State& state) {
   auto filter = std::static_pointer_cast<BooleanArray>(
       rand.Boolean(array_size, 0.75, args.null_proportion));
 
+  FilterOptions options;
   FunctionContext ctx;
   for (auto _ : state) {
     Datum out;
-    ABORT_NOT_OK(Filter(&ctx, Datum(array), Datum(filter), &out));
+    ABORT_NOT_OK(Filter(&ctx, Datum(array), Datum(filter), options, &out));
     benchmark::DoNotOptimize(out);
   }
 }


### PR DESCRIPTION
This issue exposes a blind spot in our CI -- we are not checking that our benchmarks compile. I think we should alter the CI to fix this -- I opened ARROW-8333. 