### PR TITLE
ARROW-8171: [Java] Consider pre-allocating memory for fix-width vector in Avro adapter iterator

### DIFF
--- a/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/AvroToArrowUtils.java
@@ -91,6 +91,7 @@ import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.util.JsonStringArrayList;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -737,6 +738,7 @@ public class AvroToArrowUtils {
     int valueCount = 0;
     try {
       while (true) {
+        ValueVectorUtility.ensureCapacity(root, valueCount + 1);
         compositeConsumer.consume(decoder);
         valueCount++;
       }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroArraysConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroArraysConsumer.java
@@ -45,6 +45,7 @@ public class AvroArraysConsumer extends BaseAvroConsumer<ListVector> {
     long totalCount = 0;
     for (long count = decoder.readArrayStart(); count != 0; count = decoder.arrayNext()) {
       totalCount += count;
+      ensureInnerVectorCapacity(totalCount);
       for (int element = 0; element < count; element++) {
         delegate.consume(decoder);
       }
@@ -63,5 +64,11 @@ public class AvroArraysConsumer extends BaseAvroConsumer<ListVector> {
   public boolean resetValueVector(ListVector vector) {
     this.delegate.resetValueVector(vector.getDataVector());
     return super.resetValueVector(vector);
+  }
+
+  void ensureInnerVectorCapacity(long targetCapacity) {
+    while (vector.getDataVector().getValueCapacity() < targetCapacity) {
+      vector.getDataVector().reAlloc();
+    }
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroBooleanConsumer.java
@@ -37,7 +37,7 @@ public class AvroBooleanConsumer extends BaseAvroConsumer<BitVector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex, decoder.readBoolean() ? 1 : 0);
+    vector.set(currentIndex, decoder.readBoolean() ? 1 : 0);
     currentIndex++;
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroDoubleConsumer.java
@@ -37,6 +37,6 @@ public class AvroDoubleConsumer extends BaseAvroConsumer<Float8Vector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readDouble());
+    vector.set(currentIndex++, decoder.readDouble());
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroFloatConsumer.java
@@ -37,6 +37,6 @@ public class AvroFloatConsumer extends BaseAvroConsumer<Float4Vector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readFloat());
+    vector.set(currentIndex++, decoder.readFloat());
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroIntConsumer.java
@@ -37,6 +37,6 @@ public class AvroIntConsumer extends BaseAvroConsumer<IntVector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readInt());
+    vector.set(currentIndex++, decoder.readInt());
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/AvroLongConsumer.java
@@ -37,6 +37,6 @@ public class AvroLongConsumer extends BaseAvroConsumer<BigIntVector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readLong());
+    vector.set(currentIndex++, decoder.readLong());
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroDateConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroDateConsumer.java
@@ -38,6 +38,6 @@ public class AvroDateConsumer extends BaseAvroConsumer<DateDayVector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readInt());
+    vector.set(currentIndex++, decoder.readInt());
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroDecimalConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroDecimalConsumer.java
@@ -58,7 +58,7 @@ public abstract class AvroDecimalConsumer extends BaseAvroConsumer<DecimalVector
       byte[] bytes = new byte[cacheBuffer.limit()];
       Preconditions.checkArgument(bytes.length <= 16, "Decimal bytes length should <= 16.");
       cacheBuffer.get(bytes);
-      vector.setBigEndianSafe(currentIndex++, bytes);
+      vector.setBigEndian(currentIndex++, bytes);
     }
 
   }
