### PR TITLE
ARROW-9124: [Rust][Datafusion] optimize DFParser::parse_sql to take query string as &str

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -129,7 +129,7 @@ impl ExecutionContext {
 
     /// Creates a logical plan
     pub fn create_logical_plan(&mut self, sql: &str) -> Result<LogicalPlan> {
-        let ast = DFParser::parse_sql(String::from(sql))?;
+        let ast = DFParser::parse_sql(sql)?;
 
         match ast {
             DFASTNode::ANSI(ansi) => {

--- a/rust/datafusion/src/sql/parser.rs
+++ b/rust/datafusion/src/sql/parser.rs
@@ -71,9 +71,9 @@ pub struct DFParser {
 
 impl DFParser {
     /// Parse the specified tokens
-    pub fn new(sql: String) -> Result<Self, ParserError> {
+    pub fn new(sql: &str) -> Result<Self, ParserError> {
         let dialect = GenericSqlDialect {};
-        let mut tokenizer = Tokenizer::new(&dialect, &sql);
+        let mut tokenizer = Tokenizer::new(&dialect, sql);
         let tokens = tokenizer.tokenize()?;
         Ok(DFParser {
             parser: Parser::new(tokens),
@@ -81,7 +81,7 @@ impl DFParser {
     }
 
     /// Parse a SQL statement and produce an Abstract Syntax Tree (AST)
-    pub fn parse_sql(sql: String) -> Result<DFASTNode, ParserError> {
+    pub fn parse_sql(sql: &str) -> Result<DFASTNode, ParserError> {
         let mut parser = DFParser::new(sql)?;
         parser.parse()
     }


### PR DESCRIPTION
This avoids an unnecessary heap allocation.