### PR TITLE
ARROW-8633: [C++] Add ValidateAscii function

### DIFF
--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -190,12 +190,15 @@ inline bool ValidateAsciiSw(const uint8_t* data, int64_t len) {
     orall = !((or1 | or2) & 0x8080808080808080ULL) - 1;
   }
 
-  while (len--) orall |= *data++;
+  while (len--) {
+    orall |= *data++;
+  }
 
-  if (orall < 0x80)
+  if (orall < 0x80) {
     return true;
-  else
+  } else {
     return false;
+  }
 }
 
 #ifdef ARROW_HAVE_NEON
@@ -217,7 +220,9 @@ inline bool ValidateAsciiSimd(const uint8_t* data, int64_t len) {
     }
 
     or1 = vorrq_u8(or1, or2);
-    if (vmaxvq_u8(or1) >= 0x80) return false;
+    if (vmaxvq_u8(or1) >= 0x80) {
+      return false;
+    }
   }
 
   return ValidateAsciiSw(data, len);
@@ -243,7 +248,9 @@ inline bool ValidateAsciiSimd(const uint8_t* data, int64_t len) {
     }
 
     or1 = _mm_or_si128(or1, or2);
-    if (_mm_movemask_epi8(_mm_cmplt_epi8(or1, _mm_set1_epi8(0)))) return false;
+    if (_mm_movemask_epi8(_mm_cmplt_epi8(or1, _mm_set1_epi8(0)))) {
+      return false;
+    }
   }
 
   return ValidateAsciiSw(data, len);

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -25,6 +25,7 @@
 
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/simd.h"
 #include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
 
@@ -170,6 +171,100 @@ inline bool ValidateUTF8(const util::string_view& str) {
 
   return ValidateUTF8(data, length);
 }
+
+inline bool ValidateAscii(const uint8_t* data, int64_t len) {
+  uint8_t orall = 0;
+
+  if (len >= 16) {
+    uint64_t or1 = 0, or2 = 0;
+    const uint8_t* data2 = data + 8;
+
+    do {
+      or1 |= *(const uint64_t*)data;
+      or2 |= *(const uint64_t*)data2;
+      data += 16;
+      data2 += 16;
+      len -= 16;
+    } while (len >= 16);
+
+    orall = !((or1 | or2) & 0x8080808080808080ULL) - 1;
+  }
+
+  while (len--) orall |= *data++;
+
+  if (orall < 0x80)
+    return true;
+  else
+    return false;
+}
+
+inline bool ValidateAscii(const util::string_view& str) {
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(str.data());
+  const size_t length = str.size();
+
+  return ValidateAscii(data, length);
+}
+
+#ifdef ARROW_HAVE_NEON
+inline bool ValidateAsciiSimd(const uint8_t* data, int64_t len) {
+  if (len >= 32) {
+    const uint8_t* data2 = data + 16;
+    uint8x16_t or1 = vdupq_n_u8(0), or2 = or1;
+
+    while (len >= 32) {
+      const uint8x16_t input1 = vld1q_u8(data);
+      const uint8x16_t input2 = vld1q_u8(data2);
+
+      or1 = vorrq_u8(or1, input1);
+      or2 = vorrq_u8(or2, input2);
+
+      data += 32;
+      data2 += 32;
+      len -= 32;
+    }
+
+    or1 = vorrq_u8(or1, or2);
+    if (vmaxvq_u8(or1) >= 0x80) return false;
+  }
+
+  return ValidateAscii(data, len);
+}
+#endif  // ARROW_HAVE_NEON
+
+#if defined(ARROW_HAVE_SSE4_2)
+inline bool ValidateAsciiSimd(const uint8_t* data, int64_t len) {
+  if (len >= 32) {
+    const uint8_t* data2 = data + 16;
+    __m128i or1 = _mm_set1_epi8(0), or2 = or1;
+
+    while (len >= 32) {
+      __m128i input1 = _mm_lddqu_si128((const __m128i*)data);
+      __m128i input2 = _mm_lddqu_si128((const __m128i*)data2);
+
+      or1 = _mm_or_si128(or1, input1);
+      or2 = _mm_or_si128(or2, input2);
+
+      data += 32;
+      data2 += 32;
+      len -= 32;
+    }
+
+    or1 = _mm_or_si128(or1, or2);
+    if (_mm_movemask_epi8(_mm_cmplt_epi8(or1, _mm_set1_epi8(0)))) return false;
+  }
+
+  return ValidateAscii(data, len);
+}
+#endif  // ARROW_HAVE_SSE4_2
+
+#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2)
+inline bool ValidateAsciiSimd(const util::string_view& str) {
+  const uint8_t* data = reinterpret_cast<const uint8_t*>(str.data());
+  const size_t length = str.size();
+
+  return ValidateAsciiSimd(data, length);
+}
+#endif  // ARROW_HAVE_NEON || ARROW_HAVE_SSE4_2
 
 // Skip UTF8 byte order mark, if any.
 ARROW_EXPORT

