### PR TITLE
ARROW-8929: [C++] Set the default for compute::Arity::VarArgs to 0

### DIFF
--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -60,7 +60,10 @@ struct ARROW_EXPORT Arity {
   static Arity Ternary() { return Arity(3, false); }
 
   /// \brief A function taking a variable number of arguments
-  static Arity VarArgs(int min_args = 1) { return Arity(min_args, true); }
+  ///
+  /// \param[in] min_args the minimum number of arguments required when
+  /// invoking the function
+  static Arity VarArgs(int min_args = 0) { return Arity(min_args, true); }
 
   explicit Arity(int num_args, bool is_varargs = false)
       : num_args(num_args), is_varargs(is_varargs) {}

--- a/cpp/src/arrow/compute/function_test.cc
+++ b/cpp/src/arrow/compute/function_test.cc
@@ -48,7 +48,7 @@ TEST(Arity, Basics) {
   ASSERT_EQ(3, ternary.num_args);
 
   auto varargs = Arity::VarArgs();
-  ASSERT_EQ(1, varargs.num_args);
+  ASSERT_EQ(0, varargs.num_args);
   ASSERT_TRUE(varargs.is_varargs);
 
   auto varargs2 = Arity::VarArgs(2);


### PR DESCRIPTION
As Micah pointed out, 0 is a more reasonable default for the minimum number of arguments than 1 is. 