### PR TITLE
ARROW-13208: [Python][CI] Create a build for validating python docstrings

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,7 +58,7 @@ jobs:
         include:
           - name: conda-python-numpydoc
             cache: conda-python-3.8
-            image: conda-python
+            image: conda-python-numpydoc
             title: AMD64 Conda Python Numpydoc
             python: 3.8
           - name: conda-python-3.8-nopandas

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,10 +51,16 @@ jobs:
       fail-fast: false
       matrix:
         name:
+          - conda-python-numpydoc
           - conda-python-3.8-nopandas
           - conda-python-3.6-pandas-0.23
           - conda-python-3.7-pandas-latest
         include:
+          - name: conda-python-numpydoc
+            cache: conda-python-3.8
+            image: conda-python
+            title: AMD64 Conda Python Numpydoc
+            python: 3.8
           - name: conda-python-3.8-nopandas
             cache: conda-python-3.8
             image: conda-python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,16 +51,16 @@ jobs:
       fail-fast: false
       matrix:
         name:
-          - conda-python-numpydoc
+          - conda-python-docs
           - conda-python-3.8-nopandas
           - conda-python-3.6-pandas-0.23
           - conda-python-3.7-pandas-latest
         include:
-          - name: conda-python-numpydoc
-            cache: conda-python-3.8
-            image: conda-python-numpydoc
-            title: AMD64 Conda Python Numpydoc
-            python: 3.8
+          - name: conda-python-docs
+            cache: conda-python-3.9
+            image: conda-python-docs
+            title: AMD64 Conda Python 3.9 Sphinx & Numpydoc
+            python: 3.9
           - name: conda-python-3.8-nopandas
             cache: conda-python-3.8
             image: conda-python

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -105,8 +105,8 @@ class NumpyDoc:
     def __init__(self, symbols=None):
         if not have_numpydoc:
             raise RuntimeError(
-                'Numpydoc is not available, install the development version '
-                'with command: pip install numpydoc==1.1.0'
+                'Numpydoc is not available, install with command: '
+                'pip install numpydoc==1.1.0'
             )
         self.symbols = set(symbols or {'pyarrow'})
 

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -246,7 +246,7 @@ def python_numpydoc(symbols=None, allow_rules=None, disallow_rules=None):
         'pyarrow.csv',
         'pyarrow.dataset',
         'pyarrow.feather',
-        'pyarrow.flight',
+        # 'pyarrow.flight',
         'pyarrow.fs',
         'pyarrow.gandiva',
         'pyarrow.ipc',

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -36,6 +36,7 @@ extras = {
                  'setuptools_scm'],
     'crossbow-upload': ['github3.py', jinja_req, 'ruamel.yaml',
                         'setuptools_scm'],
