### PR TITLE
ARROW-9628: [Rust] Disable artifact caching for Mac OSX builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -152,12 +152,8 @@ jobs:
       - name: Fetch Submodules and Tags
         shell: bash
         run: ci/scripts/util_checkout.sh
-      - name: Cache Build Artifacts
-        uses: actions/cache@v1
-        with:
-          path: rust/target
-          key: macos-10-rust-${{ hashFiles('rust/**.rs') }}
-          restore-keys: macos-10-rust-
+      # Note we don't cache the build artifacts for MacOSX as it was causing intermittent failures
+      # see https://issues.apache.org/jira/browse/ARROW-9628
       - name: Run Clippy
         shell: bash
         run: ci/scripts/rust_lint.sh $(pwd)


### PR DESCRIPTION
This PR proposes disabling "build artifact caching" on Mac OSX builds because using this caching seems to cause intermittent CI failures for reasons I can't figure out. Perhaps someone that is more of an expert on github actions can help with a better root cause analysis

For example  https://github.com/apache/arrow/pull/7924/ @ https://github.com/apache/arrow/pull/7924/commits/2bc6bcc587b60af72a8d90ca1c5c741ab6e8bca0 fails in CI https://github.com/apache/arrow/runs/967509493 like this:

```
  Downloaded rand_core v0.5.1
    Checking arrow v2.0.0-SNAPSHOT (/Users/runner/work/arrow/arrow/rust/arrow)
error[E0463]: can't find crate for `serde_derive`
  --> arrow/src/datatypes.rs:36:5
   |
36 | use serde_derive::{Deserialize, Serialize};
   |     ^^^^^^^^^^^^ can't find crate

error: aborting due to previous error

For more information about this error, try `rustc --explain E0463`.
error: could not compile `arrow`.

To learn more, run the command again with --verbose.
##[error]Process completed with exit code 101.
```

When I remove the artifact caching step in https://github.com/apache/arrow/pull/7924 @ https://github.com/apache/arrow/pull/7924/commits/70ce8f4816cc1f486c528d153b9ef56ba290ee29, the tests passed: https://github.com/apache/arrow/runs/967743121


The caching was originally added in https://github.com/apache/arrow/commit/651201b0f516272d360e1717461fc72597365168 / https://github.com/apache/arrow/pull/7799 by @jorgecarleitao  / @kszucs  so perhaps they have some thoughts about better ways to fix this
