### PR TITLE
ARROW-9461: [Rust] Fixed error in reading Date32 and Date64.

### DIFF
--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -29,15 +29,15 @@ use arrow::array::{
     Int16BufferBuilder, StructArray,
 };
 use arrow::buffer::{Buffer, MutableBuffer};
-use arrow::datatypes::{DataType as ArrowType, Field, IntervalUnit, TimeUnit};
+use arrow::datatypes::{DataType as ArrowType, DateUnit, Field, IntervalUnit, TimeUnit};
 
 use crate::arrow::converter::{
     BinaryArrayConverter, BinaryConverter, BoolConverter, BooleanArrayConverter,
-    Converter, FixedLenBinaryConverter, FixedSizeArrayConverter, Float32Converter,
-    Float64Converter, Int16Converter, Int32Converter, Int64Converter, Int8Converter,
-    Int96ArrayConverter, Int96Converter, TimestampMicrosecondConverter,
-    TimestampMillisecondConverter, UInt16Converter, UInt32Converter, UInt64Converter,
-    UInt8Converter, Utf8ArrayConverter, Utf8Converter,
+    Converter, Date32Converter, FixedLenBinaryConverter,
+    FixedSizeArrayConverter, Float32Converter, Float64Converter, Int16Converter,
+    Int32Converter, Int64Converter, Int8Converter, Int96ArrayConverter, Int96Converter,
+    TimestampMicrosecondConverter, TimestampMillisecondConverter, UInt16Converter,
+    UInt32Converter, UInt64Converter, UInt8Converter, Utf8ArrayConverter, Utf8Converter,
 };
 use crate::arrow::record_reader::RecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
@@ -196,11 +196,10 @@ impl<T: DataType> ArrayReader for PrimitiveArrayReader<T> {
                         .convert(self.record_reader.cast::<Int64Type>()),
                     _ => Err(general_err!("No conversion from parquet type to arrow type for timestamp with unit {:?}", unit)),
                 },
