### PR TITLE
ARROW-8720: [C++] Fix checked_pointer_cast ifdef logic

### DIFF
--- a/cpp/src/arrow/util/checked_cast.h
+++ b/cpp/src/arrow/util/checked_cast.h
@@ -40,7 +40,7 @@ inline OutputType checked_cast(InputType&& value) {
 
 template <class T, class U>
 std::shared_ptr<T> checked_pointer_cast(const std::shared_ptr<U>& r) noexcept {
-#ifndef NDEBUG
+#ifdef NDEBUG
   return std::static_pointer_cast<T>(r);
 #else
   return std::dynamic_pointer_cast<T>(r);
@@ -49,7 +49,7 @@ std::shared_ptr<T> checked_pointer_cast(const std::shared_ptr<U>& r) noexcept {
 
 template <class T, class U>
 std::unique_ptr<T> checked_pointer_cast(std::unique_ptr<U> r) noexcept {
-#ifndef NDEBUG
+#ifdef NDEBUG
   return std::unique_ptr<T>(static_cast<T*>(r.release()));
 #else
   return std::unique_ptr<T>(dynamic_cast<T*>(r.release()));


### PR DESCRIPTION
The expensive version (dynamic_pointer_cast) was enabled in release build instead of debug builds. This aligns with `checked_cast`.