### PR TITLE
ARROW-8389: [Integration] Run tests in parallel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1043,7 +1043,7 @@ services:
         /arrow/ci/scripts/java_build.sh /arrow /build &&
         /arrow/ci/scripts/js_build.sh /arrow /build &&
         pip install -e /arrow/dev/archery &&
-        archery integration --with-all --serial --run-flight"]
+        archery integration --with-all --run-flight"]
 
   ################################ Docs #######################################
 


### PR DESCRIPTION
Now that Flight port binding has been fixed in ARROW-8176, we are able to run integration tests in parallel.