### PR TITLE
ARROW-9443: [C++] Bundled bz2 build should only build libbz2

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -86,6 +86,7 @@ jobs:
           archery docker run ubuntu-r
       - name: Dump install logs
         run: cat r/check/arrow.Rcheck/00install.out
+        if: always()
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         continue-on-error: true
@@ -134,6 +135,7 @@ jobs:
           archery docker run r
       - name: Dump install logs
         run: cat r/check/arrow.Rcheck/00install.out
+        if: always()
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         continue-on-error: true
@@ -210,3 +212,4 @@ jobs:
       - name: Dump install logs
         shell: cmd
         run: cat check/arrow.Rcheck/00install.out
+        if: always()

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2057,7 +2057,8 @@ macro(build_bzip2)
                       ${EP_LOG_OPTIONS}
                       CONFIGURE_COMMAND ""
                       BUILD_IN_SOURCE 1
-                      BUILD_COMMAND ${MAKE} ${MAKE_BUILD_ARGS} ${BZIP2_EXTRA_ARGS}
+                      BUILD_COMMAND ${MAKE} libbz2.a ${MAKE_BUILD_ARGS}
+                                    ${BZIP2_EXTRA_ARGS}
                       INSTALL_COMMAND ${MAKE} install PREFIX=${BZIP2_PREFIX}
                                       ${BZIP2_EXTRA_ARGS}
                       INSTALL_DIR ${BZIP2_PREFIX}

--- a/dev/tasks/r/azure.linux.yml
+++ b/dev/tasks/r/azure.linux.yml
@@ -56,3 +56,4 @@ jobs:
         set -ex
         cat arrow/r/check/arrow.Rcheck/00install.out
       displayName: Dump install logs
+      condition: succeededOrFailed()

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -67,3 +67,4 @@ jobs:
         run: cd arrow && docker-compose run r
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
+        if: always()

--- a/r/configure
+++ b/r/configure
@@ -131,11 +131,21 @@ else
       fi
       ${R_HOME}/bin/Rscript tools/linuxlibs.R $VERSION
       PKG_CFLAGS="-I$(pwd)/libarrow/arrow-${VERSION}/include $PKG_CFLAGS"
-      # Also enumerate the static libs (technically repeating arrow libs so they're in the right order)
-      # TODO: there must be a better way; also what about non-bundled deps?
-      BUNDLED_LIBS=`cd libarrow/arrow-${VERSION}/lib && ls *.a`
-      BUNDLED_LIBS=`echo $BUNDLED_LIBS | sed -E "s/lib(.*)\.a/-l\1/" | sed -e "s/\\.a lib/ -l/g"`
-      PKG_LIBS="-L$(pwd)/libarrow/arrow-${VERSION}/lib $PKG_LIBS $BUNDLED_LIBS"
+
+      LIB_DIR="libarrow/arrow-${VERSION}/lib"
+      if [ -d "$LIB_DIR" ]; then
+        # Enumerate the static libs and add to PKG_LIBS
+        # (technically repeating arrow libs so they're in the right order)
+        #
+        # If tools/linuxlibs.R fails to produce libs, this dir won't exist
+        # so don't try (the error message from `ls` would be misleading)
+        # Assume linuxlibs.R has handled and messaged about its failure already
+        #
+        # TODO: what about non-bundled deps?
+        BUNDLED_LIBS=`cd $LIB_DIR && ls *.a`
+        BUNDLED_LIBS=`echo $BUNDLED_LIBS | sed -E "s/lib(.*)\.a/-l\1/" | sed -e "s/\\.a lib/ -l/g"`
+        PKG_LIBS="-L$(pwd)/$LIB_DIR $PKG_LIBS $BUNDLED_LIBS"
+      fi
     fi
   fi
 fi

--- a/r/inst/build_arrow_static.sh
+++ b/r/inst/build_arrow_static.sh
@@ -81,17 +81,4 @@ ${CMAKE} -DARROW_BOOST_USE_SHARED=OFF \
     -G ${CMAKE_GENERATOR:-"Unix Makefiles"} \
     ${SOURCE_DIR}
 ${CMAKE} --build . --target install
-
-if [ $? -ne 0 ]; then
-  if [ "${DEBUG_DIR}" != "" ]; then
-    # For debugging installation problems, copy the build contents somewhere not tmp
-    mkdir -p ${DEBUG_DIR}
-    cp -r ./* ${DEBUG_DIR}
-    echo "**** Error building Arrow C++. See ${DEBUG_DIR} for details."
-  else
-    # Emit a clear message that the C++ build failed
-    echo "**** Error building Arrow C++. Re-run with ARROW_R_DEV=true for debug information."
-  fi
-fi
-
 popd

--- a/r/vignettes/install.Rmd
+++ b/r/vignettes/install.Rmd
@@ -305,7 +305,7 @@ By default, these are all unset. All boolean variables are case-insensitive.
 * `ARROW_R_DEV`: If set to `true`, more verbose messaging will be printed
   in the build script. This variable also is needed if you're modifying `Rcpp`
   code in the package: see "Editing Rcpp code" in the README.
-* `DEBUG_DIR`: If the C++ library building from source fails (`cmake`),
+* `LIBARROW_DEBUG_DIR`: If the C++ library building from source fails (`cmake`),
   there may be messages telling you to check some log file in the build directory.
   However, when the library is built during R package installation,
   that location is in a temp directory that is already deleted.


### PR DESCRIPTION
There are a couple of things fixed here:

1. For reasons that were not clear, `bz2` was failing to build because `cmp: command not found`. It turns out that `cmp` is only called in `make test`, which we were calling via just `make` https://sourceware.org/git/?p=bzip2.git;a=blob;f=Makefile;h=b0fef950f361d84a5ec42749529fb34276e2de2d;hb=HEAD#l38. This was doing unnecessary work, aside from testing it was building command line utilities etc., so I made it only build libbz2. It's possible that we need to do [something different on MSVC](https://sourceware.org/git/?p=bzip2.git;a=blob;f=makefile.msc;h=799a18a5f1a7b084274ce1cd63997aeb4f9c2688;hb=HEAD) but I don't understand this well enough to be sure.

2. The arrow-r-nightly builds found a bug where the build uses system cmake instead of downloading it.

3. I fixed the install log reporting on CI builds, inadvertently turned off in my last patch.