### PR TITLE
ARROW-8969: [C++] Reduce binary size of kernels/scalar_compare.cc.o by reusing more kernels between types, operators

### DIFF
--- a/cpp/src/arrow/compute/kernel.cc
+++ b/cpp/src/arrow/compute/kernel.cc
@@ -112,42 +112,61 @@ std::shared_ptr<TypeMatcher> SameTypeId(Type::type type_id) {
   return std::make_shared<SameTypeIdMatcher>(type_id);
 }
 
-class TimestampUnitMatcher : public TypeMatcher {
- public:
-  explicit TimestampUnitMatcher(TimeUnit::type accepted_unit)
-      : accepted_unit_(accepted_unit) {}
-
-  bool Matches(const DataType& type) const override {
-    if (type.id() != Type::TIMESTAMP) {
-      return false;
-    }
-    const auto& ts_type = checked_cast<const TimestampType&>(type);
-    return ts_type.unit() == accepted_unit_;
+#define TIME_UNIT_MATCHER(NAME)                                         \
+  class NAME##TypeUnitMatcher : public TypeMatcher {                    \
+   public:                                                              \
+    explicit NAME##TypeUnitMatcher(TimeUnit::type accepted_unit)        \
+        : accepted_unit_(accepted_unit) {}                              \
+                                                                        \
+    bool Matches(const DataType& type) const override {                 \
+      if (type.id() != NAME##Type::type_id) {                           \
+        return false;                                                   \
+      }                                                                 \
+      const auto& subtype = checked_cast<const NAME##Type&>(type);      \
+      return subtype.unit() == accepted_unit_;                          \
+    }                                                                   \
+                                                                        \
+    bool Equals(const TypeMatcher& other) const override {              \
+      if (this == &other) {                                             \
+        return true;                                                    \
+      }                                                                 \
+      auto casted = dynamic_cast<const NAME##TypeUnitMatcher*>(&other); \
+      if (casted == nullptr) {                                          \
+        return false;                                                   \
+      }                                                                 \
+      return this->accepted_unit_ == casted->accepted_unit_;            \
+    }                                                                   \
+                                                                        \
+    std::string ToString() const override {                             \
+      std::stringstream ss;                                             \
+      ss << NAME##Type::type_name() << "("                              \
+         << ::arrow::internal::ToString(accepted_unit_) << ")";         \
+      return ss.str();                                                  \
+    }                                                                   \
+                                                                        \
+   private:                                                             \
+    TimeUnit::type accepted_unit_;                                      \
   }
 
-  bool Equals(const TypeMatcher& other) const override {
-    if (this == &other) {
-      return true;
-    }
-    auto casted = dynamic_cast<const TimestampUnitMatcher*>(&other);
-    if (casted == nullptr) {
-      return false;
-    }
-    return this->accepted_unit_ == casted->accepted_unit_;
-  }
+TIME_UNIT_MATCHER(Timestamp);
+TIME_UNIT_MATCHER(Time32);
+TIME_UNIT_MATCHER(Time64);
+TIME_UNIT_MATCHER(Duration);
 
-  std::string ToString() const override {
-    std::stringstream ss;
-    ss << "timestamp(" << ::arrow::internal::ToString(accepted_unit_) << ")";
-    return ss.str();
-  }
+std::shared_ptr<TypeMatcher> TimestampTypeUnit(TimeUnit::type unit) {
+  return std::make_shared<TimestampTypeUnitMatcher>(unit);
+}
 
- private:
-  TimeUnit::type accepted_unit_;
-};
+std::shared_ptr<TypeMatcher> Time32TypeUnit(TimeUnit::type unit) {
+  return std::make_shared<Time32TypeUnitMatcher>(unit);
+}
 
