### PR TITLE
ARROW-9126: [C++] Fix building trimmed Boost bundle on Windows

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -176,6 +176,7 @@ jobs:
       ARROW_BUILD_STATIC: OFF
       ARROW_BOOST_USE_SHARED: OFF
       ARROW_VERBOSE_THIRDPARTY_BUILD: OFF
+      BOOST_SOURCE: BUNDLED
       NPROC: 2
     steps:
       - name: Disable Crash Dialogs
@@ -200,7 +201,6 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          export BOOST_ROOT=$BOOST_ROOT_1_72_0
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash

--- a/cpp/build-support/trim-boost.sh
+++ b/cpp/build-support/trim-boost.sh
@@ -40,7 +40,7 @@ BOOST_LIBS="$BOOST_LIBS regex.hpp"
 # Gandiva needs these
 BOOST_LIBS="$BOOST_LIBS multiprecision/cpp_int.hpp"
 # These are for Thrift when Thrift_SOURCE=BUNDLED
-BOOST_LIBS="$BOOST_LIBS algorithm/string.hpp locale.hpp noncopyable.hpp numeric/conversion/cast.hpp scope_exit.hpp scoped_array.hpp shared_array.hpp tokenizer.hpp version.hpp"
+BOOST_LIBS="$BOOST_LIBS algorithm/string.hpp locale.hpp noncopyable.hpp numeric/conversion/cast.hpp scope_exit.hpp typeof/incr_registration_group.hpp scoped_array.hpp shared_array.hpp tokenizer.hpp version.hpp"
 
 if [ ! -d ${BOOST_FILE} ]; then
   curl -L "${BOOST_URL}" > ${BOOST_FILE}.tar.gz

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -597,14 +597,21 @@ macro(build_boost)
   else()
     set(BOOST_CONFIGURE_COMMAND "./bootstrap.sh")
   endif()
+
+  list(APPEND BOOST_BUILD_WITH_LIBRARIES "filesystem" "regex" "system")
+
+  list(JOIN BOOST_BUILD_WITH_LIBRARIES "," BOOST_CONFIGURE_LIBRARIES)
   list(APPEND BOOST_CONFIGURE_COMMAND "--prefix=${BOOST_PREFIX}"
-              "--with-libraries=filesystem,regex,system")
+              "--with-libraries=${BOOST_CONFIGURE_LIBRARIES}")
   set(BOOST_BUILD_COMMAND "./b2" "-j${NPROC}" "link=${BOOST_BUILD_LINK}"
                           "variant=${BOOST_BUILD_VARIANT}")
   if(MSVC)
     string(REGEX
            REPLACE "([0-9])$" ".\\1" BOOST_TOOLSET_MSVC_VERSION ${MSVC_TOOLSET_VERSION})
     list(APPEND BOOST_BUILD_COMMAND "toolset=msvc-${BOOST_TOOLSET_MSVC_VERSION}")
+    # Create --with-<library> flags
+    list(TRANSFORM BOOST_BUILD_WITH_LIBRARIES PREPEND "--with-")
+    list(APPEND BOOST_BUILD_COMMAND ${BOOST_BUILD_WITH_LIBRARIES})
   else()
     list(APPEND BOOST_BUILD_COMMAND "cxxflags=-fPIC")
   endif()

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -598,9 +598,8 @@ macro(build_boost)
     set(BOOST_CONFIGURE_COMMAND "./bootstrap.sh")
   endif()
 
