### PR TITLE
ARROW-9016: [Java] Remove direct references to Netty/Unsafe Allocators

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/CheckAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/CheckAllocator.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Static method to ensure we have a RootAllocator on the classpath and report which one is used.
+ */
+final class CheckAllocator {
+  private static final Logger logger = LoggerFactory.getLogger(CheckAllocator.class);
+  private static final String ALLOCATOR_PATH = "org/apache/arrow/memory/DefaultAllocationManagerFactory.class";
+
+  private CheckAllocator() {
+
+  }
+
+  static String check() {
+    Set<URL> urls = scanClasspath();
+    URL rootAllocator = assertOnlyOne(urls);
+    reportResult(rootAllocator);
+    return "org.apache.arrow.memory.DefaultAllocationManagerFactory";
+  }
+
+
+  private static Set<URL> scanClasspath() {
+    // LinkedHashSet appropriate here because it preserves insertion order
+    // during iteration
+    Set<URL> allocatorPathSet = new LinkedHashSet<>();
+    try {
+      ClassLoader allocatorClassLoader = CheckAllocator.class.getClassLoader();
+      Enumeration<URL> paths;
+      if (allocatorClassLoader == null) {
+        paths = ClassLoader.getSystemResources(ALLOCATOR_PATH);
+      } else {
+        paths = allocatorClassLoader.getResources(ALLOCATOR_PATH);
+      }
+      while (paths.hasMoreElements()) {
+        URL path = paths.nextElement();
+        allocatorPathSet.add(path);
+      }
+    } catch (IOException ioe) {
+      logger.error("Error getting resources from path", ioe);
+    }
+    return allocatorPathSet;
+  }
+
+  private static void reportResult(URL rootAllocator) {
+    String path = rootAllocator.getPath();
+    String subPath = path.substring(path.indexOf("memory"));
+    logger.info("Using DefaultAllocationManager at {}", subPath);
+  }
+
+  private static URL assertOnlyOne(Set<URL> urls) {
+    if (urls.size() > 1) {
+      logger.warn("More than one DefaultAllocationManager on classpath. Choosing first found");
+    }
+    if (urls.isEmpty()) {
+      throw new RuntimeException("No DefaultAllocationManager found on classpath. Can't allocate Arrow buffers.");
+    }
+    return urls.iterator().next();
+  }
+
+}

--- a/java/memory/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerFactory.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerFactory.java
@@ -17,38 +17,19 @@
 
 package org.apache.arrow.memory;
 
-import org.apache.arrow.memory.util.MemoryUtil;
-
 /**
- * Allocation manager based on unsafe API.
+ * The default Allocation Manager Factory for a module.
+ *
+ * This will be split out to the arrow-memory-netty/arrow-memory-unsafe modules
+ * as part of ARROW-8230. This is currently a placeholder which defaults to Netty.
+ *
  */
-public final class UnsafeAllocationManager extends AllocationManager {
+public class DefaultAllocationManagerFactory implements AllocationManager.Factory {
 
-  public static final AllocationManager.Factory FACTORY = UnsafeAllocationManager::new;
-
-  private final long allocatedSize;
-
-  private final long allocatedAddress;
-
-  UnsafeAllocationManager(BaseAllocator accountingAllocator, long requestedSize) {
-    super(accountingAllocator);
-    allocatedAddress = MemoryUtil.UNSAFE.allocateMemory(requestedSize);
-    allocatedSize = requestedSize;
-  }
+  public static final AllocationManager.Factory FACTORY = new DefaultAllocationManagerFactory();
 
   @Override
-  public long getSize() {
-    return allocatedSize;
+  public AllocationManager create(BaseAllocator accountingAllocator, long size) {
+    return new NettyAllocationManager(accountingAllocator, size);
   }
-
-  @Override
-  protected long memoryAddress() {
-    return allocatedAddress;
-  }
-
-  @Override
-  protected void release0() {
-    MemoryUtil.UNSAFE.freeMemory(allocatedAddress);
-  }
-
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/NettyAllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/NettyAllocationManager.java
@@ -27,7 +27,7 @@ import io.netty.util.internal.PlatformDependent;
  */
 public class NettyAllocationManager extends AllocationManager {
 
-  public static final Factory FACTORY = new Factory();
+  public static final AllocationManager.Factory FACTORY = NettyAllocationManager::new;
 
   /**
    * The default cut-off value for switching allocation strategies.
@@ -105,15 +105,4 @@ public class NettyAllocationManager extends AllocationManager {
     return allocatedSize;
   }
 
-  /**
-   * Factory for creating {@link NettyAllocationManager}.
-   */
-  public static class Factory implements AllocationManager.Factory {
-    private Factory() {}
-
-    @Override
-    public AllocationManager create(BaseAllocator accountingAllocator, long size) {
-      return new NettyAllocationManager(accountingAllocator, size);
-    }
-  }
 }


### PR DESCRIPTION
As part of ARROW-8230 this removes direct references to Netty and Unsafe Allocation
managers in the `DefaultAllocationManagerOption`.

This maintains Netty as the default allocator until ARROW-8230 is closed.