### PR TITLE
ARROW-8975: [FlightRPC][C++] try to fix MacOS flaky tests

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -116,10 +116,6 @@ jobs:
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: ON
-      # ARROW-7551: for now, build without Homebrew gRPC, as gRPC
-      # 1.26.0 is broken. https://github.com/grpc/grpc/pull/21662
-      gRPC_SOURCE: BUNDLED
-      Protobuf_SOURCE: BUNDLED
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2
@@ -131,11 +127,6 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: brew bundle --file=cpp/Brewfile
-        # ARROW-7551: for now, build without Homebrew gRPC, as gRPC
-        # 1.26.0 is broken. https://github.com/grpc/grpc/pull/21662
-      - name: Uninstall Problematic Homebrew Dependencies
-        shell: bash
-        run: brew uninstall grpc protobuf
       - name: Build
         shell: bash
         run: ci/scripts/cpp_build.sh $(pwd) $(pwd)/build

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -198,6 +198,8 @@ endif()
 
 if(ARROW_FLIGHT)
   set(ARROW_WITH_GRPC ON)
+  # gRPC requires zlib
+  set(ARROW_WITH_ZLIB ON)
 endif()
 
 if(ARROW_JSON)
@@ -2045,7 +2047,8 @@ macro(build_grpc)
     add_dependencies(grpc_dependencies gflags_ep)
   endif()
 
-  add_dependencies(grpc_dependencies ${ARROW_PROTOBUF_LIBPROTOBUF} c-ares::cares)
+  add_dependencies(grpc_dependencies ${ARROW_PROTOBUF_LIBPROTOBUF} c-ares::cares
+                   ZLIB::ZLIB)
 
   get_target_property(GRPC_PROTOBUF_INCLUDE_DIR ${ARROW_PROTOBUF_LIBPROTOBUF}
                       INTERFACE_INCLUDE_DIRECTORIES)

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -24,7 +24,8 @@ set(ARROW_FLIGHT_STATIC_LINK_LIBS
     gRPC::grpc++
     gRPC::grpc
     gRPC::gpr
-    c-ares::cares)
+    c-ares::cares
+    ZLIB::ZLIB)
 
 if(WIN32)
   list(APPEND ARROW_FLIGHT_STATIC_LINK_LIBS ws2_32.lib)


### PR DESCRIPTION
This seems OK in CI and should speed up the build as we no longer have to compile Protobuf and gRPC. I'm still a bit bothered since it's unclear upstream whether the root issue is truly fixed or not; if we see any more failures, we should just disable tests using TLS entirely on MacOS.