### PR TITLE
ARROW-7605: [C++] Bundle jemalloc into static libarrow

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -781,12 +781,6 @@ endif()
 
 set(ARROW_SYSTEM_LINK_LIBS)
 
-if(ARROW_JEMALLOC)
-  add_definitions(-DARROW_JEMALLOC)
-  add_definitions(-DARROW_JEMALLOC_INCLUDE_DIR=${JEMALLOC_INCLUDE_DIR})
-  list(APPEND ARROW_SYSTEM_LINK_LIBS jemalloc::jemalloc)
-endif()
-
 if(ARROW_MIMALLOC)
   add_definitions(-DARROW_MIMALLOC)
   list(APPEND ARROW_SYSTEM_LINK_LIBS mimalloc::mimalloc)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -448,6 +448,17 @@ add_arrow_lib(arrow
 
 add_dependencies(arrow ${ARROW_LIBRARIES})
 
+if(ARROW_JEMALLOC)
+  if(ARROW_BUILD_SHARED)
+    target_sources(arrow_shared PRIVATE
+        $<TARGET_OBJECTS:jemalloc::jemalloc>)
+  endif()
+  if(ARROW_BUILD_STATIC)
+    target_sources(arrow_static PRIVATE
+        $<TARGET_OBJECTS:jemalloc::jemalloc>)
+  endif()
+endif()
+
 if(ARROW_BUILD_STATIC AND WIN32)
   target_compile_definitions(arrow_static PUBLIC ARROW_STATIC)
 endif()


### PR DESCRIPTION
This is an alternative to #6220.

This changes the linking method to jemalloc from linking to `libjemalloc.a` to using the objects it is comprised of when linking `libarrow`. The advantage over #6220 is that the approach taken here does not require different methods of linking jemalloc for `libarrow.so` and `libarrow.a`.

Mimalloc would need a similar treatment before this can be merged, but I'm putting this out for comment before I develop it any further.