### PR TITLE
ARROW-9425: [Rust][DataFusion] Made ExecutionContext sharable and sync

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -63,7 +63,7 @@ use sqlparser::sqlast::{SQLColumnDef, SQLType};
 
 /// Execution context for registering data sources and executing queries
 pub struct ExecutionContext {
-    datasources: HashMap<String, Box<dyn TableProvider>>,
+    datasources: HashMap<String, Box<dyn TableProvider + Send + Sync>>,
     scalar_functions: HashMap<String, Box<ScalarFunction>>,
 }
 
@@ -236,7 +236,11 @@ impl ExecutionContext {
     }
 
     /// Register a table so that it can be queried from SQL
-    pub fn register_table(&mut self, name: &str, provider: Box<dyn TableProvider>) {
+    pub fn register_table(
+        &mut self,
+        name: &str,
+        provider: Box<dyn TableProvider + Send + Sync>,
+    ) {
         self.datasources.insert(name.to_string(), provider);
     }
 
@@ -643,7 +647,7 @@ impl ExecutionContext {
 }
 
 struct ExecutionContextSchemaProvider<'a> {
-    datasources: &'a HashMap<String, Box<dyn TableProvider>>,
+    datasources: &'a HashMap<String, Box<dyn TableProvider + Send + Sync>>,
     scalar_functions: &'a HashMap<String, Box<ScalarFunction>>,
 }
 


### PR DESCRIPTION
This is required when the library is used by other applications that leverage a long-living context.