### PR TITLE
ARROW-9360: [CI][Crossbow] Nightly homebrew-cpp job times out

### DIFF
--- a/dev/tasks/homebrew-formulae/travis.osx.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.yml
@@ -43,5 +43,5 @@ before_script:
 - brew doctor || true
 - brew audit $ARROW_FORMULA
 script:
-- brew install --HEAD $ARROW_FORMULA
+- brew install -v --HEAD $ARROW_FORMULA
 - brew test $ARROW_FORMULA

--- a/dev/tasks/homebrew-formulae/travis.osx.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.yml
@@ -43,5 +43,5 @@ before_script:
 - brew doctor || true
 - brew audit $ARROW_FORMULA
 script:
-- brew install -v --build-from-source --HEAD $ARROW_FORMULA
+- brew install --HEAD $ARROW_FORMULA
 - brew test $ARROW_FORMULA


### PR DESCRIPTION
After successfully building arrow, it then does

```
==> Upgrading 64 dependents:
ansible 2.9.6_1 -> 2.9.10, ansible 2.9.6_1 -> 2.9.10, ansible 2.9.6_1 -> 2.9.10, cairo 1.16.0_2 -> 1.16.0_3, cairo 1.16.0_2 -> 1.16.0_3, cairo 1.16.0_2 -> 1.16.0_3, cairo 1.16.0_2 -> 1.16.0_3, cgal 5.0.2 -> 5.0.2_1, cgal 5.0.2 -> 5.0.2_1, gdal 2.4.4_2 -> 3.1.1_1, gdal 2.4.4_2 -> 3.1.1_1, gdal 2.4.4_2 -> 3.1.1_1, gdal 2.4.4_2 -> 3.1.1_1, gdal 2.4.4_2 -> 3.1.1_1, gdal 2.4.4_2 -> 3.1.1_1, gdal 2.4.4_2 -> 3.1.1_1, gdal 2.4.4_2 -> 3.1.1_1, geos 3.8.1 -> 3.8.1_1, geos 3.8.1 -> 3.8.1_1, geos 3.8.1 -> 3.8.1_1, glib 2.64.1 -> 2.64.3, glib 2.64.1 -> 2.64.3, glib 2.64.1 -> 2.64.3, glib 2.64.1 -> 2.64.3, gnutls 3.6.12 -> 3.6.14, gnutls 3.6.12 -> 3.6.14, hdf5 1.12.0 -> 1.12.0_1, krb5 1.18 -> 1.18.2, libdap 3.20.5 -> 3.20.6, libdap 3.20.5 -> 3.20.6, libdap 3.20.5 -> 3.20.6, libpq 12.2_1 -> 12.3, libssh 0.9.3 -> 0.9.4, libxml2 2.9.10 -> 2.9.10_1, libxml2 2.9.10 -> 2.9.10_1, libxml2 2.9.10 -> 2.9.10_1, mercurial 5.3.1 -> 5.4.2, mercurial 5.3.1 -> 5.4.2, mercurial 5.3.1 -> 5.4.2, netcdf 4.7.3_2 -> 4.7.4_1, node 13.12.0 -> 14.5.0, p11-kit 0.23.20 -> 0.23.20_1, poppler 0.86.1_1 -> 0.90.0, poppler 0.86.1_1 -> 0.90.0, poppler 0.86.1_1 -> 0.90.0, poppler 0.86.1_1 -> 0.90.0, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgis 3.0.1_1 -> 3.0.1_2, postgresql 12.2 -> 12.3_4, postgresql 12.2 -> 12.3_4, protobuf-c 1.3.3 -> 1.3.3_1, pyenv 1.2.17 -> 1.2.19, sfcgal 1.3.7_2 -> 1.3.8, sfcgal 1.3.7_2 -> 1.3.8, unbound 1.10.0 -> 1.10.1
```

which times out. https://travis-ci.org/github/ursa-labs/crossbow/builds/705060949