### PR TITLE
ARROW-9095: [Rust] Spec-compliant NullArray

### DIFF
--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -25,13 +25,12 @@ use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
 
 use crate::array::*;
-use crate::buffer::{Buffer, MutableBuffer};
+use crate::buffer::Buffer;
 use crate::compute::cast;
 use crate::datatypes::{DataType, Field, IntervalUnit, Schema, SchemaRef};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
 use crate::record_batch::{RecordBatch, RecordBatchReader};
-use crate::util::bit_util;
 use DataType::*;
 
 const CONTINUATION_MARKER: u32 = 0xffff_ffff;
@@ -193,14 +192,6 @@ fn create_array(
             let length = nodes[node_index].length() as usize;
             let data = ArrayData::builder(data_type.clone())
                 .len(length)
-                .null_count(length)
-                .null_bit_buffer({
-                    // create a buffer and fill it with invalid bits
-                    let num_bytes = bit_util::ceil(length, 8);
-                    let buffer = MutableBuffer::new(num_bytes);
-                    let buffer = buffer.with_bitset(num_bytes, false);
-                    buffer.freeze()
-                })
                 .offset(0)
                 .build();
             node_index += 1;


### PR DESCRIPTION
The change removes the buffer allocation, ensures that no default null buffers are written, and verifies that a roundtrip of an array with nulls works correctly.

As a side effect, the NullArray integration tests should now pass.