### PR TITLE
ARROW-8541: [Release] Don't remove previous source releases automatically

### DIFF
--- a/dev/release/post-01-upload.sh
+++ b/dev/release/post-01-upload.sh
@@ -49,8 +49,6 @@ mkdir -p ${tmp_dir}/release/${release_version}
 cp -r ${tmp_dir}/dev/* ${tmp_dir}/release/${release_version}/
 svn add ${tmp_dir}/release/${release_version}
 
-echo $tmp_dir
-
 echo "Commit release"
 svn ci -m "Apache Arrow ${version}" ${tmp_dir}/release
 

--- a/dev/release/post-01-upload.sh
+++ b/dev/release/post-01-upload.sh
@@ -52,7 +52,7 @@ svn add ${tmp_dir}/release/${release_version}
 echo "Keep only the three most recent versions"
 old_releases=$(
   svn ls ${tmp_dir}/release/ | \
-  grep '^arrow-\d' | \
+  grep '^arrow-' | \
   sort --version-sort --reverse | \
   tail -n +4
 )

--- a/dev/release/post-01-upload.sh
+++ b/dev/release/post-01-upload.sh
@@ -20,14 +20,13 @@
 set -e
 set -u
 
-if [ "$#" -ne 3 ]; then
-  echo "Usage: $0 <previous-version> <version> <rc-num>"
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <version> <rc-num>"
   exit
 fi
 
-previous_version=$1
-version=$2
-rc=$3
+version=$1
+rc=$2
 
 tmp_dir=tmp-apache-arrow-dist
 
@@ -45,12 +44,12 @@ echo "Clone release dist repository"
 svn co https://dist.apache.org/repos/dist/release/arrow ${tmp_dir}/release
 
 echo "Copy ${version}-rc${rc} to release working copy"
-previous_release_version=arrow-${previous_version}
 release_version=arrow-${version}
 mkdir -p ${tmp_dir}/release/${release_version}
 cp -r ${tmp_dir}/dev/* ${tmp_dir}/release/${release_version}/
 svn add ${tmp_dir}/release/${release_version}
-svn delete ${tmp_dir}/release/${previous_release_version}
+
+echo $tmp_dir
 
 echo "Commit release"
 svn ci -m "Apache Arrow ${version}" ${tmp_dir}/release

--- a/dev/release/post-01-upload.sh
+++ b/dev/release/post-01-upload.sh
@@ -49,6 +49,18 @@ mkdir -p ${tmp_dir}/release/${release_version}
 cp -r ${tmp_dir}/dev/* ${tmp_dir}/release/${release_version}/
 svn add ${tmp_dir}/release/${release_version}
 
+echo "Keep only the three most recent versions"
+old_releases=$(
+  svn ls ${tmp_dir}/release/ | \
+  grep '^arrow-\d' | \
+  sort --version-sort --reverse | \
+  tail -n +4
+)
+for old_release_version in $old_releases; do
+  echo "Remove old release ${old_release_version}"
+  svn delete ${tmp_dir}/release/${old_release_version}
+done
+
 echo "Commit release"
 svn ci -m "Apache Arrow ${version}" ${tmp_dir}/release
 


### PR DESCRIPTION
We should keep at least the last 3 source tarballs instead of automatically removing the previous release.