### PR TITLE
ARROW-9469: [Python] Make more objects weakrefable

### DIFF
--- a/python/pyarrow/_compute.pxd
+++ b/python/pyarrow/_compute.pxd
@@ -22,7 +22,7 @@ from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 
 
-cdef class FunctionOptions:
+cdef class FunctionOptions(_Weakrefable):
 
     cdef const CFunctionOptions* get_options(self) except NULL
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -96,7 +96,7 @@ cdef wrap_scalar_aggregate_kernel(const CScalarAggregateKernel* c_kernel):
     return kernel
 
 
-cdef class Kernel:
+cdef class Kernel(_Weakrefable):
 
     def __init__(self):
         raise TypeError("Do not call {}'s constructor directly"
@@ -139,7 +139,7 @@ cdef class ScalarAggregateKernel(Kernel):
                 .format(frombytes(self.kernel.signature.get().ToString())))
 
 
-cdef class Function:
+cdef class Function(_Weakrefable):
     cdef:
         shared_ptr[CFunction] sp_func
         CFunction* base_func
@@ -264,7 +264,7 @@ cdef _pack_compute_args(object values, vector[CDatum]* out):
                             "for compute function".format(type(val)))
 
 
-cdef class FunctionRegistry:
+cdef class FunctionRegistry(_Weakrefable):
     cdef:
         CFunctionRegistry* registry
 
@@ -296,7 +296,7 @@ def call_function(name, args, options=None):
     return func.call(args, options=options)
 
 
-cdef class FunctionOptions:
+cdef class FunctionOptions(_Weakrefable):
 
     cdef const CFunctionOptions* get_options(self) except NULL:
         raise NotImplementedError("Unimplemented base options")

--- a/python/pyarrow/_csv.pxd
+++ b/python/pyarrow/_csv.pxd
@@ -18,9 +18,10 @@
 # cython: language_level = 3
 
 from pyarrow.includes.libarrow cimport *
+from pyarrow.lib cimport _Weakrefable
 
 
-cdef class ParseOptions:
+cdef class ParseOptions(_Weakrefable):
     cdef:
         CCSVParseOptions options
 

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -43,7 +43,7 @@ cdef unsigned char _single_char(s) except 0:
     return <unsigned char> val
 
 
-cdef class ReadOptions:
+cdef class ReadOptions(_Weakrefable):
     """
     Options for reading CSV files.
 
@@ -159,7 +159,7 @@ cdef class ReadOptions:
         self.options.autogenerate_column_names = value
 
 
-cdef class ParseOptions:
+cdef class ParseOptions(_Weakrefable):
     """
     Options for parsing CSV files.
 
@@ -318,7 +318,7 @@ cdef class ParseOptions:
          self.ignore_empty_lines) = state
 
 
-cdef class _ISO8601:
+cdef class _ISO8601(_Weakrefable):
     """
     A special object indicating ISO-8601 parsing.
     """
@@ -334,7 +334,7 @@ cdef class _ISO8601:
 ISO8601 = _ISO8601()
 
 
-cdef class ConvertOptions:
+cdef class ConvertOptions(_Weakrefable):
     """
     Options for converting CSV data.
 

--- a/python/pyarrow/_cuda.pxd
+++ b/python/pyarrow/_cuda.pxd
@@ -23,7 +23,7 @@ from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_cuda cimport *
 
 
-cdef class Context:
+cdef class Context(_Weakrefable):
     cdef:
         shared_ptr[CCudaContext] context
         int device_number
@@ -31,7 +31,7 @@ cdef class Context:
     cdef void init(self, const shared_ptr[CCudaContext]& ctx)
 
 
-cdef class IpcMemHandle:
+cdef class IpcMemHandle(_Weakrefable):
     cdef:
         shared_ptr[CCudaIpcMemHandle] handle
 

--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -24,7 +24,7 @@ from pyarrow.util import get_contiguous_span
 cimport cpython as cp
 
 
-cdef class Context:
+cdef class Context(_Weakrefable):
     """
     CUDA driver context.
     """
@@ -327,7 +327,7 @@ cdef class Context:
                              ' `%s` object' % (type(obj)))
 
 
-cdef class IpcMemHandle:
+cdef class IpcMemHandle(_Weakrefable):
     """A serializable container for a CUDA IPC handle.
     """
     cdef void init(self, shared_ptr[CCudaIpcMemHandle]& h):

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -77,7 +77,7 @@ cdef CFileSource _make_file_source(object file, FileSystem filesystem=None):
     return c_source
 
 
-cdef class Expression:
+cdef class Expression(_Weakrefable):
 
     cdef:
         shared_ptr[CExpression] wrapped
@@ -234,7 +234,7 @@ _deserialize = Expression._deserialize
 cdef Expression _true = Expression._scalar(True)
 
 
-cdef class Dataset:
+cdef class Dataset(_Weakrefable):
     """
     Collection of data fragments and potentially child datasets.
 
@@ -584,7 +584,7 @@ cdef shared_ptr[CExpression] _insert_implicit_casts(Expression filter,
     )
 
 
-cdef class FileFormat:
+cdef class FileFormat(_Weakrefable):
 
     cdef:
         shared_ptr[CFileFormat] wrapped
@@ -647,7 +647,7 @@ cdef class FileFormat:
             return False
 
 
-cdef class Fragment:
+cdef class Fragment(_Weakrefable):
     """Fragment of data from a Dataset."""
 
     cdef:
@@ -839,7 +839,7 @@ cdef class FileFragment(Fragment):
         return FileFormat.wrap(self.file_fragment.format())
 
 
-cdef class RowGroupInfo:
+cdef class RowGroupInfo(_Weakrefable):
     """A wrapper class for RowGroup information"""
 
     cdef:
@@ -976,7 +976,7 @@ cdef class ParquetFileFragment(FileFragment):
         return [Fragment.wrap(c_fragment) for c_fragment in c_fragments]
 
 
