### PR TITLE
ARROW-8940: [Java] Fix the performance degradation of integration tests

### DIFF
--- a/java/memory/pom.xml
+++ b/java/memory/pom.xml
@@ -61,6 +61,7 @@
               <systemPropertyVariables>
                 <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
                 <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
+                <arrow.memory.debug.allocator>false</arrow.memory.debug.allocator>
                 <user.timezone>UTC</user.timezone>
               </systemPropertyVariables>
               <argLine></argLine>

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -42,10 +42,20 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   public static final String DEBUG_ALLOCATOR = "arrow.memory.debug.allocator";
   public static final int DEBUG_LOG_LENGTH = 6;
-  public static final boolean DEBUG = AssertionUtil.isAssertionsEnabled() ||
-      Boolean.parseBoolean(System.getProperty(DEBUG_ALLOCATOR, "false"));
+  public static final boolean DEBUG;
   private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(BaseAllocator.class);
   public static final Config DEFAULT_CONFIG = ImmutableConfig.builder().build();
+
+  static {
+    // the system property takes precedence.
+    String propValue = System.getProperty(DEBUG_ALLOCATOR);
+    if (propValue != null) {
+      DEBUG = Boolean.parseBoolean(propValue);
+    } else {
+      DEBUG = AssertionUtil.isAssertionsEnabled();
+    }
+    logger.info("Debug mode " + (DEBUG ? "enabled." : "disabled."));
+  }
 
   // Package exposed for sharing between AllocatorManger and BaseAllocator objects
   final String name;

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -403,7 +403,6 @@
             <systemPropertyVariables>
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
               <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
-              <arrow.vector.max_allocation_bytes>1048576</arrow.vector.max_allocation_bytes>
               <user.timezone>UTC</user.timezone>
             </systemPropertyVariables>
             <!-- Note: changing the below configuration might increase the max allocation size for a vector

--- a/java/vector/pom.xml
+++ b/java/vector/pom.xml
@@ -222,6 +222,7 @@
               <systemPropertyVariables>
                 <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
                 <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
+                <arrow.memory.debug.allocator>false</arrow.memory.debug.allocator>
                 <user.timezone>UTC</user.timezone>
               </systemPropertyVariables>
               <argLine></argLine>


### PR DESCRIPTION
In the past, we run integration tests from main methods, and recently, we have changed this to run them by the failsafe plugin.

This is a good change, but it also leads to significant performance degradation. In the past, it took about 10s to run ITTestLargeVector#testLargeDecimalVector, now it takes more than half an hour.

Our investigation shows that the problem was caused by calling HistoricalLog#recordEvent repeatedly. This method is called only when BaseAllocator#DEBUG is enabled. In a unit/integration test, the flag is enabled by default.

We solve the problem with the following steps:
1. We set system property to disable the BaseAllocator#DEBUG flag.
2. We change the logic so that the system property takes precedence over the AssertionUtil#isAssertionsEnabled method.

This makes the integration tests as fast as before.