### PR TITLE
ARROW-8837: [Rust] Implement Null data type

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -303,6 +303,7 @@ pub fn make_array(data: ArrayDataRef) -> ArrayRef {
             }
             dt => panic!("Unexpected dictionary key type {:?}", dt),
         },
+        DataType::Null => Arc::new(NullArray::from(data)) as ArrayRef,
         dt => panic!("Unexpected data type {:?}", dt),
     }
 }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1084,6 +1084,7 @@ impl StructBuilder {
 
     fn from_field(f: Field, capacity: usize) -> Box<ArrayBuilder> {
         match f.data_type() {
+            DataType::Null => unimplemented!(),
             DataType::Boolean => Box::new(BooleanBuilder::new(capacity)),
             DataType::Int8 => Box::new(Int8Builder::new(capacity)),
             DataType::Int16 => Box::new(Int16Builder::new(capacity)),

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -723,6 +723,33 @@ impl ArrayEqual for UnionArray {
     }
 }
 
+impl ArrayEqual for NullArray {
+    fn equals(&self, other: &dyn Array) -> bool {
+        if other.data_type() != &DataType::Null {
+            return false;
+        }
+
+        if self.len() != other.len() {
+            return false;
+        }
+        if self.null_count() != other.null_count() {
+            return false;
+        }
+
+        true
+    }
+
+    fn range_equals(
+        &self,
+        _other: &dyn Array,
+        _start_idx: usize,
+        _end_idx: usize,
+        _other_start_idx: usize,
+    ) -> bool {
+        unimplemented!("Range comparison for null array not yet supported")
+    }
+}
+
 // Compare if the common basic fields between the two arrays are equal
 fn base_equal(this: &ArrayDataRef, other: &ArrayDataRef) -> bool {
     if this.data_type() != other.data_type() {
@@ -1076,6 +1103,12 @@ impl JsonEqual for UnionArray {
         unimplemented!(
             "Added to allow UnionArray to implement the Array trait: see ARROW-8547"
         )
+    }
+}
+
+impl JsonEqual for NullArray {
+    fn equals_json(&self, _json: &[&Value]) -> bool {
+        unimplemented!("JsonEqual for NullArray not yet supported")
     }
 }
 

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -1107,8 +1107,13 @@ impl JsonEqual for UnionArray {
 }
 
 impl JsonEqual for NullArray {
-    fn equals_json(&self, _json: &[&Value]) -> bool {
-        unimplemented!("JsonEqual for NullArray not yet supported")
+    fn equals_json(&self, json: &[&Value]) -> bool {
+        if self.len() != json.len() {
+            return false;
+        }
+
+        // all JSON values must be nulls
+        json.iter().all(|&v| v == &JNull)
     }
 }
 

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -85,6 +85,7 @@ mod array;
 mod builder;
 mod data;
 mod equal;
+mod null;
 mod union;
 
 use crate::datatypes::*;
@@ -105,6 +106,7 @@ pub use self::array::ListArray;
 pub use self::array::PrimitiveArray;
 pub use self::array::StringArray;
 pub use self::array::StructArray;
+pub use self::null::NullArray;
 pub use self::union::UnionArray;
 
 pub(crate) use self::array::make_array;

--- a/rust/arrow/src/array/null.rs
+++ b/rust/arrow/src/array/null.rs
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::any::Any;
+use std::fmt;
+
+use crate::array::{Array, ArrayData, ArrayDataRef};
+use crate::datatypes::*;
+
+/// Array where all elements are nulls
+pub struct NullArray {
+    data: ArrayDataRef,
+}
+
+impl NullArray {
+    /// Create a new null array of the specified length
+    pub fn new(length: usize) -> Self {
+        let array_data = ArrayData::builder(DataType::Null)
+            .len(length)
+            .null_count(length)
+            .build();
+        NullArray::from(array_data)
+    }
+}
+
+impl Array for NullArray {
+    fn as_any(&self) -> &Any {
+        self
+    }
+
+    fn data(&self) -> ArrayDataRef {
+        self.data.clone()
+    }
+
+    fn data_ref(&self) -> &ArrayDataRef {
+        &self.data
+    }
+}
+
+impl From<ArrayDataRef> for NullArray {
+    fn from(data: ArrayDataRef) -> Self {
+        assert_eq!(
+            data.buffers().len(),
+            0,
+            "NullArray data should contain 0 buffers"
+        );
+        Self { data }
+    }
+}
+
+impl fmt::Debug for NullArray {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "NullArray")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_null_array() {
+        let array1 = NullArray::new(32);
+
+        assert_eq!(array1.len(), 32);
+        assert_eq!(array1.null_count(), 32);
+    }
+}

--- a/rust/arrow/src/array/null.rs
+++ b/rust/arrow/src/array/null.rs
@@ -15,6 +15,28 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//! Contains the `NullArray` type.
+//!
+//! A `NullArray` is a simplified array where all values are null.
+//! Although the [specification](https://arrow.apache.org/docs/format/Columnar.html#null-layout)
+//! allows for not allocating any memory buffers, the Rust implementation allocates null buffers
+//! to ensure consistency of null checks.
+//!
+//! # Example: Create an array
+//!
+//! ```
+//! use arrow::array::{Array, NullArray};
+//!
+//! # fn main() -> arrow::error::Result<()> {
+//! let array = NullArray::new(10);
+//!
+//! assert_eq!(array.len(), 10);
+//! assert_eq!(array.null_count(), 10);
+//!
+//! # Ok(())
+//! # }
+//! ```
+
 use std::any::Any;
 use std::fmt;
 
@@ -23,7 +45,7 @@ use crate::buffer::MutableBuffer;
 use crate::datatypes::*;
 use crate::util::bit_util;
 
-/// Array where all elements are nulls
+/// An Array where all elements are nulls
 pub struct NullArray {
     data: ArrayDataRef,
 }
@@ -62,6 +84,10 @@ impl From<ArrayDataRef> for NullArray {
             data.buffers().len(),
             0,
             "NullArray data should contain 0 buffers"
+        );
+        assert!(
+            data.null_buffer().is_some(),
+            "NullArray data should contain a null buffer"
         );
         Self { data }
     }

--- a/rust/arrow/src/array/union.rs
+++ b/rust/arrow/src/array/union.rs
@@ -417,6 +417,7 @@ impl FieldData {
     /// where `T` satisfies the bound `ArrowPrimitiveType`.
     fn append_null_dynamic(&mut self) -> Result<()> {
         match self.data_type {
+            DataType::Null => unimplemented!(),
             DataType::Boolean => self.append_null::<BooleanType>()?,
             DataType::Int8 => self.append_null::<Int8Type>()?,
             DataType::Int16 => self.append_null::<Int16Type>()?,

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -25,12 +25,13 @@ use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 use crate::array::*;
-use crate::buffer::Buffer;
+use crate::buffer::{Buffer, MutableBuffer};
 use crate::compute::cast;
 use crate::datatypes::{DataType, Field, IntervalUnit, Schema, SchemaRef};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
 use crate::record_batch::{RecordBatch, RecordBatchReader};
+use crate::util::bit_util;
 use DataType::*;
 
 const CONTINUATION_MARKER: u32 = 0xffff_ffff;
@@ -193,6 +194,13 @@ fn create_array(
             let data = ArrayData::builder(data_type.clone())
                 .len(length)
                 .null_count(length)
+                .null_bit_buffer({
+                    // create a buffer and fill it with invalid bits
+                    let num_bytes = bit_util::ceil(length, 8);
+                    let buffer = MutableBuffer::new(num_bytes);
+                    let buffer = buffer.with_bitset(num_bytes, false);
+                    buffer.freeze()
+                })
                 .offset(0)
                 .build();
             node_index += 1;

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -188,6 +188,17 @@ fn create_array(
                 value_array,
             )
         }
+        Null => {
+            let length = nodes[node_index].length() as usize;
+            let data = ArrayData::builder(data_type.clone())
+                .len(length)
+                .null_count(length)
+                .offset(0)
+                .build();
+            node_index += 1;
+            // no buffer increases
+            make_array(data)
+        }
         _ => {
             let array = create_primitive_array(
                 &nodes[node_index],

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -30,6 +30,7 @@ use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::ipc;
 use crate::record_batch::RecordBatch;
+use crate::util::bit_util;
 
 pub struct FileWriter<W: Write> {
     /// The object to write to
@@ -349,8 +350,9 @@ fn write_array_data(
     let null_buffer = match array_data.null_buffer() {
         None => {
             // create a buffer and fill it with valid bits
-            let buffer = MutableBuffer::new(num_rows);
-            let buffer = buffer.with_bitset(num_rows, true);
+            let num_bytes = bit_util::ceil(num_rows, 8);
+            let buffer = MutableBuffer::new(num_bytes);
+            let buffer = buffer.with_bitset(num_bytes, true);
             buffer.freeze()
         }
         Some(buffer) => buffer.clone(),

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -393,6 +393,7 @@ impl<R: Read> Reader<R> {
             })
             .map(|field| {
                 match field.data_type().clone() {
+                    DataType::Null => unimplemented!(),
                     DataType::Boolean => self.build_boolean_array(rows, field.name()),
                     DataType::Float64 => {
                         self.build_primitive_array::<Float64Type>(rows, field.name())
@@ -440,6 +441,7 @@ impl<R: Read> Reader<R> {
                         DataType::UInt64 => self.build_list_array::<UInt64Type>(rows, field.name()),
                         DataType::Float32 => self.build_list_array::<Float32Type>(rows, field.name()),
                         DataType::Float64 => self.build_list_array::<Float64Type>(rows, field.name()),
+                        DataType::Null => unimplemented!(),
                         DataType::Boolean => self.build_boolean_list_array(rows, field.name()),
                         DataType::Utf8 => {
                             let values_builder = StringBuilder::new(rows.len() * 5);

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -63,7 +63,7 @@ pub struct ArrowJsonColumn {
     name: String,
     pub count: usize,
     #[serde(rename = "VALIDITY")]
-    pub validity: Vec<u8>,
+    pub validity: Option<Vec<u8>>,
     #[serde(rename = "DATA")]
     pub data: Option<Vec<Value>>,
     #[serde(rename = "OFFSET")]
@@ -125,6 +125,7 @@ impl ArrowJsonBatch {
                 }
                 let json_array: Vec<Value> = json_from_col(&col, field.data_type());
                 match field.data_type() {
+                    DataType::Null => unimplemented!(),
                     DataType::Boolean => {
                         let arr = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
@@ -345,7 +346,7 @@ impl ArrowJsonBatch {
                     ArrowJsonColumn {
                         name: field.name().clone(),
                         count: col.len(),
-                        validity,
+                        validity: Some(validity),
                         data: Some(data),
                         offset: None,
                         children: None,
@@ -354,7 +355,7 @@ impl ArrowJsonBatch {
                 _ => ArrowJsonColumn {
                     name: field.name().clone(),
                     count: col.len(),
-                    validity: vec![],
+                    validity: None,
                     data: None,
                     offset: None,
                     children: None,
@@ -376,7 +377,10 @@ fn json_from_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value> {
             json_from_fixed_size_list_col(col, &**dt, *list_size as usize)
         }
         DataType::Struct(fields) => json_from_struct_col(col, fields),
-        _ => merge_json_array(&col.validity, &col.data.clone().unwrap()),
+        _ => merge_json_array(
+            col.validity.as_ref().unwrap().as_slice(),
+            &col.data.clone().unwrap(),
+        ),
     }
 }
 
@@ -440,14 +444,24 @@ fn json_from_list_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value>
     let inner = match data_type {
         DataType::List(ref dt) => json_from_col(child, &**dt),
         DataType::Struct(fields) => json_from_struct_col(col, fields),
-        _ => merge_json_array(&child.validity, &child.data.clone().unwrap()),
+        _ => merge_json_array(
+            child.validity.as_ref().unwrap().as_slice(),
+            &child.data.clone().unwrap(),
+        ),
     };
 
     for i in 0..col.count {
-        match col.validity[i] {
-            0 => values.push(Value::Null),
-            1 => values.push(Value::Array(inner[offsets[i]..offsets[i + 1]].to_vec())),
-            _ => panic!("Validity data should be 0 or 1"),
+        match &col.validity {
+            Some(validity) => match &validity[i] {
+                0 => values.push(Value::Null),
+                1 => {
+                    values.push(Value::Array(inner[offsets[i]..offsets[i + 1]].to_vec()))
+                }
+                _ => panic!("Validity data should be 0 or 1"),
+            },
+            None => {
+                // Null type does not have a validity vector
+            }
         }
     }
 
@@ -468,16 +482,22 @@ fn json_from_fixed_size_list_col(
         DataType::List(ref dt) => json_from_col(child, &**dt),
         DataType::FixedSizeList(ref dt, _) => json_from_col(child, &**dt),
         DataType::Struct(fields) => json_from_struct_col(col, fields),
-        _ => merge_json_array(&child.validity, &child.data.clone().unwrap()),
+        _ => merge_json_array(
+            child.validity.as_ref().unwrap().as_slice(),
+            &child.data.clone().unwrap(),
+        ),
     };
 
     for i in 0..col.count {
-        match col.validity[i] {
-            0 => values.push(Value::Null),
-            1 => values.push(Value::Array(
-                inner[(list_size * i)..(list_size * (i + 1))].to_vec(),
-            )),
-            _ => panic!("Validity data should be 0 or 1"),
+        match &col.validity {
+            Some(validity) => match &validity[i] {
+                0 => values.push(Value::Null),
+                1 => values.push(Value::Array(
+                    inner[(list_size * i)..(list_size * (i + 1))].to_vec(),
+                )),
+                _ => panic!("Validity data should be 0 or 1"),
+            },
+            None => {}
         }
     }
 

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -125,7 +125,10 @@ impl ArrowJsonBatch {
                 }
                 let json_array: Vec<Value> = json_from_col(&col, field.data_type());
                 match field.data_type() {
-                    DataType::Null => unimplemented!(),
+                    DataType::Null => {
+                        let arr = arr.as_any().downcast_ref::<NullArray>().unwrap();
+                        arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])
+                    }
                     DataType::Boolean => {
                         let arr = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
                         arr.equals_json(&json_array.iter().collect::<Vec<&Value>>()[..])

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -22,8 +22,8 @@ use arrow::util::integration_util::{ArrowJson, ArrowJsonBatch, ArrowJsonSchema};
 
 use arrow::array::{
     ArrayRef, BinaryBuilder, BooleanBuilder, FixedSizeBinaryBuilder, Float32Builder,
-    Float64Builder, Int16Builder, Int32Builder, Int64Builder, Int8Builder, StringBuilder,
-    UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
+    Float64Builder, Int16Builder, Int32Builder, Int64Builder, Int8Builder, NullArray,
+    StringBuilder, UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
 };
 use arrow::datatypes::{DataType, Schema};
 use arrow::error::{ArrowError, Result};
@@ -109,7 +109,7 @@ fn record_batch_from_json(
         // }
 
         let col: ArrayRef = match field.data_type() {
-            DataType::Null => unimplemented!(),
+            DataType::Null => Arc::new(NullArray::new(json_col.count)),
             DataType::Boolean => {
                 let mut b = BooleanBuilder::new(json_col.count);
                 for (is_valid, value) in json_col

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -407,7 +407,19 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
     let arrow_schema = arrow_reader.schema().as_ref().to_owned();
 
     // compare schemas
-    assert!(json_schema == arrow_schema);
+    if json_schema != arrow_schema {
+        return Err(ArrowError::ComputeError(format!(
+            "Schemas do not match. JSON: {:?}. Arrow: {:?}",
+            json_schema, arrow_schema
+        )));
+    }
+
+    if verbose {
+        eprintln!(
+            "Schemas match. JSON file has {} batches.",
+            json_batches.len()
+        );
+    }
 
     for json_batch in &json_batches {
         if let Some(arrow_batch) = arrow_reader.next_batch()? {

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -103,16 +103,21 @@ fn record_batch_from_json(
     let mut columns = vec![];
 
     for (field, json_col) in schema.fields().iter().zip(json_batch.columns) {
-        if json_col.data.is_none() {
-            //columns.push(Arc::new(vec![]));
-            continue;
-        }
+        // if json_col.data.is_none() {
+        //     //columns.push(Arc::new(vec![]));
+        //     continue;
+        // }
 
         let col: ArrayRef = match field.data_type() {
+            DataType::Null => unimplemented!(),
             DataType::Boolean => {
                 let mut b = BooleanBuilder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_bool().unwrap()),
@@ -124,8 +129,12 @@ fn record_batch_from_json(
             }
             DataType::Int8 => {
                 let mut b = Int8Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_i64().unwrap() as i8),
@@ -137,8 +146,12 @@ fn record_batch_from_json(
             }
             DataType::Int16 => {
                 let mut b = Int16Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_i64().unwrap() as i16),
@@ -150,8 +163,12 @@ fn record_batch_from_json(
             }
             DataType::Int32 => {
                 let mut b = Int32Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_i64().unwrap() as i32),
@@ -163,8 +180,12 @@ fn record_batch_from_json(
             }
             DataType::Int64 => {
                 let mut b = Int64Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_i64().unwrap()),
@@ -176,8 +197,12 @@ fn record_batch_from_json(
             }
             DataType::UInt8 => {
                 let mut b = UInt8Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_u64().unwrap() as u8),
@@ -189,8 +214,12 @@ fn record_batch_from_json(
             }
             DataType::UInt16 => {
                 let mut b = UInt16Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_u64().unwrap() as u16),
@@ -202,8 +231,12 @@ fn record_batch_from_json(
             }
             DataType::UInt32 => {
                 let mut b = UInt32Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_u64().unwrap() as u32),
@@ -215,8 +248,12 @@ fn record_batch_from_json(
             }
             DataType::UInt64 => {
                 let mut b = UInt64Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_u64().unwrap()),
@@ -228,8 +265,12 @@ fn record_batch_from_json(
             }
             DataType::Float32 => {
                 let mut b = Float32Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_f64().unwrap() as f32),
@@ -241,8 +282,12 @@ fn record_batch_from_json(
             }
             DataType::Float64 => {
                 let mut b = Float64Builder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_f64().unwrap()),
@@ -254,8 +299,12 @@ fn record_batch_from_json(
             }
             DataType::Binary => {
                 let mut b = BinaryBuilder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => {
@@ -270,8 +319,12 @@ fn record_batch_from_json(
             }
             DataType::Utf8 => {
                 let mut b = StringBuilder::new(json_col.count);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => b.append_value(value.as_str().unwrap()),
@@ -283,8 +336,12 @@ fn record_batch_from_json(
             }
             DataType::FixedSizeBinary(len) => {
                 let mut b = FixedSizeBinaryBuilder::new(json_col.count, *len);
-                for (is_valid, value) in
-                    json_col.validity.iter().zip(json_col.data.unwrap())
+                for (is_valid, value) in json_col
+                    .validity
+                    .as_ref()
+                    .unwrap()
+                    .iter()
+                    .zip(json_col.data.unwrap())
                 {
                     match is_valid {
                         1 => {

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -103,11 +103,6 @@ fn record_batch_from_json(
     let mut columns = vec![];
 
     for (field, json_col) in schema.fields().iter().zip(json_batch.columns) {
-        // if json_col.data.is_none() {
-        //     //columns.push(Arc::new(vec![]));
-        //     continue;
-        // }
-
         let col: ArrayRef = match field.data_type() {
             DataType::Null => Arc::new(NullArray::new(json_col.count)),
             DataType::Boolean => {


### PR DESCRIPTION
There are now fewer failures with this support for the Null type. The failures are for other reasons and we already have JIRAs filed for those.

```
################# FAILURES #################
FAILED TEST: primitive Java producing,  Rust consuming

FAILED TEST: primitive_zerolength Java producing,  Rust consuming

FAILED TEST: null Java producing,  Rust consuming

FAILED TEST: null_trivial Java producing,  Rust consuming

FAILED TEST: datetime Java producing,  Rust consuming

FAILED TEST: null Rust producing,  Java consuming

FAILED TEST: null_trivial Rust producing,  Java consuming

FAILED TEST: datetime Rust producing,  Java consuming

FAILED TEST: primitive_large_offsets Rust producing,  Rust consuming

FAILED TEST: datetime Rust producing,  Rust consuming

10 failures
```