### PR TITLE
ARROW-9395: [Python] allow configuring MetadataVersion

### DIFF
--- a/cpp/src/arrow/python/flight.cc
+++ b/cpp/src/arrow/python/flight.cc
@@ -231,8 +231,8 @@ Status PyFlightDataStream::Next(FlightPayload* payload) { return stream_->Next(p
 
 PyGeneratorFlightDataStream::PyGeneratorFlightDataStream(
     PyObject* generator, std::shared_ptr<arrow::Schema> schema,
-    PyGeneratorFlightDataStreamCallback callback)
-    : schema_(schema), options_(ipc::IpcWriteOptions::Defaults()), callback_(callback) {
+    PyGeneratorFlightDataStreamCallback callback, const ipc::IpcWriteOptions& options)
+    : schema_(schema), options_(options), callback_(callback) {
   Py_INCREF(generator);
   generator_.reset(generator);
 }

--- a/cpp/src/arrow/python/flight.h
+++ b/cpp/src/arrow/python/flight.h
@@ -319,7 +319,8 @@ class ARROW_PYFLIGHT_EXPORT PyGeneratorFlightDataStream
   /// Must only be called while holding the GIL.
   explicit PyGeneratorFlightDataStream(PyObject* generator,
                                        std::shared_ptr<arrow::Schema> schema,
-                                       PyGeneratorFlightDataStreamCallback callback);
+                                       PyGeneratorFlightDataStreamCallback callback,
+                                       const ipc::IpcWriteOptions& options);
   std::shared_ptr<Schema> schema() override;
   Status GetSchemaPayload(arrow::flight::FlightPayload* payload) override;
   Status Next(arrow::flight::FlightPayload* payload) override;

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1303,6 +1303,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         int32_t alignment
         c_bool write_legacy_ipc_format
         CMemoryPool* memory_pool
+        CMetadataVersion metadata_version
 
         @staticmethod
         CIpcWriteOptions Defaults()

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -153,7 +153,8 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
 
     cdef cppclass CMetadataRecordBatchWriter \
             " arrow::flight::MetadataRecordBatchWriter"(CRecordBatchWriter):
-        CStatus Begin(shared_ptr[CSchema] schema)
+        CStatus Begin(shared_ptr[CSchema] schema,
+                      const CIpcWriteOptions& options)
         CStatus WriteMetadata(shared_ptr[CBuffer] app_metadata)
         CStatus WriteWithMetadata(const CRecordBatch& batch,
                                   shared_ptr[CBuffer] app_metadata)
@@ -176,7 +177,8 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
 
     cdef cppclass CRecordBatchStream \
             " arrow::flight::RecordBatchStream"(CFlightDataStream):
-        CRecordBatchStream(shared_ptr[CRecordBatchReader]& reader)
+        CRecordBatchStream(shared_ptr[CRecordBatchReader]& reader,
+                           const CIpcWriteOptions& options)
 
     cdef cppclass CFlightMetadataReader" arrow::flight::FlightMetadataReader":
         CStatus ReadMetadata(shared_ptr[CBuffer]* out)
@@ -213,6 +215,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
     cdef cppclass CFlightCallOptions" arrow::flight::FlightCallOptions":
         CFlightCallOptions()
         CTimeoutDuration timeout
+        CIpcWriteOptions write_options
 
     cdef cppclass CCertKeyPair" arrow::flight::CertKeyPair":
         CCertKeyPair()
@@ -472,7 +475,8 @@ cdef extern from "arrow/python/flight.h" namespace "arrow::py::flight" nogil:
             (CFlightDataStream):
         CPyGeneratorFlightDataStream(object generator,
                                      shared_ptr[CSchema] schema,
-                                     function[cb_data_stream_next] callback)
+                                     function[cb_data_stream_next] callback,
+                                     const CIpcWriteOptions& options)
 
     cdef cppclass PyServerMiddlewareVtable\
             " arrow::py::flight::PyServerMiddleware::Vtable":

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -17,10 +17,12 @@
 
 # Arrow file and stream reader/writer classes, and other messaging tools
 
+import os
 
 import pyarrow as pa
 
