### PR TITLE
ARROW-9241: [C++] Add forward compatibility check for Decimal bit width

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -221,6 +221,8 @@ static inline TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit) {
   return TimeUnit::SECOND;
 }
 
+constexpr int32_t kDecimalBitWidth = 128;
+
 Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
                                   const std::vector<std::shared_ptr<Field>>& children,
                                   std::shared_ptr<DataType>* out) {
@@ -257,6 +259,9 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
       return Status::OK();
     case flatbuf::Type::Decimal: {
       auto dec_type = static_cast<const flatbuf::Decimal*>(type_data);
+      if (dec_type->bitWidth() != kDecimalBitWidth) {
+        return Status::Invalid("Library only supports 128-bit decimal values");
+      }
       return Decimal128Type::Make(dec_type->precision(), dec_type->scale()).Value(out);
     }
     case flatbuf::Type::Date: {


### PR DESCRIPTION
Also updates the generated Flatbuffers bindings. 