### PR TITLE
ARROW-8344: [C#] Bug-fixes to binary array plus other improvements

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -101,7 +101,7 @@ namespace Apache.Arrow
                 };
                 var data = new ArrayData(
                     DataType,
-                    length: ValueOffsets.Length - 1,
+                    length: Length,
                     NullCount,
                     offset: 0,
                     bufs);

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -192,6 +192,11 @@ namespace Apache.Arrow
             /// <returns>Returns the builder (for fluent-style composition).</returns>
             public TBuilder AppendRange(IEnumerable<byte> values)
             {
+                if (values == null)
+                {
+                    throw new ArgumentNullException(nameof(values));
+                }
+
                 foreach (byte b in values)
                 {
                     Append(b);
@@ -207,9 +212,21 @@ namespace Apache.Arrow
             /// <returns>Returns the builder (for fluent-style composition).</returns>
             public TBuilder AppendRange(IEnumerable<byte[]> values)
             {
+                if (values == null)
+                {
+                    throw new ArgumentNullException(nameof(values));
+                }
+
                 foreach (byte[] arr in values)
                 {
-                    Append((IEnumerable<byte>)arr);
+                    if (arr == null)
+                    {
+                        AppendNull();
+                    }
+                    else
+                    {
+                        Append((ReadOnlySpan<byte>)arr);
+                    }
                 }
 
                 return Instance;

--- a/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
+++ b/csharp/src/Apache.Arrow/Arrays/BinaryArray.cs
@@ -66,87 +66,158 @@ namespace Apache.Arrow
                 ValueOffsets = new ArrowBuffer.Builder<int>();
                 ValueBuffer = new ArrowBuffer.Builder<byte>();
                 ValidityBuffer = new ArrowBuffer.BitmapBuilder();
+
+                // From the docs:
+                //
+                // The offsets buffer contains length + 1 signed integers (either 32-bit or 64-bit, depending on the
+                // logical type), which encode the start position of each slot in the data buffer. The length of the
+                // value in each slot is computed using the difference between the offset at that slot’s index and the
+                // subsequent offset.
+                //
+                // In this builder, we choose to append the first offset (zero) upon construction, and each trailing
+                // offset is then added after each individual item has been appended.
+                ValueOffsets.Append(this.Offset);
             }
 
             protected abstract TArray Build(ArrayData data);
 
-            public int Length => ValueOffsets.Length;
+            /// <summary>
+            /// Gets the length of the array built so far.
+            /// </summary>
+            public int Length => ValueOffsets.Length - 1;
 
+            /// <summary>
+            /// Build an Arrow array from the appended contents so far.
+            /// </summary>
+            /// <param name="allocator">Optional memory allocator.</param>
+            /// <returns>Returns an array of type <typeparamref name="TArray"/>.</returns>
             public TArray Build(MemoryAllocator allocator = default)
             {
-                ValueOffsets.Append(Offset);
-
-                ArrowBuffer validityBuffer = NullCount > 0
-                                        ? ValidityBuffer.Build(allocator)
-                                        : ArrowBuffer.Empty;
-
-                var data = new ArrayData(DataType, ValueOffsets.Length - 1, NullCount, 0,
-                    new[] { validityBuffer, ValueOffsets.Build(allocator), ValueBuffer.Build(allocator) });
+                var bufs = new[]
+                {
+                    NullCount > 0 ? ValidityBuffer.Build(allocator) : ArrowBuffer.Empty,
+                    ValueOffsets.Build(allocator),
+                    ValueBuffer.Build(allocator),
+                };
+                var data = new ArrayData(
+                    DataType,
+                    length: ValueOffsets.Length - 1,
+                    NullCount,
+                    offset: 0,
+                    bufs);
 
                 return Build(data);
             }
 
+            /// <summary>
+            /// Append a single null value to the array.
+            /// </summary>
+            /// <returns>Returns the builder (for fluent-style composition).</returns>
             public TBuilder AppendNull()
             {
-                ValueOffsets.Append(Offset);
+                // Do not add to the value buffer in the case of a null.
+                // Note that we do not need to increment the offset as a result.
                 ValidityBuffer.Append(false);
+                ValueOffsets.Append(Offset);
                 return Instance;
             }
 
+            /// <summary>
+            /// Appends a value, consisting of a single byte, to the array.
+            /// </summary>
+            /// <param name="value">Byte value to append.</param>
+            /// <returns>Returns the builder (for fluent-style composition).</returns>
             public TBuilder Append(byte value)
             {
-                ValueOffsets.Append(Offset);
                 ValueBuffer.Append(value);
-                Offset++;
                 ValidityBuffer.Append(true);
+                Offset++;
+                ValueOffsets.Append(Offset);
                 return Instance;
             }
 
+            /// <summary>
+            /// Append a value, consisting of a span of bytes, to the array.
+            /// </summary>
+            /// <remarks>
+            /// Note that a single value is added, which consists of arbitrarily many bytes.  If multiple values are
+            /// to be added, use the <see cref="AppendRange"/> method.
+            /// </remarks>
+            /// <param name="span">Span of bytes to add.</param>
+            /// <returns>Returns the builder (for fluent-style composition).</returns>
             public TBuilder Append(ReadOnlySpan<byte> span)
             {
-                ValueOffsets.Append(Offset);
                 ValueBuffer.Append(span);
                 ValidityBuffer.Append(true);
                 Offset += span.Length;
+                ValueOffsets.Append(Offset);
                 return Instance;
             }
 
+            /// <summary>
+            /// Append a value, consisting of an enumerable collection of bytes, to the array.
+            /// </summary>
+            /// <remarks>
+            /// Note that this method appends a single value, which may consist of arbitrarily many bytes.  If multiple
+            /// values are to be added, use the <see cref="AppendRange(IEnumerable{byte})"/> method instead.
+            /// </remarks>
+            /// <param name="value">Enumerable collection of bytes to add.</param>
+            /// <returns>Returns the builder (for fluent-style composition).</returns>
+            public TBuilder Append(IEnumerable<byte> value)
+            {
+                if (value == null)
+                {
+                    return AppendNull();
+                }
+
+                // Note: by looking at the length of the value buffer before and after, we avoid having to iterate
+                // through the enumerable multiple times to get both length and contents.
+                int priorLength = ValueBuffer.Length;
+                ValueBuffer.AppendRange(value);
+                int valueLength = ValueBuffer.Length - priorLength;
+                Offset += valueLength;
+                ValidityBuffer.Append(true);
+                ValueOffsets.Append(Offset);
+                return Instance;
+            }
+
+            /// <summary>
+            /// Append an enumerable collection of single-byte values to the array.
+            /// </summary>
+            /// <remarks>
+            /// Note that this method appends multiple values, each of which is a single byte.  If a single value is
+            /// to be added, use the <see cref="Append(IEnumerable{byte})"/> method instead.
+            /// </remarks>
+            /// <param name="values">Single-byte values to add.</param>
+            /// <returns>Returns the builder (for fluent-style composition).</returns>
+            public TBuilder AppendRange(IEnumerable<byte> values)
+            {
+                foreach (byte b in values)
+                {
+                    Append(b);
+                }
+
+                return Instance;
+            }
+
+            /// <summary>
+            /// Append an enumerable collection of values to the array.
+            /// </summary>
+            /// <param name="values">Values to add.</param>
+            /// <returns>Returns the builder (for fluent-style composition).</returns>
             public TBuilder AppendRange(IEnumerable<byte[]> values)
             {
                 foreach (byte[] arr in values)
                 {
-                    if (arr == null)
-                    {
-                        AppendNull();
-                        continue;
-                    }
-                    int len = ValueBuffer.Length;
-                    ValueOffsets.Append(Offset);
-                    ValueBuffer.Append(arr);
-                    ValidityBuffer.Append(true);
-                    Offset += ValueBuffer.Length - len;
+                    Append((IEnumerable<byte>)arr);
                 }
 
-                return Instance;
-            }
-
-            public TBuilder AppendRange(IEnumerable<byte> values)
-            {
-                if (values == null)
-                {
-                    return AppendNull();
-                }
-                int len = ValueBuffer.Length;
-                ValueBuffer.AppendRange(values);
-                int valOffset = ValueBuffer.Length - len;
-                ValueOffsets.Append(Offset);
-                Offset += valOffset;
-                ValidityBuffer.Append(true);
                 return Instance;
             }
 
             public TBuilder Reserve(int capacity)
             {
+                // TODO: [ARROW-9366] Reserve capacity in the value buffer in a more sensible way.
                 ValueOffsets.Reserve(capacity + 1);
                 ValueBuffer.Reserve(capacity);
                 ValidityBuffer.Reserve(capacity + 1);
@@ -155,6 +226,7 @@ namespace Apache.Arrow
 
             public TBuilder Resize(int length)
             {
+                // TODO: [ARROW-9366] Resize the value buffer to a safe length based on offsets, not `length`.
                 ValueOffsets.Resize(length + 1);
                 ValueBuffer.Resize(length);
                 ValidityBuffer.Resize(length + 1);
@@ -173,11 +245,19 @@ namespace Apache.Arrow
                 throw new NotImplementedException();
             }
 
+            /// <summary>
+            /// Clear all contents appended so far.
+            /// </summary>
+            /// <returns>Returns the builder (for fluent-style composition).</returns>
             public TBuilder Clear()
             {
                 ValueOffsets.Clear();
                 ValueBuffer.Clear();
                 ValidityBuffer.Clear();
+
+                // Always write the first offset before anything has been written.
+                Offset = 0;
+                ValueOffsets.Append(Offset);
                 return Instance;
             }
         }
@@ -228,6 +308,18 @@ namespace Apache.Arrow
             return offsets[index + 1] - offsets[index];
         }
 
+        /// <summary>
+        /// Get the collection of bytes, as a read-only span, at a given index in the array.
+        /// </summary>
+        /// <remarks>
+        /// Note that this method cannot reliably identify null values, which are indistinguishable from empty byte
+        /// collection values when seen in the context of this method's return type of <see cref="ReadOnlySpan{Byte}"/>.
+        /// Use the <see cref="Array.IsNull"/> method instead to reliably determine null values.
+        /// </remarks>
+        /// <param name="index">Index at which to get bytes.</param>
+        /// <returns>Returns a <see cref="ReadOnlySpan{Byte}"/> object.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">If the index is negative or beyond the length of the array.
+        /// </exception>
         public ReadOnlySpan<byte> GetBytes(int index)
         {
             if (index < 0 || index >= Length)
@@ -237,7 +329,9 @@ namespace Apache.Arrow
 
             if (IsNull(index))
             {
-                return null;
+                // Note that `return null;` is valid syntax, but would be misleading as `null` in the context of a span
+                // is actually returned as an empty span.
+                return ReadOnlySpan<byte>.Empty;
             }
 
             return ValueBuffer.Span.Slice(ValueOffsets[index], GetValueLength(index));

--- a/csharp/test/Apache.Arrow.Tests/BinaryArrayBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/BinaryArrayBuilderTests.cs
@@ -1,0 +1,489 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Apache.Arrow.Memory;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class BinaryArrayBuilderTests
+    {
+        private static readonly MemoryAllocator _allocator = new NativeMemoryAllocator();
+
+        // Various example byte arrays for use in testing.
+        private static readonly byte[] _exampleNull = null;
+        private static readonly byte[] _exampleEmpty = { };
+        private static readonly byte[] _exampleNonEmpty1 = { 10, 20, 30, 40 };
+        private static readonly byte[] _exampleNonEmpty2 = { 50, 60, 70, 80 };
+        private static readonly byte[] _exampleNonEmpty3 = { 90 };
+
+        // Base set of single bytes that may be used to append to a builder in testing.
+        private static readonly byte[] _singleBytesToAppend = { 0, 123, 127, 255 };
+
+        // Base set of byte arrays that may be used to append to a builder in testing.
+        private static readonly byte[][] _byteArraysToAppend =
+        {
+            _exampleNull,
+            _exampleEmpty,
+            _exampleNonEmpty2,
+            _exampleNonEmpty3,
+        };
+
+        // Base set of multiple byte arrays that may be used to append to a builder in testing.
+        private static readonly byte[][][] _byteArrayArraysToAppend =
+        {
+            new byte[][] { },
+            new[] { _exampleNull },
+            new[] { _exampleEmpty },
+            new[] { _exampleNonEmpty2 },
+            new[] { _exampleNonEmpty2, _exampleNonEmpty3 },
+            new[] { _exampleNonEmpty2, _exampleEmpty, _exampleNull },
+        };
+
+        // Base set of byte arrays that can be used as "initial contents" of any builder under test.
+        private static readonly byte[][][] _initialContentsSet =
+        {
+            new byte[][] { },
+            new[] { _exampleNull },
+            new[] { _exampleEmpty },
+            new[] { _exampleNonEmpty1 },
+            new[] { _exampleNonEmpty1, _exampleNonEmpty3 },
+            new[] { _exampleNonEmpty1, _exampleEmpty, _exampleNull },
+        };
+
+        public class Append
+        {
+            public static IEnumerable<object[]> _appendSingleByteTestData =
+                from initialContents in _initialContentsSet
+                from singleByte in _singleBytesToAppend
+                select new object[] { initialContents, singleByte };
+
+            [Theory]
+            [MemberData(nameof(_appendSingleByteTestData))]
+            public void AppendSingleByte(byte[][] initialContents, byte singleByte)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                int initialLength = builder.Length;
+                int expectedLength = initialLength + 1;
+                var expectedArrayContents = initialContents.Append(new[] { singleByte });
+
+                // Act
+                var actualReturnValue = builder.Append(singleByte);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(expectedLength, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+
+            [Theory]
+            [MemberData(nameof(_appendSingleByteTestData))]
+            public void AppendSingleByteAfterClear(byte[][] initialContents, byte singleByte)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                builder.Clear();
+                var expectedArrayContents = new[] { new[] { singleByte } };
+
+                // Act
+                var actualReturnValue = builder.Append(singleByte);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(1, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+
+            public static readonly IEnumerable<object[]> _appendNullTestData =
+                from initialContents in _initialContentsSet
+                select new object[] { initialContents };
+
+            [Theory]
+            [MemberData(nameof(_appendNullTestData))]
+            public void AppendNull(byte[][] initialContents)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                int initialLength = builder.Length;
+                int expectedLength = initialLength + 1;
+                var expectedArrayContents = initialContents.Append(null);
+
+                // Act
+                var actualReturnValue = builder.AppendNull();
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(expectedLength, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+
+            [Theory]
+            [MemberData(nameof(_appendNullTestData))]
+            public void AppendNullAfterClear(byte[][] initialContents)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                builder.Clear();
+                var expectedArrayContents = new byte[][] { null };
+
+                // Act
+                var actualReturnValue = builder.AppendNull();
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(1, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+
+            public static readonly IEnumerable<object[]> _appendNonNullByteArrayTestData =
+                from initialContents in _initialContentsSet
+                from bytes in _byteArraysToAppend
+                where bytes != null
+                select new object[] { initialContents, bytes };
+
+            [Theory]
+            [MemberData(nameof(_appendNonNullByteArrayTestData))]
+            public void AppendReadOnlySpan(byte[][] initialContents, byte[] bytes)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                int initialLength = builder.Length;
+                var span = (ReadOnlySpan<byte>)bytes;
+                int expectedLength = initialLength + 1;
+                var expectedArrayContents = initialContents.Append(bytes);
+
+                // Act
+                var actualReturnValue = builder.Append(span);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(expectedLength, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+
+            [Theory]
+            [MemberData(nameof(_appendNonNullByteArrayTestData))]
+            public void AppendReadOnlySpanAfterClear(byte[][] initialContents, byte[] bytes)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                builder.Clear();
+                var span = (ReadOnlySpan<byte>)bytes;
+                var expectedArrayContents = new[] { bytes };
+
+                // Act
+                var actualReturnValue = builder.Append(span);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(1, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+
+            public static readonly IEnumerable<object[]> _appendByteArrayTestData =
+                from initialContents in _initialContentsSet
+                from bytes in _byteArraysToAppend
+                select new object[] { initialContents, bytes };
+
+            [Theory]
+            [MemberData(nameof(_appendByteArrayTestData))]
+            public void AppendEnumerable(byte[][] initialContents, byte[] bytes)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                int initialLength = builder.Length;
+                int expectedLength = initialLength + 1;
+                var enumerable = (IEnumerable<byte>)bytes;
+                var expectedArrayContents = initialContents.Append(bytes);
+
+                // Act
+                var actualReturnValue = builder.Append(enumerable);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(expectedLength, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+
+            [Theory]
+            [MemberData(nameof(_appendByteArrayTestData))]
+            public void AppendEnumerableAfterClear(byte[][] initialContents, byte[] bytes)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                builder.Clear();
+                var enumerable = (IEnumerable<byte>)bytes;
+                var expectedArrayContents = new[] { bytes };
+
+                // Act
+                var actualReturnValue = builder.Append(enumerable);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(1, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+        }
+
+        public class AppendRange
+        {
+            public static readonly IEnumerable<object[]> _appendRangeSingleBytesTestData =
+                from initialContents in _initialContentsSet
+                select new object[] { initialContents, _singleBytesToAppend };
+
+            [Theory]
+            [MemberData(nameof(_appendRangeSingleBytesTestData))]
+            public void AppendRangeSingleBytes(byte[][] initialContents, byte[] singleBytes)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                int initialLength = builder.Length;
+                int expectedNewLength = initialLength + singleBytes.Length;
+                var expectedArrayContents = initialContents.Concat(singleBytes.Select(b => new[] { b }));
+
+                // Act
+                var actualReturnValue = builder.AppendRange(singleBytes);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(expectedNewLength, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+
+            }
+
+            [Theory]
+            [MemberData(nameof(_appendRangeSingleBytesTestData))]
+            public void AppendRangeSingleBytesAfterClear(byte[][] initialContents, byte[] singleBytes)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                builder.Clear();
+                var expectedArrayContents = singleBytes.Select(b => new[] { b });
+
+                // Act
+                var actualReturnValue = builder.AppendRange(singleBytes);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(singleBytes.Length, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+
+            public static readonly IEnumerable<object[]> _appendRangeByteArraysTestData =
+                from initialContents in _initialContentsSet
+                from byteArrays in _byteArrayArraysToAppend
+                select new object[] { initialContents, byteArrays };
+
+            [Theory]
+            [MemberData(nameof(_appendRangeByteArraysTestData))]
+            public void AppendRangeArrays(byte[][] initialContents, byte[][] byteArrays)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                int initialLength = builder.Length;
+                int expectedNewLength = initialLength + byteArrays.Length;
+                var expectedArrayContents = initialContents.Concat(byteArrays);
+
+                // Act
+                var actualReturnValue = builder.AppendRange(byteArrays);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(expectedNewLength, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+
+            [Theory]
+            [MemberData(nameof(_appendRangeByteArraysTestData))]
+            public void AppendRangeArraysAfterClear(byte[][] initialContents, byte[][] byteArrays)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                if (initialContents.Length > 0)
+                    builder.AppendRange(initialContents);
+                builder.Clear();
+                var expectedArrayContents = byteArrays;
+
+                // Act
+                var actualReturnValue = builder.AppendRange(byteArrays);
+
+                // Assert
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(byteArrays.Length, builder.Length);
+                var actualArray = builder.Build(_allocator);
+                AssertArrayContents(expectedArrayContents, actualArray);
+            }
+        }
+
+        public class Clear
+        {
+            [Fact]
+            public void ClearEmpty()
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+
+                // Act
+                var actualReturnValue = builder.Clear();
+
+                // Assert
+                Assert.NotNull(actualReturnValue);
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(0, builder.Length);
+                var array = builder.Build(_allocator);
+                Assert.Equal(0, array.Length);
+            }
+
+            public static readonly IEnumerable<object[]> _testData =
+                from byteArrays in _byteArrayArraysToAppend
+                select new object[] { byteArrays };
+
+            [Theory]
+            [MemberData(nameof(_testData))]
+            public void ClearNonEmpty(byte[][] byteArrays)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                builder.AppendRange(byteArrays);
+
+                // Act
+                var actualReturnValue = builder.Clear();
+
+                // Assert
+                Assert.NotNull(actualReturnValue);
+                Assert.Equal(builder, actualReturnValue);
+                Assert.Equal(0, builder.Length);
+                var array = builder.Build(_allocator);
+                Assert.Equal(0, array.Length);
+            }
+        }
+
+        public class Build
+        {
+            [Fact]
+            public void BuildImmediately()
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+
+                // Act
+                var array = builder.Build(_allocator);
+
+                // Assert
+                Assert.Equal(0, array.Length);
+            }
+
+            public static readonly IEnumerable<object[]> _testData =
+                from ba1 in _initialContentsSet
+                from ba2 in _byteArrayArraysToAppend
+                select new object[] { ba1.Concat(ba2) };
+
+            [Theory]
+            [MemberData(nameof(_testData))]
+            public void AppendThenBuild(byte[][] byteArrays)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                foreach (var byteArray in byteArrays)
+                {
+                    // Test the type of byte array to ensure each Append() overload is exercised.
+                    if (byteArray == null)
+                    {
+                        builder.AppendNull();
+                    }
+                    else if (byteArray.Length == 1)
+                    {
+                        builder.Append(byteArray[0]);
+                    }
+                    else
+                    {
+                        builder.Append((ReadOnlySpan<byte>)byteArray);
+                    }
+                }
+
+                // Act
+                var array = builder.Build(_allocator);
+
+                // Assert
+                AssertArrayContents(byteArrays, array);
+            }
+
+            [Theory]
+            [MemberData(nameof(_testData))]
+            public void BuildMultipleTimes(byte[][] byteArrays)
+            {
+                // Arrange
+                var builder = new BinaryArray.Builder();
+                builder.AppendRange(byteArrays);
+                builder.Build(_allocator);
+
+                // Act
+                var array = builder.Build(_allocator);
+
+                // Assert
+                AssertArrayContents(byteArrays, array);
+            }
+        }
+
+        private static void AssertArrayContents(IEnumerable<byte[]> expectedContents, BinaryArray array)
+        {
+            var expectedContentsArr = expectedContents.ToArray();
+            Assert.Equal(expectedContentsArr.Length, array.Length);
+            for (int i = 0; i < array.Length; i++)
+            {
+                var expectedArray = expectedContentsArr[i];
+                var actualArray = array.IsNull(i) ? null : array.GetBytes(i).ToArray();
+                Assert.Equal(expectedArray, actualArray);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a few bugs in `BinaryArray.Builder()`:
* Fixes the `Clear()` method, which previously would break all subsequently-appended values (see JIRA ticket for examples).
* Makes the `Build()` method idempotent, by making sure the builder's internal arrays are not modified when it is called.

And makes a few other improvements:
* Comprehensive test coverage of the builder's key methods (this was written in proper TDD-style, so these tests would fail if run on `master`).
* XML docstrings for all methods affected.