-  list(APPEND BOOST_BUILD_WITH_LIBRARIES "filesystem" "regex" "system")
-
-  list(JOIN BOOST_BUILD_WITH_LIBRARIES "," BOOST_CONFIGURE_LIBRARIES)
+  set(BOOST_BUILD_WITH_LIBRARIES "filesystem" "regex" "system")
+  string(REPLACE ";" "," BOOST_CONFIGURE_LIBRARIES "${BOOST_BUILD_WITH_LIBRARIES}")
   list(APPEND BOOST_CONFIGURE_COMMAND "--prefix=${BOOST_PREFIX}"
               "--with-libraries=${BOOST_CONFIGURE_LIBRARIES}")
   set(BOOST_BUILD_COMMAND "./b2" "-j${NPROC}" "link=${BOOST_BUILD_LINK}"
@@ -609,9 +608,11 @@ macro(build_boost)
     string(REGEX
            REPLACE "([0-9])$" ".\\1" BOOST_TOOLSET_MSVC_VERSION ${MSVC_TOOLSET_VERSION})
     list(APPEND BOOST_BUILD_COMMAND "toolset=msvc-${BOOST_TOOLSET_MSVC_VERSION}")
-    # Create --with-<library> flags
-    list(TRANSFORM BOOST_BUILD_WITH_LIBRARIES PREPEND "--with-")
-    list(APPEND BOOST_BUILD_COMMAND ${BOOST_BUILD_WITH_LIBRARIES})
+    set(BOOST_BUILD_WITH_LIBRARIES_MSVC)
+    foreach(_BOOST_LIB ${BOOST_BUILD_WITH_LIBRARIES})
+      list(APPEND BOOST_BUILD_WITH_LIBRARIES_MSVC "--with-${_BOOST_LIB}")
+    endforeach()
+    list(APPEND BOOST_BUILD_COMMAND ${BOOST_BUILD_WITH_LIBRARIES_MSVC})
   else()
     list(APPEND BOOST_BUILD_COMMAND "cxxflags=-fPIC")
   endif()


### PR DESCRIPTION
On Linux, the configuration step of Boost allows selecting a subset of the libraries being built using the `--with-libraries=` flag. However, this flag does not exist in the configure script on Windows, so the bundle building step is actually building all Boost libraries, including those being trimmed:
```
Component configuration:

 - atomic : building
 - chrono : building
 - container : building
 - date_time : building
 - exception : building
 - filesystem : building
 - headers : building
 - iostreams : building
 - locale : building
 - log : building
 - mpi : building
 - program_options : building
 - python : building
 - random : building
 - regex : building
 - serialization : building
 - system : building
 - test : building
 - thread : building
 - timer : building
 - wave : building
```

To select only the necessary libraries on Windows, we can provide the `--with-<library>` flag to `./b2`. Doing so helped me pass the boost building step but the thrift building step failed. This time, it was due to the header file `typeof/incr_registration_group.hpp` missing in Boost (this file is only required on Windows but not on Linux); thus, added that header file to the `trim-boost.sh` script. 

I verified that this can now build on both Windows and Linux with the commands:
```
mkdir build
cd build
cmake .. -DARROW_PARQUET=ON
cmake --build .
```

On Linux:
```
Component configuration:

    - atomic                   : not building
    - chrono                   : not building
    - container                : not building
    - date_time                : not building
    - exception                : not building
    - filesystem               : building
    - headers                  : not building
    - iostreams                : not building
    - locale                   : not building
    - log                      : not building
    - mpi                      : not building
    - program_options          : not building
    - python                   : not building
    - random                   : not building
    - regex                    : building
    - serialization            : not building
    - system                   : building
    - test                     : not building
    - thread                   : not building
    - timer                    : not building
    - wave                     : not building
```

On Windows:
```
Component configuration:

    - atomic                   : not building
    - chrono                   : not building
    - container                : not building
    - date_time                : not building
    - exception                : not building
    - filesystem               : building
    - headers                  : not building
    - iostreams                : not building
    - locale                   : not building
    - log                      : not building
    - mpi                      : not building
    - program_options          : not building
    - python                   : not building
    - random                   : not building
    - regex                    : building
    - serialization            : not building
    - system                   : building
    - test                     : not building
    - thread                   : not building
    - timer                    : not building
    - wave                     : not building
```