### PR TITLE
ARROW-8351: [R][CI] Store the Rtools-built Arrow C++ library as a build artifact

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -159,6 +159,10 @@ jobs:
           rtools-version: ${{ matrix.rtools }}
       - name: Build Arrow C++
         run: msys2do ci/scripts/r_windows_build.sh
+      - uses: actions/upload-artifact@v1
+        with:
+          name: Rtools Arrow C++
+          path: libarrow.zip
       - name: Install R package dependencies
         shell: Rscript {0}
         run: |


### PR DESCRIPTION
cc @bkietz @wesm 

See build at https://github.com/nealrichardson/arrow/runs/565181788 with artifact attached.