### PR TITLE
ARROW-8655: [Python][Dataset] Provide helper method to get keys from a partition expression

### DIFF
--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -124,6 +124,17 @@ Status KeyValuePartitioning::VisitKeys(
                  checked_cast<const ScalarExpression*>(rhs)->value());
 }
 
+Result<std::unordered_map<std::string, std::shared_ptr<Scalar>>>
+KeyValuePartitioning::GetKeys(const Expression& expr) {
+  std::unordered_map<std::string, std::shared_ptr<Scalar>> keys;
+  RETURN_NOT_OK(
+      VisitKeys(expr, [&](const std::string& name, const std::shared_ptr<Scalar>& value) {
+        keys.emplace(name, value);
+        return Status::OK();
+      }));
+  return keys;
+}
+
 Status KeyValuePartitioning::SetDefaultValuesFromKeys(const Expression& expr,
                                                       RecordBatchProjector* projector) {
   return KeyValuePartitioning::VisitKeys(

--- a/cpp/src/arrow/dataset/partition.h
+++ b/cpp/src/arrow/dataset/partition.h
@@ -175,6 +175,9 @@ class ARROW_DS_EXPORT KeyValuePartitioning : public Partitioning {
       const std::function<Status(const std::string& name,
                                  const std::shared_ptr<Scalar>& value)>& visitor);
 
+  static Result<std::unordered_map<std::string, std::shared_ptr<Scalar>>> GetKeys(
+      const Expression& expr);
+
   static Status SetDefaultValuesFromKeys(const Expression& expr,
                                          RecordBatchProjector* projector);
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1982,64 +1982,24 @@ cdef class Scanner:
             yield Fragment.wrap(GetResultValue(move(maybe_fragment)))
 
 
-cdef _unwrap_equality(shared_ptr[CExpression] expr):
-    cdef:
-        shared_ptr[CExpression] left_operand, right_operand
-        CCompareOperator comp_op
-        CFieldExpression* field_expr
-        CScalarExpression* scalar_expr
-        c_string field_name
-        Scalar scalar
-
-    comp_expr = <CComparisonExpression*> expr.get()
-    left_operand = comp_expr.left_operand()
-    right_operand = comp_expr.right_operand()
-    assert comp_expr.op() == CCompareOperator_EQUAL
-
-    # get field name
-    assert left_operand.get().type() == CExpressionType_FIELD
-    field_expr = <CFieldExpression*> left_operand.get()
-    field_name = field_expr.name()
-
-    # get scalar
-    assert right_operand.get().type() == CExpressionType_SCALAR
-    scalar_expr = <CScalarExpression*> right_operand.get()
-    scalar = pyarrow_wrap_scalar(scalar_expr.value())
-
-    return (frombytes(field_name), scalar.as_py())
-
-
-cdef _recurse_expressions(shared_ptr[CExpression] expr, list result):
-    cdef:
-        CBinaryExpression* and_expr
-        CComparisonExpression* comp_exp
-        shared_ptr[CExpression] left_operand, right_operand
-
-    typ = expr.get().type()
-
-    if typ == CExpressionType_AND:
-        and_expr = <CBinaryExpression*> expr.get()
-        left_operand = and_expr.left_operand()
-        right_operand = and_expr.right_operand()
-        _recurse_expressions(left_operand, result)
-        _recurse_expressions(right_operand, result)
-    elif typ == CExpressionType_COMPARISON:
-        result.append(_unwrap_equality(expr))
-    else:
-        return
-
-
-def _unwrap_partition_expression(Expression partition_expression):
+def _get_partition_keys(Expression partition_expression):
     """
-    Convert a partition expression to a list of (field_name, value) tuples.
+    Extract partition keys (equality constraints between a field and a scalar)
+    from an expression as a dict mapping the field's name to its value.
+
+    NB: All expressions yielded by a HivePartitioning or DirectoryPartitioning
+    will be conjunctions of equality conditions and are accessible through this
+    function. Other subexpressions will be ignored.
 
     For example, an expression of
     <pyarrow.dataset.Expression ((part == A:string) and (year == 2016:int32))>
-    is converted to [('part', 'a'), ('year', 2016)]
+    is converted to {'part': 'a', 'year': 2016}
     """
     cdef:
         shared_ptr[CExpression] expr = partition_expression.unwrap()
+        pair[c_string, shared_ptr[CScalar]] name_val
 
-    result = []
-    _recurse_expressions(expr, result)
-    return result
+    return {
+        frombytes(name_val.first): pyarrow_wrap_scalar(name_val.second).as_py()
+        for name_val in GetResultValue(CGetPartitionKeys(deref(expr.get())))
+    }

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -46,7 +46,8 @@ from pyarrow._dataset import (  # noqa
     Scanner,
     ScanTask,
     UnionDataset,
-    UnionDatasetFactory
+    UnionDatasetFactory,
+    _unwrap_partition_expression
 )
 
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -47,7 +47,7 @@ from pyarrow._dataset import (  # noqa
     ScanTask,
     UnionDataset,
     UnionDatasetFactory,
-    _unwrap_partition_expression
+    _get_partition_keys
 )
 
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1696,9 +1696,6 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         shared_ptr[CTable] table()
         shared_ptr[CScalar] scalar()
 
-    enum CCompareOperator "arrow::compute::CompareOperator":
-        CCompareOperator_EQUAL "arrow::compute::CompareOperator::EQUAL"
-
 
 cdef extern from "arrow/python/api.h" namespace "arrow::py":
     # Requires GIL

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1696,6 +1696,9 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         shared_ptr[CTable] table()
         shared_ptr[CScalar] scalar()
 
+    enum CCompareOperator "arrow::compute::CompareOperator":
+        CCompareOperator_EQUAL "arrow::compute::CompareOperator::EQUAL"
+
 
 cdef extern from "arrow/python/api.h" namespace "arrow::py":
     # Requires GIL

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -33,13 +33,6 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
 cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
-    cdef enum CExpressionType "arrow::dataset::ExpressionType::type":
-        CExpressionType_FIELD "arrow::dataset::ExpressionType::type::FIELD"
-        CExpressionType_SCALAR "arrow::dataset::ExpressionType::type::SCALAR"
-        CExpressionType_AND "arrow::dataset::ExpressionType::type::AND"
-        CExpressionType_COMPARISON \
-            "arrow::dataset::ExpressionType::type::COMPARISON"
-
     cdef cppclass CExpression "arrow::dataset::Expression":
         c_bool Equals(const CExpression& other) const
         c_bool Equals(const shared_ptr[CExpression]& other) const
@@ -49,7 +42,6 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             const shared_ptr[CExpression]& given) const
         c_string ToString() const
         shared_ptr[CExpression] Copy() const
-        CExpressionType type() const
 
         const CExpression& In(shared_ptr[CArray]) const
         const CExpression& IsValid() const
@@ -61,26 +53,12 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[shared_ptr[CExpression]] Deserialize(const CBuffer& buffer)
         CResult[shared_ptr[CBuffer]] Serialize() const
 
-    cdef cppclass CBinaryExpression "arrow::dataset::BinaryExpression"(
-            CExpression):
-        const shared_ptr[CExpression]& left_operand() const
-        const shared_ptr[CExpression]& right_operand() const
-
-    cdef cppclass CScalarExpression "arrow::dataset::ScalarExpression"(
-            CExpression):
-        CScalarExpression(const shared_ptr[CScalar]& value)
-        const shared_ptr[CScalar]& value() const
-
-    cdef cppclass CFieldExpression "arrow::dataset::FieldExpression"(
-            CExpression):
-        c_string name() const
-
-    cdef cppclass CComparisonExpression "arrow::dataset::ComparisonExpression"(
-            CBinaryExpression):
-        CCompareOperator op() const
-
     ctypedef vector[shared_ptr[CExpression]] CExpressionVector \
         "arrow::dataset::ExpressionVector"
+
+    cdef cppclass CScalarExpression \
+            "arrow::dataset::ScalarExpression"(CExpression):
+        CScalarExpression(const shared_ptr[CScalar]& value)
 
     cdef shared_ptr[CExpression] CMakeFieldExpression \
         "arrow::dataset::field_ref"(c_string name)
@@ -335,6 +313,10 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         "arrow::dataset::KeyValuePartitioning::SetDefaultValuesFromKeys"(
             const CExpression& partition_expression,
             CRecordBatchProjector* projector)
+
+    cdef CResult[unordered_map[c_string, shared_ptr[CScalar]]] \
+        CGetPartitionKeys "arrow::dataset::KeyValuePartitioning::GetKeys"(
+        const CExpression& partition_expression)
 
     cdef cppclass CFileSystemFactoryOptions \
             "arrow::dataset::FileSystemFactoryOptions":

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -33,6 +33,13 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
 
 cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
+    cdef enum CExpressionType "arrow::dataset::ExpressionType::type":
+        CExpressionType_FIELD "arrow::dataset::ExpressionType::type::FIELD"
+        CExpressionType_SCALAR "arrow::dataset::ExpressionType::type::SCALAR"
+        CExpressionType_AND "arrow::dataset::ExpressionType::type::AND"
+        CExpressionType_COMPARISON \
+            "arrow::dataset::ExpressionType::type::COMPARISON"
+
     cdef cppclass CExpression "arrow::dataset::Expression":
         c_bool Equals(const CExpression& other) const
         c_bool Equals(const shared_ptr[CExpression]& other) const
@@ -42,6 +49,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             const shared_ptr[CExpression]& given) const
         c_string ToString() const
         shared_ptr[CExpression] Copy() const
