### PR TITLE
ARROW-9384: [C++] Avoid memory blowup on invalid IPC input

### DIFF
--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -186,7 +186,7 @@ class ConcatenateImpl {
   }
 
   Status Concatenate(std::shared_ptr<ArrayData>* out) && {
-    if (out_->null_count != 0) {
+    if (out_->null_count != 0 && internal::HasValidityBitmap(out_->type->id())) {
       RETURN_NOT_OK(ConcatenateBitmaps(Bitmaps(0), pool_, &out_->buffers[0]));
     }
     RETURN_NOT_OK(VisitTypeInline(*out_->type, this));
@@ -201,7 +201,7 @@ class ConcatenateImpl {
   }
 
   Status Visit(const FixedWidthType& fixed) {
-    // handles numbers, decimal128, fixed_size_binary
+    // Handles numbers, decimal128, fixed_size_binary
     return ConcatenateBuffers(Buffers(1, fixed), pool_).Value(&out_->buffers[1]);
   }
 

--- a/cpp/src/arrow/array/concatenate_test.cc
+++ b/cpp/src/arrow/array/concatenate_test.cc
@@ -144,6 +144,12 @@ TYPED_TEST(PrimitiveConcatenateTest, Primitives) {
   });
 }
 
+TEST_F(ConcatenateTest, NullType) {
+  Check([](int32_t size, double null_probability, std::shared_ptr<Array>* out) {
+    *out = std::make_shared<NullArray>(size);
+  });
+}
+
 TEST_F(ConcatenateTest, StringType) {
   Check([this](int32_t size, double null_probability, std::shared_ptr<Array>* out) {
     *out = rng_.String(size, /*min_length =*/0, /*max_length =*/15, null_probability);


### PR DESCRIPTION
Do not attempt to allocate a null bitmap when concatenating null arrays.
Also add a test for concatenation of null arrays.

Should fix the following issue:
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24014