### PR TITLE
ARROW-8687: [Java] Remove references to io.netty.buffer.ArrowBuf

### DIFF
--- a/java/memory/src/test/java/org/apache/arrow/memory/TestLargeArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestLargeArrowBuf.java
@@ -19,10 +19,8 @@ package org.apache.arrow.memory;
 
 import static org.junit.Assert.assertEquals;
 
-import io.netty.buffer.ArrowBuf;
-
 /**
- * Integration test for large (more than 2GB) {@link io.netty.buffer.ArrowBuf}.
+ * Integration test for large (more than 2GB) {@link org.apache.arrow.memory.ArrowBuf}.
  * To run this test, please make sure there is at least 4GB memory in the system.
  * <p>
  *   Please note that this is not a standard test case, so please run it by manually invoking the

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestNettyAllocationManager.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestNettyAllocationManager.java
@@ -24,8 +24,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import io.netty.buffer.ArrowBuf;
-
 /**
  * Test cases for {@link NettyAllocationManager}.
  */

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestLargeVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestLargeVector.java
@@ -20,13 +20,12 @@ package org.apache.arrow.vector;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 
-import io.netty.buffer.ArrowBuf;
-
 /**
- * Integration test for a vector with a large (more than 2GB) {@link io.netty.buffer.ArrowBuf} as
+ * Integration test for a vector with a large (more than 2GB) {@link org.apache.arrow.memory.ArrowBuf} as
  * the data buffer.
  * To run this test, please make sure there is at least 4GB free memory in the system.
  * <p>

--- a/python/pyarrow/jvm.py
+++ b/python/pyarrow/jvm.py
@@ -30,12 +30,12 @@ import pyarrow as pa
 
 def jvm_buffer(arrowbuf):
     """
-    Construct an Arrow buffer from io.netty.buffer.ArrowBuf
+    Construct an Arrow buffer from org.apache.arrow.memory.ArrowBuf
 
     Parameters
     ----------
 
-    arrowbuf: io.netty.buffer.ArrowBuf
+    arrowbuf: org.apache.arrow.memory.ArrowBuf
         Arrow Buffer representation on the JVM.
 
     Returns


### PR DESCRIPTION
Some references to `io.netty.buffer.ArrowBuf` were missed off
in ARROW-8229. This cleans up the last remaining references.