### PR TITLE
ARROW-8730: [Rust] Use slice instead of &Vec for function args

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -877,7 +877,7 @@ mod tests {
         let provider = MemTable::new(schema, vec![batch])?;
         ctx.register_table("t", Box::new(provider));
 
-        let myfunc: ScalarUdf = |args: &Vec<ArrayRef>| {
+        let myfunc: ScalarUdf = |args: &[ArrayRef]| {
             let l = &args[0]
                 .as_any()
                 .downcast_ref::<Int32Array>()

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -667,7 +667,7 @@ enum GroupByScalar {
 
 /// Create a Vec<GroupByScalar> that can be used as a map key
 fn create_key(
-    group_by_keys: &Vec<ArrayRef>,
+    group_by_keys: &[ArrayRef],
     row: usize,
     vec: &mut Vec<GroupByScalar>,
 ) -> Result<()> {

--- a/rust/datafusion/src/execution/physical_plan/math_expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/math_expressions.rs
@@ -32,7 +32,7 @@ macro_rules! math_unary_function {
             $NAME,
             vec![Field::new("n", DataType::Float64, true)],
             DataType::Float64,
-            |args: &Vec<ArrayRef>| {
+            |args: &[ArrayRef]| {
                 let n = &args[0].as_any().downcast_ref::<Float64Array>();
                 match n {
                     Some(array) => {

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -27,7 +27,7 @@ use arrow::record_batch::RecordBatch;
 use std::sync::Arc;
 
 /// Scalar UDF
-pub type ScalarUdf = fn(input: &Vec<ArrayRef>) -> Result<ArrayRef>;
+pub type ScalarUdf = fn(input: &[ArrayRef]) -> Result<ArrayRef>;
 
 /// Scalar UDF Expression
 #[derive(Clone)]

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -183,7 +183,7 @@ impl ProjectionPushDown {
 
     fn rewrite_expr_list(
         &self,
-        expr: &Vec<Expr>,
+        expr: &[Expr],
         mapping: &HashMap<usize, usize>,
     ) -> Result<Vec<Expr>> {
         Ok(expr

--- a/rust/datafusion/src/optimizer/resolve_columns.rs
+++ b/rust/datafusion/src/optimizer/resolve_columns.rs
@@ -63,7 +63,7 @@ impl OptimizerRule for ResolveColumnsRule {
         }
     }
 }
-fn rewrite_expr_list(expr: &Vec<Expr>, schema: &Schema) -> Result<Vec<Expr>> {
+fn rewrite_expr_list(expr: &[Expr], schema: &Schema) -> Result<Vec<Expr>> {
     Ok(expr
         .iter()
         .map(|e| rewrite_expr(e, schema))

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -45,7 +45,7 @@ impl<'a> TypeCoercionRule<'a> {
     }
 
     /// Rewrite an expression list to include explicit CAST operations when required
-    fn rewrite_expr_list(&self, expr: &Vec<Expr>, schema: &Schema) -> Result<Vec<Expr>> {
+    fn rewrite_expr_list(&self, expr: &[Expr], schema: &Schema) -> Result<Vec<Expr>> {
         Ok(expr
             .iter()
             .map(|e| self.rewrite_expr(e, schema))

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -27,7 +27,7 @@ use crate::logicalplan::Expr;
 /// Recursively walk a list of expression trees, collecting the unique set of column
 /// indexes referenced in the expression
 pub fn exprlist_to_column_indices(
-    expr: &Vec<Expr>,
+    expr: &[Expr],
     accum: &mut HashSet<usize>,
 ) -> Result<()> {
     for e in expr {
@@ -123,7 +123,7 @@ pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
 }
 
 /// Create field meta-data from an expression, for use in a result set schema
-pub fn exprlist_to_fields(expr: &Vec<Expr>, input_schema: &Schema) -> Result<Vec<Field>> {
+pub fn exprlist_to_fields(expr: &[Expr], input_schema: &Schema) -> Result<Vec<Field>> {
     expr.iter()
         .map(|e| expr_to_field(e, input_schema))
         .collect()

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -171,7 +171,7 @@ fn create_ctx() -> Result<ExecutionContext> {
     Ok(ctx)
 }
 
-fn custom_sqrt(args: &Vec<ArrayRef>) -> Result<ArrayRef> {
+fn custom_sqrt(args: &[ArrayRef]) -> Result<ArrayRef> {
     let input = &args[0]
         .as_any()
         .downcast_ref::<Float64Array>()
@@ -463,7 +463,7 @@ fn execute(ctx: &mut ExecutionContext, sql: &str) -> Vec<String> {
     result_str(&results)
 }
 
-fn result_str(results: &Vec<RecordBatch>) -> Vec<String> {
+fn result_str(results: &[RecordBatch]) -> Vec<String> {
     let mut result = vec![];
     for batch in results {
         for row_index in 0..batch.num_rows() {


### PR DESCRIPTION
Use slice instead of &Vec for function args