### PR TITLE
ARROW-8467: [C++] Fix TestArrayImport tests for big-endian platforms 

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -714,7 +714,7 @@ Result<std::shared_ptr<KeyValueMetadata>> DecodeMetadata(const char* metadata) {
     int32_t v;
     memcpy(&v, metadata, 4);
     metadata += 4;
-    *out = BitUtil::FromLittleEndian(v);
+    *out = v;
     if (*out < 0) {
       return Status::Invalid("Invalid encoded metadata string");
     }

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1498,14 +1498,43 @@ static const void* buffers_nulls_no_data1[1] = {bits_buffer1};
 static const uint8_t data_buffer1[] = {1, 2,  3,  4,  5,  6,  7,  8,
                                        9, 10, 11, 12, 13, 14, 15, 16};
 static const uint8_t data_buffer2[] = "abcdefghijklmnopqrstuvwxyz";
+#if ARROW_LITTLE_ENDIAN
 static const uint64_t data_buffer3[] = {123456789, 0, 987654321, 0};
+#else
+static const uint64_t data_buffer3[] = {0x15cd5b0700000000, 0, 0xb168de3a00000000, 0};
+#endif
 static const uint8_t data_buffer4[] = {1, 2, 0, 1, 3, 0};
 static const float data_buffer5[] = {0.0f, 1.5f, -2.0f, 3.0f, 4.0f, 5.0f};
 static const double data_buffer6[] = {0.0, 1.5, -2.0, 3.0, 4.0, 5.0};
 static const int32_t data_buffer7[] = {1234, 5678, 9012, 3456};
 static const int64_t data_buffer8[] = {123456789, 987654321, -123456789, -987654321};
-static const void* primitive_buffers_no_nulls1[2] = {nullptr, data_buffer1};
-static const void* primitive_buffers_nulls1[2] = {bits_buffer1, data_buffer1};
+#if ARROW_LITTLE_ENDIAN
+static const void* primitive_buffers_no_nulls1_8[2] = {nullptr, data_buffer1};
+static const void* primitive_buffers_no_nulls1_16[2] = {nullptr, data_buffer1};
+static const void* primitive_buffers_no_nulls1_32[2] = {nullptr, data_buffer1};
+static const void* primitive_buffers_no_nulls1_64[2] = {nullptr, data_buffer1};
+static const void* primitive_buffers_nulls1_8[2] = {bits_buffer1, data_buffer1};
+static const void* primitive_buffers_nulls1_16[2] = {bits_buffer1, data_buffer1};
+static const void* primitive_buffers_nulls1_32[2] = {bits_buffer1, data_buffer1};
+static const void* primitive_buffers_nulls1_64[2] = {bits_buffer1, data_buffer1};
+#else
+static const uint8_t data_buffer1_16[] = {2,  1,  4,  3,  6,  5,  8,  7,
+                                          10, 9, 12, 11, 14, 13, 16, 15};
+static const uint8_t data_buffer1_32[] = {4,  3,  2,  1,  8,  7,  6,  5,
+                                          12, 11, 10, 9, 16, 15, 14, 13};
+static const uint8_t data_buffer1_64[] = {8,  7,  6,  5,  4,  3,  2,  1,
+                                          16, 15, 14, 13, 12, 11, 10, 9};
+static const void* primitive_buffers_no_nulls1_1[2] = {nullptr, data_buffer1};
+static const void* primitive_buffers_no_nulls1_8[2] = {nullptr, data_buffer1};
+static const void* primitive_buffers_no_nulls1_16[2] = {nullptr, data_buffer1_16};
+static const void* primitive_buffers_no_nulls1_32[2] = {nullptr, data_buffer1_32};
+static const void* primitive_buffers_no_nulls1_64[2] = {nullptr, data_buffer1_64};
+static const void* primitive_buffers_nulls1_1[2] = {bits_buffer1, data_buffer1};
+static const void* primitive_buffers_nulls1_8[2] = {bits_buffer1, data_buffer1};
+static const void* primitive_buffers_nulls1_16[2] = {bits_buffer1, data_buffer1_16};
+static const void* primitive_buffers_nulls1_32[2] = {bits_buffer1, data_buffer1_32};
+static const void* primitive_buffers_nulls1_64[2] = {bits_buffer1, data_buffer1_64};
+#endif
 static const void* primitive_buffers_no_nulls2[2] = {nullptr, data_buffer2};
 static const void* primitive_buffers_no_nulls3[2] = {nullptr, data_buffer3};
 static const void* primitive_buffers_no_nulls4[2] = {nullptr, data_buffer4};
@@ -1761,24 +1790,24 @@ class TestArrayImport : public ::testing::Test {
 };
 
 TEST_F(TestArrayImport, Primitive) {
-  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1_8);
   CheckImport(ArrayFromJSON(int8(), "[1, 2, 3]"));
-  FillPrimitive(5, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(5, 0, 0, primitive_buffers_no_nulls1_8);
   CheckImport(ArrayFromJSON(uint8(), "[1, 2, 3, 4, 5]"));
-  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1_16);
   CheckImport(ArrayFromJSON(int16(), "[513, 1027, 1541]"));
-  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1_16);
   CheckImport(ArrayFromJSON(uint16(), "[513, 1027, 1541]"));
