### PR TITLE
ARROW-9529: [Dev][Release] Improvements to release verification scripts

### DIFF
--- a/dev/release/verify-release-candidate-wheels.bat
+++ b/dev/release/verify-release-candidate-wheels.bat
@@ -33,6 +33,22 @@ if not exist %_VERIFICATION_DIR% mkdir %_VERIFICATION_DIR%
 
 cd %_VERIFICATION_DIR%
 
+@rem clone Arrow repository to obtain test requirements
+set GIT_ENV_PATH=%_VERIFICATION_DIR%\_git
+call conda create -p %GIT_ENV_PATH% ^
+    --no-shortcuts -f -q -y git ^
+    || EXIT /B 1
+call activate %GIT_ENV_PATH%
+
+git clone https://github.com/apache/arrow.git || EXIT /B 1
+pushd arrow
+git submodule update --init
+popd
+
+call deactivate
+
+set ARROW_TEST_DATA=%cd%\arrow\testing\data
+
 CALL :verify_wheel 3.5 %1 %2 m
 if errorlevel 1 GOTO error
 
@@ -77,6 +93,11 @@ set WHEEL_FILENAME=pyarrow-%ARROW_VERSION%-cp%PY_VERSION_NO_PERIOD%-cp%PY_VERSIO
 wget --no-check-certificate -O %WHEEL_FILENAME% https://bintray.com/apache/arrow/download_file?file_path=python-rc%%2F%ARROW_VERSION%-rc%RC_NUMBER%%%2F%WHEEL_FILENAME% || EXIT /B 1
 
 pip install %WHEEL_FILENAME% || EXIT /B 1
+
+pip install -r arrow/python/requirements-test.txt || EXIT /B 1
+
+py.test %CONDA_ENV_PATH%\Lib\site-packages\pyarrow --pdb -v || EXIT /B 1
+
 python -c "import pyarrow" || EXIT /B 1
 python -c "import pyarrow.parquet" || EXIT /B 1
 
@@ -85,7 +106,6 @@ if "%PY_VERSION%"=="3.5" GOTO done
 :python36_and_higher_checks
 
 python -c "import pyarrow.flight" || EXIT /B 1
-python -c "import pyarrow.gandiva" || EXIT /B 1
 python -c "import pyarrow.dataset" || EXIT /B 1
 
 :done

--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -119,11 +119,13 @@ popd
 @rem Build and import pyarrow
 pushd %ARROW_SOURCE%\python
 
+pip install -r requirements-test.txt || exit /B 1
+
 set PYARROW_CMAKE_GENERATOR=%GENERATOR%
 set PYARROW_WITH_FLIGHT=1
 set PYARROW_WITH_PARQUET=1
 set PYARROW_WITH_DATASET=1
-python setup.py build_ext --inplace --bundle-arrow-cpp bdist_wheel  || exit /B 1
+python setup.py build_ext --inplace --bundle-arrow-cpp bdist_wheel || exit /B 1
 py.test pyarrow -v -s --enable-parquet || exit /B 1
 
 popd

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -73,6 +73,7 @@ if [ -z "${ARROW_CUDA:-}" ] && detect_cuda; then
 fi
 : ${ARROW_CUDA:=OFF}
 : ${ARROW_FLIGHT:=ON}
+: ${ARROW_GANDIVA:=ON}
 
 ARROW_DIST_URL='https://dist.apache.org/repos/dist/dev/arrow'
 
@@ -278,7 +279,7 @@ ${ARROW_CMAKE_OPTIONS:-}
 -DARROW_PLASMA=ON
 -DARROW_ORC=ON
 -DARROW_PYTHON=ON
--DARROW_GANDIVA=ON
+-DARROW_GANDIVA=${ARROW_GANDIVA}
 -DARROW_PARQUET=ON
 -DARROW_DATASET=ON
 -DPARQUET_REQUIRE_ENCRYPTION=ON
@@ -372,7 +373,6 @@ test_python() {
   pip install -r requirements-build.txt -r requirements-test.txt
 
   export PYARROW_WITH_DATASET=1
-  export PYARROW_WITH_GANDIVA=1
   export PYARROW_WITH_PARQUET=1
   export PYARROW_WITH_PLASMA=1
   if [ "${ARROW_CUDA}" = "ON" ]; then
@@ -380,6 +380,9 @@ test_python() {
   fi
   if [ "${ARROW_FLIGHT}" = "ON" ]; then
     export PYARROW_WITH_FLIGHT=1
+  fi
+  if [ "${ARROW_GANDIVA}" = "ON" ]; then
+    export PYARROW_WITH_GANDIVA=1
   fi
 
   python setup.py build_ext --inplace


### PR DESCRIPTION
* Install all test dependencies for running Python unit tests on Windows
* Run unit tests when verifying wheels
* Add option to run the C++/Python RC verification without Gandiva (didn't have LLVM configured properly on one machine)