### PR TITLE
ARROW-8597 [Rust] Lints and readability improvements for arrow crate

### DIFF
--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1099,7 +1099,7 @@ impl StructBuilder {
                 let schema = Schema::new(fields.clone());
                 Box::new(Self::from_schema(schema, capacity))
             }
-            t @ _ => panic!("Data type {:?} is not currently supported", t),
+            t => panic!("Data type {:?} is not currently supported", t),
         }
     }
 
@@ -1185,8 +1185,8 @@ where
         values_builder: PrimitiveBuilder<V>,
     ) -> Self {
         Self {
-            keys_builder: keys_builder,
-            values_builder: values_builder,
+            keys_builder,
+            values_builder,
             map: HashMap::new(),
         }
     }

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -113,12 +113,11 @@ impl ArrayEqual for BooleanArray {
 
         // TODO: we can do this more efficiently if all values are not-null
         for i in 0..self.len() {
-            if self.is_valid(i) {
-                if bit_util::get_bit(values, i + self.offset())
+            if self.is_valid(i)
+                && bit_util::get_bit(values, i + self.offset())
                     != bit_util::get_bit(other_values, i + other.offset())
-                {
-                    return false;
-                }
+            {
+                return false;
             }
         }
 
@@ -730,7 +729,7 @@ fn value_offset_equal<T: Array + ListArrayOps>(this: &T, other: &T) -> bool {
     }
 
     // The expensive case
-    for i in 0..this.len() + 1 {
+    for i in 0..=this.len() {
         if this.value_offset_at(i) - this.value_offset_at(0)
             != other.value_offset_at(i) - other.value_offset_at(0)
         {
@@ -761,12 +760,10 @@ impl<T: ArrowPrimitiveType> JsonEqual for PrimitiveArray<T> {
             return false;
         }
 
-        let result = (0..self.len()).all(|i| match json[i] {
+        (0..self.len()).all(|i| match json[i] {
             Value::Null => self.is_null(i),
             v => self.is_valid(i) && Some(v) == self.value(i).into_json_value().as_ref(),
-        });
-
-        result
+        })
     }
 }
 
@@ -794,13 +791,11 @@ impl JsonEqual for ListArray {
             return false;
         }
 
-        let result = (0..self.len()).all(|i| match json[i] {
+        (0..self.len()).all(|i| match json[i] {
             Value::Array(v) => self.is_valid(i) && self.value(i).equals_json_values(v),
             Value::Null => self.is_null(i) || self.value_length(i) == 0,
             _ => false,
-        });
-
-        result
+        })
     }
 }
 
@@ -858,13 +853,11 @@ impl JsonEqual for FixedSizeListArray {
             return false;
         }
 
-        let result = (0..self.len()).all(|i| match json[i] {
+        (0..self.len()).all(|i| match json[i] {
             Value::Array(v) => self.is_valid(i) && self.value(i).equals_json_values(v),
             Value::Null => self.is_null(i) || self.value_length() == 0,
             _ => false,
-        });
-
-        result
+        })
     }
 }
 
@@ -916,7 +909,7 @@ impl JsonEqual for StructArray {
             }
         }
 
-        return true;
+        true
     }
 }
 

