### PR TITLE
ARROW-8568: [C++] Fix decimal to decimal cast issues

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -519,8 +519,8 @@ struct ScalarUnaryNotNullStateful {
     }
   };
 
-  template <>
-  struct ArrayExec<Decimal128Type> {
+  template <typename Type>
+  struct ArrayExec<Type, enable_if_t<std::is_same<Type, Decimal128Type>::value>> {
     static void Exec(const ThisType& functor, KernelContext* ctx, const ExecBatch& batch,
                      Datum* out) {
       ArrayData* out_arr = out->mutable_array();

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -29,6 +29,7 @@ using internal::checked_cast;
 using internal::HashTraits;
 
 namespace compute {
+namespace {
 
 template <typename T, typename R = void>
 using enable_if_supports_set_lookup =
@@ -106,6 +107,12 @@ struct InitStateVisitor {
   enable_if_supports_set_lookup<Type, Status> Visit(const Type&) {
     return Init<Type>();
   }
+
+  // Handle Decimal128 as a physical string, not a number
+  Status Visit(const Decimal128Type& type) {
+    return Visit(checked_cast<const FixedSizeBinaryType&>(type));
+  }
+
   Status GetResult(std::unique_ptr<KernelState>* out) {
     RETURN_NOT_OK(VisitTypeInline(*options->value_set.type(), this));
     *out = std::move(result);
@@ -175,6 +182,11 @@ struct MatchVisitor {
     };
     VisitArrayDataInline<Type>(data, lookup_value);
     return Status::OK();
+  }
+
+  // Handle Decimal128 as a physical string, not a number
+  Status Visit(const Decimal128Type& type) {
+    return Visit(checked_cast<const FixedSizeBinaryType&>(type));
   }
 
   Status Execute() {
@@ -248,6 +260,11 @@ struct IsInVisitor {
     return Status::OK();
   }
 
+  // Handle Decimal128 as a physical string, not a number
+  Status Visit(const Decimal128Type& type) {
+    return Visit(checked_cast<const FixedSizeBinaryType&>(type));
+  }
+
   Status Execute() { return VisitTypeInline(*data.type, this); }
 };
 
@@ -255,8 +272,6 @@ void ExecIsIn(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   IsInVisitor dispatch(ctx, *batch[0].array(), out);
   ctx->SetStatus(dispatch.Execute());
 }
-
-namespace codegen {
 
 // Unary set lookup kernels available for the following input types
 //
@@ -289,7 +304,7 @@ void AddBasicSetLookupKernels(ScalarKernel kernel,
   }
 }
 
-}  // namespace codegen
+}  // namespace
 
 namespace internal {
 
@@ -301,7 +316,7 @@ void RegisterScalarSetLookup(FunctionRegistry* registry) {
     isin_base.exec = ExecIsIn;
     auto isin = std::make_shared<ScalarFunction>("isin", Arity::Unary());
 
-    codegen::AddBasicSetLookupKernels(isin_base, /*output_type=*/boolean(), isin.get());
+    AddBasicSetLookupKernels(isin_base, /*output_type=*/boolean(), isin.get());
 
     isin_base.signature = KernelSignature::Make({InputType::Array(null())}, boolean());
     isin_base.null_handling = NullHandling::COMPUTED_PREALLOCATE;
@@ -317,7 +332,7 @@ void RegisterScalarSetLookup(FunctionRegistry* registry) {
     match_base.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
     match_base.mem_allocation = MemAllocation::NO_PREALLOCATE;
     auto match = std::make_shared<ScalarFunction>("match", Arity::Unary());
-    codegen::AddBasicSetLookupKernels(match_base, /*output_type=*/int32(), match.get());
+    AddBasicSetLookupKernels(match_base, /*output_type=*/int32(), match.get());
 
     match_base.signature = KernelSignature::Make({InputType::Array(null())}, int32());
     DCHECK_OK(match->AddKernel(match_base));

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -504,12 +504,15 @@ void AddHashKernels(VectorFunction* func, VectorKernel base,
 
   // Example parametric types that we want to match only on Type::type
   auto parametric_types = {time32(TimeUnit::SECOND), time64(TimeUnit::MICRO),
-                           timestamp(TimeUnit::SECOND), fixed_size_binary(0),
-                           decimal(12, 2)};
+                           timestamp(TimeUnit::SECOND), fixed_size_binary(0)};
   for (const auto& ty : parametric_types) {
     base.signature = KernelSignature::Make({InputType::Array(ty->id())}, out_ty);
     AddKernel<Action>(func, base, /*dummy=*/ty);
   }
+
+  // Handle Decimal as a physical string, not a number
+  base.signature = KernelSignature::Make({InputType::Array(Type::DECIMAL)}, out_ty);
+  AddKernel<Action>(func, base, fixed_size_binary(0));
 }
 
 }  // namespace

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -138,6 +138,11 @@ class ARROW_EXPORT BasicDecimal128 {
   /// - If 'round' is false, the right-most digits are simply dropped.
   BasicDecimal128 ReduceScaleBy(int32_t reduce_by, bool round = true) const;
 
+  /// \brief Whether this number fits in the given precision
+  ///
+  /// Return true if the number of significant digits is less or equal to `precision`.
+  bool FitsInPrecision(int32_t precision) const;
+
   // returns 1 for positive and zero decimal values, -1 for negative decimal values.
   inline int64_t Sign() const { return 1 | (high_bits_ >> 63); }
 

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -676,4 +676,26 @@ TEST(Decimal128Test, ReduceScaleAndRound) {
   ASSERT_EQ(-1238, out);
 }
 
+TEST(Decimal128Test, FitsInPrecision) {
+  ASSERT_TRUE(Decimal128("0").FitsInPrecision(1));
+  ASSERT_TRUE(Decimal128("9").FitsInPrecision(1));
+  ASSERT_TRUE(Decimal128("-9").FitsInPrecision(1));
+  ASSERT_FALSE(Decimal128("10").FitsInPrecision(1));
+  ASSERT_FALSE(Decimal128("-10").FitsInPrecision(1));
+
+  ASSERT_TRUE(Decimal128("0").FitsInPrecision(2));
+  ASSERT_TRUE(Decimal128("10").FitsInPrecision(2));
+  ASSERT_TRUE(Decimal128("-10").FitsInPrecision(2));
+  ASSERT_TRUE(Decimal128("99").FitsInPrecision(2));
+  ASSERT_TRUE(Decimal128("-99").FitsInPrecision(2));
+  ASSERT_FALSE(Decimal128("100").FitsInPrecision(2));
+  ASSERT_FALSE(Decimal128("-100").FitsInPrecision(2));
+
+  ASSERT_TRUE(Decimal128("99999999999999999999999999999999999999").FitsInPrecision(38));
+  ASSERT_TRUE(Decimal128("-99999999999999999999999999999999999999").FitsInPrecision(38));
+  ASSERT_FALSE(Decimal128("100000000000000000000000000000000000000").FitsInPrecision(38));
+  ASSERT_FALSE(
+      Decimal128("-100000000000000000000000000000000000000").FitsInPrecision(38));
+}
+
 }  // namespace arrow

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1164,9 +1164,9 @@ def test_decimal_to_decimal():
     )
     assert result.equals(expected)
 
-    # TODO FIXME
-    # this should fail but decimal overflow is not implemented
-    result = arr.cast(pa.decimal128(1, 2))
+    with pytest.raises(pa.ArrowInvalid,
+                       match='Decimal value does not fit in precision'):
+        result = arr.cast(pa.decimal128(5, 2))
 
 
 def test_safe_cast_nan_to_int_raises():


### PR DESCRIPTION
- Allow same-scale casts
- Detect truncation when target precision is too small