### PR TITLE
ARROW-8559: [Rust] Consolidate Record Batch reader traits in main arrow crate

### DIFF
--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -3498,6 +3498,7 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "DictionaryKeyOverflowError")]
     fn test_primitive_dictionary_overflow() {
         let key_builder = PrimitiveBuilder::<UInt8Type>::new(257);
         let value_builder = PrimitiveBuilder::<UInt32Type>::new(257);
@@ -3507,10 +3508,7 @@ mod tests {
             builder.append(i + 1000).unwrap();
         }
         // Special error if the key overflows (256th entry)
-        assert_eq!(
-            builder.append(1257),
-            Err(ArrowError::DictionaryKeyOverflowError)
-        );
+        builder.append(1257).unwrap();
     }
 
     #[test]

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -392,13 +392,11 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "DivideByZero")]
     fn test_primitive_array_divide_by_zero() {
         let a = Int32Array::from(vec![15]);
         let b = Int32Array::from(vec![0]);
-        assert_eq!(
-            ArrowError::DivideByZero,
-            divide(&a, &b).err().expect("divide by zero should fail")
-        );
+        divide(&a, &b).unwrap();
     }
 
     #[test]

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -169,32 +169,35 @@ mod tests {
     #[test]
     fn test_apply_bin_op_to_option_bitmap() {
         assert_eq!(
-            Ok(None),
-            apply_bin_op_to_option_bitmap(&None, &None, |a, b| a & b)
+            None,
+            apply_bin_op_to_option_bitmap(&None, &None, |a, b| a & b).unwrap()
         );
         assert_eq!(
-            Ok(Some(Buffer::from([0b01101010]))),
+            Some(Buffer::from([0b01101010])),
             apply_bin_op_to_option_bitmap(
                 &Some(Bitmap::from(Buffer::from([0b01101010]))),
                 &None,
                 |a, b| a & b,
             )
+            .unwrap()
         );
         assert_eq!(
-            Ok(Some(Buffer::from([0b01001110]))),
+            Some(Buffer::from([0b01001110])),
             apply_bin_op_to_option_bitmap(
                 &None,
                 &Some(Bitmap::from(Buffer::from([0b01001110]))),
                 |a, b| a & b,
             )
+            .unwrap()
         );
         assert_eq!(
-            Ok(Some(Buffer::from([0b01001010]))),
+            Some(Buffer::from([0b01001010])),
             apply_bin_op_to_option_bitmap(
                 &Some(Bitmap::from(Buffer::from([0b01101010]))),
                 &Some(Bitmap::from(Buffer::from([0b01001110]))),
                 |a, b| a & b,
             )
+            .unwrap()
         );
     }
 

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -695,7 +695,7 @@ mod tests {
         let batch = csv.next().unwrap().unwrap();
         let batch_schema = batch.schema();
 
-        assert_eq!(&schema, batch_schema);
+        assert_eq!(schema, batch_schema);
         assert_eq!(37, batch.num_rows());
         assert_eq!(3, batch.num_columns());
 
@@ -735,7 +735,7 @@ mod tests {
         ]));
         assert_eq!(projected_schema.clone(), csv.schema());
         let batch = csv.next().unwrap().unwrap();
