### PR TITLE
ARROW-8745: [C++] Enhance Bitmap::ToString test for big-endian platforms 

### DIFF
--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1241,17 +1241,13 @@ TEST(Bitmap, VisitPartialWords) {
 #endif  // ARROW_VALGRIND
 
 TEST(Bitmap, ToString) {
-  uint64_t bitmap_value = 0xCAAC, bitmap_storage = 0;
-  Bitmap bitmap(&bitmap_storage, 0, sizeof(uint64_t) * 8);
-  for (size_t i = 0; i < sizeof(uint64_t) * 8; i++) {
-    bitmap.SetBitTo(i, (bitmap_value & (1ULL << i)) ? true : false);
-  }
-  EXPECT_EQ(bitmap.Slice(/*bit_offset*/ 0, /*length=*/34).ToString(),
+  uint8_t bitmap[8] = {0xAC, 0xCA, 0, 0, 0, 0, 0, 0};
+  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 0, /*length=*/34).ToString(),
             "00110101 01010011 00000000 00000000 00");
-  EXPECT_EQ(bitmap.Slice(/*bit_offset*/ 0, /*length=*/16).ToString(),
+  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 0, /*length=*/16).ToString(),
             "00110101 01010011");
-  EXPECT_EQ(bitmap.Slice(/*bit_offset*/ 0, /*length=*/11).ToString(), "00110101 010");
-  EXPECT_EQ(bitmap.Slice(/*bit_offset*/ 3, /*length=*/8).ToString(), "10101010");
+  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 0, /*length=*/11).ToString(), "00110101 010");
+  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 3, /*length=*/8).ToString(), "10101010");
 }
 
 // compute bitwise AND of bitmaps using word-wise visit

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1243,12 +1243,21 @@ TEST(Bitmap, VisitPartialWords) {
 TEST(Bitmap, ToString) {
   uint64_t bitmap_value = 0xCAAC;
   uint8_t* bitmap = reinterpret_cast<uint8_t*>(&bitmap_value);
+#if ARROW_LITTLE_ENDIAN
   EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 0, /*length=*/34).ToString(),
             "00110101 01010011 00000000 00000000 00");
   EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 0, /*length=*/16).ToString(),
             "00110101 01010011");
   EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 0, /*length=*/11).ToString(), "00110101 010");
   EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 3, /*length=*/8).ToString(), "10101010");
+#else
+  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 30, /*length=*/34).ToString(),
+            "00000000 00000000 00010100 11001101 01");
+  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 48, /*length=*/16).ToString(),
+            "01010011 00110101");
+  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 48, /*length=*/11).ToString(), "01010011 001");
+  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 53, /*length=*/8).ToString(), "01100110");
+#endif
 }
 
 // compute bitwise AND of bitmaps using word-wise visit

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1244,7 +1244,7 @@ TEST(Bitmap, ToString) {
   uint64_t bitmap_value = 0xCAAC, bitmap_storage = 0;
   Bitmap bitmap(&bitmap_storage, 0, sizeof(uint64_t) * 8);
   for (size_t i = 0; i < sizeof(uint64_t) * 8; i++) {
-    bitmap.SetBitTo(i, (bitmap_value & (1L << i)) ? true : false);
+    bitmap.SetBitTo(i, (bitmap_value & (1ULL << i)) ? true : false);
   }
   EXPECT_EQ(bitmap.Slice(/*bit_offset*/ 0, /*length=*/34).ToString(),
             "00110101 01010011 00000000 00000000 00");

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1241,23 +1241,17 @@ TEST(Bitmap, VisitPartialWords) {
 #endif  // ARROW_VALGRIND
 
 TEST(Bitmap, ToString) {
-  uint64_t bitmap_value = 0xCAAC;
-  uint8_t* bitmap = reinterpret_cast<uint8_t*>(&bitmap_value);
-#if ARROW_LITTLE_ENDIAN
-  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 0, /*length=*/34).ToString(),
+  uint64_t bitmap_value = 0xCAAC, bitmap_storage = 0;
+  Bitmap bitmap(&bitmap_storage, 0, sizeof(uint64_t) * 8);
+  for (size_t i = 0; i < sizeof(uint64_t) * 8; i++) {
+    bitmap.SetBitTo(i, (bitmap_value & (1L << i)) ? true : false);
+  }
+  EXPECT_EQ(bitmap.Slice(/*bit_offset*/ 0, /*length=*/34).ToString(),
             "00110101 01010011 00000000 00000000 00");
-  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 0, /*length=*/16).ToString(),
+  EXPECT_EQ(bitmap.Slice(/*bit_offset*/ 0, /*length=*/16).ToString(),
             "00110101 01010011");
-  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 0, /*length=*/11).ToString(), "00110101 010");
-  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 3, /*length=*/8).ToString(), "10101010");
-#else
-  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 30, /*length=*/34).ToString(),
-            "00000000 00000000 00010100 11001101 01");
-  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 48, /*length=*/16).ToString(),
-            "01010011 00110101");
-  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 48, /*length=*/11).ToString(), "01010011 001");
-  EXPECT_EQ(Bitmap(bitmap, /*bit_offset*/ 53, /*length=*/8).ToString(), "01100110");
-#endif
+  EXPECT_EQ(bitmap.Slice(/*bit_offset*/ 0, /*length=*/11).ToString(), "00110101 010");
+  EXPECT_EQ(bitmap.Slice(/*bit_offset*/ 3, /*length=*/8).ToString(), "10101010");
 }
 
 // compute bitwise AND of bitmaps using word-wise visit


### PR DESCRIPTION
This PR fixes the failure of `Bitmap::ToString` that currently takes care of little-endian platforms. This test was added by #6987 

This PR updates the test using an endian-agnostic implementation.