### PR TITLE
ARROW-9528: [Python] Honor tzinfo when converting from datetime

### DIFF
--- a/ci/docker/conda-python-spark.dockerfile
+++ b/ci/docker/conda-python-spark.dockerfile
@@ -40,6 +40,10 @@ RUN /arrow/ci/scripts/install_spark.sh ${spark} /spark
 COPY ci/etc/integration_spark_ARROW-9438.patch /arrow/ci/etc/
 RUN patch -d /spark -p1 -i /arrow/ci/etc/integration_spark_ARROW-9438.patch
 
+# patch spark to handle struct timestamps with tzinfo
+COPY ci/etc/integration_spark_ARROW-9223.patch /arrow/ci/etc/
+RUN patch -d /spark -p1 -i /arrow/ci/etc/integration_spark_ARROW-9223.patch
+
 # build cpp with tests
 ENV CC=gcc \
     CXX=g++ \

--- a/ci/etc/integration_spark_ARROW-9223.patch
+++ b/ci/etc/integration_spark_ARROW-9223.patch
@@ -1,0 +1,37 @@
+diff --git a/python/pyspark/sql/pandas/serializers.py b/python/pyspark/sql/pandas/serializers.py
+index 42562e1fb9..d00b67e99b 100644
+--- a/python/pyspark/sql/pandas/serializers.py
++++ b/python/pyspark/sql/pandas/serializers.py
+@@ -120,15 +120,30 @@ class ArrowStreamPandasSerializer(ArrowStreamSerializer):
+ 
+     def arrow_to_pandas(self, arrow_column):
+         from pyspark.sql.pandas.types import _check_series_localize_timestamps
+-        import pyarrow
++        import pyarrow as pa
+ 
+         # If the given column is a date type column, creates a series of datetime.date directly
+         # instead of creating datetime64[ns] as intermediate data to avoid overflow caused by
+         # datetime64[ns] type handling.
+         s = arrow_column.to_pandas(date_as_object=True)
+ 
+-        if pyarrow.types.is_timestamp(arrow_column.type):
++        if pa.types.is_timestamp(arrow_column.type):
+             return _check_series_localize_timestamps(s, self._timezone)
++        elif pa.types.is_struct(arrow_column.type):
++            if isinstance(arrow_column, pa.ChunkedArray):
++                arrow_column = pa.concat_arrays(arrow_column.iterchunks())
++            children = []
++            names = []
++            for f in arrow_column.type:
++                child = arrow_column.field(f.name)
++                if pa.types.is_timestamp(child.type):
++                    child_series = child.to_pandas()
++                    child_series = _check_series_localize_timestamps(child_series, self._timezone)
++                    child = pa.array(child_series, type=pa.timestamp('us'))
++                children.append(child)
++                names.append(f.name)
++            arr = pa.StructArray.from_arrays(children, names)
++            return arr.to_pandas(date_as_object=True)
+         else:
+             return s
+ 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -331,7 +331,8 @@ cdef class Date64Scalar(Scalar):
 
     def as_py(self):
         """
-        Return this value as a Python datetime.datetime instance.
+        Return this value as a Pandas Timestamp instance (if available),
+        otherwise as a Python datetime.datetime instance.
         """
         cdef CDate64Scalar* sp = <CDate64Scalar*> self.wrapped.get()
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3325,6 +3325,21 @@ def test_cast_timestamp_unit():
     assert result.equals(expected)
 
 
+def test_nested_with_timestamp_tz_round_trip():
+    ts = pd.Timestamp.now()
+    ts_dt = ts.to_pydatetime()
+    arr = pa.array([ts_dt], type=pa.timestamp('us', tz='America/New_York'))
+    struct = pa.StructArray.from_arrays([arr, arr], ['start', 'stop'])
+
+    result = struct.to_pandas()
+    # N.B. we test with Panaas because the Arrow types are not
+    # actually equal.  All Timezone aware times are currently normalized
+    # to "UTC" as the timesetamp type.but since this conversion results
+    # in object dtypes, and tzinfo is preserrved the comparison should
+    # result in equality.
+    pd.testing.assert_series_equal(pa.array(result).to_pandas(), result)
+
+
 def test_nested_with_timestamp_tz():
     # ARROW-7723
     ts = pd.Timestamp.now()


### PR DESCRIPTION
Draft PR to enable round trip to TZ info to hopefully solve spark issues.