### PR TITLE
ARROW-7784: [C++] Improve compilation time of arrow/array/diff.cc and reduce code size

### DIFF
--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -169,13 +169,11 @@ class QuadraticSpaceMyersDiff {
   bool ValuesEqual(int64_t base_index, int64_t target_index) const {
     bool base_null = base_.IsNull(base_index);
     bool target_null = target_.IsNull(target_index);
-    if (base_null && target_null) {
-      return true;
-    } else if (base_null || target_null) {
-      return false;
-    } else {
-      return value_comparator_(base_, base_index, target_, target_index);
+    if (base_null || target_null) {
+      // If only one is null, then this is false, otherwise true
+      return base_null && target_null;
     }
+    return value_comparator_(base_, base_index, target_, target_index);
   }
 
   // increment the position within base (the element pointed to was deleted)
@@ -374,7 +372,7 @@ Result<std::shared_ptr<StructArray>> Diff(const Array& base, const Array& target
     auto base_storage = checked_cast<const ExtensionArray&>(base).storage();
     auto target_storage = checked_cast<const ExtensionArray&>(target).storage();
     return Diff(*base_storage, *target_storage, pool);
-  } else if (base.type()->id() == Type::EXTENSION) {
+  } else if (base.type()->id() == Type::DICTIONARY) {
     return Status::NotImplemented("diffing arrays of type ", *base.type());
   } else {
     return QuadraticSpaceMyersDiff(base, target, pool).Diff();

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -126,11 +126,13 @@ struct ValueComparatorVisitor {
     return Status::OK();
   }
 
-  Status Visit(const NullType&) { return Status::NotImplemented("extension type"); }
+  Status Visit(const NullType&) { return Status::NotImplemented("null type"); }
 
   Status Visit(const ExtensionType&) { return Status::NotImplemented("extension type"); }
 
-  Status Visit(const DictionaryType&) { return Status::NotImplemented("extension type"); }
+  Status Visit(const DictionaryType&) {
+    return Status::NotImplemented("dictionary type");
+  }
 
   std::unique_ptr<ValueComparator> Create() {
     DCHECK_OK(VisitTypeInline(*base.type(), this));

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -54,7 +54,7 @@ class MemoryPool;
 /// \return an edit script array which can be applied to base to produce target
 ARROW_EXPORT
 Result<std::shared_ptr<StructArray>> Diff(const Array& base, const Array& target,
-                                          MemoryPool* pool);
+                                          MemoryPool* pool = default_memory_pool());
 
 /// \brief visitor interface for easy traversal of an edit script
 ///

--- a/cpp/src/arrow/array/diff_test.cc
+++ b/cpp/src/arrow/array/diff_test.cc
@@ -586,6 +586,9 @@ TEST_F(DiffTest, DictionaryDiffFormatter) {
 )";
   ASSERT_EQ(formatted.str(), formatted_expected_indices);
 
+  // Note: Diff doesn't work at the moment with dictionary arrays
+  ASSERT_RAISES(NotImplemented, Diff(*base_, *target_));
+
   // differing dictionaries
   target_dict = ArrayFromJSON(utf8(), R"(["b", "c", "a"])");
   target_indices = base_indices;


### PR DESCRIPTION
This refactors diff.cc slightly to instantiate fewer templates.

On my machine with clang-8:

* Before: 15.5s compilation time of diff.cc in -03, 1633704 bytes of object code
* After: 4.1s compilation time, 498328 bytes of object code

There are probably more improvements here both in compilation time and code size but cutting 10 seconds out of release builds is already a good improvement. 