### PR TITLE
ARROW-7924: [Rust] Add sort for float types

### DIFF
--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -478,7 +478,7 @@ mod tests {
                 None,
             ],
             None,
-            vec![3, 1, 4, 2, 0, 5],
+            vec![0, 5, 3, 1, 4, 2],
         );
         test_sort_to_indices_primitive_arrays::<Float64Type>(
             vec![
@@ -490,7 +490,7 @@ mod tests {
                 None,
             ],
             None,
-            vec![3, 1, 4, 2, 0, 5],
+            vec![0, 5, 3, 1, 4, 2],
         );
 
         // descending

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -269,9 +269,6 @@ fn arrow_to_parquet_type(field: &Field) -> Result<Type> {
             let dict_field = Field::new(name, *value.clone(), field.is_nullable());
             arrow_to_parquet_type(&dict_field)
         }
-        DataType::Union(_) => Err(ArrowError(
-            "Converting Union to parquet not supported".to_string(),
-        )),
     }
 }
 /// This struct is used to group methods and data structures used to convert parquet

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -269,6 +269,9 @@ fn arrow_to_parquet_type(field: &Field) -> Result<Type> {
             let dict_field = Field::new(name, *value.clone(), field.is_nullable());
             arrow_to_parquet_type(&dict_field)
         }
+        DataType::Union(_) => Err(ArrowError(
+            "Converting Union to parquet not supported".to_string(),
+        )),
     }
 }
 /// This struct is used to group methods and data structures used to convert parquet


### PR DESCRIPTION
This relaxes the trait bound of `std::cmp::Ord` to `std::cmp::PartialOrd` to enable sorting by floats