### PR TITLE
ARROW-9703: [Developer][Archery] Restartable cherry-picking process for creating maintenance branches

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -34,7 +34,7 @@ on:
 jobs:
 
   test:
-    # if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     name: Archery Unittests and Crossbow Check Config
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -44,21 +44,25 @@ jobs:
           fetch-depth: 0
       - name: Git Debug
         shell: bash
-        run: git log --oneline apache-arrow-1.0.0..apache-arrow-0.17.0
-      - name: Free Up Disk Space
-        run: ci/scripts/util_cleanup.sh
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.5'
-      - name: Install Archery, Crossbow- and Test Dependencies
-        working-directory: dev/archery
-        run: pip install pytest responses toolz jinja2 -e .[all]
-      - name: Archery Unittests
-        working-directory: dev/archery
-        run: pytest -v archery
-      - name: Archery Docker Validation
-        run: archery docker
-      - name: Crossbow Check Config
-        working-directory: dev/tasks
-        run: python crossbow.py check-config
+        run: |
+          git status
+          git tag -l
+          git branch -a
+          git log --oneline apache-arrow-1.0.0..apache-arrow-0.17.0
+      # - name: Free Up Disk Space
+      #   run: ci/scripts/util_cleanup.sh
+      # - name: Setup Python
+      #   uses: actions/setup-python@v1
+      #   with:
+      #     python-version: '3.5'
+      # - name: Install Archery, Crossbow- and Test Dependencies
+      #   working-directory: dev/archery
+      #   run: pip install pytest responses toolz jinja2 -e .[all]
+      # - name: Archery Unittests
+      #   working-directory: dev/archery
+      #   run: pytest -v archery
+      # - name: Archery Docker Validation
+      #   run: archery docker
+      # - name: Crossbow Check Config
+      #   working-directory: dev/tasks
+      #   run: python crossbow.py check-config

--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -34,7 +34,7 @@ on:
 jobs:
 
   test:
-    if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
+    # if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     name: Archery Unittests and Crossbow Check Config
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -42,9 +42,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Fetch Submodules and Tags
+      - name: Git Debug
         shell: bash
-        run: ci/scripts/util_checkout.sh
+        run: git log --oneline apache-arrow-1.0.0..apache-arrow-0.17.0
       - name: Free Up Disk Space
         run: ci/scripts/util_cleanup.sh
       - name: Setup Python

--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -42,27 +42,23 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Git Debug
+      - name: Git Fixup
         shell: bash
-        run: |
-          git status
-          git tag -l
-          git branch -a
-          git log --oneline apache-arrow-1.0.0..apache-arrow-0.17.0
-      # - name: Free Up Disk Space
-      #   run: ci/scripts/util_cleanup.sh
-      # - name: Setup Python
-      #   uses: actions/setup-python@v1
-      #   with:
-      #     python-version: '3.5'
-      # - name: Install Archery, Crossbow- and Test Dependencies
-      #   working-directory: dev/archery
-      #   run: pip install pytest responses toolz jinja2 -e .[all]
-      # - name: Archery Unittests
-      #   working-directory: dev/archery
-      #   run: pytest -v archery
-      # - name: Archery Docker Validation
-      #   run: archery docker
-      # - name: Crossbow Check Config
-      #   working-directory: dev/tasks
-      #   run: python crossbow.py check-config
+        run: git branch master origin/master
+      - name: Free Up Disk Space
+        run: ci/scripts/util_cleanup.sh
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.5'
+      - name: Install Archery, Crossbow- and Test Dependencies
+        working-directory: dev/archery
+        run: pip install pytest responses toolz jinja2 -e .[all]
+      - name: Archery Unittests
+        working-directory: dev/archery
+        run: pytest -v archery
+      - name: Archery Docker Validation
+        run: archery docker
+      - name: Crossbow Check Config
+        working-directory: dev/tasks
+        run: python crossbow.py check-config

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -954,6 +954,9 @@ def release_cherry_pick(obj, version, dry_run):
         release.cherry_pick_commits()
         click.echo('Executed the following commands:\n')
 
+    click.echo(
+        'git checkout {} -b {}'.format(release.previous.tag, release.branch)
+    )
     for commit in release.commits_to_pick():
         click.echo('git cherry-pick {}'.format(commit.hexsha))
 

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -950,11 +950,12 @@ def release_cherry_pick(obj, version, dry_run):
         raise click.UsageError('Cherry-pick command only supported for minor '
                                'and patch releases')
 
