### PR TITLE
ARROW-8968: [C++][Gandiva] set data layout for pre-compiled IR to llvm::module

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1068,8 +1068,9 @@ support library is itself covered by the above license.
 
 --------------------------------------------------------------------------------
 
-3rdparty dependency LLVM is statically linked in certain binary
-distributions. LLVM has the following license:
+3rdparty dependency LLVM is statically linked in certain binary distributions.
+Additionally some sections of source code have been derived from sources in LLVM
+and have been clearly labeled as such. LLVM has the following license:
 
 ==============================================================================
 LLVM Release License

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -165,7 +165,7 @@ static void setDataLayout(llvm::Module* module) {
   llvm::StringMap<bool> hostFeatures;
 
   if (llvm::sys::getHostCPUFeatures(hostFeatures))
-    for (auto &f : hostFeatures) features.AddFeature(f.first(), f.second);
+    for (auto& f : hostFeatures) features.AddFeature(f.first(), f.second);
 
   std::unique_ptr<llvm::TargetMachine> machine(
       target->createTargetMachine(targetTriple, cpu, features.getString(), {}, {}));

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -152,27 +152,40 @@ Status Engine::Make(const std::shared_ptr<Configuration>& conf,
   return Status::OK();
 }
 
-static void setDataLayout(llvm::Module* module) {
-  auto targetTriple = llvm::sys::getDefaultTargetTriple();
-  std::string errorMessage;
-  auto target = llvm::TargetRegistry::lookupTarget(targetTriple, errorMessage);
+// This method was modified from its original version for a part of MLIR
+// Original source:
+// from https://github.com/llvm/llvm-project/blob/9f2ce5b915a505a5488a5cf91bb0a8efa9ddfff7/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
+// The original copyright notice follows.
+
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+static void SetDataLayout(llvm::Module* module) {
+  auto target_triple = llvm::sys::getDefaultTargetTriple();
+  std::string error_message;
+  auto target = llvm::TargetRegistry::lookupTarget(target_triple, error_message);
   if (!target) {
     return;
   }
 
   std::string cpu(llvm::sys::getHostCPUName());
   llvm::SubtargetFeatures features;
-  llvm::StringMap<bool> hostFeatures;
+  llvm::StringMap<bool> host_features;
 
-  if (llvm::sys::getHostCPUFeatures(hostFeatures))
-    for (auto& f : hostFeatures) features.AddFeature(f.first(), f.second);
+  if (llvm::sys::getHostCPUFeatures(host_features)) {
+    for (auto& f : host_features) {
+      features.AddFeature(f.first(), f.second);
+    }
+  }
 
   std::unique_ptr<llvm::TargetMachine> machine(
-      target->createTargetMachine(targetTriple, cpu, features.getString(), {}, {}));
+      target->createTargetMachine(target_triple, cpu, features.getString(), {}, {}));
 
   module->setDataLayout(machine->createDataLayout());
 }
-
+// end of the mofified method from MLIR
+  
 // Handling for pre-compiled IR libraries.
 Status Engine::LoadPreCompiledIR() {
   auto bitcode = llvm::StringRef(reinterpret_cast<const char*>(kPrecompiledBitcode),
@@ -202,7 +215,7 @@ Status Engine::LoadPreCompiledIR() {
   std::unique_ptr<llvm::Module> ir_module = move(module_or_error.get());
 
   // set dataLayout
-  setDataLayout(ir_module.get());
+  SetDataLayout(ir_module.get());
 
   ARROW_RETURN_IF(llvm::verifyModule(*ir_module, &llvm::errs()),
                   Status::CodeGenError("verify of IR Module failed"));

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -153,8 +153,8 @@ Status Engine::Make(const std::shared_ptr<Configuration>& conf,
 }
 
 // This method was modified from its original version for a part of MLIR
-// Original source:
-// from https://github.com/llvm/llvm-project/blob/9f2ce5b915a505a5488a5cf91bb0a8efa9ddfff7/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
+// Original source from
+// https://github.com/llvm/llvm-project/blob/9f2ce5b915a505a5488a5cf91bb0a8efa9ddfff7/mlir/lib/ExecutionEngine/ExecutionEngine.cpp
 // The original copyright notice follows.
 
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -185,7 +185,7 @@ static void SetDataLayout(llvm::Module* module) {
   module->setDataLayout(machine->createDataLayout());
 }
 // end of the mofified method from MLIR
-  
+
 // Handling for pre-compiled IR libraries.
 Status Engine::LoadPreCompiledIR() {
   auto bitcode = llvm::StringRef(reinterpret_cast<const char*>(kPrecompiledBitcode),

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -165,11 +165,10 @@ static void setDataLayout(llvm::Module* module) {
   llvm::StringMap<bool> hostFeatures;
 
   if (llvm::sys::getHostCPUFeatures(hostFeatures))
-    for (auto &f : hostFeatures)
-      features.AddFeature(f.first(), f.second);
+    for (auto &f : hostFeatures) features.AddFeature(f.first(), f.second);
 
-  std::unique_ptr<llvm::TargetMachine> machine(target->createTargetMachine(
-      targetTriple, cpu, features.getString(), {}, {}));
+  std::unique_ptr<llvm::TargetMachine> machine(
+      target->createTargetMachine(targetTriple, cpu, features.getString(), {}, {}));
 
   module->setDataLayout(machine->createDataLayout());
 }


### PR DESCRIPTION
This PR explicitly sets data layout for pre-compiled IR to `llvm:module`. Without the PR, the following warning message is shown at link time of gandiva.

Most of this code comes from https://reviews.llvm.org/D80130 by @imaihal in llvm.

```
~/arrow/cpp/src/gandiva$ ../../build/debug/gandiva-binary-test -V
Running main() from /home/ishizaki/arrow/cpp/googletest_ep-prefix/src/googletest_ep/googletest/src/gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TestBinary
[ RUN      ] TestBinary.TestSimple
warning: Linking two modules of different data layouts: 'precompiled' is 'E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-a:8:16-n32:64' whereas 'codegen' is 'E-m:e-i1:8:16-i8:8:16-i64:64-f128:64-v128:64-a:8:16-n32:64'

[       OK ] TestBinary.TestSimple (41 ms)
[----------] 1 test from TestBinary (41 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (41 ms total)
[  PASSED  ] 1 test.
```