### PR TITLE
ARROW-8505: [Release][C#] "sourcelink test" is failed by Apache.ArrowAssemblyInfo.cs

### DIFF
--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -1,3 +1,20 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 <Project>
 
   <!-- Common repo directories -->

--- a/csharp/Directory.Build.targets
+++ b/csharp/Directory.Build.targets
@@ -1,0 +1,12 @@
+<Project>
+
+  <!-- The following works around https://github.com/dotnet/sourcelink/issues/572  -->
+  <PropertyGroup>
+    <TargetFrameworkMonikerAssemblyAttributesPath>$([System.IO.Path]::Combine('$(IntermediateOutputPath)','$(TargetFrameworkMoniker).AssemblyAttributes$(DefaultLanguageSourceExtension)'))</TargetFrameworkMonikerAssemblyAttributesPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <EmbeddedFiles Include="$(GeneratedAssemblyInfoFile)"/>
+    <EmbeddedFiles Include="$(TargetFrameworkMonikerAssemblyAttributesPath)"/>
+  </ItemGroup>
+  
+</Project>

--- a/csharp/Directory.Build.targets
+++ b/csharp/Directory.Build.targets
@@ -1,3 +1,20 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 <Project>
 
   <!-- The following works around https://github.com/dotnet/sourcelink/issues/572  -->

--- a/csharp/test/Directory.Build.props
+++ b/csharp/test/Directory.Build.props
@@ -1,3 +1,20 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements. See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
 <Project>
 
   <Import Project="..\Directory.Build.props" />

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -202,7 +202,6 @@ csharp/.gitattributes
 csharp/dummy.git/*
 csharp/src/Apache.Arrow/Flatbuf/*
 csharp/Apache.Arrow.sln
-csharp/Directory.Build.props
 csharp/examples/FluentBuilderExample/FluentBuilderExample.csproj
 csharp/examples/Examples.sln
 csharp/src/Apache.Arrow/Apache.Arrow.csproj
@@ -211,7 +210,6 @@ csharp/src/Apache.Arrow/Properties/Resources.resx
 csharp/test/Apache.Arrow.Benchmarks/Apache.Arrow.Benchmarks.csproj
 csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
 csharp/test/Apache.Arrow.Tests/app.config
-csharp/test/Directory.Build.props
 *.html
 *.sgml
 *.css


### PR DESCRIPTION
Workaround https://github.com/dotnet/sourcelink/issues/572 by explicitly embedding the AssemblyAttributes file into the pdb.