### PR TITLE
ARROW-9585: [Rust][DataFusion] Remove duplicated to-do line

### DIFF
--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -42,7 +42,6 @@ DataFusion includes a simple command-line interactive SQL utility. See the [CLI 
 - [x] SQL Query Planner
 - [x] Query Optimizer
 - [x] Projection push down
-- [x] Projection push down
 - [ ] Predicate push down
 - [x] Type coercion
 - [x] Parallel query execution


### PR DESCRIPTION
Looks like a copy-paste error perhaps; I can't imagine it's intentional.