### PR TITLE
ARROW-9046: [C++][R] Put more things in type_fwds

### DIFF
--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -46,6 +46,9 @@ namespace dataset {
 class Dataset;
 using DatasetVector = std::vector<std::shared_ptr<Dataset>>;
 
+class UnionDataset;
+class DatasetFactory;
+
 class Fragment;
 using FragmentIterator = Iterator<std::shared_ptr<Fragment>>;
 using FragmentVector = std::vector<std::shared_ptr<Fragment>>;

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -23,23 +23,15 @@
 #include <vector>
 
 #include "arrow/dataset/visibility.h"
-#include "arrow/type_fwd.h"  // IWYU pragma: export
+#include "arrow/filesystem/type_fwd.h"  // IWYU pragma: export
+#include "arrow/type_fwd.h"             // IWYU pragma: export
 
 namespace arrow {
-
 namespace compute {
 
 class ExecContext;
 
 }  // namespace compute
-
-namespace fs {
-
-class FileSystem;
-
-struct FileInfo;
-
-}  // namespace fs
 
 namespace dataset {
 

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -25,6 +25,8 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/filesystem/type_fwd.h"
+#include "arrow/io/type_fwd.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/compare.h"
 #include "arrow/util/macros.h"
@@ -32,37 +34,12 @@
 #include "arrow/util/windows_fixup.h"
 
 namespace arrow {
-
-namespace io {
-
-class InputStream;
-class LatencyGenerator;
-class OutputStream;
-class RandomAccessFile;
-
-}  // namespace io
-
 namespace fs {
 
 // A system clock time point expressed as a 64-bit (or more) number of
 // nanoseconds since the epoch.
 using TimePoint =
     std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>;
-
-/// \brief FileSystem entry type
-enum class FileType : int8_t {
-  /// Entry is not found
-  NotFound,
-  /// Entry exists but its type is unknown
-  ///
-  /// This can designate a special file such as a Unix socket or character
-  /// device, or Windows NUL / CON / ...
-  Unknown,
-  /// Entry is a regular file
-  File,
-  /// Entry is a directory
-  Directory
-};
 
 ARROW_EXPORT std::string ToString(FileType);
 

--- a/cpp/src/arrow/filesystem/type_fwd.h
+++ b/cpp/src/arrow/filesystem/type_fwd.h
@@ -18,29 +18,35 @@
 #pragma once
 
 namespace arrow {
-namespace io {
+namespace fs {
 
-struct FileMode {
-  enum type { READ, WRITE, READWRITE };
+/// \brief FileSystem entry type
+enum class FileType : int8_t {
+  /// Entry is not found
+  NotFound,
+  /// Entry exists but its type is unknown
+  ///
+  /// This can designate a special file such as a Unix socket or character
+  /// device, or Windows NUL / CON / ...
+  Unknown,
+  /// Entry is a regular file
+  File,
+  /// Entry is a directory
+  Directory
 };
 
-class FileInterface;
-class Seekable;
-class Writable;
-class Readable;
-class OutputStream;
-class FileOutputStream;
-class InputStream;
-class ReadableFile;
-class RandomAccessFile;
-class MemoryMappedFile;
-class WritableFile;
-class ReadWriteFileInterface;
+struct FileInfo;
 
-class LatencyGenerator;
+struct FileSelector;
 
-class CompressedInputStream;
-class CompressedOutputStream;
+class FileSystem;
+class SubTreeFileSystem;
+class SlowFileSystem;
+class LocalFileSystem;
 
-}  // namespace io
+#if defined(ARROW_R_WITH_S3)
+class S3FileSystem;
+#endif
+
+}  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -673,13 +673,13 @@ class DoPutPayloadWriter : public ipc::internal::IpcPayloadWriter {
 
     if (first_payload_) {
       // First Flight message needs to encore the Flight descriptor
-      if (ipc_payload.type != ipc::Message::SCHEMA) {
+      if (ipc_payload.type != ipc::MessageType::SCHEMA) {
         return Status::Invalid("First IPC message should be schema");
       }
       // Write the descriptor to begin with
       RETURN_NOT_OK(internal::ToPayload(descriptor_, &payload.descriptor));
       first_payload_ = false;
-    } else if (ipc_payload.type == ipc::Message::RECORD_BATCH &&
+    } else if (ipc_payload.type == ipc::MessageType::RECORD_BATCH &&
                stream_writer_->app_metadata_) {
       payload.app_metadata = std::move(stream_writer_->app_metadata_);
     }

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -218,7 +218,7 @@ grpc::Status FlightDataSerialize(const FlightPayload& msg, ByteBuffer* out,
 
   const arrow::ipc::internal::IpcPayload& ipc_msg = msg.ipc_message;
   // No data in this payload (metadata-only).
-  bool has_ipc = ipc_msg.type != ipc::Message::NONE;
+  bool has_ipc = ipc_msg.type != ipc::MessageType::NONE;
   bool has_body = has_ipc ? ipc::Message::HasBody(ipc_msg.type) : false;
 
   if (has_ipc) {

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -460,7 +460,7 @@ Status NumberingStream::GetSchemaPayload(FlightPayload* payload) {
 
 Status NumberingStream::Next(FlightPayload* payload) {
   RETURN_NOT_OK(stream_->Next(payload));
-  if (payload && payload->ipc_message.type == ipc::Message::RECORD_BATCH) {
+  if (payload && payload->ipc_message.type == ipc::MessageType::RECORD_BATCH) {
     payload->app_metadata = Buffer::FromString(std::to_string(counter_));
     counter_++;
   }

--- a/cpp/src/arrow/io/type_fwd.h
+++ b/cpp/src/arrow/io/type_fwd.h
@@ -29,10 +29,16 @@ class Seekable;
 class Writable;
 class Readable;
 class OutputStream;
+class FileOutputStream;
 class InputStream;
+class ReadableFile;
 class RandomAccessFile;
+class MemoryMappedFile;
 class WritableFile;
 class ReadWriteFileInterface;
+
+class CompressedInputStream;
+class CompressedOutputStream;
 
 }  // namespace io
 }  // namespace arrow

--- a/cpp/src/arrow/io/type_fwd.h
+++ b/cpp/src/arrow/io/type_fwd.h
@@ -39,8 +39,14 @@ class ReadWriteFileInterface;
 
 class LatencyGenerator;
 
+class BufferReader;
+
+class BufferInputStream;
+class BufferOutputStream;
 class CompressedInputStream;
 class CompressedOutputStream;
+class BufferedInputStream;
+class BufferedOutputStream;
 
 }  // namespace io
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -68,20 +68,20 @@ class Message::MessageImpl {
     return Status::OK();
   }
 
-  Message::Type type() const {
+  MessageType type() const {
     switch (message_->header_type()) {
       case flatbuf::MessageHeader::Schema:
-        return Message::SCHEMA;
+        return MessageType::SCHEMA;
       case flatbuf::MessageHeader::DictionaryBatch:
-        return Message::DICTIONARY_BATCH;
+        return MessageType::DICTIONARY_BATCH;
       case flatbuf::MessageHeader::RecordBatch:
-        return Message::RECORD_BATCH;
+        return MessageType::RECORD_BATCH;
       case flatbuf::MessageHeader::Tensor:
-        return Message::TENSOR;
+        return MessageType::TENSOR;
       case flatbuf::MessageHeader::SparseTensor:
-        return Message::SPARSE_TENSOR;
+        return MessageType::SPARSE_TENSOR;
       default:
-        return Message::NONE;
+        return MessageType::NONE;
     }
   }
 
@@ -132,7 +132,7 @@ int64_t Message::body_length() const { return impl_->body_length(); }
 
 std::shared_ptr<Buffer> Message::metadata() const { return impl_->metadata(); }
 
-Message::Type Message::type() const { return impl_->type(); }
+MessageType Message::type() const { return impl_->type(); }
 
 MetadataVersion Message::metadata_version() const { return impl_->version(); }
 
@@ -254,13 +254,13 @@ bool Message::Verify() const {
   return internal::VerifyMessage(metadata()->data(), metadata()->size(), &unused).ok();
 }
 
-std::string FormatMessageType(Message::Type type) {
+std::string FormatMessageType(MessageType type) {
   switch (type) {
-    case Message::SCHEMA:
+    case MessageType::SCHEMA:
       return "schema";
-    case Message::RECORD_BATCH:
+    case MessageType::RECORD_BATCH:
       return "record batch";
-    case Message::DICTIONARY_BATCH:
+    case MessageType::DICTIONARY_BATCH:
       return "dictionary";
     default:
       break;

--- a/cpp/src/arrow/ipc/message.h
+++ b/cpp/src/arrow/ipc/message.h
@@ -24,6 +24,8 @@
 #include <string>
 #include <utility>
 
+#include "arrow/io/type_fwd.h"
+#include "arrow/ipc/type_fwd.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
@@ -31,33 +33,9 @@
 #include "arrow/util/visibility.h"
 
 namespace arrow {
-
-namespace io {
-
-class FileInterface;
-class InputStream;
-class OutputStream;
-class RandomAccessFile;
-
-}  // namespace io
-
 namespace ipc {
 
 struct IpcWriteOptions;
-
-enum class MetadataVersion : char {
-  /// 0.1.0
-  V1,
-
-  /// 0.2.0
-  V2,
-
-  /// 0.3.0 to 0.7.1
-  V3,
-
-  /// >= 0.8.0
-  V4
-};
 
 // Read interface classes. We do not fully deserialize the flatbuffers so that
 // individual fields metadata can be retrieved from very large schema without
@@ -67,8 +45,6 @@ enum class MetadataVersion : char {
 /// \brief An IPC message including metadata and body
 class ARROW_EXPORT Message {
  public:
-  enum Type { NONE, SCHEMA, DICTIONARY_BATCH, RECORD_BATCH, TENSOR, SPARSE_TENSOR };
-
   /// \brief Construct message, but do not validate
   ///
   /// Use at your own risk; Message::Open has more metadata validation
@@ -130,7 +106,7 @@ class ARROW_EXPORT Message {
   int64_t body_length() const;
 
   /// \brief The Message type
-  Type type() const;
+  MessageType type() const;
 
   /// \brief The Message metadata version
   MetadataVersion metadata_version() const;
@@ -150,7 +126,9 @@ class ARROW_EXPORT Message {
   bool Verify() const;
 
   /// \brief Whether a given message type needs a body.
-  static bool HasBody(Type type) { return type != NONE && type != SCHEMA; }
+  static bool HasBody(MessageType type) {
+    return type != MessageType::NONE && type != MessageType::SCHEMA;
+  }
 
  private:
   // Hide serialization details from user API
@@ -160,7 +138,7 @@ class ARROW_EXPORT Message {
   ARROW_DISALLOW_COPY_AND_ASSIGN(Message);
 };
 
-ARROW_EXPORT std::string FormatMessageType(Message::Type type);
+ARROW_EXPORT std::string FormatMessageType(MessageType type);
 
 /// \class MessageDecoderListener
 /// \brief An abstract class to listen events from MessageDecoder.

--- a/cpp/src/arrow/ipc/options.cc
+++ b/cpp/src/arrow/ipc/options.cc
@@ -17,6 +17,8 @@
 
 #include "arrow/ipc/options.h"
 
+#include "arrow/status.h"
+
 namespace arrow {
 namespace ipc {
 

--- a/cpp/src/arrow/ipc/type_fwd.h
+++ b/cpp/src/arrow/ipc/type_fwd.h
@@ -18,7 +18,6 @@
 #pragma once
 
 namespace arrow {
-
 namespace ipc {
 
 enum class MetadataVersion : char {
@@ -58,5 +57,4 @@ class Reader;
 
 }  // namespace feather
 }  // namespace ipc
-
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/type_fwd.h
+++ b/cpp/src/arrow/ipc/type_fwd.h
@@ -21,7 +21,31 @@ namespace arrow {
 
 namespace ipc {
 
-// TODO: add Message et al.
+enum class MetadataVersion : char {
+  /// 0.1.0
+  V1,
+
+  /// 0.2.0
+  V2,
+
+  /// 0.3.0 to 0.7.1
+  V3,
+
+  /// >= 0.8.0
+  V4
+};
+
+class Message;
+enum class MessageType {
+  NONE,
+  SCHEMA,
+  DICTIONARY_BATCH,
+  RECORD_BATCH,
+  TENSOR,
+  SPARSE_TENSOR
+};
+
+class MessageReader;
 
 class RecordBatchStreamReader;
 class RecordBatchStreamWriter;
@@ -29,6 +53,7 @@ class RecordBatchFileReader;
 class RecordBatchWriter;
 
 namespace feather {
+
 class Reader;
 
 }  // namespace feather

--- a/cpp/src/arrow/ipc/type_fwd.h
+++ b/cpp/src/arrow/ipc/type_fwd.h
@@ -1,0 +1,37 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace arrow {
+
+namespace ipc {
+
+// TODO: add Message et al.
+
+class RecordBatchStreamReader;
+class RecordBatchStreamWriter;
+class RecordBatchFileReader;
+class RecordBatchWriter;
+
+namespace feather {
+class Reader;
+
+}  // namespace feather
+}  // namespace ipc
+
+}  // namespace arrow

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -584,13 +584,13 @@ Status WriteIpcPayload(const IpcPayload& payload, const IpcWriteOptions& options
 
 Status GetSchemaPayload(const Schema& schema, const IpcWriteOptions& options,
                         DictionaryMemo* dictionary_memo, IpcPayload* out) {
-  out->type = Message::SCHEMA;
+  out->type = MessageType::SCHEMA;
   return WriteSchemaMessage(schema, dictionary_memo, &out->metadata);
 }
 
 Status GetDictionaryPayload(int64_t id, const std::shared_ptr<Array>& dictionary,
                             const IpcWriteOptions& options, IpcPayload* out) {
-  out->type = Message::DICTIONARY_BATCH;
+  out->type = MessageType::DICTIONARY_BATCH;
   // Frame of reference is 0, see ARROW-384
   DictionarySerializer assembler(id, /*buffer_start_offset=*/0, options, out);
   return assembler.Assemble(dictionary);
@@ -598,7 +598,7 @@ Status GetDictionaryPayload(int64_t id, const std::shared_ptr<Array>& dictionary
 
 Status GetRecordBatchPayload(const RecordBatch& batch, const IpcWriteOptions& options,
                              IpcPayload* out) {
-  out->type = Message::RECORD_BATCH;
+  out->type = MessageType::RECORD_BATCH;
   RecordBatchSerializer assembler(/*buffer_start_offset=*/0, options, out);
   return assembler.Assemble(batch);
 }
@@ -1111,10 +1111,10 @@ class PayloadFileWriter : public internal::IpcPayloadWriter, protected StreamBoo
 
     // Record position and size of some message types, to list them in the footer
     switch (payload.type) {
-      case Message::DICTIONARY_BATCH:
+      case MessageType::DICTIONARY_BATCH:
         dictionaries_.push_back(block);
         break;
-      case Message::RECORD_BATCH:
+      case MessageType::RECORD_BATCH:
         record_batches_.push_back(block);
         break;
       default:

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -265,7 +265,7 @@ namespace internal {
 // Intermediate data structure with metadata header, and zero or more buffers
 // for the message body.
 struct IpcPayload {
-  Message::Type type = Message::NONE;
+  MessageType type = MessageType::NONE;
   std::shared_ptr<Buffer> metadata;
   std::vector<std::shared_ptr<Buffer>> body_buffers;
   int64_t body_length = 0;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1064,8 +1064,6 @@ class ARROW_EXPORT UnionType : public NestedType {
 // ----------------------------------------------------------------------
 // Date and time types
 
-enum class DateUnit : char { DAY = 0, MILLI = 1 };
-
 /// \brief Base type for all date and time types
 class ARROW_EXPORT TemporalType : public FixedWidthType {
  public:

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -34,6 +34,17 @@ class Result;
 
 class Status;
 
+struct Compression {
+  /// \brief Compression algorithm
+  enum type { UNCOMPRESSED, SNAPPY, GZIP, BROTLI, ZSTD, LZ4, LZ4_FRAME, LZO, BZ2 };
+
+  static const int kUseDefaultCompressionLevel;
+};
+
+namespace util {
+class Codec;
+}  // namespace util
+
 class Buffer;
 class Device;
 class MemoryManager;
@@ -79,6 +90,8 @@ class NullType;
 class NullArray;
 class NullBuilder;
 struct NullScalar;
+
+struct FixedWidthType;
 
 class BooleanType;
 class BooleanArray;
@@ -136,6 +149,7 @@ class StructBuilder;
 struct StructScalar;
 
 class Decimal128;
+class DecimalType;
 class Decimal128Type;
 class Decimal128Array;
 class Decimal128Builder;
@@ -178,6 +192,9 @@ _NUMERIC_TYPE_DECL(Double)
 
 #undef _NUMERIC_TYPE_DECL
 
+enum class DateUnit : char { DAY = 0, MILLI = 1 };
+
+class DateType;
 class Date32Type;
 using Date32Array = NumericArray<Date32Type>;
 using Date32Builder = NumericBuilder<Date32Type>;
@@ -193,6 +210,7 @@ struct TimeUnit {
   enum type { SECOND = 0, MILLI = 1, MICRO = 2, NANO = 3 };
 };
 
+class TimeType;
 class Time32Type;
 using Time32Array = NumericArray<Time32Type>;
 using Time32Builder = NumericBuilder<Time32Type>;

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -34,7 +34,7 @@ class Result;
 
 class Status;
 
-struct Compression {
+struct ARROW_EXPORT Compression {
   /// \brief Compression algorithm
   enum type { UNCOMPRESSED, SNAPPY, GZIP, BROTLI, ZSTD, LZ4, LZ4_FRAME, LZO, BZ2 };
 

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -64,6 +64,7 @@ using ScalarVector = std::vector<std::shared_ptr<Scalar>>;
 
 class ChunkedArray;
 class RecordBatch;
+class RecordBatchReader;
 class Table;
 
 using ChunkedArrayVector = std::vector<std::shared_ptr<ChunkedArray>>;

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -91,7 +91,7 @@ class NullArray;
 class NullBuilder;
 struct NullScalar;
 
-struct FixedWidthType;
+class FixedWidthType;
 
 class BooleanType;
 class BooleanArray;

--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/util/compression.h"
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -26,6 +27,9 @@
 #include "arrow/util/compression_internal.h"
 
 namespace arrow {
+
+const int Compression::kUseDefaultCompressionLevel = std::numeric_limits<int>::min();
+
 namespace util {
 
 Compressor::~Compressor() {}

--- a/cpp/src/arrow/util/compression.h
+++ b/cpp/src/arrow/util/compression.h
@@ -22,22 +22,13 @@
 #include <memory>
 #include <string>
 
-#include "arrow/result.h"
-#include "arrow/status.h"
+#include "arrow/type_fwd.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
-
-struct Compression {
-  /// \brief Compression algorithm
-  enum type { UNCOMPRESSED, SNAPPY, GZIP, BROTLI, ZSTD, LZ4, LZ4_FRAME, LZO, BZ2 };
-
-  static constexpr int kUseDefaultCompressionLevel = std::numeric_limits<int>::min();
-};
-
 namespace util {
 
-constexpr int kUseDefaultCompressionLevel = Compression::kUseDefaultCompressionLevel;
+static const int kUseDefaultCompressionLevel = Compression::kUseDefaultCompressionLevel;
 
 /// \brief Streaming compressor interface
 ///

--- a/cpp/src/parquet/type_fwd.h
+++ b/cpp/src/parquet/type_fwd.h
@@ -17,30 +17,15 @@
 
 #pragma once
 
+namespace parquet {
+
+class FileMetaData;
+class SchemaDescriptor;
+
 namespace arrow {
-namespace io {
 
-struct FileMode {
-  enum type { READ, WRITE, READWRITE };
-};
+class FileWriter;
+class FileReader;
 
-class FileInterface;
-class Seekable;
-class Writable;
-class Readable;
-class OutputStream;
-class FileOutputStream;
-class InputStream;
-class ReadableFile;
-class RandomAccessFile;
-class MemoryMappedFile;
-class WritableFile;
-class ReadWriteFileInterface;
-
-class LatencyGenerator;
-
-class CompressedInputStream;
-class CompressedOutputStream;
-
-}  // namespace io
 }  // namespace arrow
+}  // namespace parquet

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1189,7 +1189,8 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     enum MessageType" arrow::ipc::MessageType":
         MessageType_SCHEMA" arrow::ipc::MessageType::SCHEMA"
         MessageType_RECORD_BATCH" arrow::ipc::MessageType::RECORD_BATCH"
-        MessageType_DICTIONARY_BATCH" arrow::ipc::MessageType::DICTIONARY_BATCH"
+        MessageType_DICTIONARY_BATCH\
+            " arrow::ipc::MessageType::DICTIONARY_BATCH"
 
     enum MetadataVersion" arrow::ipc::MetadataVersion":
         MessageType_V1" arrow::ipc::MetadataVersion::V1"

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1186,10 +1186,10 @@ cdef extern from "arrow/io/api.h" namespace "arrow::io" nogil:
 
 
 cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
-    enum MessageType" arrow::ipc::Message::Type":
-        MessageType_SCHEMA" arrow::ipc::Message::SCHEMA"
-        MessageType_RECORD_BATCH" arrow::ipc::Message::RECORD_BATCH"
-        MessageType_DICTIONARY_BATCH" arrow::ipc::Message::DICTIONARY_BATCH"
+    enum MessageType" arrow::ipc::MessageType":
+        MessageType_SCHEMA" arrow::ipc::MessageType::SCHEMA"
+        MessageType_RECORD_BATCH" arrow::ipc::MessageType::RECORD_BATCH"
+        MessageType_DICTIONARY_BATCH" arrow::ipc::MessageType::DICTIONARY_BATCH"
 
     enum MetadataVersion" arrow::ipc::MetadataVersion":
         MessageType_V1" arrow::ipc::MetadataVersion::V1"

--- a/r/R/compression.R
+++ b/r/R/compression.R
@@ -46,7 +46,7 @@ Codec <- R6Class("Codec", inherit = ArrowObject,
 )
 Codec$create <- function(type = "gzip", compression_level = NA) {
   if (is.string(type)) {
-    type <- unique_ptr(Codec, util___Codec__Create(
+    type <- shared_ptr(Codec, util___Codec__Create(
       compression_from_name(type), compression_level
     ))
   }

--- a/r/R/enums.R
+++ b/r/R/enums.R
@@ -92,7 +92,7 @@ FileMode <- enum("FileMode",
 
 #' @rdname enums
 #' @export
-MessageType <- enum("Message::Type",
+MessageType <- enum("MessageType",
   NONE = 0L, SCHEMA = 1L, DICTIONARY_BATCH = 2L, RECORD_BATCH = 3L, TENSOR = 4L
 )
 

--- a/r/R/message.R
+++ b/r/R/message.R
@@ -59,7 +59,7 @@ Message <- R6Class("Message", inherit = ArrowObject,
 #' @export
 MessageReader <- R6Class("MessageReader", inherit = ArrowObject,
   public = list(
-    ReadNextMessage = function() unique_ptr(Message, ipc___MessageReader__ReadNextMessage(self))
+    ReadNextMessage = function() shared_ptr(Message, ipc___MessageReader__ReadNextMessage(self))
   )
 )
 
@@ -67,7 +67,7 @@ MessageReader$create <- function(stream) {
   if (!inherits(stream, "InputStream")) {
     stream <- BufferReader$create(stream)
   }
-  unique_ptr(MessageReader, ipc___MessageReader__Open(stream))
+  shared_ptr(MessageReader, ipc___MessageReader__Open(stream))
 }
 
 #' Read a Message from a stream
@@ -86,7 +86,7 @@ read_message.default <- function(stream) {
 
 #' @export
 read_message.InputStream <- function(stream) {
-  unique_ptr(Message, ipc___ReadMessage(stream) )
+  shared_ptr(Message, ipc___ReadMessage(stream) )
 }
 
 #' @export

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -403,7 +403,7 @@ ParquetFileWriter$create <- function(
   properties = ParquetWriterProperties$create(),
   arrow_properties = ParquetArrowWriterProperties$create()
 ) {
-  unique_ptr(
+  shared_ptr(
     ParquetFileWriter,
     parquet___arrow___ParquetFileWriter__Open(schema, sink, properties, arrow_properties)
   )
@@ -480,7 +480,7 @@ ParquetFileReader$create <- function(file,
   file <- make_readable_file(file, mmap)
   assert_is(props, "ParquetReaderProperties")
 
-  unique_ptr(ParquetFileReader, parquet___arrow___FileReader__OpenFile(file, props))
+  shared_ptr(ParquetFileReader, parquet___arrow___FileReader__OpenFile(file, props))
 }
 
 #' @title ParquetReaderProperties class

--- a/r/man/enums.Rd
+++ b/r/man/enums.Rd
@@ -24,7 +24,7 @@ An object of class \code{StatusCode} (inherits from \code{arrow-enum}) of length
 
 An object of class \code{FileMode} (inherits from \code{arrow-enum}) of length 3.
 
-An object of class \code{Message::Type} (inherits from \code{arrow-enum}) of length 5.
+An object of class \code{MessageType} (inherits from \code{arrow-enum}) of length 5.
 
 An object of class \code{Compression::type} (inherits from \code{arrow-enum}) of length 9.
 

--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -20,11 +20,10 @@
 #include "./arrow_types.h"
 
 #if defined(ARROW_R_WITH_ARROW)
-#include <arrow/array.h>
+#include <arrow/array/array_base.h>
 #include <arrow/builder.h>
 #include <arrow/table.h>
 #include <arrow/util/bitmap_writer.h>
-// This says "Private header, not to be exported"
 #include <arrow/visitor_inline.h>
 
 using arrow::internal::checked_cast;

--- a/r/src/arraydata.cpp
+++ b/r/src/arraydata.cpp
@@ -21,7 +21,7 @@ using Rcpp::List;
 using Rcpp::wrap;
 
 #if defined(ARROW_R_WITH_ARROW)
-#include <arrow/array.h>
+#include <arrow/array/data.h>
 
 // [[arrow::export]]
 std::shared_ptr<arrow::DataType> ArrayData__get_type(

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -908,7 +908,7 @@ RcppExport SEXP _arrow_ChunkedArray__Equals(SEXP x_sexp, SEXP y_sexp){
 
 // compression.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::unique_ptr<arrow::util::Codec> util___Codec__Create(arrow::Compression::type codec, int compression_level);
+std::shared_ptr<arrow::util::Codec> util___Codec__Create(arrow::Compression::type codec, int compression_level);
 RcppExport SEXP _arrow_util___Codec__Create(SEXP codec_sexp, SEXP compression_level_sexp){
 BEGIN_RCPP
 	Rcpp::traits::input_parameter<arrow::Compression::type>::type codec(codec_sexp);
@@ -924,10 +924,10 @@ RcppExport SEXP _arrow_util___Codec__Create(SEXP codec_sexp, SEXP compression_le
 
 // compression.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::string util___Codec__name(const std::unique_ptr<arrow::util::Codec>& codec);
+std::string util___Codec__name(const std::shared_ptr<arrow::util::Codec>& codec);
 RcppExport SEXP _arrow_util___Codec__name(SEXP codec_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::unique_ptr<arrow::util::Codec>&>::type codec(codec_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::util::Codec>&>::type codec(codec_sexp);
 	return Rcpp::wrap(util___Codec__name(codec));
 END_RCPP
 }
@@ -954,10 +954,10 @@ RcppExport SEXP _arrow_util___Codec__IsAvailable(SEXP codec_sexp){
 
 // compression.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<arrow::io::CompressedOutputStream> io___CompressedOutputStream__Make(const std::unique_ptr<arrow::util::Codec>& codec, const std::shared_ptr<arrow::io::OutputStream>& raw);
+std::shared_ptr<arrow::io::CompressedOutputStream> io___CompressedOutputStream__Make(const std::shared_ptr<arrow::util::Codec>& codec, const std::shared_ptr<arrow::io::OutputStream>& raw);
 RcppExport SEXP _arrow_io___CompressedOutputStream__Make(SEXP codec_sexp, SEXP raw_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::unique_ptr<arrow::util::Codec>&>::type codec(codec_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::util::Codec>&>::type codec(codec_sexp);
 	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::io::OutputStream>&>::type raw(raw_sexp);
 	return Rcpp::wrap(io___CompressedOutputStream__Make(codec, raw));
 END_RCPP
@@ -970,10 +970,10 @@ RcppExport SEXP _arrow_io___CompressedOutputStream__Make(SEXP codec_sexp, SEXP r
 
 // compression.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<arrow::io::CompressedInputStream> io___CompressedInputStream__Make(const std::unique_ptr<arrow::util::Codec>& codec, const std::shared_ptr<arrow::io::InputStream>& raw);
+std::shared_ptr<arrow::io::CompressedInputStream> io___CompressedInputStream__Make(const std::shared_ptr<arrow::util::Codec>& codec, const std::shared_ptr<arrow::io::InputStream>& raw);
 RcppExport SEXP _arrow_io___CompressedInputStream__Make(SEXP codec_sexp, SEXP raw_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::unique_ptr<arrow::util::Codec>&>::type codec(codec_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::util::Codec>&>::type codec(codec_sexp);
 	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::io::InputStream>&>::type raw(raw_sexp);
 	return Rcpp::wrap(io___CompressedInputStream__Make(codec, raw));
 END_RCPP
@@ -4028,7 +4028,7 @@ RcppExport SEXP _arrow_parquet___arrow___ArrowReaderProperties__set_read_diction
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::unique_ptr<parquet::arrow::FileReader> parquet___arrow___FileReader__OpenFile(const std::shared_ptr<arrow::io::RandomAccessFile>& file, const std::shared_ptr<parquet::ArrowReaderProperties>& props);
+std::shared_ptr<parquet::arrow::FileReader> parquet___arrow___FileReader__OpenFile(const std::shared_ptr<arrow::io::RandomAccessFile>& file, const std::shared_ptr<parquet::ArrowReaderProperties>& props);
 RcppExport SEXP _arrow_parquet___arrow___FileReader__OpenFile(SEXP file_sexp, SEXP props_sexp){
 BEGIN_RCPP
 	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::io::RandomAccessFile>&>::type file(file_sexp);
@@ -4044,10 +4044,10 @@ RcppExport SEXP _arrow_parquet___arrow___FileReader__OpenFile(SEXP file_sexp, SE
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable1(const std::unique_ptr<parquet::arrow::FileReader>& reader);
+std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable1(const std::shared_ptr<parquet::arrow::FileReader>& reader);
 RcppExport SEXP _arrow_parquet___arrow___FileReader__ReadTable1(SEXP reader_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::unique_ptr<parquet::arrow::FileReader>&>::type reader(reader_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::arrow::FileReader>&>::type reader(reader_sexp);
 	return Rcpp::wrap(parquet___arrow___FileReader__ReadTable1(reader));
 END_RCPP
 }
@@ -4059,10 +4059,10 @@ RcppExport SEXP _arrow_parquet___arrow___FileReader__ReadTable1(SEXP reader_sexp
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable2(const std::unique_ptr<parquet::arrow::FileReader>& reader, const std::vector<int>& column_indices);
+std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable2(const std::shared_ptr<parquet::arrow::FileReader>& reader, const std::vector<int>& column_indices);
 RcppExport SEXP _arrow_parquet___arrow___FileReader__ReadTable2(SEXP reader_sexp, SEXP column_indices_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::unique_ptr<parquet::arrow::FileReader>&>::type reader(reader_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::arrow::FileReader>&>::type reader(reader_sexp);
 	Rcpp::traits::input_parameter<const std::vector<int>&>::type column_indices(column_indices_sexp);
 	return Rcpp::wrap(parquet___arrow___FileReader__ReadTable2(reader, column_indices));
 END_RCPP
@@ -4075,10 +4075,10 @@ RcppExport SEXP _arrow_parquet___arrow___FileReader__ReadTable2(SEXP reader_sexp
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-int64_t parquet___arrow___FileReader__num_rows(const std::unique_ptr<parquet::arrow::FileReader>& reader);
+int64_t parquet___arrow___FileReader__num_rows(const std::shared_ptr<parquet::arrow::FileReader>& reader);
 RcppExport SEXP _arrow_parquet___arrow___FileReader__num_rows(SEXP reader_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::unique_ptr<parquet::arrow::FileReader>&>::type reader(reader_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::arrow::FileReader>&>::type reader(reader_sexp);
 	return Rcpp::wrap(parquet___arrow___FileReader__num_rows(reader));
 END_RCPP
 }
@@ -4090,7 +4090,7 @@ RcppExport SEXP _arrow_parquet___arrow___FileReader__num_rows(SEXP reader_sexp){
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<parquet::ArrowWriterProperties::Builder> parquet___ArrowWriterProperties___Builder__create();
+std::shared_ptr<parquet::ArrowWriterPropertiesBuilder> parquet___ArrowWriterProperties___Builder__create();
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__create(){
 BEGIN_RCPP
 	return Rcpp::wrap(parquet___ArrowWriterProperties___Builder__create());
@@ -4104,10 +4104,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__create(){
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__store_schema(const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder);
+void parquet___ArrowWriterProperties___Builder__store_schema(const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__store_schema(SEXP builder_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>&>::type builder(builder_sexp);
 	parquet___ArrowWriterProperties___Builder__store_schema(builder);
 	return R_NilValue;
 END_RCPP
@@ -4120,10 +4120,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__store_schema(S
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__enable_deprecated_int96_timestamps(const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder);
+void parquet___ArrowWriterProperties___Builder__enable_deprecated_int96_timestamps(const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__enable_deprecated_int96_timestamps(SEXP builder_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>&>::type builder(builder_sexp);
 	parquet___ArrowWriterProperties___Builder__enable_deprecated_int96_timestamps(builder);
 	return R_NilValue;
 END_RCPP
@@ -4136,10 +4136,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__enable_depreca
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__disable_deprecated_int96_timestamps(const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder);
+void parquet___ArrowWriterProperties___Builder__disable_deprecated_int96_timestamps(const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__disable_deprecated_int96_timestamps(SEXP builder_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>&>::type builder(builder_sexp);
 	parquet___ArrowWriterProperties___Builder__disable_deprecated_int96_timestamps(builder);
 	return R_NilValue;
 END_RCPP
@@ -4152,10 +4152,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__disable_deprec
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__coerce_timestamps(const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder, arrow::TimeUnit::type unit);
+void parquet___ArrowWriterProperties___Builder__coerce_timestamps(const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder, arrow::TimeUnit::type unit);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__coerce_timestamps(SEXP builder_sexp, SEXP unit_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<arrow::TimeUnit::type>::type unit(unit_sexp);
 	parquet___ArrowWriterProperties___Builder__coerce_timestamps(builder, unit);
 	return R_NilValue;
@@ -4169,10 +4169,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__coerce_timesta
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__allow_truncated_timestamps(const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder);
+void parquet___ArrowWriterProperties___Builder__allow_truncated_timestamps(const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__allow_truncated_timestamps(SEXP builder_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>&>::type builder(builder_sexp);
 	parquet___ArrowWriterProperties___Builder__allow_truncated_timestamps(builder);
 	return R_NilValue;
 END_RCPP
@@ -4185,10 +4185,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__allow_truncate
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__disallow_truncated_timestamps(const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder);
+void parquet___ArrowWriterProperties___Builder__disallow_truncated_timestamps(const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__disallow_truncated_timestamps(SEXP builder_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>&>::type builder(builder_sexp);
 	parquet___ArrowWriterProperties___Builder__disallow_truncated_timestamps(builder);
 	return R_NilValue;
 END_RCPP
@@ -4201,10 +4201,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__disallow_trunc
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<parquet::ArrowWriterProperties> parquet___ArrowWriterProperties___Builder__build(const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder);
+std::shared_ptr<parquet::ArrowWriterProperties> parquet___ArrowWriterProperties___Builder__build(const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__build(SEXP builder_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>&>::type builder(builder_sexp);
 	return Rcpp::wrap(parquet___ArrowWriterProperties___Builder__build(builder));
 END_RCPP
 }
@@ -4230,7 +4230,7 @@ RcppExport SEXP _arrow_parquet___default_writer_properties(){
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<parquet::WriterProperties::Builder> parquet___WriterProperties___Builder__create();
+std::shared_ptr<parquet::WriterPropertiesBuilder> parquet___WriterProperties___Builder__create();
 RcppExport SEXP _arrow_parquet___WriterProperties___Builder__create(){
 BEGIN_RCPP
 	return Rcpp::wrap(parquet___WriterProperties___Builder__create());
@@ -4244,10 +4244,10 @@ RcppExport SEXP _arrow_parquet___WriterProperties___Builder__create(){
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___WriterProperties___Builder__version(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, const parquet::ParquetVersion::type& version);
+void parquet___WriterProperties___Builder__version(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, const parquet::ParquetVersion::type& version);
 RcppExport SEXP _arrow_parquet___WriterProperties___Builder__version(SEXP builder_sexp, SEXP version_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<const parquet::ParquetVersion::type&>::type version(version_sexp);
 	parquet___WriterProperties___Builder__version(builder, version);
 	return R_NilValue;
@@ -4261,10 +4261,10 @@ RcppExport SEXP _arrow_parquet___WriterProperties___Builder__version(SEXP builde
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__default_compression(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, const arrow::Compression::type& compression);
+void parquet___ArrowWriterProperties___Builder__default_compression(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, const arrow::Compression::type& compression);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__default_compression(SEXP builder_sexp, SEXP compression_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<const arrow::Compression::type&>::type compression(compression_sexp);
 	parquet___ArrowWriterProperties___Builder__default_compression(builder, compression);
 	return R_NilValue;
@@ -4278,10 +4278,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__default_compre
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__set_compressions(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, const std::vector<std::string>& paths, const Rcpp::IntegerVector& types);
+void parquet___ArrowWriterProperties___Builder__set_compressions(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, const std::vector<std::string>& paths, const Rcpp::IntegerVector& types);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__set_compressions(SEXP builder_sexp, SEXP paths_sexp, SEXP types_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<const std::vector<std::string>&>::type paths(paths_sexp);
 	Rcpp::traits::input_parameter<const Rcpp::IntegerVector&>::type types(types_sexp);
 	parquet___ArrowWriterProperties___Builder__set_compressions(builder, paths, types);
@@ -4296,10 +4296,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__set_compressio
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__default_compression_level(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, int compression_level);
+void parquet___ArrowWriterProperties___Builder__default_compression_level(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, int compression_level);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__default_compression_level(SEXP builder_sexp, SEXP compression_level_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<int>::type compression_level(compression_level_sexp);
 	parquet___ArrowWriterProperties___Builder__default_compression_level(builder, compression_level);
 	return R_NilValue;
@@ -4313,10 +4313,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__default_compre
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__set_compression_levels(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, const std::vector<std::string>& paths, const Rcpp::IntegerVector& levels);
+void parquet___ArrowWriterProperties___Builder__set_compression_levels(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, const std::vector<std::string>& paths, const Rcpp::IntegerVector& levels);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__set_compression_levels(SEXP builder_sexp, SEXP paths_sexp, SEXP levels_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<const std::vector<std::string>&>::type paths(paths_sexp);
 	Rcpp::traits::input_parameter<const Rcpp::IntegerVector&>::type levels(levels_sexp);
 	parquet___ArrowWriterProperties___Builder__set_compression_levels(builder, paths, levels);
@@ -4331,10 +4331,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__set_compressio
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__default_write_statistics(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, bool write_statistics);
+void parquet___ArrowWriterProperties___Builder__default_write_statistics(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, bool write_statistics);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__default_write_statistics(SEXP builder_sexp, SEXP write_statistics_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<bool>::type write_statistics(write_statistics_sexp);
 	parquet___ArrowWriterProperties___Builder__default_write_statistics(builder, write_statistics);
 	return R_NilValue;
@@ -4348,10 +4348,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__default_write_
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__default_use_dictionary(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, bool use_dictionary);
+void parquet___ArrowWriterProperties___Builder__default_use_dictionary(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, bool use_dictionary);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__default_use_dictionary(SEXP builder_sexp, SEXP use_dictionary_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<bool>::type use_dictionary(use_dictionary_sexp);
 	parquet___ArrowWriterProperties___Builder__default_use_dictionary(builder, use_dictionary);
 	return R_NilValue;
@@ -4365,10 +4365,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__default_use_di
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__set_use_dictionary(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, const std::vector<std::string>& paths, const Rcpp::LogicalVector& use_dictionary);
+void parquet___ArrowWriterProperties___Builder__set_use_dictionary(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, const std::vector<std::string>& paths, const Rcpp::LogicalVector& use_dictionary);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__set_use_dictionary(SEXP builder_sexp, SEXP paths_sexp, SEXP use_dictionary_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<const std::vector<std::string>&>::type paths(paths_sexp);
 	Rcpp::traits::input_parameter<const Rcpp::LogicalVector&>::type use_dictionary(use_dictionary_sexp);
 	parquet___ArrowWriterProperties___Builder__set_use_dictionary(builder, paths, use_dictionary);
@@ -4383,10 +4383,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__set_use_dictio
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__set_write_statistics(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, const std::vector<std::string>& paths, const Rcpp::LogicalVector& write_statistics);
+void parquet___ArrowWriterProperties___Builder__set_write_statistics(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, const std::vector<std::string>& paths, const Rcpp::LogicalVector& write_statistics);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__set_write_statistics(SEXP builder_sexp, SEXP paths_sexp, SEXP write_statistics_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<const std::vector<std::string>&>::type paths(paths_sexp);
 	Rcpp::traits::input_parameter<const Rcpp::LogicalVector&>::type write_statistics(write_statistics_sexp);
 	parquet___ArrowWriterProperties___Builder__set_write_statistics(builder, paths, write_statistics);
@@ -4401,10 +4401,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__set_write_stat
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___ArrowWriterProperties___Builder__data_page_size(const std::shared_ptr<parquet::WriterProperties::Builder>& builder, int64_t data_page_size);
+void parquet___ArrowWriterProperties___Builder__data_page_size(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder, int64_t data_page_size);
 RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__data_page_size(SEXP builder_sexp, SEXP data_page_size_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	Rcpp::traits::input_parameter<int64_t>::type data_page_size(data_page_size_sexp);
 	parquet___ArrowWriterProperties___Builder__data_page_size(builder, data_page_size);
 	return R_NilValue;
@@ -4418,10 +4418,10 @@ RcppExport SEXP _arrow_parquet___ArrowWriterProperties___Builder__data_page_size
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<parquet::WriterProperties> parquet___WriterProperties___Builder__build(const std::shared_ptr<parquet::WriterProperties::Builder>& builder);
+std::shared_ptr<parquet::WriterProperties> parquet___WriterProperties___Builder__build(const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder);
 RcppExport SEXP _arrow_parquet___WriterProperties___Builder__build(SEXP builder_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterProperties::Builder>&>::type builder(builder_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::WriterPropertiesBuilder>&>::type builder(builder_sexp);
 	return Rcpp::wrap(parquet___WriterProperties___Builder__build(builder));
 END_RCPP
 }
@@ -4433,7 +4433,7 @@ RcppExport SEXP _arrow_parquet___WriterProperties___Builder__build(SEXP builder_
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::unique_ptr<parquet::arrow::FileWriter> parquet___arrow___ParquetFileWriter__Open(const std::shared_ptr<arrow::Schema>& schema, const std::shared_ptr<arrow::io::OutputStream>& sink, const std::shared_ptr<parquet::WriterProperties>& properties, const std::shared_ptr<parquet::ArrowWriterProperties>& arrow_properties);
+std::shared_ptr<parquet::arrow::FileWriter> parquet___arrow___ParquetFileWriter__Open(const std::shared_ptr<arrow::Schema>& schema, const std::shared_ptr<arrow::io::OutputStream>& sink, const std::shared_ptr<parquet::WriterProperties>& properties, const std::shared_ptr<parquet::ArrowWriterProperties>& arrow_properties);
 RcppExport SEXP _arrow_parquet___arrow___ParquetFileWriter__Open(SEXP schema_sexp, SEXP sink_sexp, SEXP properties_sexp, SEXP arrow_properties_sexp){
 BEGIN_RCPP
 	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::Schema>&>::type schema(schema_sexp);
@@ -4451,10 +4451,10 @@ RcppExport SEXP _arrow_parquet___arrow___ParquetFileWriter__Open(SEXP schema_sex
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___arrow___FileWriter__WriteTable(const std::unique_ptr<parquet::arrow::FileWriter>& writer, const std::shared_ptr<arrow::Table>& table, int64_t chunk_size);
+void parquet___arrow___FileWriter__WriteTable(const std::shared_ptr<parquet::arrow::FileWriter>& writer, const std::shared_ptr<arrow::Table>& table, int64_t chunk_size);
 RcppExport SEXP _arrow_parquet___arrow___FileWriter__WriteTable(SEXP writer_sexp, SEXP table_sexp, SEXP chunk_size_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::unique_ptr<parquet::arrow::FileWriter>&>::type writer(writer_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::arrow::FileWriter>&>::type writer(writer_sexp);
 	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::Table>&>::type table(table_sexp);
 	Rcpp::traits::input_parameter<int64_t>::type chunk_size(chunk_size_sexp);
 	parquet___arrow___FileWriter__WriteTable(writer, table, chunk_size);
@@ -4469,10 +4469,10 @@ RcppExport SEXP _arrow_parquet___arrow___FileWriter__WriteTable(SEXP writer_sexp
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void parquet___arrow___FileWriter__Close(const std::unique_ptr<parquet::arrow::FileWriter>& writer);
+void parquet___arrow___FileWriter__Close(const std::shared_ptr<parquet::arrow::FileWriter>& writer);
 RcppExport SEXP _arrow_parquet___arrow___FileWriter__Close(SEXP writer_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::unique_ptr<parquet::arrow::FileWriter>&>::type writer(writer_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::arrow::FileWriter>&>::type writer(writer_sexp);
 	parquet___arrow___FileWriter__Close(writer);
 	return R_NilValue;
 END_RCPP
@@ -4504,10 +4504,10 @@ RcppExport SEXP _arrow_parquet___arrow___WriteTable(SEXP table_sexp, SEXP sink_s
 
 // parquet.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::shared_ptr<arrow::Schema> parquet___arrow___FileReader__GetSchema(const std::unique_ptr<parquet::arrow::FileReader>& reader);
+std::shared_ptr<arrow::Schema> parquet___arrow___FileReader__GetSchema(const std::shared_ptr<parquet::arrow::FileReader>& reader);
 RcppExport SEXP _arrow_parquet___arrow___FileReader__GetSchema(SEXP reader_sexp){
 BEGIN_RCPP
-	Rcpp::traits::input_parameter<const std::unique_ptr<parquet::arrow::FileReader>&>::type reader(reader_sexp);
+	Rcpp::traits::input_parameter<const std::shared_ptr<parquet::arrow::FileReader>&>::type reader(reader_sexp);
 	return Rcpp::wrap(parquet___arrow___FileReader__GetSchema(reader));
 END_RCPP
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3824,7 +3824,7 @@ RcppExport SEXP _arrow_ipc___Message__Verify(SEXP message_sexp){
 
 // message.cpp
 #if defined(ARROW_R_WITH_ARROW)
-arrow::ipc::Message::Type ipc___Message__type(const std::unique_ptr<arrow::ipc::Message>& message);
+arrow::ipc::MessageType ipc___Message__type(const std::unique_ptr<arrow::ipc::Message>& message);
 RcppExport SEXP _arrow_ipc___Message__type(SEXP message_sexp){
 BEGIN_RCPP
 	Rcpp::traits::input_parameter<const std::unique_ptr<arrow::ipc::Message>&>::type message(message_sexp);
@@ -3901,7 +3901,7 @@ RcppExport SEXP _arrow_ipc___ReadSchema_Message(SEXP message_sexp){
 
 // message.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::unique_ptr<arrow::ipc::MessageReader> ipc___MessageReader__Open(const std::shared_ptr<arrow::io::InputStream>& stream);
+std::shared_ptr<arrow::ipc::MessageReader> ipc___MessageReader__Open(const std::shared_ptr<arrow::io::InputStream>& stream);
 RcppExport SEXP _arrow_ipc___MessageReader__Open(SEXP stream_sexp){
 BEGIN_RCPP
 	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::io::InputStream>&>::type stream(stream_sexp);
@@ -3916,7 +3916,7 @@ RcppExport SEXP _arrow_ipc___MessageReader__Open(SEXP stream_sexp){
 
 // message.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::unique_ptr<arrow::ipc::Message> ipc___MessageReader__ReadNextMessage(const std::unique_ptr<arrow::ipc::MessageReader>& reader);
+std::shared_ptr<arrow::ipc::Message> ipc___MessageReader__ReadNextMessage(const std::unique_ptr<arrow::ipc::MessageReader>& reader);
 RcppExport SEXP _arrow_ipc___MessageReader__ReadNextMessage(SEXP reader_sexp){
 BEGIN_RCPP
 	Rcpp::traits::input_parameter<const std::unique_ptr<arrow::ipc::MessageReader>&>::type reader(reader_sexp);
@@ -3931,7 +3931,7 @@ RcppExport SEXP _arrow_ipc___MessageReader__ReadNextMessage(SEXP reader_sexp){
 
 // message.cpp
 #if defined(ARROW_R_WITH_ARROW)
-std::unique_ptr<arrow::ipc::Message> ipc___ReadMessage(const std::shared_ptr<arrow::io::InputStream>& stream);
+std::shared_ptr<arrow::ipc::Message> ipc___ReadMessage(const std::shared_ptr<arrow::io::InputStream>& stream);
 RcppExport SEXP _arrow_ipc___ReadMessage(SEXP stream_sexp){
 BEGIN_RCPP
 	Rcpp::traits::input_parameter<const std::shared_ptr<arrow::io::InputStream>&>::type stream(stream_sexp);

--- a/r/src/arrow_exports.h
+++ b/r/src/arrow_exports.h
@@ -22,19 +22,50 @@
 #include "./arrow_rcpp.h"
 
 #if defined(ARROW_R_WITH_ARROW)
-#include <arrow/compute/cast.h>
-#include <arrow/csv/reader.h>
 #include <arrow/dataset/type_fwd.h>
 #include <arrow/filesystem/filesystem.h>
-#include <arrow/filesystem/localfs.h>
 #include <arrow/io/type_fwd.h>
-#include <arrow/ipc/feather.h>
-#include <arrow/ipc/reader.h>
-#include <arrow/ipc/writer.h>
-#include <arrow/json/reader.h>
+#include <arrow/ipc/message.h>
+#include <arrow/ipc/type_fwd.h>
 #include <arrow/type_fwd.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
+
+namespace arrow {
+namespace compute {
+
+class CastOptions;
+
+}  // namespace compute
+
+namespace csv {
+
+class TableReader;
+class ConvertOptions;
+class ReadOptions;
+class ParseOptions;
+
+}  // namespace csv
+
+namespace fs {
+
+class LocalFileSystem;
+
+}  // namespace fs
+
+namespace json {
+
+class TableReader;
+class ReadOptions;
+class ParseOptions;
+
+}  // namespace json
+
+}  // namespace arrow
+
+namespace parquet {
+namespace arrow {}
+}  // namespace parquet
 
 RCPP_EXPOSED_ENUM_NODECL(arrow::Type::type)
 RCPP_EXPOSED_ENUM_NODECL(arrow::DateUnit)
@@ -52,5 +83,9 @@ namespace fs = ::arrow::fs;
 #endif
 
 #if defined(ARROW_R_WITH_S3)
-#include <arrow/filesystem/s3fs.h>
+namespace arrow {
+namespace fs {
+class S3FileSystem;
+}  // namespace fs
+}  // namespace arrow
 #endif

--- a/r/src/arrow_exports.h
+++ b/r/src/arrow_exports.h
@@ -22,11 +22,11 @@
 #include "./arrow_rcpp.h"
 
 #if defined(ARROW_R_WITH_ARROW)
+#include <arrow/compute/cast.h>
 #include <arrow/csv/reader.h>
-#include <arrow/dataset/api.h>
+#include <arrow/dataset/type_fwd.h>
 #include <arrow/filesystem/filesystem.h>
 #include <arrow/filesystem/localfs.h>
-#include <arrow/io/compressed.h>
 #include <arrow/io/type_fwd.h>
 #include <arrow/ipc/feather.h>
 #include <arrow/ipc/reader.h>

--- a/r/src/arrow_exports.h
+++ b/r/src/arrow_exports.h
@@ -23,15 +23,15 @@
 
 #if defined(ARROW_R_WITH_ARROW)
 #include <arrow/dataset/type_fwd.h>
-#include <arrow/filesystem/filesystem.h>
+#include <arrow/filesystem/type_fwd.h>
 #include <arrow/io/type_fwd.h>
-#include <arrow/ipc/message.h>
 #include <arrow/ipc/type_fwd.h>
 #include <arrow/type_fwd.h>
 #include <parquet/arrow/reader.h>
 #include <parquet/arrow/writer.h>
 
 namespace arrow {
+
 namespace compute {
 
 class CastOptions;
@@ -47,12 +47,6 @@ class ParseOptions;
 
 }  // namespace csv
 
-namespace fs {
-
-class LocalFileSystem;
-
-}  // namespace fs
-
 namespace json {
 
 class TableReader;
@@ -63,16 +57,12 @@ class ParseOptions;
 
 }  // namespace arrow
 
-namespace parquet {
-namespace arrow {}
-}  // namespace parquet
-
 RCPP_EXPOSED_ENUM_NODECL(arrow::Type::type)
 RCPP_EXPOSED_ENUM_NODECL(arrow::DateUnit)
 RCPP_EXPOSED_ENUM_NODECL(arrow::TimeUnit::type)
 RCPP_EXPOSED_ENUM_NODECL(arrow::StatusCode)
 RCPP_EXPOSED_ENUM_NODECL(arrow::io::FileMode::type)
-RCPP_EXPOSED_ENUM_NODECL(arrow::ipc::Message::Type)
+RCPP_EXPOSED_ENUM_NODECL(arrow::ipc::MessageType)
 RCPP_EXPOSED_ENUM_NODECL(arrow::Compression::type)
 RCPP_EXPOSED_ENUM_NODECL(arrow::fs::FileType)
 RCPP_EXPOSED_ENUM_NODECL(parquet::ParquetVersion::type)
@@ -80,12 +70,4 @@ RCPP_EXPOSED_ENUM_NODECL(parquet::ParquetVersion::type)
 namespace ds = ::arrow::dataset;
 namespace fs = ::arrow::fs;
 
-#endif
-
-#if defined(ARROW_R_WITH_S3)
-namespace arrow {
-namespace fs {
-class S3FileSystem;
-}  // namespace fs
-}  // namespace arrow
 #endif

--- a/r/src/arrow_exports.h
+++ b/r/src/arrow_exports.h
@@ -27,13 +27,20 @@
 #include <arrow/io/type_fwd.h>
 #include <arrow/ipc/type_fwd.h>
 #include <arrow/type_fwd.h>
-#include <parquet/arrow/reader.h>
-#include <parquet/arrow/writer.h>
 
 namespace arrow {
 
-namespace compute {
+struct Type {
+  enum type {
+    // forward declaration
+  };
+};
 
+enum class StatusCode : char {
+  // forward declaration
+};
+
+namespace compute {
 class CastOptions;
 
 }  // namespace compute
@@ -57,6 +64,33 @@ class ParseOptions;
 
 }  // namespace arrow
 
+namespace ds = ::arrow::dataset;
+namespace fs = ::arrow::fs;
+
+namespace parquet {
+
+struct ParquetVersion {
+  enum type {
+    // forward declaration
+  };
+};
+
+class ReaderProperties;
+class ArrowReaderProperties;
+
+class WriterProperties;
+class WriterPropertiesBuilder;
+class ArrowWriterProperties;
+class ArrowWriterPropertiesBuilder;
+
+namespace arrow {
+
+class FileReader;
+class FileWriter;
+
+}  // namespace arrow
+}  // namespace parquet
+
 RCPP_EXPOSED_ENUM_NODECL(arrow::Type::type)
 RCPP_EXPOSED_ENUM_NODECL(arrow::DateUnit)
 RCPP_EXPOSED_ENUM_NODECL(arrow::TimeUnit::type)
@@ -66,8 +100,5 @@ RCPP_EXPOSED_ENUM_NODECL(arrow::ipc::MessageType)
 RCPP_EXPOSED_ENUM_NODECL(arrow::Compression::type)
 RCPP_EXPOSED_ENUM_NODECL(arrow::fs::FileType)
 RCPP_EXPOSED_ENUM_NODECL(parquet::ParquetVersion::type)
-
-namespace ds = ::arrow::dataset;
-namespace fs = ::arrow::fs;
 
 #endif

--- a/r/src/chunkedarray.cpp
+++ b/r/src/chunkedarray.cpp
@@ -22,7 +22,6 @@ using Rcpp::wrap;
 
 #if defined(ARROW_R_WITH_ARROW)
 
-#include <arrow/array.h>
 #include <arrow/table.h>
 
 // [[arrow::export]]

--- a/r/src/compression.cpp
+++ b/r/src/compression.cpp
@@ -24,13 +24,13 @@
 RCPP_EXPOSED_ENUM_NODECL(arrow::Compression::type)
 
 // [[arrow::export]]
-std::unique_ptr<arrow::util::Codec> util___Codec__Create(arrow::Compression::type codec,
+std::shared_ptr<arrow::util::Codec> util___Codec__Create(arrow::Compression::type codec,
                                                          int compression_level) {
   return ValueOrStop(arrow::util::Codec::Create(codec, compression_level));
 }
 
 // [[arrow::export]]
-std::string util___Codec__name(const std::unique_ptr<arrow::util::Codec>& codec) {
+std::string util___Codec__name(const std::shared_ptr<arrow::util::Codec>& codec) {
   return codec->name();
 }
 
@@ -41,14 +41,14 @@ bool util___Codec__IsAvailable(arrow::Compression::type codec) {
 
 // [[arrow::export]]
 std::shared_ptr<arrow::io::CompressedOutputStream> io___CompressedOutputStream__Make(
-    const std::unique_ptr<arrow::util::Codec>& codec,
+    const std::shared_ptr<arrow::util::Codec>& codec,
     const std::shared_ptr<arrow::io::OutputStream>& raw) {
   return ValueOrStop(arrow::io::CompressedOutputStream::Make(codec.get(), raw));
 }
 
 // [[arrow::export]]
 std::shared_ptr<arrow::io::CompressedInputStream> io___CompressedInputStream__Make(
-    const std::unique_ptr<arrow::util::Codec>& codec,
+    const std::shared_ptr<arrow::util::Codec>& codec,
     const std::shared_ptr<arrow::io::InputStream>& raw) {
   return ValueOrStop(arrow::io::CompressedInputStream::Make(codec.get(), raw));
 }

--- a/r/src/message.cpp
+++ b/r/src/message.cpp
@@ -21,7 +21,7 @@
 #include <arrow/ipc/reader.h>
 #include <arrow/ipc/writer.h>
 
-RCPP_EXPOSED_ENUM_NODECL(arrow::ipc::Message::Type)
+RCPP_EXPOSED_ENUM_NODECL(arrow::ipc::MessageType)
 
 // [[arrow::export]]
 int64_t ipc___Message__body_length(const std::unique_ptr<arrow::ipc::Message>& message) {
@@ -46,7 +46,7 @@ int64_t ipc___Message__Verify(const std::unique_ptr<arrow::ipc::Message>& messag
 }
 
 // [[arrow::export]]
-arrow::ipc::Message::Type ipc___Message__type(
+arrow::ipc::MessageType ipc___Message__type(
     const std::unique_ptr<arrow::ipc::Message>& message) {
   return message->type();
 }
@@ -85,19 +85,19 @@ std::shared_ptr<arrow::Schema> ipc___ReadSchema_Message(
 //--------- MessageReader
 
 // [[arrow::export]]
-std::unique_ptr<arrow::ipc::MessageReader> ipc___MessageReader__Open(
+std::shared_ptr<arrow::ipc::MessageReader> ipc___MessageReader__Open(
     const std::shared_ptr<arrow::io::InputStream>& stream) {
   return arrow::ipc::MessageReader::Open(stream);
 }
 
 // [[arrow::export]]
-std::unique_ptr<arrow::ipc::Message> ipc___MessageReader__ReadNextMessage(
+std::shared_ptr<arrow::ipc::Message> ipc___MessageReader__ReadNextMessage(
     const std::unique_ptr<arrow::ipc::MessageReader>& reader) {
   return ValueOrStop(reader->ReadNextMessage());
 }
 
 // [[arrow::export]]
-std::unique_ptr<arrow::ipc::Message> ipc___ReadMessage(
+std::shared_ptr<arrow::ipc::Message> ipc___ReadMessage(
     const std::shared_ptr<arrow::io::InputStream>& stream) {
   return ValueOrStop(arrow::ipc::ReadMessage(stream.get()));
 }

--- a/r/src/parquet.cpp
+++ b/r/src/parquet.cpp
@@ -58,19 +58,19 @@ void parquet___arrow___ArrowReaderProperties__set_read_dictionary(
 }
 
 // [[arrow::export]]
-std::unique_ptr<parquet::arrow::FileReader> parquet___arrow___FileReader__OpenFile(
+std::shared_ptr<parquet::arrow::FileReader> parquet___arrow___FileReader__OpenFile(
     const std::shared_ptr<arrow::io::RandomAccessFile>& file,
     const std::shared_ptr<parquet::ArrowReaderProperties>& props) {
   std::unique_ptr<parquet::arrow::FileReader> reader;
   parquet::arrow::FileReaderBuilder builder;
   PARQUET_THROW_NOT_OK(builder.Open(file));
   PARQUET_THROW_NOT_OK(builder.properties(*props)->Build(&reader));
-  return reader;
+  return std::move(reader);
 }
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable1(
-    const std::unique_ptr<parquet::arrow::FileReader>& reader) {
+    const std::shared_ptr<parquet::arrow::FileReader>& reader) {
   std::shared_ptr<arrow::Table> table;
   PARQUET_THROW_NOT_OK(reader->ReadTable(&table));
   return table;
@@ -78,7 +78,7 @@ std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable1(
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable2(
-    const std::unique_ptr<parquet::arrow::FileReader>& reader,
+    const std::shared_ptr<parquet::arrow::FileReader>& reader,
     const std::vector<int>& column_indices) {
   std::shared_ptr<arrow::Table> table;
   PARQUET_THROW_NOT_OK(reader->ReadTable(column_indices, &table));
@@ -87,57 +87,71 @@ std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable2(
 
 // [[arrow::export]]
 int64_t parquet___arrow___FileReader__num_rows(
-    const std::unique_ptr<parquet::arrow::FileReader>& reader) {
+    const std::shared_ptr<parquet::arrow::FileReader>& reader) {
   return reader->parquet_reader()->metadata()->num_rows();
 }
 
+namespace parquet {
+
+class WriterPropertiesBuilder : public WriterProperties::Builder {
+ public:
+  using WriterProperties::Builder::Builder;
+};
+
+class ArrowWriterPropertiesBuilder : public ArrowWriterProperties::Builder {
+ public:
+  using ArrowWriterProperties::Builder::Builder;
+};
+
+}  // namespace parquet
+
 // [[arrow::export]]
-std::shared_ptr<parquet::ArrowWriterProperties::Builder>
+std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>
 parquet___ArrowWriterProperties___Builder__create() {
-  return std::make_shared<parquet::ArrowWriterProperties::Builder>();
+  return std::make_shared<parquet::ArrowWriterPropertiesBuilder>();
 }
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__store_schema(
-    const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder) {
+    const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder) {
   builder->store_schema();
 }
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__enable_deprecated_int96_timestamps(
-    const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder) {
+    const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder) {
   builder->enable_deprecated_int96_timestamps();
 }
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__disable_deprecated_int96_timestamps(
-    const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder) {
+    const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder) {
   builder->disable_deprecated_int96_timestamps();
 }
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__coerce_timestamps(
-    const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder,
     arrow::TimeUnit::type unit) {
   builder->coerce_timestamps(unit);
 }
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__allow_truncated_timestamps(
-    const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder) {
+    const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder) {
   builder->allow_truncated_timestamps();
 }
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__disallow_truncated_timestamps(
-    const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder) {
+    const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder) {
   builder->disallow_truncated_timestamps();
 }
 
 // [[arrow::export]]
 std::shared_ptr<parquet::ArrowWriterProperties>
 parquet___ArrowWriterProperties___Builder__build(
-    const std::shared_ptr<parquet::ArrowWriterProperties::Builder>& builder) {
+    const std::shared_ptr<parquet::ArrowWriterPropertiesBuilder>& builder) {
   return builder->build();
 }
 
@@ -147,28 +161,28 @@ std::shared_ptr<parquet::WriterProperties> parquet___default_writer_properties()
 }
 
 // [[arrow::export]]
-std::shared_ptr<parquet::WriterProperties::Builder>
+std::shared_ptr<parquet::WriterPropertiesBuilder>
 parquet___WriterProperties___Builder__create() {
-  return std::make_shared<parquet::WriterProperties::Builder>();
+  return std::make_shared<parquet::WriterPropertiesBuilder>();
 }
 
 // [[arrow::export]]
 void parquet___WriterProperties___Builder__version(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     const parquet::ParquetVersion::type& version) {
   builder->version(version);
 }
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__default_compression(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     const arrow::Compression::type& compression) {
   builder->compression(compression);
 }
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__set_compressions(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     const std::vector<std::string>& paths, const Rcpp::IntegerVector& types) {
   auto n = paths.size();
   for (decltype(n) i = 0; i < n; i++) {
@@ -178,14 +192,14 @@ void parquet___ArrowWriterProperties___Builder__set_compressions(
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__default_compression_level(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     int compression_level) {
   builder->compression_level(compression_level);
 }
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__set_compression_levels(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     const std::vector<std::string>& paths, const Rcpp::IntegerVector& levels) {
   auto n = paths.size();
   for (decltype(n) i = 0; i < n; i++) {
@@ -195,7 +209,7 @@ void parquet___ArrowWriterProperties___Builder__set_compression_levels(
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__default_write_statistics(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     bool write_statistics) {
   if (write_statistics) {
     builder->enable_statistics();
@@ -206,7 +220,7 @@ void parquet___ArrowWriterProperties___Builder__default_write_statistics(
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__default_use_dictionary(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     bool use_dictionary) {
   if (use_dictionary) {
     builder->enable_dictionary();
@@ -217,7 +231,7 @@ void parquet___ArrowWriterProperties___Builder__default_use_dictionary(
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__set_use_dictionary(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     const std::vector<std::string>& paths, const Rcpp::LogicalVector& use_dictionary) {
   builder->disable_dictionary();
   auto n = paths.size();
@@ -232,7 +246,7 @@ void parquet___ArrowWriterProperties___Builder__set_use_dictionary(
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__set_write_statistics(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     const std::vector<std::string>& paths, const Rcpp::LogicalVector& write_statistics) {
   builder->disable_statistics();
   auto n = paths.size();
@@ -247,19 +261,19 @@ void parquet___ArrowWriterProperties___Builder__set_write_statistics(
 
 // [[arrow::export]]
 void parquet___ArrowWriterProperties___Builder__data_page_size(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder,
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder,
     int64_t data_page_size) {
   builder->data_pagesize(data_page_size);
 }
 
 // [[arrow::export]]
 std::shared_ptr<parquet::WriterProperties> parquet___WriterProperties___Builder__build(
-    const std::shared_ptr<parquet::WriterProperties::Builder>& builder) {
+    const std::shared_ptr<parquet::WriterPropertiesBuilder>& builder) {
   return builder->build();
 }
 
 // [[arrow::export]]
-std::unique_ptr<parquet::arrow::FileWriter> parquet___arrow___ParquetFileWriter__Open(
+std::shared_ptr<parquet::arrow::FileWriter> parquet___arrow___ParquetFileWriter__Open(
     const std::shared_ptr<arrow::Schema>& schema,
     const std::shared_ptr<arrow::io::OutputStream>& sink,
     const std::shared_ptr<parquet::WriterProperties>& properties,
@@ -268,19 +282,19 @@ std::unique_ptr<parquet::arrow::FileWriter> parquet___arrow___ParquetFileWriter_
   PARQUET_THROW_NOT_OK(
       parquet::arrow::FileWriter::Open(*schema, arrow::default_memory_pool(), sink,
                                        properties, arrow_properties, &writer));
-  return writer;
+  return std::move(writer);
 }
 
 // [[arrow::export]]
 void parquet___arrow___FileWriter__WriteTable(
-    const std::unique_ptr<parquet::arrow::FileWriter>& writer,
+    const std::shared_ptr<parquet::arrow::FileWriter>& writer,
     const std::shared_ptr<arrow::Table>& table, int64_t chunk_size) {
   PARQUET_THROW_NOT_OK(writer->WriteTable(*table, chunk_size));
 }
 
 // [[arrow::export]]
 void parquet___arrow___FileWriter__Close(
-    const std::unique_ptr<parquet::arrow::FileWriter>& writer) {
+    const std::shared_ptr<parquet::arrow::FileWriter>& writer) {
   PARQUET_THROW_NOT_OK(writer->Close());
 }
 
@@ -297,7 +311,7 @@ void parquet___arrow___WriteTable(
 
 // [[arrow::export]]
 std::shared_ptr<arrow::Schema> parquet___arrow___FileReader__GetSchema(
-    const std::unique_ptr<parquet::arrow::FileReader>& reader) {
+    const std::shared_ptr<parquet::arrow::FileReader>& reader) {
   std::shared_ptr<arrow::Schema> schema;
   StopIfNotOk(reader->GetSchema(&schema));
   return schema;

--- a/r/src/recordbatch.cpp
+++ b/r/src/recordbatch.cpp
@@ -18,7 +18,7 @@
 #include "./arrow_types.h"
 
 #if defined(ARROW_R_WITH_ARROW)
-#include <arrow/array.h>
+#include <arrow/array/array_base.h>
 #include <arrow/io/file.h>
 #include <arrow/io/memory.h>
 #include <arrow/ipc/reader.h>

--- a/r/src/scalar.cpp
+++ b/r/src/scalar.cpp
@@ -19,7 +19,8 @@
 
 #if defined(ARROW_R_WITH_ARROW)
 
-#include <arrow/array.h>
+#include <arrow/array/array_base.h>
+#include <arrow/array/util.h>
 #include <arrow/scalar.h>
 
 // [[arrow::export]]

--- a/r/src/table.cpp
+++ b/r/src/table.cpp
@@ -18,10 +18,6 @@
 #include "./arrow_types.h"
 #if defined(ARROW_R_WITH_ARROW)
 
-#include <arrow/array.h>
-#include <arrow/io/file.h>
-#include <arrow/ipc/reader.h>
-#include <arrow/ipc/writer.h>
 #include <arrow/table.h>
 #include <arrow/util/key_value_metadata.h>
 


### PR DESCRIPTION
cc @fsaintjacques @bkietz 

This goes on the assumptions that (1) all arrowExports.cpp needs are `**/type_fwd.h` and (2) that doing so would speed up compile time. My understanding is that (1) is true, assuming the type_fwd headers are complete enough, but IDK how much of an effect changing this has on (2).