### PR TITLE
ARROW-9280: [Rust] [Parquet] Calculate page and column statistics

### DIFF
--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "arrow/array.h"
+#include "arrow/array/concatenate.h"
 #include "arrow/extension_type.h"
 #include "arrow/record_batch.h"
 #include "arrow/status.h"
@@ -138,6 +139,23 @@ Status DictionaryMemo::AddDictionary(int64_t id,
   if (HasDictionary(id)) {
     return Status::KeyError("Dictionary with id ", id, " already exists");
   }
+  id_to_dictionary_[id] = dictionary;
+  return Status::OK();
+}
+
+Status DictionaryMemo::AddDictionaryDelta(int64_t id,
+                                          const std::shared_ptr<Array>& dictionary,
+                                          MemoryPool* pool) {
+  std::shared_ptr<Array> originalDict, combinedDict;
+  RETURN_NOT_OK(GetDictionary(id, &originalDict));
+  ArrayVector dictsToCombine{originalDict, dictionary};
+  ARROW_ASSIGN_OR_RAISE(combinedDict, Concatenate(dictsToCombine, pool));
+  id_to_dictionary_[id] = combinedDict;
+  return Status::OK();
+}
+
+Status DictionaryMemo::AddOrReplaceDictionary(int64_t id,
+                                              const std::shared_ptr<Array>& dictionary) {
   id_to_dictionary_[id] = dictionary;
   return Status::OK();
 }

--- a/cpp/src/arrow/ipc/dictionary.h
+++ b/cpp/src/arrow/ipc/dictionary.h
@@ -25,6 +25,7 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/memory_pool.h"
 #include "arrow/status.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
