### PR TITLE
ARROW-8510: [C++][Datasets] Do not use variant in WritePlan to fix compiler error with VS 2017

### DIFF
--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -162,10 +162,10 @@ Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Write(
   std::vector<std::shared_ptr<FileFragment>> fragments;
   for (size_t i = 0; i < plan.paths.size(); ++i) {
     const auto& op = plan.fragment_or_partition_expressions[i];
-    if (util::holds_alternative<std::shared_ptr<Fragment>>(op)) {
+    if (op.kind() == WritePlan::FragmentOrPartitionExpression::FRAGMENT) {
       auto path = partition_base_dir + plan.paths[i] + extension;
 
-      const auto& input_fragment = util::get<std::shared_ptr<Fragment>>(op);
+      const auto& input_fragment = op.fragment();
       FileSource dest(path, filesystem);
 
       ARROW_ASSIGN_OR_RAISE(


### PR DESCRIPTION
Even without the compiler error on VS 2017 I am not a fan of using variant to solve problems like these (so to me this new code is strictly preferable to the old code), nor exposing a variant in public (or "public") APIs unless it is definitely needed. 