### PR TITLE
ARROW-8692: [C++] Avoid memory copies when downloading from S3

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -703,10 +703,12 @@ endif()
 
 # - Parquet requires boost only with gcc 4.8 (because of missing std::regex).
 # - Gandiva has a compile-time (header-only) dependency on Boost, not runtime.
-# - Tests and Flight benchmarks need Boost at runtime.
+# - Tests need Boost at runtime.
+# - S3FS and Flight benchmarks need Boost at runtime.
 if(ARROW_BUILD_INTEGRATION
    OR ARROW_BUILD_TESTS
    OR (ARROW_FLIGHT AND ARROW_BUILD_BENCHMARKS)
+   OR (ARROW_S3 AND ARROW_BUILD_BENCHMARKS)
    OR ARROW_GANDIVA
    OR (ARROW_WITH_THRIFT AND Thrift_SOURCE STREQUAL "BUNDLED")
    OR (ARROW_PARQUET

--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -102,9 +102,9 @@ Status ErrorToStatus(const Aws::Client::AWSError<ErrorType>& error) {
   return ErrorToStatus(std::string(), error);
 }
 
-template <typename Result, typename Error>
+template <typename AwsResult, typename Error>
 Status OutcomeToStatus(const std::string& prefix,
-                       const Aws::Utils::Outcome<Result, Error>& outcome) {
+                       const Aws::Utils::Outcome<AwsResult, Error>& outcome) {
   if (outcome.IsSuccess()) {
     return Status::OK();
   } else {
@@ -112,9 +112,9 @@ Status OutcomeToStatus(const std::string& prefix,
   }
 }
 
-template <typename Result, typename Error, typename... Args>
+template <typename AwsResult, typename Error, typename... Args>
 Status OutcomeToStatus(const std::tuple<Args&...>& prefix,
-                       const Aws::Utils::Outcome<Result, Error>& outcome) {
+                       const Aws::Utils::Outcome<AwsResult, Error>& outcome) {
   if (outcome.IsSuccess()) {
     return Status::OK();
   } else {
@@ -122,9 +122,18 @@ Status OutcomeToStatus(const std::tuple<Args&...>& prefix,
   }
 }
 
-template <typename Result, typename Error>
-Status OutcomeToStatus(const Aws::Utils::Outcome<Result, Error>& outcome) {
+template <typename AwsResult, typename Error>
+Status OutcomeToStatus(const Aws::Utils::Outcome<AwsResult, Error>& outcome) {
   return OutcomeToStatus(std::string(), outcome);
+}
+
+template <typename AwsResult, typename Error>
+Result<AwsResult> OutcomeToResult(Aws::Utils::Outcome<AwsResult, Error> outcome) {
+  if (outcome.IsSuccess()) {
+    return std::move(outcome).GetResultWithOwnership();
+  } else {
+    return ErrorToStatus(outcome.GetError());
+  }
 }
 
 inline Aws::String ToAwsString(const std::string& s) {

--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -58,7 +58,8 @@ static const char* kEnvAwsRegion = "ARROW_TEST_S3_REGION";
 class MinioFixture : public benchmark::Fixture {
  public:
   void SetUp(const ::benchmark::State& state) override {
-    ASSERT_OK(minio_.Start());
+    minio_.reset(new MinioTestServer());
+    ASSERT_OK(minio_->Start());
 
     const char* region_str = std::getenv(kEnvAwsRegion);
     if (region_str) {
@@ -77,13 +78,13 @@ class MinioFixture : public benchmark::Fixture {
       std::cerr << "Using default bucket: " << bucket_ << std::endl;
     }
 
-    client_config_.endpointOverride = ToAwsString(minio_.connect_string());
+    client_config_.endpointOverride = ToAwsString(minio_->connect_string());
     client_config_.scheme = Aws::Http::Scheme::HTTP;
     if (!region_.empty()) {
       client_config_.region = ToAwsString(region_);
     }
     client_config_.retryStrategy = std::make_shared<ConnectRetryStrategy>();
-    credentials_ = {ToAwsString(minio_.access_key()), ToAwsString(minio_.secret_key())};
+    credentials_ = {ToAwsString(minio_->access_key()), ToAwsString(minio_->secret_key())};
     bool use_virtual_addressing = false;
     client_.reset(
         new Aws::S3::S3Client(credentials_, client_config_,
@@ -106,12 +107,12 @@ class MinioFixture : public benchmark::Fixture {
   }
 
   void MakeFileSystem() {
-    options_.ConfigureAccessKey(minio_.access_key(), minio_.secret_key());
+    options_.ConfigureAccessKey(minio_->access_key(), minio_->secret_key());
     options_.scheme = "http";
     if (!region_.empty()) {
       options_.region = region_;
     }
-    options_.endpoint_override = minio_.connect_string();
+    options_.endpoint_override = minio_->connect_string();
     ASSERT_OK_AND_ASSIGN(fs_, S3FileSystem::Make(options_));
   }
 
@@ -180,10 +181,14 @@ class MinioFixture : public benchmark::Fixture {
     return Status::OK();
   }
 
-  void TearDown(const ::benchmark::State& state) override { ASSERT_OK(minio_.Stop()); }
+  void TearDown(const ::benchmark::State& state) override {
+    ASSERT_OK(minio_->Stop());
+    // Delete temporary directory, freeing up disk space
+    minio_.reset();
+  }
 
  protected:
-  MinioTestServer minio_;
+  std::unique_ptr<MinioTestServer> minio_;
   std::string region_;
   std::string bucket_;
   Aws::Client::ClientConfiguration client_config_;


### PR DESCRIPTION
The AWS SDK creates a auto-growing StringStream by default, entailing multiple memory copies when transferring large data blocks (because of resizes).  Instead, write directly into the target data area.

Low-level benchmarks with a local Minio server:
* before:
```
-----------------------------------------------------------------------------------------------------
Benchmark                                           Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------------------------
MinioFixture/ReadAll500Mib/real_time        434528630 ns    431461370 ns            2 bytes_per_second=1.1237G/s items_per_second=2.30134/s
MinioFixture/ReadChunked500Mib/real_time    419380389 ns    339293384 ns            2 bytes_per_second=1.16429G/s items_per_second=2.38447/s
MinioFixture/ReadCoalesced500Mib/real_time  258812283 ns       470149 ns            3 bytes_per_second=1.88662G/s items_per_second=3.8638/s
```
* after:
```
MinioFixture/ReadAll500Mib/real_time        194620947 ns    161227337 ns            4 bytes_per_second=2.50888G/s items_per_second=5.13819/s
MinioFixture/ReadChunked500Mib/real_time    276437393 ns    183030215 ns            3 bytes_per_second=1.76634G/s items_per_second=3.61746/s
MinioFixture/ReadCoalesced500Mib/real_time   86693750 ns       448568 ns            6 bytes_per_second=5.63225G/s items_per_second=11.5349/s
```

Parquet read benchmarks from a local Minio server show speedups from 1.1x to 1.9x.
