### PR TITLE
ARROW-8858: [FlightRPC] ensure binary/multi-valued headers are properly exposed

### DIFF
--- a/cpp/src/arrow/flight/middleware.h
+++ b/cpp/src/arrow/flight/middleware.h
@@ -20,9 +20,9 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <utility>
 
 #include "arrow/flight/visibility.h"  // IWYU pragma: keep
@@ -33,7 +33,10 @@ namespace arrow {
 
 namespace flight {
 
-using CallHeaders = std::unordered_multimap<util::string_view, util::string_view>;
+/// \brief Headers sent from the client or server.
+///
+/// Header values are ordered.
+using CallHeaders = std::multimap<util::string_view, util::string_view>;
 
 /// \brief A write-only wrapper around headers for an RPC call.
 class ARROW_FLIGHT_EXPORT AddCallHeaders {

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallHeaders.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/CallHeaders.java
@@ -26,7 +26,6 @@ public interface CallHeaders {
   /**
    * Get the value of a metadata key. If multiple values are present, then get the last one.
    */
-  @Deprecated()
   String get(String key);
 
   /**
@@ -37,7 +36,6 @@ public interface CallHeaders {
   /**
    * Get all values present for the given metadata key.
    */
-  @Deprecated
   Iterable<String> getAll(String key);
 
   /**
@@ -50,7 +48,6 @@ public interface CallHeaders {
    *
    * <p>Duplicate metadata are permitted.
    */
-  @Deprecated
   void insert(String key, String value);
 
   /**

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/MetadataAdapter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/MetadataAdapter.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.flight.grpc;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -78,13 +79,15 @@ class MetadataAdapter implements CallHeaders {
 
   @Override
   public Set<String> keys() {
-    // Remove binary keys - we don't expose those
-    return this.metadata.keys().stream().filter(key -> !key.endsWith(Metadata.BINARY_HEADER_SUFFIX))
-        .collect(Collectors.toSet());
+    return new HashSet<>(this.metadata.keys());
   }
 
   @Override
   public boolean containsKey(String key) {
+    if (key.endsWith("-bin")) {
+      final Key<?> grpcKey = Key.of(key, Metadata.BINARY_BYTE_MARSHALLER);
+      return this.metadata.containsKey(grpcKey);
+    }
     final Key<?> grpcKey = Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
     return this.metadata.containsKey(grpcKey);
   }


### PR DESCRIPTION
This fixes a few things:
- Sending/receiving text headers in Java
- Iterating over all headers in Java (binary ones used to be filtered out)
- Receiving binary headers in Python