### PR TITLE
ARROW-8710: [Rust] Ensure right order of messages written, and flush stream when complete.

### DIFF
--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -189,8 +189,10 @@ impl<W: Write> StreamWriter<W> {
 
     /// Write continuation bytes, and mark the stream as done
     pub fn finish(&mut self) -> Result<()> {
-        self.writer.write_all(&[0u8, 0, 0, 0])?;
         self.writer.write_all(&[255u8, 255, 255, 255])?;
+        self.writer.write_all(&[0u8, 0, 0, 0])?;
+        self.writer.flush()?;
+
         self.finished = true;
 
         Ok(())


### PR DESCRIPTION
The continuation marker needs to be written before the message byte
length, according to the Arrow specification.

Also for safety's sake the writer needs to be flushed once complete.