### PR TITLE
ARROW-9071: [C++] Fixed a bug in MakeArrayOfNull

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -274,6 +274,7 @@ TEST_F(TestArray, TestCopy) {}
 
 TEST_F(TestArray, TestMakeArrayOfNull) {
   std::shared_ptr<DataType> types[] = {
+      // clang-format off
       null(),
       boolean(),
       int8(),
@@ -287,18 +288,20 @@ TEST_F(TestArray, TestMakeArrayOfNull) {
       decimal(16, 4),
       utf8(),
       large_utf8(),
-      list(utf8()),
-      // ARROW-9071
-      list(int64()),
 
+      list(utf8()),
+      list(int64()),  // ARROW-9071
       large_list(large_utf8()),
       fixed_size_list(utf8(), 3),
+      fixed_size_list(int64(), 4),
       dictionary(int32(), utf8()),
       struct_({field("a", utf8()), field("b", int32())}),
       union_({field("a", utf8()), field("b", int32())}, {0, 1}, UnionMode::SPARSE),
-      union_({field("a", utf8()), field("b", int32())}, {0, 1}, UnionMode::DENSE)};
+      union_({field("a", utf8()), field("b", int32())}, {0, 1}, UnionMode::DENSE)
+      // clang-format on
+  };
 
-  for (int64_t length : {16}) {
+  for (int64_t length : {0, 1, 16, 133}) {
     for (auto type : types) {
       ASSERT_OK_AND_ASSIGN(auto array, MakeArrayOfNull(type, length));
       ASSERT_OK(array->ValidateFull());

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -288,6 +288,9 @@ TEST_F(TestArray, TestMakeArrayOfNull) {
       utf8(),
       large_utf8(),
       list(utf8()),
+      // ARROW-9071
+      list(int64()),
+
       large_list(large_utf8()),
       fixed_size_list(utf8(), 3),
       dictionary(int32(), utf8()),

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -215,7 +215,7 @@ class NullArrayFactory {
   template <typename T>
   enable_if_var_size_list<T, Status> Visit(const T& type) {
     out_->buffers.resize(2, buffer_);
-    ARROW_ASSIGN_OR_RAISE(out_->child_data[0], CreateChild(0, length_));
+    ARROW_ASSIGN_OR_RAISE(out_->child_data[0], CreateChild(0, /*length=*/0));
     return Status::OK();
   }
 


### PR DESCRIPTION
The child array of a ListArray of nulls should have length 0. 