### PR TITLE
ARROW-9331: [C++] Improve the performance of Tensor-to-SparseTensor conversion

### DIFF
--- a/cpp/src/arrow/tensor/converter_internal.h
+++ b/cpp/src/arrow/tensor/converter_internal.h
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/tensor/converter.h"
+
+#define DISPATCH(ACTION, index_elsize, value_elsize, ...) \
+  switch (index_elsize) { \
+    case 1: \
+      switch (value_elsize) { \
+        case 1: \
+          ACTION(uint8_t, uint8_t, __VA_ARGS__); \
+          break; \
+        case 2: \
+          ACTION(uint8_t, uint16_t, __VA_ARGS__); \
+          break; \
+        case 4: \
+          ACTION(uint8_t, uint32_t, __VA_ARGS__); \
+          break; \
+        case 8: \
+          ACTION(uint8_t, uint64_t, __VA_ARGS__); \
+          break; \
+      } \
+      break; \
+    case 2: \
+      switch (value_elsize) { \
+        case 1: \
+          ACTION(uint16_t, uint8_t, __VA_ARGS__); \
+          break; \
+        case 2: \
+          ACTION(uint16_t, uint16_t, __VA_ARGS__); \
+          break; \
+        case 4: \
+          ACTION(uint16_t, uint32_t, __VA_ARGS__); \
+          break; \
+        case 8: \
+          ACTION(uint16_t, uint64_t, __VA_ARGS__); \
+          break; \
+      } \
+      break; \
+    case 4: \
+      switch (value_elsize) { \
+        case 1: \
+          ACTION(uint32_t, uint8_t, __VA_ARGS__); \
+          break; \
+        case 2: \
+          ACTION(uint32_t, uint16_t, __VA_ARGS__); \
+          break; \
+        case 4: \
+          ACTION(uint32_t, uint32_t, __VA_ARGS__); \
+          break; \
+        case 8: \
+          ACTION(uint32_t, uint64_t, __VA_ARGS__); \
+          break; \
+      } \
+      break; \
+    case 8: \
+      switch (value_elsize) { \
+        case 1: \
+          ACTION(int64_t, uint8_t, __VA_ARGS__); \
+          break; \
+        case 2: \
+          ACTION(int64_t, uint16_t, __VA_ARGS__); \
+          break; \
+        case 4: \
+          ACTION(int64_t, uint32_t, __VA_ARGS__); \
+          break; \
+        case 8: \
+          ACTION(int64_t, uint64_t, __VA_ARGS__); \
+          break; \
+      } \
+      break; \
+  }
+

--- a/cpp/src/arrow/tensor/converter_internal.h
+++ b/cpp/src/arrow/tensor/converter_internal.h
@@ -20,70 +20,69 @@
 #include "arrow/tensor/converter.h"
 
 #define DISPATCH(ACTION, index_elsize, value_elsize, ...) \
