### PR TITLE
ARROW-8855: [Rust] [Integration] Complete record_batch_from_json types

### DIFF
--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -327,9 +327,13 @@ pub fn cast(array: &ArrayRef, to_type: &DataType) -> Result<ArrayRef> {
 
         // temporal casts
         (Int32, Date32(_)) => cast_array_data::<Date32Type>(array, to_type.clone()),
+        (Int32, Time32(_)) => cast_array_data::<Date32Type>(array, to_type.clone()),
         (Date32(_), Int32) => cast_array_data::<Int32Type>(array, to_type.clone()),
+        (Time32(_), Int32) => cast_array_data::<Int32Type>(array, to_type.clone()),
         (Int64, Date64(_)) => cast_array_data::<Date64Type>(array, to_type.clone()),
+        (Int64, Time64(_)) => cast_array_data::<Date64Type>(array, to_type.clone()),
         (Date64(_), Int64) => cast_array_data::<Int64Type>(array, to_type.clone()),
+        (Time64(_), Int64) => cast_array_data::<Int64Type>(array, to_type.clone()),
         (Date32(DateUnit::Day), Date64(DateUnit::Millisecond)) => {
             let date_array = array.as_any().downcast_ref::<Date32Array>().unwrap();
             let mut b = Date64Builder::new(array.len());

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -25,7 +25,7 @@ use arrow::array::{
     Float64Builder, Int16Builder, Int32Builder, Int64Builder, Int8Builder, StringBuilder,
     UInt16Builder, UInt32Builder, UInt64Builder, UInt8Builder,
 };
-use arrow::datatypes::{DataType, Schema};
+use arrow::datatypes::{DataType, DateUnit, IntervalUnit, Schema};
 use arrow::error::{ArrowError, Result};
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
@@ -148,7 +148,10 @@ fn record_batch_from_json(
                 }
                 Arc::new(b.finish())
             }
-            DataType::Int32 => {
+            DataType::Int32
+            | DataType::Date32(DateUnit::Day)
+            | DataType::Time32(_)
+            | DataType::Interval(IntervalUnit::YearMonth) => {
                 let mut b = Int32Builder::new(json_col.count);
                 for (is_valid, value) in
                     json_col.validity.iter().zip(json_col.data.unwrap())
@@ -159,9 +162,15 @@ fn record_batch_from_json(
                     }
                     .unwrap();
                 }
-                Arc::new(b.finish())
+                let array = Arc::new(b.finish()) as ArrayRef;
+                arrow::compute::cast(&array, field.data_type()).unwrap()
             }
-            DataType::Int64 => {
+            DataType::Int64
+            | DataType::Date64(DateUnit::Millisecond)
+            | DataType::Time64(_)
+            | DataType::Timestamp(_, _)
+            | DataType::Duration(_)
+            | DataType::Interval(IntervalUnit::DayTime) => {
                 let mut b = Int64Builder::new(json_col.count);
                 for (is_valid, value) in
                     json_col.validity.iter().zip(json_col.data.unwrap())
@@ -172,7 +181,8 @@ fn record_batch_from_json(
                     }
                     .unwrap();
                 }
-                Arc::new(b.finish())
+                let array = Arc::new(b.finish()) as ArrayRef;
+                arrow::compute::cast(&array, field.data_type()).unwrap()
             }
             DataType::UInt8 => {
                 let mut b = UInt8Builder::new(json_col.count);


### PR DESCRIPTION
Adds missing types in `record_batch_from_json`.
This however excludes list types, we can add them separately.