### PR TITLE
ARROW-8947: [Java] MapWithOrdinal javadoc doesn't describe actual behaviour

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinalImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/MapWithOrdinalImpl.java
@@ -105,12 +105,18 @@ public class MapWithOrdinalImpl<K, V> implements MapWithOrdinal<K, V> {
     public V remove(Object key) {
       final Entry<Integer, V> oldPair = primary.remove(key);
       if (oldPair != null) {
-        final int lastOrdinal = secondary.size();
+        final int lastOrdinal = secondary.size() - 1;
         final V last = secondary.get(lastOrdinal);
         // normalize mappings so that all numbers until primary.size() is assigned
         // swap the last element with the deleted one
         secondary.put(oldPair.getKey(), last);
-        primary.put((K) key, new AbstractMap.SimpleImmutableEntry<>(oldPair.getKey(), last));
+        secondary.remove(lastOrdinal);
+        primary.entrySet()
+            .stream()
+            .filter(e -> e.getValue().getValue().equals(last))
+            .map(Entry::getKey)
+            .findFirst()
+            .ifPresent(lastKey -> primary.put(lastKey, new AbstractMap.SimpleImmutableEntry<>(oldPair.getKey(), last)));
       }
       return oldPair == null ? null : oldPair.getValue();
     }

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
@@ -113,9 +113,9 @@ public class TestPromotableWriter {
       Field childField1 = container.getField().getChildren().get(0).getChildren().get(0);
       Field childField2 = container.getField().getChildren().get(0).getChildren().get(1);
       assertEquals("Child field should be union type: " +
-          childField1.getName(), ArrowTypeID.Union, childField1.getType().getTypeID());
+          childField2.getName(), ArrowTypeID.Union, childField2.getType().getTypeID());
       assertEquals("Child field should be decimal type: " +
-          childField2.getName(), ArrowTypeID.Decimal, childField2.getType().getTypeID());
+          childField1.getName(), ArrowTypeID.Decimal, childField1.getType().getTypeID());
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/util/TestMapWithOrdinal.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/util/TestMapWithOrdinal.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestMapWithOrdinal {
+
+  @Test
+  public void testRemove() {
+    MapWithOrdinal<String, String> map = new MapWithOrdinalImpl<>();
+    map.put("x", "1", true);
+    map.put("y", "2", true);
+    map.put("z", "3", true);
+    map.removeAll("x");
+    Assert.assertEquals(2, map.size());
+    Assert.assertEquals(0, map.getOrdinal("z"));
+    Assert.assertEquals(1, map.getOrdinal("y"));
+    map.put("a", "4", true);
+    map.put("b", "5", true);
+    map.removeAll("z");
+    map.removeAll("a");
+    Assert.assertEquals(2, map.size());
+    Assert.assertEquals("2", map.get("y"));
+    Assert.assertEquals("5", map.get("b"));
+    Assert.assertNull(map.get("x"));
+    Assert.assertNull(map.get("z"));
+    Assert.assertNull(map.get("a"));
+    Assert.assertEquals(1, map.getOrdinal("y"));
+    Assert.assertEquals(0, map.getOrdinal("b"));
+  }
+}


### PR DESCRIPTION
MapWithOrdinal states that ordinals are recycled when keys are removed, it does not currently do this and grows unbounded.

This commit ensures keys are recycled and the map size reports correctly.

@jacques-n @StevenMPhillips this has been around for ages, wondering if you have any historical context? Is this even safe to fix?