### PR TITLE
[CI] Set allow_failures on Travis CI jobs until they stop being broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,9 @@ jobs:
         UBUNTU: "20.04"
         cares_SOURCE: "BUNDLED"
         gRPC_SOURCE: "BUNDLED"
+  allow_failures:
+    - arch: arm64
+    - arch: s390x
 
 env:
   DOCKER_BUILDKIT: 0


### PR DESCRIPTION
Travis CI has been flaky for days. This is adding a lot of noise to our workflows so I think we should allow them to fail until they become more consistently happy.