-    if dry_run:
-        for commit in release.commits_to_pick():
-            click.echo('git cherry-pick {}'.format(commit.hexsha))
-    else:
-        pass
+    if not dry_run:
+        release.cherry_pick_commits()
+        click.echo('Executed the following commands:\n')
+
+    for commit in release.commits_to_pick():
+        click.echo('git cherry-pick {}'.format(commit.hexsha))
 
 
 if __name__ == "__main__":

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -938,7 +938,7 @@ def release_changelog_regenerate(obj):
 
 @release.command('cherry-pick')
 @click.argument('version')
-@click.option('--dry-run/--execute', default=False,
+@click.option('--dry-run/--execute', default=True,
               help="Display the git commands instead of executing them.")
 @click.pass_obj
 def release_cherry_pick(obj, version, dry_run):

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -940,9 +940,14 @@ def release_changelog_regenerate(obj):
 @click.argument('version')
 @click.option('--dry-run/--execute', default=True,
               help="Display the git commands instead of executing them.")
+@click.option('--recreate/--continue', default=True,
+              help="Recreate the maintenance branch or only apply unapplied "
+                   "patches.")
 @click.pass_obj
-def release_cherry_pick(obj, version, dry_run):
-    """Cherry pick commits."""
+def release_cherry_pick(obj, version, dry_run, recreate):
+    """
+    Cherry pick commits.
+    """
     from .release import Release, MinorRelease, PatchRelease
 
     release = Release.from_jira(version, jira=obj['jira'], repo=obj['repo'])
@@ -951,14 +956,14 @@ def release_cherry_pick(obj, version, dry_run):
                                'and patch releases')
 
     if not dry_run:
-        release.cherry_pick_commits()
+        release.cherry_pick_commits(recreate_branch=recreate)
         click.echo('Executed the following commands:\n')
 
     click.echo(
         'git checkout {} -b {}'.format(release.previous.tag, release.branch)
     )
     for commit in release.commits_to_pick():
-        click.echo('git cherry-pick -X theirs {}'.format(commit.hexsha))
+        click.echo('git cherry-pick {}'.format(commit.hexsha))
 
 
 if __name__ == "__main__":

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -958,7 +958,7 @@ def release_cherry_pick(obj, version, dry_run):
         'git checkout {} -b {}'.format(release.previous.tag, release.branch)
     )
     for commit in release.commits_to_pick():
-        click.echo('git cherry-pick {}'.format(commit.hexsha))
+        click.echo('git cherry-pick -X theirs {}'.format(commit.hexsha))
 
 
 if __name__ == "__main__":

--- a/dev/archery/archery/release.py
+++ b/dev/archery/archery/release.py
@@ -450,6 +450,24 @@ class MaintenanceMixin:
 
         return patches_to_pick
 
+    def cherry_pick_commits(self):
+        current_branch = self.repo.active_branch()
+
+        if self.branch in self.repo.branches:
+            # always recreate the maintenance branch to keep the commit order
+            self.repo.delete_head(self.branch)
+
+        try:
+            # create and checkout the maintenance branch based off of the
+            # previous tag
+            self.repo.git.checkout(self.previous.tag, b=self.branch)
+
+            # cherry pick the commits based on the jira tickets
+            for commit in self.commits_to_pick():
+                self.repo.git.cherry_pick(commit.hexsha)
+        finally:
+            self.repo.git.checkout(current_branch)
+
 
 class MajorRelease(Release):
 
