### PR TITLE
ARROW-8826: [Crossbow] remote URL should always have .git

### DIFF
--- a/dev/tasks/homebrew-formulae/travis.osx.r.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.r.yml
@@ -42,8 +42,9 @@ before_install:
 # Put the formula inside r/ so that it's included in the package build
 - cp ../dev/tasks/homebrew-formulae/autobrew/apache-arrow.rb tools/apache-arrow.rb
 # Pin the current commit in the formula to test so that we're not always pulling from master
-- sed -i.bak -E -e 's@https://github.com/apache/arrow.git"$@{{ arrow.remote }}", :revision => "{{ arrow.head }}"@' tools/apache-arrow.rb
-- rm -f tools/apache-arrow.rb.bak
+- sed -i.bak -E -e 's@https://github.com/apache/arrow.git"$@{{ arrow.remote }}.git", :revision => "{{ arrow.head }}"@' tools/apache-arrow.rb && rm -f tools/apache-arrow.rb.bak
+# Sometimes crossbow gives a remote URL with .git and sometimes not. Make sure there's only one
+- sed -i.bak -E -e 's@.git.git@.git@' tools/apache-arrow.rb && rm -f tools/apache-arrow.rb.bak
 script:
 - Rscript -e 'install.packages("rcmdcheck")'
 # Note that this is not --as-cran. CRAN doesn't do macOS checks --as-cran

--- a/dev/tasks/homebrew-formulae/travis.osx.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.yml
@@ -32,8 +32,9 @@ before_script:
 - git -C arrow fetch -t {{ arrow.remote }} {{ arrow.branch }}
 - if [ $CROSSBOW_USE_COMMIT_ID = true ]; then git -C arrow checkout {{ arrow.head }}; else git -C arrow checkout FETCH_HEAD; fi
 # Pin the current commit in the formula to test so that we're not always pulling from master
-- sed -i.bak -E -e 's@https://github.com/apache/arrow.git"$@{{ arrow.remote }}", :revision => "{{ arrow.head }}"@' $ARROW_FORMULA
-- rm -f $ARROW_FORMULA.bak
+- sed -i.bak -E -e 's@https://github.com/apache/arrow.git"$@{{ arrow.remote }}.git", :revision => "{{ arrow.head }}"@' $ARROW_FORMULA && rm -f $ARROW_FORMULA.bak
+# Sometimes crossbow gives a remote URL with .git and sometimes not. Make sure there's only one
+- sed -i.bak -E -e 's@.git.git@.git@' $ARROW_FORMULA && rm -f $ARROW_FORMULA.bak
 - brew update
 - brew uninstall --ignore-dependencies boost
 - brew --version


### PR DESCRIPTION
Since crossbow doesn't have tests, I was afraid to poke at the python code for fear of breaking something else, so I've tried to work around the inconsistency in the Travis scripts. What's one more `sed` anyway?