### PR TITLE
ARROW-9631: [Rust] Make arrow not depend on flight

### DIFF
--- a/dev/release/00-prepare-test.rb
+++ b/dev/release/00-prepare-test.rb
@@ -290,10 +290,10 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@snapshot_version}\"",
                         "+version = \"#{@release_version}\""],
-                       ["-arrow = { path = \"../arrow\", version = \"#{@snapshot_version}\" }",
-                        "-parquet = { path = \"../parquet\", version = \"#{@snapshot_version}\" }",
-                        "+arrow = { path = \"../arrow\", version = \"#{@release_version}\" }",
-                        "+parquet = { path = \"../parquet\", version = \"#{@release_version}\" }"],
+                       ["-arrow = { path = \"../arrow\", version = \"#{@snapshot_version}\", features = [\"prettyprint\"] }",
+                        "-parquet = { path = \"../parquet\", version = \"#{@snapshot_version}\", features = [\"arrow\"] }",
+                        "+arrow = { path = \"../arrow\", version = \"#{@release_version}\", features = [\"prettyprint\"] }",
+                        "+parquet = { path = \"../parquet\", version = \"#{@release_version}\", features = [\"arrow\"] }"],
                        ["-arrow-flight = { path = \"../arrow-flight\", version = \"#{@snapshot_version}\" }",
                         "+arrow-flight = { path = \"../arrow-flight\", version = \"#{@release_version}\" }"]
                      ],
@@ -497,10 +497,10 @@ class PrepareTest < Test::Unit::TestCase
                      hunks: [
                        ["-version = \"#{@release_version}\"",
                         "+version = \"#{@next_snapshot_version}\""],
-                       ["-arrow = { path = \"../arrow\", version = \"#{@release_version}\" }",
-                        "-parquet = { path = \"../parquet\", version = \"#{@release_version}\" }",
-                        "+arrow = { path = \"../arrow\", version = \"#{@next_snapshot_version}\" }",
-                        "+parquet = { path = \"../parquet\", version = \"#{@next_snapshot_version}\" }"],
+                       ["-arrow = { path = \"../arrow\", version = \"#{@release_version}\", features = [\"prettyprint\"] }",
+                        "-parquet = { path = \"../parquet\", version = \"#{@release_version}\", features = [\"arrow\"] }",
+                        "+arrow = { path = \"../arrow\", version = \"#{@next_snapshot_version}\", features = [\"prettyprint\"] }",
+                        "+parquet = { path = \"../parquet\", version = \"#{@next_snapshot_version}\", features = [\"arrow\"] }"],
                        ["-arrow-flight = { path = \"../arrow-flight\", version = \"#{@release_version}\" }",
                         "+arrow-flight = { path = \"../arrow-flight\", version = \"#{@next_snapshot_version}\" }"]
                      ],

