### PR TITLE
ARROW-8501: [Packaging][RPM] Upgrade devtoolset to 8 on CentOS 6

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-6/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-6/Dockerfile
@@ -20,7 +20,7 @@ FROM centos:6
 ARG DEBUG
 
 ENV \
-  DEVTOOLSET_VERSION=6 \
+  DEVTOOLSET_VERSION=8 \
   LIBARCHIVE_SRPM_BASE=libarchive-3.1.2-10.el7_2.src.rpm \
   SRPM_DOWNLOAD_URL=http://vault.centos.org/7.6.1810/os/Source/SPackages
 


### PR DESCRIPTION
It seems that devtoolset-6 is removed.