### PR TITLE
ARROW-8979: [C++] Refine bitmap unaligned word access

### DIFF
--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -92,7 +92,7 @@ int64_t CountSetBits(const uint8_t* data, int64_t bit_offset, int64_t length);
 
 ARROW_EXPORT
 bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-                  int64_t right_offset, int64_t bit_length);
+                  int64_t right_offset, int64_t length);
 
 /// \brief Do a "bitmap and" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put


### PR DESCRIPTION
This patch adds word based bitmap reader/writer class to hold common
code in unaligned bitmap operations(copy, compare, logical).

It processes in words, then bytes, and finally in bits. Bitmap copying
improves about 5% ~ 10% performance. Slight drop(2% ~ 5%) for bitmap
comparing. No obvious difference for logical operations.