### PR TITLE
ARROW-9183: [C++] Fix build with clang & old libstdc++.

### DIFF
--- a/cpp/src/arrow/util/atomic_shared_ptr.h
+++ b/cpp/src/arrow/util/atomic_shared_ptr.h
@@ -24,7 +24,9 @@
 namespace arrow {
 namespace internal {
 
-#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ < 5
+// https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html#abi.versioning
+// https://gcc.gnu.org/develop.html#timeline
+#if defined(__GLIBCXX__) && __GLIBCXX__ < 20150422
 
 // atomic shared_ptr operations only appeared in gcc 5,
 // emulate them with unsafe ops on gcc 4.x.
@@ -39,7 +41,7 @@ inline void atomic_store(std::shared_ptr<T>* p, std::shared_ptr<T> r) {
   *p = r;
 }
 
-#else
+#else  // defined(__GLIBCXX__) && __GLIBCXX__ < 20150422
 
 template <class T>
 inline std::shared_ptr<T> atomic_load(const std::shared_ptr<T>* p) {
@@ -51,7 +53,7 @@ inline void atomic_store(std::shared_ptr<T>* p, std::shared_ptr<T> r) {
   std::atomic_store(p, std::move(r));
 }
 
-#endif
+#endif  // defined(__GLIBCXX__) && __GLIBCXX__ < 20150422
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/atomic_shared_ptr.h
+++ b/cpp/src/arrow/util/atomic_shared_ptr.h
@@ -24,12 +24,13 @@
 namespace arrow {
 namespace internal {
 
-// https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html#abi.versioning
-// https://gcc.gnu.org/develop.html#timeline
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20150422
 
-// atomic shared_ptr operations only appeared in gcc 5,
-// emulate them with unsafe ops on gcc 4.x.
+// Atomic shared_ptr operations only appeared in gcc 5's libstdc++,
+// emulate them with unsafe ops if unavailable.
+//
+// The libstdc++ version is a the encoded release date of gcc 5, see
+// https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html#abi.versioning.__GLIBCXX__
 
 template <class T>
 inline std::shared_ptr<T> atomic_load(const std::shared_ptr<T>* p) {

--- a/cpp/src/arrow/util/atomic_shared_ptr.h
+++ b/cpp/src/arrow/util/atomic_shared_ptr.h
@@ -24,7 +24,11 @@
 namespace arrow {
 namespace internal {
 
-#if defined(__GLIBCXX__) && __GLIBCXX__ < 20150422
+#if defined(__GLIBCPP__) /* Before GCC 3.4.0 */ ||                           \
+    (defined(__GLIBCXX__) && __GLIBCXX__ < 20150422 /* Before GCC 5.1 */) || \
+    (defined(__GLIBCXX__) && __GLIBCXX__ == 20150623 /* GCC 4.8.5 */) ||     \
+    (defined(__GLIBCXX__) && __GLIBCXX__ == 20150626 /* GCC 4.9.3 */) ||     \
+    (defined(__GLIBCXX__) && __GLIBCXX__ == 20160803 /* GCC 4.9.4 */)
 
 // Atomic shared_ptr operations only appeared in gcc 5's libstdc++,
 // emulate them with unsafe ops if unavailable.
@@ -42,7 +46,7 @@ inline void atomic_store(std::shared_ptr<T>* p, std::shared_ptr<T> r) {
   *p = r;
 }
 
-#else  // defined(__GLIBCXX__) && __GLIBCXX__ < 20150422
+#else  // GLIBC version < 5
 
 template <class T>
 inline std::shared_ptr<T> atomic_load(const std::shared_ptr<T>* p) {
@@ -54,7 +58,7 @@ inline void atomic_store(std::shared_ptr<T>* p, std::shared_ptr<T> r) {
   std::atomic_store(p, std::move(r));
 }
 
-#endif  // defined(__GLIBCXX__) && __GLIBCXX__ < 20150422
+#endif  // GLIBC version < 5
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/type_traits.h
+++ b/cpp/src/arrow/util/type_traits.h
@@ -41,14 +41,5 @@ template <typename T>
 struct is_null_pointer : std::is_same<std::nullptr_t, typename std::remove_cv<T>::type> {
 };
 
-template <typename... Ts>
-struct VoidTImpl {
-  using type = void;
-};
-
-/// \brief void_t from C++17
-template <typename... Ts>
-using void_t = typename VoidTImpl<Ts...>::type;
-
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/type_traits.h
+++ b/cpp/src/arrow/util/type_traits.h
@@ -41,5 +41,14 @@ template <typename T>
 struct is_null_pointer : std::is_same<std::nullptr_t, typename std::remove_cv<T>::type> {
 };
 
+template <typename... Ts>
+struct VoidTImpl {
+  using type = void;
+};
+
+/// \brief void_t from C++17
+template <typename... Ts>
+using void_t = typename VoidTImpl<Ts...>::type;
+
 }  // namespace internal
 }  // namespace arrow


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/ARROW-9183# for further details & discussion.