### PR TITLE
ARROW-8744: [Rust] handle channel close in parquet batch iterator

### DIFF
--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -36,7 +36,7 @@ use crate::error::{ArrowError, Result};
 /// serialization and computation functions, possibly incremental.  
 /// See also [CSV reader](crate::csv::Reader) and
 /// [JSON reader](crate::json::Reader).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RecordBatch {
     schema: Arc<Schema>,
     columns: Vec<Arc<Array>>,


### PR DESCRIPTION
Once reached end of iteration, calling next on ParquetIterator will
result in an error. This is inconvenient in two ways:

* when shared between multiple threads, only one of the thread will be
able to terminate without error

* sender for response_rx cannot terminate the iteration early and free
up resources. instead, it needs to always wait for signal from
request_tx before closing up the connection

This patch changed the next method to always return None after
connection has been closed by the sender to address the above mentioned
issues.