### PR TITLE
ARROW-8923: [C++] Improve usability of arrow::compute::CallFunction

### DIFF
--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -64,6 +64,5 @@ add_arrow_compute_test(internals_test
                        exec_test.cc
                        kernel_test.cc
                        registry_test.cc)
-add_arrow_compute_test(exec_test)
 
 add_subdirectory(kernels)

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -26,19 +26,19 @@ namespace compute {
 // Scalar aggregates
 
 Result<Datum> Count(const Datum& value, CountOptions options, ExecContext* ctx) {
-  return CallFunction(ctx, "count", {value}, &options);
+  return CallFunction("count", {value}, &options, ctx);
 }
 
 Result<Datum> Mean(const Datum& value, ExecContext* ctx) {
-  return CallFunction(ctx, "mean", {value});
+  return CallFunction("mean", {value}, ctx);
 }
 
 Result<Datum> Sum(const Datum& value, ExecContext* ctx) {
-  return CallFunction(ctx, "sum", {value});
+  return CallFunction("sum", {value}, ctx);
 }
 
 Result<Datum> MinMax(const Datum& value, const MinMaxOptions& options, ExecContext* ctx) {
-  return CallFunction(ctx, "minmax", {value}, &options);
+  return CallFunction("minmax", {value}, &options, ctx);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -28,12 +28,12 @@ namespace compute {
 
 #define SCALAR_EAGER_UNARY(NAME, REGISTRY_NAME)              \
   Result<Datum> NAME(const Datum& value, ExecContext* ctx) { \
-    return CallFunction(ctx, REGISTRY_NAME, {value});        \
+    return CallFunction(REGISTRY_NAME, {value}, ctx);        \
   }
 
 #define SCALAR_EAGER_BINARY(NAME, REGISTRY_NAME)                                \
   Result<Datum> NAME(const Datum& left, const Datum& right, ExecContext* ctx) { \
-    return CallFunction(ctx, REGISTRY_NAME, {left, right});                     \
+    return CallFunction(REGISTRY_NAME, {left, right}, ctx);                     \
   }
 
 // ----------------------------------------------------------------------
@@ -58,7 +58,7 @@ static Result<Datum> ExecSetLookup(const std::string& func_name, const Datum& da
     return Status::Invalid(ss.str());
   }
   SetLookupOptions options(value_set, !add_nulls_to_hash_table);
-  return CallFunction(ctx, func_name, {data}, &options);
+  return CallFunction(func_name, {data}, &options, ctx);
 }
 
 Result<Datum> IsIn(const Datum& values, const Datum& value_set, ExecContext* ctx) {
@@ -106,7 +106,7 @@ Result<Datum> Compare(const Datum& left, const Datum& right, CompareOptions opti
       func_name = "less_equal";
       break;
   }
-  return CallFunction(ctx, func_name, {left, right}, &options);
+  return CallFunction(func_name, {left, right}, &options, ctx);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -37,27 +37,27 @@ Result<std::shared_ptr<Array>> NthToIndices(const Array& values, int64_t n,
                                             ExecContext* ctx) {
   PartitionOptions options(/*pivot=*/n);
   ARROW_ASSIGN_OR_RAISE(
-      Datum result, CallFunction(ctx, "partition_indices", {Datum(values)}, &options));
+      Datum result, CallFunction("partition_indices", {Datum(values)}, &options, ctx));
   return result.make_array();
 }
 
 Result<std::shared_ptr<Array>> SortToIndices(const Array& values, ExecContext* ctx) {
-  ARROW_ASSIGN_OR_RAISE(Datum result, CallFunction(ctx, "sort_indices", {Datum(values)}));
+  ARROW_ASSIGN_OR_RAISE(Datum result, CallFunction("sort_indices", {Datum(values)}, ctx));
   return result.make_array();
 }
 
 Result<Datum> Take(const Datum& values, const Datum& indices, const TakeOptions& options,
                    ExecContext* ctx) {
-  return CallFunction(ctx, "take", {values, indices}, &options);
+  return CallFunction("take", {values, indices}, &options, ctx);
 }
 
 Result<std::shared_ptr<Array>> Unique(const Datum& value, ExecContext* ctx) {
-  ARROW_ASSIGN_OR_RAISE(Datum result, CallFunction(ctx, "unique", {value}));
+  ARROW_ASSIGN_OR_RAISE(Datum result, CallFunction("unique", {value}, ctx));
   return result.make_array();
 }
 
 Result<Datum> DictionaryEncode(const Datum& value, ExecContext* ctx) {
-  return CallFunction(ctx, "dictionary_encode", {value});
+  return CallFunction("dictionary_encode", {value}, ctx);
 }
 
 const char kValuesFieldName[] = "values";
@@ -66,7 +66,7 @@ const int32_t kValuesFieldIndex = 0;
 const int32_t kCountsFieldIndex = 1;
 
 Result<std::shared_ptr<Array>> ValueCounts(const Datum& value, ExecContext* ctx) {
-  ARROW_ASSIGN_OR_RAISE(Datum result, CallFunction(ctx, "value_counts", {value}));
+  ARROW_ASSIGN_OR_RAISE(Datum result, CallFunction("value_counts", {value}, ctx));
   return result.make_array();
 }
 
@@ -122,7 +122,7 @@ Result<Datum> Filter(const Datum& values, const Datum& filter, FilterOptions opt
                           FilterTable(*values.table(), filter, options, ctx));
     return Datum(out_table);
   } else {
-    return CallFunction(ctx, "filter", {values, filter}, &options);
+    return CallFunction("filter", {values, filter}, &options, ctx);
   }
 }
 

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -926,16 +926,20 @@ Result<std::shared_ptr<SelectionVector>> SelectionVector::FromMask(
   return Status::NotImplemented("FromMask");
 }
 
-Result<Datum> CallFunction(ExecContext* ctx, const std::string& func_name,
-                           const std::vector<Datum>& args,
-                           const FunctionOptions* options) {
+Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,
+                           const FunctionOptions* options, ExecContext* ctx) {
   if (ctx == nullptr) {
     ExecContext default_ctx;
-    return CallFunction(&default_ctx, func_name, args, options);
+    return CallFunction(func_name, args, options, &default_ctx);
   }
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<const Function> func,
                         ctx->func_registry()->GetFunction(func_name));
   return func->Execute(args, options, ctx);
+}
+
+Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,
+                           ExecContext* ctx) {
+  return CallFunction(func_name, args, /*options=*/nullptr, ctx);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec.h
+++ b/cpp/src/arrow/compute/exec.h
@@ -175,9 +175,13 @@ struct ExecBatch {
 /// argument checking, iteration of ChunkedArray inputs, and wrapping of
 /// outputs
 ARROW_EXPORT
-Result<Datum> CallFunction(ExecContext* ctx, const std::string& func_name,
-                           const std::vector<Datum>& args,
-                           const FunctionOptions* options = NULLPTR);
+Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,
+                           const FunctionOptions* options, ExecContext* ctx = NULLPTR);
+
+/// \brief Variant of CallFunction for functions not requiring options
+ARROW_EXPORT
+Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,
+                           ExecContext* ctx = NULLPTR);
 
 }  // namespace compute
 }  // namespace arrow


### PR DESCRIPTION
This removes the burden of constructing an `ExecContext` in cases where you are OK with the default options