### PR TITLE
ARROW-8950: [C++] Avoid HEAD when possible in S3 filesystem

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -556,6 +556,7 @@ function(ADD_TEST_CASE REL_TEST_NAME)
       EXTRA_INCLUDES
       EXTRA_DEPENDENCIES
       LABELS
+      EXTRA_LABELS
       PREFIX)
   cmake_parse_arguments(ARG
                         "${options}"
@@ -652,10 +653,15 @@ function(ADD_TEST_CASE REL_TEST_NAME)
     add_dependencies(${TARGET} ${TEST_NAME})
   endforeach()
 
+  set(LABELS)
+  list(APPEND LABELS "unittest")
   if(ARG_LABELS)
-    set(ARG_LABELS "unittest;${ARG_LABELS}")
-  else()
-    set(ARG_LABELS unittest)
+    list(APPEND LABELS ${ARG_LABELS})
+  endif()
+  # EXTRA_LABELS don't create their own dependencies, they are only used
+  # to ease running certain test categories.
+  if(ARG_EXTRA_LABELS)
+    list(APPEND LABELS ${ARG_EXTRA_LABELS})
   endif()
 
   foreach(LABEL ${ARG_LABELS})
@@ -673,7 +679,7 @@ function(ADD_TEST_CASE REL_TEST_NAME)
     add_dependencies(${LABEL_TEST_NAME} ${TEST_NAME})
   endforeach()
 
-  set_property(TEST ${TEST_NAME} APPEND PROPERTY LABELS ${ARG_LABELS})
+  set_property(TEST ${TEST_NAME} APPEND PROPERTY LABELS ${LABELS})
 endfunction()
 
 #

--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -103,9 +103,9 @@ Result<std::shared_ptr<Dataset>> UnionDatasetFactory::Finish(FinishOptions optio
 }
 
 FileSystemDatasetFactory::FileSystemDatasetFactory(
-    std::vector<std::string> paths, std::shared_ptr<fs::FileSystem> filesystem,
+    std::vector<fs::FileInfo> files, std::shared_ptr<fs::FileSystem> filesystem,
     std::shared_ptr<FileFormat> format, FileSystemFactoryOptions options)
-    : paths_(std::move(paths)),
+    : files_(std::move(files)),
       fs_(std::move(filesystem)),
       format_(std::move(format)),
       options_(std::move(options)) {}
@@ -113,7 +113,7 @@ FileSystemDatasetFactory::FileSystemDatasetFactory(
 Result<std::shared_ptr<DatasetFactory>> FileSystemDatasetFactory::Make(
     std::shared_ptr<fs::FileSystem> filesystem, const std::vector<std::string>& paths,
     std::shared_ptr<FileFormat> format, FileSystemFactoryOptions options) {
-  std::vector<std::string> filtered_paths;
+  std::vector<fs::FileInfo> filtered_files;
   for (const auto& path : paths) {
     if (options.exclude_invalid_files) {
       ARROW_ASSIGN_OR_RAISE(auto supported,
@@ -123,11 +123,32 @@ Result<std::shared_ptr<DatasetFactory>> FileSystemDatasetFactory::Make(
       }
     }
 
-    filtered_paths.push_back(path);
+    filtered_files.emplace_back(path);
   }
 
   return std::shared_ptr<DatasetFactory>(
-      new FileSystemDatasetFactory(std::move(filtered_paths), std::move(filesystem),
+      new FileSystemDatasetFactory(std::move(filtered_files), std::move(filesystem),
+                                   std::move(format), std::move(options)));
+}
+
+Result<std::shared_ptr<DatasetFactory>> FileSystemDatasetFactory::Make(
+    std::shared_ptr<fs::FileSystem> filesystem, const std::vector<fs::FileInfo>& files,
+    std::shared_ptr<FileFormat> format, FileSystemFactoryOptions options) {
+  std::vector<fs::FileInfo> filtered_files;
+  for (const auto& info : files) {
+    if (options.exclude_invalid_files) {
+      ARROW_ASSIGN_OR_RAISE(auto supported,
+                            format->IsSupported(FileSource(info, filesystem)));
+      if (!supported) {
+        continue;
+      }
+    }
+
+    filtered_files.emplace_back(info);
+  }
+
+  return std::shared_ptr<DatasetFactory>(
+      new FileSystemDatasetFactory(std::move(filtered_files), std::move(filesystem),
                                    std::move(format), std::move(options)));
 }
 
@@ -156,13 +177,12 @@ Result<std::shared_ptr<DatasetFactory>> FileSystemDatasetFactory::Make(
 
   ARROW_ASSIGN_OR_RAISE(auto files, filesystem->GetFileInfo(selector));
 
-  std::vector<std::string> paths;
+  // XXX We may avoid copying around vectors of FileInfo by filtering in place.
+  std::vector<fs::FileInfo> filtered_files;
   for (const auto& info : files) {
     const auto& path = info.path();
 
     if (!info.IsFile()) {
-      // TODO(fsaintjacques): push this filtering into Selector logic so we
-      // don't copy big vector around.
       continue;
     }
 
@@ -170,13 +190,13 @@ Result<std::shared_ptr<DatasetFactory>> FileSystemDatasetFactory::Make(
       continue;
     }
 
-    paths.push_back(path);
+    filtered_files.push_back(info);
   }
 
   // Sorting by path guarantees a stability sometimes needed by unit tests.
-  std::sort(paths.begin(), paths.end());
+  std::sort(filtered_files.begin(), filtered_files.end(), fs::FileInfo::ByPath());
 
-  return Make(std::move(filesystem), std::move(paths), std::move(format),
+  return Make(std::move(filesystem), std::move(filtered_files), std::move(format),
               std::move(options));
 }
 
@@ -186,15 +206,15 @@ Result<std::vector<std::shared_ptr<Schema>>> FileSystemDatasetFactory::InspectSc
 
   const bool has_fragments_limit = options.fragments >= 0;
   int fragments = options.fragments;
-  for (const auto& path : paths_) {
+  for (const auto& info : files_) {
     if (has_fragments_limit && fragments-- == 0) break;
-    ARROW_ASSIGN_OR_RAISE(auto schema, format_->Inspect({path, fs_}));
+    ARROW_ASSIGN_OR_RAISE(auto schema, format_->Inspect({info, fs_}));
     schemas.push_back(schema);
   }
 
   ARROW_ASSIGN_OR_RAISE(auto partition_schema,
                         options_.partitioning.GetOrInferSchema(
-                            StripPrefixAndFilename(paths_, options_.partition_base_dir)));
+                            StripPrefixAndFilename(files_, options_.partition_base_dir)));
   schemas.push_back(partition_schema);
 
   return schemas;
@@ -223,10 +243,10 @@ Result<std::shared_ptr<Dataset>> FileSystemDatasetFactory::Finish(FinishOptions 
   }
 
   std::vector<std::shared_ptr<FileFragment>> fragments;
-  for (const auto& path : paths_) {
-    auto fixed_path = StripPrefixAndFilename(path, options_.partition_base_dir);
+  for (const auto& info : files_) {
+    auto fixed_path = StripPrefixAndFilename(info.path(), options_.partition_base_dir);
     ARROW_ASSIGN_OR_RAISE(auto partition, partitioning->Parse(fixed_path));
-    ARROW_ASSIGN_OR_RAISE(auto fragment, format_->MakeFragment({path, fs_}, partition));
+    ARROW_ASSIGN_OR_RAISE(auto fragment, format_->MakeFragment({info, fs_}, partition));
     fragments.push_back(fragment);
   }
 

--- a/cpp/src/arrow/dataset/discovery.h
+++ b/cpp/src/arrow/dataset/discovery.h
@@ -222,14 +222,18 @@ class ARROW_DS_EXPORT FileSystemDatasetFactory : public DatasetFactory {
   Result<std::shared_ptr<Dataset>> Finish(FinishOptions options) override;
 
  protected:
-  FileSystemDatasetFactory(std::vector<std::string> paths,
+  static Result<std::shared_ptr<DatasetFactory>> Make(
+      std::shared_ptr<fs::FileSystem> filesystem, const std::vector<fs::FileInfo>& files,
+      std::shared_ptr<FileFormat> format, FileSystemFactoryOptions options);
+
+  FileSystemDatasetFactory(std::vector<fs::FileInfo> files,
                            std::shared_ptr<fs::FileSystem> filesystem,
                            std::shared_ptr<FileFormat> format,
                            FileSystemFactoryOptions options);
 
   Result<std::shared_ptr<Schema>> PartitionSchema();
 
-  std::vector<std::string> paths_;
+  std::vector<fs::FileInfo> files_;
   std::shared_ptr<fs::FileSystem> fs_;
   std::shared_ptr<FileFormat> format_;
   FileSystemFactoryOptions options_;

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -222,9 +222,10 @@ TEST_F(FileSystemDatasetFactoryTest, MissingDirectories) {
   factory_options_.partitioning = std::make_shared<HivePartitioning>(
       schema({field("a", int32()), field("b", int32())}));
 
+  auto paths = std::vector<std::string>{partition_path, unpartition_path};
+
   ASSERT_OK_AND_ASSIGN(
-      factory_, FileSystemDatasetFactory::Make(fs_, {partition_path, unpartition_path},
-                                               format_, factory_options_));
+      factory_, FileSystemDatasetFactory::Make(fs_, paths, format_, factory_options_));
 
   InspectOptions options;
   AssertInspect(schema({field("a", int32()), field("b", int32())}), options);

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -36,7 +36,7 @@ namespace dataset {
 
 Result<std::shared_ptr<arrow::io::RandomAccessFile>> FileSource::Open() const {
   if (filesystem_) {
-    return filesystem_->OpenInputFile(path_);
+    return filesystem_->OpenInputFile(file_info_);
   }
 
   if (buffer_) {

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -47,7 +47,13 @@ class ARROW_DS_EXPORT FileSource {
  public:
   FileSource(std::string path, std::shared_ptr<fs::FileSystem> filesystem,
              Compression::type compression = Compression::UNCOMPRESSED)
-      : path_(std::move(path)),
+      : file_info_(std::move(path)),
+        filesystem_(std::move(filesystem)),
+        compression_(compression) {}
+
+  FileSource(fs::FileInfo info, std::shared_ptr<fs::FileSystem> filesystem,
+             Compression::type compression = Compression::UNCOMPRESSED)
+      : file_info_(std::move(info)),
         filesystem_(std::move(filesystem)),
         compression_(compression) {}
 
@@ -87,7 +93,7 @@ class ARROW_DS_EXPORT FileSource {
   const std::string& path() const {
     static std::string buffer_path = "<Buffer>";
     static std::string custom_open_path = "<Buffer>";
-    return filesystem_ ? path_ : buffer_ ? buffer_path : custom_open_path;
+    return filesystem_ ? file_info_.path() : buffer_ ? buffer_path : custom_open_path;
   }
 
   /// \brief Return the filesystem, if any. Otherwise returns nullptr
@@ -104,7 +110,7 @@ class ARROW_DS_EXPORT FileSource {
     return Status::Invalid("Called Open() on an uninitialized FileSource");
   }
 
-  std::string path_;
+  fs::FileInfo file_info_;
   std::shared_ptr<fs::FileSystem> filesystem_;
   std::shared_ptr<Buffer> buffer_;
   CustomOpen custom_open_;

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -571,6 +571,8 @@ static inline Result<std::string> FileFromRowGroup(
       }
     }
 
+    // TODO Is it possible to infer the file size and return a populated FileInfo?
+    // This could avoid some spurious HEAD requests on S3 (ARROW-8950)
     path = fs::internal::JoinAbstractPath(std::vector<std::string>{base_path, path});
     // Normalizing path is required for Windows.
     return filesystem->NormalizePath(std::move(path));

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -608,8 +608,19 @@ std::string StripPrefixAndFilename(const std::string& path, const std::string& p
 std::vector<std::string> StripPrefixAndFilename(const std::vector<std::string>& paths,
                                                 const std::string& prefix) {
   std::vector<std::string> result;
+  result.reserve(paths.size());
   for (const auto& path : paths) {
     result.emplace_back(StripPrefixAndFilename(path, prefix));
+  }
+  return result;
+}
+
+std::vector<std::string> StripPrefixAndFilename(const std::vector<fs::FileInfo>& files,
+                                                const std::string& prefix) {
+  std::vector<std::string> result;
+  result.reserve(files.size());
+  for (const auto& info : files) {
+    result.emplace_back(StripPrefixAndFilename(info.path(), prefix));
   }
   return result;
 }

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -264,6 +264,10 @@ ARROW_DS_EXPORT std::string StripPrefixAndFilename(const std::string& path,
 ARROW_DS_EXPORT std::vector<std::string> StripPrefixAndFilename(
     const std::vector<std::string>& paths, const std::string& prefix);
 
+/// \brief Vector version of StripPrefixAndFilename.
+ARROW_DS_EXPORT std::vector<std::string> StripPrefixAndFilename(
+    const std::vector<fs::FileInfo>& files, const std::string& prefix);
+
 /// \brief Either a Partitioning or a PartitioningFactory
 class ARROW_DS_EXPORT PartitioningOrFactory {
  public:

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -311,7 +311,7 @@ struct MakeFileSystemDatasetMixin {
       }
 
       ASSERT_OK_AND_ASSIGN(auto fragment,
-                           format->MakeFragment({info.path(), fs_}, partitions[i]));
+                           format->MakeFragment({info, fs_}, partitions[i]));
       fragments.push_back(std::move(fragment));
     }
 

--- a/cpp/src/arrow/filesystem/CMakeLists.txt
+++ b/cpp/src/arrow/filesystem/CMakeLists.txt
@@ -25,10 +25,12 @@ add_arrow_test(filesystem-test
                SOURCES
                filesystem_test.cc
                localfs_test.cc
-               path_forest_test.cc)
+               path_forest_test.cc
+               EXTRA_LABELS
+               filesystem)
 
 if(ARROW_S3)
-  add_arrow_test(s3fs_test)
+  add_arrow_test(s3fs_test EXTRA_LABELS filesystem)
 
   if(ARROW_BUILD_TESTS)
     add_executable(arrow-s3fs-narrative-test s3fs_narrative_test.cc)
@@ -48,5 +50,5 @@ if(ARROW_S3)
 endif()
 
 if(ARROW_HDFS)
-  add_arrow_test(hdfs_test)
+  add_arrow_test(hdfs_test EXTRA_LABELS filesystem)
 endif()

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -137,6 +137,28 @@ Status FileSystem::DeleteFiles(const std::vector<std::string>& paths) {
   return st;
 }
 
+Result<std::shared_ptr<io::InputStream>> FileSystem::OpenInputStream(
+    const FileInfo& info) {
+  if (info.type() == FileType::NotFound) {
+    return internal::PathNotFound(info.path());
+  }
+  if (info.type() != FileType::File && info.type() != FileType::Unknown) {
+    return internal::NotAFile(info.path());
+  }
+  return OpenInputStream(info.path());
+}
+
+Result<std::shared_ptr<io::RandomAccessFile>> FileSystem::OpenInputFile(
+    const FileInfo& info) {
+  if (info.type() == FileType::NotFound) {
+    return internal::PathNotFound(info.path());
+  }
+  if (info.type() != FileType::File && info.type() != FileType::Unknown) {
+    return internal::NotAFile(info.path());
+  }
+  return OpenInputFile(info.path());
+}
+
 //////////////////////////////////////////////////////////////////////////
 // SubTreeFileSystem implementation
 
@@ -264,11 +286,29 @@ Result<std::shared_ptr<io::InputStream>> SubTreeFileSystem::OpenInputStream(
   return base_fs_->OpenInputStream(s);
 }
 
+Result<std::shared_ptr<io::InputStream>> SubTreeFileSystem::OpenInputStream(
+    const FileInfo& info) {
+  auto s = info.path();
+  RETURN_NOT_OK(PrependBaseNonEmpty(&s));
+  FileInfo new_info(info);
+  new_info.set_path(std::move(s));
+  return base_fs_->OpenInputStream(new_info);
+}
+
 Result<std::shared_ptr<io::RandomAccessFile>> SubTreeFileSystem::OpenInputFile(
     const std::string& path) {
   auto s = path;
   RETURN_NOT_OK(PrependBaseNonEmpty(&s));
   return base_fs_->OpenInputFile(s);
+}
+
+Result<std::shared_ptr<io::RandomAccessFile>> SubTreeFileSystem::OpenInputFile(
+    const FileInfo& info) {
+  auto s = info.path();
+  RETURN_NOT_OK(PrependBaseNonEmpty(&s));
+  FileInfo new_info(info);
+  new_info.set_path(std::move(s));
+  return base_fs_->OpenInputFile(new_info);
 }
 
 Result<std::shared_ptr<io::OutputStream>> SubTreeFileSystem::OpenOutputStream(
@@ -349,10 +389,24 @@ Result<std::shared_ptr<io::InputStream>> SlowFileSystem::OpenInputStream(
   return std::make_shared<io::SlowInputStream>(stream, latencies_);
 }
 
+Result<std::shared_ptr<io::InputStream>> SlowFileSystem::OpenInputStream(
+    const FileInfo& info) {
+  latencies_->Sleep();
+  ARROW_ASSIGN_OR_RAISE(auto stream, base_fs_->OpenInputStream(info));
+  return std::make_shared<io::SlowInputStream>(stream, latencies_);
+}
+
 Result<std::shared_ptr<io::RandomAccessFile>> SlowFileSystem::OpenInputFile(
     const std::string& path) {
   latencies_->Sleep();
   ARROW_ASSIGN_OR_RAISE(auto file, base_fs_->OpenInputFile(path));
+  return std::make_shared<io::SlowRandomAccessFile>(file, latencies_);
+}
+
+Result<std::shared_ptr<io::RandomAccessFile>> SlowFileSystem::OpenInputFile(
+    const FileInfo& info) {
+  latencies_->Sleep();
+  ARROW_ASSIGN_OR_RAISE(auto file, base_fs_->OpenInputFile(info));
   return std::make_shared<io::SlowRandomAccessFile>(file, latencies_);
 }
 

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -26,6 +26,7 @@
 #include "arrow/buffer.h"
 #include "arrow/filesystem/mockfs.h"
 #include "arrow/filesystem/path_util.h"
+#include "arrow/filesystem/util_internal.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/io/memory.h"
 #include "arrow/util/logging.h"
@@ -37,18 +38,6 @@ namespace fs {
 namespace internal {
 
 namespace {
-
-Status PathNotFound(const std::string& path) {
-  return Status::IOError("Path does not exist '", path, "'");
-}
-
-Status NotADir(const std::string& path) {
-  return Status::IOError("Not a directory: '", path, "'");
-}
-
-Status NotAFile(const std::string& path) {
-  return Status::IOError("Not a regular file: '", path, "'");
-}
 
 ////////////////////////////////////////////////////////////////////////////
 // Filesystem structure

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -119,12 +119,23 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   /// a custom readahead strategy to avoid idle waits.
   Result<std::shared_ptr<io::InputStream>> OpenInputStream(
       const std::string& path) override;
+  /// Create a sequential input stream for reading from a S3 object.
+  ///
+  /// This override avoids a HEAD request by assuming the FileInfo
+  /// contains correct information.
+  Result<std::shared_ptr<io::InputStream>> OpenInputStream(const FileInfo& info) override;
 
   /// Create a random access file for reading from a S3 object.
   ///
   /// See OpenInputStream for performance notes.
   Result<std::shared_ptr<io::RandomAccessFile>> OpenInputFile(
       const std::string& path) override;
+  /// Create a random access file for reading from a S3 object.
+  ///
+  /// This override avoids a HEAD request by assuming the FileInfo
+  /// contains correct information.
+  Result<std::shared_ptr<io::RandomAccessFile>> OpenInputFile(
+      const FileInfo& info) override;
 
   /// Create a sequential output stream for writing to a S3 object.
   ///

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -826,6 +826,36 @@ void GenericFileSystemTest::TestOpenInputStream(FileSystem* fs) {
   ASSERT_RAISES(IOError, fs->OpenInputStream("AB"));
 }
 
+void GenericFileSystemTest::TestOpenInputStreamWithFileInfo(FileSystem* fs) {
+  ASSERT_OK(fs->CreateDir("AB"));
+  CreateFile(fs, "AB/abc", "some data");
+
+  ASSERT_OK_AND_ASSIGN(auto info, fs->GetFileInfo("AB/abc"));
+
+  ASSERT_OK_AND_ASSIGN(auto stream, fs->OpenInputStream(info));
+  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(9));
+  AssertBufferEqual(*buffer, "some data");
+
+  // Passing an incomplete FileInfo should also work
+  info.set_type(FileType::Unknown);
+  info.set_size(kNoSize);
+  info.set_mtime(kNoTime);
+  ASSERT_OK_AND_ASSIGN(stream, fs->OpenInputStream(info));
+  ASSERT_OK_AND_ASSIGN(buffer, stream->Read(4));
+  AssertBufferEqual(*buffer, "some");
+
+  // File does not exist
+  ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo("zzzzt"));
+  ASSERT_RAISES(IOError, fs->OpenInputStream(info));
+  // (same, with incomplete FileInfo)
+  info.set_type(FileType::Unknown);
+  ASSERT_RAISES(IOError, fs->OpenInputStream(info));
+
+  // Cannot open directory
+  ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo("AB"));
+  ASSERT_RAISES(IOError, fs->OpenInputStream(info));
+}
+
 void GenericFileSystemTest::TestOpenInputFile(FileSystem* fs) {
   ASSERT_OK(fs->CreateDir("AB"));
   CreateFile(fs, "AB/abc", "some other data");
@@ -845,6 +875,38 @@ void GenericFileSystemTest::TestOpenInputFile(FileSystem* fs) {
 
   // Cannot open directory
   ASSERT_RAISES(IOError, fs->OpenInputFile("AB"));
+}
+
+void GenericFileSystemTest::TestOpenInputFileWithFileInfo(FileSystem* fs) {
+  ASSERT_OK(fs->CreateDir("AB"));
+  CreateFile(fs, "AB/abc", "some data");
+
+  ASSERT_OK_AND_ASSIGN(auto info, fs->GetFileInfo("AB/abc"));
+
+  ASSERT_OK_AND_ASSIGN(auto file, fs->OpenInputFile(info));
+  ASSERT_OK_AND_EQ(9, file->GetSize());
+  ASSERT_OK_AND_ASSIGN(auto buffer, file->Read(9));
+  AssertBufferEqual(*buffer, "some data");
+
+  // Passing an incomplete FileInfo should also work
+  info.set_type(FileType::Unknown);
+  info.set_size(kNoSize);
+  info.set_mtime(kNoTime);
+  ASSERT_OK_AND_ASSIGN(file, fs->OpenInputFile(info));
+  ASSERT_OK_AND_EQ(9, file->GetSize());
+  ASSERT_OK_AND_ASSIGN(buffer, file->Read(4));
+  AssertBufferEqual(*buffer, "some");
+
+  // File does not exist
+  ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo("zzzzt"));
+  ASSERT_RAISES(IOError, fs->OpenInputFile(info));
+  // (same, with incomplete FileInfo)
+  info.set_type(FileType::Unknown);
+  ASSERT_RAISES(IOError, fs->OpenInputFile(info));
+
+  // Cannot open directory
+  ASSERT_OK_AND_ASSIGN(info, fs->GetFileInfo("AB"));
+  ASSERT_RAISES(IOError, fs->OpenInputFile(info));
 }
 
 #define GENERIC_FS_TEST_DEFINE(FUNC_NAME) \
@@ -867,7 +929,11 @@ GENERIC_FS_TEST_DEFINE(TestGetFileInfoSelectorWithRecursion)
 GENERIC_FS_TEST_DEFINE(TestOpenOutputStream)
 GENERIC_FS_TEST_DEFINE(TestOpenAppendStream)
 GENERIC_FS_TEST_DEFINE(TestOpenInputStream)
+GENERIC_FS_TEST_DEFINE(TestOpenInputStreamWithFileInfo)
 GENERIC_FS_TEST_DEFINE(TestOpenInputFile)
+GENERIC_FS_TEST_DEFINE(TestOpenInputFileWithFileInfo)
+
+#undef GENERIC_FS_TEST_DEFINE
 
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -30,17 +30,11 @@ namespace fs {
 static constexpr double kTimeSlack = 2.0;  // In seconds
 
 static inline FileInfo File(std::string path) {
-  FileInfo info;
-  info.set_type(FileType::File);
-  info.set_path(path);
-  return info;
+  return FileInfo(std::move(path), FileType::File);
 }
 
 static inline FileInfo Dir(std::string path) {
-  FileInfo info;
-  info.set_type(FileType::Directory);
-  info.set_path(path);
-  return info;
+  return FileInfo(std::move(path), FileType::Directory);
 }
 
 ARROW_EXPORT
@@ -115,7 +109,9 @@ class ARROW_EXPORT GenericFileSystemTest {
   void TestOpenOutputStream();
   void TestOpenAppendStream();
   void TestOpenInputStream();
+  void TestOpenInputStreamWithFileInfo();
   void TestOpenInputFile();
+  void TestOpenInputFileWithFileInfo();
 
  protected:
   // This function should return the filesystem under test.
@@ -153,7 +149,9 @@ class ARROW_EXPORT GenericFileSystemTest {
   void TestOpenOutputStream(FileSystem* fs);
   void TestOpenAppendStream(FileSystem* fs);
   void TestOpenInputStream(FileSystem* fs);
+  void TestOpenInputStreamWithFileInfo(FileSystem* fs);
   void TestOpenInputFile(FileSystem* fs);
+  void TestOpenInputFileWithFileInfo(FileSystem* fs);
 };
 
 #define GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, NAME) \
@@ -177,7 +175,9 @@ class ARROW_EXPORT GenericFileSystemTest {
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, OpenOutputStream)                 \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, OpenAppendStream)                 \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, OpenInputStream)                  \
-  GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, OpenInputFile)
+  GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, OpenInputStreamWithFileInfo)      \
+  GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, OpenInputFile)                    \
+  GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, OpenInputFileWithFileInfo)
 
 #define GENERIC_FS_TEST_FUNCTIONS(TEST_CLASS) \
   GENERIC_FS_TEST_FUNCTIONS_MACROS(TEST_F, TEST_CLASS)

--- a/cpp/src/arrow/filesystem/util_internal.cc
+++ b/cpp/src/arrow/filesystem/util_internal.cc
@@ -47,6 +47,18 @@ Status CopyStream(const std::shared_ptr<io::InputStream>& src,
   return Status::OK();
 }
 
+Status PathNotFound(const std::string& path) {
+  return Status::IOError("Path does not exist '", path, "'");
+}
+
+Status NotADir(const std::string& path) {
+  return Status::IOError("Not a directory: '", path, "'");
+}
+
+Status NotAFile(const std::string& path) {
+  return Status::IOError("Not a regular file: '", path, "'");
+}
+
 }  // namespace internal
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/util_internal.h
+++ b/cpp/src/arrow/filesystem/util_internal.h
@@ -36,6 +36,15 @@ ARROW_EXPORT
 Status CopyStream(const std::shared_ptr<io::InputStream>& src,
                   const std::shared_ptr<io::OutputStream>& dest, int64_t chunk_size);
 
+ARROW_EXPORT
+Status PathNotFound(const std::string& path);
+
+ARROW_EXPORT
+Status NotADir(const std::string& path);
+
+ARROW_EXPORT
+Status NotAFile(const std::string& path);
+
 }  // namespace internal
 }  // namespace fs
 }  // namespace arrow


### PR DESCRIPTION
Add FileSystem::OpenInput{Stream,File} overrides that accept a FileInfo parameter.
This can be used to optimize file opening when it the file size and existence is already known.  Concretely, avoids a HEAD request in S3.