### PR TITLE
ARROW-8524: [CI] Free up space on github actions

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -43,6 +43,8 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        run: ci/scripts/util_cleanup.sh
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -53,6 +53,7 @@ jobs:
           archery trigger-bot \
             --event-name ${{ github.event_name }} \
             --event-payload ${{ github.event_path }}
+
   autotune:
     name: "Fix all the things"
     if: startsWith(github.event.comment.body, 'autotune')

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -43,12 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     # if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
-      - name: free disk space
-        run: |
-          df -h
-          env
-          df -h
-          du -d2 -h /
+      - name: Free up disk space
+        run: ci/scripts/util_cleanup.sh
       # - name: Checkout Arrow
       #   uses: actions/checkout@v2
       #   with:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -41,35 +41,43 @@ jobs:
   conda:
     name: AMD64 Conda C++
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    # if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
-      - name: Checkout Arrow
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Fetch Submodules and Tags
-        shell: bash
-        run: ci/scripts/util_checkout.sh
-      - name: Docker Pull
-        shell: bash
-        run: docker-compose pull --ignore-pull-failures conda-cpp
-      - name: Docker Build
-        shell: bash
-        run: docker-compose build conda-cpp
-      - name: Docker Run
-        shell: bash
+      - name: free disk space
         run: |
-          sudo sysctl -w kernel.core_pattern="core.%e.%p"
-          ulimit -c unlimited
-          docker-compose run conda-cpp
-      - name: Docker Push
-        if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
-        continue-on-error: true
-        shell: bash
-        run: |
-          docker login -u ${{ secrets.DOCKERHUB_USER }} \
-                       -p ${{ secrets.DOCKERHUB_TOKEN }}
-          docker-compose push conda-cpp
+          df -h
+          sudo swapoff -a
+          sudo rm -f /swapfile
+          sudo apt clean
+          docker rmi $(docker image ls -aq)
+          df -h
+      # - name: Checkout Arrow
+      #   uses: actions/checkout@v2
+      #   with:
+      #     fetch-depth: 0
+      # - name: Fetch Submodules and Tags
+      #   shell: bash
+      #   run: ci/scripts/util_checkout.sh
+      # - name: Docker Pull
+      #   shell: bash
+      #   run: docker-compose pull --ignore-pull-failures conda-cpp
+      # - name: Docker Build
+      #   shell: bash
+      #   run: docker-compose build conda-cpp
+      # - name: Docker Run
+      #   shell: bash
+      #   run: |
+      #     sudo sysctl -w kernel.core_pattern="core.%e.%p"
+      #     ulimit -c unlimited
+      #     docker-compose run conda-cpp
+      # - name: Docker Push
+      #   if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
+      #   continue-on-error: true
+      #   shell: bash
+      #   run: |
+      #     docker login -u ${{ secrets.DOCKERHUB_USER }} \
+      #                  -p ${{ secrets.DOCKERHUB_TOKEN }}
+      #     docker-compose push conda-cpp
 
   ubuntu-sanitizer:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} C++ ASAN UBSAN

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -51,7 +51,7 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
-          du -d2 -h
+          du -d2 -h /
       # - name: Checkout Arrow
       #   uses: actions/checkout@v2
       #   with:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -51,6 +51,7 @@ jobs:
           sudo apt clean
           docker rmi $(docker image ls -aq)
           df -h
+          du -d2 -h
       # - name: Checkout Arrow
       #   uses: actions/checkout@v2
       #   with:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -41,7 +41,7 @@ jobs:
   conda:
     name: AMD64 Conda C++
     runs-on: ubuntu-latest
-    # if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2
@@ -50,29 +50,29 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
-      - name: Free up disk space
+      - name: Free Up Disk Space
+        shell: bash
         run: ci/scripts/util_cleanup.sh
