### PR TITLE
ARROW-8487: [FlightRPC] Provide a way to target a particular payload size

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -60,7 +60,30 @@ class MemoryPool;
 
 namespace flight {
 
+const char* kWriteSizeDetailTypeId = "flight::FlightWriteSizeStatusDetail";
+
 FlightCallOptions::FlightCallOptions() : timeout(-1) {}
+
+const char* FlightWriteSizeStatusDetail::type_id() const {
+  return kWriteSizeDetailTypeId;
+}
+
+std::string FlightWriteSizeStatusDetail::ToString() const {
+  std::stringstream ss;
+  ss << "IPC payload size (" << actual_ << " bytes) exceeded soft limit (" << limit_
+     << " bytes)";
+  return ss.str();
+}
+
+std::shared_ptr<FlightWriteSizeStatusDetail> FlightWriteSizeStatusDetail::UnwrapStatus(
+    const arrow::Status& status) {
+  if (!status.detail() || status.detail()->type_id() != kWriteSizeDetailTypeId) {
+    return nullptr;
+  }
+  return std::dynamic_pointer_cast<FlightWriteSizeStatusDetail>(status.detail());
+}
+
+FlightClientOptions FlightClientOptions::Defaults() { return FlightClientOptions(); }
 
 struct ClientRpc {
   grpc::ClientContext context;
@@ -550,17 +573,19 @@ class GrpcStreamWriter : public FlightStreamWriter {
 
   explicit GrpcStreamWriter(
       const FlightDescriptor& descriptor, std::shared_ptr<ClientRpc> rpc,
+      int64_t write_size_limit_bytes,
       std::shared_ptr<FinishableWritableStream<GrpcStream, FlightReadT>> writer)
       : app_metadata_(nullptr),
         batch_writer_(nullptr),
         writer_(std::move(writer)),
         rpc_(std::move(rpc)),
+        write_size_limit_bytes_(write_size_limit_bytes),
         descriptor_(descriptor),
         writer_closed_(false) {}
 
   static Status Open(
       const FlightDescriptor& descriptor, std::shared_ptr<Schema> schema,
-      std::shared_ptr<ClientRpc> rpc,
+      std::shared_ptr<ClientRpc> rpc, int64_t write_size_limit_bytes,
       std::shared_ptr<FinishableWritableStream<GrpcStream, FlightReadT>> writer,
       std::unique_ptr<FlightStreamWriter>* out);
 
@@ -576,8 +601,8 @@ class GrpcStreamWriter : public FlightStreamWriter {
       return Status::Invalid("This writer has already been started.");
     }
     std::unique_ptr<ipc::internal::IpcPayloadWriter> payload_writer(
-        new DoPutPayloadWriter<ProtoReadT, FlightReadT>(descriptor_, std::move(rpc_),
-                                                        writer_, this));
+        new DoPutPayloadWriter<ProtoReadT, FlightReadT>(
+            descriptor_, std::move(rpc_), write_size_limit_bytes_, writer_, this));
     // XXX: this does not actually write the message to the stream.
     // See Close().
     ARROW_ASSIGN_OR_RAISE(batch_writer_, ipc::internal::OpenRecordBatchWriter(
@@ -642,6 +667,7 @@ class GrpcStreamWriter : public FlightStreamWriter {
   // Fields used to lazy-initialize the IpcPayloadWriter. They're
   // invalid once Begin() is called.
   std::shared_ptr<ClientRpc> rpc_;
+  int64_t write_size_limit_bytes_;
   FlightDescriptor descriptor_;
   bool writer_closed_;
 };
@@ -655,10 +681,12 @@ class DoPutPayloadWriter : public ipc::internal::IpcPayloadWriter {
 
   DoPutPayloadWriter(
       const FlightDescriptor& descriptor, std::shared_ptr<ClientRpc> rpc,
+      int64_t write_size_limit_bytes,
       std::shared_ptr<FinishableWritableStream<GrpcStream, FlightReadT>> writer,
       GrpcStreamWriter<ProtoReadT, FlightReadT>* stream_writer)
       : descriptor_(descriptor),
         rpc_(rpc),
+        write_size_limit_bytes_(write_size_limit_bytes),
         writer_(std::move(writer)),
         first_payload_(true),
         stream_writer_(stream_writer) {}
@@ -684,6 +712,23 @@ class DoPutPayloadWriter : public ipc::internal::IpcPayloadWriter {
       payload.app_metadata = std::move(stream_writer_->app_metadata_);
     }
 
+    if (write_size_limit_bytes_ > 0) {
+      // Check if the total size is greater than the user-configured
+      // soft-limit.
+      int64_t size = ipc_payload.body_length + ipc_payload.metadata->size();
+      if (payload.descriptor) {
+        size += payload.descriptor->size();
+      }
+      if (payload.app_metadata) {
+        size += payload.app_metadata->size();
+      }
+      if (size > write_size_limit_bytes_) {
+        return arrow::Status(
+            arrow::StatusCode::IOError, "IPC payload size exceeded soft limit",
+            std::make_shared<FlightWriteSizeStatusDetail>(write_size_limit_bytes_, size));
+      }
+    }
+
     if (!internal::WritePayload(payload, writer_->stream().get())) {
       return writer_->Finish(MakeFlightError(FlightStatusCode::Internal,
                                              "Could not write record batch to stream"));
@@ -699,6 +744,7 @@ class DoPutPayloadWriter : public ipc::internal::IpcPayloadWriter {
  protected:
   const FlightDescriptor descriptor_;
   std::shared_ptr<ClientRpc> rpc_;
+  int64_t write_size_limit_bytes_;
   std::shared_ptr<FinishableWritableStream<GrpcStream, FlightReadT>> writer_;
   bool first_payload_;
   GrpcStreamWriter<ProtoReadT, FlightReadT>* stream_writer_;
@@ -708,11 +754,12 @@ template <typename ProtoReadT, typename FlightReadT>
 Status GrpcStreamWriter<ProtoReadT, FlightReadT>::Open(
     const FlightDescriptor& descriptor,
     std::shared_ptr<Schema> schema,  // this schema is nullable
-    std::shared_ptr<ClientRpc> rpc,
+    std::shared_ptr<ClientRpc> rpc, int64_t write_size_limit_bytes,
     std::shared_ptr<FinishableWritableStream<GrpcStream, FlightReadT>> writer,
     std::unique_ptr<FlightStreamWriter>* out) {
   std::unique_ptr<GrpcStreamWriter<ProtoReadT, FlightReadT>> instance(
-      new GrpcStreamWriter<ProtoReadT, FlightReadT>(descriptor, std::move(rpc), writer));
+      new GrpcStreamWriter<ProtoReadT, FlightReadT>(descriptor, std::move(rpc),
+                                                    write_size_limit_bytes, writer));
   if (schema) {
     // The schema was provided (DoPut). Eagerly write the schema and
     // descriptor together as the first message.
@@ -809,6 +856,7 @@ class FlightClient::FlightClientImpl {
         grpc::experimental::CreateCustomChannelWithInterceptors(
             grpc_uri.str(), creds, args, std::move(interceptors)));
 
+    write_size_limit_bytes_ = options.write_size_limit_bytes;
     return Status::OK();
   }
 
@@ -971,7 +1019,8 @@ class FlightClient::FlightClientImpl {
             rpc, read_mutex, stream);
     *reader =
         std::unique_ptr<FlightMetadataReader>(new GrpcMetadataReader(stream, read_mutex));
-    return StreamWriter::Open(descriptor, schema, rpc, finishable_stream, out);
+    return StreamWriter::Open(descriptor, schema, rpc, write_size_limit_bytes_,
+                              finishable_stream, out);
   }
 
   Status DoExchange(const FlightCallOptions& options, const FlightDescriptor& descriptor,
@@ -995,12 +1044,14 @@ class FlightClient::FlightClientImpl {
         new StreamReader(rpc, read_mutex, finishable_stream));
     // Do not eagerly read the schema. There may be metadata messages
     // before any data is sent, or data may not be sent at all.
-    return StreamWriter::Open(descriptor, nullptr, rpc, finishable_stream, writer);
+    return StreamWriter::Open(descriptor, nullptr, rpc, write_size_limit_bytes_,
+                              finishable_stream, writer);
   }
 
  private:
   std::unique_ptr<pb::FlightService::Stub> stub_;
   std::shared_ptr<ClientAuthHandler> auth_handler_;
+  int64_t write_size_limit_bytes_;
 };
 
 FlightClient::FlightClient() { impl_.reset(new FlightClientImpl); }

--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -60,6 +60,24 @@ class ARROW_FLIGHT_EXPORT FlightCallOptions {
   TimeoutDuration timeout;
 };
 
+/// \brief Indicate that the client attempted to write a message
+///     larger than the soft limit set via write_size_limit_bytes.
+class ARROW_FLIGHT_EXPORT FlightWriteSizeStatusDetail : public arrow::StatusDetail {
+ public:
+  explicit FlightWriteSizeStatusDetail(int64_t limit, int64_t actual)
+      : limit_(limit), actual_(actual) {}
+  const char* type_id() const override;
+  std::string ToString() const override;
+  int64_t limit() const { return limit_; }
+  int64_t actual() const { return actual_; }
+  static std::shared_ptr<FlightWriteSizeStatusDetail> UnwrapStatus(
+      const arrow::Status& status);
+
+ private:
+  int64_t limit_;
+  int64_t actual_;
+};
+
 class ARROW_FLIGHT_EXPORT FlightClientOptions {
  public:
   /// \brief Root certificates to use for validating server
@@ -73,6 +91,16 @@ class ARROW_FLIGHT_EXPORT FlightClientOptions {
   std::string private_key;
   /// \brief A list of client middleware to apply.
   std::vector<std::shared_ptr<ClientMiddlewareFactory>> middleware;
+  /// \brief A soft limit on the number of bytes to write when sending
+  ///     Arrow data to a server.
+  ///
+  /// Used to help limit server memory consumption. Only enabled if
+  /// positive. When enabled, \a FlightStreamWriter.Write* may yield a
+  /// \a IOError with error detail \a TODO.
+  int64_t write_size_limit_bytes;
+
+  /// \brief Get default options.
+  static FlightClientOptions Defaults();
 };
 
 /// \brief A RecordBatchReader exposing Flight metadata and cancel

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -33,6 +33,7 @@
 #include "arrow/flight/api.h"
 #include "arrow/ipc/test_common.h"
 #include "arrow/status.h"
+#include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/util/make_unique.h"
@@ -323,7 +324,7 @@ Status MakeServer(std::unique_ptr<FlightServerBase>* server,
   RETURN_NOT_OK((*server)->Init(server_options));
   Location real_location;
   RETURN_NOT_OK(Location::ForGrpcTcp("localhost", (*server)->port(), &real_location));
-  FlightClientOptions client_options;
+  FlightClientOptions client_options = FlightClientOptions::Defaults();
   RETURN_NOT_OK(make_client_options(&client_options));
   return FlightClient::Connect(real_location, client_options, client);
 }
@@ -1354,6 +1355,46 @@ TEST_F(TestDoPut, DoPutDicts) {
   }
 
   CheckDoPut(descr, schema, batches);
+}
+
+TEST_F(TestDoPut, DoPutSizeLimit) {
+  const int64_t size_limit = 4096;
+  Location location;
+  ASSERT_OK(Location::ForGrpcTcp("localhost", server_->port(), &location));
+  FlightClientOptions client_options;
+  client_options.write_size_limit_bytes = size_limit;
+  std::unique_ptr<FlightClient> client;
+  ASSERT_OK(FlightClient::Connect(location, client_options, &client));
+
+  auto descr = FlightDescriptor::Path({"ints"});
+  // Batch is too large to fit in one message
+  auto schema = arrow::schema({field("f1", arrow::int64())});
+  auto batch = arrow::ConstantArrayGenerator::Zeroes(768, schema);
+  BatchVector batches;
+  batches.push_back(batch->Slice(0, 384));
+  batches.push_back(batch->Slice(384));
+
+  std::unique_ptr<FlightStreamWriter> stream;
+  std::unique_ptr<FlightMetadataReader> reader;
+  ASSERT_OK(client->DoPut(descr, schema, &stream, &reader));
+
+  // Large batch will exceed the limit
+  const auto status = stream->WriteRecordBatch(*batch);
+  EXPECT_RAISES_WITH_MESSAGE_THAT(IOError, ::testing::HasSubstr("exceeded soft limit"),
+                                  status);
+  auto detail = FlightWriteSizeStatusDetail::UnwrapStatus(status);
+  ASSERT_NE(nullptr, detail);
+  ASSERT_EQ(size_limit, detail->limit());
+  ASSERT_GT(detail->actual(), size_limit);
+
+  // But we can retry with a smaller batch
+  for (const auto& batch : batches) {
+    ASSERT_OK(stream->WriteRecordBatch(*batch));
+  }
+
+  ASSERT_OK(stream->DoneWriting());
+  ASSERT_OK(stream->Close());
+  CheckBatches(descr, batches);
 }
 
 TEST_F(TestAuthHandler, PassAuthenticatedCalls) {

--- a/cpp/src/arrow/flight/test_integration_client.cc
+++ b/cpp/src/arrow/flight/test_integration_client.cc
@@ -212,7 +212,8 @@ int main(int argc, char** argv) {
     scenario = std::make_shared<arrow::flight::IntegrationTestScenario>();
   }
 
-  arrow::flight::FlightClientOptions options;
+  arrow::flight::FlightClientOptions options =
+      arrow::flight::FlightClientOptions::Defaults();
   std::unique_ptr<arrow::flight::FlightClient> client;
 
   ABORT_NOT_OK(scenario->MakeClient(&options));

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -70,6 +70,14 @@ cdef int check_flight_status(const CStatus& status) nogil except -1:
             elif detail.get().code() == CFlightStatusUnavailable:
                 raise FlightUnavailableError(message, detail_msg)
 
+    size_detail = FlightWriteSizeStatusDetail.UnwrapStatus(status)
+    if size_detail:
+        with gil:
+            message = frombytes(status.message())
+            raise FlightWriteSizeExceededError(
+                message,
+                size_detail.get().limit(), size_detail.get().actual())
+
     return check_status(status)
 
 
@@ -176,6 +184,16 @@ cdef class FlightUnavailableError(FlightError, ArrowException):
     cdef CStatus to_status(self):
         return MakeFlightError(CFlightStatusUnavailable, tobytes(str(self)),
                                self.extra_info)
+
+
+class FlightWriteSizeExceededError(OSError, ArrowException):
+    """A write operation exceeded the client-configured limit."""
+
+    def __init__(self, message, limit, actual):
+        super().__init__(message)
+        self.limit = limit
+        self.actual = actual
+
 
 cdef class Action:
     """An action executable on a Flight service."""
@@ -847,6 +865,23 @@ cdef class FlightStreamReader(MetadataRecordBatchReader):
 cdef class FlightStreamWriter(_CRecordBatchWriter):
     """A RecordBatchWriter that also allows writing application metadata."""
 
+    def write_batch(self, RecordBatch batch):
+        """
+        Write RecordBatch to stream.
+
+        Parameters
+        ----------
+        batch : RecordBatch
+        """
+        # Override superclass method to use check_flight_status so we
+        # can generate FlightWriteSizeExceededError. We don't do this
+        # for write_table as callers who intend to handle the error
+        # and retry with a smaller batch should be working with
+        # individual batches to have control.
+        with nogil:
+            check_flight_status(
+                self.writer.get().WriteRecordBatch(deref(batch.batch)))
+
     def write_with_metadata(self, RecordBatch batch, buf):
         """Write a RecordBatch along with Flight metadata.
 
@@ -927,12 +962,19 @@ cdef class FlightClient:
         Override the hostname checked by TLS. Insecure, use with caution.
     middleware : list optional, default None
         A list of ClientMiddlewareFactory instances.
+    write_size_limit_bytes : int optional, default None
+        A soft limit on the size of a data payload sent to the
+        server. Enabled if positive. If enabled, writing a record
+        batch that (when serialized) exceeds this limit will raise an
+        exception; the client can retry the write with a smaller
+        batch.
     """
     cdef:
         unique_ptr[CFlightClient] client
 
     def __init__(self, location, tls_root_certs=None, cert_chain=None,
-                 private_key=None, override_hostname=None, middleware=None):
+                 private_key=None, override_hostname=None, middleware=None,
+                 write_size_limit_bytes=None):
         if isinstance(location, (bytes, str)):
             location = Location(location)
         elif isinstance(location, tuple):
@@ -945,10 +987,11 @@ cdef class FlightClient:
             raise TypeError('`location` argument must be a string, tuple or a '
                             'Location instance')
         self.init(location, tls_root_certs, cert_chain, private_key,
-                  override_hostname, middleware)
+                  override_hostname, middleware, write_size_limit_bytes)
 
     cdef init(self, Location location, tls_root_certs, cert_chain,
-              private_key, override_hostname, middleware):
+              private_key, override_hostname, middleware,
+              write_size_limit_bytes):
         cdef:
             int c_port = 0
             CLocation c_location = Location.unwrap(location)
@@ -970,6 +1013,10 @@ cdef class FlightClient:
                     <shared_ptr[CClientMiddlewareFactory]>
                     make_shared[CPyClientMiddlewareFactory](
                         <PyObject*> factory, start_call))
+        if write_size_limit_bytes is not None:
+            c_options.write_size_limit_bytes = write_size_limit_bytes
+        else:
+            c_options.write_size_limit_bytes = 0
 
         with nogil:
             check_flight_status(CFlightClient.Connect(c_location, c_options,

--- a/python/pyarrow/flight.py
+++ b/python/pyarrow/flight.py
@@ -37,6 +37,7 @@ from pyarrow._flight import (  # noqa
     FlightUnauthenticatedError,
     FlightUnauthorizedError,
     FlightUnavailableError,
+    FlightWriteSizeExceededError,
     GeneratorStream,
     Location,
     Ticket,

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -281,6 +281,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
         c_string private_key
         c_string override_hostname
         vector[shared_ptr[CClientMiddlewareFactory]] middleware
+        int64_t write_size_limit_bytes
 
     cdef cppclass CFlightClient" arrow::flight::FlightClient":
         @staticmethod
@@ -336,6 +337,15 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
 
         @staticmethod
         shared_ptr[FlightStatusDetail] UnwrapStatus(const CStatus& status)
+
+    cdef cppclass FlightWriteSizeStatusDetail\
+            " arrow::flight::FlightWriteSizeStatusDetail":
+        int64_t limit()
+        int64_t actual()
+
+        @staticmethod
+        shared_ptr[FlightWriteSizeStatusDetail] UnwrapStatus(
+            const CStatus& status)
 
     cdef CStatus MakeFlightError" arrow::flight::MakeFlightError" \
         (CFlightStatusCode code, const c_string& message)

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -23,6 +23,7 @@ import threading
 import time
 import traceback
 
+import numpy as np
 import pytest
 import pyarrow as pa
 
@@ -922,6 +923,34 @@ def test_flight_do_put_metadata():
                 assert buf is not None
                 server_idx, = struct.unpack('<i', buf.to_pybytes())
                 assert idx == server_idx
+
+
+def test_flight_do_put_limit():
+    """Try a simple do_put call with a size limit."""
+    large_batch = pa.RecordBatch.from_arrays([
+        pa.array(np.ones(768, dtype=np.int64())),
+    ], names=['a'])
+
+    with EchoFlightServer() as server:
+        client = FlightClient(('localhost', server.port),
+                              write_size_limit_bytes=4096)
+        writer, metadata_reader = client.do_put(
+            flight.FlightDescriptor.for_path(''),
+            large_batch.schema)
+        with writer:
+            with pytest.raises(flight.FlightWriteSizeExceededError,
+                               match="exceeded soft limit") as excinfo:
+                writer.write_batch(large_batch)
+            assert excinfo.value.limit == 4096
+            smaller_batches = [
+                large_batch.slice(0, 384),
+                large_batch.slice(384),
+            ]
+            for batch in smaller_batches:
+                writer.write_batch(batch)
+        expected = pa.Table.from_batches([large_batch])
+        actual = client.do_get(flight.Ticket(b'')).read_all()
+        assert expected == actual
 
 
 @pytest.mark.slow


### PR DESCRIPTION
I'd appreciate feedback on this. This is a specialized API to limit the payload size when a client is sending data to a server. 

While Flight by default removes the gRPC-level limits on message sizes, we've found setting server-side limits on the size of incoming messages is still useful to ensure clients don't overwhelm a server/exhaust server memory by sending very large messages. However, if you exceed the limit at the gRPC level, the server resets the connection, making it hard for a client to recover gracefully. This PR adds an optional client-side check, so the client can catch the error and retry with a smaller record batch, or provide a meaningful error to the user if the batch cannot be made small enough.

Unlike solutions involving `pa.ipc.get_record_batch_size`, this avoids duplicate re-serialization of the record batch.

This is essentially a flight-specific version of [ARROW-5377](https://issues.apache.org/jira/browse/ARROW-5377). I proposed a candidate API there, but it's much more complex than the solution here.