### PR TITLE
ARROW-9358: [Integration] remove generated_large_batch.json

### DIFF
--- a/cpp/src/arrow/flight/test_util.cc
+++ b/cpp/src/arrow/flight/test_util.cc
@@ -38,6 +38,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/ipc/test_common.h"
+#include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/util/logging.h"
@@ -154,6 +155,11 @@ Status GetBatchForFlight(const Ticket& ticket, std::shared_ptr<RecordBatchReader
   } else if (ticket.ticket == "ticket-dicts-1") {
     BatchVector batches;
     RETURN_NOT_OK(ExampleDictBatches(&batches));
+    *out = std::make_shared<BatchIterator>(batches[0]->schema(), batches);
+    return Status::OK();
+  } else if (ticket.ticket == "ticket-large-batch-1") {
+    BatchVector batches;
+    RETURN_NOT_OK(ExampleLargeBatches(&batches));
     *out = std::make_shared<BatchIterator>(batches[0]->schema(), batches);
     return Status::OK();
   } else {
@@ -504,6 +510,15 @@ std::shared_ptr<Schema> ExampleDictSchema() {
   return batch->schema();
 }
 
+std::shared_ptr<Schema> ExampleLargeSchema() {
+  std::vector<std::shared_ptr<arrow::Field>> fields;
+  for (int i = 0; i < 128; i++) {
+    const auto field_name = "f" + std::to_string(i);
+    fields.push_back(arrow::field(field_name, arrow::float64()));
+  }
+  return arrow::schema(fields);
+}
+
 std::vector<FlightInfo> ExampleFlightInfo() {
   Location location1;
   Location location2;
@@ -579,6 +594,20 @@ Status ExampleNestedBatches(BatchVector* out) {
     RETURN_NOT_OK(ipc::test::MakeListRecordBatch(&batch));
     out->push_back(batch);
   }
+  return Status::OK();
+}
+
+Status ExampleLargeBatches(BatchVector* out) {
+  const auto array_length = 32768;
+  std::shared_ptr<RecordBatch> batch;
+  std::vector<std::shared_ptr<arrow::Array>> arrays;
+  const auto arr = arrow::ConstantArrayGenerator::Float64(array_length, 1.0);
+  for (int i = 0; i < 128; i++) {
+    arrays.push_back(arr);
+  }
+  auto schema = ExampleLargeSchema();
+  out->push_back(RecordBatch::Make(schema, array_length, arrays));
+  out->push_back(RecordBatch::Make(schema, array_length, arrays));
   return Status::OK();
 }
 

--- a/cpp/src/arrow/flight/test_util.h
+++ b/cpp/src/arrow/flight/test_util.h
@@ -141,6 +141,9 @@ ARROW_FLIGHT_EXPORT
 std::shared_ptr<Schema> ExampleDictSchema();
 
 ARROW_FLIGHT_EXPORT
+std::shared_ptr<Schema> ExampleLargeSchema();
+
+ARROW_FLIGHT_EXPORT
 Status ExampleIntBatches(BatchVector* out);
 
 ARROW_FLIGHT_EXPORT
@@ -151,6 +154,9 @@ Status ExampleDictBatches(BatchVector* out);
 
 ARROW_FLIGHT_EXPORT
 Status ExampleNestedBatches(BatchVector* out);
+
+ARROW_FLIGHT_EXPORT
+Status ExampleLargeBatches(BatchVector* out);
 
 ARROW_FLIGHT_EXPORT
 std::vector<FlightInfo> ExampleFlightInfo();

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1485,7 +1485,7 @@ def generate_extension_case():
                           dictionaries=[dict0])
 
 
-def get_generated_json_files(tempdir=None, flight=False):
+def get_generated_json_files(tempdir=None):
     tempdir = tempdir or tempfile.mkdtemp(prefix='arrow-integration-')
 
     def _temp_path():
@@ -1582,11 +1582,6 @@ def get_generated_json_files(tempdir=None, flight=False):
         .skip_category('JS')
         .skip_category('Rust'),
     ]
-
-    if flight:
-        file_objs.append(generate_primitive_case([24 * 1024],
-                                                 name='large_batch')
-                         .skip_category('Rust'))
 
     generated_paths = []
     for file_obj in file_objs:

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -337,10 +337,7 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
         testers.append(RustTester(**kwargs))
 
     static_json_files = get_static_json_files()
