### PR TITLE
ARROW-9632: [Rust] add a func "new" for ExecutionContextSchemaProvider

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -260,11 +260,6 @@ impl ExecutionContext {
         self.datasources.insert(name.to_string(), provider);
     }
 
-    /// Get a reference to the registered data sources
-    pub fn datasources(&self) -> &HashMap<String, Box<dyn TableProvider + Send + Sync>> {
-        &self.datasources
-    }
-
     /// Get a table by name
     pub fn table(&mut self, table_name: &str) -> Result<Arc<dyn Table>> {
         match self.datasources.get(table_name) {

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -195,7 +195,8 @@ impl ExecutionContext {
         &self.scalar_functions
     }
 
-    fn build_schema(&self, columns: &Vec<SQLColumnDef>) -> Result<Schema> {
+    /// Get schema from columns
+    pub fn build_schema(&self, columns: &Vec<SQLColumnDef>) -> Result<Schema> {
         let mut fields = Vec::new();
 
         for column in columns {
@@ -257,6 +258,11 @@ impl ExecutionContext {
         provider: Box<dyn TableProvider + Send + Sync>,
     ) {
         self.datasources.insert(name.to_string(), provider);
+    }
+
+    /// Get a reference to the registered data sources
+    pub fn datasources(&self) -> &HashMap<String, Box<dyn TableProvider + Send + Sync>> {
+        &self.datasources
     }
 
     /// Get a table by name
@@ -667,9 +673,23 @@ impl ExecutionContext {
     }
 }
 
-struct ExecutionContextSchemaProvider<'a> {
+/// Get schema and scalar functions for execution context
+pub struct ExecutionContextSchemaProvider<'a> {
     datasources: &'a HashMap<String, Box<dyn TableProvider + Send + Sync>>,
     scalar_functions: &'a HashMap<String, Box<ScalarFunction>>,
+}
+
+impl<'a> ExecutionContextSchemaProvider<'a> {
+    /// Create a new ExecutionContextSchemaProvider based on data sources and scalar functions
+    pub fn new(
+        datasources: &'a HashMap<String, Box<dyn TableProvider + Send + Sync>>,
+        scalar_functions: &'a HashMap<String, Box<ScalarFunction>>,
+    ) -> Self {
+        ExecutionContextSchemaProvider {
+            datasources,
+            scalar_functions,
+        }
+    }
 }
 
 impl SchemaProvider for ExecutionContextSchemaProvider<'_> {


### PR DESCRIPTION
I use ExecutionContextSchemaProvider in outside app, so i add keyword "pub" for ExecutionContextSchemaProvider, and add a new func "new" for ExecutionContextSchemaProvider.

I add keyword "pub" for build_schema also.