### PR TITLE
ARROW-8065: [C++][Dataset] Refactor ScanOptions and Fragment relation

### DIFF
--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -30,20 +30,20 @@
 namespace arrow {
 namespace dataset {
 
-Fragment::Fragment(std::shared_ptr<Schema> physical_schema,
-                   std::shared_ptr<Expression> partition_expression)
-    : physical_schema_(std::move(physical_schema)),
-      partition_expression_(partition_expression ? partition_expression : scalar(true)) {
-  /// TODO(ARROW-8065)
-  if (physical_schema_ == nullptr) {
-    physical_schema_ = schema({});
+Fragment::Fragment(std::shared_ptr<Expression> partition_expression)
+    : partition_expression_(partition_expression ? partition_expression : scalar(true)) {}
+
+Result<std::shared_ptr<Schema>> InMemoryFragment::ReadPhysicalSchema() {
+  if (record_batches_.empty()) {
+    return schema({});
   }
+
+  return record_batches_[0]->schema();
 }
 
 InMemoryFragment::InMemoryFragment(RecordBatchVector record_batches,
                                    std::shared_ptr<Expression> partition_expression)
-    : Fragment(record_batches.empty() ? schema({}) : record_batches[0]->schema(),
-               std::move(partition_expression)),
+    : Fragment(std::move(partition_expression)),
       record_batches_(std::move(record_batches)) {}
 
 Result<ScanTaskIterator> InMemoryFragment::Scan(std::shared_ptr<ScanOptions> options,

--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -35,13 +35,13 @@ namespace dataset {
 /// \brief GetFragmentsFromDatasets transforms a vector<Dataset> into a
 /// flattened FragmentIterator.
 static inline FragmentIterator GetFragmentsFromDatasets(
-    const DatasetVector& datasets, std::shared_ptr<ScanOptions> options) {
+    const DatasetVector& datasets, std::shared_ptr<Expression> predicate) {
   // Iterator<Dataset>
   auto datasets_it = MakeVectorIterator(datasets);
 
   // Dataset -> Iterator<Fragment>
-  auto fn = [options](std::shared_ptr<Dataset> dataset) -> FragmentIterator {
-    return dataset->GetFragments(options);
+  auto fn = [predicate](std::shared_ptr<Dataset> dataset) -> FragmentIterator {
+    return dataset->GetFragments(predicate);
   };
 
   // Iterator<Iterator<Fragment>>

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -44,8 +44,7 @@ TEST_F(TestInMemoryFragment, Scan) {
   auto reader = ConstantArrayGenerator::Repeat(kNumberBatches, batch);
 
   // Creates a InMemoryFragment of the same repeated batch.
-  auto fragment =
-      InMemoryFragment({static_cast<size_t>(kNumberBatches), batch}, options_);
+  auto fragment = InMemoryFragment({static_cast<size_t>(kNumberBatches), batch});
 
   AssertFragmentEquals(reader.get(), &fragment);
 }

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -150,7 +150,7 @@ class FileSystemDatasetFactoryTest : public DatasetFactoryTest {
     }
     options_ = ScanOptions::Make(schema);
     ASSERT_OK_AND_ASSIGN(dataset_, factory_->Finish(schema));
-    AssertFragmentsAreFromPath(dataset_->GetFragments(options_), paths);
+    AssertFragmentsAreFromPath(dataset_->GetFragments(), paths);
   }
 
  protected:

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -72,6 +72,10 @@ Result<std::shared_ptr<WriteTask>> FileFormat::WriteFragment(
   return Status::NotImplemented("writing fragment of format ", type_name());
 }
 
+Result<std::shared_ptr<Schema>> FileFragment::ReadPhysicalSchema() {
+  return format_->Inspect(source_);
+}
+
 Result<ScanTaskIterator> FileFragment::Scan(std::shared_ptr<ScanOptions> options,
                                             std::shared_ptr<ScanContext> context) {
   return format_->ScanFile(source_, std::move(options), std::move(context));

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -55,26 +55,26 @@ Result<std::shared_ptr<arrow::io::OutputStream>> FileSource::OpenWritable() cons
   return std::make_shared<::arrow::io::BufferOutputStream>(b);
 }
 
-Result<std::shared_ptr<FileFragment>> FileFormat::MakeFragment(
-    FileSource source, std::shared_ptr<ScanOptions> options) {
-  return MakeFragment(std::move(source), std::move(options), scalar(true));
+Result<std::shared_ptr<FileFragment>> FileFormat::MakeFragment(FileSource source) {
+  return MakeFragment(std::move(source), scalar(true));
 }
 
 Result<std::shared_ptr<FileFragment>> FileFormat::MakeFragment(
-    FileSource source, std::shared_ptr<ScanOptions> options,
-    std::shared_ptr<Expression> partition_expression) {
+    FileSource source, std::shared_ptr<Expression> partition_expression) {
   return std::shared_ptr<FileFragment>(new FileFragment(
-      std::move(source), shared_from_this(), options, std::move(partition_expression)));
+      std::move(source), shared_from_this(), std::move(partition_expression)));
 }
 
 Result<std::shared_ptr<WriteTask>> FileFormat::WriteFragment(
     FileSource destination, std::shared_ptr<Fragment> fragment,
+    std::shared_ptr<ScanOptions> scan_options,
     std::shared_ptr<ScanContext> scan_context) {
   return Status::NotImplemented("writing fragment of format ", type_name());
 }
 
-Result<ScanTaskIterator> FileFragment::Scan(std::shared_ptr<ScanContext> context) {
-  return format_->ScanFile(source_, scan_options_, std::move(context));
+Result<ScanTaskIterator> FileFragment::Scan(std::shared_ptr<ScanOptions> options,
+                                            std::shared_ptr<ScanContext> context) {
+  return format_->ScanFile(source_, std::move(options), std::move(context));
 }
 
 FileSystemDataset::FileSystemDataset(std::shared_ptr<Schema> schema,
@@ -167,10 +167,8 @@ std::shared_ptr<Expression> FoldingAnd(const std::shared_ptr<Expression>& l,
 }
 
 FragmentIterator FileSystemDataset::GetFragmentsImpl(
-    std::shared_ptr<ScanOptions> root_options) {
+    std::shared_ptr<ScanOptions> scan_options) {
   FragmentVector fragments;
-
-  std::vector<std::shared_ptr<ScanOptions>> options(forest_.size());
 
   ExpressionVector fragment_partitions(forest_.size());
 
@@ -180,33 +178,24 @@ FragmentIterator FileSystemDataset::GetFragmentsImpl(
     // if available, copy parent's filter and projector
     // (which are appropriately simplified and loaded with default values)
     if (auto parent = ref.parent()) {
-      options[ref.i].reset(new ScanOptions(*options[parent.i]));
-      fragment_partitions[ref.i] =
-          FoldingAnd(fragment_partitions[parent.i], partitions_[ref.i]);
+      fragment_partitions[ref.i] = FoldingAnd(fragment_partitions[parent.i], partition);
     } else {
-      options[ref.i].reset(new ScanOptions(*root_options));
-      fragment_partitions[ref.i] = FoldingAnd(partition_expression_, partitions_[ref.i]);
+      fragment_partitions[ref.i] = FoldingAnd(partition_expression_, partition);
     }
 
     // simplify filter by partition information
-    auto filter = options[ref.i]->filter->Assume(partition);
-    options[ref.i]->filter = filter;
-
+    auto filter = scan_options->filter->Assume(partition);
     if (filter->IsNull() || filter->Equals(false)) {
       // directories (and descendants) which can't satisfy the filter are pruned
       return fs::PathForest::Prune;
     }
 
-    // if possible, extract a partition key and pass it to the projector
-    RETURN_NOT_OK(KeyValuePartitioning::SetDefaultValuesFromKeys(
-        *partition, &options[ref.i]->projector));
-
     if (ref.info().IsFile()) {
       // generate a fragment for this file
       FileSource src(ref.info().path(), filesystem_.get());
-      ARROW_ASSIGN_OR_RAISE(auto fragment,
-                            format_->MakeFragment(std::move(src), options[ref.i],
-                                                  std::move(fragment_partitions[ref.i])));
+      ARROW_ASSIGN_OR_RAISE(
+          auto fragment,
+          format_->MakeFragment(std::move(src), std::move(fragment_partitions[ref.i])));
       fragments.push_back(std::move(fragment));
     }
 
@@ -222,9 +211,8 @@ FragmentIterator FileSystemDataset::GetFragmentsImpl(
 }
 
 Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Write(
-    const WritePlan& plan, std::shared_ptr<ScanContext> scan_context) {
-  std::vector<std::shared_ptr<ScanOptions>> options(plan.paths.size());
-
+    const WritePlan& plan, std::shared_ptr<ScanOptions> scan_options,
+    std::shared_ptr<ScanContext> scan_context) {
   auto filesystem = plan.filesystem;
   if (filesystem == nullptr) {
     filesystem = std::make_shared<fs::LocalFileSystem>();
@@ -251,9 +239,9 @@ Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Write(
       const auto& fragment = util::get<std::shared_ptr<Fragment>>(op);
 
       FileSource dest(files[i].path(), filesystem.get());
-      ARROW_ASSIGN_OR_RAISE(
-          auto write_task,
-          plan.format->WriteFragment(std::move(dest), fragment, scan_context));
+      ARROW_ASSIGN_OR_RAISE(auto write_task,
+                            plan.format->WriteFragment(std::move(dest), fragment,
+                                                       scan_options, scan_context));
 
       task_group->Append([write_task] { return write_task->Execute(); });
     }

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -144,23 +144,23 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
 
   /// \brief Open a fragment
   virtual Result<std::shared_ptr<FileFragment>> MakeFragment(
-      FileSource source, std::shared_ptr<ScanOptions> options,
-      std::shared_ptr<Expression> partition_expression);
+      FileSource source, std::shared_ptr<Expression> partition_expression);
 
-  Result<std::shared_ptr<FileFragment>> MakeFragment(
-      FileSource source, std::shared_ptr<ScanOptions> options);
+  Result<std::shared_ptr<FileFragment>> MakeFragment(FileSource source);
 
   /// \brief Write a fragment. If the parent directory of destination does not exist, it
   /// will be created.
   virtual Result<std::shared_ptr<WriteTask>> WriteFragment(
       FileSource destination, std::shared_ptr<Fragment> fragment,
+      std::shared_ptr<ScanOptions> options,
       std::shared_ptr<ScanContext> scan_context);  // FIXME(bkietz) make this pure virtual
 };
 
 /// \brief A Fragment that is stored in a file with a known format
 class ARROW_DS_EXPORT FileFragment : public Fragment {
  public:
-  Result<ScanTaskIterator> Scan(std::shared_ptr<ScanContext> context) override;
+  Result<ScanTaskIterator> Scan(std::shared_ptr<ScanOptions> options,
+                                std::shared_ptr<ScanContext> context) override;
 
   std::string type_name() const override { return format_->type_name(); }
   bool splittable() const override { return format_->splittable(); }
@@ -170,9 +170,8 @@ class ARROW_DS_EXPORT FileFragment : public Fragment {
 
  protected:
   FileFragment(FileSource source, std::shared_ptr<FileFormat> format,
-               std::shared_ptr<ScanOptions> scan_options,
                std::shared_ptr<Expression> partition_expression)
-      : Fragment(std::move(scan_options), std::move(partition_expression)),
+      : Fragment(NULLPTR, std::move(partition_expression)),
         source_(std::move(source)),
         format_(std::move(format)) {}
 
@@ -240,7 +239,8 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
   /// \param[in] plan the WritePlan to execute.
   /// \param[in] scan_context context in which to scan fragments before writing.
   static Result<std::shared_ptr<FileSystemDataset>> Write(
-      const WritePlan& plan, std::shared_ptr<ScanContext> scan_context);
+      const WritePlan& plan, std::shared_ptr<ScanOptions> scan_options,
+      std::shared_ptr<ScanContext> scan_context);
 
   std::string type_name() const override { return "filesystem"; }
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -159,6 +159,8 @@ class ARROW_DS_EXPORT FileFormat : public std::enable_shared_from_this<FileForma
 /// \brief A Fragment that is stored in a file with a known format
 class ARROW_DS_EXPORT FileFragment : public Fragment {
  public:
+  Result<std::shared_ptr<Schema>> ReadPhysicalSchema() override;
+
   Result<ScanTaskIterator> Scan(std::shared_ptr<ScanOptions> options,
                                 std::shared_ptr<ScanContext> context) override;
 
@@ -171,7 +173,7 @@ class ARROW_DS_EXPORT FileFragment : public Fragment {
  protected:
   FileFragment(FileSource source, std::shared_ptr<FileFormat> format,
                std::shared_ptr<Expression> partition_expression)
-      : Fragment(NULLPTR, std::move(partition_expression)),
+      : Fragment(std::move(partition_expression)),
         source_(std::move(source)),
         format_(std::move(format)) {}
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -256,7 +256,7 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
   std::string ToString() const;
 
  protected:
-  FragmentIterator GetFragmentsImpl(std::shared_ptr<ScanOptions> options) override;
+  FragmentIterator GetFragmentsImpl(std::shared_ptr<Expression> predicate) override;
 
   FileSystemDataset(std::shared_ptr<Schema> schema,
                     std::shared_ptr<Expression> root_partition,

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -158,7 +158,6 @@ Result<ScanTaskIterator> IpcFileFormat::ScanFile(
   return IpcScanTaskIterator::Make(options, context, source);
 }
 
-namespace internal {
 class IpcWriteTask : public WriteTask {
  public:
   IpcWriteTask(FileSource destination, std::shared_ptr<FileFormat> format,
@@ -199,15 +198,14 @@ class IpcWriteTask : public WriteTask {
   std::shared_ptr<ScanOptions> scan_options_;
   std::shared_ptr<ScanContext> scan_context_;
 };
-}  // namespace internal
 
 Result<std::shared_ptr<WriteTask>> IpcFileFormat::WriteFragment(
     FileSource destination, std::shared_ptr<Fragment> fragment,
     std::shared_ptr<ScanOptions> scan_options,
     std::shared_ptr<ScanContext> scan_context) {
-  return std::make_shared<internal::IpcWriteTask>(
-      std::move(destination), shared_from_this(), std::move(fragment),
-      std::move(scan_options), std::move(scan_context));
+  return std::make_shared<IpcWriteTask>(std::move(destination), shared_from_this(),
+                                        std::move(fragment), std::move(scan_options),
+                                        std::move(scan_context));
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -158,44 +158,56 @@ Result<ScanTaskIterator> IpcFileFormat::ScanFile(
   return IpcScanTaskIterator::Make(options, context, source);
 }
 
-Result<std::shared_ptr<WriteTask>> IpcFileFormat::WriteFragment(
-    FileSource destination, std::shared_ptr<Fragment> fragment,
-    std::shared_ptr<ScanContext> scan_context) {
-  struct Task : WriteTask {
-    Task(FileSource destination, std::shared_ptr<FileFormat> format,
-         std::shared_ptr<Fragment> fragment, std::shared_ptr<ScanContext> scan_context)
-        : WriteTask(std::move(destination), std::move(format)),
-          fragment_(std::move(fragment)),
-          scan_context_(std::move(scan_context)) {}
+namespace internal {
+class IpcWriteTask : public WriteTask {
+ public:
+  IpcWriteTask(FileSource destination, std::shared_ptr<FileFormat> format,
+               std::shared_ptr<Fragment> fragment,
+               std::shared_ptr<ScanOptions> scan_options,
+               std::shared_ptr<ScanContext> scan_context)
+      : WriteTask(std::move(destination), std::move(format)),
+        fragment_(std::move(fragment)),
+        scan_options_(std::move(scan_options)),
+        scan_context_(std::move(scan_context)) {}
 
-    Status Execute() override {
-      RETURN_NOT_OK(CreateDestinationParentDir());
+  Status Execute() override {
+    RETURN_NOT_OK(CreateDestinationParentDir());
 
-      ARROW_ASSIGN_OR_RAISE(auto out_stream, destination_.OpenWritable());
-      ARROW_ASSIGN_OR_RAISE(auto writer,
-                            ipc::NewFileWriter(out_stream.get(), fragment_->schema()));
-      ARROW_ASSIGN_OR_RAISE(auto scan_task_it, fragment_->Scan(scan_context_));
+    auto schema = scan_options_->schema();
 
-      for (auto maybe_scan_task : scan_task_it) {
-        ARROW_ASSIGN_OR_RAISE(auto scan_task, maybe_scan_task);
+    ARROW_ASSIGN_OR_RAISE(auto out_stream, destination_.OpenWritable());
+    ARROW_ASSIGN_OR_RAISE(auto writer, ipc::NewFileWriter(out_stream.get(), schema));
+    ARROW_ASSIGN_OR_RAISE(auto scan_task_it,
+                          fragment_->Scan(scan_options_, scan_context_));
 
-        ARROW_ASSIGN_OR_RAISE(auto batch_it, scan_task->Execute());
+    for (auto maybe_scan_task : scan_task_it) {
+      ARROW_ASSIGN_OR_RAISE(auto scan_task, maybe_scan_task);
 
-        for (auto maybe_batch : batch_it) {
-          ARROW_ASSIGN_OR_RAISE(auto batch, std::move(maybe_batch));
-          RETURN_NOT_OK(writer->WriteRecordBatch(*batch));
-        }
+      ARROW_ASSIGN_OR_RAISE(auto batch_it, scan_task->Execute());
+
+      for (auto maybe_batch : batch_it) {
+        ARROW_ASSIGN_OR_RAISE(auto batch, std::move(maybe_batch));
+        RETURN_NOT_OK(writer->WriteRecordBatch(*batch));
       }
-
-      return writer->Close();
     }
 
-    std::shared_ptr<Fragment> fragment_;
-    std::shared_ptr<ScanContext> scan_context_;
-  };
+    return writer->Close();
+  }
 
-  return std::make_shared<Task>(std::move(destination), shared_from_this(),
-                                std::move(fragment), std::move(scan_context));
+ private:
+  std::shared_ptr<Fragment> fragment_;
+  std::shared_ptr<ScanOptions> scan_options_;
+  std::shared_ptr<ScanContext> scan_context_;
+};
+}  // namespace internal
+
+Result<std::shared_ptr<WriteTask>> IpcFileFormat::WriteFragment(
+    FileSource destination, std::shared_ptr<Fragment> fragment,
+    std::shared_ptr<ScanOptions> scan_options,
+    std::shared_ptr<ScanContext> scan_context) {
+  return std::make_shared<internal::IpcWriteTask>(
+      std::move(destination), shared_from_this(), std::move(fragment),
+      std::move(scan_options), std::move(scan_context));
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_ipc.h
+++ b/cpp/src/arrow/dataset/file_ipc.h
@@ -47,6 +47,7 @@ class ARROW_DS_EXPORT IpcFileFormat : public FileFormat {
 
   Result<std::shared_ptr<WriteTask>> WriteFragment(
       FileSource destination, std::shared_ptr<Fragment> fragment,
+      std::shared_ptr<ScanOptions> options,
       std::shared_ptr<ScanContext> context) override;
 };
 

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -99,7 +99,7 @@ class TestIpcFileFormat : public ArrowIpcWriterMixin {
   }
 
   RecordBatchIterator Batches(Fragment* fragment) {
-    EXPECT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(ctx_));
+    EXPECT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(opts_, ctx_));
     return Batches(std::move(scan_task_it));
   }
 
@@ -115,7 +115,7 @@ TEST_F(TestIpcFileFormat, ScanRecordBatchReader) {
   auto source = GetFileSource(reader.get());
 
   opts_ = ScanOptions::Make(reader->schema());
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
   int64_t row_count = 0;
 
@@ -132,11 +132,12 @@ TEST_F(TestIpcFileFormat, WriteRecordBatchReader) {
   auto source = GetFileSource(reader.get());
 
   opts_ = ScanOptions::Make(reader->schema());
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
   EXPECT_OK_AND_ASSIGN(auto sink, GetFileSink());
 
-  EXPECT_OK_AND_ASSIGN(auto write_task, format_->WriteFragment(sink, fragment, ctx_));
+  EXPECT_OK_AND_ASSIGN(auto write_task,
+                       format_->WriteFragment(sink, fragment, opts_, ctx_));
 
   ASSERT_OK(write_task->Execute());
 
@@ -186,14 +187,14 @@ TEST_F(TestIpcFileSystemDataset, Write) {
   opts_ = ScanOptions::Make(schema);
 
   auto partitioning_factory = DirectoryPartitioning::MakeFactory({"str", "i32"});
-  ASSERT_OK_AND_ASSIGN(
-      auto plan, partitioning_factory->MakeWritePlan(dataset_->GetFragments(options_)));
+  ASSERT_OK_AND_ASSIGN(auto plan, partitioning_factory->MakeWritePlan(
+                                      schema, dataset_->GetFragments(options_)));
 
   plan.format = format_;
   plan.filesystem = fs_;
   plan.partition_base_dir = "new_root/";
 
-  ASSERT_OK_AND_ASSIGN(auto written, FileSystemDataset::Write(plan, ctx_));
+  ASSERT_OK_AND_ASSIGN(auto written, FileSystemDataset::Write(plan, opts_, ctx_));
 
   using E = TestExpression;
   std::vector<E> actual_partitions;
@@ -249,7 +250,7 @@ TEST_F(TestIpcFileFormat, ScanRecordBatchReaderProjected) {
 
   auto reader = GetRecordBatchReader();
   auto source = GetFileSource(reader.get());
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
   int64_t row_count = 0;
 
@@ -282,7 +283,7 @@ TEST_F(TestIpcFileFormat, ScanRecordBatchReaderProjectedMissingCols) {
   auto readers = {reader.get(), reader_without_i32.get(), reader_without_f64.get()};
   for (auto reader : readers) {
     auto source = GetFileSource(reader);
-    ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+    ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
     // NB: projector is applied by the scanner; Fragment does not evaluate it.
     // We will not drop "i32" even though it is not in the projector's schema.

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -187,8 +187,8 @@ TEST_F(TestIpcFileSystemDataset, Write) {
   opts_ = ScanOptions::Make(schema);
 
   auto partitioning_factory = DirectoryPartitioning::MakeFactory({"str", "i32"});
-  ASSERT_OK_AND_ASSIGN(auto plan, partitioning_factory->MakeWritePlan(
-                                      schema, dataset_->GetFragments(options_)));
+  ASSERT_OK_AND_ASSIGN(
+      auto plan, partitioning_factory->MakeWritePlan(schema, dataset_->GetFragments()));
 
   plan.format = format_;
   plan.filesystem = fs_;

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -220,8 +220,7 @@ class RowGroupSkipper {
     }
 
     auto stats_expr = maybe_stats_expr.ValueOrDie();
-    auto expr = filter_->Assume(stats_expr);
-    return (expr->IsNull() || expr->Equals(false));
+    return !filter_->Assume(stats_expr)->IsSatisfiable();
   }
 
   std::shared_ptr<parquet::FileMetaData> metadata_;

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -415,7 +415,7 @@ Result<std::shared_ptr<FileFragment>> ParquetFileFormat::MakeFragment(
 }
 
 Result<FragmentIterator> ParquetFileFormat::GetRowGroupFragments(
-    const ParquetFileFragment& fragment, std::shared_ptr<Expression> extra_filter) {
+    const ParquetFileFragment& fragment, std::shared_ptr<Expression> filter) {
   auto properties = MakeReaderProperties(*this);
   ARROW_ASSIGN_OR_RAISE(auto reader,
                         OpenReader(fragment.source(), std::move(properties)));
@@ -430,8 +430,8 @@ Result<FragmentIterator> ParquetFileFormat::GetRowGroupFragments(
   }
   FragmentVector fragments(row_groups.size());
 
-  RowGroupSkipper skipper(std::move(metadata), std::move(arrow_properties), extra_filter,
-                          std::move(row_groups));
+  RowGroupSkipper skipper(std::move(metadata), std::move(arrow_properties),
+                          std::move(filter), std::move(row_groups));
 
   for (int i = 0, row_group = skipper.Next();
        row_group != RowGroupSkipper::kIterationDone; row_group = skipper.Next()) {

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -402,19 +402,17 @@ Result<ScanTaskIterator> ParquetFileFormat::ScanFile(
 }
 
 Result<std::shared_ptr<FileFragment>> ParquetFileFormat::MakeFragment(
-    FileSource source, std::shared_ptr<ScanOptions> options,
-    std::shared_ptr<Expression> partition_expression, std::vector<int> row_groups) {
+    FileSource source, std::shared_ptr<Expression> partition_expression,
+    std::vector<int> row_groups) {
   return std::shared_ptr<FileFragment>(
-      new ParquetFileFragment(std::move(source), shared_from_this(), std::move(options),
+      new ParquetFileFragment(std::move(source), shared_from_this(),
                               std::move(partition_expression), std::move(row_groups)));
 }
 
 Result<std::shared_ptr<FileFragment>> ParquetFileFormat::MakeFragment(
-    FileSource source, std::shared_ptr<ScanOptions> options,
-    std::shared_ptr<Expression> partition_expression) {
-  return std::shared_ptr<FileFragment>(
-      new ParquetFileFragment(std::move(source), shared_from_this(), std::move(options),
-                              std::move(partition_expression), {}));
+    FileSource source, std::shared_ptr<Expression> partition_expression) {
+  return std::shared_ptr<FileFragment>(new ParquetFileFragment(
+      std::move(source), shared_from_this(), std::move(partition_expression), {}));
 }
 
 Result<FragmentIterator> ParquetFileFormat::GetRowGroupFragments(
@@ -433,26 +431,22 @@ Result<FragmentIterator> ParquetFileFormat::GetRowGroupFragments(
   }
   FragmentVector fragments(row_groups.size());
 
-  auto new_options = std::make_shared<ScanOptions>(*fragment.scan_options());
-  if (!extra_filter->Equals(true)) {
-    new_options->filter = and_(std::move(extra_filter), std::move(new_options->filter));
-  }
-
-  RowGroupSkipper skipper(std::move(metadata), std::move(arrow_properties),
-                          new_options->filter, std::move(row_groups));
+  RowGroupSkipper skipper(std::move(metadata), std::move(arrow_properties), extra_filter,
+                          std::move(row_groups));
 
   for (int i = 0, row_group = skipper.Next();
        row_group != RowGroupSkipper::kIterationDone; row_group = skipper.Next()) {
-    ARROW_ASSIGN_OR_RAISE(fragments[i++],
-                          MakeFragment(fragment.source(), new_options,
-                                       fragment.partition_expression(), {row_group}));
+    ARROW_ASSIGN_OR_RAISE(
+        fragments[i++],
+        MakeFragment(fragment.source(), fragment.partition_expression(), {row_group}));
   }
 
   return MakeVectorIterator(std::move(fragments));
 }
 
-Result<ScanTaskIterator> ParquetFileFragment::Scan(std::shared_ptr<ScanContext> context) {
-  return parquet_format().ScanFile(source_, scan_options_, std::move(context),
+Result<ScanTaskIterator> ParquetFileFragment::Scan(std::shared_ptr<ScanOptions> options,
+                                                   std::shared_ptr<ScanContext> context) {
+  return parquet_format().ScanFile(source_, std::move(options), std::move(context),
                                    row_groups_);
 }
 

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -108,11 +108,15 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
       std::vector<int> row_groups);
 
   /// \brief Split a ParquetFileFragment into a Fragment for each row group.
-  /// Row groups whose metadata contradicts the fragment's filter or the extra_filter
-  /// will be excluded.
+  ///
+  /// \param[in] fragment to split
+  /// \param[in] filter expression that will ignore RowGroup that can't satisfy
+  ///            the filter.
+  ///
+  /// \return An iterator of fragment.
   Result<FragmentIterator> GetRowGroupFragments(
       const ParquetFileFragment& fragment,
-      std::shared_ptr<Expression> extra_filter = scalar(true));
+      std::shared_ptr<Expression> filter = scalar(true));
 };
 
 class ARROW_DS_EXPORT ParquetFileFragment : public FileFragment {

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -100,13 +100,12 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
   using FileFormat::MakeFragment;
 
   Result<std::shared_ptr<FileFragment>> MakeFragment(
-      FileSource source, std::shared_ptr<ScanOptions> options,
-      std::shared_ptr<Expression> partition_expression) override;
+      FileSource source, std::shared_ptr<Expression> partition_expression) override;
 
   /// \brief Create a Fragment, restricted to the specified row groups.
   Result<std::shared_ptr<FileFragment>> MakeFragment(
-      FileSource source, std::shared_ptr<ScanOptions> options,
-      std::shared_ptr<Expression> partition_expression, std::vector<int> row_groups);
+      FileSource source, std::shared_ptr<Expression> partition_expression,
+      std::vector<int> row_groups);
 
   /// \brief Split a ParquetFileFragment into a Fragment for each row group.
   /// Row groups whose metadata contradicts the fragment's filter or the extra_filter
@@ -118,7 +117,8 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
 
 class ARROW_DS_EXPORT ParquetFileFragment : public FileFragment {
  public:
-  Result<ScanTaskIterator> Scan(std::shared_ptr<ScanContext> context) override;
+  Result<ScanTaskIterator> Scan(std::shared_ptr<ScanOptions> options,
+                                std::shared_ptr<ScanContext> context) override;
 
   /// \brief The row groups viewed by this Fragment. This may be empty which signifies all
   /// row groups are selected.
@@ -126,10 +126,9 @@ class ARROW_DS_EXPORT ParquetFileFragment : public FileFragment {
 
  private:
   ParquetFileFragment(FileSource source, std::shared_ptr<FileFormat> format,
-                      std::shared_ptr<ScanOptions> scan_options,
                       std::shared_ptr<Expression> partition_expression,
                       std::vector<int> row_groups)
-      : FileFragment(std::move(source), std::move(format), std::move(scan_options),
+      : FileFragment(std::move(source), std::move(format),
                      std::move(partition_expression)),
         row_groups_(std::move(row_groups)) {}
 

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -467,7 +467,7 @@ TEST_F(TestParquetFileFormat, PredicatePushdownRowGroupFragments) {
                            "i64"_ >= int64_t(6));
 
   CountRowGroupsInFragment(fragment, {5, 6, 7},
-                           "i64"_ >= int64_t(6) && "i64"_ < int64_t(8));
+                           "i64"_ >= int64_t(6) and "i64"_ < int64_t(8));
 }
 
 TEST_F(TestParquetFileFormat, ExplicitRowGroupSelection) {

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -149,7 +149,7 @@ class TestParquetFileFormat : public ArrowParquetWriterMixin {
   }
 
   RecordBatchIterator Batches(Fragment* fragment) {
-    EXPECT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(ctx_));
+    EXPECT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(opts_, ctx_));
     return Batches(std::move(scan_task_it));
   }
 
@@ -181,14 +181,10 @@ class TestParquetFileFormat : public ArrowParquetWriterMixin {
 
   void CountRowGroupsInFragment(const std::shared_ptr<Fragment>& fragment,
                                 std::vector<int> expected_row_groups,
-                                const Expression& filter,
-                                const Expression& extra_filter = *scalar(true)) {
-    fragment->scan_options()->filter = filter.Copy();
-
+                                const Expression& filter) {
     auto parquet_fragment = checked_pointer_cast<ParquetFileFragment>(fragment);
-    ASSERT_OK_AND_ASSIGN(
-        auto row_group_fragments,
-        format_->GetRowGroupFragments(*parquet_fragment, extra_filter.Copy()));
+    ASSERT_OK_AND_ASSIGN(auto row_group_fragments,
+                         format_->GetRowGroupFragments(*parquet_fragment, filter.Copy()));
 
     auto expected_row_group = expected_row_groups.begin();
     for (auto maybe_fragment : row_group_fragments) {
@@ -214,7 +210,7 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   auto source = GetFileSource(reader.get());
 
   opts_ = ScanOptions::Make(reader->schema());
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
   int64_t row_count = 0;
 
@@ -235,9 +231,9 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderDictEncoded) {
   opts_ = ScanOptions::Make(reader->schema());
 
   format_->reader_options.dict_columns = {"utf8"};
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
-  ASSERT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(ctx_));
+  ASSERT_OK_AND_ASSIGN(auto scan_task_it, fragment->Scan(opts_, ctx_));
   int64_t row_count = 0;
 
   Schema expected_schema({field("utf8", dictionary(int32(), utf8()))});
@@ -283,7 +279,7 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjected) {
 
   auto reader = GetRecordBatchReader();
   auto source = GetFileSource(reader.get());
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
   int64_t row_count = 0;
 
@@ -316,7 +312,7 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjectedMissingCols) {
   auto readers = {reader.get(), reader_without_i32.get(), reader_without_f64.get()};
   for (auto reader : readers) {
     auto source = GetFileSource(reader);
-    ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+    ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
     // NB: projector is applied by the scanner; ParquetFragment does not evaluate it.
     // We will not drop "i32" even though it is not in the projector's schema.
@@ -404,7 +400,7 @@ TEST_F(TestParquetFileFormat, PredicatePushdown) {
   auto source = GetFileSource(reader.get());
 
   opts_ = ScanOptions::Make(reader->schema());
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
   opts_->filter = scalar(true);
   CountRowsAndBatchesInScan(fragment, kTotalNumRows, kNumRowGroups);
@@ -444,7 +440,7 @@ TEST_F(TestParquetFileFormat, PredicatePushdownRowGroupFragments) {
   auto source = GetFileSource(reader.get());
 
   opts_ = ScanOptions::Make(reader->schema());
-  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source, opts_));
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
   CountRowGroupsInFragment(fragment, internal::Iota(static_cast<int>(kTotalNumRows)),
                            *scalar(true));
@@ -460,7 +456,7 @@ TEST_F(TestParquetFileFormat, PredicatePushdownRowGroupFragments) {
 
   // No rows match 1 and 2.
   CountRowGroupsInFragment(fragment, {}, "i64"_ == int64_t(1) and "u8"_ == uint8_t(2));
-  CountRowGroupsInFragment(fragment, {}, "i64"_ == int64_t(2), "i64"_ == int64_t(4));
+  CountRowGroupsInFragment(fragment, {}, "i64"_ == int64_t(2) and "i64"_ == int64_t(4));
 
   CountRowGroupsInFragment(fragment, {1, 3},
                            "i64"_ == int64_t(2) or "i64"_ == int64_t(4));
@@ -470,8 +466,8 @@ TEST_F(TestParquetFileFormat, PredicatePushdownRowGroupFragments) {
   CountRowGroupsInFragment(fragment, internal::Iota(5, static_cast<int>(kNumRowGroups)),
                            "i64"_ >= int64_t(6));
 
-  CountRowGroupsInFragment(fragment, {5, 6, 7}, "i64"_ >= int64_t(6),
-                           "i64"_ < int64_t(8));
+  CountRowGroupsInFragment(fragment, {5, 6, 7},
+                           "i64"_ >= int64_t(6) && "i64"_ < int64_t(8));
 }
 
 TEST_F(TestParquetFileFormat, ExplicitRowGroupSelection) {
@@ -485,7 +481,7 @@ TEST_F(TestParquetFileFormat, ExplicitRowGroupSelection) {
 
   auto row_groups_fragment = [&](std::vector<int> row_groups) {
     EXPECT_OK_AND_ASSIGN(auto fragment,
-                         format_->MakeFragment(*source, opts_, scalar(true), row_groups));
+                         format_->MakeFragment(*source, scalar(true), row_groups));
     return internal::checked_pointer_cast<ParquetFileFragment>(fragment);
   };
 
@@ -517,7 +513,7 @@ TEST_F(TestParquetFileFormat, ExplicitRowGroupSelection) {
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       IndexError,
       testing::HasSubstr("only has " + std::to_string(kNumRowGroups) + " row groups"),
-      row_groups_fragment({kNumRowGroups + 1})->Scan(ctx_));
+      row_groups_fragment({kNumRowGroups + 1})->Scan(opts_, ctx_));
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -80,15 +80,15 @@ TEST(FileSource, BufferBased) {
 
 TEST_F(TestFileSystemDataset, Basic) {
   MakeDataset({});
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(), {});
 
   MakeDataset({fs::File("a"), fs::File("b"), fs::File("c")});
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {"a", "b", "c"});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(), {"a", "b", "c"});
   AssertFilesAre(dataset_, {"a", "b", "c"});
 
   // Should not create fragment from directories.
   MakeDataset({fs::Dir("A"), fs::Dir("A/B"), fs::File("A/a"), fs::File("A/B/b")});
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {"A/a", "A/B/b"});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(), {"A/a", "A/B/b"});
   AssertFilesAre(dataset_, {"A/a", "A/B/b"});
 }
 
@@ -121,27 +121,22 @@ TEST_F(TestFileSystemDataset, RootPartitionPruning) {
   MakeDataset({fs::File("a"), fs::File("b")}, root_partition);
 
   // Default filter should always return all data.
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {"a", "b"});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(), {"a", "b"});
 
   // filter == partition
-  options_->filter = root_partition;
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {"a", "b"});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(root_partition), {"a", "b"});
 
   // Same partition key, but non matching filter
-  options_->filter = ("a"_ == 6).Copy();
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(("a"_ == 6).Copy()), {});
 
-  options_->filter = ("a"_ > 1).Copy();
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {"a", "b"});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(("a"_ > 1).Copy()), {"a", "b"});
 
   // different key shouldn't prune
-  options_->filter = ("b"_ == 6).Copy();
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {"a", "b"});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(("b"_ == 6).Copy()), {"a", "b"});
 
   // No partition should match
   MakeDataset({fs::File("a"), fs::File("b")});
-  options_->filter = ("b"_ == 6).Copy();
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {"a", "b"});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(("b"_ == 6).Copy()), {"a", "b"});
 }
 
 TEST_F(TestFileSystemDataset, TreePartitionPruning) {
@@ -165,21 +160,20 @@ TEST_F(TestFileSystemDataset, TreePartitionPruning) {
   std::vector<std::string> franklins = {"CA/Franklin", "NY/Franklin"};
 
   // Default filter should always return all data.
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), all_cities);
+  AssertFragmentsAreFromPath(dataset_->GetFragments(), all_cities);
 
   // Dataset's partitions are respected
-  options_->filter = ("country"_ == "US").Copy();
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), all_cities);
-  options_->filter = ("country"_ == "FR").Copy();
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), {});
+  AssertFragmentsAreFromPath(dataset_->GetFragments(("country"_ == "US").Copy()),
+                             all_cities);
+  AssertFragmentsAreFromPath(dataset_->GetFragments(("country"_ == "FR").Copy()), {});
 
-  options_->filter = ("state"_ == "CA").Copy();
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), ca_cities);
+  AssertFragmentsAreFromPath(dataset_->GetFragments(("state"_ == "CA").Copy()),
+                             ca_cities);
 
   // Filter where no decisions can be made on inner nodes when filter don't
   // apply to inner partitions.
-  options_->filter = ("city"_ == "Franklin").Copy();
-  AssertFragmentsAreFromPath(dataset_->GetFragments(options_), franklins);
+  AssertFragmentsAreFromPath(dataset_->GetFragments(("city"_ == "Franklin").Copy()),
+                             franklins);
 }
 
 TEST_F(TestFileSystemDataset, FragmentPartitions) {
@@ -202,7 +196,7 @@ TEST_F(TestFileSystemDataset, FragmentPartitions) {
   };
 
   AssertFragmentsHavePartitionExpressions(
-      dataset_->GetFragments(options_),
+      dataset_->GetFragments(),
       {
           with_root("state"_ == "CA", "city"_ == "San Francisco"),
           with_root("state"_ == "CA", "city"_ == "Franklin"),

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -49,8 +49,8 @@ namespace arrow {
 namespace dataset {
 
 using arrow::compute::Datum;
-using internal::checked_cast;
-using internal::checked_pointer_cast;
+using arrow::internal::checked_cast;
+using arrow::internal::checked_pointer_cast;
 
 inline std::shared_ptr<ScalarExpression> NullExpression() {
   return std::make_shared<ScalarExpression>(std::make_shared<BooleanScalar>());
@@ -655,31 +655,32 @@ std::string ScalarExpression::ToString() const {
   return value_->ToString() + ":" + type_repr;
 }
 
+using arrow::internal::JoinStrings;
+
 std::string AndExpression::ToString() const {
-  return internal::JoinStrings(
+  return JoinStrings(
       {"(", left_operand_->ToString(), " and ", right_operand_->ToString(), ")"}, "");
 }
 
 std::string OrExpression::ToString() const {
-  return internal::JoinStrings(
+  return JoinStrings(
       {"(", left_operand_->ToString(), " or ", right_operand_->ToString(), ")"}, "");
 }
 
 std::string NotExpression::ToString() const {
   if (operand_->type() == ExpressionType::IS_VALID) {
     const auto& is_valid = checked_cast<const IsValidExpression&>(*operand_);
-    return internal::JoinStrings({"(", is_valid.operand()->ToString(), " is null)"}, "");
+    return JoinStrings({"(", is_valid.operand()->ToString(), " is null)"}, "");
   }
-  return internal::JoinStrings({"(not ", operand_->ToString(), ")"}, "");
+  return JoinStrings({"(not ", operand_->ToString(), ")"}, "");
 }
 
 std::string IsValidExpression::ToString() const {
-  return internal::JoinStrings({"(", operand_->ToString(), " is not null)"}, "");
+  return JoinStrings({"(", operand_->ToString(), " is not null)"}, "");
 }
 
 std::string InExpression::ToString() const {
-  return internal::JoinStrings(
-      {"(", operand_->ToString(), " is in ", set_->ToString(), ")"}, "");
+  return JoinStrings({"(", operand_->ToString(), " is in ", set_->ToString(), ")"}, "");
 }
 
 std::string CastExpression::ToString() const {
@@ -691,13 +692,13 @@ std::string CastExpression::ToString() const {
     auto like = arrow::util::get<std::shared_ptr<Expression>>(to_);
     to = " like " + like->ToString();
   }
-  return internal::JoinStrings({"(cast ", operand_->ToString(), std::move(to), ")"}, "");
+  return JoinStrings({"(cast ", operand_->ToString(), std::move(to), ")"}, "");
 }
 
 std::string ComparisonExpression::ToString() const {
-  return internal::JoinStrings({"(", left_operand_->ToString(), " ", OperatorName(op()),
-                                " ", right_operand_->ToString(), ")"},
-                               "");
+  return JoinStrings({"(", left_operand_->ToString(), " ", OperatorName(op()), " ",
+                      right_operand_->ToString(), ")"},
+                     "");
 }
 
 bool UnaryExpression::Equals(const Expression& other) const {

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -183,6 +183,11 @@ class ARROW_DS_EXPORT Expression {
     return Assume(*given);
   }
 
+  /// Indicates if the expression is satisfiable.
+  ///
+  /// This is a shortcut to check if the expression is neither null nor false.
+  bool IsSatisfiable() const { return !IsNull() && !Equals(false); }
+
   /// returns a debug string representing this expression
   virtual std::string ToString() const = 0;
 

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -64,13 +64,15 @@ std::shared_ptr<Partitioning> Partitioning::Default() {
   return std::make_shared<DefaultPartitioning>();
 }
 
-Result<WritePlan> PartitioningFactory::MakeWritePlan(FragmentIterator fragment_it) {
+Result<WritePlan> PartitioningFactory::MakeWritePlan(std::shared_ptr<Schema> schema,
+                                                     FragmentIterator fragment_it) {
   return Status::NotImplemented("MakeWritePlan from PartitioningFactory of type ",
                                 type_name());
 }
 
 Result<WritePlan> PartitioningFactory::MakeWritePlan(
-    FragmentIterator fragment_it, const std::shared_ptr<Schema>& schema) {
+    std::shared_ptr<Schema> schema, FragmentIterator fragment_it,
+    std::shared_ptr<Schema> partition_schema) {
   return Status::NotImplemented("MakeWritePlan from PartitioningFactory of type ",
                                 type_name());
 }
@@ -297,10 +299,12 @@ class DirectoryPartitioningFactory : public PartitioningFactory {
 
   struct MakeWritePlanImpl;
 
-  Result<WritePlan> MakeWritePlan(FragmentIterator fragments) override;
+  Result<WritePlan> MakeWritePlan(std::shared_ptr<Schema> schema,
+                                  FragmentIterator fragments) override;
 
-  Result<WritePlan> MakeWritePlan(FragmentIterator fragments,
-                                  const std::shared_ptr<Schema>& schema) override;
+  Result<WritePlan> MakeWritePlan(std::shared_ptr<Schema> schema,
+                                  FragmentIterator fragments,
+                                  std::shared_ptr<Schema> partition_schema) override;
 
  private:
   std::vector<std::string> field_names_;
@@ -309,9 +313,10 @@ class DirectoryPartitioningFactory : public PartitioningFactory {
 struct DirectoryPartitioningFactory::MakeWritePlanImpl {
   using Indices = std::basic_string<int>;
 
-  MakeWritePlanImpl(DirectoryPartitioningFactory* factory,
+  MakeWritePlanImpl(DirectoryPartitioningFactory* factory, std::shared_ptr<Schema> schema,
                     FragmentVector source_fragments)
       : this_(factory),
+        schema_(std::move(schema)),
         source_fragments_(std::move(source_fragments)),
         right_hand_sides_(source_fragments_.size(), Indices(num_fields(), -1)) {}
 
@@ -416,23 +421,6 @@ struct DirectoryPartitioningFactory::MakeWritePlanImpl {
     return std::to_string(milliseconds_since_epoch);
   }
 
-  // remove fields which will be implicit in the partitioning; writing them to files would
-  // be redundant
-  Status DropPartitionFields(const std::shared_ptr<Partitioning>& partitioning,
-                             Fragment* fragment) {
-    auto schema = fragment->schema();
-    for (const auto& field : partitioning->schema()->fields()) {
-      int field_i = schema->GetFieldIndex(field->name());
-      if (field_i != -1) {
-        ARROW_ASSIGN_OR_RAISE(schema, schema->RemoveField(field_i));
-      }
-    }
-
-    // the fragment being scanned to disk will now deselect redundant columns
-    fragment->scan_options()->projector = RecordBatchProjector(std::move(schema));
-    return Status::OK();
-  }
-
   Result<WritePlan> Finish(std::shared_ptr<Schema> partitioning_schema = nullptr) && {
     WritePlan out;
 
@@ -444,10 +432,9 @@ struct DirectoryPartitioningFactory::MakeWritePlanImpl {
     ARROW_ASSIGN_OR_RAISE(out.partitioning,
                           this_->Finish(std::move(partitioning_schema)));
 
-    auto fragment_schema =
-        source_fragments_.empty() ? schema({}) : source_fragments_.front()->schema();
+    // There's no guarantee that all Fragments have the same schema.
     ARROW_ASSIGN_OR_RAISE(out.schema,
-                          UnifySchemas({out.partitioning->schema(), fragment_schema}));
+                          UnifySchemas({out.partitioning->schema(), schema_}));
 
     // Lexicographic ordering WRT right_hand_sides_ ensures that source_fragments_ are in
     // a depth first visitation order WRT their partition expressions. This makes
@@ -473,9 +460,6 @@ struct DirectoryPartitioningFactory::MakeWritePlanImpl {
     Indices current_parents(num_fields() + 1, -1);
 
     for (size_t fragment_i = 0; fragment_i < source_fragments_.size(); ++fragment_i) {
-      RETURN_NOT_OK(
-          DropPartitionFields(out.partitioning, source_fragments_[fragment_i].get()));
-
       int field_i = 0;
       for (; field_i < num_fields(); ++field_i) {
         // these directories have already been created and we're still writing their
@@ -528,6 +512,7 @@ struct DirectoryPartitioningFactory::MakeWritePlanImpl {
   }
 
   DirectoryPartitioningFactory* this_;
+  std::shared_ptr<Schema> schema_;
   FragmentVector source_fragments_;
 
   struct {
@@ -552,15 +537,16 @@ struct DirectoryPartitioningFactory::MakeWritePlanImpl {
 };
 
 Result<WritePlan> DirectoryPartitioningFactory::MakeWritePlan(
-    FragmentIterator fragment_it, const std::shared_ptr<Schema>& schema) {
+    std::shared_ptr<Schema> schema, FragmentIterator fragment_it,
+    std::shared_ptr<Schema> partition_schema) {
   ARROW_ASSIGN_OR_RAISE(auto fragments, fragment_it.ToVector());
-  return MakeWritePlanImpl(this, std::move(fragments)).Finish(schema);
+  return MakeWritePlanImpl(this, schema, std::move(fragments)).Finish(partition_schema);
 }
 
 Result<WritePlan> DirectoryPartitioningFactory::MakeWritePlan(
-    FragmentIterator fragment_it) {
+    std::shared_ptr<Schema> schema, FragmentIterator fragment_it) {
   ARROW_ASSIGN_OR_RAISE(auto fragments, fragment_it.ToVector());
-  return MakeWritePlanImpl(this, std::move(fragments)).Finish();
+  return MakeWritePlanImpl(this, schema, std::move(fragments)).Finish();
 }
 
 std::shared_ptr<PartitioningFactory> DirectoryPartitioning::MakeFactory(

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -42,7 +42,7 @@ namespace dataset {
 
 using util::string_view;
 
-using internal::checked_cast;
+using arrow::internal::checked_cast;
 
 Result<std::shared_ptr<Expression>> Partitioning::Parse(const std::string& path) const {
   ExpressionVector expressions;
@@ -440,9 +440,9 @@ struct DirectoryPartitioningFactory::MakeWritePlanImpl {
     // a depth first visitation order WRT their partition expressions. This makes
     // generation of the full directory tree far simpler since a directory's files are
     // grouped.
-    auto permutation = internal::ArgSort(right_hand_sides_);
-    internal::Permute(permutation, &source_fragments_);
-    internal::Permute(permutation, &right_hand_sides_);
+    auto permutation = arrow::internal::ArgSort(right_hand_sides_);
+    arrow::internal::Permute(permutation, &source_fragments_);
+    arrow::internal::Permute(permutation, &right_hand_sides_);
 
     // the basename of out.paths[i] is stored in segments[i] (full paths will be assembled
     // after segments is complete)

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -104,10 +104,12 @@ class ARROW_DS_EXPORT PartitioningFactory {
 
   // FIXME(bkietz) Make these pure virtual
   /// Construct a WritePlan for the provided fragments
-  virtual Result<WritePlan> MakeWritePlan(FragmentIterator fragments,
-                                          const std::shared_ptr<Schema>& schema);
+  virtual Result<WritePlan> MakeWritePlan(std::shared_ptr<Schema> schema,
+                                          FragmentIterator fragments,
+                                          std::shared_ptr<Schema> partition_schema);
   /// Construct a WritePlan for the provided fragments, inferring schema
-  virtual Result<WritePlan> MakeWritePlan(FragmentIterator fragments);
+  virtual Result<WritePlan> MakeWritePlan(std::shared_ptr<Schema> schema,
+                                          FragmentIterator fragments);
 };
 
 /// \brief Subclass for representing the default, a partitioning that returns

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -80,14 +80,7 @@ Result<ScanTaskIterator> Scanner::Scan() {
   // Transforms Iterator<Fragment> into a unified
   // Iterator<ScanTask>. The first Iterator::Next invocation is going to do
   // all the work of unwinding the chained iterators.
-  auto scan_task_it = GetScanTaskIterator(GetFragments(), scan_context_);
-
-  // Apply the filter and/or projection to incoming RecordBatches by
-  // wrapping the ScanTask with a FilterAndProjectScanTask
-  auto wrap_scan_task = [](std::shared_ptr<ScanTask> task) -> std::shared_ptr<ScanTask> {
-    return std::make_shared<FilterAndProjectScanTask>(std::move(task));
-  };
-  return MakeMapIterator(wrap_scan_task, std::move(scan_task_it));
+  return GetScanTaskIterator(GetFragments(), scan_options_, scan_context_);
 }
 
 Result<ScanTaskIterator> ScanTaskIteratorFromRecordBatch(

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -73,7 +73,7 @@ FragmentIterator Scanner::GetFragments() {
   // Transform Datasets in a flat Iterator<Fragment>. This
   // iterator is lazily constructed, i.e. Dataset::GetFragments is
   // not invoked until a Fragment is requested.
-  return GetFragmentsFromDatasets({dataset_}, scan_options_);
+  return GetFragmentsFromDatasets({dataset_}, scan_options_->filter);
 }
 
 Result<ScanTaskIterator> Scanner::Scan() {

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -143,13 +143,12 @@ ARROW_DS_EXPORT Result<ScanTaskIterator> ScanTaskIteratorFromRecordBatch(
 
 /// \brief Scanner is a materialized scan operation with context and options
 /// bound. A scanner is the class that glues ScanTask, Fragment,
-/// and Source. In python pseudo code, it performs the following:
+/// and Dataset. In python pseudo code, it performs the following:
 ///
 ///  def Scan():
-///    for source in this.sources_:
-///      for fragment in source.GetFragments(this.options_):
-///        for scan_task in fragment.Scan(this.context_):
-///          yield scan_task
+///    for fragment in self.dataset.GetFragments(this.options.filter):
+///      for scan_task in fragment.Scan(this.options):
+///        yield scan_task
 class ARROW_DS_EXPORT Scanner {
  public:
   Scanner(std::shared_ptr<Dataset> dataset, std::shared_ptr<ScanOptions> scan_options,
@@ -200,6 +199,9 @@ class ARROW_DS_EXPORT ScannerBuilder {
   ScannerBuilder(std::shared_ptr<Dataset> dataset,
                  std::shared_ptr<ScanContext> scan_context);
 
+  ScannerBuilder(std::shared_ptr<Schema> schema, std::shared_ptr<Fragment> fragment,
+                 std::shared_ptr<ScanContext> scan_context);
+
   /// \brief Set the subset of columns to materialize.
   ///
   /// This subset will be passed down to Sources and corresponding Fragments.
@@ -241,10 +243,11 @@ class ARROW_DS_EXPORT ScannerBuilder {
   /// \brief Return the constructed now-immutable Scanner object
   Result<std::shared_ptr<Scanner>> Finish() const;
 
-  std::shared_ptr<Schema> schema() const { return dataset_->schema(); }
+  std::shared_ptr<Schema> schema() const { return scan_options_->schema(); }
 
  private:
   std::shared_ptr<Dataset> dataset_;
+  std::shared_ptr<Fragment> fragment_;
   std::shared_ptr<ScanOptions> scan_options_;
   std::shared_ptr<ScanContext> scan_context_;
   bool has_projection_ = false;

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -158,9 +158,10 @@ class ARROW_DS_EXPORT Scanner {
         scan_options_(std::move(scan_options)),
         scan_context_(std::move(scan_context)) {}
 
-  Scanner(std::shared_ptr<Fragment> fragment, std::shared_ptr<ScanContext> scan_context)
+  Scanner(std::shared_ptr<Fragment> fragment, std::shared_ptr<ScanOptions> scan_options,
+          std::shared_ptr<ScanContext> scan_context)
       : fragment_(std::move(fragment)),
-        scan_options_(fragment_->scan_options()),
+        scan_options_(std::move(scan_options)),
         scan_context_(std::move(scan_context)) {}
 
   /// \brief The Scan operator returns a stream of ScanTask. The caller is

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -119,7 +119,7 @@ class DatasetFixtureMixin : public ::testing::Test {
   /// record batches yielded by the data fragment.
   void AssertFragmentEquals(RecordBatchReader* expected, Fragment* fragment,
                             bool ensure_drained = true) {
-    ASSERT_OK_AND_ASSIGN(auto it, fragment->Scan(ctx_));
+    ASSERT_OK_AND_ASSIGN(auto it, fragment->Scan(options_, ctx_));
 
     ARROW_EXPECT_OK(it.Visit([&](std::shared_ptr<ScanTask> task) -> Status {
       AssertScanTaskEquals(expected, task.get(), false);

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -135,7 +135,7 @@ class DatasetFixtureMixin : public ::testing::Test {
   /// record batches yielded by the data fragments of a dataset.
   void AssertDatasetFragmentsEqual(RecordBatchReader* expected, Dataset* dataset,
                                    bool ensure_drained = true) {
-    auto it = dataset->GetFragments(options_);
+    auto it = dataset->GetFragments(options_->filter);
 
     ARROW_EXPECT_OK(it.Visit([&](std::shared_ptr<Fragment> fragment) -> Status {
       AssertFragmentEquals(expected, fragment.get(), false);

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -137,6 +137,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CScanOptions "arrow::dataset::ScanOptions":
         CRecordBatchProjector projector
+        @staticmethod
+        shared_ptr[CScanOptions] Make(shared_ptr[CSchema] schema)
+
 
     cdef cppclass CScanContext "arrow::dataset::ScanContext":
         c_bool use_threads
@@ -149,8 +152,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[CRecordBatchIterator] Execute()
 
     cdef cppclass CFragment "arrow::dataset::Fragment":
-        CResult[CScanTaskIterator] Scan(shared_ptr[CScanContext] context)
-        const shared_ptr[CSchema]& schema() const
+        CResult[CScanTaskIterator] Scan(
+            shared_ptr[CScanOptions] options, shared_ptr[CScanContext] context)
+        const shared_ptr[CSchema]& physical_schema() const
         c_bool splittable() const
         c_string type_name() const
         const shared_ptr[CExpression]& partition_expression() const
@@ -162,7 +166,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         "arrow::dataset::FragmentIterator"
 
     cdef cppclass CScanner "arrow::dataset::Scanner":
-        CScanner(shared_ptr[CFragment], shared_ptr[CScanContext])
+        CScanner(shared_ptr[CFragment], shared_ptr[CScanOptions], shared_ptr[CScanContext])
         CResult[CScanTaskIterator] Scan()
         CResult[shared_ptr[CTable]] ToTable()
         CFragmentIterator GetFragments()
@@ -232,7 +236,6 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[shared_ptr[CSchema]] Inspect(const CFileSource&) const
         CResult[shared_ptr[CFileFragment]] MakeFragment(
             CFileSource source,
-            shared_ptr[CScanOptions] options,
             shared_ptr[CExpression] partition_expression)
 
     cdef cppclass CFileFragment "arrow::dataset::FileFragment"(
@@ -272,7 +275,6 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             shared_ptr[CExpression] extra_filter)
         CResult[shared_ptr[CFileFragment]] MakeFragment(
             CFileSource source,
-            shared_ptr[CScanOptions] options,
             shared_ptr[CExpression] partition_expression,
             vector[int] row_groups)
 

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -188,6 +188,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CDataset "arrow::dataset::Dataset":
         const shared_ptr[CSchema] & schema()
+        CFragmentIterator GetFragments()
+        CFragmentIterator GetFragments(shared_ptr[CExpression] predicate)
         const shared_ptr[CExpression] & partition_expression()
         c_string type_name()
 

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -140,7 +140,6 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         @staticmethod
         shared_ptr[CScanOptions] Make(shared_ptr[CSchema] schema)
 
-
     cdef cppclass CScanContext "arrow::dataset::ScanContext":
         c_bool use_threads
         CMemoryPool * pool
@@ -152,9 +151,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[CRecordBatchIterator] Execute()
 
     cdef cppclass CFragment "arrow::dataset::Fragment":
+        CResult[shared_ptr[CSchema]] ReadPhysicalSchema()
         CResult[CScanTaskIterator] Scan(
             shared_ptr[CScanOptions] options, shared_ptr[CScanContext] context)
-        const shared_ptr[CSchema]& physical_schema() const
         c_bool splittable() const
         c_string type_name() const
         const shared_ptr[CExpression]& partition_expression() const
@@ -166,7 +165,10 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         "arrow::dataset::FragmentIterator"
 
     cdef cppclass CScanner "arrow::dataset::Scanner":
-        CScanner(shared_ptr[CFragment], shared_ptr[CScanOptions], shared_ptr[CScanContext])
+        CScanner(shared_ptr[CDataset], shared_ptr[CScanOptions],
+                 shared_ptr[CScanContext])
+        CScanner(shared_ptr[CFragment], shared_ptr[CScanOptions],
+                 shared_ptr[CScanContext])
         CResult[CScanTaskIterator] Scan()
         CResult[shared_ptr[CTable]] ToTable()
         CFragmentIterator GetFragments()
@@ -174,6 +176,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CScannerBuilder "arrow::dataset::ScannerBuilder":
         CScannerBuilder(shared_ptr[CDataset],
+                        shared_ptr[CScanContext] scan_context)
+        CScannerBuilder(shared_ptr[CSchema], shared_ptr[CFragment],
                         shared_ptr[CScanContext] scan_context)
         CStatus Project(const vector[c_string]& columns)
         CStatus Filter(const CExpression& filter)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -270,12 +270,8 @@ def test_filesystem_dataset(mockfs):
         assert row_group_fragments[0].path == path
         assert row_group_fragments[0].row_groups == {0}
 
-    # test predicate pushdown using row group metadata
-    # ARROW-8065
-    # fragments = list(dataset.get_fragments(filter=ds.field("const") == 0))
-    # assert len(fragments) == 2
-    # assert len(list(fragments[0].get_row_group_fragments())) == 1
-    # assert len(list(fragments[1].get_row_group_fragments())) == 0
+    fragments = list(dataset.get_fragments(filter=ds.field("const") == 0))
+    assert len(fragments) == 2
 
 
 def test_dataset(dataset):
@@ -652,13 +648,14 @@ def _create_dataset_for_fragments(tempdir, chunk_size=None):
         [range(8), [1] * 8, ['a'] * 4 + ['b'] * 4],
         names=['f1', 'f2', 'part']
     )
+
+    path = str(tempdir / "test_parquet_dataset")
+
     # write_to_dataset currently requires pandas
-    pq.write_to_dataset(table, str(tempdir / "test_parquet_dataset"),
+    pq.write_to_dataset(table, path,
                         partition_cols=["part"], chunk_size=chunk_size)
 
-    dataset = ds.dataset(str(tempdir / "test_parquet_dataset/"),
-                         format="parquet", partitioning="hive")
-    return table, dataset
+    return table, ds.dataset(path, format="parquet", partitioning="hive")
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -271,10 +271,11 @@ def test_filesystem_dataset(mockfs):
         assert row_group_fragments[0].row_groups == {0}
 
     # test predicate pushdown using row group metadata
-    fragments = list(dataset.get_fragments(filter=ds.field("const") == 0))
-    assert len(fragments) == 2
-    assert len(list(fragments[0].get_row_group_fragments())) == 1
-    assert len(list(fragments[1].get_row_group_fragments())) == 0
+    # ARROW-8065
+    # fragments = list(dataset.get_fragments(filter=ds.field("const") == 0))
+    # assert len(fragments) == 2
+    # assert len(list(fragments[0].get_row_group_fragments())) == 1
+    # assert len(list(fragments[1].get_row_group_fragments())) == 0
 
 
 def test_dataset(dataset):
@@ -671,9 +672,10 @@ def test_fragments(tempdir):
     f = fragments[0]
 
     # file's schema does not include partition column
-    phys_schema = f.schema.remove(f.schema.get_field_index('part'))
-    assert f.format.inspect(f.path, f.filesystem) == phys_schema
-    assert f.partition_expression.equals(ds.field('part') == 'a')
+    # TODO(ARROW-8065)
+    # phys_schema = f.schema.remove(f.schema.get_field_index('part'))
+    # assert f.format.inspect(f.path, f.filesystem) == phys_schema
+    # assert f.partition_expression.equals(ds.field('part') == 'a')
 
     # scanning fragment includes partition columns
     result = f.to_table()
@@ -716,7 +718,7 @@ def test_fragments_reconstruct(tempdir):
 
     # manually re-construct a fragment, with explicit schema
     new_fragment = parquet_format.make_fragment(
-        fragment.path, fragment.filesystem, schema=dataset.schema,
+        fragment.path, fragment.filesystem,
         partition_expression=fragment.partition_expression)
     assert new_fragment.to_table().equals(fragment.to_table())
     assert_yields_projected(new_fragment, (0, 4), table.column_names)


### PR DESCRIPTION
This is the first part of a refactor to make Fragment accessible without a Scan operation instance. This is a breaking change. It introduces the concept of a physical schema and read schema, these concepts are analogous to Avro writer and reader schema.

- Move ScanOptions at Fragment::Scan instead of a property
- Refactor Dataset::GetFragments(ScanOptions) to Dataset::GetFragments(Expression)
- Add Fragment::ReadPhysicalSchema
- Normalize Python's {Dataset,Fragment,Scanner}.{scan,to_table,to_batches}()