### PR TITLE
ARROW-8862: [C++] NumericBuilder should use MemoryPool passed to CTOR

### DIFF
--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -66,10 +66,10 @@ class NumericBuilder : public ArrayBuilder {
   template <typename T1 = T>
   explicit NumericBuilder(
       enable_if_parameter_free<T1, MemoryPool*> pool = default_memory_pool())
-      : ArrayBuilder(pool), type_(TypeTraits<T>::type_singleton()) {}
+      : ArrayBuilder(pool), type_(TypeTraits<T>::type_singleton()), data_builder_(pool) {}
 
   NumericBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool)
-      : ArrayBuilder(pool), type_(type) {}
+      : ArrayBuilder(pool), type_(type), data_builder_(pool) {}
 
   /// Append a single scalar and increase the size if necessary.
   Status Append(const value_type val) {


### PR DESCRIPTION
`NumericBuilder` uses the `pool` (`MemoryPool*`) parameter to initialise the `ArrayBuilder` base class, but does not use it to initialise its own internal builder, `data_builder_` (`TypedBufferBuilder`).  For comparison `ArrayBuilder` uses the `pool` to initialise its own `null_bitmap_builder_` member (also a `TypedBufferBuilder`).

This effect was observed when trying to switch to a custom `MemoryPool` for performance reasons.  A hook was used to detect any use of the `MemoryPool` proved by `default_memory_pool()`.