### PR TITLE
ARROW-9263: [C++] Promote compute aggregate benchmark size to 1M.

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
@@ -315,9 +315,13 @@ static void SumKernel(benchmark::State& state) {
   }
 }
 
+static void SumKernelArgs(benchmark::internal::Benchmark* bench) {
+  BenchmarkSetArgsWithSizes(bench, {1 * 1024 * 1024});  // 1M
+}
+
 #define SUM_KERNEL_BENCHMARK(FuncName, Type)                                \
   static void FuncName(benchmark::State& state) { SumKernel<Type>(state); } \
-  BENCHMARK(FuncName)->Apply(RegressionSetArgs)
+  BENCHMARK(FuncName)->Apply(SumKernelArgs)
 
 SUM_KERNEL_BENCHMARK(SumKernelFloat, FloatType);
 SUM_KERNEL_BENCHMARK(SumKernelDouble, DoubleType);

--- a/cpp/src/arrow/util/benchmark_util.h
+++ b/cpp/src/arrow/util/benchmark_util.h
@@ -98,7 +98,7 @@ void BenchmarkSetArgs(benchmark::internal::Benchmark* bench) {
 void RegressionSetArgs(benchmark::internal::Benchmark* bench) {
   // Regression do not need to account for cache hierarchy, thus optimize for
   // the best case.
-  BenchmarkSetArgsWithSizes(bench, {kL2Size});
+  BenchmarkSetArgsWithSizes(bench, {kL1Size});
 }
 
 // RAII struct to handle some of the boilerplate in regression benchmarks

--- a/cpp/src/arrow/util/benchmark_util.h
+++ b/cpp/src/arrow/util/benchmark_util.h
@@ -98,7 +98,7 @@ void BenchmarkSetArgs(benchmark::internal::Benchmark* bench) {
 void RegressionSetArgs(benchmark::internal::Benchmark* bench) {
   // Regression do not need to account for cache hierarchy, thus optimize for
   // the best case.
-  BenchmarkSetArgsWithSizes(bench, {kL1Size});
+  BenchmarkSetArgsWithSizes(bench, {kL2Size});
 }
 
 // RAII struct to handle some of the boilerplate in regression benchmarks


### PR DESCRIPTION
The 0.01% null probability on L1(32K) size generate all true values for double/float type, set size to 1M.

Signed-off-by: Frank Du <frank.du@intel.com>