### PR TITLE
ARROW-8487: [FlightRPC] Provide a way to target a particular payload size

### DIFF
--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -60,6 +60,27 @@ class ARROW_FLIGHT_EXPORT FlightCallOptions {
   TimeoutDuration timeout;
 };
 
+/// \brief Indicate that the client attempted to write a message
+///     larger than the soft limit set via write_size_limit_bytes.
+class ARROW_FLIGHT_EXPORT FlightWriteSizeStatusDetail : public arrow::StatusDetail {
+ public:
+  explicit FlightWriteSizeStatusDetail(int64_t limit, int64_t actual)
+      : limit_(limit), actual_(actual) {}
+  const char* type_id() const override;
+  std::string ToString() const override;
+  int64_t limit() const { return limit_; }
+  int64_t actual() const { return actual_; }
+
+  /// \brief Extract this status detail from a status, or return
+  ///     nullptr if the status doesn't contain this status detail.
+  static std::shared_ptr<FlightWriteSizeStatusDetail> UnwrapStatus(
+      const arrow::Status& status);
+
+ private:
+  int64_t limit_;
+  int64_t actual_;
+};
+
 class ARROW_FLIGHT_EXPORT FlightClientOptions {
  public:
   /// \brief Root certificates to use for validating server
@@ -73,6 +94,16 @@ class ARROW_FLIGHT_EXPORT FlightClientOptions {
   std::string private_key;
   /// \brief A list of client middleware to apply.
   std::vector<std::shared_ptr<ClientMiddlewareFactory>> middleware;
+  /// \brief A soft limit on the number of bytes to write in a single
+  ///     batch when sending Arrow data to a server.
+  ///
+  /// Used to help limit server memory consumption. Only enabled if
+  /// positive. When enabled, FlightStreamWriter.Write* may yield a
+  /// IOError with error detail FlightWriteSizeStatusDetail.
+  int64_t write_size_limit_bytes;
+
+  /// \brief Get default options.
+  static FlightClientOptions Defaults();
 };
 
 /// \brief A RecordBatchReader exposing Flight metadata and cancel

--- a/cpp/src/arrow/flight/test_integration_client.cc
+++ b/cpp/src/arrow/flight/test_integration_client.cc
@@ -212,7 +212,8 @@ int main(int argc, char** argv) {
     scenario = std::make_shared<arrow::flight::IntegrationTestScenario>();
   }
 
-  arrow::flight::FlightClientOptions options;
+  arrow::flight::FlightClientOptions options =
+      arrow::flight::FlightClientOptions::Defaults();
   std::unique_ptr<arrow::flight::FlightClient> client;
 
   ABORT_NOT_OK(scenario->MakeClient(&options));

--- a/python/pyarrow/flight.py
+++ b/python/pyarrow/flight.py
@@ -47,6 +47,7 @@ from pyarrow._flight import (  # noqa:F401
     FlightUnauthenticatedError,
     FlightUnauthorizedError,
     FlightUnavailableError,
+    FlightWriteSizeExceededError,
     GeneratorStream,
     Location,
     MetadataRecordBatchReader,

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -292,6 +292,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
         c_string private_key
         c_string override_hostname
         vector[shared_ptr[CClientMiddlewareFactory]] middleware
+        int64_t write_size_limit_bytes
 
     cdef cppclass CFlightClient" arrow::flight::FlightClient":
         @staticmethod
@@ -351,6 +352,15 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
 
         @staticmethod
         shared_ptr[FlightStatusDetail] UnwrapStatus(const CStatus& status)
+
+    cdef cppclass FlightWriteSizeStatusDetail\
+            " arrow::flight::FlightWriteSizeStatusDetail":
+        int64_t limit()
+        int64_t actual()
+
+        @staticmethod
+        shared_ptr[FlightWriteSizeStatusDetail] UnwrapStatus(
+            const CStatus& status)
 
     cdef CStatus MakeFlightError" arrow::flight::MakeFlightError" \
         (CFlightStatusCode code, const c_string& message)

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -24,6 +24,7 @@ import threading
 import time
 import traceback
 
+import numpy as np
 import pytest
 import pyarrow as pa
 
@@ -1071,6 +1072,34 @@ def test_flight_do_put_metadata():
                 assert buf is not None
                 server_idx, = struct.unpack('<i', buf.to_pybytes())
                 assert idx == server_idx
+
+
+def test_flight_do_put_limit():
+    """Try a simple do_put call with a size limit."""
+    large_batch = pa.RecordBatch.from_arrays([
+        pa.array(np.ones(768, dtype=np.int64())),
+    ], names=['a'])
+
+    with EchoFlightServer() as server:
+        client = FlightClient(('localhost', server.port),
+                              write_size_limit_bytes=4096)
+        writer, metadata_reader = client.do_put(
+            flight.FlightDescriptor.for_path(''),
+            large_batch.schema)
+        with writer:
+            with pytest.raises(flight.FlightWriteSizeExceededError,
+                               match="exceeded soft limit") as excinfo:
+                writer.write_batch(large_batch)
+            assert excinfo.value.limit == 4096
+            smaller_batches = [
+                large_batch.slice(0, 384),
+                large_batch.slice(384),
+            ]
+            for batch in smaller_batches:
+                writer.write_batch(batch)
+        expected = pa.Table.from_batches([large_batch])
+        actual = client.do_get(flight.Ticket(b'')).read_all()
+        assert expected == actual
 
 
 @pytest.mark.slow


### PR DESCRIPTION
(Recreated since I rebased before reopening.)

I'd appreciate feedback on this. This is a specialized API to limit the payload size when a client is sending data to a server.

While Flight by default removes the gRPC-level limits on message sizes, we've found setting server-side limits on the size of incoming messages is still useful to ensure clients don't overwhelm a server/exhaust server memory by sending very large messages. However, if you exceed the limit at the gRPC level, the server resets the connection, making it hard for a client to recover gracefully. This PR adds an optional client-side check, so the client can catch the error and retry with a smaller record batch, or provide a meaningful error to the user if the batch cannot be made small enough.

Unlike solutions involving pa.ipc.get_record_batch_size, this avoids duplicate re-serialization of the record batch.