### PR TITLE
ARROW-9700: [Python] fix create_library_symlinks for macos

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -380,7 +380,9 @@ def create_library_symlinks():
         bundled_libs = glob.glob(_os.path.join(package_cwd, '*.*.dylib'))
 
         def get_symlink_path(hard_path):
-            return '.'.join((hard_path.split('.')[0], 'dylib'))
+            splits = hard_path.split('.')
+            splits.pop(-2)
+            return '.'.join(splits)
 
     for lib_hard_path in bundled_libs:
         symlink_path = get_symlink_path(lib_hard_path)

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -380,9 +380,7 @@ def create_library_symlinks():
         bundled_libs = glob.glob(_os.path.join(package_cwd, '*.*.dylib'))
 
         def get_symlink_path(hard_path):
-            splits = hard_path.split('.')
-            splits.pop(-2)
-            return '.'.join(splits)
+            return '.'.join((hard_path.rsplit('.', 2)[0], 'dylib'))
 
     for lib_hard_path in bundled_libs:
         symlink_path = get_symlink_path(lib_hard_path)


### PR DESCRIPTION
If there is any `.` is included in path such as `/Users/xxx/anaconda3/envs/ray/lib/python3.6/site-packages/pyarrow/libarrow.100.dylib`, the current implementation generates wrong symlink path such as `/Users/xxx/anaconda3/envs/ray/lib/python3.dylib`.