### PR TITLE
ARROW-9064: [APT] Use --no-install-recommends

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -127,9 +127,9 @@ jobs:
           pip install cython setuptools pytest jira
           wget -q https://packages.microsoft.com/config/ubuntu/16.04/packages-microsoft-prod.deb
           sudo dpkg -i packages-microsoft-prod.deb
-          sudo apt-get install apt-transport-https
+          sudo apt-get install -y -q --no-install-recommends apt-transport-https
           sudo apt-get update
-          sudo apt-get install dotnet-sdk-2.2
+          sudo apt-get install -y -q --no-install-recommends dotnet-sdk-2.2
       - name: Run Release Test
         shell: bash
         run: |

--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -129,7 +129,7 @@ to build Arrow GLib. You can install them by the followings:
 On Debian GNU/Linux or Ubuntu:
 
 ```console
-% sudo apt install -y -V gtk-doc-tools autoconf-archive libgirepository1.0-dev meson ninja-build
+% sudo apt-get install -y -q --no-install-recommends gtk-doc-tools autoconf-archive libgirepository1.0-dev meson ninja-build
 ```
 
 On CentOS 7 or later:
@@ -225,7 +225,7 @@ You can install them by the followings:
 On Debian GNU/Linux or Ubuntu:
 
 ```console
-% sudo apt install -y -V ruby-dev
+% sudo apt-get install -y -q --no-install-recommends ruby-dev
 % sudo gem install bundler
 % (cd c_glib && bundle install)
 ```

--- a/c_glib/example/lua/README.md
+++ b/c_glib/example/lua/README.md
@@ -29,7 +29,7 @@ Arrow GLib based bindings.
 Here are command lines to install LGI on Debian GNU/Linux and Ubuntu:
 
 ```text
-% sudo apt install -y luarocks
+% sudo apt-get install -y -q --no-install-recommends luarocks
 % sudo luarocks install lgi
 ```
 

--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -25,7 +25,7 @@ ARG prefix=/opt/conda
 # install build essentials
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update -y -q && \
-    apt-get install -y -q wget tzdata libc6-dbg \
+    apt-get install -y -q --no-install-recommends wget tzdata libc6-dbg \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/conda-r.dockerfile
+++ b/ci/docker/conda-r.dockerfile
@@ -21,7 +21,7 @@ FROM ${repo}:${arch}-conda-cpp
 
 # Need locales so we can set UTF-8
 RUN apt-get update -y && \
-    apt-get install -y locales && \
+    apt-get install -y -q --no-install-recommends locales && \
     locale-gen en_US.UTF-8 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/ci/docker/debian-10-rust.dockerfile
+++ b/ci/docker/debian-10-rust.dockerfile
@@ -20,7 +20,7 @@ FROM ${arch}/rust
 
 # install pre-requisites for building flatbuffers
 RUN apt-get update -y && \
-    apt-get install -y build-essential cmake && \
+    apt-get install -y -q --no-install-recommends build-essential cmake && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/linux-apt-c-glib.dockerfile
+++ b/ci/docker/linux-apt-c-glib.dockerfile
@@ -19,7 +19,7 @@ ARG base
 FROM ${base}
 
 RUN apt-get update -y -q && \
-    apt-get install -y -q \
+    apt-get install -y -q --no-install-recommends \
         python3 \
         python3-pip \
         gtk-doc-tools \

--- a/ci/docker/linux-apt-cmake.dockerfile
+++ b/ci/docker/linux-apt-cmake.dockerfile
@@ -19,7 +19,7 @@ ARG base
 FROM ${base}
 
 RUN apt-get update && \
-    apt-get install -y -q \
+    apt-get install -y -q --no-install-recommends \
         libidn11 \
         wget && \
     apt-get clean && \

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -22,7 +22,7 @@ ARG r=3.6
 ARG jdk=8
 
 RUN apt-get update -y && \
-    apt-get install -y \
+    apt-get install -y -q --no-install-recommends \
         dirmngr \
         apt-transport-https \
         software-properties-common && \
@@ -30,7 +30,7 @@ RUN apt-get update -y && \
         --keyserver keyserver.ubuntu.com \
         --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 && \
     add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu '$(lsb_release -cs)'-cran35/' && \
-    apt-get install -y \
+    apt-get install -y -q --no-install-recommends \
         autoconf-archive \
         automake \
         curl \
@@ -63,7 +63,7 @@ RUN mvn -version
 
 ARG node=11
 RUN wget -q -O - https://deb.nodesource.com/setup_${node}.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get install -y -q --no-install-recommends nodejs && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/linux-apt-lint.dockerfile
+++ b/ci/docker/linux-apt-lint.dockerfile
@@ -21,7 +21,7 @@ FROM ${base}
 
 ARG clang_tools
 RUN apt-get update && \
