### PR TITLE
ARROW-7233: [C++] Use Result<T> in remaining value-returning IPC APIs

### DIFF
--- a/c_glib/arrow-glib/reader.cpp
+++ b/c_glib/arrow-glib/reader.cpp
@@ -507,13 +507,11 @@ garrow_record_batch_file_reader_read_record_batch(GArrowRecordBatchFileReader *r
                                                   GError **error)
 {
   auto arrow_reader = garrow_record_batch_file_reader_get_raw(reader);
-  std::shared_ptr<arrow::RecordBatch> arrow_record_batch;
-  auto status = arrow_reader->ReadRecordBatch(i, &arrow_record_batch);
+  auto arrow_record_batch = arrow_reader->ReadRecordBatch(i);
 
-  if (garrow_error_check(error,
-                         status,
-                         "[record-batch-file-reader][read-record-batch]")) {
-    return garrow_record_batch_new_raw(&arrow_record_batch);
+  if (garrow::check(error, arrow_record_batch,
+                    "[record-batch-file-reader][read-record-batch]")) {
+    return garrow_record_batch_new_raw(&(*arrow_record_batch));
   } else {
     return NULL;
   }

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -75,8 +75,8 @@ class IpcScanTask : public ScanTask {
           return nullptr;
         }
 
-        std::shared_ptr<RecordBatch> batch;
-        RETURN_NOT_OK(reader_->ReadRecordBatch(i_++, &batch));
+        ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> batch,
+                              reader_->ReadRecordBatch(i_++));
         return projector_.Project(*batch, pool_);
       }
 

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -38,6 +38,7 @@
 #include "arrow/ipc/writer.h"
 #include "arrow/memory_pool.h"
 #include "arrow/record_batch.h"