-std::shared_ptr<TypeMatcher> TimestampUnit(TimeUnit::type unit) {
-  return std::make_shared<TimestampUnitMatcher>(unit);
+std::shared_ptr<TypeMatcher> Time64TypeUnit(TimeUnit::type unit) {
+  return std::make_shared<Time64TypeUnitMatcher>(unit);
+}
+
+std::shared_ptr<TypeMatcher> DurationTypeUnit(TimeUnit::type unit) {
+  return std::make_shared<DurationTypeUnitMatcher>(unit);
 }
 
 class IntegerMatcher : public TypeMatcher {

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -148,7 +148,10 @@ ARROW_EXPORT std::shared_ptr<TypeMatcher> SameTypeId(Type::type type_id);
 
 /// \brief Match any TimestampType instance having the same unit, but the time
 /// zones can be different.
-ARROW_EXPORT std::shared_ptr<TypeMatcher> TimestampUnit(TimeUnit::type unit);
+ARROW_EXPORT std::shared_ptr<TypeMatcher> TimestampTypeUnit(TimeUnit::type unit);
+ARROW_EXPORT std::shared_ptr<TypeMatcher> Time32TypeUnit(TimeUnit::type unit);
+ARROW_EXPORT std::shared_ptr<TypeMatcher> Time64TypeUnit(TimeUnit::type unit);
+ARROW_EXPORT std::shared_ptr<TypeMatcher> DurationTypeUnit(TimeUnit::type unit);
 
 // \brief Match any integer type
 ARROW_EXPORT std::shared_ptr<TypeMatcher> Integer();

--- a/cpp/src/arrow/compute/kernel_test.cc
+++ b/cpp/src/arrow/compute/kernel_test.cc
@@ -45,23 +45,23 @@ TEST(TypeMatcher, SameTypeId) {
   ASSERT_FALSE(matcher->Equals(*match::SameTypeId(Type::TIMESTAMP)));
 }
 
-TEST(TypeMatcher, TimestampUnit) {
-  std::shared_ptr<TypeMatcher> matcher = match::TimestampUnit(TimeUnit::MILLI);
+TEST(TypeMatcher, TimestampTypeUnit) {
+  std::shared_ptr<TypeMatcher> matcher = match::TimestampTypeUnit(TimeUnit::MILLI);
 
   ASSERT_TRUE(matcher->Matches(*timestamp(TimeUnit::MILLI)));
   ASSERT_TRUE(matcher->Matches(*timestamp(TimeUnit::MILLI, "utc")));
   ASSERT_FALSE(matcher->Matches(*timestamp(TimeUnit::SECOND)));
 
   // Check ToString representation
-  ASSERT_EQ("timestamp(s)", match::TimestampUnit(TimeUnit::SECOND)->ToString());
-  ASSERT_EQ("timestamp(ms)", match::TimestampUnit(TimeUnit::MILLI)->ToString());
-  ASSERT_EQ("timestamp(us)", match::TimestampUnit(TimeUnit::MICRO)->ToString());
-  ASSERT_EQ("timestamp(ns)", match::TimestampUnit(TimeUnit::NANO)->ToString());
+  ASSERT_EQ("timestamp(s)", match::TimestampTypeUnit(TimeUnit::SECOND)->ToString());
+  ASSERT_EQ("timestamp(ms)", match::TimestampTypeUnit(TimeUnit::MILLI)->ToString());
+  ASSERT_EQ("timestamp(us)", match::TimestampTypeUnit(TimeUnit::MICRO)->ToString());
+  ASSERT_EQ("timestamp(ns)", match::TimestampTypeUnit(TimeUnit::NANO)->ToString());
 
   // Equals implementation
   ASSERT_TRUE(matcher->Equals(*matcher));
-  ASSERT_TRUE(matcher->Equals(*match::TimestampUnit(TimeUnit::MILLI)));
-  ASSERT_FALSE(matcher->Equals(*match::TimestampUnit(TimeUnit::MICRO)));
+  ASSERT_TRUE(matcher->Equals(*match::TimestampTypeUnit(TimeUnit::MILLI)));
+  ASSERT_FALSE(matcher->Equals(*match::TimestampTypeUnit(TimeUnit::MICRO)));
 }
 
 // ----------------------------------------------------------------------
@@ -135,7 +135,7 @@ TEST(InputType, Constructors) {
   ASSERT_EQ("array[Type::DECIMAL]", ty2_array.ToString());
   ASSERT_EQ("scalar[Type::DECIMAL]", ty2_scalar.ToString());
 
-  InputType ty7(match::TimestampUnit(TimeUnit::MICRO));
+  InputType ty7(match::TimestampTypeUnit(TimeUnit::MICRO));
   ASSERT_EQ("any[timestamp(us)]", ty7.ToString());
 }
 

--- a/cpp/src/arrow/compute/kernel_test.cc
+++ b/cpp/src/arrow/compute/kernel_test.cc
@@ -46,11 +46,14 @@ TEST(TypeMatcher, SameTypeId) {
 }
 
 TEST(TypeMatcher, TimestampTypeUnit) {
-  std::shared_ptr<TypeMatcher> matcher = match::TimestampTypeUnit(TimeUnit::MILLI);
+  auto matcher = match::TimestampTypeUnit(TimeUnit::MILLI);
+  auto matcher2 = match::Time32TypeUnit(TimeUnit::MILLI);
 
   ASSERT_TRUE(matcher->Matches(*timestamp(TimeUnit::MILLI)));
   ASSERT_TRUE(matcher->Matches(*timestamp(TimeUnit::MILLI, "utc")));
   ASSERT_FALSE(matcher->Matches(*timestamp(TimeUnit::SECOND)));
+  ASSERT_FALSE(matcher->Matches(*time32(TimeUnit::MILLI)));
+  ASSERT_TRUE(matcher2->Matches(*time32(TimeUnit::MILLI)));
 
   // Check ToString representation
   ASSERT_EQ("timestamp(s)", match::TimestampTypeUnit(TimeUnit::SECOND)->ToString());
@@ -62,6 +65,7 @@ TEST(TypeMatcher, TimestampTypeUnit) {
   ASSERT_TRUE(matcher->Equals(*matcher));
   ASSERT_TRUE(matcher->Equals(*match::TimestampTypeUnit(TimeUnit::MILLI)));
   ASSERT_FALSE(matcher->Equals(*match::TimestampTypeUnit(TimeUnit::MICRO)));
+  ASSERT_FALSE(matcher->Equals(*match::Time32TypeUnit(TimeUnit::MILLI)));
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -31,11 +31,12 @@ void ExecFail(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   ctx->SetStatus(Status::NotImplemented("This kernel is malformed"));
 }
 
-void BinaryExecFlipped(KernelContext* ctx, ArrayKernelExec exec, const ExecBatch& batch,
-                       Datum* out) {
-  ExecBatch flipped_batch = batch;
-  std::swap(flipped_batch.values[0], flipped_batch.values[1]);
-  exec(ctx, flipped_batch, out);
+ArrayKernelExec MakeFlippedBinaryExec(ArrayKernelExec exec) {
+  return [exec](KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    ExecBatch flipped_batch = batch;
+    std::swap(flipped_batch.values[0], flipped_batch.values[1]);
+    exec(ctx, flipped_batch, out);
+  };
 }
 
 std::vector<std::shared_ptr<DataType>> g_signed_int_types;

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -502,6 +502,8 @@ struct ScalarUnaryNotNullStateful {
   struct ArrayExec<Type, enable_if_base_binary<Type>> {
     static void Exec(const ThisType& functor, KernelContext* ctx, const ExecBatch& batch,
                      Datum* out) {
+      // TODO: This code path is currently inadequately tested.
+
       using offset_type = typename Type::offset_type;
       const ArrayData& arg0 = *batch[0].array();
       typename TypeTraits<Type>::ArrayType arg0_boxed(batch[0].array());
@@ -511,26 +513,30 @@ struct ScalarUnaryNotNullStateful {
       TypedBufferBuilder<uint8_t> data_builder;
 
       KERNEL_RETURN_IF_ERROR(ctx, offset_builder.Reserve(arg0.length + 1));
-      offset_type offset = 0;
+      offset_type out_offset = 0;
 
       const offset_type* in_offsets = arg0_boxed.raw_value_offsets();
       const uint8_t* in_data = arg0.buffers[2]->data();
       offset_type cur_offset = in_offsets[0];
       for (int64_t i = 0; i < arg0.length; ++i) {
+        offset_builder.UnsafeAppend(out_offset);
         offset_type next_offset = in_offsets[i + 1];
         if (arg0_boxed.IsValid(i)) {
           auto val_size = next_offset - cur_offset;
           auto val =
               functor.op.Call(ctx, util::string_view(in_data + cur_offset, val_size));
           if (std::is_same<offset_type, int32_t>::value &&
-              (static_cast<int64_t>(offset) + val_size > kBinaryMemoryLimit)) {
+              (static_cast<int64_t>(out_offset) + val_size > kBinaryMemoryLimit)) {
             ctx->SetStatus(Status::OutOfMemory("Overflowed 32-bit binary builder"));
             return;
           }
           KERNEL_RETURN_IF_ERROR(ctx, data_builder.Append(val.data(), val_size));
+          out_offset += val_size;
         }
         cur_offset = next_offset;
       }
+      // Last offset
+      offset_builder.UnsafeAppend(out_offset);
       if (!ctx->HasError()) {
         KERNEL_RETURN_IF_ERROR(ctx, offset_builder.Finish(&out_arr->buffers[1]));
         KERNEL_RETURN_IF_ERROR(ctx, data_builder.Finish(&out_arr->buffers[2]));

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -150,7 +150,7 @@ struct UnboxScalar;
 
 template <typename Type>
 struct UnboxScalar<Type, enable_if_has_c_type<Type>> {
-  using ScalarType = typename TypeTraits<Type>::ScalarType;
+  using ScalarType = ::arrow::internal::PrimitiveScalar<typename Type::StorageType>;
   static typename Type::c_type Unbox(const Datum& datum) {
     return datum.scalar_as<ScalarType>().value;
   }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
@@ -52,13 +52,12 @@ std::vector<std::shared_ptr<CastFunction>> GetBooleanCasts() {
 
   for (const auto& ty : NumericTypes()) {
     ArrayKernelExec exec =
-        codegen::Numeric<codegen::ScalarUnary, BooleanType, IsNonZero>(*ty);
+        GenerateNumeric<codegen::ScalarUnary, BooleanType, IsNonZero>(*ty);
     DCHECK_OK(func->AddKernel(ty->id(), {ty}, boolean(), exec));
   }
   for (const auto& ty : BaseBinaryTypes()) {
-    ArrayKernelExec exec =
-        codegen::BaseBinary<codegen::ScalarUnaryNotNull, BooleanType, ParseBooleanString>(
-            *ty);
+    ArrayKernelExec exec = GenerateVarBinaryBase<codegen::ScalarUnaryNotNull, BooleanType,
+                                                 ParseBooleanString>(*ty);
     DCHECK_OK(func->AddKernel(ty->id(), {ty}, boolean(), exec));
   }
   return {func};

--- a/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
@@ -484,13 +484,13 @@ void AddPrimitiveNumberCasts(const std::shared_ptr<DataType>& out_ty,
 
   // Cast from other numbers
   for (const std::shared_ptr<DataType>& in_ty : NumericTypes()) {
-    auto exec = codegen::Numeric<CastFunctor, OutType>(*in_ty);
+    auto exec = GenerateNumeric<CastFunctor, OutType>(*in_ty);
     DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, out_ty, exec));
   }
 
   // Cast from other strings
   for (const std::shared_ptr<DataType>& in_ty : BaseBinaryTypes()) {
-    auto exec = codegen::BaseBinary<CastFunctor, OutType>(*in_ty);
+    auto exec = GenerateVarBinaryBase<CastFunctor, OutType>(*in_ty);
     DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, out_ty, exec));
   }
 }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -139,7 +139,7 @@ void AddNumberToStringCasts(std::shared_ptr<DataType> out_ty, CastFunction* func
 
   for (const std::shared_ptr<DataType>& in_ty : NumericTypes()) {
     DCHECK_OK(func->AddKernel(in_ty->id(), {in_ty}, out_ty,
-                              codegen::Numeric<CastFunctor, OutType>(*in_ty),
+                              GenerateNumeric<CastFunctor, OutType>(*in_ty),
                               NullHandling::COMPUTED_NO_PREALLOCATE));
   }
 }

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -91,11 +91,34 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name) {
 
   // Add timestamp kernels
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
-    InputType in_type(match::TimestampUnit(unit));
+    InputType in_type(match::TimestampTypeUnit(unit));
     auto exec =
         codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int64());
     DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
+
+  // Duration
+  for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
+    InputType in_type(match::DurationTypeUnit(unit));
+    auto exec =
+        codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int64());
+    DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
+  }
+
+  // Time32 and Time64
+  for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI}) {
+    InputType in_type(match::Time32TypeUnit(unit));
+    auto exec =
+        codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int32());
+    DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
+  }
+  for (auto unit : {TimeUnit::MICRO, TimeUnit::NANO}) {
+    InputType in_type(match::Time64TypeUnit(unit));
+    auto exec =
+        codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int64());
+    DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
+  }
+
   for (const std::shared_ptr<DataType>& ty : BaseBinaryTypes()) {
     auto exec =
         codegen::BaseBinary<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -26,6 +26,8 @@ using util::string_view;
 namespace compute {
 namespace internal {
 
+namespace {
+
 struct Equal {
   template <typename T>
   static constexpr bool Call(KernelContext*, const T& left, const T& right) {
@@ -37,20 +39,6 @@ struct NotEqual {
   template <typename T>
   static constexpr bool Call(KernelContext*, const T& left, const T& right) {
     return left != right;
-  }
-};
-
-struct Greater {
-  template <typename T>
-  static constexpr bool Call(KernelContext*, const T& left, const T& right) {
-    return left > right;
-  }
-};
-
-struct GreaterEqual {
-  template <typename T>
-  static constexpr bool Call(KernelContext*, const T& left, const T& right) {
-    return left >= right;
   }
 };
 
@@ -68,33 +56,45 @@ struct LessEqual {
   }
 };
 
+// Implement Greater, GreaterEqual by flipping arguments to Less, LessEqual
+
+template <typename Op>
+void AddIntegerCompare(const std::shared_ptr<DataType>& ty, ScalarFunction* func) {
+  auto exec =
+      codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
+  DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));
+}
+
 template <typename InType, typename Op>
-void AddCompare(const std::shared_ptr<DataType>& ty, ScalarFunction* func) {
-  ArrayKernelExec exec = codegen::ScalarBinaryEqualTypes<BooleanType, InType, Op>::Exec;
-  DCHECK_OK(func->AddKernel({ty, ty}, boolean(), exec));
+void AddGenericCompare(const std::shared_ptr<DataType>& ty, ScalarFunction* func) {
+  DCHECK_OK(
+      func->AddKernel({ty, ty}, boolean(),
+                      codegen::ScalarBinaryEqualTypes<BooleanType, InType, Op>::Exec));
 }
 
 template <typename Op>
-void AddTimestampComparisons(ScalarFunction* func) {
-  ArrayKernelExec exec =
-      codegen::ScalarBinaryEqualTypes<BooleanType, TimestampType, Op>::Exec;
-  for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
-    InputType in_type(match::TimestampUnit(unit));
-    DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), exec));
-  }
-}
-
-template <typename Op>
-void MakeCompareFunction(std::string name, FunctionRegistry* registry) {
+std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Binary());
 
   DCHECK_OK(func->AddKernel(
       {boolean(), boolean()}, boolean(),
       codegen::ScalarBinary<BooleanType, BooleanType, BooleanType, Op>::Exec));
 
-  for (const std::shared_ptr<DataType>& ty : NumericTypes()) {
-    auto exec = codegen::Numeric<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
-    DCHECK_OK(func->AddKernel({ty, ty}, boolean(), exec));
+  for (const std::shared_ptr<DataType>& ty : IntTypes()) {
+    AddIntegerCompare<Op>(ty, func.get());
+  }
+  AddIntegerCompare<Op>(date32(), func.get());
+  AddIntegerCompare<Op>(date64(), func.get());
+
+  AddGenericCompare<FloatType, Op>(float32(), func.get());
+  AddGenericCompare<DoubleType, Op>(float64(), func.get());
+
+  // Add timestamp kernels
+  for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
+    InputType in_type(match::TimestampUnit(unit));
+    auto exec =
+        codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int64());
+    DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), exec));
   }
   for (const std::shared_ptr<DataType>& ty : BaseBinaryTypes()) {
     auto exec =
@@ -102,24 +102,36 @@ void MakeCompareFunction(std::string name, FunctionRegistry* registry) {
     DCHECK_OK(func->AddKernel({ty, ty}, boolean(), exec));
   }
 
-  // Temporal types requires some care because cross-unit comparisons with
-  // everything but DATE32 and DATE64 are not implemented yet
-  AddCompare<Date32Type, Op>(date32(), func.get());
-  AddCompare<Date64Type, Op>(date64(), func.get());
-  AddTimestampComparisons<Op>(func.get());
-
   // TODO: Leave time32, time64, and duration for follow up work
 
-  DCHECK_OK(registry->AddFunction(std::move(func)));
+  return func;
 }
 
