### PR TITLE
ARROW-9143: [C++] Do not produce internal ArrayData with kUnknownNullCount in RecordBatch::Slice if source ArrayData::null_count is set to 0

### DIFF
--- a/cpp/src/arrow/array/array_base.cc
+++ b/cpp/src/arrow/array/array_base.cc
@@ -200,7 +200,7 @@ bool Array::RangeEquals(int64_t start_idx, int64_t end_idx, int64_t other_start_
 }
 
 std::shared_ptr<Array> Array::Slice(int64_t offset, int64_t length) const {
-  return MakeArray(std::make_shared<ArrayData>(data_->Slice(offset, length)));
+  return MakeArray(data_->Slice(offset, length));
 }
 
 std::shared_ptr<Array> Array::Slice(int64_t offset) const {

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -486,8 +486,7 @@ std::shared_ptr<Array> StructArray::field(int i) const {
   if (!result) {
     std::shared_ptr<ArrayData> field_data;
     if (data_->offset != 0 || data_->child_data[i]->length != data_->length) {
-      field_data = std::make_shared<ArrayData>(
-          data_->child_data[i]->Slice(data_->offset, data_->length));
+      field_data = data_->child_data[i]->Slice(data_->offset, data_->length);
     } else {
       field_data = data_->child_data[i];
     }
@@ -515,7 +514,7 @@ Result<ArrayVector> StructArray::Flatten(MemoryPool* pool) const {
 
     // Need to adjust for parent offset
     if (data_->offset != 0 || data_->length != child_data->length) {
-      *child_data = child_data->Slice(data_->offset, data_->length);
+      child_data = child_data->Slice(data_->offset, data_->length);
     }
     std::shared_ptr<Buffer> child_null_bitmap = child_data->buffers[0];
     const int64_t child_offset = child_data->offset;
@@ -711,7 +710,7 @@ std::shared_ptr<Array> UnionArray::field(int i) const {
       // (for dense unions, the need to lookup through the offsets
       //  makes this unnecessary)
       if (data_->offset != 0 || child_data->length > data_->length) {
-        *child_data = child_data->Slice(data_->offset, data_->length);
+        child_data = child_data->Slice(data_->offset, data_->length);
       }
     }
     result = MakeArray(child_data);

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -81,18 +81,18 @@ std::shared_ptr<ArrayData> ArrayData::Make(const std::shared_ptr<DataType>& type
   return std::make_shared<ArrayData>(type, length, null_count, offset);
 }
 
-ArrayData ArrayData::Slice(int64_t off, int64_t len) const {
+std::shared_ptr<ArrayData> ArrayData::Slice(int64_t off, int64_t len) const {
   ARROW_CHECK_LE(off, length) << "Slice offset greater than array length";
   len = std::min(length - off, len);
   off += offset;
 
-  auto copy = *this;
-  copy.length = len;
-  copy.offset = off;
+  auto copy = this->Copy();
+  copy->length = len;
+  copy->offset = off;
   if (null_count == length) {
-    copy.null_count = len;
+    copy->null_count = len;
   } else {
-    copy.null_count = null_count != 0 ? kUnknownNullCount : 0;
+    copy->null_count = null_count != 0 ? kUnknownNullCount : 0;
   }
   return copy;
 }

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -196,7 +196,7 @@ struct ARROW_EXPORT ArrayData {
   }
 
   // Construct a zero-copy slice of the data with the indicated offset and length
-  ArrayData Slice(int64_t offset, int64_t length) const;
+  std::shared_ptr<ArrayData> Slice(int64_t offset, int64_t length) const;
 
   void SetNullCount(int64_t v) { null_count.store(v); }
 

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -643,11 +643,7 @@ class ScalarExecutor : public FunctionExecutorImpl<ScalarFunction> {
         if (batch.length < batch_iterator_->length()) {
           // If this is a partial execution, then we write into a slice of
           // preallocated_
-          //
-          // XXX: ArrayData::Slice not returning std::shared_ptr<ArrayData> is
-          // a nuisance
-          out->value = std::make_shared<ArrayData>(
-              preallocated_->Slice(batch_start_position, batch.length));
+          out->value = preallocated_->Slice(batch_start_position, batch.length);
         } else {
           // Otherwise write directly into preallocated_. The main difference
           // computationally (versus the Slice approach) is that the null_count

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -121,14 +121,7 @@ class SimpleRecordBatch : public RecordBatch {
     std::vector<std::shared_ptr<ArrayData>> arrays;
     arrays.reserve(num_columns());
     for (const auto& field : columns_) {
-      int64_t col_length = std::min(field->length - offset, length);
-      int64_t col_offset = field->offset + offset;
-
-      auto new_data = std::make_shared<ArrayData>(*field);
-      new_data->length = col_length;
-      new_data->offset = col_offset;
-      new_data->null_count = kUnknownNullCount;
-      arrays.emplace_back(new_data);
+      arrays.emplace_back(field->Slice(offset, length));
     }
     int64_t num_rows = std::min(num_rows_ - offset, length);
     return std::make_shared<SimpleRecordBatch>(schema_, num_rows, std::move(arrays));

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1352,6 +1352,10 @@ def test_dictionary_encode_sliced():
         assert result.num_chunks == 0
         assert result.type == expected.type
 
+    # ARROW-9143 dictionary_encode after slice was segfaulting
+    array = pa.array(['foo', 'bar', 'baz'])
+    array.slice(1).dictionary_encode()
+
 
 def test_dictionary_encode_zero_length():
     # User-facing experience of ARROW-7008


### PR DESCRIPTION
This field being non-zero caused code paths that assumed `buffers[0]` to be non-null. 

I also changed `ArrayData::Slice` to return a shared_ptr since there's little useful about a stack-allocated ArrayData