### PR TITLE
ARROW-8822: [Rust] [DataFusion] Add InMemoryScan to LogicalPlan

### DIFF
--- a/rust/datafusion/examples/memory_table_api.rs
+++ b/rust/datafusion/examples/memory_table_api.rs
@@ -49,7 +49,7 @@ fn main() -> Result<()> {
     let mut ctx = ExecutionContext::new();
 
     // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
-    let provider = MemTable::new(schema, vec![batch])?;
+    let provider = MemTable::new(schema, vec![vec![batch]])?;
     ctx.register_table("t", Box::new(provider));
     let t = ctx.table("t")?;
 

--- a/rust/datafusion/src/datasource/mod.rs
+++ b/rust/datafusion/src/datasource/mod.rs
@@ -24,4 +24,4 @@ pub mod parquet;
 
 pub use self::csv::{CsvBatchIterator, CsvFile};
 pub use self::datasource::{ScanResult, TableProvider};
-pub use self::memory::{MemBatchIterator, MemTable};
+pub use self::memory::MemTable;

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -41,6 +41,7 @@ use crate::execution::physical_plan::expressions::{
 use crate::execution::physical_plan::hash_aggregate::HashAggregateExec;
 use crate::execution::physical_plan::limit::LimitExec;
 use crate::execution::physical_plan::math_expressions::register_math_functions;
+use crate::execution::physical_plan::memory::MemoryExec;
 use crate::execution::physical_plan::merge::MergeExec;
 use crate::execution::physical_plan::parquet::ParquetExec;
 use crate::execution::physical_plan::projection::ProjectionExec;
@@ -299,6 +300,16 @@ impl ExecutionContext {
                     table_name
                 ))),
             },
