### PR TITLE
ARROW-8477: [C++] Enable reading and writing of long filenames for Windows

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -228,7 +228,9 @@ jobs:
         run: ci/scripts/util_checkout.sh
       - name: Build
         shell: bash
-        run: ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
+        run: |
+          export BOOST_ROOT=$BOOST_ROOT_1_72_0
+          ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash
         run: ci/scripts/cpp_test.sh $(pwd) $(pwd)/build

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -46,8 +46,6 @@ esac
 
 pushd ${build_dir}
 
-ctest -V -R arrow-utility-test
-
 ctest -L unittest --output-on-failure -j${n_jobs}
 
 if [ "${ARROW_FUZZING}" == "ON" ]; then

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -46,6 +46,8 @@ esac
 
 pushd ${build_dir}
 
+ctest -V -R arrow-utility-test
+
 ctest -L unittest --output-on-failure -j${n_jobs}
 
 if [ "${ARROW_FUZZING}" == "ON" ]; then

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -27,6 +27,8 @@ arrow_install_all_headers("arrow/util")
 #
 
 if(WIN32)
+  # This manifest enables long file paths on Windows 10+
+  # See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later
   if(MSVC)
     set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.manifest)
   else()

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -26,6 +26,16 @@ arrow_install_all_headers("arrow/util")
 # arrow_test_main
 #
 
