### PR TITLE
ARROW-8734: [R] improve nightly build installation

### DIFF
--- a/dev/tasks/homebrew-formulae/travis.osx.r.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.r.yml
@@ -31,7 +31,6 @@ if: tag IS blank
 env:
   global:
     - TRAVIS_TAG={{ task.tag }}
-    - LOCAL_AUTOBREW="TRUE"
     - TEST_R_WITH_ARROW="TRUE"
     - _R_CHECK_TESTS_NLINES_=0
     - _R_CHECK_CRAN_INCOMING_REMOTE_="FALSE"

--- a/r/R/install-arrow.R
+++ b/r/R/install-arrow.R
@@ -64,6 +64,15 @@ install_arrow <- function(nightly = FALSE,
         LIBARRWOW_MINIMAL = minimal,
         ARROW_USE_PKG_CONFIG = use_system
       )
+      if (isTRUE(binary)) {
+        # Unless otherwise directed, don't consider newer source packages when
+        # options(pkgType) == "both" (default on win/mac)
+        opts <- options(
+          install.packages.check.source = "no",
+          install.packages.compile.from.source = "never"
+        )
+        on.exit(options(opts))
+      }
       install.packages("arrow", repos = arrow_repos(repos, nightly), ...)
     }
     if ("arrow" %in% loadedNamespaces()) {

--- a/r/configure
+++ b/r/configure
@@ -53,6 +53,12 @@ if [ -f "tools/apache-arrow.rb" ]; then
   # $ cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb tools/apache-arrow.rb
   # before R CMD build or INSTALL (assuming a local checkout of the apache/arrow repository)
   cp tools/autobrew .
+  if [ "$FORCE_AUTOBREW" != "false" ]; then
+    # It is possible to turn off forced autobrew if the formula is included,
+    # but most likely you shouldn't because the included formula will reference
+    # the C++ library at the version that matches the R package.
+    FORCE_AUTOBREW="true"
+  fi
 fi
 
 if [ "$FORCE_AUTOBREW" = "true" ]; then

--- a/r/configure
+++ b/r/configure
@@ -36,7 +36,6 @@ PKG_LIBS="-larrow_dataset -lparquet -larrow"
 
 # Make some env vars case-insensitive
 ARROW_R_DEV=`echo $ARROW_R_DEV | tr '[:upper:]' '[:lower:]'`
-LOCAL_AUTOBREW=`echo $LOCAL_AUTOBREW | tr '[:upper:]' '[:lower:]'`
 FORCE_AUTOBREW=`echo $FORCE_AUTOBREW | tr '[:upper:]' '[:lower:]'`
 ARROW_USE_PKG_CONFIG=`echo $ARROW_USE_PKG_CONFIG | tr '[:upper:]' '[:lower:]'`
 
@@ -49,15 +48,14 @@ if [ "$ARROW_R_DEV" = "true" ]; then
   ${R_HOME}/bin/Rscript data-raw/codegen.R
 fi
 
-if [ "$LOCAL_AUTOBREW" = "true" ]; then
-  # LOCAL_AUTOBREW means use the script in tools/
-  # If you want to use a local apache-arrow.rb formula, do:
+if [ -f "tools/apache-arrow.rb" ]; then
+  # If you want to use a local apache-arrow.rb formula, do
   # $ cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb tools/apache-arrow.rb
-  # before R CMD build (assuming a local checkout of the apache/arrow repository)
-  # FORCE_AUTOBREW without LOCAL_AUTOBREW means to pull from jeroen.github.io
+  # before R CMD build or INSTALL (assuming a local checkout of the apache/arrow repository)
   cp tools/autobrew .
-  cp tools/apache-arrow.rb .
-  FORCE_AUTOBREW="true"
+fi
+
+if [ "$FORCE_AUTOBREW" = "true" ]; then
   ARROW_USE_PKG_CONFIG="false"
 fi
 

--- a/r/tools/autobrew
+++ b/r/tools/autobrew
@@ -34,19 +34,20 @@ curl -fsSL https://github.com/$UPSTREAM_ORG/brew/tarball/master | tar xz --strip
 
 # Install bottle + dependencies
 export HOMEBREW_CACHE="$AUTOBREW"
-if [ -f "./${PKG_BREW_NAME}.rb" ]; then
+LOCAL_FORMULA="tools/${PKG_BREW_NAME}.rb"
+if [ -f "$LOCAL_FORMULA" ]; then
   # Use the local brew formula and install --HEAD
-  $BREW deps -n "./${PKG_BREW_NAME}.rb" 2>/dev/null
-  BREW_DEPS=$($BREW deps -n "./${PKG_BREW_NAME}.rb" 2>/dev/null)
+  $BREW deps -n "$LOCAL_FORMULA" 2>/dev/null
+  BREW_DEPS=$($BREW deps -n "$LOCAL_FORMULA" 2>/dev/null)
   $BREW install --force-bottle $BREW_DEPS 2>&1 | perl -pe 's/Warning/Note/gi'
-  $BREW install --build-from-source --HEAD "./${PKG_BREW_NAME}.rb" 2>&1 | perl -pe 's/Warning/Note/gi'
+  $BREW install --build-from-source --HEAD "$LOCAL_FORMULA" 2>&1 | perl -pe 's/Warning/Note/gi'
 else
   $BREW install --force-bottle $BREW_DEPS $PKG_BREW_NAME 2>&1 | perl -pe 's/Warning/Note/gi'
 fi
 
 # Hardcode this for my custom autobrew build
 rm -f $BREWDIR/lib/*.dylib
-PKG_LIBS="-L$BREWDIR/lib -lparquet -larrow_dataset -larrow -lthrift -llz4 -lboost_system -lboost_regex -lsnappy"
+PKG_LIBS="-L$BREWDIR/lib -lparquet -larrow_dataset -larrow -lthrift -llz4 -lsnappy"
 
 # Prevent CRAN builder from linking against old libs in /usr/local/lib
 for FILE in $BREWDIR/Cellar/*/*/lib/*.a; do
@@ -59,6 +60,3 @@ done
 
 unset HOMEBREW_NO_ANALYTICS
 unset HOMEBREW_NO_AUTO_UPDATE
-
-# Hack to work around segfault on CRAN server
-# rm -f tests/testthat.R


### PR DESCRIPTION
Among the changes here:

* `install_arrow(binary=TRUE)` (default) will not prompt the user whether they want to install a newer version from source
* If a `brew` formula is included in `r/tools`, source installation on macOS will use it
