### PR TITLE
ARROW-842: [Python] Recognize pandas.NaT as null when converting object arrays with from_pandas=True

### DIFF
--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -70,7 +70,7 @@ inline bool IsPyInteger(PyObject* obj) { return PyLong_Check(obj); }
 
 // \brief Import symbols from pandas that we need for various type-checking,
 // like pandas.NaT or pandas.NA
-Status InitPandasStaticData();
+void InitPandasStaticData();
 
 // \brief Use pandas missing value semantics to check if a value is null
 ARROW_PYTHON_EXPORT

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -68,6 +68,10 @@ Status ImportFromModule(PyObject* module, const std::string& name, OwnedRef* ref
 // \brief Check whether obj is an integer, independent of Python versions.
 inline bool IsPyInteger(PyObject* obj) { return PyLong_Check(obj); }
 
+// \brief Import symbols from pandas that we need for various type-checking,
+// like pandas.NaT or pandas.NA
+Status InitPandasStaticData();
+
 // \brief Use pandas missing value semantics to check if a value is null
 ARROW_PYTHON_EXPORT
 bool PandasObjectIsNull(PyObject* obj);

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -1171,6 +1171,10 @@ Status GetConverterFlat(const std::shared_ptr<DataType>& type, bool strict_conve
 
 Status GetConverter(const std::shared_ptr<DataType>& type, bool from_pandas,
                     bool strict_conversions, std::unique_ptr<SeqConverter>* out) {
+  if (from_pandas) {
+    RETURN_NOT_OK(internal::InitPandasStaticData());
+  }
+
   switch (type->id()) {
     case Type::LIST:
       if (from_pandas) {

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -1172,7 +1172,9 @@ Status GetConverterFlat(const std::shared_ptr<DataType>& type, bool strict_conve
 Status GetConverter(const std::shared_ptr<DataType>& type, bool from_pandas,
                     bool strict_conversions, std::unique_ptr<SeqConverter>* out) {
   if (from_pandas) {
-    RETURN_NOT_OK(internal::InitPandasStaticData());
+    // ARROW-842: If pandas is not installed then null checks will be less
+    // comprehensive, but that is okay.
+    internal::InitPandasStaticData();
   }
 
   switch (type->id()) {

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1205,6 +1205,16 @@ class TestConvertDateTimeLikeTypes:
         tm.assert_frame_equal(table_pandas_objects,
                               expected_pandas_objects)
 
+    def test_NaT_in_object_array(self):
+        # ARROW-842
+        values = np.array([datetime(2000, 1, 1), pd.NaT], dtype=object)
+        values_with_none = np.array([datetime(2000, 1, 1), None],
+                                    dtype=object)
+        result = pa.array(values, from_pandas=True)
+        expected = pa.array(values_with_none, from_pandas=True)
+        assert result.equals(expected)
+        assert result.null_count == 1
+
     def test_dates_from_integers(self):
         t1 = pa.date32()
         t2 = pa.date64()

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1205,15 +1205,16 @@ class TestConvertDateTimeLikeTypes:
         tm.assert_frame_equal(table_pandas_objects,
                               expected_pandas_objects)
 
-    def test_NaT_in_object_array(self):
+    def test_object_null_values(self):
         # ARROW-842
-        values = np.array([datetime(2000, 1, 1), pd.NaT], dtype=object)
-        values_with_none = np.array([datetime(2000, 1, 1), None],
+        NA = getattr(pd, 'NA', None)
+        values = np.array([datetime(2000, 1, 1), pd.NaT, NA], dtype=object)
+        values_with_none = np.array([datetime(2000, 1, 1), None, None],
                                     dtype=object)
         result = pa.array(values, from_pandas=True)
         expected = pa.array(values_with_none, from_pandas=True)
         assert result.equals(expected)
-        assert result.null_count == 1
+        assert result.null_count == 2
 
     def test_dates_from_integers(self):
         t1 = pa.date32()


### PR DESCRIPTION
This has been the root cause of a number of bugs. I'm unclear if there's a race condition with tearing down a `static OwnedRef` so we might need some other approach to managing symbols imported from various Python modules