### PR TITLE
ARROW-8473: [Rust] Untick "Statistics support"

### DIFF
--- a/rust/parquet/README.md
+++ b/rust/parquet/README.md
@@ -59,7 +59,7 @@ version is available. Then simply update version of `parquet-format` crate in Ca
   - [X] Primitive column value readers
   - [X] Row record reader
   - [X] Arrow record reader
-- [X] Statistics support
+- [ ] Statistics support
 - [X] Write support
   - [X] Primitive column value writers
   - [ ] Row record writer


### PR DESCRIPTION
The statistics are not supported in parquet-rs. Search for "statistics" in src/column/writer.rs or reader.rs for confirmation.
https://issues.apache.org/jira/browse/ARROW-8473