### PR TITLE
ARROW-8803: [Java] Row count should be set before loading buffers in VectorLoader

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/VectorLoader.java
@@ -52,12 +52,12 @@ public class VectorLoader {
    * @param recordBatch the batch to load
    */
   public void load(ArrowRecordBatch recordBatch) {
+    root.setRowCount(recordBatch.getLength());
     Iterator<ArrowBuf> buffers = recordBatch.getBuffers().iterator();
     Iterator<ArrowFieldNode> nodes = recordBatch.getNodes().iterator();
     for (FieldVector fieldVector : root.getFieldVectors()) {
       loadBuffers(fieldVector, fieldVector.getField(), buffers, nodes);
     }
-    root.setRowCount(recordBatch.getLength());
     if (nodes.hasNext() || buffers.hasNext()) {
       throw new IllegalArgumentException("not all nodes and buffers were consumed. nodes: " +
           Collections2.toList(nodes).toString() + " buffers: " + Collections2.toList(buffers).toString());


### PR DESCRIPTION
In my use case, I need to read RecordBatch with **compressed** underlying buffers using Java's IPC API, and I'm finally blocked by the VectorLoader's "load" method. In this method,

    root.setRowCount(recordBatch.getLength());

It not only set the rowCount for the root, but also set the valueCount for the vectors the root holds, **which have already been set once when load buffers**.

It's not a bug... I know. But if I try to load some compressed buffers, I will get the following exceptions:

    java.lang.IndexOutOfBoundsException: index: 0, length: 512 (expected: range(0, 504))
    at io.netty.buffer.ArrowBuf.checkIndex(ArrowBuf.java:718)
    at io.netty.buffer.ArrowBuf.setBytes(ArrowBuf.java:965)
    at org.apache.arrow.vector.BaseFixedWidthVector.reAlloc(BaseFixedWidthVector.java:439)
    at org.apache.arrow.vector.BaseFixedWidthVector.setValueCount(BaseFixedWidthVector.java:708)
    at org.apache.arrow.vector.VectorSchemaRoot.setRowCount(VectorSchemaRoot.java:226)
    at org.apache.arrow.vector.VectorLoader.load(VectorLoader.java:61)
    at org.apache.arrow.vector.ipc.ArrowReader.loadRecordBatch(ArrowReader.java:205)
    at org.apache.arrow.vector.ipc.ArrowStreamReader.loadNextBatch(ArrowStreamReader.java:122)

And I start to think that if it would be more make sense to call root.setRowCount before loadbuffers?
In root.setRowCount it also calls each vector's setValueCount, which I think is unnecessary here since the vectors after calling loadbuffers are already formed.

Another existing piece of code upstream is similar to this change. [JsonFileReader.java#L170-L178](https://github.com/apache/arrow/blob/ed1f771dccdde623ce85e212eccb2b573185c461/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java#L170-L178)