### PR TITLE
ARROW-8839: [Rust] [DataFusion] support CSV schema inference in logical plan

### DIFF
--- a/rust/arrow/examples/read_csv.rs
+++ b/rust/arrow/examples/read_csv.rs
@@ -34,7 +34,7 @@ fn main() -> Result<()> {
 
     let file = File::open("test/data/uk_cities.csv").unwrap();
 
-    let mut csv = csv::Reader::new(file, Arc::new(schema), false, 1024, None);
+    let mut csv = csv::Reader::new(file, Arc::new(schema), false, None, 1024, None);
     let batch = csv.next().unwrap().unwrap();
     print_batches(&vec![batch])
 }

--- a/rust/arrow/examples/read_csv_infer_schema.rs
+++ b/rust/arrow/examples/read_csv_infer_schema.rs
@@ -25,7 +25,7 @@ use std::fs::File;
 fn main() -> Result<()> {
     let file = File::open("test/data/uk_cities_with_headers.csv").unwrap();
     let builder = csv::ReaderBuilder::new()
-        .has_headers(true)
+        .has_header(true)
         .infer_schema(Some(100));
     let mut csv = builder.build(file).unwrap();
     let batch = csv.next().unwrap().unwrap();

--- a/rust/arrow/src/csv/mod.rs
+++ b/rust/arrow/src/csv/mod.rs
@@ -20,6 +20,7 @@
 pub mod reader;
 pub mod writer;
 
+pub use self::reader::infer_file_schema;
 pub use self::reader::Reader;
 pub use self::reader::ReaderBuilder;
 pub use self::writer::Writer;

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -57,7 +57,7 @@ use self::csv_crate::{StringRecord, StringRecordsIntoIter};
 
 lazy_static! {
     static ref DECIMAL_RE: Regex = Regex::new(r"^-?(\d+\.\d+)$").unwrap();
-    static ref INTEGER_RE: Regex = Regex::new(r"^-?(\d*.)$").unwrap();
+    static ref INTEGER_RE: Regex = Regex::new(r"^-?(\d+)$").unwrap();
     static ref BOOLEAN_RE: Regex = RegexBuilder::new(r"^(true)$|^(false)$")
         .case_insensitive(true)
         .build()
@@ -767,5 +767,15 @@ mod tests {
             ),
             Ok(_) => panic!("should have failed"),
         }
+    }
+
+    #[test]
+    fn test_infer_field_schema() {
+        assert_eq!(infer_field_schema("A"), DataType::Utf8);
+        assert_eq!(infer_field_schema("\"123\""), DataType::Utf8);
+        assert_eq!(infer_field_schema("10"), DataType::Int64);
+        assert_eq!(infer_field_schema("10.2"), DataType::Float64);
+        assert_eq!(infer_field_schema("true"), DataType::Boolean);
+        assert_eq!(infer_field_schema("false"), DataType::Boolean);
     }
 }

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -198,7 +198,7 @@ impl<R: Read> Reader<R> {
     pub fn new(
         reader: R,
         schema: Arc<Schema>,
-        has_headers: bool,
+        has_header: bool,
         delimiter: Option<u8>,
         batch_size: usize,
         projection: Option<Vec<usize>>,
@@ -206,7 +206,7 @@ impl<R: Read> Reader<R> {
         Self::from_buf_reader(
             BufReader::new(reader),
             schema,
-            has_headers,
+            has_header,
             delimiter,
             batch_size,
             projection,
@@ -235,13 +235,13 @@ impl<R: Read> Reader<R> {
     pub fn from_buf_reader(
         buf_reader: BufReader<R>,
         schema: Arc<Schema>,
-        has_headers: bool,
+        has_header: bool,
         delimiter: Option<u8>,
         batch_size: usize,
         projection: Option<Vec<usize>>,
     ) -> Self {
         let mut reader_builder = csv_crate::ReaderBuilder::new();
-        reader_builder.has_headers(has_headers);
+        reader_builder.has_headers(has_header);
 
         match delimiter {
             Some(c) => {
@@ -257,7 +257,7 @@ impl<R: Read> Reader<R> {
             projection,
             record_iter,
             batch_size,
-            line_number: if has_headers { 1 } else { 0 },
+            line_number: if has_header { 1 } else { 0 },
         }
     }
 
@@ -406,7 +406,7 @@ pub struct ReaderBuilder {
     ///
     /// If schema inference is run on a file with no headers, default column names
     /// are created.
-    has_headers: bool,
+    has_header: bool,
     /// An optional column delimiter. Defaults to `b','`
     delimiter: Option<u8>,
     /// Optional maximum number of records to read during schema inference
@@ -425,7 +425,7 @@ impl Default for ReaderBuilder {
     fn default() -> ReaderBuilder {
         ReaderBuilder {
             schema: None,
-            has_headers: false,
+            has_header: false,
             delimiter: None,
             max_records: None,
             batch_size: 1024,
@@ -469,8 +469,8 @@ impl ReaderBuilder {
     }
 
     /// Set whether the CSV file has headers
-    pub fn has_headers(mut self, has_headers: bool) -> Self {
-        self.has_headers = has_headers;
+    pub fn has_header(mut self, has_header: bool) -> Self {
+        self.has_header = has_header;
         self
     }
 
@@ -512,7 +512,7 @@ impl ReaderBuilder {
                     &mut buf_reader,
                     delimiter,
                     self.max_records,
-                    self.has_headers,
+                    self.has_header,
                 )?;
 
                 Arc::new(inferred_schema)
@@ -520,7 +520,7 @@ impl ReaderBuilder {
         };
         let csv_reader = csv_crate::ReaderBuilder::new()
             .delimiter(delimiter)
-            .has_headers(self.has_headers)
+            .has_headers(self.has_header)
             .from_reader(buf_reader);
         let record_iter = csv_reader.into_records();
         Ok(Reader {
@@ -528,7 +528,7 @@ impl ReaderBuilder {
             projection: self.projection.clone(),
             record_iter,
             batch_size: self.batch_size,
-            line_number: if self.has_headers { 1 } else { 0 },
+            line_number: if self.has_header { 1 } else { 0 },
         })
     }
 }
@@ -609,7 +609,7 @@ mod tests {
     fn test_csv_with_schema_inference() {
         let file = File::open("test/data/uk_cities_with_headers.csv").unwrap();
 
-        let builder = ReaderBuilder::new().has_headers(true).infer_schema(None);
+        let builder = ReaderBuilder::new().has_header(true).infer_schema(None);
 
         let mut csv = builder.build(file).unwrap();
         let expected_schema = Schema::new(vec![
@@ -727,7 +727,7 @@ mod tests {
 
         let builder = ReaderBuilder::new()
             .infer_schema(None)
-            .has_headers(true)
+            .has_header(true)
             .with_delimiter(b'|')
             .with_batch_size(512)
             .with_projection(vec![0, 1, 2, 3]);
@@ -770,7 +770,7 @@ mod tests {
 
         let builder = ReaderBuilder::new()
             .with_schema(Arc::new(schema))
-            .has_headers(true)
+            .has_header(true)
             .with_delimiter(b'|')
             .with_batch_size(512)
             .with_projection(vec![0, 1, 2, 3]);

--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -63,6 +63,7 @@ fn create_context() -> ExecutionContext {
         &format!("{}/csv/aggregate_test_100.csv", testdata),
         &schema,
         true,
+        None,
     );
 
     let mem_table = MemTable::load(&csv).unwrap();

--- a/rust/datafusion/examples/csv_sql.rs
+++ b/rust/datafusion/examples/csv_sql.rs
@@ -52,6 +52,7 @@ fn main() -> Result<()> {
         &format!("{}/csv/aggregate_test_100.csv", testdata),
         &schema,
         true,
+        None,
     );
 
     let sql = "SELECT c1, MIN(c12), MAX(c12) FROM aggregate_test_100 WHERE c11 > 0.1 AND c11 < 0.9 GROUP BY c1";

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -736,7 +736,7 @@ mod tests {
         let partitions = 4;
         let path = test::create_partitioned_csv("aggregate_test_100.csv", partitions)?;
 
-        let csv = CsvExec::try_new(&path, schema.clone(), true, None, 1024)?;
+        let csv = CsvExec::try_new(&path, Some(schema.clone()), true, None, None, 1024)?;
 
         let group_expr: Vec<Arc<dyn PhysicalExpr>> = vec![col(1, schema.as_ref())];
 

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -183,7 +183,7 @@ mod tests {
         let path =
             test::create_partitioned_csv("aggregate_test_100.csv", num_partitions)?;
 
-        let csv = CsvExec::try_new(&path, schema.clone(), true, None, 1024)?;
+        let csv = CsvExec::try_new(&path, Some(schema.clone()), true, None, None, 1024)?;
 
         // input should have 4 partitions
         let input = csv.partitions()?;

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -111,7 +111,7 @@ mod tests {
         let path =
             test::create_partitioned_csv("aggregate_test_100.csv", num_partitions)?;
 
-        let csv = CsvExec::try_new(&path, schema.clone(), true, None, 1024)?;
+        let csv = CsvExec::try_new(&path, Some(schema.clone()), true, None, None, 1024)?;
 
         // input should have 4 partitions
         let input = csv.partitions()?;

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -150,7 +150,7 @@ mod tests {
         let partitions = 4;
         let path = test::create_partitioned_csv("aggregate_test_100.csv", partitions)?;
 
-        let csv = CsvExec::try_new(&path, schema.clone(), true, None, 1024)?;
+        let csv = CsvExec::try_new(&path, Some(schema.clone()), true, None, None, 1024)?;
 
         let projection = ProjectionExec::try_new(
             vec![Arc::new(Column::new(0, &schema.as_ref().field(0).name()))],

--- a/rust/datafusion/src/execution/physical_plan/selection.rs
+++ b/rust/datafusion/src/execution/physical_plan/selection.rs
@@ -159,7 +159,7 @@ mod tests {
         let partitions = 4;
         let path = test::create_partitioned_csv("aggregate_test_100.csv", partitions)?;
 
-        let csv = CsvExec::try_new(&path, schema.clone(), true, None, 1024)?;
+        let csv = CsvExec::try_new(&path, Some(schema.clone()), true, None, None, 1024)?;
 
         let predicate: Arc<dyn PhysicalExpr> = binary(
             binary(

--- a/rust/datafusion/src/execution/table_impl.rs
+++ b/rust/datafusion/src/execution/table_impl.rs
@@ -267,6 +267,7 @@ mod tests {
             &format!("{}/csv/aggregate_test_100.csv", testdata),
             &schema,
             true,
+            None,
         );
     }
 }

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -25,6 +25,7 @@ use std::fmt;
 
 use arrow::datatypes::{DataType, Field, Schema};
 
+use crate::datasource::csv::CsvFile;
 use crate::datasource::parquet::ParquetTable;
 use crate::datasource::TableProvider;
 use crate::error::{ExecutionError, Result};
@@ -548,6 +549,8 @@ pub enum LogicalPlan {
         schema: Box<Schema>,
         /// Whether the CSV file(s) have a header containing column names
         has_header: bool,
+        /// An optional column delimiter. Defaults to `b','`
+        delimiter: Option<u8>,
         /// Optional column indices to use as a projection
         projection: Option<Vec<usize>>,
         /// The projected schema
@@ -776,16 +779,27 @@ impl LogicalPlanBuilder {
     pub fn scan_csv(
         path: &str,
         has_header: bool,
-        schema: &Schema,
+        schema: Option<&Schema>,
+        delimiter: Option<u8>,
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
+        let schema: Schema = match schema {
+            Some(s) => s.to_owned(),
+            None => CsvFile::try_new(path, None, has_header, delimiter)?
+                .schema()
+                .as_ref()
+                .to_owned(),
+        };
+
         let projected_schema = projection
             .clone()
             .map(|p| Schema::new(p.iter().map(|i| schema.field(*i).clone()).collect()));
+
         Ok(Self::from(&LogicalPlan::CsvScan {
             path: path.to_owned(),
             schema: Box::new(schema.to_owned()),
             has_header,
+            delimiter,
             projection,
             projected_schema: Box::new(
                 projected_schema.or(Some(schema.clone())).unwrap(),
@@ -797,7 +811,6 @@ impl LogicalPlanBuilder {
     pub fn scan_parquet(path: &str, projection: Option<Vec<usize>>) -> Result<Self> {
         let p = ParquetTable::try_new(path)?;
         let schema = p.schema().as_ref().to_owned();
-        println!("{:?}", schema);
         let projected_schema = projection
             .clone()
             .map(|p| Schema::new(p.iter().map(|i| schema.field(*i).clone()).collect()));
@@ -939,7 +952,8 @@ mod tests {
         let plan = LogicalPlanBuilder::scan_csv(
             "employee.csv",
             true,
-            &employee_schema(),
+            Some(&employee_schema()),
+            None,
             Some(vec![0, 3]),
         )?
         .filter(col("state").eq(&lit_str("CO")))?

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -117,6 +117,7 @@ impl ProjectionPushDown {
             LogicalPlan::CsvScan {
                 path,
                 has_header,
+                delimiter,
                 schema,
                 projection,
                 ..
@@ -128,6 +129,7 @@ impl ProjectionPushDown {
                     path: path.to_owned(),
                     has_header: *has_header,
                     schema: schema.clone(),
+                    delimiter: *delimiter,
                     projection: Some(projection),
                     projected_schema: Box::new(projected_schema),
                 })

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -56,7 +56,7 @@ fn nyc() -> Result<()> {
     ]);
 
     let mut ctx = ExecutionContext::new();
-    ctx.register_csv("tripdata", "file.csv", &schema, true);
+    ctx.register_csv("tripdata", "file.csv", &schema, true, None);
 
     let logical_plan = ctx.create_logical_plan(
         "SELECT passenger_count, MIN(fare_amount), MAX(fare_amount) \
@@ -442,7 +442,7 @@ fn register_csv(
     filename: &str,
     schema: &Arc<Schema>,
 ) {
-    ctx.register_csv(name, filename, &schema, true);
+    ctx.register_csv(name, filename, &schema, true, None);
 }
 
 fn register_alltypes_parquet(ctx: &mut ExecutionContext) {


### PR DESCRIPTION
This PR changes schema argument for scan_csv method into `Option<&Schema>`. Other related changes are needed to make this happen including:

* added delimiter argument to all csv related structs and functions
* fixed a bug in schema field inference function
* made `arrow::csv::reader::infer_file_schema` public so it can be used by data fusion

Known limitations: 
* when provided with a directory of csv files, schema inference code only reads rows from the first file.
* to avoid adding yet another argument to all csv related functions, i hard coded number of rows to read for schema inference to 1000

Open questions:
* Should we rename `datasource::csv::CsvFile` struct to `CsvTable` to keep it consistent with ParquetTable and MemoryTable? The implementation of CsvFile also supports reading from a directory of files, so `CsvFile` is not an accurate name.
* csv related function arguments are getting a bit long, should we introduce a csv option struct to capture the following configs with sensible defaults?
  - schema
  - has_header
  - delimiter
  - infer_max_read_records
