### PR TITLE
ARROW-8318: [C++][Dataset] Construct FileSystemDataset from fragments

### DIFF
--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -103,54 +103,51 @@ Result<std::shared_ptr<Dataset>> UnionDatasetFactory::Finish(FinishOptions optio
 }
 
 FileSystemDatasetFactory::FileSystemDatasetFactory(
-    std::shared_ptr<fs::FileSystem> filesystem, fs::PathForest forest,
+    std::vector<std::string> paths, std::shared_ptr<fs::FileSystem> filesystem,
     std::shared_ptr<FileFormat> format, FileSystemFactoryOptions options)
-    : fs_(std::move(filesystem)),
-      forest_(std::move(forest)),
+    : paths_(std::move(paths)),
+      fs_(std::move(filesystem)),
       format_(std::move(format)),
       options_(std::move(options)) {}
 
-bool StartsWithAnyOf(const std::vector<std::string>& prefixes, const std::string& path) {
-  if (prefixes.empty()) {
-    return false;
-  }
-
-  auto basename = fs::internal::GetAbstractPathParent(path).second;
-
-  return std::any_of(prefixes.cbegin(), prefixes.cend(), [&](util::string_view prefix) {
-    return util::string_view(basename).starts_with(prefix);
-  });
+util::optional<util::string_view> FileSystemDatasetFactory::BaselessPath(
+    util::string_view path) {
+  const util::string_view partition_base_dir{options_.partition_base_dir};
+  return fs::internal::RemoveAncestor(partition_base_dir, path);
 }
 
 Result<std::shared_ptr<DatasetFactory>> FileSystemDatasetFactory::Make(
     std::shared_ptr<fs::FileSystem> filesystem, const std::vector<std::string>& paths,
     std::shared_ptr<FileFormat> format, FileSystemFactoryOptions options) {
-  ARROW_ASSIGN_OR_RAISE(auto files, filesystem->GetFileInfo(paths));
-  ARROW_ASSIGN_OR_RAISE(auto forest, fs::PathForest::Make(std::move(files)));
-
-  std::unordered_set<fs::FileInfo, fs::FileInfo::ByPath> missing;
-  DCHECK_OK(forest.Visit([&](fs::PathForest::Ref ref) {
-    util::string_view parent_path = options.partition_base_dir;
-    if (auto parent = ref.parent()) {
-      parent_path = parent.info().path();
+  std::vector<std::string> filtered_paths;
+  for (const auto& path : paths) {
+    if (options.exclude_invalid_files) {
+      ARROW_ASSIGN_OR_RAISE(auto supported,
+                            format->IsSupported(FileSource(path, filesystem)));
+      if (!supported) {
+        continue;
+      }
     }
 
-    for (auto&& path :
-         fs::internal::AncestorsFromBasePath(parent_path, ref.info().path())) {
-      ARROW_ASSIGN_OR_RAISE(auto file, filesystem->GetFileInfo(std::move(path)));
-      missing.insert(std::move(file));
-    }
-    return Status::OK();
-  }));
+    filtered_paths.push_back(path);
+  }
 
-  files = std::move(forest).infos();
-  files.resize(files.size() + missing.size());
-  std::move(missing.begin(), missing.end(), files.end() - missing.size());
+  return std::shared_ptr<DatasetFactory>(
+      new FileSystemDatasetFactory(std::move(filtered_paths), std::move(filesystem),
+                                   std::move(format), std::move(options)));
+}
 
-  ARROW_ASSIGN_OR_RAISE(forest, fs::PathForest::Make(std::move(files)));
+bool StartsWithAnyOf(const std::string& path, const std::vector<std::string>& prefixes) {
+  if (prefixes.empty()) {
+    return false;
+  }
 
-  return std::shared_ptr<DatasetFactory>(new FileSystemDatasetFactory(
-      std::move(filesystem), std::move(forest), std::move(format), std::move(options)));
+  auto parts = fs::internal::SplitAbstractPath(path);
+  return std::any_of(parts.cbegin(), parts.cend(), [&](util::string_view part) {
+    return std::any_of(prefixes.cbegin(), prefixes.cend(), [&](util::string_view prefix) {
+      return util::string_view(part).starts_with(prefix);
+    });
+  });
 }
 
 Result<std::shared_ptr<DatasetFactory>> FileSystemDatasetFactory::Make(
@@ -164,34 +161,29 @@ Result<std::shared_ptr<DatasetFactory>> FileSystemDatasetFactory::Make(
   }
 
   ARROW_ASSIGN_OR_RAISE(auto files, filesystem->GetFileInfo(selector));
-  ARROW_ASSIGN_OR_RAISE(auto forest, fs::PathForest::Make(std::move(files)));
 
-  std::vector<fs::FileInfo> filtered_files;
+  std::vector<std::string> paths;
+  for (const auto& info : files) {
+    const auto& path = info.path();
 
-  RETURN_NOT_OK(forest.Visit([&](fs::PathForest::Ref ref) -> fs::PathForest::MaybePrune {
-    const auto& path = ref.info().path();
-
-    if (StartsWithAnyOf(options.selector_ignore_prefixes, path)) {
-      return fs::PathForest::Prune;
+    if (!info.IsFile()) {
+      // TODO(fsaintjacques): push this filtering into Selector logic so we
+      // don't copy big vector around.
+      continue;
     }
 
-    if (ref.info().IsFile() && options.exclude_invalid_files) {
-      ARROW_ASSIGN_OR_RAISE(auto supported,
-                            format->IsSupported(FileSource(path, filesystem.get())));
-      if (!supported) {
-        return fs::PathForest::Continue;
-      }
+    if (StartsWithAnyOf(path, options.selector_ignore_prefixes)) {
+      continue;
     }
 
-    filtered_files.push_back(std::move(forest.infos()[ref.i]));
-    return fs::PathForest::Continue;
-  }));
+    paths.push_back(path);
+  }
 
-  ARROW_ASSIGN_OR_RAISE(forest,
-                        fs::PathForest::MakeFromPreSorted(std::move(filtered_files)));
+  // Sorting by path guarantees a stability sometimes needed by unit tests.
+  std::sort(paths.begin(), paths.end());
 
-  return std::shared_ptr<DatasetFactory>(new FileSystemDatasetFactory(
-      filesystem, std::move(forest), std::move(format), std::move(options)));
+  return Make(std::move(filesystem), std::move(paths), std::move(format),
+              std::move(options));
 }
 
 Result<std::shared_ptr<Schema>> FileSystemDatasetFactory::PartitionSchema() {
@@ -199,15 +191,14 @@ Result<std::shared_ptr<Schema>> FileSystemDatasetFactory::PartitionSchema() {
     return partitioning->schema();
   }
 
-  std::vector<util::string_view> paths;
-  for (const auto& info : forest_.infos()) {
-    if (auto relative =
-            fs::internal::RemoveAncestor(options_.partition_base_dir, info.path())) {
-      paths.push_back(*relative);
+  std::vector<util::string_view> relative_paths;
+  for (const auto& path : paths_) {
+    if (auto relative = BaselessPath(path)) {
+      relative_paths.push_back(*relative);
     }
   }
 
-  return options_.partitioning.factory()->Inspect(paths);
+  return options_.partitioning.factory()->Inspect(relative_paths);
 }
 
 Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSchemas(
@@ -216,11 +207,9 @@ Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSc
 
   const bool has_fragments_limit = options.fragments >= 0;
   int fragments = options.fragments;
-  for (const auto& f : forest_.infos()) {
-    if (!f.IsFile()) continue;
+  for (const auto& path : paths_) {
     if (has_fragments_limit && fragments-- == 0) break;
-    FileSource src(f.path(), fs_.get());
-    ARROW_ASSIGN_OR_RAISE(auto schema, format_->Inspect(src));
+    ARROW_ASSIGN_OR_RAISE(auto schema, format_->Inspect({path, fs_}));
     schemas.push_back(schema);
   }
 
@@ -246,32 +235,25 @@ Result<std::shared_ptr<Dataset>> FileSystemDatasetFactory::Finish(FinishOptions 
     }
   }
 
-  ExpressionVector partitions(forest_.size(), scalar(true));
   std::shared_ptr<Partitioning> partitioning = options_.partitioning.partitioning();
   if (partitioning == nullptr) {
     auto factory = options_.partitioning.factory();
     ARROW_ASSIGN_OR_RAISE(partitioning, factory->Finish(schema));
   }
 
-  // apply partitioning to forest to derive partitions
-  auto apply_partitioning = [&](fs::PathForest::Ref ref) {
-    if (auto relative = fs::internal::RemoveAncestor(options_.partition_base_dir,
-                                                     ref.info().path())) {
-      auto segments = fs::internal::SplitAbstractPath(relative->to_string());
-
-      if (segments.size() > 0) {
-        auto segment_index = static_cast<int>(segments.size()) - 1;
-        auto maybe_partition = partitioning->Parse(segments.back(), segment_index);
-
-        partitions[ref.i] = std::move(maybe_partition).ValueOr(scalar(true));
-      }
+  FragmentVector fragments;
+  for (const auto& path : paths_) {
+    std::shared_ptr<Expression> partition = scalar(true);
+    if (auto relative = BaselessPath(path)) {
+      std::string path_string{*relative};
+      partition = partitioning->Parse(path_string).ValueOr(scalar(true));
     }
-    return Status::OK();
-  };
 
-  RETURN_NOT_OK(forest_.Visit(apply_partitioning));
-  return FileSystemDataset::Make(schema, root_partition_, format_, fs_, forest_,
-                                 std::move(partitions));
+    ARROW_ASSIGN_OR_RAISE(auto fragment, format_->MakeFragment({path, fs_}, partition));
+    fragments.push_back(fragment);
+  }
+
+  return FileSystemDataset::Make(schema, root_partition_, format_, fragments);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -220,16 +220,20 @@ class ARROW_DS_EXPORT FileSystemDatasetFactory : public DatasetFactory {
   Result<std::shared_ptr<Dataset>> Finish(FinishOptions options) override;
 
  protected:
-  FileSystemDatasetFactory(std::shared_ptr<fs::FileSystem> filesystem,
-                           fs::PathForest forest, std::shared_ptr<FileFormat> format,
+  FileSystemDatasetFactory(std::vector<std::string> paths,
+                           std::shared_ptr<fs::FileSystem> filesystem,
+                           std::shared_ptr<FileFormat> format,
                            FileSystemFactoryOptions options);
 
   Result<std::shared_ptr<Schema>> PartitionSchema();
 
+  std::vector<std::string> paths_;
   std::shared_ptr<fs::FileSystem> fs_;
-  fs::PathForest forest_;
   std::shared_ptr<FileFormat> format_;
   FileSystemFactoryOptions options_;
+
+ private:
+  util::optional<util::string_view> BaselessPath(util::string_view path);
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -233,7 +233,7 @@ class ARROW_DS_EXPORT FileSystemDatasetFactory : public DatasetFactory {
   FileSystemFactoryOptions options_;
 
  private:
-  util::optional<util::string_view> BaselessPath(util::string_view path);
+  util::optional<util::string_view> RemovePartitionBaseDir(util::string_view path);
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -35,7 +35,7 @@ namespace arrow {
 namespace dataset {
 
 Result<std::shared_ptr<arrow::io::RandomAccessFile>> FileSource::Open() const {
-  if (type() == PATH) {
+  if (id() == PATH) {
     return filesystem()->OpenInputFile(path());
   }
 
@@ -47,7 +47,7 @@ Result<std::shared_ptr<arrow::io::OutputStream>> FileSource::OpenWritable() cons
     return Status::Invalid("file source '", path(), "' is not writable");
   }
 
-  if (type() == PATH) {
+  if (id() == PATH) {
     return filesystem()->OpenOutputStream(path());
   }
 
@@ -84,61 +84,38 @@ Result<ScanTaskIterator> FileFragment::Scan(std::shared_ptr<ScanOptions> options
 FileSystemDataset::FileSystemDataset(std::shared_ptr<Schema> schema,
                                      std::shared_ptr<Expression> root_partition,
                                      std::shared_ptr<FileFormat> format,
-                                     std::shared_ptr<fs::FileSystem> filesystem,
-                                     fs::PathForest forest,
-                                     ExpressionVector file_partitions)
+                                     std::vector<std::shared_ptr<FileFragment>> fragments)
     : Dataset(std::move(schema), std::move(root_partition)),
       format_(std::move(format)),
-      filesystem_(std::move(filesystem)),
-      forest_(std::move(forest)),
-      partitions_(std::move(file_partitions)) {
-  DCHECK_EQ(static_cast<size_t>(forest_.size()), partitions_.size());
-}
+      fragments_(std::move(fragments)) {}
 
 Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Make(
     std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-    std::shared_ptr<FileFormat> format, std::shared_ptr<fs::FileSystem> filesystem,
-    std::vector<fs::FileInfo> infos) {
-  ExpressionVector partitions(infos.size(), scalar(true));
-  return Make(std::move(schema), std::move(root_partition), std::move(format),
-              std::move(filesystem), std::move(infos), std::move(partitions));
-}
+    std::shared_ptr<FileFormat> format, FragmentVector fragments) {
+  std::vector<std::shared_ptr<FileFragment>> file_fragments;
+  for (const auto& fragment : fragments) {
+    auto file_fragment = internal::checked_pointer_cast<FileFragment>(fragment);
+    file_fragments.push_back(std::move(file_fragment));
+  }
 
-Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Make(
-    std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-    std::shared_ptr<FileFormat> format, std::shared_ptr<fs::FileSystem> filesystem,
-    std::vector<fs::FileInfo> infos, ExpressionVector partitions) {
-  ARROW_ASSIGN_OR_RAISE(auto forest, fs::PathForest::Make(std::move(infos), &partitions));
-  return Make(std::move(schema), std::move(root_partition), std::move(format),
-              std::move(filesystem), std::move(forest), std::move(partitions));
-}
-
-Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Make(
-    std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-    std::shared_ptr<FileFormat> format, std::shared_ptr<fs::FileSystem> filesystem,
-    fs::PathForest forest, ExpressionVector partitions) {
-  return std::shared_ptr<FileSystemDataset>(new FileSystemDataset(
-      std::move(schema), std::move(root_partition), std::move(format),
-      std::move(filesystem), std::move(forest), std::move(partitions)));
+  return std::shared_ptr<FileSystemDataset>(
+      new FileSystemDataset(std::move(schema), std::move(root_partition),
+                            std::move(format), std::move(file_fragments)));
 }
 
 Result<std::shared_ptr<Dataset>> FileSystemDataset::ReplaceSchema(
     std::shared_ptr<Schema> schema) const {
   RETURN_NOT_OK(CheckProjectable(*schema_, *schema));
-  return std::shared_ptr<Dataset>(
-      new FileSystemDataset(std::move(schema), partition_expression_, format_,
-                            filesystem_, forest_, partitions_));
+  return std::shared_ptr<Dataset>(new FileSystemDataset(
+      std::move(schema), partition_expression_, format_, fragments_));
 }
 
 std::vector<std::string> FileSystemDataset::files() const {
   std::vector<std::string> files;
 
-  DCHECK_OK(forest_.Visit([&](fs::PathForest::Ref ref) {
-    if (ref.info().IsFile()) {
-      files.push_back(ref.info().path());
-    }
-    return Status::OK();
-  }));
+  for (const auto& fragment : fragments_) {
+    files.push_back(fragment->source().path());
+  }
 
   return files;
 }
@@ -146,68 +123,30 @@ std::vector<std::string> FileSystemDataset::files() const {
 std::string FileSystemDataset::ToString() const {
   std::string repr = "FileSystemDataset:";
 
-  if (forest_.size() == 0) {
+  if (fragments_.empty()) {
     return repr + " []";
   }
 
-  DCHECK_OK(forest_.Visit([&](fs::PathForest::Ref ref) {
-    repr += "\n" + ref.info().path();
+  for (const auto& fragment : fragments_) {
+    repr += "\n" + fragment->source().path();
 
-    if (!partitions_[ref.i]->Equals(true)) {
-      repr += ": " + partitions_[ref.i]->ToString();
+    const auto& partition = fragment->partition_expression();
+    if (!partition->Equals(true)) {
+      repr += ": " + partition->ToString();
     }
-
-    return Status::OK();
-  }));
+  }
 
   return repr;
-}
-
-std::shared_ptr<Expression> FoldingAnd(const std::shared_ptr<Expression>& l,
-                                       const std::shared_ptr<Expression>& r) {
-  if (l->Equals(true)) return r;
-  if (r->Equals(true)) return l;
-  return and_(l, r);
 }
 
 FragmentIterator FileSystemDataset::GetFragmentsImpl(
     std::shared_ptr<Expression> predicate) {
   FragmentVector fragments;
 
-  ExpressionVector fragment_partitions(forest_.size());
-
-  auto collect_fragments = [&](fs::PathForest::Ref ref) -> fs::PathForest::MaybePrune {
-    auto partition = partitions_[ref.i];
-
-    // if available, copy parent's filter and projector
-    // (which are appropriately simplified and loaded with default values)
-    if (auto parent = ref.parent()) {
-      fragment_partitions[ref.i] = FoldingAnd(fragment_partitions[parent.i], partition);
-    } else {
-      fragment_partitions[ref.i] = FoldingAnd(partition_expression_, partition);
+  for (const auto& fragment : fragments_) {
+    if (predicate->IsSatisfiableWith(fragment->partition_expression())) {
+      fragments.push_back(fragment);
     }
-
-    auto simplified_predicate = predicate->Assume(partition);
-    if (!simplified_predicate->IsSatisfiable()) {
-      // directories (and descendants) which can't satisfy the filter are pruned
-      return fs::PathForest::Prune;
-    }
-
-    if (ref.info().IsFile()) {
-      // generate a fragment for this file
-      FileSource src(ref.info().path(), filesystem_.get());
-      ARROW_ASSIGN_OR_RAISE(
-          auto fragment,
-          format_->MakeFragment(std::move(src), std::move(fragment_partitions[ref.i])));
-      fragments.push_back(std::move(fragment));
-    }
-
-    return fs::PathForest::Continue;
-  };
-
-  auto status = forest_.Visit(collect_fragments);
-  if (!status.ok()) {
-    return MakeErrorIterator<std::shared_ptr<Fragment>>(status);
   }
 
   return MakeVectorIterator(std::move(fragments));
@@ -221,42 +160,34 @@ Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Write(
     filesystem = std::make_shared<fs::LocalFileSystem>();
   }
 
-  std::vector<fs::FileInfo> files(plan.paths.size());
-  ExpressionVector partition_expressions(plan.paths.size(), scalar(true));
   auto task_group = scan_context->TaskGroup();
-
   auto partition_base_dir = fs::internal::EnsureTrailingSlash(plan.partition_base_dir);
   auto extension = "." + plan.format->type_name();
 
+  FragmentVector fragments;
   for (size_t i = 0; i < plan.paths.size(); ++i) {
     const auto& op = plan.fragment_or_partition_expressions[i];
-    if (util::holds_alternative<std::shared_ptr<Expression>>(op)) {
-      files[i].set_type(fs::FileType::Directory);
-      files[i].set_path(partition_base_dir + plan.paths[i]);
+    if (util::holds_alternative<std::shared_ptr<Fragment>>(op)) {
+      auto path = partition_base_dir + plan.paths[i] + extension;
 
-      partition_expressions[i] = util::get<std::shared_ptr<Expression>>(op);
-    } else {
-      files[i].set_type(fs::FileType::File);
-      files[i].set_path(partition_base_dir + plan.paths[i] + extension);
+      const auto& input_fragment = util::get<std::shared_ptr<Fragment>>(op);
+      FileSource dest(path, filesystem);
 
-      const auto& fragment = util::get<std::shared_ptr<Fragment>>(op);
+      ARROW_ASSIGN_OR_RAISE(
+          auto fragment,
+          plan.format->MakeFragment(dest, input_fragment->partition_expression()));
+      fragments.push_back(std::move(fragment));
 
-      FileSource dest(files[i].path(), filesystem.get());
-      ARROW_ASSIGN_OR_RAISE(auto write_task,
-                            plan.format->WriteFragment(std::move(dest), fragment,
-                                                       scan_options, scan_context));
-
+      ARROW_ASSIGN_OR_RAISE(
+          auto write_task,
+          plan.format->WriteFragment(dest, input_fragment, scan_options, scan_context));
       task_group->Append([write_task] { return write_task->Execute(); });
     }
   }
 
   RETURN_NOT_OK(task_group->Finish());
 
-  ARROW_ASSIGN_OR_RAISE(auto forest, fs::PathForest::MakeFromPreSorted(std::move(files)));
-
-  auto partition_expression = scalar(true);
-  return Make(plan.schema, partition_expression, plan.format, std::move(filesystem),
-              std::move(forest), std::move(partition_expressions));
+  return Make(plan.schema, scalar(true), plan.format, fragments);
 }
 
 Status WriteTask::CreateDestinationParentDir() const {

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -91,16 +91,11 @@ FileSystemDataset::FileSystemDataset(std::shared_ptr<Schema> schema,
 
 Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Make(
     std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-    std::shared_ptr<FileFormat> format, FragmentVector fragments) {
-  std::vector<std::shared_ptr<FileFragment>> file_fragments;
-  for (const auto& fragment : fragments) {
-    auto file_fragment = internal::checked_pointer_cast<FileFragment>(fragment);
-    file_fragments.push_back(std::move(file_fragment));
-  }
-
+    std::shared_ptr<FileFormat> format,
+    std::vector<std::shared_ptr<FileFragment>> fragments) {
   return std::shared_ptr<FileSystemDataset>(
       new FileSystemDataset(std::move(schema), std::move(root_partition),
-                            std::move(format), std::move(file_fragments)));
+                            std::move(format), std::move(fragments)));
 }
 
 Result<std::shared_ptr<Dataset>> FileSystemDataset::ReplaceSchema(
@@ -164,7 +159,7 @@ Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Write(
   auto partition_base_dir = fs::internal::EnsureTrailingSlash(plan.partition_base_dir);
   auto extension = "." + plan.format->type_name();
 
-  FragmentVector fragments;
+  std::vector<std::shared_ptr<FileFragment>> fragments;
   for (size_t i = 0; i < plan.paths.size(); ++i) {
     const auto& op = plan.fragment_or_partition_expressions[i];
     if (util::holds_alternative<std::shared_ptr<Fragment>>(op)) {

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -44,12 +44,12 @@ namespace dataset {
 class ARROW_DS_EXPORT FileSource {
  public:
   // NOTE(kszucs): it'd be better to separate the BufferSource from FileSource
-  enum DatasetType { PATH, BUFFER };
+  enum SourceKind { PATH, BUFFER };
 
-  FileSource(std::string path, fs::FileSystem* filesystem,
+  FileSource(std::string path, std::shared_ptr<fs::FileSystem> filesystem,
              Compression::type compression = Compression::UNCOMPRESSED,
              bool writable = true)
-      : impl_(PathAndFileSystem{std::move(path), filesystem}),
+      : impl_(PathAndFileSystem{std::move(path), std::move(filesystem)}),
         compression_(compression),
         writable_(writable) {}
 
@@ -62,11 +62,11 @@ class ARROW_DS_EXPORT FileSource {
       : impl_(std::move(buffer)), compression_(compression), writable_(true) {}
 
   bool operator==(const FileSource& other) const {
-    if (type() != other.type()) {
+    if (id() != other.id()) {
       return false;
     }
 
-    if (type() == PATH) {
+    if (id() == PATH) {
       return path() == other.path() && filesystem() == other.filesystem();
     }
 
@@ -75,7 +75,7 @@ class ARROW_DS_EXPORT FileSource {
 
   /// \brief The kind of file, whether stored in a filesystem, memory
   /// resident, or other
-  DatasetType type() const { return static_cast<DatasetType>(impl_.index()); }
+  SourceKind id() const { return static_cast<SourceKind>(impl_.index()); }
 
   /// \brief Return the type of raw compression on the file, if any
   Compression::type compression() const { return compression_; }
@@ -87,20 +87,21 @@ class ARROW_DS_EXPORT FileSource {
   /// type is PATH
   const std::string& path() const {
     static std::string buffer_path = "<Buffer>";
-    return type() == PATH ? util::get<PATH>(impl_).path : buffer_path;
+    return id() == PATH ? util::get<PATH>(impl_).path : buffer_path;
   }
 
   /// \brief Return the filesystem, if any. Only non null when file
   /// source type is PATH
-  fs::FileSystem* filesystem() const {
-    return type() == PATH ? util::get<PATH>(impl_).filesystem : NULLPTR;
+  const std::shared_ptr<fs::FileSystem>& filesystem() const {
+    static std::shared_ptr<fs::FileSystem> no_fs = NULLPTR;
+    return id() == PATH ? util::get<PATH>(impl_).filesystem : no_fs;
   }
 
   /// \brief Return the buffer containing the file, if any. Only value
   /// when file source type is BUFFER
   const std::shared_ptr<Buffer>& buffer() const {
     static std::shared_ptr<Buffer> path_buffer = NULLPTR;
-    return type() == BUFFER ? util::get<BUFFER>(impl_) : path_buffer;
+    return id() == BUFFER ? util::get<BUFFER>(impl_) : path_buffer;
   }
 
   /// \brief Get a RandomAccessFile which views this file source
@@ -112,7 +113,7 @@ class ARROW_DS_EXPORT FileSource {
  private:
   struct PathAndFileSystem {
     std::string path;
-    fs::FileSystem* filesystem;
+    std::shared_ptr<fs::FileSystem> filesystem;
   };
 
   util::variant<PathAndFileSystem, std::shared_ptr<Buffer>> impl_;
@@ -184,57 +185,24 @@ class ARROW_DS_EXPORT FileFragment : public Fragment {
 };
 
 /// \brief A Dataset of FileFragments.
+///
+/// A FileSystemDataset is composed of one or more FileFragment. The fragments
+/// are independent and don't need to share the same format and/or filesystem.
 class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
  public:
   /// \brief Create a FileSystemDataset.
   ///
-  /// \param[in] schema the top-level schema of the DataDataset
-  /// \param[in] root_partition the top-level partition of the DataDataset
-  /// \param[in] format file format to create fragments from.
-  /// \param[in] filesystem the filesystem which files are from.
-  /// \param[in] infos a list of files/directories to consume.
-  /// attach additional partition expressions to FileInfo found in `infos`.
+  /// \param[in] schema the schema of the dataset
+  /// \param[in] root_partition the partition expression of the dataset
+  /// \param[in] fragments list of fragments to create the dataset from
   ///
-  /// The caller is not required to provide a complete coverage of nodes and
-  /// partitions.
+  /// Note that all fragment must be of `FileFragment` type. The type are
+  /// erased to simplify callers.
+  ///
+  /// \return A constructed dataset.
   static Result<std::shared_ptr<FileSystemDataset>> Make(
       std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-      std::shared_ptr<FileFormat> format, std::shared_ptr<fs::FileSystem> filesystem,
-      std::vector<fs::FileInfo> infos);
-
-  /// \brief Create a FileSystemDataset with file-level partitions.
-  ///
-  /// \param[in] schema the top-level schema of the DataDataset
-  /// \param[in] root_partition the top-level partition of the DataDataset
-  /// \param[in] format file format to create fragments from.
-  /// \param[in] filesystem the filesystem which files are from.
-  /// \param[in] infos a list of files/directories to consume.
-  /// \param[in] partitions partition information associated with `infos`.
-  /// attach additional partition expressions to FileInfo found in `infos`.
-  ///
-  /// The caller is not required to provide a complete coverage of nodes and
-  /// partitions.
-  static Result<std::shared_ptr<FileSystemDataset>> Make(
-      std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-      std::shared_ptr<FileFormat> format, std::shared_ptr<fs::FileSystem> filesystem,
-      std::vector<fs::FileInfo> infos, ExpressionVector partitions);
-
-  /// \brief Create a FileSystemDataset with file-level partitions.
-  ///
-  /// \param[in] schema the top-level schema of the DataDataset
-  /// \param[in] root_partition the top-level partition of the DataDataset
-  /// \param[in] format file format to create fragments from.
-  /// \param[in] filesystem the filesystem which files are from.
-  /// \param[in] forest a PathForest of files/directories to consume.
-  /// \param[in] partitions partition information associated with `forest`.
-  /// attach additional partition expressions to FileInfo found in `forest`.
-  ///
-  /// The caller is not required to provide a complete coverage of nodes and
-  /// partitions.
-  static Result<std::shared_ptr<FileSystemDataset>> Make(
-      std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-      std::shared_ptr<FileFormat> format, std::shared_ptr<fs::FileSystem> filesystem,
-      fs::PathForest forest, ExpressionVector partitions);
+      std::shared_ptr<FileFormat> format, FragmentVector fragments);
 
   /// \brief Write to a new format and filesystem location, preserving partitioning.
   ///
@@ -245,16 +213,18 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
       const WritePlan& plan, std::shared_ptr<ScanOptions> scan_options,
       std::shared_ptr<ScanContext> scan_context);
 
+  /// \brief Return the type name of the dataset.
   std::string type_name() const override { return "filesystem"; }
 
+  /// \brief Replace the schema of the dataset.
   Result<std::shared_ptr<Dataset>> ReplaceSchema(
       std::shared_ptr<Schema> schema) const override;
 
-  const std::shared_ptr<FileFormat>& format() const { return format_; }
-
+  /// \brief Return the path of files.
   std::vector<std::string> files() const;
 
-  const ExpressionVector& partitions() const { return partitions_; }
+  /// \brief Return the format.
+  const std::shared_ptr<FileFormat>& format() const { return format_; }
 
   std::string ToString() const;
 
@@ -264,13 +234,10 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
   FileSystemDataset(std::shared_ptr<Schema> schema,
                     std::shared_ptr<Expression> root_partition,
                     std::shared_ptr<FileFormat> format,
-                    std::shared_ptr<fs::FileSystem> filesystem, fs::PathForest forest,
-                    ExpressionVector file_partitions);
+                    std::vector<std::shared_ptr<FileFragment>> fragments);
 
   std::shared_ptr<FileFormat> format_;
-  std::shared_ptr<fs::FileSystem> filesystem_;
-  fs::PathForest forest_;
-  ExpressionVector partitions_;
+  std::vector<std::shared_ptr<FileFragment>> fragments_;
 };
 
 /// \brief Write a fragment to a single OutputStream.

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -194,6 +194,7 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
   ///
   /// \param[in] schema the schema of the dataset
   /// \param[in] root_partition the partition expression of the dataset
+  /// \param[in] format the format of each FileFragment.
   /// \param[in] fragments list of fragments to create the dataset from
   ///
   /// Note that all fragment must be of `FileFragment` type. The type are
@@ -202,7 +203,8 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
   /// \return A constructed dataset.
   static Result<std::shared_ptr<FileSystemDataset>> Make(
       std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-      std::shared_ptr<FileFormat> format, FragmentVector fragments);
+      std::shared_ptr<FileFormat> format,
+      std::vector<std::shared_ptr<FileFragment>> fragments);
 
   /// \brief Write to a new format and filesystem location, preserving partitioning.
   ///

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -92,7 +92,7 @@ TEST_F(TestCsvFileFormat, OpenFailureWithRelevantError) {
   ASSERT_OK_AND_ASSIGN(
       auto fs, fs::internal::MockFileSystem::Make(fs::kNoTime, {fs::File(file_name)}));
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr(file_name),
-                                  format_->Inspect({file_name, fs.get()}).status());
+                                  format_->Inspect({file_name, fs}).status());
 }
 
 TEST_F(TestCsvFileFormat, Inspect) {

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -260,7 +260,7 @@ TEST_F(TestParquetFileFormat, OpenFailureWithRelevantError) {
   constexpr auto file_name = "herp/derp";
   ASSERT_OK_AND_ASSIGN(
       auto fs, fs::internal::MockFileSystem::Make(fs::kNoTime, {fs::File(file_name)}));
-  result = format_->Inspect({file_name, fs.get()});
+  result = format_->Inspect({file_name, fs});
   EXPECT_RAISES_WITH_MESSAGE_THAT(IOError, testing::HasSubstr(file_name),
                                   result.status());
 }

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -188,7 +188,11 @@ class ARROW_DS_EXPORT Expression {
   /// This is a shortcut to check if the expression is neither null nor false.
   bool IsSatisfiable() const { return !IsNull() && !Equals(false); }
 
-  bool IsSatisfiableWith(const std::shared_ptr<Expression> other) const {
+  /// Indicates if the expression is satisfiable given an other expression.
+  ///
+  /// This behaves like IsSatisfiable, but it simplifies the current expression
+  /// with the given `other` information.
+  bool IsSatisfiableWith(const std::shared_ptr<Expression>& other) const {
     return Assume(other)->IsSatisfiable();
   }
 

--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -188,6 +188,10 @@ class ARROW_DS_EXPORT Expression {
   /// This is a shortcut to check if the expression is neither null nor false.
   bool IsSatisfiable() const { return !IsNull() && !Equals(false); }
 
+  bool IsSatisfiableWith(const std::shared_ptr<Expression> other) const {
+    return Assume(other)->IsSatisfiable();
+  }
+
   /// returns a debug string representing this expression
   virtual std::string ToString() const = 0;
 

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -300,7 +300,7 @@ struct MakeFileSystemDatasetMixin {
     MakeFileSystem(infos);
     auto format = std::make_shared<DummyFileFormat>();
 
-    FragmentVector fragments;
+    std::vector<std::shared_ptr<FileFragment>> fragments;
     for (size_t i = 0; i < n_fragments; i++) {
       const auto& info = infos[i];
       if (!info.IsFile()) {

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -292,15 +292,28 @@ struct MakeFileSystemDatasetMixin {
   void MakeDataset(const std::vector<fs::FileInfo>& infos,
                    std::shared_ptr<Expression> root_partition = scalar(true),
                    ExpressionVector partitions = {}) {
+    auto n_fragments = infos.size();
     if (partitions.empty()) {
-      partitions.resize(infos.size(), scalar(true));
+      partitions.resize(n_fragments, scalar(true));
     }
 
     MakeFileSystem(infos);
     auto format = std::make_shared<DummyFileFormat>();
-    ASSERT_OK_AND_ASSIGN(
-        dataset_, FileSystemDataset::Make(schema({}), root_partition, format, fs_, infos,
-                                          partitions));
+
+    FragmentVector fragments;
+    for (size_t i = 0; i < n_fragments; i++) {
+      const auto& info = infos[i];
+      if (!info.IsFile()) {
+        continue;
+      }
+
+      ASSERT_OK_AND_ASSIGN(auto fragment,
+                           format->MakeFragment({info.path(), fs_}, partitions[i]));
+      fragments.push_back(std::move(fragment));
+    }
+
+    ASSERT_OK_AND_ASSIGN(dataset_, FileSystemDataset::Make(schema({}), root_partition,
+                                                           format, std::move(fragments)));
   }
 
   void MakeDatasetFromPathlist(const std::string& pathlist,

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -192,6 +192,19 @@ def _apply_options(cmd, options):
               "it will toggle required options")
 @click.option("--with-s3", default=None, type=BOOL,
               help="Build Arrow with S3 support.")
+# Compressions
+@click.option("--with-brotli", default=None, type=BOOL,
+              help="Build Arrow with brotli compression.")
+@click.option("--with-bz2", default=None, type=BOOL,
+              help="Build Arrow with bz2 compression.")
+@click.option("--with-lz4", default=None, type=BOOL,
+              help="Build Arrow with lz4 compression.")
+@click.option("--with-snappy", default=None, type=BOOL,
+              help="Build Arrow with snappy compression.")
+@click.option("--with-zlib", default=None, type=BOOL,
+              help="Build Arrow with zlib compression.")
+@click.option("--with-zstd", default=None, type=BOOL,
+              help="Build Arrow with zstd compression.")
 # CMake extra feature
 @click.option("--cmake-extras", type=str, multiple=True,
               help="Extra flags/options to pass to cmake invocation. "

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -275,8 +275,10 @@ cdef class FileSystemDataset(Dataset):
         cdef:
             FileInfo info
             Expression expr
+            Fragment fragment
             vector[CFileInfo] c_file_infos
             vector[shared_ptr[CExpression]] c_partitions
+            vector[shared_ptr[CFragment]] c_fragments
             CResult[shared_ptr[CDataset]] result
 
         # validate required arguments
@@ -291,20 +293,22 @@ cdef class FileSystemDataset(Dataset):
                     "got {2})".format(name, class_.__name__, type(arg))
                 )
 
-        for info in filesystem.get_file_info(paths_or_selector):
-            c_file_infos.push_back(info.unwrap())
+        infos = filesystem.get_file_info(paths_or_selector)
 
         if partitions is None:
-            partitions = [
-                ScalarExpression(True) for _ in range(c_file_infos.size())]
-        for expr in partitions:
-            c_partitions.push_back(expr.unwrap())
+            partitions = [ScalarExpression(True) for _ in range(len(infos))]
 
-        if c_file_infos.size() != c_partitions.size():
+        if len(infos) != len(partitions):
             raise ValueError(
                 'The number of files resulting from paths_or_selector '
                 'must be equal to the number of partitions.'
             )
+
+        for i, info in enumerate(infos):
+            if info.is_file:
+                fragment = format.make_fragment(info.path, filesystem,
+                                                partitions[i])
+                c_fragments.push_back(fragment.unwrap())
 
         if root_partition is None:
             root_partition = ScalarExpression(True)
@@ -318,9 +322,7 @@ cdef class FileSystemDataset(Dataset):
             pyarrow_unwrap_schema(schema),
             (<Expression> root_partition).unwrap(),
             (<FileFormat> format).unwrap(),
-            (<FileSystem> filesystem).unwrap(),
-            c_file_infos,
-            c_partitions
+            c_fragments
         )
         self.init(GetResultValue(result))
 
@@ -338,6 +340,7 @@ cdef class FileSystemDataset(Dataset):
     def format(self):
         """The FileFormat of this source."""
         return FileFormat.wrap(self.filesystem_dataset.format())
+
 
 cdef shared_ptr[CExpression] _insert_implicit_casts(Expression filter,
                                                     Schema schema) except *:
@@ -393,7 +396,7 @@ cdef class FileFormat:
             shared_ptr[CSchema] c_schema
 
         c_schema = GetResultValue(self.format.Inspect(CFileSource(
-            tobytes(path), filesystem.unwrap().get())))
+            tobytes(path), filesystem.unwrap())))
         return pyarrow_wrap_schema(move(c_schema))
 
     def make_fragment(self, str path not None, FileSystem filesystem not None,
@@ -408,7 +411,7 @@ cdef class FileFormat:
 
         c_fragment = GetResultValue(
             self.format.MakeFragment(CFileSource(tobytes(path),
-                                                 filesystem.unwrap().get()),
+                                                 filesystem.unwrap()),
                                      partition_expression.unwrap()))
         return Fragment.wrap(<shared_ptr[CFragment]> move(c_fragment))
 
@@ -569,7 +572,7 @@ cdef class FileFragment(Fragment):
         """
         cdef:
             shared_ptr[CFileSystem] fs
-        fs = self.file_fragment.source().filesystem().shared_from_this()
+        fs = self.file_fragment.source().filesystem()
         return FileSystem.wrap(fs)
 
     @property
@@ -748,8 +751,7 @@ cdef class ParquetFileFormat(FileFormat):
 
         c_fragment = GetResultValue(
             self.parquet_format.MakeFragment(CFileSource(tobytes(path),
-                                                         filesystem.unwrap()
-                                                         .get()),
+                                                         filesystem.unwrap()),
                                              partition_expression.unwrap(),
                                              move(c_row_groups)))
         return Fragment.wrap(<shared_ptr[CFragment]> move(c_fragment))

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -81,7 +81,7 @@ cdef class FileInfo:
                 return ''
 
         s = '<FileInfo for {!r}: type={}'.format(self.path, str(self.type))
-        if self.type == FileType.File:
+        if self.is_file:
             s += ', size={}'.format(self.size)
         s += '>'
         return s
@@ -107,6 +107,12 @@ cdef class FileInfo:
         return FileType(<int8_t> self.info.type())
 
     @property
+    def is_file(self):
+        """
+        """
+        return self.type == FileType.File
+
+    @property
     def path(self):
         """
         The full file path in the filesystem.
@@ -129,9 +135,7 @@ cdef class FileInfo:
 
         Only regular files are guaranteed to have a size.
         """
-        if self.info.type() != CFileType_File:
-            return None
-        return self.info.size()
+        return self.info.size() if self.is_file else None
 
     @property
     def extension(self):

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -260,7 +260,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             shared_ptr[CSchema] schema,
             shared_ptr[CExpression] source_partition,
             shared_ptr[CFileFormat] format,
-            CFragmentVector fragments)
+            vector[shared_ptr[CFileFragment]] fragments)
         c_string type()
         vector[c_string] files()
         const shared_ptr[CFileFormat]& format() const

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -233,9 +233,9 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CFileSource "arrow::dataset::FileSource":
         const c_string& path() const
-        CFileSystem* filesystem() const
+        const shared_ptr[CFileSystem]& filesystem() const
         const shared_ptr[CBuffer]& buffer() const
-        CFileSource(c_string path, CFileSystem* filesystem)
+        CFileSource(c_string path, shared_ptr[CFileSystem] filesystem)
 
     cdef cppclass CFileFormat "arrow::dataset::FileFormat":
         c_string type_name() const
@@ -260,12 +260,10 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             shared_ptr[CSchema] schema,
             shared_ptr[CExpression] source_partition,
             shared_ptr[CFileFormat] format,
-            shared_ptr[CFileSystem] filesystem,
-            vector[CFileInfo] infos,
-            CExpressionVector partitions)
+            CFragmentVector fragments)
         c_string type()
         vector[c_string] files()
-        const shared_ptr[CFileFormat] format()
+        const shared_ptr[CFileFormat]& format() const
 
     cdef cppclass CParquetFileFormatReaderOptions \
             "arrow::dataset::ParquetFileFormat::ReaderOptions":

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -209,12 +209,14 @@ def test_filesystem_dataset(mockfs):
         paths_or_selector=paths,
         partitions=partitions
     )
+
     assert isinstance(dataset.format, ds.ParquetFileFormat)
 
     # the root_partition and partitions keywords have defaults
     dataset = ds.FileSystemDataset(
         paths, schema, format=file_format, filesystem=mockfs,
     )
+
     assert isinstance(dataset.format, ds.ParquetFileFormat)
 
     # validation of required arguments
@@ -259,9 +261,9 @@ def test_filesystem_dataset(mockfs):
 
     fragments = list(dataset.get_fragments())
     for fragment, partition, path in zip(fragments, partitions, paths):
-        assert fragment.partition_expression.equals(
-            ds.AndExpression(root_partition, partition))
+        assert fragment.partition_expression.equals(partition)
         assert fragment.path == path
+        assert isinstance(fragment.format, ds.ParquetFileFormat)
         assert isinstance(fragment, ds.ParquetFileFragment)
         assert fragment.row_groups is None
 


### PR DESCRIPTION
* Simplified FileSystemDataset to hold a FragmentVector. Each Fragment must be a FileFragment and is checked at `FileSystemDataset::Make`.  Fragments are not required to use the same backing filesystem nor the same format.

* Removed `FileSystemDataset::format` and `FileSystemDataset::partitions`.

* Since FileInfo is not required by neither FileSystemDataset and FileSystemDatasetFactory, it is possible to create a dataset without any IO involved.

* Re-introduced the natural behavior of creating FileFragment with their full partition expressions instead of removing the ancestors common partitions.

* Added `Expression::IsSatisfiableWith` method.

* Added missing compression cmake options to archery.

* Ensure FileSource holds a shared_ptr<FileSystem> pointer. This is required to refactor FileSystemDataset to support Buffer FileSource and heterogeneous FileSystems.

* Rename `type` to `id`, following other classes.