### PR TITLE
ARROW-5649: [Integration][C++] Create integration test for extension types

### DIFF
--- a/cpp/src/arrow/extension_type_test.cc
+++ b/cpp/src/arrow/extension_type_test.cc
@@ -184,7 +184,7 @@ class ExtStructType : public ExtensionType {
 
 class TestExtensionType : public ::testing::Test {
  public:
-  void SetUp() { ASSERT_OK(RegisterExtensionType(std::make_shared<UUIDType>())); }
+  void SetUp() { ASSERT_OK(RegisterExtensionType(std::make_shared<UuidType>())); }
 
   void TearDown() {
     if (GetExtensionType("uuid")) {
@@ -227,7 +227,7 @@ auto RoundtripBatch = [](const std::shared_ptr<RecordBatch>& batch,
 };
 
 TEST_F(TestExtensionType, IpcRoundtrip) {
-  auto ext_arr = ExampleUUID();
+  auto ext_arr = ExampleUuid();
   auto batch = RecordBatch::Make(schema({field("f0", uuid())}), 4, {ext_arr});
 
   std::shared_ptr<RecordBatch> read_batch;
@@ -243,7 +243,7 @@ TEST_F(TestExtensionType, IpcRoundtrip) {
 }
 
 TEST_F(TestExtensionType, UnrecognizedExtension) {
-  auto ext_arr = ExampleUUID();
+  auto ext_arr = ExampleUuid();
   auto batch = RecordBatch::Make(schema({field("f0", uuid())}), 4, {ext_arr});
 
   auto storage_arr = static_cast<const ExtensionArray&>(*ext_arr).storage();
@@ -327,7 +327,7 @@ std::shared_ptr<Array> ExampleStruct() {
 }
 
 TEST_F(TestExtensionType, ValidateExtensionArray) {
-  auto ext_arr1 = ExampleUUID();
+  auto ext_arr1 = ExampleUuid();
   auto p1_type = std::make_shared<Parametric1Type>(6);
   auto ext_arr2 = ExampleParametric(p1_type, "[null, 1, 2, 3]");
   auto ext_arr3 = ExampleStruct();

--- a/cpp/src/arrow/extension_type_test.cc
+++ b/cpp/src/arrow/extension_type_test.cc
@@ -259,7 +259,7 @@ TEST_F(TestExtensionType, UnrecognizedExtension) {
   ASSERT_OK(UnregisterExtensionType("uuid"));
   auto ext_metadata =
       key_value_metadata({{"ARROW:extension:name", "uuid"},
-                          {"ARROW:extension:metadata", "uuid-serialization"}});
+                          {"ARROW:extension:metadata", "uuid-serialized"}});
   auto ext_field = field("f0", fixed_size_binary(16), true, ext_metadata);
   auto batch_no_ext = RecordBatch::Make(schema({ext_field}), 4, {storage_arr});
 

--- a/cpp/src/arrow/extension_type_test.cc
+++ b/cpp/src/arrow/extension_type_test.cc
@@ -259,7 +259,7 @@ TEST_F(TestExtensionType, UnrecognizedExtension) {
   ASSERT_OK(UnregisterExtensionType("uuid"));
   auto ext_metadata =
       key_value_metadata({{"ARROW:extension:name", "uuid"},
-                          {"ARROW:extension:metadata", "uuid-type-unique-code"}});
+                          {"ARROW:extension:metadata", "uuid-serialization"}});
   auto ext_field = field("f0", fixed_size_binary(16), true, ext_metadata);
   auto batch_no_ext = RecordBatch::Make(schema({ext_field}), 4, {storage_arr});
 

--- a/cpp/src/arrow/flight/test_integration_client.cc
+++ b/cpp/src/arrow/flight/test_integration_client.cc
@@ -127,7 +127,7 @@ Status ConsumeFlightLocation(
 }
 
 int RunIntegrationClient() {
-  // Make sure the UUID extension type is registered, it will be referenced
+  // Make sure the Uuid extension type is registered, it will be referenced
   // in some test data.
   ExtensionTypeGuard ext_guard(uuid());
 

--- a/cpp/src/arrow/flight/test_integration_client.cc
+++ b/cpp/src/arrow/flight/test_integration_client.cc
@@ -127,9 +127,9 @@ Status ConsumeFlightLocation(
 }
 
 int RunIntegrationClient() {
-  // Make sure the Uuid extension type is registered, it will be referenced
-  // in some test data.
-  ExtensionTypeGuard ext_guard(uuid());
+  // Make sure the required extension types are registered.
+  ExtensionTypeGuard uuid_ext_guard(uuid());
+  ExtensionTypeGuard dict_ext_guard(dict_extension_type());
 
   std::unique_ptr<FlightClient> client;
   Location location;

--- a/cpp/src/arrow/flight/test_integration_client.cc
+++ b/cpp/src/arrow/flight/test_integration_client.cc
@@ -34,6 +34,7 @@
 #include "arrow/ipc/writer.h"
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
+#include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/logging.h"
 
@@ -44,35 +45,36 @@ DEFINE_string(host, "localhost", "Server port to connect to");
 DEFINE_int32(port, 31337, "Server port to connect to");
 DEFINE_string(path, "", "Resource path to request");
 
+namespace arrow {
+namespace flight {
+
 /// \brief Helper to read all batches from a JsonReader
-arrow::Status ReadBatches(std::unique_ptr<arrow::ipc::internal::json::JsonReader>& reader,
-                          std::vector<std::shared_ptr<arrow::RecordBatch>>* chunks) {
-  std::shared_ptr<arrow::RecordBatch> chunk;
+Status ReadBatches(std::unique_ptr<ipc::internal::json::JsonReader>& reader,
+                   std::vector<std::shared_ptr<RecordBatch>>* chunks) {
+  std::shared_ptr<RecordBatch> chunk;
   for (int i = 0; i < reader->num_record_batches(); i++) {
     RETURN_NOT_OK(reader->ReadRecordBatch(i, &chunk));
     RETURN_NOT_OK(chunk->ValidateFull());
     chunks->push_back(chunk);
   }
-  return arrow::Status::OK();
+  return Status::OK();
 }
 
 /// \brief Upload the a list of batches to a Flight server, validating
 /// the application metadata on the side.
-arrow::Status UploadBatchesToFlight(
-    const std::vector<std::shared_ptr<arrow::RecordBatch>>& chunks,
-    arrow::flight::FlightStreamWriter& writer,
-    arrow::flight::FlightMetadataReader& metadata_reader) {
+Status UploadBatchesToFlight(const std::vector<std::shared_ptr<RecordBatch>>& chunks,
+                             FlightStreamWriter& writer,
+                             FlightMetadataReader& metadata_reader) {
   int counter = 0;
   for (const auto& chunk : chunks) {
-    std::shared_ptr<arrow::Buffer> metadata =
-        arrow::Buffer::FromString(std::to_string(counter));
+    std::shared_ptr<Buffer> metadata = Buffer::FromString(std::to_string(counter));
     RETURN_NOT_OK(writer.WriteWithMetadata(*chunk, metadata));
     // Wait for the server to ack the result
-    std::shared_ptr<arrow::Buffer> ack_metadata;
+    std::shared_ptr<Buffer> ack_metadata;
     RETURN_NOT_OK(metadata_reader.ReadMetadata(&ack_metadata));
     if (!ack_metadata->Equals(*metadata)) {
-      return arrow::Status::Invalid("Expected metadata value: " + metadata->ToString() +
-                                    " but got: " + ack_metadata->ToString());
+      return Status::Invalid("Expected metadata value: " + metadata->ToString() +
+                             " but got: " + ack_metadata->ToString());
     }
     counter++;
   }
@@ -80,85 +82,84 @@ arrow::Status UploadBatchesToFlight(
 }
 
 /// \brief Retrieve the given Flight and compare to the original expected batches.
-arrow::Status ConsumeFlightLocation(
-    const arrow::flight::Location& location, const arrow::flight::Ticket& ticket,
-    const std::vector<std::shared_ptr<arrow::RecordBatch>>& retrieved_data) {
-  std::unique_ptr<arrow::flight::FlightClient> read_client;
-  RETURN_NOT_OK(arrow::flight::FlightClient::Connect(location, &read_client));
+Status ConsumeFlightLocation(
+    const Location& location, const Ticket& ticket,
+    const std::vector<std::shared_ptr<RecordBatch>>& retrieved_data) {
+  std::unique_ptr<FlightClient> read_client;
+  RETURN_NOT_OK(FlightClient::Connect(location, &read_client));
 
-  std::unique_ptr<arrow::flight::FlightStreamReader> stream;
+  std::unique_ptr<FlightStreamReader> stream;
   RETURN_NOT_OK(read_client->DoGet(ticket, &stream));
 
   int counter = 0;
   const int expected = static_cast<int>(retrieved_data.size());
   for (const auto& original_batch : retrieved_data) {
-    arrow::flight::FlightStreamChunk chunk;
+    FlightStreamChunk chunk;
     RETURN_NOT_OK(stream->Next(&chunk));
     if (chunk.data == nullptr) {
-      return arrow::Status::Invalid("Got fewer batches than expected, received so far: ",
-                                    counter, " expected ", expected);
+      return Status::Invalid("Got fewer batches than expected, received so far: ",
+                             counter, " expected ", expected);
     }
 
     if (!original_batch->Equals(*chunk.data)) {
-      return arrow::Status::Invalid("Batch ", counter, " does not match");
+      return Status::Invalid("Batch ", counter, " does not match");
     }
 
     const auto st = chunk.data->ValidateFull();
     if (!st.ok()) {
-      return arrow::Status::Invalid("Batch ", counter, " is not valid: ", st.ToString());
+      return Status::Invalid("Batch ", counter, " is not valid: ", st.ToString());
     }
 
     if (std::to_string(counter) != chunk.app_metadata->ToString()) {
-      return arrow::Status::Invalid(
-          "Expected metadata value: " + std::to_string(counter) +
-          " but got: " + chunk.app_metadata->ToString());
+      return Status::Invalid("Expected metadata value: " + std::to_string(counter) +
+                             " but got: " + chunk.app_metadata->ToString());
     }
     counter++;
   }
 
-  arrow::flight::FlightStreamChunk chunk;
+  FlightStreamChunk chunk;
   RETURN_NOT_OK(stream->Next(&chunk));
   if (chunk.data != nullptr) {
-    return arrow::Status::Invalid("Got more batches than the expected ", expected);
+    return Status::Invalid("Got more batches than the expected ", expected);
   }
 
-  return arrow::Status::OK();
+  return Status::OK();
 }
 
-int main(int argc, char** argv) {
-  gflags::SetUsageMessage("Integration testing client for Flight.");
-  gflags::ParseCommandLineFlags(&argc, &argv, true);
+int RunIntegrationClient() {
+  // Make sure the UUID extension type is registered, it will be referenced
+  // in some test data.
+  ExtensionTypeGuard ext_guard(uuid());
 
-  std::unique_ptr<arrow::flight::FlightClient> client;
-  arrow::flight::Location location;
-  ABORT_NOT_OK(arrow::flight::Location::ForGrpcTcp(FLAGS_host, FLAGS_port, &location));
-  ABORT_NOT_OK(arrow::flight::FlightClient::Connect(location, &client));
+  std::unique_ptr<FlightClient> client;
+  Location location;
+  ABORT_NOT_OK(Location::ForGrpcTcp(FLAGS_host, FLAGS_port, &location));
+  ABORT_NOT_OK(FlightClient::Connect(location, &client));
 
-  arrow::flight::FlightDescriptor descr{
-      arrow::flight::FlightDescriptor::PATH, "", {FLAGS_path}};
+  FlightDescriptor descr{FlightDescriptor::PATH, "", {FLAGS_path}};
 
   // 1. Put the data to the server.
-  std::unique_ptr<arrow::ipc::internal::json::JsonReader> reader;
+  std::unique_ptr<ipc::internal::json::JsonReader> reader;
   std::cout << "Opening JSON file '" << FLAGS_path << "'" << std::endl;
-  auto in_file = *arrow::io::ReadableFile::Open(FLAGS_path);
-  ABORT_NOT_OK(arrow::ipc::internal::json::JsonReader::Open(arrow::default_memory_pool(),
-                                                            in_file, &reader));
+  auto in_file = *io::ReadableFile::Open(FLAGS_path);
+  ABORT_NOT_OK(
+      ipc::internal::json::JsonReader::Open(default_memory_pool(), in_file, &reader));
 
-  std::shared_ptr<arrow::Schema> original_schema = reader->schema();
-  std::vector<std::shared_ptr<arrow::RecordBatch>> original_data;
+  std::shared_ptr<Schema> original_schema = reader->schema();
+  std::vector<std::shared_ptr<RecordBatch>> original_data;
   ABORT_NOT_OK(ReadBatches(reader, &original_data));
 
-  std::unique_ptr<arrow::flight::FlightStreamWriter> write_stream;
-  std::unique_ptr<arrow::flight::FlightMetadataReader> metadata_reader;
+  std::unique_ptr<FlightStreamWriter> write_stream;
+  std::unique_ptr<FlightMetadataReader> metadata_reader;
   ABORT_NOT_OK(client->DoPut(descr, original_schema, &write_stream, &metadata_reader));
   ABORT_NOT_OK(UploadBatchesToFlight(original_data, *write_stream, *metadata_reader));
 
   // 2. Get the ticket for the data.
-  std::unique_ptr<arrow::flight::FlightInfo> info;
+  std::unique_ptr<FlightInfo> info;
   ABORT_NOT_OK(client->GetFlightInfo(descr, &info));
 
-  std::shared_ptr<arrow::Schema> schema;
-  arrow::ipc::DictionaryMemo dict_memo;
+  std::shared_ptr<Schema> schema;
+  ipc::DictionaryMemo dict_memo;
   ABORT_NOT_OK(info->GetSchema(&dict_memo, &schema));
 
   if (info->endpoints().size() == 0) {
@@ -166,7 +167,7 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  for (const arrow::flight::FlightEndpoint& endpoint : info->endpoints()) {
+  for (const FlightEndpoint& endpoint : info->endpoints()) {
     const auto& ticket = endpoint.ticket;
 
     auto locations = endpoint.locations;
@@ -181,4 +182,12 @@ int main(int argc, char** argv) {
     }
   }
   return 0;
+}
+
+}  // namespace flight
+}  // namespace arrow
+
+int main(int argc, char** argv) {
+  gflags::SetUsageMessage("Integration testing client for Flight.");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
 }

--- a/cpp/src/arrow/flight/test_integration_client.cc
+++ b/cpp/src/arrow/flight/test_integration_client.cc
@@ -190,4 +190,5 @@ int RunIntegrationClient() {
 int main(int argc, char** argv) {
   gflags::SetUsageMessage("Integration testing client for Flight.");
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  return arrow::flight::RunIntegrationClient();
 }

--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -23,11 +23,16 @@
 #include <vector>
 
 #include "arrow/array.h"
+#include "arrow/extension_type.h"
 #include "arrow/record_batch.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace ipc {
 
 // ----------------------------------------------------------------------
@@ -58,13 +63,16 @@ Status DictionaryMemo::GetDictionary(int64_t id,
 Status DictionaryMemo::AddFieldInternal(int64_t id, const std::shared_ptr<Field>& field) {
   field_to_id_[field.get()] = id;
 
-  if (field->type()->id() != Type::DICTIONARY) {
-    return Status::Invalid("Field type was not DictionaryType",
-                           field->type()->ToString());
+  auto field_type = field->type();
+  if (field_type->id() == Type::EXTENSION) {
+    field_type = checked_cast<const ExtensionType&>(*field_type).storage_type();
+  }
+  if (field_type->id() != Type::DICTIONARY) {
+    return Status::Invalid("Field type was not DictionaryType: ", field_type->ToString());
   }
 
   std::shared_ptr<DataType> value_type =
-      static_cast<const DictionaryType&>(*field->type()).value_type();
+      checked_cast<const DictionaryType&>(*field_type).value_type();
 
   // Add the value type for the dictionary
   auto it = id_to_type_.find(id);
@@ -142,25 +150,29 @@ struct DictionaryCollector {
   Status WalkChildren(const DataType& type, const Array& array) {
     for (int i = 0; i < type.num_children(); ++i) {
       auto boxed_child = MakeArray(array.data()->child_data[i]);
-      RETURN_NOT_OK(Visit(type.child(i), *boxed_child));
+      RETURN_NOT_OK(Visit(type.child(i), boxed_child.get()));
     }
     return Status::OK();
   }
 
-  Status Visit(const std::shared_ptr<Field>& field, const Array& array) {
-    auto type = array.type();
+  Status Visit(const std::shared_ptr<Field>& field, const Array* array) {
+    const DataType* type = array->type().get();
+    if (type->id() == Type::EXTENSION) {
+      type = checked_cast<const ExtensionType&>(*type).storage_type().get();
+      array = checked_cast<const ExtensionArray&>(*array).storage().get();
+    }
     if (type->id() == Type::DICTIONARY) {
-      const auto& dict_array = static_cast<const DictionaryArray&>(array);
+      const auto& dict_array = checked_cast<const DictionaryArray&>(*array);
       auto dictionary = dict_array.dictionary();
       int64_t id = -1;
       RETURN_NOT_OK(dictionary_memo_->GetOrAssignId(field, &id));
       RETURN_NOT_OK(dictionary_memo_->AddDictionary(id, dictionary));
 
       // Traverse the dictionary to gather any nested dictionaries
-      const auto& dict_type = static_cast<const DictionaryType&>(*type);
+      const auto& dict_type = checked_cast<const DictionaryType&>(*type);
       RETURN_NOT_OK(WalkChildren(*dict_type.value_type(), *dictionary));
     } else {
-      RETURN_NOT_OK(WalkChildren(*type, array));
+      RETURN_NOT_OK(WalkChildren(*type, *array));
     }
     return Status::OK();
   }
@@ -168,7 +180,7 @@ struct DictionaryCollector {
   Status Collect(const RecordBatch& batch) {
     const Schema& schema = *batch.schema();
     for (int i = 0; i < schema.num_fields(); ++i) {
-      RETURN_NOT_OK(Visit(schema.field(i), *batch.column(i)));
+      RETURN_NOT_OK(Visit(schema.field(i), batch.column(i).get()));
     }
     return Status::OK();
   }

--- a/cpp/src/arrow/ipc/generate_fuzz_corpus.cc
+++ b/cpp/src/arrow/ipc/generate_fuzz_corpus.cc
@@ -44,7 +44,7 @@ using ::arrow::internal::PlatformFilename;
 using internal::json::ArrayFromJSON;
 
 Result<std::shared_ptr<RecordBatch>> MakeExtensionBatch() {
-  auto array = ExampleUUID();
+  auto array = ExampleUuid();
   auto md = key_value_metadata({"key1", "key2"}, {"value1", ""});
   auto schema = ::arrow::schema({field("f0", array->type())}, md);
   return RecordBatch::Make(schema, array->length(), {array});

--- a/cpp/src/arrow/ipc/json_integration_test.cc
+++ b/cpp/src/arrow/ipc/json_integration_test.cc
@@ -35,6 +35,7 @@
 #include "arrow/pretty_print.h"
 #include "arrow/record_batch.h"
 #include "arrow/status.h"
+#include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
 #include "arrow/util/io_util.h"
@@ -181,6 +182,10 @@ static Status ValidateArrowVsJson(const std::string& arrow_path,
 
 Status RunCommand(const std::string& json_path, const std::string& arrow_path,
                   const std::string& command) {
+  // Make sure the UUID extension type is registered, it will be referenced
+  // in some test data.
+  ExtensionTypeGuard ext_guard(uuid());
+
   if (json_path == "") {
     return Status::Invalid("Must specify json file name");
   }

--- a/cpp/src/arrow/ipc/json_integration_test.cc
+++ b/cpp/src/arrow/ipc/json_integration_test.cc
@@ -182,7 +182,7 @@ static Status ValidateArrowVsJson(const std::string& arrow_path,
 
 Status RunCommand(const std::string& json_path, const std::string& arrow_path,
                   const std::string& command) {
-  // Make sure the UUID extension type is registered, it will be referenced
+  // Make sure the Uuid extension type is registered, it will be referenced
   // in some test data.
   ExtensionTypeGuard ext_guard(uuid());
 

--- a/cpp/src/arrow/ipc/json_integration_test.cc
+++ b/cpp/src/arrow/ipc/json_integration_test.cc
@@ -182,9 +182,10 @@ static Status ValidateArrowVsJson(const std::string& arrow_path,
 
 Status RunCommand(const std::string& json_path, const std::string& arrow_path,
                   const std::string& command) {
-  // Make sure the Uuid extension type is registered, it will be referenced
-  // in some test data.
-  ExtensionTypeGuard ext_guard(uuid());
+  // Make sure the required extension types are registered, as they will be
+  // referenced in test data.
+  ExtensionTypeGuard uuid_ext_guard(uuid());
+  ExtensionTypeGuard dict_ext_guard(dict_extension_type());
 
   if (json_path == "") {
     return Status::Invalid("Must specify json file name");

--- a/cpp/src/arrow/ipc/json_test.cc
+++ b/cpp/src/arrow/ipc/json_test.cc
@@ -547,12 +547,12 @@ TEST(TestJsonFileReadWrite, JsonExample2) {
 
     auto storage_array =
         ArrayFromJSON(fixed_size_binary(16), R"(["0123456789abcdef", null])");
-    AssertArraysEqual(*batch->column(0), UUIDArray(uuid_type, storage_array));
+    AssertArraysEqual(*batch->column(0), UuidArray(uuid_type, storage_array));
 
     AssertArraysEqual(*batch->column(1), NullArray(2));
   }
 
-  // Should fail now that the UUID extension is unregistered
+  // Should fail now that the Uuid extension is unregistered
   ASSERT_RAISES(KeyError, JsonReader::Open(buffer, &reader));
 }
 

--- a/cpp/src/arrow/ipc/json_test.cc
+++ b/cpp/src/arrow/ipc/json_test.cc
@@ -103,7 +103,7 @@ static const char* json_example2 = R"example(
         "children" : [],
         "metadata" : [
            {"key": "ARROW:extension:name", "value": "uuid"},
-           {"key": "ARROW:extension:metadata", "value": "uuid-serialization"}
+           {"key": "ARROW:extension:metadata", "value": "uuid-serialized"}
         ]
       },
       {
@@ -164,7 +164,7 @@ static const char* json_example3 = R"example(
         },
         "metadata" : [
            {"key": "ARROW:extension:name", "value": "dict-extension"},
-           {"key": "ARROW:extension:metadata", "value": ""}
+           {"key": "ARROW:extension:metadata", "value": "dict-extension-serialized"}
         ]
       }
     ]

--- a/cpp/src/arrow/ipc/json_test.cc
+++ b/cpp/src/arrow/ipc/json_test.cc
@@ -33,18 +33,187 @@
 #include "arrow/ipc/test_common.h"
 #include "arrow/memory_pool.h"
 #include "arrow/record_batch.h"
+#include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/checked_cast.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace ipc {
 namespace internal {
 namespace json {
 
 using namespace ::arrow::ipc::test;  // NOLINT
+
+static const char* json_example1 = R"example(
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "foo",
+        "type": {"name": "int", "isSigned": true, "bitWidth": 32},
+        "nullable": true, "children": []
+      },
+      {
+        "name": "bar",
+        "type": {"name": "floatingpoint", "precision": "DOUBLE"},
+        "nullable": true, "children": []
+      }
+    ]
+  },
+  "batches": [
+    {
+      "count": 5,
+      "columns": [
+        {
+          "name": "foo",
+          "count": 5,
+          "DATA": [1, 2, 3, 4, 5],
+          "VALIDITY": [1, 0, 1, 1, 1]
+        },
+        {
+          "name": "bar",
+          "count": 5,
+          "DATA": [1.0, 2.0, 3.0, 4.0, 5.0],
+          "VALIDITY": [1, 0, 0, 1, 1]
+        }
+      ]
+    }
+  ]
+}
+)example";
+
+static const char* json_example2 = R"example(
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "uuids",
+        "type" : {
+           "name" : "fixedsizebinary",
+           "byteWidth" : 16
+        },
+        "nullable": true,
+        "children" : [],
+        "metadata" : [
+           {"key": "ARROW:extension:name", "value": "uuid"},
+           {"key": "ARROW:extension:metadata", "value": "uuid-serialization"}
+        ]
+      },
+      {
+        "name": "things",
+        "type" : {
+           "name" : "null"
+        },
+        "nullable": true,
+        "children" : [],
+        "metadata" : [
+           {"key": "ARROW:extension:name", "value": "!doesn't exist!"},
+           {"key": "ARROW:extension:metadata", "value": ""},
+           {"key": "ARROW:integration:allow_unregistered_extension", "value": "true"}
+        ]
+      }
+    ]
+  },
+  "batches": [
+    {
+      "count": 2,
+      "columns": [
+        {
+          "name": "uuids",
+          "count": 2,
+          "DATA": ["30313233343536373839616263646566",
+                   "00000000000000000000000000000000"],
+          "VALIDITY": [1, 0]
+        },
+        {
+          "name": "things",
+          "count": 2
+        }
+      ]
+    }
+  ]
+}
+)example";
+
+static const char* json_example3 = R"example(
+{
+  "schema": {
+    "fields": [
+      {
+        "name": "dict-extensions",
+        "type" : {
+           "name" : "utf8"
+        },
+        "nullable": true,
+        "children" : [],
+        "dictionary": {
+          "id": 0,
+          "indexType": {
+            "name": "int",
+            "isSigned": true,
+            "bitWidth": 8
+          },
+          "isOrdered": false
+        },
+        "metadata" : [
+           {"key": "ARROW:extension:name", "value": "dict-extension"},
+           {"key": "ARROW:extension:metadata", "value": ""}
+        ]
+      }
+    ]
+  },
+  "dictionaries": [
+    {
+      "id": 0,
+      "data": {
+        "count": 10,
+        "columns": [
+          {
+            "name": "DICT0",
+            "count": 3,
+            "VALIDITY": [
+              1,
+              1,
+              1
+            ],
+            "OFFSET": [
+              0,
+              3,
+              6,
+              10
+            ],
+            "DATA": [
+              "foo",
+              "bar",
+              "quux"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "batches": [
+    {
+      "count": 5,
+      "columns": [
+        {
+          "name": "dict-extensions",
+          "count": 5,
+          "DATA": [2, 0, 1, 1, 2],
+          "VALIDITY": [1, 1, 0, 1, 1]
+        }
+      ]
+    }
+  ]
+}
+)example";
 
 void TestSchemaRoundTrip(const Schema& schema) {
   rj::StringBuffer sb;
@@ -329,46 +498,8 @@ TEST(TestJsonFileReadWrite, BasicRoundTrip) {
   }
 }
 
-TEST(TestJsonFileReadWrite, MinimalFormatExample) {
-  static const char* example = R"example(
-{
-  "schema": {
-    "fields": [
-      {
-        "name": "foo",
-        "type": {"name": "int", "isSigned": true, "bitWidth": 32},
-        "nullable": true, "children": []
-      },
-      {
-        "name": "bar",
-        "type": {"name": "floatingpoint", "precision": "DOUBLE"},
-        "nullable": true, "children": []
-      }
-    ]
-  },
-  "batches": [
-    {
-      "count": 5,
-      "columns": [
-        {
-          "name": "foo",
-          "count": 5,
-          "DATA": [1, 2, 3, 4, 5],
-          "VALIDITY": [1, 0, 1, 1, 1]
-        },
-        {
-          "name": "bar",
-          "count": 5,
-          "DATA": [1.0, 2.0, 3.0, 4.0, 5.0],
-          "VALIDITY": [1, 0, 0, 1, 1]
-        }
-      ]
-    }
-  ]
-}
-)example";
-
-  auto buffer = Buffer::Wrap(example, strlen(example));
+TEST(TestJsonFileReadWrite, JsonExample1) {
+  auto buffer = Buffer::Wrap(json_example1, strlen(json_example1));
 
   std::unique_ptr<JsonReader> reader;
   ASSERT_OK(JsonReader::Open(buffer, &reader));
@@ -394,13 +525,68 @@ TEST(TestJsonFileReadWrite, MinimalFormatExample) {
   ASSERT_TRUE(batch->column(1)->Equals(bar));
 }
 
-#define BATCH_CASES()                                                              \
-  ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch,                     \
-                    &MakeFixedSizeListRecordBatch, &MakeNonNullRecordBatch,        \
-                    &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,             \
-                    &MakeStringTypesRecordBatchWithNulls, &MakeStruct, &MakeUnion, \
-                    &MakeDates, &MakeTimestamps, &MakeTimes, &MakeFWBinary,        \
-                    &MakeDecimal, &MakeDictionary, &MakeIntervals)
+TEST(TestJsonFileReadWrite, JsonExample2) {
+  // Example 2: two extension types (one registered, one unregistered)
+  auto uuid_type = uuid();
+  auto buffer = Buffer::Wrap(json_example2, strlen(json_example2));
+
+  std::unique_ptr<JsonReader> reader;
+  {
+    ExtensionTypeGuard ext_guard(uuid_type);
+
+    ASSERT_OK(JsonReader::Open(buffer, &reader));
+    // The second field is an unregistered extension and will be read as
+    // its underlying storage.
+    Schema ex_schema({field("uuids", uuid_type), field("things", null())});
+
+    AssertSchemaEqual(ex_schema, *reader->schema());
+    ASSERT_EQ(1, reader->num_record_batches());
+
+    std::shared_ptr<RecordBatch> batch;
+    ASSERT_OK(reader->ReadRecordBatch(0, &batch));
+
+    auto storage_array =
+        ArrayFromJSON(fixed_size_binary(16), R"(["0123456789abcdef", null])");
+    AssertArraysEqual(*batch->column(0), UUIDArray(uuid_type, storage_array));
+
+    AssertArraysEqual(*batch->column(1), NullArray(2));
+  }
+
+  // Should fail now that the UUID extension is unregistered
+  ASSERT_RAISES(KeyError, JsonReader::Open(buffer, &reader));
+}
+
+TEST(TestJsonFileReadWrite, JsonExample3) {
+  // Example 3: An extension type with a dictionary storage type
+  auto dict_ext_type = std::make_shared<DictExtensionType>();
+  auto buffer = Buffer::Wrap(json_example3, strlen(json_example3));
+
+  ExtensionTypeGuard ext_guard(dict_ext_type);
+
+  std::unique_ptr<JsonReader> reader;
+  ASSERT_OK(JsonReader::Open(buffer, &reader));
+  Schema ex_schema({field("dict-extensions", dict_ext_type)});
+
+  AssertSchemaEqual(ex_schema, *reader->schema());
+  ASSERT_EQ(1, reader->num_record_batches());
+
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(reader->ReadRecordBatch(0, &batch));
+
+  auto storage_array = std::make_shared<DictionaryArray>(
+      dict_ext_type->storage_type(), ArrayFromJSON(int8(), "[2, 0, null, 1, 2]"),
+      ArrayFromJSON(utf8(), R"(["foo", "bar", "quux"])"));
+  AssertArraysEqual(*batch->column(0), ExtensionArray(dict_ext_type, storage_array),
+                    /*verbose=*/true);
+}
+
+#define BATCH_CASES()                                                             \
+  ::testing::Values(                                                              \
+      &MakeIntRecordBatch, &MakeListRecordBatch, &MakeFixedSizeListRecordBatch,   \
+      &MakeNonNullRecordBatch, &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList, \
+      &MakeStringTypesRecordBatchWithNulls, &MakeStruct, &MakeUnion, &MakeDates,  \
+      &MakeTimestamps, &MakeTimes, &MakeFWBinary, &MakeDecimal, &MakeDictionary,  \
+      &MakeIntervals, &MakeUuid, &MakeDictExtension)
 
 class TestJsonRoundTrip : public ::testing::TestWithParam<MakeRecordBatch*> {
  public:
@@ -409,6 +595,9 @@ class TestJsonRoundTrip : public ::testing::TestWithParam<MakeRecordBatch*> {
 };
 
 void CheckRoundtrip(const RecordBatch& batch) {
+  ExtensionTypeGuard uuid_ext_guard(uuid());
+  ExtensionTypeGuard dict_ext_guard(dict_extension_type());
+
   TestSchemaRoundTrip(*batch.schema());
 
   std::unique_ptr<JsonWriter> writer;

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -60,8 +60,9 @@ class Message::MessageImpl {
 
     if (message_->custom_metadata() != nullptr) {
       // Deserialize from Flatbuffers if first time called
-      RETURN_NOT_OK(
-          internal::GetKeyValueMetadata(message_->custom_metadata(), &custom_metadata_));
+      std::shared_ptr<KeyValueMetadata> md;
+      RETURN_NOT_OK(internal::GetKeyValueMetadata(message_->custom_metadata(), &md));
+      custom_metadata_ = std::move(md);  // const-ify
     }
 
     return Status::OK();

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -358,36 +358,6 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
   }
 }
 
-static Status TypeFromFlatbuffer(const flatbuf::Field* field,
-                                 const std::vector<std::shared_ptr<Field>>& children,
-                                 const KeyValueMetadata* field_metadata,
-                                 std::shared_ptr<DataType>* out) {
-  auto type_data = field->type();
-  CHECK_FLATBUFFERS_NOT_NULL(type_data, "Field.type");
-  RETURN_NOT_OK(ConcreteTypeFromFlatbuffer(field->type_type(), type_data, children, out));
-
-  // Look for extension metadata in custom_metadata field
-  // TODO(wesm): Should this be part of the Field Flatbuffers table?
-  if (field_metadata != nullptr) {
-    int name_index = field_metadata->FindKey(kExtensionTypeKeyName);
-    if (name_index == -1) {
-      return Status::OK();
-    }
-    std::string type_name = field_metadata->value(name_index);
-    int data_index = field_metadata->FindKey(kExtensionMetadataKeyName);
-    std::string type_data = data_index == -1 ? "" : field_metadata->value(data_index);
-
-    std::shared_ptr<ExtensionType> type = GetExtensionType(type_name);
-    if (type == nullptr) {
-      // TODO(wesm): Extension type is unknown; we do not raise here and simply
-      // return the raw data
-      return Status::OK();
-    }
-    ARROW_ASSIGN_OR_RAISE(*out, type->Deserialize(*out, type_data));
-  }
-  return Status::OK();
-}
-
 Status TensorTypeToFlatbuffer(FBB& fbb, const DataType& type, flatbuf::Type* out_type,
                               Offset* offset) {
   switch (type.id()) {
@@ -426,12 +396,11 @@ Status TensorTypeToFlatbuffer(FBB& fbb, const DataType& type, flatbuf::Type* out
   return Status::OK();
 }
 
-Status GetDictionaryEncoding(FBB& fbb, const std::shared_ptr<Field>& field,
-                             DictionaryMemo* memo, DictionaryOffset* out) {
+static Status GetDictionaryEncoding(FBB& fbb, const std::shared_ptr<Field>& field,
+                                    const DictionaryType& type, DictionaryMemo* memo,
+                                    DictionaryOffset* out) {
   int64_t dictionary_id = -1;
   RETURN_NOT_OK(memo->GetOrAssignId(field, &dictionary_id));
-
-  const auto& type = checked_cast<const DictionaryType&>(*field->type());
 
   // We assume that the dictionary index type (as an integer) has already been
   // validated elsewhere, and can safely assume we are dealing with signed
@@ -685,8 +654,15 @@ class FieldToFlatbufferVisitor {
     auto fb_children = fbb_.CreateVector(children_.data(), children_.size());
 
     DictionaryOffset dictionary = 0;
-    if (field->type()->id() == Type::DICTIONARY) {
-      RETURN_NOT_OK(GetDictionaryEncoding(fbb_, field, dictionary_memo_, &dictionary));
+    const DataType* storage_type = field->type().get();
+    if (storage_type->id() == Type::EXTENSION) {
+      storage_type =
+          checked_cast<const ExtensionType&>(*storage_type).storage_type().get();
+    }
+    if (storage_type->id() == Type::DICTIONARY) {
+      RETURN_NOT_OK(GetDictionaryEncoding(
+          fbb_, field, checked_cast<const DictionaryType&>(*storage_type),
+          dictionary_memo_, &dictionary));
     }
 
     auto metadata = field->metadata();
@@ -733,19 +709,24 @@ Status FieldFromFlatbuffer(const flatbuf::Field* field, DictionaryMemo* dictiona
   RETURN_NOT_OK(internal::GetKeyValueMetadata(field->custom_metadata(), &metadata));
 
   // Reconstruct the data type
-  auto children = field->children();
+  // 1. Data type children
+  const auto& children = field->children();
   CHECK_FLATBUFFERS_NOT_NULL(children, "Field.children");
   std::vector<std::shared_ptr<Field>> child_fields(children->size());
   for (int i = 0; i < static_cast<int>(children->size()); ++i) {
     RETURN_NOT_OK(
         FieldFromFlatbuffer(children->Get(i), dictionary_memo, &child_fields[i]));
   }
-  RETURN_NOT_OK(TypeFromFlatbuffer(field, child_fields, metadata.get(), &type));
 
-  auto field_name = StringFromFlatbuffers(field->name());
+  // 2. Top-level concrete data type
+  auto type_data = field->type();
+  CHECK_FLATBUFFERS_NOT_NULL(type_data, "Field.type");
+  RETURN_NOT_OK(
+      ConcreteTypeFromFlatbuffer(field->type_type(), type_data, child_fields, &type));
 
+  // 3. Is it a dictionary type?
+  int64_t dictionary_id = -1;
   const flatbuf::DictionaryEncoding* encoding = field->dictionary();
-
   if (encoding != nullptr) {
     // The field is dictionary-encoded. Construct the DictionaryType
     // based on the DictionaryEncoding metadata and record in the
@@ -756,10 +737,33 @@ Status FieldFromFlatbuffer(const flatbuf::Field* field, DictionaryMemo* dictiona
     RETURN_NOT_OK(IntFromFlatbuffer(int_data, &index_type));
     ARROW_ASSIGN_OR_RAISE(type,
                           DictionaryType::Make(index_type, type, encoding->isOrdered()));
-    *out = ::arrow::field(field_name, type, field->nullable(), metadata);
-    RETURN_NOT_OK(dictionary_memo->AddField(encoding->id(), *out));
-  } else {
-    *out = ::arrow::field(field_name, type, field->nullable(), metadata);
+    dictionary_id = encoding->id();
+  }
+
+  // 4. Is it an extension type?
+  if (metadata != nullptr) {
+    // Look for extension metadata in custom_metadata field
+    int name_index = metadata->FindKey(kExtensionTypeKeyName);
+    if (name_index != -1) {
+      std::string type_name = metadata->value(name_index);
+      int data_index = metadata->FindKey(kExtensionMetadataKeyName);
+      std::string type_data = data_index == -1 ? "" : metadata->value(data_index);
+
+      std::shared_ptr<ExtensionType> ext_type = GetExtensionType(type_name);
+      if (ext_type != nullptr) {
+        ARROW_ASSIGN_OR_RAISE(type, ext_type->Deserialize(type, type_data));
+      }
+    }
+    // NOTE: if extension type is unknown, we do not raise here and
+    // simply return the storage type.
+  }
+
+  // Reconstruct field
+  auto field_name = StringFromFlatbuffers(field->name());
+  *out =
+      ::arrow::field(std::move(field_name), type, field->nullable(), std::move(metadata));
+  if (dictionary_id != -1) {
+    RETURN_NOT_OK(dictionary_memo->AddField(dictionary_id, *out));
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -152,7 +152,7 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
                                SparseTensorFormat::type* sparse_tensor_format_id);
 
 Status GetKeyValueMetadata(const KVVector* fb_metadata,
-                           std::shared_ptr<const KeyValueMetadata>* out);
+                           std::shared_ptr<KeyValueMetadata>* out);
 
 static inline Status VerifyMessage(const uint8_t* data, int64_t size,
                                    const flatbuf::Message** out) {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -455,7 +455,7 @@ Status GetCompression(const flatbuf::Message* message, Compression::type* out) {
   *out = Compression::UNCOMPRESSED;
   if (message->custom_metadata() != nullptr) {
     // TODO: Ensure this deserialization only ever happens once
-    std::shared_ptr<const KeyValueMetadata> metadata;
+    std::shared_ptr<KeyValueMetadata> metadata;
     RETURN_NOT_OK(internal::GetKeyValueMetadata(message->custom_metadata(), &metadata));
     int index = metadata->FindKey("ARROW:experimental_compression");
     if (index != -1) {
@@ -899,7 +899,9 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
 
     auto fb_metadata = footer_->custom_metadata();
     if (fb_metadata != nullptr) {
-      RETURN_NOT_OK(internal::GetKeyValueMetadata(fb_metadata, &metadata_));
+      std::shared_ptr<KeyValueMetadata> md;
+      RETURN_NOT_OK(internal::GetKeyValueMetadata(fb_metadata, &md));
+      metadata_ = std::move(md);  // const-ify
     }
 
     return Status::OK();

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -770,9 +770,9 @@ Status MakeUuid(std::shared_ptr<RecordBatch>* out) {
   auto f1 = field("f1", uuid_type, /*nullable=*/false);
   auto schema = ::arrow::schema({f0, f1});
 
-  auto a0 = std::make_shared<UUIDArray>(
+  auto a0 = std::make_shared<UuidArray>(
       uuid_type, ArrayFromJSON(storage_type, R"(["0123456789abcdef", null])"));
-  auto a1 = std::make_shared<UUIDArray>(
+  auto a1 = std::make_shared<UuidArray>(
       uuid_type,
       ArrayFromJSON(storage_type, R"(["ZYXWVUTSRQPONMLK", "JIHGFEDBA9876543"])"));
 

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -30,14 +30,19 @@
 #include "arrow/pretty_print.h"
 #include "arrow/record_batch.h"
 #include "arrow/status.h"
+#include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/checked_cast.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+
 namespace ipc {
 namespace test {
 
@@ -754,6 +759,46 @@ Status MakeNull(std::shared_ptr<RecordBatch>* out) {
   ArrayFromVector<Int64Type, int64_t>(f1->type(), is_valid, int_values, &a2);
 
   *out = RecordBatch::Make(schema, a1->length(), {a1, a2});
+  return Status::OK();
+}
+
+Status MakeUuid(std::shared_ptr<RecordBatch>* out) {
+  auto uuid_type = uuid();
+  auto storage_type = checked_cast<const ExtensionType&>(*uuid_type).storage_type();
+
+  auto f0 = field("f0", uuid_type);
+  auto f1 = field("f1", uuid_type, /*nullable=*/false);
+  auto schema = ::arrow::schema({f0, f1});
+
+  auto a0 = std::make_shared<UUIDArray>(
+      uuid_type, ArrayFromJSON(storage_type, R"(["0123456789abcdef", null])"));
+  auto a1 = std::make_shared<UUIDArray>(
+      uuid_type,
+      ArrayFromJSON(storage_type, R"(["ZYXWVUTSRQPONMLK", "JIHGFEDBA9876543"])"));
+
+  *out = RecordBatch::Make(schema, a1->length(), {a0, a1});
+  return Status::OK();
+}
+
+Status MakeDictExtension(std::shared_ptr<RecordBatch>* out) {
+  auto type = dict_extension_type();
+  auto storage_type = checked_cast<const ExtensionType&>(*type).storage_type();
+
+  auto f0 = field("f0", type);
+  auto f1 = field("f1", type, /*nullable=*/false);
+  auto schema = ::arrow::schema({f0, f1});
+
+  auto storage0 = std::make_shared<DictionaryArray>(
+      storage_type, ArrayFromJSON(int8(), "[1, 0, null, 1, 1]"),
+      ArrayFromJSON(utf8(), R"(["foo", "bar"])"));
+  auto a0 = std::make_shared<ExtensionArray>(type, storage0);
+
+  auto storage1 = std::make_shared<DictionaryArray>(
+      storage_type, ArrayFromJSON(int8(), "[2, 0, 0, 1, 1]"),
+      ArrayFromJSON(utf8(), R"(["arrow", "parquet", "plasma"])"));
+  auto a1 = std::make_shared<ExtensionArray>(type, storage1);
+
+  *out = RecordBatch::Make(schema, a1->length(), {a0, a1});
   return Status::OK();
 }
 

--- a/cpp/src/arrow/ipc/test_common.h
+++ b/cpp/src/arrow/ipc/test_common.h
@@ -136,6 +136,12 @@ Status MakeDecimal(std::shared_ptr<RecordBatch>* out);
 ARROW_EXPORT
 Status MakeNull(std::shared_ptr<RecordBatch>* out);
 
+ARROW_EXPORT
+Status MakeUuid(std::shared_ptr<RecordBatch>* out);
+
+ARROW_EXPORT
+Status MakeDictExtension(std::shared_ptr<RecordBatch>* out);
+
 }  // namespace test
 }  // namespace ipc
 }  // namespace arrow

--- a/cpp/src/arrow/testing/extension_type.h
+++ b/cpp/src/arrow/testing/extension_type.h
@@ -26,14 +26,14 @@
 
 namespace arrow {
 
-class ARROW_EXPORT UUIDArray : public ExtensionArray {
+class ARROW_EXPORT UuidArray : public ExtensionArray {
  public:
   using ExtensionArray::ExtensionArray;
 };
 
-class ARROW_EXPORT UUIDType : public ExtensionType {
+class ARROW_EXPORT UuidType : public ExtensionType {
  public:
-  UUIDType() : ExtensionType(fixed_size_binary(16)) {}
+  UuidType() : ExtensionType(fixed_size_binary(16)) {}
 
   std::string extension_name() const override { return "uuid"; }
 
@@ -97,7 +97,7 @@ ARROW_EXPORT
 std::shared_ptr<DataType> dict_extension_type();
 
 ARROW_EXPORT
-std::shared_ptr<Array> ExampleUUID();
+std::shared_ptr<Array> ExampleUuid();
 
 ARROW_EXPORT
 std::shared_ptr<Array> ExampleSmallint();

--- a/cpp/src/arrow/testing/extension_type.h
+++ b/cpp/src/arrow/testing/extension_type.h
@@ -108,8 +108,11 @@ class ARROW_EXPORT ExtensionTypeGuard {
  public:
   explicit ExtensionTypeGuard(const std::shared_ptr<DataType>& type);
   ~ExtensionTypeGuard();
+  ARROW_DEFAULT_MOVE_AND_ASSIGN(ExtensionTypeGuard);
 
  protected:
+  ARROW_DISALLOW_COPY_AND_ASSIGN(ExtensionTypeGuard);
+
   std::string extension_name_;
 };
 

--- a/cpp/src/arrow/testing/extension_type.h
+++ b/cpp/src/arrow/testing/extension_type.h
@@ -45,7 +45,7 @@ class ARROW_EXPORT UuidType : public ExtensionType {
       std::shared_ptr<DataType> storage_type,
       const std::string& serialized) const override;
 
-  std::string Serialize() const override { return "uuid-serialization"; }
+  std::string Serialize() const override { return "uuid-serialized"; }
 };
 
 class ARROW_EXPORT SmallintArray : public ExtensionArray {
@@ -84,7 +84,7 @@ class ARROW_EXPORT DictExtensionType : public ExtensionType {
       std::shared_ptr<DataType> storage_type,
       const std::string& serialized) const override;
 
-  std::string Serialize() const override { return ""; }
+  std::string Serialize() const override { return "dict-extension-serialized"; }
 };
 
 ARROW_EXPORT

--- a/cpp/src/arrow/testing/extension_type.h
+++ b/cpp/src/arrow/testing/extension_type.h
@@ -45,7 +45,7 @@ class ARROW_EXPORT UUIDType : public ExtensionType {
       std::shared_ptr<DataType> storage_type,
       const std::string& serialized) const override;
 
-  std::string Serialize() const override { return "uuid-type-unique-code"; }
+  std::string Serialize() const override { return "uuid-serialization"; }
 };
 
 class ARROW_EXPORT SmallintArray : public ExtensionArray {
@@ -70,6 +70,23 @@ class ARROW_EXPORT SmallintType : public ExtensionType {
   std::string Serialize() const override { return "smallint"; }
 };
 
+class ARROW_EXPORT DictExtensionType : public ExtensionType {
+ public:
+  DictExtensionType() : ExtensionType(dictionary(int8(), utf8())) {}
+
+  std::string extension_name() const override { return "dict-extension"; }
+
+  bool ExtensionEquals(const ExtensionType& other) const override;
+
+  std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override;
+
+  Result<std::shared_ptr<DataType>> Deserialize(
+      std::shared_ptr<DataType> storage_type,
+      const std::string& serialized) const override;
+
+  std::string Serialize() const override { return ""; }
+};
+
 ARROW_EXPORT
 std::shared_ptr<DataType> uuid();
 
@@ -77,9 +94,23 @@ ARROW_EXPORT
 std::shared_ptr<DataType> smallint();
 
 ARROW_EXPORT
+std::shared_ptr<DataType> dict_extension_type();
+
+ARROW_EXPORT
 std::shared_ptr<Array> ExampleUUID();
 
 ARROW_EXPORT
 std::shared_ptr<Array> ExampleSmallint();
+
+// A RAII class that registers an extension type on construction
+// and unregisters it on destruction.
+class ARROW_EXPORT ExtensionTypeGuard {
+ public:
+  explicit ExtensionTypeGuard(const std::shared_ptr<DataType>& type);
+  ~ExtensionTypeGuard();
+
+ protected:
+  std::string extension_name_;
+};
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -386,25 +386,25 @@ void SleepFor(double seconds) {
 ///////////////////////////////////////////////////////////////////////////
 // Extension types
 
-bool UUIDType::ExtensionEquals(const ExtensionType& other) const {
+bool UuidType::ExtensionEquals(const ExtensionType& other) const {
   return (other.extension_name() == this->extension_name());
 }
 
-std::shared_ptr<Array> UUIDType::MakeArray(std::shared_ptr<ArrayData> data) const {
+std::shared_ptr<Array> UuidType::MakeArray(std::shared_ptr<ArrayData> data) const {
   DCHECK_EQ(data->type->id(), Type::EXTENSION);
   DCHECK_EQ("uuid", static_cast<const ExtensionType&>(*data->type).extension_name());
-  return std::make_shared<UUIDArray>(data);
+  return std::make_shared<UuidArray>(data);
 }
 
-Result<std::shared_ptr<DataType>> UUIDType::Deserialize(
+Result<std::shared_ptr<DataType>> UuidType::Deserialize(
     std::shared_ptr<DataType> storage_type, const std::string& serialized) const {
   if (serialized != "uuid-serialization") {
     return Status::Invalid("Type identifier did not match: '", serialized, "'");
   }
   if (!storage_type->Equals(*fixed_size_binary(16))) {
-    return Status::Invalid("Invalid storage type for UUIDType");
+    return Status::Invalid("Invalid storage type for UuidType");
   }
-  return std::make_shared<UUIDType>();
+  return std::make_shared<UuidType>();
 }
 
 bool SmallintType::ExtensionEquals(const ExtensionType& other) const {
@@ -448,7 +448,7 @@ Result<std::shared_ptr<DataType>> DictExtensionType::Deserialize(
   return std::make_shared<DictExtensionType>();
 }
 
-std::shared_ptr<DataType> uuid() { return std::make_shared<UUIDType>(); }
+std::shared_ptr<DataType> uuid() { return std::make_shared<UuidType>(); }
 
 std::shared_ptr<DataType> smallint() { return std::make_shared<SmallintType>(); }
 
@@ -456,7 +456,7 @@ std::shared_ptr<DataType> dict_extension_type() {
   return std::make_shared<DictExtensionType>();
 }
 
-std::shared_ptr<Array> ExampleUUID() {
+std::shared_ptr<Array> ExampleUuid() {
   auto storage_type = fixed_size_binary(16);
   auto ext_type = uuid();
 

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -398,11 +398,12 @@ std::shared_ptr<Array> UuidType::MakeArray(std::shared_ptr<ArrayData> data) cons
 
 Result<std::shared_ptr<DataType>> UuidType::Deserialize(
     std::shared_ptr<DataType> storage_type, const std::string& serialized) const {
-  if (serialized != "uuid-serialization") {
+  if (serialized != "uuid-serialized") {
     return Status::Invalid("Type identifier did not match: '", serialized, "'");
   }
   if (!storage_type->Equals(*fixed_size_binary(16))) {
-    return Status::Invalid("Invalid storage type for UuidType");
+    return Status::Invalid("Invalid storage type for UuidType: ",
+                           storage_type->ToString());
   }
   return std::make_shared<UuidType>();
 }
@@ -423,7 +424,8 @@ Result<std::shared_ptr<DataType>> SmallintType::Deserialize(
     return Status::Invalid("Type identifier did not match: '", serialized, "'");
   }
   if (!storage_type->Equals(*int16())) {
-    return Status::Invalid("Invalid storage type for SmallintType");
+    return Status::Invalid("Invalid storage type for SmallintType: ",
+                           storage_type->ToString());
   }
   return std::make_shared<SmallintType>();
 }
@@ -442,8 +444,12 @@ std::shared_ptr<Array> DictExtensionType::MakeArray(
 
 Result<std::shared_ptr<DataType>> DictExtensionType::Deserialize(
     std::shared_ptr<DataType> storage_type, const std::string& serialized) const {
+  if (serialized != "dict-extension-serialized") {
+    return Status::Invalid("Type identifier did not match: '", serialized, "'");
+  }
   if (!storage_type->Equals(*storage_type_)) {
-    return Status::Invalid("Invalid storage type for DictExtensionType");
+    return Status::Invalid("Invalid storage type for DictExtensionType: ",
+                           storage_type->ToString());
   }
   return std::make_shared<DictExtensionType>();
 }

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -46,9 +46,13 @@
 #include "arrow/status.h"
 #include "arrow/table.h"
 #include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+using internal::checked_pointer_cast;
 
 template <typename T, typename... ExtraArgs>
 void AssertTsEqual(const T& expected, const T& actual, ExtraArgs... args) {
@@ -132,10 +136,8 @@ void AssertFingerprintablesEqual(const T& left, const T& right, bool check_metad
       << "' should have compared equal";
   auto lfp = left.fingerprint();
   auto rfp = right.fingerprint();
-  // All types tested in this file should implement fingerprinting
-  ASSERT_NE(lfp, "") << "fingerprint for '" << left.ToString() << "' should not be empty";
-  ASSERT_NE(rfp, "") << "fingerprint for '" << right.ToString()
-                     << "' should not be empty";
+  // Note: all types tested in this file should implement fingerprinting,
+  // except extension types.
   if (check_metadata) {
     lfp += left.metadata_fingerprint();
     rfp += right.metadata_fingerprint();
@@ -161,17 +163,17 @@ void AssertFingerprintablesNotEqual(const T& left, const T& right, bool check_me
       << "' should have compared unequal";
   auto lfp = left.fingerprint();
   auto rfp = right.fingerprint();
-  // All types tested in this file should implement fingerprinting
-  ASSERT_NE(lfp, "") << "fingerprint for '" << left.ToString() << "' should not be empty";
-  ASSERT_NE(rfp, "") << "fingerprint for '" << right.ToString()
-                     << "' should not be empty";
-  if (check_metadata) {
-    lfp += left.metadata_fingerprint();
-    rfp += right.metadata_fingerprint();
+  // Note: all types tested in this file should implement fingerprinting,
+  // except extension types.
+  if (lfp != "" && rfp != "") {
+    if (check_metadata) {
+      lfp += left.metadata_fingerprint();
+      rfp += right.metadata_fingerprint();
+    }
+    ASSERT_NE(lfp, rfp) << "Fingerprints for " << types_plural << " '" << left.ToString()
+                        << "' and '" << right.ToString()
+                        << "' should have compared unequal";
   }
-  ASSERT_NE(lfp, rfp) << "Fingerprints for " << types_plural << " '" << left.ToString()
-                      << "' and '" << right.ToString()
-                      << "' should have compared unequal";
 }
 
 template <typename T>
@@ -396,28 +398,13 @@ std::shared_ptr<Array> UUIDType::MakeArray(std::shared_ptr<ArrayData> data) cons
 
 Result<std::shared_ptr<DataType>> UUIDType::Deserialize(
     std::shared_ptr<DataType> storage_type, const std::string& serialized) const {
-  if (serialized != "uuid-type-unique-code") {
-    return Status::Invalid("Type identifier did not match");
+  if (serialized != "uuid-serialization") {
+    return Status::Invalid("Type identifier did not match: '", serialized, "'");
   }
   if (!storage_type->Equals(*fixed_size_binary(16))) {
     return Status::Invalid("Invalid storage type for UUIDType");
   }
   return std::make_shared<UUIDType>();
-}
-
-std::shared_ptr<DataType> uuid() { return std::make_shared<UUIDType>(); }
-
-std::shared_ptr<Array> ExampleUUID() {
-  auto storage_type = fixed_size_binary(16);
-  auto ext_type = uuid();
-
-  auto arr = ArrayFromJSON(
-      storage_type,
-      "[null, \"abcdefghijklmno0\", \"abcdefghijklmno1\", \"abcdefghijklmno2\"]");
-
-  auto ext_data = arr->data()->Copy();
-  ext_data->type = ext_type;
-  return MakeArray(ext_data);
 }
 
 bool SmallintType::ExtensionEquals(const ExtensionType& other) const {
@@ -433,7 +420,7 @@ std::shared_ptr<Array> SmallintType::MakeArray(std::shared_ptr<ArrayData> data) 
 Result<std::shared_ptr<DataType>> SmallintType::Deserialize(
     std::shared_ptr<DataType> storage_type, const std::string& serialized) const {
   if (serialized != "smallint") {
-    return Status::Invalid("Type identifier did not match");
+    return Status::Invalid("Type identifier did not match: '", serialized, "'");
   }
   if (!storage_type->Equals(*int16())) {
     return Status::Invalid("Invalid storage type for SmallintType");
@@ -441,7 +428,46 @@ Result<std::shared_ptr<DataType>> SmallintType::Deserialize(
   return std::make_shared<SmallintType>();
 }
 
+bool DictExtensionType::ExtensionEquals(const ExtensionType& other) const {
+  return (other.extension_name() == this->extension_name());
+}
+
+std::shared_ptr<Array> DictExtensionType::MakeArray(
+    std::shared_ptr<ArrayData> data) const {
+  DCHECK_EQ(data->type->id(), Type::EXTENSION);
+  DCHECK(ExtensionEquals(checked_cast<const ExtensionType&>(*data->type)));
+  // No need for a specific ExtensionArray derived class
+  return std::make_shared<ExtensionArray>(data);
+}
+
+Result<std::shared_ptr<DataType>> DictExtensionType::Deserialize(
+    std::shared_ptr<DataType> storage_type, const std::string& serialized) const {
+  if (!storage_type->Equals(*storage_type_)) {
+    return Status::Invalid("Invalid storage type for DictExtensionType");
+  }
+  return std::make_shared<DictExtensionType>();
+}
+
+std::shared_ptr<DataType> uuid() { return std::make_shared<UUIDType>(); }
+
 std::shared_ptr<DataType> smallint() { return std::make_shared<SmallintType>(); }
+
+std::shared_ptr<DataType> dict_extension_type() {
+  return std::make_shared<DictExtensionType>();
+}
+
+std::shared_ptr<Array> ExampleUUID() {
+  auto storage_type = fixed_size_binary(16);
+  auto ext_type = uuid();
+
+  auto arr = ArrayFromJSON(
+      storage_type,
+      "[null, \"abcdefghijklmno0\", \"abcdefghijklmno1\", \"abcdefghijklmno2\"]");
+
+  auto ext_data = arr->data()->Copy();
+  ext_data->type = ext_type;
+  return MakeArray(ext_data);
+}
 
 std::shared_ptr<Array> ExampleSmallint() {
   auto storage_type = int16();
@@ -450,6 +476,21 @@ std::shared_ptr<Array> ExampleSmallint() {
   auto ext_data = arr->data()->Copy();
   ext_data->type = ext_type;
   return MakeArray(ext_data);
+}
+
+ExtensionTypeGuard::ExtensionTypeGuard(const std::shared_ptr<DataType>& type) {
+  ARROW_CHECK_EQ(type->id(), Type::EXTENSION);
+  auto ext_type = checked_pointer_cast<ExtensionType>(type);
+
+  ARROW_CHECK_OK(RegisterExtensionType(ext_type));
+  extension_name_ = ext_type->extension_name();
+  DCHECK(!extension_name_.empty());
+}
+
+ExtensionTypeGuard::~ExtensionTypeGuard() {
+  if (!extension_name_.empty()) {
+    ARROW_CHECK_OK(UnregisterExtensionType(extension_name_));
+  }
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -307,8 +307,8 @@ void AssertTablesEqual(const Table& expected, const Table& actual, bool same_chu
 void CompareBatch(const RecordBatch& left, const RecordBatch& right,
                   bool compare_metadata) {
   if (!left.schema()->Equals(*right.schema(), compare_metadata)) {
-    FAIL() << "Left schema: " << left.schema()->ToString()
-           << "\nRight schema: " << right.schema()->ToString();
+    FAIL() << "Left schema: " << left.schema()->ToString(compare_metadata)
+           << "\nRight schema: " << right.schema()->ToString(compare_metadata);
   }
   ASSERT_EQ(left.num_columns(), right.num_columns())
       << left.schema()->ToString() << " result: " << right.schema()->ToString();

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1211,7 +1211,7 @@ std::string Schema::ToString(bool show_metadata) const {
     if (i > 0) {
       buffer << std::endl;
     }
-    buffer << field->ToString();
+    buffer << field->ToString(show_metadata);
     ++i;
   }
 

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -130,9 +130,6 @@ Status KeyValueMetadata::Delete(const std::string& key) {
     return Status::KeyError(key);
   } else {
     return Delete(index);
-    keys_.erase(keys_.begin() + index);
-    values_.erase(values_.begin() + index);
-    return Status::OK();
   }
 }
 

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -94,11 +94,42 @@ Result<std::string> KeyValueMetadata::Get(const std::string& key) const {
   }
 }
 
+Status KeyValueMetadata::Delete(int64_t index) {
+  keys_.erase(keys_.begin() + index);
+  values_.erase(values_.begin() + index);
+  return Status::OK();
+}
+
+Status KeyValueMetadata::DeleteMany(std::vector<int64_t> indices) {
+  std::sort(indices.begin(), indices.end());
+  const int64_t size = static_cast<int64_t>(keys_.size());
+  indices.push_back(size);
+
+  int64_t shift = 0;
+  for (int64_t i = 0; i < static_cast<int64_t>(indices.size() - 1); ++i) {
+    ++shift;
+    const auto start = indices[i] + 1;
+    const auto stop = indices[i + 1];
+    DCHECK_GE(start, 0);
+    DCHECK_LE(start, size);
+    DCHECK_GE(stop, 0);
+    DCHECK_LE(stop, size);
+    for (int64_t index = start; index < stop; ++index) {
+      keys_[index - shift] = std::move(keys_[index]);
+      values_[index - shift] = std::move(values_[index]);
+    }
+  }
+  keys_.resize(size - shift);
+  values_.resize(size - shift);
+  return Status::OK();
+}
+
 Status KeyValueMetadata::Delete(const std::string& key) {
   auto index = FindKey(key);
   if (index < 0) {
     return Status::KeyError(key);
   } else {
+    return Delete(index);
     keys_.erase(keys_.begin() + index);
     values_.erase(values_.begin() + index);
     return Status::OK();

--- a/cpp/src/arrow/util/key_value_metadata.h
+++ b/cpp/src/arrow/util/key_value_metadata.h
@@ -43,9 +43,12 @@ class ARROW_EXPORT KeyValueMetadata {
   void Append(const std::string& key, const std::string& value);
 
   Result<std::string> Get(const std::string& key) const;
-  Status Delete(const std::string& key);
-  Status Set(const std::string& key, const std::string& value);
   bool Contains(const std::string& key) const;
+  // Note that deleting may invalidate known indices
+  Status Delete(const std::string& key);
+  Status Delete(int64_t index);
+  Status DeleteMany(std::vector<int64_t> indices);
+  Status Set(const std::string& key, const std::string& value);
 
   void reserve(int64_t n);
   int64_t size() const;

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -48,7 +48,7 @@ class Field(object):
         ]
 
         if self.metadata is not None and len(self.metadata) > 0:
-            entries.append(('metadata', self.metadata))
+            entries.append(('metadata', metadata_key_values(self.metadata)))
 
         return OrderedDict(entries)
 
@@ -586,7 +586,7 @@ class Schema(object):
         ]
 
         if self.metadata is not None and len(self.metadata) > 0:
-            entries.append(('metadata', self.metadata))
+            entries.append(('metadata', metadata_key_values(self.metadata)))
 
         return OrderedDict(entries)
 
@@ -1015,10 +1015,10 @@ ExtensionType = namedtuple(
 class ExtensionField(Field):
 
     def __init__(self, name, extension_type, *, nullable=True, metadata=[]):
-        metadata += metadata_key_values([
+        metadata += [
             ('ARROW:extension:name', extension_type.extension_name),
             ('ARROW:extension:metadata', extension_type.serialized),
-        ])
+        ]
         super().__init__(name, nullable=nullable, metadata=metadata)
         self.extension_type = extension_type
 
@@ -1191,8 +1191,7 @@ def generate_custom_metadata_case():
     def meta(items):
         # Generate a simple block of metadata where each value is '{}'.
         # Keys are delimited by whitespace in `items`.
-        # TODO: move encoding logic in get_json()
-        return metadata_key_values((k, '{}') for k in items.split())
+        return [(k, '{}') for k in items.split()]
 
     fields = [
         get_field('sort_of_pandas', 'int8', metadata=meta('pandas')),

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1200,11 +1200,11 @@ def generate_custom_metadata_case():
 
         get_field(
             'unregistered_extension', 'int8',
-            metadata=metadata_key_values([
+            metadata=[
                 ('ARROW:extension:name', '!nonexistent'),
                 ('ARROW:extension:metadata', ''),
                 ('ARROW:integration:allow_unregistered_extension', 'true'),
-            ])),
+            ]),
 
         ListField('list_with_odd_values',
                   get_field('item', 'int32', metadata=meta('odd_values'))),

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -305,7 +305,7 @@ def get_static_json_files():
 def run_all_tests(with_cpp=True, with_java=True, with_js=True,
                   with_go=True, run_flight=False,
                   tempdir=None, **kwargs):
-    tempdir = tempdir or tempfile.mkdtemp()
+    tempdir = tempdir or tempfile.mkdtemp(prefix='arrow-integration-')
 
     testers = []
 

--- a/docs/source/format/Integration.rst
+++ b/docs/source/format/Integration.rst
@@ -328,6 +328,25 @@ Null: ::
       "name": "null"
     }
 
+Extension types are, as in the IPC format, represented as their underlying
+storage type plus some dedicated field metadata to reconstruct the extension
+type.  For example, assuming a "uuid" extension type backed by a
+FixedSizeBinary(16) storage, here is how a "uuid" field would be represented::
+
+    {
+      "name" : "name_of_the_field",
+      "nullable" : /* boolean */,
+      "type" : {
+         "name" : "fixedsizebinary",
+         "byteWidth" : 16
+      },
+      "children" : [],
+      "metadata" : [
+         {"key": "ARROW:extension:name", "value": "uuid"},
+         {"key": "ARROW:extension:metadata", "value": "uuid-serialization"}
+      ]
+    }
+
 **RecordBatch**::
 
     {

--- a/docs/source/format/Integration.rst
+++ b/docs/source/format/Integration.rst
@@ -343,7 +343,7 @@ FixedSizeBinary(16) storage, here is how a "uuid" field would be represented::
       "children" : [],
       "metadata" : [
          {"key": "ARROW:extension:name", "value": "uuid"},
-         {"key": "ARROW:extension:metadata", "value": "uuid-serialization"}
+         {"key": "ARROW:extension:metadata", "value": "uuid-serialized"}
       ]
     }
 

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -468,6 +468,7 @@ def test_parquet(tmpdir, registered_period_type):
         b'PARQUET:field_id': b'1',
     }
 
+
 def test_to_numpy():
     period_type = PeriodType('D')
     storage = pa.array([1, 2, 3, 4], pa.int64())

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -425,7 +425,7 @@ def test_generic_ext_type_register(registered_period_type):
 
 @pytest.mark.parquet
 def test_parquet(tmpdir, registered_period_type):
-    # parquet support for extension types
+    # Parquet support for extension types
     period_type, period_class = registered_period_type
     storage = pa.array([1, 2, 3, 4], pa.int64())
     arr = pa.ExtensionArray.from_storage(period_type, storage)
@@ -436,7 +436,7 @@ def test_parquet(tmpdir, registered_period_type):
     filename = tmpdir / 'extension_type.parquet'
     pq.write_table(table, filename)
 
-    # stored in parquet as storage type but with extension metadata saved
+    # Stored in parquet as storage type but with extension metadata saved
     # in the serialized arrow schema
     meta = pq.read_metadata(filename)
     assert meta.schema.column(0).physical_type == "INT64"
@@ -445,22 +445,28 @@ def test_parquet(tmpdir, registered_period_type):
     import base64
     decoded_schema = base64.b64decode(meta.metadata[b"ARROW:schema"])
     schema = pa.ipc.read_schema(pa.BufferReader(decoded_schema))
-    assert schema.field("ext").metadata == {
-        b'ARROW:extension:metadata': b'freq=D',
-        b'ARROW:extension:name': b'pandas.period'}
+    # Since the type could be reconstructed, the extension type metadata is
+    # absent.
+    assert schema.field("ext").metadata == {}
 
-    # when reading in, properly create extension type if it is registered
+    # When reading in, properly create extension type if it is registered
     result = pq.read_table(filename)
-    assert result.column("ext").type == period_type
-    # get the exact array class defined by the registered type.
+    assert result.schema.field("ext").type == period_type
+    assert result.schema.field("ext").metadata == {b'PARQUET:field_id': b'1'}
+    # Get the exact array class defined by the registered type.
     result_array = result.column("ext").chunk(0)
-    assert type(result_array) == period_class
+    assert type(result_array) is period_class
 
-    # when the type is not registered, read in as storage type
+    # When the type is not registered, read in as storage type
     pa.unregister_extension_type(period_type.extension_name)
     result = pq.read_table(filename)
-    assert result.column("ext").type == pa.int64()
-
+    assert result.schema.field("ext").type == pa.int64()
+    # The extension metadata is present for roundtripping.
+    assert result.schema.field("ext").metadata == {
+        b'ARROW:extension:metadata': b'freq=D',
+        b'ARROW:extension:name': b'pandas.period',
+        b'PARQUET:field_id': b'1',
+    }
 
 def test_to_numpy():
     period_type = PeriodType('D')


### PR DESCRIPTION
Integration for extension types is only supported on C++.

Also fix the dictionary decoding logic to correctly interpret extension types with a dictionary storage type, and add tests for that.