### PR TITLE
ARROW-4221: [C++][Python] Add canonical flag in COO sparse index

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -961,7 +961,8 @@ Status MakeSparseTensorIndexCOO(FBB& fbb, const SparseCOOIndex& sparse_index,
   flatbuf::Buffer indices(indices_metadata.offset, indices_metadata.length);
 
   *fb_sparse_index =
-      flatbuf::CreateSparseTensorIndexCOO(fbb, indices_type_offset, fb_strides, &indices)
+      flatbuf::CreateSparseTensorIndexCOO(fbb, indices_type_offset, fb_strides, &indices,
+                                          sparse_index.is_canonical())
           .Union();
   *num_buffers = 1;
   return Status::OK();

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1745,6 +1745,7 @@ class TestSparseTensorRoundTrip : public ::testing::Test, public IpcTestFixture 
     const auto& resulted_sparse_index =
         checked_cast<const SparseCOOIndex&>(*result->sparse_index());
     ASSERT_EQ(resulted_sparse_index.indices()->data()->size(), indices_length);
+    ASSERT_EQ(resulted_sparse_index.is_canonical(), sparse_index.is_canonical());
     ASSERT_EQ(result->data()->size(), data_length);
     ASSERT_TRUE(result->Equals(sparse_tensor));
   }
@@ -1908,6 +1909,7 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor) {
   // idx[2] = [0 2 1 3 0 2  1  3  0  2  1  3]
   // data   = [1 2 3 4 5 6 11 12 13 14 15 16]
 
+  // canonical
   std::vector<c_index_value_type> coords_values = {0, 0, 0, 0, 0, 2, 0, 1, 1, 0, 1, 3,
                                                    0, 2, 0, 0, 2, 2, 1, 0, 1, 1, 0, 3,
                                                    1, 1, 0, 1, 1, 2, 1, 2, 1, 1, 2, 3};
@@ -1917,11 +1919,22 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexRowMajor) {
       si, SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
                                {sizeof_index_value * 3, sizeof_index_value},
                                Buffer::Wrap(coords_values)));
+  ASSERT_TRUE(si->is_canonical());
 
   std::vector<int64_t> shape = {2, 3, 4};
   std::vector<std::string> dim_names = {"foo", "bar", "baz"};
   std::vector<int64_t> values = {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16};
   std::shared_ptr<SparseCOOTensor> st;
+  ASSERT_OK_AND_ASSIGN(st, this->MakeSparseCOOTensor(si, values, shape, dim_names));
+
+  this->CheckSparseCOOTensorRoundTrip(*st);
+
+  // non-canonical
+  ASSERT_OK_AND_ASSIGN(
+      si, SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
+                               {sizeof_index_value * 3, sizeof_index_value},
+                               Buffer::Wrap(coords_values), false));
+  ASSERT_FALSE(si->is_canonical());
   ASSERT_OK_AND_ASSIGN(st, this->MakeSparseCOOTensor(si, values, shape, dim_names));
 
   this->CheckSparseCOOTensorRoundTrip(*st);
@@ -1956,6 +1969,7 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
   // idx[2] = [0 2 1 3 0 2  1  3  0  2  1  3]
   // data   = [1 2 3 4 5 6 11 12 13 14 15 16]
 
+  // canonical
   std::vector<c_index_value_type> coords_values = {0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
                                                    0, 0, 1, 1, 2, 2, 0, 0, 1, 1, 2, 2,
                                                    0, 2, 1, 3, 0, 2, 1, 3, 0, 2, 1, 3};
@@ -1965,12 +1979,23 @@ TYPED_TEST_P(TestSparseTensorRoundTrip, WithSparseCOOIndexColumnMajor) {
       si, SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
                                {sizeof_index_value, sizeof_index_value * 12},
                                Buffer::Wrap(coords_values)));
+  ASSERT_TRUE(si->is_canonical());
 
   std::vector<int64_t> shape = {2, 3, 4};
   std::vector<std::string> dim_names = {"foo", "bar", "baz"};
   std::vector<int64_t> values = {1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 15, 16};
 
   std::shared_ptr<SparseCOOTensor> st;
