### PR TITLE
ARROW-8848: [Ruby][CI] Fix MSYS2 update error

### DIFF
--- a/ci/scripts/msys2_system_upgrade.sh
+++ b/ci/scripts/msys2_system_upgrade.sh
@@ -19,12 +19,13 @@
 
 set -eux
 
-# Ensure using the latest pacman
-pacman \
-  --noconfirm \
-  --sync \
-  -yy \
-  pacman
+# Update pacman manually from old MSYS2.
+# See also: https://github.com/msys2/MSYS2-packages/issues/1960
+pacman --noconfirm --refresh --sync zstd
+wget -q http://repo.msys2.org/msys/x86_64/pacman-5.2.1-7-x86_64.pkg.tar.zst
+zstd -d pacman-5.2.1-7-x86_64.pkg.tar.zst
+gzip pacman-5.2.1-7-x86_64.pkg.tar
+pacman --noconfirm --upgrade ./pacman-5.2.1-7-x86_64.pkg.tar.gz
 
 pacman \
   --noconfirm \


### PR DESCRIPTION
pacman 5.2.1 uses zstd instead of gzip. Upgrading pacman by pacman
from old MSYS2 doesn't work. We need to upgrade pacman manually.

See also: https://github.com/msys2/MSYS2-packages/issues/1960