### PR TITLE
ARROW-8444: [Documentation] Fix spelling errors across the codebase

### DIFF
--- a/cpp/build-support/asan_symbolize.py
+++ b/cpp/build-support/asan_symbolize.py
@@ -36,7 +36,7 @@ class Symbolizer(object):
   def symbolize(self, addr, binary, offset):
     """Symbolize the given address (pair of binary and offset).
 
-    Overriden in subclasses.
+    Overridden in subclasses.
     Args:
         addr: virtual address of an instruction.
         binary: path to executable/shared object containing this instruction.

--- a/cpp/build-support/cpplint.py
+++ b/cpp/build-support/cpplint.py
@@ -122,7 +122,7 @@ Syntax: cpplint.py [--verbose=#] [--output=emacs|eclipse|vs7|junit]
       likely to be false positives.
 
     quiet
-      Supress output other than linting errors, such as information about
+      Suppress output other than linting errors, such as information about
       which files have been processed and excluded.
 
     filter=-x,+y,...
@@ -632,7 +632,7 @@ _repository = None
 # Files to exclude from linting. This is set by the --exclude flag.
 _excludes = None
 
-# Whether to supress PrintInfo messages
+# Whether to suppress PrintInfo messages
 _quiet = False
 
 # The allowed line length of files.

--- a/cpp/cmake_modules/FindPythonLibsNew.cmake
+++ b/cpp/cmake_modules/FindPythonLibsNew.cmake
@@ -1,5 +1,5 @@
 # - Find python libraries
-# This module finds the libraries corresponding to the Python interpeter
+# This module finds the libraries corresponding to the Python interpreter
 # FindPythonInterp provides.
 # This code sets the following variables:
 #

--- a/cpp/src/arrow/adapters/orc/adapter_util.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_util.cc
@@ -40,7 +40,7 @@ namespace orc {
 
 using internal::checked_cast;
 
-// The numer of nanoseconds in a second
+// The number of nanoseconds in a second
 constexpr int64_t kOneSecondNanos = 1000000000LL;
 
 Status AppendStructBatch(const liborc::Type* type, liborc::ColumnVectorBatch* cbatch,

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -75,7 +75,7 @@ AdaptiveIntBuilderBase::ExpandIntSizeInternal() {
 
   const old_type* src = reinterpret_cast<old_type*>(raw_data_);
   new_type* dst = reinterpret_cast<new_type*>(raw_data_);
-  // By doing the backward copy, we ensure that no element is overriden during
+  // By doing the backward copy, we ensure that no element is overridden during
   // the copy process while the copy stays in-place.
   std::copy_backward(src, src + length_, dst + length_);
 

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -162,7 +162,7 @@ class BaseListBuilder : public ArrayBuilder {
 /// To use this class, you must append values to the child array builder and use
 /// the Append function to delimit each distinct list value (once the values
 /// have been appended to the child array) or use the bulk API to append
-/// a sequence of offests and null values.
+/// a sequence of offsets and null values.
 ///
 /// A note on types.  Per arrow/type.h all types in the c++ implementation are
 /// logical so even though this class always builds list array, this can
@@ -203,7 +203,7 @@ class ARROW_EXPORT LargeListBuilder : public BaseListBuilder<LargeListType> {
 ///
 /// To use this class, you must append values to the key and item array builders
 /// and use the Append function to delimit each distinct map (once the keys and items
-/// have been appended) or use the bulk API to append a sequence of offests and null
+/// have been appended) or use the bulk API to append a sequence of offsets and null
 /// maps.
 ///
 /// Key uniqueness and ordering are not validated.

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -36,7 +36,7 @@ class MemoryPool;
 /// or deleted from (false) base. Each insertion or deletion is followed by a run of
 /// elements which are unchanged from base to target; the length of this run is stored
 /// in "run_length". (Note that the edit script begins and ends with a run of shared
-/// elements but both fields of the struct must have the same length. To accomodate this
+/// elements but both fields of the struct must have the same length. To accommodate this
 /// the first element of "insert" should be ignored.)
 ///
 /// For example for base "hlloo" and target "hello", the edit script would be

--- a/cpp/src/arrow/compute/kernels/hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_test.cc
@@ -587,7 +587,8 @@ TEST_F(TestHashKernel, DictEncodeDecimal) {
                                               {}, {0, 0, 1, 0, 2});
 }
 
-/* TODO(ARROW-4124): Determine if we want to do something that is reproducible with floats.
+/* TODO(ARROW-4124): Determine if we want to do something that is reproducible with
+ * floats.
 TEST_F(TestHashKernel, ValueCountsFloat) {
 
     // No nulls

--- a/cpp/src/arrow/compute/kernels/hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/hash_test.cc
@@ -587,7 +587,7 @@ TEST_F(TestHashKernel, DictEncodeDecimal) {
                                               {}, {0, 0, 1, 0, 2});
 }
 
-/* TODO(ARROW-4124): Determine if we wan to do something that is reproducable with floats.
+/* TODO(ARROW-4124): Determine if we want to do something that is reproducible with floats.
 TEST_F(TestHashKernel, ValueCountsFloat) {
 
     // No nulls

--- a/cpp/src/arrow/compute/kernels/match.h
+++ b/cpp/src/arrow/compute/kernels/match.h
@@ -31,7 +31,7 @@ namespace compute {
 
 /// \brief Match examines each slot in the haystack against a needles array.
 /// If the value is not found in needles, null will be output.
-/// If found, the index of occurence within needles (ignoring duplicates)
+/// If found, the index of occurrence within needles (ignoring duplicates)
 /// will be output.
 ///
 /// For example given haystack = [99, 42, 3, null] and

--- a/cpp/src/arrow/compute/kernels/sort_to_indices.cc
+++ b/cpp/src/arrow/compute/kernels/sort_to_indices.cc
@@ -168,7 +168,7 @@ class CountOrCompareSorter {
       };
       VisitArrayDataInline<ArrowType>(*values.data(), std::move(update_minmax));
       // For signed int32/64, (max - min) may overflow and trigger UBSAN.
-      // Cast to largest unsigned type(uint64_t) before substraction.
+      // Cast to largest unsigned type(uint64_t) before subtraction.
       if (static_cast<uint64_t>(max) - static_cast<uint64_t>(min) <=
           countsort_max_range_) {
         count_sorter_.SetMinMax(min, max);

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -435,7 +435,7 @@ TEST_F(TestEndToEnd, EndToEndSingleDataset) {
   options.selector_ignore_prefixes = {"."};
 
   // Partitions expressions can be discovered for Dataset and Fragments.
-  // This metadata is then used in conjuction with the query filter to apply
+  // This metadata is then used in conjunction with the query filter to apply
   // the pushdown predicate optimization.
   //
   // The DirectoryPartitioning is a partitioning where the path is split with

--- a/cpp/src/arrow/dbi/hiveserver2/thrift/ImpalaService.thrift
+++ b/cpp/src/arrow/dbi/hiveserver2/thrift/ImpalaService.thrift
@@ -159,7 +159,7 @@ enum TImpalaQueryOptions {
   APPX_COUNT_DISTINCT,
 
   // If true, allows Impala to internally disable spilling for potentially
-  // disastrous query plans. Impala will excercise this option if a query
+  // disastrous query plans. Impala will exercise this option if a query
   // has no plan hints, and at least one table is missing relevant stats.
   DISABLE_UNSAFE_SPILLS,
 

--- a/cpp/src/arrow/dbi/hiveserver2/thrift/TCLIService.thrift
+++ b/cpp/src/arrow/dbi/hiveserver2/thrift/TCLIService.thrift
@@ -678,7 +678,7 @@ struct TExecuteStatementReq {
   // The statement to be executed (DML, DDL, SET, etc)
   2: required string statement
 
-  // Configuration properties that are overlayed on top of the
+  // Configuration properties that are overlaid on top of the
   // the existing session configuration before this statement
   // is executed. These properties apply to this statement
   // only and will not affect the subsequent state of the Session.

--- a/cpp/src/arrow/device.h
+++ b/cpp/src/arrow/device.h
@@ -137,7 +137,7 @@ class ARROW_EXPORT MemoryManager : public std::enable_shared_from_this<MemoryMan
 
   explicit MemoryManager(const std::shared_ptr<Device>& device) : device_(device) {}
 
-  // Default implementations always return nullptr, should be overriden
+  // Default implementations always return nullptr, should be overridden
   // by subclasses that support data transfer.
   // (returning nullptr means unsupported copy / view)
   // In CopyBufferFrom and ViewBufferFrom, the `from` parameter is guaranteed to

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -105,7 +105,7 @@ class Message::MessageImpl {
   std::shared_ptr<Buffer> metadata_;
   const flatbuf::Message* message_;
 
-  // The recontructed custom_metadata field from the Message Flatbuffer
+  // The reconstructed custom_metadata field from the Message Flatbuffer
   std::shared_ptr<const KeyValueMetadata> custom_metadata_;
 
   // The message body, if any

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -954,7 +954,7 @@ class StructConverter
 
   Status AppendItem(PyObject* obj) {
     RETURN_NOT_OK(this->typed_builder_->Append());
-    // Note heterogenous sequences are not allowed
+    // Note heterogeneous sequences are not allowed
     if (ARROW_PREDICT_FALSE(source_kind_ == SourceKind::UNKNOWN)) {
       if (PyDict_Check(obj)) {
         source_kind_ = SourceKind::DICTS;

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -192,7 +192,7 @@ class SequenceBuilder {
 
   // Appending a buffer to the sequence
   //
-  // \param buffer_index Indes of the buffer in the object.
+  // \param buffer_index Index of the buffer in the object.
   Status AppendBuffer(const int32_t buffer_index) {
     RETURN_NOT_OK(CreateAndUpdate(&buffer_indices_, PythonType::BUFFER,
                                   [this]() { return new Int32Builder(pool_); }));

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -351,7 +351,7 @@ class ARROW_EXPORT SparseCSCIndex
 /// CSF is implemented with three vectors.
 ///
 /// Vectors inptr and indices contain N-1 and N buffers respectively, where N is the
-/// number of dimensions. Axis_order is a vector of integers of legth N. Indptr and
+/// number of dimensions. Axis_order is a vector of integers of length N. Indptr and
 /// indices describe the set of prefix trees. Trees traverse dimensions in order given by
 /// axis_order.
 class ARROW_EXPORT SparseCSFIndex : public internal::SparseIndexBase<SparseCSFIndex> {

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -101,7 +101,7 @@ class ARROW_EXPORT StatusDetail {
  public:
   virtual ~StatusDetail() = default;
   /// \brief Return a unique id for the type of the StatusDetail
-  /// (effectively a poor man's substitude for RTTI).
+  /// (effectively a poor man's substitute for RTTI).
   virtual const char* type_id() const = 0;
   /// \brief Produce a human-readable description of this status.
   virtual std::string ToString() const = 0;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1652,7 +1652,7 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   /// \brief Return the number of fields (columns) in the schema
   int num_fields() const;
 
-  /// Return the ith schema element. Does not boundscheck
+  /// Return the with schema element. Does not boundscheck
   const std::shared_ptr<Field>& field(int i) const;
 
   const std::vector<std::shared_ptr<Field>>& fields() const;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1652,7 +1652,7 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   /// \brief Return the number of fields (columns) in the schema
   int num_fields() const;
 
-  /// Return the with schema element. Does not boundscheck
+  /// Return the ith schema element. Does not boundscheck
   const std::shared_ptr<Field>& field(int i) const;
 
   const std::vector<std::shared_ptr<Field>>& fields() const;

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1133,7 +1133,7 @@ TEST(Bitmap, ShiftingWordsOptimization) {
         ASSERT_EQ(BitUtil::GetBit(bytes, i), bool((word >> i) & 1));
       }
 
-      // bit offset can therefore be accomodated by shifting the word
+      // bit offset can therefore be accommodated by shifting the word
       for (size_t offset = 0; offset < (kBitWidth * 3) / 4; ++offset) {
         uint64_t shifted_word = word >> offset;
         auto shifted_bytes = reinterpret_cast<uint8_t*>(&shifted_word);
@@ -1160,7 +1160,7 @@ TEST(Bitmap, ShiftingWordsOptimization) {
         ASSERT_EQ(BitUtil::GetBit(bytes, i + kBitWidth), bool((words[1] >> i) & 1));
       }
 
-      // bit offset can therefore be accomodated by shifting the word
+      // bit offset can therefore be accommodated by shifting the word
       for (size_t offset = 1; offset < (kBitWidth * 3) / 4; offset += 3) {
         uint64_t shifted_words[2];
         shifted_words[0] = words[0] >> offset | (words[1] << (kBitWidth - offset));

--- a/cpp/src/gandiva/decimal_type_util.h
+++ b/cpp/src/gandiva/decimal_type_util.h
@@ -52,7 +52,7 @@ class GANDIVA_EXPORT DecimalTypeUtil {
   static constexpr int32_t kMaxScale = kMaxPrecision;
 
   // When operating on decimal inputs, the integer part of the output can exceed the
-  // max precision. In such cases, the scale can be reduced, upto a minimum of
+  // max precision. In such cases, the scale can be reduced, up to a minimum of
   // kMinAdjustedScale.
   // * There is no strong reason for 6, but both SQLServer and Impala use 6 too.
   static constexpr int32_t kMinAdjustedScale = 6;

--- a/cpp/src/gandiva/expr_validator.cc
+++ b/cpp/src/gandiva/expr_validator.cc
@@ -124,7 +124,7 @@ Status ExprValidator::Visit(const BooleanNode& node) {
   ARROW_RETURN_IF(
       node.children().size() < 2,
       Status::ExpressionValidationError("Boolean expression has ", node.children().size(),
-                                        " children, expected atleast two"));
+                                        " children, expected at least two"));
 
   for (auto& child : node.children()) {
     const auto bool_type = arrow::boolean();

--- a/cpp/src/gandiva/llvm_generator.cc
+++ b/cpp/src/gandiva/llvm_generator.cc
@@ -822,7 +822,7 @@ void LLVMGenerator::Visitor::Visit(const NullableInternalFuncDex& dex) {
   auto params = BuildParams(dex.function_holder().get(), dex.args(), true,
                             native_function->NeedsContext());
 
-  // add an extra arg for validity (alloced on stack).
+  // add an extra arg for validity (allocated on stack).
   llvm::AllocaInst* result_valid_ptr =
       new llvm::AllocaInst(types->i8_type(), 0, "result_valid", entry_block_);
   params.push_back(result_valid_ptr);
@@ -934,7 +934,7 @@ void LLVMGenerator::Visitor::Visit(const BooleanAndDex& dex) {
   }
   builder->CreateBr(non_short_circuit_bb);
 
-  // Short-circuit case (atleast one of the expressions is valid and false).
+  // Short-circuit case (at least one of the expressions is valid and false).
   // No need to set validity bit (valid by default).
   builder->SetInsertPoint(short_circuit_bb);
   ADD_VISITOR_TRACE("BooleanAndExpression result value false");
@@ -1000,7 +1000,7 @@ void LLVMGenerator::Visitor::Visit(const BooleanOrDex& dex) {
   }
   builder->CreateBr(non_short_circuit_bb);
 
-  // Short-circuit case (atleast one of the expressions is valid and true).
+  // Short-circuit case (at least one of the expressions is valid and true).
   // No need to set validity bit (valid by default).
   builder->SetInsertPoint(short_circuit_bb);
   ADD_VISITOR_TRACE("BooleanOrExpression result value true");
@@ -1175,7 +1175,7 @@ LValuePtr LLVMGenerator::Visitor::BuildFunctionCall(const NativeFunction* func,
         isDecimalFunction = true;
       }
     }
-    // add extra arg for return length for variable len return types (alloced on stack).
+    // add extra arg for return length for variable len return types (allocated on stack).
     llvm::AllocaInst* result_len_ptr = nullptr;
     if (arrow::is_binary_like(arrow_return_type_id)) {
       result_len_ptr = new llvm::AllocaInst(generator_->types()->i32_type(), 0,

--- a/cpp/src/gandiva/local_bitmaps_holder.h
+++ b/cpp/src/gandiva/local_bitmaps_holder.h
@@ -48,7 +48,7 @@ class LocalBitMapsHolder {
   /// number of records in the current batch.
   int64_t num_records_;
 
-  /// A container of 'local_bitmaps_', each sized to accomodate 'num_records'.
+  /// A container of 'local_bitmaps_', each sized to accommodate 'num_records'.
   std::vector<std::unique_ptr<uint8_t[]>> local_bitmaps_vec_;
 
   /// An array of the local bitmaps.

--- a/cpp/src/gandiva/precompiled/decimal_ops.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops.cc
@@ -356,7 +356,7 @@ BasicDecimal128 Divide(int64_t context, const BasicDecimalScalar128& x,
     return 0;
   }
 
-  // scale upto the output scale, and do an integer division.
+  // scale up to the output scale, and do an integer division.
   int32_t delta_scale = out_scale + y.scale() - x.scale();
   DCHECK_GE(delta_scale, 0);
 
@@ -627,7 +627,7 @@ static BasicDecimal128 RoundWithPositiveScale(const BasicDecimalScalar128& x,
   }
 
   // If there is a rounding delta, the output scale must be less than the input scale.
-  // That means atleast one digit is dropped after the decimal. The delta add can add
+  // That means at least one digit is dropped after the decimal. The delta add can add
   // utmost one digit before the decimal. So, overflow will occur only if the output
   // precision has changed.
   DCHECK_GT(x.scale(), out_scale);

--- a/cpp/src/gandiva/precompiled/decimal_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops_test.cc
@@ -857,7 +857,7 @@ TEST_F(TestDecimalSql, Convert) {
   }
 }
 
-// double can store upto this integer value without losing precision
+// double can store up to this integer value without losing precision
 static const int64_t kMaxDoubleInt = 1ull << 53;
 
 TEST_F(TestDecimalSql, FromDouble) {

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -312,7 +312,7 @@ const char* castVARCHAR_utf8_int64(gdv_int64 context, const char* data,
     // and it won't be 0 for bytes of a multibyte char
     char* data_ptr = const_cast<char*>(data);
 
-    // we advance byte by byte till the 8 byte boudary then advance 8 bytes at a time
+    // we advance byte by byte till the 8 byte boundary then advance 8 bytes at a time
     auto num_bytes = reinterpret_cast<uintptr_t>(data_ptr) & 0x07;
     num_bytes = (8 - num_bytes) & 0x07;
     while (num_bytes > 0) {

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -461,7 +461,7 @@ static int days_in_month[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 
 bool IsLastDayOfMonth(const EpochTimePoint& tp) {
   if (tp.TmMon() != 1) {
-    // not February. Dont worry about leap year
+    // not February. Don't worry about leap year
     return (tp.TmMday() == days_in_month[tp.TmMon()]);
   }
 
@@ -621,7 +621,7 @@ gdv_timestamp castTIMESTAMP_utf8(int64_t context, const char* input, gdv_int32 l
           ts_field_index++;
           break;
         case '+':
-          // +08:00, means time zone is 8 hours ahead. Need to substract.
+          // +08:00, means time zone is 8 hours ahead. Need to subtract.
           add_displacement = false;
           ts_field_index = TimeFields::kDisplacementHours;
           break;

--- a/cpp/src/gandiva/projector.h
+++ b/cpp/src/gandiva/projector.h
@@ -127,7 +127,7 @@ class GANDIVA_EXPORT Projector {
   Status AllocArrayData(const DataTypePtr& type, int64_t num_records,
                         arrow::MemoryPool* pool, ArrayDataPtr* array_data);
 
-  /// Validate that the ArrayData has sufficient capacity to accomodate 'num_records'.
+  /// Validate that the ArrayData has sufficient capacity to accommodate 'num_records'.
   Status ValidateArrayDataCapacity(const arrow::ArrayData& array_data,
                                    const arrow::Field& field, int64_t num_records);
 

--- a/cpp/src/gandiva/selection_vector.cc
+++ b/cpp/src/gandiva/selection_vector.cc
@@ -67,7 +67,7 @@ Status SelectionVector::PopulateFromBitMap(const uint8_t* bitmap, int64_t bitmap
 
       int64_t pos_in_bitmap = bitmap_idx * 64 + pos_in_word;
       if (pos_in_bitmap > max_bitmap_index) {
-        // the bitmap may be slighly larger for alignment/padding.
+        // the bitmap may be slightly larger for alignment/padding.
         break;
       }
 

--- a/cpp/src/gandiva/selection_vector.h
+++ b/cpp/src/gandiva/selection_vector.h
@@ -83,7 +83,7 @@ class GANDIVA_EXPORT SelectionVector {
   /// \brief make selection vector with int16 type records.
   ///
   /// \param[in] max_slots max number of slots
-  /// \param[in] buffer buffer sized to accomodate max_slots
+  /// \param[in] buffer buffer sized to accommodate max_slots
   /// \param[out] selection_vector selection vector backed by 'buffer'
   static Status MakeInt16(int64_t max_slots, std::shared_ptr<arrow::Buffer> buffer,
                           std::shared_ptr<SelectionVector>* selection_vector);
@@ -107,7 +107,7 @@ class GANDIVA_EXPORT SelectionVector {
   /// \brief make selection vector with int32 type records.
   ///
   /// \param[in] max_slots max number of slots
-  /// \param[in] buffer buffer sized to accomodate max_slots
+  /// \param[in] buffer buffer sized to accommodate max_slots
   /// \param[out] selection_vector selection vector backed by 'buffer'
   static Status MakeInt32(int64_t max_slots, std::shared_ptr<arrow::Buffer> buffer,
                           std::shared_ptr<SelectionVector>* selection_vector);
@@ -133,7 +133,7 @@ class GANDIVA_EXPORT SelectionVector {
   /// \brief make selection vector with int64 type records.
   ///
   /// \param[in] max_slots max number of slots
-  /// \param[in] buffer buffer sized to accomodate max_slots
+  /// \param[in] buffer buffer sized to accommodate max_slots
   /// \param[out] selection_vector selection vector backed by 'buffer'
   static Status MakeInt64(int64_t max_slots, std::shared_ptr<arrow::Buffer> buffer,
                           std::shared_ptr<SelectionVector>* selection_vector);

--- a/cpp/src/gandiva/simple_arena.h
+++ b/cpp/src/gandiva/simple_arena.h
@@ -86,7 +86,7 @@ class SimpleArena {
   // buffer from current chunk.
   uint8_t* avail_buf_;
 
-  // List of alloced chunks.
+  // List of allocated chunks.
   std::vector<Chunk> chunks_;
 };
 

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -584,7 +584,7 @@ TEST_F(TestProjector, TestZeroCopyNegative) {
   status = projector->Evaluate(*in_batch, {null_array_data});
   EXPECT_EQ(status.code(), StatusCode::Invalid);
 
-  // the output array must have atleast two buffers.
+  // the output array must have at least two buffers.
   auto bad_array_data = arrow::ArrayData::Make(float32(), num_records, {bitmap_buf});
   status = projector->Evaluate(*in_batch, {bad_array_data});
   EXPECT_EQ(status.code(), StatusCode::Invalid);

--- a/cpp/src/generated/File_generated.h
+++ b/cpp/src/generated/File_generated.h
@@ -44,7 +44,7 @@ FLATBUFFERS_MANUALLY_ALIGNED_STRUCT(8) Block FLATBUFFERS_FINAL_CLASS {
     return flatbuffers::EndianScalar(metaDataLength_);
   }
   /// Length of the data (this is aligned so there can be a gap between this and
-  /// the metatdata).
+  /// the metadata).
   int64_t bodyLength() const {
     return flatbuffers::EndianScalar(bodyLength_);
   }

--- a/cpp/src/parquet/arrow/path_internal_test.cc
+++ b/cpp/src/parquet/arrow/path_internal_test.cc
@@ -83,7 +83,7 @@ class CapturedResult {
   }
 
   friend std::ostream& operator<<(std::ostream& os, const CapturedResult& result) {
-    // This print method is to silence valgrind issues.  Whats printed
+    // This print method is to silence valgrind issues.  What's printed
     // is not important because all asserts happen directly on
     // members.
     os << "CapturedResult (null def, null_rep):" << result.null_def_levels << " "

--- a/cpp/src/parquet/column_reader_test.cc
+++ b/cpp/src/parquet/column_reader_test.cc
@@ -400,7 +400,7 @@ TEST(TestColumnReader, DefinitionLevelsToBitmap) {
   ASSERT_EQ(9, values_read);
   ASSERT_EQ(1, null_count);
 
-  // Call again with 0 definition levels, make sure that valid_bits is unmodifed
+  // Call again with 0 definition levels, make sure that valid_bits is unmodified
   const uint8_t current_byte = valid_bits[1];
   null_count = 0;
   internal::DefinitionLevelsToBitmap(def_levels.data(), 0, max_def_level, max_rep_level,

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -161,7 +161,7 @@ class TypedColumnWriter : public ColumnWriter {
   /// Write a batch of repetition levels, definition levels, and values to the
   /// column.
   ///
-  /// In comparision to WriteBatch the length of repetition and definition levels
+  /// In comparison to WriteBatch the length of repetition and definition levels
   /// is the same as of the number of values read for max_definition_level == 1.
   /// In the case of max_definition_level > 1, the repetition and definition
   /// levels are larger than the values but the values include the null entries

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -763,11 +763,11 @@ TEST(TestColumnWriter, RepeatedListsUpdateSpacedBug) {
 
 void GenerateLevels(int min_repeat_factor, int max_repeat_factor, int max_level,
                     std::vector<int16_t>& input_levels) {
-  // for each repetition count upto max_repeat_factor
+  // for each repetition count up to max_repeat_factor
   for (int repeat = min_repeat_factor; repeat <= max_repeat_factor; repeat++) {
     // repeat count increases by a factor of 2 for every iteration
     int repeat_count = (1 << repeat);
-    // generate levels for repetition count upto the maximum level
+    // generate levels for repetition count up to the maximum level
     int16_t value = 0;
     int bwidth = 0;
     while (value <= max_level) {
@@ -879,7 +879,7 @@ TEST(TestLevels, TestLevelsDecodeMultipleBitWidth) {
   // for each encoding
   for (int encode = 0; encode < 2; encode++) {
     Encoding::type encoding = encodings[encode];
-    // BIT_PACKED requires a sequence of atleast 8
+    // BIT_PACKED requires a sequence of at least 8
     if (encoding == Encoding::BIT_PACKED) min_repeat_factor = 3;
     // for each maximum bit-width
     for (int bit_width = 1; bit_width <= max_bit_width; bit_width++) {

--- a/cpp/src/parquet/encryption.h
+++ b/cpp/src/parquet/encryption.h
@@ -307,7 +307,7 @@ class PARQUET_EXPORT FileDecryptionProperties {
     /// By default, reading plaintext (unencrypted) files is not
     /// allowed when using a decryptor
     /// - in order to detect files that were not encrypted by mistake.
-    /// However, the default behavior can be overriden by calling this method.
+    /// However, the default behavior can be overridden by calling this method.
     /// The caller should use then a different method to ensure encryption
     /// of files with sensitive data.
     Builder* plaintext_files_allowed() {

--- a/cpp/src/parquet/schema_test.cc
+++ b/cpp/src/parquet/schema_test.cc
@@ -1014,7 +1014,7 @@ static void ConfirmConvertedTypeCompatibility(
       << " logical type unexpectedly returns incorrect converted type";
   ASSERT_FALSE(converted_decimal_metadata.isset)
       << original->ToString()
-      << " logical type unexpectedly returns converted decimal metatdata that is set";
+      << " logical type unexpectedly returns converted decimal metadata that is set";
   ASSERT_TRUE(original->is_compatible(converted_type, converted_decimal_metadata))
       << original->ToString()
       << " logical type unexpectedly is incompatible with converted type and decimal "

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -565,7 +565,7 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   }
 
   void SetMinMaxPair(std::pair<T, T> min_max) {
-    // CleanStatistic can return a nullopt in case of erronous values, e.g. NaN
+    // CleanStatistic can return a nullopt in case of erroneous values, e.g. NaN
     auto maybe_min_max = CleanStatistic(min_max);
     if (!maybe_min_max) return;
 

--- a/cpp/src/plasma/thirdparty/dlmalloc.c
+++ b/cpp/src/plasma/thirdparty/dlmalloc.c
@@ -4691,7 +4691,7 @@ void* dlmalloc(size_t bytes) {
 
 void dlfree(void* mem) {
   /*
-     Consolidate freed chunks with preceeding or succeeding bordering
+     Consolidate freed chunks with preceding or succeeding bordering
      free chunks, if they exist, and then place in a bin.  Intermixed
      with special cases for top, dv, mmapped chunks, and usage errors.
   */
@@ -6226,10 +6226,10 @@ History:
         Wolfram Gloger (Gloger@lrz.uni-muenchen.de).
       * Use last_remainder in more cases.
       * Pack bins using idea from  colin@nyx10.cs.du.edu
-      * Use ordered bins instead of best-fit threshhold
+      * Use ordered bins instead of best-fit threshold
       * Eliminate block-local decls to simplify tracing and debugging.
       * Support another case of realloc via move into top
-      * Fix error occuring when initial sbrk_base not word-aligned.
+      * Fix error occurring when initial sbrk_base not word-aligned.
       * Rely on page size for units instead of SBRK_UNIT to
         avoid surprises about sbrk alignment conventions.
       * Add mallinfo, mallopt. Thanks to Raymond Nijssen

--- a/dev/archery/archery/lang/cpp.py
+++ b/dev/archery/archery/lang/cpp.py
@@ -40,7 +40,7 @@ class CppConfiguration:
                  cpp_package_prefix=None, install_prefix=None, use_conda=None,
                  # tests & examples
                  with_tests=True, with_benchmarks=False, with_examples=False,
-                 # Langauges support
+                 # Languages support
                  with_python=True,
                  # Format support
                  with_parquet=False,

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -70,7 +70,7 @@ def _convert_typehint(tokens):
 
 def inspect_signature(obj):
     """
