### PR TITLE
ARROW-8942: [R] Detect compression in reading CSV/JSON

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -21,14 +21,17 @@
 
 ## Datasets
 
-* Read datasets directly on S3 by passing a URL like `ds <- open_dataset("s3://...")`. Currently requires a special C++ library build with additional dependencies; that is, this is not available in CRAN releases or in nightly packages.
 * CSV and other text-delimited datasets are now supported
+* Read datasets directly on S3 by passing a URL like `ds <- open_dataset("s3://...")`. Note that this currently requires a special C++ library build with additional dependencies; that is, this is not yet available in CRAN releases or in nightly packages.
+* When reading individual CSV and JSON files, compression is automatically detected from the file extension
 
 ## Other
 
+* Initial support for C++ aggregation methods: `sum()` and `mean()` are implemented for `Array` and `ChunkedArray`
 * Schema metadata is now exposed as a named list, and it can be modified by assignment like `batch$metadata$new_key <- "new value"`
 * Tables and RecordBatches have additional data.frame-like methods, including `dimnames()` and `as.list()`
 * Linux installation: some tweaks to OS detection for binaries, some updates to known installation issues in the vignette.
+* Various streamlining efforts to reduce library size and compile time.
 
 # arrow 0.17.1
 

--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -32,7 +32,11 @@
 #' `parse_options`, `convert_options`, or `read_options` arguments, or you can
 #' use [CsvTableReader] directly for lower-level access.
 #'
-#' @inheritParams make_readable_file
+#' @param file A character file name, `raw` vector, or an Arrow input stream.
+#' If a file name, a memory-mapped Arrow [InputStream] will be opened and
+#' closed when finished; compression will be detected from the file extension
+#' and handled automatically. If an input stream is provided, it will be left
+#' open.
 #' @param delim Single character used to separate fields within a record.
 #' @param quote Single character used to quote strings.
 #' @param escape_double Does the file escape quotes by doubling them?
@@ -114,7 +118,7 @@ read_delim_arrow <- function(file,
     convert_options <- readr_to_csv_convert_options(na, quoted_na)
   }
 
