### PR TITLE
ARROW-9569: [CI][R] Fix rtools35 builds for msys2 key change

### DIFF
--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -26,6 +26,9 @@ export ARROW_HOME="$(cd "${ARROW_HOME}" && pwd)"
 if [ "$RTOOLS_VERSION" = "35" ]; then
   # Use rtools-backports if building with rtools35
   curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
+  # Update keys: https://www.msys2.org/news/#2020-06-29-new-packagers
+  curl -OSsl "http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz && rm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
   pacman --noconfirm -Scc
   pacman --noconfirm -Syy
   # lib-4.9.3 is for libraries compiled with gcc 4.9 (Rtools 3.5)


### PR DESCRIPTION
Following https://github.com/r-windows/rtools-packages/commit/2babb630c3e0bb9b770463aa0c5a95aa2d5a08cb#diff-fec826feae04e51c0d94076385408bdcR24-R25