### PR TITLE
ARROW-9105: [C++][Dataset][Python] Pass an explicit schema to split_by_row_groups

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -25,6 +25,7 @@
 #include "arrow/dataset/filter.h"
 #include "arrow/dataset/test_util.h"
 #include "arrow/record_batch.h"
+#include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
@@ -439,8 +440,9 @@ TEST_F(TestParquetFileFormat, PredicatePushdownRowGroupFragments) {
   opts_ = ScanOptions::Make(reader->schema());
   ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
 
-  CountRowGroupsInFragment(fragment, internal::Iota(static_cast<int>(kNumRowGroups)),
-                           *scalar(true));
+  auto all_row_groups = internal::Iota(static_cast<int>(kNumRowGroups));
+  CountRowGroupsInFragment(fragment, all_row_groups, *scalar(true));
+  CountRowGroupsInFragment(fragment, all_row_groups, "not here"_ == 0);
 
   for (int i = 0; i < kNumRowGroups; ++i) {
     CountRowGroupsInFragment(fragment, {i}, "i64"_ == int64_t(i + 1));
@@ -458,6 +460,10 @@ TEST_F(TestParquetFileFormat, PredicatePushdownRowGroupFragments) {
   CountRowGroupsInFragment(fragment, {1, 3},
                            "i64"_ == int64_t(2) or "i64"_ == int64_t(4));
 
+  // TODO(bkietz): better Assume support for InExpression
+  // auto set = ArrayFromJSON(int64(), "[2, 4]");
+  // CountRowGroupsInFragment(fragment, {1, 3}, "i64"_.In(set));
+
   CountRowGroupsInFragment(fragment, {0, 1, 2, 3, 4}, "i64"_ < int64_t(6));
 
   CountRowGroupsInFragment(fragment, internal::Iota(5, static_cast<int>(kNumRowGroups)),
@@ -465,6 +471,24 @@ TEST_F(TestParquetFileFormat, PredicatePushdownRowGroupFragments) {
 
   CountRowGroupsInFragment(fragment, {5, 6},
                            "i64"_ >= int64_t(6) and "i64"_ < int64_t(8));
+}
+
+TEST_F(TestParquetFileFormat, PredicatePushdownRowGroupFragmentsUsingStringColumn) {
+  auto table =
+      TableFromJSON(schema({field("x", utf8())}), {
+                                                      R"([{"x": "a"}, {"x": "a"}])",
+                                                      R"([{"x": "b"}, {"x": "b"}])",
+                                                      R"([{"x": "c"}, {"x": "c"}])",
+                                                      R"([{"x": "a"}, {"x": "b"}])",
+                                                  });
+  TableBatchReader reader(*table);
+  auto source = GetFileSource(&reader);
+
+  opts_ = ScanOptions::Make(reader.schema());
+  ASSERT_OK_AND_ASSIGN(auto fragment, format_->MakeFragment(*source));
+
+  // TODO(bkietz): support strings in StatisticsAsScalars
+  // CountRowGroupsInFragment(fragment, {0, 3}, "x"_ == "a");
 }
 
 TEST_F(TestParquetFileFormat, ExplicitRowGroupSelection) {

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -699,6 +699,30 @@ def test_fragments_parquet_row_groups(tempdir):
 
 @pytest.mark.pandas
 @pytest.mark.parquet
+def test_fragments_parquet_row_groups_predicate(tempdir):
+    table, dataset = _create_dataset_for_fragments(tempdir, chunk_size=2)
+
+    fragment = list(dataset.get_fragments())[0]
+    assert fragment.partition_expression.equals(ds.field('part') == 'a')
+
+    # predicate may reference a partition field not present in the
+    # physical_schema if an explicit schema is provided to split_by_row_group
+
+    # filter matches partition_expression: all row groups
+    row_group_fragments = list(
+        fragment.split_by_row_group(ds.field('part') == 'a',
+                                    schema=dataset.schema))
+    assert len(row_group_fragments) == 2
+
+    # filter contradicts partition_expression: no row groups
+    row_group_fragments = list(
+        fragment.split_by_row_group(ds.field('part') == 'b',
+                                    schema=dataset.schema))
+    assert len(row_group_fragments) == 0
+
+
+@pytest.mark.pandas
+@pytest.mark.parquet
 def test_fragments_parquet_row_groups_reconstruct(tempdir):
     table, dataset = _create_dataset_for_fragments(tempdir, chunk_size=2)
 


### PR DESCRIPTION
This allows row group `predicate`s to reference fields not present in the fragment's physical schema (for example a virtual partition column). Also applies the fragment's partition expression to the predicate so *no* row groups will be yielded if the partition expression contradicts the predicate.