### PR TITLE
ARROW-8555: [FlightRPC][Java] implement DoExchange

### DIFF
--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -132,6 +132,14 @@
       <version>1.12.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <extensions>

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ArrowMessage.java
@@ -154,6 +154,24 @@ class ArrowMessage implements AutoCloseable {
     this.appMetadata = null;
   }
 
+  /**
+   * Create an ArrowMessage containing only application metadata.
+   * @param appMetadata The application-provided metadata buffer.
+   */
+  public ArrowMessage(ArrowBuf appMetadata) {
+    this.message = null;
+    this.bufs = ImmutableList.of();
+    this.descriptor = null;
+    this.appMetadata = appMetadata;
+  }
+
+  public ArrowMessage(FlightDescriptor descriptor) {
+    this.message = null;
+    this.bufs = ImmutableList.of();
+    this.descriptor = descriptor;
+    this.appMetadata = null;
+  }
+
   private ArrowMessage(FlightDescriptor descriptor, MessageMetadataResult message, ArrowBuf appMetadata,
                        ArrowBuf buf) {
     this.message = message;
@@ -171,6 +189,10 @@ class ArrowMessage implements AutoCloseable {
   }
 
   public HeaderType getMessageType() {
+    if (message == null) {
+      // Null message occurs for metadata-only messages (in DoExchange)
+      return HeaderType.NONE;
+    }
     return HeaderType.getHeader(message.headerType());
   }
 
@@ -271,8 +293,19 @@ class ArrowMessage implements AutoCloseable {
    * @return InputStream
    */
   private InputStream asInputStream(BufferAllocator allocator) {
-    try {
+    if (message == null) {
+      // If we have no IPC message, it's a pure-metadata message
+      final FlightData.Builder builder = FlightData.newBuilder();
+      if (descriptor != null) {
+        builder.setFlightDescriptor(descriptor);
+      }
+      if (appMetadata != null) {
+        builder.setAppMetadata(ByteString.copyFrom(appMetadata.nioBuffer()));
+      }
+      return NO_BODY_MARSHALLER.stream(builder.build());
+    }
 
+    try {
       final ByteString bytes = ByteString.copyFrom(message.getMessageBuffer(),
           message.bytesAfterMessage());
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallStatus.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallStatus.java
@@ -137,7 +137,7 @@ public class CallStatus {
         "code=" + code +
         ", cause=" + cause +
         ", description='" + description +
-        ", metadata='" + metadata + '\'' +
+        "', metadata='" + metadata + '\'' +
         '}';
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightMethod.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightMethod.java
@@ -31,6 +31,7 @@ public enum FlightMethod {
   DO_PUT,
   DO_ACTION,
   LIST_ACTIONS,
+  DO_EXCHANGE,
   ;
 
   /**
@@ -55,6 +56,8 @@ public enum FlightMethod {
       return DO_ACTION;
     } else if (FlightServiceGrpc.getListActionsMethod().getFullMethodName().equals(methodName)) {
       return LIST_ACTIONS;
+    } else if (FlightServiceGrpc.getDoExchangeMethod().getFullMethodName().equals(methodName)) {
+      return DO_EXCHANGE;
     }
     throw new IllegalArgumentException("Not a Flight method name in gRPC: " + methodName);
   }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
@@ -42,6 +42,8 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.util.VisibleForTesting;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import io.grpc.Server;
 import io.grpc.ServerInterceptors;
 import io.grpc.netty.NettyServerBuilder;
@@ -243,7 +245,9 @@ public class FlightServer implements AutoCloseable {
         exec = executor;
         grpcExecutor = null;
       } else {
-        exec = Executors.newCachedThreadPool();
+        exec = Executors.newCachedThreadPool(
+            // Name threads for better debuggability
+            new ThreadFactoryBuilder().setNameFormat("flight-server-default-executor-%d").build());
         grpcExecutor = exec;
       }
       final FlightBindingService flightService = new FlightBindingService(allocator, producer, authHandler, exec);

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStream.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStream.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -60,16 +61,16 @@ public class FlightStream implements AutoCloseable {
   private final Cancellable cancellable;
   private final LinkedBlockingQueue<AutoCloseable> queue = new LinkedBlockingQueue<>();
   private final SettableFuture<VectorSchemaRoot> root = SettableFuture.create();
+  private final SettableFuture<FlightDescriptor> descriptor = SettableFuture.create();
   private final int pendingTarget;
   private final Requestor requestor;
+  final CompletableFuture<Void> completed;
 
   private volatile int pending = 1;
-  private boolean completed = false;
   private volatile VectorSchemaRoot fulfilledRoot;
   private DictionaryProvider.MapDictionaryProvider dictionaries;
   private volatile VectorLoader loader;
   private volatile Throwable ex;
-  private volatile FlightDescriptor descriptor;
   private volatile ArrowBuf applicationMetadata = null;
 
   /**
@@ -86,6 +87,7 @@ public class FlightStream implements AutoCloseable {
     this.cancellable = cancellable;
     this.requestor = requestor;
     this.dictionaries = new DictionaryProvider.MapDictionaryProvider();
+    this.completed = new CompletableFuture<>();
   }
 
   /**
@@ -136,9 +138,15 @@ public class FlightStream implements AutoCloseable {
    * client sends the descriptor.
    */
   public FlightDescriptor getDescriptor() {
-    // This blocks until the schema message (with the descriptor) is sent.
-    getRoot();
-    return descriptor;
+    // This blocks until the first message from the client is received.
+    try {
+      return descriptor.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw CallStatus.INTERNAL.withCause(e).withDescription("Interrupted").toRuntimeException();
+    } catch (ExecutionException e) {
+      throw CallStatus.INTERNAL.withCause(e).withDescription("Error getting descriptor").toRuntimeException();
+    }
   }
 
   /**
@@ -150,11 +158,13 @@ public class FlightStream implements AutoCloseable {
     final List<AutoCloseable> closeables = new ArrayList<>();
     // cancellation can throw, but we still want to clean up resources, so make it an AutoCloseable too
     closeables.add(() -> {
-      if (!completed && cancellable != null) {
+      if (!completed.isDone() && cancellable != null) {
         cancel("Stream closed before end.", /* no exception to report */ null);
       }
     });
-    closeables.add(root.get());
+    if (fulfilledRoot != null) {
+      closeables.add(fulfilledRoot);
+    }
     closeables.add(applicationMetadata);
     closeables.addAll(queue);
     if (dictionaries != null) {
@@ -162,6 +172,9 @@ public class FlightStream implements AutoCloseable {
     }
 
     AutoCloseables.close(closeables);
+    // Other code ignores the value of this CompletableFuture, only whether it's completed (or has an exception)
+    // No-op if already complete; do this after the check in the AutoCloseable lambda above
+    completed.complete(null);
   }
 
   /**
@@ -170,13 +183,9 @@ public class FlightStream implements AutoCloseable {
    */
   public boolean next() {
     try {
-      // make sure we have the root
-      root.get().clear();
-
-      if (completed && queue.isEmpty()) {
+      if (completed.isDone() && queue.isEmpty()) {
         return false;
       }
-
 
       pending--;
       requestOutstanding();
@@ -184,7 +193,8 @@ public class FlightStream implements AutoCloseable {
       Object data = queue.take();
       if (DONE == data) {
         queue.put(DONE);
-        completed = true;
+        // Other code ignores the value of this CompletableFuture, only whether it's completed (or has an exception)
+        completed.complete(null);
         return false;
       } else if (DONE_EX == data) {
         queue.put(DONE_EX);
@@ -195,18 +205,22 @@ public class FlightStream implements AutoCloseable {
         }
       } else {
         try (ArrowMessage msg = ((ArrowMessage) data)) {
-          if (msg.getMessageType() == HeaderType.RECORD_BATCH) {
+          if (msg.getMessageType() == HeaderType.NONE) {
+            updateMetadata(msg);
+            // We received a message without data, so erase any leftover data
+            if (fulfilledRoot != null) {
+              fulfilledRoot.clear();
+            }
+          } else if (msg.getMessageType() == HeaderType.RECORD_BATCH) {
+            // Ensure we have the root
+            root.get().clear();
             try (ArrowRecordBatch arb = msg.asRecordBatch()) {
               loader.load(arb);
             }
-            if (this.applicationMetadata != null) {
-              this.applicationMetadata.close();
-            }
-            this.applicationMetadata = msg.getApplicationMetadata();
-            if (this.applicationMetadata != null) {
-              this.applicationMetadata.getReferenceManager().retain();
-            }
+            updateMetadata(msg);
           } else if (msg.getMessageType() == HeaderType.DICTIONARY_BATCH) {
+            // Ensure we have the root
+            root.get().clear();
             try (ArrowDictionaryBatch arb = msg.asDictionaryBatch()) {
               final long id = arb.getDictionaryId();
               if (dictionaries == null) {
@@ -239,6 +253,17 @@ public class FlightStream implements AutoCloseable {
     }
   }
 
+  /** Update our metdata reference with a new one from this message. */
+  private void updateMetadata(ArrowMessage msg) {
+    if (this.applicationMetadata != null) {
+      this.applicationMetadata.close();
+    }
+    this.applicationMetadata = msg.getApplicationMetadata();
+    if (this.applicationMetadata != null) {
+      this.applicationMetadata.getReferenceManager().retain();
+    }
+  }
+
   /**
    * Get the current vector data from the stream.
    *
@@ -255,6 +280,17 @@ public class FlightStream implements AutoCloseable {
     } catch (ExecutionException e) {
       throw StatusUtils.fromThrowable(e.getCause());
     }
+  }
+
+  /**
+   * Check if there is a root (i.e. whether the other end has started sending data).
+   *
+   * Updated by calls to {@link #next()}.
+   *
+   * @return true if and only if the other end has started sending data.
+   */
+  public boolean hasRoot() {
+    return root.isDone();
   }
 
   /**
@@ -285,6 +321,16 @@ public class FlightStream implements AutoCloseable {
     public void onNext(ArrowMessage msg) {
       requestOutstanding();
       switch (msg.getMessageType()) {
+        case NONE: {
+          // No IPC message - pure metadata or descriptor
+          if (msg.getDescriptor() != null) {
+            descriptor.set(new FlightDescriptor(msg.getDescriptor()));
+          }
+          if (msg.getApplicationMetadata() != null) {
+            queue.add(msg);
+          }
+          break;
+        }
         case SCHEMA: {
           Schema schema = msg.asSchema();
           final List<Field> fields = new ArrayList<>();
@@ -299,7 +345,9 @@ public class FlightStream implements AutoCloseable {
           schema = new Schema(fields, schema.getCustomMetadata());
           fulfilledRoot = VectorSchemaRoot.create(schema, allocator);
           loader = new VectorLoader(fulfilledRoot);
-          descriptor = msg.getDescriptor() != null ? new FlightDescriptor(msg.getDescriptor()) : null;
+          if (msg.getDescriptor() != null) {
+            descriptor.set(new FlightDescriptor(msg.getDescriptor()));
+          }
           root.set(fulfilledRoot);
 
           break;
@@ -310,7 +358,6 @@ public class FlightStream implements AutoCloseable {
         case DICTIONARY_BATCH:
           queue.add(msg);
           break;
-        case NONE:
         case TENSOR:
         default:
           queue.add(DONE_EX);
@@ -320,18 +367,14 @@ public class FlightStream implements AutoCloseable {
 
     @Override
     public void onError(Throwable t) {
-      ex = t;
+      ex = StatusUtils.fromThrowable(t);
       queue.add(DONE_EX);
-      root.setException(t);
+      root.setException(ex);
     }
 
     @Override
     public void onCompleted() {
       // Depends on gRPC calling onNext and onCompleted non-concurrently
-      if (!root.isDone()) {
-        root.setException(
-            CallStatus.INTERNAL.withDescription("Stream completed without receiving schema.").toRuntimeException());
-      }
       queue.add(DONE);
     }
   }
@@ -342,6 +385,8 @@ public class FlightStream implements AutoCloseable {
    * @throws UnsupportedOperationException on a stream being uploaded from the client.
    */
   public void cancel(String message, Throwable exception) {
+    completed.completeExceptionally(
+        CallStatus.CANCELLED.withDescription(message).withCause(exception).toRuntimeException());
     if (cancellable != null) {
       cancellable.cancel(message, exception);
     } else {
@@ -357,6 +402,7 @@ public class FlightStream implements AutoCloseable {
   /**
    * Provides a callback to cancel a process that is in progress.
    */
+  @FunctionalInterface
   public interface Cancellable {
     void cancel(String message, Throwable exception);
   }
@@ -364,6 +410,7 @@ public class FlightStream implements AutoCloseable {
   /**
    * Provides a interface to request more items from a stream producer.
    */
+  @FunctionalInterface
   public interface Requestor {
     /**
      * Requests <code>count</code> more messages from the instance of this object.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+
+/**
+ * An interface for writing data to a peer, client or server.
+ */
+public interface OutboundStreamListener {
+
+  /**
+   * A hint indicating whether the client is ready to receive data without excessive buffering.
+   *
+   * <p>Writers should poll this flag before sending data to respect backpressure from the client and
+   * avoid sending data faster than the client can handle. Ignoring this flag may mean that the server
+   * will start consuming excessive amounts of memory, as it may buffer messages in memory.
+   */
+  boolean isReady();
+
+  /**
+   * Start sending data, using the schema of the given {@link VectorSchemaRoot}.
+   *
+   * <p>This method must be called before all others, except {@link #putMetadata(ArrowBuf)}.
+   */
+  void start(VectorSchemaRoot root);
+
+  /**
+   * Start sending data, using the schema of the given {@link VectorSchemaRoot}.
+   *
+   * <p>This method must be called before all others.
+   */
+  void start(VectorSchemaRoot root, DictionaryProvider dictionaries);
+
+  /**
+   * Send the current contents of the associated {@link VectorSchemaRoot}.
+   *
+   * <p>This will not necessarily block until the message is actually sent; it may buffer messages
+   * in memory. Use {@link #isReady()} to check if there is backpressure and avoid excessive buffering.
+   */
+  void putNext();
+
+  /**
+   * Send the current contents of the associated {@link VectorSchemaRoot} alongside application-defined metadata.
+   * @param metadata The metadata to send. Ownership of the buffer is transferred to the Flight implementation.
+   */
+  void putNext(ArrowBuf metadata);
+
+  /**
+   * Send a pure metadata message without any associated data.
+   *
+   * <p>This may be called without starting the stream.
+   */
+  void putMetadata(ArrowBuf metadata);
+
+  /**
+   * Indicate an error to the client. Terminates the stream; do not call {@link #completed()} afterwards.
+   */
+  void error(Throwable ex);
+
+  /**
+   * Indicate that transmission is finished.
+   */
+  void completed();
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListenerImpl.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListenerImpl.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import org.apache.arrow.flight.grpc.StatusUtils;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.VectorUnloader;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+
+import io.grpc.stub.CallStreamObserver;
+
+/**
+ * A base class for writing Arrow data to a Flight stream.
+ */
+abstract class OutboundStreamListenerImpl implements OutboundStreamListener {
+  private final FlightDescriptor descriptor; // nullable
+  protected final CallStreamObserver<ArrowMessage> responseObserver;
+  protected volatile VectorUnloader unloader; // null until stream started
+
+  OutboundStreamListenerImpl(FlightDescriptor descriptor, CallStreamObserver<ArrowMessage> responseObserver) {
+    Preconditions.checkNotNull(responseObserver, "responseObserver must be provided");
+    this.descriptor = descriptor;
+    this.responseObserver = responseObserver;
+    this.unloader = null;
+  }
+
+  @Override
+  public boolean isReady() {
+    return responseObserver.isReady();
+  }
+
+  @Override
+  public void start(VectorSchemaRoot root) {
+    start(root, new DictionaryProvider.MapDictionaryProvider());
+  }
+
+  @Override
+  public void start(VectorSchemaRoot root, DictionaryProvider dictionaries) {
+    try {
+      DictionaryUtils.generateSchemaMessages(root.getSchema(), descriptor, dictionaries, responseObserver::onNext);
+    } catch (Exception e) {
+      // Only happens if closing buffers somehow fails - indicates application is an unknown state so propagate
+      // the exception
+      throw new RuntimeException("Could not generate and send all schema messages", e);
+    }
+    // We include the null count and align buffers to be compatible with Flight/C++
+    unloader = new VectorUnloader(root, /* includeNullCount */ true, /* alignBuffers */ true);
+  }
+
+  @Override
+  public void putNext() {
+    putNext(null);
+  }
+
+  /**
+   * Busy-wait until the stream is ready.
+   *
+   * <p>This is overridable as client/server have different behavior.
+   */
+  protected abstract void waitUntilStreamReady();
+
+  @Override
+  public void putNext(ArrowBuf metadata) {
+    if (unloader == null) {
+      throw CallStatus.INTERNAL.withDescription("Stream was not started, call start()").toRuntimeException();
+    }
+
+    waitUntilStreamReady();
+    // close is a no-op if the message has been written to gRPC, otherwise frees the associated buffers
+    // in some code paths (e.g. if the call is cancelled), gRPC does not write the message, so we need to clean up
+    // ourselves. Normally, writing the ArrowMessage will transfer ownership of the data to gRPC/Netty.
+    try (final ArrowMessage message = new ArrowMessage(unloader.getRecordBatch(), metadata)) {
+      responseObserver.onNext(message);
+    } catch (Exception e) {
+      // This exception comes from ArrowMessage#close, not responseObserver#onNext.
+      // Generally this should not happen - ArrowMessage's implementation only closes non-throwing things.
+      // The user can't reasonably do anything about this, but if something does throw, we shouldn't let
+      // execution continue since other state (e.g. allocators) may be in an odd state.
+      throw new RuntimeException("Could not free ArrowMessage", e);
+    }
+  }
+
+  @Override
+  public void putMetadata(ArrowBuf metadata) {
+    waitUntilStreamReady();
+    try (final ArrowMessage message = new ArrowMessage(metadata)) {
+      responseObserver.onNext(message);
+    } catch (Exception e) {
+      throw StatusUtils.fromThrowable(e);
+    }
+  }
+
+  @Override
+  public void error(Throwable ex) {
+    responseObserver.onError(StatusUtils.toGrpcException(ex));
+  }
+
+  @Override
+  public void completed() {
+    responseObserver.onCompleted();
+  }
+}

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
@@ -228,15 +228,18 @@ public class TestBasicOperation {
   @Test
   public void getStream() throws Exception {
     test(c -> {
-      FlightStream stream = c.getStream(new Ticket(new byte[0]));
-      VectorSchemaRoot root = stream.getRoot();
-      IntVector iv = (IntVector) root.getVector("c1");
-      int value = 0;
-      while (stream.next()) {
-        for (int i = 0; i < root.getRowCount(); i++) {
-          Assert.assertEquals(value, iv.get(i));
-          value++;
+      try (final FlightStream stream = c.getStream(new Ticket(new byte[0]))) {
+        VectorSchemaRoot root = stream.getRoot();
+        IntVector iv = (IntVector) root.getVector("c1");
+        int value = 0;
+        while (stream.next()) {
+          for (int i = 0; i < root.getRowCount(); i++) {
+            Assert.assertEquals(value, iv.get(i));
+            value++;
+          }
         }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
       }
     });
   }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestErrorMetadata.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestErrorMetadata.java
@@ -48,12 +48,12 @@ public class TestErrorMetadata {
              FlightTestUtil.getStartedServer(
                (location) -> FlightServer.builder(allocator, location, new TestFlightProducer(perf)).build());
           final FlightClient client = FlightClient.builder(allocator, s.getLocation()).build()) {
-      FlightStream stream = client.getStream(new Ticket("abs".getBytes()));
-      stream.next();
-      Assert.fail();
-    } catch (FlightRuntimeException fre) {
+      final CallStatus flightStatus = FlightTestUtil.assertCode(FlightStatusCode.CANCELLED, () -> {
+        FlightStream stream = client.getStream(new Ticket("abs".getBytes()));
+        stream.next();
+      });
       PerfOuterClass.Perf newPerf = null;
-      ErrorFlightMetadata metadata = fre.status().metadata();
+      ErrorFlightMetadata metadata = flightStatus.metadata();
       Assert.assertNotNull(metadata);
       Assert.assertEquals(2, metadata.keys().size());
       Assert.assertTrue(metadata.containsKey("grpc-status-details-bin"));

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerOptions.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerOptions.java
@@ -124,14 +124,15 @@ public class TestServerOptions {
                 (port) -> FlightServer.builder(a, location, producer).build()
             )) {
       try (FlightClient c = FlightClient.builder(a, location).build()) {
-        FlightStream stream = c.getStream(new Ticket(new byte[0]));
-        VectorSchemaRoot root = stream.getRoot();
-        IntVector iv = (IntVector) root.getVector("c1");
-        int value = 0;
-        while (stream.next()) {
-          for (int i = 0; i < root.getRowCount(); i++) {
-            Assert.assertEquals(value, iv.get(i));
-            value++;
+        try (FlightStream stream = c.getStream(new Ticket(new byte[0]))) {
+          VectorSchemaRoot root = stream.getRoot();
+          IntVector iv = (IntVector) root.getVector("c1");
+          int value = 0;
+          while (stream.next()) {
+            for (int i = 0; i < root.getRowCount(); i++) {
+              Assert.assertEquals(value, iv.get(i));
+              value++;
+            }
           }
         }
       }


### PR DESCRIPTION
This is a complete implementation of DoExchange for Java. It is not tested against the C++ implementation yet, however, it still passes integration tests, so the internal refactoring should not have broken compatibility with existing clients/servers.

In this PR, I've refactored DoGet/DoPut/DoExchange on the client and server to share their implementation as much as possible. DoGet/DoPut retain their behavior of "eagerly" reading/writing schemas, but DoExchange allows the client/server to delay writing the schema until ready. This is checked in the unit tests.

I also ran into some test flakes and tried to address them, by making sure we clean up things in the right order, and adding missing `close()` calls in some existing tests.