### PR TITLE
ARROW-9511: [Packaging][Release] Set conda packages' build number to 0

### DIFF
--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = ARROW_VERSION %}
-{% set number = "6" %}
+{% set number = "0" %}
 {% set cuda_enabled = cuda_compiler_version is not undefined and cuda_compiler_version == '9.2' %}
 {% set build_ext_version = "1.0.0" %}
 {% set build_ext = "cuda" if cuda_enabled else "cpu" %}


### PR DESCRIPTION
The artifacts patterns in the crossbow tasks definitions expect conda packages with build number 0. We should keep the build number always zero in the vendored conda-forge recipes.