### PR TITLE
ARROW-8906: [Rust] [DataFusion] support schema inference from multiple CSV files

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,4 +1,4 @@
 Cargo.lock
 target
-
+rusty-tags.vi
 .history

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -61,6 +61,7 @@ default = ["flight"]
 criterion = "0.3"
 lazy_static = "1"
 flate2 = "1"
+tempfile = "3"
 
 [[bench]]
 name = "array_from_vec"

--- a/rust/arrow/src/csv/mod.rs
+++ b/rust/arrow/src/csv/mod.rs
@@ -20,7 +20,7 @@
 pub mod reader;
 pub mod writer;
 
-pub use self::reader::infer_file_schema;
+pub use self::reader::infer_schema_from_files;
 pub use self::reader::Reader;
 pub use self::reader::ReaderBuilder;
 pub use self::writer::Writer;

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1222,33 +1222,16 @@ impl Field {
         format!("{}: {:?}", self.name, self.data_type)
     }
 
-    /// Merge field into self if it is compatible. Struct fields will be merged recursively.
+    /// Merge field into self if it is compatible. Struct will be merged recursively.
     ///
     /// Example:
     ///
     /// ```
     /// use arrow::datatypes::*;
     ///
-    /// let merged = Schema::try_merge(&vec![
-    ///     Schema::new(vec![
-    ///         Field::new("c1", DataType::Int64, false),
-    ///         Field::new("c2", DataType::Utf8, false),
-    ///     ]),
-    ///     Schema::new(vec![
-    ///         Field::new("c1", DataType::Int64, true),
-    ///         Field::new("c2", DataType::Utf8, false),
-    ///         Field::new("c3", DataType::Utf8, false),
-    ///     ]),
-    /// ]).unwrap();
-    ///
-    /// assert_eq!(
-    ///     merged,
-    ///     Schema::new(vec![
-    ///         Field::new("c1", DataType::Int64, true),
-    ///         Field::new("c2", DataType::Utf8, false),
-    ///         Field::new("c3", DataType::Utf8, false),
-    ///     ]),
-    /// );
+    /// let mut field = Field::new("c1", DataType::Int64, false);
+    /// assert!(field.try_merge(&Field::new("c1", DataType::Int64, true)).is_ok());
+    /// assert!(field.is_nullable());
     /// ```
     pub fn try_merge(&mut self, from: &Field) -> Result<()> {
         if from.dict_id != self.dict_id {
@@ -1417,6 +1400,34 @@ impl Schema {
         Self { fields, metadata }
     }
 
+    /// Merge schema into self if it is compatible. Struct fields will be merged recursively.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// use arrow::datatypes::*;
+    ///
+    /// let merged = Schema::try_merge(&vec![
+    ///     Schema::new(vec![
+    ///         Field::new("c1", DataType::Int64, false),
+    ///         Field::new("c2", DataType::Utf8, false),
+    ///     ]),
+    ///     Schema::new(vec![
+    ///         Field::new("c1", DataType::Int64, true),
+    ///         Field::new("c2", DataType::Utf8, false),
+    ///         Field::new("c3", DataType::Utf8, false),
+    ///     ]),
+    /// ]).unwrap();
+    ///
+    /// assert_eq!(
+    ///     merged,
+    ///     Schema::new(vec![
+    ///         Field::new("c1", DataType::Int64, true),
+    ///         Field::new("c2", DataType::Utf8, false),
+    ///         Field::new("c3", DataType::Utf8, false),
+    ///     ]),
+    /// );
+    /// ```
     pub fn try_merge(schemas: &Vec<Self>) -> Result<Self> {
         let mut merged = Self::empty();
 

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1221,6 +1221,133 @@ impl Field {
     pub fn to_string(&self) -> String {
         format!("{}: {:?}", self.name, self.data_type)
     }
+
+    /// Merge field into self if it is compatible. Struct fields will be merged recursively.
+    ///
+    /// Example:
+    ///
+    /// ```
+    /// use arrow::datatypes::*;
+    ///
+    /// let merged = Schema::try_merge(&vec![
+    ///     Schema::new(vec![
+    ///         Field::new("c1", DataType::Int64, false),
+    ///         Field::new("c2", DataType::Utf8, false),
+    ///     ]),
+    ///     Schema::new(vec![
+    ///         Field::new("c1", DataType::Int64, true),
+    ///         Field::new("c2", DataType::Utf8, false),
+    ///         Field::new("c3", DataType::Utf8, false),
+    ///     ]),
+    /// ]).unwrap();
+    ///
+    /// assert_eq!(
+    ///     merged,
+    ///     Schema::new(vec![
+    ///         Field::new("c1", DataType::Int64, true),
+    ///         Field::new("c2", DataType::Utf8, false),
+    ///         Field::new("c3", DataType::Utf8, false),
+    ///     ]),
+    /// );
+    /// ```
+    pub fn try_merge(&mut self, from: &Field) -> Result<()> {
+        if from.dict_id != self.dict_id {
+            return Err(ArrowError::SchemaError(
+                "Fail to merge schema Field due to conflicting dict_id".to_string(),
+            ));
+        }
+        if from.dict_is_ordered != self.dict_is_ordered {
+            return Err(ArrowError::SchemaError(
+                "Fail to merge schema Field due to conflicting dict_is_ordered"
+                    .to_string(),
+            ));
+        }
+        match &mut self.data_type {
+            DataType::Struct(nested_fields) => match &from.data_type {
+                DataType::Struct(from_nested_fields) => {
+                    for from_field in from_nested_fields {
+                        let mut is_new_field = true;
+                        for self_field in nested_fields.into_iter() {
+                            if self_field.name != from_field.name {
+                                continue;
+                            }
+                            is_new_field = false;
+                            self_field.try_merge(&from_field)?;
+                        }
+                        if is_new_field {
+                            nested_fields.push(from_field.clone());
+                        }
+                    }
+                }
+                _ => {
+                    return Err(ArrowError::SchemaError(
+                        "Fail to merge schema Field due to conflicting datatype"
+                            .to_string(),
+                    ));
+                }
+            },
+            DataType::Union(nested_fields) => match &from.data_type {
+                DataType::Union(from_nested_fields) => {
+                    for from_field in from_nested_fields {
+                        let mut is_new_field = true;
+                        for self_field in nested_fields.into_iter() {
+                            if from_field == self_field {
+                                is_new_field = false;
+                                break;
+                            }
+                        }
+                        if is_new_field {
+                            nested_fields.push(from_field.clone());
+                        }
+                    }
+                }
+                _ => {
+                    return Err(ArrowError::SchemaError(
+                        "Fail to merge schema Field due to conflicting datatype"
+                            .to_string(),
+                    ));
+                }
+            },
+            DataType::Null
+            | DataType::Boolean
+            | DataType::Int8
+            | DataType::Int16
+            | DataType::Int32
+            | DataType::Int64
+            | DataType::UInt8
+            | DataType::UInt16
+            | DataType::UInt32
+            | DataType::UInt64
+            | DataType::Float16
+            | DataType::Float32
+            | DataType::Float64
+            | DataType::Timestamp(_, _)
+            | DataType::Date32(_)
+            | DataType::Date64(_)
+            | DataType::Time32(_)
+            | DataType::Time64(_)
+            | DataType::Duration(_)
+            | DataType::Binary
+            | DataType::Interval(_)
+            | DataType::List(_)
+            | DataType::Dictionary(_, _)
+            | DataType::FixedSizeList(_, _)
+            | DataType::FixedSizeBinary(_)
+            | DataType::Utf8 => {
+                if self.data_type != from.data_type {
+                    return Err(ArrowError::SchemaError(
+                        "Fail to merge schema Field due to conflicting datatype"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+        if from.nullable {
+            self.nullable = from.nullable;
+        }
+
+        Ok(())
+    }
 }
 
 impl fmt::Display for Field {
@@ -1265,6 +1392,7 @@ impl Schema {
     pub fn new(fields: Vec<Field>) -> Self {
         Self::new_with_metadata(fields, HashMap::new())
     }
+
     /// Creates a new `Schema` from a sequence of `Field` values
     /// and adds additional metadata in form of key value pairs.
     ///
@@ -1287,6 +1415,46 @@ impl Schema {
         metadata: HashMap<String, String>,
     ) -> Self {
         Self { fields, metadata }
+    }
+
+    pub fn try_merge(schemas: &Vec<Self>) -> Result<Self> {
+        let mut merged = Self::empty();
+
+        for schema in schemas {
+            for (key, value) in schema.metadata.iter() {
+                // merge metadata
+                match merged.metadata.get(key) {
+                    Some(old_val) => {
+                        if old_val != value {
+                            return Err(ArrowError::SchemaError(
+                                "Fail to merge schema due to conflicting metadata"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                    None => {
+                        merged.metadata.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+            // merge fileds
+            for field in &schema.fields {
+                let mut new_field = true;
+                for merged_field in &mut merged.fields {
+                    if field.name != merged_field.name {
+                        continue;
+                    }
+                    new_field = false;
+                    merged_field.try_merge(field)?
+                }
+                // found a new field, add to field list
+                if new_field {
+                    merged.fields.push(field.clone());
+                }
+            }
+        }
+
+        Ok(merged)
     }
 
     /// Returns an immutable reference of the vector of `Field` instances
@@ -2185,5 +2353,127 @@ mod tests {
                 false,
             ),
         ])
+    }
+
+    #[test]
+    fn test_schema_merge() -> Result<()> {
+        let merged = Schema::try_merge(&vec![
+            Schema::new(vec![
+                Field::new("first_name", DataType::Utf8, false),
+                Field::new("last_name", DataType::Utf8, false),
+                Field::new(
+                    "address",
+                    DataType::Struct(vec![Field::new("zip", DataType::UInt16, false)]),
+                    false,
+                ),
+            ]),
+            Schema::new_with_metadata(
+                vec![
+                    // nullable merge
+                    Field::new("last_name", DataType::Utf8, true),
+                    Field::new(
+                        "address",
+                        DataType::Struct(vec![
+                            // add new nested field
+                            Field::new("street", DataType::Utf8, false),
+                            // nullable merge on nested field
+                            Field::new("zip", DataType::UInt16, true),
+                        ]),
+                        false,
+                    ),
+                    // new field
+                    Field::new("number", DataType::Utf8, true),
+                ],
+                [("foo".to_string(), "bar".to_string())]
+                    .iter()
+                    .cloned()
+                    .collect::<HashMap<String, String>>(),
+            ),
+        ])?;
+
+        assert_eq!(
+            merged,
+            Schema::new_with_metadata(
+                vec![
+                    Field::new("first_name", DataType::Utf8, false),
+                    Field::new("last_name", DataType::Utf8, true),
+                    Field::new(
+                        "address",
+                        DataType::Struct(vec![
+                            Field::new("zip", DataType::UInt16, true),
+                            Field::new("street", DataType::Utf8, false),
+                        ]),
+                        false,
+                    ),
+                    Field::new("number", DataType::Utf8, true),
+                ],
+                [("foo".to_string(), "bar".to_string())]
+                    .iter()
+                    .cloned()
+                    .collect::<HashMap<String, String>>()
+            )
+        );
+
+        // support merge union fields
+        assert_eq!(
+            Schema::try_merge(&vec![
+                Schema::new(vec![Field::new(
+                    "c1",
+                    DataType::Union(vec![
+                        Field::new("c11", DataType::Utf8, true),
+                        Field::new("c12", DataType::Utf8, true),
+                    ]),
+                    false
+                ),]),
+                Schema::new(vec![Field::new(
+                    "c1",
+                    DataType::Union(vec![
+                        Field::new("c12", DataType::Utf8, true),
+                        Field::new("c13", DataType::Time64(TimeUnit::Second), true),
+                    ]),
+                    false
+                ),])
+            ])?,
+            Schema::new(vec![Field::new(
+                "c1",
+                DataType::Union(vec![
+                    Field::new("c11", DataType::Utf8, true),
+                    Field::new("c12", DataType::Utf8, true),
+                    Field::new("c13", DataType::Time64(TimeUnit::Second), true),
+                ]),
+                false
+            ),]),
+        );
+
+        // incompatible field should throw error
+        assert!(Schema::try_merge(&vec![
+            Schema::new(vec![
+                Field::new("first_name", DataType::Utf8, false),
+                Field::new("last_name", DataType::Utf8, false),
+            ]),
+            Schema::new(vec![Field::new("last_name", DataType::Int64, false),]),
+        ])
+        .is_err());
+
+        // incompatible metadata should throw error
+        assert!(Schema::try_merge(&vec![
+            Schema::new_with_metadata(
+                vec![Field::new("first_name", DataType::Utf8, false)],
+                [("foo".to_string(), "bar".to_string()),]
+                    .iter()
+                    .cloned()
+                    .collect::<HashMap<String, String>>()
+            ),
+            Schema::new_with_metadata(
+                vec![Field::new("last_name", DataType::Utf8, false)],
+                [("foo".to_string(), "baz".to_string()),]
+                    .iter()
+                    .cloned()
+                    .collect::<HashMap<String, String>>()
+            ),
+        ])
+        .is_err());
+
+        Ok(())
     }
 }

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -26,6 +26,7 @@ use csv as csv_crate;
 pub enum ArrowError {
     MemoryError(String),
     ParseError(String),
+    SchemaError(String),
     ComputeError(String),
     DivideByZero,
     CsvError(String),
@@ -73,6 +74,7 @@ impl Display for ArrowError {
         match *self {
             ArrowError::MemoryError(ref desc) => write!(f, "Memory error: {}", desc),
             ArrowError::ParseError(ref desc) => write!(f, "Parser error: {}", desc),
+            ArrowError::SchemaError(ref desc) => write!(f, "Schema error: {}", desc),
             ArrowError::ComputeError(ref desc) => write!(f, "Compute error: {}", desc),
             ArrowError::DivideByZero => write!(f, "Divide by zero error"),
             ArrowError::CsvError(ref desc) => write!(f, "Csv error: {}", desc),

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -18,7 +18,6 @@
 //! Execution plan for reading CSV files
 
 use std::fs::File;
-use std::io::BufReader;
 use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};
@@ -139,10 +138,8 @@ impl CsvExec {
             return Err(ExecutionError::General("No files found".to_string()));
         }
 
-        let f = File::open(&filenames[0])?;
-
-        Ok(csv::infer_file_schema(
-            &mut BufReader::new(f),
+        Ok(csv::infer_schema_from_files(
+            &filenames,
             options.delimiter,
             Some(options.schema_infer_max_records),
             options.has_header,


### PR DESCRIPTION
This change adds `infer_schema_from_files` function to arrow csv reader module. Datafusion's `CsvExec` struct is now using this function to do schema inference from multiple CSV files if needed.

Second follow up PR for #7210.