### PR TITLE
ARROW-9315: [Java] Fix the failure of testAllocationManagerType

### DIFF
--- a/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/BaseAllocator.java
@@ -716,7 +716,7 @@ abstract class BaseAllocator extends Accountant implements BufferAllocator {
      */
     @Value.Default
     AllocationManager.Factory getAllocationManagerFactory() {
-      return DefaultAllocationManagerOption.DEFAULT_ALLOCATION_MANAGER_FACTORY;
+      return DefaultAllocationManagerOption.getDefaultAllocationManagerFactory();
     }
 
     /**

--- a/java/memory/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerOption.java
+++ b/java/memory/src/main/java/org/apache/arrow/memory/DefaultAllocationManagerOption.java
@@ -39,8 +39,7 @@ public class DefaultAllocationManagerOption {
   /**
    * The default allocation manager factory.
    */
-  public static final AllocationManager.Factory DEFAULT_ALLOCATION_MANAGER_FACTORY =
-      getDefaultAllocationManagerFactory();
+  private static AllocationManager.Factory DEFAULT_ALLOCATION_MANAGER_FACTORY = null;
 
   /**
    * The allocation manager type.
@@ -83,19 +82,25 @@ public class DefaultAllocationManagerOption {
   }
 
   static AllocationManager.Factory getDefaultAllocationManagerFactory() {
+    if (DEFAULT_ALLOCATION_MANAGER_FACTORY != null) {
+      return DEFAULT_ALLOCATION_MANAGER_FACTORY;
+    }
     AllocationManagerType type = getDefaultAllocationManagerType();
-
     switch (type) {
       case Netty:
-        return getNettyFactory();
+        DEFAULT_ALLOCATION_MANAGER_FACTORY = getNettyFactory();
+        break;
       case Unsafe:
-        return getUnsafeFactory();
+        DEFAULT_ALLOCATION_MANAGER_FACTORY = getUnsafeFactory();
+        break;
       case Unknown:
         LOGGER.info("allocation manager type not specified, using netty as the default type");
-        return getFactory(CheckAllocator.check());
+        DEFAULT_ALLOCATION_MANAGER_FACTORY = getFactory(CheckAllocator.check());
+        break;
       default:
         throw new IllegalStateException("Unknown allocation manager type: " + type);
     }
+    return DEFAULT_ALLOCATION_MANAGER_FACTORY;
   }
 
   private static AllocationManager.Factory getFactory(String clazzName) {


### PR DESCRIPTION
The problem was caused by a cyclic dependency of class loading. 

Please see the discussion in the jira:
https://issues.apache.org/jira/browse/ARROW-9315

We solve it by making DefaultAllocationManagerOption#DEFAULT_ALLOCATION_MANAGER_FACTORY initialize lazily. 