### PR TITLE
ARROW-9696: [Rust] [DataFusion] fix nested binary expressions

### DIFF
--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -321,6 +321,7 @@ pub enum Expr {
         /// Right-hand side of the expression
         right: Box<Expr>,
     },
+    Nested(Box<Expr>),
     /// unary NOT
     Not(Box<Expr>),
     /// unary IS NOT NULL
@@ -399,6 +400,7 @@ impl Expr {
             Expr::Wildcard => Err(ExecutionError::General(
                 "Wildcard expressions are not valid in a logical query plan".to_owned(),
             )),
+            Expr::Nested(e) => e.get_type(schema),
         }
     }
 
@@ -646,6 +648,7 @@ impl fmt::Debug for Expr {
                 write!(f, ")")
             }
             Expr::Wildcard => write!(f, "*"),
+            Expr::Nested(expr) => write!(f, "({:?})", expr),
         }
     }
 }

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -321,6 +321,7 @@ pub enum Expr {
         /// Right-hand side of the expression
         right: Box<Expr>,
     },
+    /// Nested expression e.g. `(foo > bar)` or `(1)`
     Nested(Box<Expr>),
     /// unary NOT
     Not(Box<Expr>),

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -137,6 +137,7 @@ impl<'a> TypeCoercionRule<'a> {
             Expr::Wildcard { .. } => Err(ExecutionError::General(
                 "Wildcard expressions are not valid in a logical query plan".to_owned(),
             )),
+            Expr::Nested(e) => self.rewrite_expr(e, schema),
         }
     }
 }

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -64,6 +64,7 @@ pub fn expr_to_column_names(expr: &Expr, accum: &mut HashSet<String>) -> Result<
         Expr::Wildcard => Err(ExecutionError::General(
             "Wildcard expressions are not valid in a logical query plan".to_owned(),
         )),
+        Expr::Nested(e) => expr_to_column_names(e, accum),
     }
 }
 

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -648,7 +648,7 @@ mod tests {
     #[test]
     fn select_binary_expr_nested() {
         let sql = "SELECT (age + salary)/2 from person";
-        let expected = "Projection: #age Plus #salary\
+        let expected = "Projection: #age Plus #salary Divide Int64(2)\
                         \n  TableScan: person projection=None";
         quick_test(sql, expected);
     }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -515,6 +515,8 @@ impl<S: SchemaProvider> SqlToRel<S> {
                 }
             }
 
+            SQLExpr::Nested(e) => self.sql_to_rex(&e, &schema),
+
             _ => Err(ExecutionError::General(format!(
                 "Unsupported ast node {:?} in sqltorel",
                 sql
@@ -632,6 +634,22 @@ mod tests {
                         And #age Lt Int64(65) \
                         And #age LtEq Int64(65)\
                         \n    TableScan: person projection=None";
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn select_binary_expr() {
+        let sql = "SELECT age + salary from person";
+        let expected = "Projection: #age Plus #salary\
+                        \n  TableScan: person projection=None";
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn select_binary_expr_nested() {
+        let sql = "SELECT (age + salary)/2 from person";
+        let expected = "Projection: #age Plus #salary\
+                        \n  TableScan: person projection=None";
         quick_test(sql, expected);
     }
 


### PR DESCRIPTION
Nested binary expressions like `(a+b)/2` were previously supported and were broken by the upgrade to sqlparser 0.6.1.