+            LogicalPlan::InMemoryScan {
+                data,
+                schema,
+                projection,
+                ..
+            } => Ok(Arc::new(MemoryExec::try_new(
+                data,
+                Arc::new(schema.as_ref().to_owned()),
+                projection.to_owned(),
+            )?)),
             LogicalPlan::CsvScan {
                 path,
                 schema,

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -908,7 +908,7 @@ mod tests {
 
         let mut ctx = ExecutionContext::new();
 
-        let provider = MemTable::new(Arc::new(schema), vec![batch])?;
+        let provider = MemTable::new(Arc::new(schema), vec![vec![batch]])?;
         ctx.register_table("t", Box::new(provider));
 
         let myfunc: ScalarUdf = |args: &[ArrayRef]| {

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -1,0 +1,159 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Execution plan for reading in-memory batches of data
+
+use std::sync::{Arc, Mutex};
+
+use crate::error::Result;
+use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
+use arrow::datatypes::Schema;
+use arrow::record_batch::RecordBatch;
+
+/// Execution plan for scanning a Memory file
+pub struct MemoryExec {
+    /// The data to query
+    partitions: Vec<Vec<RecordBatch>>,
+    /// Schema representing the Memory files after the optional projection is applied
+    schema: Arc<Schema>,
+    /// Optional projection for which columns to load
+    projection: Option<Vec<usize>>,
+}
+
+impl ExecutionPlan for MemoryExec {
+    /// Get the schema for this execution plan
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
+    }
+
+    /// Get the partitions for this execution plan. Each partition can be executed in parallel.
+    fn partitions(&self) -> Result<Vec<Arc<dyn Partition>>> {
+        let partitions = self
+            .partitions
+            .iter()
+            .map(|vec| {
+                Arc::new(MemoryPartition::new(
+                    vec.clone(),
+                    self.schema.clone(),
+                    self.projection.clone(),
+                )) as Arc<dyn Partition>
+            })
+            .collect();
+        Ok(partitions)
+    }
+}
+
+impl MemoryExec {
+    /// Create a new execution plan for reading in-memory record batches
+    pub fn try_new(
+        partitions: &Vec<Vec<RecordBatch>>,
+        schema: Arc<Schema>,
+        projection: Option<Vec<usize>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            partitions: partitions.clone(),
+            schema,
+            projection,
+        })
+    }
+}
+
+/// Memory Partition
+struct MemoryPartition {
+    /// Vector of record batches
+    data: Vec<RecordBatch>,
+    /// Schema representing the data
+    schema: Arc<Schema>,
+    /// Optional projection for which columns to load
+    projection: Option<Vec<usize>>,
+}
+
+impl MemoryPartition {
+    fn new(
+        data: Vec<RecordBatch>,
+        schema: Arc<Schema>,
+        projection: Option<Vec<usize>>,
+    ) -> Self {
+        Self {
+            data: data.clone(),
+            schema,
+            projection,
+        }
+    }
+}
+
+impl Partition for MemoryPartition {
+    /// Execute this partition and return an iterator over RecordBatch
+    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>> {
+        Ok(Arc::new(Mutex::new(MemoryIterator::try_new(
+            self.data.clone(),
+            self.schema.clone(),
+            self.projection.clone(),
+        )?)))
+    }
+}
+
+/// Iterator over batches
+struct MemoryIterator {
+    /// Vector of record batches
+    data: Vec<RecordBatch>,
+    /// Schema representing the data
+    schema: Arc<Schema>,
+    /// Optional projection for which columns to load
+    projection: Option<Vec<usize>>,
+    /// Index into the data
+    index: usize,
+}
+
+impl MemoryIterator {
+    /// Create an iterator for a Memory file
+    pub fn try_new(
+        data: Vec<RecordBatch>,
+        schema: Arc<Schema>,
+        projection: Option<Vec<usize>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            data: data.clone(),
+            schema: schema.clone(),
+            projection,
+            index: 0,
+        })
+    }
+}
+
+impl BatchIterator for MemoryIterator {
+    /// Get the schema
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
+    }
+
+    /// Get the next RecordBatch
+    fn next(&mut self) -> Result<Option<RecordBatch>> {
+        if self.index < self.data.len() {
+            self.index += 1;
+            let batch = &self.data[self.index - 1];
+            // apply projection
+            let batch = match &self.projection {
+                Some(p) => unimplemented!(),
+                None => batch,
+            };
+            Ok(Some(batch.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -147,11 +147,13 @@ impl BatchIterator for MemoryIterator {
             self.index += 1;
             let batch = &self.data[self.index - 1];
             // apply projection
-            let batch = match &self.projection {
-                Some(p) => unimplemented!(),
-                None => batch,
-            };
-            Ok(Some(batch.clone()))
+            match &self.projection {
+                Some(columns) => Ok(Some(RecordBatch::try_new(
+                    self.schema.clone(),
+                    columns.iter().map(|i| batch.column(*i).clone()).collect(),
+                )?)),
+                None => Ok(Some(batch.clone())),
+            }
         } else {
             Ok(None)
         }

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -90,7 +90,7 @@ impl MemoryPartition {
         projection: Option<Vec<usize>>,
     ) -> Self {
         Self {
-            data: data.clone(),
+            data,
             schema,
             projection,
         }

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -24,13 +24,13 @@ use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
 use arrow::record_batch::RecordBatch;
 
-/// Execution plan for scanning a Memory file
+/// Execution plan for reading in-memory batches of data
 pub struct MemoryExec {
-    /// The data to query
+    /// The partitions to query
     partitions: Vec<Vec<RecordBatch>>,
-    /// Schema representing the Memory files after the optional projection is applied
+    /// Schema representing the data after the optional projection is applied
     schema: Arc<Schema>,
-    /// Optional projection for which columns to load
+    /// Optional projection
     projection: Option<Vec<usize>>,
 }
 
@@ -72,17 +72,18 @@ impl MemoryExec {
     }
 }
 
-/// Memory Partition
+/// Memory partition
 struct MemoryPartition {
     /// Vector of record batches
     data: Vec<RecordBatch>,
     /// Schema representing the data
     schema: Arc<Schema>,
-    /// Optional projection for which columns to load
+    /// Optional projection
     projection: Option<Vec<usize>>,
 }
 
 impl MemoryPartition {
+    /// Create a new in-memory partition
     fn new(
         data: Vec<RecordBatch>,
         schema: Arc<Schema>,
@@ -120,7 +121,7 @@ struct MemoryIterator {
 }
 
 impl MemoryIterator {
-    /// Create an iterator for a Memory file
+    /// Create an iterator for a vector of record batches
     pub fn try_new(
         data: Vec<RecordBatch>,
         schema: Arc<Schema>,

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -92,6 +92,7 @@ pub mod expressions;
 pub mod hash_aggregate;
 pub mod limit;
 pub mod math_expressions;
+pub mod memory;
 pub mod merge;
 pub mod parquet;
 pub mod projection;

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -530,8 +530,8 @@ pub enum LogicalPlan {
     },
     /// A table scan against a vector of record batches
     InMemoryScan {
-        /// Vector of record batches
-        data: Vec<RecordBatch>,
+        /// Record batch partitions
+        data: Vec<Vec<RecordBatch>>,
         /// The schema of the record batches
         schema: Box<Schema>,
         /// Optional column indices to use as a projection

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -30,6 +30,7 @@ use crate::datasource::TableProvider;
 use crate::error::{ExecutionError, Result};
 use crate::optimizer::utils;
 use crate::sql::parser::FileType;
+use arrow::record_batch::RecordBatch;
 
 /// Enumeration of supported function types (Scalar and Aggregate)
 #[derive(Debug, Clone)]
@@ -527,6 +528,17 @@ pub enum LogicalPlan {
         /// The projected schema
         projected_schema: Box<Schema>,
     },
+    /// A table scan against a vector of record batches
+    InMemoryScan {
+        /// Vector of record batches
+        data: Vec<RecordBatch>,
+        /// The schema of the record batches
+        schema: Box<Schema>,
+        /// Optional column indices to use as a projection
+        projection: Option<Vec<usize>>,
+        /// The projected schema
+        projected_schema: Box<Schema>,
+    },
     /// A table scan against a Parquet data source
     ParquetScan {
         /// The path to the files
@@ -585,6 +597,9 @@ impl LogicalPlan {
     pub fn schema(&self) -> &Box<Schema> {
         match self {
             LogicalPlan::EmptyRelation { schema } => &schema,
+            LogicalPlan::InMemoryScan {
+                projected_schema, ..
+            } => &projected_schema,
             LogicalPlan::CsvScan {
                 projected_schema, ..
             } => &projected_schema,
@@ -619,6 +634,9 @@ impl LogicalPlan {
                 ref projection,
                 ..
             } => write!(f, "TableScan: {} projection={:?}", table_name, projection),
+            LogicalPlan::InMemoryScan { ref projection, .. } => {
+                write!(f, "InMemoryScan: projection={:?}", projection)
+            }
             LogicalPlan::CsvScan {
                 ref path,
                 ref projection,

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -114,6 +114,22 @@ impl ProjectionPushDown {
                     projection: Some(projection),
                 })
             }
+            LogicalPlan::InMemoryScan {
+                data,
+                schema,
+                projection,
+                ..
+            } => {
+                let (projection, projected_schema) =
+                    get_projected_schema(&schema, projection, accum, mapping)?;
+
+                Ok(LogicalPlan::InMemoryScan {
+                    data: data.clone(),
+                    schema: schema.clone(),
+                    projection: Some(projection),
+                    projected_schema: Box::new(projected_schema),
+                })
+            }
             LogicalPlan::CsvScan {
                 path,
                 has_header,


### PR DESCRIPTION
Add InMemoryScan to LogicalPlan. I forgot to add this one when adding CsvScan and ParquetScan and this one turned out to be a larger change because the memory data source was a bit neglected. 

This PR introduces a new Physical Plan for reading partitioned in-memory data sources and updates the MemTable to delegate to it, adding support for partitioning as a side-effect.