### PR TITLE
ARROW-9512: [C++] Avoid variadic template unpack inside lambda to work around gcc 4.8 bug

### DIFF
--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -106,13 +106,6 @@ void AssertTsSame(const T& expected, const T& actual, CompareFunctor&& compare) 
   }
 }
 
-template <typename T, typename... ExtraArgs>
-void AssertTsEqual(const T& expected, const T& actual, ExtraArgs... args) {
-  return AssertTsSame(expected, actual, [&](const T& expected, const T& actual) {
-    return expected.Equals(actual, args...);
-  });
-}
-
 template <typename T>
 void AssertTsApproxEqual(const T& expected, const T& actual) {
   return AssertTsSame(expected, actual, [](const T& expected, const T& actual) {
@@ -175,11 +168,17 @@ void AssertScalarsEqual(const Scalar& expected, const Scalar& actual, bool verbo
 
 void AssertBatchesEqual(const RecordBatch& expected, const RecordBatch& actual,
                         bool check_metadata) {
-  AssertTsEqual(expected, actual, check_metadata);
+  AssertTsSame(expected, actual,
+               [&](const RecordBatch& expected, const RecordBatch& actual) {
+                 return expected.Equals(actual, check_metadata);
+               });
 }
 
 void AssertBatchesApproxEqual(const RecordBatch& expected, const RecordBatch& actual) {
-  AssertTsApproxEqual(expected, actual);
+  AssertTsSame(expected, actual,
+               [&](const RecordBatch& expected, const RecordBatch& actual) {
+                 return expected.ApproxEquals(actual);
+               });
 }
 
 void AssertChunkedEqual(const ChunkedArray& expected, const ChunkedArray& actual) {

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -106,13 +106,6 @@ void AssertTsSame(const T& expected, const T& actual, CompareFunctor&& compare) 
   }
 }
 
-template <typename T>
-void AssertTsApproxEqual(const T& expected, const T& actual) {
-  return AssertTsSame(expected, actual, [](const T& expected, const T& actual) {
-    return expected.ApproxEquals(actual);
-  });
-}
-
 template <typename CompareFunctor>
 void AssertArraysEqualWith(const Array& expected, const Array& actual, bool verbose,
                            CompareFunctor&& compare) {


### PR DESCRIPTION
This works around a gcc bug. This only affects compilation of unit tests on gcc 4.8 so not an issue for the 1.0.0 RC1

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47226