### PR TITLE
[C++][MINOR] Enable clang-format in a place where it was accidentally disabled

### DIFF
--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -128,7 +128,7 @@ static const std::string kEncodedMetadata1{  // NOLINT: runtime/string
     0, 0, 0, 4, 'k', 'e', 'y', '1', 0, 0, 0, 0,
     0, 0, 0, 4, 'k', 'e', 'y', '2', 0, 0, 0, 3, 'b', 'a', 'r'};
 #endif
-// clang-format off
+// clang-format on
 
 static const std::vector<std::string> kMetadataKeys2{"key"};
 static const std::vector<std::string> kMetadataValues2{"abcde"};
@@ -141,7 +141,7 @@ static const std::string kEncodedMetadata2{  // NOLINT: runtime/string
     0, 0, 0, 1,
     0, 0, 0, 3, 'k', 'e', 'y', 0, 0, 0, 5, 'a', 'b', 'c', 'd', 'e'};
 #endif
-// clang-format off
+// clang-format on
 
 static constexpr int64_t kDefaultFlags = ARROW_FLAG_NULLABLE;
 
@@ -223,7 +223,8 @@ class TestSchemaExport : public ::testing::Test {
                   std::vector<int64_t> flattened_flags = {},
                   std::vector<std::string> flattened_metadata = {}) {
     SchemaExportChecker checker(std::move(flattened_formats), std::move(flattened_names),
-                          std::move(flattened_flags), std::move(flattened_metadata));
+                                std::move(flattened_flags),
+                                std::move(flattened_metadata));
 
     auto orig_bytes = pool_->bytes_allocated();
 
@@ -242,9 +243,9 @@ class TestSchemaExport : public ::testing::Test {
   }
 
   template <typename T>