-  if (is.string(file)) {
+  if (!inherits(file, "InputStream")) {
     file <- make_readable_file(file)
     on.exit(file$close())
   }

--- a/r/R/deprecated.R
+++ b/r/R/deprecated.R
@@ -34,18 +34,18 @@ read_record_batch <- function(obj, schema) {
 #' @rdname read_ipc_stream
 #' @export
 #' @include ipc_stream.R
-read_table <- function(x, ...) {
+read_table <- function(file, ...) {
   .Deprecated("read_arrow")
-  read_arrow(x, ..., as_data_frame = FALSE)
+  read_arrow(file, ..., as_data_frame = FALSE)
 }
 
 #' @rdname read_ipc_stream
 #' @export
-read_arrow <- function(x, ...) {
-  if (inherits(x, "raw")) {
-    read_ipc_stream(x, ...)
+read_arrow <- function(file, ...) {
+  if (inherits(file, "raw")) {
+    read_ipc_stream(file, ...)
   } else {
-    read_feather(x, ...)
+    read_feather(file, ...)
   }
 }
 

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -122,8 +122,7 @@ write_feather <- function(x,
 #' This function reads both the original, limited specification of the format
 #' and the version 2 specification, which is the Apache Arrow IPC file format.
 #'
-#' @param file A character file path, a raw vector, or `InputStream`, passed to
-#' `FeatherReader$create()`.
+#' @inheritParams read_ipc_stream
 #' @inheritParams read_delim_arrow
 #' @param ... additional parameters, passed to [FeatherReader$create()][FeatherReader]
 #'

--- a/r/R/io.R
+++ b/r/R/io.R
@@ -220,18 +220,40 @@ mmap_open <- function(path, mode = c("read", "write", "readwrite")) {
 #' Handle a range of possible input sources
 #' @param file A character file name, `raw` vector, or an Arrow input stream
 #' @param mmap Logical: whether to memory-map the file (default `TRUE`)
+#' @param compression If the file is compressed, created a [CompressedInputStream]
+#' with this compression codec, either a [Codec] or the string name of one.
+#' If `NULL` (default) and `file` is a string file name, the function will try
+#' to infer compression from the file extension.
 #' @return An `InputStream` or a subclass of one.
 #' @keywords internal
-make_readable_file <- function(file, mmap = TRUE) {
+make_readable_file <- function(file, mmap = TRUE, compression = NULL) {
   if (is.string(file)) {
+    if (is.null(compression)) {
+      # Infer compression from the file path
+      compression <- detect_compression(file)
+    }
     if (isTRUE(mmap)) {
       file <- mmap_open(file)
     } else {
       file <- ReadableFile$create(file)
+    }
+    if (!identical(compression, "uncompressed")) {
+      file <- CompressedInputStream$create(file, compression)
     }
   } else if (inherits(file, c("raw", "Buffer"))) {
     file <- BufferReader$create(file)
   }
   assert_is(file, "InputStream")
   file
+}
+
+detect_compression <- function(path) {
+  assert_that(is.string(path))
+  switch(tools::file_ext(path),
+    bz2 = "bz2",
+    gz = "gzip",
+    lz4 = "lz4",
+    zst = "zstd",
+    "uncompressed"
+  )
 }

--- a/r/R/ipc_stream.R
+++ b/r/R/ipc_stream.R
@@ -85,8 +85,12 @@ write_to_raw <- function(x, format = c("stream", "file")) {
 #' a file or `InputStream` may contain either. `read_table()`, a wrapper around
 #' `read_arrow()`, is also deprecated
 #'
-#' @param x A character file name, `raw` vector, or an Arrow input stream
-#' @inheritParams read_delim_arrow
+#' @param file A character file name, `raw` vector, or an Arrow input stream.
+#' If a file name, a memory-mapped Arrow [InputStream] will be opened and
+#' closed when finished. If an input stream is provided, it will be left
+#' open.
+#' @param as_data_frame Should the function return a `data.frame` (default) or
+#' an Arrow [Table]?
 #' @param ... extra parameters passed to `read_feather()`.
 #'
 #' @return A `data.frame` if `as_data_frame` is `TRUE` (the default), or an
@@ -94,19 +98,15 @@ write_to_raw <- function(x, format = c("stream", "file")) {
 #' @seealso [read_feather()] for writing IPC files. [RecordBatchReader] for a
 #' lower-level interface.
 #' @export
-read_ipc_stream <- function(x, as_data_frame = TRUE, ...) {
-  if (inherits(x, "raw")) {
-    x <- BufferReader$create(x)
-    on.exit(x$close())
-  } else if (is.string(x)) {
-    x <- ReadableFile$create(x)
-    on.exit(x$close())
+read_ipc_stream <- function(file, as_data_frame = TRUE, ...) {
+  if (!inherits(file, "InputStream")) {
+    file <- make_readable_file(file)
+    on.exit(file$close())
   }
-  assert_is(x, "InputStream")
 
   # TODO: this could take col_select, like the other readers
   # https://issues.apache.org/jira/browse/ARROW-6830
-  out <- RecordBatchStreamReader$create(x)$read_table()
+  out <- RecordBatchStreamReader$create(file)$read_table()
   if (as_data_frame) {
     out <- as.data.frame(out)
   }

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -20,7 +20,7 @@
 #' '[Parquet](https://parquet.apache.org/)' is a columnar storage file format.
 #' This function enables you to read Parquet files into R.
 #'
-#' @inheritParams read_delim_arrow
+#' @inheritParams read_feather
 #' @param props [ParquetReaderProperties]
 #' @param ... Additional arguments passed to `ParquetFileReader$create()`
 #'

--- a/r/man/enums.Rd
+++ b/r/man/enums.Rd
@@ -18,7 +18,7 @@ An object of class \code{TimeUnit::type} (inherits from \code{arrow-enum}) of le
 
 An object of class \code{DateUnit} (inherits from \code{arrow-enum}) of length 2.
 
-An object of class \code{Type::type} (inherits from \code{arrow-enum}) of length 29.
+An object of class \code{Type::type} (inherits from \code{arrow-enum}) of length 30.
 
 An object of class \code{StatusCode} (inherits from \code{arrow-enum}) of length 17.
 

--- a/r/man/make_readable_file.Rd
+++ b/r/man/make_readable_file.Rd
@@ -4,12 +4,17 @@
 \alias{make_readable_file}
 \title{Handle a range of possible input sources}
 \usage{
-make_readable_file(file, mmap = TRUE)
+make_readable_file(file, mmap = TRUE, compression = NULL)
 }
 \arguments{
 \item{file}{A character file name, \code{raw} vector, or an Arrow input stream}
 
 \item{mmap}{Logical: whether to memory-map the file (default \code{TRUE})}
+
+\item{compression}{If the file is compressed, created a \link{CompressedInputStream}
+with this compression codec, either a \link{Codec} or the string name of one.
+If \code{NULL} (default) and \code{file} is a string file name, the function will try
+to infer compression from the file extension.}
 }
 \value{
 An \code{InputStream} or a subclass of one.

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -59,7 +59,11 @@ read_tsv_arrow(
 )
 }
 \arguments{
-\item{file}{A character file name, \code{raw} vector, or an Arrow input stream}
+\item{file}{A character file name, \code{raw} vector, or an Arrow input stream.
+If a file name, a memory-mapped Arrow \link{InputStream} will be opened and
+closed when finished; compression will be detected from the file extension
+and handled automatically. If an input stream is provided, it will be left
+open.}
 
 \item{delim}{Single character used to separate fields within a record.}
 

--- a/r/man/read_feather.Rd
+++ b/r/man/read_feather.Rd
@@ -7,8 +7,10 @@
 read_feather(file, col_select = NULL, as_data_frame = TRUE, ...)
 }
 \arguments{
-\item{file}{A character file path, a raw vector, or \code{InputStream}, passed to
-\code{FeatherReader$create()}.}
+\item{file}{A character file name, \code{raw} vector, or an Arrow input stream.
+If a file name, a memory-mapped Arrow \link{InputStream} will be opened and
+closed when finished. If an input stream is provided, it will be left
+open.}
 
 \item{col_select}{A character vector of column names to keep, as in the
 "select" argument to \code{data.table::fread()}, or a

--- a/r/man/read_ipc_stream.Rd
+++ b/r/man/read_ipc_stream.Rd
@@ -6,14 +6,17 @@
 \alias{read_arrow}
 \title{Read Arrow IPC stream format}
 \usage{
-read_ipc_stream(x, as_data_frame = TRUE, ...)
+read_ipc_stream(file, as_data_frame = TRUE, ...)
 
-read_table(x, ...)
+read_table(file, ...)
 
-read_arrow(x, ...)
+read_arrow(file, ...)
 }
 \arguments{
-\item{x}{A character file name, \code{raw} vector, or an Arrow input stream}
+\item{file}{A character file name, \code{raw} vector, or an Arrow input stream.
+If a file name, a memory-mapped Arrow \link{InputStream} will be opened and
+closed when finished. If an input stream is provided, it will be left
+open.}
 
 \item{as_data_frame}{Should the function return a \code{data.frame} (default) or
 an Arrow \link{Table}?}

--- a/r/man/read_json_arrow.Rd
+++ b/r/man/read_json_arrow.Rd
@@ -7,7 +7,11 @@
 read_json_arrow(file, col_select = NULL, as_data_frame = TRUE, ...)
 }
 \arguments{
-\item{file}{A character file name, \code{raw} vector, or an Arrow input stream}
+\item{file}{A character file name, \code{raw} vector, or an Arrow input stream.
+If a file name, a memory-mapped Arrow \link{InputStream} will be opened and
+closed when finished; compression will be detected from the file extension
+and handled automatically. If an input stream is provided, it will be left
+open.}
 
 \item{col_select}{A character vector of column names to keep, as in the
 "select" argument to \code{data.table::fread()}, or a

--- a/r/man/read_parquet.Rd
+++ b/r/man/read_parquet.Rd
@@ -13,7 +13,10 @@ read_parquet(
 )
 }
 \arguments{
-\item{file}{A character file name, \code{raw} vector, or an Arrow input stream}
+\item{file}{A character file name, \code{raw} vector, or an Arrow input stream.
+If a file name, a memory-mapped Arrow \link{InputStream} will be opened and
+closed when finished. If an input stream is provided, it will be left
+open.}
 
 \item{col_select}{A character vector of column names to keep, as in the
 "select" argument to \code{data.table::fread()}, or a

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -168,3 +168,15 @@ test_that("read_csv_arrow() respects col_select", {
   tib <- read_csv_arrow(tf, col_select = starts_with("Sepal"), as_data_frame = TRUE)
   expect_equal(tib, tibble::tibble(Sepal.Length = iris$Sepal.Length, Sepal.Width = iris$Sepal.Width))
 })
+
+test_that("read_csv_arrow() respects col_select", {
+  tf <- tempfile(fileext = ".csv.gz")
+  on.exit(unlink(tf))
+
+  write.csv(iris, gzfile(tf), row.names = FALSE, quote = FALSE)
+
+  iris$Species <- as.character(iris$Species)
+
+  tab1 <- read_csv_arrow(tf)
+  expect_equivalent(iris, tab1)
+})

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -169,7 +169,7 @@ test_that("read_csv_arrow() respects col_select", {
   expect_equal(tib, tibble::tibble(Sepal.Length = iris$Sepal.Length, Sepal.Width = iris$Sepal.Width))
 })
 
-test_that("read_csv_arrow() respects col_select", {
+test_that("read_csv_arrow() can detect compression from file name", {
   tf <- tempfile(fileext = ".csv.gz")
   on.exit(unlink(tf))
 


### PR DESCRIPTION
This extends `make_readable_file` to sniff compression based on the file extension. The switch statement in `detect_compression` is a translation of the `pyarrow` `_detect_compression` function that does the same.