### PR TITLE
ARROW-8561: [C++][Gandiva] Stop using deprecated google::protobuf::MessageLite::ByteSize()

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1225,6 +1225,10 @@ if(ARROW_WITH_PROTOBUF)
   if(ARROW_WITH_GRPC)
     # gRPC 1.21.0 or later require Protobuf 3.7.0 or later.
     set(ARROW_PROTOBUF_REQUIRED_VERSION "3.7.0")
+  elseif(ARROW_GANDIVA_JAVA)
+    # google::protobuf::MessageLite::ByteSize() is deprecated since
+    # Protobuf 3.4.0.
+    set(ARROW_PROTOBUF_REQUIRED_VERSION "3.4.0")
   else()
     set(ARROW_PROTOBUF_REQUIRED_VERSION "2.6.1")
   endif()

--- a/cpp/src/gandiva/jni/expression_registry_helper.cc
+++ b/cpp/src/gandiva/jni/expression_registry_helper.cc
@@ -163,7 +163,7 @@ Java_org_apache_arrow_gandiva_evaluator_ExpressionRegistryJniHelper_getGandivaSu
     types::ExtGandivaType* gandiva_data_type = gandiva_data_types.add_datatype();
     ArrowToProtobuf(type, gandiva_data_type);
   }
-  int size = gandiva_data_types.ByteSize();
+  auto size = gandiva_data_types.ByteSizeLong();
   std::unique_ptr<jbyte[]> buffer{new jbyte[size]};
   gandiva_data_types.SerializeToArray(reinterpret_cast<void*>(buffer.get()), size);
   jbyteArray ret = env->NewByteArray(size);
@@ -192,7 +192,7 @@ Java_org_apache_arrow_gandiva_evaluator_ExpressionRegistryJniHelper_getGandivaSu
       ArrowToProtobuf(param_type, proto_param_type);
     }
   }
-  int size = gandiva_functions.ByteSize();
+  auto size = gandiva_functions.ByteSizeLong();
   std::unique_ptr<jbyte[]> buffer{new jbyte[size]};
   gandiva_functions.SerializeToArray(reinterpret_cast<void*>(buffer.get()), size);
   jbyteArray ret = env->NewByteArray(size);


### PR DESCRIPTION
ByteSize() is deprecated and ByteSizeLong() is added since Protobuf 3.4.0.

https://github.com/protocolbuffers/protobuf/blob/v3.4.0/CHANGES.txt#L58-L59

> * ByteSize() and SpaceUsed() are deprecated.Use ByteSizeLong() and
>    SpaceUsedLong() instead