### PR TITLE
ARROW-9599: [CI] Appveyor toolchain build fails because CMake detects different C and C++ compilers

### DIFF
--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -61,6 +61,7 @@ if "%JOB%" NEQ "Build_Debug" (
   conda create -n arrow -q -y -c conda-forge ^
     --file=ci\conda_env_python.yml ^
     %CONDA_PACKAGES%  ^
+    "cmake=3.17" ^
     "boost-cpp<1.70" ^
     "ninja" ^
     "nomkl" ^


### PR DESCRIPTION
CMake released 3.18 version two weeks ago. We may want to report this issue upstream, until it is resolved pinning cmake to version 3.17 fixes the toolchain build.