### PR TITLE
ARROW-9174: [Go] Fix table panic on 386

### DIFF
--- a/go/arrow/array/table.go
+++ b/go/arrow/array/table.go
@@ -98,9 +98,9 @@ func (col *Column) NewSlice(i, j int64) *Column {
 
 // Chunked manages a collection of primitives arrays as one logical large array.
 type Chunked struct {
+	refCount int64 // refCount must be first in the struct for 64 bit alignment and sync/atomic (https://github.com/golang/go/issues/37262)
+	
 	chunks []Interface
-
-	refCount int64
 
 	length int
 	nulls  int


### PR DESCRIPTION
Due to a current bug in Go's `sync/atomic` , refCount must be the first property in the struct so it is byte aligned or it will panic.

Issue: https://issues.apache.org/jira/browse/ARROW-9174#