-cdef class ParquetReadOptions:
+cdef class ParquetReadOptions(_Weakrefable):
     """
     Parquet format specific options for reading.
 
@@ -1133,7 +1133,7 @@ cdef class CsvFileFormat(FileFormat):
         return CsvFileFormat, (self.parse_options,)
 
 
-cdef class Partitioning:
+cdef class Partitioning(_Weakrefable):
 
     cdef:
         shared_ptr[CPartitioning] wrapped
@@ -1177,7 +1177,7 @@ cdef class Partitioning:
         return pyarrow_wrap_schema(self.partitioning.schema())
 
 
-cdef class PartitioningFactory:
+cdef class PartitioningFactory(_Weakrefable):
 
     cdef:
         shared_ptr[CPartitioningFactory] wrapped
@@ -1356,7 +1356,7 @@ cdef class HivePartitioning(Partitioning):
             CHivePartitioning.MakeFactory(options))
 
 
-cdef class DatasetFactory:
+cdef class DatasetFactory(_Weakrefable):
     """
     DatasetFactory is used to create a Dataset, inspect the Schema
     of the fragments contained in it, and declare a partitioning.
@@ -1451,7 +1451,7 @@ cdef class DatasetFactory:
         return Dataset.wrap(GetResultValue(result))
 
 
-cdef class FileSystemFactoryOptions:
+cdef class FileSystemFactoryOptions(_Weakrefable):
     """
     Influences the discovery of filesystem paths.
 
@@ -1655,7 +1655,7 @@ cdef class UnionDatasetFactory(DatasetFactory):
         self.union_factory = <CUnionDatasetFactory*> sp.get()
 
 
-cdef class ParquetFactoryOptions:
+cdef class ParquetFactoryOptions(_Weakrefable):
     """
     Influences the discovery of parquet dataset.
 
@@ -1778,7 +1778,7 @@ cdef class ParquetDatasetFactory(DatasetFactory):
         self.parquet_factory = <CParquetDatasetFactory*> sp.get()
 
 
-cdef class ScanTask:
+cdef class ScanTask(_Weakrefable):
     """Read record batches from a range of a single data fragment.
 
     A ScanTask is meant to be a unit of work to be dispatched.
@@ -1851,7 +1851,7 @@ cdef void _populate_builder(const shared_ptr[CScannerBuilder]& ptr,
     check_status(builder.BatchSize(batch_size))
 
 
-cdef class Scanner:
+cdef class Scanner(_Weakrefable):
     """A materialized scan operation with context and options bound.
 
     A scanner is the class that glues the scan tasks, data fragments and data

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -101,7 +101,7 @@ cdef IpcWriteOptions _get_options(options):
         use_legacy_format=None, options=options)
 
 
-cdef class FlightCallOptions:
+cdef class FlightCallOptions(_Weakrefable):
     """RPC-layer options for a Flight call."""
 
     cdef:
@@ -204,7 +204,7 @@ class FlightWriteSizeExceededError(ArrowInvalid):
         self.actual = actual
 
 
-cdef class Action:
+cdef class Action(_Weakrefable):
     """An action executable on a Flight service."""
     cdef:
         CAction action
@@ -255,7 +255,7 @@ class ActionType(_ActionType):
         return Action(self.type, buf)
 
 
-cdef class Result:
+cdef class Result(_Weakrefable):
     """A result from executing an Action."""
     cdef:
         unique_ptr[CFlightResult] result
@@ -276,7 +276,7 @@ cdef class Result:
         return pyarrow_wrap_buffer(self.result.get().body)
 
 
-cdef class BasicAuth:
+cdef class BasicAuth(_Weakrefable):
     """A container for basic auth."""
     cdef:
         unique_ptr[CBasicAuth] basic_auth
@@ -378,7 +378,7 @@ cdef wrap_flight_method(CFlightMethod method):
     return FlightMethod.INVALID
 
 
-cdef class FlightDescriptor:
+cdef class FlightDescriptor(_Weakrefable):
     """A description of a data stream available from a Flight service."""
     cdef:
         CFlightDescriptor descriptor
@@ -476,7 +476,7 @@ cdef class FlightDescriptor:
         return self.descriptor == other.descriptor
 
 
-cdef class Ticket:
+cdef class Ticket(_Weakrefable):
     """A ticket for requesting a Flight stream."""
 
     cdef:
@@ -524,7 +524,7 @@ cdef class Ticket:
         return '<Ticket {}>'.format(self.ticket.ticket)
 
 
-cdef class Location:
+cdef class Location(_Weakrefable):
     """The location of a Flight service."""
     cdef:
         CLocation location
@@ -597,7 +597,7 @@ cdef class Location:
         return (<Location> location).location
 
 
-cdef class FlightEndpoint:
+cdef class FlightEndpoint(_Weakrefable):
     """A Flight stream, along with the ticket and locations to access it."""
     cdef:
         CFlightEndpoint endpoint
@@ -652,7 +652,7 @@ cdef class FlightEndpoint:
         return self.endpoint == other.endpoint
 
 
-cdef class SchemaResult:
+cdef class SchemaResult(_Weakrefable):
     """A result from a getschema request. Holding a schema"""
     cdef:
         unique_ptr[CSchemaResult] result
@@ -680,7 +680,7 @@ cdef class SchemaResult:
         return pyarrow_wrap_schema(schema)
 
 
-cdef class FlightInfo:
+cdef class FlightInfo(_Weakrefable):
     """A description of a Flight stream."""
     cdef:
         unique_ptr[CFlightInfo] info
@@ -787,7 +787,7 @@ cdef class FlightInfo:
         return info
 
 
-cdef class FlightStreamChunk:
+cdef class FlightStreamChunk(_Weakrefable):
     """A RecordBatch with application metadata on the side."""
     cdef:
         CFlightStreamChunk chunk
@@ -812,7 +812,7 @@ cdef class FlightStreamChunk:
             self.chunk.data != NULL, self.chunk.app_metadata != NULL)
 
 
-cdef class _MetadataRecordBatchReader:
+cdef class _MetadataRecordBatchReader(_Weakrefable):
     """A reader for Flight streams."""
 
     # Needs to be separate class so the "real" class can subclass the
@@ -951,7 +951,7 @@ cdef class FlightStreamWriter(MetadataRecordBatchWriter):
                 (<CFlightStreamWriter*> self.writer.get()).DoneWriting())
 
 
-cdef class FlightMetadataReader:
+cdef class FlightMetadataReader(_Weakrefable):
     """A reader for Flight metadata messages sent during a DoPut."""
 
     cdef:
