### PR TITLE
ARROW-9631: [Rust] flight should depend on arrow, not the other way around

### DIFF
--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -474,8 +474,8 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@release_version}\"",
                         "+version = \"#{@next_snapshot_version}\""],
-                       ["-arrow-flight = { path = \"../arrow-flight\", version = \"#{@release_version}\" }",
-                        "+arrow-flight = { path = \"../arrow-flight\", version = \"#{@next_snapshot_version}\" }"],
+                       ["-arrow = { path = \"../arrow\", version = \"#{@release_version}\" }",
+                        "+arrow = { path = \"../arrow\", version = \"#{@next_snapshot_version}\" }"],
                      ],
                    },
                    {

--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -267,6 +267,8 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",
                         "+version = \"#{@release_version}\""],
+                       ["-arrow = { path = \"../arrow\", version = \"#{@snapshot_version}\" }",
+                        "+arrow = { path = \"../arrow\", version = \"#{@release_version}\" }"],
                      ],
                    },
                    {
@@ -274,8 +276,6 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",
                         "+version = \"#{@release_version}\""],
-                       ["-arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@snapshot_version}\" }",
-                        "+arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@release_version}\" }"],
                      ],
                    },
                    {
@@ -474,6 +474,8 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@release_version}\"",
                         "+version = \"#{@next_snapshot_version}\""],
+                       ["-arrow-flight = { path = \"../arrow-flight\", version = \"#{@release_version}\" }",
+                        "+arrow-flight = { path = \"../arrow-flight\", version = \"#{@next_snapshot_version}\" }"],
                      ],
                    },
                    {
@@ -481,8 +483,6 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@release_version}\"",
                         "+version = \"#{@next_snapshot_version}\""],
-                       ["-arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@release_version}\" }",
-                        "+arrow-flight = { path = \"../arrow-flight\", optional = true, version = \"#{@next_snapshot_version}\" }"],
                      ],
                    },
                    {

--- a/rust/arrow-flight/Cargo.toml
+++ b/rust/arrow-flight/Cargo.toml
@@ -26,6 +26,7 @@ repository = "https://github.com/apache/arrow"
 license = "Apache-2.0"
 
 [dependencies]
+arrow = { path = "../arrow", version = "2.0.0-SNAPSHOT" }
 tonic = "0.2"
 bytes = "0.5"
 prost = "0.6"
@@ -39,6 +40,6 @@ tonic-build = "0.2"
 # (and checked in) arrow.flight.protocol.rs from changing
 proc-macro2 = "=1.0.18"
 
-[lib]
-name = "flight"
-path = "src/lib.rs"
+#[lib]
+#name = "flight"
+#path = "src/lib.rs"

--- a/rust/arrow-flight/examples/server.rs
+++ b/rust/arrow-flight/examples/server.rs
@@ -21,7 +21,7 @@ use futures::Stream;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status, Streaming};
 