-    generated_json_files = datagen.get_generated_json_files(
-        tempdir=tempdir,
-        flight=run_flight
-    )
+    generated_json_files = datagen.get_generated_json_files(tempdir=tempdir)
     json_files = static_json_files + generated_json_files
 
     # Additional integration test cases for Arrow Flight.

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBasicOperation.java
@@ -20,10 +20,12 @@ package org.apache.arrow.flight;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -33,6 +35,8 @@ import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.impl.Flight.FlightDescriptor.DescriptorType;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.types.pojo.ArrowType;
@@ -244,6 +248,50 @@ public class TestBasicOperation {
     });
   }
 
+  /** Ensure the client is configured to accept large messages. */
+  @Test
+  public void getStreamLargeBatch() throws Exception {
+    test(c -> {
+      try (final FlightStream stream = c.getStream(new Ticket(Producer.TICKET_LARGE_BATCH))) {
+        Assert.assertEquals(128, stream.getRoot().getFieldVectors().size());
+        Assert.assertTrue(stream.next());
+        Assert.assertEquals(65536, stream.getRoot().getRowCount());
+        Assert.assertTrue(stream.next());
+        Assert.assertEquals(65536, stream.getRoot().getRowCount());
+        Assert.assertFalse(stream.next());
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  /** Ensure the server is configured to accept large messages. */
+  @Test
+  public void startPutLargeBatch() throws Exception {
+    try (final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE)) {
+      final List<FieldVector> vectors = new ArrayList<>();
+      for (int col = 0; col < 128; col++) {
+        final BigIntVector vector = new BigIntVector("f" + col, allocator);
+        for (int row = 0; row < 65536; row++) {
+          vector.setSafe(row, row);
+        }
+        vectors.add(vector);
+      }
+      test(c -> {
+        try (final VectorSchemaRoot root = new VectorSchemaRoot(vectors)) {
+          root.setRowCount(65536);
+          final ClientStreamListener stream = c.startPut(FlightDescriptor.path(""), root, new SyncPutListener());
+          stream.putNext();
+          stream.putNext();
+          stream.completed();
+          stream.getResult();
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      });
+    }
+  }
+
   private void test(Consumer<FlightClient> consumer) throws Exception {
     test((c, a) -> {
       consumer.accept(c);
@@ -273,6 +321,7 @@ public class TestBasicOperation {
    * An example FlightProducer for test purposes.
    */
   public static class Producer implements FlightProducer, AutoCloseable {
+    static final byte[] TICKET_LARGE_BATCH = "large-batch".getBytes(StandardCharsets.UTF_8);
 
     private final BufferAllocator allocator;
 
@@ -313,8 +362,11 @@ public class TestBasicOperation {
     }
 
     @Override
-    public void getStream(CallContext context, Ticket ticket,
-        ServerStreamListener listener) {
+    public void getStream(CallContext context, Ticket ticket, ServerStreamListener listener) {
+      if (Arrays.equals(TICKET_LARGE_BATCH, ticket.getBytes())) {
+        getLargeBatch(listener);
+        return;
+      }
       final int size = 10;
 
       IntVector iv = new IntVector("c1", allocator);
@@ -341,6 +393,24 @@ public class TestBasicOperation {
       listener.putNext();
       root.clear();
       listener.completed();
+    }
+
+    private void getLargeBatch(ServerStreamListener listener) {
+      final List<FieldVector> vectors = new ArrayList<>();
+      for (int col = 0; col < 128; col++) {
+        final BigIntVector vector = new BigIntVector("f" + col, allocator);
+        for (int row = 0; row < 65536; row++) {
+          vector.setSafe(row, row);
+        }
+        vectors.add(vector);
+      }
+      try (final VectorSchemaRoot root = new VectorSchemaRoot(vectors)) {
+        root.setRowCount(65536);
+        listener.start(root);
+        listener.putNext();
+        listener.putNext();
+        listener.completed();
+      }
     }
 
     @Override


### PR DESCRIPTION
This should speed up integration tests by moving the expensive large batch test to the individual Flight implementations.