### PR TITLE
PARQUET-1845: [C++] Add expected results of Int96 in big-endian

### DIFF
--- a/cpp/src/parquet/types_test.cc
+++ b/cpp/src/parquet/types_test.cc
@@ -102,8 +102,13 @@ TEST(TypePrinter, StatisticsTypes) {
   ASSERT_STREQ("1.0245", FormatStatValue(Type::DOUBLE, smin).c_str());
   ASSERT_STREQ("2.0489", FormatStatValue(Type::DOUBLE, smax).c_str());
 
+#if ARROW_LITTLE_ENDIAN
   Int96 Int96_min = {{1024, 2048, 4096}};
   Int96 Int96_max = {{2048, 4096, 8192}};
+#else
+  Int96 Int96_min = {{2048, 1024, 4096}};
+  Int96 Int96_max = {{4096, 2048, 8192}};
+#endif
   smin = std::string(reinterpret_cast<char*>(&Int96_min), sizeof(Int96));
   smax = std::string(reinterpret_cast<char*>(&Int96_max), sizeof(Int96));
   ASSERT_STREQ("1024 2048 4096", FormatStatValue(Type::INT96, smin).c_str());
@@ -126,9 +131,15 @@ TEST(TypePrinter, StatisticsTypes) {
 
 TEST(TestInt96Timestamp, Decoding) {
   auto check = [](int32_t julian_day, uint64_t nanoseconds) {
+#if ARROW_LITTLE_ENDIAN
     Int96 i96{static_cast<uint32_t>(nanoseconds),
               static_cast<uint32_t>(nanoseconds >> 32),
               static_cast<uint32_t>(julian_day)};
+#else
+    Int96 i96{static_cast<uint32_t>(nanoseconds >> 32),
+              static_cast<uint32_t>(nanoseconds),
+              static_cast<uint32_t>(julian_day)};
+#endif
     // Official formula according to https://github.com/apache/parquet-format/pull/49
     int64_t expected =
         (julian_day - 2440588) * (86400LL * 1000 * 1000 * 1000) + nanoseconds;

--- a/cpp/src/parquet/types_test.cc
+++ b/cpp/src/parquet/types_test.cc
@@ -137,8 +137,7 @@ TEST(TestInt96Timestamp, Decoding) {
               static_cast<uint32_t>(julian_day)};
 #else
     Int96 i96{static_cast<uint32_t>(nanoseconds >> 32),
-              static_cast<uint32_t>(nanoseconds),
-              static_cast<uint32_t>(julian_day)};
+              static_cast<uint32_t>(nanoseconds), static_cast<uint32_t>(julian_day)};
 #endif
     // Official formula according to https://github.com/apache/parquet-format/pull/49
     int64_t expected =


### PR DESCRIPTION
This PR adds expected results of Int96 for parquet-internals-test in big-endian.

This PR assumes that uint_64 and uint_32 elements in Int96 are handled using a native endian for effectiveness.