-
-      # - name: Docker Pull
-      #   shell: bash
-      #   run: docker-compose pull --ignore-pull-failures conda-cpp
-      # - name: Docker Build
-      #   shell: bash
-      #   run: docker-compose build conda-cpp
-      # - name: Docker Run
-      #   shell: bash
-      #   run: |
-      #     sudo sysctl -w kernel.core_pattern="core.%e.%p"
-      #     ulimit -c unlimited
-      #     docker-compose run conda-cpp
-      # - name: Docker Push
-      #   if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
-      #   continue-on-error: true
-      #   shell: bash
-      #   run: |
-      #     docker login -u ${{ secrets.DOCKERHUB_USER }} \
-      #                  -p ${{ secrets.DOCKERHUB_TOKEN }}
-      #     docker-compose push conda-cpp
+      - name: Docker Pull
+        shell: bash
+        run: docker-compose pull --ignore-pull-failures conda-cpp
+      - name: Docker Build
+        shell: bash
+        run: docker-compose build conda-cpp
+      - name: Docker Run
+        shell: bash
+        run: |
+          sudo sysctl -w kernel.core_pattern="core.%e.%p"
+          ulimit -c unlimited
+          docker-compose run conda-cpp
+      - name: Docker Push
+        if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
+        continue-on-error: true
+        shell: bash
+        run: |
+          docker login -u ${{ secrets.DOCKERHUB_USER }} \
+                       -p ${{ secrets.DOCKERHUB_TOKEN }}
+          docker-compose push conda-cpp
 
   ubuntu-sanitizer:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} C++ ASAN UBSAN
@@ -92,6 +92,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: docker-compose pull --ignore-pull-failures ubuntu-cpp-sanitizer

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -43,15 +43,16 @@ jobs:
     runs-on: ubuntu-latest
     # if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
+      - name: Checkout Arrow
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch Submodules and Tags
+        shell: bash
+        run: ci/scripts/util_checkout.sh
       - name: Free up disk space
         run: ci/scripts/util_cleanup.sh
-      # - name: Checkout Arrow
-      #   uses: actions/checkout@v2
-      #   with:
-      #     fetch-depth: 0
-      # - name: Fetch Submodules and Tags
-      #   shell: bash
-      #   run: ci/scripts/util_checkout.sh
+
       # - name: Docker Pull
       #   shell: bash
       #   run: docker-compose pull --ignore-pull-failures conda-cpp

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -46,10 +46,7 @@ jobs:
       - name: free disk space
         run: |
           df -h
-          sudo swapoff -a
-          sudo rm -f /swapfile
-          sudo apt clean
-          docker rmi $(docker image ls -aq)
+          env
           df -h
           du -d2 -h /
       # - name: Checkout Arrow

--- a/.github/workflows/cpp_cron.yml
+++ b/.github/workflows/cpp_cron.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: docker-compose pull --ignore-pull-failures debian-cpp
@@ -93,6 +96,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: docker-compose pull --ignore-pull-failures fedora-cpp
@@ -132,6 +138,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: docker-compose pull --ignore-pull-failures ubuntu-cpp
@@ -164,6 +173,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |
@@ -205,6 +217,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Checkout OSS-Fuzz
         uses: actions/checkout@v1
         with:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         run: |
           docker-compose pull --ignore-pull-failures ubuntu-cpp
@@ -114,6 +117,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         run: |
           docker-compose pull --ignore-pull-failures ubuntu-cpp

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         run: docker-compose pull --ignore-pull-failures debian-go
       - name: Docker Build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         run: |
           docker-compose pull --ignore-pull-failures conda-cpp

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -55,9 +55,15 @@ jobs:
       MAVEN: ${{ matrix.maven }}
     steps:
       - name: Checkout Arrow
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
-          submodules: true
+          fetch-depth: 0
+      - name: Fetch Submodules and Tags
+        shell: bash
+        run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         run: docker-compose pull --ignore-pull-failures debian-java
       - name: Docker Build

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         run: |
           docker-compose pull --ignore-pull-failures debian-java

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         run: docker-compose pull --ignore-pull-failures debian-js
       - name: Docker Build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |
