### PR TITLE
ARROW-9683: [Rust][DataFusion] Add debug printing to physical plans and associated types

### DIFF
--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -93,6 +93,7 @@ impl<'a> CsvReadOptions<'a> {
 }
 
 /// Execution plan for scanning a CSV file
+#[derive(Debug)]
 pub struct CsvExec {
     /// Path to directory containing partitioned CSV files with the same schema
     path: String,
@@ -184,6 +185,7 @@ impl ExecutionPlan for CsvExec {
 }
 
 /// CSV Partition
+#[derive(Debug)]
 struct CsvPartition {
     /// Path to the CSV File
     path: String,

--- a/rust/datafusion/src/execution/physical_plan/datasource.rs
+++ b/rust/datafusion/src/execution/physical_plan/datasource.rs
@@ -17,7 +17,10 @@
 
 //! ExecutionPlan implementation for DataFusion data sources
 
-use std::sync::{Arc, Mutex};
+use std::{
+    fmt::{self, Debug, Formatter},
+    sync::{Arc, Mutex},
+};
 
 use crate::error::Result;
 use crate::execution::physical_plan::{ExecutionPlan, Partition};
@@ -28,6 +31,15 @@ use arrow::record_batch::RecordBatchReader;
 pub struct DatasourceExec {
     schema: SchemaRef,
     partitions: Vec<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>,
+}
+
+impl Debug for DatasourceExec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DataSourceExec")
+            .field("schema", &self.schema)
+            .field("partitions.len", &self.partitions.len())
+            .finish()
+    }
 }
 
 impl DatasourceExec {
@@ -59,6 +71,12 @@ impl ExecutionPlan for DatasourceExec {
 /// Wrapper to convert a `SendableRecordBatchReader` into a `Partition`.
 pub struct DatasourcePartition {
     batch_iter: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
+}
+
+impl Debug for DatasourcePartition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DatasourcePartition").finish()
+    }
 }
 
 impl DatasourcePartition {

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -49,6 +49,7 @@ use arrow::datatypes::{DataType, Schema, TimeUnit};
 use arrow::record_batch::RecordBatch;
 
 /// Represents the column at a given index in a RecordBatch
+#[derive(Debug)]
 pub struct Column {
     name: String,
 }
@@ -94,6 +95,7 @@ pub fn col(name: &str) -> Arc<dyn PhysicalExpr> {
 }
 
 /// SUM aggregate expression
+#[derive(Debug)]
 pub struct Sum {
     expr: Arc<dyn PhysicalExpr>,
 }
@@ -152,6 +154,7 @@ macro_rules! sum_accumulate {
     }};
 }
 
+#[derive(Debug)]
 struct SumAccumulator {
     sum: Option<ScalarValue>,
 }
@@ -286,6 +289,7 @@ pub fn sum(expr: Arc<dyn PhysicalExpr>) -> Arc<dyn AggregateExpr> {
 }
 
 /// AVG aggregate expression
+#[derive(Debug)]
 pub struct Avg {
     expr: Arc<dyn PhysicalExpr>,
 }
@@ -347,6 +351,7 @@ macro_rules! avg_accumulate {
         };
     }};
 }
+#[derive(Debug)]
 struct AvgAccumulator {
     sum: Option<f64>,
     count: Option<i64>,
@@ -400,6 +405,7 @@ pub fn avg(expr: Arc<dyn PhysicalExpr>) -> Arc<dyn AggregateExpr> {
 }
 
 /// MAX aggregate expression
+#[derive(Debug)]
 pub struct Max {
     expr: Arc<dyn PhysicalExpr>,
 }
@@ -461,6 +467,7 @@ macro_rules! max_accumulate {
         };
     }};
 }
+#[derive(Debug)]
 struct MaxAccumulator {
     max: Option<ScalarValue>,
 }
@@ -595,6 +602,7 @@ pub fn max(expr: Arc<dyn PhysicalExpr>) -> Arc<dyn AggregateExpr> {
 }
 
 /// MIN aggregate expression
+#[derive(Debug)]
 pub struct Min {
     expr: Arc<dyn PhysicalExpr>,
 }
@@ -656,6 +664,7 @@ macro_rules! min_accumulate {
         };
     }};
 }
