### PR TITLE
ARROW-9327: [Rust] Fix all clippy errors for arrow crate

### DIFF
--- a/ci/scripts/rust_lint.sh
+++ b/ci/scripts/rust_lint.sh
@@ -21,21 +21,6 @@ set -e
 
 source_dir=${1}/rust
 
-pushd ${source_dir}
-    max_error_cnt=3
-    max_warn_cnt=9
-
-    error_msg=$(cargo clippy -- -A clippy::redundant_field_names 2>&1 | grep 'error: aborting due to')
-
-    error_cnt=$(echo "${error_msg}" | awk '{print $5}')
-    [[ ${error_cnt} -gt ${max_error_cnt} ]] && {
-        echo "More clippy errors introduced, got: ${error_cnt}, was: ${max_error_cnt}"
-        exit 1
-    }
-
-    warn_cnt=$(echo "${error_msg}" | awk '{print $8}')
-    [[ ${warn_cnt} -gt ${max_warn_cnt} ]] && {
-        echo "More clippy warnings introduced, got: ${warn_cnt}, was: ${max_warn_cnt}"
-        exit 1
-    }
+pushd ${source_dir}/arrow
+    cargo clippy -- -A clippy::redundant_field_names
 popd

--- a/rust/arrow-flight/build.rs
+++ b/rust/arrow-flight/build.rs
@@ -45,8 +45,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .write(true)
             .truncate(true)
             .open("src/arrow.flight.protocol.rs")?;
