### PR TITLE
ARROW-8467: [C++] Fix Array::View tests for big-endian platforms

### DIFF
--- a/cpp/src/arrow/array_view_test.cc
+++ b/cpp/src/arrow/array_view_test.cc
@@ -103,7 +103,11 @@ TEST(TestArrayView, PrimitiveAsPrimitive) {
 }
 
 TEST(TestArrayView, PrimitiveAsFixedSizeBinary) {
+#if ARROW_LITTLE_ENDIAN
   auto arr = ArrayFromJSON(int32(), "[2020568934, 2054316386, null]");
+#else
+  auto arr = ArrayFromJSON(int32(), "[1718579064, 1650553466, null]");
+#endif
   auto expected = ArrayFromJSON(fixed_size_binary(4), R"(["foox", "barz", null])");
   CheckView(arr, expected);
   CheckView(expected, arr);
@@ -145,7 +149,11 @@ TEST(TestArrayView, StructAsStructSimple) {
   CheckView(expected, arr);
 
   ty2 = struct_({field("c", uint8()), field("d", fixed_size_binary(4))});
+#if ARROW_LITTLE_ENDIAN
   arr = ArrayFromJSON(ty1, "[[0, null], null, [-1, 2020568934]]");
+#else
+  arr = ArrayFromJSON(ty1, "[[0, null], null, [-1, 1718579064]]");
+#endif
   expected = ArrayFromJSON(ty2, R"([[0, null], null, [255, "foox"]])");
   CheckView(arr, expected);
   CheckView(expected, arr);
@@ -395,7 +403,11 @@ TEST(TestArrayView, ExtensionType) {
   auto data = ArrayFromJSON(ty1->storage_type(), R"(["ABCD", null])")->data();
   data->type = ty1;
   auto arr = ty1->MakeArray(data);
+#if ARROW_LITTLE_ENDIAN
   auto expected = ArrayFromJSON(uint32(), "[1145258561, null]");
+#else
+  auto expected = ArrayFromJSON(uint32(), "[1094861636, null]");
+#endif
   CheckView(arr, expected);
   CheckView(expected, arr);
 }

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -175,8 +175,13 @@ TEST_F(TestChunkedArray, Validate) {
 TEST_F(TestChunkedArray, View) {
   auto in_ty = int32();
   auto out_ty = fixed_size_binary(4);
+#if ARROW_LITTLE_ENDIAN
   auto arr = ArrayFromJSON(in_ty, "[2020568934, 2054316386, null]");
   auto arr2 = ArrayFromJSON(in_ty, "[2020568934, 2054316386]");
+#else
+  auto arr = ArrayFromJSON(in_ty, "[1718579064, 1650553466, null]");
+  auto arr2 = ArrayFromJSON(in_ty, "[1718579064, 1650553466]");
+#endif
   auto ex = ArrayFromJSON(out_ty, R"(["foox", "barz", null])");
   auto ex2 = ArrayFromJSON(out_ty, R"(["foox", "barz"])");
 


### PR DESCRIPTION
This PR adds the appropriate input on big-endian platform for test cases using ArrayFromJSON with fixed_size_binary.

I saw a problem with the following test:
```
TEST(TestArrayView, PrimitiveAsFixedSizeBinary) {
  auto arr = ArrayFromJSON(int32(), "[2020568934, 2054316386, null]");
  auto expected = ArrayFromJSON(fixed_size_binary(4), R"(["foox", "barz", null])");
  CheckView(arr, expected);
  CheckView(expected, arr);
}
```

Here, the expected strings are represented in binary as follows:
```
"foox" = [0x66 0x6f 0x6f 0x78]
"barz" = [0x62 0x61 0x72 0x7a]
```

This test gives a value as raw int32. The current values assume only a little-endian platform as follows to generate the expected binary sequence.
````
2020568934 = 0x786f6f66
2054316386 = 0x7a726162
````
IMHO, for big-endian platform, the following value should be given
```
1718579064 = 0x666f6f78
1650553466 = 0x6261727a
```

These tests have the above problems:
TEST_F(TestChunkedArray, View) at https://github.com/apache/arrow/blob/master/cpp/src/arrow/table_test.cc#L175
TEST(TestArrayView, PrimitiveAsFixedSizeBinary) at https://github.com/apache/arrow/blob/master/cpp/src/arrow/array_view_test.cc#L105
TEST(TestArrayView, StructAsStructSimple) at https://github.com/apache/arrow/blob/master/cpp/src/arrow/array_view_test.cc#L126
TEST(TestArrayView, ExtensionType) at https://github.com/apache/arrow/blob/master/cpp/src/arrow/array_view_test.cc#L393


