### PR TITLE
ARROW-9013: [C++] Validate CMake options

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,6 +18,37 @@
 cmake_minimum_required(VERSION 3.2)
 message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 
+cmake_policy(SET CMP0025 NEW)
+# IN_LIST if() operator
+cmake_policy(SET CMP0057 NEW)
+
+# Compatibility with CMake 3.1
+if(POLICY CMP0054)
+  # http://www.cmake.org/cmake/help/v3.1/policy/CMP0054.html
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
+if(POLICY CMP0068)
+  # https://cmake.org/cmake/help/v3.9/policy/CMP0068.html
+  cmake_policy(SET CMP0068 NEW)
+endif()
+
+# don't ignore <PackageName>_ROOT variables in find_package
+if(POLICY CMP0074)
+  # https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
+# Adapted from Apache Kudu: https://github.com/apache/kudu/commit/bd549e13743a51013585
+# Honor visibility properties for all target types. See
+# "cmake --help-policy CMP0063" for details.
+#
+# This policy was only added to cmake in version 3.3, so until the cmake in
+# thirdparty is updated, we must check if the policy exists before setting it.
+if(POLICY CMP0063)
+  cmake_policy(SET CMP0063 NEW)
+endif()
+
 set(ARROW_VERSION "1.0.0-SNAPSHOT")
 
 string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" ARROW_BASE_VERSION "${ARROW_VERSION}")
@@ -67,25 +98,6 @@ include(ExternalProject)
 include(FindPkgConfig)
 
 include(GNUInstallDirs)
-
-cmake_policy(SET CMP0025 NEW)
-
-# Compatibility with CMake 3.1
-if(POLICY CMP0054)
-  # http://www.cmake.org/cmake/help/v3.1/policy/CMP0054.html
-  cmake_policy(SET CMP0054 NEW)
-endif()
-
-if(POLICY CMP0068)
-  # https://cmake.org/cmake/help/v3.9/policy/CMP0068.html
-  cmake_policy(SET CMP0068 NEW)
-endif()
-
-# don't ignore <PackageName>_ROOT variables in find_package
-if(POLICY CMP0074)
-  # https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
-  cmake_policy(SET CMP0074 NEW)
-endif()
 
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 
@@ -508,16 +520,6 @@ include_directories(src/generated)
 # For generate_export_header() and add_compiler_export_flags().
 include(GenerateExportHeader)
 
-# Adapted from Apache Kudu: https://github.com/apache/kudu/commit/bd549e13743a51013585
-# Honor visibility properties for all target types. See
-# "cmake --help-policy CMP0063" for details.
-#
-# This policy was only added to cmake in version 3.3, so until the cmake in
-# thirdparty is updated, we must check if the policy exists before setting it.
-if(POLICY CMP0063)
-  cmake_policy(SET CMP0063 NEW)
-endif()
-
 if(PARQUET_BUILD_SHARED)
   if(POLICY CMP0063)
     set_target_properties(arrow_shared
@@ -867,6 +869,11 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/../LICENSE.txt
               ${CMAKE_CURRENT_SOURCE_DIR}/README.md
         DESTINATION "${ARROW_DOC_DIR}")
 
+#
+# Validate and print out Arrow configuration options
+#
+
+validate_config()
 config_summary_message()
 if(${ARROW_BUILD_CONFIG_SUMMARY_JSON})
   config_summary_json()

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -18,13 +18,18 @@
 cmake_minimum_required(VERSION 3.2)
 message(STATUS "Building using CMake version: ${CMAKE_VERSION}")
 
+# Compiler id for Apple Clang is now AppleClang.
 cmake_policy(SET CMP0025 NEW)
+
 # IN_LIST if() operator
-cmake_policy(SET CMP0057 NEW)
+if(POLICY CMP0057)
+  cmake_policy(SET CMP0057 NEW)
+endif()
 
 # Compatibility with CMake 3.1
+# Only interpret if() arguments as variables or keywords when unquoted.
 if(POLICY CMP0054)
-  # http://www.cmake.org/cmake/help/v3.1/policy/CMP0054.html
+  # https://www.cmake.org/cmake/help/v3.1/policy/CMP0054.html
   cmake_policy(SET CMP0054 NEW)
 endif()
 
@@ -33,7 +38,7 @@ if(POLICY CMP0068)
   cmake_policy(SET CMP0068 NEW)
 endif()
 
-# don't ignore <PackageName>_ROOT variables in find_package
+# Don't ignore <PackageName>_ROOT variables in find_package
 if(POLICY CMP0074)
   # https://cmake.org/cmake/help/v3.12/policy/CMP0074.html
   cmake_policy(SET CMP0074 NEW)

--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -67,11 +67,11 @@ macro(define_option_string name description default)
   set("${name}_OPTION_DESCRIPTION" ${description})
   set("${name}_OPTION_DEFAULT" "\"${default}\"")
   set("${name}_OPTION_TYPE" "string")
-  set("${name}_OPTION_ENUM" ${ARGN})
+  set("${name}_OPTION_POSSIBLE_VALUES" ${ARGN})
 
-  list_join("${name}_OPTION_ENUM" "|" "${name}_OPTION_ENUM")
+  list_join("${name}_OPTION_POSSIBLE_VALUES" "|" "${name}_OPTION_ENUM")
   if(NOT ("${${name}_OPTION_ENUM}" STREQUAL ""))
-    set_property(CACHE ${name} PROPERTY STRINGS ${ARGN})
+    set_property(CACHE ${name} PROPERTY STRINGS "${name}_OPTION_POSSIBLE_VALUES")
   endif()
 endmacro()
 
@@ -389,6 +389,25 @@ that have not been built" OFF)
   option(ARROW_BUILD_CONFIG_SUMMARY_JSON "Summarize build configuration in a JSON file"
          ON)
 endif()
+
+macro(validate_config)
+  foreach(category ${ARROW_OPTION_CATEGORIES})
+    set(option_names ${ARROW_${category}_OPTION_NAMES})
+
+    foreach(name ${option_names})
+      set(possible_values ${${name}_OPTION_POSSIBLE_VALUES})
+      set(value "${${name}}")
+      if(possible_values)
+        if(NOT ("${value}" IN_LIST possible_values))
+          message(
+            FATAL_ERROR "Configuration option ${name} got invalid value '${value}'. "
+                        "Allowed values: ${${name}_OPTION_ENUM}.")
+        endif()
+      endif()
+    endforeach()
+
+  endforeach()
+endmacro()
 
 macro(config_summary_message)
   message(STATUS "---------------------------------------------------------------------")

--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -398,7 +398,8 @@ macro(validate_config)
       set(possible_values ${${name}_OPTION_POSSIBLE_VALUES})
       set(value "${${name}}")
       if(possible_values)
-        if(NOT ("${value}" IN_LIST possible_values))
+        if(NOT CMAKE_VERSION VERSION_LESS "3.3"
+           AND NOT ("${value}" IN_LIST possible_values))
           message(
             FATAL_ERROR "Configuration option ${name} got invalid value '${value}'. "
                         "Allowed values: ${${name}_OPTION_ENUM}.")


### PR DESCRIPTION
Disallow passing invalid values to enum-style CMake options
(such as `-DARROW_SIMD_LEVEL=xyzzy`)