### PR TITLE
ARROW-8723: [Rust] Remove SIMD specific benchmark code

### DIFF
--- a/rust/arrow/benches/comparison_kernels.rs
+++ b/rust/arrow/benches/comparison_kernels.rs
@@ -37,228 +37,84 @@ fn create_array(size: usize) -> Float32Array {
     builder.finish()
 }
 
-pub fn eq_no_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op(
-        criterion::black_box(arr_a),
-        criterion::black_box(arr_b),
-        |a, b| a == b,
-    )
-    .unwrap();
-}
-
-pub fn eq_no_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op_scalar(
-        criterion::black_box(arr_a),
-        criterion::black_box(value_b),
-        |a, b| a == b,
-    )
-    .unwrap();
-}
-
-pub fn neq_no_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op(
-        criterion::black_box(arr_a),
-        criterion::black_box(arr_b),
-        |a, b| a != b,
-    )
-    .unwrap();
-}
-
-pub fn neq_no_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op_scalar(
-        criterion::black_box(arr_a),
-        criterion::black_box(value_b),
-        |a, b| a != b,
-    )
-    .unwrap();
-}
-
-pub fn lt_no_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op(
-        criterion::black_box(arr_a),
-        criterion::black_box(arr_b),
-        |a, b| a < b,
-    )
-    .unwrap();
-}
-
-pub fn lt_no_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op_scalar(
-        criterion::black_box(arr_a),
-        criterion::black_box(value_b),
-        |a, b| a < b,
-    )
-    .unwrap();
-}
-
-fn lt_eq_no_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op(
-        criterion::black_box(arr_a),
-        criterion::black_box(arr_b),
-        |a, b| a <= b,
-    )
-    .unwrap();
-}
-
-fn lt_eq_no_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op_scalar(
-        criterion::black_box(arr_a),
-        criterion::black_box(value_b),
-        |a, b| a <= b,
-    )
-    .unwrap();
-}
-
-pub fn gt_no_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op(
-        criterion::black_box(arr_a),
-        criterion::black_box(arr_b),
-        |a, b| a > b,
-    )
-    .unwrap();
-}
-
-pub fn gt_no_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op_scalar(
-        criterion::black_box(arr_a),
-        criterion::black_box(value_b),
-        |a, b| a > b,
-    )
-    .unwrap();
-}
-
-fn gt_eq_no_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op(
-        criterion::black_box(arr_a),
-        criterion::black_box(arr_b),
-        |a, b| a >= b,
-    )
-    .unwrap();
-}
-
-fn gt_eq_no_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
-where
-    T: ArrowNumericType,
-{
-    no_simd_compare_op_scalar(
-        criterion::black_box(arr_a),
-        criterion::black_box(value_b),
-        |a, b| a >= b,
-    )
-    .unwrap();
-}
-
-fn eq_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
+fn bench_eq<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
 where
     T: ArrowNumericType,
 {
     eq(criterion::black_box(arr_a), criterion::black_box(arr_b)).unwrap();
 }
 
-fn eq_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
+fn bench_eq_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
 where
     T: ArrowNumericType,
 {
     eq_scalar(criterion::black_box(arr_a), criterion::black_box(value_b)).unwrap();
 }
 
-fn neq_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
+fn bench_neq<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
 where
     T: ArrowNumericType,
 {
     neq(criterion::black_box(arr_a), criterion::black_box(arr_b)).unwrap();
 }
 
-fn neq_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
+fn bench_neq_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
 where
     T: ArrowNumericType,
 {
     neq_scalar(criterion::black_box(arr_a), criterion::black_box(value_b)).unwrap();
 }
 
-fn lt_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
+fn bench_lt<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
 where
     T: ArrowNumericType,
 {
     lt(criterion::black_box(arr_a), criterion::black_box(arr_b)).unwrap();
 }
 
-fn lt_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
+fn bench_lt_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
 where
     T: ArrowNumericType,
 {
     lt_scalar(criterion::black_box(arr_a), criterion::black_box(value_b)).unwrap();
 }
 
-fn lt_eq_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
+fn bench_lt_eq<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
 where
     T: ArrowNumericType,
 {
     lt_eq(criterion::black_box(arr_a), criterion::black_box(arr_b)).unwrap();
 }
 
-fn lt_eq_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
+fn bench_lt_eq_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
 where
     T: ArrowNumericType,
 {
     lt_eq_scalar(criterion::black_box(arr_a), criterion::black_box(value_b)).unwrap();
 }
 
-fn gt_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
+fn bench_gt<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
 where
     T: ArrowNumericType,
 {
     gt(criterion::black_box(arr_a), criterion::black_box(arr_b)).unwrap();
 }
 
-fn gt_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
+fn bench_gt_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
 where
     T: ArrowNumericType,
 {
     gt_scalar(criterion::black_box(arr_a), criterion::black_box(value_b)).unwrap();
 }
 
-fn gt_eq_simd<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
+fn bench_gt_eq<T>(arr_a: &PrimitiveArray<T>, arr_b: &PrimitiveArray<T>)
 where
     T: ArrowNumericType,
 {
     gt_eq(criterion::black_box(arr_a), criterion::black_box(arr_b)).unwrap();
 }
 
