### PR TITLE
ARROW-9517: [C++/Python] Add support for temporary credentials to S3Options

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2632,7 +2632,7 @@ macro(build_awssdk)
   set(AWSSDK_CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=Release
       -DCMAKE_INSTALL_LIBDIR=lib
-      -DBUILD_ONLY=s3;core;config
+      -DBUILD_ONLY=s3;core;config;identity-management;sts
       -DENABLE_UNITY_BUILD=on
       -DENABLE_TESTING=off
       "-DCMAKE_C_FLAGS=${EP_C_FLAGS}"
@@ -2646,7 +2646,16 @@ macro(build_awssdk)
     AWSSDK_S3_SHARED_LIB
     "${AWSSDK_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}aws-cpp-sdk-s3${CMAKE_SHARED_LIBRARY_SUFFIX}"
     )
-  set(AWSSDK_SHARED_LIBS "${AWSSDK_CORE_SHARED_LIB}" "${AWSSDK_S3_SHARED_LIB}")
+  set(
+    AWSSDK_IAM_SHARED_LIB
+    "${AWSSDK_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}aws-cpp-sdk-identity-management${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    )
+  set(
+    AWSSDK_STS_SHARED_LIB
+    "${AWSSDK_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}aws-cpp-sdk-sts${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    )
+  set(AWSSDK_SHARED_LIBS "${AWSSDK_CORE_SHARED_LIB}" "${AWSSDK_S3_SHARED_LIB}"
+                         "${AWSSDK_IAM_SHARED_LIB}" "${AWSSDK_STS_SHARED_LIB}")
 
   externalproject_add(awssdk_ep
                       ${EP_LOG_OPTIONS}
@@ -2668,14 +2677,24 @@ if(ARROW_S3)
 
   # Need to customize the find_package() call, so cannot call resolve_dependency()
   if(AWSSDK_SOURCE STREQUAL "AUTO")
-    find_package(AWSSDK COMPONENTS config s3 transfer)
+    find_package(AWSSDK
+                 COMPONENTS config
+                            s3
+                            transfer
+                            identity-management
+                            sts)
     if(NOT AWSSDK_FOUND)
       build_awssdk()
     endif()
   elseif(AWSSDK_SOURCE STREQUAL "BUNDLED")
     build_awssdk()
   elseif(AWSSDK_SOURCE STREQUAL "SYSTEM")
-    find_package(AWSSDK REQUIRED COMPONENTS config s3 transfer)
+    find_package(AWSSDK REQUIRED
+                 COMPONENTS config
+                            s3
+                            transfer
+                            identity-management
+                            sts)
   endif()
 
   include_directories(SYSTEM ${AWSSDK_INCLUDE_DIR})

--- a/python/manylinux1/scripts/build_aws_sdk.sh
+++ b/python/manylinux1/scripts/build_aws_sdk.sh
@@ -34,7 +34,7 @@ cmake .. -GNinja \
     -DCMAKE_C_FLAGS=${CFLAGS} \
     -DCMAKE_CXX_FLAGS=${CFLAGS} \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DBUILD_ONLY='s3;core;transfer;config' \
+    -DBUILD_ONLY='s3;core;transfer;config;identity-management;sts' \
     -DBUILD_SHARED_LIBS=OFF \
     -DENABLE_CURL_LOGGING=ON \
     -DENABLE_UNITY_BUILD=ON \

--- a/python/manylinux201x/scripts/build_aws_sdk.sh
+++ b/python/manylinux201x/scripts/build_aws_sdk.sh
@@ -30,7 +30,7 @@ pushd build
 cmake .. -GNinja \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-    -DBUILD_ONLY='s3;core;transfer;config' \
+    -DBUILD_ONLY='s3;core;transfer;config;identity-management;sts' \
     -DBUILD_SHARED_LIBS=OFF \
     -DENABLE_CURL_LOGGING=ON \
     -DENABLE_UNITY_BUILD=ON \

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -130,11 +130,17 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string endpoint_override
         c_string scheme
         c_bool background_writes
+        c_string role_arn
+        c_string session_name
+        c_string external_id
+        int load_frequency
         void ConfigureDefaultCredentials()
         void ConfigureAccessKey(const c_string& access_key,
-                                const c_string& secret_key)
+                                const c_string& secret_key,
+                                const c_string& session_token)
         c_string GetAccessKey()
         c_string GetSecretKey()
+        c_string GetSessionToken()
         c_bool Equals(const CS3Options& other)
 
         @staticmethod
@@ -145,7 +151,14 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
 
         @staticmethod
         CS3Options FromAccessKey(const c_string& access_key,
-                                 const c_string& secret_key)
+                                 const c_string& secret_key,
+                                 const c_string& session_token)
+
+        @staticmethod
+        CS3Options FromAssumeRole(const c_string& role_arn,
+                                  const c_string& session_name,
+                                  const c_string& external_id,
+                                  const int load_frequency)
 
     cdef cppclass CS3FileSystem "arrow::fs::S3FileSystem"(CFileSystem):
         @staticmethod

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -975,8 +975,13 @@ def test_s3_options():
     from pyarrow.fs import S3FileSystem
 
     fs = S3FileSystem(access_key='access', secret_key='secret',
-                      region='us-east-1', scheme='https',
-                      endpoint_override='localhost:8999')
+                      session_token='token', region='us-east-1',
+                      scheme='https', endpoint_override='localhost:8999')
+    assert isinstance(fs, S3FileSystem)
+    assert pickle.loads(pickle.dumps(fs)) == fs
+
+    fs = S3FileSystem(role_arn='role', session_name='session',
+                      external_id='id', load_frequency=100)
     assert isinstance(fs, S3FileSystem)
     assert pickle.loads(pickle.dumps(fs)) == fs
 
