### PR TITLE
ARROW-9365: [Go] Added the rest of the implemented array builders to NewBuilder

### DIFF
--- a/go/arrow/array/builder.go
+++ b/go/arrow/array/builder.go
@@ -212,6 +212,7 @@ func NewBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
 	// FIXME(sbinet): use a type switch on dtype instead?
 	switch dtype.ID() {
 	case arrow.NULL:
+		return NewNullBuilder(mem)
 	case arrow.BOOL:
 		return NewBooleanBuilder(mem)
 	case arrow.UINT8:
@@ -244,8 +245,12 @@ func NewBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
 		typ := dtype.(*arrow.FixedSizeBinaryType)
 		return NewFixedSizeBinaryBuilder(mem, typ)
 	case arrow.DATE32:
+		return NewDate32Builder(mem)
 	case arrow.DATE64:
+		return NewDate64Builder(mem)
 	case arrow.TIMESTAMP:
+		typ := dtype.(*arrow.TimestampType)
+		return NewTimestampBuilder(mem, typ)
 	case arrow.TIME32:
 		typ := dtype.(*arrow.Time32Type)
 		return NewTime32Builder(mem, typ)
@@ -253,7 +258,16 @@ func NewBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
 		typ := dtype.(*arrow.Time64Type)
 		return NewTime64Builder(mem, typ)
 	case arrow.INTERVAL:
+		switch dtype.(type) {
+		case *arrow.DayTimeIntervalType:
+			return NewDayTimeIntervalBuilder(mem)
+		case *arrow.MonthIntervalType:
+			return NewMonthIntervalBuilder(mem)
+		}
 	case arrow.DECIMAL:
+		if typ, ok := dtype.(*arrow.Decimal128Type); ok {
+			return NewDecimal128Builder(mem, typ)
+		}
 	case arrow.LIST:
 		typ := dtype.(*arrow.ListType)
 		return NewListBuilder(mem, typ.Elem())
@@ -268,6 +282,8 @@ func NewBuilder(mem memory.Allocator, dtype arrow.DataType) Builder {
 		typ := dtype.(*arrow.FixedSizeListType)
 		return NewFixedSizeListBuilder(mem, typ.Len(), typ.Elem())
 	case arrow.DURATION:
+		typ := dtype.(*arrow.DurationType)
+		return NewDurationBuilder(mem, typ)
 	}
 	panic(fmt.Errorf("arrow/array: unsupported builder for %T", dtype))
 }


### PR DESCRIPTION
This PR adds the rest of the implemented typed array builders to the NewBuilder function. I ran into needing this because `NewStructBuilder` internally calls `NewBuilder`.