### PR TITLE
ARROW-8574: [Rust] Implement Debug for all plain types

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -2149,6 +2149,7 @@ pub struct DictionaryArray<K: ArrowPrimitiveType> {
     is_ordered: bool,
 }
 
+#[derive(Debug)]
 pub struct NullableIter<'a, T> {
     data: &'a ArrayDataRef, // TODO: Use a pointer to the null bitmap.
     ptr: *const T,

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -22,6 +22,7 @@
 
 use std::any::Any;
 use std::collections::HashMap;
+use std::fmt;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::mem;
@@ -85,6 +86,7 @@ pub(crate) fn builder_to_mutable_buffer<T: ArrowPrimitiveType>(
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Debug)]
 pub struct BufferBuilder<T: ArrowPrimitiveType> {
     buffer: MutableBuffer,
     len: usize,
@@ -455,6 +457,7 @@ pub trait ArrayBuilder: Any {
 }
 
 ///  Array builder for fixed-width primitive types
+#[derive(Debug)]
 pub struct PrimitiveBuilder<T: ArrowPrimitiveType> {
     values_builder: BufferBuilder<T>,
     bitmap_builder: BooleanBufferBuilder,
@@ -650,6 +653,7 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
 }
 
 ///  Array builder for `ListArray`
+#[derive(Debug)]
 pub struct ListBuilder<T: ArrayBuilder> {
     offsets_builder: Int32BufferBuilder,
     bitmap_builder: BooleanBufferBuilder,
@@ -854,6 +858,7 @@ where
 }
 
 ///  Array builder for `ListArray`
+#[derive(Debug)]
 pub struct LargeListBuilder<T: ArrayBuilder> {
     offsets_builder: Int64BufferBuilder,
     bitmap_builder: BooleanBufferBuilder,
@@ -1059,6 +1064,7 @@ where
 }
 
 ///  Array builder for `ListArray`
+#[derive(Debug)]
 pub struct FixedSizeListBuilder<T: ArrayBuilder> {
     bitmap_builder: BooleanBufferBuilder,
     values_builder: T,
@@ -1243,22 +1249,27 @@ where
 }
 
 ///  Array builder for `BinaryArray`
+#[derive(Debug)]
 pub struct BinaryBuilder {
     builder: ListBuilder<UInt8Builder>,
 }
 
+#[derive(Debug)]
 pub struct LargeBinaryBuilder {
     builder: LargeListBuilder<UInt8Builder>,
 }
 
+#[derive(Debug)]
 pub struct StringBuilder {
     builder: ListBuilder<UInt8Builder>,
 }
 
+#[derive(Debug)]
 pub struct LargeStringBuilder {
     builder: LargeListBuilder<UInt8Builder>,
 }
 
+#[derive(Debug)]
 pub struct FixedSizeBinaryBuilder {
     builder: FixedSizeListBuilder<UInt8Builder>,
 }
@@ -1873,6 +1884,17 @@ pub struct StructBuilder {
     len: usize,
 }
 
+impl fmt::Debug for StructBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StructBuilder")
+            .field("fields", &self.fields)
+            .field("field_anys", &self.field_anys)
+            .field("bitmap_builder", &self.bitmap_builder)
+            .field("len", &self.len)
+            .finish()
+    }
+}
+
 impl ArrayBuilder for StructBuilder {
     /// Returns the number of array slots in the builder.
     ///
@@ -2141,6 +2163,7 @@ impl Drop for StructBuilder {
 /// Array builder for `DictionaryArray`. For example to map a set of byte indices
 /// to f32 values. Note that the use of a `HashMap` here will not scale to very large
 /// arrays or result in an ordered dictionary.
+#[derive(Debug)]
 pub struct PrimitiveDictionaryBuilder<K, V>
 where
     K: ArrowPrimitiveType,
@@ -2259,6 +2282,7 @@ where
 /// Array builder for `DictionaryArray`. For example to map a set of byte indices
 /// to f32 values. Note that the use of a `HashMap` here will not scale to very large
 /// arrays or result in an ordered dictionary.
+#[derive(Debug)]
 pub struct StringDictionaryBuilder<K>
 where
     K: ArrowDictionaryKeyType,

--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -162,6 +162,7 @@ impl ArrayData {
 }
 
 /// Builder for `ArrayData` type
+#[derive(Debug)]
 pub struct ArrayDataBuilder {
     data_type: DataType,
     len: usize,

--- a/rust/arrow/src/array/union.rs
+++ b/rust/arrow/src/array/union.rs
@@ -332,6 +332,7 @@ impl fmt::Debug for UnionArray {
 }
 
 /// `FieldData` is a helper struct to track the state of the fields in the `UnionBuilder`.
+#[derive(Debug)]
 struct FieldData {
     /// The type id for this field
     type_id: i8,
@@ -446,6 +447,7 @@ impl FieldData {
 }
 
 /// Builder type for creating a new `UnionArray`.
+#[derive(Debug)]
 pub struct UnionBuilder {
     /// The current number of slots in the array
     len: usize,

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -130,7 +130,7 @@ pub fn sort_to_indices(
 }
 
 /// Options that define how sort kernels should behave
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct SortOptions {
     /// Whether to sort in descending order
     pub descending: bool,
@@ -223,7 +223,7 @@ fn sort_string(
 }
 
 /// One column to be used in lexicographical sort
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SortColumn {
     pub values: ArrayRef,
     pub options: Option<SortOptions>,

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -126,7 +126,7 @@ pub fn take(
 }
 
 /// Options that define how `take` should behave
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TakeOptions {
     /// Perform bounds check before taking indices from values.
     /// If enabled, an `ArrowError` is returned if the indices are out of bounds.

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -43,6 +43,7 @@
 use lazy_static::lazy_static;
 use regex::{Regex, RegexBuilder};
 use std::collections::HashSet;
+use std::fmt;
 use std::fs::File;
 use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::sync::Arc;
@@ -227,6 +228,20 @@ pub struct Reader<R: Read> {
     batch_size: usize,
     /// Current line number, used in error reporting
     line_number: usize,
+}
+
+impl<R> fmt::Debug for Reader<R>
+where
+    R: Read,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Reader")
+            .field("schema", &self.schema)
+            .field("projection", &self.projection)
+            .field("batch_size", &self.batch_size)
+            .field("line_number", &self.line_number)
+            .finish()
+    }
 }
 
 impl<R: Read> Reader<R> {
@@ -434,6 +449,7 @@ impl<R: Read> Reader<R> {
 }
 
 /// CSV file reader builder
+#[derive(Debug)]
 pub struct ReaderBuilder {
     /// Optional schema for the CSV file
     ///

--- a/rust/arrow/src/csv/writer.rs
+++ b/rust/arrow/src/csv/writer.rs
@@ -88,6 +88,7 @@ where
 }
 
 /// A CSV writer
+#[derive(Debug)]
 pub struct Writer<W: Write> {
     /// The object to write to
     writer: csv_crate::Writer<W>,
@@ -275,6 +276,7 @@ impl<W: Write> Writer<W> {
 }
 
 /// A CSV writer builder
+#[derive(Debug)]
 pub struct WriterBuilder {
     /// Optional column delimiter. Defaults to `b','`
     delimiter: Option<u8>,

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -348,6 +348,7 @@ impl ArrowNativeType for f64 {
 
 macro_rules! make_type {
     ($name:ident, $native_ty:ty, $data_ty:expr, $bit_width:expr, $default_val:expr) => {
+        #[derive(Debug)]
         pub struct $name {}
 
         impl ArrowPrimitiveType for $name {

--- a/rust/arrow/src/ipc/mod.rs
+++ b/rust/arrow/src/ipc/mod.rs
@@ -15,6 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// TODO: (vcq): Protobuf codegen is not generating Debug impls.
+#![allow(missing_debug_implementations)]
+
 pub mod convert;
 pub mod reader;
 pub mod writer;

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -360,6 +360,7 @@ pub fn infer_json_schema<R: Read>(
 }
 
 /// JSON file reader
+#[derive(Debug)]
 pub struct Reader<R: Read> {
     /// Explicit schema for the JSON file
     schema: SchemaRef,
@@ -730,6 +731,7 @@ impl<R: Read> Reader<R> {
 }
 
 /// JSON file reader builder
+#[derive(Debug)]
 pub struct ReaderBuilder {
     /// Optional schema for the JSON file
     ///

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -25,6 +25,7 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
 #![allow(bare_trait_objects)]
+#![warn(missing_debug_implementations)]
 
 pub mod array;
 pub mod bitmap;

--- a/rust/arrow/src/tensor.rs
+++ b/rust/arrow/src/tensor.rs
@@ -55,6 +55,7 @@ fn compute_column_major_strides<T: ArrowPrimitiveType>(shape: &[usize]) -> Vec<u
 }
 
 /// Tensor of primitive types
+#[derive(Debug)]
 pub struct Tensor<'a, T: ArrowPrimitiveType> {
     data_type: DataType,
     buffer: Buffer,

--- a/rust/arrow/src/util/string_writer.rs
+++ b/rust/arrow/src/util/string_writer.rs
@@ -62,6 +62,7 @@
 
 use std::io::{Error, ErrorKind, Result, Write};
 
+#[derive(Debug)]
 pub struct StringWriter {
     data: String,
 }


### PR DESCRIPTION
Implements debug for all plain types exposed. Enforces implementing Debug when a new struct added.
Ignores protobuf codegen.

@andygrove @nevi-me @paddyhoran 