### PR TITLE
ARROW-9618: [Rust] [DataFusion] Made it easier to write optimizers

### DIFF
--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -717,8 +717,6 @@ pub enum LogicalPlan {
         expr: Vec<Expr>,
         /// The incoming logical plan
         input: Box<LogicalPlan>,
-        /// The schema description of the otuput
-        schema: Box<Schema>,
     },
     /// Produces rows from a table that has been registered on a
     /// context
@@ -782,8 +780,6 @@ pub enum LogicalPlan {
         n: usize,
         /// The logical plan
         input: Box<LogicalPlan>,
-        /// The schema description of the output
-        schema: Box<Schema>,
     },
     /// Creates an external table.
     CreateExternalTable {
@@ -832,8 +828,8 @@ impl LogicalPlan {
             LogicalPlan::Projection { schema, .. } => &schema,
             LogicalPlan::Selection { input, .. } => input.schema(),
             LogicalPlan::Aggregate { schema, .. } => &schema,
-            LogicalPlan::Sort { schema, .. } => &schema,
-            LogicalPlan::Limit { schema, .. } => &schema,
+            LogicalPlan::Sort { input, .. } => input.schema(),
+            LogicalPlan::Limit { input, .. } => input.schema(),
             LogicalPlan::CreateExternalTable { schema, .. } => &schema,
             LogicalPlan::Explain { schema, .. } => &schema,
         }
@@ -1133,7 +1129,6 @@ impl LogicalPlanBuilder {
         Ok(Self::from(&LogicalPlan::Limit {
             n,
             input: Box::new(self.plan.clone()),
-            schema: self.plan.schema().clone(),
         }))
     }
 
@@ -1142,7 +1137,6 @@ impl LogicalPlanBuilder {
         Ok(Self::from(&LogicalPlan::Sort {
             expr,
             input: Box::new(self.plan.clone()),
-            schema: self.plan.schema().clone(),
         }))
     }
 

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -28,7 +28,9 @@ use std::collections::HashSet;
 use utils::optimize_explain;
 
 /// Projection Push Down optimizer rule ensures that only referenced columns are
-/// loaded into memory
+/// loaded into memory.
+///
+/// This optimizer does not modify expressions in the plan; it only changes the read projections
 pub struct ProjectionPushDown {}
 
 impl OptimizerRule for ProjectionPushDown {
@@ -56,63 +58,6 @@ impl ProjectionPushDown {
         has_projection: bool,
     ) -> Result<LogicalPlan> {
         match plan {
-            LogicalPlan::Projection {
-                expr,
-                input,
-                schema,
-            } => {
-                // collect all columns referenced by projection expressions
-                utils::exprlist_to_column_names(&expr, accum)?;
-
-                Ok(LogicalPlan::Projection {
-                    expr: expr.clone(),
-                    input: Box::new(self.optimize_plan(&input, accum, true)?),
-                    schema: schema.clone(),
-                })
-            }
-            LogicalPlan::Selection { expr, input } => {
-                // collect all columns referenced by filter expression
-                utils::expr_to_column_names(expr, accum)?;
-
-                Ok(LogicalPlan::Selection {
-                    expr: expr.clone(),
-                    input: Box::new(self.optimize_plan(&input, accum, has_projection)?),
-                })
-            }
-            LogicalPlan::Aggregate {
-                input,
-                group_expr,
-                aggr_expr,
-                schema,
-            } => {
-                // collect all columns referenced by grouping and aggregate expressions
-                utils::exprlist_to_column_names(&group_expr, accum)?;
-                utils::exprlist_to_column_names(&aggr_expr, accum)?;
-
-                Ok(LogicalPlan::Aggregate {
-                    input: Box::new(self.optimize_plan(&input, accum, has_projection)?),
-                    group_expr: group_expr.clone(),
-                    aggr_expr: aggr_expr.clone(),
-                    schema: schema.clone(),
-                })
-            }
-            LogicalPlan::Sort {
-                expr,
-                input,
-            } => {
-                // collect all columns referenced by sort expressions
-                utils::exprlist_to_column_names(&expr, accum)?;
-
-                Ok(LogicalPlan::Sort {
-                    expr: expr.clone(),
-                    input: Box::new(self.optimize_plan(&input, accum, has_projection)?),
-                })
-            }
-            LogicalPlan::Limit { n, input } => Ok(LogicalPlan::Limit {
-                n: n.clone(),
-                input: Box::new(self.optimize_plan(&input, accum, has_projection)?),
-            }),
-            LogicalPlan::EmptyRelation { .. } => Ok(plan.clone()),
             LogicalPlan::TableScan {
                 schema_name,
                 table_name,
@@ -187,13 +132,32 @@ impl ProjectionPushDown {
                     projected_schema: Box::new(projected_schema),
                 })
             }
-            LogicalPlan::CreateExternalTable { .. } => Ok(plan.clone()),
             LogicalPlan::Explain {
                 verbose,
                 plan,
                 stringified_plans,
                 schema,
             } => optimize_explain(self, *verbose, &*plan, stringified_plans, &*schema),
+            // in all other cases, we construct a new plan based on the optimized inputs and re-written expressions
+            _ => {
+                let has_projection = match plan {
+                    LogicalPlan::Projection { .. } => true,
+                    _ => false,
+                };
+
+                let expr = utils::expressions(plan);
+                // collect all columns referenced by projection expressions
+                utils::exprlist_to_column_names(&expr, accum)?;
+
+                // apply the optimization to all inputs of the plan
+                let inputs = utils::inputs(plan);
+                let new_inputs = inputs
+                    .iter()
+                    .map(|plan| self.optimize_plan(plan, accum, has_projection))
+                    .collect::<Result<Vec<_>>>()?;
+
+                utils::from_plan(plan, &expr, &new_inputs)
+            }
         }
     }
 }

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -99,7 +99,6 @@ impl ProjectionPushDown {
             LogicalPlan::Sort {
                 expr,
                 input,
-                schema,
             } => {
                 // collect all columns referenced by sort expressions
                 utils::exprlist_to_column_names(&expr, accum)?;
@@ -107,13 +106,11 @@ impl ProjectionPushDown {
                 Ok(LogicalPlan::Sort {
                     expr: expr.clone(),
                     input: Box::new(self.optimize_plan(&input, accum, has_projection)?),
-                    schema: schema.clone(),
                 })
             }
-            LogicalPlan::Limit { n, input, schema } => Ok(LogicalPlan::Limit {
+            LogicalPlan::Limit { n, input } => Ok(LogicalPlan::Limit {
                 n: n.clone(),
                 input: Box::new(self.optimize_plan(&input, accum, has_projection)?),
-                schema: schema.clone(),
             }),
             LogicalPlan::EmptyRelation { .. } => Ok(plan.clone()),
             LogicalPlan::TableScan {


### PR DESCRIPTION
This PR adds 5 auxiliary functions to the optimizer package that allow us to more easily write optimizers and re-writes the optimizers using them.

This PR assumes that the majority of the optimizations will:

* recurse logical expressions and re-write them (currently we have the type coercion)
* recurse logical plans and re-write them (currently we have the projection pushdown)

To transverse and re-write expressions, this PR introduces two functions:

```
/// Returns all expressions composing the expression.
/// E.g. if the expression is "(a + 1) + 1", it returns ["a + 1", "1"] (as Expr objects)
fn expr_expressions(expr: &Expr) -> Result<Vec<&Expr>>

/// returns a new expression where the expressions in expr are replaced by the ones in `expr`.
/// This is used in conjunction with ``expr_expressions`` to re-write expressions.
pub fn from_expression(expr: &Expr, expressions: &Vec<Expr>) -> Result<Expr> {
```

these are used on an optimizer as follows:

```
let mut expressions = expr_expressions(expr)?;

# recurse on the expression
let mut expressions = expressions.iter().map(|e| recursion(e)).collect()

# modify `expressions` (optimizer's code)

utils::from_expression(expr, &expressions)
```

Likewise, this PR introduces 3 functions for the plans:

```
/// returns all expressions in the logical plan.
pub fn expressions(plan: &LogicalPlan) -> Vec<Expr>

/// returns all inputs in the logical plan
pub fn inputs(plan: &LogicalPlan) -> Vec<&LogicalPlan>

/// Returns a new logical plan based on the original one with inputs and expressions replaced
pub fn from_plan(
    plan: &LogicalPlan,
    expr: &Vec<Expr>,
    inputs: &Vec<LogicalPlan>,
) -> Result<LogicalPlan>
```

Overall, these make writing optimizers a much developer-friendlier experience because expressions or plans that the optimizer does not care can just be left alone.