### PR TITLE
ARROW-9175: [FlightRPC][C++] Expose peer to server

### DIFF
--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -392,7 +392,9 @@ class AuthTestServer : public FlightServerBase {
   Status DoAction(const ServerCallContext& context, const Action& action,
                   std::unique_ptr<ResultStream>* result) override {
     auto buf = Buffer::FromString(context.peer_identity());
-    *result = std::unique_ptr<ResultStream>(new SimpleResultStream({Result{buf}}));
+    auto peer = Buffer::FromString(context.peer());
+    *result = std::unique_ptr<ResultStream>(
+        new SimpleResultStream({Result{buf}, Result{peer}}));
     return Status::OK();
   }
 };
@@ -1527,6 +1529,11 @@ TEST_F(TestAuthHandler, CheckPeerIdentity) {
   ASSERT_NE(result, nullptr);
   // Action returns the peer identity as the result.
   ASSERT_EQ(result->body->ToString(), "user");
+
+  ASSERT_OK(results->Next(&result));
+  ASSERT_NE(result, nullptr);
+  // Action returns the peer address as the result.
+  ASSERT_NE(result->body->ToString(), "");
 }
 
 TEST_F(TestBasicAuthHandler, PassAuthenticatedCalls) {

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -359,9 +359,11 @@ class DoExchangeMessageWriter : public FlightMessageWriter {
 
 class FlightServiceImpl;
 class GrpcServerCallContext : public ServerCallContext {
-  explicit GrpcServerCallContext(grpc::ServerContext* context) : context_(context) {}
+  explicit GrpcServerCallContext(grpc::ServerContext* context)
+      : context_(context), peer_(context_->peer()) {}
 
   const std::string& peer_identity() const override { return peer_identity_; }
+  const std::string& peer() const override { return peer_; }
 
   // Helper method that runs interceptors given the result of an RPC,
   // then returns the final gRPC status to send to the client
@@ -392,6 +394,7 @@ class GrpcServerCallContext : public ServerCallContext {
  private:
   friend class FlightServiceImpl;
   ServerContext* context_;
+  std::string peer_;
   std::string peer_identity_;
   std::vector<std::shared_ptr<ServerMiddleware>> middleware_;
   std::unordered_map<std::string, std::shared_ptr<ServerMiddleware>> middleware_map_;

--- a/cpp/src/arrow/flight/server.h
+++ b/cpp/src/arrow/flight/server.h
@@ -113,6 +113,8 @@ class ARROW_FLIGHT_EXPORT ServerCallContext {
   virtual ~ServerCallContext() = default;
   /// \brief The name of the authenticated peer (may be the empty string)
   virtual const std::string& peer_identity() const = 0;
+  /// \brief The peer address (not validated)
+  virtual const std::string& peer() const = 0;
   /// \brief Look up a middleware by key. Do not maintain a reference
   /// to the object beyond the request body.
   /// \return The middleware, or nullptr if not found.

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1413,6 +1413,10 @@ cdef class ServerCallContext:
         """
         return tobytes(self.context.peer_identity())
 
+    def peer(self):
+        """Get the address of the peer."""
+        return frombytes(self.context.peer())
+
     def get_middleware(self, key):
         """
         Get a middleware instance by key.

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -206,6 +206,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
 
     cdef cppclass CServerCallContext" arrow::flight::ServerCallContext":
         c_string& peer_identity()
+        c_string& peer()
         CServerMiddleware* GetMiddleware(const c_string& key)
 
     cdef cppclass CTimeoutDuration" arrow::flight::TimeoutDuration":

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -215,7 +215,7 @@ class EchoStreamFlightServer(EchoFlightServer):
 
     def do_action(self, context, action):
         if action.type == "who-am-i":
-            return [context.peer_identity()]
+            return [context.peer_identity(), context.peer().encode("utf-8")]
         raise NotImplementedError
 
 
@@ -935,8 +935,11 @@ def test_http_basic_auth():
         client = FlightClient(('localhost', server.port))
         action = flight.Action("who-am-i", b"")
         client.authenticate(HttpBasicClientAuthHandler('test', 'p4ssw0rd'))
-        identity = next(client.do_action(action))
+        results = client.do_action(action)
+        identity = next(results)
         assert identity.body.to_pybytes() == b'test'
+        peer_address = next(results)
+        assert peer_address.body.to_pybytes() != b''
 
 
 def test_http_basic_auth_invalid_password():


### PR DESCRIPTION
Being able to read and log the client IP/port is often useful when analyzing a request after-the-fact.