### PR TITLE
ARROW-8553: [C++] Optimize unaligned bitmap operations

### DIFF
--- a/cpp/src/arrow/util/bit_util.cc
+++ b/cpp/src/arrow/util/bit_util.cc
@@ -299,13 +299,13 @@ void UnalignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* 
     const Word out_mask = (1U << out_offset) - 1;
 
     length -= (nwords - 1) * bits_per_word;
-    Word left_word0 = util::SafeLoadAs<Word>(left);
-    Word right_word0 = util::SafeLoadAs<Word>(right);
-    Word out_word0 = util::SafeLoadAs<Word>(out);
+    Word left_word0 = BitUtil::ToLittleEndian(util::SafeLoadAs<Word>(left));
+    Word right_word0 = BitUtil::ToLittleEndian(util::SafeLoadAs<Word>(right));
+    Word out_word0 = BitUtil::ToLittleEndian(util::SafeLoadAs<Word>(out));
 
     do {
       left += sizeof(Word);
-      const Word left_word1 = util::SafeLoadAs<Word>(left);
+      const Word left_word1 = BitUtil::ToLittleEndian(util::SafeLoadAs<Word>(left));
       Word left_word = left_word0;
       if (left_offset) {
         // combine two adjacent words into one word
@@ -325,7 +325,7 @@ void UnalignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* 
       left_word0 = left_word1;
 
       right += sizeof(Word);
-      const Word right_word1 = util::SafeLoadAs<Word>(right);
+      const Word right_word1 = BitUtil::ToLittleEndian(util::SafeLoadAs<Word>(right));
       Word right_word = right_word0;
       if (right_offset) {
         right_word >>= right_offset;
@@ -348,13 +348,14 @@ void UnalignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* 
         // |<--- out_word1 --->|<--- out_word0 --->|
         out_word = (out_word << out_offset) | (out_word >> (bits_per_word - out_offset));
         Word out_word1 = util::SafeLoadAs<Word>(out + sizeof(Word));
+        out_word1 = BitUtil::ToLittleEndian(out_word1);
         out_word0 = (out_word0 & out_mask) | (out_word & ~out_mask);
         out_word1 = (out_word1 & ~out_mask) | (out_word & out_mask);
-        util::SafeStore(out, out_word0);
-        util::SafeStore(out + sizeof(Word), out_word1);
+        util::SafeStore(out, BitUtil::FromLittleEndian(out_word0));
+        util::SafeStore(out + sizeof(Word), BitUtil::FromLittleEndian(out_word1));
         out_word0 = out_word1;
       } else {
-        util::SafeStore(out, out_word);
+        util::SafeStore(out, BitUtil::FromLittleEndian(out_word));
       }
       out += sizeof(Word);
 

--- a/cpp/src/arrow/util/bit_util.cc
+++ b/cpp/src/arrow/util/bit_util.cc
@@ -39,6 +39,7 @@
 #include "arrow/util/align_util.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/ubsan.h"
 
 namespace arrow {
 
@@ -256,11 +257,11 @@ bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right
 
 namespace {
 
-template <typename Op>
+template <template <typename> class BitOp>
 void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                      int64_t right_offset, uint8_t* out, int64_t out_offset,
                      int64_t length) {
-  Op op;
+  BitOp<uint8_t> op;
   DCHECK_EQ(left_offset % 8, right_offset % 8);
   DCHECK_EQ(left_offset % 8, out_offset % 8);
 
@@ -273,28 +274,115 @@ void AlignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* ri
   }
 }
 
-template <typename Op>
+template <template <typename> class BitOp, typename LogicalOp>
 void UnalignedBitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                        int64_t right_offset, uint8_t* out, int64_t out_offset,
                        int64_t length) {
-  Op op;
-  auto left_reader = internal::BitmapReader(left, left_offset, length);
-  auto right_reader = internal::BitmapReader(right, right_offset, length);
-  auto writer = internal::BitmapWriter(out, out_offset, length);
-  for (int64_t i = 0; i < length; ++i) {
-    if (op(left_reader.IsSet(), right_reader.IsSet())) {
-      writer.Set();
-    } else {
-      writer.Clear();
-    }
-    left_reader.Next();
-    right_reader.Next();
-    writer.Next();
+  using Word = uint64_t;
+
+  left += left_offset / 8;
+  right += right_offset / 8;
+  out += out_offset / 8;
+
+  left_offset %= 8;
+  right_offset %= 8;
+  out_offset %= 8;
+
+  const int64_t min_offset = std::min({left_offset, right_offset, out_offset});
+  const int64_t min_nbytes = BitUtil::BytesForBits(length + min_offset);
+  int64_t nwords = min_nbytes / sizeof(Word);
+
+  // process in words, we may touch two words in each iteration
+  if (nwords > 1) {
+    BitOp<Word> op;
+    constexpr int64_t bits_per_word = sizeof(Word) * 8;
+    const Word out_mask = (1U << out_offset) - 1;
+
+    length -= (nwords - 1) * bits_per_word;
+    Word left_word0 = util::SafeLoadAs<Word>(left);
+    Word right_word0 = util::SafeLoadAs<Word>(right);
+    Word out_word0 = util::SafeLoadAs<Word>(out);
+
+    do {
+      left += sizeof(Word);
+      const Word left_word1 = util::SafeLoadAs<Word>(left);
+      Word left_word = left_word0;
+      if (left_offset) {
+        // combine two adjacent words into one word
+        // |<-- left_word1 --->|<-- left_word0 --->|
+        // +-------------+-----+-------------+-----+
+        // |     ---     |  A  |      B      | --- |
+        // +-------------+-----+-------------+-----+
+        //                  |         |       offset
+        //                  v         v
+        //               +-----+-------------+
+        //               |  A  |      B      |
+        //               +-----+-------------+
+        //               |<--- left_word --->|
+        left_word >>= left_offset;
+        left_word |= left_word1 << (bits_per_word - left_offset);
+      }
+      left_word0 = left_word1;
+
+      right += sizeof(Word);
+      const Word right_word1 = util::SafeLoadAs<Word>(right);
+      Word right_word = right_word0;
+      if (right_offset) {
+        right_word >>= right_offset;
+        right_word |= right_word1 << (bits_per_word - right_offset);
+      }
+      right_word0 = right_word1;
+
+      Word out_word = op(left_word, right_word);
+      if (out_offset) {
+        // break one word into two adjacent words, don't touch unused bits
+        //               |<---- out_word --->|
+        //               +-----+-------------+
+        //               |  A  |      B      |
+        //               +-----+-------------+
+        //                  |         |
+        //                  v         v       offset
+        // +-------------+-----+-------------+-----+
+        // |     ---     |  A  |      B      | --- |
+        // +-------------+-----+-------------+-----+
+        // |<--- out_word1 --->|<--- out_word0 --->|
+        out_word = (out_word << out_offset) | (out_word >> (bits_per_word - out_offset));
+        Word out_word1 = util::SafeLoadAs<Word>(out + sizeof(Word));
+        out_word0 = (out_word0 & out_mask) | (out_word & ~out_mask);
+        out_word1 = (out_word1 & ~out_mask) | (out_word & out_mask);
+        util::SafeStore(out, out_word0);
+        util::SafeStore(out + sizeof(Word), out_word1);
+        out_word0 = out_word1;
+      } else {
+        util::SafeStore(out, out_word);
+      }
+      out += sizeof(Word);
+
+      --nwords;
+    } while (nwords > 1);
   }
-  writer.Finish();
+
+  // process in bits
+  if (length) {
+    auto left_reader = internal::BitmapReader(left, left_offset, length);
+    auto right_reader = internal::BitmapReader(right, right_offset, length);
+    auto writer = internal::BitmapWriter(out, out_offset, length);
+    LogicalOp op;
+    while (length--) {
+      if (op(left_reader.IsSet(), right_reader.IsSet())) {
+        writer.Set();
+      } else {
+        writer.Clear();
+      }
+      left_reader.Next();
+      right_reader.Next();
+      writer.Next();
+    }
+    writer.Finish();
+  }
 }
 
-template <typename BitOp, typename LogicalOp>
+template <template <typename> class BitOp, typename LogicalOp>
 void BitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* right,
               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* dest) {
   if ((out_offset % 8 == left_offset % 8) && (out_offset % 8 == right_offset % 8)) {
@@ -303,12 +391,12 @@ void BitmapOp(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                            length);
   } else {
     // Unaligned
-    UnalignedBitmapOp<LogicalOp>(left, left_offset, right, right_offset, dest, out_offset,
-                                 length);
+    UnalignedBitmapOp<BitOp, LogicalOp>(left, left_offset, right, right_offset, dest,
+                                        out_offset, length);
   }
 }
 
-template <typename BitOp, typename LogicalOp>
+template <template <typename> class BitOp, typename LogicalOp>
 Result<std::shared_ptr<Buffer>> BitmapOp(MemoryPool* pool, const uint8_t* left,
                                          int64_t left_offset, const uint8_t* right,
                                          int64_t right_offset, int64_t length,
@@ -357,42 +445,42 @@ Result<std::shared_ptr<Buffer>> BitmapAnd(MemoryPool* pool, const uint8_t* left,
                                           int64_t left_offset, const uint8_t* right,
                                           int64_t right_offset, int64_t length,
                                           int64_t out_offset) {
-  return BitmapOp<std::bit_and<uint8_t>, std::logical_and<bool>>(
-      pool, left, left_offset, right, right_offset, length, out_offset);
+  return BitmapOp<std::bit_and, std::logical_and<bool>>(pool, left, left_offset, right,
+                                                        right_offset, length, out_offset);
 }
 
 void BitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
-  BitmapOp<std::bit_and<uint8_t>, std::logical_and<bool>>(
-      left, left_offset, right, right_offset, length, out_offset, out);
+  BitmapOp<std::bit_and, std::logical_and<bool>>(left, left_offset, right, right_offset,
+                                                 length, out_offset, out);
 }
 
 Result<std::shared_ptr<Buffer>> BitmapOr(MemoryPool* pool, const uint8_t* left,
                                          int64_t left_offset, const uint8_t* right,
                                          int64_t right_offset, int64_t length,
                                          int64_t out_offset) {
-  return BitmapOp<std::bit_or<uint8_t>, std::logical_or<bool>>(
-      pool, left, left_offset, right, right_offset, length, out_offset);
+  return BitmapOp<std::bit_or, std::logical_or<bool>>(pool, left, left_offset, right,
+                                                      right_offset, length, out_offset);
 }
 
 void BitmapOr(const uint8_t* left, int64_t left_offset, const uint8_t* right,
               int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
-  BitmapOp<std::bit_or<uint8_t>, std::logical_or<bool>>(
-      left, left_offset, right, right_offset, length, out_offset, out);
+  BitmapOp<std::bit_or, std::logical_or<bool>>(left, left_offset, right, right_offset,
+                                               length, out_offset, out);
 }
 
 Result<std::shared_ptr<Buffer>> BitmapXor(MemoryPool* pool, const uint8_t* left,
                                           int64_t left_offset, const uint8_t* right,
                                           int64_t right_offset, int64_t length,
                                           int64_t out_offset) {
-  return BitmapOp<std::bit_xor<uint8_t>, std::bit_xor<bool>>(
-      pool, left, left_offset, right, right_offset, length, out_offset);
+  return BitmapOp<std::bit_xor, std::bit_xor<bool>>(pool, left, left_offset, right,
+                                                    right_offset, length, out_offset);
 }
 
 void BitmapXor(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                int64_t right_offset, int64_t length, int64_t out_offset, uint8_t* out) {
-  BitmapOp<std::bit_xor<uint8_t>, std::bit_xor<bool>>(
-      left, left_offset, right, right_offset, length, out_offset, out);
+  BitmapOp<std::bit_xor, std::bit_xor<bool>>(left, left_offset, right, right_offset,
+                                             length, out_offset, out);
 }
 
 Result<std::shared_ptr<Buffer>> BitmapAllButOne(MemoryPool* pool, int64_t length,

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -661,6 +661,33 @@ TEST_F(BitmapOp, Xor) {
   TestUnaligned(op, left, right, result);
 }
 
+TEST_F(BitmapOp, RandomXor) {
+  const int kBitCount = 1000;
+  uint8_t buffer[kBitCount * 2] = {0};
+
+  random_bytes(kBitCount * 2, 0, buffer);
+
+  std::vector<int> left(kBitCount);
+  std::vector<int> right(kBitCount);
+  std::vector<int> result(kBitCount);
+
+  for (int i = 0; i < kBitCount; ++i) {
+    left[i] = buffer[i] & 1;
+    right[i] = buffer[i + kBitCount] & 1;
+    result[i] = left[i] ^ right[i];
+  }
+
+  BitmapXorOp op;
+  for (int i = 0; i < 3; ++i) {
+    TestAligned(op, left, right, result);
+    TestUnaligned(op, left, right, result);
+
+    left.resize(left.size() * 5 / 11);
+    right.resize(left.size());
+    result.resize(left.size());
+  }
+}
+
 static inline int64_t SlowCountBits(const uint8_t* data, int64_t bit_offset,
                                     int64_t length) {
   int64_t count = 0;

--- a/cpp/src/arrow/util/ubsan.h
+++ b/cpp/src/arrow/util/ubsan.h
@@ -78,5 +78,11 @@ SafeCopy(T value) {
   return ret;
 }
 
+template <typename T>
+inline typename std::enable_if<std::is_trivial<T>::value, void>::type SafeStore(
+    void* unaligned, T value) {
+  std::memcpy(unaligned, &value, sizeof(T));
+}
+
 }  // namespace util
 }  // namespace arrow

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -462,7 +462,7 @@ def benchmark_run(ctx, rev_or_path, src, preserve, output, cmake_extras,
               help="Regression failure threshold in percentage.")
 @click.argument("contender", metavar="[<contender>",
                 default=ArrowSources.WORKSPACE, required=False)
-@click.argument("baseline", metavar="[<baseline>]]", default="master",
+@click.argument("baseline", metavar="[<baseline>]]", default="origin/master",
                 required=False)
 @click.pass_context
 def benchmark_diff(ctx, src, preserve, output, cmake_extras,


### PR DESCRIPTION
Unaligned bitmap operations are currently calculated bit-by-bit.
Processing it word-by-word in uint64 improves performance significantly.
BenchmarkBitmapAnd/32768/1 jumps from 56M/s to 4.1G/s on my test machine.

This patch also improves unit test to cover new code thoroughly.