@@ -77,6 +78,15 @@ class ARROW_EXPORT DictionaryMemo {
   /// \brief Add a dictionary to the memo with a particular id. Returns
   /// KeyError if that dictionary already exists
   Status AddDictionary(int64_t id, const std::shared_ptr<Array>& dictionary);
+
+  /// \brief Append a dictionary delta to the memo with a particular id. Returns
+  /// KeyError if that dictionary does not exists
+  Status AddDictionaryDelta(int64_t id, const std::shared_ptr<Array>& dictionary,
+                            MemoryPool* pool);
+
+  /// \brief Add a dictionary to the memo if it does not have one with the id,
+  /// otherwise, replace the dictionary with the new one.
+  Status AddOrReplaceDictionary(int64_t id, const std::shared_ptr<Array>& dictionary);
 
   /// \brief The stored dictionaries, in ascending id order.
   DictionaryVector dictionaries() const;

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -1209,7 +1209,7 @@ Result<std::shared_ptr<Buffer>> WriteSparseTensorMessage(
 }
 
 Status WriteDictionaryMessage(
-    int64_t id, int64_t length, int64_t body_length,
+    int64_t id, bool is_delta, int64_t length, int64_t body_length,
     const std::shared_ptr<const KeyValueMetadata>& custom_metadata,
     const std::vector<FieldMetadata>& nodes, const std::vector<BufferMetadata>& buffers,
     const IpcWriteOptions& options, std::shared_ptr<Buffer>* out) {
@@ -1217,7 +1217,8 @@ Status WriteDictionaryMessage(
   RecordBatchOffset record_batch;
   RETURN_NOT_OK(
       MakeRecordBatch(fbb, length, body_length, nodes, buffers, options, &record_batch));
-  auto dictionary_batch = flatbuf::CreateDictionaryBatch(fbb, id, record_batch).Union();
+  auto dictionary_batch =
+      flatbuf::CreateDictionaryBatch(fbb, id, record_batch, is_delta).Union();
   return WriteFBMessage(fbb, flatbuf::MessageHeader::DictionaryBatch, dictionary_batch,
                         body_length, custom_metadata)
       .Value(out);

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -195,7 +195,8 @@ Status WriteFileFooter(const Schema& schema, const std::vector<FileBlock>& dicti
                        io::OutputStream* out);
 
 Status WriteDictionaryMessage(
-    const int64_t id, const int64_t length, const int64_t body_length,
+    const int64_t id, const bool is_delta, const int64_t length,
+    const int64_t body_length,
     const std::shared_ptr<const KeyValueMetadata>& custom_metadata,
     const std::vector<FieldMetadata>& nodes, const std::vector<BufferMetadata>& buffers,
     const IpcWriteOptions& options, std::shared_ptr<Buffer>* out);

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1228,6 +1228,157 @@ TEST_P(TestFileFormat, RoundTrip) {
   TestZeroLengthRoundTrip(*GetParam(), options);
 }
 
+Status MakeDictionaryBatch(std::shared_ptr<RecordBatch>* out) {
+  auto f0_type = arrow::dictionary(int32(), utf8());
+  auto f1_type = arrow::dictionary(int8(), utf8());
+
+  auto dict = ArrayFromJSON(utf8(), "[\"foo\", \"bar\", \"baz\"]");
+
+  auto indices0 = ArrayFromJSON(int32(), "[1, 2, null, 0, 2, 0]");
+  auto indices1 = ArrayFromJSON(int8(), "[0, 0, 2, 2, 1, 1]");
+
+  auto a0 = std::make_shared<DictionaryArray>(f0_type, indices0, dict);
+  auto a1 = std::make_shared<DictionaryArray>(f1_type, indices1, dict);
+
+  // construct batch
+  auto schema = ::arrow::schema({field("dict1", f0_type), field("dict2", f1_type)});
+
+  *out = RecordBatch::Make(schema, 6, {a0, a1});
+  return Status::OK();
+}
+
+// A utility that supports reading/writing record batches,
+// and manually specifying dictionaries.
+class DictionaryBatchHelper {
+ public:
+  explicit DictionaryBatchHelper(const Schema& schema) : schema_(schema) {
+    buffer_ = *AllocateResizableBuffer(0);
+    sink_.reset(new io::BufferOutputStream(buffer_));
+    payload_writer_ = *internal::MakePayloadStreamWriter(sink_.get());
+  }
+
+  Status Start() {
+    RETURN_NOT_OK(payload_writer_->Start());
+
+    // write schema
+    IpcPayload payload;
+    RETURN_NOT_OK(GetSchemaPayload(schema_, IpcWriteOptions::Defaults(),
+                                   &dictionary_memo_, &payload));
+    return payload_writer_->WritePayload(payload);
+  }
+
+  Status WriteDictionary(int64_t dictionary_id, const std::shared_ptr<Array>& dictionary,
+                         bool is_delta) {
+    IpcPayload payload;
+    RETURN_NOT_OK(GetDictionaryPayload(dictionary_id, is_delta, dictionary,
+                                       IpcWriteOptions::Defaults(), &payload));
+    RETURN_NOT_OK(payload_writer_->WritePayload(payload));
+    return Status::OK();
+  }
+
+  Status WriteBatchPayload(const RecordBatch& batch) {
+    // write record batch payload only
+    IpcPayload payload;
+    RETURN_NOT_OK(GetRecordBatchPayload(batch, IpcWriteOptions::Defaults(), &payload));
+    return payload_writer_->WritePayload(payload);
+  }
+
+  Status Close() {
+    RETURN_NOT_OK(payload_writer_->Close());
+    return sink_->Close();
+  }
+
+  Status ReadBatch(std::shared_ptr<RecordBatch>* out_batch) {
+    auto buf_reader = std::make_shared<io::BufferReader>(buffer_);
+    std::shared_ptr<RecordBatchReader> reader;
+    ARROW_ASSIGN_OR_RAISE(
+        reader, RecordBatchStreamReader::Open(buf_reader, IpcReadOptions::Defaults()))
+    return reader->ReadNext(out_batch);
+  }
+
+  std::unique_ptr<internal::IpcPayloadWriter> payload_writer_;
+  const Schema& schema_;
+  DictionaryMemo dictionary_memo_;
+  std::shared_ptr<ResizableBuffer> buffer_;
+  std::unique_ptr<io::BufferOutputStream> sink_;
+};
+
+TEST(TestDictionaryBatch, DictionaryDelta) {
+  std::shared_ptr<RecordBatch> in_batch;
+  std::shared_ptr<RecordBatch> out_batch;
+  ASSERT_OK(MakeDictionaryBatch(&in_batch));
+
+  auto dict1 = ArrayFromJSON(utf8(), "[\"foo\", \"bar\"]");
+  auto dict2 = ArrayFromJSON(utf8(), "[\"baz\"]");
+
+  DictionaryBatchHelper helper(*in_batch->schema());
+  ASSERT_OK(helper.Start());
+
+  ASSERT_OK(helper.WriteDictionary(0L, dict1, /*is_delta=*/false));
+  ASSERT_OK(helper.WriteDictionary(0L, dict2, /*is_delta=*/true));
+
+  ASSERT_OK(helper.WriteDictionary(1L, dict1, /*is_delta=*/false));
+  ASSERT_OK(helper.WriteDictionary(1L, dict2, /*is_delta=*/true));
+
+  ASSERT_OK(helper.WriteBatchPayload(*in_batch));
+  ASSERT_OK(helper.Close());
+
+  ASSERT_OK(helper.ReadBatch(&out_batch));
+
+  ASSERT_BATCHES_EQUAL(*in_batch, *out_batch);
+}
+
+TEST(TestDictionaryBatch, DictionaryDeltaWithUnknownId) {
+  std::shared_ptr<RecordBatch> in_batch;
+  std::shared_ptr<RecordBatch> out_batch;
+  ASSERT_OK(MakeDictionaryBatch(&in_batch));
+
+  auto dict1 = ArrayFromJSON(utf8(), "[\"foo\", \"bar\"]");
+  auto dict2 = ArrayFromJSON(utf8(), "[\"baz\"]");
+
+  DictionaryBatchHelper helper(*in_batch->schema());
+  ASSERT_OK(helper.Start());
+
+  ASSERT_OK(helper.WriteDictionary(0L, dict1, /*is_delta=*/false));
+  ASSERT_OK(helper.WriteDictionary(0L, dict2, /*is_delta=*/true));
+
+  /* This delta dictionary does not have a base dictionary previously in stream */
+  ASSERT_OK(helper.WriteDictionary(1L, dict2, /*is_delta=*/true));
+
+  ASSERT_OK(helper.WriteBatchPayload(*in_batch));
+  ASSERT_OK(helper.Close());
+
+  ASSERT_RAISES(KeyError, helper.ReadBatch(&out_batch));
+}
+
+TEST(TestDictionaryBatch, DictionaryReplacement) {
+  std::shared_ptr<RecordBatch> in_batch;
+  std::shared_ptr<RecordBatch> out_batch;
+  ASSERT_OK(MakeDictionaryBatch(&in_batch));
+
+  auto dict = ArrayFromJSON(utf8(), "[\"foo\", \"bar\", \"baz\"]");
+  auto dict1 = ArrayFromJSON(utf8(), "[\"foo1\", \"bar1\", \"baz1\"]");
+  auto dict2 = ArrayFromJSON(utf8(), "[\"foo2\", \"bar2\", \"baz2\"]");
+
+  DictionaryBatchHelper helper(*in_batch->schema());
+  ASSERT_OK(helper.Start());
+
+  // the old dictionaries will be overwritten by
+  // the new dictionaries with the same ids.
+  ASSERT_OK(helper.WriteDictionary(0L, dict1, /*is_delta=*/false));
+  ASSERT_OK(helper.WriteDictionary(0L, dict, /*is_delta=*/false));
+
+  ASSERT_OK(helper.WriteDictionary(1L, dict2, /*is_delta=*/false));
+  ASSERT_OK(helper.WriteDictionary(1L, dict, /*is_delta=*/false));
+
+  ASSERT_OK(helper.WriteBatchPayload(*in_batch));
+  ASSERT_OK(helper.Close());
+
+  ASSERT_OK(helper.ReadBatch(&out_batch));
+
+  ASSERT_BATCHES_EQUAL(*in_batch, *out_batch);
+}
+
 TEST_P(TestStreamFormat, RoundTrip) {
   TestRoundTrip(*GetParam(), IpcWriteOptions::Defaults());
   TestZeroLengthRoundTrip(*GetParam(), IpcWriteOptions::Defaults());

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -297,6 +297,18 @@ ARROW_EXPORT
 Status GetDictionaryPayload(int64_t id, const std::shared_ptr<Array>& dictionary,
                             const IpcWriteOptions& options, IpcPayload* payload);
 
+/// \brief Compute IpcPayload for a dictionary
+/// \param[in] id the dictionary id
+/// \param[in] is_delta whether the dictionary is a delta dictionary
+/// \param[in] dictionary the dictionary values
+/// \param[in] options options for serialization
+/// \param[out] payload the output IpcPayload
+/// \return Status
+ARROW_EXPORT
+Status GetDictionaryPayload(int64_t id, bool is_delta,
+                            const std::shared_ptr<Array>& dictionary,
+                            const IpcWriteOptions& options, IpcPayload* payload);
+
 /// \brief Compute IpcPayload for the given record batch
 /// \param[in] batch the RecordBatch that is being serialized
 /// \param[in] options options for serialization
@@ -340,6 +352,29 @@ class ARROW_EXPORT IpcPayloadWriter {
 
   virtual Status Close() = 0;
 };
+
+/// Create a new IPC payload stream writer from stream sink. User is
+/// responsible for closing the actual OutputStream.
+///
+/// \param[in] sink output stream to write to
+/// \param[in] options options for serialization
+/// \return Result<std::shared_ptr<IpcPayloadWriter>>
+ARROW_EXPORT
+Result<std::unique_ptr<IpcPayloadWriter>> MakePayloadStreamWriter(
+    io::OutputStream* sink, const IpcWriteOptions& options = IpcWriteOptions::Defaults());
+
+/// Create a new IPC payload file writer from stream sink.
+///
+/// \param[in] sink output stream to write to
+/// \param[in] schema the schema of the record batches to be written
+/// \param[in] options options for serialization, optional
+/// \param[in] metadata custom metadata for File Footer, optional
+/// \return Status
+ARROW_EXPORT
+Result<std::unique_ptr<IpcPayloadWriter>> MakePayloadFileWriter(
+    io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
+    const IpcWriteOptions& options = IpcWriteOptions::Defaults(),
+    const std::shared_ptr<const KeyValueMetadata>& metadata = NULLPTR);
 
 /// Create a new RecordBatchWriter from IpcPayloadWriter and schema.
 ///

--- a/java/memory/src/main/java/io/netty/buffer/ExpandableByteBuf.java
+++ b/java/memory/src/main/java/io/netty/buffer/ExpandableByteBuf.java
@@ -41,7 +41,7 @@ public class ExpandableByteBuf extends MutableWrappedByteBuf {
   @Override
   public ByteBuf capacity(int newCapacity) {
     if (newCapacity > capacity()) {
-      ByteBuf newBuf = allocator.buffer(newCapacity).asNettyBuffer();
+      ByteBuf newBuf = NettyArrowBuf.unwrapBuffer(allocator.buffer(newCapacity));
       newBuf.writeBytes(buffer, 0, buffer.capacity());
       newBuf.readerIndex(buffer.readerIndex());
       newBuf.writerIndex(buffer.writerIndex());

--- a/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/AllocationManager.java
@@ -210,5 +210,7 @@ public abstract class AllocationManager {
      * @return The created AllocationManager used by this allocator
      */
     AllocationManager create(BaseAllocator accountingAllocator, long size);
+
+    ArrowBuf empty();
   }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/ArrowByteBufAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/ArrowByteBufAllocator.java
@@ -21,6 +21,7 @@ import io.netty.buffer.AbstractByteBufAllocator;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.buffer.ExpandableByteBuf;
+import io.netty.buffer.NettyArrowBuf;
 
 /**
  * An implementation of ByteBufAllocator that wraps a Arrow BufferAllocator. This allows the RPC
@@ -56,7 +57,7 @@ public class ArrowByteBufAllocator extends AbstractByteBufAllocator {
 
   @Override
   public ByteBuf buffer(int initialCapacity) {
-    return new ExpandableByteBuf(allocator.buffer(initialCapacity).asNettyBuffer(), allocator);
+    return new ExpandableByteBuf(NettyArrowBuf.unwrapBuffer(allocator.buffer(initialCapacity)), allocator);
   }
 
   @Override
@@ -86,7 +87,7 @@ public class ArrowByteBufAllocator extends AbstractByteBufAllocator {
 
   @Override
   public ByteBuf directBuffer(int initialCapacity) {
-    return allocator.buffer(initialCapacity).asNettyBuffer();
+    return NettyArrowBuf.unwrapBuffer(allocator.buffer(initialCapacity));
   }
 
   @Override

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferAllocator.java
@@ -19,8 +19,6 @@ package org.apache.arrow.memory;
 
 import java.util.Collection;
 
-import io.netty.buffer.ByteBufAllocator;
-
 /**
  * Wrapper class to deal with byte buffer allocation. Ensures users only use designated methods.
  */
@@ -50,16 +48,6 @@ public interface BufferAllocator extends AutoCloseable {
    * @throws OutOfMemoryException if buffer cannot be allocated
    */
   ArrowBuf buffer(long size, BufferManager manager);
-
-  /**
-   * Returns the allocator this allocator falls back to when it needs more memory.
-   *
-   * @return the underlying allocator used by this allocator
-   *
-   * @deprecated This method may be removed in a future release.
-   */
-  @Deprecated
-  ByteBufAllocator getAsByteBufAllocator();
 
   /**
    * Create a new child allocator.

--- a/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BufferLedger.java
@@ -25,8 +25,6 @@ import org.apache.arrow.memory.util.CommonUtil;
 import org.apache.arrow.memory.util.HistoricalLog;
 import org.apache.arrow.util.Preconditions;
 
-import io.netty.buffer.UnsafeDirectLittleEndian;
-
 /**
  * The reference manager that binds an {@link AllocationManager} to
  * {@link BufferAllocator} and a set of {@link ArrowBuf}. The set of
@@ -516,16 +514,6 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
   }
 
   /**
-   * Returns the underlying {@link UnsafeDirectLittleEndian} instance used by this BufferLedger.
-   *
-   * @deprecated This method may be removed in a future release.
-   */
-  @Deprecated
-  public UnsafeDirectLittleEndian getUnderlying() {
-    return unwrap(UnsafeDirectLittleEndian.class);
-  }
-
-  /**
    * Get the {@link AllocationManager} used by this BufferLedger.
    *
    * @return The AllocationManager used by this BufferLedger.
@@ -534,18 +522,4 @@ public class BufferLedger implements ValueWithKeyIncluded<BaseAllocator>, Refere
     return allocationManager;
   }
 
-  /**
-   * Return the {@link AllocationManager} used or underlying {@link UnsafeDirectLittleEndian} instance
-   * (in the case of we use a {@link NettyAllocationManager}), and cast to desired class.
-   *
-   * @param clazz The desired class to cast into
-   * @return The AllocationManager used by this BufferLedger, or the underlying UnsafeDirectLittleEndian object.
-   */
-  public <T> T unwrap(Class<T> clazz) {
-    if (clazz.isInstance(allocationManager)) {
-      return clazz.cast(allocationManager);
-    }
-
-    throw new IllegalArgumentException("Unexpected unwrapping class: " + clazz);
-  }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerFactory.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerFactory.java
@@ -32,4 +32,9 @@ public class DefaultAllocationManagerFactory implements AllocationManager.Factor
   public AllocationManager create(BaseAllocator accountingAllocator, long size) {
     return new NettyAllocationManager(accountingAllocator, size);
   }
+
+  @Override
+  public ArrowBuf empty() {
+    return NettyAllocationManager.EMPTY_BUFFER;
+  }
 }

--- a/java/memory/src/main/java/org/apache/arrow/memory/NettyAllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/NettyAllocationManager.java
@@ -27,7 +27,18 @@ import io.netty.util.internal.PlatformDependent;
  */
 public class NettyAllocationManager extends AllocationManager {
 
-  public static final AllocationManager.Factory FACTORY = NettyAllocationManager::new;
+  public static final AllocationManager.Factory FACTORY = new AllocationManager.Factory() {
+
+    @Override
+    public AllocationManager create(BaseAllocator accountingAllocator, long size) {
+      return new NettyAllocationManager(accountingAllocator, size);
+    }
+
+    @Override
+    public ArrowBuf empty() {
+      return EMPTY_BUFFER;
+    }
+  };
 
   /**
    * The default cut-off value for switching allocation strategies.
@@ -39,6 +50,10 @@ public class NettyAllocationManager extends AllocationManager {
 
   private static final PooledByteBufAllocatorL INNER_ALLOCATOR = new PooledByteBufAllocatorL();
   static final UnsafeDirectLittleEndian EMPTY = INNER_ALLOCATOR.empty;
+  static final ArrowBuf EMPTY_BUFFER = new ArrowBuf(ReferenceManager.NO_OP,
+      null,
+      0,
+      NettyAllocationManager.EMPTY.memoryAddress());
   static final long CHUNK_SIZE = INNER_ALLOCATOR.getChunkSize();
 
   private final long allocatedSize;

--- a/java/memory/src/main/java/org/apache/arrow/memory/RootAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/RootAllocator.java
@@ -37,7 +37,8 @@ public class RootAllocator extends BaseAllocator {
   }
 
   public RootAllocator(final AllocationListener listener, final long limit) {
-    this(listener, limit, DefaultRoundingPolicy.INSTANCE);
+    //todo fix DefaultRoundingPolicy when using Netty
+    this(listener, limit, DefaultRoundingPolicy.DEFAULT_ROUNDING_POLICY);
   }
 
   /**

--- a/java/memory/src/main/java/org/apache/arrow/memory/UnsafeAllocationManager.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/UnsafeAllocationManager.java
@@ -24,7 +24,23 @@ import org.apache.arrow.memory.util.MemoryUtil;
  */
 public final class UnsafeAllocationManager extends AllocationManager {
 
-  public static final AllocationManager.Factory FACTORY = UnsafeAllocationManager::new;
+  private static final ArrowBuf EMPTY = new ArrowBuf(ReferenceManager.NO_OP,
+      null,
+      0,
+      MemoryUtil.UNSAFE.allocateMemory(0)
+  );
+
+  public static final AllocationManager.Factory FACTORY = new Factory() {
+    @Override
+    public AllocationManager create(BaseAllocator accountingAllocator, long size) {
+      return new UnsafeAllocationManager(accountingAllocator, size);
+    }
+
+    @Override
+    public ArrowBuf empty() {
+      return EMPTY;
+    }
+  };
 
   private final long allocatedSize;
 

--- a/java/memory/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/rounding/DefaultRoundingPolicy.java
@@ -17,10 +17,11 @@
 
 package org.apache.arrow.memory.rounding;
 
-import java.lang.reflect.Field;
-
-import org.apache.arrow.memory.NettyAllocationManager;
 import org.apache.arrow.memory.util.CommonUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.netty.util.internal.SystemPropertyUtil;
 
 /**
  * The default rounding policy. That is, if the requested size is within the chunk size,
@@ -28,22 +29,83 @@ import org.apache.arrow.memory.util.CommonUtil;
  * will be identical to the requested size.
  */
 public class DefaultRoundingPolicy implements RoundingPolicy {
-
+  private static final Logger logger = LoggerFactory.getLogger(DefaultRoundingPolicy.class);
   public final long chunkSize;
+
+  /**
+   * The variables here and the static block calculates the DEFAULT_CHUNK_SIZE.
+   *
+   * <p>
+   *   It was copied from {@link io.netty.buffer.PooledByteBufAllocator}.
+   * </p>
+   */
+  private static final int MIN_PAGE_SIZE = 4096;
+  private static final int MAX_CHUNK_SIZE = (int) (((long) Integer.MAX_VALUE + 1) / 2);
+  private static final long DEFAULT_CHUNK_SIZE;
+
+
+  static {
+    int defaultPageSize = SystemPropertyUtil.getInt("org.apache.memory.allocator.pageSize", 8192);
+    Throwable pageSizeFallbackCause = null;
+    try {
+      validateAndCalculatePageShifts(defaultPageSize);
+    } catch (Throwable t) {
+      pageSizeFallbackCause = t;
+      defaultPageSize = 8192;
+    }
+
+    int defaultMaxOrder = SystemPropertyUtil.getInt("org.apache.memory.allocator.maxOrder", 11);
+    Throwable maxOrderFallbackCause = null;
+    try {
+      validateAndCalculateChunkSize(defaultPageSize, defaultMaxOrder);
+    } catch (Throwable t) {
+      maxOrderFallbackCause = t;
+      defaultMaxOrder = 11;
+    }
+    DEFAULT_CHUNK_SIZE = validateAndCalculateChunkSize(defaultPageSize, defaultMaxOrder);
+    if (logger.isDebugEnabled()) {
+      logger.debug("-Dorg.apache.memory.allocator.pageSize: {}", defaultPageSize);
+      logger.debug("-Dorg.apache.memory.allocator.maxOrder: {}", defaultMaxOrder);
+    }
+  }
+
+  private static int validateAndCalculatePageShifts(int pageSize) {
+    if (pageSize < MIN_PAGE_SIZE) {
+      throw new IllegalArgumentException("pageSize: " + pageSize + " (expected: " + MIN_PAGE_SIZE + ")");
+    }
+
+    if ((pageSize & pageSize - 1) != 0) {
+      throw new IllegalArgumentException("pageSize: " + pageSize + " (expected: power of 2)");
+    }
+
+    // Logarithm base 2. At this point we know that pageSize is a power of two.
+    return Integer.SIZE - 1 - Integer.numberOfLeadingZeros(pageSize);
+  }
+
+  private static int validateAndCalculateChunkSize(int pageSize, int maxOrder) {
+    if (maxOrder > 14) {
+      throw new IllegalArgumentException("maxOrder: " + maxOrder + " (expected: 0-14)");
+    }
+
+    // Ensure the resulting chunkSize does not overflow.
+    int chunkSize = pageSize;
+    for (int i = maxOrder; i > 0; i --) {
+      if (chunkSize > MAX_CHUNK_SIZE / 2) {
+        throw new IllegalArgumentException(String.format(
+            "pageSize (%d) << maxOrder (%d) must not exceed %d", pageSize, maxOrder, MAX_CHUNK_SIZE));
+      }
+      chunkSize <<= 1;
+    }
+    return chunkSize;
+  }
 
   /**
    * The singleton instance.
    */
-  public static final DefaultRoundingPolicy INSTANCE = new DefaultRoundingPolicy();
+  public static final DefaultRoundingPolicy DEFAULT_ROUNDING_POLICY = new DefaultRoundingPolicy(DEFAULT_CHUNK_SIZE);
 
-  private DefaultRoundingPolicy() {
-    try {
-      Field field = NettyAllocationManager.class.getDeclaredField("CHUNK_SIZE");
-      field.setAccessible(true);
-      chunkSize = (Long) field.get(null);
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to get chunk size from allocation manager");
-    }
+  private DefaultRoundingPolicy(long chunkSize) {
+    this.chunkSize = chunkSize;
   }
 
   @Override

--- a/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
+++ b/java/memory/src/test/java/io/netty/buffer/TestNettyArrowBuf.java
@@ -33,7 +33,7 @@ public class TestNettyArrowBuf {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
     ) {
-      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       nettyBuf.writerIndex(20);
       nettyBuf.readerIndex(10);
       NettyArrowBuf slicedBuffer = nettyBuf.slice();
@@ -47,7 +47,7 @@ public class TestNettyArrowBuf {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
     ) {
-      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       ByteBuffer byteBuffer = nettyBuf.nioBuffer(4, 6);
       // Nio Buffers should always be 0 indexed
       Assert.assertEquals(0, byteBuffer.position());
@@ -63,7 +63,7 @@ public class TestNettyArrowBuf {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
     ) {
-      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       ByteBuffer byteBuffer = nettyBuf.internalNioBuffer(4, 6);
       Assert.assertEquals(0, byteBuffer.position());
       Assert.assertEquals(6, byteBuffer.limit());
@@ -78,7 +78,7 @@ public class TestNettyArrowBuf {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
     ) {
-      NettyArrowBuf nettyBuf = buf.asNettyBuffer();
+      NettyArrowBuf nettyBuf = NettyArrowBuf.unwrapBuffer(buf);
       int [] intVals = new int[] {Integer.MIN_VALUE, Short.MIN_VALUE - 1, Short.MIN_VALUE, 0 ,
         Short.MAX_VALUE , Short.MAX_VALUE + 1, Integer.MAX_VALUE};
       for (int intValue :intVals ) {
@@ -104,7 +104,7 @@ public class TestNettyArrowBuf {
   public void testSetCompositeBuffer() {
     try (BufferAllocator allocator = new RootAllocator(128);
          ArrowBuf buf = allocator.buffer(20);
-         NettyArrowBuf buf2 = allocator.buffer(20).asNettyBuffer();
+         NettyArrowBuf buf2 = NettyArrowBuf.unwrapBuffer(allocator.buffer(20));
     ) {
       CompositeByteBuf byteBufs = new CompositeByteBuf(new ArrowByteBufAllocator(allocator),
               true, 1);
@@ -112,7 +112,7 @@ public class TestNettyArrowBuf {
       buf2.setInt(0, expected);
       buf2.writerIndex(4);
       byteBufs.addComponent(true, buf2);
-      buf.asNettyBuffer().setBytes(0, byteBufs, 4);
+      NettyArrowBuf.unwrapBuffer(buf).setBytes(0, byteBufs, 4);
       int actual = buf.getInt(0);
       Assert.assertEquals(expected, actual);
     }
@@ -127,12 +127,12 @@ public class TestNettyArrowBuf {
               true, 1);
       int expected = 4;
       buf.setInt(0, expected);
-      NettyArrowBuf buf2 = allocator.buffer(20).asNettyBuffer();
+      NettyArrowBuf buf2 = NettyArrowBuf.unwrapBuffer(allocator.buffer(20));
       // composite buffers are a bit weird, need to jump hoops
       // to set capacity.
       byteBufs.addComponent(true, buf2);
       byteBufs.capacity(20);
-      buf.asNettyBuffer().getBytes(0, byteBufs, 4);
+      NettyArrowBuf.unwrapBuffer(buf).getBytes(0, byteBufs, 4);
       int actual = byteBufs.getInt(0);
       Assert.assertEquals(expected, actual);
       byteBufs.component(0).release();

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestArrowBuf.java
@@ -27,8 +27,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import io.netty.buffer.PooledByteBufAllocatorL;
-
 public class TestArrowBuf {
 
   private static final int MAX_ALLOCATION = 8 * 1024;
@@ -124,42 +122,6 @@ public class TestArrowBuf {
       buf.getBytes(0, actual);
       assertArrayEquals(expected, actual);
     }
-  }
-
-  @Test
-  public void testEmptyArrowBuf() {
-    ArrowBuf buf = new ArrowBuf(ReferenceManager.NO_OP, null,
-        1024, new PooledByteBufAllocatorL().empty.memoryAddress());
-
-    buf.getReferenceManager().retain();
-    buf.getReferenceManager().retain(8);
-    assertEquals(1024, buf.capacity());
-    assertEquals(1, buf.getReferenceManager().getRefCount());
-    assertEquals(0, buf.getActualMemoryConsumed());
-
-    for (int i = 0; i < 10; i++) {
-      buf.setByte(i, i);
-    }
-    assertEquals(0, buf.getActualMemoryConsumed());
-    assertEquals(0, buf.getReferenceManager().getSize());
-    assertEquals(0, buf.getReferenceManager().getAccountedSize());
-    assertEquals(false, buf.getReferenceManager().release());
-    assertEquals(false, buf.getReferenceManager().release(2));
-    assertEquals(0, buf.getReferenceManager().getAllocator().getLimit());
-    assertEquals(buf, buf.getReferenceManager().transferOwnership(buf, allocator).getTransferredBuffer());
-    assertEquals(0, buf.readerIndex());
-    assertEquals(0, buf.writerIndex());
-    assertEquals(1, buf.refCnt());
-
-    ArrowBuf derive = buf.getReferenceManager().deriveBuffer(buf, 0, 100);
-    assertEquals(derive, buf);
-    assertEquals(1, buf.refCnt());
-    assertEquals(1, derive.refCnt());
-
-    buf.close();
-
-    ArrowBuf buf2 = ArrowBuf.empty(10);
-    assertEquals(10, buf2.capacity());
   }
 
 }

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestEmptyArrowBuf.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestEmptyArrowBuf.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.memory;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.netty.buffer.PooledByteBufAllocatorL;
+
+public class TestEmptyArrowBuf {
+
+  private static final int MAX_ALLOCATION = 8 * 1024;
+  private static RootAllocator allocator;
+
+  @BeforeClass
+  public static void beforeClass() {
+    allocator = new RootAllocator(MAX_ALLOCATION);
+  }
+  
+  /** Ensure the allocator is closed. */
+  @AfterClass
+  public static void afterClass() {
+    if (allocator != null) {
+      allocator.close();
+    }
+  }
+
+  @Test
+  public void testEmptyArrowBuf() {
+    ArrowBuf buf = new ArrowBuf(ReferenceManager.NO_OP, null,
+        1024, new PooledByteBufAllocatorL().empty.memoryAddress());
+
+    buf.getReferenceManager().retain();
+    buf.getReferenceManager().retain(8);
+    assertEquals(1024, buf.capacity());
+    assertEquals(1, buf.getReferenceManager().getRefCount());
+    assertEquals(0, buf.getActualMemoryConsumed());
+
+    for (int i = 0; i < 10; i++) {
+      buf.setByte(i, i);
+    }
+    assertEquals(0, buf.getActualMemoryConsumed());
+    assertEquals(0, buf.getReferenceManager().getSize());
+    assertEquals(0, buf.getReferenceManager().getAccountedSize());
+    assertEquals(false, buf.getReferenceManager().release());
+    assertEquals(false, buf.getReferenceManager().release(2));
+    assertEquals(0, buf.getReferenceManager().getAllocator().getLimit());
+    assertEquals(buf, buf.getReferenceManager().transferOwnership(buf, allocator).getTransferredBuffer());
+    assertEquals(0, buf.readerIndex());
+    assertEquals(0, buf.writerIndex());
+    assertEquals(1, buf.refCnt());
+
+    ArrowBuf derive = buf.getReferenceManager().deriveBuffer(buf, 0, 100);
+    assertEquals(derive, buf);
+    assertEquals(1, buf.refCnt());
+    assertEquals(1, derive.refCnt());
+
+    buf.close();
+
+  }
+
+}

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestEndianness.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestEndianness.java
@@ -22,13 +22,14 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.NettyArrowBuf;
 
 public class TestEndianness {
 
   @Test
   public void testLittleEndian() {
     final BufferAllocator a = new RootAllocator(10000);
-    final ByteBuf b = a.buffer(4).asNettyBuffer();
+    final ByteBuf b = NettyArrowBuf.unwrapBuffer(a.buffer(4));
     b.setInt(0, 35);
     assertEquals(b.getByte(0), 35);
     assertEquals(b.getByte(1), 0);

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestNettyAllocationManager.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestNettyAllocationManager.java
@@ -33,9 +33,17 @@ public class TestNettyAllocationManager {
 
   private BaseAllocator createCustomizedAllocator() {
     return new RootAllocator(BaseAllocator.configBuilder()
-        .allocationManagerFactory((accountingAllocator, requestedSize) ->
-            new NettyAllocationManager(
-                accountingAllocator, requestedSize, CUSTOMIZED_ALLOCATION_CUTOFF_VALUE)).build());
+        .allocationManagerFactory(new AllocationManager.Factory() {
+          @Override
+          public AllocationManager create(BaseAllocator accountingAllocator, long size) {
+            return new NettyAllocationManager(accountingAllocator, size, CUSTOMIZED_ALLOCATION_CUTOFF_VALUE);
+          }
+
+          @Override
+          public ArrowBuf empty() {
+            return null;
+          }
+        }).build());
   }
 
   private void readWriteArrowBuf(ArrowBuf buffer) {

--- a/java/memory/src/test/java/org/apache/arrow/memory/TestUnsafeAllocationManager.java
+++ b/java/memory/src/test/java/org/apache/arrow/memory/TestUnsafeAllocationManager.java
@@ -28,10 +28,8 @@ import org.junit.Test;
 public class TestUnsafeAllocationManager {
 
   private BaseAllocator createUnsafeAllocator() {
-    return new RootAllocator(BaseAllocator.configBuilder()
-        .allocationManagerFactory((accountingAllocator, requestedSize) ->
-            new UnsafeAllocationManager(
-                accountingAllocator, requestedSize)).build());
+    return new RootAllocator(BaseAllocator.configBuilder().allocationManagerFactory(UnsafeAllocationManager.FACTORY)
+        .build());
   }
 
   private void readWriteArrowBuf(ArrowBuf buffer) {

--- a/rust/parquet/src/column/writer.rs
+++ b/rust/parquet/src/column/writer.rs
@@ -16,23 +16,25 @@
 // under the License.
 
 //! Contains column writer API.
-
 use std::{cmp, collections::VecDeque, rc::Rc};
 
 use crate::basic::{Compression, Encoding, PageType, Type};
-use crate::column::page::{CompressedPage, Page, PageWriteSpec, PageWriter};
-use crate::compression::{create_codec, Codec};
+use crate::column::page::{CompressedPage, Page, PageWriter, PageWriteSpec};
+use crate::compression::{Codec, create_codec};
 use crate::data_type::*;
+use crate::data_type::AsBytes;
 use crate::encodings::{
-    encoding::{get_encoder, DictEncoder, Encoder},
-    levels::{max_buffer_size, LevelEncoder},
+    encoding::{DictEncoder, Encoder, get_encoder},
+    levels::{LevelEncoder, max_buffer_size},
 };
 use crate::errors::{ParquetError, Result};
 use crate::file::{
     metadata::ColumnChunkMetaData,
     properties::{WriterProperties, WriterPropertiesPtr, WriterVersion},
 };
+use crate::file::statistics::Statistics;
 use crate::schema::types::ColumnDescPtr;
+use crate::util::bit_util::FromBytes;
 use crate::util::memory::{ByteBufferPtr, MemTracker};
 
 /// Column writer for a Parquet type.
@@ -45,6 +47,22 @@ pub enum ColumnWriter {
     DoubleColumnWriter(ColumnWriterImpl<DoubleType>),
     ByteArrayColumnWriter(ColumnWriterImpl<ByteArrayType>),
     FixedLenByteArrayColumnWriter(ColumnWriterImpl<FixedLenByteArrayType>),
+}
+
+macro_rules! gen_page_stats_section {
+    ($self: ident, $physical_ty: ty, $stat_fn: ident) => {{
+        let min = $self.min_page_value.clone().and_then(|v| Some(read_num_bytes!($physical_ty, v.as_bytes().len(), &v.as_bytes())));
+        let max = $self.max_page_value.clone().and_then(|v| Some(read_num_bytes!($physical_ty, v.as_bytes().len(), &v.as_bytes())));
+        Statistics::$stat_fn(min, max, $self.page_distinct_count, $self.num_page_nulls, false)
+    }};
+}
+
+macro_rules! gen_column_stats_section {
+    ($self: ident, $physical_ty: ty, $stat_fn: ident) => {{
+        let min = $self.min_column_value.clone().and_then(|v| Some(read_num_bytes!($physical_ty, v.as_bytes().len(), &v.as_bytes())));
+        let max = $self.max_column_value.clone().and_then(|v| Some(read_num_bytes!($physical_ty, v.as_bytes().len(), &v.as_bytes())));
+        Statistics::$stat_fn(min, max, $self.column_distinct_count, $self.num_column_nulls, false)
+    }};
 }
 
 /// Gets a specific column writer corresponding to column descriptor `descr`.
@@ -149,6 +167,10 @@ pub struct ColumnWriterImpl<T: DataType> {
     num_buffered_values: u32,
     num_buffered_encoded_values: u32,
     num_buffered_rows: u32,
+    min_page_value: Option<T::T>,
+    max_page_value: Option<T::T>,
+    num_page_nulls: u64,
+    page_distinct_count: Option<u64>,
     // Metrics per column writer
     total_bytes_written: u64,
     total_rows_written: u64,
@@ -157,6 +179,10 @@ pub struct ColumnWriterImpl<T: DataType> {
     total_num_values: u64,
     dictionary_page_offset: Option<u64>,
     data_page_offset: Option<u64>,
+    min_column_value: Option<T::T>,
+    max_column_value: Option<T::T>,
+    num_column_nulls: u64,
+    column_distinct_count: Option<u64>,
     // Reused buffers
     def_levels_sink: Vec<i16>,
     rep_levels_sink: Vec<i16>,
@@ -192,7 +218,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
                 .unwrap_or(Self::fallback_encoding(&props)),
             Rc::new(MemTracker::new()),
         )
-        .unwrap();
+            .unwrap();
 
         Self {
             descr,
@@ -216,26 +242,26 @@ impl<T: DataType> ColumnWriterImpl<T> {
             def_levels_sink: vec![],
             rep_levels_sink: vec![],
             data_pages: VecDeque::new(),
+            min_page_value: None,
+            max_page_value: None,
+            num_page_nulls: 0,
+            page_distinct_count: None,
+            min_column_value: None,
+            max_column_value: None,
+            num_column_nulls: 0,
+            column_distinct_count: None,
         }
     }
 
-    /// Writes batch of values, definition levels and repetition levels.
-    /// Returns number of values processed (written).
-    ///
-    /// If definition and repetition levels are provided, we write fully those levels and
-    /// select how many values to write (this number will be returned), since number of
-    /// actual written values may be smaller than provided values.
-    ///
-    /// If only values are provided, then all values are written and the length of
-    /// of the values buffer is returned.
-    ///
-    /// Definition and/or repetition levels can be omitted, if values are
-    /// non-nullable and/or non-repeated.
-    pub fn write_batch(
+    fn write_batch_internal(
         &mut self,
         values: &[T::T],
         def_levels: Option<&[i16]>,
         rep_levels: Option<&[i16]>,
+        min: &Option<T::T>,
+        max: &Option<T::T>,
+        null_count: Option<u64>,
+        distinct_count: Option<u64>,
     ) -> Result<usize> {
         // We check for DataPage limits only after we have inserted the values. If a user
         // writes a large number of values, the DataPage size can be well above the limit.
@@ -263,11 +289,32 @@ impl<T: DataType> ColumnWriterImpl<T> {
         let mut values_offset = 0;
         let mut levels_offset = 0;
 
+        // Process pre-calculated statistics
+        match (min, max) {
+            (Some(min), Some(max)) => {
+                if self.min_column_value.is_none() || self.min_column_value.as_ref().unwrap() > min { self.min_column_value = Some(min.clone()); }
+                if self.max_column_value.is_none() || self.max_column_value.as_ref().unwrap() < max { self.max_column_value = Some(max.clone()); }
+            }
+            (None, Some(_)) | (Some(_), None) => panic!("min/max should be both set or both None"),
+            (None, None) => {}
+        }
+
+        if let Some(distinct) = distinct_count {
+            self.column_distinct_count = Some(self.column_distinct_count.unwrap_or(0) + distinct);
+        }
+
+        if let Some(nulls) = null_count {
+            self.num_column_nulls += nulls;
+        }
+
+        let calculate_page_stats = (min.is_none() || max.is_none()) && null_count.is_none() && distinct_count.is_none();
+
         for _ in 0..num_batches {
             values_offset += self.write_mini_batch(
                 &values[values_offset..values_offset + write_batch_size],
                 def_levels.map(|lv| &lv[levels_offset..levels_offset + write_batch_size]),
                 rep_levels.map(|lv| &lv[levels_offset..levels_offset + write_batch_size]),
+                calculate_page_stats,
             )?;
             levels_offset += write_batch_size;
         }
@@ -276,10 +323,48 @@ impl<T: DataType> ColumnWriterImpl<T> {
             &values[values_offset..],
             def_levels.map(|lv| &lv[levels_offset..]),
             rep_levels.map(|lv| &lv[levels_offset..]),
+            calculate_page_stats,
         )?;
 
         // Return total number of values processed.
         Ok(values_offset)
+    }
+
+    /// Writes batch of values, definition levels and repetition levels.
+    /// Returns number of values processed (written).
+    ///
+    /// If definition and repetition levels are provided, we write fully those levels and
+    /// select how many values to write (this number will be returned), since number of
+    /// actual written values may be smaller than provided values.
+    ///
+    /// If only values are provided, then all values are written and the length of
+    /// of the values buffer is returned.
+    ///
+    /// Definition and/or repetition levels can be omitted, if values are
+    /// non-nullable and/or non-repeated.
+    pub fn write_batch(
+        &mut self,
+        values: &[T::T],
+        def_levels: Option<&[i16]>,
+        rep_levels: Option<&[i16]>,
+    ) -> Result<usize> {
+        self.write_batch_internal(values, def_levels, rep_levels, &None, &None, None, None)
+    }
+
+    /// Writer may optionally provide pre-calculated statistics for this batch, in which case we do
+    /// not calculate page level statistics as this will defeat the purpose of speeding up the write
+    /// process with pre-calculated statistics.
+    pub fn write_batch_with_statistics(
+        &mut self,
+        values: &[T::T],
+        def_levels: Option<&[i16]>,
+        rep_levels: Option<&[i16]>,
+        min: &Option<T::T>,
+        max: &Option<T::T>,
+        nulls_count: Option<u64>,
+        distinct_count: Option<u64>,
+    ) -> Result<usize> {
+        self.write_batch_internal(values, def_levels, rep_levels, min, max, nulls_count, distinct_count)
     }
 
     /// Returns total number of bytes written by this column writer so far.
@@ -316,6 +401,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
         values: &[T::T],
         def_levels: Option<&[i16]>,
         rep_levels: Option<&[i16]>,
+        calculate_page_stats: bool,
     ) -> Result<usize> {
         let num_values;
         let mut values_to_write = 0;
@@ -346,7 +432,11 @@ impl<T: DataType> ColumnWriterImpl<T> {
             let levels = def_levels.unwrap();
             num_values = levels.len();
             for &level in levels {
-                values_to_write += (level == self.descr.max_def_level()) as usize;
+                if level == self.descr.max_def_level() {
+                    values_to_write += 1;
+                } else {
+                    if calculate_page_stats { self.num_page_nulls += 1 };
+                }
             }
 
             self.write_definition_levels(levels);
@@ -387,7 +477,12 @@ impl<T: DataType> ColumnWriterImpl<T> {
             ));
         }
 
-        // TODO: update page statistics
+        if calculate_page_stats {
+            for val in &values[0..values_to_write] {
+                if self.min_page_value.is_none() || self.min_page_value.as_ref().unwrap() > val { self.min_page_value = Some(val.clone()); }
+                if self.max_page_value.is_none() || self.max_page_value.as_ref().unwrap() < val { self.max_page_value = Some(val.clone()); }
+            }
+        }
 
         self.write_values(&values[0..values_to_write])?;
 
@@ -395,7 +490,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
         self.num_buffered_encoded_values += values_to_write as u32;
 
         if self.should_add_data_page() {
-            self.add_data_page()?;
+            self.add_data_page(calculate_page_stats)?;
         }
 
         if self.should_dict_fallback() {
@@ -463,7 +558,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
 
     /// Adds data page.
     /// Data page is either buffered in case of dictionary encoding or written directly.
-    fn add_data_page(&mut self) -> Result<()> {
+    fn add_data_page(&mut self, calculate_page_stat: bool) -> Result<()> {
         // Extract encoded values
         let value_bytes = match self.dict_encoder {
             Some(ref mut encoder) => encoder.write_indices()?,
@@ -479,6 +574,15 @@ impl<T: DataType> ColumnWriterImpl<T> {
 
         let max_def_level = self.descr.max_def_level();
         let max_rep_level = self.descr.max_rep_level();
+
+        let mut page_statistics: Option<Statistics> = None;
+
+        if calculate_page_stat {
+            if self.min_column_value.is_none() || self.min_column_value.as_ref().unwrap() > self.min_page_value.as_ref().unwrap() { self.min_column_value = self.min_page_value.clone(); }
+            if self.max_column_value.is_none() || self.max_column_value.as_ref().unwrap() < self.max_page_value.as_ref().unwrap() { self.max_column_value = self.max_page_value.clone(); }
+            self.num_column_nulls += self.num_page_nulls;
+            page_statistics = Some(self.make_page_statistics());
+        }
 
         let compressed_page = match self.props.writer_version() {
             WriterVersion::PARQUET_1_0 => {
@@ -519,8 +623,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
                     encoding,
                     def_level_encoding: Encoding::RLE,
                     rep_level_encoding: Encoding::RLE,
-                    // TODO: process statistics
-                    statistics: None,
+                    statistics: page_statistics,
                 };
 
                 CompressedPage::new(data_page, uncompressed_size)
@@ -570,8 +673,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
                     def_levels_byte_len: def_levels_byte_len as u32,
                     rep_levels_byte_len: rep_levels_byte_len as u32,
                     is_compressed: self.compressor.is_some(),
-                    // TODO: process statistics
-                    statistics: None,
+                    statistics: page_statistics,
                 };
 
                 CompressedPage::new(data_page, uncompressed_size)
@@ -594,6 +696,10 @@ impl<T: DataType> ColumnWriterImpl<T> {
         self.num_buffered_values = 0;
         self.num_buffered_encoded_values = 0;
         self.num_buffered_rows = 0;
+        self.min_page_value = None;
+        self.max_page_value = None;
+        self.num_page_nulls = 0;
+        self.page_distinct_count = None;
 
         Ok(())
     }
@@ -603,8 +709,9 @@ impl<T: DataType> ColumnWriterImpl<T> {
     #[inline]
     fn flush_data_pages(&mut self) -> Result<()> {
         // Write all outstanding data to a new page.
+        let calculate_page_stats = self.min_page_value.is_some() && self.max_page_value.is_some();
         if self.num_buffered_values > 0 {
-            self.add_data_page()?;
+            self.add_data_page(calculate_page_stats)?;
         }
 
         while let Some(page) = self.data_pages.pop_front() {
@@ -643,6 +750,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
         // We use only RLE level encoding for data page v1 and data page v2.
         encodings.push(Encoding::RLE);
 
+        let statistics = self.make_column_statistics();
         let metadata = ColumnChunkMetaData::builder(self.descr.clone())
             .set_compression(self.codec)
             .set_encodings(encodings)
@@ -652,6 +760,7 @@ impl<T: DataType> ColumnWriterImpl<T> {
             .set_num_values(num_values)
             .set_data_page_offset(data_page_offset)
             .set_dictionary_page_offset(dict_page_offset)
+            .set_statistics(statistics)
             .build()?;
 
         self.page_writer.write_metadata(&metadata)?;
@@ -755,6 +864,32 @@ impl<T: DataType> ColumnWriterImpl<T> {
     fn get_page_writer_ref(&self) -> &Box<PageWriter> {
         &self.page_writer
     }
+
+    fn make_column_statistics(&self) -> Statistics {
+        match self.descr.physical_type() {
+            Type::INT32 => gen_column_stats_section!(self, i32, int32),
+            Type::BOOLEAN => gen_column_stats_section!(self, i32, int32),
+            Type::INT64 => gen_column_stats_section!(self, i64, int64),
+            Type::INT96 => gen_column_stats_section!(self, Int96, int96),
+            Type::FLOAT => gen_column_stats_section!(self, f32, float),
+            Type::DOUBLE => gen_column_stats_section!(self, f64, double),
+            Type::BYTE_ARRAY => gen_column_stats_section!(self, ByteArray, byte_array),
+            Type::FIXED_LEN_BYTE_ARRAY => gen_column_stats_section!(self, ByteArray, fixed_len_byte_array),
+        }
+    }
+
+    fn make_page_statistics(&self) -> Statistics {
+        match self.descr.physical_type() {
+            Type::INT32 => gen_page_stats_section!(self, i32, int32),
+            Type::BOOLEAN => gen_page_stats_section!(self, i32, int32),
+            Type::INT64 => gen_page_stats_section!(self, i64, int64),
+            Type::INT96 => gen_page_stats_section!(self, Int96, int96),
+            Type::FLOAT => gen_page_stats_section!(self, f32, float),
+            Type::DOUBLE => gen_page_stats_section!(self, f64, double),
+            Type::BYTE_ARRAY => gen_page_stats_section!(self, ByteArray, byte_array),
+            Type::FIXED_LEN_BYTE_ARRAY => gen_page_stats_section!(self, ByteArray, fixed_len_byte_array),
+        }
+    }
 }
 
 // ----------------------------------------------------------------------
@@ -846,13 +981,11 @@ impl EncodingWriteSupport for ColumnWriterImpl<FixedLenByteArrayType> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use rand::distributions::uniform::SampleUniform;
 
     use crate::column::{
         page::PageReader,
-        reader::{get_column_reader, get_typed_column_reader, ColumnReaderImpl},
+        reader::{ColumnReaderImpl, get_column_reader, get_typed_column_reader},
     };
     use crate::file::{
         properties::WriterProperties, reader::SerializedPageReader,
@@ -863,6 +996,8 @@ mod tests {
         io::{FileSink, FileSource},
         test_common::{get_temp_file, random_numbers_range},
     };
+
+    use super::*;
 
     #[test]
     fn test_column_writer_inconsistent_def_rep_length() {
@@ -966,9 +1101,7 @@ mod tests {
                 .build(),
         );
         let mut writer = get_test_column_writer::<BoolType>(page_writer, 0, 0, props);
-        writer
-            .write_batch(&[true, false, true, false], None, None)
-            .unwrap();
+        writer.write_batch(&[true, false, true, false], None, None).unwrap();
 
         let (bytes_written, rows_written, metadata) = writer.close().unwrap();
         // PlainEncoder uses bit writer to write boolean values, which all fit into 1
@@ -1255,6 +1388,45 @@ mod tests {
         assert_eq!(metadata.uncompressed_size(), 20);
         assert_eq!(metadata.data_page_offset(), 0);
         assert_eq!(metadata.dictionary_page_offset(), Some(0));
+        if let Some(stats) = metadata.statistics() {
+            assert!(stats.has_min_max_set());
+            assert_eq!(stats.null_count(), 0);
+            assert_eq!(stats.distinct_count(), None);
+            if let Statistics::Int32(stats) = stats {
+                assert_eq!(stats.min(), &1);
+                assert_eq!(stats.max(), &4);
+            } else { assert!(false, "expecting Statistics::Int32"); }
+        } else { assert!(false, "metadata missing statistics"); }
+    }
+
+    #[test]
+    fn test_column_writer_precalculated_statistics() {
+        let page_writer = get_test_page_writer();
+        let props = Rc::new(WriterProperties::builder().build());
+        let mut writer = get_test_column_writer::<Int32Type>(page_writer, 0, 0, props);
+        writer.write_batch_with_statistics(&[1, 2, 3, 4], None, None, &Some(-17), &Some(9000), Some(21), Some(55)).unwrap();
+
+        let (bytes_written, rows_written, metadata) = writer.close().unwrap();
+        assert_eq!(bytes_written, 20);
+        assert_eq!(rows_written, 4);
+        assert_eq!(
+            metadata.encodings(),
+            &vec![Encoding::PLAIN, Encoding::RLE_DICTIONARY, Encoding::RLE]
+        );
+        assert_eq!(metadata.num_values(), 8); // dictionary + value indexes
+        assert_eq!(metadata.compressed_size(), 20);
+        assert_eq!(metadata.uncompressed_size(), 20);
+        assert_eq!(metadata.data_page_offset(), 0);
+        assert_eq!(metadata.dictionary_page_offset(), Some(0));
+        if let Some(stats) = metadata.statistics() {
+            assert!(stats.has_min_max_set());
+            assert_eq!(stats.null_count(), 21);
+            assert_eq!(stats.distinct_count().unwrap_or(0), 55);
+            if let Statistics::Int32(stats) = stats {
+                assert_eq!(stats.min(), &-17);
+                assert_eq!(stats.max(), &9000);
+            } else { assert!(false, "expecting Statistics::Int32"); }
+        } else { assert!(false, "metadata missing statistics"); }
     }
 
     #[test]
@@ -1434,7 +1606,7 @@ mod tests {
                 Compression::UNCOMPRESSED,
                 Int32Type::get_physical_type(),
             )
-            .unwrap(),
+                .unwrap(),
         );
         let mut res = Vec::new();
         while let Some(page) = page_reader.get_next_page().unwrap() {
@@ -1545,7 +1717,7 @@ mod tests {
                 column_metadata.compression(),
                 T::get_physical_type(),
             )
-            .unwrap(),
+                .unwrap(),
         );
         let reader =
             get_test_column_reader::<T>(page_reader, max_def_level, max_rep_level);

--- a/rust/parquet/src/data_type.rs
+++ b/rust/parquet/src/data_type.rs
@@ -623,8 +623,8 @@ impl FromBytes for ByteArray {
     fn from_be_bytes(_bs: Self::Buffer) -> Self {
         unreachable!()
     }
-    fn from_ne_bytes(_bs: Self::Buffer) -> Self {
-        unreachable!()
+    fn from_ne_bytes(bs: Self::Buffer) -> Self {
+        ByteArray::from(bs.to_vec())
     }
 }
 

--- a/rust/parquet/src/data_type.rs
+++ b/rust/parquet/src/data_type.rs
@@ -17,8 +17,9 @@
 
 //! Data types that connect Parquet physical types with their Rust-specific
 //! representations.
-
+use std::cmp::Ordering;
 use std::mem;
+use std::str::from_utf8;
 
 use byteorder::{BigEndian, ByteOrder};
 
@@ -30,11 +31,10 @@ use crate::util::{
     bit_util::{from_ne_slice, FromBytes},
     memory::{ByteBuffer, ByteBufferPtr},
 };
-use std::str::from_utf8;
 
 /// Rust representation for logical type INT96, value is backed by an array of `u32`.
 /// The type only takes 12 bytes, without extra padding.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialOrd)]
 pub struct Int96 {
     value: Option<[u32; 3]>,
 }
@@ -101,6 +101,19 @@ impl From<Vec<u32>> for Int96 {
 #[derive(Clone, Debug)]
 pub struct ByteArray {
     data: Option<ByteBufferPtr>,
+}
+
+impl PartialOrd for ByteArray {
+    fn partial_cmp(&self, other: &ByteArray) -> Option<Ordering> {
+        if self.data.is_some() && other.data.is_some() {
+            if self.len() > other.len() { Some(Ordering::Greater) } else if self.len() < other.len() { Some(Ordering::Less) } else {
+                for (v1, v2) in self.data().iter().zip(other.data().iter()) {
+                    if *v1 > *v2 { return Some(Ordering::Greater); } else if *v1 < *v2 { return Some(Ordering::Less); }
+                }
+                return Some(Ordering::Equal);
+            }
+        } else { None }
+    }
 }
 
 impl ByteArray {
@@ -401,11 +414,12 @@ impl AsBytes for str {
 /// presentation.
 pub trait DataType: 'static {
     type T: std::cmp::PartialEq
-        + std::fmt::Debug
-        + std::default::Default
-        + std::clone::Clone
-        + AsBytes
-        + FromBytes;
+    + std::fmt::Debug
+    + std::default::Default
+    + std::clone::Clone
+    + AsBytes
+    + FromBytes
+    + PartialOrd;
 
     /// Returns Parquet physical type.
     fn get_physical_type() -> Type;
@@ -414,42 +428,41 @@ pub trait DataType: 'static {
     fn get_type_size() -> usize;
 
     fn get_column_reader(column_writer: ColumnReader) -> Option<ColumnReaderImpl<Self>>
-    where
-        Self: Sized;
+        where
+            Self: Sized;
 
     fn get_column_writer(column_writer: ColumnWriter) -> Option<ColumnWriterImpl<Self>>
-    where
-        Self: Sized;
+        where
+            Self: Sized;
 
     fn get_column_writer_ref(
         column_writer: &ColumnWriter,
     ) -> Option<&ColumnWriterImpl<Self>>
-    where
-        Self: Sized;
+        where
+            Self: Sized;
 
     fn get_column_writer_mut(
         column_writer: &mut ColumnWriter,
     ) -> Option<&mut ColumnWriterImpl<Self>>
-    where
-        Self: Sized;
+        where
+            Self: Sized;
 }
 
 // Workaround bug in specialization
 pub trait SliceAsBytesDataType: DataType
-where
-    Self::T: SliceAsBytes,
-{
-}
+    where
+        Self::T: SliceAsBytes,
+{}
 
 impl<T> SliceAsBytesDataType for T
-where
-    T: DataType,
-    <T as DataType>::T: SliceAsBytes,
-{
-}
+    where
+        T: DataType,
+        <T as DataType>::T: SliceAsBytes,
+{}
 
 macro_rules! make_type {
     ($name:ident, $physical_ty:path, $reader_ident: ident, $writer_ident: ident, $native_ty:ty, $size:expr) => {
+        #[derive(Clone)]
         pub struct $name {}
 
         impl DataType for $name {
@@ -689,5 +702,21 @@ mod tests {
         assert!(Decimal::from_i32(222, 5, 2) != Decimal::from_i32(222, 5, 3));
 
         assert!(Decimal::from_i64(222, 5, 2) != Decimal::from_i32(222, 5, 2));
+    }
+
+    #[test]
+    fn test_byte_array_ord() {
+        let ba1 = ByteArray::from(vec![1, 2, 3]);
+        let ba11 = ByteArray::from(vec![1, 2, 3]);
+        let ba2 = ByteArray::from(vec![3, 4]);
+        let ba3 = ByteArray::from(vec![1, 2, 4]);
+        let ba4 = ByteArray::from(vec![]);
+        let ba5 = ByteArray::from(vec![2, 2, 3]);
+
+        assert!(ba1 > ba2);
+        assert!(ba3 > ba1);
+        assert!(ba1 > ba4);
+        assert_eq!(ba1, ba11);
+        assert!(ba5 > ba1);
     }
 }

--- a/rust/parquet/src/data_type.rs
+++ b/rust/parquet/src/data_type.rs
@@ -106,13 +106,23 @@ pub struct ByteArray {
 impl PartialOrd for ByteArray {
     fn partial_cmp(&self, other: &ByteArray) -> Option<Ordering> {
         if self.data.is_some() && other.data.is_some() {
-            if self.len() > other.len() { Some(Ordering::Greater) } else if self.len() < other.len() { Some(Ordering::Less) } else {
+            if self.len() > other.len() {
+                Some(Ordering::Greater)
+            } else if self.len() < other.len() {
+                Some(Ordering::Less)
+            } else {
                 for (v1, v2) in self.data().iter().zip(other.data().iter()) {
-                    if *v1 > *v2 { return Some(Ordering::Greater); } else if *v1 < *v2 { return Some(Ordering::Less); }
+                    if *v1 > *v2 {
+                        return Some(Ordering::Greater);
+                    } else if *v1 < *v2 {
+                        return Some(Ordering::Less);
+                    }
                 }
                 return Some(Ordering::Equal);
             }
-        } else { None }
+        } else {
+            None
+        }
     }
 }
 
@@ -414,12 +424,12 @@ impl AsBytes for str {
 /// presentation.
 pub trait DataType: 'static {
     type T: std::cmp::PartialEq
-    + std::fmt::Debug
-    + std::default::Default
-    + std::clone::Clone
-    + AsBytes
-    + FromBytes
-    + PartialOrd;
+        + std::fmt::Debug
+        + std::default::Default
+        + std::clone::Clone
+        + AsBytes
+        + FromBytes
+        + PartialOrd;
 
     /// Returns Parquet physical type.
     fn get_physical_type() -> Type;
@@ -428,37 +438,39 @@ pub trait DataType: 'static {
     fn get_type_size() -> usize;
 
     fn get_column_reader(column_writer: ColumnReader) -> Option<ColumnReaderImpl<Self>>
-        where
-            Self: Sized;
+    where
+        Self: Sized;
 
     fn get_column_writer(column_writer: ColumnWriter) -> Option<ColumnWriterImpl<Self>>
-        where
-            Self: Sized;
+    where
+        Self: Sized;
 
     fn get_column_writer_ref(
         column_writer: &ColumnWriter,
     ) -> Option<&ColumnWriterImpl<Self>>
-        where
-            Self: Sized;
+    where
+        Self: Sized;
 
     fn get_column_writer_mut(
         column_writer: &mut ColumnWriter,
     ) -> Option<&mut ColumnWriterImpl<Self>>
-        where
-            Self: Sized;
+    where
+        Self: Sized;
 }
 
 // Workaround bug in specialization
 pub trait SliceAsBytesDataType: DataType
-    where
-        Self::T: SliceAsBytes,
-{}
+where
+    Self::T: SliceAsBytes,
+{
+}
 
 impl<T> SliceAsBytesDataType for T
-    where
-        T: DataType,
-        <T as DataType>::T: SliceAsBytes,
-{}
+where
+    T: DataType,
+    <T as DataType>::T: SliceAsBytes,
+{
+}
 
 macro_rules! make_type {
     ($name:ident, $physical_ty:path, $reader_ident: ident, $writer_ident: ident, $native_ty:ty, $size:expr) => {

--- a/rust/parquet/src/file/statistics.rs
+++ b/rust/parquet/src/file/statistics.rs
@@ -630,13 +630,13 @@ mod tests {
                 Some(ByteArray::from(vec![1, 2, 3])),
                 None,
                 0,
-                true
+                true,
             ) != Statistics::fixed_len_byte_array(
                 Some(ByteArray::from(vec![1, 2, 3])),
                 Some(ByteArray::from(vec![1, 2, 3])),
                 None,
                 0,
-                true
+                true,
             )
         );
     }


### PR DESCRIPTION
1. Calculate page and column statistics
2. Use pre-calculated statistics when available to speed-up when writing data from other formats like ORC.