### PR TITLE
ARROW-9047: [Rust] Fix a segfault when setting zero bits in a zero-length bitset.

### DIFF
--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -349,7 +349,7 @@ impl BufferBuilderTrait<BooleanType> for BufferBuilder<BooleanType> {
 
     fn append_n(&mut self, n: usize, v: bool) -> Result<()> {
         self.reserve(n)?;
-        if v {
+        if n != 0 && v {
             unsafe {
                 bit_util::set_bits_raw(self.buffer.raw_data_mut(), self.len, self.len + n)
             }


### PR DESCRIPTION
If the mutable bitset is allocated with zero elements it'll have an
address that, when accessed, segfaults. Even if the number of bits (n)
set is zero, it still reads from this invalid address and things crash.