### PR TITLE
ARROW-9223: [Python] Propagate timezone information in pandas conversion

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -17,9 +17,8 @@
 
 // Functions for pandas conversion via NumPy
 
-#include "arrow/python/numpy_interop.h"  // IWYU pragma: expand
-
 #include "arrow/python/arrow_to_pandas.h"
+#include "arrow/python/numpy_interop.h"  // IWYU pragma: expand
 
 #include <cmath>
 #include <cstdint>
@@ -642,15 +641,15 @@ inline Status ConvertStruct(const PandasOptions& options, const ChunkedArray& da
   std::vector<OwnedRef> fields_data(num_fields);
   OwnedRef dict_item;
 
-  // XXX(wesm): In ARROW-7723, we found as a result of ARROW-3789 that second
+  // In ARROW-7723, we found as a result of ARROW-3789 that second
   // through microsecond resolution tz-aware timestamps were being promoted to
   // use the DATETIME_NANO_TZ conversion path, yielding a datetime64[ns] NumPy
   // array in this function. PyArray_GETITEM returns datetime.datetime for
   // units second through microsecond but PyLong for nanosecond (because
-  // datetime.datetime does not support nanoseconds). We inserted this hack to
-  // preserve the <= 0.15.1 behavior until a better solution can be devised
+  // datetime.datetime does not support nanoseconds).
+  // We force the object conversion to preserve the value of the timezone.
   PandasOptions modified_options = options;
-  modified_options.ignore_timezone = true;
+  modified_options.timestamp_as_object = true;
   modified_options.coerce_temporal_nanoseconds = false;
 
   for (int c = 0; c < data.num_chunks(); c++) {
@@ -951,8 +950,21 @@ struct ObjectWriterVisitor {
   template <typename Type>
   enable_if_timestamp<Type, Status> Visit(const Type& type) {
     const TimeUnit::type unit = type.unit();
-    auto WrapValue = [unit](typename Type::c_type value, PyObject** out) {
+    PyObject* tzinfo = nullptr;
+    if (!type.timezone().empty()) {
+      RETURN_NOT_OK(internal::StringToTzinfo(type.timezone(), &tzinfo));
+    }
+    auto WrapValue = [unit, tzinfo](typename Type::c_type value, PyObject** out) {
+      OwnedRef tz(tzinfo);
       RETURN_NOT_OK(internal::PyDateTime_from_int(value, unit, out));
+      RETURN_IF_PYERROR();
+      if (tzinfo != nullptr) {
+        PyObject* with_tz = PyObject_CallMethod(*out, "astimezone", "O", tzinfo);
+        RETURN_IF_PYERROR();
+        Py_DECREF(*out);
+        *out = with_tz;
+      }
+
       RETURN_IF_PYERROR();
       return Status::OK();
     };
@@ -1721,8 +1733,7 @@ static Status GetPandasWriterType(const ChunkedArray& data, const PandasOptions&
         // Nanoseconds are never out of bounds for pandas, so in that case
         // we don't convert to object
         *output_type = PandasWriter::OBJECT;
-      } else if (ts_type.timezone() != "" && !options.ignore_timezone) {
-        // XXX: ignore_timezone: hack here for ARROW-7723
+      } else if (!ts_type.timezone().empty()) {
         *output_type = PandasWriter::DATETIME_NANO_TZ;
       } else if (options.coerce_temporal_nanoseconds) {
         *output_type = PandasWriter::DATETIME_NANO;

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -650,17 +650,14 @@ inline Status ConvertStruct(const PandasOptions& options, const ChunkedArray& da
   // We force the object conversion to preserve the value of the timezone.
   PandasOptions modified_options = options;
   modified_options.coerce_temporal_nanoseconds = false;
+  modified_options.timestamp_as_object = true;
 
   for (int c = 0; c < data.num_chunks(); c++) {
     auto arr = checked_cast<const StructArray*>(data.chunk(c).get());
     // Convert the struct arrays first
     for (int32_t i = 0; i < num_fields; i++) {
-      // Se notes above about conversion.
-      std::shared_ptr<Array> field = arr->field(static_cast<int>(i));
-      modified_options.timestamp_as_object =
-          field->type()->id() == Type::TIMESTAMP &&
-          !checked_cast<const TimestampType&>(*field->type()).timezone().empty();
       PyObject* numpy_array;
+      std::shared_ptr<Array> field = arr->field(static_cast<int>(i));
       RETURN_NOT_OK(ConvertArrayToPandas(modified_options, field, nullptr, &numpy_array));
       fields_data[i].reset(numpy_array);
     }

--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -744,6 +744,7 @@ Status ConvertListsLike(const PandasOptions& options, const ChunkedArray& data,
   // nanoseconds. Bit of a hack but this seemed the simplest thing to satisfy
   // the existing unit tests
   PandasOptions modified_options = options;
+  // Force object converation here as well for timestamps?
   modified_options.coerce_temporal_nanoseconds = false;
 
   OwnedRefNoGIL owned_numpy_array;

--- a/cpp/src/arrow/python/arrow_to_pandas.h
+++ b/cpp/src/arrow/python/arrow_to_pandas.h
@@ -56,10 +56,6 @@ struct PandasOptions {
   /// Coerce all date and timestamp to datetime64[ns]
   bool coerce_temporal_nanoseconds = false;
 
-  /// XXX(wesm): Hack for ARROW-7723 to opt out of DATETIME_NANO_TZ conversion
-  /// path
-  bool ignore_timezone = false;
-
   /// \brief If true, do not create duplicate PyObject versions of equal
   /// objects. This only applies to immutable objects like strings or datetime
   /// objects

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -272,7 +272,7 @@ Status StringToTzinfo(const std::string& tz, PyObject** tzinfo) {
   RETURN_NOT_OK(internal::ImportModule("pytz", &pytz));
 
   std::cmatch match;
-  if (std::regex_match(tz.c_str(), match, kFixedOffset)) {
+  if (std::regex_match(tz.data(), tz.data() + tz.size(), match, kFixedOffset)) {
     int sign = -1;
     if (match.str(1) == "+") {
       sign = 1;

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -34,6 +34,9 @@ namespace internal {
 
 namespace {
 
+// Same as Regex '([+-])(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])$'.
+// GCC 4.9 doesn't support regex, so handcode until support for it
+// is dropped.
 bool MatchFixedOffset(const std::string& tz, util::string_view* sign,
                       util::string_view* hour, util::string_view* minute) {
   if (tz.size() < 5) {
@@ -303,6 +306,8 @@ int64_t PyDate_to_days(PyDateTime_Date* pydate) {
 }
 
 // GIL must be held when calling this function.
+// Converted from python.  See https://github.com/apache/arrow/pull/7604
+// for details.
 Status StringToTzinfo(const std::string& tz, PyObject** tzinfo) {
   util::string_view sign_str, hour_str, minute_str;
   OwnedRef pytz;

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -282,7 +282,7 @@ Status StringToTzinfo(const std::string& tz, PyObject** tzinfo) {
     uint32_t minutes, hours;
     if (!::arrow::internal::ParseUnsigned(match[2].first, match[2].length(), &hours) ||
         !::arrow::internal::ParseUnsigned(match[3].first, match[3].length(), &minutes)) {
-      return Status::Invalid("Invalid timezone: ", timezone);
+      return Status::Invalid("Invalid timezone: ", tz);
     }
     OwnedRef total_minutes(PyLong_FromLong(
         sign * ((static_cast<int>(hours) * 60) + static_cast<int>(minutes))));

--- a/cpp/src/arrow/python/datetime.h
+++ b/cpp/src/arrow/python/datetime.h
@@ -157,6 +157,17 @@ inline int64_t PyDelta_to_ns(PyDateTime_Delta* pytimedelta) {
   return PyDelta_to_us(pytimedelta) * 1000;
 }
 
+/// \brief Convert a time zone name into a time zone object.
+///
+/// Supported input strings are:
+///  * As used in the Olson time zone database (the "tz database" or
+///   "tzdata"), such as "America/New_York"
+/// * An absolute time zone offset of the form +XX:XX or -XX:XX, such as +07:30
+
+// GIL must be held when calling this method.
+ARROW_PYTHON_EXPORT
+Status StringToTzinfo(const std::string& tz, PyObject** tzinfo);
+
 }  // namespace internal
 }  // namespace py
 }  // namespace arrow

--- a/cpp/src/arrow/python/datetime.h
+++ b/cpp/src/arrow/python/datetime.h
@@ -163,8 +163,7 @@ inline int64_t PyDelta_to_ns(PyDateTime_Delta* pytimedelta) {
 ///  * As used in the Olson time zone database (the "tz database" or
 ///   "tzdata"), such as "America/New_York"
 /// * An absolute time zone offset of the form +XX:XX or -XX:XX, such as +07:30
-
-// GIL must be held when calling this method.
+/// GIL must be held when calling this method.
 ARROW_PYTHON_EXPORT
 Status StringToTzinfo(const std::string& tz, PyObject** tzinfo);
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1174,7 +1174,9 @@ cdef _array_like_to_pandas(obj, options):
     result = pandas_api.series(arr, dtype=dtype, name=name)
 
     if (isinstance(original_type, TimestampType) and
-            original_type.tz is not None):
+            original_type.tz is not None and
+            # can be object dtype for non-ns and timestamp_as_object=True
+            result.dtype.kind == "M"):
         from pyarrow.pandas_compat import make_tz_aware
         result = make_tz_aware(result, original_type.tz)
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1819,6 +1819,7 @@ cdef extern from "arrow/python/api.h" namespace "arrow::py::internal" nogil:
     int64_t TimePoint_to_ns(CTimePoint val)
     CTimePoint TimePoint_from_s(double val)
     CTimePoint TimePoint_from_ns(int64_t val)
+    CStatus StringToTzinfo(c_string, PyObject** tzinfo)
 
 
 cdef extern from 'arrow/python/init.h':

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3336,20 +3336,28 @@ def test_struct_with_timestamp_tz():
 
         result = arr3.to_pandas()
         assert isinstance(result[0]['start'], datetime)
+        assert result[0]['start'].tzinfo is None
         assert isinstance(result[0]['stop'], datetime)
+        assert result[0]['stop'].tzinfo is None
 
         result = arr4.to_pandas()
         assert isinstance(result[0]['start'], datetime)
+        assert result[0]['start'].tzinfo is not None
         assert isinstance(result[0]['stop'], datetime)
+        assert result[0]['start'].tzinfo is not None
 
         # same conversion for table
         result = pa.table({'a': arr3}).to_pandas()
         assert isinstance(result['a'][0]['start'], datetime)
+        assert result['a'][0]['start'].tzinfo is None
         assert isinstance(result['a'][0]['stop'], datetime)
+        assert result['a'][0]['start'].tzinfo is None
 
         result = pa.table({'a': arr4}).to_pandas()
         assert isinstance(result['a'][0]['start'], datetime)
+        assert result['a'][0]['start'].tzinfo is not None
         assert isinstance(result['a'][0]['stop'], datetime)
+        assert result['a'][0]['start'].tzinfo is not None
 
 
 # ----------------------------------------------------------------------

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3335,19 +3335,13 @@ def test_nested_with_timestamp_tz():
         arr2 = pa.array([ts], type=pa.timestamp(unit, tz='America/New_York'))
 
         arr3 = pa.StructArray.from_arrays([arr, arr], ['start', 'stop'])
-        list_arr3 = pa.ListArray.from_arrays([0, 1], arr)
         arr4 = pa.StructArray.from_arrays([arr2, arr2], ['start', 'stop'])
-        list_arr4 = pa.ListArray.from_arrays([0, 1], arr2)
 
         result = arr3.to_pandas()
         assert isinstance(result[0]['start'], datetime)
         assert result[0]['start'].tzinfo is None
         assert isinstance(result[0]['stop'], datetime)
         assert result[0]['stop'].tzinfo is None
-
-        result = list_arr3.to_pandas()
-        assert isinstance(result[0][0], datetime)
-        assert result[0][0].tzinfo is None
 
         result = arr4.to_pandas()
         assert isinstance(result[0]['start'], datetime)
@@ -3357,28 +3351,18 @@ def test_nested_with_timestamp_tz():
         assert isinstance(result[0]['stop'], datetime)
         assert result[0]['stop'].tzinfo is not None
 
-        result = list_arr4.to_pandas()
-        assert isinstance(result[0][0], datetime)
-        utc_dt = result[0][0].astimezone(timezone.utc)
-        assert utc_dt.replace(tzinfo=None, microsecond=0) == ts_dt
-        assert result[0][0].tzinfo is not None
-
         # same conversion for table
-        result = pa.table({'a': arr3, 'b': list_arr3}).to_pandas()
+        result = pa.table({'a': arr3}).to_pandas()
         assert isinstance(result['a'][0]['start'], datetime)
         assert result['a'][0]['start'].tzinfo is None
         assert isinstance(result['a'][0]['stop'], datetime)
         assert result['a'][0]['stop'].tzinfo is None
-        assert isinstance(result['b'][0][0], datetime)
-        assert result['b'][0][0].tzinfo is None
 
-        result = pa.table({'a': arr4, 'b': list_arr4}).to_pandas()
+        result = pa.table({'a': arr4}).to_pandas()
         assert isinstance(result['a'][0]['start'], datetime)
         assert result['a'][0]['start'].tzinfo is not None
         assert isinstance(result['a'][0]['stop'], datetime)
         assert result['a'][0]['stop'].tzinfo is not None
-        assert isinstance(result['b'][0][0], datetime)
-        assert result['b'][0][0].tzinfo is not None
 
 
 # ----------------------------------------------------------------------

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4044,6 +4044,8 @@ def test_timestamp_as_object_non_nanosecond(resolution, tz, dt):
         assert isinstance(result[0], datetime)
         if tz:
             assert result[0].tzinfo is not None
+            expected = result[0].tzinfo.fromutc(dt)
         else:
             assert result[0].tzinfo is None
-        assert result[0] == dt
+            expected = dt
+        assert result[0] == expected

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3332,9 +3332,9 @@ def test_nested_with_timestamp_tz():
         if unit in ['s', 'ms']:
             # This is used for verifying timezone conversion to micros are not
             # important
-            truncate = lambda x: x.replace(microsecond=0)
+            def truncate(x): return x.replace(microsecond=0)
         else:
-            truncate = lambda x: x
+            def truncate(x): return x
         arr = pa.array([ts], type=pa.timestamp(unit))
         arr2 = pa.array([ts], type=pa.timestamp(unit, tz='America/New_York'))
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3324,14 +3324,14 @@ def test_cast_timestamp_unit():
 def test_nested_with_timestamp_tz():
     # ARROW-7723
     ts = pd.Timestamp.now()
-    # This is used for verifying timezone conversion to micros are not
-    # important
     ts_dt = ts.to_pydatetime()
 
     # XXX: Ensure that this data does not get promoted to nanoseconds (and thus
     # integers) to preserve behavior in 0.15.1
     for unit in ['s', 'ms', 'us']:
         if unit in ['s', 'ms']:
+            # This is used for verifying timezone conversion to micros are not
+            # important
             truncate = lambda x: x.replace(microsecond=0)
         else:
             truncate = lambda x: x

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1816,9 +1816,6 @@ cdef timeunit_to_string(TimeUnit unit):
         return 'ns'
 
 
-_FIXED_OFFSET_RE = re.compile(r'([+-])(0[0-9]|1[0-9]|2[0-3]):([0-5][0-9])$')
-
-
 def tzinfo_to_string(tz):
     """
     Converts a time zone object into a string indicating the name of a time

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1884,15 +1884,9 @@ def string_to_tzinfo(name):
       tz : datetime.tzinfo
         Time zone object
     """
-    import pytz
-    m = _FIXED_OFFSET_RE.match(name)
-    if m:
-        sign = 1 if m.group(1) == '+' else -1
-        hours, minutes = map(int, m.group(2, 3))
-        return pytz.FixedOffset(sign * (hours * 60 + minutes))
-    else:
-        return pytz.timezone(name)
-
+    cdef PyObject* tz
+    check_status(libarrow.StringToTzinfo(name.encode('utf-8'), &tz))
+    return PyObject_to_object(tz)
 
 def timestamp(unit, tz=None):
     """

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1885,6 +1885,7 @@ def string_to_tzinfo(name):
     check_status(libarrow.StringToTzinfo(name.encode('utf-8'), &tz))
     return PyObject_to_object(tz)
 
+
 def timestamp(unit, tz=None):
     """
     Create instance of timestamp type with resolution and optional time zone.


### PR DESCRIPTION
- Ports string_to_timezone to C++
- Causes nested timestamp columns within structs that have timezones to go through
  object conversion
- Copy timezone on to_object path.

Open to other suggestions on how to solve this.  It still seems like this is inconsistent with nested timestamps in lists which isn't great.