### PR TITLE
ARROW-9509: [Release] Don't test Gandiva in the windows wheel verification script

### DIFF
--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -85,7 +85,6 @@ if "%PY_VERSION%"=="3.5" GOTO done
 :python36_and_higher_checks
 
 python -c "import pyarrow.flight" || EXIT /B 1
-python -c "import pyarrow.gandiva" || EXIT /B 1
 python -c "import pyarrow.dataset" || EXIT /B 1
 
 :done


### PR DESCRIPTION
Since gandiva is no longer included.

The passed build is available in the release verification PR where I applied this patch.

See https://github.com/apache/arrow/pull/7787#issuecomment-659993670