-        file.write("// This file was automatically generated through the build.rs script, and should not be edited.\n\n".as_bytes())?;
-        file.write(buffer.as_bytes())?;
+        file.write_all("// This file was automatically generated through the build.rs script, and should not be edited.\n\n".as_bytes())?;
+        file.write_all(buffer.as_bytes())?;
     }
 
     // As the proto file is checked in, the build should not fail if the file is not found

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -135,6 +135,20 @@ pub trait BufferBuilderTrait<T: ArrowPrimitiveType> {
     /// ```
     fn len(&self) -> usize;
 
+    /// Returns whether the internal buffer is empty.
+    ///
+    /// # Example:
+    ///
+    /// ```
+    /// use arrow::array::{UInt8BufferBuilder, BufferBuilderTrait};
+    ///
+    /// let mut builder = UInt8BufferBuilder::new(10);
+    /// builder.append(42);
+    ///
+    /// assert_eq!(builder.is_empty(), false);
+    /// ```
+    fn is_empty(&self) -> bool;
+
     /// Returns the actual capacity (number of elements) of the internal buffer.
     ///
     /// Note: the internal capacity returned by this method might be larger than
@@ -248,6 +262,10 @@ impl<T: ArrowPrimitiveType> BufferBuilderTrait<T> for BufferBuilder<T> {
 
     fn len(&self) -> usize {
         self.len
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     fn capacity(&self) -> usize {
@@ -402,6 +420,9 @@ pub trait ArrayBuilder: Any {
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize;
 
+    /// Returns whether number of array slots is zero
+    fn is_empty(&self) -> bool;
+
     /// Appends data from other arrays into the builder
     ///
     /// This is most useful when concatenating arrays of the same type into a builder.
@@ -458,6 +479,11 @@ impl<T: ArrowPrimitiveType> ArrayBuilder for PrimitiveBuilder<T> {
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.values_builder.len
+    }
+
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.values_builder.is_empty()
     }
 
     /// Appends data from other arrays into the builder
@@ -725,7 +751,6 @@ where
             self.values().append_data(&[sliced.data()])?;
             let adjusted_offsets: Vec<i32> = offsets
                 .windows(2)
-                .into_iter()
                 .map(|w| {
                     let curr_offset = w[1] - w[0] + cum_offset;
                     cum_offset = curr_offset;
@@ -766,6 +791,11 @@ where
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.len
+    }
+
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Builds the array and reset this builder.
@@ -925,7 +955,6 @@ where
             self.values().append_data(&[sliced.data()])?;
             let adjusted_offsets: Vec<i64> = offsets
                 .windows(2)
-                .into_iter()
                 .map(|w| {
                     let curr_offset = w[1] - w[0] + cum_offset;
                     cum_offset = curr_offset;
@@ -966,6 +995,11 @@ where
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.len
+    }
+
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Builds the array and reset this builder.
@@ -1137,6 +1171,11 @@ where
         self.len
     }
 
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
     /// Builds the array and reset this builder.
     fn finish(&mut self) -> ArrayRef {
         Arc::new(self.finish())
@@ -1267,6 +1306,11 @@ impl ArrayBuilder for BinaryBuilder {
         self.builder.len()
     }
 
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.builder.is_empty()
+    }
+
     /// Builds the array and reset this builder.
     fn finish(&mut self) -> ArrayRef {
         Arc::new(self.finish())
@@ -1308,6 +1352,11 @@ impl ArrayBuilder for LargeBinaryBuilder {
         self.builder.len()
     }
 
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.builder.is_empty()
+    }
+
     /// Builds the array and reset this builder.
     fn finish(&mut self) -> ArrayRef {
         Arc::new(self.finish())
@@ -1347,6 +1396,11 @@ impl ArrayBuilder for StringBuilder {
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.builder.len()
+    }
+
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.builder.is_empty()
     }
 
     /// Builds the array and reset this builder.
@@ -1447,7 +1501,7 @@ fn append_large_binary_data(
                     DataType::LargeList(Box::new(DataType::UInt8)),
                     array.len(),
                     None,
-                    array.null_buffer().map(|buf| buf.clone()),
+                    array.null_buffer().cloned(),
                     array.offset(),
                     vec![(&array.buffers()[0]).clone()],
                     vec![int_data],
@@ -1492,6 +1546,11 @@ impl ArrayBuilder for LargeStringBuilder {
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.builder.len()
+    }
+
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.builder.is_empty()
     }
 
     /// Builds the array and reset this builder.
@@ -1570,6 +1629,11 @@ impl ArrayBuilder for FixedSizeBinaryBuilder {
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.builder.len()
+    }
+
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.builder.is_empty()
     }
 
     /// Builds the array and reset this builder.
@@ -1817,6 +1881,11 @@ impl ArrayBuilder for StructBuilder {
     /// builder should have the equal number of elements.
     fn len(&self) -> usize {
         self.len
+    }
+
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     /// Appends data from other arrays into the builder
@@ -2125,6 +2194,11 @@ where
         self.keys_builder.len()
     }
 
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.keys_builder.is_empty()
+    }
+
     /// Appends data from other arrays into the builder
     ///
     /// This is most useful when concatenating arrays of the same type into a builder.
@@ -2282,6 +2356,11 @@ where
     /// Returns the number of array slots in the builder
     fn len(&self) -> usize {
         self.keys_builder.len()
+    }
+
+    /// Returns whether the number of array slots is zero
+    fn is_empty(&self) -> bool {
+        self.keys_builder.is_empty()
     }
 
     /// Appends data from other arrays into the builder

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -250,7 +250,7 @@ pub struct SortColumn {
 /// assert_eq!(as_primitive_array::<Int64Type>(&sorted_columns[0]).value(1), -64);
 /// assert!(sorted_columns[0].is_null(0));
 /// ```
-pub fn lexsort(columns: &Vec<SortColumn>) -> Result<Vec<ArrayRef>> {
+pub fn lexsort(columns: &[SortColumn]) -> Result<Vec<ArrayRef>> {
     let indices = lexsort_to_indices(columns)?;
     columns
         .iter()
@@ -260,7 +260,7 @@ pub fn lexsort(columns: &Vec<SortColumn>) -> Result<Vec<ArrayRef>> {
 
 /// Sort elements lexicographically from a list of `ArrayRef` into an unsigned integer
 /// (`UInt32Array`) of indices.
-pub fn lexsort_to_indices(columns: &Vec<SortColumn>) -> Result<UInt32Array> {
+pub fn lexsort_to_indices(columns: &[SortColumn]) -> Result<UInt32Array> {
     if columns.len() == 1 {
         // fallback to non-lexical sort
         let column = &columns[0];
@@ -304,7 +304,7 @@ pub fn lexsort_to_indices(columns: &Vec<SortColumn>) -> Result<UInt32Array> {
                     match values.cmp_value(*a_idx, *b_idx) {
                         // equal, move on to next column
                         Ordering::Equal => continue,
-                        order @ _ => {
+                        order => {
                             if sort_option.descending {
                                 return order.reverse();
                             } else {

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -35,17 +35,16 @@ pub fn schema_to_fb(schema: &Schema) -> FlatBufferBuilder {
     let mut fields = vec![];
     for field in schema.fields() {
         let fb_field_name = fbb.create_string(field.name().as_str());
-        let (ipc_type_type, ipc_type, ipc_children) =
-            get_fb_field_type(field.data_type(), &mut fbb);
+        let field_type = get_fb_field_type(field.data_type(), &mut fbb);
         let mut field_builder = ipc::FieldBuilder::new(&mut fbb);
         field_builder.add_name(fb_field_name);
-        field_builder.add_type_type(ipc_type_type);
+        field_builder.add_type_type(field_type.type_type);
         field_builder.add_nullable(field.is_nullable());
-        match ipc_children {
+        match field_type.children {
             None => {}
             Some(children) => field_builder.add_children(children),
         };
-        field_builder.add_type_(ipc_type);
+        field_builder.add_type_(field_type.type_);
         fields.push(field_builder.finish());
     }
 
@@ -82,17 +81,16 @@ pub fn schema_to_fb_offset<'a: 'b, 'b>(
     let mut fields = vec![];
     for field in schema.fields() {
         let fb_field_name = fbb.create_string(field.name().as_str());
-        let (ipc_type_type, ipc_type, ipc_children) =
-            get_fb_field_type(field.data_type(), fbb);
+        let field_type = get_fb_field_type(field.data_type(), fbb);
         let mut field_builder = ipc::FieldBuilder::new(fbb);
         field_builder.add_name(fb_field_name);
-        field_builder.add_type_type(ipc_type_type);
+        field_builder.add_type_type(field_type.type_type);
         field_builder.add_nullable(field.is_nullable());
-        match ipc_children {
+        match field_type.children {
             None => {}
             Some(children) => field_builder.add_children(children),
         };
-        field_builder.add_type_(ipc_type);
+        field_builder.add_type_(field_type.type_);
         fields.push(field_builder.finish());
     }
 
@@ -329,32 +327,31 @@ pub(crate) fn get_data_type(field: ipc::Field, may_be_dictionary: bool) -> DataT
     }
 }
 
+pub(crate) struct FBFieldType<'b> {
+    pub(crate) type_type: ipc::Type,
+    pub(crate) type_: WIPOffset<UnionWIPOffset>,
+    pub(crate) children: Option<WIPOffset<Vector<'b, ForwardsUOffset<ipc::Field<'b>>>>>,
+}
+
 /// Get the IPC type of a data type
 pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
     data_type: &DataType,
     fbb: &mut FlatBufferBuilder<'a>,
-) -> (
-    ipc::Type,
-    WIPOffset<UnionWIPOffset>,
-    Option<WIPOffset<Vector<'b, ForwardsUOffset<ipc::Field<'b>>>>>,
-) {
+) -> FBFieldType<'b> {
     // some IPC implementations expect an empty list for child data, instead of a null value.
     // An empty field list is thus returned for primitive types
     let empty_fields: Vec<WIPOffset<ipc::Field>> = vec![];
     match data_type {
-        Null => (
-            ipc::Type::Null,
-            ipc::NullBuilder::new(fbb).finish().as_union_value(),
-            None,
-        ),
-        Boolean => {
-            let children = fbb.create_vector(&empty_fields[..]);
-            (
-                ipc::Type::Bool,
-                ipc::BoolBuilder::new(fbb).finish().as_union_value(),
-                Some(children),
-            )
-        }
+        Null => FBFieldType {
+            type_type: ipc::Type::Null,
+            type_: ipc::NullBuilder::new(fbb).finish().as_union_value(),
+            children: None,
+        },
+        Boolean => FBFieldType {
+            type_type: ipc::Type::Bool,
+            type_: ipc::BoolBuilder::new(fbb).finish().as_union_value(),
+            children: Some(fbb.create_vector(&empty_fields[..])),
+        },
         UInt8 | UInt16 | UInt32 | UInt64 => {
             let children = fbb.create_vector(&empty_fields[..]);
             let mut builder = ipc::IntBuilder::new(fbb);
@@ -366,11 +363,11 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                 UInt64 => builder.add_bitWidth(64),
                 _ => {}
             };
-            (
-                ipc::Type::Int,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::Int,
+                type_: builder.finish().as_union_value(),
+                children: Some(children),
+            }
         }
         Int8 | Int16 | Int32 | Int64 => {
             let children = fbb.create_vector(&empty_fields[..]);
@@ -383,11 +380,11 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                 Int64 => builder.add_bitWidth(64),
                 _ => {}
             };
-            (
-                ipc::Type::Int,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::Int,
+                type_: builder.finish().as_union_value(),
+                children: Some(children),
+            }
         }
         Float16 | Float32 | Float64 => {
             let children = fbb.create_vector(&empty_fields[..]);
@@ -398,76 +395,60 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                 Float64 => builder.add_precision(ipc::Precision::DOUBLE),
                 _ => {}
             };
-            (
-                ipc::Type::FloatingPoint,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::FloatingPoint,
+                type_: builder.finish().as_union_value(),
+                children: Some(children),
+            }
         }
-        Binary => {
-            let children = fbb.create_vector(&empty_fields[..]);
-            (
-                ipc::Type::Binary,
-                ipc::BinaryBuilder::new(fbb).finish().as_union_value(),
-                Some(children),
-            )
-        }
-        LargeBinary => {
-            let children = fbb.create_vector(&empty_fields[..]);
-            (
-                ipc::Type::LargeBinary,
-                ipc::LargeBinaryBuilder::new(fbb).finish().as_union_value(),
-                Some(children),
-            )
-        }
-        Utf8 => {
-            let children = fbb.create_vector(&empty_fields[..]);
-            (
-                ipc::Type::Utf8,
-                ipc::Utf8Builder::new(fbb).finish().as_union_value(),
-                Some(children),
-            )
-        }
-        LargeUtf8 => {
-            let children = fbb.create_vector(&empty_fields[..]);
-            (
-                ipc::Type::LargeUtf8,
-                ipc::LargeUtf8Builder::new(fbb).finish().as_union_value(),
-                Some(children),
-            )
-        }
+        Binary => FBFieldType {
+            type_type: ipc::Type::Binary,
+            type_: ipc::BinaryBuilder::new(fbb).finish().as_union_value(),
+            children: Some(fbb.create_vector(&empty_fields[..])),
+        },
+        LargeBinary => FBFieldType {
+            type_type: ipc::Type::LargeBinary,
+            type_: ipc::LargeBinaryBuilder::new(fbb).finish().as_union_value(),
+            children: Some(fbb.create_vector(&empty_fields[..])),
+        },
+        Utf8 => FBFieldType {
+            type_type: ipc::Type::Utf8,
+            type_: ipc::Utf8Builder::new(fbb).finish().as_union_value(),
+            children: Some(fbb.create_vector(&empty_fields[..])),
+        },
+        LargeUtf8 => FBFieldType {
+            type_type: ipc::Type::LargeUtf8,
+            type_: ipc::LargeUtf8Builder::new(fbb).finish().as_union_value(),
+            children: Some(fbb.create_vector(&empty_fields[..])),
+        },
         FixedSizeBinary(len) => {
-            let children = fbb.create_vector(&empty_fields[..]);
             let mut builder = ipc::FixedSizeBinaryBuilder::new(fbb);
             builder.add_byteWidth(*len as i32);
-            (
-                ipc::Type::FixedSizeBinary,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::FixedSizeBinary,
+                type_: builder.finish().as_union_value(),
+                children: Some(fbb.create_vector(&empty_fields[..])),
+            }
         }
         Date32(_) => {
-            let children = fbb.create_vector(&empty_fields[..]);
             let mut builder = ipc::DateBuilder::new(fbb);
             builder.add_unit(ipc::DateUnit::DAY);
-            (
-                ipc::Type::Date,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::Date,
+                type_: builder.finish().as_union_value(),
+                children: Some(fbb.create_vector(&empty_fields[..])),
+            }
         }
         Date64(_) => {
-            let children = fbb.create_vector(&empty_fields[..]);
             let mut builder = ipc::DateBuilder::new(fbb);
             builder.add_unit(ipc::DateUnit::MILLISECOND);
-            (
-                ipc::Type::Date,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::Date,
+                type_: builder.finish().as_union_value(),
+                children: Some(fbb.create_vector(&empty_fields[..])),
+            }
         }
         Time32(unit) | Time64(unit) => {
-            let children = fbb.create_vector(&empty_fields[..]);
             let mut builder = ipc::TimeBuilder::new(fbb);
             match unit {
                 TimeUnit::Second => {
@@ -487,14 +468,13 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                     builder.add_unit(ipc::TimeUnit::NANOSECOND);
                 }
             }
-            (
-                ipc::Type::Time,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::Time,
+                type_: builder.finish().as_union_value(),
+                children: Some(fbb.create_vector(&empty_fields[..])),
+            }
         }
         Timestamp(unit, tz) => {
-            let children = fbb.create_vector(&empty_fields[..]);
             let tz = tz.clone().unwrap_or_else(|| Arc::new(String::new()));
             let tz_str = fbb.create_string(tz.as_str());
             let mut builder = ipc::TimestampBuilder::new(fbb);
@@ -508,28 +488,26 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
             if !tz.is_empty() {
                 builder.add_timezone(tz_str);
             }
-            (
-                ipc::Type::Timestamp,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::Timestamp,
+                type_: builder.finish().as_union_value(),
+                children: Some(fbb.create_vector(&empty_fields[..])),
+            }
         }
         Interval(unit) => {
-            let children = fbb.create_vector(&empty_fields[..]);
             let mut builder = ipc::IntervalBuilder::new(fbb);
             let interval_unit = match unit {
                 IntervalUnit::YearMonth => ipc::IntervalUnit::YEAR_MONTH,
                 IntervalUnit::DayTime => ipc::IntervalUnit::DAY_TIME,
             };
             builder.add_unit(interval_unit);
-            (
-                ipc::Type::Interval,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::Interval,
+                type_: builder.finish().as_union_value(),
+                children: Some(fbb.create_vector(&empty_fields[..])),
+            }
         }
         Duration(unit) => {
-            let children = fbb.create_vector(&empty_fields[..]);
             let mut builder = ipc::DurationBuilder::new(fbb);
             let time_unit = match unit {
                 TimeUnit::Second => ipc::TimeUnit::SECOND,
@@ -538,11 +516,11 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                 TimeUnit::Nanosecond => ipc::TimeUnit::NANOSECOND,
             };
             builder.add_unit(time_unit);
-            (
-                ipc::Type::Duration,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::Duration,
+                type_: builder.finish().as_union_value(),
+                children: Some(fbb.create_vector(&empty_fields[..])),
+            }
         }
         List(ref list_type) => {
             let inner_types = get_fb_field_type(list_type, fbb);
@@ -551,19 +529,18 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                 &ipc::FieldArgs {
                     name: None,
                     nullable: false,
-                    type_type: inner_types.0,
-                    type_: Some(inner_types.1),
+                    type_type: inner_types.type_type,
+                    type_: Some(inner_types.type_),
+                    children: inner_types.children,
                     dictionary: None,
-                    children: inner_types.2,
                     custom_metadata: None,
                 },
             );
-            let children = fbb.create_vector(&[child]);
-            (
-                ipc::Type::List,
-                ipc::ListBuilder::new(fbb).finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::List,
+                type_: ipc::ListBuilder::new(fbb).finish().as_union_value(),
+                children: Some(fbb.create_vector(&[child])),
+            }
         }
         LargeList(ref list_type) => {
             let inner_types = get_fb_field_type(list_type, fbb);
@@ -572,19 +549,18 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                 &ipc::FieldArgs {
                     name: None,
                     nullable: false,
-                    type_type: inner_types.0,
-                    type_: Some(inner_types.1),
+                    type_type: inner_types.type_type,
+                    type_: Some(inner_types.type_),
                     dictionary: None,
-                    children: inner_types.2,
+                    children: inner_types.children,
                     custom_metadata: None,
                 },
             );
-            let children = fbb.create_vector(&[child]);
-            (
-                ipc::Type::LargeList,
-                ipc::LargeListBuilder::new(fbb).finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::LargeList,
+                type_: ipc::LargeListBuilder::new(fbb).finish().as_union_value(),
+                children: Some(fbb.create_vector(&[child])),
+            }
         }
         FixedSizeList(ref list_type, len) => {
             let inner_types = get_fb_field_type(list_type, fbb);
@@ -593,21 +569,20 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                 &ipc::FieldArgs {
                     name: None,
                     nullable: false,
-                    type_type: inner_types.0,
-                    type_: Some(inner_types.1),
+                    type_type: inner_types.type_type,
+                    type_: Some(inner_types.type_),
                     dictionary: None,
-                    children: inner_types.2,
+                    children: inner_types.children,
                     custom_metadata: None,
                 },
             );
-            let children = fbb.create_vector(&[child]);
             let mut builder = ipc::FixedSizeListBuilder::new(fbb);
             builder.add_listSize(*len as i32);
-            (
-                ipc::Type::FixedSizeList,
-                builder.finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::FixedSizeList,
+                type_: builder.finish().as_union_value(),
+                children: Some(fbb.create_vector(&[child])),
+            }
         }
         Struct(fields) => {
             // struct's fields are children
@@ -620,20 +595,19 @@ pub(crate) fn get_fb_field_type<'a: 'b, 'b>(
                     &ipc::FieldArgs {
                         name: Some(field_name),
                         nullable: field.is_nullable(),
-                        type_type: inner_types.0,
-                        type_: Some(inner_types.1),
+                        type_type: inner_types.type_type,
+                        type_: Some(inner_types.type_),
                         dictionary: None,
-                        children: inner_types.2,
+                        children: inner_types.children,
                         custom_metadata: None,
                     },
                 ));
             }
-            let children = fbb.create_vector(&children[..]);
-            (
-                ipc::Type::Struct_,
-                ipc::Struct_Builder::new(fbb).finish().as_union_value(),
-                Some(children),
-            )
+            FBFieldType {
+                type_type: ipc::Type::Struct_,
+                type_: ipc::Struct_Builder::new(fbb).finish().as_union_value(),
+                children: Some(fbb.create_vector(&children[..])),
+            }
         }
         t => unimplemented!("Type {:?} not supported", t),
     }

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -95,17 +95,17 @@ impl<W: Write> FileWriter<W> {
             let mut fields = vec![];
             for field in self.schema.fields() {
                 let fb_field_name = fbb.create_string(field.name().as_str());
-                let (ipc_type_type, ipc_type, ipc_children) =
+                let field_type =
                     ipc::convert::get_fb_field_type(field.data_type(), &mut fbb);
                 let mut field_builder = ipc::FieldBuilder::new(&mut fbb);
                 field_builder.add_name(fb_field_name);
-                field_builder.add_type_type(ipc_type_type);
+                field_builder.add_type_type(field_type.type_type);
                 field_builder.add_nullable(field.is_nullable());
-                match ipc_children {
+                match field_type.children {
                     None => {}
                     Some(children) => field_builder.add_children(children),
                 };
-                field_builder.add_type_(ipc_type);
+                field_builder.add_type_(field_type.type_);
                 fields.push(field_builder.finish());
             }
 

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -393,7 +393,7 @@ fn json_from_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value> {
                 .unwrap()
                 .iter()
                 .map(|v| {
-                    Value::Number(VNumber::from(match v {
+                    Value::Number(match v {
                         Value::Number(number) => number.clone(),
                         Value::String(string) => VNumber::from(
                             string
@@ -401,7 +401,7 @@ fn json_from_col(col: &ArrowJsonColumn, data_type: &DataType) -> Vec<Value> {
                                 .expect("Unable to parse string as i64"),
                         ),
                         t => panic!("Cannot convert {} to number", t),
-                    }))
+                    })
                 })
                 .collect();
             merge_json_array(


### PR DESCRIPTION
Also change rust_lint.sh to only run clippy on arrow crate since we
still have hundreds of warnnings/errors for parquet and datafusion
crates.