### PR TITLE
ARROW-8778: [C++][Gandiva] Fix SelectionVector related failure on big-endian platform 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ jobs:
         ARCH: s390x
         ARROW_CI_MODULES: "CPP"
         ARROW_FLIGHT: "ON"
-        ARROW_GANDIVA: "OFF"
         ARROW_PARQUET: "OFF"
         DOCKER_IMAGE_ID: ubuntu-cpp
         PARQUET_BUILD_EXAMPLES: "OFF"
@@ -91,7 +90,6 @@ script:
   - |
     archery docker run \
       -e ARROW_FLIGHT=${ARROW_FLIGHT:-OFF} \
-      -e ARROW_GANDIVA=${ARROW_GANDIVA:-ON} \
       -e ARROW_PARQUET=${ARROW_PARQUET:-ON} \
       -e PARQUET_BUILD_EXAMPLES=${PARQUET_BUILD_EXAMPLES:-ON} \
       -e PARQUET_BUILD_EXECUTABLES=${PARQUET_BUILD_EXECUTABLES:-ON} \

--- a/cpp/src/gandiva/selection_vector.cc
+++ b/cpp/src/gandiva/selection_vector.cc
@@ -49,7 +49,7 @@ Status SelectionVector::PopulateFromBitMap(const uint8_t* bitmap, int64_t bitmap
   int64_t selection_idx = 0;
   const uint64_t* bitmap_64 = reinterpret_cast<const uint64_t*>(bitmap);
   for (int64_t bitmap_idx = 0; bitmap_idx < bitmap_size / 8; ++bitmap_idx) {
-    uint64_t current_word = bitmap_64[bitmap_idx];
+    uint64_t current_word = arrow::BitUtil::ToLittleEndian(bitmap_64[bitmap_idx]);
 
     while (current_word != 0) {
 #if defined(_MSC_VER)


### PR DESCRIPTION
This PR consists of two items:
1. Support big-endian for `SelectionVector::PopulateFromBitMap`. This optimized bit operation assumed only little-endian platforms.
2. Enable gandiva build & test on s390x (we still see failures related to decimal128).