### PR TITLE
ARROW-9179: [R] Replace usage of iris dataset in tests

### DIFF
--- a/r/R/csv.R
+++ b/r/R/csv.R
@@ -77,11 +77,11 @@
 #' \donttest{
 #'   tf <- tempfile()
 #'   on.exit(unlink(tf))
-#'   write.csv(iris, file = tf)
+#'   write.csv(mtcars, file = tf)
 #'   df <- read_csv_arrow(tf)
 #'   dim(df)
 #'   # Can select columns
-#'   df <- read_csv_arrow(tf, col_select = starts_with("Sepal"))
+#'   df <- read_csv_arrow(tf, col_select = starts_with("d"))
 #' }
 read_delim_arrow <- function(file,
                              delim = ",",

--- a/r/R/feather.R
+++ b/r/R/feather.R
@@ -135,11 +135,11 @@ write_feather <- function(x,
 #' \donttest{
 #' tf <- tempfile()
 #' on.exit(unlink(tf))
-#' write_feather(iris, tf)
+#' write_feather(mtcars, tf)
 #' df <- read_feather(tf)
 #' dim(df)
 #' # Can select columns
-#' df <- read_feather(tf, col_select = starts_with("Sepal"))
+#' df <- read_feather(tf, col_select = starts_with("d"))
 #' }
 read_feather <- function(file, col_select = NULL, as_data_frame = TRUE, ...) {
   if (!inherits(file, "InputStream")) {

--- a/r/R/record-batch-reader.R
+++ b/r/R/record-batch-reader.R
@@ -61,7 +61,7 @@
 #' tf <- tempfile()
 #' on.exit(unlink(tf))
 #'
-#' batch <- record_batch(iris)
+#' batch <- record_batch(chickwts)
 #'
 #' # This opens a connection to the file in Arrow
 #' file_obj <- FileOutputStream$create(tf)
@@ -87,7 +87,7 @@
 #' # Call as.data.frame to turn that Table into an R data.frame
 #' df <- as.data.frame(tab)
 #' # This should be the same data we sent
-#' all.equal(df, iris, check.attributes = FALSE)
+#' all.equal(df, chickwts, check.attributes = FALSE)
 #' # Unlike the Writers, we don't have to close RecordBatchReaders,
 #' # but we do still need to close the file connection
 #' read_file_obj$close()

--- a/r/R/record-batch-writer.R
+++ b/r/R/record-batch-writer.R
@@ -60,7 +60,7 @@
 #' tf <- tempfile()
 #' on.exit(unlink(tf))
 #'
-#' batch <- record_batch(iris)
+#' batch <- record_batch(chickwts)
 #'
 #' # This opens a connection to the file in Arrow
 #' file_obj <- FileOutputStream$create(tf)
@@ -86,7 +86,7 @@
 #' # Call as.data.frame to turn that Table into an R data.frame
 #' df <- as.data.frame(tab)
 #' # This should be the same data we sent
-#' all.equal(df, iris, check.attributes = FALSE)
+#' all.equal(df, chickwts, check.attributes = FALSE)
 #' # Unlike the Writers, we don't have to close RecordBatchReaders,
 #' # but we do still need to close the file connection
 #' read_file_obj$close()

--- a/r/man/RecordBatchReader.Rd
+++ b/r/man/RecordBatchReader.Rd
@@ -48,7 +48,7 @@ are in the file.
 tf <- tempfile()
 on.exit(unlink(tf))
 
-batch <- record_batch(iris)
+batch <- record_batch(chickwts)
 
 # This opens a connection to the file in Arrow
 file_obj <- FileOutputStream$create(tf)
@@ -74,7 +74,7 @@ tab <- reader$read_table()
 # Call as.data.frame to turn that Table into an R data.frame
 df <- as.data.frame(tab)
 # This should be the same data we sent
-all.equal(df, iris, check.attributes = FALSE)
+all.equal(df, chickwts, check.attributes = FALSE)
 # Unlike the Writers, we don't have to close RecordBatchReaders,
 # but we do still need to close the file connection
 read_file_obj$close()

--- a/r/man/RecordBatchWriter.Rd
+++ b/r/man/RecordBatchWriter.Rd
@@ -46,7 +46,7 @@ to be closed separately.
 tf <- tempfile()
 on.exit(unlink(tf))
 
-batch <- record_batch(iris)
+batch <- record_batch(chickwts)
 
 # This opens a connection to the file in Arrow
 file_obj <- FileOutputStream$create(tf)
@@ -72,7 +72,7 @@ tab <- reader$read_table()
 # Call as.data.frame to turn that Table into an R data.frame
 df <- as.data.frame(tab)
 # This should be the same data we sent
-all.equal(df, iris, check.attributes = FALSE)
+all.equal(df, chickwts, check.attributes = FALSE)
 # Unlike the Writers, we don't have to close RecordBatchReaders,
 # but we do still need to close the file connection
 read_file_obj$close()

--- a/r/man/read_delim_arrow.Rd
+++ b/r/man/read_delim_arrow.Rd
@@ -136,10 +136,10 @@ use \link{CsvTableReader} directly for lower-level access.
 \donttest{
   tf <- tempfile()
   on.exit(unlink(tf))
-  write.csv(iris, file = tf)
+  write.csv(mtcars, file = tf)
   df <- read_csv_arrow(tf)
   dim(df)
   # Can select columns
-  df <- read_csv_arrow(tf, col_select = starts_with("Sepal"))
+  df <- read_csv_arrow(tf, col_select = starts_with("d"))
 }
 }

--- a/r/man/read_feather.Rd
+++ b/r/man/read_feather.Rd
@@ -37,11 +37,11 @@ and the version 2 specification, which is the Apache Arrow IPC file format.
 \donttest{
 tf <- tempfile()
 on.exit(unlink(tf))
-write_feather(iris, tf)
+write_feather(mtcars, tf)
 df <- read_feather(tf)
 dim(df)
 # Can select columns
-df <- read_feather(tf, col_select = starts_with("Sepal"))
+df <- read_feather(tf, col_select = starts_with("d"))
 }
 }
 \seealso{

--- a/r/tests/testthat/helper-data.R
+++ b/r/tests/testthat/helper-data.R
@@ -1,0 +1,8 @@
+example_data <- tibble::tibble(
+  int = c(1:3, NA_integer_, 5:10),
+  dbl = c(1:8, NA, 10) + .1,
+  lgl = sample(c(TRUE, FALSE, NA), 10, replace = TRUE),
+  false = logical(10),
+  chr = letters[c(1:5, NA, 7:10)],
+  fct = factor(letters[c(1:4, NA, NA, 7:10)])
+)

--- a/r/tests/testthat/helper-data.R
+++ b/r/tests/testthat/helper-data.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 example_data <- tibble::tibble(
   int = c(1:3, NA_integer_, 5:10),
   dbl = c(1:8, NA, 10) + .1,

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -102,10 +102,10 @@ test_that("RecordBatch", {
 })
 
 test_that("RecordBatch S3 methods", {
-  tab <- RecordBatch$create(iris)
+  tab <- RecordBatch$create(example_data)
   for (f in c("dim", "nrow", "ncol", "dimnames", "colnames", "row.names", "as.list")) {
     fun <- get(f)
-    expect_identical(fun(tab), fun(iris), info = f)
+    expect_identical(fun(tab), fun(example_data), info = f)
   }
 })
 

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -66,10 +66,10 @@ test_that("Table cast (ARROW-3741)", {
 })
 
 test_that("Table S3 methods", {
-  tab <- Table$create(iris)
+  tab <- Table$create(example_data)
   for (f in c("dim", "nrow", "ncol", "dimnames", "colnames", "row.names", "as.list")) {
     fun <- get(f)
-    expect_identical(fun(tab), fun(iris), info = f)
+    expect_identical(fun(tab), fun(example_data), info = f)
   }
 })
 

--- a/r/tests/testthat/test-csv.R
+++ b/r/tests/testthat/test-csv.R
@@ -17,14 +17,16 @@
 
 context("CsvTableReader")
 
+# Not all types round trip via CSV 100% identical by default
+tbl <- example_data[, c("dbl", "lgl", "false", "chr")]
+
 test_that("Can read csv file", {
   tf <- tempfile()
   on.exit(unlink(tf))
 
-  write.csv(iris, tf, row.names = FALSE)
+  write.csv(tbl, tf, row.names = FALSE)
 
-  iris$Species <- as.character(iris$Species)
-  tab0 <- Table$create(!!!iris)
+  tab0 <- Table$create(tbl)
   tab1 <- read_csv_arrow(tf, as_data_frame = FALSE)
   expect_equal(tab0, tab1)
   tab2 <- read_csv_arrow(mmap_open(tf), as_data_frame = FALSE)
@@ -37,24 +39,20 @@ test_that("read_csv_arrow(as_data_frame=TRUE)", {
   tf <- tempfile()
   on.exit(unlink(tf))
 
-  write.csv(iris, tf, row.names = FALSE)
-  iris$Species <- as.character(iris$Species)
-
+  write.csv(tbl, tf, row.names = FALSE)
   tab1 <- read_csv_arrow(tf, as_data_frame = TRUE)
-  expect_equivalent(iris, tab1)
+  expect_equivalent(tbl, tab1)
 })
 
 test_that("read_delim_arrow parsing options: delim", {
   tf <- tempfile()
   on.exit(unlink(tf))
 
-  write.table(iris, tf, sep = "\t", row.names = FALSE)
+  write.table(tbl, tf, sep = "\t", row.names = FALSE)
   tab1 <- read_tsv_arrow(tf)
   tab2 <- read_delim_arrow(tf, delim = "\t")
   expect_equivalent(tab1, tab2)
-
-  iris$Species <- as.character(iris$Species)
-  expect_equivalent(iris, tab1)
+  expect_equivalent(tbl, tab1)
 })
 
 test_that("read_delim_arrow parsing options: quote", {
@@ -79,26 +77,25 @@ test_that("read_csv_arrow parsing options: col_names", {
   on.exit(unlink(tf))
 
   # Writing the CSV without the header
-  write.table(iris, tf, sep = ",", row.names = FALSE, col.names = FALSE)
+  write.table(tbl, tf, sep = ",", row.names = FALSE, col.names = FALSE)
 
   # Reading with col_names = FALSE autogenerates names
   no_names <- read_csv_arrow(tf, col_names = FALSE)
-  expect_equal(no_names$f0, iris$Sepal.Length)
+  expect_equal(no_names$f0, tbl[[1]])
 
-  tab1 <- read_csv_arrow(tf, col_names = names(iris))
+  tab1 <- read_csv_arrow(tf, col_names = names(tbl))
 
-  expect_identical(names(tab1), names(iris))
-  iris$Species <- as.character(iris$Species)
-  expect_equivalent(iris, tab1)
+  expect_identical(names(tab1), names(tbl))
+  expect_equivalent(tbl, tab1)
 
   # This errors (correctly) because I haven't given enough names
   # but the error message is "Invalid: Empty CSV file", which is not accurate
   expect_error(
-    read_csv_arrow(tf, col_names = names(iris)[1])
+    read_csv_arrow(tf, col_names = names(tbl)[1])
   )
   # Same here
   expect_error(
-    read_csv_arrow(tf, col_names = c(names(iris), names(iris)))
+    read_csv_arrow(tf, col_names = c(names(tbl), names(tbl)))
   )
 })
 
@@ -108,25 +105,24 @@ test_that("read_csv_arrow parsing options: skip", {
 
   # Adding two garbage lines to start the csv
   cat("asdf\nqwer\n", file = tf)
-  suppressWarnings(write.table(iris, tf, sep = ",", row.names = FALSE, append = TRUE))
+  suppressWarnings(write.table(tbl, tf, sep = ",", row.names = FALSE, append = TRUE))
 
   tab1 <- read_csv_arrow(tf, skip = 2)
 
-  expect_identical(names(tab1), names(iris))
-  iris$Species <- as.character(iris$Species)
-  expect_equivalent(iris, tab1)
+  expect_identical(names(tab1), names(tbl))
+  expect_equivalent(tbl, tab1)
 })
 
 test_that("read_csv_arrow parsing options: skip_empty_rows", {
   tf <- tempfile()
   on.exit(unlink(tf))
 
-  write.csv(iris, tf, row.names = FALSE)
+  write.csv(tbl, tf, row.names = FALSE)
   cat("\n\n", file = tf, append = TRUE)
 
   tab1 <- read_csv_arrow(tf, skip_empty_rows = FALSE)
 
-  expect_equal(nrow(tab1), nrow(iris) + 2)
+  expect_equal(nrow(tab1), nrow(tbl) + 2)
   expect_true(is.na(tail(tab1, 1)[[1]]))
 })
 
@@ -160,13 +156,13 @@ test_that("read_csv_arrow() respects col_select", {
   tf <- tempfile()
   on.exit(unlink(tf))
 
-  write.csv(iris, tf, row.names = FALSE, quote = FALSE)
+  write.csv(tbl, tf, row.names = FALSE, quote = FALSE)
 
-  tab <- read_csv_arrow(tf, col_select = starts_with("Sepal"), as_data_frame = FALSE)
-  expect_equal(tab, Table$create(Sepal.Length = iris$Sepal.Length, Sepal.Width = iris$Sepal.Width))
+  tab <- read_csv_arrow(tf, col_select = ends_with("l"), as_data_frame = FALSE)
+  expect_equal(tab, Table$create(example_data[, c("dbl", "lgl")]))
 
-  tib <- read_csv_arrow(tf, col_select = starts_with("Sepal"), as_data_frame = TRUE)
-  expect_equal(tib, tibble::tibble(Sepal.Length = iris$Sepal.Length, Sepal.Width = iris$Sepal.Width))
+  tib <- read_csv_arrow(tf, col_select = ends_with("l"), as_data_frame = TRUE)
+  expect_equal(tib, example_data[, c("dbl", "lgl")])
 })
 
 test_that("read_csv_arrow() can detect compression from file name", {
@@ -174,10 +170,7 @@ test_that("read_csv_arrow() can detect compression from file name", {
   tf <- tempfile(fileext = ".csv.gz")
   on.exit(unlink(tf))
 
-  write.csv(iris, gzfile(tf), row.names = FALSE, quote = FALSE)
-
-  iris$Species <- as.character(iris$Species)
-
+  write.csv(tbl, gzfile(tf), row.names = FALSE, quote = FALSE)
   tab1 <- read_csv_arrow(tf)
-  expect_equivalent(iris, tab1)
+  expect_equivalent(tbl, tab1)
 })

--- a/r/tests/testthat/test-type.R
+++ b/r/tests/testthat/test-type.R
@@ -34,7 +34,7 @@ test_that("type() infers from R type", {
   expect_type_equal(type(raw()), int8())
   expect_type_equal(type(""), utf8())
   expect_type_equal(
-    type(iris$Species),
+    type(example_data$fct),
     dictionary(int8(), utf8(), FALSE)
   )
   expect_type_equal(


### PR DESCRIPTION
FYI @romainfrancois @wesm 

It's not a great dataset anyway for our tests because there's basically no variation in data type or missingness. Switching some tests to use a more fully-featured data frame revealed some other issues, in fact.