### PR TITLE
ARROW-9653: [Rust][DataFusion] Do not error in planner with SQL has multiple group by expressions

### DIFF
--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -500,50 +500,49 @@ impl RecordBatchReader for GroupedHashAggregateIterator {
                 )),
             };
             result_arrays.push(array.map_err(ExecutionError::into_arrow_external_error)?);
+        }
 
-            // aggregate values
-            for i in 0..self.aggr_expr.len() {
-                let aggr_data_type = self.aggr_expr[i]
-                    .data_type(&input_schema)
-                    .map_err(ExecutionError::into_arrow_external_error)?;
-                let array = match aggr_data_type {
-                    DataType::UInt8 => {
-                        aggr_array_from_map_entries!(UInt64Builder, UInt8, u64, map, i)
-                    }
-                    DataType::UInt16 => {
-                        aggr_array_from_map_entries!(UInt64Builder, UInt16, u64, map, i)
-                    }
-                    DataType::UInt32 => {
-                        aggr_array_from_map_entries!(UInt64Builder, UInt32, u64, map, i)
-                    }
-                    DataType::UInt64 => {
-                        aggr_array_from_map_entries!(UInt64Builder, UInt64, u64, map, i)
-                    }
-                    DataType::Int8 => {
-                        aggr_array_from_map_entries!(Int64Builder, Int8, i64, map, i)
-                    }
-                    DataType::Int16 => {
-                        aggr_array_from_map_entries!(Int64Builder, Int16, i64, map, i)
-                    }
-                    DataType::Int32 => {
-                        aggr_array_from_map_entries!(Int64Builder, Int32, i64, map, i)
-                    }
-                    DataType::Int64 => {
-                        aggr_array_from_map_entries!(Int64Builder, Int64, i64, map, i)
-                    }
-                    DataType::Float32 => {
-                        aggr_array_from_map_entries!(Float32Builder, Float32, f32, map, i)
-                    }
-                    DataType::Float64 => {
-                        aggr_array_from_map_entries!(Float64Builder, Float64, f64, map, i)
-                    }
-                    _ => Err(ExecutionError::ExecutionError(
-                        "Unsupported aggregate expr".to_string(),
-                    )),
-                };
-                result_arrays
-                    .push(array.map_err(ExecutionError::into_arrow_external_error)?);
-            }
+        // aggregate values
+        for i in 0..self.aggr_expr.len() {
+            let aggr_data_type = self.aggr_expr[i]
+                .data_type(&input_schema)
+                .map_err(ExecutionError::into_arrow_external_error)?;
+            let array = match aggr_data_type {
+                DataType::UInt8 => {
+                    aggr_array_from_map_entries!(UInt64Builder, UInt8, u64, map, i)
+                }
+                DataType::UInt16 => {
+                    aggr_array_from_map_entries!(UInt64Builder, UInt16, u64, map, i)
+                }
+                DataType::UInt32 => {
+                    aggr_array_from_map_entries!(UInt64Builder, UInt32, u64, map, i)
+                }
+                DataType::UInt64 => {
+                    aggr_array_from_map_entries!(UInt64Builder, UInt64, u64, map, i)
+                }
+                DataType::Int8 => {
+                    aggr_array_from_map_entries!(Int64Builder, Int8, i64, map, i)
+                }
+                DataType::Int16 => {
+                    aggr_array_from_map_entries!(Int64Builder, Int16, i64, map, i)
+                }
+                DataType::Int32 => {
+                    aggr_array_from_map_entries!(Int64Builder, Int32, i64, map, i)
+                }
+                DataType::Int64 => {
+                    aggr_array_from_map_entries!(Int64Builder, Int64, i64, map, i)
+                }
+                DataType::Float32 => {
+                    aggr_array_from_map_entries!(Float32Builder, Float32, f32, map, i)
+                }
+                DataType::Float64 => {
+                    aggr_array_from_map_entries!(Float64Builder, Float64, f64, map, i)
+                }
+                _ => Err(ExecutionError::ExecutionError(
+                    "Unsupported aggregate expr".to_string(),
+                )),
+            };
+            result_arrays.push(array.map_err(ExecutionError::into_arrow_external_error)?);
         }
 
         let batch = RecordBatch::try_new(self.schema.clone(), result_arrays)?;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -154,6 +154,44 @@ fn csv_query_group_by_int_min_max() -> Result<()> {
 }
 
 #[test]
+fn csv_query_group_by_two_columns() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv(&mut ctx)?;
+    let sql = "SELECT c1, c2, MIN(c3) FROM aggregate_test_100 GROUP BY c1, c2";
+    let mut actual = execute(&mut ctx, sql);
+    actual.sort();
+    let expected = [
+        "\"a\"\t1\t-85",
+        "\"a\"\t2\t-48",
+        "\"a\"\t3\t-72",
+        "\"a\"\t4\t-101",
+        "\"a\"\t5\t-101",
+        "\"b\"\t1\t12",
+        "\"b\"\t2\t-60",
+        "\"b\"\t3\t-101",
+        "\"b\"\t4\t-117",
+        "\"b\"\t5\t-82",
+        "\"c\"\t1\t-24",
+        "\"c\"\t2\t-117",
+        "\"c\"\t3\t-2",
+        "\"c\"\t4\t-90",
+        "\"c\"\t5\t-94",
+        "\"d\"\t1\t-99",
+        "\"d\"\t2\t93",
+        "\"d\"\t3\t-76",
+        "\"d\"\t4\t5",
+        "\"d\"\t5\t-59",
+        "\"e\"\t1\t36",
+        "\"e\"\t2\t-61",
+        "\"e\"\t3\t-95",
+        "\"e\"\t4\t-56",
+        "\"e\"\t5\t-86",
+    ];
+    assert_eq!(expected.join("\n"), actual.join("\n"));
+    Ok(())
+}
+
+#[test]
 fn csv_query_avg_sqrt() -> Result<()> {
     let mut ctx = create_ctx()?;
     register_aggregate_csv(&mut ctx)?;


### PR DESCRIPTION
Fix a loop bound bug in aggregate expression handling, tests for same

h2. Before this PR
```
CREATE EXTERNAL TABLE repro(a INT, b INT)
STORED AS CSV
WITH HEADER ROW
LOCATION 'repro.csv';

select sum(a), a, b from repro group by a, b;
ArrowError(InvalidArgumentError("number of columns(4) must match number of fields(3) in schema"))
```


h2. After this PR: 

```
CREATE EXTERNAL TABLE repro(a INT, b INT)
STORED AS CSV
WITH HEADER ROW
LOCATION 'repro.csv';

> select sum(a), a, b from repro group by a, b;

+--------+---+-----+
| sum(a) | a | b   |
+--------+---+-----+
| 2      | 2 | 100 |
| 1      | 1 | 100 |
| 2      | 2 | 200 |
| 1      | 1 | 200 |
| 2      | 2 | 300 |
+--------+---+-----+
5 row in set. Query took 0 seconds.
```

contents of `repro.csv`
```
a,b
1,100
1,200
2,100
2,200
2,300
```
