### PR TITLE
ARROW-9024: [C++/Python] Install anaconda-client in conda-clean job

### DIFF
--- a/dev/tasks/conda-recipes/azure.clean.yml
+++ b/dev/tasks/conda-recipes/azure.clean.yml
@@ -13,7 +13,7 @@ jobs:
     displayName: Clone arrow
 
   - script: |
-      conda install -y -c conda-forge pandas
+      conda install -y -c conda-forge pandas anaconda-client
     displayName: Install requirements
 
   - script: |


### PR DESCRIPTION
This wasn't needed for the dry-runs and thus we didn't catch it.