### PR TITLE
ARROW-5377: [C++] Make IpcPayload public and add GetPayloadSize

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -667,7 +667,7 @@ class DoPutPayloadWriter : public ipc::internal::IpcPayloadWriter {
 
   Status Start() override { return Status::OK(); }
 
-  Status WritePayload(const ipc::internal::IpcPayload& ipc_payload) override {
+  Status WritePayload(const ipc::IpcPayload& ipc_payload) override {
     FlightPayload payload;
     payload.ipc_message = ipc_payload;
 

--- a/cpp/src/arrow/flight/perf_server.cc
+++ b/cpp/src/arrow/flight/perf_server.cc
@@ -73,8 +73,8 @@ class PerfDataStream : public FlightDataStream {
   std::shared_ptr<Schema> schema() override { return schema_; }
 
   Status GetSchemaPayload(FlightPayload* payload) override {
-    return ipc::internal::GetSchemaPayload(*schema_, ipc_options_, &dictionary_memo_,
-                                           &payload->ipc_message);
+    return ipc::GetSchemaPayload(*schema_, ipc_options_, &dictionary_memo_,
+                                 &payload->ipc_message);
   }
 
   Status Next(FlightPayload* payload) override {
@@ -102,8 +102,7 @@ class PerfDataStream : public FlightDataStream {
     } else {
       records_sent_ += batch_length_;
     }
-    return ipc::internal::GetRecordBatchPayload(*batch, ipc_options_,
-                                                &payload->ipc_message);
+    return ipc::GetRecordBatchPayload(*batch, ipc_options_, &payload->ipc_message);
   }
 
  private:

--- a/cpp/src/arrow/flight/serialization_internal.cc
+++ b/cpp/src/arrow/flight/serialization_internal.cc
@@ -61,7 +61,7 @@ namespace arrow {
 namespace flight {
 namespace internal {
 
-using arrow::ipc::internal::IpcPayload;
+using arrow::ipc::IpcPayload;
 
 using google::protobuf::internal::WireFormatLite;
 using google::protobuf::io::ArrayOutputStream;
@@ -163,8 +163,8 @@ grpc::Slice SliceFromBuffer(const std::shared_ptr<Buffer>& buf) {
 static const uint8_t kPaddingBytes[8] = {0, 0, 0, 0, 0, 0, 0, 0};
 
 // Update the sizes of our Protobuf fields based on the given IPC payload.
-grpc::Status IpcMessageHeaderSize(const arrow::ipc::internal::IpcPayload& ipc_msg,
-                                  bool has_body, size_t* body_size, size_t* header_size,
+grpc::Status IpcMessageHeaderSize(const arrow::ipc::IpcPayload& ipc_msg, bool has_body,
+                                  size_t* body_size, size_t* header_size,
                                   int32_t* metadata_size) {
   DCHECK_LT(ipc_msg.metadata->size(), kInt32Max);
   *metadata_size = static_cast<int32_t>(ipc_msg.metadata->size());
@@ -216,7 +216,7 @@ grpc::Status FlightDataSerialize(const FlightPayload& msg, ByteBuffer* out,
     header_size += 1 + WireFormatLite::LengthDelimitedSize(app_metadata_size);
   }
 
-  const arrow::ipc::internal::IpcPayload& ipc_msg = msg.ipc_message;
+  const arrow::ipc::IpcPayload& ipc_msg = msg.ipc_message;
   // No data in this payload (metadata-only).
   bool has_ipc = ipc_msg.type != ipc::MessageType::NONE;
   bool has_body = has_ipc ? ipc::Message::HasBody(ipc_msg.type) : false;

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -287,8 +287,8 @@ class DoExchangeMessageWriter : public FlightMessageWriter {
     started_ = true;
 
     FlightPayload schema_payload;
-    RETURN_NOT_OK(ipc::internal::GetSchemaPayload(
-        *schema, ipc_options_, &dictionary_memo_, &schema_payload.ipc_message));
+    RETURN_NOT_OK(ipc::GetSchemaPayload(*schema, ipc_options_, &dictionary_memo_,
+                                        &schema_payload.ipc_message));
     return WritePayload(schema_payload);
   }
 
@@ -310,8 +310,7 @@ class DoExchangeMessageWriter : public FlightMessageWriter {
     if (app_metadata) {
       payload.app_metadata = app_metadata;
     }
-    RETURN_NOT_OK(
-        ipc::internal::GetRecordBatchPayload(batch, ipc_options_, &payload.ipc_message));
+    RETURN_NOT_OK(ipc::GetRecordBatchPayload(batch, ipc_options_, &payload.ipc_message));
     return WritePayload(payload);
   }
 
@@ -344,8 +343,8 @@ class DoExchangeMessageWriter : public FlightMessageWriter {
     RETURN_NOT_OK(ipc::CollectDictionaries(batch, &dictionary_memo_));
     for (auto& pair : dictionary_memo_.dictionaries()) {
       FlightPayload payload{};
-      RETURN_NOT_OK(ipc::internal::GetDictionaryPayload(
-          pair.first, pair.second, ipc_options_, &payload.ipc_message));
+      RETURN_NOT_OK(ipc::GetDictionaryPayload(pair.first, pair.second, ipc_options_,
+                                              &payload.ipc_message));
       RETURN_NOT_OK(WritePayload(payload));
     }
     return Status::OK();
@@ -972,8 +971,8 @@ class RecordBatchStream::RecordBatchStreamImpl {
   std::shared_ptr<Schema> schema() { return reader_->schema(); }
 
   Status GetSchemaPayload(FlightPayload* payload) {
-    return ipc::internal::GetSchemaPayload(*reader_->schema(), ipc_options_,
-                                           &dictionary_memo_, &payload->ipc_message);
+    return ipc::GetSchemaPayload(*reader_->schema(), ipc_options_, &dictionary_memo_,
+                                 &payload->ipc_message);
   }
 
   Status Next(FlightPayload* payload) {
@@ -991,8 +990,8 @@ class RecordBatchStream::RecordBatchStreamImpl {
     if (stage_ == Stage::DICTIONARY) {
       if (dictionary_index_ == static_cast<int>(dictionaries_.size())) {
         stage_ = Stage::RECORD_BATCH;
-        return ipc::internal::GetRecordBatchPayload(*current_batch_, ipc_options_,
-                                                    &payload->ipc_message);
+        return ipc::GetRecordBatchPayload(*current_batch_, ipc_options_,
+                                          &payload->ipc_message);
       } else {
         return GetNextDictionary(payload);
       }
@@ -1006,16 +1005,16 @@ class RecordBatchStream::RecordBatchStreamImpl {
       payload->ipc_message.metadata = nullptr;
       return Status::OK();
     } else {
-      return ipc::internal::GetRecordBatchPayload(*current_batch_, ipc_options_,
-                                                  &payload->ipc_message);
+      return ipc::GetRecordBatchPayload(*current_batch_, ipc_options_,
+                                        &payload->ipc_message);
     }
   }
 
  private:
   Status GetNextDictionary(FlightPayload* payload) {
     const auto& it = dictionaries_[dictionary_index_++];
-    return ipc::internal::GetDictionaryPayload(it.first, it.second, ipc_options_,
-                                               &payload->ipc_message);
+    return ipc::GetDictionaryPayload(it.first, it.second, ipc_options_,
+                                     &payload->ipc_message);
   }
 
   Status CollectDictionaries(const RecordBatch& batch) {

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -347,7 +347,7 @@ struct ARROW_FLIGHT_EXPORT FlightEndpoint {
 struct ARROW_FLIGHT_EXPORT FlightPayload {
   std::shared_ptr<Buffer> descriptor;
   std::shared_ptr<Buffer> app_metadata;
-  ipc::internal::IpcPayload ipc_message;
+  ipc::IpcPayload ipc_message;
 };
 
 /// \brief Schema result returned after a schema request RPC

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -153,14 +153,13 @@ TEST(TestMessage, LegacyIpcBackwardsCompatibility) {
   auto RoundtripWithOptions = [&](const IpcWriteOptions& arg_options,
                                   std::shared_ptr<Buffer>* out_serialized,
                                   std::unique_ptr<Message>* out) {
-    internal::IpcPayload payload;
-    ASSERT_OK(internal::GetRecordBatchPayload(*batch, arg_options, &payload));
+    IpcPayload payload;
+    ASSERT_OK(GetRecordBatchPayload(*batch, arg_options, &payload));
 
     ASSERT_OK_AND_ASSIGN(auto stream, io::BufferOutputStream::Create(1 << 20));
 
     int32_t metadata_length = -1;
-    ASSERT_OK(
-        internal::WriteIpcPayload(payload, arg_options, stream.get(), &metadata_length));
+    ASSERT_OK(WriteIpcPayload(payload, arg_options, stream.get(), &metadata_length));
 
     ASSERT_OK_AND_ASSIGN(*out_serialized, stream->Finish());
     io::BufferReader io_reader(*out_serialized);
@@ -680,13 +679,17 @@ TEST_F(TestWriteRecordBatch, RoundtripPreservesBufferSizes) {
 void TestGetRecordBatchSize(const IpcWriteOptions& options,
                             std::shared_ptr<RecordBatch> batch) {
   io::MockOutputStream mock;
+  ipc::IpcPayload payload;
   int32_t mock_metadata_length = -1;
   int64_t mock_body_length = -1;
   int64_t size = -1;
   ASSERT_OK(WriteRecordBatch(*batch, 0, &mock, &mock_metadata_length, &mock_body_length,
                              options));
+  ASSERT_OK(GetRecordBatchPayload(*batch, options, &payload));
+  int64_t payload_size = GetPayloadSize(payload, options);
   ASSERT_OK(GetRecordBatchSize(*batch, options, &size));
   ASSERT_EQ(mock.GetExtentBytesWritten(), size);
+  ASSERT_EQ(mock.GetExtentBytesWritten(), payload_size);
 }
 
 TEST_F(TestWriteRecordBatch, IntegerGetRecordBatchSize) {
@@ -1398,14 +1401,13 @@ void SpliceMessages(std::shared_ptr<Buffer> stream,
     }
 
     IpcWriteOptions options;
-    internal::IpcPayload payload;
+    IpcPayload payload;
     payload.type = msg->type();
     payload.metadata = msg->metadata();
     payload.body_buffers.push_back(msg->body());
     payload.body_length = msg->body()->size();
     int32_t unused_metadata_length = -1;
-    ASSERT_OK(
-        internal::WriteIpcPayload(payload, options, out.get(), &unused_metadata_length));
+    ASSERT_OK(ipc::WriteIpcPayload(payload, options, out.get(), &unused_metadata_length));
   }
   ASSERT_OK_AND_ASSIGN(*spliced_stream, out->Finish());
 }

--- a/cpp/src/arrow/ipc/reader.h
+++ b/cpp/src/arrow/ipc/reader.h
@@ -50,12 +50,7 @@ class RandomAccessFile;
 namespace ipc {
 
 class DictionaryMemo;
-
-namespace internal {
-
 struct IpcPayload;
-
-}  // namespace internal
 
 using RecordBatchReader = ::arrow::RecordBatchReader;
 

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -433,7 +433,7 @@ Status GetSerializedFromComponents(int num_tensors,
 
   // Zero-copy reconstruct sparse tensors
   for (int i = 0, n = num_sparse_tensors.num_total_tensors(); i < n; ++i) {
-    ipc::internal::IpcPayload payload;
+    ipc::IpcPayload payload;
     RETURN_NOT_OK(GetBuffer(buffer_index++, &payload.metadata));
 
     ARROW_ASSIGN_OR_RAISE(

--- a/cpp/src/arrow/python/flight.cc
+++ b/cpp/src/arrow/python/flight.cc
@@ -240,8 +240,8 @@ PyGeneratorFlightDataStream::PyGeneratorFlightDataStream(
 std::shared_ptr<Schema> PyGeneratorFlightDataStream::schema() { return schema_; }
 
 Status PyGeneratorFlightDataStream::GetSchemaPayload(FlightPayload* payload) {
-  return ipc::internal::GetSchemaPayload(*schema_, options_, &dictionary_memo_,
-                                         &payload->ipc_message);
+  return ipc::GetSchemaPayload(*schema_, options_, &dictionary_memo_,
+                               &payload->ipc_message);
 }
 
 Status PyGeneratorFlightDataStream::Next(FlightPayload* payload) {

--- a/cpp/src/arrow/python/serialize.cc
+++ b/cpp/src/arrow/python/serialize.cc
@@ -767,9 +767,8 @@ Status SerializedPyObject::GetComponents(MemoryPool* memory_pool, PyObject** out
 
   // For each sparse tensor, get a metadata buffer and buffers containing index and data
   for (const auto& sparse_tensor : this->sparse_tensors) {
-    ipc::internal::IpcPayload payload;
-    RETURN_NOT_OK(
-        ipc::internal::GetSparseTensorPayload(*sparse_tensor, memory_pool, &payload));
+    ipc::IpcPayload payload;
+    RETURN_NOT_OK(ipc::GetSparseTensorPayload(*sparse_tensor, memory_pool, &payload));
     RETURN_NOT_OK(PushBuffer(payload.metadata));
     for (const auto& body : payload.body_buffers) {
       RETURN_NOT_OK(PushBuffer(body));

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1219,7 +1219,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     cdef cppclass CDictionaryMemo" arrow::ipc::DictionaryMemo":
         pass
 
-    cdef cppclass CIpcPayload" arrow::ipc::internal::IpcPayload":
+    cdef cppclass CIpcPayload" arrow::ipc::IpcPayload":
         MessageType type
         shared_ptr[CBuffer] metadata
         vector[shared_ptr[CBuffer]] body_buffers
@@ -1328,7 +1328,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
     CStatus AlignStream(COutputStream* stream, int64_t alignment)
 
     cdef CStatus GetRecordBatchPayload\
-        " arrow::ipc::internal::GetRecordBatchPayload"(
+        " arrow::ipc::GetRecordBatchPayload"(
             const CRecordBatch& batch,
             const CIpcWriteOptions& options,
             CIpcPayload* out)


### PR DESCRIPTION
As discussed in #7299, this makes IpcPayload and related functions public, and adds `arrow::ipc::GetPayloadSize`. It also adds a synthetic benchmark comparing it to `GetRecordBatchSize`. (Obviously, a very unfair comparison.)

```
-------------------------------------------------------------------------
Benchmark                                  Time           CPU Iterations
-------------------------------------------------------------------------
GetIpcPayloadSize/1/real_time             18 ns         18 ns   39779690   54.6317TB/s
GetIpcPayloadSize/4/real_time             18 ns         18 ns   39345745   54.2457TB/s
GetIpcPayloadSize/16/real_time            18 ns         18 ns   39393839   54.2546TB/s
GetIpcPayloadSize/64/real_time            19 ns         19 ns   38973515   51.9554TB/s
GetIpcPayloadSize/256/real_time           18 ns         18 ns   37427051    53.213TB/s
GetIpcPayloadSize/1024/real_time          18 ns         18 ns   38466296    55.367TB/s
GetIpcPayloadSize/4096/real_time          19 ns         19 ns   38322691    62.537TB/s
GetIpcPayloadSize/8192/real_time          19 ns         19 ns   38556584   72.0611TB/s
GetRecordBatchSize/1/real_time         10308 ns      10298 ns      67088    96.227GB/s
GetRecordBatchSize/4/real_time         15564 ns      15547 ns      45002    63.744GB/s
GetRecordBatchSize/16/real_time        30790 ns      30759 ns      22630   32.2385GB/s
GetRecordBatchSize/64/real_time        87783 ns      87687 ns       8037   11.3322GB/s
GetRecordBatchSize/256/real_time      307918 ns     307583 ns       2292   3.25852GB/s
GetRecordBatchSize/1024/real_time    1215936 ns    1214092 ns        582   873.888MB/s
GetRecordBatchSize/4096/real_time    5498273 ns    5486982 ns        126   221.522MB/s
GetRecordBatchSize/8192/real_time   12711545 ns   12680450 ns         55   112.191MB/s
```

This _doesn't_ meet the goal of ARROW-8487, which was to allow clients to limit the size of record batches sent via Flight. I tried adding `RecordBatchWriter::WritePayload`, but this needs some thought; in particular, when you have dictionaries, you need to assemble the dictionary payloads yourself, but can't do so because you can't get the writer's internal DictionaryMemo.