### PR TITLE
ARROW-9408: [Integration] Fix Windows numpy datagen issues

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -181,7 +181,7 @@ class IntegerField(PrimitiveField):
 
     def generate_range(self, size, lower, upper, name=None,
                        include_extremes=False):
-        values = np.random.randint(lower, upper, size=size)
+        values = np.random.randint(lower, upper, size=size, dtype=np.int64)
         if include_extremes and size >= 2:
             values[:2] = [lower, upper]
         values = list(map(int if self.bit_width < 64 else str, values))


### PR DESCRIPTION
We found that the integer range check when generating integration data doesn't work in Windows because the default C integers that numpy uses are 32-bit by default in Windows.

This fixes that issue by forcing 64-bit integers.