### PR TITLE
ARROW-8684: [Python] Workaround Cython type initialization bug

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -29,6 +29,7 @@ streaming messaging and interprocess communication.
 For more information see the official page at https://arrow.apache.org
 """
 
+import gc as _gc
 import os as _os
 import sys as _sys
 
@@ -55,6 +56,14 @@ except ImportError:
 
 
 import pyarrow.compat as compat
+
+# ARROW-8684: Disable GC while initializing Cython extension module,
+# to workaround Cython bug in https://github.com/cython/cython/issues/3603
+_gc_enabled = _gc.isenabled()
+_gc.disable()
+import pyarrow.lib as _lib
+if _gc_enabled:
+    _gc.enable()
 
 from pyarrow.lib import cpu_count, set_cpu_count
 from pyarrow.lib import (null, bool_,


### PR DESCRIPTION
This should fix a crash on some macOS builds.