### PR TITLE
ARROW-9284: [Java] fix getMinorTypeForArrowType with dense unions

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/Types.java
@@ -809,7 +809,14 @@ public class Types {
 
       @Override
       public MinorType visit(Union type) {
-        return MinorType.UNION;
+        switch (type.getMode()) {
+          case Sparse:
+            return MinorType.UNION;
+          case Dense:
+            return MinorType.DENSEUNION;
+          default:
+            throw new IllegalArgumentException("Unknown union mode: " + type.getMode());
+        }
       }
 
       @Override


### PR DESCRIPTION
We added a new minor type but didn't adjust the type -> minor type mapping. 