### PR TITLE
ARROW-9087: [C++] Support additional HDFS options

### DIFF
--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -278,6 +278,10 @@ void HdfsOptions::ConfigureBlockSize(int64_t default_block_size) {
   this->default_block_size = default_block_size;
 }
 
+void HdfsOptions::ConfigureExtraConf(std::string key, std::string val) {
+  connection_config.extra_conf.emplace(std::move(key), std::move(val));
+}
+
 bool HdfsOptions::Equals(const HdfsOptions& other) const {
   return (buffer_size == other.buffer_size && replication == other.replication &&
           default_block_size == other.default_block_size &&
@@ -318,6 +322,7 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
       return Status::Invalid("Invalid value for option 'replication': '", v, "'");
     }
     options.ConfigureReplication(replication);
+    options_map.erase(it);
   }
 
   // configure buffer_size
@@ -329,6 +334,7 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
       return Status::Invalid("Invalid value for option 'buffer_size': '", v, "'");
     }
     options.ConfigureBufferSize(buffer_size);
+    options_map.erase(it);
   }
 
   // configure default_block_size
@@ -340,6 +346,7 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
       return Status::Invalid("Invalid value for option 'default_block_size': '", v, "'");
     }
     options.ConfigureBlockSize(default_block_size);
+    options_map.erase(it);
   }
 
   // configure user
@@ -347,6 +354,22 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   if (it != options_map.end()) {
     const auto& user = it->second;
     options.ConfigureUser(user);
+    options_map.erase(it);
+  }
+
+  // configure kerberos
+  it = options_map.find("kerb_ticket");
+  if (it != options_map.end()) {
+    const auto& ticket = it->second;
+    options.ConfigureKerberosTicketCachePath(ticket);
+    options_map.erase(it);
+  }
+
+  // configure other options
+  for (auto it : options_map) {
+    const auto key = it.first;
+    const auto val = it.second;
+    options.ConfigureExtraConf(key, val);
   }
 
   return options;

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -366,10 +366,8 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   }
 
   // configure other options