--- a/dev/release/00-prepare.sh
+++ b/dev/release/00-prepare.sh
@@ -148,9 +148,9 @@ update_versions() {
   cd "${SOURCE_DIR}/../../rust"
   sed -i.bak -E \
     -e "s/^version = \".+\"/version = \"${version}\"/g" \
-    -e "s/^(arrow = .* version = )\".*\"(, features = .*)?$/\\1\"${version}\"\\2/g" \
+    -e "s/^(arrow = .* version = )\".*\"(( .*)|(, features = .*))$/\\1\"${version}\"\\2/g" \
     -e "s/^(arrow-flight = .* version = )\".+\"( .*)/\\1\"${version}\"\\2/g" \
-    -e "s/^(parquet = .* version = )\".*\"(, features = .*)?$/\\1\"${version}\"\\2/g" \
+    -e "s/^(parquet = .* version = )\".*\"(( .*)|(, features = .*))$/\\1\"${version}\"\\2/g" \
     */Cargo.toml
   rm -f */Cargo.toml.bak
   git add */Cargo.toml

--- a/dev/release/00-prepare.sh
+++ b/dev/release/00-prepare.sh
@@ -148,9 +148,9 @@ update_versions() {
   cd "${SOURCE_DIR}/../../rust"
   sed -i.bak -E \
     -e "s/^version = \".+\"/version = \"${version}\"/g" \
-    -e "s/^(arrow = .* version = )\".+\"( .*)/\\1\"${version}\"\\2/g" \
+    -e "s/^(arrow = .* version = )\".*\"(, features = .*)$/\\1\"${version}\"\\2/g" \
     -e "s/^(arrow-flight = .* version = )\".+\"( .*)/\\1\"${version}\"\\2/g" \
-    -e "s/^(parquet = .* version = )\".+\"( .*)/\\1\"${version}\"\\2/g" \
+    -e "s/^(parquet = .* version = )\".*\"(, features = .*)$/\\1\"${version}\"\\2/g" \
     */Cargo.toml
   rm -f */Cargo.toml.bak
   git add */Cargo.toml

--- a/dev/release/00-prepare.sh
+++ b/dev/release/00-prepare.sh
@@ -148,9 +148,9 @@ update_versions() {
   cd "${SOURCE_DIR}/../../rust"
   sed -i.bak -E \
     -e "s/^version = \".+\"/version = \"${version}\"/g" \
-    -e "s/^(arrow = .* version = )\".*\"(, features = .*)$/\\1\"${version}\"\\2/g" \
+    -e "s/^(arrow = .* version = )\".*\"(, features = .*)?$/\\1\"${version}\"\\2/g" \
     -e "s/^(arrow-flight = .* version = )\".+\"( .*)/\\1\"${version}\"\\2/g" \
-    -e "s/^(parquet = .* version = )\".*\"(, features = .*)$/\\1\"${version}\"\\2/g" \
+    -e "s/^(parquet = .* version = )\".*\"(, features = .*)?$/\\1\"${version}\"\\2/g" \
     */Cargo.toml
   rm -f */Cargo.toml.bak
   git add */Cargo.toml

--- a/rust/arrow-flight/src/arrow.flight.protocol.rs
+++ b/rust/arrow-flight/src/arrow.flight.protocol.rs
@@ -632,7 +632,6 @@ pub mod flight_service_server {
     #[doc = " accessed using the Arrow Flight Protocol. Additionally, a flight service"]
     #[doc = " can expose a set of actions that are available."]
     #[derive(Debug)]
-    #[doc(hidden)]
     pub struct FlightServiceServer<T: FlightService> {
         inner: _Inner<T>,
     }
@@ -687,7 +686,7 @@ pub mod flight_service_server {
                             >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.handshake(request).await };
+                            let fut = async move { (*inner).handshake(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -725,7 +724,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Criteria>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.list_flights(request).await };
+                            let fut = async move { (*inner).list_flights(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -760,7 +759,8 @@ pub mod flight_service_server {
                             request: tonic::Request<super::FlightDescriptor>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.get_flight_info(request).await };
+                            let fut =
+                                async move { (*inner).get_flight_info(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -795,7 +795,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::FlightDescriptor>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.get_schema(request).await };
+                            let fut = async move { (*inner).get_schema(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -833,7 +833,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Ticket>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.do_get(request).await };
+                            let fut = async move { (*inner).do_get(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -871,7 +871,7 @@ pub mod flight_service_server {
                             request: tonic::Request<tonic::Streaming<super::FlightData>>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.do_put(request).await };
+                            let fut = async move { (*inner).do_put(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -909,7 +909,7 @@ pub mod flight_service_server {
                             request: tonic::Request<tonic::Streaming<super::FlightData>>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.do_exchange(request).await };
+                            let fut = async move { (*inner).do_exchange(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -947,7 +947,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Action>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.do_action(request).await };
+                            let fut = async move { (*inner).do_action(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -985,7 +985,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Empty>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.list_actions(request).await };
+                            let fut = async move { (*inner).list_actions(request).await };
                             Box::pin(fut)
                         }
                     }

--- a/rust/arrow-flight/src/arrow.flight.protocol.rs
+++ b/rust/arrow-flight/src/arrow.flight.protocol.rs
@@ -632,6 +632,7 @@ pub mod flight_service_server {
     #[doc = " accessed using the Arrow Flight Protocol. Additionally, a flight service"]
     #[doc = " can expose a set of actions that are available."]
     #[derive(Debug)]
+    #[doc(hidden)]
     pub struct FlightServiceServer<T: FlightService> {
         inner: _Inner<T>,
     }
@@ -686,7 +687,7 @@ pub mod flight_service_server {
                             >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).handshake(request).await };
+                            let fut = async move { inner.handshake(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -724,7 +725,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Criteria>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).list_flights(request).await };
+                            let fut = async move { inner.list_flights(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -759,8 +760,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::FlightDescriptor>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut =
-                                async move { (*inner).get_flight_info(request).await };
+                            let fut = async move { inner.get_flight_info(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -795,7 +795,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::FlightDescriptor>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).get_schema(request).await };
+                            let fut = async move { inner.get_schema(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -833,7 +833,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Ticket>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).do_get(request).await };
+                            let fut = async move { inner.do_get(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -871,7 +871,7 @@ pub mod flight_service_server {
                             request: tonic::Request<tonic::Streaming<super::FlightData>>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).do_put(request).await };
+                            let fut = async move { inner.do_put(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -909,7 +909,7 @@ pub mod flight_service_server {
                             request: tonic::Request<tonic::Streaming<super::FlightData>>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).do_exchange(request).await };
+                            let fut = async move { inner.do_exchange(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -947,7 +947,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Action>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).do_action(request).await };
+                            let fut = async move { inner.do_action(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -985,7 +985,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Empty>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { (*inner).list_actions(request).await };
+                            let fut = async move { inner.list_actions(request).await };
                             Box::pin(fut)
                         }
                     }

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -52,9 +52,9 @@ hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
 
 [features]
+default = []
 simd = ["packed_simd"]
 prettyprint = ["prettytable-rs"]
-default = ["prettyprint"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -46,7 +46,7 @@ cli = ["rustyline"]
 [dependencies]
 fnv = "1.0"
 arrow = { path = "../arrow", version = "2.0.0-SNAPSHOT", features = ["prettyprint"] }
-parquet = { path = "../parquet", version = "2.0.0-SNAPSHOT", default-features = false }
+parquet = { path = "../parquet", version = "2.0.0-SNAPSHOT", features = ["arrow"] }
 sqlparser = "0.6.1"
 clap = "2.33"
 rustyline = {version = "6.0", optional = true}

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -53,7 +53,6 @@ rustyline = {version = "6.0", optional = true}
 crossbeam = "0.7"
 paste = "0.1"
 
-
 [dev-dependencies]
 criterion = "0.3"
 tempdir = "0.3"

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -45,11 +45,10 @@ cli = ["rustyline"]
 
 [dependencies]
 fnv = "1.0"
-arrow = { path = "../arrow", version = "2.0.0-SNAPSHOT" }
-parquet = { path = "../parquet", version = "2.0.0-SNAPSHOT" }
+arrow = { path = "../arrow", version = "2.0.0-SNAPSHOT", features = ["prettyprint"] }
+parquet = { path = "../parquet", version = "2.0.0-SNAPSHOT", default-features = false }
 sqlparser = "0.6.1"
 clap = "2.33"
-prettytable-rs = "0.8.0"
 rustyline = {version = "6.0", optional = true}
 crossbeam = "0.7"
 paste = "0.1"
@@ -60,8 +59,8 @@ tempdir = "0.3"
 futures = "0.3"
 prost = "0.6"
 tokio = { version = "0.2", features = ["macros"] }
-tonic = "0.2"
 arrow-flight = { path = "../arrow-flight", version = "2.0.0-SNAPSHOT" }
+tonic = "0.2"
 
 [[bench]]
 name = "aggregate_query_sql"

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -53,6 +53,7 @@ rustyline = {version = "6.0", optional = true}
 crossbeam = "0.7"
 paste = "0.1"
 
+
 [dev-dependencies]
 criterion = "0.3"
 tempdir = "0.3"


### PR DESCRIPTION
reexports flight from arrow if enabled.
removes unnecessary datafusion deps.
now by default arrow uses no features. features should be handpicked by the user.