### PR TITLE
ARROW-9608: [Rust] Leaner feature gating for arrow in parquet

### DIFF
--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -39,7 +39,7 @@ lz4 = { version = "1.23", optional = true }
 zstd = { version = "0.5", optional = true }
 chrono = "0.4"
 num-bigint = "0.3"
-arrow = { path = "../arrow", version = "2.0.0-SNAPSHOT", optional = true }
+arrow = { path = "../arrow", version = "2.0.0-SNAPSHOT", optional = true, default-features = false }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [dev-dependencies]
@@ -49,7 +49,6 @@ brotli = "3.3"
 flate2 = "1.0"
 lz4 = "1.23"
 zstd = "0.5"
-arrow = { path = "../arrow", version = "2.0.0-SNAPSHOT" }
 
 [features]
 default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd"]


### PR DESCRIPTION
Currently, the parquet is installing arrow-flight and it's dependencies, which breaks the CI builds and it's unnecessary because it is not used. Parquet should work without default features of `arrow` by default. Simple PR will enable building it leaner.