### PR TITLE
ARROW-7801: [Developer] Add issue_comment workflow to fix lint/style/codegen

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -25,9 +25,9 @@ on:
       - edited
 
 jobs:
-
-  listen:
+  crossbow:
     name: Listen!
+    if: startsWith(github.event.comment.body, '@github-actions')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Arrow
@@ -53,5 +53,38 @@ jobs:
           archery trigger-bot \
             --event-name ${{ github.event_name }} \
             --event-payload ${{ github.event_path }}
-
-
+  autotune:
+    name: "Fix all the things"
+    if: startsWith(github.event.comment.body, 'autotune')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/pr-fetch@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: See what is different
+        run: |
+          set -ex
+          changed() {
+            git diff --name-only HEAD^.. | grep -e "$1" >/dev/null 2>&1
+          }
+          if changed '^r/.*\.R$'; then
+            echo ".R changed"
+            echo "::set-env name=R_DOCS::true"
+          fi
+      - uses: r-lib/actions/setup-r@v1
+        if: env.R_DOCS == 'true'
+      - name: Update R docs
+        if: env.R_DOCS == 'true'
+        shell: Rscript
+        run: |
+          source("ci/etc/rprofile")
+          install.packages(c("remotes", "roxygen2"))
+          remotes::install_deps(r")
+          roxygen2::roxygenize("r")
+      - name: Commit results
+        run: |
+          git commit -a -m 'Autoformat/render all the things [automated commit]' --author 'GitHub Actions <actions@github.com>' || echo "No changes to commit"
+      - uses: r-lib/actions/pr-push@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -76,22 +76,31 @@ jobs:
           if changed 'cmake' || changed 'CMake'; then
             echo "::set-env name=CMAKE_FORMAT::true"
           fi
-          if changed '^cpp/src' || changed '^r/src'; then
-            echo "::set-env name=CLANG_FORMAT::true"
+          if changed '^cpp/src'; then
+            echo "::set-env name=CLANG_FORMAT_CPP::true"
+          fi
+          if changed '^r/src'; then
+            echo "::set-env name=CLANG_FORMAT_R::true"
           fi
       - name: Run cmake_format
         if: env.CMAKE_FORMAT == 'true'
         run: |
-          python3 -m pip install -r dev/archery/requirements-lint.txt
-          python3 run-cmake-format.py
-      - name: Run clang-format
-        if: env.CLANG_FORMAT == 'true'
+          virtualenv venv
+          . venv/bin/activate
+          pip install -r dev/archery/requirements-lint.txt
+          run-cmake-format.py
+      - name: Run clang-format on cpp
+        if: env.CLANG_FORMAT_CPP == 'true'
         run: |
           . .env # To get the clang version we use
           cpp/build-support/run_clang_format.py \
               --clang_format_binary=clang-format-${CLANG_TOOLS} \
               --exclude_glob=cpp/build-support/lint_exclusions.txt \
               --source_dir=cpp/src --quiet --fix
+      - name: Run clang-format on r
+        if: env.CLANG_FORMAT_R == 'true'
+        run: |
+          . .env # To get the clang version we use
           cpp/build-support/run_clang_format.py \
               --clang_format_binary=clang-format-${CLANG_TOOLS} \
               --exclude_glob=cpp/build-support/lint_exclusions.txt \

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -84,6 +84,7 @@ jobs:
           fi
       - name: Run cmake_format
         if: false
+        # TODO: make this work https://issues.apache.org/jira/browse/ARROW-8489
         # if: env.CMAKE_FORMAT == 'true' || endsWith(github.event.comment.body, 'everything')
         run: |
           python3 -m pip install -r dev/archery/requirements-lint.txt

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -86,7 +86,9 @@ jobs:
           roxygen2::roxygenize("r")
       - name: Commit results
         run: |
-          git commit -a -m 'Autoformat/render all the things [automated commit]' --author 'GitHub Actions <actions@github.com>' || echo "No changes to commit"
+          git config user.name "$(git log -1 --pretty=format:%an)"
+          git config user.email "$(git log -1 --pretty=format:%ae)"
+          git commit -a -m 'Autoformat/render all the things [automated commit]' || echo "No changes to commit"
       - uses: r-lib/actions/pr-push@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -84,12 +84,12 @@ jobs:
           fi
       - name: Run cmake_format
         if: false
-        # if: env.CMAKE_FORMAT == 'true'
+        # if: env.CMAKE_FORMAT == 'true' || endsWith(github.event.comment.body, 'everything')
         run: |
           python3 -m pip install -r dev/archery/requirements-lint.txt
           python3 run-cmake-format.py
       - name: Run clang-format on cpp
-        if: env.CLANG_FORMAT_CPP == 'true'
+        if: env.CLANG_FORMAT_CPP == 'true' || endsWith(github.event.comment.body, 'everything')
         run: |
           . .env # To get the clang version we use
           cpp/build-support/run_clang_format.py \
@@ -97,7 +97,7 @@ jobs:
               --exclude_glob=cpp/build-support/lint_exclusions.txt \
               --source_dir=cpp/src --quiet --fix
       - name: Run clang-format on r
-        if: env.CLANG_FORMAT_R == 'true'
+        if: env.CLANG_FORMAT_R == 'true' || endsWith(github.event.comment.body, 'everything')
         run: |
           . .env # To get the clang version we use
           cpp/build-support/run_clang_format.py \
@@ -105,9 +105,9 @@ jobs:
               --exclude_glob=cpp/build-support/lint_exclusions.txt \
               --source_dir=r/src --quiet --fix
       - uses: r-lib/actions/setup-r@v1
-        if: env.R_DOCS == 'true'
+        if: env.R_DOCS == 'true' || endsWith(github.event.comment.body, 'everything')
       - name: Update R docs
-        if: env.R_DOCS == 'true'
+        if: env.R_DOCS == 'true' || endsWith(github.event.comment.body, 'everything')
         shell: Rscript {0}
         run: |
           source("ci/etc/rprofile")

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -71,9 +71,31 @@ jobs:
             git diff --name-only HEAD^..upstream/master | grep -e "$1" >/dev/null 2>&1
           }
           if changed '^r/.*\.R$'; then
