### PR TITLE
ARROW-6645: [Python] Use common boundschecking function for checking dictionary indices when converting to pandas

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -384,10 +384,10 @@ class TestConvertMetadata:
             batch = pa.RecordBatch.from_arrays([arr], ['foo'])
             table = pa.Table.from_batches([batch, batch, batch])
 
-            with pytest.raises(pa.ArrowInvalid):
+            with pytest.raises(IndexError):
                 arr.to_pandas()
 
-            with pytest.raises(pa.ArrowInvalid):
+            with pytest.raises(IndexError):
                 table.to_pandas()
 
     def test_unicode_with_unicode_column_and_index(self):


### PR DESCRIPTION
The new function is faster and this means less code to maintain. I had originally suggested doing away with the boundschecking but unless we demonstrate that it really is a performance issue this should be good enough for now. 