### PR TITLE
ARROW-9639: [Ruby] Add dependency version check

### DIFF
--- a/ruby/red-arrow-cuda/dependency-check/Rakefile
+++ b/ruby/red-arrow-cuda/dependency-check/Rakefile
@@ -19,6 +19,7 @@
 
 require "pkg-config"
 require "native-package-installer"
+require_relative "../lib/arrow-cuda/version"
 
 case RUBY_PLATFORM
 when /mingw|mswin/
@@ -33,7 +34,10 @@ end
 namespace :dependency do
   desc "Check dependency"
   task :check do
-    unless PKGConfig.check_version?("arrow-cuda-glib")
+    unless PKGConfig.check_version?("arrow-cuda-glib",
+                                    ArrowCUDA::Version::MAJOR,
+                                    ArrowCUDA::Version::MINOR,
+                                    ArrowCUDA::Version::MICRO)
       unless NativePackageInstaller.install(:debian => "libarrow-cuda-glib-dev",
                                             :redhat => "arrow-cuda-glib-devel")
         exit(false)

--- a/ruby/red-arrow-dataset/dependency-check/Rakefile
+++ b/ruby/red-arrow-dataset/dependency-check/Rakefile
@@ -19,6 +19,7 @@
 
 require "pkg-config"
 require "native-package-installer"
+require_relative "../lib/arrow-dataset/version"
 
 case RUBY_PLATFORM
 when /mingw|mswin/
@@ -33,7 +34,10 @@ end
 namespace :dependency do
   desc "Check dependency"
   task :check do
-    unless PKGConfig.check_version?("arrow-dataset-glib")
+    unless PKGConfig.check_version?("arrow-dataset-glib",
+                                    ArrowDataset::Version::MAJOR,
+                                    ArrowDataset::Version::MINOR,
+                                    ArrowDataset::Version::MICRO)
       unless NativePackageInstaller.install(:debian => "libarrow-dataset-glib-dev",
                                             :redhat => "arrow-dataset-glib-devel")
         exit(false)

--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -16,7 +16,8 @@
 # under the License.
 
 require "extpp"
-require "mkmf-gnome2"
+require "mkmf-gnome"
+require_relative "../../lib/arrow/version"
 
 arrow_pkg_config_path = ENV["ARROW_PKG_CONFIG_PATH"]
 if arrow_pkg_config_path
@@ -24,7 +25,12 @@ if arrow_pkg_config_path
   ENV["PKG_CONFIG_PATH"] = pkg_config_paths.join(File::PATH_SEPARATOR)
 end
 
-unless required_pkg_config_package("arrow",
+unless required_pkg_config_package([
+                                     "arrow",
+                                     Arrow::Version::MAJOR,
+                                     Arrow::Version::MINOR,
+                                     Arrow::Version::MICRO,
+                                   ],
                                    debian: "libarrow-dev",
                                    redhat: "arrow-devel",
                                    homebrew: "apache-arrow",
@@ -32,7 +38,12 @@ unless required_pkg_config_package("arrow",
   exit(false)
 end
 
-unless required_pkg_config_package("arrow-glib",
+unless required_pkg_config_package([
+                                     "arrow-glib",
+                                     Arrow::Version::MAJOR,
+                                     Arrow::Version::MINOR,
+                                     Arrow::Version::MICRO,
+                                   ],
                                    debian: "libarrow-glib-dev",
                                    redhat: "arrow-glib-devel",
                                    homebrew: "apache-arrow-glib",

--- a/ruby/red-gandiva/dependency-check/Rakefile
+++ b/ruby/red-gandiva/dependency-check/Rakefile
@@ -19,6 +19,7 @@
 
 require "pkg-config"
 require "native-package-installer"
+require_relative "../lib/gandiva/version"
 
 case RUBY_PLATFORM
 when /mingw|mswin/
@@ -33,7 +34,10 @@ end
 namespace :dependency do
   desc "Check dependency"
   task :check do
-    unless PKGConfig.check_version?("gandiva-glib")
+    unless PKGConfig.check_version?("gandiva-glib",
+                                    Gandiva::Version::MAJOR,
+                                    Gandiva::Version::MINOR,
+                                    Gandiva::Version::MICRO)
       unless NativePackageInstaller.install(:debian => "libgandiva-glib-dev",
                                             :redhat => "gandiva-glib-devel")
         exit(false)

--- a/ruby/red-parquet/dependency-check/Rakefile
+++ b/ruby/red-parquet/dependency-check/Rakefile
@@ -19,6 +19,7 @@
 
 require "pkg-config"
 require "native-package-installer"
+require_relative "../lib/parquet/version"
 
 case RUBY_PLATFORM
 when /mingw|mswin/
@@ -33,7 +34,10 @@ end
 namespace :dependency do
   desc "Check dependency"
   task :check do
-    unless PKGConfig.check_version?("parquet-glib")
+    unless PKGConfig.check_version?("parquet-glib",
+                                    Parquet::Version::MAJOR,
+                                    Parquet::Version::MINOR,
+                                    Parquet::Version::MICRO)
       unless NativePackageInstaller.install(:debian => "libparquet-glib-dev",
                                             :redhat => "parquet-glib-devel")
         exit(false)

--- a/ruby/red-plasma/dependency-check/Rakefile
+++ b/ruby/red-plasma/dependency-check/Rakefile
@@ -19,6 +19,7 @@
 
 require "pkg-config"
 require "native-package-installer"
+require_relative "../lib/plasma/version"
 
 case RUBY_PLATFORM
 when /mingw|mswin/
@@ -33,7 +34,10 @@ end
 namespace :dependency do
   desc "Check dependency"
   task :check do
-    unless PKGConfig.check_version?("plasma-glib")
+    unless PKGConfig.check_version?("plasma-glib",
+                                    Plasma::Version::MAJOR,
+                                    Plasma::Version::MINOR,
+                                    Plasma::Version::MICRO)
       unless NativePackageInstaller.install(:debian => "libplasma-glib-dev",
                                             :redhat => "plasma-glib-devel")
         exit(false)


### PR DESCRIPTION
This avoids building Red Arrow 1.0.0 with Arrow GLib 0.17.1.