### PR TITLE
ARROW-8213: [Python][Dataset] Opening a dataset with a local incorrect path gives confusing error message

### DIFF
--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -179,7 +179,14 @@ def _ensure_fs_and_paths(path, filesystem=None):
     # Return filesystem and list of string paths or FileSelector
     from pyarrow.fs import FileType, FileSelector
 
-    filesystem, path = _ensure_fs(filesystem, _stringify_path(path))
+    path = _stringify_path(path)
+    try:
+        scheme, _ = path.split('://', 1)  # noqa
+    except ValueError:
+        # ARROW-8213: missing scheme, assume local path
+        path = 'file://{}'.format(path)
+
+    filesystem, path = _ensure_fs(filesystem, path)
     infos = filesystem.get_file_info([path])[0]
     if infos.type == FileType.Directory:
         # for directory, pass a selector

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1042,6 +1042,13 @@ def test_open_dataset_from_source_additional_kwargs(multisourcefs):
         ds.dataset(child, format="parquet")
 
 
+def test_open_dataset_non_existing_file():
+    # ARROW-8213: Opening a dataset with a local incorrect path gives confusing
+    #             error message
+    with pytest.raises(FileNotFoundError):
+        ds.dataset('i-am-not-existing.parquet', format='parquet')
+
+
 @pytest.mark.parquet
 @pytest.mark.s3
 def test_open_dataset_from_uri_s3(s3_connection, s3_server):


### PR DESCRIPTION
Workaround until it is properly handled in the C++ implementation.