### PR TITLE
ARROW-7256: [C++] Remove ARROW_MEMORY_POOL_DEFAULT macro

### DIFF
--- a/cpp/apidoc/Doxyfile
+++ b/cpp/apidoc/Doxyfile
@@ -2167,7 +2167,7 @@ PREDEFINED             = __attribute__(x)= \
 # definition found in the source code.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_AS_DEFINED      = ARROW_MEMORY_POOL_DEFAULT
+EXPAND_AS_DEFINED      =
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then doxygen's preprocessor will
 # remove all references to function-like macros that are alone on a line, have

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -244,7 +244,7 @@ std::shared_ptr<Array> MakeArray(const std::shared_ptr<ArrayData>& data);
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> MakeArrayOfNull(
     const std::shared_ptr<DataType>& type, int64_t length,
-    MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+    MemoryPool* pool = default_memory_pool());
 
 /// \brief Create an Array instance whose slots are the given scalar
 /// \param[in] scalar the value with which to fill the array
@@ -252,7 +252,7 @@ Result<std::shared_ptr<Array>> MakeArrayOfNull(
 /// \param[in] pool the memory pool to allocate memory from
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> MakeArrayFromScalar(
-    const Scalar& scalar, int64_t length, MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+    const Scalar& scalar, int64_t length, MemoryPool* pool = default_memory_pool());
 
 /// \brief Create a strongly-typed Array instance with all elements null
 /// \param[in] type the array type
@@ -637,7 +637,7 @@ class ARROW_EXPORT ListArray : public BaseListArray<ListType> {
   /// allocated because of null values
   static Result<std::shared_ptr<Array>> FromArrays(
       const Array& offsets, const Array& values,
-      MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+      MemoryPool* pool = default_memory_pool());
 
   ARROW_DEPRECATED("Use Result-returning version")
   static Status FromArrays(const Array& offsets, const Array& values, MemoryPool* pool,
@@ -683,7 +683,7 @@ class ARROW_EXPORT LargeListArray : public BaseListArray<LargeListType> {
   /// allocated because of null values
   static Result<std::shared_ptr<Array>> FromArrays(
       const Array& offsets, const Array& values,
-      MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+      MemoryPool* pool = default_memory_pool());
 
   ARROW_DEPRECATED("Use Result-returning version")
   static Status FromArrays(const Array& offsets, const Array& values, MemoryPool* pool,
@@ -740,7 +740,7 @@ class ARROW_EXPORT MapArray : public ListArray {
   /// allocated because of null values
   static Result<std::shared_ptr<Array>> FromArrays(
       const std::shared_ptr<Array>& offsets, const std::shared_ptr<Array>& keys,
-      const std::shared_ptr<Array>& items, MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+      const std::shared_ptr<Array>& items, MemoryPool* pool = default_memory_pool());
 
   ARROW_DEPRECATED("Use Result-returning version")
   static Status FromArrays(const std::shared_ptr<Array>& offsets,
@@ -1087,7 +1087,7 @@ class ARROW_EXPORT StructArray : public Array {
   /// \brief Flatten this array as a vector of arrays, one for each field
   ///
   /// \param[in] pool The pool to allocate null bitmaps from, if necessary
-  Result<ArrayVector> Flatten(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT) const;
+  Result<ArrayVector> Flatten(MemoryPool* pool = default_memory_pool()) const;
 
   ARROW_DEPRECATED("Use Result-returning version")
   Status Flatten(MemoryPool* pool, ArrayVector* out) const;
@@ -1354,7 +1354,7 @@ class ARROW_EXPORT DictionaryArray : public Array {
   /// \param[in] pool a pool to allocate the array data from
   Result<std::shared_ptr<Array>> Transpose(
       const std::shared_ptr<DataType>& type, const std::shared_ptr<Array>& dictionary,
-      const int32_t* transpose_map, MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT) const;
+      const int32_t* transpose_map, MemoryPool* pool = default_memory_pool()) const;
 
   ARROW_DEPRECATED("Use Result-returning version")
   Status Transpose(MemoryPool* pool, const std::shared_ptr<DataType>& type,

--- a/cpp/src/arrow/array.h
+++ b/cpp/src/arrow/array.h
@@ -242,9 +242,9 @@ std::shared_ptr<Array> MakeArray(const std::shared_ptr<ArrayData>& data);
 /// \param[in] length the array length
 /// \param[in] pool the memory pool to allocate memory from
 ARROW_EXPORT
-Result<std::shared_ptr<Array>> MakeArrayOfNull(
-    const std::shared_ptr<DataType>& type, int64_t length,
-    MemoryPool* pool = default_memory_pool());
+Result<std::shared_ptr<Array>> MakeArrayOfNull(const std::shared_ptr<DataType>& type,
+                                               int64_t length,
+                                               MemoryPool* pool = default_memory_pool());
 
 /// \brief Create an Array instance whose slots are the given scalar
 /// \param[in] scalar the value with which to fill the array

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -92,7 +92,7 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
 
 class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase {
  public:
-  explicit AdaptiveUIntBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+  explicit AdaptiveUIntBuilder(MemoryPool* pool = default_memory_pool());
 
   using ArrayBuilder::Advance;
   using internal::AdaptiveIntBuilderBase::Reset;
@@ -126,7 +126,7 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
 
 class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase {
  public:
-  explicit AdaptiveIntBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+  explicit AdaptiveIntBuilder(MemoryPool* pool = default_memory_pool());
 
   using ArrayBuilder::Advance;
   using internal::AdaptiveIntBuilderBase::Reset;

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -46,7 +46,7 @@ class BaseBinaryBuilder : public ArrayBuilder {
   using TypeClass = TYPE;
   using offset_type = typename TypeClass::offset_type;
 
-  explicit BaseBinaryBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit BaseBinaryBuilder(MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool), offsets_builder_(pool), value_data_builder_(pool) {}
 
   BaseBinaryBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
@@ -400,7 +400,7 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
   using TypeClass = FixedSizeBinaryType;
 
   explicit FixedSizeBinaryBuilder(const std::shared_ptr<DataType>& type,
-                                  MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+                                  MemoryPool* pool = default_memory_pool());
 
   Status Append(const uint8_t* value) {
     ARROW_RETURN_NOT_OK(Reserve(1));
@@ -515,10 +515,10 @@ namespace internal {
 class ARROW_EXPORT ChunkedBinaryBuilder {
  public:
   explicit ChunkedBinaryBuilder(int32_t max_chunk_value_length,
-                                MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+                                MemoryPool* pool = default_memory_pool());
 
   ChunkedBinaryBuilder(int32_t max_chunk_value_length, int32_t max_chunk_length,
-                       MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+                       MemoryPool* pool = default_memory_pool());
 
   virtual ~ChunkedBinaryBuilder() = default;
 

--- a/cpp/src/arrow/array/builder_decimal.h
+++ b/cpp/src/arrow/array/builder_decimal.h
@@ -31,7 +31,7 @@ class ARROW_EXPORT Decimal128Builder : public FixedSizeBinaryBuilder {
   using TypeClass = Decimal128Type;
 
   explicit Decimal128Builder(const std::shared_ptr<DataType>& type,
-                             MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+                             MemoryPool* pool = default_memory_pool());
 
   using FixedSizeBinaryBuilder::Append;
   using FixedSizeBinaryBuilder::AppendValues;

--- a/cpp/src/arrow/array/builder_time.h
+++ b/cpp/src/arrow/array/builder_time.h
@@ -32,11 +32,11 @@ class ARROW_EXPORT DayTimeIntervalBuilder : public NumericBuilder<DayTimeInterva
  public:
   using DayMilliseconds = DayTimeIntervalType::DayMilliseconds;
 
-  explicit DayTimeIntervalBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit DayTimeIntervalBuilder(MemoryPool* pool = default_memory_pool())
       : DayTimeIntervalBuilder(day_time_interval(), pool) {}
 
   explicit DayTimeIntervalBuilder(std::shared_ptr<DataType> type,
-                                  MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+                                  MemoryPool* pool = default_memory_pool())
       : NumericBuilder<DayTimeIntervalType>(type, pool) {}
 };
 

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -41,7 +41,7 @@ namespace arrow {
 /// data
 class ARROW_EXPORT BufferBuilder {
  public:
-  explicit BufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit BufferBuilder(MemoryPool* pool = default_memory_pool())
       : pool_(pool),
         data_(/*ensure never null to make ubsan happy and avoid check penalties below*/
               &util::internal::non_null_filler),
@@ -53,7 +53,7 @@ class ARROW_EXPORT BufferBuilder {
   /// the provided buffer until Finish/Reset are called.
   /// The buffer is not resized.
   explicit BufferBuilder(std::shared_ptr<ResizableBuffer> buffer,
-                         MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+                         MemoryPool* pool = default_memory_pool())
       : buffer_(std::move(buffer)),
         pool_(pool),
         data_(buffer_->mutable_data()),
@@ -194,11 +194,11 @@ class TypedBufferBuilder<
     T, typename std::enable_if<std::is_arithmetic<T>::value ||
                                std::is_standard_layout<T>::value>::type> {
  public:
-  explicit TypedBufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit TypedBufferBuilder(MemoryPool* pool = default_memory_pool())
       : bytes_builder_(pool) {}
 
   explicit TypedBufferBuilder(std::shared_ptr<ResizableBuffer> buffer,
-                              MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+                              MemoryPool* pool = default_memory_pool())
       : bytes_builder_(std::move(buffer), pool) {}
 
   Status Append(T value) {
@@ -270,7 +270,7 @@ class TypedBufferBuilder<
 template <>
 class TypedBufferBuilder<bool> {
  public:
-  explicit TypedBufferBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit TypedBufferBuilder(MemoryPool* pool = default_memory_pool())
       : bytes_builder_(pool) {}
 
   Status Append(bool value) {

--- a/cpp/src/arrow/compute/context.h
+++ b/cpp/src/arrow/compute/context.h
@@ -45,7 +45,7 @@ namespace compute {
 /// \brief Container for variables and options used by function evaluation
 class ARROW_EXPORT FunctionContext {
  public:
-  explicit FunctionContext(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+  explicit FunctionContext(MemoryPool* pool = default_memory_pool());
   MemoryPool* memory_pool() const;
 
   /// \brief Allocate buffer from the context's memory pool

--- a/cpp/src/arrow/csv/converter.h
+++ b/cpp/src/arrow/csv/converter.h
@@ -44,7 +44,7 @@ class ARROW_EXPORT Converter {
 
   static Result<std::shared_ptr<Converter>> Make(
       const std::shared_ptr<DataType>& type, const ConvertOptions& options,
-      MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+      MemoryPool* pool = default_memory_pool());
 
  protected:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Converter);
@@ -68,7 +68,7 @@ class ARROW_EXPORT DictionaryConverter : public Converter {
 
   static Result<std::shared_ptr<DictionaryConverter>> Make(
       const std::shared_ptr<DataType>& value_type, const ConvertOptions& options,
-      MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT);
+      MemoryPool* pool = default_memory_pool());
 };
 
 }  // namespace csv

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -66,7 +66,7 @@ Status Append(PyObject* context, PyObject* elem, SequenceBuilder* builder,
 // scalar Python types, lists, tuples, dictionaries, tensors and sparse tensors.
 class SequenceBuilder {
  public:
-  explicit SequenceBuilder(MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT)
+  explicit SequenceBuilder(MemoryPool* pool = default_memory_pool())
       : pool_(pool),
         types_(::arrow::int8(), pool),
         offsets_(::arrow::int32(), pool),

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -83,7 +83,7 @@ class ARROW_EXPORT ChunkedArray {
   ///
   /// \param[in] pool The pool for buffer allocations, if any
   Result<std::vector<std::shared_ptr<ChunkedArray>>> Flatten(
-      MemoryPool* pool ARROW_MEMORY_POOL_DEFAULT) const;
+      MemoryPool* pool = default_memory_pool()) const;
 
   ARROW_DEPRECATED("Use Result-returning version")
   Status Flatten(MemoryPool* pool, std::vector<std::shared_ptr<ChunkedArray>>* out) const;

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -427,8 +427,4 @@ std::shared_ptr<Schema> schema(
 /// Return the process-wide default memory pool.
 ARROW_EXPORT MemoryPool* default_memory_pool();
 
-#ifndef ARROW_MEMORY_POOL_DEFAULT
-#define ARROW_MEMORY_POOL_DEFAULT = default_memory_pool()
-#endif
-
 }  // namespace arrow

--- a/docs/source/developers/cpp/conventions.rst
+++ b/docs/source/developers/cpp/conventions.rst
@@ -37,12 +37,7 @@ automatically installed by the build.
 Memory Pools
 ============
 
-We provide a default memory pool with ``arrow::default_memory_pool()``. As a
-matter of convenience, some of the array builder classes have constructors
-which use the default pool without explicitly passing it. One can override the
-default optional memory pool by defining the ``ARROW_MEMORY_POOL_DEFAULT``
-macro to an assignment of a global function,
-e.g. ``= my_default_memory_pool()``.
+We provide a default memory pool with ``arrow::default_memory_pool()``.
 
 Error Handling and Exceptions
 =============================


### PR DESCRIPTION
This should fix the doxygen warning (which is turned into error).