### PR TITLE
ARROW-9570: [Doc] Clean up sphinx sidebar

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ such topics as:
 
 .. toctree::
    :maxdepth: 2
-   :caption: Arrow Specifications and Protocols
+   :caption: Specifications and Protocols
 
    format/Versioning
    format/Columnar
@@ -49,7 +49,7 @@ such topics as:
 
 .. toctree::
    :maxdepth: 2
-   :caption: Arrow Libraries
+   :caption: Libraries
 
    status
    C/GLib <https://arrow.apache.org/docs/c_glib/>
@@ -68,7 +68,7 @@ such topics as:
 
 .. toctree::
    :maxdepth: 2
-   :caption: Development and Contributing
+   :caption: Development
 
    developers/contributing
    developers/cpp/index


### PR DESCRIPTION
Saying "Arrow" is redundant and consumes unnecessary screen real estate, leading to: 

![image](https://user-images.githubusercontent.com/2975928/88416853-ca88b700-cd95-11ea-82f8-fe67d80fdf66.png)