@@ -967,7 +967,7 @@ cdef class FlightMetadataReader:
         return pyarrow_wrap_buffer(buf)
 
 
-cdef class FlightMetadataWriter:
+cdef class FlightMetadataWriter(_Weakrefable):
     """A sender for Flight metadata messages during a DoPut."""
 
     cdef:
@@ -986,7 +986,7 @@ cdef class FlightMetadataWriter:
             check_flight_status(self.writer.get().WriteMetadata(deref(buf)))
 
 
-cdef class FlightClient:
+cdef class FlightClient(_Weakrefable):
     """A client to a Flight service.
 
     Connect to a Flight service on the given host and port.
@@ -1339,7 +1339,7 @@ cdef class FlightClient:
         return py_writer, py_reader
 
 
-cdef class FlightDataStream:
+cdef class FlightDataStream(_Weakrefable):
     """Abstract base class for Flight data streams."""
 
     cdef CFlightDataStream* to_stream(self) except *:
@@ -1421,7 +1421,7 @@ cdef class GeneratorStream(FlightDataStream):
                                                 self.c_options)
 
 
-cdef class ServerCallContext:
+cdef class ServerCallContext(_Weakrefable):
     """Per-call state/context."""
     cdef:
         const CServerCallContext* context
@@ -1463,7 +1463,7 @@ cdef class ServerCallContext:
         return result
 
 
-cdef class ServerAuthReader:
+cdef class ServerAuthReader(_Weakrefable):
     """A reader for messages from the client during an auth handshake."""
     cdef:
         CServerAuthReader* reader
@@ -1494,7 +1494,7 @@ cdef class ServerAuthReader:
         return result
 
 
-cdef class ServerAuthSender:
+cdef class ServerAuthSender(_Weakrefable):
     """A writer for messages to the client during an auth handshake."""
     cdef:
         CServerAuthSender* sender
@@ -1524,7 +1524,7 @@ cdef class ServerAuthSender:
         return result
 
 
-cdef class ClientAuthReader:
+cdef class ClientAuthReader(_Weakrefable):
     """A reader for messages from the server during an auth handshake."""
     cdef:
         CClientAuthReader* reader
@@ -1555,7 +1555,7 @@ cdef class ClientAuthReader:
         return result
 
 
-cdef class ClientAuthSender:
+cdef class ClientAuthSender(_Weakrefable):
     """A writer for messages to the server during an auth handshake."""
     cdef:
         CClientAuthSender* sender
@@ -2006,7 +2006,7 @@ cdef CStatus _client_middleware_start_call(
     return CStatus_OK()
 
 
-cdef class ServerAuthHandler:
+cdef class ServerAuthHandler(_Weakrefable):
     """Authentication middleware for a server.
 
     To implement an authentication mechanism, subclass this class and
@@ -2050,7 +2050,7 @@ cdef class ServerAuthHandler:
         return new PyServerAuthHandler(self, vtable)
 
 
-cdef class ClientAuthHandler:
+cdef class ClientAuthHandler(_Weakrefable):
     """Authentication plugin for a client."""
 
     def authenticate(self, outgoing, incoming):
@@ -2088,7 +2088,7 @@ cdef wrap_call_info(const CCallInfo& c_info):
     return CallInfo(method=method)
 
 
-cdef class ClientMiddlewareFactory:
+cdef class ClientMiddlewareFactory(_Weakrefable):
     """A factory for new middleware instances.
 
     All middleware methods will be called from the same thread as the
@@ -2116,7 +2116,7 @@ cdef class ClientMiddlewareFactory:
         """
 
 
-cdef class ClientMiddleware:
+cdef class ClientMiddleware(_Weakrefable):
     """Client-side middleware for a call, instantiated per RPC.
 
     Methods here should be fast and must be infallible: they should
@@ -2177,7 +2177,7 @@ cdef class ClientMiddleware:
         c_instance[0].reset(new CPyClientMiddleware(py_middleware, vtable))
 
 
-cdef class ServerMiddlewareFactory:
+cdef class ServerMiddlewareFactory(_Weakrefable):
     """A factory for new middleware instances.
 
     All middleware methods will be called from the same thread as the
@@ -2215,7 +2215,7 @@ cdef class ServerMiddlewareFactory:
         """
 
 
-cdef class ServerMiddleware:
+cdef class ServerMiddleware(_Weakrefable):
     """Server-side middleware for a call, instantiated per RPC.
 
     Methods here should be fast and must be infalliable: they should
@@ -2307,7 +2307,7 @@ cdef class _ServerMiddlewareWrapper(ServerMiddleware):
             instance.call_completed(exception)
 
 
-cdef class FlightServerBase:
+cdef class FlightServerBase(_Weakrefable):
     """A Flight service definition.
 
     Override methods to define your Flight service.

--- a/python/pyarrow/_fs.pxd
+++ b/python/pyarrow/_fs.pxd
@@ -30,7 +30,7 @@ cpdef enum FileType:
     Directory = <int8_t> CFileType_Directory
 
 
-cdef class FileInfo:
+cdef class FileInfo(_Weakrefable):
     cdef:
         CFileInfo info
 
@@ -43,7 +43,7 @@ cdef class FileInfo:
     cdef CFileInfo unwrap_safe(obj)
 
 
-cdef class FileSelector:
+cdef class FileSelector(_Weakrefable):
     cdef:
         CFileSelector selector
 
@@ -53,7 +53,7 @@ cdef class FileSelector:
     cdef inline CFileSelector unwrap(self) nogil
 
 
-cdef class FileSystem:
+cdef class FileSystem(_Weakrefable):
     cdef:
         shared_ptr[CFileSystem] wrapped
         CFileSystem* fs

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -92,7 +92,7 @@ cdef CFileType _unwrap_file_type(FileType ty) except *:
     assert 0
 
 
-cdef class FileInfo:
+cdef class FileInfo(_Weakrefable):
     """
     FileSystem entry info.
 
@@ -256,7 +256,7 @@ cdef class FileInfo:
         return (nanoseconds if nanoseconds != -1 else None)
 
 
