### PR TITLE
ARROW-9262: [Packaging][Linux][CI] Use Ubuntu 18.04 to build ARM64 packages on Travis CI

### DIFF
--- a/dev/tasks/linux-packages/travis.linux.arm64.yml
+++ b/dev/tasks/linux-packages/travis.linux.arm64.yml
@@ -17,7 +17,7 @@
 
 os: linux
 arch: arm64
-dist: focal
+dist: bionic
 language: minimal
 
 addons:
@@ -69,7 +69,7 @@ after_success:
       github3.py \
       jinja2 \
       jira \
-      pygit2==0.28.2 \
+      pygit2==0.26.4 \
       ruamel.yaml \
       setuptools_scm \
       toolz


### PR DESCRIPTION
We got the following error with Ubuntu 20.04:

    gpg: Fatal: can't disable core dumps: Operation not permitted