### PR TITLE
ARROW-8230: [Java] Remove netty dependency from arrow-memory

### DIFF
--- a/java/memory/src/main/java/io/netty/buffer/ExpandableByteBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ExpandableByteBuf.java
@@ -41,7 +41,7 @@ public class ExpandableByteBuf extends MutableWrappedByteBuf {
   @Override
   public ByteBuf capacity(int newCapacity) {
     if (newCapacity > capacity()) {
-      ByteBuf newBuf = allocator.buffer(newCapacity).asNettyBuffer();
+      ByteBuf newBuf = NettyArrowBuf.unwrapBuffer(allocator.buffer(newCapacity));
       newBuf.writeBytes(buffer, 0, buffer.capacity());
       newBuf.readerIndex(buffer.readerIndex());
       newBuf.writerIndex(buffer.writerIndex());

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
@@ -210,5 +210,7 @@ public abstract class AllocationManager {
      * @return The created AllocationManager used by this allocator
      */
     AllocationManager create(BaseAllocator accountingAllocator, long size);
+
+    ArrowBuf empty();
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowByteBufAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowByteBufAllocator.java
@@ -21,6 +21,7 @@ import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.ExpandableByteBuf;
+import io.netty.buffer.NettyArrowBuf;
 
 /**
  * An implementation of ByteBufAllocator that wraps a Arrow BufferAllocator. This allows the RPC
@@ -56,7 +57,7 @@ public class ArrowByteBufAllocator extends AbstractByteBufAllocator {
 
   @Override
   public ByteBuf buffer(int initialCapacity) {
-    return new ExpandableByteBuf(allocator.buffer(initialCapacity).asNettyBuffer(), allocator);
+    return new ExpandableByteBuf(NettyArrowBuf.unwrapBuffer(allocator.buffer(initialCapacity)), allocator);
   }
 
   @Override
@@ -86,7 +87,7 @@ public class ArrowByteBufAllocator extends AbstractByteBufAllocator {
 
   @Override
   public ByteBuf directBuffer(int initialCapacity) {
-    return allocator.buffer(initialCapacity).asNettyBuffer();
+    return NettyArrowBuf.unwrapBuffer(allocator.buffer(initialCapacity));
   }
 
   @Override

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -19,8 +19,6 @@ package org.apache.arrow.memory;
 
 import java.util.Collection;
 
-import io.netty.buffer.ByteBufAllocator;
-
 /**
  * Wrapper class to deal with byte buffer allocation. Ensures users only use designated methods.
  */
@@ -50,16 +48,6 @@ public interface BufferAllocator extends AutoCloseable {
    * @throws OutOfMemoryException if buffer cannot be allocated
    */
   ArrowBuf buffer(long size, BufferManager manager);
-
-  /**
-   * Returns the allocator this allocator falls back to when it needs more memory.
-   *
-   * @return the underlying allocator used by this allocator
-   *
-   * @deprecated This method may be removed in a future release.
-   */
-  @Deprecated
-  ByteBufAllocator getAsByteBufAllocator();
 
   /**
    * Create a new child allocator.

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -25,8 +25,6 @@ import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.HistoricalLog;
 import org.apache.arrow.util.Preconditions;
 
-import io.netty.buffer.UnsafeDirectLittleEndian;
-
 /**
  * The reference manager that binds an {@link AllocationManager} to
  * {@link BufferAllocator} and a set of {@link ArrowBuf}. The set of
@@ -516,16 +514,6 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
   }
 
   /**
-   * Returns the underlying {@link UnsafeDirectLittleEndian} instance used by this BufferLedger.
-   *
-   * @deprecated This method may be removed in a future release.
-   */
-  @Deprecated
-  public UnsafeDirectLittleEndian getUnderlying() {
-    return unwrap(UnsafeDirectLittleEndian.class);
-  }
-
-  /**
    * Get the {@link AllocationManager} used by this BufferLedger.
    *
    * @return The AllocationManager used by this BufferLedger.
@@ -534,18 +522,4 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
     return allocationManager;
   }
 
-  /**
-   * Return the {@link AllocationManager} used or underlying {@link UnsafeDirectLittleEndian} instance
-   * (in the case of we use a {@link NettyAllocationManager}), and cast to desired class.
-   *
-   * @param clazz The desired class to cast into
-   * @return The AllocationManager used by this BufferLedger, or the underlying UnsafeDirectLittleEndian object.
-   */
-  public <T> T unwrap(Class<T> clazz) {
-    if (clazz.isInstance(allocationManager)) {
-      return clazz.cast(allocationManager);
-    }
-
-    throw new IllegalArgumentException("Unexpected unwrapping class: " + clazz);
-  }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerFactory.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerFactory.java
@@ -32,4 +32,9 @@ public class DefaultAllocationManagerFactory implements AllocationManager.Factor
   public AllocationManager create(BaseAllocator accountingAllocator, long size) {
     return new NettyAllocationManager(accountingAllocator, size);
   }
+
+  @Override
+  public ArrowBuf empty() {
+    return NettyAllocationManager.EMPTY_BUFFER;
+  }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/NettyAllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/NettyAllocationManager.java
@@ -27,7 +27,18 @@ import io.netty.util.internal.PlatformDependent;
  */
 public class NettyAllocationManager extends AllocationManager {
 
-  public static final AllocationManager.Factory FACTORY = NettyAllocationManager::new;
+  public static final AllocationManager.Factory FACTORY = new AllocationManager.Factory() {
+
+    @Override
+    public AllocationManager create(BaseAllocator accountingAllocator, long size) {
+      return new NettyAllocationManager(accountingAllocator, size);
+    }
+
+    @Override
+    public ArrowBuf empty() {
+      return EMPTY_BUFFER;
+    }
+  };
 
   /**
    * The default cut-off value for switching allocation strategies.
@@ -39,6 +50,10 @@ public class NettyAllocationManager extends AllocationManager {
 
   private static final PooledByteBufAllocatorL INNER_ALLOCATOR = new PooledByteBufAllocatorL();
   static final UnsafeDirectLittleEndian EMPTY = INNER_ALLOCATOR.empty;
+  static final ArrowBuf EMPTY_BUFFER = new ArrowBuf(ReferenceManager.NO_OP,
+      null,
+      0,
+      NettyAllocationManager.EMPTY.memoryAddress());
   static final long CHUNK_SIZE = INNER_ALLOCATOR.getChunkSize();
 
   private final long allocatedSize;

--- a/java/memory/src/main/java/org/apache/arrow/memory/RootAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/RootAllocator.java
@@ -37,7 +37,8 @@ public class RootAllocator extends BaseAllocator {
   }
 
   public RootAllocator(final AllocationListener listener, final long limit) {
-    this(listener, limit, DefaultRoundingPolicy.INSTANCE);
+    //todo fix DefaultRoundingPolicy when using Netty
+    this(listener, limit, DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY);
   }
 
   /**

--- a/java/memory/src/main/java/org/apache/arrow/memory/UnsafeAllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/UnsafeAllocationManager.java
@@ -24,7 +24,23 @@ import org.apache.arrow.memory.util.MemoryUtil;
  */
 public final class UnsafeAllocationManager extends AllocationManager {
 
-  public static final AllocationManager.Factory FACTORY = UnsafeAllocationManager::new;
+  private static final ArrowBuf EMPTY = new ArrowBuf(ReferenceManager.NO_OP,
+      null,
+      0,
+      MemoryUtil.UNSAFE.allocateMemory(0)
+  );
+
+  public static final AllocationManager.Factory FACTORY = new Factory() {
+    @Override
+    public AllocationManager create(BaseAllocator accountingAllocator, long size) {
+      return new UnsafeAllocationManager(accountingAllocator, size);
+    }
+
+    @Override
+    public ArrowBuf empty() {
+      return EMPTY;
+    }
+  };
 
   private final long allocatedSize;
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
@@ -17,10 +17,11 @@
 
 package org.apache.arrow.memory.rounding;
 
-import java.lang.reflect.Field;
-
-import org.apache.arrow.memory.NettyAllocationManager;
 import org.apache.arrow.memory.util.CommonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.util.internal.SystemPropertyUtil;
 
 /**
  * The default rounding policy. That is, if the requested size is within the chunk size,
@@ -28,22 +29,83 @@ import org.apache.arrow.memory.util.CommonUtil;
  * will be identical to the requested size.
  */
 public class DefaultRoundingPolicy implements RoundingPolicy {
-
+  private static final Logger logger = LoggerFactory.getLogger(DefaultRoundingPolicy.class);
   public final long chunkSize;
+
+  /**
+   * The variables here and the static block calculates the DEFAULT_CHUNK_SIZE.
+   *
+   * <p>
+   *   It was copied from {@link io.netty.buffer.PooledByteBufAllocator}.
+   * </p>
+   */
+  private static final int MIN_PAGE_SIZE = 4096;
+  private static final int MAX_CHUNK_SIZE = (int) (((long) Integer.MAX_VALUE + 1) / 2);
+  private static final long DEFAULT_CHUNK_SIZE;
+
+
+  static {
+    int defaultPageSize = SystemPropertyUtil.getInt("org.apache.memory.allocator.pageSize", 8192);
+    Throwable pageSizeFallbackCause = null;
+    try {
+      validateAndCalculatePageShifts(defaultPageSize);
+    } catch (Throwable t) {
+      pageSizeFallbackCause = t;
+      defaultPageSize = 8192;
+    }
+
+    int defaultMaxOrder = SystemPropertyUtil.getInt("org.apache.memory.allocator.maxOrder", 11);
+    Throwable maxOrderFallbackCause = null;
+    try {
+      validateAndCalculateChunkSize(defaultPageSize, defaultMaxOrder);
+    } catch (Throwable t) {
+      maxOrderFallbackCause = t;
+      defaultMaxOrder = 11;
+    }
+    DEFAULT_CHUNK_SIZE = validateAndCalculateChunkSize(defaultPageSize, defaultMaxOrder);
+    if (logger.isDebugEnabled()) {
+      logger.debug("-Dorg.apache.memory.allocator.pageSize: {}", defaultPageSize);
+      logger.debug("-Dorg.apache.memory.allocator.maxOrder: {}", defaultMaxOrder);
+    }
+  }
+
+  private static int validateAndCalculatePageShifts(int pageSize) {
+    if (pageSize < MIN_PAGE_SIZE) {
+      throw new IllegalArgumentException("pageSize: " + pageSize + " (expected: " + MIN_PAGE_SIZE + ")");
+    }
+
+    if ((pageSize & pageSize - 1) != 0) {
+      throw new IllegalArgumentException("pageSize: " + pageSize + " (expected: power of 2)");
+    }
+
+    // Logarithm base 2. At this point we know that pageSize is a power of two.
+    return Integer.SIZE - 1 - Integer.numberOfLeadingZeros(pageSize);
+  }
+
+  private static int validateAndCalculateChunkSize(int pageSize, int maxOrder) {
+    if (maxOrder > 14) {
+      throw new IllegalArgumentException("maxOrder: " + maxOrder + " (expected: 0-14)");
+    }
+
+    // Ensure the resulting chunkSize does not overflow.
+    int chunkSize = pageSize;
+    for (int i = maxOrder; i > 0; i --) {
+      if (chunkSize > MAX_CHUNK_SIZE / 2) {
+        throw new IllegalArgumentException(String.format(
+            "pageSize (%d) << maxOrder (%d) must not exceed %d", pageSize, maxOrder, MAX_CHUNK_SIZE));
+      }
+      chunkSize <<= 1;
+    }
+    return chunkSize;
+  }
 
   /**
    * The singleton instance.
    */
-  public static final DefaultRoundingPolicy INSTANCE = new DefaultRoundingPolicy();
+  public static final DefaultRoundingPolicy DEFAULT_ROUNDING_POLICY = new DefaultRoundingPolicy(DEFAULT_CHUNK_SIZE);
 
-  private DefaultRoundingPolicy() {
-    try {
-      Field field = NettyAllocationManager.class.getDeclaredField("CHUNK_SIZE");
-      field.setAccessible(true);
-      chunkSize = (Long) field.get(null);
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to get chunk size from allocation manager");
-    }
+  private DefaultRoundingPolicy(long chunkSize) {
+    this.chunkSize = chunkSize;
   }
 
   @Override

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -33,7 +33,7 @@ public class TestNettyArrowBuf {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
     ) {
-      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       nettyBuf.writerIndex(20);
       nettyBuf.readerIndex(10);
       NettyArrowBuf slicedBuffer = nettyBuf.slice();
@@ -47,7 +47,7 @@ public class TestNettyArrowBuf {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
     ) {
-      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       ByteBuffer byteBuffer = nettyBuf.nioBuffer(4, 6);
       // Nio Buffers should always be 0 indexed
       Assert.assertEquals(0, byteBuffer.position());
@@ -63,7 +63,7 @@ public class TestNettyArrowBuf {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
     ) {
-      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       ByteBuffer byteBuffer = nettyBuf.internalNioBuffer(4, 6);
       Assert.assertEquals(0, byteBuffer.position());
       Assert.assertEquals(6, byteBuffer.limit());
@@ -78,7 +78,7 @@ public class TestNettyArrowBuf {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
     ) {
-      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       int [] intVals = new int[] {Integer.MIN_VALUE, Short.MIN_VALUE - 1, Short.MIN_VALUE, 0 ,
         Short.MAX_VALUE , Short.MAX_VALUE + 1, Integer.MAX_VALUE};
       for (int intValue :intVals ) {
@@ -104,7 +104,7 @@ public class TestNettyArrowBuf {
   public void testSetCompositeBuffer() {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
-         NettyArrowBuf buf2 = allocator.buffer(20).asNettyBuffer();
+         NettyArrowBuf buf2 = NettyArrowBuf.unwrapBuffer(allocator.buffer(20));
     ) {
       CompositeByteBuf byteBufs = new CompositeByteBuf(new ArrowByteBufAllocator(allocator),
               true, 1);
@@ -112,7 +112,7 @@ public class TestNettyArrowBuf {
       buf2.setInt(0, expected);
       buf2.writerIndex(4);
       byteBufs.addComponent(true, buf2);
-      buf.asNettyBuffer().setBytes(0, byteBufs, 4);
+      NettyArrowBuf.unwrapBuffer(buf).setBytes(0, byteBufs, 4);
       int actual = buf.getInt(0);
       Assert.assertEquals(expected, actual);
     }
@@ -127,12 +127,12 @@ public class TestNettyArrowBuf {
               true, 1);
       int expected = 4;
       buf.setInt(0, expected);
-      NettyArrowBuf buf2 = allocator.buffer(20).asNettyBuffer();
+      NettyArrowBuf buf2 = NettyArrowBuf.unwrapBuffer(allocator.buffer(20));
       // composite buffers are a bit weird, need to jump hoops
       // to set capacity.
       byteBufs.addComponent(true, buf2);
       byteBufs.capacity(20);
-      buf.asNettyBuffer().getBytes(0, byteBufs, 4);
+      NettyArrowBuf.unwrapBuffer(buf).getBytes(0, byteBufs, 4);
       int actual = byteBufs.getInt(0);
       Assert.assertEquals(expected, actual);
       byteBufs.component(0).release();

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
@@ -27,8 +27,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import io.netty.buffer.PooledByteBufAllocatorL;
-
 public class TestArrowBuf {
 
   private static final int MAX_ALLOCATION = 8 * 1024;
@@ -124,42 +122,6 @@ public class TestArrowBuf {
       buf.getBytes(0, actual);
       assertArrayEquals(expected, actual);
     }
-  }
-
-  @Test
-  public void testEmptyArrowBuf() {
-    ArrowBuf buf = new ArrowBuf(ReferenceManager.NO_OP, null,
-        1024, new PooledByteBufAllocatorL().empty.memoryAddress());
-
-    buf.getReferenceManager().retain();
-    buf.getReferenceManager().retain(8);
-    assertEquals(1024, buf.capacity());
-    assertEquals(1, buf.getReferenceManager().getRefCount());
-    assertEquals(0, buf.getActualMemoryConsumed());
-
-    for (int i = 0; i < 10; i++) {
-      buf.setByte(i, i);
-    }
-    assertEquals(0, buf.getActualMemoryConsumed());
-    assertEquals(0, buf.getReferenceManager().getSize());
-    assertEquals(0, buf.getReferenceManager().getAccountedSize());
-    assertEquals(false, buf.getReferenceManager().release());
-    assertEquals(false, buf.getReferenceManager().release(2));
-    assertEquals(0, buf.getReferenceManager().getAllocator().getLimit());
-    assertEquals(buf, buf.getReferenceManager().transferOwnership(buf, allocator).getTransferredBuffer());
-    assertEquals(0, buf.readerIndex());
-    assertEquals(0, buf.writerIndex());
-    assertEquals(1, buf.refCnt());
-
-    ArrowBuf derive = buf.getReferenceManager().deriveBuffer(buf, 0, 100);
-    assertEquals(derive, buf);
-    assertEquals(1, buf.refCnt());
-    assertEquals(1, derive.refCnt());
-
-    buf.close();
-
-    ArrowBuf buf2 = ArrowBuf.empty(10);
-    assertEquals(10, buf2.capacity());
   }
 
 }

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestEmptyArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestEmptyArrowBuf.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.netty.buffer.PooledByteBufAllocatorL;
+
+public class TestEmptyArrowBuf {
+
+  private static final int MAX_ALLOCATION = 8 * 1024;
+  private static RootAllocator allocator;
+
+  @BeforeClass
+  public static void beforeClass() {
+    allocator = new RootAllocator(MAX_ALLOCATION);
+  }
+  
+  /** Ensure the allocator is closed. */
+  @AfterClass
+  public static void afterClass() {
+    if (allocator != null) {
+      allocator.close();
+    }
+  }
+
+  @Test
+  public void testEmptyArrowBuf() {
+    ArrowBuf buf = new ArrowBuf(ReferenceManager.NO_OP, null,
+        1024, new PooledByteBufAllocatorL().empty.memoryAddress());
+
+    buf.getReferenceManager().retain();
+    buf.getReferenceManager().retain(8);
+    assertEquals(1024, buf.capacity());
+    assertEquals(1, buf.getReferenceManager().getRefCount());
+    assertEquals(0, buf.getActualMemoryConsumed());
+
+    for (int i = 0; i < 10; i++) {
+      buf.setByte(i, i);
+    }
+    assertEquals(0, buf.getActualMemoryConsumed());
+    assertEquals(0, buf.getReferenceManager().getSize());
+    assertEquals(0, buf.getReferenceManager().getAccountedSize());
+    assertEquals(false, buf.getReferenceManager().release());
+    assertEquals(false, buf.getReferenceManager().release(2));
+    assertEquals(0, buf.getReferenceManager().getAllocator().getLimit());
+    assertEquals(buf, buf.getReferenceManager().transferOwnership(buf, allocator).getTransferredBuffer());
+    assertEquals(0, buf.readerIndex());
+    assertEquals(0, buf.writerIndex());
+    assertEquals(1, buf.refCnt());
+
+    ArrowBuf derive = buf.getReferenceManager().deriveBuffer(buf, 0, 100);
+    assertEquals(derive, buf);
+    assertEquals(1, buf.refCnt());
+    assertEquals(1, derive.refCnt());
+
+    buf.close();
+
+  }
+
+}

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestEndianness.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestEndianness.java
@@ -22,13 +22,14 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.NettyArrowBuf;
 
 public class TestEndianness {
 
   @Test
   public void testLittleEndian() {
     final BufferAllocator a = new RootAllocator(10000);
-    final ByteBuf b = a.buffer(4).asNettyBuffer();
+    final ByteBuf b = NettyArrowBuf.unwrapBuffer(a.buffer(4));
     b.setInt(0, 35);
     assertEquals(b.getByte(0), 35);
     assertEquals(b.getByte(1), 0);

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestNettyAllocationManager.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestNettyAllocationManager.java
@@ -33,9 +33,17 @@ public class TestNettyAllocationManager {
 
   private BaseAllocator createCustomizedAllocator() {
     return new RootAllocator(BaseAllocator.configBuilder()
-        .allocationManagerFactory((accountingAllocator, requestedSize) ->
-            new NettyAllocationManager(
-                accountingAllocator, requestedSize, CUSTOMIZED_ALLOCATION_CUTOFF_VALUE)).build());
+        .allocationManagerFactory(new AllocationManager.Factory() {
+          @Override
+          public AllocationManager create(BaseAllocator accountingAllocator, long size) {
+            return new NettyAllocationManager(accountingAllocator, size, CUSTOMIZED_ALLOCATION_CUTOFF_VALUE);
+          }
+
+          @Override
+          public ArrowBuf empty() {
+            return null;
+          }
+        }).build());
   }
 
   private void readWriteArrowBuf(ArrowBuf buffer) {

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestUnsafeAllocationManager.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestUnsafeAllocationManager.java
@@ -28,10 +28,8 @@ import org.junit.Test;
 public class TestUnsafeAllocationManager {
 
   private BaseAllocator createUnsafeAllocator() {
-    return new RootAllocator(BaseAllocator.configBuilder()
-        .allocationManagerFactory((accountingAllocator, requestedSize) ->
-            new UnsafeAllocationManager(
-                accountingAllocator, requestedSize)).build());
+    return new RootAllocator(BaseAllocator.configBuilder().allocationManagerFactory(UnsafeAllocationManager.FACTORY)
+        .build());
   }
 
   private void readWriteArrowBuf(ArrowBuf buffer) {


### PR DESCRIPTION
This commit moves all Netty specific calls into a few classes.
This is the precursor to splitting the netty and unsafe allocatorsout to their own modules

