### PR TITLE
ARROW-8114: [Java][Integration] Enable custom_metadata integration test

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1522,7 +1522,6 @@ def get_generated_json_files(tempdir=None, flight=False):
 
         generate_custom_metadata_case()
         .skip_category('Go')
-        .skip_category('Java')
         .skip_category('JS')
         .skip_category('Rust'),
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/Field.java
@@ -20,6 +20,7 @@ package org.apache.arrow.vector.types.pojo;
 import static org.apache.arrow.util.Preconditions.checkNotNull;
 import static org.apache.arrow.vector.complex.BaseRepeatedValueVector.DATA_VECTOR_NAME;
 import static org.apache.arrow.vector.types.pojo.ArrowType.getTypeForField;
+import static org.apache.arrow.vector.types.pojo.Schema.convertMetadata;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -66,6 +67,16 @@ public class Field {
   private final FieldType fieldType;
   private final List<Field> children;
 
+  private Field(
+      String name,
+      boolean nullable,
+      ArrowType type,
+      DictionaryEncoding dictionary,
+      List<Field> children,
+      Map<String, String> metadata) {
+    this(name, new FieldType(nullable, type, dictionary, metadata), children);
+  }
+
   @JsonCreator
   private Field(
       @JsonProperty("name") String name,
@@ -73,8 +84,8 @@ public class Field {
       @JsonProperty("type") ArrowType type,
       @JsonProperty("dictionary") DictionaryEncoding dictionary,
       @JsonProperty("children") List<Field> children,
-      @JsonProperty("metadata") Map<String, String> metadata) {
-    this(name, new FieldType(nullable, type, dictionary, metadata), children);
+      @JsonProperty("metadata") List<Map<String, String>> metadata) {
+    this(name, new FieldType(nullable, type, dictionary, convertMetadata(metadata)), children);
   }
 
   private Field(String name, FieldType fieldType, List<Field> children, TypeLayout typeLayout) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowFile.java
@@ -740,7 +740,7 @@ public class TestArrowFile extends BaseFileTest {
     int numBlocksWritten = 0;
 
     try (IntVector vector = new IntVector("foo", allocator);) {
-      Schema schema = new Schema(Collections.singletonList(vector.getField()), null);
+      Schema schema = new Schema(Collections.singletonList(vector.getField()));
       try (FileOutputStream fileOutputStream = new FileOutputStream(file);
            VectorSchemaRoot root =
               new VectorSchemaRoot(schema, Collections.singletonList((FieldVector) vector), vector.getValueCount());

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowStream.java
@@ -62,7 +62,7 @@ public class TestArrowStream extends BaseFileTest {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
 
     try (IntVector vector = new IntVector("foo", allocator);) {
-      Schema schema = new Schema(Collections.singletonList(vector.getField()), null);
+      Schema schema = new Schema(Collections.singletonList(vector.getField()));
       try (VectorSchemaRoot root =
              new VectorSchemaRoot(schema, Collections.singletonList(vector), vector.getValueCount());
            ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(os));) {
@@ -129,7 +129,7 @@ public class TestArrowStream extends BaseFileTest {
     ByteArrayOutputStream os = new ByteArrayOutputStream();
 
     try (IntVector vector = new IntVector("foo", allocator);) {
-      Schema schema = new Schema(Collections.singletonList(vector.getField()), null);
+      Schema schema = new Schema(Collections.singletonList(vector.getField()));
       try (VectorSchemaRoot root =
              new VectorSchemaRoot(schema, Collections.singletonList(vector), vector.getValueCount());
            ArrowStreamWriter writer = new ArrowStreamWriter(root, null, Channels.newChannel(os));) {


### PR DESCRIPTION
This fixes custom metadata on the Java side by correcting the type used in JSON deserialisation