### PR TITLE
ARROW-7028: [R] Date roundtrip results in different R storage mode

### DIFF
--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -164,15 +164,22 @@ class Converter_SimpleArray : public Converter {
   }
 };
 
-class Converter_Date32 : public Converter_SimpleArray<INTSXP> {
+class Converter_Date32 : public Converter_SimpleArray<REALSXP> {
  public:
   explicit Converter_Date32(const ArrayVector& arrays)
-      : Converter_SimpleArray<INTSXP>(arrays) {}
+      : Converter_SimpleArray<REALSXP>(arrays) {}
 
   SEXP Allocate(R_xlen_t n) const {
-    IntegerVector data(no_init(n));
+    Rcpp::NumericVector data(no_init(n));
     data.attr("class") = "Date";
     return data;
+  }
+
+  Status Ingest_some_nulls(SEXP data, const std::shared_ptr<arrow::Array>& array,
+                           R_xlen_t start, R_xlen_t n) const {
+    auto convert = [](int days) { return static_cast<double>(days); };
+    return SomeNull_Ingest<REALSXP, int>(
+        data, start, n, array->data()->GetValues<int>(1), array, convert);
   }
 };
 

--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -178,8 +178,8 @@ class Converter_Date32 : public Converter_SimpleArray<REALSXP> {
   Status Ingest_some_nulls(SEXP data, const std::shared_ptr<arrow::Array>& array,
                            R_xlen_t start, R_xlen_t n) const {
     auto convert = [](int days) { return static_cast<double>(days); };
-    return SomeNull_Ingest<REALSXP, int>(
-        data, start, n, array->data()->GetValues<int>(1), array, convert);
+    return SomeNull_Ingest<REALSXP, int>(data, start, n, array->data()->GetValues<int>(1),
+                                         array, convert);
   }
 };
 

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -202,6 +202,8 @@ test_that("array supports Date (ARROW-3340)", {
   expect_array_roundtrip(d2, date32())
   # PSA: IngestDoubleRange(Date32Builder) truncates decimals, so this only
   # works where the dates are integer-ish
+
+  expect_equal(typeof(Array$create(d)$as_vector()), "double")
 })
 
 test_that("array supports POSIXct (ARROW-3340)", {

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -28,6 +28,8 @@ expect_array_roundtrip <- function(x, type) {
     expect_identical(is.na(a), is.na(x))
   }
   expect_equal(as.vector(a), x)
+  # Make sure the storage mode is the same on roundtrip (esp. integer vs. numeric)
+  expect_identical(typeof(as.vector(a)), typeof(x))
 
   if (length(x)) {
     a_sliced <- a$Slice(1)
@@ -196,14 +198,6 @@ test_that("array supports Date (ARROW-3340)", {
 
   d[5] <- NA
   expect_array_roundtrip(d, date32())
-
-  # Test code path where Date is numeric underneath, not integer
-  d2 <- structure(as.numeric(d), class = "Date")
-  expect_array_roundtrip(d2, date32())
-  # PSA: IngestDoubleRange(Date32Builder) truncates decimals, so this only
-  # works where the dates are integer-ish
-
-  expect_equal(typeof(Array$create(d)$as_vector()), "double")
 })
 
 test_that("array supports POSIXct (ARROW-3340)", {


### PR DESCRIPTION
Although it's to some extent tolerated that Date vectors are backed by `integer` vectors, it's much more common that they are backed by numeric: 

``` r
.Internal(inspect(Sys.Date()))
#> @7fb95b8178c0 14 REALSXP g0c1 [OBJ,ATT] (len=1, tl=0) 18425
#> ATTRIB:
#>   @7fb9586b1808 02 LISTSXP g0c0 [REF(1)] 
#>     TAG: @7fb957004fd0 01 SYMSXP g0c0 [MARK,REF(25905),LCK,gp=0x6000] "class" (has value)
#>     @7fb95b817888 16 STRSXP g0c1 [REF(1)] (len=1, tl=0)
#>       @7fb9571c1530 09 CHARSXP g0c1 [MARK,REF(191),gp=0x61] [ASCII] [cached] "Date"
.Internal(inspect(as.Date("1982-05-15")))
#> @7fb95c10eb58 14 REALSXP g0c1 [OBJ,ATT] (len=1, tl=0) 4517
#> ATTRIB:
#>   @7fb9587cbc48 02 LISTSXP g0c0 [REF(1)] 
#>     TAG: @7fb957004fd0 01 SYMSXP g0c0 [MARK,REF(25948),LCK,gp=0x6000] "class" (has value)
#>     @7fb95c10eb20 16 STRSXP g0c1 [REF(1)] (len=1, tl=0)
#>       @7fb9571c1530 09 CHARSXP g0c1 [MARK,REF(192),gp=0x61] [ASCII] [cached] "Date"
```

<sup>Created on 2020-06-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

So I've changed `Converter_Date32` to convert to a numeric vector: 

``` r
library(dplyr, warn.conflicts = FALSE)

tmp = tempdir()
dat = tibble(tag = as.Date("2018-01-01"))
dat2 = tibble(tag2 = as.Date("2019-01-01"))

arrow::write_parquet(dat, file.path(tmp, "dat.parquet"))
dat = arrow::read_parquet(file.path(tmp, "dat.parquet"))

typeof(dat$tag)
#> [1] "double"
typeof(dat2$tag2)
#> [1] "double"

bind_cols(dat, dat2) %>%
  mutate(comparison = if_else(TRUE, tag, tag2))
#> # A tibble: 1 x 3
#>   tag        tag2       comparison
#>   <date>     <date>     <date>    
#> 1 2018-01-01 2019-01-01 2018-01-01
```

<sup>Created on 2020-06-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

Note: `dplyr::if_else` is due a rewrite, probably in `funs::` that will be more `vctrs`-correct and perhaps would deal with the issue: 

``` r
library(dplyr, warn.conflicts = FALSE)

today_dbl <- Sys.Date()
today_int <- structure(as.integer(today_dbl), class = "Date")

dplyr::if_else(TRUE, today_dbl, today_int)
#> Error: `false` must be a `Date` object, not a `Date` object.
```

<sup>Created on 2020-06-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This might be a usecase for `vctrs::vec_cast_common()`. ping @lionel- @DavisVaughan: 

``` r
library(dplyr, warn.conflicts = FALSE)

today_dbl <- Sys.Date()
today_int <- structure(as.integer(today_dbl), class = "Date")
.Internal(inspect(
  vctrs::vec_cast_common(today_dbl, today_int)
))
#> @7ffe825f1688 19 VECSXP g0c2 [] (len=2, tl=0)
#>   @7ffe823aeaa0 14 REALSXP g0c1 [OBJ,REF(12),ATT] (len=1, tl=0) 18425
#>   ATTRIB:
#>     @7ffe823b5408 02 LISTSXP g0c0 [REF(1)] 
#>       TAG: @7ffe80804fd0 01 SYMSXP g1c0 [MARK,REF(33031),LCK,gp=0x6000] "class" (has value)
#>       @7ffe823aea68 16 STRSXP g0c1 [REF(65535)] (len=1, tl=0)
#>  @7ffe809c1530 09 CHARSXP g1c1 [MARK,REF(395),gp=0x61] [ASCII] [cached] "Date"
#>   @7ffe8265eb30 14 REALSXP g0c1 [OBJ,REF(1),ATT] (len=1, tl=0) 18425
#>   ATTRIB:
#>     @7ffe82664938 02 LISTSXP g0c0 [REF(1)] 
#>       TAG: @7ffe80804fd0 01 SYMSXP g1c0 [MARK,REF(33031),LCK,gp=0x6000] "class" (has value)
#>       @7ffe82d15d60 16 STRSXP g1c1 [MARK,REF(65535)] (len=1, tl=0)
#>  @7ffe809c1530 09 CHARSXP g1c1 [MARK,REF(395),gp=0x61] [ASCII] [cached] "Date"
```

<sup>Created on 2020-06-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>