### PR TITLE
ARROW-1692: [Java] UnionArray round trip not working

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1548,7 +1548,6 @@ def get_generated_json_files(tempdir=None, flight=False):
 
         generate_unions_case()
         .skip_category('Go')
-        .skip_category('Java')  # TODO(ARROW-1692)
         .skip_category('JS')
         .skip_category('Rust'),
 

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -126,6 +126,8 @@ class IntegrationRunner(object):
                             if f.name == name).skip
             except StopIteration:
                 skip = set()
+            if name == 'union' and prefix == '0.17.1':
+                skip.add("Java")
             yield datagen.File(name, None, None, skip=skip, path=out_path)
 
     def _run_test_cases(self, producer, consumer, case_runner,

--- a/java/vector/src/main/java/org/apache/arrow/vector/BufferLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BufferLayout.java
@@ -33,7 +33,7 @@ public class BufferLayout {
     DATA("DATA"),
     OFFSET("OFFSET"),
     VALIDITY("VALIDITY"),
-    TYPE("TYPE");
+    TYPE("TYPE_ID");
 
     private final String name;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NullVector.java
@@ -223,10 +223,7 @@ public class NullVector implements FieldVector {
 
   @Override
   public boolean isNull(int index) {
-    if (index < valueCount) {
-      return true;
-    }
-    throw new IndexOutOfBoundsException();
+    return true;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/TypeLayout.java
@@ -71,8 +71,6 @@ public class TypeLayout {
         switch (type.getMode()) {
           case Dense:
             vectors = asList(
-                // TODO: validate this
-                BufferLayout.validityVector(),
                 BufferLayout.typeBuffer(),
                 BufferLayout.offsetBuffer() // offset to find the vector
             );
@@ -278,7 +276,7 @@ public class TypeLayout {
         switch (type.getMode()) {
           case Dense:
             // TODO: validate this
-            return 3;
+            return 2;
           case Sparse:
             // type buffer
             return 1;

--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/JsonFileReader.java
@@ -59,6 +59,7 @@ import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.DecimalUtility;
@@ -69,7 +70,9 @@ import org.apache.commons.codec.binary.Hex;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.MappingJsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A reader for JSON files that translates them into vectors. This reader is used for integration tests.
@@ -92,7 +95,10 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
   public JsonFileReader(File inputFile, BufferAllocator allocator) throws JsonParseException, IOException {
     super();
     this.allocator = allocator;
-    MappingJsonFactory jsonFactory = new MappingJsonFactory();
+    MappingJsonFactory jsonFactory = new MappingJsonFactory(new ObjectMapper()
+        //ignore case for enums
+        .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+    );
     this.parser = jsonFactory.createParser(inputFile);
     // Allow reading NaN for floating point values
     this.parser.configure(JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS, true);
@@ -173,7 +179,6 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
     if (t == START_OBJECT) {
       {
         int count = readNextField("count", Integer.class);
-        root.setRowCount(count);
         nextFieldIs("columns");
         readToken(START_ARRAY);
         {
@@ -183,6 +188,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
           }
         }
         readToken(END_ARRAY);
+        root.setRowCount(count);
       }
       readToken(END_OBJECT);
       return true;
@@ -707,7 +713,7 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
         BufferType bufferType = vectorTypes.get(v);
         nextFieldIs(bufferType.getName());
         int innerBufferValueCount = valueCount;
-        if (bufferType.equals(OFFSET)) {
+        if (bufferType.equals(OFFSET) && !field.getType().getTypeID().equals(ArrowType.ArrowTypeID.Union)) {
           /* offset buffer has 1 additional value capacity */
           innerBufferValueCount = valueCount + 1;
         }
@@ -720,7 +726,10 @@ public class JsonFileReader implements AutoCloseable, DictionaryProvider {
         return;
       }
 
-      final int nullCount = BitVectorHelper.getNullCount(vectorBuffers[0], valueCount);
+      int nullCount = 0;
+      if (!(vector.getField().getFieldType().getType() instanceof ArrowType.Union)) {
+        nullCount = BitVectorHelper.getNullCount(vectorBuffers[0], valueCount);
+      }
       final ArrowFieldNode fieldNode = new ArrowFieldNode(valueCount, nullCount);
       vector.loadFieldBuffers(fieldNode, Arrays.asList(vectorBuffers));
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -822,7 +822,14 @@ public class Types {
 
       @Override
       public MinorType visit(Union type) {
-        return MinorType.UNION;
+        switch (type.getMode()) {
+          case Sparse:
+            return MinorType.UNION;
+          case Dense:
+            return MinorType.DENSEUNION;
+          default:
+            throw new IllegalArgumentException("only Dense or Sparse unions supported: " + type);
+        }
       }
 
       @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/Validator.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/Validator.java
@@ -151,6 +151,8 @@ public class Validator {
     } else if (type instanceof ArrowType.Binary || type instanceof ArrowType.LargeBinary ||
         type instanceof ArrowType.FixedSizeBinary) {
       return Arrays.equals((byte[]) o1, (byte[]) o2);
+    } else if (o1 instanceof byte[] && o2 instanceof byte[]) {
+      return Arrays.equals((byte[]) o1, (byte[]) o2);
     }
 
     return Objects.equals(o1, o2);

--- a/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/util/VectorAppender.java
@@ -374,18 +374,18 @@ class VectorAppender implements VectorVisitor<ValueVector, Void> {
     }
 
     // append type buffers
-    PlatformDependent.copyMemory(deltaVector.getValidityBufferAddress(),
-            targetUnionVector.getValidityBufferAddress() + targetVector.getValueCount(),
+    PlatformDependent.copyMemory(deltaVector.getTypeBufferAddress(),
+            targetUnionVector.getTypeBufferAddress() + targetVector.getValueCount(),
             deltaVector.getValueCount());
 
     // build the hash set for all types
     HashSet<Integer> targetTypes = new HashSet<>();
     for (int i = 0; i < targetUnionVector.getValueCount(); i++) {
-      targetTypes.add((int) targetUnionVector.getValidityBuffer().getByte(i));
+      targetTypes.add(targetUnionVector.getTypeValue(i));
     }
     HashSet<Integer> deltaTypes = new HashSet<>();
     for (int i = 0; i < deltaVector.getValueCount(); i++) {
-      deltaTypes.add((int) deltaVector.getValidityBuffer().getByte(i));
+      deltaTypes.add(deltaVector.getTypeValue(i));
     }
 
     // append child vectors
@@ -431,11 +431,6 @@ class VectorAppender implements VectorVisitor<ValueVector, Void> {
     while (targetDenseUnionVector.getValueCapacity() < newValueCount) {
       targetDenseUnionVector.reAlloc();
     }
-
-    // append validity buffers
-    BitVectorHelper.concatBits(
-        targetVector.getValidityBuffer(), targetVector.getValueCount(),
-        deltaVector.getValidityBuffer(), deltaVector.getValueCount(), targetVector.getValidityBuffer());
 
     // append type buffers
     PlatformDependent.copyMemory(deltaVector.getTypeBuffer().memoryAddress(),

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDenseUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDenseUnionVector.java
@@ -89,12 +89,12 @@ public class TestDenseUnionVector {
       assertEquals(false, unionVector.isNull(0));
       assertEquals(100, unionVector.getObject(0));
 
-      assertEquals(true, unionVector.isNull(1));
+      assertNull(unionVector.getObject(1));
 
       assertEquals(false, unionVector.isNull(2));
       assertEquals(100, unionVector.getObject(2));
 
-      assertEquals(true, unionVector.isNull(3));
+      assertNull(unionVector.getObject(3));
     }
   }
 
@@ -136,12 +136,12 @@ public class TestDenseUnionVector {
         assertFalse(destVector.isNull(1));
         assertEquals(false, destVector.getObject(1));
 
-        assertTrue(destVector.isNull(2));
+        assertNull(destVector.getObject(2));
 
         assertFalse(destVector.isNull(3));
         assertEquals(10, destVector.getObject(3));
 
-        assertTrue(destVector.isNull(4));
+        assertNull(destVector.getObject(4));
 
         assertFalse(destVector.isNull(5));
         assertEquals(false, destVector.getObject(5));
@@ -385,7 +385,6 @@ public class TestDenseUnionVector {
 
       List<ArrowBuf> buffers = vector.getFieldBuffers();
 
-      long bitAddress = vector.getValidityBufferAddress();
       long offsetAddress = vector.getOffsetBufferAddress();
 
       try {
@@ -396,9 +395,8 @@ public class TestDenseUnionVector {
         assertTrue(error);
       }
 
-      assertEquals(3, buffers.size());
-      assertEquals(bitAddress, buffers.get(0).memoryAddress());
-      assertEquals(offsetAddress, buffers.get(2).memoryAddress());
+      assertEquals(2, buffers.size());
+      assertEquals(offsetAddress, buffers.get(1).memoryAddress());
     }
   }
 
@@ -461,15 +459,12 @@ public class TestDenseUnionVector {
 
       unionVector.setTypeId(0, typeId1);
       offsetBuf.setInt(0, 0);
-      BitVectorHelper.setBit(unionVector.getValidityBuffer(), 0);
 
       unionVector.setTypeId(1, typeId2);
       offsetBuf.setInt(DenseUnionVector.OFFSET_WIDTH, 0);
-      BitVectorHelper.setBit(unionVector.getValidityBuffer(), 1);
 
       unionVector.setTypeId(2, typeId1);
       offsetBuf.setInt(DenseUnionVector.OFFSET_WIDTH * 2, 1);
-      BitVectorHelper.setBit(unionVector.getValidityBuffer(), 2);
 
       unionVector.setValueCount(3);
 
@@ -526,25 +521,19 @@ public class TestDenseUnionVector {
       // slot 0 points to child1
       unionVector.setTypeId(0, typeId1);
       offsetBuf.setInt(0, 0);
-      BitVectorHelper.setBit(unionVector.getValidityBuffer(), 0);
 
       // slot 1 points to child2
       unionVector.setTypeId(1, typeId2);
       offsetBuf.setInt(DenseUnionVector.OFFSET_WIDTH, 0);
-      BitVectorHelper.setBit(unionVector.getValidityBuffer(), 1);
 
       // slot 2 points to child2
       unionVector.setTypeId(2, typeId2);
       offsetBuf.setInt(DenseUnionVector.OFFSET_WIDTH * 2, 1);
-      BitVectorHelper.setBit(unionVector.getValidityBuffer(), 2);
 
-      // slot 3 points to null
-      BitVectorHelper.unsetBit(unionVector.getValidityBuffer(), 3);
 
       // slot 4 points to child1
       unionVector.setTypeId(4, typeId1);
       offsetBuf.setInt(DenseUnionVector.OFFSET_WIDTH * 4, 1);
-      BitVectorHelper.setBit(unionVector.getValidityBuffer(), 4);
 
       unionVector.setValueCount(5);
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestTypeLayout.java
@@ -34,7 +34,7 @@ public class TestTypeLayout {
     ArrowType type = new ArrowType.Int(8, true);
     assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
-    type = new ArrowType.Union(UnionMode.Sparse, new int[3]);
+    type = new ArrowType.Union(UnionMode.Sparse, new int[2]);
     assertEquals(TypeLayout.getTypeBufferCount(type), TypeLayout.getTypeLayout(type).getBufferLayouts().size());
 
     type = new ArrowType.Union(UnionMode.Dense, new int[1]);

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestUnionVector.java
@@ -19,6 +19,7 @@ package org.apache.arrow.vector;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -81,12 +82,12 @@ public class TestUnionVector {
       assertEquals(false, unionVector.isNull(0));
       assertEquals(100, unionVector.getObject(0));
 
-      assertEquals(true, unionVector.isNull(1));
+      assertNull(unionVector.getObject(1));
 
       assertEquals(false, unionVector.isNull(2));
       assertEquals(100, unionVector.getObject(2));
 
-      assertEquals(true, unionVector.isNull(3));
+      assertNull(unionVector.getObject(3));
     }
   }
 
@@ -126,12 +127,12 @@ public class TestUnionVector {
         assertFalse(destVector.isNull(1));
         assertEquals(false, destVector.getObject(1));
 
-        assertTrue(destVector.isNull(2));
+        assertNull(destVector.getObject(2));
 
         assertFalse(destVector.isNull(3));
         assertEquals(10, destVector.getObject(3));
 
-        assertTrue(destVector.isNull(4));
+        assertNull(destVector.getObject(4));
 
         assertFalse(destVector.isNull(5));
         assertEquals(false, destVector.getObject(5));
@@ -365,7 +366,6 @@ public class TestUnionVector {
 
       List<ArrowBuf> buffers = vector.getFieldBuffers();
 
-      long bitAddress = vector.getValidityBufferAddress();
 
       try {
         long offsetAddress = vector.getOffsetBufferAddress();
@@ -385,7 +385,6 @@ public class TestUnionVector {
       }
 
       assertEquals(1, buffers.size());
-      assertEquals(bitAddress, buffers.get(0).memoryAddress());
     }
   }
 
@@ -407,7 +406,7 @@ public class TestUnionVector {
       holder.isSet = 0;
       srcVector.setSafe(0, holder);
 
-      assertTrue(srcVector.isNull(0));
+      assertNull(srcVector.getObject(0));
     }
   }
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -2798,36 +2798,36 @@ public class TestValueVector {
     }
 
     try (final UnionVector vector = UnionVector.empty("v", allocator)) {
-      assertEquals(1, vector.getValidityBuffer().refCnt());
-      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(1, vector.getTypeBuffer().refCnt());
+      assertEquals(0, vector.getTypeBuffer().capacity());
 
       vector.setValueCount(10);
       vector.allocateNewSafe();
-      assertEquals(1, vector.getValidityBuffer().refCnt());
-      assertEquals(4096, vector.getValidityBuffer().capacity());
+      assertEquals(1, vector.getTypeBuffer().refCnt());
+      assertEquals(4096, vector.getTypeBuffer().capacity());
 
       vector.close();
-      assertEquals(1, vector.getValidityBuffer().refCnt());
-      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(1, vector.getTypeBuffer().refCnt());
+      assertEquals(0, vector.getTypeBuffer().capacity());
     }
 
     try (final DenseUnionVector vector = DenseUnionVector.empty("v", allocator)) {
-      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getTypeBuffer().refCnt());
       assertEquals(1, vector.getOffsetBuffer().refCnt());
-      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(0, vector.getTypeBuffer().capacity());
       assertEquals(0, vector.getOffsetBuffer().capacity());
 
       vector.setValueCount(valueCount);
       vector.allocateNew();
-      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getTypeBuffer().refCnt());
       assertEquals(1, vector.getOffsetBuffer().refCnt());
-      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(4096, vector.getTypeBuffer().capacity());
       assertEquals(16384, vector.getOffsetBuffer().capacity());
 
       vector.close();
-      assertEquals(1, vector.getValidityBuffer().refCnt());
+      assertEquals(1, vector.getTypeBuffer().refCnt());
       assertEquals(1, vector.getOffsetBuffer().refCnt());
-      assertEquals(0, vector.getValidityBuffer().capacity());
+      assertEquals(0, vector.getTypeBuffer().capacity());
       assertEquals(0, vector.getOffsetBuffer().capacity());
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
@@ -19,7 +19,7 @@ package org.apache.arrow.vector.complex.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.DirtyRootAllocator;
@@ -93,7 +93,7 @@ public class TestPromotableWriter {
       assertFalse("2 shouldn't be null", uv.isNull(2));
       assertEquals(10, uv.getObject(2));
 
-      assertTrue("3 should be null", uv.isNull(3));
+      assertNull("3 should be null", uv.getObject(3));
 
       assertFalse("4 shouldn't be null", uv.isNull(4));
       assertEquals(100, uv.getObject(4));


### PR DESCRIPTION
This fixes the integration tests for Union Arrays.

Both Dense and Sparse unions now work:

* validity buffer added to Sparse Union
* both Union types now track logical types rather than MinorType enum ordinal

Dependent on #7289 for duplicate field names.