### PR TITLE
ARROW-8834: [Rust] [Integration Testing] Implement stream-to-file, file-to-stream

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1489,24 +1489,24 @@ def get_generated_json_files(tempdir=None, flight=False):
         .skip_category('Go'),  # TODO(ARROW-7901)
 
         generate_decimal_case()
-        .skip_category('Go') # TODO(ARROW-7948): Decimal + Go
+        .skip_category('Go')  # TODO(ARROW-7948): Decimal + Go
         .skip_category('Rust'),
 
         generate_datetime_case(),
 
         generate_interval_case()
-        .skip_category('JS') # TODO(ARROW-5239): Intervals + JS
+        .skip_category('JS')  # TODO(ARROW-5239): Intervals + JS
         .skip_category('Rust'),
 
         generate_map_case()
-        .skip_category('Go') # TODO(ARROW-5620): Map + Go
+        .skip_category('Go')  # TODO(ARROW-5620): Map + Go
         .skip_category('Rust'),
 
         generate_nested_case()
         .skip_category('Rust'),
 
         generate_recursive_nested_case()
-        .skip_category('Go') # TODO(ARROW-8453)
+        .skip_category('Go')  # TODO(ARROW-8453)
         .skip_category('Rust'),
 
         generate_nested_large_offsets_case()
@@ -1534,7 +1534,7 @@ def get_generated_json_files(tempdir=None, flight=False):
         .skip_category('Rust'),
 
         generate_dictionary_case()
-        .skip_category('Go') # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
+        .skip_category('Go')  # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
         .skip_category('Rust'),
 
         # TODO(ARROW-7902)

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1488,42 +1488,54 @@ def get_generated_json_files(tempdir=None, flight=False):
         .skip_category('JS')   # TODO(ARROW-7900)
         .skip_category('Go'),  # TODO(ARROW-7901)
 
-        # TODO(ARROW-7948): Decimal + Go
-        generate_decimal_case().skip_category('Go'),
+        generate_decimal_case()
+        .skip_category('Go') # TODO(ARROW-7948): Decimal + Go
+        .skip_category('Rust'),
 
         generate_datetime_case(),
 
-        # TODO(ARROW-5239): Intervals + JS
-        generate_interval_case().skip_category('JS'),
+        generate_interval_case()
+        .skip_category('JS') # TODO(ARROW-5239): Intervals + JS
+        .skip_category('Rust'),
 
-        # TODO(ARROW-5620): Map + Go
-        generate_map_case().skip_category('Go'),
+        generate_map_case()
+        .skip_category('Go') # TODO(ARROW-5620): Map + Go
+        .skip_category('Rust'),
 
-        generate_nested_case(),
+        generate_nested_case()
+        .skip_category('Rust'),
 
-        # TODO(ARROW-8453)
-        generate_recursive_nested_case().skip_category('Go'),
+        generate_recursive_nested_case()
+        .skip_category('Go') # TODO(ARROW-8453)
+        .skip_category('Rust'),
 
         generate_nested_large_offsets_case()
         .skip_category('Go')
         .skip_category('Java')  # TODO(ARROW-6111)
-        .skip_category('JS'),
+        .skip_category('JS')
+        .skip_category('Rust'),
 
         generate_unions_case()
         .skip_category('Go')
         .skip_category('Java')  # TODO(ARROW-1692)
-        .skip_category('JS'),
+        .skip_category('JS')
+        .skip_category('Rust'),
 
-        generate_custom_metadata_case().skip_category('Go')
-                                       .skip_category('Java')
-                                       .skip_category('JS'),
+        generate_custom_metadata_case()
+        .skip_category('Go')
+        .skip_category('Java')
+        .skip_category('JS')
+        .skip_category('Rust'),
 
-        generate_duplicate_fieldnames_case().skip_category('Go')
-                                            .skip_category('Java')
-                                            .skip_category('JS'),
+        generate_duplicate_fieldnames_case()
+        .skip_category('Go')
+        .skip_category('Java')
+        .skip_category('JS')
+        .skip_category('Rust'),
 
-        # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
-        generate_dictionary_case().skip_category('Go'),
+        generate_dictionary_case()
+        .skip_category('Go') # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
+        .skip_category('Rust'),
 
         # TODO(ARROW-7902)
         generate_nested_dictionary_case().skip_category(SKIP_ARROW)
@@ -1531,7 +1543,8 @@ def get_generated_json_files(tempdir=None, flight=False):
 
         generate_extension_case().skip_category('Go')
                                  .skip_category('Java')  # TODO(ARROW-8485)
-                                 .skip_category('JS'),
+                                 .skip_category('JS')
+                                 .skip_category('Rust'),
     ]
 
     if flight:

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1533,8 +1533,9 @@ def get_generated_json_files(tempdir=None, flight=False):
         .skip_category('JS')
         .skip_category('Rust'),
 
+        # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
         generate_dictionary_case()
