### PR TITLE
ARROW-9042: [C++] Add Subtract and Multiply arithmetic kernels with wrap-around behavior

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -42,6 +42,8 @@ namespace compute {
 // Arithmetic
 
 SCALAR_EAGER_BINARY(Add, "add")
+SCALAR_EAGER_BINARY(Sub, "sub")
+SCALAR_EAGER_BINARY(Mul, "mul")
 
 // ----------------------------------------------------------------------
 // Set-related operations

--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -42,8 +42,8 @@ namespace compute {
 // Arithmetic
 
 SCALAR_EAGER_BINARY(Add, "add")
-SCALAR_EAGER_BINARY(Sub, "sub")
-SCALAR_EAGER_BINARY(Mul, "mul")
+SCALAR_EAGER_BINARY(Subtract, "subtract")
+SCALAR_EAGER_BINARY(Multiply, "multiply")
 
 // ----------------------------------------------------------------------
 // Set-related operations

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -45,6 +45,26 @@ namespace compute {
 ARROW_EXPORT
 Result<Datum> Add(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 
+/// \brief Subtract two values. Array values must be the same length. If a
+/// value is null in either addend, the result is null
+///
+/// \param[in] left the first value
+/// \param[in] right the second value
+/// \param[in] ctx the function execution context, optional
+/// \return the elementwise addition of the values
+ARROW_EXPORT
+Result<Datum> Sub(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
+
+/// \brief Multiply two values. Array values must be the same length. If a
+/// value is null in either addend, the result is null
+///
+/// \param[in] left the first value
+/// \param[in] right the second value
+/// \param[in] ctx the function execution context, optional
+/// \return the elementwise addition of the values
+ARROW_EXPORT
+Result<Datum> Mul(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
+
 enum CompareOperator {
   EQUAL,
   NOT_EQUAL,

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -45,23 +45,23 @@ namespace compute {
 ARROW_EXPORT
 Result<Datum> Add(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 
-/// \brief Subtract two values. Array values must be the same length. If a
-/// value is null in either addend, the result is null
+/// \brief Subtract two values. Array values must be the same length. If the
+/// minuend or minuend is null the result will be null.
 ///
-/// \param[in] left the first value
-/// \param[in] right the second value
+/// \param[in] minuend the value subtracted from
+/// \param[in] subtrahend the value by which the minuend is reduced
 /// \param[in] ctx the function execution context, optional
-/// \return the elementwise addition of the values
+/// \return the elementwise difference of the values
 ARROW_EXPORT
 Result<Datum> Sub(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 
-/// \brief Multiply two values. Array values must be the same length. If a
-/// value is null in either addend, the result is null
+/// \brief Multiply two values. Array values must be the same length. If either
+/// factor is null, the result is null
 ///
-/// \param[in] left the first value
-/// \param[in] right the second value
+/// \param[in] left the first factor
+/// \param[in] right the second factor
 /// \param[in] ctx the function execution context, optional
-/// \return the elementwise addition of the values
+/// \return the elementwise product of the factors
 ARROW_EXPORT
 Result<Datum> Mul(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -35,33 +35,33 @@ namespace compute {
 
 // ----------------------------------------------------------------------
 
-/// \brief Add two values together. Array values must be the same length. If a
-/// value is null in either addend, the result is null
+/// \brief Add two values together. Array values must be the same length. If
+/// either addend is null the result will be null.
 ///
-/// \param[in] left the first value
-/// \param[in] right the second value
+/// \param[in] left the first addend
+/// \param[in] right the second addend
 /// \param[in] ctx the function execution context, optional
-/// \return the elementwise addition of the values
+/// \return the elementwise sum
 ARROW_EXPORT
 Result<Datum> Add(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 
 /// \brief Subtract two values. Array values must be the same length. If the
-/// minuend or minuend is null the result will be null.
+/// minuend or subtrahend is null the result will be null.
 ///
-/// \param[in] left minuend, the value subtracted from
-/// \param[in] right subtrahend, the value by which the minuend is reduced
+/// \param[in] left the value subtracted from (minuend)
+/// \param[in] right the value by which the minuend is reduced (subtrahend)
 /// \param[in] ctx the function execution context, optional
-/// \return the elementwise difference of the values
+/// \return the elementwise difference
 ARROW_EXPORT
 Result<Datum> Subtract(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 
 /// \brief Multiply two values. Array values must be the same length. If either
-/// factor is null, the result is null
+/// factor is null the result will be null.
 ///
 /// \param[in] left the first factor
 /// \param[in] right the second factor
 /// \param[in] ctx the function execution context, optional
-/// \return the elementwise product of the factors
+/// \return the elementwise product
 ARROW_EXPORT
 Result<Datum> Multiply(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -48,12 +48,12 @@ Result<Datum> Add(const Datum& left, const Datum& right, ExecContext* ctx = NULL
 /// \brief Subtract two values. Array values must be the same length. If the
 /// minuend or minuend is null the result will be null.
 ///
-/// \param[in] minuend the value subtracted from
-/// \param[in] subtrahend the value by which the minuend is reduced
+/// \param[in] left minuend, the value subtracted from
+/// \param[in] right subtrahend, the value by which the minuend is reduced
 /// \param[in] ctx the function execution context, optional
 /// \return the elementwise difference of the values
 ARROW_EXPORT
-Result<Datum> Sub(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
+Result<Datum> Subtract(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 
 /// \brief Multiply two values. Array values must be the same length. If either
 /// factor is null, the result is null
@@ -63,7 +63,7 @@ Result<Datum> Sub(const Datum& left, const Datum& right, ExecContext* ctx = NULL
 /// \param[in] ctx the function execution context, optional
 /// \return the elementwise product of the factors
 ARROW_EXPORT
-Result<Datum> Mul(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
+Result<Datum> Multiply(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 
 enum CompareOperator {
   EQUAL,

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -619,6 +619,8 @@ struct ScalarBinary {
   static void ArrayArray(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     ArrayIterator<Arg0Type> arg0(*batch[0].array());
     ArrayIterator<Arg1Type> arg1(*batch[1].array());
+    // I don't get it why it is unable to deduce the OUT type of Call since it is
+    // explicitly defined as the return type of the lambda.
     OutputAdapter<OutType>::Write(ctx, out, [&]() -> OUT {
         return Op::template Call(ctx, arg0(), arg1());
     });

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -644,7 +644,6 @@ struct ScalarBinary {
   }
 
   static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-
     if (batch[0].kind() == Datum::ARRAY) {
       if (batch[1].kind() == Datum::ARRAY) {
         return ArrayArray<Op>(ctx, batch, out);
@@ -720,43 +719,6 @@ ArrayKernelExec NumericEqualTypesUnary(detail::GetTypeId get_id) {
       return ScalarPrimitiveExecUnary<Op, FloatType, FloatType>;
     case Type::DOUBLE:
       return ScalarPrimitiveExecUnary<Op, DoubleType, DoubleType>;
-    default:
-      DCHECK(false);
-      return ExecFail;
-  }
-}
-
-// Generate a kernel given a functor of type
-//
-// struct OPERATOR_NAME {
-//   template <typename OUT, typename ARG0, typename ARG1>
-//   static OUT Call(KernelContext*, ARG0 left, ARG1 right) {
-//     // IMPLEMENTATION
-//   }
-// };
-template <typename Op>
-ArrayKernelExec NumericEqualTypesBinary(detail::GetTypeId get_id) {
-  switch (get_id.id) {
-    case Type::INT8:
-      return ScalarPrimitiveExecBinary<Op, Int8Type, Int8Type, Int8Type>;
-    case Type::UINT8:
-      return ScalarPrimitiveExecBinary<Op, UInt8Type, UInt8Type, UInt8Type>;
-    case Type::INT16:
-      return ScalarPrimitiveExecBinary<Op, Int16Type, Int16Type, Int16Type>;
-    case Type::UINT16:
-      return ScalarPrimitiveExecBinary<Op, UInt16Type, UInt16Type, UInt16Type>;
-    case Type::INT32:
-      return ScalarPrimitiveExecBinary<Op, Int32Type, Int32Type, Int32Type>;
-    case Type::UINT32:
-      return ScalarPrimitiveExecBinary<Op, UInt32Type, UInt32Type, UInt32Type>;
-    case Type::INT64:
-      return ScalarPrimitiveExecBinary<Op, Int64Type, Int64Type, Int64Type>;
-    case Type::UINT64:
-      return ScalarPrimitiveExecBinary<Op, UInt64Type, UInt64Type, UInt64Type>;
-    case Type::FLOAT:
-      return ScalarPrimitiveExecBinary<Op, FloatType, FloatType, FloatType>;
-    case Type::DOUBLE:
-      return ScalarPrimitiveExecBinary<Op, DoubleType, DoubleType, DoubleType>;
     default:
       DCHECK(false);
       return ExecFail;

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -709,43 +709,6 @@ ArrayKernelExec NumericEqualTypesUnary(detail::GetTypeId get_id) {
   }
 }
 
-// Generate a kernel given a functor of type
-//
-// struct OPERATOR_NAME {
-//   template <typename OUT, typename ARG0, typename ARG1>
-//   static OUT Call(KernelContext*, ARG0 left, ARG1 right) {
-//     // IMPLEMENTATION
-//   }
-// };
-template <typename Op>
-ArrayKernelExec NumericEqualTypesBinary(detail::GetTypeId get_id) {
-  switch (get_id.id) {
-    case Type::INT8:
-      return ScalarBinaryEqualTypes<Int8Type, Int8Type, Op>::Exec;
-    case Type::UINT8:
-      return ScalarBinaryEqualTypes<UInt8Type, UInt8Type, Op>::Exec;
-    case Type::INT16:
-      return ScalarBinaryEqualTypes<Int16Type, Int16Type, Op>::Exec;
-    case Type::UINT16:
-      return ScalarBinaryEqualTypes<UInt16Type, UInt16Type, Op>::Exec;
-    case Type::INT32:
-      return ScalarBinaryEqualTypes<Int32Type, Int32Type, Op>::Exec;
-    case Type::UINT32:
-      return ScalarBinaryEqualTypes<UInt32Type, UInt32Type, Op>::Exec;
-    case Type::INT64:
-      return ScalarBinaryEqualTypes<Int64Type, Int64Type, Op>::Exec;
-    case Type::UINT64:
-      return ScalarBinaryEqualTypes<UInt64Type, UInt64Type, Op>::Exec;
-    case Type::FLOAT:
-      return ScalarBinaryEqualTypes<FloatType, FloatType, Op>::Exec;
-    case Type::DOUBLE:
-      return ScalarBinaryEqualTypes<DoubleType, DoubleType, Op>::Exec;
-    default:
-      DCHECK(false);
-      return ExecFail;
-  }
-}
-
 // Generate a kernel given a templated functor. This template effectively
 // "curries" the first type argument. The functor must be of the form:
 //

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -648,8 +648,7 @@ struct ScalarBinary {
 
 // A kernel exec generator for binary kernels where both input types are the
 // same
-template <typename OutType, typename ArgType, typename Op,
-          typename FlippedOp = Op>
+template <typename OutType, typename ArgType, typename Op>
 using ScalarBinaryEqualTypes = ScalarBinary<OutType, ArgType, ArgType, Op>;
 
 // ----------------------------------------------------------------------
@@ -704,6 +703,43 @@ ArrayKernelExec NumericEqualTypesUnary(detail::GetTypeId get_id) {
       return ScalarPrimitiveExecUnary<Op, FloatType, FloatType>;
     case Type::DOUBLE:
       return ScalarPrimitiveExecUnary<Op, DoubleType, DoubleType>;
+    default:
+      DCHECK(false);
+      return ExecFail;
+  }
+}
+
+// Generate a kernel given a functor of type
+//
+// struct OPERATOR_NAME {
+//   template <typename OUT, typename ARG0, typename ARG1>
+//   static OUT Call(KernelContext*, ARG0 left, ARG1 right) {
+//     // IMPLEMENTATION
+//   }
+// };
+template <typename Op>
+ArrayKernelExec NumericEqualTypesBinary(detail::GetTypeId get_id) {
+  switch (get_id.id) {
+    case Type::INT8:
+      return ScalarBinaryEqualTypes<Int8Type, Int8Type, Op>::Exec;
+    case Type::UINT8:
+      return ScalarBinaryEqualTypes<UInt8Type, UInt8Type, Op>::Exec;
+    case Type::INT16:
+      return ScalarBinaryEqualTypes<Int16Type, Int16Type, Op>::Exec;
+    case Type::UINT16:
+      return ScalarBinaryEqualTypes<UInt16Type, UInt16Type, Op>::Exec;
+    case Type::INT32:
+      return ScalarBinaryEqualTypes<Int32Type, Int32Type, Op>::Exec;
+    case Type::UINT32:
+      return ScalarBinaryEqualTypes<UInt32Type, UInt32Type, Op>::Exec;
+    case Type::INT64:
+      return ScalarBinaryEqualTypes<Int64Type, Int64Type, Op>::Exec;
+    case Type::UINT64:
+      return ScalarBinaryEqualTypes<UInt64Type, UInt64Type, Op>::Exec;
+    case Type::FLOAT:
+      return ScalarBinaryEqualTypes<FloatType, FloatType, Op>::Exec;
+    case Type::DOUBLE:
+      return ScalarBinaryEqualTypes<DoubleType, DoubleType, Op>::Exec;
     default:
       DCHECK(false);
       return ExecFail;

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -22,22 +22,27 @@
 namespace arrow {
 namespace compute {
 
+// explicitly disallow signed integers as input arguments
+template <typename T>
+using enable_if_unsigned_or_floating =
+    enable_if_t<std::is_unsigned<T>::value || std::is_floating_point<T>::value>;
+
 struct Add {
-  template <typename T>
+  template <typename T, typename = enable_if_unsigned_or_floating<T>>
   static constexpr T Call(KernelContext*, T left, T right) {
     return left + right;
   }
 };
 
 struct Sub {
-  template <typename T>
+  template <typename T, typename = enable_if_unsigned_or_floating<T>>
   static constexpr T Call(KernelContext*, T left, T right) {
     return left - right;
   }
 };
 
 struct Mul {
-  template <typename T>
+  template <typename T, typename = enable_if_unsigned_or_floating<T>>
   static constexpr T Call(KernelContext*, T left, T right) {
     return left * right;
   }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -21,10 +21,39 @@ namespace arrow {
 namespace compute {
 
 struct Add {
-  template <typename ARG0, typename ARG1>
-  static constexpr auto Call(KernelContext*, ARG0 left, ARG1 right)
-      -> decltype(left + right) {
-    return left + right;
+  template <typename OUT = int16_t>
+  static constexpr OUT Call(KernelContext*, int8_t l, int8_t r) {
+    return static_cast<OUT>(l) + static_cast<OUT>(r);
+  }
+
+  template <typename OUT = int32_t>
+  static constexpr OUT Call(KernelContext*, int16_t l, int16_t r) {
+    return static_cast<OUT>(l) + static_cast<OUT>(r);
+  }
+
+  template <typename OUT = int64_t>
+  static constexpr OUT Call(KernelContext*, int32_t l, int32_t r) {
+    return static_cast<OUT>(l) + static_cast<OUT>(r);
+  }
+
+  template <typename OUT = uint16_t>
+  static constexpr OUT Call(KernelContext*, uint8_t l, uint8_t r) {
+    return static_cast<OUT>(l) + static_cast<OUT>(r);
+  }
+
+  template <typename OUT = uint32_t>
+  static constexpr OUT Call(KernelContext*, uint16_t l, uint16_t r) {
+    return static_cast<OUT>(l) + static_cast<OUT>(r);
+  }
+
+  template <typename OUT = uint64_t>
+  static constexpr OUT Call(KernelContext*, uint32_t l, uint32_t r) {
+    return static_cast<OUT>(l) + static_cast<OUT>(r);
+  }
+
+  template <typename OUT>
+  static constexpr OUT Call(KernelContext*, OUT l, OUT r) {
+    return l + r;
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -145,7 +145,7 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
   // ../src/arrow/compute/kernels/scalar_arithmetic.cc:25:24: note: candidate template ignored: couldn't infer template argument 'OUT'
   //   static constexpr OUT Call(KernelContext*, ARG0 left, ARG1 right) {
   //
-                         ^
+
   // codegen::MakeBinaryFunction2<Add>("add", registry);
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -89,12 +89,8 @@ void MakeBinaryFunction(std::string name, FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Binary());
   for (const std::shared_ptr<DataType>& input_type : NumericTypes()) {
     DCHECK_OK(
-      func->AddKernel(
-        {InputType::Array(input_type), InputType::Array(input_type)},
-        GetOutputType(input_type),
-        GetBinaryExec<Op>(*input_type)
-      )
-    );
+        func->AddKernel({InputType::Array(input_type), InputType::Array(input_type)},
+                        GetOutputType(input_type), GetBinaryExec<Op>(*input_type)));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -68,9 +68,3 @@ void RegisterScalarArithmetic(FunctionRegistry* registry) {
 }  // namespace internal
 }  // namespace compute
 }  // namespace arrow
-
-
-// add, checked_add, safe_add
-// ne legyen ertelmeze sub unsigned tipusokon
-// unsigned arithmetikat hasznalni signed muveletekhez hogy az undefined behaviourt elkeruljuk
-//

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -17,7 +17,6 @@
 
 #include "arrow/compute/kernels/common.h"
 #include "arrow/util/int_util.h"
-#include "iostream"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -21,101 +21,44 @@ namespace arrow {
 namespace compute {
 
 struct Add {
-  template <typename OUT, typename ARG0, typename ARG1>
-  static constexpr OUT Call(KernelContext*, ARG0 left, ARG1 right) {
+  template <typename ARG0, typename ARG1>
+  static constexpr auto Call(KernelContext*, ARG0 left, ARG1 right)
+      -> decltype(left + right) {
     return left + right;
   }
 };
 
 namespace codegen {
 
-template <typename Op>
-ArrayKernelExec GetBinaryExec(detail::GetTypeId get_id) {
-  // These execution functions doesn't support operations between multiple shapes,
-  // only op(array like, array like) is supported.
-  // Note that we don't have plans to add binary kernels with differntly types
-  // lhs and rhs arguments, that will be handled with implicit casts during the
-  // kernel dispatch procedure.
-  //
-  // There is a ScalarBinary facility in the codegen_internals.h which already
-  // handles those cases. I illustrate my plan MakeBinaryFunction2 by trying to
-  // add a single kernel to the function.
-  switch (get_id.id) {
-    case Type::INT8:
-      return ScalarPrimitiveExecBinary<Op, Int16Type, Int8Type, Int8Type>;
-    case Type::UINT8:
-      return ScalarPrimitiveExecBinary<Op, UInt16Type, UInt8Type, UInt8Type>;
-    case Type::INT16:
-      return ScalarPrimitiveExecBinary<Op, Int32Type, Int16Type, Int16Type>;
-    case Type::UINT16:
-      return ScalarPrimitiveExecBinary<Op, UInt32Type, UInt16Type, UInt16Type>;
-    case Type::INT32:
-      return ScalarPrimitiveExecBinary<Op, Int64Type, Int32Type, Int32Type>;
-    case Type::UINT32:
-      return ScalarPrimitiveExecBinary<Op, UInt64Type, UInt32Type, UInt32Type>;
-    case Type::INT64:
-      return ScalarPrimitiveExecBinary<Op, Int64Type, Int64Type, Int64Type>;
-    case Type::UINT64:
-      return ScalarPrimitiveExecBinary<Op, UInt64Type, UInt64Type, UInt64Type>;
-    case Type::FLOAT:
-      return ScalarPrimitiveExecBinary<Op, FloatType, FloatType, FloatType>;
-    case Type::DOUBLE:
-      return ScalarPrimitiveExecBinary<Op, DoubleType, DoubleType, DoubleType>;
-    default:
-      DCHECK(false);
-      return ExecFail;
-  }
-}
-
-std::shared_ptr<DataType> GetOutputType(detail::GetTypeId get_id) {
-  switch (get_id.id) {
-    case Type::INT8:
-      return int16();
-    case Type::INT16:
-      return int32();
-    case Type::INT32:
-    case Type::INT64:
-      return int64();
-    case Type::UINT8:
-      return uint16();
-    case Type::UINT16:
-      return uint32();
-    case Type::UINT32:
-    case Type::UINT64:
-      return uint64();
-    case Type::FLOAT:
-      return float32();
-    case Type::DOUBLE:
-      return float64();
-    default:
-      DCHECK(false);
-      return nullptr;
-  }
+template <typename Op, typename ArgType, typename OutType>
+void AddBinaryKernel(const std::shared_ptr<ScalarFunction>& func) {
+  // create an exec function with the requested signature
+  ArrayKernelExec exec = ScalarBinaryEqualTypes<OutType, ArgType, Op>::Exec;
+  // create type objects based on the template arguments
+  auto arg = TypeTraits<ArgType>::type_singleton();
+  auto out = TypeTraits<OutType>::type_singleton();
+  // add the exec function as a kernel with the appropiate signature
+  DCHECK_OK(func->AddKernel({arg, arg}, out, exec));
 }
 
 template <typename Op>
-void MakeBinaryFunction(std::string name, FunctionRegistry* registry) {
-  auto func = std::make_shared<ScalarFunction>(name, Arity::Binary());
-  for (const std::shared_ptr<DataType>& input_type : NumericTypes()) {
-    DCHECK_OK(
-        func->AddKernel({InputType::Array(input_type), InputType::Array(input_type)},
-                        GetOutputType(input_type), GetBinaryExec<Op>(*input_type)));
-  }
-  DCHECK_OK(registry->AddFunction(std::move(func)));
-}
-
-// Here is the function which doesn't compile because of type deduction error
-template <typename Op>
-void MakeBinaryFunction2(std::string name, FunctionRegistry* registry) {
+void AddBinaryFunction(std::string name, FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Binary());
 
-  // create an exec function with signature (int8, int8) -> int16
-  ArrayKernelExec exec = codegen::ScalarBinaryEqualTypes<Int16Type, Int8Type, Op>::Exec;
+  // signed integers
+  AddBinaryKernel<Op, Int8Type, Int16Type>(func);
+  AddBinaryKernel<Op, Int16Type, Int32Type>(func);
+  AddBinaryKernel<Op, Int32Type, Int64Type>(func);
+  AddBinaryKernel<Op, Int64Type, Int64Type>(func);
+  // unsigned integers
+  AddBinaryKernel<Op, UInt8Type, UInt16Type>(func);
+  AddBinaryKernel<Op, UInt16Type, UInt32Type>(func);
+  AddBinaryKernel<Op, UInt32Type, UInt64Type>(func);
+  AddBinaryKernel<Op, UInt64Type, UInt64Type>(func);
+  // floating-point types, TODO(kszucs): add half-float
+  AddBinaryKernel<Op, FloatType, FloatType>(func);
+  AddBinaryKernel<Op, DoubleType, DoubleType>(func);
 
-  // add this exec function as a kernel with the appropiate signature
-  DCHECK_OK(func->AddKernel({int8(), int8()}, int16(), exec));
-
-  // finally register the function, but the
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
 
@@ -124,29 +67,7 @@ void MakeBinaryFunction2(std::string name, FunctionRegistry* registry) {
 namespace internal {
 
 void RegisterScalarArithmetic(FunctionRegistry* registry) {
-  codegen::MakeBinaryFunction<Add>("add", registry);
-
-  // Uncommenting the line below raises the following compiler error:
-  //
-  // In file included from ../src/arrow/compute/kernels/scalar_arithmetic.cc:18:
-  // In file included from ../src/arrow/compute/kernels/common.h:31:
-  // ../src/arrow/compute/kernels/codegen_internal.h:537:16: error: no matching function for call to 'Call'
-  //         return Op::template Call(ctx, arg0(), arg1());
-  //                ^~~~~~~~~~~~~~~~~
-  // ../src/arrow/compute/kernels/codegen_internal.h:567:16: note: in instantiation of member function 'arrow::compute::codegen::ScalarBinary<arrow::Int16Type, arrow::Int8Type, arrow::Int8Type, arrow::compute::Add>::ArrayArray' requested here
-  //         return ArrayArray(ctx, batch, out);
-  //                ^
-  // ../src/arrow/compute/kernels/scalar_arithmetic.cc:113:84: note: in instantiation of member function 'arrow::compute::codegen::ScalarBinary<arrow::Int16Type, arrow::Int8Type, arrow::Int8Type, arrow::compute::Add>::Exec' requested here
-  //   ArrayKernelExec exec = codegen::ScalarBinaryEqualTypes<Int16Type, Int8Type, Op>::Exec;
-  //                                                                                    ^
-  // ../src/arrow/compute/kernels/scalar_arithmetic.cc:129:12: note: in instantiation of function template specialization 'arrow::compute::codegen::MakeBinaryFunction2<arrow::compute::Add>' requested here
-  //   codegen::MakeBinaryFunction2<Add>("add", registry);
-  //            ^
-  // ../src/arrow/compute/kernels/scalar_arithmetic.cc:25:24: note: candidate template ignored: couldn't infer template argument 'OUT'
-  //   static constexpr OUT Call(KernelContext*, ARG0 left, ARG1 right) {
-  //
-
-  // codegen::MakeBinaryFunction2<Add>("add", registry);
+  codegen::AddBinaryFunction<Add>("add", registry);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -88,16 +88,18 @@ struct Multiply {
   }
 
   template <typename T>
-  static constexpr enable_if_t<std::is_same<T, uint16_t>::value, T> Call(KernelContext*,
-                                                                         T left,
-                                                                         T right) {
+  static constexpr enable_if_t<
+      std::is_same<T, uint16_t>::value || std::is_same<T, int16_t>::value, T>
+  Call(KernelContext*, T left, T right) {
     // exception because multiplying to uint16 values involves implicit promotion
     // to signed int32 type which can trigger undefined behaviour by signed overflow
     return static_cast<uint32_t>(left) * static_cast<uint32_t>(right);
   }
 
   template <typename T>
-  static constexpr enable_if_signed_integer<T> Call(KernelContext*, T left, T right) {
+  static constexpr enable_if_t<
+      is_signed_integer<T>::value && !std::is_same<T, int16_t>::value, T>
+  Call(KernelContext*, T left, T right) {
     using Unsigned = typename std::make_unsigned<T>::type;
     return static_cast<Unsigned>(left) * static_cast<Unsigned>(right);
   }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -45,6 +45,40 @@ struct Mul {
 
 namespace codegen {
 
+// Generate a kernel given an arithmetic functor
+//
+// To avoid undefined behaviour of signed integer overflow treat the signed
+// input argument values as unsigned then cast them to signed making them wrap
+// around.
+template <typename Op>
+ArrayKernelExec NumericEqualTypesBinary(detail::GetTypeId get_id) {
+  switch (get_id.id) {
+    case Type::INT8:
+      return ScalarBinaryEqualTypes<Int8Type, UInt8Type, Op>::Exec;
+    case Type::UINT8:
+      return ScalarBinaryEqualTypes<UInt8Type, UInt8Type, Op>::Exec;
+    case Type::INT16:
+      return ScalarBinaryEqualTypes<Int16Type, UInt16Type, Op>::Exec;
+    case Type::UINT16:
+      return ScalarBinaryEqualTypes<UInt16Type, UInt16Type, Op>::Exec;
+    case Type::INT32:
+      return ScalarBinaryEqualTypes<Int32Type, UInt32Type, Op>::Exec;
+    case Type::UINT32:
+      return ScalarBinaryEqualTypes<UInt32Type, UInt32Type, Op>::Exec;
+    case Type::INT64:
+      return ScalarBinaryEqualTypes<Int64Type, UInt64Type, Op>::Exec;
+    case Type::UINT64:
+      return ScalarBinaryEqualTypes<UInt64Type, UInt64Type, Op>::Exec;
+    case Type::FLOAT:
+      return ScalarBinaryEqualTypes<FloatType, FloatType, Op>::Exec;
+    case Type::DOUBLE:
+      return ScalarBinaryEqualTypes<DoubleType, DoubleType, Op>::Exec;
+    default:
+      DCHECK(false);
+      return ExecFail;
+  }
+}
+
 template <typename Op>
 void AddBinaryFunction(std::string name, FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Binary());

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -33,14 +33,14 @@ struct Add {
   }
 };
 
-struct Sub {
+struct Subtract {
   template <typename T, typename = enable_if_unsigned_or_floating<T>>
   static constexpr T Call(KernelContext*, T left, T right) {
     return left - right;
   }
 };
 
-struct Mul {
+struct Multiply {
   template <typename T, typename = enable_if_unsigned_or_floating<T>>
   static constexpr T Call(KernelContext*, T left, T right) {
     return left * right;
@@ -99,8 +99,8 @@ namespace internal {
 
 void RegisterScalarArithmetic(FunctionRegistry* registry) {
   codegen::AddBinaryFunction<Add>("add", registry);
-  codegen::AddBinaryFunction<Sub>("sub", registry);
-  codegen::AddBinaryFunction<Mul>("mul", registry);
+  codegen::AddBinaryFunction<Subtract>("subtract", registry);
+  codegen::AddBinaryFunction<Multiply>("multiply", registry);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -125,7 +125,27 @@ namespace internal {
 
 void RegisterScalarArithmetic(FunctionRegistry* registry) {
   codegen::MakeBinaryFunction<Add>("add", registry);
-  // Comment me out to raise my second problem
+
+  // Uncommenting the line below raises the following compiler error:
+  //
+  // In file included from ../src/arrow/compute/kernels/scalar_arithmetic.cc:18:
+  // In file included from ../src/arrow/compute/kernels/common.h:31:
+  // ../src/arrow/compute/kernels/codegen_internal.h:537:16: error: no matching function for call to 'Call'
+  //         return Op::template Call(ctx, arg0(), arg1());
+  //                ^~~~~~~~~~~~~~~~~
+  // ../src/arrow/compute/kernels/codegen_internal.h:567:16: note: in instantiation of member function 'arrow::compute::codegen::ScalarBinary<arrow::Int16Type, arrow::Int8Type, arrow::Int8Type, arrow::compute::Add>::ArrayArray' requested here
+  //         return ArrayArray(ctx, batch, out);
+  //                ^
+  // ../src/arrow/compute/kernels/scalar_arithmetic.cc:113:84: note: in instantiation of member function 'arrow::compute::codegen::ScalarBinary<arrow::Int16Type, arrow::Int8Type, arrow::Int8Type, arrow::compute::Add>::Exec' requested here
+  //   ArrayKernelExec exec = codegen::ScalarBinaryEqualTypes<Int16Type, Int8Type, Op>::Exec;
+  //                                                                                    ^
+  // ../src/arrow/compute/kernels/scalar_arithmetic.cc:129:12: note: in instantiation of function template specialization 'arrow::compute::codegen::MakeBinaryFunction2<arrow::compute::Add>' requested here
+  //   codegen::MakeBinaryFunction2<Add>("add", registry);
+  //            ^
+  // ../src/arrow/compute/kernels/scalar_arithmetic.cc:25:24: note: candidate template ignored: couldn't infer template argument 'OUT'
+  //   static constexpr OUT Call(KernelContext*, ARG0 left, ARG1 right) {
+  //
+                         ^
   // codegen::MakeBinaryFunction2<Add>("add", registry);
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -25,7 +25,7 @@ namespace compute {
 struct Add {
   template <typename T>
   static constexpr T Call(KernelContext*, T left, T right) {
-    return left - right;
+    return left + right;
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -30,11 +30,71 @@ struct Add {
 namespace codegen {
 
 template <typename Op>
+ArrayKernelExec GetBinaryExec(detail::GetTypeId get_id) {
+  switch (get_id.id) {
+    case Type::INT8:
+      return ScalarPrimitiveExecBinary<Op, Int16Type, Int8Type, Int8Type>;
+    case Type::UINT8:
+      return ScalarPrimitiveExecBinary<Op, UInt16Type, UInt8Type, UInt8Type>;
+    case Type::INT16:
+      return ScalarPrimitiveExecBinary<Op, Int32Type, Int16Type, Int16Type>;
+    case Type::UINT16:
+      return ScalarPrimitiveExecBinary<Op, UInt32Type, UInt16Type, UInt16Type>;
+    case Type::INT32:
+      return ScalarPrimitiveExecBinary<Op, Int64Type, Int32Type, Int32Type>;
+    case Type::UINT32:
+      return ScalarPrimitiveExecBinary<Op, UInt64Type, UInt32Type, UInt32Type>;
+    case Type::INT64:
+      return ScalarPrimitiveExecBinary<Op, Int64Type, Int64Type, Int64Type>;
+    case Type::UINT64:
+      return ScalarPrimitiveExecBinary<Op, UInt64Type, UInt64Type, UInt64Type>;
+    case Type::FLOAT:
+      return ScalarPrimitiveExecBinary<Op, FloatType, FloatType, FloatType>;
+    case Type::DOUBLE:
+      return ScalarPrimitiveExecBinary<Op, DoubleType, DoubleType, DoubleType>;
+    default:
+      DCHECK(false);
+      return ExecFail;
+  }
+}
+
+std::shared_ptr<DataType> GetOutputType(detail::GetTypeId get_id) {
+  switch (get_id.id) {
+    case Type::INT8:
+      return int16();
+    case Type::INT16:
+      return int32();
+    case Type::INT32:
+    case Type::INT64:
+      return int64();
+    case Type::UINT8:
+      return uint16();
+    case Type::UINT16:
+      return uint32();
+    case Type::UINT32:
+    case Type::UINT64:
+      return uint64();
+    case Type::FLOAT:
+      return float32();
+    case Type::DOUBLE:
+      return float64();
+    default:
+      DCHECK(false);
+      return nullptr;
+  }
+}
+
+template <typename Op>
 void MakeBinaryFunction(std::string name, FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Binary());
-  for (const std::shared_ptr<DataType>& ty : NumericTypes()) {
-    DCHECK_OK(func->AddKernel({InputType::Array(ty), InputType::Array(ty)}, ty,
-                              NumericEqualTypesBinary<Op>(*ty)));
+  for (const std::shared_ptr<DataType>& input_type : NumericTypes()) {
+    DCHECK_OK(
+      func->AddKernel(
+        {InputType::Array(input_type), InputType::Array(input_type)},
+        GetOutputType(input_type),
+        GetBinaryExec<Op>(*input_type)
+      )
+    );
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -123,13 +123,22 @@ TYPED_TEST(TestBinaryArithmeticsIntegral, AddCheckExtremes) {
   using InputCType = typename TestFixture::InputCType;
   using OutputCType = typename TestFixture::OutputCType;
 
+  if (std::is_same<InputCType, OutputCType>::value) {
+    // this test case is incompatible with Int64 and UInt64 types because there
+    // are no wider integer types to overflow to
+    return;
+  }
+
   auto min = std::numeric_limits<InputCType>::min();
   auto max = std::numeric_limits<InputCType>::max();
 
   auto left = this->MakeInputArray({1, 2, 3, min, max});
   auto right = this->MakeInputArray({0, 10, 11, min, max});
-  auto expected = this->MakeOutputArray({1, 12, 14, static_cast<OutputCType>(min + min),
-                                         static_cast<OutputCType>(max + max)});
+
+  OutputCType expected_min = 2 * static_cast<OutputCType>(min);
+  OutputCType expected_max = 2 * static_cast<OutputCType>(max);
+
+  auto expected = this->MakeOutputArray({1, 12, 14, expected_min, expected_max});
 
   this->AssertBinop(arrow::compute::Add, left, right, expected);
 }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <algorithm>
-#include <iostream>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -63,6 +62,23 @@ class TestBinaryArithmetics<std::pair<I, O>> : public TestBase {
     ArrayFromVector<OutputType>(values, &out);
     return out;
   }
+
+  // (Scalar, Array)
+  // virtual void AssertBinop(BinaryFunction func, InputCType lhs,
+  //                          const std::string& rhs,
+  //                          const std::string& expected) {
+  //   auto input_type = TypeTraits<InputType>::type_singleton();
+  //   auto output_type = TypeTraits<OutputType>::type_singleton();
+
+  //   auto left = Datum(MakeScalar(input_type, lhs).ValueOrDie());
+  //   auto right = Datum(ArrayFromJSON(input_type, rhs));
+  //   auto exp = ArrayFromJSON(output_type, expected);
+
+  //   ASSERT_OK_AND_ASSIGN(Datum result, func(left, right, nullptr));
+  //   std::shared_ptr<Array> out = result.make_array();
+  //   ASSERT_OK(out->ValidateFull());
+  //   AssertArraysEqual(*exp, *out);
+  // }
 
   // (Array, Array)
   virtual void AssertBinop(BinaryFunction func, const std::shared_ptr<Array>& lhs,
@@ -132,6 +148,9 @@ TYPED_TEST(TestBinaryArithmeticsIntegral, Add) {
 
   this->AssertBinop(arrow::compute::Add, "[null, 1, 3, null, 2, 5]", "[1, 4, 2, 5, 0, 3]",
                     "[null, 5, 5, null, 2, 8]");
+
+  // this->AssertBinop(arrow::compute::Add, 10, "[null, 1, 3, null, 2, 5]",
+  //                   "[null, 11, 13, null, 12, 15]");
 }
 
 TYPED_TEST(TestBinaryArithmeticsIntegral, Sub) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -263,7 +263,7 @@ TYPED_TEST(TestBinaryArithmeticsFloating, Add) {
   this->AssertBinop(arrow::compute::Add, "[null, 1, 3.3, null, 2, 5.3]",
                     "[1, 4, 2, 5, 0, 3]", "[null, 5, 5.3, null, 2, 8.3]");
 
-  this->AssertBinop(arrow::compute::Add, 1.1, "[null, 1, 3.3, null, 2, 5.3]",
+  this->AssertBinop(arrow::compute::Add, 1.1F, "[null, 1, 3.3, null, 2, 5.3]",
                     "[null, 2.1, 4.4, null, 3.1, 6.4]");
 }
 
@@ -286,7 +286,7 @@ TYPED_TEST(TestBinaryArithmeticsFloating, Sub) {
   this->AssertBinop(arrow::compute::Subtract, "[null, 1, 3.3, null, 2, 5.3]",
                     "[1, 4, 2, 5, 0, 3]", "[null, -3, 1.3, null, 2, 2.3]");
 
-  this->AssertBinop(arrow::compute::Subtract, 0.1, "[null, 1, 3.3, null, 2, 5.3]",
+  this->AssertBinop(arrow::compute::Subtract, 0.1F, "[null, 1, 3.3, null, 2, 5.3]",
                     "[null, -0.9, -3.2, null, -1.9, -5.2]");
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -48,15 +48,12 @@ class TestBinaryArithmetics<std::pair<I, O>> : public TestBase {
   using InputCType = typename I::c_type;
   using OutputCType = typename O::c_type;
 
-  using BinaryFunction = std::function<Result<Datum>(const Datum&, const Datum&, ExecContext*)>;
+  using BinaryFunction =
+      std::function<Result<Datum>(const Datum&, const Datum&, ExecContext*)>;
 
-  static InputCType GetMin() {
-    return std::numeric_limits<InputCType>::min();
-  }
+  static InputCType GetMin() { return std::numeric_limits<InputCType>::min(); }
 
-  static InputCType GetMax() {
-    return std::numeric_limits<InputCType>::max();
-  }
+  static InputCType GetMax() { return std::numeric_limits<InputCType>::max(); }
 
   std::shared_ptr<Array> MakeInputArray(const std::vector<InputCType>& values) {
     std::shared_ptr<Array> out;
@@ -70,8 +67,7 @@ class TestBinaryArithmetics<std::pair<I, O>> : public TestBase {
     return out;
   }
 
-  virtual void AssertBinop(BinaryFunction func,
-                           const std::shared_ptr<Array>& lhs,
+  virtual void AssertBinop(BinaryFunction func, const std::shared_ptr<Array>& lhs,
                            const std::shared_ptr<Array>& rhs,
                            const std::shared_ptr<Array>& expected) {
     ASSERT_OK_AND_ASSIGN(Datum result, func(lhs, rhs, nullptr));
@@ -97,22 +93,17 @@ class TestBinaryArithmeticsFloating : public TestBinaryArithmetics<TypePair> {};
 
 // InputType - OutputType pairs
 using IntegralPairs = testing::Types<
-  // std::pair<Int8Type, Int16Type>,
-  std::pair<Int16Type, Int32Type>,
-  std::pair<Int32Type, Int64Type>,
-  std::pair<Int64Type, Int64Type>,
-  // std::pair<UInt8Type, UInt16Type>,
-  // std::pair<UInt16Type, UInt32Type>,
-  std::pair<UInt32Type, UInt64Type>,
-  std::pair<UInt64Type, UInt64Type>
->;
+    // std::pair<Int8Type, Int16Type>,
+    std::pair<Int16Type, Int32Type>, std::pair<Int32Type, Int64Type>,
+    std::pair<Int64Type, Int64Type>,
+    // std::pair<UInt8Type, UInt16Type>,
+    // std::pair<UInt16Type, UInt32Type>,
+    std::pair<UInt32Type, UInt64Type>, std::pair<UInt64Type, UInt64Type>>;
 
 // InputType - OutputType pairs
 using FloatingPairs = testing::Types<
-  // std::pair<HalfFloatType, HalfFloatType>,
-  std::pair<FloatType, FloatType>,
-  std::pair<DoubleType, DoubleType>
->;
+    // std::pair<HalfFloatType, HalfFloatType>,
+    std::pair<FloatType, FloatType>, std::pair<DoubleType, DoubleType>>;
 
 TYPED_TEST_SUITE(TestBinaryArithmeticsIntegral, IntegralPairs);
 TYPED_TEST_SUITE(TestBinaryArithmeticsFloating, FloatingPairs);
@@ -122,29 +113,31 @@ TYPED_TEST(TestBinaryArithmeticsIntegral, Add) {
   this->AssertBinop(arrow::compute::Add, "[]", "[]", "[]");
   this->AssertBinop(arrow::compute::Add, "[3, 2, 6]", "[1, 0, 2]", "[4, 2, 8]");
 
-  this->AssertBinop(arrow::compute::Add, "[1, 2, 3, 4, 5, 6, 7]",
-                    "[0, 1, 2, 3, 4, 5, 6]", "[1, 3, 5, 7, 9, 11, 13]");
+  this->AssertBinop(arrow::compute::Add, "[1, 2, 3, 4, 5, 6, 7]", "[0, 1, 2, 3, 4, 5, 6]",
+                    "[1, 3, 5, 7, 9, 11, 13]");
 
-  this->AssertBinop(arrow::compute::Add, "[7, 6, 5, 4, 3, 2, 1]",
-                    "[6, 5, 4, 3, 2, 1, 0]", "[13, 11, 9, 7, 5, 3, 1]");
+  this->AssertBinop(arrow::compute::Add, "[7, 6, 5, 4, 3, 2, 1]", "[6, 5, 4, 3, 2, 1, 0]",
+                    "[13, 11, 9, 7, 5, 3, 1]");
 
   this->AssertBinop(arrow::compute::Add, "[10, 12, 4, 50, 50, 32, 11]",
                     "[2, 0, 6, 1, 5, 3, 4]", "[12, 12, 10, 51, 55, 35, 15]");
 
-  this->AssertBinop(arrow::compute::Add, "[null, 1, 3, null, 2, 5]",
-                    "[1, 4, 2, 5, 0, 3]", "[null, 5, 5, null, 2, 8]");
+  this->AssertBinop(arrow::compute::Add, "[null, 1, 3, null, 2, 5]", "[1, 4, 2, 5, 0, 3]",
+                    "[null, 5, 5, null, 2, 8]");
 }
 
-// If I uncomment the commented out signed integer pairs above then clang gives me the following
-// warning:
+// If I uncomment the commented out signed integer pairs above then clang gives me the
+// following warning:
 //
-// ../src/arrow/compute/kernels/scalar_arithmetic_test.cc:150:64: note: insert an explicit cast to silence this issue
+// ../src/arrow/compute/kernels/scalar_arithmetic_test.cc:150:64: note: insert an explicit
+// cast to silence this issue
 //   auto expected = this->MakeOutputArray({1, 12, 14, min + min, max + max});
 //                                                                ^~~~~~~~~
-//                                                                static_cast<unsigned short>( )
+//                                                                static_cast<unsigned
+//                                                                short>( )
 //
-// Since I don't really access the types within this typed test, I assume I need a different
-// approach?
+// Since I don't really access the types within this typed test, I assume I need a
+// different approach?
 TYPED_TEST(TestBinaryArithmeticsIntegral, AddCheckExtremes) {
   auto min = this->GetMin();
   auto max = this->GetMax();
@@ -159,19 +152,20 @@ TYPED_TEST(TestBinaryArithmeticsIntegral, AddCheckExtremes) {
 TYPED_TEST(TestBinaryArithmeticsFloating, Add) {
   this->AssertBinop(arrow::compute::Add, "[]", "[]", "[]");
 
-  this->AssertBinop(arrow::compute::Add, "[3.4, 2.6, 6.3]", "[1, 0, 2]", "[4.4, 2.6, 8.3]");
+  this->AssertBinop(arrow::compute::Add, "[3.4, 2.6, 6.3]", "[1, 0, 2]",
+                    "[4.4, 2.6, 8.3]");
 
-  this->AssertBinop(arrow::compute::Add, "[1.1, 2.4, 3.5, 4.3, 5.1, 6.8, 7.3]", "[0, 1, 2, 3, 4, 5, 6]",
-                  "[1.1, 3.4, 5.5, 7.3, 9.1, 11.8, 13.3]");
+  this->AssertBinop(arrow::compute::Add, "[1.1, 2.4, 3.5, 4.3, 5.1, 6.8, 7.3]",
+                    "[0, 1, 2, 3, 4, 5, 6]", "[1.1, 3.4, 5.5, 7.3, 9.1, 11.8, 13.3]");
 
   this->AssertBinop(arrow::compute::Add, "[7, 6, 5, 4, 3, 2, 1]", "[6, 5, 4, 3, 2, 1, 0]",
-                  "[13, 11, 9, 7, 5, 3, 1]");
+                    "[13, 11, 9, 7, 5, 3, 1]");
 
-  this->AssertBinop(arrow::compute::Add, "[10.4, 12, 4.2, 50, 50.3, 32, 11]", "[2, 0, 6, 1, 5, 3, 4]",
-                  "[12.4, 12, 10.2, 51, 55.3, 35, 15]");
+  this->AssertBinop(arrow::compute::Add, "[10.4, 12, 4.2, 50, 50.3, 32, 11]",
+                    "[2, 0, 6, 1, 5, 3, 4]", "[12.4, 12, 10.2, 51, 55.3, 35, 15]");
 
-  this->AssertBinop(arrow::compute::Add, "[null, 1, 3.3, null, 2, 5.3]", "[1, 4, 2, 5, 0, 3]",
-                  "[null, 5, 5.3, null, 2, 8.3]");
+  this->AssertBinop(arrow::compute::Add, "[null, 1, 3.3, null, 2, 5.3]",
+                    "[1, 4, 2, 5, 0, 3]", "[null, 5, 5.3, null, 2, 8.3]");
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -163,6 +163,19 @@ TYPED_TEST(TestBinaryArithmeticsSigned, Add) {
                     "[-6, 5, -4, 3, -2, 1, 0]", "[-13, 11, 1, 7, 1, 3, 1]");
 }
 
+TYPED_TEST(TestBinaryArithmeticsSigned, AddOverflow) {
+  using InputCType = typename TestFixture::InputCType;
+
+  auto min = std::numeric_limits<InputCType>::min();
+  auto max = std::numeric_limits<InputCType>::max();
+
+  auto left = this->MakeInputArray({max});
+  auto right = this->MakeInputArray({1});
+  auto expected = this->MakeOutputArray({min});
+
+  this->AssertBinop(arrow::compute::Add, left, right, expected);
+}
+
 TYPED_TEST(TestBinaryArithmeticsSigned, Sub) {
   this->AssertBinop(arrow::compute::Sub, "[0, 1, 2, 3, 4, 5, 6]", "[1, 2, 3, 4, 5, 6, 7]",
                     "[-1, -1, -1, -1, -1, -1, -1]");

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -64,6 +64,7 @@ class TestBinaryArithmetics<std::pair<I, O>> : public TestBase {
     return out;
   }
 
+  // (Array, Array)
   virtual void AssertBinop(BinaryFunction func, const std::shared_ptr<Array>& lhs,
                            const std::shared_ptr<Array>& rhs,
                            const std::shared_ptr<Array>& expected) {
@@ -134,27 +135,27 @@ TYPED_TEST(TestBinaryArithmeticsIntegral, Add) {
 }
 
 TYPED_TEST(TestBinaryArithmeticsIntegral, Sub) {
-  this->AssertBinop(arrow::compute::Sub, "[]", "[]", "[]");
-  this->AssertBinop(arrow::compute::Sub, "[null]", "[null]", "[null]");
-  this->AssertBinop(arrow::compute::Sub, "[3, 2, 6]", "[1, 0, 2]", "[2, 2, 4]");
+  this->AssertBinop(arrow::compute::Subtract, "[]", "[]", "[]");
+  this->AssertBinop(arrow::compute::Subtract, "[null]", "[null]", "[null]");
+  this->AssertBinop(arrow::compute::Subtract, "[3, 2, 6]", "[1, 0, 2]", "[2, 2, 4]");
 
-  this->AssertBinop(arrow::compute::Sub, "[1, 2, 3, 4, 5, 6, 7]", "[0, 1, 2, 3, 4, 5, 6]",
-                    "[1, 1, 1, 1, 1, 1, 1]");
+  this->AssertBinop(arrow::compute::Subtract, "[1, 2, 3, 4, 5, 6, 7]",
+                    "[0, 1, 2, 3, 4, 5, 6]", "[1, 1, 1, 1, 1, 1, 1]");
 }
 
 TYPED_TEST(TestBinaryArithmeticsIntegral, Mul) {
-  this->AssertBinop(arrow::compute::Mul, "[]", "[]", "[]");
-  this->AssertBinop(arrow::compute::Mul, "[null]", "[null]", "[null]");
-  this->AssertBinop(arrow::compute::Mul, "[3, 2, 6]", "[1, 0, 2]", "[3, 0, 12]");
+  this->AssertBinop(arrow::compute::Multiply, "[]", "[]", "[]");
+  this->AssertBinop(arrow::compute::Multiply, "[null]", "[null]", "[null]");
+  this->AssertBinop(arrow::compute::Multiply, "[3, 2, 6]", "[1, 0, 2]", "[3, 0, 12]");
 
-  this->AssertBinop(arrow::compute::Mul, "[1, 2, 3, 4, 5, 6, 7]", "[0, 1, 2, 3, 4, 5, 6]",
-                    "[0, 2, 6, 12, 20, 30, 42]");
+  this->AssertBinop(arrow::compute::Multiply, "[1, 2, 3, 4, 5, 6, 7]",
+                    "[0, 1, 2, 3, 4, 5, 6]", "[0, 2, 6, 12, 20, 30, 42]");
 
-  this->AssertBinop(arrow::compute::Mul, "[7, 6, 5, 4, 3, 2, 1]", "[6, 5, 4, 3, 2, 1, 0]",
-                    "[42, 30, 20, 12, 6, 2, 0]");
+  this->AssertBinop(arrow::compute::Multiply, "[7, 6, 5, 4, 3, 2, 1]",
+                    "[6, 5, 4, 3, 2, 1, 0]", "[42, 30, 20, 12, 6, 2, 0]");
 
-  this->AssertBinop(arrow::compute::Mul, "[null, 1, 3, null, 2, 5]", "[1, 4, 2, 5, 0, 3]",
-                    "[null, 4, 6, null, 0, 15]");
+  this->AssertBinop(arrow::compute::Multiply, "[null, 1, 3, null, 2, 5]",
+                    "[1, 4, 2, 5, 0, 3]", "[null, 4, 6, null, 0, 15]");
 }
 
 TYPED_TEST(TestBinaryArithmeticsSigned, Add) {
@@ -179,14 +180,14 @@ TYPED_TEST(TestBinaryArithmeticsUnsigned, OverflowWraps) {
     auto left = this->MakeInputArray({min, max});
     auto right = this->MakeInputArray({1, max});
     auto expected = this->MakeOutputArray({max, min});
-    this->AssertBinop(arrow::compute::Sub, left, right, expected);
+    this->AssertBinop(arrow::compute::Subtract, left, right, expected);
   }
   {
     // Multiplication
     auto left = this->MakeInputArray({min, max, max});
     auto right = this->MakeInputArray({max, 2, max});
     auto expected = this->MakeOutputArray({min, static_cast<InputCType>(max - 1), 1});
-    this->AssertBinop(arrow::compute::Mul, left, right, expected);
+    this->AssertBinop(arrow::compute::Multiply, left, right, expected);
   }
 }
 
@@ -207,33 +208,33 @@ TYPED_TEST(TestBinaryArithmeticsSigned, OverflowWraps) {
     auto left = this->MakeInputArray({min, max});
     auto right = this->MakeInputArray({1, -1});
     auto expected = this->MakeOutputArray({max, min});
-    this->AssertBinop(arrow::compute::Sub, left, right, expected);
+    this->AssertBinop(arrow::compute::Subtract, left, right, expected);
   }
   {
     // Multiplication
     auto left = this->MakeInputArray({min, max});
     auto right = this->MakeInputArray({-1, 2});
     auto expected = this->MakeOutputArray({min, -2});
-    this->AssertBinop(arrow::compute::Mul, left, right, expected);
+    this->AssertBinop(arrow::compute::Multiply, left, right, expected);
   }
 }
 
 TYPED_TEST(TestBinaryArithmeticsSigned, Sub) {
-  this->AssertBinop(arrow::compute::Sub, "[0, 1, 2, 3, 4, 5, 6]", "[1, 2, 3, 4, 5, 6, 7]",
-                    "[-1, -1, -1, -1, -1, -1, -1]");
+  this->AssertBinop(arrow::compute::Subtract, "[0, 1, 2, 3, 4, 5, 6]",
+                    "[1, 2, 3, 4, 5, 6, 7]", "[-1, -1, -1, -1, -1, -1, -1]");
 
-  this->AssertBinop(arrow::compute::Sub, "[0, 0, 0, 0, 0, 0, 0]", "[6, 5, 4, 3, 2, 1, 0]",
-                    "[-6, -5, -4, -3, -2, -1, 0]");
+  this->AssertBinop(arrow::compute::Subtract, "[0, 0, 0, 0, 0, 0, 0]",
+                    "[6, 5, 4, 3, 2, 1, 0]", "[-6, -5, -4, -3, -2, -1, 0]");
 
-  this->AssertBinop(arrow::compute::Sub, "[10, 12, 4, 50, 50, 32, 11]",
+  this->AssertBinop(arrow::compute::Subtract, "[10, 12, 4, 50, 50, 32, 11]",
                     "[2, 0, 6, 1, 5, 3, 4]", "[8, 12, -2, 49, 45, 29, 7]");
 
-  this->AssertBinop(arrow::compute::Sub, "[null, 1, 3, null, 2, 5]", "[1, 4, 2, 5, 0, 3]",
-                    "[null, -3, 1, null, 2, 2]");
+  this->AssertBinop(arrow::compute::Subtract, "[null, 1, 3, null, 2, 5]",
+                    "[1, 4, 2, 5, 0, 3]", "[null, -3, 1, null, 2, 2]");
 }
 
 TYPED_TEST(TestBinaryArithmeticsSigned, Mul) {
-  this->AssertBinop(arrow::compute::Mul, "[-10, 12, 4, 50, -5, 32, 11]",
+  this->AssertBinop(arrow::compute::Multiply, "[-10, 12, 4, 50, -5, 32, 11]",
                     "[-2, 0, -6, 1, 5, 3, 4]", "[20, 0, -24, 50, -25, 96, 44]");
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <algorithm>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -169,9 +170,9 @@ TYPED_TEST(TestBinaryArithmeticsSigned, AddOverflow) {
   auto min = std::numeric_limits<InputCType>::min();
   auto max = std::numeric_limits<InputCType>::max();
 
-  auto left = this->MakeInputArray({max});
-  auto right = this->MakeInputArray({1});
-  auto expected = this->MakeOutputArray({min});
+  auto left = this->MakeInputArray({max, min});
+  auto right = this->MakeInputArray({1, -1});
+  auto expected = this->MakeOutputArray({min, max});
 
   this->AssertBinop(arrow::compute::Add, left, right, expected);
 }
@@ -194,30 +195,6 @@ TYPED_TEST(TestBinaryArithmeticsSigned, Mul) {
   this->AssertBinop(arrow::compute::Mul, "[-10, 12, 4, 50, -5, 32, 11]",
                     "[-2, 0, -6, 1, 5, 3, 4]", "[20, 0, -24, 50, -25, 96, 44]");
 }
-
-// TYPED_TEST(TestBinaryArithmeticsIntegral, AddCheckExtremes) {
-//   using InputCType = typename TestFixture::InputCType;
-//   using OutputCType = typename TestFixture::OutputCType;
-
-//   if (std::is_same<InputCType, OutputCType>::value) {
-//     // this test case is incompatible with Int64 and UInt64 types because there
-//     // are no wider integer types to overflow to
-//     return;
-//   }
-
-//   auto min = std::numeric_limits<InputCType>::min();
-//   auto max = std::numeric_limits<InputCType>::max();
-
-//   auto left = this->MakeInputArray({1, 2, 3, min, max});
-//   auto right = this->MakeInputArray({0, 10, 11, min, max});
-
-//   OutputCType expected_min = 2 * static_cast<OutputCType>(min);
-//   OutputCType expected_max = 2 * static_cast<OutputCType>(max);
-
-//   auto expected = this->MakeOutputArray({1, 12, 14, expected_min, expected_max});
-
-//   this->AssertBinop(arrow::compute::Add, left, right, expected);
-// }
 
 TYPED_TEST(TestBinaryArithmeticsFloating, Add) {
   this->AssertBinop(arrow::compute::Add, "[]", "[]", "[]");

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -88,7 +88,8 @@ template <typename TypePair>
 class TestBinaryArithmeticsSigned : public TestBinaryArithmeticsIntegral<TypePair> {};
 
 // template <typename TypePair>
-// class TestBinaryArithmeticsUnsigned : public TestBinaryArithmeticsIntegral<TypePair> {};
+// class TestBinaryArithmeticsUnsigned : public TestBinaryArithmeticsIntegral<TypePair>
+// {};
 
 template <typename TypePair>
 class TestBinaryArithmeticsFloating : public TestBinaryArithmetics<TypePair> {};
@@ -106,7 +107,8 @@ using SignedIntegerPairs =
 
 // using UnsignedIntegerPairs =
 //     testing::Types<std::pair<UInt8Type, UInt8Type>, std::pair<UInt16Type, UInt16Type>,
-//                    std::pair<UInt32Type, UInt32Type>, std::pair<UInt64Type, UInt64Type>>;
+//                    std::pair<UInt32Type, UInt32Type>, std::pair<UInt64Type,
+//                    UInt64Type>>;
 
 // TODO(kszucs): add half-float
 using FloatingPairs =
@@ -157,8 +159,8 @@ TYPED_TEST(TestBinaryArithmeticsIntegral, Mul) {
 }
 
 TYPED_TEST(TestBinaryArithmeticsSigned, Add) {
-  this->AssertBinop(arrow::compute::Add, "[-7, 6, 5, 4, 3, 2, 1]", "[-6, 5, -4, 3, -2, 1, 0]",
-                    "[-13, 11, 1, 7, 1, 3, 1]");
+  this->AssertBinop(arrow::compute::Add, "[-7, 6, 5, 4, 3, 2, 1]",
+                    "[-6, 5, -4, 3, -2, 1, 0]", "[-13, 11, 1, 7, 1, 3, 1]");
 }
 
 TYPED_TEST(TestBinaryArithmeticsSigned, Sub) {

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -82,6 +82,21 @@ void AssertArraysEqual(const Array& expected, const Array& actual, bool verbose)
   }
 }
 
+void AssertArraysApproxEqual(const Array& expected, const Array& actual, bool verbose) {
+  std::stringstream diff;
+  if (!expected.ApproxEquals(actual, EqualOptions().diff_sink(&diff))) {
+    if (verbose) {
+      ::arrow::PrettyPrintOptions options(/*indent=*/2);
+      options.window = 50;
+      diff << "Expected:\n";
+      ARROW_EXPECT_OK(PrettyPrint(expected, options, &diff));
+      diff << "\nActual:\n";
+      ARROW_EXPECT_OK(PrettyPrint(actual, options, &diff));
+    }
+    FAIL() << diff.str();
+  }
+}
+
 void AssertScalarsEqual(const Scalar& expected, const Scalar& actual, bool verbose) {
   std::stringstream diff;
   // ARROW-8956, ScalarEquals returns false when both are null

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -41,13 +41,6 @@
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
-namespace arrow {
-
-template <typename T>
-class Result;
-
-}  // namespace arrow
-
 // NOTE: failing must be inline in the macros below, to get correct file / line number
 // reporting on test failures.
 
@@ -167,6 +160,8 @@ struct Datum;
 // If verbose is true, then the arrays will be pretty printed
 ARROW_EXPORT void AssertArraysEqual(const Array& expected, const Array& actual,
                                     bool verbose = false);
+ARROW_EXPORT void AssertArraysApproxEqual(const Array& expected, const Array& actual,
+                                          bool verbose = false);
 // Returns true when values are both null
 ARROW_EXPORT void AssertScalarsEqual(const Scalar& expected, const Scalar& actual,
                                      bool verbose = false);


### PR DESCRIPTION
~Currently the output type of the Add function is identical with the argument types which makes it unsafe to add numeric limit values, so instead of using `(int8, int8) -> int8` signature we should use `(int8, int8) -> int16`.~

- avoid undefined behaviour caused by signed integer overflow by casting to unsigned counterparts before operation
- added subtract and multiply kernels (multiply required special handling for uint16 types to avoid casting the operands to signed int32 types)
- test case parametrization supporting different argument and output types (not used for the current tests cases, but will be useful for the upcoming arithmetic kernels)

follow-ups:
- variants that raise on overflow
- AssertArrayAlmostEqual for floating point comparisons