### PR TITLE
ARROW-9258: [FORMAT] Add V5 MetadataVersion to Schema.fbs

### DIFF
--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -20,17 +20,24 @@
 namespace org.apache.arrow.flatbuf;
 
 enum MetadataVersion:short {
-  /// 0.1.0
+  /// 0.1.0 (October 2016).
   V1,
 
-  /// 0.2.0
+  /// 0.2.0 (February 2017). Non-backwards compatible with V1.
   V2,
 
-  /// 0.3.0 -> 0.7.1
+  /// 0.3.0 -> 0.7.1 (May - December 2017). Non-backwards compatible with V2.
   V3,
 
-  /// >= 0.8.0
+  /// >= 0.8.0 (December 2017). Non-backwards compatible with V3.
   V4,
+
+  /// >= 1.0.0 (July 2020. Backwards compatible with V4 (V5 readers can read V4
+  /// metadata and IPC messages). Implementations are recommended to provide a
+  /// V4 compatibility mode with V5 format changes disabled.
+  ///
+  /// TODO: Add list of non-forward compatible changes.
+  V5,
 }
 
 /// These are stored in the flatbuffer in the Type union below


### PR DESCRIPTION
Version V4 is backwards compatible (with compatibility code for reading unions), but V5 is primarily about guaranteeing that the forward compatibility additions have the intended effect. Additionally the IPC serialization format for unions has changed between V4 and V5. 