### PR TITLE
ARROW-9380: [C++] Fix Filter crashes and bug in kernels with NullHandling::OUTPUT_NOT_NULL

### DIFF
--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -203,6 +203,12 @@ struct ARROW_EXPORT ArrayData {
   /// \brief Return null count, or compute and set it if it's not known
   int64_t GetNullCount() const;
 
+  bool MayHaveNulls() const {
+    // If an ArrayData is slightly malformed it may have kUnknownNullCount set
+    // but no buffer
+    return null_count.load() != 0 && buffers[0] != NULLPTR;
+  }
+
   std::shared_ptr<DataType> type;
   int64_t length;
   mutable std::atomic<int64_t> null_count;

--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -141,6 +141,8 @@ class ARROW_EXPORT Function {
         arity_(arity),
         default_options_(default_options) {}
 
+  Status CheckArity(int passed_num_args) const;
+
   std::string name_;
   Function::Kind kind_;
   Arity arity_;

--- a/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity_test.cc
@@ -76,6 +76,12 @@ TEST_F(TestValidityKernels, ArrayIsNull) {
                    "[true, false, false, true]");
 }
 
+TEST_F(TestValidityKernels, IsNullSetsZeroNullCount) {
+  auto arr = ArrayFromJSON(int32(), "[1, 2, 3, 4]");
+  std::shared_ptr<ArrayData> result = (*IsNull(arr)).array();
+  ASSERT_EQ(result->null_count, 0);
+}
+
 TEST_F(TestValidityKernels, ScalarIsNull) {
   CheckScalarUnary("is_null", MakeScalar(19.7), MakeScalar(false));
   CheckScalarUnary("is_null", MakeNullScalar(float64()), MakeScalar(true));

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -61,7 +61,8 @@ namespace internal {
 int64_t GetFilterOutputSize(const ArrayData& filter,
                             FilterOptions::NullSelectionBehavior null_selection) {
   int64_t output_size = 0;
-  if (filter.null_count.load() != 0) {
+
+  if (filter.MayHaveNulls()) {
     const uint8_t* filter_is_valid = filter.buffers[0]->data();
     BinaryBitBlockCounter bit_counter(filter.buffers[1]->data(), filter.offset,
                                       filter_is_valid, filter.offset, filter.length);
@@ -101,7 +102,7 @@ Result<std::shared_ptr<ArrayData>> GetTakeIndicesImpl(
 
   // The current position taking the filter offset into account
   int64_t position_with_offset = filter.offset;
-  if (filter.null_count != 0) {
+  if (filter.MayHaveNulls()) {
     // The filter may have nulls, so we scan the validity bitmap and the filter
     // data bitmap together, branching on the null selection type.
     const uint8_t* filter_is_valid = filter.buffers[0]->data();
@@ -1294,7 +1295,7 @@ struct Selection {
     OptionalBitIndexer indices_is_valid(selection->buffers[0], selection->offset);
     OptionalBitIndexer values_is_valid(values->buffers[0], values->offset);
 
-    const bool values_have_nulls = values->null_count.load() != 0;
+    const bool values_have_nulls = values->MayHaveNulls();
     OptionalBitBlockCounter bit_counter(is_valid, selection->offset, selection->length);
     int64_t position = 0;
     while (position < selection->length) {

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -417,6 +417,18 @@ TYPED_TEST(TestFilterKernelWithNumeric, ScalarInRangeAndFilterRandomNumeric) {
   }
 }
 
+TEST(TestFilterKernel, NoValidityBitmapButUnknownNullCount) {
+  auto values = ArrayFromJSON(int32(), "[1, 2, 3, 4]");
+  auto filter = ArrayFromJSON(boolean(), "[true, true, false, true]");
+
+  auto expected = (*Filter(values, filter)).make_array();
+
+  filter->data()->null_count = kUnknownNullCount;
+  auto result = (*Filter(values, filter)).make_array();
+
+  AssertArraysEqual(*expected, *result);
+}
+
 using StringTypes =
     ::testing::Types<BinaryType, StringType, LargeBinaryType, LargeStringType>;
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -798,6 +798,10 @@ TEST_F(TestFilterKernelWithTable, FilterTable) {
                             expected_drop);
 }
 
+TEST(TestFilterMetaFunction, ArityChecking) {
+  ASSERT_RAISES(Invalid, CallFunction("filter", {}));
+}
+
 // ----------------------------------------------------------------------
 // Take tests
 
@@ -1519,6 +1523,10 @@ TEST_F(TestTakeKernelWithTable, TakeTable) {
       "[{\"a\": 4, \"b\": \"eh\"},{\"a\": 1, \"b\": \"\"},{\"a\": null, \"b\": \"yo\"}]"};
   this->AssertTake(schm, table_json, "[3, 1, 0]", expected_310);
   this->AssertChunkedTake(schm, table_json, {"[0, 1]", "[2, 3]"}, table_json);
+}
+
+TEST(TestTakeMetaFunction, ArityChecking) {
+  ASSERT_RAISES(Invalid, CallFunction("take", {}));
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
A few interrelated fixes:

* The `is_null` kernel was returning a slightly malformed `ArrayData` with the null_count set to -1 even though the validity bitmap is null.
* Adds `ArrayData::MayHaveNulls` function to help with checking for the above problem
* Make filter implementation robust to the previous bullet point (no validity bitmap but atomic null count non-zero)
* Argument arity was not being checked in metafunctions, so this is now checked in a single place at `MetaFunction::Execute`