### PR TITLE
ARROW-8496: [C++] Refine ByteStreamSplitDecodeScalar

### DIFF
--- a/cpp/src/arrow/util/byte_stream_split.h
+++ b/cpp/src/arrow/util/byte_stream_split.h
@@ -595,14 +595,13 @@ template <typename T>
 void ByteStreamSplitDecodeScalar(const uint8_t* data, int64_t num_values, int64_t stride,
                                  T* out) {
   constexpr size_t kNumStreams = sizeof(T);
+  auto output_buffer_raw = reinterpret_cast<uint8_t*>(out);
 
   for (int64_t i = 0; i < num_values; ++i) {
-    uint8_t gathered_byte_data[kNumStreams];
     for (size_t b = 0; b < kNumStreams; ++b) {
       const size_t byte_index = b * stride + i;
-      gathered_byte_data[b] = data[byte_index];
+      output_buffer_raw[i * kNumStreams + b] = data[byte_index];
     }
-    out[i] = arrow::util::SafeLoadAs<T>(&gathered_byte_data[0]);
   }
 }
 


### PR DESCRIPTION
I simplified DecoderScalar code and see huge performance boost from
clang generated code. Per my test on Intel E5-2650 with clang-9,
Decode_Float_Scalar test jumps from 600M/s to 20G/s, even better
than SSE version(17G/s). Similar behaviour observed on Arm64.

Some digging shows clang auto vectorized the simplified decoder code,
but gcc cannot: https://godbolt.org/z/kq9FAs
Interestingly, gcc is able to auto vectorize EncoderFloatScalar code,
but clang cannot: https://godbolt.org/z/E3LnZD

NOTE: This scalar code is not tested in default x86_64 build, which
goes the SSE version. Arm64 build goes this scalar code path.