### PR TITLE
ARROW-9606: [C++][Dataset] Support `"a"_.In(<>).Assume(<compound>)` 

### DIFF
--- a/cpp/src/arrow/dataset/filter.h
+++ b/cpp/src/arrow/dataset/filter.h
@@ -575,6 +575,16 @@ auto VisitExpression(const Expression& expr, Visitor&& visitor)
   return visitor(internal::checked_cast<const CustomExpression&>(expr));
 }
 
+/// \brief Visit each subexpression of an arbitrarily nested conjunction.
+///
+/// | given                          | visit                                       |
+/// |--------------------------------|---------------------------------------------|
+/// | a and b                        | visit(a), visit(b)                          |
+/// | c                              | visit(c)                                    |
+/// | (a and b) and ((c or d) and e) | visit(a), visit(b), visit(c or d), visit(e) |
+ARROW_DS_EXPORT Status VisitConjunctionMembers(
+    const Expression& expr, const std::function<Status(const Expression&)>& visitor);
+
 /// \brief Insert CastExpressions where necessary to make a valid expression.
 ARROW_DS_EXPORT Result<std::shared_ptr<Expression>> InsertImplicitCasts(
     const Expression& expr, const Schema& schema);

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -72,7 +72,8 @@ class ExpressionsTest : public ::testing::Test {
   std::shared_ptr<DataType> ns = timestamp(TimeUnit::NANO);
   std::shared_ptr<Schema> schema_ =
       schema({field("a", int32()), field("b", int32()), field("f", float64()),
-              field("s", utf8()), field("ts", ns)});
+              field("s", utf8()), field("ts", ns),
+              field("dict_b", dictionary(int32(), int32()))});
   std::shared_ptr<Expression> always = scalar(true);
   std::shared_ptr<Expression> never = scalar(false);
 };
@@ -135,6 +136,12 @@ TEST_F(ExpressionsTest, SimplificationAgainstCompoundCondition) {
   auto set_123 = ArrayFromJSON(int32(), R"([1, 2, 3])");
   AssertSimplifiesTo("b"_.In(set_123), "a"_ == 3 and "b"_ == 3, *always);
   AssertSimplifiesTo("b"_.In(set_123), "a"_ == 3 and "b"_ == 5, *never);
+
+  auto dict_set_123 =
+      DictArrayFromJSON(dictionary(int32(), int32()), R"([1,2,0])", R"([1,2,3])");
+  ASSERT_OK_AND_ASSIGN(auto b_dict, dict_set_123->GetScalar(0));
+  AssertSimplifiesTo("b_dict"_.In(dict_set_123), "a"_ == 3 and "b_dict"_ == b_dict,
+                     *always);
 }
 
 TEST_F(ExpressionsTest, SimplificationToNull) {

--- a/cpp/src/arrow/dataset/filter_test.cc
+++ b/cpp/src/arrow/dataset/filter_test.cc
@@ -131,6 +131,10 @@ TEST_F(ExpressionsTest, SimplificationAgainstCompoundCondition) {
   AssertSimplifiesTo("b"_ > 5, "b"_ == 3 or "b"_ == 6, "b"_ > 5);
   AssertSimplifiesTo("b"_ > 7, "b"_ == 3 or "b"_ == 6, *never);
   AssertSimplifiesTo("b"_ > 5 and "b"_ < 10, "b"_ > 6 and "b"_ < 13, "b"_ < 10);
+
+  auto set_123 = ArrayFromJSON(int32(), R"([1, 2, 3])");
+  AssertSimplifiesTo("b"_.In(set_123), "a"_ == 3 and "b"_ == 3, *always);
+  AssertSimplifiesTo("b"_.In(set_123), "a"_ == 3 and "b"_ == 5, *never);
 }
 
 TEST_F(ExpressionsTest, SimplificationToNull) {

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -392,6 +392,7 @@ test_that("filter() with %in%", {
     tibble(int = df1$int[c(3, 4, 6)], part = 1)
   )
 
+# ARROW-9606: bug in %in% filter on partition column with >1 partition columns
   ds <- open_dataset(hive_dir)
   expect_equivalent(
     ds %>%

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -391,6 +391,17 @@ test_that("filter() with %in%", {
       collect(),
     tibble(int = df1$int[c(3, 4, 6)], part = 1)
   )
+
+  ds <- open_dataset(hive_dir, partitioning = hive_partition(other = utf8(), group = uint8()))
+  expect_equivalent(
+    ds %>%
+      filter(group %in% c(2)) %>%
+      select(chr, dbl) %>%
+      filter(dbl > 7 & dbl < 53) %>%
+      collect() %>%
+      arrange(dbl),
+    df2[1:2, c("chr", "dbl")]
+  )
 })
 
 test_that("filter() on timestamp columns", {

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -397,6 +397,7 @@ test_that("filter() with %in%", {
   expect_equivalent(
     ds %>%
       filter(group %in% 2) %>%
+      select(names(df2)) %>%
       collect(),
     df2
   )

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -392,7 +392,7 @@ test_that("filter() with %in%", {
     tibble(int = df1$int[c(3, 4, 6)], part = 1)
   )
 
-  ds <- open_dataset(hive_dir, partitioning = hive_partition(other = utf8(), group = uint8()))
+  ds <- open_dataset(hive_dir)
   expect_equivalent(
     ds %>%
       filter(group %in% 2) %>%

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -395,12 +395,9 @@ test_that("filter() with %in%", {
   ds <- open_dataset(hive_dir, partitioning = hive_partition(other = utf8(), group = uint8()))
   expect_equivalent(
     ds %>%
-      filter(group %in% c(2)) %>%
-      select(chr, dbl) %>%
-      filter(dbl > 7 & dbl < 53) %>%
-      collect() %>%
-      arrange(dbl),
-    df2[1:2, c("chr", "dbl")]
+      filter(group %in% 2) %>%
+      collect(),
+    df2
   )
 })
 


### PR DESCRIPTION
This enables predicate pushdown of `%in%` filters in the presence of compound partition information

@mpjdem