-cdef class FileSelector:
+cdef class FileSelector(_Weakrefable):
     """
     File and directory selector.
 
@@ -320,7 +320,7 @@ cdef class FileSelector:
                 "recursive={0.recursive}>".format(self))
 
 
-cdef class FileSystem:
+cdef class FileSystem(_Weakrefable):
     """
     Abstract file system API.
     """

--- a/python/pyarrow/_json.pyx
+++ b/python/pyarrow/_json.pyx
@@ -22,14 +22,14 @@
 
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
-from pyarrow.lib cimport (check_status, Field, MemoryPool, ensure_type,
-                          maybe_unbox_memory_pool, get_input_stream,
-                          pyarrow_wrap_table, pyarrow_wrap_data_type,
-                          pyarrow_unwrap_data_type, pyarrow_wrap_schema,
-                          pyarrow_unwrap_schema)
+from pyarrow.lib cimport (check_status, _Weakrefable, Field, MemoryPool,
+                          ensure_type, maybe_unbox_memory_pool,
+                          get_input_stream, pyarrow_wrap_table,
+                          pyarrow_wrap_data_type, pyarrow_unwrap_data_type,
+                          pyarrow_wrap_schema, pyarrow_unwrap_schema)
 
 
-cdef class ReadOptions:
+cdef class ReadOptions(_Weakrefable):
     """
     Options for reading JSON files.
 
@@ -81,7 +81,7 @@ cdef class ReadOptions:
         self.options.block_size = value
 
 
-cdef class ParseOptions:
+cdef class ParseOptions(_Weakrefable):
     """
     Options for parsing JSON files.
 

--- a/python/pyarrow/_orc.pyx
+++ b/python/pyarrow/_orc.pyx
@@ -32,7 +32,7 @@ from pyarrow.lib cimport (check_status,
                           get_reader)
 
 
-cdef class ORCReader:
+cdef class ORCReader(_Weakrefable):
     cdef:
         object source
         CMemoryPool* allocator

--- a/python/pyarrow/_orc.pyx
+++ b/python/pyarrow/_orc.pyx
@@ -23,7 +23,7 @@ from cython.operator cimport dereference as deref
 from libcpp.vector cimport vector as std_vector
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
-from pyarrow.lib cimport (check_status,
+from pyarrow.lib cimport (check_status, _Weakrefable,
                           MemoryPool, maybe_unbox_memory_pool,
                           Schema, pyarrow_wrap_schema,
                           pyarrow_wrap_batch,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -28,7 +28,7 @@ import numpy as np
 from cython.operator cimport dereference as deref
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
-from pyarrow.lib cimport (Buffer, Array, Schema,
+from pyarrow.lib cimport (_Weakrefable, Buffer, Array, Schema,
                           check_status,
                           MemoryPool, maybe_unbox_memory_pool,
                           Table, NativeFile,
@@ -45,7 +45,7 @@ from pyarrow.lib import (ArrowException, NativeFile, BufferOutputStream,
 cimport cpython as cp
 
 
-cdef class Statistics:
+cdef class Statistics(_Weakrefable):
     cdef:
         shared_ptr[CStatistics] statistics
         ColumnChunkMetaData parent
@@ -166,7 +166,7 @@ cdef class Statistics:
         return converted_type_name_from_enum(raw_converted_type)
 
 
-cdef class ParquetLogicalType:
+cdef class ParquetLogicalType(_Weakrefable):
     cdef:
         shared_ptr[const CParquetLogicalType] type
 
@@ -296,7 +296,7 @@ cdef _box_flba(ParquetFLBA val, uint32_t len):
     return cp.PyBytes_FromStringAndSize(<char*> val.ptr, <Py_ssize_t> len)
 
 
-cdef class ColumnChunkMetaData:
+cdef class ColumnChunkMetaData(_Weakrefable):
     cdef:
         unique_ptr[CColumnChunkMetaData] up_metadata
         CColumnChunkMetaData* metadata
@@ -458,7 +458,7 @@ cdef class ColumnChunkMetaData:
         return self.metadata.total_uncompressed_size()
 
 
-cdef class RowGroupMetaData:
+cdef class RowGroupMetaData(_Weakrefable):
     cdef:
         int index  # for pickling support
         unique_ptr[CRowGroupMetaData] up_metadata
@@ -546,7 +546,7 @@ def _reconstruct_filemetadata(Buffer serialized):
     return metadata
 
 
-cdef class FileMetaData:
+cdef class FileMetaData(_Weakrefable):
     cdef:
         shared_ptr[CFileMetaData] sp_metadata
         CFileMetaData* _metadata
@@ -705,7 +705,7 @@ cdef class FileMetaData:
                 WriteMetaDataFile(deref(self._metadata), sink.get()))
 
 
-cdef class ParquetSchema:
+cdef class ParquetSchema(_Weakrefable):
     cdef:
         FileMetaData parent  # the FileMetaData owning the SchemaDescriptor
         const SchemaDescriptor* schema
@@ -768,7 +768,7 @@ cdef class ParquetSchema:
         return ColumnSchema(self, i)
 
 
-cdef class ColumnSchema:
+cdef class ColumnSchema(_Weakrefable):
     cdef:
         int index
         ParquetSchema parent
@@ -976,7 +976,7 @@ cdef ParquetCompression compression_from_name(name):
         return ParquetCompression_UNCOMPRESSED
 
 
-cdef class ParquetReader:
+cdef class ParquetReader(_Weakrefable):
     cdef:
         object source
         CMemoryPool* pool
@@ -1188,7 +1188,7 @@ cdef class ParquetReader:
         return pyarrow_wrap_chunked_array(out)
 
 
-cdef class ParquetWriter:
+cdef class ParquetWriter(_Weakrefable):
     cdef:
         unique_ptr[FileWriter] writer
         shared_ptr[COutputStream] sink

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -35,7 +35,8 @@ import socket
 import warnings
 
 import pyarrow
-from pyarrow.lib cimport Buffer, NativeFile, check_status, pyarrow_wrap_buffer
+from pyarrow.lib cimport (Buffer, NativeFile, _Weakrefable,
+                          check_status, pyarrow_wrap_buffer)
 from pyarrow.lib import ArrowException, frombytes
 from pyarrow.includes.libarrow cimport (CBuffer, CMutableBuffer,
                                         CFixedSizeBufferWriter, CStatus)

--- a/python/pyarrow/_plasma.pyx
+++ b/python/pyarrow/_plasma.pyx
@@ -154,7 +154,7 @@ def make_object_id(object_id):
     return ObjectID(object_id)
 
 
-cdef class ObjectID:
+cdef class ObjectID(_Weakrefable):
     """
     An ObjectID represents a string of bytes used to identify Plasma objects.
     """
@@ -210,7 +210,7 @@ cdef class ObjectID:
         return ObjectID(random_id)
 
 
-cdef class ObjectNotAvailable:
+cdef class ObjectNotAvailable(_Weakrefable):
     """
     Placeholder for an object that was not available within the given timeout.
     """
@@ -293,7 +293,7 @@ def get_socket_from_fd(fileno, family, type):
     return socket.socket(fileno=fileno, family=family, type=type)
 
 
-cdef class PlasmaClient:
+cdef class PlasmaClient(_Weakrefable):
     """
     The PlasmaClient is used to interface with a plasma store and manager.
 

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -619,7 +619,7 @@ def _restore_array(data):
     return pyarrow_wrap_array(MakeArray(ad))
 
 
