### PR TITLE
ARROW-9057: [Rust][Datafusion] Fix projection on in memory scan

### DIFF
--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -84,9 +84,11 @@ impl RecordBatch {
         }
         // check that number of fields in schema match column length
         if schema.fields().len() != columns.len() {
-            return Err(ArrowError::InvalidArgumentError(
-                "number of columns must match number of fields in schema".to_string(),
-            ));
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "number of columns({}) must match number of fields({}) in schema",
+                columns.len(),
+                schema.fields().len(),
+            )));
         }
         // check that all columns have the same row count, and match the schema
         let len = columns[0].data().len();

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -208,7 +208,8 @@ impl ProjectionPushDown {
             )),
             Expr::Column(i) => Ok(Expr::Column(self.new_index(mapping, i)?)),
             Expr::UnresolvedColumn(_) => Err(ExecutionError::ExecutionError(
-                "Columns need to be resolved before this rule can run".to_owned(),
+                "Columns need to be resolved before projection push down rule can run"
+                    .to_owned(),
             )),
             Expr::Literal(_) => Ok(expr.clone()),
             Expr::Not(e) => Ok(Expr::Not(Box::new(self.rewrite_expr(e, mapping)?))),

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -46,7 +46,8 @@ pub fn expr_to_column_indices(expr: &Expr, accum: &mut HashSet<usize>) -> Result
             Ok(())
         }
         Expr::UnresolvedColumn(_) => Err(ExecutionError::ExecutionError(
-            "Columns need to be resolved before this rule can run".to_owned(),
+            "Columns need to be resolved before column indexes resolution rule can run"
+                .to_owned(),
         )),
         Expr::Literal(_) => {
             // not needed


### PR DESCRIPTION
This fixes the `ArrowError::InvalidArgumentError` returned by `RecordBatch::try_new` when projection is applied to in memory scan.