+  ASSERT_OK_AND_ASSIGN(st, this->MakeSparseCOOTensor(si, values, shape, dim_names));
+
+  this->CheckSparseCOOTensorRoundTrip(*st);
+
+  // non-canonical
+  ASSERT_OK_AND_ASSIGN(
+      si, SparseCOOIndex::Make(TypeTraits<IndexValueType>::type_singleton(), {12, 3},
+                               {sizeof_index_value, sizeof_index_value * 12},
+                               Buffer::Wrap(coords_values), false));
+  ASSERT_FALSE(si->is_canonical());
   ASSERT_OK_AND_ASSIGN(st, this->MakeSparseCOOTensor(si, values, shape, dim_names));
 
   this->CheckSparseCOOTensorRoundTrip(*st);

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1263,7 +1263,8 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
     strides[0] = indices_elsize * ndim;
     strides[1] = indices_elsize;
   }
-  return std::make_shared<SparseCOOIndex>(
+  // TODO: support is_canonical that read from buffer or stream
+  return SparseCOOIndex::Make(
       std::make_shared<Tensor>(indices_type, indices_data, indices_shape, strides));
 }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1263,9 +1263,9 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCOOIndex(
     strides[0] = indices_elsize * ndim;
     strides[1] = indices_elsize;
   }
