### PR TITLE
ARROW-8659: [Rust] ListBuilder allocate with_capacity

### DIFF
--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -128,7 +128,12 @@ pub struct Utf8ArrayConverter {}
 
 impl Converter<Vec<Option<ByteArray>>, StringArray> for Utf8ArrayConverter {
     fn convert(source: Vec<Option<ByteArray>>) -> Result<StringArray> {
-        let mut builder = StringBuilder::new(source.len());
+        let data_size = source
+            .iter()
+            .map(|x| x.as_ref().map(|b| b.len()).unwrap_or(0))
+            .sum();
+
+        let mut builder = StringBuilder::with_capacity(source.len(), data_size);
         for v in source {
             match v {
                 Some(array) => builder.append_value(array.as_utf8()?),


### PR DESCRIPTION
Both ListBuilder and FixedSizeListBuilder accept a values_builder as a constructor argument and then set the capacity of their internal builders based off the length of this values_builder. Unfortunately at construction time this values_builder is normally empty, and consequently programs spend an unnecessary amount of time reallocating memory.

This PR adds new constructor methods that allow specifying the desired capacity upfront.