### PR TITLE
ARROW-5359: [Python] Support non-nanosecond out-of-range timestamps in conversion to pandas

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -934,6 +934,17 @@ struct ObjectWriterVisitor {
     return ConvertAsPyObjects<Type>(options, data, WrapValue, out_values);
   }
 
+  template <typename Type>
+  enable_if_timestamp<Type, Status> Visit(const Type& type) {
+    const TimeUnit::type unit = type.unit();
+    auto WrapValue = [unit](typename Type::c_type value, PyObject** out) {
+      RETURN_NOT_OK(internal::PyDateTime_from_int(value, unit, out));
+      RETURN_IF_PYERROR();
+      return Status::OK();
+    };
+    return ConvertAsPyObjects<Type>(options, data, WrapValue, out_values);
+  }
+
   Status Visit(const Decimal128Type& type) {
     OwnedRef decimal;
     OwnedRef Decimal;
@@ -982,7 +993,6 @@ struct ObjectWriterVisitor {
                   std::is_same<DurationType, Type>::value ||
                   std::is_same<ExtensionType, Type>::value ||
                   std::is_base_of<IntervalType, Type>::value ||
-                  std::is_same<TimestampType, Type>::value ||
                   std::is_base_of<UnionType, Type>::value,
               Status>
   Visit(const Type& type) {
@@ -1688,10 +1698,15 @@ static Status GetPandasWriterType(const ChunkedArray& data, const PandasOptions&
       break;
     case Type::TIMESTAMP: {
       const auto& ts_type = checked_cast<const TimestampType&>(*data.type());
+      if (options.timestamp_as_object && ts_type.unit() != TimeUnit::NANO) {
+        // Nanoseconds are never out of bounds for pandas, so in that case
+        // we don't convert to object
+        *output_type = PandasWriter::OBJECT;
+      }
       // XXX: Hack here for ARROW-7723
-      if (ts_type.timezone() != "" && !options.ignore_timezone) {
+      else if (ts_type.timezone() != "" && !options.ignore_timezone) {
         *output_type = PandasWriter::DATETIME_NANO_TZ;
-      } else if (!options.timestamp_as_object && options.coerce_temporal_nanoseconds) {
+      } else if (options.coerce_temporal_nanoseconds) {
         *output_type = PandasWriter::DATETIME_NANO;
       } else {
         // Timestamps will be converted to objects unless they are nanosecond

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1691,7 +1691,11 @@ static Status GetPandasWriterType(const ChunkedArray& data, const PandasOptions&
       // XXX: Hack here for ARROW-7723
       if (ts_type.timezone() != "" && !options.ignore_timezone) {
         *output_type = PandasWriter::DATETIME_NANO_TZ;
+      } else if (!options.timestamp_as_object && options.coerce_temporal_nanoseconds) {
+        *output_type = PandasWriter::DATETIME_NANO;
       } else {
+        // Timestamps will be converted to objects unless they are nanosecond
+        // resolution.
         switch (ts_type.unit()) {
           case TimeUnit::SECOND:
             *output_type = PandasWriter::DATETIME_SECOND;

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1691,8 +1691,6 @@ static Status GetPandasWriterType(const ChunkedArray& data, const PandasOptions&
       // XXX: Hack here for ARROW-7723
       if (ts_type.timezone() != "" && !options.ignore_timezone) {
         *output_type = PandasWriter::DATETIME_NANO_TZ;
-      } else if (options.coerce_temporal_nanoseconds) {
-        *output_type = PandasWriter::DATETIME_NANO;
       } else {
         switch (ts_type.unit()) {
           case TimeUnit::SECOND:

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1702,9 +1702,8 @@ static Status GetPandasWriterType(const ChunkedArray& data, const PandasOptions&
         // Nanoseconds are never out of bounds for pandas, so in that case
         // we don't convert to object
         *output_type = PandasWriter::OBJECT;
-      }
-      // XXX: Hack here for ARROW-7723
-      else if (ts_type.timezone() != "" && !options.ignore_timezone) {
+      } else if (ts_type.timezone() != "" && !options.ignore_timezone) {
+        // XXX: ignore_timezone: hack here for ARROW-7723
         *output_type = PandasWriter::DATETIME_NANO_TZ;
       } else if (options.coerce_temporal_nanoseconds) {
         *output_type = PandasWriter::DATETIME_NANO;

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -1709,8 +1709,6 @@ static Status GetPandasWriterType(const ChunkedArray& data, const PandasOptions&
       } else if (options.coerce_temporal_nanoseconds) {
         *output_type = PandasWriter::DATETIME_NANO;
       } else {
-        // Timestamps will be converted to objects unless they are nanosecond
-        // resolution.
         switch (ts_type.unit()) {
           case TimeUnit::SECOND:
             *output_type = PandasWriter::DATETIME_SECOND;

--- a/cpp/src/arrow/python/arrow_to_pandas.h
+++ b/cpp/src/arrow/python/arrow_to_pandas.h
@@ -50,6 +50,7 @@ struct PandasOptions {
   bool zero_copy_only = false;
   bool integer_object_nulls = false;
   bool date_as_object = false;
+  bool timestamp_as_object = false;
   bool use_threads = false;
 
   /// Coerce all date and timestamp to datetime64[ns]

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1135,13 +1135,11 @@ cdef _array_like_to_pandas(obj, options):
                 obj, &out))
 
     arr = wrap_array_output(out)
-    if (isinstance(arr, np.ndarray) and
-            (arr.dtype.type == np.datetime64) and
-            (arr.dtype.name != "datetime64[ns]")):
-        # ARROW-5359 - if we get non-ns datetime64 resolution, it means that
-        # timestamp_as_object=True was specified, and we need to convert to
-        # object dtype to avoid pandas coercing back to ns resolution
-        arr = arr.astype(np.dtype("O"))
+
+    if (isinstance(original_type, TimestampType) and
+            options["timestamp_as_object"]):
+        # ARROW-5359 - need to specify object dtype to avoid pandas to
+        # coerce back to ns resolution
         dtype = "object"
     else:
         dtype = None

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -512,6 +512,7 @@ cdef class _PandasConvertible:
             bint zero_copy_only=False,
             bint integer_object_nulls=False,
             bint date_as_object=True,
+            bint timestamp_as_object=False,
             bint use_threads=True,
             bint deduplicate_objects=True,
             bint ignore_metadata=False,
@@ -540,6 +541,11 @@ cdef class _PandasConvertible:
             Cast integers with nulls to objects
         date_as_object : bool, default True
             Cast dates to objects. If False, convert to datetime64[ns] dtype.
+        timestamp_as_object : bool, default False
+            Cast non-nanosecond timestamps (np.datetime64) to objects. This is
+            useful if you have timestamps that don't fit in the normal date
+            range of nanosecond timestamps (1678 CE-2262 CE).
+            If False, all timestamps are converted to datetime64[ns] dtype.
         use_threads: bool, default True
             Whether to parallelize the conversion using multiple threads.
         deduplicate_objects : bool, default False
@@ -582,6 +588,7 @@ cdef class _PandasConvertible:
             zero_copy_only=zero_copy_only,
             integer_object_nulls=integer_object_nulls,
             date_as_object=date_as_object,
+            timestamp_as_object=timestamp_as_object,
             use_threads=use_threads,
             deduplicate_objects=deduplicate_objects,
             safe=safe,
@@ -600,6 +607,7 @@ cdef PandasOptions _convert_pandas_options(dict options):
     result.zero_copy_only = options['zero_copy_only']
     result.integer_object_nulls = options['integer_object_nulls']
     result.date_as_object = options['date_as_object']
+    result.timestamp_as_object = options['timestamp_as_object']
     result.use_threads = options['use_threads']
     result.deduplicate_objects = options['deduplicate_objects']
     result.safe_cast = options['safe']

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1736,6 +1736,7 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:
         c_bool zero_copy_only
         c_bool integer_object_nulls
         c_bool date_as_object
+        c_bool timestamp_as_object
         c_bool use_threads
         c_bool coerce_temporal_nanoseconds
         c_bool deduplicate_objects

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -704,9 +704,14 @@ def _reconstruct_block(item, columns=None, extension_columns=None):
             (block_arr.dtype.type == np.datetime64) and
             (block_arr.dtype.name != "datetime64[ns]")
     ):
-        # Non-nanosecond timestamps can express much larger values than
-        # nanosecond timestamps, and pandas checks that the values fit into
-        # nanosecond range, so this needs to be an object as dtype.
+        # 1. Non-nanosecond timestamps can express dates outside
+        #    the range supported by nanoseconds.
+        # 2. If the dtype is datetime64 of any sort, deep inside
+        #    Panda's make_block() code path is will do
+        #    ensure_datetime64ns(values), which will blow up for
+        #    those out-of-range timestamps.
+        # 3. To support non-nanosecond timestamps we therefore need to
+        #    use a non-timestamp dtype.
         block_arr = block_arr.astype(np.dtype("O"))
 
     if 'dictionary' in item:

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -699,21 +699,6 @@ def _reconstruct_block(item, columns=None, extension_columns=None):
     block_arr = item.get('block', None)
     placement = item['placement']
 
-    if (
-            (block_arr is not None) and
-            (block_arr.dtype.type == np.datetime64) and
-            (block_arr.dtype.name != "datetime64[ns]")
-    ):
-        # 1. Non-nanosecond timestamps can express dates outside
-        #    the range supported by nanoseconds.
-        # 2. If the dtype is datetime64 of any sort, deep inside
-        #    pandas' make_block() code path it will do
-        #    ensure_datetime64ns(values), which will blow up for
-        #    those out-of-range timestamps.
-        # 3. To support non-nanosecond timestamps we therefore need to
-        #    use a non-timestamp dtype (ARROW-5359).
-        block_arr = block_arr.astype(np.dtype("O"))
-
     if 'dictionary' in item:
         cat = _pandas_api.categorical_type.from_codes(
             block_arr, categories=item['dictionary'],

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -698,6 +698,15 @@ def _reconstruct_block(item, columns=None, extension_columns=None):
 
     block_arr = item.get('block', None)
     placement = item['placement']
+
+    if (
+            (block_arr.dtype.type == np.datetime64) and
+            (block_arr.dtype.name != "datetime64[ns]")
+    ):
+        # Non-nanosecond timestamps can express much larger values, so this
+        # needs to be an object as dtype.
+        block_arr = block_arr.astype(np.dtype("O"))
+
     if 'dictionary' in item:
         cat = _pandas_api.categorical_type.from_codes(
             block_arr, categories=item['dictionary'],

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -711,7 +711,7 @@ def _reconstruct_block(item, columns=None, extension_columns=None):
         #    ensure_datetime64ns(values), which will blow up for
         #    those out-of-range timestamps.
         # 3. To support non-nanosecond timestamps we therefore need to
-        #    use a non-timestamp dtype.
+        #    use a non-timestamp dtype (ARROW-5359).
         block_arr = block_arr.astype(np.dtype("O"))
 
     if 'dictionary' in item:

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -700,11 +700,13 @@ def _reconstruct_block(item, columns=None, extension_columns=None):
     placement = item['placement']
 
     if (
+            (block_arr is not None) and
             (block_arr.dtype.type == np.datetime64) and
             (block_arr.dtype.name != "datetime64[ns]")
     ):
-        # Non-nanosecond timestamps can express much larger values, so this
-        # needs to be an object as dtype.
+        # Non-nanosecond timestamps can express much larger values than
+        # nanosecond timestamps, and pandas checks that the values fit into
+        # nanosecond range, so this needs to be an object as dtype.
         block_arr = block_arr.astype(np.dtype("O"))
 
     if 'dictionary' in item:

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -698,7 +698,6 @@ def _reconstruct_block(item, columns=None, extension_columns=None):
 
     block_arr = item.get('block', None)
     placement = item['placement']
-
     if 'dictionary' in item:
         cat = _pandas_api.categorical_type.from_codes(
             block_arr, categories=item['dictionary'],

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -707,7 +707,7 @@ def _reconstruct_block(item, columns=None, extension_columns=None):
         # 1. Non-nanosecond timestamps can express dates outside
         #    the range supported by nanoseconds.
         # 2. If the dtype is datetime64 of any sort, deep inside
-        #    Panda's make_block() code path is will do
+        #    pandas' make_block() code path it will do
         #    ensure_datetime64ns(values), which will blow up for
         #    those out-of-range timestamps.
         # 3. To support non-nanosecond timestamps we therefore need to

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3970,6 +3970,7 @@ def make_df_with_timestamps():
     # Not part of what we're testing, just ensuring that the inputs are what we
     # expect.
     assert (df.dateTimeMs.dtype, df.dateTimeNs.dtype) == (
+        # O == object, <M8[ns] == timestamp64[ns]
         np.dtype("O"), np.dtype("<M8[ns]")
     )
     return df

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -40,7 +40,7 @@ import pyarrow as pa
 try:
     from pyarrow import parquet as pq
 except ImportError:
-    pq = None
+    pass
 
 try:
     import pandas as pd
@@ -3950,7 +3950,7 @@ def test_metadata_compat_missing_field_name():
     tm.assert_frame_equal(result, expected, check_like=True)
 
 
-@pytest.mark.skipif(pq is None, reason="Parquet not available")
+@pytest.mark.parquet
 def test_timestamp_as_object():
     # Timestamps can be stored as Parquet and reloaded into Pandas with no loss
     # of information if the timestamp_as_object option is True.

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4001,11 +4001,17 @@ def test_timestamp_as_object_out_of_range():
 @pytest.mark.parametrize("resolution", ["s", "ms", "us"])
 # One datetime outside nanosecond range, one inside nanosecond range:
 @pytest.mark.parametrize("dt", [datetime(1553, 1, 1), datetime(2020, 1, 1)])
-def test_timestamp_as_object_explicit_type(resolution, dt):
+def test_timestamp_as_object_non_nanosecond(resolution, dt):
     # Timestamps can be converted Arrow and reloaded into Pandas with no loss
     # of information if the timestamp_as_object option is True.
     arr = pa.array([dt], type=pa.timestamp(resolution))
     result = arr.to_pandas(timestamp_as_object=True)
+    assert result.dtype == object
+    assert isinstance(result[0], datetime)
+    assert result[0] == dt
+
+    table = pa.table({'a': arr})
+    result = table.to_pandas(timestamp_as_object=True)['a']
     assert result.dtype == object
     assert isinstance(result[0], datetime)
     assert result[0] == dt

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3987,7 +3987,7 @@ def test_timestamp_as_object_parquet(tempdir):
     pq.write_table(table, filename, version="2.0")
     result = pq.read_table(filename)
     df2 = result.to_pandas(timestamp_as_object=True)
-    tm.assert_frame_equal(df, df2, check_like=True)
+    tm.assert_frame_equal(df, df2)
 
 
 def test_timestamp_as_object_out_of_range():
@@ -3996,7 +3996,7 @@ def test_timestamp_as_object_out_of_range():
     df = make_df_with_timestamps()
     table = pa.Table.from_pandas(df)
     df2 = table.to_pandas(timestamp_as_object=True)
-    tm.assert_frame_equal(df, df2, check_like=True)
+    tm.assert_frame_equal(df, df2)
 
 
 @pytest.mark.parametrize("resolution", ["s", "ms", "us"])

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3951,9 +3951,9 @@ def test_metadata_compat_missing_field_name():
 
 
 @pytest.mark.skipif(pq is None, reason="Parquet not available")
-def test_parquet_timestamp_roundtrip():
+def test_timestamp_as_object():
     # Timestamps can be stored as Parquet and reloaded into Pandas with no loss
-    # of information.
+    # of information if the timestamp_as_object option is True.
     df = pd.DataFrame({
         'dateTimeMs': [
             np.datetime64('0001-01-01 00:00', 'ms'),
@@ -3971,5 +3971,5 @@ def test_parquet_timestamp_roundtrip():
     table = pa.Table.from_pandas(df)
     pq.write_table(table, 'timeseries.parquet', version="2.0")
     result = pq.read_table('timeseries.parquet')
-    df2 = result.to_pandas()
+    df2 = result.to_pandas(timestamp_as_object=True)
     tm.assert_frame_equal(df, df2, check_like=True)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3999,10 +3999,11 @@ def test_timestamp_as_object_out_of_range():
 
 
 @pytest.mark.parametrize("resolution", ["s", "ms", "us"])
-def test_timestamp_as_object_explicit_type(resolution):
+# One datetime outside nanosecond range, one inside nanosecond range:
+@pytest.mark.parametrize("dt", [datetime(1553, 1, 1), datetime(2020, 1, 1)])
+def test_timestamp_as_object_explicit_type(resolution, dt):
     # Timestamps can be converted Arrow and reloaded into Pandas with no loss
     # of information if the timestamp_as_object option is True.
-    dt = datetime(1553, 1, 1)
     arr = pa.array([dt], type=pa.timestamp(resolution))
     result = arr.to_pandas(timestamp_as_object=True)
     assert result.dtype == object

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -20,7 +20,6 @@ import decimal
 import json
 import multiprocessing as mp
 import sys
-from datetime import datetime
 
 from collections import OrderedDict
 from datetime import date, datetime, time, timedelta

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3961,9 +3961,15 @@ def test_parquet_timestamp_roundtrip():
             np.datetime64('2012-05-03 15:42', 'ms'),
             np.datetime64('3000-05-03 15:42', 'ms'),
         ],
+        'dateTimeNs': [
+            np.datetime64('1991-01-01 00:00', 'ns'),
+            np.datetime64('2012-05-02 12:35', 'ns'),
+            np.datetime64('2012-05-03 15:42', 'ns'),
+            np.datetime64('2050-05-03 15:42', 'ns'),
+        ],
     })
     table = pa.Table.from_pandas(df)
-    pq.write_table(table, 'timeseries.parquet')
+    pq.write_table(table, 'timeseries.parquet', version="2.0")
     result = pq.read_table('timeseries.parquet')
     df2 = result.to_pandas()
     tm.assert_frame_equal(df, df2, check_like=True)


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/ARROW-5359 by adding a new flag, `timestamp_as_object`.

In this PR the default is to be False. Plausibly it should default to True, much like `date_as_object` is True by default, but that would be backwards incompatible. There are definitely a number of tests that fail when the default is changed, but they might be overly brittle tests.