@@ -82,7 +82,7 @@ public abstract class AvroDecimalConsumer extends BaseAvroConsumer<DecimalVector
     @Override
     public void consume(Decoder decoder) throws IOException {
       decoder.readFixed(reuseBytes);
-      vector.setBigEndianSafe(currentIndex++, reuseBytes);
+      vector.setBigEndian(currentIndex++, reuseBytes);
     }
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimeMicroConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimeMicroConsumer.java
@@ -38,6 +38,6 @@ public class AvroTimeMicroConsumer extends BaseAvroConsumer<TimeMicroVector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readLong());
+    vector.set(currentIndex++, decoder.readLong());
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimeMillisConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimeMillisConsumer.java
@@ -38,6 +38,6 @@ public class AvroTimeMillisConsumer extends BaseAvroConsumer<TimeMilliVector> {
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readInt());
+    vector.set(currentIndex++, decoder.readInt());
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimestampMicrosConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimestampMicrosConsumer.java
@@ -38,6 +38,6 @@ public class AvroTimestampMicrosConsumer extends BaseAvroConsumer<TimeStampMicro
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readLong());
+    vector.set(currentIndex++, decoder.readLong());
   }
 }

--- a/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimestampMillisConsumer.java
+++ b/java/adapter/avro/src/main/java/org/apache/arrow/consumers/logical/AvroTimestampMillisConsumer.java
@@ -38,6 +38,6 @@ public class AvroTimestampMillisConsumer extends BaseAvroConsumer<TimeStampMilli
 
   @Override
   public void consume(Decoder decoder) throws IOException {
-    vector.setSafe(currentIndex++, decoder.readLong());
+    vector.set(currentIndex++, decoder.readLong());
   }
 }

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
@@ -28,6 +28,7 @@ import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 
 /**
  * Utility class to convert JDBC objects to columnar Arrow format objects.
@@ -221,7 +222,7 @@ public class JdbcToArrow {
     VectorSchemaRoot root = VectorSchemaRoot.create(
         JdbcToArrowUtils.jdbcToArrowSchema(resultSet.getMetaData(), config), config.getAllocator());
     if (config.getTargetBatchSize() != JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE) {
-      ArrowVectorIterator.preAllocate(root, config);
+      ValueVectorUtility.preAllocate(root, config.getTargetBatchSize());
     }
     JdbcToArrowUtils.jdbcToArrowVectors(resultSet, root, config);
     return root;

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowUtils.java
@@ -80,6 +80,7 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
+import org.apache.arrow.vector.util.ValueVectorUtility;
 
 /**
  * Class that does most of the work to convert JDBC ResultSet data into Arrow columnar format Vector objects.
@@ -357,7 +358,7 @@ public class JdbcToArrowUtils {
       int readRowCount = 0;
       if (config.getTargetBatchSize() == JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE) {
         while (rs.next()) {
-          ArrowVectorIterator.ensureCapacity(root, readRowCount + 1);
+          ValueVectorUtility.ensureCapacity(root, readRowCount + 1);
           compositeConsumer.consume(rs);
           readRowCount++;
         }

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
@@ -19,10 +19,12 @@ package org.apache.arrow.vector.util;
 
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BufferLayout;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.TypeLayout;
 import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.validate.ValidateVectorVisitor;
 
@@ -126,6 +128,31 @@ public class ValueVectorUtility {
 
     ValidateVectorVisitor visitor = new ValidateVectorVisitor();
     vector.accept(visitor, null);
+  }
+
+
+  /**
+   * Pre allocate memory for BaseFixedWidthVector.
+   */
+  public static void preAllocate(VectorSchemaRoot root, int targetSize) {
+    for (ValueVector vector : root.getFieldVectors()) {
+      if (vector instanceof BaseFixedWidthVector) {
+        ((BaseFixedWidthVector) vector).allocateNew(targetSize);
+      }
+    }
+  }
+
+  /**
+   * Ensure capacity for BaseFixedWidthVector.
+   */
+  public static void ensureCapacity(VectorSchemaRoot root, int targetCapacity) {
+    for (ValueVector vector : root.getFieldVectors()) {
+      if (vector instanceof BaseFixedWidthVector) {
+        while (vector.getValueCapacity() < targetCapacity) {
+          vector.reAlloc();
+        }
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Related to [ARROW-8171](https://issues.apache.org/jira/browse/ARROW-8171).

Similar with the same optimization in Jdbc adapter in ARROW-8169.