### PR TITLE
ARROW-7903: [Rust] [DataFusion] Migrated to sqlparser 0.6.1

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -47,7 +47,7 @@ cli = ["rustyline"]
 fnv = "1.0"
 arrow = { path = "../arrow", version = "1.1.0-SNAPSHOT" }
 parquet = { path = "../parquet", version = "1.1.0-SNAPSHOT" }
-sqlparser = "0.2.6"
+sqlparser = "0.6.1"
 clap = "2.33"
 prettytable-rs = "0.8.0"
 rustyline = {version = "6.0", optional = true}

--- a/rust/datafusion/src/error.rs
+++ b/rust/datafusion/src/error.rs
@@ -25,7 +25,7 @@ use std::result;
 use arrow::error::ArrowError;
 use parquet::errors::ParquetError;
 
-use sqlparser::sqlparser::ParserError;
+use sqlparser::parser::ParserError;
 
 /// Result type for operations that could result in an `ExecutionError`
 pub type Result<T> = result::Result<T, ExecutionError>;

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -56,10 +56,12 @@ use crate::logicalplan::{
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::projection_push_down::ProjectionPushDown;
 use crate::optimizer::type_coercion::TypeCoercionRule;
-use crate::sql::parser::{DFASTNode, DFParser, FileType};
-use crate::sql::planner::{SchemaProvider, SqlToRel};
+use crate::sql::{
+    parser::{DFParser, FileType, Statement},
+    planner::{SchemaProvider, SqlToRel},
+};
 use crate::table::Table;
-use sqlparser::sqlast::{SQLColumnDef, SQLType};
+use sqlparser::ast::{ColumnDef as SQLColumnDef, ColumnOption, DataType as SQLDataType};
 
 /// Execution context for registering data sources and executing queries
 pub struct ExecutionContext {
@@ -140,10 +142,10 @@ impl ExecutionContext {
 
     /// Creates a logical plan
     pub fn create_logical_plan(&mut self, sql: &str) -> Result<LogicalPlan> {
-        let ast = DFParser::parse_sql(sql)?;
+        let statements = DFParser::parse_sql(sql)?;
 
-        match ast {
-            DFASTNode::ANSI(ansi) => {
+        match &statements[0] {
+            Statement::Statement(s) => {
                 let schema_provider = ExecutionContextSchemaProvider {
                     datasources: &self.datasources,
                     scalar_functions: &self.scalar_functions,
@@ -153,25 +155,25 @@ impl ExecutionContext {
                 let query_planner = SqlToRel::new(schema_provider);
 
                 // plan the query (create a logical relational plan)
-                let plan = query_planner.sql_to_rel(&ansi)?;
+                let plan = query_planner.statement_to_plan(&s)?;
 
                 Ok(plan)
             }
-            DFASTNode::CreateExternalTable {
+            Statement::CreateExternalTable {
                 name,
                 columns,
                 file_type,
                 has_header,
                 location,
             } => {
-                let schema = Box::new(self.build_schema(columns)?);
+                let schema = Box::new(self.build_schema(&columns)?);
 
                 Ok(LogicalPlan::CreateExternalTable {
                     schema,
-                    name,
-                    location,
-                    file_type,
-                    has_header,
+                    name: name.clone(),
+                    location: location.clone(),
+                    file_type: file_type.clone(),
+                    has_header: has_header.clone(),
                 })
             }
         }
@@ -187,39 +189,37 @@ impl ExecutionContext {
         &self.scalar_functions
     }
 
-    fn build_schema(&self, columns: Vec<SQLColumnDef>) -> Result<Schema> {
+    fn build_schema(&self, columns: &Vec<SQLColumnDef>) -> Result<Schema> {
         let mut fields = Vec::new();
 
         for column in columns {
-            let data_type = self.make_data_type(column.data_type)?;
-            fields.push(Field::new(&column.name, data_type, column.allow_null));
+            let data_type = self.make_data_type(&column.data_type)?;
+            let allow_null = column
+                .options
+                .iter()
+                .any(|x| x.option == ColumnOption::Null);
+            fields.push(Field::new(&column.name.value, data_type, allow_null));
         }
 
         Ok(Schema::new(fields))
     }
 
-    fn make_data_type(&self, sql_type: SQLType) -> Result<DataType> {
+    fn make_data_type(&self, sql_type: &SQLDataType) -> Result<DataType> {
         match sql_type {
-            SQLType::BigInt => Ok(DataType::Int64),
-            SQLType::Int => Ok(DataType::Int32),
-            SQLType::SmallInt => Ok(DataType::Int16),
-            SQLType::Char(_) | SQLType::Varchar(_) | SQLType::Text => Ok(DataType::Utf8),
-            SQLType::Decimal(_, _) => Ok(DataType::Float64),
-            SQLType::Float(_) => Ok(DataType::Float32),
-            SQLType::Real | SQLType::Double => Ok(DataType::Float64),
-            SQLType::Boolean => Ok(DataType::Boolean),
-            SQLType::Date => Ok(DataType::Date64(DateUnit::Day)),
-            SQLType::Time => Ok(DataType::Time64(TimeUnit::Millisecond)),
-            SQLType::Timestamp => Ok(DataType::Date64(DateUnit::Millisecond)),
-            SQLType::Uuid
-            | SQLType::Clob(_)
-            | SQLType::Binary(_)
-            | SQLType::Varbinary(_)
-            | SQLType::Blob(_)
-            | SQLType::Regclass
-            | SQLType::Bytea
-            | SQLType::Custom(_)
-            | SQLType::Array(_) => Err(ExecutionError::General(format!(
+            SQLDataType::BigInt => Ok(DataType::Int64),
+            SQLDataType::Int => Ok(DataType::Int32),
+            SQLDataType::SmallInt => Ok(DataType::Int16),
+            SQLDataType::Char(_) | SQLDataType::Varchar(_) | SQLDataType::Text => {
+                Ok(DataType::Utf8)
+            }
+            SQLDataType::Decimal(_, _) => Ok(DataType::Float64),
+            SQLDataType::Float(_) => Ok(DataType::Float32),
+            SQLDataType::Real | SQLDataType::Double => Ok(DataType::Float64),
+            SQLDataType::Boolean => Ok(DataType::Boolean),
+            SQLDataType::Date => Ok(DataType::Date64(DateUnit::Day)),
+            SQLDataType::Time => Ok(DataType::Time64(TimeUnit::Millisecond)),
+            SQLDataType::Timestamp => Ok(DataType::Date64(DateUnit::Millisecond)),
+            _ => Err(ExecutionError::General(format!(
                 "Unsupported data type: {:?}.",
                 sql_type
             ))),

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -144,6 +144,12 @@ impl ExecutionContext {
     pub fn create_logical_plan(&mut self, sql: &str) -> Result<LogicalPlan> {
         let statements = DFParser::parse_sql(sql)?;
 
+        if statements.len() != 1 {
+            return Err(ExecutionError::NotImplemented(format!(
+                "The context currently only supports a single SQL statement",
+            )));
+        }
+
         match &statements[0] {
             Statement::Statement(s) => {
                 let schema_provider = ExecutionContextSchemaProvider {

--- a/rust/datafusion/src/sql/parser.rs
+++ b/rust/datafusion/src/sql/parser.rs
@@ -116,18 +116,21 @@ impl DFParser {
 
     /// Parse a new expression
     pub fn parse_statement(&mut self) -> Result<Statement, ParserError> {
-        match self.parser.next_token() {
+        match self.parser.peek_token() {
             Token::Word(w) => match w.keyword {
-                Keyword::CREATE => Ok(self.parse_create()?),
+                Keyword::CREATE => {
+                    // move one token forward
+                    self.parser.next_token();
+                    // use custom parsing
+                    Ok(self.parse_create()?)
+                }
                 _ => {
-                    // roll back and use the native parser
-                    self.parser.prev_token();
+                    // use the native parser
                     Ok(Statement::Statement(self.parser.parse_statement()?))
                 }
             },
             _ => {
-                // roll back and use the native parser
-                self.parser.prev_token();
+                // use the native parser
                 Ok(Statement::Statement(self.parser.parse_statement()?))
             }
         }

--- a/rust/datafusion/src/sql/parser.rs
+++ b/rust/datafusion/src/sql/parser.rs
@@ -17,14 +17,16 @@
 
 //! SQL Parser
 //!
-//! Note that most SQL parsing is now delegated to the sqlparser crate, which handles ANSI
-//! SQL but this module contains DataFusion-specific SQL extensions.
+//! Declares a SQL parser based on sqlparser that handles custom formats that we need.
 
-use sqlparser::dialect::*;
-use sqlparser::sqlast::*;
-use sqlparser::sqlparser::*;
-use sqlparser::sqltokenizer::*;
+use sqlparser::{
+    ast::{ColumnDef, Statement as SQLStatement, TableConstraint},
+    dialect::{keywords::Keyword, GenericDialect},
+    parser::{Parser, ParserError},
+    tokenizer::{Token, Tokenizer},
+};
 
+// Use `Parser::expected` instead, if possible
 macro_rules! parser_err {
     ($MSG:expr) => {
         Err(ParserError::ParserError($MSG.to_string()))
@@ -42,19 +44,19 @@ pub enum FileType {
     CSV,
 }
 
-/// DataFrame AST Node representations.
+/// DataFrame Statement's representations.
 ///
 /// Tokens parsed by `DFParser` are converted into these values.
 #[derive(Debug, Clone)]
-pub enum DFASTNode {
+pub enum Statement {
     /// ANSI SQL AST node
-    ANSI(ASTNode),
+    Statement(SQLStatement),
     /// DDL for creating an external table in DataFusion
     CreateExternalTable {
         /// Table name
         name: String,
         /// Optional schema
-        columns: Vec<SQLColumnDef>,
+        columns: Vec<ColumnDef>,
         /// File type (Parquet, NDJSON, CSV)
         file_type: FileType,
         /// CSV Header row?
@@ -72,7 +74,7 @@ pub struct DFParser {
 impl DFParser {
     /// Parse the specified tokens
     pub fn new(sql: &str) -> Result<Self, ParserError> {
-        let dialect = GenericSqlDialect {};
+        let dialect = GenericDialect {};
         let mut tokenizer = Tokenizer::new(&dialect, sql);
         let tokens = tokenizer.tokenize()?;
         Ok(DFParser {
@@ -80,145 +82,177 @@ impl DFParser {
         })
     }
 
-    /// Parse a SQL statement and produce an Abstract Syntax Tree (AST)
-    pub fn parse_sql(sql: &str) -> Result<DFASTNode, ParserError> {
+    /// Parse a SQL statement and produce a set of statements
+    pub fn parse_sql(sql: &str) -> Result<Vec<Statement>, ParserError> {
+        let mut tokenizer = Tokenizer::new(&GenericDialect {}, &sql);
+        tokenizer.tokenize()?;
         let mut parser = DFParser::new(sql)?;
-        parser.parse()
+        let mut stmts = Vec::new();
+        let mut expecting_statement_delimiter = false;
+        loop {
+            // ignore empty statements (between successive statement delimiters)
+            while parser.parser.consume_token(&Token::SemiColon) {
+                expecting_statement_delimiter = false;
+            }
+
+            if parser.parser.peek_token() == Token::EOF {
+                break;
+            }
+            if expecting_statement_delimiter {
+                return parser.expected("end of statement", parser.parser.peek_token());
+            }
+
+            let statement = parser.parse_statement()?;
+            stmts.push(statement);
+            expecting_statement_delimiter = true;
+        }
+        Ok(stmts)
+    }
+
+    /// Report unexpected token
+    fn expected<T>(&self, expected: &str, found: Token) -> Result<T, ParserError> {
+        parser_err!(format!("Expected {}, found: {}", expected, found))
     }
 
     /// Parse a new expression
-    pub fn parse(&mut self) -> Result<DFASTNode, ParserError> {
-        self.parse_expr(0)
-    }
-
-    /// Parse tokens until the precedence changes
-    fn parse_expr(&mut self, precedence: u8) -> Result<DFASTNode, ParserError> {
-        let mut expr = self.parse_prefix()?;
-        loop {
-            let next_precedence = self.parser.get_next_precedence()?;
-            if precedence >= next_precedence {
-                break;
-            }
-
-            if let Some(infix_expr) = self.parse_infix(expr.clone(), next_precedence)? {
-                expr = infix_expr;
-            }
-        }
-        Ok(expr)
-    }
-
-    /// Parse an expression prefix
-    fn parse_prefix(&mut self) -> Result<DFASTNode, ParserError> {
-        if self
-            .parser
-            .parse_keywords(vec!["CREATE", "EXTERNAL", "TABLE"])
-        {
-            match self.parser.next_token() {
-                Some(Token::Identifier(id)) => {
-                    // parse optional column list (schema)
-                    let mut columns = vec![];
-                    if self.parser.consume_token(&Token::LParen) {
-                        loop {
-                            if let Some(Token::Identifier(column_name)) =
-                                self.parser.next_token()
-                            {
-                                if let Ok(data_type) = self.parser.parse_data_type() {
-                                    let allow_null = if self
-                                        .parser
-                                        .parse_keywords(vec!["NOT", "NULL"])
-                                    {
-                                        false
-                                    } else if self.parser.parse_keyword("NULL") {
-                                        true
-                                    } else {
-                                        true
-                                    };
-
-                                    columns.push(SQLColumnDef {
-                                        name: column_name,
-                                        data_type: data_type,
-                                        allow_null,
-                                        default: None,
-                                        is_primary: false,
-                                        is_unique: false,
-                                    });
-                                    match self.parser.next_token() {
-                                        Some(Token::Comma) => continue,
-                                        Some(Token::RParen) => break,
-                                        _ => {
-                                            return parser_err!(
-                                                "Expected ',' or ')' after column definition"
-                                            );
-                                        }
-                                    }
-                                } else {
-                                    return parser_err!(
-                                        "Error parsing data type in column definition"
-                                    );
-                                }
-                            } else {
-                                return parser_err!("Error parsing column name");
-                            }
-                        }
-                    }
-
-                    let mut has_header = true;
-                    let file_type: FileType = if self
-                        .parser
-                        .parse_keywords(vec!["STORED", "AS", "CSV"])
-                    {
-                        if self.parser.parse_keywords(vec!["WITH", "HEADER", "ROW"]) {
-                            has_header = true;
-                        } else if self
-                            .parser
-                            .parse_keywords(vec!["WITHOUT", "HEADER", "ROW"])
-                        {
-                            has_header = false;
-                        }
-                        FileType::CSV
-                    } else if self.parser.parse_keywords(vec!["STORED", "AS", "NDJSON"]) {
-                        FileType::NdJson
-                    } else if self.parser.parse_keywords(vec!["STORED", "AS", "PARQUET"])
-                    {
-                        FileType::Parquet
-                    } else {
-                        return parser_err!(format!(
-                            "Expected 'STORED AS' clause, found {:?}",
-                            self.parser.peek_token()
-                        ));
-                    };
-
-                    let location: String = if self.parser.parse_keywords(vec!["LOCATION"])
-                    {
-                        self.parser.parse_literal_string()?
-                    } else {
-                        return parser_err!("Missing 'LOCATION' clause");
-                    };
-
-                    Ok(DFASTNode::CreateExternalTable {
-                        name: id,
-                        columns,
-                        file_type,
-                        has_header,
-                        location,
-                    })
+    pub fn parse_statement(&mut self) -> Result<Statement, ParserError> {
+        match self.parser.next_token() {
+            Token::Word(w) => match w.keyword {
+                Keyword::CREATE => Ok(self.parse_create()?),
+                _ => {
+                    // roll back and use the native parser
+                    self.parser.prev_token();
+                    Ok(Statement::Statement(self.parser.parse_statement()?))
                 }
-                _ => parser_err!(format!(
-                    "Unexpected token after CREATE EXTERNAL TABLE: {:?}",
-                    self.parser.peek_token()
-                )),
+            },
+            _ => {
+                // roll back and use the native parser
+                self.parser.prev_token();
+                Ok(Statement::Statement(self.parser.parse_statement()?))
             }
-        } else {
-            Ok(DFASTNode::ANSI(self.parser.parse_prefix()?))
         }
     }
 
-    /// Parse an infix operator
-    pub fn parse_infix(
+    /// Parse a SQL CREATE statement
+    pub fn parse_create(&mut self) -> Result<Statement, ParserError> {
+        if self.parser.parse_keyword(Keyword::EXTERNAL) {
+            self.parse_create_external_table()
+        } else {
+            Ok(Statement::Statement(self.parser.parse_create()?))
+        }
+    }
+
+    // This is a copy of the equivalent implementation in sqlparser.
+    fn parse_columns(
         &mut self,
-        _expr: DFASTNode,
-        _precedence: u8,
-    ) -> Result<Option<DFASTNode>, ParserError> {
-        unimplemented!()
+    ) -> Result<(Vec<ColumnDef>, Vec<TableConstraint>), ParserError> {
+        let mut columns = vec![];
+        let mut constraints = vec![];
+        if !self.parser.consume_token(&Token::LParen)
+            || self.parser.consume_token(&Token::RParen)
+        {
+            return Ok((columns, constraints));
+        }
+
+        loop {
+            if let Some(constraint) = self.parser.parse_optional_table_constraint()? {
+                constraints.push(constraint);
+            } else if let Token::Word(_) = self.parser.peek_token() {
+                let column_def = self.parse_column_def()?;
+                columns.push(column_def);
+            } else {
+                return self.expected(
+                    "column name or constraint definition",
+                    self.parser.peek_token(),
+                );
+            }
+            let comma = self.parser.consume_token(&Token::Comma);
+            if self.parser.consume_token(&Token::RParen) {
+                // allow a trailing comma, even though it's not in standard
+                break;
+            } else if !comma {
+                return self.expected(
+                    "',' or ')' after column definition",
+                    self.parser.peek_token(),
+                );
+            }
+        }
+
+        Ok((columns, constraints))
+    }
+
+    fn parse_column_def(&mut self) -> Result<ColumnDef, ParserError> {
+        let name = self.parser.parse_identifier()?;
+        let data_type = self.parser.parse_data_type()?;
+        let collation = if self.parser.parse_keyword(Keyword::COLLATE) {
+            Some(self.parser.parse_object_name()?)
+        } else {
+            None
+        };
+        let mut options = vec![];
+        loop {
+            match self.parser.peek_token() {
+                Token::EOF | Token::Comma | Token::RParen => break,
+                _ => options.push(self.parser.parse_column_option_def()?),
+            }
+        }
+        Ok(ColumnDef {
+            name,
+            data_type,
+            collation,
+            options,
+        })
+    }
+
+    fn parse_create_external_table(&mut self) -> Result<Statement, ParserError> {
+        self.parser.expect_keyword(Keyword::TABLE)?;
+        let table_name = self.parser.parse_object_name()?;
+        let (columns, _) = self.parse_columns()?;
+        self.parser
+            .expect_keywords(&[Keyword::STORED, Keyword::AS])?;
+
+        // THIS is the main difference: we parse a different file format.
+        let file_type = self.parse_file_format()?;
+
+        let has_header = self.parse_csv_has_header();
+
+        self.parser.expect_keyword(Keyword::LOCATION)?;
+        let location = self.parser.parse_literal_string()?;
+
+        Ok(Statement::CreateExternalTable {
+            name: table_name.to_string(),
+            columns,
+            file_type,
+            has_header,
+            location,
+        })
+    }
+
+    /// Parses the set of valid formats
+    fn parse_file_format(&mut self) -> Result<FileType, ParserError> {
+        match self.parser.next_token() {
+            Token::Word(w) => match &*w.value {
+                "PARQUET" => Ok(FileType::Parquet),
+                "NDJSON" => Ok(FileType::NdJson),
+                "CSV" => Ok(FileType::CSV),
+                _ => self.expected("fileformat", Token::Word(w)),
+            },
+            unexpected => self.expected("fileformat", unexpected),
+        }
+    }
+
+    fn consume_token(&mut self, expected: &str) -> bool {
+        if self.parser.peek_token().to_string() == *expected {
+            self.parser.next_token();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn parse_csv_has_header(&mut self) -> bool {
+        self.consume_token("WITH")
+            & self.consume_token("HEADER")
+            & self.consume_token("ROW")
     }
 }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -20,14 +20,18 @@
 use std::sync::Arc;
 
 use crate::error::{ExecutionError, Result};
+use crate::logicalplan::Expr::Alias;
 use crate::logicalplan::{
     lit, Expr, FunctionMeta, LogicalPlan, LogicalPlanBuilder, Operator, ScalarValue,
 };
 
 use arrow::datatypes::*;
 
-use crate::logicalplan::Expr::Alias;
-use sqlparser::sqlast::*;
+use sqlparser::ast::{
+    BinaryOperator, DataType as SQLDataType, Expr as SQLExpr, Query, Select, SelectItem,
+    SetExpr, TableFactor, TableWithJoins, UnaryOperator, Value,
+};
+use sqlparser::ast::{OrderByExpr, Statement};
 
 /// The SchemaProvider trait allows the query planner to obtain meta-data about tables and
 /// functions referenced in SQL statements
@@ -49,87 +53,102 @@ impl<S: SchemaProvider> SqlToRel<S> {
         SqlToRel { schema_provider }
     }
 
-    /// Generate a logic plan from a SQL AST node
-    pub fn sql_to_rel(&self, sql: &ASTNode) -> Result<LogicalPlan> {
-        match *sql {
-            ASTNode::SQLSelect {
-                ref projection,
-                ref relation,
-                ref selection,
-                ref order_by,
-                ref limit,
-                ref group_by,
-                ref having,
-                ..
-            } => {
-                if having.is_some() {
-                    return Err(ExecutionError::NotImplemented(
-                        "HAVING is not implemented yet".to_string(),
-                    ));
-                }
+    /// Generate a logic plan from an SQL statement
+    pub fn statement_to_plan(&self, sql: &Statement) -> Result<LogicalPlan> {
+        match sql {
+            Statement::Query(query) => self.query_to_plan(&query),
+            _ => Err(ExecutionError::NotImplemented(
+                "Only SELECT statements are implemented".to_string(),
+            )),
+        }
+    }
 
-                // parse the input relation so we have access to the row type
-                let plan = match *relation {
-                    Some(ref r) => self.sql_to_rel(r)?,
-                    None => LogicalPlanBuilder::empty().build()?,
-                };
+    /// Generate a logic plan from an SQL query
+    pub fn query_to_plan(&self, query: &Query) -> Result<LogicalPlan> {
+        let plan = match &query.body {
+            SetExpr::Select(s) => self.select_to_plan(s.as_ref()),
+            _ => Err(ExecutionError::NotImplemented(
+                format!("Query {} not implemented yet", query.body).to_owned(),
+            )),
+        }?;
 
-                // selection first
-                let plan = self.filter(&plan, selection)?;
+        let plan = self.order_by(&plan, &query.order_by)?;
 
-                let projection_expr: Vec<Expr> = projection
-                    .iter()
-                    .map(|e| self.sql_to_rex(&e, &plan.schema()))
-                    .collect::<Result<Vec<Expr>>>()?;
+        self.limit(&plan, &query.limit)
+    }
 
-                let aggr_expr: Vec<Expr> = projection_expr
-                    .iter()
-                    .filter(|e| is_aggregate_expr(e))
-                    .map(|e| e.clone())
-                    .collect();
-
-                // apply projection or aggregate
-                let plan = if group_by.is_some() || aggr_expr.len() > 0 {
-                    self.aggregate(&plan, projection_expr, group_by, aggr_expr)?
-                } else {
-                    self.project(&plan, projection_expr)?
-                };
-
-                // apply ORDER BY
-                let plan = self.order_by(&plan, order_by)?;
-
-                // apply LIMIT
-                self.limit(&plan, limit)
-            }
-
-            ASTNode::SQLIdentifier(ref id) => {
-                match self.schema_provider.get_table_meta(id.as_ref()) {
+    fn from_join_to_plan(&self, from: &Vec<TableWithJoins>) -> Result<LogicalPlan> {
+        if from.len() == 0 {
+            return Ok(LogicalPlanBuilder::empty().build()?);
+        }
+        if from.len() != 1 {
+            return Err(ExecutionError::NotImplemented(
+                "FROM with multiple tables is still not implemented".to_string(),
+            ));
+        };
+        let relation = &from[0].relation;
+        match relation {
+            TableFactor::Table { name, .. } => {
+                let name = name.to_string();
+                match self.schema_provider.get_table_meta(&name) {
                     Some(schema) => Ok(LogicalPlanBuilder::scan(
                         "default",
-                        id,
+                        &name,
                         schema.as_ref(),
                         None,
                     )?
                     .build()?),
                     None => Err(ExecutionError::General(format!(
                         "no schema found for table {}",
-                        id
+                        name
                     ))),
                 }
             }
-
-            _ => Err(ExecutionError::ExecutionError(format!(
-                "sql_to_rel does not support this relation: {:?}",
-                sql
-            ))),
+            _ => Err(ExecutionError::NotImplemented(
+                "Subqueries are still not supported".to_string(),
+            )),
         }
+    }
+
+    /// Generate a logic plan from an SQL select
+    fn select_to_plan(&self, select: &Select) -> Result<LogicalPlan> {
+        if select.having.is_some() {
+            return Err(ExecutionError::NotImplemented(
+                "HAVING is not implemented yet".to_string(),
+            ));
+        }
+
+        let plan = self.from_join_to_plan(&select.from)?;
+
+        // selection first
+        let plan = self.filter(&plan, &select.selection)?;
+
+        let projection_expr: Vec<Expr> = select
+            .projection
+            .iter()
+            .map(|e| self.sql_select_to_rex(&e, &plan.schema()))
+            .collect::<Result<Vec<Expr>>>()?;
+
+        let aggr_expr: Vec<Expr> = projection_expr
+            .iter()
+            .filter(|e| is_aggregate_expr(e))
+            .map(|e| e.clone())
+            .collect();
+
+        // apply projection or aggregate
+        let plan = if (select.group_by.len() > 0) | (aggr_expr.len() > 0) {
+            self.aggregate(&plan, projection_expr, &select.group_by, aggr_expr)?
+        } else {
+            self.project(&plan, projection_expr)?
+        };
+        Ok(plan)
     }
 
     /// Apply a filter to the plan
     fn filter(
         &self,
         plan: &LogicalPlan,
-        selection: &Option<Box<ASTNode>>,
+        selection: &Option<SQLExpr>,
     ) -> Result<LogicalPlan> {
         match *selection {
             Some(ref filter_expr) => LogicalPlanBuilder::from(&plan)
@@ -149,16 +168,13 @@ impl<S: SchemaProvider> SqlToRel<S> {
         &self,
         input: &LogicalPlan,
         projection_expr: Vec<Expr>,
-        group_by: &Option<Vec<ASTNode>>,
+        group_by: &Vec<SQLExpr>,
         aggr_expr: Vec<Expr>,
     ) -> Result<LogicalPlan> {
-        let group_expr: Vec<Expr> = match group_by {
-            Some(gbe) => gbe
-                .iter()
-                .map(|e| self.sql_to_rex(&e, &input.schema()))
-                .collect::<Result<Vec<Expr>>>()?,
-            None => vec![],
-        };
+        let group_expr: Vec<Expr> = group_by
+            .iter()
+            .map(|e| self.sql_to_rex(&e, &input.schema()))
+            .collect::<Result<Vec<Expr>>>()?;
 
         let group_by_count = group_expr.len();
         let aggr_count = aggr_expr.len();
@@ -198,11 +214,7 @@ impl<S: SchemaProvider> SqlToRel<S> {
     }
 
     /// Wrap a plan in a limit
-    fn limit(
-        &self,
-        input: &LogicalPlan,
-        limit: &Option<Box<ASTNode>>,
-    ) -> Result<LogicalPlan> {
+    fn limit(&self, input: &LogicalPlan, limit: &Option<SQLExpr>) -> Result<LogicalPlan> {
         match *limit {
             Some(ref limit_expr) => {
                 let n = match self.sql_to_rex(&limit_expr, &input.schema())? {
@@ -221,49 +233,55 @@ impl<S: SchemaProvider> SqlToRel<S> {
     /// Wrap the logical in a sort
     fn order_by(
         &self,
-        group_by_plan: &LogicalPlan,
-        order_by: &Option<Vec<SQLOrderByExpr>>,
+        plan: &LogicalPlan,
+        order_by: &Vec<OrderByExpr>,
     ) -> Result<LogicalPlan> {
-        match *order_by {
-            Some(ref order_by_expr) => {
-                let input_schema = group_by_plan.schema();
-                let order_by_rex: Result<Vec<Expr>> = order_by_expr
-                    .iter()
-                    .map(|e| {
-                        Ok(Expr::Sort {
-                            expr: Box::new(
-                                self.sql_to_rex(&e.expr, &input_schema).unwrap(),
-                            ),
-                            asc: e.asc,
-                            // by default nulls first to be consistent with spark
-                            nulls_first: e.nulls_first.unwrap_or(true),
-                        })
-                    })
-                    .collect();
+        if order_by.len() == 0 {
+            return Ok(plan.clone());
+        }
 
-                LogicalPlanBuilder::from(&group_by_plan)
-                    .sort(order_by_rex?)?
-                    .build()
-            }
-            _ => Ok(group_by_plan.clone()),
+        let input_schema = plan.schema();
+        let order_by_rex: Result<Vec<Expr>> = order_by
+            .iter()
+            .map(|e| {
+                Ok(Expr::Sort {
+                    expr: Box::new(self.sql_to_rex(&e.expr, &input_schema).unwrap()),
+                    // by default asc
+                    asc: e.asc.unwrap_or(true),
+                    // by default nulls first to be consistent with spark
+                    nulls_first: e.nulls_first.unwrap_or(true),
+                })
+            })
+            .collect();
+
+        LogicalPlanBuilder::from(&plan).sort(order_by_rex?)?.build()
+    }
+
+    /// Generate a relational expression from a select SQL expression
+    fn sql_select_to_rex(&self, sql: &SelectItem, schema: &Schema) -> Result<Expr> {
+        match sql {
+            SelectItem::UnnamedExpr(expr) => self.sql_to_rex(expr, schema),
+            SelectItem::ExprWithAlias { expr, alias } => Ok(Alias(
+                Box::new(self.sql_to_rex(&expr, schema)?),
+                alias.value.clone(),
+            )),
+            SelectItem::Wildcard => Ok(Expr::Wildcard),
+            SelectItem::QualifiedWildcard(_) => Err(ExecutionError::NotImplemented(
+                "Qualified wildcards are not supported".to_string(),
+            )),
         }
     }
 
     /// Generate a relational expression from a SQL expression
-    pub fn sql_to_rex(&self, sql: &ASTNode, schema: &Schema) -> Result<Expr> {
-        match *sql {
-            ASTNode::SQLValue(sqlparser::sqlast::Value::Long(n)) => Ok(lit(n)),
-            ASTNode::SQLValue(sqlparser::sqlast::Value::Double(n)) => Ok(lit(n)),
-            ASTNode::SQLValue(sqlparser::sqlast::Value::SingleQuotedString(ref s)) => {
-                Ok(lit(s.clone()))
-            }
+    pub fn sql_to_rex(&self, sql: &SQLExpr, schema: &Schema) -> Result<Expr> {
+        match sql {
+            SQLExpr::Value(Value::Number(n)) => match n.parse::<i64>() {
+                Ok(n) => Ok(lit(n)),
+                Err(_) => Ok(lit(n.parse::<f64>().unwrap())),
+            },
+            SQLExpr::Value(Value::SingleQuotedString(ref s)) => Ok(lit(s.clone())),
 
-            ASTNode::SQLAliasedExpr(ref expr, ref alias) => Ok(Alias(
-                Box::new(self.sql_to_rex(&expr, schema)?),
-                alias.to_owned(),
-            )),
-
-            ASTNode::SQLIdentifier(ref id) => match schema.field_with_name(id) {
+            SQLExpr::Identifier(ref id) => match schema.field_with_name(&id.value) {
                 Ok(field) => Ok(Expr::Column(field.name().clone())),
                 Err(_) => Err(ExecutionError::ExecutionError(format!(
                     "Invalid identifier '{}' for schema {}",
@@ -272,9 +290,9 @@ impl<S: SchemaProvider> SqlToRel<S> {
                 ))),
             },
 
-            ASTNode::SQLWildcard => Ok(Expr::Wildcard),
+            SQLExpr::Wildcard => Ok(Expr::Wildcard),
 
-            ASTNode::SQLCast {
+            SQLExpr::Cast {
                 ref expr,
                 ref data_type,
             } => Ok(Expr::Cast {
@@ -282,19 +300,16 @@ impl<S: SchemaProvider> SqlToRel<S> {
                 data_type: convert_data_type(data_type)?,
             }),
 
-            ASTNode::SQLIsNull(ref expr) => {
+            SQLExpr::IsNull(ref expr) => {
                 Ok(Expr::IsNull(Box::new(self.sql_to_rex(expr, schema)?)))
             }
 
-            ASTNode::SQLIsNotNull(ref expr) => {
+            SQLExpr::IsNotNull(ref expr) => {
                 Ok(Expr::IsNotNull(Box::new(self.sql_to_rex(expr, schema)?)))
             }
 
-            ASTNode::SQLUnary {
-                ref operator,
-                ref expr,
-            } => match *operator {
-                SQLOperator::Not => {
+            SQLExpr::UnaryOp { ref op, ref expr } => match *op {
+                UnaryOperator::Not => {
                     Ok(Expr::Not(Box::new(self.sql_to_rex(expr, schema)?)))
                 }
                 _ => Err(ExecutionError::InternalError(format!(
@@ -302,29 +317,32 @@ impl<S: SchemaProvider> SqlToRel<S> {
                 ))),
             },
 
-            ASTNode::SQLBinaryExpr {
+            SQLExpr::BinaryOp {
                 ref left,
                 ref op,
                 ref right,
             } => {
                 let operator = match *op {
-                    SQLOperator::Gt => Operator::Gt,
-                    SQLOperator::GtEq => Operator::GtEq,
-                    SQLOperator::Lt => Operator::Lt,
-                    SQLOperator::LtEq => Operator::LtEq,
-                    SQLOperator::Eq => Operator::Eq,
-                    SQLOperator::NotEq => Operator::NotEq,
-                    SQLOperator::Plus => Operator::Plus,
-                    SQLOperator::Minus => Operator::Minus,
-                    SQLOperator::Multiply => Operator::Multiply,
-                    SQLOperator::Divide => Operator::Divide,
-                    SQLOperator::Modulus => Operator::Modulus,
-                    SQLOperator::And => Operator::And,
-                    SQLOperator::Or => Operator::Or,
-                    SQLOperator::Not => Operator::Not,
-                    SQLOperator::Like => Operator::Like,
-                    SQLOperator::NotLike => Operator::NotLike,
-                };
+                    BinaryOperator::Gt => Ok(Operator::Gt),
+                    BinaryOperator::GtEq => Ok(Operator::GtEq),
+                    BinaryOperator::Lt => Ok(Operator::Lt),
+                    BinaryOperator::LtEq => Ok(Operator::LtEq),
+                    BinaryOperator::Eq => Ok(Operator::Eq),
+                    BinaryOperator::NotEq => Ok(Operator::NotEq),
+                    BinaryOperator::Plus => Ok(Operator::Plus),
+                    BinaryOperator::Minus => Ok(Operator::Minus),
+                    BinaryOperator::Multiply => Ok(Operator::Multiply),
+                    BinaryOperator::Divide => Ok(Operator::Divide),
+                    BinaryOperator::Modulus => Ok(Operator::Modulus),
+                    BinaryOperator::And => Ok(Operator::And),
+                    BinaryOperator::Or => Ok(Operator::Or),
+                    BinaryOperator::Like => Ok(Operator::Like),
+                    BinaryOperator::NotLike => Ok(Operator::NotLike),
+                    _ => Err(ExecutionError::NotImplemented(format!(
+                        "Unsupported SQL binary operator {:?}",
+                        op
+                    ))),
+                }?;
 
                 match operator {
                     Operator::Not => Err(ExecutionError::InternalError(format!(
@@ -338,15 +356,13 @@ impl<S: SchemaProvider> SqlToRel<S> {
                 }
             }
 
-            //            &ASTNode::SQLOrderBy { ref expr, asc } => Ok(Expr::Sort {
-            //                expr: Box::new(self.sql_to_rex(&expr, &schema)?),
-            //                asc,
-            //            }),
-            ASTNode::SQLFunction { ref id, ref args } => {
+            SQLExpr::Function(function) => {
                 //TODO: fix this hack
-                match id.to_lowercase().as_ref() {
+                let name: String = function.name.to_string();
+                match name.to_lowercase().as_ref() {
                     "min" | "max" | "sum" | "avg" => {
-                        let rex_args = args
+                        let rex_args = function
+                            .args
                             .iter()
                             .map(|a| self.sql_to_rex(a, schema))
                             .collect::<Result<Vec<Expr>>>()?;
@@ -356,32 +372,32 @@ impl<S: SchemaProvider> SqlToRel<S> {
                         let return_type = rex_args[0].get_type(schema)?.clone();
 
                         Ok(Expr::AggregateFunction {
-                            name: id.clone(),
+                            name: name.clone(),
                             args: rex_args,
                             return_type,
                         })
                     }
                     "count" => {
-                        let rex_args = args
+                        let rex_args = function
+                            .args
                             .iter()
                             .map(|a| match a {
-                                ASTNode::SQLValue(sqlparser::sqlast::Value::Long(_)) => {
-                                    Ok(lit(1_u8))
-                                }
-                                ASTNode::SQLWildcard => Ok(lit(1_u8)),
+                                SQLExpr::Value(Value::Number(_)) => Ok(lit(1_u8)),
+                                SQLExpr::Wildcard => Ok(lit(1_u8)),
                                 _ => self.sql_to_rex(a, schema),
                             })
                             .collect::<Result<Vec<Expr>>>()?;
 
                         Ok(Expr::AggregateFunction {
-                            name: id.clone(),
+                            name: name.clone(),
                             args: rex_args,
                             return_type: DataType::UInt64,
                         })
                     }
-                    _ => match self.schema_provider.get_function_meta(id) {
+                    _ => match self.schema_provider.get_function_meta(&name) {
                         Some(fm) => {
-                            let rex_args = args
+                            let rex_args = function
+                                .args
                                 .iter()
                                 .map(|a| self.sql_to_rex(a, schema))
                                 .collect::<Result<Vec<Expr>>>()?;
@@ -395,14 +411,14 @@ impl<S: SchemaProvider> SqlToRel<S> {
                             }
 
                             Ok(Expr::ScalarFunction {
-                                name: id.clone(),
+                                name: name.clone(),
                                 args: safe_args,
                                 return_type: fm.return_type().clone(),
                             })
                         }
                         _ => Err(ExecutionError::General(format!(
                             "Invalid function '{}'",
-                            id
+                            name
                         ))),
                     },
                 }
@@ -425,16 +441,16 @@ fn is_aggregate_expr(e: &Expr) -> bool {
 }
 
 /// Convert SQL data type to relational representation of data type
-pub fn convert_data_type(sql: &SQLType) -> Result<DataType> {
+pub fn convert_data_type(sql: &SQLDataType) -> Result<DataType> {
     match sql {
-        SQLType::Boolean => Ok(DataType::Boolean),
-        SQLType::SmallInt => Ok(DataType::Int16),
-        SQLType::Int => Ok(DataType::Int32),
-        SQLType::BigInt => Ok(DataType::Int64),
-        SQLType::Float(_) | SQLType::Real => Ok(DataType::Float64),
-        SQLType::Double => Ok(DataType::Float64),
-        SQLType::Char(_) | SQLType::Varchar(_) => Ok(DataType::Utf8),
-        SQLType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+        SQLDataType::Boolean => Ok(DataType::Boolean),
+        SQLDataType::SmallInt => Ok(DataType::Int16),
+        SQLDataType::Int => Ok(DataType::Int32),
+        SQLDataType::BigInt => Ok(DataType::Int64),
+        SQLDataType::Float(_) | SQLDataType::Real => Ok(DataType::Float64),
+        SQLDataType::Double => Ok(DataType::Float64),
+        SQLDataType::Char(_) | SQLDataType::Varchar(_) => Ok(DataType::Utf8),
+        SQLDataType::Timestamp => Ok(DataType::Timestamp(TimeUnit::Nanosecond, None)),
         other => Err(ExecutionError::NotImplemented(format!(
             "Unsupported SQL type {:?}",
             other
@@ -447,7 +463,7 @@ mod tests {
 
     use super::*;
     use crate::logicalplan::FunctionType;
-    use sqlparser::sqlparser::*;
+    use sqlparser::{dialect::GenericDialect, parser::Parser};
 
     #[test]
     fn select_no_relation() {
@@ -673,11 +689,10 @@ mod tests {
     }
 
     fn logical_plan(sql: &str) -> Result<LogicalPlan> {
-        use sqlparser::dialect::*;
-        let dialect = GenericSqlDialect {};
+        let dialect = GenericDialect {};
         let planner = SqlToRel::new(MockSchemaProvider {});
-        let ast = Parser::parse_sql(&dialect, sql.to_string()).unwrap();
-        planner.sql_to_rel(&ast)
+        let ast = Parser::parse_sql(&dialect, sql).unwrap();
+        planner.statement_to_plan(&ast[0])
     }
 
     /// Create logical plan, write with formatter, compare to expected output


### PR DESCRIPTION
AFAIK this keeps all functionality that we have available and open the doors to all the goodies of the newer version. There are too many to enumerate here, but the most predominant for me are multi statements and sub-queries.

As a side note, sqlparser is very well designed and easy-to-use, and I am convinced that we should continue to take this dependency. We currently need some custom parsing and it was very easy to understand what I needed to do based on the documentation and their code.

I am not sure this PR keeps the same SQL notation for registering CSV tables: this PR offloads the parsing of the optional schema to sqlparser, and thus if we were accepting non-compliant SQL, then we no longer accept it. I think that the parser would benefit from tests in this area.