### PR TITLE
ARROW-8796: [Rust] feat: Allow writers to use &mut Vec

### DIFF
--- a/rust/parquet/src/data_type.rs
+++ b/rust/parquet/src/data_type.rs
@@ -449,15 +449,15 @@ pub trait DataType: 'static {
     where
         Self: Sized;
 
-    fn get_column_writer_ref(
-        column_writer: &ColumnWriter,
-    ) -> Option<&ColumnWriterImpl<Self>>
+    fn get_column_writer_ref<'a, 'b>(
+        column_writer: &'a ColumnWriter<'b>,
+    ) -> Option<&'a ColumnWriterImpl<'b, Self>>
     where
         Self: Sized;
 
-    fn get_column_writer_mut(
-        column_writer: &mut ColumnWriter,
-    ) -> Option<&mut ColumnWriterImpl<Self>>
+    fn get_column_writer_mut<'a, 'b>(
+        column_writer: &'a mut ColumnWriter<'b>,
+    ) -> Option<&'a mut ColumnWriterImpl<'b, Self>>
     where
         Self: Sized;
 }
@@ -502,26 +502,26 @@ macro_rules! make_type {
             }
 
             fn get_column_writer(
-                column_writer: ColumnWriter,
-            ) -> Option<ColumnWriterImpl<Self>> {
+                column_writer: ColumnWriter<'_>,
+            ) -> Option<ColumnWriterImpl<'_, Self>> {
                 match column_writer {
                     ColumnWriter::$writer_ident(w) => Some(w),
                     _ => None,
                 }
             }
 
-            fn get_column_writer_ref(
-                column_writer: &ColumnWriter,
-            ) -> Option<&ColumnWriterImpl<Self>> {
+            fn get_column_writer_ref<'a, 'b>(
+                column_writer: &'a ColumnWriter<'b>,
+            ) -> Option<&'a ColumnWriterImpl<'b, Self>> {
                 match column_writer {
                     ColumnWriter::$writer_ident(w) => Some(w),
                     _ => None,
                 }
             }
 
-            fn get_column_writer_mut(
-                column_writer: &mut ColumnWriter,
-            ) -> Option<&mut ColumnWriterImpl<Self>> {
+            fn get_column_writer_mut<'a, 'b>(
+                column_writer: &'a mut ColumnWriter<'b>,
+            ) -> Option<&'a mut ColumnWriterImpl<'b, Self>> {
                 match column_writer {
                     ColumnWriter::$writer_ident(w) => Some(w),
                     _ => None,

--- a/rust/parquet/src/file/mod.rs
+++ b/rust/parquet/src/file/mod.rs
@@ -48,12 +48,20 @@
 //! let props = Rc::new(WriterProperties::builder().build());
 //! let file = fs::File::create(&path).unwrap();
 //! let mut writer = SerializedFileWriter::new(file, schema, props).unwrap();
-//! let mut row_group_writer = writer.next_row_group().unwrap();
-//! while let Some(mut col_writer) = row_group_writer.next_column().unwrap() {
-//!     // ... write values to a column writer
-//!     row_group_writer.close_column(col_writer).unwrap();
-//! }
-//! writer.close_row_group(row_group_writer).unwrap();
+//! let row_group_metadata = {
+//!     let mut row_group_writer = writer.next_row_group().unwrap();
+//!     loop {
+//!         let col_metadata = if let Some(mut col_writer) = row_group_writer.next_column().unwrap() {
+//!             // ... write values to a column writer
+//!             col_writer.close().unwrap()
+//!         } else {
+//!             break;
+//!         };
+//!         row_group_writer.close_column(col_metadata).unwrap();
+//!     }
+//!     row_group_writer.close().unwrap()
+//! };
+//! writer.close_row_group(row_group_metadata).unwrap();
 //! writer.close().unwrap();
 //!
 //! let bytes = fs::read(&path).unwrap();


### PR DESCRIPTION
Allows parquet to be easily be written directly to memory without needing a
file to roundtrip.