### PR TITLE
ARROW-8962: [C++] Add explicit implementation for junk values

### DIFF
--- a/cpp/src/arrow/util/value_parsing.cc
+++ b/cpp/src/arrow/util/value_parsing.cc
@@ -47,6 +47,10 @@ struct StringToFloatConverterImpl {
 
 static const StringToFloatConverterImpl g_string_to_float;
 
+// Older clang versions need an explicit implementation definition.
+constexpr double StringToFloatConverterImpl::main_junk_value_;
+constexpr double StringToFloatConverterImpl::fallback_junk_value_;
+
 }  // namespace
 
 bool StringToFloat(const char* s, size_t length, float* out) {


### PR DESCRIPTION
When linking the tests with `clang-4.0`, I get

```
Undefined symbols for architecture x86_64:
  "arrow::internal::(anonymous namespace)::StringToFloatConverterImpl::main_junk_value_", referenced from:
      arrow::internal::StringToFloat(char const*, unsigned long, float*) in libarrow.a(value_parsing.cc.o)
      arrow::internal::StringToFloat(char const*, unsigned long, double*) in libarrow.a(value_parsing.cc.o)
  "arrow::internal::(anonymous namespace)::StringToFloatConverterImpl::fallback_junk_value_", referenced from:
      arrow::internal::StringToFloat(char const*, unsigned long, float*) in libarrow.a(value_parsing.cc.o)
      arrow::internal::StringToFloat(char const*, unsigned long, double*) in libarrow.a(value_parsing.cc.o)
ld: symbol(s) not found for architecture x86_64
```

These older clang versions need an explicit implementation definition.