### PR TITLE
ARROW-8804: [R][CI] Followup to Rtools40 upgrade

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -182,8 +182,10 @@ jobs:
           r-version: '3.6'
           Ncpus: 2
       - name: Build Arrow C++
-        run: |
-          C:\rtools40\usr\bin\bash --login -c "export RTOOLS_VERSION=${{ matrix.rtools }} && cd /d/a/arrow/arrow && ci/scripts/r_windows_build.sh"
+        shell: bash
+        env:
+          RTOOLS_VERSION: ${{ matrix.rtools }}
+        run: ci/scripts/r_windows_build.sh
       - uses: actions/upload-artifact@v1
         with:
           name: Rtools ${{ matrix.rtools }} Arrow C++

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -57,7 +57,10 @@ ls $MSYS_LIB_DIR/mingw32/lib/
 ls *.xz | xargs -n 1 tar -xJf
 mkdir -p $DST_DIR
 # Grab the headers from one, either one is fine
-mv mingw64/include $DST_DIR
+# (if we're building twice to combine old and new toolchains, this may already exist)
+if [ ! -d $DST_DIR/include ]; then
+  mv mingw64/include $DST_DIR
+fi
 
 # Make the rest of the directory structure
 # lib-4.9.3 is for libraries compiled with gcc 4.9 (Rtools 3.5)

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -43,8 +43,8 @@ DST_DIR="arrow-$VERSION"
 
 # Collect the build artifacts and make the shape of zip file that rwinlib expects
 ls
-mkdir build
-cp mingw* build
+mkdir -p build
+mv mingw* build
 cd build
 
 # This may vary by system/CI provider
@@ -55,7 +55,7 @@ ls $MSYS_LIB_DIR/mingw32/lib/
 
 # Untar the two builds we made
 ls | xargs -n 1 tar -xJf
-mkdir $DST_DIR
+mkdir -p $DST_DIR
 # Grab the headers from one, either one is fine
 mv mingw64/include $DST_DIR
 

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -54,7 +54,7 @@ ls $MSYS_LIB_DIR/mingw64/lib/
 ls $MSYS_LIB_DIR/mingw32/lib/
 
 # Untar the two builds we made
-ls | xargs -n 1 tar -xJf
+ls *.xz | xargs -n 1 tar -xJf
 mkdir -p $DST_DIR
 # Grab the headers from one, either one is fine
 mv mingw64/include $DST_DIR

--- a/r/tools/winlibs.R
+++ b/r/tools/winlibs.R
@@ -39,9 +39,7 @@ if(!file.exists(sprintf("windows/arrow-%s/include/arrow/api.h", VERSION))){
       )
     }
     # URL templates
-    # TODO: don't hard-code RTools 3.5? Can we detect which toolchain we have?
-    # ifelse(nzchar(Sys.getenv("RTOOLS40_HOME")), "40", "35")
-    nightly <- "https://dl.bintray.com/ursalabs/arrow-r/libarrow/bin/windows-35/arrow-%s.zip"
+    nightly <- "https://dl.bintray.com/ursalabs/arrow-r/libarrow/bin/windows/arrow-%s.zip"
     rwinlib <- "https://github.com/rwinlib/arrow/archive/v%s.zip"
     # First look for a nightly
     get_file(nightly, VERSION)


### PR DESCRIPTION
In https://github.com/ursa-labs/arrow-r-nightly/pull/10 I discovered some ways to simplify the GHA workflow, and I also needed to tweak the build script so that it could be run twice in the same job (once with the old toolchain and once with the new). That's useful for the nightly packaging done there, but it's not something we need to do in our CI (it's slow). 