### PR TITLE
ARROW-8886: [C#] Resize to negative length no longer permitted

### DIFF
--- a/csharp/src/Apache.Arrow/ArrowBuffer.BitmapBuilder.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.BitmapBuilder.cs
@@ -195,14 +195,15 @@ namespace Apache.Arrow
             /// Note that if the required capacity is smaller than the current length of the populated buffer so far,
             /// the buffer will be truncated and items at the end of the buffer will be lost.
             /// </remarks>
-            /// <remarks>
-            /// Note also that a negative capacity will result in the buffer being resized to zero.
-            /// </remarks>
             /// <param name="capacity">Number of bits of required capacity.</param>
             /// <returns>Returns the builder (for fluent-style composition).</returns>
             public BitmapBuilder Resize(int capacity)
             {
-                capacity = capacity < 0 ? 0 : capacity;
+                if (capacity < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be non-negative");
+                }
+
                 EnsureCapacity(capacity);
                 Length = capacity;
 

--- a/csharp/src/Apache.Arrow/ArrowBuffer.Builder.cs
+++ b/csharp/src/Apache.Arrow/ArrowBuffer.Builder.cs
@@ -168,14 +168,15 @@ namespace Apache.Arrow
             /// Note that if the required capacity is smaller than the current length of the populated buffer so far,
             /// the buffer will be truncated and items at the end of the buffer will be lost.
             /// </remarks>
-            /// <remarks>
-            /// Note also that a negative capacity will result in the buffer being resized to zero.
-            /// </remarks>
             /// <param name="capacity">Number of items of required capacity.</param>
             /// <returns>Returns the builder (for fluent-style composition).</returns>
             public Builder<T> Resize(int capacity)
             {
-                capacity = capacity < 0 ? 0 : capacity;
+                if (capacity < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity must be non-negative");
+                }
+
                 EnsureCapacity(capacity);
                 Length = capacity;
 

--- a/csharp/test/Apache.Arrow.Tests/ArrowBufferBitmapBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowBufferBitmapBuilderTests.cs
@@ -195,18 +195,15 @@ namespace Apache.Arrow.Tests
             }
 
             [Fact]
-            public void NegativeLengthResizesToZero()
+            public void NegativeLengthThrows()
             {
                 // Arrange
                 var builder = new ArrowBuffer.BitmapBuilder();
                 builder.Append(false);
                 builder.Append(true);
 
-                // Act
-                builder.Resize(-1);
-
-                // Assert
-                Assert.Equal(0, builder.Length);
+                // Act/Assert
+                Assert.Throws<ArgumentOutOfRangeException>(() => builder.Resize(-1));
             }
         }
 

--- a/csharp/test/Apache.Arrow.Tests/ArrowBufferBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowBufferBuilderTests.cs
@@ -136,7 +136,7 @@ namespace Apache.Arrow.Tests
                 var length = builder.Length;
                 var data = Enumerable.Range(0, 10).Select(x => x).ToArray();
                 var count = data.Length;
-                
+
                 builder.AppendRange(data);
 
                 Assert.Equal(length + count, builder.Length);
@@ -200,14 +200,15 @@ namespace Apache.Arrow.Tests
             }
 
             [Fact]
-            public void NegativeLengthResizesToZero()
+            public void NegativeLengthThrows()
             {
+                // Arrange
                 var builder = new ArrowBuffer.Builder<int>();
                 builder.Append(10);
                 builder.Append(20);
-                builder.Resize(-1);
 
-                Assert.Equal(0, builder.Length);
+                // Act/Assert
+                Assert.Throws<ArgumentOutOfRangeException>(() => builder.Resize(-1));
             }
         }
 


### PR DESCRIPTION
The C# implementation of buffer builders previously accepted a negative length to the `Resize()` method, and clamped it to zero.  However, based on [comments by the original author of that code](https://github.com/apache/arrow/pull/7158#discussion_r437589084) @chutchinson , this behaviour is being changed to disallow negative lengths:

> It's hard to say why I chose this behavior; this was written over a year ago. I can only imagine my thought process was that the capacity "can't go any lower", and avoiding the costs that come with throwing an exception.
>
> The unit test existed to verify the behavior as written, not necessarily to satisfy requirements, which I would agree was misguided.
>
> My current stance would be to match the behavior of the more mature implementations, and throw **ArgumentOutOfRangeException**. I tend to prefer avoiding exceptions and bounds checking where possible, but as a consumer I could understand being surprised to find that passing a negative capacity results in an empty buffer. I'm not sure I would expect this method in a situation where the bounds checking or exception stack unwinding would be harmful enough to be undesirable.

The new behaviour is in line with the [behaviour in the C++ Arrow implementation](https://github.com/apache/arrow/blob/master/cpp/src/arrow/array/builder_base.h#L190), and library functions like [`System.Array.Resize<T>()`](https://docs.microsoft.com/en-us/dotnet/api/system.array.resize?view=netcore-3.1).