### PR TITLE
ARROW-9394: [Python] Support pickling of Scalars

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -97,6 +97,9 @@ cdef class Scalar(_Weakrefable):
         cdef CScalarHash hasher
         return hasher(self.wrapped)
 
+    def __reduce__(self):
+        return scalar, (self.as_py(), self.type)
+
     def as_py(self):
         raise NotImplementedError()
 


### PR DESCRIPTION
Since there are no sequence converters available for Dictionary and Union types we cannot construct them directly thus `pa.scalar` fail as the reducer function to reconstruct them.

We can add custom reducers for them later, so I'm leaving them as NotImplemented for now.