### PR TITLE
ARROW-8554: [C++][Benchmark] Fix building error "cannot bind lvalue"

### DIFF
--- a/cpp/src/arrow/util/bit_util_benchmark.cc
+++ b/cpp/src/arrow/util/bit_util_benchmark.cc
@@ -93,7 +93,7 @@ static std::shared_ptr<Buffer> CreateRandomBuffer(int64_t nbytes) {
   auto buffer = *AllocateBuffer(nbytes);
   memset(buffer->mutable_data(), 0, nbytes);
   random_bytes(nbytes, 0, buffer->mutable_data());
-  return buffer;
+  return std::move(buffer);
 }
 
 template <typename DoAnd>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/ARROW-8554