### PR TITLE
ARROW-7136: [Rust] Added caching to the docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -48,3 +48,10 @@
 !ruby/red-plasma/Gemfile
 !ruby/red-plasma/lib/plasma/version.rb
 !ruby/red-plasma/red-plasma.gemspec
+!rust/arrow/Cargo.toml
+!rust/arrow/benches
+!rust/arrow-flight/Cargo.toml
+!rust/parquet/Cargo.toml
+!rust/parquet/build.rs
+!rust/datafusion/Cargo.toml
+!rust/datafusion/benches

--- a/.dockerignore
+++ b/.dockerignore
@@ -48,6 +48,8 @@
 !ruby/red-plasma/Gemfile
 !ruby/red-plasma/lib/plasma/version.rb
 !ruby/red-plasma/red-plasma.gemspec
+!rust/Cargo.toml
+!rust/benchmarks/Cargo.toml
 !rust/arrow/Cargo.toml
 !rust/arrow/benches
 !rust/arrow-flight/Cargo.toml
@@ -55,3 +57,4 @@
 !rust/parquet/build.rs
 !rust/datafusion/Cargo.toml
 !rust/datafusion/benches
+!rust/integration-testing/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,7 @@ env:
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
+
   debian:
     name: AMD64 Debian 10 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,6 +64,12 @@ jobs:
       - name: Free Up Disk Space
         shell: bash
         run: ci/scripts/util_cleanup.sh
+      - name: Cache Docker Volumes
+        uses: actions/cache@v1
+        with:
+          path: .docker
+          key: debian-rust-${{ hashFiles('rust/**') }}
+          restore-keys: debian-rust-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -151,15 +151,15 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
-      - name: Run Clippy
-        shell: bash
-        run: ci/scripts/rust_lint.sh $(pwd)
       - name: Cache Build Artifacts
         uses: actions/cache@v1
         with:
           path: rust/target
-          key: macos-rust-${{ hashFiles('rust/**.rs') }}
+          key: macos-10-rust-${{ hashFiles('rust/**.rs') }}
           restore-keys: macos-rust-
+      - name: Run Clippy
+        shell: bash
+        run: ci/scripts/rust_lint.sh $(pwd)
       - name: Build
         shell: bash
         run: ci/scripts/rust_build.sh $(pwd) $(pwd)/build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .docker
-          key: debian-rust-${{ hashFiles('rust/**') }}
+          key: debian-rust-${{ hashFiles('rust/**.rs') }}
           restore-keys: debian-rust-
       - name: Setup Python
         uses: actions/setup-python@v1
@@ -116,7 +116,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: rust/target
-          key: windows-rust-${{ hashFiles('rust/**') }}
+          key: windows-rust-${{ hashFiles('rust/**.rs') }}
           restore-keys: windows-rust-
       - name: Build
         shell: bash
@@ -154,7 +154,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: rust/target
-          key: macos-rust-${{ hashFiles('rust/**') }}
+          key: macos-rust-${{ hashFiles('rust/**.rs') }}
           restore-keys: macos-rust-
       - name: Run Clippy
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,18 +51,22 @@ jobs:
       matrix:
         variant:
           - no-cache
-          - cached
-          - volume-cached
+          - download-cache
+          - download-build-cache
+          - download-build-cache-volume
         include:
           - variant: no-cache
-            command: docker-compose run --rm -e CARGO_TARGET_DIR=/tmp/rust debian-rust
+            command: docker-compose run --rm -e CARGO_HOME=/tmp/cargo -e CARGO_TARGET_DIR=/tmp/target debian-rust
             name: No Cache
-          - variant: cached
-            command: docker-compose run --rm -e CARGO_TARGET_DIR=/rust/dummy-build debian-rust
-            name: Use dependency cache within the image
-          - variant: volume-cached
-            command: docker-compose run --rm debian-rust
-            name: Use dependency cache from a mounted volume
+          - variant: download-cache
+            command: docker-compose run --rm -e CARGO_HOME=/rust/cargo -e CARGO_TARGET_DIR=/tmp/target debian-rust
+            name: Download Cache
+          - variant: download-build-cache
+            command: docker-compose run --rm -e CARGO_HOME=/rust/cargo -e CARGO_TARGET_DIR=/rust/target debian-rust
+            name: Download and Build Cache
+          - variant: download-build-cache-volume
+            command: docker-compose run --rm -e CARGO_HOME=/rust/cargo -e CARGO_TARGET_DIR=/build/rust debian-rust
+            name: Download and Build Cache on a Volume
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,8 @@ jobs:
           sudo sysctl -w kernel.core_pattern="core.%e.%p"
           ulimit -c unlimited
           archery docker run debian-rust
