### PR TITLE
ARROW-8622: [Rust] Allow the parquet crate to be compiled on aarch64 platforms

### DIFF
--- a/rust/parquet/src/util/hash_util.rs
+++ b/rust/parquet/src/util/hash_util.rs
@@ -32,6 +32,11 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
             murmur_hash2_64a(data, seed as u64) as u32
         }
     }
+
+    #[cfg(target_arch = "aarch64")]
+    unsafe {
+        murmur_hash2_64a(data, seed as u64) as u32
+    }
 }
 
 const MURMUR_PRIME: u64 = 0xc6a4a7935bd1e995;


### PR DESCRIPTION
The following compile error shows up on aarch64 because the body of `hash_` was `#cfg`'d to basically empty.


```
    error[E0308]: mismatched types
      --> /home/tyler/.cargo/git/checkouts/arrow-3a9cfebb6b7b2bdc/283e188/rust/parquet/src/util/hash_util.rs:26:37
       |
    26 | fn hash_(data: &[u8], seed: u32) -> u32 {
       |    -----                            ^^^ expected `u32`, found `()`
       |    |
       |    implicitly returns `()` as its body has no tail or `return` expression

    error: aborting due to previous error
```