### PR TITLE
ARROW-9000: [Java] Update errorprone to 2.4.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -378,7 +378,7 @@
               <path>
                 <groupId>com.google.errorprone</groupId>
                 <artifactId>error_prone_core</artifactId>
-                <version>2.3.3</version>
+                <version>2.4.0</version>
               </path>
               <path>
                 <groupId>org.immutables</groupId>


### PR DESCRIPTION
Errorprone 2.3.3 is not compatible with JDK14 and crashes while building
the project.

Update to 2.4.0 version which is compatible with latest JDK.