-cdef class _PandasConvertible:
+cdef class _PandasConvertible(_Weakrefable):
 
     def to_pandas(
             self,

--- a/python/pyarrow/builder.pxi
+++ b/python/pyarrow/builder.pxi
@@ -16,7 +16,7 @@
 # under the License.
 
 
-cdef class StringBuilder:
+cdef class StringBuilder(_Weakrefable):
     """
     Builder class for UTF8 strings.
 

--- a/python/pyarrow/feather.pxi
+++ b/python/pyarrow/feather.pxi
@@ -52,7 +52,7 @@ def write_feather(Table table, object dest, compression=None,
                                   properties))
 
 
-cdef class FeatherReader:
+cdef class FeatherReader(_Weakrefable):
     cdef:
         shared_ptr[CFeatherReader] reader
 

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -30,7 +30,7 @@ from libc.stdint cimport int64_t, int32_t, uint8_t, uintptr_t
 from pyarrow.includes.libarrow cimport *
 from pyarrow.lib cimport (Array, DataType, Field, MemoryPool, RecordBatch,
                           Schema, check_status, pyarrow_wrap_array,
-                          pyarrow_wrap_data_type, ensure_type)
+                          pyarrow_wrap_data_type, ensure_type, _Weakrefable)
 from pyarrow.lib import frombytes
 
 from pyarrow.includes.libgandiva cimport (
@@ -75,7 +75,7 @@ from pyarrow.includes.libgandiva cimport (
     GetRegisteredFunctionSignatures)
 
 
-cdef class Node:
+cdef class Node(_Weakrefable):
     cdef:
         shared_ptr[CNode] node
 
@@ -90,14 +90,14 @@ cdef class Node:
         self.node = node
         return self
 
-cdef class Expression:
+cdef class Expression(_Weakrefable):
     cdef:
         shared_ptr[CExpression] expression
 
     cdef void init(self, shared_ptr[CExpression] expression):
         self.expression = expression
 
-cdef class Condition:
+cdef class Condition(_Weakrefable):
     cdef:
         shared_ptr[CCondition] condition
 
@@ -112,7 +112,7 @@ cdef class Condition:
         self.condition = condition
         return self
 
-cdef class SelectionVector:
+cdef class SelectionVector(_Weakrefable):
     cdef:
         shared_ptr[CSelectionVector] selection_vector
 
@@ -130,7 +130,7 @@ cdef class SelectionVector:
         cdef shared_ptr[CArray] result = self.selection_vector.get().ToArray()
         return pyarrow_wrap_array(result)
 
-cdef class Projector:
+cdef class Projector(_Weakrefable):
     cdef:
         shared_ptr[CProjector] projector
         MemoryPool pool
@@ -161,7 +161,7 @@ cdef class Projector:
             arrays.append(pyarrow_wrap_array(result))
         return arrays
 
-cdef class Filter:
+cdef class Filter(_Weakrefable):
     cdef:
         shared_ptr[CFilter] filter
 
@@ -203,7 +203,7 @@ cdef class Filter:
         return SelectionVector.create(selection)
 
 
-cdef class TreeExprBuilder:
+cdef class TreeExprBuilder(_Weakrefable):
 
     def make_literal(self, value, dtype):
         cdef:
@@ -410,7 +410,7 @@ cpdef make_filter(Schema schema, Condition condition):
     check_status(Filter_Make(schema.sp_schema, condition.condition, &result))
     return Filter.create(result)
 
-cdef class FunctionSignature:
+cdef class FunctionSignature(_Weakrefable):
     """
     Signature of a Gandiva function including name, parameter types
     and return type.

--- a/python/pyarrow/io-hdfs.pxi
+++ b/python/pyarrow/io-hdfs.pxi
@@ -41,7 +41,7 @@ def strip_hdfs_abspath(path):
         return path
 
 
-cdef class HadoopFileSystem:
+cdef class HadoopFileSystem(_Weakrefable):
     cdef:
         shared_ptr[CIOHadoopFileSystem] client
 
@@ -441,7 +441,7 @@ cdef class HadoopFileSystem:
 # client. During deallocation of the extension class, the attributes are
 # decref'd which can cause the client to get closed first if the file has the
 # last remaining reference
-cdef class _HdfsFileNanny:
+cdef class _HdfsFileNanny(_Weakrefable):
     cdef:
         object client
         object file_handle_ref

--- a/python/pyarrow/io.pxi
+++ b/python/pyarrow/io.pxi
@@ -41,7 +41,7 @@ cdef extern from "Python.h":
         char *v, Py_ssize_t len) except NULL
 
 
-cdef class NativeFile:
+cdef class NativeFile(_Weakrefable):
     """
     The base class for all Arrow streams.
 
@@ -878,7 +878,7 @@ cdef class FixedSizeBufferWriter(NativeFile):
 # Arrow buffers
 
 
-cdef class Buffer:
+cdef class Buffer(_Weakrefable):
     """
     The base class for all Arrow buffers.
 
@@ -1576,7 +1576,7 @@ cdef str _compression_name(CCompressionType ctype):
         raise RuntimeError('Unexpected CCompressionType value')
 
 
