### PR TITLE
ARROW-8447: [C++][Dataset] Ensure row deterministic ordering in Scanner::ToTable

### DIFF
--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -165,23 +165,47 @@ std::shared_ptr<TaskGroup> ScanContext::TaskGroup() const {
   return TaskGroup::MakeSerial();
 }
 
+static inline RecordBatchVector FlattenRecordBatchVector(
+    std::vector<RecordBatchVector> nested_batches) {
+  RecordBatchVector flattened;
+
+  for (auto& task_batches : nested_batches) {
+    for (auto& batch : task_batches) {
+      flattened.emplace_back(std::move(batch));
+    }
+  }
+
+  return flattened;
+}
+
 Result<std::shared_ptr<Table>> Scanner::ToTable() {
   ARROW_ASSIGN_OR_RAISE(auto scan_task_it, Scan());
-  std::mutex mutex;
-  RecordBatchVector batches;
-
   auto task_group = scan_context_->TaskGroup();
 
+  // Protecting mutating accesses to batches
+  std::mutex mutex;
+  std::vector<RecordBatchVector> batches;
+  size_t scan_task_id = 0;
   for (auto maybe_scan_task : scan_task_it) {
     ARROW_ASSIGN_OR_RAISE(auto scan_task, std::move(maybe_scan_task));
 
-    task_group->Append([&batches, &mutex, scan_task] {
+    auto id = scan_task_id++;
+    task_group->Append([&batches, &mutex, id, scan_task] {
       ARROW_ASSIGN_OR_RAISE(auto batch_it, scan_task->Execute());
 
+      RecordBatchVector local;
       for (auto maybe_batch : batch_it) {
         ARROW_ASSIGN_OR_RAISE(auto batch, std::move(maybe_batch));
+        local.emplace_back(std::move(batch));
+      }
+
+      {
+        // Move into global batches.
         std::lock_guard<std::mutex> lock(mutex);
-        batches.emplace_back(std::move(batch));
+        if (batches.size() <= id) {
+          batches.resize(id + 1);
+        }
+        batches[id] = std::move(local);
       }
 
       return Status::OK();
@@ -191,7 +215,8 @@ Result<std::shared_ptr<Table>> Scanner::ToTable() {
   // Wait for all tasks to complete, or the first error.
   RETURN_NOT_OK(task_group->Finish());
 
-  return Table::FromRecordBatches(scan_options_->schema(), std::move(batches));
+  return Table::FromRecordBatches(scan_options_->schema(),
+                                  FlattenRecordBatchVector(batches));
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -306,11 +306,11 @@ class SimpleRecordBatchReader : public RecordBatchReader {
  public:
   SimpleRecordBatchReader(Iterator<std::shared_ptr<RecordBatch>> it,
                           std::shared_ptr<Schema> schema)
-      : schema_(schema), it_(std::move(it)) {}
+      : schema_(std::move(schema)), it_(std::move(it)) {}
 
   SimpleRecordBatchReader(std::vector<std::shared_ptr<RecordBatch>> batches,
                           std::shared_ptr<Schema> schema)
-      : schema_(schema), it_(MakeVectorIterator(std::move(batches))) {}
+      : schema_(std::move(schema)), it_(MakeVectorIterator(std::move(batches))) {}
 
   Status ReadNext(std::shared_ptr<RecordBatch>* batch) override {
     return it_.Next().Value(batch);
@@ -323,7 +323,7 @@ class SimpleRecordBatchReader : public RecordBatchReader {
   Iterator<std::shared_ptr<RecordBatch>> it_;
 };
 
-Result<std::shared_ptr<RecordBatchReader>> MakeRecordBatchReader(
+Result<std::shared_ptr<RecordBatchReader>> RecordBatchReader::Make(
     std::vector<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema) {
   if (schema == nullptr) {
     if (batches.size() == 0 || batches[0] == nullptr) {
@@ -336,10 +336,15 @@ Result<std::shared_ptr<RecordBatchReader>> MakeRecordBatchReader(
   return std::make_shared<SimpleRecordBatchReader>(std::move(batches), schema);
 }
 
+Result<std::shared_ptr<RecordBatchReader>> MakeRecordBatchReader(
+    std::vector<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema) {
+  return RecordBatchReader::Make(std::move(batches), std::move(schema));
+}
+
 Status MakeRecordBatchReader(std::vector<std::shared_ptr<RecordBatch>> batches,
                              std::shared_ptr<Schema> schema,
                              std::shared_ptr<RecordBatchReader>* out) {
-  return MakeRecordBatchReader(std::move(batches), std::move(schema)).Value(out);
+  return RecordBatchReader::Make(std::move(batches), std::move(schema)).Value(out);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -233,18 +233,23 @@ class ARROW_EXPORT RecordBatchReader {
 
   /// \brief Read all batches and concatenate as arrow::Table
   Status ReadAll(std::shared_ptr<Table>* table);
+
+  /// \brief Create a RecordBatchReader from a vector of RecordBatch.
+  ///
+  /// \param[in] batches the vector of RecordBatch to read from
+  /// \param[in] schema schema to conform to. Will be inferred from the first
+  ///            element if not provided.
+  static Result<std::shared_ptr<RecordBatchReader>> Make(
+      std::vector<std::shared_ptr<RecordBatch>> batches,
+      std::shared_ptr<Schema> schema = NULLPTR);
 };
 
-/// \brief Create a RecordBatchReader from a vector of RecordBatch.
-///
-/// \param[in] batches the vector of RecordBatch to read from
-/// \param[in] schema schema to conform to. Will be inferred from the first
-///            element if not provided.
+ARROW_DEPRECATED("Use RecordBatchReader::Make")
 ARROW_EXPORT Result<std::shared_ptr<RecordBatchReader>> MakeRecordBatchReader(
     std::vector<std::shared_ptr<RecordBatch>> batches,
     std::shared_ptr<Schema> schema = NULLPTR);
 
-ARROW_DEPRECATED("Use Result-returning version")
+ARROW_DEPRECATED("Use RecordBatchReader::Make")
 ARROW_EXPORT Status MakeRecordBatchReader(
     std::vector<std::shared_ptr<RecordBatch>> batches, std::shared_ptr<Schema> schema,
     std::shared_ptr<RecordBatchReader>* out);

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -480,6 +480,12 @@ std::shared_ptr<Table> Table::Make(std::shared_ptr<Schema> schema,
   return std::make_shared<SimpleTable>(std::move(schema), arrays, num_rows);
 }
 
+Result<std::shared_ptr<Table>> Table::FromRecordBatchReader(RecordBatchReader* reader) {
+  std::shared_ptr<Table> table = nullptr;
+  RETURN_NOT_OK(reader->ReadAll(&table));
+  return table;
+}
+
 Result<std::shared_ptr<Table>> Table::FromRecordBatches(
     std::shared_ptr<Schema> schema,
     const std::vector<std::shared_ptr<RecordBatch>>& batches) {

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -223,21 +223,29 @@ class ARROW_EXPORT Table {
   virtual ~Table() = default;
 
   /// \brief Construct a Table from schema and columns
+  ///
   /// If columns is zero-length, the table's number of rows is zero
-  /// \param schema The table schema (column types)
-  /// \param columns The table's columns as chunked arrays
-  /// \param num_rows number of rows in table, -1 (default) to infer from columns
+  ///
+  /// \param[in] schema The table schema (column types)
+  /// \param[in] columns The table's columns as chunked arrays
+  /// \param[in] num_rows number of rows in table, -1 (default) to infer from columns
   static std::shared_ptr<Table> Make(std::shared_ptr<Schema> schema,
                                      std::vector<std::shared_ptr<ChunkedArray>> columns,
                                      int64_t num_rows = -1);
 
   /// \brief Construct a Table from schema and arrays
-  /// \param schema The table schema (column types)
-  /// \param arrays The table's columns as arrays
-  /// \param num_rows number of rows in table, -1 (default) to infer from columns
+  ///
+  /// \param[in] schema The table schema (column types)
+  /// \param[in] arrays The table's columns as arrays
+  /// \param[in] num_rows number of rows in table, -1 (default) to infer from columns
   static std::shared_ptr<Table> Make(std::shared_ptr<Schema> schema,
                                      const std::vector<std::shared_ptr<Array>>& arrays,
                                      int64_t num_rows = -1);
+
+  /// \brief Construct a Table from a RecordBatchReader.
+  ///
+  /// \param[in] reader the arrow::Schema for each batch
+  static Result<std::shared_ptr<Table>> FromRecordBatchReader(RecordBatchReader* reader);
 
   /// \brief Construct a Table from RecordBatches, using schema supplied by the first
   /// RecordBatch.

--- a/cpp/src/arrow/testing/generator.h
+++ b/cpp/src/arrow/testing/generator.h
@@ -224,7 +224,7 @@ class ARROW_EXPORT ConstantArrayGenerator {
       int64_t n_batch, const std::shared_ptr<RecordBatch> batch) {
     std::vector<std::shared_ptr<RecordBatch>> batches(static_cast<size_t>(n_batch),
                                                       batch);
-    return *MakeRecordBatchReader(batches);
+    return *RecordBatchReader::Make(batches);
   }
 
   /// \brief Generates a RecordBatchReader of zeroes batches

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -865,12 +865,12 @@ def test_partitioning_function():
         ds.partitioning(schema, flavor="unsupported")
 
 
-def _create_single_file(base_dir, table=None):
+def _create_single_file(base_dir, table=None, row_group_size=None):
     import pyarrow.parquet as pq
     if table is None:
         table = pa.table({'a': range(9), 'b': [0.] * 4 + [1.] * 5})
     path = base_dir / "test.parquet"
-    pq.write_table(table, path)
+    pq.write_table(table, path, row_group_size=row_group_size)
     return table, path
 
 
@@ -887,8 +887,7 @@ def _create_directory_of_files(base_dir):
 
 def _check_dataset(dataset, table):
     assert dataset.schema.equals(table.schema)
-    result = dataset.to_table(use_threads=False)  # deterministic row order
-    assert result.equals(table)
+    assert dataset.to_table().equals(table)
 
 
 def _check_dataset_from_path(path, table, **kwargs):
@@ -911,6 +910,15 @@ def _check_dataset_from_path(path, table, **kwargs):
 @pytest.mark.parquet
 def test_open_dataset_single_file(tempdir):
     table, path = _create_single_file(tempdir)
+    _check_dataset_from_path(path, table)
+
+
+@pytest.mark.parquet
+def test_deterministic_row_order(tempdir):
+    # ARROW-8447 Ensure that dataset.to_table (and Scanner::ToTable) returns a
+    # deterministic row ordering. This is achieved by constructing a single
+    # parquet file with one row per RowGroup.
+    table, path = _create_single_file(tempdir, row_group_size=1)
     _check_dataset_from_path(path, table)
 
 


### PR DESCRIPTION
* This fixes the issue where ScanTask would race to push to the accumulating RecordBatchVector. The new version assign an ordered index to each ScanTask preserving the order in which they were generated by Scanner::Scan.
* Deprecate MakeRecordBatchReader into RecordBatchReader::Make
* Add Table::FromRecordBatchReader