### PR TITLE
ARROW-9130: [Python] Add deprecation wrapper for pyarrow.compat and guid function for Dask

### DIFF
--- a/python/pyarrow/compat.py
+++ b/python/pyarrow/compat.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# flake8: noqa
+
+import pyarrow.util as util
+import warnings
+
+
+warnings.warn("pyarrow.compat has been deprecated and will be removed in a "
+              "future release", FutureWarning)
+
+
+guid = util._deprecate_api("compat.guid", "util.guid",
+                           util.guid, "1.0.0")


### PR DESCRIPTION
This fixes the import error but the integration tests fail with other errors

https://gist.github.com/wesm/312a26a9fcb2521756410251f6672e99