### PR TITLE
ARROW-9113: [Archery] Fix exception causes in cli.py

### DIFF
--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -91,7 +91,7 @@ def validate_arrow_sources(ctx, param, src):
     try:
         return ArrowSources.find(src)
     except InvalidArrowSource as e:
-        raise click.BadParameter(str(e))
+        raise click.BadParameter(str(e)) from e
 
 
 build_dir_type = click.Path(dir_okay=True, file_okay=False, resolve_path=True)
@@ -768,9 +768,9 @@ def docker_compose_run(obj, image, command, env, force_pull, force_build,
         raise click.ClickException(
             "There is no service/image defined in docker-compose.yml with "
             "name: {}".format(str(e))
-        )
+        ) from e
     except RuntimeError as e:
-        raise click.ClickException(str(e))
+        raise click.ClickException(str(e)) from e
 
 
 @docker_compose.command('push')


### PR DESCRIPTION
I recently went over [Matplotlib](https://github.com/matplotlib/matplotlib/pull/16706), [Pandas](https://github.com/pandas-dev/pandas/pull/32322) and [NumPy](https://github.com/numpy/numpy/pull/15731), fixing a small mistake in the way that Python 3's exception chaining is used. If you're interested, I can do it here too. I've done it on just one file right now. 

The mistake is this: In some parts of the code, an exception is being caught and replaced with a more user-friendly error. In these cases the syntax `raise new_error from old_error` needs to be used.

Python 3's exception chaining means it shows not only the traceback of the current exception, but that of the original exception (and possibly more.) This is regardless of `raise from`. The usage of `raise from` tells Python to put a more accurate message between the tracebacks. Instead of this: 

    During handling of the above exception, another exception occurred:

You'll get this: 

    The above exception was the direct cause of the following exception:

The first is inaccurate, because it signifies a bug in the exception-handling code itself, which is a separate situation than wrapping an exception.

Let me know what you think! 