### PR TITLE
ARROW-9265: [C++] Allow writing and reading V4-compliant IPC data

### DIFF
--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -23,7 +23,10 @@ arrow_dir=${1}
 source_dir=${1}/cpp
 build_dir=${2}/cpp
 gold_dir_0_14_1=$arrow_dir/testing/data/arrow-ipc-stream/integration/0.14.1
+gold_dir_0_17_1=$arrow_dir/testing/data/arrow-ipc-stream/integration/0.17.1
 
 pip install -e $arrow_dir/dev/archery
 
-archery integration --with-all --run-flight --gold-dirs=$gold_dir_0_14_1
+archery integration --with-all --run-flight \
+    --gold-dirs=$gold_dir_0_14_1 \
+    --gold-dirs=$gold_dir_0_17_1 \

--- a/cpp/src/arrow/ipc/file_to_stream.cc
+++ b/cpp/src/arrow/ipc/file_to_stream.cc
@@ -39,7 +39,11 @@ Status ConvertToStream(const char* path) {
 
   ARROW_ASSIGN_OR_RAISE(auto in_file, io::ReadableFile::Open(path));
   ARROW_ASSIGN_OR_RAISE(auto reader, ipc::RecordBatchFileReader::Open(in_file.get()));
-  ARROW_ASSIGN_OR_RAISE(auto writer, ipc::NewStreamWriter(&sink, reader->schema()));
+  auto options = IpcWriteOptions::Defaults();
+  // Use V5 to get up-to-date Union buffer layout
+  options.metadata_version = MetadataVersion::V5;
+  ARROW_ASSIGN_OR_RAISE(auto writer,
+                        ipc::NewStreamWriter(&sink, reader->schema(), options));
   for (int i = 0; i < reader->num_record_batches(); ++i) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> chunk, reader->ReadRecordBatch(i));
     RETURN_NOT_OK(writer->WriteRecordBatch(*chunk));

--- a/cpp/src/arrow/ipc/file_to_stream.cc
+++ b/cpp/src/arrow/ipc/file_to_stream.cc
@@ -39,11 +39,8 @@ Status ConvertToStream(const char* path) {
 
   ARROW_ASSIGN_OR_RAISE(auto in_file, io::ReadableFile::Open(path));
   ARROW_ASSIGN_OR_RAISE(auto reader, ipc::RecordBatchFileReader::Open(in_file.get()));
-  auto options = IpcWriteOptions::Defaults();
-  // Use V5 to get up-to-date Union buffer layout
-  options.metadata_version = MetadataVersion::V5;
-  ARROW_ASSIGN_OR_RAISE(auto writer,
-                        ipc::NewStreamWriter(&sink, reader->schema(), options));
+  ARROW_ASSIGN_OR_RAISE(auto writer, ipc::NewStreamWriter(&sink, reader->schema(),
+                                                          IpcWriteOptions::Defaults()));
   for (int i = 0; i < reader->num_record_batches(); ++i) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> chunk, reader->ReadRecordBatch(i));
     RETURN_NOT_OK(writer->WriteRecordBatch(*chunk));

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -59,7 +59,7 @@ using KVVector = flatbuffers::Vector<KeyValueOffset>;
 constexpr int32_t kIpcContinuationToken = -1;
 
 static constexpr flatbuf::MetadataVersion kCurrentMetadataVersion =
-    flatbuf::MetadataVersion::V4;
+    flatbuf::MetadataVersion::V5;
 
 static constexpr flatbuf::MetadataVersion kLatestMetadataVersion =
     flatbuf::MetadataVersion::V5;

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -29,6 +29,7 @@
 #include <flatbuffers/flatbuffers.h>
 
 #include "arrow/buffer.h"
+#include "arrow/io/type_fwd.h"
 #include "arrow/ipc/message.h"
 #include "arrow/result.h"
 #include "arrow/sparse_tensor.h"
