### PR TITLE
ARROW-9007: [Rust] Support appending array data to builders

### DIFF
--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -118,7 +118,7 @@ impl ArrayData {
     /// Returns whether the element at index `i` is null
     pub fn is_null(&self, i: usize) -> bool {
         if let Some(ref b) = self.null_bitmap {
-            return !b.is_set(self.offset() + i);
+            return !b.is_set(i);
         }
         false
     }
@@ -136,7 +136,7 @@ impl ArrayData {
     /// Returns whether the element at index `i` is not null
     pub fn is_valid(&self, i: usize) -> bool {
         if let Some(ref b) = self.null_bitmap {
-            return b.is_set(self.offset() + i);
+            return b.is_set(i);
         }
         true
     }

--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -118,7 +118,7 @@ impl ArrayData {
     /// Returns whether the element at index `i` is null
     pub fn is_null(&self, i: usize) -> bool {
         if let Some(ref b) = self.null_bitmap {
-            return !b.is_set(i);
+            return !b.is_set(self.offset() + i);
         }
         false
     }
@@ -136,7 +136,7 @@ impl ArrayData {
     /// Returns whether the element at index `i` is not null
     pub fn is_valid(&self, i: usize) -> bool {
         if let Some(ref b) = self.null_bitmap {
-            return b.is_set(i);
+            return b.is_set(self.offset() + i);
         }
         true
     }


### PR DESCRIPTION
This enables appending `ArrayDataRef` to builders, which makes it easier to concatenate arrays.

All array types are supported except for dictionaries and unions. 🎊️
Dictionaries require some extra logic, so I left them out.
Unions could use similar logic to structs, but because their implementation is still incomplete (e.g. equality checks), I've also left them out of this PR.