-    apt-get install -y -q \
+    apt-get install -y -q --no-install-recommends \
         clang-${clang_tools} \
         clang-format-${clang_tools} \
         clang-tidy-${clang_tools} \

--- a/ci/docker/linux-apt-python-3.dockerfile
+++ b/ci/docker/linux-apt-python-3.dockerfile
@@ -19,7 +19,7 @@ ARG base
 FROM ${base}
 
 RUN apt-get update -y -q && \
-    apt-get install -y -q \
+    apt-get install -y -q --no-install-recommends \
         python3 \
         python3-pip \
         python3-dev && \

--- a/ci/docker/linux-apt-r.dockerfile
+++ b/ci/docker/linux-apt-r.dockerfile
@@ -23,7 +23,7 @@ FROM ${base}
 # [2] https://linuxize.com/post/how-to-install-r-on-ubuntu-18-04/#installing-r-packages-from-cran
 ARG r=3.6
 RUN apt-get update -y && \
-    apt-get install -y \
+    apt-get install -y -q --no-install-recommends \
         dirmngr \
         apt-transport-https \
         software-properties-common && \
@@ -37,7 +37,7 @@ RUN apt-get update -y && \
     # TODO: make sure OS version and R version are valid together and conditionally set repo suffix
     # This is a hack to turn 3.6 into 35 and 4.0 into 40:
     add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu '$(lsb_release -cs)'-cran'$(echo "${r}" | tr -d . | tr 6 5)'/' && \
-    apt-get install -y \
+    apt-get install -y -q --no-install-recommends \
         r-base=${r}* \
         # system libs needed by core R packages
         libxml2-dev \

--- a/dev/release/VERIFY.md
+++ b/dev/release/VERIFY.md
@@ -43,7 +43,7 @@ You need the followings to verify C GLib build:
 You can install them by the followings on Debian GNU/Linux and Ubuntu:
 
 ```console
-% sudo apt install -y -V libgirepository1.0-dev ruby-dev
+% sudo apt-get install -y -q --no-install-recommends libgirepository1.0-dev ruby-dev
 % sudo gem install gobject-introspection test-unit
 ```
 

--- a/dev/release/binary/Dockerfile
+++ b/dev/release/binary/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     apt-utils \
     createrepo \
     devscripts \

--- a/dev/release/source/Dockerfile
+++ b/dev/release/source/Dockerfile
@@ -20,7 +20,7 @@ FROM debian:buster
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt update && \
-  apt install -y -V \
+  apt-get install -y -q --no-install-recommends \
     autoconf-archive \
     gtk-doc-tools \
     libgirepository1.0-dev \

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -37,7 +37,7 @@ deb_version="${VERSION}-1"
 export DEBIAN_FRONTEND=noninteractive
 
 apt update
-apt install -y -V \
+apt-get install -y -q --no-install-recommends \
   curl \
   lsb-release
 
@@ -84,7 +84,7 @@ keyring_archive_base_name="apache-arrow-archive-keyring-latest-${code_name}.deb"
 curl \
   --output "${keyring_archive_base_name}" \
   "${bintray_base_url}/${keyring_archive_base_name}"
-apt install -y -V "./${keyring_archive_base_name}"
+apt-get install -y -q --no-install-recommends "./${keyring_archive_base_name}"
 if [ "${BINTRAY_REPOSITORY}" = "apache/arrow" ]; then
   if [ "${IS_RC}" = "yes" ]; then
     sed \
@@ -101,25 +101,25 @@ fi
 
 apt update
 
-apt install -y -V libarrow-glib-dev=${deb_version}
-apt install -y -V libarrow-glib-doc=${deb_version}
+apt-get install -y -q --no-install-recommends libarrow-glib-dev=${deb_version}
+apt-get install -y -q --no-install-recommends libarrow-glib-doc=${deb_version}
 
 if [ "${have_flight}" = "yes" ]; then
-  apt install -y -V libarrow-flight-dev=${deb_version}
+  apt-get install -y -q --no-install-recommends libarrow-flight-dev=${deb_version}
 fi
 
-apt install -y -V libarrow-python-dev=${deb_version}
+apt-get install -y -q --no-install-recommends libarrow-python-dev=${deb_version}
 
 if [ "${have_plasma}" = "yes" ]; then
-  apt install -y -V libplasma-glib-dev=${deb_version}
-  apt install -y -V libplasma-glib-doc=${deb_version}
-  apt install -y -V plasma-store-server=${deb_version}
+  apt-get install -y -q --no-install-recommends libplasma-glib-dev=${deb_version}
+  apt-get install -y -q --no-install-recommends libplasma-glib-doc=${deb_version}
+  apt-get install -y -q --no-install-recommends plasma-store-server=${deb_version}
 fi
 
 if [ "${have_gandiva}" = "yes" ]; then
