### PR TITLE
ARROW-9110: [C++] Fix CPU cache size detection on macOS

### DIFF
--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -301,7 +301,7 @@ void CpuInfo::Init() {
 
 #ifdef __APPLE__
   // On Mac OS X use sysctl() to get the cache sizes
-  static size_t len = sizeof(int64_t);
+  size_t len = sizeof(int64_t);
   int64_t data[1];
   sysctlbyname("hw.l1dcachesize", data, &len, NULL, 0);
   cache_sizes_[0] = data[0];

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -301,15 +301,14 @@ void CpuInfo::Init() {
 
 #ifdef __APPLE__
   // On Mac OS X use sysctl() to get the cache sizes
-  size_t len = 0;
-  sysctlbyname("hw.cachesize", NULL, &len, NULL, 0);
-  uint64_t* data = static_cast<uint64_t*>(malloc(len));
-  sysctlbyname("hw.cachesize", data, &len, NULL, 0);
-  DCHECK_GE(len / sizeof(uint64_t), 4);
-  // first number is the size of the available ram
-  for (size_t i = 1; i < 4; ++i) {
-    cache_sizes_[i] = data[i];
-  }
+  static size_t len = sizeof(int64_t);
+  int64_t data[1];
+  sysctlbyname("hw.l1dcachesize", data, &len, NULL, 0);
+  cache_sizes_[0] = data[0];
+  sysctlbyname("hw.l2cachesize", data, &len, NULL, 0);
+  cache_sizes_[1] = data[0];
+  sysctlbyname("hw.l3cachesize", data, &len, NULL, 0);
+  cache_sizes_[2] = data[0];
 #elif _WIN32
   if (!RetrieveCacheSize(cache_sizes_)) {
     SetDefaultCacheSize();

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -305,8 +305,9 @@ void CpuInfo::Init() {
   sysctlbyname("hw.cachesize", NULL, &len, NULL, 0);
   uint64_t* data = static_cast<uint64_t*>(malloc(len));
   sysctlbyname("hw.cachesize", data, &len, NULL, 0);
-  DCHECK_GE(len / sizeof(uint64_t), 3);
-  for (size_t i = 0; i < 3; ++i) {
+  DCHECK_GE(len / sizeof(uint64_t), 4);
+  // first number is the size of the available ram
+  for (size_t i = 1; i < 4; ++i) {
     cache_sizes_[i] = data[i];
   }
 #elif _WIN32


### PR DESCRIPTION
Querying locally shows my RAM size at the first position:

```
❯ sysctl -a | grep hw\.cachesize
hw.cachesize: 68719476736 32768 262144 16777216 0 0 0 0 0 0
```

I'm unsure how to test it, it has fixed running the benchmarks locally for me.