+std::shared_ptr<ScalarFunction> MakeFlippedFunction(std::string name,
+                                                    const ScalarFunction& func) {
+  auto flipped_func = std::make_shared<ScalarFunction>(name, Arity::Binary());
+  for (const ScalarKernel* kernel : func.kernels()) {
+    ScalarKernel flipped_kernel = *kernel;
+    flipped_kernel.exec = MakeFlippedBinaryExec(kernel->exec);
+    DCHECK_OK(flipped_func->AddKernel(std::move(flipped_kernel)));
+  }
+  return flipped_func;
+}
+
+}  // namespace
+
 void RegisterScalarComparison(FunctionRegistry* registry) {
-  MakeCompareFunction<Equal>("equal", registry);
-  MakeCompareFunction<NotEqual>("not_equal", registry);
-  MakeCompareFunction<Less>("less", registry);
-  MakeCompareFunction<LessEqual>("less_equal", registry);
-  MakeCompareFunction<Greater>("greater", registry);
-  MakeCompareFunction<GreaterEqual>("greater_equal", registry);
+  DCHECK_OK(registry->AddFunction(MakeCompareFunction<Equal>("equal")));
+  DCHECK_OK(registry->AddFunction(MakeCompareFunction<NotEqual>("not_equal")));
+
+  auto less = MakeCompareFunction<Less>("less");
+  auto greater = MakeFlippedFunction("greater", *less);
+  auto less_equal = MakeCompareFunction<LessEqual>("less_equal");
+  auto greater_equal = MakeFlippedFunction("greater_equal", *less_equal);
+  DCHECK_OK(registry->AddFunction(std::move(less)));
+  DCHECK_OK(registry->AddFunction(std::move(less_equal)));
+  DCHECK_OK(registry->AddFunction(std::move(greater)));
+  DCHECK_OK(registry->AddFunction(std::move(greater_equal)));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -56,12 +56,12 @@ struct GreaterEqual {
   }
 };
 
