### PR TITLE
PARQUET-1877: [C++] Reconcile thrift limits

### DIFF
--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -363,7 +363,9 @@ inline void DeserializeThriftUnencryptedMsg(const uint8_t* buf, uint32_t* len,
   apache::thrift::protocol::TCompactProtocolFactoryT<ThriftBuffer> tproto_factory;
   // Protect against CPU and memory bombs
   tproto_factory.setStringSizeLimit(100 * 1000 * 1000);
-  tproto_factory.setContainerSizeLimit(10 * 1000 * 1000);
+  // Structs in the thrift definition are relatively large (at least 300 bytes).
+  // This limits total memory to the same order of magnitude as stringSize.
+  tproto_factory.setContainerSizeLimit(1000 * 1000);
   shared_ptr<apache::thrift::protocol::TProtocol> tproto =  //
       tproto_factory.getProtocol(tmem_transport);
   try {


### PR DESCRIPTION
Sets container size limit to have an upper bound memory footprint at the same order of magnitude as string size limits.