### PR TITLE
ARROW-8366: [Rust] Revert "ARROW-7794: [Rust] Support releasing arrow-flight"

### DIFF
--- a/rust/arrow-flight/build.rs
+++ b/rust/arrow-flight/build.rs
@@ -15,17 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::env;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // The current working directory can vary depending on how the project is being
-    // built or released so we build an absolute path to the proto file
-    let mut path = env::current_dir()?;
-    while !path.ends_with("arrow") {
-        path.pop();
-    }
-    path.push("format");
-    path.push("Flight.proto");
-    tonic_build::compile_protos(path)?;
+    tonic_build::compile_protos("../../format/Flight.proto")?;
     Ok(())
 }


### PR DESCRIPTION
This reverts commit 528d71e8d4f73e70732ae6300bd4d48f740ceeae.

This change broke projects that depend on this crate due to the build.rs looking for a top-level "arrow" directory that doesn't exist.