### PR TITLE
PARQUET-1878: [C++] lz4 codec is not compatible with Hadoop Lz4Codec

### DIFF
--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -54,6 +54,8 @@ std::string Codec::GetCodecAsString(Compression::type t) {
       return "LZ4_RAW";
     case Compression::LZ4_FRAME:
       return "LZ4";
+    case Compression::LZ4_HADOOP:
+      return "LZ4_HADOOP";
     case Compression::ZSTD:
       return "ZSTD";
     case Compression::BZ2:
@@ -78,6 +80,8 @@ Result<Compression::type> Codec::GetCompressionType(const std::string& name) {
     return Compression::LZ4;
   } else if (name == "LZ4") {
     return Compression::LZ4_FRAME;
+  } else if (name == "LZ4_HADOOP") {
+    return Compression::LZ4_HADOOP;
   } else if (name == "ZSTD") {
     return Compression::ZSTD;
   } else if (name == "BZ2") {
@@ -131,7 +135,7 @@ Result<std::unique_ptr<Codec>> Codec::Create(Compression::type codec_type,
       if (compression_level_set) {
         return Status::Invalid("LZ4 doesn't support setting a compression level.");
       }
-      codec = internal::MakeLz4HadoopRawCodec();
+      codec = internal::MakeLz4RawCodec();
       break;
 #else
       return Status::NotImplemented("LZ4 codec support not built");
@@ -142,6 +146,16 @@ Result<std::unique_ptr<Codec>> Codec::Create(Compression::type codec_type,
         return Status::Invalid("LZ4 doesn't support setting a compression level.");
       }
       codec = internal::MakeLz4FrameCodec();
+      break;
+#else
+      return Status::NotImplemented("LZ4 codec support not built");
+#endif
+    case Compression::LZ4_HADOOP:
+#ifdef ARROW_WITH_LZ4
+      if (compression_level_set) {
+        return Status::Invalid("LZ4 doesn't support setting a compression level.");
+      }
+      codec = internal::MakeLz4HadoopRawCodec();
       break;
 #else
       return Status::NotImplemented("LZ4 codec support not built");
@@ -194,6 +208,7 @@ bool Codec::IsAvailable(Compression::type codec_type) {
 #endif
     case Compression::LZ4:
     case Compression::LZ4_FRAME:
+    case Compression::LZ4_HADOOP:
 #ifdef ARROW_WITH_LZ4
       return true;
 #else

--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -131,7 +131,7 @@ Result<std::unique_ptr<Codec>> Codec::Create(Compression::type codec_type,
       if (compression_level_set) {
         return Status::Invalid("LZ4 doesn't support setting a compression level.");
       }
-      codec = internal::MakeLz4RawCodec();
+      codec = internal::MakeLz4HadoopRawCodec();
       break;
 #else
       return Status::NotImplemented("LZ4 codec support not built");

--- a/cpp/src/arrow/util/compression.h
+++ b/cpp/src/arrow/util/compression.h
@@ -38,9 +38,9 @@ struct Compression {
     ZSTD,
     LZ4,
     LZ4_FRAME,
-    LZ4_HADOOP,
     LZO,
-    BZ2
+    BZ2,
+    LZ4_HADOOP
   };
 
   static constexpr int kUseDefaultCompressionLevel = std::numeric_limits<int>::min();

--- a/cpp/src/arrow/util/compression.h
+++ b/cpp/src/arrow/util/compression.h
@@ -30,7 +30,18 @@ namespace arrow {
 
 struct Compression {
   /// \brief Compression algorithm
-  enum type { UNCOMPRESSED, SNAPPY, GZIP, BROTLI, ZSTD, LZ4, LZ4_FRAME, LZO, BZ2 };
+  enum type {
+    UNCOMPRESSED,
+    SNAPPY,
+    GZIP,
+    BROTLI,
+    ZSTD,
+    LZ4,
+    LZ4_FRAME,
+    LZ4_HADOOP,
+    LZO,
+    BZ2
+  };
 
   static constexpr int kUseDefaultCompressionLevel = std::numeric_limits<int>::min();
 };

--- a/cpp/src/arrow/util/compression_internal.h
+++ b/cpp/src/arrow/util/compression_internal.h
@@ -61,7 +61,7 @@ std::unique_ptr<Codec> MakeSnappyCodec();
 // Lz4 "raw" format codec.
 std::unique_ptr<Codec> MakeLz4RawCodec();
 
-// Lz4 hadoop "raw" format codec.
+// Lz4 "Hadoop" format codec (== Lz4 raw codec prefixed with lengths header)
 std::unique_ptr<Codec> MakeLz4HadoopRawCodec();
 
 // Lz4 frame format codec.

--- a/cpp/src/arrow/util/compression_internal.h
+++ b/cpp/src/arrow/util/compression_internal.h
@@ -61,6 +61,9 @@ std::unique_ptr<Codec> MakeSnappyCodec();
 // Lz4 "raw" format codec.
 std::unique_ptr<Codec> MakeLz4RawCodec();
 
+// Lz4 hadoop "raw" format codec.
+std::unique_ptr<Codec> MakeLz4HadoopRawCodec();
+
 // Lz4 frame format codec.
 std::unique_ptr<Codec> MakeLz4FrameCodec();
 

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -314,11 +314,11 @@ class Lz4Codec : public Codec {
     uint32_t expected_decompressed_size = ARROW_BYTE_SWAP32(input_as_uint32[0]);
     uint32_t compressed_size = ARROW_BYTE_SWAP32(input_as_uint32[1]);
 
-    int64_t decompressed_size = LZ4_decompress_safe(
-        reinterpret_cast<const char*>(input + data_byte_offset),
-        reinterpret_cast<char*>(output_buffer),
-        static_cast<int>(input_len - data_byte_offset),
-        static_cast<int>(output_buffer_len));
+    int64_t decompressed_size =
+        LZ4_decompress_safe(reinterpret_cast<const char*>(input + data_byte_offset),
+                            reinterpret_cast<char*>(output_buffer),
+                            static_cast<int>(input_len - data_byte_offset),
+                            static_cast<int>(output_buffer_len));
     if (decompressed_size < 0 || decompressed_size != expected_decompressed_size) {
       return Status::IOError("Corrupt Lz4 compressed data.");
     }
@@ -335,8 +335,7 @@ class Lz4Codec : public Codec {
     int64_t output_len = LZ4_compress_default(
         reinterpret_cast<const char*>(input),
         reinterpret_cast<char*>(output_buffer + data_byte_offset),
-        static_cast<int>(input_len),
-        static_cast<int>(output_buffer_len));
+        static_cast<int>(input_len), static_cast<int>(output_buffer_len));
     if (output_len > 0) {
       // Prepend decompressed size in bytes and compressed size in bytes
       // to be compatible with Hadoop Lz4Codec
@@ -364,7 +363,7 @@ class Lz4Codec : public Codec {
 
  protected:
   static const int64_t data_byte_offset = sizeof(uint32_t) * 2;
-    // Offset starting at which page data can be read/written
+  // Offset starting at which page data can be read/written
 };
 
 }  // namespace

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -359,7 +359,7 @@ class Lz4HadoopCodec : public Lz4Codec {
                              int64_t output_buffer_len, uint8_t* output_buffer) override {
     // The following variables only make sense if the parquet file being read was
     // compressed using the Hadoop Lz4Codec.
-    // 
+    //
     // We use a heuristic to determine if the parquet file being read
     // was compressed using the Hadoop Lz4Codec.
     //

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -20,13 +20,13 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
-#include "arrow/util/bit_util.h"
 
 #include <lz4.h>
 #include <lz4frame.h>
 
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 
@@ -312,7 +312,6 @@ class Lz4Codec : public Codec {
                              int64_t output_buffer_len, uint8_t* output_buffer) override {
     const uint32_t* input_as_uint32 = reinterpret_cast<const uint32_t*>(input);
     uint32_t expected_decompressed_size = ARROW_BYTE_SWAP32(input_as_uint32[0]);
-    uint32_t compressed_size = ARROW_BYTE_SWAP32(input_as_uint32[1]);
 
     int64_t decompressed_size =
         LZ4_decompress_safe(reinterpret_cast<const char*>(input + data_byte_offset),
@@ -362,8 +361,8 @@ class Lz4Codec : public Codec {
   const char* name() const override { return "lz4_raw"; }
 
  protected:
-  static const int64_t data_byte_offset = sizeof(uint32_t) * 2;
   // Offset starting at which page data can be read/written
+  static const int64_t data_byte_offset = sizeof(uint32_t) * 2;
 };
 
 }  // namespace

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -378,10 +378,12 @@ class Lz4HadoopCodec : public Lz4Codec {
           Lz4Codec::Decompress(input_len, input, output_buffer_len, output_buffer));
     } else {
       // Parquet file was likely compressed with Hadoop Lz4Codec
-      Result<int64_t> decompressed_size_result = Lz4Codec::Decompress(lz4_compressed_buffer_size, input + data_byte_offset,
+      Result<int64_t> decompressed_size_result =
+          Lz4Codec::Decompress(lz4_compressed_buffer_size, input + data_byte_offset,
                                output_buffer_len, output_buffer);
-      
-      if (!decompressed_size_result.ok() || decompressed_size_result.ValueOrDie() != expected_decompressed_size) {
+
+      if (!decompressed_size_result.ok() ||
+          decompressed_size_result.ValueOrDie() != expected_decompressed_size) {
         // Fall back on regular LZ4-block decompression
         ARROW_ASSIGN_OR_RAISE(
             decompressed_size,

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -357,16 +357,36 @@ class Lz4HadoopCodec : public Lz4Codec {
  public:
   Result<int64_t> Decompress(int64_t input_len, const uint8_t* input,
                              int64_t output_buffer_len, uint8_t* output_buffer) override {
+    // The following variables only make sense if the parquet file being read was
+    // compressed using the Hadoop Lz4Codec.
+    // 
+    // We use a heuristic to determine if the parquet file being read
+    // was compressed using the Hadoop Lz4Codec.
+    //
+    // Parquet files written with the Hadoop Lz4Codec contain at the beginning
+    // of the input buffer two uint32_t's representing (in this order) expected
+    // decompressed size in bytes and expected compressed size in bytes.
     const uint32_t* input_as_uint32 = reinterpret_cast<const uint32_t*>(input);
     uint32_t expected_decompressed_size = ARROW_BYTE_SWAP32(input_as_uint32[0]);
+    uint32_t expected_compressed_size = ARROW_BYTE_SWAP32(input_as_uint32[1]);
+    int64_t lz4_compressed_buffer_size = input_len - data_byte_offset;
 
-    ARROW_ASSIGN_OR_RAISE(
-        int64_t decompressed_size,
-        Lz4Codec::Decompress(input_len - data_byte_offset, input + data_byte_offset,
-                             output_buffer_len, output_buffer));
+    int64_t decompressed_size;
+    if (lz4_compressed_buffer_size != expected_compressed_size) {
+      // Parquet file was compressed without Hadoop Lz4Codec
+      ARROW_ASSIGN_OR_RAISE(
+          decompressed_size,
+          Lz4Codec::Decompress(input_len, input, output_buffer_len, output_buffer));
+    } else {
+      // Parquet file was compressed with Hadoop Lz4Codec
+      ARROW_ASSIGN_OR_RAISE(
+          decompressed_size,
+          Lz4Codec::Decompress(lz4_compressed_buffer_size, input + data_byte_offset,
+                               output_buffer_len, output_buffer));
 
-    if (decompressed_size != expected_decompressed_size) {
-      return Status::IOError("Corrupt Lz4 compressed data.");
+      if (decompressed_size != expected_decompressed_size) {
+        return Status::IOError("Corrupt Lz4 compressed data.");
+      }
     }
 
     return decompressed_size;

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -358,47 +358,13 @@ class Lz4HadoopCodec : public Lz4Codec {
  public:
   Result<int64_t> Decompress(int64_t input_len, const uint8_t* input,
                              int64_t output_buffer_len, uint8_t* output_buffer) override {
-    // The following variables only make sense if the parquet file being read was
-    // compressed using the Hadoop Lz4Codec.
-    //
-    // Parquet files written with the Hadoop Lz4Codec contain at the beginning
-    // of the input buffer two uint32_t's representing (in this order) expected
-    // decompressed size in bytes and expected compressed size in bytes.
-    //
-    // The Hadoop Lz4Codec source code can be found here:
-    // https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/Lz4Codec.cc
-    uint32_t expected_decompressed_size =
-        BitUtil::FromBigEndian(SafeLoadAs<uint32_t>(input));
-    uint32_t expected_compressed_size =
-        BitUtil::FromBigEndian(SafeLoadAs<uint32_t>(input + sizeof(uint32_t)));
-    int64_t lz4_compressed_buffer_size = input_len - kPrefixLength;
-
-    // We use a heuristic to determine if the parquet file being read
-    // was compressed using the Hadoop Lz4Codec.
-    int64_t decompressed_size;
-    if (lz4_compressed_buffer_size != expected_compressed_size) {
-      // Parquet file was compressed without Hadoop Lz4Codec
-      ARROW_ASSIGN_OR_RAISE(
-          decompressed_size,
-          Lz4Codec::Decompress(input_len, input, output_buffer_len, output_buffer));
-    } else {
-      // Parquet file was likely compressed with Hadoop Lz4Codec
-      Result<int64_t> decompressed_size_result =
-          Lz4Codec::Decompress(lz4_compressed_buffer_size, input + kPrefixLength,
-                               output_buffer_len, output_buffer);
-
-      if (!decompressed_size_result.ok() ||
-          decompressed_size_result.ValueOrDie() != expected_decompressed_size) {
-        // Fall back on regular LZ4-block decompression
-        ARROW_ASSIGN_OR_RAISE(
-            decompressed_size,
-            Lz4Codec::Decompress(input_len, input, output_buffer_len, output_buffer));
-      } else {
-        decompressed_size = decompressed_size_result.ValueOrDie();
-      }
+    const int64_t decompressed_size =
+        TryDecompressHadoop(input_len, input, output_buffer_len, output_buffer);
+    if (decompressed_size != kNotHadoop) {
+      return decompressed_size;
     }
-
-    return decompressed_size;
+    // Fall back on raw LZ4 codec (for files produces by earlier versions of Parquet C++)
+    return Lz4Codec::Decompress(input_len, input, output_buffer_len, output_buffer);
   }
 
   int64_t MaxCompressedLen(int64_t input_len,
@@ -439,6 +405,44 @@ class Lz4HadoopCodec : public Lz4Codec {
  protected:
   // Offset starting at which page data can be read/written
   static const int64_t kPrefixLength = sizeof(uint32_t) * 2;
+
+  static const int64_t kNotHadoop = -1;
+
+  int64_t TryDecompressHadoop(int64_t input_len, const uint8_t* input,
+                              int64_t output_buffer_len, uint8_t* output_buffer) {
+    // Parquet files written with the Hadoop Lz4Codec contain at the beginning
+    // of the input buffer two uint32_t's representing (in this order) expected
+    // decompressed size in bytes and expected compressed size in bytes.
+    //
+    // The Hadoop Lz4Codec source code can be found here:
+    // https://github.com/apache/hadoop/blob/trunk/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-nativetask/src/main/native/src/codec/Lz4Codec.cc
+    if (input_len < kPrefixLength) {
+      return kNotHadoop;
+    }
+
+    const uint32_t expected_decompressed_size =
+        BitUtil::FromBigEndian(SafeLoadAs<uint32_t>(input));
+    const uint32_t expected_compressed_size =
+        BitUtil::FromBigEndian(SafeLoadAs<uint32_t>(input + sizeof(uint32_t)));
+    const int64_t lz4_compressed_buffer_size = input_len - kPrefixLength;
+
+    // We use a heuristic to determine if the parquet file being read
+    // was compressed using the Hadoop Lz4Codec.
+    if (lz4_compressed_buffer_size == expected_compressed_size) {
+      // Parquet file was likely compressed with Hadoop Lz4Codec.
+      auto maybe_decompressed_size =
+          Lz4Codec::Decompress(lz4_compressed_buffer_size, input + kPrefixLength,
+                               output_buffer_len, output_buffer);
+
+      if (maybe_decompressed_size.ok() &&
+          *maybe_decompressed_size == expected_decompressed_size) {
+        return *maybe_decompressed_size;
+      }
+    }
+
+    // Parquet file was compressed without Hadoop Lz4Codec (or data is corrupt)
+    return kNotHadoop;
+  }
 };
 
 }  // namespace

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -221,7 +221,7 @@ class SerializedPageReader : public PageReader {
       InitDecryption();
     }
     max_page_header_size_ = kDefaultMaxPageHeaderSize;
-    decompressor_ = internal::GetReadCodec(codec);
+    decompressor_ = GetCodec(codec);
   }
 
   // Implement the PageReader interface

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -172,7 +172,7 @@ class SerializedPageWriter : public PageWriter {
     if (data_encryptor_ != nullptr || meta_encryptor_ != nullptr) {
       InitEncryption();
     }
-    compressor_ = internal::GetWriteCodec(codec, compression_level);
+    compressor_ = GetCodec(codec, compression_level);
     thrift_serializer_.reset(new ThriftSerializer);
   }
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -488,15 +488,13 @@ TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndGzipCompression) {
 
 #ifdef ARROW_WITH_LZ4
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithLz4Compression) {
-  ASSERT_THROW(this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false,
-                                              false, LARGE_SIZE),
-               ParquetException);
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, false,
+                                 LARGE_SIZE);
 }
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndLz4Compression) {
-  ASSERT_THROW(this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false,
-                                              true, LARGE_SIZE),
-               ParquetException);
+  this->TestRequiredWithSettings(Encoding::PLAIN, Compression::LZ4, false, true,
+                                 LARGE_SIZE);
 }
 #endif
 

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -251,6 +251,7 @@ TEST_F(TestPageSerde, Compression) {
 
 #ifdef ARROW_WITH_LZ4
   codec_types.push_back(Compression::LZ4);
+  codec_types.push_back(Compression::LZ4_HADOOP);
 #endif
 
 #ifdef ARROW_WITH_ZSTD
@@ -260,7 +261,7 @@ TEST_F(TestPageSerde, Compression) {
   const int32_t num_rows = 32;  // dummy value
   data_page_header_.num_values = num_rows;
 
-  int num_pages = 10;
+  const int num_pages = 10;
 
   std::vector<std::vector<uint8_t>> faux_data;
   faux_data.resize(num_pages);

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -249,8 +249,9 @@ TEST_F(TestPageSerde, Compression) {
   codec_types.push_back(Compression::GZIP);
 #endif
 
-  // TODO: Add LZ4 compression type after PARQUET-1878 is complete.
-  // Testing for deserializing LZ4 is hard without writing enabled, so it is not included.
+#ifdef ARROW_WITH_LZ4
+  codec_types.push_back(Compression::LZ4);
+#endif
 
 #ifdef ARROW_WITH_ZSTD
   codec_types.push_back(Compression::ZSTD);

--- a/cpp/src/parquet/file_serialize_test.cc
+++ b/cpp/src/parquet/file_serialize_test.cc
@@ -57,6 +57,11 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
   int rows_per_batch_;
 
   void FileSerializeTest(Compression::type codec_type) {
+    FileSerializeTest(codec_type, codec_type);
+  }
+
+  void FileSerializeTest(Compression::type codec_type,
+                         Compression::type expected_codec_type) {
     auto sink = CreateOutputStream();
     auto gnode = std::static_pointer_cast<GroupNode>(this->node_);
 
@@ -123,7 +128,8 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
       ASSERT_EQ(num_columns_, rg_reader->metadata()->num_columns());
       ASSERT_EQ(rows_per_rowgroup_, rg_reader->metadata()->num_rows());
       // Check that the specified compression was actually used.
-      ASSERT_EQ(codec_type, rg_reader->metadata()->ColumnChunk(0)->compression());
+      ASSERT_EQ(expected_codec_type,
+                rg_reader->metadata()->ColumnChunk(0)->compression());
 
       int64_t values_read;
 
@@ -309,7 +315,12 @@ TYPED_TEST(TestSerialize, SmallFileGzip) {
 
 #ifdef ARROW_WITH_LZ4
 TYPED_TEST(TestSerialize, SmallFileLz4) {
-  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::LZ4));
+  ASSERT_NO_FATAL_FAILURE(
+      this->FileSerializeTest(Compression::LZ4, Compression::LZ4_HADOOP));
+}
+
+TYPED_TEST(TestSerialize, SmallFileLz4Hadoop) {
+  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::LZ4_HADOOP));
 }
 #endif
 

--- a/cpp/src/parquet/file_serialize_test.cc
+++ b/cpp/src/parquet/file_serialize_test.cc
@@ -309,7 +309,7 @@ TYPED_TEST(TestSerialize, SmallFileGzip) {
 
 #ifdef ARROW_WITH_LZ4
 TYPED_TEST(TestSerialize, SmallFileLz4) {
-  ASSERT_THROW(this->FileSerializeTest(Compression::LZ4), ParquetException);
+  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::LZ4));
 }
 #endif
 

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -58,22 +58,18 @@ std::string nation_dict_truncated_data_page() {
   return data_file("nation.dict-malformed.parquet");
 }
 
-std::string hadoop_lz4_compressed() {
-  return data_file("hadoop_lz4_compressed.parquet");
-}
+std::string hadoop_lz4_compressed() { return data_file("hadoop_lz4_compressed.parquet"); }
 
 // TODO: Assert on definition and repetition levels
 template <typename DType, typename ValueType>
-void ASSERT_BATCH_EQUAL(std::shared_ptr<TypedColumnReader<DType>> col,
-                        int64_t batch_size,
+void ASSERT_BATCH_EQUAL(std::shared_ptr<TypedColumnReader<DType>> col, int64_t batch_size,
                         int64_t expected_levels_read,
                         std::vector<ValueType>& expected_values,
                         int64_t expected_values_read) {
   ValueType values[batch_size];
   int64_t values_read;
 
-  auto levels_read =
-    col->ReadBatch(batch_size, nullptr, nullptr, values, &values_read);
+  auto levels_read = col->ReadBatch(batch_size, nullptr, nullptr, values, &values_read);
   ASSERT_EQ(expected_levels_read, levels_read);
 
   ASSERT_EQ(expected_values, std::vector<ValueType>(values, values + batch_size));
@@ -82,7 +78,7 @@ void ASSERT_BATCH_EQUAL(std::shared_ptr<TypedColumnReader<DType>> col,
 
 TEST(TestHadoopCompatibility, Lz4Codec) {
   std::unique_ptr<ParquetFileReader> reader_ =
-    ParquetFileReader::OpenFile(hadoop_lz4_compressed());
+      ParquetFileReader::OpenFile(hadoop_lz4_compressed());
   std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
   // This file only has 4 rows
@@ -98,26 +94,21 @@ TEST(TestHadoopCompatibility, Lz4Codec) {
 
   // column 0, c0
   std::shared_ptr<Int64Reader> col0 =
-    std::dynamic_pointer_cast<Int64Reader>(group->Column(0));
-  std::vector<int64_t> expected_values =
-    {1593604800, 1593604800, 1593604801, 1593604801};
+      std::dynamic_pointer_cast<Int64Reader>(group->Column(0));
+  std::vector<int64_t> expected_values = {1593604800, 1593604800, 1593604801, 1593604801};
   ASSERT_BATCH_EQUAL(col0, 4, 4, expected_values, 4);
 
   // col1, c1
-  std::vector<ByteArray> expected_byte_arrays = {
-    ByteArray("abc"),
-    ByteArray("def"),
-    ByteArray("abc"),
-    ByteArray("def")
-  };
+  std::vector<ByteArray> expected_byte_arrays = {ByteArray("abc"), ByteArray("def"),
+                                                 ByteArray("abc"), ByteArray("def")};
   std::shared_ptr<ByteArrayReader> col1 =
-    std::dynamic_pointer_cast<ByteArrayReader>(group->Column(1));
+      std::dynamic_pointer_cast<ByteArrayReader>(group->Column(1));
   ASSERT_BATCH_EQUAL(col1, 4, 4, expected_byte_arrays, 4);
 
   // col2, v11
   std::vector<double> expected_double_values = {42.0, 7.7, 42.125, 7.7};
   std::shared_ptr<DoubleReader> col2 =
-    std::dynamic_pointer_cast<DoubleReader>(group->Column(2));
+      std::dynamic_pointer_cast<DoubleReader>(group->Column(2));
   ASSERT_BATCH_EQUAL(col2, 4, 4, expected_double_values, 4);
 }
 

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -85,15 +85,15 @@ TEST(TestHadoopCompatibility, Lz4Codec) {
     ParquetFileReader::OpenFile(hadoop_lz4_compressed());
   std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
-  // This file only has 5 rows
+  // This file only has 4 rows
   ASSERT_EQ(4, reader_->metadata()->num_rows());
   // This file only has 3 columns
   ASSERT_EQ(3, reader_->metadata()->num_columns());
   // This file only has 1 row group
   ASSERT_EQ(1, reader_->metadata()->num_row_groups());
-  // Size of the metadata is 395 bytes
+  // Size of the metadata is 376 bytes
   ASSERT_EQ(376, reader_->metadata()->size());
-  // This row group must have 5 rows
+  // This row group must have 4 rows
   ASSERT_EQ(4, group->metadata()->num_rows());
 
   // column 0, c0

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -28,6 +28,7 @@
 #include "arrow/io/file.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
+#include "arrow/util/checked_cast.h"
 
 #include "parquet/column_reader.h"
 #include "parquet/column_scanner.h"
@@ -38,8 +39,9 @@
 #include "parquet/printer.h"
 #include "parquet/test_util.h"
 
-namespace parquet {
+using arrow::internal::checked_pointer_cast;
 
+namespace parquet {
 using schema::GroupNode;
 using schema::PrimitiveNode;
 
@@ -79,56 +81,6 @@ void AssertColumnValues(std::shared_ptr<TypedColumnReader<DType>> col, int64_t b
 
   ASSERT_EQ(expected_values, values);
   ASSERT_EQ(expected_values_read, values_read);
-}
-
-struct CodecTestParam {
-  CodecTestParam(std::string data_file, uint32_t expected_metadata_size)
-      : data_file(data_file), expected_metadata_size(expected_metadata_size) {}
-
-  std::string data_file;
-  uint32_t expected_metadata_size;
-};
-
-class TestCodec : public ::testing::TestWithParam<CodecTestParam> {
- protected:
-  const std::string& GetDataFile() { return GetParam().data_file; }
-
-  uint32_t GetExpectedMetadataSize() { return GetParam().expected_metadata_size; }
-};
-
-TEST_P(TestCodec, FileMetadataAndValues) {
-  std::unique_ptr<ParquetFileReader> reader_ = ParquetFileReader::OpenFile(GetDataFile());
-  std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
-
-  // This file only has 4 rows
-  ASSERT_EQ(4, reader_->metadata()->num_rows());
-  // This file only has 3 columns
-  ASSERT_EQ(3, reader_->metadata()->num_columns());
-  // This file only has 1 row group
-  ASSERT_EQ(1, reader_->metadata()->num_row_groups());
-  // Size of the metadata is given by GetExpectedMetadataSize()
-  ASSERT_EQ(GetExpectedMetadataSize(), reader_->metadata()->size());
-  // This row group must have 4 rows
-  ASSERT_EQ(4, group->metadata()->num_rows());
-
-  // column 0, c0
-  std::shared_ptr<Int64Reader> col0 =
-      std::dynamic_pointer_cast<Int64Reader>(group->Column(0));
-  std::vector<int64_t> expected_values = {1593604800, 1593604800, 1593604801, 1593604801};
-  AssertColumnValues(col0, 4, 4, expected_values, 4);
-
-  // column 1, c1
-  std::vector<ByteArray> expected_byte_arrays = {ByteArray("abc"), ByteArray("def"),
-                                                 ByteArray("abc"), ByteArray("def")};
-  std::shared_ptr<ByteArrayReader> col1 =
-      std::dynamic_pointer_cast<ByteArrayReader>(group->Column(1));
-  AssertColumnValues(col1, 4, 4, expected_byte_arrays, 4);
-
-  // column 2, v11
-  std::vector<double> expected_double_values = {42.0, 7.7, 42.125, 7.7};
-  std::shared_ptr<DoubleReader> col2 =
-      std::dynamic_pointer_cast<DoubleReader>(group->Column(2));
-  AssertColumnValues(col2, 4, 4, expected_double_values, 4);
 }
 
 class TestAllTypesPlain : public ::testing::Test {
@@ -558,6 +510,53 @@ TEST(TestFileReader, BufferedReads) {
     ASSERT_TRUE(
         scratch_space[col_index]->Equals(*column_data[col_index]->data()->buffers[1]));
   }
+}
+
+struct CodecTestParam {
+  CodecTestParam(std::string data_file, uint32_t expected_metadata_size)
+      : data_file(data_file), expected_metadata_size(expected_metadata_size) {}
+
+  std::string data_file;
+  uint32_t expected_metadata_size;
+};
+
+class TestCodec : public ::testing::TestWithParam<CodecTestParam> {
+ protected:
+  const std::string& GetDataFile() { return GetParam().data_file; }
+
+  uint32_t GetExpectedMetadataSize() { return GetParam().expected_metadata_size; }
+};
+
+TEST_P(TestCodec, FileMetadataAndValues) {
+  std::unique_ptr<ParquetFileReader> reader_ = ParquetFileReader::OpenFile(GetDataFile());
+  std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
+
+  // This file only has 4 rows
+  ASSERT_EQ(4, reader_->metadata()->num_rows());
+  // This file only has 3 columns
+  ASSERT_EQ(3, reader_->metadata()->num_columns());
+  // This file only has 1 row group
+  ASSERT_EQ(1, reader_->metadata()->num_row_groups());
+  // Size of the metadata is given by GetExpectedMetadataSize()
+  ASSERT_EQ(GetExpectedMetadataSize(), reader_->metadata()->size());
+  // This row group must have 4 rows
+  ASSERT_EQ(4, group->metadata()->num_rows());
+
+  // column 0, c0
+  auto col0 = checked_pointer_cast<Int64Reader>(group->Column(0));
+  std::vector<int64_t> expected_values = {1593604800, 1593604800, 1593604801, 1593604801};
+  AssertColumnValues(col0, 4, 4, expected_values, 4);
+
+  // column 1, c1
+  std::vector<ByteArray> expected_byte_arrays = {ByteArray("abc"), ByteArray("def"),
+                                                 ByteArray("abc"), ByteArray("def")};
+  auto col1 = checked_pointer_cast<ByteArrayReader>(group->Column(1));
+  AssertColumnValues(col1, 4, 4, expected_byte_arrays, 4);
+
+  // column 2, v11
+  std::vector<double> expected_double_values = {42.0, 7.7, 42.125, 7.7};
+  auto col2 = checked_pointer_cast<DoubleReader>(group->Column(2));
+  AssertColumnValues(col2, 4, 4, expected_double_values, 4);
 }
 
 #ifdef ARROW_WITH_LZ4

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -66,13 +66,13 @@ void ASSERT_BATCH_EQUAL(std::shared_ptr<TypedColumnReader<DType>> col, int64_t b
                         int64_t expected_levels_read,
                         std::vector<ValueType>& expected_values,
                         int64_t expected_values_read) {
-  ValueType values[batch_size];
+  std::vector<ValueType> values(batch_size);
   int64_t values_read;
 
-  auto levels_read = col->ReadBatch(batch_size, nullptr, nullptr, values, &values_read);
+  auto levels_read = col->ReadBatch(batch_size, nullptr, nullptr, values.data(), &values_read);
   ASSERT_EQ(expected_levels_read, levels_read);
 
-  ASSERT_EQ(expected_values, std::vector<ValueType>(values, values + batch_size));
+  ASSERT_EQ(expected_values, values);
   ASSERT_EQ(expected_values_read, values_read);
 }
 

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -69,7 +69,8 @@ void ASSERT_BATCH_EQUAL(std::shared_ptr<TypedColumnReader<DType>> col, int64_t b
   std::vector<ValueType> values(batch_size);
   int64_t values_read;
 
-  auto levels_read = col->ReadBatch(batch_size, nullptr, nullptr, values.data(), &values_read);
+  auto levels_read =
+      col->ReadBatch(batch_size, nullptr, nullptr, values.data(), &values_read);
   ASSERT_EQ(expected_levels_read, levels_read);
 
   ASSERT_EQ(expected_values, values);

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -62,7 +62,7 @@ std::string hadoop_lz4_compressed() { return data_file("hadoop_lz4_compressed.pa
 
 // TODO: Assert on definition and repetition levels
 template <typename DType, typename ValueType>
-void ASSERT_BATCH_EQUAL(std::shared_ptr<TypedColumnReader<DType>> col, int64_t batch_size,
+void AssertColumnValues(std::shared_ptr<TypedColumnReader<DType>> col, int64_t batch_size,
                         int64_t expected_levels_read,
                         std::vector<ValueType>& expected_values,
                         int64_t expected_values_read) {
@@ -98,20 +98,20 @@ TEST(TestHadoopCompatibility, Lz4Codec) {
   std::shared_ptr<Int64Reader> col0 =
       std::dynamic_pointer_cast<Int64Reader>(group->Column(0));
   std::vector<int64_t> expected_values = {1593604800, 1593604800, 1593604801, 1593604801};
-  ASSERT_BATCH_EQUAL(col0, 4, 4, expected_values, 4);
+  AssertColumnValues(col0, 4, 4, expected_values, 4);
 
   // column 1, c1
   std::vector<ByteArray> expected_byte_arrays = {ByteArray("abc"), ByteArray("def"),
                                                  ByteArray("abc"), ByteArray("def")};
   std::shared_ptr<ByteArrayReader> col1 =
       std::dynamic_pointer_cast<ByteArrayReader>(group->Column(1));
-  ASSERT_BATCH_EQUAL(col1, 4, 4, expected_byte_arrays, 4);
+  AssertColumnValues(col1, 4, 4, expected_byte_arrays, 4);
 
   // column 2, v11
   std::vector<double> expected_double_values = {42.0, 7.7, 42.125, 7.7};
   std::shared_ptr<DoubleReader> col2 =
       std::dynamic_pointer_cast<DoubleReader>(group->Column(2));
-  ASSERT_BATCH_EQUAL(col2, 4, 4, expected_double_values, 4);
+  AssertColumnValues(col2, 4, 4, expected_double_values, 4);
 }
 #endif
 

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -90,15 +90,14 @@ struct CodecTestParam {
 };
 
 class TestCodec : public ::testing::TestWithParam<CodecTestParam> {
-  protected:
-    const std::string& GetDataFile() { return GetParam().data_file; }
+ protected:
+  const std::string& GetDataFile() { return GetParam().data_file; }
 
-    uint32_t GetExpectedMetadataSize() { return GetParam().expected_metadata_size; }
+  uint32_t GetExpectedMetadataSize() { return GetParam().expected_metadata_size; }
 };
 
 TEST_P(TestCodec, FileMetadataAndValues) {
-  std::unique_ptr<ParquetFileReader> reader_ =
-      ParquetFileReader::OpenFile(GetDataFile());
+  std::unique_ptr<ParquetFileReader> reader_ = ParquetFileReader::OpenFile(GetDataFile());
   std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
 
   // This file only has 4 rows

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -76,6 +76,7 @@ void ASSERT_BATCH_EQUAL(std::shared_ptr<TypedColumnReader<DType>> col, int64_t b
   ASSERT_EQ(expected_values_read, values_read);
 }
 
+#ifdef ARROW_WITH_LZ4
 TEST(TestHadoopCompatibility, Lz4Codec) {
   std::unique_ptr<ParquetFileReader> reader_ =
       ParquetFileReader::OpenFile(hadoop_lz4_compressed());
@@ -111,6 +112,7 @@ TEST(TestHadoopCompatibility, Lz4Codec) {
       std::dynamic_pointer_cast<DoubleReader>(group->Column(2));
   ASSERT_BATCH_EQUAL(col2, 4, 4, expected_double_values, 4);
 }
+#endif
 
 class TestAllTypesPlain : public ::testing::Test {
  public:

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -58,6 +58,69 @@ std::string nation_dict_truncated_data_page() {
   return data_file("nation.dict-malformed.parquet");
 }
 
+std::string hadoop_lz4_compressed() {
+  return data_file("hadoop_lz4_compressed.parquet");
+}
+
+// TODO: Assert on definition and repetition levels
+template <typename DType, typename ValueType>
+void ASSERT_BATCH_EQUAL(std::shared_ptr<TypedColumnReader<DType>> col,
+                        int64_t batch_size,
+                        int64_t expected_levels_read,
+                        std::vector<ValueType>& expected_values,
+                        int64_t expected_values_read) {
+  ValueType values[batch_size];
+  int64_t values_read;
+
+  auto levels_read =
+    col->ReadBatch(batch_size, nullptr, nullptr, values, &values_read);
+  ASSERT_EQ(expected_levels_read, levels_read);
+
+  ASSERT_EQ(expected_values, std::vector<ValueType>(values, values + batch_size));
+  ASSERT_EQ(expected_values_read, values_read);
+}
+
+TEST(TestHadoopCompatibility, Lz4Codec) {
+  std::unique_ptr<ParquetFileReader> reader_ =
+    ParquetFileReader::OpenFile(hadoop_lz4_compressed());
+  std::shared_ptr<RowGroupReader> group = reader_->RowGroup(0);
+
+  // This file only has 5 rows
+  ASSERT_EQ(4, reader_->metadata()->num_rows());
+  // This file only has 3 columns
+  ASSERT_EQ(3, reader_->metadata()->num_columns());
+  // This file only has 1 row group
+  ASSERT_EQ(1, reader_->metadata()->num_row_groups());
+  // Size of the metadata is 395 bytes
+  ASSERT_EQ(376, reader_->metadata()->size());
+  // This row group must have 5 rows
+  ASSERT_EQ(4, group->metadata()->num_rows());
+
+  // column 0, c0
+  std::shared_ptr<Int64Reader> col0 =
+    std::dynamic_pointer_cast<Int64Reader>(group->Column(0));
+  std::vector<int64_t> expected_values =
+    {1593604800, 1593604800, 1593604801, 1593604801};
+  ASSERT_BATCH_EQUAL(col0, 4, 4, expected_values, 4);
+
+  // col1, c1
+  std::vector<ByteArray> expected_byte_arrays = {
+    ByteArray("abc"),
+    ByteArray("def"),
+    ByteArray("abc"),
+    ByteArray("def")
+  };
+  std::shared_ptr<ByteArrayReader> col1 =
+    std::dynamic_pointer_cast<ByteArrayReader>(group->Column(1));
+  ASSERT_BATCH_EQUAL(col1, 4, 4, expected_byte_arrays, 4);
+
+  // col2, v11
+  std::vector<double> expected_double_values = {42.0, 7.7, 42.125, 7.7};
+  std::shared_ptr<DoubleReader> col2 =
+    std::dynamic_pointer_cast<DoubleReader>(group->Column(2));
+  ASSERT_BATCH_EQUAL(col2, 4, 4, expected_double_values, 4);
+}
+
 class TestAllTypesPlain : public ::testing::Test {
  public:
   void SetUp() { reader_ = ParquetFileReader::OpenFile(alltypes_plain()); }

--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -98,14 +98,14 @@ TEST(TestHadoopCompatibility, Lz4Codec) {
   std::vector<int64_t> expected_values = {1593604800, 1593604800, 1593604801, 1593604801};
   ASSERT_BATCH_EQUAL(col0, 4, 4, expected_values, 4);
 
-  // col1, c1
+  // column 1, c1
   std::vector<ByteArray> expected_byte_arrays = {ByteArray("abc"), ByteArray("def"),
                                                  ByteArray("abc"), ByteArray("def")};
   std::shared_ptr<ByteArrayReader> col1 =
       std::dynamic_pointer_cast<ByteArrayReader>(group->Column(1));
   ASSERT_BATCH_EQUAL(col1, 4, 4, expected_byte_arrays, 4);
 
-  // col2, v11
+  // column 2, v11
   std::vector<double> expected_double_values = {42.0, 7.7, 42.125, 7.7};
   std::shared_ptr<DoubleReader> col2 =
       std::dynamic_pointer_cast<DoubleReader>(group->Column(2));

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -101,6 +101,7 @@ static inline Compression::type FromThriftUnsafe(format::CompressionCodec::type 
     case format::CompressionCodec::BROTLI:
       return Compression::BROTLI;
     case format::CompressionCodec::LZ4:
+      // ARROW-9424: Existing files use LZ4_RAW but this may need to change
       return Compression::LZ4;
     case format::CompressionCodec::ZSTD:
       return Compression::ZSTD;

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -101,8 +101,7 @@ static inline Compression::type FromThriftUnsafe(format::CompressionCodec::type 
     case format::CompressionCodec::BROTLI:
       return Compression::BROTLI;
     case format::CompressionCodec::LZ4:
-      // ARROW-9424: Existing files use LZ4_RAW but this may need to change
-      return Compression::LZ4;
+      return Compression::LZ4_HADOOP;
     case format::CompressionCodec::ZSTD:
       return Compression::ZSTD;
     default:
@@ -280,7 +279,9 @@ static inline format::CompressionCodec::type ToThrift(Compression::type type) {
       return format::CompressionCodec::LZO;
     case Compression::BROTLI:
       return format::CompressionCodec::BROTLI;
+    // For compatibility with existing source code
     case Compression::LZ4:
+    case Compression::LZ4_HADOOP:
       return format::CompressionCodec::LZ4;
     case Compression::ZSTD:
       return format::CompressionCodec::ZSTD;

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -101,7 +101,6 @@ static inline Compression::type FromThriftUnsafe(format::CompressionCodec::type 
     case format::CompressionCodec::BROTLI:
       return Compression::BROTLI;
     case format::CompressionCodec::LZ4:
-      // ARROW-9424: Existing files use LZ4_RAW but this may need to change
       return Compression::LZ4;
     case format::CompressionCodec::ZSTD:
       return Compression::ZSTD;

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -30,7 +30,7 @@
 
 #include "generated/parquet_types.h"
 
-using ::arrow::internal::checked_cast;
+using arrow::internal::checked_cast;
 using arrow::util::Codec;
 
 namespace parquet {
@@ -43,6 +43,7 @@ bool IsCodecSupported(Compression::type codec) {
     case Compression::BROTLI:
     case Compression::ZSTD:
     case Compression::LZ4:
+    case Compression::LZ4_HADOOP:
       return true;
     default:
       return false;
@@ -60,6 +61,11 @@ std::unique_ptr<Codec> GetCodec(Compression::type codec, int compression_level) 
     ss << "Codec type " << Codec::GetCodecAsString(codec)
        << " not supported in Parquet format";
     throw ParquetException(ss.str());
+  }
+
+  if (codec == Compression::LZ4) {
+    // For compatibility with existing source code
+    codec = Compression::LZ4_HADOOP;
   }
 
   PARQUET_ASSIGN_OR_THROW(result, Codec::Create(codec, compression_level));

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -49,19 +49,12 @@ bool IsCodecSupported(Compression::type codec) {
   }
 }
 
-namespace internal {
+std::unique_ptr<Codec> GetCodec(Compression::type codec) {
+  return GetCodec(codec, Codec::UseDefaultCompressionLevel());
+}
 
-std::unique_ptr<Codec> GetCodec(Compression::type codec, int compression_level,
-                                bool for_writing) {
+std::unique_ptr<Codec> GetCodec(Compression::type codec, int compression_level) {
   std::unique_ptr<Codec> result;
-  if (for_writing && (codec == Compression::LZ4 || codec == Compression::LZ4_FRAME)) {
-    throw ParquetException(
-        "Per ARROW-9424, writing files with LZ4 compression has been "
-        "disabled until implementation issues have been resolved. "
-        "It is recommended to read any existing files and rewrite them "
-        "using a different compression.");
-  }
-
   if (!IsCodecSupported(codec)) {
     std::stringstream ss;
     ss << "Codec type " << Codec::GetCodecAsString(codec)
@@ -71,24 +64,6 @@ std::unique_ptr<Codec> GetCodec(Compression::type codec, int compression_level,
 
   PARQUET_ASSIGN_OR_THROW(result, Codec::Create(codec, compression_level));
   return result;
-}
-
-std::unique_ptr<Codec> GetReadCodec(Compression::type codec) {
-  return GetCodec(codec, Codec::UseDefaultCompressionLevel(), /*for_writing=*/false);
-}
-
-std::unique_ptr<Codec> GetWriteCodec(Compression::type codec, int compression_level) {
-  return GetCodec(codec, compression_level, /*for_writing=*/true);
-}
-
-}  // namespace internal
-
-std::unique_ptr<Codec> GetCodec(Compression::type codec, int compression_level) {
-  return internal::GetCodec(codec, compression_level, /*for_writing=*/false);
-}
-
-std::unique_ptr<Codec> GetCodec(Compression::type codec) {
-  return GetCodec(codec, Codec::UseDefaultCompressionLevel());
 }
 
 std::string FormatStatValue(Type::type parquet_type, ::arrow::util::string_view val) {

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -464,15 +464,6 @@ struct Encoding {
 PARQUET_EXPORT
 bool IsCodecSupported(Compression::type codec);
 
-namespace internal {
-
-// ARROW-9424: Separate functions for reading and writing so we can disable LZ4
-// on writing
-std::unique_ptr<Codec> GetReadCodec(Compression::type codec);
-std::unique_ptr<Codec> GetWriteCodec(Compression::type codec, int compression_level);
-
-}  // namespace internal
-
 PARQUET_EXPORT
 std::unique_ptr<Codec> GetCodec(Compression::type codec);
 

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -718,10 +718,6 @@ def test_pandas_parquet_pyfile_roundtrip(tempdir, use_legacy_dataset):
     tm.assert_frame_equal(df, df_read)
 
 
-# ARROW-9424: LZ4 support is currently disabled
-SUPPORTED_COMPRESSIONS = ['NONE', 'SNAPPY', 'GZIP', 'ZSTD']
-
-
 @pytest.mark.pandas
 @parametrize_legacy_dataset
 def test_pandas_parquet_configuration_options(tempdir, use_legacy_dataset):
@@ -759,7 +755,7 @@ def test_pandas_parquet_configuration_options(tempdir, use_legacy_dataset):
         df_read = table_read.to_pandas()
         tm.assert_frame_equal(df, df_read)
 
-    for compression in SUPPORTED_COMPRESSIONS:
+    for compression in ['NONE', 'SNAPPY', 'GZIP', 'LZ4', 'ZSTD']:
         if (compression != 'NONE' and
                 not pa.lib.Codec.is_available(compression)):
             continue
@@ -769,13 +765,6 @@ def test_pandas_parquet_configuration_options(tempdir, use_legacy_dataset):
             filename, use_legacy_dataset=use_legacy_dataset)
         df_read = table_read.to_pandas()
         tm.assert_frame_equal(df, df_read)
-
-
-# ARROW-9424: LZ4 support is currently disabled
-def test_lz4_compression_disabled():
-    table = pa.table([pa.array([1, 2, 3, 4, 5])], names=['f0'])
-    with pytest.raises(IOError):
-        pq.write_table(table, pa.BufferOutputStream(), compression='lz4')
 
 
 def make_sample_file(table_or_df):
@@ -859,9 +848,8 @@ def test_compression_level(use_legacy_dataset):
     # level.
     # GZIP (zlib) allows for specifying a compression level but as of up
     # to version 1.2.11 the valid range is [-1, 9].
-    invalid_combinations = [("snappy", 4), ("gzip", -1337),
+    invalid_combinations = [("snappy", 4), ("lz4", 5), ("gzip", -1337),
                             ("None", 444), ("lzo", 14)]
-    # ARROW-9424: lz4 is disabled for now ("lz4", 5),
     buf = io.BytesIO()
     for (codec, level) in invalid_combinations:
         with pytest.raises((ValueError, OSError)):


### PR DESCRIPTION
This patch makes arrow's Lz4Codec compatible with the Hadoop Lz4Codec by prepending 8 bytes (two `uint32_t`s representing expected decompressed size in bytes and compressed size in bytes) to arrow's lz4 decompression/compression.