### PR TITLE
ARROW-8025: [C++] Implement cast from String to Binary

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -147,10 +147,13 @@ void AddNumberToStringCasts(std::shared_ptr<DataType> out_ty, CastFunction* func
 std::vector<std::shared_ptr<CastFunction>> GetBinaryLikeCasts() {
   auto cast_binary = std::make_shared<CastFunction>("cast_binary", Type::BINARY);
   AddCommonCasts(Type::BINARY, binary(), cast_binary.get());
+  AddZeroCopyCast(Type::STRING, {utf8()}, binary(), cast_binary.get());
 
   auto cast_large_binary =
       std::make_shared<CastFunction>("cast_large_binary", Type::LARGE_BINARY);
   AddCommonCasts(Type::LARGE_BINARY, large_binary(), cast_large_binary.get());
+  AddZeroCopyCast(Type::LARGE_STRING, {large_utf8()}, large_binary(),
+                  cast_large_binary.get());
 
   auto cast_fsb =
       std::make_shared<CastFunction>("cast_fixed_size_binary", Type::FIXED_SIZE_BINARY);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -157,6 +157,27 @@ class TestCast : public TestBase {
         src_type, strings, all, dest_type, strings, options);
   }
 
+  template <typename SourceType, typename DestType>
+  void TestCastStringToBinary() {
+    CastOptions options;
+    auto src_type = TypeTraits<SourceType>::type_singleton();
+    auto dest_type = TypeTraits<DestType>::type_singleton();
+
+    // All valid except the last one
+    std::vector<bool> all = {1, 1, 1, 1, 1};
+    std::vector<bool> valid = {1, 1, 1, 1, 0};
+    std::vector<std::string> strings = {"Hi", "olá mundo", "你好世界", "", kInvalidUtf8};
+
+    std::shared_ptr<Array> array;
+
+    // Should accept when invalid but null.
+    ArrayFromVector<SourceType, std::string>(src_type, valid, strings, &array);
+    CheckZeroCopy(*array, dest_type);
+
+    CheckCase<SourceType, std::string, DestType, std::string>(
+        src_type, strings, all, dest_type, strings, options);
+  }
+
   template <typename DestType>
   void TestCastNumberToString() {
     auto dest_type = TypeTraits<DestType>::type_singleton();
@@ -1361,6 +1382,12 @@ TEST_F(TestCast, BinaryToString) { TestCastBinaryToString<BinaryType, StringType
 
 TEST_F(TestCast, LargeBinaryToLargeString) {
   TestCastBinaryToString<LargeBinaryType, LargeStringType>();
+}
+
+TEST_F(TestCast, StringToBinary) { TestCastStringToBinary<StringType, BinaryType>(); }
+
+TEST_F(TestCast, LargeStringToLargeBinary) {
+  TestCastStringToBinary<LargeStringType, LargeBinaryType>();
 }
 
 TEST_F(TestCast, NumberToString) { TestCastNumberToString<StringType>(); }


### PR DESCRIPTION
I'd defer the following conversions to folllow-up PRs, these require custom CastFunctors:
- String/Binary -> FixedSizedBinary
- FixedSizedBinary -> String/Binary