### PR TITLE
ARROW-8747: [C++] Write compressed size in little-endian format for Feather V2 

### DIFF
--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -174,7 +174,8 @@ class RecordBatchSerializer {
     ARROW_ASSIGN_OR_RAISE(actual_length,
                           codec->Compress(buffer.size(), buffer.data(), maximum_length,
                                           result->mutable_data() + sizeof(int64_t)));
-    *reinterpret_cast<int64_t*>(result->mutable_data()) = buffer.size();
+    *reinterpret_cast<int64_t*>(result->mutable_data()) =
+        BitUtil::ToLittleEndian(buffer.size());
     *out = SliceBuffer(std::move(result), /*offset=*/0, actual_length + sizeof(int64_t));
     return Status::OK();
   }


### PR DESCRIPTION
This PR always puts the compressed size in little-endian format for Feather V2 since the reader expected the little-endian format.

Based on [the discussion](https://github.com/apache/arrow/pull/6777#discussion_r400770040) at #6777, [this commit](https://github.com/apache/arrow/pull/6777/commits/aa282801e18c2f13a145390ae3b42be23578a2d8) reads compressed_length in Feather V2 format as little-endian. However, the writer [puts compressed_length in native-endian](https://github.com/apache/arrow/blob/master/cpp/src/arrow/ipc/writer.cc#L177).

This PR can fix failures related to reading compressed feather format in `arrow-ipc-read-write-test` and `arrow-feather-test`.