### PR TITLE
ARROW-8695: [Java] Remove references to PlatformDependent in arrow-memory

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/ByteFunctionHelpers.java
@@ -22,8 +22,6 @@ import org.apache.arrow.memory.BoundsChecking;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.memory.util.hash.SimpleHasher;
 
-import io.netty.util.internal.PlatformDependent;
-
 /**
  * Utility methods for memory comparison at a byte level.
  */
@@ -61,8 +59,8 @@ public class ByteFunctionHelpers {
 
       while (n > 63) {
         for (int x = 0; x < 8; x++) {
-          long leftLong = PlatformDependent.getLong(lPos);
-          long rightLong = PlatformDependent.getLong(rPos);
+          long leftLong = MemoryUtil.UNSAFE.getLong(lPos);
+          long rightLong = MemoryUtil.UNSAFE.getLong(rPos);
           if (leftLong != rightLong) {
             return 0;
           }
@@ -73,8 +71,8 @@ public class ByteFunctionHelpers {
       }
 
       while (n > 7) {
-        long leftLong = PlatformDependent.getLong(lPos);
-        long rightLong = PlatformDependent.getLong(rPos);
+        long leftLong = MemoryUtil.UNSAFE.getLong(lPos);
+        long rightLong = MemoryUtil.UNSAFE.getLong(rPos);
         if (leftLong != rightLong) {
           return 0;
         }
@@ -84,8 +82,8 @@ public class ByteFunctionHelpers {
       }
 
       if (n > 3) {
-        int leftInt = PlatformDependent.getInt(lPos);
-        int rightInt = PlatformDependent.getInt(rPos);
+        int leftInt = MemoryUtil.UNSAFE.getInt(lPos);
+        int rightInt = MemoryUtil.UNSAFE.getInt(rPos);
         if (leftInt != rightInt) {
           return 0;
         }
@@ -95,8 +93,8 @@ public class ByteFunctionHelpers {
       }
 
       while (n-- != 0) {
-        byte leftByte = PlatformDependent.getByte(lPos);
-        byte rightByte = PlatformDependent.getByte(rPos);
+        byte leftByte = MemoryUtil.UNSAFE.getByte(lPos);
+        byte rightByte = MemoryUtil.UNSAFE.getByte(rPos);
         if (leftByte != rightByte) {
           return 0;
         }
@@ -151,8 +149,8 @@ public class ByteFunctionHelpers {
 
     while (n > 63) {
       for (int x = 0; x < 8; x++) {
-        long leftLong = PlatformDependent.getLong(lPos);
-        long rightLong = PlatformDependent.getLong(rPos);
+        long leftLong = MemoryUtil.UNSAFE.getLong(lPos);
+        long rightLong = MemoryUtil.UNSAFE.getLong(rPos);
         if (leftLong != rightLong) {
           return unsignedLongCompare(Long.reverseBytes(leftLong), Long.reverseBytes(rightLong));
         }
@@ -163,8 +161,8 @@ public class ByteFunctionHelpers {
     }
 
     while (n > 7) {
-      long leftLong = PlatformDependent.getLong(lPos);
-      long rightLong = PlatformDependent.getLong(rPos);
+      long leftLong = MemoryUtil.UNSAFE.getLong(lPos);
+      long rightLong = MemoryUtil.UNSAFE.getLong(rPos);
       if (leftLong != rightLong) {
         return unsignedLongCompare(Long.reverseBytes(leftLong), Long.reverseBytes(rightLong));
       }
@@ -174,8 +172,8 @@ public class ByteFunctionHelpers {
     }
 
     if (n > 3) {
-      int leftInt = PlatformDependent.getInt(lPos);
-      int rightInt = PlatformDependent.getInt(rPos);
+      int leftInt = MemoryUtil.UNSAFE.getInt(lPos);
+      int rightInt = MemoryUtil.UNSAFE.getInt(rPos);
       if (leftInt != rightInt) {
         return unsignedIntCompare(Integer.reverseBytes(leftInt), Integer.reverseBytes(rightInt));
       }
@@ -185,8 +183,8 @@ public class ByteFunctionHelpers {
     }
 
     while (n-- != 0) {
-      byte leftByte = PlatformDependent.getByte(lPos);
-      byte rightByte = PlatformDependent.getByte(rPos);
+      byte leftByte = MemoryUtil.UNSAFE.getByte(lPos);
+      byte rightByte = MemoryUtil.UNSAFE.getByte(rPos);
       if (leftByte != rightByte) {
         return ((leftByte & 0xFF) - (rightByte & 0xFF)) > 0 ? 1 : -1;
       }
@@ -258,8 +256,8 @@ public class ByteFunctionHelpers {
     int rPos = rStart;
 
     while (n > 7) {
-      long leftLong = PlatformDependent.getLong(lPos);
-      long rightLong = PlatformDependent.getLong(right, rPos);
+      long leftLong = MemoryUtil.UNSAFE.getLong(lPos);
+      long rightLong = MemoryUtil.UNSAFE.getLong(right, rPos);
       if (leftLong != rightLong) {
         return unsignedLongCompare(Long.reverseBytes(leftLong), Long.reverseBytes(rightLong));
       }
@@ -269,8 +267,8 @@ public class ByteFunctionHelpers {
     }
 
     if (n > 3) {
-      int leftInt = PlatformDependent.getInt(lPos);
-      int rightInt = PlatformDependent.getInt(right, rPos);
+      int leftInt = MemoryUtil.UNSAFE.getInt(lPos);
+      int rightInt = MemoryUtil.UNSAFE.getInt(right, rPos);
       if (leftInt != rightInt) {
         return unsignedIntCompare(Integer.reverseBytes(leftInt), Integer.reverseBytes(rightInt));
       }
@@ -280,7 +278,7 @@ public class ByteFunctionHelpers {
     }
 
     while (n-- != 0) {
-      byte leftByte = PlatformDependent.getByte(lPos);
+      byte leftByte = MemoryUtil.UNSAFE.getByte(lPos);
       byte rightByte = right[rPos];
       if (leftByte != rightByte) {
         return ((leftByte & 0xFF) - (rightByte & 0xFF)) > 0 ? 1 : -1;

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/MurmurHasher.java
@@ -17,10 +17,8 @@
 
 package org.apache.arrow.memory.util.hash;
 
-import static io.netty.util.internal.PlatformDependent.getByte;
-import static io.netty.util.internal.PlatformDependent.getInt;
-
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.util.MemoryUtil;
 
 /**
  * Implementation of the Murmur hashing algorithm.
@@ -90,7 +88,7 @@ public class MurmurHasher implements ArrowBufHasher {
     int index = 0;
     int hash = seed;
     while (index + 4 <= length) {
-      int intValue = getInt(address + index);
+      int intValue = MemoryUtil.UNSAFE.getInt(address + index);
       hash = combineHashCode(hash, intValue);
       index += 4;
     }
@@ -100,7 +98,7 @@ public class MurmurHasher implements ArrowBufHasher {
       int intValue = 0;
       for (int i = index - 1; i >= index; i--) {
         intValue <<= 8;
-        intValue |= (getByte(address + i) & 0x000000ff);
+        intValue |= (MemoryUtil.UNSAFE.getByte(address + i) & 0x000000ff);
         index += 1;
       }
       hash = combineHashCode(hash, intValue);

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/hash/SimpleHasher.java
@@ -17,11 +17,9 @@
 
 package org.apache.arrow.memory.util.hash;
 
-import static io.netty.util.internal.PlatformDependent.getByte;
-import static io.netty.util.internal.PlatformDependent.getInt;
-import static io.netty.util.internal.PlatformDependent.getLong;
 
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.util.MemoryUtil;
 
 /**
  * A simple hasher that calculates the hash code of integers as is,
@@ -58,21 +56,21 @@ public class SimpleHasher implements ArrowBufHasher {
     int hashValue = 0;
     int index = 0;
     while (index + 8 <= length) {
-      long longValue = getLong(address + index);
+      long longValue = MemoryUtil.UNSAFE.getLong(address + index);
       int longHash = getLongHashCode(longValue);
       hashValue = combineHashCode(hashValue, longHash);
       index += 8;
     }
 
     if (index + 4 <= length) {
-      int intValue = getInt(address + index);
+      int intValue = MemoryUtil.UNSAFE.getInt(address + index);
       int intHash = intValue;
       hashValue = combineHashCode(hashValue, intHash);
       index += 4;
     }
 
     while (index < length) {
-      byte byteValue = getByte(address + index);
+      byte byteValue = MemoryUtil.UNSAFE.getByte(address + index);
       int byteHash = byteValue;
       hashValue = combineHashCode(hashValue, byteHash);
       index += 1;


### PR DESCRIPTION
As part of ARROW-8230 we are reducing the usages of Netty inside the arrow-memory module. This step simply removes Netty utils references