### PR TITLE
ARROW-9600: [Rust] pin proc macro

### DIFF
--- a/rust/arrow-flight/Cargo.toml
+++ b/rust/arrow-flight/Cargo.toml
@@ -37,7 +37,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"]}
 tonic-build = "0.2"
 # Pin specific version of the tonic-build dependencies to avoid auto-generated
 # (and checked in) arrow.flight.protocol.rs from changing
-proc-macro2="1.0.18"
+proc-macro2 = "=1.0.18"
 
 [lib]
 name = "flight"

--- a/rust/arrow-flight/src/arrow.flight.protocol.rs
+++ b/rust/arrow-flight/src/arrow.flight.protocol.rs
@@ -632,6 +632,7 @@ pub mod flight_service_server {
     #[doc = " accessed using the Arrow Flight Protocol. Additionally, a flight service"]
     #[doc = " can expose a set of actions that are available."]
     #[derive(Debug)]
+    #[doc(hidden)]
     pub struct FlightServiceServer<T: FlightService> {
         inner: _Inner<T>,
     }
@@ -686,7 +687,7 @@ pub mod flight_service_server {
                             >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).handshake(request).await };
+                            let fut = async move { inner.handshake(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -724,7 +725,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Criteria>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).list_flights(request).await };
+                            let fut = async move { inner.list_flights(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -759,8 +760,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::FlightDescriptor>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut =
-                                async move { (*inner).get_flight_info(request).await };
+                            let fut = async move { inner.get_flight_info(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -795,7 +795,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::FlightDescriptor>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).get_schema(request).await };
+                            let fut = async move { inner.get_schema(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -833,7 +833,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Ticket>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).do_get(request).await };
+                            let fut = async move { inner.do_get(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -871,7 +871,7 @@ pub mod flight_service_server {
                             request: tonic::Request<tonic::Streaming<super::FlightData>>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).do_put(request).await };
+                            let fut = async move { inner.do_put(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -909,7 +909,7 @@ pub mod flight_service_server {
                             request: tonic::Request<tonic::Streaming<super::FlightData>>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).do_exchange(request).await };
+                            let fut = async move { inner.do_exchange(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -947,7 +947,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Action>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).do_action(request).await };
+                            let fut = async move { inner.do_action(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -985,7 +985,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Empty>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).list_actions(request).await };
+                            let fut = async move { inner.list_actions(request).await };
                             Box::pin(fut)
                         }
                     }


### PR DESCRIPTION
The previous PR that was merged for this did not correctly pin the version and did not check in the corresponding generated code for that version.

We need to use `=1.0.18` to pin an exact version since `1.0.18` means 1.0.18 or later.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html