### PR TITLE
ARROW-8801: [Python] Fix memory leak when converting datetime64-with-tz data to pandas

### DIFF
--- a/python/scripts/test_leak.py
+++ b/python/scripts/test_leak.py
@@ -97,5 +97,14 @@ def test_leak3():
                          check_interval=50, tolerance=20)
 
 
+def test_ARROW_8801():
+    x = pd.to_datetime(np.random.randint(0, 2**32, size=2**20),
+                       unit='ms', utc=True)
+    table = pa.table(pd.DataFrame({'x': x}))
+
+    assert_does_not_leak(lambda: table.to_pandas(split_blocks=False),
+                         iterations=1000, check_interval=50, tolerance=1000)
+
+
 if __name__ == '__main__':
-    test_leak3()
+    test_ARROW_8801()


### PR DESCRIPTION
An array object was failing to be decref'd on the DatetimeTZ conversion path. The code is slightly complicated by the different calling reference ownership semantics of the Array/ChunkedArray conversion path (which expects to own the created array when it calls `GetSeriesResult` while the `GetResultBlock` code retains its array in a `OwnedRefNoGIL`). This was the simplest thing that fixed the memory leak for me. There is leak checking code that can be used to verify this in python/scripts/test_leak.py (just run the script). 