### PR TITLE
ARROW-8604: [R][CI] Update CI to use R 4.0

### DIFF
--- a/.env
+++ b/.env
@@ -40,7 +40,7 @@ KARTOTHEK=latest
 HDFS=2.9.2
 SPARK=master
 DOTNET=2.1
-R=3.6
+R=4.0
 ARROW_R_DEV=TRUE
 # These correspond to images on Docker Hub that contain R, e.g. rhub/ubuntu-gcc-release:latest
 R_ORG=rhub

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: [3.6, 4.0]
+        r: ["3.6", "4.0"]
         ubuntu: [18.04]
     env:
       R: ${{ matrix.r }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -168,18 +168,13 @@ jobs:
           cd r/tests
           sed -i.bak -E -e 's/"arrow"/"arrow", reporter = "location"/' testthat.R
           rm -f testthat.R.bak
-      # - name: Fetch Submodules and Tags
-      #   shell: bash
-      #   run: ci/scripts/util_checkout.sh
-      - uses: nealrichardson/actions/setup-r@no-qpdf
+      - uses: r-lib/actions/setup-r@master
         with:
           rtools-version: ${{ matrix.rtools }}
           r-version: '4.0'
           Ncpus: 2
-          qpdf: false
       - name: Build Arrow C++
         run: |
-          C:\rtools40\usr\bin\pacman --noconfirm -Syyu
           C:\rtools40\usr\bin\bash --login -c "cd /d/a/arrow/arrow && ci/scripts/r_windows_build.sh"
       - uses: actions/upload-artifact@v1
         with:
@@ -204,3 +199,5 @@ jobs:
             error_on = 'warning',
             check_dir = 'check'
           )
+      - name: Dump install logs
+        run: cat r/check/arrow.Rcheck/00install.out

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -104,8 +104,8 @@ jobs:
         r_image:
           - centos7
     env:
-      R_ORG: "rstudio"
-      R_IMAGE: "r-base"
+      R_ORG: rstudio
+      R_IMAGE: r-base
       R_TAG: ${{ matrix.r_version }}-${{ matrix.r_image }}
     steps:
       - name: Checkout Arrow

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -168,9 +168,9 @@ jobs:
           cd r/tests
           sed -i.bak -E -e 's/"arrow"/"arrow", reporter = "location"/' testthat.R
           rm -f testthat.R.bak
-      - name: Fetch Submodules and Tags
-        shell: bash
-        run: ci/scripts/util_checkout.sh
+      # - name: Fetch Submodules and Tags
+      #   shell: bash
+      #   run: ci/scripts/util_checkout.sh
       - uses: r-lib/actions/setup-r@master
         with:
           rtools-version: ${{ matrix.rtools }}
@@ -178,7 +178,7 @@ jobs:
       - name: Build Arrow C++
         run: |
           C:\rtools40\usr\bin\pacman --noconfirm -Syyu
-          C:\rtools40\usr\bin\bash --login -c "pwd && printenv"
+          C:\rtools40\usr\bin\bash --login -c "cd $GITHUB_WORKSPACE && pwd && ls && printenv"
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -176,7 +176,9 @@ jobs:
           rtools-version: ${{ matrix.rtools }}
           r-version: '4.0'
       - name: Build Arrow C++
-        run: C:/rtools40/usr/bin/bash --login -c "cd $GITHUB_WORKSPACE && ci/scripts/r_windows_build.sh"
+        run: |
+          C:\rtools40\usr\bin\pacman --noconfirm -Syyu
+          C:\rtools40\usr\bin\bash --login -c "$(cygpath ${GITHUB_WORKSPACE})/ci/scripts/r_windows_build.sh"
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -176,7 +176,7 @@ jobs:
           rtools-version: ${{ matrix.rtools }}
           r-version: '4.0'
       - name: Build Arrow C++
-        run: C:/rtools40/usr/bin/bash --login -c ci/scripts/r_windows_build.sh
+        run: C:/rtools40/usr/bin/bash --login -c "cd $GITHUB_WORKSPACE && ci/scripts/r_windows_build.sh"
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         # See https://hub.docker.com/r/rstudio/r-base
-        r_version: ["3.6"]
+        r_version: ["3.6", "4.0"]
         r_image:
           - centos7
     env:
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rtools: [35, 40]
+        rtools: [35]
     env:
       TEST_R_WITH_ARROW: "TRUE"
       ARROW_R_CXXFLAGS: '-Werror'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -168,8 +168,8 @@ jobs:
           cd r/tests
           sed -i.bak -E -e 's/"arrow"/"arrow", reporter = "location"/' testthat.R
           rm -f testthat.R.bak
