### PR TITLE
PARQUET-1882: [C++] Buffered Reads should allow for 0 length

### DIFF
--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -368,7 +368,7 @@ class BufferedInputStream::Impl : public BufferedBase {
 
   Result<int64_t> Read(int64_t nbytes, void* out) {
     if (ARROW_PREDICT_FALSE(nbytes < 0)) {
-      return Status::Invalid("Bytes to read must be positive. Received", nbytes);
+      return Status::Invalid("Bytes to read must be positive. Received:", nbytes);
     }
 
     if (nbytes < buffer_size_) {

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -367,7 +367,9 @@ class BufferedInputStream::Impl : public BufferedBase {
   }
 
   Result<int64_t> Read(int64_t nbytes, void* out) {
-    ARROW_CHECK_GT(nbytes, 0);
+    if (ARROW_PREDICT_FALSE(nbytes < 0)) {
+      return Status::Invalid("Bytes to read must be positive. Received", nbytes);
+    }
 
     if (nbytes < buffer_size_) {
       // Pre-buffer for small reads

--- a/cpp/src/arrow/io/buffered_test.cc
+++ b/cpp/src/arrow/io/buffered_test.cc
@@ -331,6 +331,14 @@ class TestBufferedInputStream : public FileTestFixture<BufferedInputStream> {
   std::shared_ptr<InputStream> raw_;
 };
 
+TEST_F(TestBufferedInputStream, InvalidReads) {
+  const int64_t kBufferSize = 10;
+  MakeExample1(kBufferSize);
+  ASSERT_EQ(kBufferSize, buffered_->buffer_size());
+  std::vector<char> buf(test_data_.size());
+  ASSERT_RAISES(Invalid, buffered_->Read(-1, buf.data()));
+}
+
 TEST_F(TestBufferedInputStream, BasicOperation) {
   const int64_t kBufferSize = 10;
   MakeExample1(kBufferSize);
@@ -342,6 +350,7 @@ TEST_F(TestBufferedInputStream, BasicOperation) {
   ASSERT_EQ(0, buffered_->bytes_buffered());
 
   std::vector<char> buf(test_data_.size());
+  ASSERT_OK_AND_EQ(0, buffered_->Read(0, buf.data()));
   ASSERT_OK_AND_EQ(4, buffered_->Read(4, buf.data()));
   ASSERT_EQ(0, memcmp(buf.data(), test_data_.data(), 4));
 

--- a/cpp/src/parquet/file_serialize_test.cc
+++ b/cpp/src/parquet/file_serialize_test.cc
@@ -400,46 +400,44 @@ TEST(TestBufferedRowGroupWriter, MultiPageDisabledDictionary) {
   }
 }
 
-TEST(Roundtrip, AllNulls) {
-  auto primitiveNode =
+TEST(ParquetRoundtrip, AllNulls) {
+  auto primitive_node =
       PrimitiveNode::Make("nulls", Repetition::OPTIONAL, nullptr, Type::INT32);
-  schema::NodeVector columns({primitiveNode});
+  schema::NodeVector columns({primitive_node});
 
-  auto rootNode = GroupNode::Make("root", Repetition::REQUIRED, columns, nullptr);
+  auto root_node = GroupNode::Make("root", Repetition::REQUIRED, columns, nullptr);
 
   auto sink = CreateOutputStream();
 
-  auto fileWriter =
-      ParquetFileWriter::Open(sink, std::static_pointer_cast<GroupNode>(rootNode));
-  auto rowGroupWriter = fileWriter->AppendRowGroup();
-  auto columnWriter = static_cast<Int32Writer*>(rowGroupWriter->NextColumn());
+  auto file_writer =
+      ParquetFileWriter::Open(sink, std::static_pointer_cast<GroupNode>(root_node));
+  auto row_group_writer = file_writer->AppendRowGroup();
+  auto column_writer = static_cast<Int32Writer*>(row_group_writer->NextColumn());
 
   int32_t values[3];
-  int16_t defLevels[] = {0, 0, 0};
+  int16_t def_levels[] = {0, 0, 0};
 
-  columnWriter->WriteBatch(3, defLevels, nullptr, values);
+  column_writer->WriteBatch(3, def_levels, nullptr, values);
 
-  columnWriter->Close();
-  rowGroupWriter->Close();
-  fileWriter->Close();
+  column_writer->Close();
+  row_group_writer->Close();
+  file_writer->Close();
 
   ReaderProperties props = default_reader_properties();
   props.enable_buffered_stream();
   PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
 
   auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
-  auto file_reader = ParquetFileReader::Open(source);
+  auto file_reader = ParquetFileReader::Open(source, props);
+  auto row_group_reader = file_reader->RowGroup(0);
+  auto column_reader = std::static_pointer_cast<Int32Reader>(row_group_reader->Column(0));
 
-  auto fileReader = ParquetFileReader::Open(source, props);
-  auto rowGroupReader = fileReader->RowGroup(0);
-  auto columnReader = std::static_pointer_cast<Int32Reader>(rowGroupReader->Column(0));
-
-  int64_t valuesRead;
-  defLevels[0] = -1;
-  defLevels[1] = -1;
-  defLevels[2] = -1;
-  columnReader->ReadBatch(3, defLevels, nullptr, values, &valuesRead);
-  EXPECT_THAT(defLevels, ElementsAre(0, 0, 0));
+  int64_t values_read;
+  def_levels[0] = -1;
+  def_levels[1] = -1;
+  def_levels[2] = -1;
+  column_reader->ReadBatch(3, def_levels, nullptr, values, &values_read);
+  EXPECT_THAT(def_levels, ElementsAre(0, 0, 0));
 }
 
 }  // namespace test


### PR DESCRIPTION
Also, there doessn't seem like a great reason to crash when non-zero.
