### PR TITLE
ARROW-9368: [Python] Rename predicate argument to filter in split_by_row_group()

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -925,7 +925,7 @@ cdef class ParquetFileFragment(FileFragment):
             return None
         return [RowGroupInfo.wrap(row_group) for row_group in c_row_groups]
 
-    def split_by_row_group(self, Expression predicate=None,
+    def split_by_row_group(self, Expression filter=None,
                            Schema schema=None):
         """
         Split the fragment into multiple fragments.
@@ -936,7 +936,7 @@ cdef class ParquetFileFragment(FileFragment):
 
         Parameters
         ----------
-        predicate : Expression, default None
+        filter : Expression, default None
             Exclude RowGroups whose statistics contradicts the predicate.
         schema : Schema, default None
             Schema to use when filtering row groups. Defaults to the
@@ -948,14 +948,14 @@ cdef class ParquetFileFragment(FileFragment):
         """
         cdef:
             vector[shared_ptr[CFragment]] c_fragments
-            shared_ptr[CExpression] c_predicate
+            shared_ptr[CExpression] c_filter
             shared_ptr[CFragment] c_fragment
 
         schema = schema or self.physical_schema
-        c_predicate = _insert_implicit_casts(predicate, schema)
+        c_filter = _insert_implicit_casts(filter, schema)
         with nogil:
             c_fragments = move(GetResultValue(
-                self.parquet_file_fragment.SplitByRowGroup(move(c_predicate))))
+                self.parquet_file_fragment.SplitByRowGroup(move(c_filter))))
 
         return [Fragment.wrap(c_fragment) for c_fragment in c_fragments]
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -932,12 +932,13 @@ cdef class ParquetFileFragment(FileFragment):
 
         Yield a Fragment wrapping each row group in this ParquetFileFragment.
         Row groups will be excluded whose metadata contradicts the optional
-        predicate.
+        filter.
 
         Parameters
         ----------
         filter : Expression, default None
-            Exclude RowGroups whose statistics contradicts the predicate.
+            Only include the row groups which satisfy this predicate (using
+            the Parquet RowGroup statistics).
         schema : Schema, default None
             Schema to use when filtering row groups. Defaults to the
             Fragment's phsyical schema

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -832,13 +832,13 @@ def test_fragments_parquet_row_groups_predicate(tempdir):
 
     # filter matches partition_expression: all row groups
     row_group_fragments = list(
-        fragment.split_by_row_group(ds.field('part') == 'a',
+        fragment.split_by_row_group(filter=ds.field('part') == 'a',
                                     schema=dataset.schema))
     assert len(row_group_fragments) == 2
 
     # filter contradicts partition_expression: no row groups
     row_group_fragments = list(
-        fragment.split_by_row_group(ds.field('part') == 'b',
+        fragment.split_by_row_group(filter=ds.field('part') == 'b',
                                     schema=dataset.schema))
     assert len(row_group_fragments) == 0
 


### PR DESCRIPTION
Small change, for consistency with the `filter` keyword in `to_table()` and `get_fragments()` methods.