### PR TITLE
ARROW-8609: [C++] Fix ORC Java JNI crash

### DIFF
--- a/ci/scripts/java_test.sh
+++ b/ci/scripts/java_test.sh
@@ -33,7 +33,7 @@ pushd ${source_dir}
 ${mvn} test
 
 if [ "${ARROW_GANDIVA_JAVA}" = "ON" ]; then
-  ${mvn} test -Parrow-jni -pl gandiva -Darrow.cpp.build.dir=${cpp_build_dir}
+  ${mvn} test -Parrow-jni -pl adapter/orc,gandiva -Darrow.cpp.build.dir=${cpp_build_dir}
 fi
 
 if [ "${ARROW_PLASMA}" = "ON" ]; then

--- a/cpp/src/jni/orc/jni_wrapper.cpp
+++ b/cpp/src/jni/orc/jni_wrapper.cpp
@@ -276,9 +276,16 @@ Java_org_apache_arrow_adapter_orc_OrcStripeReaderJniWrapper_next(JNIEnv* env,
 
   for (size_t j = 0; j < buffers.size(); ++j) {
     auto buffer = buffers[j];
+    uint8_t* data = nullptr;
+    int size = 0;
+    int64_t capacity = 0;
+    if (buffer != nullptr) {
+      data = (uint8_t*)buffer->data();
+      size = (int)buffer->size();
+      capacity = buffer->capacity();
+    }
     jobject memory = env->NewObject(orc_memory_class, orc_memory_constructor,
-                                    buffer_holder_.Insert(buffer), buffer->data(),
-                                    buffer->size(), buffer->capacity());
+                                    buffer_holder_.Insert(buffer), data, size, capacity);
     env->SetObjectArrayElement(memory_array, j, memory);
   }
 

--- a/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
+++ b/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
@@ -47,7 +47,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 
-@Ignore
 public class OrcReaderTest {
 
   @Rule

--- a/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
+++ b/java/adapter/orc/src/test/java/org/apache/arrow/adapter/orc/OrcReaderTest.java
@@ -41,7 +41,6 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;


### PR DESCRIPTION
check if arrow buffer is null before passing to the constructor

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>