### PR TITLE
ARROW-8965: [Python][Doc] Pyarrow documentation for pip nightlies references 404'd location

### DIFF
--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -83,5 +83,5 @@ Install the development version from an `alternative PyPI
 
 .. code-block:: bash
 
-    pip install --extra-index-url https://repo.fury.io/arrow-nightlies/ \
+    pip install --extra-index-url https://pypi.fury.io/arrow-nightlies/ \
         --pre pyarrow


### PR DESCRIPTION
It was recently renamed by gemfury. `www` queries work only with the new `pypi` subdomain, but both urls work when installing wheels via pip, so we don't need to rerender the documentation.