@@ -91,6 +94,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |
@@ -133,6 +139,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |
@@ -216,6 +225,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: docker-compose pull centos-python-manylinux1

--- a/.github/workflows/python_cron.yml
+++ b/.github/workflows/python_cron.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |
@@ -92,6 +95,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |
@@ -132,6 +138,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |
@@ -209,6 +218,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -64,6 +64,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |
@@ -112,6 +115,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: docker-compose pull --ignore-pull-failures r

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         shell: bash
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
       - name: Docker Pull
         run: docker-compose pull --ignore-pull-failures debian-rust
       - name: Docker Build

--- a/ci/scripts/util_cleanup.sh
+++ b/ci/scripts/util_cleanup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# this script is github actions specific to free up disk space
+
+if [ $RUNNER_OS = "Linux" ]; then
+    # remove swap
+    sudo swapoff -a
+    sudo rm -f /swapfile
+
+    # clean apt cache
+    sudo apt clean
+
+    # remove haskell, consumes 8.6 GB
+    sudo rm -rf /opt/ghc
+
+    # remove cached docker images, around 13 GB
+    docker rmi $(docker image ls -aq)
+fi
+
+df -h

--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -36,6 +36,9 @@ jobs:
           git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
           git -C arrow checkout FETCH_HEAD
           git -C arrow submodule update --init --recursive
+      - name: Free Up Disk Space
+        shell: bash
+        run: arrow/ci/scripts/util_cleanup.sh
       - name: Run Docker Build
         shell: bash
         run: |

--- a/dev/tasks/linux-packages/github.linux.arm64.yml
+++ b/dev/tasks/linux-packages/github.linux.arm64.yml
@@ -37,6 +37,10 @@ jobs:
           git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
           git -C arrow checkout FETCH_HEAD
           git -C arrow submodule update --init --recursive
+      - name: Free Up Disk Space
+        shell: bash
+        run: arrow/ci/scripts/util_cleanup.sh
+
       # We can remove this with binfmt-support 2.1.7 or later and
       # qemu-user-static 2.12 or later. It requires Debian buster or later,
       # or Ubuntu 18.10 or later.

--- a/dev/tasks/linux-packages/github.linux.yml
+++ b/dev/tasks/linux-packages/github.linux.yml
@@ -37,6 +37,9 @@ jobs:
           git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
           git -C arrow checkout FETCH_HEAD
           git -C arrow submodule update --init --recursive
+      - name: Free Up Disk Space
+        shell: bash
+        run: arrow/ci/scripts/util_cleanup.sh
       - name: Build
         run: |
           set -e

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -50,6 +50,9 @@ jobs:
           git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
           git -C arrow checkout FETCH_HEAD
           git -C arrow submodule update --init --recursive
+      - name: Free Up Disk Space
+        shell: bash
+        run: arrow/ci/scripts/util_cleanup.sh
       - name: Fetch Submodules and Tags
         shell: bash
         run: cd arrow && ci/scripts/util_checkout.sh

--- a/dev/tasks/verify-rc/github.nix.yml
+++ b/dev/tasks/verify-rc/github.nix.yml
@@ -35,6 +35,9 @@ jobs:
           git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
           git -C arrow checkout FETCH_HEAD
           git -C arrow submodule update --init --recursive
+      - name: Free Up Disk Space
+        shell: bash
+        run: arrow/ci/scripts/util_cleanup.sh
       - name: Fetch Submodules and Tags
         shell: bash
         run: cd arrow && ci/scripts/util_checkout.sh


### PR DESCRIPTION
By default the root drive has ~8.3GB free space out of 84GB on the ubuntu-latest runner. 
Github actions ships a lot of [preinstalled software](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) which are essentially needless when we run docker based builds.

I added a script to clean up just a couple of thing:
- remove swap
- clean apt cache
- remove cached docker images
- remove haskell 

This increases the available free space to [31GB](https://github.com/apache/arrow/pull/6988/checks?check_run_id=600949543#step:4:101).