-cdef class Codec:
+cdef class Codec(_Weakrefable):
     """
     Compression codec.
 

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -45,7 +45,7 @@ cdef CMetadataVersion _unwrap_metadata_version(
     raise ValueError("Not a metadata version: " + repr(version))
 
 
-cdef class IpcWriteOptions:
+cdef class IpcWriteOptions(_Weakrefable):
     """Serialization options for the IPC format.
 
     Parameters
@@ -115,7 +115,7 @@ cdef class IpcWriteOptions:
         self.c_options.use_threads = value
 
 
-cdef class Message:
+cdef class Message(_Weakrefable):
     """
     Container for an Arrow IPC message with metadata and optional body
     """
@@ -221,7 +221,7 @@ metadata length: {1}
 body length: {2}""".format(self.type, metadata_len, body_len)
 
 
-cdef class MessageReader:
+cdef class MessageReader(_Weakrefable):
     """
     Interface for reading Message objects from some source (like an
     InputStream)
@@ -277,7 +277,7 @@ cdef class MessageReader:
 # ----------------------------------------------------------------------
 # File and stream readers and writers
 
-cdef class _CRecordBatchWriter:
+cdef class _CRecordBatchWriter(_Weakrefable):
     """The base RecordBatchWriter wrapper.
 
     Provides common implementations of convenience methods. Should not
@@ -398,7 +398,7 @@ cdef _get_input_stream(object source, shared_ptr[CInputStream]* out):
     get_input_stream(source, True, out)
 
 
-cdef class _CRecordBatchReader:
+cdef class _CRecordBatchReader(_Weakrefable):
     """The base RecordBatchReader wrapper.
 
     Provides common implementations of convenience methods. Should not
@@ -483,7 +483,7 @@ cdef class _RecordBatchFileWriter(_RecordBatchStreamWriter):
                 NewFileWriter(self.sink.get(), schema.sp_schema, self.options))
 
 
-cdef class _RecordBatchFileReader:
+cdef class _RecordBatchFileReader(_Weakrefable):
     cdef:
         shared_ptr[CRecordBatchFileReader] reader
         shared_ptr[CRandomAccessFile] file

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -31,17 +31,21 @@ cdef extern from "Python.h":
 cdef int check_status(const CStatus& status) nogil except -1
 
 
-cdef class IpcWriteOptions:
+cdef class _Weakrefable:
+    cdef object __weakref__
+
+
+cdef class IpcWriteOptions(_Weakrefable):
     cdef:
         CIpcWriteOptions c_options
 
 
-cdef class Message:
+cdef class Message(_Weakrefable):
     cdef:
         unique_ptr[CMessage] message
 
 
-cdef class MemoryPool:
+cdef class MemoryPool(_Weakrefable):
     cdef:
         CMemoryPool* pool
 
@@ -51,12 +55,11 @@ cdef class MemoryPool:
 cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool)
 
 
-cdef class DataType:
+cdef class DataType(_Weakrefable):
     cdef:
         shared_ptr[CDataType] sp_type
         CDataType* type
         bytes pep3118_format
-        object __weakref__
 
     cdef void init(self, const shared_ptr[CDataType]& type) except *
     cdef Field field(self, int i)
@@ -89,7 +92,7 @@ cdef class StructType(DataType):
     cdef Field field_by_name(self, name)
 
 
-cdef class DictionaryMemo:
+cdef class DictionaryMemo(_Weakrefable):
     cdef:
         # Even though the CDictionaryMemo instance is private, we allocate
         # it on the heap so as to avoid C++ ABI issues with Python wheels.
@@ -146,7 +149,7 @@ cdef class PyExtensionType(ExtensionType):
     pass
 
 
-cdef class _Metadata:
+cdef class _Metadata(_Weakrefable):
     # required because KeyValueMetadata also extends collections.abc.Mapping
     # and the first parent class must be an extension type
     pass
@@ -164,7 +167,7 @@ cdef class KeyValueMetadata(_Metadata):
     cdef inline shared_ptr[const CKeyValueMetadata] unwrap(self) nogil
 
 
-cdef class Field:
+cdef class Field(_Weakrefable):
     cdef:
         shared_ptr[CField] sp_field
         CField* field
@@ -175,7 +178,7 @@ cdef class Field:
     cdef void init(self, const shared_ptr[CField]& field)
 
 
-cdef class Schema:
+cdef class Schema(_Weakrefable):
     cdef:
         shared_ptr[CSchema] sp_schema
         CSchema* schema
@@ -184,7 +187,7 @@ cdef class Schema:
     cdef void init_schema(self, const shared_ptr[CSchema]& schema)
 
 
-cdef class Scalar:
+cdef class Scalar(_Weakrefable):
     cdef:
         shared_ptr[CScalar] wrapped
 
@@ -196,7 +199,7 @@ cdef class Scalar:
     cdef inline shared_ptr[CScalar] unwrap(self) nogil
 
 
-cdef class _PandasConvertible:
+cdef class _PandasConvertible(_Weakrefable):
     pass
 
 
@@ -204,7 +207,6 @@ cdef class Array(_PandasConvertible):
     cdef:
         shared_ptr[CArray] sp_array
         CArray* ap
-        object __weakref__
 
     cdef readonly:
         DataType type
@@ -216,7 +218,7 @@ cdef class Array(_PandasConvertible):
     cdef int64_t length(self)
 
 
-cdef class Tensor:
+cdef class Tensor(_Weakrefable):
     cdef:
         shared_ptr[CTensor] sp_tensor
         CTensor* tp
@@ -227,7 +229,7 @@ cdef class Tensor:
     cdef void init(self, const shared_ptr[CTensor]& sp_tensor)
 
 
-cdef class SparseCSRMatrix:
+cdef class SparseCSRMatrix(_Weakrefable):
     cdef:
         shared_ptr[CSparseCSRMatrix] sp_sparse_tensor
         CSparseCSRMatrix* stp
@@ -238,7 +240,7 @@ cdef class SparseCSRMatrix:
     cdef void init(self, const shared_ptr[CSparseCSRMatrix]& sp_sparse_tensor)
 
 
-cdef class SparseCSCMatrix:
+cdef class SparseCSCMatrix(_Weakrefable):
     cdef:
         shared_ptr[CSparseCSCMatrix] sp_sparse_tensor
         CSparseCSCMatrix* stp
@@ -249,7 +251,7 @@ cdef class SparseCSCMatrix:
     cdef void init(self, const shared_ptr[CSparseCSCMatrix]& sp_sparse_tensor)
 
 
