### PR TITLE
ARROW-8978: [C++][CI] Fix valgrind warnings in cpp-conda-valgrind nightly build

### DIFF
--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -30,6 +30,7 @@
 #include "arrow/compute/function.h"
 #include "arrow/compute/kernel.h"
 #include "arrow/compute/registry.h"
+#include "arrow/compute/util_internal.h"
 #include "arrow/datum.h"
 #include "arrow/scalar.h"
 #include "arrow/status.h"
@@ -495,6 +496,13 @@ class FunctionExecutorImpl : public FunctionExecutor {
 
     if (validity_preallocated_) {
       ARROW_ASSIGN_OR_RAISE(out->buffers[0], kernel_ctx_.AllocateBitmap(length));
+#ifdef ARROW_VALGRIND
+      // ARROW-8976: When writing kernel results chunkwise into larger
+      // preallocations, if the exec_chunksize is not a multiple of 8, then
+      // functions in NullPropagator will access bits that have not yet been
+      // intialized, triggering benign valgrind warnings.
+      internal::ZeroMemory(out->buffers[0].get());
+#endif
     }
     if (data_preallocated_) {
       const auto& fw_type = checked_cast<const FixedWidthType&>(*out->type);

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -559,6 +559,7 @@ void ExecComputedBitmap(KernelContext* ctx, const ExecBatch& batch, Datum* out) 
                                    out_arr->buffers[0]->data(), out_arr->offset,
                                    batch.length));
   }
+
   internal::CopyBitmap(arg0.buffers[0]->data(), arg0.offset, batch.length,
                        out_arr->buffers[0]->mutable_data(), out_arr->offset);
   ExecCopy(ctx, batch, out);
@@ -750,10 +751,8 @@ TEST_F(TestCallScalarFunction, PreallocationCases) {
       AssertArraysEqual(*arr, *result.make_array());
     }
 
-    exec_ctx_->set_exec_chunksize(12);
-
-    // Chunksize not multiple of 8
     {
+      // Chunksize not multiple of 8
       std::vector<Datum> args = {Datum(arr)};
       exec_ctx_->set_exec_chunksize(111);
       ASSERT_OK_AND_ASSIGN(Datum result, CallFunction(func_name, args, exec_ctx_.get()));

--- a/cpp/src/arrow/compute/kernel.cc
+++ b/cpp/src/arrow/compute/kernel.cc
@@ -24,6 +24,7 @@
 
 #include "arrow/buffer.h"
 #include "arrow/compute/exec.h"
+#include "arrow/compute/util_internal.h"
 #include "arrow/result.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
@@ -43,10 +44,6 @@ namespace compute {
 // ----------------------------------------------------------------------
 // KernelContext
 
-inline void ZeroLastByte(Buffer* buffer) {
-  *(buffer->mutable_data() + (buffer->size() - 1)) = 0;
-}
-
 Result<std::shared_ptr<Buffer>> KernelContext::Allocate(int64_t nbytes) {
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> result,
                         AllocateBuffer(nbytes, exec_ctx_->memory_pool()));
@@ -62,7 +59,7 @@ Result<std::shared_ptr<Buffer>> KernelContext::AllocateBitmap(int64_t num_bits) 
   // initialized this makes valgrind/asan unhappy, so we proactively
   // zero it.
   if (nbytes > 0) {
-    ZeroLastByte(result.get());
+    internal::ZeroByte(result.get(), result->size() - 1);
     result->ZeroPadding();
   }
   return result;

--- a/cpp/src/arrow/compute/util_internal.h
+++ b/cpp/src/arrow/compute/util_internal.h
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/buffer.h"
+
+namespace arrow {
+namespace compute {
+namespace internal {
+
+/// \brief Set data at byte offset in buffer to 0. To help with valgrind issues
+static inline void ZeroByte(Buffer* buffer, int64_t byte_index) {
+  *(buffer->mutable_data() + byte_index) = 0;
+}
+
+static inline void ZeroMemory(Buffer* buffer) {
+  std::memset(buffer->mutable_data(), 0, buffer->size());
+}
+
+}  // namespace internal
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/util_internal.h
+++ b/cpp/src/arrow/compute/util_internal.h
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#pragma once
+
 #include "arrow/buffer.h"
 
 namespace arrow {


### PR DESCRIPTION
There are benign warnings in the cpp-conda-valgrind build due to accessing uninitialized trailing bits in validity bitmaps. Fixing the warnings without relying on compiler definitions is more complex than it seems (assuming you don't want to always memset the bitmap to all 0).