### PR TITLE
ARROW-8775: [C++][FlightRPC] fix integration tests

### DIFF
--- a/cpp/src/arrow/flight/test_integration_client.cc
+++ b/cpp/src/arrow/flight/test_integration_client.cc
@@ -217,5 +217,6 @@ int main(int argc, char** argv) {
   arrow::flight::Location location;
   ABORT_NOT_OK(arrow::flight::Location::ForGrpcTcp(FLAGS_host, FLAGS_port, &location));
   ABORT_NOT_OK(arrow::flight::FlightClient::Connect(location, options, &client));
+  ABORT_NOT_OK(scenario->RunClient(std::move(client)));
   return 0;
 }


### PR DESCRIPTION
A bad rebase meant the C++ client wasn't running integration tests.