### PR TITLE
ARROW-8373: [CI][GLib] Find gio-2.0 manually on macOS

### DIFF
--- a/c_glib/arrow-glib/arrow-glib.pc.in
+++ b/c_glib/arrow-glib/arrow-glib.pc.in
@@ -25,4 +25,4 @@ Description: C API for Apache Arrow based on GLib
 Version: @VERSION@
 Libs: -L${libdir} -larrow-glib
 Cflags: -I${includedir}
-Requires: gio-2.0 arrow
+Requires: gobject-2.0 arrow

--- a/c_glib/arrow-glib/meson.build
+++ b/c_glib/arrow-glib/meson.build
@@ -207,10 +207,20 @@ headers = c_headers + cpp_headers
 install_headers(headers, subdir: meson.project_name())
 
 
+gobject = dependency('gobject-2.0')
+gobject_libdir = gobject.get_variable(pkgconfig: 'libdir')
+# This is for Homebrew. "pkg-config --cflags gio-2.0" includes the
+# "-I$(xcrun --show-sdk-path)/usr/include" flag by zlib.pc. The
+# include path includes the standard C headers such as stdlib.h. It
+# confuses clang++ (/usr/bin/c++).
+gio = cxx.find_library('gio-2.0', dirs: [gobject_libdir], required: false)
+if not gio.found()
+  gio = dependency('gio-2.0')
+endif
 dependencies = [
   arrow,
-  dependency('gobject-2.0'),
-  dependency('gio-2.0'),
+  gobject,
+  gio,
 ]
 libarrow_glib = library('arrow-glib',
                         sources: sources + enums,
@@ -229,7 +239,7 @@ pkgconfig.generate(libarrow_glib,
                    name: 'Apache Arrow GLib',
                    description: 'C API for Apache Arrow based on GLib',
                    version: version,
-                   requires: ['gio-2.0', 'arrow'])
+                   requires: ['gobject-2.0', 'arrow'])
 if have_arrow_orc
   pkgconfig.generate(filebase: 'arrow-orc-glib',
                      name: 'Apache Arrow GLib ORC',

--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -26,12 +26,6 @@ build_dir=${2}/c_glib
 
 export PKG_CONFIG_PATH=${ARROW_HOME}/lib/pkgconfig
 
-if which brew > /dev/null 2>&1; then
-  export $(echo env | brew sh | grep "^HOMEBREW_SDKROOT=")
-  export $(echo env | brew sh | grep "^PKG_CONFIG=")
-  PKG_CONFIG_PATH=${PKG_CONFIG_PATH}:$(echo 'echo $PKG_CONFIG_LIBDIR' | brew sh)
-fi
-
 export CFLAGS="-DARROW_NO_DEPRECATED_API"
 export CXXFLAGS="-DARROW_NO_DEPRECATED_API"
 


### PR DESCRIPTION
Because "pkg-config --cflags gio-2.0" includes the "-I$(xcrun
--show-sdk-path)/usr/include" flag by zlib.pc. The include path
includes the standard C headers such as stdlib.h. It confuses
clang++ (/usr/bin/c++).

This also removes needless gio-2.0 dependency from arrow-glib.pc.