### PR TITLE
ARROW-8927: [C++] Support dictionary memo in CUDA IPC ReadRecordBatch functions

### DIFF
--- a/cpp/src/arrow/gpu/cuda_arrow_ipc.cc
+++ b/cpp/src/arrow/gpu/cuda_arrow_ipc.cc
@@ -50,8 +50,8 @@ Result<std::shared_ptr<CudaBuffer>> SerializeRecordBatch(const RecordBatch& batc
 }
 
 Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
-    const std::shared_ptr<Schema>& schema, const std::shared_ptr<CudaBuffer>& buffer,
-    MemoryPool* pool) {
+    const std::shared_ptr<Schema>& schema, const ipc::DictionaryMemo* dictionary_memo,
+    const std::shared_ptr<CudaBuffer>& buffer, MemoryPool* pool) {
   CudaBufferReader cuda_reader(buffer);
 
   // The pool is only used for metadata allocation
@@ -61,8 +61,7 @@ Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
   }
 
   // Zero-copy read on device memory
-  ipc::DictionaryMemo unused_memo;
-  return ipc::ReadRecordBatch(*message, schema, &unused_memo,
+  return ipc::ReadRecordBatch(*message, schema, dictionary_memo,
                               ipc::IpcReadOptions::Defaults());
 }
 

--- a/cpp/src/arrow/gpu/cuda_arrow_ipc.h
+++ b/cpp/src/arrow/gpu/cuda_arrow_ipc.h
@@ -35,6 +35,7 @@ class Schema;
 namespace ipc {
 
 class Message;
+class DictionaryMemo;
 
 }  // namespace ipc
 
@@ -59,8 +60,8 @@ Result<std::shared_ptr<CudaBuffer>> SerializeRecordBatch(const RecordBatch& batc
 /// \return RecordBatch or Status
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatch>> ReadRecordBatch(
-    const std::shared_ptr<Schema>& schema, const std::shared_ptr<CudaBuffer>& buffer,
-    MemoryPool* pool = default_memory_pool());
+    const std::shared_ptr<Schema>& schema, const ipc::DictionaryMemo* dictionary_memo,
+    const std::shared_ptr<CudaBuffer>& buffer, MemoryPool* pool = default_memory_pool());
 
 /// @}
 

--- a/cpp/src/arrow/gpu/cuda_arrow_ipc.h
+++ b/cpp/src/arrow/gpu/cuda_arrow_ipc.h
@@ -55,6 +55,9 @@ Result<std::shared_ptr<CudaBuffer>> SerializeRecordBatch(const RecordBatch& batc
 
 /// \brief ReadRecordBatch specialized to handle metadata on CUDA device
 /// \param[in] schema the Schema for the record batch
+/// \param[in] dictionary_memo DictionaryMemo which has any
+/// dictionaries. Can be nullptr if you are sure there are no
+/// dictionary-encoded fields
 /// \param[in] buffer a CudaBuffer containing the complete IPC message
 /// \param[in] pool a MemoryPool to use for allocating space for the metadata
 /// \return RecordBatch or Status

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -572,8 +572,10 @@ TEST_F(TestCudaArrowIpc, BasicWriteRead) {
   ASSERT_OK_AND_ASSIGN(device_serialized, SerializeRecordBatch(*batch, context_.get()));
 
   // Test that ReadRecordBatch works properly
+  ipc::DictionaryMemo unused_memo;
   std::shared_ptr<RecordBatch> device_batch;
-  ASSERT_OK_AND_ASSIGN(device_batch, ReadRecordBatch(batch->schema(), device_serialized));
+  ASSERT_OK_AND_ASSIGN(device_batch,
+                       ReadRecordBatch(batch->schema(), &unused_memo, device_serialized));
 
   // Copy data from device, read batch, and compare
   int64_t size = device_serialized->size();
@@ -582,9 +584,37 @@ TEST_F(TestCudaArrowIpc, BasicWriteRead) {
 
   std::shared_ptr<RecordBatch> cpu_batch;
   io::BufferReader cpu_reader(std::move(host_buffer));
-  ipc::DictionaryMemo unused_memo;
   ASSERT_OK_AND_ASSIGN(
       cpu_batch, ipc::ReadRecordBatch(batch->schema(), &unused_memo,
+                                      ipc::IpcReadOptions::Defaults(), &cpu_reader));
+
+  CompareBatch(*batch, *cpu_batch);
+}
+
+TEST_F(TestCudaArrowIpc, DictionaryWriteRead) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(ipc::test::MakeDictionary(&batch));
+
+  ipc::DictionaryMemo dictionary_memo;
+  ASSERT_OK(ipc::CollectDictionaries(*batch, &dictionary_memo));
+
+  std::shared_ptr<CudaBuffer> device_serialized;
+  ASSERT_OK_AND_ASSIGN(device_serialized, SerializeRecordBatch(*batch, context_.get()));
+
+  // Test that ReadRecordBatch works properly
+  std::shared_ptr<RecordBatch> device_batch;
+  ASSERT_OK_AND_ASSIGN(device_batch, ReadRecordBatch(batch->schema(), &dictionary_memo,
+                                                     device_serialized));
+
+  // Copy data from device, read batch, and compare
+  int64_t size = device_serialized->size();
+  ASSERT_OK_AND_ASSIGN(auto host_buffer, AllocateBuffer(size, pool_));
+  ASSERT_OK(device_serialized->CopyToHost(0, size, host_buffer->mutable_data()));
+
+  std::shared_ptr<RecordBatch> cpu_batch;
+  io::BufferReader cpu_reader(std::move(host_buffer));
+  ASSERT_OK_AND_ASSIGN(
+      cpu_batch, ipc::ReadRecordBatch(batch->schema(), &dictionary_memo,
                                       ipc::IpcReadOptions::Defaults(), &cpu_reader));
 
   CompareBatch(*batch, *cpu_batch);

--- a/python/pyarrow/includes/libarrow_cuda.pxd
+++ b/python/pyarrow/includes/libarrow_cuda.pxd
@@ -102,5 +102,6 @@ cdef extern from "arrow/gpu/cuda_api.h" namespace "arrow::cuda" nogil:
     CResult[shared_ptr[CRecordBatch]] \
         CudaReadRecordBatch" arrow::cuda::ReadRecordBatch"\
         (const shared_ptr[CSchema]& schema,
+         CDictionaryMemo* dictionary_memo,
          const shared_ptr[CCudaBuffer]& buffer,
          CMemoryPool* pool)


### PR DESCRIPTION
Adds support for dictionary memo in `ReadRecordBatch` for CUDA IPC, passing the memo directly to the `ipc::ReadRecordBatch` function. This allows one to handle record batches with dictionaries, though it might be worth adding some tests around using `SerializeSchema` as well, so we can have the complete CPU + GPU IPC path in place -- let me know and I'd be happy to do so. 