### PR TITLE
ARROW-9600: [Rust][Arrow] pin older version of proc-macro2 during build

### DIFF
--- a/rust/arrow-flight/Cargo.toml
+++ b/rust/arrow-flight/Cargo.toml
@@ -35,8 +35,10 @@ futures = { version = "0.3", default-features = false, features = ["alloc"]}
 
 [build-dependencies]
 tonic-build = "0.2"
+# Pin specific version of the tonic-build dependencies to avoid auto-generated
+# (and checked in) arrow.flight.protocol.rs from changing
+proc-macro2="1.0.18"
 
 [lib]
 name = "flight"
 path = "src/lib.rs"
-


### PR DESCRIPTION
When used as a crate dependency, arrow-flight is rebuilt on every invocation of cargo build

# Repro:

Create a new repo, add `arrow=1.0.0` as a dependency, and then run `cargo build`

*Expected behavior*: After the first successful invocation of `cargo build`, arrow-flight will not recompile if no other changes are made.

*Actual behavior*: After every invocation of `cargo build`, arrow-flight is recompiled, even when nothing has changed

Here is an example:

Create a new crate
```
alamb@ip-192-168-0-129 arrow_rebuilds % cargo new too_many_rebuilds --bin
cargo new too_many_rebuilds --bin
     Created binary (application) `too_many_rebuilds` package
```

Add arrow as a dependency in Cargo.toml:

```
diff --git a/Cargo.toml b/Cargo.toml
index a239680..44ed358 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ authors = ["alamb <andrew@nerdnetworks.org>"]
 edition = "2018"

 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+arrow = "1.0.0"

```
>
Now, all invocations of `cargo build` will rebuild arrow, even though nothing in the code has changed:

```
alamb@ip-192-168-0-129 too_many_rebuilds % cargo build
cargo build
   Compiling arrow-flight v1.0.0
   Compiling arrow v1.0.0
   Compiling too_many_rebuilds v0.1.0 (/Users/alamb/Software/bugs/arrow_rebuilds/too_many_rebuilds)
    Finished dev [unoptimized + debuginfo] target(s) in 8.70s
alamb@ip-192-168-0-129 too_many_rebuilds % cargo build
cargo build
   Compiling arrow-flight v1.0.0
   Compiling arrow v1.0.0
   Compiling too_many_rebuilds v0.1.0 (/Users/alamb/Software/bugs/arrow_rebuilds/too_many_rebuilds)
    Finished dev [unoptimized + debuginfo] target(s) in 8.65s
```
You can see what is happening by checking out a fresh copy of arrow/master (no Cargo.log) and running `cargo build` -- you'll see your local checkout has changes in rust/arrow-flight/src/arrow.flight.protocol.rs:

There is more detail on https://issues.apache.org/jira/browse/ARROW-9600

# Proposed Fix:
This proposed patch pins to the same version of proc-macro2 that was used to create the currently checked in version of rust/arrow-flight/src/arrow.flight.protocol.rs.

Alternately, I could pin to the newer version of proc-macro2 and update the checked in version of rust/arrow-flight/src/arrow.flight.protocol.rs.