-// Implement Greater, GreaterEqual by flipping arguments to Less, LessEqual
+// Implement Less, LessEqual by flipping arguments to Greater, GreaterEqual
 
 template <typename Op>
 void AddIntegerCompare(const std::shared_ptr<DataType>& ty, ScalarFunction* func) {
   auto exec =
-      codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
+      GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
   DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));
 }
 
@@ -92,40 +92,38 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name) {
   // Add timestamp kernels
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
     InputType in_type(match::TimestampTypeUnit(unit));
-    auto exec =
-        codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int64());
+    auto exec = GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(
+        int64());
     DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
 
   // Duration
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
     InputType in_type(match::DurationTypeUnit(unit));
-    auto exec =
-        codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int64());
+    auto exec = GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(
+        int64());
     DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
 
   // Time32 and Time64
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI}) {
     InputType in_type(match::Time32TypeUnit(unit));
-    auto exec =
-        codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int32());
+    auto exec = GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(
+        int32());
     DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
   for (auto unit : {TimeUnit::MICRO, TimeUnit::NANO}) {
     InputType in_type(match::Time64TypeUnit(unit));
-    auto exec =
-        codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int64());
+    auto exec = GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(
+        int64());
     DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
 
   for (const std::shared_ptr<DataType>& ty : BaseBinaryTypes()) {
     auto exec =
-        codegen::BaseBinary<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
+        GenerateVarBinaryBase<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
     DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));
   }
