### PR TITLE
ARROW-8924: [C++][Gandiva] Avoid potential int overflow in castDATE_date32()

### DIFF
--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -458,7 +458,9 @@ FORCE_INLINE
 gdv_date32 castDATE_int32(gdv_int32 in) { return in; }
 
 FORCE_INLINE
-gdv_date64 castDATE_date32(gdv_date32 days) { return days * MILLIS_IN_DAY; }
+gdv_date64 castDATE_date32(gdv_date32 days) {
+  return days * static_cast<gdv_date64>(MILLIS_IN_DAY);
+}
 
 static int days_in_month[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 


### PR DESCRIPTION
This PR avoids the potential int overflow due to int32 multiplication in castDATE_date32().

In https://github.com/apache/arrow/blob/master/cpp/src/gandiva/precompiled/time.cc#L461, the following code performs the multiplication of two `int32`. The result is also `int32`. Then, the result is converted to `int64`.

This code may cause overflow if the result is more than 32-bit. To avoid the overflow, this PR pre-casts the constant to `int64`. As a result, the multiplication will become `int64` * `int64`.
```
gdv_date64 castDATE_date32(gdv_date32 days) { return days * MILLIS_IN_DAY; }
```

This can fix the following failure:
```
The following tests FAILED:
	 67 - gandiva-date-time-test (Failed)
```