### PR TITLE
ARROW-8815: [Dev][Release] Binary upload script should retry on unexpected bintray request error

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -610,7 +610,7 @@ class BinaryTask
               $stderr.puts(build_download_error_message(url, response))
               return
             else
-              raise message
+              raise
             end
           end
         end

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -579,7 +579,10 @@ class BinaryTask
       url = URI("https://dl.bintray.com/#{@repository}/#{path}")
       begin
         download_url(url, output_path)
-      rescue SocketError, SystemCallError, Timeout::Error => error
+      rescue OpenSSL::OpenSSLError,
+             SocketError,
+             SystemCallError,
+             Timeout::Error => error
         n_retries += 1
         if n_retries <= max_n_retries
           $stderr.puts
@@ -764,7 +767,10 @@ class BinaryTask
             $stderr.puts(error)
           end
         end
-      rescue SocketError, SystemCallError, Timeout::Error => error
+      rescue OpenSSL::OpenSSLError,
+             SocketError,
+             SystemCallError,
+             Timeout::Error => error
         n_retries += 1
         if n_retries <= max_n_retries
           $stderr.puts

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -610,7 +610,7 @@ class BinaryTask
               $stderr.puts(build_download_error_message(url, response))
               return
             else
-              raise
+              raise build_download_error_message(url, response)
             end
           end
         end


### PR DESCRIPTION
During uploading the binaries to bintray the script exited multiple times because of unhandled HTTP errors.