### PR TITLE
ARROW-9015: [Java] Make BaseAllocator package private

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrow.java
@@ -24,7 +24,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Calendar;
 
-import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -80,7 +80,7 @@ public class JdbcToArrow {
    *                      ResultSet and Statement objects.
    */
   @Deprecated
-  public static VectorSchemaRoot sqlToArrow(Connection connection, String query, BaseAllocator allocator)
+  public static VectorSchemaRoot sqlToArrow(Connection connection, String query, BufferAllocator allocator)
       throws SQLException, IOException {
     Preconditions.checkNotNull(allocator, "Memory allocator object can not be null");
 
@@ -106,7 +106,7 @@ public class JdbcToArrow {
   public static VectorSchemaRoot sqlToArrow(
       Connection connection,
       String query,
-      BaseAllocator allocator,
+      BufferAllocator allocator,
       Calendar calendar) throws SQLException, IOException {
 
     Preconditions.checkNotNull(allocator, "Memory allocator object can not be null");
@@ -162,7 +162,7 @@ public class JdbcToArrow {
    * @throws SQLException on error
    */
   @Deprecated
-  public static VectorSchemaRoot sqlToArrow(ResultSet resultSet, BaseAllocator allocator)
+  public static VectorSchemaRoot sqlToArrow(ResultSet resultSet, BufferAllocator allocator)
       throws SQLException, IOException {
     Preconditions.checkNotNull(allocator, "Memory Allocator object can not be null");
 
@@ -197,7 +197,7 @@ public class JdbcToArrow {
   @Deprecated
   public static VectorSchemaRoot sqlToArrow(
       ResultSet resultSet,
-      BaseAllocator allocator,
+      BufferAllocator allocator,
       Calendar calendar)
       throws SQLException, IOException {
     Preconditions.checkNotNull(allocator, "Memory Allocator object can not be null");
@@ -245,7 +245,7 @@ public class JdbcToArrow {
    */
   public static ArrowVectorIterator sqlToArrowVectorIterator(
       ResultSet resultSet,
-      BaseAllocator allocator)
+      BufferAllocator allocator)
       throws SQLException, IOException {
     Preconditions.checkNotNull(allocator, "Memory Allocator object can not be null");
 

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfig.java
@@ -20,7 +20,7 @@ package org.apache.arrow.adapter.jdbc;
 import java.util.Calendar;
 import java.util.Map;
 
-import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 
 /**
@@ -48,7 +48,7 @@ import org.apache.arrow.util.Preconditions;
 public final class JdbcToArrowConfig {
 
   private Calendar calendar;
-  private BaseAllocator allocator;
+  private BufferAllocator allocator;
   private boolean includeMetadata;
   private Map<Integer, JdbcFieldInfo> arraySubTypesByColumnIndex;
   private Map<String, JdbcFieldInfo> arraySubTypesByColumnName;
@@ -76,7 +76,7 @@ public final class JdbcToArrowConfig {
    * @param allocator       The memory allocator to construct the Arrow vectors with.
    * @param calendar        The calendar to use when constructing Timestamp fields and reading time-based results.
    */
-  JdbcToArrowConfig(BaseAllocator allocator, Calendar calendar) {
+  JdbcToArrowConfig(BufferAllocator allocator, Calendar calendar) {
     Preconditions.checkNotNull(allocator, "Memory allocator cannot be null");
 
     this.allocator = allocator;
@@ -98,7 +98,7 @@ public final class JdbcToArrowConfig {
    * @param arraySubTypesByColumnName  The type of the JDBC array at the column name.
    */
   JdbcToArrowConfig(
-      BaseAllocator allocator,
+      BufferAllocator allocator,
       Calendar calendar,
       boolean includeMetadata,
       Map<Integer, JdbcFieldInfo> arraySubTypesByColumnIndex,
@@ -128,7 +128,7 @@ public final class JdbcToArrowConfig {
    * The Arrow memory allocator.
    * @return the allocator.
    */
-  public BaseAllocator getAllocator() {
+  public BufferAllocator getAllocator() {
     return allocator;
   }
 

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -22,7 +22,7 @@ import static org.apache.arrow.adapter.jdbc.JdbcToArrowConfig.DEFAULT_TARGET_BAT
 import java.util.Calendar;
 import java.util.Map;
 
-import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
 
 /**
@@ -30,7 +30,7 @@ import org.apache.arrow.util.Preconditions;
  */
 public class JdbcToArrowConfigBuilder {
   private Calendar calendar;
-  private BaseAllocator allocator;
+  private BufferAllocator allocator;
   private boolean includeMetadata;
   private Map<Integer, JdbcFieldInfo> arraySubTypesByColumnIndex;
   private Map<String, JdbcFieldInfo> arraySubTypesByColumnName;
@@ -65,7 +65,7 @@ public class JdbcToArrowConfigBuilder {
    * @param allocator The Arrow Vector memory allocator.
    * @param calendar The calendar to use when constructing timestamp fields.
    */
-  public JdbcToArrowConfigBuilder(BaseAllocator allocator, Calendar calendar) {
+  public JdbcToArrowConfigBuilder(BufferAllocator allocator, Calendar calendar) {
     this();
 
     Preconditions.checkNotNull(allocator, "Memory allocator cannot be null");
@@ -96,7 +96,7 @@ public class JdbcToArrowConfigBuilder {
    * @param allocator The Arrow Vector memory allocator.
    * @param calendar The calendar to use when constructing timestamp fields.
    */
-  public JdbcToArrowConfigBuilder(BaseAllocator allocator, Calendar calendar, boolean includeMetadata) {
+  public JdbcToArrowConfigBuilder(BufferAllocator allocator, Calendar calendar, boolean includeMetadata) {
     this(allocator, calendar);
     this.includeMetadata = includeMetadata;
   }
@@ -107,7 +107,7 @@ public class JdbcToArrowConfigBuilder {
    * @param allocator the allocator to set.
    * @exception NullPointerException if <code>allocator</code> is null.
    */
-  public JdbcToArrowConfigBuilder setAllocator(BaseAllocator allocator) {
+  public JdbcToArrowConfigBuilder setAllocator(BufferAllocator allocator) {
     Preconditions.checkNotNull(allocator, "Memory allocator cannot be null");
     this.allocator = allocator;
     return this;
@@ -165,7 +165,7 @@ public class JdbcToArrowConfigBuilder {
 
   /**
    * This builds the {@link JdbcToArrowConfig} from the provided
-   * {@link BaseAllocator} and {@link Calendar}.
+   * {@link BufferAllocator} and {@link Calendar}.
    *
    * @return The built {@link JdbcToArrowConfig}
    * @throws NullPointerException if either the allocator or calendar was not set.

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
@@ -25,13 +25,13 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.Test;
 
 public class JdbcToArrowConfigTest {
 
-  private static final RootAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
+  private static final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
   private static final Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"), Locale.ROOT);
 
   @Test(expected = NullPointerException.class)
@@ -89,7 +89,7 @@ public class JdbcToArrowConfigTest {
     assertTrue(calendar == config.getCalendar());
 
     Calendar newCalendar = Calendar.getInstance();
-    BaseAllocator newAllocator = new RootAllocator(Integer.SIZE);
+    BufferAllocator newAllocator = new RootAllocator(Integer.SIZE);
 
     builder.setAllocator(newAllocator).setCalendar(newCalendar);
     config = builder.build();

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowTest.java
@@ -76,6 +76,7 @@ import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowTestHelper;
 import org.apache.arrow.adapter.jdbc.JdbcToArrowUtils;
 import org.apache.arrow.adapter.jdbc.Table;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
@@ -225,7 +226,7 @@ public class JdbcToArrowTest extends AbstractJdbcToArrowTest {
 
   @Test
   public void runLargeNumberOfRows() throws IOException, SQLException {
-    RootAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
+    BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
     int x = 0;
     final int targetRows = 600000;
     ResultSet rs = new FakeResultSet(targetRows);

--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowBuf.java
@@ -28,6 +28,7 @@ import java.nio.ReadOnlyBufferException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.arrow.memory.BaseAllocator.Verbosity;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.HistoricalLog;
 import org.apache.arrow.memory.util.MemoryUtil;
 import org.apache.arrow.util.Preconditions;
@@ -1102,7 +1103,7 @@ public final class ArrowBuf implements AutoCloseable {
    *
    */
   public void print(StringBuilder sb, int indent, Verbosity verbosity) {
-    BaseAllocator.indent(sb, indent).append(toString());
+    CommonUtil.indent(sb, indent).append(toString());
 
     if (BaseAllocator.DEBUG && verbosity.includeHistoricalLog) {
       sb.append("\n");

--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -17,7 +17,6 @@
 
 package org.apache.arrow.memory;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -28,6 +27,7 @@ import java.util.Set;
 import org.apache.arrow.memory.rounding.DefaultRoundingPolicy;
 import org.apache.arrow.memory.rounding.RoundingPolicy;
 import org.apache.arrow.memory.util.AssertionUtil;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.HistoricalLog;
 import org.apache.arrow.util.Preconditions;
 import org.immutables.value.Value;
@@ -38,7 +38,7 @@ import org.immutables.value.Value;
  * <p>The class is abstract to enforce usage of {@linkplain RootAllocator}/{@linkplain ChildAllocator}
  * facades.
  */
-public abstract class BaseAllocator extends Accountant implements BufferAllocator {
+abstract class BaseAllocator extends Accountant implements BufferAllocator {
 
   public static final String DEBUG_ALLOCATOR = "arrow.memory.debug.allocator";
   public static final int DEBUG_LOG_LENGTH = 6;
@@ -139,56 +139,6 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
         "Unable to allocate buffer of size %d due to memory limit. Current " +
           "allocation: %d", rounded, allocator.getAllocatedMemory());
     }
-  }
-
-  /**
-   * Rounds up the provided value to the nearest power of two.
-   *
-   * @param val An integer value.
-   * @return The closest power of two of that value.
-   */
-  public static int nextPowerOfTwo(int val) {
-    if (val == 0 || val == 1) {
-      return val + 1;
-    }
-    int highestBit = Integer.highestOneBit(val);
-    if (highestBit == val) {
-      return val;
-    } else {
-      return highestBit << 1;
-    }
-  }
-
-  /**
-   * Rounds up the provided value to the nearest power of two.
-   *
-   * @param val A long value.
-   * @return The closest power of two of that value.
-   */
-  public static long nextPowerOfTwo(long val) {
-    if (val == 0 || val == 1) {
-      return val + 1;
-    }
-    long highestBit = Long.highestOneBit(val);
-    if (highestBit == val) {
-      return val;
-    } else {
-      return highestBit << 1;
-    }
-  }
-
-  /**
-   * Specify an indentation amount when using a StringBuilder.
-   *
-   * @param sb StringBuilder to use
-   * @param indent Indentation amount
-   * @return the StringBuilder object with indentation applied
-   */
-  public static StringBuilder indent(StringBuilder sb, int indent) {
-    final char[] indentation = new char[indent * 2];
-    Arrays.fill(indentation, ' ');
-    sb.append(indentation);
-    return sb;
   }
 
   public static boolean isDebug() {
@@ -667,7 +617,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
 
   void print(StringBuilder sb, int level, Verbosity verbosity) {
 
-    indent(sb, level)
+    CommonUtil.indent(sb, level)
       .append("Allocator(")
       .append(name)
       .append(") ")
@@ -682,18 +632,18 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       .append('\n');
 
     if (DEBUG) {
-      indent(sb, level + 1).append(String.format("child allocators: %d\n", childAllocators.size()));
+      CommonUtil.indent(sb, level + 1).append(String.format("child allocators: %d\n", childAllocators.size()));
       for (BaseAllocator child : childAllocators.keySet()) {
         child.print(sb, level + 2, verbosity);
       }
 
-      indent(sb, level + 1).append(String.format("ledgers: %d\n", childLedgers.size()));
+      CommonUtil.indent(sb, level + 1).append(String.format("ledgers: %d\n", childLedgers.size()));
       for (BufferLedger ledger : childLedgers.keySet()) {
         ledger.print(sb, level + 2, verbosity);
       }
 
       final Set<Reservation> reservations = this.reservations.keySet();
-      indent(sb, level + 1).append(String.format("reservations: %d\n", reservations.size()));
+      CommonUtil.indent(sb, level + 1).append(String.format("reservations: %d\n", reservations.size()));
       for (final Reservation reservation : reservations) {
         if (verbosity.includeHistoricalLog) {
           reservation.historicalLog.buildHistory(sb, level + 3, true);
@@ -846,7 +796,7 @@ public abstract class BaseAllocator extends Accountant implements BufferAllocato
       // modifying this behavior so that we maintain what we reserve and what the user asked for
       // and make sure to only
       // round to power of two as necessary.
-      final int nBytesTwo = BaseAllocator.nextPowerOfTwo(nBytes);
+      final int nBytesTwo = CommonUtil.nextPowerOfTwo(nBytes);
       if (!reserve(nBytesTwo)) {
         return false;
       }

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -17,12 +17,11 @@
 
 package org.apache.arrow.memory;
 
-import static org.apache.arrow.memory.BaseAllocator.indent;
-
 import java.util.IdentityHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.HistoricalLog;
 import org.apache.arrow.util.Preconditions;
 
@@ -485,7 +484,7 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
    * @param verbosity The level of verbosity to print.
    */
   void print(StringBuilder sb, int indent, BaseAllocator.Verbosity verbosity) {
-    indent(sb, indent)
+    CommonUtil.indent(sb, indent)
       .append("ledger[")
       .append(ledgerId)
       .append("] allocator: ")

--- a/java/memory/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
@@ -19,8 +19,8 @@ package org.apache.arrow.memory.rounding;
 
 import java.lang.reflect.Field;
 
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.NettyAllocationManager;
+import org.apache.arrow.memory.util.CommonUtil;
 
 /**
  * The default rounding policy. That is, if the requested size is within the chunk size,
@@ -49,6 +49,6 @@ public class DefaultRoundingPolicy implements RoundingPolicy {
   @Override
   public long getRoundedSize(long requestSize) {
     return requestSize < chunkSize ?
-            BaseAllocator.nextPowerOfTwo(requestSize) : requestSize;
+            CommonUtil.nextPowerOfTwo(requestSize) : requestSize;
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/util/CommonUtil.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/util/CommonUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory.util;
+
+import java.util.Arrays;
+
+/**
+ * Utilities and static methods needed for arrow-memory.
+ */
+public final class CommonUtil {
+
+  private CommonUtil() { }
+
+  /**
+   * Rounds up the provided value to the nearest power of two.
+   *
+   * @param val An integer value.
+   * @return The closest power of two of that value.
+   */
+  public static int nextPowerOfTwo(int val) {
+    if (val == 0 || val == 1) {
+      return val + 1;
+    }
+    int highestBit = Integer.highestOneBit(val);
+    if (highestBit == val) {
+      return val;
+    } else {
+      return highestBit << 1;
+    }
+  }
+
+  /**
+   * Rounds up the provided value to the nearest power of two.
+   *
+   * @param val A long value.
+   * @return The closest power of two of that value.
+   */
+  public static long nextPowerOfTwo(long val) {
+    if (val == 0 || val == 1) {
+      return val + 1;
+    }
+    long highestBit = Long.highestOneBit(val);
+    if (highestBit == val) {
+      return val;
+    } else {
+      return highestBit << 1;
+    }
+  }
+
+  /**
+   * Specify an indentation amount when using a StringBuilder.
+   *
+   * @param sb StringBuilder to use
+   * @param indent Indentation amount
+   * @return the StringBuilder object with indentation applied
+   */
+  public static StringBuilder indent(StringBuilder sb, int indent) {
+    final char[] indentation = new char[indent * 2];
+    Arrays.fill(indentation, ' ');
+    sb.append(indentation);
+    return sb;
+  }
+}
+

--- a/java/performance/src/test/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/adapter/jdbc/JdbcAdapterBenchmarks.java
@@ -29,7 +29,7 @@ import org.apache.arrow.adapter.jdbc.consumer.BitConsumer;
 import org.apache.arrow.adapter.jdbc.consumer.IntConsumer;
 import org.apache.arrow.adapter.jdbc.consumer.JdbcConsumer;
 import org.apache.arrow.adapter.jdbc.consumer.VarCharConsumer;
-import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
@@ -77,7 +77,7 @@ public class JdbcAdapterBenchmarks {
 
     private ResultSet resultSet = null;
 
-    private BaseAllocator allocator;
+    private BufferAllocator allocator;
 
     private Statement statement;
 
@@ -140,7 +140,7 @@ public class JdbcAdapterBenchmarks {
 
     private ResultSet resultSet = null;
 
-    private BaseAllocator allocator;
+    private BufferAllocator allocator;
 
     private Statement statement;
 
@@ -242,7 +242,7 @@ public class JdbcAdapterBenchmarks {
 
     private ResultSet resultSet = null;
 
-    private BaseAllocator allocator;
+    private BufferAllocator allocator;
 
     private Statement statement;
 

--- a/java/performance/src/test/java/org/apache/arrow/algorithm/search/ParallelSearcherBenchmarks.java
+++ b/java/performance/src/test/java/org/apache/arrow/algorithm/search/ParallelSearcherBenchmarks.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.arrow.memory.BaseAllocator;
+import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -55,7 +55,7 @@ public class ParallelSearcherBenchmarks {
     @Param({"1", "2", "5", "10", "20", "50", "100"})
     int numThreads;
 
-    BaseAllocator allocator;
+    BufferAllocator allocator;
 
     ExecutorService threadPool;
 

--- a/java/vector/src/main/codegen/templates/DenseUnionVector.java
+++ b/java/vector/src/main/codegen/templates/DenseUnionVector.java
@@ -18,6 +18,7 @@
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.util.DataSizeRoundingUtil;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseValueVector;
@@ -50,13 +51,13 @@ package org.apache.arrow.vector.complex;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.memory.util.hash.SimpleHasher;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.vector.BaseValueVector;
 import org.apache.arrow.vector.util.OversizedAllocationException;
 import org.apache.arrow.util.DataSizeRoundingUtil;
@@ -412,7 +413,8 @@ public class DenseUnionVector implements FieldVector {
         newAllocationSize = DataSizeRoundingUtil.divideBy8Ceil(BaseValueVector.INITIAL_VALUE_ALLOCATION) * 2;
       }
     }
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
     if (newAllocationSize > BaseValueVector.MAX_ALLOCATION_SIZE) {
@@ -437,7 +439,8 @@ public class DenseUnionVector implements FieldVector {
         newAllocationSize = BaseValueVector.INITIAL_VALUE_ALLOCATION * TYPE_WIDTH * 2;
       }
     }
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
     if (newAllocationSize > BaseValueVector.MAX_ALLOCATION_SIZE) {
@@ -462,7 +465,8 @@ public class DenseUnionVector implements FieldVector {
         newAllocationSize = BaseValueVector.INITIAL_VALUE_ALLOCATION * OFFSET_WIDTH * 2;
       }
     }
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
     if (newAllocationSize > BaseValueVector.MAX_ALLOCATION_SIZE) {

--- a/java/vector/src/main/codegen/templates/UnionVector.java
+++ b/java/vector/src/main/codegen/templates/UnionVector.java
@@ -18,6 +18,7 @@
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.FieldVector;
@@ -43,12 +44,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.vector.compare.VectorVisitor;
 import org.apache.arrow.vector.complex.impl.ComplexCopier;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.ValueVectorUtility;
 import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.vector.BaseValueVector;
@@ -333,7 +334,7 @@ public class UnionVector implements FieldVector {
         newAllocationSize = BaseValueVector.INITIAL_VALUE_ALLOCATION * TYPE_WIDTH * 2;
       }
     }
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
     if (newAllocationSize > BaseValueVector.MAX_ALLOCATION_SIZE) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseLargeVariableWidthVector.java
@@ -25,11 +25,11 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.compare.VectorVisitor;
@@ -486,7 +486,7 @@ public abstract class BaseLargeVariableWidthVector extends BaseValueVector
         newAllocationSize = INITIAL_BYTE_COUNT * 2;
       }
     }
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
     checkDataBufferSize(newAllocationSize);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -21,9 +21,9 @@ import java.util.Collections;
 import java.util.Iterator;
 
 import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.ReferenceManager;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.util.DataSizeRoundingUtil;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.util.TransferPair;
@@ -141,7 +141,7 @@ public abstract class BaseValueVector implements ValueVector {
     } else {
       bufferSize += DataSizeRoundingUtil.roundUpTo8Multiple((long) valueCount * typeWidth);
     }
-    return BaseAllocator.nextPowerOfTwo(bufferSize);
+    return CommonUtil.nextPowerOfTwo(bufferSize);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseVariableWidthVector.java
@@ -25,11 +25,11 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.compare.VectorVisitor;
@@ -506,7 +506,7 @@ public abstract class BaseVariableWidthVector extends BaseValueVector
         newAllocationSize = INITIAL_BYTE_COUNT * 2;
       }
     }
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
     checkDataBufferSize(newAllocationSize);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/BaseRepeatedValueVector.java
@@ -26,8 +26,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.AddOrGetResult;
 import org.apache.arrow.vector.BaseFixedWidthVector;
@@ -122,7 +122,7 @@ public abstract class BaseRepeatedValueVector extends BaseValueVector implements
       }
     }
 
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     newAllocationSize = Math.min(newAllocationSize, (long) (OFFSET_WIDTH) * Integer.MAX_VALUE);
     assert newAllocationSize >= 1;
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -30,11 +30,11 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.AddOrGetResult;
@@ -256,7 +256,8 @@ public class FixedSizeListVector extends BaseValueVector implements BaseListVect
         newAllocationSize = getValidityBufferSizeFromCount(INITIAL_VALUE_ALLOCATION) * 2;
       }
     }
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
     if (newAllocationSize > MAX_ALLOCATION_SIZE) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -28,11 +28,11 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.util.ArrowBufPointer;
 import org.apache.arrow.memory.util.ByteFunctionHelpers;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.AddOrGetResult;
@@ -326,7 +326,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
         newAllocationSize = getValidityBufferSizeFromCount(INITIAL_VALUE_ALLOCATION) * 2;
       }
     }
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
     if (newAllocationSize > MAX_ALLOCATION_SIZE) {

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/StructVector.java
@@ -25,9 +25,9 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.hash.ArrowBufHasher;
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.BaseValueVector;
@@ -434,7 +434,7 @@ public class StructVector extends NonNullableStructVector implements FieldVector
         newAllocationSize = BitVectorHelper.getValidityBufferSize(BaseValueVector.INITIAL_VALUE_ALLOCATION) * 2;
       }
     }
-    newAllocationSize = BaseAllocator.nextPowerOfTwo(newAllocationSize);
+    newAllocationSize = CommonUtil.nextPowerOfTwo(newAllocationSize);
     assert newAllocationSize >= 1;
 
     if (newAllocationSize > BaseValueVector.MAX_ALLOCATION_SIZE) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestValueVector.java
@@ -36,10 +36,10 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.arrow.memory.ArrowBuf;
-import org.apache.arrow.memory.BaseAllocator;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.memory.util.ArrowBufPointer;
+import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
 import org.apache.arrow.vector.compare.VectorEqualsVisitor;
@@ -1937,22 +1937,22 @@ public class TestValueVector {
       vector.setInitialCapacity(defaultCapacity);
       vector.allocateNew();
       assertEquals(defaultCapacity, vector.getValueCapacity());
-      assertEquals(BaseAllocator.nextPowerOfTwo(defaultCapacity * 8), vector.getDataBuffer().capacity());
+      assertEquals(CommonUtil.nextPowerOfTwo(defaultCapacity * 8), vector.getDataBuffer().capacity());
 
       vector.setInitialCapacity(defaultCapacity, 1);
       vector.allocateNew();
       assertEquals(defaultCapacity, vector.getValueCapacity());
-      assertEquals(BaseAllocator.nextPowerOfTwo(defaultCapacity), vector.getDataBuffer().capacity());
+      assertEquals(CommonUtil.nextPowerOfTwo(defaultCapacity), vector.getDataBuffer().capacity());
 
       vector.setInitialCapacity(defaultCapacity, 0.1);
       vector.allocateNew();
       assertEquals(defaultCapacity, vector.getValueCapacity());
-      assertEquals(BaseAllocator.nextPowerOfTwo((int) (defaultCapacity * 0.1)), vector.getDataBuffer().capacity());
+      assertEquals(CommonUtil.nextPowerOfTwo((int) (defaultCapacity * 0.1)), vector.getDataBuffer().capacity());
 
       vector.setInitialCapacity(defaultCapacity, 0.01);
       vector.allocateNew();
       assertEquals(defaultCapacity, vector.getValueCapacity());
-      assertEquals(BaseAllocator.nextPowerOfTwo((int) (defaultCapacity * 0.01)), vector.getDataBuffer().capacity());
+      assertEquals(CommonUtil.nextPowerOfTwo((int) (defaultCapacity * 0.01)), vector.getDataBuffer().capacity());
 
       vector.setInitialCapacity(5, 0.01);
       vector.allocateNew();


### PR DESCRIPTION
BaseAllocator should be package private and shouldn't be used as a
concrete type in other modules. This commit makes it package private
and replaces `BaseAllocator` with `BufferAllocator` references.

It also creates a `CommonUtil` class which holds the static utils
that `BaseAllocator` used to