### PR TITLE
ARROW-8724: [Packaging][deb][RPM] Use directory in host as build directory

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -181,7 +181,7 @@ include_directories(SYSTEM "${THIRDPARTY_DIR}/flatbuffers/include")
 # ----------------------------------------------------------------------
 # Some EP's require other EP's
 
-if(ARROW_THRIFT OR ARROW_WITH_ZLIB)
+if(ARROW_THRIFT)
   set(ARROW_WITH_ZLIB ON)
 endif()
 

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-7/Dockerfile
@@ -53,3 +53,7 @@ RUN \
     tar \
     zlib-devel && \
   yum clean ${quiet} all
+
+ENV \
+  BOOST_INCLUDEDIR=/usr/include/boost169 \
+  BOOST_LIBRARYDIR=/usr/lib64/boost169

--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -46,7 +46,7 @@ jobs:
           pushd arrow/dev/tasks/linux-packages
           rake version:update
           rake docker:pull || :
-          rake {{ build_task }}
+          rake BUILD_DIR=build {{ build_task }}
           popd
         env:
           APT_TARGETS: {{ target }}

--- a/dev/tasks/linux-packages/package-task.rb
+++ b/dev/tasks/linux-packages/package-task.rb
@@ -135,6 +135,7 @@ class PackageTask
     run_command_line = [
       "docker",
       "run",
+      "--interactive",
       "--rm",
       "--tty",
       "--volume", "#{Dir.pwd}:/host:rw",

--- a/dev/tasks/linux-packages/package-task.rb
+++ b/dev/tasks/linux-packages/package-task.rb
@@ -135,11 +135,11 @@ class PackageTask
     run_command_line = [
       "docker",
       "run",
-      "--interactive",
       "--rm",
       "--tty",
       "--volume", "#{Dir.pwd}:/host:rw",
     ]
+    run_command_line << "--interactive" if $stdin.tty?
     build_dir = ENV["BUILD_DIR"]
     if build_dir
       build_dir = "#{File.expand_path(build_dir)}/#{id}"

--- a/dev/tasks/linux-packages/package-task.rb
+++ b/dev/tasks/linux-packages/package-task.rb
@@ -139,6 +139,12 @@ class PackageTask
       "--tty",
       "--volume", "#{Dir.pwd}:/host:rw",
     ]
+    build_dir = ENV["BUILD_DIR"]
+    if build_dir
+      build_dir = "#{File.expand_path(build_dir)}/#{id}"
+      mkdir_p(build_dir)
+      run_command_line.concat(["--volume", "#{build_dir}:/build:rw"])
+    end
     if debug_build?
       build_command_line.concat(["--build-arg", "DEBUG=yes"])
       run_command_line.concat(["--env", "DEBUG=yes"])

--- a/dev/tasks/linux-packages/travis.linux.arm64.yml
+++ b/dev/tasks/linux-packages/travis.linux.arm64.yml
@@ -51,7 +51,7 @@ script:
   - rake version:update
   - |
     rake docker:pull || :
-  - rake {{ build_task }}
+  - rake BUILD_DIR=build {{ build_task }}
   - popd
 
 after_success:

--- a/dev/tasks/linux-packages/yum/build.sh
+++ b/dev/tasks/linux-packages/yum/build.sh
@@ -48,6 +48,10 @@ case "${architecture}" in
     ;;
 esac
 
+cd
+
+run mkdir -p /build/rpmbuild
+run ln -fs /build/rpmbuild ./
 if [ -x /usr/bin/rpmdev-setuptree ]; then
   rm -rf .rpmmacros
   run rpmdev-setuptree
@@ -55,11 +59,11 @@ else
   run cat <<EOM > ~/.rpmmacros
 %_topdir ${HOME}/rpmbuild
 EOM
-  run mkdir -p ~/rpmbuild/SOURCES
-  run mkdir -p ~/rpmbuild/SPECS
-  run mkdir -p ~/rpmbuild/BUILD
-  run mkdir -p ~/rpmbuild/RPMS
-  run mkdir -p ~/rpmbuild/SRPMS
+  run mkdir -p rpmbuild/SOURCES
+  run mkdir -p rpmbuild/SPECS
+  run mkdir -p rpmbuild/BUILD
+  run mkdir -p rpmbuild/RPMS
+  run mkdir -p rpmbuild/SRPMS
 fi
 
 repositories="/host/repositories"
@@ -70,8 +74,6 @@ run mkdir -p "${rpm_dir}" "${srpm_dir}"
 
 # for debug
 # rpmbuild_options="$rpmbuild_options --define 'optflags -O0 -g3'"
-
-cd
 
 if [ -n "${SOURCE_ARCHIVE}" ]; then
   case "${RELEASE}" in


### PR DESCRIPTION
Travis CI uses different partition for workspace (/) and
Docker (/var/lib/docker/) and /var/lib/docker/ doesn't have enough
disk space. If we use directory in host as build directory, we can use
disk space in /.