### PR TITLE
ARROW-9736 : [Ruby] gem no doc tweak

### DIFF
--- a/c_glib/README.md
+++ b/c_glib/README.md
@@ -226,7 +226,7 @@ On Debian GNU/Linux or Ubuntu:
 
 ```console
 % sudo apt install -y -V ruby-dev
-% sudo gem install bundler
+% sudo gem install --no-document bundler
 % (cd c_glib && bundle install)
 ```
 
@@ -242,7 +242,7 @@ On CentOS 7 or later:
 % sudo yum install -y gcc make patch openssl-devel readline-devel zlib-devel
 % rbenv install 2.4.1
 % rbenv global 2.4.1
-% gem install bundler
+% gem install --no-document bundler
 % (cd c_glib && bundle install)
 ```
 

--- a/ci/docker/linux-apt-c-glib.dockerfile
+++ b/ci/docker/linux-apt-c-glib.dockerfile
@@ -54,7 +54,7 @@ RUN luarocks install lgi
 # ERROR: Command errored out with exit status 1: /usr/bin/python3 /usr/share/python-wheels/pep517-0.7.0-py2.py3-none-any.whl/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpsk4jveay Check the logs for full command output.
 RUN (python3 -m pip install meson || \
          python3 -m pip install --no-use-pep517 meson) && \
-    gem install bundler
+    gem install --no-document bundler
 
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN bundle install --gemfile /arrow/c_glib/Gemfile

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -75,7 +75,7 @@ RUN pip install \
         sphinx_rtd_theme
 
 COPY c_glib/Gemfile /arrow/c_glib/
-RUN gem install bundler && \
+RUN gem install --no-document bundler && \
     bundle install --gemfile /arrow/c_glib/Gemfile
 
 COPY ci/scripts/r_deps.sh /arrow/ci/scripts/

--- a/dev/release/VERIFY.md
+++ b/dev/release/VERIFY.md
@@ -44,7 +44,7 @@ You can install them by the followings on Debian GNU/Linux and Ubuntu:
 
 ```console
 % sudo apt install -y -V libgirepository1.0-dev ruby-dev
-% sudo gem install gobject-introspection test-unit
+% sudo gem install --no-document gobject-introspection test-unit
 ```
 
 You can install them by the followings on CentOS:
@@ -59,14 +59,14 @@ You can install them by the followings on CentOS:
 % sudo yum install -y gcc make patch openssl-devel readline-devel zlib-devel
 % rbenv install 2.4.2
 % rbenv global 2.4.2
-% gem install gobject-introspection test-unit
+% gem install --no-document gobject-introspection test-unit
 ```
 
 You can install them by the followings on macOS:
 
 ```console
 % brew install -y gobject-introspection
-% gem install gobject-introspection test-unit
+% gem install --no-document gobject-introspection test-unit
 ```
 
 You need to set `PKG_CONFIG_PATH` to find libffi on macOS:

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -408,7 +408,7 @@ test_glib() {
   export GI_TYPELIB_PATH=$ARROW_HOME/lib/girepository-1.0:$GI_TYPELIB_PATH
 
   if ! bundle --version; then
-    gem install bundler
+    gem install --no-document bundler
   fi
 
   bundle install --path vendor/bundle

--- a/ruby/red-arrow-cuda/README.md
+++ b/ruby/red-arrow-cuda/README.md
@@ -38,7 +38,7 @@ Install Apache Arrow CUDA GLib before install Red Arrow CUDA. Install Apache Arr
 Install Red Arrow CUDA after you install Apache Arrow CUDA GLib:
 
 ```text
-% gem install red-arrow-cuda
+% gem install --no-document red-arrow-cuda
 ```
 
 ## Usage

--- a/ruby/red-arrow/README.md
+++ b/ruby/red-arrow/README.md
@@ -38,7 +38,7 @@ Install Apache Arrow GLib before install Red Arrow. See [Apache Arrow install do
 Install Red Arrow after you install Apache Arrow GLib:
 
 ```console
-% gem install red-arrow
+% gem install --no-document red-arrow
 ```
 
 ## Usage

--- a/ruby/red-gandiva/README.md
+++ b/ruby/red-gandiva/README.md
@@ -38,7 +38,7 @@ Install Gandiva GLib before install Red Gandiva. See [Apache Arrow install docum
 Install Red Gandiva after you install Gandiva GLib:
 
 ```text
-% gem install red-gandiva
+% gem install --no-document red-gandiva
 ```
 
 ## Usage

--- a/ruby/red-parquet/README.md
+++ b/ruby/red-parquet/README.md
@@ -38,7 +38,7 @@ Install Apache Parquet GLib before install Red Parquet. See [Apache Arrow instal
 Install Red Parquet after you install Apache Parquet GLib:
 
 ```text
-% gem install red-parquet
+% gem install --no-document red-parquet
 ```
 
 ## Usage

--- a/ruby/red-plasma/README.md
+++ b/ruby/red-plasma/README.md
@@ -38,7 +38,7 @@ Install Plasma GLib before install Red Plasma. See [Apache Arrow install documen
 Install Red Plasma after you install Plasma GLib:
 
 ```text
-% gem install red-plasma
+% gem install --no-document red-plasma
 ```
 
 ## Usage


### PR DESCRIPTION
Optimization tweak for ruby gems no doc while gems installation using
 "--no-document" . Also removal of depricated "--no-ri" and "--no-rdoc".

 More detail can be found at
 https://guides.rubygems.org/command-reference/#installupdate-options-2

 Signed-off-by: Pratik raj <rajpratik71@gmail.com>