-        assert_eq!(&projected_schema, batch.schema());
+        assert_eq!(projected_schema, batch.schema());
         assert_eq!(37, batch.num_rows());
         assert_eq!(2, batch.num_columns());
     }

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -218,7 +218,7 @@ pub fn infer_schema_from_files(
 /// CSV file reader
 pub struct Reader<R: Read> {
     /// Explicit schema for the CSV file
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Optional projection for which columns to load (zero-based column indices)
     projection: Option<Vec<usize>>,
     /// File reader
@@ -237,7 +237,7 @@ impl<R: Read> Reader<R> {
     /// `ReaderBuilder`.
     pub fn new(
         reader: R,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         has_header: bool,
         delimiter: Option<u8>,
         batch_size: usize,
@@ -255,7 +255,7 @@ impl<R: Read> Reader<R> {
 
     /// Returns the schema of the reader, useful for getting the schema without reading
     /// record batches
-    pub fn schema(&self) -> Arc<Schema> {
+    pub fn schema(&self) -> SchemaRef {
         match &self.projection {
             Some(projection) => {
                 let fields = self.schema.fields();
@@ -274,7 +274,7 @@ impl<R: Read> Reader<R> {
     /// csv reader.
     pub fn from_buf_reader(
         buf_reader: BufReader<R>,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         has_header: bool,
         delimiter: Option<u8>,
         batch_size: usize,
@@ -439,7 +439,7 @@ pub struct ReaderBuilder {
     ///
     /// If the schema is not supplied, the reader will try to infer the schema
     /// based on the CSV structure.
-    schema: Option<Arc<Schema>>,
+    schema: Option<SchemaRef>,
     /// Whether the file has headers or not
     ///
     /// If schema inference is run on a file with no headers, default column names
@@ -501,7 +501,7 @@ impl ReaderBuilder {
     }
 
     /// Set the CSV file's schema
-    pub fn with_schema(mut self, schema: Arc<Schema>) -> Self {
+    pub fn with_schema(mut self, schema: SchemaRef) -> Self {
         self.schema = Some(schema);
         self
     }

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -2350,26 +2350,27 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "InvalidArgumentError(\"nickname\")")]
     fn schema_index_of() {
         let schema = person_schema();
-        assert_eq!(schema.index_of("first_name"), Ok(0));
-        assert_eq!(schema.index_of("last_name"), Ok(1));
-        assert_eq!(
-            schema.index_of("nickname"),
-            Err(ArrowError::InvalidArgumentError("nickname".to_owned()))
-        );
+        assert_eq!(schema.index_of("first_name").unwrap(), 0);
+        assert_eq!(schema.index_of("last_name").unwrap(), 1);
+        schema.index_of("nickname").unwrap();
     }
 
     #[test]
-    fn schema_field_with_name() -> Result<()> {
+    #[should_panic(expected = "InvalidArgumentError(\"nickname\")")]
+    fn schema_field_with_name() {
         let schema = person_schema();
-        assert_eq!(schema.field_with_name("first_name")?.name(), "first_name");
-        assert_eq!(schema.field_with_name("last_name")?.name(), "last_name");
         assert_eq!(
-            schema.field_with_name("nickname"),
-            Err(ArrowError::InvalidArgumentError("nickname".to_owned()))
+            schema.field_with_name("first_name").unwrap().name(),
+            "first_name"
         );
-        Ok(())
+        assert_eq!(
+            schema.field_with_name("last_name").unwrap().name(),
+            "last_name"
+        );
+        schema.field_with_name("nickname").unwrap();
     }
 
     #[test]

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -16,14 +16,28 @@
 // under the License.
 
 //! Defines `ArrowError` for representing failures in various Arrow operations
-use std::error::Error;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
 use csv as csv_crate;
+use std::error::Error;
+
+#[derive(Debug)]
+pub struct ExternalError {
+    pub source: Box<dyn Error + Send + Sync>,
+}
+
+impl Error for ExternalError {}
+
+impl Display for ExternalError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Arrow external error: {}", self.source)
+    }
+}
 
 /// Many different operations in the `arrow` crate return this error type
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub enum ArrowError {
+    ExternalError(ExternalError),
     MemoryError(String),
     ParseError(String),
     SchemaError(String),
@@ -35,6 +49,14 @@ pub enum ArrowError {
     InvalidArgumentError(String),
     ParquetError(String),
     DictionaryKeyOverflowError,
+}
+
+impl ArrowError {
+    pub fn from_external_error(
+        error: Box<dyn ::std::error::Error + Send + Sync>,
+    ) -> Self {
+        Self::ExternalError(ExternalError { source: error })
+    }
 }
 
 impl From<::std::io::Error> for ArrowError {
@@ -71,19 +93,20 @@ impl From<::std::string::FromUtf8Error> for ArrowError {
 
 impl Display for ArrowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            ArrowError::MemoryError(ref desc) => write!(f, "Memory error: {}", desc),
-            ArrowError::ParseError(ref desc) => write!(f, "Parser error: {}", desc),
-            ArrowError::SchemaError(ref desc) => write!(f, "Schema error: {}", desc),
-            ArrowError::ComputeError(ref desc) => write!(f, "Compute error: {}", desc),
+        match self {
+            ArrowError::ExternalError(source) => Display::fmt(&source, f),
+            ArrowError::MemoryError(desc) => write!(f, "Memory error: {}", desc),
+            ArrowError::ParseError(desc) => write!(f, "Parser error: {}", desc),
+            ArrowError::SchemaError(desc) => write!(f, "Schema error: {}", desc),
+            ArrowError::ComputeError(desc) => write!(f, "Compute error: {}", desc),
             ArrowError::DivideByZero => write!(f, "Divide by zero error"),
-            ArrowError::CsvError(ref desc) => write!(f, "Csv error: {}", desc),
-            ArrowError::JsonError(ref desc) => write!(f, "Json error: {}", desc),
-            ArrowError::IoError(ref desc) => write!(f, "Io error: {}", desc),
-            ArrowError::InvalidArgumentError(ref desc) => {
+            ArrowError::CsvError(desc) => write!(f, "Csv error: {}", desc),
+            ArrowError::JsonError(desc) => write!(f, "Json error: {}", desc),
+            ArrowError::IoError(desc) => write!(f, "Io error: {}", desc),
+            ArrowError::InvalidArgumentError(desc) => {
                 write!(f, "Invalid argument error: {}", desc)
             }
-            ArrowError::ParquetError(ref desc) => {
+            ArrowError::ParquetError(desc) => {
                 write!(f, "Parquet argument error: {}", desc)
             }
             ArrowError::DictionaryKeyOverflowError => {

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -15,29 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines `ArrowError` for representing failures in various Arrow operations
+//! Defines `ArrowError` for representing failures in various Arrow operations.
 use std::fmt::{Debug, Display, Formatter};
 
 use csv as csv_crate;
 use std::error::Error;
 
-#[derive(Debug)]
-pub struct ExternalError {
-    pub source: Box<dyn Error + Send + Sync>,
-}
-
-impl Error for ExternalError {}
-
-impl Display for ExternalError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Arrow external error: {}", self.source)
-    }
-}
-
-/// Many different operations in the `arrow` crate return this error type
+/// Many different operations in the `arrow` crate return this error type.
 #[derive(Debug)]
 pub enum ArrowError {
-    ExternalError(ExternalError),
+    ExternalError(Box<dyn Error + Send + Sync>),
     MemoryError(String),
     ParseError(String),
     SchemaError(String),
@@ -52,10 +39,11 @@ pub enum ArrowError {
 }
 
 impl ArrowError {
+    /// Wraps an external error in an `ArrowError`.
     pub fn from_external_error(
         error: Box<dyn ::std::error::Error + Send + Sync>,
     ) -> Self {
-        Self::ExternalError(ExternalError { source: error })
+        Self::ExternalError(error)
     }
 }
 
@@ -94,7 +82,7 @@ impl From<::std::string::FromUtf8Error> for ArrowError {
 impl Display for ArrowError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            ArrowError::ExternalError(source) => Display::fmt(&source, f),
+            ArrowError::ExternalError(source) => write!(f, "External error: {}", &source),
             ArrowError::MemoryError(desc) => write!(f, "Memory error: {}", desc),
             ArrowError::ParseError(desc) => write!(f, "Parser error: {}", desc),
             ArrowError::SchemaError(desc) => write!(f, "Schema error: {}", desc),

--- a/rust/arrow/src/flight/mod.rs
+++ b/rust/arrow/src/flight/mod.rs
@@ -18,11 +18,10 @@
 //! Utilities to assist with reading and writing Arrow data as Flight messages
 
 use std::convert::TryFrom;
-use std::sync::Arc;
 
 use flight::{FlightData, SchemaResult};
 
-use crate::datatypes::Schema;
+use crate::datatypes::{Schema, SchemaRef};
 use crate::error::{ArrowError, Result};
 use crate::ipc::{convert, reader, writer};
 use crate::record_batch::RecordBatch;
@@ -93,7 +92,7 @@ impl TryFrom<&SchemaResult> for Schema {
 /// Convert a FlightData message to a RecordBatch
 pub fn flight_data_to_batch(
     data: &FlightData,
-    schema: Arc<Schema>,
+    schema: SchemaRef,
 ) -> Result<Option<RecordBatch>> {
     // check that the data_header is a record batch message
     let message = crate::ipc::get_root_as_message(&data.data_header[..]);

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -30,7 +30,7 @@ use crate::compute::cast;
 use crate::datatypes::{DataType, Field, IntervalUnit, Schema, SchemaRef};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
-use crate::record_batch::{RecordBatchReader, RecordBatch};
+use crate::record_batch::{RecordBatch, RecordBatchReader};
 use DataType::*;
 
 const CONTINUATION_MARKER: u32 = 0xffff_ffff;
@@ -861,7 +861,6 @@ impl<R: Read> RecordBatchReader for StreamReader<R> {
         self.schema.clone()
     }
 
-    #[allow(clippy::should_implement_trait)]
     fn next(&mut self) -> Result<Option<RecordBatch>> {
         self.next_batch()
     }

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -30,8 +30,7 @@ use crate::compute::cast;
 use crate::datatypes::{DataType, Field, IntervalUnit, Schema, SchemaRef};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
-use crate::record_batch::{RecordBatch, BatchReader};
-use crate::util::bit_util;
+use crate::record_batch::{BatchReader, RecordBatch};
 use DataType::*;
 
 const CONTINUATION_MARKER: u32 = 0xffff_ffff;

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -30,7 +30,7 @@ use crate::compute::cast;
 use crate::datatypes::{DataType, Field, IntervalUnit, Schema, SchemaRef};
 use crate::error::{ArrowError, Result};
 use crate::ipc;
-use crate::record_batch::{BatchReader, RecordBatch};
+use crate::record_batch::{RecordBatchReader, RecordBatch};
 use DataType::*;
 
 const CONTINUATION_MARKER: u32 = 0xffff_ffff;
@@ -699,7 +699,7 @@ impl<R: Read + Seek> FileReader<R> {
     }
 }
 
-impl<R: Read + Seek> BatchReader for FileReader<R> {
+impl<R: Read + Seek> RecordBatchReader for FileReader<R> {
     fn schema(&mut self) -> SchemaRef {
         self.schema.clone()
     }
@@ -856,7 +856,7 @@ impl<R: Read> StreamReader<R> {
     }
 }
 
-impl<R: Read> BatchReader for StreamReader<R> {
+impl<R: Read> RecordBatchReader for StreamReader<R> {
     fn schema(&mut self) -> SchemaRef {
         self.schema.clone()
     }

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -700,7 +700,7 @@ impl<R: Read + Seek> FileReader<R> {
 }
 
 impl<R: Read + Seek> RecordBatchReader for FileReader<R> {
-    fn schema(&mut self) -> SchemaRef {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
@@ -857,7 +857,7 @@ impl<R: Read> StreamReader<R> {
 }
 
 impl<R: Read> RecordBatchReader for StreamReader<R> {
-    fn schema(&mut self) -> SchemaRef {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -412,7 +412,7 @@ fn create_dictionary_array(
 pub(crate) fn read_record_batch(
     buf: &[u8],
     batch: ipc::RecordBatch,
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     dictionaries: &[Option<ArrayRef>],
 ) -> Result<Option<RecordBatch>> {
     let buffers = batch.buffers().ok_or_else(|| {
@@ -465,7 +465,7 @@ pub struct FileReader<R: Read + Seek> {
     reader: BufReader<R>,
 
     /// The schema that is read from the file header
-    schema: Arc<Schema>,
+    schema: SchemaRef,
 
     /// The blocks in the file
     ///
@@ -714,7 +714,7 @@ pub struct StreamReader<R: Read> {
     /// Buffered stream reader
     reader: BufReader<R>,
     /// The schema that is read from the stream's first message
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// An indicator of whether the strewam is complete.
     ///
     /// This value is set to `true` the first time the reader's `next()` returns `None`.

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -457,7 +457,7 @@ mod tests {
                 File::open(format!("target/debug/testdata/{}.arrow_file", "arrow"))
                     .unwrap();
             let mut reader = FileReader::try_new(file).unwrap();
-            while let Ok(Some(read_batch)) = reader.next() {
+            while let Ok(Some(read_batch)) = reader.next_batch() {
                 read_batch
                     .columns()
                     .iter()
@@ -504,7 +504,7 @@ mod tests {
         {
             let file = File::open("target/debug/testdata/nulls.arrow_file").unwrap();
             let mut reader = FileReader::try_new(file).unwrap();
-            while let Ok(Some(read_batch)) = reader.next() {
+            while let Ok(Some(read_batch)) = reader.next_batch() {
                 read_batch
                     .columns()
                     .iter()
@@ -545,7 +545,7 @@ mod tests {
                     File::create(format!("target/debug/testdata/{}.arrow_file", path))
                         .unwrap();
                 let mut writer = FileWriter::try_new(file, &reader.schema()).unwrap();
-                while let Ok(Some(batch)) = reader.next() {
+                while let Ok(Some(batch)) = reader.next_batch() {
                     writer.write(&batch).unwrap();
                 }
                 writer.finish().unwrap();
@@ -587,7 +587,7 @@ mod tests {
                 let file = File::create(format!("target/debug/testdata/{}.stream", path))
                     .unwrap();
                 let mut writer = StreamWriter::try_new(file, &reader.schema()).unwrap();
-                while let Ok(Some(batch)) = reader.next() {
+                while let Ok(Some(batch)) = reader.next_batch() {
                     writer.write(&batch).unwrap();
                 }
                 writer.finish().unwrap();

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -415,9 +415,9 @@ mod tests {
     use flate2::read::GzDecoder;
 
     use crate::array::*;
-    use crate::record_batch::BatchReader;
     use crate::datatypes::Field;
     use crate::ipc::reader::*;
+    use crate::record_batch::BatchReader;
     use crate::util::integration_util::*;
     use std::env;
     use std::fs::File;

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -417,7 +417,7 @@ mod tests {
     use crate::array::*;
     use crate::datatypes::Field;
     use crate::ipc::reader::*;
-    use crate::record_batch::BatchReader;
+    use crate::record_batch::RecordBatchReader;
     use crate::util::integration_util::*;
     use std::env;
     use std::fs::File;

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -415,6 +415,7 @@ mod tests {
     use flate2::read::GzDecoder;
 
     use crate::array::*;
+    use crate::record_batch::BatchReader;
     use crate::datatypes::Field;
     use crate::ipc::reader::*;
     use crate::util::integration_util::*;

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -853,7 +853,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(&schema, batch_schema);
+        assert_eq!(schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
         assert_eq!(0, a.0);
@@ -911,7 +911,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(&schema, batch_schema);
+        assert_eq!(schema, batch_schema);
 
         let a = schema.column_with_name("a").unwrap();
         assert_eq!(&DataType::Int64, a.1.data_type());
@@ -1038,7 +1038,7 @@ mod tests {
         assert_eq!(12, batch.num_rows());
 
         let schema = batch.schema();
-        assert_eq!(&reader_schema, schema);
+        assert_eq!(reader_schema, schema);
 
         let a = schema.column_with_name("a").unwrap();
         assert_eq!(0, a.0);
@@ -1239,7 +1239,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(&schema, batch_schema);
+        assert_eq!(schema, batch_schema);
 
         let d = schema.column_with_name("d").unwrap();
         assert_eq!(
@@ -1297,7 +1297,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(&schema, batch_schema);
+        assert_eq!(schema, batch_schema);
 
         let d = schema.column_with_name("d").unwrap();
         assert_eq!(
@@ -1326,7 +1326,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(&schema, batch_schema);
+        assert_eq!(schema, batch_schema);
 
         let d = schema.column_with_name("d").unwrap();
         assert_eq!(
@@ -1355,7 +1355,7 @@ mod tests {
 
         let schema = reader.schema();
         let batch_schema = batch.schema();
-        assert_eq!(&schema, batch_schema);
+        assert_eq!(schema, batch_schema);
 
         let d = schema.column_with_name("d").unwrap();
         assert_eq!(

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -135,7 +135,7 @@ fn coerce_data_type(dt: Vec<&DataType>) -> Result<DataType> {
 }
 
 /// Generate schema from JSON field names and inferred data types
-fn generate_schema(spec: HashMap<String, HashSet<DataType>>) -> Result<Arc<Schema>> {
+fn generate_schema(spec: HashMap<String, HashSet<DataType>>) -> Result<SchemaRef> {
     let fields: Result<Vec<Field>> = spec
         .iter()
         .map(|(k, hs)| {
@@ -175,7 +175,7 @@ fn generate_schema(spec: HashMap<String, HashSet<DataType>>) -> Result<Arc<Schem
 pub fn infer_json_schema_from_seekable<R: Read + Seek>(
     reader: &mut BufReader<R>,
     max_read_records: Option<usize>,
-) -> Result<Arc<Schema>> {
+) -> Result<SchemaRef> {
     let schema = infer_json_schema(reader, max_read_records);
     // return the reader seek back to the start
     reader.seek(SeekFrom::Start(0))?;
@@ -212,7 +212,7 @@ pub fn infer_json_schema_from_seekable<R: Read + Seek>(
 pub fn infer_json_schema<R: Read>(
     reader: &mut BufReader<R>,
     max_read_records: Option<usize>,
-) -> Result<Arc<Schema>> {
+) -> Result<SchemaRef> {
     let mut values: HashMap<String, HashSet<DataType>> = HashMap::new();
 
     let mut line = String::new();
@@ -362,7 +362,7 @@ pub fn infer_json_schema<R: Read>(
 /// JSON file reader
 pub struct Reader<R: Read> {
     /// Explicit schema for the JSON file
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Optional projection for which columns to load (case-sensitive names)
     projection: Option<Vec<String>>,
     /// File reader
@@ -378,7 +378,7 @@ impl<R: Read> Reader<R> {
     /// inference, use `ReaderBuilder`.
     pub fn new(
         reader: R,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         batch_size: usize,
         projection: Option<Vec<String>>,
     ) -> Self {
@@ -387,7 +387,7 @@ impl<R: Read> Reader<R> {
 
     /// Returns the schema of the reader, useful for getting the schema without reading
     /// record batches
-    pub fn schema(&self) -> Arc<Schema> {
+    pub fn schema(&self) -> SchemaRef {
         match &self.projection {
             Some(projection) => {
                 let fields = self.schema.fields();
@@ -413,7 +413,7 @@ impl<R: Read> Reader<R> {
     /// To customize the schema, such as to enable schema inference, use `ReaderBuilder`
     pub fn from_buf_reader(
         reader: BufReader<R>,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         batch_size: usize,
         projection: Option<Vec<String>>,
     ) -> Self {
@@ -735,7 +735,7 @@ pub struct ReaderBuilder {
     ///
     /// If the schema is not supplied, the reader will try to infer the schema
     /// based on the JSON structure.
-    schema: Option<Arc<Schema>>,
+    schema: Option<SchemaRef>,
     /// Optional maximum number of records to read during schema inference
     ///
     /// If a number is not provided, all the records are read.
@@ -788,7 +788,7 @@ impl ReaderBuilder {
     }
 
     /// Set the JSON file's schema
-    pub fn with_schema(mut self, schema: Arc<Schema>) -> Self {
+    pub fn with_schema(mut self, schema: SchemaRef) -> Self {
         self.schema = Some(schema);
         self
     }

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -38,7 +38,7 @@ use crate::error::{ArrowError, Result};
 /// [JSON reader](crate::json::Reader).
 #[derive(Clone, Debug)]
 pub struct RecordBatch {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     columns: Vec<Arc<Array>>,
 }
 
@@ -74,7 +74,7 @@ impl RecordBatch {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn try_new(schema: Arc<Schema>, columns: Vec<ArrayRef>) -> Result<Self> {
+    pub fn try_new(schema: SchemaRef, columns: Vec<ArrayRef>) -> Result<Self> {
         // check that there are some columns
         if columns.is_empty() {
             return Err(ArrowError::InvalidArgumentError(
@@ -111,8 +111,8 @@ impl RecordBatch {
     }
 
     /// Returns the [`Schema`](crate::datatypes::Schema) of the record batch.
-    pub fn schema(&self) -> &Arc<Schema> {
-        &self.schema
+    pub fn schema(&self) -> SchemaRef {
+        self.schema.clone()
     }
 
     /// Returns the number of columns in the record batch.

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -240,7 +240,6 @@ pub trait SendableBatchReader: Send + Sync {
     fn next(&mut self) -> Result<Option<RecordBatch>>;
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -225,7 +225,7 @@ pub trait RecordBatchReader {
     fn schema(&self) -> SchemaRef;
 
     /// Reads the next `RecordBatch`.
-    fn next(&mut self) -> Result<Option<RecordBatch>>;
+    fn next_batch(&mut self) -> Result<Option<RecordBatch>>;
 }
 
 #[cfg(test)]

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -216,25 +216,13 @@ impl Into<StructArray> for RecordBatch {
     }
 }
 
-/// Trait for types that can read `RecordBatch`'s in a single-threaded context.
+/// Trait for types that can read `RecordBatch`'s.
 pub trait RecordBatchReader {
     /// Returns the schema of this `RecordBatchReader`.
     ///
     /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
     /// reader should have the same schema as returned from this method.
-    fn schema(&mut self) -> SchemaRef;
-
-    /// Reads the next `RecordBatch`.
-    fn next(&mut self) -> Result<Option<RecordBatch>>;
-}
-
-/// Trait for types that can read `RecordBatch`'s in a multi-threaded context.
-pub trait SendableRecordBatchReader: Send + Sync {
-    /// Returns the schema of this `SendableRecordBatchReader`.
-    ///
-    /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
-    /// reader should have the same schema as returned from this method.
-    fn schema(&self) -> Arc<Schema>;
+    fn schema(&self) -> SchemaRef;
 
     /// Reads the next `RecordBatch`.
     fn next(&mut self) -> Result<Option<RecordBatch>>;

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -217,8 +217,8 @@ impl Into<StructArray> for RecordBatch {
 }
 
 /// Definition of type that can read `RecordBatch`'s in a single-threaded context.
-pub trait BatchReader {
-    /// Returns schema of this `BatchReader`.
+pub trait RecordBatchReader {
+    /// Returns schema of this `RecordBatchReader`.
     ///
     /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
     /// reader should have same schema as returned from this method.
@@ -229,8 +229,8 @@ pub trait BatchReader {
 }
 
 /// Definition of type that can read `RecordBatch`'s in a multi-threaded context.
-pub trait SendableBatchReader: Send + Sync {
-    /// Returns schemas of this `BatchReader`.
+pub trait SendableRecordBatchReader: Send + Sync {
+    /// Returns schemas of this `SendableRecordBatchReader`.
     ///
     /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
     /// reader should have same schema as returned from this method.

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -216,16 +216,30 @@ impl Into<StructArray> for RecordBatch {
     }
 }
 
-/// Definition of record batch reader.
-pub trait RecordBatchReader {
-    /// Returns schemas of this record batch reader.
-    /// Implementation of this trait should guarantee that all record batches returned
-    /// by this reader should have same schema as returned from this method.
+/// Definition of type that can read `RecordBatch`'s in a single-threaded context.
+pub trait BatchReader {
+    /// Returns schema of this `BatchReader`.
+    ///
+    /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
+    /// reader should have same schema as returned from this method.
     fn schema(&mut self) -> SchemaRef;
 
-    /// Returns next record batch.
-    fn next_batch(&mut self) -> Result<Option<RecordBatch>>;
+    /// Reads the next `RecordBatch`.
+    fn next(&mut self) -> Result<Option<RecordBatch>>;
 }
+
+/// Definition of type that can read `RecordBatch`'s in a multi-threaded context.
+pub trait SendableBatchReader: Send + Sync {
+    /// Returns schemas of this `BatchReader`.
+    ///
+    /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
+    /// reader should have same schema as returned from this method.
+    fn schema(&self) -> Arc<Schema>;
+
+    /// Reads the next `RecordBatch`.
+    fn next(&mut self) -> Result<Option<RecordBatch>>;
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -216,24 +216,24 @@ impl Into<StructArray> for RecordBatch {
     }
 }
 
-/// Definition of type that can read `RecordBatch`'s in a single-threaded context.
+/// Trait for types that can read `RecordBatch`'s in a single-threaded context.
 pub trait RecordBatchReader {
-    /// Returns schema of this `RecordBatchReader`.
+    /// Returns the schema of this `RecordBatchReader`.
     ///
     /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
-    /// reader should have same schema as returned from this method.
+    /// reader should have the same schema as returned from this method.
     fn schema(&mut self) -> SchemaRef;
 
     /// Reads the next `RecordBatch`.
     fn next(&mut self) -> Result<Option<RecordBatch>>;
 }
 
-/// Definition of type that can read `RecordBatch`'s in a multi-threaded context.
+/// Trait for types that can read `RecordBatch`'s in a multi-threaded context.
 pub trait SendableRecordBatchReader: Send + Sync {
-    /// Returns schemas of this `SendableRecordBatchReader`.
+    /// Returns the schema of this `SendableRecordBatchReader`.
     ///
     /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
-    /// reader should have same schema as returned from this method.
+    /// reader should have the same schema as returned from this method.
     fn schema(&self) -> Arc<Schema>;
 
     /// Reads the next `RecordBatch`.

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -73,7 +73,7 @@ pub struct ArrowJsonColumn {
 
 impl ArrowJson {
     /// Compare the Arrow JSON with a record batch reader
-    pub fn equals_reader(&self, reader: &mut RecordBatchReader) -> bool {
+    pub fn equals_reader(&self, reader: &mut dyn RecordBatchReader) -> bool {
         if !self.schema.equals_schema(&reader.schema()) {
             return false;
         }

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -78,7 +78,7 @@ impl ArrowJson {
             return false;
         }
         self.batches.iter().all(|col| {
-            let batch = reader.next();
+            let batch = reader.next_batch();
             match batch {
                 Ok(Some(batch)) => col.equals_batch(&batch),
                 _ => false,

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -24,7 +24,7 @@ use serde_json::{Number as VNumber, Value};
 
 use crate::array::*;
 use crate::datatypes::*;
-use crate::record_batch::{RecordBatch, RecordBatchReader};
+use crate::record_batch::{RecordBatch, BatchReader};
 
 /// A struct that represents an Arrow file with a schema and record batches
 #[derive(Deserialize, Serialize, Debug)]
@@ -73,12 +73,12 @@ pub struct ArrowJsonColumn {
 
 impl ArrowJson {
     /// Compare the Arrow JSON with a record batch reader
-    pub fn equals_reader(&self, reader: &mut RecordBatchReader) -> bool {
+    pub fn equals_reader(&self, reader: &mut BatchReader) -> bool {
         if !self.schema.equals_schema(&reader.schema()) {
             return false;
         }
         self.batches.iter().all(|col| {
-            let batch = reader.next_batch();
+            let batch = reader.next();
             match batch {
                 Ok(Some(batch)) => col.equals_batch(&batch),
                 _ => false,

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -24,7 +24,7 @@ use serde_json::{Number as VNumber, Value};
 
 use crate::array::*;
 use crate::datatypes::*;
-use crate::record_batch::{RecordBatchReader, RecordBatch};
+use crate::record_batch::{RecordBatch, RecordBatchReader};
 
 /// A struct that represents an Arrow file with a schema and record batches
 #[derive(Deserialize, Serialize, Debug)]

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -24,7 +24,7 @@ use serde_json::{Number as VNumber, Value};
 
 use crate::array::*;
 use crate::datatypes::*;
-use crate::record_batch::{BatchReader, RecordBatch};
+use crate::record_batch::{RecordBatchReader, RecordBatch};
 
 /// A struct that represents an Arrow file with a schema and record batches
 #[derive(Deserialize, Serialize, Debug)]
@@ -73,7 +73,7 @@ pub struct ArrowJsonColumn {
 
 impl ArrowJson {
     /// Compare the Arrow JSON with a record batch reader
-    pub fn equals_reader(&self, reader: &mut BatchReader) -> bool {
+    pub fn equals_reader(&self, reader: &mut RecordBatchReader) -> bool {
         if !self.schema.equals_schema(&reader.schema()) {
             return false;
         }

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -24,7 +24,7 @@ use serde_json::{Number as VNumber, Value};
 
 use crate::array::*;
 use crate::datatypes::*;
-use crate::record_batch::{RecordBatch, BatchReader};
+use crate::record_batch::{BatchReader, RecordBatch};
 
 /// A struct that represents an Arrow file with a schema and record batches
 #[derive(Deserialize, Serialize, Debug)]

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -150,7 +150,7 @@ impl RecordBatchReader for CsvBatchIterator {
         self.schema.clone()
     }
 
-    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         self.reader.next()
     }
 }

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -37,7 +37,8 @@ use std::fs::File;
 
 use arrow::csv;
 use arrow::datatypes::{Field, Schema};
-use arrow::record_batch::RecordBatch;
+use arrow::error::Result as ArrowResult;
+use arrow::record_batch::{RecordBatch, SendableBatchReader};
 use std::string::String;
 use std::sync::Arc;
 
@@ -45,7 +46,7 @@ use crate::datasource::{ScanResult, TableProvider};
 use crate::error::Result;
 use crate::execution::physical_plan::csv::CsvExec;
 pub use crate::execution::physical_plan::csv::CsvReadOptions;
-use crate::execution::physical_plan::{BatchIterator, ExecutionPlan};
+use crate::execution::physical_plan::ExecutionPlan;
 
 /// Represents a CSV file with a provided schema
 pub struct CsvFile {
@@ -144,12 +145,12 @@ impl CsvBatchIterator {
     }
 }
 
-impl BatchIterator for CsvBatchIterator {
+impl SendableBatchReader for CsvBatchIterator {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }
 
-    fn next(&mut self) -> Result<Option<RecordBatch>> {
-        Ok(self.reader.next()?)
+    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+        self.reader.next()
     }
 }

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -38,7 +38,7 @@ use std::fs::File;
 use arrow::csv;
 use arrow::datatypes::{Field, Schema};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use std::string::String;
 use std::sync::Arc;
 
@@ -145,7 +145,7 @@ impl CsvBatchIterator {
     }
 }
 
-impl SendableRecordBatchReader for CsvBatchIterator {
+impl RecordBatchReader for CsvBatchIterator {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -36,7 +36,7 @@
 use std::fs::File;
 
 use arrow::csv;
-use arrow::datatypes::{Field, Schema};
+use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use std::string::String;
@@ -51,7 +51,7 @@ use crate::execution::physical_plan::ExecutionPlan;
 /// Represents a CSV file with a provided schema
 pub struct CsvFile {
     filename: String,
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     has_header: bool,
     delimiter: u8,
 }
@@ -74,7 +74,7 @@ impl CsvFile {
 }
 
 impl TableProvider for CsvFile {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
@@ -104,7 +104,7 @@ impl TableProvider for CsvFile {
 /// Iterator over CSV batches
 // TODO: usage example (rather than documenting `new()`)
 pub struct CsvBatchIterator {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     reader: csv::Reader<File>,
 }
 
@@ -112,7 +112,7 @@ impl CsvBatchIterator {
     #[allow(missing_docs)]
     pub fn try_new(
         filename: &str,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         has_header: bool,
         delimiter: Option<u8>,
         projection: &Option<Vec<usize>>,
@@ -146,7 +146,7 @@ impl CsvBatchIterator {
 }
 
 impl RecordBatchReader for CsvBatchIterator {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -38,7 +38,7 @@ use std::fs::File;
 use arrow::csv;
 use arrow::datatypes::{Field, Schema};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 use std::string::String;
 use std::sync::Arc;
 
@@ -145,7 +145,7 @@ impl CsvBatchIterator {
     }
 }
 
-impl SendableBatchReader for CsvBatchIterator {
+impl SendableRecordBatchReader for CsvBatchIterator {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -19,14 +19,14 @@
 
 use std::sync::{Arc, Mutex};
 
+use arrow::record_batch::SendableBatchReader;
 use arrow::datatypes::Schema;
 
 use crate::error::Result;
-use crate::execution::physical_plan::BatchIterator;
 
-/// Returned by implementors of `Table#scan`, this `BatchIterator` is wrapped with
+/// Returned by implementors of `Table#scan`, this `SendableBatchReader` is wrapped with
 /// an `Arc` and `Mutex` so that it can be shared across threads as it is used.
-pub type ScanResult = Arc<Mutex<dyn BatchIterator>>;
+pub type ScanResult = Arc<Mutex<dyn SendableBatchReader>>;
 
 /// Source table
 pub trait TableProvider {

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -19,8 +19,8 @@
 
 use std::sync::{Arc, Mutex};
 
-use arrow::record_batch::SendableBatchReader;
 use arrow::datatypes::Schema;
+use arrow::record_batch::SendableBatchReader;
 
 use crate::error::Result;
 

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -20,13 +20,13 @@
 use std::sync::{Arc, Mutex};
 
 use arrow::datatypes::Schema;
-use arrow::record_batch::SendableBatchReader;
+use arrow::record_batch::SendableRecordBatchReader;
 
 use crate::error::Result;
 
-/// Returned by implementors of `Table#scan`, this `SendableBatchReader` is wrapped with
+/// Returned by implementors of `Table#scan`, this `SendableRecordBatchReader` is wrapped with
 /// an `Arc` and `Mutex` so that it can be shared across threads as it is used.
-pub type ScanResult = Arc<Mutex<dyn SendableBatchReader>>;
+pub type ScanResult = Arc<Mutex<dyn SendableRecordBatchReader>>;
 
 /// Source table
 pub trait TableProvider {

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -19,7 +19,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use arrow::datatypes::Schema;
+use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatchReader;
 
 use crate::error::Result;
@@ -31,7 +31,7 @@ pub type ScanResult = Arc<Mutex<dyn RecordBatchReader + Send + Sync>>;
 /// Source table
 pub trait TableProvider {
     /// Get a reference to the schema for this table
-    fn schema(&self) -> Arc<Schema>;
+    fn schema(&self) -> SchemaRef;
 
     /// Perform a scan of a table and return a sequence of iterators over the data (one
     /// iterator per partition)

--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -20,13 +20,13 @@
 use std::sync::{Arc, Mutex};
 
 use arrow::datatypes::Schema;
-use arrow::record_batch::SendableRecordBatchReader;
+use arrow::record_batch::RecordBatchReader;
 
 use crate::error::Result;
 
 /// Returned by implementors of `Table#scan`, this `SendableRecordBatchReader` is wrapped with
 /// an `Arc` and `Mutex` so that it can be shared across threads as it is used.
-pub type ScanResult = Arc<Mutex<dyn SendableRecordBatchReader>>;
+pub type ScanResult = Arc<Mutex<dyn RecordBatchReader + Send + Sync>>;
 
 /// Source table
 pub trait TableProvider {

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -21,7 +21,7 @@
 
 use std::sync::Arc;
 
-use arrow::datatypes::{Field, Schema};
+use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 
 use crate::datasource::{ScanResult, TableProvider};
@@ -31,13 +31,13 @@ use crate::execution::physical_plan::ExecutionPlan;
 
 /// In-memory table
 pub struct MemTable {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     batches: Vec<Vec<RecordBatch>>,
 }
 
 impl MemTable {
     /// Create a new in-memory table from the provided schema and record batches
-    pub fn new(schema: Arc<Schema>, partitions: Vec<Vec<RecordBatch>>) -> Result<Self> {
+    pub fn new(schema: SchemaRef, partitions: Vec<Vec<RecordBatch>>) -> Result<Self> {
         if partitions.iter().all(|partition| {
             partition
                 .iter()
@@ -73,7 +73,7 @@ impl MemTable {
 }
 
 impl TableProvider for MemTable {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -62,7 +62,7 @@ impl MemTable {
         let mut data: Vec<Vec<RecordBatch>> = Vec::with_capacity(partitions.len());
         for it in &partitions {
             let mut partition = vec![];
-            while let Ok(Some(batch)) = it.lock().unwrap().next() {
+            while let Ok(Some(batch)) = it.lock().unwrap().next_batch() {
                 partition.push(batch);
             }
             data.push(partition);
@@ -151,7 +151,7 @@ mod tests {
 
         // scan with projection
         let partitions = provider.scan(&Some(vec![2, 1]), 1024).unwrap();
-        let batch2 = partitions[0].lock().unwrap().next().unwrap().unwrap();
+        let batch2 = partitions[0].lock().unwrap().next_batch().unwrap().unwrap();
         assert_eq!(2, batch2.schema().fields().len());
         assert_eq!("c", batch2.schema().field(0).name());
         assert_eq!("b", batch2.schema().field(1).name());
@@ -179,7 +179,7 @@ mod tests {
         let provider = MemTable::new(schema, vec![vec![batch]]).unwrap();
 
         let partitions = provider.scan(&None, 1024).unwrap();
-        let batch1 = partitions[0].lock().unwrap().next().unwrap().unwrap();
+        let batch1 = partitions[0].lock().unwrap().next_batch().unwrap().unwrap();
         assert_eq!(3, batch1.schema().fields().len());
         assert_eq!(3, batch1.num_columns());
     }

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -88,7 +88,7 @@ mod tests {
         let mut it = scan[0].lock().unwrap();
 
         let mut count = 0;
-        while let Some(batch) = it.next().unwrap() {
+        while let Some(batch) = it.next_batch().unwrap() {
             assert_eq!(11, batch.num_columns());
             assert_eq!(2, batch.num_rows());
             count += 1;
@@ -127,7 +127,7 @@ mod tests {
         let projection = None;
         let scan = table.scan(&projection, 1024).unwrap();
         let mut it = scan[0].lock().unwrap();
-        let batch = it.next().unwrap().unwrap();
+        let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(11, batch.num_columns());
         assert_eq!(8, batch.num_rows());
@@ -140,7 +140,7 @@ mod tests {
         let projection = Some(vec![1]);
         let scan = table.scan(&projection, 1024).unwrap();
         let mut it = scan[0].lock().unwrap();
-        let batch = it.next().unwrap().unwrap();
+        let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());
         assert_eq!(8, batch.num_rows());
@@ -168,7 +168,7 @@ mod tests {
         let projection = Some(vec![0]);
         let scan = table.scan(&projection, 1024).unwrap();
         let mut it = scan[0].lock().unwrap();
-        let batch = it.next().unwrap().unwrap();
+        let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());
         assert_eq!(8, batch.num_rows());
@@ -193,7 +193,7 @@ mod tests {
         let projection = Some(vec![10]);
         let scan = table.scan(&projection, 1024).unwrap();
         let mut it = scan[0].lock().unwrap();
-        let batch = it.next().unwrap().unwrap();
+        let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());
         assert_eq!(8, batch.num_rows());
@@ -218,8 +218,7 @@ mod tests {
         let projection = Some(vec![6]);
         let scan = table.scan(&projection, 1024).unwrap();
         let mut it = scan[0].lock().unwrap();
-        let batch = it.next().unwrap().unwrap();
-
+        let batch = it.next_batch().unwrap().unwrap();
         assert_eq!(1, batch.num_columns());
         assert_eq!(8, batch.num_rows());
 
@@ -246,7 +245,7 @@ mod tests {
         let projection = Some(vec![7]);
         let scan = table.scan(&projection, 1024).unwrap();
         let mut it = scan[0].lock().unwrap();
-        let batch = it.next().unwrap().unwrap();
+        let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());
         assert_eq!(8, batch.num_rows());
@@ -274,7 +273,7 @@ mod tests {
         let projection = Some(vec![9]);
         let scan = table.scan(&projection, 1024).unwrap();
         let mut it = scan[0].lock().unwrap();
-        let batch = it.next().unwrap().unwrap();
+        let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());
         assert_eq!(8, batch.num_rows());

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -18,7 +18,6 @@
 //! Parquet data source
 
 use std::string::String;
-use std::sync::Arc;
 
 use arrow::datatypes::*;
 
@@ -27,14 +26,14 @@ use crate::error::Result;
 use crate::execution::physical_plan::parquet::ParquetExec;
 use crate::execution::physical_plan::ExecutionPlan;
 
-/// Table-based representation of a `ParquetFile`
+/// Table-based representation of a `ParquetFile`.
 pub struct ParquetTable {
     path: String,
-    schema: Arc<Schema>,
+    schema: SchemaRef,
 }
 
 impl ParquetTable {
-    /// Attempt to initialize a new `ParquetTable` from a file path
+    /// Attempt to initialize a new `ParquetTable` from a file path.
     pub fn try_new(path: &str) -> Result<Self> {
         let parquet_exec = ParquetExec::try_new(path, None, 0)?;
         let schema = parquet_exec.schema();
@@ -46,13 +45,13 @@ impl ParquetTable {
 }
 
 impl TableProvider for ParquetTable {
-    /// Get the schema for this parquet file
-    fn schema(&self) -> Arc<Schema> {
+    /// Get the schema for this parquet file.
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
     /// Scan the file(s), using the provided projection, and return one BatchIterator per
-    /// partition
+    /// partition.
     fn scan(
         &self,
         projection: &Option<Vec<usize>>,

--- a/rust/datafusion/src/error.rs
+++ b/rust/datafusion/src/error.rs
@@ -54,6 +54,13 @@ pub enum ExecutionError {
     ExecutionError(String),
 }
 
+impl ExecutionError {
+    /// Wraps this `ExecutionError` in arrow's `ExternalError` variant.
+    pub fn into_arrow_external_error(self) -> ArrowError {
+        ArrowError::from_external_error(Box::new(self))
+    }
+}
+
 impl From<Error> for ExecutionError {
     fn from(e: Error) -> Self {
         ExecutionError::IoError(e)

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -648,7 +648,7 @@ struct ExecutionContextSchemaProvider<'a> {
 }
 
 impl SchemaProvider for ExecutionContextSchemaProvider<'_> {
-    fn get_table_meta(&self, name: &str) -> Option<Arc<Schema>> {
+    fn get_table_meta(&self, name: &str) -> Option<SchemaRef> {
         self.datasources.get(name).map(|ds| ds.schema().clone())
     }
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -616,10 +616,10 @@ impl ExecutionContext {
                     let path = Path::new(&path).join(&filename);
                     let file = fs::File::create(path)?;
                     let mut writer = csv::Writer::new(file);
-                    let it = p.execute()?;
-                    let mut it = it.lock().unwrap();
+                    let reader = p.execute()?;
+                    let mut reader = reader.lock().unwrap();
                     loop {
-                        match it.next() {
+                        match reader.next_batch() {
                             Ok(Some(batch)) => {
                                 writer.write(&batch)?;
                             }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -624,7 +624,7 @@ impl ExecutionContext {
                                 writer.write(&batch)?;
                             }
                             Ok(None) => break,
-                            Err(e) => return Err(e),
+                            Err(e) => return Err(ExecutionError::from(e)),
                         }
                     }
                     Ok(())

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -27,7 +27,7 @@ use crate::logicalplan::ScalarValue;
 use arrow::array::{self, ArrayRef};
 use arrow::datatypes::{DataType, Schema};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 
 /// Iterator over a vector of record batches
 pub struct RecordBatchIterator {
@@ -47,7 +47,7 @@ impl RecordBatchIterator {
     }
 }
 
-impl SendableBatchReader for RecordBatchIterator {
+impl SendableRecordBatchReader for RecordBatchIterator {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }
@@ -63,7 +63,7 @@ impl SendableBatchReader for RecordBatchIterator {
 }
 
 /// Create a vector of record batches from an iterator
-pub fn collect(it: Arc<Mutex<dyn SendableBatchReader>>) -> Result<Vec<RecordBatch>> {
+pub fn collect(it: Arc<Mutex<dyn SendableRecordBatchReader>>) -> Result<Vec<RecordBatch>> {
     let mut it = it.lock().unwrap();
     let mut results: Vec<RecordBatch> = vec![];
     loop {

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -25,20 +25,20 @@ use crate::error::{ExecutionError, Result};
 
 use crate::logicalplan::ScalarValue;
 use arrow::array::{self, ArrayRef};
-use arrow::datatypes::{DataType, Schema};
+use arrow::datatypes::{DataType, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Iterator over a vector of record batches
 pub struct RecordBatchIterator {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     batches: Vec<Arc<RecordBatch>>,
     index: usize,
 }
 
 impl RecordBatchIterator {
     /// Create a new RecordBatchIterator
-    pub fn new(schema: Arc<Schema>, batches: Vec<Arc<RecordBatch>>) -> Self {
+    pub fn new(schema: SchemaRef, batches: Vec<Arc<RecordBatch>>) -> Self {
         RecordBatchIterator {
             schema,
             index: 0,
@@ -48,7 +48,7 @@ impl RecordBatchIterator {
 }
 
 impl RecordBatchReader for RecordBatchIterator {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -26,6 +26,7 @@ use crate::error::{ExecutionError, Result};
 use crate::logicalplan::ScalarValue;
 use arrow::array::{self, ArrayRef};
 use arrow::datatypes::{DataType, Schema};
+use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, SendableBatchReader};
 
 /// Iterator over a vector of record batches
@@ -51,7 +52,7 @@ impl SendableBatchReader for RecordBatchIterator {
         self.schema.clone()
     }
 
-    fn next(&mut self) -> Result<Option<RecordBatch>> {
+    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
         if self.index < self.batches.len() {
             self.index += 1;
             Ok(Some(self.batches[self.index - 1].as_ref().clone()))
@@ -74,7 +75,7 @@ pub fn collect(it: Arc<Mutex<dyn SendableBatchReader>>) -> Result<Vec<RecordBatc
                 // end of result set
                 return Ok(results);
             }
-            Err(e) => return Err(e),
+            Err(e) => return Err(ExecutionError::from(e)),
         }
     }
 }

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -63,7 +63,9 @@ impl SendableRecordBatchReader for RecordBatchIterator {
 }
 
 /// Create a vector of record batches from an iterator
-pub fn collect(it: Arc<Mutex<dyn SendableRecordBatchReader>>) -> Result<Vec<RecordBatch>> {
+pub fn collect(
+    it: Arc<Mutex<dyn SendableRecordBatchReader>>,
+) -> Result<Vec<RecordBatch>> {
     let mut it = it.lock().unwrap();
     let mut results: Vec<RecordBatch> = vec![];
     loop {

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -27,7 +27,7 @@ use crate::logicalplan::ScalarValue;
 use arrow::array::{self, ArrayRef};
 use arrow::datatypes::{DataType, Schema};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Iterator over a vector of record batches
 pub struct RecordBatchIterator {
@@ -47,7 +47,7 @@ impl RecordBatchIterator {
     }
 }
 
-impl SendableRecordBatchReader for RecordBatchIterator {
+impl RecordBatchReader for RecordBatchIterator {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }
@@ -64,7 +64,7 @@ impl SendableRecordBatchReader for RecordBatchIterator {
 
 /// Create a vector of record batches from an iterator
 pub fn collect(
-    it: Arc<Mutex<dyn SendableRecordBatchReader>>,
+    it: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
 ) -> Result<Vec<RecordBatch>> {
     let mut it = it.lock().unwrap();
     let mut results: Vec<RecordBatch> = vec![];

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -52,7 +52,7 @@ impl RecordBatchReader for RecordBatchIterator {
         self.schema.clone()
     }
 
-    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         if self.index < self.batches.len() {
             self.index += 1;
             Ok(Some(self.batches[self.index - 1].as_ref().clone()))
@@ -66,10 +66,10 @@ impl RecordBatchReader for RecordBatchIterator {
 pub fn collect(
     it: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
 ) -> Result<Vec<RecordBatch>> {
-    let mut it = it.lock().unwrap();
+    let mut reader = it.lock().unwrap();
     let mut results: Vec<RecordBatch> = vec![];
     loop {
-        match it.next() {
+        match reader.next_batch() {
             Ok(Some(batch)) => {
                 results.push(batch);
             }

--- a/rust/datafusion/src/execution/physical_plan/common.rs
+++ b/rust/datafusion/src/execution/physical_plan/common.rs
@@ -22,12 +22,11 @@ use std::fs::metadata;
 use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};
-use crate::execution::physical_plan::BatchIterator;
 
 use crate::logicalplan::ScalarValue;
 use arrow::array::{self, ArrayRef};
 use arrow::datatypes::{DataType, Schema};
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, SendableBatchReader};
 
 /// Iterator over a vector of record batches
 pub struct RecordBatchIterator {
@@ -47,7 +46,7 @@ impl RecordBatchIterator {
     }
 }
 
-impl BatchIterator for RecordBatchIterator {
+impl SendableBatchReader for RecordBatchIterator {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }
@@ -63,7 +62,7 @@ impl BatchIterator for RecordBatchIterator {
 }
 
 /// Create a vector of record batches from an iterator
-pub fn collect(it: Arc<Mutex<dyn BatchIterator>>) -> Result<Vec<RecordBatch>> {
+pub fn collect(it: Arc<Mutex<dyn SendableBatchReader>>) -> Result<Vec<RecordBatch>> {
     let mut it = it.lock().unwrap();
     let mut results: Vec<RecordBatch> = vec![];
     loop {

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -25,6 +25,7 @@ use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::csv;
 use arrow::datatypes::Schema;
+use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, SendableBatchReader};
 
 /// CSV file read option
@@ -269,7 +270,7 @@ impl SendableBatchReader for CsvIterator {
     }
 
     /// Get the next RecordBatch
-    fn next(&mut self) -> Result<Option<RecordBatch>> {
+    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
         Ok(self.reader.next()?)
     }
 }

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -270,7 +270,7 @@ impl RecordBatchReader for CsvIterator {
     }
 
     /// Get the next RecordBatch
-    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         Ok(self.reader.next()?)
     }
 }
@@ -298,7 +298,7 @@ mod tests {
         let partitions = csv.partitions()?;
         let results = partitions[0].execute()?;
         let mut it = results.lock().unwrap();
-        let batch = it.next()?.unwrap();
+        let batch = it.next_batch()?.unwrap();
         assert_eq!(3, batch.num_columns());
         let batch_schema = batch.schema();
         assert_eq!(3, batch_schema.fields().len());
@@ -322,7 +322,7 @@ mod tests {
         let partitions = csv.partitions()?;
         let results = partitions[0].execute()?;
         let mut it = results.lock().unwrap();
-        let batch = it.next()?.unwrap();
+        let batch = it.next_batch()?.unwrap();
         assert_eq!(13, batch.num_columns());
         let batch_schema = batch.schema();
         assert_eq!(13, batch_schema.fields().len());

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -26,7 +26,7 @@ use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::csv;
 use arrow::datatypes::Schema;
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// CSV file read option
 #[derive(Copy, Clone)]
@@ -221,7 +221,7 @@ impl CsvPartition {
 
 impl Partition for CsvPartition {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         Ok(Arc::new(Mutex::new(CsvIterator::try_new(
             &self.path,
             self.schema.clone(),
@@ -263,7 +263,7 @@ impl CsvIterator {
     }
 }
 
-impl SendableRecordBatchReader for CsvIterator {
+impl RecordBatchReader for CsvIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.reader.schema()

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -22,10 +22,10 @@ use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::common;
-use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
+use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::csv;
 use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, SendableBatchReader};
 
 /// CSV file read option
 #[derive(Copy, Clone)]
@@ -220,7 +220,7 @@ impl CsvPartition {
 
 impl Partition for CsvPartition {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
         Ok(Arc::new(Mutex::new(CsvIterator::try_new(
             &self.path,
             self.schema.clone(),
@@ -262,7 +262,7 @@ impl CsvIterator {
     }
 }
 
-impl BatchIterator for CsvIterator {
+impl SendableBatchReader for CsvIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.reader.schema()

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -24,7 +24,7 @@ use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::csv;
-use arrow::datatypes::Schema;
+use arrow::datatypes::{Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
@@ -97,7 +97,7 @@ pub struct CsvExec {
     /// Path to directory containing partitioned CSV files with the same schema
     path: String,
     /// Schema representing the CSV file
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Does the CSV file have a header?
     has_header: bool,
     /// An optional column delimiter. Defaults to `b','`
@@ -105,7 +105,7 @@ pub struct CsvExec {
     /// Optional projection for which columns to load
     projection: Option<Vec<usize>>,
     /// Schema after the projection has been applied
-    projected_schema: Arc<Schema>,
+    projected_schema: SchemaRef,
     /// Batch size
     batch_size: usize,
 }
@@ -158,7 +158,7 @@ impl CsvExec {
 
 impl ExecutionPlan for CsvExec {
     /// Get the schema for this execution plan
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.projected_schema.clone()
     }
 
@@ -188,7 +188,7 @@ struct CsvPartition {
     /// Path to the CSV File
     path: String,
     /// Schema representing the CSV file
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Does the CSV file have a header?
     has_header: bool,
     /// An optional column delimiter. Defaults to `b','`
@@ -202,7 +202,7 @@ struct CsvPartition {
 impl CsvPartition {
     fn new(
         path: &str,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         has_header: bool,
         delimiter: Option<u8>,
         projection: Option<Vec<usize>>,
@@ -243,7 +243,7 @@ impl CsvIterator {
     /// Create an iterator for a CSV file
     pub fn try_new(
         filename: &str,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         has_header: bool,
         delimiter: Option<u8>,
         projection: &Option<Vec<usize>>,
@@ -265,7 +265,7 @@ impl CsvIterator {
 
 impl RecordBatchReader for CsvIterator {
     /// Get the schema
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.reader.schema()
     }
 

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -26,7 +26,7 @@ use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::csv;
 use arrow::datatypes::Schema;
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 
 /// CSV file read option
 #[derive(Copy, Clone)]
@@ -221,7 +221,7 @@ impl CsvPartition {
 
 impl Partition for CsvPartition {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         Ok(Arc::new(Mutex::new(CsvIterator::try_new(
             &self.path,
             self.schema.clone(),
@@ -263,7 +263,7 @@ impl CsvIterator {
     }
 }
 
-impl SendableBatchReader for CsvIterator {
+impl SendableRecordBatchReader for CsvIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.reader.schema()

--- a/rust/datafusion/src/execution/physical_plan/datasource.rs
+++ b/rust/datafusion/src/execution/physical_plan/datasource.rs
@@ -22,19 +22,19 @@ use std::sync::{Arc, Mutex};
 use crate::error::Result;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
-use arrow::record_batch::SendableBatchReader;
+use arrow::record_batch::SendableRecordBatchReader;
 
 /// Datasource execution plan
 pub struct DatasourceExec {
     schema: Arc<Schema>,
-    partitions: Vec<Arc<Mutex<dyn SendableBatchReader>>>,
+    partitions: Vec<Arc<Mutex<dyn SendableRecordBatchReader>>>,
 }
 
 impl DatasourceExec {
     /// Create a new data source execution plan
     pub fn new(
         schema: Arc<Schema>,
-        partitions: Vec<Arc<Mutex<dyn SendableBatchReader>>>,
+        partitions: Vec<Arc<Mutex<dyn SendableRecordBatchReader>>>,
     ) -> Self {
         Self { schema, partitions }
     }
@@ -56,19 +56,19 @@ impl ExecutionPlan for DatasourceExec {
     }
 }
 
-/// Wrapper to convert a `SendableBatchReader` into a `Partition`.
+/// Wrapper to convert a `ader` into a `Partition`.
 pub struct DatasourcePartition {
-    batch_iter: Arc<Mutex<dyn SendableBatchReader>>,
+    batch_iter: Arc<Mutex<dyn SendableRecordBatchReader>>,
 }
 
 impl DatasourcePartition {
-    fn new(batch_iter: Arc<Mutex<dyn SendableBatchReader>>) -> Self {
+    fn new(batch_iter: Arc<Mutex<dyn SendableRecordBatchReader>>) -> Self {
         Self { batch_iter }
     }
 }
 
 impl Partition for DatasourcePartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         Ok(self.batch_iter.clone())
     }
 }

--- a/rust/datafusion/src/execution/physical_plan/datasource.rs
+++ b/rust/datafusion/src/execution/physical_plan/datasource.rs
@@ -56,7 +56,7 @@ impl ExecutionPlan for DatasourceExec {
     }
 }
 
-/// Wrapper to convert a `ader` into a `Partition`.
+/// Wrapper to convert a `SendableRecordBatchReader` into a `Partition`.
 pub struct DatasourcePartition {
     batch_iter: Arc<Mutex<dyn SendableRecordBatchReader>>,
 }

--- a/rust/datafusion/src/execution/physical_plan/datasource.rs
+++ b/rust/datafusion/src/execution/physical_plan/datasource.rs
@@ -20,20 +20,21 @@
 use std::sync::{Arc, Mutex};
 
 use crate::error::Result;
-use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
+use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
+use arrow::record_batch::SendableBatchReader;
 
 /// Datasource execution plan
 pub struct DatasourceExec {
     schema: Arc<Schema>,
-    partitions: Vec<Arc<Mutex<dyn BatchIterator>>>,
+    partitions: Vec<Arc<Mutex<dyn SendableBatchReader>>>,
 }
 
 impl DatasourceExec {
     /// Create a new data source execution plan
     pub fn new(
         schema: Arc<Schema>,
-        partitions: Vec<Arc<Mutex<dyn BatchIterator>>>,
+        partitions: Vec<Arc<Mutex<dyn SendableBatchReader>>>,
     ) -> Self {
         Self { schema, partitions }
     }
@@ -55,19 +56,19 @@ impl ExecutionPlan for DatasourceExec {
     }
 }
 
-/// Wrapper to convert a BatchIterator into a Partition
+/// Wrapper to convert a `SendableBatchReader` into a `Partition`.
 pub struct DatasourcePartition {
-    batch_iter: Arc<Mutex<dyn BatchIterator>>,
+    batch_iter: Arc<Mutex<dyn SendableBatchReader>>,
 }
 
 impl DatasourcePartition {
-    fn new(batch_iter: Arc<Mutex<dyn BatchIterator>>) -> Self {
+    fn new(batch_iter: Arc<Mutex<dyn SendableBatchReader>>) -> Self {
         Self { batch_iter }
     }
 }
 
 impl Partition for DatasourcePartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
         Ok(self.batch_iter.clone())
     }
 }

--- a/rust/datafusion/src/execution/physical_plan/datasource.rs
+++ b/rust/datafusion/src/execution/physical_plan/datasource.rs
@@ -22,19 +22,19 @@ use std::sync::{Arc, Mutex};
 use crate::error::Result;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
-use arrow::record_batch::SendableRecordBatchReader;
+use arrow::record_batch::RecordBatchReader;
 
 /// Datasource execution plan
 pub struct DatasourceExec {
     schema: Arc<Schema>,
-    partitions: Vec<Arc<Mutex<dyn SendableRecordBatchReader>>>,
+    partitions: Vec<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>,
 }
 
 impl DatasourceExec {
     /// Create a new data source execution plan
     pub fn new(
         schema: Arc<Schema>,
-        partitions: Vec<Arc<Mutex<dyn SendableRecordBatchReader>>>,
+        partitions: Vec<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>,
     ) -> Self {
         Self { schema, partitions }
     }
@@ -58,17 +58,17 @@ impl ExecutionPlan for DatasourceExec {
 
 /// Wrapper to convert a `SendableRecordBatchReader` into a `Partition`.
 pub struct DatasourcePartition {
-    batch_iter: Arc<Mutex<dyn SendableRecordBatchReader>>,
+    batch_iter: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
 }
 
 impl DatasourcePartition {
-    fn new(batch_iter: Arc<Mutex<dyn SendableRecordBatchReader>>) -> Self {
+    fn new(batch_iter: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>) -> Self {
         Self { batch_iter }
     }
 }
 
 impl Partition for DatasourcePartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         Ok(self.batch_iter.clone())
     }
 }

--- a/rust/datafusion/src/execution/physical_plan/datasource.rs
+++ b/rust/datafusion/src/execution/physical_plan/datasource.rs
@@ -21,19 +21,19 @@ use std::sync::{Arc, Mutex};
 
 use crate::error::Result;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
-use arrow::datatypes::Schema;
+use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatchReader;
 
 /// Datasource execution plan
 pub struct DatasourceExec {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     partitions: Vec<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>,
 }
 
 impl DatasourceExec {
     /// Create a new data source execution plan
     pub fn new(
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         partitions: Vec<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>,
     ) -> Self {
         Self { schema, partitions }
@@ -41,7 +41,7 @@ impl DatasourceExec {
 }
 
 impl ExecutionPlan for DatasourceExec {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -2004,7 +2004,7 @@ mod tests {
     }
 
     fn apply_arithmetic<T: ArrowNumericType>(
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         data: Vec<ArrayRef>,
         op: Operator,
         expected: PrimitiveArray<T>,

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -297,7 +297,7 @@ impl RecordBatchReader for GroupedHashAggregateIterator {
         self.schema.clone()
     }
 
-    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         if self.finished {
             return Ok(None);
         }
@@ -312,7 +312,7 @@ impl RecordBatchReader for GroupedHashAggregateIterator {
         let mut input = self.input.lock().unwrap();
 
         // iterate over input and perform aggregation
-        while let Some(batch) = input.next()? {
+        while let Some(batch) = input.next_batch()? {
             // evaluate the grouping expressions for this batch
             let group_values = self
                 .group_expr
@@ -585,7 +585,7 @@ impl RecordBatchReader for HashAggregateIterator {
         self.schema.clone()
     }
 
-    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         if self.finished {
             return Ok(None);
         }
@@ -602,7 +602,7 @@ impl RecordBatchReader for HashAggregateIterator {
         let mut input = self.input.lock().unwrap();
 
         // iterate over input and perform aggregation
-        while let Some(batch) = input.next()? {
+        while let Some(batch) = input.next_batch()? {
             // evaluate the inputs to the aggregate expressions for this batch
             let aggr_input_values = self
                 .aggr_expr

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -35,7 +35,7 @@ use arrow::array::{
     Int8Builder, StringBuilder, UInt16Builder, UInt32Builder, UInt64Builder,
     UInt8Builder,
 };
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
@@ -48,7 +48,7 @@ pub struct HashAggregateExec {
     group_expr: Vec<Arc<dyn PhysicalExpr>>,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
     input: Arc<dyn ExecutionPlan>,
-    schema: Arc<Schema>,
+    schema: SchemaRef,
 }
 
 impl HashAggregateExec {
@@ -103,7 +103,7 @@ impl HashAggregateExec {
 }
 
 impl ExecutionPlan for HashAggregateExec {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
@@ -131,7 +131,7 @@ struct HashAggregatePartition {
     group_expr: Vec<Arc<dyn PhysicalExpr>>,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
     input: Arc<dyn Partition>,
-    schema: Arc<Schema>,
+    schema: SchemaRef,
 }
 
 impl HashAggregatePartition {
@@ -140,7 +140,7 @@ impl HashAggregatePartition {
         group_expr: Vec<Arc<dyn PhysicalExpr>>,
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
         input: Arc<dyn Partition>,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
     ) -> Self {
         HashAggregatePartition {
             group_expr,
@@ -249,7 +249,7 @@ struct MapEntry {
 }
 
 struct GroupedHashAggregateIterator {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     group_expr: Vec<Arc<dyn PhysicalExpr>>,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
     input: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
@@ -259,7 +259,7 @@ struct GroupedHashAggregateIterator {
 impl GroupedHashAggregateIterator {
     /// Create a new HashAggregateIterator
     pub fn new(
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         group_expr: Vec<Arc<dyn PhysicalExpr>>,
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
         input: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
@@ -293,7 +293,7 @@ macro_rules! update_accumulators {
 }
 
 impl RecordBatchReader for GroupedHashAggregateIterator {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
@@ -558,7 +558,7 @@ impl RecordBatchReader for GroupedHashAggregateIterator {
 }
 
 struct HashAggregateIterator {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
     input: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
     finished: bool,
@@ -567,7 +567,7 @@ struct HashAggregateIterator {
 impl HashAggregateIterator {
     /// Create a new HashAggregateIterator
     pub fn new(
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
         input: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
     ) -> Self {
@@ -581,7 +581,7 @@ impl HashAggregateIterator {
 }
 
 impl RecordBatchReader for HashAggregateIterator {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -37,7 +37,7 @@ use arrow::array::{
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 
 use crate::execution::physical_plan::expressions::Column;
 use crate::logicalplan::ScalarValue;
@@ -152,7 +152,7 @@ impl HashAggregatePartition {
 }
 
 impl Partition for HashAggregatePartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         if self.group_expr.is_empty() {
             Ok(Arc::new(Mutex::new(HashAggregateIterator::new(
                 self.schema.clone(),
@@ -252,7 +252,7 @@ struct GroupedHashAggregateIterator {
     schema: Arc<Schema>,
     group_expr: Vec<Arc<dyn PhysicalExpr>>,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
-    input: Arc<Mutex<dyn SendableBatchReader>>,
+    input: Arc<Mutex<dyn SendableRecordBatchReader>>,
     finished: bool,
 }
 
@@ -262,7 +262,7 @@ impl GroupedHashAggregateIterator {
         schema: Arc<Schema>,
         group_expr: Vec<Arc<dyn PhysicalExpr>>,
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
-        input: Arc<Mutex<dyn SendableBatchReader>>,
+        input: Arc<Mutex<dyn SendableRecordBatchReader>>,
     ) -> Self {
         GroupedHashAggregateIterator {
             schema,
@@ -292,7 +292,7 @@ macro_rules! update_accumulators {
     }};
 }
 
-impl SendableBatchReader for GroupedHashAggregateIterator {
+impl SendableRecordBatchReader for GroupedHashAggregateIterator {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }
@@ -560,7 +560,7 @@ impl SendableBatchReader for GroupedHashAggregateIterator {
 struct HashAggregateIterator {
     schema: Arc<Schema>,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
-    input: Arc<Mutex<dyn SendableBatchReader>>,
+    input: Arc<Mutex<dyn SendableRecordBatchReader>>,
     finished: bool,
 }
 
@@ -569,7 +569,7 @@ impl HashAggregateIterator {
     pub fn new(
         schema: Arc<Schema>,
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
-        input: Arc<Mutex<dyn SendableBatchReader>>,
+        input: Arc<Mutex<dyn SendableRecordBatchReader>>,
     ) -> Self {
         HashAggregateIterator {
             schema,
@@ -580,7 +580,7 @@ impl HashAggregateIterator {
     }
 }
 
-impl SendableBatchReader for HashAggregateIterator {
+impl SendableRecordBatchReader for HashAggregateIterator {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -20,11 +20,11 @@
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::common::RecordBatchIterator;
 use crate::execution::physical_plan::ExecutionPlan;
-use crate::execution::physical_plan::{BatchIterator, Partition};
+use crate::execution::physical_plan::Partition;
 use arrow::array::ArrayRef;
 use arrow::compute::limit;
 use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, SendableBatchReader};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
@@ -78,7 +78,7 @@ struct LimitPartition {
 }
 
 impl Partition for LimitPartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
         // collect up to "limit" rows on each partition
         let threads: Vec<JoinHandle<Result<Vec<RecordBatch>>>> = self
             .partitions
@@ -136,7 +136,7 @@ pub fn truncate_batch(batch: &RecordBatch, n: usize) -> Result<RecordBatch> {
 
 /// Create a vector of record batches from an iterator
 fn collect_with_limit(
-    it: Arc<Mutex<dyn BatchIterator>>,
+    it: Arc<Mutex<dyn SendableBatchReader>>,
     limit: usize,
 ) -> Result<Vec<RecordBatch>> {
     let mut count = 0;

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -24,7 +24,7 @@ use crate::execution::physical_plan::Partition;
 use arrow::array::ArrayRef;
 use arrow::compute::limit;
 use arrow::datatypes::Schema;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
@@ -78,7 +78,7 @@ struct LimitPartition {
 }
 
 impl Partition for LimitPartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         // collect up to "limit" rows on each partition
         let threads: Vec<JoinHandle<Result<Vec<RecordBatch>>>> = self
             .partitions
@@ -136,7 +136,7 @@ pub fn truncate_batch(batch: &RecordBatch, n: usize) -> Result<RecordBatch> {
 
 /// Create a vector of record batches from an iterator
 fn collect_with_limit(
-    it: Arc<Mutex<dyn SendableBatchReader>>,
+    it: Arc<Mutex<dyn SendableRecordBatchReader>>,
     limit: usize,
 ) -> Result<Vec<RecordBatch>> {
     let mut count = 0;

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -23,7 +23,7 @@ use crate::execution::physical_plan::ExecutionPlan;
 use crate::execution::physical_plan::Partition;
 use arrow::array::ArrayRef;
 use arrow::compute::limit;
-use arrow::datatypes::Schema;
+use arrow::datatypes::SchemaRef;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -32,7 +32,7 @@ use std::thread::JoinHandle;
 /// Limit execution plan
 pub struct LimitExec {
     /// Input schema
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Input partitions
     partitions: Vec<Arc<dyn Partition>>,
     /// Maximum number of rows to return
@@ -42,7 +42,7 @@ pub struct LimitExec {
 impl LimitExec {
     /// Create a new MergeExec
     pub fn new(
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         partitions: Vec<Arc<dyn Partition>>,
         limit: usize,
     ) -> Self {
@@ -55,7 +55,7 @@ impl LimitExec {
 }
 
 impl ExecutionPlan for LimitExec {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
@@ -70,7 +70,7 @@ impl ExecutionPlan for LimitExec {
 
 struct LimitPartition {
     /// Input schema
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Input partitions
     partitions: Vec<Arc<dyn Partition>>,
     /// Maximum number of rows to return

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -162,7 +162,7 @@ fn collect_with_limit(
                 // end of result set
                 return Ok(results);
             }
-            Err(e) => return Err(e),
+            Err(e) => return Err(ExecutionError::from(e)),
         }
     }
 }

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -24,7 +24,7 @@ use crate::execution::physical_plan::Partition;
 use arrow::array::ArrayRef;
 use arrow::compute::limit;
 use arrow::datatypes::Schema;
-use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
@@ -78,7 +78,7 @@ struct LimitPartition {
 }
 
 impl Partition for LimitPartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         // collect up to "limit" rows on each partition
         let threads: Vec<JoinHandle<Result<Vec<RecordBatch>>>> = self
             .partitions
@@ -136,7 +136,7 @@ pub fn truncate_batch(batch: &RecordBatch, n: usize) -> Result<RecordBatch> {
 
 /// Create a vector of record batches from an iterator
 fn collect_with_limit(
-    it: Arc<Mutex<dyn SendableRecordBatchReader>>,
+    it: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
     limit: usize,
 ) -> Result<Vec<RecordBatch>> {
     let mut count = 0;

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -136,14 +136,14 @@ pub fn truncate_batch(batch: &RecordBatch, n: usize) -> Result<RecordBatch> {
 
 /// Create a vector of record batches from an iterator
 fn collect_with_limit(
-    it: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
+    reader: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
     limit: usize,
 ) -> Result<Vec<RecordBatch>> {
     let mut count = 0;
-    let mut it = it.lock().unwrap();
+    let mut reader = reader.lock().unwrap();
     let mut results: Vec<RecordBatch> = vec![];
     loop {
-        match it.next() {
+        match reader.next_batch() {
             Ok(Some(batch)) => {
                 let capacity = limit - count;
                 if batch.num_rows() <= capacity {

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -23,7 +23,7 @@ use crate::error::Result;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Execution plan for reading in-memory batches of data
 pub struct MemoryExec {
@@ -100,7 +100,7 @@ impl MemoryPartition {
 
 impl Partition for MemoryPartition {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         Ok(Arc::new(Mutex::new(MemoryIterator::try_new(
             self.data.clone(),
             self.schema.clone(),
@@ -137,7 +137,7 @@ impl MemoryIterator {
     }
 }
 
-impl SendableRecordBatchReader for MemoryIterator {
+impl RecordBatchReader for MemoryIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -21,7 +21,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::error::Result;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
-use arrow::datatypes::Schema;
+use arrow::datatypes::SchemaRef;
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
@@ -30,14 +30,14 @@ pub struct MemoryExec {
     /// The partitions to query
     partitions: Vec<Vec<RecordBatch>>,
     /// Schema representing the data after the optional projection is applied
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Optional projection
     projection: Option<Vec<usize>>,
 }
 
 impl ExecutionPlan for MemoryExec {
     /// Get the schema for this execution plan
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
@@ -62,7 +62,7 @@ impl MemoryExec {
     /// Create a new execution plan for reading in-memory record batches
     pub fn try_new(
         partitions: &Vec<Vec<RecordBatch>>,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
         Ok(Self {
@@ -78,7 +78,7 @@ struct MemoryPartition {
     /// Vector of record batches
     data: Vec<RecordBatch>,
     /// Schema representing the data
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Optional projection
     projection: Option<Vec<usize>>,
 }
@@ -87,7 +87,7 @@ impl MemoryPartition {
     /// Create a new in-memory partition
     fn new(
         data: Vec<RecordBatch>,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         projection: Option<Vec<usize>>,
     ) -> Self {
         Self {
@@ -114,7 +114,7 @@ struct MemoryIterator {
     /// Vector of record batches
     data: Vec<RecordBatch>,
     /// Schema representing the data
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Optional projection for which columns to load
     projection: Option<Vec<usize>>,
     /// Index into the data
@@ -125,7 +125,7 @@ impl MemoryIterator {
     /// Create an iterator for a vector of record batches
     pub fn try_new(
         data: Vec<RecordBatch>,
-        schema: Arc<Schema>,
+        schema: SchemaRef,
         projection: Option<Vec<usize>>,
     ) -> Result<Self> {
         Ok(Self {
@@ -139,7 +139,7 @@ impl MemoryIterator {
 
 impl RecordBatchReader for MemoryIterator {
     /// Get the schema
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -20,9 +20,9 @@
 use std::sync::{Arc, Mutex};
 
 use crate::error::Result;
-use crate::execution::physical_plan::{BatchIterator, ExecutionPlan, Partition};
+use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, SendableBatchReader};
 
 /// Execution plan for reading in-memory batches of data
 pub struct MemoryExec {
@@ -99,7 +99,7 @@ impl MemoryPartition {
 
 impl Partition for MemoryPartition {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
         Ok(Arc::new(Mutex::new(MemoryIterator::try_new(
             self.data.clone(),
             self.schema.clone(),
@@ -136,7 +136,7 @@ impl MemoryIterator {
     }
 }
 
-impl BatchIterator for MemoryIterator {
+impl SendableBatchReader for MemoryIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -22,6 +22,7 @@ use std::sync::{Arc, Mutex};
 use crate::error::Result;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
+use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, SendableBatchReader};
 
 /// Execution plan for reading in-memory batches of data
@@ -143,7 +144,7 @@ impl SendableBatchReader for MemoryIterator {
     }
 
     /// Get the next RecordBatch
-    fn next(&mut self) -> Result<Option<RecordBatch>> {
+    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
         if self.index < self.data.len() {
             self.index += 1;
             let batch = &self.data[self.index - 1];

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -23,7 +23,7 @@ use crate::error::Result;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 
 /// Execution plan for reading in-memory batches of data
 pub struct MemoryExec {
@@ -100,7 +100,7 @@ impl MemoryPartition {
 
 impl Partition for MemoryPartition {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         Ok(Arc::new(Mutex::new(MemoryIterator::try_new(
             self.data.clone(),
             self.schema.clone(),
@@ -137,7 +137,7 @@ impl MemoryIterator {
     }
 }
 
-impl SendableBatchReader for MemoryIterator {
+impl SendableRecordBatchReader for MemoryIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -144,7 +144,7 @@ impl RecordBatchReader for MemoryIterator {
     }
 
     /// Get the next RecordBatch
-    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         if self.index < self.data.len() {
             self.index += 1;
             let batch = &self.data[self.index - 1];

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -21,9 +21,9 @@
 use crate::error::Result;
 use crate::execution::physical_plan::common::RecordBatchIterator;
 use crate::execution::physical_plan::{common, ExecutionPlan};
-use crate::execution::physical_plan::{BatchIterator, Partition};
+use crate::execution::physical_plan::Partition;
 use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, SendableBatchReader};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
@@ -65,7 +65,7 @@ struct MergePartition {
 }
 
 impl Partition for MergePartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
         let threads: Vec<JoinHandle<Result<Vec<RecordBatch>>>> = self
             .partitions
             .iter()

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -20,8 +20,8 @@
 
 use crate::error::Result;
 use crate::execution::physical_plan::common::RecordBatchIterator;
-use crate::execution::physical_plan::{common, ExecutionPlan};
 use crate::execution::physical_plan::Partition;
+use crate::execution::physical_plan::{common, ExecutionPlan};
 use arrow::datatypes::Schema;
 use arrow::record_batch::{RecordBatch, SendableBatchReader};
 use std::sync::{Arc, Mutex};

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -23,7 +23,7 @@ use crate::execution::physical_plan::common::RecordBatchIterator;
 use crate::execution::physical_plan::Partition;
 use crate::execution::physical_plan::{common, ExecutionPlan};
 use arrow::datatypes::Schema;
-use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
@@ -65,7 +65,7 @@ struct MergePartition {
 }
 
 impl Partition for MergePartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         let threads: Vec<JoinHandle<Result<Vec<RecordBatch>>>> = self
             .partitions
             .iter()

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -22,7 +22,7 @@ use crate::error::Result;
 use crate::execution::physical_plan::common::RecordBatchIterator;
 use crate::execution::physical_plan::Partition;
 use crate::execution::physical_plan::{common, ExecutionPlan};
-use arrow::datatypes::Schema;
+use arrow::datatypes::SchemaRef;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -32,20 +32,20 @@ use std::thread::JoinHandle;
 /// partition. No guarantees are made about the order of the resulting partition.
 pub struct MergeExec {
     /// Input schema
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Input partitions
     partitions: Vec<Arc<dyn Partition>>,
 }
 
 impl MergeExec {
     /// Create a new MergeExec
-    pub fn new(schema: Arc<Schema>, partitions: Vec<Arc<dyn Partition>>) -> Self {
+    pub fn new(schema: SchemaRef, partitions: Vec<Arc<dyn Partition>>) -> Self {
         MergeExec { schema, partitions }
     }
 }
 
 impl ExecutionPlan for MergeExec {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
@@ -59,7 +59,7 @@ impl ExecutionPlan for MergeExec {
 
 struct MergePartition {
     /// Input schema
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// Input partitions
     partitions: Vec<Arc<dyn Partition>>,
 }

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -23,7 +23,7 @@ use crate::execution::physical_plan::common::RecordBatchIterator;
 use crate::execution::physical_plan::Partition;
 use crate::execution::physical_plan::{common, ExecutionPlan};
 use arrow::datatypes::Schema;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
@@ -65,7 +65,7 @@ struct MergePartition {
 }
 
 impl Partition for MergePartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         let threads: Vec<JoinHandle<Result<Vec<RecordBatch>>>> = self
             .partitions
             .iter()

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -25,7 +25,7 @@ use crate::error::Result;
 use crate::logicalplan::ScalarValue;
 use arrow::array::ArrayRef;
 use arrow::datatypes::{DataType, Field, Schema};
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, SendableBatchReader};
 
 /// Partition-aware execution plan for a relation
 pub trait ExecutionPlan {
@@ -38,15 +38,7 @@ pub trait ExecutionPlan {
 /// Represents a partition of an execution plan that can be executed on a thread
 pub trait Partition: Send + Sync {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>>;
-}
-
-/// Iterator over RecordBatch that can be sent between threads
-pub trait BatchIterator: Send + Sync {
-    /// Get the schema for the batches returned by this iterator
-    fn schema(&self) -> Arc<Schema>;
-    /// Get the next RecordBatch
-    fn next(&mut self) -> Result<Option<RecordBatch>>;
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>>;
 }
 
 /// Expression that can be evaluated against a RecordBatch
@@ -69,7 +61,7 @@ pub trait PhysicalExpr: Send + Sync {
     }
 }
 
-/// Agggregate expression that can be evaluated against a RecordBatch
+/// Aggregate expression that can be evaluated against a RecordBatch
 pub trait AggregateExpr: Send + Sync {
     /// Get the name to use in a schema to represent the result of this expression
     fn name(&self) -> String;

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -25,7 +25,7 @@ use crate::error::Result;
 use crate::logicalplan::ScalarValue;
 use arrow::array::ArrayRef;
 use arrow::datatypes::{DataType, Field, Schema};
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 
 /// Partition-aware execution plan for a relation
 pub trait ExecutionPlan {
@@ -38,7 +38,7 @@ pub trait ExecutionPlan {
 /// Represents a partition of an execution plan that can be executed on a thread
 pub trait Partition: Send + Sync {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>>;
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>>;
 }
 
 /// Expression that can be evaluated against a RecordBatch

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -25,7 +25,7 @@ use crate::error::Result;
 use crate::logicalplan::ScalarValue;
 use arrow::array::ArrayRef;
 use arrow::datatypes::{DataType, Field, Schema};
-use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Partition-aware execution plan for a relation
 pub trait ExecutionPlan {
@@ -38,7 +38,7 @@ pub trait ExecutionPlan {
 /// Represents a partition of an execution plan that can be executed on a thread
 pub trait Partition: Send + Sync {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>>;
+    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>;
 }
 
 /// Expression that can be evaluated against a RecordBatch

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -24,13 +24,13 @@ use std::sync::{Arc, Mutex};
 use crate::error::Result;
 use crate::logicalplan::ScalarValue;
 use arrow::array::ArrayRef;
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Partition-aware execution plan for a relation
 pub trait ExecutionPlan {
     /// Get the schema for this execution plan
-    fn schema(&self) -> Arc<Schema>;
+    fn schema(&self) -> SchemaRef;
     /// Get the partitions for this execution plan. Each partition can be executed in parallel.
     fn partitions(&self) -> Result<Vec<Arc<dyn Partition>>>;
 }

--- a/rust/datafusion/src/execution/physical_plan/parquet.rs
+++ b/rust/datafusion/src/execution/physical_plan/parquet.rs
@@ -27,7 +27,7 @@ use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
 use arrow::error::{ArrowError, Result as ArrowResult};
-use arrow::record_batch::{BatchReader, RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatchReader, RecordBatch, SendableRecordBatchReader};
 use parquet::file::reader::SerializedFileReader;
 
 use crossbeam::channel::{unbounded, Receiver, RecvError, SendError, Sender};
@@ -107,7 +107,7 @@ impl ExecutionPlan for ParquetExec {
 }
 
 struct ParquetPartition {
-    iterator: Arc<Mutex<dyn SendableBatchReader>>,
+    iterator: Arc<Mutex<dyn SendableRecordBatchReader>>,
 }
 
 impl ParquetPartition {
@@ -192,7 +192,7 @@ impl ParquetPartition {
 }
 
 impl Partition for ParquetPartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         Ok(self.iterator.clone())
     }
 }
@@ -203,7 +203,7 @@ struct ParquetIterator {
     response_rx: Receiver<ArrowResult<Option<RecordBatch>>>,
 }
 
-impl SendableBatchReader for ParquetIterator {
+impl SendableRecordBatchReader for ParquetIterator {
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()
     }

--- a/rust/datafusion/src/execution/physical_plan/parquet.rs
+++ b/rust/datafusion/src/execution/physical_plan/parquet.rs
@@ -27,7 +27,7 @@ use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
 use arrow::datatypes::Schema;
 use arrow::error::{ArrowError, Result as ArrowResult};
-use arrow::record_batch::{RecordBatchReader, RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader, SendableRecordBatchReader};
 use parquet::file::reader::SerializedFileReader;
 
 use crossbeam::channel::{unbounded, Receiver, RecvError, SendError, Sender};

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -24,10 +24,10 @@ use std::sync::{Arc, Mutex};
 
 use crate::error::Result;
 use crate::execution::physical_plan::{
-    BatchIterator, ExecutionPlan, Partition, PhysicalExpr,
+    ExecutionPlan, Partition, PhysicalExpr,
 };
 use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, SendableBatchReader};
 
 /// Execution plan for a projection
 pub struct ProjectionExec {
@@ -98,7 +98,7 @@ struct ProjectionPartition {
 
 impl Partition for ProjectionPartition {
     /// Execute the projection
-    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
         Ok(Arc::new(Mutex::new(ProjectionIterator {
             schema: self.schema.clone(),
             expr: self.expr.clone(),
@@ -111,10 +111,10 @@ impl Partition for ProjectionPartition {
 struct ProjectionIterator {
     schema: Arc<Schema>,
     expr: Vec<Arc<dyn PhysicalExpr>>,
-    input: Arc<Mutex<dyn BatchIterator>>,
+    input: Arc<Mutex<dyn SendableBatchReader>>,
 }
 
-impl BatchIterator for ProjectionIterator {
+impl SendableBatchReader for ProjectionIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -120,9 +120,9 @@ impl RecordBatchReader for ProjectionIterator {
     }
 
     /// Get the next batch
-    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         let mut input = self.input.lock().unwrap();
-        match input.next()? {
+        match input.next_batch()? {
             Some(batch) => {
                 let arrays: Result<Vec<_>> =
                     self.expr.iter().map(|expr| expr.evaluate(&batch)).collect();
@@ -167,7 +167,7 @@ mod tests {
             partition_count += 1;
             let iterator = partition.execute()?;
             let mut iterator = iterator.lock().unwrap();
-            while let Some(batch) = iterator.next()? {
+            while let Some(batch) = iterator.next_batch()? {
                 assert_eq!(1, batch.num_columns());
                 row_count += batch.num_rows();
             }

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::{ExecutionPlan, Partition, PhysicalExpr};
-use arrow::datatypes::Schema;
+use arrow::datatypes::{Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
@@ -33,7 +33,7 @@ pub struct ProjectionExec {
     /// The projection expressions
     expr: Vec<Arc<dyn PhysicalExpr>>,
     /// The schema once the projection has been applied to the input
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     /// The input plan
     input: Arc<dyn ExecutionPlan>,
 }
@@ -63,7 +63,7 @@ impl ProjectionExec {
 
 impl ExecutionPlan for ProjectionExec {
     /// Get the schema for this execution plan
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 
@@ -90,7 +90,7 @@ impl ExecutionPlan for ProjectionExec {
 
 /// Represents a single partition of a projection execution plan
 struct ProjectionPartition {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     expr: Vec<Arc<dyn PhysicalExpr>>,
     input: Arc<dyn Partition>,
 }
@@ -108,14 +108,14 @@ impl Partition for ProjectionPartition {
 
 /// Projection iterator
 struct ProjectionIterator {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     expr: Vec<Arc<dyn PhysicalExpr>>,
     input: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
 }
 
 impl RecordBatchReader for ProjectionIterator {
     /// Get the schema
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -26,7 +26,7 @@ use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::{ExecutionPlan, Partition, PhysicalExpr};
 use arrow::datatypes::Schema;
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 
 /// Execution plan for a projection
 pub struct ProjectionExec {
@@ -97,7 +97,7 @@ struct ProjectionPartition {
 
 impl Partition for ProjectionPartition {
     /// Execute the projection
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         Ok(Arc::new(Mutex::new(ProjectionIterator {
             schema: self.schema.clone(),
             expr: self.expr.clone(),
@@ -110,10 +110,10 @@ impl Partition for ProjectionPartition {
 struct ProjectionIterator {
     schema: Arc<Schema>,
     expr: Vec<Arc<dyn PhysicalExpr>>,
-    input: Arc<Mutex<dyn SendableBatchReader>>,
+    input: Arc<Mutex<dyn SendableRecordBatchReader>>,
 }
 
-impl SendableBatchReader for ProjectionIterator {
+impl SendableRecordBatchReader for ProjectionIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/datafusion/src/execution/physical_plan/selection.rs
+++ b/rust/datafusion/src/execution/physical_plan/selection.rs
@@ -23,7 +23,7 @@ use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::{ExecutionPlan, Partition, PhysicalExpr};
 use arrow::array::BooleanArray;
 use arrow::compute::filter;
-use arrow::datatypes::Schema;
+use arrow::datatypes::SchemaRef;
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
@@ -50,7 +50,7 @@ impl SelectionExec {
 
 impl ExecutionPlan for SelectionExec {
     /// Get the schema for this execution plan
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         // The selection operator does not make any changes to the schema of its input
         self.input.schema()
     }
@@ -79,7 +79,7 @@ impl ExecutionPlan for SelectionExec {
 
 /// Represents a single partition of a Selection execution plan
 struct SelectionPartition {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     expr: Arc<dyn PhysicalExpr>,
     input: Arc<dyn Partition>,
 }
@@ -97,14 +97,14 @@ impl Partition for SelectionPartition {
 
 /// Selection iterator
 struct SelectionIterator {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     expr: Arc<dyn PhysicalExpr>,
     input: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
 }
 
 impl RecordBatchReader for SelectionIterator {
     /// Get the schema
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/datafusion/src/execution/physical_plan/selection.rs
+++ b/rust/datafusion/src/execution/physical_plan/selection.rs
@@ -109,9 +109,9 @@ impl RecordBatchReader for SelectionIterator {
     }
 
     /// Get the next batch
-    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         let mut input = self.input.lock().unwrap();
-        match input.next()? {
+        match input.next_batch()? {
             Some(batch) => {
                 // evaluate the selection predicate to get a boolean array
                 let predicate_result = self

--- a/rust/datafusion/src/execution/physical_plan/selection.rs
+++ b/rust/datafusion/src/execution/physical_plan/selection.rs
@@ -25,7 +25,7 @@ use arrow::array::BooleanArray;
 use arrow::compute::filter;
 use arrow::datatypes::Schema;
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 
 /// Execution plan for a Selection
 pub struct SelectionExec {
@@ -86,7 +86,7 @@ struct SelectionPartition {
 
 impl Partition for SelectionPartition {
     /// Execute the Selection
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         Ok(Arc::new(Mutex::new(SelectionIterator {
             schema: self.schema.clone(),
             expr: self.expr.clone(),
@@ -99,10 +99,10 @@ impl Partition for SelectionPartition {
 struct SelectionIterator {
     schema: Arc<Schema>,
     expr: Arc<dyn PhysicalExpr>,
-    input: Arc<Mutex<dyn SendableBatchReader>>,
+    input: Arc<Mutex<dyn SendableRecordBatchReader>>,
 }
 
-impl SendableBatchReader for SelectionIterator {
+impl SendableRecordBatchReader for SelectionIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/datafusion/src/execution/physical_plan/selection.rs
+++ b/rust/datafusion/src/execution/physical_plan/selection.rs
@@ -25,7 +25,7 @@ use arrow::array::BooleanArray;
 use arrow::compute::filter;
 use arrow::datatypes::Schema;
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Execution plan for a Selection
 pub struct SelectionExec {
@@ -86,7 +86,7 @@ struct SelectionPartition {
 
 impl Partition for SelectionPartition {
     /// Execute the Selection
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         Ok(Arc::new(Mutex::new(SelectionIterator {
             schema: self.schema.clone(),
             expr: self.expr.clone(),
@@ -99,10 +99,10 @@ impl Partition for SelectionPartition {
 struct SelectionIterator {
     schema: Arc<Schema>,
     expr: Arc<dyn PhysicalExpr>,
-    input: Arc<Mutex<dyn SendableRecordBatchReader>>,
+    input: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
 }
 
-impl SendableRecordBatchReader for SelectionIterator {
+impl RecordBatchReader for SelectionIterator {
     /// Get the schema
     fn schema(&self) -> Arc<Schema> {
         self.schema.clone()

--- a/rust/datafusion/src/execution/physical_plan/sort.rs
+++ b/rust/datafusion/src/execution/physical_plan/sort.rs
@@ -25,7 +25,7 @@ use arrow::array::ArrayRef;
 pub use arrow::compute::SortOptions;
 use arrow::compute::{concat, lexsort_to_indices, take, SortColumn, TakeOptions};
 use arrow::datatypes::Schema;
-use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 use crate::error::Result;
 use crate::execution::physical_plan::common::RecordBatchIterator;
@@ -74,7 +74,7 @@ struct SortPartition {
 
 impl Partition for SortPartition {
     /// Execute the sort
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         let threads: Vec<JoinHandle<Result<Vec<RecordBatch>>>> = self
             .input
             .iter()

--- a/rust/datafusion/src/execution/physical_plan/sort.rs
+++ b/rust/datafusion/src/execution/physical_plan/sort.rs
@@ -24,7 +24,7 @@ use std::thread::JoinHandle;
 use arrow::array::ArrayRef;
 pub use arrow::compute::SortOptions;
 use arrow::compute::{concat, lexsort_to_indices, take, SortColumn, TakeOptions};
-use arrow::datatypes::Schema;
+use arrow::datatypes::SchemaRef;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 use crate::error::Result;
@@ -50,7 +50,7 @@ impl SortExec {
 }
 
 impl ExecutionPlan for SortExec {
-    fn schema(&self) -> Arc<Schema> {
+    fn schema(&self) -> SchemaRef {
         self.input.schema().clone()
     }
 
@@ -67,7 +67,7 @@ impl ExecutionPlan for SortExec {
 
 /// Represents a single partition of a Sort execution plan
 struct SortPartition {
-    schema: Arc<Schema>,
+    schema: SchemaRef,
     expr: Vec<PhysicalSortExpr>,
     input: Vec<Arc<dyn Partition>>,
 }

--- a/rust/datafusion/src/execution/physical_plan/sort.rs
+++ b/rust/datafusion/src/execution/physical_plan/sort.rs
@@ -25,12 +25,12 @@ use arrow::array::ArrayRef;
 pub use arrow::compute::SortOptions;
 use arrow::compute::{concat, lexsort_to_indices, take, SortColumn, TakeOptions};
 use arrow::datatypes::Schema;
-use arrow::record_batch::RecordBatch;
+use arrow::record_batch::{RecordBatch, SendableBatchReader};
 
 use crate::error::Result;
 use crate::execution::physical_plan::common::RecordBatchIterator;
 use crate::execution::physical_plan::expressions::PhysicalSortExpr;
-use crate::execution::physical_plan::{common, BatchIterator, ExecutionPlan, Partition};
+use crate::execution::physical_plan::{common, ExecutionPlan, Partition};
 
 /// Sort execution plan
 pub struct SortExec {
@@ -74,7 +74,7 @@ struct SortPartition {
 
 impl Partition for SortPartition {
     /// Execute the sort
-    fn execute(&self) -> Result<Arc<Mutex<dyn BatchIterator>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
         let threads: Vec<JoinHandle<Result<Vec<RecordBatch>>>> = self
             .input
             .iter()

--- a/rust/datafusion/src/execution/physical_plan/sort.rs
+++ b/rust/datafusion/src/execution/physical_plan/sort.rs
@@ -25,7 +25,7 @@ use arrow::array::ArrayRef;
 pub use arrow::compute::SortOptions;
 use arrow::compute::{concat, lexsort_to_indices, take, SortColumn, TakeOptions};
 use arrow::datatypes::Schema;
-use arrow::record_batch::{RecordBatch, SendableBatchReader};
+use arrow::record_batch::{RecordBatch, SendableRecordBatchReader};
 
 use crate::error::Result;
 use crate::execution::physical_plan::common::RecordBatchIterator;
@@ -74,7 +74,7 @@ struct SortPartition {
 
 impl Partition for SortPartition {
     /// Execute the sort
-    fn execute(&self) -> Result<Arc<Mutex<dyn SendableBatchReader>>> {
+    fn execute(&self) -> Result<Arc<Mutex<dyn SendableRecordBatchReader>>> {
         let threads: Vec<JoinHandle<Result<Vec<RecordBatch>>>> = self
             .input
             .iter()

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -33,7 +33,7 @@ use sqlparser::sqlast::*;
 /// functions referenced in SQL statements
 pub trait SchemaProvider {
     /// Getter for a field description
-    fn get_table_meta(&self, name: &str) -> Option<Arc<Schema>>;
+    fn get_table_meta(&self, name: &str) -> Option<SchemaRef>;
     /// Getter for a UDF description
     fn get_function_meta(&self, name: &str) -> Option<Arc<FunctionMeta>>;
 }
@@ -698,7 +698,7 @@ mod tests {
     struct MockSchemaProvider {}
 
     impl SchemaProvider for MockSchemaProvider {
-        fn get_table_meta(&self, name: &str) -> Option<Arc<Schema>> {
+        fn get_table_meta(&self, name: &str) -> Option<SchemaRef> {
             match name {
                 "person" => Some(Arc::new(Schema::new(vec![
                     Field::new("id", DataType::UInt32, false),

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -87,7 +87,7 @@ pub fn create_partitioned_csv(filename: &str, partitions: usize) -> Result<Strin
 }
 
 /// Get the schema for the aggregate_test_* csv files
-pub fn aggr_test_schema() -> Arc<Schema> {
+pub fn aggr_test_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("c1", DataType::Utf8, false),
         Field::new("c2", DataType::UInt32, false),

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -22,7 +22,7 @@ use crate::execution::context::ExecutionContext;
 use crate::execution::physical_plan::ExecutionPlan;
 use crate::logicalplan::{Expr, LogicalPlan, LogicalPlanBuilder};
 use arrow::array;
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use std::env;
 use std::fs::File;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -22,7 +22,7 @@ extern crate arrow;
 extern crate datafusion;
 
 use arrow::array::*;
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 
 use datafusion::datasource::csv::CsvReadOptions;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -394,7 +394,7 @@ fn csv_query_count_one() {
     assert_eq!(expected, actual);
 }
 
-fn aggr_test_schema() -> Arc<Schema> {
+fn aggr_test_schema() -> SchemaRef {
     Arc::new(Schema::new(vec![
         Field::new("c1", DataType::Utf8, false),
         Field::new("c2", DataType::UInt32, false),

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -19,10 +19,10 @@ use std::env;
 use std::fs::File;
 use std::io::{self, BufReader};
 
-use arrow::record_batch::BatchReader;
 use arrow::error::Result;
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::StreamWriter;
+use arrow::record_batch::BatchReader;
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
 
     let mut writer = StreamWriter::try_new(io::stdout(), &schema)?;
 
-    while let Some(batch) = reader.next()? {
+    while let Some(batch) = reader.next_batch()? {
         writer.write(&batch)?;
     }
     writer.finish()?;

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -19,6 +19,7 @@ use std::env;
 use std::fs::File;
 use std::io::{self, BufReader};
 
+use arrow::record_batch::BatchReader;
 use arrow::error::Result;
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::StreamWriter;

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -22,7 +22,7 @@ use std::io::{self, BufReader};
 use arrow::error::Result;
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::StreamWriter;
-use arrow::record_batch::BatchReader;
+use arrow::record_batch::RecordBatchReader;
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::{DataType, DateUnit, IntervalUnit, Schema};
 use arrow::error::{ArrowError, Result};
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
-use arrow::record_batch::{BatchReader, RecordBatch};
+use arrow::record_batch::{RecordBatchReader, RecordBatch};
 
 use hex::decode;
 use std::env;

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -432,7 +432,7 @@ fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()>
     let schema = ArrowJsonSchema { fields };
 
     let mut batches = vec![];
-    while let Ok(Some(batch)) = reader.next() {
+    while let Ok(Some(batch)) = reader.next_batch() {
         batches.push(ArrowJsonBatch::from_batch(&batch));
     }
 
@@ -483,7 +483,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
     }
 
     for json_batch in &json_batches {
-        if let Some(arrow_batch) = arrow_reader.next()? {
+        if let Some(arrow_batch) = arrow_reader.next_batch()? {
             // compare batches
             assert!(arrow_batch.num_columns() == json_batch.num_columns());
             assert!(arrow_batch.num_rows() == json_batch.num_rows());
@@ -500,7 +500,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
         }
     }
 
-    if let Some(_) = arrow_reader.next()? {
+    if let Some(_) = arrow_reader.next_batch()? {
         return Err(ArrowError::ComputeError(
             "no more json batches left".to_owned(),
         ));

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::{DataType, DateUnit, IntervalUnit, Schema};
 use arrow::error::{ArrowError, Result};
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
-use arrow::record_batch::{RecordBatchReader, RecordBatch};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 use hex::decode;
 use std::env;

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::{DataType, DateUnit, IntervalUnit, Schema};
 use arrow::error::{ArrowError, Result};
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
-use arrow::record_batch::{RecordBatch, RecordBatchReader};
+use arrow::record_batch::{RecordBatch, BatchReader};
 
 use hex::decode;
 use std::env;
@@ -432,7 +432,7 @@ fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()>
     let schema = ArrowJsonSchema { fields };
 
     let mut batches = vec![];
-    while let Ok(Some(batch)) = reader.next_batch() {
+    while let Ok(Some(batch)) = reader.next() {
         batches.push(ArrowJsonBatch::from_batch(&batch));
     }
 
@@ -483,7 +483,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
     }
 
     for json_batch in &json_batches {
-        if let Some(arrow_batch) = arrow_reader.next_batch()? {
+        if let Some(arrow_batch) = arrow_reader.next()? {
             // compare batches
             assert!(arrow_batch.num_columns() == json_batch.num_columns());
             assert!(arrow_batch.num_rows() == json_batch.num_rows());
@@ -500,7 +500,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
         }
     }
 
-    if let Some(_) = arrow_reader.next_batch()? {
+    if let Some(_) = arrow_reader.next()? {
         return Err(ArrowError::ComputeError(
             "no more json batches left".to_owned(),
         ));

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::{DataType, DateUnit, IntervalUnit, Schema};
 use arrow::error::{ArrowError, Result};
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
-use arrow::record_batch::{RecordBatch, BatchReader};
+use arrow::record_batch::{BatchReader, RecordBatch};
 
 use hex::decode;
 use std::env;

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -21,7 +21,7 @@ use std::io;
 use arrow::error::Result;
 use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::FileWriter;
-use arrow::record_batch::BatchReader;
+use arrow::record_batch::RecordBatchReader;
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
 
     let mut writer = FileWriter::try_new(io::stdout(), &schema)?;
 
-    while let Some(batch) = arrow_stream_reader.next()? {
+    while let Some(batch) = arrow_stream_reader.next_batch()? {
         writer.write(&batch)?;
     }
     writer.finish()?;

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -18,10 +18,10 @@
 use std::env;
 use std::io;
 
-use arrow::record_batch::BatchReader;
 use arrow::error::Result;
 use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::FileWriter;
+use arrow::record_batch::BatchReader;
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -18,6 +18,7 @@
 use std::env;
 use std::io;
 
+use arrow::record_batch::BatchReader;
 use arrow::error::Result;
 use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::FileWriter;

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -25,7 +25,7 @@ use crate::file::reader::FileReader;
 use arrow::array::StructArray;
 use arrow::datatypes::{DataType as ArrowType, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatchReader, RecordBatch};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use std::rc::Rc;
 use std::sync::Arc;
 

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -25,7 +25,7 @@ use crate::file::reader::FileReader;
 use arrow::array::StructArray;
 use arrow::datatypes::{DataType as ArrowType, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, RecordBatchReader};
+use arrow::record_batch::{RecordBatch, BatchReader};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -33,7 +33,7 @@ use std::sync::Arc;
 /// With this api, user can get arrow schema from parquet file, and read parquet data
 /// into arrow arrays.
 pub trait ArrowReader {
-    type RecordReader: RecordBatchReader;
+    type RecordReader: BatchReader;
 
     /// Read parquet schema and convert it into arrow schema.
     fn get_schema(&mut self) -> Result<Schema>;
@@ -143,12 +143,12 @@ pub struct ParquetRecordBatchReader {
     schema: SchemaRef,
 }
 
-impl RecordBatchReader for ParquetRecordBatchReader {
+impl BatchReader for ParquetRecordBatchReader {
     fn schema(&mut self) -> SchemaRef {
         self.schema.clone()
     }
 
-    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
         self.array_reader
             .next_batch(self.batch_size)
             .map_err(|err| err.into())

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -144,7 +144,7 @@ pub struct ParquetRecordBatchReader {
 }
 
 impl RecordBatchReader for ParquetRecordBatchReader {
-    fn schema(&mut self) -> SchemaRef {
+    fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
 

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -148,7 +148,7 @@ impl RecordBatchReader for ParquetRecordBatchReader {
         self.schema.clone()
     }
 
-    fn next(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
         self.array_reader
             .next_batch(self.batch_size)
             .map_err(|err| err.into())
@@ -399,7 +399,7 @@ mod tests {
         for i in 0..num_iterations {
             let start = i * record_batch_size;
 
-            let batch = record_reader.next().unwrap();
+            let batch = record_reader.next_batch().unwrap();
             if start < expected_data.len() {
                 let end = min(start + record_batch_size, expected_data.len());
                 assert!(batch.is_some());
@@ -481,7 +481,7 @@ mod tests {
     ) {
         for i in 0..20 {
             let array: Option<StructArray> = record_batch_reader
-                .next()
+                .next_batch()
                 .expect("Failed to read record batch!")
                 .map(|r| r.into());
 

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -25,7 +25,7 @@ use crate::file::reader::FileReader;
 use arrow::array::StructArray;
 use arrow::datatypes::{DataType as ArrowType, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{BatchReader, RecordBatch};
+use arrow::record_batch::{RecordBatchReader, RecordBatch};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -33,7 +33,7 @@ use std::sync::Arc;
 /// With this api, user can get arrow schema from parquet file, and read parquet data
 /// into arrow arrays.
 pub trait ArrowReader {
-    type RecordReader: BatchReader;
+    type RecordReader: RecordBatchReader;
 
     /// Read parquet schema and convert it into arrow schema.
     fn get_schema(&mut self) -> Result<Schema>;
@@ -143,7 +143,7 @@ pub struct ParquetRecordBatchReader {
     schema: SchemaRef,
 }
 
-impl BatchReader for ParquetRecordBatchReader {
+impl RecordBatchReader for ParquetRecordBatchReader {
     fn schema(&mut self) -> SchemaRef {
         self.schema.clone()
     }
@@ -221,7 +221,7 @@ mod tests {
     use arrow::array::{
         Array, BooleanArray, FixedSizeBinaryArray, StringArray, StructArray,
     };
-    use arrow::record_batch::BatchReader;
+    use arrow::record_batch::RecordBatchReader;
     use rand::RngCore;
     use serde_json::json;
     use serde_json::Value::{Array as JArray, Null as JNull, Object as JObject};
@@ -475,7 +475,7 @@ mod tests {
     }
 
     fn compare_batch_json(
-        record_batch_reader: &mut dyn BatchReader,
+        record_batch_reader: &mut dyn RecordBatchReader,
         json_values: Vec<serde_json::Value>,
         max_len: usize,
     ) {

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -25,7 +25,7 @@ use crate::file::reader::FileReader;
 use arrow::array::StructArray;
 use arrow::datatypes::{DataType as ArrowType, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, BatchReader};
+use arrow::record_batch::{BatchReader, RecordBatch};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -221,7 +221,7 @@ mod tests {
     use arrow::array::{
         Array, BooleanArray, FixedSizeBinaryArray, StringArray, StructArray,
     };
-    use arrow::record_batch::RecordBatchReader;
+    use arrow::record_batch::BatchReader;
     use rand::RngCore;
     use serde_json::json;
     use serde_json::Value::{Array as JArray, Null as JNull, Object as JObject};
@@ -399,7 +399,7 @@ mod tests {
         for i in 0..num_iterations {
             let start = i * record_batch_size;
 
-            let batch = record_reader.next_batch().unwrap();
+            let batch = record_reader.next().unwrap();
             if start < expected_data.len() {
                 let end = min(start + record_batch_size, expected_data.len());
                 assert!(batch.is_some());
@@ -475,13 +475,13 @@ mod tests {
     }
 
     fn compare_batch_json(
-        record_batch_reader: &mut RecordBatchReader,
+        record_batch_reader: &mut dyn BatchReader,
         json_values: Vec<serde_json::Value>,
         max_len: usize,
     ) {
         for i in 0..20 {
             let array: Option<StructArray> = record_batch_reader
-                .next_batch()
+                .next()
                 .expect("Failed to read record batch!")
                 .map(|r| r.into());
 

--- a/rust/parquet/src/arrow/mod.rs
+++ b/rust/parquet/src/arrow/mod.rs
@@ -40,7 +40,7 @@
 //! let mut record_batch_reader = arrow_reader.get_record_reader(2048).unwrap();
 //!
 //! loop {
-//!    let record_batch = record_batch_reader.next().unwrap().unwrap();
+//!    let record_batch = record_batch_reader.next_batch().unwrap().unwrap();
 //!    if record_batch.num_rows() > 0 {
 //!        println!("Read {} records.", record_batch.num_rows());
 //!    } else {

--- a/rust/parquet/src/arrow/mod.rs
+++ b/rust/parquet/src/arrow/mod.rs
@@ -23,7 +23,7 @@
 //! # Example of reading parquet file into arrow record batch
 //!
 //! ```rust, no_run
-//! use arrow::record_batch::RecordBatchReader;
+//! use arrow::record_batch::BatchReader;
 //! use parquet::file::reader::SerializedFileReader;
 //! use parquet::arrow::{ParquetFileArrowReader, ArrowReader};
 //! use std::rc::Rc;
@@ -40,7 +40,7 @@
 //! let mut record_batch_reader = arrow_reader.get_record_reader(2048).unwrap();
 //!
 //! loop {
-//!    let record_batch = record_batch_reader.next_batch().unwrap().unwrap();
+//!    let record_batch = record_batch_reader.next().unwrap().unwrap();
 //!    if record_batch.num_rows() > 0 {
 //!        println!("Read {} records.", record_batch.num_rows());
 //!    } else {

--- a/rust/parquet/src/arrow/mod.rs
+++ b/rust/parquet/src/arrow/mod.rs
@@ -23,7 +23,7 @@
 //! # Example of reading parquet file into arrow record batch
 //!
 //! ```rust, no_run
-//! use arrow::record_batch::BatchReader;
+//! use arrow::record_batch::RecordBatchReader;
 //! use parquet::file::reader::SerializedFileReader;
 //! use parquet::arrow::{ParquetFileArrowReader, ArrowReader};
 //! use std::rc::Rc;


### PR DESCRIPTION
Most libraries that use `Arrow` are likely to want to define types that produce `RecordBatch`'s.  This PR defines the `RecordBatchReader` and `SendableRecordBatchReader` traits and updates other crates (in particular, DataFusion) to use these traits.  In short, I think these traits should be defined in the main arrow crate.

It was mentioned on the JIRA that we could just use a single trait and allow users to implement `Send`/`Sync` as necessary.  The fact the the `schema` method returns a reference counted type makes this hard to do (`Rc` vs `Arc`) so I settled on two different traits.  This seemed like the easiest to do in advance of 1.0, maybe we can improve on this.

As `next` returns `Arrow`'s error type I added a new variant to allow wrapping external errors once they implement the standard `Error` trait and `Send`, `Sync`.  I remove the `PartialEq` and `Clone` bounds on the DataFusion error type as we were only using these in testing (the tests are updated) and it's best to keep the requirements on external implementers as low a possible.

