### PR TITLE
ARROW-8789: [Rust] Add separate crate for integration test binaries

### DIFF
--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -481,6 +481,13 @@ class PrepareTest < Test::Unit::TestCase
                      ],
                    },
                    {
+                     path: "rust/integration-testing/Cargo.toml",
+                     hunks: [
+                       ["-version = \"#{@release_version}\"",
+                        "+version = \"#{@next_snapshot_version}\""],
+                     ],
+                   },
+                   {
                      path: "rust/parquet/Cargo.toml",
                      hunks: [
                        ["-version = \"#{@release_version}\"",

--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -290,6 +290,13 @@ class PrepareTest < Test::Unit::TestCase
                      ],
                    },
                    {
+                     path: "rust/integration-testing/Cargo.toml",
+                     hunks: [
+                       ["-version = \"#{@snapshot_version}\"",
+                        "+version = \"#{@release_version}\""],
+                     ],
+                   },
+                   {
                      path: "rust/parquet/Cargo.toml",
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,5 +21,5 @@ members = [
         "parquet",
         "datafusion",
         "arrow-flight",
-	"integration-testing",
+        "integration-testing",
 ]

--- a/rust/integration-testing/Cargo.toml
+++ b/rust/integration-testing/Cargo.toml
@@ -15,11 +15,28 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[workspace]
-members = [
-        "arrow",
-        "parquet",
-        "datafusion",
-        "arrow-flight",
-	"integration-testing",
-]
+[package]
+name = "arrow-integration-testing"
+description = "Binaries used in the Arrow integration tests"
+version = "0.18.0-SNAPSHOT"
+homepage = "https://github.com/apache/arrow"
+repository = "https://github.com/apache/arrow"
+authors = ["Apache Arrow <dev@arrow.apache.org>"]
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+arrow = { path = "../arrow" }
+clap = "2.33"
+
+[[bin]]
+name = "arrow-file-to-stream"
+path = "src/bin/arrow-file-to-stream.rs"
+
+[[bin]]
+name = "arrow-stream-to-file"
+path = "src/bin/arrow-stream-to-file.rs"
+
+[[bin]]
+name = "arrow-json-integration-test"
+path = "src/bin/arrow-json-integration-test.rs"

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+fn main() {
+    panic!("not implemented");
+}

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+fn main() {
+    panic!("not implemented");
+}

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -1,0 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+fn main() {
+    panic!("not implemented");
+}

--- a/rust/integration-testing/src/lib.rs
+++ b/rust/integration-testing/src/lib.rs
@@ -1,0 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Common code used in the integration test binaries


### PR DESCRIPTION
This PR simply adds a separate crate for integration test binaries with binaries that do nothing yet.

Since this crate is not one we ship, I think we can more freely accept PRs into this crate as we collaborate on the integration testing, and this will have lower overhead than maintaining a separate branch for integration testing, IMHO.