### PR TITLE
ARROW-8982: [CI] Remove allow_failures for s390x on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,6 @@ jobs:
         UBUNTU: "20.04"
         cares_SOURCE: "BUNDLED"
         gRPC_SOURCE: "BUNDLED"
-  allow_failures:
-    - arch: s390x
 
 env:
   DOCKER_BUILDKIT: 0


### PR DESCRIPTION
This PR removes `allow_failures` option for s390x on TravisCI. This is because the current master can succeed all of the existing tests enabled for s390x, as you can see https://travis-ci.org/github/apache/arrow/jobs/692580505.