-      # We use the makepkg-mingw setup that is included in rtools40
-      # even when we use the rtools35 compilers
+      # We use the makepkg-mingw setup that is included in rtools40 even when
+      # we use the rtools35 compilers, so we always install R 4.0/Rtools40
       - uses: r-lib/actions/setup-r@master
         with:
           rtools-version: 40

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Build Arrow C++
         run: |
           C:\rtools40\usr\bin\pacman --noconfirm -Syyu
-          C:\rtools40\usr\bin\bash --login -c "${GITHUB_WORKSPACE}/ci/scripts/r_windows_build.sh"
+          C:\rtools40\usr\bin\bash --login -c "pwd && printenv"
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Build Arrow C++
         run: |
           C:\rtools40\usr\bin\pacman --noconfirm -Syyu
-          C:\rtools40\usr\bin\bash --login -c "$(cygpath ${GITHUB_WORKSPACE})/ci/scripts/r_windows_build.sh"
+          C:\rtools40\usr\bin\bash --login -c "${GITHUB_WORKSPACE}/ci/scripts/r_windows_build.sh"
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Build Arrow C++
         run: |
           C:\rtools40\usr\bin\pacman --noconfirm -Syyu
-          C:\rtools40\usr\bin\bash --login -c "cd $GITHUB_WORKSPACE && pwd && ls && printenv"
+          C:\rtools40\usr\bin\bash --login -c "cd $OLDPWD && pwd && ls && printenv"
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -171,10 +171,12 @@ jobs:
       # - name: Fetch Submodules and Tags
       #   shell: bash
       #   run: ci/scripts/util_checkout.sh
-      - uses: r-lib/actions/setup-r@master
+      - uses: nealrichardson/actions/setup-r@no-qpdf
         with:
           rtools-version: ${{ matrix.rtools }}
           r-version: '4.0'
+          Ncpus: 2
+          qpdf: false
       - name: Build Arrow C++
         run: |
           C:\rtools40\usr\bin\pacman --noconfirm -Syyu

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -209,4 +209,4 @@ jobs:
           )
       - name: Dump install logs
         shell: cmd
-        run: cat r/check/arrow.Rcheck/00install.out
+        run: cat check/arrow.Rcheck/00install.out

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -148,16 +148,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rtools: [35]
+        rtools: [40]
     env:
       TEST_R_WITH_ARROW: "TRUE"
       ARROW_R_CXXFLAGS: '-Werror'
       _R_CHECK_TESTS_NLINES_: 0
     steps:
       - run: git config --global core.autocrlf false
-      - uses: numworks/setup-msys2@v1
-        with:
-          update: true
       - name: Checkout Arrow
         uses: actions/checkout@v2
         with:
@@ -177,9 +174,9 @@ jobs:
       - uses: r-lib/actions/setup-r@master
         with:
           rtools-version: ${{ matrix.rtools }}
-          r-version: '3.6'
+          r-version: '4.0'
       - name: Build Arrow C++
-        run: msys2do ci/scripts/r_windows_build.sh
+        run: C:/rtools40/usr/bin/bash --login -c ci/scripts/r_windows_build.sh
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Build Arrow C++
         run: |
           C:\rtools40\usr\bin\pacman --noconfirm -Syyu
-          C:\rtools40\usr\bin\bash --login -c "pwd && cd /d/a/arrow/arrow && pwd"
+          C:\rtools40\usr\bin\bash --login -c "cd /d/a/arrow/arrow && ci/scripts/r_windows_build.sh"
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -46,14 +46,18 @@ env:
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
-
   ubuntu:
-    name: AMD64 Ubuntu 18.04 R 3.6
+    name: AMD64 Ubuntu ${{ matrix.ubuntu }} R ${{ matrix.r }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        r: [3.6, 4.0]
+        ubuntu: [18.04]
     env:
-      R: '3.6'
-      UBUNTU: '18.04'
+      R: ${{ matrix.r }}
+      UBUNTU: ${{ matrix.ubuntu }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2
@@ -67,8 +71,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .docker
-          key: ubuntu-18.04-r-3.6-${{ hashFiles('cpp/**') }}
-          restore-keys: ubuntu-18.04-r-3.6-
+          key: ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-${{ hashFiles('cpp/**') }}
+          restore-keys: ubuntu-${{ matrix.ubuntu }}-r-${{ matrix.r }}-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -89,13 +93,20 @@ jobs:
         run: archery docker push ubuntu-r
 
   rstudio:
-    name: AMD64 CentOS 7 RStudio R 3.6
+    name: "rstudio/r-base:${{ matrix.r_version }}-${{ matrix.r_image }}"
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # See https://hub.docker.com/r/rstudio/r-base
+        r_version: ["3.6"]
+        r_image:
+          - centos7
     env:
-      R_ORG: rstudio
-      R_IMAGE: r-base
-      R_TAG: 3.6-centos7
+      R_ORG: "rstudio"
+      R_IMAGE: "r-base"
+      R_TAG: ${{ matrix.r_version }}-${{ matrix.r_image }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2
@@ -109,8 +120,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .docker
-          key: centos-7-r-${{ hashFiles('cpp/**') }}
-          restore-keys: centos-7-r-
+          key: ${{ matrix.r_image }}-r-${{ hashFiles('cpp/**') }}
+          restore-keys: ${{ matrix.r_image }}-r-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -137,8 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: test on rtools40
-        rtools: [35]
+        rtools: [35, 40]
     env:
       TEST_R_WITH_ARROW: "TRUE"
       ARROW_R_CXXFLAGS: '-Werror'
@@ -172,7 +182,7 @@ jobs:
         run: msys2do ci/scripts/r_windows_build.sh
       - uses: actions/upload-artifact@v1
         with:
-          name: Rtools Arrow C++
+          name: Rtools ${{ matrix.rtools }} Arrow C++
           path: libarrow.zip
       - name: Install R package dependencies
         shell: Rscript {0}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -176,7 +176,7 @@ jobs:
           r-version: '4.0'
           Ncpus: 2
       - uses: r-lib/actions/setup-r@master
-        if: ${{ matrix.rtools }} == 35
+        if: ${{ matrix.rtools == 35 }}
         with:
           rtools-version: 35
           r-version: '3.6'

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rtools: [40]
+        rtools: [35, 40]
     env:
       TEST_R_WITH_ARROW: "TRUE"
       ARROW_R_CXXFLAGS: '-Werror'
@@ -168,14 +168,22 @@ jobs:
           cd r/tests
           sed -i.bak -E -e 's/"arrow"/"arrow", reporter = "location"/' testthat.R
           rm -f testthat.R.bak
+      # We use the makepkg-mingw setup that is included in rtools40
+      # even when we use the rtools35 compilers
       - uses: r-lib/actions/setup-r@master
         with:
-          rtools-version: ${{ matrix.rtools }}
+          rtools-version: 40
           r-version: '4.0'
+          Ncpus: 2
+      - uses: r-lib/actions/setup-r@master
+        if: ${{ matrix.rtools }} == 35
+        with:
+          rtools-version: 35
+          r-version: '3.6'
           Ncpus: 2
       - name: Build Arrow C++
         run: |
-          C:\rtools40\usr\bin\bash --login -c "cd /d/a/arrow/arrow && ci/scripts/r_windows_build.sh"
+          C:\rtools40\usr\bin\bash --login -c "export RTOOLS_VERSION=${{ matrix.rtools }} && cd /d/a/arrow/arrow && ci/scripts/r_windows_build.sh"
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++
@@ -200,4 +208,5 @@ jobs:
             check_dir = 'check'
           )
       - name: Dump install logs
+        shell: cmd
         run: cat r/check/arrow.Rcheck/00install.out

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Build Arrow C++
         run: |
           C:\rtools40\usr\bin\pacman --noconfirm -Syyu
-          C:\rtools40\usr\bin\bash --login -c "cd $OLDPWD && pwd && ls && printenv"
+          C:\rtools40\usr\bin\bash --login -c "pwd && cd /d/a/arrow/arrow && pwd"
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -30,10 +30,13 @@ RUN apt-get update -y && \
     apt-key adv \
         --keyserver keyserver.ubuntu.com \
         --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
-    # NOTE: as of 2019-12, R 3.5 and 3.6 are available in the repos with -cran35 suffix
+    # NOTE: R 3.5 and 3.6 are available in the repos with -cran35 suffix
+    # for trusty, xenial, bionic, and eoan (as of May 2020)
+    # -cran40 has 4.0 versions for bionic and focal
     # R 3.2, 3.3, 3.4 are available without the suffix but only for trusty and xenial
     # TODO: make sure OS version and R version are valid together and conditionally set repo suffix
-    add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu '$(lsb_release -cs)'-cran35/' && \
+    # This is a hack to turn 3.6 into 35 and 4.0 into 40:
+    add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu '$(lsb_release -cs)'-cran'$(echo "${r}" | tr -d . | tr 6 5)'/' && \
     apt-get install -y \
         r-base=${r}* \
         # system libs needed by core R packages

--- a/ci/docker/ubuntu-18.04-r-sanitizer.dockerfile
+++ b/ci/docker/ubuntu-18.04-r-sanitizer.dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update -y -q && \
 # and use pre-built binaries where possible
 RUN printf "\
     options(Ncpus = parallel::detectCores(), \
-            repos = 'https://demo.rstudiopm.com/all/__linux__/bionic/latest', \
+            repos = 'https://packagemanager.rstudio.com/cran/__linux__/bionic/latest', \
             HTTPUserAgent = sprintf(\
                 'R/%%s R (%%s)', getRversion(), \
                 paste(getRversion(), R.version\$platform, R.version\$arch, R.version\$os)))\n" \

--- a/ci/etc/rprofile
+++ b/ci/etc/rprofile
@@ -1,6 +1,6 @@
 .pick_cran <- function() {
   # Return a CRAN repo URL, preferring RSPM binaries if available for this OS
-  rspm_template <- "https://demo.rstudiopm.com/all/__linux__/%s/latest"
+  rspm_template <- "https://packagemanager.rstudio.com/cran/__linux__/%s/latest"
   supported_os <- c("xenial", "bionic", "centos7", "opensuse42", "opensuse15")
 
   if (nzchar(Sys.which("lsb_release"))) {

--- a/ci/scripts/PKGBUILD
+++ b/ci/scripts/PKGBUILD
@@ -64,14 +64,14 @@ build() {
 
   # This is the difference between rtools-packages and rtools-backports
   # Remove this when submitting to rtools-packages
-  if [ "$RTOOLS_BACKPORTS" = "true" ]; then
+  if [ "$RTOOLS_VERSION" = "35" ]; then
     export CC="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/gcc"
     export CXX="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/g++"
     export PATH="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin:$PATH"
     export CPPFLAGS="-I${MINGW_PREFIX}/include"
     export LIBS="-L${MINGW_PREFIX}/libs"
   fi
-  
+
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
     ${ARROW_CPP_DIR} \

--- a/ci/scripts/PKGBUILD
+++ b/ci/scripts/PKGBUILD
@@ -64,12 +64,14 @@ build() {
 
   # This is the difference between rtools-packages and rtools-backports
   # Remove this when submitting to rtools-packages
-  export CC="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/gcc"
-  export CXX="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/g++"
-  export PATH="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin:$PATH"
-  export CPPFLAGS="-I${MINGW_PREFIX}/include"
-  export LIBS="-L${MINGW_PREFIX}/libs"
-
+  if [ "$RTOOLS_BACKPORTS" = "true" ]; then
+    export CC="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/gcc"
+    export CXX="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin/g++"
+    export PATH="/C/Rtools${MINGW_PREFIX/mingw/mingw_}/bin:$PATH"
+    export CPPFLAGS="-I${MINGW_PREFIX}/include"
+    export LIBS="-L${MINGW_PREFIX}/libs"
+  fi
+  
   MSYS2_ARG_CONV_EXCL="-DCMAKE_INSTALL_PREFIX=" \
     ${MINGW_PREFIX}/bin/cmake.exe \
     ${ARROW_CPP_DIR} \

--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -60,7 +60,7 @@ ${R_BIN} -e "as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
   }"
 
 AFTER=$(ls -alh ~/)
-if [ "$BEFORE" != "$AFTER" ]; then
+if [ "$NOT_CRAN" != "true" ] && [ "$BEFORE" != "$AFTER" ]; then
   ls -alh ~/.cmake/packages
   exit 1
 fi

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -28,8 +28,6 @@ export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 # pacman --noconfirm -Scc
 # pacman --noconfirm -Syyu
 
-gcc --version
-
 cp $ARROW_HOME/ci/scripts/PKGBUILD .
 printenv
 makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --cleanbuild

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -22,13 +22,16 @@ set -ex
 : ${ARROW_HOME:=$(pwd)}
 # Make sure it is absolute and exported
 export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
-export PATH="/c/rtools40/usr/bin:$PATH"
 
 if [ "$RTOOLS_BACKPORTS" = "true" ]; then
   # Use rtools-backports if building with rtools35
   curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
   pacman --noconfirm -Scc
   pacman --noconfirm -Syyu
+  # lib-4.9.3 is for libraries compiled with gcc 4.9 (Rtools 3.5)
+  RWINLIB_LIB_DIR="lib-4.9.3"
+else
+  RWINLIB_LIB_DIR="lib"
 fi
 
 cp $ARROW_HOME/ci/scripts/PKGBUILD .
@@ -58,20 +61,20 @@ mv mingw64/include $DST_DIR
 
 # Make the rest of the directory structure
 # lib-4.9.3 is for libraries compiled with gcc 4.9 (Rtools 3.5)
-mkdir -p $DST_DIR/lib-4.9.3/x64
-mkdir -p $DST_DIR/lib-4.9.3/i386
+mkdir -p $DST_DIR/${RWINLIB_LIB_DIR}/x64
+mkdir -p $DST_DIR/${RWINLIB_LIB_DIR}/i386
 # lib is for the new gcc 8 toolchain (Rtools 4.0)
 mkdir -p $DST_DIR/lib/x64
 mkdir -p $DST_DIR/lib/i386
 
 # Move the 64-bit versions of libarrow into the expected location
-mv mingw64/lib/*.a $DST_DIR/lib-4.9.3/x64
+mv mingw64/lib/*.a $DST_DIR/${RWINLIB_LIB_DIR}/x64
 # Same for the 32-bit versions
-mv mingw32/lib/*.a $DST_DIR/lib-4.9.3/i386
+mv mingw32/lib/*.a $DST_DIR/${RWINLIB_LIB_DIR}/i386
 
-# These are from https://dl.bintray.com/rtools/backports/
-cp $MSYS_LIB_DIR/mingw64/lib/lib{thrift,snappy}.a $DST_DIR/lib-4.9.3/x64
-cp $MSYS_LIB_DIR/mingw32/lib/lib{thrift,snappy}.a $DST_DIR/lib-4.9.3/i386
+# These may be from https://dl.bintray.com/rtools/backports/
+cp $MSYS_LIB_DIR/mingw64/lib/lib{thrift,snappy}.a $DST_DIR/${RWINLIB_LIB_DIR}/x64
+cp $MSYS_LIB_DIR/mingw32/lib/lib{thrift,snappy}.a $DST_DIR/${RWINLIB_LIB_DIR}/i386
 
 # These are from https://dl.bintray.com/rtools/mingw{32,64}/
 cp $MSYS_LIB_DIR/mingw64/lib/lib{zstd,lz4,crypto}.a $DST_DIR/lib/x64

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -39,7 +39,7 @@ pacman --noconfirm --needed -S mingw-w64-{i686,x86_64}-{toolchain,crt,winpthread
 # Force static linking
 rm -f /mingw32/lib/*.dll.a
 rm -f /mingw64/lib/*.dll.a
-export PKG_CONFIG="/${MINGW_PREFIX}/bin/pkg-config --static"
+export PKG_CONFIG="C:/rtools40/usr/bin/pkg-config --static"
 
 cp $ARROW_HOME/ci/scripts/PKGBUILD .
 export PKGEXT='.pkg.tar.xz' # pacman default changed to .zst in 2020, but keep the old ext for compat
@@ -56,7 +56,7 @@ cp mingw* build
 cd build
 
 # This may vary by system/CI provider
-MSYS_LIB_DIR="D:/a/_temp/msys/msys64"
+MSYS_LIB_DIR="C:/rtools40"
 
 ls $MSYS_LIB_DIR/mingw64/lib/
 ls $MSYS_LIB_DIR/mingw32/lib/
@@ -74,6 +74,9 @@ mkdir -p $DST_DIR/lib-4.9.3/i386
 # lib is for the new gcc 8 toolchain (Rtools 4.0)
 mkdir -p $DST_DIR/lib/x64
 mkdir -p $DST_DIR/lib/i386
+
+echo gcc --version
+echo "$(subst gcc,,$(COMPILED_BY))"
 
 # Move the 64-bit versions of libarrow into the expected location
 mv mingw64/lib/*.a $DST_DIR/lib-4.9.3/x64

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -28,7 +28,11 @@ export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 
 # msys64: remove preinstalled toolchains and switch to rtools40 repositories
 pacman --noconfirm -Rcsu mingw-w64-{i686,x86_64}-toolchain
-curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
+# Use rtools-backports if building with rtools35
+curl https://raw.githubusercontent.com/r-windows/rtools-packages/master/pacman.conf > /etc/pacman.conf
+
+echo gcc --version
+echo "$(subst gcc,,$(COMPILED_BY))"
 
 pacman --noconfirm -Scc
 pacman --noconfirm -Syyu
@@ -75,9 +79,6 @@ mkdir -p $DST_DIR/lib-4.9.3/i386
 # lib is for the new gcc 8 toolchain (Rtools 4.0)
 mkdir -p $DST_DIR/lib/x64
 mkdir -p $DST_DIR/lib/i386
-
-echo gcc --version
-echo "$(subst gcc,,$(COMPILED_BY))"
 
 # Move the 64-bit versions of libarrow into the expected location
 mv mingw64/lib/*.a $DST_DIR/lib-4.9.3/x64

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -22,6 +22,7 @@ set -ex
 : ${ARROW_HOME:=$(pwd)}
 # Make sure it is absolute and exported
 export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
+export PATH="/c/rtools40/usr/bin:$PATH"
 
 # Use rtools-backports if building with rtools35
 # curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
@@ -42,7 +43,7 @@ cp mingw* build
 cd build
 
 # This may vary by system/CI provider
-MSYS_LIB_DIR="C:/rtools40"
+MSYS_LIB_DIR="/c/rtools40"
 
 ls $MSYS_LIB_DIR/mingw64/lib/
 ls $MSYS_LIB_DIR/mingw32/lib/

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -27,7 +27,7 @@ export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 # pacman --sync --noconfirm ccache
 
 # msys64: remove preinstalled toolchains and switch to rtools40 repositories
-pacman --noconfirm -Rcsu mingw-w64-{i686,x86_64}-toolchain gcc pkg-config
+pacman --noconfirm -Rcsu mingw-w64-{i686,x86_64}-toolchain
 curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
 
 pacman --noconfirm -Scc

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -26,8 +26,7 @@ export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 # ccache may be broken on MinGW.
 # pacman --sync --noconfirm ccache
 
-wget https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf
-cp -f pacman.conf /etc/pacman.conf
+curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
 
 pacman --noconfirm -Scc
 pacman --noconfirm -Syyu

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -23,7 +23,7 @@ set -ex
 # Make sure it is absolute and exported
 export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 
-if [ "$RTOOLS_BACKPORTS" = "true" ]; then
+if [ "$RTOOLS_VERSION" = "35" ]; then
   # Use rtools-backports if building with rtools35
   curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
   pacman --noconfirm -Scc

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -24,10 +24,12 @@ set -ex
 export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 export PATH="/c/rtools40/usr/bin:$PATH"
 
-# Use rtools-backports if building with rtools35
-# curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
-# pacman --noconfirm -Scc
-# pacman --noconfirm -Syyu
+if [ "$RTOOLS_BACKPORTS" = "true" ]; then
+  # Use rtools-backports if building with rtools35
+  curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
+  pacman --noconfirm -Scc
+  pacman --noconfirm -Syyu
+fi
 
 cp $ARROW_HOME/ci/scripts/PKGBUILD .
 printenv

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -23,31 +23,14 @@ set -ex
 # Make sure it is absolute and exported
 export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 
-# ccache may be broken on MinGW.
-# pacman --sync --noconfirm ccache
-
-# msys64: remove preinstalled toolchains and switch to rtools40 repositories
-pacman --noconfirm -Rcsu mingw-w64-{i686,x86_64}-toolchain
 # Use rtools-backports if building with rtools35
-curl https://raw.githubusercontent.com/r-windows/rtools-packages/master/pacman.conf > /etc/pacman.conf
+# curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
+# pacman --noconfirm -Scc
+# pacman --noconfirm -Syyu
 
-echo gcc --version
-echo "$(subst gcc,,$(COMPILED_BY))"
-
-pacman --noconfirm -Scc
-pacman --noconfirm -Syyu
-pacman --noconfirm --needed -S git base-devel binutils zip
-
-# Install core build stuff
-pacman --noconfirm --needed -S mingw-w64-{i686,x86_64}-{toolchain,crt,winpthreads,gcc,libtre,pkg-config,xz}
-
-# Force static linking
-rm -f /mingw32/lib/*.dll.a
-rm -f /mingw64/lib/*.dll.a
-export PKG_CONFIG="C:/rtools40/usr/bin/pkg-config --static"
+gcc --version
 
 cp $ARROW_HOME/ci/scripts/PKGBUILD .
-export PKGEXT='.pkg.tar.xz' # pacman default changed to .zst in 2020, but keep the old ext for compat
 printenv
 makepkg-mingw --noconfirm --noprogressbar --skippgpcheck --nocheck --syncdeps --cleanbuild
 

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -26,6 +26,8 @@ export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 # ccache may be broken on MinGW.
 # pacman --sync --noconfirm ccache
 
+# msys64: remove preinstalled toolchains and switch to rtools40 repositories
+pacman --noconfirm -Rcsu mingw-w64-{i686,x86_64}-toolchain gcc pkg-config
 curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
 
 pacman --noconfirm -Scc

--- a/dev/tasks/r/azure.linux.yml
+++ b/dev/tasks/r/azure.linux.yml
@@ -33,9 +33,9 @@ jobs:
         docker -v
         docker-compose -v
         cd arrow
-        R_ORG={{ r_org }}
-        R_IMAGE={{ r_image }}
-        R_TAG={{ r_tag }}
+        export R_ORG={{ r_org }}
+        export R_IMAGE={{ r_image }}
+        export R_TAG={{ r_tag }}
         docker-compose pull --ignore-pull-failures r
         docker-compose build r
       displayName: Docker build
@@ -43,9 +43,9 @@ jobs:
     - script: |
         set -ex
         cd arrow
-        R_ORG={{ r_org }}
-        R_IMAGE={{ r_image }}
-        R_TAG={{ r_tag }}
+        export R_ORG={{ r_org }}
+        export R_IMAGE={{ r_image }}
+        export R_TAG={{ r_tag }}
         # we have to export this (right?) because we need it in the build env
         export ARROW_R_DEV={{ not_cran }}
         # Note that ci/scripts/r_test.sh sets NOT_CRAN=true if ARROW_R_DEV=TRUE

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1657,7 +1657,6 @@ tasks:
 
   test-r-rstudio-r-base-3.6-centos8:
     ci: azure
-    platform: linux
     template: r/azure.linux.yml
     params:
       r_org: rstudio

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1680,7 +1680,7 @@ tasks:
     params:
       r_org: rstudio
       r_image: r-base
-      r_tag: 3.6-opensuse24
+      r_tag: 3.6-opensuse42
       not_cran: "TRUE"
 
   test-conda-r-4.0:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1655,6 +1655,16 @@ tasks:
       r_tag: 3.6-centos6
       not_cran: "TRUE"
 
+  test-r-rstudio-r-base-3.6-centos8:
+    ci: azure
+    platform: linux
+    template: r/azure.linux.yml
+    params:
+      r_org: rstudio
+      r_image: r-base
+      r_tag: 3.6-centos8
+      not_cran: "TRUE"
+
   test-r-rstudio-r-base-3.6-opensuse15:
     ci: azure
     template: r/azure.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1683,21 +1683,12 @@ tasks:
       r_tag: 3.6-opensuse24
       not_cran: "TRUE"
 
-  test-ubuntu-18.04-r-3.6:
-    ci: azure
-    template: docker-tests/azure.linux.yml
-    params:
-      env:
-        UBUNTU: 18.04
-        R: 3.6
-      run: ubuntu-r
-
-  test-conda-r-3.6:
+  test-conda-r-4.0:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        R: 3.6
+        R: 4.0
       run: conda-r
 
   test-ubuntu-18.04-r-sanitizer:


### PR DESCRIPTION
Among the updates and fixes here:

* Change the default R version everywhere from 3.6 to 4.0 (current version as of April 24, 2020). Some jobs that were using a "release" alias were already running on 4.0, but many were not.
* Adapt the apt dockerfile to find the 4.0 CRAN apt servers
* Switch the Windows builds to use the new Rtools40 toolchain, which includes enough msys2 functionality that we can delete a bunch of setup
* Fix a few bugs in the crossbow config that meant that we weren't actually testing on a build matrix of linux distros (environment variables needed to be exported to get picked up by docker-compose.