### PR TITLE
ARROW-8751: [Rust] support empty parquet file in arrow array reader

### DIFF
--- a/rust/parquet/src/arrow/record_reader.rs
+++ b/rust/parquet/src/arrow/record_reader.rs
@@ -156,7 +156,10 @@ impl<T: DataType> RecordReader<T> {
     ///
     /// Number of actual records read.
     pub fn read_records(&mut self, num_records: usize) -> Result<usize> {
-        assert!(self.column_reader.is_some());
+        if self.column_reader.is_none() {
+            return Ok(0);
+        }
+
         let mut records_read = 0;
 
         // Used to mark whether we have reached the end of current


### PR DESCRIPTION
Sometimes spark will write out parquet files with zero row groups, which will result in error if read using ParquetFileArrowReader.

It would be more convenient if ParquetFileArrowReader can support this edge-case out of the box.