### PR TITLE
ARROW-8437: [C++] Remove std::move return value from MakeRandomNullBitmap test utility

### DIFF
--- a/cpp/src/arrow/testing/gtest_common.h
+++ b/cpp/src/arrow/testing/gtest_common.h
@@ -50,7 +50,7 @@ class TestBase : public ::testing::Test {
     for (int64_t i = 0; i < null_count; i++) {
       BitUtil::ClearBit(null_bitmap->mutable_data(), i * (length / null_count));
     }
-    return std::move(null_bitmap);
+    return null_bitmap;
   }
 
   template <typename ArrayType>


### PR DESCRIPTION
Introduced by #6910, the builds triggered on the PR have not catched the compile error.