-fn gt_eq_simd_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
+fn bench_gt_eq_scalar<T>(arr_a: &PrimitiveArray<T>, value_b: T::Native)
 where
     T: ArrowNumericType,
 {
@@ -270,66 +126,34 @@ fn add_benchmark(c: &mut Criterion) {
     let arr_a = create_array(size);
     let arr_b = create_array(size);
 
-    c.bench_function("eq Float32", |b| b.iter(|| eq_no_simd(&arr_a, &arr_b)));
+    c.bench_function("eq Float32", |b| b.iter(|| bench_eq(&arr_a, &arr_b)));
     c.bench_function("eq scalar Float32", |b| {
-        b.iter(|| eq_no_simd_scalar(&arr_a, 1.0))
-    });
-    c.bench_function("eq Float32 simd", |b| b.iter(|| eq_simd(&arr_a, &arr_b)));
-    c.bench_function("eq scalar Float32 simd", |b| {
-        b.iter(|| eq_simd_scalar(&arr_a, 1.0))
+        b.iter(|| bench_eq_scalar(&arr_a, 1.0))
     });
 
-    c.bench_function("neq Float32", |b| b.iter(|| neq_no_simd(&arr_a, &arr_b)));
+    c.bench_function("neq Float32", |b| b.iter(|| bench_neq(&arr_a, &arr_b)));
     c.bench_function("neq scalar Float32", |b| {
-        b.iter(|| neq_no_simd_scalar(&arr_a, 1.0))
-    });
-    c.bench_function("neq Float32 simd", |b| b.iter(|| neq_simd(&arr_a, &arr_b)));
-    c.bench_function("neq scalar Float32 simd", |b| {
-        b.iter(|| neq_simd_scalar(&arr_a, 1.0))
+        b.iter(|| bench_neq_scalar(&arr_a, 1.0))
     });
 
-    c.bench_function("lt Float32", |b| b.iter(|| lt_no_simd(&arr_a, &arr_b)));
+    c.bench_function("lt Float32", |b| b.iter(|| bench_lt(&arr_a, &arr_b)));
     c.bench_function("lt scalar Float32", |b| {
-        b.iter(|| lt_no_simd_scalar(&arr_a, 1.0))
-    });
-    c.bench_function("lt Float32 simd", |b| b.iter(|| lt_simd(&arr_a, &arr_b)));
-    c.bench_function("lt scalar Float32 simd", |b| {
-        b.iter(|| lt_simd_scalar(&arr_a, 1.0))
+        b.iter(|| bench_lt_scalar(&arr_a, 1.0))
     });
 
-    c.bench_function("lt_eq Float32", |b| {
-        b.iter(|| lt_eq_no_simd(&arr_a, &arr_b))
-    });
+    c.bench_function("lt_eq Float32", |b| b.iter(|| bench_lt_eq(&arr_a, &arr_b)));
     c.bench_function("lt_eq scalar Float32", |b| {
-        b.iter(|| lt_eq_no_simd_scalar(&arr_a, 1.0))
-    });
-    c.bench_function("lt_eq Float32 simd", |b| {
-        b.iter(|| lt_eq_simd(&arr_a, &arr_b))
-    });
-    c.bench_function("lt_eq scalar Float32 simd", |b| {
-        b.iter(|| lt_eq_simd_scalar(&arr_a, 1.0))
+        b.iter(|| bench_lt_eq_scalar(&arr_a, 1.0))
     });
 
-    c.bench_function("gt Float32", |b| b.iter(|| gt_no_simd(&arr_a, &arr_b)));
+    c.bench_function("gt Float32", |b| b.iter(|| bench_gt(&arr_a, &arr_b)));
     c.bench_function("gt scalar Float32", |b| {
-        b.iter(|| gt_no_simd_scalar(&arr_a, 1.0))
-    });
-    c.bench_function("gt Float32 simd", |b| b.iter(|| gt_simd(&arr_a, &arr_b)));
-    c.bench_function("gt scalar Float32 simd", |b| {
-        b.iter(|| gt_simd_scalar(&arr_a, 1.0))
+        b.iter(|| bench_gt_scalar(&arr_a, 1.0))
     });
 
-    c.bench_function("gt_eq Float32", |b| {
-        b.iter(|| gt_eq_no_simd(&arr_a, &arr_b))
-    });
+    c.bench_function("gt_eq Float32", |b| b.iter(|| bench_gt_eq(&arr_a, &arr_b)));
     c.bench_function("gt_eq scalar Float32", |b| {
-        b.iter(|| gt_eq_no_simd_scalar(&arr_a, 1.0))
-    });
-    c.bench_function("gt_eq Float32 simd", |b| {
-        b.iter(|| gt_eq_simd(&arr_a, &arr_b))
-    });
-    c.bench_function("gt_eq scalar Float32 simd", |b| {
-        b.iter(|| gt_eq_simd_scalar(&arr_a, 1.0))
+        b.iter(|| bench_gt_eq_scalar(&arr_a, 1.0))
     });
 }
 


### PR DESCRIPTION
The benchmarks take long enough as it is and (explicit) SIMD can now be turned on and off via a feature flag which was not the case when these benchmarks were added.