### PR TITLE
ARROW-8434: [C++] Avoid multiple schema deserializations in RecordBatchFileReader

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -863,8 +863,8 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
 
     CHECK_HAS_BODY(*message);
     ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));
-    return ::arrow::ipc::ReadRecordBatch(*message->metadata(), schema_, &dictionary_memo_,
-                                         options_, reader.get());
+    return ReadRecordBatchInternal(*message->metadata(), schema_, field_inclusion_mask_,
+                                   &dictionary_memo_, options_, reader.get());
   }
 
   Status Open(const std::shared_ptr<io::RandomAccessFile>& file, int64_t footer_offset,

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -107,7 +107,7 @@ Result<std::shared_ptr<RecordBatchWriter>> NewStreamWriter(
 /// \param[in] schema the schema of the record batches to be written
 /// \param[in] options options for serialization, optional
 /// \param[in] metadata custom metadata for File Footer, optional
-/// \return Status
+/// \return Result<std::shared_ptr<RecordBatchWriter>>
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatchWriter>> NewFileWriter(
     io::OutputStream* sink, const std::shared_ptr<Schema>& schema,


### PR DESCRIPTION
This doesn't seem to make a difference in the included benchmark.