### PR TITLE
ARROW-8726: [C++] Filename should not be part of DirectoryPartitioning

### DIFF
--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -265,7 +265,7 @@ class DirectoryPartitioningFactory : public PartitioningFactory {
   std::string type_name() const override { return "schema"; }
 
   Result<std::shared_ptr<Schema>> Inspect(
-      const std::vector<string_view>& paths) const override {
+      const std::vector<std::string>& paths) const override {
     KeyValuePartitioningInspectImpl impl;
 
     for (const auto& name : field_names_) {
@@ -274,7 +274,7 @@ class DirectoryPartitioningFactory : public PartitioningFactory {
 
     for (auto path : paths) {
       size_t field_index = 0;
-      for (auto&& segment : fs::internal::SplitAbstractPath(path.to_string())) {
+      for (auto&& segment : fs::internal::SplitAbstractPath(path)) {
         if (field_index == field_names_.size()) break;
 
         impl.InsertRepr(static_cast<int>(field_index++), std::move(segment));
@@ -574,11 +574,11 @@ class HivePartitioningFactory : public PartitioningFactory {
   std::string type_name() const override { return "hive"; }
 
   Result<std::shared_ptr<Schema>> Inspect(
-      const std::vector<string_view>& paths) const override {
+      const std::vector<std::string>& paths) const override {
     KeyValuePartitioningInspectImpl impl;
 
     for (auto path : paths) {
-      for (auto&& segment : fs::internal::SplitAbstractPath(path.to_string())) {
+      for (auto&& segment : fs::internal::SplitAbstractPath(path)) {
         if (auto key = HivePartitioning::ParseKey(segment)) {
           impl.InsertRepr(key->name, key->value);
         }

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -97,7 +97,7 @@ class ARROW_DS_EXPORT PartitioningFactory {
 
   /// Get the schema for the resulting Partitioning.
   virtual Result<std::shared_ptr<Schema>> Inspect(
-      const std::vector<util::string_view>& paths) const = 0;
+      const std::vector<std::string>& paths) const = 0;
 
   /// Create a partitioning using the provided schema
   /// (fields may be dropped).

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -54,14 +54,14 @@ class TestPartitioning : public ::testing::Test {
     AssertParse(path, expected.Copy());
   }
 
-  void AssertInspect(const std::vector<util::string_view>& paths,
+  void AssertInspect(const std::vector<std::string>& paths,
                      const std::vector<std::shared_ptr<Field>>& expected) {
     ASSERT_OK_AND_ASSIGN(auto actual, factory_->Inspect(paths));
     ASSERT_EQ(*actual, Schema(expected));
     ASSERT_OK(factory_->Finish(actual).status());
   }
 
-  void AssertInspectError(const std::vector<util::string_view>& paths) {
+  void AssertInspectError(const std::vector<std::string>& paths) {
     ASSERT_RAISES(Invalid, factory_->Inspect(paths));
   }
 


### PR DESCRIPTION
As the name of the class imply, only directory should be considered for partitions values.