### PR TITLE
ARROW-8649: [Java] [Website] Java documentation on website is hidden

### DIFF
--- a/ci/scripts/docs_build.sh
+++ b/ci/scripts/docs_build.sh
@@ -40,7 +40,7 @@ rsync -a ${arrow_dir}/r/docs/ ${build_dir}/r
 rsync -a ${ARROW_HOME}/share/gtk-doc/html/ ${build_dir}/c_glib
 
 # Java
-rsync -a ${arrow_dir}/java/target/site/apidocs/ ${build_dir}/java
+rsync -a ${arrow_dir}/java/target/site/apidocs/ ${build_dir}/java/reference
 
 # Javascript
 rsync -a ${arrow_dir}/js/doc/ ${build_dir}/js

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -52,11 +52,11 @@ such topics as:
    :caption: Arrow Libraries
 
    status
-   C++ <cpp/index>
-   Python <python/index>
-   Java <https://arrow.apache.org/docs/java/>
    C/GLib <https://arrow.apache.org/docs/c_glib/>
+   C++ <cpp/index>
+   Java <java/index>
    JavaScript <https://arrow.apache.org/docs/js/>
+   Python <python/index>
    R <https://arrow.apache.org/docs/r/>
 
 .. _toc.development:

--- a/docs/source/java/index.rst
+++ b/docs/source/java/index.rst
@@ -27,4 +27,4 @@ on the Arrow format and other language bindings see the :doc:`parent documentati
    vector
    vector_schema_root
    ipc
-
+   Reference (javadoc) <https://arrow.apache.org/docs/java/reference/>


### PR DESCRIPTION
This proposal moves the generated javadoc site from /docs/java/ to /docs/java/reference/. It appears that Sphinx is generating a /docs/java/index.html that has links to the Java prose docs, but the docs_build.sh script was overwriting it with the javadoc.