@@ -984,6 +989,14 @@ def test_s3_options():
         S3FileSystem(access_key='access')
     with pytest.raises(ValueError):
         S3FileSystem(secret_key='secret')
+    with pytest.raises(ValueError):
+        S3FileSystem(access_key='access', session_token='token')
+    with pytest.raises(ValueError):
+        S3FileSystem(secret_key='secret', session_token='token')
+    with pytest.raises(ValueError):
+        S3FileSystem(
+            access_key='access', secret_key='secret', role_arn='arn'
+        )
 
 
 @pytest.mark.hdfs


### PR DESCRIPTION
### Background
AWS provides a mechanism for using temporary credentials to access AWS resources.  When accessing AWS resources with a set of temporary credentials,[ users must provide a session token](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html) in addition to the usual access key id and secret access key.

This PR adds support for providing a session token when initializing an S3FileSystem.

Additionally, this PR adds support for auto-refreshing temporary credentials via STS AssumeRole: instead of passing explicit credentials, users supply the arn of a role to assume, and an `STSAssumeRoleCredentialsProvider` will be created to handle fetching temporary credentials by assuming this role.

### Changes
#### C++
- updated `S3Options.FromAccessKey` and `S3Options.ConfigureAccessKey` to accept an optional `session_token` argument (defaulting to empty string, in accordance with the convention of [Aws::Auth::AWSCredentials](https://sdk.amazonaws.com/cpp/api/0.12.9/d4/d27/class_aws_1_1_auth_1_1_a_w_s_credentials.html) as implemented in the AWS C++ SDK.)
- updated `S3FileSystem` implementation to initialize S3Client with CredentialsProvider instead of directly passing AwsCredentials (enabling auto-refreshing of AwsCredentials from provider)
- added `S3Options.GetSessionToken` method
- added `S3Options.FromAssumeRole` and `S3Options.ConfigureAssumeRoleCredentials` to support auto-refreshing temporary credentials via STS AssumeRole.

#### Python
- updated cdef `CS3Options` to reflect updates to C++ library
- added optional `session_token` argument to `S3FileSystem.__init__`.

### Testing
- updated `test_s3_options` python unittest to include a mock session_token when initializing S3FileSystem.
- updated `test_s3_options` python unittest to include relevant scenarios for provided a `role_arn` when initializing S3FileSystem.
- updated `s3fs_test.cc` c++ tests to cover changes to FromAccessKey as well as the newly added FromAssumeRole.
- successfully ran ctest suite and pytest suite with `--enable-s3` option.