### PR TITLE
ARROW-8428: [C++] GCC 4.8 Implicit move-on-return failure in C++ tests

### DIFF
--- a/cpp/src/arrow/testing/gtest_common.h
+++ b/cpp/src/arrow/testing/gtest_common.h
@@ -45,7 +45,7 @@ class TestBase : public ::testing::Test {
   std::shared_ptr<Buffer> MakeRandomNullBitmap(int64_t length, int64_t null_count) {
     const int64_t null_nbytes = BitUtil::BytesForBits(length);
 
-    auto null_bitmap = *AllocateBuffer(null_nbytes, pool_);
+    std::shared_ptr<Buffer> null_bitmap = *AllocateBuffer(null_nbytes, pool_);
     memset(null_bitmap->mutable_data(), 255, null_nbytes);
     for (int64_t i = 0; i < null_count; i++) {
       BitUtil::ClearBit(null_bitmap->mutable_data(), i * (length / null_count));


### PR DESCRIPTION
@kszucs ideally this would be caught by CI. It's not caught by [manylinux1](https://github.com/apache/arrow/pull/6894/files#diff-c3f6c815734a6b07796306773dbae224R206) since that job doesn't build the C++ tests