### PR TITLE
ARROW-8617: [Rust] Avoid loading simd_load_set_invalid which doesn't exist on aarch64

### DIFF
--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -38,7 +38,7 @@ use crate::buffer::Buffer;
 #[cfg(feature = "simd")]
 use crate::buffer::MutableBuffer;
 use crate::compute::util::apply_bin_op_to_option_bitmap;
-#[cfg(feature = "simd")]
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 use crate::compute::util::simd_load_set_invalid;
 use crate::datatypes;
 use crate::datatypes::ToByteSlice;


### PR DESCRIPTION
    error[E0432]: unresolved import `crate::compute::util::simd_load_set_invalid`
    --> /home/tyler/.cargo/git/checkouts/arrow-3a9cfebb6b7b2bdc/2a8e37d/rust/arrow/src/compute/kernels/arithmetic.rs:42:5
    |
    42 | use crate::compute::util::simd_load_set_invalid;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `simd_load_set_invalid` in `compute::util`

    Compiling thiserror v1.0.16
    error: aborting due to previous error