+      - name: Fix Cache Permissions
+        run: sudo chmod -R o+r .docker
       - name: Docker Push
         if: success() && github.event_name == 'push' && github.repository == 'apache/arrow'
         continue-on-error: true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,44 @@ env:
 
 jobs:
 
+  bench:
+    name: Rust - ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - no-cache
+          - cached
+          - volume-cached
+        include:
+          - variant: no-cache
+            command: docker-compose run --rm -e CARGO_TARGET_DIR=/tmp/rust debian-rust
+            name: No Cache
+          - variant: cached
+            command: docker-compose run --rm -e CARGO_TARGET_DIR=/rust/dummy-build debian-rust
+            name: Use dependency cache within the image
+          - variant: volume-cached
+            command: docker-compose run --rm debian-rust
+            name: Use dependency cache from a mounted volume
+    steps:
+      - name: Checkout Arrow
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch Submodules and Tags
+        shell: bash
+        run: ci/scripts/util_checkout.sh
+      - name: Free Up Disk Space
+        shell: bash
+        run: ci/scripts/util_cleanup.sh
+      - name: Build
+        shell: bash
+        run: docker-compose build debian-rust
+      - name: Run
+        shell: bash
+        run: time ${{ matrix.command }}
+
   debian:
     name: AMD64 Debian 10 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           path: rust/target
           key: macos-10-rust-${{ hashFiles('rust/**.rs') }}
-          restore-keys: macos-rust-
+          restore-keys: macos-10-rust-
       - name: Run Clippy
         shell: bash
         run: ci/scripts/rust_lint.sh $(pwd)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,48 +43,6 @@ env:
 
 jobs:
 