-  switch (index_elsize) { \
-    case 1: \
-      switch (value_elsize) { \
-        case 1: \
-          ACTION(uint8_t, uint8_t, __VA_ARGS__); \
-          break; \
-        case 2: \
-          ACTION(uint8_t, uint16_t, __VA_ARGS__); \
-          break; \
-        case 4: \
-          ACTION(uint8_t, uint32_t, __VA_ARGS__); \
-          break; \
-        case 8: \
-          ACTION(uint8_t, uint64_t, __VA_ARGS__); \
-          break; \
-      } \
-      break; \
-    case 2: \
-      switch (value_elsize) { \
-        case 1: \
-          ACTION(uint16_t, uint8_t, __VA_ARGS__); \
-          break; \
-        case 2: \
-          ACTION(uint16_t, uint16_t, __VA_ARGS__); \
-          break; \
-        case 4: \
-          ACTION(uint16_t, uint32_t, __VA_ARGS__); \
-          break; \
-        case 8: \
-          ACTION(uint16_t, uint64_t, __VA_ARGS__); \
-          break; \
-      } \
-      break; \
-    case 4: \
-      switch (value_elsize) { \
-        case 1: \
-          ACTION(uint32_t, uint8_t, __VA_ARGS__); \
-          break; \
-        case 2: \
-          ACTION(uint32_t, uint16_t, __VA_ARGS__); \
-          break; \
-        case 4: \
-          ACTION(uint32_t, uint32_t, __VA_ARGS__); \
-          break; \
-        case 8: \
-          ACTION(uint32_t, uint64_t, __VA_ARGS__); \
-          break; \
-      } \
-      break; \
-    case 8: \
-      switch (value_elsize) { \
-        case 1: \
-          ACTION(int64_t, uint8_t, __VA_ARGS__); \
-          break; \
-        case 2: \
-          ACTION(int64_t, uint16_t, __VA_ARGS__); \
-          break; \
-        case 4: \
-          ACTION(int64_t, uint32_t, __VA_ARGS__); \
-          break; \
-        case 8: \
-          ACTION(int64_t, uint64_t, __VA_ARGS__); \
-          break; \
-      } \
-      break; \
+  switch (index_elsize) {                                 \
+    case 1:                                               \
+      switch (value_elsize) {                             \
+        case 1:                                           \
+          ACTION(uint8_t, uint8_t, __VA_ARGS__);          \
+          break;                                          \
+        case 2:                                           \
+          ACTION(uint8_t, uint16_t, __VA_ARGS__);         \
+          break;                                          \
+        case 4:                                           \
+          ACTION(uint8_t, uint32_t, __VA_ARGS__);         \
+          break;                                          \
+        case 8:                                           \
+          ACTION(uint8_t, uint64_t, __VA_ARGS__);         \
+          break;                                          \
+      }                                                   \
+      break;                                              \
+    case 2:                                               \
+      switch (value_elsize) {                             \
+        case 1:                                           \
+          ACTION(uint16_t, uint8_t, __VA_ARGS__);         \
+          break;                                          \
+        case 2:                                           \
+          ACTION(uint16_t, uint16_t, __VA_ARGS__);        \
+          break;                                          \
+        case 4:                                           \
+          ACTION(uint16_t, uint32_t, __VA_ARGS__);        \
+          break;                                          \
+        case 8:                                           \
+          ACTION(uint16_t, uint64_t, __VA_ARGS__);        \
+          break;                                          \
+      }                                                   \
+      break;                                              \
+    case 4:                                               \
+      switch (value_elsize) {                             \
+        case 1:                                           \
+          ACTION(uint32_t, uint8_t, __VA_ARGS__);         \
+          break;                                          \
+        case 2:                                           \
+          ACTION(uint32_t, uint16_t, __VA_ARGS__);        \
+          break;                                          \
+        case 4:                                           \
+          ACTION(uint32_t, uint32_t, __VA_ARGS__);        \
+          break;                                          \
+        case 8:                                           \
+          ACTION(uint32_t, uint64_t, __VA_ARGS__);        \
+          break;                                          \
+      }                                                   \
+      break;                                              \
+    case 8:                                               \
+      switch (value_elsize) {                             \
+        case 1:                                           \
+          ACTION(int64_t, uint8_t, __VA_ARGS__);          \
+          break;                                          \
+        case 2:                                           \
+          ACTION(int64_t, uint16_t, __VA_ARGS__);         \
+          break;                                          \
+        case 4:                                           \
+          ACTION(int64_t, uint32_t, __VA_ARGS__);         \
+          break;                                          \
+        case 8:                                           \
+          ACTION(int64_t, uint64_t, __VA_ARGS__);         \
+          break;                                          \
+      }                                                   \
+      break;                                              \
   }
-

--- a/cpp/src/arrow/tensor/coo_converter.cc
+++ b/cpp/src/arrow/tensor/coo_converter.cc
@@ -202,11 +202,14 @@ class SparseCOOTensorConverter : private SparseTensorConverterMixin {
         tensor_data += value_elsize;
       }
     } else if (tensor_.is_row_major()) {
-      DISPATCH(CONVERT_TENSOR, index_elsize, value_elsize, ROW_MAJOR, indices, values, nonzero_count);
+      DISPATCH(CONVERT_TENSOR, index_elsize, value_elsize, ROW_MAJOR, indices, values,
+               nonzero_count);
     } else if (tensor_.is_column_major()) {
-      DISPATCH(CONVERT_TENSOR, index_elsize, value_elsize, COLUMN_MAJOR, indices, values, nonzero_count);
+      DISPATCH(CONVERT_TENSOR, index_elsize, value_elsize, COLUMN_MAJOR, indices, values,
+               nonzero_count);
     } else {
-      DISPATCH(CONVERT_TENSOR, index_elsize, value_elsize, STRIDED, indices, values, nonzero_count);
+      DISPATCH(CONVERT_TENSOR, index_elsize, value_elsize, STRIDED, indices, values,
+               nonzero_count);
     }
 
     // make results

--- a/cpp/src/arrow/tensor/csx_converter.cc
+++ b/cpp/src/arrow/tensor/csx_converter.cc
@@ -181,7 +181,7 @@ Result<std::shared_ptr<Tensor>> MakeTensorFromSparseCSXMatrix(
 
   const auto nc = shape[1];
 
-  int64_t offset;
+  int64_t offset = 0;
   for (int64_t i = 0; i < indptr->size() - 1; ++i) {
     const auto start =
         SparseTensorConverterMixin::GetIndexValue(indptr_data, indptr_elsize);

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 
+#define ARROW_EXPAND(x) x
 #define ARROW_STRINGIFY(x) #x
 #define ARROW_CONCAT(x, y) x##y
 


### PR DESCRIPTION
In this pull-request, the slowing down of the conversion introduced in #7539 is canceled, and the conversion speed is improved than before #7539 in some cases.