### PR TITLE
ARROW-8575: [Developer] Add issue_comment workflow to rebase a PR

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           set -ex
           git remote add upstream https://github.com/${{ github.repository }}
-          git fetch upstream
+          git fetch upstream master
           git rebase upstream/master
           if [ "$(git status --porcelain)" = "" ]; then
             # There are no rebase conflicts

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -137,10 +137,10 @@ jobs:
       - name: Rebase on ${{ github.repository }} master
         run: |
           set -ex
-          git log --oneline
+          git config user.name "$(git log -1 --pretty=format:%an)"
+          git config user.email "$(git log -1 --pretty=format:%ae)"
           git remote add upstream https://github.com/${{ github.repository }}
           git fetch --unshallow upstream master
-          git log --oneline upstream/master
           git rebase upstream/master
           if [ "$(git status --porcelain)" = "" ]; then
             # There are no rebase conflicts

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -137,8 +137,10 @@ jobs:
       - name: Rebase on ${{ github.repository }} master
         run: |
           set -ex
+          git log --oneline
           git remote add upstream https://github.com/${{ github.repository }}
           git fetch upstream master
+          git log --oneline upstream/master
           git rebase upstream/master
           if [ "$(git status --porcelain)" = "" ]; then
             # There are no rebase conflicts

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   crossbow:
     name: Listen!
-    if: startsWith(github.event.comment.body, '@github-actions')
+    if: startsWith(github.event.comment.body, '@github-actions crossbow')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Arrow
@@ -56,7 +56,7 @@ jobs:
 
   autotune:
     name: "Fix all the things"
-    if: startsWith(github.event.comment.body, 'autotune')
+    if: startsWith(github.event.comment.body, '@github-actions autotune')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -127,7 +127,7 @@ jobs:
 
   rebase:
     name: "Rebase"
-    if: startsWith(github.event.comment.body, 'rebase')
+    if: startsWith(github.event.comment.body, '@github-actions rebase')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -142,7 +142,7 @@ jobs:
           git remote add upstream https://github.com/${{ github.repository }}
           git fetch --unshallow upstream master
           git rebase upstream/master
-      - uses: nealrichardson/actions/pr-push@pr-push-args
+      - uses: r-lib/actions/pr-push@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           args: "--force"

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -142,6 +142,7 @@ jobs:
           git remote add upstream https://github.com/${{ github.repository }}
           git fetch --unshallow upstream master
           git rebase upstream/master
-      - uses: r-lib/actions/pr-push@master
+      - uses: nealrichardson/actions/pr-push@pr-push-args
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          args: "--force"

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -142,11 +142,6 @@ jobs:
           git remote add upstream https://github.com/${{ github.repository }}
           git fetch --unshallow upstream master
           git rebase upstream/master
-          if [ "$(git status --porcelain)" = "" ]; then
-            # There are no rebase conflicts
-            echo "::set-env name=OK_TO_PUSH::true"
-          fi
       - uses: r-lib/actions/pr-push@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-        if: env.OK_TO_PUSH == 'true'

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -139,7 +139,7 @@ jobs:
           set -ex
           git log --oneline
           git remote add upstream https://github.com/${{ github.repository }}
-          git fetch upstream master
+          git fetch --unshallow upstream master
           git log --oneline upstream/master
           git rebase upstream/master
           if [ "$(git status --porcelain)" = "" ]; then

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -124,3 +124,27 @@ jobs:
       - uses: r-lib/actions/pr-push@master
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  rebase:
+    name: "Rebase"
+    if: startsWith(github.event.comment.body, 'rebase')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: r-lib/actions/pr-fetch@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Rebase on ${{ github.repository }} master
+        run: |
+          set -ex
+          git remote add upstream https://github.com/${{ github.repository }}
+          git fetch upstream
+          git rebase upstream/master
+          if [ "$(git status --porcelain)" = "" ]; then
+            # There are no rebase conflicts
+            echo "::set-env name=OK_TO_PUSH::true"
+          fi
+      - uses: r-lib/actions/pr-push@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        if: env.OK_TO_PUSH == 'true'


### PR DESCRIPTION
Instead of adding a PR comment of "This needs rebase" and wait for the author to get around to it, with this workflow you can just type "rebase" and GHA will do it for you. If it rebases cleanly, the workflow force pushes; see [this demonstration](https://github.com/nealrichardson/arrow/runs/613698512?check_suite_focus=true#step:5:6) on my fork. If there are merge conflicts, well, the PR will probably tell you so you know not to try to auto-rebase, but if you do run this workflow and rebase is not clean, it exits with an error and does not push anything (see [this example](https://github.com/nealrichardson/arrow/runs/613691328?check_suite_focus=true)).

Relatedly, see https://github.com/r-lib/actions/pull/90 where I add the ability to add args to `git push` in the action. This workflows is currently set to run using my fork, which is fine. If that PR is merged before this one is, we can switch back to using upstream; otherwise, I'll switch in ARROW-8489.

Recall that you can't test issue_comment workflow changes on PRs themselves because issue_comment workflows always run off of master, so if you make a "rebase" comment on this PR, it won't do anything.