@@ -45,16 +46,6 @@ namespace arrow {
 
 namespace flatbuf = org::apache::arrow::flatbuf;
 
-class DataType;
-class KeyValueMetadata;
-class Schema;
-
-namespace io {
-
-class OutputStream;
-
-}  // namespace io
-
 namespace ipc {
 
 class DictionaryMemo;
@@ -70,10 +61,20 @@ constexpr int32_t kIpcContinuationToken = -1;
 static constexpr flatbuf::MetadataVersion kCurrentMetadataVersion =
     flatbuf::MetadataVersion::V4;
 
+static constexpr flatbuf::MetadataVersion kLatestMetadataVersion =
+    flatbuf::MetadataVersion::V5;
+
 static constexpr flatbuf::MetadataVersion kMinMetadataVersion =
     flatbuf::MetadataVersion::V4;
 
 MetadataVersion GetMetadataVersion(flatbuf::MetadataVersion version);
+
+// This function is used in a unit test
+ARROW_EXPORT
+flatbuf::MetadataVersion MetadataVersionToFlatbuffer(MetadataVersion version);
+
+// Whether the type has a validity bitmap in the given IPC version
+bool HasValidityBitmap(Type::type type_id, MetadataVersion version);
 
 static constexpr const char* kArrowMagicBytes = "ARROW1";
 
@@ -172,7 +173,7 @@ static inline Status VerifyMessage(const uint8_t* data, int64_t size,
 // \param[out] out the serialized arrow::Buffer
 // \return Status outcome
 Status WriteSchemaMessage(const Schema& schema, DictionaryMemo* dictionary_memo,
-                          std::shared_ptr<Buffer>* out);
+                          const IpcWriteOptions& options, std::shared_ptr<Buffer>* out);
 
 // This function is used in a unit test
 ARROW_EXPORT
@@ -183,11 +184,12 @@ Status WriteRecordBatchMessage(
     const IpcWriteOptions& options, std::shared_ptr<Buffer>* out);
 
 Result<std::shared_ptr<Buffer>> WriteTensorMessage(const Tensor& tensor,
-                                                   const int64_t buffer_start_offset);
+                                                   const int64_t buffer_start_offset,
+                                                   const IpcWriteOptions& options);
 
 Result<std::shared_ptr<Buffer>> WriteSparseTensorMessage(
     const SparseTensor& sparse_tensor, int64_t body_length,
-    const std::vector<BufferMetadata>& buffers);
+    const std::vector<BufferMetadata>& buffers, const IpcWriteOptions& options);
 
 Status WriteFileFooter(const Schema& schema, const std::vector<FileBlock>& dictionaries,
                        const std::vector<FileBlock>& record_batches,

--- a/cpp/src/arrow/ipc/options.h
+++ b/cpp/src/arrow/ipc/options.h
@@ -67,9 +67,11 @@ struct ARROW_EXPORT IpcWriteOptions {
   /// like compression
   bool use_threads = true;
 
-  /// \brief Format version to use for IPC messages and their
-  /// metadata. Presently using V4 version (readable by v0.8.0 and later).
-  MetadataVersion metadata_version = MetadataVersion::V4;
+  /// \brief Format version to use for IPC messages and their metadata.
+  ///
+  /// Presently using V5 version (readable by 1.0.0 and later).
+  /// V4 is also available (readable by 0.8.0 and later).
+  MetadataVersion metadata_version = MetadataVersion::V5;
 
   static IpcWriteOptions Defaults();
 };

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -476,10 +476,12 @@ TEST_P(TestIpcRoundTrip, RoundTrip) {
 }
 
 TEST_F(TestIpcRoundTrip, DefaultMetadataVersion) {
-  TestMetadataVersion(MetadataVersion::V4);
+  TestMetadataVersion(MetadataVersion::V5);
 }
 
 TEST_F(TestIpcRoundTrip, SpecificMetadataVersion) {
+  options_.metadata_version = MetadataVersion::V4;
+  TestMetadataVersion(MetadataVersion::V4);
   options_.metadata_version = MetadataVersion::V5;
   TestMetadataVersion(MetadataVersion::V5);
 }

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -63,6 +63,24 @@ namespace test {
 
 using BatchVector = std::vector<std::shared_ptr<RecordBatch>>;
 
+const std::vector<MetadataVersion> kMetadataVersions = {MetadataVersion::V4,
+                                                        MetadataVersion::V5};
+
+class TestMessage : public ::testing::TestWithParam<MetadataVersion> {
+ public:
+  void SetUp() {
+    version_ = GetParam();
+    fb_version_ = internal::MetadataVersionToFlatbuffer(version_);
+    options_ = IpcWriteOptions::Defaults();
+    options_.metadata_version = version_;
+  }
+
+ protected:
+  MetadataVersion version_;
+  flatbuf::MetadataVersion fb_version_;
+  IpcWriteOptions options_;
+};
+
 TEST(TestMessage, Equals) {
   std::string metadata = "foo";
   std::string body = "bar";
@@ -89,13 +107,12 @@ TEST(TestMessage, Equals) {
   ASSERT_FALSE(msg5.Equals(msg1));
 }
 
-TEST(TestMessage, SerializeTo) {
+TEST_P(TestMessage, SerializeTo) {
   const int64_t body_length = 64;
 
   flatbuffers::FlatBufferBuilder fbb;
-  fbb.Finish(flatbuf::CreateMessage(fbb, internal::kCurrentMetadataVersion,
-                                    flatbuf::MessageHeader::RecordBatch, 0 /* header */,
-                                    body_length));
+  fbb.Finish(flatbuf::CreateMessage(fbb, fb_version_, flatbuf::MessageHeader::RecordBatch,
+                                    0 /* header */, body_length));
 
   std::shared_ptr<Buffer> metadata;
   ASSERT_OK_AND_ASSIGN(metadata, internal::WriteFlatbufferBuilder(fbb));
@@ -106,12 +123,11 @@ TEST(TestMessage, SerializeTo) {
                        Message::Open(metadata, std::make_shared<Buffer>(body)));
 
   auto CheckWithAlignment = [&](int32_t alignment) {
-    IpcWriteOptions options;
-    options.alignment = alignment;
+    options_.alignment = alignment;
     const int32_t prefix_size = 8;
     int64_t output_length = 0;
     ASSERT_OK_AND_ASSIGN(auto stream, io::BufferOutputStream::Create(1 << 10));
-    ASSERT_OK(message->SerializeTo(stream.get(), options, &output_length));
+    ASSERT_OK(message->SerializeTo(stream.get(), options_, &output_length));
     ASSERT_EQ(BitUtil::RoundUp(metadata->size() + prefix_size, alignment) + body_length,
               output_length);
     ASSERT_OK_AND_EQ(output_length, stream->Tell());
@@ -121,7 +137,7 @@ TEST(TestMessage, SerializeTo) {
   CheckWithAlignment(64);
 }
 
-TEST(TestMessage, SerializeCustomMetadata) {
+TEST_P(TestMessage, SerializeCustomMetadata) {
   std::vector<std::shared_ptr<KeyValueMetadata>> cases = {
       nullptr, key_value_metadata({}, {}),
       key_value_metadata({"foo", "bar"}, {"fizz", "buzz"})};
@@ -130,7 +146,7 @@ TEST(TestMessage, SerializeCustomMetadata) {
     ASSERT_OK(internal::WriteRecordBatchMessage(
         /*length=*/0, /*body_length=*/0, metadata,
         /*nodes=*/{},
-        /*buffers=*/{}, IpcWriteOptions::Defaults(), &serialized));
+        /*buffers=*/{}, options_, &serialized));
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<Message> message,
                          Message::Open(serialized, /*body=*/nullptr));
 
@@ -148,20 +164,19 @@ void BuffersOverlapEquals(const Buffer& left, const Buffer& right) {
   ASSERT_TRUE(left.Equals(right, std::min(left.size(), right.size())));
 }
 
-TEST(TestMessage, LegacyIpcBackwardsCompatibility) {
+TEST_P(TestMessage, LegacyIpcBackwardsCompatibility) {
   std::shared_ptr<RecordBatch> batch;
   ASSERT_OK(MakeIntBatchSized(36, &batch));
 
-  auto RoundtripWithOptions = [&](const IpcWriteOptions& arg_options,
-                                  std::shared_ptr<Buffer>* out_serialized,
+  auto RoundtripWithOptions = [&](std::shared_ptr<Buffer>* out_serialized,
                                   std::unique_ptr<Message>* out) {
     IpcPayload payload;
-    ASSERT_OK(GetRecordBatchPayload(*batch, arg_options, &payload));
+    ASSERT_OK(GetRecordBatchPayload(*batch, options_, &payload));
 
     ASSERT_OK_AND_ASSIGN(auto stream, io::BufferOutputStream::Create(1 << 20));
 
     int32_t metadata_length = -1;
-    ASSERT_OK(WriteIpcPayload(payload, arg_options, stream.get(), &metadata_length));
+    ASSERT_OK(WriteIpcPayload(payload, options_, stream.get(), &metadata_length));
 
     ASSERT_OK_AND_ASSIGN(*out_serialized, stream->Finish());
     io::BufferReader io_reader(*out_serialized);
@@ -171,14 +186,13 @@ TEST(TestMessage, LegacyIpcBackwardsCompatibility) {
   std::shared_ptr<Buffer> serialized, legacy_serialized;
   std::unique_ptr<Message> message, legacy_message;
 
-  IpcWriteOptions options;
-  RoundtripWithOptions(options, &serialized, &message);
+  RoundtripWithOptions(&serialized, &message);
 
   // First 4 bytes 0xFFFFFFFF Continuation marker
   ASSERT_EQ(-1, util::SafeLoadAs<int32_t>(serialized->data()));
 
-  options.write_legacy_ipc_format = true;
-  RoundtripWithOptions(options, &legacy_serialized, &legacy_message);
+  options_.write_legacy_ipc_format = true;
+  RoundtripWithOptions(&legacy_serialized, &legacy_message);
 
   // Check that the continuation marker is not written
   ASSERT_NE(-1, util::SafeLoadAs<int32_t>(legacy_serialized->data()));
@@ -196,11 +210,14 @@ TEST(TestMessage, Verify) {
   ASSERT_FALSE(message.Verify());
 }
 
+INSTANTIATE_TEST_SUITE_P(TestMessage, TestMessage,
+                         ::testing::ValuesIn(kMetadataVersions));
+
 class TestSchemaMetadata : public ::testing::Test {
  public:
   void SetUp() {}
 
-  void CheckRoundtrip(const Schema& schema) {
+  void CheckSchemaRoundtrip(const Schema& schema) {
     DictionaryMemo in_memo, out_memo;
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<Buffer> buffer,
                          SerializeSchema(schema, &out_memo, default_memory_pool()));
@@ -227,7 +244,7 @@ TEST_F(TestSchemaMetadata, PrimitiveFields) {
   auto f10 = field("f10", std::make_shared<BooleanType>());
 
   Schema schema({f0, f1, f2, f3, f4, f5, f6, f7, f8, f9, f10});
-  CheckRoundtrip(schema);
+  CheckSchemaRoundtrip(schema);
 }
 
 TEST_F(TestSchemaMetadata, NestedFields) {
@@ -239,7 +256,7 @@ TEST_F(TestSchemaMetadata, NestedFields) {
   auto f1 = field("f1", type2);
 
   Schema schema({f0, f1});
-  CheckRoundtrip(schema);
+  CheckSchemaRoundtrip(schema);
 }
 
 TEST_F(TestSchemaMetadata, DictionaryFields) {
@@ -249,14 +266,14 @@ TEST_F(TestSchemaMetadata, DictionaryFields) {
     auto f1 = field("f1", list(dict_type));
 
     Schema schema({f0, f1});
-    CheckRoundtrip(schema);
+    CheckSchemaRoundtrip(schema);
   }
   {
     auto dict_type = dictionary(int8(), list(int32()));
     auto f0 = field("f0", dict_type);
 
     Schema schema({f0});
-    CheckRoundtrip(schema);
+    CheckSchemaRoundtrip(schema);
   }
 }
 
@@ -266,7 +283,7 @@ TEST_F(TestSchemaMetadata, NestedDictionaryFields) {
     auto dict_type = dictionary(int16(), list(inner_dict_type));
 
     Schema schema({field("f0", dict_type)});
-    CheckRoundtrip(schema);
+    CheckSchemaRoundtrip(schema);
   }
   {
     auto dict_type1 = dictionary(int8(), utf8(), /*ordered=*/true);
@@ -279,7 +296,7 @@ TEST_F(TestSchemaMetadata, NestedDictionaryFields) {
 
     Schema schema({field("f1", dictionary(int32(), struct_type1)),
                    field("f2", dictionary(int32(), struct_type2))});
-    CheckRoundtrip(schema);
+    CheckSchemaRoundtrip(schema);
   }
 }
 
@@ -291,7 +308,7 @@ TEST_F(TestSchemaMetadata, KeyValueMetadata) {
   auto f1 = field("f1", std::make_shared<Int16Type>(), false, field_metadata);
 
   Schema schema({f0, f1}, schema_metadata);
-  CheckRoundtrip(schema);
+  CheckSchemaRoundtrip(schema);
 }
 
 #define BATCH_CASES()                                                                    \
@@ -400,6 +417,7 @@ class IpcTestFixture : public io::MemoryMapFixture, public ExtensionTypesMixin {
     ASSERT_OK_AND_ASSIGN(result, DoLargeRoundTrip(batch, /*zero_data=*/true));
     CheckReadResult(*result, batch);
   }
+
   void CheckRoundtrip(const std::shared_ptr<Array>& array,
                       IpcWriteOptions options = IpcWriteOptions::Defaults(),
                       int64_t buffer_size = 1 << 20) {
@@ -427,34 +445,43 @@ class TestIpcRoundTrip : public ::testing::TestWithParam<MakeRecordBatch*>,
  public:
   void SetUp() { IpcTestFixture::SetUp(); }
   void TearDown() { IpcTestFixture::TearDown(); }
+
+  void TestMetadataVersion(MetadataVersion expected_version) {
+    std::shared_ptr<RecordBatch> batch;
+    ASSERT_OK(MakeIntRecordBatch(&batch));
+
+    ASSERT_OK_AND_ASSIGN(mmap_,
+                         io::MemoryMapFixture::InitMemoryMap(1 << 16, "test-metadata"));
+
+    int32_t metadata_length;
+    int64_t body_length;
+    const int64_t buffer_offset = 0;
+    ASSERT_OK(WriteRecordBatch(*batch, buffer_offset, mmap_.get(), &metadata_length,
+                               &body_length, options_));
+
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<Message> message,
+                         ReadMessage(0, metadata_length, mmap_.get()));
+    ASSERT_EQ(expected_version, message->metadata_version());
+  }
 };
 
 TEST_P(TestIpcRoundTrip, RoundTrip) {
   std::shared_ptr<RecordBatch> batch;
   ASSERT_OK((*GetParam())(&batch));  // NOLINT clang-tidy gtest issue
 
-  CheckRoundtrip(*batch);
+  for (const auto version : kMetadataVersions) {
+    options_.metadata_version = version;
+    CheckRoundtrip(*batch);
+  }
 }
 
-TEST_F(TestIpcRoundTrip, MetadataVersion) {
-  std::shared_ptr<RecordBatch> batch;
-  ASSERT_OK(MakeIntRecordBatch(&batch));
+TEST_F(TestIpcRoundTrip, DefaultMetadataVersion) {
+  TestMetadataVersion(MetadataVersion::V4);
+}
 
-  ASSERT_OK_AND_ASSIGN(mmap_,
-                       io::MemoryMapFixture::InitMemoryMap(1 << 16, "test-metadata"));
-
-  int32_t metadata_length;
-  int64_t body_length;
-
-  const int64_t buffer_offset = 0;
-
-  ASSERT_OK(WriteRecordBatch(*batch, buffer_offset, mmap_.get(), &metadata_length,
-                             &body_length, options_));
-
-  ASSERT_OK_AND_ASSIGN(std::unique_ptr<Message> message,
-                       ReadMessage(0, metadata_length, mmap_.get()));
-
-  ASSERT_EQ(MetadataVersion::V4, message->metadata_version());
+TEST_F(TestIpcRoundTrip, SpecificMetadataVersion) {
+  options_.metadata_version = MetadataVersion::V5;
+  TestMetadataVersion(MetadataVersion::V5);
 }
 
 TEST(TestReadMessage, CorruptedSmallInput) {

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -450,6 +450,7 @@ class TestIpcRoundTrip : public ::testing::TestWithParam<MakeRecordBatch*>,
     std::shared_ptr<RecordBatch> batch;
     ASSERT_OK(MakeIntRecordBatch(&batch));
 
+    mmap_.reset();  // Ditch previous mmap view, to avoid errors on Windows
     ASSERT_OK_AND_ASSIGN(mmap_,
                          io::MemoryMapFixture::InitMemoryMap(1 << 16, "test-metadata"));
 

--- a/cpp/src/arrow/ipc/stream_to_file.cc
+++ b/cpp/src/arrow/ipc/stream_to_file.cc
@@ -37,10 +37,8 @@ Status ConvertToFile() {
   io::StdoutStream sink;
 
   ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchStreamReader::Open(&input));
-  auto options = IpcWriteOptions::Defaults();
-  // Use V5 to get up-to-date Union buffer layout
-  options.metadata_version = MetadataVersion::V5;
-  ARROW_ASSIGN_OR_RAISE(auto writer, NewFileWriter(&sink, reader->schema(), options));
+  ARROW_ASSIGN_OR_RAISE(
+      auto writer, NewFileWriter(&sink, reader->schema(), IpcWriteOptions::Defaults()));
   std::shared_ptr<RecordBatch> batch;
   while (true) {
     ARROW_ASSIGN_OR_RAISE(batch, reader->Next());

--- a/cpp/src/arrow/ipc/stream_to_file.cc
+++ b/cpp/src/arrow/ipc/stream_to_file.cc
@@ -37,7 +37,10 @@ Status ConvertToFile() {
   io::StdoutStream sink;
 
   ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchStreamReader::Open(&input));
-  ARROW_ASSIGN_OR_RAISE(auto writer, NewFileWriter(&sink, reader->schema()));
+  auto options = IpcWriteOptions::Defaults();
+  // Use V5 to get up-to-date Union buffer layout
+  options.metadata_version = MetadataVersion::V5;
+  ARROW_ASSIGN_OR_RAISE(auto writer, NewFileWriter(&sink, reader->schema(), options));
   std::shared_ptr<RecordBatch> batch;
   while (true) {
     ARROW_ASSIGN_OR_RAISE(batch, reader->Next());

--- a/cpp/src/arrow/ipc/type_fwd.h
+++ b/cpp/src/arrow/ipc/type_fwd.h
@@ -30,8 +30,11 @@ enum class MetadataVersion : char {
   /// 0.3.0 to 0.7.1
   V3,
 
-  /// >= 0.8.0
-  V4
+  /// 0.8.0 to 0.17.0
+  V4,
+
+  /// >= 1.0.0
+  V5
 };
 
 class Message;

--- a/cpp/src/arrow/testing/json_integration_test.cc
+++ b/cpp/src/arrow/testing/json_integration_test.cc
@@ -83,11 +83,8 @@ static Status ConvertJsonToArrow(const std::string& json_path,
               << reader->schema()->ToString(/* show_metadata = */ true) << std::endl;
   }
 
-  auto options = IpcWriteOptions::Defaults();
-  // Use V5 to get up-to-date Union buffer layout
-  options.metadata_version = MetadataVersion::V5;
-  ARROW_ASSIGN_OR_RAISE(auto writer,
-                        ipc::NewFileWriter(out_file.get(), reader->schema(), options));
+  ARROW_ASSIGN_OR_RAISE(auto writer, ipc::NewFileWriter(out_file.get(), reader->schema(),
+                                                        IpcWriteOptions::Defaults()));
   for (int i = 0; i < reader->num_record_batches(); ++i) {
     std::shared_ptr<RecordBatch> batch;
     RETURN_NOT_OK(reader->ReadRecordBatch(i, &batch));

--- a/cpp/src/arrow/testing/json_integration_test.cc
+++ b/cpp/src/arrow/testing/json_integration_test.cc
@@ -57,12 +57,12 @@ DEFINE_bool(verbose, true, "Verbose output");
 
 namespace arrow {
 
-class Buffer;
 using internal::TemporaryDir;
+using ipc::DictionaryMemo;
+using ipc::IpcWriteOptions;
+using ipc::MetadataVersion;
 
 namespace testing {
-
-using ::arrow::ipc::DictionaryMemo;
 
 using namespace ::arrow::ipc::test;  // NOLINT
 
@@ -83,8 +83,11 @@ static Status ConvertJsonToArrow(const std::string& json_path,
               << reader->schema()->ToString(/* show_metadata = */ true) << std::endl;
   }
 
+  auto options = IpcWriteOptions::Defaults();
+  // Use V5 to get up-to-date Union buffer layout
+  options.metadata_version = MetadataVersion::V5;
   ARROW_ASSIGN_OR_RAISE(auto writer,
-                        ipc::NewFileWriter(out_file.get(), reader->schema()));
+                        ipc::NewFileWriter(out_file.get(), reader->schema(), options));
   for (int i = 0; i < reader->num_record_batches(); ++i) {
     std::shared_ptr<RecordBatch> batch;
     RETURN_NOT_OK(reader->ReadRecordBatch(i, &batch));

--- a/cpp/src/arrow/testing/json_internal.cc
+++ b/cpp/src/arrow/testing/json_internal.cc
@@ -940,6 +940,7 @@ static Status GetUnion(const RjObject& json_type,
 
   std::vector<int8_t> type_codes;
   const auto& id_array = it_type_codes->value.GetArray();
+  type_codes.reserve(id_array.Size());
   for (const rj::Value& val : id_array) {
     DCHECK(val.IsInt());
     type_codes.push_back(static_cast<int8_t>(val.GetInt()));
@@ -1591,6 +1592,7 @@ class ArrayReader {
     RETURN_NOT_ARRAY("VALIDITY", json_valid_iter, obj_);
     const auto& json_validity = json_valid_iter->value.GetArray();
     DCHECK_EQ(static_cast<int>(json_validity.Size()), length_);
+    is_valid_.reserve(json_validity.Size());
     for (const rj::Value& val : json_validity) {
       DCHECK(val.IsInt());
       is_valid_.push_back(val.GetInt() != 0);

--- a/cpp/src/generated/Schema_generated.h
+++ b/cpp/src/generated/Schema_generated.h
@@ -89,43 +89,109 @@ struct Schema;
 struct SchemaBuilder;
 
 enum class MetadataVersion : int16_t {
-  /// 0.1.0
+  /// 0.1.0 (October 2016).
   V1 = 0,
-  /// 0.2.0
+  /// 0.2.0 (February 2017). Non-backwards compatible with V1.
   V2 = 1,
-  /// 0.3.0 -> 0.7.1
+  /// 0.3.0 -> 0.7.1 (May - December 2017). Non-backwards compatible with V2.
   V3 = 2,
-  /// >= 0.8.0
+  /// >= 0.8.0 (December 2017). Non-backwards compatible with V3.
   V4 = 3,
+  /// >= 1.0.0 (July 2020. Backwards compatible with V4 (V5 readers can read V4
+  /// metadata and IPC messages). Implementations are recommended to provide a
+  /// V4 compatibility mode with V5 format changes disabled.
+  ///
+  /// Incompatible changes between V4 and V5:
+  /// - Union buffer layout has changed. In V5, Unions don't have a validity
+  ///   bitmap buffer.
+  V5 = 4,
   MIN = V1,
-  MAX = V4
+  MAX = V5
 };
 
-inline const MetadataVersion (&EnumValuesMetadataVersion())[4] {
+inline const MetadataVersion (&EnumValuesMetadataVersion())[5] {
   static const MetadataVersion values[] = {
     MetadataVersion::V1,
     MetadataVersion::V2,
     MetadataVersion::V3,
-    MetadataVersion::V4
+    MetadataVersion::V4,
+    MetadataVersion::V5
   };
   return values;
 }
 
 inline const char * const *EnumNamesMetadataVersion() {
-  static const char * const names[5] = {
+  static const char * const names[6] = {
     "V1",
     "V2",
     "V3",
     "V4",
+    "V5",
     nullptr
   };
   return names;
 }
 
 inline const char *EnumNameMetadataVersion(MetadataVersion e) {
-  if (flatbuffers::IsOutRange(e, MetadataVersion::V1, MetadataVersion::V4)) return "";
+  if (flatbuffers::IsOutRange(e, MetadataVersion::V1, MetadataVersion::V5)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesMetadataVersion()[index];
+}
+
+/// Represents Arrow Features that might not have full support
+/// within implementations. This is intended to be used in
+/// two scenarios:
+///  1.  A mechanism for readers of Arrow Streams
+///      and files to understand that the stream or file makes
+///      use of a feature that isn't supported or unknown to
+///      the implementation (and therefore can meet the Arrow
+///      forward compatibility guarantees).
+///  2.  A means of negotiating between a client and server
+///      what features a stream is allowed to use. The enums
+///      values here are intented to represent higher level
+///      features, additional details maybe negotiated
+///      with key-value pairs specific to the protocol.
+///
+/// Enums added to this list should be assigned power-of-two values
+/// to facilitate exchanging and comparing bitmaps for supported
+/// features.
+enum class Feature : int64_t {
+  /// Needed to make flatbuffers happy.
+  UNUSED = 0,
+  /// The stream makes use of multiple full dictionaries with the
+  /// same ID and assumes clients implement dictionary replacement
+  /// correctly.
+  DICTIONARY_REPLACEMENT = 1LL,
+  /// The stream makes use of compressed bodies as described
+  /// in Message.fbs.
+  COMPRESSED_BODY = 2LL,
+  MIN = UNUSED,
+  MAX = COMPRESSED_BODY
+};
+
+inline const Feature (&EnumValuesFeature())[3] {
+  static const Feature values[] = {
+    Feature::UNUSED,
+    Feature::DICTIONARY_REPLACEMENT,
+    Feature::COMPRESSED_BODY
+  };
+  return values;
+}
+
+inline const char * const *EnumNamesFeature() {
+  static const char * const names[4] = {
+    "UNUSED",
+    "DICTIONARY_REPLACEMENT",
+    "COMPRESSED_BODY",
+    nullptr
+  };
+  return names;
+}
+
+inline const char *EnumNameFeature(Feature e) {
+  if (flatbuffers::IsOutRange(e, Feature::UNUSED, Feature::COMPRESSED_BODY)) return "";
+  const size_t index = static_cast<size_t>(e);
+  return EnumNamesFeature()[index];
 }
 
 enum class UnionMode : int16_t {
@@ -1595,8 +1661,11 @@ struct DictionaryEncoding FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   int64_t id() const {
     return GetField<int64_t>(VT_ID, 0);
   }
-  /// The dictionary indices are constrained to be positive integers. If this
-  /// field is null, the indices must be signed int32
+  /// The dictionary indices are constrained to be non-negative integers. If
+  /// this field is null, the indices must be signed int32. To maximize
+  /// cross-language compatibility and performance, implementations are
+  /// recommended to prefer signed integer types over unsigned integer types
+  /// and to avoid uint64 indices unless they are required by an application.
   const org::apache::arrow::flatbuf::Int *indexType() const {
     return GetPointer<const org::apache::arrow::flatbuf::Int *>(VT_INDEXTYPE);
   }
@@ -1960,7 +2029,8 @@ struct Schema FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
     VT_ENDIANNESS = 4,
     VT_FIELDS = 6,
-    VT_CUSTOM_METADATA = 8
+    VT_CUSTOM_METADATA = 8,
+    VT_FEATURES = 10
   };
   /// endianness of the buffer
   /// it is Little Endian by default
@@ -1974,6 +2044,10 @@ struct Schema FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
   const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata() const {
     return GetPointer<const flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *>(VT_CUSTOM_METADATA);
   }
+  /// Features used in the stream/file.
+  const flatbuffers::Vector<int64_t> *features() const {
+    return GetPointer<const flatbuffers::Vector<int64_t> *>(VT_FEATURES);
+  }
   bool Verify(flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
            VerifyField<int16_t>(verifier, VT_ENDIANNESS) &&
@@ -1983,6 +2057,8 @@ struct Schema FLATBUFFERS_FINAL_CLASS : private flatbuffers::Table {
            VerifyOffset(verifier, VT_CUSTOM_METADATA) &&
            verifier.VerifyVector(custom_metadata()) &&
            verifier.VerifyVectorOfTables(custom_metadata()) &&
+           VerifyOffset(verifier, VT_FEATURES) &&
+           verifier.VerifyVector(features()) &&
            verifier.EndTable();
   }
 };
@@ -2000,6 +2076,9 @@ struct SchemaBuilder {
   void add_custom_metadata(flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata) {
     fbb_.AddOffset(Schema::VT_CUSTOM_METADATA, custom_metadata);
   }
+  void add_features(flatbuffers::Offset<flatbuffers::Vector<int64_t>> features) {
+    fbb_.AddOffset(Schema::VT_FEATURES, features);
+  }
   explicit SchemaBuilder(flatbuffers::FlatBufferBuilder &_fbb)
         : fbb_(_fbb) {
     start_ = fbb_.StartTable();
@@ -2016,8 +2095,10 @@ inline flatbuffers::Offset<Schema> CreateSchema(
     flatbuffers::FlatBufferBuilder &_fbb,
     org::apache::arrow::flatbuf::Endianness endianness = org::apache::arrow::flatbuf::Endianness::Little,
     flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>> fields = 0,
-    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata = 0) {
+    flatbuffers::Offset<flatbuffers::Vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata = 0,
+    flatbuffers::Offset<flatbuffers::Vector<int64_t>> features = 0) {
   SchemaBuilder builder_(_fbb);
+  builder_.add_features(features);
   builder_.add_custom_metadata(custom_metadata);
   builder_.add_fields(fields);
   builder_.add_endianness(endianness);
@@ -2028,14 +2109,17 @@ inline flatbuffers::Offset<Schema> CreateSchemaDirect(
     flatbuffers::FlatBufferBuilder &_fbb,
     org::apache::arrow::flatbuf::Endianness endianness = org::apache::arrow::flatbuf::Endianness::Little,
     const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>> *fields = nullptr,
-    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata = nullptr) {
+    const std::vector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata = nullptr,
+    const std::vector<int64_t> *features = nullptr) {
   auto fields__ = fields ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>(*fields) : 0;
   auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>(*custom_metadata) : 0;
+  auto features__ = features ? _fbb.CreateVector<int64_t>(*features) : 0;
   return org::apache::arrow::flatbuf::CreateSchema(
       _fbb,
       endianness,
       fields__,
-      custom_metadata__);
+      custom_metadata__,
+      features__);
 }
 
 inline bool VerifyType(flatbuffers::Verifier &verifier, const void *obj, Type type) {

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -36,7 +36,9 @@ enum MetadataVersion:short {
   /// metadata and IPC messages). Implementations are recommended to provide a
   /// V4 compatibility mode with V5 format changes disabled.
   ///
-  /// TODO: Add list of non-forward compatible changes.
+  /// Incompatible changes between V4 and V5:
+  /// - Union buffer layout has changed. In V5, Unions don't have a validity
+  ///   bitmap buffer.
   V5,
 }
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -200,9 +200,9 @@ def _plasma_store_entry_point():
                                             "plasma-store-server")
     _os.execv(plasma_store_executable, _sys.argv)
 
+
 # ----------------------------------------------------------------------
 # Deprecations
-
 
 from pyarrow.util import _deprecate_api, _deprecate_class
 
@@ -279,7 +279,7 @@ DurationValue = _deprecate_scalar("Duration", DurationScalar)
 
 
 # TODO: Deprecate these somehow in the pyarrow namespace
-from pyarrow.ipc import (Message, MessageReader,
+from pyarrow.ipc import (Message, MessageReader, MetadataVersion,
                          RecordBatchFileReader, RecordBatchFileWriter,
                          RecordBatchStreamReader, RecordBatchStreamWriter)
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1287,7 +1287,10 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         MessageType_DICTIONARY_BATCH\
             " arrow::ipc::MessageType::DICTIONARY_BATCH"
 
-    enum CMetadataVersion" arrow::ipc::MetadataVersion":
+    # TODO: use "cpdef enum class" to automatically get a Python wrapper?
+    # See
+    # https://github.com/cython/cython/commit/2c7c22f51405299a4e247f78edf52957d30cf71d#diff-61c1365c0f761a8137754bb3a73bfbf7
+    ctypedef enum CMetadataVersion" arrow::ipc::MetadataVersion":
         CMetadataVersion_V1" arrow::ipc::MetadataVersion::V1"
         CMetadataVersion_V2" arrow::ipc::MetadataVersion::V2"
         CMetadataVersion_V3" arrow::ipc::MetadataVersion::V3"

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1287,11 +1287,12 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         MessageType_DICTIONARY_BATCH\
             " arrow::ipc::MessageType::DICTIONARY_BATCH"
 
-    enum MetadataVersion" arrow::ipc::MetadataVersion":
-        MessageType_V1" arrow::ipc::MetadataVersion::V1"
-        MessageType_V2" arrow::ipc::MetadataVersion::V2"
-        MessageType_V3" arrow::ipc::MetadataVersion::V3"
-        MessageType_V4" arrow::ipc::MetadataVersion::V4"
+    enum CMetadataVersion" arrow::ipc::MetadataVersion":
+        CMetadataVersion_V1" arrow::ipc::MetadataVersion::V1"
+        CMetadataVersion_V2" arrow::ipc::MetadataVersion::V2"
+        CMetadataVersion_V3" arrow::ipc::MetadataVersion::V3"
+        CMetadataVersion_V4" arrow::ipc::MetadataVersion::V4"
+        CMetadataVersion_V5" arrow::ipc::MetadataVersion::V5"
 
     cdef cppclass CIpcWriteOptions" arrow::ipc::IpcWriteOptions":
         c_bool allow_64bit
@@ -1329,7 +1330,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         c_bool Equals(const CMessage& other)
 
         shared_ptr[CBuffer] metadata()
-        MetadataVersion metadata_version()
+        CMetadataVersion metadata_version()
         MessageType type()
 
         CStatus SerializeTo(COutputStream* stream,

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -18,6 +18,32 @@
 import warnings
 
 
+cpdef enum MetadataVersion:
+    V1 = <char> CMetadataVersion_V1
+    V2 = <char> CMetadataVersion_V2
+    V3 = <char> CMetadataVersion_V3
+    V4 = <char> CMetadataVersion_V4
+    V5 = <char> CMetadataVersion_V5
+
+
+cdef object _wrap_metadata_version(CMetadataVersion version):
+    return MetadataVersion(<char> version)
+
+
+cdef CMetadataVersion _unwrap_metadata_version(
+        MetadataVersion version) except *:
+    if version == MetadataVersion.V1:
+        return CMetadataVersion_V1
+    elif version == MetadataVersion.V2:
+        return CMetadataVersion_V2
+    elif version == MetadataVersion.V3:
+        return CMetadataVersion_V3
+    elif version == MetadataVersion.V4:
+        return CMetadataVersion_V4
+    elif version == MetadataVersion.V5:
+        return CMetadataVersion_V5
+
+
 cdef class Message:
     """
     Container for an Arrow IPC message with metadata and optional body
@@ -38,6 +64,10 @@ cdef class Message:
     @property
     def metadata(self):
         return pyarrow_wrap_buffer(self.message.get().metadata())
+
+    @property
+    def metadata_version(self):
+        return _wrap_metadata_version(self.message.get().metadata_version())
 
     @property
     def body(self):

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -20,7 +20,7 @@
 
 import pyarrow as pa
 
-from pyarrow.lib import (Message, MessageReader,  # noqa
+from pyarrow.lib import (Message, MessageReader, MetadataVersion,  # noqa
                          read_message, read_record_batch, read_schema,
                          read_tensor, write_tensor,
                          get_record_batch_size, get_tensor_size)

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -374,13 +374,13 @@ def test_message_reader(example_messages):
     assert messages[0].type == 'schema'
     assert isinstance(messages[0].metadata, pa.Buffer)
     assert isinstance(messages[0].body, pa.Buffer)
-    assert messages[0].metadata_version == pa.MetadataVersion.V4
+    assert messages[0].metadata_version == pa.MetadataVersion.V5
 
     for msg in messages[1:]:
         assert msg.type == 'record batch'
         assert isinstance(msg.metadata, pa.Buffer)
         assert isinstance(msg.body, pa.Buffer)
-        assert msg.metadata_version == pa.MetadataVersion.V4
+        assert msg.metadata_version == pa.MetadataVersion.V5
 
 
 def test_message_serialize_read_message(example_messages):

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -374,11 +374,13 @@ def test_message_reader(example_messages):
     assert messages[0].type == 'schema'
     assert isinstance(messages[0].metadata, pa.Buffer)
     assert isinstance(messages[0].body, pa.Buffer)
+    assert messages[0].metadata_version == pa.MetadataVersion.V4
 
     for msg in messages[1:]:
         assert msg.type == 'record batch'
         assert isinstance(msg.metadata, pa.Buffer)
         assert isinstance(msg.body, pa.Buffer)
+        assert msg.metadata_version == pa.MetadataVersion.V4
 
 
 def test_message_serialize_read_message(example_messages):


### PR DESCRIPTION
V4 Union arrays with top-level null slots are disallowed, though.