### PR TITLE
ARROW-8776: [FlightRPC] Fix discrepancy between headers in Java and C++

### DIFF
--- a/cpp/src/arrow/flight/test_integration.cc
+++ b/cpp/src/arrow/flight/test_integration.cc
@@ -103,9 +103,141 @@ class AuthBasicProtoScenario : public Scenario {
   }
 };
 
+class TestServerMiddleware : public ServerMiddleware {
+ public:
+  explicit TestServerMiddleware(std::string received) : received_(received) {}
+  void SendingHeaders(AddCallHeaders* outgoing_headers) override {
+    outgoing_headers->AddHeader("x-middleware", received_);
+  }
+  void CallCompleted(const Status& status) override {}
+
+  std::string name() const override { return "GrpcTrailersMiddleware"; }
+
+ private:
+  std::string received_;
+};
+
+class TestServerMiddlewareFactory : public ServerMiddlewareFactory {
+ public:
+  Status StartCall(const CallInfo& info, const CallHeaders& incoming_headers,
+                   std::shared_ptr<ServerMiddleware>* middleware) override {
+    const std::pair<CallHeaders::const_iterator, CallHeaders::const_iterator>& iter_pair =
+        incoming_headers.equal_range("x-middleware");
+    std::string received = "";
+    if (iter_pair.first != iter_pair.second) {
+      const util::string_view& value = (*iter_pair.first).second;
+      received = std::string(value);
+    }
+    *middleware = std::make_shared<TestServerMiddleware>(received);
+    return Status::OK();
+  }
+};
+
+class TestClientMiddleware : public ClientMiddleware {
+ public:
+  explicit TestClientMiddleware(std::string* received_header)
+      : received_header_(received_header) {}
+
+  void SendingHeaders(AddCallHeaders* outgoing_headers) {
+    outgoing_headers->AddHeader("x-middleware", "expected value");
+  }
+
+  void ReceivedHeaders(const CallHeaders& incoming_headers) {
+    const std::pair<CallHeaders::const_iterator, CallHeaders::const_iterator>& iter_pair =
+        incoming_headers.equal_range("x-middleware");
+    if (iter_pair.first != iter_pair.second) {
+      const util::string_view& value = (*iter_pair.first).second;
+      *received_header_ = std::string(value);
+    }
+  }
+
+  void CallCompleted(const Status& status) {}
+
+ private:
+  std::string* received_header_;
+};
+
+class TestClientMiddlewareFactory : public ClientMiddlewareFactory {
+ public:
+  void StartCall(const CallInfo& info, std::unique_ptr<ClientMiddleware>* middleware) {
+    *middleware =
+        std::unique_ptr<ClientMiddleware>(new TestClientMiddleware(&received_header_));
+  }
+
+  std::string received_header_;
+};
+
+class MiddlewareServer : public FlightServerBase {
+  Status GetFlightInfo(const ServerCallContext& context,
+                       const FlightDescriptor& descriptor,
+                       std::unique_ptr<FlightInfo>* result) override {
+    if (descriptor.type == FlightDescriptor::DescriptorType::CMD &&
+        descriptor.cmd == "success") {
+      // Don't fail
+      std::shared_ptr<Schema> schema = arrow::schema({});
+      Location location;
+      RETURN_NOT_OK(Location::ForGrpcTcp("localhost", 10010, &location));
+      std::vector<FlightEndpoint> endpoints{FlightEndpoint{{"foo"}, {location}}};
+      ARROW_ASSIGN_OR_RAISE(auto info,
+                            FlightInfo::Make(*schema, descriptor, endpoints, -1, -1));
+      *result = std::unique_ptr<FlightInfo>(new FlightInfo(info));
+      return Status::OK();
+    }
+    // Fail the call immediately. In some gRPC implementations, this
+    // means that gRPC sends only HTTP/2 trailers and not headers. We want
+    // Flight middleware to be agnostic to this difference.
+    return Status::UnknownError("Unknown");
+  }
+};
+
+class MiddlewareScenario : public Scenario {
+  Status MakeServer(std::unique_ptr<FlightServerBase>* server,
+                    FlightServerOptions* options) override {
+    options->middleware.push_back(
+        {"grpc_trailers", std::make_shared<TestServerMiddlewareFactory>()});
+    server->reset(new MiddlewareServer());
+    return Status::OK();
+  }
+
+  Status MakeClient(FlightClientOptions* options) override {
+    client_middleware_ = std::make_shared<TestClientMiddlewareFactory>();
+    options->middleware.push_back(client_middleware_);
+    return Status::OK();
+  }
+
+  Status RunClient(std::unique_ptr<FlightClient> client) override {
+    std::unique_ptr<FlightInfo> info;
+    if (client->GetFlightInfo(FlightDescriptor::Command(""), &info).ok()) {
+      return Status::Invalid("Expected call to fail");
+    }
+    if (client_middleware_->received_header_ != "expected value") {
+      return Status::Invalid(
+          "Expected to receive header x-middleware: expected value, but instead got ",
+          client_middleware_->received_header_);
+    }
+    std::cerr << "Headers received successfully on failing call." << std::endl;
+
+    // This call should succeed
+    client_middleware_->received_header_ = "";
+    RETURN_NOT_OK(client->GetFlightInfo(FlightDescriptor::Command("success"), &info));
+    if (client_middleware_->received_header_ != "expected value") {
+      return Status::Invalid(
+          "Expected to receive header x-middleware: expected value, but instead got ",
+          client_middleware_->received_header_);
+    }
+    std::cerr << "Headers received successfully on passing call." << std::endl;
+    return Status::OK();
+  }
+
+  std::shared_ptr<TestClientMiddlewareFactory> client_middleware_;
+};
+
 Status GetScenario(const std::string& scenario_name, std::shared_ptr<Scenario>* out) {
   if (scenario_name == "auth:basic_proto") {
     *out = std::make_shared<AuthBasicProtoScenario>();
+    return Status::OK();
+  } else if (scenario_name == "middleware") {
+    *out = std::make_shared<MiddlewareScenario>();
     return Status::OK();
   }
   return Status::KeyError("Scenario not found: ", scenario_name);

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -176,6 +176,19 @@ Status Ticket::Deserialize(const std::string& serialized, Ticket* out) {
   return internal::FromProto(pb_ticket, out);
 }
 
+arrow::Result<FlightInfo> FlightInfo::Make(const Schema& schema,
+                                           const FlightDescriptor& descriptor,
+                                           const std::vector<FlightEndpoint>& endpoints,
+                                           int64_t total_records, int64_t total_bytes) {
+  FlightInfo::Data data;
+  data.descriptor = descriptor;
+  data.endpoints = endpoints;
+  data.total_records = total_records;
+  data.total_bytes = total_bytes;
+  RETURN_NOT_OK(internal::SchemaToString(schema, &data.schema));
+  return FlightInfo(data);
+}
+
 Status FlightInfo::GetSchema(ipc::DictionaryMemo* dictionary_memo,
                              std::shared_ptr<Schema>* out) const {
   if (reconstructed_schema_) {

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -384,6 +384,12 @@ class ARROW_FLIGHT_EXPORT FlightInfo {
   explicit FlightInfo(Data&& data)
       : data_(std::move(data)), reconstructed_schema_(false) {}
 
+  /// \brief Factory method to construct a FlightInfo.
+  static arrow::Result<FlightInfo> Make(const Schema& schema,
+                                        const FlightDescriptor& descriptor,
+                                        const std::vector<FlightEndpoint>& endpoints,
+                                        int64_t total_records, int64_t total_bytes);
+
   /// \brief Deserialize the Arrow schema of the dataset, to be passed
   /// to each call to DoGet. Populate any dictionary encoded fields
   /// into a DictionaryMemo for bookkeeping

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -346,6 +346,9 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
         Scenario(
             "auth:basic_proto",
             description="Authenticate using the BasicAuth protobuf."),
+        Scenario(
+            "middleware",
+            description="Ensure headers are propagated via middleware."),
     ]
 
     runner = IntegrationRunner(json_files, flight_scenarios, testers, **kwargs)

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/example/integration/MiddlewareScenario.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/example/integration/MiddlewareScenario.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.example.integration;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.CallInfo;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightClientMiddleware;
+import org.apache.arrow.flight.FlightDescriptor;
+import org.apache.arrow.flight.FlightInfo;
+import org.apache.arrow.flight.FlightProducer;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.apache.arrow.flight.FlightServer;
+import org.apache.arrow.flight.FlightServerMiddleware;
+import org.apache.arrow.flight.Location;
+import org.apache.arrow.flight.NoOpFlightProducer;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+/**
+ * Test an edge case in middleware: gRPC-Java consolidates headers and trailers if a call fails immediately. On the
+ * gRPC implementation side, we need to watch for this, or else we'll have a call with "no headers" if we only look
+ * for headers.
+ */
+final class MiddlewareScenario implements Scenario {
+
+  private static final String HEADER = "x-middleware";
+  private static final String EXPECTED_HEADER_VALUE = "expected value";
+  private static final byte[] COMMAND_SUCCESS = "success".getBytes(StandardCharsets.UTF_8);
+
+  @Override
+  public FlightProducer producer(BufferAllocator allocator, Location location) {
+    return new NoOpFlightProducer() {
+      @Override
+      public FlightInfo getFlightInfo(CallContext context, FlightDescriptor descriptor) {
+        if (descriptor.isCommand()) {
+          if (Arrays.equals(COMMAND_SUCCESS, descriptor.getCommand())) {
+            return new FlightInfo(new Schema(Collections.emptyList()), descriptor, Collections.emptyList(), -1, -1);
+          }
+        }
+        throw CallStatus.UNIMPLEMENTED.toRuntimeException();
+      }
+    };
+  }
+
+  @Override
+  public void buildServer(FlightServer.Builder builder) {
+    builder.middleware(FlightServerMiddleware.Key.of("test"), new InjectingServerMiddleware.Factory());
+  }
+
+  @Override
+  public void client(BufferAllocator allocator, Location location, FlightClient ignored) throws Exception {
+    final ExtractingClientMiddleware.Factory factory = new ExtractingClientMiddleware.Factory();
+    try (final FlightClient client = FlightClient.builder(allocator, location).intercept(factory).build()) {
+      // Should fail immediately
+      IntegrationAssertions.assertThrows(FlightRuntimeException.class,
+          () -> client.getInfo(FlightDescriptor.command(new byte[0])));
+      if (!EXPECTED_HEADER_VALUE.equals(factory.extractedHeader)) {
+        throw new AssertionError(
+            "Expected to extract the header value '" +
+                EXPECTED_HEADER_VALUE +
+                "', but found: " +
+                factory.extractedHeader);
+      }
+
+      // Should not fail
+      factory.extractedHeader = "";
+      client.getInfo(FlightDescriptor.command(COMMAND_SUCCESS));
+      if (!EXPECTED_HEADER_VALUE.equals(factory.extractedHeader)) {
+        throw new AssertionError(
+            "Expected to extract the header value '" +
+                EXPECTED_HEADER_VALUE +
+                "', but found: " +
+                factory.extractedHeader);
+      }
+    }
+  }
+
+  /** Middleware that inserts a constant value in outgoing requests. */
+  static class InjectingServerMiddleware implements FlightServerMiddleware {
+
+    private final String headerValue;
+
+    InjectingServerMiddleware(String incoming) {
+      this.headerValue = incoming;
+    }
+
+    @Override
+    public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
+      outgoingHeaders.insert("x-middleware", headerValue);
+    }
+
+    @Override
+    public void onCallCompleted(CallStatus status) {
+    }
+
+    @Override
+    public void onCallErrored(Throwable err) {
+    }
+
+    /** The factory for the server middleware. */
+    static class Factory implements FlightServerMiddleware.Factory<InjectingServerMiddleware> {
+
+      @Override
+      public InjectingServerMiddleware onCallStarted(CallInfo info, CallHeaders incomingHeaders) {
+        String incoming = incomingHeaders.get(HEADER);
+        return new InjectingServerMiddleware(incoming == null ? "" : incoming);
+      }
+    }
+  }
+
+  /** Middleware that pulls a value out of incoming responses. */
+  static class ExtractingClientMiddleware implements FlightClientMiddleware {
+
+    private final ExtractingClientMiddleware.Factory factory;
+
+    public ExtractingClientMiddleware(ExtractingClientMiddleware.Factory factory) {
+      this.factory = factory;
+    }
+
+    @Override
+    public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
+      outgoingHeaders.insert(HEADER, EXPECTED_HEADER_VALUE);
+    }
+
+    @Override
+    public void onHeadersReceived(CallHeaders incomingHeaders) {
+      this.factory.extractedHeader = incomingHeaders.get(HEADER);
+    }
+
+    @Override
+    public void onCallCompleted(CallStatus status) {
+    }
+
+    /** The factory for the client middleware. */
+    static class Factory implements FlightClientMiddleware.Factory {
+
+      String extractedHeader = null;
+
+      @Override
+      public FlightClientMiddleware onCallStarted(CallInfo info) {
+        return new ExtractingClientMiddleware(this);
+      }
+    }
+  }
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/example/integration/Scenarios.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/example/integration/Scenarios.java
@@ -40,6 +40,7 @@ final class Scenarios {
   private Scenarios() {
     scenarios = new TreeMap<>();
     scenarios.put("auth:basic_proto", AuthBasicProtoScenario::new);
+    scenarios.put("middleware", MiddlewareScenario::new);
   }
 
   private static Scenarios getInstance() {


### PR DESCRIPTION
A Java service, on a failed unary-unary call, will not send separate headers and trailers, but will instead consolidate headers into the trailers. So C++ clients should check both for headers and trailers, or it may miss headers that the Java server intended for clients.