### PR TITLE
ARROW-9326: [Python][TRIAGE] Pin to setuptools version prior to distutils-related changes on July 3

### DIFF
--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,5 +1,5 @@
 cython>=0.29
 numpy>=1.14,<1.19; python_version < "3.6"
 numpy>=1.14; python_version >= "3.6"
-setuptools==47.3.2
+setuptools==47.3.2; python_version >= "3.6"
 setuptools_scm

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,4 +1,5 @@
 cython>=0.29
 numpy>=1.14,<1.19; python_version < "3.6"
 numpy>=1.14; python_version >= "3.6"
+setuptools==47.3.2
 setuptools_scm


### PR DESCRIPTION
Until setuptools stabilizes we should pin the version we depend on. 