### PR TITLE
ARROW-9621: [Python] Skip test_move_file for in-memory fsspec filesystem

### DIFF
--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -789,6 +789,9 @@ def test_move_directory(fs, pathfn, allow_move_dir):
 
 
 def test_move_file(fs, pathfn):
+    if fs.type_name == "py::fsspec+memory":
+        # https://github.com/intake/filesystem_spec/issues/367
+        pytest.xfail(reason='Not working with in-memory fsspec')
     s = pathfn('test-move-source-file')
     t = pathfn('test-move-target-file')
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -790,6 +790,7 @@ def test_move_directory(fs, pathfn, allow_move_dir):
 
 def test_move_file(fs, pathfn):
     if fs.type_name == "py::fsspec+memory":
+        # https://issues.apache.org/jira/browse/ARROW-9621
         # https://github.com/intake/filesystem_spec/issues/367
         pytest.xfail(reason='Not working with in-memory fsspec')
     s = pathfn('test-move-source-file')


### PR DESCRIPTION
Awaiting a proper fix (ARROW-9621, https://github.com/intake/filesystem_spec/issues/367), let's disable the test so it doesn't cause noise in our CI.