### PR TITLE
ARROW-8520: [Developer] Use .asf.yaml to direct GitHub notifications to JIRA and mailing lists

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+notifications:
+  commits:      commits@arrow.apache.org
+  issues:       github@arrow.apache.org
+  pullrequests: github@arrow.apache.org
+  jira:         link label worklog


### PR DESCRIPTION
Context: INFRA-20149

Following instructions per https://s.apache.org/asfyaml-notify