### PR TITLE
ARROW-8771: [C++] Add boost/process library to build support

### DIFF
--- a/cpp/build-support/trim-boost.sh
+++ b/cpp/build-support/trim-boost.sh
@@ -41,6 +41,8 @@ BOOST_LIBS="$BOOST_LIBS regex.hpp"
 BOOST_LIBS="$BOOST_LIBS multiprecision/cpp_int.hpp"
 # These are for Thrift when Thrift_SOURCE=BUNDLED
 BOOST_LIBS="$BOOST_LIBS algorithm/string.hpp locale.hpp noncopyable.hpp numeric/conversion/cast.hpp scope_exit.hpp scoped_array.hpp shared_array.hpp tokenizer.hpp version.hpp"
+#These are for flight
+BOOST_LIBS="$BOOST_LIBS process.hpp process asio fusion"
 
 if [ ! -d ${BOOST_FILE} ]; then
   curl -L "${BOOST_URL}" > ${BOOST_FILE}.tar.gz

--- a/cpp/build-support/trim-boost.sh
+++ b/cpp/build-support/trim-boost.sh
@@ -32,7 +32,9 @@ set -eu
 : ${BOOST_URL:=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/${BOOST_FILE}.tar.gz}
 
 # Arrow tests require these
-BOOST_LIBS="process.hpp filesystem.hpp"
+# TODO: is system still required? We declare `--with-libraries=filesystem,regex,system`
+# in cmake, but there is no #include <boost/system.hpp> in our source anymore
+BOOST_LIBS="system.hpp process.hpp filesystem.hpp"
 # Add these to be able to build those
 BOOST_LIBS="$BOOST_LIBS config build boost_install headers log predef"
 # Parquet needs this (if using gcc < 4.9)

--- a/cpp/build-support/trim-boost.sh
+++ b/cpp/build-support/trim-boost.sh
@@ -32,17 +32,15 @@ set -eu
 : ${BOOST_URL:=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/${BOOST_FILE}.tar.gz}
 
 # Arrow tests require these
-BOOST_LIBS="system.hpp filesystem.hpp"
+BOOST_LIBS="process.hpp filesystem.hpp"
 # Add these to be able to build those
 BOOST_LIBS="$BOOST_LIBS config build boost_install headers log predef"
 # Parquet needs this (if using gcc < 4.9)
 BOOST_LIBS="$BOOST_LIBS regex.hpp"
-# Gandiva needs these
+# Gandiva needs this, and so does an arrow test
 BOOST_LIBS="$BOOST_LIBS multiprecision/cpp_int.hpp"
 # These are for Thrift when Thrift_SOURCE=BUNDLED
 BOOST_LIBS="$BOOST_LIBS algorithm/string.hpp locale.hpp noncopyable.hpp numeric/conversion/cast.hpp scope_exit.hpp scoped_array.hpp shared_array.hpp tokenizer.hpp version.hpp"
-#These are for flight
-BOOST_LIBS="$BOOST_LIBS process.hpp process asio fusion"
 
 if [ ! -d ${BOOST_FILE} ]; then
   curl -L "${BOOST_URL}" > ${BOOST_FILE}.tar.gz


### PR DESCRIPTION
Some of our test source code requires the process.hpp file (and its dependent libraries). Our current build support does not include these files, causing build failures like:

`fatal error: boost/process.hpp: No such file or directory`

In this PR, we add required header files which are sufficient to make flight build successful. 
The added header files are verified in my local machine. However, it seems the script is supposed to run from the server side, so we cannot test it. 