### PR TITLE
ARROW-8684: [Python] Do not call tobytes inside atexit extension type teardown function

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -817,7 +817,9 @@ def register_extension_type(ext_type):
     _python_extension_types_registry.append(_type)
 
 
-def _unregister_extension_type(bytes type_name):
+cdef _unregister_extension_type(bytes type_name):
+    # ARROW-8684: Due to a Cython (?) bug we cannot call "compat.tobytes"
+    # inside the atexit handler
     check_status(UnregisterPyExtensionType(type_name))
 
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -831,7 +831,7 @@ def unregister_extension_type(type_name):
         The name of the ExtensionType subclass to unregister.
 
     """
-    return _unregister_extension_type(type_name)
+    return _unregister_extension_type(tobytes(type_name))
 
 
 cdef class KeyValueMetadata(_Metadata, Mapping):


### PR DESCRIPTION
It seems that Cython calling out to some pure Python code (here `pyarrow.compat.tobytes`) inside the atexit handler hits an esoteric bug on Python >= 3.7.5 on macOS. These code changes fix the problem for me. I'll try to create a minimal reproducer for the benefit of the Cython issue tracker since this seems to be a Cython bug