### PR TITLE
ARROW-8663: [Documentation] Small correction to building.rst

### DIFF
--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -124,7 +124,7 @@ Minimal debug build with unit tests:
    make unittest
 
 The unit tests are not built by default. After building, one can also invoke
-the unit tests using the ``ctest`` tool provided by CMake (not that ``test``
+the unit tests using the ``ctest`` tool provided by CMake (note that ``test``
 depends on ``python`` being available).
 
 On some Linux distributions, running the test suite might require setting an


### PR DESCRIPTION
simple typo: not -> note