### PR TITLE
[Release][Rust] Arrow dependency version was not updated in the parquet crate

### DIFF
--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -39,7 +39,7 @@ lz4 = { version = "1.23", optional = true }
 zstd = { version = "0.5", optional = true }
 chrono = "0.4"
 num-bigint = "0.3"
-arrow = { path = "../arrow", version = "1.0.0-SNAPSHOT", optional = true }
+arrow = { path = "../arrow", version = "1.1.0-SNAPSHOT", optional = true }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Created a follow-up to fix the release script https://issues.apache.org/jira/browse/ARROW-9553