### PR TITLE
ARROW-8237: [Python][Documentation] Minor corrections to python minimal build documentation

### DIFF
--- a/python/examples/minimal_build/README.md
+++ b/python/examples/minimal_build/README.md
@@ -26,50 +26,47 @@ environments.
 
 ## Fedora 31
 
-Build image:
-
+First, build the Docker image using:
 ```
-docker build -t arrow_fedora_minimal -f Dockerfile.fedora
+docker build -t arrow_fedora_minimal -f Dockerfile.fedora .
 ```
 
-Build with conda or pip/virtualenv:
-
+Then build PyArrow with conda or pip/virtualenv, respectively:
 ```
 # With pip/virtualenv
-docker run --rm -t -i -v $PWD:/io arrow_fedora_minimal /io/build_venv.sh .
+docker run --rm -t -i -v $PWD:/io arrow_fedora_minimal /io/build_venv.sh
 
 # With conda
-docker run --rm -t -i -v $PWD:/io arrow_fedora_minimal /io/build_conda.sh .
+docker run --rm -t -i -v $PWD:/io arrow_fedora_minimal /io/build_conda.sh
 ```
 
 ## Ubuntu 18.04
 
-Build image:
-
+First, build the Docker image using:
 ```
-docker build -t arrow_ubuntu_minimal -f Dockerfile.ubuntu
+docker build -t arrow_ubuntu_minimal -f Dockerfile.ubuntu .
 ```
 
-Build with conda or pip/virtualenv:
-
+Then build PyArrow with conda or pip/virtualenv, respectively:
 ```
 # With pip/virtualenv
-docker run --rm -t -i -v $PWD:/io arrow_ubuntu_minimal /io/build_venv.sh .
+docker run --rm -t -i -v $PWD:/io arrow_ubuntu_minimal /io/build_venv.sh
 
 # With conda
-docker run --rm -t -i -v $PWD:/io arrow_ubuntu_minimal /io/build_conda.sh .
+docker run --rm -t -i -v $PWD:/io arrow_ubuntu_minimal /io/build_conda.sh
 ```
 
-## Building on Fedora - podman and SELinux
+## Building on Fedora - Podman and SELinux
 
-In addition to using podman you need to specify :Z for selinux relabelling:
+In addition to using Podman instead of Docker, you need to specify `:Z`
+for SELinux relabelling when binding a volume.
 
+First, build the image using:
 ```
 podman build -t arrow_fedora_minimal -f Dockerfile.fedora
 ```
 
-Arrow build with pip/virtualenv:
-
+Then build PyArrow with pip/virtualenv:
 ```
 # With pip/virtualenv
 podman run --rm -i -v $PWD:/io:Z -t arrow_fedora_minimal /io/build_venv.sh

--- a/python/examples/minimal_build/README.md
+++ b/python/examples/minimal_build/README.md
@@ -36,10 +36,10 @@ Build with conda or pip/virtualenv:
 
 ```
 # With pip/virtualenv
-docker run --rm -t -i -v $PWD:/io arrow_fedora_minimal /io/build_venv.sh
+docker run --rm -t -i -v $PWD:/io arrow_fedora_minimal /io/build_venv.sh .
 
 # With conda
-docker run --rm -t -i -v $PWD:/io arrow_fedora_minimal /io/build_conda.sh
+docker run --rm -t -i -v $PWD:/io arrow_fedora_minimal /io/build_conda.sh .
 ```
 
 ## Ubuntu 18.04
@@ -54,8 +54,23 @@ Build with conda or pip/virtualenv:
 
 ```
 # With pip/virtualenv
-docker run --rm -t -i -v $PWD:/io arrow_ubuntu_minimal /io/build_venv.sh
+docker run --rm -t -i -v $PWD:/io arrow_ubuntu_minimal /io/build_venv.sh .
 
 # With conda
-docker run --rm -t -i -v $PWD:/io arrow_ubuntu_minimal /io/build_conda.sh
+docker run --rm -t -i -v $PWD:/io arrow_ubuntu_minimal /io/build_conda.sh .
+```
+
+## Building on Fedora - podman and SELinux
+
+In addition to using podman you need to specify :Z for selinux relabelling:
+
+```
+podman build -t arrow_fedora_minimal -f Dockerfile.fedora
+```
+
+Arrow build with pip/virtualenv:
+
+```
+# With pip/virtualenv
+podman run --rm -i -v $PWD:/io:Z -t arrow_fedora_minimal /io/build_venv.sh
 ```

--- a/python/examples/minimal_build/build_venv.sh
+++ b/python/examples/minimal_build/build_venv.sh
@@ -21,20 +21,21 @@ set -e
 #----------------------------------------------------------------------
 # Change this to whatever makes sense for your system
 
-MINICONDA=$HOME/miniconda-for-arrow
-LIBRARY_INSTALL_DIR=$HOME/local-libs
-CPP_BUILD_DIR=$HOME/arrow-cpp-build
-ARROW_ROOT=/arrow
-export ARROW_HOME=/dist
-export LD_LIBRARY_PATH=/dist/lib:$LD_LIBRARY_PATH
+WORKDIR=${WORKDIR:-$HOME}
+MINICONDA=$WORKDIR/miniconda-for-arrow
+LIBRARY_INSTALL_DIR=$WORKDIR/local-libs
+CPP_BUILD_DIR=$WORKDIR/arrow-cpp-build
+ARROW_ROOT=$WORKDIR/arrow
+export ARROW_HOME=$WORKDIR/dist
+export LD_LIBRARY_PATH=$ARROW_HOME/lib:$LD_LIBRARY_PATH
 
-git clone https://github.com/apache/arrow.git /arrow
+virtualenv $WORKDIR/venv
+source $WORKDIR/venv/bin/activate
 
-virtualenv /venv
-source /venv/bin/activate
+git clone https://github.com/apache/arrow.git $ARROW_ROOT
 
-pip install -r /arrow/python/requirements-build.txt \
-     -r /arrow/python/requirements-test.txt
+pip install -r $ARROW_ROOT/python/requirements-build.txt \
+     -r $ARROW_ROOT/python/requirements-test.txt
 
 #----------------------------------------------------------------------
 # Build C++ library


### PR DESCRIPTION
* Fedora instructions changed to podman with disclaimer added

* venv script modified to use environment variables more allowing user to put all build related files to single directory (before some were in HOME, other in / )