### PR TITLE
ARROW-9022: [C++] Add/Sub/Mul arithmetic kernels with overflow check

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -41,12 +41,16 @@ namespace compute {
 // ----------------------------------------------------------------------
 // Arithmetic
 
-SCALAR_EAGER_BINARY(Add, "add")
-SCALAR_EAGER_BINARY(AddChecked, "add_checked")
-SCALAR_EAGER_BINARY(Subtract, "subtract")
-SCALAR_EAGER_BINARY(SubtractChecked, "subtract_checked")
-SCALAR_EAGER_BINARY(Multiply, "multiply")
-SCALAR_EAGER_BINARY(MultiplyChecked, "multiply_checked")
+#define SCALAR_ARITHMETIC_BINARY(NAME, REGISTRY_NAME, REGISTRY_CHECKED_NAME)           \
+  Result<Datum> NAME(const Datum& left, const Datum& right, ArithmeticOptions options, \
+                     ExecContext* ctx) {                                               \
+    auto func_name = (options.check_overflow) ? REGISTRY_CHECKED_NAME : REGISTRY_NAME; \
+    return CallFunction(func_name, {left, right}, ctx);                                \
+  }
+
+SCALAR_ARITHMETIC_BINARY(Add, "add", "add_checked")
+SCALAR_ARITHMETIC_BINARY(Subtract, "subtract", "subtract_checked")
+SCALAR_ARITHMETIC_BINARY(Multiply, "multiply", "multiply_checked")
 
 // ----------------------------------------------------------------------
 // Set-related operations

--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -42,8 +42,11 @@ namespace compute {
 // Arithmetic
 
 SCALAR_EAGER_BINARY(Add, "add")
+SCALAR_EAGER_BINARY(AddChecked, "add_checked")
 SCALAR_EAGER_BINARY(Subtract, "subtract")
+SCALAR_EAGER_BINARY(SubtractChecked, "subtract_checked")
 SCALAR_EAGER_BINARY(Multiply, "multiply")
+SCALAR_EAGER_BINARY(MultiplyChecked, "multiply_checked")
 
 // ----------------------------------------------------------------------
 // Set-related operations

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -35,6 +35,11 @@ namespace compute {
 
 // ----------------------------------------------------------------------
 
+struct ArithmeticOptions : public FunctionOptions {
+  ArithmeticOptions() : check_overflow(false) {}
+  bool check_overflow;
+};
+
 /// \brief Add two values together. Array values must be the same length. If
 /// either addend is null the result will be null.
 ///
@@ -43,13 +48,9 @@ namespace compute {
 /// \param[in] ctx the function execution context, optional
 /// \return the elementwise sum
 ARROW_EXPORT
-Result<Datum> Add(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
-
-// TODO(kszucs): create add/arithmetic options to select between the underlying kernels
-// and remove these functions
-ARROW_EXPORT
-Result<Datum> AddChecked(const Datum& left, const Datum& right,
-                         ExecContext* ctx = NULLPTR);
+Result<Datum> Add(const Datum& left, const Datum& right,
+                  ArithmeticOptions options = ArithmeticOptions(),
+                  ExecContext* ctx = NULLPTR);
 
 /// \brief Subtract two values. Array values must be the same length. If the
 /// minuend or subtrahend is null the result will be null.
@@ -59,13 +60,9 @@ Result<Datum> AddChecked(const Datum& left, const Datum& right,
 /// \param[in] ctx the function execution context, optional
 /// \return the elementwise difference
 ARROW_EXPORT
-Result<Datum> Subtract(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
-
-// TODO(kszucs): create sub/arithmetic options to select between the underlying kernels
-// and remove these functions
-ARROW_EXPORT
-Result<Datum> SubtractChecked(const Datum& left, const Datum& right,
-                              ExecContext* ctx = NULLPTR);
+Result<Datum> Subtract(const Datum& left, const Datum& right,
+                       ArithmeticOptions options = ArithmeticOptions(),
+                       ExecContext* ctx = NULLPTR);
 
 /// \brief Multiply two values. Array values must be the same length. If either
 /// factor is null the result will be null.
@@ -75,13 +72,9 @@ Result<Datum> SubtractChecked(const Datum& left, const Datum& right,
 /// \param[in] ctx the function execution context, optional
 /// \return the elementwise product
 ARROW_EXPORT
-Result<Datum> Multiply(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
-
-// TODO(kszucs): create mul/arithmetic options to select between the underlying kernels
-// and remove these functions
-ARROW_EXPORT
-Result<Datum> MultiplyChecked(const Datum& left, const Datum& right,
-                              ExecContext* ctx = NULLPTR);
+Result<Datum> Multiply(const Datum& left, const Datum& right,
+                       ArithmeticOptions options = ArithmeticOptions(),
+                       ExecContext* ctx = NULLPTR);
 
 enum CompareOperator {
   EQUAL,

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -45,6 +45,12 @@ namespace compute {
 ARROW_EXPORT
 Result<Datum> Add(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 
+// TODO(kszucs): create add/arithmetic options to select between the underlying kernels
+// and remove these functions
+ARROW_EXPORT
+Result<Datum> AddChecked(const Datum& left, const Datum& right,
+                         ExecContext* ctx = NULLPTR);
+
 /// \brief Subtract two values. Array values must be the same length. If the
 /// minuend or subtrahend is null the result will be null.
 ///
@@ -55,6 +61,12 @@ Result<Datum> Add(const Datum& left, const Datum& right, ExecContext* ctx = NULL
 ARROW_EXPORT
 Result<Datum> Subtract(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
 
+// TODO(kszucs): create sub/arithmetic options to select between the underlying kernels
+// and remove these functions
+ARROW_EXPORT
+Result<Datum> SubtractChecked(const Datum& left, const Datum& right,
+                              ExecContext* ctx = NULLPTR);
+
 /// \brief Multiply two values. Array values must be the same length. If either
 /// factor is null the result will be null.
 ///
@@ -64,6 +76,12 @@ Result<Datum> Subtract(const Datum& left, const Datum& right, ExecContext* ctx =
 /// \return the elementwise product
 ARROW_EXPORT
 Result<Datum> Multiply(const Datum& left, const Datum& right, ExecContext* ctx = NULLPTR);
+
+// TODO(kszucs): create mul/arithmetic options to select between the underlying kernels
+// and remove these functions
+ARROW_EXPORT
+Result<Datum> MultiplyChecked(const Datum& left, const Datum& right,
+                              ExecContext* ctx = NULLPTR);
 
 enum CompareOperator {
   EQUAL,

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -81,7 +81,7 @@ struct AddChecked {
 #else
   template <typename T>
   static enable_if_unsigned_integer<T> Call(KernelContext* ctx, T left, T right) {
-    if (internal::HasAdditionOverflow(left, right)) {
+    if (arrow::internal::HasAdditionOverflow(left, right)) {
       ctx->SetStatus(Status::Invalid("overflow"));
     }
     return left + right;
@@ -91,7 +91,7 @@ struct AddChecked {
   static enable_if_signed_integer<T> Call(KernelContext* ctx, T left, T right) {
     auto unsigned_left = to_unsigned(left);
     auto unsigned_right = to_unsigned(right);
-    if (internal::HasAdditionOverflow(unsigned_left, unsigned_right)) {
+    if (arrow::internal::HasAdditionOverflow(unsigned_left, unsigned_right)) {
       ctx->SetStatus(Status::Invalid("overflow"));
     }
     return unsigned_left + unsigned_right;
@@ -134,7 +134,7 @@ struct SubtractChecked {
 #else
   template <typename T>
   static enable_if_unsigned_integer<T> Call(KernelContext* ctx, T left, T right) {
-    if (internal::HasSubtractionOverflow(left, right)) {
+    if (arrow::internal::HasSubtractionOverflow(left, right)) {
       ctx->SetStatus(Status::Invalid("overflow"));
     }
     return left - right;
@@ -142,7 +142,7 @@ struct SubtractChecked {
 
   template <typename T>
   static enable_if_signed_integer<T> Call(KernelContext* ctx, T left, T right) {
-    if (internal::HasSubtractionOverflow(left, right)) {
+    if (arrow::internal::HasSubtractionOverflow(left, right)) {
       ctx->SetStatus(Status::Invalid("overflow"));
     }
     return to_unsigned(left) - to_unsigned(right);

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_benchmark.cc
@@ -30,7 +30,8 @@ namespace compute {
 
 constexpr auto kSeed = 0x94378165;
 
-using BinaryOp = Result<Datum>(const Datum&, const Datum&, ExecContext*);
+using BinaryOp = Result<Datum>(const Datum&, const Datum&, ArithmeticOptions,
+                               ExecContext*);
 
 template <BinaryOp& Op, typename ArrowType, typename CType = typename ArrowType::c_type>
 static void ArrayScalarKernel(benchmark::State& state) {
@@ -46,7 +47,7 @@ static void ArrayScalarKernel(benchmark::State& state) {
 
   Datum fifteen(CType(15));
   for (auto _ : state) {
-    ABORT_NOT_OK(Op(lhs, fifteen, nullptr).status());
+    ABORT_NOT_OK(Op(lhs, fifteen, ArithmeticOptions(), nullptr).status());
   }
   state.SetItemsProcessed(state.iterations() * array_size);
 }
@@ -66,7 +67,7 @@ static void ArrayArrayKernel(benchmark::State& state) {
       rand.Numeric<ArrowType>(array_size, min, max, args.null_proportion));
 
   for (auto _ : state) {
-    ABORT_NOT_OK(Op(lhs, rhs, nullptr).status());
+    ABORT_NOT_OK(Op(lhs, rhs, ArithmeticOptions(), nullptr).status());
   }
   state.SetItemsProcessed(state.iterations() * array_size);
 }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -223,9 +223,27 @@ TYPED_TEST(TestBinaryArithmeticsSigned, OverflowWraps) {
 
   this->AssertBinop(arrow::compute::Subtract, MakeArray(min, max, min),
                     MakeArray(1, max, max), MakeArray(max, 0, 1));
-
   this->AssertBinop(arrow::compute::Multiply, MakeArray(min, max, max),
                     MakeArray(max, 2, max), MakeArray(min, CType(-2), 1));
+}
+
+TYPED_TEST(TestBinaryArithmeticsIntegral, OverflowRaises) {
+  using CType = typename TestFixture::CType;
+
+  auto min = std::numeric_limits<CType>::lowest();
+  auto max = std::numeric_limits<CType>::max();
+
+  this->SetOverflowCheck(true);
+
+  this->AssertBinopRaises(arrow::compute::Add, MakeArray(min, max, max),
+                          MakeArray(CType(-1), 1, max), "overflow");
+  this->AssertBinopRaises(arrow::compute::Subtract, MakeArray(min, max),
+                          MakeArray(1, max), "overflow");
+  this->AssertBinopRaises(arrow::compute::Subtract, MakeArray(min), MakeArray(max),
+                          "overflow");
+
+  this->AssertBinopRaises(arrow::compute::Multiply, MakeArray(min, max, max),
+                          MakeArray(max, 2, max), "overflow");
 }
 
 TYPED_TEST(TestBinaryArithmeticsSigned, OverflowRaises) {
@@ -236,12 +254,12 @@ TYPED_TEST(TestBinaryArithmeticsSigned, OverflowRaises) {
 
   this->SetOverflowCheck(true);
 
-  this->AssertBinopRaises(arrow::compute::Add, MakeArray(min, max, max),
-                          MakeArray(CType(-1), 1, max), "overflow");
-  this->AssertBinopRaises(arrow::compute::Subtract, MakeArray(min, max, min),
-                          MakeArray(1, max, max), "overflow");
-  this->AssertBinopRaises(arrow::compute::Multiply, MakeArray(min, max, max),
-                          MakeArray(max, 2, max), "overflow");
+  this->AssertBinop(arrow::compute::Multiply, MakeArray(max), MakeArray(-1),
+                    MakeArray(min + 1));
+  this->AssertBinopRaises(arrow::compute::Multiply, MakeArray(max), MakeArray(2),
+                          "overflow");
+  this->AssertBinopRaises(arrow::compute::Multiply, MakeArray(min), MakeArray(-1),
+                          "overflow");
 }
 
 TYPED_TEST(TestBinaryArithmeticsUnsigned, OverflowWraps) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -52,11 +52,6 @@ class TestBinaryArithmetics : public TestBase {
 
   void SetUp() { options_.check_overflow = false; }
 
-  void TearDown() {
-    options_.check_overflow = false;
-    // writer_ = StreamWriter{};
-  }
-
   // (Scalar, Scalar)
   void AssertBinop(BinaryFunction func, CType lhs, CType rhs, CType expected) {
     ASSERT_OK_AND_ASSIGN(auto left, MakeScalar(type_singleton(), lhs));

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -47,8 +47,15 @@ class TestBinaryArithmetics : public TestBase {
     return TypeTraits<ArrowType>::type_singleton();
   }
 
-  using BinaryFunction =
-      std::function<Result<Datum>(const Datum&, const Datum&, ExecContext*)>;
+  using BinaryFunction = std::function<Result<Datum>(const Datum&, const Datum&,
+                                                     ArithmeticOptions, ExecContext*)>;
+
+  void SetUp() { options_.check_overflow = false; }
+
+  void TearDown() {
+    options_.check_overflow = false;
+    // writer_ = StreamWriter{};
+  }
 
   // (Scalar, Scalar)
   void AssertBinop(BinaryFunction func, CType lhs, CType rhs, CType expected) {
@@ -56,7 +63,7 @@ class TestBinaryArithmetics : public TestBase {
     ASSERT_OK_AND_ASSIGN(auto right, MakeScalar(type_singleton(), rhs));
     ASSERT_OK_AND_ASSIGN(auto exp, MakeScalar(type_singleton(), expected));
 
-    ASSERT_OK_AND_ASSIGN(auto actual, func(left, right, nullptr));
+    ASSERT_OK_AND_ASSIGN(auto actual, func(left, right, options_, nullptr));
     AssertScalarsEqual(*exp, *actual.scalar(), true);
   }
 
@@ -67,7 +74,7 @@ class TestBinaryArithmetics : public TestBase {
     auto right = ArrayFromJSON(type_singleton(), rhs);
     auto exp = ArrayFromJSON(type_singleton(), expected);
 
-    ASSERT_OK_AND_ASSIGN(auto actual, func(left, right, nullptr));
+    ASSERT_OK_AND_ASSIGN(auto actual, func(left, right, options_, nullptr));
     ValidateAndAssertApproxEqual(actual.make_array(), expected);
   }
 
@@ -77,7 +84,7 @@ class TestBinaryArithmetics : public TestBase {
     auto left = ArrayFromJSON(type_singleton(), lhs);
     auto right = ArrayFromJSON(type_singleton(), rhs);
 
-    ASSERT_OK_AND_ASSIGN(Datum actual, func(left, right, nullptr));
+    ASSERT_OK_AND_ASSIGN(Datum actual, func(left, right, options_, nullptr));
     ValidateAndAssertApproxEqual(actual.make_array(), expected);
   }
 
@@ -87,7 +94,7 @@ class TestBinaryArithmetics : public TestBase {
     auto right = ArrayFromJSON(type_singleton(), rhs);
 
     EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr(expected_msg),
-                                    func(left, right, nullptr));
+                                    func(left, right, options_, nullptr));
   }
 
   void ValidateAndAssertApproxEqual(std::shared_ptr<Array> actual,
@@ -96,6 +103,10 @@ class TestBinaryArithmetics : public TestBase {
     ASSERT_OK(actual->ValidateFull());
     AssertArraysApproxEqual(*exp, *actual);
   }
+
+  void SetOverflowCheck(bool value = true) { options_.check_overflow = value; }
+
+  ArithmeticOptions options_ = ArithmeticOptions();
 };
 
 template <typename... Elements>
@@ -139,90 +150,58 @@ TYPED_TEST_SUITE(TestBinaryArithmeticsUnsigned, UnsignedIntegerTypes);
 TYPED_TEST_SUITE(TestBinaryArithmeticsFloating, FloatingTypes);
 
 TYPED_TEST(TestBinaryArithmeticsIntegral, Add) {
-  this->AssertBinop(arrow::compute::Add, "[]", "[]", "[]");
-  this->AssertBinop(arrow::compute::Add, "[null]", "[null]", "[null]");
-  this->AssertBinop(arrow::compute::Add, "[3, 2, 6]", "[1, 0, 2]", "[4, 2, 8]");
+  for (auto check_overflow : {false, true}) {
+    this->SetOverflowCheck(check_overflow);
 
-  this->AssertBinop(arrow::compute::Add, "[1, 2, 3, 4, 5, 6, 7]", "[0, 1, 2, 3, 4, 5, 6]",
-                    "[1, 3, 5, 7, 9, 11, 13]");
+    this->AssertBinop(arrow::compute::Add, "[]", "[]", "[]");
+    this->AssertBinop(arrow::compute::Add, "[null]", "[null]", "[null]");
+    this->AssertBinop(arrow::compute::Add, "[3, 2, 6]", "[1, 0, 2]", "[4, 2, 8]");
 
-  this->AssertBinop(arrow::compute::Add, "[10, 12, 4, 50, 50, 32, 11]",
-                    "[2, 0, 6, 1, 5, 3, 4]", "[12, 12, 10, 51, 55, 35, 15]");
+    this->AssertBinop(arrow::compute::Add, "[1, 2, 3, 4, 5, 6, 7]",
+                      "[0, 1, 2, 3, 4, 5, 6]", "[1, 3, 5, 7, 9, 11, 13]");
 
-  this->AssertBinop(arrow::compute::Add, "[null, 1, 3, null, 2, 5]", "[1, 4, 2, 5, 0, 3]",
-                    "[null, 5, 5, null, 2, 8]");
-
-  this->AssertBinop(arrow::compute::Add, 10, "[null, 1, 3, null, 2, 5]",
-                    "[null, 11, 13, null, 12, 15]");
-
-  this->AssertBinop(arrow::compute::Add, 17, 42, 59);
-
-  // TODO(kszucs): consolidate these
-  this->AssertBinop(arrow::compute::AddChecked, "[]", "[]", "[]");
-  this->AssertBinop(arrow::compute::AddChecked, "[null]", "[null]", "[null]");
-  this->AssertBinop(arrow::compute::AddChecked, "[3, 2, 6]", "[1, 0, 2]", "[4, 2, 8]");
-
-  this->AssertBinop(arrow::compute::AddChecked, "[1, 2, 3, 4, 5, 6, 7]",
-                    "[0, 1, 2, 3, 4, 5, 6]", "[1, 3, 5, 7, 9, 11, 13]");
-
-  this->AssertBinop(arrow::compute::AddChecked, "[10, 12, 4, 50, 50, 32, 11]",
-                    "[2, 0, 6, 1, 5, 3, 4]", "[12, 12, 10, 51, 55, 35, 15]");
-
-  this->AssertBinop(arrow::compute::AddChecked, "[null, 1, 3, null, 2, 5]",
-                    "[1, 4, 2, 5, 0, 3]", "[null, 5, 5, null, 2, 8]");
-
-  this->AssertBinop(arrow::compute::AddChecked, 10, "[null, 1, 3, null, 2, 5]",
-                    "[null, 11, 13, null, 12, 15]");
-
-  this->AssertBinop(arrow::compute::AddChecked, 17, 42, 59);
+    this->AssertBinop(arrow::compute::Add, "[10, 12, 4, 50, 50, 32, 11]",
+                      "[2, 0, 6, 1, 5, 3, 4]", "[12, 12, 10, 51, 55, 35, 15]");
+    this->AssertBinop(arrow::compute::Add, "[null, 1, 3, null, 2, 5]",
+                      "[1, 4, 2, 5, 0, 3]", "[null, 5, 5, null, 2, 8]");
+    this->AssertBinop(arrow::compute::Add, 10, "[null, 1, 3, null, 2, 5]",
+                      "[null, 11, 13, null, 12, 15]");
+    this->AssertBinop(arrow::compute::Add, 17, 42, 59);
+  }
 }
 
 TYPED_TEST(TestBinaryArithmeticsIntegral, Sub) {
-  this->AssertBinop(arrow::compute::Subtract, "[]", "[]", "[]");
-  this->AssertBinop(arrow::compute::Subtract, "[null]", "[null]", "[null]");
-  this->AssertBinop(arrow::compute::Subtract, "[3, 2, 6]", "[1, 0, 2]", "[2, 2, 4]");
+  for (auto check_overflow : {false, true}) {
+    this->SetOverflowCheck(check_overflow);
 
-  this->AssertBinop(arrow::compute::Subtract, "[1, 2, 3, 4, 5, 6, 7]",
-                    "[0, 1, 2, 3, 4, 5, 6]", "[1, 1, 1, 1, 1, 1, 1]");
-
-  this->AssertBinop(arrow::compute::Subtract, 10, "[null, 1, 3, null, 2, 5]",
-                    "[null, 9, 7, null, 8, 5]");
-
-  this->AssertBinop(arrow::compute::Subtract, 20, 9, 11);
-
-  // TODO(kszucs): consolidate these
-  this->AssertBinop(arrow::compute::SubtractChecked, "[]", "[]", "[]");
-  this->AssertBinop(arrow::compute::SubtractChecked, "[null]", "[null]", "[null]");
-  this->AssertBinop(arrow::compute::SubtractChecked, "[3, 2, 6]", "[1, 0, 2]",
-                    "[2, 2, 4]");
-
-  this->AssertBinop(arrow::compute::SubtractChecked, "[1, 2, 3, 4, 5, 6, 7]",
-                    "[0, 1, 2, 3, 4, 5, 6]", "[1, 1, 1, 1, 1, 1, 1]");
-
-  this->AssertBinop(arrow::compute::SubtractChecked, 10, "[null, 1, 3, null, 2, 5]",
-                    "[null, 9, 7, null, 8, 5]");
-
-  this->AssertBinop(arrow::compute::SubtractChecked, 20, 9, 11);
+    this->AssertBinop(arrow::compute::Subtract, "[]", "[]", "[]");
+    this->AssertBinop(arrow::compute::Subtract, "[null]", "[null]", "[null]");
+    this->AssertBinop(arrow::compute::Subtract, "[3, 2, 6]", "[1, 0, 2]", "[2, 2, 4]");
+    this->AssertBinop(arrow::compute::Subtract, "[1, 2, 3, 4, 5, 6, 7]",
+                      "[0, 1, 2, 3, 4, 5, 6]", "[1, 1, 1, 1, 1, 1, 1]");
+    this->AssertBinop(arrow::compute::Subtract, 10, "[null, 1, 3, null, 2, 5]",
+                      "[null, 9, 7, null, 8, 5]");
+    this->AssertBinop(arrow::compute::Subtract, 20, 9, 11);
+  }
 }
 
 TYPED_TEST(TestBinaryArithmeticsIntegral, Mul) {
-  this->AssertBinop(arrow::compute::Multiply, "[]", "[]", "[]");
-  this->AssertBinop(arrow::compute::Multiply, "[null]", "[null]", "[null]");
-  this->AssertBinop(arrow::compute::Multiply, "[3, 2, 6]", "[1, 0, 2]", "[3, 0, 12]");
+  for (auto check_overflow : {false, true}) {
+    this->SetOverflowCheck(check_overflow);
 
-  this->AssertBinop(arrow::compute::Multiply, "[1, 2, 3, 4, 5, 6, 7]",
-                    "[0, 1, 2, 3, 4, 5, 6]", "[0, 2, 6, 12, 20, 30, 42]");
-
-  this->AssertBinop(arrow::compute::Multiply, "[7, 6, 5, 4, 3, 2, 1]",
-                    "[6, 5, 4, 3, 2, 1, 0]", "[42, 30, 20, 12, 6, 2, 0]");
-
-  this->AssertBinop(arrow::compute::Multiply, "[null, 1, 3, null, 2, 5]",
-                    "[1, 4, 2, 5, 0, 3]", "[null, 4, 6, null, 0, 15]");
-
-  this->AssertBinop(arrow::compute::Multiply, 3, "[null, 1, 3, null, 2, 5]",
-                    "[null, 3, 9, null, 6, 15]");
-
-  this->AssertBinop(arrow::compute::Multiply, 6, 7, 42);
+    this->AssertBinop(arrow::compute::Multiply, "[]", "[]", "[]");
+    this->AssertBinop(arrow::compute::Multiply, "[null]", "[null]", "[null]");
+    this->AssertBinop(arrow::compute::Multiply, "[3, 2, 6]", "[1, 0, 2]", "[3, 0, 12]");
+    this->AssertBinop(arrow::compute::Multiply, "[1, 2, 3, 4, 5, 6, 7]",
+                      "[0, 1, 2, 3, 4, 5, 6]", "[0, 2, 6, 12, 20, 30, 42]");
+    this->AssertBinop(arrow::compute::Multiply, "[7, 6, 5, 4, 3, 2, 1]",
+                      "[6, 5, 4, 3, 2, 1, 0]", "[42, 30, 20, 12, 6, 2, 0]");
+    this->AssertBinop(arrow::compute::Multiply, "[null, 1, 3, null, 2, 5]",
+                      "[1, 4, 2, 5, 0, 3]", "[null, 4, 6, null, 0, 15]");
+    this->AssertBinop(arrow::compute::Multiply, 3, "[null, 1, 3, null, 2, 5]",
+                      "[null, 3, 9, null, 6, 15]");
+    this->AssertBinop(arrow::compute::Multiply, 6, 7, 42);
+  }
 }
 
 TYPED_TEST(TestBinaryArithmeticsSigned, Add) {
@@ -255,13 +234,13 @@ TYPED_TEST(TestBinaryArithmeticsSigned, OverflowRaises) {
   auto min = std::numeric_limits<CType>::lowest();
   auto max = std::numeric_limits<CType>::max();
 
-  this->AssertBinopRaises(arrow::compute::AddChecked, MakeArray(min, max, max),
+  this->SetOverflowCheck(true);
+
+  this->AssertBinopRaises(arrow::compute::Add, MakeArray(min, max, max),
                           MakeArray(CType(-1), 1, max), "overflow");
-
-  this->AssertBinopRaises(arrow::compute::SubtractChecked, MakeArray(min, max, min),
+  this->AssertBinopRaises(arrow::compute::Subtract, MakeArray(min, max, min),
                           MakeArray(1, max, max), "overflow");
-
-  this->AssertBinopRaises(arrow::compute::MultiplyChecked, MakeArray(min, max, max),
+  this->AssertBinopRaises(arrow::compute::Multiply, MakeArray(min, max, max),
                           MakeArray(max, 2, max), "overflow");
 }
 
@@ -271,6 +250,7 @@ TYPED_TEST(TestBinaryArithmeticsUnsigned, OverflowWraps) {
   auto min = std::numeric_limits<CType>::lowest();
   auto max = std::numeric_limits<CType>::max();
 
+  this->SetOverflowCheck(false);
   this->AssertBinop(arrow::compute::Add, MakeArray(min, max, max),
                     MakeArray(CType(-1), 1, max), MakeArray(max, min, CType(-2)));
 

--- a/cpp/src/arrow/util/int_util.h
+++ b/cpp/src/arrow/util/int_util.h
@@ -100,6 +100,12 @@ bool HasAdditionOverflow(Integer value, Integer addend) {
   return (value > std::numeric_limits<Integer>::max() - addend);
 }
 
+/// Detect addition overflow between integers
+template <typename Integer>
+bool HasSubtractionOverflow(Integer value, Integer minuend) {
+  return (value < minuend);
+}
+
 /// Upcast an integer to the largest possible width (currently 64 bits)
 
 template <typename Integer>


### PR DESCRIPTION
Quick draft for checked arithmetics.

TODOs:
 - [x] more portable overflow checks
 - [x] consolidate the tests
 - [x] add arithmetics options to let the user choose which variant to run (so remove the `*Checked` functions)