-                (ArrowType::Date32(_), PhysicalType::INT32) => {
-                    UInt32Converter::new().convert(self.record_reader.cast::<Int32Type>())
-                }
-                (ArrowType::Date64(_), PhysicalType::INT64) => {
-                    UInt64Converter::new().convert(self.record_reader.cast::<Int64Type>())
+                (ArrowType::Date32(unit), PhysicalType::INT32) => match unit {
+                    DateUnit::Day => Date32Converter::new()
+                        .convert(self.record_reader.cast::<Int32Type>()),
+                    _ => Err(general_err!("No conversion from parquet type to arrow type for date with unit {:?}", unit)),
                 }
                 (ArrowType::Time32(_), PhysicalType::INT32) => {
                     UInt32Converter::new().convert(self.record_reader.cast::<Int32Type>())
@@ -947,7 +946,7 @@ mod tests {
     use crate::util::test_common::{get_test_file, make_pages};
     use arrow::array::{Array, ArrayRef, PrimitiveArray, StringArray, StructArray};
     use arrow::datatypes::{
-        DataType as ArrowType, Field, Int32Type as ArrowInt32,
+        DataType as ArrowType, Date32Type as ArrowDate32, Field, Int32Type as ArrowInt32,
         TimestampMicrosecondType as ArrowTimestampMicrosecondType,
         TimestampMillisecondType as ArrowTimestampMillisecondType,
         UInt32Type as ArrowUInt32, UInt64Type as ArrowUInt64,
@@ -1160,8 +1159,8 @@ mod tests {
             Int32Type,
             PhysicalType::INT32,
             "DATE",
-            ArrowUInt32,
-            u32
+            ArrowDate32,
+            i32
         );
         test_primitive_array_reader_one_type!(
             Int32Type,

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -33,11 +33,11 @@ use arrow::datatypes::{DataType as ArrowType, DateUnit, Field, IntervalUnit, Tim
 
 use crate::arrow::converter::{
     BinaryArrayConverter, BinaryConverter, BoolConverter, BooleanArrayConverter,
-    Converter, Date32Converter, FixedLenBinaryConverter,
-    FixedSizeArrayConverter, Float32Converter, Float64Converter, Int16Converter,
-    Int32Converter, Int64Converter, Int8Converter, Int96ArrayConverter, Int96Converter,
-    TimestampMicrosecondConverter, TimestampMillisecondConverter, UInt16Converter,
-    UInt32Converter, UInt64Converter, UInt8Converter, Utf8ArrayConverter, Utf8Converter,
+    Converter, Date32Converter, FixedLenBinaryConverter, FixedSizeArrayConverter,
+    Float32Converter, Float64Converter, Int16Converter, Int32Converter, Int64Converter,
+    Int8Converter, Int96ArrayConverter, Int96Converter, TimestampMicrosecondConverter,
+    TimestampMillisecondConverter, UInt16Converter, UInt32Converter, UInt64Converter,
+    UInt8Converter, Utf8ArrayConverter, Utf8Converter,
 };
 use crate::arrow::record_reader::RecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;

--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -41,8 +41,8 @@ use crate::data_type::{
     Int32Type as ParquetInt32Type, Int64Type as ParquetInt64Type,
 };
 use arrow::datatypes::{
-    Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
-    TimestampMicrosecondType, TimestampMillisecondType, UInt16Type, UInt32Type,
+    Date32Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type,
+    Int8Type, TimestampMicrosecondType, TimestampMillisecondType, UInt16Type, UInt32Type,
     UInt64Type, UInt8Type,
 };
 
@@ -221,6 +221,7 @@ pub type UInt16Converter = CastConverter<ParquetInt32Type, Int32Type, UInt16Type
 pub type Int32Converter = CastConverter<ParquetInt32Type, Int32Type, Int32Type>;
 pub type UInt32Converter = CastConverter<ParquetInt32Type, UInt32Type, UInt32Type>;
 pub type Int64Converter = CastConverter<ParquetInt64Type, Int64Type, Int64Type>;
+pub type Date32Converter = CastConverter<ParquetInt32Type, Date32Type, Date32Type>;
 pub type TimestampMillisecondConverter =
     CastConverter<ParquetInt64Type, TimestampMillisecondType, TimestampMillisecondType>;
 pub type TimestampMicrosecondConverter =

--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -41,8 +41,8 @@ use crate::data_type::{
     Int32Type as ParquetInt32Type, Int64Type as ParquetInt64Type,
 };
 use arrow::datatypes::{
-    Date32Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type,
-    Int8Type, TimestampMicrosecondType, TimestampMillisecondType, UInt16Type, UInt32Type,
+    Date32Type, Float32Type, Float64Type, Int16Type, Int32Type, Int64Type, Int8Type,
+    TimestampMicrosecondType, TimestampMillisecondType, UInt16Type, UInt32Type,
     UInt64Type, UInt8Type,
 };
 
@@ -314,72 +314,58 @@ mod tests {
     use arrow::datatypes::{Int16Type, Int32Type};
     use std::rc::Rc;
 
-    #[test]
-    fn test_converter_arrow_source_target_different() {
-        let raw_data = vec![Some(1i16), None, Some(2i16), Some(3i16)];
+    macro_rules! converter_arrow_source_target {
+        ($raw_data:expr, $physical_type:expr, $result_arrow_type:ty, $converter:ty) => {{
+            // Construct record reader
+            let mut record_reader = {
+                // Construct column schema
+                let message_type = &format!(
+                    "
+                message test_schema {{
+                OPTIONAL {} leaf;
+                }}
+                ",
+                    $physical_type
+                );
 
-        // Construct record reader
-        let mut record_reader = {
-            // Construct column schema
-            let message_type = "
-            message test_schema {
-              OPTIONAL INT32 leaf;
-            }
-            ";
+                let def_levels = [1i16, 0i16, 1i16, 1i16];
+                build_record_reader(
+                    message_type,
+                    &[1, 2, 3],
+                    0i16,
+                    None,
+                    1i16,
+                    Some(&def_levels),
+                    10,
+                )
+            };
 
-            let def_levels = [1i16, 0i16, 1i16, 1i16];
-            build_record_reader(
-                message_type,
-                &[1, 2, 3],
-                0i16,
-                None,
-                1i16,
-                Some(&def_levels),
-                10,
-            )
-        };
+            let array = <$converter>::new().convert(&mut record_reader).unwrap();
+            let array = array
+                .as_any()
+                .downcast_ref::<PrimitiveArray<$result_arrow_type>>()
+                .unwrap();
 
-        let array = Int16Converter::new().convert(&mut record_reader).unwrap();
-        let array = array
-            .as_any()
-            .downcast_ref::<PrimitiveArray<Int16Type>>()
-            .unwrap();
-
-        assert!(array.equals(&PrimitiveArray::<Int16Type>::from(raw_data)));
+            assert!(array.equals(&PrimitiveArray::<$result_arrow_type>::from($raw_data)));
+        }};
     }
 
     #[test]
-    fn test_converter_arrow_source_target_same() {
-        let raw_data = vec![Some(1), None, Some(2), Some(3)];
+    fn test_converter_arrow_source_i16_target_i32() {
+        let raw_data = vec![Some(1i16), None, Some(2i16), Some(3i16)];
+        converter_arrow_source_target!(raw_data, "INT32", Int16Type, Int16Converter)
+    }
 
-        // Construct record reader
-        let mut record_reader = {
-            // Construct column schema
-            let message_type = "
-            message test_schema {
-              OPTIONAL INT32 leaf;
-            }
-            ";
+    #[test]
+    fn test_converter_arrow_source_i32_target_date32() {
+        let raw_data = vec![Some(1i32), None, Some(2i32), Some(3i32)];
+        converter_arrow_source_target!(raw_data, "INT32", Date32Type, Date32Converter)
+    }
 
-            let def_levels = [1i16, 0i16, 1i16, 1i16];
-            build_record_reader(
-                message_type,
-                &[1, 2, 3],
-                0i16,
-                None,
-                1i16,
-                Some(&def_levels),
-                10,
-            )
-        };
-
-        let array = Int32Converter::new().convert(&mut record_reader).unwrap();
-        let array = array
-            .as_any()
-            .downcast_ref::<PrimitiveArray<Int32Type>>()
-            .unwrap();
-
-        assert!(array.equals(&PrimitiveArray::<Int32Type>::from(raw_data)));
+    #[test]
+    fn test_converter_arrow_source_i32_target_i32() {
+        let raw_data = vec![Some(1i32), None, Some(2i32), Some(3i32)];
+        converter_arrow_source_target!(raw_data, "INT32", Int32Type, Int32Converter)
     }
 
     fn build_record_reader<T: DataType>(


### PR DESCRIPTION
This caused an error as the column.schema() became different from the expected schema, as the conversion was incorrect.