### PR TITLE
ARROW-8349: [CI][NIGHTLY:gandiva-jar-osx] Use latest pygit2

### DIFF
--- a/dev/tasks/gandiva-jars/travis.osx.yml
+++ b/dev/tasks/gandiva-jars/travis.osx.yml
@@ -57,7 +57,7 @@ script:
   # gandiva libraries are already built we can reset MACOS_DEPLOYMENT_TARGET to current osx version
   - if [[ $MACOSX_DEPLOYMENT_TARGET ]] ; then export MACOSX_DEPLOYMENT_TARGET=$(sw_vers -productVersion | cut -d '.' -f 1,2) ; fi
   - brew install libgit2
-  - pip3 install pygit2==1.0.3
+  - pip3 install pygit2
   - pip3 install click github3.py jinja2 jira ruamel.yaml setuptools_scm toolz
   - >
     python3 dev/tasks/crossbow.py


### PR DESCRIPTION
Now that homebrew provides compatible libgit2, we can use latest pygit2