### PR TITLE
ARROW-8336: [Packaging][deb] Use libthrift-dev on Debian 10 and Ubuntu 19.10 or later

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-buster/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-buster/Dockerfile
@@ -62,6 +62,7 @@ RUN \
     libre2-dev \
     libsnappy-dev \
     libssl-dev \
+    libthrift-dev \
     libzstd-dev \
     llvm-${LLVM}-dev \
     lsb-release \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-eoan/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-eoan/Dockerfile
@@ -55,6 +55,7 @@ RUN \
     libre2-dev \
     libsnappy-dev \
     libssl-dev \
+    libthrift-dev \
     libzstd-dev \
     llvm-${LLVM}-dev \
     lsb-release \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-focal/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-focal/Dockerfile
@@ -55,6 +55,7 @@ RUN \
     libre2-dev \
     libsnappy-dev \
     libssl-dev \
+    libthrift-dev \
     libzstd-dev \
     llvm-${LLVM}-dev \
     lsb-release \


### PR DESCRIPTION
They have Trhift 0.11.0 or later.