### PR TITLE
ARROW-9424: [C++][Parquet] Disable writing files with LZ4 codec

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -182,7 +182,7 @@ class SerializedPageReader : public PageReader {
       InitDecryption();
     }
     max_page_header_size_ = kDefaultMaxPageHeaderSize;
-    decompressor_ = GetCodec(codec);
+    decompressor_ = internal::GetReadCodec(codec);
   }
 
   // Implement the PageReader interface

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -172,7 +172,7 @@ class SerializedPageWriter : public PageWriter {
     if (data_encryptor_ != nullptr || meta_encryptor_ != nullptr) {
       InitEncryption();
     }
-    compressor_ = GetCodec(codec, compression_level);
+    compressor_ = internal::GetWriteCodec(codec, compression_level);
     thrift_serializer_.reset(new ThriftSerializer);
   }
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -488,13 +488,13 @@ TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndGzipCompression) {
 
 #ifdef ARROW_WITH_LZ4
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithLz4Compression) {
-  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, false,
-                                 LARGE_SIZE);
+  ASSERT_THROW(this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, false,
+                                 LARGE_SIZE), ParquetException);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndLz4Compression) {
-  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, true,
-                                 LARGE_SIZE);
+  ASSERT_THROW(this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, true,
+                                 LARGE_SIZE), ParquetException);
 }
 #endif
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -488,13 +488,19 @@ TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndGzipCompression) {
 
 #ifdef ARROW_WITH_LZ4
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithLz4Compression) {
-  ASSERT_THROW(this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, false,
-                                 LARGE_SIZE), ParquetException);
+  ASSERT_THROW(
+    this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, false, 
+      LARGE_SIZE), 
+    ParquetException
+  );
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndLz4Compression) {
-  ASSERT_THROW(this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, true,
-                                 LARGE_SIZE), ParquetException);
+  ASSERT_THROW(
+    this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, true, 
+      LARGE_SIZE),
+    ParquetException
+  );
 }
 #endif
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -488,19 +488,15 @@ TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndGzipCompression) {
 
 #ifdef ARROW_WITH_LZ4
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithLz4Compression) {
-  ASSERT_THROW(
-    this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, false, 
-      LARGE_SIZE), 
-    ParquetException
-  );
+  ASSERT_THROW(this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false,
+                                              false, LARGE_SIZE),
+               ParquetException);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndLz4Compression) {
-  ASSERT_THROW(
-    this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, true, 
-      LARGE_SIZE),
-    ParquetException
-  );
+  ASSERT_THROW(this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false,
+                                              true, LARGE_SIZE),
+               ParquetException);
 }
 #endif
 

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -249,9 +249,8 @@ TEST_F(TestPageSerde, Compression) {
   codec_types.push_back(Compression::GZIP);
 #endif
 
-#ifdef ARROW_WITH_LZ4
-  codec_types.push_back(Compression::LZ4);
-#endif
+// TODO: Add LZ4 compression type after PARQUET-1878 is complete.
+// Testing for deserializing LZ4 is hard without writing enabled, so it is not included here.
 
 #ifdef ARROW_WITH_ZSTD
   codec_types.push_back(Compression::ZSTD);

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -250,7 +250,7 @@ TEST_F(TestPageSerde, Compression) {
 #endif
 
 // TODO: Add LZ4 compression type after PARQUET-1878 is complete.
-// Testing for deserializing LZ4 is hard without writing enabled, so it is not included here.
+// Testing for deserializing LZ4 is hard without writing enabled, so it is not included.
 
 #ifdef ARROW_WITH_ZSTD
   codec_types.push_back(Compression::ZSTD);

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -249,8 +249,8 @@ TEST_F(TestPageSerde, Compression) {
   codec_types.push_back(Compression::GZIP);
 #endif
 
-// TODO: Add LZ4 compression type after PARQUET-1878 is complete.
-// Testing for deserializing LZ4 is hard without writing enabled, so it is not included.
+  // TODO: Add LZ4 compression type after PARQUET-1878 is complete.
+  // Testing for deserializing LZ4 is hard without writing enabled, so it is not included.
 
 #ifdef ARROW_WITH_ZSTD
   codec_types.push_back(Compression::ZSTD);

--- a/cpp/src/parquet/file_serialize_test.cc
+++ b/cpp/src/parquet/file_serialize_test.cc
@@ -309,7 +309,7 @@ TYPED_TEST(TestSerialize, SmallFileGzip) {
 
 #ifdef ARROW_WITH_LZ4
 TYPED_TEST(TestSerialize, SmallFileLz4) {
-  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::LZ4));
+  ASSERT_THROW(this->FileSerializeTest(Compression::LZ4), ParquetException);
 }
 #endif
 

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -101,6 +101,7 @@ static inline Compression::type FromThriftUnsafe(format::CompressionCodec::type 
     case format::CompressionCodec::BROTLI:
       return Compression::BROTLI;
     case format::CompressionCodec::LZ4:
+      // ARROW-9424: Existing files use LZ4_RAW but this may need to change
       return Compression::LZ4;
     case format::CompressionCodec::ZSTD:
       return Compression::ZSTD;

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -42,8 +42,11 @@ bool IsCodecSupported(Compression::type codec) {
     case Compression::GZIP:
     case Compression::BROTLI:
     case Compression::ZSTD:
-    case Compression::LZ4:
       return true;
+    case Compression::LZ4:
+      // TODO: Re-enable after PARQUET-1878 is complete.
+      // Temporarily disabled because of ARROW-9424.
+      return false;
     default:
       return false;
   }

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -43,6 +43,7 @@ bool IsCodecSupported(Compression::type codec) {
     case Compression::BROTLI:
     case Compression::ZSTD:
       return true;
+    case Compression::LZ4_FRAME:
     case Compression::LZ4:
       // TODO: Re-enable after PARQUET-1878 is complete.
       // Temporarily disabled because of ARROW-9424.
@@ -58,6 +59,14 @@ std::unique_ptr<Codec> GetCodec(Compression::type codec) {
 
 std::unique_ptr<Codec> GetCodec(Compression::type codec, int compression_level) {
   std::unique_ptr<Codec> result;
+  if (codec == Compression::LZ4 || codec == Compression::LZ4_FRAME) {
+    throw ParquetException(
+        "Per ARROW-9424, writing files with LZ4 compression has been "
+        "disabled until implementation issues have been resolved. "
+        "It is recommended to read any existing files and rewrite them "
+        "using a different compression.");
+  }
+
   if (!IsCodecSupported(codec)) {
     std::stringstream ss;
     ss << "Codec type " << Codec::GetCodecAsString(codec)

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -42,12 +42,8 @@ bool IsCodecSupported(Compression::type codec) {
     case Compression::GZIP:
     case Compression::BROTLI:
     case Compression::ZSTD:
-      return true;
-    case Compression::LZ4_FRAME:
     case Compression::LZ4:
-      // TODO: Re-enable after PARQUET-1878 is complete.
-      // Temporarily disabled because of ARROW-9424.
-      return false;
+      return true;
     default:
       return false;
   }

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -465,6 +465,15 @@ struct Encoding {
 PARQUET_EXPORT
 bool IsCodecSupported(Compression::type codec);
 
+namespace internal {
+
+// ARROW-9424: Separate functions for reading and writing so we can disable LZ4
+// on writing
+std::unique_ptr<Codec> GetReadCodec(Compression::type codec);
+std::unique_ptr<Codec> GetWriteCodec(Compression::type codec, int compression_level);
+
+}  // namespace internal
+
 PARQUET_EXPORT
 std::unique_ptr<Codec> GetCodec(Compression::type codec);
 


### PR DESCRIPTION
Due to ongoing LZ4 problems with Parquet files, this patch disables writing files with LZ4 codec by throwing a `ParquetException`.

In progress: adding exceptions for pyarrow when using LZ4 to write files and updating relevant pytests

Mailing list discussion: https://mail-archives.apache.org/mod_mbox/arrow-dev/202007.mbox/%3CCAJPUwMCM4ZaJB720%2BuoM1aSA2oD9jSEnzuwWjJiw6vwXxHk7nw%40mail.gmail.com%3E

Jira ticket: https://issues.apache.org/jira/browse/ARROW-9424