### PR TITLE
ARROW-9678: [Rust] [DataFusion] Improve projection push down to remove unused columns

### DIFF
--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -231,3 +231,11 @@ pub fn max(expr: Expr) -> Expr {
         return_type: DataType::Float64,
     }
 }
+
+pub fn min(expr: Expr) -> Expr {
+    Expr::AggregateFunction {
+        name: "MIN".to_owned(),
+        args: vec![expr],
+        return_type: DataType::Float64,
+    }
+}


### PR DESCRIPTION
This PR makes the projection optimizer remove any projection or aggregation that is not used down the plan, thus improving speed and convenience.

This is worked on top of #7879 and only the last commit is specific to this PR.
