### PR TITLE
ARROW-9390: [C++][Doc] Review compute function names

### DIFF
--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -38,7 +38,7 @@ Result<Datum> Sum(const Datum& value, ExecContext* ctx) {
 }
 
 Result<Datum> MinMax(const Datum& value, const MinMaxOptions& options, ExecContext* ctx) {
-  return CallFunction("minmax", {value}, &options, ctx);
+  return CallFunction("min_max", {value}, &options, ctx);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -73,12 +73,12 @@ static Result<Datum> ExecSetLookup(const std::string& func_name, const Datum& da
 }
 
 Result<Datum> IsIn(const Datum& values, const Datum& value_set, ExecContext* ctx) {
-  return ExecSetLookup("isin", values, value_set,
+  return ExecSetLookup("is_in", values, value_set,
                        /*add_nulls_to_hash_table=*/false, ctx);
 }
 
-Result<Datum> Match(const Datum& values, const Datum& value_set, ExecContext* ctx) {
-  return ExecSetLookup("match", values, value_set,
+Result<Datum> IndexIn(const Datum& values, const Datum& value_set, ExecContext* ctx) {
+  return ExecSetLookup("index_in", values, value_set,
                        /*add_nulls_to_hash_table=*/true, ctx);
 }
 

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -42,15 +42,14 @@ struct ArithmeticOptions : public FunctionOptions {
   bool check_overflow;
 };
 
-struct ARROW_EXPORT BinaryContainsExactOptions : public FunctionOptions {
-  explicit BinaryContainsExactOptions(std::string pattern)
-      : pattern(std::move(pattern)) {}
+struct ARROW_EXPORT MatchSubstringOptions : public FunctionOptions {
+  explicit MatchSubstringOptions(std::string pattern) : pattern(std::move(pattern)) {}
 
-  /// The exact pattern to look for inside input values.
+  /// The exact substring to look for inside input values.
   std::string pattern;
 };
 
-/// Options for IsIn and Match functions
+/// Options for IsIn and IndexIn functions
 struct ARROW_EXPORT SetLookupOptions : public FunctionOptions {
   explicit SetLookupOptions(Datum value_set, bool skip_nulls)
       : value_set(std::move(value_set)), skip_nulls(skip_nulls) {}
@@ -60,7 +59,7 @@ struct ARROW_EXPORT SetLookupOptions : public FunctionOptions {
   /// Whether nulls in `value_set` count for lookup.
   ///
   /// If true, any null in `value_set` is ignored and nulls in the input
-  /// produce null (Match) or false (IsIn) values in the output.
+  /// produce null (IndexIn) or false (IsIn) values in the output.
   /// If false, any null in `value_set` is successfully matched in
   /// the input.
   bool skip_nulls;
@@ -238,7 +237,7 @@ ARROW_EXPORT
 Result<Datum> IsIn(const Datum& values, const Datum& value_set,
                    ExecContext* ctx = NULLPTR);
 
-/// \brief Match examines each slot in the values against a value_set array.
+/// \brief IndexIn examines each slot in the values against a value_set array.
 /// If the value is not found in value_set, null will be output.
 /// If found, the index of occurrence within value_set (ignoring duplicates)
 /// will be output.
@@ -259,8 +258,8 @@ Result<Datum> IsIn(const Datum& values, const Datum& value_set,
 /// \since 1.0.0
 /// \note API not yet finalized
 ARROW_EXPORT
-Result<Datum> Match(const Datum& values, const Datum& value_set,
-                    ExecContext* ctx = NULLPTR);
+Result<Datum> IndexIn(const Datum& values, const Datum& value_set,
+                      ExecContext* ctx = NULLPTR);
 
 /// \brief IsValid returns true for each element of `values` that is not null,
 /// false otherwise

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -35,9 +35,9 @@ namespace compute {
 
 Result<std::shared_ptr<Array>> NthToIndices(const Array& values, int64_t n,
                                             ExecContext* ctx) {
-  PartitionOptions options(/*pivot=*/n);
-  ARROW_ASSIGN_OR_RAISE(
-      Datum result, CallFunction("partition_indices", {Datum(values)}, &options, ctx));
+  PartitionNthOptions options(/*pivot=*/n);
+  ARROW_ASSIGN_OR_RAISE(Datum result, CallFunction("partition_nth_indices",
+                                                   {Datum(values)}, &options, ctx));
   return result.make_array();
 }
 

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -59,8 +59,8 @@ struct ARROW_EXPORT TakeOptions : public FunctionOptions {
 };
 
 /// \brief Partitioning options for NthToIndices
-struct PartitionOptions : public FunctionOptions {
-  explicit PartitionOptions(int64_t pivot) : pivot(pivot) {}
+struct PartitionNthOptions : public FunctionOptions {
+  explicit PartitionNthOptions(int64_t pivot) : pivot(pivot) {}
 
   /// The index into the equivalent sorted array of the partition pivot element.
   int64_t pivot;

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -398,7 +398,7 @@ void RegisterScalarAggregateBasic(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(std::move(func)));
 
   static auto default_minmax_options = MinMaxOptions::Defaults();
-  func = std::make_shared<ScalarAggregateFunction>("minmax", Arity::Unary(),
+  func = std::make_shared<ScalarAggregateFunction>("min_max", Arity::Unary(),
                                                    &default_minmax_options);
   aggregate::AddMinMaxKernels(aggregate::MinMaxInit, {boolean()}, func.get());
   aggregate::AddMinMaxKernels(aggregate::MinMaxInit, NumericTypes(), func.get());

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -583,11 +583,11 @@ TYPED_TEST(TestFloatingMinMaxKernel, Floats) {
 TYPED_TEST(TestFloatingMinMaxKernel, DefaultOptions) {
   auto values = ArrayFromJSON(this->type_singleton(), "[0, 1, 2, 3, 4]");
 
-  ASSERT_OK_AND_ASSIGN(auto no_options_provided, CallFunction("minmax", {values}));
+  ASSERT_OK_AND_ASSIGN(auto no_options_provided, CallFunction("min_max", {values}));
 
   auto default_options = MinMaxOptions::Defaults();
   ASSERT_OK_AND_ASSIGN(auto explicit_defaults,
-                       CallFunction("minmax", {values}, &default_options));
+                       CallFunction("min_max", {values}, &default_options));
 
   AssertDatumsEqual(explicit_defaults, no_options_provided);
 }

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -28,7 +28,7 @@ namespace internal {
 namespace {
 
 template <typename Type, typename offset_type = typename Type::offset_type>
-void ListValueLengths(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+void ListValueLength(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
   using ScalarType = typename TypeTraits<Type>::ScalarType;
   using OffsetScalarType = typename TypeTraits<Type>::OffsetScalarType;
 
@@ -55,13 +55,13 @@ void ListValueLengths(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
 }  // namespace
 
 void RegisterScalarNested(FunctionRegistry* registry) {
-  auto list_value_lengths =
-      std::make_shared<ScalarFunction>("list_value_lengths", Arity::Unary());
-  DCHECK_OK(list_value_lengths->AddKernel({InputType(Type::LIST)}, int32(),
-                                          ListValueLengths<ListType>));
-  DCHECK_OK(list_value_lengths->AddKernel({InputType(Type::LARGE_LIST)}, int64(),
-                                          ListValueLengths<LargeListType>));
-  DCHECK_OK(registry->AddFunction(std::move(list_value_lengths)));
+  auto list_value_length =
+      std::make_shared<ScalarFunction>("list_value_length", Arity::Unary());
+  DCHECK_OK(list_value_length->AddKernel({InputType(Type::LIST)}, int32(),
+                                         ListValueLength<ListType>));
+  DCHECK_OK(list_value_length->AddKernel({InputType(Type::LARGE_LIST)}, int64(),
+                                         ListValueLength<LargeListType>));
+  DCHECK_OK(registry->AddFunction(std::move(list_value_length)));
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested_test.cc
@@ -29,9 +29,9 @@ static std::shared_ptr<DataType> GetOffsetType(const DataType& type) {
   return type.id() == Type::LIST ? int32() : int64();
 }
 
-TEST(TestScalarNested, ListValueLengths) {
+TEST(TestScalarNested, ListValueLength) {
   for (auto ty : {list(int32()), large_list(int32())}) {
-    CheckScalarUnary("list_value_lengths", ty, "[[0, null, 1], null, [2, 3], []]",
+    CheckScalarUnary("list_value_length", ty, "[[0, null, 1], null, [2, 3], []]",
                      GetOffsetType(*ty), "[3, null, 2, 0]");
   }
 }

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -253,7 +253,6 @@ TEST_F(TestIsInKernel, IsInBoolean) {
                                {});
 }
 
-using BinaryTypes = ::testing::Types<BinaryType, StringType>;
 TYPED_TEST_SUITE(TestIsInKernelBinary, BinaryTypes);
 
 TYPED_TEST(TestIsInKernelBinary, IsInBinary) {
@@ -596,7 +595,6 @@ TEST_F(TestMatchKernel, MatchBoolean) {
 template <typename Type>
 class TestMatchKernelBinary : public TestMatchKernel {};
 
-using BinaryTypes = ::testing::Types<BinaryType, StringType>;
 TYPED_TEST_SUITE(TestMatchKernelBinary, BinaryTypes);
 
 TYPED_TEST(TestMatchKernelBinary, MatchBinary) {

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup_test.cc
@@ -73,9 +73,9 @@ class TestIsInKernel : public ::testing::Test {};
 TEST_F(TestIsInKernel, CallBinary) {
   auto haystack = ArrayFromJSON(int8(), "[0, 1, 2, 3, 4, 5, 6, 7, 8]");
   auto needles = ArrayFromJSON(int8(), "[2, 3, 5, 7]");
-  ASSERT_RAISES(Invalid, CallFunction("isin", {haystack, needles}));
+  ASSERT_RAISES(Invalid, CallFunction("is_in", {haystack, needles}));
 
-  ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("isin_meta_binary", {haystack, needles}));
+  ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("is_in_meta_binary", {haystack, needles}));
   auto expected = ArrayFromJSON(boolean(), ("[false, false, true, true, false,"
                                             "true, false, true, false]"));
   AssertArraysEqual(*expected, *out.make_array());
@@ -118,6 +118,7 @@ TYPED_TEST(TestIsInKernelPrimitive, IsIn) {
   CheckIsIn<TypeParam, T>(
       type, {2, 1, 2, 3}, {false, false, false, false}, {2, 1, 2, 1, 2, 3, 3},
       {false, false, false, false, false, false, false}, {true, true, true, true}, {});
+
   // No Match
   CheckIsIn<TypeParam, T>(
       type, {2, 1, 7, 3, 8}, {true, false, true, true, true}, {2, 1, 2, 1, 6, 3, 3},
@@ -411,7 +412,7 @@ TEST_F(TestIsInKernel, IsInChunkedArrayInvoke) {
   AssertChunkedEquivalent(*expected_carr, *encoded_out.chunked_array());
 }
 // ----------------------------------------------------------------------
-// Match tests
+// IndexIn tests
 
 class TestMatchKernel : public ::testing::Test {
  public:
@@ -421,7 +422,7 @@ class TestMatchKernel : public ::testing::Test {
     std::shared_ptr<Array> needles = ArrayFromJSON(type, needles_json);
     std::shared_ptr<Array> expected = ArrayFromJSON(int32(), expected_json);
 
-    ASSERT_OK_AND_ASSIGN(Datum actual_datum, Match(haystack, needles));
+    ASSERT_OK_AND_ASSIGN(Datum actual_datum, IndexIn(haystack, needles));
     std::shared_ptr<Array> actual = actual_datum.make_array();
     AssertArraysEqual(*expected, *actual, /*verbose=*/true);
   }
@@ -430,9 +431,10 @@ class TestMatchKernel : public ::testing::Test {
 TEST_F(TestMatchKernel, CallBinary) {
   auto haystack = ArrayFromJSON(int8(), "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]");
   auto needles = ArrayFromJSON(int8(), "[2, 3, 5, 7]");
-  ASSERT_RAISES(Invalid, CallFunction("match", {haystack, needles}));
+  ASSERT_RAISES(Invalid, CallFunction("index_in", {haystack, needles}));
 
-  ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("match_meta_binary", {haystack, needles}));
+  ASSERT_OK_AND_ASSIGN(Datum out,
+                       CallFunction("index_in_meta_binary", {haystack, needles}));
   auto expected = ArrayFromJSON(int32(), ("[null, null, 0, 1, null, 2, null, 3, null,"
                                           " null, null]"));
   AssertArraysEqual(*expected, *out.make_array());
@@ -448,7 +450,7 @@ using PrimitiveDictionaries =
 
 TYPED_TEST_SUITE(TestMatchKernelPrimitive, PrimitiveDictionaries);
 
-TYPED_TEST(TestMatchKernelPrimitive, Match) {
+TYPED_TEST(TestMatchKernelPrimitive, IndexIn) {
   auto type = TypeTraits<TypeParam>::type_singleton();
 
   // No Nulls
@@ -508,7 +510,7 @@ TYPED_TEST(TestMatchKernelPrimitive, PrimitiveResizeTable) {
   needles = haystack;
   ASSERT_OK(expected_builder.Finish(&expected));
 
-  ASSERT_OK_AND_ASSIGN(Datum actual_datum, Match(haystack, needles));
+  ASSERT_OK_AND_ASSIGN(Datum actual_datum, IndexIn(haystack, needles));
   std::shared_ptr<Array> actual = actual_datum.make_array();
   ASSERT_ARRAYS_EQUAL(*expected, *actual);
 }
@@ -667,7 +669,7 @@ TEST_F(TestMatchKernel, BinaryResizeTable) {
   needles = haystack;
   ASSERT_OK(expected_builder.Finish(&expected));
 
-  ASSERT_OK_AND_ASSIGN(Datum actual_datum, Match(haystack, needles));
+  ASSERT_OK_AND_ASSIGN(Datum actual_datum, IndexIn(haystack, needles));
   std::shared_ptr<Array> actual = actual_datum.make_array();
   ASSERT_ARRAYS_EQUAL(*expected, *actual);
 }
@@ -749,7 +751,7 @@ TEST_F(TestMatchKernel, MatchChunkedArrayInvoke) {
   ArrayVector expected = {i1, i2};
   auto expected_carr = std::make_shared<ChunkedArray>(expected);
 
-  ASSERT_OK_AND_ASSIGN(Datum encoded_out, Match(carr, Datum(member_set)));
+  ASSERT_OK_AND_ASSIGN(Datum encoded_out, IndexIn(carr, Datum(member_set)));
   ASSERT_EQ(Datum::CHUNKED_ARRAY, encoded_out.kind());
 
   AssertChunkedEquivalent(*expected_carr, *encoded_out.chunked_array());

--- a/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
@@ -61,9 +61,9 @@ static void IsAlphaNumericAscii(benchmark::State& state) {
   UnaryStringBenchmark(state, "ascii_isalnum");
 }
 
-static void BinaryContainsExact(benchmark::State& state) {
-  BinaryContainsExactOptions options("abac");
-  UnaryStringBenchmark(state, "binary_contains_exact", &options);
+static void MatchSubstring(benchmark::State& state) {
+  MatchSubstringOptions options("abac");
+  UnaryStringBenchmark(state, "match_substring", &options);
 }
 
 #ifdef ARROW_WITH_UTF8PROC
@@ -83,7 +83,7 @@ static void IsAlphaNumericUnicode(benchmark::State& state) {
 BENCHMARK(AsciiLower);
 BENCHMARK(AsciiUpper);
 BENCHMARK(IsAlphaNumericAscii);
-BENCHMARK(BinaryContainsExact);
+BENCHMARK(MatchSubstring);
 #ifdef ARROW_WITH_UTF8PROC
 BENCHMARK(Utf8Lower);
 BENCHMARK(Utf8Upper);

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -30,10 +30,6 @@
 namespace arrow {
 namespace compute {
 
-using BinaryTypes =
-    ::testing::Types<BinaryType, LargeBinaryType, StringType, LargeStringType>;
-using StringTypes = ::testing::Types<StringType, LargeStringType>;
-
 // interesting utf8 characters for testing (lower case / upper case):
 //  * ῦ / Υ͂ (3 to 4 code units) (Note, we don't support this yet, utf8proc does not use
 //  SpecialCasing.txt)

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -30,6 +30,8 @@
 namespace arrow {
 namespace compute {
 
+using BinaryTypes =
+    ::testing::Types<BinaryType, LargeBinaryType, StringType, LargeStringType>;
 using StringTypes = ::testing::Types<StringType, LargeStringType>;
 
 // interesting utf8 characters for testing (lower case / upper case):
@@ -40,43 +42,48 @@ using StringTypes = ::testing::Types<StringType, LargeStringType>;
 //  * Ⱥ / ⱥ  (2 to 3 code units)
 
 template <typename TestType>
-class TestStringKernels : public ::testing::Test {
+class BaseTestStringKernels : public ::testing::Test {
  protected:
   using OffsetType = typename TypeTraits<TestType>::OffsetType;
 
   void CheckUnary(std::string func_name, std::string json_input,
                   std::shared_ptr<DataType> out_ty, std::string json_expected,
                   const FunctionOptions* options = nullptr) {
-    CheckScalarUnary(func_name, string_type(), json_input, out_ty, json_expected,
-                     options);
+    CheckScalarUnary(func_name, type(), json_input, out_ty, json_expected, options);
   }
 
-  std::shared_ptr<DataType> string_type() {
-    return TypeTraits<TestType>::type_singleton();
-  }
+  std::shared_ptr<DataType> type() { return TypeTraits<TestType>::type_singleton(); }
 
   std::shared_ptr<DataType> offset_type() {
     return TypeTraits<OffsetType>::type_singleton();
   }
 };
 
-TYPED_TEST_SUITE(TestStringKernels, StringTypes);
+template <typename TestType>
+class TestBinaryKernels : public BaseTestStringKernels<TestType> {};
 
-TYPED_TEST(TestStringKernels, AsciiLength) {
-  this->CheckUnary("ascii_length", R"(["aaa", null, "", "b"])", this->offset_type(),
+TYPED_TEST_SUITE(TestBinaryKernels, BinaryTypes);
+
+TYPED_TEST(TestBinaryKernels, BinaryLength) {
+  this->CheckUnary("binary_length", R"(["aaa", null, "", "b"])", this->offset_type(),
                    "[3, null, 0, 1]");
 }
 
+template <typename TestType>
+class TestStringKernels : public BaseTestStringKernels<TestType> {};
+
+TYPED_TEST_SUITE(TestStringKernels, StringTypes);
+
 TYPED_TEST(TestStringKernels, AsciiUpper) {
-  this->CheckUnary("ascii_upper", "[]", this->string_type(), "[]");
-  this->CheckUnary("ascii_upper", "[\"aAazZæÆ&\", null, \"\", \"bbb\"]",
-                   this->string_type(), "[\"AAAZZæÆ&\", null, \"\", \"BBB\"]");
+  this->CheckUnary("ascii_upper", "[]", this->type(), "[]");
+  this->CheckUnary("ascii_upper", "[\"aAazZæÆ&\", null, \"\", \"bbb\"]", this->type(),
+                   "[\"AAAZZæÆ&\", null, \"\", \"BBB\"]");
 }
 
 TYPED_TEST(TestStringKernels, AsciiLower) {
-  this->CheckUnary("ascii_lower", "[]", this->string_type(), "[]");
-  this->CheckUnary("ascii_lower", "[\"aAazZæÆ&\", null, \"\", \"BBB\"]",
-                   this->string_type(), "[\"aaazzæÆ&\", null, \"\", \"bbb\"]");
+  this->CheckUnary("ascii_lower", "[]", this->type(), "[]");
+  this->CheckUnary("ascii_lower", "[\"aAazZæÆ&\", null, \"\", \"BBB\"]", this->type(),
+                   "[\"aaazzæÆ&\", null, \"\", \"bbb\"]");
 }
 
 TEST(TestStringKernels, LARGE_MEMORY_TEST(Utf8Upper32bitGrowth)) {
@@ -101,46 +108,44 @@ TEST(TestStringKernels, LARGE_MEMORY_TEST(Utf8Upper32bitGrowth)) {
 #ifdef ARROW_WITH_UTF8PROC
 
 TYPED_TEST(TestStringKernels, Utf8Upper) {
-  this->CheckUnary("utf8_upper", "[\"aAazZæÆ&\", null, \"\", \"b\"]", this->string_type(),
+  this->CheckUnary("utf8_upper", "[\"aAazZæÆ&\", null, \"\", \"b\"]", this->type(),
                    "[\"AAAZZÆÆ&\", null, \"\", \"B\"]");
 
   // test varying encoding lenghts and thus changing indices/offsets
-  this->CheckUnary("utf8_upper", "[\"ɑɽⱤoW\", null, \"ıI\", \"b\"]", this->string_type(),
+  this->CheckUnary("utf8_upper", "[\"ɑɽⱤoW\", null, \"ıI\", \"b\"]", this->type(),
                    "[\"ⱭⱤⱤOW\", null, \"II\", \"B\"]");
 
   // ῦ to Υ͂ not supported
-  // this->CheckUnary("utf8_upper", "[\"ῦɐɜʞȿ\"]", this->string_type(),
+  // this->CheckUnary("utf8_upper", "[\"ῦɐɜʞȿ\"]", this->type(),
   // "[\"Υ͂ⱯꞫꞰⱾ\"]");
 
   // test maximum buffer growth
-  this->CheckUnary("utf8_upper", "[\"ɑɑɑɑ\"]", this->string_type(), "[\"ⱭⱭⱭⱭ\"]");
+  this->CheckUnary("utf8_upper", "[\"ɑɑɑɑ\"]", this->type(), "[\"ⱭⱭⱭⱭ\"]");
 
   // Test invalid data
-  auto invalid_input =
-      ArrayFromJSON(this->string_type(), "[\"ɑa\xFFɑ\", \"ɽ\xe1\xbdɽaa\"]");
+  auto invalid_input = ArrayFromJSON(this->type(), "[\"ɑa\xFFɑ\", \"ɽ\xe1\xbdɽaa\"]");
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("Invalid UTF8 sequence"),
                                   CallFunction("utf8_upper", {invalid_input}));
 }
 
 TYPED_TEST(TestStringKernels, Utf8Lower) {
-  this->CheckUnary("utf8_lower", "[\"aAazZæÆ&\", null, \"\", \"b\"]", this->string_type(),
+  this->CheckUnary("utf8_lower", "[\"aAazZæÆ&\", null, \"\", \"b\"]", this->type(),
                    "[\"aaazzææ&\", null, \"\", \"b\"]");
 
   // test varying encoding lenghts and thus changing indices/offsets
-  this->CheckUnary("utf8_lower", "[\"ⱭɽⱤoW\", null, \"ıI\", \"B\"]", this->string_type(),
+  this->CheckUnary("utf8_lower", "[\"ⱭɽⱤoW\", null, \"ıI\", \"B\"]", this->type(),
                    "[\"ɑɽɽow\", null, \"ıi\", \"b\"]");
 
   // ῦ to Υ͂ is not supported, but in principle the reverse is, but it would need
   // normalization
-  // this->CheckUnary("utf8_lower", "[\"Υ͂ⱯꞫꞰⱾ\"]", this->string_type(),
+  // this->CheckUnary("utf8_lower", "[\"Υ͂ⱯꞫꞰⱾ\"]", this->type(),
   // "[\"ῦɐɜʞȿ\"]");
 
   // test maximum buffer growth
-  this->CheckUnary("utf8_lower", "[\"ȺȺȺȺ\"]", this->string_type(), "[\"ⱥⱥⱥⱥ\"]");
+  this->CheckUnary("utf8_lower", "[\"ȺȺȺȺ\"]", this->type(), "[\"ⱥⱥⱥⱥ\"]");
 
   // Test invalid data
-  auto invalid_input =
-      ArrayFromJSON(this->string_type(), "[\"Ⱥa\xFFⱭ\", \"Ɽ\xe1\xbdⱤaA\"]");
+  auto invalid_input = ArrayFromJSON(this->type(), "[\"Ⱥa\xFFⱭ\", \"Ɽ\xe1\xbdⱤaA\"]");
   EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("Invalid UTF8 sequence"),
                                   CallFunction("utf8_lower", {invalid_input}));
 }
@@ -160,7 +165,7 @@ TYPED_TEST(TestStringKernels, IsAlphaUnicode) {
 }
 
 TYPED_TEST(TestStringKernels, IsAscii) {
-  this->CheckUnary("binary_isascii", "[\"azAZ~\", null, \"Ɑ\", \"\"]", boolean(),
+  this->CheckUnary("string_isascii", "[\"azAZ~\", null, \"Ɑ\", \"\"]", boolean(),
                    "[true, null, false, true]");
 }
 
@@ -311,23 +316,23 @@ TYPED_TEST(TestStringKernels, IsUpperAscii) {
                    boolean(), "[false, null, false, true, true, false, false]");
 }
 
-TYPED_TEST(TestStringKernels, BinaryContainsExact) {
-  BinaryContainsExactOptions options{"ab"};
-  this->CheckUnary("binary_contains_exact", "[]", boolean(), "[]", &options);
-  this->CheckUnary("binary_contains_exact", R"(["abc", "acb", "cab", null, "bac"])",
-                   boolean(), "[true, false, true, null, false]", &options);
+TYPED_TEST(TestStringKernels, MatchSubstring) {
+  MatchSubstringOptions options{"ab"};
+  this->CheckUnary("match_substring", "[]", boolean(), "[]", &options);
+  this->CheckUnary("match_substring", R"(["abc", "acb", "cab", null, "bac"])", boolean(),
+                   "[true, false, true, null, false]", &options);
 
-  BinaryContainsExactOptions options_repeated{"abab"};
-  this->CheckUnary("binary_contains_exact", R"(["abab", "ab", "cababc", null, "bac"])",
+  MatchSubstringOptions options_repeated{"abab"};
+  this->CheckUnary("match_substring", R"(["abab", "ab", "cababc", null, "bac"])",
                    boolean(), "[true, false, true, null, false]", &options_repeated);
 
   // ARROW-9460
-  BinaryContainsExactOptions options_double_char{"aab"};
-  this->CheckUnary("binary_contains_exact", R"(["aacb", "aab", "ab", "aaab"])", boolean(),
+  MatchSubstringOptions options_double_char{"aab"};
+  this->CheckUnary("match_substring", R"(["aacb", "aab", "ab", "aaab"])", boolean(),
                    "[false, true, false, true]", &options_double_char);
-  BinaryContainsExactOptions options_double_char_2{"bbcaa"};
-  this->CheckUnary("binary_contains_exact", R"(["abcbaabbbcaabccabaab"])", boolean(),
-                   "[true]", &options_double_char_2);
+  MatchSubstringOptions options_double_char_2{"bbcaa"};
+  this->CheckUnary("match_substring", R"(["abcbaabbbcaabccabaab"])", boolean(), "[true]",
+                   &options_double_char_2);
 }
 
 TYPED_TEST(TestStringKernels, Strptime) {
@@ -338,8 +343,7 @@ TYPED_TEST(TestStringKernels, Strptime) {
 }
 
 TYPED_TEST(TestStringKernels, StrptimeDoesNotProvideDefaultOptions) {
-  auto input =
-      ArrayFromJSON(this->string_type(), R"(["2020-05-01", null, "1900-12-11"])");
+  auto input = ArrayFromJSON(this->type(), R"(["2020-05-01", null, "1900-12-11"])");
   ASSERT_RAISES(Invalid, CallFunction("strptime", {input}));
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -37,7 +37,7 @@ struct IsValidOperator {
   static void Call(KernelContext* ctx, const ArrayData& arr, ArrayData* out) {
     DCHECK_EQ(out->offset, 0);
     DCHECK_LE(out->length, arr.length);
-    if (arr.null_count != 0 && arr.buffers[0] != nullptr) {
+    if (arr.MayHaveNulls()) {
       // Input has nulls => output is the null (validity) bitmap.
       // To avoid copying the null bitmap, slice from the starting byte offset
       // and set the offset to the remaining bit offset.
@@ -62,7 +62,7 @@ struct IsNullOperator {
   }
 
   static void Call(KernelContext* ctx, const ArrayData& arr, ArrayData* out) {
-    if (arr.null_count != 0 && arr.buffers[0] != nullptr) {
+    if (arr.MayHaveNulls()) {
       // Input has nulls => output is the inverted null (validity) bitmap.
       InvertBitmap(arr.buffers[0]->data(), arr.offset, arr.length,
                    out->buffers[1]->mutable_data(), out->offset);

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -37,23 +37,22 @@ struct IsValidOperator {
   static void Call(KernelContext* ctx, const ArrayData& arr, ArrayData* out) {
     DCHECK_EQ(out->offset, 0);
     DCHECK_LE(out->length, arr.length);
-    if (arr.buffers[0] != nullptr) {
-      out->buffers[1] = arr.offset == 0
-                            ? arr.buffers[0]
-                            : SliceBuffer(arr.buffers[0], arr.offset / 8, arr.length / 8);
+    if (arr.null_count != 0 && arr.buffers[0] != nullptr) {
+      // Input has nulls => output is the null (validity) bitmap.
+      // To avoid copying the null bitmap, slice from the starting byte offset
+      // and set the offset to the remaining bit offset.
       out->offset = arr.offset % 8;
+      out->buffers[1] =
+          arr.offset == 0 ? arr.buffers[0]
+                          : SliceBuffer(arr.buffers[0], arr.offset / 8,
+                                        BitUtil::BytesForBits(out->length + out->offset));
       return;
     }
 
-    KERNEL_RETURN_IF_ERROR(ctx, ctx->AllocateBitmap(out->length).Value(&out->buffers[1]));
-
-    if (arr.null_count == 0 || arr.buffers[0] == nullptr) {
-      BitUtil::SetBitsTo(out->buffers[1]->mutable_data(), out->offset, out->length, true);
-      return;
-    }
-
-    CopyBitmap(arr.buffers[0]->data(), arr.offset, arr.length,
-               out->buffers[1]->mutable_data(), out->offset);
+    // Input has no nulls => output is entirely true.
+    KERNEL_ASSIGN_OR_RAISE(out->buffers[1], ctx,
+                           ctx->AllocateBitmap(out->length + out->offset));
+    BitUtil::SetBitsTo(out->buffers[1]->mutable_data(), out->offset, out->length, true);
   }
 };
 
@@ -63,14 +62,15 @@ struct IsNullOperator {
   }
 
   static void Call(KernelContext* ctx, const ArrayData& arr, ArrayData* out) {
-    if (arr.null_count == 0 || arr.buffers[0] == nullptr) {
-      BitUtil::SetBitsTo(out->buffers[1]->mutable_data(), out->offset, out->length,
-                         false);
+    if (arr.null_count != 0 && arr.buffers[0] != nullptr) {
+      // Input has nulls => output is the inverted null (validity) bitmap.
+      InvertBitmap(arr.buffers[0]->data(), arr.offset, arr.length,
+                   out->buffers[1]->mutable_data(), out->offset);
       return;
     }
 
-    InvertBitmap(arr.buffers[0]->data(), arr.offset, arr.length,
-                 out->buffers[1]->mutable_data(), out->offset);
+    // Input has no nulls => output is entirely false.
+    BitUtil::SetBitsTo(out->buffers[1]->mutable_data(), out->offset, out->length, false);
   }
 };
 

--- a/cpp/src/arrow/compute/kernels/test_util.cc
+++ b/cpp/src/arrow/compute/kernels/test_util.cc
@@ -31,39 +31,55 @@
 namespace arrow {
 namespace compute {
 
-void CheckScalarUnary(std::string func_name, std::shared_ptr<Array> input,
-                      std::shared_ptr<Array> expected, const FunctionOptions* options) {
+namespace {
+
+void CheckScalarUnaryNonRecursive(const std::string& func_name,
+                                  const std::shared_ptr<Array>& input,
+                                  const std::shared_ptr<Array>& expected,
+                                  const FunctionOptions* options) {
   ASSERT_OK_AND_ASSIGN(Datum out, CallFunction(func_name, {input}, options));
   std::shared_ptr<Array> actual = std::move(out).make_array();
   ASSERT_OK(actual->ValidateFull());
   AssertArraysEqual(*expected, *actual, /*verbose=*/true);
+}
 
-  // Check all the scalars
+}  // namespace
+
+void CheckScalarUnary(std::string func_name, std::shared_ptr<Array> input,
+                      std::shared_ptr<Array> expected, const FunctionOptions* options) {
+  CheckScalarUnaryNonRecursive(func_name, input, expected, options);
+
+  // Check all the input scalars
   for (int64_t i = 0; i < input->length(); ++i) {
     ASSERT_OK_AND_ASSIGN(auto val, input->GetScalar(i));
     ASSERT_OK_AND_ASSIGN(auto ex_val, expected->GetScalar(i));
     CheckScalarUnary(func_name, val, ex_val, options);
   }
 
-  if (auto length = input->length() / 3) {
-    // XXX Is the recursive call intended?
-    CheckScalarUnary(func_name, input->Slice(0, length), expected->Slice(0, length),
-                     options);
+  const auto slice_length = input->length() / 3;
+  // Since it's a scalar function, calling it on a sliced input should
+  // result in the sliced expected output.
+  if (slice_length > 0) {
+    CheckScalarUnaryNonRecursive(func_name, input->Slice(0, slice_length),
+                                 expected->Slice(0, slice_length), options);
 
-    CheckScalarUnary(func_name, input->Slice(length, length),
-                     expected->Slice(length, length), options);
+    CheckScalarUnaryNonRecursive(func_name, input->Slice(slice_length, slice_length),
+                                 expected->Slice(slice_length, slice_length), options);
 
-    CheckScalarUnary(func_name, input->Slice(2 * length), expected->Slice(2 * length),
-                     options);
+    CheckScalarUnaryNonRecursive(func_name, input->Slice(2 * slice_length),
+                                 expected->Slice(2 * slice_length), options);
   }
 
-  if (auto length = input->length() / 3) {
-    ArrayVector input_chunks{input->Slice(0, length), input->Slice(length)},
-        expected_chunks{expected->Slice(0, 2 * length), expected->Slice(2 * length)};
+  // Ditto with a ChunkedArray input
+  if (slice_length > 0) {
+    ArrayVector input_chunks{input->Slice(0, slice_length), input->Slice(slice_length)},
+        expected_chunks{expected->Slice(0, 2 * slice_length),
+                        expected->Slice(2 * slice_length)};
 
     ASSERT_OK_AND_ASSIGN(
         Datum out,
         CallFunction(func_name, {std::make_shared<ChunkedArray>(input_chunks)}, options));
+    ASSERT_OK(out.chunked_array()->ValidateFull());
     AssertDatumsEqual(std::make_shared<ChunkedArray>(expected_chunks), out);
   }
 }
@@ -79,6 +95,14 @@ void CheckScalarUnary(std::string func_name, std::shared_ptr<Scalar> input,
                       std::shared_ptr<Scalar> expected, const FunctionOptions* options) {
   ASSERT_OK_AND_ASSIGN(Datum out, CallFunction(func_name, {input}, options));
   AssertScalarsEqual(*expected, *out.scalar(), /*verbose=*/true);
+}
+
+void CheckVectorUnary(std::string func_name, Datum input, std::shared_ptr<Array> expected,
+                      const FunctionOptions* options) {
+  ASSERT_OK_AND_ASSIGN(Datum out, CallFunction(func_name, {input}, options));
+  std::shared_ptr<Array> actual = std::move(out).make_array();
+  ASSERT_OK(actual->ValidateFull());
+  AssertArraysEqual(*expected, *actual, /*verbose=*/true);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/test_util.cc
+++ b/cpp/src/arrow/compute/kernels/test_util.cc
@@ -34,7 +34,9 @@ namespace compute {
 void CheckScalarUnary(std::string func_name, std::shared_ptr<Array> input,
                       std::shared_ptr<Array> expected, const FunctionOptions* options) {
   ASSERT_OK_AND_ASSIGN(Datum out, CallFunction(func_name, {input}, options));
-  AssertArraysEqual(*expected, *out.make_array(), /*verbose=*/true);
+  std::shared_ptr<Array> actual = std::move(out).make_array();
+  ASSERT_OK(actual->ValidateFull());
+  AssertArraysEqual(*expected, *actual, /*verbose=*/true);
 
   // Check all the scalars
   for (int64_t i = 0; i < input->length(); ++i) {
@@ -44,6 +46,7 @@ void CheckScalarUnary(std::string func_name, std::shared_ptr<Array> input,
   }
 
   if (auto length = input->length() / 3) {
+    // XXX Is the recursive call intended?
     CheckScalarUnary(func_name, input->Slice(0, length), expected->Slice(0, length),
                      options);
 

--- a/cpp/src/arrow/compute/kernels/test_util.h
+++ b/cpp/src/arrow/compute/kernels/test_util.h
@@ -103,6 +103,9 @@ void CheckScalarUnary(std::string func_name, std::shared_ptr<Scalar> input,
                       std::shared_ptr<Scalar> expected,
                       const FunctionOptions* options = nullptr);
 
+void CheckVectorUnary(std::string func_name, Datum input, std::shared_ptr<Array> expected,
+                      const FunctionOptions* options = nullptr);
+
 using BinaryTypes =
     ::testing::Types<BinaryType, LargeBinaryType, StringType, LargeStringType>;
 using StringTypes = ::testing::Types<StringType, LargeStringType>;

--- a/cpp/src/arrow/compute/kernels/test_util.h
+++ b/cpp/src/arrow/compute/kernels/test_util.h
@@ -103,8 +103,9 @@ void CheckScalarUnary(std::string func_name, std::shared_ptr<Scalar> input,
                       std::shared_ptr<Scalar> expected,
                       const FunctionOptions* options = nullptr);
 
-using TestingStringTypes =
-    ::testing::Types<StringType, LargeStringType, BinaryType, LargeBinaryType>;
+using BinaryTypes =
+    ::testing::Types<BinaryType, LargeBinaryType, StringType, LargeStringType>;
+using StringTypes = ::testing::Types<StringType, LargeStringType>;
 
 static constexpr random::SeedType kRandomSeed = 0x0ff1ce;
 

--- a/cpp/src/arrow/compute/kernels/vector_hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash_test.cc
@@ -655,7 +655,6 @@ TEST_F(TestHashKernel, ZeroLengthDictionaryEncode) {
 
   std::shared_ptr<Array> result = datum_result.make_array();
   const auto& dict_result = checked_cast<const DictionaryArray&>(*result);
-  ASSERT_OK(dict_result.Validate());
   ASSERT_OK(dict_result.ValidateFull());
 }
 

--- a/cpp/src/arrow/compute/kernels/vector_hash_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash_test.cc
@@ -359,7 +359,7 @@ class TestHashKernelBinaryTypes : public TestHashKernel {
   }
 };
 
-TYPED_TEST_SUITE(TestHashKernelBinaryTypes, TestingStringTypes);
+TYPED_TEST_SUITE(TestHashKernelBinaryTypes, BinaryTypes);
 
 TYPED_TEST(TestHashKernelBinaryTypes, ZeroChunks) {
   auto type = this->type();

--- a/cpp/src/arrow/compute/kernels/vector_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested_test.cc
@@ -30,7 +30,9 @@ TEST(TestVectorNested, ListFlatten) {
     auto input = ArrayFromJSON(ty, "[[0, null, 1], null, [2, 3], []]");
     auto expected = ArrayFromJSON(int32(), "[0, null, 1, 2, 3]");
     ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("list_flatten", {input}));
-    AssertArraysEqual(*expected, *out.make_array());
+    std::shared_ptr<Array> actual = std::move(out).make_array();
+    ASSERT_OK(actual->ValidateFull());
+    AssertArraysEqual(*expected, *actual);
   }
 }
 
@@ -41,7 +43,9 @@ TEST(TestVectorNested, ListParentIndices) {
     auto out_ty = ty->id() == Type::LIST ? int32() : int64();
     auto expected = ArrayFromJSON(out_ty, "[0, 0, 0, 2, 2, 4, 4]");
     ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("list_parent_indices", {input}));
-    AssertArraysEqual(*expected, *out.make_array());
+    std::shared_ptr<Array> actual = std::move(out).make_array();
+    ASSERT_OK(actual->ValidateFull());
+    AssertArraysEqual(*expected, *actual);
   }
 
   // Construct a list with non-empty null slots
@@ -51,7 +55,9 @@ TEST(TestVectorNested, ListParentIndices) {
       (ArrayFromJSON(boolean(), "[true, false, true, true, true]")->data()->buffers[1]);
   auto expected = ArrayFromJSON(int32(), "[0, 0, 0, 1, 1, 2, 2, 4, 4]");
   ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("list_parent_indices", {data}));
-  AssertArraysEqual(*expected, *out.make_array());
+  std::shared_ptr<Array> actual = std::move(out).make_array();
+  ASSERT_OK(actual->ValidateFull());
+  AssertArraysEqual(*expected, *actual);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/vector_nested_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested_test.cc
@@ -29,10 +29,7 @@ TEST(TestVectorNested, ListFlatten) {
   for (auto ty : {list(int32()), large_list(int32())}) {
     auto input = ArrayFromJSON(ty, "[[0, null, 1], null, [2, 3], []]");
     auto expected = ArrayFromJSON(int32(), "[0, null, 1, 2, 3]");
-    ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("list_flatten", {input}));
-    std::shared_ptr<Array> actual = std::move(out).make_array();
-    ASSERT_OK(actual->ValidateFull());
-    AssertArraysEqual(*expected, *actual);
+    CheckVectorUnary("list_flatten", input, expected);
   }
 }
 
@@ -42,10 +39,7 @@ TEST(TestVectorNested, ListParentIndices) {
 
     auto out_ty = ty->id() == Type::LIST ? int32() : int64();
     auto expected = ArrayFromJSON(out_ty, "[0, 0, 0, 2, 2, 4, 4]");
-    ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("list_parent_indices", {input}));
-    std::shared_ptr<Array> actual = std::move(out).make_array();
-    ASSERT_OK(actual->ValidateFull());
-    AssertArraysEqual(*expected, *actual);
+    CheckVectorUnary("list_parent_indices", input, expected);
   }
 
   // Construct a list with non-empty null slots
@@ -54,10 +48,7 @@ TEST(TestVectorNested, ListParentIndices) {
   data->buffers[0] =
       (ArrayFromJSON(boolean(), "[true, false, true, true, true]")->data()->buffers[1]);
   auto expected = ArrayFromJSON(int32(), "[0, 0, 0, 1, 1, 2, 2, 4, 4]");
-  ASSERT_OK_AND_ASSIGN(Datum out, CallFunction("list_parent_indices", {data}));
-  std::shared_ptr<Array> actual = std::move(out).make_array();
-  ASSERT_OK(actual->ValidateFull());
-  AssertArraysEqual(*expected, *actual);
+  CheckVectorUnary("list_parent_indices", data, expected);
 }
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -168,6 +168,7 @@ class TestFilterKernel : public ::testing::Test {
     expected = out_datum.make_array();
     ASSERT_OK_AND_ASSIGN(out_datum, Filter(values, filter, drop_));
     actual = out_datum.make_array();
+    ASSERT_OK(actual->ValidateFull());
     AssertArraysEqual(*expected, *actual);
   }
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_test.cc
@@ -430,9 +430,6 @@ TEST(TestFilterKernel, NoValidityBitmapButUnknownNullCount) {
   AssertArraysEqual(*expected, *result);
 }
 
-using StringTypes =
-    ::testing::Types<BinaryType, StringType, LargeBinaryType, LargeStringType>;
-
 template <typename TypeClass>
 class TestFilterKernelWithString : public TestFilterKernel<TypeClass> {
  protected:
@@ -464,7 +461,7 @@ class TestFilterKernelWithString : public TestFilterKernel<TypeClass> {
   }
 };
 
-TYPED_TEST_SUITE(TestFilterKernelWithString, StringTypes);
+TYPED_TEST_SUITE(TestFilterKernelWithString, BinaryTypes);
 
 TYPED_TEST(TestFilterKernelWithString, FilterString) {
   this->AssertFilter(R"(["a", "b", "c"])", "[0, 1, 0]", R"(["b"])");
@@ -1028,7 +1025,7 @@ class TestTakeKernelWithString : public TestTakeKernel<TypeClass> {
   }
 };
 
-TYPED_TEST_SUITE(TestTakeKernelWithString, TestingStringTypes);
+TYPED_TEST_SUITE(TestTakeKernelWithString, BinaryTypes);
 
 TYPED_TEST(TestTakeKernelWithString, TakeString) {
   this->AssertTake(R"(["a", "b", "c"])", "[0, 1, 0]", R"(["a", "b", "a"])");

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -113,7 +113,7 @@ TYPED_TEST_SUITE(TestNthToIndicesForStrings, testing::Types<StringType>);
 
 TYPED_TEST(TestNthToIndicesForReal, NthToIndicesDoesNotProvideDefaultOptions) {
   auto input = ArrayFromJSON(this->type_singleton(), "[null, 1, 3.3, null, 2, 5.3]");
-  ASSERT_RAISES(Invalid, CallFunction("partition_indices", {input}));
+  ASSERT_RAISES(Invalid, CallFunction("partition_nth_indices", {input}));
 }
 
 TYPED_TEST(TestNthToIndicesForReal, Real) {
@@ -308,6 +308,7 @@ using SortToIndicesableTypes =
 
 template <typename ArrayType>
 void ValidateSorted(const ArrayType& array, UInt64Array& offsets) {
+  ASSERT_OK(array.ValidateFull());
   SortComparator<ArrayType> compare;
   for (int i = 1; i < array.length(); i++) {
     uint64_t lhs = offsets.Value(i - 1);

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -178,7 +178,7 @@ Result<std::shared_ptr<Expression>> KeyValuePartitioning::ConvertKey(
 
     // look up the partition value in the dictionary
     ARROW_ASSIGN_OR_RAISE(converted, Scalar::Parse(value.dictionary->type(), key.value));
-    ARROW_ASSIGN_OR_RAISE(auto index, compute::Match(converted, value.dictionary));
+    ARROW_ASSIGN_OR_RAISE(auto index, compute::IndexIn(converted, value.dictionary));
     value.index = index.scalar();
     if (!value.index->is_valid) {
       return Status::Invalid("Dictionary supplied for field ", field->ToString(),

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -241,6 +241,7 @@ struct TypeTraits<BinaryType> {
   using ArrayType = BinaryArray;
   using BuilderType = BinaryBuilder;
   using ScalarType = BinaryScalar;
+  using OffsetType = Int32Type;
   constexpr static bool is_parameter_free = true;
   static inline std::shared_ptr<DataType> type_singleton() { return binary(); }
 };
@@ -250,6 +251,7 @@ struct TypeTraits<LargeBinaryType> {
   using ArrayType = LargeBinaryArray;
   using BuilderType = LargeBinaryBuilder;
   using ScalarType = LargeBinaryScalar;
+  using OffsetType = Int64Type;
   constexpr static bool is_parameter_free = true;
   static inline std::shared_ptr<DataType> type_singleton() { return large_binary(); }
 };

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -260,7 +260,8 @@ cdef _pack_compute_args(object values, vector[CDatum]* out):
         elif isinstance(val, Table):
             out.push_back(CDatum((<Table> val).sp_table))
         else:
-            raise TypeError(type(val))
+            raise TypeError("Got unexpected argument type {} "
+                            "for compute function".format(type(val)))
 
 
 cdef class FunctionRegistry:
@@ -399,16 +400,16 @@ cdef class CastOptions(FunctionOptions):
         self.options.allow_invalid_utf8 = flag
 
 
-cdef class BinaryContainsExactOptions(FunctionOptions):
+cdef class MatchSubstringOptions(FunctionOptions):
     cdef:
-        unique_ptr[CBinaryContainsExactOptions] binary_contains_exact_options
+        unique_ptr[CMatchSubstringOptions] match_substring_options
 
     def __init__(self, pattern):
-        self.binary_contains_exact_options.reset(
-            new CBinaryContainsExactOptions(tobytes(pattern)))
+        self.match_substring_options.reset(
+            new CMatchSubstringOptions(tobytes(pattern)))
 
     cdef const CFunctionOptions* get_options(self) except NULL:
-        return self.binary_contains_exact_options.get()
+        return self.match_substring_options.get()
 
 
 cdef class FilterOptions(FunctionOptions):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1515,7 +1515,7 @@ cdef class BaseListArray(Array):
           1
         ]
         """
-        return _pc().list_value_lengths(self)
+        return _pc().list_value_length(self)
 
 
 cdef class ListArray(BaseListArray):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1669,9 +1669,9 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     CFunctionRegistry* GetFunctionRegistry()
 
-    cdef cppclass CBinaryContainsExactOptions \
-            "arrow::compute::BinaryContainsExactOptions"(CFunctionOptions):
-        CBinaryContainsExactOptions(c_string pattern)
+    cdef cppclass CMatchSubstringOptions \
+            "arrow::compute::MatchSubstringOptions"(CFunctionOptions):
+        CMatchSubstringOptions(c_string pattern)
         c_string pattern
 
     cdef cppclass CCastOptions" arrow::compute::CastOptions"(CFunctionOptions):

--- a/r/R/compute.R
+++ b/r/R/compute.R
@@ -44,12 +44,12 @@ mean.Scalar <- mean.Array
 
 #' @export
 min.Array <- function(..., na.rm = FALSE) {
-  scalar_aggregate("minmax", ..., na.rm = na.rm)$GetFieldByName("min")
+  scalar_aggregate("min_max", ..., na.rm = na.rm)$GetFieldByName("min")
 }
 
 #' @export
 max.Array <- function(..., na.rm = FALSE) {
-  scalar_aggregate("minmax", ..., na.rm = na.rm)$GetFieldByName("max")
+  scalar_aggregate("min_max", ..., na.rm = na.rm)$GetFieldByName("max")
 }
 
 scalar_aggregate <- function(FUN, ..., na.rm = FALSE) {

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -160,7 +160,7 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
     return out;
   }
 
-  if (func_name == "minmax") {
+  if (func_name == "min_max") {
     using Options = arrow::compute::MinMaxOptions;
     auto out = std::make_shared<Options>(Options::Defaults());
     out->null_handling = options["na.rm"] ? Options::SKIP : Options::OUTPUT_NULL;


### PR DESCRIPTION
Modified function names:
* minmax -> min_max
* binary_isascii -> string_isascii (only works on string types)
* ascii_length -> binary_length (also make it work on binary types)
* binary_contains_exact -> match_substring
  (other possibility: has_substring ?)
* match -> index_in
* isin -> is_in
* list_value_lengths -> list_value_length
* partition_indices -> partition_nth_indices
  (other kinds of partitioning would be possible, e.g. using a predicate)

Document string predicate functions (ARROW-9444).

Also fix the allocation of IsValid output buffer in certain cases.