### PR TITLE
ARROW-8931: [Rust] add lexical sort support to arrow compute kernel

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -81,7 +81,7 @@ pub trait Array: fmt::Debug + Send + Sync + ArrayEqual + JsonEqual {
     /// Returns a borrowed & reference-counted pointer to the underlying data of this array.
     fn data_ref(&self) -> &ArrayDataRef;
 
-    /// Returns a reference to the [`DataType`](crate::datatype::DataType) of this array.
+    /// Returns a reference to the [`DataType`](crate::datatypes::DataType) of this array.
     ///
     /// # Example:
     ///

--- a/rust/arrow/src/array/cast.rs
+++ b/rust/arrow/src/array/cast.rs
@@ -1,0 +1,53 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines helper functions for force Array type downcast
+
+use crate::array::*;
+use crate::datatypes::*;
+
+/// Force downcast ArrayRef to PrimitiveArray<T>
+pub fn as_primitive_array<T>(arr: &ArrayRef) -> &PrimitiveArray<T>
+where
+    T: ArrowPrimitiveType,
+{
+    arr.as_any()
+        .downcast_ref::<PrimitiveArray<T>>()
+        .expect("Unable to downcast to primitive array")
+}
+
+macro_rules! array_downcast_fn {
+    ($name: ident, $arrty: ty, $arrty_str:expr) => {
+        #[doc = "Force downcast ArrayRef to "]
+        #[doc = $arrty_str]
+        pub fn $name(arr: &ArrayRef) -> &$arrty {
+            arr.as_any().downcast_ref::<$arrty>().expect(concat!(
+                "Unable to downcast to typed array through ",
+                stringify!($name)
+            ))
+        }
+    };
+
+    // use recursive macro to generate dynamic doc string for a given array type
+    ($name: ident, $arrty: ty) => {
+        array_downcast_fn!($name, $arrty, stringify!($arrty));
+    };
+}
+
+array_downcast_fn!(as_string_array, StringArray);
+array_downcast_fn!(as_boolean_array, BooleanArray);
+array_downcast_fn!(as_null_array, NullArray);

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -83,9 +83,11 @@
 
 mod array;
 mod builder;
+mod cast;
 mod data;
 mod equal;
 mod null;
+mod ord;
 mod union;
 
 use crate::datatypes::*;
@@ -231,3 +233,13 @@ pub type DurationNanosecondBuilder = PrimitiveBuilder<DurationNanosecondType>;
 
 pub use self::equal::ArrayEqual;
 pub use self::equal::JsonEqual;
+
+// --------------------- Sortable Array ---------------------
+
+pub use self::ord::{as_ordarray, OrdArray};
+
+// --------------------- Array downcast helper functions ---------------------
+
+pub use self::cast::{
+    as_boolean_array, as_null_array, as_primitive_array, as_string_array,
+};

--- a/rust/arrow/src/array/ord.rs
+++ b/rust/arrow/src/array/ord.rs
@@ -1,0 +1,134 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines trait for array element comparison
+
+use std::cmp::Ordering;
+
+use crate::array::*;
+use crate::datatypes::*;
+use crate::error::{ArrowError, Result};
+
+use TimeUnit::*;
+
+/// Trait for Arrays that can be sorted
+///
+/// Example:
+/// ```
+/// use std::cmp::Ordering;
+/// use arrow::array::*;
+/// use arrow::datatypes::*;
+///
+/// let arr: Box<dyn OrdArray> = Box::new(PrimitiveArray::<Int64Type>::from(vec![
+///     Some(-2),
+///     Some(89),
+///     Some(-64),
+///     Some(101),
+/// ]));
+///
+/// assert_eq!(arr.cmp_value(1, 2), Ordering::Greater);
+/// ```
+pub trait OrdArray: Array {
+    /// Return ordering between array element at index i and j
+    fn cmp_value(&self, i: usize, j: usize) -> Ordering;
+}
+
+impl<T: ArrowPrimitiveType> OrdArray for PrimitiveArray<T>
+where
+    T::Native: std::cmp::Ord,
+{
+    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
+        self.value(i).cmp(&self.value(j))
+    }
+}
+
+impl OrdArray for StringArray {
+    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
+        self.value(i).cmp(self.value(j))
+    }
+}
+
+impl OrdArray for NullArray {
+    fn cmp_value(&self, _i: usize, _j: usize) -> Ordering {
+        Ordering::Equal
+    }
+}
+
+/// Convert ArrayRef to OrdArray trait object
+pub fn as_ordarray(values: &ArrayRef) -> Result<Box<&OrdArray>> {
+    match values.data_type() {
+        DataType::Boolean => Ok(Box::new(as_boolean_array(&values))),
+        DataType::Utf8 => Ok(Box::new(as_string_array(&values))),
+        DataType::Null => Ok(Box::new(as_null_array(&values))),
+        DataType::Int8 => Ok(Box::new(as_primitive_array::<Int8Type>(&values))),
+        DataType::Int16 => Ok(Box::new(as_primitive_array::<Int16Type>(&values))),
+        DataType::Int32 => Ok(Box::new(as_primitive_array::<Int32Type>(&values))),
+        DataType::Int64 => Ok(Box::new(as_primitive_array::<Int64Type>(&values))),
+        DataType::UInt8 => Ok(Box::new(as_primitive_array::<UInt8Type>(&values))),
+        DataType::UInt16 => Ok(Box::new(as_primitive_array::<UInt16Type>(&values))),
+        DataType::UInt32 => Ok(Box::new(as_primitive_array::<UInt32Type>(&values))),
+        DataType::UInt64 => Ok(Box::new(as_primitive_array::<UInt64Type>(&values))),
+        DataType::Date32(_) => Ok(Box::new(as_primitive_array::<Date32Type>(&values))),
+        DataType::Date64(_) => Ok(Box::new(as_primitive_array::<Date64Type>(&values))),
+        DataType::Time32(Second) => {
+            Ok(Box::new(as_primitive_array::<Time32SecondType>(&values)))
+        }
+        DataType::Time32(Millisecond) => Ok(Box::new(as_primitive_array::<
+            Time32MillisecondType,
+        >(&values))),
+        DataType::Time64(Microsecond) => Ok(Box::new(as_primitive_array::<
+            Time64MicrosecondType,
+        >(&values))),
+        DataType::Time64(Nanosecond) => Ok(Box::new(as_primitive_array::<
+            Time64NanosecondType,
+        >(&values))),
+        DataType::Timestamp(Second, _) => {
+            Ok(Box::new(as_primitive_array::<TimestampSecondType>(&values)))
+        }
+        DataType::Timestamp(Millisecond, _) => Ok(Box::new(as_primitive_array::<
+            TimestampMillisecondType,
+        >(&values))),
+        DataType::Timestamp(Microsecond, _) => Ok(Box::new(as_primitive_array::<
+            TimestampMicrosecondType,
+        >(&values))),
+        DataType::Timestamp(Nanosecond, _) => Ok(Box::new(as_primitive_array::<
+            TimestampNanosecondType,
+        >(&values))),
+        DataType::Interval(IntervalUnit::YearMonth) => Ok(Box::new(
+            as_primitive_array::<IntervalYearMonthType>(&values),
+        )),
+        DataType::Interval(IntervalUnit::DayTime) => {
+            Ok(Box::new(as_primitive_array::<IntervalDayTimeType>(&values)))
+        }
+        DataType::Duration(TimeUnit::Second) => {
+            Ok(Box::new(as_primitive_array::<DurationSecondType>(&values)))
+        }
+        DataType::Duration(TimeUnit::Millisecond) => Ok(Box::new(as_primitive_array::<
+            DurationMillisecondType,
+        >(&values))),
+        DataType::Duration(TimeUnit::Microsecond) => Ok(Box::new(as_primitive_array::<
+            DurationMicrosecondType,
+        >(&values))),
+        DataType::Duration(TimeUnit::Nanosecond) => Ok(Box::new(as_primitive_array::<
+            DurationNanosecondType,
+        >(&values))),
+        t => Err(ArrowError::ComputeError(format!(
+            "Lexical Sort not supported for data type {:?}",
+            t
+        ))),
+    }
+}

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -17,7 +17,7 @@
 
 //! Defines sort kernel for `ArrayRef`
 
