### PR TITLE
ARROW-9390: [Doc] Add missing file

### DIFF
--- a/docs/source/cpp/api/scalar.rst
+++ b/docs/source/cpp/api/scalar.rst
@@ -1,0 +1,38 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+=======
+Scalars
+=======
+
+.. doxygenstruct:: arrow::Scalar
+   :project: arrow_cpp
+   :members:
+
+Factory functions
+=================
+
+.. doxygengroup:: scalar-factories
+   :content-only:
+
+Concrete scalar subclasses
+==========================
+
+.. doxygengroup:: concrete-scalar-classes
+   :content-only:
+   :members:
+   :undoc-members:


### PR DESCRIPTION
Followup from PR #7755: a new doc file wasn't checked in, and Sphinx only emits a warning.