### PR TITLE
ARROW-9439: [C++] Fix crash on invalid IPC input

### DIFF
--- a/cpp/src/arrow/array/array_base.cc
+++ b/cpp/src/arrow/array/array_base.cc
@@ -246,6 +246,19 @@ std::shared_ptr<Array> Array::Slice(int64_t offset) const {
   return Slice(offset, slice_length);
 }
 
+Result<std::shared_ptr<Array>> Array::SliceSafe(int64_t offset, int64_t length) const {
+  ARROW_ASSIGN_OR_RAISE(auto sliced_data, data_->SliceSafe(offset, length));
+  return MakeArray(std::move(sliced_data));
+}
+
+Result<std::shared_ptr<Array>> Array::SliceSafe(int64_t offset) const {
+  if (offset < 0) {
+    // Avoid UBSAN in subtraction below
+    return Status::Invalid("Negative buffer slice offset");
+  }
+  return SliceSafe(offset, data_->length - offset);
+}
+
 std::string Array::ToString() const {
   std::stringstream ss;
   ARROW_CHECK_OK(PrettyPrint(*this, 0, &ss));

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -151,6 +151,11 @@ class ARROW_EXPORT Array {
   /// Slice from offset until end of the array
   std::shared_ptr<Array> Slice(int64_t offset) const;
 
+  /// Input-checking variant of Array::Slice
+  Result<std::shared_ptr<Array>> SliceSafe(int64_t offset, int64_t length) const;
+  /// Input-checking variant of Array::Slice
+  Result<std::shared_ptr<Array>> SliceSafe(int64_t offset) const;
+
   std::shared_ptr<ArrayData> data() const { return data_; }
 
   int num_fields() const { return static_cast<int>(data_->child_data.size()); }

--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -151,6 +151,10 @@ static Status PutOffsets(const std::shared_ptr<Buffer>& src, Offset first_offset
     return Status::Invalid("offset overflow while concatenating arrays");
   }
 
+  // Concatenate can be called during IPC reads to append delta dictionaries,
+  // on non-validate input.  Be sure to avoid reading out of buffer boundaries.
+  // XXX
+
   // Write offsets into dst, ensuring that the first offset written is
   // first_offset
   auto adjustment = first_offset - src_begin[0];
@@ -202,47 +206,55 @@ class ConcatenateImpl {
 
   Status Visit(const FixedWidthType& fixed) {
     // Handles numbers, decimal128, fixed_size_binary
-    return ConcatenateBuffers(Buffers(1, fixed), pool_).Value(&out_->buffers[1]);
+    ARROW_ASSIGN_OR_RAISE(auto buffers, Buffers(1, fixed));
+    return ConcatenateBuffers(buffers, pool_).Value(&out_->buffers[1]);
   }
 
   Status Visit(const BinaryType&) {
     std::vector<Range> value_ranges;
-    RETURN_NOT_OK(ConcatenateOffsets<int32_t>(Buffers(1, sizeof(int32_t)), pool_,
-                                              &out_->buffers[1], &value_ranges));
-    return ConcatenateBuffers(Buffers(2, value_ranges), pool_).Value(&out_->buffers[2]);
+    ARROW_ASSIGN_OR_RAISE(auto index_buffers, Buffers(1, sizeof(int32_t)));
+    RETURN_NOT_OK(ConcatenateOffsets<int32_t>(index_buffers, pool_, &out_->buffers[1],
+                                              &value_ranges));
+    ARROW_ASSIGN_OR_RAISE(auto value_buffers, Buffers(2, value_ranges));
+    return ConcatenateBuffers(value_buffers, pool_).Value(&out_->buffers[2]);
   }
 
   Status Visit(const LargeBinaryType&) {
     std::vector<Range> value_ranges;
-    RETURN_NOT_OK(ConcatenateOffsets<int64_t>(Buffers(1, sizeof(int64_t)), pool_,
-                                              &out_->buffers[1], &value_ranges));
-    return ConcatenateBuffers(Buffers(2, value_ranges), pool_).Value(&out_->buffers[2]);
+    ARROW_ASSIGN_OR_RAISE(auto index_buffers, Buffers(1, sizeof(int64_t)));
+    RETURN_NOT_OK(ConcatenateOffsets<int64_t>(index_buffers, pool_, &out_->buffers[1],
+                                              &value_ranges));
+    ARROW_ASSIGN_OR_RAISE(auto value_buffers, Buffers(2, value_ranges));
+    return ConcatenateBuffers(value_buffers, pool_).Value(&out_->buffers[2]);
   }
 
   Status Visit(const ListType&) {
     std::vector<Range> value_ranges;
-    RETURN_NOT_OK(ConcatenateOffsets<int32_t>(Buffers(1, sizeof(int32_t)), pool_,
-                                              &out_->buffers[1], &value_ranges));
-    return ConcatenateImpl(ChildData(0, value_ranges), pool_)
-        .Concatenate(&out_->child_data[0]);
+    ARROW_ASSIGN_OR_RAISE(auto index_buffers, Buffers(1, sizeof(int32_t)));
+    RETURN_NOT_OK(ConcatenateOffsets<int32_t>(index_buffers, pool_, &out_->buffers[1],
+                                              &value_ranges));
+    ARROW_ASSIGN_OR_RAISE(auto child_data, ChildData(0, value_ranges));
+    return ConcatenateImpl(child_data, pool_).Concatenate(&out_->child_data[0]);
   }
 
   Status Visit(const LargeListType&) {
     std::vector<Range> value_ranges;
-    RETURN_NOT_OK(ConcatenateOffsets<int64_t>(Buffers(1, sizeof(int64_t)), pool_,
-                                              &out_->buffers[1], &value_ranges));
-    return ConcatenateImpl(ChildData(0, value_ranges), pool_)
-        .Concatenate(&out_->child_data[0]);
+    ARROW_ASSIGN_OR_RAISE(auto index_buffers, Buffers(1, sizeof(int64_t)));
+    RETURN_NOT_OK(ConcatenateOffsets<int64_t>(index_buffers, pool_, &out_->buffers[1],
+                                              &value_ranges));
+    ARROW_ASSIGN_OR_RAISE(auto child_data, ChildData(0, value_ranges));
+    return ConcatenateImpl(child_data, pool_).Concatenate(&out_->child_data[0]);
   }
 
   Status Visit(const FixedSizeListType&) {
-    return ConcatenateImpl(ChildData(0), pool_).Concatenate(&out_->child_data[0]);
+    ARROW_ASSIGN_OR_RAISE(auto child_data, ChildData(0));
+    return ConcatenateImpl(child_data, pool_).Concatenate(&out_->child_data[0]);
   }
 
   Status Visit(const StructType& s) {
     for (int i = 0; i < s.num_fields(); ++i) {
-      RETURN_NOT_OK(
-          ConcatenateImpl(ChildData(i), pool_).Concatenate(&out_->child_data[i]));
+      ARROW_ASSIGN_OR_RAISE(auto child_data, ChildData(i));
+      RETURN_NOT_OK(ConcatenateImpl(child_data, pool_).Concatenate(&out_->child_data[i]));
     }
     return Status::OK();
   }
@@ -263,7 +275,8 @@ class ConcatenateImpl {
 
     if (dictionaries_same) {
       out_->dictionary = in_[0]->dictionary;
-      return ConcatenateBuffers(Buffers(1, *fixed), pool_).Value(&out_->buffers[1]);
+      ARROW_ASSIGN_OR_RAISE(auto index_buffers, Buffers(1, *fixed));
+      return ConcatenateBuffers(index_buffers, pool_).Value(&out_->buffers[1]);
     } else {
       return Status::NotImplemented("Concat with dictionary unification NYI");
     }
@@ -283,13 +296,16 @@ class ConcatenateImpl {
   // Bytes are sliced with that input's offset and length.
   // Note that BufferVector will not contain the buffer of in_[i] if it's
   // nullptr.
-  BufferVector Buffers(size_t index) {
+  Result<BufferVector> Buffers(size_t index) {
     BufferVector buffers;
     buffers.reserve(in_.size());
     for (const std::shared_ptr<const ArrayData>& array_data : in_) {
       const auto& buffer = array_data->buffers[index];
       if (buffer != nullptr) {
-        buffers.push_back(SliceBuffer(buffer, array_data->offset, array_data->length));
+        ARROW_ASSIGN_OR_RAISE(
+            auto sliced_buffer,
+            SliceBufferSafe(buffer, array_data->offset, array_data->length));
+        buffers.push_back(std::move(sliced_buffer));
       }
     }
     return buffers;
@@ -299,14 +315,17 @@ class ConcatenateImpl {
   // Bytes are sliced with the explicitly passed ranges.
   // Note that BufferVector will not contain the buffer of in_[i] if it's
   // nullptr.
-  BufferVector Buffers(size_t index, const std::vector<Range>& ranges) {
+  Result<BufferVector> Buffers(size_t index, const std::vector<Range>& ranges) {
     DCHECK_EQ(in_.size(), ranges.size());
     BufferVector buffers;
     buffers.reserve(in_.size());
     for (size_t i = 0; i < in_.size(); ++i) {
       const auto& buffer = in_[i]->buffers[index];
       if (buffer != nullptr) {
-        buffers.push_back(SliceBuffer(buffer, ranges[i].offset, ranges[i].length));
+        ARROW_ASSIGN_OR_RAISE(
+            auto sliced_buffer,
+            SliceBufferSafe(buffer, ranges[i].offset, ranges[i].length));
+        buffers.push_back(std::move(sliced_buffer));
       } else {
         DCHECK_EQ(ranges[i].length, 0);
       }
@@ -319,14 +338,16 @@ class ConcatenateImpl {
   // those elements are sliced with that input's offset and length.
   // Note that BufferVector will not contain the buffer of in_[i] if it's
   // nullptr.
-  BufferVector Buffers(size_t index, int byte_width) {
+  Result<BufferVector> Buffers(size_t index, int byte_width) {
     BufferVector buffers;
     buffers.reserve(in_.size());
     for (const std::shared_ptr<const ArrayData>& array_data : in_) {
       const auto& buffer = array_data->buffers[index];
       if (buffer != nullptr) {
-        buffers.push_back(SliceBuffer(buffer, array_data->offset * byte_width,
-                                      array_data->length * byte_width));
+        ARROW_ASSIGN_OR_RAISE(auto sliced_buffer,
+                              SliceBufferSafe(buffer, array_data->offset * byte_width,
+                                              array_data->length * byte_width));
+        buffers.push_back(std::move(sliced_buffer));
       }
     }
     return buffers;
@@ -337,7 +358,7 @@ class ConcatenateImpl {
   // those elements are sliced with that input's offset and length.
   // Note that BufferVector will not contain the buffer of in_[i] if it's
   // nullptr.
-  BufferVector Buffers(size_t index, const FixedWidthType& fixed) {
+  Result<BufferVector> Buffers(size_t index, const FixedWidthType& fixed) {
     DCHECK_EQ(fixed.bit_width() % 8, 0);
     return Buffers(index, fixed.bit_width() / 8);
   }
@@ -355,23 +376,24 @@ class ConcatenateImpl {
 
   // Gather the index-th child_data of each input into a vector.
   // Elements are sliced with that input's offset and length.
-  std::vector<std::shared_ptr<const ArrayData>> ChildData(size_t index) {
+  Result<std::vector<std::shared_ptr<const ArrayData>>> ChildData(size_t index) {
     std::vector<std::shared_ptr<const ArrayData>> child_data(in_.size());
     for (size_t i = 0; i < in_.size(); ++i) {
-      child_data[i] = in_[i]->child_data[index]->Slice(in_[i]->offset, in_[i]->length);
+      ARROW_ASSIGN_OR_RAISE(child_data[i], in_[i]->child_data[index]->SliceSafe(
+                                               in_[i]->offset, in_[i]->length));
     }
     return child_data;
   }
 
   // Gather the index-th child_data of each input into a vector.
   // Elements are sliced with the explicitly passed ranges.
-  std::vector<std::shared_ptr<const ArrayData>> ChildData(
+  Result<std::vector<std::shared_ptr<const ArrayData>>> ChildData(
       size_t index, const std::vector<Range>& ranges) {
     DCHECK_EQ(in_.size(), ranges.size());
     std::vector<std::shared_ptr<const ArrayData>> child_data(in_.size());
     for (size_t i = 0; i < in_.size(); ++i) {
-      child_data[i] =
-          in_[i]->child_data[index]->Slice(ranges[i].offset, ranges[i].length);
+      ARROW_ASSIGN_OR_RAISE(child_data[i], in_[i]->child_data[index]->SliceSafe(
+                                               ranges[i].offset, ranges[i].length));
     }
     return child_data;
   }

--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -151,10 +151,6 @@ static Status PutOffsets(const std::shared_ptr<Buffer>& src, Offset first_offset
     return Status::Invalid("offset overflow while concatenating arrays");
   }
 
-  // Concatenate can be called during IPC reads to append delta dictionaries,
-  // on non-validate input.  Be sure to avoid reading out of buffer boundaries.
-  // XXX
-
   // Write offsets into dst, ensuring that the first offset written is
   // first_offset
   auto adjustment = first_offset - src_begin[0];
@@ -292,6 +288,10 @@ class ConcatenateImpl {
   }
 
  private:
+  // NOTE: Concatenate() can be called during IPC reads to append delta dictionaries
+  // on non-validated input.  Therefore, the input-checking SliceBufferSafe and
+  // ArrayData::SliceSafe are used below.
+
   // Gather the index-th buffer of each input into a vector.
   // Bytes are sliced with that input's offset and length.
   // Note that BufferVector will not contain the buffer of in_[i] if it's

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -107,18 +107,7 @@ std::shared_ptr<ArrayData> ArrayData::Slice(int64_t off, int64_t len) const {
 }
 
 Result<std::shared_ptr<ArrayData>> ArrayData::SliceSafe(int64_t off, int64_t len) const {
-  if (off < 0) {
-    return Status::Invalid("Negative array slice offset");
-  }
-  if (len < 0) {
-    return Status::Invalid("Negative array slice length");
-  }
-  if (internal::HasPositiveAdditionOverflow(off, len)) {
-    return Status::Invalid("Array slice would overflow");
-  }
-  if (off + len > length) {
-    return Status::Invalid("Array slice would exceed array length");
-  }
+  RETURN_NOT_OK(internal::CheckSliceParams(length, off, len, "array"));
   return Slice(off, len);
 }
 

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -195,10 +195,13 @@ struct ARROW_EXPORT ArrayData {
     return GetMutableValues<T>(i, offset);
   }
 
-  // Construct a zero-copy slice of the data with the indicated offset and length
+  /// \brief Construct a zero-copy slice of the data with the given offset and length
   std::shared_ptr<ArrayData> Slice(int64_t offset, int64_t length) const;
 
-  // Input-checking variant of Slice
+  /// \brief Input-checking variant of Slice
+  ///
+  /// An Invalid Status is returned if the requested slice falls out of bounds.
+  /// Note that unlike Slice, `length` isn't clamped to the available buffer size.
   Result<std::shared_ptr<ArrayData>> SliceSafe(int64_t offset, int64_t length) const;
 
   void SetNullCount(int64_t v) { null_count.store(v); }

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -198,6 +198,9 @@ struct ARROW_EXPORT ArrayData {
   // Construct a zero-copy slice of the data with the indicated offset and length
   std::shared_ptr<ArrayData> Slice(int64_t offset, int64_t length) const;
 
+  // Input-checking variant of Slice
+  Result<std::shared_ptr<ArrayData>> SliceSafe(int64_t offset, int64_t length) const;
+
   void SetNullCount(int64_t v) { null_count.store(v); }
 
   /// \brief Return null count, or compute and set it if it's not known

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -47,17 +47,7 @@ Result<std::shared_ptr<Buffer>> Buffer::CopySlice(const int64_t start,
 namespace {
 
 Status CheckBufferSlice(const Buffer& buffer, int64_t offset, int64_t length) {
-  if (ARROW_PREDICT_FALSE(offset < 0)) {
-    return Status::Invalid("Negative buffer slice offset");
-  }
-  if (ARROW_PREDICT_FALSE(length < 0)) {
-    return Status::Invalid("Negative buffer slice length");
-  }
-  // (`offset + length` would risk signed overflow)
-  if (ARROW_PREDICT_FALSE(length > buffer.size() - offset)) {
-    return Status::Invalid("Buffer slice would exceed buffer length");
-  }
-  return Status::OK();
+  return internal::CheckSliceParams(buffer.size(), offset, length, "buffer");
 }
 
 Status CheckBufferSlice(const Buffer& buffer, int64_t offset) {

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -25,6 +25,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/int_util.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/string.h"
 
@@ -41,6 +42,56 @@ Result<std::shared_ptr<Buffer>> Buffer::CopySlice(const int64_t start,
   ARROW_ASSIGN_OR_RAISE(auto new_buffer, AllocateResizableBuffer(nbytes, pool));
   std::memcpy(new_buffer->mutable_data(), data() + start, static_cast<size_t>(nbytes));
   return std::move(new_buffer);
+}
+
+namespace {
+
+Status CheckBufferSlice(const Buffer& buffer, int64_t offset, int64_t length) {
+  if (ARROW_PREDICT_FALSE(offset < 0)) {
+    return Status::Invalid("Negative buffer slice offset");
+  }
+  if (ARROW_PREDICT_FALSE(length < 0)) {
+    return Status::Invalid("Negative buffer slice length");
+  }
+  // (`offset + length` would risk signed overflow)
+  if (ARROW_PREDICT_FALSE(length > buffer.size() - offset)) {
+    return Status::Invalid("Buffer slice would exceed buffer length");
+  }
+  return Status::OK();
+}
+
+Status CheckBufferSlice(const Buffer& buffer, int64_t offset) {
+  if (ARROW_PREDICT_FALSE(offset < 0)) {
+    // Avoid UBSAN in subtraction below
+    return Status::Invalid("Negative buffer slice offset");
+  }
+  return CheckBufferSlice(buffer, offset, buffer.size() - offset);
+}
+
+}  // namespace
+
+Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
+                                                int64_t offset) {
+  RETURN_NOT_OK(CheckBufferSlice(*buffer, offset));
+  return SliceBuffer(buffer, offset);
+}
+
+Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
+                                                int64_t offset, int64_t length) {
+  RETURN_NOT_OK(CheckBufferSlice(*buffer, offset, length));
+  return SliceBuffer(buffer, offset, length);
+}
+
+Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
+    const std::shared_ptr<Buffer>& buffer, int64_t offset) {
+  RETURN_NOT_OK(CheckBufferSlice(*buffer, offset));
+  return SliceMutableBuffer(buffer, offset);
+}
+
+Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
+    const std::shared_ptr<Buffer>& buffer, int64_t offset, int64_t length) {
+  RETURN_NOT_OK(CheckBufferSlice(*buffer, offset, length));
+  return SliceMutableBuffer(buffer, offset, length);
 }
 
 std::string Buffer::ToHexString() {

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -336,6 +336,17 @@ static inline std::shared_ptr<Buffer> SliceBuffer(const std::shared_ptr<Buffer>&
   return SliceBuffer(buffer, offset, length);
 }
 
+/// \brief Input-checking version of SliceBuffer
+///
+/// An Invalid Status is returned if the requested slice falls out of bounds.
+Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
+                                                int64_t offset);
+/// \brief Input-checking version of SliceBuffer
+///
+/// An Invalid Status is returned if the requested slice falls out of bounds.
+Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
+                                                int64_t offset, int64_t length);
+
 /// \brief Like SliceBuffer, but construct a mutable buffer slice.
 ///
 /// If the parent buffer is not mutable, behavior is undefined (it may abort
@@ -353,6 +364,17 @@ static inline std::shared_ptr<Buffer> SliceMutableBuffer(
   int64_t length = buffer->size() - offset;
   return SliceMutableBuffer(buffer, offset, length);
 }
+
+/// \brief Input-checking version of SliceMutableBuffer
+///
+/// An Invalid Status is returned if the requested slice falls out of bounds.
+Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
+    const std::shared_ptr<Buffer>& buffer, int64_t offset);
+/// \brief Input-checking version of SliceMutableBuffer
+///
+/// An Invalid Status is returned if the requested slice falls out of bounds.
+Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
+    const std::shared_ptr<Buffer>& buffer, int64_t offset, int64_t length);
 
 /// @}
 

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -339,11 +339,14 @@ static inline std::shared_ptr<Buffer> SliceBuffer(const std::shared_ptr<Buffer>&
 /// \brief Input-checking version of SliceBuffer
 ///
 /// An Invalid Status is returned if the requested slice falls out of bounds.
+ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
                                                 int64_t offset);
 /// \brief Input-checking version of SliceBuffer
 ///
 /// An Invalid Status is returned if the requested slice falls out of bounds.
+/// Note that unlike SliceBuffer, `length` isn't clamped to the available buffer size.
+ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
                                                 int64_t offset, int64_t length);
 
@@ -368,11 +371,14 @@ static inline std::shared_ptr<Buffer> SliceMutableBuffer(
 /// \brief Input-checking version of SliceMutableBuffer
 ///
 /// An Invalid Status is returned if the requested slice falls out of bounds.
+ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
     const std::shared_ptr<Buffer>& buffer, int64_t offset);
 /// \brief Input-checking version of SliceMutableBuffer
 ///
 /// An Invalid Status is returned if the requested slice falls out of bounds.
+/// Note that unlike SliceBuffer, `length` isn't clamped to the available buffer size.
+ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
     const std::shared_ptr<Buffer>& buffer, int64_t offset, int64_t length);
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -123,6 +123,12 @@ class ArrayLoader {
     if (skip_io_) {
       return Status::OK();
     }
+    if (offset < 0) {
+      return Status::Invalid("Negative offset for reading buffer ", buffer_index_);
+    }
+    if (length < 0) {
+      return Status::Invalid("Negative length for reading buffer ", buffer_index_);
+    }
     // This construct permits overriding GetBuffer at compile time
     if (!BitUtil::IsMultipleOf8(offset)) {
       return Status::Invalid("Buffer ", buffer_index_,

--- a/cpp/src/arrow/util/int_util.h
+++ b/cpp/src/arrow/util/int_util.h
@@ -150,6 +150,23 @@ UpcastInt(Integer v) {
   return v;
 }
 
+static inline Status CheckSliceParams(int64_t object_length, int64_t slice_offset,
+                                      int64_t slice_length, const char* object_name) {
+  if (slice_offset < 0) {
+    return Status::Invalid("Negative ", object_name, " slice offset");
+  }
+  if (slice_length < 0) {
+    return Status::Invalid("Negative ", object_name, " slice length");
+  }
+  if (internal::HasPositiveAdditionOverflow(slice_offset, slice_length)) {
+    return Status::Invalid(object_name, " slice would overflow");
+  }
+  if (slice_offset + slice_length > object_length) {
+    return Status::Invalid(object_name, " slice would exceed ", object_name, " length");
+  }
+  return Status::OK();
+}
+
 /// \brief Do vectorized boundschecking of integer-type array indices. The
 /// indices must be non-nonnegative and strictly less than the passed upper
 /// limit (which is usually the length of an array that is being indexed-into).


### PR DESCRIPTION
Also add argument-checking variants of SliceBuffer, SliceMutableBuffer, Array::Slice and ArrayData::Slice.

Should fix the following issue:
* https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=24101