### PR TITLE
ARROW-9326: [FOLLOWUP] Use requirements-build.txt exclusively for installing setuptools

### DIFF
--- a/ci/docker/linux-apt-python-3.dockerfile
+++ b/ci/docker/linux-apt-python-3.dockerfile
@@ -35,8 +35,7 @@ COPY python/requirements-build.txt \
 
 RUN pip install \
     -r arrow/python/requirements-build.txt \
-    -r arrow/python/requirements-test.txt \
-    setuptools
+    -r arrow/python/requirements-test.txt
 
 ENV ARROW_PYTHON=ON \
     ARROW_BUILD_STATIC=OFF \


### PR DESCRIPTION
see https://github.com/apache/arrow/pull/7636#issuecomment-653938188