### PR TITLE
ARROW-8985: [Format] Add Decimal::bitWidth field with default value of 128 for forward compatibility

### DIFF
--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -134,12 +134,19 @@ table FixedSizeBinary {
 table Bool {
 }
 
+/// Exact decimal value represented as an integer value in two's
+/// complement. Currently only 128-bit (16-byte) integers are used but this may
+/// be expanded in the future.
 table Decimal {
   /// Total number of decimal digits
   precision: int;
+
   /// Number of digits after the decimal point "."
   scale: int;
-  /// Number of bytes per value
+
+  /// Number of bytes per value. The only accepted width right now is 16 but
+  /// this field exists for forward compatibility so that other byte widths may
+  /// be supported in future format versions.
   byteWidth: int = 16;
 }
 

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -136,7 +136,8 @@ table Bool {
 
 /// Exact decimal value represented as an integer value in two's
 /// complement. Currently only 128-bit (16-byte) integers are used but this may
-/// be expanded in the future.
+/// be expanded in the future. The representation uses the endianness indicated
+/// in the Schema.
 table Decimal {
   /// Total number of decimal digits
   precision: int;
@@ -144,10 +145,11 @@ table Decimal {
   /// Number of digits after the decimal point "."
   scale: int;
 
-  /// Number of bytes per value. The only accepted width right now is 16 but
-  /// this field exists for forward compatibility so that other byte widths may
-  /// be supported in future format versions.
-  byteWidth: int = 16;
+  /// Number of bits per value. The only accepted width right now is 128 but
+  /// this field exists for forward compatibility so that other bit widths may
+  /// be supported in future format versions. We use bitWidth for consistency
+  /// with Int::bitWidth.
+  bitWidth: int = 128;
 }
 
 enum DateUnit: short {

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -139,6 +139,8 @@ table Decimal {
   precision: int;
   /// Number of digits after the decimal point "."
   scale: int;
+  /// Number of bytes per value
+  byteWidth: int = 16;
 }
 
 enum DateUnit: short {


### PR DESCRIPTION
As discussed and voted on the mailing list [1], this adds a "bit width" field to the Decimal metadata to permit supporting decimal binary representations other than 128-bit while allowing current libraries to reject such differently-sized data if they receive it from a future library version. 

[1]: https://s.apache.org/decimal-bit-width