@@ -493,15 +511,3 @@ class PatchRelease(Release, MaintenanceMixin):
         No filtering, consider all releases.
         """
         return self.jira.project_versions('ARROW')
-
-    def cherry_pick_commits(self):
-        if self.branch in self.repo.branches:
-            # always recreate the maintenance branch to keep the commit order
-            self.repo.delete_head(self.branch)
-
-        # create and checkout the maintenance branch based on the previous tag
-        self.repo.git.checkout(self.previous.tag, b=self.branch)
-
-        # cherry pick the commits based on the jira tickets
-        for commit in self.commits_to_pick():
-            self.repo.git.cherry_pick(commit.hexsha)

--- a/dev/archery/archery/release.py
+++ b/dev/archery/archery/release.py
@@ -461,7 +461,7 @@ class MaintenanceMixin:
 
         # cherry pick the commits based on the jira tickets
         for commit in self.commits_to_pick():
-            self.repo.git.cherry_pick(commit.hexsha)
+            self.repo.git.cherry_pick(commit.hexsha, X='theirs')
 
 
 class MajorRelease(Release):

--- a/dev/archery/archery/release.py
+++ b/dev/archery/archery/release.py
@@ -453,7 +453,7 @@ class MaintenanceMixin:
     def cherry_pick_commits(self):
         if self.branch in self.repo.branches:
             # always recreate the maintenance branch to keep the commit order
-            self.repo.delete_head(self.branch)
+            self.repo.git.branch('-D', self.branch)
 
         # create and checkout the maintenance branch based off of the
         # previous tag

--- a/dev/archery/archery/release.py
+++ b/dev/archery/archery/release.py
@@ -448,7 +448,7 @@ class MaintenanceMixin:
         # the ones that are included in the jira release
         patches_to_pick = [c for c in commits if c.issue in self.issues]
 
-        return patches_to_pick
+        return reversed(patches_to_pick)
 
     def cherry_pick_commits(self):
         if self.branch in self.repo.branches:

--- a/dev/archery/archery/release.py
+++ b/dev/archery/archery/release.py
@@ -451,22 +451,17 @@ class MaintenanceMixin:
         return patches_to_pick
 
     def cherry_pick_commits(self):
-        current_branch = self.repo.active_branch
-
         if self.branch in self.repo.branches:
             # always recreate the maintenance branch to keep the commit order
             self.repo.delete_head(self.branch)
 
-        try:
-            # create and checkout the maintenance branch based off of the
-            # previous tag
-            self.repo.git.checkout(self.previous.tag, b=self.branch)
+        # create and checkout the maintenance branch based off of the
+        # previous tag
+        self.repo.git.checkout(self.previous.tag, b=self.branch)
 
-            # cherry pick the commits based on the jira tickets
-            for commit in self.commits_to_pick():
-                self.repo.git.cherry_pick(commit.hexsha)
-        finally:
-            self.repo.git.checkout(current_branch)
+        # cherry pick the commits based on the jira tickets
+        for commit in self.commits_to_pick():
+            self.repo.git.cherry_pick(commit.hexsha)
 
 
 class MajorRelease(Release):

--- a/dev/archery/archery/release.py
+++ b/dev/archery/archery/release.py
@@ -19,6 +19,7 @@ from collections import defaultdict
 import functools
 import os
 import re
+import pathlib
 import shelve
 import warnings
 
@@ -34,22 +35,39 @@ def cached_property(fn):
     return property(functools.lru_cache(maxsize=1)(fn))
 
 
-class JiraVersion(SemVer):
+class Version(SemVer):
 
     __slots__ = SemVer.__slots__ + ('released', 'release_date')
 
-    def __init__(self, original_jira_version):
-        super().__init__(**SemVer.parse(original_jira_version.name).to_dict())
-        self.released = original_jira_version.released
-        self.release_date = getattr(original_jira_version, 'releaseDate', None)
+    def __init__(self, version_string, released=False, release_date=None):
+        semver = SemVer.parse(version_string)
+        super().__init__(**semver.to_dict())
+        self.released = released
+        self.release_date = release_date
+
+    @classmethod
+    def from_jira(cls, jira_version):
+        return cls(
+            version_string=jira_version.name,
+            released=jira_version.released,
+            release_date=getattr(jira_version, 'releaseDate', None)
+        )
 
 
-class JiraIssue:
+class Issue:
 
-    def __init__(self, original_jira_issue):
-        self.key = original_jira_issue.key
-        self.type = original_jira_issue.fields.issuetype.name
-        self.summary = original_jira_issue.fields.summary
+    def __init__(self, key, type, summary):
+        self.key = key
+        self.type = type
+        self.summary = summary
+
+    @classmethod
+    def from_jira(cls, jira_issue):
+        return cls(
+            key=jira_issue.key,
+            type=jira_issue.fields.issuetype.name,
+            summary=jira_issue.fields.summary
+        )
 
     @property
     def project(self):
@@ -62,37 +80,35 @@ class JiraIssue:
 
 class Jira(JIRA):
 
-    def __init__(self, user=None, password=None):
+    def __init__(self, user=None, password=None,
+                 url='https://issues.apache.org/jira'):
         user = user or os.environ.get('APACHE_JIRA_USER')
         password = password or os.environ.get('APACHE_JIRA_PASSWORD')
-        super().__init__(
-            {'server': 'https://issues.apache.org/jira'},
-            basic_auth=(user, password)
-        )
+        super().__init__(url, basic_auth=(user, password))
 
-    def arrow_version(self, version_string):
+    def project_version(self, version_string, project='ARROW'):
         # query version from jira to populated with additional metadata
-        versions = self.arrow_versions()
-        # JiraVersion instances are comparable with strings
+        versions = self.project_versions(project)
+        # Version instances are comparable with strings
         return versions[versions.index(version_string)]
 
-    def arrow_versions(self):
+    def project_versions(self, project):
         versions = []
-        for v in self.project_versions('ARROW'):
+        for v in super().project_versions(project):
             try:
-                versions.append(JiraVersion(v))
+                versions.append(Version.from_jira(v))
             except ValueError:
                 # ignore invalid semantic versions like JS-0.4.0
                 continue
         return sorted(versions, reverse=True)
 
     def issue(self, key):
-        return JiraIssue(super().issue(key))
+        return Issue.from_jira(super().issue(key))
 
-    def arrow_issues(self, version):
-        query = "project=ARROW AND fixVersion={}".format(version)
-        issues = self.search_issues(query, maxResults=False)
-        return list(map(JiraIssue, issues))
+    def project_issues(self, version, project='ARROW'):
+        query = "project={} AND fixVersion={}".format(project, version)
+        issues = super().search_issues(query, maxResults=False)
+        return list(map(Issue.from_jira, issues))
 
 
 class CachedJira:
@@ -229,23 +245,41 @@ class Release:
         return "<{} {!r} {}>".format(self.__class__.__name__,
                                      str(self.version), status)
 
-    @classmethod
-    def from_jira(cls, version, jira=None, repo=None):
-        jira = jira or Jira()
+    @staticmethod
+    def from_jira(version, jira=None, repo=None):
+        if jira is None:
+            jira = Jira()
+        elif isinstance(jira, str):
+            jira = Jira(jira)
+        elif not isinstance(jira, (Jira, CachedJira)):
+            raise TypeError("`jira` argument must be a server url or a valid "
+                            "Jira instance")
 
         if repo is None:
             arrow = ArrowSources.find()
             repo = Repo(arrow.path)
-        else:
+        elif isinstance(repo, (str, pathlib.Path)):
             repo = Repo(repo)
+        elif not isinstance(repo, Repo):
+            raise TypeError("`repo` argument must be a path or a valid Repo "
+                            "instance")
 
         if isinstance(version, str):
-            version = jira.arrow_version(version)
-        elif not isinstance(version, JiraVersion):
+            version = jira.project_version(version, project='ARROW')
+        elif not isinstance(version, Version):
             raise TypeError(version)
 
         # decide the type of the release based on the version number
-        klass = Release if version.patch == 0 else PatchRelease
+        if version.patch == 0:
+            if version.minor == 0:
+                klass = MajorRelease
+            elif version.major == 0:
+                # handle minor releases before 1.0 as major releases
+                klass = MajorRelease
+            else:
+                klass = MinorRelease
+        else:
+            klass = PatchRelease
 
         # prevent instantiating release object directly
         obj = klass.__new__(klass)
@@ -265,23 +299,41 @@ class Release:
 
     @property
     def branch(self):
-        # TODO(kszucs): add apache remote
-        return "master"
+        raise NotImplementedError()
+
+    @property
+    def siblings(self):
+        """
+        Releases to consider when calculating previous and next releases.
+        """
+        raise NotImplementedError()
 
     @cached_property
     def previous(self):
         # select all non-patch releases
-        versions = [v for v in self.jira.arrow_versions() if v.patch == 0]
-        position = versions.index(self.version) + 1
-        if position == len(versions):
+        position = self.siblings.index(self.version)
+        try:
+            previous = self.siblings[position + 1]
+        except IndexError:
             # first release doesn't have a previous one
             return None
-        previous = versions[position]
-        return Release.from_jira(previous)
+        else:
+            return Release.from_jira(previous, jira=self.jira, repo=self.repo)
+
+    @cached_property
+    def next(self):
+        # select all non-patch releases
+        position = self.siblings.index(self.version)
+        if position <= 0:
+            raise ValueError("There is no upcoming release set in JIRA after "
+                             "version {}".format(self.version))
+        upcoming = self.siblings[position - 1]
+        return Release.from_jira(upcoming, jira=self.jira, repo=self.repo)
 
     @cached_property
     def issues(self):
-        return {i.key: i for i in self.jira.arrow_issues(self.version)}
+        issues = self.jira.project_issues(self.version, project='ARROW')
+        return {i.key: i for i in issues}
 
     @cached_property
     def commits(self):
@@ -370,52 +422,86 @@ class Release:
         return JiraChangelog(release=self, categories=categories)
 
 
-class PatchRelease(Release):
+class MaintenanceMixin:
+    """
+    Utility methods for cherry-picking commits from the main branch.
+    """
+
+    def commits_to_pick(self):
+        # collect commits applied on the main branch since the root of the
+        # maintenance branch (the previous major release)
+        if self.version.major == 0:
+            # treat minor releases as major releases preceeding 1.0.0 release
+            commit_range = "apache-arrow-0.{}.0..master".format(
+                self.version.minor - 1
+            )
+        else:
+            commit_range = "apache-arrow-{}.0.0..master".format(
+                self.version.major
+            )
+
+        # keeping the original order of the commits helps to minimize the merge
+        # conflicts during cherry-picks
+        commits = map(Commit, self.repo.iter_commits(commit_range))
+
+        # iterate over the commits applied on the main branch and filter out
+        # the ones that are included in the jira release
+        patches_to_pick = [c for c in commits if c.issue in self.issues]
+
+        return patches_to_pick
+
+
+class MajorRelease(Release):
 
     @property
     def branch(self):
-        # TODO(kszucs): add apache remote
+        return "master"
+
+    @cached_property
+    def siblings(self):
+        """
+        Filter only the major releases.
+        """
+        # handle minor releases before 1.0 as major releases
+        return [v for v in self.jira.project_versions('ARROW')
+                if v.patch == 0 and (v.major == 0 or v.minor == 0)]
+
+
+class MinorRelease(Release, MaintenanceMixin):
+
+    @property
+    def branch(self):
+        return "maint-{}.x.x".format(self.version.major)
+
+    @cached_property
+    def siblings(self):
+        """
+        Filter the major and minor releases.
+        """
+        return [v for v in self.jira.project_versions('ARROW') if v.patch == 0]
+
+
+class PatchRelease(Release, MaintenanceMixin):
+
+    @property
+    def branch(self):
         return "maint-{}.{}.x".format(self.version.major, self.version.minor)
 
     @cached_property
-    def previous(self):
-        # select all releases under this minor
-        versions = [v for v in self.jira.arrow_versions()
-                    if v.minor == self.version.minor]
-        previous = versions[versions.index(self.version) + 1]
-        return Release.from_jira(previous)
+    def siblings(self):
+        """
+        No filtering, consider all releases.
+        """
+        return self.jira.project_versions('ARROW')
 
-    def generate_update_branch_commands(self):
-        # cherry pick not yet cherry picked commits on top of the maintenance
-        # branch
-        try:
-            target = self.repo.branches[self.branch]
-        except IndexError:
-            # maintenance branch doesn't exist yet, so create one based off of
-            # the previous git tag
-            target = self.repo.create_head(self.branch, self.previous.tag)
+    def cherry_pick_commits(self):
+        if self.branch in self.repo.branches:
+            # always recreate the maintenance branch to keep the commit order
+            self.repo.delete_head(self.branch)
 
-        # collect commits applied on master since the root of the maintenance
-        # branch (the minor release of this patch release)
-        commit_range = "apache-arrow-{}.{}.0..master".format(
-            self.version.major, self.version.minor
-        )
-        commits = list(map(Commit, self.repo.iter_commits(commit_range)))
+        # create and checkout the maintenance branch based on the previous tag
+        self.repo.git.checkout(self.previous.tag, b=self.branch)
 
-        # iterate over commits applied on master and keep the original order of
-        # the commits to minimize the merge conflicts during cherry-picks
-        patch_commits = [c for c in commits if c.issue in self.issues]
-
-        commands = [
-            'git checkout -b {} {}'.format(target, self.previous.tag)
-        ]
-        for c in reversed(patch_commits):
-            commands.append(
-                'git cherry-pick {}  # {}'.format(c.hexsha, c.title)
-            )
-
-        return commands
-
-    # TODO(kszucs): update_branch method which tries to cherry pick to a
-    # temporary branch and if the patches apply cleanly then update the maint
-    # reference
+        # cherry pick the commits based on the jira tickets
+        for commit in self.commits_to_pick():
+            self.repo.git.cherry_pick(commit.hexsha)

--- a/dev/archery/archery/release.py
+++ b/dev/archery/archery/release.py
@@ -451,7 +451,7 @@ class MaintenanceMixin:
         return patches_to_pick
 
     def cherry_pick_commits(self):
-        current_branch = self.repo.active_branch()
+        current_branch = self.repo.active_branch
 
         if self.branch in self.repo.branches:
             # always recreate the maintenance branch to keep the commit order

--- a/dev/archery/archery/testing.py
+++ b/dev/archery/archery/testing.py
@@ -21,6 +21,19 @@ from unittest import mock
 import re
 
 
+class DotDict(dict):
+
+    def __getattr__(self, key):
+        try:
+            item = self[key]
+        except KeyError:
+            raise AttributeError(key)
+        if isinstance(item, dict):
+            return DotDict(item)
+        else:
+            return item
+
+
 class PartialEnv(dict):
 
     def __eq__(self, other):

--- a/dev/archery/archery/tests/test_release.py
+++ b/dev/archery/archery/tests/test_release.py
@@ -306,9 +306,9 @@ def test_maintenance_patch_selection(fake_jira):
 
     shas_to_pick = [c.hexsha for c in r.commits_to_pick()]
     expected = [
-        '9123dadfd123bca7af4eaa9455f5b0d1ca8b929d',
-        '6002ec388840de5622e39af85abdc57a2cccc9b2',
+        '8939b4bd446ee406d5225c79d563a27d30fd7d6d',
         'bcef6c95a324417e85e0140f9745d342cd8784b3',
-        '8939b4bd446ee406d5225c79d563a27d30fd7d6d'
+        '6002ec388840de5622e39af85abdc57a2cccc9b2',
+        '9123dadfd123bca7af4eaa9455f5b0d1ca8b929d',
     ]
     assert shas_to_pick == expected

--- a/dev/archery/archery/tests/test_release.py
+++ b/dev/archery/archery/tests/test_release.py
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import pytest
 
 from archery.release import (

--- a/dev/archery/archery/tests/test_release.py
+++ b/dev/archery/archery/tests/test_release.py
@@ -304,7 +304,9 @@ def test_release_commits(fake_jira, version, ncommits):
 def test_maintenance_patch_selection(fake_jira):
     r = Release.from_jira("0.17.1", jira=fake_jira)
 
-    shas_to_pick = [c.hexsha for c in r.commits_to_pick()]
+    shas_to_pick = [
+        c.hexsha for c in r.commits_to_pick(exclude_already_applied=False)
+    ]
     expected = [
         '8939b4bd446ee406d5225c79d563a27d30fd7d6d',
         'bcef6c95a324417e85e0140f9745d342cd8784b3',

--- a/dev/archery/archery/tests/test_release.py
+++ b/dev/archery/archery/tests/test_release.py
@@ -1,0 +1,314 @@
+import pytest
+
+from archery.release import (
+    Release, MajorRelease, MinorRelease, PatchRelease,
+    Jira, Version, Issue, CommitTitle, Commit
+)
+from archery.testing import DotDict
+
+
+# subset of issues per revision
+_issues = {
+    "1.0.1": [
+        Issue("ARROW-9684", type="Bug", summary="[C++] Title"),
+        Issue("ARROW-9667", type="New Feature", summary="[Crossbow] Title"),
+        Issue("ARROW-9659", type="Bug", summary="[C++] Title"),
+        Issue("ARROW-9644", type="Bug", summary="[C++][Dataset] Title"),
+        Issue("ARROW-9643", type="Bug", summary="[C++] Title"),
+        Issue("ARROW-9609", type="Bug", summary="[C++] Title"),
+        Issue("ARROW-9606", type="Bug", summary="[C++][Dataset] Title")
+    ],
+    "1.0.0": [
+        Issue("ARROW-300", type="New Feature", summary="[Format] Title"),
+        Issue("ARROW-4427", type="Task", summary="[Doc] Title"),
+        Issue("ARROW-5035", type="Improvement", summary="[C#] Title"),
+        Issue("ARROW-8473", type="Bug", summary="[Rust] Title"),
+        Issue("ARROW-8472", type="Bug", summary="[Go][Integration] Title"),
+        Issue("ARROW-8471", type="Bug", summary="[C++][Integration] Title"),
+        Issue("ARROW-8974", type="Improvement", summary="[C++] Title"),
+        Issue("ARROW-8973", type="New Feature", summary="[Java] Title")
+    ],
+    "0.17.1": [
+        Issue("ARROW-8684", type="Bug", summary="[Python] Title"),
+        Issue("ARROW-8657", type="Bug", summary="[C++][Parquet] Title"),
+        Issue("ARROW-8641", type="Bug", summary="[Python] Title"),
+        Issue("ARROW-8609", type="Bug", summary="[C++] Title"),
+    ],
+    "0.17.0": [
+        Issue("ARROW-2882", type="New Feature", summary="[C++][Python] Title"),
+        Issue("ARROW-2587", type="Bug", summary="[Python] Title"),
+        Issue("ARROW-2447", type="Improvement", summary="[C++] Title"),
+        Issue("ARROW-2255", type="Bug", summary="[Integration] Title"),
+        Issue("ARROW-1907", type="Bug", summary="[C++/Python] Title"),
+        Issue("ARROW-1636", type="New Feature", summary="[Format] Title")
+    ]
+}
+
+
+class FakeJira(Jira):
+
+    def __init__(self):
+        pass
+
+    def project_versions(self, project='ARROW'):
+        return [
+            Version("3.0.0", released=False),
+            Version("2.0.0", released=False),
+            Version("1.1.0", released=False),
+            Version("1.0.1", released=False),
+            Version("1.0.0", released=True),
+            Version("0.17.1", released=True),
+            Version("0.17.0", released=True),
+            Version("0.16.0", released=True),
+            Version("0.15.2", released=True),
+            Version("0.15.1", released=True),
+            Version("0.15.0", released=True),
+        ]
+
+    def project_issues(self, version, project='ARROW'):
+        return _issues[str(version)]
+
+
+@pytest.fixture
+def fake_jira():
+    return FakeJira()
+
+
+def test_version(fake_jira):
+    v = Version("1.2.5")
+    assert str(v) == "1.2.5"
+    assert v.major == 1
+    assert v.minor == 2
+    assert v.patch == 5
+    assert v.released is False
+    assert v.release_date is None
+
+    v = Version("1.0.0", released=True, release_date="2020-01-01")
+    assert str(v) == "1.0.0"
+    assert v.major == 1
+    assert v.minor == 0
+    assert v.patch == 0
+    assert v.released is True
+    assert v.release_date == "2020-01-01"
+
+
+def test_issue(fake_jira):
+    i = Issue("ARROW-1234", type='Bug', summary="title")
+    assert i.key == "ARROW-1234"
+    assert i.type == "Bug"
+    assert i.summary == "title"
+    assert i.project == "ARROW"
+    assert i.number == 1234
+
+    i = Issue("PARQUET-1111", type='Improvement', summary="another title")
+    assert i.key == "PARQUET-1111"
+    assert i.type == "Improvement"
+    assert i.summary == "another title"
+    assert i.project == "PARQUET"
+    assert i.number == 1111
+
+    fake_jira_issue = DotDict({
+        'key': 'ARROW-2222',
+        'fields': {
+            'issuetype': {
+                'name': 'Feature'
+            },
+            'summary': 'Issue title'
+        }
+    })
+    i = Issue.from_jira(fake_jira_issue)
+    assert i.key == "ARROW-2222"
+    assert i.type == "Feature"
+    assert i.summary == "Issue title"
+    assert i.project == "ARROW"
+    assert i.number == 2222
+
+
+def test_commit_title():
+    t = CommitTitle.parse(
+        "ARROW-9598: [C++][Parquet] Fix writing nullable structs"
+    )
+    assert t.project == "ARROW"
+    assert t.issue == "ARROW-9598"
+    assert t.components == ["C++", "Parquet"]
+    assert t.summary == "Fix writing nullable structs"
+
+    t = CommitTitle.parse(
+        "ARROW-8002: [C++][Dataset][R] Support partitioned dataset writing"
+    )
+    assert t.project == "ARROW"
+    assert t.issue == "ARROW-8002"
+    assert t.components == ["C++", "Dataset", "R"]
+    assert t.summary == "Support partitioned dataset writing"
+
+    t = CommitTitle.parse(
+        "ARROW-9600: [Rust][Arrow] pin older version of proc-macro2 during "
+        "build"
+    )
+    assert t.project == "ARROW"
+    assert t.issue == "ARROW-9600"
+    assert t.components == ["Rust", "Arrow"]
+    assert t.summary == "pin older version of proc-macro2 during build"
+
+    t = CommitTitle.parse("[Release] Update versions for 1.0.0")
+    assert t.project is None
+    assert t.issue is None
+    assert t.components == ["Release"]
+    assert t.summary == "Update versions for 1.0.0"
+
+    t = CommitTitle.parse("[Python][Doc] Fix rst role dataset.rst (#7725)")
+    assert t.project is None
+    assert t.issue is None
+    assert t.components == ["Python", "Doc"]
+    assert t.summary == "Fix rst role dataset.rst (#7725)"
+
+    t = CommitTitle.parse(
+        "PARQUET-1882: [C++] Buffered Reads should allow for 0 length"
+    )
+    assert t.project == 'PARQUET'
+    assert t.issue == 'PARQUET-1882'
+    assert t.components == ["C++"]
+    assert t.summary == "Buffered Reads should allow for 0 length"
+
+    t = CommitTitle.parse(
+        "ARROW-9340 [R] Use CRAN version of decor package "
+        "\nsomething else\n"
+        "\nwhich should be truncated"
+    )
+    assert t.project == 'ARROW'
+    assert t.issue == 'ARROW-9340'
+    assert t.components == ["R"]
+    assert t.summary == "Use CRAN version of decor package "
+
+
+def test_release_basics(fake_jira):
+    r = Release.from_jira("1.0.0", jira=fake_jira)
+    assert isinstance(r, MajorRelease)
+    assert r.is_released is True
+    assert r.branch == 'master'
+    assert r.tag == 'apache-arrow-1.0.0'
+
+    r = Release.from_jira("1.1.0", jira=fake_jira)
+    assert isinstance(r, MinorRelease)
+    assert r.is_released is False
+    assert r.branch == 'maint-1.x.x'
+    assert r.tag == 'apache-arrow-1.1.0'
+
+    # minor releases before 1.0 are treated as major releases
+    r = Release.from_jira("0.17.0", jira=fake_jira)
+    assert isinstance(r, MajorRelease)
+    assert r.is_released is True
+    assert r.branch == 'master'
+    assert r.tag == 'apache-arrow-0.17.0'
+
+    r = Release.from_jira("0.17.1", jira=fake_jira)
+    assert isinstance(r, PatchRelease)
+    assert r.is_released is True
+    assert r.branch == 'maint-0.17.x'
+    assert r.tag == 'apache-arrow-0.17.1'
+
+
+def test_previous_and_next_release(fake_jira):
+    r = Release.from_jira("3.0.0", jira=fake_jira)
+    assert isinstance(r.previous, MajorRelease)
+    assert r.previous.version == "2.0.0"
+    with pytest.raises(ValueError, match="There is no upcoming release set"):
+        assert r.next
+
+    r = Release.from_jira("2.0.0", jira=fake_jira)
+    assert isinstance(r.previous, MajorRelease)
+    assert isinstance(r.next, MajorRelease)
+    assert r.previous.version == "1.0.0"
+    assert r.next.version == "3.0.0"
+
+    r = Release.from_jira("1.1.0", jira=fake_jira)
+    assert isinstance(r.previous, MajorRelease)
+    assert isinstance(r.next, MajorRelease)
+    assert r.previous.version == "1.0.0"
+    assert r.next.version == "2.0.0"
+
+    r = Release.from_jira("1.0.0", jira=fake_jira)
+    assert isinstance(r.next, MajorRelease)
+    assert isinstance(r.previous, MajorRelease)
+    assert r.previous.version == "0.17.0"
+    assert r.next.version == "2.0.0"
+
+    r = Release.from_jira("0.17.0", jira=fake_jira)
+    assert isinstance(r.previous, MajorRelease)
+    assert r.previous.version == "0.16.0"
+
+    r = Release.from_jira("0.15.2", jira=fake_jira)
+    assert isinstance(r.previous, PatchRelease)
+    assert isinstance(r.next, MajorRelease)
+    assert r.previous.version == "0.15.1"
+    assert r.next.version == "0.16.0"
+
+    r = Release.from_jira("0.15.1", jira=fake_jira)
+    assert isinstance(r.previous, MajorRelease)
+    assert isinstance(r.next, PatchRelease)
+    assert r.previous.version == "0.15.0"
+    assert r.next.version == "0.15.2"
+
+
+def test_release_issues(fake_jira):
+    # major release issues
+    r = Release.from_jira("1.0.0", jira=fake_jira)
+    assert r.issues.keys() == set([
+        "ARROW-300",
+        "ARROW-4427",
+        "ARROW-5035",
+        "ARROW-8473",
+        "ARROW-8472",
+        "ARROW-8471",
+        "ARROW-8974",
+        "ARROW-8973"
+    ])
+    # minor release issues
+    r = Release.from_jira("0.17.0", jira=fake_jira)
+    assert r.issues.keys() == set([
+        "ARROW-2882",
+        "ARROW-2587",
+        "ARROW-2447",
+        "ARROW-2255",
+        "ARROW-1907",
+        "ARROW-1636",
+    ])
+    # patch release issues
+    r = Release.from_jira("1.0.1", jira=fake_jira)
+    assert r.issues.keys() == set([
+        "ARROW-9684",
+        "ARROW-9667",
+        "ARROW-9659",
+        "ARROW-9644",
+        "ARROW-9643",
+        "ARROW-9609",
+        "ARROW-9606"
+    ])
+
+
+@pytest.mark.parametrize(('version', 'ncommits'), [
+    ("1.0.0", 771),
+    ("0.17.1", 27),
+    ("0.17.0", 569),
+    ("0.15.1", 41)
+])
+def test_release_commits(fake_jira, version, ncommits):
+    r = Release.from_jira(version, jira=fake_jira)
+    assert len(r.commits) == ncommits
+    for c in r.commits:
+        assert isinstance(c, Commit)
+        assert isinstance(c.title, CommitTitle)
+        assert c.url.endswith(c.hexsha)
+
+
+def test_maintenance_patch_selection(fake_jira):
+    r = Release.from_jira("0.17.1", jira=fake_jira)
+
+    shas_to_pick = [c.hexsha for c in r.commits_to_pick()]
+    expected = [
+        '9123dadfd123bca7af4eaa9455f5b0d1ca8b929d',
+        '6002ec388840de5622e39af85abdc57a2cccc9b2',
+        'bcef6c95a324417e85e0140f9745d342cd8784b3',
+        '8939b4bd446ee406d5225c79d563a27d30fd7d6d'
+    ]
+    assert shas_to_pick == expected


### PR DESCRIPTION
Refactored the release related utilities and also covered the main components with unit tests.

Updated the cherry-picking command to calculate the patches required to pick but not yet picked to the maintenance branch, so the cherry-picking procedure can be restarted now. 

1. `archery release cherry-pick 1.0.1 --execute --recreate`: re-creates `maint-1.0.x` and tries to apply all the required patches
2. `archery release cherry-pick 1.0.1 --execute --continue`: in case of a merge conflict the process can be continued 

