### PR TITLE
ARROW-8882: [C#] Add .editorconfig to C# code

### DIFF
--- a/csharp/.editorconfig
+++ b/csharp/.editorconfig
@@ -1,0 +1,169 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+# C# files
+[*.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = one_less_than_current
+
+# Modifier preferences
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
+
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+# Types: use keywords instead of BCL types, and permit var only when the type is clear
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = false:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds   = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols  = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style    = static_prefix_style
+dotnet_naming_symbols.static_fields.applicable_kinds   = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case 
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols  = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style    = camel_case_underscore_style
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case 
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true
+csharp_prefer_braces = true:refactoring
+csharp_preserve_single_line_blocks = true:none
+csharp_preserve_single_line_statements = false:none
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = true:refactoring
+csharp_style_expression_bodied_constructors = true:refactoring
+csharp_style_expression_bodied_operators = true:refactoring
+csharp_style_expression_bodied_properties = true:refactoring
+csharp_style_expression_bodied_indexers = true:refactoring
+csharp_style_expression_bodied_accessors = true:refactoring
+csharp_style_expression_bodied_lambdas = true:refactoring
+csharp_style_expression_bodied_local_functions = true:refactoring
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = do_not_ignore
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Xml project files
+[*.{csproj,props,targets}]
+indent_size = 2
+charset = utf-8

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -171,6 +171,10 @@ Build from the Apache Arrow project root.
 
 All build artifacts are placed in the **artifacts** folder in the project root.
 
+# Coding Style
+
+This project follows the coding style specified in [Coding Style](https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md).
+
 # Updating FlatBuffers code
 
 See https://google.github.io/flatbuffers/flatbuffers_guide_use_java_c-sharp.html for how to get the `flatc` executable.

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -76,7 +76,7 @@ namespace Apache.Arrow
             {
                 ValueOffsets.Append(Offset);
 
-                var validityBuffer = NullCount > 0
+                ArrowBuffer validityBuffer = NullCount > 0
                                         ? ValidityBuffer.Build(allocator).ValueBuffer
                                         : ArrowBuffer.Empty;
 
@@ -114,14 +114,14 @@ namespace Apache.Arrow
 
             public TBuilder AppendRange(IEnumerable<byte[]> values)
             {
-                foreach (var arr in values)
+                foreach (byte[] arr in values)
                 {
                     if (arr == null)
                     {
                         AppendNull();
                         continue;
                     }
-                    var len = ValueBuffer.Length;
+                    int len = ValueBuffer.Length;
                     ValueOffsets.Append(Offset);
                     ValueBuffer.Append(arr);
                     ValidityBuffer.Append(true);
@@ -137,9 +137,9 @@ namespace Apache.Arrow
                 {
                     return AppendNull();
                 }
-                var len = ValueBuffer.Length;
+                int len = ValueBuffer.Length;
                 ValueBuffer.AppendRange(values);
-                var valOffset = ValueBuffer.Length - len;
+                int valOffset = ValueBuffer.Length - len;
                 ValueOffsets.Append(Offset);
                 Offset += valOffset;
                 ValidityBuffer.Append(true);
@@ -225,7 +225,7 @@ namespace Apache.Arrow
                 return 0;
             }
 
-            var offsets = ValueOffsets;
+            ReadOnlySpan<int> offsets = ValueOffsets;
             return offsets[index + 1] - offsets[index];
         }
 

--- a/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BooleanArray.cs
@@ -62,7 +62,7 @@ namespace Apache.Arrow
 
             public Builder Append(ReadOnlySpan<bool> span)
             {
-                foreach (var value in span)
+                foreach (bool value in span)
                 {
                     Append(value);
                 }
@@ -71,7 +71,7 @@ namespace Apache.Arrow
 
             public Builder AppendRange(IEnumerable<bool> values)
             {
-                foreach (var value in values)
+                foreach (bool value in values)
                 {
                     Append(value);
                 }
@@ -85,7 +85,7 @@ namespace Apache.Arrow
 
             public BooleanArray Build(MemoryAllocator allocator = default)
             {
-                var validityBuffer = NullCount > 0
+                ArrowBuffer validityBuffer = NullCount > 0
                                         ? ValidityBuffer.Build(allocator)
                                         : ArrowBuffer.Empty;
 
@@ -154,10 +154,10 @@ namespace Apache.Arrow
             {
                 CheckIndex(i);
                 CheckIndex(j);
-                var bi = BitUtility.GetBit(ValueBuffer.Span, i);
-                var biValid = BitUtility.GetBit(ValidityBuffer.Span, i);
-                var bj = BitUtility.GetBit(ValueBuffer.Span, j);
-                var bjValid = BitUtility.GetBit(ValidityBuffer.Span, j);
+                bool bi = BitUtility.GetBit(ValueBuffer.Span, i);
+                bool biValid = BitUtility.GetBit(ValidityBuffer.Span, i);
+                bool bj = BitUtility.GetBit(ValueBuffer.Span, j);
+                bool bjValid = BitUtility.GetBit(ValidityBuffer.Span, j);
                 BitUtility.SetBit(ValueBuffer.Span, i, bj);
                 BitUtility.SetBit(ValidityBuffer.Span, i, bjValid);
                 BitUtility.SetBit(ValueBuffer.Span, j, bi);

--- a/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date32Array.cs
@@ -57,7 +57,7 @@ namespace Apache.Arrow
 
         public DateTimeOffset? GetDate(int index)
         {
-            var value = GetValue(index);
+            int? value = GetValue(index);
 
             if (!value.HasValue)
             {

--- a/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
@@ -57,7 +57,7 @@ namespace Apache.Arrow
 
         public DateTimeOffset? GetDate(int index)
         {
-            var value = GetValue(index);
+            long? value = GetValue(index);
 
             if (!value.HasValue)
             {

--- a/csharp/src/Apache.Arrow/Arrays/ListArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/ListArray.cs
@@ -81,7 +81,7 @@ namespace Apache.Arrow
             {
                 Append();
 
-                var validityBuffer = NullCount > 0
+                ArrowBuffer validityBuffer = NullCount > 0
                                         ? ValidityBufferBuilder.Build(allocator).ValueBuffer
                                         : ArrowBuffer.Empty;
 
@@ -166,7 +166,7 @@ namespace Apache.Arrow
                 return 0;
             }
 
-            var offsets = ValueOffsets;
+            ReadOnlySpan<int> offsets = ValueOffsets;
             return offsets[index + 1] - offsets[index];
         }
 

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArray.cs
@@ -44,12 +44,12 @@ namespace Apache.Arrow
 
         public IList<T?> ToList(bool includeNulls = false)
         {
-            var span = Values;
+            ReadOnlySpan<T> span = Values;
             var list = new List<T?>(span.Length);
 
-            for (var i = 0; i < span.Length; i++)
+            for (int i = 0; i < span.Length; i++)
             {
-                var value = GetValue(i);
+                T? value = GetValue(i);
 
                 if (value.HasValue)
                 {

--- a/csharp/src/Apache.Arrow/Arrays/PrimitiveArrayBuilder.cs
+++ b/csharp/src/Apache.Arrow/Arrays/PrimitiveArrayBuilder.cs
@@ -46,7 +46,7 @@ namespace Apache.Arrow
         public TBuilder Append(ReadOnlySpan<TFrom> span)
         {
             ArrayBuilder.Reserve(span.Length);
-            foreach (var value in span)
+            foreach (TFrom value in span)
             {
                 Append(value);
             }
@@ -139,7 +139,7 @@ namespace Apache.Arrow
 
         public TBuilder Append(ReadOnlySpan<T> span)
         {
-            var len = ValueBuffer.Length;
+            int len = ValueBuffer.Length;
             ValueBuffer.Append(span);
             ValidityBuffer.AppendRange(Enumerable.Repeat(true, ValueBuffer.Length - len));
             return Instance;
@@ -147,7 +147,7 @@ namespace Apache.Arrow
 
         public TBuilder AppendRange(IEnumerable<T> values)
         {
-            var len = ValueBuffer.Length;
+            int len = ValueBuffer.Length;
             ValueBuffer.AppendRange(values);
             ValidityBuffer.AppendRange(Enumerable.Repeat(true, ValueBuffer.Length - len));
             return Instance;
@@ -177,7 +177,7 @@ namespace Apache.Arrow
 
         public TBuilder Swap(int i, int j)
         {
-            var x = ValueBuffer.Span[i];
+            T x = ValueBuffer.Span[i];
             ValueBuffer.Span[i] = ValueBuffer.Span[j];
             ValueBuffer.Span[j] = x;
             ValidityBuffer.Swap(i, j);
@@ -186,7 +186,7 @@ namespace Apache.Arrow
 
         public TArray Build(MemoryAllocator allocator = default)
         {
-            var validityBuffer = NullCount > 0
+            ArrowBuffer validityBuffer = NullCount > 0
                                     ? ValidityBuffer.Build(allocator).ValueBuffer
                                     : ArrowBuffer.Empty;
 

--- a/csharp/src/Apache.Arrow/Arrays/StringArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/StringArray.cs
@@ -41,13 +41,13 @@ namespace Apache.Arrow
                     return AppendNull();
                 }
                 encoding = encoding ?? DefaultEncoding;
-                var span = encoding.GetBytes(value);
+                byte[] span = encoding.GetBytes(value);
                 return Append(span.AsSpan());
             }
 
             public Builder AppendRange(IEnumerable<string> values, Encoding encoding = null)
             {
-                foreach (var value in values)
+                foreach (string value in values)
                 {
                     Append(value, encoding);
                 }
@@ -74,7 +74,7 @@ namespace Apache.Arrow
         {
             encoding = encoding ?? DefaultEncoding;
 
-            var bytes = GetBytes(index);
+            ReadOnlySpan<byte> bytes = GetBytes(index);
 
             if (bytes == default)
             {

--- a/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/TimestampArray.cs
@@ -22,7 +22,7 @@ namespace Apache.Arrow
 {
     public class TimestampArray: PrimitiveArray<long>
     {
-        private static readonly DateTimeOffset Epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
+        private static readonly DateTimeOffset s_epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
 
         public class Builder: PrimitiveArrayBuilder<DateTimeOffset, long, TimestampArray, Builder>
         {
@@ -70,8 +70,8 @@ namespace Apache.Arrow
                 // - Compute time span between epoch and specified time
                 // - Compute time divisions per tick
 
-                var timeSpan = value - Epoch;
-                var ticks = timeSpan.Ticks;
+                TimeSpan timeSpan = value - s_epoch;
+                long ticks = timeSpan.Ticks;
 
                 switch (DataType.Unit)
                 {
@@ -109,7 +109,7 @@ namespace Apache.Arrow
         public DateTimeOffset GetTimestampUnchecked(int index)
         {
             var type = (TimestampType) Data.DataType;
-            var value = Values[index];
+            long value = Values[index];
 
             long ticks;
 
@@ -132,7 +132,7 @@ namespace Apache.Arrow
                         $"Unsupported timestamp unit <{type.Unit}>");
             }
 
-            return new DateTimeOffset(Epoch.Ticks + ticks, TimeSpan.Zero);
+            return new DateTimeOffset(s_epoch.Ticks + ticks, TimeSpan.Zero);
         }
 
         public DateTimeOffset? GetTimestamp(int index)

--- a/csharp/src/Apache.Arrow/ArrowBuffer.Builder.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.Builder.cs
@@ -15,6 +15,7 @@
 
 using Apache.Arrow.Memory;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
@@ -71,7 +72,7 @@ namespace Apache.Arrow
             {
                 if (values != null)
                 {
-                    foreach (var v in values)
+                    foreach (T v in values)
                     {
                         Append(v);
                     }
@@ -106,8 +107,8 @@ namespace Apache.Arrow
                 int currentBytesLength = Length * _size;
                 int bufferLength = checked((int)BitUtility.RoundUpToMultipleOf64(currentBytesLength));
 
-                var memoryAllocator = allocator ?? MemoryAllocator.Default.Value;
-                var memoryOwner = memoryAllocator.Allocate(bufferLength);
+                MemoryAllocator memoryAllocator = allocator ?? MemoryAllocator.Default.Value;
+                IMemoryOwner<byte> memoryOwner = memoryAllocator.Allocate(bufferLength);
                 Memory.Slice(0, currentBytesLength).CopyTo(memoryOwner.Memory);
 
                 return new ArrowBuffer(memoryOwner);
@@ -115,13 +116,13 @@ namespace Apache.Arrow
 
             private void EnsureCapacity(int n)
             {
-                var length = checked(Length + n);
+                int length = checked(Length + n);
 
                 if (length > Capacity)
                 {
                     // TODO: specifiable growth strategy
 
-                    var capacity = Math.Max(length * _size, Memory.Length * 2);
+                    int capacity = Math.Max(length * _size, Memory.Length * 2);
                     Reallocate(capacity);
                 }
             }

--- a/csharp/src/Apache.Arrow/BitUtility.cs
+++ b/csharp/src/Apache.Arrow/BitUtility.cs
@@ -22,7 +22,7 @@ namespace Apache.Arrow
 {
     public static class BitUtility
     {
-        private static readonly byte[] PopcountTable = {
+        private static ReadOnlySpan<byte> PopcountTable => new byte[] {
             0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4, 1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5,
             1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
             1, 2, 2, 3, 2, 3, 3, 4, 2, 3, 3, 4, 3, 4, 4, 5, 2, 3, 3, 4, 3, 4, 4, 5, 3, 4, 4, 5, 4, 5, 5, 6,
@@ -33,7 +33,7 @@ namespace Apache.Arrow
             3, 4, 4, 5, 4, 5, 5, 6, 4, 5, 5, 6, 5, 6, 6, 7, 4, 5, 5, 6, 5, 6, 6, 7, 5, 6, 6, 7, 6, 7, 7, 8,
         };
 
-        private static readonly byte[] BitMask = {
+        private static ReadOnlySpan<byte> BitMask => new byte[] {
             1, 2, 4, 8, 16, 32, 64, 128
         };
 
@@ -55,8 +55,8 @@ namespace Apache.Arrow
 
         public static void SetBit(Span<byte> data, int index, bool value)
         {
-            var idx = index / 8;
-            var mod = index % 8;
+            int idx = index / 8;
+            int mod = index % 8;
             data[idx] = value
                 ? (byte)(data[idx] | BitMask[mod])
                 : (byte)(data[idx] & ~BitMask[mod]);
@@ -76,17 +76,17 @@ namespace Apache.Arrow
         /// <returns>Count of set (one) bits/returns>
         public static int CountBits(ReadOnlySpan<byte> data, int offset)
         {
-            var start = (offset / 8);
-            var startBit = offset % 8;
+            int start = (offset / 8);
+            int startBit = offset % 8;
 
             if (startBit < 0) return 0;
             if (startBit == 0) return CountBits(data);
 
-            var count = 0;
+            int count = 0;
 
             count += CountBits(data.Slice(start + 1));
 
-            for (var i = startBit; i < 8; i++)
+            for (int i = startBit; i < 8; i++)
             {
                 if (GetBit(data.Slice(start, 1), i))
                     count++;
@@ -102,8 +102,8 @@ namespace Apache.Arrow
         /// <returns>Count of set (one) bits.</returns>
         public static int CountBits(ReadOnlySpan<byte> data)
         {
-            var count = 0;
-            foreach (var t in data)
+            int count = 0;
+            foreach (byte t in data)
                 count += PopcountTable[t];
             return count;
         }

--- a/csharp/src/Apache.Arrow/Column.cs
+++ b/csharp/src/Apache.Arrow/Column.cs
@@ -25,45 +25,44 @@ namespace Apache.Arrow
     public class Column
     {
         public Field Field { get;  }
-        private readonly ChunkedArray _columnArrays;
-        public ChunkedArray Data => _columnArrays;
+        public ChunkedArray Data { get; }
 
         public Column(Field field, IList<Array> arrays)
         {
-            _columnArrays = new ChunkedArray(arrays);
+            Data = new ChunkedArray(arrays);
             Field = field;
             if (!ValidateArrayDataTypes())
             {
-                throw new ArgumentException($"{Field.DataType} must match {_columnArrays.DataType}");
+                throw new ArgumentException($"{Field.DataType} must match {Data.DataType}");
             }
         }
 
         private Column(Field field, ChunkedArray arrays)
         {
             Field = field;
-            _columnArrays = arrays;
+            Data = arrays;
         }
 
-        public long Length => _columnArrays.Length;
-        public long NullCount => _columnArrays.NullCount;
+        public long Length => Data.Length;
+        public long NullCount => Data.NullCount;
         public string Name => Field.Name;
         public IArrowType Type => Field.DataType;
 
         public Column Slice(int offset, int length)
         {
-            return new Column(Field, _columnArrays.Slice(offset, length));
+            return new Column(Field, Data.Slice(offset, length));
         }
 
         public Column Slice(int offset)
         {
-            return new Column(Field, _columnArrays.Slice(offset));
+            return new Column(Field, Data.Slice(offset));
         }
 
         private bool ValidateArrayDataTypes()
         {
-            for (int i = 0; i < _columnArrays.ArrayCount; i++)
+            for (int i = 0; i < Data.ArrayCount; i++)
             {
-                if (_columnArrays.Array(i).Data.DataType != Field.DataType)
+                if (Data.Array(i).Data.DataType != Field.DataType)
                 {
                     return false;
                 }

--- a/csharp/src/Apache.Arrow/Extensions/ArrowTypeExtensions.cs
+++ b/csharp/src/Apache.Arrow/Extensions/ArrowTypeExtensions.cs
@@ -20,23 +20,23 @@ namespace Apache.Arrow
 {
     public static class ArrowTypeExtensions
     {
-        private static readonly ISet<ArrowTypeId> IntegralTypes = 
+        private static readonly ISet<ArrowTypeId> s_integralTypes = 
             new HashSet<ArrowTypeId>(new[]
             {
                 ArrowTypeId.Int8, ArrowTypeId.Int16, ArrowTypeId.Int32, ArrowTypeId.Int64,
                 ArrowTypeId.UInt8, ArrowTypeId.UInt16, ArrowTypeId.UInt32, ArrowTypeId.UInt64,
             });
 
-        private static readonly ISet<ArrowTypeId> FloatingPointTypes =
+        private static readonly ISet<ArrowTypeId> s_floatingPointTypes =
             new HashSet<ArrowTypeId>(new[]
             {
                 ArrowTypeId.HalfFloat, ArrowTypeId.Float, ArrowTypeId.Double
             });
 
         public static bool IsIntegral(this IArrowType type) 
-            => IntegralTypes.Contains(type.TypeId);
+            => s_integralTypes.Contains(type.TypeId);
 
         public static bool IsFloatingPoint(this IArrowType type)
-            => FloatingPointTypes.Contains(type.TypeId);
+            => s_floatingPointTypes.Contains(type.TypeId);
     }
 }

--- a/csharp/src/Apache.Arrow/Extensions/TimeSpanExtensions.cs
+++ b/csharp/src/Apache.Arrow/Extensions/TimeSpanExtensions.cs
@@ -26,11 +26,10 @@ namespace Apache.Arrow
         /// <returns>ISO 8601 offset string</returns>
         public static string ToTimeZoneOffsetString(this TimeSpan timeSpan)
         {
-            var sign = timeSpan.Hours >= 0 ? "+" : "-";
-            var hours = Math.Abs(timeSpan.Hours);
-            var minutes = Math.Abs(timeSpan.Minutes);
+            string sign = timeSpan.Hours >= 0 ? "+" : "-";
+            int hours = Math.Abs(timeSpan.Hours);
+            int minutes = Math.Abs(timeSpan.Minutes);
             return sign + hours.ToString("00") + ":" + minutes.ToString("00");
         }
-           
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileReaderImplementation.cs
@@ -149,7 +149,7 @@ namespace Apache.Arrow.Ipc
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            var block = _footer.GetRecordBatchBlock(index);
+            Block block = _footer.GetRecordBatchBlock(index);
 
             BaseStream.Position = block.Offset;
 
@@ -165,7 +165,7 @@ namespace Apache.Arrow.Ipc
                 throw new ArgumentOutOfRangeException(nameof(index));
             }
 
-            var block = _footer.GetRecordBatchBlock(index);
+            Block block = _footer.GetRecordBatchBlock(index);
 
             BaseStream.Position = block.Offset;
 
@@ -181,7 +181,7 @@ namespace Apache.Arrow.Ipc
                 return null;
             }
 
-            var result = await ReadRecordBatchAsync(_recordBatchIndex, cancellationToken).ConfigureAwait(false);
+            RecordBatch result = await ReadRecordBatchAsync(_recordBatchIndex, cancellationToken).ConfigureAwait(false);
             _recordBatchIndex++;
 
             return result;
@@ -234,8 +234,8 @@ namespace Apache.Arrow.Ipc
 
         private async ValueTask ValidateMagicAsync()
         {
-            var startingPosition = BaseStream.Position;
-            var magicLength = ArrowFileConstants.Magic.Length;
+            long startingPosition = BaseStream.Position;
+            int magicLength = ArrowFileConstants.Magic.Length;
 
             try
             {
@@ -266,8 +266,8 @@ namespace Apache.Arrow.Ipc
 
         private void ValidateMagic()
         {
-            var startingPosition = BaseStream.Position;
-            var magicLength = ArrowFileConstants.Magic.Length;
+            long startingPosition = BaseStream.Position;
+            int magicLength = ArrowFileConstants.Magic.Length;
 
             try
             {

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFileWriter.cs
@@ -124,34 +124,34 @@ namespace Apache.Arrow.Ipc
         {
             Builder.Clear();
 
-            var offset = BaseStream.Position;
+            long offset = BaseStream.Position;
 
             // Serialize the schema
 
-            var schemaOffset = SerializeSchema(schema);
+            FlatBuffers.Offset<Flatbuf.Schema> schemaOffset = SerializeSchema(schema);
 
             // Serialize all record batches
 
             Flatbuf.Footer.StartRecordBatchesVector(Builder, RecordBatchBlocks.Count);
 
-            foreach (var recordBatch in RecordBatchBlocks)
+            foreach (Block recordBatch in RecordBatchBlocks)
             {
                 Flatbuf.Block.CreateBlock(
                     Builder, recordBatch.Offset, recordBatch.MetadataLength, recordBatch.BodyLength);
             }
 
-            var recordBatchesVectorOffset = Builder.EndVector();
+            FlatBuffers.VectorOffset recordBatchesVectorOffset = Builder.EndVector();
 
             // Serialize all dictionaries
             // NOTE: Currently unsupported.
 
             Flatbuf.Footer.StartDictionariesVector(Builder, 0);
 
-            var dictionaryBatchesOffset = Builder.EndVector();
+            FlatBuffers.VectorOffset dictionaryBatchesOffset = Builder.EndVector();
 
             // Serialize and write the footer flatbuffer
 
-            var footerOffset = Flatbuf.Footer.CreateFooter(Builder, CurrentMetadataVersion,
+            FlatBuffers.Offset<Flatbuf.Footer> footerOffset = Flatbuf.Footer.CreateFooter(Builder, CurrentMetadataVersion,
                 schemaOffset, dictionaryBatchesOffset, recordBatchesVectorOffset);
 
             Builder.Finish(footerOffset.Value);

--- a/csharp/src/Apache.Arrow/Ipc/ArrowFooter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowFooter.cs
@@ -68,9 +68,9 @@ namespace Apache.Arrow.Ipc
 
         private static IEnumerable<Block> GetDictionaries(Flatbuf.Footer footer)
         {
-            for (var i = 0; i < footer.DictionariesLength; i++)
+            for (int i = 0; i < footer.DictionariesLength; i++)
             {
-                var block = footer.Dictionaries(i);
+                Flatbuf.Block? block = footer.Dictionaries(i);
 
                 if (block.HasValue)
                 {
@@ -81,9 +81,9 @@ namespace Apache.Arrow.Ipc
 
         private static IEnumerable<Block> GetRecordBatches(Flatbuf.Footer footer)
         {
-            for (var i = 0; i < footer.RecordBatchesLength; i++)
+            for (int i = 0; i < footer.RecordBatchesLength; i++)
             {
-                var block = footer.RecordBatches(i);
+                Flatbuf.Block? block = footer.RecordBatches(i);
 
                 if (block.HasValue)
                 {

--- a/csharp/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowReaderImplementation.cs
@@ -46,8 +46,8 @@ namespace Apache.Arrow.Ipc
         protected static T ReadMessage<T>(ByteBuffer bb)
             where T : struct, IFlatbufferObject
         {
-            var returnType = typeof(T);
-            var msg = Flatbuf.Message.GetRootAsMessage(bb);
+            Type returnType = typeof(T);
+            Flatbuf.Message msg = Flatbuf.Message.GetRootAsMessage(bb);
 
             if (MatchEnum(msg.HeaderType, returnType))
             {
@@ -92,7 +92,7 @@ namespace Apache.Arrow.Ipc
                     Debug.WriteLine("Dictionaries are not yet supported.");
                     break;
                 case Flatbuf.MessageHeader.RecordBatch:
-                    var rb = message.Header<Flatbuf.RecordBatch>().Value;
+                    Flatbuf.RecordBatch rb = message.Header<Flatbuf.RecordBatch>().Value;
                     List<IArrowArray> arrays = BuildArrays(Schema, bodyByteBuffer, rb);
                     return new RecordBatch(Schema, memoryOwner, arrays, (int)rb.Length);
                 default:
@@ -122,13 +122,13 @@ namespace Apache.Arrow.Ipc
             }
 
             var recordBatchEnumerator = new RecordBatchEnumerator(in recordBatchMessage);
-            var schemaFieldIndex = 0;
+            int schemaFieldIndex = 0;
             do
             {
-                var field = schema.GetFieldByIndex(schemaFieldIndex++);
-                var fieldNode = recordBatchEnumerator.CurrentNode;
+                Field field = schema.GetFieldByIndex(schemaFieldIndex++);
+                Flatbuf.FieldNode fieldNode = recordBatchEnumerator.CurrentNode;
 
-                var arrayData = field.DataType.IsFixedPrimitive()
+                ArrayData arrayData = field.DataType.IsFixedPrimitive()
                     ? LoadPrimitiveField(ref recordBatchEnumerator, field, in fieldNode, messageBuffer)
                     : LoadVariableField(ref recordBatchEnumerator, field, in fieldNode, messageBuffer);
 
@@ -152,8 +152,8 @@ namespace Apache.Arrow.Ipc
             recordBatchEnumerator.MoveNextBuffer();
 
 
-            var fieldLength = (int)fieldNode.Length;
-            var fieldNullCount = (int)fieldNode.NullCount;
+            int fieldLength = (int)fieldNode.Length;
+            int fieldNullCount = (int)fieldNode.NullCount;
 
             if (fieldLength < 0)
             {
@@ -165,8 +165,8 @@ namespace Apache.Arrow.Ipc
                 throw new InvalidDataException("Null count length must be >= 0"); // TODO:Localize exception message
             }
 
-            var arrowBuff = new[] { nullArrowBuffer, valueArrowBuffer };
-            var children = GetChildren(ref recordBatchEnumerator, field, bodyData);
+            ArrowBuffer[] arrowBuff = new[] { nullArrowBuffer, valueArrowBuffer };
+            ArrayData[] children = GetChildren(ref recordBatchEnumerator, field, bodyData);
 
             return new ArrayData(field.DataType, fieldLength, fieldNullCount, 0, arrowBuff, children);
         }
@@ -186,8 +186,8 @@ namespace Apache.Arrow.Ipc
             ArrowBuffer valueArrowBuffer = BuildArrowBuffer(bodyData, recordBatchEnumerator.CurrentBuffer);
             recordBatchEnumerator.MoveNextBuffer();
 
-            var fieldLength = (int)fieldNode.Length;
-            var fieldNullCount = (int)fieldNode.NullCount;
+            int fieldLength = (int)fieldNode.Length;
+            int fieldNullCount = (int)fieldNode.NullCount;
 
             if (fieldLength < 0)
             {
@@ -199,8 +199,8 @@ namespace Apache.Arrow.Ipc
                 throw new InvalidDataException("Null count length must be >= 0"); //TODO: Localize exception message
             }
 
-            var arrowBuff = new[] { nullArrowBuffer, offsetArrowBuffer, valueArrowBuffer };
-            var children = GetChildren(ref recordBatchEnumerator, field, bodyData);
+            ArrowBuffer[] arrowBuff = new[] { nullArrowBuffer, offsetArrowBuffer, valueArrowBuffer };
+            ArrayData[] children = GetChildren(ref recordBatchEnumerator, field, bodyData);
 
             return new ArrayData(field.DataType, fieldLength, fieldNullCount, 0, arrowBuff, children);
         }
@@ -212,15 +212,15 @@ namespace Apache.Arrow.Ipc
         {
             if (!(field.DataType is NestedType type)) return null;
 
-            var childrenCount = type.Children.Count;
+            int childrenCount = type.Children.Count;
             var children = new ArrayData[childrenCount];
-            for (var index = 0; index < childrenCount; index++)
+            for (int index = 0; index < childrenCount; index++)
             {
                 recordBatchEnumerator.MoveNextNode();
                 Flatbuf.FieldNode childFieldNode = recordBatchEnumerator.CurrentNode;
 
-                var childField = type.Children[index];
-                var child = childField.DataType.IsFixedPrimitive()
+                Field childField = type.Children[index];
+                ArrayData child = childField.DataType.IsFixedPrimitive()
                     ? LoadPrimitiveField(ref recordBatchEnumerator, childField, in childFieldNode, bodyData)
                     : LoadVariableField(ref recordBatchEnumerator, childField, in childFieldNode, bodyData);
 

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
@@ -143,7 +143,7 @@ namespace Apache.Arrow.Ipc
                 int bytesRead = await BaseStream.ReadFullBufferAsync(buff).ConfigureAwait(false);
                 EnsureFullRead(buff, bytesRead);
 
-                var schemabb = CreateByteBuffer(buff);
+                FlatBuffers.ByteBuffer schemabb = CreateByteBuffer(buff);
                 Schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(schemabb));
             }).ConfigureAwait(false);
         }
@@ -163,7 +163,7 @@ namespace Apache.Arrow.Ipc
                 int bytesRead = BaseStream.ReadFullBuffer(buff);
                 EnsureFullRead(buff, bytesRead);
 
-                var schemabb = CreateByteBuffer(buff);
+                FlatBuffers.ByteBuffer schemabb = CreateByteBuffer(buff);
                 Schema = MessageSerializer.GetSchema(ReadMessage<Flatbuf.Schema>(schemabb));
             });
         }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowTypeFlatbufferBuilder.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowTypeFlatbufferBuilder.cs
@@ -112,7 +112,7 @@ namespace Apache.Arrow.Ipc
             public void Visit(StringType type)
             {
                 Flatbuf.Utf8.StartUtf8(Builder);
-                var offset = Flatbuf.Utf8.EndUtf8(Builder);
+                Offset<Utf8> offset = Flatbuf.Utf8.EndUtf8(Builder);
                 Result = FieldType.Build(
                     Flatbuf.Type.Utf8, offset);
             }

--- a/csharp/src/Apache.Arrow/Ipc/IpcOptions.cs
+++ b/csharp/src/Apache.Arrow/Ipc/IpcOptions.cs
@@ -17,7 +17,7 @@ namespace Apache.Arrow.Ipc
 {
     public class IpcOptions
     {
-        internal static readonly IpcOptions Default = new IpcOptions();
+        internal static IpcOptions Default { get; } = new IpcOptions();
 
         /// <summary>
         /// Write the pre-0.15.0 encapsulated IPC message format

--- a/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
+++ b/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
@@ -54,9 +54,9 @@ namespace Apache.Arrow.Ipc
         {
             var schemaBuilder = new Schema.Builder();
 
-            for (var i = 0; i < schema.FieldsLength; i++)
+            for (int i = 0; i < schema.FieldsLength; i++)
             {
-                var field = schema.Fields(i).GetValueOrDefault();
+                Flatbuf.Field field = schema.Fields(i).GetValueOrDefault();
 
                 schemaBuilder.Field(
                     new Field(field.Name, GetFieldArrowType(field), field.Nullable));
@@ -71,10 +71,10 @@ namespace Apache.Arrow.Ipc
             switch (field.TypeType)
             {
                 case Flatbuf.Type.Int:
-                    var intMetaData = field.Type<Flatbuf.Int>().Value;
+                    Flatbuf.Int intMetaData = field.Type<Flatbuf.Int>().Value;
                     return MessageSerializer.GetNumberType(intMetaData.BitWidth, intMetaData.IsSigned);
                 case Flatbuf.Type.FloatingPoint:
-                    var floatingPointTypeMetadata = field.Type<Flatbuf.FloatingPoint>().Value;
+                    Flatbuf.FloatingPoint floatingPointTypeMetadata = field.Type<Flatbuf.FloatingPoint>().Value;
                     switch (floatingPointTypeMetadata.Precision)
                     {
                         case Flatbuf.Precision.SINGLE:
@@ -89,10 +89,10 @@ namespace Apache.Arrow.Ipc
                 case Flatbuf.Type.Bool:
                     return new Types.BooleanType();
                 case Flatbuf.Type.Decimal:
-                    var decMeta = field.Type<Flatbuf.Decimal>().Value;
+                    Flatbuf.Decimal decMeta = field.Type<Flatbuf.Decimal>().Value;
                     return new Types.DecimalType(decMeta.Precision, decMeta.Scale);
                 case Flatbuf.Type.Date:
-                    var dateMeta = field.Type<Flatbuf.Date>().Value;
+                    Flatbuf.Date dateMeta = field.Type<Flatbuf.Date>().Value;
                     switch (dateMeta.Unit)
                     {
                         case Flatbuf.DateUnit.DAY:
@@ -103,7 +103,7 @@ namespace Apache.Arrow.Ipc
                             throw new InvalidDataException("Unsupported date unit");
                     }
                 case Flatbuf.Type.Time:
-                    var timeMeta = field.Type<Flatbuf.Time>().Value;
+                    Flatbuf.Time timeMeta = field.Type<Flatbuf.Time>().Value;
                     switch (timeMeta.BitWidth)
                     {
                         case 32:
@@ -114,12 +114,12 @@ namespace Apache.Arrow.Ipc
                             throw new InvalidDataException("Unsupported time bit width");
                     }
                 case Flatbuf.Type.Timestamp:
-                    var timestampTypeMetadata = field.Type<Flatbuf.Timestamp>().Value;
-                    var unit = timestampTypeMetadata.Unit.ToArrow();
-                    var timezone = timestampTypeMetadata.Timezone;
+                    Flatbuf.Timestamp timestampTypeMetadata = field.Type<Flatbuf.Timestamp>().Value;
+                    Types.TimeUnit unit = timestampTypeMetadata.Unit.ToArrow();
+                    string timezone = timestampTypeMetadata.Timezone;
                     return new Types.TimestampType(unit, timezone);
                 case Flatbuf.Type.Interval:
-                    var intervalMetadata = field.Type<Flatbuf.Interval>().Value;
+                    Flatbuf.Interval intervalMetadata = field.Type<Flatbuf.Interval>().Value;
                     return new Types.IntervalType(intervalMetadata.Unit.ToArrow());
                 case Flatbuf.Type.Utf8:
                     return new Types.StringType();

--- a/csharp/src/Apache.Arrow/Memory/MemoryAllocator.cs
+++ b/csharp/src/Apache.Arrow/Memory/MemoryAllocator.cs
@@ -23,7 +23,7 @@ namespace Apache.Arrow.Memory
     {
         public const int DefaultAlignment = 64;
 
-        private static readonly IMemoryOwner<byte> NullMemoryOwner = new NullMemoryOwner();
+        private static IMemoryOwner<byte> NullMemoryOwner { get; } = new NullMemoryOwner();
 
         public static Lazy<MemoryAllocator> Default { get; } = new Lazy<MemoryAllocator>(BuildDefault, true);
 
@@ -64,7 +64,7 @@ namespace Apache.Arrow.Memory
                 return NullMemoryOwner;
             }
 
-            var memoryOwner = AllocateInternal(length, out var bytesAllocated);
+            IMemoryOwner<byte> memoryOwner = AllocateInternal(length, out int bytesAllocated);
 
             Statistics.Allocate(bytesAllocated);
 

--- a/csharp/src/Apache.Arrow/Memory/NativeMemoryAllocator.cs
+++ b/csharp/src/Apache.Arrow/Memory/NativeMemoryAllocator.cs
@@ -33,9 +33,9 @@ namespace Apache.Arrow.Memory
 
             // TODO: Should the allocation be moved to NativeMemory?
 
-            var size = length + Alignment;
-            var ptr =  Marshal.AllocHGlobal(size);
-            var offset = (int)(Alignment - (ptr.ToInt64() & (Alignment - 1)));
+            int size = length + Alignment;
+            IntPtr ptr =  Marshal.AllocHGlobal(size);
+            int offset = (int)(Alignment - (ptr.ToInt64() & (Alignment - 1)));
             var manager = new NativeMemoryManager(ptr, offset, length);
 
             bytesAllocated = (length + Alignment);

--- a/csharp/src/Apache.Arrow/Memory/NativeMemoryManager.cs
+++ b/csharp/src/Apache.Arrow/Memory/NativeMemoryManager.cs
@@ -42,7 +42,7 @@ namespace Apache.Arrow.Memory
 
         public override unsafe Span<byte> GetSpan()
         {
-            var ptr = CalculatePointer(0);
+            void* ptr = CalculatePointer(0);
             return new Span<byte>(ptr, _length);
         }
 
@@ -51,7 +51,7 @@ namespace Apache.Arrow.Memory
             // NOTE: Unmanaged memory doesn't require GC pinning because by definition it's not
             // managed by the garbage collector.
 
-            var ptr = CalculatePointer(elementIndex);
+            void* ptr = CalculatePointer(elementIndex);
             return new MemoryHandle(ptr, default, this);
         }
 

--- a/csharp/src/Apache.Arrow/RecordBatch.Builder.cs
+++ b/csharp/src/Apache.Arrow/RecordBatch.Builder.cs
@@ -88,8 +88,8 @@ namespace Apache.Arrow
 
             public RecordBatch Build()
             {
-                var schema = _schemaBuilder.Build();
-                var length = _arrays.Max(x => x.Length);
+                Schema schema = _schemaBuilder.Build();
+                int length = _arrays.Max(x => x.Length);
 
                 // each array has its own memoryOwner, so the RecordBatch itself doesn't
                 // have a memoryOwner
@@ -108,12 +108,12 @@ namespace Apache.Arrow
 
             public Builder Append(RecordBatch batch)
             {
-                foreach (var field in batch.Schema.Fields)
+                foreach (KeyValuePair<string, Field> field in batch.Schema.Fields)
                 {
                     _schemaBuilder.Field(field.Value);
                 }
 
-                foreach (var array in batch.Arrays)
+                foreach (IArrowArray array in batch.Arrays)
                 {
                     _arrays.Add(array);
                 }
@@ -150,13 +150,12 @@ namespace Apache.Arrow
             {
                 if (action == null) return this;
 
-                var array = action(_arrayBuilder);
+                TArray array = action(_arrayBuilder);
 
                 Append(name, nullable, array);
 
                 return this;
             }
-
         }
     }
 }

--- a/csharp/src/Apache.Arrow/RecordBatch.cs
+++ b/csharp/src/Apache.Arrow/RecordBatch.cs
@@ -38,7 +38,7 @@ namespace Apache.Arrow
 
         public IArrowArray Column(string columnName)
         {
-            var fieldIndex = Schema.GetFieldIndex(columnName);
+            int fieldIndex = Schema.GetFieldIndex(columnName);
             return _arrays[fieldIndex];
         }
 

--- a/csharp/src/Apache.Arrow/Schema.Builder.cs
+++ b/csharp/src/Apache.Arrow/Schema.Builder.cs
@@ -53,7 +53,7 @@ namespace Apache.Arrow
 
                 var fieldBuilder = new Field.Builder();
                 fieldBuilderAction(fieldBuilder);
-                var field = fieldBuilder.Build();
+                Field field = fieldBuilder.Build();
 
                 _fields.Add(field);
                 return this;
@@ -78,7 +78,7 @@ namespace Apache.Arrow
                 }
                 foreach (KeyValuePair<string, string> entry in dictionary)
                 {
-                    this.Metadata(entry.Key, entry.Value);
+                    Metadata(entry.Key, entry.Value);
                 }
                 return this;
             }

--- a/csharp/src/Apache.Arrow/Schema.cs
+++ b/csharp/src/Apache.Arrow/Schema.cs
@@ -59,7 +59,7 @@ namespace Apache.Arrow
         }
 
         public Field GetFieldByName(string name) =>
-            Fields.TryGetValue(name, out var field) ? field : null;
+            Fields.TryGetValue(name, out Field field) ? field : null;
 
         public int GetFieldIndex(string name, StringComparer comparer = default)
         {


### PR DESCRIPTION
Adding an `.editorconfig` using the rules from dotnet/runtime repo. See:

* https://github.com/dotnet/runtime/blob/master/docs/coding-guidelines/coding-style.md
* https://github.com/dotnet/runtime/blob/master/.editorconfig

Violating these rules won't fail the build, but Visual Studio will respect these rules when formatting the code and make suggestions.

The bulk of the violations were `var` usages. There was one unnecessary usage of `this.`. And the rest were naming static fields with `s_`. In `BitUtility.cs`, I made a slight optimization using the pattern recognized by https://github.com/dotnet/roslyn/pull/24621 instead of prefixing the fields with `s_`.

Tagging anyone who has contributed to the C# library (please let me know if I missed anyone):
@chutchinson @zgramana @nhustler @HashidaTKS @abbotware @pgovind @stephentoub 