### PR TITLE
ARROW-8402: [Java] Support ValidateFull methods in Java

### DIFF
--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -122,7 +122,7 @@ public class DenseUnionVector implements FieldVector {
 
   private final FieldType fieldType;
 
-  private static final byte TYPE_WIDTH = 1;
+  public static final byte TYPE_WIDTH = 1;
   public static final byte OFFSET_WIDTH = 4;
 
   private static final FieldType INTERNAL_STRUCT_TYPE = new FieldType(/*nullable*/ false,

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -108,7 +108,7 @@ public class UnionVector implements FieldVector {
   private final FieldType fieldType;
   private final Field[] typeIds = new Field[Byte.MAX_VALUE + 1];
 
-  private static final byte TYPE_WIDTH = 1;
+  public static final byte TYPE_WIDTH = 1;
   private static final FieldType INTERNAL_STRUCT_TYPE = new FieldType(false /*nullable*/,
       ArrowType.Struct.INSTANCE, null /*dictionary*/, null /*metadata*/);
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/DurationVector.java
@@ -44,6 +44,7 @@ import org.apache.arrow.vector.util.TransferPair;
 public final class DurationVector extends BaseFixedWidthVector {
   private static final byte TYPE_WIDTH = 8;
   private final FieldReader reader;
+
   private final TimeUnit unit;
 
   /**
@@ -191,6 +192,13 @@ public final class DurationVector extends BaseFixedWidthVector {
 
   private StringBuilder getAsStringBuilderHelper(int index) {
     return new StringBuilder(getObject(index).toString());
+  }
+
+  /**
+   * Gets the time unit of the duration.
+   */
+  public TimeUnit getUnit() {
+    return unit;
   }
 
   /*----------------------------------------------------------------*

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
@@ -17,7 +17,7 @@
 
 package org.apache.arrow.vector.util;
 
-import static org.apache.arrow.vector.validate.ValidateUtility.validateOrThrow;
+import static org.apache.arrow.vector.validate.ValidateUtil.validateOrThrow;
 
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseFixedWidthVector;
@@ -122,10 +122,11 @@ public class ValueVectorUtility {
   public static void validate(VectorSchemaRoot root) {
     Preconditions.checkNotNull(root);
     int valueCount = root.getRowCount();
-    validateOrThrow(valueCount >= 0, "The row count of vector schema root must be non-negative");
+    validateOrThrow(valueCount >= 0, "The row count of vector schema root %s is negative.", valueCount);
     for (ValueVector childVec : root.getFieldVectors()) {
       validateOrThrow(valueCount == childVec.getValueCount(),
-          "Child vector and vector schema root have different value counts");
+          "Child vector and vector schema root have different value counts. " +
+              "Child vector value count %s, vector schema root value count %s", childVec.getValueCount(), valueCount);
       validate(childVec);
     }
   }
@@ -136,10 +137,11 @@ public class ValueVectorUtility {
   public static void validateFull(VectorSchemaRoot root) {
     Preconditions.checkNotNull(root);
     int valueCount = root.getRowCount();
-    validateOrThrow(valueCount >= 0, "The row count of vector schema root must be non-negative");
+    validateOrThrow(valueCount >= 0, "The row count of vector schema root %s is negative.", valueCount);
     for (ValueVector childVec : root.getFieldVectors()) {
       validateOrThrow(valueCount == childVec.getValueCount(),
-          "Child vector and vector schema root have different value counts");
+          "Child vector and vector schema root have different value counts. " +
+              "Child vector value count %s, vector schema root value count %s", childVec.getValueCount(), valueCount);
       validateFull(childVec);
     }
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/ValueVectorUtility.java
@@ -17,21 +17,23 @@
 
 package org.apache.arrow.vector.util;
 
-import org.apache.arrow.memory.ArrowBuf;
+import static org.apache.arrow.vector.validate.ValidateUtility.validateOrThrow;
+
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseFixedWidthVector;
-import org.apache.arrow.vector.BufferLayout;
-import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.TypeLayout;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
-import org.apache.arrow.vector.types.pojo.ArrowType;
-import org.apache.arrow.vector.validate.ValidateVectorVisitor;
+import org.apache.arrow.vector.validate.ValidateVectorBufferVisitor;
+import org.apache.arrow.vector.validate.ValidateVectorDataVisitor;
+import org.apache.arrow.vector.validate.ValidateVectorTypeVisitor;
 
 /**
  * Utility methods for {@link ValueVector}.
  */
 public class ValueVectorUtility {
+
+  private ValueVectorUtility() {
+  }
 
   /**
    * Get the toString() representation of vector suitable for debugging.
@@ -92,44 +94,55 @@ public class ValueVectorUtility {
   }
 
   /**
-   * Validate field vector.
+   * Utility to validate vector in O(1) time.
    */
-  public static void validate(FieldVector vector) {
+  public static void validate(ValueVector vector) {
     Preconditions.checkNotNull(vector);
 
-    ArrowType arrowType = vector.getField().getType();
-    int typeBufferCount = TypeLayout.getTypeBufferCount(arrowType);
-    TypeLayout typeLayout = TypeLayout.getTypeLayout(arrowType);
+    ValidateVectorTypeVisitor typeVisitor = new ValidateVectorTypeVisitor();
+    vector.accept(typeVisitor, null);
 
-    if (vector.getValueCount() < 0) {
-      throw new IllegalArgumentException("vector valueCount is negative");
-    }
-
-    if (vector.getFieldBuffers().size() != typeBufferCount) {
-      throw new IllegalArgumentException(String.format("Expected %s buffers in vector of type %s, got %s",
-          typeBufferCount, vector.getField().getType().toString(), vector.getBufferSize()));
-    }
-
-    for (int i = 0; i < typeBufferCount; i++) {
-      ArrowBuf buffer = vector.getFieldBuffers().get(i);
-      BufferLayout bufferLayout = typeLayout.getBufferLayouts().get(i);
-      if (buffer == null) {
-        continue;
-      }
-      int minBufferSize = vector.getValueCount() * bufferLayout.getTypeBitWidth();
-
-      if (buffer.capacity() < minBufferSize / 8) {
-        throw new IllegalArgumentException(String.format("Buffer #%s too small in vector of type %s" +
-                "and valueCount %s : expected at least %s byte(s), got %s",
-            i, vector.getField().getType().toString(),
-            vector.getValueCount(), minBufferSize, buffer.capacity()));
-      }
-    }
-
-    ValidateVectorVisitor visitor = new ValidateVectorVisitor();
-    vector.accept(visitor, null);
+    ValidateVectorBufferVisitor bufferVisitor = new ValidateVectorBufferVisitor();
+    vector.accept(bufferVisitor, null);
   }
 
+  /**
+   * Utility to validate vector in O(n) time, where n is the value count.
+   */
+  public static void validateFull(ValueVector vector) {
+    validate(vector);
+
+    ValidateVectorDataVisitor dataVisitor = new ValidateVectorDataVisitor();
+    vector.accept(dataVisitor, null);
+  }
+
+  /**
+   * Utility to validate vector schema root in O(1) time.
+   */
+  public static void validate(VectorSchemaRoot root) {
+    Preconditions.checkNotNull(root);
+    int valueCount = root.getRowCount();
+    validateOrThrow(valueCount >= 0, "The row count of vector schema root must be non-negative");
+    for (ValueVector childVec : root.getFieldVectors()) {
+      validateOrThrow(valueCount == childVec.getValueCount(),
+          "Child vector and vector schema root have different value counts");
+      validate(childVec);
+    }
+  }
+
+  /**
+   * Utility to validate vector in O(n) time, where n is the value count.
+   */
+  public static void validateFull(VectorSchemaRoot root) {
+    Preconditions.checkNotNull(root);
+    int valueCount = root.getRowCount();
+    validateOrThrow(valueCount >= 0, "The row count of vector schema root must be non-negative");
+    for (ValueVector childVec : root.getFieldVectors()) {
+      validateOrThrow(valueCount == childVec.getValueCount(),
+          "Child vector and vector schema root have different value counts");
+      validateFull(childVec);
+    }
+  }
 
   /**
    * Pre allocate memory for BaseFixedWidthVector.
@@ -154,5 +167,4 @@ public class ValueVectorUtility {
       }
     }
   }
-
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateUtil.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateUtil.java
@@ -20,9 +20,9 @@ package org.apache.arrow.vector.validate;
 /**
  * Utilities for vector validation.
  */
-public class ValidateUtility {
+public class ValidateUtil {
 
-  private ValidateUtility() {
+  private ValidateUtil() {
   }
 
   /**
@@ -34,6 +34,19 @@ public class ValidateUtility {
   public static void validateOrThrow(boolean expression, String errorMessage) {
     if (!expression) {
       throw new ValidateException(errorMessage);
+    }
+  }
+
+  /**
+   * Validate the expression.
+   * @param expression the expression to validate.
+   * @param errorMessage the error message template.
+   * @param args the error message arguments.
+   * @throws ValidateException if the expression evaluates to false.
+   */
+  public static void validateOrThrow(boolean expression, String errorMessage, Object... args) {
+    if (!expression) {
+      throw new ValidateException(String.format(errorMessage, args));
     }
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateUtility.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateUtility.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.validate;
+
+/**
+ * Utilities for vector validation.
+ */
+public class ValidateUtility {
+
+  private ValidateUtility() {
+  }
+
+  /**
+   * Validate the expression.
+   * @param expression the expression to validate.
+   * @param errorMessage the error message.
+   * @throws ValidateException if the expression evaluates to false.
+   */
+  public static void validateOrThrow(boolean expression, String errorMessage) {
+    if (!expression) {
+      throw new ValidateException(errorMessage);
+    }
+  }
+
+  /**
+   * A exception that is thrown when the vector validation fails.
+   */
+  public static class ValidateException extends RuntimeException {
+    public ValidateException(String message) {
+      super(message);
+    }
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorBufferVisitor.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.validate;
+
+import static org.apache.arrow.vector.validate.ValidateUtility.validateOrThrow;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseLargeVariableWidthVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.TypeLayout;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.compare.VectorVisitor;
+import org.apache.arrow.vector.complex.DenseUnionVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.UnionVector;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+/**
+ * Visitor to validate vector buffers.
+ */
+public class ValidateVectorBufferVisitor implements VectorVisitor<Void, Void> {
+
+  private void validateVectorCommon(ValueVector vector) {
+    ArrowType arrowType = vector.getField().getType();
+    validateOrThrow(vector.getValueCount() >= 0, "vector valueCount is negative");
+
+    if (vector instanceof FieldVector) {
+      FieldVector fieldVector = (FieldVector) vector;
+      int typeBufferCount = TypeLayout.getTypeBufferCount(arrowType);
+      validateOrThrow(fieldVector.getFieldBuffers().size() == typeBufferCount,
+          String.format("Expected %s buffers in vector of type %s, got %s",
+              typeBufferCount, vector.getField().getType().toString(), fieldVector.getFieldBuffers().size()));
+    }
+  }
+
+  private void validateValidityBuffer(ValueVector vector, int valueCount) {
+    ArrowBuf validityBuffer = vector.getValidityBuffer();
+    validateOrThrow(validityBuffer != null, "The validity buffer is null.");
+    validateOrThrow(validityBuffer.capacity() * 8 >= valueCount, "No enough capacity for the validity buffer.");
+  }
+
+  private void validateOffsetBuffer(ValueVector vector, int valueCount) {
+    ArrowBuf offsetBuffer = vector.getOffsetBuffer();
+    validateOrThrow(offsetBuffer != null, "The offset buffer is null.");
+    if (valueCount > 0) {
+      validateOrThrow(offsetBuffer.capacity() >= (valueCount + 1) * 4, "No enough capacity for the offset buffer.");
+    }
+  }
+
+  private void validateLargeOffsetBuffer(ValueVector vector, int valueCount) {
+    ArrowBuf offsetBuffer = vector.getOffsetBuffer();
+    validateOrThrow(offsetBuffer != null, "The large offset buffer is null.");
+    if (valueCount > 0) {
+      validateOrThrow(offsetBuffer.capacity() >= (valueCount + 1) * 8,
+          "No enough capacity for the large offset buffer.");
+    }
+  }
+
+  private void validateFixedWidthDataBuffer(ValueVector vector, int valueCount, int bitWidth) {
+    ArrowBuf dataBuffer = vector.getDataBuffer();
+    validateOrThrow(dataBuffer != null, "The fixed width data buffer is null.");
+    validateOrThrow((long) bitWidth * valueCount <= dataBuffer.capacity() * 8L,
+        "No enough capacity for fixed width data buffer");
+  }
+
+  private void validateDataBuffer(ValueVector vector, long minCapacity) {
+    ArrowBuf dataBuffer = vector.getDataBuffer();
+    validateOrThrow(dataBuffer != null, "The data buffer is null.");
+    validateOrThrow(dataBuffer.capacity() >= minCapacity, "No enough capacity for data buffer");
+  }
+
+  @Override
+  public Void visit(BaseFixedWidthVector vector, Void value) {
+    int bitWidth = (vector instanceof BitVector) ? 1 : vector.getTypeWidth() * 8;
+    int valueCount = vector.getValueCount();
+    validateVectorCommon(vector);
+    validateValidityBuffer(vector, valueCount);
+    validateFixedWidthDataBuffer(vector, valueCount, bitWidth);
+    return null;
+  }
+
+  @Override
+  public Void visit(BaseVariableWidthVector vector, Void value) {
+    int valueCount = vector.getValueCount();
+    validateVectorCommon(vector);
+    validateValidityBuffer(vector, valueCount);
+    validateOffsetBuffer(vector, valueCount);
+    int lastOffset = valueCount == 0 ? 0 :
+        vector.getOffsetBuffer().getInt(valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
+    validateDataBuffer(vector, lastOffset);
+    return null;
+  }
+
+  @Override
+  public Void visit(BaseLargeVariableWidthVector vector, Void value) {
+    int valueCount = vector.getValueCount();
+    validateVectorCommon(vector);
+    validateValidityBuffer(vector, valueCount);
+    validateLargeOffsetBuffer(vector, valueCount);
+    long lastOffset = valueCount == 0 ? 0L :
+        vector.getOffsetBuffer().getLong((long) valueCount * BaseLargeVariableWidthVector.OFFSET_WIDTH);
+    validateDataBuffer(vector, lastOffset);
+    return null;
+  }
+
+  @Override
+  public Void visit(ListVector vector, Void value) {
+    int valueCount = vector.getValueCount();
+    validateVectorCommon(vector);
+    validateValidityBuffer(vector, valueCount);
+    validateOffsetBuffer(vector, valueCount);
+
+    FieldVector dataVector = vector.getDataVector();
+    int lastOffset = valueCount == 0 ? 0 :
+        vector.getOffsetBuffer().getInt(valueCount * BaseVariableWidthVector.OFFSET_WIDTH);
+    int dataVectorLength = dataVector == null ? 0 : dataVector.getValueCount();
+    validateOrThrow(dataVectorLength >= lastOffset,
+        "Inner vector does not contain enough elements.");
+
+    if (dataVector != null) {
+      dataVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(FixedSizeListVector vector, Void value) {
+    int valueCount = vector.getValueCount();
+    validateVectorCommon(vector);
+    validateValidityBuffer(vector, valueCount);
+    FieldVector dataVector = vector.getDataVector();
+    int dataVectorLength = dataVector == null ? 0 : dataVector.getValueCount();
+    validateOrThrow(dataVectorLength >= valueCount * vector.getListSize(),
+        "Inner vector does not contain enough elements.");
+    if (dataVector != null) {
+      dataVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(NonNullableStructVector vector, Void value) {
+    int valueCount = vector.getValueCount();
+    validateVectorCommon(vector);
+    validateValidityBuffer(vector, valueCount);
+    for (ValueVector subVector : vector.getChildrenFromFields()) {
+      validateOrThrow(valueCount == subVector.getValueCount(),
+          "Struct vector length not equal to child vector length");
+      subVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(UnionVector vector, Void value) {
+    int valueCount = vector.getValueCount();
+    validateVectorCommon(vector);
+    for (ValueVector subVector : vector.getChildrenFromFields()) {
+      validateOrThrow(valueCount == subVector.getValueCount(),
+          "Union vector length not equal to child vector length");
+      subVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(DenseUnionVector vector, Void value) {
+    int valueCount = vector.getValueCount();
+    validateVectorCommon(vector);
+    validateValidityBuffer(vector, valueCount);
+    for (ValueVector subVector : vector.getChildrenFromFields()) {
+      subVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(NullVector vector, Void value) {
+    return null;
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorDataVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorDataVisitor.java
@@ -28,6 +28,7 @@ import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.LargeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.NonNullableStructVector;
 import org.apache.arrow.vector.complex.UnionVector;
@@ -99,6 +100,16 @@ public class ValidateVectorDataVisitor implements VectorVisitor<Void, Void> {
   @Override
   public Void visit(FixedSizeListVector vector, Void value) {
     validateOffsetBuffer(vector, vector.getValueCount());
+    ValueVector innerVector = vector.getDataVector();
+    if (innerVector != null) {
+      innerVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(LargeListVector vector, Void value) {
+    validateLargeOffsetBuffer(vector, vector.getValueCount());
     ValueVector innerVector = vector.getDataVector();
     if (innerVector != null) {
       innerVector.accept(this, null);

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorDataVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorDataVisitor.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.validate;
+
+import static org.apache.arrow.vector.validate.ValidateUtility.validateOrThrow;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseLargeVariableWidthVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.compare.VectorVisitor;
+import org.apache.arrow.vector.complex.DenseUnionVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.UnionVector;
+
+/**
+ * Utility for validating vector data.
+ */
+public class ValidateVectorDataVisitor implements VectorVisitor<Void, Void> {
+
+  private void validateOffsetBuffer(ValueVector vector, int valueCount) {
+    if (valueCount == 0) {
+      return;
+    }
+    ArrowBuf offsetBuffer = vector.getOffsetBuffer();
+
+    // verify that the values in the offset buffer is non-decreasing
+    int prevValue = offsetBuffer.getInt(0);
+    for (int i = 1; i <= valueCount; i++) {
+      int curValue = offsetBuffer.getInt(i * 4);
+      validateOrThrow(curValue >= 0, "The values in the offset buffer must be non-negative");
+      validateOrThrow(curValue >= prevValue, "The values in the offset buffer are decreasing");
+      prevValue = curValue;
+    }
+  }
+
+  private void validateLargeOffsetBuffer(ValueVector vector, int valueCount) {
+    if (valueCount == 0) {
+      return;
+    }
+    ArrowBuf offsetBuffer = vector.getOffsetBuffer();
+
+    // verify that the values in the large offset buffer is non-decreasing
+    long prevValue = offsetBuffer.getLong(0);
+    for (int i = 1; i <= valueCount; i++) {
+      long curValue = offsetBuffer.getLong((long) i * 8);
+      validateOrThrow(curValue >= 0L, "The values in the large offset buffer must be non-negative");
+      validateOrThrow(curValue >= prevValue, "The values in the large offset buffer are decreasing");
+      prevValue = curValue;
+    }
+  }
+
+  @Override
+  public Void visit(BaseFixedWidthVector vector, Void value) {
+    return null;
+  }
+
+  @Override
+  public Void visit(BaseVariableWidthVector vector, Void value) {
+    validateOffsetBuffer(vector, vector.getValueCount());
+    return null;
+  }
+
+  @Override
+  public Void visit(BaseLargeVariableWidthVector vector, Void value) {
+    validateLargeOffsetBuffer(vector, vector.getValueCount());
+    return null;
+  }
+
+  @Override
+  public Void visit(ListVector vector, Void value) {
+    validateOffsetBuffer(vector, vector.getValueCount());
+    ValueVector innerVector = vector.getDataVector();
+    if (innerVector != null) {
+      innerVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(FixedSizeListVector vector, Void value) {
+    validateOffsetBuffer(vector, vector.getValueCount());
+    ValueVector innerVector = vector.getDataVector();
+    if (innerVector != null) {
+      innerVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(NonNullableStructVector vector, Void value) {
+    for (ValueVector subVector : vector.getChildrenFromFields()) {
+      subVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(UnionVector vector, Void value) {
+    for (ValueVector subVector : vector.getChildrenFromFields()) {
+      subVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(DenseUnionVector vector, Void value) {
+    for (ValueVector subVector : vector.getChildrenFromFields()) {
+      subVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(NullVector vector, Void value) {
+    return null;
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorTypeVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorTypeVisitor.java
@@ -61,6 +61,7 @@ import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.LargeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.NonNullableStructVector;
 import org.apache.arrow.vector.complex.UnionVector;
@@ -284,6 +285,16 @@ public class ValidateVectorTypeVisitor implements VectorVisitor<Void, Void> {
     validateOrThrow(arrowType.getListSize() == vector.getListSize(),
         "Inconsistent list size for FixedSizeListVector");
     validateOrThrow(arrowType.getListSize() > 0, "The list size must be positive");
+    ValueVector innerVector = vector.getDataVector();
+    if (innerVector != null) {
+      innerVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(LargeListVector vector, Void value) {
+    validateVectorCommon(vector, ArrowType.LargeList.class);
     ValueVector innerVector = vector.getDataVector();
     if (innerVector != null) {
       innerVector.accept(this, null);

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorTypeVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorTypeVisitor.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.validate;
+
+import static org.apache.arrow.vector.validate.ValidateUtility.validateOrThrow;
+
+import org.apache.arrow.vector.BaseFixedWidthVector;
+import org.apache.arrow.vector.BaseLargeVariableWidthVector;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DateMilliVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.DurationVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.IntervalDayVector;
+import org.apache.arrow.vector.IntervalYearVector;
+import org.apache.arrow.vector.LargeVarBinaryVector;
+import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliTZVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoTZVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecTZVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.compare.VectorVisitor;
+import org.apache.arrow.vector.complex.DenseUnionVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.NonNullableStructVector;
+import org.apache.arrow.vector.complex.UnionVector;
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.IntervalUnit;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.UnionMode;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.FieldType;
+
+/**
+ * Utility to validate vector type information.
+ */
+public class ValidateVectorTypeVisitor implements VectorVisitor<Void, Void> {
+
+  private void validateVectorCommon(ValueVector vector, Class<? extends ArrowType> expectedArrowType) {
+    validateOrThrow(vector.getField() != null, "Vector field is empty.");
+    validateOrThrow(vector.getField().getFieldType() != null, "Vector field type is empty.");
+    ArrowType arrowType = vector.getField().getFieldType().getType();
+    validateOrThrow(arrowType != null, "Vector arrow type is empty.");
+    validateOrThrow(expectedArrowType == arrowType.getClass(),
+        "Incorrect arrow type for " + vector.getClass() + " : " + arrowType.toString());
+  }
+
+  private void validateIntVector(ValueVector vector, int expectedWidth, boolean expectedSigned) {
+    validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Int,
+        "Vector " + vector.getClass() + " is not an integer vector");
+    ArrowType.Int intType = (ArrowType.Int) vector.getField().getFieldType().getType();
+    validateOrThrow(intType.getIsSigned() == expectedSigned,
+        "Expecting bit width = " + expectedWidth + ", actual width = " + intType.getBitWidth());
+    validateOrThrow(intType.getBitWidth() == expectedWidth,
+        "Expecting bit width = " + expectedWidth + ", actual width = " + intType.getBitWidth());
+  }
+
+  private void validateFloatingPointVector(ValueVector vector, FloatingPointPrecision expectedPrecision) {
+    validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.FloatingPoint,
+        "Vector " + vector.getClass() + " is not a floating point vector");
+    ArrowType.FloatingPoint floatType = (ArrowType.FloatingPoint) vector.getField().getFieldType().getType();
+    validateOrThrow(floatType.getPrecision() == expectedPrecision,
+        "Expecting precision = " + expectedPrecision + ", actual precision = " + floatType.getPrecision());
+  }
+
+  private void validateDateVector(ValueVector vector, DateUnit expectedDateUnit) {
+    validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Date,
+        "Vector " + vector.getClass() + " is not a date vector");
+    ArrowType.Date dateType = (ArrowType.Date) vector.getField().getFieldType().getType();
+    validateOrThrow(dateType.getUnit() == expectedDateUnit,
+        "Expecting date unit = " + expectedDateUnit + ", actual date unit = " + dateType.getUnit());
+  }
+
+  private void validateTimeVector(ValueVector vector, TimeUnit expectedTimeUnit, int expectedBitWidth) {
+    validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Time,
+        "Vector " + vector.getClass() + " is not a time vector");
+    ArrowType.Time timeType = (ArrowType.Time) vector.getField().getFieldType().getType();
+    validateOrThrow(timeType.getUnit() == expectedTimeUnit,
+        "Expecting time unit = " + expectedTimeUnit + ", actual time unit = " + timeType.getUnit());
+    validateOrThrow(timeType.getBitWidth() == expectedBitWidth,
+        "Expecting bit width = " + expectedBitWidth + ", actual bit width = " + timeType.getBitWidth());
+  }
+
+  private void validateIntervalVector(ValueVector vector, IntervalUnit expectedIntervalUnit) {
+    validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Interval,
+        "Vector " + vector.getClass() + " is not an interval vector");
+    ArrowType.Interval intervalType = (ArrowType.Interval) vector.getField().getFieldType().getType();
+    validateOrThrow(intervalType.getUnit() == expectedIntervalUnit,
+        "Expecting interval unit = " + expectedIntervalUnit + ", actual date unit = " + intervalType.getUnit());
+  }
+
+  private void validateTimeStampVector(ValueVector vector, TimeUnit expectedTimeUnit, boolean expectTZ) {
+    validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Timestamp,
+        "Vector " + vector.getClass() + " is not a time stamp vector");
+    ArrowType.Timestamp timestampType = (ArrowType.Timestamp) vector.getField().getFieldType().getType();
+    validateOrThrow(timestampType.getUnit() == expectedTimeUnit,
+        "Expecting time stamp unit = " + expectedTimeUnit + ", actual time stamp unit = " + timestampType.getUnit());
+    if (expectTZ) {
+      validateOrThrow(timestampType.getTimezone() != null, "The time zone should not be null");
+    } else {
+      validateOrThrow(timestampType.getTimezone() == null, "The time zone should be null");
+    }
+  }
+
+  @Override
+  public Void visit(BaseFixedWidthVector vector, Void value) {
+    if (vector instanceof TinyIntVector) {
+      validateVectorCommon(vector, ArrowType.Int.class);
+      validateIntVector(vector, 8, true);
+    } else if (vector instanceof SmallIntVector) {
+      validateVectorCommon(vector, ArrowType.Int.class);
+      validateIntVector(vector, 16, true);
+    } else if (vector instanceof IntVector) {
+      validateVectorCommon(vector, ArrowType.Int.class);
+      validateIntVector(vector, 32, true);
+    } else if (vector instanceof BigIntVector) {
+      validateVectorCommon(vector, ArrowType.Int.class);
+      validateIntVector(vector, 64, true);
+    } else if (vector instanceof UInt1Vector) {
+      validateVectorCommon(vector, ArrowType.Int.class);
+      validateIntVector(vector, 8, false);
+    } else if (vector instanceof UInt2Vector) {
+      validateVectorCommon(vector, ArrowType.Int.class);
+      validateIntVector(vector, 16, false);
+    } else if (vector instanceof UInt4Vector) {
+      validateVectorCommon(vector, ArrowType.Int.class);
+      validateIntVector(vector, 32, false);
+    } else if (vector instanceof UInt8Vector) {
+      validateVectorCommon(vector, ArrowType.Int.class);
+      validateIntVector(vector, 64, false);
+    } else if (vector instanceof BitVector) {
+      validateVectorCommon(vector, ArrowType.Bool.class);
+    } else if (vector instanceof DecimalVector) {
+      validateVectorCommon(vector, ArrowType.Decimal.class);
+      ArrowType.Decimal arrowType = (ArrowType.Decimal) vector.getField().getType();
+      validateOrThrow(arrowType.getScale() > 0, "The scale of decimal must be positive");
+      validateOrThrow(arrowType.getPrecision() > 0, "The precision of decimal must be positive");
+    } else if (vector instanceof DateDayVector) {
+      validateVectorCommon(vector, ArrowType.Date.class);
+      validateDateVector(vector, DateUnit.DAY);
+    } else if (vector instanceof DateMilliVector) {
+      validateVectorCommon(vector, ArrowType.Date.class);
+      validateDateVector(vector, DateUnit.MILLISECOND);
+    } else if (vector instanceof DurationVector) {
+      validateVectorCommon(vector, ArrowType.Duration.class);
+      ArrowType.Duration arrowType = (ArrowType.Duration) vector.getField().getType();
+      validateOrThrow(((DurationVector) vector).getUnit() == arrowType.getUnit(),
+          "Different duration time unit for vector and arrow type");
+    } else if (vector instanceof Float4Vector) {
+      validateVectorCommon(vector, ArrowType.FloatingPoint.class);
+      validateFloatingPointVector(vector, FloatingPointPrecision.SINGLE);
+    } else if (vector instanceof Float8Vector) {
+      validateVectorCommon(vector, ArrowType.FloatingPoint.class);
+      validateFloatingPointVector(vector, FloatingPointPrecision.DOUBLE);
+    } else if (vector instanceof IntervalDayVector) {
+      validateVectorCommon(vector, ArrowType.Interval.class);
+      validateIntervalVector(vector, IntervalUnit.DAY_TIME);
+    } else if (vector instanceof IntervalYearVector) {
+      validateVectorCommon(vector, ArrowType.Interval.class);
+      validateIntervalVector(vector, IntervalUnit.YEAR_MONTH);
+    } else if (vector instanceof TimeMicroVector) {
+      validateVectorCommon(vector, ArrowType.Time.class);
+      validateTimeVector(vector, TimeUnit.MICROSECOND, 64);
+    } else if (vector instanceof TimeMilliVector) {
+      validateVectorCommon(vector, ArrowType.Time.class);
+      validateTimeVector(vector, TimeUnit.MILLISECOND, 32);
+    } else if (vector instanceof TimeNanoVector) {
+      validateVectorCommon(vector, ArrowType.Time.class);
+      validateTimeVector(vector, TimeUnit.NANOSECOND, 64);
+    } else if (vector instanceof TimeSecVector) {
+      validateVectorCommon(vector, ArrowType.Time.class);
+      validateTimeVector(vector, TimeUnit.SECOND, 32);
+    } else if (vector instanceof TimeStampMicroTZVector) {
+      validateVectorCommon(vector, ArrowType.Timestamp.class);
+      validateTimeStampVector(vector, TimeUnit.MICROSECOND, true);
+    } else if (vector instanceof TimeStampMicroVector) {
+      validateVectorCommon(vector, ArrowType.Timestamp.class);
+      validateTimeStampVector(vector, TimeUnit.MICROSECOND, false);
+    } else if (vector instanceof TimeStampMilliTZVector) {
+      validateVectorCommon(vector, ArrowType.Timestamp.class);
+      validateTimeStampVector(vector, TimeUnit.MILLISECOND, true);
+    } else if (vector instanceof TimeStampMilliVector) {
+      validateVectorCommon(vector, ArrowType.Timestamp.class);
+      validateTimeStampVector(vector, TimeUnit.MILLISECOND, false);
+    } else if (vector instanceof TimeStampNanoTZVector) {
+      validateVectorCommon(vector, ArrowType.Timestamp.class);
+      validateTimeStampVector(vector, TimeUnit.NANOSECOND, true);
+    } else if (vector instanceof TimeStampNanoVector) {
+      validateVectorCommon(vector, ArrowType.Timestamp.class);
+      validateTimeStampVector(vector, TimeUnit.NANOSECOND, false);
+    } else if (vector instanceof TimeStampSecTZVector) {
+      validateVectorCommon(vector, ArrowType.Timestamp.class);
+      validateTimeStampVector(vector, TimeUnit.SECOND, true);
+    } else if (vector instanceof TimeStampSecVector) {
+      validateVectorCommon(vector, ArrowType.Timestamp.class);
+      validateTimeStampVector(vector, TimeUnit.SECOND, false);
+    } else if (vector instanceof FixedSizeBinaryVector) {
+      validateVectorCommon(vector, ArrowType.FixedSizeBinary.class);
+      ArrowType.FixedSizeBinary arrowType = (ArrowType.FixedSizeBinary) vector.getField().getType();
+      validateOrThrow(arrowType.getByteWidth() > 0, "The byte width of a FixedSizeBinaryVector must be positive");
+      validateOrThrow(arrowType.getByteWidth() == vector.getTypeWidth(),
+          "Type width mismatch for FixedSizeBinaryVector");
+    } else {
+      throw new IllegalArgumentException("Unknown type for fixed width vector " + vector.getClass());
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(BaseVariableWidthVector vector, Void value) {
+    if (vector instanceof VarCharVector) {
+      validateVectorCommon(vector, ArrowType.Utf8.class);
+    } else if (vector instanceof VarBinaryVector) {
+      validateVectorCommon(vector, ArrowType.Binary.class);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(BaseLargeVariableWidthVector vector, Void value) {
+    if (vector instanceof LargeVarCharVector) {
+      validateVectorCommon(vector, ArrowType.LargeUtf8.class);
+    } else if (vector instanceof LargeVarBinaryVector) {
+      validateVectorCommon(vector, ArrowType.LargeBinary.class);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(ListVector vector, Void value) {
+    validateVectorCommon(vector, ArrowType.List.class);
+    ValueVector innerVector = vector.getDataVector();
+    if (innerVector != null) {
+      innerVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(FixedSizeListVector vector, Void value) {
+    validateVectorCommon(vector, ArrowType.FixedSizeList.class);
+    ArrowType.FixedSizeList arrowType = (ArrowType.FixedSizeList) vector.getField().getType();
+    validateOrThrow(arrowType.getListSize() == vector.getListSize(),
+        "Inconsistent list size for FixedSizeListVector");
+    validateOrThrow(arrowType.getListSize() > 0, "The list size must be positive");
+    ValueVector innerVector = vector.getDataVector();
+    if (innerVector != null) {
+      innerVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(NonNullableStructVector vector, Void value) {
+    validateVectorCommon(vector, ArrowType.Struct.class);
+    validateOrThrow(vector.getField().getChildren().size() == vector.getChildrenFromFields().size(),
+        "Child field count and child vector count mismatch.");
+    for (int i = 0; i < vector.getChildrenFromFields().size(); i++) {
+      ValueVector subVector = vector.getChildByOrdinal(i);
+      FieldType subType = vector.getField().getChildren().get(i).getFieldType();
+
+      validateOrThrow(subType.equals(subVector.getField().getFieldType()),
+          "Struct vector's field type not equal to the child vecto's field type");
+      subVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(UnionVector vector, Void value) {
+    validateVectorCommon(vector, ArrowType.Union.class);
+    ArrowType.Union arrowType = (ArrowType.Union) vector.getField().getType();
+    validateOrThrow(arrowType.getMode() == UnionMode.Sparse, "The union mode of UnionVector must be sparse");
+    for (ValueVector subVector : vector.getChildrenFromFields()) {
+      subVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(DenseUnionVector vector, Void value) {
+    validateVectorCommon(vector, ArrowType.Union.class);
+    ArrowType.Union arrowType = (ArrowType.Union) vector.getField().getType();
+    validateOrThrow(arrowType.getMode() == UnionMode.Dense, "The union mode of DenseUnionVector must be dense");
+    for (ValueVector subVector : vector.getChildrenFromFields()) {
+      subVector.accept(this, null);
+    }
+    return null;
+  }
+
+  @Override
+  public Void visit(NullVector vector, Void value) {
+    validateVectorCommon(vector, ArrowType.Null.class);
+    return null;
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorTypeVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/validate/ValidateVectorTypeVisitor.java
@@ -17,7 +17,7 @@
 
 package org.apache.arrow.vector.validate;
 
-import static org.apache.arrow.vector.validate.ValidateUtility.validateOrThrow;
+import static org.apache.arrow.vector.validate.ValidateUtil.validateOrThrow;
 
 import org.apache.arrow.vector.BaseFixedWidthVector;
 import org.apache.arrow.vector.BaseLargeVariableWidthVector;
@@ -89,54 +89,54 @@ public class ValidateVectorTypeVisitor implements VectorVisitor<Void, Void> {
 
   private void validateIntVector(ValueVector vector, int expectedWidth, boolean expectedSigned) {
     validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Int,
-        "Vector " + vector.getClass() + " is not an integer vector");
+        "Vector %s is not an integer vector.", vector.getClass());
     ArrowType.Int intType = (ArrowType.Int) vector.getField().getFieldType().getType();
     validateOrThrow(intType.getIsSigned() == expectedSigned,
-        "Expecting bit width = " + expectedWidth + ", actual width = " + intType.getBitWidth());
-    validateOrThrow(intType.getBitWidth() == expectedWidth,
-        "Expecting bit width = " + expectedWidth + ", actual width = " + intType.getBitWidth());
+        "Expecting bit width %s, actual width %s.", expectedWidth, intType.getBitWidth());
+    validateOrThrow(intType.getBitWidth() == expectedWidth, "Expecting bit width %s, actual bit width %s.",
+        expectedWidth, intType.getBitWidth());
   }
 
   private void validateFloatingPointVector(ValueVector vector, FloatingPointPrecision expectedPrecision) {
     validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.FloatingPoint,
-        "Vector " + vector.getClass() + " is not a floating point vector");
+        "Vector %s is not a floating point vector.", vector.getClass());
     ArrowType.FloatingPoint floatType = (ArrowType.FloatingPoint) vector.getField().getFieldType().getType();
-    validateOrThrow(floatType.getPrecision() == expectedPrecision,
-        "Expecting precision = " + expectedPrecision + ", actual precision = " + floatType.getPrecision());
+    validateOrThrow(floatType.getPrecision() == expectedPrecision, "Expecting precision %s, actual precision %s.",
+        expectedPrecision, floatType.getPrecision());
   }
 
   private void validateDateVector(ValueVector vector, DateUnit expectedDateUnit) {
     validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Date,
-        "Vector " + vector.getClass() + " is not a date vector");
+        "Vector %s is not a date vector", vector.getClass());
     ArrowType.Date dateType = (ArrowType.Date) vector.getField().getFieldType().getType();
     validateOrThrow(dateType.getUnit() == expectedDateUnit,
-        "Expecting date unit = " + expectedDateUnit + ", actual date unit = " + dateType.getUnit());
+        "Expecting date unit %s, actual date unit %s.", expectedDateUnit, dateType.getUnit());
   }
 
   private void validateTimeVector(ValueVector vector, TimeUnit expectedTimeUnit, int expectedBitWidth) {
     validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Time,
-        "Vector " + vector.getClass() + " is not a time vector");
+        "Vector %s is not a time vector.", vector.getClass());
     ArrowType.Time timeType = (ArrowType.Time) vector.getField().getFieldType().getType();
     validateOrThrow(timeType.getUnit() == expectedTimeUnit,
-        "Expecting time unit = " + expectedTimeUnit + ", actual time unit = " + timeType.getUnit());
+        "Expecting time unit %s, actual time unit %s.", expectedTimeUnit, timeType.getUnit());
     validateOrThrow(timeType.getBitWidth() == expectedBitWidth,
-        "Expecting bit width = " + expectedBitWidth + ", actual bit width = " + timeType.getBitWidth());
+        "Expecting bit width %s, actual bit width %s.", expectedBitWidth, timeType.getBitWidth());
   }
 
   private void validateIntervalVector(ValueVector vector, IntervalUnit expectedIntervalUnit) {
     validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Interval,
-        "Vector " + vector.getClass() + " is not an interval vector");
+        "Vector %s is not an interval vector.", vector.getClass());
     ArrowType.Interval intervalType = (ArrowType.Interval) vector.getField().getFieldType().getType();
     validateOrThrow(intervalType.getUnit() == expectedIntervalUnit,
-        "Expecting interval unit = " + expectedIntervalUnit + ", actual date unit = " + intervalType.getUnit());
+        "Expecting interval unit %s, actual date unit %s.", expectedIntervalUnit, intervalType.getUnit());
   }
 
   private void validateTimeStampVector(ValueVector vector, TimeUnit expectedTimeUnit, boolean expectTZ) {
     validateOrThrow(vector.getField().getFieldType().getType() instanceof ArrowType.Timestamp,
-        "Vector " + vector.getClass() + " is not a time stamp vector");
+        "Vector %s is not a time stamp vector.", vector.getClass());
     ArrowType.Timestamp timestampType = (ArrowType.Timestamp) vector.getField().getFieldType().getType();
     validateOrThrow(timestampType.getUnit() == expectedTimeUnit,
-        "Expecting time stamp unit = " + expectedTimeUnit + ", actual time stamp unit = " + timestampType.getUnit());
+        "Expecting time stamp unit %s, actual time stamp unit %s.", expectedTimeUnit, timestampType.getUnit());
     if (expectTZ) {
       validateOrThrow(timestampType.getTimezone() != null, "The time zone should not be null");
     } else {
@@ -175,8 +175,9 @@ public class ValidateVectorTypeVisitor implements VectorVisitor<Void, Void> {
     } else if (vector instanceof DecimalVector) {
       validateVectorCommon(vector, ArrowType.Decimal.class);
       ArrowType.Decimal arrowType = (ArrowType.Decimal) vector.getField().getType();
-      validateOrThrow(arrowType.getScale() > 0, "The scale of decimal must be positive");
-      validateOrThrow(arrowType.getPrecision() > 0, "The precision of decimal must be positive");
+      validateOrThrow(arrowType.getScale() > 0, "The scale of decimal %s is not positive.", arrowType.getScale());
+      validateOrThrow(arrowType.getPrecision() > 0, "The precision of decimal %S is not positive.",
+          arrowType.getPrecision());
     } else if (vector instanceof DateDayVector) {
       validateVectorCommon(vector, ArrowType.Date.class);
       validateDateVector(vector, DateUnit.DAY);
@@ -187,7 +188,8 @@ public class ValidateVectorTypeVisitor implements VectorVisitor<Void, Void> {
       validateVectorCommon(vector, ArrowType.Duration.class);
       ArrowType.Duration arrowType = (ArrowType.Duration) vector.getField().getType();
       validateOrThrow(((DurationVector) vector).getUnit() == arrowType.getUnit(),
-          "Different duration time unit for vector and arrow type");
+          "Different duration time unit for vector and arrow type. Vector time unit %s, type time unit %s.",
+          ((DurationVector) vector).getUnit(), arrowType.getUnit());
     } else if (vector instanceof Float4Vector) {
       validateVectorCommon(vector, ArrowType.FloatingPoint.class);
       validateFloatingPointVector(vector, FloatingPointPrecision.SINGLE);
@@ -239,9 +241,11 @@ public class ValidateVectorTypeVisitor implements VectorVisitor<Void, Void> {
     } else if (vector instanceof FixedSizeBinaryVector) {
       validateVectorCommon(vector, ArrowType.FixedSizeBinary.class);
       ArrowType.FixedSizeBinary arrowType = (ArrowType.FixedSizeBinary) vector.getField().getType();
-      validateOrThrow(arrowType.getByteWidth() > 0, "The byte width of a FixedSizeBinaryVector must be positive");
+      validateOrThrow(arrowType.getByteWidth() > 0, "The byte width of a FixedSizeBinaryVector %s is not positive.",
+          arrowType.getByteWidth());
       validateOrThrow(arrowType.getByteWidth() == vector.getTypeWidth(),
-          "Type width mismatch for FixedSizeBinaryVector");
+          "Type width mismatch for FixedSizeBinaryVector. Vector type width %s, arrow type type width %s.",
+          vector.getTypeWidth(), arrowType.getByteWidth());
     } else {
       throw new IllegalArgumentException("Unknown type for fixed width vector " + vector.getClass());
     }
@@ -283,8 +287,9 @@ public class ValidateVectorTypeVisitor implements VectorVisitor<Void, Void> {
     validateVectorCommon(vector, ArrowType.FixedSizeList.class);
     ArrowType.FixedSizeList arrowType = (ArrowType.FixedSizeList) vector.getField().getType();
     validateOrThrow(arrowType.getListSize() == vector.getListSize(),
-        "Inconsistent list size for FixedSizeListVector");
-    validateOrThrow(arrowType.getListSize() > 0, "The list size must be positive");
+        "Inconsistent list size for FixedSizeListVector. Vector list size %s, arrow type list size %s.",
+        vector.getListSize(), arrowType.getListSize());
+    validateOrThrow(arrowType.getListSize() > 0, "The list size %s is not positive.", arrowType.getListSize());
     ValueVector innerVector = vector.getDataVector();
     if (innerVector != null) {
       innerVector.accept(this, null);
@@ -306,13 +311,15 @@ public class ValidateVectorTypeVisitor implements VectorVisitor<Void, Void> {
   public Void visit(NonNullableStructVector vector, Void value) {
     validateVectorCommon(vector, ArrowType.Struct.class);
     validateOrThrow(vector.getField().getChildren().size() == vector.getChildrenFromFields().size(),
-        "Child field count and child vector count mismatch.");
+        "Child field count and child vector count mismatch. Vector child count %s, field child count %s",
+        vector.getChildrenFromFields().size(), vector.getField().getChildren().size());
     for (int i = 0; i < vector.getChildrenFromFields().size(); i++) {
       ValueVector subVector = vector.getChildByOrdinal(i);
       FieldType subType = vector.getField().getChildren().get(i).getFieldType();
 
       validateOrThrow(subType.equals(subVector.getField().getFieldType()),
-          "Struct vector's field type not equal to the child vecto's field type");
+          "Struct vector's field type not equal to the child vector's field type. " +
+              "Struct field type %s, sub-vector field type %s", subType, subVector.getField().getFieldType());
       subVector.accept(this, null);
     }
     return null;

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVector.java
@@ -34,6 +34,7 @@ import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.LargeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
@@ -117,6 +118,21 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getDataVector().setValueCount(3);
+      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validate(vector));
+      assertEquals("Inner vector does not contain enough elements.",
+          e.getMessage());
+    }
+  }
+
+  @Test
+  public void testLargeListVector() {
+    try (final LargeListVector vector = LargeListVector.empty("v", allocator)) {
+      validate(vector);
+      setVector(vector, Arrays.asList(1, 2, 3, 4), Arrays.asList(5, 6));
+      validate(vector);
+
+      vector.getDataVector().setValueCount(4);
       ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
           () -> validate(vector));
       assertEquals("Inner vector does not contain enough elements.",

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVector.java
@@ -19,7 +19,6 @@ package org.apache.arrow.vector.validate;
 
 import static org.apache.arrow.vector.testing.ValueVectorDataPopulator.setVector;
 import static org.apache.arrow.vector.util.ValueVectorUtility.validate;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -76,9 +75,9 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getDataBuffer().capacity(0);
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
-      assertTrue(e.getMessage().contains("No enough capacity for fixed width data buffer"));
+      assertTrue(e.getMessage().contains("Not enough capacity for fixed width data buffer"));
     }
   }
 
@@ -90,9 +89,9 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getDataBuffer().capacity(0);
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
-      assertTrue(e.getMessage().contains("No enough capacity for data buffer"));
+      assertTrue(e.getMessage().contains("Not enough capacity for data buffer"));
     }
   }
 
@@ -104,9 +103,9 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getDataBuffer().capacity(0);
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
-      assertTrue(e.getMessage().contains("No enough capacity for data buffer"));
+      assertTrue(e.getMessage().contains("Not enough capacity for data buffer"));
     }
   }
 
@@ -118,10 +117,9 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getDataVector().setValueCount(3);
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
-      assertEquals("Inner vector does not contain enough elements.",
-          e.getMessage());
+      assertTrue(e.getMessage().contains("Inner vector does not contain enough elements."));
     }
   }
 
@@ -133,10 +131,9 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getDataVector().setValueCount(4);
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
-      assertEquals("Inner vector does not contain enough elements.",
-          e.getMessage());
+      assertTrue(e.getMessage().contains("Inner vector does not contain enough elements."));
     }
   }
 
@@ -148,10 +145,9 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getDataVector().setValueCount(3);
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
-      assertEquals("Inner vector does not contain enough elements.",
-          e.getMessage());
+      assertTrue(e.getMessage().contains("Inner vector does not contain enough elements."));
     }
   }
 
@@ -174,7 +170,7 @@ public class TestValidateVector {
       writer.setValueCount(5);
 
       vector.getChild("f0").setValueCount(2);
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
       assertTrue(e.getMessage().contains("Struct vector length not equal to child vector length"));
 
@@ -182,9 +178,9 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getChild("f0").getDataBuffer().capacity(0);
-      ValidateUtility.ValidateException e2 = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e2 = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
-      assertTrue(e2.getMessage().contains("No enough capacity for fixed width data buffer"));
+      assertTrue(e2.getMessage().contains("Not enough capacity for fixed width data buffer"));
     }
   }
 
@@ -210,7 +206,7 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getChildrenFromFields().get(0).setValueCount(1);
-      ValidateUtility.ValidateException e1 = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e1 = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
       assertTrue(e1.getMessage().contains("Union vector length not equal to child vector length"));
 
@@ -218,9 +214,9 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getChildrenFromFields().get(0).getDataBuffer().capacity(0);
-      ValidateUtility.ValidateException e2 = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e2 = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
-      assertTrue(e2.getMessage().contains("No enough capacity for fixed width data buffer"));
+      assertTrue(e2.getMessage().contains("Not enough capacity for fixed width data buffer"));
     }
   }
 
@@ -249,9 +245,9 @@ public class TestValidateVector {
       validate(vector);
 
       vector.getChildrenFromFields().get(0).getDataBuffer().capacity(0);
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(vector));
-      assertTrue(e.getMessage().contains("No enough capacity for fixed width data buffer"));
+      assertTrue(e.getMessage().contains("Not enough capacity for fixed width data buffer"));
     }
   }
 
@@ -261,6 +257,4 @@ public class TestValidateVector {
     writer.bigInt("f1").writeBigInt(value2);
     writer.end();
   }
-
-
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorFull.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorFull.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.validate;
+
+import static org.apache.arrow.vector.testing.ValueVectorDataPopulator.setVector;
+import static org.apache.arrow.vector.util.ValueVectorUtility.validateFull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestValidateVectorFull {
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void init() {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+  }
+
+  @After
+  public void terminate() throws Exception {
+    allocator.close();
+  }
+
+  @Test
+  public void testBaseVariableWidthVector() {
+    try (final VarCharVector vector = new VarCharVector("v", allocator)) {
+      validateFull(vector);
+      setVector(vector, "aaa", "bbb", "ccc");
+      validateFull(vector);
+
+      ArrowBuf offsetBuf = vector.getOffsetBuffer();
+      offsetBuf.setInt(0, 100);
+      offsetBuf.setInt(4, 50);
+
+      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validateFull(vector));
+      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+    }
+  }
+
+  @Test
+  public void testBaseLargeVariableWidthVector() {
+    try (final LargeVarCharVector vector = new LargeVarCharVector("v", allocator)) {
+      validateFull(vector);
+      setVector(vector, "aaa", "bbb", null, "ccc");
+      validateFull(vector);
+
+      ArrowBuf offsetBuf = vector.getOffsetBuffer();
+      offsetBuf.setInt(0, 100);
+      offsetBuf.setInt(4, 50);
+
+      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validateFull(vector));
+      assertTrue(e.getMessage().contains("The values in the large offset buffer are decreasing"));
+    }
+  }
+
+  @Test
+  public void testListVector() {
+    try (final ListVector vector = ListVector.empty("v", allocator)) {
+      validateFull(vector);
+      setVector(vector, Arrays.asList(1, 2, 3), Arrays.asList(4, 5), Arrays.asList(6, 7, 8, 9));
+      validateFull(vector);
+
+      ArrowBuf offsetBuf = vector.getOffsetBuffer();
+      offsetBuf.setInt(0, 100);
+      offsetBuf.setInt(8, 50);
+
+      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validateFull(vector));
+      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+    }
+  }
+
+  @Test
+  public void testStructVectorRangeEquals() {
+    try (final StructVector vector = StructVector.empty("struct", allocator)) {
+      IntVector intVector =
+          vector.addOrGet("f0", FieldType.nullable(new ArrowType.Int(32, true)), IntVector.class);
+      VarCharVector strVector =
+          vector.addOrGet("f1", FieldType.nullable(new ArrowType.Utf8()), VarCharVector.class);
+
+      validateFull(vector);
+      validateFull(intVector);
+      validateFull(strVector);
+
+      ValueVectorDataPopulator.setVector(intVector, 1, 2, 3, 4, 5);
+      ValueVectorDataPopulator.setVector(strVector, "a", "b", "c", "d", "e");
+      vector.setValueCount(5);
+
+      validateFull(vector);
+      validateFull(intVector);
+      validateFull(strVector);
+
+      ArrowBuf offsetBuf = strVector.getOffsetBuffer();
+      offsetBuf.setInt(0, 100);
+      offsetBuf.setInt(8, 50);
+
+      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validateFull(strVector));
+      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+
+      e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validateFull(vector));
+      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+    }
+  }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorFull.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorFull.java
@@ -74,9 +74,9 @@ public class TestValidateVectorFull {
       offsetBuf.setInt(0, 100);
       offsetBuf.setInt(4, 50);
 
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(vector));
-      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+      assertTrue(e.getMessage().contains("The values in positions 0 and 1 of the offset buffer are decreasing"));
     }
   }
 
@@ -88,12 +88,12 @@ public class TestValidateVectorFull {
       validateFull(vector);
 
       ArrowBuf offsetBuf = vector.getOffsetBuffer();
-      offsetBuf.setInt(0, 100);
-      offsetBuf.setInt(4, 50);
+      offsetBuf.setLong(0, 100);
+      offsetBuf.setLong(8, 50);
 
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(vector));
-      assertTrue(e.getMessage().contains("The values in the large offset buffer are decreasing"));
+      assertTrue(e.getMessage().contains("The values in positions 0 and 1 of the large offset buffer are decreasing"));
     }
   }
 
@@ -108,9 +108,9 @@ public class TestValidateVectorFull {
       offsetBuf.setInt(0, 100);
       offsetBuf.setInt(8, 50);
 
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(vector));
-      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+      assertTrue(e.getMessage().contains("The values in positions 0 and 1 of the offset buffer are decreasing"));
     }
   }
 
@@ -125,9 +125,9 @@ public class TestValidateVectorFull {
       offsetBuf.setLong(0, 100);
       offsetBuf.setLong(16, 50);
 
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(vector));
-      assertTrue(e.getMessage().contains("The values in the large offset buffer are decreasing"));
+      assertTrue(e.getMessage().contains("The values in positions 0 and 1 of the large offset buffer are decreasing"));
     }
   }
 
@@ -155,13 +155,13 @@ public class TestValidateVectorFull {
       offsetBuf.setInt(0, 100);
       offsetBuf.setInt(8, 50);
 
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(strVector));
-      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+      assertTrue(e.getMessage().contains("The values in positions 0 and 1 of the offset buffer are decreasing"));
 
-      e = assertThrows(ValidateUtility.ValidateException.class,
+      e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(vector));
-      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+      assertTrue(e.getMessage().contains("The values in positions 0 and 1 of the offset buffer are decreasing"));
     }
   }
 
@@ -189,9 +189,9 @@ public class TestValidateVectorFull {
       // negative type id
       vector.getTypeBuffer().setByte(0, -1);
 
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(vector));
-      assertTrue(e.getMessage().contains("The type id must be non-negative"));
+      assertTrue(e.getMessage().contains("The type id at position 0 is negative"));
     }
   }
 
@@ -226,7 +226,7 @@ public class TestValidateVectorFull {
       // shrink sub-vector
       subVector.setValueCount(0);
 
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(vector));
       assertTrue(e.getMessage().contains("Dense union vector offset exceeds sub-vector boundary"));
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorFull.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorFull.java
@@ -30,6 +30,7 @@ import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.LargeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
@@ -101,6 +102,23 @@ public class TestValidateVectorFull {
       ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
           () -> validateFull(vector));
       assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+    }
+  }
+
+  @Test
+  public void testLargeListVector() {
+    try (final LargeListVector vector = LargeListVector.empty("v", allocator)) {
+      validateFull(vector);
+      setVector(vector, Arrays.asList(1, 2, 3), Arrays.asList(4, 5), Arrays.asList(6, 7, 8, 9));
+      validateFull(vector);
+
+      ArrowBuf offsetBuf = vector.getOffsetBuffer();
+      offsetBuf.setLong(0, 100);
+      offsetBuf.setLong(16, 50);
+
+      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validateFull(vector));
+      assertTrue(e.getMessage().contains("The values in the large offset buffer are decreasing"));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorSchemaRoot.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorSchemaRoot.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.validate;
+
+import static org.apache.arrow.vector.util.ValueVectorUtility.validate;
+import static org.apache.arrow.vector.util.ValueVectorUtility.validateFull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestValidateVectorSchemaRoot {
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void init() {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+  }
+
+  @After
+  public void terminate() throws Exception {
+    allocator.close();
+  }
+
+  @Test
+  public void testValidatePositive() {
+    try (IntVector intVector = new IntVector("int vector", allocator);
+         VarCharVector strVector = new VarCharVector("var char vector", allocator)) {
+
+      VectorSchemaRoot root = VectorSchemaRoot.of(intVector, strVector);
+
+      validate(root);
+      validateFull(root);
+
+      ValueVectorDataPopulator.setVector(intVector, 1, 2, 3, 4, 5);
+      ValueVectorDataPopulator.setVector(strVector, "a", "b", "c", "d", "e");
+      root.setRowCount(5);
+
+      validate(root);
+      validateFull(root);
+    }
+  }
+
+  @Test
+  public void testValidateNegative() {
+    try (IntVector intVector = new IntVector("int vector", allocator);
+         VarCharVector strVector = new VarCharVector("var char vector", allocator)) {
+
+      VectorSchemaRoot root = VectorSchemaRoot.of(intVector, strVector);
+
+      ValueVectorDataPopulator.setVector(intVector, 1, 2, 3, 4, 5);
+      ValueVectorDataPopulator.setVector(strVector, "a", "b", "c", "d", "e");
+
+      // validate mismatching value counts
+      root.setRowCount(4);
+      intVector.setValueCount(5);
+      strVector.setValueCount(5);
+      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validate(root));
+      assertTrue(e.getMessage().contains("Child vector and vector schema root have different value counts"));
+      e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validateFull(root));
+      assertTrue(e.getMessage().contains("Child vector and vector schema root have different value counts"));
+
+      // valid problems with the child vector
+      root.setRowCount(5);
+      ArrowBuf offsetBuf = strVector.getOffsetBuffer();
+      offsetBuf.setInt(0, 100);
+      offsetBuf.setInt(8, 50);
+      validate(root);
+      e = assertThrows(ValidateUtility.ValidateException.class,
+          () -> validateFull(root));
+      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+    }
+  }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorSchemaRoot.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorSchemaRoot.java
@@ -80,10 +80,10 @@ public class TestValidateVectorSchemaRoot {
       root.setRowCount(4);
       intVector.setValueCount(5);
       strVector.setValueCount(5);
-      ValidateUtility.ValidateException e = assertThrows(ValidateUtility.ValidateException.class,
+      ValidateUtil.ValidateException e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validate(root));
       assertTrue(e.getMessage().contains("Child vector and vector schema root have different value counts"));
-      e = assertThrows(ValidateUtility.ValidateException.class,
+      e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(root));
       assertTrue(e.getMessage().contains("Child vector and vector schema root have different value counts"));
 
@@ -93,9 +93,9 @@ public class TestValidateVectorSchemaRoot {
       offsetBuf.setInt(0, 100);
       offsetBuf.setInt(8, 50);
       validate(root);
-      e = assertThrows(ValidateUtility.ValidateException.class,
+      e = assertThrows(ValidateUtil.ValidateException.class,
           () -> validateFull(root));
-      assertTrue(e.getMessage().contains("The values in the offset buffer are decreasing"));
+      assertTrue(e.getMessage().contains("The values in positions 0 and 1 of the offset buffer are decreasing"));
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorTypeVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorTypeVisitor.java
@@ -61,6 +61,7 @@ import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.complex.DenseUnionVector;
 import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.LargeListVector;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.StructVector;
 import org.apache.arrow.vector.complex.UnionVector;
@@ -260,6 +261,14 @@ public class TestValidateVectorTypeVisitor {
 
     testNegativeCase(
         () -> new ListVector("vector", allocator, FieldType.nullable(Types.MinorType.INT.getType()), null));
+  }
+
+  @Test
+  public void testLargeListVector() {
+    testPositiveCase(() -> LargeListVector.empty("vector", allocator));
+
+    testNegativeCase(
+        () -> new LargeListVector("vector", allocator, FieldType.nullable(Types.MinorType.INT.getType()), null));
   }
 
   @Test

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorTypeVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorTypeVisitor.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.validate;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.function.Supplier;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DateMilliVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.DurationVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.IntervalDayVector;
+import org.apache.arrow.vector.IntervalYearVector;
+import org.apache.arrow.vector.LargeVarBinaryVector;
+import org.apache.arrow.vector.LargeVarCharVector;
+import org.apache.arrow.vector.NullVector;
+import org.apache.arrow.vector.SmallIntVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeMilliVector;
+import org.apache.arrow.vector.TimeNanoVector;
+import org.apache.arrow.vector.TimeSecVector;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampMilliTZVector;
+import org.apache.arrow.vector.TimeStampMilliVector;
+import org.apache.arrow.vector.TimeStampNanoTZVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.TimeStampSecTZVector;
+import org.apache.arrow.vector.TimeStampSecVector;
+import org.apache.arrow.vector.TinyIntVector;
+import org.apache.arrow.vector.UInt1Vector;
+import org.apache.arrow.vector.UInt2Vector;
+import org.apache.arrow.vector.UInt4Vector;
+import org.apache.arrow.vector.UInt8Vector;
+import org.apache.arrow.vector.ValueVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.complex.DenseUnionVector;
+import org.apache.arrow.vector.complex.FixedSizeListVector;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.complex.UnionVector;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test cases for {@link ValidateVectorTypeVisitor}.
+ */
+public class TestValidateVectorTypeVisitor {
+
+  private BufferAllocator allocator;
+
+  private ValidateVectorTypeVisitor visitor = new ValidateVectorTypeVisitor();
+
+  @Before
+  public void init() {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+  }
+
+  @After
+  public void terminate() throws Exception {
+    allocator.close();
+  }
+
+  private void testPositiveCase(Supplier<ValueVector> vectorGenerator) {
+    try (ValueVector vector = vectorGenerator.get();) {
+      vector.accept(visitor, null);
+    }
+  }
+
+  private void testNegativeCase(Supplier<ValueVector> vectorGenerator) {
+    try (ValueVector vector = vectorGenerator.get()) {
+      assertThrows(ValidateUtility.ValidateException.class, () -> {
+        vector.accept(visitor, null);
+      });
+    }
+  }
+
+  @Test
+  public void testFixedWidthVectorsPositive() {
+    // integer vectors
+    testPositiveCase(() -> new TinyIntVector("vector", allocator));
+    testPositiveCase(() -> new SmallIntVector("vector", allocator));
+    testPositiveCase(() -> new IntVector("vector", allocator));
+    testPositiveCase(() -> new BigIntVector("vector", allocator));
+    testPositiveCase(() -> new UInt1Vector("vector", allocator));
+    testPositiveCase(() -> new UInt2Vector("vector", allocator));
+    testPositiveCase(() -> new UInt4Vector("vector", allocator));
+    testPositiveCase(() -> new UInt8Vector("vector", allocator));
+
+    testPositiveCase(() -> new BitVector("vector", allocator));
+    testPositiveCase(() -> new DecimalVector("vector", allocator, 30, 16));
+
+    // date vectors
+    testPositiveCase(() -> new DateDayVector("vector", allocator));
+    testPositiveCase(() -> new DateMilliVector("vector", allocator));
+
+    testPositiveCase(() -> new DurationVector(
+        "vector", FieldType.nullable(new ArrowType.Duration(TimeUnit.SECOND)), allocator));
+
+    // float vectors
+    testPositiveCase(() -> new Float4Vector("vector", allocator));
+    testPositiveCase(() -> new Float8Vector("vector", allocator));
+
+    // interval vectors
+    testPositiveCase(() -> new IntervalDayVector("vector", allocator));
+    testPositiveCase(() -> new IntervalYearVector("vector", allocator));
+
+    // time vectors
+    testPositiveCase(() -> new TimeMicroVector("vector", allocator));
+    testPositiveCase(() -> new TimeMilliVector("vector", allocator));
+    testPositiveCase(() -> new TimeMicroVector("vector", allocator));
+    testPositiveCase(() -> new TimeSecVector("vector", allocator));
+
+    // time stamp vectors
+    testPositiveCase(() -> new TimeStampMicroTZVector("vector", allocator, "cn"));
+    testPositiveCase(() -> new TimeStampMicroVector("vector", allocator));
+    testPositiveCase(() -> new TimeStampMilliTZVector("vector", allocator, "cn"));
+    testPositiveCase(() -> new TimeStampMilliVector("vector", allocator));
+    testPositiveCase(() -> new TimeStampNanoTZVector("vector", allocator, "cn"));
+    testPositiveCase(() -> new TimeStampNanoVector("vector", allocator));
+    testPositiveCase(() -> new TimeStampSecTZVector("vector", allocator, "cn"));
+    testPositiveCase(() -> new TimeStampSecVector("vector", allocator));
+
+    testPositiveCase(() -> new FixedSizeBinaryVector("vector", allocator, 5));
+  }
+
+  @Test
+  public void testFixedWidthVectorsNegative() {
+    // integer vectors
+    testNegativeCase(
+        () -> new TinyIntVector("vector", FieldType.nullable(Types.MinorType.INT.getType()), allocator));
+    testNegativeCase(
+        () -> new SmallIntVector("vector", FieldType.nullable(Types.MinorType.INT.getType()), allocator));
+    testNegativeCase(
+        () -> new BigIntVector("vector", FieldType.nullable(Types.MinorType.SMALLINT.getType()), allocator));
+    testNegativeCase(
+        () -> new BigIntVector("vector", FieldType.nullable(Types.MinorType.SMALLINT.getType()), allocator));
+    testNegativeCase(
+        () -> new UInt1Vector("vector", FieldType.nullable(Types.MinorType.SMALLINT.getType()), allocator));
+    testNegativeCase(
+        () -> new UInt2Vector("vector", FieldType.nullable(Types.MinorType.SMALLINT.getType()), allocator));
+    testNegativeCase(
+        () -> new UInt4Vector("vector", FieldType.nullable(Types.MinorType.SMALLINT.getType()), allocator));
+    testNegativeCase(
+        () -> new UInt8Vector("vector", FieldType.nullable(Types.MinorType.SMALLINT.getType()), allocator));
+
+    testNegativeCase(
+        () -> new BitVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+    testNegativeCase(
+        () -> new DecimalVector("vector", allocator, 30, -16));
+
+    // date vectors
+    testNegativeCase(
+        () -> new DateDayVector("vector", FieldType.nullable(Types.MinorType.FLOAT4.getType()), allocator));
+    testNegativeCase(
+        () -> new DateMilliVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+
+    // float pont vectors
+    testNegativeCase(
+        () -> new Float4Vector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+    testNegativeCase(
+        () -> new Float8Vector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+
+    // interval vectors
+    testNegativeCase(
+        () -> new IntervalDayVector("vector", FieldType.nullable(Types.MinorType.INT.getType()), allocator));
+    testNegativeCase(
+        () -> new IntervalYearVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+
+    // time vectors
+    testNegativeCase(
+        () -> new TimeMilliVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+    testNegativeCase(
+        () -> new TimeMicroVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+    testNegativeCase(
+        () -> new TimeNanoVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+    testNegativeCase(
+        () -> new TimeSecVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+
+    // time stamp vectors
+    testNegativeCase(
+        () -> new TimeStampMicroTZVector("vector", allocator, null));
+    testNegativeCase(
+        () -> new TimeStampMicroVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+    testNegativeCase(
+        () -> new TimeStampMilliTZVector("vector", allocator, null));
+    testNegativeCase(
+        () -> new TimeStampMilliVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+    testNegativeCase(
+        () -> new TimeStampNanoTZVector("vector", allocator, null));
+    testNegativeCase(
+        () -> new TimeStampNanoVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+    testNegativeCase(
+        () -> new TimeStampSecTZVector("vector", allocator, null));
+    testNegativeCase(
+        () -> new TimeStampSecVector("vector", FieldType.nullable(Types.MinorType.BIGINT.getType()), allocator));
+  }
+
+  @Test
+  public void testVariableWidthVectorsPositive() {
+    testPositiveCase(() -> new VarCharVector("vector", allocator));
+    testPositiveCase(() -> new VarBinaryVector("vector", allocator));
+  }
+
+  @Test
+  public void testVariableWidthVectorsNegative() {
+    testNegativeCase(
+        () -> new VarCharVector("vector", FieldType.nullable(Types.MinorType.INT.getType()), allocator));
+    testNegativeCase(
+        () -> new VarBinaryVector("vector", FieldType.nullable(Types.MinorType.INT.getType()), allocator));
+  }
+
+  @Test
+  public void testLargeVariableWidthVectorsPositive() {
+    testPositiveCase(() -> new LargeVarCharVector("vector", allocator));
+    testPositiveCase(() -> new LargeVarBinaryVector("vector", allocator));
+  }
+
+  @Test
+  public void testLargeVariableWidthVectorsNegative() {
+    testNegativeCase(
+        () -> new LargeVarCharVector("vector", FieldType.nullable(Types.MinorType.INT.getType()), allocator));
+    testNegativeCase(
+        () -> new LargeVarBinaryVector("vector", FieldType.nullable(Types.MinorType.INT.getType()), allocator));
+  }
+
+  @Test
+  public void testListVector() {
+    testPositiveCase(() -> ListVector.empty("vector", allocator));
+
+    testNegativeCase(
+        () -> new ListVector("vector", allocator, FieldType.nullable(Types.MinorType.INT.getType()), null));
+  }
+
+  @Test
+  public void testFixedSizeListVector() {
+    testPositiveCase(() -> FixedSizeListVector.empty("vector", 10, allocator));
+  }
+
+  @Test
+  public void testStructVector() {
+    testPositiveCase(() -> StructVector.empty("vector", allocator));
+
+    testNegativeCase(
+        () -> new StructVector("vector", allocator, FieldType.nullable(Types.MinorType.INT.getType()), null));
+  }
+
+  @Test
+  public void testUnionVector() {
+    testPositiveCase(() -> UnionVector.empty("vector", allocator));
+  }
+
+  @Test
+  public void testDenseUnionVector() {
+    testPositiveCase(() -> DenseUnionVector.empty("vector", allocator));
+  }
+
+  @Test
+  public void testNullVector() {
+    testPositiveCase(() -> new NullVector());
+  }
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorTypeVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/validate/TestValidateVectorTypeVisitor.java
@@ -100,7 +100,7 @@ public class TestValidateVectorTypeVisitor {
 
   private void testNegativeCase(Supplier<ValueVector> vectorGenerator) {
     try (ValueVector vector = vectorGenerator.get()) {
-      assertThrows(ValidateUtility.ValidateException.class, () -> {
+      assertThrows(ValidateUtil.ValidateException.class, () -> {
         vector.accept(visitor, null);
       });
     }


### PR DESCRIPTION
In this PR, we provide the validateFull functionalities, and refactor the validate logic. We separate the validation logic into 3 visitors:

1. Type validation: validate vector type information (O(1) time complexity).
2. Buffer validation: validate buffer count/size, etc. (O(1) time complexity).
3. Data validation: validate content of data buffers. (O(n) time complexity).

For the `validate` method, we perform validations 1 and 2, with a total time complexity of O(1).
For the `validateFull` method, we perform validations 1, 2, and 3, with a total time complexity of O(n).
