### PR TITLE
ARROW-9144: [CI] OSS-Fuzz build fails because recent changes in the google repository

### DIFF
--- a/.github/workflows/cpp_cron.yml
+++ b/.github/workflows/cpp_cron.yml
@@ -138,7 +138,7 @@ jobs:
         working-directory: ../oss-fuzz
         run: |
           python3 -m pip install setuptools
-          python3 -m pip install -r infra/travis/requirements.txt
+          python3 -m pip install -r infra/ci/requirements.txt
       - name: Build image
         shell: bash
         working-directory: ../oss-fuzz


### PR DESCRIPTION
The `infra/travis` directory was recently [renamed](https://github.com/google/oss-fuzz/tree/master/infra/ci) to `infra/ci` in the google repository.