### PR TITLE
ARROW-9168: [C++][Flight] Don't share TCP connection among clients

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -858,6 +858,9 @@ class FlightClient::FlightClientImpl {
     args.SetInt(GRPC_ARG_INITIAL_RECONNECT_BACKOFF_MS, 100);
     // Receive messages of any size
     args.SetMaxReceiveMessageSize(-1);
+    // Setting this arg enables each client to open it's own TCP connection to server,
+    // not sharing one single connection, which becomes bottleneck under high load.
+    args.SetInt(GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL, 1);
 
     if (options.override_hostname != "") {
       args.SetSslTargetNameOverride(options.override_hostname);


### PR DESCRIPTION
Flight benchmark performs worse when working threads increases. It can
be improved by setting gRPC option GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL
to make each client creating its own TCP connection to server, without
sharing one connection.