-    Custom signature inspection primarly for cython generated callables.
+    Custom signature inspection primarily for cython generated callables.
 
     Cython puts the signatures to the first line of the docstrings, which we
     can reuse to parse the python signature from, but some gymnastics are

--- a/dev/archery/archery/tests/test_bot.py
+++ b/dev/archery/archery/tests/test_bot.py
@@ -102,7 +102,7 @@ def test_crossbow_comment_formatter():
 
 
 @pytest.mark.parametrize('fixture_name', [
-    # the bot is not mentiond, nothing to do
+    # the bot is not mentioned, nothing to do
     'event-issue-comment-not-mentioning-ursabot.json',
     # don't respond to itself, it prevents recursive comment storms!
     'event-issue-comment-by-ursabot.json',

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -217,7 +217,7 @@ def rat_linter(src, root):
     logger.info("Running apache-rat linter")
 
     if src.git_dirty:
-        logger.warn("Due to the usage of git-archive, uncommited files will"
+        logger.warn("Due to the usage of git-archive, uncommitted files will"
                     " not be checked for rat violations. ")
 
     exclusion = exclusion_from_globs(

--- a/docs/source/cpp/memory.rst
+++ b/docs/source/cpp/memory.rst
@@ -138,7 +138,7 @@ Arrow represents the CPU and other devices using the
 specifies how to allocate on a given device.  Each device has a default memory manager, but
 additional instances may be constructed (for example, wrapping a custom
 :class:`arrow::MemoryPool` the CPU).
-:class:`arrow::MemoryManager` instances which specifiy how to allocate
+:class:`arrow::MemoryManager` instances which specify how to allocate
 memory on a given device (for example, using a particular
 :class:`arrow::MemoryPool` on the CPU).
 

--- a/docs/source/cpp/parquet.rst
+++ b/docs/source/cpp/parquet.rst
@@ -150,7 +150,7 @@ StreamWriter
 
 The :class:`StreamWriter` allows for Parquet files to be written using
 standard C++ output operators.  This type-safe approach also ensures
-that rows are written without ommitting fields and allows for new row
+that rows are written without omitting fields and allows for new row
 groups to be created automatically (after certain volume of data) or
 explicitly by using the :type:`EndRowGroup` stream modifier.
 

--- a/docs/source/cpp/tables.rst
+++ b/docs/source/cpp/tables.rst
@@ -23,8 +23,8 @@ Tabular Data
 ============
 
 While arrays and chunked arrays represent a one-dimensional sequence of
-homogenous values, data often comes in the form of two-dimensional sets of
-heterogenous data (such as database tables, CSV files...).  Arrow provides
+homogeneous values, data often comes in the form of two-dimensional sets of
+heterogeneous data (such as database tables, CSV files...).  Arrow provides
 several abstractions to handle such data conveniently and efficiently.
 
 Fields

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -214,7 +214,7 @@ the float NaN value which is either represented by the Python object
 value during the conversion. If an integer input is supplied to
 ``pyarrow.array`` that contains ``np.nan``, ``ValueError`` is raised.
 
-To handle better compability with Pandas, we support interpreting NaN values as
+To handle better compatibility with Pandas, we support interpreting NaN values as
 null elements. This is enabled automatically on all ``from_pandas`` function and
 can be enable on the other conversion functions by passing ``from_pandas=True``
 as a function parameter.

--- a/format/File.fbs
+++ b/format/File.fbs
@@ -45,7 +45,7 @@ struct Block {
   metaDataLength: int;
 
   /// Length of the data (this is aligned so there can be a gap between this and
-  /// the metatdata).
+  /// the metadata).
   bodyLength: long;
 }
 

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -528,7 +528,7 @@ cdef class CudaBuffer(Buffer):
           Specify data in host. It can be array-like that is valid
           argument to py_buffer
         position : int
-          Specify the starting position of the copy in devive buffer.
+          Specify the starting position of the copy in device buffer.
           Default: 0.
         nbytes : int
           Specify the number of bytes to copy. Default: -1 (all from

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -217,7 +217,7 @@ cdef class Dataset:
             e.g. Parquet statistics. Otherwise filters the loaded
             RecordBatches before yielding them.
         use_threads : boolean, default True
-            If enabled, then maximum paralellism will be used determined by
+            If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
@@ -286,7 +286,7 @@ cdef class FileSystemDataset(Dataset):
     filesystem : FileSystem
         The filesystem which files are from.
     partitions : List[Expression], optional
-        Attach aditional partition information for the file paths.
+        Attach additional partition information for the file paths.
     root_partition : Expression, optional
         The top-level partition of the DataDataset.
     """
@@ -1333,7 +1333,7 @@ cdef class Scanner:
         source, e.g. Parquet statistics. Otherwise filters the loaded
         RecordBatches before yielding them.
     use_threads : bool, default True
-        If enabled, then maximum paralellism will be used determined by
+        If enabled, then maximum parallelism will be used determined by
         the number of available CPU cores.
     batch_size : int, default 32K
         The maximum row count for scanned record batches. If scanned

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -250,8 +250,8 @@ cdef class FileSystem:
 
         Returns
         -------
-        With (filesystem, path) tuple where path is the abtract path inside the
-        FileSystem instance.
+        With (filesystem, path) tuple where path is the abstract path inside
+        the FileSystem instance.
         """
         cdef:
             c_string path

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -127,14 +127,14 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
     mask : array[bool], optional
         Indicate which values are null (True) or not null (False).
     size : int64, optional
-        Size of the elements. If the imput is larger than size bail at this
+        Size of the elements. If the input is larger than size bail at this
         length. For iterators, if size is larger than the input iterator this
         will be treated as a "max size", but will involve an initial allocation
         of size followed by a resize to the actual size (so if you know the
         exact size specifying it correctly will give you better performance).
     from_pandas : bool, default None
         Use pandas's semantics for inferring nulls from values in
-        ndarray-like data. If passed, the mask tasks precendence, but
+        ndarray-like data. If passed, the mask tasks precedence, but
         if a value is unmasked (not-null), but still null according to
         pandas semantics, then it is null. Defaults to False if not
         passed explicitly by user, or True if a pandas object is

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -107,7 +107,7 @@ cdef class Message:
 
     def __repr__(self):
         if self.message == nullptr:
-            return """pyarrow.Message(unitialized)"""
+            return """pyarrow.Message(uninitialized)"""
 
         metadata_len = self.metadata.size
         body = self.body

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -473,7 +473,7 @@ compression_level: int or dict, default None
 use_byte_stream_split: bool or list, default False
     Specify if the byte_stream_split encoding should be used in general or
     only for some columns. If both dictionary and byte_stream_stream are
-    enabled, then dictionary is prefered.
+    enabled, then dictionary is preferred.
     The byte_stream_split encoding is valid only for floating-point data types
     and should be combined with a compression codec.
 writer_engine_version: str, default "V2"

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -116,7 +116,7 @@ cdef class ChunkedArray(_PandasConvertible):
     @property
     def null_count(self):
         """
-        Number of null entires
+        Number of null entries
 
         Returns
         -------

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -656,7 +656,7 @@ def test_hdfs_options(hdfs_connection):
 
 
 @pytest.mark.parametrize(('uri', 'expected_klass', 'expected_path'), [
-    # leading slashes are removed intentionally, becuase MockFileSystem doesn't
+    # leading slashes are removed intentionally, because MockFileSystem doesn't
     # have a distinction between relative and absolute paths
     ('mock:', _MockFileSystem, ''),
     ('mock:foo/bar', _MockFileSystem, 'foo/bar'),

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -376,7 +376,7 @@ def test_buffer_from_numpy():
     assert buf.is_cpu
     assert buf.is_mutable
     assert buf.to_pybytes() == arr.tobytes()
-    # F-contiguous; note strides informations is lost
+    # F-contiguous; note strides information is lost
     buf = pa.py_buffer(arr.T)
     assert buf.is_cpu
     assert buf.is_mutable

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -2643,7 +2643,7 @@ def test_noncoerced_nanoseconds_written_without_exception(tempdir):
     recovered_table = pq.read_table(filename)
     assert tb.equals(recovered_table)
 
-    # Loss of data thru coercion (without explicit override) still an error
+    # Loss of data through coercion (without explicit override) still an error
     filename = tempdir / 'not_written.parquet'
     with pytest.raises(ValueError):
         pq.write_table(tb, filename, coerce_timestamps='ms', version='2.0')

--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -638,7 +638,7 @@ def test_key_value_metadata():
     assert list(md.keys()) == [k for k, _ in expected]
     assert list(md.values()) == [v for _, v in expected]
 
-    # first occurence
+    # first occurrence
     assert md['a'] == b'alpha'
     assert md['b'] == b'beta'
     assert md.get_all('a') == [b'alpha', b'Alpha', b'ALPHA']

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -79,7 +79,7 @@ def randdecimal(precision, scale):
     Returns
     -------
     decimal_value : decimal.Decimal
-        A random decimal.Decimal object with the specifed precision and scale.
+        A random decimal.Decimal object with the specified precision and scale.
     """
     assert 1 <= precision <= 38, 'precision must be between 1 and 38 inclusive'
     if scale < 0:


### PR DESCRIPTION
Quickly run `codespell` which found a couple of misspellings.