### PR TITLE
ARROW-8499: [C++][Dataset] In ScannerBuilder, batch_size will not wor…

### DIFF
--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -43,6 +43,7 @@ std::shared_ptr<ScanOptions> ScanOptions::ReplaceSchema(
   auto copy = ScanOptions::Make(std::move(schema));
   copy->filter = filter;
   copy->evaluator = evaluator;
+  copy->batch_size = batch_size;
   return copy;
 }
 


### PR DESCRIPTION
…k if projecter is not empty