--- a/rust/arrow/src/bitmap.rs
+++ b/rust/arrow/src/bitmap.rs
@@ -96,7 +96,7 @@ impl PartialEq for Bitmap {
         if self_len != other_len {
             return false;
         }
-        &self.bits.data()[..self_len] == &other.bits.data()[..self_len]
+        self.bits.data()[..self_len] == other.bits.data()[..self_len]
     }
 }
 

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -277,15 +277,10 @@ where
     let mut result = MutableBuffer::new(left.len()).with_bitset(left.len(), false);
     let lanes = u8x64::lanes();
     for i in (0..left.len()).step_by(lanes) {
-        let left_data =
-            unsafe { from_raw_parts(left.raw_data().add(i), lanes) };
-        let right_data =
-            unsafe { from_raw_parts(right.raw_data().add(i), lanes) };
+        let left_data = unsafe { from_raw_parts(left.raw_data().add(i), lanes) };
+        let right_data = unsafe { from_raw_parts(right.raw_data().add(i), lanes) };
         let result_slice: &mut [u8] = unsafe {
-            from_raw_parts_mut(
-                (result.data_mut().as_mut_ptr() as *mut u8).add(i),
-                lanes,
-            )
+            from_raw_parts_mut((result.data_mut().as_mut_ptr() as *mut u8).add(i), lanes)
         };
         unsafe {
             bit_util::bitwise_bin_op_simd(&left_data, &right_data, result_slice, &op)

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -78,7 +78,7 @@ impl PartialEq for BufferData {
 impl Drop for BufferData {
     fn drop(&mut self) {
         if !self.ptr.is_null() && self.owned {
-            memory::free_aligned(self.ptr as *mut u8, self.capacity);
+            unsafe { memory::free_aligned(self.ptr as *mut u8, self.capacity) };
         }
     }
 }
@@ -215,7 +215,7 @@ impl Buffer {
     /// Note that this should be used cautiously, and the returned pointer should not be
     /// stored anywhere, to avoid dangling pointers.
     pub fn raw_data(&self) -> *const u8 {
-        unsafe { self.data.ptr.offset(self.offset as isize) }
+        unsafe { self.data.ptr.add(self.offset) }
     }
 
     /// View buffer as typed slice.
@@ -232,7 +232,7 @@ impl Buffer {
         assert_eq!(self.len() % mem::size_of::<T>(), 0);
         assert!(memory::is_ptr_aligned::<T>(self.raw_data() as *const T));
         from_raw_parts(
-            mem::transmute::<*const u8, *const T>(self.raw_data()),
+            self.raw_data() as *const T,
             self.len() / mem::size_of::<T>(),
         )
     }
@@ -278,12 +278,12 @@ where
     let lanes = u8x64::lanes();
     for i in (0..left.len()).step_by(lanes) {
         let left_data =
-            unsafe { from_raw_parts(left.raw_data().offset(i as isize), lanes) };
+            unsafe { from_raw_parts(left.raw_data().add(i), lanes) };
         let right_data =
-            unsafe { from_raw_parts(right.raw_data().offset(i as isize), lanes) };
+            unsafe { from_raw_parts(right.raw_data().add(i), lanes) };
         let result_slice: &mut [u8] = unsafe {
             from_raw_parts_mut(
-                (result.data_mut().as_mut_ptr() as *mut u8).offset(i as isize),
+                (result.data_mut().as_mut_ptr() as *mut u8).add(i),
                 lanes,
             )
         };
@@ -291,7 +291,7 @@ where
             bit_util::bitwise_bin_op_simd(&left_data, &right_data, result_slice, &op)
         };
     }
-    return result.freeze();
+    result.freeze()
 }
 
 impl<'a, 'b> BitAnd<&'b Buffer> for &'a Buffer {
@@ -374,11 +374,11 @@ impl Not for &Buffer {
             let lanes = u8x64::lanes();
             for i in (0..self.len()).step_by(lanes) {
                 unsafe {
-                    let data = from_raw_parts(self.raw_data().offset(i as isize), lanes);
+                    let data = from_raw_parts(self.raw_data().add(i), lanes);
                     let data_simd = u8x64::from_slice_unaligned_unchecked(data);
                     let simd_result = !data_simd;
                     let result_slice: &mut [u8] = from_raw_parts_mut(
-                        (result.data_mut().as_mut_ptr() as *mut u8).offset(i as isize),
+                        (result.data_mut().as_mut_ptr() as *mut u8).add(i),
                         lanes,
                     );
                     simd_result.write_to_slice_unaligned_unchecked(result_slice);
@@ -449,7 +449,7 @@ impl MutableBuffer {
     pub fn set_null_bits(&mut self, start: usize, count: usize) {
         assert!(start + count <= self.capacity);
         unsafe {
-            std::ptr::write_bytes(self.data.offset(start as isize), 0, count);
+            std::ptr::write_bytes(self.data.add(start), 0, count);
         }
     }
 
@@ -461,7 +461,8 @@ impl MutableBuffer {
         if capacity > self.capacity {
             let new_capacity = bit_util::round_upto_multiple_of_64(capacity);
             let new_capacity = cmp::max(new_capacity, self.capacity * 2);
-            let new_data = memory::reallocate(self.data, self.capacity, new_capacity);
+            let new_data =
+                unsafe { memory::reallocate(self.data, self.capacity, new_capacity) };
             self.data = new_data as *mut u8;
             self.capacity = new_capacity;
         }
@@ -481,7 +482,8 @@ impl MutableBuffer {
         } else {
             let new_capacity = bit_util::round_upto_multiple_of_64(new_len);
             if new_capacity < self.capacity {
-                let new_data = memory::reallocate(self.data, self.capacity, new_capacity);
+                let new_data =
+                    unsafe { memory::reallocate(self.data, self.capacity, new_capacity) };
                 self.data = new_data as *mut u8;
                 self.capacity = new_capacity;
             }
@@ -571,7 +573,7 @@ impl MutableBuffer {
 impl Drop for MutableBuffer {
     fn drop(&mut self) {
         if !self.data.is_null() {
-            memory::free_aligned(self.data, self.capacity);
+            unsafe { memory::free_aligned(self.data, self.capacity) };
         }
     }
 }
@@ -595,7 +597,7 @@ impl Write for MutableBuffer {
             return Err(IoError::new(ErrorKind::Other, "Buffer not big enough"));
         }
         unsafe {
-            memory::memcpy(self.data.offset(self.len as isize), buf.as_ptr(), buf.len());
+            memory::memcpy(self.data.add(self.len), buf.as_ptr(), buf.len());
             self.len += buf.len();
             Ok(buf.len())
         }

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -80,17 +80,17 @@ where
         let mut n: T::Native = T::default_value();
         let data = array.data();
         let m = array.value_slice(0, data.len());
-        for i in 0..data.len() {
-            n = n + m[i];
+        for item in m.iter().take(data.len()) {
+            n = n + *item;
         }
         Some(n)
     } else {
         let mut n: T::Native = T::default_value();
         let data = array.data();
         let m = array.value_slice(0, data.len());
-        for i in 0..data.len() {
+        for (i, item) in m.iter().enumerate() {
             if data.is_valid(i) {
-                n = n + m[i];
+                n = n + *item;
             }
         }
         Some(n)

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -123,7 +123,7 @@ where
 
         let result_slice: &mut [T::Native] = unsafe {
             from_raw_parts_mut(
-                (result.data_mut().as_mut_ptr() as *mut T::Native).offset(i as isize),
+                (result.data_mut().as_mut_ptr() as *mut T::Native).add(i),
                 lanes,
             )
         };
@@ -186,14 +186,14 @@ where
 
         let result_slice: &mut [T::Native] = unsafe {
             from_raw_parts_mut(
-                (result.data_mut().as_mut_ptr() as *mut T::Native).offset(i as isize),
+                (result.data_mut().as_mut_ptr() as *mut T::Native).add(i),
                 lanes,
             )
         };
         T::write(simd_result, result_slice);
     }
 
-    let null_bit_buffer = bitmap.and_then(|b| Some(b.bits));
+    let null_bit_buffer = bitmap.map(|b| b.bits);
 
     let data = ArrayData::new(
         T::get_data_type(),

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -163,7 +163,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
                     if array.is_null(i) {
                         b.append(false)?;
                     } else {
-                        b.append_value(if from.value(i) {"1"} else {"0"})?;
+                        b.append_value(if from.value(i) { "1" } else { "0" })?;
                     }
                 }
 

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -106,7 +106,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
             // cast primitive to list's primitive
             let cast_array = cast(array, &to)?;
             // create offsets, where if array.len() = 2, we have [0,1,2]
-            let offsets: Vec<i32> = (0..array.len() as i32 + 1).collect();
+            let offsets: Vec<i32> = (0..=array.len() as i32).collect();
             let value_offsets = Buffer::from(offsets[..].to_byte_slice());
             let list_data = ArrayData::new(
                 *to.clone(),
@@ -163,10 +163,7 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
                     if array.is_null(i) {
                         b.append(false)?;
                     } else {
-                        b.append_value(match from.value(i) {
-                            true => "1",
-                            false => "0",
-                        })?;
+                        b.append_value(if from.value(i) {"1"} else {"0"})?;
                     }
                 }
 
@@ -708,12 +705,10 @@ where
     for i in 0..from.len() {
         if from.is_null(i) {
             b.append_null()?;
+        } else if from.value(i) != T::default_value() {
+            b.append_value(true)?;
         } else {
-            if from.value(i) != T::default_value() {
-                b.append_value(true)?;
-            } else {
-                b.append_value(false)?;
-            }
+            b.append_value(false)?;
         }
     }
 
@@ -742,16 +737,14 @@ where
     for i in 0..from.len() {
         if from.is_null(i) {
             b.append_null()?;
+        } else if from.value(i) {
+            // a workaround to cast a primitive to T::Native, infallible
+            match num::cast::cast(1) {
+                Some(v) => b.append_value(v)?,
+                None => b.append_null()?,
+            };
         } else {
-            if from.value(i) {
-                // a workaround to cast a primitive to T::Native, infallible
-                match num::cast::cast(1) {
-                    Some(v) => b.append_value(v)?,
-                    None => b.append_null()?,
-                };
-            } else {
-                b.append_value(T::default_value())?;
-            }
+            b.append_value(T::default_value())?;
         }
     }
 

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -265,7 +265,7 @@ where
     T: ArrowNumericType,
 {
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    return simd_compare_op(left, right,T::eq);
+    return simd_compare_op(left, right, T::eq);
 
     #[cfg(any(
         not(any(target_arch = "x86", target_arch = "x86_64")),

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -265,7 +265,7 @@ where
     T: ArrowNumericType,
 {
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    return simd_compare_op(left, right, |a, b| T::eq(a, b));
+    return simd_compare_op(left, right,T::eq);
 
     #[cfg(any(
         not(any(target_arch = "x86", target_arch = "x86_64")),
@@ -280,7 +280,7 @@ where
     T: ArrowNumericType,
 {
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    return simd_compare_op(left, right, |a, b| T::ne(a, b));
+    return simd_compare_op(left, right, T::ne);
 
     #[cfg(any(
         not(any(target_arch = "x86", target_arch = "x86_64")),
@@ -296,7 +296,7 @@ where
     T: ArrowNumericType,
 {
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    return simd_compare_op(left, right, |a, b| T::lt(a, b));
+    return simd_compare_op(left, right, T::lt);
 
     #[cfg(any(
         not(any(target_arch = "x86", target_arch = "x86_64")),
@@ -315,7 +315,7 @@ where
     T: ArrowNumericType,
 {
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    return simd_compare_op(left, right, |a, b| T::le(a, b));
+    return simd_compare_op(left, right, T::le);
 
     #[cfg(any(
         not(any(target_arch = "x86", target_arch = "x86_64")),
@@ -331,7 +331,7 @@ where
     T: ArrowNumericType,
 {
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    return simd_compare_op(left, right, |a, b| T::gt(a, b));
+    return simd_compare_op(left, right, T::gt);
 
     #[cfg(any(
         not(any(target_arch = "x86", target_arch = "x86_64")),
@@ -350,7 +350,7 @@ where
     T: ArrowNumericType,
 {
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    return simd_compare_op(left, right, |a, b| T::ge(a, b));
+    return simd_compare_op(left, right, T::ge);
 
     #[cfg(any(
         not(any(target_arch = "x86", target_arch = "x86_64")),

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -38,7 +38,7 @@ pub fn take(
     indices: &UInt32Array,
     options: Option<TakeOptions>,
 ) -> Result<ArrayRef> {
-    let options = options.unwrap_or(Default::default());
+    let options = options.unwrap_or_default();
     if options.check_bounds {
         let len = values.len();
         for i in 0..indices.len() {
@@ -121,7 +121,7 @@ pub fn take(
                 fields.clone().into_iter().zip(arrays).collect();
             Ok(Arc::new(StructArray::from(pairs)) as ArrayRef)
         }
-        t @ _ => unimplemented!("Take not supported for data type {:?}", t),
+        t => unimplemented!("Take not supported for data type {:?}", t),
     }
 }
 
@@ -210,7 +210,7 @@ fn take_list(values: &ArrayRef, indices: &UInt32Array) -> Result<ArrayRef> {
     let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
     {
         let null_slice = null_buf.data_mut();
-        &offsets[..]
+        offsets[..]
             .windows(2)
             .enumerate()
             .for_each(|(i, window): (usize, &[i32])| {

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -83,7 +83,7 @@ pub(super) fn take_value_indices_from_list(
             if start != end {
                 // type annotation needed to guide compiler a bit
                 let mut offsets: Vec<Option<u32>> =
-                    (start..end).map(|v| Some(v)).collect::<Vec<Option<u32>>>();
+                    (start..end).map(Some).collect::<Vec<Option<u32>>>();
                 values.append(&mut offsets);
             }
         } else {
@@ -113,7 +113,7 @@ where
     let mut validity = T::mask_init(true);
 
     // Validity based on `Bitmap`
-    if let &Some(b) = &bitmap {
+    if let Some(b) = bitmap {
         for j in i..min(array_len, simd_upper_bound) {
             if !b.is_set(j) {
                 validity = T::mask_set(validity, j - i, false);

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -68,18 +68,18 @@ lazy_static! {
 fn infer_field_schema(string: &str) -> DataType {
     // when quoting is enabled in the reader, these quotes aren't escaped, we default to
     // Utf8 for them
-    if string.starts_with("\"") {
+    if string.starts_with('"') {
         return DataType::Utf8;
     }
     // match regex in a particular order
     if BOOLEAN_RE.is_match(string) {
-        return DataType::Boolean;
+        DataType::Boolean
     } else if DECIMAL_RE.is_match(string) {
-        return DataType::Float64;
+        DataType::Float64
     } else if INTEGER_RE.is_match(string) {
-        return DataType::Int64;
+        DataType::Int64
     } else {
-        return DataType::Utf8;
+        DataType::Utf8
     }
 }
 
@@ -106,7 +106,6 @@ fn infer_file_schema<R: Read + Seek>(
         let first_record_count = &csv_reader.headers()?.len();
         (0..*first_record_count)
             .map(|i| format!("column_{}", i + 1))
-            .into_iter()
             .collect()
     };
 
@@ -131,16 +130,12 @@ fn infer_file_schema<R: Read + Seek>(
         let record = result?;
 
         for i in 0..header_length {
-            let string: Option<&str> = record.get(i);
-            match string {
-                Some(s) => {
-                    if s == "" {
+            if let Some(string) = record.get(i) {
+                    if string == "" {
                         nulls[i] = true;
                     } else {
-                        column_types[i].insert(infer_field_schema(s));
+                        column_types[i].insert(infer_field_schema(string));
                     }
-                }
-                _ => {}
             }
         }
     }
@@ -295,7 +290,8 @@ impl<R: Read> Reader<R> {
         let arrays: Result<Vec<ArrayRef>> = projection
             .iter()
             .map(|i| {
-                let field = self.schema.field(*i);
+                let i = *i;
+                let field = self.schema.field(i);
                 match field.data_type() {
                     &DataType::Boolean => {
                         self.build_primitive_array::<BooleanType>(rows, i)
@@ -322,8 +318,8 @@ impl<R: Read> Reader<R> {
                     }
                     &DataType::Utf8 => {
                         let mut builder = StringBuilder::new(rows.len());
-                        for row_index in 0..rows.len() {
-                            match rows[row_index].get(*i) {
+                        for row in rows.iter() {
+                            match row.get(i) {
                                 Some(s) => builder.append_value(s).unwrap(),
                                 _ => builder.append(false).unwrap(),
                             }
@@ -350,21 +346,21 @@ impl<R: Read> Reader<R> {
         let projected_schema = Arc::new(Schema::new(projected_fields));
 
         arrays.and_then(|arr| {
-            RecordBatch::try_new(projected_schema, arr).map(|batch| Some(batch))
+            RecordBatch::try_new(projected_schema, arr).map(Some)
         })
     }
 
     fn build_primitive_array<T: ArrowPrimitiveType>(
         &self,
         rows: &[StringRecord],
-        col_idx: &usize,
+        col_idx: usize,
     ) -> Result<ArrayRef> {
         let mut builder = PrimitiveBuilder::<T>::new(rows.len());
         let is_boolean_type =
-            *self.schema.field(*col_idx).data_type() == DataType::Boolean;
-        for row_index in 0..rows.len() {
-            match rows[row_index].get(*col_idx) {
-                Some(s) if s.len() > 0 => {
+            *self.schema.field(col_idx).data_type() == DataType::Boolean;
+        for (row_index, row) in rows.iter().enumerate() {
+            match row.get(col_idx) {
+                Some(s) if !s.is_empty() => {
                     let t = if is_boolean_type {
                         s.to_lowercase().parse::<T::Native>()
                     } else {

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -131,11 +131,11 @@ fn infer_file_schema<R: Read + Seek>(
 
         for i in 0..header_length {
             if let Some(string) = record.get(i) {
-                    if string == "" {
-                        nulls[i] = true;
-                    } else {
-                        column_types[i].insert(infer_field_schema(string));
-                    }
+                if string == "" {
+                    nulls[i] = true;
+                } else {
+                    column_types[i].insert(infer_field_schema(string));
+                }
             }
         }
     }
@@ -345,9 +345,7 @@ impl<R: Read> Reader<R> {
 
         let projected_schema = Arc::new(Schema::new(projected_fields));
 
-        arrays.and_then(|arr| {
-            RecordBatch::try_new(projected_schema, arr).map(Some)
-        })
+        arrays.and_then(|arr| RecordBatch::try_new(projected_schema, arr).map(Some))
     }
 
     fn build_primitive_array<T: ArrowPrimitiveType>(

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -254,7 +254,7 @@ impl<W: Write> Writer<W> {
         if self.beginning {
             if self.has_headers {
                 let mut headers: Vec<String> = Vec::with_capacity(num_columns);
-                &batch
+                batch
                     .schema()
                     .fields()
                     .iter()
@@ -366,11 +366,15 @@ impl WriterBuilder {
             writer,
             delimiter,
             has_headers: self.has_headers,
-            date_format: self.date_format.unwrap_or(DEFAULT_DATE_FORMAT.to_string()),
-            time_format: self.time_format.unwrap_or(DEFAULT_TIME_FORMAT.to_string()),
+            date_format: self
+                .date_format
+                .unwrap_or_else(|| DEFAULT_DATE_FORMAT.to_string()),
+            time_format: self
+                .time_format
+                .unwrap_or_else(|| DEFAULT_TIME_FORMAT.to_string()),
             timestamp_format: self
                 .timestamp_format
-                .unwrap_or(DEFAULT_TIMESTAMP_FORMAT.to_string()),
+                .unwrap_or_else(|| DEFAULT_TIMESTAMP_FORMAT.to_string()),
             beginning: false,
         }
     }

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -327,13 +327,13 @@ impl ArrowNativeType for u64 {
 impl ArrowNativeType for f32 {
     fn into_json_value(self) -> Option<Value> {
         Number::from_f64(f64::round(self as f64 * 1000.0) / 1000.0)
-            .map(|num| VNumber(num))
+            .map(VNumber)
     }
 }
 
 impl ArrowNativeType for f64 {
     fn into_json_value(self) -> Option<Value> {
-        Number::from_f64(self).map(|num| VNumber(num))
+        Number::from_f64(self).map(VNumber)
     }
 }
 
@@ -758,9 +758,9 @@ impl DataType {
                     if let Some(Value::Number(size)) = map.get("byteWidth") {
                         Ok(DataType::FixedSizeBinary(size.as_i64().unwrap() as i32))
                     } else {
-                        Err(ArrowError::ParseError(format!(
-                            "Expecting a byteWidth for fixedsizebinary",
-                        )))
+                        Err(ArrowError::ParseError(
+                            "Expecting a byteWidth for fixedsizebinary".to_string()
+                        ))
                     }
                 }
                 Some(s) if s == "floatingpoint" => match map.get("precision") {
@@ -888,9 +888,9 @@ impl DataType {
                             size.as_i64().unwrap() as i32,
                         ))
                     } else {
-                        Err(ArrowError::ParseError(format!(
-                            "Expecting a listSize for fixedsizelist",
-                        )))
+                        Err(ArrowError::ParseError(
+                            "Expecting a listSize for fixedsizelist".to_string(),
+                        ))
                     }
                 }
                 Some(s) if s == "struct" => {
@@ -1284,7 +1284,7 @@ impl Schema {
 
     /// Returns an immutable reference of a specific `Field` instance selected by name
     pub fn field_with_name(&self, name: &str) -> Result<&Field> {
-        return Ok(&self.fields[self.index_of(name)?]);
+        Ok(&self.fields[self.index_of(name)?])
     }
 
     /// Find the index of the column with the given name

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -326,8 +326,7 @@ impl ArrowNativeType for u64 {
 
 impl ArrowNativeType for f32 {
     fn into_json_value(self) -> Option<Value> {
-        Number::from_f64(f64::round(self as f64 * 1000.0) / 1000.0)
-            .map(VNumber)
+        Number::from_f64(f64::round(self as f64 * 1000.0) / 1000.0).map(VNumber)
     }
 }
 
@@ -759,7 +758,7 @@ impl DataType {
                         Ok(DataType::FixedSizeBinary(size.as_i64().unwrap() as i32))
                     } else {
                         Err(ArrowError::ParseError(
-                            "Expecting a byteWidth for fixedsizebinary".to_string()
+                            "Expecting a byteWidth for fixedsizebinary".to_string(),
                         ))
                     }
                 }

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -51,9 +51,7 @@ impl From<csv_crate::Error> for ArrowError {
                 err.to_string()
             )),
             csv_crate::ErrorKind::UnequalLengths {
-                expected_len,
-                len,
-                ..
+                expected_len, len, ..
             } => ArrowError::CsvError(format!(
                 "Encountered unequal lengths between records on CSV file. Expected {} \
                  records, found {} records",

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -51,9 +51,9 @@ impl From<csv_crate::Error> for ArrowError {
                 err.to_string()
             )),
             csv_crate::ErrorKind::UnequalLengths {
-                pos: _,
                 expected_len,
                 len,
+                ..
             } => ArrowError::CsvError(format!(
                 "Encountered unequal lengths between records on CSV file. Expected {} \
                  records, found {} records",
@@ -72,21 +72,21 @@ impl From<::std::string::FromUtf8Error> for ArrowError {
 
 impl Display for ArrowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            &ArrowError::MemoryError(ref desc) => write!(f, "Memory error: {}", desc),
-            &ArrowError::ParseError(ref desc) => write!(f, "Parser error: {}", desc),
-            &ArrowError::ComputeError(ref desc) => write!(f, "Compute error: {}", desc),
-            &ArrowError::DivideByZero => write!(f, "Divide by zero error"),
-            &ArrowError::CsvError(ref desc) => write!(f, "Csv error: {}", desc),
-            &ArrowError::JsonError(ref desc) => write!(f, "Json error: {}", desc),
-            &ArrowError::IoError(ref desc) => write!(f, "Io error: {}", desc),
-            &ArrowError::InvalidArgumentError(ref desc) => {
+        match *self {
+            ArrowError::MemoryError(ref desc) => write!(f, "Memory error: {}", desc),
+            ArrowError::ParseError(ref desc) => write!(f, "Parser error: {}", desc),
+            ArrowError::ComputeError(ref desc) => write!(f, "Compute error: {}", desc),
+            ArrowError::DivideByZero => write!(f, "Divide by zero error"),
+            ArrowError::CsvError(ref desc) => write!(f, "Csv error: {}", desc),
+            ArrowError::JsonError(ref desc) => write!(f, "Json error: {}", desc),
+            ArrowError::IoError(ref desc) => write!(f, "Io error: {}", desc),
+            ArrowError::InvalidArgumentError(ref desc) => {
                 write!(f, "Invalid argument error: {}", desc)
             }
-            &ArrowError::ParquetError(ref desc) => {
+            ArrowError::ParquetError(ref desc) => {
                 write!(f, "Parquet argument error: {}", desc)
             }
-            &ArrowError::DictionaryKeyOverflowError => {
+            ArrowError::DictionaryKeyOverflowError => {
                 write!(f, "Dictionary key bigger than the key type")
             }
         }

--- a/rust/arrow/src/flight/mod.rs
+++ b/rust/arrow/src/flight/mod.rs
@@ -68,9 +68,11 @@ impl From<&Schema> for FlightData {
 impl TryFrom<&FlightData> for Schema {
     type Error = ArrowError;
     fn try_from(data: &FlightData) -> Result<Self> {
-        convert::schema_from_bytes(&data.data_header[..]).ok_or(ArrowError::ParseError(
-            "Unable to convert flight data to Arrow schema".to_string(),
-        ))
+        convert::schema_from_bytes(&data.data_header[..]).ok_or_else(|| {
+            ArrowError::ParseError(
+                "Unable to convert flight data to Arrow schema".to_string(),
+            )
+        })
     }
 }
 
@@ -80,9 +82,11 @@ impl TryFrom<&FlightData> for Schema {
 impl TryFrom<&SchemaResult> for Schema {
     type Error = ArrowError;
     fn try_from(data: &SchemaResult) -> Result<Self> {
-        convert::schema_from_bytes(&data.schema[..]).ok_or(ArrowError::ParseError(
-            "Unable to convert schema result to Arrow schema".to_string(),
-        ))
+        convert::schema_from_bytes(&data.schema[..]).ok_or_else(|| {
+            ArrowError::ParseError(
+                "Unable to convert schema result to Arrow schema".to_string(),
+            )
+        })
     }
 }
 
@@ -94,11 +98,11 @@ pub fn flight_data_to_batch(
     // check that the data_header is a record batch message
     let message = crate::ipc::get_root_as_message(&data.data_header[..]);
     let dictionaries_by_field = Vec::new();
-    let batch_header = message
-        .header_as_record_batch()
-        .ok_or(ArrowError::ParseError(
+    let batch_header = message.header_as_record_batch().ok_or_else(|| {
+        ArrowError::ParseError(
             "Unable to convert flight data header to a record batch".to_string(),
-        ))?;
+        )
+    })?;
     reader::read_record_batch(
         &data.data_body,
         batch_header,

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -462,7 +462,7 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
         }
         Timestamp(unit, tz) => {
             let children = fbb.create_vector(&empty_fields[..]);
-            let tz = tz.clone().unwrap_or_else( || Arc::new(String::new()));
+            let tz = tz.clone().unwrap_or_else(|| Arc::new(String::new()));
             let tz_str = fbb.create_string(tz.as_str());
             let mut builder = ipc::TimestampBuilder::new(fbb);
             let time_unit = match unit {

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -154,8 +154,10 @@ pub fn fb_to_schema(fb: ipc::Schema) -> Schema {
             let kv = md_fields.get(i);
             let k_str = kv.key();
             let v_str = kv.value();
-            if k_str.is_some() && v_str.is_some() {
-                metadata.insert(k_str.unwrap().to_string(), v_str.unwrap().to_string());
+            if let Some(k) = k_str {
+                if let Some(v) = v_str {
+                    metadata.insert(k.to_string(), v.to_string());
+                }
             }
         }
     }
@@ -239,7 +241,7 @@ pub(crate) fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataT
                     DataType::Time64(TimeUnit::Microsecond)
                 }
                 (64, ipc::TimeUnit::NANOSECOND) => DataType::Time64(TimeUnit::Nanosecond),
-                z @ _ => panic!(
+                z => panic!(
                     "Time type with bit width of {} and unit of {:?} not supported",
                     z.0, z.1
                 ),
@@ -311,7 +313,7 @@ pub(crate) fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataT
 
             DataType::Struct(fields)
         }
-        t @ _ => unimplemented!("Type {:?} not supported", t),
+        t => unimplemented!("Type {:?} not supported", t),
     }
 }
 
@@ -460,7 +462,7 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
         }
         Timestamp(unit, tz) => {
             let children = fbb.create_vector(&empty_fields[..]);
-            let tz = tz.clone().unwrap_or(Arc::new(String::new()));
+            let tz = tz.clone().unwrap_or_else( || Arc::new(String::new()));
             let tz_str = fbb.create_string(tz.as_str());
             let mut builder = ipc::TimestampBuilder::new(fbb);
             let time_unit = match unit {
@@ -579,7 +581,7 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                 Some(children),
             )
         }
-        t @ _ => unimplemented!("Type {:?} not supported", t),
+        t => unimplemented!("Type {:?} not supported", t),
     }
 }
 

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -35,6 +35,11 @@ pub mod datatypes;
 pub mod error;
 #[cfg(feature = "flight")]
 pub mod flight;
+#[allow(clippy::redundant_closure)]
+#[allow(clippy::needless_lifetimes)]
+#[allow(clippy::extra_unused_lifetimes)]
+#[allow(clippy::redundant_static_lifetimes)]
+#[allow(clippy::redundant_field_names)]
 pub mod ipc;
 pub mod json;
 pub mod memory;

--- a/rust/arrow/src/memory.rs
+++ b/rust/arrow/src/memory.rs
@@ -30,8 +30,8 @@ pub fn allocate_aligned(size: usize) -> *mut u8 {
     }
 }
 
-pub unsafe fn free_aligned(p: *mut u8, size: usize) { 
-        std::alloc::dealloc(p, Layout::from_size_align_unchecked(size, ALIGNMENT));
+pub unsafe fn free_aligned(p: *mut u8, size: usize) {
+    std::alloc::dealloc(p, Layout::from_size_align_unchecked(size, ALIGNMENT));
 }
 
 pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, new_size: usize) -> *mut u8 {

--- a/rust/arrow/src/memory.rs
+++ b/rust/arrow/src/memory.rs
@@ -30,24 +30,20 @@ pub fn allocate_aligned(size: usize) -> *mut u8 {
     }
 }
 
-pub fn free_aligned(p: *mut u8, size: usize) {
-    unsafe {
+pub unsafe fn free_aligned(p: *mut u8, size: usize) { 
         std::alloc::dealloc(p, Layout::from_size_align_unchecked(size, ALIGNMENT));
-    }
 }
 
-pub fn reallocate(ptr: *mut u8, old_size: usize, new_size: usize) -> *mut u8 {
-    unsafe {
-        let new_ptr = std::alloc::realloc(
-            ptr,
-            Layout::from_size_align_unchecked(old_size, ALIGNMENT),
-            new_size,
-        );
-        if !new_ptr.is_null() && new_size > old_size {
-            new_ptr.add(old_size).write_bytes(0, new_size - old_size);
-        }
-        new_ptr
+pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, new_size: usize) -> *mut u8 {
+    let new_ptr = std::alloc::realloc(
+        ptr,
+        Layout::from_size_align_unchecked(old_size, ALIGNMENT),
+        new_size,
+    );
+    if !new_ptr.is_null() && new_size > old_size {
+        new_ptr.add(old_size).write_bytes(0, new_size - old_size);
     }
+    new_ptr
 }
 
 pub unsafe fn memcpy(dst: *mut u8, src: *const u8, len: usize) {

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -90,17 +90,18 @@ impl RecordBatch {
         }
         // check that all columns have the same row count, and match the schema
         let len = columns[0].data().len();
-        for i in 0..columns.len() {
-            if columns[i].len() != len {
+
+        for (i, column) in columns.iter().enumerate() {
+            if column.len() != len {
                 return Err(ArrowError::InvalidArgumentError(
                     "all columns in a record batch must have the same length".to_string(),
                 ));
             }
-            if columns[i].data_type() != schema.field(i).data_type() {
+            if column.data_type() != schema.field(i).data_type() {
                 return Err(ArrowError::InvalidArgumentError(format!(
                     "column types must match schema types, expected {:?} but found {:?} at column index {}",
                     schema.field(i).data_type(),
-                    columns[i].data_type(),
+                    column.data_type(),
                     i)));
             }
         }

--- a/rust/arrow/src/tensor.rs
+++ b/rust/arrow/src/tensor.rs
@@ -25,7 +25,7 @@ use crate::buffer::Buffer;
 use crate::datatypes::*;
 
 /// Computes the strides required assuming a row major memory layout
-fn compute_row_major_strides<T: ArrowPrimitiveType>(shape: &Vec<usize>) -> Vec<usize> {
+fn compute_row_major_strides<T: ArrowPrimitiveType>(shape: &[usize]) -> Vec<usize> {
     let mut remaining_bytes = mem::size_of::<T::Native>();
     for i in shape {
         remaining_bytes = remaining_bytes
@@ -42,7 +42,7 @@ fn compute_row_major_strides<T: ArrowPrimitiveType>(shape: &Vec<usize>) -> Vec<u
 }
 
 /// Computes the strides required assuming a column major memory layout
-fn compute_column_major_strides<T: ArrowPrimitiveType>(shape: &Vec<usize>) -> Vec<usize> {
+fn compute_column_major_strides<T: ArrowPrimitiveType>(shape: &[usize]) -> Vec<usize> {
     let mut remaining_bytes = mem::size_of::<T::Native>();
     let mut strides = Vec::<usize>::new();
     for i in shape {
@@ -189,7 +189,7 @@ impl<'a, T: ArrowPrimitiveType> Tensor<'a, T> {
     pub fn size(&self) -> usize {
         match self.shape {
             None => 0,
-            Some(ref s) => s.iter().fold(1, |a, b| a * b),
+            Some(ref s) => s.iter().product(),
         }
     }
 

--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -60,7 +60,7 @@ pub fn get_bit(data: &[u8], i: usize) -> bool {
 /// responsible to guarantee that `i` is within bounds.
 #[inline]
 pub unsafe fn get_bit_raw(data: *const u8, i: usize) -> bool {
-    (*data.offset((i >> 3) as isize) & BIT_MASK[i & 7]) != 0
+    (*data.add(i >> 3) & BIT_MASK[i & 7]) != 0
 }
 
 /// Sets bit at position `i` for `data`
@@ -75,7 +75,8 @@ pub fn set_bit(data: &mut [u8], i: usize) {
 /// responsible to guarantee that `i` is within bounds.
 #[inline]
 pub unsafe fn set_bit_raw(data: *mut u8, i: usize) {
-    *data.offset((i >> 3) as isize) |= BIT_MASK[i & 7]
+    // *data.offset((i >> 3) as isize) |= BIT_MASK[i & 7]
+    *data.add(i >> 3) |= BIT_MASK[i & 7]
 }
 
 /// Sets bits in the non-inclusive range `start..end` for `data`

--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -75,7 +75,6 @@ pub fn set_bit(data: &mut [u8], i: usize) {
 /// responsible to guarantee that `i` is within bounds.
 #[inline]
 pub unsafe fn set_bit_raw(data: *mut u8, i: usize) {
-    // *data.offset((i >> 3) as isize) |= BIT_MASK[i & 7]
     *data.add(i >> 3) |= BIT_MASK[i & 7]
 }
 

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -309,9 +309,9 @@ impl ArrowJsonBatch {
                                 &json_array.iter().collect::<Vec<&Value>>()[..],
                             )
                         }
-                        t @ _ => panic!("Unsupported dictionary comparison for {:?}", t),
+                        t => panic!("Unsupported dictionary comparison for {:?}", t),
                     },
-                    t @ _ => panic!("Unsupported comparison for {:?}", t),
+                    t => panic!("Unsupported comparison for {:?}", t),
                 }
             })
     }
@@ -330,7 +330,7 @@ fn json_from_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value> {
 }
 
 /// Merge VALIDITY and DATA vectors from a primitive data type into a `Value` vector with nulls
-fn merge_json_array(validity: &Vec<u8>, data: &Vec<Value>) -> Vec<Value> {
+fn merge_json_array(validity: &[u8], data: &[Value]) -> Vec<Value> {
     validity
         .iter()
         .zip(data)
@@ -343,7 +343,7 @@ fn merge_json_array(validity: &Vec<u8>, data: &Vec<Value>) -> Vec<Value> {
 }
 
 /// Convert an Arrow JSON column/array of a `DataType::Struct` into a vector of `Value`
-fn json_from_struct_col(col: &ArrowJsonColumn, fields: &Vec<Field>) -> Vec<Value> {
+fn json_from_struct_col(col: &ArrowJsonColumn, fields: &[Field]) -> Vec<Value> {
     let mut values = Vec::with_capacity(col.count);
 
     let children: Vec<Vec<Value>> = col
@@ -379,7 +379,7 @@ fn json_from_list_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value>
         .unwrap()
         .iter()
         .map(|o| match o {
-            Value::String(s) => *&s.parse::<usize>().unwrap(),
+            Value::String(s) => s.parse::<usize>().unwrap(),
             Value::Number(n) => n.as_u64().unwrap() as usize,
             _ => panic!(
                 "Offsets should be numbers or strings that are convertible to numbers"

--- a/rust/arrow/src/util/test_util.rs
+++ b/rust/arrow/src/util/test_util.rs
@@ -25,7 +25,7 @@ pub fn random_bytes(n: usize) -> Vec<u8> {
     let mut result = vec![];
     let mut rng = thread_rng();
     for _ in 0..n {
-        result.push(rng.gen_range(0, 255) & 0xFF);
+        result.push(rng.gen_range(0, 255));
     }
     result
 }


### PR DESCRIPTION
+ Pedantic fixes to `unsafe`
+ Changes to function arguments to pass in references or values as appropriate
+ Refactor pointer arithmetic to use `usize` instead of `isize` casting
+ Ignore generated code clippy warnings
+ Refactor loops to use iterators where appropriate
+ Remove unnecessary `return` statements
+ Remove unnecessary `clone` statements
+ Remove unnecessary closures
+ A bunch of similar small scale refactorings

Tests below are currently failing on master locally as well with `ARROW_TEST_DATA not defined: NotPresent`, assuming that is ok for now:

```
ipc::reader::tests::read_generated_files
ipc::reader::tests::read_generated_streams
ipc::writer::tests::read_and_rewrite_generated_files
ipc::writer::tests::read_and_rewrite_generated_streams
```