### PR TITLE
ARROW-4390: [R] Serialize "labeled" metadata in Feather files, IPC messages

### DIFF
--- a/r/tests/testthat/helper-data.R
+++ b/r/tests/testthat/helper-data.R
@@ -40,3 +40,18 @@ example_with_metadata <- tibble::tibble(
 #   field_one = 12,
 #   field_two = "more stuff"
 # )
+
+haven_data <- tibble::tibble(
+  num = structure(c(5.1, 4.9),
+    format.spss = "F8.2"
+  ),
+  cat_int = structure(c(3, 1),
+    format.spss = "F8.0",
+    labels = c(first = 1, second = 2, third = 3),
+    class = c("haven_labelled", "vctrs_vctr", "double")
+  ),
+  cat_chr = structure(c("B", "B"),
+    labels = c(Alpha = "A", Beta = "B"),
+    class = c("haven_labelled", "vctrs_vctr", "character")
+  )
+)

--- a/r/tests/testthat/test-feather.R
+++ b/r/tests/testthat/test-feather.R
@@ -193,4 +193,12 @@ test_that("R metadata roundtrip via feather", {
   expect_identical(read_feather(tf), example_with_metadata)
 })
 
+test_that("haven types roundtrip via feather", {
+  tf <- tempfile()
+  on.exit(unlink(tf))
+
+  write_feather(haven_data, tf)
+  expect_identical(read_feather(tf), haven_data)
+})
+
 unlink(feather_file)


### PR DESCRIPTION
The work for this was done in ARROW-8899; this just adds a test confirming the expected behavior on types created by the `haven` package.