-use std::cmp::Reverse;
+use std::cmp::{Ordering, Reverse};
 
 use crate::array::*;
 use crate::compute::take;
@@ -31,7 +31,7 @@ use TimeUnit::*;
 /// Performs a stable sort on values and indices, returning nulls after sorted valid values,
 /// while preserving the order of the nulls.
 ///
-/// Returns and `ArrowError::ComputeError(String)` if the array type is either unsupported by `sort_to_indices` or `take`.
+/// Returns an `ArrowError::ComputeError(String)` if the array type is either unsupported by `sort_to_indices` or `take`.
 pub fn sort(values: &ArrayRef, options: Option<SortOptions>) -> Result<ArrayRef> {
     let indices = sort_to_indices(values, options)?;
     take(values, &indices, None)
@@ -110,12 +110,12 @@ pub fn sort_to_indices(
 }
 
 /// Options that define how sort kernels should behave
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct SortOptions {
     /// Whether to sort in descending order
-    descending: bool,
+    pub descending: bool,
     /// Whether to sort nulls first
-    nulls_first: bool,
+    pub nulls_first: bool,
 }
 
 impl Default for SortOptions {
@@ -138,10 +138,7 @@ where
     T: ArrowPrimitiveType,
     T::Native: std::cmp::Ord,
 {
-    let values = values
-        .as_any()
-        .downcast_ref::<PrimitiveArray<T>>()
-        .expect("Unable to downcast to primitive array");
+    let values = as_primitive_array::<T>(values);
     // create tuples that are used for sorting
     let mut valids = value_indices
         .into_iter()
@@ -174,10 +171,7 @@ fn sort_string(
     null_indices: Vec<u32>,
     options: &SortOptions,
 ) -> Result<UInt32Array> {
-    let values = values
-        .as_any()
-        .downcast_ref::<StringArray>()
-        .expect("Unable to downcast to string array");
+    let values = as_string_array(values);
     let mut valids = value_indices
         .into_iter()
         .map(|index| (index as u32, values.value(index)))
@@ -201,6 +195,154 @@ fn sort_string(
     valid_indices.append(&mut nulls);
 
     Ok(UInt32Array::from(valid_indices))
+}
+
+/// One column to be used in lexicographical sort
+#[derive(Clone)]
+pub struct SortColumn {
+    pub values: ArrayRef,
+    pub options: Option<SortOptions>,
+}
+
+/// Sort a list of `ArrayRef` using `SortOptions` provided for each array.
+///
+/// Performs a stable lexicographical sort on values and indices.
+///
+/// Returns an `ArrowError::ComputeError(String)` if any of the array type is either unsupported by
+/// `lexsort_to_indices` or `take`.
+///
+/// Example:
+///
+/// ```
+/// use std::convert::TryFrom;
+/// use std::sync::Arc;
+/// use arrow::array::{ArrayRef, StringArray, PrimitiveArray, as_primitive_array};
+/// use arrow::compute::kernels::sort::{SortColumn, SortOptions, lexsort};
+/// use arrow::datatypes::Int64Type;
+///
+/// let sorted_columns = lexsort(&vec![
+///     SortColumn {
+///         values: Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+///             None,
+///             Some(-2),
+///             Some(89),
+///             Some(-64),
+///             Some(101),
+///         ])) as ArrayRef,
+///         options: None,
+///     },
+///     SortColumn {
+///         values: Arc::new(StringArray::try_from(vec![
+///             Some("hello"),
+///             Some("world"),
+///             Some(","),
+///             Some("foobar"),
+///             Some("!"),
+///         ]).unwrap()) as ArrayRef,
+///         options: Some(SortOptions {
+///             descending: true,
+///             nulls_first: false,
+///         }),
+///     },
+/// ]).unwrap();
+///
+/// assert_eq!(as_primitive_array::<Int64Type>(&sorted_columns[0]).value(0), -64);
+/// assert!(sorted_columns[0].is_null(4));
+/// ```
+pub fn lexsort(columns: &Vec<SortColumn>) -> Result<Vec<ArrayRef>> {
+    let indices = lexsort_to_indices(columns)?;
+    columns
+        .iter()
+        .map(|c| take(&c.values, &indices, None))
+        .collect()
+}
+
+/// Sort elements lexicographically from a list of `ArrayRef` into an unsigned integer
+/// (`UInt32Array`) of indices.
+pub fn lexsort_to_indices(columns: &Vec<SortColumn>) -> Result<UInt32Array> {
+    if columns.len() == 1 {
+        // fallback to non-lexical sort
+        let column = &columns[0];
+        return sort_to_indices(&column.values, column.options);
+    }
+
+    let mut row_count = None;
+    // convert ArrayRefs to OrdArray trait objects and perform row count check
+    let flat_columns = columns
+        .iter()
+        .map(|column| -> Result<(Box<&OrdArray>, SortOptions)> {
+            // row count check
+            let curr_row_count = column.values.len() - column.values.offset();
+            match row_count {
+                None => {
+                    row_count = Some(curr_row_count);
+                }
+                Some(cnt) => {
+                    if curr_row_count != cnt {
+                        return Err(ArrowError::ComputeError(
+                            "lexical sort columns have different row counts".to_string(),
+                        ));
+                    }
+                }
+            }
+            // flatten and convert to OrdArray
+            Ok((
+                as_ordarray(&column.values)?,
+                column.options.unwrap_or_default(),
+            ))
+        })
+        .collect::<Result<Vec<(Box<&OrdArray>, SortOptions)>>>()?;
+
+    let lex_comparator = |a_idx: &usize, b_idx: &usize| -> Ordering {
+        for column in flat_columns.iter() {
+            let values = &column.0;
+            let sort_option = column.1;
+
+            match (values.is_valid(*a_idx), values.is_valid(*b_idx)) {
+                (true, true) => {
+                    match values.cmp_value(*a_idx, *b_idx) {
+                        // equal, move on to next column
+                        Ordering::Equal => continue,
+                        order @ _ => {
+                            if sort_option.descending {
+                                return order.reverse();
+                            } else {
+                                return order;
+                            }
+                        }
+                    }
+                }
+                (false, true) => {
+                    return if sort_option.nulls_first {
+                        Ordering::Less
+                    } else {
+                        Ordering::Greater
+                    };
+                }
+                (true, false) => {
+                    return if sort_option.nulls_first {
+                        Ordering::Greater
+                    } else {
+                        Ordering::Less
+                    };
+                }
+                // equal, move on to next column
+                (false, false) => continue,
+            }
+        }
+
+        Ordering::Equal
+    };
+
+    let mut value_indices = (0..row_count.unwrap()).collect::<Vec<usize>>();
+    value_indices.sort_by(lex_comparator);
+
+    Ok(UInt32Array::from(
+        value_indices
+            .into_iter()
+            .map(|i| i as u32)
+            .collect::<Vec<u32>>(),
+    ))
 }
 
 #[cfg(test)]
@@ -259,6 +401,26 @@ mod tests {
         let output = sort(&(Arc::new(output) as ArrayRef), options).unwrap();
         let output = output.as_any().downcast_ref::<StringArray>().unwrap();
         assert!(output.equals(&expected))
+    }
+
+    fn test_lex_sort_arrays(input: Vec<SortColumn>, expected_output: Vec<ArrayRef>) {
+        let sorted = lexsort(&input).unwrap();
+        let sorted2cmp = sorted.iter().map(|arr| -> Box<&dyn ArrayEqual> {
+            match arr.data_type() {
+                DataType::Int64 => Box::new(as_primitive_array::<Int64Type>(&arr)),
+                DataType::UInt32 => Box::new(as_primitive_array::<UInt32Type>(&arr)),
+                DataType::Utf8 => Box::new(as_string_array(&arr)),
+                _ => panic!("unexpected array type"),
+            }
+        });
+        for (i, values) in sorted2cmp.enumerate() {
+            assert!(
+                values.equals(&(*expected_output[i])),
+                "expect {:#?} to be: {:#?}",
+                sorted,
+                expected_output
+            );
+        }
     }
 
     #[test]
@@ -667,5 +829,301 @@ mod tests {
                 Some("-ad"),
             ],
         );
+    }
+
+    #[test]
+    fn test_lex_sort_single_column() {
+        let input = vec![SortColumn {
+            values: Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(17),
+                Some(2),
+                Some(-1),
+                Some(0),
+            ])) as ArrayRef,
+            options: None,
+        }];
+        let expected = vec![Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+            Some(-1),
+            Some(0),
+            Some(2),
+            Some(17),
+        ])) as ArrayRef];
+        test_lex_sort_arrays(input, expected);
+    }
+
+    #[test]
+    fn test_lex_sort_unaligned_rows() {
+        let input = vec![
+            SortColumn {
+                values: Arc::new(PrimitiveArray::<Int64Type>::from(vec![None, Some(-1)]))
+                    as ArrayRef,
+                options: None,
+            },
+            SortColumn {
+                values: Arc::new(
+                    StringArray::try_from(vec![Some("foo")])
+                        .expect("Unable to create string array"),
+                ) as ArrayRef,
+                options: None,
+            },
+        ];
+        assert!(
+            lexsort(&input).is_err(),
+            "lexsort should reject columns with different row counts"
+        );
+    }
+
+    #[test]
+    fn test_lex_sort_mixed_types() {
+        let input = vec![
+            SortColumn {
+                values: Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                    Some(0),
+                    Some(2),
+                    Some(-1),
+                    Some(0),
+                ])) as ArrayRef,
+                options: None,
+            },
+            SortColumn {
+                values: Arc::new(PrimitiveArray::<UInt32Type>::from(vec![
+                    Some(101),
+                    Some(8),
+                    Some(7),
+                    Some(102),
+                ])) as ArrayRef,
+                options: None,
+            },
+            SortColumn {
+                values: Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                    Some(-1),
+                    Some(-2),
+                    Some(-3),
+                    Some(-4),
+                ])) as ArrayRef,
+                options: None,
+            },
+        ];
+        let expected = vec![
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(-1),
+                Some(0),
+                Some(0),
+                Some(2),
+            ])) as ArrayRef,
+            Arc::new(PrimitiveArray::<UInt32Type>::from(vec![
+                Some(7),
+                Some(101),
+                Some(102),
+                Some(8),
+            ])) as ArrayRef,
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(-3),
+                Some(-1),
+                Some(-4),
+                Some(-2),
+            ])) as ArrayRef,
+        ];
+        test_lex_sort_arrays(input, expected);
+
+        // test mix of string and in64 with option
+        let input = vec![
+            SortColumn {
+                values: Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                    Some(0),
+                    Some(2),
+                    Some(-1),
+                    Some(0),
+                ])) as ArrayRef,
+                options: Some(SortOptions {
+                    descending: true,
+                    nulls_first: true,
+                }),
+            },
+            SortColumn {
+                values: Arc::new(
+                    StringArray::try_from(vec![
+                        Some("foo"),
+                        Some("9"),
+                        Some("7"),
+                        Some("bar"),
+                    ])
+                    .expect("Unable to create string array"),
+                ) as ArrayRef,
+                options: Some(SortOptions {
+                    descending: true,
+                    nulls_first: true,
+                }),
+            },
+        ];
+        let expected = vec![
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(2),
+                Some(0),
+                Some(0),
+                Some(-1),
+            ])) as ArrayRef,
+            Arc::new(
+                StringArray::try_from(vec![
+                    Some("9"),
+                    Some("foo"),
+                    Some("bar"),
+                    Some("7"),
+                ])
+                .expect("Unable to create string array"),
+            ) as ArrayRef,
+        ];
+        test_lex_sort_arrays(input, expected);
+
+        // test sort with nulls first
+        let input = vec![
+            SortColumn {
+                values: Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                    None,
+                    Some(-1),
+                    Some(2),
+                    None,
+                ])) as ArrayRef,
+                options: Some(SortOptions {
+                    descending: true,
+                    nulls_first: true,
+                }),
+            },
+            SortColumn {
+                values: Arc::new(
+                    StringArray::try_from(vec![
+                        Some("foo"),
+                        Some("world"),
+                        Some("hello"),
+                        None,
+                    ])
+                    .expect("Unable to create string array"),
+                ) as ArrayRef,
+                options: Some(SortOptions {
+                    descending: true,
+                    nulls_first: true,
+                }),
+            },
+        ];
+        let expected = vec![
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                None,
+                None,
+                Some(2),
+                Some(-1),
+            ])) as ArrayRef,
+            Arc::new(
+                StringArray::try_from(vec![
+                    None,
+                    Some("foo"),
+                    Some("hello"),
+                    Some("world"),
+                ])
+                .expect("Unable to create string array"),
+            ) as ArrayRef,
+        ];
+        test_lex_sort_arrays(input, expected);
+
+        // test sort with nulls last
+        let input = vec![
+            SortColumn {
+                values: Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                    None,
+                    Some(-1),
+                    Some(2),
+                    None,
+                ])) as ArrayRef,
+                options: Some(SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                }),
+            },
+            SortColumn {
+                values: Arc::new(
+                    StringArray::try_from(vec![
+                        Some("foo"),
+                        Some("world"),
+                        Some("hello"),
+                        None,
+                    ])
+                    .expect("Unable to create string array"),
+                ) as ArrayRef,
+                options: Some(SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                }),
+            },
+        ];
+        let expected = vec![
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(2),
+                Some(-1),
+                None,
+                None,
+            ])) as ArrayRef,
+            Arc::new(
+                StringArray::try_from(vec![
+                    Some("hello"),
+                    Some("world"),
+                    Some("foo"),
+                    None,
+                ])
+                .expect("Unable to create string array"),
+            ) as ArrayRef,
+        ];
+        test_lex_sort_arrays(input, expected);
+
+        // test sort with opposite options
+        let input = vec![
+            SortColumn {
+                values: Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                    None,
+                    Some(-1),
+                    Some(2),
+                    Some(-1),
+                    None,
+                ])) as ArrayRef,
+                options: Some(SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                }),
+            },
+            SortColumn {
+                values: Arc::new(
+                    StringArray::try_from(vec![
+                        Some("foo"),
+                        Some("bar"),
+                        Some("world"),
+                        Some("hello"),
+                        None,
+                    ])
+                    .expect("Unable to create string array"),
+                ) as ArrayRef,
+                options: Some(SortOptions {
+                    descending: true,
+                    nulls_first: true,
+                }),
+            },
+        ];
+        let expected = vec![
+            Arc::new(PrimitiveArray::<Int64Type>::from(vec![
+                Some(-1),
+                Some(-1),
+                Some(2),
+                None,
+                None,
+            ])) as ArrayRef,
+            Arc::new(
+                StringArray::try_from(vec![
+                    Some("hello"),
+                    Some("bar"),
+                    Some("world"),
+                    None,
+                    Some("foo"),
+                ])
+                .expect("Unable to create string array"),
+            ) as ArrayRef,
+        ];
+        test_lex_sort_arrays(input, expected);
     }
 }

--- a/rust/arrow/src/compute/mod.rs
+++ b/rust/arrow/src/compute/mod.rs
@@ -28,5 +28,6 @@ pub use self::kernels::cast::*;
 pub use self::kernels::comparison::*;
 pub use self::kernels::filter::*;
 pub use self::kernels::limit::*;
+pub use self::kernels::sort::*;
 pub use self::kernels::take::*;
 pub use self::kernels::temporal::*;


### PR DESCRIPTION
In preparation for datafusion sort expression support.