+if(WIN32)
+  if(MSVC)
+    set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.manifest)
+  else()
+    set(IO_UTIL_TEST_SOURCES io_util_test.cc io_util_test.rc)
+  endif()
+else()
+  set(IO_UTIL_TEST_SOURCES io_util_test.cc)
+endif()
+
 add_arrow_test(utility-test
                SOURCES
                align_util_test.cc
@@ -37,8 +47,7 @@ add_arrow_test(utility-test
                key_value_metadata_test.cc
                hashing_test.cc
                int_util_test.cc
-               io_util_test.cc
-               io_util_test.manifest
+               ${IO_UTIL_TEST_SOURCES}
                iterator_test.cc
                logging_test.cc
                parsing_util_test.cc

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -38,6 +38,7 @@ add_arrow_test(utility-test
                hashing_test.cc
                int_util_test.cc
                io_util_test.cc
+               io_util_test.manifest
                iterator_test.cc
                logging_test.cc
                parsing_util_test.cc

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -844,10 +844,11 @@ Result<int> FileOpenReadable(const PlatformFilename& file_name) {
   DWORD last_error = GetLastError();
   if (last_error == ERROR_SUCCESS) {
     errno_actual = 0;
-    fd = _open_osfhandle((intptr_t)file_handle, _O_RDONLY | _O_BINARY | _O_NOINHERIT);
+    fd = _open_osfhandle(reinterpret_cast<intptr_t>(file_handle),
+                         _O_RDONLY | _O_BINARY | _O_NOINHERIT);
   } else {
-    return IOErrorFromWinError(last_error, "Failed to open file '", file_name.ToString(),
-                               "'");
+    return IOErrorFromWinError(last_error, "Failed to open local file '",
+                               file_name.ToString(), "'");
   }
 #else
   fd = open(file_name.ToNative().c_str(), O_RDONLY);
@@ -905,10 +906,10 @@ Result<int> FileOpenWritable(const PlatformFilename& file_name, bool write_only,
   DWORD last_error = GetLastError();
   if (last_error == ERROR_SUCCESS || last_error == ERROR_ALREADY_EXISTS) {
     errno_actual = 0;
-    fd = _open_osfhandle((intptr_t)file_handle, oflag);
+    fd = _open_osfhandle(reinterpret_cast<intptr_t>(file_handle), oflag);
   } else {
-    return IOErrorFromWinError(last_error, "Failed to open file '", file_name.ToString(),
-                               "'");
+    return IOErrorFromWinError(last_error, "Failed to open local file '",
+                               file_name.ToString(), "'");
   }
 #else
   int oflag = O_CREAT;

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -837,8 +837,18 @@ Result<int> FileOpenReadable(const PlatformFilename& file_name) {
   int fd, errno_actual;
 #if defined(_WIN32)
   SetLastError(0);
-  errno_actual = _wsopen_s(&fd, file_name.ToNative().c_str(),
-                           _O_RDONLY | _O_BINARY | _O_NOINHERIT, _SH_DENYNO, _S_IREAD);
+  HANDLE file_handle = CreateFileW(file_name.ToNative().c_str(), GENERIC_READ,
+                                   FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
+                                   OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+
+  DWORD last_error = GetLastError();
+  if (last_error == ERROR_SUCCESS) {
+    errno_actual = 0;
+    fd = _open_osfhandle((intptr_t)file_handle, _O_RDONLY | _O_BINARY | _O_NOINHERIT);
+  } else {
+    return IOErrorFromWinError(last_error, "Failed to open file '", file_name.ToString(),
+                               "'");
+  }
 #else
   fd = open(file_name.ToNative().c_str(), O_RDONLY);
   errno_actual = errno;
@@ -868,23 +878,40 @@ Result<int> FileOpenWritable(const PlatformFilename& file_name, bool write_only,
 #if defined(_WIN32)
   SetLastError(0);
   int oflag = _O_CREAT | _O_BINARY | _O_NOINHERIT;
-  int pmode = _S_IREAD | _S_IWRITE;
+  DWORD desired_access = GENERIC_WRITE;
+  DWORD share_mode = FILE_SHARE_READ | FILE_SHARE_WRITE;
+  DWORD creation_disposition = OPEN_ALWAYS;
+
+  if (append) {
+    oflag |= _O_APPEND;
+  }
 
   if (truncate) {
     oflag |= _O_TRUNC;
-  }
-  if (append) {
-    oflag |= _O_APPEND;
+    creation_disposition = CREATE_ALWAYS;
   }
 
   if (write_only) {
     oflag |= _O_WRONLY;
   } else {
     oflag |= _O_RDWR;
+    desired_access |= GENERIC_READ;
   }
 
-  errno_actual = _wsopen_s(&fd, file_name.ToNative().c_str(), oflag, _SH_DENYNO, pmode);
+  HANDLE file_handle =
+      CreateFileW(file_name.ToNative().c_str(), desired_access, share_mode, NULL,
+                  creation_disposition, FILE_ATTRIBUTE_NORMAL, NULL);
 
+  DWORD last_error = GetLastError();
+  if (last_error == ERROR_SUCCESS ||
+      ((creation_disposition == OPEN_ALWAYS || creation_disposition == CREATE_ALWAYS) &&
+       last_error == ERROR_ALREADY_EXISTS)) {
+    errno_actual = 0;
+    fd = _open_osfhandle((intptr_t)file_handle, oflag);
+  } else {
+    return IOErrorFromWinError(last_error, "Failed to open file '", file_name.ToString(),
+                               "'");
+  }
 #else
   int oflag = O_CREAT;
 

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -903,9 +903,7 @@ Result<int> FileOpenWritable(const PlatformFilename& file_name, bool write_only,
                   creation_disposition, FILE_ATTRIBUTE_NORMAL, NULL);
 
   DWORD last_error = GetLastError();
-  if (last_error == ERROR_SUCCESS ||
-      ((creation_disposition == OPEN_ALWAYS || creation_disposition == CREATE_ALWAYS) &&
-       last_error == ERROR_ALREADY_EXISTS)) {
+  if (last_error == ERROR_SUCCESS || last_error == ERROR_ALREADY_EXISTS) {
     errno_actual = 0;
     fd = _open_osfhandle((intptr_t)file_handle, oflag);
   } else {

--- a/cpp/src/arrow/util/io_util_test.cc
+++ b/cpp/src/arrow/util/io_util_test.cc
@@ -429,7 +429,7 @@ TEST(TemporaryDir, Basics) {
 TEST(CreateDirTree, Basics) {
   std::unique_ptr<TemporaryDir> temp_dir;
   PlatformFilename fn;
-  bool created, deleted;
+  bool created;
 
   ASSERT_OK_AND_ASSIGN(temp_dir, TemporaryDir::Make("io-util-test-"));
 
@@ -447,6 +447,8 @@ TEST(CreateDirTree, Basics) {
   ASSERT_OK_AND_ASSIGN(created, CreateDirTree(fn));
   ASSERT_TRUE(created);
 
+#ifndef __APPLE__
+  bool deleted;
 #ifdef _WIN32
   const std::string KEY_NAME = R"(SYSTEM\CurrentControlSet\Control\FileSystem)";
   const std::string VALUE_NAME = "LongPathsEnabled";
@@ -493,6 +495,7 @@ TEST(CreateDirTree, Basics) {
     ASSERT_OK_AND_ASSIGN(deleted, DeleteDirTree(long_path));
     ASSERT_TRUE(deleted);
   }
+#endif
 }
 
 TEST(ListDir, Basics) {

--- a/cpp/src/arrow/util/io_util_test.cc
+++ b/cpp/src/arrow/util/io_util_test.cc
@@ -383,10 +383,6 @@ TEST(DeleteDirContents, Basics) {
   ASSERT_TRUE(deleted);
   AssertExists(parent);
 
-  // Now actually delete the test directory
-  ASSERT_OK_AND_ASSIGN(deleted, DeleteDirTree(parent));
-  ASSERT_TRUE(deleted);
-
   // It's not an error to call DeleteDirContents on a nonexistent path.
   ASSERT_OK_AND_ASSIGN(deleted, DeleteDirContents(child1));
   ASSERT_FALSE(deleted);
@@ -398,6 +394,10 @@ TEST(DeleteDirContents, Basics) {
 #else
   ASSERT_EQ(ErrnoFromStatus(status), ENOENT);
 #endif
+
+  // Now actually delete the test directory
+  ASSERT_OK_AND_ASSIGN(deleted, DeleteDirTree(parent));
+  ASSERT_TRUE(deleted);
 }
 
 TEST(TemporaryDir, Basics) {

--- a/cpp/src/arrow/util/io_util_test.cc
+++ b/cpp/src/arrow/util/io_util_test.cc
@@ -446,56 +446,6 @@ TEST(CreateDirTree, Basics) {
   ASSERT_OK_AND_ASSIGN(fn, temp_dir->path().Join("EF"));
   ASSERT_OK_AND_ASSIGN(created, CreateDirTree(fn));
   ASSERT_TRUE(created);
-
-#ifndef __APPLE__
-  bool deleted;
-#ifdef _WIN32
-  const std::string KEY_NAME = R"(SYSTEM\CurrentControlSet\Control\FileSystem)";
-  const std::string VALUE_NAME = "LongPathsEnabled";
-  DWORD value = 0;
-  DWORD size = sizeof(value);
-  LSTATUS status = RegGetValueA(HKEY_LOCAL_MACHINE, KEY_NAME.c_str(), VALUE_NAME.c_str(),
-                                RRF_RT_REG_DWORD, NULL, &value, &size);
-  bool test_long_paths = (status == ERROR_SUCCESS && value == 1);
-  if (!test_long_paths) {
-    ARROW_LOG(WARNING)
-        << "Tests for accessing files with long path names have been disabled. "
-        << "To enable these tests, set the value of " << VALUE_NAME
-        << " in registry key \\HKEY_LOCAL_MACHINE\\" << KEY_NAME
-        << " to 1 on the test host.";
-  }
-#else
-  bool test_long_paths = true;
-#endif
-
-  if (test_long_paths) {
-    const std::string LONG_BASE = "xxx-io-util-test-dir-long";
-    PlatformFilename long_path, long_filename;
-    int fd = -1;
-    std::stringstream fs;
-    fs << LONG_BASE;
-    for (int i = 0; i < 64; ++i) {
-      fs << "/123456789ABCDEF";
-    }
-    ASSERT_OK_AND_ASSIGN(
-        long_path, PlatformFilename::FromString(fs.str()));  // long_path length > 1024
-    ASSERT_OK_AND_ASSIGN(created, CreateDirTree(long_path));
-    ASSERT_TRUE(created);
-    AssertExists(long_path);
-    ASSERT_OK_AND_ASSIGN(long_filename,
-                         PlatformFilename::FromString(fs.str() + "/file.txt"));
-    ASSERT_OK_AND_ASSIGN(fd, FileOpenWritable(long_filename));
-    ASSERT_OK(FileClose(fd));
-    AssertExists(long_filename);
-    fd = -1;
-    ASSERT_OK_AND_ASSIGN(fd, FileOpenReadable(long_filename));
-    ASSERT_OK(FileClose(fd));
-    ASSERT_OK_AND_ASSIGN(deleted, DeleteDirContents(long_path));
-    ASSERT_TRUE(deleted);
-    ASSERT_OK_AND_ASSIGN(deleted, DeleteDirTree(long_path));
-    ASSERT_TRUE(deleted);
-  }
-#endif
 }
 
 TEST(ListDir, Basics) {
@@ -572,6 +522,56 @@ TEST(DeleteFile, Basics) {
   AssertExists(fn);
   ASSERT_RAISES(IOError, DeleteFile(fn));
 }
+
+#ifndef __APPLE__
+TEST(FileUtils, LongPaths) {
+  // ARROW-8477: check using long file paths under Windows (> 260 characters).
+  bool created, deleted;
+#ifdef _WIN32
+  const char* kRegKeyName = R"(SYSTEM\CurrentControlSet\Control\FileSystem)";
+  const char* kRegValueName = "LongPathsEnabled";
+  DWORD value = 0;
+  DWORD size = sizeof(value);
+  LSTATUS status = RegGetValueA(HKEY_LOCAL_MACHINE, kRegKeyName, kRegValueName,
+                                RRF_RT_REG_DWORD, NULL, &value, &size);
+  bool test_long_paths = (status == ERROR_SUCCESS && value == 1);
+  if (!test_long_paths) {
+    ARROW_LOG(WARNING)
+        << "Tests for accessing files with long path names have been disabled. "
+        << "To enable these tests, set the value of " << kRegValueName
+        << " in registry key \\HKEY_LOCAL_MACHINE\\" << kRegKeyName
+        << " to 1 on the test host.";
+    return;
+  }
+#endif
+
+  const std::string LONG_BASE = "xxx-io-util-test-dir-long";
+  PlatformFilename long_path, long_filename;
+  int fd = -1;
+  std::stringstream fs;
+  fs << LONG_BASE;
+  for (int i = 0; i < 64; ++i) {
+    fs << "/123456789ABCDEF";
+  }
+  ASSERT_OK_AND_ASSIGN(
+      long_path, PlatformFilename::FromString(fs.str()));  // long_path length > 1024
+  ASSERT_OK_AND_ASSIGN(created, CreateDirTree(long_path));
+  ASSERT_TRUE(created);
+  AssertExists(long_path);
+  ASSERT_OK_AND_ASSIGN(long_filename,
+                       PlatformFilename::FromString(fs.str() + "/file.txt"));
+  ASSERT_OK_AND_ASSIGN(fd, FileOpenWritable(long_filename));
+  ASSERT_OK(FileClose(fd));
+  AssertExists(long_filename);
+  fd = -1;
+  ASSERT_OK_AND_ASSIGN(fd, FileOpenReadable(long_filename));
+  ASSERT_OK(FileClose(fd));
+  ASSERT_OK_AND_ASSIGN(deleted, DeleteDirContents(long_path));
+  ASSERT_TRUE(deleted);
+  ASSERT_OK_AND_ASSIGN(deleted, DeleteDirTree(long_path));
+  ASSERT_TRUE(deleted);
+}
+#endif
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/io_util_test.cc
+++ b/cpp/src/arrow/util/io_util_test.cc
@@ -383,6 +383,10 @@ TEST(DeleteDirContents, Basics) {
   ASSERT_TRUE(deleted);
   AssertExists(parent);
 
+  // Now actually delete the test directory
+  ASSERT_OK_AND_ASSIGN(deleted, DeleteDirTree(parent));
+  ASSERT_TRUE(deleted);
+
   // It's not an error to call DeleteDirContents on a nonexistent path.
   ASSERT_OK_AND_ASSIGN(deleted, DeleteDirContents(child1));
   ASSERT_FALSE(deleted);
@@ -545,14 +549,16 @@ TEST(FileUtils, LongPaths) {
   }
 #endif
 
-  const std::string LONG_BASE = "xxx-io-util-test-dir-long";
-  PlatformFilename long_path, long_filename;
+  const std::string BASE = "xxx-io-util-test-dir-long";
+  PlatformFilename base_path, long_path, long_filename;
   int fd = -1;
   std::stringstream fs;
-  fs << LONG_BASE;
+  fs << BASE;
   for (int i = 0; i < 64; ++i) {
     fs << "/123456789ABCDEF";
   }
+  ASSERT_OK_AND_ASSIGN(base_path,
+                       PlatformFilename::FromString(BASE));  // long_path length > 1024
   ASSERT_OK_AND_ASSIGN(
       long_path, PlatformFilename::FromString(fs.str()));  // long_path length > 1024
   ASSERT_OK_AND_ASSIGN(created, CreateDirTree(long_path));
@@ -569,6 +575,10 @@ TEST(FileUtils, LongPaths) {
   ASSERT_OK_AND_ASSIGN(deleted, DeleteDirContents(long_path));
   ASSERT_TRUE(deleted);
   ASSERT_OK_AND_ASSIGN(deleted, DeleteDirTree(long_path));
+  ASSERT_TRUE(deleted);
+
+  // Now delete the whole test directory tree
+  ASSERT_OK_AND_ASSIGN(deleted, DeleteDirTree(base_path));
   ASSERT_TRUE(deleted);
 }
 #endif

--- a/cpp/src/arrow/util/io_util_test.manifest
+++ b/cpp/src/arrow/util/io_util_test.manifest
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity type="win32" name="ArrowUtilityTest" version="1.1.1.1"/>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
@@ -6,4 +24,11 @@
       <ws2:longPathAware>true</ws2:longPathAware>
     </windowsSettings>
   </application>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
 </assembly>

--- a/cpp/src/arrow/util/io_util_test.manifest
+++ b/cpp/src/arrow/util/io_util_test.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity type="win32" name="ArrowUtilityTest" version="1.1.1.1"/>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/cpp/src/arrow/util/io_util_test.manifest
+++ b/cpp/src/arrow/util/io_util_test.manifest
@@ -17,6 +17,11 @@
  specific language governing permissions and limitations
  under the License.
 -->
+
+<!--
+  -- Enable long file paths on the target application
+  -- See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later
+  -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity type="win32" name="ArrowUtilityTest" version="1.1.1.1"/>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">

--- a/cpp/src/arrow/util/io_util_test.manifest
+++ b/cpp/src/arrow/util/io_util_test.manifest
@@ -19,8 +19,8 @@
 -->
 
 <!--
-  -- Enable long file paths on the target application
-  -- See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later
+  Enable long file paths on the target application
+  See https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file#enable-long-paths-in-windows-10-version-1607-and-later
   -->
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
   <assemblyIdentity type="win32" name="ArrowUtilityTest" version="1.1.1.1"/>

--- a/cpp/src/arrow/util/io_util_test.rc
+++ b/cpp/src/arrow/util/io_util_test.rc
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#ifndef CREATEPROCESS_MANIFEST_RESOURCE_ID
+#define CREATEPROCESS_MANIFEST_RESOURCE_ID  1
+#endif
+#ifndef RT_MANIFEST
+#define RT_MANIFEST  24
+#endif
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST
+BEGIN
+  "<?xml version=""1.0"" encoding=""UTF-8"" standalone=""yes""?>"
+  "<assembly xmlns=""urn:schemas-microsoft-com:asm.v1"" manifestVersion=""1.0"">"
+    "<assemblyIdentity type=""win32"" name=""ArrowUtilityTest"" version=""1.1.1.1""/>"
+    "<application xmlns=""urn:schemas-microsoft-com:asm.v3"">"
+      "<windowsSettings xmlns:ws2=""http://schemas.microsoft.com/SMI/2016/WindowsSettings"">"
+        "<ws2:longPathAware>true</ws2:longPathAware>"
+      "</windowsSettings>"
+    "</application>"
+    "<trustInfo xmlns=""urn:schemas-microsoft-com:asm.v3"">"
+      "<security>"
+        "<requestedPrivileges>"
+          "<requestedExecutionLevel level=""asInvoker"" uiAccess=""false""/>"
+        "</requestedPrivileges>"
+      "</security>"
+    "</trustInfo>"
+  "</assembly>"
+END
+


### PR DESCRIPTION
This patch enables reading/writing of files with long (>260 characters) pathnames in Windows.

In order for the new test to run under Windows, both (1) the test host must have long paths enabled in its registry, and (2) the test executable (arrow_utility_test.exe) must include a manifest indicating support for long paths (see https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#enable-long-paths-in-windows-10-version-1607-and-later).  The test source code checks for (1) and the cmake file changes ensure (2).