-  // TODO: support is_canonical that read from buffer or stream
   return SparseCOOIndex::Make(
-      std::make_shared<Tensor>(indices_type, indices_data, indices_shape, strides));
+      std::make_shared<Tensor>(indices_type, indices_data, indices_shape, strides),
+      sparse_index->isCanonical());
 }
 
 Result<std::shared_ptr<SparseIndex>> ReadSparseCSXIndex(

--- a/cpp/src/arrow/python/numpy_convert.cc
+++ b/cpp/src/arrow/python/numpy_convert.cc
@@ -442,8 +442,8 @@ Status NdarraysToSparseCOOTensor(MemoryPool* pool, PyObject* data_ao, PyObject* 
   RETURN_NOT_OK(NdarrayToTensor(pool, coords_ao, {}, &coords));
   ARROW_CHECK_EQ(coords->type_id(), Type::INT64);  // Should be ensured by caller
 
-  std::shared_ptr<SparseCOOIndex> sparse_index = std::make_shared<SparseCOOIndex>(
-      std::static_pointer_cast<NumericTensor<Int64Type>>(coords));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<SparseCOOIndex> sparse_index,
+                        SparseCOOIndex::Make(coords));
   *out = std::make_shared<SparseTensorImpl<SparseCOOIndex>>(sparse_index, type_data, data,
                                                             shape, dim_names);
   return Status::OK();

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -184,7 +184,7 @@ void get_coo_index_tensor_row(const std::shared_ptr<Tensor>& coords, const int64
 }
 
 bool DetectSparseCOOIndexCanonicality(const std::shared_ptr<Tensor>& coords) {
-  DCHECK(coords->ndim() == 2);
+  DCHECK_EQ(coords->ndim(), 2);
 
   const auto& shape = coords->shape();
   const int64_t non_zero_length = shape[0];

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -151,36 +151,33 @@ void GetCOOIndexTensorRow(const std::shared_ptr<Tensor>& coords, const int64_t r
   DCHECK(0 <= row && row < non_zero_length);
 
   const int64_t ndim = shape[1];
-  std::vector<int64_t> index;
-  index.reserve(ndim);
+  out_index->resize(ndim);
 
   switch (indices_elsize) {
     case 1:  // Int8, UInt8
       for (int64_t i = 0; i < ndim; ++i) {
-        index.push_back(static_cast<int64_t>(coords->Value<UInt8Type>({row, i})));
+        (*out_index)[i] = static_cast<int64_t>(coords->Value<UInt8Type>({row, i}));
       }
       break;
     case 2:  // Int16, UInt16
       for (int64_t i = 0; i < ndim; ++i) {
-        index.push_back(static_cast<int64_t>(coords->Value<UInt16Type>({row, i})));
+        (*out_index)[i] = static_cast<int64_t>(coords->Value<UInt16Type>({row, i}));
       }
       break;
     case 4:  // Int32, UInt32
       for (int64_t i = 0; i < ndim; ++i) {
-        index.push_back(static_cast<int64_t>(coords->Value<UInt32Type>({row, i})));
+        (*out_index)[i] = static_cast<int64_t>(coords->Value<UInt32Type>({row, i}));
       }
       break;
     case 8:  // Int64
       for (int64_t i = 0; i < ndim; ++i) {
-        index.push_back(coords->Value<Int64Type>({row, i}));
+        (*out_index)[i] = coords->Value<Int64Type>({row, i});
       }
       break;
     default:
       DCHECK(false) << "Must not reach here";
       break;
   }
-
-  *out_index = std::move(index);
 }
 
 bool DetectSparseCOOIndexCanonicality(const std::shared_ptr<Tensor>& coords) {

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -140,8 +140,8 @@ inline Status CheckSparseCOOIndexValidity(const std::shared_ptr<DataType>& type,
   return Status::OK();
 }
 
-void get_coo_index_tensor_row(const std::shared_ptr<Tensor>& coords, const int64_t row,
-                              std::vector<int64_t>* out_index) {
+void GetCOOIndexTensorRow(const std::shared_ptr<Tensor>& coords, const int64_t row,
+                          std::vector<int64_t>* out_index) {
   const auto& fw_index_value_type =
       internal::checked_cast<const FixedWidthType&>(*coords->type());
   const size_t indices_elsize = fw_index_value_type.bit_width() / CHAR_BIT;
@@ -192,9 +192,9 @@ bool DetectSparseCOOIndexCanonicality(const std::shared_ptr<Tensor>& coords) {
 
   const int64_t ndim = shape[1];
   std::vector<int64_t> last_index, index;
-  get_coo_index_tensor_row(coords, 0, &last_index);
+  GetCOOIndexTensorRow(coords, 0, &last_index);
   for (int64_t i = 1; i < non_zero_length; ++i) {
-    get_coo_index_tensor_row(coords, i, &index);
+    GetCOOIndexTensorRow(coords, i, &index);
     int64_t j = 0;
     while (j < ndim) {
       if (last_index[j] > index[j]) {

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -140,7 +140,112 @@ inline Status CheckSparseCOOIndexValidity(const std::shared_ptr<DataType>& type,
   return Status::OK();
 }
 
+void get_coo_index_tensor_row(const std::shared_ptr<Tensor>& coords, const int64_t row,
+                              std::vector<int64_t>* out_index) {
+  const auto& fw_index_value_type =
+      internal::checked_cast<const FixedWidthType&>(*coords->type());
+  const size_t indices_elsize = fw_index_value_type.bit_width() / CHAR_BIT;
+
+  const auto& shape = coords->shape();
+  const int64_t non_zero_length = shape[0];
+  DCHECK(0 <= row && row < non_zero_length);
+
+  const int64_t ndim = shape[1];
+  std::vector<int64_t> index;
+  index.reserve(ndim);
+
+  switch (indices_elsize) {
+    case 1:  // Int8, UInt8
+      for (int64_t i = 0; i < ndim; ++i) {
+        index.push_back(static_cast<int64_t>(coords->Value<UInt8Type>({row, i})));
+      }
+      break;
+    case 2:  // Int16, UInt16
+      for (int64_t i = 0; i < ndim; ++i) {
+        index.push_back(static_cast<int64_t>(coords->Value<UInt16Type>({row, i})));
+      }
+      break;
+    case 4:  // Int32, UInt32
+      for (int64_t i = 0; i < ndim; ++i) {
+        index.push_back(static_cast<int64_t>(coords->Value<UInt32Type>({row, i})));
+      }
+      break;
+    case 8:  // Int64
+      for (int64_t i = 0; i < ndim; ++i) {
+        index.push_back(coords->Value<Int64Type>({row, i}));
+      }
+      break;
+    default:
+      DCHECK(false) << "Must not reach here";
+      break;
+  }
+
+  *out_index = std::move(index);
+}
+
+bool DetectSparseCOOIndexCanonicality(const std::shared_ptr<Tensor>& coords) {
+  DCHECK(coords->ndim() == 2);
+
+  const auto& shape = coords->shape();
+  const int64_t non_zero_length = shape[0];
+  if (non_zero_length <= 1) return true;
+
+  const int64_t ndim = shape[1];
+  std::vector<int64_t> last_index, index;
+  get_coo_index_tensor_row(coords, 0, &last_index);
+  for (int64_t i = 1; i < non_zero_length; ++i) {
+    get_coo_index_tensor_row(coords, i, &index);
+    int64_t j = 0;
+    while (j < ndim) {
+      if (last_index[j] > index[j]) {
+        // last_index > index, so we can detect non-canonical here
+        return false;
+      }
+      if (last_index[j] < index[j]) {
+        // last_index < index, so we can skip the remaining dimensions
+        break;
+      }
+      ++j;
+    }
+    if (j == ndim) {
+      // last_index == index, so we can detect non-canonical here
+      return false;
+    }
+    swap(last_index, index);
+  }
+
+  return true;
+}
+
 }  // namespace
+
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
+    const std::shared_ptr<Tensor>& coords, bool is_canonical) {
+  RETURN_NOT_OK(
+      CheckSparseCOOIndexValidity(coords->type(), coords->shape(), coords->strides()));
+  return std::make_shared<SparseCOOIndex>(coords, is_canonical);
+}
+
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
+    const std::shared_ptr<Tensor>& coords) {
+  RETURN_NOT_OK(
+      CheckSparseCOOIndexValidity(coords->type(), coords->shape(), coords->strides()));
+  auto is_canonical = DetectSparseCOOIndexCanonicality(coords);
+  return std::make_shared<SparseCOOIndex>(coords, is_canonical);
+}
+
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
+    const std::shared_ptr<DataType>& indices_type,
+    const std::vector<int64_t>& indices_shape,
+    const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data,
+    bool is_canonical) {
+  RETURN_NOT_OK(
+      CheckSparseCOOIndexValidity(indices_type, indices_shape, indices_strides));
+  return std::make_shared<SparseCOOIndex>(
+      std::make_shared<Tensor>(indices_type, indices_data, indices_shape,
+                               indices_strides),
+      is_canonical);
+}
 
 Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
     const std::shared_ptr<DataType>& indices_type,
@@ -148,8 +253,24 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
     const std::vector<int64_t>& indices_strides, std::shared_ptr<Buffer> indices_data) {
   RETURN_NOT_OK(
       CheckSparseCOOIndexValidity(indices_type, indices_shape, indices_strides));
-  return std::make_shared<SparseCOOIndex>(std::make_shared<Tensor>(
-      indices_type, indices_data, indices_shape, indices_strides));
+  auto coords = std::make_shared<Tensor>(indices_type, indices_data, indices_shape,
+                                         indices_strides);
+  auto is_canonical = DetectSparseCOOIndexCanonicality(coords);
+  return std::make_shared<SparseCOOIndex>(coords, is_canonical);
+}
+
+Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
+    const std::shared_ptr<DataType>& indices_type, const std::vector<int64_t>& shape,
+    int64_t non_zero_length, std::shared_ptr<Buffer> indices_data, bool is_canonical) {
+  auto ndim = static_cast<int64_t>(shape.size());
+  if (!is_integer(indices_type->id())) {
+    return Status::TypeError("Type of SparseCOOIndex indices must be integer");
+  }
+  const int64_t elsize =
+      internal::checked_cast<const IntegerType&>(*indices_type).bit_width() / 8;
+  std::vector<int64_t> indices_shape({non_zero_length, ndim});
+  std::vector<int64_t> indices_strides({elsize * ndim, elsize});
+  return Make(indices_type, indices_shape, indices_strides, indices_data, is_canonical);
 }
 
 Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
@@ -166,8 +287,8 @@ Result<std::shared_ptr<SparseCOOIndex>> SparseCOOIndex::Make(
 }
 
 // Constructor with a contiguous NumericTensor
-SparseCOOIndex::SparseCOOIndex(const std::shared_ptr<Tensor>& coords)
-    : SparseIndexBase(), coords_(coords) {
+SparseCOOIndex::SparseCOOIndex(const std::shared_ptr<Tensor>& coords, bool is_canonical)
+    : SparseIndexBase(), coords_(coords), is_canonical_(is_canonical) {
   ARROW_CHECK_OK(
       CheckSparseCOOIndexValidity(coords_->type(), coords_->shape(), coords_->strides()));
 }

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -746,6 +746,23 @@ class TestSparseCSRMatrixBase : public TestSparseTensorBase<Int64Type> {
 
 class TestSparseCSRMatrix : public TestSparseCSRMatrixBase<Int64Type> {};
 
+TEST_F(TestSparseCSRMatrix, CreationFromZeroTensor) {
+  const auto dense_size =
+      std::accumulate(this->shape_.begin(), this->shape_.end(), int64_t(1),
+                      [](int64_t a, int64_t x) { return a * x; });
+  std::vector<int64_t> dense_values(dense_size, 0);
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Tensor> t_zero,
+                       Tensor::Make(int64(), Buffer::Wrap(dense_values), this->shape_));
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<SparseCSRMatrix> st_zero,
+                       SparseCSRMatrix::Make(*t_zero, int64()));
+
+  ASSERT_EQ(0, st_zero->non_zero_length());
+  ASSERT_EQ(dense_size, st_zero->size());
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Tensor> t, st_zero->ToTensor());
+  ASSERT_TRUE(t->Equals(*t_zero));
+}
+
 TEST_F(TestSparseCSRMatrix, CreationFromNumericTensor2D) {
   std::shared_ptr<Buffer> buffer = Buffer::Wrap(this->dense_values_);
   NumericTensor<Int64Type> tensor(buffer, this->shape_);
@@ -1063,6 +1080,23 @@ class TestSparseCSCMatrixBase : public TestSparseTensorBase<Int64Type> {
 };
 
 class TestSparseCSCMatrix : public TestSparseCSCMatrixBase<Int64Type> {};
+
+TEST_F(TestSparseCSCMatrix, CreationFromZeroTensor) {
+  const auto dense_size =
+      std::accumulate(this->shape_.begin(), this->shape_.end(), int64_t(1),
+                      [](int64_t a, int64_t x) { return a * x; });
+  std::vector<int64_t> dense_values(dense_size, 0);
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Tensor> t_zero,
+                       Tensor::Make(int64(), Buffer::Wrap(dense_values), this->shape_));
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<SparseCSCMatrix> st_zero,
+                       SparseCSCMatrix::Make(*t_zero, int64()));
+
+  ASSERT_EQ(0, st_zero->non_zero_length());
+  ASSERT_EQ(dense_size, st_zero->size());
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Tensor> t, st_zero->ToTensor());
+  ASSERT_TRUE(t->Equals(*t_zero));
+}
 
 TEST_F(TestSparseCSCMatrix, CreationFromNumericTensor2D) {
   std::shared_ptr<Buffer> buffer = Buffer::Wrap(this->dense_values_);
@@ -1424,6 +1458,25 @@ class TestSparseCSFTensorBase : public TestSparseTensorBase<Int16Type> {
   int16_t dense_values_[2][3][4][5] = {};
   std::shared_ptr<SparseCSFTensor> sparse_tensor_from_dense_;
 };
+
+class TestSparseCSFTensor : public TestSparseCSFTensorBase<Int64Type> {};
+
+TEST_F(TestSparseCSFTensor, CreationFromZeroTensor) {
+  const auto dense_size =
+      std::accumulate(this->shape_.begin(), this->shape_.end(), int64_t(1),
+                      [](int64_t a, int64_t x) { return a * x; });
+  std::vector<int64_t> dense_values(dense_size, 0);
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Tensor> t_zero,
+                       Tensor::Make(int64(), Buffer::Wrap(dense_values), this->shape_));
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<SparseCSFTensor> st_zero,
+                       SparseCSFTensor::Make(*t_zero, int64()));
+
+  ASSERT_EQ(0, st_zero->non_zero_length());
+  ASSERT_EQ(dense_size, st_zero->size());
+
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Tensor> t, st_zero->ToTensor());
+  ASSERT_TRUE(t->Equals(*t_zero));
+}
 
 template <typename IndexValueType>
 class TestSparseCSFTensorForIndexValueType

