### PR TITLE
ARROW-6945: [Rust] WIP: Add initial skeleton for Rust integration tests

### DIFF
--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -573,6 +573,8 @@ def _set_default(opt, default):
               help='Include JavaScript in integration tests')
 @click.option('--with-go', type=bool, default=False,
               help='Include Go in integration tests')
+@click.option('--with-rust', type=bool, default=False,
+              help='Include Rust in integration tests')
 @click.option('--write_generated_json', default=False,
               help='Generate test JSON to indicated path')
 @click.option('--run-flight', is_flag=True, default=False,
@@ -604,7 +606,7 @@ def integration(with_all=False, random_seed=12345, **args):
 
     gen_path = args['write_generated_json']
 
-    languages = ['cpp', 'java', 'js', 'go']
+    languages = ['cpp', 'java', 'js', 'go', 'rust']
 
     enabled_languages = 0
     for lang in languages:

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -28,6 +28,7 @@ import traceback
 
 from .tester_cpp import CPPTester
 from .tester_go import GoTester
+from .tester_rust import RustTester
 from .tester_java import JavaTester
 from .tester_js import JSTester
 from .util import (ARROW_ROOT_DEFAULT, guid, SKIP_ARROW, SKIP_FLIGHT,
@@ -303,7 +304,7 @@ def get_static_json_files():
 
 
 def run_all_tests(with_cpp=True, with_java=True, with_js=True,
-                  with_go=True, run_flight=False,
+                  with_go=True, with_rust=True, run_flight=False,
                   tempdir=None, **kwargs):
     tempdir = tempdir or tempfile.mkdtemp()
 
@@ -320,6 +321,9 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
 
     if with_go:
         testers.append(GoTester(**kwargs))
+
+    if with_rust:
+        testers.append(RustTester(**kwargs))
 
     static_json_files = get_static_json_files()
     generated_json_files = datagen.get_generated_json_files(

--- a/dev/archery/archery/integration/tester_rust.py
+++ b/dev/archery/archery/integration/tester_rust.py
@@ -1,0 +1,106 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import contextlib
+import os
+import subprocess
+
+from .tester import Tester
+from .util import run_cmd, ARROW_ROOT_DEFAULT, log
+
+
+class RustTester(Tester):
+    PRODUCER = True
+    CONSUMER = True
+    # FLIGHT_SERVER = True
+    # FLIGHT_CLIENT = True
+
+    EXE_PATH = os.path.join(ARROW_ROOT_DEFAULT, 'rust/target/debug')
+
+    RUST_INTEGRATION_EXE = os.path.join(EXE_PATH, 'arrow-json-integration-test')
+    STREAM_TO_FILE = os.path.join(EXE_PATH, 'arrow-stream-to-file')
+    FILE_TO_STREAM = os.path.join(EXE_PATH, 'arrow-file-to-stream')
+
+    # FLIGHT_SERVER_CMD = [
+    #     os.path.join(EXE_PATH, 'flight-test-integration-server')]
+    # FLIGHT_CLIENT_CMD = [
+    #     os.path.join(EXE_PATH, 'flight-test-integration-client'),
+    #     "-host", "localhost"]
+
+    name = 'Rust'
+
+    def _run(self, arrow_path=None, json_path=None, command='VALIDATE'):
+        cmd = [self.RUST_INTEGRATION_EXE, '--integration']
+
+        if arrow_path is not None:
+            cmd.append('--arrow=' + arrow_path)
+
+        if json_path is not None:
+            cmd.append('--json=' + json_path)
+
+        cmd.append('--mode=' + command)
+
+        if self.debug:
+            log(' '.join(cmd))
+
+        run_cmd(cmd)
+
+    def validate(self, json_path, arrow_path):
+        return self._run(arrow_path, json_path, 'VALIDATE')
+
+    def json_to_file(self, json_path, arrow_path):
+        return self._run(arrow_path, json_path, 'JSON_TO_ARROW')
+
+    def stream_to_file(self, stream_path, file_path):
+        cmd = [self.STREAM_TO_FILE, '<', stream_path, '>', file_path]
+        self.run_shell_command(cmd)
+
+    def file_to_stream(self, file_path, stream_path):
+        cmd = [self.FILE_TO_STREAM, file_path, '>', stream_path]
+        self.run_shell_command(cmd)
+
+    # @contextlib.contextmanager
+    # def flight_server(self):
+    #     cmd = self.FLIGHT_SERVER_CMD + ['-port=0']
+    #     if self.debug:
+    #         log(' '.join(cmd))
+    #     server = subprocess.Popen(cmd,
+    #                               stdout=subprocess.PIPE,
+    #                               stderr=subprocess.PIPE)
+    #     try:
+    #         output = server.stdout.readline().decode()
+    #         if not output.startswith("Server listening on localhost:"):
+    #             server.kill()
+    #             out, err = server.communicate()
+    #             raise RuntimeError(
+    #                 "Flight-C++ server did not start properly, "
+    #                 "stdout:\n{}\n\nstderr:\n{}\n"
+    #                 .format(output + out.decode(), err.decode()))
+    #         port = int(output.split(":")[1])
+    #         yield port
+    #     finally:
+    #         server.kill()
+    #         server.wait(5)
+
+    # def flight_request(self, port, json_path):
+    #     cmd = self.FLIGHT_CLIENT_CMD + [
+    #         '-port=' + str(port),
+    #         '-path=' + json_path,
+    #     ]
+    #     if self.debug:
+    #         log(' '.join(cmd))
+    #     run_cmd(cmd)

--- a/go/arrow/ipc/cmd/arrow-json-integration-test/main.go
+++ b/go/arrow/ipc/cmd/arrow-json-integration-test/main.go
@@ -205,11 +205,11 @@ func validate(arrowName, jsonName string, verbose bool) error {
 	for i := 0; i < arr.NumRecords(); i++ {
 		arec, err := arr.Read()
 		if err != nil {
-			return xerrors.Errorf("could not read record %d from ARROW file: %w", i, err)
+			return xerrors.Errorf("schema: %s\n208 could not read record %d from ARROW file: %w", arr.Schema(), i, err)
 		}
 		jrec, err := jrr.Read()
 		if err != nil {
-			return xerrors.Errorf("could not read record %d from JSON file: %w", i, err)
+			return xerrors.Errorf("212 could not read record %d from JSON file: %w", i, err)
 		}
 		if !array.RecordApproxEqual(jrec, arec) {
 			return xerrors.Errorf("record batch %d did not match\nJSON:\n%v\nARROW:\n%v\n",

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -50,6 +50,7 @@ chrono = "0.4"
 flatbuffers = "0.6"
 hex = "0.4"
 arrow-flight = { path = "../arrow-flight", optional = true }
+clap = "2.33.0"
 
 [features]
 simd = ["packed_simd"]

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -189,8 +189,8 @@ pub use self::builder::FixedSizeListBuilder;
 pub use self::builder::ListBuilder;
 pub use self::builder::PrimitiveBuilder;
 pub use self::builder::PrimitiveDictionaryBuilder;
-pub use self::builder::StringBuilder;
 pub use self::builder::StringDictionaryBuilder;
+pub use self::builder::StringBuilder;
 pub use self::builder::StructBuilder;
 
 pub type BooleanBuilder = PrimitiveBuilder<BooleanType>;

--- a/rust/arrow/src/bin/arrow-file-to-stream.rs
+++ b/rust/arrow/src/bin/arrow-file-to-stream.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod bit_util;
-pub mod integration_util;
-pub mod string_writer;
-pub mod test_util;
+extern crate arrow;
+
+fn main() {
+   panic!("not implemented");
+}

--- a/rust/arrow/src/bin/arrow-json-integration-test.rs
+++ b/rust/arrow/src/bin/arrow-json-integration-test.rs
@@ -1,0 +1,297 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use clap::{Arg, App};
+use serde_json::Value;
+
+use arrow::util::integration_util::{ArrowJson, ArrowJsonSchema, ArrowJsonBatch};
+
+use std::env;
+use std::fs::File;
+use arrow::ipc::reader::FileReader;
+use arrow::record_batch::{RecordBatchReader, RecordBatch};
+use std::io::BufReader;
+use arrow::datatypes::{Schema, DataType};
+use std::sync::Arc;
+use arrow::ipc::writer::FileWriter;
+use arrow::array::{ArrayRef, UInt32Builder, BooleanBuilder, Int8Builder, Int16Builder, Int32Builder, Int64Builder, UInt8Builder, UInt16Builder, UInt64Builder, Float32Builder, Float64Builder, BinaryBuilder, StringBuilder, FixedSizeBinaryBuilder};
+use hex::decode;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    println!("{:?}", args);
+    let matches = App::new("rust arrow-json-integrationtest")
+        .arg(Arg::with_name("integration")
+            .long("integration"))
+        .arg(Arg::with_name("arrow")
+            .long("arrow")
+            .help("path to ARROW file")
+            .takes_value(true))
+        .arg(Arg::with_name("json")
+            .long("json")
+            .help("path to JSON file")
+            .takes_value(true))
+        .arg(Arg::with_name("mode")
+            .long("mode")
+            .help("mode of integration testing tool (ARROW_TO_JSON, JSON_TO_ARROW, VALIDATE)")
+            .takes_value(true)
+            .default_value("VALIDATE"))
+        .arg(Arg::with_name("verbose")
+            .long("verbose")
+            .help("enable/disable verbose mode"))
+        .get_matches();
+
+    let arrow_file = matches.value_of("arrow").expect("must provide path to arrow file");
+    let json_file = matches.value_of("json").expect("must provide path to json file");
+    let mode = matches.value_of("mode").unwrap();
+    let verbose = matches.value_of("verbose").is_some();
+
+    let res = match mode {
+        "JSON_TO_ARROW" => json_to_arrow(json_file, arrow_file, verbose),
+        "ARROW_TO_JSON" => arrow_to_json(arrow_file, json_file, verbose),
+        "VALIDATE" => validate(arrow_file, json_file, verbose),
+        _ => panic!(format!("mode {} not supported", mode)),
+    };
+
+    match res {
+        Ok(_) => (),
+        Err(e) => eprint!("error: {}", e),
+    }
+}
+
+fn json_to_arrow(json_name: &str, arrow_name: &str, _verbose: bool) -> Result<(), String> {
+    let json_file = File::open(json_name).unwrap();
+    let reader = BufReader::new(json_file);
+
+    let arrow_json: Value = serde_json::from_reader(reader).unwrap();
+
+    let schema = Arc::new(Schema::from(&arrow_json["schema"]).unwrap());
+
+    let mut batches = vec![];
+
+    for b in arrow_json["batches"].as_array().unwrap() {
+        let json_batch: ArrowJsonBatch = serde_json::from_value(b.clone()).unwrap();
+        let batch = record_batch_from_json(schema.clone(), json_batch)?;
+        batches.push(batch);
+    }
+
+    let arrow_file = File::create(arrow_name).unwrap();
+    let mut writer = FileWriter::try_new(arrow_file, schema.as_ref()).unwrap();
+
+    for b in batches {
+        writer.write(&b).unwrap();
+    }
+
+    Ok(())
+}
+
+fn record_batch_from_json(schema: Arc<Schema>, json_batch: ArrowJsonBatch) -> Result<RecordBatch, String> {
+    let mut columns= vec![];
+
+    for (field, json_col) in schema.fields().iter().zip(json_batch.columns) {
+        if json_col.data.is_none() {
+            //columns.push(Arc::new(vec![]));
+            continue
+        }
+
+        let col: ArrayRef = match field.data_type() {
+            DataType::Boolean => {
+                let mut b = BooleanBuilder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_bool().unwrap()),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::Int8 => {
+                let mut b = Int8Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_i64().unwrap() as i8),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::Int16 => {
+                let mut b = Int16Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_i64().unwrap() as i16),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::Int32 => {
+                let mut b = Int32Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_i64().unwrap() as i32),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::Int64 => {
+                let mut b = Int64Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_i64().unwrap()),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::UInt8 => {
+                let mut b = UInt8Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_u64().unwrap() as u8),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::UInt16 => {
+                let mut b = UInt16Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_u64().unwrap() as u16),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::UInt32 => {
+                let mut b = UInt32Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_u64().unwrap() as u32),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::UInt64 => {
+                let mut b = UInt64Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_u64().unwrap()),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::Float32 => {
+                let mut b = Float32Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_f64().unwrap() as f32),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::Float64 => {
+                let mut b = Float64Builder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_f64().unwrap()),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::Binary => {
+                let mut b = BinaryBuilder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => {
+                            let v = decode(value.as_str().unwrap()).unwrap();
+                            b.append_value(&v)
+                        },
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::Utf8 => {
+                let mut b = StringBuilder::new(json_col.count);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => b.append_value(value.as_str().unwrap()),
+                        _ => b.append_null(),
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            DataType::FixedSizeBinary(len) => {
+                let mut b = FixedSizeBinaryBuilder::new(json_col.count, *len);
+                for (is_valid, value) in json_col.validity.iter().zip(json_col.data.unwrap()) {
+                    match is_valid {
+                        1 => {
+                            let v = hex::decode(value.as_str().unwrap()).unwrap();
+                            b.append_value(&v)
+                        },
+                        _ => {
+                            b.append_null()
+                        }
+                    }.unwrap();
+                }
+                Arc::new(b.finish())
+            },
+            t => return Err(format!("data type {:?} not supported", t)),
+        };
+        columns.push(col);
+    }
+
+    RecordBatch::try_new(schema, columns).map_err(|e| e.to_string())
+}
+
+fn arrow_to_json(arrow_name: &str, json_name: &str, _verbose: bool) -> Result<(), String> {
+    let arrow_file = File::open(arrow_name).unwrap();
+    let mut reader = FileReader::try_new(arrow_file).unwrap();
+
+    let mut fields = vec![];
+    for f in reader.schema().fields() {
+        fields.push(f.to_json());
+    }
+    let schema = ArrowJsonSchema{ fields };
+
+    let mut batches = vec![];
+    while let Ok(Some(batch)) = reader.next_batch() {
+        batches.push(ArrowJsonBatch::from_batch(&batch));
+    }
+
+    let arrow_json = ArrowJson{
+        schema,
+        batches,
+        dictionaries: None
+    };
+
+    let json_file = File::create(json_name).unwrap();
+    serde_json::to_writer(&json_file, &arrow_json).unwrap();
+
+    Ok(())
+}
+
+fn validate(_arrow_name: &str, _json_name: &str, _verbose: bool) -> Result<(), String> {
+    panic!("validate not implemented");
+}

--- a/rust/arrow/src/bin/arrow-stream-to-file.rs
+++ b/rust/arrow/src/bin/arrow-stream-to-file.rs
@@ -15,7 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub mod bit_util;
-pub mod integration_util;
-pub mod string_writer;
-pub mod test_util;
+extern crate arrow;
+
+fn main() {
+   panic!("not implemented!");
+}

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -19,7 +19,7 @@
 //!
 //! These utilities define structs that read the integration JSON format for integration testing purposes.
 
-use serde_derive::Deserialize;
+use serde_derive::{Deserialize, Serialize};
 use serde_json::{Number as VNumber, Value};
 
 use crate::array::*;
@@ -27,48 +27,48 @@ use crate::datatypes::*;
 use crate::record_batch::{RecordBatch, RecordBatchReader};
 
 /// A struct that represents an Arrow file with a schema and record batches
-#[derive(Deserialize)]
-pub(crate) struct ArrowJson {
-    schema: ArrowJsonSchema,
-    batches: Vec<ArrowJsonBatch>,
-    dictionaries: Option<Vec<ArrowJsonDictionaryBatch>>,
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ArrowJson {
+    pub schema: ArrowJsonSchema,
+    pub batches: Vec<ArrowJsonBatch>,
+    pub dictionaries: Option<Vec<ArrowJsonDictionaryBatch>>,
 }
 
 /// A struct that partially reads the Arrow JSON schema.
 ///
 /// Fields are left as JSON `Value` as they vary by `DataType`
-#[derive(Deserialize)]
-struct ArrowJsonSchema {
-    fields: Vec<Value>,
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ArrowJsonSchema {
+    pub fields: Vec<Value>,
 }
 
 /// A struct that partially reads the Arrow JSON record batch
-#[derive(Deserialize)]
-struct ArrowJsonBatch {
+#[derive(Deserialize, Serialize, Debug)]
+pub struct ArrowJsonBatch {
     count: usize,
-    columns: Vec<ArrowJsonColumn>,
+    pub columns: Vec<ArrowJsonColumn>,
 }
 
 /// A struct that partially reads the Arrow JSON dictionary batch
-#[derive(Deserialize)]
+#[derive(Deserialize, Serialize, Debug)]
 #[allow(non_snake_case)]
-struct ArrowJsonDictionaryBatch {
+pub struct ArrowJsonDictionaryBatch {
     id: i64,
     data: ArrowJsonBatch,
 }
 
 /// A struct that partially reads the Arrow JSON column/array
-#[derive(Deserialize, Clone, Debug)]
-struct ArrowJsonColumn {
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct ArrowJsonColumn {
     name: String,
-    count: usize,
+    pub count: usize,
     #[serde(rename = "VALIDITY")]
-    validity: Vec<u8>,
+    pub validity: Vec<u8>,
     #[serde(rename = "DATA")]
-    data: Option<Vec<Value>>,
+    pub data: Option<Vec<Value>>,
     #[serde(rename = "OFFSET")]
-    offset: Option<Vec<Value>>, // leaving as Value as 64-bit offsets are strings
-    children: Option<Vec<ArrowJsonColumn>>,
+    pub offset: Option<Vec<Value>>, // leaving as Value as 64-bit offsets are strings
+    pub children: Option<Vec<ArrowJsonColumn>>,
 }
 
 impl ArrowJson {
@@ -314,6 +314,57 @@ impl ArrowJsonBatch {
                     t => panic!("Unsupported comparison for {:?}", t),
                 }
             })
+    }
+
+    pub fn from_batch(batch: &RecordBatch) -> ArrowJsonBatch {
+        let mut json_batch = ArrowJsonBatch{
+            count: batch.num_rows(),
+            columns: Vec::with_capacity(batch.num_columns()),
+        };
+
+        for (col, field) in batch.columns().iter().zip(batch.schema().fields.iter()) {
+            let json_col = match field.data_type() {
+                DataType::Int8 => {
+                    let col = col.as_any().downcast_ref::<Int8Array>().unwrap();
+
+                    let mut validity: Vec<u8> = Vec::with_capacity(col.len());
+                    let mut data: Vec<Value> = Vec::with_capacity(col.len());
+
+                    for i in 0..col.len() {
+                        if col.is_null(i) {
+                            validity.push(1);
+                            data.push(Int8Type::default_value().into_json_value().unwrap());
+                        } else {
+                            validity.push(0);
+                            data.push(col.value(i).into_json_value().unwrap());
+                        }
+                    }
+
+                    ArrowJsonColumn{
+                        name: field.name().clone(),
+                        count: col.len(),
+                        validity,
+                        data: Some(data),
+                        offset: None,
+                        children: None
+                    }
+                },
+                _ => {
+                    ArrowJsonColumn{
+                        name: field.name().clone(),
+                        count: col.len(),
+                        validity: vec![],
+                        data: None,
+                        offset: None,
+                        children: None,
+                    }
+                },
+            };
+
+            json_batch.columns.push(json_col);
+        };
+
+        json_batch
     }
 }
 


### PR DESCRIPTION
This isn't even close to being mergable, but I'm hoping to get some additional eyes on this at this point. I have an initial skeleton of the integration test. I started out only implementing part of the `arrow-json-integration-test` executor. I started by trying to get Rust to consume JSON and produce Arrow for the `generated_primitive` test/JSON.

I was only able to build the Go version of things. For some reason none of the docker-compose builds worked for C++ or Java and I was completely unsuccessful getting them to build on OSX Catalina. I figured if Go works then I'd use that as my comparison for now and try to get C++ to build later when I need to hook up the Flight integration test.

On running this with Archery and having Rust producing and Go consuming, it comes up with the following error output from the Go executable when trying to validate the Arrow file produced by Rust:

```
arrow-json:  could not read record 0 from ARROW file: arrow/ipc: invalid file metadata=1580 position for record 0
```

I checked what's being passed to the Rust FileWriter and I think it looks correct (2 record batches with 17 and 20 rows respectively). I can continue digging to see if it's something in the FileWriter, but I wanted to get some feedback on all of this before I go even deeper into this rabbit hole.

So here are a few specific questions:
* Does the structure of this look roughly correct?
* How should I go about troubleshooting and fixing the generated Arrow file that is failing to be read by the Go reader?

Apologies if there is a more preferred way to open up this kind of discussion, any pointers are appreciated. I'd love to contribute to the Rust implementation and get it over the line to be included in the integration tests for release.