### PR TITLE
ARROW-8786: [Packaging][rpm] Use bundled zstd in the CentOS 8 build

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -45,6 +45,7 @@
 %define use_meson (%{_centos_ver} >= 8)
 
 %define have_rapidjson (%{_centos_ver} == 7)
+%define have_zstd (%{_centos_ver} < 8)
 
 Name:		@PACKAGE@
 Version:	@VERSION@
@@ -70,7 +71,9 @@ BuildRequires:	git
 %if %{_centos_ver} >= 7
 BuildRequires:	glog-devel
 %endif
+%if %{have_zstd}
 BuildRequires:	libzstd-devel
+%endif
 BuildRequires:	lz4-devel
 BuildRequires:	pkgconfig
 BuildRequires:	python%{python_version}-devel

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -222,7 +222,9 @@ Requires:	brotli
 Requires:	gflags
 Requires:	glog
 %endif
+%if %{have_zstd}
 Requires:	libzstd
+%endif
 Requires:	lz4
 %if %{_centos_ver} >= 8
 Requires:	re2

--- a/dev/tasks/linux-packages/apache-arrow/yum/centos-8/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/centos-8/Dockerfile
@@ -39,7 +39,7 @@ RUN \
     glog-devel \
     gobject-introspection-devel \
     gtk-doc \
-    libzstd-devel \
+    # libzstd-devel \
     llvm-devel \
     llvm-static \
     lz4-devel \


### PR DESCRIPTION
There was an update in the epel-release repository in the last 12 hours, since then yum/dnf is unable to find libzstd-devel.

libzstd is added to the BaseOS repository and removed from EPEL:
https://src.fedoraproject.org/rpms/zstd/c/2eaa0955a5176319f2a59294ee339cb2fff87bc5?branch=epel8

But CentOS 8 that includes zstd isn't released yet. We'll be able to revert this change with the next CentOS 8 release.