### PR TITLE
ARROW-8455: [Rust] Parquet Arrow column read on partially compatible files FIX

### DIFF
--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -223,7 +223,8 @@ mod tests {
     };
     use arrow::record_batch::RecordBatchReader;
     use rand::RngCore;
-    use serde_json::Value::Array as JArray;
+    use serde_json::json;
+    use serde_json::Value::{Array as JArray, Null as JNull, Object as JObject};
     use std::cmp::min;
     use std::convert::TryFrom;
     use std::env;
@@ -232,15 +233,8 @@ mod tests {
     use std::rc::Rc;
 
     #[test]
-    fn test_arrow_reader() {
-        let json_values = match serde_json::from_reader(get_test_file(
-            "parquet/generated_simple_numerics/blogs.json",
-        ))
-        .expect("Failed to read json value from file!")
-        {
-            JArray(values) => values,
-            _ => panic!("Input should be json array!"),
-        };
+    fn test_arrow_reader_all_columns() {
+        let json_values = get_json_array("parquet/generated_simple_numerics/blogs.json");
 
         let parquet_file_reader =
             get_test_reader("parquet/generated_simple_numerics/blogs.parquet");
@@ -253,24 +247,44 @@ mod tests {
             .get_record_reader(60)
             .expect("Failed to read into array!");
 
-        for i in 0..20 {
-            let array: Option<StructArray> = record_batch_reader
-                .next_batch()
-                .expect("Failed to read record batch!")
-                .map(|r| r.into());
+        // Verify that the schema was correctly parsed
+        let original_schema = arrow_reader.get_schema().unwrap().fields().clone();
+        assert_eq!(original_schema, *record_batch_reader.schema().fields());
 
-            let (start, end) = (i * 60 as usize, (i + 1) * 60 as usize);
+        compare_batch_json(&mut record_batch_reader, json_values, max_len);
+    }
 
-            if start < max_len {
-                assert!(array.is_some());
-                assert_ne!(0, array.as_ref().unwrap().len());
-                let end = min(end, max_len);
-                let json = JArray(Vec::from(&json_values[start..end]));
-                assert_eq!(array.unwrap(), json)
-            } else {
-                assert!(array.is_none());
-            }
-        }
+    #[test]
+    fn test_arrow_reader_single_column() {
+        let json_values = get_json_array("parquet/generated_simple_numerics/blogs.json");
+
+        let projected_json_values = json_values
+            .into_iter()
+            .map(|value| match value {
+                JObject(fields) => {
+                    json!({ "blog_id": fields.get("blog_id").unwrap_or(&JNull).clone()})
+                }
+                _ => panic!("Input should be json object array!"),
+            })
+            .collect::<Vec<_>>();
+
+        let parquet_file_reader =
+            get_test_reader("parquet/generated_simple_numerics/blogs.parquet");
+
+        let max_len = parquet_file_reader.metadata().file_metadata().num_rows() as usize;
+
+        let mut arrow_reader = ParquetFileArrowReader::new(parquet_file_reader);
+
+        let mut record_batch_reader = arrow_reader
+            .get_record_reader_by_columns(vec![2], 60)
+            .expect("Failed to read into array!");
+
+        // Verify that the schema was correctly parsed
+        let original_schema = arrow_reader.get_schema().unwrap().fields().clone();
+        assert_eq!(1, record_batch_reader.schema().fields().len());
+        assert_eq!(original_schema[1], record_batch_reader.schema().fields()[0]);
+
+        compare_batch_json(&mut record_batch_reader, projected_json_values, max_len);
     }
 
     #[test]
@@ -449,5 +463,39 @@ mod tests {
         path.push(file_name);
 
         File::open(path.as_path()).expect("File not found!")
+    }
+
+    fn get_json_array(filename: &str) -> Vec<serde_json::Value> {
+        match serde_json::from_reader(get_test_file(filename))
+            .expect("Failed to read json value from file!")
+        {
+            JArray(values) => values,
+            _ => panic!("Input should be json array!"),
+        }
+    }
+
+    fn compare_batch_json(
+        record_batch_reader: &mut RecordBatchReader,
+        json_values: Vec<serde_json::Value>,
+        max_len: usize,
+    ) {
+        for i in 0..20 {
+            let array: Option<StructArray> = record_batch_reader
+                .next_batch()
+                .expect("Failed to read record batch!")
+                .map(|r| r.into());
+
+            let (start, end) = (i * 60 as usize, (i + 1) * 60 as usize);
+
+            if start < max_len {
+                assert!(array.is_some());
+                assert_ne!(0, array.as_ref().unwrap().len());
+                let end = min(end, max_len);
+                let json = JArray(Vec::from(&json_values[start..end]));
+                assert_eq!(array.unwrap(), json)
+            } else {
+                assert!(array.is_none());
+            }
+        }
     }
 }


### PR DESCRIPTION
This is a fix for the faulty https://github.com/apache/arrow/pull/6935

It addresses https://issues.apache.org/jira/browse/ARROW-8455
>Seen behavior: When reading a Parquet file into Arrow with get_record_reader_by_columns, it will fail if one of the column of the file is a list (or any other unsupported type).

>Expected behavior: it should only fail if you are actually reading the column with unsuported type.