-
-  // TODO: Leave time32, time64, and duration for follow up work
 
   return func;
 }

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -42,17 +42,17 @@ struct NotEqual {
   }
 };
 
-struct Less {
+struct Greater {
   template <typename T>
   static constexpr bool Call(KernelContext*, const T& left, const T& right) {
-    return left < right;
+    return left > right;
   }
 };
 
-struct LessEqual {
+struct GreaterEqual {
   template <typename T>
   static constexpr bool Call(KernelContext*, const T& left, const T& right) {
-    return left <= right;
+    return left >= right;
   }
 };
 
@@ -147,10 +147,12 @@ void RegisterScalarComparison(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(MakeCompareFunction<Equal>("equal")));
   DCHECK_OK(registry->AddFunction(MakeCompareFunction<NotEqual>("not_equal")));
 
-  auto less = MakeCompareFunction<Less>("less");
-  auto greater = MakeFlippedFunction("greater", *less);
-  auto less_equal = MakeCompareFunction<LessEqual>("less_equal");
-  auto greater_equal = MakeFlippedFunction("greater_equal", *less_equal);
+  // Note: benchmarking suggests that >, >= perform better than <, <=
+  auto greater = MakeCompareFunction<Greater>("greater");
+  auto greater_equal = MakeCompareFunction<GreaterEqual>("greater_equal");
+
+  auto less = MakeFlippedFunction("less", *greater);
+  auto less_equal = MakeFlippedFunction("less_equal", *greater_equal);
   DCHECK_OK(registry->AddFunction(std::move(less)));
   DCHECK_OK(registry->AddFunction(std::move(less_equal)));
   DCHECK_OK(registry->AddFunction(std::move(greater)));

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -147,7 +147,6 @@ void RegisterScalarComparison(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(MakeCompareFunction<Equal>("equal")));
   DCHECK_OK(registry->AddFunction(MakeCompareFunction<NotEqual>("not_equal")));
 
-  // Note: benchmarking suggests that >, >= perform better than <, <=
   auto greater = MakeCompareFunction<Greater>("greater");
   auto greater_equal = MakeCompareFunction<GreaterEqual>("greater_equal");
 

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -94,12 +94,12 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name) {
     InputType in_type(match::TimestampUnit(unit));
     auto exec =
         codegen::IntegerBased<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(int64());
-    DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), exec));
+    DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
   for (const std::shared_ptr<DataType>& ty : BaseBinaryTypes()) {
     auto exec =
         codegen::BaseBinary<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
-    DCHECK_OK(func->AddKernel({ty, ty}, boolean(), exec));
+    DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));
   }
 
   // TODO: Leave time32, time64, and duration for follow up work

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -377,33 +377,26 @@ void DoRandomCompare(const std::shared_ptr<DataType>& type) {
   using ScalarType = typename TypeTraits<Type>::ScalarType;
   using CType = typename TypeTraits<Type>::CType;
   auto rand = random::RandomArrayGenerator(0x5416447);
-  for (size_t i = 3; i < 10; i++) {
-    for (auto null_probability : {0.0, 0.01, 0.1, 0.25, 0.5, 1.0}) {
-      for (auto op : {EQUAL, NOT_EQUAL, GREATER, LESS_EQUAL}) {
-        const int64_t length = static_cast<int64_t>(1ULL << i);
-        auto data =
-            rand.Numeric<typename Type::StorageType>(length, 0, 100, null_probability);
+  const int64_t length = 1000;
+  for (auto null_probability : {0.0, 0.01, 0.1, 0.25, 0.5, 1.0}) {
+    for (auto op : {EQUAL, NOT_EQUAL, GREATER, LESS_EQUAL}) {
+      auto data =
+          rand.Numeric<typename Type::PhysicalType>(length, 0, 100, null_probability);
 
-        // Create view of data as the type (e.g. timestamp)
-        auto array = Datum(*data->View(type));
-        auto fifty = Datum(std::make_shared<ScalarType>(CType(50), type));
-        auto options = CompareOptions(op);
-        ValidateCompare<Type>(options, array, fifty);
-        ValidateCompare<Type>(options, fifty, array);
-      }
-    }
-  }
-  for (size_t i = 3; i < 5; i++) {
-    for (auto null_probability : {0.0, 0.01, 0.1, 0.25, 0.5, 1.0}) {
-      for (auto op : {EQUAL, NOT_EQUAL, GREATER, LESS_EQUAL}) {
-        const int64_t length = static_cast<int64_t>(1ULL << i);
-        auto lhs = rand.Numeric<typename Type::StorageType>(length << i, 0, 100,
-                                                            null_probability);
-        auto rhs = rand.Numeric<typename Type::StorageType>(length << i, 0, 100,
-                                                            null_probability);
-        auto options = CompareOptions(op);
-        ValidateCompare<Type>(options, *lhs->View(type), *rhs->View(type));
-      }
+      auto data1 =
+          rand.Numeric<typename Type::PhysicalType>(length, 0, 100, null_probability);
+      auto data2 =
+          rand.Numeric<typename Type::PhysicalType>(length, 0, 100, null_probability);
+
+      // Create view of data as the type (e.g. timestamp)
+      auto array1 = Datum(*data1->View(type));
+      auto array2 = Datum(*data2->View(type));
+      auto fifty = Datum(std::make_shared<ScalarType>(CType(50), type));
+      auto options = CompareOptions(op);
+
+      ValidateCompare<Type>(options, array1, fifty);
+      ValidateCompare<Type>(options, fifty, array1);
+      ValidateCompare<Type>(options, array1, array2);
     }
   }
 }

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -269,7 +269,7 @@ void AddSortingKernels(VectorKernel base, VectorFunction* func) {
   }
   for (const auto& ty : BaseBinaryTypes()) {
     base.signature = KernelSignature::Make({InputType::Array(ty)}, uint64());
-    base.exec = codegen::BaseBinary<ExecTemplate, UInt64Type>(*ty);
+    base.exec = codegen::BaseBinarySpecific<ExecTemplate, UInt64Type>(*ty);
     DCHECK_OK(func->AddKernel(base));
   }
 }

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -264,12 +264,12 @@ template <template <typename...> class ExecTemplate>
 void AddSortingKernels(VectorKernel base, VectorFunction* func) {
   for (const auto& ty : NumericTypes()) {
     base.signature = KernelSignature::Make({InputType::Array(ty)}, uint64());
-    base.exec = codegen::Numeric<ExecTemplate, UInt64Type>(*ty);
+    base.exec = GenerateNumeric<ExecTemplate, UInt64Type>(*ty);
     DCHECK_OK(func->AddKernel(base));
   }
   for (const auto& ty : BaseBinaryTypes()) {
     base.signature = KernelSignature::Make({InputType::Array(ty)}, uint64());
-    base.exec = codegen::BaseBinarySpecific<ExecTemplate, UInt64Type>(*ty);
+    base.exec = GenerateVarBinary<ExecTemplate, UInt64Type>(*ty);
     DCHECK_OK(func->AddKernel(base));
   }
 }

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -105,6 +105,11 @@ struct ARROW_EXPORT PrimitiveScalar : public Scalar {
     ARROW_CHECK_EQ(this->type->id(), T::type_id);
   }
 
+  explicit PrimitiveScalar(std::shared_ptr<DataType> type)
+      : Scalar(std::move(type), false) {
+    ARROW_CHECK_EQ(this->type->id(), T::type_id);
+  }
+
   explicit PrimitiveScalar(ValueType value)
       : PrimitiveScalar(value, TypeTraits<T>::type_singleton()) {}
 
@@ -238,18 +243,8 @@ struct ARROW_EXPORT FixedSizeBinaryScalar : public BinaryScalar {
 };
 
 template <typename T>
-struct ARROW_EXPORT TemporalScalar : public Scalar {
-  using Scalar::Scalar;
-  using TypeClass = T;
-  using ValueType = typename T::c_type;
-
-  TemporalScalar(ValueType value, std::shared_ptr<DataType> type)
-      : Scalar(std::move(type), true), value(value) {}
-
-  explicit TemporalScalar(std::shared_ptr<DataType> type)
-      : Scalar(std::move(type), false) {}
-
-  ValueType value;
+struct ARROW_EXPORT TemporalScalar : public internal::PrimitiveScalar<T> {
+  using internal::PrimitiveScalar<T>::PrimitiveScalar;
 };
 
 template <typename T>

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -115,8 +115,7 @@ struct ARROW_EXPORT BooleanScalar : public internal::PrimitiveScalar<BooleanType
   using Base = internal::PrimitiveScalar<BooleanType, bool>;
   using Base::Base;
 
-  explicit BooleanScalar(bool value)
-    : Base(value, boolean()) {}
+  explicit BooleanScalar(bool value) : Base(value, boolean()) {}
 
   BooleanScalar() : Base(boolean()) {}
 };
@@ -266,7 +265,7 @@ struct ARROW_EXPORT DateScalar : public TemporalScalar<T> {
   using ValueType = typename TemporalScalar<T>::ValueType;
 
   explicit DateScalar(ValueType value)
-    : TemporalScalar<T>(std::move(value), TypeTraits<T>::type_singleton()) {}
+      : TemporalScalar<T>(std::move(value), TypeTraits<T>::type_singleton()) {}
   DateScalar() : TemporalScalar<T>(TypeTraits<T>::type_singleton()) {}
 };
 

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -246,10 +246,10 @@ struct ARROW_EXPORT FixedSizeBinaryScalar : public BinaryScalar {
   explicit FixedSizeBinaryScalar(std::shared_ptr<DataType> type) : BinaryScalar(type) {}
 };
 
-template <typename T, typename StorageType = typename T::StorageType,
+template <typename T, typename PhysicalType = typename T::PhysicalType,
           typename Enable = void>
-struct ARROW_EXPORT TemporalScalar : internal::PrimitiveScalar<StorageType> {
-  using internal::PrimitiveScalar<StorageType>::PrimitiveScalar;
+struct ARROW_EXPORT TemporalScalar : internal::PrimitiveScalar<PhysicalType> {
+  using internal::PrimitiveScalar<PhysicalType>::PrimitiveScalar;
   using TypeClass = T;
 };
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -485,7 +485,7 @@ class ARROW_EXPORT CTypeImpl : public BASE {
  public:
   static constexpr Type::type type_id = TYPE_ID;
   using c_type = C_TYPE;
-  using StorageType = DERIVED;
+  using PhysicalType = DERIVED;
 
   CTypeImpl() : BASE(TYPE_ID) {}
 
@@ -1125,7 +1125,7 @@ class ARROW_EXPORT Date32Type : public DateType {
   static constexpr Type::type type_id = Type::DATE32;
   static constexpr DateUnit UNIT = DateUnit::DAY;
   using c_type = int32_t;
-  using StorageType = Int32Type;
+  using PhysicalType = Int32Type;
 
   static constexpr const char* type_name() { return "date32"; }
 
@@ -1148,7 +1148,7 @@ class ARROW_EXPORT Date64Type : public DateType {
   static constexpr Type::type type_id = Type::DATE64;
   static constexpr DateUnit UNIT = DateUnit::MILLI;
   using c_type = int64_t;
-  using StorageType = Int64Type;
+  using PhysicalType = Int64Type;
 
   static constexpr const char* type_name() { return "date64"; }
 
@@ -1186,7 +1186,7 @@ class ARROW_EXPORT Time32Type : public TimeType {
  public:
   static constexpr Type::type type_id = Type::TIME32;
   using c_type = int32_t;
-  using StorageType = Int32Type;
+  using PhysicalType = Int32Type;
 
   static constexpr const char* type_name() { return "time32"; }
 
@@ -1205,7 +1205,7 @@ class ARROW_EXPORT Time64Type : public TimeType {
  public:
   static constexpr Type::type type_id = Type::TIME64;
   using c_type = int64_t;
-  using StorageType = Int64Type;
+  using PhysicalType = Int64Type;
 
   static constexpr const char* type_name() { return "time64"; }
 
@@ -1256,7 +1256,7 @@ class ARROW_EXPORT TimestampType : public TemporalType, public ParametricType {
 
   static constexpr Type::type type_id = Type::TIMESTAMP;
   using c_type = int64_t;
-  using StorageType = Int64Type;
+  using PhysicalType = Int64Type;
 
   static constexpr const char* type_name() { return "timestamp"; }
 
@@ -1302,7 +1302,7 @@ class ARROW_EXPORT MonthIntervalType : public IntervalType {
  public:
   static constexpr Type::type type_id = Type::INTERVAL_MONTHS;
   using c_type = int32_t;
-  using StorageType = Int32Type;
+  using PhysicalType = Int32Type;
 
   static constexpr const char* type_name() { return "month_interval"; }
 
@@ -1331,7 +1331,7 @@ class ARROW_EXPORT DayTimeIntervalType : public IntervalType {
     }
   };
   using c_type = DayMilliseconds;
-  using StorageType = DayTimeIntervalType;
+  using PhysicalType = DayTimeIntervalType;
 
   static_assert(sizeof(DayMilliseconds) == 8,
                 "DayMilliseconds struct assumed to be of size 8 bytes");
@@ -1356,7 +1356,7 @@ class ARROW_EXPORT DurationType : public TemporalType, public ParametricType {
 
   static constexpr Type::type type_id = Type::DURATION;
   using c_type = int64_t;
-  using StorageType = Int64Type;
+  using PhysicalType = Int64Type;
 
   static constexpr const char* type_name() { return "duration"; }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -485,6 +485,7 @@ class ARROW_EXPORT CTypeImpl : public BASE {
  public:
   static constexpr Type::type type_id = TYPE_ID;
   using c_type = C_TYPE;
+  using StorageType = DERIVED;
 
   CTypeImpl() : BASE(TYPE_ID) {}
 
@@ -1124,6 +1125,7 @@ class ARROW_EXPORT Date32Type : public DateType {
   static constexpr Type::type type_id = Type::DATE32;
   static constexpr DateUnit UNIT = DateUnit::DAY;
   using c_type = int32_t;
+  using StorageType = Int32Type;
 
   static constexpr const char* type_name() { return "date32"; }
 
@@ -1146,6 +1148,7 @@ class ARROW_EXPORT Date64Type : public DateType {
   static constexpr Type::type type_id = Type::DATE64;
   static constexpr DateUnit UNIT = DateUnit::MILLI;
   using c_type = int64_t;
+  using StorageType = Int64Type;
 
   static constexpr const char* type_name() { return "date64"; }
 
@@ -1183,6 +1186,7 @@ class ARROW_EXPORT Time32Type : public TimeType {
  public:
   static constexpr Type::type type_id = Type::TIME32;
   using c_type = int32_t;
+  using StorageType = Int32Type;
 
   static constexpr const char* type_name() { return "time32"; }
 
@@ -1201,6 +1205,7 @@ class ARROW_EXPORT Time64Type : public TimeType {
  public:
   static constexpr Type::type type_id = Type::TIME64;
   using c_type = int64_t;
+  using StorageType = Int64Type;
 
   static constexpr const char* type_name() { return "time64"; }
 
@@ -1251,6 +1256,7 @@ class ARROW_EXPORT TimestampType : public TemporalType, public ParametricType {
 
   static constexpr Type::type type_id = Type::TIMESTAMP;
   using c_type = int64_t;
+  using StorageType = Int64Type;
 
   static constexpr const char* type_name() { return "timestamp"; }
 
@@ -1296,6 +1302,7 @@ class ARROW_EXPORT MonthIntervalType : public IntervalType {
  public:
   static constexpr Type::type type_id = Type::INTERVAL_MONTHS;
   using c_type = int32_t;
+  using StorageType = Int32Type;
 
   static constexpr const char* type_name() { return "month_interval"; }
 
@@ -1324,6 +1331,8 @@ class ARROW_EXPORT DayTimeIntervalType : public IntervalType {
     }
   };
   using c_type = DayMilliseconds;
+  using StorageType = DayTimeIntervalType;
+
   static_assert(sizeof(DayMilliseconds) == 8,
                 "DayMilliseconds struct assumed to be of size 8 bytes");
   static constexpr Type::type type_id = Type::INTERVAL_DAY_TIME;
@@ -1347,6 +1356,7 @@ class ARROW_EXPORT DurationType : public TemporalType, public ParametricType {
 
   static constexpr Type::type type_id = Type::DURATION;
   using c_type = int64_t;
+  using StorageType = Int64Type;
 
   static constexpr const char* type_name() { return "duration"; }
 


### PR DESCRIPTION
With clang-8 on Linux this unit is now 654KB down from 1257KB. 

A few strategies:

* Use same binary code for Less/Greater and LessEqual/GreaterEqual with arguments flipped
* Reuse kernels for primitive types represented as integers
* Reuse kernels for binary/string and largebinary/largestring

On the latter matter, I had to rewrite some of the codegen_internal.h routines where they assumed they would receive the specific logical type as the compile-time parameter (possibly causing a conflict when trying to put a BinaryArray box around a StringArray's ArrayData). This makes kernel execution against string data faster in the places where `ArrayIterator` is used. Will run benchmarks

As an aside, in general these kernel code generators will likely have lower and lower level code over time.