### PR TITLE
ARROW-8782: [Rust] Add benchmark crate

### DIFF
--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -270,6 +270,13 @@ class PrepareTest < Test::Unit::TestCase
                      ],
                    },
                    {
+                     path: "rust/benchmarks/Cargo.toml",
+                     hunks: [
+                       ["-version = \"#{@snapshot_version}\"",
+                        "+version = \"#{@release_version}\""],
+                     ],
+                   },
+                   {
                      path: "rust/datafusion/Cargo.toml",
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",
@@ -455,6 +462,13 @@ class PrepareTest < Test::Unit::TestCase
                    },
                    {
                      path: "rust/arrow/Cargo.toml",
+                     hunks: [
+                       ["-version = \"#{@release_version}\"",
+                        "+version = \"#{@next_snapshot_version}\""],
+                     ],
+                   },
+                   {
+                     path: "rust/benchmarks/Cargo.toml",
                      hunks: [
                        ["-version = \"#{@release_version}\"",
                         "+version = \"#{@next_snapshot_version}\""],

--- a/rust/benchmarks/Cargo.toml
+++ b/rust/benchmarks/Cargo.toml
@@ -15,12 +15,18 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[workspace]
-members = [
-        "arrow",
-        "parquet",
-        "datafusion",
-        "arrow-flight",
-        "integration-testing",
-	"benchmarks",
-]
+[package]
+name = "arrow-benchmarks"
+description = "Apache Arrow Benchmarks"
+version = "0.18.0-SNAPSHOT"
+edition = "2018"
+authors = ["Apache Arrow <dev@arrow.apache.org>"]
+homepage = "https://github.com/apache/arrow"
+repository = "https://github.com/apache/arrow"
+license = "Apache-2.0"
+
+[dependencies]
+arrow = { path = "../arrow" }
+datafusion = { path = "../datafusion" }
+
+structopt = { version = "0.3", default-features = false }

--- a/rust/benchmarks/README.md
+++ b/rust/benchmarks/README.md
@@ -1,0 +1,38 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Apache Arrow Rust Benchmarks
+
+This crate contains benchmarks based on the [New York Taxi and Limousine Commission](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page) data set.
+
+Currently, only DataFusion benchmarks exist, but the plan is to add benchmarks for the arrow, flight, and parquet crates as well.
+
+```bash
+cargo run --release -- --iterations 3 --path /mnt/nyctaxi/csv --format csv --batch-size 4096
+```
+
+Example output:
+
+```bash
+Running benchmarks with the following options: Opt { debug: false, iterations: 3, batch_size: 4096, path: "/mnt/nyctaxi/csv", file_format: "csv" }
+Executing 'fare_amt_by_passenger'
+Query 'fare_amt_by_passenger' iteration 0 took 7138 ms
+Query 'fare_amt_by_passenger' iteration 1 took 7599 ms
+Query 'fare_amt_by_passenger' iteration 2 took 7969 ms
+```

--- a/rust/benchmarks/src/main.rs
+++ b/rust/benchmarks/src/main.rs
@@ -1,0 +1,139 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Apache Arrow Rust Benchmarks
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process;
+use std::time::Instant;
+
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::util::pretty;
+use datafusion::error::Result;
+use datafusion::execution::context::ExecutionContext;
+
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "Benchmarks", about = "Apache Arrow Rust Benchmarks.")]
+struct Opt {
+    /// Activate debug mode to see query results
+    #[structopt(short, long)]
+    debug: bool,
+
+    /// Number of iterations of each test run
+    #[structopt(short = "i", long = "iterations", default_value = "3")]
+    iterations: usize,
+
+    /// Batch size when reading CSV or Parquet files
+    #[structopt(short = "s", long = "batch-size", default_value = "4096")]
+    batch_size: usize,
+
+    /// Path to data files
+    #[structopt(parse(from_os_str), required = true, short = "p", long = "path")]
+    path: PathBuf,
+
+    /// File format: `csv` or `parquet`
+    #[structopt(short = "f", long = "format", default_value = "csv")]
+    file_format: String,
+}
+
+fn main() -> Result<()> {
+    let opt = Opt::from_args();
+    println!("Running benchmarks with the following options: {:?}", opt);
+
+    let mut ctx = ExecutionContext::new();
+
+    let path = opt.path.to_str().unwrap();
+
+    match opt.file_format.as_str() {
+        "csv" => ctx.register_csv("tripdata", path, &nyctaxi_schema(), true),
+        "parquet" => ctx.register_parquet("tripdata", path)?,
+        other => {
+            println!("Invalid file format '{}'", other);
+            process::exit(-1);
+        }
+    }
+
+    datafusion_sql_benchmarks(&mut ctx, opt.iterations, opt.batch_size, opt.debug)
+}
+
+fn datafusion_sql_benchmarks(
+    ctx: &mut ExecutionContext,
+    iterations: usize,
+    batch_size: usize,
+    debug: bool,
+) -> Result<()> {
+    let mut queries = HashMap::new();
+    queries.insert("fare_amt_by_passenger", "SELECT passenger_count, MIN(fare_amount), MIN(fare_amount), SUM(fare_amount) FROM tripdata GROUP BY passenger_count");
+    for (name, sql) in &queries {
+        println!("Executing '{}'", name);
+        for i in 0..iterations {
+            let start = Instant::now();
+            execute_sql(ctx, sql, batch_size, debug)?;
+            println!(
+                "Query '{}' iteration {} took {} ms",
+                name,
+                i,
+                start.elapsed().as_millis()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn execute_sql(
+    ctx: &mut ExecutionContext,
+    sql: &str,
+    batch_size: usize,
+    debug: bool,
+) -> Result<()> {
+    let plan = ctx.create_logical_plan(sql)?;
+    let plan = ctx.optimize(&plan)?;
+    if debug {
+        println!("Optimized logical plan:\n{:?}", plan);
+    }
+    let physical_plan = ctx.create_physical_plan(&plan, batch_size)?;
+    let result = ctx.collect(physical_plan.as_ref())?;
+    if debug {
+        pretty::print_batches(&result)?;
+    }
+    Ok(())
+}
+
+fn nyctaxi_schema() -> Schema {
+    Schema::new(vec![
+        Field::new("VendorID", DataType::Utf8, true),
+        Field::new("tpep_pickup_datetime", DataType::Utf8, true),
+        Field::new("tpep_dropoff_datetime", DataType::Utf8, true),
+        Field::new("passenger_count", DataType::Int32, true),
+        Field::new("trip_distance", DataType::Utf8, true),
+        Field::new("RatecodeID", DataType::Utf8, true),
+        Field::new("store_and_fwd_flag", DataType::Utf8, true),
+        Field::new("PULocationID", DataType::Utf8, true),
+        Field::new("DOLocationID", DataType::Utf8, true),
+        Field::new("payment_type", DataType::Utf8, true),
+        Field::new("fare_amount", DataType::Float64, true),
+        Field::new("extra", DataType::Float64, true),
+        Field::new("mta_tax", DataType::Float64, true),
+        Field::new("tip_amount", DataType::Float64, true),
+        Field::new("tolls_amount", DataType::Float64, true),
+        Field::new("improvement_surcharge", DataType::Float64, true),
+        Field::new("total_amount", DataType::Float64, true),
+    ])
+}


### PR DESCRIPTION
This PR adds a new crate for benchmarks based on the [New York Taxi and Limousine Commission](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page) data set.

Currently, only DataFusion benchmarks exist, but the plan is to add benchmarks for the arrow, flight, and parquet crates as well.

Example usage:

```bash
cargo run --release -- --iterations 3 --path /mnt/nyctaxi/csv --format csv --batch-size 4096
```

Example output:

```bash
Running benchmarks with the following options: Opt { debug: false, iterations: 3, batch_size: 4096, path: "/mnt/nyctaxi/csv", file_format: "csv" }
Executing 'fare_amt_by_passenger'
Query 'fare_amt_by_passenger' iteration 0 took 7138 ms
Query 'fare_amt_by_passenger' iteration 1 took 7599 ms
Query 'fare_amt_by_passenger' iteration 2 took 7969 ms
```

Follow-up PRs will add additional functionality, such as:

- Storing results in structured files (json perhaps)
- Adding a Dockerfile so that the benchmarks can be run with CPU and RAM constraints