### PR TITLE
ARROW-9326: [Python] Remove setuptools pinning

### DIFF
--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,5 +1,5 @@
 cython>=0.29
 numpy>=1.14,<1.19; python_version < "3.6"
 numpy>=1.14; python_version >= "3.6"
-setuptools==47.3.2; python_version >= "3.6"
+setuptools; python_version >= "3.6"
 setuptools_scm


### PR DESCRIPTION
It seems this was only needed as a temporary measure.