### PR TITLE
ARROW-9120: [C++] Do not suppress linting on files with "codegen" in their name

### DIFF
--- a/cpp/build-support/lint_exclusions.txt
+++ b/cpp/build-support/lint_exclusions.txt
@@ -1,4 +1,3 @@
-*codegen*
 *_generated*
 *parquet_constants.*
 *parquet_types.*

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -178,8 +178,8 @@ struct ParseStrptime {
 template <typename InputType>
 void StrptimeExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   const auto& options = checked_cast<const StrptimeWrapper*>(ctx->state())->options;
-  codegen::ScalarUnaryNotNullStateful<TimestampType, InputType, ParseStrptime> kernel =
-      ParseStrptime(options);
+  codegen::ScalarUnaryNotNullStateful<TimestampType, InputType, ParseStrptime> kernel{
+      ParseStrptime(options)};
   return kernel.Exec(ctx, batch, out);
 }
 


### PR DESCRIPTION
This is an artifact of the old kernels code where there was a generated file that was not linted. 