-  bench:
-    name: Rust - ${{ matrix.name }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        variant:
-          - no-cache
-          - download-cache
-          - download-build-cache
-          - download-build-cache-volume
-        include:
-          - variant: no-cache
-            command: docker-compose run --rm -e CARGO_HOME=/tmp/cargo -e CARGO_TARGET_DIR=/tmp/target debian-rust
-            name: No Cache
-          - variant: download-cache
-            command: docker-compose run --rm -e CARGO_HOME=/rust/cargo -e CARGO_TARGET_DIR=/tmp/target debian-rust
-            name: Download Cache
-          - variant: download-build-cache
-            command: docker-compose run --rm -e CARGO_HOME=/rust/cargo -e CARGO_TARGET_DIR=/rust/target debian-rust
-            name: Download and Build Cache
-          - variant: download-build-cache-volume
-            command: docker-compose run --rm -e CARGO_HOME=/rust/cargo -e CARGO_TARGET_DIR=/build/rust debian-rust
-            name: Download and Build Cache on a Volume
-    steps:
-      - name: Checkout Arrow
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Fetch Submodules and Tags
-        shell: bash
-        run: ci/scripts/util_checkout.sh
-      - name: Free Up Disk Space
-        shell: bash
-        run: ci/scripts/util_cleanup.sh
-      - name: Build
-        shell: bash
-        run: docker-compose build debian-rust
-      - name: Run
-        shell: bash
-        run: time ${{ matrix.command }}
-
   debian:
     name: AMD64 Debian 10 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -112,6 +112,12 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Cache Build Artifacts
+        uses: actions/cache@v1
+        with:
+          path: rust/target
+          key: windows-rust-${{ hashFiles('rust/**') }}
+          restore-keys: windows-rust-
       - name: Build
         shell: bash
         run: ci/scripts/rust_build.sh $(pwd) $(pwd)/build
@@ -144,6 +150,12 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Cache Build Artifacts
+        uses: actions/cache@v1
+        with:
+          path: rust/target
+          key: macos-rust-${{ hashFiles('rust/**') }}
+          restore-keys: macos-rust-
       - name: Run Clippy
         shell: bash
         run: ci/scripts/rust_lint.sh $(pwd)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,7 +42,6 @@ env:
   ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
 jobs:
-
   debian:
     name: AMD64 Debian 10 Rust ${{ matrix.rust }}
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,8 +67,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .docker
-          key: debian-rust-${{ hashFiles('rust/**.rs') }}
-          restore-keys: debian-rust-
+          key: debian-10-rust-${{ hashFiles('rust/**.rs') }}
+          restore-keys: debian-10-rust-
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
@@ -151,15 +151,15 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
+      - name: Run Clippy
+        shell: bash
+        run: ci/scripts/rust_lint.sh $(pwd)
       - name: Cache Build Artifacts
         uses: actions/cache@v1
         with:
           path: rust/target
           key: macos-rust-${{ hashFiles('rust/**.rs') }}
           restore-keys: macos-rust-
-      - name: Run Clippy
-        shell: bash
-        run: ci/scripts/rust_lint.sh $(pwd)
       - name: Build
         shell: bash
         run: ci/scripts/rust_build.sh $(pwd) $(pwd)/build

--- a/ci/docker/debian-10-rust.dockerfile
+++ b/ci/docker/debian-10-rust.dockerfile
@@ -33,13 +33,51 @@ RUN wget -q -O - https://github.com/google/flatbuffers/archive/v${flatbuffers}.t
     cd / && \
     rm -rf flatbuffers-${flatbuffers}
 
-# sadly cargo doesn't have a command to fetch and build the
-# dependencies without building the library itself
 ARG rust=nightly-2020-04-22
-RUN rustup default ${rust}
-RUN rustup component add rustfmt --toolchain ${rust}-x86_64-unknown-linux-gnu
 
-# TODO(kszucs):
-# 1. add the files required to install the dependencies to .dockerignore
-# 2. copy these files to their appropriate path
-# 3. download and compile the dependencies
+# freeze the version for deterministic builds
+RUN rustup default ${rust} && \
+    rustup component add rustfmt --toolchain ${rust}-x86_64-unknown-linux-gnu
+
+# Compile a dummy program, so that the dependencies are compiled and cached on a layer
+# see https://stackoverflow.com/a/58474618/931303 for details
+# We do not compile any of the workspace or we defeat the purpose of caching - we only
+# compile their external dependencies.
+
+# The artifact of the steps below is a "/target" containing compiled dependencies
+# Uses the directory /dependency_build for temporary files
+
+# arrow-flight
+COPY rust/arrow-flight/Cargo.toml /dependency_build/arrow-flight/Cargo.toml
+## Create the directory and place an empty lib.rs (required for steps below)
+RUN mkdir -p /dependency_build/arrow-flight/src && touch dependency_build/arrow-flight/src/lib.rs
+
+# arrow
+COPY rust/arrow/Cargo.toml /dependency_build/arrow/Cargo.toml
+## this is unfortunately necessary as cargo checks that the benches exist
+COPY rust/arrow/benches /dependency_build/arrow/benches
+RUN mkdir -p /dependency_build/arrow/src && touch /dependency_build/arrow/src/lib.rs
+
+# parquet
+COPY rust/parquet/Cargo.toml /dependency_build/parquet/Cargo.toml
+COPY rust/parquet/build.rs /dependency_build/parquet/build.rs
+RUN mkdir -p /dependency_build/parquet/src && touch /dependency_build/parquet/src/lib.rs
+
+# datafusion
+COPY rust/datafusion/Cargo.toml /dependency_build/datafusion/Cargo.toml
+COPY rust/datafusion/benches /dependency_build/datafusion/benches
+RUN mkdir -p /dependency_build/datafusion/src && touch /dependency_build/datafusion/src/lib.rs
+
+# we can add more workspaces here if they justify the burden vs compile time.
+
+# set configurations valid across builds.
+# Changing them requires re-building dependencies
+ENV CARGO_HOME="/build/cargo"
+ENV RUSTFLAGS="-D warnings"
+
+# Finally, compile parquet's dependencies (will also compile other's dependencies)
+RUN cd /dependency_build/datafusion && cargo build --lib
+
+# move the "target" directory to the root, which is our cache, and remove temp directory
+RUN mv dependency_build/datafusion/target / && \
+    rm -rf /dependency_build

--- a/ci/docker/debian-10-rust.dockerfile
+++ b/ci/docker/debian-10-rust.dockerfile
@@ -45,7 +45,7 @@ RUN rustup default ${rust} && \
 # compile their external dependencies.
 
 ENV CARGO_HOME="/rust/cargo" \
-    CARGO_TARGET_DIR="/build/rust" \
+    CARGO_TARGET_DIR="/rust/target" \
     RUSTFLAGS="-D warnings"
 
 # The artifact of the steps below is a "${CARGO_TARGET_DIR}" containing
@@ -68,5 +68,4 @@ RUN mkdir \
         /arrow/rust/parquet/src/lib.rs
 
 # Compile dependencies for the whole workspace
-RUN cd /arrow/rust && \
-    CARGO_TARGET_DIR=/rust/dummy-build cargo build --workspace --lib --all-features
+RUN cd /arrow/rust && cargo build --workspace --lib --all-features

--- a/ci/scripts/rust_build.sh
+++ b/ci/scripts/rust_build.sh
@@ -23,7 +23,6 @@ source_dir=${1}/rust
 
 export ARROW_TEST_DATA=${arrow_dir}/testing/data
 export PARQUET_TEST_DATA=${arrow_dir}/cpp/submodules/parquet-testing/data
-export RUSTFLAGS="-D warnings"
 
 # show activated toolchain
 rustup show

--- a/ci/scripts/rust_test.sh
+++ b/ci/scripts/rust_test.sh
@@ -26,7 +26,6 @@ build_dir=${2}/rust
 export ARROW_TEST_DATA=${arrow_dir}/testing/data
 export PARQUET_TEST_DATA=${arrow_dir}/cpp/submodules/parquet-testing/data
 export CARGO_TARGET_DIR=${build_dir}
-export RUSTFLAGS="-D warnings"
 
 pushd ${source_dir}
 

--- a/ci/scripts/rust_test.sh
+++ b/ci/scripts/rust_test.sh
@@ -21,7 +21,6 @@ set -ex
 
 arrow_dir=${1}
 source_dir=${1}/rust
-build_dir=${2}/rust
 
 export ARROW_TEST_DATA=${arrow_dir}/testing/data
 export PARQUET_TEST_DATA=${arrow_dir}/cpp/submodules/parquet-testing/data

--- a/ci/scripts/rust_test.sh
+++ b/ci/scripts/rust_test.sh
@@ -25,7 +25,6 @@ build_dir=${2}/rust
 
 export ARROW_TEST_DATA=${arrow_dir}/testing/data
 export PARQUET_TEST_DATA=${arrow_dir}/cpp/submodules/parquet-testing/data
-export CARGO_TARGET_DIR=${build_dir}
 
 pushd ${source_dir}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -939,11 +939,10 @@ services:
         arch: ${ARCH}
         rust: ${RUST}
     shm_size: *shm-size
-    environment:
-      CARGO_HOME: /build/cargo
     volumes: *debian-volumes
     command: &rust-command >
       /bin/bash -c "
+        mv /target/ /arrow/rust/ &&
         echo ${RUST} > /arrow/rust/rust-toolchain &&
         /arrow/ci/scripts/rust_build.sh /arrow /build &&
         /arrow/ci/scripts/rust_test.sh /arrow /build"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -939,6 +939,9 @@ services:
         arch: ${ARCH}
         rust: ${RUST}
     shm_size: *shm-size
+    environment:
+      CARGO_HOME: /rust/cargo
+      CARGO_TARGET_DIR: /build/rust
     volumes: &rust-volumes
       - .:/arrow:delegated
       - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${ARCH}-debian-${DEBIAN}-rust:/build:delegated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -939,11 +939,13 @@ services:
         arch: ${ARCH}
         rust: ${RUST}
     shm_size: *shm-size
-    volumes: *debian-volumes
+    volumes: &rust-volumes
+      - .:/arrow:delegated
+      - ${DOCKER_VOLUME_DIRECTORY:-.docker}/${ARCH}-debian-${DEBIAN}-rust:/build:delegated
     command: &rust-command >
       /bin/bash -c "
-        mv /target/ /arrow/rust/ &&
         echo ${RUST} > /arrow/rust/rust-toolchain &&
+        if [ ! -d "/build/rust" ]; then mv /rust/dummy-build /build/rust; fi &&
         /arrow/ci/scripts/rust_build.sh /arrow /build &&
         /arrow/ci/scripts/rust_test.sh /arrow /build"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -945,7 +945,7 @@ services:
     command: &rust-command >
       /bin/bash -c "
         echo ${RUST} > /arrow/rust/rust-toolchain &&
-        if [ ! -d "/build/rust" ]; then mv /rust/dummy-build /build/rust; fi &&
+        if [ ! -d "/build/rust" ]; then mv /rust/target /build/rust; fi &&
         /arrow/ci/scripts/rust_build.sh /arrow /build &&
         /arrow/ci/scripts/rust_test.sh /arrow /build"
 


### PR DESCRIPTION
This allow us to build the crate without having to re-build nor download all its dependencies at the expense of a larger (build) image.

Here I am extending the ideas of a non-workspace rust project to a workspace rust project. See [here](https://github.com/rust-lang/cargo/issues/2644) for a _long_ discussion on the issue. Essentially, it is not easy to do this atm with cargo. 

IMO I think that this is worth it, but I need your help to judge it; it incurs some maintenance (duplication of configurations).