### PR TITLE
ARROW-9092: [C++][TRIAGE] Do not enable TestRoundFunctions when using LLVM 9 until gandiva-decimal-test is fixed

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -34,6 +34,8 @@ else()
   set(GANDIVA_CXX_STANDARD 14)
 endif()
 
+add_definitions(-DGANDIVA_LLVM_VERSION=${LLVM_VERSION_MAJOR})
+
 # Set the path where the bitcode file generated, see precompiled/CMakeLists.txt
 set(GANDIVA_PRECOMPILED_BC_PATH "${CMAKE_CURRENT_BINARY_DIR}/irhelpers.bc")
 set(GANDIVA_PRECOMPILED_CC_PATH "${CMAKE_CURRENT_BINARY_DIR}/precompiled_bitcode.cc")

--- a/cpp/src/gandiva/tests/decimal_test.cc
+++ b/cpp/src/gandiva/tests/decimal_test.cc
@@ -301,6 +301,8 @@ TEST_F(TestDecimal, TestCompare) {
                             outputs[5]);  // greater_than_or_equal_to
 }
 
+// ARROW-9092: This test is conditionally disabled when building with LLVM 9
+// because it hangs.
 #if GANDIVA_LLVM_VERSION != 9
 
 TEST_F(TestDecimal, TestRoundFunctions) {

--- a/cpp/src/gandiva/tests/decimal_test.cc
+++ b/cpp/src/gandiva/tests/decimal_test.cc
@@ -301,6 +301,8 @@ TEST_F(TestDecimal, TestCompare) {
                             outputs[5]);  // greater_than_or_equal_to
 }
 
+#if GANDIVA_LLVM_VERSION != 9
+
 TEST_F(TestDecimal, TestRoundFunctions) {
   // schema for input fields
   constexpr int32_t precision = 38;
@@ -403,6 +405,8 @@ TEST_F(TestDecimal, TestRoundFunctions) {
                             validity),
       outputs[6]);
 }
+
+#endif  // GANDIVA_LLVM_VERSION != 9
 
 TEST_F(TestDecimal, TestCastFunctions) {
   // schema for input fields


### PR DESCRIPTION
This unblocks LLVM 9 users from running the test suite. Whoever merges this, please leave the JIRA issue open. 