### PR TITLE
ARROW-8563: [Go] Minor change to make newBuilder public

### DIFF
--- a/go/arrow/array/builder.go
+++ b/go/arrow/array/builder.go
@@ -208,7 +208,7 @@ func (b *builder) UnsafeAppendBoolToBitmap(isValid bool) {
 	b.length++
 }
 
-func newBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
+func NewBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
 	// FIXME(sbinet): use a type switch on dtype instead?
 	switch dtype.ID() {
 	case arrow.NULL:

--- a/go/arrow/array/fixed_size_list.go
+++ b/go/arrow/array/fixed_size_list.go
@@ -125,7 +125,7 @@ func NewFixedSizeListBuilder(mem memory.Allocator, n int32, etype arrow.DataType
 		builder: builder{refCount: 1, mem: mem},
 		etype:   etype,
 		n:       n,
-		values:  newBuilder(mem, etype),
+		values:  NewBuilder(mem, etype),
 	}
 }
 

--- a/go/arrow/array/list.go
+++ b/go/arrow/array/list.go
@@ -127,7 +127,7 @@ func NewListBuilder(mem memory.Allocator, etype arrow.DataType) *ListBuilder {
 	return &ListBuilder{
 		builder: builder{refCount: 1, mem: mem},
 		etype:   etype,
-		values:  newBuilder(mem, etype),
+		values:  NewBuilder(mem, etype),
 		offsets: NewInt32Builder(mem),
 	}
 }

--- a/go/arrow/array/record.go
+++ b/go/arrow/array/record.go
@@ -273,7 +273,7 @@ func NewRecordBuilder(mem memory.Allocator, schema *arrow.Schema) *RecordBuilder
 	}
 
 	for i, f := range schema.Fields() {
-		b.fields[i] = newBuilder(b.mem, f.Type)
+		b.fields[i] = NewBuilder(b.mem, f.Type)
 	}
 
 	return b

--- a/go/arrow/array/struct.go
+++ b/go/arrow/array/struct.go
@@ -144,7 +144,7 @@ func NewStructBuilder(mem memory.Allocator, dtype *arrow.StructType) *StructBuil
 		fields:  make([]Builder, len(dtype.Fields())),
 	}
 	for i, f := range dtype.Fields() {
-		b.fields[i] = newBuilder(b.mem, f.Type)
+		b.fields[i] = NewBuilder(b.mem, f.Type)
 	}
 	return b
 }


### PR DESCRIPTION
Hello team,
This minor change makes newBuilder() public to reduce verbosity. 

To give you example, I am working on a parquet read / write into Arrow Record batch where the parquet data types are mapped to Arrow data types.  
My Repo: https://github.com/mindhash/arrow-parquet-go

In such cases, it will be nice to have a builder API (newBuilder) be generic to accept a data type and return a respective array.

I am looking at a similar situation for JSON reader. I think this change will make the builder API much easier for upstream as well as internal packages. 