+        CExpressionType type() const
 
         const CExpression& In(shared_ptr[CArray]) const
         const CExpression& IsValid() const
@@ -53,12 +61,26 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[shared_ptr[CExpression]] Deserialize(const CBuffer& buffer)
         CResult[shared_ptr[CBuffer]] Serialize() const
 
+    cdef cppclass CBinaryExpression "arrow::dataset::BinaryExpression"(
+            CExpression):
+        const shared_ptr[CExpression]& left_operand() const
+        const shared_ptr[CExpression]& right_operand() const
+
+    cdef cppclass CScalarExpression "arrow::dataset::ScalarExpression"(
+            CExpression):
+        CScalarExpression(const shared_ptr[CScalar]& value)
+        const shared_ptr[CScalar]& value() const
+
+    cdef cppclass CFieldExpression "arrow::dataset::FieldExpression"(
+            CExpression):
+        c_string name() const
+
+    cdef cppclass CComparisonExpression "arrow::dataset::ComparisonExpression"(
+            CBinaryExpression):
+        CCompareOperator op() const
+
     ctypedef vector[shared_ptr[CExpression]] CExpressionVector \
         "arrow::dataset::ExpressionVector"
-
-    cdef cppclass CScalarExpression \
-            "arrow::dataset::ScalarExpression"(CExpression):
-        CScalarExpression(const shared_ptr[CScalar]& value)
 
     cdef shared_ptr[CExpression] CMakeFieldExpression \
         "arrow::dataset::field_ref"(c_string name)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -471,6 +471,16 @@ def test_expression_construction():
         field != {1}
 
 
+def test_partition_keys():
+    a, b, c = [ds.field(f) == f for f in 'abc']
+    assert ds._get_partition_keys(a) == {'a': 'a'}
+    assert ds._get_partition_keys(a & b & c) == {f: f for f in 'abc'}
+
+    nope = ds.field('d') >= 3
+    assert ds._get_partition_keys(nope) == {}
+    assert ds._get_partition_keys(a & nope) == {'a': 'a'}
+
+
 def test_parquet_read_options():
     opts1 = ds.ParquetReadOptions()
     opts2 = ds.ParquetReadOptions(buffer_size=4096,


### PR DESCRIPTION
Not an actual proper fix for ARROW-8655, but it can provide a workaround for now to retrieve the partition fields' name and value from the `partition_expression`