### PR TITLE
ARROW-9484: [Docs] Update is* functions to be is_* in the compute docs

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
@@ -58,7 +58,7 @@ static void AsciiUpper(benchmark::State& state) {
 }
 
 static void IsAlphaNumericAscii(benchmark::State& state) {
-  UnaryStringBenchmark(state, "ascii_isalnum");
+  UnaryStringBenchmark(state, "ascii_is_alnum");
 }
 
 static void MatchSubstring(benchmark::State& state) {
@@ -76,7 +76,7 @@ static void Utf8Lower(benchmark::State& state) {
 }
 
 static void IsAlphaNumericUnicode(benchmark::State& state) {
-  UnaryStringBenchmark(state, "utf8_isalnum");
+  UnaryStringBenchmark(state, "utf8_is_alnum");
 }
 #endif
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -263,37 +263,37 @@ given class:
 +--------------------------+------------+--------------------+----------------+----------------------------------+
 | Function name            | Arity      | Input types        | Output type    | Matched character class          |
 +==========================+============+====================+================+==================================+
-| ascii_is_alnum            | Unary      | String-like        | Boolean        | Alphanumeric ASCII               |
+| ascii_is_alnum           | Unary      | String-like        | Boolean        | Alphanumeric ASCII               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_is_alpha            | Unary      | String-like        | Boolean        | Alphabetic ASCII                 |
+| ascii_is_alpha           | Unary      | String-like        | Boolean        | Alphabetic ASCII                 |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_is_decimal          | Unary      | String-like        | Boolean        | Decimal ASCII \(1)               |
+| ascii_is_decimal         | Unary      | String-like        | Boolean        | Decimal ASCII \(1)               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_is_lower            | Unary      | String-like        | Boolean        | Lowercase ASCII \(2)             |
+| ascii_is_lower           | Unary      | String-like        | Boolean        | Lowercase ASCII \(2)             |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_is_printable        | Unary      | String-like        | Boolean        | Printable ASCII                  |
+| ascii_is_printable       | Unary      | String-like        | Boolean        | Printable ASCII                  |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_is_space            | Unary      | String-like        | Boolean        | Whitespace ASCII                 |
+| ascii_is_space           | Unary      | String-like        | Boolean        | Whitespace ASCII                 |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_is_upper            | Unary      | String-like        | Boolean        | Uppercase ASCII \(2)             |
+| ascii_is_upper           | Unary      | String-like        | Boolean        | Uppercase ASCII \(2)             |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_is_alnum             | Unary      | String-like        | Boolean        | Alphanumeric Unicode             |
+| utf8_is_alnum            | Unary      | String-like        | Boolean        | Alphanumeric Unicode             |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_is_alpha             | Unary      | String-like        | Boolean        | Alphabetic Unicode               |
+| utf8_is_alpha            | Unary      | String-like        | Boolean        | Alphabetic Unicode               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_is_decimal           | Unary      | String-like        | Boolean        | Decimal Unicode                  |
+| utf8_is_decimal          | Unary      | String-like        | Boolean        | Decimal Unicode                  |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_isdigit             | Unary      | String-like        | Boolean        | Unicode digit \(3)               |
+| utf8_is_digit            | Unary      | String-like        | Boolean        | Unicode digit \(3)               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_is_lower             | Unary      | String-like        | Boolean        | Lowercase Unicode \(2)           |
+| utf8_is_lower            | Unary      | String-like        | Boolean        | Lowercase Unicode \(2)           |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_isnumeric           | Unary      | String-like        | Boolean        | Numeric Unicode \(4)             |
+| utf8_is_numeric          | Unary      | String-like        | Boolean        | Numeric Unicode \(4)             |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_is_printable         | Unary      | String-like        | Boolean        | Printable Unicode                |
+| utf8_is_printable        | Unary      | String-like        | Boolean        | Printable Unicode                |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_is_space             | Unary      | String-like        | Boolean        | Whitespace Unicode               |
+| utf8_is_space            | Unary      | String-like        | Boolean        | Whitespace Unicode               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_is_upper             | Unary      | String-like        | Boolean        | Uppercase Unicode \(2)           |
+| utf8_is_upper            | Unary      | String-like        | Boolean        | Uppercase Unicode \(2)           |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
 
 * \(1) Also matches all numeric ASCII characters and all ASCII digits.
@@ -310,9 +310,9 @@ element:
 +--------------------------+------------+--------------------+---------------------+---------+
 | Function name            | Arity      | Input types        | Output type         | Notes   |
 +==========================+============+====================+=====================+=========+
-| ascii_is_title            | Unary      | String-like        | Boolean             | \(1)    |
+| ascii_is_title           | Unary      | String-like        | Boolean             | \(1)    |
 +--------------------------+------------+--------------------+---------------------+---------+
-| utf8_is_title             | Unary      | String-like        | Boolean             | \(1)    |
+| utf8_is_title            | Unary      | String-like        | Boolean             | \(1)    |
 +--------------------------+------------+--------------------+---------------------+---------+
 
 * \(1) Output is true iff the input string element is title-cased, i.e. any
@@ -324,7 +324,7 @@ The third set of functions examines string elements on a byte-per-byte basis:
 +--------------------------+------------+--------------------+---------------------+---------+
 | Function name            | Arity      | Input types        | Output type         | Notes   |
 +==========================+============+====================+=====================+=========+
-| string_is_ascii           | Unary      | String-like        | Boolean             | \(1)    |
+| string_is_ascii          | Unary      | String-like        | Boolean             | \(1)    |
 +--------------------------+------------+--------------------+---------------------+---------+
 
 * \(1) Output is true iff the input string element contains only ASCII characters,

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -263,46 +263,46 @@ given class:
 +--------------------------+------------+--------------------+----------------+----------------------------------+
 | Function name            | Arity      | Input types        | Output type    | Matched character class          |
 +==========================+============+====================+================+==================================+
-| ascii_isalnum            | Unary      | String-like        | Boolean        | Alphanumeric ASCII               |
+| ascii_is_alnum            | Unary      | String-like        | Boolean        | Alphanumeric ASCII               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_isalpha            | Unary      | String-like        | Boolean        | Alphabetic ASCII                 |
+| ascii_is_alpha            | Unary      | String-like        | Boolean        | Alphabetic ASCII                 |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_isdecimal          | Unary      | String-like        | Boolean        | Decimal ASCII \(1)               |
+| ascii_is_decimal          | Unary      | String-like        | Boolean        | Decimal ASCII \(1)               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_islower            | Unary      | String-like        | Boolean        | Lowercase ASCII \(2)             |
+| ascii_is_lower            | Unary      | String-like        | Boolean        | Lowercase ASCII \(2)             |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_isprintable        | Unary      | String-like        | Boolean        | Printable ASCII                  |
+| ascii_is_printable        | Unary      | String-like        | Boolean        | Printable ASCII                  |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_isspace            | Unary      | String-like        | Boolean        | Whitespace ASCII                 |
+| ascii_is_space            | Unary      | String-like        | Boolean        | Whitespace ASCII                 |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| ascii_isupper            | Unary      | String-like        | Boolean        | Uppercase ASCII \(2)             |
+| ascii_is_upper            | Unary      | String-like        | Boolean        | Uppercase ASCII \(2)             |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_isalnum             | Unary      | String-like        | Boolean        | Alphanumeric Unicode             |
+| utf8_is_alnum             | Unary      | String-like        | Boolean        | Alphanumeric Unicode             |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_isalpha             | Unary      | String-like        | Boolean        | Alphabetic Unicode               |
+| utf8_is_alpha             | Unary      | String-like        | Boolean        | Alphabetic Unicode               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_isdecimal           | Unary      | String-like        | Boolean        | Decimal Unicode                  |
+| utf8_is_decimal           | Unary      | String-like        | Boolean        | Decimal Unicode                  |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
 | utf8_isdigit             | Unary      | String-like        | Boolean        | Unicode digit \(3)               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_islower             | Unary      | String-like        | Boolean        | Lowercase Unicode \(2)           |
+| utf8_is_lower             | Unary      | String-like        | Boolean        | Lowercase Unicode \(2)           |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
 | utf8_isnumeric           | Unary      | String-like        | Boolean        | Numeric Unicode \(4)             |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_isprintable         | Unary      | String-like        | Boolean        | Printable Unicode                |
+| utf8_is_printable         | Unary      | String-like        | Boolean        | Printable Unicode                |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_isspace             | Unary      | String-like        | Boolean        | Whitespace Unicode               |
+| utf8_is_space             | Unary      | String-like        | Boolean        | Whitespace Unicode               |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
-| utf8_isupper             | Unary      | String-like        | Boolean        | Uppercase Unicode \(2)           |
+| utf8_is_upper             | Unary      | String-like        | Boolean        | Uppercase Unicode \(2)           |
 +--------------------------+------------+--------------------+----------------+----------------------------------+
 
 * \(1) Also matches all numeric ASCII characters and all ASCII digits.
 
 * \(2) Non-cased characters, such as punctuation, do not match.
 
-* \(3) This is currently the same as ``utf8_isdecimal``.
+* \(3) This is currently the same as ``utf8_is_decimal``.
 
-* \(4) Unlike ``utf8_isdecimal``, non-decimal numeric characters also match.
+* \(4) Unlike ``utf8_is_decimal``, non-decimal numeric characters also match.
 
 The second set of functions also consider the character order in a string
 element:
@@ -310,9 +310,9 @@ element:
 +--------------------------+------------+--------------------+---------------------+---------+
 | Function name            | Arity      | Input types        | Output type         | Notes   |
 +==========================+============+====================+=====================+=========+
-| ascii_istitle            | Unary      | String-like        | Boolean             | \(1)    |
+| ascii_is_title            | Unary      | String-like        | Boolean             | \(1)    |
 +--------------------------+------------+--------------------+---------------------+---------+
-| utf8_istitle             | Unary      | String-like        | Boolean             | \(1)    |
+| utf8_is_title             | Unary      | String-like        | Boolean             | \(1)    |
 +--------------------------+------------+--------------------+---------------------+---------+
 
 * \(1) Output is true iff the input string element is title-cased, i.e. any
@@ -324,7 +324,7 @@ The third set of functions examines string elements on a byte-per-byte basis:
 +--------------------------+------------+--------------------+---------------------+---------+
 | Function name            | Arity      | Input types        | Output type         | Notes   |
 +==========================+============+====================+=====================+=========+
-| string_isascii           | Unary      | String-like        | Boolean             | \(1)    |
+| string_is_ascii           | Unary      | String-like        | Boolean             | \(1)    |
 +--------------------------+------------+--------------------+---------------------+---------+
 
 * \(1) Output is true iff the input string element contains only ASCII characters,

--- a/r/README.md
+++ b/r/README.md
@@ -158,12 +158,6 @@ you will need to set the `ARROW_R_DEV` environment variable to `TRUE`
 sessions) so that the `data-raw/codegen.R` file is used for code
 generation.
 
-The codegen.R script has these additional dependencies:
-
-``` r
-install.packages("glue")
-```
-
 We use Google C++ style in our C++ code. Check for style errors with
 
     ./lint.sh


### PR DESCRIPTION
Also snuck in a little r/README.md cleanup