-            echo ".R changed"
             echo "::set-env name=R_DOCS::true"
           fi
+          if changed 'cmake' || changed 'CMake'; then
+            echo "::set-env name=CMAKE_FORMAT::true"
+          fi
+          if changed '^cpp/src' || changed '^r/src'; then
+            echo "::set-env name=CLANG_FORMAT::true"
+          fi
+      - name: Run cmake_format
+        if: env.CMAKE_FORMAT == 'true'
+        run: |
+          python3 -m pip install -r dev/archery/requirements-lint.txt
+          python3 run-cmake-format.py
+      - name: Run clang-format
+        if: env.CLANG_FORMAT == 'true'
+        run: |
+          . .env # To get the clang version we use
+          cpp/build-support/run_clang_format.py \
+              --clang_format_binary=clang-format-${CLANG_TOOLS} \
+              --exclude_glob=cpp/build-support/lint_exclusions.txt \
+              --source_dir=cpp/src --quiet --fix
+          cpp/build-support/run_clang_format.py \
+              --clang_format_binary=clang-format-${CLANG_TOOLS} \
+              --exclude_glob=cpp/build-support/lint_exclusions.txt \
+              --source_dir=r/src --quiet --fix
       - uses: r-lib/actions/setup-r@v1
         if: env.R_DOCS == 'true'
       - name: Update R docs

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -83,13 +83,11 @@ jobs:
             echo "::set-env name=CLANG_FORMAT_R::true"
           fi
       - name: Run cmake_format
-        if: env.CMAKE_FORMAT == 'true'
+        if: false
+        # if: env.CMAKE_FORMAT == 'true'
         run: |
-          pip install virtualenv
-          virtualenv venv
-          . venv/bin/activate
-          pip install -r dev/archery/requirements-lint.txt
-          run-cmake-format.py
+          python3 -m pip install -r dev/archery/requirements-lint.txt
+          python3 run-cmake-format.py
       - name: Run clang-format on cpp
         if: env.CLANG_FORMAT_CPP == 'true'
         run: |

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Run cmake_format
         if: env.CMAKE_FORMAT == 'true'
         run: |
+          pip install virtualenv
           virtualenv venv
           . venv/bin/activate
           pip install -r dev/archery/requirements-lint.txt

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -65,8 +65,10 @@ jobs:
       - name: See what is different
         run: |
           set -ex
+          git remote add upstream https://github.com/apache/arrow
+          git fetch upstream
           changed() {
-            git diff --name-only HEAD^.. | grep -e "$1" >/dev/null 2>&1
+            git diff --name-only HEAD^..upstream/master | grep -e "$1" >/dev/null 2>&1
           }
           if changed '^r/.*\.R$'; then
             echo ".R changed"
@@ -76,7 +78,7 @@ jobs:
         if: env.R_DOCS == 'true'
       - name: Update R docs
         if: env.R_DOCS == 'true'
-        shell: Rscript
+        shell: Rscript {0}
         run: |
           source("ci/etc/rprofile")
           install.packages(c("remotes", "roxygen2"))

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           source("ci/etc/rprofile")
           install.packages(c("remotes", "roxygen2"))
-          remotes::install_deps(r")
+          remotes::install_deps("r")
           roxygen2::roxygenize("r")
       - name: Commit results
         run: |


### PR DESCRIPTION
#6411 tried to do this work automatically, but some were uncomfortable with that; this version instead is triggered by PR comment.

Currently implemented:

* R documentation (`roxygen2`, updating `r/man/*.Rd` based on docstrings in `r/R/*.R`)
* clang-format on changes to `cpp/src` or `r/src`
* cmake_format is currently disabled because I didn't feel like fighting further with python versions and environments; in https://github.com/nealrichardson/arrow/runs/590355718?check_suite_focus=true#step:5:34 you can see that it pip installs cmake_format but then in the next line can't find cmake_format :shrug:

To trigger the build, add a comment with the message "autotune" (seemed appropriate since this is using computers to make sure our code stays in harmony). By default it will check for which files changed and only run the relevant tasks, but if you comment "autotune everything" it will run everything.

Since `issue_comment` workflows are only run off the master branch, I tested this by merging these commits to master on my fork and triggering it on a PR there. See e.g. https://github.com/nealrichardson/arrow/pull/2#issuecomment-613138356