### PR TITLE
ARROW-8606: [CI] Don't trigger all builds on a change to any file in ci/

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -21,13 +21,19 @@ on:
   push:
     paths:
       - '.github/workflows/cpp.yml'
-      - 'ci/**'
+      - 'ci/docker/**'
+      - 'ci/scripts/util_*'
+      - 'ci/scripts/msys_*'
+      - 'ci/scripts/cpp_*'
       - 'cpp/**'
       - 'format/Flight.proto'
   pull_request:
     paths:
       - '.github/workflows/cpp.yml'
-      - 'ci/**'
+      - 'ci/docker/**'
+      - 'ci/scripts/util_*'
+      - 'ci/scripts/msys_*'
+      - 'ci/scripts/cpp_*'
       - 'cpp/**'
       - 'format/Flight.proto'
 

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -21,12 +21,12 @@ on:
   push:
     paths:
       - '.github/workflows/csharp.yml'
-      - 'ci/**'
+      - 'ci/scripts/csharp_*'
       - 'csharp/**'
   pull_request:
     paths:
       - '.github/workflows/csharp.yml'
-      - 'ci/**'
+      - 'ci/scripts/csharp_*'
       - 'csharp/**'
 
 jobs:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,12 +21,15 @@ on:
   push:
     paths:
       - '.github/workflows/go.yml'
-      - 'ci/**'
+      - 'ci/docker/*_go.dockerfile'
+      - 'ci/scripts/go_*'
       - 'go/**'
   pull_request:
     paths:
       - '.github/workflows/go.yml'
-      - 'ci/**'
+      - 'ci/docker/*_go.dockerfile'
+      - 'ci/docker/**'
+      - 'ci/scripts/go_*'
       - 'go/**'
 
 env:

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -21,13 +21,17 @@ on:
   push:
     paths:
       - '.github/workflows/java_jni.yml'
-      - 'ci/**'
+      - 'ci/docker/**'
+      - 'ci/scripts/cpp_build.sh'
+      - 'ci/scripts/java_*'
       - 'cpp/**'
       - 'java/**'
   pull_request:
     paths:
       - '.github/workflows/java_jni.yml'
-      - 'ci/**'
+      - 'ci/docker/**'
+      - 'ci/scripts/cpp_build.sh'
+      - 'ci/scripts/java_*'
       - 'cpp/**'
       - 'java/**'
 

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -21,12 +21,14 @@ on:
   push:
     paths:
       - '.github/workflows/js.yml'
-      - 'ci/**'
+      - 'ci/docker/*js.dockerfile'
+      - 'ci/scripts/js_*'
       - 'js/**'
   pull_request:
     paths:
       - '.github/workflows/js.yml'
-      - 'ci/**'
+      - 'ci/docker/*js.dockerfile'
+      - 'ci/scripts/js_*'
       - 'js/**'
 
 env:


### PR DESCRIPTION
If I edit an R build script, we shouldn't be running JS and Go builds.