### PR TITLE
ARROW-9224: [Dev][Archery] clone local source with --shared

### DIFF
--- a/dev/archery/archery/utils/source.py
+++ b/dev/archery/archery/utils/source.py
@@ -143,7 +143,9 @@ class ArrowSources:
         # A local clone is required to leave the current sources intact such
         # that builds depending on said sources are not invalidated (or worse
         # slightly affected when re-invoking the generator).
-        git.clone("--local", self.path, clone_dir)
+        # "--local" only works when dest dir is on same volume of source dir.
+        # "--shared" works even if dest dir is on different volume.
+        git.clone("--shared", self.path, clone_dir)
 
         # Revision can reference "origin/" (or any remotes) that are not found
         # in the local clone. Thus, revisions are dereferenced in the source


### PR DESCRIPTION
`archery benchmark diff` runs "git clone --local" to clone source code
to /tmp. If /tmp and source directory are at different disk volumes, it
fails because "git clone --local" uses hard links which only works on
same volume. This patch replaces "--local" with "--shared".

Error log:
fatal: failed to create link '/tmp/arrow-archery-lwm7k6wm/origin_master/arrow/.git/objects/2d/80a4d2da431dbfe3c736b6349eb4a0bcb6ece5': Invalid cross-device link
subprocess.CalledProcessError: Command '['git', 'clone', '--local', PosixPath('/home/cyb/arrow'), '/tmp/arrow-archery-lwm7k6wm/origin_master/arrow']' returned non-zero exit status 128.