### PR TITLE
ARROW-9141: [R] Update cross-package documentation links

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
     utils,
     vctrs
 Roxygen: list(markdown = TRUE, r6 = FALSE, load = "source")
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.0.9000
 VignetteBuilder: knitr
 Suggests:
     dplyr,

--- a/r/man/CsvReadOptions.Rd
+++ b/r/man/CsvReadOptions.Rd
@@ -58,7 +58,7 @@ generate a row of missing values (if \code{FALSE})?
 \item \code{check_utf8} Logical: check UTF8 validity of string columns? (default \code{TRUE})
 \item \code{null_values} character vector of recognized spellings for null values.
 Analogous to the \code{na.strings} argument to
-\code{\link[utils:read.csv]{read.csv()}} or \code{na} in \code{readr::read_csv()}.
+\code{\link[utils:read.table]{read.csv()}} or \code{na} in \code{readr::read_csv()}.
 \item \code{strings_can_be_null} Logical: can string / binary columns have
 null values? Similar to the \code{quoted_na} argument to \code{readr::read_csv()}.
 (default \code{FALSE})

--- a/r/man/reexports.Rd
+++ b/r/man/reexports.Rd
@@ -21,8 +21,8 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{bit64}{\code{\link[bit64]{print.integer64}}, \code{\link[bit64]{str.integer64}}}
+  \item{bit64}{\code{\link[bit64:bit64-package]{print.integer64}}, \code{\link[bit64:bit64-package]{str.integer64}}}
 
-  \item{tidyselect}{\code{\link[tidyselect]{contains}}, \code{\link[tidyselect]{ends_with}}, \code{\link[tidyselect]{everything}}, \code{\link[tidyselect]{last_col}}, \code{\link[tidyselect]{matches}}, \code{\link[tidyselect]{num_range}}, \code{\link[tidyselect]{one_of}}, \code{\link[tidyselect]{starts_with}}}
+  \item{tidyselect}{\code{\link[tidyselect:starts_with]{contains}}, \code{\link[tidyselect:starts_with]{ends_with}}, \code{\link[tidyselect]{everything}}, \code{\link[tidyselect:everything]{last_col}}, \code{\link[tidyselect:starts_with]{matches}}, \code{\link[tidyselect:starts_with]{num_range}}, \code{\link[tidyselect]{one_of}}, \code{\link[tidyselect]{starts_with}}}
 }}
 

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -170,6 +170,7 @@ test_that("read_csv_arrow() respects col_select", {
 })
 
 test_that("read_csv_arrow() can detect compression from file name", {
+  skip_if_not_available("gzip")
   tf <- tempfile(fileext = ".csv.gz")
   on.exit(unlink(tf))
 


### PR DESCRIPTION
Allegedly this is an old policy newly enforced in `R CMD check --as-cran`. See discussion at https://stat.ethz.ch/pipermail/r-package-devel/2020q2/005562.html