### PR TITLE
ARROW-8375: [CI][R] Make Windows tests more verbose in case of segfault

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -155,9 +155,7 @@ jobs:
         shell: cmd
         run: |
           cd r/tests
-          sed -i.bak -E -e \
-            's/"arrow"/"arrow", reporter = "location"/' \
-            testthat.R
+          sed -i.bak -E -e 's/"arrow"/"arrow", reporter = "location"/' testthat.R
           rm -f testthat.R.bak
       - name: Fetch Submodules and Tags
         shell: bash

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -151,6 +151,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Make R tests verbose
+        shell: cmd
+        run: |
+          cd r/tests
+          sed -i.bak -E -e \
+            's/"arrow"/"arrow", reporter = "location"/' \
+            testthat.R
+          rm -f testthat.R.bak
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -18,6 +18,11 @@
 # Wrap testthat::test_that with a check for the C++ library
 options(..skip.tests = !arrow:::arrow_available())
 
+if (tolower(Sys.info()[["sysname"]]) == "windows") {
+  # See if this stabilizes tests; TODO fix the underlying issue
+  options(arrow.use_threads = FALSE)
+}
+
 test_that <- function(what, code) {
   testthat::test_that(what, {
     skip_if(getOption("..skip.tests", TRUE), "arrow C++ library not available")

--- a/r/tests/testthat/test-chunked-array.R
+++ b/r/tests/testthat/test-chunked-array.R
@@ -46,8 +46,6 @@ expect_chunked_roundtrip <- function(x, type) {
   invisible(a)
 }
 
-stop("exit here")
-
 test_that("ChunkedArray", {
   x <- expect_chunked_roundtrip(list(1:10, 1:10, 1:5), int32())
 

--- a/r/tests/testthat/test-chunked-array.R
+++ b/r/tests/testthat/test-chunked-array.R
@@ -46,6 +46,8 @@ expect_chunked_roundtrip <- function(x, type) {
   invisible(a)
 }
 
+stop("exit here")
+
 test_that("ChunkedArray", {
   x <- expect_chunked_roundtrip(list(1:10, 1:10, 1:5), int32())
 


### PR DESCRIPTION
The verbose output will at least tell us what was being run when the crash happened.