### PR TITLE
ARROW-9116: [C++][FOLLOWUP] Add 0-length test for BaseBinaryArray::total_values_length

### DIFF
--- a/cpp/src/arrow/array/array_binary.h
+++ b/cpp/src/arrow/array/array_binary.h
@@ -105,8 +105,12 @@ class BaseBinaryArray : public FlatArray {
   /// referenced by this array. If the array has been sliced then this may be
   /// less than the size of the data buffer (data_->buffers[2]).
   offset_type total_values_length() const {
-    return raw_value_offsets_[data_->length + data_->offset] -
-           raw_value_offsets_[data_->offset];
+    if (data_->length > 0) {
+      return raw_value_offsets_[data_->length + data_->offset] -
+             raw_value_offsets_[data_->offset];
+    } else {
+      return 0;
+    }
   }
 
  protected:

--- a/cpp/src/arrow/array/array_binary_test.cc
+++ b/cpp/src/arrow/array/array_binary_test.cc
@@ -119,6 +119,11 @@ class TestStringArray : public ::testing::Test {
     offset_type sliced_values_length =
         checked_cast<const ArrayType&>(*arr.Slice(3)).total_values_length();
     ASSERT_EQ(sliced_values_length, static_cast<offset_type>(9));
+
+    // Zero-length array is a special case
+    offset_type zero_size_length =
+        checked_cast<const ArrayType&>(*arr.Slice(0, 0)).total_values_length();
+    ASSERT_EQ(zero_size_length, static_cast<offset_type>(0));
   }
 
   void TestType() {


### PR DESCRIPTION
This also protects against the offsets buffer being null. 