### PR TITLE
WIP: ARROW-9030: [Python] Clean up some usages of pyarrow.compat module

### DIFF
--- a/python/pyarrow/__init__.pxd
+++ b/python/pyarrow/__init__.pxd
@@ -21,7 +21,6 @@ from pyarrow.includes.libarrow cimport (CArray, CBuffer, CDataType,
                                         CTable, CTensor, CSparseCOOTensor,
                                         CSparseCSRMatrix, CSparseCSCMatrix,
                                         CSparseCSFTensor)
-from pyarrow.compat import frombytes
 
 cdef extern from "arrow/python/pyarrow.h" namespace "arrow::py":
     cdef int import_pyarrow() except -1

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -55,9 +55,6 @@ except ImportError:
     except ImportError:
         __version__ = None
 
-
-import pyarrow.compat as compat
-
 # ARROW-8684: Disable GC while initializing Cython extension module,
 # to workaround Cython bug in https://github.com/cython/cython/issues/3603
 _gc_enabled = _gc.isenabled()

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -17,7 +17,7 @@
 
 # cython: language_level = 3
 
-from pyarrow.compat import frombytes, tobytes, ordered_dict
+from pyarrow.lib import frombytes, tobytes, ordered_dict
 from pyarrow.lib cimport *
 from pyarrow.includes.libarrow cimport *
 import pyarrow.lib as lib

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -21,6 +21,7 @@
 # cython: language_level = 3
 
 
+from collections.abc import Mapping
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.lib cimport (check_status, Field, MemoryPool, Schema,
@@ -28,8 +29,7 @@ from pyarrow.lib cimport (check_status, Field, MemoryPool, Schema,
                           maybe_unbox_memory_pool, get_input_stream,
                           pyarrow_wrap_schema, pyarrow_wrap_table,
                           pyarrow_wrap_data_type, pyarrow_unwrap_data_type)
-
-from pyarrow.compat import frombytes, tobytes, Mapping
+from pyarrow.lib import frombytes, tobytes
 
 
 cdef unsigned char _single_char(s) except 0:

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -16,7 +16,7 @@
 # under the License.
 
 
-from pyarrow.compat import tobytes
+from pyarrow.lib import tobytes
 from pyarrow.lib cimport *
 from pyarrow.includes.libarrow_cuda cimport *
 from pyarrow.lib import py_buffer, allocate_buffer, as_buffer, ArrowTypeError

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -24,8 +24,8 @@ from cython.operator cimport dereference as deref
 
 import pyarrow as pa
 from pyarrow.lib cimport *
+from pyarrow.lib import frombytes, tobytes
 from pyarrow.includes.libarrow_dataset cimport *
-from pyarrow.compat import frombytes, tobytes
 from pyarrow._fs cimport FileSystem, FileInfo, FileSelector
 from pyarrow._csv cimport ParseOptions
 from pyarrow._compute cimport CastOptions

--- a/python/pyarrow/_fs.pxd
+++ b/python/pyarrow/_fs.pxd
@@ -17,10 +17,9 @@
 
 # cython: language_level = 3
 
-from pyarrow.compat import frombytes, tobytes
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow_fs cimport *
-from pyarrow.lib import _detect_compression
+from pyarrow.lib import _detect_compression, frombytes, tobytes
 from pyarrow.lib cimport *
 
 

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -19,10 +19,9 @@
 
 from cpython.datetime cimport datetime, PyDateTime_DateTime
 
-from pyarrow.compat import frombytes, tobytes
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport PyDateTime_to_TimePoint
-from pyarrow.lib import _detect_compression
+from pyarrow.lib import _detect_compression, frombytes, tobytes
 from pyarrow.lib cimport *
 from pyarrow.util import _stringify_path
 

--- a/python/pyarrow/_hdfs.pyx
+++ b/python/pyarrow/_hdfs.pyx
@@ -23,7 +23,7 @@ from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_fs cimport *
 from pyarrow._fs cimport FileSystem
 
-from pyarrow.compat import frombytes, tobytes
+from pyarrow.lib import frombytes, tobytes
 from pyarrow.util import _stringify_path
 
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -38,12 +38,12 @@ from pyarrow.lib cimport (Buffer, Array, Schema,
                           pyarrow_wrap_buffer,
                           NativeFile, get_reader, get_writer)
 
-from pyarrow.compat import tobytes, frombytes
 from pyarrow.lib import (ArrowException, NativeFile, _stringify_path,
                          BufferOutputStream,
                          _datetime_conversion_functions,
                          _box_time_milli,
-                         _box_time_micro)
+                         _box_time_micro,
+                         tobytes, frombytes)
 
 cimport cpython as cp
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1088,8 +1088,7 @@ cdef class ParquetReader:
             vector[int] c_row_groups
             vector[int] c_column_indices
 
