### PR TITLE
ARROW-8759: [C++][Plasma] Fix TestPlasmaSerialization.DeleteReply failure on big-endian platforms

### DIFF
--- a/cpp/src/plasma/protocol.cc
+++ b/cpp/src/plasma/protocol.cc
@@ -508,7 +508,7 @@ Status ReadDeleteReply(const uint8_t* data, size_t size,
     return ObjectID::from_binary(request.object_ids()->Get(i)->str());
   });
   ToVector(*message, errors, [](const PlasmaDeleteReply& request, int i) {
-    return static_cast<PlasmaError>(request.errors()->data()[i]);
+    return static_cast<PlasmaError>(request.errors()->Get(i));
   });
   return Status::OK();
 }


### PR DESCRIPTION
This PR gets an element data using an endianless API in Flatbuffer instead of getting a pointer. This can fix a failure of TestPlasmaSerialization.DeleteReply in plasma-serialization-tests.

Without this PR
```
1: [==========] Running 14 tests from 1 test case.
1: [----------] Global test environment set-up.
1: [----------] 14 tests from TestPlasmaSerialization
1: [ RUN      ] TestPlasmaSerialization.CreateRequest
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-kk8t88p9/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.CreateRequest (2 ms)
1: [ RUN      ] TestPlasmaSerialization.CreateReply
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-97gspx5v/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.CreateReply (0 ms)
1: [ RUN      ] TestPlasmaSerialization.SealRequest
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-dkksx76p/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.SealRequest (1 ms)
1: [ RUN      ] TestPlasmaSerialization.SealReply
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-oqbs9vm0/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.SealReply (0 ms)
1: [ RUN      ] TestPlasmaSerialization.GetRequest
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-d7q6h5q4/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.GetRequest (1 ms)
1: [ RUN      ] TestPlasmaSerialization.GetReply
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-sxsncs72/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.GetReply (1 ms)
1: [ RUN      ] TestPlasmaSerialization.ReleaseRequest
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-njc3g3b5/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.ReleaseRequest (0 ms)
1: [ RUN      ] TestPlasmaSerialization.ReleaseReply
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-917ybxmo/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.ReleaseReply (1 ms)
1: [ RUN      ] TestPlasmaSerialization.DeleteRequest
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-1kwauefv/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.DeleteRequest (0 ms)
1: [ RUN      ] TestPlasmaSerialization.DeleteReply
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-4ftq28pq/fileXXXXXX'
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:271: Failure
1: Value of: error_vec[0] == PlasmaError::ObjectExists
1:   Actual: false
1: Expected: true
1: [  FAILED  ] TestPlasmaSerialization.DeleteReply (1 ms)
1: [ RUN      ] TestPlasmaSerialization.EvictRequest
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-vl97870w/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.EvictRequest (0 ms)
1: [ RUN      ] TestPlasmaSerialization.EvictReply
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-3am9a6rv/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.EvictReply (1 ms)
1: [ RUN      ] TestPlasmaSerialization.DataRequest
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-plye5tmm/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.DataRequest (0 ms)
1: [ RUN      ] TestPlasmaSerialization.DataReply
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma/test/serialization_tests.cc:87: file path: '/tmp/ser-test-mbu6lqsq/fileXXXXXX'
1: [       OK ] TestPlasmaSerialization.DataReply (1 ms)
1: [----------] 14 tests from TestPlasmaSerialization (9 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 14 tests from 1 test case ran. (9 ms total)
1: [  PASSED  ] 13 tests.
1: [  FAILED  ] 1 test, listed below:
1: [  FAILED  ] TestPlasmaSerialization.DeleteReply
1: 
1:  1 FAILED TEST
1: /home/ishizaki/Arrow/arrow/cpp/src/plasma
1/3 Test #1: plasma-serialization-tests .......***Failed    0.27 sec
...
3/3 Test #3: plasma-external-store-tests ......   Passed    0.46 sec
```

With this PR
```
$ ctest 
Test project /home/ishizaki/Arrow/arrow/cpp/src/plasma
    Start 1: plasma-serialization-tests
1/3 Test #1: plasma-serialization-tests .......   Passed    0.26 sec
    Start 2: plasma-client-tests
2/3 Test #2: plasma-client-tests ..............   Passed   14.99 sec
    Start 3: plasma-external-store-tests
3/3 Test #3: plasma-external-store-tests ......   Passed    0.49 sec

100% tests passed, 0 tests failed out of 3

Label Time Summary:
plasma-tests    =  15.74 sec (3 tests)
unittest        =  15.74 sec (3 tests)

Total Test time (real) =  15.74 sec
```