-        .skip_category('Go')  # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
+        .skip_category('Go')
         .skip_category('Rust'),
 
         # TODO(ARROW-7902)

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -24,8 +24,12 @@ use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::StreamWriter;
 
 fn main() -> Result<()> {
-    let filename = env::args().next().unwrap();
+    let args: Vec<String> = env::args().collect();
+    eprintln!("Rust: arrow-file-to-stream; args={:?}", args);
+
+    let filename = &args[0];
     eprintln!("Reading from Arrow file {}", filename);
+
     let f = File::open(filename)?;
     let reader = BufReader::new(f);
     let mut reader = FileReader::try_new(reader)?;
@@ -33,8 +37,8 @@ fn main() -> Result<()> {
 
     let writer = BufWriter::new(io::stdout());
     let mut writer = StreamWriter::try_new(writer, &schema)?;
+
     while let Some(batch) = reader.next()? {
-        println!("got batch OK");
         writer.write(&batch)?;
     }
     writer.finish()?;

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     eprintln!("Rust: arrow-file-to-stream; args={:?}", args);
 
-    let filename = &args[0];
+    let filename = &args[1];
     eprintln!("Reading from Arrow file {}", filename);
 
     let f = File::open(filename)?;

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -15,6 +15,29 @@
 // specific language governing permissions and limitations
 // under the License.
 
-fn main() {
-    panic!("not implemented");
+use std::env;
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter};
+
+use arrow::error::Result;
+use arrow::ipc::reader::FileReader;
+use arrow::ipc::writer::StreamWriter;
+
+fn main() -> Result<()> {
+    let filename = env::args().next().unwrap();
+    eprintln!("Reading from Arrow file {}", filename);
+    let f = File::open(filename)?;
+    let reader = BufReader::new(f);
+    let mut reader = FileReader::try_new(reader)?;
+    let schema = reader.schema();
+
+    let writer = BufWriter::new(io::stdout());
+    let mut writer = StreamWriter::try_new(writer, &schema)?;
+    while let Some(batch) = reader.next()? {
+        println!("got batch OK");
+        writer.write(&batch)?;
+    }
+    writer.finish()?;
+
+    Ok(())
 }

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -83,7 +83,11 @@ fn main() {
     }
 }
 
-fn json_to_arrow(json_name: &str, arrow_name: &str, _verbose: bool) -> Result<()> {
+fn json_to_arrow(json_name: &str, arrow_name: &str, verbose: bool) -> Result<()> {
+    if verbose {
+        println!("Converting {} to {}", json_name, arrow_name);
+    }
+
     let (schema, batches) = read_json_file(json_name)?;
 
     let arrow_file = File::create(arrow_name)?;
@@ -310,7 +314,11 @@ fn record_batch_from_json(
     RecordBatch::try_new(Arc::new(schema.clone()), columns)
 }
 
-fn arrow_to_json(arrow_name: &str, json_name: &str, _verbose: bool) -> Result<()> {
+fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
+    if verbose {
+        println!("Converting {} to {}", arrow_name, json_name);
+    }
+
     let arrow_file = File::open(arrow_name)?;
     let mut reader = FileReader::try_new(arrow_file)?;
 
@@ -337,7 +345,11 @@ fn arrow_to_json(arrow_name: &str, json_name: &str, _verbose: bool) -> Result<()
     Ok(())
 }
 
-fn validate(arrow_name: &str, json_name: &str, _verbose: bool) -> Result<()> {
+fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
+    if verbose {
+        println!("Validating {} and {}", arrow_name, json_name);
+    }
+
     // open JSON file
     let (json_schema, json_batches) = read_json_file(json_name)?;
 

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -15,6 +15,31 @@
 // specific language governing permissions and limitations
 // under the License.
 
-fn main() {
-    panic!("not implemented");
+use std::env;
+use std::fs::File;
+use std::io::BufWriter;
+use std::io::{self, BufReader};
+
+use arrow::error::Result;
+use arrow::ipc::reader::StreamReader;
+use arrow::ipc::writer::FileWriter;
+
+fn main() -> Result<()> {
+    let filename = env::args().next().unwrap();
+    eprintln!("Writing to Arrow file {}", filename);
+
+    let reader = BufReader::new(io::stdin());
+    let mut arrow_stream_reader = StreamReader::try_new(reader)?;
+    let schema = arrow_stream_reader.schema();
+
+    let file = File::create(filename)?;
+    let writer = BufWriter::new(file);
+    let mut writer = FileWriter::try_new(writer, &schema)?;
+
+    while let Some(batch) = arrow_stream_reader.next()? {
+        writer.write(&batch)?;
+    }
+    writer.finish()?;
+
+    Ok(())
 }

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::env;
-use std::fs::File;
 use std::io::BufWriter;
 use std::io::{self, BufReader};
 
@@ -25,15 +23,13 @@ use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::FileWriter;
 
 fn main() -> Result<()> {
-    let filename = env::args().next().unwrap();
-    eprintln!("Writing to Arrow file {}", filename);
+    eprintln!("Rust: arrow-stream-to-file");
 
     let reader = BufReader::new(io::stdin());
     let mut arrow_stream_reader = StreamReader::try_new(reader)?;
     let schema = arrow_stream_reader.schema();
 
-    let file = File::create(filename)?;
-    let writer = BufWriter::new(file);
+    let writer = BufWriter::new(io::stdout());
     let mut writer = FileWriter::try_new(writer, &schema)?;
 
     while let Some(batch) = arrow_stream_reader.next()? {


### PR DESCRIPTION
Implements stream-to-file, file-to-stream for integration tests.

With this, I am now able to run the integration tests and get a list of failed tests.

```
################# FAILURES #################
FAILED TEST: null Java producing,  Rust consuming

FAILED TEST: null_trivial Java producing,  Rust consuming

FAILED TEST: null Rust producing,  Java consuming

FAILED TEST: null_trivial Rust producing,  Java consuming

FAILED TEST: datetime Rust producing,  Java consuming

FAILED TEST: primitive_large_offsets Rust producing,  Rust consuming

FAILED TEST: null Rust producing,  Rust consuming

FAILED TEST: null_trivial Rust producing,  Rust consuming

FAILED TEST: datetime Rust producing,  Rust consuming

9 failures

```