### PR TITLE
ARROW-9121: [C++] Forbid empty or root path in FileSystem::DeleteDirContents

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -253,8 +253,19 @@ Status SubTreeFileSystem::DeleteDir(const std::string& path) {
 }
 
 Status SubTreeFileSystem::DeleteDirContents(const std::string& path) {
+  if (internal::IsEmptyPath(path)) {
+    return internal::InvalidDeleteDirContents(path);
+  }
   auto s = PrependBase(path);
   return base_fs_->DeleteDirContents(s);
+}
+
+Status SubTreeFileSystem::DeleteRootDirContents() {
+  if (base_path_.empty()) {
+    return base_fs_->DeleteRootDirContents();
+  } else {
+    return base_fs_->DeleteDirContents(base_path_);
+  }
 }
 
 Status SubTreeFileSystem::DeleteFile(const std::string& path) {
@@ -365,6 +376,11 @@ Status SlowFileSystem::DeleteDir(const std::string& path) {
 Status SlowFileSystem::DeleteDirContents(const std::string& path) {
   latencies_->Sleep();
   return base_fs_->DeleteDirContents(path);
+}
+
+Status SlowFileSystem::DeleteRootDirContents() {
+  latencies_->Sleep();
+  return base_fs_->DeleteRootDirContents();
 }
 
 Status SlowFileSystem::DeleteFile(const std::string& path) {

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -181,8 +181,15 @@ class ARROW_EXPORT FileSystem : public std::enable_shared_from_this<FileSystem> 
   /// Delete a directory's contents, recursively.
   ///
   /// Like DeleteDir, but doesn't delete the directory itself.
-  /// Passing an empty path ("") will wipe the entire filesystem tree.
+  /// Passing an empty path ("" or "/") is disallowed, see DeleteRootDirContents.
   virtual Status DeleteDirContents(const std::string& path) = 0;
+
+  /// EXPERIMENTAL: Delete the root directory's contents, recursively.
+  ///
+  /// Implementations may decide to raise an error if this operation is
+  /// too dangerous.
+  // NOTE: may decide to remove this if it's deemed not useful
+  virtual Status DeleteRootDirContents() = 0;
 
   /// Delete a file.
   virtual Status DeleteFile(const std::string& path) = 0;
@@ -273,6 +280,7 @@ class ARROW_EXPORT SubTreeFileSystem : public FileSystem {
 
   Status DeleteDir(const std::string& path) override;
   Status DeleteDirContents(const std::string& path) override;
+  Status DeleteRootDirContents() override;
 
   Status DeleteFile(const std::string& path) override;
 
@@ -328,6 +336,7 @@ class ARROW_EXPORT SlowFileSystem : public FileSystem {
 
   Status DeleteDir(const std::string& path) override;
   Status DeleteDirContents(const std::string& path) override;
+  Status DeleteRootDirContents() override;
 
   Status DeleteFile(const std::string& path) override;
 

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -22,6 +22,7 @@
 
 #include "arrow/filesystem/hdfs.h"
 #include "arrow/filesystem/path_util.h"
+#include "arrow/filesystem/util_internal.h"
 #include "arrow/io/hdfs.h"
 #include "arrow/io/hdfs_internal.h"
 #include "arrow/util/checked_cast.h"
@@ -421,8 +422,13 @@ Status HadoopFileSystem::DeleteDir(const std::string& path) {
 }
 
 Status HadoopFileSystem::DeleteDirContents(const std::string& path) {
+  if (internal::IsEmptyPath(path)) {
+    return internal::InvalidDeleteDirContents(path);
+  }
   return impl_->DeleteDirContents(path);
 }
+
+Status HadoopFileSystem::DeleteRootDirContents() { return impl_->DeleteDirContents(""); }
 
 Status HadoopFileSystem::DeleteFile(const std::string& path) {
   return impl_->DeleteFile(path);

--- a/cpp/src/arrow/filesystem/hdfs.h
+++ b/cpp/src/arrow/filesystem/hdfs.h
@@ -79,6 +79,8 @@ class ARROW_EXPORT HadoopFileSystem : public FileSystem {
 
   Status DeleteDirContents(const std::string& path) override;
 
+  Status DeleteRootDirContents() override;
+
   Status DeleteFile(const std::string& path) override;
 
   Status Move(const std::string& src, const std::string& dest) override;

--- a/cpp/src/arrow/filesystem/localfs.cc
+++ b/cpp/src/arrow/filesystem/localfs.cc
@@ -319,6 +319,9 @@ Status LocalFileSystem::DeleteDir(const std::string& path) {
 }
 
 Status LocalFileSystem::DeleteDirContents(const std::string& path) {
+  if (internal::IsEmptyPath(path)) {
+    return internal::InvalidDeleteDirContents(path);
+  }
   ARROW_ASSIGN_OR_RAISE(auto fn, PlatformFilename::FromString(path));
   auto st = ::arrow::internal::DeleteDirContents(fn, /*allow_not_found=*/false).status();
   if (!st.ok()) {
@@ -327,6 +330,10 @@ Status LocalFileSystem::DeleteDirContents(const std::string& path) {
     return st.WithMessage(ss.str());
   }
   return Status::OK();
+}
+
+Status LocalFileSystem::DeleteRootDirContents() {
+  return Status::Invalid("LocalFileSystem::DeleteRootDirContents is strictly forbidden");
 }
 
 Status LocalFileSystem::DeleteFile(const std::string& path) {

--- a/cpp/src/arrow/filesystem/localfs.h
+++ b/cpp/src/arrow/filesystem/localfs.h
@@ -77,6 +77,7 @@ class ARROW_EXPORT LocalFileSystem : public FileSystem {
 
   Status DeleteDir(const std::string& path) override;
   Status DeleteDirContents(const std::string& path) override;
+  Status DeleteRootDirContents() override;
 
   Status DeleteFile(const std::string& path) override;
 

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -426,8 +426,7 @@ Status MockFileSystem::DeleteDirContents(const std::string& path) {
 
   if (parts.empty()) {
     // Wipe filesystem
-    impl_->RootDir().entries.clear();
-    return Status::OK();
+    return internal::InvalidDeleteDirContents(path);
   }
 
   Entry* entry = impl_->FindEntry(parts);
@@ -438,6 +437,11 @@ Status MockFileSystem::DeleteDirContents(const std::string& path) {
     return NotADir(path);
   }
   entry->as_dir().entries.clear();
+  return Status::OK();
+}
+
+Status MockFileSystem::DeleteRootDirContents() {
+  impl_->RootDir().entries.clear();
   return Status::OK();
 }
 

--- a/cpp/src/arrow/filesystem/mockfs.h
+++ b/cpp/src/arrow/filesystem/mockfs.h
@@ -75,6 +75,7 @@ class ARROW_EXPORT MockFileSystem : public FileSystem {
 
   Status DeleteDir(const std::string& path) override;
   Status DeleteDirContents(const std::string& path) override;
+  Status DeleteRootDirContents() override;
 
   Status DeleteFile(const std::string& path) override;
 

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -227,6 +227,15 @@ std::string ToSlashes(util::string_view v) {
   return s;
 }
 
+bool IsEmptyPath(util::string_view v) {
+  for (const auto c : v) {
+    if (c != '/') {
+      return false;
+    }
+  }
+  return true;
+}
+
 }  // namespace internal
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -114,6 +114,9 @@ std::string ToBackslashes(util::string_view s);
 ARROW_EXPORT
 std::string ToSlashes(util::string_view s);
 
+ARROW_EXPORT
+bool IsEmptyPath(util::string_view s);
+
 }  // namespace internal
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1433,6 +1433,10 @@ Status S3FileSystem::DeleteDirContents(const std::string& s) {
   return impl_->EnsureDirectoryExists(path);
 }
 
+Status S3FileSystem::DeleteRootDirContents() {
+  return Status::NotImplemented("Cannot delete all S3 buckets");
+}
+
 Status S3FileSystem::DeleteFile(const std::string& s) {
   ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));
   RETURN_NOT_OK(ValidateFilePath(path));

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -112,6 +112,7 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
 
   Status DeleteDir(const std::string& path) override;
   Status DeleteDirContents(const std::string& path) override;
+  Status DeleteRootDirContents() override;
 
   Status DeleteFile(const std::string& path) override;
 

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -241,20 +241,34 @@ void GenericFileSystemTest::TestDeleteDirContents(FileSystem* fs) {
   AssertAllDirs(fs, {"AB", "AB/CD", "AB/GH", "AB/GH/IJ"});
   AssertAllFiles(fs, {"AB/abc"});
 
-  // Also with "" (== wipe filesystem)
-  ASSERT_OK(fs->DeleteDirContents(""));
-  if (!have_flaky_directory_tree_deletion()) {
-    AssertAllDirs(fs, {});
-  }
-  AssertAllFiles(fs, {});
+  // Calling DeleteDirContents on root directory is disallowed
+  ASSERT_RAISES(Invalid, fs->DeleteDirContents(""));
+  ASSERT_RAISES(Invalid, fs->DeleteDirContents("/"));
+  AssertAllDirs(fs, {"AB", "AB/CD", "AB/GH", "AB/GH/IJ"});
+  AssertAllFiles(fs, {"AB/abc"});
 
   // Not a directory
   CreateFile(fs, "abc", "");
   ASSERT_RAISES(IOError, fs->DeleteDirContents("abc"));
-  if (!have_flaky_directory_tree_deletion()) {
-    AssertAllDirs(fs, {});
+  AssertAllFiles(fs, {"AB/abc", "abc"});
+}
+
+void GenericFileSystemTest::TestDeleteRootDirContents(FileSystem* fs) {
+  ASSERT_OK(fs->CreateDir("AB/CD"));
+  CreateFile(fs, "AB/abc", "");
+
+  auto st = fs->DeleteRootDirContents();
+  if (!st.ok()) {
+    // Not all filesystems support deleting root directory contents
+    ASSERT_TRUE(st.IsInvalid() || st.IsNotImplemented());
+    AssertAllDirs(fs, {"AB", "AB/CD"});
+    AssertAllFiles(fs, {"AB/abc"});
+  } else {
+    if (!have_flaky_directory_tree_deletion()) {
+      AssertAllDirs(fs, {});
+    }
+    AssertAllFiles(fs, {});
   }
-  AssertAllFiles(fs, {"abc"});
 }
 
 void GenericFileSystemTest::TestDeleteFile(FileSystem* fs) {
@@ -917,6 +931,7 @@ GENERIC_FS_TEST_DEFINE(TestNormalizePath)
 GENERIC_FS_TEST_DEFINE(TestCreateDir)
 GENERIC_FS_TEST_DEFINE(TestDeleteDir)
 GENERIC_FS_TEST_DEFINE(TestDeleteDirContents)
+GENERIC_FS_TEST_DEFINE(TestDeleteRootDirContents)
 GENERIC_FS_TEST_DEFINE(TestDeleteFile)
 GENERIC_FS_TEST_DEFINE(TestDeleteFiles)
 GENERIC_FS_TEST_DEFINE(TestMoveFile)

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -98,6 +98,7 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   void TestCreateDir();
   void TestDeleteDir();
   void TestDeleteDirContents();
+  void TestDeleteRootDirContents();
   void TestDeleteFile();
   void TestDeleteFiles();
   void TestMoveFile();
@@ -138,6 +139,7 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   void TestCreateDir(FileSystem* fs);
   void TestDeleteDir(FileSystem* fs);
   void TestDeleteDirContents(FileSystem* fs);
+  void TestDeleteRootDirContents(FileSystem* fs);
   void TestDeleteFile(FileSystem* fs);
   void TestDeleteFiles(FileSystem* fs);
   void TestMoveFile(FileSystem* fs);
@@ -164,6 +166,7 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, CreateDir)                        \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, DeleteDir)                        \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, DeleteDirContents)                \
+  GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, DeleteRootDirContents)            \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, DeleteFile)                       \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, DeleteFiles)                      \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, MoveFile)                         \

--- a/cpp/src/arrow/filesystem/util_internal.cc
+++ b/cpp/src/arrow/filesystem/util_internal.cc
@@ -59,6 +59,12 @@ Status NotAFile(const std::string& path) {
   return Status::IOError("Not a regular file: '", path, "'");
 }
 
+Status InvalidDeleteDirContents(const std::string& path) {
+  return Status::Invalid(
+      "DeleteDirContents called on invalid path '", path, "'. ",
+      "If you wish to delete the root directory's contents, call DeleteRootDirContents.");
+}
+
 FileSystemGlobalOptions global_options;
 
 }  // namespace internal

--- a/cpp/src/arrow/filesystem/util_internal.h
+++ b/cpp/src/arrow/filesystem/util_internal.h
@@ -45,6 +45,9 @@ Status NotADir(const std::string& path);
 ARROW_EXPORT
 Status NotAFile(const std::string& path);
 
+ARROW_EXPORT
+Status InvalidDeleteDirContents(const std::string& path);
+
 extern FileSystemGlobalOptions global_options;
 
 }  // namespace internal

--- a/cpp/src/arrow/python/filesystem.cc
+++ b/cpp/src/arrow/python/filesystem.cc
@@ -119,6 +119,13 @@ Status PyFileSystem::DeleteDirContents(const std::string& path) {
   });
 }
 
