### PR TITLE
ARROW-8733: [Python][Dataset] Expose statistics of ParquetFileFragment::RowGroupInfo

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1603,6 +1603,15 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         shared_ptr[CTable] table()
         shared_ptr[CScalar] scalar()
 
+    enum CCompareOperator "arrow::compute::CompareOperator":
+        CCompareOperator_EQUAL "arrow::compute::CompareOperator::EQUAL"
+        CCompareOperator_NOT_EQUAL "arrow::compute::CompareOperator::NOT_EQUAL"
+        CCompareOperator_GREATER "arrow::compute::CompareOperator::GREATER"
+        CCompareOperator_GREATER_EQUAL \
+            "arrow::compute::CompareOperator::GREATER_EQUAL"
+        CCompareOperator_LESS "arrow::compute::CompareOperator::LESS"
+        CCompareOperator_LESS_EQUAL \
+            "arrow::compute::CompareOperator::LESS_EQUAL"
 
 cdef extern from "arrow/python/api.h" namespace "arrow::py":
     # Requires GIL


### PR DESCRIPTION
Not a polished PR, just a quick try (in cython, since that's faster for me) to expose the RowGroupInfo statistics in Python + convert the expression into min/max information. More as food for discussion for now.

What this enables:

```
In [1]: import pyarrow.dataset as ds 
   ...: dataset = ds.parquet_dataset("test_parquet_dask/_metadata", partitioning="hive") 
   ...: fragment = list(dataset.get_fragments())[0]  
   ...: rg = fragment.row_groups[0]  

In [2]: ds.get_min_max_statistics(rg.statistics) 
Out[2]: 
[{'col': {'min': -1.43563008497128}},
 {'col': {'max': 1.2929964609736964}},
 {'index': {'min': 335}},
 {'index': {'max': 359}}]
```