### PR TITLE
ARROW-8420: [C++] Distinguish ARMv7 from ARMv8 in SetupCxxFlags.cmake

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -21,10 +21,12 @@ include(CheckCXXCompilerFlag)
 # Get cpu architecture
 set(ARROW_CPU_FLAG "x86")
 
-message(STATUS "System architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+message(STATUS "System processor: ${CMAKE_SYSTEM_PROCESSOR}")
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
-  set(ARROW_CPU_FLAG "arm")
+  set(ARROW_CPU_FLAG "armv8")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "armv7")
+  set(ARROW_CPU_FLAG "armv7")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc")
   set(ARROW_CPU_FLAG "ppc")
 endif()
@@ -49,7 +51,7 @@ elseif(ARROW_CPU_FLAG STREQUAL "ppc")
   # power compiler flags, gcc/clang only
   set(ARROW_ALTIVEC_FLAG "-maltivec")
   check_cxx_compiler_flag(${ARROW_ALTIVEC_FLAG} CXX_SUPPORTS_ALTIVEC)
-elseif(ARROW_CPU_FLAG STREQUAL "arm")
+elseif(ARROW_CPU_FLAG STREQUAL "armv8")
   # Arm64 compiler flags, gcc/clang only
   set(ARROW_ARMV8_ARCH_FLAG "-march=${ARROW_ARMV8_ARCH}")
   check_cxx_compiler_flag(${ARROW_ARMV8_ARCH_FLAG} CXX_SUPPORTS_ARMV8_ARCH)
@@ -330,7 +332,7 @@ if(ARROW_CPU_FLAG STREQUAL "ppc" AND ARROW_USE_SIMD)
   endif()
 endif()
 
-if(ARROW_CPU_FLAG STREQUAL "arm")
+if(ARROW_CPU_FLAG STREQUAL "armv8")
   if(NOT CXX_SUPPORTS_ARMV8_ARCH)
     message(FATAL_ERROR "Unsupported arch flag: ${ARROW_ARMV8_ARCH_FLAG}.")
   endif()

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -20,6 +20,9 @@
 include(CheckCXXCompilerFlag)
 # Get cpu architecture
 set(ARROW_CPU_FLAG "x86")
+
+message(STATUS "System architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|ARM64")
   set(ARROW_CPU_FLAG "arm")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc")


### PR DESCRIPTION
ARMv7 machines may not be that practical for data processing purposes, but the project should at least build there. 