### PR TITLE
ARROW-8802: [C++][Dataset] Preserve dataset schema's metadata on column projection

### DIFF
--- a/cpp/src/arrow/dataset/dataset_internal.h
+++ b/cpp/src/arrow/dataset/dataset_internal.h
@@ -65,7 +65,7 @@ inline std::shared_ptr<Schema> SchemaFromColumnNames(
     }
   }
 
-  return schema(std::move(columns));
+  return schema(std::move(columns))->WithMetadata(input->metadata());
 }
 
 }  // namespace dataset

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1566,3 +1566,18 @@ def test_parquet_dataset_factory_partitioned(tempdir):
     result = result.to_pandas().sort_values("f1").reset_index(drop=True)
     expected = table.to_pandas().drop(columns=["part"])
     pd.testing.assert_frame_equal(result, expected)
+
+
+@pytest.mark.parquet
+@pytest.mark.pandas
+def test_dataset_schema_metadata(tempdir):
+    # ARROW-8802
+    df = pd.DataFrame({'a': [1, 2, 3]})
+    path = tempdir / "test.parquet"
+    df.to_parquet(path)
+    dataset = ds.dataset(path)
+
+    schema = dataset.to_table().schema
+    projected_schema = dataset.to_table(columns=["a"]).schema
+
+    assert schema.equals(projected_schema, check_metadata=True)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1580,4 +1580,7 @@ def test_dataset_schema_metadata(tempdir):
     schema = dataset.to_table().schema
     projected_schema = dataset.to_table(columns=["a"]).schema
 
+    # ensure the pandas metadata is included in the schema
+    assert b"pandas" in schema.metadata
+    # ensure it is still there in a projected schema (with column selection)
     assert schema.equals(projected_schema, check_metadata=True)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -278,7 +278,7 @@ class PeriodType(pa.ExtensionType):
         # attributes need to be set first before calling
         # super init (as that calls serialize)
         self._freq = freq
-        pa.ExtensionType.__init__(self, pa.int64(), 'pandas.period')
+        pa.ExtensionType.__init__(self, pa.int64(), 'test.period')
 
     @property
     def freq(self):
@@ -325,14 +325,14 @@ def registered_period_type(request):
     yield period_type, period_class
     # teardown
     try:
-        pa.unregister_extension_type('pandas.period')
+        pa.unregister_extension_type('test.period')
     except KeyError:
         pass
 
 
 def test_generic_ext_type():
     period_type = PeriodType('D')
-    assert period_type.extension_name == "pandas.period"
+    assert period_type.extension_name == "test.period"
     assert period_type.storage_type == pa.int64()
     # default ext_class expected.
     assert period_type.__arrow_ext_class__() == pa.ExtensionArray
@@ -353,7 +353,7 @@ def test_generic_ext_type_ipc(registered_period_type):
     result = batch.column(0)
     # check the deserialized array class is the expected one
     assert type(result) == period_class
-    assert result.type.extension_name == "pandas.period"
+    assert result.type.extension_name == "test.period"
     assert arr.storage.to_pylist() == [1, 2, 3, 4]
 
     # we get back an actual PeriodType
@@ -363,7 +363,7 @@ def test_generic_ext_type_ipc(registered_period_type):
 
     # using different parametrization as how it was registered
     period_type_H = period_type.__class__('H')
-    assert period_type_H.extension_name == "pandas.period"
+    assert period_type_H.extension_name == "test.period"
     assert period_type_H.freq == 'H'
 
     arr = pa.ExtensionArray.from_storage(period_type_H, storage)
@@ -389,7 +389,7 @@ def test_generic_ext_type_ipc_unknown(registered_period_type):
 
     # unregister type before loading again => reading unknown extension type
     # as plain array (but metadata in schema's field are preserved)
-    pa.unregister_extension_type('pandas.period')
+    pa.unregister_extension_type('test.period')
 
     batch = ipc_read_batch(buf)
     result = batch.column(0)
@@ -398,13 +398,13 @@ def test_generic_ext_type_ipc_unknown(registered_period_type):
     ext_field = batch.schema.field('ext')
     assert ext_field.metadata == {
         b'ARROW:extension:metadata': b'freq=D',
-        b'ARROW:extension:name': b'pandas.period'
+        b'ARROW:extension:name': b'test.period'
     }
 
 
 def test_generic_ext_type_equality():
     period_type = PeriodType('D')
-    assert period_type.extension_name == "pandas.period"
+    assert period_type.extension_name == "test.period"
 
     period_type2 = PeriodType('D')
     period_type3 = PeriodType('H')
@@ -464,7 +464,7 @@ def test_parquet(tmpdir, registered_period_type):
     # The extension metadata is present for roundtripping.
     assert result.schema.field("ext").metadata == {
         b'ARROW:extension:metadata': b'freq=D',
-        b'ARROW:extension:name': b'pandas.period',
+        b'ARROW:extension:name': b'test.period',
         b'PARQUET:field_id': b'1',
     }
 


### PR DESCRIPTION
Scanner does not preserve the original schema metadata when columns are projected.