+#[derive(Debug)]
 struct MinAccumulator {
     min: Option<ScalarValue>,
 }
@@ -791,6 +800,7 @@ pub fn min(expr: Arc<dyn PhysicalExpr>) -> Arc<dyn AggregateExpr> {
 
 /// COUNT aggregate expression
 /// Returns the amount of non-null values of the given expression.
+#[derive(Debug)]
 pub struct Count {
     expr: Arc<dyn PhysicalExpr>,
 }
@@ -820,6 +830,7 @@ impl AggregateExpr for Count {
     }
 }
 
+#[derive(Debug)]
 struct CountAccumulator {
     count: u64,
 }
@@ -955,6 +966,7 @@ macro_rules! boolean_op {
     }};
 }
 /// Binary expression
+#[derive(Debug)]
 pub struct BinaryExpr {
     left: Arc<dyn PhysicalExpr>,
     op: Operator,
@@ -1051,6 +1063,7 @@ pub fn binary(
 }
 
 /// Not expression
+#[derive(Debug)]
 pub struct NotExpr {
     arg: Arc<dyn PhysicalExpr>,
 }
@@ -1099,6 +1112,7 @@ pub fn not(arg: Arc<dyn PhysicalExpr>) -> Arc<dyn PhysicalExpr> {
 }
 
 /// CAST expression casts an expression to a specific data type
+#[derive(Debug)]
 pub struct CastExpr {
     /// The expression to cast
     expr: Arc<dyn PhysicalExpr>,
@@ -1166,6 +1180,7 @@ impl PhysicalExpr for CastExpr {
 }
 
 /// Represents a non-null literal value
+#[derive(Debug)]
 pub struct Literal {
     value: ScalarValue,
 }
@@ -1252,7 +1267,7 @@ pub fn lit(value: ScalarValue) -> Arc<dyn PhysicalExpr> {
 }
 
 /// Represents Sort operation for a column in a RecordBatch
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PhysicalSortExpr {
     /// Physical expression representing the column to sort
     pub expr: Arc<dyn PhysicalExpr>,

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -44,6 +44,7 @@ use crate::logicalplan::ScalarValue;
 use fnv::FnvHashMap;
 
 /// Hash aggregate execution plan
+#[derive(Debug)]
 pub struct HashAggregateExec {
     group_expr: Vec<Arc<dyn PhysicalExpr>>,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
@@ -121,6 +122,7 @@ impl ExecutionPlan for HashAggregateExec {
     }
 }
 
+#[derive(Debug)]
 struct HashAggregatePartition {
     group_expr: Vec<Arc<dyn PhysicalExpr>>,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -30,6 +30,7 @@ use std::thread;
 use std::thread::JoinHandle;
 
 /// Limit execution plan
+#[derive(Debug)]
 pub struct LimitExec {
     /// Input schema
     schema: SchemaRef,
@@ -68,6 +69,7 @@ impl ExecutionPlan for LimitExec {
     }
 }
 
+#[derive(Debug)]
 struct LimitPartition {
     /// Input schema
     schema: SchemaRef,

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -26,6 +26,7 @@ use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Execution plan for reading in-memory batches of data
+#[derive(Debug)]
 pub struct MemoryExec {
     /// The partitions to query
     partitions: Vec<Vec<RecordBatch>>,
@@ -74,6 +75,7 @@ impl MemoryExec {
 }
 
 /// Memory partition
+#[derive(Debug)]
 struct MemoryPartition {
     /// Vector of record batches
     data: Vec<RecordBatch>,

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -30,6 +30,7 @@ use std::thread::JoinHandle;
 
 /// Merge execution plan executes partitions in parallel and combines them into a single
 /// partition. No guarantees are made about the order of the resulting partition.
+#[derive(Debug)]
 pub struct MergeExec {
     /// Input schema
     schema: SchemaRef,
@@ -57,6 +58,7 @@ impl ExecutionPlan for MergeExec {
     }
 }
 
+#[derive(Debug)]
 struct MergePartition {
     /// Input schema
     schema: SchemaRef,

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -18,7 +18,7 @@
 //! Traits for physical query plan, supporting parallel execution for partitioned relations.
 
 use std::cell::RefCell;
-use std::fmt::Display;
+use std::fmt::{Debug, Display};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
@@ -29,7 +29,7 @@ use arrow::datatypes::{DataType, Schema, SchemaRef};
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Partition-aware execution plan for a relation
-pub trait ExecutionPlan {
+pub trait ExecutionPlan: Debug {
     /// Get the schema for this execution plan
     fn schema(&self) -> SchemaRef;
     /// Get the partitions for this execution plan. Each partition can be executed in parallel.
@@ -37,14 +37,14 @@ pub trait ExecutionPlan {
 }
 
 /// Represents a partition of an execution plan that can be executed on a thread
-pub trait Partition: Send + Sync {
+pub trait Partition: Send + Sync + Debug {
     /// Execute this partition and return an iterator over RecordBatch
     fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>;
 }
 
 /// Expression that can be evaluated against a RecordBatch
 /// A Physical expression knows its type, nullability and how to evaluate itself.
-pub trait PhysicalExpr: Send + Sync + Display {
+pub trait PhysicalExpr: Send + Sync + Display + Debug {
     /// Get the data type of this expression, given the schema of the input
     fn data_type(&self, input_schema: &Schema) -> Result<DataType>;
     /// Decide whehter this expression is nullable, given the schema of the input
@@ -54,7 +54,7 @@ pub trait PhysicalExpr: Send + Sync + Display {
 }
 
 /// Aggregate expression that can be evaluated against a RecordBatch
-pub trait AggregateExpr: Send + Sync {
+pub trait AggregateExpr: Send + Sync + Debug {
     /// Get the data type of this expression, given the schema of the input
     fn data_type(&self, input_schema: &Schema) -> Result<DataType>;
     /// Evaluate the expression being aggregated
@@ -68,7 +68,7 @@ pub trait AggregateExpr: Send + Sync {
 }
 
 /// Aggregate accumulator
-pub trait Accumulator {
+pub trait Accumulator: Debug {
     /// Update the accumulator based on a row in a batch
     fn accumulate_scalar(&mut self, value: Option<ScalarValue>) -> Result<()>;
     /// Update the accumulator based on an array in a batch

--- a/rust/datafusion/src/execution/physical_plan/parquet.rs
+++ b/rust/datafusion/src/execution/physical_plan/parquet.rs
@@ -20,7 +20,7 @@
 use std::fs::File;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
-use std::thread;
+use std::{fmt, thread};
 
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::common;
@@ -31,9 +31,11 @@ use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use parquet::file::reader::SerializedFileReader;
 
 use crossbeam::channel::{bounded, Receiver, RecvError, Sender};
+use fmt::{Debug, Formatter};
 use parquet::arrow::{ArrowReader, ParquetFileArrowReader};
 
 /// Execution plan for scanning a Parquet file
+#[derive(Debug)]
 pub struct ParquetExec {
     /// Path to directory containing partitioned Parquet files with the same schema
     filenames: Vec<String>,
@@ -108,6 +110,12 @@ impl ExecutionPlan for ParquetExec {
 
 struct ParquetPartition {
     iterator: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
+}
+
+impl Debug for ParquetPartition {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ParquetPartition").finish()
+    }
 }
 
 impl ParquetPartition {

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -29,6 +29,7 @@ use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Execution plan for a projection
+#[derive(Debug)]
 pub struct ProjectionExec {
     /// The projection expressions
     expr: Vec<Arc<dyn PhysicalExpr>>,
@@ -95,6 +96,7 @@ impl ExecutionPlan for ProjectionExec {
 }
 
 /// Represents a single partition of a projection execution plan
+#[derive(Debug)]
 struct ProjectionPartition {
     schema: SchemaRef,
     expr: Vec<Arc<dyn PhysicalExpr>>,

--- a/rust/datafusion/src/execution/physical_plan/selection.rs
+++ b/rust/datafusion/src/execution/physical_plan/selection.rs
@@ -28,6 +28,7 @@ use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Execution plan for a Selection
+#[derive(Debug)]
 pub struct SelectionExec {
     /// The selection predicate expression
     expr: Arc<dyn PhysicalExpr>,
@@ -78,6 +79,7 @@ impl ExecutionPlan for SelectionExec {
 }
 
 /// Represents a single partition of a Selection execution plan
+#[derive(Debug)]
 struct SelectionPartition {
     schema: SchemaRef,
     expr: Arc<dyn PhysicalExpr>,

--- a/rust/datafusion/src/execution/physical_plan/sort.rs
+++ b/rust/datafusion/src/execution/physical_plan/sort.rs
@@ -33,6 +33,7 @@ use crate::execution::physical_plan::expressions::PhysicalSortExpr;
 use crate::execution::physical_plan::{common, ExecutionPlan, Partition};
 
 /// Sort execution plan
+#[derive(Debug)]
 pub struct SortExec {
     /// Input schema
     input: Arc<dyn ExecutionPlan>,
@@ -66,6 +67,7 @@ impl ExecutionPlan for SortExec {
 }
 
 /// Represents a single partition of a Sort execution plan
+#[derive(Debug)]
 struct SortPartition {
     schema: SchemaRef,
     expr: Vec<PhysicalSortExpr>,

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -26,6 +26,7 @@ use crate::error::Result;
 use crate::execution::physical_plan::PhysicalExpr;
 
 use arrow::record_batch::RecordBatch;
+use fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 /// Scalar UDF
@@ -42,6 +43,17 @@ pub struct ScalarFunction {
     pub return_type: DataType,
     /// UDF implementation
     pub fun: ScalarUdf,
+}
+
+impl Debug for ScalarFunction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScalarFunction")
+            .field("name", &self.name)
+            .field("args", &self.args)
+            .field("return_type", &self.return_type)
+            .field("fun", &"<FUNC>")
+            .finish()
+    }
 }
 
 impl ScalarFunction {
@@ -67,6 +79,17 @@ pub struct ScalarFunctionExpr {
     name: String,
     args: Vec<Arc<dyn PhysicalExpr>>,
     return_type: DataType,
+}
+
+impl Debug for ScalarFunctionExpr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ScalarFunctionExpr")
+            .field("fun", &"<FUNC>")
+            .field("name", &self.name)
+            .field("args", &self.args)
+            .field("return_type", &self.return_type)
+            .finish()
+    }
 }
 
 impl ScalarFunctionExpr {


### PR DESCRIPTION
For ARROW-9653, I was trying to debug the execution plan and I would have found it easier if there had been a way to display the execution plan to better understand and isolate the issue. This would also be nice to have as part of EXPLAIN plan functionality in ARROW-9654

In general, for debugging purposes, we would like to be able to dump out an execution plan. To do so in the idiomatic rust way, I made `ExecutionPlan` also implement `std::fmt::Debug` and then followed `rustc` guidance until I got everything that was needed

Here is an example plan for `"SELECT c1, c2, MIN(c3) FROM aggregate_test_100 GROUP BY c1, c2"` when printed using `println!("{:#?}", plan)`:

```
physical plan is HashAggregateExec {
    group_expr: [
        Column {
            name: "c1",
        },
        Column {
            name: "c2",
        },
    ],
    aggr_expr: [
        Min {
            expr: Column {
                name: "c3",
            },
        },
    ],
    input: DataSourceExec {
        schema: Schema {
            fields: [
                Field {
                    name: "c1",
                    data_type: Utf8,
                    nullable: false,
                    dict_id: 0,
                    dict_is_ordered: false,
                },
                Field {
                    name: "c2",
                    data_type: UInt32,
                    nullable: false,
                    dict_id: 0,
                    dict_is_ordered: false,
                },
                Field {
                    name: "c3",
                    data_type: Int8,
                    nullable: false,
                    dict_id: 0,
                    dict_is_ordered: false,
                },
            ],
            metadata: {},
        },
        partitions.len: 1,
    },
    schema: Schema {
        fields: [
            Field {
                name: "c1",
                data_type: Utf8,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
            },
            Field {
                name: "c2",
                data_type: UInt32,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
            },
            Field {
                name: "MIN(c3)",
                data_type: Int64,
                nullable: true,
                dict_id: 0,
                dict_is_ordered: false,
            },
        ],
        metadata: {},
    },
}
```