### PR TITLE
ARROW-8299: [C++] Reusable "optional ParallelFor" function for optional use of multithreading

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -384,15 +384,8 @@ Status DecompressBuffers(Compression::type compression, const IpcReadOptions& op
     return Status::OK();
   };
 
-  if (options.use_threads) {
-    return ::arrow::internal::ParallelFor(static_cast<int>(fields->size()),
-                                          DecompressOne);
-  } else {
-    for (int i = 0; i < static_cast<int>(fields->size()); ++i) {
-      RETURN_NOT_OK(DecompressOne(i));
-    }
-    return Status::OK();
-  }
+  return ::arrow::internal::OptionalParallelFor(
+      options.use_threads, static_cast<int>(fields->size()), DecompressOne);
 }
 
 Result<std::shared_ptr<RecordBatch>> LoadRecordBatchSubset(

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -199,15 +199,8 @@ class RecordBatchSerializer {
       return Status::OK();
     };
 
-    if (options_.use_threads) {
-      return ::arrow::internal::ParallelFor(static_cast<int>(out_->body_buffers.size()),
-                                            CompressOne);
-    } else {
-      for (size_t i = 0; i < out_->body_buffers.size(); ++i) {
-        RETURN_NOT_OK(CompressOne(i));
-      }
-      return Status::OK();
-    }
+    return ::arrow::internal::OptionalParallelFor(
+        options_.use_threads, static_cast<int>(out_->body_buffers.size()), CompressOne);
   }
 
   Status Assemble(const RecordBatch& batch) {

--- a/cpp/src/arrow/util/parallel.h
+++ b/cpp/src/arrow/util/parallel.h
@@ -44,5 +44,21 @@ Status ParallelFor(int num_tasks, FUNCTION&& func) {
   return st;
 }
 
+// A parallelizer that takes a `Status(int)` function and calls it with
+// arguments between 0 and `num_tasks - 1`, in sequence or in parallel,
+// depending on the input boolean.
+
+template <class FUNCTION>
+Status OptionalParallelFor(bool use_threads, int num_tasks, FUNCTION&& func) {
+  if (use_threads) {
+    return ParallelFor(num_tasks, std::forward<FUNCTION>(func));
+  } else {
+    for (int i = 0; i < num_tasks; ++i) {
+      RETURN_NOT_OK(func(i));
+    }
+    return Status::OK();
+  }
+}
+
 }  // namespace internal
 }  // namespace arrow


### PR DESCRIPTION
We often see code like
```
    if (use_threads) {
      return ::arrow::internal::ParallelFor(n, Func);
    } else {
      for (size_t i = 0; i < n; ++i) {
        RETURN_NOT_OK(Func(i));
      }
      return Status::OK();
```

This patch adds a helper function to do this. 