### PR TITLE
ARROW-9644: [C++][Dataset] Don't apply ignore_prefixes to partition base_dir

### DIFF
--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -176,6 +176,7 @@ Result<std::shared_ptr<DatasetFactory>> FileSystemDatasetFactory::Make(
     options.partition_base_dir = selector.base_dir;
   }
 
+  ARROW_ASSIGN_OR_RAISE(selector.base_dir, filesystem->NormalizePath(selector.base_dir));
   ARROW_ASSIGN_OR_RAISE(auto files, filesystem->GetFileInfo(selector));
 
   // Filter out anything that's not a file or that's explicitly ignored

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -282,6 +282,24 @@ TEST_F(FileSystemDatasetFactoryTest, OptionsIgnoredNoPrefixes) {
                          "not_ignored_by_default_either/dat"});
 }
 
+TEST_F(FileSystemDatasetFactoryTest, OptionsIgnoredPrefixesWithBaseDirectory) {
+  // ignore nothing
+  std::string dir = "_shouldnt_be_ignored/dataset/";
+  selector_.base_dir = dir;
+  selector_.recursive = true;
+  MakeFactory({
+      fs::File(dir + "."),
+      fs::File(dir + "_"),
+      fs::File(dir + "_$folder$/dat"),
+      fs::File(dir + "_SUCCESS"),
+      fs::File(dir + "not_ignored_by_default"),
+      fs::File(dir + "not_ignored_by_default_either/dat"),
+  });
+
+  AssertFinishWithPaths(
+      {dir + "not_ignored_by_default", dir + "not_ignored_by_default_either/dat"});
+}
+
 TEST_F(FileSystemDatasetFactoryTest, Inspect) {
   auto s = schema({field("f64", float64())});
   format_ = std::make_shared<DummyFileFormat>(s);

--- a/cpp/src/arrow/dataset/discovery_test.cc
+++ b/cpp/src/arrow/dataset/discovery_test.cc
@@ -220,6 +220,8 @@ TEST_F(FileSystemDatasetFactoryTest, MissingDirectories) {
 }
 
 TEST_F(FileSystemDatasetFactoryTest, OptionsIgnoredDefaultPrefixes) {
+  // When constructing a factory from a FileSelector,
+  // `selector_ignore_prefixes` governs which files are filtered out.
   selector_.recursive = true;
   MakeFactory({
       fs::File("."),
@@ -234,6 +236,8 @@ TEST_F(FileSystemDatasetFactoryTest, OptionsIgnoredDefaultPrefixes) {
 }
 
 TEST_F(FileSystemDatasetFactoryTest, OptionsIgnoredDefaultExplicitFiles) {
+  // When constructing a factory from an explicit list of paths,
+  // `selector_ignore_prefixes` is ignored.
   selector_.recursive = true;
   std::vector<fs::FileInfo> ignored_by_default = {
       fs::File(".ignored_by_default.parquet"),
@@ -266,7 +270,7 @@ TEST_F(FileSystemDatasetFactoryTest, OptionsIgnoredCustomPrefixes) {
 }
 
 TEST_F(FileSystemDatasetFactoryTest, OptionsIgnoredNoPrefixes) {
-  // ignore nothing
+  // Ignore nothing
   selector_.recursive = true;
   factory_options_.selector_ignore_prefixes = {};
   MakeFactory({
@@ -283,8 +287,9 @@ TEST_F(FileSystemDatasetFactoryTest, OptionsIgnoredNoPrefixes) {
 }
 
 TEST_F(FileSystemDatasetFactoryTest, OptionsIgnoredPrefixesWithBaseDirectory) {
-  // ignore nothing
-  std::string dir = "_shouldnt_be_ignored/dataset/";
+  //  ARROW-9644: the selector base_dir shouldn't be filtered out even if matches
+  // `selector_ignore_prefixes`.
+  std::string dir = "_shouldnt_be_ignored/.dataset/";
   selector_.base_dir = dir;
   selector_.recursive = true;
   MakeFactory({

--- a/cpp/src/arrow/python/filesystem.cc
+++ b/cpp/src/arrow/python/filesystem.cc
@@ -191,6 +191,16 @@ Result<std::shared_ptr<io::OutputStream>> PyFileSystem::OpenAppendStream(
   return stream;
 }
 
+Result<std::string> PyFileSystem::NormalizePath(std::string path) {
+  std::string normalized;
+  auto st = SafeCallIntoPython([&]() -> Status {
+    vtable_.normalize_path(handler_.obj(), path, &normalized);
+    return CheckPyError();
+  });
+  RETURN_NOT_OK(st);
+  return normalized;
+}
+
 }  // namespace fs
 }  // namespace py
 }  // namespace arrow

--- a/cpp/src/arrow/python/filesystem.h
+++ b/cpp/src/arrow/python/filesystem.h
@@ -65,6 +65,9 @@ class ARROW_PYTHON_EXPORT PyFileSystemVtable {
   std::function<void(PyObject*, const std::string& path,
                      std::shared_ptr<io::OutputStream>* out)>
       open_append_stream;
+
+  std::function<void(PyObject*, const std::string& path, std::string* out)>
+      normalize_path;
 };
 
 class ARROW_PYTHON_EXPORT PyFileSystem : public arrow::fs::FileSystem {
@@ -104,6 +107,8 @@ class ARROW_PYTHON_EXPORT PyFileSystem : public arrow::fs::FileSystem {
       const std::string& path) override;
   Result<std::shared_ptr<io::OutputStream>> OpenAppendStream(
       const std::string& path) override;
+
+  Result<std::string> NormalizePath(std::string path) override;
 
   PyObject* handler() const { return handler_.obj(); }
 

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -18,7 +18,7 @@
 """Dataset is currently unstable. APIs subject to change without notice."""
 
 import pyarrow as pa
-from pyarrow.fs import _normalize_path, _MockFileSystem
+from pyarrow.fs import _MockFileSystem
 from pyarrow.util import _stringify_path, _is_path_like
 
 from pyarrow._dataset import (  # noqa
@@ -227,7 +227,7 @@ def _ensure_fs(fs_or_uri):
         # component then it will be treated as a path prefix
         filesystem, prefix = FileSystem.from_uri(fs_or_uri)
         is_local = isinstance(filesystem, LocalFileSystem)
-        prefix = _normalize_path(filesystem, prefix)
+        prefix = filesystem.normalize_path(prefix)
         if prefix:
             # validate that the prefix is pointing to a directory
             prefix_info = filesystem.get_file_info([prefix])[0]
@@ -294,7 +294,7 @@ def _ensure_multiple_sources(paths, filesystem=None):
     filesystem, is_local = _ensure_fs(filesystem)
 
     # allow normalizing irregular paths such as Windows local paths
-    paths = [_normalize_path(filesystem, _stringify_path(p)) for p in paths]
+    paths = [filesystem.normalize_path(_stringify_path(p)) for p in paths]
 
     # validate that all of the paths are pointing to existing *files*
     # possible improvement is to group the file_infos by type and raise for
@@ -384,7 +384,7 @@ def _ensure_single_source(path, filesystem=None):
     filesystem, _ = _ensure_fs(filesystem)
 
     # ensure that the path is normalized before passing to dataset discovery
-    path = _normalize_path(filesystem, path)
+    path = filesystem.normalize_path(path)
 
     # retrieve the file descriptor
     if file_info is None:
@@ -502,7 +502,7 @@ def parquet_dataset(metadata_path, schema=None, filesystem=None, format=None,
     else:
         filesystem, _ = _ensure_fs(filesystem)
 
-    metadata_path = _normalize_path(filesystem, _stringify_path(metadata_path))
+    metadata_path = filesystem.normalize_path(_stringify_path(metadata_path))
     options = ParquetFactoryOptions(
         partition_base_dir=partition_base_dir,
         partitioning=_ensure_partitioning(partitioning)

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -27,7 +27,6 @@ from pyarrow._fs import (  # noqa
     LocalFileSystem,
     SubTreeFileSystem,
     _MockFileSystem,
-    _normalize_path,
     FileSystemHandler,
     PyFileSystem,
 )
@@ -116,6 +115,9 @@ class FSSpecHandler(FileSystemHandler):
         if isinstance(protocol, list):
             protocol = protocol[0]
         return "fsspec+{0}".format(protocol)
+
+    def normalize_path(self, path):
+        return path
 
     @staticmethod
     def _create_file_info(path, info):

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -209,6 +209,7 @@ ctypedef void CallbackOpenInputFile(object, const c_string&,
                                     shared_ptr[CRandomAccessFile]*)
 ctypedef void CallbackOpenOutputStream(object, const c_string&,
                                        shared_ptr[COutputStream]*)
+ctypedef void CallbackNormalizePath(object, const c_string&, c_string*)
 
 cdef extern from "arrow/python/filesystem.h" namespace "arrow::py::fs" nogil:
 
@@ -230,6 +231,7 @@ cdef extern from "arrow/python/filesystem.h" namespace "arrow::py::fs" nogil:
         function[CallbackOpenInputFile] open_input_file
         function[CallbackOpenOutputStream] open_output_stream
         function[CallbackOpenOutputStream] open_append_stream
+        function[CallbackNormalizePath] normalize_path
 
     cdef cppclass CPyFileSystem "arrow::py::fs::PyFileSystem":
         @staticmethod

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -127,18 +127,18 @@ def mockfs():
 
 @pytest.fixture
 def open_logging_fs(monkeypatch):
-    from pyarrow.fs import PyFileSystem, LocalFileSystem, _normalize_path
+    from pyarrow.fs import PyFileSystem, LocalFileSystem
     from .test_fs import ProxyHandler
 
     localfs = LocalFileSystem()
 
     def normalized(paths):
-        return {_normalize_path(localfs, str(p)) for p in paths}
+        return {localfs.normalize_path(str(p)) for p in paths}
 
     opened = set()
 
     def open_input_file(self, path):
-        path = _normalize_path(localfs, str(path))
+        path = localfs.normalize_path(str(path))
         opened.add(path)
         return self._fs.open_input_file(path)
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -48,6 +48,9 @@ class DummyHandler(FileSystemHandler):
     def get_type_name(self):
         return "dummy"
 
+    def normalize_path(self, path):
+        return path
+
     def get_file_info(self, paths):
         info = []
         for path in paths:
@@ -150,6 +153,9 @@ class ProxyHandler(FileSystemHandler):
 
     def get_type_name(self):
         return "proxy::" + self._fs.type_name
+
+    def normalize_path(self, path):
+        return self._fs.normalize_path(path)
 
     def get_file_info(self, paths):
         return self._fs.get_file_info(paths)
@@ -575,6 +581,12 @@ def test_type_name():
     assert fs.type_name == "local"
     fs = _MockFileSystem()
     assert fs.type_name == "mock"
+
+
+def test_normalize_path(fs):
+    # Trivial path names (without separators) should generally be
+    # already normalized.  Just a sanity check.
+    assert fs.normalize_path("foo") == "foo"
 
 
 def test_non_path_like_input_raises(fs):

--- a/python/pyarrow/tests/test_parquet.py
+++ b/python/pyarrow/tests/test_parquet.py
@@ -2662,7 +2662,7 @@ def test_ignore_hidden_files_underscore(tempdir, use_legacy_dataset):
 @pytest.mark.pandas
 @parametrize_legacy_dataset
 @pytest.mark.parametrize('dir_prefix', ['_', '.'])
-def test_ignore_no_private_directories_path_list(
+def test_ignore_no_private_directories_in_base_path(
     tempdir, dir_prefix, use_legacy_dataset
 ):
     # ARROW-8427 - don't ignore explicitly listed files if parent directory
@@ -2674,7 +2674,10 @@ def test_ignore_no_private_directories_path_list(
                                             file_nrows=5)
 
     dataset = pq.ParquetDataset(paths, use_legacy_dataset=use_legacy_dataset)
+    _assert_dataset_paths(dataset, paths, use_legacy_dataset)
 
+    # ARROW-9644 - don't ignore full directory with underscore in base path
+    dataset = pq.ParquetDataset(dirpath, use_legacy_dataset=use_legacy_dataset)
     _assert_dataset_paths(dataset, paths, use_legacy_dataset)
 
 


### PR DESCRIPTION
I still apply ignore_prefixes to all segments of paths yielded by a selector which lie *outside* an explicit partition base directory.