-  void TestPrimitive(const std::shared_ptr<T>& schema_like,
-                     const char* format, const std::string& name = "",
-                     int64_t flags = kDefaultFlags, const std::string& metadata = "") {
+  void TestPrimitive(const std::shared_ptr<T>& schema_like, const char* format,
+                     const std::string& name = "", int64_t flags = kDefaultFlags,
+                     const std::string& metadata = "") {
     TestNested(schema_like, {format}, {name}, {flags}, {metadata});
   }
 
@@ -305,13 +306,10 @@ TEST_F(TestSchemaExport, Temporal) {
 
 TEST_F(TestSchemaExport, List) {
   TestNested(list(int8()), {"+l", "c"}, {"", "item"});
-  TestNested(large_list(uint16()), {"+L", "S"},
-             {"", "item"});
-  TestNested(fixed_size_list(int64(), 2), {"+w:2", "l"},
-             {"", "item"});
+  TestNested(large_list(uint16()), {"+L", "S"}, {"", "item"});
+  TestNested(fixed_size_list(int64(), 2), {"+w:2", "l"}, {"", "item"});
 
-  TestNested(list(large_list(int32())), {"+l", "+L", "i"},
-             {"", "item", "item"});
+  TestNested(list(large_list(int32())), {"+l", "+L", "i"}, {"", "item", "item"});
 }
 
 TEST_F(TestSchemaExport, Struct) {
@@ -326,22 +324,20 @@ TEST_F(TestSchemaExport, Struct) {
 
   // With metadata
   auto f0 = type->field(0);
-  auto f1 = type->field(1)->WithMetadata(
-      key_value_metadata(kMetadataKeys1, kMetadataValues1));
+  auto f1 =
+      type->field(1)->WithMetadata(key_value_metadata(kMetadataKeys1, kMetadataValues1));
   type = struct_({f0, f1});
   TestNested(type, {"+s", "c", "u"}, {"", "a", "b"},
-             {ARROW_FLAG_NULLABLE, 0, ARROW_FLAG_NULLABLE},
-             {"", "", kEncodedMetadata1});
+             {ARROW_FLAG_NULLABLE, 0, ARROW_FLAG_NULLABLE}, {"", "", kEncodedMetadata1});
 }
 
 TEST_F(TestSchemaExport, Map) {
-  TestNested(map(int8(), utf8()),
-             {"+m", "+s", "c", "u"}, {"", "entries", "key", "value"},
+  TestNested(map(int8(), utf8()), {"+m", "+s", "c", "u"}, {"", "entries", "key", "value"},
              {ARROW_FLAG_NULLABLE, 0, 0, ARROW_FLAG_NULLABLE});
-  TestNested(map(int8(), utf8(), /*keys_sorted=*/ true),
-             {"+m", "+s", "c", "u"}, {"", "entries", "key", "value"},
-             {ARROW_FLAG_NULLABLE | ARROW_FLAG_MAP_KEYS_SORTED, 0, 0,
-              ARROW_FLAG_NULLABLE});
+  TestNested(
+      map(int8(), utf8(), /*keys_sorted=*/true), {"+m", "+s", "c", "u"},
+      {"", "entries", "key", "value"},
+      {ARROW_FLAG_NULLABLE | ARROW_FLAG_MAP_KEYS_SORTED, 0, 0, ARROW_FLAG_NULLABLE});
 }
 
 TEST_F(TestSchemaExport, Union) {
@@ -361,12 +357,12 @@ TEST_F(TestSchemaExport, Union) {
 
 TEST_F(TestSchemaExport, Dictionary) {
   TestNested(dictionary(int32(), utf8()), {"i", "u"}, {"", ""});
-  TestNested(dictionary(int32(), list(utf8()), /*ordered=*/true),
-             {"i", "+l", "u"}, {"", "", "item"},
-             {ARROW_FLAG_NULLABLE | ARROW_FLAG_DICTIONARY_ORDERED,
-              ARROW_FLAG_NULLABLE, ARROW_FLAG_NULLABLE});
-  TestNested(large_list(dictionary(int32(), list(utf8()))),
-             {"+L", "i", "+l", "u"}, {"", "item", "", "item"});
+  TestNested(dictionary(int32(), list(utf8()), /*ordered=*/true), {"i", "+l", "u"},
+             {"", "", "item"},
+             {ARROW_FLAG_NULLABLE | ARROW_FLAG_DICTIONARY_ORDERED, ARROW_FLAG_NULLABLE,
+              ARROW_FLAG_NULLABLE});
+  TestNested(large_list(dictionary(int32(), list(utf8()))), {"+L", "i", "+l", "u"},
+             {"", "item", "", "item"});
 }
 
 TEST_F(TestSchemaExport, ExportField) {
@@ -460,8 +456,7 @@ struct RecordBatchExportChecker {
       // Recurse into children
       for (int i = 0; i < expected_batch.num_columns(); ++i) {
         ASSERT_NE(c_export->children[i], nullptr);
-        array_checker(c_export->children[i],
-                      *expected_batch.column(i)->data());
+        array_checker(c_export->children[i], *expected_batch.column(i)->data());
       }
     } else {
       ASSERT_EQ(c_export->children, nullptr);
@@ -678,8 +673,8 @@ class TestArrayExport : public ::testing::Test {
   void TestMoveChildren(ArrayFactory&& factory, const std::vector<int64_t> children_ids) {
     ArrayExportChecker checker;
 
-    TestMoveChildrenWithArrayFactory(std::forward<ArrayFactory>(factory),
-                                     children_ids, checker);
+    TestMoveChildrenWithArrayFactory(std::forward<ArrayFactory>(factory), children_ids,
+                                     checker);
   }
 
   void TestMoveChildren(const std::shared_ptr<DataType>& type, const char* json,
@@ -793,7 +788,7 @@ TEST_F(TestArrayExport, Struct) {
 TEST_F(TestArrayExport, Map) {
   const char* json = R"([[[1, "foo"], [2, null]], [[3, "bar"]]])";
   TestNested(map(int8(), utf8()), json);
-  TestNested(map(int8(), utf8(), /*keys_sorted=*/ true), json);
+  TestNested(map(int8(), utf8(), /*keys_sorted=*/true), json);
 }
 
 TEST_F(TestArrayExport, Union) {
@@ -816,7 +811,8 @@ TEST_F(TestArrayExport, Dictionary) {
       auto values = ArrayFromJSON(utf8(), R"(["foo", "bar", "quux"])");
       auto indices = ArrayFromJSON(int32(), "[0, 2, 1, null, 1]");
       return DictionaryArray::FromArrays(dictionary(indices->type(), values->type()),
-                                         indices, values).Value(out);
+                                         indices, values)
+          .Value(out);
     };
     TestNested(factory);
   }
@@ -825,8 +821,9 @@ TEST_F(TestArrayExport, Dictionary) {
       auto values = ArrayFromJSON(list(utf8()), R"([["abc", "def"], ["efg"], []])");
       auto indices = ArrayFromJSON(int32(), "[0, 2, 1, null, 1]");
       return DictionaryArray::FromArrays(
-          dictionary(indices->type(), values->type(), /*ordered=*/true),
-          indices, values).Value(out);
+                 dictionary(indices->type(), values->type(), /*ordered=*/true), indices,
+                 values)
+          .Value(out);
     };
     TestNested(factory);
   }
@@ -839,8 +836,7 @@ TEST_F(TestArrayExport, Dictionary) {
           DictionaryArray::FromArrays(dictionary(indices->type(), values->type()),
                                       indices, values));
       auto offsets = ArrayFromJSON(int64(), "[0, 2, 5]");
-      RETURN_NOT_OK(
-          LargeListArray::FromArrays(*offsets, *dict_array).Value(out));
+      RETURN_NOT_OK(LargeListArray::FromArrays(*offsets, *dict_array).Value(out));
       return (*out)->ValidateFull();
     };
     TestNested(factory);
@@ -866,7 +862,8 @@ TEST_F(TestArrayExport, MoveDictionary) {
       auto values = ArrayFromJSON(utf8(), R"(["foo", "bar", "quux"])");
       auto indices = ArrayFromJSON(int32(), "[0, 2, 1, null, 1]");
       return DictionaryArray::FromArrays(dictionary(indices->type(), values->type()),
-                                         indices, values).Value(out);
+                                         indices, values)
+          .Value(out);
     };
     TestMoveNested(factory);
   }
@@ -879,8 +876,7 @@ TEST_F(TestArrayExport, MoveDictionary) {
           DictionaryArray::FromArrays(dictionary(indices->type(), values->type()),
                                       indices, values));
       auto offsets = ArrayFromJSON(int64(), "[0, 2, 5]");
-      RETURN_NOT_OK(
-          LargeListArray::FromArrays(*offsets, *dict_array).Value(out));
+      RETURN_NOT_OK(LargeListArray::FromArrays(*offsets, *dict_array).Value(out));
       return (*out)->ValidateFull();
     };
     TestMoveNested(factory);
@@ -906,8 +902,7 @@ TEST_F(TestArrayExport, MoveChild) {
           DictionaryArray::FromArrays(dictionary(indices->type(), values->type()),
                                       indices, values));
       auto offsets = ArrayFromJSON(int64(), "[0, 2, 5]");
-      RETURN_NOT_OK(
-          LargeListArray::FromArrays(*offsets, *dict_array).Value(out));
+      RETURN_NOT_OK(LargeListArray::FromArrays(*offsets, *dict_array).Value(out));
       return (*out)->ValidateFull();
     };
     TestMoveChild(factory, /*child_id=*/0);
@@ -921,8 +916,8 @@ TEST_F(TestArrayExport, MoveSeveralChildren) {
 }
 
 TEST_F(TestArrayExport, ExportArrayAndType) {
-  struct ArrowSchema c_schema{};
-  struct ArrowArray c_array{};
+  struct ArrowSchema c_schema {};
+  struct ArrowArray c_array {};
   SchemaExportGuard schema_guard(&c_schema);
   ArrayExportGuard array_guard(&c_array);
 
@@ -939,8 +934,8 @@ TEST_F(TestArrayExport, ExportArrayAndType) {
 }
 
 TEST_F(TestArrayExport, ExportRecordBatch) {
-  struct ArrowSchema c_schema{};
-  struct ArrowArray c_array{};
+  struct ArrowSchema c_schema {};
+  struct ArrowArray c_array {};
 
   auto schema = ::arrow::schema(
       {field("ints", int16()), field("bools", boolean(), /*nullable=*/false)});
@@ -948,9 +943,7 @@ TEST_F(TestArrayExport, ExportRecordBatch) {
   auto arr0 = ArrayFromJSON(int16(), "[1, 2, null]");
   auto arr1 = ArrayFromJSON(boolean(), "[false, true, false]");
 
-  auto batch_factory = [&]() {
-    return RecordBatch::Make(schema, 3, {arr0, arr1});
-  };
+  auto batch_factory = [&]() { return RecordBatch::Make(schema, 3, {arr0, arr1}); };
 
   {
     auto batch = batch_factory();
@@ -988,9 +981,7 @@ TEST_F(TestArrayExport, ExportRecordBatch) {
 ////////////////////////////////////////////////////////////////////////////
 // Schema import tests
 
-void NoOpSchemaRelease(struct ArrowSchema* schema) {
-  ArrowSchemaMarkReleased(schema);
-}
+void NoOpSchemaRelease(struct ArrowSchema* schema) { ArrowSchemaMarkReleased(schema); }
 
 class SchemaStructBuilder {
  public:
@@ -1042,8 +1033,8 @@ class SchemaStructBuilder {
 
   void FillDictionary(struct ArrowSchema* c) { c->dictionary = LastChild(c); }
 
-  void FillListLike(struct ArrowSchema* c, const char* format,
-                    const char* name = nullptr, int64_t flags = kDefaultFlags) {
+  void FillListLike(struct ArrowSchema* c, const char* format, const char* name = nullptr,
+                    int64_t flags = kDefaultFlags) {
     c->flags = flags;
     c->format = format;
     c->name = name;
@@ -1052,9 +1043,8 @@ class SchemaStructBuilder {
     c->children[0]->name = "item";
   }
 
-  void FillStructLike(struct ArrowSchema* c, const char* format,
-                      int64_t n_children, const char* name = nullptr,
-                      int64_t flags = kDefaultFlags) {
+  void FillStructLike(struct ArrowSchema* c, const char* format, int64_t n_children,
+                      const char* name = nullptr, int64_t flags = kDefaultFlags) {
     c->flags = flags;
     c->format = format;
     c->name = name;
@@ -1074,8 +1064,8 @@ class SchemaStructBuilder {
     FillListLike(&c_struct_, format, name, flags);
   }
 
-  void FillStructLike(const char* format, int64_t n_children,
-                      const char* name = nullptr, int64_t flags = kDefaultFlags) {
+  void FillStructLike(const char* format, int64_t n_children, const char* name = nullptr,
+                      int64_t flags = kDefaultFlags) {
     FillStructLike(&c_struct_, format, n_children, name, flags);
   }
 
@@ -1088,16 +1078,14 @@ class SchemaStructBuilder {
 
 class TestSchemaImport : public ::testing::Test, public SchemaStructBuilder {
  public:
-  void SetUp() override {
-    Reset();
-  }
+  void SetUp() override { Reset(); }
 
   void CheckImport(const std::shared_ptr<DataType>& expected) {
     SchemaReleaseCallback cb(&c_struct_);
 
     ASSERT_OK_AND_ASSIGN(auto type, ImportType(&c_struct_));
     ASSERT_TRUE(ArrowSchemaIsReleased(&c_struct_));
-    Reset();  // for further tests
+    Reset();            // for further tests
     cb.AssertCalled();  // was released
     AssertTypeEqual(*expected, *type);
   }
@@ -1107,7 +1095,7 @@ class TestSchemaImport : public ::testing::Test, public SchemaStructBuilder {
 
     ASSERT_OK_AND_ASSIGN(auto field, ImportField(&c_struct_));
     ASSERT_TRUE(ArrowSchemaIsReleased(&c_struct_));
-    Reset();  // for further tests
+    Reset();            // for further tests
     cb.AssertCalled();  // was released
     AssertFieldEqual(*expected, *field);
   }
@@ -1117,7 +1105,7 @@ class TestSchemaImport : public ::testing::Test, public SchemaStructBuilder {
 
     ASSERT_OK_AND_ASSIGN(auto schema, ImportSchema(&c_struct_));
     ASSERT_TRUE(ArrowSchemaIsReleased(&c_struct_));
-    Reset();  // for further tests
+    Reset();            // for further tests
     cb.AssertCalled();  // was released
     AssertSchemaEqual(*expected, *schema);
   }
@@ -1240,7 +1228,7 @@ TEST_F(TestSchemaImport, List) {
 
   FillPrimitive(AddChild(), "s", "item", 0);
   FillListLike("+l");
-  CheckImport(list(field("item", int16(), /*nullable=*/ false)));
+  CheckImport(list(field("item", int16(), /*nullable=*/false)));
 
   // Large list
   FillPrimitive(AddChild(), "s");
@@ -1275,8 +1263,8 @@ TEST_F(TestSchemaImport, Struct) {
   FillPrimitive(AddChild(), "u", "strs", 0);
   FillPrimitive(AddChild(), "S", "ints", kDefaultFlags);
   FillStructLike("+s", 2);
-  expected = struct_({field("strs", utf8(), /*nullable=*/false),
-                      field("ints", uint16())});
+  expected =
+      struct_({field("strs", utf8(), /*nullable=*/false), field("ints", uint16())});
   CheckImport(expected);
 
   // With metadata
@@ -1285,10 +1273,9 @@ TEST_F(TestSchemaImport, Struct) {
   c->metadata = kEncodedMetadata2.c_str();
   FillPrimitive(AddChild(), "S", "ints", kDefaultFlags);
   FillStructLike("+s", 2);
-  expected = struct_(
-      {field("strs", utf8(), /*nullable=*/false,
-             key_value_metadata(kMetadataKeys2, kMetadataValues2)),
-       field("ints", uint16())});
+  expected = struct_({field("strs", utf8(), /*nullable=*/false,
+                            key_value_metadata(kMetadataKeys2, kMetadataValues2)),
+                      field("ints", uint16())});
   CheckImport(expected);
 }
 
@@ -1297,16 +1284,14 @@ TEST_F(TestSchemaImport, Union) {
   FillPrimitive(AddChild(), "u", "strs");
   FillPrimitive(AddChild(), "c", "ints");
   FillStructLike("+us:43,42", 2);
-  auto expected =
-      sparse_union({field("strs", utf8()), field("ints", int8())}, {43, 42});
+  auto expected = sparse_union({field("strs", utf8()), field("ints", int8())}, {43, 42});
   CheckImport(expected);
 
   // Dense
   FillPrimitive(AddChild(), "u", "strs");
   FillPrimitive(AddChild(), "c", "ints");
   FillStructLike("+ud:43,42", 2);
-  expected =
-      dense_union({field("strs", utf8()), field("ints", int8())}, {43, 42});
+  expected = dense_union({field("strs", utf8()), field("ints", int8())}, {43, 42});
   CheckImport(expected);
 }
 
@@ -1322,7 +1307,7 @@ TEST_F(TestSchemaImport, Map) {
   FillPrimitive(AddChild(), "i", "value");
   FillStructLike(AddChild(), "+s", 2, "entries");
   FillListLike("+m", "", ARROW_FLAG_MAP_KEYS_SORTED);
-  expected = map(utf8(), int32(), /*keys_sorted=*/ true);
+  expected = map(utf8(), int32(), /*keys_sorted=*/true);
   CheckImport(expected);
 }
 
@@ -1446,11 +1431,11 @@ TEST_F(TestSchemaImport, ImportField) {
   FillPrimitive("c", "thing", kDefaultFlags);
   CheckImport(field("thing", int8()));
   FillPrimitive("c", "thing", 0);
-  CheckImport(field("thing", int8(), /*nullable=*/ false));
+  CheckImport(field("thing", int8(), /*nullable=*/false));
   // With metadata
   FillPrimitive("c", "thing", kDefaultFlags);
   c_struct_.metadata = kEncodedMetadata1.c_str();
-  CheckImport(field("thing", int8(), /*nullable=*/ true,
+  CheckImport(field("thing", int8(), /*nullable=*/true,
                     key_value_metadata(kMetadataKeys1, kMetadataValues1)));
 }
 
@@ -1517,9 +1502,9 @@ static const void* primitive_buffers_no_nulls1_64[2] = {nullptr, data_buffer1};
 static const void* primitive_buffers_nulls1_8[2] = {bits_buffer1, data_buffer1};
 static const void* primitive_buffers_nulls1_16[2] = {bits_buffer1, data_buffer1};
 #else
-static const uint8_t data_buffer1_16[] = {2,  1,  4,  3,  6,  5,  8,  7,
+static const uint8_t data_buffer1_16[] = {2,  1, 4,  3,  6,  5,  8,  7,
                                           10, 9, 12, 11, 14, 13, 16, 15};
-static const uint8_t data_buffer1_32[] = {4,  3,  2,  1,  8,  7,  6,  5,
+static const uint8_t data_buffer1_32[] = {4,  3,  2,  1, 8,  7,  6,  5,
                                           12, 11, 10, 9, 16, 15, 14, 13};
 static const uint8_t data_buffer1_64[] = {8,  7,  6,  5,  4,  3,  2,  1,
                                           16, 15, 14, 13, 12, 11, 10, 9};
@@ -1577,15 +1562,11 @@ static const void* sparse_union_buffers_no_nulls1[3] = {nullptr, type_codes_buff
 static const void* dense_union_buffers_no_nulls1[3] = {nullptr, type_codes_buffer1,
                                                        union_offsets_buffer1};
 
-void NoOpArrayRelease(struct ArrowArray* schema) {
-  ArrowArrayMarkReleased(schema);
-}
+void NoOpArrayRelease(struct ArrowArray* schema) { ArrowArrayMarkReleased(schema); }
 
 class TestArrayImport : public ::testing::Test {
  public:
-  void SetUp() override {
-    Reset();
-  }
+  void SetUp() override { Reset(); }
 
   void Reset() {
     memset(&c_struct_, 0, sizeof(c_struct_));
@@ -1624,8 +1605,8 @@ class TestArrayImport : public ::testing::Test {
     return *NLastChildren(1, parent);
   }
 
-  void FillPrimitive(struct ArrowArray* c, int64_t length,
-                     int64_t null_count, int64_t offset, const void** buffers) {
+  void FillPrimitive(struct ArrowArray* c, int64_t length, int64_t null_count,
+                     int64_t offset, const void** buffers) {
     c->length = length;
     c->null_count = null_count;
     c->offset = offset;
@@ -1635,8 +1616,8 @@ class TestArrayImport : public ::testing::Test {
 
   void FillDictionary(struct ArrowArray* c) { c->dictionary = LastChild(c); }
 
-  void FillStringLike(struct ArrowArray* c, int64_t length,
-                      int64_t null_count, int64_t offset, const void** buffers) {
+  void FillStringLike(struct ArrowArray* c, int64_t length, int64_t null_count,
+                      int64_t offset, const void** buffers) {
     c->length = length;
     c->null_count = null_count;
     c->offset = offset;
@@ -1644,8 +1625,8 @@ class TestArrayImport : public ::testing::Test {
     c->buffers = buffers;
   }
 
-  void FillListLike(struct ArrowArray* c, int64_t length,
-                    int64_t null_count, int64_t offset, const void** buffers) {
+  void FillListLike(struct ArrowArray* c, int64_t length, int64_t null_count,
+                    int64_t offset, const void** buffers) {
     c->length = length;
     c->null_count = null_count;
     c->offset = offset;
@@ -1655,8 +1636,8 @@ class TestArrayImport : public ::testing::Test {
     c->children = NLastChildren(1, c);
   }
 
-  void FillFixedSizeListLike(struct ArrowArray* c, int64_t length,
-                             int64_t null_count, int64_t offset, const void** buffers) {
+  void FillFixedSizeListLike(struct ArrowArray* c, int64_t length, int64_t null_count,
+                             int64_t offset, const void** buffers) {
     c->length = length;
     c->null_count = null_count;
     c->offset = offset;
@@ -1666,9 +1647,8 @@ class TestArrayImport : public ::testing::Test {
     c->children = NLastChildren(1, c);
   }
 
-  void FillStructLike(struct ArrowArray* c, int64_t length,
-                      int64_t null_count, int64_t offset,
-                      int64_t n_children, const void** buffers) {
+  void FillStructLike(struct ArrowArray* c, int64_t length, int64_t null_count,
+                      int64_t offset, int64_t n_children, const void** buffers) {
     c->length = length;
     c->null_count = null_count;
     c->offset = offset;
@@ -1679,8 +1659,8 @@ class TestArrayImport : public ::testing::Test {
   }
 
   void FillUnionLike(struct ArrowArray* c, UnionMode::type mode, int64_t length,
-                     int64_t null_count, int64_t offset,
-                     int64_t n_children, const void** buffers) {
+                     int64_t null_count, int64_t offset, int64_t n_children,
+                     const void** buffers) {
     c->length = length;
     c->null_count = null_count;
     c->offset = offset;
@@ -1690,37 +1670,35 @@ class TestArrayImport : public ::testing::Test {
     c->children = NLastChildren(c->n_children, c);
   }
 
-  void FillPrimitive(int64_t length, int64_t null_count,
-                     int64_t offset, const void** buffers) {
+  void FillPrimitive(int64_t length, int64_t null_count, int64_t offset,
+                     const void** buffers) {
     FillPrimitive(&c_struct_, length, null_count, offset, buffers);
   }
 
   void FillDictionary() { FillDictionary(&c_struct_); }
 
-  void FillStringLike(int64_t length, int64_t null_count,
-                      int64_t offset, const void** buffers) {
+  void FillStringLike(int64_t length, int64_t null_count, int64_t offset,
+                      const void** buffers) {
     FillStringLike(&c_struct_, length, null_count, offset, buffers);
   }
 
-  void FillListLike(int64_t length, int64_t null_count,
-                    int64_t offset, const void** buffers) {
+  void FillListLike(int64_t length, int64_t null_count, int64_t offset,
+                    const void** buffers) {
     FillListLike(&c_struct_, length, null_count, offset, buffers);
   }
 
-  void FillFixedSizeListLike(int64_t length, int64_t null_count,
-                             int64_t offset, const void** buffers) {
+  void FillFixedSizeListLike(int64_t length, int64_t null_count, int64_t offset,
+                             const void** buffers) {
     FillFixedSizeListLike(&c_struct_, length, null_count, offset, buffers);
   }
 
-  void FillStructLike(int64_t length, int64_t null_count,
-                      int64_t offset, int64_t n_children,
-                      const void** buffers) {
+  void FillStructLike(int64_t length, int64_t null_count, int64_t offset,
+                      int64_t n_children, const void** buffers) {
     FillStructLike(&c_struct_, length, null_count, offset, n_children, buffers);
   }
 
   void FillUnionLike(UnionMode::type mode, int64_t length, int64_t null_count,
-                     int64_t offset, int64_t n_children,
-                     const void** buffers) {
+                     int64_t offset, int64_t n_children, const void** buffers) {
     FillUnionLike(&c_struct_, mode, length, null_count, offset, n_children, buffers);
   }
 
@@ -1730,7 +1708,7 @@ class TestArrayImport : public ::testing::Test {
     auto type = expected->type();
     ASSERT_OK_AND_ASSIGN(auto array, ImportArray(&c_struct_, type));
     ASSERT_TRUE(ArrowArrayIsReleased(&c_struct_));  // was moved
-    Reset();  // for further tests
+    Reset();                                        // for further tests
 
     ASSERT_OK(array->ValidateFull());
     // Special case: Null array doesn't have any data, so it needn't
@@ -1749,7 +1727,7 @@ class TestArrayImport : public ::testing::Test {
     auto schema = expected->schema();
     ASSERT_OK_AND_ASSIGN(auto batch, ImportRecordBatch(&c_struct_, schema));
     ASSERT_TRUE(ArrowArrayIsReleased(&c_struct_));  // was moved
-    Reset();  // for further tests
+    Reset();                                        // for further tests
 
     ASSERT_OK(batch->ValidateFull());
     AssertBatchesEqual(*expected, *batch);
@@ -1763,7 +1741,7 @@ class TestArrayImport : public ::testing::Test {
 
     ASSERT_RAISES(Invalid, ImportArray(&c_struct_, type));
     ASSERT_TRUE(ArrowArrayIsReleased(&c_struct_));
-    Reset();  // for further tests
+    Reset();            // for further tests
     cb.AssertCalled();  // was released
   }
 
@@ -1772,7 +1750,7 @@ class TestArrayImport : public ::testing::Test {
 
     ASSERT_RAISES(Invalid, ImportRecordBatch(&c_struct_, schema));
     ASSERT_TRUE(ArrowArrayIsReleased(&c_struct_));
-    Reset();  // for further tests
+    Reset();            // for further tests
     cb.AssertCalled();  // was released
   }
 
@@ -2023,8 +2001,7 @@ TEST_F(TestArrayImport, Union) {
   FillStringLike(AddChild(), 4, 0, 0, string_buffers_no_nulls1);
   FillPrimitive(AddChild(), 4, -1, 0, primitive_buffers_nulls1_8);
   FillUnionLike(UnionMode::SPARSE, 4, 0, 0, 2, sparse_union_buffers_no_nulls1);
-  auto type =
-      sparse_union({field("strs", utf8()), field("ints", int8())}, {43, 42});
+  auto type = sparse_union({field("strs", utf8()), field("ints", int8())}, {43, 42});
   auto expected =
       ArrayFromJSON(type, R"([[42, 1], [42, null], [43, "bar"], [43, "quux"]])");
   CheckImport(expected);
@@ -2033,8 +2010,7 @@ TEST_F(TestArrayImport, Union) {
   FillStringLike(AddChild(), 2, 0, 0, string_buffers_no_nulls1);
   FillPrimitive(AddChild(), 3, -1, 0, primitive_buffers_nulls1_8);
   FillUnionLike(UnionMode::DENSE, 5, 0, 0, 2, dense_union_buffers_no_nulls1);
-  type =
-      dense_union({field("strs", utf8()), field("ints", int8())}, {43, 42});
+  type = dense_union({field("strs", utf8()), field("ints", int8())}, {43, 42});
   expected =
       ArrayFromJSON(type, R"([[42, 1], [42, null], [43, "foo"], [43, ""], [42, 3]])");
   CheckImport(expected);
@@ -2076,9 +2052,9 @@ TEST_F(TestArrayImport, Dictionary) {
 
   auto dict_values = ArrayFromJSON(utf8(), R"(["foo", "", "bar", "quux"])");
   auto indices = ArrayFromJSON(int8(), "[1, 2, 0, 1, 3, 0]");
-  ASSERT_OK_AND_ASSIGN(auto expected,
-                       DictionaryArray::FromArrays(dictionary(int8(), utf8()),
-                                                   indices, dict_values));
+  ASSERT_OK_AND_ASSIGN(
+      auto expected,
+      DictionaryArray::FromArrays(dictionary(int8(), utf8()), indices, dict_values));
   CheckImport(expected);
 
   FillStringLike(AddChild(), 4, 0, 0, string_buffers_no_nulls1);
@@ -2086,9 +2062,8 @@ TEST_F(TestArrayImport, Dictionary) {
   FillDictionary();
 
   ASSERT_OK_AND_ASSIGN(
-      expected,
-      DictionaryArray::FromArrays(dictionary(int8(), utf8(), /*ordered=*/true),
-                                  indices, dict_values));
+      expected, DictionaryArray::FromArrays(dictionary(int8(), utf8(), /*ordered=*/true),
+                                            indices, dict_values));
   CheckImport(expected);
 }
 
@@ -2112,12 +2087,11 @@ TEST_F(TestArrayImport, NestedDictionary) {
 
   dict_values = ArrayFromJSON(utf8(), R"(["foo", "", "bar", "quux"])");
   indices = ArrayFromJSON(int8(), "[1, 2, 0, 1, 3, 0]");
-  ASSERT_OK_AND_ASSIGN(auto dict_array,
-                       DictionaryArray::FromArrays(dictionary(int8(), utf8()),
-                                                   indices, dict_values));
+  ASSERT_OK_AND_ASSIGN(
+      auto dict_array,
+      DictionaryArray::FromArrays(dictionary(int8(), utf8()), indices, dict_values));
   auto offsets = ArrayFromJSON(int32(), "[0, 2, 2, 5]");
-  ASSERT_OK_AND_ASSIGN(expected,
-                       ListArray::FromArrays(*offsets, *dict_array));
+  ASSERT_OK_AND_ASSIGN(expected, ListArray::FromArrays(*offsets, *dict_array));
   CheckImport(expected);
 }
 
@@ -2128,9 +2102,9 @@ TEST_F(TestArrayImport, DictionaryWithOffset) {
 
   auto dict_values = ArrayFromJSON(utf8(), R"(["", "bar", "quux"])");
   auto indices = ArrayFromJSON(int8(), "[1, 2, 0]");
-  ASSERT_OK_AND_ASSIGN(auto expected,
-                       DictionaryArray::FromArrays(dictionary(int8(), utf8()),
-                                                   indices, dict_values));
+  ASSERT_OK_AND_ASSIGN(
+      auto expected,
+      DictionaryArray::FromArrays(dictionary(int8(), utf8()), indices, dict_values));
   CheckImport(expected);
 
   FillStringLike(AddChild(), 4, 0, 0, string_buffers_no_nulls1);
@@ -2139,9 +2113,8 @@ TEST_F(TestArrayImport, DictionaryWithOffset) {
 
   dict_values = ArrayFromJSON(utf8(), R"(["foo", "", "bar", "quux"])");
   indices = ArrayFromJSON(int8(), "[0, 1, 3, 0]");
-  ASSERT_OK_AND_ASSIGN(expected,
-                       DictionaryArray::FromArrays(dictionary(int8(), utf8()),
-                                                   indices, dict_values));
+  ASSERT_OK_AND_ASSIGN(expected, DictionaryArray::FromArrays(dictionary(int8(), utf8()),
+                                                             indices, dict_values));
   CheckImport(expected);
 }
 
@@ -2308,7 +2281,7 @@ class TestSchemaRoundtrip : public ::testing::Test {
   template <typename TypeFactory>
   void TestWithTypeFactory(TypeFactory&& factory) {
     std::shared_ptr<DataType> type, actual;
-    struct ArrowSchema c_schema{};  // zeroed
+    struct ArrowSchema c_schema {};  // zeroed
     SchemaExportGuard schema_guard(&c_schema);
 
     auto orig_bytes = pool_->bytes_allocated();
@@ -2334,7 +2307,7 @@ class TestSchemaRoundtrip : public ::testing::Test {
   template <typename SchemaFactory>
   void TestWithSchemaFactory(SchemaFactory&& factory) {
     std::shared_ptr<Schema> schema, actual;
-    struct ArrowSchema c_schema{};  // zeroed
+    struct ArrowSchema c_schema {};  // zeroed
     SchemaExportGuard schema_guard(&c_schema);
 
     auto orig_bytes = pool_->bytes_allocated();
@@ -2361,9 +2334,7 @@ class TestSchemaRoundtrip : public ::testing::Test {
   MemoryPool* pool_;
 };
 
-TEST_F(TestSchemaRoundtrip, Null) {
-  TestWithTypeFactory(null);
-}
+TEST_F(TestSchemaRoundtrip, Null) { TestWithTypeFactory(null); }
 
 TEST_F(TestSchemaRoundtrip, Primitive) {
   TestWithTypeFactory(int32);
@@ -2393,7 +2364,7 @@ TEST_F(TestSchemaRoundtrip, List) {
 }
 
 TEST_F(TestSchemaRoundtrip, Struct) {
-  auto f1 = field("f1", utf8(), /*nullable=*/ false);
+  auto f1 = field("f1", utf8(), /*nullable=*/false);
   auto f2 = field("f2", list(decimal(19, 4)));
 
   TestWithTypeFactory([&]() { return struct_({f1, f2}); });
@@ -2402,7 +2373,7 @@ TEST_F(TestSchemaRoundtrip, Struct) {
 }
 
 TEST_F(TestSchemaRoundtrip, Union) {
-  auto f1 = field("f1", utf8(), /*nullable=*/ false);
+  auto f1 = field("f1", utf8(), /*nullable=*/false);
   auto f2 = field("f2", list(decimal(19, 4)));
   auto type_codes = std::vector<int8_t>{42, 43};
 
@@ -2413,7 +2384,7 @@ TEST_F(TestSchemaRoundtrip, Union) {
 
 TEST_F(TestSchemaRoundtrip, Dictionary) {
   TestWithTypeFactory([&]() { return dictionary(int32(), utf8()); });
-  TestWithTypeFactory([&]() { return dictionary(int32(), utf8(), /*ordered=*/ true); });
+  TestWithTypeFactory([&]() { return dictionary(int32(), utf8(), /*ordered=*/true); });
 
   TestWithTypeFactory([&]() { return dictionary(int32(), list(utf8())); });
   TestWithTypeFactory([&]() { return list(dictionary(int32(), list(utf8()))); });
@@ -2426,7 +2397,7 @@ TEST_F(TestSchemaRoundtrip, Map) {
 }
 
 TEST_F(TestSchemaRoundtrip, Schema) {
-  auto f1 = field("f1", utf8(), /*nullable=*/ false);
+  auto f1 = field("f1", utf8(), /*nullable=*/false);
   auto f2 = field("f2", list(decimal(19, 4)));
   auto md1 = key_value_metadata(kMetadataKeys1, kMetadataValues1);
   auto md2 = key_value_metadata(kMetadataKeys2, kMetadataValues2);
@@ -2465,8 +2436,8 @@ class TestArrayRoundtrip : public ::testing::Test {
   template <typename ArrayFactory>
   void TestWithArrayFactory(ArrayFactory&& factory) {
     std::shared_ptr<Array> array;
-    struct ArrowArray c_array{};
-    struct ArrowSchema c_schema{};
+    struct ArrowArray c_array {};
+    struct ArrowSchema c_schema {};
     ArrayExportGuard array_guard(&c_array);
     SchemaExportGuard schema_guard(&c_schema);
 
@@ -2510,8 +2481,8 @@ class TestArrayRoundtrip : public ::testing::Test {
   template <typename BatchFactory>
   void TestWithBatchFactory(BatchFactory&& factory) {
     std::shared_ptr<RecordBatch> batch;
-    struct ArrowArray c_array{};
-    struct ArrowSchema c_schema{};
+    struct ArrowArray c_array {};
+    struct ArrowSchema c_schema {};
     ArrayExportGuard array_guard(&c_array);
     SchemaExportGuard schema_guard(&c_schema);
 
@@ -2576,15 +2547,16 @@ TEST_F(TestArrayRoundtrip, Primitive) {
 }
 
 TEST_F(TestArrayRoundtrip, UnknownNullCount) {
-    TestWithArrayFactory([](std::shared_ptr<Array>* arr) -> Status {
+  TestWithArrayFactory([](std::shared_ptr<Array>* arr) -> Status {
     *arr = ArrayFromJSON(int32(), "[0, 1, 2]");
     if ((*arr)->null_bitmap()) {
-      return Status::Invalid("Failed precondition: "
-                             "the array shouldn't have a null bitmap.");
+      return Status::Invalid(
+          "Failed precondition: "
+          "the array shouldn't have a null bitmap.");
     }
     (*arr)->data()->SetNullCount(kUnknownNullCount);
     return Status::OK();
-    });
+  });
 }
 
 TEST_F(TestArrayRoundtrip, Nested) {
@@ -2617,7 +2589,7 @@ TEST_F(TestArrayRoundtrip, Nested) {
   TestWithJSON(type, json);
   TestWithJSONSliced(type, json);
 
-  type = map(utf8(), int32(), /*keys_sorted=*/ true);
+  type = map(utf8(), int32(), /*keys_sorted=*/true);
   TestWithJSON(type, json);
   TestWithJSONSliced(type, json);
 }
@@ -2628,7 +2600,8 @@ TEST_F(TestArrayRoundtrip, Dictionary) {
       auto values = ArrayFromJSON(utf8(), R"(["foo", "bar", "quux"])");
       auto indices = ArrayFromJSON(int32(), "[0, 2, 1, null, 1]");
       return DictionaryArray::FromArrays(dictionary(indices->type(), values->type()),
-                                         indices, values).Value(out);
+                                         indices, values)
+          .Value(out);
     };
     TestWithArrayFactory(factory);
     TestWithArrayFactory(SlicedArrayFactory(factory));
@@ -2638,8 +2611,9 @@ TEST_F(TestArrayRoundtrip, Dictionary) {
       auto values = ArrayFromJSON(list(utf8()), R"([["abc", "def"], ["efg"], []])");
       auto indices = ArrayFromJSON(int32(), "[0, 2, 1, null, 1]");
       return DictionaryArray::FromArrays(
-          dictionary(indices->type(), values->type(), /*ordered=*/true),
-          indices, values).Value(out);
+                 dictionary(indices->type(), values->type(), /*ordered=*/true), indices,
+                 values)
+          .Value(out);
     };
     TestWithArrayFactory(factory);
     TestWithArrayFactory(SlicedArrayFactory(factory));
@@ -2665,8 +2639,8 @@ TEST_F(TestArrayRoundtrip, RecordBatch) {
       auto f0 = schema->field(0);
       auto f1 = schema->field(1);
       f1 = f1->WithMetadata(key_value_metadata(kMetadataKeys1, kMetadataValues1));
-      auto schema_with_md = ::arrow::schema({f0, f1},
-          key_value_metadata(kMetadataKeys2, kMetadataValues2));
+      auto schema_with_md =
+          ::arrow::schema({f0, f1}, key_value_metadata(kMetadataKeys2, kMetadataValues2));
       *out = RecordBatch::Make(schema_with_md, 3, {arr0, arr1});
       return Status::OK();
     };

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -113,6 +113,7 @@
 #  define ARROW_DEPRECATED_USING(...)
 # endif
 #endif
+// clang-format on
 
 // ----------------------------------------------------------------------
 


### PR DESCRIPTION
I discovered a place where clang-format was left disabled by accident relatively early in a file and so doing the reformatting as a separate PR to not have the diff noise in another patch. 