### PR TITLE
ARROW-9077: [C++] Fix aggregate/scalar-compare benchmark null_percent calculation

### DIFF
--- a/cpp/src/arrow/compute/benchmark_util.h
+++ b/cpp/src/arrow/compute/benchmark_util.h
@@ -56,9 +56,12 @@ void BenchmarkSetArgsWithSizes(benchmark::internal::Benchmark* bench,
                                const std::vector<int64_t>& sizes = kMemorySizes) {
   bench->Unit(benchmark::kMicrosecond);
 
-  for (auto size : sizes)
-    for (auto nulls : std::vector<ArgsType>({10000, 1000, 100, 50, 10, 1}))
-      bench->Args({static_cast<ArgsType>(size), nulls});
+  for (const auto size : sizes) {
+    for (const auto inverse_null_proportion :
+         std::vector<ArgsType>({10000, 100, 10, 2, 1})) {
+      bench->Args({static_cast<ArgsType>(size), inverse_null_proportion});
+    }
+  }
 }
 
 void BenchmarkSetArgs(benchmark::internal::Benchmark* bench) {

--- a/cpp/src/arrow/compute/kernels/scalar_compare_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_benchmark.cc
@@ -31,42 +31,32 @@ namespace compute {
 constexpr auto kSeed = 0x94378165;
 
 static void CompareArrayScalarKernel(benchmark::State& state) {
-  const int64_t memory_size = state.range(0);
-  const int64_t array_size = memory_size / sizeof(int64_t);
-  const double null_percent = static_cast<double>(state.range(1)) / 100.0;
+  RegressionArgs args(state);
+  const int64_t array_size = args.size / sizeof(int64_t);
   auto rand = random::RandomArrayGenerator(kSeed);
   auto array = std::static_pointer_cast<NumericArray<Int64Type>>(
-      rand.Int64(array_size, -100, 100, null_percent));
+      rand.Int64(array_size, -100, 100, args.null_proportion));
 
   CompareOptions ge{GREATER_EQUAL};
 
   for (auto _ : state) {
     ABORT_NOT_OK(Compare(array, Datum(int64_t(0)), ge).status());
   }
-
-  state.counters["size"] = static_cast<double>(memory_size);
-  state.counters["null_percent"] = static_cast<double>(state.range(1));
-  state.SetBytesProcessed(state.iterations() * array_size * sizeof(int64_t));
 }
 
 static void CompareArrayArrayKernel(benchmark::State& state) {
-  const int64_t memory_size = state.range(0);
-  const int64_t array_size = memory_size / sizeof(int64_t);
-  const double null_percent = static_cast<double>(state.range(1)) / 100.0;
+  RegressionArgs args(state);
+  const int64_t array_size = args.size / sizeof(int64_t);
   auto rand = random::RandomArrayGenerator(kSeed);
   auto lhs = std::static_pointer_cast<NumericArray<Int64Type>>(
-      rand.Int64(array_size, -100, 100, null_percent));
+      rand.Int64(array_size, -100, 100, args.null_proportion));
   auto rhs = std::static_pointer_cast<NumericArray<Int64Type>>(
-      rand.Int64(array_size, -100, 100, null_percent));
+      rand.Int64(array_size, -100, 100, args.null_proportion));
 
   CompareOptions ge(GREATER_EQUAL);
   for (auto _ : state) {
     ABORT_NOT_OK(Compare(lhs, rhs, ge).status());
   }
-
-  state.counters["size"] = static_cast<double>(memory_size);
-  state.counters["null_percent"] = static_cast<double>(state.range(1));
-  state.SetBytesProcessed(state.iterations() * array_size * sizeof(int64_t) * 2);
 }
 
 BENCHMARK(CompareArrayScalarKernel)->Apply(RegressionSetArgs);


### PR DESCRIPTION
Correct both to use the new defined boilerplate.

Signed-off-by: Frank Du <frank.du@intel.com>