+Status PyFileSystem::DeleteRootDirContents() {
+  return SafeCallIntoPython([&]() -> Status {
+    vtable_.delete_root_dir_contents(handler_.obj());
+    return CheckPyError();
+  });
+}
+
 Status PyFileSystem::DeleteFile(const std::string& path) {
   return SafeCallIntoPython([&]() -> Status {
     vtable_.delete_file(handler_.obj(), path);

--- a/cpp/src/arrow/python/filesystem.h
+++ b/cpp/src/arrow/python/filesystem.h
@@ -47,6 +47,7 @@ class ARROW_PYTHON_EXPORT PyFileSystemVtable {
   std::function<void(PyObject*, const std::string& path, bool)> create_dir;
   std::function<void(PyObject*, const std::string& path)> delete_dir;
   std::function<void(PyObject*, const std::string& path)> delete_dir_contents;
+  std::function<void(PyObject*)> delete_root_dir_contents;
   std::function<void(PyObject*, const std::string& path)> delete_file;
   std::function<void(PyObject*, const std::string& src, const std::string& dest)> move;
   std::function<void(PyObject*, const std::string& src, const std::string& dest)>
@@ -87,6 +88,7 @@ class ARROW_PYTHON_EXPORT PyFileSystem : public arrow::fs::FileSystem {
 
   Status DeleteDir(const std::string& path) override;
   Status DeleteDirContents(const std::string& path) override;
+  Status DeleteRootDirContents() override;
 
   Status DeleteFile(const std::string& path) override;
 

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -475,7 +475,7 @@ cdef class FileSystem:
         with nogil:
             check_status(self.fs.DeleteDir(directory))
 
-    def delete_dir_contents(self, path):
+    def delete_dir_contents(self, path, *, bint accept_root_dir=False):
         """Delete a directory's contents, recursively.
 
         Like delete_dir, but doesn't delete the directory itself.
@@ -484,10 +484,17 @@ cdef class FileSystem:
         ----------
         path : str
             The path of the directory to be deleted.
+        accept_root_dir : boolean, default False
+            Allow deleting the root directory's contents
+            (if path is empty or "/")
         """
         cdef c_string directory = _path_as_bytes(path)
-        with nogil:
-            check_status(self.fs.DeleteDirContents(directory))
+        if accept_root_dir and directory in (b"", b"/"):
+            with nogil:
+                check_status(self.fs.DeleteRootDirContents())
+        else:
+            with nogil:
+                check_status(self.fs.DeleteDirContents(directory))
 
     def move(self, src, dest):
         """
@@ -836,6 +843,7 @@ cdef class PyFileSystem(FileSystem):
         vtable.create_dir = _cb_create_dir
         vtable.delete_dir = _cb_delete_dir
         vtable.delete_dir_contents = _cb_delete_dir_contents
+        vtable.delete_root_dir_contents = _cb_delete_root_dir_contents
         vtable.delete_file = _cb_delete_file
         vtable.move = _cb_move
         vtable.copy_file = _cb_copy_file
@@ -905,6 +913,12 @@ class FileSystemHandler(ABC):
     def delete_dir_contents(self, path):
         """
         Implement PyFileSystem.delete_dir_contents(...).
+        """
+
+    @abstractmethod
+    def delete_root_dir_contents(self):
+        """
+        Implement PyFileSystem.delete_dir_contents("/", accept_root_dir=True).
         """
 
     @abstractmethod
@@ -998,6 +1012,9 @@ cdef void _cb_delete_dir(handler, const c_string& path) except *:
 
 cdef void _cb_delete_dir_contents(handler, const c_string& path) except *:
     handler.delete_dir_contents(frombytes(path))
+
+cdef void _cb_delete_root_dir_contents(handler) except *:
+    handler.delete_root_dir_contents()
 
 cdef void _cb_delete_file(handler, const c_string& path) except *:
     handler.delete_file(frombytes(path))

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -489,7 +489,7 @@ cdef class FileSystem:
             (if path is empty or "/")
         """
         cdef c_string directory = _path_as_bytes(path)
-        if accept_root_dir and directory in (b"", b"/"):
+        if accept_root_dir and directory.strip(b"/") == b"":
             with nogil:
                 check_status(self.fs.DeleteRootDirContents())
         else:

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -154,7 +154,7 @@ class FSSpecHandler(FileSystemHandler):
                 self.fs.rm(subpath)
 
     def delete_dir_contents(self, path):
-        if path in ("", "/"):
+        if path.strip("/") == "":
             raise ValueError(
                 "delete_dir_contents called on path '", path, "'")
         self._delete_dir_contents(path)

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -146,12 +146,21 @@ class FSSpecHandler(FileSystemHandler):
     def delete_dir(self, path):
         self.fs.rm(path, recursive=True)
 
-    def delete_dir_contents(self, path):
+    def _delete_dir_contents(self, path):
         for subpath in self.fs.listdir(path, detail=False):
             if self.fs.isdir(subpath):
                 self.fs.rm(subpath, recursive=True)
             elif self.fs.isfile(subpath):
                 self.fs.rm(subpath)
+
+    def delete_dir_contents(self, path):
+        if path in ("", "/"):
+            raise ValueError(
+                "delete_dir_contents called on path '", path, "'")
+        self._delete_dir_contents(path)
+
+    def delete_root_dir_contents(self):
+        self._delete_dir_contents("/")
 
     def delete_file(self, path):
         # fs.rm correctly raises IsADirectoryError when `path` is a directory

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -63,6 +63,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         CStatus CreateDir(const c_string& path, c_bool recursive)
         CStatus DeleteDir(const c_string& path)
         CStatus DeleteDirContents(const c_string& path)
+        CStatus DeleteRootDirContents()
         CStatus DeleteFile(const c_string& path)
         CStatus DeleteFiles(const vector[c_string]& paths)
         CStatus Move(const c_string& src, const c_string& dest)
@@ -197,6 +198,7 @@ ctypedef void CallbackGetFileInfoSelector(object, const CFileSelector&,
 ctypedef void CallbackCreateDir(object, const c_string&, c_bool)
 ctypedef void CallbackDeleteDir(object, const c_string&)
 ctypedef void CallbackDeleteDirContents(object, const c_string&)
+ctypedef void CallbackDeleteRootDirContents(object)
 ctypedef void CallbackDeleteFile(object, const c_string&)
 ctypedef void CallbackMove(object, const c_string&, const c_string&)
 ctypedef void CallbackCopyFile(object, const c_string&, const c_string&)
@@ -220,6 +222,7 @@ cdef extern from "arrow/python/filesystem.h" namespace "arrow::py::fs" nogil:
         function[CallbackCreateDir] create_dir
         function[CallbackDeleteDir] delete_dir
         function[CallbackDeleteDirContents] delete_dir_contents
+        function[CallbackDeleteRootDirContents] delete_root_dir_contents
         function[CallbackDeleteFile] delete_file
         function[CallbackMove] move
         function[CallbackCopyFile] copy_file

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -92,7 +92,7 @@ class DummyHandler(FileSystemHandler):
         assert path == "delete_dir"
 
     def delete_dir_contents(self, path):
-        if path in ("", "/"):
+        if not path.strip("/"):
             raise ValueError
         assert path == "delete_dir_contents"
 
@@ -736,8 +736,12 @@ def _check_root_dir_contents(config):
         fs.delete_dir_contents("")
     with pytest.raises(pa.ArrowInvalid):
         fs.delete_dir_contents("/")
+    with pytest.raises(pa.ArrowInvalid):
+        fs.delete_dir_contents("//")
 
     fs.delete_dir_contents("", accept_root_dir=True)
+    fs.delete_dir_contents("/", accept_root_dir=True)
+    fs.delete_dir_contents("//", accept_root_dir=True)
     with pytest.raises(pa.ArrowIOError):
         fs.delete_dir(d)
 
@@ -1231,9 +1235,10 @@ def test_py_filesystem_ops():
 
     fs.delete_dir("delete_dir")
     fs.delete_dir_contents("delete_dir_contents")
-    with pytest.raises(ValueError):
-        fs.delete_dir_contents("")
-    fs.delete_dir_contents("", accept_root_dir=True)
+    for path in ("", "/", "//"):
+        with pytest.raises(ValueError):
+            fs.delete_dir_contents(path)
+        fs.delete_dir_contents(path, accept_root_dir=True)
     fs.delete_file("delete_file")
     fs.move("move_from", "move_to")
     fs.copy_file("copy_file_from", "copy_file_to")

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -92,7 +92,12 @@ class DummyHandler(FileSystemHandler):
         assert path == "delete_dir"
 
     def delete_dir_contents(self, path):
+        if path in ("", "/"):
+            raise ValueError
         assert path == "delete_dir_contents"
+
+    def delete_root_dir_contents(self):
+        pass
 
     def delete_file(self, path):
         assert path == "delete_file"
@@ -161,6 +166,9 @@ class ProxyHandler(FileSystemHandler):
     def delete_dir_contents(self, path):
         return self._fs.delete_dir_contents(path)
 
+    def delete_root_dir_contents(self):
+        return self._fs.delete_dir_contents("", accept_root_dir=True)
+
     def delete_file(self, path):
         return self._fs.delete_file(path)
 
@@ -209,6 +217,17 @@ def py_localfs(request, tempdir):
 def mockfs(request):
     return dict(
         fs=_MockFileSystem(),
+        pathfn=lambda p: p,
+        allow_copy_file=True,
+        allow_move_dir=True,
+        allow_append_to_file=True,
+    )
+
+
+@pytest.fixture
+def py_mockfs(request):
+    return dict(
+        fs=PyFileSystem(ProxyHandler(_MockFileSystem())),
         pathfn=lambda p: p,
         allow_copy_file=True,
         allow_move_dir=True,
@@ -379,6 +398,10 @@ def py_fsspec_s3fs(request, s3_connection, s3_server):
         id='PyFileSystem(ProxyHandler(LocalFileSystem()))'
     ),
     pytest.param(
+        pytest.lazy_fixture('py_mockfs'),
+        id='PyFileSystem(ProxyHandler(_MockFileSystem()))'
+    ),
+    pytest.param(
         pytest.lazy_fixture('py_fsspec_localfs'),
         id='PyFileSystem(FSSpecHandler(fsspec.LocalFileSystem()))'
     ),
@@ -516,7 +539,7 @@ def test_subtree_filesystem():
 
 
 def test_filesystem_pickling(fs):
-    if isinstance(fs, _MockFileSystem):
+    if fs.type_name.split('::')[-1] == 'mock':
         pytest.xfail(reason='MockFileSystem is not serializable')
 
     serialized = pickle.dumps(fs)
@@ -526,7 +549,7 @@ def test_filesystem_pickling(fs):
 
 
 def test_filesystem_is_functional_after_pickling(fs, pathfn):
-    if isinstance(fs, _MockFileSystem):
+    if fs.type_name.split('::')[-1] == 'mock':
         pytest.xfail(reason='MockFileSystem is not serializable')
     skip_fsspec_s3fs(fs)
 
@@ -699,6 +722,29 @@ def test_delete_dir_contents(fs, pathfn):
     fs.delete_dir(d)
     with pytest.raises(pa.ArrowIOError):
         fs.delete_dir(d)
+
+
+def _check_root_dir_contents(config):
+    fs = config['fs']
+    pathfn = config['pathfn']
+
+    d = pathfn('directory/')
+    nd = pathfn('directory/nested/')
+
+    fs.create_dir(nd)
+    with pytest.raises(pa.ArrowInvalid):
+        fs.delete_dir_contents("")
+    with pytest.raises(pa.ArrowInvalid):
+        fs.delete_dir_contents("/")
+
+    fs.delete_dir_contents("", accept_root_dir=True)
+    with pytest.raises(pa.ArrowIOError):
+        fs.delete_dir(d)
+
+
+def test_delete_root_dir_contents(mockfs, py_mockfs):
+    _check_root_dir_contents(mockfs)
+    _check_root_dir_contents(py_mockfs)
 
 
 def test_copy_file(fs, pathfn, allow_copy_file):
@@ -1185,6 +1231,9 @@ def test_py_filesystem_ops():
 
     fs.delete_dir("delete_dir")
     fs.delete_dir_contents("delete_dir_contents")
+    with pytest.raises(ValueError):
+        fs.delete_dir_contents("")
+    fs.delete_dir_contents("", accept_root_dir=True)
     fs.delete_file("delete_file")
     fs.move("move_from", "move_to")
     fs.copy_file("copy_file_from", "copy_file_to")


### PR DESCRIPTION
Add a separate method DeleteRootDirContents, in case the operation of wiping the root directory is really desired.