### PR TITLE
PARQUET-1840: [C++] Stop Early on DecodeSpaced

### DIFF
--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -304,10 +304,17 @@ class TypedDecoder : virtual public Decoder {
 
     // Add spacing for null entries. As we have filled the buffer from the front,
     // we need to add the spacing from the back.
-    int values_to_move = values_read;
-    for (int i = num_values - 1; i > (values_to_move - 1) && values_to_move > 0; i--) {
+    int values_to_move = values_read - 1;
+    // We stop early on one of two conditions:
+    // 1. There are more null values that need spacing. Note we infer this backwards,
+    //    when 'i' is equal to values to move it indicates all nulls have been consumed.
+    //    to move it implies all nulls have been spaced.
+    // 2. There are no more value values that need to values to move which indicates
+    //    all remaining slots are null, so there exact value doesn't matter.
+    for (int i = num_values - 1; (i > values_to_move) && (values_to_move >= 0); i--) {
       if (BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
-        buffer[i] = buffer[--values_to_move];
+        buffer[i] = buffer[values_to_move];
+        values_to_move--;
       }
     }
     return num_values;

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -296,9 +296,6 @@ class TypedDecoder : virtual public Decoder {
 
     // Depending on the number of nulls, some of the value slots in buffer may
     // be uninitialized, and this will cause valgrind warnings / potentially UB
-    // TODO: With SIMD shuffle in the loop below we might be able to get better
-    // performance on doing the memset only on values that aren't copied, and fill
-    // in all the values below.
     memset(static_cast<void*>(buffer + values_read), 0,
            (num_values - values_read) * sizeof(T));
 

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -303,11 +303,11 @@ class TypedDecoder : virtual public Decoder {
     // we need to add the spacing from the back.
     int values_to_move = values_read - 1;
     // We stop early on one of two conditions:
-    // 1. There are more null values that need spacing. Note we infer this backwards,
-    //    when 'i' is equal to values to move it indicates all nulls have been consumed.
-    //    to move it implies all nulls have been spaced.
-    // 2. There are no more value values that need to values to move which indicates
-    //    all remaining slots are null, so there exact value doesn't matter.
+    // 1. There are no more null values that need spacing.  Note we infer this
+    //     backwards, when 'i' is equal to 'values_to_move' it indicates
+    //    all nulls have been consumed.
+    // 2. There are no more non-null values that need to move which indicates
+    //    all remaining slots are null, so their exact value doesn't matter.
     for (int i = num_values - 1; (i > values_to_move) && (values_to_move >= 0); i--) {
       if (BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
         buffer[i] = buffer[values_to_move];

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -296,13 +296,16 @@ class TypedDecoder : virtual public Decoder {
 
     // Depending on the number of nulls, some of the value slots in buffer may
     // be uninitialized, and this will cause valgrind warnings / potentially UB
+    // TODO: With SIMD shuffle in the loop below we might be able to get better
+    // performance on doing the memset only on values that aren't copied, and fill
+    // in all the values below.
     memset(static_cast<void*>(buffer + values_read), 0,
            (num_values - values_read) * sizeof(T));
 
     // Add spacing for null entries. As we have filled the buffer from the front,
     // we need to add the spacing from the back.
     int values_to_move = values_read;
-    for (int i = num_values - 1; i >= 0; i--) {
+    for (int i = num_values - 1; i > (values_to_move - 1) && values_to_move > 0; i--) {
       if (BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
         buffer[i] = buffer[--values_to_move];
       }


### PR DESCRIPTION
This only makes appropriate stoppage early when possible:
1.  When there are no more values to use.
2.  When all remaining elements are present.

I put a TODO to look at SIMD for using intrinsics to potentially speed up moving the data (when they can be applied for ints/floats).  I tried to do this without SIMD and it looks like it made things slightly worse, so I removed it.  @jianxind this might be of interest to you.

As it stands these changes seem to be within noise on the current benchmarks but I expect in real world scenarios they could improve a a decent amount (mostly populated or mostly null values).