### PR TITLE
ARROW-8957: [FlightRPC][C++] directly use IpcWriteOptions

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -408,7 +408,7 @@ class GrpcIpcMessageReader : public ipc::MessageReader {
       return stream_->Finish(result.status());
     }
     *app_metadata_ = std::move(data->app_metadata);
-    return std::move(result);
+    return result;
   }
 
  private:

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -278,7 +278,7 @@ class DoExchangeMessageWriter : public FlightMessageWriter {
  public:
   explicit DoExchangeMessageWriter(
       grpc::ServerReaderWriter<pb::FlightData, pb::FlightData>* stream)
-      : stream_(stream), ipc_options_(ipc::IpcOptions::Defaults()) {}
+      : stream_(stream), ipc_options_(::arrow::ipc::IpcWriteOptions::Defaults()) {}
 
   Status Begin(const std::shared_ptr<Schema>& schema) override {
     if (started_) {
@@ -352,7 +352,7 @@ class DoExchangeMessageWriter : public FlightMessageWriter {
   }
 
   grpc::ServerReaderWriter<pb::FlightData, pb::FlightData>* stream_;
-  ipc::IpcOptions ipc_options_;
+  ::arrow::ipc::IpcWriteOptions ipc_options_;
   ipc::DictionaryMemo dictionary_memo_;
   bool started_ = false;
   bool dictionaries_written_ = false;


### PR DESCRIPTION
The build fails when using `-DARROW_NO_DEPRECATED_API`