### PR TITLE
ARROW-8790: [C++][CI] Enable arrow-flight-test on s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,13 +50,13 @@ jobs:
         ARROW_FLIGHT: "ON"
         ARROW_GANDIVA: "OFF"
         ARROW_PARQUET: "OFF"
+        DOCKER_IMAGE_ID: ubuntu-cpp
         PARQUET_BUILD_EXAMPLES: "OFF"
         PARQUET_BUILD_EXECUTABLES: "OFF"
-        cares_SOURCE: "BUNDLED"
         Protobuf_SOURCE: "BUNDLED"
-        gRPC_SOURCE: "BUNDLED"
-        DOCKER_IMAGE_ID: ubuntu-cpp
         UBUNTU: "20.04"
+        cares_SOURCE: "BUNDLED"
+        gRPC_SOURCE: "BUNDLED"
   allow_failures:
     - arch: s390x
 
@@ -95,9 +95,9 @@ script:
       -e ARROW_PARQUET=${ARROW_PARQUET:-ON} \
       -e PARQUET_BUILD_EXAMPLES=${PARQUET_BUILD_EXAMPLES:-ON} \
       -e PARQUET_BUILD_EXECUTABLES=${PARQUET_BUILD_EXECUTABLES:-ON} \
-      -e cares_SOURCE=${cares_SOURCE:-AUTO} \
-      -e gRPC_SOURCE=${gRPC_SOURCE:-AUTO} \
-      -e Protobuf_SOURCE=${Protobuf_SOURCE:-AUTO} \
+      -e Protobuf_SOURCE=${Protobuf_SOURCE:-} \
+      -e cares_SOURCE=${cares_SOURCE:-} \
+      -e gRPC_SOURCE=${gRPC_SOURCE:-} \
       --volume ${PWD}/build:/build \
       ${DOCKER_IMAGE_ID}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,11 +47,13 @@ jobs:
       env:
         ARCH: s390x
         ARROW_CI_MODULES: "CPP"
-        ARROW_FLIGHT: "OFF"
         ARROW_GANDIVA: "OFF"
         ARROW_PARQUET: "OFF"
         PARQUET_BUILD_EXAMPLES: "OFF"
         PARQUET_BUILD_EXECUTABLES: "OFF"
+        cares_SOURCE: "BUNDLED"
+        Protobuf_SOURCE: "BUNDLED"
+        gRPC_SOURCE: "BUNDLED"
         DOCKER_IMAGE_ID: ubuntu-cpp
         UBUNTU: "20.04"
   allow_failures:
@@ -87,11 +89,13 @@ script:
     ulimit -c unlimited || :
   - |
     archery docker run \
-      -e ARROW_FLIGHT=${ARROW_FLIGHT:-OFF} \
       -e ARROW_GANDIVA=${ARROW_GANDIVA:-ON} \
       -e ARROW_PARQUET=${ARROW_PARQUET:-ON} \
       -e PARQUET_BUILD_EXAMPLES=${PARQUET_BUILD_EXAMPLES:-ON} \
       -e PARQUET_BUILD_EXECUTABLES=${PARQUET_BUILD_EXECUTABLES:-ON} \
+      -e cares_SOURCE=${cares_SOURCE:-AUTO} \
+      -e gRPC_SOURCE=${gRPC_SOURCE:-AUTO} \
+      -e Protobuf_SOURCE=${Protobuf_SOURCE:-AUTO} \
       --volume ${PWD}/build:/build \
       ${DOCKER_IMAGE_ID}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ jobs:
       env:
         ARCH: s390x
         ARROW_CI_MODULES: "CPP"
+        ARROW_FLIGHT: "ON"
         ARROW_GANDIVA: "OFF"
         ARROW_PARQUET: "OFF"
         PARQUET_BUILD_EXAMPLES: "OFF"
@@ -89,6 +90,7 @@ script:
     ulimit -c unlimited || :
   - |
     archery docker run \
+      -e ARROW_FLIGHT=${ARROW_FLIGHT:-OFF} \
       -e ARROW_GANDIVA=${ARROW_GANDIVA:-ON} \
       -e ARROW_PARQUET=${ARROW_PARQUET:-ON} \
       -e PARQUET_BUILD_EXAMPLES=${PARQUET_BUILD_EXAMPLES:-ON} \


### PR DESCRIPTION
This PR enables build & test of arrow-flight on TravisCI s390x.

This PR uses three BUNDLED packages to build Arrow on s390x.