--- a/cpp/src/arrow/tensor/coo_converter.cc
+++ b/cpp/src/arrow/tensor/coo_converter.cc
@@ -117,8 +117,9 @@ class SparseCOOTensorConverter : private SparseTensorConverterMixin {
     // make results
     const std::vector<int64_t> indices_shape = {nonzero_count, ndim};
     const std::vector<int64_t> indices_strides = {index_elsize * ndim, index_elsize};
-    sparse_index = std::make_shared<SparseCOOIndex>(std::make_shared<Tensor>(
-        index_value_type_, std::move(indices_buffer), indices_shape, indices_strides));
+    auto coords = std::make_shared<Tensor>(index_value_type_, std::move(indices_buffer),
+                                           indices_shape, indices_strides);
+    ARROW_ASSIGN_OR_RAISE(sparse_index, SparseCOOIndex::Make(coords, true));
     data = std::move(values_buffer);
 
     return Status::OK();

--- a/cpp/src/arrow/tensor/coo_converter.cc
+++ b/cpp/src/arrow/tensor/coo_converter.cc
@@ -116,7 +116,10 @@ class SparseCOOTensorConverter : private SparseTensorConverterMixin {
 
     // make results
     const std::vector<int64_t> indices_shape = {nonzero_count, ndim};
-    const std::vector<int64_t> indices_strides = {index_elsize * ndim, index_elsize};
+    std::vector<int64_t> indices_strides;
+    internal::ComputeRowMajorStrides(
+        checked_cast<const FixedWidthType&>(*index_value_type_), indices_shape,
+        &indices_strides);
     auto coords = std::make_shared<Tensor>(index_value_type_, std::move(indices_buffer),
                                            indices_shape, indices_strides);
     ARROW_ASSIGN_OR_RAISE(sparse_index, SparseCOOIndex::Make(coords, true));

--- a/cpp/src/generated/SparseTensor_generated.h
+++ b/cpp/src/generated/SparseTensor_generated.h
@@ -146,7 +146,8 @@ struct SparseTensorIndexCOO FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_INDICESTYPE = 4,
     VT_INDICESSTRIDES = 6,
-    VT_INDICESBUFFER = 8
+    VT_INDICESBUFFER = 8,
+    VT_ISCANONICAL = 10
   };
   /// The type of values in indicesBuffer
   const org::apache::arrow::flatbuf::Int *indicesType() const {
@@ -161,6 +162,10 @@ struct SparseTensorIndexCOO FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
   const org::apache::arrow::flatbuf::Buffer *indicesBuffer() const {
     return GetStruct<const org::apache::arrow::flatbuf::Buffer *>(VT_INDICESBUFFER);
   }
+  /// The canonicality flag
+  bool isCanonical() const {
+    return GetField<uint8_t>(VT_ISCANONICAL, 0) != 0;
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyOffsetRequired(verifier, VT_INDICESTYPE) &&
@@ -168,6 +173,7 @@ struct SparseTensorIndexCOO FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table
            VerifyOffset(verifier, VT_INDICESSTRIDES) &&
            verifier.VerifyVector(indicesStrides()) &&
            VerifyFieldRequired<org::apache::arrow::flatbuf::Buffer>(verifier, VT_INDICESBUFFER) &&
+           VerifyField<uint8_t>(verifier, VT_ISCANONICAL) &&
            verifier.EndTable();
   }
 };
@@ -184,6 +190,9 @@ struct SparseTensorIndexCOOBuilder {
   }
   void add_indicesBuffer(const org::apache::arrow::flatbuf::Buffer *indicesBuffer) {
     fbb_.AddStruct(SparseTensorIndexCOO::VT_INDICESBUFFER, indicesBuffer);
+  }
+  void add_isCanonical(bool isCanonical) {
+    fbb_.AddElement<uint8_t>(SparseTensorIndexCOO::VT_ISCANONICAL, static_cast<uint8_t>(isCanonical), 0);
   }
   explicit SparseTensorIndexCOOBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
@@ -203,11 +212,13 @@ inline flatbuffers::Offset<SparseTensorIndexCOO> CreateSparseTensorIndexCOO(
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indicesType = 0,
     flatbuffers::Offset<flatbuffers::Vector<int64_t>> indicesStrides = 0,
-    const org::apache::arrow::flatbuf::Buffer *indicesBuffer = 0) {
+    const org::apache::arrow::flatbuf::Buffer *indicesBuffer = 0,
+    bool isCanonical = false) {
   SparseTensorIndexCOOBuilder builder_(_fbb);
   builder_.add_indicesBuffer(indicesBuffer);
   builder_.add_indicesStrides(indicesStrides);
   builder_.add_indicesType(indicesType);
+  builder_.add_isCanonical(isCanonical);
   return builder_.Finish();
 }
 
@@ -215,13 +226,15 @@ inline flatbuffers::Offset<SparseTensorIndexCOO> CreateSparseTensorIndexCOODirec
     flatbuffers::FlatBufferBuilder &_fbb,
     flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indicesType = 0,
     const std::vector<int64_t> *indicesStrides = nullptr,
-    const org::apache::arrow::flatbuf::Buffer *indicesBuffer = 0) {
+    const org::apache::arrow::flatbuf::Buffer *indicesBuffer = 0,
+    bool isCanonical = false) {
   auto indicesStrides__ = indicesStrides ? _fbb.CreateVector<int64_t>(*indicesStrides) : 0;
   return org::apache::arrow::flatbuf::CreateSparseTensorIndexCOO(
       _fbb,
       indicesType,
       indicesStrides__,
-      indicesBuffer);
+      indicesBuffer,
+      isCanonical);
 }
 
 /// Compressed Sparse format, that is matrix-specific.

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -64,7 +64,11 @@ table SparseTensorIndexCOO {
   /// The location and size of the indices matrix's data
   indicesBuffer: Buffer (required);
 
-  /// The canonicality flag
+  /// This flag is true if and only if the indices matrix is sorted in
+  /// row-major order, and does not have duplicated entries.
+  /// This sort order is the same as of Tensorflow's SparseTensor,
+  /// but it is inverse order of SciPy's canonical coo_matrix
+  /// (SciPy employs column-major order for its coo_matrix).
   isCanonical: bool;
 }
 

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -63,6 +63,9 @@ table SparseTensorIndexCOO {
 
   /// The location and size of the indices matrix's data
   indicesBuffer: Buffer (required);
+
+  /// The canonicality flag
+  isCanonical: bool;
 }
 
 enum SparseMatrixCompressedAxis: short { Row, Column }

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -52,7 +52,9 @@ namespace org.apache.arrow.flatbuf;
 ///    [2, 2, 3, 1, 2, 0],
 ///    [0, 1, 0, 0, 3, 4]]
 ///