+#include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/logging.h"
@@ -279,7 +280,15 @@ class GrpcIpcMessageReader : public ipc::MessageReader {
         stream_(std::move(stream)),
         stream_finished_(false) {}
 
-  Status ReadNextMessage(std::unique_ptr<ipc::Message>* out) override {
+  ::arrow::Result<std::unique_ptr<ipc::Message>> ReadNextMessage() override {
+    std::unique_ptr<ipc::Message> out;
+    RETURN_NOT_OK(GetNextMessage(&out));
+    return out;
+  }
+
+ protected:
+  Status GetNextMessage(std::unique_ptr<ipc::Message>* out) {
+    // TODO: Use Result APIs
     if (stream_finished_) {
       *out = nullptr;
       flight_reader_->last_app_metadata_ = nullptr;
@@ -303,7 +312,6 @@ class GrpcIpcMessageReader : public ipc::MessageReader {
     return Status::OK();
   }
 
- protected:
   Status OverrideWithServerError(Status&& st) {
     // Get the gRPC status if not OK, to propagate any server error message
     RETURN_NOT_OK(internal::FromGrpcStatus(stream_->Finish(), &rpc_->context));
@@ -484,8 +492,8 @@ Status GrpcStreamWriter::Open(
   std::unique_ptr<GrpcStreamWriter> result(new GrpcStreamWriter(writer));
   std::unique_ptr<ipc::internal::IpcPayloadWriter> payload_writer(new DoPutPayloadWriter(
       descriptor, std::move(rpc), std::move(response), read_mutex, writer, result.get()));
-  RETURN_NOT_OK(ipc::internal::OpenRecordBatchWriter(std::move(payload_writer), schema,
-                                                     &result->batch_writer_));
+  ARROW_ASSIGN_OR_RAISE(result->batch_writer_, ipc::internal::OpenRecordBatchWriter(
+                                                   std::move(payload_writer), schema));
   *out = std::move(result);
   return Status::OK();
 }

--- a/cpp/src/arrow/flight/internal.cc
+++ b/cpp/src/arrow/flight/internal.cc
@@ -381,7 +381,7 @@ Status FromProto(const pb::FlightData& pb_data, FlightDescriptor* descriptor,
   if (header_buf == nullptr || body_buf == nullptr) {
     return Status::UnknownError("Could not create buffers from protobuf");
   }
-  return ipc::Message::Open(header_buf, body_buf, message);
+  return ipc::Message::Open(header_buf, body_buf).Value(message);
 }
 
 // FlightEndpoint
@@ -466,10 +466,10 @@ Status FromProto(const pb::SchemaResult& pb_result, std::string* result) {
 
 Status SchemaToString(const Schema& schema, std::string* out) {
   // TODO(wesm): Do we care about better memory efficiency here?
-  std::shared_ptr<Buffer> serialized_schema;
   ipc::DictionaryMemo unused_dict_memo;
-  RETURN_NOT_OK(ipc::SerializeSchema(schema, &unused_dict_memo, default_memory_pool(),
-                                     &serialized_schema));
+  ARROW_ASSIGN_OR_RAISE(
+      std::shared_ptr<Buffer> serialized_schema,
+      ipc::SerializeSchema(schema, &unused_dict_memo, default_memory_pool()));
   *out = std::string(reinterpret_cast<const char*>(serialized_schema->data()),
                      static_cast<size_t>(serialized_schema->size()));
   return Status::OK();

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -344,7 +344,7 @@ grpc::Status FlightDataDeserialize(ByteBuffer* buffer, FlightData* out) {
 }
 
 Status FlightData::OpenMessage(std::unique_ptr<ipc::Message>* message) {
-  return ipc::Message::Open(metadata, body, message);
+  return ipc::Message::Open(metadata, body).Value(message);
 }
 
 // The pointer bitcast hack below causes legitimate warnings, silence them.

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -99,7 +99,17 @@ class FlightIpcMessageReader : public ipc::MessageReader {
       std::shared_ptr<Buffer>* last_metadata)
       : reader_(reader), app_metadata_(last_metadata) {}
 
-  Status ReadNextMessage(std::unique_ptr<ipc::Message>* out) override {
+  const FlightDescriptor& descriptor() const { return descriptor_; }
+
+  ::arrow::Result<std::unique_ptr<ipc::Message>> ReadNextMessage() override {
+    std::unique_ptr<ipc::Message> out;
+    RETURN_NOT_OK(GetNextMessage(&out));
+    return out;
+  }
+
+ protected:
+  Status GetNextMessage(std::unique_ptr<ipc::Message>* out) {
+    // TODO: Migrate to Result APIs
     if (stream_finished_) {
       *out = nullptr;
       *app_metadata_ = nullptr;
@@ -131,9 +141,6 @@ class FlightIpcMessageReader : public ipc::MessageReader {
     return Status::OK();
   }
 
-  const FlightDescriptor& descriptor() const { return descriptor_; }
-
- protected:
   grpc::ServerReaderWriter<pb::PutResult, pb::FlightData>* reader_;
   bool stream_finished_ = false;
   bool first_message_ = true;

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -718,7 +718,7 @@ class ReaderV2 : public Reader {
     ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchFileReader::Open(source_, options));
     std::vector<std::shared_ptr<RecordBatch>> batches(reader->num_record_batches());
     for (int i = 0; i < reader->num_record_batches(); ++i) {
-      RETURN_NOT_OK(reader->ReadRecordBatch(i, &batches[i]));
+      ARROW_ASSIGN_OR_RAISE(batches[i], reader->ReadRecordBatch(i));
     }
 
     // XXX: Handle included_fields in RecordBatchFileReader::schema

--- a/cpp/src/arrow/ipc/file_to_stream.cc
+++ b/cpp/src/arrow/ipc/file_to_stream.cc
@@ -40,8 +40,7 @@ Status ConvertToStream(const char* path) {
   ARROW_ASSIGN_OR_RAISE(auto reader, ipc::RecordBatchFileReader::Open(in_file.get()));
   ARROW_ASSIGN_OR_RAISE(auto writer, ipc::NewStreamWriter(&sink, reader->schema()));
   for (int i = 0; i < reader->num_record_batches(); ++i) {
-    std::shared_ptr<RecordBatch> chunk;
-    RETURN_NOT_OK(reader->ReadRecordBatch(i, &chunk));
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> chunk, reader->ReadRecordBatch(i));
     RETURN_NOT_OK(writer->WriteRecordBatch(*chunk));
   }
   return writer->Close();

--- a/cpp/src/arrow/ipc/json_integration_test.cc
+++ b/cpp/src/arrow/ipc/json_integration_test.cc
@@ -97,8 +97,7 @@ static Status ConvertArrowToJson(const std::string& arrow_path,
   RETURN_NOT_OK(internal::json::JsonWriter::Open(reader->schema(), &writer));
 
   for (int i = 0; i < reader->num_record_batches(); ++i) {
-    std::shared_ptr<RecordBatch> batch;
-    RETURN_NOT_OK(reader->ReadRecordBatch(i, &batch));
+    ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> batch, reader->ReadRecordBatch(i));
     RETURN_NOT_OK(writer->WriteRecordBatch(*batch));
   }
 
@@ -152,7 +151,7 @@ static Status ValidateArrowVsJson(const std::string& arrow_path,
   std::shared_ptr<RecordBatch> json_batch;
   for (int i = 0; i < json_nbatches; ++i) {
     RETURN_NOT_OK(json_reader->ReadRecordBatch(i, &json_batch));
-    RETURN_NOT_OK(arrow_reader->ReadRecordBatch(i, &arrow_batch));
+    ARROW_ASSIGN_OR_RAISE(arrow_batch, arrow_reader->ReadRecordBatch(i));
     Status valid_st = json_batch->ValidateFull();
     if (!valid_st.ok()) {
       return Status::Invalid("JSON record batch ", i, " did not validate:\n",

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -45,9 +45,8 @@ namespace ipc {
 
 class Message::MessageImpl {
  public:
-  explicit MessageImpl(const std::shared_ptr<Buffer>& metadata,
-                       const std::shared_ptr<Buffer>& body)
-      : metadata_(metadata), message_(nullptr), body_(body) {}
+  explicit MessageImpl(std::shared_ptr<Buffer> metadata, std::shared_ptr<Buffer> body)
+      : metadata_(std::move(metadata)), message_(nullptr), body_(std::move(body)) {}
 
   Status Open() {
     RETURN_NOT_OK(
@@ -112,15 +111,15 @@ class Message::MessageImpl {
   std::shared_ptr<Buffer> body_;
 };
 
-Message::Message(const std::shared_ptr<Buffer>& metadata,
-                 const std::shared_ptr<Buffer>& body) {
-  impl_.reset(new MessageImpl(metadata, body));
+Message::Message(std::shared_ptr<Buffer> metadata, std::shared_ptr<Buffer> body) {
+  impl_.reset(new MessageImpl(std::move(metadata), std::move(body)));
 }
 
-Status Message::Open(const std::shared_ptr<Buffer>& metadata,
-                     const std::shared_ptr<Buffer>& body, std::unique_ptr<Message>* out) {
-  out->reset(new Message(metadata, body));
-  return (*out)->impl_->Open();
+Result<std::unique_ptr<Message>> Message::Open(std::shared_ptr<Buffer> metadata,
+                                               std::shared_ptr<Buffer> body) {
+  std::unique_ptr<Message> result(new Message(std::move(metadata), std::move(body)));
+  RETURN_NOT_OK(result->impl_->Open());
+  return result;
 }
 
 Message::~Message() {}
@@ -182,8 +181,8 @@ Status CheckMetadataAndGetBodyLength(const Buffer& metadata, int64_t* body_lengt
   return Status::OK();
 }
 
-Status Message::ReadFrom(std::shared_ptr<Buffer> metadata, io::InputStream* stream,
-                         std::unique_ptr<Message>* out) {
+Result<std::unique_ptr<Message>> Message::ReadFrom(std::shared_ptr<Buffer> metadata,
+                                                   io::InputStream* stream) {
   RETURN_NOT_OK(MaybeAlignMetadata(&metadata));
   int64_t body_length = -1;
   RETURN_NOT_OK(CheckMetadataAndGetBodyLength(*metadata, &body_length));
@@ -194,11 +193,12 @@ Status Message::ReadFrom(std::shared_ptr<Buffer> metadata, io::InputStream* stre
                            " bytes for message body, got ", body->size());
   }
 
-  return Message::Open(metadata, body, out);
+  return Message::Open(metadata, body);
 }
 
-Status Message::ReadFrom(const int64_t offset, std::shared_ptr<Buffer> metadata,
-                         io::RandomAccessFile* file, std::unique_ptr<Message>* out) {
+Result<std::unique_ptr<Message>> Message::ReadFrom(const int64_t offset,
+                                                   std::shared_ptr<Buffer> metadata,
+                                                   io::RandomAccessFile* file) {
   RETURN_NOT_OK(MaybeAlignMetadata(&metadata));
   int64_t body_length = -1;
   RETURN_NOT_OK(CheckMetadataAndGetBodyLength(*metadata, &body_length));
@@ -209,7 +209,7 @@ Status Message::ReadFrom(const int64_t offset, std::shared_ptr<Buffer> metadata,
                            " bytes for message body, got ", body->size());
   }
 
-  return Message::Open(metadata, body, out);
+  return Message::Open(metadata, body);
 }
 
 Status WritePadding(io::OutputStream* stream, int64_t nbytes) {
@@ -261,8 +261,8 @@ std::string FormatMessageType(Message::Type type) {
   return "unknown";
 }
 
-Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile* file,
-                   std::unique_ptr<Message>* message) {
+Result<std::unique_ptr<Message>> ReadMessage(int64_t offset, int32_t metadata_length,
+                                             io::RandomAccessFile* file) {
   if (static_cast<size_t>(metadata_length) < sizeof(int32_t)) {
     return Status::Invalid("metadata_length should be at least 4");
   }
@@ -309,7 +309,7 @@ Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile
 
   std::shared_ptr<Buffer> metadata =
       SliceBuffer(buffer, prefix_size, buffer->size() - prefix_size);
-  return Message::ReadFrom(offset + metadata_length, metadata, file, message);
+  return Message::ReadFrom(offset + metadata_length, metadata, file);
 }
 
 Status AlignStream(io::InputStream* stream, int32_t alignment) {
@@ -336,9 +336,7 @@ Status CheckAligned(io::FileInterface* stream, int32_t alignment) {
   }
 }
 
-namespace {
-
-Result<std::unique_ptr<Message>> DoReadMessage(io::InputStream* file, MemoryPool* pool) {
+Result<std::unique_ptr<Message>> ReadMessage(io::InputStream* file, MemoryPool* pool) {
   int32_t continuation = 0;
   ARROW_ASSIGN_OR_RAISE(int64_t bytes_read, file->Read(sizeof(int32_t), &continuation));
 
@@ -374,19 +372,7 @@ Result<std::unique_ptr<Message>> DoReadMessage(io::InputStream* file, MemoryPool
   ARROW_ASSIGN_OR_RAISE(metadata,
                         Buffer::ViewOrCopy(metadata, CPUDevice::memory_manager(pool)));
 
-  std::unique_ptr<Message> message;
-  RETURN_NOT_OK(Message::ReadFrom(metadata, file, &message));
-  return std::move(message);
-}
-
-}  // namespace
-
-Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* out) {
-  return DoReadMessage(file, default_memory_pool()).Value(out);
-}
-
-Result<std::unique_ptr<Message>> ReadMessage(io::InputStream* file, MemoryPool* pool) {
-  return DoReadMessage(file, pool);
+  return Message::ReadFrom(metadata, file);
 }
 
 Status WriteMessage(const Buffer& message, const IpcWriteOptions& options,
@@ -436,9 +422,7 @@ class InputStreamMessageReader : public MessageReader {
 
   ~InputStreamMessageReader() {}
 
-  Status ReadNextMessage(std::unique_ptr<Message>* message) {
-    return ReadMessage(stream_, message);
-  }
+  Result<std::unique_ptr<Message>> ReadNextMessage() { return ReadMessage(stream_); }
 
  private:
   io::InputStream* stream_;
@@ -452,6 +436,18 @@ std::unique_ptr<MessageReader> MessageReader::Open(io::InputStream* stream) {
 std::unique_ptr<MessageReader> MessageReader::Open(
     const std::shared_ptr<io::InputStream>& owned_stream) {
   return std::unique_ptr<MessageReader>(new InputStreamMessageReader(owned_stream));
+}
+
+// ----------------------------------------------------------------------
+// Deprecated functions
+
+Status ReadMessage(int64_t offset, int32_t metadata_length, io::RandomAccessFile* file,
+                   std::unique_ptr<Message>* message) {
+  return ReadMessage(offset, metadata_length, file).Value(message);
+}
+
+Status ReadMessage(io::InputStream* file, std::unique_ptr<Message>* out) {
+  return ReadMessage(file, default_memory_pool()).Value(out);
 }
 
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -119,7 +119,7 @@ Result<std::unique_ptr<Message>> Message::Open(std::shared_ptr<Buffer> metadata,
                                                std::shared_ptr<Buffer> body) {
   std::unique_ptr<Message> result(new Message(std::move(metadata), std::move(body)));
   RETURN_NOT_OK(result->impl_->Open());
-  return result;
+  return std::move(result);
 }
 
 Message::~Message() {}

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -185,9 +185,13 @@ class ARROW_EXPORT RecordBatchFileReader {
   /// if the input source supports zero-copy.
   ///
   /// \param[in] i the index of the record batch to return
-  /// \param[out] batch the read batch
-  /// \return Status
-  virtual Status ReadRecordBatch(int i, std::shared_ptr<RecordBatch>* batch) = 0;
+  /// \return the read batch
+  virtual Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(int i) = 0;
+
+  ARROW_DEPRECATED("Use version with Result return value")
+  Status ReadRecordBatch(int i, std::shared_ptr<RecordBatch>* batch) {
+    return ReadRecordBatch(i).Value(batch);
+  }
 };
 
 // Generic read functions; does not copy data if the input supports zero copy reads

--- a/cpp/src/arrow/ipc/stream_to_file.cc
+++ b/cpp/src/arrow/ipc/stream_to_file.cc
@@ -40,7 +40,7 @@ Status ConvertToFile() {
   ARROW_ASSIGN_OR_RAISE(auto writer, NewFileWriter(&sink, reader->schema()));
   std::shared_ptr<RecordBatch> batch;
   while (true) {
-    RETURN_NOT_OK(reader->ReadNext(&batch));
+    ARROW_ASSIGN_OR_RAISE(batch, reader->Next());
     if (batch == nullptr) break;
     RETURN_NOT_OK(writer->WriteRecordBatch(*batch));
   }

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -79,7 +79,7 @@ class ARROW_EXPORT RecordBatchWriter {
   /// \return Status
   virtual Status Close() = 0;
 
-  ARROW_DEPRECATED("No-op. Pass MemoryPool using IpcWriteOptions")
+  ARROW_DEPRECATED("Deprecated in 0.17.0. No-op. Pass MemoryPool using IpcWriteOptions")
   void set_memory_pool(MemoryPool* pool) {}
 };
 
@@ -130,11 +130,10 @@ Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
 ///
 /// \param[in] batch the record batch
 /// \param[in] options the IpcWriteOptions to use for serialization
-/// \param[out] out the serialized message
-/// \return Status
+/// \return the serialized message
 ARROW_EXPORT
-Status SerializeRecordBatch(const RecordBatch& batch, const IpcWriteOptions& options,
-                            std::shared_ptr<Buffer>* out);
+Result<std::shared_ptr<Buffer>> SerializeRecordBatch(const RecordBatch& batch,
+                                                     const IpcWriteOptions& options);
 
 /// \brief Serialize record batch as encapsulated IPC message in a new buffer
 ///
@@ -163,11 +162,11 @@ Status SerializeRecordBatch(const RecordBatch& batch, const IpcWriteOptions& opt
 /// \param[in] schema the schema to write
 /// \param[in] dictionary_memo a DictionaryMemo for recording dictionary ids
 /// \param[in] pool a MemoryPool to allocate memory from
-/// \param[out] out the serialized schema
-/// \return Status
+/// \return the serialized schema
 ARROW_EXPORT
-Status SerializeSchema(const Schema& schema, DictionaryMemo* dictionary_memo,
-                       MemoryPool* pool, std::shared_ptr<Buffer>* out);
+Result<std::shared_ptr<Buffer>> SerializeSchema(const Schema& schema,
+                                                DictionaryMemo* dictionary_memo,
+                                                MemoryPool* pool = default_memory_pool());
 
 /// \brief Write multiple record batches to OutputStream, including schema
 /// \param[in] batches a vector of batches. Must all have same schema
@@ -199,11 +198,9 @@ Status GetTensorSize(const Tensor& tensor, int64_t* size);
 ///
 /// \param[in] tensor the Tensor to write
 /// \param[in] pool MemoryPool to allocate space for metadata
-/// \param[out] out the resulting Message
-/// \return Status
+/// \return the resulting Message
 ARROW_EXPORT
-Status GetTensorMessage(const Tensor& tensor, MemoryPool* pool,
-                        std::unique_ptr<Message>* out);
+Result<std::unique_ptr<Message>> GetTensorMessage(const Tensor& tensor, MemoryPool* pool);
 
 /// \brief Write arrow::Tensor as a contiguous message.
 ///
@@ -235,11 +232,10 @@ Status WriteTensor(const Tensor& tensor, io::OutputStream* dst, int32_t* metadat
 ///
 /// \param[in] sparse_tensor the SparseTensor to write
 /// \param[in] pool MemoryPool to allocate space for metadata
-/// \param[out] out the resulting Message
-/// \return Status
+/// \return the resulting Message
 ARROW_EXPORT
-Status GetSparseTensorMessage(const SparseTensor& sparse_tensor, MemoryPool* pool,
-                              std::unique_ptr<Message>* out);
+Result<std::unique_ptr<Message>> GetSparseTensorMessage(const SparseTensor& sparse_tensor,
+                                                        MemoryPool* pool);
 
 /// \brief EXPERIMENTAL: Write arrow::SparseTensor as a contiguous message. The metadata,
 /// sparse index, and body are written assuming 64-byte alignment. It is the
@@ -286,10 +282,6 @@ class ARROW_EXPORT IpcPayloadWriter {
 /// \param[in] schema the schema of the record batches to be written
 /// \param[out] out the created RecordBatchWriter
 /// \return Status
-ARROW_EXPORT
-Status OpenRecordBatchWriter(std::unique_ptr<IpcPayloadWriter> sink,
-                             const std::shared_ptr<Schema>& schema,
-                             std::unique_ptr<RecordBatchWriter>* out);
 
 /// Create a new RecordBatchWriter from IpcPayloadWriter and schema.
 ///
@@ -300,7 +292,7 @@ Status OpenRecordBatchWriter(std::unique_ptr<IpcPayloadWriter> sink,
 ARROW_EXPORT
 Result<std::unique_ptr<RecordBatchWriter>> OpenRecordBatchWriter(
     std::unique_ptr<IpcPayloadWriter> sink, const std::shared_ptr<Schema>& schema,
-    const IpcWriteOptions& options);
+    const IpcWriteOptions& options = IpcWriteOptions::Defaults());
 
 /// \brief Compute IpcPayload for the given schema
 /// \param[in] schema the Schema that is being serialized
@@ -360,7 +352,7 @@ class ARROW_EXPORT RecordBatchStreamWriter : public RecordBatchWriter {
   /// \param[in] schema the schema of the record batches to be written
   /// \param[out] out the created stream writer
   /// \return Status
-  ARROW_DEPRECATED("Use arrow::ipc::NewStreamWriter()")
+  ARROW_DEPRECATED("Deprecated in 0.17.0. Use arrow::ipc::NewStreamWriter()")
   static Status Open(io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
                      std::shared_ptr<RecordBatchWriter>* out);
 
@@ -370,11 +362,11 @@ class ARROW_EXPORT RecordBatchStreamWriter : public RecordBatchWriter {
   /// \param[in] sink output stream to write to
   /// \param[in] schema the schema of the record batches to be written
   /// \return Result<std::shared_ptr<RecordBatchWriter>>
-  ARROW_DEPRECATED("Use arrow::ipc::NewStreamWriter()")
+  ARROW_DEPRECATED("Deprecated in 0.17.0. Use arrow::ipc::NewStreamWriter()")
   static Result<std::shared_ptr<RecordBatchWriter>> Open(
       io::OutputStream* sink, const std::shared_ptr<Schema>& schema);
 
-  ARROW_DEPRECATED("Use arrow::ipc::NewStreamWriter()")
+  ARROW_DEPRECATED("Deprecated in 0.17.0. Use arrow::ipc::NewStreamWriter()")
   static Result<std::shared_ptr<RecordBatchWriter>> Open(
       io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
       const IpcWriteOptions& options);
@@ -393,7 +385,7 @@ class ARROW_EXPORT RecordBatchFileWriter : public RecordBatchStreamWriter {
   /// \param[in] schema the schema of the record batches to be written
   /// \param[out] out the created stream writer
   /// \return Status
-  ARROW_DEPRECATED("Use arrow::ipc::NewFileWriter")
+  ARROW_DEPRECATED("Deprecated in 0.17.0. Use arrow::ipc::NewFileWriter")
   static Status Open(io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
                      std::shared_ptr<RecordBatchWriter>* out);
 
@@ -402,18 +394,18 @@ class ARROW_EXPORT RecordBatchFileWriter : public RecordBatchStreamWriter {
   /// \param[in] sink output stream to write to
   /// \param[in] schema the schema of the record batches to be written
   /// \return Result<std::shared_ptr<RecordBatchWriter>>
-  ARROW_DEPRECATED("Use arrow::ipc::NewFileWriter")
+  ARROW_DEPRECATED("Deprecated in 0.17.0. Use arrow::ipc::NewFileWriter")
   static Result<std::shared_ptr<RecordBatchWriter>> Open(
       io::OutputStream* sink, const std::shared_ptr<Schema>& schema);
 
-  ARROW_DEPRECATED("Use arrow::ipc::NewFileWriter")
+  ARROW_DEPRECATED("Deprecated in 0.17.0. Use arrow::ipc::NewFileWriter")
   static Result<std::shared_ptr<RecordBatchWriter>> Open(
       io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
       const IpcWriteOptions& options);
 };
 
 ARROW_DEPRECATED(
-    "Use version without MemoryPool argument "
+    "Deprecated in 0.17.0. Use version without MemoryPool argument "
     "(use IpcWriteOptions to pass MemoryPool")
 ARROW_EXPORT
 Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
@@ -421,25 +413,55 @@ Status WriteRecordBatch(const RecordBatch& batch, int64_t buffer_start_offset,
                         int64_t* body_length, const IpcWriteOptions& options,
                         MemoryPool* pool);
 
-ARROW_DEPRECATED("Use version with IpcWriteOptions")
+ARROW_DEPRECATED("Deprecated in 0.17.0. Use Result-returning version")
+ARROW_EXPORT
+Status SerializeRecordBatch(const RecordBatch& batch, const IpcWriteOptions& options,
+                            std::shared_ptr<Buffer>* out);
+
+ARROW_DEPRECATED(
+    "Deprecated in 0.17.0. Use Result-returning version with "
+    "IpcWriteOptions")
 ARROW_EXPORT
 Status SerializeRecordBatch(const RecordBatch& batch, MemoryPool* pool,
                             std::shared_ptr<Buffer>* out);
 
-ARROW_DEPRECATED("Use version with IpcWriteOptions")
+ARROW_DEPRECATED(
+    "Deprecated in 0.17.0. Use Result-returning version with "
+    "IpcWriteOptions")
 ARROW_EXPORT
 Status SerializeRecordBatch(const RecordBatch& batch, MemoryPool* pool,
                             io::OutputStream* out);
 
+ARROW_DEPRECATED("Deprecated in 0.17.0. Use Result-returning version")
+ARROW_EXPORT
+Status SerializeSchema(const Schema& schema, DictionaryMemo* dictionary_memo,
+                       MemoryPool* pool, std::shared_ptr<Buffer>* out);
+
+ARROW_DEPRECATED("Deprecated in 0.17.0. Use Result-returning version")
+ARROW_EXPORT
+Status GetTensorMessage(const Tensor& tensor, MemoryPool* pool,
+                        std::unique_ptr<Message>* out);
+
+ARROW_DEPRECATED("Deprecated in 0.17.0. Use Result-returning version")
+ARROW_EXPORT
+Status GetSparseTensorMessage(const SparseTensor& sparse_tensor, MemoryPool* pool,
+                              std::unique_ptr<Message>* out);
+
 namespace internal {
 
-ARROW_DEPRECATED("Pass MemoryPool with IpcWriteOptions")
+ARROW_DEPRECATED("Deprecated in 0.17.0. Use Result-returning version")
+ARROW_EXPORT
+Status OpenRecordBatchWriter(std::unique_ptr<IpcPayloadWriter> sink,
+                             const std::shared_ptr<Schema>& schema,
+                             std::unique_ptr<RecordBatchWriter>* out);
+
+ARROW_DEPRECATED("Deprecated in 0.17.0. Pass MemoryPool with IpcWriteOptions")
 ARROW_EXPORT
 Status GetDictionaryPayload(int64_t id, const std::shared_ptr<Array>& dictionary,
                             const IpcWriteOptions& options, MemoryPool* pool,
                             IpcPayload* payload);
 
-ARROW_DEPRECATED("Pass MemoryPool with IpcWriteOptions")
+ARROW_DEPRECATED("Deprecated in 0.17.0. Pass MemoryPool with IpcWriteOptions")
 ARROW_EXPORT
 Status GetRecordBatchPayload(const RecordBatch& batch, const IpcWriteOptions& options,
                              MemoryPool* pool, IpcPayload* out);

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -739,8 +739,8 @@ Status SerializedPyObject::GetComponents(MemoryPool* memory_pool, PyObject** out
 
   // For each tensor, get a metadata buffer and a buffer for the body
   for (const auto& tensor : this->tensors) {
-    std::unique_ptr<ipc::Message> message;
-    RETURN_NOT_OK(ipc::GetTensorMessage(*tensor, memory_pool, &message));
+    ARROW_ASSIGN_OR_RAISE(std::unique_ptr<ipc::Message> message,
+                          ipc::GetTensorMessage(*tensor, memory_pool));
     RETURN_NOT_OK(PushBuffer(message->metadata()));
     RETURN_NOT_OK(PushBuffer(message->body()));
   }
@@ -758,8 +758,8 @@ Status SerializedPyObject::GetComponents(MemoryPool* memory_pool, PyObject** out
 
   // For each ndarray, get a metadata buffer and a buffer for the body
   for (const auto& ndarray : this->ndarrays) {
-    std::unique_ptr<ipc::Message> message;
-    RETURN_NOT_OK(ipc::GetTensorMessage(*ndarray, memory_pool, &message));
+    ARROW_ASSIGN_OR_RAISE(std::unique_ptr<ipc::Message> message,
+                          ipc::GetTensorMessage(*ndarray, memory_pool));
     RETURN_NOT_OK(PushBuffer(message->metadata()));
     RETURN_NOT_OK(PushBuffer(message->body()));
   }

--- a/cpp/src/jni/orc/jni_wrapper.cpp
+++ b/cpp/src/jni/orc/jni_wrapper.cpp
@@ -226,16 +226,15 @@ Java_org_apache_arrow_adapter_orc_OrcStripeReaderJniWrapper_getSchema(JNIEnv* en
 
   auto schema = stripe_reader->schema();
 
-  std::shared_ptr<arrow::Buffer> out;
-  auto status =
-      arrow::ipc::SerializeSchema(*schema, nullptr, arrow::default_memory_pool(), &out);
-  if (!status.ok()) {
+  auto maybe_buffer = arrow::ipc::SerializeSchema(*schema, nullptr);
+  if (!maybe_buffer.ok()) {
     return nullptr;
   }
+  auto buffer = *std::move(maybe_buffer);
 
-  jbyteArray ret = env->NewByteArray(out->size());
-  auto src = reinterpret_cast<const jbyte*>(out->data());
-  env->SetByteArrayRegion(ret, 0, out->size(), src);
+  jbyteArray ret = env->NewByteArray(buffer->size());
+  auto src = reinterpret_cast<const jbyte*>(buffer->data());
+  env->SetByteArrayRegion(ret, 0, buffer->size(), src);
   return ret;
 }
 

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -763,8 +763,8 @@ Status GetSchemaMetadata(const ::arrow::Schema& schema, ::arrow::MemoryPool* poo
   }
 
   ::arrow::ipc::DictionaryMemo dict_memo;
-  std::shared_ptr<Buffer> serialized;
-  RETURN_NOT_OK(::arrow::ipc::SerializeSchema(schema, &dict_memo, pool, &serialized));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> serialized,
+                        ::arrow::ipc::SerializeSchema(schema, &dict_memo, pool));
 
   // The serialized schema is not UTF-8, which is required for Thrift
   std::string schema_as_string = serialized->ToString();

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1225,9 +1225,8 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         int64_t body_length
 
     cdef cppclass CMessage" arrow::ipc::Message":
-        CStatus Open(const shared_ptr[CBuffer]& metadata,
-                     const shared_ptr[CBuffer]& body,
-                     unique_ptr[CMessage]* out)
+        CResult[unique_ptr[CMessage]] Open(shared_ptr[CBuffer] metadata,
+                                           shared_ptr[CBuffer] body)
 
         shared_ptr[CBuffer] body()
 
@@ -1247,7 +1246,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         @staticmethod
         unique_ptr[CMessageReader] Open(const shared_ptr[CInputStream]& stream)
 
-        CStatus ReadNextMessage(unique_ptr[CMessage]* out)
+        CResult[unique_ptr[CMessage]] ReadNextMessage()
 
     cdef cppclass CRecordBatchWriter" arrow::ipc::RecordBatchWriter":
         CStatus Close()
@@ -1289,7 +1288,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
 
         int num_record_batches()
 
-        CStatus ReadRecordBatch(int i, shared_ptr[CRecordBatch]* batch)
+        CResult[shared_ptr[CRecordBatch]] ReadRecordBatch(int i)
 
     CResult[unique_ptr[CMessage]] ReadMessage(CInputStream* stream,
                                               CMemoryPool* pool)
@@ -1308,13 +1307,12 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         CDictionaryMemo* dictionary_memo,
         const CIpcReadOptions& options)
 
-    CStatus SerializeSchema(const CSchema& schema,
-                            CDictionaryMemo* dictionary_memo,
-                            CMemoryPool* pool, shared_ptr[CBuffer]* out)
+    CResult[shared_ptr[CBuffer]] SerializeSchema(
+        const CSchema& schema, CDictionaryMemo* dictionary_memo,
+        CMemoryPool* pool)
 
-    CStatus SerializeRecordBatch(const CRecordBatch& schema,
-                                 const CIpcWriteOptions& options,
-                                 shared_ptr[CBuffer]* out)
+    CResult[shared_ptr[CBuffer]] SerializeRecordBatch(
+        const CRecordBatch& schema, const CIpcWriteOptions& options)
 
     CResult[shared_ptr[CSchema]] ReadSchema(CInputStream* stream,
                                             CDictionaryMemo* dictionary_memo)

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -164,7 +164,8 @@ cdef class MessageReader:
         cdef Message result = Message.__new__(Message)
 
         with nogil:
-            check_status(self.reader.get().ReadNextMessage(&result.message))
+            result.message = move(GetResultValue(self.reader.get()
+                                                 .ReadNextMessage()))
 
         if result.message.get() == NULL:
             raise StopIteration
@@ -420,7 +421,7 @@ cdef class _RecordBatchFileReader:
             raise ValueError('Batch number {0} out of range'.format(i))
 
         with nogil:
-            check_status(self.reader.get().ReadRecordBatch(i, &batch))
+            batch = GetResultValue(self.reader.get().ReadRecordBatch(i))
 
         return pyarrow_wrap_batch(batch)
 
@@ -442,7 +443,8 @@ cdef class _RecordBatchFileReader:
         batches.resize(nbatches)
         with nogil:
             for i in range(nbatches):
-                check_status(self.reader.get().ReadRecordBatch(i, &batches[i]))
+                batches[i] = GetResultValue(self.reader.get()
+                                            .ReadRecordBatch(i))
             table = GetResultValue(
                 CTable.FromRecordBatches(self.schema.sp_schema, move(batches)))
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -765,8 +765,8 @@ cdef class RecordBatch(_PandasConvertible):
         options.memory_pool = maybe_unbox_memory_pool(memory_pool)
 
         with nogil:
-            check_status(SerializeRecordBatch(deref(self.batch),
-                                              options, &buffer))
+            buffer = GetResultValue(
+                SerializeRecordBatch(deref(self.batch), options))
         return pyarrow_wrap_buffer(buffer)
 
     def slice(self, offset=0, length=None):

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1531,8 +1531,8 @@ cdef class Schema:
             arg_dict_memo = &temp_memo
 
         with nogil:
-            check_status(SerializeSchema(deref(self.schema), arg_dict_memo,
-                                         pool, &buffer))
+            buffer = GetResultValue(SerializeSchema(deref(self.schema),
+                                                    arg_dict_memo, pool))
         return pyarrow_wrap_buffer(buffer)
 
     def remove_metadata(self):

--- a/r/src/message.cpp
+++ b/r/src/message.cpp
@@ -89,17 +89,13 @@ std::unique_ptr<arrow::ipc::MessageReader> ipc___MessageReader__Open(
 // [[arrow::export]]
 std::unique_ptr<arrow::ipc::Message> ipc___MessageReader__ReadNextMessage(
     const std::unique_ptr<arrow::ipc::MessageReader>& reader) {
-  std::unique_ptr<arrow::ipc::Message> message;
-  STOP_IF_NOT_OK(reader->ReadNextMessage(&message));
-  return message;
+  return VALUE_OR_STOP(reader->ReadNextMessage());
 }
 
 // [[arrow::export]]
 std::unique_ptr<arrow::ipc::Message> ipc___ReadMessage(
     const std::shared_ptr<arrow::io::InputStream>& stream) {
-  std::unique_ptr<arrow::ipc::Message> message;
-  STOP_IF_NOT_OK(arrow::ipc::ReadMessage(stream.get(), &message));
-  return message;
+  return VALUE_OR_STOP(arrow::ipc::ReadMessage(stream.get()));
 }
 
 #endif

--- a/r/src/recordbatchreader.cpp
+++ b/r/src/recordbatchreader.cpp
@@ -75,11 +75,10 @@ int ipc___RecordBatchFileReader__num_record_batches(
 // [[arrow::export]]
 std::shared_ptr<arrow::RecordBatch> ipc___RecordBatchFileReader__ReadRecordBatch(
     const std::shared_ptr<arrow::ipc::RecordBatchFileReader>& reader, int i) {
-  std::shared_ptr<arrow::RecordBatch> batch;
-  if (i >= 0 && i < reader->num_record_batches()) {
-    STOP_IF_NOT_OK(reader->ReadRecordBatch(i, &batch));
+  if (i < 0 && i >= reader->num_record_batches()) {
+    Rcpp::stop("Record batch index out of bounds");
   }
-  return batch;
+  return VALUE_OR_STOP(reader->ReadRecordBatch(i));
 }
 
 // [[arrow::export]]
@@ -95,7 +94,7 @@ std::shared_ptr<arrow::Table> Table__from_RecordBatchFileReader(
   int num_batches = reader->num_record_batches();
   std::vector<std::shared_ptr<arrow::RecordBatch>> batches(num_batches);
   for (int i = 0; i < num_batches; i++) {
-    STOP_IF_NOT_OK(reader->ReadRecordBatch(i, &batches[i]));
+    batches[i] = VALUE_OR_STOP(reader->ReadRecordBatch(i));
   }
 
   return VALUE_OR_STOP(arrow::Table::FromRecordBatches(std::move(batches)));
@@ -122,7 +121,7 @@ std::vector<std::shared_ptr<arrow::RecordBatch>> ipc___RecordBatchFileReader__ba
   std::vector<std::shared_ptr<arrow::RecordBatch>> res(n);
 
   for (int i = 0; i < n; i++) {
-    STOP_IF_NOT_OK(reader->ReadRecordBatch(i, &res[i]));
+    res[i] = VALUE_OR_STOP(reader->ReadRecordBatch(i));
   }
 
   return res;

--- a/r/src/schema.cpp
+++ b/r/src/schema.cpp
@@ -84,9 +84,8 @@ std::shared_ptr<arrow::Schema> Schema__WithMetadata(
 // [[arrow::export]]
 Rcpp::RawVector Schema__serialize(const std::shared_ptr<arrow::Schema>& schema) {
   arrow::ipc::DictionaryMemo empty_memo;
-  std::shared_ptr<arrow::Buffer> out;
-  STOP_IF_NOT_OK(arrow::ipc::SerializeSchema(*schema, &empty_memo,
-                                             arrow::default_memory_pool(), &out));
+  std::shared_ptr<arrow::Buffer> out =
+      VALUE_OR_STOP(arrow::ipc::SerializeSchema(*schema, &empty_memo));
 
   auto n = out->size();
   Rcpp::RawVector vec(out->size());


### PR DESCRIPTION
There were a number of APIs left. 