### PR TITLE
ARROW-9544: [R] Fix version argument of write_parquet()

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -50,6 +50,7 @@
 
 * Non-UTF-8 strings (common on Windows) are correctly coerced to UTF-8 when passing to Arrow memory and appropriately re-localized when converting to R
 * The `coerce_timestamps` option to `write_parquet()` is now correctly implemented.
+* The `version` option to `write_parquet()` is now correctly implemented.
 * Creating a Dictionary array respects the `type` definition if provided by the user  
 * `read_arrow` and `write_arrow` are now deprecated; use the `read/write_feather()` and `read/write_ipc_stream()` functions depending on whether you're working with the Arrow IPC file or stream format, respectively.
 * Previously deprecated `FileStats`, `read_record_batch`, and `read_table` have been removed.

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -19,6 +19,10 @@
 
 # arrow 1.0.0.9000
 
+## Bug fixes
+
+* The `version` option to `write_parquet()` is now correctly implemented.
+
 # arrow 1.0.0
 
 ## Arrow format conversion
@@ -50,7 +54,6 @@
 
 * Non-UTF-8 strings (common on Windows) are correctly coerced to UTF-8 when passing to Arrow memory and appropriately re-localized when converting to R
 * The `coerce_timestamps` option to `write_parquet()` is now correctly implemented.
-* The `version` option to `write_parquet()` is now correctly implemented.
 * Creating a Dictionary array respects the `type` definition if provided by the user  
 * `read_arrow` and `write_arrow` are now deprecated; use the `read/write_feather()` and `read/write_ipc_stream()` functions depending on whether you're working with the Arrow IPC file or stream format, respectively.
 * Previously deprecated `FileStats`, `read_record_batch`, and `read_table` have been removed.

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -257,7 +257,7 @@ ParquetWriterProperties <- R6Class("ParquetWriterProperties", inherit = ArrowObj
 ParquetWriterPropertiesBuilder <- R6Class("ParquetWriterPropertiesBuilder", inherit = ArrowObject,
   public = list(
     set_version = function(version) {
-      parquet___ArrowWriterProperties___Builder__version(self, make_valid_version(version))
+      parquet___WriterProperties___Builder__version(self, make_valid_version(version))
     },
     set_compression = function(table, compression) {
       compression <- compression_from_name(compression)

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -62,7 +62,8 @@ read_parquet <- function(file,
 #' @param sink an [arrow::io::OutputStream][OutputStream] or a string which is interpreted as a file path
 #' @param chunk_size chunk size in number of rows. If NULL, the total number of rows is used.
 #'
-#' @param version parquet version, "1.0" or "2.0". Default "1.0"
+#' @param version parquet version, "1.0" or "2.0". Default "1.0". Numeric values
+#'   are coerced to character.
 #' @param compression compression algorithm. Default "snappy". See details.
 #' @param compression_level compression level. Meaning depends on compression algorithm
 #' @param use_dictionary Specify if we should use dictionary encoding. Default `TRUE`

--- a/r/man/write_parquet.Rd
+++ b/r/man/write_parquet.Rd
@@ -33,7 +33,8 @@ write_parquet(
 
 \item{chunk_size}{chunk size in number of rows. If NULL, the total number of rows is used.}
 
-\item{version}{parquet version, "1.0" or "2.0". Default "1.0"}
+\item{version}{parquet version, "1.0" or "2.0". Default "1.0". Numeric values
+are coerced to character.}
 
 \item{compression}{compression algorithm. Default "snappy". See details.}
 

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -177,3 +177,17 @@ test_that("write_parquet() returns its input", {
   df_out <- write_parquet(df, tf)
   expect_equivalent(df, df_out)
 })
+
+test_that("write_parquet() handles version argument", {
+  df <- tibble::tibble(x = 1:5)
+  tf <- tempfile()
+  on.exit(unlink(tf))
+
+  purrr::walk(list("1.0", "2.0", 1.0, 2.0, 1L, 2L), ~ {
+    write_parquet(df, tf, version = .x)
+    expect_identical(read_parquet(tf), df)
+  })
+  purrr::walk(list("3.0", 3.0, 3L, "A"), ~ {
+    expect_error(write_parquet(df, tf, version = .x))
+  })
+})


### PR DESCRIPTION
Setting the version argument in `write_parquet()` did not work due to an incorrect function name. This PR fixes the bug, adds tests and amends the documentation.