### PR TITLE
ARROW-9642: [C++] Let MakeBuilder refer DictionaryType's index_type for deciding the starting bit width of the indices

### DIFF
--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+#include <iostream>
+
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
@@ -911,12 +913,14 @@ template <typename IndexType, typename ValueType>
 void AssertIndexByteWidth(const std::shared_ptr<DataType>& value_type =
                               TypeTraits<ValueType>::type_singleton()) {
   auto index_type = TypeTraits<IndexType>::type_singleton();
-  auto dict_type = dictionary(index_type, value_type);
+  auto dict_type =
+      checked_pointer_cast<DictionaryType>(dictionary(index_type, value_type));
   std::unique_ptr<ArrayBuilder> builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), dict_type, &builder));
-  ASSERT_TRUE(dict_type->Equals(builder->type()))
-      << "builder's type is " << builder->type()->ToString() << ", but "
-      << dict_type->ToString() << " is expected";
+  auto builder_dict_type = checked_pointer_cast<DictionaryType>(builder->type());
+  ASSERT_TRUE(dict_type->index_type()->Equals(builder_dict_type->index_type()))
+      << "builder's index type is " << builder_dict_type->index_type()->ToString()
+      << ", but " << dict_type->index_type()->ToString() << " is expected";
 }
 
 typedef ::testing::Types<Int8Type, Int16Type, Int32Type, Int64Type> IndexTypes;

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -905,6 +905,34 @@ TEST(TestDecimalDictionaryBuilder, DoubleTableSize) {
 }
 
 // ----------------------------------------------------------------------
+// Index byte width tests
+
+template <typename IndexType, typename ValueType>
+void AssertIndexByteWidth(const std::shared_ptr<DataType>& value_type = TypeTraits<ValueType>::type_singleton()) {
+  auto index_type = TypeTraits<IndexType>::type_singleton();
+  auto dict_type = dictionary(index_type, value_type);
+  std::unique_ptr<ArrayBuilder> builder;
+  ASSERT_OK(MakeBuilder(default_memory_pool(), dict_type, &builder));
+  ASSERT_TRUE(dict_type->Equals(builder->type()))
+    << "builder's type is " << builder->type()->ToString()
+    << ", but " << dict_type->ToString() << " is expected";
+}
+
+typedef ::testing::Types<Int8Type, Int16Type, Int32Type, Int64Type> IndexTypes;
+
+template <typename Type>
+class TestDictionaryBuilderIndexByteWidth : public TestBuilder {};
+
+TYPED_TEST_SUITE(TestDictionaryBuilderIndexByteWidth, IndexTypes);
+
+TYPED_TEST(TestDictionaryBuilderIndexByteWidth, MakeBuilder) {
+  AssertIndexByteWidth<TypeParam, FloatType>();
+  AssertIndexByteWidth<TypeParam, BinaryType>();
+  AssertIndexByteWidth<TypeParam, StringType>();
+  AssertIndexByteWidth<TypeParam, FixedSizeBinaryType>(fixed_size_binary(4));
+}
+
+// ----------------------------------------------------------------------
 // DictionaryArray tests
 
 TEST(TestDictionary, Equals) {

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -908,14 +908,15 @@ TEST(TestDecimalDictionaryBuilder, DoubleTableSize) {
 // Index byte width tests
 
 template <typename IndexType, typename ValueType>
-void AssertIndexByteWidth(const std::shared_ptr<DataType>& value_type = TypeTraits<ValueType>::type_singleton()) {
+void AssertIndexByteWidth(const std::shared_ptr<DataType>& value_type =
+                              TypeTraits<ValueType>::type_singleton()) {
   auto index_type = TypeTraits<IndexType>::type_singleton();
   auto dict_type = dictionary(index_type, value_type);
   std::unique_ptr<ArrayBuilder> builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), dict_type, &builder));
   ASSERT_TRUE(dict_type->Equals(builder->type()))
-    << "builder's type is " << builder->type()->ToString()
-    << ", but " << dict_type->ToString() << " is expected";
+      << "builder's type is " << builder->type()->ToString() << ", but "
+      << dict_type->ToString() << " is expected";
 }
 
 typedef ::testing::Types<Int8Type, Int16Type, Int32Type, Int64Type> IndexTypes;

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -22,8 +22,6 @@
 #include <string>
 #include <vector>
 
