### PR TITLE
ARROW-9216: [C++] Use BitBlockCounter for plain spaced encoding/decoding

### DIFF
--- a/cpp/src/arrow/util/spaced.h
+++ b/cpp/src/arrow/util/spaced.h
@@ -1,0 +1,199 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/util/align_util.h"
+#include "arrow/util/bit_block_counter.h"
+#include "arrow/util/bitmap_reader.h"
+
+namespace arrow {
+namespace util {
+namespace internal {
+
+/// \brief Compress the buffer to spaced, excluding the null entries.
+///
+/// \param[in] src the source buffer
+/// \param[in] num_values the size of source buffer
+/// \param[in] valid_bits bitmap data indicating position of valid slots
+/// \param[in] valid_bits_offset offset into valid_bits
+/// \param[out] output the output buffer spaced
+/// \return The size of spaced buffer.
+template <typename T>
+inline int SpacedCompress(const T* src, int num_values, const uint8_t* valid_bits,
+                          int64_t valid_bits_offset, T* output) {
+  int num_valid_values = 0;
+  int idx_src = 0;
+
+  const auto p =
+      arrow::internal::BitmapWordAlign<1>(valid_bits, valid_bits_offset, num_values);
+  // First handle the leading bits
+  const int leading_bits = static_cast<int>(p.leading_bits);
+  while (idx_src < leading_bits) {
+    if (BitUtil::GetBit(valid_bits, valid_bits_offset)) {
+      output[num_valid_values] = src[idx_src];
+      num_valid_values++;
+    }
+    idx_src++;
+    valid_bits_offset++;
+  }
+
+  // The aligned parts scaned with BitBlockCounter
+  arrow::internal::BitBlockCounter data_counter(valid_bits, valid_bits_offset,
+                                                num_values - leading_bits);
+  auto current_block = data_counter.NextWord();
+  while (idx_src < num_values) {
+    if (current_block.AllSet()) {  // All true values
+      int run_length = 0;
+      // Scan forward until a block that has some false values (or the end)
+      while (current_block.length > 0 && current_block.AllSet()) {
+        run_length += current_block.length;
+        current_block = data_counter.NextWord();
+      }
+      // Fill all valid values of this scan
+      std::memcpy(&output[num_valid_values], &src[idx_src], run_length * sizeof(T));
+      num_valid_values += run_length;
+      idx_src += run_length;
+      valid_bits_offset += run_length;
+      // The current_block already computed, advance to next loop
+      continue;
+    } else if (!current_block.NoneSet()) {  // Some values are null
+      arrow::internal::BitmapReader valid_bits_reader(valid_bits, valid_bits_offset,
+                                                      current_block.length);
+      for (int64_t i = 0; i < current_block.length; i++) {
+        if (valid_bits_reader.IsSet()) {
+          output[num_valid_values] = src[idx_src];
+          num_valid_values++;
+        }
+        idx_src++;
+        valid_bits_reader.Next();
+      }
+      valid_bits_offset += current_block.length;
+    } else {  // All null values
+      idx_src += current_block.length;
+      valid_bits_offset += current_block.length;
+    }
+    current_block = data_counter.NextWord();
+  }
+
+  return num_valid_values;
+}
+
+/// \brief Expand the buffer but leave spaces for null entries.
+///
+/// \param[in, out] buffer the in-place buffer
+/// \param[in] num_values total size of buffer including null slots
+/// \param[in] null_count number of null slots
+/// \param[in] valid_bits bitmap data indicating position of valid slots
+/// \param[in] valid_bits_offset offset into valid_bits
+/// \return The number of values expanded, including nulls.
+template <typename T>
+inline int SpacedExpand(T* buffer, int num_values, int null_count,
+                        const uint8_t* valid_bits, int64_t valid_bits_offset) {
+  constexpr uint64_t kBatchSize = 64;
+  static_assert(kBatchSize == 64, "Invalid batch size, BitBlockCounter stick to 64");
+  constexpr uint64_t kBatchByteSize = kBatchSize / 8;
+
+  // Point to end as we add the spacing from the back.
+  int idx_decode = num_values - null_count - 1;
+  int idx_buffer = num_values - 1;
+  int64_t idx_valid_bits = valid_bits_offset + idx_buffer;
+
+  // Depending on the number of nulls, some of the value slots in buffer may
+  // be uninitialized, and this will cause valgrind warnings / potentially UB
+  std::memset(static_cast<void*>(&buffer[idx_decode + 1]), 0, null_count * sizeof(T));
+  if (idx_decode < 0) {
+    return num_values;
+  }
+
+  // Access the bitmap by aligned way
+  const auto p = arrow::internal::BitmapWordAlign<kBatchByteSize>(
+      valid_bits, valid_bits_offset, num_values);
+
+  // The trailing bits
+  auto trailing_bits = p.trailing_bits;
+  while (trailing_bits > 0) {
+    if (BitUtil::GetBit(valid_bits, idx_valid_bits)) {
+      buffer[idx_buffer] = buffer[idx_decode];
+      idx_decode--;
+    }
+
+    idx_buffer--;
+    idx_valid_bits--;
+    trailing_bits--;
+  }
+
+  // The aligned parts scaned from the back with BitBlockCounter
+  auto aligned_words = p.aligned_words;
+  T tmp[kBatchSize];
+  std::memset(&tmp, 0, kBatchSize * sizeof(T));
+  while (aligned_words > 0 && idx_decode < idx_buffer) {
+    const uint8_t* aligned_bits = p.aligned_start + (aligned_words - 1) * kBatchByteSize;
+    arrow::internal::BitBlockCounter data_counter(aligned_bits, 0, kBatchSize);
+    const auto current_block = data_counter.NextWord();
+    if (current_block.AllSet()) {  // All true values
+      idx_buffer -= kBatchSize;
+      idx_decode -= kBatchSize;
+      if (idx_buffer >= idx_decode + static_cast<int>(kBatchSize)) {
+        std::memcpy(&buffer[idx_buffer + 1], &buffer[idx_decode + 1],
+                    kBatchSize * sizeof(T));
+      } else {
+        // Exchange the data to avoid the buffer overlap
+        std::memcpy(tmp, &buffer[idx_decode + 1], kBatchSize * sizeof(T));
+        std::memcpy(&buffer[idx_buffer + 1], tmp, kBatchSize * sizeof(T));
+      }
+    } else if (!current_block.NoneSet()) {  // Some values are null
+      arrow::internal::BitmapReader valid_bits_reader(aligned_bits, 0, kBatchSize);
+      idx_buffer -= kBatchSize;
+      idx_decode -= current_block.popcount;
+
+      // Foward scan and pack the target data to temp
+      int idx = idx_decode + 1;
+      for (uint64_t i = 0; i < kBatchSize; i++) {
+        if (valid_bits_reader.IsSet()) {
+          tmp[i] = buffer[idx];
+          idx++;
+        }
+        valid_bits_reader.Next();
+      }
+      std::memcpy(&buffer[idx_buffer + 1], tmp, kBatchSize * sizeof(T));
+    } else {  // All null values
+      idx_buffer -= kBatchSize;
+    }
+
+    idx_valid_bits -= kBatchSize;
+    aligned_words--;
+  }
+
+  // The remaining leading bits
+  auto leading_bits = p.leading_bits;
+  while (leading_bits > 0) {
+    if (BitUtil::GetBit(valid_bits, idx_valid_bits)) {
+      buffer[idx_buffer] = buffer[idx_decode];
+      idx_decode--;
+    }
+    leading_bits--;
+    idx_buffer--;
+    idx_valid_bits--;
+  }
+
+  return num_values;
+}
+
+}  // namespace internal
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/spaced.h
+++ b/cpp/src/arrow/util/spaced.h
@@ -52,7 +52,7 @@ inline int SpacedCompress(const T* src, int num_values, const uint8_t* valid_bit
     valid_bits_offset++;
   }
 
-  // The aligned parts scaned with BitBlockCounter
+  // The aligned parts scanned with BitBlockCounter
   arrow::internal::BitBlockCounter data_counter(valid_bits, valid_bits_offset,
                                                 num_values - leading_bits);
   auto current_block = data_counter.NextWord();
@@ -93,7 +93,8 @@ inline int SpacedCompress(const T* src, int num_values, const uint8_t* valid_bit
   return num_valid_values;
 }
 
-/// \brief Expand the buffer but leave spaces for null entries.
+/// \brief Relocate values in buffer into positions of non-null values as indicated by
+/// a validity bitmap.
 ///
 /// \param[in, out] buffer the in-place buffer
 /// \param[in] num_values total size of buffer including null slots
@@ -115,7 +116,7 @@ inline int SpacedExpand(T* buffer, int num_values, int null_count,
 
   // Depending on the number of nulls, some of the value slots in buffer may
   // be uninitialized, and this will cause valgrind warnings / potentially UB
-  std::memset(static_cast<void*>(&buffer[idx_decode + 1]), 0, null_count * sizeof(T));
+  std::memset(&buffer[idx_decode + 1], 0, null_count * sizeof(T));
   if (idx_decode < 0) {
     return num_values;
   }
@@ -137,7 +138,7 @@ inline int SpacedExpand(T* buffer, int num_values, int null_count,
     trailing_bits--;
   }
 
-  // The aligned parts scaned from the back with BitBlockCounter
+  // The aligned parts scanned from the back with BitBlockCounter
   auto aligned_words = p.aligned_words;
   T tmp[kBatchSize];
   std::memset(&tmp, 0, kBatchSize * sizeof(T));

--- a/cpp/src/arrow/util/spaced.h
+++ b/cpp/src/arrow/util/spaced.h
@@ -116,7 +116,7 @@ inline int SpacedExpand(T* buffer, int num_values, int null_count,
 
   // Depending on the number of nulls, some of the value slots in buffer may
   // be uninitialized, and this will cause valgrind warnings / potentially UB
-  std::memset(&buffer[idx_decode + 1], 0, null_count * sizeof(T));
+  std::memset(static_cast<void*>(&buffer[idx_decode + 1]), 0, null_count * sizeof(T));
   if (idx_decode < 0) {
     return num_values;
   }

--- a/cpp/src/parquet/encoding.cc
+++ b/cpp/src/parquet/encoding.cc
@@ -105,16 +105,9 @@ class PlainEncoder : public EncoderImpl, virtual public TypedEncoder<DType> {
                  int64_t valid_bits_offset) override {
     PARQUET_ASSIGN_OR_THROW(
         auto buffer, arrow::AllocateBuffer(num_values * sizeof(T), this->memory_pool()));
-    int32_t num_valid_values = 0;
-    arrow::internal::BitmapReader valid_bits_reader(valid_bits, valid_bits_offset,
-                                                    num_values);
     T* data = reinterpret_cast<T*>(buffer->mutable_data());
-    for (int32_t i = 0; i < num_values; i++) {
-      if (valid_bits_reader.IsSet()) {
-        data[num_valid_values++] = src[i];
-      }
-      valid_bits_reader.Next();
-    }
+    int num_valid_values = arrow::util::internal::SpacedCompress<T>(
+        src, num_values, valid_bits, valid_bits_offset, data);
     Put(data, num_valid_values);
   }
 
@@ -305,16 +298,9 @@ class PlainEncoder<BooleanType> : public EncoderImpl, virtual public BooleanEnco
                  int64_t valid_bits_offset) override {
     PARQUET_ASSIGN_OR_THROW(
         auto buffer, arrow::AllocateBuffer(num_values * sizeof(T), this->memory_pool()));
-    int32_t num_valid_values = 0;
-    arrow::internal::BitmapReader valid_bits_reader(valid_bits, valid_bits_offset,
-                                                    num_values);
     T* data = reinterpret_cast<T*>(buffer->mutable_data());
-    for (int32_t i = 0; i < num_values; i++) {
-      if (valid_bits_reader.IsSet()) {
-        data[num_valid_values++] = src[i];
-      }
-      valid_bits_reader.Next();
-    }
+    int num_valid_values = arrow::util::internal::SpacedCompress<T>(
+        src, num_values, valid_bits, valid_bits_offset, data);
     Put(data, num_valid_values);
   }
 
@@ -897,16 +883,9 @@ void ByteStreamSplitEncoder<DType>::PutSpaced(const T* src, int num_values,
                                               int64_t valid_bits_offset) {
   PARQUET_ASSIGN_OR_THROW(
       auto buffer, arrow::AllocateBuffer(num_values * sizeof(T), this->memory_pool()));
-  int32_t num_valid_values = 0;
-  arrow::internal::BitmapReader valid_bits_reader(valid_bits, valid_bits_offset,
-                                                  num_values);
   T* data = reinterpret_cast<T*>(buffer->mutable_data());
-  for (int32_t i = 0; i < num_values; i++) {
-    if (valid_bits_reader.IsSet()) {
-      data[num_valid_values++] = src[i];
-    }
-    valid_bits_reader.Next();
-  }
+  int num_valid_values = arrow::util::internal::SpacedCompress<T>(
+      src, num_values, valid_bits, valid_bits_offset, data);
   Put(data, num_valid_values);
 }
 

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -22,6 +22,8 @@
 #include <memory>
 #include <vector>
 
+#include "arrow/util/spaced.h"
+
 #include "parquet/exception.h"
 #include "parquet/platform.h"
 #include "parquet/types.h"
@@ -294,27 +296,8 @@ class TypedDecoder : virtual public Decoder {
       throw ParquetException("Number of values / definition_levels read did not match");
     }
 
-    // Depending on the number of nulls, some of the value slots in buffer may
-    // be uninitialized, and this will cause valgrind warnings / potentially UB
-    memset(static_cast<void*>(buffer + values_read), 0,
-           (num_values - values_read) * sizeof(T));
-
-    // Add spacing for null entries. As we have filled the buffer from the front,
-    // we need to add the spacing from the back.
-    int values_to_move = values_read - 1;
-    // We stop early on one of two conditions:
-    // 1. There are no more null values that need spacing.  Note we infer this
-    //     backwards, when 'i' is equal to 'values_to_move' it indicates
-    //    all nulls have been consumed.
-    // 2. There are no more non-null values that need to move which indicates
-    //    all remaining slots are null, so their exact value doesn't matter.
-    for (int i = num_values - 1; (i > values_to_move) && (values_to_move >= 0); i--) {
-      if (BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
-        buffer[i] = buffer[values_to_move];
-        values_to_move--;
-      }
-    }
-    return num_values;
+    return ::arrow::util::internal::SpacedExpand<T>(buffer, num_values, null_count,
+                                                    valid_bits, valid_bits_offset);
   }
 
   /// \brief Decode into an ArrayBuilder or other accumulator

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -132,8 +132,8 @@ void VerifyResults(T* result, T* expected, int num_values) {
 }
 
 template <typename T>
-void VerifyResultsSpaced(T* result, T* expected, int num_values, uint8_t* valid_bits,
-                         int64_t valid_bits_offset) {
+void VerifyResultsSpaced(T* result, T* expected, int num_values,
+                         const uint8_t* valid_bits, int64_t valid_bits_offset) {
   for (auto i = 0; i < num_values; ++i) {
     if (BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
       ASSERT_EQ(expected[i], result[i]) << i;
@@ -150,7 +150,7 @@ void VerifyResults<FLBA>(FLBA* result, FLBA* expected, int num_values) {
 
 template <>
 void VerifyResultsSpaced<FLBA>(FLBA* result, FLBA* expected, int num_values,
-                               uint8_t* valid_bits, int64_t valid_bits_offset) {
+                               const uint8_t* valid_bits, int64_t valid_bits_offset) {
   for (auto i = 0; i < num_values; ++i) {
     if (BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
       ASSERT_EQ(0, memcmp(expected[i].ptr, result[i].ptr, flba_length)) << i;
@@ -210,22 +210,25 @@ class TestEncodingBase : public ::testing::Test {
 
   virtual void CheckRoundtrip() = 0;
 
-  virtual void CheckRoundtripSpaced(int64_t valid_bits_offset) {}
+  virtual void CheckRoundtripSpaced(const uint8_t* valid_bits,
+                                    int64_t valid_bits_offset) {}
 
   void Execute(int nvalues, int repeats) {
     InitData(nvalues, repeats);
     CheckRoundtrip();
   }
 
-  void ExecuteSpaced(int nvalues, int repeats, int64_t valid_bits_offset) {
+  void ExecuteSpaced(int nvalues, int repeats, int64_t valid_bits_offset,
+                     double null_probability) {
     InitData(nvalues, repeats);
-    auto num_value_valid_bits_buffer =
-        static_cast<int>(arrow::BitUtil::BytesForBits(num_values_ + valid_bits_offset));
-    valid_bits_buffer_.resize(num_value_valid_bits_buffer * sizeof(uint8_t));
-    // Random initialization the valid bits map
-    random_bytes(num_value_valid_bits_buffer, 0, &valid_bits_buffer_);
-    valid_bits_ = valid_bits_buffer_.data();
-    CheckRoundtripSpaced(valid_bits_offset);
+
+    int64_t size = num_values_ + valid_bits_offset;
+    auto rand = ::arrow::random::RandomArrayGenerator(1923);
+    const auto array = rand.UInt8(size, 0, 100, null_probability);
+    const auto valid_bits = array->null_bitmap_data();
+    if (valid_bits) {
+      CheckRoundtripSpaced(valid_bits, valid_bits_offset);
+    }
   }
 
  protected:
@@ -238,9 +241,6 @@ class TestEncodingBase : public ::testing::Test {
   std::vector<uint8_t> input_bytes_;
   std::vector<uint8_t> output_bytes_;
   std::vector<uint8_t> data_buffer_;
-
-  uint8_t* valid_bits_;  // valid bits map for spaced
-  std::vector<uint8_t> valid_bits_buffer_;
 
   std::shared_ptr<Buffer> encode_buffer_;
   std::shared_ptr<ColumnDescriptor> descr_;
@@ -256,8 +256,7 @@ class TestEncodingBase : public ::testing::Test {
   using TestEncodingBase<Type>::data_buffer_;   \
   using TestEncodingBase<Type>::type_length_;   \
   using TestEncodingBase<Type>::encode_buffer_; \
-  using TestEncodingBase<Type>::decode_buf_;    \
-  using TestEncodingBase<Type>::valid_bits_
+  using TestEncodingBase<Type>::decode_buf_;
 
 template <typename Type>
 class TestPlainEncoding : public TestEncodingBase<Type> {
@@ -278,25 +277,25 @@ class TestPlainEncoding : public TestEncodingBase<Type> {
     ASSERT_NO_FATAL_FAILURE(VerifyResults<T>(decode_buf_, draws_, num_values_));
   }
 
-  void CheckRoundtripSpaced(int64_t valid_bits_offset) {
+  void CheckRoundtripSpaced(const uint8_t* valid_bits, int64_t valid_bits_offset) {
     auto encoder = MakeTypedEncoder<Type>(Encoding::PLAIN, false, descr_.get());
     auto decoder = MakeTypedDecoder<Type>(Encoding::PLAIN, descr_.get());
     int null_count = 0;
     for (auto i = 0; i < num_values_; i++) {
-      if (!BitUtil::GetBit(valid_bits_, valid_bits_offset + i)) {
+      if (!BitUtil::GetBit(valid_bits, valid_bits_offset + i)) {
         null_count++;
       }
     }
 
-    encoder->PutSpaced(draws_, num_values_, valid_bits_, valid_bits_offset);
+    encoder->PutSpaced(draws_, num_values_, valid_bits, valid_bits_offset);
     encode_buffer_ = encoder->FlushValues();
     decoder->SetData(num_values_ - null_count, encode_buffer_->data(),
                      static_cast<int>(encode_buffer_->size()));
     auto values_decoded = decoder->DecodeSpaced(decode_buf_, num_values_, null_count,
-                                                valid_bits_, valid_bits_offset);
+                                                valid_bits, valid_bits_offset);
     ASSERT_EQ(num_values_, values_decoded);
     ASSERT_NO_FATAL_FAILURE(VerifyResultsSpaced<T>(decode_buf_, draws_, num_values_,
-                                                   valid_bits_, valid_bits_offset));
+                                                   valid_bits, valid_bits_offset));
   }
 
  protected:
@@ -313,16 +312,18 @@ TYPED_TEST(TestPlainEncoding, BasicRoundTrip) {
   constexpr int kSimdSize = kAvx512Size;  // Current the max is Avx512
   constexpr int kMultiSimdSize = kSimdSize * 33;
 
-  // Test with both size and offset up to 3 Simd block
-  for (auto i = 1; i < kSimdSize * 3; i++) {
-    ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(i, 1, 0));
-    ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(i, 1, i + 1));
+  for (auto null_prob : {0.001, 0.1, 0.5, 0.9, 0.999}) {
+    // Test with both size and offset up to 3 Simd block
+    for (auto i = 1; i < kSimdSize * 3; i++) {
+      ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(i, 1, 0, null_prob));
+      ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(i, 1, i + 1, null_prob));
+    }
+    // Large block and offset
+    ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(kMultiSimdSize, 1, 0, null_prob));
+    ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(kMultiSimdSize + 33, 1, 0, null_prob));
+    ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(kMultiSimdSize, 1, 33, null_prob));
+    ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(kMultiSimdSize + 33, 1, 33, null_prob));
   }
-  // Large block and offset
-  ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(kMultiSimdSize, 1, 0));
-  ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(kMultiSimdSize + 33, 1, 0));
-  ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(kMultiSimdSize, 1, 33));
-  ASSERT_NO_FATAL_FAILURE(this->ExecuteSpaced(kMultiSimdSize + 33, 1, 33));
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
Speedup the typical use case which most data are true values, also add null probability
test case.

Signed-off-by: Frank Du <frank.du@intel.com>