### PR TITLE
ARROW-8261: [Rust-DataFusion] Made limit accept integers and no longer accept expressions.

### DIFF
--- a/rust/datafusion/src/execution/table_impl.rs
+++ b/rust/datafusion/src/execution/table_impl.rs
@@ -23,8 +23,8 @@ use crate::arrow::datatypes::DataType;
 use crate::arrow::record_batch::RecordBatch;
 use crate::error::{ExecutionError, Result};
 use crate::execution::context::ExecutionContext;
+use crate::logicalplan::LogicalPlanBuilder;
 use crate::logicalplan::{Expr, LogicalPlan};
-use crate::logicalplan::{LogicalPlanBuilder, ScalarValue};
 use crate::table::*;
 use arrow::datatypes::Schema;
 
@@ -83,10 +83,8 @@ impl Table for TableImpl {
     }
 
     /// Limit the number of rows
-    fn limit(&self, n: u32) -> Result<Arc<dyn Table>> {
-        let plan = LogicalPlanBuilder::from(&self.plan)
-            .limit(Expr::Literal(ScalarValue::UInt32(n)))?
-            .build()?;
+    fn limit(&self, n: usize) -> Result<Arc<dyn Table>> {
+        let plan = LogicalPlanBuilder::from(&self.plan).limit(n)?.build()?;
         Ok(Arc::new(TableImpl::new(&plan)))
     }
 

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -586,8 +586,8 @@ pub enum LogicalPlan {
     },
     /// Represents the maximum number of records to return
     Limit {
-        /// The expression
-        expr: Expr,
+        /// The limit
+        n: usize,
         /// The logical plan
         input: Box<LogicalPlan>,
         /// The schema description
@@ -713,11 +713,9 @@ impl LogicalPlan {
                 input.fmt_with_indent(f, indent + 1)
             }
             LogicalPlan::Limit {
-                ref input,
-                ref expr,
-                ..
+                ref input, ref n, ..
             } => {
-                write!(f, "Limit: {:?}", expr)?;
+                write!(f, "Limit: {}", n)?;
                 input.fmt_with_indent(f, indent + 1)
             }
             LogicalPlan::CreateExternalTable { ref name, .. } => {
@@ -916,9 +914,9 @@ impl LogicalPlanBuilder {
     }
 
     /// Apply a limit
-    pub fn limit(&self, expr: Expr) -> Result<Self> {
+    pub fn limit(&self, n: usize) -> Result<Self> {
         Ok(Self::from(&LogicalPlan::Limit {
-            expr,
+            n,
             input: Box::new(self.plan.clone()),
             schema: self.plan.schema().clone(),
         }))

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -215,16 +215,14 @@ impl<S: SchemaProvider> SqlToRel<S> {
     ) -> Result<LogicalPlan> {
         match *limit {
             Some(ref limit_expr) => {
-                let limit_rex = match self.sql_to_rex(&limit_expr, &input.schema())? {
-                    Expr::Literal(ScalarValue::Int64(n)) => {
-                        Ok(Expr::Literal(ScalarValue::UInt32(n as u32)))
-                    }
+                let n = match self.sql_to_rex(&limit_expr, &input.schema())? {
+                    Expr::Literal(ScalarValue::Int64(n)) => Ok(n as usize),
                     _ => Err(ExecutionError::General(
                         "Unexpected expression for LIMIT clause".to_string(),
                     )),
                 }?;
 
-                LogicalPlanBuilder::from(&input).limit(limit_rex)?.build()
+                LogicalPlanBuilder::from(&input).limit(n)?.build()
             }
             _ => Ok(input.clone()),
         }

--- a/rust/datafusion/src/table.rs
+++ b/rust/datafusion/src/table.rs
@@ -44,7 +44,7 @@ pub trait Table {
     ) -> Result<Arc<dyn Table>>;
 
     /// limit the number of rows
-    fn limit(&self, n: u32) -> Result<Arc<dyn Table>>;
+    fn limit(&self, n: usize) -> Result<Arc<dyn Table>>;
 
     /// Return the logical plan
     fn to_logical_plan(&self) -> LogicalPlan;


### PR DESCRIPTION
Also made the type consistent across the project (=usize).

This change is backward incompatible.

The rational for this change is that limit() is almost never called
with an expression in real world cases, since it is used to limit
results before an action.