### PR TITLE
ARROW-9531: [Packaging][Release] Update conda forge dependency pins 

### DIFF
--- a/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.6.____cpython.yaml
@@ -27,7 +27,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -44,15 +44,13 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.7.____cpython.yaml
@@ -27,7 +27,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -44,15 +44,13 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.7.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.8.____cpython.yaml
@@ -27,7 +27,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -44,15 +44,13 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.8.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.6.____cpython.yaml
@@ -25,7 +25,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -42,12 +42,10 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zip_keys:
@@ -56,4 +54,4 @@ zip_keys:
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.7.____cpython.yaml
@@ -25,7 +25,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -42,12 +42,10 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.7.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zip_keys:
@@ -56,4 +54,4 @@ zip_keys:
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.8.____cpython.yaml
@@ -25,7 +25,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -42,12 +42,10 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.8.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zip_keys:
@@ -56,4 +54,4 @@ zip_keys:
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.6.____cpython.yaml
@@ -25,7 +25,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -42,12 +42,10 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zip_keys:
@@ -56,4 +54,4 @@ zip_keys:
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.7.____cpython.yaml
@@ -25,7 +25,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -42,12 +42,10 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.7.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zip_keys:
@@ -56,4 +54,4 @@ zip_keys:
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.8.____cpython.yaml
@@ -25,7 +25,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -42,12 +42,10 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.8.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zip_keys:
@@ -56,4 +54,4 @@ zip_keys:
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/osx_python3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/osx_python3.6.____cpython.yaml
@@ -7,7 +7,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '9'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 gflags:
 - '2.2'
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -42,15 +42,13 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/osx_python3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/osx_python3.7.____cpython.yaml
@@ -7,7 +7,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '9'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 gflags:
 - '2.2'
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -42,15 +42,13 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.7.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/osx_python3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/osx_python3.8.____cpython.yaml
@@ -7,7 +7,7 @@ bzip2:
 c_compiler:
 - clang
 c_compiler_version:
-- '9'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
@@ -15,13 +15,13 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '9'
+- '10'
 gflags:
 - '2.2'
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -42,15 +42,13 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.8.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/win_python3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/win_python3.6.____cpython.yaml
@@ -15,7 +15,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -32,15 +32,13 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/win_python3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/win_python3.7.____cpython.yaml
@@ -15,7 +15,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -32,15 +32,13 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.7.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/.ci_support/win_python3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/win_python3.8.____cpython.yaml
@@ -15,7 +15,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.29'
+- '1.30'
 libprotobuf:
 - '3.12'
 lz4_c:
@@ -32,15 +32,13 @@ pin_run_as_build:
     max_pin: x.x
   zlib:
     max_pin: x.x
-  zstd:
-    max_pin: x.x.x
 python:
 - 3.8.* *_cpython
 re2:
-- 2020.06.01
+- 2020.07.06
 snappy:
 - '1'
 zlib:
 - '1.2'
 zstd:
-- 1.4.4
+- '1.4'

--- a/dev/tasks/conda-recipes/azure.win.yml
+++ b/dev/tasks/conda-recipes/azure.win.yml
@@ -34,11 +34,10 @@ jobs:
 
     - task: CondaEnvironment@1
       inputs:
-        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=2' # Optional
+        packageSpecs: 'python=3.6 conda-build conda conda-forge::conda-forge-ci-setup=3 pip' # Optional
         installOptions: "-c conda-forge"
         updateConda: true
       displayName: Install conda-build and activate environment
-
     - script: set PYTHONUNBUFFERED=1
 
     - script: |
@@ -55,13 +54,9 @@ jobs:
     # Configure the VM.
     - script: |
         set "CI=azure"
+        call activate base
         run_conda_forge_build_setup
       displayName: conda-forge build setup
-
-    - script: |
-        rmdir C:\strawberry /s /q
-      continueOnError: true
-      displayName: remove strawberryperl
 
     - script: |
         conda.exe build arrow-cpp parquet-cpp -m .ci_support\%CONFIG%.yaml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -211,7 +211,7 @@ tasks:
 
   ############################## Conda Windows ################################
 
-  conda-win-vs2015-py36:
+  conda-win-vs2017-py36:
     ci: azure
     template: conda-recipes/azure.win.yml
     params:
@@ -220,7 +220,7 @@ tasks:
       - arrow-cpp-{no_rc_version}-py36(h[a-z0-9]+)_0_cpu.tar.bz2
       - pyarrow-{no_rc_version}-py36(h[a-z0-9]+)_0_cpu.tar.bz2
 
-  conda-win-vs2015-py37:
+  conda-win-vs2017-py37:
     ci: azure
     template: conda-recipes/azure.win.yml
     params:
@@ -229,7 +229,7 @@ tasks:
       - arrow-cpp-{no_rc_version}-py37(h[a-z0-9]+)_0_cpu.tar.bz2
       - pyarrow-{no_rc_version}-py37(h[a-z0-9]+)_0_cpu.tar.bz2
 
-  conda-win-vs2015-py38:
+  conda-win-vs2017-py38:
     ci: azure
     template: conda-recipes/azure.win.yml
     params:


### PR DESCRIPTION
All of the nightly conda package builds are failing with dependency resolution issues: https://github.com/ursa-labs/crossbow/branches/all?query=nightly-2020-07-20-0-azure-conda

Hopefully updating the vendored recipes after the upstream conda-smithy rerender will resolve the build failures.