### PR TITLE
ARROW-8572: [Python] expose UnionArray fields to Python

### DIFF
--- a/cpp/src/arrow/array.cc
+++ b/cpp/src/arrow/array.cc
@@ -975,6 +975,10 @@ Result<std::shared_ptr<Array>> UnionArray::MakeSparse(
 }
 
 std::shared_ptr<Array> UnionArray::child(int i) const {
+  if (i < 0 ||
+      static_cast<decltype(boxed_fields_)::size_type>(i) >= boxed_fields_.size()) {
+    return nullptr;
+  }
   std::shared_ptr<Array> result = internal::atomic_load(&boxed_fields_[i]);
   if (!result) {
     std::shared_ptr<ArrayData> child_data = data_->child_data[i]->Copy();

--- a/cpp/src/arrow/array_union_test.cc
+++ b/cpp/src/arrow/array_union_test.cc
@@ -122,6 +122,8 @@ class TestUnionArrayFactories : public ::testing::Test {
     for (int64_t i = 0; i < type_ids.length(); ++i) {
       ASSERT_EQ(array.child_id(i), type_ids.Value(i));
     }
+    ASSERT_EQ(nullptr, array.child(-1));
+    ASSERT_EQ(nullptr, array.child(type_ids.length()));
   }
 
   void CheckFieldNames(const UnionArray& array, const std::vector<std::string>& names) {

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -567,8 +567,10 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
             const vector[c_string]& field_names,
             const vector[int8_t]& type_codes)
 
+        shared_ptr[CBuffer] type_codes()
         int8_t* raw_type_codes()
         int32_t value_offset(int i)
+        shared_ptr[CBuffer] value_offsets()
         int child_id(int64_t index)
         shared_ptr[CArray] child(int pos)
         const CArray* UnsafeChild(int pos)


### PR DESCRIPTION
- Adds an explicit range check to `UnionArray.child`
- Exposes `child`, `value_offsets`, and `type_codes` to Python. (In Python, they're wrapped in arrays for you to save you the trouble.)

This lets you losslessly assemble and then disassemble a union array in Python.