### PR TITLE
ARROW-8821: [Rust] fix type cast for nested binary expression using Like, NotLike, Not operators

### DIFF
--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -260,6 +260,8 @@ impl Expr {
                 ref right,
                 ref op,
             } => match op {
+                Operator::Not => Ok(DataType::Boolean),
+                Operator::Like | Operator::NotLike => Ok(DataType::Boolean),
                 Operator::Eq | Operator::NotEq => Ok(DataType::Boolean),
                 Operator::Lt | Operator::LtEq => Ok(DataType::Boolean),
                 Operator::Gt | Operator::GtEq => Ok(DataType::Boolean),


### PR DESCRIPTION
Without this change, nested binary expressions are casted into Utf8, which results in general DataFusionError.