### PR TITLE
ARROW-8756: [C++] Fix Bitmap Words tests' failures on big-endian platforms

### DIFF
--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -999,16 +999,10 @@ class ARROW_EXPORT Bitmap : public util::ToStringOstreamable<Bitmap>,
           if (offsets[i] == 0) {
             visited_words[i] = words[i][word_i];
           } else {
-#if ARROW_LITTLE_ENDIAN
-            visited_words[i] = words[i][word_i] >> offsets[i];
-            visited_words[i] |= words[i][word_i + 1] << (kBitWidth - offsets[i]);
-#else
-            auto words0 = BitUtil::ByteSwap(words[i][word_i]);
-            auto words1 = BitUtil::ByteSwap(words[i][word_i + 1]);
-            auto visited_word =
-                (words0 >> offsets[i]) | (words1 << (kBitWidth - offsets[i]));
-            visited_words[i] = BitUtil::ByteSwap(visited_word);
-#endif
+            auto words0 = BitUtil::ToLittleEndian(words[i][word_i]);
+            auto words1 = BitUtil::ToLittleEndian(words[i][word_i + 1]);
+            visited_words[i] = BitUtil::FromLittleEndian(
+                (words0 >> offsets[i]) | (words1 << (kBitWidth - offsets[i])));
           }
         }
         visitor(visited_words);

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -999,8 +999,16 @@ class ARROW_EXPORT Bitmap : public util::ToStringOstreamable<Bitmap>,
           if (offsets[i] == 0) {
             visited_words[i] = words[i][word_i];
           } else {
+#if ARROW_LITTLE_ENDIAN
             visited_words[i] = words[i][word_i] >> offsets[i];
             visited_words[i] |= words[i][word_i + 1] << (kBitWidth - offsets[i]);
+#else
+            auto words0 = BitUtil::ByteSwap(words[i][word_i]);
+            auto words1 = BitUtil::ByteSwap(words[i][word_i + 1]);
+            auto visited_word =
+                (words0 >> offsets[i]) | (words1 << (kBitWidth - offsets[i]));
+            visited_words[i] = BitUtil::ByteSwap(visited_word);
+#endif
           }
         }
         visitor(visited_words);

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1160,8 +1160,7 @@ TEST(Bitmap, ShiftingWordsOptimization) {
         ASSERT_EQ(BitUtil::GetBit(bytes, i), bool((native_words0 >> i) & 1));
       }
       for (size_t i = 0; i < kBitWidth; ++i) {
-        ASSERT_EQ(BitUtil::GetBit(bytes, i + kBitWidth),
-                  bool((native_words1 >> i) & 1));
+        ASSERT_EQ(BitUtil::GetBit(bytes, i + kBitWidth), bool((native_words1 >> i) & 1));
       }
 
       // bit offset can therefore be accommodated by shifting the word


### PR DESCRIPTION
This PR adds support of multiple-word operation on big-endian platforms. There are optimized code to concat multiple words into one word with bit shift operations. The current code assumes a little-endian platform.   
This code support bit-endian by adding conversions between little-endian and big-endian. This is because the shift operations assume the little-endian layout. It is easy to implement by adding conversions.

With #7136 and this PR, the following failures in arrow-utility-test will be fixed.
```
[  FAILED  ] Bitmap.VisitWordsAnd
[  FAILED  ] Bitmap.ShiftingWordsOptimization
```