### PR TITLE
ARROW-9059: [Rust] Fix sign in array slice_data_docstring

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -312,7 +312,7 @@ pub fn make_array(data: ArrayDataRef) -> ArrayRef {
 ///
 /// # Panics
 ///
-/// Panics if `offset + length < data.len()`.
+/// Panics if `offset + length > data.len()`.
 fn slice_data(data: ArrayDataRef, mut offset: usize, length: usize) -> ArrayDataRef {
     assert!((offset + length) <= data.len());
 


### PR DESCRIPTION
Change the panic behavior in the docstring to reflect the panic behavior in the code