### PR TITLE
ARROW-8841: [C++] Add benchmark and unittest for encoding::PLAIN spaced

### DIFF
--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -208,6 +208,8 @@ static void BM_PlainSpacedArgs(benchmark::internal::Benchmark* bench) {
   bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/1});
   bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/10});
   bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/50});
+  bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/90});
+  bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/99});
 }
 
 static void BM_PlainEncodingSpacedBoolean(benchmark::State& state) {
@@ -253,16 +255,6 @@ static void BM_PlainEncodingSpaced(benchmark::State& state) {
   }
   state.SetBytesProcessed(state.iterations() * num_values * sizeof(CType));
 }
-
-static void BM_PlainEncodingSpacedInt32(benchmark::State& state) {
-  BM_PlainEncodingSpaced<Int32Type>(state);
-}
-BENCHMARK(BM_PlainEncodingSpacedInt32)->Apply(BM_PlainSpacedArgs);
-
-static void BM_PlainEncodingSpacedInt64(benchmark::State& state) {
-  BM_PlainEncodingSpaced<Int64Type>(state);
-}
-BENCHMARK(BM_PlainEncodingSpacedInt64)->Apply(BM_PlainSpacedArgs);
 
 static void BM_PlainEncodingSpacedFloat(benchmark::State& state) {
   BM_PlainEncodingSpaced<FloatType>(state);
@@ -326,16 +318,6 @@ static void BM_PlainDecodingSpaced(benchmark::State& state) {
   }
   state.SetBytesProcessed(state.iterations() * num_values * sizeof(CType));
 }
-
-static void BM_PlainDecodingSpacedInt32(benchmark::State& state) {
-  BM_PlainDecodingSpaced<Int32Type>(state);
-}
-BENCHMARK(BM_PlainDecodingSpacedInt32)->Apply(BM_PlainSpacedArgs);
-
-static void BM_PlainDecodingSpacedInt64(benchmark::State& state) {
-  BM_PlainDecodingSpaced<Int64Type>(state);
-}
-BENCHMARK(BM_PlainDecodingSpacedInt64)->Apply(BM_PlainSpacedArgs);
 
 static void BM_PlainDecodingSpacedFloat(benchmark::State& state) {
   BM_PlainDecodingSpaced<FloatType>(state);

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -25,7 +25,6 @@
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
 #include "arrow/util/byte_stream_split.h"
-#include "arrow/util/cpu_info.h"
 
 #include "parquet/encoding.h"
 #include "parquet/platform.h"
@@ -216,15 +215,13 @@ struct BM_SpacedEncodingTraits<BooleanType> {
 };
 
 static void BM_PlainSpacedArgs(benchmark::internal::Benchmark* bench) {
-  static const auto BM_kPlainSpacedSize =
-      arrow::internal::CpuInfo::GetInstance()->CacheSize(
-          arrow::internal::CpuInfo::L1_CACHE);
+  constexpr auto kPlainSpacedSize = 32 * 1024;  // 32k
 
-  bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/1});
-  bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/10});
-  bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/50});
-  bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/90});
-  bench->Args({/*size*/ BM_kPlainSpacedSize, /*null_percentage=*/99});
+  bench->Args({/*size*/ kPlainSpacedSize, /*null_percentage=*/1});
+  bench->Args({/*size*/ kPlainSpacedSize, /*null_percentage=*/10});
+  bench->Args({/*size*/ kPlainSpacedSize, /*null_percentage=*/50});
+  bench->Args({/*size*/ kPlainSpacedSize, /*null_percentage=*/90});
+  bench->Args({/*size*/ kPlainSpacedSize, /*null_percentage=*/99});
 }
 
 template <typename ParquetType>


### PR DESCRIPTION
Benchmark(1%, 10%, 50%, 90%, 99% null probabilities) and unittest for future SIMD optimizations.

Signed-off-by: Frank Du <frank.du@intel.com>