### PR TITLE
ARROW-9345: [C++][Dataset] Support casting scalars to dictionary scalars

### DIFF
--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -33,6 +33,7 @@
 namespace arrow {
 
 using internal::checked_cast;
+using internal::checked_pointer_cast;
 
 TEST(TestNullScalar, Basics) {
   NullScalar scalar;
@@ -47,7 +48,7 @@ TEST(TestNullScalar, Basics) {
 template <typename T>
 class TestNumericScalar : public ::testing::Test {
  public:
-  TestNumericScalar() {}
+  TestNumericScalar() = default;
 };
 
 TYPED_TEST_SUITE(TestNumericScalar, NumericArrowTypes);
@@ -198,7 +199,7 @@ TEST(TestStringScalar, MakeScalar) {
   ASSERT_EQ(StringScalar("three"), *three);
 
   // test Array.GetScalar
-  auto arr = ArrayFromJSON(utf8(), "[null, \"one\", \"two\"]");
+  auto arr = ArrayFromJSON(utf8(), R"([null, "one", "two"])");
   ASSERT_OK_AND_ASSIGN(auto null, arr->GetScalar(0));
   ASSERT_OK_AND_ASSIGN(auto one, arr->GetScalar(1));
   ASSERT_OK_AND_ASSIGN(auto two, arr->GetScalar(2));
@@ -221,7 +222,7 @@ TEST(TestFixedSizeBinaryScalar, Basics) {
 
   // test Array.GetScalar
   auto ty = fixed_size_binary(3);
-  auto arr = ArrayFromJSON(ty, "[null, \"one\", \"two\"]");
+  auto arr = ArrayFromJSON(ty, R"([null, "one", "two"])");
   ASSERT_OK_AND_ASSIGN(auto null, arr->GetScalar(0));
   ASSERT_OK_AND_ASSIGN(auto one, arr->GetScalar(1));
   ASSERT_OK_AND_ASSIGN(auto two, arr->GetScalar(2));
@@ -581,9 +582,9 @@ TEST(TestStructScalar, FieldAccess) {
 }
 
 TEST(TestDictionaryScalar, Basics) {
-  auto CheckIndexType = [&](const std::shared_ptr<DataType>& index_ty) {
+  for (auto index_ty : all_dictionary_index_types()) {
     auto ty = dictionary(index_ty, utf8());
-    auto dict = ArrayFromJSON(utf8(), "[\"alpha\", \"beta\", \"gamma\"]");
+    auto dict = ArrayFromJSON(utf8(), R"(["alpha", "beta", "gamma"])");
 
     DictionaryScalar::ValueType alpha;
     ASSERT_OK_AND_ASSIGN(alpha.index, MakeScalar(index_ty, 0));
@@ -621,10 +622,34 @@ TEST(TestDictionaryScalar, Basics) {
     ASSERT_TRUE(first->Equals(scalar_gamma));
     ASSERT_TRUE(second->Equals(scalar_alpha));
     ASSERT_TRUE(last->Equals(scalar_null));
-  };
+  }
+}
 
-  for (auto ty : all_dictionary_index_types()) {
-    CheckIndexType(ty);
+TEST(TestDictionaryScalar, Cast) {
+  for (auto index_ty : all_dictionary_index_types()) {
+    auto ty = dictionary(index_ty, utf8());
+    auto dict = checked_pointer_cast<StringArray>(
+        ArrayFromJSON(utf8(), R"(["alpha", "beta", "gamma"])"));
+
+    for (int64_t i = 0; i < dict->length(); ++i) {
+      auto alpha = MakeScalar(dict->GetString(i));
+      ASSERT_OK_AND_ASSIGN(auto cast_alpha, alpha->CastTo(ty));
+      ASSERT_OK_AND_ASSIGN(
+          auto roundtripped_alpha,
+          checked_cast<const DictionaryScalar&>(*cast_alpha).GetEncodedValue());
+
+      ASSERT_OK_AND_ASSIGN(auto i_scalar, MakeScalar(index_ty, i));
+      auto alpha_dict = DictionaryScalar({i_scalar, dict}, ty);
+      ASSERT_OK_AND_ASSIGN(
+          auto encoded_alpha,
+          checked_cast<const DictionaryScalar&>(alpha_dict).GetEncodedValue());
+
+      AssertScalarsEqual(*alpha, *roundtripped_alpha);
+      AssertScalarsEqual(*encoded_alpha, *roundtripped_alpha);
+
+      // dictionaries differ, though encoded values are identical
+      ASSERT_FALSE(alpha_dict.Equals(cast_alpha));
+    }
   }
 }
 
@@ -641,7 +666,7 @@ TEST(TestSparseUnionScalar, Basics) {
 
   // test Array.GetScalar
   std::vector<std::shared_ptr<Array>> children{
-      ArrayFromJSON(utf8(), "[\"alpha\", \"\", \"beta\", null, \"gamma\"]"),
+      ArrayFromJSON(utf8(), R"(["alpha", "", "beta", null, "gamma"])"),
       ArrayFromJSON(uint64(), "[1, 2, 11, 22, null]")};
 
   auto type_ids = ArrayFromJSON(int8(), "[0, 1, 0, 0, 1]");
@@ -697,7 +722,7 @@ TEST(TestDenseUnionScalar, Basics) {
 
   // test Array.GetScalar
   std::vector<std::shared_ptr<Array>> children = {
-      ArrayFromJSON(utf8(), "[\"alpha\", \"beta\", null]"),
+      ArrayFromJSON(utf8(), R"(["alpha", "beta", null])"),
       ArrayFromJSON(uint64(), "[2, 3]")};
 
   auto type_ids = ArrayFromJSON(int8(), "[0, 1, 0, 0, 1]");

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1068,6 +1068,12 @@ def test_partitioning_factory_dictionary(mockfs):
         expected = pa.array(['xxx'] * 5 + ['yyy'] * 5).dictionary_encode()
         assert actual.equals(expected)
 
+        # ARROW-9345 ensure filtering on the partition field works
+        table = factory.finish().to_table(filter=ds.field('key') == 'xxx')
+        actual = table.column('key').chunk(0)
+        expected = expected.slice(0, 5)
+        assert actual.equals(expected)
+
 
 def test_partitioning_function():
     schema = pa.schema([("year", pa.int16()), ("month", pa.int8())])


### PR DESCRIPTION
Enable casting from Scalar DictionaryScalar, which allows InsertImplicitCasts to convert non-dict scalars embedded in filter expressions.