### PR TITLE
ARROW-9543: [C++] Simplify parsing/formatting utilities

### DIFF
--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -116,9 +116,22 @@ class BaseBinaryBuilder : public ArrayBuilder {
     UnsafeAppend(value.data(), static_cast<offset_type>(value.size()));
   }
 
+  /// \brief Allow a function to write one string value directly into value_data_builder_
+  ///
+  /// \param[in] formatter a Callable<int64_t(char*)> which will write directly to
+  ///            value_data_builder_, returning the number of characters written.
+  template <typename Formatter>
+  void UnsafeFormat(Formatter&& formatter) {
+    UnsafeAppendNextOffset();
+    auto appended_size =
+        formatter(reinterpret_cast<char*>(value_data_builder_.mutable_data()) +
+                  value_data_builder_.length());
+    value_data_builder_.UnsafeAdvance(static_cast<int64_t>(appended_size));
+    UnsafeAppendToBitmap(true);
+  }
+
   void UnsafeAppendNull() {
-    const int64_t num_bytes = value_data_builder_.length();
-    offsets_builder_.UnsafeAppend(static_cast<offset_type>(num_bytes));
+    UnsafeAppendNextOffset();
     UnsafeAppendToBitmap(false);
   }
 

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -240,6 +240,8 @@ class TypedBufferBuilder<
     std::fill(data, data + num_copies, value);
   }
 