-  FillPrimitive(2, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(2, 0, 0, primitive_buffers_no_nulls1_32);
   CheckImport(ArrayFromJSON(int32(), "[67305985, 134678021]"));
-  FillPrimitive(2, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(2, 0, 0, primitive_buffers_no_nulls1_32);
   CheckImport(ArrayFromJSON(uint32(), "[67305985, 134678021]"));
-  FillPrimitive(2, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(2, 0, 0, primitive_buffers_no_nulls1_64);
   CheckImport(ArrayFromJSON(int64(), "[578437695752307201, 1157159078456920585]"));
-  FillPrimitive(2, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(2, 0, 0, primitive_buffers_no_nulls1_64);
   CheckImport(ArrayFromJSON(uint64(), "[578437695752307201, 1157159078456920585]"));
 
-  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1_8);
   CheckImport(ArrayFromJSON(boolean(), "[true, false, false]"));
   FillPrimitive(6, 0, 0, primitive_buffers_no_nulls5);
   CheckImport(ArrayFromJSON(float32(), "[0.0, 1.5, -2.0, 3.0, 4.0, 5.0]"));
@@ -1786,17 +1815,17 @@ TEST_F(TestArrayImport, Primitive) {
   CheckImport(ArrayFromJSON(float64(), "[0.0, 1.5, -2.0, 3.0, 4.0, 5.0]"));
 
   // With nulls
-  FillPrimitive(9, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(9, -1, 0, primitive_buffers_nulls1_8);
   CheckImport(ArrayFromJSON(int8(), "[1, null, 3, 4, null, 6, 7, 8, 9]"));
-  FillPrimitive(9, 2, 0, primitive_buffers_nulls1);
+  FillPrimitive(9, 2, 0, primitive_buffers_nulls1_8);
   CheckImport(ArrayFromJSON(int8(), "[1, null, 3, 4, null, 6, 7, 8, 9]"));
-  FillPrimitive(3, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(3, -1, 0, primitive_buffers_nulls1_16);
   CheckImport(ArrayFromJSON(int16(), "[513, null, 1541]"));
-  FillPrimitive(3, 1, 0, primitive_buffers_nulls1);
+  FillPrimitive(3, 1, 0, primitive_buffers_nulls1_16);
   CheckImport(ArrayFromJSON(int16(), "[513, null, 1541]"));
-  FillPrimitive(3, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(3, -1, 0, primitive_buffers_nulls1_8);
   CheckImport(ArrayFromJSON(boolean(), "[true, null, false]"));
-  FillPrimitive(3, 1, 0, primitive_buffers_nulls1);
+  FillPrimitive(3, 1, 0, primitive_buffers_nulls1_8);
   CheckImport(ArrayFromJSON(boolean(), "[true, null, false]"));
 }
 
@@ -1868,12 +1897,12 @@ TEST_F(TestArrayImport, Null) {
 }
 
 TEST_F(TestArrayImport, PrimitiveWithOffset) {
-  FillPrimitive(3, 0, 2, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 0, 2, primitive_buffers_no_nulls1_8);
   CheckImport(ArrayFromJSON(int8(), "[3, 4, 5]"));
-  FillPrimitive(3, 0, 1, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 0, 1, primitive_buffers_no_nulls1_16);
   CheckImport(ArrayFromJSON(uint16(), "[1027, 1541, 2055]"));
 
-  FillPrimitive(4, 0, 7, primitive_buffers_no_nulls1);
+  FillPrimitive(4, 0, 7, primitive_buffers_no_nulls1_8);
   CheckImport(ArrayFromJSON(boolean(), "[false, false, true, false]"));
 }
 
@@ -1904,34 +1933,34 @@ TEST_F(TestArrayImport, String) {
 }
 
 TEST_F(TestArrayImport, List) {
-  FillPrimitive(AddChild(), 8, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 8, 0, 0, primitive_buffers_no_nulls1_8);
   FillListLike(5, 0, 0, list_buffers_no_nulls1);
   CheckImport(ArrayFromJSON(list(int8()), "[[1, 2], [], [3, 4, 5], [6], [7, 8]]"));
-  FillPrimitive(AddChild(), 5, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 5, 0, 0, primitive_buffers_no_nulls1_16);
   FillListLike(3, 1, 0, list_buffers_nulls1);
   CheckImport(ArrayFromJSON(list(int16()), "[[513, 1027], null, [1541, 2055, 2569]]"));
 
   // Large list
-  FillPrimitive(AddChild(), 5, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 5, 0, 0, primitive_buffers_no_nulls1_16);
   FillListLike(3, 0, 0, large_list_buffers_no_nulls1);
   CheckImport(
       ArrayFromJSON(large_list(int16()), "[[513, 1027], [], [1541, 2055, 2569]]"));
 
   // Fixed-size list
-  FillPrimitive(AddChild(), 9, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 9, 0, 0, primitive_buffers_no_nulls1_8);
   FillFixedSizeListLike(3, 0, 0, buffers_no_nulls_no_data);
   CheckImport(
       ArrayFromJSON(fixed_size_list(int8(), 3), "[[1, 2, 3], [4, 5, 6], [7, 8, 9]]"));
 }
 
 TEST_F(TestArrayImport, NestedList) {
-  FillPrimitive(AddChild(), 8, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 8, 0, 0, primitive_buffers_no_nulls1_8);
   FillListLike(AddChild(), 5, 0, 0, list_buffers_no_nulls1);
   FillListLike(3, 0, 0, large_list_buffers_no_nulls1);
   CheckImport(ArrayFromJSON(large_list(list(int8())),
                             "[[[1, 2], []], [], [[3, 4, 5], [6], [7, 8]]]"));
 
-  FillPrimitive(AddChild(), 6, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 6, 0, 0, primitive_buffers_no_nulls1_8);
   FillFixedSizeListLike(AddChild(), 2, 0, 0, buffers_no_nulls_no_data);
   FillListLike(2, 0, 0, list_buffers_no_nulls1);
   CheckImport(
@@ -1940,31 +1969,31 @@ TEST_F(TestArrayImport, NestedList) {
 
 TEST_F(TestArrayImport, ListWithOffset) {
   // Offset in child
-  FillPrimitive(AddChild(), 8, 0, 1, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 8, 0, 1, primitive_buffers_no_nulls1_8);
   FillListLike(5, 0, 0, list_buffers_no_nulls1);
   CheckImport(ArrayFromJSON(list(int8()), "[[2, 3], [], [4, 5, 6], [7], [8, 9]]"));
 
-  FillPrimitive(AddChild(), 9, 0, 1, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 9, 0, 1, primitive_buffers_no_nulls1_8);
   FillFixedSizeListLike(3, 0, 0, buffers_no_nulls_no_data);
   CheckImport(
       ArrayFromJSON(fixed_size_list(int8(), 3), "[[2, 3, 4], [5, 6, 7], [8, 9, 10]]"));
 
   // Offset in parent
-  FillPrimitive(AddChild(), 8, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 8, 0, 0, primitive_buffers_no_nulls1_8);
   FillListLike(4, 0, 1, list_buffers_no_nulls1);
   CheckImport(ArrayFromJSON(list(int8()), "[[], [3, 4, 5], [6], [7, 8]]"));
 
-  FillPrimitive(AddChild(), 9, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 9, 0, 0, primitive_buffers_no_nulls1_8);
   FillFixedSizeListLike(3, 0, 1, buffers_no_nulls_no_data);
   CheckImport(
       ArrayFromJSON(fixed_size_list(int8(), 3), "[[4, 5, 6], [7, 8, 9], [10, 11, 12]]"));
 
   // Both
-  FillPrimitive(AddChild(), 8, 0, 2, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 8, 0, 2, primitive_buffers_no_nulls1_8);
   FillListLike(4, 0, 1, list_buffers_no_nulls1);
   CheckImport(ArrayFromJSON(list(int8()), "[[], [5, 6, 7], [8], [9, 10]]"));
 
-  FillPrimitive(AddChild(), 9, 0, 2, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 9, 0, 2, primitive_buffers_no_nulls1_8);
   FillFixedSizeListLike(3, 0, 1, buffers_no_nulls_no_data);
   CheckImport(ArrayFromJSON(fixed_size_list(int8(), 3),
                             "[[6, 7, 8], [9, 10, 11], [12, 13, 14]]"));
@@ -1972,21 +2001,21 @@ TEST_F(TestArrayImport, ListWithOffset) {
 
 TEST_F(TestArrayImport, Struct) {
   FillStringLike(AddChild(), 3, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1_16);
   FillStructLike(3, 0, 0, 2, buffers_no_nulls_no_data);
   auto expected = ArrayFromJSON(struct_({field("strs", utf8()), field("ints", uint16())}),
                                 R"([["foo", 513], ["", null], ["bar", 1541]])");
   CheckImport(expected);
 
   FillStringLike(AddChild(), 3, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 3, 0, 0, primitive_buffers_no_nulls1_16);
   FillStructLike(3, -1, 0, 2, buffers_nulls_no_data1);
   expected = ArrayFromJSON(struct_({field("strs", utf8()), field("ints", uint16())}),
                            R"([["foo", 513], null, ["bar", 1541]])");
   CheckImport(expected);
 
   FillStringLike(AddChild(), 3, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 3, 0, 0, primitive_buffers_no_nulls1_16);
   FillStructLike(3, -1, 0, 2, buffers_nulls_no_data1);
   expected = ArrayFromJSON(
       struct_({field("strs", utf8(), /*nullable=*/false), field("ints", uint16())}),
@@ -1997,7 +2026,7 @@ TEST_F(TestArrayImport, Struct) {
 TEST_F(TestArrayImport, Union) {
   // Sparse
   FillStringLike(AddChild(), 4, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 4, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(AddChild(), 4, -1, 0, primitive_buffers_nulls1_8);
   FillUnionLike(4, 0, 0, 2, sparse_union_buffers_no_nulls1);
   auto type =
       union_({field("strs", utf8()), field("ints", int8())}, {43, 42}, UnionMode::SPARSE);
@@ -2007,7 +2036,7 @@ TEST_F(TestArrayImport, Union) {
 
   // Dense
   FillStringLike(AddChild(), 2, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1_8);
   FillUnionLike(5, 0, 0, 2, dense_union_buffers_no_nulls1);
   type =
       union_({field("strs", utf8()), field("ints", int8())}, {43, 42}, UnionMode::DENSE);
@@ -2019,7 +2048,7 @@ TEST_F(TestArrayImport, Union) {
 TEST_F(TestArrayImport, StructWithOffset) {
   // Child
   FillStringLike(AddChild(), 3, 0, 1, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, 0, 2, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 3, 0, 2, primitive_buffers_no_nulls1_8);
   FillStructLike(3, 0, 0, 2, buffers_no_nulls_no_data);
   auto expected = ArrayFromJSON(struct_({field("strs", utf8()), field("ints", int8())}),
                                 R"([["", 3], ["bar", 4], ["quux", 5]])");
@@ -2027,7 +2056,7 @@ TEST_F(TestArrayImport, StructWithOffset) {
 
   // Parent and child
   FillStringLike(AddChild(), 4, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 4, 0, 2, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 4, 0, 2, primitive_buffers_no_nulls1_8);
   FillStructLike(3, 0, 1, 2, buffers_no_nulls_no_data);
   expected = ArrayFromJSON(struct_({field("strs", utf8()), field("ints", int8())}),
                            R"([["", 4], ["bar", 5], ["quux", 6]])");
@@ -2036,7 +2065,7 @@ TEST_F(TestArrayImport, StructWithOffset) {
 
 TEST_F(TestArrayImport, Map) {
   FillStringLike(AddChild(), 5, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 5, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 5, 0, 0, primitive_buffers_no_nulls1_8);
   FillStructLike(AddChild(), 5, 0, 0, 2, buffers_no_nulls_no_data);
   FillListLike(3, 1, 0, list_buffers_nulls1);
   auto expected = ArrayFromJSON(
@@ -2069,7 +2098,7 @@ TEST_F(TestArrayImport, Dictionary) {
 }
 
 TEST_F(TestArrayImport, NestedDictionary) {
-  FillPrimitive(AddChild(), 6, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 6, 0, 0, primitive_buffers_no_nulls1_8);
   FillListLike(AddChild(), 4, 0, 0, list_buffers_no_nulls1);
   FillPrimitive(6, 0, 0, primitive_buffers_no_nulls4);
   FillDictionary();
@@ -2123,19 +2152,19 @@ TEST_F(TestArrayImport, DictionaryWithOffset) {
 
 TEST_F(TestArrayImport, PrimitiveError) {
   // Bad number of buffers
-  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1_8);
   c_struct_.n_buffers = 1;
   CheckImportError(int8());
 
   // Zero null bitmap but non-zero null_count
-  FillPrimitive(3, 1, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 1, 0, primitive_buffers_no_nulls1_8);
   CheckImportError(int8());
 }
 
 TEST_F(TestArrayImport, StructError) {
   // Bad number of children
   FillStringLike(AddChild(), 3, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1_8);
   FillStructLike(3, 0, 0, 2, buffers_no_nulls_no_data);
   CheckImportError(struct_({field("strs", utf8())}));
 }
@@ -2176,7 +2205,7 @@ TEST_F(TestArrayImport, ImportRecordBatch) {
   auto expected_ints = ArrayFromJSON(uint16(), "[513, null, 1541]");
 
   FillStringLike(AddChild(), 3, 0, 1, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1_16);
   FillStructLike(3, 0, 0, 2, buffers_no_nulls_no_data);
 
   auto expected = RecordBatch::Make(schema, 3, {expected_strs, expected_ints});
@@ -2186,14 +2215,14 @@ TEST_F(TestArrayImport, ImportRecordBatch) {
 TEST_F(TestArrayImport, ImportRecordBatchError) {
   // Struct with non-zero parent offset
   FillStringLike(AddChild(), 4, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 4, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 4, 0, 0, primitive_buffers_no_nulls1_16);
   FillStructLike(3, 0, 1, 2, buffers_no_nulls_no_data);
   auto schema = ::arrow::schema({field("strs", utf8()), field("ints", uint16())});
   CheckImportError(schema);
 
   // Struct with nulls in parent
   FillStringLike(AddChild(), 3, 0, 0, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(AddChild(), 3, 0, 0, primitive_buffers_no_nulls1_8);
   FillStructLike(3, 1, 0, 2, buffers_nulls_no_data1);
   CheckImportError(schema);
 }
@@ -2204,7 +2233,7 @@ TEST_F(TestArrayImport, ImportArrayAndType) {
   schema_builder.FillPrimitive("c");
   SchemaReleaseCallback schema_cb(&schema_builder.c_struct_);
 
-  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1_8);
   ArrayReleaseCallback array_cb(&c_struct_);
 
   ASSERT_OK_AND_ASSIGN(auto array, ImportArray(&c_struct_, &schema_builder.c_struct_));
@@ -2222,7 +2251,7 @@ TEST_F(TestArrayImport, ImportArrayAndTypeError) {
   schema_builder.FillPrimitive("cc");
   SchemaReleaseCallback schema_cb(&schema_builder.c_struct_);
 
-  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1);
+  FillPrimitive(3, 0, 0, primitive_buffers_no_nulls1_8);
   ArrayReleaseCallback array_cb(&c_struct_);
 
   ASSERT_RAISES(Invalid, ImportArray(&c_struct_, &schema_builder.c_struct_));
@@ -2243,7 +2272,7 @@ TEST_F(TestArrayImport, ImportRecordBatchAndSchema) {
   SchemaReleaseCallback schema_cb(&schema_builder.c_struct_);
 
   FillStringLike(AddChild(), 3, 0, 1, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1_16);
   FillStructLike(3, 0, 0, 2, buffers_no_nulls_no_data);
   ArrayReleaseCallback array_cb(&c_struct_);
 
@@ -2265,7 +2294,7 @@ TEST_F(TestArrayImport, ImportRecordBatchAndSchemaError) {
   SchemaReleaseCallback schema_cb(&schema_builder.c_struct_);
 
   FillStringLike(AddChild(), 3, 0, 1, string_buffers_no_nulls1);
-  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1);
+  FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1_8);
   FillStructLike(3, 0, 0, 2, buffers_no_nulls_no_data);
   ArrayReleaseCallback array_cb(&c_struct_);
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1515,8 +1515,6 @@ static const void* primitive_buffers_no_nulls1_32[2] = {nullptr, data_buffer1};
 static const void* primitive_buffers_no_nulls1_64[2] = {nullptr, data_buffer1};
 static const void* primitive_buffers_nulls1_8[2] = {bits_buffer1, data_buffer1};
 static const void* primitive_buffers_nulls1_16[2] = {bits_buffer1, data_buffer1};
-static const void* primitive_buffers_nulls1_32[2] = {bits_buffer1, data_buffer1};
-static const void* primitive_buffers_nulls1_64[2] = {bits_buffer1, data_buffer1};
 #else
 static const uint8_t data_buffer1_16[] = {2,  1,  4,  3,  6,  5,  8,  7,
                                           10, 9, 12, 11, 14, 13, 16, 15};
@@ -1524,16 +1522,12 @@ static const uint8_t data_buffer1_32[] = {4,  3,  2,  1,  8,  7,  6,  5,
                                           12, 11, 10, 9, 16, 15, 14, 13};
 static const uint8_t data_buffer1_64[] = {8,  7,  6,  5,  4,  3,  2,  1,
                                           16, 15, 14, 13, 12, 11, 10, 9};
-static const void* primitive_buffers_no_nulls1_1[2] = {nullptr, data_buffer1};
 static const void* primitive_buffers_no_nulls1_8[2] = {nullptr, data_buffer1};
 static const void* primitive_buffers_no_nulls1_16[2] = {nullptr, data_buffer1_16};
 static const void* primitive_buffers_no_nulls1_32[2] = {nullptr, data_buffer1_32};
 static const void* primitive_buffers_no_nulls1_64[2] = {nullptr, data_buffer1_64};
-static const void* primitive_buffers_nulls1_1[2] = {bits_buffer1, data_buffer1};
 static const void* primitive_buffers_nulls1_8[2] = {bits_buffer1, data_buffer1};
 static const void* primitive_buffers_nulls1_16[2] = {bits_buffer1, data_buffer1_16};
-static const void* primitive_buffers_nulls1_32[2] = {bits_buffer1, data_buffer1_32};
-static const void* primitive_buffers_nulls1_64[2] = {bits_buffer1, data_buffer1_64};
 #endif
 static const void* primitive_buffers_no_nulls2[2] = {nullptr, data_buffer2};
 static const void* primitive_buffers_no_nulls3[2] = {nullptr, data_buffer3};


### PR DESCRIPTION
This PR fixes two problems.

1.  `DecodeMetadata()` always assume that a length of metadata is stored in a little-endian format. According to [this specification](https://github.com/apache/arrow/blob/master/docs/source/format/CDataInterface.rst#the-arrowschema-structure), the length is stored in a native endianness. This causes the following failure. This PR makes the interpretation of the length correct.

```
12: [ RUN      ] TestSchemaImport.Struct
12: /home/ishizaki/Arrow/arrow/cpp/build-support/run-test.sh: line 92: 19528 Segmentation fault      (core dumped) $TEST_EXECUTABLE "$@" 2>&1
12:      19529 Done                    | $ROOT/build-support/asan_symbolize.py
12:      19530 Done                    | ${CXXFILT:-c++filt}
12:      19531 Done                    | $ROOT/build-support/stacktrace_addr2line.pl $TEST_EXECUTABLE
12:      19532 Done                    | $pipe_cmd 2>&1
12:      19533 Done                    | tee $LOGFILE
```

1.  `primitive_buffers_...` used in `TestImportArray` implicitly assumes little-endian. The following is an example. 

```
static const uint8_t data_buffer1[] = {1, 2,  3,  4,  5,  6,  7,  8,
                                        9, 10, 11, 12, 13, 14, 15, 16};
static const void* primitive_buffers_no_nulls1[2] = {nullptr, data_buffer1};
...
 TEST_F(TestArrayImport, PrimitiveWithOffset) {
   ...
   FillPrimitive(3, 0, 1, primitive_buffers_no_nulls1);
   CheckImport(ArrayFromJSON(uint16(), "[1027, 1541, 2055]"));
```

The above code works since `03 04 05 06 07 08` is interpreted as `0x0403` (=1027), `0x0605` (=1541), and `0x0807` (=2055) on a little-endian platform. It is interpreted as `0x0304`, `0x0506`, and `0x0708` on a big-endian platform. This causes the following failure. The PR prepares `data_buffer` for each type on both endians.

```
12: [ RUN      ] TestArrayImport.PrimitiveWithOffset
12: /home/ishizaki/Arrow/arrow/cpp/src/arrow/testing/gtest_util.cc:77: Failure
12: Failed
12: 
12: @@ -0, +0 @@
12: -1027
12: -1541
12: -2055
12: +772
12: +1286
12: +1800
12: Expected:
12:   [
12:     1027,
12:     1541,
12:     2055
12:   ]
12: Actual:
12:   [
12:     772,
12:     1286,
12:     1800
12:   ]
```