-        if use_threads:
-            self.set_use_threads(use_threads)
+        self.set_use_threads(use_threads)
 
         for row_group in row_groups:
             c_row_groups.push_back(row_group)
@@ -1114,8 +1113,7 @@ cdef class ParquetReader:
             shared_ptr[CTable] ctable
             vector[int] c_column_indices
 
-        if use_threads:
-            self.set_use_threads(use_threads)
+        self.set_use_threads(use_threads)
 
         if column_indices is not None:
             for index in column_indices:

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -18,7 +18,7 @@
 # cython: language_level = 3
 
 from pyarrow.lib cimport check_status
-from pyarrow.compat import frombytes, tobytes
+from pyarrow.lib import frombytes, tobytes
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_fs cimport *

--- a/python/pyarrow/builder.pxi
+++ b/python/pyarrow/builder.pxi
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from pyarrow.compat import tobytes
-
 
 cdef class StringBuilder:
     """

--- a/python/pyarrow/compat.pxi
+++ b/python/pyarrow/compat.pxi
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+def encode_file_path(path):
+    if isinstance(path, str):
+        # POSIX systems can handle utf-8. UTF8 is converted to utf16-le in
+        # libarrow
+        encoded_path = path.encode('utf-8')
+    else:
+        encoded_path = path
+
+    # Windows file system requires utf-16le for file names; Arrow C++ libraries
+    # will convert utf8 to utf16
+    return encoded_path
+
+
+if sys.version_info >= (3, 7):
+    # Starting with Python 3.7, dicts are guaranteed to be insertion-ordered.
+    ordered_dict = dict
+else:
+    import collections
+    ordered_dict = collections.OrderedDict
+
+
+try:
+    import pickle5 as builtin_pickle
+except ImportError:
+    import pickle as builtin_pickle
+
+
+try:
+    import cloudpickle as pickle
+except ImportError:
+    pickle = builtin_pickle
+
+
+def tobytes(o):
+    if isinstance(o, str):
+        return o.encode('utf8')
+    else:
+        return o
+
+
+def frombytes(o, *, safe=False):
+    if safe:
+        return o.decode('utf8', errors='replace')
+    else:
+        return o.decode('utf8')

--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -23,58 +23,12 @@ import unittest
 
 import numpy as np
 
-try:
-    import pickle5 as builtin_pickle
-except ImportError:
-    import pickle as builtin_pickle
-
 from collections.abc import Iterable, Mapping, Sequence
-
+from pyarrow.lib import frombytes, tobytes
 
 def guid():
     from uuid import uuid4
     return uuid4().hex
-
-
-def tobytes(o):
-    if isinstance(o, str):
-        return o.encode('utf8')
-    else:
-        return o
-
-
-def frombytes(o, *, safe=False):
-    if safe:
-        return o.decode('utf8', errors='replace')
-    else:
-        return o.decode('utf8')
-
-
-if sys.version_info >= (3, 7):
-    # Starting with Python 3.7, dicts are guaranteed to be insertion-ordered.
-    ordered_dict = dict
-else:
-    import collections
-    ordered_dict = collections.OrderedDict
-
-
-try:
-    import cloudpickle as pickle
-except ImportError:
-    pickle = builtin_pickle
-
-
-def encode_file_path(path):
-    if isinstance(path, str):
-        # POSIX systems can handle utf-8. UTF8 is converted to utf16-le in
-        # libarrow
-        encoded_path = path.encode('utf-8')
-    else:
-        encoded_path = path
-
-    # Windows file system requires utf-16le for file names; Arrow C++ libraries
-    # will convert utf8 to utf16
-    return encoded_path
 
 
 integer_types = (int, np.integer,)

--- a/python/pyarrow/error.pxi
+++ b/python/pyarrow/error.pxi
@@ -17,7 +17,6 @@
 
 from pyarrow.includes.libarrow cimport CStatus, IsPyError, RestorePyError
 from pyarrow.includes.common cimport c_string
-from pyarrow.compat import frombytes
 
 
 class ArrowException(Exception):

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -28,8 +28,6 @@ import warnings
 from io import BufferedIOBase, IOBase, TextIOBase, UnsupportedOperation
 
 from pyarrow.util import _is_path_like, _stringify_path
-from pyarrow.compat import (
-    builtin_pickle, frombytes, tobytes, encode_file_path)
 
 
 # 64K

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -24,8 +24,7 @@ import decimal as _pydecimal
 import json
 import numpy as np
 import os
-
-from pyarrow.compat import frombytes, tobytes, ordered_dict
+import sys
 
 from cython.operator cimport dereference as deref
 from pyarrow.includes.libarrow cimport *
@@ -40,6 +39,8 @@ arrow_init_numpy()
 import_pyarrow()
 set_numpy_nan(np.nan)
 
+# pandas API shim
+include "compat.pxi"
 
 def cpu_count():
     """

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -21,7 +21,6 @@
 
 import datetime
 import decimal as _pydecimal
