### PR TITLE
ARROW-9447 [Rust][DataFusion] Made ScalarUDF (Send + Sync)

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -1085,7 +1085,7 @@ mod tests {
         let provider = MemTable::new(Arc::new(schema), vec![vec![batch]])?;
         ctx.register_table("t", Box::new(provider));
 
-        let myfunc: ScalarUdf = |args: &[ArrayRef]| {
+        let myfunc: ScalarUdf = Arc::new(|args: &[ArrayRef]| {
             let l = &args[0]
                 .as_any()
                 .downcast_ref::<Int32Array>()
@@ -1095,7 +1095,7 @@ mod tests {
                 .downcast_ref::<Int32Array>()
                 .expect("cast failed");
             Ok(Arc::new(add(l, r)?))
-        };
+        });
 
         let my_add = ScalarFunction::new(
             "my_add",

--- a/rust/datafusion/src/execution/physical_plan/math_expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/math_expressions.rs
@@ -32,7 +32,7 @@ macro_rules! math_unary_function {
             $NAME,
             vec![Field::new("n", DataType::Float64, true)],
             DataType::Float64,
-            |args: &[ArrayRef]| {
+            Arc::new(|args: &[ArrayRef]| {
                 let n = &args[0].as_any().downcast_ref::<Float64Array>();
                 match n {
                     Some(array) => {
@@ -51,7 +51,7 @@ macro_rules! math_unary_function {
                         $NAME
                     ))),
                 }
-            },
+            }),
         )
     };
 }

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -27,7 +27,7 @@ use arrow::record_batch::RecordBatch;
 use std::sync::Arc;
 
 /// Scalar UDF
-pub type ScalarUdf = fn(input: &[ArrayRef]) -> Result<ArrayRef>;
+pub type ScalarUdf = Arc<dyn Fn(&[ArrayRef]) -> Result<ArrayRef> + Send + Sync>;
 
 /// Scalar UDF Expression
 #[derive(Clone)]

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -173,7 +173,7 @@ fn create_ctx() -> Result<ExecutionContext> {
         "custom_sqrt",
         vec![Field::new("n", DataType::Float64, true)],
         DataType::Float64,
-        custom_sqrt,
+        Arc::new(custom_sqrt),
     ));
 
     Ok(ctx)


### PR DESCRIPTION
This allows udfs be declared dynamically from closures.

I found this necessary while declaring a scalarUDF that runs a closure that is declared non-statically.

Note that our current test passed because the closure did not move any value from outside and was thus coerced to `fn` as described under [RFC-1558](https://github.com/rust-lang/rfcs/blob/master/text/1558-closure-to-fn-coercion.md).