--- a/cpp/src/arrow/util/utf8_util_benchmark.cc
+++ b/cpp/src/arrow/util/utf8_util_benchmark.cc
@@ -77,22 +77,14 @@ static void BenchmarkASCIIValidation(
   auto data_size = static_cast<int64_t>(s.size());
 
   InitializeUTF8();
-#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2)
-  bool b = ValidateAsciiSimd(data, data_size);
-#else
   bool b = ValidateAscii(data, data_size);
-#endif
   if (b != expected) {
     std::cerr << "Unexpected validation result" << std::endl;
     std::abort();
   }
 
   while (state.KeepRunning()) {
-#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2)
-    bool b = ValidateAsciiSimd(data, data_size);
-#else
     bool b = ValidateAscii(data, data_size);
-#endif
     benchmark::DoNotOptimize(b);
   }
   state.SetBytesProcessed(state.iterations() * s.size());

--- a/cpp/src/arrow/util/utf8_util_test.cc
+++ b/cpp/src/arrow/util/utf8_util_test.cc
@@ -60,6 +60,9 @@ class UTF8Test : public ::testing::Test {
   static std::vector<std::string> invalid_sequences_4;
 
   static std::vector<std::string> all_invalid_sequences;
+
+  static std::vector<std::string> valid_sequences_ascii;
+  static std::vector<std::string> invalid_sequences_ascii;
 };
 
 std::vector<std::string> UTF8Test::valid_sequences_1 = {"a", "\x7f"};
@@ -87,7 +90,13 @@ std::vector<std::string> UTF8Test::invalid_sequences_4 = {
 
 std::vector<std::string> UTF8Test::all_invalid_sequences;
 
+std::vector<std::string> UTF8Test::valid_sequences_ascii = {"a", "\x7f", "B", "&"};
+std::vector<std::string> UTF8Test::invalid_sequences_ascii = {
+    "\x80", "\xa0\x1e", "\xbf\xef\x6a", "\xc1\x9f\xc3\xd9"};
+
 class UTF8ValidationTest : public UTF8Test {};
+
+class ASCIIValidationTest : public UTF8Test {};
 
 ::testing::AssertionResult IsValidUTF8(const std::string& s) {
   if (ValidateUTF8(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
@@ -110,9 +119,54 @@ class UTF8ValidationTest : public UTF8Test {};
   }
 }
 
+::testing::AssertionResult IsValidASCII(const std::string& s) {
+#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2)
+  if (ValidateAsciiSimd(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
+#else
+  if (ValidateAscii(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
+#endif
+    return ::testing::AssertionSuccess();
+  } else {
+    std::string h = HexEncode(reinterpret_cast<const uint8_t*>(s.data()),
+                              static_cast<int32_t>(s.size()));
+    return ::testing::AssertionFailure()
+           << "string '" << h << "' didn't validate as ASCII";
+  }
+}
+
+::testing::AssertionResult IsInvalidASCII(const std::string& s) {
+#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2)
+  if (!ValidateAsciiSimd(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
+#else
+  if (!ValidateAscii(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
+#endif
+    return ::testing::AssertionSuccess();
+  } else {
+    std::string h = HexEncode(reinterpret_cast<const uint8_t*>(s.data()),
+                              static_cast<int32_t>(s.size()));
+    return ::testing::AssertionFailure() << "string '" << h << "' validated as ASCII";
+  }
+}
+
 void AssertValidUTF8(const std::string& s) { ASSERT_TRUE(IsValidUTF8(s)); }
 
 void AssertInvalidUTF8(const std::string& s) { ASSERT_TRUE(IsInvalidUTF8(s)); }
+
+void AssertValidASCII(const std::string& s) { ASSERT_TRUE(IsValidASCII(s)); }
+
+void AssertInvalidASCII(const std::string& s) { ASSERT_TRUE(IsInvalidASCII(s)); }
+
+TEST_F(ASCIIValidationTest, AsciiValid) {
+  for (const auto& s : valid_sequences_ascii) {
+    AssertValidASCII(s);
+  }
+}
+
+TEST_F(ASCIIValidationTest, AsciiInvalid) {
+  for (const auto& s : invalid_sequences_ascii) {
+    AssertInvalidASCII(s);
+  }
+}
 
 TEST_F(UTF8ValidationTest, EmptyString) { AssertValidUTF8(""); }
 

--- a/cpp/src/arrow/util/utf8_util_test.cc
+++ b/cpp/src/arrow/util/utf8_util_test.cc
@@ -120,11 +120,7 @@ class ASCIIValidationTest : public UTF8Test {};
 }
 
 ::testing::AssertionResult IsValidASCII(const std::string& s) {
-#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2)
-  if (ValidateAsciiSimd(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
-#else
   if (ValidateAscii(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
-#endif
     return ::testing::AssertionSuccess();
   } else {
     std::string h = HexEncode(reinterpret_cast<const uint8_t*>(s.data()),
@@ -135,11 +131,7 @@ class ASCIIValidationTest : public UTF8Test {};
 }
 
 ::testing::AssertionResult IsInvalidASCII(const std::string& s) {
-#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2)
-  if (!ValidateAsciiSimd(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
-#else
   if (!ValidateAscii(reinterpret_cast<const uint8_t*>(s.data()), s.size())) {
-#endif
     return ::testing::AssertionSuccess();
   } else {
     std::string h = HexEncode(reinterpret_cast<const uint8_t*>(s.data()),


### PR DESCRIPTION
The patch is to implement ValidateAscii function.
The benchmark and test facilities are also added.

### The benchmark on x86:
**Original:**
```
Run on (20 X 3000 MHz CPU s)
CPU Caches:
  L1 Data 32K (x10)
  L1 Instruction 32K (x10)
  L2 Unified 256K (x10)
  L3 Unified 25600K (x1)
Load Average: 4.79, 5.63, 2.68
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
ValidateTinyAscii              2.39 ns         2.39 ns    276349157 bytes_per_second=3.8964G/s
ValidateTinyNonAscii           8.21 ns         8.21 ns     85421905 bytes_per_second=1.24781G/s
ValidateSmallAscii             10.9 ns         10.9 ns     65497418 bytes_per_second=11.6721G/s
ValidateSmallAlmostAscii       46.1 ns         46.1 ns     15204522 bytes_per_second=2.99142G/s
ValidateSmallNonAscii          84.6 ns         84.6 ns      8303767 bytes_per_second=1.47429G/s
ValidateLargeAscii             4997 ns         4997 ns       136960 bytes_per_second=18.6385G/s
ValidateLargeAlmostAscii      30575 ns        30575 ns        22651 bytes_per_second=3.04752G/s
ValidateLargeNonAscii         73714 ns        73713 ns         9385 bytes_per_second=1.26467G/s

```
**Enable simd**
```
Run on (20 X 3000 MHz CPU s)
CPU Caches:
  L1 Data 32K (x10)
  L1 Instruction 32K (x10)
  L2 Unified 256K (x10)
  L3 Unified 25600K (x1)
Load Average: 4.79, 5.63, 2.68
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
ValidateTinyAscii              6.36 ns         6.36 ns    100259371 bytes_per_second=1.46438G/s
ValidateTinyNonAscii           11.3 ns         11.3 ns     61604638 bytes_per_second=926.575M/s
ValidateSmallAscii             9.74 ns         9.74 ns     71987411 bytes_per_second=13.0987G/s
ValidateSmallAlmostAscii       51.1 ns         51.1 ns     13677942 bytes_per_second=2.69774G/s
ValidateSmallNonAscii          84.5 ns         84.5 ns      8135065 bytes_per_second=1.47735G/s
ValidateLargeAscii             2363 ns         2363 ns       298863 bytes_per_second=39.4107G/s
ValidateLargeAlmostAscii      31006 ns        31006 ns        22642 bytes_per_second=3.00508G/s
ValidateLargeNonAscii         76222 ns        76222 ns         8703 bytes_per_second=1.22305G/s
```


### The benchmark on Arm64
**Original:**
```
Run on (46 X 2600 MHz CPU s)
Load Average: 0.19, 0.66, 1.73
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
ValidateTinyAscii              14.7 ns         14.7 ns     47461698 bytes_per_second=646.682M/s
ValidateTinyNonAscii           48.0 ns         48.0 ns     14576733 bytes_per_second=218.46M/s
ValidateSmallAscii              109 ns          109 ns      6404395 bytes_per_second=1.1667G/s
ValidateSmallAlmostAscii        275 ns          275 ns      2544737 bytes_per_second=513.185M/s
ValidateSmallNonAscii           555 ns          555 ns      1261830 bytes_per_second=230.408M/s
ValidateLargeAscii            78511 ns        78502 ns         8915 bytes_per_second=1.18649G/s
ValidateLargeAlmostAscii     179928 ns       179907 ns         3891 bytes_per_second=530.347M/s
ValidateLargeNonAscii        415107 ns       415058 ns         1686 bytes_per_second=229.994M/s
```
**Enable simd**
```
Run on (46 X 2600 MHz CPU s)
Load Average: 0.19, 0.66, 1.73
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
-----------------------------------------------------------------------------------
Benchmark                         Time             CPU   Iterations UserCounters...
-----------------------------------------------------------------------------------
ValidateTinyAscii              65.9 ns         65.9 ns     10597823 bytes_per_second=144.749M/s
ValidateTinyNonAscii           48.0 ns         48.0 ns     14584553 bytes_per_second=218.732M/s
ValidateSmallAscii             83.7 ns         83.7 ns      8367346 bytes_per_second=1.52478G/s
ValidateSmallAlmostAscii        275 ns          275 ns      2542186 bytes_per_second=512.498M/s
ValidateSmallNonAscii           555 ns          555 ns      1261774 bytes_per_second=230.301M/s
ValidateLargeAscii             3109 ns         3108 ns       225186 bytes_per_second=29.9637G/s
ValidateLargeAlmostAscii     179998 ns       179974 ns         3889 bytes_per_second=530.149M/s
ValidateLargeNonAscii        414228 ns       414181 ns         1691 bytes_per_second=230.481M/s
```

 `ValidateLargeAscii` case will get performance boost when leveraging simd: 

- x86:      `18.6385G/s  -> 39.4107G/s`

- Arm64:  `1.18649G/s -> 29.9637G/s`

