### PR TITLE
ARROW-9418 [R] nyc-taxi Parquet files not downloaded in binary mode on Windows

### DIFF
--- a/r/vignettes/dataset.Rmd
+++ b/r/vignettes/dataset.Rmd
@@ -48,7 +48,8 @@ for (year in 2009:2019) {
     dir.create(file.path("nyc-taxi", year, month))
     download.file(
       paste(bucket, year, month, "data.parquet", sep = "/"),
-      file.path("nyc-taxi", year, month, "data.parquet")
+      file.path("nyc-taxi", year, month, "data.parquet"),
+      mode = 'wb'
     )
   }
 }


### PR DESCRIPTION
According to https://stat.ethz.ch/R-manual/R-devel/library/utils/html/download.file.html
"On Windows, if mode is not supplied (missing()) and url ends in one of .gz, .bz2, .xz, .tgz, .zip, .rda, .rds or .RData, mode = "wb" is set such that a binary transfer is done to help unwary users.
Code written to download binary files must use mode = "wb" (or "ab"), but the problems incurred by a text transfer will only be seen on Windows."
This minor change allows the download code to work on Windows.