### PR TITLE
ARROW-9417: [C++] Write length in IPC message by using little-endian 

### DIFF
--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -131,6 +131,11 @@ TEST_P(TestMessage, SerializeTo) {
     ASSERT_EQ(BitUtil::RoundUp(metadata->size() + prefix_size, alignment) + body_length,
               output_length);
     ASSERT_OK_AND_EQ(output_length, stream->Tell());
+    ASSERT_OK_AND_ASSIGN(auto buffer, stream->Finish());
+    // chech whether length is written in little endian
+    auto buffer_ptr = buffer.get()->data();
+    ASSERT_EQ(output_length - body_length - prefix_size,
+              BitUtil::FromLittleEndian(*(uint32_t *)(buffer_ptr + 4)));
   };
 
   CheckWithAlignment(8);
@@ -1504,6 +1509,7 @@ TEST(TestIpcFileFormat, FooterMetaData) {
   ASSERT_OK(helper.Finish());
 
   ASSERT_OK_AND_ASSIGN(auto out_metadata, helper.ReadFooterMetadata());
+
   ASSERT_TRUE(out_metadata->Equals(*metadata));
 }
 

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -1509,7 +1509,6 @@ TEST(TestIpcFileFormat, FooterMetaData) {
   ASSERT_OK(helper.Finish());
 
   ASSERT_OK_AND_ASSIGN(auto out_metadata, helper.ReadFooterMetadata());
-
   ASSERT_TRUE(out_metadata->Equals(*metadata));
 }
 

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -135,7 +135,7 @@ TEST_P(TestMessage, SerializeTo) {
     // chech whether length is written in little endian
     auto buffer_ptr = buffer.get()->data();
     ASSERT_EQ(output_length - body_length - prefix_size,
-              BitUtil::FromLittleEndian(*(uint32_t *)(buffer_ptr + 4)));
+              BitUtil::FromLittleEndian(*(uint32_t*)(buffer_ptr + 4)));
   };
 
   CheckWithAlignment(8);

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -979,7 +979,8 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
       return Status::Invalid("Not an Arrow file");
     }
 
-    int32_t footer_length = *reinterpret_cast<const int32_t*>(buffer->data());
+    int32_t footer_length =
+        BitUtil::FromLittleEndian(*reinterpret_cast<const int32_t*>(buffer->data()));
 
     if (footer_length <= 0 || footer_length > footer_offset_ - magic_size * 2 - 4) {
       return Status::Invalid("File is smaller than indicated metadata size");

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -1184,6 +1184,8 @@ class PayloadFileWriter : public internal::IpcPayloadWriter, protected StreamBoo
       return Status::Invalid("Invalid file footer");
     }
 
+    // write footer length in little endian
+    footer_length = BitUtil::ToLittleEndian(footer_length);
     RETURN_NOT_OK(Write(&footer_length, sizeof(int32_t)));
 
     // Write magic bytes to end file


### PR DESCRIPTION
This PR forces to write metadata_length and footer_length in IPC messages by using little-endian to follow [the specification](https://github.com/apache/arrow/blob/master/docs/source/format/Columnar.rst).