-cdef class SparseCOOTensor:
+cdef class SparseCOOTensor(_Weakrefable):
     cdef:
         shared_ptr[CSparseCOOTensor] sp_sparse_tensor
         CSparseCOOTensor* stp
@@ -260,7 +262,7 @@ cdef class SparseCOOTensor:
     cdef void init(self, const shared_ptr[CSparseCOOTensor]& sp_sparse_tensor)
 
 
-cdef class SparseCSFTensor:
+cdef class SparseCSFTensor(_Weakrefable):
     cdef:
         shared_ptr[CSparseCSFTensor] sp_sparse_tensor
         CSparseCSFTensor* stp
@@ -422,7 +424,7 @@ cdef class RecordBatch(_PandasConvertible):
     cdef void init(self, const shared_ptr[CRecordBatch]& table)
 
 
-cdef class Buffer:
+cdef class Buffer(_Weakrefable):
     cdef:
         shared_ptr[CBuffer] buffer
         Py_ssize_t shape[1]
@@ -437,7 +439,7 @@ cdef class ResizableBuffer(Buffer):
     cdef void init_rz(self, const shared_ptr[CResizableBuffer]& buffer)
 
 
-cdef class NativeFile:
+cdef class NativeFile(_Weakrefable):
     cdef:
         shared_ptr[CInputStream] input_stream
         shared_ptr[CRandomAccessFile] random_access
@@ -446,7 +448,6 @@ cdef class NativeFile:
         bint is_writable
         bint is_seekable
         bint own_file
-        object __weakref__
 
     # By implementing these "virtual" functions (all functions in Cython
     # extension classes are technically virtual in the C++ sense) we can expose
@@ -477,17 +478,17 @@ cdef class CompressedOutputStream(NativeFile):
     pass
 
 
-cdef class _CRecordBatchWriter:
+cdef class _CRecordBatchWriter(_Weakrefable):
     cdef:
         shared_ptr[CRecordBatchWriter] writer
 
 
-cdef class _CRecordBatchReader:
+cdef class _CRecordBatchReader(_Weakrefable):
     cdef:
         shared_ptr[CRecordBatchReader] reader
 
 
-cdef class Codec:
+cdef class Codec(_Weakrefable):
     cdef:
         unique_ptr[CCodec] wrapped
 

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -20,7 +20,7 @@
 # cython: embedsignature = True
 
 
-cdef class MemoryPool:
+cdef class MemoryPool(_Weakrefable):
     """
     Base class for memory allocation.
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -19,7 +19,7 @@
 import collections
 
 
-cdef class Scalar:
+cdef class Scalar(_Weakrefable):
     """
     The base class for scalars.
     """

--- a/python/pyarrow/serialization.pxi
+++ b/python/pyarrow/serialization.pxi
@@ -43,7 +43,7 @@ class DeserializationCallbackError(ArrowSerializationError):
         self.type_id = type_id
 
 
-cdef class SerializationContext:
+cdef class SerializationContext(_Weakrefable):
     cdef:
         object type_to_type_id
         object whitelisted_types
@@ -231,7 +231,7 @@ def _get_default_context():
     return _default_serialization_context
 
 
-cdef class SerializedPyObject:
+cdef class SerializedPyObject(_Weakrefable):
     """
     Arrow-serialized representation of Python object.
     """

--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -16,7 +16,7 @@
 # under the License.
 
 
-cdef class Tensor:
+cdef class Tensor(_Weakrefable):
     """
     A n-dimensional array a.k.a Tensor.
     """
@@ -129,7 +129,7 @@ strides: {0.strides}""".format(self)
 ctypedef CSparseCOOIndex* _CSparseCOOIndexPtr
 
 
-cdef class SparseCOOTensor:
+cdef class SparseCOOTensor(_Weakrefable):
     """
     A sparse COO tensor.
     """
@@ -371,7 +371,7 @@ shape: {0.shape}""".format(self)
             return csi.is_canonical()
         return True
 
-cdef class SparseCSRMatrix:
+cdef class SparseCSRMatrix(_Weakrefable):
     """
     A sparse CSR matrix.
     """
@@ -554,7 +554,7 @@ shape: {0.shape}""".format(self)
     def non_zero_length(self):
         return self.stp.non_zero_length()
 
-cdef class SparseCSCMatrix:
+cdef class SparseCSCMatrix(_Weakrefable):
     """
     A sparse CSC matrix.
     """
