### PR TITLE
ARROW-8727: [C++] Don't require stack allocation of any object to use StringConverter, hide behind ParseValue function

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -652,9 +652,8 @@ class FormatStringParser {
   template <typename IntType = int32_t>
   Result<IntType> ParseInt(util::string_view v) {
     using ArrowIntType = typename CTypeTraits<IntType>::ArrowType;
-    internal::StringConverter<ArrowIntType> converter;
     IntType value;
-    if (!converter(v.data(), v.size(), &value)) {
+    if (!internal::StringConverter<ArrowIntType>::Convert(v.data(), v.size(), &value)) {
       return Invalid();
     }
     return value;

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -653,7 +653,7 @@ class FormatStringParser {
   Result<IntType> ParseInt(util::string_view v) {
     using ArrowIntType = typename CTypeTraits<IntType>::ArrowType;
     IntType value;
-    if (!internal::StringConverter<ArrowIntType>::Convert(v.data(), v.size(), &value)) {
+    if (!internal::ParseValue<ArrowIntType>(v.data(), v.size(), &value)) {
       return Invalid();
     }
     return value;

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -1079,7 +1079,7 @@ struct CastFunctor<
       }
 
       auto str = input_array.GetView(i);
-      if (!internal::StringConverter<O>::Convert(str.data(), str.length(), out_data)) {
+      if (!internal::ParseValue<O>(str.data(), str.length(), out_data)) {
         ctx->SetStatus(Status::Invalid("Failed to cast String '", str, "' into ",
                                        output->type->ToString()));
         return;
@@ -1107,8 +1107,7 @@ struct CastFunctor<BooleanType, I, enable_if_t<is_string_like_type<I>::value>> {
 
       bool value;
       auto str = input_array.GetView(i);
-      if (!internal::StringConverter<BooleanType>::Convert(str.data(), str.length(),
-                                                           &value)) {
+      if (!internal::ParseValue<BooleanType>(str.data(), str.length(), &value)) {
         ctx->SetStatus(Status::Invalid("Failed to cast String '",
                                        input_array.GetString(i), "' into ",
                                        output->type->ToString()));

--- a/cpp/src/arrow/compute/kernels/cast.cc
+++ b/cpp/src/arrow/compute/kernels/cast.cc
@@ -1137,7 +1137,6 @@ struct CastFunctor<TimestampType, I, enable_if_t<is_string_like_type<I>::value>>
     typename TypeTraits<I>::ArrayType input_array(input.Copy());
     auto out_data = output->GetMutableValues<out_type>(1);
 
-    auto parser = TimestampParser::MakeISO8601();
     const TimeUnit::type unit = checked_cast<const TimestampType&>(*output->type).unit();
 
     for (int64_t i = 0; i < input.length; ++i, ++out_data) {
@@ -1145,7 +1144,7 @@ struct CastFunctor<TimestampType, I, enable_if_t<is_string_like_type<I>::value>>
         continue;
       }
       const auto str = input_array.GetView(i);
-      if (!(*parser)(str.data(), str.length(), unit, out_data)) {
+      if (!internal::ParseTimestampISO8601(str.data(), str.length(), unit, out_data)) {
         ctx->SetStatus(Status::Invalid("Failed to cast String '", str, "' into ",
                                        output->type->ToString()));
         return;

--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -40,7 +40,6 @@ namespace arrow {
 namespace csv {
 
 using internal::checked_cast;
-using internal::StringConverter;
 using internal::Trie;
 using internal::TrieBuilder;
 
@@ -349,7 +348,7 @@ class NumericConverter : public ConcreteConverter {
   Result<std::shared_ptr<Array>> Convert(const BlockParser& parser,
                                          int32_t col_index) override {
     using BuilderType = typename TypeTraits<T>::BuilderType;
-    using value_type = typename StringConverter<T>::value_type;
+    using value_type = typename T::c_type;
 
     BuilderType builder(type_, pool_);
 
@@ -363,7 +362,7 @@ class NumericConverter : public ConcreteConverter {
       if (!std::is_same<BooleanType, T>::value) {
         TrimWhiteSpace(&data, &size);
       }
-      if (ARROW_PREDICT_FALSE(!StringConverter<T>::Convert(
+      if (ARROW_PREDICT_FALSE(!internal::ParseValue<T>(
               reinterpret_cast<const char*>(data), size, &value))) {
         return GenericConversionError(type_, data, size);
       }

--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -352,7 +352,6 @@ class NumericConverter : public ConcreteConverter {
     using value_type = typename StringConverter<T>::value_type;
 
     BuilderType builder(type_, pool_);
-    StringConverter<T> converter;
 
     auto visit = [&](const uint8_t* data, uint32_t size, bool quoted) -> Status {
       // XXX should quoted values be allowed at all?
@@ -364,8 +363,8 @@ class NumericConverter : public ConcreteConverter {
       if (!std::is_same<BooleanType, T>::value) {
         TrimWhiteSpace(&data, &size);
       }
-      if (ARROW_PREDICT_FALSE(
-              !converter(reinterpret_cast<const char*>(data), size, &value))) {
+      if (ARROW_PREDICT_FALSE(!StringConverter<T>::Convert(
+              reinterpret_cast<const char*>(data), size, &value))) {
         return GenericConversionError(type_, data, size);
       }
       builder.UnsafeAppend(value);

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -31,7 +31,7 @@
 
 namespace arrow {
 
-using internal::StringConverter;
+using internal::ParseValue;
 using internal::Uri;
 
 namespace fs {
@@ -314,7 +314,7 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   if (it != options_map.end()) {
     const auto& v = it->second;
     int16_t replication;
-    if (!StringConverter<Int16Type>::Convert(v.data(), v.size(), &replication)) {
+    if (!ParseValue<Int16Type>(v.data(), v.size(), &replication)) {
       return Status::Invalid("Invalid value for option 'replication': '", v, "'");
     }
     options.ConfigureReplication(replication);
@@ -325,7 +325,7 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   if (it != options_map.end()) {
     const auto& v = it->second;
     int32_t buffer_size;
-    if (!StringConverter<Int32Type>::Convert(v.data(), v.size(), &buffer_size)) {
+    if (!ParseValue<Int32Type>(v.data(), v.size(), &buffer_size)) {
       return Status::Invalid("Invalid value for option 'buffer_size': '", v, "'");
     }
     options.ConfigureBufferSize(buffer_size);
@@ -336,7 +336,7 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   if (it != options_map.end()) {
     const auto& v = it->second;
     int64_t default_block_size;
-    if (!StringConverter<Int64Type>::Convert(v.data(), v.size(), &default_block_size)) {
+    if (!ParseValue<Int64Type>(v.data(), v.size(), &default_block_size)) {
       return Status::Invalid("Invalid value for option 'default_block_size': '", v, "'");
     }
     options.ConfigureBlockSize(default_block_size);

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -31,6 +31,7 @@
 
 namespace arrow {
 
+using internal::StringConverter;
 using internal::Uri;
 
 namespace fs {
@@ -312,9 +313,8 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   auto it = options_map.find("replication");
   if (it != options_map.end()) {
     const auto& v = it->second;
-    ::arrow::internal::StringConverter<Int16Type> converter;
     int16_t replication;
-    if (!converter(v.data(), v.size(), &replication)) {
+    if (!StringConverter<Int16Type>::Convert(v.data(), v.size(), &replication)) {
       return Status::Invalid("Invalid value for option 'replication': '", v, "'");
     }
     options.ConfigureReplication(replication);
@@ -324,9 +324,8 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   it = options_map.find("buffer_size");
   if (it != options_map.end()) {
     const auto& v = it->second;
-    ::arrow::internal::StringConverter<Int32Type> converter;
     int32_t buffer_size;
-    if (!converter(v.data(), v.size(), &buffer_size)) {
+    if (!StringConverter<Int32Type>::Convert(v.data(), v.size(), &buffer_size)) {
       return Status::Invalid("Invalid value for option 'buffer_size': '", v, "'");
     }
     options.ConfigureBufferSize(buffer_size);
@@ -336,9 +335,8 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   it = options_map.find("default_block_size");
   if (it != options_map.end()) {
     const auto& v = it->second;
-    ::arrow::internal::StringConverter<Int64Type> converter;
     int64_t default_block_size;
-    if (!converter(v.data(), v.size(), &default_block_size)) {
+    if (!StringConverter<Int64Type>::Convert(v.data(), v.size(), &default_block_size)) {
       return Status::Invalid("Invalid value for option 'default_block_size': '", v, "'");
     }
     options.ConfigureBlockSize(default_block_size);

--- a/cpp/src/arrow/json/converter.cc
+++ b/cpp/src/arrow/json/converter.cc
@@ -109,7 +109,7 @@ struct ParserAdapter {
   void InitParser(const DataType& type) {}
 
   bool ConvertOne(const char* s, size_t length, value_type* out) {
-    return internal::StringConverter<T>::Convert(s, length, out);
+    return internal::ParseValue<T>(s, length, out);
   }
 };
 

--- a/cpp/src/arrow/json/converter.cc
+++ b/cpp/src/arrow/json/converter.cc
@@ -103,12 +103,38 @@ class BooleanConverter : public PrimitiveConverter {
 };
 
 template <typename T>
-class NumericConverter : public PrimitiveConverter {
+struct ParserAdapter {
+  using value_type = typename T::c_type;
+
+  void InitParser(const DataType& type) {}
+
+  bool ConvertOne(const char* s, size_t length, value_type* out) {
+    return internal::StringConverter<T>::Convert(s, length, out);
+  }
+};
+
+template <>
+struct ParserAdapter<TimestampType> {
+  void InitParser(const DataType& type) {
+    this->unit = internal::checked_cast<const TimestampType&>(type).unit();
+  }
+
+  bool ConvertOne(const char* s, size_t length, int64_t* out) {
+    return internal::ParseTimestampISO8601(s, length, unit, out);
+  }
+
+  TimeUnit::type unit;
+};
+
+template <typename T>
+class NumericConverter : public PrimitiveConverter, public ParserAdapter<T> {
  public:
-  using value_type = typename internal::StringConverter<T>::value_type;
+  using value_type = typename T::c_type;
 
   NumericConverter(MemoryPool* pool, const std::shared_ptr<DataType>& type)
-      : PrimitiveConverter(pool, type), convert_one_(type) {}
+      : PrimitiveConverter(pool, type) {
+    ParserAdapter<T>::InitParser(*type);
+  }
 
   Status Convert(const std::shared_ptr<Array>& in, std::shared_ptr<Array>* out) override {
     if (in->type_id() == Type::NA) {
@@ -122,7 +148,7 @@ class NumericConverter : public PrimitiveConverter {
 
     auto visit_valid = [&](string_view repr) {
       value_type value;
-      if (!convert_one_(repr.data(), repr.size(), &value)) {
+      if (!ParserAdapter<T>::ConvertOne(repr.data(), repr.size(), &value)) {
         return GenericConversionError(*out_type_, ", couldn't parse:", repr);
       }
 
@@ -138,8 +164,6 @@ class NumericConverter : public PrimitiveConverter {
     RETURN_NOT_OK(VisitDictionaryEntries(dict_array, visit_valid, visit_null));
     return builder.Finish(out);
   }
-
-  internal::StringConverter<T> convert_one_;
 };
 
 template <typename DateTimeType>

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -50,7 +50,7 @@
 namespace arrow {
 
 using internal::checked_cast;
-using internal::StringConverter;
+using internal::ParseValue;
 
 namespace py {
 
@@ -234,7 +234,7 @@ Status GetPythonTypes(const UnionArray& data, std::vector<int8_t>* result) {
   for (int i = 0; i < type->num_children(); ++i) {
     int8_t tag = 0;
     const std::string& data = type->child(i)->name();
-    if (!StringConverter<Int8Type>::Convert(data.c_str(), data.size(), &tag)) {
+    if (!ParseValue<Int8Type>(data.c_str(), data.size(), &tag)) {
       return Status::SerializationError("Cannot convert string: \"",
                                         type->child(i)->name(), "\" to int8_t");
     }

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -232,10 +232,9 @@ Status GetPythonTypes(const UnionArray& data, std::vector<int8_t>* result) {
   ARROW_CHECK(result != nullptr);
   auto type = data.type();
   for (int i = 0; i < type->num_children(); ++i) {
-    StringConverter<Int8Type> converter;
     int8_t tag = 0;
     const std::string& data = type->child(i)->name();
-    if (!converter(data.c_str(), data.size(), &tag)) {
+    if (!StringConverter<Int8Type>::Convert(data.c_str(), data.size(), &tag)) {
       return Status::SerializationError("Cannot convert string: \"",
                                         type->child(i)->name(), "\" to int8_t");
     }

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -220,11 +220,10 @@ std::string Scalar::ToString() const {
 }
 
 struct ScalarParseImpl {
-  template <typename T, typename Converter = internal::StringConverter<T>,
-            typename Value = typename Converter::value_type>
+  template <typename T, typename Value = typename T::c_type>
   Status Visit(const T& t) {
     Value value;
-    if (!Converter::Convert(s_.data(), s_.size(), &value)) {
+    if (!internal::ParseValue<T>(s_.data(), s_.size(), &value)) {
       return Status::Invalid("error parsing '", s_, "' as scalar of type ", t);
     }
     return Finish(std::move(value));

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -220,7 +220,9 @@ std::string Scalar::ToString() const {
 }
 
 struct ScalarParseImpl {
-  template <typename T, typename Value = typename T::c_type>
+  // XXX Use of detail here not ideal
+  template <typename T,
+            typename Value = typename internal::detail::StringConverter<T>::value_type>
   Status Visit(const T& t) {
     Value value;
     if (!internal::ParseValue<T>(s_.data(), s_.size(), &value)) {

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -224,10 +224,18 @@ struct ScalarParseImpl {
             typename Value = typename Converter::value_type>
   Status Visit(const T& t) {
     Value value;
-    if (!Converter{type_}(s_.data(), s_.size(), &value)) {
+    if (!Converter::Convert(s_.data(), s_.size(), &value)) {
       return Status::Invalid("error parsing '", s_, "' as scalar of type ", t);
     }
     return Finish(std::move(value));
+  }
+
+  Status Visit(const TimestampType& t) {
+    int64_t value;
+    if (!internal::ParseTimestampISO8601(s_.data(), s_.size(), t.unit(), &value)) {
+      return Status::Invalid("error parsing '", s_, "' as scalar of type ", t);
+    }
+    return Finish(value);
   }
 
   Status Visit(const BinaryType&) { return FinishWithBuffer(); }

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -180,12 +180,12 @@ static constexpr int64_t kPowersOfTen[kInt64DecimalDigits + 1] = {1LL,
 // the appropriate power of 10 necessary to add source parsed as uint64 and
 // then adds the parsed value of source.
 static inline void ShiftAndAdd(const char* data, size_t length, Decimal128* out) {
-  internal::StringConverter<Int64Type> converter;
   for (size_t posn = 0; posn < length;) {
     const size_t group_size = std::min(kInt64DecimalDigits, length - posn);
     const int64_t multiple = kPowersOfTen[group_size];
     int64_t chunk = 0;
-    ARROW_CHECK(converter(data + posn, group_size, &chunk));
+    ARROW_CHECK(
+        internal::StringConverter<Int64Type>::Convert(data + posn, group_size, &chunk));
 
     *out *= multiple;
     *out += chunk;
@@ -275,8 +275,8 @@ bool ParseDecimalComponents(const char* s, size_t size, DecimalComponents* out) 
       ++pos;
     }
     out->has_exponent = true;
-    internal::StringConverter<Int32Type> exponent_converter;
-    return exponent_converter(s + pos, size - pos, &(out->exponent));
+    return internal::StringConverter<Int32Type>::Convert(s + pos, size - pos,
+                                                         &(out->exponent));
   }
   return pos == size;
 }

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -184,8 +184,7 @@ static inline void ShiftAndAdd(const char* data, size_t length, Decimal128* out)
     const size_t group_size = std::min(kInt64DecimalDigits, length - posn);
     const int64_t multiple = kPowersOfTen[group_size];
     int64_t chunk = 0;
-    ARROW_CHECK(
-        internal::StringConverter<Int64Type>::Convert(data + posn, group_size, &chunk));
+    ARROW_CHECK(internal::ParseValue<Int64Type>(data + posn, group_size, &chunk));
 
     *out *= multiple;
     *out += chunk;
@@ -275,8 +274,7 @@ bool ParseDecimalComponents(const char* s, size_t size, DecimalComponents* out) 
       ++pos;
     }
     out->has_exponent = true;
-    return internal::StringConverter<Int32Type>::Convert(s + pos, size - pos,
-                                                         &(out->exponent));
+    return internal::ParseValue<Int32Type>(s + pos, size - pos, &(out->exponent));
   }
   return pos == size;
 }

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -255,9 +255,9 @@ Status Uri::Parse(const std::string& uri_string) {
   // Parse port number
   auto port_text = TextRangeToView(impl_->uri_.portText);
   if (port_text.size()) {
-    StringConverter<UInt16Type> port_converter;
     uint16_t port_num;
-    if (!port_converter(port_text.data(), port_text.size(), &port_num)) {
+    if (!StringConverter<UInt16Type>::Convert(port_text.data(), port_text.size(),
+                                              &port_num)) {
       return Status::Invalid("Invalid port number '", port_text, "' in URI '", uri_string,
                              "'");
     }

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -256,8 +256,7 @@ Status Uri::Parse(const std::string& uri_string) {
   auto port_text = TextRangeToView(impl_->uri_.portText);
   if (port_text.size()) {
     uint16_t port_num;
-    if (!StringConverter<UInt16Type>::Convert(port_text.data(), port_text.size(),
-                                              &port_num)) {
+    if (!ParseValue<UInt16Type>(port_text.data(), port_text.size(), &port_num)) {
       return Status::Invalid("Invalid port number '", port_text, "' in URI '", uri_string,
                              "'");
     }

--- a/cpp/src/arrow/util/value_parsing.cc
+++ b/cpp/src/arrow/util/value_parsing.cc
@@ -44,7 +44,7 @@ struct StringToFloatConverterImpl {
   util::double_conversion::StringToDoubleConverter fallback_converter_;
 };
 
-static StringToFloatConverterImpl g_string_to_float;
+static const StringToFloatConverterImpl g_string_to_float;
 
 bool StringToFloat(const char* s, size_t length, float* out) {
   int processed_length;

--- a/cpp/src/arrow/util/value_parsing.cc
+++ b/cpp/src/arrow/util/value_parsing.cc
@@ -24,6 +24,7 @@
 
 namespace arrow {
 namespace internal {
+namespace detail {
 
 struct StringToFloatConverterImpl {
   StringToFloatConverterImpl()
@@ -77,6 +78,8 @@ bool StringToFloat(const char* s, size_t length, double* out) {
   *out = v;
   return true;
 }
+
+}  // namespace detail
 
 // ----------------------------------------------------------------------
 // strptime-like parsing

--- a/cpp/src/arrow/util/value_parsing.cc
+++ b/cpp/src/arrow/util/value_parsing.cc
@@ -25,8 +25,8 @@
 namespace arrow {
 namespace internal {
 
-struct StringToFloatConverter::Impl {
-  Impl()
+struct StringToFloatConverterImpl {
+  StringToFloatConverterImpl()
       : main_converter_(flags_, main_junk_value_, main_junk_value_, "inf", "nan"),
         fallback_converter_(flags_, fallback_junk_value_, fallback_junk_value_, "inf",
                             "nan") {}
@@ -43,23 +43,18 @@ struct StringToFloatConverter::Impl {
   util::double_conversion::StringToDoubleConverter fallback_converter_;
 };
 
-constexpr int StringToFloatConverter::Impl::flags_;
-constexpr double StringToFloatConverter::Impl::main_junk_value_;
-constexpr double StringToFloatConverter::Impl::fallback_junk_value_;
+static StringToFloatConverterImpl g_string_to_float;
 
-StringToFloatConverter::StringToFloatConverter() : impl_(new Impl()) {}
-
-StringToFloatConverter::~StringToFloatConverter() {}
-
-bool StringToFloatConverter::StringToFloat(const char* s, size_t length, float* out) {
+bool StringToFloat(const char* s, size_t length, float* out) {
   int processed_length;
   float v;
-  v = impl_->main_converter_.StringToFloat(s, static_cast<int>(length),
-                                           &processed_length);
-  if (ARROW_PREDICT_FALSE(v == static_cast<float>(impl_->main_junk_value_))) {
-    v = impl_->fallback_converter_.StringToFloat(s, static_cast<int>(length),
-                                                 &processed_length);
-    if (ARROW_PREDICT_FALSE(v == static_cast<float>(impl_->fallback_junk_value_))) {
+  v = g_string_to_float.main_converter_.StringToFloat(s, static_cast<int>(length),
+                                                      &processed_length);
+  if (ARROW_PREDICT_FALSE(v == static_cast<float>(g_string_to_float.main_junk_value_))) {
+    v = g_string_to_float.fallback_converter_.StringToFloat(s, static_cast<int>(length),
+                                                            &processed_length);
+    if (ARROW_PREDICT_FALSE(v ==
+                            static_cast<float>(g_string_to_float.fallback_junk_value_))) {
       return false;
     }
   }
@@ -67,15 +62,15 @@ bool StringToFloatConverter::StringToFloat(const char* s, size_t length, float* 
   return true;
 }
 
-bool StringToFloatConverter::StringToFloat(const char* s, size_t length, double* out) {
+bool StringToFloat(const char* s, size_t length, double* out) {
   int processed_length;
   double v;
-  v = impl_->main_converter_.StringToDouble(s, static_cast<int>(length),
-                                            &processed_length);
-  if (ARROW_PREDICT_FALSE(v == impl_->main_junk_value_)) {
-    v = impl_->fallback_converter_.StringToDouble(s, static_cast<int>(length),
-                                                  &processed_length);
-    if (ARROW_PREDICT_FALSE(v == impl_->fallback_junk_value_)) {
+  v = g_string_to_float.main_converter_.StringToDouble(s, static_cast<int>(length),
+                                                       &processed_length);
+  if (ARROW_PREDICT_FALSE(v == g_string_to_float.main_junk_value_)) {
+    v = g_string_to_float.fallback_converter_.StringToDouble(s, static_cast<int>(length),
+                                                             &processed_length);
+    if (ARROW_PREDICT_FALSE(v == g_string_to_float.fallback_junk_value_)) {
       return false;
     }
   }

--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -59,9 +59,7 @@ namespace detail {
 
 template <typename ARROW_TYPE>
 struct StringConverter {
-  using value_type = void;
-
-  static bool Convert(const char*, size_t, value_type*) { return false; }
+  static bool Convert(const char*, size_t, void*) { return false; }
 };
 
 template <>

--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -57,10 +57,8 @@ namespace internal {
 
 namespace detail {
 
-template <typename ARROW_TYPE>
-struct StringConverter {
-  static bool Convert(const char*, size_t, void*) { return false; }
-};
+template <typename ARROW_TYPE, typename Enable = void>
+struct StringConverter;
 
 template <>
 struct StringConverter<BooleanType> {

--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -457,8 +457,9 @@ static inline bool ParseHH_MM_SS(const char* s, std::chrono::duration<ts_type>* 
 
 /// \brief Attempt to convert a string to the primitive type corresponding to
 /// an Arrow data type
-template <typename T>
-static inline bool ParseValue(const char* s, size_t length, typename T::c_type* out) {
+template <typename T, typename ParseContext = void>
+inline bool ParseValue(const char* s, size_t length, typename T::c_type* out,
+                       const ParseContext* ctx = NULLPTR) {
   return detail::StringConverter<T>::Convert(s, length, out);
 }
 
@@ -560,6 +561,17 @@ static inline bool ParseTimestampStrptime(const char* buf, size_t length,
   }
   *out = detail::ConvertTimePoint(secs, unit);
   return true;
+}
+
+/// \brief Parsing options for timestamps
+struct ParseTimestampContext {
+  TimeUnit::type unit;
+};
+
+template <>
+inline bool ParseValue<TimestampType, ParseTimestampContext>(
+    const char* s, size_t length, int64_t* out, const ParseTimestampContext* ctx) {
+  return ParseTimestampISO8601(s, length, ctx->unit, out);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/value_parsing_benchmark.cc
+++ b/cpp/src/arrow/util/value_parsing_benchmark.cc
@@ -112,7 +112,7 @@ static void IntegerParsing(benchmark::State& state) {  // NOLINT non-const refer
     C_TYPE total = 0;
     for (const auto& s : strings) {
       C_TYPE value;
-      if (!StringConverter<ARROW_TYPE>::Convert(s.data(), s.length(), &value)) {
+      if (!ParseValue<ARROW_TYPE>(s.data(), s.length(), &value)) {
         std::cerr << "Conversion failed for '" << s << "'";
         std::abort();
       }
@@ -131,7 +131,7 @@ static void FloatParsing(benchmark::State& state) {  // NOLINT non-const referen
     C_TYPE total = 0;
     for (const auto& s : strings) {
       C_TYPE value;
-      if (!StringConverter<ARROW_TYPE>::Convert(s.data(), s.length(), &value)) {
+      if (!ParseValue<ARROW_TYPE>(s.data(), s.length(), &value)) {
         std::cerr << "Conversion failed for '" << s << "'";
         std::abort();
       }

--- a/cpp/src/arrow/util/value_parsing_benchmark.cc
+++ b/cpp/src/arrow/util/value_parsing_benchmark.cc
@@ -107,13 +107,12 @@ static std::vector<c_float> MakeFloats(int32_t num_items) {
 template <typename ARROW_TYPE, typename C_TYPE = typename ARROW_TYPE::c_type>
 static void IntegerParsing(benchmark::State& state) {  // NOLINT non-const reference
   auto strings = MakeIntStrings<C_TYPE>(1000);
-  StringConverter<ARROW_TYPE> converter;
 
   while (state.KeepRunning()) {
     C_TYPE total = 0;
     for (const auto& s : strings) {
       C_TYPE value;
-      if (!converter(s.data(), s.length(), &value)) {
+      if (!StringConverter<ARROW_TYPE>::Convert(s.data(), s.length(), &value)) {
         std::cerr << "Conversion failed for '" << s << "'";
         std::abort();
       }
@@ -127,13 +126,12 @@ static void IntegerParsing(benchmark::State& state) {  // NOLINT non-const refer
 template <typename ARROW_TYPE, typename C_TYPE = typename ARROW_TYPE::c_type>
 static void FloatParsing(benchmark::State& state) {  // NOLINT non-const reference
   auto strings = MakeFloatStrings(1000);
-  StringConverter<ARROW_TYPE> converter;
 
   while (state.KeepRunning()) {
     C_TYPE total = 0;
     for (const auto& s : strings) {
       C_TYPE value;
-      if (!converter(s.data(), s.length(), &value)) {
+      if (!StringConverter<ARROW_TYPE>::Convert(s.data(), s.length(), &value)) {
         std::cerr << "Conversion failed for '" << s << "'";
         std::abort();
       }


### PR DESCRIPTION
Using non-stateful functions or functors is more natural for template-based code generation of e.g. kernels. 