### PR TITLE
ARROW-8779: [R] Implement conversion to List<Struct>

### DIFF
--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -204,7 +204,8 @@ struct VectorToArrayConverter {
   template <typename T>
   arrow::enable_if_t<arrow::is_struct_type<T>::value, Status> Visit(const T& type) {
     using BuilderType = typename TypeTraits<T>::BuilderType;
-    ARROW_RETURN_IF(!Rf_inherits(x, "data.frame"), Status::RError("Expecting a data frame"));
+    ARROW_RETURN_IF(!Rf_inherits(x, "data.frame"),
+                    Status::RError("Expecting a data frame"));
 
     auto* struct_builder = checked_cast<BuilderType*>(builder);
 

--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -1242,6 +1242,10 @@ std::shared_ptr<arrow::Array> Array__from_vector(
   // factors only when type has been inferred
   if (type->id() == Type::DICTIONARY) {
     if (type_inferred || arrow::r::CheckCompatibleFactor(x, type)) {
+      // TODO: use VectorToArrayConverter instead, but it does not appear to work
+      // correctly with ordered dictionary yet
+      //
+      // return VectorToArrayConverter::Visit(x, type);
       return arrow::r::MakeFactorArray(x, type);
     }
 

--- a/r/src/array_from_vector.cpp
+++ b/r/src/array_from_vector.cpp
@@ -201,6 +201,11 @@ struct VectorToArrayConverter {
     return Status::OK();
   }
 
+  template <typename T>
+  arrow::enable_if_t<arrow::is_struct_type<T>::value, Status> Visit(const T& type) {
+    return Status::OK();
+  }
+
   Status Visit(const arrow::DataType& type) {
     return Status::NotImplemented("Converting vector to arrow type ", type.ToString(),
                                   " not implemented");

--- a/r/src/arrow_rcpp.h
+++ b/r/src/arrow_rcpp.h
@@ -15,12 +15,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <RcppCommon.h>
+
 #include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
-
-#include <RcppCommon.h>
 #undef Free
 
 namespace arrow {

--- a/r/src/arrow_vctrs.h
+++ b/r/src/arrow_vctrs.h
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace vctrs {
+R_len_t short_vec_size(SEXP);
+}

--- a/r/src/imports.cpp
+++ b/r/src/imports.cpp
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <Rdefines.h>
+
+namespace vctrs {
+struct vctrs_api_ptrs_t {
+  R_len_t (*short_vec_size)(SEXP x);
+
+  vctrs_api_ptrs_t() {
+    short_vec_size = (R_len_t(*)(SEXP))R_GetCCallable("vctrs", "short_vec_size");
+  }
+};
+
+const vctrs_api_ptrs_t& vctrs_api() {
+  static vctrs_api_ptrs_t ptrs;
+  return ptrs;
+}
+
+R_len_t short_vec_size(SEXP x) { return vctrs_api().short_vec_size(x); }
+
+}  // namespace vctrs

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -445,6 +445,9 @@ test_that("Array$create() handles vector -> list arrays (ARROW-7662)", {
   expect_array_roundtrip(list(character(0)), list_of(utf8()))
   expect_array_roundtrip(list("itsy", c("bitsy", "spider"), c("is")), list_of(utf8()))
   expect_array_roundtrip(list("itsy", character(0), c("bitsy", "spider", NA_character_), c("is")), list_of(utf8()))
+
+  # struct
+  expect_array_roundtrip(list(tibble::tibble(a = integer(0))), list_of(struct(a = int32())))
 })
 
 test_that("Array$create() should have helpful error on lists with type hint", {

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -446,6 +446,10 @@ test_that("Array$create() handles vector -> list arrays (ARROW-7662)", {
   expect_array_roundtrip(list("itsy", c("bitsy", "spider"), c("is")), list_of(utf8()))
   expect_array_roundtrip(list("itsy", character(0), c("bitsy", "spider", NA_character_), c("is")), list_of(utf8()))
 
+  # factor
+  expect_array_roundtrip(list(factor(c("b", "a"), levels = c("a", "b"))), list_of(dictionary(int8(), utf8())))
+  expect_array_roundtrip(list(factor(NA, levels = c("a", "b"))), list_of(dictionary(int8(), utf8())))
+
   # struct
   expect_array_roundtrip(
     list(tibble::tibble(a = integer(0), b = integer(0), c = character(0), d = logical(0))),

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -447,7 +447,14 @@ test_that("Array$create() handles vector -> list arrays (ARROW-7662)", {
   expect_array_roundtrip(list("itsy", character(0), c("bitsy", "spider", NA_character_), c("is")), list_of(utf8()))
 
   # struct
-  expect_array_roundtrip(list(tibble::tibble(a = integer(0))), list_of(struct(a = int32())))
+  expect_array_roundtrip(
+    list(tibble::tibble(a = integer(0), b = integer(0), c = character(0), d = logical(0))),
+    list_of(struct(a = int32(), b = int32(), c = utf8(), d = bool()))
+  )
+  expect_array_roundtrip(
+    list(tibble::tibble(a = list(integer()))),
+    list_of(struct(a = list_of(int32())))
+  )
 })
 
 test_that("Array$create() should have helpful error on lists with type hint", {

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -455,6 +455,9 @@ test_that("Array$create() handles vector -> list arrays (ARROW-7662)", {
     list(tibble::tibble(a = list(integer()))),
     list_of(struct(a = list_of(int32())))
   )
+  # degenerated data frame
+  df <- structure(list(x = 1:2, y = 1), class = "data.frame", row.names = 1:2)
+  expect_error(Array$create(list(df)))
 })
 
 test_that("Array$create() should have helpful error on lists with type hint", {


### PR DESCRIPTION
``` r
library(arrow)
#> 
#> Attaching package: 'arrow'
#> The following object is masked from 'package:utils':
#> 
#>     timestamp
Array$create(list(data.frame(a = 1:3, b = 11:13)))
#> ListArray
#> <list<item: struct<a: int32, b: int32>>>
#> [
#>   -- is_valid: all not null
#>   -- child 0 type: int32
#>     [
#>       1,
#>       2,
#>       3
#>     ]
#>   -- child 1 type: int32
#>     [
#>       11,
#>       12,
#>       13
#>     ]
#> ]
```

<sup>Created on 2020-06-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

However does not yet deal with the original issue: 

``` r
library(arrow)
#> 
#> Attaching package: 'arrow'
#> The following object is masked from 'package:utils':
#> 
#>     timestamp

nrows <- 1:3
df <- tibble::tibble(
    id = 1L,
    data = 
      list(
        tibble::tibble(
          a = letters[nrows],
          b = as.integer(nrows),
          c = as.factor(a),
          d = b/2
        )
      )
  )
Table$create(df)
#> Error in Table__from_dots(dots, schema): NotImplemented: Converting vector to arrow type dictionary<values=string, indices=int8, ordered=0> not implemented
```

<sup>Created on 2020-06-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>