### PR TITLE
ARROW-9546: [Python] Clean up Pandas Metadata Conversion test

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -440,9 +440,7 @@ class TestConvertMetadata:
 
         df = pd.DataFrame({'numbers': numbers}, index=index)
 
-        table = pa.Table.from_pandas(df)
-        result_df = table.to_pandas()
-        tm.assert_frame_equal(result_df, df)
+        _check_pandas_roundtrip(df, preserve_index=True)
 
     def test_metadata_with_mixed_types(self):
         df = pd.DataFrame({'data': [b'some_bytes', 'some_unicode']})


### PR DESCRIPTION
Cosmetic improvement to a pyarrow Pandas test. I rewrote the metadata conversion test using `_check_pandas_roundtrip`.