-  for (auto it : options_map) {
-    const auto key = it.first;
-    const auto val = it.second;
-    options.ConfigureExtraConf(key, val);
+  for (const auto& it : options_map) {
+    options.ConfigureExtraConf(it.first, it.second);
   }
 
   return options;

--- a/cpp/src/arrow/filesystem/hdfs.h
+++ b/cpp/src/arrow/filesystem/hdfs.h
@@ -47,6 +47,7 @@ struct ARROW_EXPORT HdfsOptions {
   void ConfigureBufferSize(int32_t buffer_size);
   void ConfigureBlockSize(int64_t default_block_size);
   void ConfigureKerberosTicketCachePath(std::string path);
+  void ConfigureExtraConf(std::string key, std::string val);
 
   bool Equals(const HdfsOptions& other) const;
 

--- a/cpp/src/arrow/filesystem/hdfs_test.cc
+++ b/cpp/src/arrow/filesystem/hdfs_test.cc
@@ -44,12 +44,19 @@ TEST(TestHdfsOptions, FromUri) {
   ASSERT_EQ(options.connection_config.port, 0);
   ASSERT_EQ(options.connection_config.user, "");
 
-  ASSERT_OK(uri.Parse("hdfs://otherhost:9999/?replication=2"));
+  ASSERT_OK(uri.Parse("hdfs://otherhost:9999/?replication=2&kerb_ticket=kerb.ticket"));
   ASSERT_OK_AND_ASSIGN(options, HdfsOptions::FromUri(uri));
   ASSERT_EQ(options.replication, 2);
+  ASSERT_EQ(options.connection_config.kerb_ticket, "kerb.ticket");
   ASSERT_EQ(options.connection_config.host, "hdfs://otherhost");
   ASSERT_EQ(options.connection_config.port, 9999);
   ASSERT_EQ(options.connection_config.user, "");
+
+  ASSERT_OK(uri.Parse("hdfs://otherhost:9999/?hdfs_token=hdfs_token_ticket"));
+  ASSERT_OK_AND_ASSIGN(options, HdfsOptions::FromUri(uri));
+  ASSERT_EQ(options.connection_config.host, "hdfs://otherhost");
+  ASSERT_EQ(options.connection_config.port, 9999);
+  ASSERT_EQ(options.connection_config.extra_conf["hdfs_token"], "hdfs_token_ticket");
 
   ASSERT_OK(uri.Parse("viewfs://other-nn/mypath/myfile"));
   ASSERT_OK_AND_ASSIGN(options, HdfsOptions::FromUri(uri));

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -347,7 +347,7 @@ class HadoopFileSystem::HadoopFileSystemImpl {
       driver_->BuilderSetKerbTicketCachePath(builder, config->kerb_ticket.c_str());
     }
 
-    for (auto& kv : config->extra_conf) {
+    for (const auto& kv : config->extra_conf) {
       int ret = driver_->BuilderConfSetStr(builder, kv.first.c_str(), kv.second.c_str());
       CHECK_FAILURE(ret, "confsetstr");
     }

--- a/python/pyarrow/_hdfs.pyx
+++ b/python/pyarrow/_hdfs.pyx
@@ -54,7 +54,8 @@ cdef class HadoopFileSystem(FileSystem):
 
     def __init__(self, str host, int port=8020, str user=None,
                  int replication=3, int buffer_size=0,
-                 default_block_size=None, kerb_ticket=None):
+                 default_block_size=None, kerb_ticket=None,
+                 extra_conf=None):
         cdef:
             CHdfsOptions options
             shared_ptr[CHadoopFileSystem] wrapped
@@ -74,6 +75,9 @@ cdef class HadoopFileSystem(FileSystem):
         if kerb_ticket is not None:
             options.ConfigureKerberosTicketCachePath(
                 tobytes(_stringify_path(kerb_ticket)))
+        if extra_conf is not None:
+            for k, v in extra_conf.items():
+                options.ConfigureExtraConf(tobytes(k), tobytes(v))
 
         with nogil:
             wrapped = GetResultValue(CHadoopFileSystem.Make(options))
@@ -127,5 +131,7 @@ cdef class HadoopFileSystem(FileSystem):
                 opts.buffer_size,
                 opts.default_block_size,
                 frombytes(opts.connection_config.kerb_ticket),
+                {frombytes(k): frombytes(v)
+                 for k, v in opts.connection_config.extra_conf},
             )
         )

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -162,6 +162,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         void ConfigureBufferSize(int32_t buffer_size)
         void ConfigureBlockSize(int64_t default_block_size)
         void ConfigureKerberosTicketCachePath(c_string path)
+        void ConfigureExtraConf(c_string key, c_string value)
 
     cdef cppclass CHadoopFileSystem "arrow::fs::HadoopFileSystem"(CFileSystem):
         @staticmethod

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -879,6 +879,9 @@ def test_hdfs_options(hdfs_connection):
                              kerb_ticket=pathlib.Path("cache_path"))
     hdfs10 = HadoopFileSystem(host, port, user='localuser',
                               kerb_ticket="cache_path2")
+    hdfs11 = HadoopFileSystem(host, port, user='localuser',
+                              kerb_ticket="cache_path",
+                              extra_conf={'hdfs_token': 'abcd'})
 
     assert hdfs1 == hdfs2
     assert hdfs5 == hdfs6
@@ -891,6 +894,7 @@ def test_hdfs_options(hdfs_connection):
     assert hdfs7 != hdfs8
     assert hdfs8 == hdfs9
     assert hdfs10 != hdfs9
+    assert hdfs11 != hdfs8
 
     with pytest.raises(TypeError):
         HadoopFileSystem()
@@ -898,7 +902,7 @@ def test_hdfs_options(hdfs_connection):
         HadoopFileSystem.from_uri(3)
 
     for fs in [hdfs1, hdfs2, hdfs3, hdfs4, hdfs5, hdfs6, hdfs7, hdfs8,
-               hdfs9, hdfs10]:
+               hdfs9, hdfs10, hdfs11]:
         assert pickle.loads(pickle.dumps(fs)) == fs
 
     host, port, user = hdfs_connection


### PR DESCRIPTION
With this patch Arrow can pass kerberos_ticket and extra_conf on connecting with HDFS.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>