### PR TITLE
ARROW-7084: [C++] Check for full type equality in ArrayRangeEquals

### DIFF
--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -208,6 +208,11 @@ class ARROW_EXPORT MapArray : public ListArray {
       const std::shared_ptr<Array>& offsets, const std::shared_ptr<Array>& keys,
       const std::shared_ptr<Array>& items, MemoryPool* pool = default_memory_pool());
 
+  static Result<std::shared_ptr<Array>> FromArrays(
+      std::shared_ptr<DataType> type, const std::shared_ptr<Array>& offsets,
+      const std::shared_ptr<Array>& keys, const std::shared_ptr<Array>& items,
+      MemoryPool* pool = default_memory_pool());
+
   const MapType* map_type() const { return map_type_; }
 
   /// \brief Return array object containing all map keys
@@ -222,6 +227,11 @@ class ARROW_EXPORT MapArray : public ListArray {
 
  protected:
   void SetData(const std::shared_ptr<ArrayData>& data);
+
+  static Result<std::shared_ptr<Array>> FromArraysInternal(
+      std::shared_ptr<DataType> type, const std::shared_ptr<Array>& offsets,
+      const std::shared_ptr<Array>& keys, const std::shared_ptr<Array>& items,
+      MemoryPool* pool);
 
  private:
   const MapType* map_type_;

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -157,6 +157,7 @@ TEST_F(TestArray, TestEquality) {
   // ARROW-2567: Ensure that not only the type id but also the type equality
   // itself is checked.
   ASSERT_FALSE(timestamp_us_array->Equals(timestamp_ns_array));
+  ASSERT_TRUE(timestamp_us_array->RangeEquals(0, 1, 0, timestamp_us_array));
   ASSERT_FALSE(timestamp_us_array->RangeEquals(0, 1, 0, timestamp_ns_array));
 }
 

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -157,6 +157,7 @@ TEST_F(TestArray, TestEquality) {
   // ARROW-2567: Ensure that not only the type id but also the type equality
   // itself is checked.
   ASSERT_FALSE(timestamp_us_array->Equals(timestamp_ns_array));
+  ASSERT_FALSE(timestamp_us_array->RangeEquals(0, 1, 0, timestamp_ns_array));
 }
 
 TEST_F(TestArray, TestNullArrayEquality) {

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -147,9 +147,10 @@ class RangeEqualsVisitor {
     return Status::OK();
   }
 
-  template <typename BinaryArrayType>
-  bool CompareBinaryRange(const BinaryArrayType& left) const {
-    const auto& right = checked_cast<const BinaryArrayType&>(right_);
+  template <typename ArrayType, typename CompareValuesFunc>
+  bool CompareWithOffsets(const ArrayType& left,
+                          CompareValuesFunc&& compare_values) const {
+    const auto& right = checked_cast<const ArrayType&>(right_);
 
     for (int64_t i = left_start_idx_, o_i = right_start_idx_; i < left_end_idx_;
          ++i, ++o_i) {
@@ -167,44 +168,72 @@ class RangeEqualsVisitor {
         return false;
       }
 
-      if (end_offset - begin_offset > 0 &&
-          std::memcmp(left.value_data()->data() + begin_offset,
-                      right.value_data()->data() + right_begin_offset,
-                      static_cast<size_t>(end_offset - begin_offset))) {
+      if (!compare_values(left, right, begin_offset, right_begin_offset,
+                          end_offset - begin_offset)) {
         return false;
       }
     }
     return true;
   }
 
+  template <typename BinaryArrayType>
+  bool CompareBinaryRange(const BinaryArrayType& left) const {
+    using offset_type = typename BinaryArrayType::offset_type;
+
+    auto compare_values = [](const BinaryArrayType& left, const BinaryArrayType& right,
+                             offset_type left_offset, offset_type right_offset,
+                             offset_type nvalues) {
+      if (nvalues == 0) {
+        return true;
+      }
+      return std::memcmp(left.value_data()->data() + left_offset,
+                         right.value_data()->data() + right_offset,
+                         static_cast<size_t>(nvalues)) == 0;
+    };
+    return CompareWithOffsets(left, compare_values);
+  }
+
   template <typename ListArrayType>
   bool CompareLists(const ListArrayType& left) {
+    using offset_type = typename ListArrayType::offset_type;
     const auto& right = checked_cast<const ListArrayType&>(right_);
-
     const std::shared_ptr<Array>& left_values = left.values();
     const std::shared_ptr<Array>& right_values = right.values();
 
-    for (int64_t i = left_start_idx_, o_i = right_start_idx_; i < left_end_idx_;
-         ++i, ++o_i) {
-      const bool is_null = left.IsNull(i);
-      if (is_null != right.IsNull(o_i)) {
-        return false;
+    auto compare_values = [&](const ListArrayType& left, const ListArrayType& right,
+                              offset_type left_offset, offset_type right_offset,
+                              offset_type nvalues) {
+      if (nvalues == 0) {
+        return true;
       }
-      if (is_null) continue;
-      const auto begin_offset = left.value_offset(i);
-      const auto end_offset = left.value_offset(i + 1);
-      const auto right_begin_offset = right.value_offset(o_i);
-      const auto right_end_offset = right.value_offset(o_i + 1);
-      // Underlying can't be equal if the size isn't equal
-      if (end_offset - begin_offset != right_end_offset - right_begin_offset) {
-        return false;
+      return left_values->RangeEquals(left_offset, left_offset + nvalues, right_offset,
+                                      right_values);
+    };
+    return CompareWithOffsets(left, compare_values);
+  }
+
+  bool CompareMaps(const MapArray& left) {
+    // We need a specific comparison helper for maps to avoid comparing
+    // struct field names (which are indifferent for maps)
+    using offset_type = typename MapArray::offset_type;
+    const auto& right = checked_cast<const MapArray&>(right_);
+    const auto left_keys = left.keys();
+    const auto left_items = left.items();
+    const auto right_keys = right.keys();
+    const auto right_items = right.items();
+
+    auto compare_values = [&](const MapArray& left, const MapArray& right,
+                              offset_type left_offset, offset_type right_offset,
+                              offset_type nvalues) {
+      if (nvalues == 0) {
+        return true;
       }
-      if (!left_values->RangeEquals(begin_offset, end_offset, right_begin_offset,
-                                    right_values)) {
-        return false;
-      }
-    }
-    return true;
+      return left_keys->RangeEquals(left_offset, left_offset + nvalues, right_offset,
+                                    right_keys) &&
+             left_items->RangeEquals(left_offset, left_offset + nvalues, right_offset,
+                                     right_items);
+    };
+    return CompareWithOffsets(left, compare_values);
   }
 
   bool CompareStructs(const StructArray& left) {
@@ -350,6 +379,11 @@ class RangeEqualsVisitor {
     result_ = left.values()->RangeEquals(
         left.value_offset(left_start_idx_), left.value_offset(left_end_idx_),
         right.value_offset(right_start_idx_), right.values());
+    return Status::OK();
+  }
+
+  Status Visit(const MapArray& left) {
+    result_ = CompareMaps(left);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -984,7 +984,8 @@ bool ArrayRangeEquals(const Array& left, const Array& right, int64_t left_start_
   bool are_equal;
   if (&left == &right) {
     are_equal = true;
-  } else if (left.type_id() != right.type_id() || !TypeEquals(*left.type(), *right.type(), false /* check_metadata */)) {
+  } else if (left.type_id() != right.type_id() ||
+             !TypeEquals(*left.type(), *right.type(), false /* check_metadata */)) {
     are_equal = false;
   } else if (left.length() == 0) {
     are_equal = true;

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -984,7 +984,7 @@ bool ArrayRangeEquals(const Array& left, const Array& right, int64_t left_start_
   bool are_equal;
   if (&left == &right) {
     are_equal = true;
-  } else if (left.type_id() != right.type_id()) {
+  } else if (left.type_id() != right.type_id() || !TypeEquals(*left.type(), *right.type(), false /* check_metadata */)) {
     are_equal = false;
   } else if (left.length() == 0) {
     are_equal = true;

--- a/cpp/src/arrow/ipc/json_test.cc
+++ b/cpp/src/arrow/ipc/json_test.cc
@@ -239,7 +239,7 @@ static const char* json_example4 = R"example(
             "nullable": false,
             "children": [
               {
-                "name": "key",
+                "name": "some_key",
                 "type": {
                   "name": "int",
                   "isSigned": true,
@@ -249,7 +249,7 @@ static const char* json_example4 = R"example(
                 "children": []
               },
               {
-                "name": "value",
+                "name": "some_value",
                 "type": {
                   "name": "int",
                   "isSigned": true,
@@ -280,13 +280,13 @@ static const char* json_example4 = R"example(
               "VALIDITY": [1, 1, 1, 1, 1],
               "children": [
                 {
-                  "name": "key",
+                  "name": "some_key",
                   "count": 5,
                   "VALIDITY": [1, 1, 1, 1, 1],
                   "DATA": [11, 22, 33, 44, 55]
                 },
                 {
-                  "name": "value",
+                  "name": "some_value",
                   "count": 5,
                   "VALIDITY": [1, 1, 0, 1, 1],
                   "DATA": [111, 222, 0, 444, 555]
@@ -667,8 +667,8 @@ TEST(TestJsonFileReadWrite, JsonExample4) {
   // Example 4: A map type with non-canonical field names
   ASSERT_OK_AND_ASSIGN(auto map_type,
                        MapType::Make(field("some_entries",
-                                           struct_({field("key", int16(), false),
-                                                    field("value", int32())}),
+                                           struct_({field("some_key", int16(), false),
+                                                    field("some_value", int32())}),
                                            false)));
   Schema ex_schema({field("maps", map_type)});
 
@@ -678,7 +678,7 @@ TEST(TestJsonFileReadWrite, JsonExample4) {
   auto expected_array = ArrayFromJSON(
       map(int16(), int32()),
       R"([[[11, 111], [22, 222], [33, null]], null, [[44, 444], [55, 555]]])");
-  AssertArraysEqual(*batch->column(0), *expected_array);
+  EXPECT_FALSE(batch->column(0)->Equals(expected_array));
 }
 
 #define BATCH_CASES()                                                             \

--- a/cpp/src/arrow/ipc/json_test.cc
+++ b/cpp/src/arrow/ipc/json_test.cc
@@ -678,7 +678,7 @@ TEST(TestJsonFileReadWrite, JsonExample4) {
   auto expected_array = ArrayFromJSON(
       map(int16(), int32()),
       R"([[[11, 111], [22, 222], [33, null]], null, [[44, 444], [55, 555]]])");
-  EXPECT_FALSE(batch->column(0)->Equals(expected_array));
+  AssertArraysEqual(*batch->column(0), *expected_array);
 }
 
 #define BATCH_CASES()                                                             \

--- a/cpp/src/arrow/ipc/json_test.cc
+++ b/cpp/src/arrow/ipc/json_test.cc
@@ -239,7 +239,7 @@ static const char* json_example4 = R"example(
             "nullable": false,
             "children": [
               {
-                "name": "some_key",
+                "name": "key",
                 "type": {
                   "name": "int",
                   "isSigned": true,
@@ -249,7 +249,7 @@ static const char* json_example4 = R"example(
                 "children": []
               },
               {
-                "name": "some_value",
+                "name": "value",
                 "type": {
                   "name": "int",
                   "isSigned": true,
@@ -280,13 +280,13 @@ static const char* json_example4 = R"example(
               "VALIDITY": [1, 1, 1, 1, 1],
               "children": [
                 {
-                  "name": "some_key",
+                  "name": "key",
                   "count": 5,
                   "VALIDITY": [1, 1, 1, 1, 1],
                   "DATA": [11, 22, 33, 44, 55]
                 },
                 {
-                  "name": "some_value",
+                  "name": "value",
                   "count": 5,
                   "VALIDITY": [1, 1, 0, 1, 1],
                   "DATA": [111, 222, 0, 444, 555]
@@ -667,8 +667,8 @@ TEST(TestJsonFileReadWrite, JsonExample4) {
   // Example 4: A map type with non-canonical field names
   ASSERT_OK_AND_ASSIGN(auto map_type,
                        MapType::Make(field("some_entries",
-                                           struct_({field("some_key", int16(), false),
-                                                    field("some_value", int32())}),
+                                           struct_({field("key", int16(), false),
+                                                    field("value", int32())}),
                                            false)));
   Schema ex_schema({field("maps", map_type)});
 


### PR DESCRIPTION
ArrayRangeEquals would only checks type IDs before comparing values. Make it check the actual type instances instead.

Also, fix the MapArray comparison logic to avoid accounting for field names.