### PR TITLE
ARROW-7794: [Rust] Support releasing arrow-flight

### DIFF
--- a/rust/arrow-flight/build.rs
+++ b/rust/arrow-flight/build.rs
@@ -15,7 +15,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
+use std::env;
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::compile_protos("../../format/Flight.proto")?;
+    // The current working directory can vary depending on how the project is being
+    // built or released so we build an absolute path to the proto file
+    let mut path = env::current_dir()?;
+    while !path.ends_with("arrow") {
+        path.pop();
+    }
+    path.push("format");
+    path.push("Flight.proto");
+    tonic_build::compile_protos(path)?;
     Ok(())
 }


### PR DESCRIPTION
I tested this by running `cargo publish --dry-run --allow-dirty` from the arrow-flight directory as well as running `cargo test` from this directory and from the root of the rust workspace. 