### PR TITLE
ARROW-8190: [FlightRPC][C++] Expose IPC options

### DIFF
--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -26,6 +26,7 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/ipc/options.h"
 #include "arrow/ipc/reader.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/status.h"
@@ -36,7 +37,6 @@
 
 namespace arrow {
 
-class MemoryPool;
 class RecordBatch;
 class Schema;
 
@@ -59,6 +59,12 @@ class ARROW_FLIGHT_EXPORT FlightCallOptions {
   /// mean an implementation-defined default behavior will be used
   /// instead. This is the default value.
   TimeoutDuration timeout;
+
+  /// \brief IPC reader options, if applicable for the call.
+  ipc::IpcReadOptions read_options;
+
+  /// \brief IPC writer options, if applicable for the call.
+  ipc::IpcWriteOptions write_options;
 };
 
 /// \brief Indicate that the client attempted to write a message

--- a/cpp/src/arrow/flight/server.h
+++ b/cpp/src/arrow/flight/server.h
@@ -30,12 +30,11 @@
 #include "arrow/flight/types.h"       // IWYU pragma: keep
 #include "arrow/flight/visibility.h"  // IWYU pragma: keep
 #include "arrow/ipc/dictionary.h"
-#include "arrow/memory_pool.h"
+#include "arrow/ipc/options.h"
 #include "arrow/record_batch.h"
 
 namespace arrow {
 
-class MemoryPool;
 class Schema;
 class Status;
 
@@ -65,9 +64,10 @@ class ARROW_FLIGHT_EXPORT FlightDataStream {
 class ARROW_FLIGHT_EXPORT RecordBatchStream : public FlightDataStream {
  public:
   /// \param[in] reader produces a sequence of record batches
-  /// \param[in,out] pool a MemoryPool to use for allocations
-  explicit RecordBatchStream(const std::shared_ptr<RecordBatchReader>& reader,
-                             MemoryPool* pool = default_memory_pool());
+  /// \param[in] options IPC options for writing
+  explicit RecordBatchStream(
+      const std::shared_ptr<RecordBatchReader>& reader,
+      const ipc::IpcWriteOptions& options = ipc::IpcWriteOptions::Defaults());
   ~RecordBatchStream() override;
 
   std::shared_ptr<Schema> schema() override;

--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -537,6 +537,15 @@ Status ExampleDictBatches(BatchVector* out) {
   return Status::OK();
 }
 
+Status ExampleNestedBatches(BatchVector* out) {
+  std::shared_ptr<RecordBatch> batch;
+  for (int i = 0; i < 3; ++i) {
+    RETURN_NOT_OK(ipc::test::MakeListRecordBatch(&batch));
+    out->push_back(batch);
+  }
+  return Status::OK();
+}
+
 std::vector<ActionType> ExampleActionTypes() {
   return {{"drop", "drop a dataset"}, {"cache", "cache a dataset"}};
 }

--- a/cpp/src/arrow/flight/test_util.h
+++ b/cpp/src/arrow/flight/test_util.h
@@ -147,6 +147,9 @@ ARROW_FLIGHT_EXPORT
 Status ExampleDictBatches(BatchVector* out);
 
 ARROW_FLIGHT_EXPORT
+Status ExampleNestedBatches(BatchVector* out);
+
+ARROW_FLIGHT_EXPORT
 std::vector<FlightInfo> ExampleFlightInfo();
 
 ARROW_FLIGHT_EXPORT

--- a/cpp/src/arrow/flight/types.cc
+++ b/cpp/src/arrow/flight/types.cc
@@ -285,6 +285,10 @@ Status MetadataRecordBatchReader::ReadAll(std::shared_ptr<Table>* table) {
   return Table::FromRecordBatches(schema, std::move(batches)).Value(table);
 }
 
+Status MetadataRecordBatchWriter::Begin(const std::shared_ptr<Schema>& schema) {
+  return Begin(schema, ipc::IpcWriteOptions::Defaults());
+}
+
 SimpleFlightListing::SimpleFlightListing(const std::vector<FlightInfo>& flights)
     : position_(0), flights_(flights) {}
 

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "arrow/flight/visibility.h"
+#include "arrow/ipc/options.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/result.h"
 
@@ -486,7 +487,9 @@ class ARROW_FLIGHT_EXPORT MetadataRecordBatchWriter : public ipc::RecordBatchWri
  public:
   virtual ~MetadataRecordBatchWriter() = default;
   /// \brief Begin writing data with the given schema. Only used with \a DoExchange.
-  virtual Status Begin(const std::shared_ptr<Schema>& schema) = 0;
+  virtual Status Begin(const std::shared_ptr<Schema>& schema,
+                       const ipc::IpcWriteOptions& options) = 0;
+  virtual Status Begin(const std::shared_ptr<Schema>& schema);
   virtual Status WriteMetadata(std::shared_ptr<Buffer> app_metadata) = 0;
   virtual Status WriteWithMetadata(const RecordBatch& batch,
                                    std::shared_ptr<Buffer> app_metadata) = 0;


### PR DESCRIPTION
- Python is not covered as I'm not sure how best to expose these structs to Python.
- Java is not covered as it doesn't use IpcOption at all currently; I'd rather hold off and see how the metadata change is implemented before trying to bind it. (The legacy/modern metadata format doesn't come into play since Flight uses Protobuf and not an IPC message exactly per se.)