-  apt install -y -V libgandiva-glib-dev=${deb_version}
-  apt install -y -V libgandiva-glib-doc=${deb_version}
+  apt-get install -y -q --no-install-recommends libgandiva-glib-dev=${deb_version}
+  apt-get install -y -q --no-install-recommends libgandiva-glib-doc=${deb_version}
 fi
 
-apt install -y -V libparquet-glib-dev=${deb_version}
-apt install -y -V libparquet-glib-doc=${deb_version}
+apt-get install -y -q --no-install-recommends libparquet-glib-dev=${deb_version}
+apt-get install -y -q --no-install-recommends libparquet-glib-doc=${deb_version}

--- a/dev/tasks/gandiva-jars/travis.linux.yml
+++ b/dev/tasks/gandiva-jars/travis.linux.yml
@@ -32,7 +32,7 @@ env:
     - ARROW_TRAVIS_USE_TOOLCHAIN=1
 
 before_install:
-  - sudo apt-get install -y libgit2-dev
+  - sudo apt-get install -y -q --no-install-recommends libgit2-dev
   - python3 -VV
   - echo "Setting python version 3.6.7 in pyenv"
   - pyenv shell 3.6.7

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/debian-buster/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/debian-buster/Dockerfile
@@ -30,7 +30,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     debhelper \
     devscripts \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/debian-stretch/Dockerfile
@@ -30,7 +30,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     debhelper \
     devscripts \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-bionic/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-bionic/Dockerfile
@@ -30,7 +30,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     debhelper \
     devscripts \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-eoan/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-eoan/Dockerfile
@@ -30,7 +30,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     debhelper \
     devscripts \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-focal/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-focal/Dockerfile
@@ -30,7 +30,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     debhelper \
     devscripts \

--- a/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-xenial/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-archive-keyring/apt/ubuntu-xenial/Dockerfile
@@ -30,7 +30,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     debhelper \
     devscripts \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-buster/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-buster/Dockerfile
@@ -39,7 +39,7 @@ ARG LLVM
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     apt-transport-https \
     ca-certificates \
     gnupg \
@@ -48,7 +48,7 @@ RUN \
   echo "deb https://apt.llvm.org/buster/ llvm-toolchain-buster-${LLVM} main" > \
     /etc/apt/sources.list.d/llvm.list && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     cmake \
     debhelper \
@@ -82,12 +82,12 @@ RUN \
     tzdata \
     zlib1g-dev && \
   if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
+    apt-get install -y -q --no-install-recommends ${quiet} \
       clang-${LLVM} \
       llvm-${LLVM}-dev; \
   fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get install -y -q --no-install-recommends ${quiet} nvidia-cuda-toolkit; \
   fi && \
   pip3 install --upgrade meson && \
   ln -s /usr/local/bin/meson /usr/bin/ && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
@@ -41,7 +41,7 @@ ARG LLVM
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     apt-transport-https \
     ca-certificates \
     gnupg \
@@ -50,7 +50,7 @@ RUN \
   echo "deb https://apt.llvm.org/stretch/ llvm-toolchain-stretch-${LLVM} main" > \
     /etc/apt/sources.list.d/llvm.list && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     cmake \
     devscripts \
@@ -81,20 +81,20 @@ RUN \
     python3-wheel \
     tzdata \
     zlib1g-dev && \
-  apt install -y -V -t stretch-backports-sloppy ${quiet} \
+  apt-get install -y -q --no-install-recommends -t stretch-backports-sloppy ${quiet} \
     libarchive13 && \
-  apt install -y -V -t stretch-backports ${quiet} \
+  apt-get install -y -q --no-install-recommends -t stretch-backports ${quiet} \
     debhelper \
     libgmock-dev \
     libgtest-dev \
     rapidjson-dev && \
   if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
+    apt-get install -y -q --no-install-recommends ${quiet} \
       clang-${LLVM} \
       llvm-${LLVM}-dev; \
   fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V -t stretch-backports ${quiet} nvidia-cuda-toolkit; \
+    apt-get install -y -q --no-install-recommends -t stretch-backports ${quiet} nvidia-cuda-toolkit; \
   fi && \
   pip3 install --upgrade meson && \
   ln -s /usr/local/bin/meson /usr/bin/ && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-bionic/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-bionic/Dockerfile
@@ -33,7 +33,7 @@ ARG LLVM
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     apt-transport-https \
     ca-certificates \
     gnupg \
@@ -42,7 +42,7 @@ RUN \
   echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM} main" > \
     /etc/apt/sources.list.d/llvm.list && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     cmake \
     devscripts \
@@ -75,14 +75,14 @@ RUN \
     tzdata \
     zlib1g-dev && \
   if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
+    apt-get install -y -q --no-install-recommends ${quiet} \
       clang-${LLVM} \
       llvm-${LLVM}-dev; \
   fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get install -y -q --no-install-recommends ${quiet} nvidia-cuda-toolkit; \
   fi && \