-#include <iostream>
-
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
@@ -964,6 +962,7 @@ TYPED_TEST(TestDictionaryBuilderIndexByteWidth, MakeBuilder) {
   AssertIndexByteWidth<TypeParam, BinaryType>();
   AssertIndexByteWidth<TypeParam, StringType>();
   AssertIndexByteWidth<TypeParam, FixedSizeBinaryType>(fixed_size_binary(4));
+  AssertIndexByteWidth<TypeParam, NullType>();
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -921,8 +921,8 @@ TEST(TestNullDictionaryBuilder, Basic) {
   ASSERT_EQ(7, builder.length());
   ASSERT_EQ(7, builder.null_count());
 
-  auto int_array = ArrayFromJSON(int8(), "[0, 1, 0, null]");
-  ASSERT_OK(builder.AppendArray(*int_array));
+  auto null_array = ArrayFromJSON(null(), "[null, null, null, null]");
+  ASSERT_OK(builder.AppendArray(*null_array));
   ASSERT_EQ(11, builder.length());
   ASSERT_EQ(11, builder.null_count());
 

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -958,9 +958,7 @@ void AssertIndexByteWidth(const std::shared_ptr<DataType>& value_type =
   std::unique_ptr<ArrayBuilder> builder;
   ASSERT_OK(MakeBuilder(default_memory_pool(), dict_type, &builder));
   auto builder_dict_type = checked_pointer_cast<DictionaryType>(builder->type());
-  ASSERT_TRUE(dict_type->index_type()->Equals(builder_dict_type->index_type()))
-      << "builder's index type is " << builder_dict_type->index_type()->ToString()
-      << ", but " << dict_type->index_type()->ToString() << " is expected";
+  AssertTypeEqual(dict_type->index_type(), builder_dict_type->index_type());
 }
 
 typedef ::testing::Types<Int8Type, Int16Type, Int32Type, Int64Type> IndexTypes;

--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -928,7 +928,7 @@ TEST(TestNullDictionaryBuilder, Basic) {
 
   std::shared_ptr<Array> result;
   ASSERT_OK(builder.Finish(&result));
-  ASSERT_TRUE(dict_type->Equals(*result->type()));
+  AssertTypeEqual(*dict_type, *result->type());
   ASSERT_EQ(11, result->length());
   ASSERT_EQ(11, result->null_count());
 }

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2104,14 +2104,14 @@ TEST_F(TestAdaptiveIntBuilder, TestAppendNulls) {
 TEST(TestAdaptiveIntBuilderWithStartIntSize, TestReset) {
   auto builder = std::make_shared<AdaptiveIntBuilder>(
       static_cast<uint8_t>(sizeof(int16_t)), default_memory_pool());
-  ASSERT_TRUE(int16()->Equals(*builder->type()));
+  AssertTypeEqual(*int16(), *builder->type());
 
   ASSERT_OK(
       builder->Append(static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1));
-  ASSERT_TRUE(int32()->Equals(*builder->type()));
+  AssertTypeEqual(*int32(), *builder->type());
 
   builder->Reset();
-  ASSERT_TRUE(int16()->Equals(*builder->type()));
+  AssertTypeEqual(*int16(), *builder->type());
 }
 
 class TestAdaptiveUIntBuilder : public TestBuilder {

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2101,6 +2101,19 @@ TEST_F(TestAdaptiveIntBuilder, TestAppendNulls) {
   }
 }
 
+TEST(TestAdaptiveIntBuilderWithStartIntSize, TestReset) {
+  auto builder = std::make_shared<AdaptiveIntBuilder>(
+      static_cast<uint8_t>(sizeof(int16_t)), default_memory_pool());
+  ASSERT_TRUE(int16()->Equals(*builder->type()));
+
+  ASSERT_OK(
+      builder->Append(static_cast<int64_t>(std::numeric_limits<int16_t>::max()) + 1));
+  ASSERT_TRUE(int32()->Equals(*builder->type()));
+
+  builder->Reset();
+  ASSERT_TRUE(int16()->Equals(*builder->type()));
+}
+
 class TestAdaptiveUIntBuilder : public TestBuilder {
  public:
   void SetUp() {
@@ -2304,6 +2317,19 @@ TEST_F(TestAdaptiveUIntBuilder, TestAppendNulls) {
   for (unsigned index = 0; index < size; ++index) {
     ASSERT_FALSE(result_->IsValid(index));
   }
+}
+
+TEST(TestAdaptiveUIntBuilderWithStartIntSize, TestReset) {
+  auto builder = std::make_shared<AdaptiveUIntBuilder>(
+      static_cast<uint8_t>(sizeof(uint16_t)), default_memory_pool());
+  ASSERT_TRUE(uint16()->Equals(*builder->type()));
+
+  ASSERT_OK(
+      builder->Append(static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1));
+  ASSERT_TRUE(uint32()->Equals(*builder->type()));
+
+  builder->Reset();
+  ASSERT_TRUE(uint16()->Equals(*builder->type()));
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2322,7 +2322,7 @@ TEST_F(TestAdaptiveUIntBuilder, TestAppendNulls) {
 TEST(TestAdaptiveUIntBuilderWithStartIntSize, TestReset) {
   auto builder = std::make_shared<AdaptiveUIntBuilder>(
       static_cast<uint8_t>(sizeof(uint16_t)), default_memory_pool());
-  ASSERT_TRUE(uint16()->Equals(*builder->type()));
+  AssertTypeEqual(uint16(), builder->type());
 
   ASSERT_OK(
       builder->Append(static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1));

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2326,10 +2326,10 @@ TEST(TestAdaptiveUIntBuilderWithStartIntSize, TestReset) {
 
   ASSERT_OK(
       builder->Append(static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()) + 1));
-  ASSERT_TRUE(uint32()->Equals(*builder->type()));
+  AssertTypeEqual(uint32(), builder->type());
 
   builder->Reset();
-  ASSERT_TRUE(uint16()->Equals(*builder->type()));
+  AssertTypeEqual(uint16(), builder->type());
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -69,13 +69,16 @@ template <typename new_type, typename old_type>
 typename std::enable_if<(sizeof(old_type) < sizeof(new_type)), Status>::type
 AdaptiveIntBuilderBase::ExpandIntSizeInternal() {
   int_size_ = sizeof(new_type);
-  RETURN_NOT_OK(Resize(data_->size() / sizeof(old_type)));
 
-  const old_type* src = reinterpret_cast<old_type*>(raw_data_);
-  new_type* dst = reinterpret_cast<new_type*>(raw_data_);
-  // By doing the backward copy, we ensure that no element is overridden during
-  // the copy process while the copy stays in-place.
-  std::copy_backward(src, src + length_, dst + length_);
+  if (data_) {
+    RETURN_NOT_OK(Resize(data_->size() / sizeof(old_type)));
+
+    const old_type* src = reinterpret_cast<old_type*>(raw_data_);
+    new_type* dst = reinterpret_cast<new_type*>(raw_data_);
+    // By doing the backward copy, we ensure that no element is overridden during
+    // the copy process while the copy stays in-place.
+    std::copy_backward(src, src + length_, dst + length_);
+  }
 
   return Status::OK();
 }

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -33,7 +33,8 @@ namespace arrow {
 
 using internal::AdaptiveIntBuilderBase;
 
-AdaptiveIntBuilderBase::AdaptiveIntBuilderBase(MemoryPool* pool) : ArrayBuilder(pool) {}
+AdaptiveIntBuilderBase::AdaptiveIntBuilderBase(uint8_t start_int_size, MemoryPool* pool)
+    : ArrayBuilder(pool), start_int_size_(start_int_size), int_size_(start_int_size) {}
 
 void AdaptiveIntBuilderBase::Reset() {
   ArrayBuilder::Reset();
@@ -41,7 +42,7 @@ void AdaptiveIntBuilderBase::Reset() {
   raw_data_ = nullptr;
   pending_pos_ = 0;
   pending_has_nulls_ = false;
-  int_size_ = sizeof(uint8_t);
+  int_size_ = start_int_size_;
 }
 
 Status AdaptiveIntBuilderBase::Resize(int64_t capacity) {
@@ -69,16 +70,13 @@ template <typename new_type, typename old_type>
 typename std::enable_if<(sizeof(old_type) < sizeof(new_type)), Status>::type
 AdaptiveIntBuilderBase::ExpandIntSizeInternal() {
   int_size_ = sizeof(new_type);
+  RETURN_NOT_OK(Resize(data_->size() / sizeof(old_type)));
 
-  if (data_) {
-    RETURN_NOT_OK(Resize(data_->size() / sizeof(old_type)));
-
-    const old_type* src = reinterpret_cast<old_type*>(raw_data_);
-    new_type* dst = reinterpret_cast<new_type*>(raw_data_);
-    // By doing the backward copy, we ensure that no element is overridden during
-    // the copy process while the copy stays in-place.
-    std::copy_backward(src, src + length_, dst + length_);
-  }
+  const old_type* src = reinterpret_cast<old_type*>(raw_data_);
+  new_type* dst = reinterpret_cast<new_type*>(raw_data_);
+  // By doing the backward copy, we ensure that no element is overridden during
+  // the copy process while the copy stays in-place.
+  std::copy_backward(src, src + length_, dst + length_);
 
   return Status::OK();
 }
@@ -127,7 +125,8 @@ std::shared_ptr<DataType> AdaptiveIntBuilder::type() const {
   return nullptr;
 }
 
-AdaptiveIntBuilder::AdaptiveIntBuilder(MemoryPool* pool) : AdaptiveIntBuilderBase(pool) {}
+AdaptiveIntBuilder::AdaptiveIntBuilder(uint8_t start_int_size, MemoryPool* pool)
+    : AdaptiveIntBuilderBase(start_int_size, pool) {}
 
 Status AdaptiveIntBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   RETURN_NOT_OK(CommitPendingData());
@@ -267,8 +266,8 @@ Status AdaptiveIntBuilder::ExpandIntSize(uint8_t new_int_size) {
   return Status::OK();
 }
 
-AdaptiveUIntBuilder::AdaptiveUIntBuilder(MemoryPool* pool)
-    : AdaptiveIntBuilderBase(pool) {}
+AdaptiveUIntBuilder::AdaptiveUIntBuilder(uint8_t start_int_size, MemoryPool* pool)
+    : AdaptiveIntBuilderBase(start_int_size, pool) {}
 
 Status AdaptiveUIntBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   RETURN_NOT_OK(CommitPendingData());

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -122,9 +122,10 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
 
   std::shared_ptr<DataType> type() const override;
 
+  Status ExpandIntSize(uint8_t new_int_size);
+
  protected:
   Status CommitPendingData() override;
-  Status ExpandIntSize(uint8_t new_int_size);
 
   Status AppendValuesInternal(const uint64_t* values, int64_t length,
                               const uint8_t* valid_bytes);
@@ -156,9 +157,10 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
 
   std::shared_ptr<DataType> type() const override;
 
+  Status ExpandIntSize(uint8_t new_int_size);
+
  protected:
   Status CommitPendingData() override;
-  Status ExpandIntSize(uint8_t new_int_size);
 
   Status AppendValuesInternal(const int64_t* values, int64_t length,
                               const uint8_t* valid_bytes);

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -131,10 +131,9 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
 
   std::shared_ptr<DataType> type() const override;
 
-  Status ExpandIntSize(uint8_t new_int_size);
-
  protected:
   Status CommitPendingData() override;
+  Status ExpandIntSize(uint8_t new_int_size);
 
   Status AppendValuesInternal(const uint64_t* values, int64_t length,
                               const uint8_t* valid_bytes);
@@ -170,10 +169,9 @@ class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase 
 
   std::shared_ptr<DataType> type() const override;
 
-  Status ExpandIntSize(uint8_t new_int_size);
-
  protected:
   Status CommitPendingData() override;
+  Status ExpandIntSize(uint8_t new_int_size);
 
   Status AppendValuesInternal(const int64_t* values, int64_t length,
                               const uint8_t* valid_bytes);

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -35,7 +35,10 @@ namespace internal {
 
 class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
  public:
-  explicit AdaptiveIntBuilderBase(MemoryPool* pool);
+  AdaptiveIntBuilderBase(uint8_t start_int_size, MemoryPool* pool);
+
+  explicit AdaptiveIntBuilderBase(MemoryPool* pool)
+      : AdaptiveIntBuilderBase(sizeof(uint8_t), pool) {}
 
   /// \brief Append multiple nulls
   /// \param[in] length the number of nulls to append
@@ -88,7 +91,9 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
 
   std::shared_ptr<ResizableBuffer> data_;
   uint8_t* raw_data_ = NULLPTR;
-  uint8_t int_size_ = sizeof(uint8_t);
+
+  const uint8_t start_int_size_;
+  uint8_t int_size_;
 
   static constexpr int32_t pending_size_ = 1024;
   uint8_t pending_valid_[pending_size_];
@@ -101,7 +106,11 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
 
 class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase {
  public:
-  explicit AdaptiveUIntBuilder(MemoryPool* pool = default_memory_pool());
+  explicit AdaptiveUIntBuilder(uint8_t start_int_size,
+                               MemoryPool* pool = default_memory_pool());
+
+  explicit AdaptiveUIntBuilder(MemoryPool* pool = default_memory_pool())
+      : AdaptiveUIntBuilder(sizeof(uint8_t), pool) {}
 
   using ArrayBuilder::Advance;
   using internal::AdaptiveIntBuilderBase::Reset;
@@ -136,7 +145,11 @@ class ARROW_EXPORT AdaptiveUIntBuilder : public internal::AdaptiveIntBuilderBase
 
 class ARROW_EXPORT AdaptiveIntBuilder : public internal::AdaptiveIntBuilderBase {
  public:
-  explicit AdaptiveIntBuilder(MemoryPool* pool = default_memory_pool());
+  explicit AdaptiveIntBuilder(uint8_t start_int_size,
+                              MemoryPool* pool = default_memory_pool());
+
+  explicit AdaptiveIntBuilder(MemoryPool* pool = default_memory_pool())
+      : AdaptiveIntBuilder(sizeof(uint8_t), pool) {}
 
   using ArrayBuilder::Advance;
   using internal::AdaptiveIntBuilderBase::Reset;

--- a/cpp/src/arrow/array/builder_base.cc
+++ b/cpp/src/arrow/array/builder_base.cc
@@ -29,6 +29,11 @@
 
 namespace arrow {
 
+void ArrayBuilder::CheckArrayType(const std::shared_ptr<DataType>& expected_type,
+                                  const Array& array, const char* message) {
+  DCHECK(expected_type->Equals(*array.type())) << message;
+}
+
 Status ArrayBuilder::TrimBuffer(const int64_t bytes_filled, ResizableBuffer* buffer) {
   if (buffer) {
     if (bytes_filled < buffer->size()) {

--- a/cpp/src/arrow/array/builder_base.cc
+++ b/cpp/src/arrow/array/builder_base.cc
@@ -29,9 +29,20 @@
 
 namespace arrow {
 
-void ArrayBuilder::CheckArrayType(const std::shared_ptr<DataType>& expected_type,
-                                  const Array& array, const char* message) {
-  DCHECK(expected_type->Equals(*array.type())) << message;
+Status ArrayBuilder::CheckArrayType(const std::shared_ptr<DataType>& expected_type,
+                                    const Array& array, const char* message) {
+  if (!expected_type->Equals(*array.type())) {
+    return Status::TypeError(message);
+  }
+  return Status::OK();
+}
+
+Status ArrayBuilder::CheckArrayType(Type::type expected_type, const Array& array,
+                                    const char* message) {
+  if (array.type_id() != expected_type) {
+    return Status::TypeError(message);
+  }
+  return Status::OK();
 }
 
 Status ArrayBuilder::TrimBuffer(const int64_t bytes_filled, ResizableBuffer* buffer) {

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -200,6 +200,10 @@ class ARROW_EXPORT ArrayBuilder {
     return Status::OK();
   }
 
+  /// \brief Check array's value type by DCHECK
+  void CheckArrayType(const std::shared_ptr<DataType>& expected_type, const Array& array,
+                      const char* message);
+
   MemoryPool* pool_;
 
   TypedBufferBuilder<bool> null_bitmap_builder_;

--- a/cpp/src/arrow/array/builder_base.h
+++ b/cpp/src/arrow/array/builder_base.h
@@ -200,9 +200,11 @@ class ARROW_EXPORT ArrayBuilder {
     return Status::OK();
   }
 
-  /// \brief Check array's value type by DCHECK
-  void CheckArrayType(const std::shared_ptr<DataType>& expected_type, const Array& array,
-                      const char* message);
+  // Check for array type
+  Status CheckArrayType(const std::shared_ptr<DataType>& expected_type,
+                        const Array& array, const char* message);
+  Status CheckArrayType(Type::type expected_type, const Array& array,
+                        const char* message);
 
   MemoryPool* pool_;
 

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -189,5 +189,10 @@ Status DictionaryMemoTable::InsertValues(const Array& array) {
 
 int32_t DictionaryMemoTable::size() const { return impl_->size(); }
 
+void CheckArrayType(const std::shared_ptr<DataType>& expected_type, const Array& array,
+                    const std::string& message) {
+  DCHECK(expected_type->Equals(*array.type())) << message;
+}
+
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -189,10 +189,5 @@ Status DictionaryMemoTable::InsertValues(const Array& array) {
 
 int32_t DictionaryMemoTable::size() const { return impl_->size(); }
 
-void CheckArrayType(const std::shared_ptr<DataType>& expected_type, const Array& array,
-                    const char* message) {
-  DCHECK(expected_type->Equals(*array.type())) << message;
-}
-
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -190,7 +190,7 @@ Status DictionaryMemoTable::InsertValues(const Array& array) {
 int32_t DictionaryMemoTable::size() const { return impl_->size(); }
 
 void CheckArrayType(const std::shared_ptr<DataType>& expected_type, const Array& array,
-                    const std::string& message) {
+                    const char* message) {
   DCHECK(expected_type->Equals(*array.type())) << message;
 }
 

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -409,6 +409,10 @@ class DictionaryBuilder : public internal::DictionaryBuilderBase<AdaptiveIntBuil
   using BASE = internal::DictionaryBuilderBase<AdaptiveIntBuilder, T>;
   using BASE::BASE;
 
+  Status ExpandIndexByteWidth(uint8_t new_index_byte_width) {
+    return BASE::indices_builder_.ExpandIntSize(new_index_byte_width);
+  }
+
   /// \brief Append dictionary indices directly without modifying memo
   ///
   /// NOTE: Experimental API

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -249,8 +249,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
     using ArrayType = typename TypeTraits<T>::ArrayType;
 
 #ifndef NDEBUG
-    ArrayBuilder::CheckArrayType(value_type_, array,
-                                 "Wrong value type of array to be appended");
+    ARROW_RETURN_NOT_OK(ArrayBuilder::CheckArrayType(
+        value_type_, array, "Wrong value type of array to be appended"));
 #endif
 
     const auto& concrete_array = static_cast<const ArrayType&>(array);
@@ -267,8 +267,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
   template <typename T1 = T>
   enable_if_fixed_size_binary<T1, Status> AppendArray(const Array& array) {
 #ifndef NDEBUG
-    ArrayBuilder::CheckArrayType(
-        value_type_, array, "Cannot append FixedSizeBinary array with non-matching type");
+    ARROW_RETURN_NOT_OK(ArrayBuilder::CheckArrayType(
+        value_type_, array, "Wrong value type of array to be appended"));
 #endif
 
     const auto& concrete_array = static_cast<const FixedSizeBinaryArray&>(array);
@@ -412,8 +412,8 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
   /// \brief Append a whole dense array to the builder
   Status AppendArray(const Array& array) {
 #ifndef NDEBUG
-    ArrayBuilder::CheckArrayType(null(), array,
-                                 "Wrong value type of array to be appended");
+    ARROW_RETURN_NOT_OK(ArrayBuilder::CheckArrayType(
+        Type::NA, array, "Wrong value type of array to be appended"));
 #endif
     for (int64_t i = 0; i < array.length(); i++) {
       ARROW_RETURN_NOT_OK(AppendNull());

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -335,9 +335,24 @@ class DictionaryBuilderBase : public ArrayBuilder {
 template <typename BuilderType>
 class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
  public:
+  template <typename B = BuilderType>
+  DictionaryBuilderBase(
+      enable_if_t<std::is_base_of<AdaptiveIntBuilderBase, B>::value, uint8_t>
+          start_int_size,
+      const std::shared_ptr<DataType>& value_type,
+      MemoryPool* pool = default_memory_pool())
+      : ArrayBuilder(pool), indices_builder_(start_int_size, pool) {}
+
   DictionaryBuilderBase(const std::shared_ptr<DataType>& value_type,
                         MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool), indices_builder_(pool) {}
+
+  template <typename B = BuilderType>
+  explicit DictionaryBuilderBase(
+      enable_if_t<std::is_base_of<AdaptiveIntBuilderBase, B>::value, uint8_t>
+          start_int_size,
+      MemoryPool* pool = default_memory_pool())
+      : ArrayBuilder(pool), indices_builder_(start_int_size, pool) {}
 
   explicit DictionaryBuilderBase(MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool), indices_builder_(pool) {}

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -93,10 +93,6 @@ class ARROW_EXPORT DictionaryMemoTable {
   std::unique_ptr<DictionaryMemoTableImpl> impl_;
 };
 
-/// \brief Check array's value type by DCHECK
-ARROW_EXPORT void CheckArrayType(const std::shared_ptr<DataType>& expected_type,
-                                 const Array& array, const char* message);
-
 /// \brief Array builder for created encoded DictionaryArray from
 /// dense array
 ///
@@ -253,7 +249,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
     using ArrayType = typename TypeTraits<T>::ArrayType;
 
 #ifndef NDEBUG
-    CheckArrayType(value_type_, array, "Wrong value type of array to be appended");
+    ArrayBuilder::CheckArrayType(value_type_, array,
+                                 "Wrong value type of array to be appended");
 #endif
 
     const auto& concrete_array = static_cast<const ArrayType&>(array);
@@ -270,8 +267,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
   template <typename T1 = T>
   enable_if_fixed_size_binary<T1, Status> AppendArray(const Array& array) {
 #ifndef NDEBUG
-    CheckArrayType(value_type_, array,
-                   "Cannot append FixedSizeBinary array with non-matching type");
+    ArrayBuilder::CheckArrayType(
+        value_type_, array, "Cannot append FixedSizeBinary array with non-matching type");
 #endif
 
     const auto& concrete_array = static_cast<const FixedSizeBinaryArray&>(array);
@@ -415,7 +412,8 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
   /// \brief Append a whole dense array to the builder
   Status AppendArray(const Array& array) {
 #ifndef NDEBUG
-    CheckArrayType(null(), array, "Wrong value type of array to be appended");
+    ArrayBuilder::CheckArrayType(null(), array,
+                                 "Wrong value type of array to be appended");
 #endif
     for (int64_t i = 0; i < array.length(); i++) {
       ARROW_RETURN_NOT_OK(AppendNull());

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -95,7 +95,7 @@ class ARROW_EXPORT DictionaryMemoTable {
 
 /// \brief Check array's value type by DCHECK
 ARROW_EXPORT void CheckArrayType(const std::shared_ptr<DataType>& expected_type,
-                                 const Array& array, const std::string& message);
+                                 const Array& array, const char* message);
 
 /// \brief Array builder for created encoded DictionaryArray from
 /// dense array

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -93,6 +93,10 @@ class ARROW_EXPORT DictionaryMemoTable {
   std::unique_ptr<DictionaryMemoTableImpl> impl_;
 };
 
+/// \brief Check array's value type by DCHECK
+ARROW_EXPORT void CheckArrayType(const std::shared_ptr<DataType>& expected_type,
+                                 const Array& array, const std::string& message);
+
 /// \brief Array builder for created encoded DictionaryArray from
 /// dense array
 ///
@@ -248,6 +252,10 @@ class DictionaryBuilderBase : public ArrayBuilder {
       const Array& array) {
     using ArrayType = typename TypeTraits<T>::ArrayType;
 
+#ifndef NDEBUG
+    CheckArrayType(value_type_, array, "Wrong value type of array to be appended");
+#endif
+
     const auto& concrete_array = static_cast<const ArrayType&>(array);
     for (int64_t i = 0; i < array.length(); i++) {
       if (array.IsNull(i)) {
@@ -261,10 +269,10 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   template <typename T1 = T>
   enable_if_fixed_size_binary<T1, Status> AppendArray(const Array& array) {
-    if (!value_type_->Equals(*array.type())) {
-      return Status::Invalid(
-          "Cannot append FixedSizeBinary array with non-matching type");
-    }
+#ifndef NDEBUG
+    CheckArrayType(value_type_, array,
+                   "Cannot append FixedSizeBinary array with non-matching type");
+#endif
 
     const auto& concrete_array = static_cast<const FixedSizeBinaryArray&>(array);
     for (int64_t i = 0; i < array.length(); i++) {
@@ -406,6 +414,9 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
 
   /// \brief Append a whole dense array to the builder
   Status AppendArray(const Array& array) {
+#ifndef NDEBUG
+    CheckArrayType(null(), array, "Wrong value type of array to be appended");
+#endif
     for (int64_t i = 0; i < array.length(); i++) {
       ARROW_RETURN_NOT_OK(AppendNull());
     }

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -139,7 +139,8 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
 
     case Type::DICTIONARY: {
       const auto& dict_type = static_cast<const DictionaryType&>(*type);
-      DictionaryBuilderCase visitor = {pool, dict_type.index_type(), dict_type.value_type(), nullptr, out};
+      DictionaryBuilderCase visitor = {pool, dict_type.index_type(),
+                                       dict_type.value_type(), nullptr, out};
       auto status = visitor.Make();
       return status;
     }
@@ -210,7 +211,8 @@ Status MakeDictionaryBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& 
                              const std::shared_ptr<Array>& dictionary,
                              std::unique_ptr<ArrayBuilder>* out) {
   const auto& dict_type = static_cast<const DictionaryType&>(*type);
-  DictionaryBuilderCase visitor = {pool, dict_type.index_type(), dict_type.value_type(), dictionary, out};
+  DictionaryBuilderCase visitor = {pool, dict_type.index_type(), dict_type.value_type(),
+                                   dictionary, out};
   return visitor.Make();
 }
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -64,17 +64,11 @@ struct DictionaryBuilderCase {
     if (dictionary != nullptr) {
       builder = new BuilderType(dictionary, pool);
     } else {
-      builder = new BuilderType(value_type, pool);
+      auto start_int_size = internal::GetByteWidth(*index_type);
+      builder = new BuilderType(start_int_size, value_type, pool);
     }
-    RETURN_NOT_OK(AdjustIndexByteWidth(builder));
     out->reset(builder);
     return Status::OK();
-  }
-
-  template <typename BuilderType>
-  Status AdjustIndexByteWidth(BuilderType* builder) {
-    const auto& fw_type = internal::checked_cast<const FixedWidthType&>(*index_type);
-    return builder->ExpandIndexByteWidth(fw_type.bit_width() / CHAR_BIT);
   }
 
   Status Make() { return VisitTypeInline(*value_type, this); }

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -136,8 +136,7 @@ Status MakeBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& type,
       const auto& dict_type = static_cast<const DictionaryType&>(*type);
       DictionaryBuilderCase visitor = {pool, dict_type.index_type(),
                                        dict_type.value_type(), nullptr, out};
-      auto status = visitor.Make();
-      return status;
+      return visitor.Make();
     }
 
     case Type::LIST: {

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -40,6 +40,7 @@ struct DictionaryBuilderCase {
     return CreateFor<ValueType>();
   }
 
+  Status Visit(const NullType&) { return CreateFor<NullType>(); }
   Status Visit(const BinaryType&) { return Create<BinaryDictionaryBuilder>(); }
   Status Visit(const StringType&) { return Create<StringDictionaryBuilder>(); }
   Status Visit(const FixedSizeBinaryType&) { return CreateFor<FixedSizeBinaryType>(); }


### PR DESCRIPTION
As [the discussion in arrow-dev ML](https://lists.apache.org/thread.html/r69b17b5043bc629507440e962fd50d087c8833cd70682651c6ebda3d%40%3Cdev.arrow.apache.org%3E), it may be better that when creating a dictionary builder by MakeBuilder function, we can specify the starting bit width of the builder's index by the dictionary index type specified in the argument of MakeBuilder.