### PR TITLE
ARROW-8757: [C++][Plasma] Write Plasma header in little-endian format

### DIFF
--- a/cpp/src/plasma/io.cc
+++ b/cpp/src/plasma/io.cc
@@ -22,6 +22,7 @@
 #include <sstream>
 
 #include "arrow/status.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/logging.h"
 
 #include "plasma/common.h"
@@ -63,10 +64,14 @@ Status WriteBytes(int fd, uint8_t* cursor, size_t length) {
 }
 
 Status WriteMessage(int fd, MessageType type, int64_t length, uint8_t* bytes) {
-  int64_t version = kPlasmaProtocolVersion;
+  int64_t version = arrow::BitUtil::ToLittleEndian(kPlasmaProtocolVersion);
+  static_assert(sizeof(MessageType) == sizeof(int64_t));
+  type = static_cast<MessageType>(
+      arrow::BitUtil::ToLittleEndian(static_cast<int64_t>(type)));
+  int64_t length_le = arrow::BitUtil::ToLittleEndian(length);
   RETURN_NOT_OK(WriteBytes(fd, reinterpret_cast<uint8_t*>(&version), sizeof(version)));
   RETURN_NOT_OK(WriteBytes(fd, reinterpret_cast<uint8_t*>(&type), sizeof(type)));
-  RETURN_NOT_OK(WriteBytes(fd, reinterpret_cast<uint8_t*>(&length), sizeof(length)));
+  RETURN_NOT_OK(WriteBytes(fd, reinterpret_cast<uint8_t*>(&length_le), sizeof(length)));
   return WriteBytes(fd, bytes, length * sizeof(char));
 }
 
@@ -97,15 +102,19 @@ Status ReadMessage(int fd, MessageType* type, std::vector<uint8_t>* buffer) {
   int64_t version;
   RETURN_NOT_OK_ELSE(ReadBytes(fd, reinterpret_cast<uint8_t*>(&version), sizeof(version)),
                      *type = MessageType::PlasmaDisconnectClient);
+  version = arrow::BitUtil::FromLittleEndian(version);
   ARROW_CHECK(version == kPlasmaProtocolVersion) << "version = " << version;
   RETURN_NOT_OK_ELSE(ReadBytes(fd, reinterpret_cast<uint8_t*>(type), sizeof(*type)),
                      *type = MessageType::PlasmaDisconnectClient);
+  static_assert(sizeof(MessageType) == sizeof(int64_t));
+  *type = static_cast<MessageType>(
+      arrow::BitUtil::FromLittleEndian(static_cast<int64_t>(*type)));
   int64_t length_temp;
   RETURN_NOT_OK_ELSE(
       ReadBytes(fd, reinterpret_cast<uint8_t*>(&length_temp), sizeof(length_temp)),
       *type = MessageType::PlasmaDisconnectClient);
   // The length must be read as an int64_t, but it should be used as a size_t.
-  size_t length = static_cast<size_t>(length_temp);
+  size_t length = static_cast<size_t>(arrow::BitUtil::FromLittleEndian(length_temp));
   if (length > buffer->size()) {
     buffer->resize(length);
   }

--- a/cpp/src/plasma/io.cc
+++ b/cpp/src/plasma/io.cc
@@ -65,7 +65,7 @@ Status WriteBytes(int fd, uint8_t* cursor, size_t length) {
 
 Status WriteMessage(int fd, MessageType type, int64_t length, uint8_t* bytes) {
   int64_t version = arrow::BitUtil::ToLittleEndian(kPlasmaProtocolVersion);
-  static_assert(sizeof(MessageType) == sizeof(int64_t));
+  assert(sizeof(MessageType) == sizeof(int64_t));
   type = static_cast<MessageType>(
       arrow::BitUtil::ToLittleEndian(static_cast<int64_t>(type)));
   int64_t length_le = arrow::BitUtil::ToLittleEndian(length);
@@ -106,7 +106,7 @@ Status ReadMessage(int fd, MessageType* type, std::vector<uint8_t>* buffer) {
   ARROW_CHECK(version == kPlasmaProtocolVersion) << "version = " << version;
   RETURN_NOT_OK_ELSE(ReadBytes(fd, reinterpret_cast<uint8_t*>(type), sizeof(*type)),
                      *type = MessageType::PlasmaDisconnectClient);
-  static_assert(sizeof(MessageType) == sizeof(int64_t));
+  assert(sizeof(MessageType) == sizeof(int64_t));
   *type = static_cast<MessageType>(
       arrow::BitUtil::FromLittleEndian(static_cast<int64_t>(*type)));
   int64_t length_temp;


### PR DESCRIPTION
This PR writes and reads Plasma header (version, type, and length) in the big-endian format. It allows us to make it easy to interpret a header of Plasma data among different endian machines.

The current issue is to write Plasma header in native endian at [here](https://github.com/apache/arrow/blob/master/cpp/src/plasma/io.cc#L65-L71). It is not possible to know version, type, and length of a given Plasma file among different platforms. Feather V2 also uses little-endian for the header based on [the discussion](https://github.com/apache/arrow/pull/6777#discussion_r400770040). This PR uses little-endian by following this discussion.