### PR TITLE
ARROW-8914: [C++] Keep BasicDecimal128 in native-endian order

### DIFF
--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1501,7 +1501,7 @@ static const uint8_t data_buffer2[] = "abcdefghijklmnopqrstuvwxyz";
 #if ARROW_LITTLE_ENDIAN
 static const uint64_t data_buffer3[] = {123456789, 0, 987654321, 0};
 #else
-static const uint64_t data_buffer3[] = {0x15cd5b0700000000, 0, 0xb168de3a00000000, 0};
+static const uint64_t data_buffer3[] = {0, 123456789, 0, 987654321};
 #endif
 static const uint8_t data_buffer4[] = {1, 2, 0, 1, 3, 0};
 static const float data_buffer5[] = {0.0f, 1.5f, -2.0f, 3.0f, 4.0f, 5.0f};

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -128,8 +128,13 @@ static constexpr BasicDecimal128 kMaxValue =
 
 BasicDecimal128::BasicDecimal128(const uint8_t* bytes)
     : BasicDecimal128(
-          BitUtil::FromLittleEndian(reinterpret_cast<const int64_t*>(bytes)[1]),
-          BitUtil::FromLittleEndian(reinterpret_cast<const uint64_t*>(bytes)[0])) {}
+#if ARROW_LITTLE_ENDIAN
+          reinterpret_cast<const int64_t*>(bytes)[1],
+          reinterpret_cast<const uint64_t*>(bytes)[0]) {}
+#else
+          reinterpret_cast<const int64_t*>(bytes)[0],
+          reinterpret_cast<const uint64_t*>(bytes)[1]) {}
+#endif
 
 std::array<uint8_t, 16> BasicDecimal128::ToBytes() const {
   std::array<uint8_t, 16> out{{0}};
@@ -139,8 +144,13 @@ std::array<uint8_t, 16> BasicDecimal128::ToBytes() const {
 
 void BasicDecimal128::ToBytes(uint8_t* out) const {
   DCHECK_NE(out, nullptr);
-  reinterpret_cast<uint64_t*>(out)[0] = BitUtil::ToLittleEndian(low_bits_);
-  reinterpret_cast<int64_t*>(out)[1] = BitUtil::ToLittleEndian(high_bits_);
+#if ARROW_LITTLE_ENDIAN
+  reinterpret_cast<uint64_t*>(out)[0] = low_bits_;
+  reinterpret_cast<int64_t*>(out)[1] = high_bits_;
+#else
+  reinterpret_cast<int64_t*>(out)[0] = high_bits_;
+  reinterpret_cast<uint64_t*>(out)[1] = low_bits_;
+#endif
 }
 
 BasicDecimal128& BasicDecimal128::Negate() {

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -126,12 +126,14 @@ static constexpr auto kCarryBit = static_cast<uint64_t>(1) << static_cast<uint64
 static constexpr BasicDecimal128 kMaxValue =
     BasicDecimal128(5421010862427522170LL, 687399551400673280ULL - 1);
 
+#if ARROW_LITTLE_ENDIAN
 BasicDecimal128::BasicDecimal128(const uint8_t* bytes)
     : BasicDecimal128(
-#if ARROW_LITTLE_ENDIAN
           reinterpret_cast<const int64_t*>(bytes)[1],
           reinterpret_cast<const uint64_t*>(bytes)[0]) {}
 #else
+BasicDecimal128::BasicDecimal128(const uint8_t* bytes)
+    : BasicDecimal128(
           reinterpret_cast<const int64_t*>(bytes)[0],
           reinterpret_cast<const uint64_t*>(bytes)[1]) {}
 #endif

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -128,14 +128,12 @@ static constexpr BasicDecimal128 kMaxValue =
 
 #if ARROW_LITTLE_ENDIAN
 BasicDecimal128::BasicDecimal128(const uint8_t* bytes)
-    : BasicDecimal128(
-          reinterpret_cast<const int64_t*>(bytes)[1],
-          reinterpret_cast<const uint64_t*>(bytes)[0]) {}
+    : BasicDecimal128(reinterpret_cast<const int64_t*>(bytes)[1],
+                      reinterpret_cast<const uint64_t*>(bytes)[0]) {}
 #else
 BasicDecimal128::BasicDecimal128(const uint8_t* bytes)
-    : BasicDecimal128(
-          reinterpret_cast<const int64_t*>(bytes)[0],
-          reinterpret_cast<const uint64_t*>(bytes)[1]) {}
+    : BasicDecimal128(reinterpret_cast<const int64_t*>(bytes)[0],
+                      reinterpret_cast<const uint64_t*>(bytes)[1]) {}
 #endif
 
 std::array<uint8_t, 16> BasicDecimal128::ToBytes() const {

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -57,7 +57,7 @@ class ARROW_EXPORT BasicDecimal128 {
                         static_cast<uint64_t>(value)) {}
 
   /// \brief Create a BasicDecimal128 from an array of bytes. Bytes are assumed to be in
-  /// little-endian byte order.
+  /// native-endian byte order.
   explicit BasicDecimal128(const uint8_t* bytes);
 
   /// \brief Negate the current value (in-place)
@@ -113,7 +113,7 @@ class ARROW_EXPORT BasicDecimal128 {
   /// \brief Get the low bits of the two's complement representation of the number.
   inline uint64_t low_bits() const { return low_bits_; }
 
-  /// \brief Return the raw bytes of the value in little-endian byte order.
+  /// \brief Return the raw bytes of the value in native-endian byte order.
   std::array<uint8_t, 16> ToBytes() const;
   void ToBytes(uint8_t* out) const;
 


### PR DESCRIPTION
This PR changes to keep BasicDecimal128 in native-endian order instead of little-endian order.

There are two rationales.
1. In 2017, Decimal128 is defined as [little-endian order](https://github.com/apache/arrow/commit/b2596f66ac2a8aa66da81c1f75c36fa30c40d0df). Now, an endianness relies on [this flag](https://github.com/apache/arrow/blob/master/docs/source/format/Columnar.rst#byte-order-endianness).

2. Generated code by Gandiva processes a computation with native-endian. The generated code uses `int128` generated by `ToBytes` for `Decimal128`.