### PR TITLE
ARROW-9014: [Packaging] Bump the minor part of the automatically generated version in crossbow

### DIFF
--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -711,7 +711,7 @@ def get_version(root, **kwargs):
     # from maintenance branches where the tags are uncreachbe from the master's
     # HEAD, so the git command above generates 0.17.0.dev300 even if arrow has
     # a never 0.17.1 patch release
-    pattern = "^(\d+)\.(\d+)\.(\d+)$"
+    pattern = r"^(\d+)\.(\d+)\.(\d+)$"
     match = re.match(pattern, str(version.tag))
     major, minor, patch = map(int, match.groups())
 

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -708,9 +708,9 @@ def get_version(root, **kwargs):
     version = parse_git_version(root, **kwargs)
 
     # increment the minor version, because there can be patch releases created
-    # from maintenance branches where the tags are uncreachbe from the master's
-    # HEAD, so the git command above generates 0.17.0.dev300 even if arrow has
-    # a never 0.17.1 patch release
+    # from maintenance branches where the tags are unreachable from the
+    # master's HEAD, so the git command above generates 0.17.0.dev300 even if
+    # arrow has a never 0.17.1 patch release
     pattern = r"^(\d+)\.(\d+)\.(\d+)$"
     match = re.match(pattern, str(version.tag))
     major, minor, patch = map(int, match.groups())

--- a/dev/tasks/crossbow.py
+++ b/dev/tasks/crossbow.py
@@ -700,13 +700,23 @@ def get_version(root, **kwargs):
     subprojects, e.g. apache-arrow-js-XXX tags.
     """
     from setuptools_scm.git import parse as parse_git_version
-    from setuptools_scm.version import guess_next_version
 
+    # query the calculated version based on the git tags
     kwargs['describe_command'] = (
         'git describe --dirty --tags --long --match "apache-arrow-[0-9].*"'
     )
     version = parse_git_version(root, **kwargs)
-    return version.format_next_version(guess_next_version)
+
+    # increment the minor version, because there can be patch releases created
+    # from maintenance branches where the tags are uncreachbe from the master's
+    # HEAD, so the git command above generates 0.17.0.dev300 even if arrow has
+    # a never 0.17.1 patch release
+    pattern = "^(\d+)\.(\d+)\.(\d+)$"
+    match = re.match(pattern, str(version.tag))
+    major, minor, patch = map(int, match.groups())
+
+    # the bumped version number after 0.17.x will be 0.18.0.dev300
+    return "{}.{}.{}.dev{}".format(major, minor + 1, patch, version.distance)
 
 
 class Serializable:


### PR DESCRIPTION
Crossbow uses setuptools_scm to generate a development version number using git describe command. This means that it finds the latest reachable tag from the current commit on master.

The minor releases are created from the master branch whereas the patch release tags point to commits on maintenance branches (like 0.17.x) which means that if we already have released a patch version, like 0.17.1 then crossbow generates a version number like 0.17.0.dev
{number-of-commits-from-0.17.0}
and bumps its patch tag, eventually creating binary packages with version 0.17.1.dev123.

The main problem with this is that the produced nightly python wheels are not picked up by pip, because on pypi we already have that patch release available and pip doesn't consider 0.17.1.dev123 newer than 0.17.1 (with --pre option passed).

So to force pip to install the newer nightly packages we need to bump the minor version instead.