@@ -739,7 +739,7 @@ shape: {0.shape}""".format(self)
         return self.stp.non_zero_length()
 
 
-cdef class SparseCSFTensor:
+cdef class SparseCSFTensor(_Weakrefable):
     """
     A sparse CSF tensor.
     """

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -25,6 +25,7 @@ import pickle
 import pytest
 import struct
 import sys
+import weakref
 
 import numpy as np
 try:
@@ -38,6 +39,14 @@ import pyarrow.tests.strategies as past
 
 def test_total_bytes_allocated():
     assert pa.total_allocated_bytes() == 0
+
+
+def test_weakref():
+    arr = pa.array([1, 2, 3])
+    wr = weakref.ref(arr)
+    assert wr() is not None
+    del arr
+    assert wr() is None
 
 
 def test_getitem_NULL():

--- a/python/pyarrow/tests/test_builder.py
+++ b/python/pyarrow/tests/test_builder.py
@@ -15,10 +15,20 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import weakref
+
 import numpy as np
 
 import pyarrow as pa
 from pyarrow.lib import StringBuilder
+
+
+def test_weakref():
+    sbuilder = StringBuilder()
+    wr = weakref.ref(sbuilder)
+    assert wr() is not None
+    del sbuilder
+    assert wr() is None
 
 
 def test_string_builder_append():

--- a/python/pyarrow/tests/test_io.py
+++ b/python/pyarrow/tests/test_io.py
@@ -349,6 +349,14 @@ def test_buffer_invalid():
         pa.py_buffer(None)
 
 
+def test_buffer_weakref():
+    buf = pa.py_buffer(b'some data')
+    wr = weakref.ref(buf)
+    assert wr() is not None
+    del buf
+    assert wr() is None
+
+
 @pytest.mark.parametrize('val, expected_hex_buffer',
                          [(b'check', b'636865636B'),
                           (b'\a0', b'0730'),

--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import contextlib
+import weakref
 
 import pyarrow as pa
 
@@ -61,6 +62,10 @@ def test_default_allocated_bytes():
 def test_proxy_memory_pool():
     pool = pa.proxy_memory_pool(pa.default_memory_pool())
     check_allocated_bytes(pool)
+    wr = weakref.ref(pool)
+    assert wr() is not None
+    del pool
+    assert wr() is None
 
 
 def test_logging_memory_pool(capfd):

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -18,6 +18,7 @@
 import datetime
 import decimal
 import pytest
+import weakref
 
 import numpy as np
 
@@ -68,6 +69,11 @@ def test_basics(value, ty, klass, deprecated):
     assert s.as_py() is None
     assert s != pa.scalar(value, type=ty)
 
+    wr = weakref.ref(s)
+    assert wr() is not None
+    del s
+    assert wr() is None
+
 
 def test_null_singleton():
     with pytest.raises(RuntimeError):
@@ -88,6 +94,11 @@ def test_nulls():
     for v in arr:
         assert v is pa.NA
         assert v.as_py() is None
+
+    wr = weakref.ref(null)
+    assert wr() is not None
+    del null
+    assert wr() is not None  # singleton
 
 
 def test_hashing():

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -18,6 +18,7 @@
 from collections import OrderedDict
 import pickle
 import sys
+import weakref
 
 from distutils.version import LooseVersion
 
@@ -242,6 +243,19 @@ baz: list<item: int8>
 
     with pytest.raises(TypeError):
         pa.schema([None])
+
+
+def test_schema_weakref():
+    fields = [
+        pa.field('foo', pa.int32()),
+        pa.field('bar', pa.string()),
+        pa.field('baz', pa.list_(pa.int8()))
+    ]
+    schema = pa.schema(fields)
+    wr = weakref.ref(schema)
+    assert wr() is not None
+    del schema
+    assert wr() is None
 
 
 def test_schema_to_string_with_metadata():

--- a/python/pyarrow/tests/test_sparse_tensor.py
+++ b/python/pyarrow/tests/test_sparse_tensor.py
@@ -17,6 +17,7 @@
 
 import pytest
 import sys
+import weakref
 
 import numpy as np
 import pyarrow as pa
@@ -71,6 +72,11 @@ def test_sparse_tensor_attrs(sparse_tensor_type):
     assert sparse_tensor.dim_name(0) == dim_names[0]
     assert sparse_tensor.dim_names == dim_names
     assert sparse_tensor.non_zero_length == 6
+
+    wr = weakref.ref(sparse_tensor)
+    assert wr() is not None
+    del sparse_tensor
+    assert wr() is None
 
 
 def test_sparse_coo_tensor_base_object():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 from collections.abc import Iterable
 import pickle
 import sys
+import weakref
 
 import numpy as np
 import pytest
@@ -49,6 +50,11 @@ def test_chunked_array_basics():
     assert data.nbytes == sum(c.nbytes for c in data.iterchunks())
     assert sys.getsizeof(data) >= object.__sizeof__(data) + data.nbytes
     data.validate()
+
+    wr = weakref.ref(data)
+    assert wr() is not None
+    del data
+    assert wr() is None
 
 
 def test_chunked_array_mismatch_types():
@@ -337,6 +343,11 @@ c0: int16
 c1: int32
 -- schema metadata --
 foo: 'bar'"""
+
+    wr = weakref.ref(batch)
+    assert wr() is not None
+    del batch
+    assert wr() is None
 
 
 def test_recordbatch_equals():
@@ -643,6 +654,11 @@ def test_table_basics():
     assert table == pa.table(columns, names=table.column_names)
     assert table != pa.table(columns[1:], names=table.column_names[1:])
     assert table != columns
+
+    wr = weakref.ref(table)
+    assert wr() is not None
+    del table
+    assert wr() is None
 
 
 def test_table_from_arrays_preserves_column_metadata():

--- a/python/pyarrow/tests/test_tensor.py
+++ b/python/pyarrow/tests/test_tensor.py
@@ -18,6 +18,7 @@
 import os
 import sys
 import pytest
+import weakref
 
 import numpy as np
 import pyarrow as pa
@@ -64,6 +65,11 @@ def test_tensor_attrs():
     assert tensor.dim_names == ['x', 'y']
     assert tensor.dim_name(0) == 'x'
     assert tensor.dim_name(1) == 'y'
+
+    wr = weakref.ref(tensor)
+    assert wr() is not None
+    del tensor
+    assert wr() is None
 
 
 def test_tensor_base_object():

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -91,7 +91,7 @@ def _is_primitive(Type type):
 ctypedef CFixedWidthType* _CFixedWidthTypePtr
 
 
-cdef class DataType:
+cdef class DataType(_Weakrefable):
     """
     Base class of all Arrow data types.
 
@@ -219,7 +219,7 @@ cdef class DataType:
         return pyarrow_wrap_data_type(result)
 
 
-cdef class DictionaryMemo:
+cdef class DictionaryMemo(_Weakrefable):
     """
     Tracking container for dictionary-encoded fields.
     """
@@ -961,7 +961,7 @@ cdef KeyValueMetadata ensure_metadata(object meta, c_bool allow_none=False):
         return KeyValueMetadata(meta)
 
 
-cdef class Field:
+cdef class Field(_Weakrefable):
     """
     A named field, with a data type, nullability, and optional metadata.
 
@@ -1149,7 +1149,7 @@ cdef class Field:
         return [pyarrow_wrap_field(f) for f in flattened]
 
 
-cdef class Schema:
+cdef class Schema(_Weakrefable):
 
     def __cinit__(self):
         pass
@@ -2597,7 +2597,7 @@ def is_float_value(object obj):
     return IsPyFloat(obj)
 
 
-cdef class _ExtensionRegistryNanny:
+cdef class _ExtensionRegistryNanny(_Weakrefable):
     # Keep the registry alive until we have unregistered PyExtensionType
     cdef:
         shared_ptr[CExtensionTypeRegistry] registry


### PR DESCRIPTION
By default, Cython extension classes (defined with "cdef class") don't have a weakref slot, so add one to all of them.

This adds just one memory word to each object, which IMHO is acceptable.