-from pyarrow.lib import (Message, MessageReader, MetadataVersion,  # noqa
+from pyarrow.lib import (IpcWriteOptions, Message, MessageReader,  # noqa
+                         MetadataVersion,
                          read_message, read_record_batch, read_schema,
                          read_tensor, write_tensor,
                          get_record_batch_size, get_tensor_size)
@@ -69,7 +71,18 @@ sink : str, pyarrow.NativeFile, or file-like Python object
     Either a file path, or a writable file object.
 schema : pyarrow.Schema
     The Arrow schema for data to be written to the file.
+options : pyarrow.ipc.IpcWriteOptions
+    Options for IPC serialization.
+
+    If None, default values will be used: the legacy format will not
+    be used unless overridden by setting the environment variable
+    ARROW_PRE_0_15_IPC_FORMAT=1, and the V5 metadata version will be
+    used unless overridden by setting the environment variable
+    ARROW_PRE_1_0_METADATA_VERSION=1.
 use_legacy_format : bool, default None
+    Deprecated in favor of setting options. Cannot be provided with
+    options.
+
     If None, False will be used unless this default is overridden by
     setting the environment variable ARROW_PRE_0_15_IPC_FORMAT=1"""
 
@@ -79,9 +92,9 @@ class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
 
 {}""".format(_ipc_writer_class_doc)
 
-    def __init__(self, sink, schema, use_legacy_format=None):
-        use_legacy_format = _get_legacy_format_default(use_legacy_format)
-        self._open(sink, schema, use_legacy_format=use_legacy_format)
+    def __init__(self, sink, schema, use_legacy_format=None, options=None):
+        options = _get_legacy_format_default(use_legacy_format, options)
+        self._open(sink, schema, options=options)
 
 
 class RecordBatchFileReader(lib._RecordBatchFileReader, _ReadPandasOption):
@@ -107,22 +120,32 @@ class RecordBatchFileWriter(lib._RecordBatchFileWriter):
 
 {}""".format(_ipc_writer_class_doc)
 
-    def __init__(self, sink, schema, use_legacy_format=None):
-        use_legacy_format = _get_legacy_format_default(use_legacy_format)
-        self._open(sink, schema, use_legacy_format=use_legacy_format)
+    def __init__(self, sink, schema, use_legacy_format=None, options=None):
+        options = _get_legacy_format_default(use_legacy_format, options)
+        self._open(sink, schema, options=options)
 
 
-def _get_legacy_format_default(use_legacy_format):
+def _get_legacy_format_default(use_legacy_format, options):
+    if use_legacy_format is not None and options is not None:
+        raise ValueError(
+            "Can provide at most one of options and use_legacy_format")
+    elif options:
+        return options
+
+    metadata_version = MetadataVersion.V5
     if use_legacy_format is None:
-        import os
-        return bool(int(os.environ.get('ARROW_PRE_0_15_IPC_FORMAT', '0')))
-    else:
-        return use_legacy_format
+        use_legacy_format = \
+            bool(int(os.environ.get('ARROW_PRE_0_15_IPC_FORMAT', '0')))
+    if bool(int(os.environ.get('ARROW_PRE_1_0_METADATA_VERSION', '0'))):
+        metadata_version = MetadataVersion.V4
+    return IpcWriteOptions(use_legacy_format=use_legacy_format,
+                           metadata_version=metadata_version)
 
 
-def new_stream(sink, schema, use_legacy_format=None):
+def new_stream(sink, schema, use_legacy_format=None, options=None):
     return RecordBatchStreamWriter(sink, schema,
-                                   use_legacy_format=use_legacy_format)
+                                   use_legacy_format=use_legacy_format,
+                                   options=options)
 
 
 new_stream.__doc__ = """\
@@ -147,9 +170,10 @@ def open_stream(source):
     return RecordBatchStreamReader(source)
 
 
-def new_file(sink, schema, use_legacy_format=None):
+def new_file(sink, schema, use_legacy_format=None, options=None):
     return RecordBatchFileWriter(sink, schema,
-                                 use_legacy_format=use_legacy_format)
+                                 use_legacy_format=use_legacy_format,
+                                 options=options)
 
 
 new_file.__doc__ = """\

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -30,6 +30,12 @@ cdef extern from "Python.h":
 
 cdef int check_status(const CStatus& status) nogil except -1
 
+
+cdef class IpcWriteOptions:
+    cdef:
+        CIpcWriteOptions c_options
+
+
 cdef class Message:
     cdef:
         unique_ptr[CMessage] message

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -124,13 +124,14 @@ class ConstantFlightServer(FlightServerBase):
 
     CRITERIA = b"the expected criteria"
 
-    def __init__(self, location=None, **kwargs):
+    def __init__(self, location=None, options=None, **kwargs):
         super().__init__(location, **kwargs)
         # Ticket -> Table
         self.table_factories = {
             b'ints': simple_ints_table,
             b'dicts': simple_dicts_table,
         }
+        self.options = options
 
     def list_flights(self, context, criteria):
         if criteria == self.CRITERIA:
@@ -145,11 +146,15 @@ class ConstantFlightServer(FlightServerBase):
         # Return a fresh table, so that Flight is the only one keeping a
         # reference.
         table = self.table_factories[ticket.ticket]()
-        return flight.RecordBatchStream(table)
+        return flight.RecordBatchStream(table, options=self.options)
 
 
 class MetadataFlightServer(FlightServerBase):
     """A Flight server that numbers incoming/outgoing data."""
+
+    def __init__(self, options=None, **kwargs):
+        super().__init__(**kwargs)
+        self.options = options
 
     def do_get(self, context, ticket):
         data = [
@@ -158,7 +163,8 @@ class MetadataFlightServer(FlightServerBase):
         table = pa.Table.from_arrays(data, names=['a'])
         return flight.GeneratorStream(
             table.schema,
-            self.number_batches(table))
+            self.number_batches(table),
+            options=self.options)
 
     def do_put(self, context, descriptor, reader, writer):
         counter = 0
@@ -351,6 +357,10 @@ class ErrorFlightServer(FlightServerBase):
 class ExchangeFlightServer(FlightServerBase):
     """A server for testing DoExchange."""
 
+    def __init__(self, options=None, **kwargs):
+        super().__init__(**kwargs)
+        self.options = options
+
     def do_exchange(self, context, descriptor, reader, writer):
         if descriptor.descriptor_type != flight.DescriptorType.CMD:
             raise pa.ArrowInvalid("Must provide a command descriptor")
@@ -388,7 +398,7 @@ class ExchangeFlightServer(FlightServerBase):
         started = False
         for chunk in reader:
             if not started and chunk.data:
-                writer.begin(chunk.data.schema)
+                writer.begin(chunk.data.schema, options=self.options)
                 started = True
             if chunk.app_metadata and chunk.data:
                 writer.write_with_metadata(chunk.data, chunk.app_metadata)
@@ -685,6 +695,13 @@ def test_flight_do_get_ints():
     table = simple_ints_table()
 
     with ConstantFlightServer() as server:
+        client = flight.connect(('localhost', server.port))
+        data = client.do_get(flight.Ticket(b'ints')).read_all()
+        assert data.equals(table)
+
+    options = pa.ipc.IpcWriteOptions(
+        metadata_version=pa.ipc.MetadataVersion.V4)
+    with ConstantFlightServer(options=options) as server:
         client = flight.connect(('localhost', server.port))
         data = client.do_get(flight.Ticket(b'ints')).read_all()
         assert data.equals(table)
@@ -1055,6 +1072,19 @@ def test_flight_do_get_metadata():
         assert data.equals(table)
 
 
+def test_flight_do_get_metadata_v4():
+    """Try a simple do_get call with V4 metadata version."""
+    table = pa.Table.from_arrays(
+        [pa.array([-10, -5, 0, 5, 10])], names=['a'])
+    options = pa.ipc.IpcWriteOptions(
+        metadata_version=pa.ipc.MetadataVersion.V4)
+    with MetadataFlightServer(options=options) as server:
+        client = FlightClient(('localhost', server.port))
+        reader = client.do_get(flight.Ticket(b''))
+        data = reader.read_all()
+        assert data.equals(table)
+
+
 def test_flight_do_put_metadata():
     """Try a simple do_put call with metadata."""
     data = [
@@ -1420,6 +1450,30 @@ def test_doexchange_echo():
                 chunk = reader.read_chunk()
                 assert chunk.data == batch
                 assert chunk.app_metadata == buf
+
+
+def test_doexchange_echo_v4():
+    """Try a DoExchange echo server using the V4 metadata version."""
+    data = pa.Table.from_arrays([
+        pa.array(range(0, 10 * 1024))
+    ], names=["a"])
+    batches = data.to_batches(max_chunksize=512)
+
+    options = pa.ipc.IpcWriteOptions(
+        metadata_version=pa.ipc.MetadataVersion.V4)
+    with ExchangeFlightServer(options=options) as server:
+        client = FlightClient(("localhost", server.port))
+        descriptor = flight.FlightDescriptor.for_command(b"echo")
+        writer, reader = client.do_exchange(descriptor)
+        with writer:
+            # Now write data without metadata.
+            writer.begin(data.schema, options=options)
+            for batch in batches:
+                writer.write_batch(batch)
+                assert reader.schema == data.schema
+                chunk = reader.read_chunk()
+                assert chunk.data == batch
+                assert chunk.app_metadata is None
 
 
 def test_doexchange_transform():


### PR DESCRIPTION
Adds the environment variable `ARROW_PRE_1_0_METADATA_VERSION`. Can rename it to anything else.

I opted to remove `use_legacy_format` in underscore APIs, but kept it in public APIs.

Also makes the necessary changes to Flight.