### PR TITLE
ARROW-9415: [C++] Arrow does not compile on Power9

### DIFF
--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -49,6 +49,13 @@
 
 #include "arrow/vendored/xxhash.h"  // IWYU pragma: keep
 
+// ARROW-9415: See https://github.com/Cyan4973/xxHash/pull/426. altivec.h on
+// gcc leaks the "bool" define which causes a compilation failure on Power9
+// architecture.
+#if XXH_VECTOR == XXH_VSX  // altivec
+#undef bool
+#endif
+
 namespace arrow {
 namespace internal {
 

--- a/cpp/src/arrow/vendored/xxhash/xxh3.h
+++ b/cpp/src/arrow/vendored/xxhash/xxh3.h
@@ -126,6 +126,7 @@
 #if XXH_VECTOR == XXH_VSX
 #  include <altivec.h>
 #  undef vector
+#  undef bool
 typedef __vector unsigned long long U64x2;
 typedef __vector unsigned U32x4;
 /* Adapted from https://github.com/google/highwayhash/blob/master/highwayhash/hh_vsx.h. */

--- a/cpp/src/arrow/vendored/xxhash/xxh3.h
+++ b/cpp/src/arrow/vendored/xxhash/xxh3.h
@@ -126,7 +126,6 @@
 #if XXH_VECTOR == XXH_VSX
 #  include <altivec.h>
 #  undef vector
-#  undef bool
 typedef __vector unsigned long long U64x2;
 typedef __vector unsigned U32x4;
 /* Adapted from https://github.com/google/highwayhash/blob/master/highwayhash/hh_vsx.h. */


### PR DESCRIPTION
Fix build on Power9

This small change addresses the following build error:
```[ 20%] Building CXX object src/arrow/CMakeFiles/arrow_objlib.dir/array/builder_nested.cc.o
In file included from /ccs/proj/stf006/glaser/rapids/arrow/cpp/src/arrow/array/dict_internal.h:35:0,
                 from /ccs/proj/stf006/glaser/rapids/arrow/cpp/src/arrow/array/builder_dict.cc:22:
/ccs/proj/stf006/glaser/rapids/arrow/cpp/src/arrow/util/hashing.h: In static member function 'static uint32_t arrow::internal::SmallScalarTraits<__vector(4) __bool int>::AsIndex(__vector(4) __bool int)':
/ccs/proj/stf006/glaser/rapids/arrow/cpp/src/arrow/util/hashing.h:495:60: error: cannot convert '__vector(4) int' to 'uint32_t {aka unsigned int}' in return
   static uint32_t AsIndex(bool value) { return value ? 1 : 0; }                                                            ^
```

The problem is caused by `bool` being defined in altivec.h 