### PR TITLE
ARROW-8616: [Rust] Turn explicit SIMD off by default

### DIFF
--- a/ci/scripts/rust_test.sh
+++ b/ci/scripts/rust_test.sh
@@ -31,6 +31,10 @@ pushd ${source_dir}
 
 # run unit tests
 cargo test
+# run unit tests with SIMD on
+pushd arrow
+cargo test --features "simd"
+popd
 
 # test arrow examples
 pushd arrow

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -54,7 +54,7 @@ arrow-flight = { path = "../arrow-flight", optional = true }
 [features]
 simd = ["packed_simd"]
 flight = ["arrow-flight"]
-default = ["simd", "flight"]
+default = ["flight"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/rust/parquet/src/util/io.rs
+++ b/rust/parquet/src/util/io.rs
@@ -254,7 +254,8 @@ mod tests {
 
         // Read data using file chunk
         let mut res = vec![0u8; 7];
-        let mut chunk = FileSource::new(&file, 0, file.metadata().unwrap().len() as usize);
+        let mut chunk =
+            FileSource::new(&file, 0, file.metadata().unwrap().len() as usize);
         chunk.read(&mut res[..]).unwrap();
 
         assert_eq!(res, vec![b'a', b'b', b'c', b'd', b'e', b'f', b'g']);


### PR DESCRIPTION
We will be removing explicit SIMD in #7037, this PR removes it from the default features in preparation of removing it completely.