### PR TITLE
ARROW-7803: [R][CI] Autobrew/homebrew tests should not always install from master

### DIFF
--- a/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb
@@ -77,8 +77,7 @@ class ApacheArrow < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}",
-      "-larrow", "-lparquet", "-lthrift", "-llz4", "-lsnappy", "-o", "test"
+    system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", "-larrow", "-o", "test"
     system "./test"
   end
 end

--- a/dev/tasks/homebrew-formulae/travis.osx.r.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.r.yml
@@ -43,7 +43,7 @@ before_install:
 # Put the formula inside r/ so that it's included in the package build
 - cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb tools/apache-arrow.rb
 # Pin the current commit in the formula to test so that we're not always pulling from master
-- sed -i.bak -E -e 's/arrow.git"$/arrow.git", :revision => "'"$(git rev-list -n 1 HEAD)"'"/' tools/apache-arrow.rb
+- sed -i.bak -E -e 's@https://github.com/apache/arrow.git"$@{{ arrow.remote }}", :revision => "'"$(git rev-list -n 1 HEAD)"'"@' tools/apache-arrow.rb
 - rm -f tools/apache-arrow.rb.bak
 # Hack for old macOS (10.11)
 # See https://travis-ci.community/t/library-developer-commandlinetools-sdks-macosx-sdk-missing-on-el-capitain/3213/3

--- a/dev/tasks/homebrew-formulae/travis.osx.r.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.r.yml
@@ -42,6 +42,9 @@ before_install:
 - cd arrow/r
 # Put the formula inside r/ so that it's included in the package build
 - cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb tools/apache-arrow.rb
+# Pin the current commit in the formula to test so that we're not always pulling from master
+- sed -i.bak -E -e 's/arrow.git"$/arrow.git", :revision => "'"$(git rev-list -n 1 HEAD)"'"/' tools/apache-arrow.rb
+- rm -f tools/apache-arrow.rb.bak
 # Hack for old macOS (10.11)
 # See https://travis-ci.community/t/library-developer-commandlinetools-sdks-macosx-sdk-missing-on-el-capitain/3213/3
 - sed -i.bak 's/-isysroot /-I/g' $(R RHOME)/etc/Makeconf

--- a/dev/tasks/homebrew-formulae/travis.osx.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.yml
@@ -32,7 +32,7 @@ before_script:
 - git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
 - if [ $CROSSBOW_USE_COMMIT_ID = true ]; then git -C arrow checkout {{ arrow.head }}; else git -C arrow checkout FETCH_HEAD; fi
 # Pin the current commit in the formula to test so that we're not always pulling from master
-- sed -i.bak -E -e 's/arrow.git"$/arrow.git", :revision => "'"$(git rev-list -n 1 HEAD)"'"/' $ARROW_FORMULA
+- sed -i.bak -E -e 's@https://github.com/apache/arrow.git"$@{{ arrow.remote }}", :revision => "{{ arrow.head }}"@' $ARROW_FORMULA
 - rm -f $ARROW_FORMULA.bak
 - brew update
 - brew uninstall --ignore-dependencies boost

--- a/dev/tasks/homebrew-formulae/travis.osx.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.yml
@@ -31,6 +31,9 @@ before_script:
 - git clone --no-checkout {{ arrow.remote }} arrow
 - git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
 - if [ $CROSSBOW_USE_COMMIT_ID = true ]; then git -C arrow checkout {{ arrow.head }}; else git -C arrow checkout FETCH_HEAD; fi
+# Pin the current commit in the formula to test so that we're not always pulling from master
+- sed -i.bak -E -e 's/arrow.git"$/arrow.git", :revision => "'"$(git rev-list -n 1 HEAD)"'"/' $ARROW_FORMULA
+- rm -f $ARROW_FORMULA.bak
 - brew update
 - brew uninstall --ignore-dependencies boost
 - brew --version


### PR DESCRIPTION
The crossbow jobs now append `, :revision => "the_current_sha"` to the git URL in the formula, which makes brew install checkout that commit to build from.

Relevant homebrew docs: https://docs.brew.sh/Formula-Cookbook#unstable-versions-devel-head