### PR TITLE
ARROW-8357: [Rust] [DataFusion] Add format dir to dockerfile for CLI

### DIFF
--- a/rust/datafusion/Dockerfile
+++ b/rust/datafusion/Dockerfile
@@ -17,6 +17,7 @@
 
 FROM rustlang/rust:nightly
 
+COPY format /arrow/format/
 COPY rust /arrow/rust/
 WORKDIR /arrow/rust/datafusion
 RUN cargo install --bin datafusion-cli --path .


### PR DESCRIPTION
Docker image for DataFusion CLI now builds as per the instructions in the repo.