### PR TITLE
ARROW-9436: [C++][CI] Fix Valgrind failure

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_fill_null_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_fill_null_test.cc
@@ -125,11 +125,10 @@ TEST_F(TestFillNullKernel, FillNullBoolean) {
   auto arr = std::static_pointer_cast<BooleanArray>(
       rand.Boolean(1000, /*true_probability=*/0.5, /*null_probability=*/0.01));
 
-  int64_t data_nbytes = arr->data()->buffers[1]->size();
   auto expected_data = arr->data()->Copy();
   expected_data->null_count = 0;
   expected_data->buffers[0] = nullptr;
-  expected_data->buffers[1] = *AllocateBuffer(data_nbytes);
+  expected_data->buffers[1] = *AllocateEmptyBitmap(arr->length());
   uint8_t* out_data = expected_data->buffers[1]->mutable_data();
   for (int64_t i = 0; i < arr->length(); ++i) {
     if (arr->IsValid(i)) {

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -177,7 +177,7 @@ Status MaybeAlignMetadata(std::shared_ptr<Buffer>* metadata) {
 }
 
 Status CheckMetadataAndGetBodyLength(const Buffer& metadata, int64_t* body_length) {
-  const flatbuf::Message* fb_message;
+  const flatbuf::Message* fb_message = nullptr;
   RETURN_NOT_OK(internal::VerifyMessage(metadata.data(), metadata.size(), &fb_message));
   *body_length = fb_message->bodyLength();
   if (*body_length < 0) {

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -1391,7 +1391,7 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
                                std::vector<std::string>* dim_names,
                                int64_t* non_zero_length,
                                SparseTensorFormat::type* sparse_tensor_format_id) {
-  const flatbuf::Message* message;
+  const flatbuf::Message* message = nullptr;
   RETURN_NOT_OK(internal::VerifyMessage(metadata.data(), metadata.size(), &message));
   auto sparse_tensor = message->header_as_SparseTensor();
   if (sparse_tensor == nullptr) {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1395,7 +1395,7 @@ Status ReadSparseTensorMetadata(const Buffer& metadata,
   RETURN_NOT_OK(internal::GetSparseTensorMetadata(
       metadata, out_type, out_shape, out_dim_names, out_non_zero_length, out_format_id));
 
-  const flatbuf::Message* message;
+  const flatbuf::Message* message = nullptr;
   RETURN_NOT_OK(internal::VerifyMessage(metadata.data(), metadata.size(), &message));
 
   auto sparse_tensor = message->header_as_SparseTensor();

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -30,7 +30,7 @@ namespace internal {
 template <typename T, typename Context = void>
 void AssertConversion(const std::string& s, typename T::c_type expected,
                       const Context* ctx = NULLPTR) {
-  typename T::c_type out;
+  typename T::c_type out{};
   ASSERT_TRUE(ParseValue<T>(s.data(), s.length(), &out, ctx))
       << "Conversion failed for '" << s << "' (expected to return " << expected << ")";
   ASSERT_EQ(out, expected) << "Conversion failed for '" << s << "'";
@@ -38,7 +38,7 @@ void AssertConversion(const std::string& s, typename T::c_type expected,
 
 template <typename T, typename Context = void>
 void AssertConversionFails(const std::string& s, const Context* ctx = NULLPTR) {
-  typename T::c_type out;
+  typename T::c_type out{};
   ASSERT_FALSE(ParseValue<T>(s.data(), s.length(), &out, ctx))
       << "Conversion should have failed for '" << s << "' (returned " << out << ")";
 }

--- a/cpp/src/parquet/column_scanner.h
+++ b/cpp/src/parquet/column_scanner.h
@@ -167,7 +167,7 @@ class PARQUET_TEMPLATE_CLASS_EXPORT TypedScanner : public Scanner {
   }
 
   virtual void PrintNext(std::ostream& out, int width, bool with_levels = false) {
-    T val;
+    T val{};
     int16_t def_level = -1;
     int16_t rep_level = -1;
     bool is_null = false;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,10 +163,10 @@ services:
       core: ${ULIMIT_CORE}
     environment:
       <<: *ccache
+      ARROW_BUILD_BENCHMARKS: "ON"
       ARROW_ENABLE_TIMING_TESTS:  # inherit
       ARROW_USE_LD_GOLD: "ON"
       ARROW_USE_PRECOMPILED_HEADERS: "ON"
-      ARROW_BUILD_BENCHMARKS: "ON"
     volumes: &conda-volumes
       - .:/arrow:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${ARCH}-conda-ccache:/ccache:delegated


### PR DESCRIPTION
Some bits were left uninitialized in the expected boolean array.

Also fix some warnings.