### PR TITLE
ARROW-8932: [C++][CI] Fix link error at arrow-orc-adapter-test

### DIFF
--- a/cpp/src/arrow/adapters/orc/CMakeLists.txt
+++ b/cpp/src/arrow/adapters/orc/CMakeLists.txt
@@ -44,8 +44,8 @@ elseif(NOT MSVC)
   set(ORC_MIN_TEST_LIBS ${ORC_MIN_TEST_LIBS} pthread ${CMAKE_DL_LIBS})
 endif()
 
-set(ORC_STATIC_TEST_LINK_LIBS ${ARROW_LIBRARIES_FOR_STATIC_TESTS} ${ORC_MIN_TEST_LIBS}
-                              orc::liborc)
+set(ORC_STATIC_TEST_LINK_LIBS orc::liborc ${ARROW_LIBRARIES_FOR_STATIC_TESTS}
+                              ${ORC_MIN_TEST_LIBS})
 
 add_arrow_test(adapter_test
                PREFIX


### PR DESCRIPTION
This PR changes the orders of libraries at `arrow-orc-adapter-test` based on https://stackoverflow.com/questions/19901934/libpthread-so-0-error-adding-symbols-dso-missing-from-command-line.

The new order will be the library (`liborc.a`) that requests symbol, and then libraries that have requested symbols.