### PR TITLE
ARROW-8301: [R] Handle ChunkedArray and Table in C data interface

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -43,8 +43,12 @@
   s3_register("dplyr::tbl_vars", "arrow_dplyr_query")
   s3_register("reticulate::py_to_r", "pyarrow.lib.Array")
   s3_register("reticulate::py_to_r", "pyarrow.lib.RecordBatch")
+  s3_register("reticulate::py_to_r", "pyarrow.lib.ChunkedArray")
+  s3_register("reticulate::py_to_r", "pyarrow.lib.Table")
   s3_register("reticulate::r_to_py", "Array")
   s3_register("reticulate::r_to_py", "RecordBatch")
+  s3_register("reticulate::r_to_py", "ChunkedArray")
+  s3_register("reticulate::r_to_py", "Table")
   invisible()
 }
 

--- a/r/tests/testthat/test-python.R
+++ b/r/tests/testthat/test-python.R
@@ -51,3 +51,31 @@ test_that("RecordBatch to/from Python", {
   expect_is(py, "pyarrow.lib.RecordBatch")
   expect_equal(reticulate::py_to_r(py), batch)
 })
+
+test_that("Table and ChunkedArray from Python", {
+  skip_if_no_pyarrow()
+  pa <- reticulate::import("pyarrow", convert=FALSE)
+  batch <- record_batch(col1=c(1, 2, 3), col2=letters[1:3])
+  tab <- Table$create(batch, batch)
+  pybatch <- reticulate::r_to_py(batch)
+  pytab <- pa$Table$from_batches(list(pybatch, pybatch))
+  expect_is(pytab, "pyarrow.lib.Table")
+  expect_is(pytab[0], "pyarrow.lib.ChunkedArray")
+  expect_equal(reticulate::py_to_r(pytab[0]), tab$col1)
+  expect_equal(reticulate::py_to_r(pytab), tab)
+})
+
+test_that("Table and ChunkedArray to Python", {
+  skip_if_no_pyarrow()
+  pa <- reticulate::import("pyarrow", convert=FALSE)
+  batch <- record_batch(col1=c(1, 2, 3), col2=letters[1:3])
+  tab <- Table$create(batch, batch)
+
+  pychunked <- reticulate::r_to_py(tab$col1)
+  expect_is(pychunked, "pyarrow.lib.ChunkedArray")
+  expect_equal(reticulate::py_to_r(pychunked), tab$col1)
+
+  pytab <- reticulate::r_to_py(tab)
+  expect_is(pytab, "pyarrow.lib.Table")
+  expect_equal(reticulate::py_to_r(pytab), tab)
+})


### PR DESCRIPTION
In terms of number of lines of code, this wasn't bad, though I don't know how efficient these methods are. Maybe there's a better way

The one thing that would be lost is any metadata attached to the Table schema because the Table is reconstructed from its ChunkedArrays without schema. I wonder if we could export the Schema on its own--the existing `_export_to_c`/`_import_from_c` methods take both an array pointer and a schema pointer.