-import json
 import numpy as np
 import os
 import sys

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -17,6 +17,7 @@
 
 
 import ast
+from collections.abc import Sequence
 from copy import deepcopy
 from itertools import zip_longest
 import json
@@ -27,9 +28,7 @@ import warnings
 import numpy as np
 
 import pyarrow as pa
-from pyarrow.lib import _pandas_api
-from pyarrow.compat import (builtin_pickle,  # noqa
-                            frombytes, Sequence)
+from pyarrow.lib import _pandas_api, builtin_pickle, frombytes  # noqa
 
 
 _logical_type_map = {}

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -17,8 +17,6 @@
 
 from cpython.ref cimport PyObject
 
-from pyarrow.compat import frombytes, pickle
-
 
 def is_named_tuple(cls):
     """

--- a/python/pyarrow/serialization.py
+++ b/python/pyarrow/serialization.py
@@ -20,8 +20,8 @@ import collections
 import numpy as np
 
 import pyarrow as pa
-from pyarrow.compat import builtin_pickle, descr_to_dtype
-from pyarrow.lib import SerializationContext, py_buffer
+from pyarrow.compat import descr_to_dtype
+from pyarrow.lib import SerializationContext, py_buffer, builtin_pickle
 
 try:
     import cloudpickle

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -21,9 +21,6 @@ import re
 import sys
 import warnings
 
-from pyarrow import compat
-from pyarrow.compat import builtin_pickle
-
 
 # These are imprecise because the type (in pandas 0.x) depends on the presence
 # of nulls
@@ -2360,7 +2357,7 @@ def struct(fields):
         vector[shared_ptr[CField]] c_fields
         cdef shared_ptr[CDataType] struct_type
 
-    if isinstance(fields, compat.Mapping):
+    if isinstance(fields, Mapping):
         fields = fields.items()
 
     for item in fields:
@@ -2557,7 +2554,7 @@ def schema(fields, metadata=None):
         Field py_field
         vector[shared_ptr[CField]] c_fields
 
-    if isinstance(fields, compat.Mapping):
+    if isinstance(fields, Mapping):
         fields = fields.items()
 
     for item in fields:


### PR DESCRIPTION
I started doing some compat refactoring to help avoid circular imports between pyarrow.lib and `pyarrow/__init__.py`