### PR TITLE
ARROW-9659: [C++] Fix RecordBatchStreamReader when source is CudaBufferReader

### DIFF
--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -187,9 +187,9 @@ class ARROW_EXPORT Array {
   const uint8_t* null_bitmap_data_;
 
   /// Protected method for constructors
-  inline void SetData(const std::shared_ptr<ArrayData>& data) {
-    if (data->buffers.size() > 0 && data->buffers[0]) {
-      null_bitmap_data_ = data->buffers[0]->data();
+  void SetData(const std::shared_ptr<ArrayData>& data) {
+    if (data->buffers.size() > 0) {
+      null_bitmap_data_ = data->GetValuesSafe<uint8_t>(0, /*offset=*/0);
     } else {
       null_bitmap_data_ = NULLPTR;
     }
@@ -225,15 +225,12 @@ class ARROW_EXPORT PrimitiveArray : public FlatArray {
  protected:
   PrimitiveArray() : raw_values_(NULLPTR) {}
 
-  inline void SetData(const std::shared_ptr<ArrayData>& data) {
-    auto values = data->buffers[1];
+  void SetData(const std::shared_ptr<ArrayData>& data) {
     this->Array::SetData(data);
-    raw_values_ = values == NULLPTR || !values->is_cpu() ? NULLPTR : values->data();
+    raw_values_ = data->GetValuesSafe<uint8_t>(1, /*offset=*/0);
   }
 
-  explicit inline PrimitiveArray(const std::shared_ptr<ArrayData>& data) {
-    SetData(data);
-  }
+  explicit PrimitiveArray(const std::shared_ptr<ArrayData>& data) { SetData(data); }
 
   const uint8_t* raw_values_;
 };
@@ -247,7 +244,7 @@ class ARROW_EXPORT NullArray : public FlatArray {
   explicit NullArray(int64_t length);
 
  private:
-  inline void SetData(const std::shared_ptr<ArrayData>& data) {
+  void SetData(const std::shared_ptr<ArrayData>& data) {
     null_bitmap_data_ = NULLPTR;
     data->null_count = data->length;
     data_ = data;

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -228,7 +228,7 @@ class ARROW_EXPORT PrimitiveArray : public FlatArray {
   inline void SetData(const std::shared_ptr<ArrayData>& data) {
     auto values = data->buffers[1];
     this->Array::SetData(data);
-    raw_values_ = values == NULLPTR ? NULLPTR : values->data();
+    raw_values_ = values == NULLPTR || !values->is_cpu() ? NULLPTR : values->data();
   }
 
   explicit inline PrimitiveArray(const std::shared_ptr<ArrayData>& data) {

--- a/cpp/src/arrow/array/array_binary.h
+++ b/cpp/src/arrow/array/array_binary.h
@@ -121,15 +121,9 @@ class BaseBinaryArray : public FlatArray {
 
   // Protected method for constructors
   void SetData(const std::shared_ptr<ArrayData>& data) {
-    auto value_offsets = data->buffers[1];
-    auto value_data = data->buffers[2];
     this->Array::SetData(data);
-    raw_data_ =
-        value_data == NULLPTR || !value_data->is_cpu() ? NULLPTR : value_data->data();
-    raw_value_offsets_ =
-        value_offsets == NULLPTR || !value_offsets->is_cpu()
-            ? NULLPTR
-            : reinterpret_cast<const offset_type*>(value_offsets->data());
+    raw_value_offsets_ = data->GetValuesSafe<offset_type>(1, /*offset=*/0);
+    raw_data_ = data->GetValuesSafe<uint8_t>(2, /*offset=*/0);
   }
 
   const offset_type* raw_value_offsets_;
@@ -231,7 +225,7 @@ class ARROW_EXPORT FixedSizeBinaryArray : public PrimitiveArray {
   const uint8_t* raw_values() const { return raw_values_ + data_->offset * byte_width_; }
 
  protected:
-  inline void SetData(const std::shared_ptr<ArrayData>& data) {
+  void SetData(const std::shared_ptr<ArrayData>& data) {
     this->PrimitiveArray::SetData(data);
     byte_width_ =
         internal::checked_cast<const FixedSizeBinaryType&>(*type()).byte_width();

--- a/cpp/src/arrow/array/array_binary.h
+++ b/cpp/src/arrow/array/array_binary.h
@@ -124,9 +124,10 @@ class BaseBinaryArray : public FlatArray {
     auto value_offsets = data->buffers[1];
     auto value_data = data->buffers[2];
     this->Array::SetData(data);
-    raw_data_ = value_data == NULLPTR ? NULLPTR : value_data->data();
+    raw_data_ =
+        value_data == NULLPTR || !value_data->is_cpu() ? NULLPTR : value_data->data();
     raw_value_offsets_ =
-        value_offsets == NULLPTR
+        value_offsets == NULLPTR || !value_data->is_cpu()
             ? NULLPTR
             : reinterpret_cast<const offset_type*>(value_offsets->data());
   }

--- a/cpp/src/arrow/array/array_binary.h
+++ b/cpp/src/arrow/array/array_binary.h
@@ -127,7 +127,7 @@ class BaseBinaryArray : public FlatArray {
     raw_data_ =
         value_data == NULLPTR || !value_data->is_cpu() ? NULLPTR : value_data->data();
     raw_value_offsets_ =
-        value_offsets == NULLPTR || !value_data->is_cpu()
+        value_offsets == NULLPTR || !value_offsets->is_cpu()
             ? NULLPTR
             : reinterpret_cast<const offset_type*>(value_offsets->data());
   }

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -41,6 +41,20 @@ namespace arrow {
 // ----------------------------------------------------------------------
 // ListArray
 
+template <typename TYPE>
+class BaseListArray;
+
+namespace internal {
+
+// Private helper for ListArray::SetData.
+// Unfortunately, trying to define BaseListArray::SetData outside of this header
+// doesn't play well with MSVC.
+template <typename TYPE>
+void SetListData(BaseListArray<TYPE>* self, const std::shared_ptr<ArrayData>& data,
+                 Type::type expected_type_id = TYPE::type_id);
+
+}  // namespace internal
+
 /// Base class for variable-sized list arrays, regardless of offset size.
 template <typename TYPE>
 class BaseListArray : public Array {
@@ -76,8 +90,9 @@ class BaseListArray : public Array {
   }
 
  protected:
-  void SetData(const std::shared_ptr<ArrayData>& data,
-               Type::type expected_type_id = TypeClass::type_id);
+  friend void internal::SetListData<TYPE>(BaseListArray<TYPE>* self,
+                                          const std::shared_ptr<ArrayData>& data,
+                                          Type::type expected_type_id);
 
   const TypeClass* list_type_ = NULLPTR;
   std::shared_ptr<Array> values_;
@@ -124,6 +139,8 @@ class ARROW_EXPORT ListArray : public BaseListArray<ListType> {
  protected:
   // This constructor defers SetData to a derived array class
   ListArray() = default;
+
+  void SetData(const std::shared_ptr<ArrayData>& data);
 };
 
 /// Concrete Array class for large list data (with 64-bit offsets)
@@ -163,6 +180,9 @@ class ARROW_EXPORT LargeListArray : public BaseListArray<LargeListType> {
 
   /// \brief Return list offsets as an Int64Array
   std::shared_ptr<Array> offsets() const;
+
+ protected:
+  void SetData(const std::shared_ptr<ArrayData>& data);
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/array_nested.h
+++ b/cpp/src/arrow/array/array_nested.h
@@ -76,6 +76,9 @@ class BaseListArray : public Array {
   }
 
  protected:
+  void SetData(const std::shared_ptr<ArrayData>& data,
+               Type::type expected_type_id = TypeClass::type_id);
+
   const TypeClass* list_type_ = NULLPTR;
   std::shared_ptr<Array> values_;
   const offset_type* raw_value_offsets_ = NULLPTR;
@@ -121,8 +124,6 @@ class ARROW_EXPORT ListArray : public BaseListArray<ListType> {
  protected:
   // This constructor defers SetData to a derived array class
   ListArray() = default;
-  void SetData(const std::shared_ptr<ArrayData>& data,
-               Type::type expected_type_id = Type::LIST);
 };
 
 /// Concrete Array class for large list data (with 64-bit offsets)
@@ -162,9 +163,6 @@ class ARROW_EXPORT LargeListArray : public BaseListArray<LargeListType> {
 
   /// \brief Return list offsets as an Int64Array
   std::shared_ptr<Array> offsets() const;
-
- protected:
-  void SetData(const std::shared_ptr<ArrayData>& data);
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/array_primitive.h
+++ b/cpp/src/arrow/array/array_primitive.h
@@ -119,11 +119,6 @@ class ARROW_EXPORT DayTimeIntervalArray : public PrimitiveArray {
   int32_t byte_width() const { return sizeof(TypeClass::DayMilliseconds); }
 
   const uint8_t* raw_values() const { return raw_values_ + data_->offset * byte_width(); }
-
- protected:
-  inline void SetData(const std::shared_ptr<ArrayData>& data) {
-    this->PrimitiveArray::SetData(data);
-  }
 };
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -114,7 +114,7 @@ Result<std::shared_ptr<ArrayData>> ArrayData::SliceSafe(int64_t off, int64_t len
 int64_t ArrayData::GetNullCount() const {
   int64_t precomputed = this->null_count.load();
   if (ARROW_PREDICT_FALSE(precomputed == kUnknownNullCount)) {
-    if (this->buffers[0]) {
+    if (this->buffers[0] && this->buffers[0]->is_cpu()) {
       precomputed = this->length -
                     CountSetBits(this->buffers[0]->data(), this->offset, this->length);
     } else {

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -114,7 +114,7 @@ Result<std::shared_ptr<ArrayData>> ArrayData::SliceSafe(int64_t off, int64_t len
 int64_t ArrayData::GetNullCount() const {
   int64_t precomputed = this->null_count.load();
   if (ARROW_PREDICT_FALSE(precomputed == kUnknownNullCount)) {
-    if (this->buffers[0] && this->buffers[0]->is_cpu()) {
+    if (this->buffers[0]) {
       precomputed = this->length -
                     CountSetBits(this->buffers[0]->data(), this->offset, this->length);
     } else {

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -180,6 +180,22 @@ struct ARROW_EXPORT ArrayData {
     return GetValues<T>(i, offset);
   }
 
+  // Like GetValues, but returns NULLPTR instead of aborting if the underlying
+  // buffer is not a CPU buffer.
+  template <typename T>
+  inline const T* GetValuesSafe(int i, int64_t absolute_offset) const {
+    if (buffers[i] && buffers[i]->is_cpu()) {
+      return reinterpret_cast<const T*>(buffers[i]->data()) + absolute_offset;
+    } else {
+      return NULLPTR;
+    }
+  }
+
+  template <typename T>
+  inline const T* GetValuesSafe(int i) const {
+    return GetValuesSafe<T>(i, offset);
+  }
+
   // Access a buffer's data as a typed C pointer
   template <typename T>
   inline T* GetMutableValues(int i, int64_t absolute_offset) {

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -46,9 +46,6 @@ struct ValidateArrayVisitor {
   }
 
   Status Visit(const PrimitiveArray& array) {
-    ARROW_RETURN_IF(array.data()->buffers.size() != 2,
-                    Status::Invalid("number of buffers is != 2"));
-
     if (array.length() > 0) {
       if (array.data()->buffers[1] == nullptr) {
         return Status::Invalid("values buffer is null");
@@ -61,9 +58,6 @@ struct ValidateArrayVisitor {
   }
 
   Status Visit(const Decimal128Array& array) {
-    if (array.data()->buffers.size() != 2) {
-      return Status::Invalid("number of buffers is != 2");
-    }
     if (array.length() > 0 && array.values() == nullptr) {
       return Status::Invalid("values is null");
     }
@@ -212,9 +206,6 @@ struct ValidateArrayVisitor {
  protected:
   template <typename BinaryArrayType>
   Status ValidateBinaryArray(const BinaryArrayType& array) {
-    if (array.data()->buffers.size() != 3) {
-      return Status::Invalid("number of buffers is != 3");
-    }
     if (array.value_data() == nullptr) {
       return Status::Invalid("value data buffer is null");
     }

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -220,7 +220,7 @@ struct ValidateArrayVisitor {
     }
     RETURN_NOT_OK(ValidateOffsets(array));
 
-    if (array.length() > 0) {
+    if (array.length() > 0 && array.value_offsets()->is_cpu()) {
       const auto first_offset = array.value_offset(0);
       const auto last_offset = array.value_offset(array.length());
       // This early test avoids undefined behaviour when computing `data_extent`
@@ -251,7 +251,7 @@ struct ValidateArrayVisitor {
     RETURN_NOT_OK(ValidateOffsets(array));
 
     // An empty list array can have 0 offsets
-    if (array.length() > 0) {
+    if (array.length() > 0 && array.value_offsets()->is_cpu()) {
       const auto first_offset = array.value_offset(0);
       const auto last_offset = array.value_offset(array.length());
       // This early test avoids undefined behaviour when computing `data_extent`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -276,7 +276,7 @@ services:
       cache_from:
         - ${REPO}:${ARCH}-ubuntu-${UBUNTU}-cuda-${CUDA}-cpp
       args:
-        base: nvidia/cuda:10.0-devel-ubuntu${UBUNTU}
+        base: nvidia/cuda:${CUDA}-devel-ubuntu${UBUNTU}
         clang_tools: ${CLANG_TOOLS}
         llvm: ${LLVM}
     shm_size: *shm-size


### PR DESCRIPTION
Related JIRA: [ARROW-9659](https://issues.apache.org/jira/browse/ARROW-9659)

Prior to 1.0.0, the `RecordBatchStreamReader` was capable of reading source CudaBuffers wrapped in a `CudaBufferReader`. In 1.0.0, the Array validation routines call into Buffer::data(), which throws an error if the source isn't in host memory.

This PR guards the call-sites I was able to find, but I may have missed others. I considered skipping Array validation if the buffers aren't on the host, but the other Array validation checks are still safe and useful to perform.