-use flight::{
+use arrow_flight::{
     flight_service_server::FlightService, flight_service_server::FlightServiceServer,
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
     HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
@@ -42,7 +42,12 @@ impl FlightService for FlightServiceImpl {
     type DoPutStream =
         Pin<Box<dyn Stream<Item = Result<PutResult, Status>> + Send + Sync + 'static>>;
     type DoActionStream = Pin<
-        Box<dyn Stream<Item = Result<flight::Result, Status>> + Send + Sync + 'static>,
+        Box<
+            dyn Stream<Item = Result<arrow_flight::Result, Status>>
+                + Send
+                + Sync
+                + 'static,
+        >,
     >;
     type ListActionsStream =
         Pin<Box<dyn Stream<Item = Result<ActionType, Status>> + Send + Sync + 'static>>;

--- a/rust/arrow-flight/src/lib.rs
+++ b/rust/arrow-flight/src/lib.rs
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-mod flight {
-    include!("arrow.flight.protocol.rs");
-}
+include!("arrow.flight.protocol.rs");
 
-pub use crate::flight::*;
+pub mod utils;

--- a/rust/arrow-flight/src/utils.rs
+++ b/rust/arrow-flight/src/utils.rs
@@ -19,12 +19,12 @@
 
 use std::convert::TryFrom;
 
-use flight::{FlightData, SchemaResult};
+use crate::{FlightData, SchemaResult};
 
-use crate::datatypes::{Schema, SchemaRef};
-use crate::error::{ArrowError, Result};
-use crate::ipc::{convert, reader, writer};
-use crate::record_batch::RecordBatch;
+use arrow::datatypes::{Schema, SchemaRef};
+use arrow::error::{ArrowError, Result};
+use arrow::ipc::{convert, reader, writer};
+use arrow::record_batch::RecordBatch;
 
 /// Convert a `RecordBatch` to `FlightData` by getting the header and body as bytes
 impl From<&RecordBatch> for FlightData {
@@ -95,7 +95,7 @@ pub fn flight_data_to_batch(
     schema: SchemaRef,
 ) -> Result<Option<RecordBatch>> {
     // check that the data_header is a record batch message
-    let message = crate::ipc::get_root_as_message(&data.data_header[..]);
+    let message = arrow::ipc::get_root_as_message(&data.data_header[..]);
     let dictionaries_by_field = Vec::new();
     let batch_header = message.header_as_record_batch().ok_or_else(|| {
         ArrowError::ParseError(

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -49,14 +49,12 @@ packed_simd = { version = "0.3", optional = true }
 chrono = "0.4"
 flatbuffers = "0.6"
 hex = "0.4"
-arrow-flight = { path = "../arrow-flight", optional = true, version = "2.0.0-SNAPSHOT" }
 prettytable-rs = { version = "0.8.0", optional = true }
 
 [features]
 simd = ["packed_simd"]
-flight = ["arrow-flight"]
 prettyprint = ["prettytable-rs"]
-default = ["flight", "prettyprint"]
+default = ["prettyprint"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -409,7 +409,7 @@ fn create_dictionary_array(
 }
 
 /// Creates a record batch from binary data using the `ipc::RecordBatch` indexes and the `Schema`
-pub(crate) fn read_record_batch(
+pub fn read_record_batch(
     buf: &[u8],
     batch: ipc::RecordBatch,
     schema: SchemaRef,

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -209,7 +209,7 @@ impl<W: Write> Drop for StreamWriter<W> {
     }
 }
 
-pub(crate) fn schema_to_bytes(schema: &Schema) -> Vec<u8> {
+pub fn schema_to_bytes(schema: &Schema) -> Vec<u8> {
     let mut fbb = FlatBufferBuilder::new();
     let schema = {
         let fb = ipc::convert::schema_to_fb_offset(&mut fbb, schema);
@@ -270,7 +270,7 @@ fn write_padded_data<R: Write>(
 }
 
 /// Write a `RecordBatch` into a tuple of bytes, one for the header (ipc::Message) and the other for the batch's data
-pub(crate) fn record_batch_to_bytes(batch: &RecordBatch) -> (Vec<u8>, Vec<u8>) {
+pub fn record_batch_to_bytes(batch: &RecordBatch) -> (Vec<u8>, Vec<u8>) {
     let mut fbb = FlatBufferBuilder::new();
 
     let mut nodes: Vec<ipc::FieldNode> = vec![];

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -34,8 +34,6 @@ pub mod compute;
 pub mod csv;
 pub mod datatypes;
 pub mod error;
-#[cfg(feature = "flight")]
-pub mod flight;
 #[allow(clippy::redundant_closure)]
 #[allow(clippy::needless_lifetimes)]
 #[allow(clippy::extra_unused_lifetimes)]

--- a/rust/datafusion/examples/flight_client.rs
+++ b/rust/datafusion/examples/flight_client.rs
@@ -19,12 +19,12 @@ use std::convert::TryFrom;
 use std::sync::Arc;
 
 use arrow::datatypes::Schema;
-use arrow::flight::flight_data_to_batch;
 use arrow::util::pretty;
 
-use flight::flight_descriptor;
-use flight::flight_service_client::FlightServiceClient;
-use flight::{FlightDescriptor, Ticket};
+use arrow_flight::flight_descriptor;
+use arrow_flight::flight_service_client::FlightServiceClient;
+use arrow_flight::utils::flight_data_to_batch;
+use arrow_flight::{FlightDescriptor, Ticket};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/rust/datafusion/examples/flight_server.rs
+++ b/rust/datafusion/examples/flight_server.rs
@@ -25,7 +25,7 @@ use datafusion::datasource::parquet::ParquetTable;
 use datafusion::datasource::TableProvider;
 use datafusion::execution::context::ExecutionContext;
 
-use flight::{
+use arrow_flight::{
     flight_service_server::FlightService, flight_service_server::FlightServiceServer,
     Action, ActionType, Criteria, Empty, FlightData, FlightDescriptor, FlightInfo,
     HandshakeRequest, HandshakeResponse, PutResult, SchemaResult, Ticket,
@@ -50,7 +50,12 @@ impl FlightService for FlightServiceImpl {
     type DoPutStream =
         Pin<Box<dyn Stream<Item = Result<PutResult, Status>> + Send + Sync + 'static>>;
     type DoActionStream = Pin<
-        Box<dyn Stream<Item = Result<flight::Result, Status>> + Send + Sync + 'static>,
+        Box<
+            dyn Stream<Item = Result<arrow_flight::Result, Status>>
+                + Send
+                + Sync
+                + 'static,
+        >,
     >;
     type ListActionsStream =
         Pin<Box<dyn Stream<Item = Result<ActionType, Status>> + Send + Sync + 'static>>;


### PR DESCRIPTION
The core `arrow` crate had a dependency on the `arrow-flight` crate, which doesn't make sense. Arrow should have minimal dependencies and should not depend on protocols or servers. Flight should depend on Arrow instead.

I also changed the name of lib from `flight` to `arrow_flight` to match the Cargo manifest. I did this because I ran into compilation issues but I think this is worth changing anyway since there is already a `flight` crate on crates.io (unrelated to Arrow). I can try and roll back this change though if there are objections.
