### PR TITLE
ARROW-9287: [C++] Support unsigned dictionary indices

### DIFF
--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -49,8 +49,7 @@ namespace arrow {
 ///   indices: [1, 0, 1, 0, 1, 0]
 ///   dictionary: ["bar", "foo"]
 ///
-/// The indices in principle may have any integer type (signed or unsigned),
-/// though presently data in IPC exchanges must be signed int32.
+/// The indices in principle may be any integer type.
 class ARROW_EXPORT DictionaryArray : public Array {
  public:
   using TypeClass = DictionaryType;
@@ -65,23 +64,22 @@ class ARROW_EXPORT DictionaryArray : public Array {
   /// array and validate
   ///
   /// This function does the validation of the indices and input type. It checks if
-  /// all indices are non-negative and smaller than the size of the dictionary
+  /// all indices are non-negative and smaller than the size of the dictionary.
   ///
   /// \param[in] type a dictionary type
   /// \param[in] dictionary the dictionary with same value type as the
   /// type object
-  /// \param[in] indices an array of non-negative signed
-  /// integers smaller than the size of the dictionary
+  /// \param[in] indices an array of non-negative integers smaller than the
+  /// size of the dictionary
   static Result<std::shared_ptr<Array>> FromArrays(
       const std::shared_ptr<DataType>& type, const std::shared_ptr<Array>& indices,
       const std::shared_ptr<Array>& dictionary);
 
   /// \brief Transpose this DictionaryArray
   ///
-  /// This method constructs a new dictionary array with the given dictionary type,
-  /// transposing indices using the transpose map.
-  /// The type and the transpose map are typically computed using
-  /// DictionaryUnifier.
+  /// This method constructs a new dictionary array with the given dictionary
+  /// type, transposing indices using the transpose map.  The type and the
+  /// transpose map are typically computed using DictionaryUnifier.
   ///
   /// \param[in] type the new type object
   /// \param[in] dictionary the new dictionary

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -98,7 +98,9 @@ class ARROW_EXPORT DictionaryArray : public Array {
   std::shared_ptr<Array> dictionary() const;
   std::shared_ptr<Array> indices() const;
 
-  /// \brief Return the ith value of indices, cast to int64_t
+  /// \brief Return the ith value of indices, cast to int64_t. Not recommended
+  /// for use in performance-sensitive code. Does not validate whether the
+  /// value is null or out-of-bounds.
   int64_t GetValueIndex(int64_t i) const;
 
   const DictionaryType* dict_type() const { return dict_type_; }

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1001,26 +1001,38 @@ TEST(TestDictionary, Validate) {
       "");
 }
 
-TEST(TestDictionary, FromArray) {
+TEST(TestDictionary, FromArrays) {
   auto dict = ArrayFromJSON(utf8(), "[\"foo\", \"bar\", \"baz\"]");
-  auto dict_type = dictionary(int16(), utf8());
+  for (auto index_ty : testing::dictionary_index_types()) {
+    auto dict_type = dictionary(index_ty, utf8());
 
-  auto indices1 = ArrayFromJSON(int16(), "[1, 2, 0, 0, 2, 0]");
-  auto indices2 = ArrayFromJSON(int16(), "[1, 2, 0, 3, 2, 0]");
+    auto indices1 = ArrayFromJSON(index_ty, "[1, 2, 0, 0, 2, 0]");
+    // Index out of bounds
+    auto indices2 = ArrayFromJSON(index_ty, "[1, 2, 0, 3, 2, 0]");
 
-  // Invalid index is masked by null
-  std::shared_ptr<Array> indices3;
-  std::vector<bool> is_valid3 = {true, true, false, true, true, true};
-  std::vector<int16_t> indices_values3 = {1, 2, -1, 0, 2, 0};
-  ArrayFromVector<Int16Type, int16_t>(is_valid3, indices_values3, &indices3);
+    ASSERT_OK_AND_ASSIGN(auto arr1,
+                         DictionaryArray::FromArrays(dict_type, indices1, dict));
+    ASSERT_RAISES(IndexError, DictionaryArray::FromArrays(dict_type, indices2, dict));
 
-  // Index out of bounds
-  auto indices4 = ArrayFromJSON(int16(), "[1, 2, null, 3, 2, 0]");
+    if (checked_cast<const IntegerType&>(*index_ty).is_signed()) {
+      // Invalid index is masked by null, so it's OK
+      auto indices3 = ArrayFromJSON(index_ty, "[1, 2, -1, null, 2, 0]");
+      BitUtil::ClearBit(indices3->data()->buffers[0]->mutable_data(), 2);
+      ASSERT_OK_AND_ASSIGN(auto arr3,
+                           DictionaryArray::FromArrays(dict_type, indices3, dict));
+    }
 
-  ASSERT_OK_AND_ASSIGN(auto arr1, DictionaryArray::FromArrays(dict_type, indices1, dict));
-  ASSERT_RAISES(Invalid, DictionaryArray::FromArrays(dict_type, indices2, dict));
-  ASSERT_OK_AND_ASSIGN(auto arr3, DictionaryArray::FromArrays(dict_type, indices3, dict));
-  ASSERT_RAISES(Invalid, DictionaryArray::FromArrays(dict_type, indices4, dict));
+    auto indices4 = ArrayFromJSON(index_ty, "[1, 2, null, 3, 2, 0]");
+    ASSERT_RAISES(IndexError, DictionaryArray::FromArrays(dict_type, indices4, dict));
+
+    // Probe other validation checks
+    ASSERT_RAISES(TypeError, DictionaryArray::FromArrays(index_ty, indices4, dict));
+
+    auto different_index_ty =
+        dictionary(index_ty->id() == Type::INT8 ? uint8() : int8(), utf8());
+    ASSERT_RAISES(TypeError,
+                  DictionaryArray::FromArrays(different_index_ty, indices4, dict));
+  }
 }
 
 static void CheckTranspose(const std::shared_ptr<Array>& input,
@@ -1113,6 +1125,31 @@ TEST(TestDictionary, TransposeTrivial) {
     expected_indices = ArrayFromJSON(int8(), "[2, 0]");
     CheckTranspose(sliced, transpose_map.data(), out_dict_type, out_dict,
                    expected_indices);
+  }
+}
+
+TEST(TestDictionary, GetValueIndex) {
+  const char* indices_json = "[0, 1, 2, 3, 4, 5]";
+  auto indices_int64 = ArrayFromJSON(int64(), indices_json);
+  auto dict = ArrayFromJSON(int32(), "[10, 20, 30, 40, 50, 60]");
+
+  const auto& typed_indices_int64 = checked_cast<const Int64Array&>(*indices_int64);
+  for (auto index_ty : testing::dictionary_index_types()) {
+    auto indices = ArrayFromJSON(index_ty, indices_json);
+    auto dict_ty = dictionary(index_ty, int32());
+
+    DictionaryArray dict_arr(dict_ty, indices, dict);
+
+    int64_t offset = 1;
+    auto sliced_dict_arr = dict_arr.Slice(offset);
+
+    for (int64_t i = 0; i < indices->length(); ++i) {
+      ASSERT_EQ(dict_arr.GetValueIndex(i), typed_indices_int64.Value(i));
+      if (i < sliced_dict_arr->length()) {
+        ASSERT_EQ(checked_cast<const DictionaryArray&>(*sliced_dict_arr).GetValueIndex(i),
+                  typed_indices_int64.Value(i + offset));
+      }
+    }
   }
 }
 

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1003,7 +1003,7 @@ TEST(TestDictionary, Validate) {
 
 TEST(TestDictionary, FromArrays) {
   auto dict = ArrayFromJSON(utf8(), "[\"foo\", \"bar\", \"baz\"]");
-  for (auto index_ty : test::dictionary_index_types()) {
+  for (auto index_ty : all_dictionary_index_types()) {
     auto dict_type = dictionary(index_ty, utf8());
 
     auto indices1 = ArrayFromJSON(index_ty, "[1, 2, 0, 0, 2, 0]");
@@ -1079,7 +1079,7 @@ TEST(TestDictionary, TransposeBasic) {
     // Transpose to other index type
     auto out_dict = ArrayFromJSON(utf8(), "[\"Z\", \"A\", \"C\", \"B\"]");
     std::vector<int32_t> transpose_map = {1, 3, 2};
-    for (auto other_ty : test::dictionary_index_types()) {
+    for (auto other_ty : all_dictionary_index_types()) {
       auto out_dict_type = dictionary(other_ty, utf8());
       auto expected_indices = ArrayFromJSON(other_ty, "[3, 2, 1, 1]");
       CheckTranspose(arr, transpose_map.data(), out_dict_type, out_dict,
@@ -1092,7 +1092,7 @@ TEST(TestDictionary, TransposeBasic) {
     }
   };
 
-  for (auto ty : test::dictionary_index_types()) {
+  for (auto ty : all_dictionary_index_types()) {
     CheckIndexType(ty);
   }
 }
@@ -1138,12 +1138,12 @@ TEST(TestDictionary, TransposeTrivial) {
 }
 
 TEST(TestDictionary, GetValueIndex) {
-  const char* indices_json = "[0, 1, 2, 3, 4, 5]";
+  const char* indices_json = "[5, 0, 1, 3, 2, 4]";
   auto indices_int64 = ArrayFromJSON(int64(), indices_json);
   auto dict = ArrayFromJSON(int32(), "[10, 20, 30, 40, 50, 60]");
 
   const auto& typed_indices_int64 = checked_cast<const Int64Array&>(*indices_int64);
-  for (auto index_ty : test::dictionary_index_types()) {
+  for (auto index_ty : all_dictionary_index_types()) {
     auto indices = ArrayFromJSON(index_ty, indices_json);
     auto dict_ty = dictionary(index_ty, int32());
 

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -817,13 +817,9 @@ struct SchemaImporter {
     // Import dictionary type
     if (c_struct_->dictionary != nullptr) {
       // Check this index type
-      bool indices_ok = false;
-      if (is_integer(type_->id())) {
-        indices_ok = checked_cast<const IntegerType&>(*type_).is_signed();
-      }
-      if (!indices_ok) {
+      if (!is_integer(type_->id())) {
         return Status::Invalid(
-            "ArrowSchema struct has a dictionary but is not a signed integer type: ",
+            "ArrowSchema struct has a dictionary but is not an integer type: ",
             type_->ToString());
       }
       SchemaImporter dict_importer;

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -355,14 +355,41 @@ TEST_F(TestSchemaExport, Union) {
              {ARROW_FLAG_NULLABLE, 0, ARROW_FLAG_NULLABLE});
 }
 
+std::string GetIndexFormat(Type::type type_id) {
+  switch (type_id) {
+    case Type::UINT8:
+      return "C";
+    case Type::INT8:
+      return "c";
+    case Type::UINT16:
+      return "S";
+    case Type::INT16:
+      return "s";
+    case Type::UINT32:
+      return "I";
+    case Type::INT32:
+      return "i";
+    case Type::UINT64:
+      return "L";
+    case Type::INT64:
+      return "l";
+    default:
+      DCHECK(false);
+      return "";
+  }
+}
+
 TEST_F(TestSchemaExport, Dictionary) {
-  TestNested(dictionary(int32(), utf8()), {"i", "u"}, {"", ""});
-  TestNested(dictionary(int32(), list(utf8()), /*ordered=*/true), {"i", "+l", "u"},
-             {"", "", "item"},
-             {ARROW_FLAG_NULLABLE | ARROW_FLAG_DICTIONARY_ORDERED, ARROW_FLAG_NULLABLE,
-              ARROW_FLAG_NULLABLE});
-  TestNested(large_list(dictionary(int32(), list(utf8()))), {"+L", "i", "+l", "u"},
-             {"", "item", "", "item"});
+  for (auto index_ty : dictionary_index_types()) {
+    std::string index_fmt = GetIndexFormat(index_ty->id());
+    TestNested(dictionary(index_ty, utf8()), {index_fmt, "u"}, {"", ""});
+    TestNested(dictionary(index_ty, list(utf8()), /*ordered=*/true),
+               {index_fmt, "+l", "u"}, {"", "", "item"},
+               {ARROW_FLAG_NULLABLE | ARROW_FLAG_DICTIONARY_ORDERED, ARROW_FLAG_NULLABLE,
+                ARROW_FLAG_NULLABLE});
+    TestNested(large_list(dictionary(index_ty, list(utf8()))),
+               {"+L", index_fmt, "+l", "u"}, {"", "item", "", "item"});
+  }
 }
 
 TEST_F(TestSchemaExport, ExportField) {
@@ -809,7 +836,7 @@ TEST_F(TestArrayExport, Dictionary) {
   {
     auto factory = [](std::shared_ptr<Array>* out) -> Status {
       auto values = ArrayFromJSON(utf8(), R"(["foo", "bar", "quux"])");
-      auto indices = ArrayFromJSON(int32(), "[0, 2, 1, null, 1]");
+      auto indices = ArrayFromJSON(uint16(), "[0, 2, 1, null, 1]");
       return DictionaryArray::FromArrays(dictionary(indices->type(), values->type()),
                                          indices, values)
           .Value(out);
@@ -2383,11 +2410,26 @@ TEST_F(TestSchemaRoundtrip, Union) {
 }
 
 TEST_F(TestSchemaRoundtrip, Dictionary) {
+<<<<<<< HEAD
   TestWithTypeFactory([&]() { return dictionary(int32(), utf8()); });
   TestWithTypeFactory([&]() { return dictionary(int32(), utf8(), /*ordered=*/true); });
 
   TestWithTypeFactory([&]() { return dictionary(int32(), list(utf8())); });
   TestWithTypeFactory([&]() { return list(dictionary(int32(), list(utf8()))); });
+||||||| merged common ancestors
+  TestWithTypeFactory([&]() { return dictionary(int32(), utf8()); });
+  TestWithTypeFactory([&]() { return dictionary(int32(), utf8(), /*ordered=*/ true); });
+
+  TestWithTypeFactory([&]() { return dictionary(int32(), list(utf8())); });
+  TestWithTypeFactory([&]() { return list(dictionary(int32(), list(utf8()))); });
+=======
+  for (auto index_ty : dictionary_index_types()) {
+    TestWithTypeFactory([&]() { return dictionary(index_ty, utf8()); });
+    TestWithTypeFactory([&]() { return dictionary(index_ty, utf8(), /*ordered=*/true); });
+    TestWithTypeFactory([&]() { return dictionary(index_ty, list(utf8())); });
+    TestWithTypeFactory([&]() { return list(dictionary(index_ty, list(utf8()))); });
+  }
+>>>>>>> Some initial unsigned integer support
 }
 
 TEST_F(TestSchemaRoundtrip, Map) {

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -380,7 +380,7 @@ std::string GetIndexFormat(Type::type type_id) {
 }
 
 TEST_F(TestSchemaExport, Dictionary) {
-  for (auto index_ty : test::dictionary_index_types()) {
+  for (auto index_ty : all_dictionary_index_types()) {
     std::string index_fmt = GetIndexFormat(index_ty->id());
     TestNested(dictionary(index_ty, utf8()), {index_fmt, "u"}, {"", ""});
     TestNested(dictionary(index_ty, list(utf8()), /*ordered=*/true),
@@ -2410,7 +2410,7 @@ TEST_F(TestSchemaRoundtrip, Union) {
 }
 
 TEST_F(TestSchemaRoundtrip, Dictionary) {
-  for (auto index_ty : test::dictionary_index_types()) {
+  for (auto index_ty : all_dictionary_index_types()) {
     TestWithTypeFactory([&]() { return dictionary(index_ty, utf8()); });
     TestWithTypeFactory([&]() { return dictionary(index_ty, utf8(), /*ordered=*/true); });
     TestWithTypeFactory([&]() { return dictionary(index_ty, list(utf8())); });

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -380,7 +380,7 @@ std::string GetIndexFormat(Type::type type_id) {
 }
 
 TEST_F(TestSchemaExport, Dictionary) {
-  for (auto index_ty : dictionary_index_types()) {
+  for (auto index_ty : test::dictionary_index_types()) {
     std::string index_fmt = GetIndexFormat(index_ty->id());
     TestNested(dictionary(index_ty, utf8()), {index_fmt, "u"}, {"", ""});
     TestNested(dictionary(index_ty, list(utf8()), /*ordered=*/true),
@@ -2410,26 +2410,12 @@ TEST_F(TestSchemaRoundtrip, Union) {
 }
 
 TEST_F(TestSchemaRoundtrip, Dictionary) {
-<<<<<<< HEAD
-  TestWithTypeFactory([&]() { return dictionary(int32(), utf8()); });
-  TestWithTypeFactory([&]() { return dictionary(int32(), utf8(), /*ordered=*/true); });
-
-  TestWithTypeFactory([&]() { return dictionary(int32(), list(utf8())); });
-  TestWithTypeFactory([&]() { return list(dictionary(int32(), list(utf8()))); });
-||||||| merged common ancestors
-  TestWithTypeFactory([&]() { return dictionary(int32(), utf8()); });
-  TestWithTypeFactory([&]() { return dictionary(int32(), utf8(), /*ordered=*/ true); });
-
-  TestWithTypeFactory([&]() { return dictionary(int32(), list(utf8())); });
-  TestWithTypeFactory([&]() { return list(dictionary(int32(), list(utf8()))); });
-=======
-  for (auto index_ty : dictionary_index_types()) {
+  for (auto index_ty : test::dictionary_index_types()) {
     TestWithTypeFactory([&]() { return dictionary(index_ty, utf8()); });
     TestWithTypeFactory([&]() { return dictionary(index_ty, utf8(), /*ordered=*/true); });
     TestWithTypeFactory([&]() { return dictionary(index_ty, list(utf8())); });
     TestWithTypeFactory([&]() { return list(dictionary(index_ty, list(utf8()))); });
   }
->>>>>>> Some initial unsigned integer support
 }
 
 TEST_F(TestSchemaRoundtrip, Map) {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1745,9 +1745,9 @@ TYPED_TEST_SUITE(TestDictionaryCast, TestTypes);
 
 TYPED_TEST(TestDictionaryCast, Basic) {
   std::shared_ptr<Array> dict =
-      TestBase::MakeRandomArray<typename TypeTraits<TypeParam>::ArrayType>(5, 0);
-  for (auto index_ty : test::dictionary_index_types()) {
-    auto indices = ArrayFromJSON(index_ty, "[4, 0, 1, 2, 0, 4, 2, 2]");
+      TestBase::MakeRandomArray<typename TypeTraits<TypeParam>::ArrayType>(5, 1);
+  for (auto index_ty : all_dictionary_index_types()) {
+    auto indices = ArrayFromJSON(index_ty, "[4, 0, 1, 2, 0, 4, null, 2]");
     auto dict_ty = dictionary(index_ty, dict->type());
     auto dict_arr = *DictionaryArray::FromArrays(dict_ty, indices, dict);
     std::shared_ptr<Array> expected = *Take(*dict, *indices);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_test.cc
@@ -1744,16 +1744,18 @@ typedef ::testing::Types<NullType, UInt8Type, Int8Type, UInt16Type, Int16Type, I
 TYPED_TEST_SUITE(TestDictionaryCast, TestTypes);
 
 TYPED_TEST(TestDictionaryCast, Basic) {
-  CastOptions options;
-  std::shared_ptr<Array> plain_array =
-      TestBase::MakeRandomArray<typename TypeTraits<TypeParam>::ArrayType>(10, 2);
+  std::shared_ptr<Array> dict =
+      TestBase::MakeRandomArray<typename TypeTraits<TypeParam>::ArrayType>(5, 0);
+  for (auto index_ty : test::dictionary_index_types()) {
+    auto indices = ArrayFromJSON(index_ty, "[4, 0, 1, 2, 0, 4, 2, 2]");
+    auto dict_ty = dictionary(index_ty, dict->type());
+    auto dict_arr = *DictionaryArray::FromArrays(dict_ty, indices, dict);
+    std::shared_ptr<Array> expected = *Take(*dict, *indices);
 
-  ASSERT_OK_AND_ASSIGN(Datum encoded, DictionaryEncode(plain_array->data()));
-  ASSERT_EQ(encoded.array()->type->id(), Type::DICTIONARY);
-
-  // TODO: Should casting dictionary scalars work?
-  this->CheckPass(*MakeArray(encoded.array()), *plain_array, plain_array->type(), options,
-                  /*check_scalar=*/false);
+    // TODO: Should casting dictionary scalars work?
+    this->CheckPass(*dict_arr, *expected, expected->type(), CastOptions::Safe(),
+                    /*check_scalar=*/false);
+  }
 }
 
 TYPED_TEST(TestDictionaryCast, NoNulls) {

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -420,9 +420,10 @@ static Status GetDictionaryEncoding(FBB& fbb, const std::shared_ptr<Field>& fiel
   // We assume that the dictionary index type (as an integer) has already been
   // validated elsewhere, and can safely assume we are dealing with signed
   // integers
-  const auto& fw_index_type = checked_cast<const FixedWidthType&>(*type.index_type());
+  const auto& index_type = checked_cast<const IntegerType&>(*type.index_type());
 
-  auto index_type_offset = flatbuf::CreateInt(fbb, fw_index_type.bit_width(), true);
+  auto index_type_offset =
+      flatbuf::CreateInt(fbb, index_type.bit_width(), index_type.is_signed());
 
   // TODO(wesm): ordered dictionaries
   *out = flatbuf::CreateDictionaryEncoding(fbb, dictionary_id, index_type_offset,

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -534,12 +534,24 @@ Status MakeDictionary(std::shared_ptr<RecordBatch>* out) {
   auto dict4 = ArrayFromJSON(dict4_ty, "[[44, 55], [], [66]]");
   auto a4 = std::make_shared<DictionaryArray>(f4_type, indices4, dict4);
 
-  // construct batch
-  auto schema = ::arrow::schema(
-      {field("dict1", f0_type), field("dict2", f1_type), field("dict3", f2_type),
-       field("list<encoded utf8>", f3_type), field("encoded list<int8>", f4_type)});
+  std::vector<std::shared_ptr<Field>> fields = {
+      field("dict1", f0_type), field("dict2", f1_type), field("dict3", f2_type),
+      field("list<encoded utf8>", f3_type), field("encoded list<int8>", f4_type)};
+  std::vector<std::shared_ptr<Array>> arrays = {a0, a1, a2, a3, a4};
 
-  *out = RecordBatch::Make(schema, length, {a0, a1, a2, a3, a4});
+  // Ensure all dictionary index types are represented
+  int field_index = 5;
+  for (auto index_ty : ::arrow::testing::dictionary_index_types()) {
+    std::stringstream ss;
+    ss << "dict" << field_index++;
+    auto ty = arrow::dictionary(index_ty, dict_ty);
+    auto indices = ArrayFromJSON(index_ty, "[0, 1, 2, 0, 2, 2]");
+    fields.push_back(field(ss.str(), ty));
+    arrays.push_back(std::make_shared<DictionaryArray>(ty, indices, dict1));
+  }
+
+  // construct batch
+  *out = RecordBatch::Make(::arrow::schema(fields), length, arrays);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -541,7 +541,7 @@ Status MakeDictionary(std::shared_ptr<RecordBatch>* out) {
 
   // Ensure all dictionary index types are represented
   int field_index = 5;
-  for (auto index_ty : ::arrow::test::dictionary_index_types()) {
+  for (auto index_ty : all_dictionary_index_types()) {
     std::stringstream ss;
     ss << "dict" << field_index++;
     auto ty = arrow::dictionary(index_ty, dict_ty);

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -541,7 +541,7 @@ Status MakeDictionary(std::shared_ptr<RecordBatch>* out) {
 
   // Ensure all dictionary index types are represented
   int field_index = 5;
-  for (auto index_ty : ::arrow::testing::dictionary_index_types()) {
+  for (auto index_ty : ::arrow::test::dictionary_index_types()) {
     std::stringstream ss;
     ss << "dict" << field_index++;
     auto ty = arrow::dictionary(index_ty, dict_ty);

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -199,25 +199,30 @@ Result<std::shared_ptr<Scalar>> DictionaryScalar::GetEncodedValue() const {
     return MakeNullScalar(dict_type.value_type());
   }
 
+  const void* index =
+      checked_cast<const internal::PrimitiveScalarBase&>(*value.index).data();
   int64_t index_value = 0;
   switch (dict_type.index_type()->id()) {
+    case Type::UINT8:
     case Type::INT8:
-      index_value = checked_cast<const Int8Scalar&>(*value.index).value;
+      index_value = static_cast<int64_t>(*reinterpret_cast<const uint8_t*>(index));
       break;
+    case Type::UINT16:
     case Type::INT16:
-      index_value = checked_cast<const Int16Scalar&>(*value.index).value;
+      index_value = static_cast<int64_t>(*reinterpret_cast<const uint16_t*>(index));
       break;
+    case Type::UINT32:
     case Type::INT32:
-      index_value = checked_cast<const Int32Scalar&>(*value.index).value;
+      index_value = static_cast<int64_t>(*reinterpret_cast<const uint32_t*>(index));
       break;
+    case Type::UINT64:
     case Type::INT64:
-      index_value = checked_cast<const Int64Scalar&>(*value.index).value;
+      index_value = static_cast<int64_t>(*reinterpret_cast<const uint64_t*>(index));
       break;
     default:
       return Status::TypeError("Not implemented dictionary index type");
       break;
   }
-
   return value.dictionary->GetScalar(index_value);
 }
 

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -199,25 +199,39 @@ Result<std::shared_ptr<Scalar>> DictionaryScalar::GetEncodedValue() const {
     return MakeNullScalar(dict_type.value_type());
   }
 
-  const void* index =
-      checked_cast<const internal::PrimitiveScalarBase&>(*value.index).data();
   int64_t index_value = 0;
   switch (dict_type.index_type()->id()) {
     case Type::UINT8:
+      index_value =
+          static_cast<int64_t>(checked_cast<const UInt8Scalar&>(*value.index).value);
+      break;
     case Type::INT8:
-      index_value = static_cast<int64_t>(*reinterpret_cast<const uint8_t*>(index));
+      index_value =
+          static_cast<int64_t>(checked_cast<const Int8Scalar&>(*value.index).value);
       break;
     case Type::UINT16:
+      index_value =
+          static_cast<int64_t>(checked_cast<const UInt16Scalar&>(*value.index).value);
+      break;
     case Type::INT16:
-      index_value = static_cast<int64_t>(*reinterpret_cast<const uint16_t*>(index));
+      index_value =
+          static_cast<int64_t>(checked_cast<const Int16Scalar&>(*value.index).value);
       break;
     case Type::UINT32:
+      index_value =
+          static_cast<int64_t>(checked_cast<const UInt32Scalar&>(*value.index).value);
+      break;
     case Type::INT32:
-      index_value = static_cast<int64_t>(*reinterpret_cast<const uint32_t*>(index));
+      index_value =
+          static_cast<int64_t>(checked_cast<const Int32Scalar&>(*value.index).value);
       break;
     case Type::UINT64:
+      index_value =
+          static_cast<int64_t>(checked_cast<const UInt64Scalar&>(*value.index).value);
+      break;
     case Type::INT64:
-      index_value = static_cast<int64_t>(*reinterpret_cast<const uint64_t*>(index));
+      index_value =
+          static_cast<int64_t>(checked_cast<const Int64Scalar&>(*value.index).value);
       break;
     default:
       return Status::TypeError("Not implemented dictionary index type");

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -581,45 +581,51 @@ TEST(TestStructScalar, FieldAccess) {
 }
 
 TEST(TestDictionaryScalar, Basics) {
-  auto ty = dictionary(int8(), utf8());
-  auto dict = ArrayFromJSON(utf8(), "[\"alpha\", \"beta\", \"gamma\"]");
+  auto CheckIndexType = [&](const std::shared_ptr<DataType>& index_ty) {
+    auto ty = dictionary(index_ty, utf8());
+    auto dict = ArrayFromJSON(utf8(), "[\"alpha\", \"beta\", \"gamma\"]");
 
-  DictionaryScalar::ValueType alpha;
-  ASSERT_OK_AND_ASSIGN(alpha.index, MakeScalar(int8(), 0));
-  alpha.dictionary = dict;
+    DictionaryScalar::ValueType alpha;
+    ASSERT_OK_AND_ASSIGN(alpha.index, MakeScalar(index_ty, 0));
+    alpha.dictionary = dict;
 
-  DictionaryScalar::ValueType gamma;
-  ASSERT_OK_AND_ASSIGN(gamma.index, MakeScalar(int8(), 2));
-  gamma.dictionary = dict;
+    DictionaryScalar::ValueType gamma;
+    ASSERT_OK_AND_ASSIGN(gamma.index, MakeScalar(index_ty, 2));
+    gamma.dictionary = dict;
 
-  auto scalar_null = MakeNullScalar(ty);
-  auto scalar_alpha = DictionaryScalar(alpha, ty);
-  auto scalar_gamma = DictionaryScalar(gamma, ty);
+    auto scalar_null = MakeNullScalar(ty);
+    auto scalar_alpha = DictionaryScalar(alpha, ty);
+    auto scalar_gamma = DictionaryScalar(gamma, ty);
 
-  ASSERT_OK_AND_ASSIGN(
-      auto encoded_null,
-      checked_cast<const DictionaryScalar&>(*scalar_null).GetEncodedValue());
-  ASSERT_TRUE(encoded_null->Equals(MakeNullScalar(utf8())));
+    ASSERT_OK_AND_ASSIGN(
+        auto encoded_null,
+        checked_cast<const DictionaryScalar&>(*scalar_null).GetEncodedValue());
+    ASSERT_TRUE(encoded_null->Equals(MakeNullScalar(utf8())));
 
-  ASSERT_OK_AND_ASSIGN(
-      auto encoded_alpha,
-      checked_cast<const DictionaryScalar&>(scalar_alpha).GetEncodedValue());
-  ASSERT_TRUE(encoded_alpha->Equals(MakeScalar("alpha")));
+    ASSERT_OK_AND_ASSIGN(
+        auto encoded_alpha,
+        checked_cast<const DictionaryScalar&>(scalar_alpha).GetEncodedValue());
+    ASSERT_TRUE(encoded_alpha->Equals(MakeScalar("alpha")));
 
-  ASSERT_OK_AND_ASSIGN(
-      auto encoded_gamma,
-      checked_cast<const DictionaryScalar&>(scalar_gamma).GetEncodedValue());
-  ASSERT_TRUE(encoded_gamma->Equals(MakeScalar("gamma")));
+    ASSERT_OK_AND_ASSIGN(
+        auto encoded_gamma,
+        checked_cast<const DictionaryScalar&>(scalar_gamma).GetEncodedValue());
+    ASSERT_TRUE(encoded_gamma->Equals(MakeScalar("gamma")));
 
-  // test Array.GetScalar
-  DictionaryArray arr(ty, ArrayFromJSON(int8(), "[2, 0, 1, null]"), dict);
-  ASSERT_OK_AND_ASSIGN(auto first, arr.GetScalar(0));
-  ASSERT_OK_AND_ASSIGN(auto second, arr.GetScalar(1));
-  ASSERT_OK_AND_ASSIGN(auto last, arr.GetScalar(3));
+    // test Array.GetScalar
+    DictionaryArray arr(ty, ArrayFromJSON(index_ty, "[2, 0, 1, null]"), dict);
+    ASSERT_OK_AND_ASSIGN(auto first, arr.GetScalar(0));
+    ASSERT_OK_AND_ASSIGN(auto second, arr.GetScalar(1));
+    ASSERT_OK_AND_ASSIGN(auto last, arr.GetScalar(3));
 
-  ASSERT_TRUE(first->Equals(scalar_gamma));
-  ASSERT_TRUE(second->Equals(scalar_alpha));
-  ASSERT_TRUE(last->Equals(scalar_null));
+    ASSERT_TRUE(first->Equals(scalar_gamma));
+    ASSERT_TRUE(second->Equals(scalar_alpha));
+    ASSERT_TRUE(last->Equals(scalar_null));
+  };
+
+  for (auto ty : test::dictionary_index_types()) {
+    CheckIndexType(ty);
+  }
 }
 
 TEST(TestSparseUnionScalar, Basics) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -623,7 +623,7 @@ TEST(TestDictionaryScalar, Basics) {
     ASSERT_TRUE(last->Equals(scalar_null));
   };
 
-  for (auto ty : test::dictionary_index_types()) {
+  for (auto ty : all_dictionary_index_types()) {
     CheckIndexType(ty);
   }
 }

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -143,8 +143,8 @@ typedef ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type
 
 typedef ::testing::Types<FloatType, DoubleType> RealArrowTypes;
 
-typedef testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
-                       Int32Type, Int64Type>
+typedef ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type,
+                         Int16Type, Int32Type, Int64Type>
     IntegralArrowTypes;
 
 class Array;

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -233,14 +233,10 @@ int GetListenPort() {
   return port;
 }
 
-namespace test {
-
-const std::vector<std::shared_ptr<DataType>>& dictionary_index_types() {
+const std::vector<std::shared_ptr<DataType>>& all_dictionary_index_types() {
   static std::vector<std::shared_ptr<DataType>> types = {
       int8(), uint8(), int16(), uint16(), int32(), uint32(), int64(), uint64()};
   return types;
 }
-
-}  // namespace test
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -233,7 +233,7 @@ int GetListenPort() {
   return port;
 }
 
-namespace testing {
+namespace test {
 
 const std::vector<std::shared_ptr<DataType>>& dictionary_index_types() {
   static std::vector<std::shared_ptr<DataType>> types = {
@@ -241,6 +241,6 @@ const std::vector<std::shared_ptr<DataType>>& dictionary_index_types() {
   return types;
 }
 
-}  // namespace testing
+}  // namespace test
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -233,4 +233,14 @@ int GetListenPort() {
   return port;
 }
 
+namespace testing {
+
+const std::vector<std::shared_ptr<DataType>>& dictionary_index_types() {
+  static std::vector<std::shared_ptr<DataType>> types = {
+      int8(), uint8(), int16(), uint16(), int32(), uint32(), int64(), uint64()};
+  return types;
+}
+
+}  // namespace testing
+
 }  // namespace arrow

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -181,11 +181,11 @@ UnionTypeFactories() {
 // Windows.
 ARROW_TESTING_EXPORT int GetListenPort();
 
-namespace testing {
+namespace test {
 
 ARROW_TESTING_EXPORT
 const std::vector<std::shared_ptr<DataType>>& dictionary_index_types();
 
-}  // namespace testing
+}  // namespace test
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -181,11 +181,7 @@ UnionTypeFactories() {
 // Windows.
 ARROW_TESTING_EXPORT int GetListenPort();
 
-namespace test {
-
 ARROW_TESTING_EXPORT
-const std::vector<std::shared_ptr<DataType>>& dictionary_index_types();
-
-}  // namespace test
+const std::vector<std::shared_ptr<DataType>>& all_dictionary_index_types();
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -181,4 +181,11 @@ UnionTypeFactories() {
 // Windows.
 ARROW_TESTING_EXPORT int GetListenPort();
 
+namespace testing {
+
+ARROW_TESTING_EXPORT
+const std::vector<std::shared_ptr<DataType>>& dictionary_index_types();
+
+}  // namespace testing
+
 }  // namespace arrow

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -762,7 +762,7 @@ Result<std::shared_ptr<DataType>> Decimal128Type::Make(int32_t precision, int32_
 Status DictionaryType::ValidateParameters(const DataType& index_type,
                                           const DataType& value_type) {
   if (!is_integer(index_type.id())) {
-    return Status::TypeError("Dictionary index type should be an integer, got ",
+    return Status::TypeError("Dictionary index type should be integer, got ",
                              index_type.ToString());
   }
   return Status::OK();

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -761,10 +761,8 @@ Result<std::shared_ptr<DataType>> Decimal128Type::Make(int32_t precision, int32_
 
 Status DictionaryType::ValidateParameters(const DataType& index_type,
                                           const DataType& value_type) {
-  const bool index_type_ok = is_integer(index_type.id()) &&
-                             checked_cast<const IntegerType&>(index_type).is_signed();
-  if (!index_type_ok) {
-    return Status::TypeError("Dictionary index type should be signed integer, got ",
+  if (!is_integer(index_type.id())) {
+    return Status::TypeError("Dictionary index type should be an integer, got ",
                              index_type.ToString());
   }
   return Status::OK();

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1388,7 +1388,7 @@ class ARROW_EXPORT DurationType : public TemporalType, public ParametricType {
 // in memory)
 
 /// \brief Dictionary-encoded value type with data-dependent
-/// dictionary
+/// dictionary. Indices are represented by any integer types.
 class ARROW_EXPORT DictionaryType : public FixedWidthType {
  public:
   static constexpr Type::type type_id = Type::DICTIONARY;

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -1581,13 +1581,8 @@ void CheckTransposeMap(const Buffer& map, std::vector<int32_t> expected) {
 TEST(TestDictionaryType, UnifyNumeric) {
   auto dict_ty = int64();
 
-  auto t1 = dictionary(int8(), dict_ty);
   auto d1 = ArrayFromJSON(dict_ty, "[3, 4, 7]");
-
-  auto t2 = dictionary(int8(), dict_ty);
   auto d2 = ArrayFromJSON(dict_ty, "[1, 7, 4, 8]");
-
-  auto t3 = dictionary(int8(), dict_ty);
   auto d3 = ArrayFromJSON(dict_ty, "[1, -200]");
 
   auto expected = dictionary(int8(), dict_ty);
@@ -1608,7 +1603,7 @@ TEST(TestDictionaryType, UnifyNumeric) {
   ASSERT_TRUE(out_type->Equals(*expected));
   ASSERT_TRUE(out_dict->Equals(*expected_dict));
 
-  std::shared_ptr<Buffer> b1, b2, b3;
+  std::shared_ptr<Buffer> b1, b2, b3, b4;
 
   ASSERT_OK(unifier->Unify(*d1, &b1));
   ASSERT_OK(unifier->Unify(*d2, &b2));

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -1603,7 +1603,7 @@ TEST(TestDictionaryType, UnifyNumeric) {
   ASSERT_TRUE(out_type->Equals(*expected));
   ASSERT_TRUE(out_dict->Equals(*expected_dict));
 
-  std::shared_ptr<Buffer> b1, b2, b3, b4;
+  std::shared_ptr<Buffer> b1, b2, b3;
 
   ASSERT_OK(unifier->Unify(*d1, &b1));
   ASSERT_OK(unifier->Unify(*d2, &b2));

--- a/cpp/src/arrow/util/int_util.cc
+++ b/cpp/src/arrow/util/int_util.cc
@@ -435,15 +435,23 @@ void TransposeInts(const InputInt* src, OutputInt* dest, int64_t length,
       const SRC* source, DEST* dest, int64_t length, const int32_t* transpose_map);
 
 #define INSTANTIATE_ALL_DEST(DEST) \
+  INSTANTIATE(uint8_t, DEST)       \
   INSTANTIATE(int8_t, DEST)        \
+  INSTANTIATE(uint16_t, DEST)      \
   INSTANTIATE(int16_t, DEST)       \
+  INSTANTIATE(uint32_t, DEST)      \
   INSTANTIATE(int32_t, DEST)       \
+  INSTANTIATE(uint64_t, DEST)      \
   INSTANTIATE(int64_t, DEST)
 
-#define INSTANTIATE_ALL()       \
-  INSTANTIATE_ALL_DEST(int8_t)  \
-  INSTANTIATE_ALL_DEST(int16_t) \
-  INSTANTIATE_ALL_DEST(int32_t) \
+#define INSTANTIATE_ALL()        \
+  INSTANTIATE_ALL_DEST(uint8_t)  \
+  INSTANTIATE_ALL_DEST(int8_t)   \
+  INSTANTIATE_ALL_DEST(uint16_t) \
+  INSTANTIATE_ALL_DEST(int16_t)  \
+  INSTANTIATE_ALL_DEST(uint32_t) \
+  INSTANTIATE_ALL_DEST(int32_t)  \
+  INSTANTIATE_ALL_DEST(uint64_t) \
   INSTANTIATE_ALL_DEST(int64_t)
 
 INSTANTIATE_ALL()

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -913,7 +913,7 @@ TEST(DictEncodingAdHoc, PutDictionaryPutIndices) {
     arrow::AssertArraysEqual(*expected, *result);
   };
 
-  for (auto ty : ::arrow::test::dictionary_index_types()) {
+  for (auto ty : ::arrow::all_dictionary_index_types()) {
     CheckIndexType(ty);
   }
 }

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -873,42 +873,49 @@ TYPED_TEST(EncodingAdHocTyped, DictArrowDirectPut) { this->Dict(0); }
 TEST(DictEncodingAdHoc, PutDictionaryPutIndices) {
   // Part of ARROW-3246
   auto dict_values = arrow::ArrayFromJSON(arrow::binary(), "[\"foo\", \"bar\", \"baz\"]");
-  auto indices = arrow::ArrayFromJSON(arrow::int32(), "[0, 1, 2]");
-  auto indices_nulls = arrow::ArrayFromJSON(arrow::int32(), "[null, 0, 1, null, 2]");
 
-  auto expected = arrow::ArrayFromJSON(arrow::binary(),
-                                       "[\"foo\", \"bar\", \"baz\", null, "
-                                       "\"foo\", \"bar\", null, \"baz\"]");
+  auto CheckIndexType = [&](const std::shared_ptr<arrow::DataType>& index_ty) {
+    auto indices = arrow::ArrayFromJSON(index_ty, "[0, 1, 2]");
+    auto indices_nulls = arrow::ArrayFromJSON(index_ty, "[null, 0, 1, null, 2]");
 
-  auto owned_encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN,
-                                                       /*use_dictionary=*/true);
-  auto owned_decoder = MakeDictDecoder<ByteArrayType>();
+    auto expected = arrow::ArrayFromJSON(arrow::binary(),
+                                         "[\"foo\", \"bar\", \"baz\", null, "
+                                         "\"foo\", \"bar\", null, \"baz\"]");
 
-  auto encoder = dynamic_cast<DictEncoder<ByteArrayType>*>(owned_encoder.get());
+    auto owned_encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN,
+                                                         /*use_dictionary=*/true);
+    auto owned_decoder = MakeDictDecoder<ByteArrayType>();
 
-  ASSERT_NO_THROW(encoder->PutDictionary(*dict_values));
+    auto encoder = dynamic_cast<DictEncoder<ByteArrayType>*>(owned_encoder.get());
 
-  // Trying to call PutDictionary again throws
-  ASSERT_THROW(encoder->PutDictionary(*dict_values), ParquetException);
+    ASSERT_NO_THROW(encoder->PutDictionary(*dict_values));
 
-  ASSERT_NO_THROW(encoder->PutIndices(*indices));
-  ASSERT_NO_THROW(encoder->PutIndices(*indices_nulls));
+    // Trying to call PutDictionary again throws
+    ASSERT_THROW(encoder->PutDictionary(*dict_values), ParquetException);
 
-  std::unique_ptr<ByteArrayDecoder> decoder;
-  std::shared_ptr<Buffer> buf, dict_buf;
-  int num_values = static_cast<int>(expected->length() - expected->null_count());
-  GetDictDecoder(encoder, num_values, &buf, &dict_buf, nullptr, &decoder);
+    ASSERT_NO_THROW(encoder->PutIndices(*indices));
+    ASSERT_NO_THROW(encoder->PutIndices(*indices_nulls));
 
-  typename EncodingTraits<ByteArrayType>::Accumulator acc;
-  acc.builder.reset(new arrow::BinaryBuilder);
-  ASSERT_EQ(num_values,
-            decoder->DecodeArrow(static_cast<int>(expected->length()),
-                                 static_cast<int>(expected->null_count()),
-                                 expected->null_bitmap_data(), expected->offset(), &acc));
+    std::unique_ptr<ByteArrayDecoder> decoder;
+    std::shared_ptr<Buffer> buf, dict_buf;
+    int num_values = static_cast<int>(expected->length() - expected->null_count());
+    GetDictDecoder(encoder, num_values, &buf, &dict_buf, nullptr, &decoder);
 
-  std::shared_ptr<::arrow::Array> result;
-  ASSERT_OK(acc.builder->Finish(&result));
-  arrow::AssertArraysEqual(*expected, *result);
+    typename EncodingTraits<ByteArrayType>::Accumulator acc;
+    acc.builder.reset(new arrow::BinaryBuilder);
+    ASSERT_EQ(num_values, decoder->DecodeArrow(static_cast<int>(expected->length()),
+                                               static_cast<int>(expected->null_count()),
+                                               expected->null_bitmap_data(),
+                                               expected->offset(), &acc));
+
+    std::shared_ptr<::arrow::Array> result;
+    ASSERT_OK(acc.builder->Finish(&result));
+    arrow::AssertArraysEqual(*expected, *result);
+  };
+
+  for (auto ty : ::arrow::test::dictionary_index_types()) {
+    CheckIndexType(ty);
+  }
 }
 
 TYPED_TEST(EncodingAdHocTyped, DictArrowDirectPutIndices) { this->DictPutIndices(); }

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1567,11 +1567,10 @@ def get_generated_json_files(tempdir=None, flight=False):
         .skip_category('Go')
         .skip_category('Rust'),
 
-        # TODO: Dictionary unsigned indices
         generate_dictionary_unsigned_case()
-        .skip_category('Go')
-        .skip_category('Java')
-        .skip_category('Rust'),
+        .skip_category('Go')     # TODO(ARROW-9378)
+        .skip_category('Java')   # TODO(ARROW-9377)
+        .skip_category('Rust'),  # TODO(ARROW-9379)
 
         generate_nested_dictionary_case()
         .skip_category('Go')

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1422,6 +1422,26 @@ def generate_dictionary_case():
                           dictionaries=[dict0, dict1, dict2])
 
 
+def generate_dictionary_unsigned_case():
+    dict0 = Dictionary(0, StringField('dictionary0'), size=5, name='DICT0')
+    dict1 = Dictionary(1, StringField('dictionary1'), size=5, name='DICT1')
+    dict2 = Dictionary(2, StringField('dictionary2'), size=5, name='DICT2')
+
+    # TODO: JavaScript does not support uint64 dictionary indices, so disabled
+    # for now
+
+    # dict3 = Dictionary(3, StringField('dictionary3'), size=5, name='DICT3')
+    fields = [
+        DictionaryField('f0', get_field('', 'uint8'), dict0),
+        DictionaryField('f1', get_field('', 'uint16'), dict1),
+        DictionaryField('f2', get_field('', 'uint32'), dict2),
+        # DictionaryField('f3', get_field('', 'uint64'), dict3)
+    ]
+    batch_sizes = [7, 10]
+    return _generate_file("dictionary_unsigned", fields, batch_sizes,
+                          dictionaries=[dict0, dict1, dict2])
+
+
 def generate_nested_dictionary_case():
     dict0 = Dictionary(0, StringField('str'), size=10, name='DICT0')
 
@@ -1545,6 +1565,12 @@ def get_generated_json_files(tempdir=None, flight=False):
         # TODO(ARROW-3039, ARROW-5267): Dictionaries in GO
         generate_dictionary_case()
         .skip_category('Go')
+        .skip_category('Rust'),
+
+        # TODO: Dictionary unsigned indices
+        generate_dictionary_unsigned_case()
+        .skip_category('Go')
+        .skip_category('Java')
         .skip_category('Rust'),
 
         generate_nested_dictionary_case()

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -389,6 +389,9 @@ def write_js_test_json(directory):
     datagen.generate_dictionary_case().write(
         os.path.join(directory, 'dictionary.json')
     )
+    datagen.generate_dictionary_unsigned_case().write(
+        os.path.join(directory, 'dictionary_unsigned.json')
+    )
     datagen.generate_primitive_case([]).write(
         os.path.join(directory, 'primitive_no_batches.json')
     )

--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apache-arrow",
-  "version": "0.18.0-SNAPSHOT",
+  "version": "1.0.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/r/tests/testthat/test-data-type.R
+++ b/r/tests/testthat/test-data-type.R
@@ -376,7 +376,7 @@ test_that("DictionaryType works as expected (ARROW-3355)", {
 test_that("DictionaryType validation", {
   expect_error(
     dictionary(utf8(), int32()),
-    "Dictionary index type should be signed integer, got string"
+    "Dictionary index type should be integer, got string"
   )
   expect_error(dictionary(4, utf8()), 'index_type must be a "DataType"')
   expect_error(dictionary(int8(), "strings"), 'value_type must be a "DataType"')


### PR DESCRIPTION
Summary of places where changes were needed:

* Add to integration tests. uint64 does not work in JavaScript so this is disabled temporarily (NEEDS TICKET)
* Support in DictionaryArray::GetValueIndex, Transpose, FromArrays
* Support in C interface implementation
* Support in IPC read/write
* Handle in `DictionaryScalar::GetEncodedValue`
* Relax checks in DictionaryType argument validation
* Add unsigned int support to internal::TransposeInts
* Support in Parquet direct dictionary encoding (`PutIndices`)

Converting to pandas from unsigned indices is disabled (raises exception). That turned out to be somewhat involved because of how nulls are handled (pandas only accepts signed integers), so think we should deal with this as follow up (NEEDS TICKET).