### PR TITLE
ARROW-9123: [Python][wheel] Use libzstd.a explicitly

### DIFF
--- a/python/manylinux201x/build_arrow.sh
+++ b/python/manylinux201x/build_arrow.sh
@@ -114,6 +114,7 @@ PATH="${CPYTHON_PATH}/bin:${PATH}" cmake \
     -DARROW_WITH_SNAPPY=ON \
     -DARROW_WITH_ZLIB=ON \
     -DARROW_WITH_ZSTD=ON \
+    -DARROW_ZSTD_USE_SHARED=OFF \
     -DBoost_NAMESPACE=arrow_boost \
     -DBOOST_ROOT=/arrow_boost_dist \
     -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
ARROW_ZSTD_USE_SHARED is introduced by ARROW-9084. We need to set
ARROW_ZSTD_USE_SHARED=OFF explicitly to use static zstd library.