### PR TITLE
ARROW-8889: [Python] avoid SIGSEGV when comparing RecordBatch to None

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -887,7 +887,7 @@ cdef class RecordBatch(_PandasConvertible):
 
         return wrap_datum(out)
 
-    def equals(self, RecordBatch other, bint check_metadata=False):
+    def equals(self, object other, bint check_metadata=False):
         """
         Check if contents of two record batches are equal.
 
@@ -904,8 +904,11 @@ cdef class RecordBatch(_PandasConvertible):
         """
         cdef:
             CRecordBatch* this_batch = self.batch
-            CRecordBatch* other_batch = other.batch
+            shared_ptr[CRecordBatch] other_batch = pyarrow_unwrap_batch(other)
             c_bool result
+
+        if not other_batch:
+            return False
 
         with nogil:
             result = this_batch.Equals(deref(other_batch), check_metadata)

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -362,6 +362,10 @@ def test_recordbatch_equals():
     assert batch_meta.equals(batch)
     assert not batch_meta.equals(batch, check_metadata=True)
 
+    # ARROW-8889
+    assert not batch.equals(None)
+    assert batch != "foo"
+
 
 def test_recordbatch_take():
     batch = pa.record_batch(


### PR DESCRIPTION
This avoids passing an invalid (null) reference to C++.