### PR TITLE
ARROW-9238: [C++][CI][FlightRPC] increase test coverage of round-robin under IPC and Flight

### DIFF
--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -431,6 +431,8 @@ class MetadataTestServer : public FlightServerBase {
     BatchVector batches;
     if (request.ticket == "dicts") {
       RETURN_NOT_OK(ExampleDictBatches(&batches));
+    } else if (request.ticket == "floats") {
+      RETURN_NOT_OK(ExampleFloatBatches(&batches));
     } else {
       RETURN_NOT_OK(ExampleIntBatches(&batches));
     }
@@ -1062,6 +1064,20 @@ TEST_F(TestFlightClient, DoGetInts) {
   CheckDoGet(descr, expected_batches, check_endpoints);
 }
 
+TEST_F(TestFlightClient, DoGetFloats) {
+  auto descr = FlightDescriptor::Path({"examples", "floats"});
+  BatchVector expected_batches;
+  ASSERT_OK(ExampleFloatBatches(&expected_batches));
+
+  auto check_endpoints = [](const std::vector<FlightEndpoint>& endpoints) {
+    // One endpoint in the example FlightInfo
+    ASSERT_EQ(1, endpoints.size());
+    AssertEqual(Ticket{"ticket-floats-1"}, endpoints[0].ticket);
+  };
+
+  CheckDoGet(descr, expected_batches, check_endpoints);
+}
+
 TEST_F(TestFlightClient, DoGetDicts) {
   auto descr = FlightDescriptor::Path({"examples", "dicts"});
   BatchVector expected_batches;
@@ -1428,9 +1444,33 @@ TEST_F(TestFlightClient, NoTimeout) {
 TEST_F(TestDoPut, DoPutInts) {
   auto descr = FlightDescriptor::Path({"ints"});
   BatchVector batches;
-  auto a1 = ArrayFromJSON(int32(), "[4, 5, 6, null]");
-  auto schema = arrow::schema({field("f1", a1->type())});
-  batches.push_back(RecordBatch::Make(schema, a1->length(), {a1}));
+  auto a0 = ArrayFromJSON(int8(), "[0, 1, 127, -128, null]");
+  auto a1 = ArrayFromJSON(uint8(), "[0, 1, 127, 255, null]");
+  auto a2 = ArrayFromJSON(int16(), "[0, 258, 32767, -32768, null]");
+  auto a3 = ArrayFromJSON(uint16(), "[0, 258, 32767, 65535, null]");
+  auto a4 = ArrayFromJSON(int32(), "[0, 65538, 2147483647, -2147483648, null]");
+  auto a5 = ArrayFromJSON(uint32(), "[0, 65538, 2147483647, 4294967295, null]");
+  auto a6 = ArrayFromJSON(
+      int64(), "[0, 4294967298, 9223372036854775807, -9223372036854775808, null]");
+  auto a7 = ArrayFromJSON(
+      uint64(), "[0, 4294967298, 9223372036854775807, 18446744073709551615, null]");
+  auto schema = arrow::schema(
+      {field("f0", a0->type()), field("f1", a1->type()), field("f2", a2->type()),
+       field("f3", a3->type()), field("f4", a4->type()), field("f5", a5->type()),
+       field("f6", a6->type()), field("f7", a7->type())});
+  batches.push_back(
+      RecordBatch::Make(schema, a0->length(), {a0, a1, a2, a3, a4, a5, a6, a7}));
+
+  CheckDoPut(descr, schema, batches);
+}
+
+TEST_F(TestDoPut, DoPutFloats) {
+  auto descr = FlightDescriptor::Path({"floats"});
+  BatchVector batches;
+  auto a0 = ArrayFromJSON(float32(), "[0, 1.2, -3.4, 5.6, null]");
+  auto a1 = ArrayFromJSON(float64(), "[0, 1.2, -3.4, 5.6, null]");
+  auto schema = arrow::schema({field("f0", a0->type()), field("f1", a1->type())});
+  batches.push_back(RecordBatch::Make(schema, a0->length(), {a0, a1}));
 
   CheckDoPut(descr, schema, batches);
 }

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -1454,10 +1454,10 @@ TEST_F(TestDoPut, DoPutInts) {
       int64(), "[0, 4294967298, 9223372036854775807, -9223372036854775808, null]");
   auto a7 = ArrayFromJSON(
       uint64(), "[0, 4294967298, 9223372036854775807, 18446744073709551615, null]");
-  auto schema = arrow::schema(
-      {field("f0", a0->type()), field("f1", a1->type()), field("f2", a2->type()),
-       field("f3", a3->type()), field("f4", a4->type()), field("f5", a5->type()),
-       field("f6", a6->type()), field("f7", a7->type())});
+  auto schema = arrow::schema({field("f0", a0->type()), field("f1", a1->type()),
+                               field("f2", a2->type()), field("f3", a3->type()),
+                               field("f4", a4->type()), field("f5", a5->type()),
+                               field("f6", a6->type()), field("f7", a7->type())});
   batches.push_back(
       RecordBatch::Make(schema, a0->length(), {a0, a1, a2, a3, a4, a5, a6, a7}));
 

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -145,13 +145,18 @@ Status GetBatchForFlight(const Ticket& ticket, std::shared_ptr<RecordBatchReader
     RETURN_NOT_OK(ExampleIntBatches(&batches));
     *out = std::make_shared<BatchIterator>(batches[0]->schema(), batches);
     return Status::OK();
+  } else if (ticket.ticket == "ticket-floats-1") {
+    BatchVector batches;
+    RETURN_NOT_OK(ExampleFloatBatches(&batches));
+    *out = std::make_shared<BatchIterator>(batches[0]->schema(), batches);
+    return Status::OK();
   } else if (ticket.ticket == "ticket-dicts-1") {
     BatchVector batches;
     RETURN_NOT_OK(ExampleDictBatches(&batches));
     *out = std::make_shared<BatchIterator>(batches[0]->schema(), batches);
     return Status::OK();
   } else {
-    return Status::NotImplemented("no stream implemented for this ticket");
+    return Status::NotImplemented("no stream implemented for ticket: " + ticket.ticket);
   }
 }
 
@@ -468,8 +473,20 @@ Status NumberingStream::Next(FlightPayload* payload) {
 }
 
 std::shared_ptr<Schema> ExampleIntSchema() {
-  auto f0 = field("f0", int32());
-  auto f1 = field("f1", int32());
+  auto f0 = field("f0", int8());
+  auto f1 = field("f1", uint8());
+  auto f2 = field("f2", int16());
+  auto f3 = field("f3", uint16());
+  auto f4 = field("f4", int32());
+  auto f5 = field("f5", uint32());
+  auto f6 = field("f6", int64());
+  auto f7 = field("f7", uint64());
+  return ::arrow::schema({f0, f1, f2, f3, f4, f5, f6, f7});
+}
+
+std::shared_ptr<Schema> ExampleFloatSchema() {
+  auto f0 = field("f0", float32());
+  auto f1 = field("f1", float64());
   return ::arrow::schema({f0, f1});
 }
 
@@ -490,31 +507,39 @@ std::vector<FlightInfo> ExampleFlightInfo() {
   Location location2;
   Location location3;
   Location location4;
+  Location location5;
   ARROW_EXPECT_OK(Location::ForGrpcTcp("foo1.bar.com", 12345, &location1));
   ARROW_EXPECT_OK(Location::ForGrpcTcp("foo2.bar.com", 12345, &location2));
   ARROW_EXPECT_OK(Location::ForGrpcTcp("foo3.bar.com", 12345, &location3));
   ARROW_EXPECT_OK(Location::ForGrpcTcp("foo4.bar.com", 12345, &location4));
+  ARROW_EXPECT_OK(Location::ForGrpcTcp("foo5.bar.com", 12345, &location5));
 
-  FlightInfo::Data flight1, flight2, flight3;
+  FlightInfo::Data flight1, flight2, flight3, flight4;
 
   FlightEndpoint endpoint1({{"ticket-ints-1"}, {location1}});
   FlightEndpoint endpoint2({{"ticket-ints-2"}, {location2}});
   FlightEndpoint endpoint3({{"ticket-cmd"}, {location3}});
   FlightEndpoint endpoint4({{"ticket-dicts-1"}, {location4}});
+  FlightEndpoint endpoint5({{"ticket-floats-1"}, {location5}});
 
   FlightDescriptor descr1{FlightDescriptor::PATH, "", {"examples", "ints"}};
   FlightDescriptor descr2{FlightDescriptor::CMD, "my_command", {}};
   FlightDescriptor descr3{FlightDescriptor::PATH, "", {"examples", "dicts"}};
+  FlightDescriptor descr4{FlightDescriptor::PATH, "", {"examples", "floats"}};
 
   auto schema1 = ExampleIntSchema();
   auto schema2 = ExampleStringSchema();
   auto schema3 = ExampleDictSchema();
+  auto schema4 = ExampleFloatSchema();
 
   ARROW_EXPECT_OK(
       MakeFlightInfo(*schema1, descr1, {endpoint1, endpoint2}, 1000, 100000, &flight1));
   ARROW_EXPECT_OK(MakeFlightInfo(*schema2, descr2, {endpoint3}, 1000, 100000, &flight2));
   ARROW_EXPECT_OK(MakeFlightInfo(*schema3, descr3, {endpoint4}, -1, -1, &flight3));
-  return {FlightInfo(flight1), FlightInfo(flight2), FlightInfo(flight3)};
+  ARROW_EXPECT_OK(MakeFlightInfo(*schema4, descr4, {endpoint5}, 1000, 100000, &flight4));
+  return {
+    FlightInfo(flight1), FlightInfo(flight2), FlightInfo(flight3), FlightInfo(flight4)
+  };
 }
 
 Status ExampleIntBatches(BatchVector* out) {
@@ -522,6 +547,16 @@ Status ExampleIntBatches(BatchVector* out) {
   for (int i = 0; i < 5; ++i) {
     // Make all different sizes, use different random seed
     RETURN_NOT_OK(ipc::test::MakeIntBatchSized(10 + i, &batch, i));
+    out->push_back(batch);
+  }
+  return Status::OK();
+}
+
+Status ExampleFloatBatches(BatchVector* out) {
+  std::shared_ptr<RecordBatch> batch;
+  for (int i = 0; i < 5; ++i) {
+    // Make all different sizes, use different random seed
+    RETURN_NOT_OK(ipc::test::MakeFloatBatchSized(10 + i, &batch, i));
     out->push_back(batch);
   }
   return Status::OK();

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -537,9 +537,8 @@ std::vector<FlightInfo> ExampleFlightInfo() {
   ARROW_EXPECT_OK(MakeFlightInfo(*schema2, descr2, {endpoint3}, 1000, 100000, &flight2));
   ARROW_EXPECT_OK(MakeFlightInfo(*schema3, descr3, {endpoint4}, -1, -1, &flight3));
   ARROW_EXPECT_OK(MakeFlightInfo(*schema4, descr4, {endpoint5}, 1000, 100000, &flight4));
-  return {
-    FlightInfo(flight1), FlightInfo(flight2), FlightInfo(flight3), FlightInfo(flight4)
-  };
+  return {FlightInfo(flight1), FlightInfo(flight2), FlightInfo(flight3),
+          FlightInfo(flight4)};
 }
 
 Status ExampleIntBatches(BatchVector* out) {

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -485,9 +485,10 @@ std::shared_ptr<Schema> ExampleIntSchema() {
 }
 
 std::shared_ptr<Schema> ExampleFloatSchema() {
-  auto f0 = field("f0", float32());
-  auto f1 = field("f1", float64());
-  return ::arrow::schema({f0, f1});
+  auto f0 = field("f0", float16());
+  auto f1 = field("f1", float32());
+  auto f2 = field("f2", float64());
+  return ::arrow::schema({f0, f1, f2});
 }
 
 std::shared_ptr<Schema> ExampleStringSchema() {

--- a/cpp/src/arrow/flight/test_util.h
+++ b/cpp/src/arrow/flight/test_util.h
@@ -144,6 +144,9 @@ ARROW_FLIGHT_EXPORT
 Status ExampleIntBatches(BatchVector* out);
 
 ARROW_FLIGHT_EXPORT
+Status ExampleFloatBatches(BatchVector* out);
+
+ARROW_FLIGHT_EXPORT
 Status ExampleDictBatches(BatchVector* out);
 
 ARROW_FLIGHT_EXPORT

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -213,7 +213,7 @@ TEST_P(TestFeather, PrimitiveIntRoundTrip) {
 
 TEST_P(TestFeather, PrimitiveFloatRoundTrip) {
   std::shared_ptr<RecordBatch> batch;
-  ASSERT_OK(ipc::test::MakeFloatBatch(&batch));
+  ASSERT_OK(ipc::test::MakeFloat3264Batch(&batch));
 
   ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatches({batch}));
 
@@ -315,7 +315,7 @@ TEST_P(TestFeather, SliceIntRoundTrip) {
 
 TEST_P(TestFeather, SliceFloatRoundTrip) {
   std::shared_ptr<RecordBatch> batch;
-  ASSERT_OK(ipc::test::MakeFloatBatchSized(600, &batch));
+  ASSERT_OK(ipc::test::MakeFloat3264BatchSized(600, &batch));
   CheckSlices(batch);
 }
 

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -325,16 +325,30 @@ INSTANTIATE_TEST_SUITE_P(
                       TestParam(kFeatherV2Version, Compression::LZ4_FRAME),
                       TestParam(kFeatherV2Version, Compression::ZSTD)));
 
-#define BATCH_CASES()                                                                    \
-  ::testing::Values(                                                                     \
-      &ipc::test::MakeIntRecordBatch, &ipc::test::MakeBooleanBatch,                      \
-      &ipc::test::MakeFloatBatch, &ipc::test::MakeListRecordBatch,                       \
-      &ipc::test::MakeNonNullRecordBatch, &ipc::test::MakeDeeplyNestedList,              \
-      &ipc::test::MakeStringTypesRecordBatchWithNulls, &ipc::test::MakeStruct,           \
-      &ipc::test::MakeUnion, &ipc::test::MakeDictionary, &ipc::test::MakeDictionaryFlat, \
-      &ipc::test::MakeNestedDictionary, &ipc::test::MakeDates,                           \
-      &ipc::test::MakeTimestamps, &ipc::test::MakeTimes, &ipc::test::MakeFWBinary,       \
-      &ipc::test::MakeNull, &ipc::test::MakeDecimal, &ipc::test::MakeIntervals)
+namespace {
+
+const std::vector<test::MakeRecordBatch*> kBatchCases = {
+    &ipc::test::MakeIntRecordBatch,
+    &ipc::test::MakeBooleanBatch,
+    &ipc::test::MakeFloatBatch,
+    &ipc::test::MakeListRecordBatch,
+    &ipc::test::MakeNonNullRecordBatch,
+    &ipc::test::MakeDeeplyNestedList,
+    &ipc::test::MakeStringTypesRecordBatchWithNulls,
+    &ipc::test::MakeStruct,
+    &ipc::test::MakeUnion,
+    &ipc::test::MakeDictionary,
+    &ipc::test::MakeDictionaryFlat,
+    &ipc::test::MakeNestedDictionary,
+    &ipc::test::MakeDates,
+    &ipc::test::MakeTimestamps,
+    &ipc::test::MakeTimes,
+    &ipc::test::MakeFWBinary,
+    &ipc::test::MakeNull,
+    &ipc::test::MakeDecimal,
+    &ipc::test::MakeIntervals};
+
+}  // namespace
 
 TEST_P(TestFeatherRoundTrip, RoundTrip) {
   std::shared_ptr<RecordBatch> batch;
@@ -343,7 +357,8 @@ TEST_P(TestFeatherRoundTrip, RoundTrip) {
   CheckRoundtrip(batch);
 }
 
-INSTANTIATE_TEST_SUITE_P(FeatherRoundTripTests, TestFeatherRoundTrip, BATCH_CASES());
+INSTANTIATE_TEST_SUITE_P(FeatherRoundTripTests, TestFeatherRoundTrip,
+                         ::testing::ValuesIn(kBatchCases));
 
 }  // namespace feather
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -165,15 +165,15 @@ TEST_P(TestFeather, ReadIndicesOrNames) {
 
   DoWrite(*table);
 
-  auto expected = Table::Make(schema({field("f1", int32())}), {batch1->column(1)});
+  auto expected = Table::Make(schema({field("f4", int32())}), {batch1->column(4)});
 
   std::shared_ptr<Table> result1, result2;
 
-  std::vector<int> indices = {1};
+  std::vector<int> indices = {4};
   ASSERT_OK(reader_->Read(indices, &result1));
   AssertTablesEqual(*expected, *result1);
 
-  std::vector<std::string> names = {"f1"};
+  std::vector<std::string> names = {"f4"};
   ASSERT_OK(reader_->Read(names, &result2));
   AssertTablesEqual(*expected, *result2);
 }
@@ -201,27 +201,13 @@ TEST_P(TestFeather, SetNumRows) {
 TEST_P(TestFeather, PrimitiveIntRoundTrip) {
   std::shared_ptr<RecordBatch> batch;
   ASSERT_OK(ipc::test::MakeIntRecordBatch(&batch));
-
-  ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatches({batch}));
-
-  DoWrite(*table);
-
-  std::shared_ptr<Table> result;
-  ASSERT_OK(reader_->Read(&result));
-  AssertTablesEqual(*table, *result);
+  CheckRoundtrip(batch);
 }
 
 TEST_P(TestFeather, PrimitiveFloatRoundTrip) {
   std::shared_ptr<RecordBatch> batch;
   ASSERT_OK(ipc::test::MakeFloat3264Batch(&batch));
-
-  ASSERT_OK_AND_ASSIGN(auto table, Table::FromRecordBatches({batch}));
-
-  DoWrite(*table);
-
-  std::shared_ptr<Table> result;
-  ASSERT_OK(reader_->Read(&result));
-  AssertTablesEqual(*table, *result);
+  CheckRoundtrip(batch);
 }
 
 TEST_P(TestFeather, CategoryRoundtrip) {
@@ -315,6 +301,7 @@ TEST_P(TestFeather, SliceIntRoundTrip) {
 
 TEST_P(TestFeather, SliceFloatRoundTrip) {
   std::shared_ptr<RecordBatch> batch;
+  // Float16 is not supported by FeatherV1
   ASSERT_OK(ipc::test::MakeFloat3264BatchSized(600, &batch));
   CheckSlices(batch);
 }

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -110,8 +110,7 @@ class TestFeatherBase {
   std::shared_ptr<Buffer> output_;
 };
 
-class TestFeather : public ::testing::TestWithParam<TestParam>,
-                    public TestFeatherBase {
+class TestFeather : public ::testing::TestWithParam<TestParam>, public TestFeatherBase {
  public:
   void SetUp() { TestFeatherBase::SetUp(); }
 

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -165,6 +165,7 @@ TEST_P(TestFeather, ReadIndicesOrNames) {
 
   DoWrite(*table);
 
+  // int32 type is at the column f4 of the result of MakeIntRecordBatch
   auto expected = Table::Make(schema({field("f4", int32())}), {batch1->column(4)});
 
   std::shared_ptr<Table> result1, result2;

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -294,14 +294,28 @@ TEST_F(TestSchemaMetadata, KeyValueMetadata) {
   CheckRoundtrip(schema);
 }
 
-#define BATCH_CASES()                                                                    \
-  ::testing::Values(&MakeIntRecordBatch, &MakeListRecordBatch, &MakeNonNullRecordBatch,  \
-                    &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList,                   \
-                    &MakeStringTypesRecordBatchWithNulls, &MakeStruct, &MakeUnion,       \
-                    &MakeDictionary, &MakeNestedDictionary, &MakeDates, &MakeTimestamps, \
-                    &MakeTimes, &MakeFWBinary, &MakeNull, &MakeDecimal,                  \
-                    &MakeBooleanBatch, &MakeFloatBatch, &MakeIntervals, &MakeUuid,       \
-                    &MakeDictExtension)
+const std::vector<test::MakeRecordBatch*> kBatchCases = {
+    &MakeIntRecordBatch,
+    &MakeListRecordBatch,
+    &MakeNonNullRecordBatch,
+    &MakeZeroLengthRecordBatch,
+    &MakeDeeplyNestedList,
+    &MakeStringTypesRecordBatchWithNulls,
+    &MakeStruct,
+    &MakeUnion,
+    &MakeDictionary,
+    &MakeNestedDictionary,
+    &MakeDates,
+    &MakeTimestamps,
+    &MakeTimes,
+    &MakeFWBinary,
+    &MakeNull,
+    &MakeDecimal,
+    &MakeBooleanBatch,
+    &MakeFloatBatch,
+    &MakeIntervals,
+    &MakeUuid,
+    &MakeDictExtension};
 
 static int g_file_number = 0;
 
@@ -1431,17 +1445,20 @@ TEST_P(TestStreamDecoderLargeChunks, RoundTrip) {
   TestZeroLengthRoundTrip(*GetParam(), options);
 }
 
-INSTANTIATE_TEST_SUITE_P(GenericIpcRoundTripTests, TestIpcRoundTrip, BATCH_CASES());
-INSTANTIATE_TEST_SUITE_P(FileRoundTripTests, TestFileFormat, BATCH_CASES());
-INSTANTIATE_TEST_SUITE_P(StreamRoundTripTests, TestStreamFormat, BATCH_CASES());
+INSTANTIATE_TEST_SUITE_P(GenericIpcRoundTripTests, TestIpcRoundTrip,
+                         ::testing::ValuesIn(kBatchCases));
+INSTANTIATE_TEST_SUITE_P(FileRoundTripTests, TestFileFormat,
+                         ::testing::ValuesIn(kBatchCases));
+INSTANTIATE_TEST_SUITE_P(StreamRoundTripTests, TestStreamFormat,
+                         ::testing::ValuesIn(kBatchCases));
 INSTANTIATE_TEST_SUITE_P(StreamDecoderDataRoundTripTests, TestStreamDecoderData,
-                         BATCH_CASES());
+                         ::testing::ValuesIn(kBatchCases));
 INSTANTIATE_TEST_SUITE_P(StreamDecoderBufferRoundTripTests, TestStreamDecoderBuffer,
-                         BATCH_CASES());
+                         ::testing::ValuesIn(kBatchCases));
 INSTANTIATE_TEST_SUITE_P(StreamDecoderSmallChunksRoundTripTests,
-                         TestStreamDecoderSmallChunks, BATCH_CASES());
+                         TestStreamDecoderSmallChunks, ::testing::ValuesIn(kBatchCases));
 INSTANTIATE_TEST_SUITE_P(StreamDecoderLargeChunksRoundTripTests,
-                         TestStreamDecoderLargeChunks, BATCH_CASES());
+                         TestStreamDecoderLargeChunks, ::testing::ValuesIn(kBatchCases));
 
 TEST(TestIpcFileFormat, FooterMetaData) {
   // ARROW-6837

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -300,7 +300,8 @@ TEST_F(TestSchemaMetadata, KeyValueMetadata) {
                     &MakeStringTypesRecordBatchWithNulls, &MakeStruct, &MakeUnion,       \
                     &MakeDictionary, &MakeNestedDictionary, &MakeDates, &MakeTimestamps, \
                     &MakeTimes, &MakeFWBinary, &MakeNull, &MakeDecimal,                  \
-                    &MakeBooleanBatch, &MakeIntervals, &MakeUuid, &MakeDictExtension)
+                    &MakeBooleanBatch, &MakeFloatBatch, &MakeIntervals, &MakeUuid,       \
+                    &MakeDictExtension)
 
 static int g_file_number = 0;
 

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -90,6 +90,28 @@ static Status MakeRandomArray(int64_t length, bool include_nulls, MemoryPool* po
   return Status::OK();
 }
 
+template <>
+Status MakeRandomArray<Int8Type>(int64_t length, bool include_nulls, MemoryPool* pool,
+                                 std::shared_ptr<Array>* out, uint32_t seed) {
+  random::RandomArrayGenerator rand(seed);
+  const double null_probability = include_nulls ? 0.5 : 0.0;
+
+  *out = rand.Numeric<Int8Type>(length, 0, 127, null_probability);
+
+  return Status::OK();
+}
+
+template <>
+Status MakeRandomArray<UInt8Type>(int64_t length, bool include_nulls, MemoryPool* pool,
+                                  std::shared_ptr<Array>* out, uint32_t seed) {
+  random::RandomArrayGenerator rand(seed);
+  const double null_probability = include_nulls ? 0.5 : 0.0;
+
+  *out = rand.Numeric<UInt8Type>(length, 0, 127, null_probability);
+
+  return Status::OK();
+}
+
 template <typename TypeClass>
 static Status MakeListArray(const std::shared_ptr<Array>& child_array, int num_lists,
                             bool include_nulls, MemoryPool* pool,

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -79,6 +79,17 @@ Status MakeRandomInt32Array(int64_t length, bool include_nulls, MemoryPool* pool
   return Status::OK();
 }
 
+template <typename ArrayType>
+static Status MakeRandomArray(int64_t length, bool include_nulls, MemoryPool* pool,
+                              std::shared_ptr<Array>* out, uint32_t seed) {
+  random::RandomArrayGenerator rand(seed);
+  const double null_probability = include_nulls ? 0.5 : 0.0;
+
+  *out = rand.Numeric<ArrayType>(length, 0, 1000, null_probability);
+
+  return Status::OK();
+}
+
 template <typename TypeClass>
 static Status MakeListArray(const std::shared_ptr<Array>& child_array, int num_lists,
                             bool include_nulls, MemoryPool* pool,
@@ -194,21 +205,52 @@ Status MakeBooleanBatch(std::shared_ptr<RecordBatch>* out) {
 
 Status MakeIntBatchSized(int length, std::shared_ptr<RecordBatch>* out, uint32_t seed) {
   // Make the schema
-  auto f0 = field("f0", int32());
-  auto f1 = field("f1", int32());
-  auto schema = ::arrow::schema({f0, f1});
+  auto f0 = field("f0", int8());
+  auto f1 = field("f1", uint8());
+  auto f2 = field("f2", int16());
+  auto f3 = field("f3", uint16());
+  auto f4 = field("f4", int32());
+  auto f5 = field("f5", uint32());
+  auto f6 = field("f6", int64());
+  auto f7 = field("f7", uint64());
+  auto schema = ::arrow::schema({f0, f1, f2, f3, f4, f5, f6, f7});
 
   // Example data
-  std::shared_ptr<Array> a0, a1;
+  std::shared_ptr<Array> a0, a1, a2, a3, a4, a5, a6, a7;
   MemoryPool* pool = default_memory_pool();
-  RETURN_NOT_OK(MakeRandomInt32Array(length, false, pool, &a0, seed));
-  RETURN_NOT_OK(MakeRandomInt32Array(length, true, pool, &a1, seed + 1));
-  *out = RecordBatch::Make(schema, length, {a0, a1});
+  RETURN_NOT_OK(MakeRandomArray<Int8Type>(length, false, pool, &a0, seed));
+  RETURN_NOT_OK(MakeRandomArray<UInt8Type>(length, false, pool, &a1, seed));
+  RETURN_NOT_OK(MakeRandomArray<Int16Type>(length, false, pool, &a2, seed));
+  RETURN_NOT_OK(MakeRandomArray<UInt16Type>(length, false, pool, &a3, seed));
+  RETURN_NOT_OK(MakeRandomArray<Int32Type>(length, false, pool, &a4, seed));
+  RETURN_NOT_OK(MakeRandomArray<UInt32Type>(length, false, pool, &a5, seed));
+  RETURN_NOT_OK(MakeRandomArray<Int64Type>(length, false, pool, &a6, seed));
+  RETURN_NOT_OK(MakeRandomArray<UInt64Type>(length, false, pool, &a7, seed));
+  *out = RecordBatch::Make(schema, length, {a0, a1, a2, a3, a4, a5, a6, a7});
   return Status::OK();
 }
 
 Status MakeIntRecordBatch(std::shared_ptr<RecordBatch>* out) {
   return MakeIntBatchSized(10, out);
+}
+
+Status MakeFloatBatchSized(int length, std::shared_ptr<RecordBatch>* out, uint32_t seed) {
+  // Make the schema
+  auto f0 = field("f0", float32());
+  auto f1 = field("f1", float64());
+  auto schema = ::arrow::schema({f0, f1});
+
+  // Example data
+  std::shared_ptr<Array> a0, a1;
+  MemoryPool* pool = default_memory_pool();
+  RETURN_NOT_OK(MakeRandomArray<FloatType>(length, false, pool, &a0, seed));
+  RETURN_NOT_OK(MakeRandomArray<DoubleType>(length, true, pool, &a1, seed + 1));
+  *out = RecordBatch::Make(schema, length, {a0, a1});
+  return Status::OK();
+}
+
+Status MakeFloatBatch(std::shared_ptr<RecordBatch>* out) {
+  return MakeFloatBatchSized(10, out);
 }
 
 Status MakeRandomStringArray(int64_t length, bool include_nulls, MemoryPool* pool,

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -79,6 +79,8 @@ Status MakeRandomInt32Array(int64_t length, bool include_nulls, MemoryPool* pool
   return Status::OK();
 }
 
+namespace {
+
 template <typename ArrayType>
 Status MakeRandomArray(int64_t length, bool include_nulls, MemoryPool* pool,
                        std::shared_ptr<Array>* out, uint32_t seed) {
@@ -113,9 +115,8 @@ Status MakeRandomArray<UInt8Type>(int64_t length, bool include_nulls, MemoryPool
 }
 
 template <typename TypeClass>
-static Status MakeListArray(const std::shared_ptr<Array>& child_array, int num_lists,
-                            bool include_nulls, MemoryPool* pool,
-                            std::shared_ptr<Array>* out) {
+Status MakeListArray(const std::shared_ptr<Array>& child_array, int num_lists,
+                     bool include_nulls, MemoryPool* pool, std::shared_ptr<Array>* out) {
   using offset_type = typename TypeClass::offset_type;
   using ArrayType = typename TypeTraits<TypeClass>::ArrayType;
 
@@ -161,6 +162,8 @@ static Status MakeListArray(const std::shared_ptr<Array>& child_array, int num_l
                                      kUnknownNullCount);
   return (**out).Validate();
 }
+
+}  // namespace
 
 Status MakeRandomListArray(const std::shared_ptr<Array>& child_array, int num_lists,
                            bool include_nulls, MemoryPool* pool,

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -80,8 +80,8 @@ Status MakeRandomInt32Array(int64_t length, bool include_nulls, MemoryPool* pool
 }
 
 template <typename ArrayType>
-static Status MakeRandomArray(int64_t length, bool include_nulls, MemoryPool* pool,
-                              std::shared_ptr<Array>* out, uint32_t seed) {
+Status MakeRandomArray(int64_t length, bool include_nulls, MemoryPool* pool,
+                       std::shared_ptr<Array>* out, uint32_t seed) {
   random::RandomArrayGenerator rand(seed);
   const double null_probability = include_nulls ? 0.5 : 0.0;
 

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -219,12 +219,12 @@ Status MakeIntBatchSized(int length, std::shared_ptr<RecordBatch>* out, uint32_t
   std::shared_ptr<Array> a0, a1, a2, a3, a4, a5, a6, a7;
   MemoryPool* pool = default_memory_pool();
   RETURN_NOT_OK(MakeRandomArray<Int8Type>(length, false, pool, &a0, seed));
-  RETURN_NOT_OK(MakeRandomArray<UInt8Type>(length, false, pool, &a1, seed));
-  RETURN_NOT_OK(MakeRandomArray<Int16Type>(length, false, pool, &a2, seed));
+  RETURN_NOT_OK(MakeRandomArray<UInt8Type>(length, true, pool, &a1, seed));
+  RETURN_NOT_OK(MakeRandomArray<Int16Type>(length, true, pool, &a2, seed));
   RETURN_NOT_OK(MakeRandomArray<UInt16Type>(length, false, pool, &a3, seed));
   RETURN_NOT_OK(MakeRandomArray<Int32Type>(length, false, pool, &a4, seed));
-  RETURN_NOT_OK(MakeRandomArray<UInt32Type>(length, false, pool, &a5, seed));
-  RETURN_NOT_OK(MakeRandomArray<Int64Type>(length, false, pool, &a6, seed));
+  RETURN_NOT_OK(MakeRandomArray<UInt32Type>(length, true, pool, &a5, seed));
+  RETURN_NOT_OK(MakeRandomArray<Int64Type>(length, true, pool, &a6, seed));
   RETURN_NOT_OK(MakeRandomArray<UInt64Type>(length, false, pool, &a7, seed));
   *out = RecordBatch::Make(schema, length, {a0, a1, a2, a3, a4, a5, a6, a7});
   return Status::OK();
@@ -234,7 +234,8 @@ Status MakeIntRecordBatch(std::shared_ptr<RecordBatch>* out) {
   return MakeIntBatchSized(10, out);
 }
 
-Status MakeFloatBatchSized(int length, std::shared_ptr<RecordBatch>* out, uint32_t seed) {
+Status MakeFloat3264BatchSized(int length, std::shared_ptr<RecordBatch>* out,
+                               uint32_t seed) {
   // Make the schema
   auto f0 = field("f0", float32());
   auto f1 = field("f1", float64());
@@ -246,6 +247,27 @@ Status MakeFloatBatchSized(int length, std::shared_ptr<RecordBatch>* out, uint32
   RETURN_NOT_OK(MakeRandomArray<FloatType>(length, false, pool, &a0, seed));
   RETURN_NOT_OK(MakeRandomArray<DoubleType>(length, true, pool, &a1, seed + 1));
   *out = RecordBatch::Make(schema, length, {a0, a1});
+  return Status::OK();
+}
+
+Status MakeFloat3264Batch(std::shared_ptr<RecordBatch>* out) {
+  return MakeFloat3264BatchSized(10, out);
+}
+
+Status MakeFloatBatchSized(int length, std::shared_ptr<RecordBatch>* out, uint32_t seed) {
+  // Make the schema
+  auto f0 = field("f0", float16());
+  auto f1 = field("f1", float32());
+  auto f2 = field("f2", float64());
+  auto schema = ::arrow::schema({f0, f1, f2});
+
+  // Example data
+  std::shared_ptr<Array> a0, a1, a2;
+  MemoryPool* pool = default_memory_pool();
+  RETURN_NOT_OK(MakeRandomArray<HalfFloatType>(length, false, pool, &a0, seed));
+  RETURN_NOT_OK(MakeRandomArray<FloatType>(length, false, pool, &a1, seed + 1));
+  RETURN_NOT_OK(MakeRandomArray<DoubleType>(length, true, pool, &a2, seed + 2));
+  *out = RecordBatch::Make(schema, length, {a0, a1, a2});
   return Status::OK();
 }
 

--- a/cpp/src/arrow/ipc/test_common.h
+++ b/cpp/src/arrow/ipc/test_common.h
@@ -76,6 +76,13 @@ ARROW_TESTING_EXPORT
 Status MakeIntRecordBatch(std::shared_ptr<RecordBatch>* out);
 
 ARROW_TESTING_EXPORT
+Status MakeFloatBatchSized(int length, std::shared_ptr<RecordBatch>* out,
+                           uint32_t seed = 0);
+
+ARROW_TESTING_EXPORT
+Status MakeFloatBatch(std::shared_ptr<RecordBatch>* out);
+
+ARROW_TESTING_EXPORT
 Status MakeRandomStringArray(int64_t length, bool include_nulls, MemoryPool* pool,
                              std::shared_ptr<Array>* out);
 

--- a/cpp/src/arrow/ipc/test_common.h
+++ b/cpp/src/arrow/ipc/test_common.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <cstdint>
-#include <functional>
 #include <memory>
 
 #include "arrow/array.h"

--- a/cpp/src/arrow/ipc/test_common.h
+++ b/cpp/src/arrow/ipc/test_common.h
@@ -76,6 +76,13 @@ ARROW_TESTING_EXPORT
 Status MakeIntRecordBatch(std::shared_ptr<RecordBatch>* out);
 
 ARROW_TESTING_EXPORT
+Status MakeFloat3264BatchSized(int length, std::shared_ptr<RecordBatch>* out,
+                               uint32_t seed = 0);
+
+ARROW_TESTING_EXPORT
+Status MakeFloat3264Batch(std::shared_ptr<RecordBatch>* out);
+
+ARROW_TESTING_EXPORT
 Status MakeFloatBatchSized(int length, std::shared_ptr<RecordBatch>* out,
                            uint32_t seed = 0);
 

--- a/cpp/src/arrow/ipc/test_common.h
+++ b/cpp/src/arrow/ipc/test_common.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 
 #include "arrow/array.h"

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -67,6 +67,19 @@ void AssertTsEqual(const T& expected, const T& actual, ExtraArgs... args) {
   }
 }
 
+template <typename T>
+void AssertTsApproxEqual(const T& expected, const T& actual) {
+  if (!expected.ApproxEquals(actual)) {
+    std::stringstream pp_expected;
+    std::stringstream pp_actual;
+    ::arrow::PrettyPrintOptions options(/*indent=*/2);
+    options.window = 50;
+    ARROW_EXPECT_OK(PrettyPrint(expected, options, &pp_expected));
+    ARROW_EXPECT_OK(PrettyPrint(actual, options, &pp_actual));
+    FAIL() << "Got: \n" << pp_actual.str() << "\nExpected: \n" << pp_expected.str();
+  }
+}
+
 void AssertArraysEqual(const Array& expected, const Array& actual, bool verbose) {
   std::stringstream diff;
   if (!expected.Equals(actual, EqualOptions().diff_sink(&diff))) {
@@ -116,6 +129,10 @@ void AssertScalarsEqual(const Scalar& expected, const Scalar& actual, bool verbo
 void AssertBatchesEqual(const RecordBatch& expected, const RecordBatch& actual,
                         bool check_metadata) {
   AssertTsEqual(expected, actual, check_metadata);
+}
+
+void AssertBatchesApproxEqual(const RecordBatch& expected, const RecordBatch& actual) {
+  AssertTsApproxEqual(expected, actual);
 }
 
 void AssertChunkedEqual(const ChunkedArray& expected, const ChunkedArray& actual) {

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -233,8 +233,9 @@ void AssertNumericDataEqual(const C_TYPE* raw_data,
 ARROW_TESTING_EXPORT void CompareBatch(const RecordBatch& left, const RecordBatch& right,
                                        bool compare_metadata = true);
 
-ARROW_EXPORT void ApproxCompareBatch(const RecordBatch& left, const RecordBatch& right,
-                                     bool compare_metadata = true);
+ARROW_TESTING_EXPORT void ApproxCompareBatch(const RecordBatch& left,
+                                             const RecordBatch& right,
+                                             bool compare_metadata = true);
 
 // Check if the padding of the buffers of the array is zero.
 // Also cause valgrind warnings if the padding bytes are uninitialized.

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -155,6 +155,7 @@ struct Datum;
 
 #define ASSERT_ARRAYS_EQUAL(lhs, rhs) AssertArraysEqual((lhs), (rhs))
 #define ASSERT_BATCHES_EQUAL(lhs, rhs) AssertBatchesEqual((lhs), (rhs))
+#define ASSERT_BATCHES_APPROX_EQUAL(lhs, rhs) AssertBatchesApproxEqual((lhs), (rhs))
 #define ASSERT_TABLES_EQUAL(lhs, rhs) AssertTablesEqual((lhs), (rhs))
 
 // If verbose is true, then the arrays will be pretty printed
@@ -169,6 +170,8 @@ ARROW_TESTING_EXPORT void AssertScalarsEqual(const Scalar& expected, const Scala
 ARROW_TESTING_EXPORT void AssertBatchesEqual(const RecordBatch& expected,
                                              const RecordBatch& actual,
                                              bool check_metadata = false);
+ARROW_TESTING_EXPORT void AssertBatchesApproxEqual(const RecordBatch& expected,
+                                                   const RecordBatch& actual);
 ARROW_TESTING_EXPORT void AssertChunkedEqual(const ChunkedArray& expected,
                                              const ChunkedArray& actual);
 ARROW_TESTING_EXPORT void AssertChunkedEqual(const ChunkedArray& actual,

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -233,6 +233,9 @@ void AssertNumericDataEqual(const C_TYPE* raw_data,
 ARROW_TESTING_EXPORT void CompareBatch(const RecordBatch& left, const RecordBatch& right,
                                        bool compare_metadata = true);
 
+ARROW_EXPORT void ApproxCompareBatch(const RecordBatch& left, const RecordBatch& right,
+                                     bool compare_metadata = true);
+
 // Check if the padding of the buffers of the array is zero.
 // Also cause valgrind warnings if the padding bytes are uninitialized.
 ARROW_TESTING_EXPORT void AssertZeroPadded(const Array& array);

--- a/cpp/src/arrow/testing/json_integration_test.cc
+++ b/cpp/src/arrow/testing/json_integration_test.cc
@@ -1050,7 +1050,8 @@ void CheckRoundtrip(const RecordBatch& batch) {
   std::shared_ptr<RecordBatch> result_batch;
   ASSERT_OK(reader->ReadRecordBatch(0, &result_batch));
 
-  CompareBatch(batch, *result_batch);
+  // take care of float rounding error in the text representation
+  ApproxCompareBatch(batch, *result_batch);
 }
 
 TEST_P(TestJsonRoundTrip, RoundTrip) {

--- a/cpp/src/arrow/testing/json_integration_test.cc
+++ b/cpp/src/arrow/testing/json_integration_test.cc
@@ -1019,8 +1019,9 @@ TEST(TestJsonFileReadWrite, JsonExample4) {
       &MakeIntRecordBatch, &MakeListRecordBatch, &MakeFixedSizeListRecordBatch,   \
       &MakeNonNullRecordBatch, &MakeZeroLengthRecordBatch, &MakeDeeplyNestedList, \
       &MakeStringTypesRecordBatchWithNulls, &MakeStruct, &MakeUnion, &MakeDates,  \
-      &MakeTimestamps, &MakeTimes, &MakeFWBinary, &MakeDecimal, &MakeDictionary,  \
-      &MakeNestedDictionary, &MakeIntervals, &MakeUuid, &MakeDictExtension)
+      &MakeTimestamps, &MakeTimes, &MakeFWBinary, &MakeDecimal, &MakeFloatBatch,  \
+      &MakeDictionary, &MakeNestedDictionary, &MakeIntervals, &MakeUuid,          \
+      &MakeDictExtension)
 
 class TestJsonRoundTrip : public ::testing::TestWithParam<MakeRecordBatch*> {
  public:

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -144,11 +144,12 @@ PRIMITIVE_RAND_INTEGER_IMPL(UInt32, uint32_t, UInt32Type)
 PRIMITIVE_RAND_INTEGER_IMPL(Int32, int32_t, Int32Type)
 PRIMITIVE_RAND_INTEGER_IMPL(UInt64, uint64_t, UInt64Type)
 PRIMITIVE_RAND_INTEGER_IMPL(Int64, int64_t, Int64Type)
+// Generate 16bit values for half-float
+PRIMITIVE_RAND_INTEGER_IMPL(Float16, int16_t, HalfFloatType)
 
 #define PRIMITIVE_RAND_FLOAT_IMPL(Name, CType, ArrowType) \
   PRIMITIVE_RAND_IMPL(Name, CType, ArrowType, std::uniform_real_distribution<CType>)
 
-PRIMITIVE_RAND_FLOAT_IMPL(Float16, float, HalfFloatType)
 PRIMITIVE_RAND_FLOAT_IMPL(Float32, float, FloatType)
 PRIMITIVE_RAND_FLOAT_IMPL(Float64, double, DoubleType)
 

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -148,6 +148,7 @@ PRIMITIVE_RAND_INTEGER_IMPL(Int64, int64_t, Int64Type)
 #define PRIMITIVE_RAND_FLOAT_IMPL(Name, CType, ArrowType) \
   PRIMITIVE_RAND_IMPL(Name, CType, ArrowType, std::uniform_real_distribution<CType>)
 
+PRIMITIVE_RAND_FLOAT_IMPL(Float16, float, HalfFloatType)
 PRIMITIVE_RAND_FLOAT_IMPL(Float32, float, FloatType)
 PRIMITIVE_RAND_FLOAT_IMPL(Float64, double, DoubleType)
 

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -148,7 +148,7 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array
-  std::shared_ptr<Array> Float16(int64_t size, float min, float max,
+  std::shared_ptr<Array> Float16(int64_t size, int16_t min, int16_t max,
                                  double null_probability = 0);
 
   /// \brief Generates a random FloatArray
@@ -202,7 +202,7 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
         return Int64(size, static_cast<int64_t>(min), static_cast<int64_t>(max),
                      null_probability);
       case Type::HALF_FLOAT:
-        return Float16(size, static_cast<float>(min), static_cast<float>(max),
+        return Float16(size, static_cast<int16_t>(min), static_cast<int16_t>(max),
                        null_probability);
       case Type::FLOAT:
         return Float32(size, static_cast<float>(min), static_cast<float>(max),

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -143,8 +143,8 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \brief Generates a random HalfFloatArray
   ///
   /// \param[in] size the size of the array to generate
-  /// \param[in] min the lower bound of the uniform distribution
-  /// \param[in] max the upper bound of the uniform distribution
+  /// \param[in] min the lower bound of the distribution
+  /// \param[in] max the upper bound of the distribution
   /// \param[in] null_probability the probability of a row being null
   ///
   /// \return a generated Array

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -140,6 +140,17 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   std::shared_ptr<Array> Int64(int64_t size, int64_t min, int64_t max,
                                double null_probability = 0);
 
+  /// \brief Generates a random HalfFloatArray
+  ///
+  /// \param[in] size the size of the array to generate
+  /// \param[in] min the lower bound of the uniform distribution
+  /// \param[in] max the upper bound of the uniform distribution
+  /// \param[in] null_probability the probability of a row being null
+  ///
+  /// \return a generated Array
+  std::shared_ptr<Array> Float16(int64_t size, float min, float max,
+                                 double null_probability = 0);
+
   /// \brief Generates a random FloatArray
   ///
   /// \param[in] size the size of the array to generate
@@ -190,6 +201,9 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
       case Type::INT64:
         return Int64(size, static_cast<int64_t>(min), static_cast<int64_t>(max),
                      null_probability);
+      case Type::HALF_FLOAT:
+        return Float16(size, static_cast<float>(min), static_cast<float>(max),
+                       null_probability);
       case Type::FLOAT:
         return Float32(size, static_cast<float>(min), static_cast<float>(max),
                        null_probability);


### PR DESCRIPTION
This PR increase test coverage of round-robin under ipc and flight. Before this PR, round-robin tests for primitive data under ipc use only int32 (and boolean in some cases). This PR adds other primitive types (i.e. int8, uint8, int16, uint16, uint32, int64, uint64, float16, float32, and float64).