### PR TITLE
ARROW-8396: [Rust] Removes libc dependency

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -36,7 +36,6 @@ name = "arrow"
 path = "src/lib.rs"
 
 [dependencies]
-libc = "0.2"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }


### PR DESCRIPTION
Since the allocation has done by std::alloc::*;