### PR TITLE
ARROW-9037: [C++] C-ABI: do not error out when importing array with null_count == -1

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -503,6 +503,8 @@ void ReleaseExportedArray(struct ArrowArray* array) {
 
 struct ArrayExporter {
   Status Export(const std::shared_ptr<ArrayData>& data) {
+    // Force computing null count.
+    data->GetNullCount();
     // Store buffer pointers
     export_.buffers_.resize(data->buffers.size());
     std::transform(data->buffers.begin(), data->buffers.end(), export_.buffers_.begin(),
@@ -1397,7 +1399,7 @@ struct ArrayImporter {
 
   Status ImportNullBitmap(int32_t buffer_id = 0) {
     RETURN_NOT_OK(ImportBitsBuffer(buffer_id));
-    if (data_->null_count != 0 && data_->buffers[buffer_id] == nullptr) {
+    if (data_->null_count > 0 && data_->buffers[buffer_id] == nullptr) {
       return Status::Invalid(
           "ArrowArray struct has null bitmap buffer but non-zero null_count ",
           data_->null_count);

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -2467,6 +2467,18 @@ TEST_F(TestArrayRoundtrip, Primitive) {
   TestWithJSONSliced(int32(), "[4, 5, 6, null]");
 }
 
+TEST_F(TestArrayRoundtrip, UnknownNullCount) {
+    TestWithArrayFactory([](std::shared_ptr<Array>* arr) -> Status {
+    *arr = ArrayFromJSON(int32(), "[0, 1, 2]");
+    if ((*arr)->null_bitmap()) {
+      return Status::Invalid("Failed precondition: "
+                             "the array shouldn't have a null bitmap.");
+    }
+    (*arr)->data()->SetNullCount(kUnknownNullCount);
+    return Status::OK();
+    });
+}
+
 TEST_F(TestArrayRoundtrip, Nested) {
   TestWithJSON(list(int32()), "[]");
   TestWithJSON(list(int32()), "[[4, 5], [6, null], null]");


### PR DESCRIPTION
Also when exporting an array, force compute the null count. This way future version will be able to import an array exported by 0.17, and vice versa.
