### PR TITLE
ARROW-9079: [C++] Write benchmark for arithmetic kernels

### DIFF
--- a/cpp/src/arrow/compute/kernels/CMakeLists.txt
+++ b/cpp/src/arrow/compute/kernels/CMakeLists.txt
@@ -28,6 +28,7 @@ add_arrow_compute_test(scalar_test
                        scalar_string_test.cc
                        test_util.cc)
 
+add_arrow_benchmark(scalar_arithmetic_benchmark PREFIX "arrow-compute")
 add_arrow_benchmark(scalar_compare_benchmark PREFIX "arrow-compute")
 add_arrow_benchmark(scalar_string_benchmark PREFIX "arrow-compute")
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -83,9 +83,7 @@ struct Multiply {
   static_assert(std::is_same<decltype(int16_t() * int16_t()), int32_t>::value, "");
   static_assert(std::is_same<decltype(uint16_t() * uint16_t()), int32_t>::value, "");
   static_assert(std::is_same<decltype(int32_t() * int32_t()), int32_t>::value, "");
-
   static_assert(std::is_same<decltype(uint32_t() * uint32_t()), uint32_t>::value, "");
-
   static_assert(std::is_same<decltype(int64_t() * int64_t()), int64_t>::value, "");
   static_assert(std::is_same<decltype(uint64_t() * uint64_t()), uint64_t>::value, "");
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_benchmark.cc
@@ -1,0 +1,92 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include <vector>
+
+#include "arrow/compute/api_scalar.h"
+#include "arrow/compute/benchmark_util.h"
+#include "arrow/compute/kernels/test_util.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+
+namespace arrow {
+namespace compute {
+
+constexpr auto kSeed = 0x94378165;
+
+template <typename ArrowType, typename CType = typename ArrowType::c_type>
+static void AddArrayScalarKernel(benchmark::State& state) {
+  RegressionArgs args(state);
+
+  const int64_t array_size = args.size / sizeof(CType);
+  auto min = std::numeric_limits<CType>::lowest();
+  auto max = std::numeric_limits<CType>::max();
+
+  auto rand = random::RandomArrayGenerator(kSeed);
+  auto lhs = std::static_pointer_cast<NumericArray<ArrowType>>(
+      rand.Numeric<ArrowType>(array_size, min, max, args.null_proportion));
+
+  for (auto _ : state) {
+    ABORT_NOT_OK(Add(lhs, Datum(CType(15))).status());
+  }
+}
+
+template <typename ArrowType, typename CType = typename ArrowType::c_type>
+static void AddArrayArrayKernel(benchmark::State& state) {
+  RegressionArgs args(state);
+
+  const int64_t array_size = args.size / sizeof(CType);
+  auto min = std::numeric_limits<CType>::lowest();
+  auto max = std::numeric_limits<CType>::max();
+
+  auto rand = random::RandomArrayGenerator(kSeed);
+  auto lhs = std::static_pointer_cast<NumericArray<ArrowType>>(
+      rand.Numeric<ArrowType>(array_size, min, max, args.null_proportion));
+  auto rhs = std::static_pointer_cast<NumericArray<ArrowType>>(
+      rand.Numeric<ArrowType>(array_size, min, max, args.null_proportion));
+
+  for (auto _ : state) {
+    ABORT_NOT_OK(Add(lhs, rhs).status());
+  }
+}
+
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, Int64Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, Int32Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, Int16Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, Int8Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, UInt64Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, UInt32Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, UInt16Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, UInt8Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, FloatType)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayArrayKernel, DoubleType)->Apply(RegressionSetArgs);
+
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, Int64Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, Int32Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, Int16Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, Int8Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, UInt64Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, UInt32Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, UInt16Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, UInt8Type)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, FloatType)->Apply(RegressionSetArgs);
+BENCHMARK_TEMPLATE(AddArrayScalarKernel, DoubleType)->Apply(RegressionSetArgs);
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_benchmark.cc
@@ -48,6 +48,7 @@ static void ArrayScalarKernel(benchmark::State& state) {
   for (auto _ : state) {
     ABORT_NOT_OK(Op(lhs, fifteen, nullptr).status());
   }
+  state.SetItemsProcessed(state.iterations() * array_size);
 }
 
 template <BinaryOp& Op, typename ArrowType, typename CType = typename ArrowType::c_type>
