### PR TITLE
ARROW-8320: [Format] Add clarification to CDataInterface.rst regarding memory alignment of buffers

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -440,6 +440,10 @@ It has the following fields:
    represent `length + offset` values encoded according to the
    :ref:`Columnar format specification <format_columnar>`.
 
+   It is recommended, but not required, that the memory addresses of the
+   buffers be aligned according to the type of primitive data that they
+   contain. Consumers MAY decide not to support unaligned memory.
+
    The pointer to the null bitmap buffer, if the data type specifies one,
    MAY be NULL only if :c:member:`ArrowArray.null_count` is 0.
 

--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -441,8 +441,8 @@ It has the following fields:
    :ref:`Columnar format specification <format_columnar>`.
 
    It is recommended, but not required, that the memory addresses of the
-   buffers be aligned according to the type of primitive data that they
-   contain. Consumers MAY decide not to support unaligned memory.
+   buffers be aligned at least according to the type of primitive data that
+   they contain. Consumers MAY decide not to support unaligned memory.
 
    The pointer to the null bitmap buffer, if the data type specifies one,
    MAY be NULL only if :c:member:`ArrowArray.null_count` is 0.


### PR DESCRIPTION
This recommends at least a minimum alignment based on the type of data the buffer contains. For example, if the buffer contains `int32_t` data, then a minimum of 4-byte alignment is recommended. 

If an Arrow implementation finds unaligned memory burdensome due to aliasing issues or undefined behavior, this also clarifies that they are not expected to support it. 