-/// Note that the indices are sorted in lexicographical order.
+/// When isCanonical is true, the indices is sorted in lexicographical order
+/// (row-major order), and it does not have duplicated entries.  Otherwise,
+/// the indices may not be sorted, or may have duplicated entries.
 table SparseTensorIndexCOO {
   /// The type of values in indicesBuffer
   indicesType: Int (required);

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -786,10 +786,18 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         Type type_id()
         c_bool Equals(const CTensor& other)
 
+    cdef cppclass CSparseIndex" arrow::SparseIndex":
+        pass
+
+    cdef cppclass CSparseCOOIndex" arrow::SparseCOOIndex":
+        c_bool is_canonical()
+
     cdef cppclass CSparseCOOTensor" arrow::SparseCOOTensor":
         shared_ptr[CDataType] type()
         shared_ptr[CBuffer] data()
         CResult[shared_ptr[CTensor]] ToTensor()
+
+        shared_ptr[CSparseIndex] sparse_index()
 
         const vector[int64_t]& shape()
         int64_t size()

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -365,7 +365,7 @@ shape: {0.shape}""".format(self)
         cdef:
             _CSparseCOOIndexPtr csi
 
-        csi = dynamic_cast[_CSparseCOOIndexPtr](self.stp.sparse_index().get())
+        csi = <_CSparseCOOIndexPtr>(self.stp.sparse_index().get())
         if csi != nullptr:
             return csi.is_canonical()
         return True

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -205,7 +205,7 @@ shape: {0.shape}""".format(self)
         row = obj.row
         col = obj.col
         if obj.has_canonical_format:
-            order = np.lexsort((col, row)) # row-major order
+            order = np.lexsort((col, row))  # row-major order
             row = row[order]
             col = col[order]
         coords = np.vstack([row, col]).T
@@ -279,7 +279,7 @@ shape: {0.shape}""".format(self)
                                               &out_data, &out_coords))
         data = PyObject_to_object(out_data)
         coords = PyObject_to_object(out_coords)
-        row, col = coords[:,0], coords[:, 1]
+        row, col = coords[:, 0], coords[:, 1]
         result = coo_matrix((data[:, 0], (row, col)), shape=self.shape)
         if self.has_canonical_format:
             result.sum_duplicates()
@@ -354,7 +354,7 @@ shape: {0.shape}""".format(self)
     @property
     def has_canonical_format(self):
         cdef:
-            _CSparseCOOIndexPtr csi;
+            _CSparseCOOIndexPtr csi
 
         csi = dynamic_cast[_CSparseCOOIndexPtr](self.stp.sparse_index().get())
         if csi != nullptr:

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -287,9 +287,10 @@ shape: {0.shape}""".format(self)
         row, col = coords[:, 0], coords[:, 1]
         result = coo_matrix((data[:, 0], (row, col)), shape=self.shape)
 
-        # As the description in from_scipy above, we sorted indices matrix in row-major order
-        # if SciPy's coo_matrix has canonical format.  So, we must call sum_duplicates() to
-        # make the result coo_matrix has canonical format.
+        # As the description in from_scipy above, we sorted indices matrix
+        # in row-major order if SciPy's coo_matrix has canonical format.
+        # So, we must call sum_duplicates() to make the result coo_matrix
+        # has canonical format.
         if self.has_canonical_format:
             result.sum_duplicates()
         return result

--- a/python/pyarrow/tests/test_sparse_tensor.py
+++ b/python/pyarrow/tests/test_sparse_tensor.py
@@ -88,6 +88,7 @@ def test_sparse_coo_tensor_base_object():
     sparse_tensor = pa.SparseCOOTensor.from_dense_numpy(array)
     n = sys.getrefcount(sparse_tensor)
     result_data, result_coords = sparse_tensor.to_numpy()
+    assert sparse_tensor.has_canonical_format
     assert sys.getrefcount(sparse_tensor) == n + 2
 
     sparse_tensor = None
@@ -394,25 +395,39 @@ def test_sparse_coo_tensor_scipy_roundtrip(dtype_str, arrow_type):
     shape = (4, 6)
     dim_names = ('x', 'y')
 
-    sparse_array = coo_matrix((data, (row, col)), shape=shape)
-    sparse_tensor = pa.SparseCOOTensor.from_scipy(sparse_array,
+    # non-canonical sparse coo matrix
+    scipy_matrix = coo_matrix((data, (row, col)), shape=shape)
+    sparse_tensor = pa.SparseCOOTensor.from_scipy(scipy_matrix,
                                                   dim_names=dim_names)
-    out_sparse_array = sparse_tensor.to_scipy()
+    out_scipy_matrix = sparse_tensor.to_scipy()
 
+    assert not scipy_matrix.has_canonical_format
+    assert not sparse_tensor.has_canonical_format
+    assert not out_scipy_matrix.has_canonical_format
     assert sparse_tensor.type == arrow_type
     assert sparse_tensor.dim_names == dim_names
-    assert sparse_array.dtype == out_sparse_array.dtype
-    assert np.array_equal(sparse_array.data, out_sparse_array.data)
-    assert np.array_equal(sparse_array.row, out_sparse_array.row)
-    assert np.array_equal(sparse_array.col, out_sparse_array.col)
+    assert scipy_matrix.dtype == out_scipy_matrix.dtype
+    assert np.array_equal(scipy_matrix.data, out_scipy_matrix.data)
+    assert np.array_equal(scipy_matrix.row, out_scipy_matrix.row)
+    assert np.array_equal(scipy_matrix.col, out_scipy_matrix.col)
 
     if dtype_str == 'f2':
         dense_array = \
-            sparse_array.astype(np.float32).toarray().astype(np.float16)
+            scipy_matrix.astype(np.float32).toarray().astype(np.float16)
     else:
-        dense_array = sparse_array.toarray()
+        dense_array = scipy_matrix.toarray()
     assert np.array_equal(dense_array, sparse_tensor.to_tensor().to_numpy())
 
+
+    # canonical sparse coo matrix
+    scipy_matrix.sum_duplicates()
+    sparse_tensor = pa.SparseCOOTensor.from_scipy(scipy_matrix,
+                                                  dim_names=dim_names)
+    out_scipy_matrix = sparse_tensor.to_scipy()
+
+    assert scipy_matrix.has_canonical_format
+    assert sparse_tensor.has_canonical_format
+    assert out_scipy_matrix.has_canonical_format
 
 @pytest.mark.skipif(not csr_matrix, reason="requires scipy")
 @pytest.mark.parametrize('dtype_str,arrow_type', tensor_type_pairs)

--- a/python/pyarrow/tests/test_sparse_tensor.py
+++ b/python/pyarrow/tests/test_sparse_tensor.py
@@ -418,7 +418,6 @@ def test_sparse_coo_tensor_scipy_roundtrip(dtype_str, arrow_type):
         dense_array = scipy_matrix.toarray()
     assert np.array_equal(dense_array, sparse_tensor.to_tensor().to_numpy())
 
-
     # canonical sparse coo matrix
     scipy_matrix.sum_duplicates()
     sparse_tensor = pa.SparseCOOTensor.from_scipy(scipy_matrix,
@@ -428,6 +427,7 @@ def test_sparse_coo_tensor_scipy_roundtrip(dtype_str, arrow_type):
     assert scipy_matrix.has_canonical_format
     assert sparse_tensor.has_canonical_format
     assert out_scipy_matrix.has_canonical_format
+
 
 @pytest.mark.skipif(not csr_matrix, reason="requires scipy")
 @pytest.mark.parametrize('dtype_str,arrow_type', tensor_type_pairs)


### PR DESCRIPTION
To support the integration with scipy.sparse.coo_matrix, it is necessary to add a flag in SparseCOOIndex.  When this flag is true, a COO sparse tensor has a lexicographically-sorted index and doesn't have duplicated elements.

TODO:
- [X] C++ implementation
- [x] Python implementation
- [x] Add tests