### PR TITLE
ARROW-6501: [C++] Remove non_zero_length_ field from SparseIndex class

### DIFF
--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -326,7 +326,7 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
 
 // Constructor with a contiguous NumericTensor
 SparseCOOIndex::SparseCOOIndex(const std::shared_ptr<Tensor>& coords)
-    : SparseIndexBase(coords->shape()[0]), coords_(coords) {
+    : SparseIndexBase(), coords_(coords) {
   ARROW_CHECK_OK(
       CheckSparseCOOIndexValidity(coords_->type(), coords_->shape(), coords_->strides()));
 }
@@ -428,10 +428,7 @@ Result<std::shared_ptr<SparseCSFIndex>> SparseCSFIndex::Make(
 SparseCSFIndex::SparseCSFIndex(const std::vector<std::shared_ptr<Tensor>>& indptr,
                                const std::vector<std::shared_ptr<Tensor>>& indices,
                                const std::vector<int64_t>& axis_order)
-    : SparseIndexBase(indices.back()->size()),
-      indptr_(indptr),
-      indices_(indices),
-      axis_order_(axis_order) {
+    : SparseIndexBase(), indptr_(indptr), indices_(indices), axis_order_(axis_order) {
   ARROW_CHECK_OK(CheckSparseCSFIndexValidity(
       indptr_.front()->type(), indices_.front()->type(), indptr_.size(), indices_.size(),
       indptr_.back()->shape(), indices_.back()->shape(), axis_order_.size()));

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -64,8 +64,7 @@ struct SparseTensorFormat {
 /// format_id must have only one corresponding concrete subclass of SparseIndex.
 class ARROW_EXPORT SparseIndex {
  public:
-  explicit SparseIndex(SparseTensorFormat::type format_id, int64_t non_zero_length)
-      : format_id_(format_id), non_zero_length_(non_zero_length) {}
+  explicit SparseIndex(SparseTensorFormat::type format_id) : format_id_(format_id) {}
 
   virtual ~SparseIndex() = default;
 
@@ -74,7 +73,7 @@ class ARROW_EXPORT SparseIndex {
 
   /// \brief Return the number of non zero values in the sparse tensor related
   /// to this sparse index
-  int64_t non_zero_length() const { return non_zero_length_; }
+  virtual int64_t non_zero_length() const = 0;
 
   /// \brief Return the string representation of the sparse index
   virtual std::string ToString() const = 0;
@@ -82,16 +81,14 @@ class ARROW_EXPORT SparseIndex {
   virtual Status ValidateShape(const std::vector<int64_t>& shape) const;
 
  protected:
-  SparseTensorFormat::type format_id_;
-  int64_t non_zero_length_;
+  const SparseTensorFormat::type format_id_;
 };
 
 namespace internal {
 template <typename SparseIndexType>
 class SparseIndexBase : public SparseIndex {
  public:
-  explicit SparseIndexBase(int64_t non_zero_length)
-      : SparseIndex(SparseIndexType::format_id, non_zero_length) {}
+  SparseIndexBase() : SparseIndex(SparseIndexType::format_id) {}
 };
 }  // namespace internal
 
@@ -130,6 +127,10 @@ class ARROW_EXPORT SparseCOOIndex : public internal::SparseIndexBase<SparseCOOIn
   /// The column at index `i` is a D-tuple of coordinates indicating that the
   /// logical value at those coordinates should be found at physical index `i`.
   const std::shared_ptr<Tensor>& indices() const { return coords_; }
+
+  /// \brief Return the number of non zero values in the sparse tensor related
+  /// to this sparse index
+  int64_t non_zero_length() const override { return coords_->shape()[0]; }
 
   /// \brief Return a string representation of the sparse index
   std::string ToString() const override;
@@ -232,9 +233,7 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
   /// \brief Construct SparseCSXIndex from two index vectors
   explicit SparseCSXIndex(const std::shared_ptr<Tensor>& indptr,
                           const std::shared_ptr<Tensor>& indices)
-      : SparseIndexBase<SparseIndexType>(indices->shape()[0]),
-        indptr_(indptr),
-        indices_(indices) {
+      : SparseIndexBase<SparseIndexType>(), indptr_(indptr), indices_(indices) {
     CheckSparseCSXIndexValidity(indptr_->type(), indices_->type(), indptr_->shape(),
                                 indices_->shape(), SparseIndexType::kTypeName);
   }
@@ -244,6 +243,10 @@ class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
 
   /// \brief Return a 1D tensor of indices vector
   const std::shared_ptr<Tensor>& indices() const { return indices_; }
+
+  /// \brief Return the number of non zero values in the sparse tensor related
+  /// to this sparse index
+  int64_t non_zero_length() const override { return indices_->shape()[0]; }
 
   /// \brief Return a string representation of the sparse index
   std::string ToString() const override {
@@ -390,6 +393,10 @@ class ARROW_EXPORT SparseCSFIndex : public internal::SparseIndexBase<SparseCSFIn
 
   /// \brief Return a 1D vector specifying the order of axes
   const std::vector<int64_t>& axis_order() const { return axis_order_; }
+
+  /// \brief Return the number of non zero values in the sparse tensor related
+  /// to this sparse index
+  int64_t non_zero_length() const override { return indices_.back()->shape()[0]; }
 
   /// \brief Return a string representation of the sparse index
   std::string ToString() const override;


### PR DESCRIPTION
This field is essentially needless, and may be obstacle to the future improvement of sparse tensors, such as adding value inserting feature.