### PR TITLE
ARROW-8535: [Rust] Specify arrow-flight version

### DIFF
--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -267,6 +267,8 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",
                         "+version = \"#{@release_version}\""],
+                        ["-arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@snapshot_version}\" }",
+                        "+arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@release_version}\" }"],
                      ],
                    },
                    {

--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -267,7 +267,7 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",
                         "+version = \"#{@release_version}\""],
-                        ["-arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@snapshot_version}\" }",
+                       ["-arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@snapshot_version}\" }",
                         "+arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@release_version}\" }"],
                      ],
                    },
@@ -467,6 +467,8 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@release_version}\"",
                         "+version = \"#{@next_snapshot_version}\""],
+                       ["-arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@release_version}\" }",
+                        "+arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@next_snapshot_version}\" }"],
                      ],
                    },
                    {

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -49,7 +49,7 @@ packed_simd = { version = "0.3", optional = true }
 chrono = "0.4"
 flatbuffers = "0.6"
 hex = "0.4"
-arrow-flight = { path = "../arrow-flight", optional = true }
+arrow-flight = { path = "../arrow-flight", optional = true, version = "1.0.0-SNAPSHOT" }
 prettytable-rs = { version = "0.8.0", optional = true }
 
 [features]


### PR DESCRIPTION
This is to ensure that Rust users who include the arrow crate from crates.io do not get errors as they would not have the arrow-flight directory