@@ -67,89 +68,35 @@ static void ArrayArrayKernel(benchmark::State& state) {
   for (auto _ : state) {
     ABORT_NOT_OK(Op(lhs, rhs, nullptr).status());
   }
+  state.SetItemsProcessed(state.iterations() * array_size);
 }
 
 void SetArgs(benchmark::internal::Benchmark* bench) {
-  bench->Unit(benchmark::kMicrosecond);
-
-  for (const auto size : kMemorySizes) {
+  for (const auto size : {kL1Size, kL2Size}) {
     for (const auto inverse_null_proportion : std::vector<ArgsType>({100, 0})) {
       bench->Args({static_cast<ArgsType>(size), inverse_null_proportion});
     }
   }
 }
 
-// Add (Array, Array)
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, Int64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, Int32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, Int16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, Int8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, UInt64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, UInt32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, UInt16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, UInt8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, FloatType)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Add, DoubleType)->Apply(SetArgs);
+#define DECLARE_ARITHMETIC_BENCHMARKS(BENCHMARK, OP)             \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, Int64Type)->Apply(SetArgs);  \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, Int32Type)->Apply(SetArgs);  \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, Int16Type)->Apply(SetArgs);  \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, Int8Type)->Apply(SetArgs);   \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, UInt64Type)->Apply(SetArgs); \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, UInt32Type)->Apply(SetArgs); \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, UInt16Type)->Apply(SetArgs); \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, UInt8Type)->Apply(SetArgs);  \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, FloatType)->Apply(SetArgs);  \
+  BENCHMARK_TEMPLATE(BENCHMARK, OP, DoubleType)->Apply(SetArgs)
 
-// Add (Array, Scalar)
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, Int64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, Int32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, Int16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, Int8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, UInt64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, UInt32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, UInt16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, UInt8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, FloatType)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Add, DoubleType)->Apply(SetArgs);
-
-// Subtract (Array, Array)
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, Int64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, Int32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, Int16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, Int8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, UInt64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, UInt32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, UInt16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, UInt8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, FloatType)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Subtract, DoubleType)->Apply(SetArgs);
-
-// Subtract (Array, Scalar)
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, Int64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, Int32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, Int16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, Int8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, UInt64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, UInt32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, UInt16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, UInt8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, FloatType)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Subtract, DoubleType)->Apply(SetArgs);
-
-// Multiply (Array, Array)
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, Int64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, Int32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, Int16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, Int8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, UInt64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, UInt32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, UInt16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, UInt8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, FloatType)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayArrayKernel, Multiply, DoubleType)->Apply(SetArgs);
-
-// Multiply (Array, Scalar)
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, Int64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, Int32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, Int16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, Int8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, UInt64Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, UInt32Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, UInt16Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, UInt8Type)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, FloatType)->Apply(SetArgs);
-BENCHMARK_TEMPLATE(ArrayScalarKernel, Multiply, DoubleType)->Apply(SetArgs);
+DECLARE_ARITHMETIC_BENCHMARKS(ArrayArrayKernel, Add);
+DECLARE_ARITHMETIC_BENCHMARKS(ArrayScalarKernel, Add);
+DECLARE_ARITHMETIC_BENCHMARKS(ArrayArrayKernel, Subtract);
+DECLARE_ARITHMETIC_BENCHMARKS(ArrayScalarKernel, Subtract);
+DECLARE_ARITHMETIC_BENCHMARKS(ArrayArrayKernel, Multiply);
+DECLARE_ARITHMETIC_BENCHMARKS(ArrayScalarKernel, Multiply);
 
 }  // namespace compute
 }  // namespace arrow


### PR DESCRIPTION
Quickly wanted to add a benchmark for the `Add` function to verify that no significant regressions were introduced by https://github.com/apache/arrow/pull/7341

Before:
```
---------------------------------------------------------------------------------------
Benchmark                                Time           CPU Iterations UserCounters...
---------------------------------------------------------------------------------------
AddArrayArrayKernel/32768/10000         18 us         18 us      35892 null_percent=0.01 size=32.768k   1.67854GB/s
AddArrayArrayKernel/32768/100           19 us         19 us      37540 null_percent=1 size=32.768k   1.61941GB/s
AddArrayArrayKernel/32768/10            20 us         20 us      37049 null_percent=10 size=32.768k   1.55599GB/s
AddArrayArrayKernel/32768/2             20 us         20 us      35394 null_percent=50 size=32.768k   1.54512GB/s
AddArrayArrayKernel/32768/1             19 us         19 us      37901 null_percent=100 size=32.768k   1.63153GB/s
```

After:
```
---------------------------------------------------------------------------------------
Benchmark                                Time           CPU Iterations UserCounters...
---------------------------------------------------------------------------------------
AddArrayArrayKernel/32768/10000         19 us         19 us      36704 null_percent=0.01 size=32.768k   1.64619GB/s
AddArrayArrayKernel/32768/100           18 us         18 us      37194 null_percent=1 size=32.768k   1.67588GB/s
AddArrayArrayKernel/32768/10            18 us         18 us      36341 null_percent=10 size=32.768k   1.65205GB/s
AddArrayArrayKernel/32768/2             18 us         18 us      37502 null_percent=50 size=32.768k     1.662GB/s
AddArrayArrayKernel/32768/1             18 us         18 us      38622 null_percent=100 size=32.768k   1.66593GB/s
```

cc @wesm 