### PR TITLE
ARROW-8386: [Python] Fix error when pyarrow.jvm gets an empty vector

### DIFF
--- a/python/pyarrow/jvm.py
+++ b/python/pyarrow/jvm.py
@@ -278,6 +278,11 @@ def array(jvm_array):
             " complex types not yet implemented.".format(minor_type_str))
     dtype = field(jvm_array.getField()).type
     length = jvm_array.getValueCount()
+
+    # If JVM has an empty Vector, buffer list will be empty so create manually
+    if length == 0:
+        return pa.array([], type=dtype)
+
     buffers = [jvm_buffer(buf)
                for buf in list(jvm_array.getBuffers(False))]
     null_count = jvm_array.getNullCount()

--- a/python/pyarrow/jvm.py
+++ b/python/pyarrow/jvm.py
@@ -277,14 +277,14 @@ def array(jvm_array):
             "Cannot convert JVM Arrow array of type {},"
             " complex types not yet implemented.".format(minor_type_str))
     dtype = field(jvm_array.getField()).type
-    length = jvm_array.getValueCount()
-
-    # If JVM has an empty Vector, buffer list will be empty so create manually
-    if length == 0:
-        return pa.array([], type=dtype)
-
     buffers = [jvm_buffer(buf)
                for buf in list(jvm_array.getBuffers(False))]
+
+    # If JVM has an empty Vector, buffer list will be empty so create manually
+    if len(buffers) == 0:
+        return pa.array([], type=dtype)
+
+    length = jvm_array.getValueCount()
     null_count = jvm_array.getNullCount()
     return pa.Array.from_buffers(dtype, length, buffers, null_count)
 

--- a/python/pyarrow/tests/test_jvm.py
+++ b/python/pyarrow/tests/test_jvm.py
@@ -219,6 +219,15 @@ def test_jvm_array(root_allocator, pa_type, py_data, jvm_type):
     assert py_array.equals(jvm_array)
 
 
+def test_jvm_array_empty(root_allocator):
+    cls = "org.apache.arrow.vector.{}".format('IntVector')
+    jvm_vector = jpype.JClass(cls)("vector", root_allocator)
+    jvm_vector.allocateNew()
+    jvm_array = pa_jvm.array(jvm_vector)
+    assert len(jvm_array) == 0
+    assert jvm_array.type == pa.int32()
+
+
 # These test parameters mostly use an integer range as an input as this is
 # often the only type that is understood by both Python and Java
 # implementations of Arrow.


### PR DESCRIPTION
When `pyarrow.jvm` gets an empty Vector from the JVM, the buffer list returned is empty and then fails with a `ValueError` in `pa.Array.from_buffers` because it still expects a list populated with buffers. This change checks if the JVM vector has a value count of 0, then manually creates an empty pyarrow Array of the same type.