### PR TITLE
ARROW-9582: [Rust] Implement memory size methods

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -215,10 +215,10 @@ pub trait Array: fmt::Debug + Send + Sync + ArrayEqual + JsonEqual {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this array.
-    fn buffer_memory_size(&self) -> usize;
+    fn memory_used(&self) -> usize;
 
     /// Returns the total number of bytes of memory occupied physically by this array.
-    fn total_memory_size(&self) -> usize;
+    fn memory_capacity(&self) -> usize;
 }
 
 /// A reference-counted reference to a generic `Array`.
@@ -451,13 +451,13 @@ impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [PrimitiveArray].
-    fn buffer_memory_size(&self) -> usize {
-        self.data.buffer_memory_size()
+    fn memory_used(&self) -> usize {
+        self.data.memory_used()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [PrimitiveArray].
-    fn total_memory_size(&self) -> usize {
-        self.data.total_memory_size() + mem::size_of_val(self)
+    fn memory_capacity(&self) -> usize {
+        self.data.memory_capacity() + mem::size_of_val(self)
     }
 }
 
@@ -1186,13 +1186,13 @@ impl Array for ListArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [ListArray].
-    fn buffer_memory_size(&self) -> usize {
-        self.data.buffer_memory_size()
+    fn memory_used(&self) -> usize {
+        self.data.memory_used()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [ListArray].
-    fn total_memory_size(&self) -> usize {
-        self.data.total_memory_size() + mem::size_of_val(self)
+    fn memory_capacity(&self) -> usize {
+        self.data.memory_capacity() + mem::size_of_val(self)
     }
 }
 
@@ -1210,14 +1210,14 @@ impl Array for LargeListArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [LargeListArray].
-    fn buffer_memory_size(&self) -> usize {
-        self.data.buffer_memory_size() + self.values().buffer_memory_size()
+    fn memory_used(&self) -> usize {
+        self.data.memory_used() + self.values().memory_used()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [LargeListArray].
-    fn total_memory_size(&self) -> usize {
-        self.data.total_memory_size()
-            + self.values().total_memory_size()
+    fn memory_capacity(&self) -> usize {
+        self.data.memory_capacity()
+            + self.values().memory_capacity()
             + mem::size_of_val(self)
     }
 }
@@ -1372,14 +1372,14 @@ impl Array for FixedSizeListArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [FixedSizeListArray].
-    fn buffer_memory_size(&self) -> usize {
-        self.data.buffer_memory_size() + self.values().buffer_memory_size()
+    fn memory_used(&self) -> usize {
+        self.data.memory_used() + self.values().memory_used()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [FixedSizeListArray].
-    fn total_memory_size(&self) -> usize {
-        self.data.total_memory_size()
-            + self.values().total_memory_size()
+    fn memory_capacity(&self) -> usize {
+        self.data.memory_capacity()
+            + self.values().memory_capacity()
             + mem::size_of_val(self)
     }
 }
@@ -1450,13 +1450,13 @@ macro_rules! make_binary_type {
             }
 
             /// Returns the total number of bytes of memory occupied by the buffers owned by this [$name].
-            fn buffer_memory_size(&self) -> usize {
-                self.data.buffer_memory_size()
+            fn memory_used(&self) -> usize {
+                self.data.memory_used()
             }
 
             /// Returns the total number of bytes of memory occupied physically by this [$name].
-            fn total_memory_size(&self) -> usize {
-                self.data.total_memory_size() + mem::size_of_val(self)
+            fn memory_capacity(&self) -> usize {
+                self.data.memory_capacity() + mem::size_of_val(self)
             }
         }
     };
@@ -2015,13 +2015,13 @@ impl Array for FixedSizeBinaryArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [FixedSizeBinaryArray].
-    fn buffer_memory_size(&self) -> usize {
-        self.data.buffer_memory_size()
+    fn memory_used(&self) -> usize {
+        self.data.memory_used()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [FixedSizeBinaryArray].
-    fn total_memory_size(&self) -> usize {
-        self.data.total_memory_size() + mem::size_of_val(self)
+    fn memory_capacity(&self) -> usize {
+        self.data.memory_capacity() + mem::size_of_val(self)
     }
 }
 
@@ -2107,13 +2107,13 @@ impl Array for StructArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [StructArray].
-    fn buffer_memory_size(&self) -> usize {
-        self.data.buffer_memory_size()
+    fn memory_used(&self) -> usize {
+        self.data.memory_used()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [StructArray].
-    fn total_memory_size(&self) -> usize {
-        self.data.total_memory_size() + mem::size_of_val(self)
+    fn memory_capacity(&self) -> usize {
+        self.data.memory_capacity() + mem::size_of_val(self)
     }
 }
 
@@ -2415,14 +2415,14 @@ impl<T: ArrowPrimitiveType> Array for DictionaryArray<T> {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [DictionaryArray].
-    fn buffer_memory_size(&self) -> usize {
-        self.data.buffer_memory_size() + self.values().buffer_memory_size()
+    fn memory_used(&self) -> usize {
+        self.data.memory_used() + self.values().memory_used()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [DictionaryArray].
-    fn total_memory_size(&self) -> usize {
-        self.data.total_memory_size()
-            + self.values().total_memory_size()
+    fn memory_capacity(&self) -> usize {
+        self.data.memory_capacity()
+            + self.values().memory_capacity()
             + mem::size_of_val(self)
     }
 }
@@ -2472,11 +2472,11 @@ mod tests {
             assert_eq!(i as i32, arr.value(i));
         }
 
-        assert_eq!(64, arr.buffer_memory_size());
+        assert_eq!(64, arr.memory_used());
         let internals_of_primitive_array = 8 + 72; // RawPtrBox & Arc<ArrayData> combined.
         assert_eq!(
-            arr.buffer_memory_size() + internals_of_primitive_array,
-            arr.total_memory_size()
+            arr.memory_used() + internals_of_primitive_array,
+            arr.memory_capacity()
         );
     }
 
@@ -2498,11 +2498,11 @@ mod tests {
             }
         }
 
-        assert_eq!(128, arr.buffer_memory_size());
+        assert_eq!(128, arr.memory_used());
         let internals_of_primitive_array = 8 + 72 + 16; // RawPtrBox & Arc<ArrayData> and it's null_bitmap combined.
         assert_eq!(
-            arr.buffer_memory_size() + internals_of_primitive_array,
-            arr.total_memory_size()
+            arr.memory_used() + internals_of_primitive_array,
+            arr.memory_capacity()
         );
     }
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -215,10 +215,10 @@ pub trait Array: fmt::Debug + Send + Sync + ArrayEqual + JsonEqual {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this array.
-    fn memory_used(&self) -> usize;
+    fn get_buffer_memory_size(&self) -> usize;
 
     /// Returns the total number of bytes of memory occupied physically by this array.
-    fn memory_capacity(&self) -> usize;
+    fn get_array_memory_size(&self) -> usize;
 }
 
 /// A reference-counted reference to a generic `Array`.
@@ -451,13 +451,13 @@ impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [PrimitiveArray].
-    fn memory_used(&self) -> usize {
-        self.data.memory_used()
+    fn get_buffer_memory_size(&self) -> usize {
+        self.data.get_buffer_memory_size()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [PrimitiveArray].
-    fn memory_capacity(&self) -> usize {
-        self.data.memory_capacity() + mem::size_of_val(self)
+    fn get_array_memory_size(&self) -> usize {
+        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 
@@ -1186,13 +1186,13 @@ impl Array for ListArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [ListArray].
-    fn memory_used(&self) -> usize {
-        self.data.memory_used()
+    fn get_buffer_memory_size(&self) -> usize {
+        self.data.get_buffer_memory_size()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [ListArray].
-    fn memory_capacity(&self) -> usize {
-        self.data.memory_capacity() + mem::size_of_val(self)
+    fn get_array_memory_size(&self) -> usize {
+        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 
@@ -1210,14 +1210,14 @@ impl Array for LargeListArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [LargeListArray].
-    fn memory_used(&self) -> usize {
-        self.data.memory_used() + self.values().memory_used()
+    fn get_buffer_memory_size(&self) -> usize {
+        self.data.get_buffer_memory_size() + self.values().get_buffer_memory_size()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [LargeListArray].
-    fn memory_capacity(&self) -> usize {
-        self.data.memory_capacity()
-            + self.values().memory_capacity()
+    fn get_array_memory_size(&self) -> usize {
+        self.data.get_array_memory_size()
+            + self.values().get_array_memory_size()
             + mem::size_of_val(self)
     }
 }
@@ -1372,14 +1372,14 @@ impl Array for FixedSizeListArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [FixedSizeListArray].
-    fn memory_used(&self) -> usize {
-        self.data.memory_used() + self.values().memory_used()
+    fn get_buffer_memory_size(&self) -> usize {
+        self.data.get_buffer_memory_size() + self.values().get_buffer_memory_size()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [FixedSizeListArray].
-    fn memory_capacity(&self) -> usize {
-        self.data.memory_capacity()
-            + self.values().memory_capacity()
+    fn get_array_memory_size(&self) -> usize {
+        self.data.get_array_memory_size()
+            + self.values().get_array_memory_size()
             + mem::size_of_val(self)
     }
 }
@@ -1450,13 +1450,13 @@ macro_rules! make_binary_type {
             }
 
             /// Returns the total number of bytes of memory occupied by the buffers owned by this [$name].
-            fn memory_used(&self) -> usize {
-                self.data.memory_used()
+            fn get_buffer_memory_size(&self) -> usize {
+                self.data.get_buffer_memory_size()
             }
 
             /// Returns the total number of bytes of memory occupied physically by this [$name].
-            fn memory_capacity(&self) -> usize {
-                self.data.memory_capacity() + mem::size_of_val(self)
+            fn get_array_memory_size(&self) -> usize {
+                self.data.get_array_memory_size() + mem::size_of_val(self)
             }
         }
     };
@@ -2015,13 +2015,13 @@ impl Array for FixedSizeBinaryArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [FixedSizeBinaryArray].
-    fn memory_used(&self) -> usize {
-        self.data.memory_used()
+    fn get_buffer_memory_size(&self) -> usize {
+        self.data.get_buffer_memory_size()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [FixedSizeBinaryArray].
-    fn memory_capacity(&self) -> usize {
-        self.data.memory_capacity() + mem::size_of_val(self)
+    fn get_array_memory_size(&self) -> usize {
+        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 
@@ -2107,13 +2107,13 @@ impl Array for StructArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [StructArray].
-    fn memory_used(&self) -> usize {
-        self.data.memory_used()
+    fn get_buffer_memory_size(&self) -> usize {
+        self.data.get_buffer_memory_size()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [StructArray].
-    fn memory_capacity(&self) -> usize {
-        self.data.memory_capacity() + mem::size_of_val(self)
+    fn get_array_memory_size(&self) -> usize {
+        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 
@@ -2415,14 +2415,14 @@ impl<T: ArrowPrimitiveType> Array for DictionaryArray<T> {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [DictionaryArray].
-    fn memory_used(&self) -> usize {
-        self.data.memory_used() + self.values().memory_used()
+    fn get_buffer_memory_size(&self) -> usize {
+        self.data.get_buffer_memory_size() + self.values().get_buffer_memory_size()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [DictionaryArray].
-    fn memory_capacity(&self) -> usize {
-        self.data.memory_capacity()
-            + self.values().memory_capacity()
+    fn get_array_memory_size(&self) -> usize {
+        self.data.get_array_memory_size()
+            + self.values().get_array_memory_size()
             + mem::size_of_val(self)
     }
 }
@@ -2472,11 +2472,11 @@ mod tests {
             assert_eq!(i as i32, arr.value(i));
         }
 
-        assert_eq!(64, arr.memory_used());
+        assert_eq!(64, arr.get_buffer_memory_size());
         let internals_of_primitive_array = 8 + 72; // RawPtrBox & Arc<ArrayData> combined.
         assert_eq!(
-            arr.memory_used() + internals_of_primitive_array,
-            arr.memory_capacity()
+            arr.get_buffer_memory_size() + internals_of_primitive_array,
+            arr.get_array_memory_size()
         );
     }
 
@@ -2498,11 +2498,11 @@ mod tests {
             }
         }
 
-        assert_eq!(128, arr.memory_used());
+        assert_eq!(128, arr.get_buffer_memory_size());
         let internals_of_primitive_array = 8 + 72 + 16; // RawPtrBox & Arc<ArrayData> and it's null_bitmap combined.
         assert_eq!(
-            arr.memory_used() + internals_of_primitive_array,
-            arr.memory_capacity()
+            arr.get_buffer_memory_size() + internals_of_primitive_array,
+            arr.get_array_memory_size()
         );
     }
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -213,6 +213,12 @@ pub trait Array: fmt::Debug + Send + Sync + ArrayEqual + JsonEqual {
     fn null_count(&self) -> usize {
         self.data().null_count()
     }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this array.
+    fn buffer_memory_size(&self) -> usize;
+
+    /// Returns the total number of bytes of memory occupied physically by this array.
+    fn total_memory_size(&self) -> usize;
 }
 
 /// A reference-counted reference to a generic `Array`.
@@ -442,6 +448,16 @@ impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
 
     fn data_ref(&self) -> &ArrayDataRef {
         &self.data
+    }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [PrimitiveArray].
+    fn buffer_memory_size(&self) -> usize {
+        self.data.buffer_memory_size()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [PrimitiveArray].
+    fn total_memory_size(&self) -> usize {
+        self.data.total_memory_size() + mem::size_of_val(self)
     }
 }
 
@@ -1168,6 +1184,16 @@ impl Array for ListArray {
     fn data_ref(&self) -> &ArrayDataRef {
         &self.data
     }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [ListArray].
+    fn buffer_memory_size(&self) -> usize {
+        self.data.buffer_memory_size()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [ListArray].
+    fn total_memory_size(&self) -> usize {
+        self.data.total_memory_size() + mem::size_of_val(self)
+    }
 }
 
 impl Array for LargeListArray {
@@ -1181,6 +1207,18 @@ impl Array for LargeListArray {
 
     fn data_ref(&self) -> &ArrayDataRef {
         &self.data
+    }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [LargeListArray].
+    fn buffer_memory_size(&self) -> usize {
+        self.data.buffer_memory_size() + self.values().buffer_memory_size()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [LargeListArray].
+    fn total_memory_size(&self) -> usize {
+        self.data.total_memory_size()
+            + self.values().total_memory_size()
+            + mem::size_of_val(self)
     }
 }
 
@@ -1332,6 +1370,18 @@ impl Array for FixedSizeListArray {
     fn data_ref(&self) -> &ArrayDataRef {
         &self.data
     }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [FixedSizeListArray].
+    fn buffer_memory_size(&self) -> usize {
+        self.data.buffer_memory_size() + self.values().buffer_memory_size()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [FixedSizeListArray].
+    fn total_memory_size(&self) -> usize {
+        self.data.total_memory_size()
+            + self.values().total_memory_size()
+            + mem::size_of_val(self)
+    }
 }
 
 impl fmt::Debug for FixedSizeListArray {
@@ -1397,6 +1447,16 @@ macro_rules! make_binary_type {
 
             fn data_ref(&self) -> &ArrayDataRef {
                 &self.data
+            }
+
+            /// Returns the total number of bytes of memory occupied by the buffers owned by this [$name].
+            fn buffer_memory_size(&self) -> usize {
+                self.data.buffer_memory_size()
+            }
+
+            /// Returns the total number of bytes of memory occupied physically by this [$name].
+            fn total_memory_size(&self) -> usize {
+                self.data.total_memory_size() + mem::size_of_val(self)
             }
         }
     };
@@ -1953,6 +2013,16 @@ impl Array for FixedSizeBinaryArray {
     fn data_ref(&self) -> &ArrayDataRef {
         &self.data
     }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [FixedSizeBinaryArray].
+    fn buffer_memory_size(&self) -> usize {
+        self.data.buffer_memory_size()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [FixedSizeBinaryArray].
+    fn total_memory_size(&self) -> usize {
+        self.data.total_memory_size() + mem::size_of_val(self)
+    }
 }
 
 /// A nested array type where each child (called *field*) is represented by a separate
@@ -2034,6 +2104,16 @@ impl Array for StructArray {
     /// Returns the length (i.e., number of elements) of this array
     fn len(&self) -> usize {
         self.data().len()
+    }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [StructArray].
+    fn buffer_memory_size(&self) -> usize {
+        self.data.buffer_memory_size()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [StructArray].
+    fn total_memory_size(&self) -> usize {
+        self.data.total_memory_size() + mem::size_of_val(self)
     }
 }
 
@@ -2333,6 +2413,18 @@ impl<T: ArrowPrimitiveType> Array for DictionaryArray<T> {
     fn data_ref(&self) -> &ArrayDataRef {
         &self.data
     }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [DictionaryArray].
+    fn buffer_memory_size(&self) -> usize {
+        self.data.buffer_memory_size() + self.values().buffer_memory_size()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [DictionaryArray].
+    fn total_memory_size(&self) -> usize {
+        self.data.total_memory_size()
+            + self.values().total_memory_size()
+            + mem::size_of_val(self)
+    }
 }
 
 impl<T: ArrowPrimitiveType> fmt::Debug for DictionaryArray<T> {
@@ -2379,6 +2471,13 @@ mod tests {
             assert!(arr.is_valid(i));
             assert_eq!(i as i32, arr.value(i));
         }
+
+        assert_eq!(64, arr.buffer_memory_size());
+        let internals_of_primitive_array = 8 + 72; // RawPtrBox & Arc<ArrayData> combined.
+        assert_eq!(
+            arr.buffer_memory_size() + internals_of_primitive_array,
+            arr.total_memory_size()
+        );
     }
 
     #[test]
@@ -2398,6 +2497,13 @@ mod tests {
                 assert!(!arr.is_valid(i));
             }
         }
+
+        assert_eq!(128, arr.buffer_memory_size());
+        let internals_of_primitive_array = 8 + 72 + 16; // RawPtrBox & Arc<ArrayData> and it's null_bitmap combined.
+        assert_eq!(
+            arr.buffer_memory_size() + internals_of_primitive_array,
+            arr.total_memory_size()
+        );
     }
 
     #[test]

--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -162,24 +162,24 @@ impl ArrayData {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [ArrayData].
-    pub fn memory_used(&self) -> usize {
+    pub fn get_buffer_memory_size(&self) -> usize {
         let mut size = 0;
         for buffer in &self.buffers {
             size += buffer.capacity();
         }
         if let Some(bitmap) = &self.null_bitmap {
-            size += bitmap.memory_used()
+            size += bitmap.get_buffer_memory_size()
         }
         for child in &self.child_data {
-            size += child.memory_used();
+            size += child.get_buffer_memory_size();
         }
         size
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [ArrayData].
-    pub fn memory_capacity(&self) -> usize {
+    pub fn get_array_memory_size(&self) -> usize {
         let mut size = 0;
-        // Calculate size of the fields that don't have [memory_capacity] method internally.
+        // Calculate size of the fields that don't have [get_array_memory_size] method internally.
         size += mem::size_of_val(self)
             - mem::size_of_val(&self.buffers)
             - mem::size_of_val(&self.null_bitmap)
@@ -191,10 +191,10 @@ impl ArrayData {
             size += buffer.capacity();
         }
         if let Some(bitmap) = &self.null_bitmap {
-            size += bitmap.memory_capacity()
+            size += bitmap.get_array_memory_size()
         }
         for child in &self.child_data {
-            size += child.memory_capacity();
+            size += child.get_array_memory_size();
         }
 
         size

--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -162,24 +162,24 @@ impl ArrayData {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [ArrayData].
-    pub fn buffer_memory_size(&self) -> usize {
+    pub fn memory_used(&self) -> usize {
         let mut size = 0;
         for buffer in &self.buffers {
             size += buffer.capacity();
         }
         if let Some(bitmap) = &self.null_bitmap {
-            size += bitmap.buffer_memory_size()
+            size += bitmap.memory_used()
         }
         for child in &self.child_data {
-            size += child.buffer_memory_size();
+            size += child.memory_used();
         }
         size
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [ArrayData].
-    pub fn total_memory_size(&self) -> usize {
+    pub fn memory_capacity(&self) -> usize {
         let mut size = 0;
-        // Calculate size of the fields that don't have [total_memory_size] method internally.
+        // Calculate size of the fields that don't have [memory_capacity] method internally.
         size += mem::size_of_val(self)
             - mem::size_of_val(&self.buffers)
             - mem::size_of_val(&self.null_bitmap)
@@ -191,10 +191,10 @@ impl ArrayData {
             size += buffer.capacity();
         }
         if let Some(bitmap) = &self.null_bitmap {
-            size += bitmap.total_memory_size()
+            size += bitmap.memory_capacity()
         }
         for child in &self.child_data {
-            size += child.total_memory_size();
+            size += child.memory_capacity();
         }
 
         size

--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -18,6 +18,7 @@
 //! Contains `ArrayData`, a generic representation of Arrow array data which encapsulates
 //! common attributes and operations for Arrow array.
 
+use std::mem;
 use std::sync::Arc;
 
 use crate::bitmap::Bitmap;
@@ -158,6 +159,45 @@ impl ArrayData {
     /// Returns the total number of nulls in this array
     pub fn null_count(&self) -> usize {
         self.null_count
+    }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [ArrayData].
+    pub fn buffer_memory_size(&self) -> usize {
+        let mut size = 0;
+        for buffer in &self.buffers {
+            size += buffer.capacity();
+        }
+        if let Some(bitmap) = &self.null_bitmap {
+            size += bitmap.buffer_memory_size()
+        }
+        for child in &self.child_data {
+            size += child.buffer_memory_size();
+        }
+        size
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [ArrayData].
+    pub fn total_memory_size(&self) -> usize {
+        let mut size = 0;
+        // Calculate size of the fields that don't have [total_memory_size] method internally.
+        size += mem::size_of_val(self)
+            - mem::size_of_val(&self.buffers)
+            - mem::size_of_val(&self.null_bitmap)
+            - mem::size_of_val(&self.child_data);
+
+        // Calculate rest of the fields top down which contain actual data
+        for buffer in &self.buffers {
+            size += mem::size_of_val(&buffer);
+            size += buffer.capacity();
+        }
+        if let Some(bitmap) = &self.null_bitmap {
+            size += bitmap.total_memory_size()
+        }
+        for child in &self.child_data {
+            size += child.total_memory_size();
+        }
+
+        size
     }
 }
 

--- a/rust/arrow/src/array/null.rs
+++ b/rust/arrow/src/array/null.rs
@@ -86,13 +86,13 @@ impl Array for NullArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [NullArray].
-    fn memory_used(&self) -> usize {
-        self.data.memory_used()
+    fn get_buffer_memory_size(&self) -> usize {
+        self.data.get_buffer_memory_size()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [NullArray].
-    fn memory_capacity(&self) -> usize {
-        self.data.memory_capacity() + mem::size_of_val(self)
+    fn get_array_memory_size(&self) -> usize {
+        self.data.get_array_memory_size() + mem::size_of_val(self)
     }
 }
 
@@ -129,11 +129,11 @@ mod tests {
         assert_eq!(null_arr.null_count(), 32);
         assert_eq!(null_arr.is_valid(0), false);
 
-        assert_eq!(0, null_arr.memory_used());
+        assert_eq!(0, null_arr.get_buffer_memory_size());
         let internals_of_null_array = 64; // Arc<ArrayData>
         assert_eq!(
-            null_arr.memory_used() + internals_of_null_array,
-            null_arr.memory_capacity()
+            null_arr.get_buffer_memory_size() + internals_of_null_array,
+            null_arr.get_array_memory_size()
         );
     }
 

--- a/rust/arrow/src/array/null.rs
+++ b/rust/arrow/src/array/null.rs
@@ -36,6 +36,7 @@
 
 use std::any::Any;
 use std::fmt;
+use std::mem;
 
 use crate::array::{Array, ArrayData, ArrayDataRef};
 use crate::datatypes::*;
@@ -83,6 +84,16 @@ impl Array for NullArray {
     fn null_count(&self) -> usize {
         self.data().len()
     }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [NullArray].
+    fn buffer_memory_size(&self) -> usize {
+        self.data.buffer_memory_size()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [NullArray].
+    fn total_memory_size(&self) -> usize {
+        self.data.total_memory_size() + mem::size_of_val(self)
+    }
 }
 
 impl From<ArrayDataRef> for NullArray {
@@ -112,11 +123,18 @@ mod tests {
 
     #[test]
     fn test_null_array() {
-        let array1 = NullArray::new(32);
+        let null_arr = NullArray::new(32);
 
-        assert_eq!(array1.len(), 32);
-        assert_eq!(array1.null_count(), 32);
-        assert_eq!(array1.is_valid(0), false);
+        assert_eq!(null_arr.len(), 32);
+        assert_eq!(null_arr.null_count(), 32);
+        assert_eq!(null_arr.is_valid(0), false);
+
+        assert_eq!(0, null_arr.buffer_memory_size());
+        let internals_of_null_array = 64; // Arc<ArrayData>
+        assert_eq!(
+            null_arr.buffer_memory_size() + internals_of_null_array,
+            null_arr.total_memory_size()
+        );
     }
 
     #[test]

--- a/rust/arrow/src/array/null.rs
+++ b/rust/arrow/src/array/null.rs
@@ -86,13 +86,13 @@ impl Array for NullArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [NullArray].
-    fn buffer_memory_size(&self) -> usize {
-        self.data.buffer_memory_size()
+    fn memory_used(&self) -> usize {
+        self.data.memory_used()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [NullArray].
-    fn total_memory_size(&self) -> usize {
-        self.data.total_memory_size() + mem::size_of_val(self)
+    fn memory_capacity(&self) -> usize {
+        self.data.memory_capacity() + mem::size_of_val(self)
     }
 }
 
@@ -129,11 +129,11 @@ mod tests {
         assert_eq!(null_arr.null_count(), 32);
         assert_eq!(null_arr.is_valid(0), false);
 
-        assert_eq!(0, null_arr.buffer_memory_size());
+        assert_eq!(0, null_arr.memory_used());
         let internals_of_null_array = 64; // Arc<ArrayData>
         assert_eq!(
-            null_arr.buffer_memory_size() + internals_of_null_array,
-            null_arr.total_memory_size()
+            null_arr.memory_used() + internals_of_null_array,
+            null_arr.memory_capacity()
         );
     }
 

--- a/rust/arrow/src/array/union.rs
+++ b/rust/arrow/src/array/union.rs
@@ -299,20 +299,20 @@ impl Array for UnionArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [UnionArray].
-    fn memory_used(&self) -> usize {
-        let mut size = self.data.memory_used();
+    fn get_buffer_memory_size(&self) -> usize {
+        let mut size = self.data.get_buffer_memory_size();
         for field in &self.boxed_fields {
-            size += field.memory_used();
+            size += field.get_buffer_memory_size();
         }
         size
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [UnionArray].
-    fn memory_capacity(&self) -> usize {
-        let mut size = self.data.memory_capacity();
+    fn get_array_memory_size(&self) -> usize {
+        let mut size = self.data.get_array_memory_size();
         size += mem::size_of_val(self) - mem::size_of_val(&self.boxed_fields);
         for field in &self.boxed_fields {
-            size += field.memory_capacity();
+            size += field.get_array_memory_size();
         }
         size
     }
@@ -696,11 +696,14 @@ mod tests {
             assert_eq!(expected_value, &value);
         }
 
-        assert_eq!(4 * 8 * 4 * mem::size_of::<i32>(), union.memory_used());
+        assert_eq!(
+            4 * 8 * 4 * mem::size_of::<i32>(),
+            union.get_buffer_memory_size()
+        );
         let internals_of_union_array = (8 + 72) + (union.boxed_fields.len() * 144); // Arc<ArrayData> & Vec<ArrayRef> combined.
         assert_eq!(
-            union.memory_used() + internals_of_union_array,
-            union.memory_capacity()
+            union.get_buffer_memory_size() + internals_of_union_array,
+            union.get_array_memory_size()
         );
     }
 

--- a/rust/arrow/src/array/union.rs
+++ b/rust/arrow/src/array/union.rs
@@ -299,20 +299,20 @@ impl Array for UnionArray {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [UnionArray].
-    fn buffer_memory_size(&self) -> usize {
-        let mut size = self.data.buffer_memory_size();
+    fn memory_used(&self) -> usize {
+        let mut size = self.data.memory_used();
         for field in &self.boxed_fields {
-            size += field.buffer_memory_size();
+            size += field.memory_used();
         }
         size
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [UnionArray].
-    fn total_memory_size(&self) -> usize {
-        let mut size = self.data.total_memory_size();
+    fn memory_capacity(&self) -> usize {
+        let mut size = self.data.memory_capacity();
         size += mem::size_of_val(self) - mem::size_of_val(&self.boxed_fields);
         for field in &self.boxed_fields {
-            size += field.total_memory_size();
+            size += field.memory_capacity();
         }
         size
     }
@@ -696,14 +696,11 @@ mod tests {
             assert_eq!(expected_value, &value);
         }
 
-        assert_eq!(
-            4 * 8 * 4 * mem::size_of::<i32>(),
-            union.buffer_memory_size()
-        );
+        assert_eq!(4 * 8 * 4 * mem::size_of::<i32>(), union.memory_used());
         let internals_of_union_array = (8 + 72) + (union.boxed_fields.len() * 144); // Arc<ArrayData> & Vec<ArrayRef> combined.
         assert_eq!(
-            union.buffer_memory_size() + internals_of_union_array,
-            union.total_memory_size()
+            union.memory_used() + internals_of_union_array,
+            union.memory_capacity()
         );
     }
 

--- a/rust/arrow/src/array/union.rs
+++ b/rust/arrow/src/array/union.rs
@@ -86,6 +86,7 @@ use crate::util::bit_util;
 use core::fmt;
 use std::any::Any;
 use std::collections::HashMap;
+use std::mem;
 use std::mem::size_of;
 
 /// An Array that can represent slots of varying types
@@ -295,6 +296,25 @@ impl Array for UnionArray {
 
     fn data_ref(&self) -> &ArrayDataRef {
         &self.data
+    }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [UnionArray].
+    fn buffer_memory_size(&self) -> usize {
+        let mut size = self.data.buffer_memory_size();
+        for field in &self.boxed_fields {
+            size += field.buffer_memory_size();
+        }
+        size
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [UnionArray].
+    fn total_memory_size(&self) -> usize {
+        let mut size = self.data.total_memory_size();
+        size += mem::size_of_val(self) - mem::size_of_val(&self.boxed_fields);
+        for field in &self.boxed_fields {
+            size += field.total_memory_size();
+        }
+        size
     }
 }
 
@@ -675,6 +695,16 @@ mod tests {
             let value = slot.value(0);
             assert_eq!(expected_value, &value);
         }
+
+        assert_eq!(
+            4 * 8 * 4 * mem::size_of::<i32>(),
+            union.buffer_memory_size()
+        );
+        let internals_of_union_array = (8 + 72) + (union.boxed_fields.len() * 144); // Arc<ArrayData> & Vec<ArrayRef> combined.
+        assert_eq!(
+            union.buffer_memory_size() + internals_of_union_array,
+            union.total_memory_size()
+        );
     }
 
     #[test]

--- a/rust/arrow/src/bitmap.rs
+++ b/rust/arrow/src/bitmap.rs
@@ -70,12 +70,12 @@ impl Bitmap {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [Bitmap].
-    pub fn memory_used(&self) -> usize {
+    pub fn get_buffer_memory_size(&self) -> usize {
         self.bits.capacity()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [Bitmap].
-    pub fn memory_capacity(&self) -> usize {
+    pub fn get_array_memory_size(&self) -> usize {
         self.bits.capacity() + mem::size_of_val(self)
     }
 }

--- a/rust/arrow/src/bitmap.rs
+++ b/rust/arrow/src/bitmap.rs
@@ -21,6 +21,7 @@
 use crate::buffer::Buffer;
 use crate::error::Result;
 use crate::util::bit_util;
+use std::mem;
 
 use std::ops::{BitAnd, BitOr};
 
@@ -66,6 +67,16 @@ impl Bitmap {
 
     pub fn into_buffer(self) -> Buffer {
         self.bits
+    }
+
+    /// Returns the total number of bytes of memory occupied by the buffers owned by this [Bitmap].
+    pub fn buffer_memory_size(&self) -> usize {
+        self.bits.capacity()
+    }
+
+    /// Returns the total number of bytes of memory occupied physically by this [Bitmap].
+    pub fn total_memory_size(&self) -> usize {
+        self.bits.capacity() + mem::size_of_val(self)
     }
 }
 

--- a/rust/arrow/src/bitmap.rs
+++ b/rust/arrow/src/bitmap.rs
@@ -70,12 +70,12 @@ impl Bitmap {
     }
 
     /// Returns the total number of bytes of memory occupied by the buffers owned by this [Bitmap].
-    pub fn buffer_memory_size(&self) -> usize {
+    pub fn memory_used(&self) -> usize {
         self.bits.capacity()
     }
 
     /// Returns the total number of bytes of memory occupied physically by this [Bitmap].
-    pub fn total_memory_size(&self) -> usize {
+    pub fn memory_capacity(&self) -> usize {
         self.bits.capacity() + mem::size_of_val(self)
     }
 }


### PR DESCRIPTION
This PR is a slightly extended version of the PR https://github.com/apache/arrow/pull/7853.

* `memory_used`: Only calculates internally held data size.
* `memory_capacity`: Calculates total physical memory size including vtable, pointed size and whatnot. (I am not sure about the name)

cc @andygrove @paddyhoran @nevi-me 