### PR TITLE
ARROW-9476: [C++][Dataset] Fix incorrect dictionary association in HivePartitioningFactory

### DIFF
--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -772,11 +772,11 @@ std::shared_ptr<Expression> and_(std::shared_ptr<Expression> lhs,
 }
 
 std::shared_ptr<Expression> and_(const ExpressionVector& subexpressions) {
-  return std::accumulate(
-      subexpressions.begin(), subexpressions.end(), scalar(true),
-      [](std::shared_ptr<Expression> acc, const std::shared_ptr<Expression>& next) {
-        return acc->Equals(true) ? next : and_(std::move(acc), next);
-      });
+  auto acc = scalar(true);
+  for (const auto& next : subexpressions) {
+    acc = acc->Equals(true) ? next : and_(std::move(acc), next);
+  }
+  return acc;
 }
 
 std::shared_ptr<Expression> or_(std::shared_ptr<Expression> lhs,
@@ -785,11 +785,11 @@ std::shared_ptr<Expression> or_(std::shared_ptr<Expression> lhs,
 }
 
 std::shared_ptr<Expression> or_(const ExpressionVector& subexpressions) {
-  return std::accumulate(
-      subexpressions.begin(), subexpressions.end(), scalar(false),
-      [](std::shared_ptr<Expression> acc, const std::shared_ptr<Expression>& next) {
-        return acc->Equals(false) ? next : or_(std::move(acc), next);
-      });
+  auto acc = scalar(false);
+  for (const auto& next : subexpressions) {
+    acc = acc->Equals(false) ? next : and_(std::move(acc), next);
+  }
+  return acc;
 }
 
 std::shared_ptr<Expression> not_(std::shared_ptr<Expression> operand) {

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -787,7 +787,7 @@ std::shared_ptr<Expression> or_(std::shared_ptr<Expression> lhs,
 std::shared_ptr<Expression> or_(const ExpressionVector& subexpressions) {
   auto acc = scalar(false);
   for (const auto& next : subexpressions) {
-    acc = acc->Equals(false) ? next : and_(std::move(acc), next);
+    acc = acc->Equals(false) ? next : or_(std::move(acc), next);
   }
   return acc;
 }

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -772,13 +772,10 @@ std::shared_ptr<Expression> and_(std::shared_ptr<Expression> lhs,
 }
 
 std::shared_ptr<Expression> and_(const ExpressionVector& subexpressions) {
-  if (subexpressions.size() == 0) {
-    return scalar(true);
-  }
   return std::accumulate(
-      subexpressions.begin(), subexpressions.end(), std::shared_ptr<Expression>(),
+      subexpressions.begin(), subexpressions.end(), scalar(true),
       [](std::shared_ptr<Expression> acc, const std::shared_ptr<Expression>& next) {
-        return acc == nullptr ? next : and_(std::move(acc), next);
+        return acc->Equals(true) ? next : and_(std::move(acc), next);
       });
 }
 
@@ -788,13 +785,10 @@ std::shared_ptr<Expression> or_(std::shared_ptr<Expression> lhs,
 }
 
 std::shared_ptr<Expression> or_(const ExpressionVector& subexpressions) {
-  if (subexpressions.size() == 0) {
-    return scalar(false);
-  }
   return std::accumulate(
-      subexpressions.begin(), subexpressions.end(), std::shared_ptr<Expression>(),
+      subexpressions.begin(), subexpressions.end(), scalar(false),
       [](std::shared_ptr<Expression> acc, const std::shared_ptr<Expression>& next) {
-        return acc == nullptr ? next : or_(std::move(acc), next);
+        return acc->Equals(false) ? next : or_(std::move(acc), next);
       });
 }
 

--- a/cpp/src/arrow/dataset/partition.cc
+++ b/cpp/src/arrow/dataset/partition.cc
@@ -318,11 +318,10 @@ class KeyValuePartitioningInspectImpl {
   }
 
   std::vector<std::string> FieldNames() {
-    std::vector<std::string> names;
-    names.reserve(name_to_index_.size());
+    std::vector<std::string> names(name_to_index_.size());
 
     for (auto kv : name_to_index_) {
-      names.push_back(kv.first);
+      names[kv.second] = kv.first;
     }
     return names;
   }

--- a/cpp/src/arrow/dataset/partition_test.cc
+++ b/cpp/src/arrow/dataset/partition_test.cc
@@ -155,6 +155,7 @@ TEST_F(TestPartitioning, DictionaryInference) {
   AssertInspect({"/a/0"}, {Dict("alpha"), Int("beta")});
   AssertInspect({"/a/0", "/a/1"}, {Dict("alpha"), Int("beta")});
   AssertInspect({"/a/0", "/b/0", "/a/1", "/b/1"}, {Dict("alpha"), Int("beta")});
+  AssertInspect({"/a/-", "/b/-", "/a/_", "/b/_"}, {Dict("alpha"), Dict("beta")});
 
   // fall back to string if max dictionary size is exceeded
   AssertInspect({"/a/0", "/b/0", "/c/1", "/d/1"}, {Str("alpha"), Int("beta")});
@@ -245,6 +246,9 @@ TEST_F(TestPartitioning, HiveDictionaryInference) {
   AssertInspect(
       {"/alpha=a/beta=0", "/alpha=b/beta=0", "/alpha=a/beta=1", "/alpha=b/beta=1"},
       {Dict("alpha"), Int("beta")});
+  AssertInspect(
+      {"/alpha=a/beta=-", "/alpha=b/beta=-", "/alpha=a/beta=_", "/alpha=b/beta=_"},
+      {Dict("alpha"), Dict("beta")});
 
   // fall back to string if max dictionary size is exceeded
   AssertInspect(

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1486,30 +1486,45 @@ def test_open_dataset_non_existing_file():
 
 @pytest.mark.parquet
 @pytest.mark.parametrize('partitioning', ["directory", "hive"])
-def test_open_dataset_partitioned_dictionary_type(tempdir, partitioning):
-    # ARROW-9288
+@pytest.mark.parametrize('partition_keys', [
+        (["A", "B", "C"], [1, 2, 3]),
+        ([1, 2, 3], ["A", "B", "C"]),
+        (["A", "B", "C"], ["D", "E", "F"]),
+        ([1, 2, 3], [4, 5, 6]),
+    ])
+def test_open_dataset_partitioned_dictionary_type(tempdir, partitioning,
+                                                  partition_keys):
+    # ARROW-9288 / ARROW-9476
     import pyarrow.parquet as pq
     table = pa.table({'a': range(9), 'b': [0.] * 4 + [1.] * 5})
 
-    path = tempdir / "dataset"
-    path.mkdir()
+    basepath = tempdir / "dataset"
+    basepath.mkdir()
 
-    for part in ["A", "B", "C"]:
-        fmt = "{}" if partitioning == "directory" else "part={}"
-        part = path / fmt.format(part)
-        part.mkdir()
-        pq.write_table(table, part / "test.parquet")
+    part_keys1, part_keys2 = partition_keys
+    for part1 in part_keys1:
+        for part2 in part_keys2:
+            if partitioning == 'directory':
+                fmt = "{0}/{1}"
+            else:
+                fmt = "part1={0}/part2={1}"
+            path = basepath / fmt.format(part1, part2)
+            path.mkdir(parents=True)
+            pq.write_table(table, path / "test.parquet")
 
     if partitioning == "directory":
         part = ds.DirectoryPartitioning.discover(
-            ["part"], max_partition_dictionary_size=-1)
+            ["part1", "part2"], max_partition_dictionary_size=None)
     else:
-        part = ds.HivePartitioning.discover(max_partition_dictionary_size=-1)
+        part = ds.HivePartitioning.discover(max_partition_dictionary_size=None)
 
-    dataset = ds.dataset(str(path), partitioning=part)
+    dataset = ds.dataset(str(basepath), partitioning=part)
+
+    dict_type = pa.dictionary(pa.int32(), pa.string())
+    part_type1 = dict_type if isinstance(part_keys1[0], str) else pa.int32()
+    part_type2 = dict_type if isinstance(part_keys2[0], str) else pa.int32()
     expected_schema = table.schema.append(
-        pa.field("part", pa.dictionary(pa.int32(), pa.string()))
-    )
+        pa.field("part1", part_type1)).append(pa.field("part2", part_type2))
     assert dataset.schema.equals(expected_schema)
 
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1487,11 +1487,11 @@ def test_open_dataset_non_existing_file():
 @pytest.mark.parquet
 @pytest.mark.parametrize('partitioning', ["directory", "hive"])
 @pytest.mark.parametrize('partition_keys', [
-        (["A", "B", "C"], [1, 2, 3]),
-        ([1, 2, 3], ["A", "B", "C"]),
-        (["A", "B", "C"], ["D", "E", "F"]),
-        ([1, 2, 3], [4, 5, 6]),
-    ])
+    (["A", "B", "C"], [1, 2, 3]),
+    ([1, 2, 3], ["A", "B", "C"]),
+    (["A", "B", "C"], ["D", "E", "F"]),
+    ([1, 2, 3], [4, 5, 6]),
+])
 def test_open_dataset_partitioned_dictionary_type(tempdir, partitioning,
                                                   partition_keys):
     # ARROW-9288 / ARROW-9476


### PR DESCRIPTION
In the presence of multiple fields, it was possible (non-deterministically) that the field->dictionary association could be scrambled.