### PR TITLE
ARROW-8558: [Rust] [CI] GitHub Actions missing rustfmt

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,6 +91,7 @@ jobs:
         with:
             toolchain: ${{ matrix.rust }}
             override: true
+            components: rustfmt
       - name: Install Flatbuffers
         shell: bash
         run: choco install flatc
@@ -122,6 +123,7 @@ jobs:
         with:
             toolchain: ${{ matrix.rust }}
             override: true
+            components: rustfmt
       - name: Install Flatbuffers
         shell: bash
         run: brew install flatbuffers


### PR DESCRIPTION
This adds the `rustfmt` component to the Rust installations in Windows and MacOS, and fixes `rustfmt` related CI failures.

@kszucs @paddyhoran 