### PR TITLE
ARROW-8647: [C++][Python][Dataset] Allow partitioning fields to be inferred with dictionary type

### DIFF
--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -317,13 +317,10 @@ class RepeatedArrayFactory {
 
   Status Visit(const DictionaryType& type) {
     const auto& value = checked_cast<const DictionaryScalar&>(scalar_).value;
-    ARROW_ASSIGN_OR_RAISE(auto dictionary, MakeArrayFromScalar(*value, 1, pool_));
-
-    ARROW_ASSIGN_OR_RAISE(auto zero, MakeScalar(type.index_type(), 0));
-    ARROW_ASSIGN_OR_RAISE(auto indices, MakeArrayFromScalar(*zero, length_, pool_));
-
+    ARROW_ASSIGN_OR_RAISE(auto indices,
+                          MakeArrayFromScalar(*value.index, length_, pool_));
     out_ = std::make_shared<DictionaryArray>(scalar_.type, std::move(indices),
-                                             std::move(dictionary));
+                                             value.dictionary);
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -943,7 +943,10 @@ class ScalarEqualsVisitor {
   Status Visit(const UnionScalar& left) { return Status::NotImplemented("union"); }
 
   Status Visit(const DictionaryScalar& left) {
-    return Status::NotImplemented("dictionary");
+    const auto& right = checked_cast<const DictionaryScalar&>(right_);
+    result_ = left.value.index->Equals(right.value.index) &&
+              left.value.dictionary->Equals(right.value.dictionary);
+    return Status::OK();
   }
 
   Status Visit(const ExtensionScalar& left) {

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -211,9 +211,25 @@ struct MatchVisitor {
   }
 };
 
+void ExecArrayOrScalar(KernelContext* ctx, const Datum& in, Datum* out,
+                       std::function<Status(const ArrayData&)> array_impl) {
+  if (in.is_array()) {
+    KERNEL_RETURN_IF_ERROR(ctx, array_impl(*in.array()));
+    return;
+  }
+
+  std::shared_ptr<Array> in_array;
+  std::shared_ptr<Scalar> out_scalar;
+  KERNEL_RETURN_IF_ERROR(ctx, MakeArrayFromScalar(*in.scalar(), 1).Value(&in_array));
+  KERNEL_RETURN_IF_ERROR(ctx, array_impl(*in_array->data()));
+  KERNEL_RETURN_IF_ERROR(ctx, out->make_array()->GetScalar(0).Value(&out_scalar));
+  *out = std::move(out_scalar);
+}
+
 void ExecMatch(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  MatchVisitor dispatch(ctx, *batch[0].array(), out);
-  ctx->SetStatus(dispatch.Execute());
+  ExecArrayOrScalar(ctx, batch[0], out, [&](const ArrayData& in) {
+    return MatchVisitor(ctx, in, out).Execute();
+  });
 }
 
 // ----------------------------------------------------------------------
@@ -284,8 +300,9 @@ struct IsInVisitor {
 };
 
 void ExecIsIn(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-  IsInVisitor dispatch(ctx, *batch[0].array(), out);
-  ctx->SetStatus(dispatch.Execute());
+  ExecArrayOrScalar(ctx, batch[0], out, [&](const ArrayData& in) {
+    return IsInVisitor(ctx, in, out).Execute();
+  });
 }
 
 // Unary set lookup kernels available for the following input types
@@ -302,7 +319,7 @@ void AddBasicSetLookupKernels(ScalarKernel kernel,
                               ScalarFunction* func) {
   auto AddKernels = [&](const std::vector<std::shared_ptr<DataType>>& types) {
     for (const std::shared_ptr<DataType>& ty : types) {
-      kernel.signature = KernelSignature::Make({InputType::Array(ty)}, out_ty);
+      kernel.signature = KernelSignature::Make({ty}, out_ty);
       DCHECK_OK(func->AddKernel(kernel));
     }
   };
@@ -331,7 +348,7 @@ void RegisterScalarSetLookup(FunctionRegistry* registry) {
 
     AddBasicSetLookupKernels(isin_base, /*output_type=*/boolean(), isin.get());
 
-    isin_base.signature = KernelSignature::Make({InputType::Array(null())}, boolean());
+    isin_base.signature = KernelSignature::Make({null()}, boolean());
     isin_base.null_handling = NullHandling::COMPUTED_PREALLOCATE;
     DCHECK_OK(isin->AddKernel(isin_base));
     DCHECK_OK(registry->AddFunction(isin));
@@ -347,7 +364,7 @@ void RegisterScalarSetLookup(FunctionRegistry* registry) {
     auto match = std::make_shared<ScalarFunction>("match", Arity::Unary());
     AddBasicSetLookupKernels(match_base, /*output_type=*/int32(), match.get());
 
-    match_base.signature = KernelSignature::Make({InputType::Array(null())}, int32());
+    match_base.signature = KernelSignature::Make({null()}, int32());
     DCHECK_OK(match->AddKernel(match_base));
     DCHECK_OK(registry->AddFunction(match));
   }

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -19,12 +19,15 @@
 
 #include <algorithm>
 #include <chrono>
-#include <map>
 #include <memory>
+#include <set>
 #include <stack>
 #include <utility>
 #include <vector>
 
+#include "arrow/array/array_base.h"
+#include "arrow/array/builder_binary.h"
+#include "arrow/compute/api_scalar.h"
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/file_base.h"
 #include "arrow/dataset/filter.h"
@@ -135,20 +138,53 @@ Status KeyValuePartitioning::SetDefaultValuesFromKeys(const Expression& expr,
 }
 
 Result<std::shared_ptr<Expression>> KeyValuePartitioning::ConvertKey(
-    const Key& key, const Schema& schema) {
-  ARROW_ASSIGN_OR_RAISE(auto field, FieldRef(key.name).GetOneOrNone(schema));
-  if (field == nullptr) {
+    const Key& key, const Schema& schema, const ArrayVector& dictionaries) {
+  ARROW_ASSIGN_OR_RAISE(auto match, FieldRef(key.name).FindOneOrNone(schema));
+  if (match.indices().empty()) {
     return scalar(true);
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto converted, Scalar::Parse(field->type(), key.value));
+  auto field_index = match.indices()[0];
+  auto field = schema.field(field_index);
+
+  std::shared_ptr<Scalar> converted;
+
+  if (field->type()->id() == Type::DICTIONARY) {
+    if (dictionaries.empty() || dictionaries[field_index] == nullptr) {
+      return Status::Invalid("No dictionary provided for dictionary field ",
+                             field->ToString());
+    }
+
+    DictionaryScalar::ValueType value;
+    value.dictionary = dictionaries[field_index];
+
+    if (!value.dictionary->type()->Equals(
+            checked_cast<const DictionaryType&>(*field->type()).value_type())) {
+      return Status::TypeError("Dictionary supplied for field ", field->ToString(),
+                               " had incorrect type ",
+                               value.dictionary->type()->ToString());
+    }
+
+    // look up the partition value in the dictionary
+    ARROW_ASSIGN_OR_RAISE(converted, Scalar::Parse(value.dictionary->type(), key.value));
+    ARROW_ASSIGN_OR_RAISE(auto index, compute::Match(converted, value.dictionary));
+    value.index = index.scalar();
+    if (!value.index->is_valid) {
+      return Status::Invalid("Dictionary supplied for field ", field->ToString(),
+                             " does not contain '", key.value, "'");
+    }
+    converted = std::make_shared<DictionaryScalar>(std::move(value), field->type());
+  } else {
+    ARROW_ASSIGN_OR_RAISE(converted, Scalar::Parse(field->type(), key.value));
+  }
+
   return equal(field_ref(field->name()), scalar(converted));
 }
 
 Result<std::shared_ptr<Expression>> KeyValuePartitioning::Parse(
     const std::string& segment, int i) const {
   if (auto key = ParseKey(segment, i)) {
-    return ConvertKey(*key, *schema_);
+    return ConvertKey(*key, *schema_, dictionaries_);
   }
 
   return scalar(true);
@@ -205,9 +241,9 @@ class KeyValuePartitioningInspectImpl {
   explicit KeyValuePartitioningInspectImpl(const PartitioningFactoryOptions& options)
       : options_(options) {}
 
-  static Result<std::shared_ptr<DataType>> InferType(
-      const std::string& name, const std::unordered_set<std::string>& reprs,
-      int max_partition_dictionary_size) {
+  static Result<std::shared_ptr<DataType>> InferType(const std::string& name,
+                                                     const std::set<std::string>& reprs,
+                                                     int max_partition_dictionary_size) {
     if (reprs.empty()) {
       return Status::Invalid("No segments were available for field '", name,
                              "'; couldn't infer type");
@@ -222,25 +258,11 @@ class KeyValuePartitioningInspectImpl {
       return int32();
     }
 
-    static_assert(static_cast<size_t>(-1) > 100, "");
-
     if (reprs.size() > static_cast<size_t>(max_partition_dictionary_size)) {
       return utf8();
     }
 
-    auto int8_max = static_cast<size_t>(std::numeric_limits<int8_t>::max()) + 1;
-    auto int16_max = static_cast<size_t>(std::numeric_limits<int16_t>::max()) + 1;
-    auto int32_max = static_cast<size_t>(std::numeric_limits<int32_t>::max()) + 1;
-
-    if (reprs.size() <= int8_max) {
-      return dictionary(int8(), utf8());
-    } else if (reprs.size() <= int16_max) {
-      return dictionary(int16(), utf8());
-    } else if (reprs.size() <= int32_max) {
-      return dictionary(int32(), utf8());
-    } else {
-      return dictionary(int64(), utf8());
-    }
+    return dictionary(int32(), utf8());
   }
 
   int GetOrInsertField(const std::string& name) {
@@ -259,7 +281,11 @@ class KeyValuePartitioningInspectImpl {
 
   void InsertRepr(int index, std::string repr) { values_[index].insert(std::move(repr)); }
 
-  Result<std::shared_ptr<Schema>> Finish() {
+  Result<std::shared_ptr<Schema>> Finish(ArrayVector* dictionaries) {
+    if (options_.max_partition_dictionary_size != 0) {
+      dictionaries->resize(name_to_index_.size());
+    }
+
     std::vector<std::shared_ptr<Field>> fields(name_to_index_.size());
 
     for (const auto& name_index : name_to_index_) {
@@ -267,7 +293,14 @@ class KeyValuePartitioningInspectImpl {
       auto index = name_index.second;
       ARROW_ASSIGN_OR_RAISE(auto type, InferType(name, values_[index],
                                                  options_.max_partition_dictionary_size));
-      fields[index] = field(name, type);
+      if (type->id() == Type::DICTIONARY) {
+        StringBuilder builder;
+        for (const auto& repr : values_[index]) {
+          RETURN_NOT_OK(builder.Append(repr));
+        }
+        RETURN_NOT_OK(builder.Finish(&dictionaries->at(index)));
+      }
+      fields[index] = field(name, std::move(type));
     }
 
     return ::arrow::schema(std::move(fields));
@@ -275,7 +308,7 @@ class KeyValuePartitioningInspectImpl {
 
  private:
   std::unordered_map<std::string, int> name_to_index_;
-  std::vector<std::unordered_set<std::string>> values_;
+  std::vector<std::set<std::string>> values_;
   const PartitioningFactoryOptions& options_;
 };
 
@@ -288,7 +321,7 @@ class DirectoryPartitioningFactory : public PartitioningFactory {
   std::string type_name() const override { return "schema"; }
 
   Result<std::shared_ptr<Schema>> Inspect(
-      const std::vector<std::string>& paths) const override {
+      const std::vector<std::string>& paths) override {
     KeyValuePartitioningInspectImpl impl(options_);
 
     for (const auto& name : field_names_) {
@@ -304,7 +337,7 @@ class DirectoryPartitioningFactory : public PartitioningFactory {
       }
     }
 
-    return impl.Finish();
+    return impl.Finish(&dictionaries_);
   }
 
   Result<std::shared_ptr<Partitioning>> Finish(
@@ -317,7 +350,7 @@ class DirectoryPartitioningFactory : public PartitioningFactory {
     // drop fields which aren't in field_names_
     auto out_schema = SchemaFromColumnNames(schema, field_names_);
 
-    return std::make_shared<DirectoryPartitioning>(std::move(out_schema));
+    return std::make_shared<DirectoryPartitioning>(std::move(out_schema), dictionaries_);
   }
 
   struct MakeWritePlanImpl;
@@ -331,6 +364,7 @@ class DirectoryPartitioningFactory : public PartitioningFactory {
 
  private:
   std::vector<std::string> field_names_;
+  ArrayVector dictionaries_;
   PartitioningFactoryOptions options_;
 };
 
@@ -601,7 +635,7 @@ class HivePartitioningFactory : public PartitioningFactory {
   std::string type_name() const override { return "hive"; }
 
   Result<std::shared_ptr<Schema>> Inspect(
-      const std::vector<std::string>& paths) const override {
+      const std::vector<std::string>& paths) override {
     KeyValuePartitioningInspectImpl impl(options_);
 
     for (auto path : paths) {
@@ -612,15 +646,16 @@ class HivePartitioningFactory : public PartitioningFactory {
       }
     }
 
-    return impl.Finish();
+    return impl.Finish(&dictionaries_);
   }
 
   Result<std::shared_ptr<Partitioning>> Finish(
       const std::shared_ptr<Schema>& schema) const override {
-    return std::shared_ptr<Partitioning>(new HivePartitioning(schema));
+    return std::shared_ptr<Partitioning>(new HivePartitioning(schema, dictionaries_));
   }
 
  private:
+  ArrayVector dictionaries_;
   PartitioningFactoryOptions options_;
 };
 

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -86,6 +86,17 @@ class ARROW_DS_EXPORT Partitioning {
   std::shared_ptr<Schema> schema_;
 };
 
+struct PartitioningFactoryOptions {
+  /// When inferring a schema for partition fields, string fields may be inferred as
+  /// a dictionary type instead. This can be more efficient when materializing virtual
+  /// columns. If the number of discovered unique values of a string field exceeds
+  /// max_partition_dictionary_size, it will instead be inferred as a string.
+  ///
+  /// max_partition_dictionary_size = 0: No fields will be inferred as dictionary.
+  /// max_partition_dictionary_size = -1: All fields will be inferred as dictionary.
+  int max_partition_dictionary_size = 0;
+};
+
 /// \brief PartitioningFactory provides creation of a partitioning  when the
 /// specific schema must be inferred from available paths (no explicit schema is known).
 class ARROW_DS_EXPORT PartitioningFactory {
@@ -203,7 +214,7 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
   Result<std::string> FormatKey(const Key& key, int i) const override;
 
   static std::shared_ptr<PartitioningFactory> MakeFactory(
-      std::vector<std::string> field_names);
+      std::vector<std::string> field_names, PartitioningFactoryOptions = {});
 };
 
 /// \brief Multi-level, directory based partitioning
@@ -230,7 +241,8 @@ class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
 
   static util::optional<Key> ParseKey(const std::string& segment);
 
-  static std::shared_ptr<PartitioningFactory> MakeFactory();
+  static std::shared_ptr<PartitioningFactory> MakeFactory(
+      PartitioningFactoryOptions = {});
 };
 
 /// \brief Implementation provided by lambda or other callable

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -107,8 +107,9 @@ class ARROW_DS_EXPORT PartitioningFactory {
   virtual std::string type_name() const = 0;
 
   /// Get the schema for the resulting Partitioning.
+  /// This may reset internal state, for example dictionaries of unique representations.
   virtual Result<std::shared_ptr<Schema>> Inspect(
-      const std::vector<std::string>& paths) const = 0;
+      const std::vector<std::string>& paths) = 0;
 
   /// Create a partitioning using the provided schema
   /// (fields may be dropped).
@@ -180,7 +181,8 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
   /// Convert a Key to a full expression.
   /// If the field referenced in key is absent from the schema will be ignored.
   static Result<std::shared_ptr<Expression>> ConvertKey(const Key& key,
-                                                        const Schema& schema);
+                                                        const Schema& schema,
+                                                        const ArrayVector& dictionaries);
 
   /// Extract a partition key from a path segment.
   virtual util::optional<Key> ParseKey(const std::string& segment, int i) const = 0;
@@ -193,7 +195,14 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
   Result<std::string> Format(const Expression& expr, int i) const override;
 
  protected:
-  using Partitioning::Partitioning;
+  KeyValuePartitioning(std::shared_ptr<Schema> schema, ArrayVector dictionaries)
+      : Partitioning(std::move(schema)), dictionaries_(std::move(dictionaries)) {
+    if (dictionaries_.empty()) {
+      dictionaries_.resize(schema_->num_fields());
+    }
+  }
+
+  ArrayVector dictionaries_;
 };
 
 /// \brief DirectoryPartitioning parses one segment of a path for each field in its
@@ -204,8 +213,11 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
 /// parsed to ("year"_ == 2009 and "month"_ == 11)
 class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
  public:
-  explicit DirectoryPartitioning(std::shared_ptr<Schema> schema)
-      : KeyValuePartitioning(std::move(schema)) {}
+  // If a field in schema is of dictionary type, the corresponding element of dictionaries
+  // must be contain the dictionary of values for that field.
+  explicit DirectoryPartitioning(std::shared_ptr<Schema> schema,
+                                 ArrayVector dictionaries = {})
+      : KeyValuePartitioning(std::move(schema), std::move(dictionaries)) {}
 
   std::string type_name() const override { return "schema"; }
 
@@ -228,8 +240,10 @@ class ARROW_DS_EXPORT DirectoryPartitioning : public KeyValuePartitioning {
 /// "/day=321/ignored=3.4/year=2009" parses to ("year"_ == 2009 and "day"_ == 321)
 class ARROW_DS_EXPORT HivePartitioning : public KeyValuePartitioning {
  public:
-  explicit HivePartitioning(std::shared_ptr<Schema> schema)
-      : KeyValuePartitioning(std::move(schema)) {}
+  // If a field in schema is of dictionary type, the corresponding element of dictionaries
+  // must be contain the dictionary of values for that field.
+  explicit HivePartitioning(std::shared_ptr<Schema> schema, ArrayVector dictionaries = {})
+      : KeyValuePartitioning(std::move(schema), std::move(dictionaries)) {}
 
   std::string type_name() const override { return "hive"; }
 
@@ -280,40 +294,28 @@ ARROW_DS_EXPORT std::vector<std::string> StripPrefixAndFilename(
 class ARROW_DS_EXPORT PartitioningOrFactory {
  public:
   explicit PartitioningOrFactory(std::shared_ptr<Partitioning> partitioning)
-      : variant_(std::move(partitioning)) {}
+      : partitioning_(std::move(partitioning)) {}
 
   explicit PartitioningOrFactory(std::shared_ptr<PartitioningFactory> factory)
-      : variant_(std::move(factory)) {}
+      : factory_(std::move(factory)) {}
 
   PartitioningOrFactory& operator=(std::shared_ptr<Partitioning> partitioning) {
-    variant_ = std::move(partitioning);
-    return *this;
+    return *this = PartitioningOrFactory(std::move(partitioning));
   }
 
   PartitioningOrFactory& operator=(std::shared_ptr<PartitioningFactory> factory) {
-    variant_ = std::move(factory);
-    return *this;
+    return *this = PartitioningOrFactory(std::move(factory));
   }
 
-  std::shared_ptr<Partitioning> partitioning() const {
-    if (util::holds_alternative<std::shared_ptr<Partitioning>>(variant_)) {
-      return util::get<std::shared_ptr<Partitioning>>(variant_);
-    }
-    return NULLPTR;
-  }
+  const std::shared_ptr<Partitioning>& partitioning() const { return partitioning_; }
 
-  std::shared_ptr<PartitioningFactory> factory() const {
-    if (util::holds_alternative<std::shared_ptr<PartitioningFactory>>(variant_)) {
-      return util::get<std::shared_ptr<PartitioningFactory>>(variant_);
-    }
-    return NULLPTR;
-  }
+  const std::shared_ptr<PartitioningFactory>& factory() const { return factory_; }
 
   Result<std::shared_ptr<Schema>> GetOrInferSchema(const std::vector<std::string>& paths);
 
  private:
-  util::variant<std::shared_ptr<PartitioningFactory>, std::shared_ptr<Partitioning>>
-      variant_;
+  std::shared_ptr<PartitioningFactory> factory_;
+  std::shared_ptr<Partitioning> partitioning_;
 };
 
 }  // namespace dataset

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -395,8 +395,10 @@ struct ARROW_EXPORT DenseUnionScalar : public UnionScalar {
 
 struct ARROW_EXPORT DictionaryScalar : public Scalar {
   using TypeClass = DictionaryType;
-  using ValueType = std::shared_ptr<Scalar>;
-  ValueType value;
+  struct ValueType {
+    std::shared_ptr<Scalar> index;
+    std::shared_ptr<Array> dictionary;
+  } value;
 
   explicit DictionaryScalar(std::shared_ptr<DataType> type);
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1172,7 +1172,7 @@ cdef class DirectoryPartitioning(Partitioning):
         self.directory_partitioning = <CDirectoryPartitioning*> sp.get()
 
     @staticmethod
-    def discover(field_names, object max_partition_dictionary_size = 0):
+    def discover(field_names, object max_partition_dictionary_size=0):
         """
         Discover a DirectoryPartitioning.
 
@@ -1254,7 +1254,7 @@ cdef class HivePartitioning(Partitioning):
         self.hive_partitioning = <CHivePartitioning*> sp.get()
 
     @staticmethod
-    def discover(object max_partition_dictionary_size = 0):
+    def discover(object max_partition_dictionary_size=0):
         """
         Discover a HivePartitioning.
 

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -267,6 +267,10 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[shared_ptr[CExpression]] Parse(const c_string & path) const
         const shared_ptr[CSchema] & schema()
 
+    cdef cppclass CPartitioningFactoryOptions \
+            "arrow::dataset::PartitioningFactoryOptions":
+        int max_partition_dictionary_size
+
     cdef cppclass CPartitioningFactory "arrow::dataset::PartitioningFactory":
         pass
 
@@ -276,14 +280,15 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
         @staticmethod
         shared_ptr[CPartitioningFactory] MakeFactory(
-            vector[c_string] field_names)
+            vector[c_string] field_names, CPartitioningFactoryOptions)
 
     cdef cppclass CHivePartitioning \
             "arrow::dataset::HivePartitioning"(CPartitioning):
         CHivePartitioning(shared_ptr[CSchema] schema)
 
         @staticmethod
-        shared_ptr[CPartitioningFactory] MakeFactory()
+        shared_ptr[CPartitioningFactory] MakeFactory(
+            CPartitioningFactoryOptions)
 
     cdef cppclass CPartitioningOrFactory \
             "arrow::dataset::PartitioningOrFactory":

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -820,7 +820,7 @@ def test_partitioning_factory_dictionary(mockfs):
         1: pa.string(),
         2: pa.dictionary(pa.int8(), pa.string()),
         64: pa.dictionary(pa.int8(), pa.string()),
-        #None: pa.dictionary(pa.int8(), pa.string()),
+        None: pa.dictionary(pa.int8(), pa.string()),
     }
 
     for max_size, expected_type in max_size_to_inferred_type.items():

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -810,6 +810,31 @@ def test_partitioning_factory(mockfs):
     assert isinstance(hive_partitioning_factory, ds.PartitioningFactory)
 
 
+def test_partitioning_factory_dictionary(mockfs):
+    paths_or_selector = fs.FileSelector('subdir', recursive=True)
+    format = ds.ParquetFileFormat()
+    options = ds.FileSystemFactoryOptions('subdir')
+
+    max_size_to_inferred_type = {
+        0: pa.string(),
+        1: pa.string(),
+        2: pa.dictionary(pa.int8(), pa.string()),
+        64: pa.dictionary(pa.int8(), pa.string()),
+        #None: pa.dictionary(pa.int8(), pa.string()),
+    }
+
+    for max_size, expected_type in max_size_to_inferred_type.items():
+        options.partitioning_factory = ds.DirectoryPartitioning.discover(
+            ['group', 'key'],
+            max_partition_dictionary_size=max_size)
+
+        factory = ds.FileSystemDatasetFactory(
+            mockfs, paths_or_selector, format, options)
+
+        inferred_schema = factory.inspect()
+        assert inferred_schema.field('key').type == expected_type
+
+
 def test_partitioning_function():
     schema = pa.schema([("year", pa.int16()), ("month", pa.int8())])
     names = ["year", "month"]

--- a/r/tests/testthat/test-expression.R
+++ b/r/tests/testthat/test-expression.R
@@ -48,7 +48,6 @@ test_that("C++ expressions", {
   ts <- Expression$scalar(as.POSIXct("2020-01-17 11:11:11"))
   i64 <- Expression$scalar(bit64::as.integer64(42))
   time <- Expression$scalar(hms::hms(56, 34, 12))
-  dict <- Expression$scalar(factor("a"))
 
   expect_is(f == g, "Expression")
   expect_is(f == 4, "Expression")
@@ -57,7 +56,6 @@ test_that("C++ expressions", {
   expect_is(f == date, "Expression")
   expect_is(f == i64, "Expression")
   expect_is(f == time, "Expression")
-  expect_is(f == dict, "Expression")
   # can't seem to make this work right now because of R Ops.method dispatch
   # expect_is(f == as.Date("2020-01-15"), "Expression")
   expect_is(f == ts, "Expression")


### PR DESCRIPTION
A maximum cardinality for the inferred dictionary can be specified:

| max | result |
|---|---|
| 0 (default) | All string partition fields will be inferred as utf8 |
| None | All string partition fields will be inferred as dictionary(<smallest integer>, utf8) |
| 64 | If a field has 64 or fewer distinct partition values, it will be inferred as dictionary(int8, utf8) otherwise as utf8 |