### PR TITLE
ARROW-9370: [Java] Bump Netty version

### DIFF
--- a/java/flight/flight-core/pom.xml
+++ b/java/flight/flight-core/pom.xml
@@ -24,7 +24,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <dep.grpc.version>1.24.0</dep.grpc.version>
+    <dep.grpc.version>1.30.2</dep.grpc.version>
     <dep.protobuf.version>3.7.1</dep.protobuf.version>
     <forkCount>1</forkCount>
   </properties>
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>2.0.12.Final</version>
+      <version>2.0.31.Final</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/java/flight/flight-grpc/pom.xml
+++ b/java/flight/flight-grpc/pom.xml
@@ -24,7 +24,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <dep.grpc.version>1.24.0</dep.grpc.version>
+    <dep.grpc.version>1.30.2</dep.grpc.version>
     <dep.protobuf.version>3.7.1</dep.protobuf.version>
     <forkCount>1</forkCount>
   </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,7 +33,7 @@
     <dep.junit.jupiter.version>5.4.0</dep.junit.jupiter.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava.version>20.0</dep.guava.version>
-    <dep.netty.version>4.1.27.Final</dep.netty.version>
+    <dep.netty.version>4.1.48.Final</dep.netty.version>
     <dep.jackson.version>2.9.8</dep.jackson.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.9.0</dep.fbs.version>


### PR DESCRIPTION
As per https://github.com/apache/arrow/pull/7619#issuecomment-655246147 there is a security
vulnerability in the current version of Netty. This upgrades to the latest version.

A compatible upgrade of grpc was also required