### PR TITLE
ARROW-8783: [Rust] [DataFusion] Add ParquetScan and CsvScan variants in LogicalPlan

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -307,7 +307,7 @@ impl ExecutionContext {
                 ..
             } => Ok(Arc::new(CsvExec::try_new(
                 path,
-                schema.clone(),
+                Arc::new(schema.as_ref().to_owned()),
                 *has_header,
                 projection.to_owned(),
                 batch_size,

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -33,6 +33,7 @@ use crate::datasource::parquet::ParquetTable;
 use crate::datasource::TableProvider;
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::common;
+use crate::execution::physical_plan::csv::CsvExec;
 use crate::execution::physical_plan::datasource::DatasourceExec;
 use crate::execution::physical_plan::expressions::{
     Alias, Avg, BinaryExpr, CastExpr, Column, Count, Literal, Max, Min, Sum,
@@ -41,6 +42,7 @@ use crate::execution::physical_plan::hash_aggregate::HashAggregateExec;
 use crate::execution::physical_plan::limit::LimitExec;
 use crate::execution::physical_plan::math_expressions::register_math_functions;
 use crate::execution::physical_plan::merge::MergeExec;
+use crate::execution::physical_plan::parquet::ParquetExec;
 use crate::execution::physical_plan::projection::ProjectionExec;
 use crate::execution::physical_plan::selection::SelectionExec;
 use crate::execution::physical_plan::udf::{ScalarFunction, ScalarFunctionExpr};
@@ -297,6 +299,26 @@ impl ExecutionContext {
                     table_name
                 ))),
             },
+            LogicalPlan::CsvScan {
+                path,
+                schema,
+                has_header,
+                projection,
+                ..
+            } => Ok(Arc::new(CsvExec::try_new(
+                path,
+                schema.clone(),
+                *has_header,
+                projection.to_owned(),
+                batch_size,
+            )?)),
+            LogicalPlan::ParquetScan {
+                path, projection, ..
+            } => Ok(Arc::new(ParquetExec::try_new(
+                path,
+                projection.to_owned(),
+                batch_size,
+            )?)),
             LogicalPlan::Projection { input, expr, .. } => {
                 let input = self.create_physical_plan(input, batch_size)?;
                 let input_schema = input.as_ref().schema().clone();

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -525,6 +525,28 @@ pub enum LogicalPlan {
         /// Optional column indices to use as a projection
         projection: Option<Vec<usize>>,
     },
+    /// A table scan against a Parquet data source
+    ParquetScan {
+        /// The path to the files
+        path: String,
+        /// Optional column indices to use as a projection
+        projection: Option<Vec<usize>>,
+        /// The projected schema
+        projected_schema: Arc<Schema>,
+    },
+    /// A table scan against a CSV data source
+    CsvScan {
+        /// The path to the files
+        path: String,
+        /// The underlying table schema
+        schema: Arc<Schema>,
+        /// Whether the CSV file(s) have a header containing column names
+        has_header: bool,
+        /// Optional column indices to use as a projection
+        projection: Option<Vec<usize>>,
+        /// The projected schema
+        projected_schema: Arc<Schema>,
+    },
     /// An empty relation with an empty schema
     EmptyRelation {
         /// The schema description
@@ -559,6 +581,12 @@ impl LogicalPlan {
     pub fn schema(&self) -> &Box<Schema> {
         match self {
             LogicalPlan::EmptyRelation { schema } => &schema,
+            LogicalPlan::CsvScan {
+                projected_schema, ..
+            } => &projected_schema,
+            LogicalPlan::ParquetScan {
+                projected_schema, ..
+            } => &projected_schema,
             LogicalPlan::TableScan {
                 projected_schema, ..
             } => &projected_schema,
@@ -587,6 +615,16 @@ impl LogicalPlan {
                 ref projection,
                 ..
             } => write!(f, "TableScan: {} projection={:?}", table_name, projection),
+            LogicalPlan::CsvScan {
+                ref path,
+                ref projection,
+                ..
+            } => write!(f, "CsvScan: {} projection={:?}", path, projection),
+            LogicalPlan::ParquetScan {
+                ref path,
+                ref projection,
+                ..
+            } => write!(f, "ParquetScan: {} projection={:?}", path, projection),
             LogicalPlan::Projection {
                 ref expr,
                 ref input,
@@ -726,6 +764,20 @@ impl LogicalPlanBuilder {
         Self::from(&LogicalPlan::EmptyRelation {
             schema: Box::new(Schema::empty()),
         })
+    }
+
+    /// Scan a CSV data source
+    pub fn scan_csv(
+        path: &str,
+        schema: &Schema,
+        projection: Option<Vec<usize>>,
+    ) -> Result<Self> {
+        unimplemented!()
+    }
+
+    /// Scan a Parquet data source
+    pub fn scan_parquet(path: &str, projection: Option<Vec<usize>>) -> Result<Self> {
+        unimplemented!()
     }
 
     /// Scan a data source

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -769,15 +769,36 @@ impl LogicalPlanBuilder {
     /// Scan a CSV data source
     pub fn scan_csv(
         path: &str,
+        has_header: bool,
         schema: &Schema,
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
-        unimplemented!()
+        let projected_schema = projection.clone().map(|p| {
+            Schema::new(p.iter().map(|i| table_schema.field(*i).clone()).collect())
+        });
+        Ok(Self::from(&LogicalPlan::CsvScan {
+            path: path.to_owned(),
+            schema: Arc::new(schema.to_owned()),
+            has_header,
+            projection,
+            projected_schema: Arc::new(
+                projected_schema.or(Some(table_schema.clone())).unwrap(),
+            )
+        }))
     }
 
     /// Scan a Parquet data source
     pub fn scan_parquet(path: &str, projection: Option<Vec<usize>>) -> Result<Self> {
-        unimplemented!()
+        let projected_schema = projection.clone().map(|p| {
+            Schema::new(p.iter().map(|i| table_schema.field(*i).clone()).collect())
+        });
+        Ok(Self::from(&LogicalPlan::ParquetScan {
+            path: path.to_owned(),
+            projection,
+            projected_schema: Arc::new(
+                projected_schema.or(Some(table_schema.clone())).unwrap(),
+            )
+        }))
     }
 
     /// Scan a data source

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -157,6 +157,21 @@ impl ProjectionPushDown {
                     projection: Some(projection),
                 })
             }
+            LogicalPlan::CsvScan {
+                path,
+                schema,
+                projection,
+                ..
+            } => {
+                //TODO refactor TableScan code from above so it can be re-used here
+                unimplemented!()
+            }
+            LogicalPlan::ParquetScan {
+                path, projection, ..
+            } => {
+                //TODO refactor TableScan code from above so it can be re-used here
+                unimplemented!()
+            }
             LogicalPlan::Limit { expr, input, .. } => {
                 // Note that limit expressions are scalar values so there is no need to
                 // rewrite them but we do need to optimize the input to the limit plan

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -102,51 +102,8 @@ impl ProjectionPushDown {
                 projection,
                 ..
             } => {
-                if projection.is_some() {
-                    return Err(ExecutionError::General(
-                        "Cannot run projection push-down rule more than once".to_string(),
-                    ));
-                }
-
-                // once we reach the table scan, we can use the accumulated set of column
-                // indexes as the projection in the table scan
-                let mut projection: Vec<usize> = Vec::with_capacity(accum.len());
-                accum.iter().for_each(|i| projection.push(*i));
-
-                // Ensure that we are reading at least one column from the table in case the query
-                // does not reference any columns directly such as "SELECT COUNT(1) FROM table"
-                if projection.is_empty() {
-                    projection.push(0);
-                }
-
-                // sort the projection otherwise we get non-deterministic behavior
-                projection.sort();
-
-                // create the projected schema
-                let mut projected_fields: Vec<Field> =
-                    Vec::with_capacity(projection.len());
-                for i in &projection {
-                    projected_fields.push(table_schema.fields()[*i].clone());
-                }
-
-                let projected_schema = Schema::new(projected_fields);
-
-                // now that the table scan is returning a different schema we need to
-                // create a mapping from the original column index to the
-                // new column index so that we can rewrite expressions as
-                // we walk back up the tree
-
-                if mapping.len() != 0 {
-                    return Err(ExecutionError::InternalError(
-                        "illegal state".to_string(),
-                    ));
-                }
-
-                for i in 0..table_schema.fields().len() {
-                    if let Some(n) = projection.iter().position(|v| *v == i) {
-                        mapping.insert(i, n);
-                    }
-                }
+                let (projection, projected_schema) =
+                    get_projected_schema(&table_schema, projection, accum, mapping)?;
 
                 // return the table scan with projection
                 Ok(LogicalPlan::TableScan {
@@ -159,18 +116,37 @@ impl ProjectionPushDown {
             }
             LogicalPlan::CsvScan {
                 path,
+                has_header,
                 schema,
                 projection,
                 ..
             } => {
-                //TODO refactor TableScan code from above so it can be re-used here
-                unimplemented!()
+                let (projection, projected_schema) =
+                    get_projected_schema(&schema, projection, accum, mapping)?;
+
+                Ok(LogicalPlan::CsvScan {
+                    path: path.to_owned(),
+                    has_header: *has_header,
+                    schema: schema.clone(),
+                    projection: Some(projection),
+                    projected_schema: Box::new(projected_schema),
+                })
             }
             LogicalPlan::ParquetScan {
-                path, projection, ..
+                path,
+                schema,
+                projection,
+                ..
             } => {
-                //TODO refactor TableScan code from above so it can be re-used here
-                unimplemented!()
+                let (projection, projected_schema) =
+                    get_projected_schema(&schema, projection, accum, mapping)?;
+
+                Ok(LogicalPlan::ParquetScan {
+                    path: path.to_owned(),
+                    schema: schema.clone(),
+                    projection: Some(projection),
+                    projected_schema: Box::new(projected_schema),
+                })
             }
             LogicalPlan::Limit { expr, input, .. } => {
                 // Note that limit expressions are scalar values so there is no need to
@@ -267,6 +243,56 @@ impl ProjectionPushDown {
             )),
         }
     }
+}
+
+fn get_projected_schema(
+    table_schema: &Schema,
+    projection: &Option<Vec<usize>>,
+    accum: &HashSet<usize>,
+    mapping: &mut HashMap<usize, usize>,
+) -> Result<(Vec<usize>, Schema)> {
+    if projection.is_some() {
+        return Err(ExecutionError::General(
+            "Cannot run projection push-down rule more than once".to_string(),
+        ));
+    }
+
+    // once we reach the table scan, we can use the accumulated set of column
+    // indexes as the projection in the table scan
+    let mut projection: Vec<usize> = Vec::with_capacity(accum.len());
+    accum.iter().for_each(|i| projection.push(*i));
+
+    // Ensure that we are reading at least one column from the table in case the query
+    // does not reference any columns directly such as "SELECT COUNT(1) FROM table"
+    if projection.is_empty() {
+        projection.push(0);
+    }
+
+    // sort the projection otherwise we get non-deterministic behavior
+    projection.sort();
+
+    // create the projected schema
+    let mut projected_fields: Vec<Field> = Vec::with_capacity(projection.len());
+    for i in &projection {
+        projected_fields.push(table_schema.fields()[*i].clone());
+    }
+
+    // now that the table scan is returning a different schema we need to
+    // create a mapping from the original column index to the
+    // new column index so that we can rewrite expressions as
+    // we walk back up the tree
+
+    if mapping.len() != 0 {
+        return Err(ExecutionError::InternalError("illegal state".to_string()));
+    }
+
+    for i in 0..table_schema.fields().len() {
+        if let Some(n) = projection.iter().position(|v| *v == i) {
+            mapping.insert(i, n);
+        }
+    }
+
+    Ok((projection, Schema::new(projected_fields)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR makes it possible to build a logical plan that reads CSV or Parquet data sources without the need to create an execution context and register data sources.

This makes it easier for other crates to leverage the DataFusion logical plan builder and query optimizer and then execute the query by other means. It also simplifies direct use of DataFusion in some cases.