+    'numpydoc': ['numpydoc']
 }
 extras['bot'] = extras['crossbow'] + ['pygithub', 'jira']
 extras['all'] = list(set(functools.reduce(operator.add, extras.values())))

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -28,7 +28,7 @@ if sys.version_info < (3, 6):
 jinja_req = 'jinja2>=2.11'
 
 extras = {
-    'lint': ['numpydoc==1.1.0', 'autopep8', 'flake8', 'cmake_format==0.6.13'],
+    'lint': ['autopep8', 'flake8', 'cmake_format==0.6.13'],
     'benchmark': ['pandas'],
     'docker': ['ruamel.yaml', 'python-dotenv'],
     'release': [jinja_req, 'jira', 'semver', 'gitpython'],
@@ -36,7 +36,7 @@ extras = {
                  'setuptools_scm'],
     'crossbow-upload': ['github3.py', jinja_req, 'ruamel.yaml',
                         'setuptools_scm'],
-    'numpydoc': ['numpydoc']
+    'numpydoc': ['numpydoc==1.1.0']
 }
 extras['bot'] = extras['crossbow'] + ['pygithub', 'jira']
 extras['all'] = list(set(functools.reduce(operator.add, extras.values())))

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -28,7 +28,7 @@ if sys.version_info < (3, 6):
 jinja_req = 'jinja2>=2.11'
 
 extras = {
-    'lint': ['autopep8', 'flake8', 'cmake_format==0.6.13'],
+    'lint': ['numpydoc==1.1.0', 'autopep8', 'flake8', 'cmake_format==0.6.13'],
     'benchmark': ['pandas'],
     'docker': ['ruamel.yaml', 'python-dotenv'],
     'release': [jinja_req, 'jira', 'semver', 'gitpython'],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ x-hierarchy:
         - conda-python-turbodbc
         - conda-python-kartothek
         - conda-python-spark
-
+        - conda-python-numpydoc
   - debian-cpp:
     - debian-c-glib:
       - debian-ruby
@@ -913,6 +913,25 @@ services:
         /arrow/ci/scripts/java_jni_manylinux_build.sh /arrow /build /arrow/java-dist"]
 
   ##############################  Integration #################################
+
+  conda-python-numpydoc:
+    # Usage:
+    #   archery docker run conda-python-numpydoc
+    #
+    # Only a single rule is enabled for now to check undocumented arguments.
+    # We should extend the list of enabled rules after adding this build to
+    # the CI pipeline.
+    image: ${REPO}:${ARCH}-conda-python-${PYTHON}
+    environment:
+      <<: *ccache
+      LC_ALL: "C.UTF-8"
+      LANG: "C.UTF-8"
+    volumes: *conda-volumes
+    command:
+      ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
+        /arrow/ci/scripts/python_build.sh /arrow /build &&
+        pip install -e /arrow/dev/archery[numpydoc] &&
+        archery numpydoc --allow-rule PR01"]
 
   conda-python-pandas:
     # Possible $PANDAS parameters:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ x-hierarchy:
         - conda-python-turbodbc
         - conda-python-kartothek
         - conda-python-spark
-        - conda-python-numpydoc
+        - conda-python-docs
   - debian-cpp:
     - debian-c-glib:
       - debian-ruby
@@ -916,7 +916,7 @@ services:
 
   conda-python-docs:
     # Usage:
-    #   archery docker run conda-python-numpydoc
+    #   archery docker run conda-python-docs
     #
     # Only a single rule is enabled for now to check undocumented arguments.
     # We should extend the list of enabled rules after adding this build to

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,8 @@ x-hierarchy:
       - conda-cpp-hiveserver2
       - conda-cpp-valgrind
       - conda-python:
-        - conda-python-pandas
+        - conda-python-pandas:
+          - conda-python-docs
         - conda-python-dask
         - conda-python-hdfs
         - conda-python-jpype
@@ -109,7 +110,6 @@ x-hierarchy:
         - conda-python-turbodbc
         - conda-python-kartothek
         - conda-python-spark
-        - conda-python-docs
   - debian-cpp:
     - debian-c-glib:
       - debian-ruby
@@ -914,26 +914,6 @@ services:
 
   ##############################  Integration #################################
 
-  conda-python-docs:
-    # Usage:
-    #   archery docker run conda-python-docs
-    #
-    # Only a single rule is enabled for now to check undocumented arguments.
-    # We should extend the list of enabled rules after adding this build to
-    # the CI pipeline.
-    image: ${REPO}:${ARCH}-conda-python-${PYTHON}
-    environment:
-      <<: *ccache
-      LC_ALL: "C.UTF-8"
-      LANG: "C.UTF-8"
-      BUILD_DOCS_PYTHON: "ON"
-    volumes: *conda-volumes
-    command:
-      ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
-        /arrow/ci/scripts/python_build.sh /arrow /build &&
-        pip install -e /arrow/dev/archery[numpydoc] &&
-        archery numpydoc --allow-rule PR01"]
-
   conda-python-pandas:
     # Possible $PANDAS parameters:
     #  - `latest`: latest release
@@ -960,12 +940,32 @@ services:
     shm_size: *shm-size
     environment:
       <<: *ccache
-      BUILD_DOCS_PYTHON: "OFF"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         /arrow/ci/scripts/python_test.sh /arrow"]
+
+  conda-python-docs:
+    # Usage:
+    #   archery docker run conda-python-docs
+    #
+    # Only a single rule is enabled for now to check undocumented arguments.
+    # We should extend the list of enabled rules after adding this build to
+    # the CI pipeline.
+    image: ${REPO}:${ARCH}-conda-python-${PYTHON}-pandas-${PANDAS}
+    environment:
+      <<: *ccache
+      LC_ALL: "C.UTF-8"
+      LANG: "C.UTF-8"
+      BUILD_DOCS_CPP: "ON"
+      BUILD_DOCS_PYTHON: "ON"
+    volumes: *conda-volumes
+    command:
+      ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
+        /arrow/ci/scripts/python_build.sh /arrow /build &&
+        pip install -e /arrow/dev/archery[numpydoc] &&
+        archery numpydoc --allow-rule PR01"]
 
   conda-python-dask:
     # Possible $DASK parameters:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -914,7 +914,7 @@ services:
 
   ##############################  Integration #################################
 
-  conda-python-numpydoc:
+  conda-python-docs:
     # Usage:
     #   archery docker run conda-python-numpydoc
     #
@@ -926,6 +926,7 @@ services:
       <<: *ccache
       LC_ALL: "C.UTF-8"
       LANG: "C.UTF-8"
+      BUILD_DOCS_PYTHON: "ON"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
@@ -959,7 +960,7 @@ services:
     shm_size: *shm-size
     environment:
       <<: *ccache
-      BUILD_DOCS_PYTHON: "ON"
+      BUILD_DOCS_PYTHON: "OFF"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&

--- a/python/pyarrow/compat.pxi
+++ b/python/pyarrow/compat.pxi
@@ -52,6 +52,14 @@ except ImportError:
 
 
 def tobytes(o):
+    """
+    Return with the byte representation of the string-like input object.
+
+    Parameters
+    ----------
+    o : bytes-like
+        Input object.
+    """
     if isinstance(o, str):
         return o.encode('utf8')
     else:
@@ -59,6 +67,16 @@ def tobytes(o):
 
 
 def frombytes(o, *, safe=False):
+    """
+    Return with the unicode string representation of a bytes-like object.
+
+    Parameters
+    ----------
+    o : bytes-like
+        Input object.
+    safe : bool, default False
+        Raise on encoding errors.
+    """
     if safe:
         return o.decode('utf8', errors='replace')
     else:

--- a/python/pyarrow/compat.pxi
+++ b/python/pyarrow/compat.pxi
@@ -53,12 +53,12 @@ except ImportError:
 
 def tobytes(o):
     """
-    Return with the byte representation of the string-like input object.
+    Encode a unicode or bytes string to bytes.
 
     Parameters
     ----------
-    o : bytes-like
-        Input object.
+    o : str or bytes
+        Input string.
     """
     if isinstance(o, str):
         return o.encode('utf8')
@@ -68,14 +68,14 @@ def tobytes(o):
 
 def frombytes(o, *, safe=False):
     """
-    Return with the unicode string representation of a bytes-like object.
+    Decode the given bytestring to unicode.
 
     Parameters
     ----------
     o : bytes-like
         Input object.
     safe : bool, default False
-        Raise on encoding errors.
+        If true, raise on encoding errors.
     """
     if safe:
         return o.decode('utf8', errors='replace')

--- a/python/pyarrow/orc.py
+++ b/python/pyarrow/orc.py
@@ -140,7 +140,7 @@ class ORCWriter:
 
         Parameters
         ----------
-        schema : pyarrow.lib.Table
+        table : pyarrow.lib.Table
             The table to be written into the ORC file
         """
         self.writer.write(table)

--- a/python/pyarrow/plasma.py
+++ b/python/pyarrow/plasma.py
@@ -83,20 +83,31 @@ def start_plasma_store(plasma_store_memory,
                        use_valgrind=False, use_profiler=False,
                        plasma_directory=None, use_hugepages=False,
                        external_store=None):
-    """Start a plasma store process.
-    Args:
-        plasma_store_memory (int): Capacity of the plasma store in bytes.
-        use_valgrind (bool): True if the plasma store should be started inside
-            of valgrind. If this is True, use_profiler must be False.
-        use_profiler (bool): True if the plasma store should be started inside
-            a profiler. If this is True, use_valgrind must be False.
-        plasma_directory (str): Directory where plasma memory mapped files
-            will be stored.
-        use_hugepages (bool): True if the plasma store should use huge pages.
-        external_store (str): External store to use for evicted objects.
-    Return:
+    """
+    Start a plasma store process.
+
+    Parameters
+    ----------
+    plasma_store_memory : int
+        Capacity of the plasma store in bytes.
+    use_valgrind : bool
+        True if the plasma store should be started inside of valgrind. If this
+        is True, use_profiler must be False.
+    use_profiler : bool
+        True if the plasma store should be started inside a profiler. If this
+        is True, use_valgrind must be False.
+    plasma_directory : str
+        Directory where plasma memory mapped files will be stored.
+    use_hugepages : bool
+        True if the plasma store should use huge pages.
+    external_store : str
+        External store to use for evicted objects.
+
+    Returns
+    -------
+    result : (str, subprocess.Popen)
         A tuple of the name of the plasma store socket and the process ID of
-            the plasma store process.
+        the plasma store process.
     """
     if use_valgrind and use_profiler:
         raise Exception("Cannot use valgrind and profiler at the same time.")

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -2439,6 +2439,13 @@ def _from_pydict(cls, mapping, schema, metadata):
 class TableGroupBy:
     """
     A grouping of columns in a table on which to perform aggregations.
+
+    Parameters
+    ----------
+    table : pyarrow.Table
+        Input table to execute the aggregation on.
+    keys : str or list[str]
+        Name of the grouped columns.
     """
 
     def __init__(self, table, keys):


### PR DESCRIPTION
Using the existing numpydoc checker in archery. I've enabled a single rule to check undocumented arguments (we have 189 currently).

Perhaps we should fix these in this PR then enable it globally to keep the docstrings in good shape?