### PR TITLE
ARROW-9604: [C++] Add aggregate min/max benchmark

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
@@ -369,5 +369,51 @@ MODE_KERNEL_BENCHMARK(ModeKernelInt16, Int16Type);
 MODE_KERNEL_BENCHMARK(ModeKernelInt32, Int32Type);
 MODE_KERNEL_BENCHMARK(ModeKernelInt64, Int64Type);
 
+template <typename ArrowType>
+static void MinMaxKernelBench(benchmark::State& state) {
+  using CType = typename TypeTraits<ArrowType>::CType;
+
+  RegressionArgs args(state);
+  const int64_t array_size = args.size / sizeof(CType);
+  auto rand = random::RandomArrayGenerator(1923);
+  auto array = rand.Numeric<ArrowType>(array_size, -100, 100, args.null_proportion);
+
+  for (auto _ : state) {
+    ABORT_NOT_OK(MinMax(array).status());
+  }
+}
+
+static void MinMaxKernelBenchArgs(benchmark::internal::Benchmark* bench) {
+  BenchmarkSetArgsWithSizes(bench, {1 * 1024 * 1024});  // 1M
+}
+
+#define MINMAX_KERNEL_BENCHMARK(FuncName, Type)                                     \
+  static void FuncName(benchmark::State& state) { MinMaxKernelBench<Type>(state); } \
+  BENCHMARK(FuncName)->Apply(MinMaxKernelBenchArgs)
+
+MINMAX_KERNEL_BENCHMARK(MinMaxKernelFloat, FloatType);
+MINMAX_KERNEL_BENCHMARK(MinMaxKernelDouble, DoubleType);
+MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt8, Int8Type);
+MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt16, Int16Type);
+MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt32, Int32Type);
+MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt64, Int64Type);
+
+static void CountKernelInt64(benchmark::State& state) {
+  RegressionArgs args(state);
+  const int64_t array_size = args.size / sizeof(int64_t);
+  auto rand = random::RandomArrayGenerator(1923);
+  auto array = rand.Numeric<Int64Type>(array_size, -100, 100, args.null_proportion);
+
+  for (auto _ : state) {
+    ABORT_NOT_OK(Count(array).status());
+  }
+}
+
+static void CountKernelBenchArgs(benchmark::internal::Benchmark* bench) {
+  BenchmarkSetArgsWithSizes(bench, {1 * 1024 * 1024});  // 1M
+}
+
+BENCHMARK(CountKernelInt64)->Apply(CountKernelBenchArgs);
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
@@ -398,22 +398,5 @@ MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt16, Int16Type);
 MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt32, Int32Type);
 MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt64, Int64Type);
 
-static void CountKernelInt64(benchmark::State& state) {
-  RegressionArgs args(state);
-  const int64_t array_size = args.size / sizeof(int64_t);
-  auto rand = random::RandomArrayGenerator(1923);
-  auto array = rand.Numeric<Int64Type>(array_size, -100, 100, args.null_proportion);
-
-  for (auto _ : state) {
-    ABORT_NOT_OK(Count(array).status());
-  }
-}
-
-static void CountKernelBenchArgs(benchmark::internal::Benchmark* bench) {
-  BenchmarkSetArgsWithSizes(bench, {1 * 1024 * 1024});  // 1M
-}
-
-BENCHMARK(CountKernelInt64)->Apply(CountKernelBenchArgs);
-
 }  // namespace compute
 }  // namespace arrow


### PR DESCRIPTION
Add benchmark for aggregate min/max compute kernels

Signed-off-by: Frank Du <frank.du@intel.com>