### PR TITLE
ARROW-8878: [R] try_download is confused when download.file.method isn't default

### DIFF
--- a/r/tools/linuxlibs.R
+++ b/r/tools/linuxlibs.R
@@ -37,13 +37,14 @@ binary_ok <- !identical(tolower(Sys.getenv("LIBARROW_BINARY", "false")), "false"
 quietly <- !env_is("ARROW_R_DEV", "true")
 
 try_download <- function(from_url, to_file) {
-  try(
+  status <- try(
     suppressWarnings(
       download.file(from_url, to_file, quiet = quietly)
     ),
     silent = quietly
   )
-  file.exists(to_file)
+  # Return whether the download was successful
+  !inherits(status, "try-error") && status == 0
 }
 
 download_binary <- function(os = identify_os()) {


### PR DESCRIPTION
Originally reported #7058

`download.file()` can be called with different methods, mostly for legacy reasons according to the docs, but apparently some are on systems where it has been set to "wget" method. In classic R fashion, the behavior of the function changes significantly depending on how this global variable is set. 

This patch should make the behavior more consistent regardless of the method used, so that the Linux installation won't proceed thinking a file was downloaded successfully when it in fact was not.