+  void UnsafeAdvance(int64_t length) { bytes_builder_.UnsafeAdvance(sizeof(T) * length); }
+
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
     return bytes_builder_.Resize(new_capacity * sizeof(T), shrink_to_fit);
   }

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -623,7 +623,7 @@ Status InvalidFormatString(util::string_view v) {
 
 class FormatStringParser {
  public:
-  FormatStringParser() {}
+  FormatStringParser() = default;
 
   explicit FormatStringParser(util::string_view v) : view_(v), index_(0) {}
 
@@ -657,11 +657,10 @@ class FormatStringParser {
   template <typename IntType = int32_t>
   Result<IntType> ParseInt(util::string_view v) {
     using ArrowIntType = typename CTypeTraits<IntType>::ArrowType;
-    IntType value;
-    if (!internal::ParseValue<ArrowIntType>(v.data(), v.size(), &value)) {
-      return Invalid();
+    if (util::optional<IntType> value = internal::ParseValue<ArrowIntType>(v)) {
+      return *value;
     }
-    return value;
+    return Invalid();
   }
 
   Result<TimeUnit::type> ParseTimeUnit() {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -643,6 +643,10 @@ struct ScalarUnaryNotNullStateful {
       return Scalar(ctx, *batch[0].scalar(), out);
     }
   }
+
+  void operator()(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    Exec(ctx, batch, out);
+  }
 };
 
 // An alternative to ScalarUnary that Applies a scalar operation on only the

--- a/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
@@ -39,7 +39,7 @@ struct ParseBooleanString {
   template <typename OutValue, typename Arg0Value>
   static OutValue Call(KernelContext* ctx, Arg0Value val) {
     bool result = false;
-    if (ARROW_PREDICT_FALSE(!ParseValue<BooleanType>(val.data(), val.size(), &result))) {
+    if (ARROW_PREDICT_FALSE(!ParseValue<BooleanType>(val, &result))) {
       ctx->SetStatus(Status::Invalid("Failed to parse value: ", val));
     }
     return result;

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
@@ -19,9 +19,11 @@
 #include "arrow/compute/cast_internal.h"
 #include "arrow/compute/kernels/common.h"
 #include "arrow/extension_type.h"
+#include "arrow/util/value_parsing.h"
 
 namespace arrow {
 
+using internal::ParseValue;
 using internal::PrimitiveScalarBase;
 
 namespace compute {
@@ -269,6 +271,30 @@ void AddCommonCasts(Type::type out_type_id, OutputType out_ty, CastFunction* fun
                             CastFromExtension, NullHandling::COMPUTED_NO_PREALLOCATE,
                             MemAllocation::NO_PREALLOCATE));
 }
+
+// TODO(bkietz): provide a generic from-string parsing cast
+//
+// template <typename OutType>
+// struct ParseString {
+//   template <typename OUT, typename ARG0>
+//   OUT Call(KernelContext* ctx, ARG0 val) const {
+//     OUT result = OUT{};
+//     if (ARROW_PREDICT_FALSE(!ParseValue(out_type_, val, &result))) {
+//       ctx->SetStatus(Status::Invalid("Failed to parse string: ", val));
+//     }
+//     return result;
+//   }
+//
+//   const OutType& out_type_;
+// };
+//
+// template <typename O, typename I>
+// enable_if_base_binary<I> AddCastFromString(CastFunction* func) {
+//   DCHECK_OK(
+//       func->AddKernel(I::type_id, {I::type_id}, O::type_id,
+//                       applicator::ScalarUnaryNotNullStateful<O, I, ParseString<O>>{}));
+// }
+//
 
 }  // namespace internal
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.h
@@ -31,7 +31,7 @@ namespace compute {
 namespace internal {
 
 template <typename OutType, typename InType, typename Enable = void>
-struct CastFunctor {};
+struct CastFunctor;
 
 // No-op functor for identity casts
 template <typename O, typename I>

--- a/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
@@ -280,7 +280,7 @@ struct ParseString {
   template <typename OutValue, typename Arg0Value>
   OutValue Call(KernelContext* ctx, Arg0Value val) const {
     OutValue result = OutValue(0);
-    if (ARROW_PREDICT_FALSE(!ParseValue<OutType>(val.data(), val.size(), &result))) {
+    if (ARROW_PREDICT_FALSE(!ParseValue<OutType>(val, &result))) {
       ctx->SetStatus(Status::Invalid("Failed to parse string: ", val));
     }
     return result;
@@ -413,10 +413,10 @@ struct SafeRescaleDecimal {
     auto result = val.Rescale(in_scale_, out_scale_);
     if (ARROW_PREDICT_FALSE(!result.ok())) {
       ctx->SetStatus(result.status());
-      return Decimal128();  // Zero
+      return {};  // Zero
     } else if (ARROW_PREDICT_FALSE(!(*result).FitsInPrecision(out_precision_))) {
       ctx->SetStatus(Status::Invalid("Decimal value does not fit in precision"));
-      return Decimal128();  // Zero
+      return {};  // Zero
     } else {
       return *std::move(result);
     }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -54,7 +54,6 @@ struct CastFunctor<
 
   static Status Convert(KernelContext* ctx, const ArrayData& input, ArrayData* output) {
     const auto& type = checked_cast<const I&>(*input.type);
-    auto max_size = FormatValueTraits<I>::MaxSize(type);
     BuilderType builder(input.type, ctx->memory_pool());
     RETURN_NOT_OK(builder.Reserve(input.length));
     RETURN_NOT_OK(VisitArrayDataInline<I>(
@@ -62,7 +61,7 @@ struct CastFunctor<
         [&](value_type v) {
           // TODO(bkietz) only ReserveData at the beginning of each bitblock,
           // where we can reserve max_size * popcount
-          RETURN_NOT_OK(builder.ReserveData(max_size));
+          RETURN_NOT_OK(builder.ReserveData(FormatValueTraits<I>::max_size));
           builder.UnsafeFormat([&](char* out) { return FormatValue(type, v, out); });
           return Status::OK();
         },

--- a/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
@@ -270,7 +270,7 @@ struct ParseTimestamp {
   template <typename OutValue, typename Arg0Value>
   OutValue Call(KernelContext* ctx, Arg0Value val) const {
     OutValue result = 0;
-    if (ARROW_PREDICT_FALSE(!ParseValue(type, val.data(), val.size(), &result))) {
+    if (ARROW_PREDICT_FALSE(!ParseValue(type, val, &result))) {
       ctx->SetStatus(Status::Invalid("Failed to parse string: ", val));
     }
     return result;

--- a/cpp/src/arrow/csv/converter.h
+++ b/cpp/src/arrow/csv/converter.h
@@ -33,8 +33,9 @@ class BlockParser;
 
 class ARROW_EXPORT Converter {
  public:
-  Converter(const std::shared_ptr<DataType>& type, const ConvertOptions& options,
+  Converter(std::shared_ptr<DataType> type, const ConvertOptions& options,
             MemoryPool* pool);
+
   virtual ~Converter() = default;
 
   virtual Result<std::shared_ptr<Array>> Convert(const BlockParser& parser,

--- a/cpp/src/arrow/filesystem/hdfs.cc
+++ b/cpp/src/arrow/filesystem/hdfs.cc
@@ -317,10 +317,10 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   // configure replication
   auto it = options_map.find("replication");
   if (it != options_map.end()) {
-    const auto& v = it->second;
     int16_t replication;
-    if (!ParseValue<Int16Type>(v.data(), v.size(), &replication)) {
-      return Status::Invalid("Invalid value for option 'replication': '", v, "'");
+    if (!ParseValue<Int16Type>(it->second, &replication)) {
+      return Status::Invalid("Invalid value for option 'replication': '", it->second,
+                             "'");
     }
     options.ConfigureReplication(replication);
     options_map.erase(it);
@@ -329,10 +329,10 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   // configure buffer_size
   it = options_map.find("buffer_size");
   if (it != options_map.end()) {
-    const auto& v = it->second;
     int32_t buffer_size;
-    if (!ParseValue<Int32Type>(v.data(), v.size(), &buffer_size)) {
-      return Status::Invalid("Invalid value for option 'buffer_size': '", v, "'");
+    if (!ParseValue<Int32Type>(it->second, &buffer_size)) {
+      return Status::Invalid("Invalid value for option 'buffer_size': '", it->second,
+                             "'");
     }
     options.ConfigureBufferSize(buffer_size);
     options_map.erase(it);
@@ -341,10 +341,10 @@ Result<HdfsOptions> HdfsOptions::FromUri(const Uri& uri) {
   // configure default_block_size
   it = options_map.find("default_block_size");
   if (it != options_map.end()) {
-    const auto& v = it->second;
     int64_t default_block_size;
-    if (!ParseValue<Int64Type>(v.data(), v.size(), &default_block_size)) {
-      return Status::Invalid("Invalid value for option 'default_block_size': '", v, "'");
+    if (!ParseValue<Int64Type>(it->second, &default_block_size)) {
+      return Status::Invalid("Invalid value for option 'default_block_size': '",
+                             it->second, "'");
     }
     options.ConfigureBlockSize(default_block_size);
     options_map.erase(it);

--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -344,7 +344,7 @@ class TimestampConverter final : public ConcreteConverter<TimestampConverter> {
       RETURN_NOT_OK(ConvertNumber<Int64Type>(json_obj, *this->type_, &value));
     } else if (json_obj.IsString()) {
       util::string_view view(json_obj.GetString(), json_obj.GetStringLength());
-      if (!ParseValue(*timestamp_type_, view.data(), view.size(), &value)) {
+      if (!ParseValue(*timestamp_type_, view, &value)) {
         return Status::Invalid("couldn't parse timestamp from ", view);
       }
     } else {

--- a/cpp/src/arrow/json/converter.cc
+++ b/cpp/src/arrow/json/converter.cc
@@ -123,13 +123,11 @@ class NumericConverter : public PrimitiveConverter {
     RETURN_NOT_OK(builder.Resize(dict_array.indices()->length()));
 
     auto visit_valid = [&](string_view repr) {
-      value_type value;
-      if (!internal::ParseValue(numeric_type_, repr.data(), repr.size(), &value)) {
-        return GenericConversionError(*out_type_, ", couldn't parse:", repr);
+      if (auto value = internal::ParseValue(numeric_type_, repr)) {
+        builder.UnsafeAppend(*value);
+        return Status::OK();
       }
-
-      builder.UnsafeAppend(value);
-      return Status::OK();
+      return GenericConversionError(*out_type_, ", couldn't parse:", repr);
     };
 
     auto visit_null = [&]() {

--- a/cpp/src/arrow/python/deserialize.cc
+++ b/cpp/src/arrow/python/deserialize.cc
@@ -237,8 +237,7 @@ Status GetPythonTypes(const UnionArray& data, std::vector<int8_t>* result) {
   auto type = data.type();
   for (int i = 0; i < type->num_fields(); ++i) {
     int8_t tag = 0;
-    const std::string& data = type->field(i)->name();
-    if (!ParseValue<Int8Type>(data.c_str(), data.size(), &tag)) {
+    if (!ParseValue<Int8Type>(type->field(i)->name(), &tag)) {
       return Status::SerializationError("Cannot convert string: \"",
                                         type->field(i)->name(), "\" to int8_t");
     }

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -499,7 +499,8 @@ template <typename ScalarType, typename T = typename ScalarType::TypeClass>
 internal::enable_if_formattable<T, Status> CastImpl(const ScalarType& from,
                                                     StringScalar* to) {
   const auto& from_type = checked_cast<const T&>(*from.type);
-  to->value = Buffer::FromString(internal::FormatValue(from_type, from.value));
+  to->value =
+      Buffer::FromString(internal::FormatValue(from_type, from.value).to_string());
   return Status::OK();
 }
 

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -442,7 +442,7 @@ TEST(TestTimestampScalars, Cast) {
 
   ASSERT_OK_AND_ASSIGN(auto str,
                        TimestampScalar(1024, timestamp(TimeUnit::MILLI)).CastTo(utf8()));
-  EXPECT_EQ(*str, StringScalar("1024"));
+  EXPECT_EQ(*str, StringScalar("1970-01-01 00:00:01.024"));
   ASSERT_OK_AND_ASSIGN(auto i64,
                        TimestampScalar(1024, timestamp(TimeUnit::MILLI)).CastTo(int64()));
   EXPECT_EQ(*i64, Int64Scalar(1024));

--- a/cpp/src/arrow/testing/json_internal.cc
+++ b/cpp/src/arrow/testing/json_internal.cc
@@ -476,7 +476,7 @@ class ArrayWriter {
   WriteDataValues(const ArrayType& arr) {
     for (int64_t i = 0; i < arr.length(); ++i) {
       if (arr.IsValid(i)) {
-        writer_->String(FormatValue<PhysicalType>(arr.Value(i)));
+        writer_->String(FormatValue<PhysicalType>(arr.Value(i)).to_string());
       } else {
         static const std::string null_string = "0";
         writer_->String(null_string);
@@ -573,7 +573,7 @@ class ArrayWriter {
       // Represent 64-bit integers as strings, as JSON numbers cannot represent
       // them exactly.
       for (int i = 0; i < length; ++i) {
-        writer_->String(FormatValue<ARROW_TYPE>(values[i]));
+        writer_->String(FormatValue<ARROW_TYPE>(values[i]).to_string());
       }
     }
     writer_->EndArray();

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -97,7 +97,10 @@ struct TypeTraits<NullType> {
 
   static constexpr int64_t bytes_required(int64_t) { return 0; }
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return null(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = null();
+    return instance;
+  }
 };
 
 template <>
@@ -111,7 +114,10 @@ struct TypeTraits<BooleanType> {
     return BitUtil::BytesForBits(elements);
   }
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return boolean(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = boolean();
+    return instance;
+  }
 };
 
 template <>
@@ -132,7 +138,10 @@ struct CTypeTraits<bool> : public TypeTraits<BooleanType> {
       return elements * static_cast<int64_t>(sizeof(CType));                             \
     }                                                                                    \
     constexpr static bool is_parameter_free = true;                                      \
-    static inline std::shared_ptr<DataType> type_singleton() { return SingletonFn(); }   \
+    static inline const std::shared_ptr<DataType>& type_singleton() {                    \
+      static auto instance = SingletonFn();                                              \
+      return instance;                                                                   \
+    }                                                                                    \
   };                                                                                     \
                                                                                          \
   template <>                                                                            \
@@ -171,7 +180,10 @@ struct TypeTraits<Date64Type> {
     return elements * static_cast<int64_t>(sizeof(int64_t));
   }
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return date64(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = date64();
+    return instance;
+  }
 };
 
 template <>
@@ -185,7 +197,10 @@ struct TypeTraits<Date32Type> {
     return elements * static_cast<int64_t>(sizeof(int32_t));
   }
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return date32(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = date32();
+    return instance;
+  }
 };
 
 template <>
@@ -224,7 +239,10 @@ struct TypeTraits<DayTimeIntervalType> {
     return elements * static_cast<int64_t>(sizeof(DayTimeIntervalType::DayMilliseconds));
   }
   constexpr static bool is_parameter_free = true;
-  static std::shared_ptr<DataType> type_singleton() { return day_time_interval(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = day_time_interval();
+    return instance;
+  }
 };
 
 template <>
@@ -237,7 +255,10 @@ struct TypeTraits<MonthIntervalType> {
     return elements * static_cast<int64_t>(sizeof(int32_t));
   }
   constexpr static bool is_parameter_free = true;
-  static std::shared_ptr<DataType> type_singleton() { return month_interval(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = month_interval();
+    return instance;
+  }
 };
 
 template <>
@@ -277,7 +298,10 @@ struct TypeTraits<HalfFloatType> {
     return elements * static_cast<int64_t>(sizeof(uint16_t));
   }
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return float16(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = float16();
+    return instance;
+  }
 };
 
 template <>
@@ -295,7 +319,10 @@ struct TypeTraits<BinaryType> {
   using ScalarType = BinaryScalar;
   using OffsetType = Int32Type;
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return binary(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = binary();
+    return instance;
+  }
 };
 
 template <>
@@ -305,7 +332,10 @@ struct TypeTraits<LargeBinaryType> {
   using ScalarType = LargeBinaryScalar;
   using OffsetType = Int64Type;
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return large_binary(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = large_binary();
+    return instance;
+  }
 };
 
 template <>
@@ -323,7 +353,10 @@ struct TypeTraits<StringType> {
   using ScalarType = StringScalar;
   using OffsetType = Int32Type;
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return utf8(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = utf8();
+    return instance;
+  }
 };
 
 template <>
@@ -333,7 +366,10 @@ struct TypeTraits<LargeStringType> {
   using ScalarType = LargeStringScalar;
   using OffsetType = Int64Type;
   constexpr static bool is_parameter_free = true;
-  static inline std::shared_ptr<DataType> type_singleton() { return large_utf8(); }
+  static inline const std::shared_ptr<DataType>& type_singleton() {
+    static auto instance = large_utf8();
+    return instance;
+  }
 };
 
 template <>

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -307,9 +307,8 @@ static void AdjustIntegerStringWithScale(int32_t scale, std::string* str) {
     if (adjusted_exponent >= 0) {
       str->push_back('+');
     }
-    std::array<char, internal::FormatValueTraits<Int32Type>::max_size> buf;
-    auto size = internal::FormatValue<Int32Type>(adjusted_exponent, buf.data());
-    str->append(buf.data(), size);
+    auto exp = internal::FormatValue<Int32Type>(adjusted_exponent);
+    str->append(exp.data(), exp.size);
     return;
   }
 

--- a/cpp/src/arrow/util/formatting.cc
+++ b/cpp/src/arrow/util/formatting.cc
@@ -21,11 +21,6 @@
 #include "arrow/util/logging.h"
 
 namespace arrow {
-
-using util::double_conversion::DoubleToStringConverter;
-
-static constexpr int kMinBufferSize = DoubleToStringConverter::kBase10MaximalLength + 1;
-
 namespace internal {
 namespace detail {
 
@@ -36,38 +31,29 @@ const char digit_pairs[] =
     "6061626364656667686970717273747576777879"
     "8081828384858687888990919293949596979899";
 
-}  // namespace detail
+using util::double_conversion::DoubleToStringConverter;
 
-struct FloatToStringFormatter::Impl {
-  Impl()
-      : converter_(DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN, "inf", "nan",
-                   'e', -6, 10, 6, 0) {}
+static DoubleToStringConverter g_double_converter(
+    DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN, "inf", "nan", 'e', -6, 10, 6,
+    0);
 
-  DoubleToStringConverter converter_;
-};
-
-FloatToStringFormatter::FloatToStringFormatter() : impl_(new Impl()) {}
-
-FloatToStringFormatter::~FloatToStringFormatter() {}
-
-int FloatToStringFormatter::FormatFloat(float v, char* out_buffer, int out_size) {
-  DCHECK_GE(out_size, kMinBufferSize);
+int FormatFloat(float v, size_t buffer_size, char* buffer) {
   // StringBuilder checks bounds in debug mode for us
-  util::double_conversion::StringBuilder builder(out_buffer, out_size);
-  bool result = impl_->converter_.ToShortestSingle(v, &builder);
+  util::double_conversion::StringBuilder builder(buffer, static_cast<int>(buffer_size));
+  bool result = g_double_converter.ToShortestSingle(v, &builder);
   DCHECK(result);
   ARROW_UNUSED(result);
   return builder.position();
 }
 
-int FloatToStringFormatter::FormatFloat(double v, char* out_buffer, int out_size) {
-  DCHECK_GE(out_size, kMinBufferSize);
-  util::double_conversion::StringBuilder builder(out_buffer, out_size);
-  bool result = impl_->converter_.ToShortest(v, &builder);
+int FormatFloat(double v, size_t buffer_size, char* buffer) {
+  util::double_conversion::StringBuilder builder(buffer, static_cast<int>(buffer_size));
+  bool result = g_double_converter.ToShortest(v, &builder);
   DCHECK(result);
   ARROW_UNUSED(result);
   return builder.position();
 }
 
+}  // namespace detail
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/formatting.cc
+++ b/cpp/src/arrow/util/formatting.cc
@@ -37,17 +37,17 @@ static DoubleToStringConverter g_double_converter(
     DoubleToStringConverter::EMIT_POSITIVE_EXPONENT_SIGN, "inf", "nan", 'e', -6, 10, 6,
     0);
 
-int FormatFloat(float v, size_t buffer_size, char* buffer) {
+int FormatFloat(float v, int buffer_size, char* buffer) {
   // StringBuilder checks bounds in debug mode for us
-  util::double_conversion::StringBuilder builder(buffer, static_cast<int>(buffer_size));
+  util::double_conversion::StringBuilder builder(buffer, buffer_size);
   bool result = g_double_converter.ToShortestSingle(v, &builder);
   DCHECK(result);
   ARROW_UNUSED(result);
   return builder.position();
 }
 
-int FormatFloat(double v, size_t buffer_size, char* buffer) {
-  util::double_conversion::StringBuilder builder(buffer, static_cast<int>(buffer_size));
+int FormatFloat(double v, int buffer_size, char* buffer) {
+  util::double_conversion::StringBuilder builder(buffer, buffer_size);
   bool result = g_double_converter.ToShortest(v, &builder);
   DCHECK(result);
   ARROW_UNUSED(result);

--- a/cpp/src/arrow/util/formatting_util_test.cc
+++ b/cpp/src/arrow/util/formatting_util_test.cc
@@ -29,401 +29,345 @@
 
 namespace arrow {
 
-using internal::StringFormatter;
+using internal::FormatValue;
+using internal::FormatValueTraits;
 
-class StringAppender {
- public:
-  Status operator()(util::string_view v) {
-    string_.append(v.data(), v.size());
-    return Status::OK();
-  }
-
-  std::string string() const { return string_; }
-
- protected:
-  std::string string_;
-};
-
-template <typename FormatterType, typename C_TYPE = typename FormatterType::value_type>
-void AssertFormatting(FormatterType& formatter, C_TYPE value,
-                      const std::string& expected) {
-  StringAppender appender;
-  ASSERT_OK(formatter(value, appender));
-  ASSERT_EQ(appender.string(), expected) << "Formatting failed (value = " << value << ")";
+template <typename ARROW_TYPE, typename Formatter = FormatValueTraits<ARROW_TYPE>,
+          typename V = typename Formatter::value_type>
+void AssertFormat(const ARROW_TYPE& type, V value, const std::string& expected) {
+  ASSERT_EQ(FormatValue(type, value), expected)
+      << "Formatting failed (value = " << value << ")";
 }
 
 TEST(Formatting, Boolean) {
-  StringFormatter<BooleanType> formatter;
+  BooleanType type;
 
-  AssertFormatting(formatter, true, "true");
-  AssertFormatting(formatter, false, "false");
+  AssertFormat(type, true, "true");
+  AssertFormat(type, false, "false");
 }
 
-template <typename FormatterType>
-void TestAnyIntUpTo8(FormatterType& formatter) {
-  AssertFormatting(formatter, 0, "0");
-  AssertFormatting(formatter, 1, "1");
-  AssertFormatting(formatter, 9, "9");
-  AssertFormatting(formatter, 10, "10");
-  AssertFormatting(formatter, 99, "99");
-  AssertFormatting(formatter, 100, "100");
-  AssertFormatting(formatter, 127, "127");
+template <typename ARROW_TYPE>
+void TestAnyIntUpTo8(const ARROW_TYPE& type) {
+  AssertFormat(type, 0, "0");
+  AssertFormat(type, 1, "1");
+  AssertFormat(type, 9, "9");
+  AssertFormat(type, 10, "10");
+  AssertFormat(type, 99, "99");
+  AssertFormat(type, 100, "100");
+  AssertFormat(type, 127, "127");
 }
 
-template <typename FormatterType>
-void TestAnyIntUpTo16(FormatterType& formatter) {
-  TestAnyIntUpTo8(formatter);
-  AssertFormatting(formatter, 999, "999");
-  AssertFormatting(formatter, 1000, "1000");
-  AssertFormatting(formatter, 9999, "9999");
-  AssertFormatting(formatter, 10000, "10000");
-  AssertFormatting(formatter, 32767, "32767");
+template <typename ARROW_TYPE>
+void TestAnyIntUpTo16(const ARROW_TYPE& type) {
+  TestAnyIntUpTo8(type);
+  AssertFormat(type, 999, "999");
+  AssertFormat(type, 1000, "1000");
+  AssertFormat(type, 9999, "9999");
+  AssertFormat(type, 10000, "10000");
+  AssertFormat(type, 32767, "32767");
 }
 
-template <typename FormatterType>
-void TestAnyIntUpTo32(FormatterType& formatter) {
-  TestAnyIntUpTo16(formatter);
-  AssertFormatting(formatter, 99999, "99999");
-  AssertFormatting(formatter, 100000, "100000");
-  AssertFormatting(formatter, 999999, "999999");
-  AssertFormatting(formatter, 1000000, "1000000");
-  AssertFormatting(formatter, 9999999, "9999999");
-  AssertFormatting(formatter, 10000000, "10000000");
-  AssertFormatting(formatter, 99999999, "99999999");
-  AssertFormatting(formatter, 100000000, "100000000");
-  AssertFormatting(formatter, 999999999, "999999999");
-  AssertFormatting(formatter, 1000000000, "1000000000");
-  AssertFormatting(formatter, 1234567890, "1234567890");
-  AssertFormatting(formatter, 2147483647, "2147483647");
+template <typename ARROW_TYPE>
+void TestAnyIntUpTo32(const ARROW_TYPE& type) {
+  TestAnyIntUpTo16(type);
+  AssertFormat(type, 99999, "99999");
+  AssertFormat(type, 100000, "100000");
+  AssertFormat(type, 999999, "999999");
+  AssertFormat(type, 1000000, "1000000");
+  AssertFormat(type, 9999999, "9999999");
+  AssertFormat(type, 10000000, "10000000");
+  AssertFormat(type, 99999999, "99999999");
+  AssertFormat(type, 100000000, "100000000");
+  AssertFormat(type, 999999999, "999999999");
+  AssertFormat(type, 1000000000, "1000000000");
+  AssertFormat(type, 1234567890, "1234567890");
+  AssertFormat(type, 2147483647, "2147483647");
 }
 
-template <typename FormatterType>
-void TestAnyIntUpTo64(FormatterType& formatter) {
-  TestAnyIntUpTo32(formatter);
-  AssertFormatting(formatter, 9999999999ULL, "9999999999");
-  AssertFormatting(formatter, 10000000000ULL, "10000000000");
-  AssertFormatting(formatter, 99999999999ULL, "99999999999");
-  AssertFormatting(formatter, 100000000000ULL, "100000000000");
-  AssertFormatting(formatter, 999999999999ULL, "999999999999");
-  AssertFormatting(formatter, 1000000000000ULL, "1000000000000");
-  AssertFormatting(formatter, 9999999999999ULL, "9999999999999");
-  AssertFormatting(formatter, 10000000000000ULL, "10000000000000");
-  AssertFormatting(formatter, 99999999999999ULL, "99999999999999");
-  AssertFormatting(formatter, 1000000000000000000ULL, "1000000000000000000");
-  AssertFormatting(formatter, 9223372036854775807ULL, "9223372036854775807");
+template <typename ARROW_TYPE>
+void TestAnyIntUpTo64(const ARROW_TYPE& type) {
+  TestAnyIntUpTo32(type);
+  AssertFormat(type, 9999999999ULL, "9999999999");
+  AssertFormat(type, 10000000000ULL, "10000000000");
+  AssertFormat(type, 99999999999ULL, "99999999999");
+  AssertFormat(type, 100000000000ULL, "100000000000");
+  AssertFormat(type, 999999999999ULL, "999999999999");
+  AssertFormat(type, 1000000000000ULL, "1000000000000");
+  AssertFormat(type, 9999999999999ULL, "9999999999999");
+  AssertFormat(type, 10000000000000ULL, "10000000000000");
+  AssertFormat(type, 99999999999999ULL, "99999999999999");
+  AssertFormat(type, 1000000000000000000ULL, "1000000000000000000");
+  AssertFormat(type, 9223372036854775807ULL, "9223372036854775807");
 }
 
-template <typename FormatterType>
-void TestUIntUpTo8(FormatterType& formatter) {
-  TestAnyIntUpTo8(formatter);
-  AssertFormatting(formatter, 128, "128");
-  AssertFormatting(formatter, 255, "255");
+template <typename ARROW_TYPE>
+void TestUIntUpTo8(const ARROW_TYPE& type) {
+  TestAnyIntUpTo8(type);
+  AssertFormat(type, 128, "128");
+  AssertFormat(type, 255, "255");
 }
 
-template <typename FormatterType>
-void TestUIntUpTo16(FormatterType& formatter) {
-  TestAnyIntUpTo16(formatter);
-  AssertFormatting(formatter, 32768, "32768");
-  AssertFormatting(formatter, 65535, "65535");
+template <typename ARROW_TYPE>
+void TestUIntUpTo16(const ARROW_TYPE& type) {
+  TestAnyIntUpTo16(type);
+  AssertFormat(type, 32768, "32768");
+  AssertFormat(type, 65535, "65535");
 }
 
-template <typename FormatterType>
-void TestUIntUpTo32(FormatterType& formatter) {
-  TestAnyIntUpTo32(formatter);
-  AssertFormatting(formatter, 2147483648U, "2147483648");
-  AssertFormatting(formatter, 4294967295U, "4294967295");
+template <typename ARROW_TYPE>
+void TestUIntUpTo32(const ARROW_TYPE& type) {
+  TestAnyIntUpTo32(type);
+  AssertFormat(type, 2147483648U, "2147483648");
+  AssertFormat(type, 4294967295U, "4294967295");
 }
 
-template <typename FormatterType>
-void TestUIntUpTo64(FormatterType& formatter) {
-  TestAnyIntUpTo64(formatter);
-  AssertFormatting(formatter, 9999999999999999999ULL, "9999999999999999999");
-  AssertFormatting(formatter, 10000000000000000000ULL, "10000000000000000000");
-  AssertFormatting(formatter, 12345678901234567890ULL, "12345678901234567890");
-  AssertFormatting(formatter, 18446744073709551615ULL, "18446744073709551615");
+template <typename ARROW_TYPE>
+void TestUIntUpTo64(const ARROW_TYPE& type) {
+  TestAnyIntUpTo64(type);
+  AssertFormat(type, 9999999999999999999ULL, "9999999999999999999");
+  AssertFormat(type, 10000000000000000000ULL, "10000000000000000000");
+  AssertFormat(type, 12345678901234567890ULL, "12345678901234567890");
+  AssertFormat(type, 18446744073709551615ULL, "18446744073709551615");
 }
 
-TEST(Formatting, UInt8) {
-  StringFormatter<UInt8Type> formatter;
+TEST(Formatting, UInt8) { TestUIntUpTo8(UInt8Type{}); }
 
-  TestUIntUpTo8(formatter);
+TEST(Formatting, UInt16) { TestUIntUpTo16(UInt16Type{}); }
+
+TEST(Formatting, UInt32) { TestUIntUpTo32(UInt32Type{}); }
+
+TEST(Formatting, UInt64) { TestUIntUpTo64(UInt64Type{}); }
+
+template <typename ARROW_TYPE>
+void TestIntUpTo8(const ARROW_TYPE& type) {
+  TestAnyIntUpTo8(type);
+  AssertFormat(type, -1, "-1");
+  AssertFormat(type, -9, "-9");
+  AssertFormat(type, -10, "-10");
+  AssertFormat(type, -99, "-99");
+  AssertFormat(type, -100, "-100");
+  AssertFormat(type, -127, "-127");
+  AssertFormat(type, -128, "-128");
 }
 
-TEST(Formatting, UInt16) {
-  StringFormatter<UInt16Type> formatter;
-
-  TestUIntUpTo16(formatter);
+template <typename ARROW_TYPE>
+void TestIntUpTo16(const ARROW_TYPE& type) {
+  TestAnyIntUpTo16(type);
+  TestIntUpTo8(type);
+  AssertFormat(type, -129, "-129");
+  AssertFormat(type, -999, "-999");
+  AssertFormat(type, -1000, "-1000");
+  AssertFormat(type, -9999, "-9999");
+  AssertFormat(type, -10000, "-10000");
+  AssertFormat(type, -32768, "-32768");
 }
 
-TEST(Formatting, UInt32) {
-  StringFormatter<UInt32Type> formatter;
-
-  TestUIntUpTo32(formatter);
+template <typename ARROW_TYPE>
+void TestIntUpTo32(const ARROW_TYPE& type) {
+  TestAnyIntUpTo32(type);
+  TestIntUpTo16(type);
+  AssertFormat(type, -32769, "-32769");
+  AssertFormat(type, -99999, "-99999");
+  AssertFormat(type, -1000000000, "-1000000000");
+  AssertFormat(type, -1234567890, "-1234567890");
+  AssertFormat(type, -2147483647, "-2147483647");
+  AssertFormat(type, -2147483647 - 1, "-2147483648");
 }
 
-TEST(Formatting, UInt64) {
-  StringFormatter<UInt64Type> formatter;
-
-  TestUIntUpTo64(formatter);
+template <typename ARROW_TYPE>
+void TestIntUpTo64(const ARROW_TYPE& type) {
+  TestAnyIntUpTo64(type);
+  TestIntUpTo32(type);
+  AssertFormat(type, -2147483649LL, "-2147483649");
+  AssertFormat(type, -9999999999LL, "-9999999999");
+  AssertFormat(type, -1000000000000000000LL, "-1000000000000000000");
+  AssertFormat(type, -9012345678901234567LL, "-9012345678901234567");
+  AssertFormat(type, -9223372036854775807LL, "-9223372036854775807");
+  AssertFormat(type, -9223372036854775807LL - 1, "-9223372036854775808");
 }
 
-template <typename FormatterType>
-void TestIntUpTo8(FormatterType& formatter) {
-  TestAnyIntUpTo8(formatter);
-  AssertFormatting(formatter, -1, "-1");
-  AssertFormatting(formatter, -9, "-9");
-  AssertFormatting(formatter, -10, "-10");
-  AssertFormatting(formatter, -99, "-99");
-  AssertFormatting(formatter, -100, "-100");
-  AssertFormatting(formatter, -127, "-127");
-  AssertFormatting(formatter, -128, "-128");
-}
+TEST(Formatting, Int8) { TestIntUpTo8(Int8Type{}); }
 
-template <typename FormatterType>
-void TestIntUpTo16(FormatterType& formatter) {
-  TestAnyIntUpTo16(formatter);
-  TestIntUpTo8(formatter);
-  AssertFormatting(formatter, -129, "-129");
-  AssertFormatting(formatter, -999, "-999");
-  AssertFormatting(formatter, -1000, "-1000");
-  AssertFormatting(formatter, -9999, "-9999");
-  AssertFormatting(formatter, -10000, "-10000");
-  AssertFormatting(formatter, -32768, "-32768");
-}
+TEST(Formatting, Int16) { TestIntUpTo16(Int16Type{}); }
 
-template <typename FormatterType>
-void TestIntUpTo32(FormatterType& formatter) {
-  TestAnyIntUpTo32(formatter);
-  TestIntUpTo16(formatter);
-  AssertFormatting(formatter, -32769, "-32769");
-  AssertFormatting(formatter, -99999, "-99999");
-  AssertFormatting(formatter, -1000000000, "-1000000000");
-  AssertFormatting(formatter, -1234567890, "-1234567890");
-  AssertFormatting(formatter, -2147483647, "-2147483647");
-  AssertFormatting(formatter, -2147483647 - 1, "-2147483648");
-}
+TEST(Formatting, Int32) { TestIntUpTo32(Int32Type{}); }
 
-template <typename FormatterType>
-void TestIntUpTo64(FormatterType& formatter) {
-  TestAnyIntUpTo64(formatter);
-  TestIntUpTo32(formatter);
-  AssertFormatting(formatter, -2147483649LL, "-2147483649");
-  AssertFormatting(formatter, -9999999999LL, "-9999999999");
-  AssertFormatting(formatter, -1000000000000000000LL, "-1000000000000000000");
-  AssertFormatting(formatter, -9012345678901234567LL, "-9012345678901234567");
-  AssertFormatting(formatter, -9223372036854775807LL, "-9223372036854775807");
-  AssertFormatting(formatter, -9223372036854775807LL - 1, "-9223372036854775808");
-}
-
-TEST(Formatting, Int8) {
-  StringFormatter<Int8Type> formatter;
-
-  TestIntUpTo8(formatter);
-}
-
-TEST(Formatting, Int16) {
-  StringFormatter<Int16Type> formatter;
-
-  TestIntUpTo16(formatter);
-}
-
-TEST(Formatting, Int32) {
-  StringFormatter<Int32Type> formatter;
-
-  TestIntUpTo32(formatter);
-}
-
-TEST(Formatting, Int64) {
-  StringFormatter<Int64Type> formatter;
-
-  TestIntUpTo64(formatter);
-}
+TEST(Formatting, Int64) { TestIntUpTo64(Int64Type{}); }
 
 TEST(Formatting, Float) {
-  StringFormatter<FloatType> formatter;
+  FloatType type;
 
-  AssertFormatting(formatter, 0.0f, "0");
-  AssertFormatting(formatter, -0.0f, "-0");
-  AssertFormatting(formatter, 1.5f, "1.5");
-  AssertFormatting(formatter, 0.0001f, "0.0001");
-  AssertFormatting(formatter, 1234.567f, "1234.567");
-  AssertFormatting(formatter, 1e9f, "1000000000");
-  AssertFormatting(formatter, 1e10f, "1e+10");
-  AssertFormatting(formatter, 1e20f, "1e+20");
-  AssertFormatting(formatter, 1e-6f, "0.000001");
-  AssertFormatting(formatter, 1e-7f, "1e-7");
-  AssertFormatting(formatter, 1e-20f, "1e-20");
+  AssertFormat(type, 0.0f, "0");
+  AssertFormat(type, -0.0f, "-0");
+  AssertFormat(type, 1.5f, "1.5");
+  AssertFormat(type, 0.0001f, "0.0001");
+  AssertFormat(type, 1234.567f, "1234.567");
+  AssertFormat(type, 1e9f, "1000000000");
+  AssertFormat(type, 1e10f, "1e+10");
+  AssertFormat(type, 1e20f, "1e+20");
+  AssertFormat(type, 1e-6f, "0.000001");
+  AssertFormat(type, 1e-7f, "1e-7");
+  AssertFormat(type, 1e-20f, "1e-20");
 
-  AssertFormatting(formatter, std::nanf(""), "nan");
-  AssertFormatting(formatter, HUGE_VALF, "inf");
-  AssertFormatting(formatter, -HUGE_VALF, "-inf");
+  AssertFormat(type, std::nanf(""), "nan");
+  AssertFormat(type, HUGE_VALF, "inf");
+  AssertFormat(type, -HUGE_VALF, "-inf");
 }
 
 TEST(Formatting, Double) {
-  StringFormatter<DoubleType> formatter;
+  DoubleType type;
 
-  AssertFormatting(formatter, 0.0, "0");
-  AssertFormatting(formatter, -0.0, "-0");
-  AssertFormatting(formatter, 1.5, "1.5");
-  AssertFormatting(formatter, 0.0001, "0.0001");
-  AssertFormatting(formatter, 1234.567, "1234.567");
-  AssertFormatting(formatter, 1e9, "1000000000");
-  AssertFormatting(formatter, 1e10, "1e+10");
-  AssertFormatting(formatter, 1e20, "1e+20");
-  AssertFormatting(formatter, 1e-6, "0.000001");
-  AssertFormatting(formatter, 1e-7, "1e-7");
-  AssertFormatting(formatter, 1e-20, "1e-20");
+  AssertFormat(type, 0.0, "0");
+  AssertFormat(type, -0.0, "-0");
+  AssertFormat(type, 1.5, "1.5");
+  AssertFormat(type, 0.0001, "0.0001");
+  AssertFormat(type, 1234.567, "1234.567");
+  AssertFormat(type, 1e9, "1000000000");
+  AssertFormat(type, 1e10, "1e+10");
+  AssertFormat(type, 1e20, "1e+20");
+  AssertFormat(type, 1e-6, "0.000001");
+  AssertFormat(type, 1e-7, "1e-7");
+  AssertFormat(type, 1e-20, "1e-20");
 
-  AssertFormatting(formatter, std::nan(""), "nan");
-  AssertFormatting(formatter, HUGE_VAL, "inf");
-  AssertFormatting(formatter, -HUGE_VAL, "-inf");
+  AssertFormat(type, std::nan(""), "nan");
+  AssertFormat(type, HUGE_VAL, "inf");
+  AssertFormat(type, -HUGE_VAL, "-inf");
 }
 
 TEST(Formatting, Date32) {
-  StringFormatter<Date32Type> formatter;
+  Date32Type type;
 
-  AssertFormatting(formatter, 0, "1970-01-01");
-  AssertFormatting(formatter, 1, "1970-01-02");
-  AssertFormatting(formatter, 30, "1970-01-31");
-  AssertFormatting(formatter, 30 + 1, "1970-02-01");
-  AssertFormatting(formatter, 30 + 28, "1970-02-28");
-  AssertFormatting(formatter, 30 + 28 + 1, "1970-03-01");
-  AssertFormatting(formatter, -1, "1969-12-31");
-  AssertFormatting(formatter, 365, "1971-01-01");
-  AssertFormatting(formatter, 2 * 365, "1972-01-01");
-  AssertFormatting(formatter, 2 * 365 + 30 + 28 + 1, "1972-02-29");
+  AssertFormat(type, 0, "1970-01-01");
+  AssertFormat(type, 1, "1970-01-02");
+  AssertFormat(type, 30, "1970-01-31");
+  AssertFormat(type, 30 + 1, "1970-02-01");
+  AssertFormat(type, 30 + 28, "1970-02-28");
+  AssertFormat(type, 30 + 28 + 1, "1970-03-01");
+  AssertFormat(type, -1, "1969-12-31");
+  AssertFormat(type, 365, "1971-01-01");
+  AssertFormat(type, 2 * 365, "1972-01-01");
+  AssertFormat(type, 2 * 365 + 30 + 28 + 1, "1972-02-29");
 }
 
 TEST(Formatting, Date64) {
-  StringFormatter<Date64Type> formatter;
-
   constexpr int64_t kMillisInDay = 24 * 60 * 60 * 1000;
-  AssertFormatting(formatter, kMillisInDay * (0), "1970-01-01");
-  AssertFormatting(formatter, kMillisInDay * (1), "1970-01-02");
-  AssertFormatting(formatter, kMillisInDay * (30), "1970-01-31");
-  AssertFormatting(formatter, kMillisInDay * (30 + 1), "1970-02-01");
-  AssertFormatting(formatter, kMillisInDay * (30 + 28), "1970-02-28");
-  AssertFormatting(formatter, kMillisInDay * (30 + 28 + 1), "1970-03-01");
-  AssertFormatting(formatter, kMillisInDay * (-1), "1969-12-31");
-  AssertFormatting(formatter, kMillisInDay * (365), "1971-01-01");
-  AssertFormatting(formatter, kMillisInDay * (2 * 365), "1972-01-01");
-  AssertFormatting(formatter, kMillisInDay * (2 * 365 + 30 + 28 + 1), "1972-02-29");
+
+  Date64Type type;
+  AssertFormat(type, kMillisInDay * (0), "1970-01-01");
+  AssertFormat(type, kMillisInDay * (1), "1970-01-02");
+  AssertFormat(type, kMillisInDay * (30), "1970-01-31");
+  AssertFormat(type, kMillisInDay * (30 + 1), "1970-02-01");
+  AssertFormat(type, kMillisInDay * (30 + 28), "1970-02-28");
+  AssertFormat(type, kMillisInDay * (30 + 28 + 1), "1970-03-01");
+  AssertFormat(type, kMillisInDay * (-1), "1969-12-31");
+  AssertFormat(type, kMillisInDay * (365), "1971-01-01");
+  AssertFormat(type, kMillisInDay * (2 * 365), "1972-01-01");
+  AssertFormat(type, kMillisInDay * (2 * 365 + 30 + 28 + 1), "1972-02-29");
 }
 
 TEST(Formatting, Time32) {
   {
-    StringFormatter<Time32Type> formatter(time32(TimeUnit::SECOND));
+    Time32Type type(TimeUnit::SECOND);
 
-    AssertFormatting(formatter, 0, "00:00:00");
-    AssertFormatting(formatter, 1, "00:00:01");
-    AssertFormatting(formatter, ((12) * 60 + 34) * 60 + 56, "12:34:56");
-    AssertFormatting(formatter, 24 * 60 * 60 - 1, "23:59:59");
+    AssertFormat(type, 0, "00:00:00");
+    AssertFormat(type, 1, "00:00:01");
+    AssertFormat(type, ((12) * 60 + 34) * 60 + 56, "12:34:56");
+    AssertFormat(type, 24 * 60 * 60 - 1, "23:59:59");
   }
 
   {
-    StringFormatter<Time32Type> formatter(time32(TimeUnit::MILLI));
+    Time32Type type(TimeUnit::MILLI);
 
-    AssertFormatting(formatter, 0, "00:00:00.000");
-    AssertFormatting(formatter, 1, "00:00:00.001");
-    AssertFormatting(formatter, 1000, "00:00:01.000");
-    AssertFormatting(formatter, (((12) * 60 + 34) * 60 + 56) * 1000 + 789,
-                     "12:34:56.789");
-    AssertFormatting(formatter, 24 * 60 * 60 * 1000 - 1, "23:59:59.999");
+    AssertFormat(type, 0, "00:00:00.000");
+    AssertFormat(type, 1, "00:00:00.001");
+    AssertFormat(type, 1000, "00:00:01.000");
+    AssertFormat(type, (((12) * 60 + 34) * 60 + 56) * 1000 + 789, "12:34:56.789");
+    AssertFormat(type, 24 * 60 * 60 * 1000 - 1, "23:59:59.999");
   }
 }
 
 TEST(Formatting, Time64) {
   {
-    StringFormatter<Time64Type> formatter(time64(TimeUnit::MICRO));
+    Time64Type type(TimeUnit::MICRO);
 
-    AssertFormatting(formatter, 0, "00:00:00.000000");
-    AssertFormatting(formatter, 1, "00:00:00.000001");
-    AssertFormatting(formatter, 1000000, "00:00:01.000000");
-    AssertFormatting(formatter, (((12) * 60 + 34) * 60 + 56) * 1000000LL + 789000,
-                     "12:34:56.789000");
-    AssertFormatting(formatter, (24 * 60 * 60) * 1000000LL - 1, "23:59:59.999999");
+    AssertFormat(type, 0, "00:00:00.000000");
+    AssertFormat(type, 1, "00:00:00.000001");
+    AssertFormat(type, 1000000, "00:00:01.000000");
+    AssertFormat(type, (((12) * 60 + 34) * 60 + 56) * 1000000LL + 789000,
+                 "12:34:56.789000");
+    AssertFormat(type, (24 * 60 * 60) * 1000000LL - 1, "23:59:59.999999");
   }
 
   {
-    StringFormatter<Time64Type> formatter(time64(TimeUnit::NANO));
+    Time64Type type(TimeUnit::NANO);
 
-    AssertFormatting(formatter, 0, "00:00:00.000000000");
-    AssertFormatting(formatter, 1, "00:00:00.000000001");
-    AssertFormatting(formatter, 1000000000LL, "00:00:01.000000000");
-    AssertFormatting(formatter, (((12) * 60 + 34) * 60 + 56) * 1000000000LL + 789000000LL,
-                     "12:34:56.789000000");
-    AssertFormatting(formatter, (24 * 60 * 60) * 1000000000LL - 1, "23:59:59.999999999");
+    AssertFormat(type, 0, "00:00:00.000000000");
+    AssertFormat(type, 1, "00:00:00.000000001");
+    AssertFormat(type, 1000000000LL, "00:00:01.000000000");
+    AssertFormat(type, (((12) * 60 + 34) * 60 + 56) * 1000000000LL + 789000000LL,
+                 "12:34:56.789000000");
+    AssertFormat(type, (24 * 60 * 60) * 1000000000LL - 1, "23:59:59.999999999");
   }
 }
 
 TEST(Formatting, Timestamp) {
   {
-    StringFormatter<TimestampType> formatter(timestamp(TimeUnit::SECOND));
+    TimestampType type(TimeUnit::SECOND);
 
-    AssertFormatting(formatter, 0, "1970-01-01 00:00:00");
-    AssertFormatting(formatter, 1, "1970-01-01 00:00:01");
-    AssertFormatting(formatter, 24 * 60 * 60, "1970-01-02 00:00:00");
-    AssertFormatting(formatter, 616377600, "1989-07-14 00:00:00");
-    AssertFormatting(formatter, 951782400, "2000-02-29 00:00:00");
-    AssertFormatting(formatter, 63730281600LL, "3989-07-14 00:00:00");
-    AssertFormatting(formatter, -2203977600LL, "1900-02-28 00:00:00");
+    AssertFormat(type, 0, "1970-01-01 00:00:00");
+    AssertFormat(type, 1, "1970-01-01 00:00:01");
+    AssertFormat(type, 24 * 60 * 60, "1970-01-02 00:00:00");
+    AssertFormat(type, 616377600, "1989-07-14 00:00:00");
+    AssertFormat(type, 951782400, "2000-02-29 00:00:00");
+    AssertFormat(type, 63730281600LL, "3989-07-14 00:00:00");
+    AssertFormat(type, -2203977600LL, "1900-02-28 00:00:00");
 
-    AssertFormatting(formatter, 1542129070, "2018-11-13 17:11:10");
-    AssertFormatting(formatter, -2203932304LL, "1900-02-28 12:34:56");
+    AssertFormat(type, 1542129070, "2018-11-13 17:11:10");
+    AssertFormat(type, -2203932304LL, "1900-02-28 12:34:56");
   }
 
   {
-    StringFormatter<TimestampType> formatter(timestamp(TimeUnit::MILLI));
+    TimestampType type(TimeUnit::MILLI);
 
-    AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000");
-    AssertFormatting(formatter, 1000L + 1, "1970-01-01 00:00:01.001");
-    AssertFormatting(formatter, 24 * 60 * 60 * 1000LL + 2, "1970-01-02 00:00:00.002");
-    AssertFormatting(formatter, 616377600 * 1000LL + 3, "1989-07-14 00:00:00.003");
-    AssertFormatting(formatter, 951782400 * 1000LL + 4, "2000-02-29 00:00:00.004");
-    AssertFormatting(formatter, 63730281600LL * 1000LL + 5, "3989-07-14 00:00:00.005");
-    AssertFormatting(formatter, -2203977600LL * 1000LL + 6, "1900-02-28 00:00:00.006");
+    AssertFormat(type, 0, "1970-01-01 00:00:00.000");
+    AssertFormat(type, 1000L + 1, "1970-01-01 00:00:01.001");
+    AssertFormat(type, 24 * 60 * 60 * 1000LL + 2, "1970-01-02 00:00:00.002");
+    AssertFormat(type, 616377600 * 1000LL + 3, "1989-07-14 00:00:00.003");
+    AssertFormat(type, 951782400 * 1000LL + 4, "2000-02-29 00:00:00.004");
+    AssertFormat(type, 63730281600LL * 1000LL + 5, "3989-07-14 00:00:00.005");
+    AssertFormat(type, -2203977600LL * 1000LL + 6, "1900-02-28 00:00:00.006");
 
-    AssertFormatting(formatter, 1542129070LL * 1000LL + 7, "2018-11-13 17:11:10.007");
-    AssertFormatting(formatter, -2203932304LL * 1000LL + 8, "1900-02-28 12:34:56.008");
+    AssertFormat(type, 1542129070LL * 1000LL + 7, "2018-11-13 17:11:10.007");
+    AssertFormat(type, -2203932304LL * 1000LL + 8, "1900-02-28 12:34:56.008");
   }
 
   {
-    StringFormatter<TimestampType> formatter(timestamp(TimeUnit::MICRO));
+    TimestampType type(TimeUnit::MICRO);
 
-    AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000000");
-    AssertFormatting(formatter, 1000000LL + 1, "1970-01-01 00:00:01.000001");
-    AssertFormatting(formatter, 24 * 60 * 60 * 1000000LL + 2,
-                     "1970-01-02 00:00:00.000002");
-    AssertFormatting(formatter, 616377600 * 1000000LL + 3, "1989-07-14 00:00:00.000003");
-    AssertFormatting(formatter, 951782400 * 1000000LL + 4, "2000-02-29 00:00:00.000004");
-    AssertFormatting(formatter, 63730281600LL * 1000000LL + 5,
-                     "3989-07-14 00:00:00.000005");
-    AssertFormatting(formatter, -2203977600LL * 1000000LL + 6,
-                     "1900-02-28 00:00:00.000006");
+    AssertFormat(type, 0, "1970-01-01 00:00:00.000000");
+    AssertFormat(type, 1000000LL + 1, "1970-01-01 00:00:01.000001");
+    AssertFormat(type, 24 * 60 * 60 * 1000000LL + 2, "1970-01-02 00:00:00.000002");
+    AssertFormat(type, 616377600 * 1000000LL + 3, "1989-07-14 00:00:00.000003");
+    AssertFormat(type, 951782400 * 1000000LL + 4, "2000-02-29 00:00:00.000004");
+    AssertFormat(type, 63730281600LL * 1000000LL + 5, "3989-07-14 00:00:00.000005");
+    AssertFormat(type, -2203977600LL * 1000000LL + 6, "1900-02-28 00:00:00.000006");
 
-    AssertFormatting(formatter, 1542129070 * 1000000LL + 7, "2018-11-13 17:11:10.000007");
-    AssertFormatting(formatter, -2203932304LL * 1000000LL + 8,
-                     "1900-02-28 12:34:56.000008");
+    AssertFormat(type, 1542129070 * 1000000LL + 7, "2018-11-13 17:11:10.000007");
+    AssertFormat(type, -2203932304LL * 1000000LL + 8, "1900-02-28 12:34:56.000008");
   }
 
   {
-    StringFormatter<TimestampType> formatter(timestamp(TimeUnit::NANO));
+    TimestampType type(TimeUnit::NANO);
 
-    AssertFormatting(formatter, 0, "1970-01-01 00:00:00.000000000");
-    AssertFormatting(formatter, 1000000000LL + 1, "1970-01-01 00:00:01.000000001");
-    AssertFormatting(formatter, 24 * 60 * 60 * 1000000000LL + 2,
-                     "1970-01-02 00:00:00.000000002");
-    AssertFormatting(formatter, 616377600 * 1000000000LL + 3,
-                     "1989-07-14 00:00:00.000000003");
-    AssertFormatting(formatter, 951782400 * 1000000000LL + 4,
-                     "2000-02-29 00:00:00.000000004");
-    AssertFormatting(formatter, -2203977600LL * 1000000000LL + 6,
-                     "1900-02-28 00:00:00.000000006");
+    AssertFormat(type, 0, "1970-01-01 00:00:00.000000000");
+    AssertFormat(type, 1000000000LL + 1, "1970-01-01 00:00:01.000000001");
+    AssertFormat(type, 24 * 60 * 60 * 1000000000LL + 2, "1970-01-02 00:00:00.000000002");
+    AssertFormat(type, 616377600 * 1000000000LL + 3, "1989-07-14 00:00:00.000000003");
+    AssertFormat(type, 951782400 * 1000000000LL + 4, "2000-02-29 00:00:00.000000004");
+    AssertFormat(type, -2203977600LL * 1000000000LL + 6, "1900-02-28 00:00:00.000000006");
 
-    AssertFormatting(formatter, 1542129070 * 1000000000LL + 7,
-                     "2018-11-13 17:11:10.000000007");
-    AssertFormatting(formatter, -2203932304LL * 1000000000LL + 8,
-                     "1900-02-28 12:34:56.000000008");
+    AssertFormat(type, 1542129070 * 1000000000LL + 7, "2018-11-13 17:11:10.000000007");
+    AssertFormat(type, -2203932304LL * 1000000000LL + 8, "1900-02-28 12:34:56.000000008");
   }
 }
 

--- a/cpp/src/arrow/util/formatting_util_test.cc
+++ b/cpp/src/arrow/util/formatting_util_test.cc
@@ -35,7 +35,7 @@ using internal::FormatValueTraits;
 template <typename ARROW_TYPE, typename Formatter = FormatValueTraits<ARROW_TYPE>,
           typename V = typename Formatter::value_type>
 void AssertFormat(const ARROW_TYPE& type, V value, const std::string& expected) {
-  ASSERT_EQ(FormatValue(type, value), expected)
+  ASSERT_EQ(FormatValue(type, value).to_string(), expected)
       << "Formatting failed (value = " << value << ")";
 }
 

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <vector>
 
+#include "arrow/util/optional.h"
 #include "arrow/util/string_view.h"
 #include "arrow/util/value_parsing.h"
 #include "arrow/vendored/uriparser/Uri.h"
@@ -264,12 +265,12 @@ Status Uri::Parse(const std::string& uri_string) {
   // Parse port number
   auto port_text = TextRangeToView(impl_->uri_.portText);
   if (port_text.size()) {
-    uint16_t port_num;
-    if (!ParseValue<UInt16Type>(port_text.data(), port_text.size(), &port_num)) {
-      return Status::Invalid("Invalid port number '", port_text, "' in URI '", uri_string,
-                             "'");
+    if (util::optional<uint16_t> port_num = ParseValue<UInt16Type>(port_text)) {
+      impl_->port_ = *port_num;
+      return Status::OK();
     }
-    impl_->port_ = port_num;
+    return Status::Invalid("Invalid port number '", port_text, "' in URI '", uri_string,
+                           "'");
   }
 
   return Status::OK();

--- a/cpp/src/arrow/util/value_parsing_benchmark.cc
+++ b/cpp/src/arrow/util/value_parsing_benchmark.cc
@@ -181,7 +181,7 @@ static void TimestampParsingStrptime(
 template <typename ARROW_TYPE, typename C_TYPE = typename ARROW_TYPE::c_type>
 static void IntegerFormatting(benchmark::State& state) {  // NOLINT non-const reference
   std::vector<C_TYPE> values = MakeInts<C_TYPE>(1000);
-  std::vector<char> buffer(FormatValueTraits<ARROW_TYPE>::MaxSize({}));
+  std::vector<char> buffer(FormatValueTraits<ARROW_TYPE>::max_size);
 
   for (auto _ : state) {
     for (const auto value : values) {
@@ -195,7 +195,7 @@ static void IntegerFormatting(benchmark::State& state) {  // NOLINT non-const re
 template <typename ARROW_TYPE, typename C_TYPE = typename ARROW_TYPE::c_type>
 static void FloatFormatting(benchmark::State& state) {  // NOLINT non-const reference
   std::vector<C_TYPE> values = MakeFloats<C_TYPE>(1000);
-  std::vector<char> buffer(FormatValueTraits<ARROW_TYPE>::MaxSize({}));
+  std::vector<char> buffer(FormatValueTraits<ARROW_TYPE>::max_size);
 
   for (auto _ : state) {
     for (const auto value : values) {

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -30,7 +30,7 @@ namespace internal {
 template <typename T>
 void AssertConversion(const T& type, const std::string& s, typename T::c_type expected) {
   typename T::c_type out{};
-  ASSERT_TRUE(ParseValue(type, s.data(), s.length(), &out))
+  ASSERT_TRUE(ParseValue(type, s, &out))
       << "Conversion failed for '" << s << "' (expected to return " << expected << ")";
   ASSERT_EQ(out, expected) << "Conversion failed for '" << s << "'";
 }
@@ -44,7 +44,7 @@ void AssertConversion(const std::string& s, typename T::c_type expected) {
 template <typename T>
 void AssertConversionFails(const T& type, const std::string& s) {
   typename T::c_type out{};
-  ASSERT_FALSE(ParseValue(type, s.data(), s.length(), &out))
+  ASSERT_FALSE(ParseValue(type, s, &out))
       << "Conversion should have failed for '" << s << "' (returned " << out << ")";
 }
 

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -152,28 +152,28 @@ char* gdv_fn_dec_to_string(int64_t context, int64_t x_high, uint64_t x_low,
   return ret;
 }
 
-#define CAST_NUMERIC_FROM_STRING(OUT_TYPE, ARROW_TYPE, TYPE_NAME)                    \
-  GANDIVA_EXPORT                                                                     \
-  OUT_TYPE gdv_fn_cast##TYPE_NAME##_utf8(int64_t context, const char* data,          \
-                                         int32_t len) {                              \
-    OUT_TYPE val = 0;                                                                \
-    /* trim leading and trailing spaces */                                           \
-    int32_t trimmed_len;                                                             \
-    int32_t start = 0, end = len - 1;                                                \
-    while (start <= end && data[start] == ' ') {                                     \
-      ++start;                                                                       \
-    }                                                                                \
-    while (end >= start && data[end] == ' ') {                                       \
-      --end;                                                                         \
-    }                                                                                \
-    trimmed_len = end - start + 1;                                                   \
-    const char* trimmed_data = data + start;                                         \
-    if (!arrow::internal::ParseValue<ARROW_TYPE>(trimmed_data, trimmed_len, &val)) { \
-      std::string err =                                                              \
-          "Failed to cast the string " + std::string(data, len) + " to " #OUT_TYPE;  \
-      gdv_fn_context_set_error_msg(context, err.c_str());                            \
-    }                                                                                \
-    return val;                                                                      \
+#define CAST_NUMERIC_FROM_STRING(OUT_TYPE, ARROW_TYPE, TYPE_NAME)                   \
+  GANDIVA_EXPORT                                                                    \
+  OUT_TYPE gdv_fn_cast##TYPE_NAME##_utf8(int64_t context, const char* data,         \
+                                         int32_t len) {                             \
+    OUT_TYPE val = 0;                                                               \
+    /* trim leading and trailing spaces */                                          \
+    int32_t start = 0, end = len - 1;                                               \
+    while (start <= end && data[start] == ' ') {                                    \
+      ++start;                                                                      \
+    }                                                                               \
+    while (end >= start && data[end] == ' ') {                                      \
+      --end;                                                                        \
+    }                                                                               \
+    size_t trimmed_len = end - start + 1;                                           \
+    const char* trimmed_data = data + start;                                        \
+    arrow::util::string_view view{trimmed_data, trimmed_len};                       \
+    if (!arrow::internal::ParseValue<ARROW_TYPE>(view, &val)) {                     \
+      std::string err =                                                             \
+          "Failed to cast the string " + std::string(data, len) + " to " #OUT_TYPE; \
+      gdv_fn_context_set_error_msg(context, err.c_str());                           \
+    }                                                                               \
+    return val;                                                                     \
   }
 
 CAST_NUMERIC_FROM_STRING(int32_t, arrow::Int32Type, INT)


### PR DESCRIPTION
Replace `StringConverter` with `ParseValueTraits` and emphasize that the function `ParseValue` is the entrypoint for parsing primitive values.

Replace `StringFormatter` with `FormatValueTraits` and add a function `FormatValue` to act as the entrypoint for formatting primitive values.

A number of convenience overloads are provided for both.