### PR TITLE
ARROW-9182: [C++] Use "applicator" namespace for some kernel execution functors. Streamline some applicator implementations

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -289,10 +289,11 @@ const std::vector<std::shared_ptr<DataType>>& TemporalTypes();
 const std::vector<std::shared_ptr<DataType>>& PrimitiveTypes();
 
 // ----------------------------------------------------------------------
-// Template functions and utilities for generating ArrayKernelExec functions
-// for kernels given functors providing the right kind of template / prototype
+// "Applicators" take an operator definition (which may be scalar-valued or
+// array-valued) and creates an ArrayKernelExec which can be used to add an
+// ArrayKernel to a Function.
 
-namespace codegen {
+namespace applicator {
 
 // Generate an ArrayKernelExec given a functor that handles all of its own
 // iteration, etc.
@@ -642,7 +643,7 @@ struct ScalarBinary {
 template <typename OutType, typename ArgType, typename Op>
 using ScalarBinaryEqualTypes = ScalarBinary<OutType, ArgType, ArgType, Op>;
 
-}  // namespace codegen
+}  // namespace applicator
 
 // ----------------------------------------------------------------------
 // BEGIN of kernel generator-dispatchers ("GD")

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -49,6 +49,7 @@
 namespace arrow {
 
 using internal::BitmapReader;
+using internal::checked_cast;
 using internal::FirstTimeBitmapWriter;
 using internal::GenerateBitsUnrolled;
 
@@ -151,22 +152,22 @@ struct UnboxScalar;
 template <typename Type>
 struct UnboxScalar<Type, enable_if_has_c_type<Type>> {
   using ScalarType = ::arrow::internal::PrimitiveScalar<typename Type::PhysicalType>;
-  static typename Type::c_type Unbox(const Datum& datum) {
-    return datum.scalar_as<ScalarType>().value;
+  static typename Type::c_type Unbox(const Scalar& val) {
+    return checked_cast<const ScalarType&>(val).value;
   }
 };
 
 template <typename Type>
 struct UnboxScalar<Type, enable_if_base_binary<Type>> {
-  static util::string_view Unbox(const Datum& datum) {
-    return util::string_view(*datum.scalar_as<BaseBinaryScalar>().value);
+  static util::string_view Unbox(const Scalar& val) {
+    return util::string_view(*checked_cast<const BaseBinaryScalar&>(val).value);
   }
 };
 
 template <>
 struct UnboxScalar<Decimal128Type> {
-  static Decimal128 Unbox(const Datum& datum) {
-    return datum.scalar_as<Decimal128Scalar>().value;
+  static Decimal128 Unbox(const Scalar& val) {
+    return checked_cast<const Decimal128Scalar&>(val).value;
   }
 };
 
@@ -385,27 +386,27 @@ struct ScalarUnary {
   using OUT = typename GetOutputType<OutType>::T;
   using ARG0 = typename GetViewType<Arg0Type>::T;
 
-  static void Array(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    ArrayIterator<Arg0Type> arg0(*batch[0].array());
+  static void Array(KernelContext* ctx, const ArrayData& arg0, Datum* out) {
+    ArrayIterator<Arg0Type> arg0_it(arg0);
     OutputAdapter<OutType>::Write(
-        ctx, out, [&]() -> OUT { return Op::template Call<OUT, ARG0>(ctx, arg0()); });
+        ctx, out, [&]() -> OUT { return Op::template Call<OUT, ARG0>(ctx, arg0_it()); });
   }
 
-  static void Scalar(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    if (batch[0].scalar()->is_valid) {
-      ARG0 arg0 = UnboxScalar<Arg0Type>::Unbox(batch[0]);
-      out->value =
-          BoxScalar<OutType>::Box(Op::template Call<OUT, ARG0>(ctx, arg0), out->type());
+  static void Scalar(KernelContext* ctx, const Scalar& arg0, Datum* out) {
+    if (arg0.is_valid) {
+      ARG0 arg0_val = UnboxScalar<Arg0Type>::Unbox(arg0);
+      out->value = BoxScalar<OutType>::Box(Op::template Call<OUT, ARG0>(ctx, arg0_val),
+                                           out->type());
     } else {
-      out->value = MakeNullScalar(batch[0].type());
+      out->value = MakeNullScalar(arg0.type);
     }
   }
 
   static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     if (batch[0].kind() == Datum::ARRAY) {
-      return Array(ctx, batch, out);
+      return Array(ctx, *batch[0].array(), out);
     } else {
-      return Scalar(ctx, batch, out);
+      return Scalar(ctx, *batch[0].scalar(), out);
     }
   }
 };
@@ -457,11 +458,11 @@ struct ScalarUnaryNotNullStateful {
   template <typename Type>
   struct ArrayExec<
       Type, enable_if_t<has_c_type<Type>::value && !is_boolean_type<Type>::value>> {
-    static void Exec(const ThisType& functor, KernelContext* ctx, const ExecBatch& batch,
+    static void Exec(const ThisType& functor, KernelContext* ctx, const ArrayData& arg0,
                      Datum* out) {
       ArrayData* out_arr = out->mutable_array();
       auto out_data = out_arr->GetMutableValues<OUT>(1);
-      VisitArrayValuesInline<Arg0Type>(*batch[0].array(), [&](util::optional<ARG0> v) {
+      VisitArrayValuesInline<Arg0Type>(arg0, [&](util::optional<ARG0> v) {
         if (v.has_value()) {
           *out_data = functor.op.template Call<OUT, ARG0>(ctx, *v);
         }
@@ -472,14 +473,14 @@ struct ScalarUnaryNotNullStateful {
 
   template <typename Type>
   struct ArrayExec<Type, enable_if_base_binary<Type>> {
-    static void Exec(const ThisType& functor, KernelContext* ctx, const ExecBatch& batch,
+    static void Exec(const ThisType& functor, KernelContext* ctx, const ArrayData& arg0,
                      Datum* out) {
       // NOTE: This code is not currently used by any kernels and has
       // suboptimal performance because it's recomputing the validity bitmap
       // that is already computed by the kernel execution layer. Consider
       // writing a lower-level "output adapter" for base binary types.
       typename TypeTraits<Type>::BuilderType builder;
-      VisitArrayValuesInline<Arg0Type>(*batch[0].array(), [&](util::optional<ARG0> v) {
+      VisitArrayValuesInline<Arg0Type>(arg0, [&](util::optional<ARG0> v) {
         if (v.has_value()) {
           KERNEL_RETURN_IF_ERROR(ctx, builder.Append(functor.op.Call(ctx, *v)));
         } else {
@@ -496,12 +497,12 @@ struct ScalarUnaryNotNullStateful {
 
   template <typename Type>
   struct ArrayExec<Type, enable_if_t<is_boolean_type<Type>::value>> {
-    static void Exec(const ThisType& functor, KernelContext* ctx, const ExecBatch& batch,
+    static void Exec(const ThisType& functor, KernelContext* ctx, const ArrayData& arg0,
                      Datum* out) {
       ArrayData* out_arr = out->mutable_array();
       FirstTimeBitmapWriter out_writer(out_arr->buffers[1]->mutable_data(),
                                        out_arr->offset, out_arr->length);
-      VisitArrayValuesInline<Arg0Type>(*batch[0].array(), [&](util::optional<ARG0> v) {
+      VisitArrayValuesInline<Arg0Type>(arg0, [&](util::optional<ARG0> v) {
         if (v.has_value()) {
           if (functor.op.template Call<OUT, ARG0>(ctx, *v)) {
             out_writer.Set();
@@ -515,11 +516,11 @@ struct ScalarUnaryNotNullStateful {
 
   template <typename Type>
   struct ArrayExec<Type, enable_if_t<std::is_same<Type, Decimal128Type>::value>> {
-    static void Exec(const ThisType& functor, KernelContext* ctx, const ExecBatch& batch,
+    static void Exec(const ThisType& functor, KernelContext* ctx, const ArrayData& arg0,
                      Datum* out) {
       ArrayData* out_arr = out->mutable_array();
       auto out_data = out_arr->GetMutableValues<uint8_t>(1);
-      VisitArrayValuesInline<Arg0Type>(*batch[0].array(), [&](util::optional<ARG0> v) {
+      VisitArrayValuesInline<Arg0Type>(arg0, [&](util::optional<ARG0> v) {
         if (v.has_value()) {
           functor.op.template Call<OUT, ARG0>(ctx, *v).ToBytes(out_data);
         }
@@ -528,21 +529,21 @@ struct ScalarUnaryNotNullStateful {
     }
   };
 
-  void Scalar(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    if (batch[0].scalar()->is_valid) {
-      ARG0 arg0 = UnboxScalar<Arg0Type>::Unbox(batch[0]);
-      out->value = BoxScalar<OutType>::Box(this->op.template Call<OUT, ARG0>(ctx, arg0),
-                                           out->type());
+  void Scalar(KernelContext* ctx, const Scalar& arg0, Datum* out) {
+    if (arg0.is_valid) {
+      ARG0 arg0_val = UnboxScalar<Arg0Type>::Unbox(arg0);
+      out->value = BoxScalar<OutType>::Box(
+          this->op.template Call<OUT, ARG0>(ctx, arg0_val), out->type());
     } else {
-      out->value = MakeNullScalar(batch[0].type());
+      out->value = MakeNullScalar(arg0.type);
     }
   }
 
   void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     if (batch[0].kind() == Datum::ARRAY) {
-      ArrayExec<OutType>::Exec(*this, ctx, batch, out);
+      ArrayExec<OutType>::Exec(*this, ctx, *batch[0].array(), out);
     } else {
-      return Scalar(ctx, batch, out);
+      return Scalar(ctx, *batch[0].scalar(), out);
     }
   }
 };
@@ -584,49 +585,53 @@ struct ScalarBinary {
   using ARG0 = typename GetViewType<Arg0Type>::T;
   using ARG1 = typename GetViewType<Arg1Type>::T;
 
-  static void ArrayArray(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    ArrayIterator<Arg0Type> arg0(*batch[0].array());
-    ArrayIterator<Arg1Type> arg1(*batch[1].array());
+  static void ArrayArray(KernelContext* ctx, const ArrayData& arg0, const ArrayData& arg1,
+                         Datum* out) {
+    ArrayIterator<Arg0Type> arg0_it(arg0);
+    ArrayIterator<Arg1Type> arg1_it(arg1);
     OutputAdapter<OutType>::Write(
-        ctx, out, [&]() -> OUT { return Op::template Call(ctx, arg0(), arg1()); });
+        ctx, out, [&]() -> OUT { return Op::template Call(ctx, arg0_it(), arg1_it()); });
   }
 
-  static void ArrayScalar(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    ArrayIterator<Arg0Type> arg0(*batch[0].array());
-    auto arg1 = UnboxScalar<Arg1Type>::Unbox(batch[1]);
+  static void ArrayScalar(KernelContext* ctx, const ArrayData& arg0, const Scalar& arg1,
+                          Datum* out) {
+    ArrayIterator<Arg0Type> arg0_it(arg0);
+    auto arg1_val = UnboxScalar<Arg1Type>::Unbox(arg1);
     OutputAdapter<OutType>::Write(
-        ctx, out, [&]() -> OUT { return Op::template Call(ctx, arg0(), arg1); });
+        ctx, out, [&]() -> OUT { return Op::template Call(ctx, arg0_it(), arg1_val); });
   }
 
-  static void ScalarArray(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    auto arg0 = UnboxScalar<Arg0Type>::Unbox(batch[0]);
-    ArrayIterator<Arg1Type> arg1(*batch[1].array());
+  static void ScalarArray(KernelContext* ctx, const Scalar& arg0, const ArrayData& arg1,
+                          Datum* out) {
+    auto arg0_val = UnboxScalar<Arg0Type>::Unbox(arg0);
+    ArrayIterator<Arg1Type> arg1_it(arg1);
     OutputAdapter<OutType>::Write(
-        ctx, out, [&]() -> OUT { return Op::template Call(ctx, arg0, arg1()); });
+        ctx, out, [&]() -> OUT { return Op::template Call(ctx, arg0_val, arg1_it()); });
   }
 
-  static void ScalarScalar(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+  static void ScalarScalar(KernelContext* ctx, const Scalar& arg0, const Scalar& arg1,
+                           Datum* out) {
     if (out->scalar()->is_valid) {
-      auto arg0 = UnboxScalar<Arg0Type>::Unbox(batch[0]);
-      auto arg1 = UnboxScalar<Arg1Type>::Unbox(batch[1]);
-      out->value =
-          BoxScalar<OutType>::Box(Op::template Call(ctx, arg0, arg1), out->type());
+      auto arg0_val = UnboxScalar<Arg0Type>::Unbox(arg0);
+      auto arg1_val = UnboxScalar<Arg1Type>::Unbox(arg1);
+      out->value = BoxScalar<OutType>::Box(Op::template Call(ctx, arg0_val, arg1_val),
+                                           out->type());
     }
   }
 
   static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     if (batch[0].kind() == Datum::ARRAY) {
       if (batch[1].kind() == Datum::ARRAY) {
-        return ArrayArray(ctx, batch, out);
+        return ArrayArray(ctx, *batch[0].array(), *batch[1].array(), out);
       } else {
-        return ArrayScalar(ctx, batch, out);
+        return ArrayScalar(ctx, *batch[0].array(), *batch[1].scalar(), out);
       }
     } else {
       if (batch[1].kind() == Datum::ARRAY) {
         // e.g. if we were doing scalar < array, we flip and do array >= scalar
-        return ScalarArray(ctx, batch, out);
+        return ScalarArray(ctx, *batch[0].scalar(), *batch[1].array(), out);
       } else {
-        return ScalarScalar(ctx, batch, out);
+        return ScalarScalar(ctx, *batch[0].scalar(), *batch[1].scalar(), out);
       }
     }
   }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -24,6 +24,7 @@
 
 namespace arrow {
 namespace compute {
+namespace {
 
 template <typename T>
 using is_unsigned_integer = std::integral_constant<bool, std::is_integral<T>::value &&
@@ -217,7 +218,7 @@ struct MultiplyChecked {
   }
 };
 
-namespace codegen {
+using applicator::ScalarBinaryEqualTypes;
 
 // Generate a kernel given an arithmetic functor
 //
@@ -257,23 +258,23 @@ template <typename Op>
 void AddBinaryFunction(std::string name, FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Binary());
   for (const auto& ty : NumericTypes()) {
-    auto exec = codegen::NumericEqualTypesBinary<Op>(ty);
+    auto exec = NumericEqualTypesBinary<Op>(ty);
     DCHECK_OK(func->AddKernel({ty, ty}, ty, exec));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));
 }
 
-}  // namespace codegen
+}  // namespace
 
 namespace internal {
 
 void RegisterScalarArithmetic(FunctionRegistry* registry) {
-  codegen::AddBinaryFunction<Add>("add", registry);
-  codegen::AddBinaryFunction<AddChecked>("add_checked", registry);
-  codegen::AddBinaryFunction<Subtract>("subtract", registry);
-  codegen::AddBinaryFunction<SubtractChecked>("subtract_checked", registry);
-  codegen::AddBinaryFunction<Multiply>("multiply", registry);
-  codegen::AddBinaryFunction<MultiplyChecked>("multiply_checked", registry);
+  AddBinaryFunction<Add>("add", registry);
+  AddBinaryFunction<AddChecked>("add_checked", registry);
+  AddBinaryFunction<Subtract>("subtract", registry);
+  AddBinaryFunction<SubtractChecked>("subtract_checked", registry);
+  AddBinaryFunction<Multiply>("multiply", registry);
+  AddBinaryFunction<MultiplyChecked>("multiply_checked", registry);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_boolean.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_boolean.cc
@@ -177,15 +177,15 @@ namespace internal {
 
 void RegisterScalarBoolean(FunctionRegistry* registry) {
   // These functions can write into sliced output bitmaps
-  MakeFunction("invert", 1, codegen::SimpleUnary<Invert>, registry);
-  MakeFunction("and", 2, codegen::SimpleBinary<And>, registry);
-  MakeFunction("or", 2, codegen::SimpleBinary<Or>, registry);
-  MakeFunction("xor", 2, codegen::SimpleBinary<Xor>, registry);
+  MakeFunction("invert", 1, applicator::SimpleUnary<Invert>, registry);
+  MakeFunction("and", 2, applicator::SimpleBinary<And>, registry);
+  MakeFunction("or", 2, applicator::SimpleBinary<Or>, registry);
+  MakeFunction("xor", 2, applicator::SimpleBinary<Xor>, registry);
 
   // The Kleene logic kernels cannot write into sliced output bitmaps
-  MakeFunction("and_kleene", 2, codegen::SimpleBinary<KleeneAnd>, registry,
+  MakeFunction("and_kleene", 2, applicator::SimpleBinary<KleeneAnd>, registry,
                /*can_write_into_slices=*/false, NullHandling::COMPUTED_PREALLOCATE);
-  MakeFunction("or_kleene", 2, codegen::SimpleBinary<KleeneOr>, registry,
+  MakeFunction("or_kleene", 2, applicator::SimpleBinary<KleeneOr>, registry,
                /*can_write_into_slices=*/false, NullHandling::COMPUTED_PREALLOCATE);
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
@@ -52,12 +52,12 @@ std::vector<std::shared_ptr<CastFunction>> GetBooleanCasts() {
 
   for (const auto& ty : NumericTypes()) {
     ArrayKernelExec exec =
-        GenerateNumeric<codegen::ScalarUnary, BooleanType, IsNonZero>(*ty);
+        GenerateNumeric<applicator::ScalarUnary, BooleanType, IsNonZero>(*ty);
     DCHECK_OK(func->AddKernel(ty->id(), {ty}, boolean(), exec));
   }
   for (const auto& ty : BaseBinaryTypes()) {
-    ArrayKernelExec exec = GenerateVarBinaryBase<codegen::ScalarUnaryNotNull, BooleanType,
-                                                 ParseBooleanString>(*ty);
+    ArrayKernelExec exec = GenerateVarBinaryBase<applicator::ScalarUnaryNotNull,
+                                                 BooleanType, ParseBooleanString>(*ty);
     DCHECK_OK(func->AddKernel(ty->id(), {ty}, boolean(), exec));
   }
   return {func};

--- a/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
@@ -270,7 +270,7 @@ template <typename I>
 struct CastFunctor<TimestampType, I, enable_if_t<is_base_binary_type<I>::value>> {
   static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     const auto& out_type = checked_cast<const TimestampType&>(*out->type());
-    codegen::ScalarUnaryNotNullStateful<TimestampType, I, ParseTimestamp> kernel(
+    applicator::ScalarUnaryNotNullStateful<TimestampType, I, ParseTimestamp> kernel(
         ParseTimestamp(out_type.unit()));
     return kernel.Exec(ctx, batch, out);
   }

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -61,7 +61,7 @@ struct GreaterEqual {
 template <typename Op>
 void AddIntegerCompare(const std::shared_ptr<DataType>& ty, ScalarFunction* func) {
   auto exec =
-      GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
+      GeneratePhysicalInteger<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
   DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));
 }
 
@@ -69,7 +69,7 @@ template <typename InType, typename Op>
 void AddGenericCompare(const std::shared_ptr<DataType>& ty, ScalarFunction* func) {
   DCHECK_OK(
       func->AddKernel({ty, ty}, boolean(),
-                      codegen::ScalarBinaryEqualTypes<BooleanType, InType, Op>::Exec));
+                      applicator::ScalarBinaryEqualTypes<BooleanType, InType, Op>::Exec));
 }
 
 template <typename Op>
@@ -78,7 +78,7 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name) {
 
   DCHECK_OK(func->AddKernel(
       {boolean(), boolean()}, boolean(),
-      codegen::ScalarBinary<BooleanType, BooleanType, BooleanType, Op>::Exec));
+      applicator::ScalarBinary<BooleanType, BooleanType, BooleanType, Op>::Exec));
 
   for (const std::shared_ptr<DataType>& ty : IntTypes()) {
     AddIntegerCompare<Op>(ty, func.get());
@@ -92,36 +92,40 @@ std::shared_ptr<ScalarFunction> MakeCompareFunction(std::string name) {
   // Add timestamp kernels
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
     InputType in_type(match::TimestampTypeUnit(unit));
-    auto exec = GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(
-        int64());
+    auto exec =
+        GeneratePhysicalInteger<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(
+            int64());
     DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
 
   // Duration
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
     InputType in_type(match::DurationTypeUnit(unit));
-    auto exec = GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(
-        int64());
+    auto exec =
+        GeneratePhysicalInteger<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(
+            int64());
     DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
 
   // Time32 and Time64
   for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI}) {
     InputType in_type(match::Time32TypeUnit(unit));
-    auto exec = GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(
-        int32());
+    auto exec =
+        GeneratePhysicalInteger<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(
+            int32());
     DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
   for (auto unit : {TimeUnit::MICRO, TimeUnit::NANO}) {
     InputType in_type(match::Time64TypeUnit(unit));
-    auto exec = GeneratePhysicalInteger<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(
-        int64());
+    auto exec =
+        GeneratePhysicalInteger<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(
+            int64());
     DCHECK_OK(func->AddKernel({in_type, in_type}, boolean(), std::move(exec)));
   }
 
   for (const std::shared_ptr<DataType>& ty : BaseBinaryTypes()) {
     auto exec =
-        GenerateVarBinaryBase<codegen::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
+        GenerateVarBinaryBase<applicator::ScalarBinaryEqualTypes, BooleanType, Op>(*ty);
     DCHECK_OK(func->AddKernel({ty, ty}, boolean(), std::move(exec)));
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -142,9 +142,9 @@ struct AsciiLower {
 void AddAsciiLength(FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>("ascii_length", Arity::Unary());
   ArrayKernelExec exec_offset_32 =
-      codegen::ScalarUnaryNotNull<Int32Type, StringType, AsciiLength>::Exec;
+      applicator::ScalarUnaryNotNull<Int32Type, StringType, AsciiLength>::Exec;
   ArrayKernelExec exec_offset_64 =
-      codegen::ScalarUnaryNotNull<Int64Type, LargeStringType, AsciiLength>::Exec;
+      applicator::ScalarUnaryNotNull<Int64Type, LargeStringType, AsciiLength>::Exec;
   DCHECK_OK(func->AddKernel({utf8()}, int32(), exec_offset_32));
   DCHECK_OK(func->AddKernel({large_utf8()}, int64(), exec_offset_64));
   DCHECK_OK(registry->AddFunction(std::move(func)));
@@ -175,7 +175,7 @@ struct ParseStrptime {
 template <typename InputType>
 void StrptimeExec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   const auto& options = checked_cast<const StrptimeWrapper*>(ctx->state())->options;
-  codegen::ScalarUnaryNotNullStateful<TimestampType, InputType, ParseStrptime> kernel{
+  applicator::ScalarUnaryNotNullStateful<TimestampType, InputType, ParseStrptime> kernel{
       ParseStrptime(options)};
   return kernel.Exec(ctx, batch, out);
 }

--- a/cpp/src/arrow/compute/kernels/scalar_string_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_string_internal.h
@@ -31,9 +31,9 @@ template <typename Op>
 void MakeUnaryStringToString(std::string name, FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary());
   ArrayKernelExec exec_offset_32 =
-      codegen::ScalarUnaryNotNull<StringType, StringType, Op>::Exec;
+      applicator::ScalarUnaryNotNull<StringType, StringType, Op>::Exec;
   ArrayKernelExec exec_offset_64 =
-      codegen::ScalarUnaryNotNull<LargeStringType, LargeStringType, Op>::Exec;
+      applicator::ScalarUnaryNotNull<LargeStringType, LargeStringType, Op>::Exec;
   DCHECK_OK(func->AddKernel({utf8()}, utf8(), exec_offset_32));
   DCHECK_OK(func->AddKernel({large_utf8()}, large_utf8(), exec_offset_64));
   DCHECK_OK(registry->AddFunction(std::move(func)));

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -94,11 +94,12 @@ namespace internal {
 
 void RegisterScalarValidity(FunctionRegistry* registry) {
   MakeFunction("is_valid", {ValueDescr::ANY}, boolean(),
-               codegen::SimpleUnary<IsValidOperator>, registry,
+               applicator::SimpleUnary<IsValidOperator>, registry,
                MemAllocation::NO_PREALLOCATE, /*can_write_into_slices=*/false);
 
   MakeFunction("is_null", {ValueDescr::ANY}, boolean(),
-               codegen::SimpleUnary<IsNullOperator>, registry, MemAllocation::PREALLOCATE,
+               applicator::SimpleUnary<IsNullOperator>, registry,
+               MemAllocation::PREALLOCATE,
                /*can_write_into_slices=*/true);
 }
 


### PR DESCRIPTION
In addition to using the "applicator" name, I am moving the argument unboxing a level higher in several places