### PR TITLE
ARROW-8980: [Python] Ensure that ARROW:schema metadata key is scrubbed when converting Parquet schema back to Arrow schema

### DIFF
--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -666,7 +666,6 @@ Status SchemaManifest::Make(const SchemaDescriptor* schema,
                             const std::shared_ptr<const KeyValueMetadata>& metadata,
                             const ArrowReaderProperties& properties,
                             SchemaManifest* manifest) {
-  std::shared_ptr<::arrow::Schema> origin_schema;
   RETURN_NOT_OK(
       GetOriginSchema(metadata, &manifest->schema_metadata, &manifest->origin_schema));
 

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -420,7 +420,13 @@ Status FromParquetSchema(
     const auto& schema_field = manifest.schema_fields[i];
     fields[i] = schema_field.field;
   }
-  *out = ::arrow::schema(fields, key_value_metadata);
+  if (manifest.origin_schema) {
+    // ARROW-8980: If the ARROW:schema was in the input metadata, then
+    // manifest.origin_schema will have it scrubbed out
+    *out = ::arrow::schema(fields, manifest.origin_schema->metadata());
+  } else {
+    *out = ::arrow::schema(fields, key_value_metadata);
+  }
   return Status::OK();
 }
 

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -499,8 +499,6 @@ test_that("Dataset and query print methods", {
       "ts: timestamp[us, tz=UTC]",
       "group: int32",
       "other: string",
-      "",
-      "See $metadata for additional Schema metadata",
       sep = "\n"
     ),
     fixed = TRUE


### PR DESCRIPTION
This was already being worked around in some unit tests... 

Also resolves ARROW-9009