### PR TITLE
ARROW-8358: [C++] Fix some clang-11 compiler warnings

### DIFF
--- a/cpp/src/arrow/flight/test_integration_client.cc
+++ b/cpp/src/arrow/flight/test_integration_client.cc
@@ -174,7 +174,7 @@ int main(int argc, char** argv) {
       locations = {location};
     }
 
-    for (const auto location : locations) {
+    for (const auto& location : locations) {
       std::cout << "Verifying location " << location.ToString() << std::endl;
       // 3. Stream data from the server, comparing individual batches.
       ABORT_NOT_OK(ConsumeFlightLocation(location, ticket, original_data));

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -959,14 +959,14 @@ Status MakeSparseTensorIndexCSF(FBB& fbb, const SparseCSFIndex& sparse_index,
   int64_t offset = 0;
   std::vector<flatbuf::Buffer> indptr, indices;
 
-  for (const std::shared_ptr<arrow::Tensor> tensor : sparse_index.indptr()) {
+  for (const std::shared_ptr<arrow::Tensor>& tensor : sparse_index.indptr()) {
     const int64_t size = tensor->data()->size() / indptr_elem_size;
     const int64_t padded_size = PaddedLength(tensor->data()->size(), kArrowIpcAlignment);
 
     indptr.push_back({offset, size});
     offset += padded_size;
   }
-  for (const std::shared_ptr<arrow::Tensor> tensor : sparse_index.indices()) {
+  for (const std::shared_ptr<arrow::Tensor>& tensor : sparse_index.indices()) {
     const int64_t size = tensor->data()->size() / indices_elem_size;
     const int64_t padded_size = PaddedLength(tensor->data()->size(), kArrowIpcAlignment);
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -835,10 +835,10 @@ class SparseTensorSerializer {
   }
 
   Status VisitSparseCSFIndex(const SparseCSFIndex& sparse_index) {
-    for (const std::shared_ptr<arrow::Tensor> indptr : sparse_index.indptr()) {
+    for (const std::shared_ptr<arrow::Tensor>& indptr : sparse_index.indptr()) {
       out_->body_buffers.emplace_back(indptr->data());
     }
-    for (const std::shared_ptr<arrow::Tensor> indices : sparse_index.indices()) {
+    for (const std::shared_ptr<arrow::Tensor>& indices : sparse_index.indices()) {
       out_->body_buffers.emplace_back(indices->data());
     }
     return Status::OK();


### PR DESCRIPTION
clang-11 detects unwanted copies in range-loops 