### PR TITLE
ARROW-9093: [FlightRPC][C++][Python] expose generic gRPC transport options

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -863,6 +863,16 @@ class FlightClient::FlightClientImpl {
       args.SetSslTargetNameOverride(options.override_hostname);
     }
 
+    // Allow setting generic gRPC options.
+    for (const auto& arg : options.generic_options) {
+      if (util::holds_alternative<int>(arg.second)) {
+        args.SetInt(arg.first, util::get<int>(arg.second));
+      } else if (util::holds_alternative<std::string>(arg.second)) {
+        args.SetString(arg.first, util::get<std::string>(arg.second));
+      }
+      // Otherwise unimplemented
+    }
+
     std::vector<std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>>
         interceptors;
     interceptors.emplace_back(

--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -29,6 +29,7 @@
 #include "arrow/ipc/reader.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/status.h"
+#include "arrow/util/variant.h"
 
 #include "arrow/flight/types.h"  // IWYU pragma: keep
 #include "arrow/flight/visibility.h"
@@ -101,6 +102,9 @@ class ARROW_FLIGHT_EXPORT FlightClientOptions {
   /// positive. When enabled, FlightStreamWriter.Write* may yield a
   /// IOError with error detail FlightWriteSizeStatusDetail.
   int64_t write_size_limit_bytes;
+  /// \brief Generic connection options, passed to the underlying
+  ///     transport; interpretation is implementation-dependent.
+  std::vector<std::pair<std::string, util::variant<int, std::string>>> generic_options;
 
   /// \brief Get default options.
   static FlightClientOptions Defaults();

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -293,6 +293,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
         c_string override_hostname
         vector[shared_ptr[CClientMiddlewareFactory]] middleware
         int64_t write_size_limit_bytes
+        vector[pair[c_string, CIntStringVariant]] generic_options
 
     cdef cppclass CFlightClient" arrow::flight::FlightClient":
         @staticmethod
@@ -530,3 +531,10 @@ cdef extern from "arrow/python/flight.h" namespace "arrow::py::flight" nogil:
     cdef CStatus SerializeBasicAuth" arrow::py::flight::SerializeBasicAuth"(
         CBasicAuth basic_auth,
         c_string* out)
+
+
+cdef extern from "arrow/util/variant.h" namespace "arrow" nogil:
+    cdef cppclass CIntStringVariant" arrow::util::variant<int, std::string>":
+        CIntStringVariant()
+        CIntStringVariant(int)
+        CIntStringVariant(c_string)


### PR DESCRIPTION
This allows passing generic client options to the underlying gRPC client in C++/Python.

The motivation is to expose these options: https://grpc.github.io/grpc/cpp/group__grpc__arg__keys.html which can be useful for tuning. For instance, we can then enable round-robin load balancing, useful in production deployments, or we can experiment with enabling SO_ZEROCOPY (which is now experimental in gRPC), without having to individually bind all of these options in Flight.

(Java doesn't require this due to the flight-grpc module, which gives you the underlying gRPC client/server resources; unfortunately a similar approach can't be done for Python since gRPC-Python is not based on gRPC-C++.)