### PR TITLE
ARROW-9021: [Python] Add the filesystem explanation to parquet.read_table docstring

### DIFF
--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1491,6 +1491,9 @@ use_threads : bool, default True
 metadata : FileMetaData
     If separately computed
 {1}
+filesystem : FileSystem, default None
+    If nothing passed, paths assumed to be found in the local on-disk
+    filesystem.
 filters : List[Tuple] or List[List[Tuple]] or None (default)
     Rows which do not match the filter predicate will be removed from scanned
     data. Partition keys embedded in a nested directory structure will be


### PR DESCRIPTION
Use same doc string as ParquetDataset. https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetDataset.html.

Looks like the arg currently has no docs. https://arrow.apache.org/docs/python/generated/pyarrow.parquet.read_table.html

cc. @jorisvandenbossche our discussion here: https://github.com/pandas-dev/pandas/issues/34467#issuecomment-636366589

