### PR TITLE
ARROW-8552: [Rust] support iterate parquet row columns

### DIFF
--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -50,6 +50,49 @@ impl Row {
     pub fn len(&self) -> usize {
         self.fields.len()
     }
+
+    /// Get an iterator to go through all columns in the row.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::fs::File;
+    /// use parquet::record::Row;
+    /// use parquet::file::reader::{FileReader, SerializedFileReader};
+    ///
+    /// let file = File::open("/path/to/file").unwrap();
+    /// let reader = SerializedFileReader::new(file).unwrap();
+    /// let row: Row = reader.get_row_iter(None).unwrap().next().unwrap();
+    /// for (idx, (name, field)) in row.get_column_iter().enumerate() {
+    ///     println!("column index: {}, column name: {}, column value: {}", idx, name, field);
+    /// }
+    /// ```
+    pub fn get_column_iter(&self) -> RowColumnIter {
+        RowColumnIter {
+            fields: &self.fields,
+            curr: 0,
+            count: self.fields.len(),
+        }
+    }
+}
+
+pub struct RowColumnIter<'a> {
+    fields: &'a Vec<(String, Field)>,
+    curr: usize,
+    count: usize,
+}
+
+impl<'a> Iterator for RowColumnIter<'a> {
+    type Item = (&'a String, &'a Field);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let idx = self.curr;
+        if idx >= self.count {
+            return None;
+        }
+        self.curr += 1;
+        Some((&self.fields[idx].0, &self.fields[idx].1))
+    }
 }
 
 /// Trait for type-safe convenient access to fields within a Row.

--- a/rust/parquet/src/record/reader.rs
+++ b/rust/parquet/src/record/reader.rs
@@ -1325,6 +1325,25 @@ mod tests {
     }
 
     #[test]
+    fn test_iter_columns_in_row() {
+        let r = row![
+            ("c".to_string(), Field::Double(1.0)),
+            ("b".to_string(), Field::Int(1))
+        ];
+        let mut result = Vec::new();
+        for (name, record) in r.get_column_iter() {
+            result.push((name, record));
+        }
+        assert_eq!(
+            vec![
+                (&"c".to_string(), &Field::Double(1.0)),
+                (&"b".to_string(), &Field::Int(1))
+            ],
+            result
+        );
+    }
+
+    #[test]
     fn test_file_reader_rows_projection_map() {
         let schema = "
       message spark_schema {


### PR DESCRIPTION
This patch adds get_column_iter method to parquet rate's Row struct, which lets users iterate columns for a particular row.