### PR TITLE
ARROW-8429: [C++] Implement missing checks in IPC MessageDecoder

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -33,8 +33,9 @@ Result<std::shared_ptr<Buffer>> Buffer::CopySlice(const int64_t start,
                                                   const int64_t nbytes,
                                                   MemoryPool* pool) const {
   // Sanity checks
-  ARROW_CHECK_LT(start, size_);
+  ARROW_CHECK_LE(start, size_);
   ARROW_CHECK_LE(nbytes, size_ - start);
+  DCHECK_GE(nbytes, 0);
 
   ARROW_ASSIGN_OR_RAISE(auto new_buffer, AllocateResizableBuffer(nbytes, pool));
   std::memcpy(new_buffer->mutable_data(), data() + start, static_cast<size_t>(nbytes));

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -438,6 +438,18 @@ TEST(TestBuffer, CopySlice) {
   ASSERT_EQ(0, memcmp(out->data() + out->size(), zeros.data(), zeros.size()));
 }
 
+TEST(TestBuffer, CopySliceEmpty) {
+  auto buf = std::make_shared<Buffer>("");
+  ASSERT_OK_AND_ASSIGN(auto out, buf->CopySlice(0, 0));
+  AssertBufferEqual(*out, "");
+
+  buf = std::make_shared<Buffer>("1234");
+  ASSERT_OK_AND_ASSIGN(out, buf->CopySlice(0, 0));
+  AssertBufferEqual(*out, "");
+  ASSERT_OK_AND_ASSIGN(out, buf->CopySlice(4, 0));
+  AssertBufferEqual(*out, "");
+}
+
 TEST(TestBuffer, ToHexString) {
   const uint8_t data_array[] = "\a0hex string\xa9";
   std::basic_string<uint8_t> data_str = data_array;


### PR DESCRIPTION
Also allow taking 0-sized slices in Buffer::CopySlice.