-  apt install -y -V -t bionic-backports ${quiet} \
+  apt-get install -y -q --no-install-recommends -t bionic-backports ${quiet} \
     debhelper && \
   pip3 install --upgrade meson && \
   ln -s /usr/local/bin/meson /usr/bin/ && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-eoan/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-eoan/Dockerfile
@@ -33,7 +33,7 @@ ARG LLVM
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     apt-transport-https \
     ca-certificates \
     gnupg \
@@ -42,7 +42,7 @@ RUN \
   echo "deb https://apt.llvm.org/eoan/ llvm-toolchain-eoan-${LLVM} main" > \
     /etc/apt/sources.list.d/llvm.list && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     cmake \
     debhelper \
@@ -75,12 +75,12 @@ RUN \
     tzdata \
     zlib1g-dev && \
   if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
+    apt-get install -y -q --no-install-recommends ${quiet} \
       clang-${LLVM} \
       llvm-${LLVM}-dev; \
   fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get install -y -q --no-install-recommends ${quiet} nvidia-cuda-toolkit; \
   fi && \
   apt clean && \
   pip3 install --upgrade meson && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-focal/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-focal/Dockerfile
@@ -33,7 +33,7 @@ ARG LLVM
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     build-essential \
     cmake \
     debhelper \
@@ -67,12 +67,12 @@ RUN \
     tzdata \
     zlib1g-dev && \
   if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
+    apt-get install -y -q --no-install-recommends ${quiet} \
       clang-${LLVM} \
       llvm-${LLVM}-dev; \
   fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get install -y -q --no-install-recommends ${quiet} nvidia-cuda-toolkit; \
   fi && \
   apt clean && \
   python3 -m pip install --no-use-pep517 meson && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-xenial/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-xenial/Dockerfile
@@ -36,7 +36,7 @@ ENV LLVM=8
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     apt-transport-https \
     ca-certificates \
     gnupg \
@@ -45,7 +45,7 @@ RUN \
   echo "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-${LLVM} main" > \
     /etc/apt/sources.list.d/llvm.list && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get install -y -q --no-install-recommends ${quiet} \
     autoconf-archive \
     build-essential \
     cmake \
@@ -76,14 +76,14 @@ RUN \
     python3-numpy \
     zlib1g-dev && \
   if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
+    apt-get install -y -q --no-install-recommends ${quiet} \
       clang-${LLVM} \
       llvm-${LLVM}-dev; \
   fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
-    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+    apt-get install -y -q --no-install-recommends ${quiet} nvidia-cuda-toolkit; \
   fi && \
-  apt install -y -V -t xenial-backports ${quiet} \
+  apt-get install -y -q --no-install-recommends -t xenial-backports ${quiet} \
     debhelper && \
   apt clean && \
   rm -rf /var/lib/apt/lists/*

--- a/dev/tasks/verify-rc/github.nix.yml
+++ b/dev/tasks/verify-rc/github.nix.yml
@@ -58,7 +58,7 @@ jobs:
           else
             # TODO: don't require removing newer llvms
             sudo apt-get --purge remove -y llvm-9 clang-9
-            sudo apt-get install -y \
+            sudo apt-get install -y -q --no-install-recommends \
               wget curl libboost-all-dev jq \
               autoconf-archive gtk-doc-tools libgirepository1.0-dev flex bison
             if [ "$TEST_JAVA" = "1" ]; then

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -44,7 +44,7 @@ On Ubuntu/Debian you can install the requirements with:
 
 .. code-block:: shell
 
-   sudo apt-get install \
+   sudo apt-get install -y -q --no-install-recommends \
         build-essential \
         cmake
 

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -222,7 +222,7 @@ dependencies will be automatically built by Arrow's third-party toolchain.
 
 .. code-block:: shell
 
-   $ sudo apt-get install libjemalloc-dev libboost-dev \
+   $ sudo apt-get install -y -q --no-install-recommends libjemalloc-dev libboost-dev \
                           libboost-filesystem-dev \
                           libboost-system-dev \
                           libboost-regex-dev \

--- a/python/manylinux1/Dockerfile-x86_64_ubuntu
+++ b/python/manylinux1/Dockerfile-x86_64_ubuntu
@@ -18,7 +18,7 @@ FROM ubuntu:14.04
 
 # Install dependencies
 RUN apt update
-RUN apt install -y ccache flex wget curl build-essential git libffi-dev autoconf pkg-config
+RUN apt-get install -y -q --no-install-recommends ccache flex wget curl build-essential git libffi-dev autoconf pkg-config
 
 ADD scripts/build_zlib.sh /
 RUN /build_zlib.sh


### PR DESCRIPTION
Fresh pull of #6590 

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik raj <rajpratik71@gmail.com>