### PR TITLE
ARROW-9163: [C++] Validate UTF8 contents of a StringArray

### DIFF
--- a/cpp/src/arrow/array/array_binary.h
+++ b/cpp/src/arrow/array/array_binary.h
@@ -161,6 +161,11 @@ class ARROW_EXPORT StringArray : public BinaryArray {
               const std::shared_ptr<Buffer>& data,
               const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
               int64_t null_count = kUnknownNullCount, int64_t offset = 0);
+
+  /// \brief Validate that this array contains only valid UTF8 entries
+  ///
+  /// This check is also implied by ValidateFull()
+  Status ValidateUTF8() const;
 };
 
 /// Concrete Array class for large variable-size binary data
@@ -189,6 +194,11 @@ class ARROW_EXPORT LargeStringArray : public LargeBinaryArray {
                    const std::shared_ptr<Buffer>& data,
                    const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
                    int64_t null_count = kUnknownNullCount, int64_t offset = 0);
+
+  /// \brief Validate that this array contains only valid UTF8 entries
+  ///
+  /// This check is also implied by ValidateFull()
+  Status ValidateUTF8() const;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -430,11 +430,17 @@ struct ValidateArrayDataVisitor {
   // Fallback
   Status Visit(const Array& array) { return Status::OK(); }
 
-  Status Visit(const StringArray& array) { return ValidateBinaryArray(array); }
+  Status Visit(const StringArray& array) {
+    RETURN_NOT_OK(ValidateBinaryArray(array));
+    return array.ValidateUTF8();
+  }
+
+  Status Visit(const LargeStringArray& array) {
+    RETURN_NOT_OK(ValidateBinaryArray(array));
+    return array.ValidateUTF8();
+  }
 
   Status Visit(const BinaryArray& array) { return ValidateBinaryArray(array); }
-
-  Status Visit(const LargeStringArray& array) { return ValidateBinaryArray(array); }
 
   Status Visit(const LargeBinaryArray& array) { return ValidateBinaryArray(array); }
 

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -80,7 +80,7 @@ void EnsureLookupTablesFilled() {
 }
 
 template <typename Type, typename Derived>
-struct Utf8Transform {
+struct UTF8Transform {
   using offset_type = typename Type::offset_type;
   using ArrayType = typename TypeTraits<Type>::ArrayType;
 
@@ -88,7 +88,7 @@ struct Utf8Transform {
                         uint8_t* output, offset_type* output_written) {
     uint8_t* output_start = output;
     if (ARROW_PREDICT_FALSE(
-            !arrow::util::Utf8Transform(input, input + input_string_ncodeunits, &output,
+            !arrow::util::UTF8Transform(input, input + input_string_ncodeunits, &output,
                                         Derived::TransformCodepoint))) {
       return false;
     }
@@ -184,7 +184,7 @@ struct Utf8Transform {
 };
 
 template <typename Type>
-struct Utf8Upper : Utf8Transform<Type, Utf8Upper<Type>> {
+struct UTF8Upper : UTF8Transform<Type, UTF8Upper<Type>> {
   inline static uint32_t TransformCodepoint(uint32_t codepoint) {
     return codepoint <= kMaxCodepointLookup ? lut_upper_codepoint[codepoint]
                                             : utf8proc_toupper(codepoint);
@@ -192,7 +192,7 @@ struct Utf8Upper : Utf8Transform<Type, Utf8Upper<Type>> {
 };
 
 template <typename Type>
-struct Utf8Lower : Utf8Transform<Type, Utf8Lower<Type>> {
+struct UTF8Lower : UTF8Transform<Type, UTF8Lower<Type>> {
   static uint32_t TransformCodepoint(uint32_t codepoint) {
     return codepoint <= kMaxCodepointLookup ? lut_lower_codepoint[codepoint]
                                             : utf8proc_tolower(codepoint);
@@ -356,7 +356,7 @@ void MakeUnaryStringBatchKernel(std::string name, FunctionRegistry* registry) {
 #ifdef ARROW_WITH_UTF8PROC
 
 template <template <typename> class Transformer>
-void MakeUnaryStringUtf8TransformKernel(std::string name, FunctionRegistry* registry) {
+void MakeUnaryStringUTF8TransformKernel(std::string name, FunctionRegistry* registry) {
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary());
   ArrayKernelExec exec_32 = Transformer<StringType>::Exec;
   ArrayKernelExec exec_64 = Transformer<LargeStringType>::Exec;
@@ -373,8 +373,8 @@ void RegisterScalarStringAscii(FunctionRegistry* registry) {
   MakeUnaryStringBatchKernel<AsciiUpper>("ascii_upper", registry);
   MakeUnaryStringBatchKernel<AsciiLower>("ascii_lower", registry);
 #ifdef ARROW_WITH_UTF8PROC
-  MakeUnaryStringUtf8TransformKernel<Utf8Upper>("utf8_upper", registry);
-  MakeUnaryStringUtf8TransformKernel<Utf8Lower>("utf8_lower", registry);
+  MakeUnaryStringUTF8TransformKernel<UTF8Upper>("utf8_upper", registry);
+  MakeUnaryStringUTF8TransformKernel<UTF8Lower>("utf8_lower", registry);
 #endif
   AddAsciiLength(registry);
   AddStrptime(registry);

--- a/cpp/src/arrow/csv/converter_test.cc
+++ b/cpp/src/arrow/csv/converter_test.cc
@@ -52,7 +52,8 @@ template <typename DATA_TYPE, typename C_TYPE>
 void AssertConversion(const std::shared_ptr<DataType>& type,
                       const std::vector<std::string>& csv_string,
                       const std::vector<std::vector<C_TYPE>>& expected,
-                      ConvertOptions options = ConvertOptions::Defaults()) {
+                      ConvertOptions options = ConvertOptions::Defaults(),
+                      bool validate_full = true) {
   std::shared_ptr<BlockParser> parser;
   std::shared_ptr<Converter> converter;
   std::shared_ptr<Array> array, expected_array;
@@ -63,7 +64,11 @@ void AssertConversion(const std::shared_ptr<DataType>& type,
   for (int32_t col_index = 0; col_index < static_cast<int32_t>(expected.size());
        ++col_index) {
     ASSERT_OK_AND_ASSIGN(array, converter->Convert(*parser, col_index));
-    ASSERT_OK(array->ValidateFull());
+    if (validate_full) {
+      ASSERT_OK(array->ValidateFull());
+    } else {
+      ASSERT_OK(array->Validate());
+    }
     ArrayFromVector<DATA_TYPE, C_TYPE>(type, expected[col_index], &expected_array);
     AssertArraysEqual(*expected_array, *array);
   }
@@ -115,7 +120,8 @@ void AssertDictConversion(const std::string& csv_string,
                           const std::shared_ptr<Array>& expected_indices,
                           const std::shared_ptr<Array>& expected_dict,
                           int32_t max_cardinality = -1,
-                          ConvertOptions options = ConvertOptions::Defaults()) {
+                          ConvertOptions options = ConvertOptions::Defaults(),
+                          bool validate_full = true) {
   std::shared_ptr<BlockParser> parser;
   std::shared_ptr<DictionaryConverter> converter;
   std::shared_ptr<Array> array, expected_array;
@@ -123,7 +129,11 @@ void AssertDictConversion(const std::string& csv_string,
 
   ASSERT_OK_AND_ASSIGN(
       array, DictConversion(expected_dict->type(), csv_string, max_cardinality, options));
-  ASSERT_OK(array->ValidateFull());
+  if (validate_full) {
+    ASSERT_OK(array->ValidateFull());
+  } else {
+    ASSERT_OK(array->Validate());
+  }
   expected_type = dictionary(expected_indices->type(), expected_dict->type());
   ASSERT_TRUE(array->type()->Equals(*expected_type));
   const auto& dict_array = internal::checked_cast<const DictionaryArray&>(*array);
@@ -193,7 +203,8 @@ static void TestStringConversionBasics() {
   auto options = ConvertOptions::Defaults();
   options.check_utf8 = false;
   AssertConversion<T, std::string>(type, {"ab,cdé\n", ",\xffgh\n"},
-                                   {{"ab", ""}, {"cdé", "\xffgh"}}, options);
+                                   {{"ab", ""}, {"cdé", "\xffgh"}}, options,
+                                   /*validate_full=*/false);
 }
 
 TEST(StringConversion, Basics) { TestStringConversionBasics<StringType>(); }
@@ -485,7 +496,8 @@ TYPED_TEST(TestDictConverter, NonUTF8) {
 
     auto options = ConvertOptions::Defaults();
     options.check_utf8 = false;
-    AssertDictConversion(csv_string, expected_indices, expected_dict, -1, options);
+    AssertDictConversion(csv_string, expected_indices, expected_dict, -1, options,
+                         /*validate_full=*/false);
   } else {
     AssertDictConversion(csv_string, expected_indices, expected_dict);
   }

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -282,7 +282,7 @@ static inline bool Utf8IsContinuation(const uint8_t codeunit) {
   return (codeunit & 0xC0) == 0x80;  // upper two bits should be 10
 }
 
-static inline uint8_t* Utf8Encode(uint8_t* str, uint32_t codepoint) {
+static inline uint8_t* UTF8Encode(uint8_t* str, uint32_t codepoint) {
   if (codepoint < 0x80) {
     *str++ = codepoint;
   } else if (codepoint < 0x800) {
@@ -303,7 +303,7 @@ static inline uint8_t* Utf8Encode(uint8_t* str, uint32_t codepoint) {
   return str;
 }
 
-static inline bool Utf8Decode(const uint8_t** data, uint32_t* codepoint) {
+static inline bool UTF8Decode(const uint8_t** data, uint32_t* codepoint) {
   const uint8_t* str = *data;
   if (*str < 0x80) {  // ascci
     *codepoint = *str++;
@@ -351,16 +351,16 @@ static inline bool Utf8Decode(const uint8_t** data, uint32_t* codepoint) {
 }
 
 template <class UnaryOperation>
-static inline bool Utf8Transform(const uint8_t* first, const uint8_t* last,
+static inline bool UTF8Transform(const uint8_t* first, const uint8_t* last,
                                  uint8_t** destination, UnaryOperation&& unary_op) {
   const uint8_t* i = first;
   uint8_t* out = *destination;
   while (i < last) {
     uint32_t codepoint = 0;
-    if (ARROW_PREDICT_FALSE(!Utf8Decode(&i, &codepoint))) {
+    if (ARROW_PREDICT_FALSE(!UTF8Decode(&i, &codepoint))) {
       return false;
     }
-    out = Utf8Encode(out, unary_op(codepoint));
+    out = UTF8Encode(out, unary_op(codepoint));
   }
   *destination = out;
   return true;

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -563,7 +563,8 @@ class BaseTestCSVRead:
         opts.auto_dict_max_cardinality = 50
         opts.check_utf8 = False
         rows = b"a,b\nab,1\ncd\xff,2\nab,3"
-        table = self.read_bytes(rows, convert_options=opts)
+        table = self.read_bytes(rows, convert_options=opts,
+                                validate_full=False)
         assert table.schema == schema
         dict_values = table['a'].chunk(0).dictionary
         assert len(dict_values) == 2
@@ -809,21 +810,21 @@ class BaseTestCSVRead:
 
 class TestSerialCSVRead(BaseTestCSVRead, unittest.TestCase):
 
-    def read_csv(self, *args, **kwargs):
+    def read_csv(self, *args, validate_full=True, **kwargs):
         read_options = kwargs.setdefault('read_options', ReadOptions())
         read_options.use_threads = False
         table = read_csv(*args, **kwargs)
-        table.validate(full=True)
+        table.validate(full=validate_full)
         return table
 
 
 class TestParallelCSVRead(BaseTestCSVRead, unittest.TestCase):
 
-    def read_csv(self, *args, **kwargs):
+    def read_csv(self, *args, validate_full=True, **kwargs):
         read_options = kwargs.setdefault('read_options', ReadOptions())
         read_options.use_threads = True
         table = read_csv(*args, **kwargs)
-        table.validate(full=True)
+        table.validate(full=validate_full)
         return table
 
 


### PR DESCRIPTION
* Add a ValidateUTF8() method to StringArray and LargeStringArray
* Automatically call ValidateUTF8() when ValidateFull() is called on
  one of those types