### PR TITLE
ARROW-8974: [C++] Simplify TransferBitmap

### DIFF
--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -79,7 +79,7 @@ static Status ConcatenateBitmaps(const std::vector<Bitmap>& bitmaps, MemoryPool*
       BitUtil::SetBitsTo(dst, bitmap_offset, bitmap.range.length, true);
     } else {
       internal::CopyBitmap(bitmap.data, bitmap.range.offset, bitmap.range.length, dst,
-                           bitmap_offset, false);
+                           bitmap_offset);
     }
     bitmap_offset += bitmap.range.length;
   }

--- a/cpp/src/arrow/util/bit_util_benchmark.cc
+++ b/cpp/src/arrow/util/bit_util_benchmark.cc
@@ -355,7 +355,7 @@ static void CopyBitmap(benchmark::State& state) {  // NOLINT non-const reference
   auto copy = *AllocateEmptyBitmap(length);
 
   for (auto _ : state) {
-    internal::CopyBitmap(src, OffsetSrc, length, copy->mutable_data(), OffsetDest, false);
+    internal::CopyBitmap(src, OffsetSrc, length, copy->mutable_data(), OffsetDest);
   }
 
   state.SetBytesProcessed(state.iterations() * buffer_size);
@@ -386,7 +386,7 @@ static void BitmapEquals(benchmark::State& state) {
   const int64_t length = bits_size - offset;
 
   auto copy = *AllocateEmptyBitmap(length + offset);
-  internal::CopyBitmap(src, 0, length, copy->mutable_data(), offset, false);
+  internal::CopyBitmap(src, 0, length, copy->mutable_data(), offset);
 
   for (auto _ : state) {
     auto is_same = internal::BitmapEquals(src, 0, copy->data(), offset, length);

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1073,7 +1073,7 @@ TEST(BitUtilTests, TestBitmapEquals) {
       for (int64_t offset_dst : offsets) {
         const auto bit_length = num_bits - offset_src;
 
-        internal::CopyBitmap(src, offset_src, bit_length, dst, offset_dst, false);
+        internal::CopyBitmap(src, offset_src, bit_length, dst, offset_dst);
         ASSERT_TRUE(internal::BitmapEquals(src, offset_src, dst, offset_dst, bit_length));
 
         // test negative cases by flip some bit at head and tail

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -317,7 +317,7 @@ void TransferBitmap(const uint8_t* data, int64_t offset, int64_t length,
     // - low  3 bits: new bits from last byte of data buffer
     // - high 5 bits: old bits from last byte of dest buffer
     int64_t trailing_bits = num_bytes * 8 - length;
-    uint8_t trail_mask = (1U << (8 - trailing_bits)) - 1;
+    uint8_t kTrailingBitmask = (1U << (8 - trailing_bits)) - 1;
     uint8_t last_data;
 
     if (mode == TransferMode::Invert) {
@@ -331,8 +331,8 @@ void TransferBitmap(const uint8_t* data, int64_t offset, int64_t length,
     }
 
     // Set last byte
-    dest[num_bytes - 1] &= ~trail_mask;
-    dest[num_bytes - 1] |= last_data & trail_mask;
+    dest[num_bytes - 1] &= ~kTrailingBitmask;
+    dest[num_bytes - 1] |= last_data & kTrailingBitmask;
   }
 }
 

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -317,7 +317,7 @@ void TransferBitmap(const uint8_t* data, int64_t offset, int64_t length,
     // - low  3 bits: new bits from last byte of data buffer
     // - high 5 bits: old bits from last byte of dest buffer
     int64_t trailing_bits = num_bytes * 8 - length;
-    uint8_t kTrailingBitmask = (1U << (8 - trailing_bits)) - 1;
+    uint8_t trail_mask = (1U << (8 - trailing_bits)) - 1;
     uint8_t last_data;
 
     if (mode == TransferMode::Invert) {
@@ -331,8 +331,8 @@ void TransferBitmap(const uint8_t* data, int64_t offset, int64_t length,
     }
 
     // Set last byte
-    dest[num_bytes - 1] &= ~kTrailingBitmask;
-    dest[num_bytes - 1] |= last_data & kTrailingBitmask;
+    dest[num_bytes - 1] &= ~trail_mask;
+    dest[num_bytes - 1] |= last_data & trail_mask;
   }
 }
 

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -48,12 +48,11 @@ Result<std::shared_ptr<Buffer>> CopyBitmap(MemoryPool* pool, const uint8_t* bitm
 /// \param[in] offset bit offset into the source data
 /// \param[in] length number of bits to copy
 /// \param[in] dest_offset bit offset into the destination
-/// \param[in] restore_trailing_bits don't clobber bits outside the destination range
 /// \param[out] dest the destination buffer, must have at least space for
 /// (offset + length) bits
 ARROW_EXPORT
 void CopyBitmap(const uint8_t* bitmap, int64_t offset, int64_t length, uint8_t* dest,
-                int64_t dest_offset, bool restore_trailing_bits = true);
+                int64_t dest_offset);
 
 /// Invert a bit range of an existing bitmap into an existing bitmap
 ///


### PR DESCRIPTION
This patch removes "restore_trailing_bits" template parameter of
TransferBitmap class. Trailing bits are now always not clobbered,
which is no harm. It also refines trailing bits processing to keep
the performance influence trivial. Besides, this patch replaces
"invert_bits" boolean parameter with enum to allow explicit naming.