### PR TITLE
ARROW-2702: [Python] Change a couple of error types in numpy_to_arrow.cc

### DIFF
--- a/cpp/src/arrow/python/numpy_to_arrow.cc
+++ b/cpp/src/arrow/python/numpy_to_arrow.cc
@@ -730,7 +730,7 @@ Status NumPyConverter::Visit(const StructType& type) {
     for (auto field : type.fields()) {
       PyObject* tup = PyDict_GetItemString(dtype_->fields, field->name().c_str());
       if (tup == NULL) {
-        return Status::TypeError("Missing field '", field->name(), "' in struct array");
+        return Status::Invalid("Missing field '", field->name(), "' in struct array");
       }
       PyArray_Descr* sub_dtype =
           reinterpret_cast<PyArray_Descr*>(PyTuple_GET_ITEM(tup, 0));
@@ -826,7 +826,9 @@ Status NdarrayToArrow(MemoryPool* pool, PyObject* ao, PyObject* mo, bool from_pa
                       const compute::CastOptions& cast_options,
                       std::shared_ptr<ChunkedArray>* out) {
   if (!PyArray_Check(ao)) {
-    return Status::Invalid("Input object was not a NumPy array");
+    // This code path cannot be reached by Python unit tests currently so this
+    // is only a sanity check.
+    return Status::TypeError("Input object was not a NumPy array");
   }
   if (PyArray_NDIM(reinterpret_cast<PyArrayObject*>(ao)) != 1) {
     return Status::Invalid("only handle 1-dimensional arrays");

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2219,7 +2219,7 @@ class TestConvertStructTypes:
                        ('z', np.bool_)])
 
         data = np.array([], dtype=dt)
-        with pytest.raises(TypeError,
+        with pytest.raises(ValueError,
                            match="Missing field 'y'"):
             pa.array(data, type=ty)
         data = np.int32([])


### PR DESCRIPTION
I quickly reviewed these errors and it seemed like one error that is hit in the test suite might be better as a ValueError but I'm not sure. 