### PR TITLE
ARROW-9701: [CI][Java] Add a job for s390x Java on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ jobs:
         ARCH: arm64v8
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
+        DOCKER_RUN_ARGS: >-
+          -e ARROW_BUILD_STATIC=OFF
+          -e ARROW_ORC=OFF
+          -e CMAKE_UNITY_BUILD=ON
         UBUNTU: "20.04"
 
     - name: "C++ on s390x"
@@ -48,16 +52,19 @@ jobs:
       env:
         ARCH: s390x
         ARROW_CI_MODULES: "CPP"
-        ARROW_FLIGHT: "ON"
-        ARROW_PARQUET: "OFF"
-        CMAKE_UNITY_BUILD: "OFF"  # Avoid compiler crash
         DOCKER_IMAGE_ID: ubuntu-cpp
-        PARQUET_BUILD_EXAMPLES: "OFF"
-        PARQUET_BUILD_EXECUTABLES: "OFF"
-        Protobuf_SOURCE: "BUNDLED"
+        # CMAKE_UNITIFY_BUILD=OFF is for avoiding compiler crash
+        DOCKER_RUN_ARGS: >-
+          -e ARROW_BUILD_STATIC=OFF
+          -e ARROW_FLIGHT=ON
+          -e ARROW_PARQUET=OFF
+          -e CMAKE_UNITY_BUILD=OFF
+          -e PARQUET_BUILD_EXAMPLES=OFF
+          -e PARQUET_BUILD_EXECUTABLES=OFF
+          -e Protobuf_SOURCE=BUNDLED
+          -e cares_SOURCE=BUNDLED
+          -e gRPC_SOURCE=BUNDLED
         UBUNTU: "20.04"
-        cares_SOURCE: "BUNDLED"
-        gRPC_SOURCE: "BUNDLED"
 
     - name: "Go on s390x"
       os: linux
@@ -74,7 +81,6 @@ jobs:
         ARCH: s390x
         ARROW_CI_MODULES: "JAVA"
         DOCKER_IMAGE_ID: debian-java
-        UBUNTU: "20.04"
 
   allow_failures:
     - arch: s390x
@@ -109,17 +115,7 @@ script:
     ulimit -c unlimited || :
   - |
     archery docker run \
-      -e ARROW_BUILD_STATIC=${ARROW_BUILD_STATIC:-OFF} \
-      -e ARROW_FLIGHT=${ARROW_FLIGHT:-OFF} \
-      -e ARROW_ORC=${ARROW_ORC:-OFF} \
-      -e ARROW_PARQUET=${ARROW_PARQUET:-ON} \
-      -e ARROW_USE_GLOG=${ARROW_USE_GLOG:-OFF} \
-      -e CMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-ON} \
-      -e PARQUET_BUILD_EXAMPLES=${PARQUET_BUILD_EXAMPLES:-ON} \
-      -e PARQUET_BUILD_EXECUTABLES=${PARQUET_BUILD_EXECUTABLES:-ON} \
-      -e Protobuf_SOURCE=${Protobuf_SOURCE:-} \
-      -e cares_SOURCE=${cares_SOURCE:-} \
-      -e gRPC_SOURCE=${gRPC_SOURCE:-} \
+      ${DOCKER_RUN_ARGS}
       --volume ${PWD}/build:/build \
       ${DOCKER_IMAGE_ID}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,11 @@ jobs:
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
         DOCKER_RUN_ARGS: >-
+          "
           -e ARROW_BUILD_STATIC=OFF
           -e ARROW_ORC=OFF
           -e CMAKE_UNITY_BUILD=ON
+          "
         UBUNTU: "20.04"
 
     - name: "C++ on s390x"
@@ -55,6 +57,7 @@ jobs:
         DOCKER_IMAGE_ID: ubuntu-cpp
         # CMAKE_UNITIFY_BUILD=OFF is for avoiding compiler crash
         DOCKER_RUN_ARGS: >-
+          "
           -e ARROW_BUILD_STATIC=OFF
           -e ARROW_FLIGHT=ON
           -e ARROW_PARQUET=OFF
@@ -64,6 +67,7 @@ jobs:
           -e Protobuf_SOURCE=BUNDLED
           -e cares_SOURCE=BUNDLED
           -e gRPC_SOURCE=BUNDLED
+          "
         UBUNTU: "20.04"
 
     - name: "Go on s390x"

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ script:
     ulimit -c unlimited || :
   - |
     archery docker run \
-      ${DOCKER_RUN_ARGS}
+      ${DOCKER_RUN_ARGS} \
       --volume ${PWD}/build:/build \
       ${DOCKER_IMAGE_ID}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ jobs:
         ARCH: s390x
         ARROW_CI_MODULES: "JAVA"
         DOCKER_IMAGE_ID: debian-java
+        JDK: 11
 
   allow_failures:
     - arch: s390x

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,13 @@ jobs:
         ARCH: arm64v8
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
+        # ARROW_USE_GLOG=OFF is needed to avoid build error caused by
+        # glog and CMAKE_UNITY_BUILD=ON.
         DOCKER_RUN_ARGS: >-
           "
           -e ARROW_BUILD_STATIC=OFF
           -e ARROW_ORC=OFF
+          -e ARROW_USE_GLOG=OFF
           -e CMAKE_UNITY_BUILD=ON
           "
         UBUNTU: "20.04"

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
         UBUNTU: "20.04"
+
     - name: "C++ on s390x"
       os: linux
       arch: s390x
@@ -57,6 +58,7 @@ jobs:
         UBUNTU: "20.04"
         cares_SOURCE: "BUNDLED"
         gRPC_SOURCE: "BUNDLED"
+
     - name: "Go on s390x"
       os: linux
       arch: s390x
@@ -64,6 +66,16 @@ jobs:
         ARCH: s390x
         ARROW_CI_MODULES: "GO"
         DOCKER_IMAGE_ID: debian-go
+
+    - name: "Java on s390x"
+      os: linux
+      arch: s390x
+      env:
+        ARCH: s390x
+        ARROW_CI_MODULES: "JAVA"
+        DOCKER_IMAGE_ID: debian-java
+        UBUNTU: "20.04"
+
   allow_failures:
     - arch: s390x
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,13 +55,13 @@ jobs:
         ARCH: s390x
         ARROW_CI_MODULES: "CPP"
         DOCKER_IMAGE_ID: ubuntu-cpp
-        # CMAKE_UNITIFY_BUILD=OFF is for avoiding compiler crash
+        # Can't use CMAKE_UNITIFY_BUILD=ON because of compiler crash
         DOCKER_RUN_ARGS: >-
           "
           -e ARROW_BUILD_STATIC=OFF
           -e ARROW_FLIGHT=ON
+          -e ARROW_ORC=OFF
           -e ARROW_PARQUET=OFF
-          -e CMAKE_UNITY_BUILD=OFF
           -e PARQUET_BUILD_EXAMPLES=OFF
           -e PARQUET_BUILD_EXECUTABLES=OFF
           -e Protobuf_SOURCE=BUNDLED

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -76,11 +76,14 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   target=${artifact}-${ver}-${classifier}.${extension}
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
   ${mvn_install} -DgroupId=${group} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${classifier} -Dpackaging=${extension} -Dfile=$(pwd)/${target}
+
+  mvn_options=""
+else
+  # Use `2 * ncores` threads
+  mvn_options="${mvn} -T 2C"
 fi
 
-mvn="mvn -B -DskipTests -Drat.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
-# Use `2 * ncores` threads
-mvn="${mvn} -T 2C"
+mvn="mvn ${mvn_options} -B -DskipTests -Drat.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
 pushd ${source_dir}
 

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -52,9 +52,9 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/libprotoc.so.18
   export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)
 
-  bintray_dir="protoc-gen-groupc-java-binary"
-  group="io.groupc"
-  artifact="protoc-gen-groupc-java"
+  bintray_dir="protoc-gen-grpc-java-binary"
+  group="io.grpc"
+  artifact="protoc-gen-grpc-java"
   ver="1.30.2"
   classifier="linux-s390_64"
   extension="exe"

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -76,15 +76,11 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   target=${artifact}-${ver}-${classifier}.${extension}
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
   ${mvn_install} -DgroupId=${group} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${classifier} -Dpackaging=${extension} -Dfile=$(pwd)/${target}
-
-  # Use `2 * ncores` threads
-  mvn_options="-T 2C -Dmaven.compiler.verbose=true"
-else
-  # Use `2 * ncores` threads
-  mvn_options="-T 2C"
 fi
 
-mvn="mvn ${mvn_options} -B -DskipTests -Drat.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+mvn="mvn -B -DskipTests -Drat.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
+# Use `2 * ncores` threads
+mvn="${mvn} -T 2C"
 
 pushd ${source_dir}
 

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -77,10 +77,11 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
   ${mvn_install} -DgroupId=${group} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${classifier} -Dpackaging=${extension} -Dfile=$(pwd)/${target}
 
-  mvn_options=""
+  # Use `2 * ncores` threads
+  mvn_options="-T 2C -Dmaven.compiler.verbose=true"
 else
   # Use `2 * ncores` threads
-  mvn_options="${mvn} -T 2C"
+  mvn_options="-T 2C"
 fi
 
 mvn="mvn ${mvn_options} -B -DskipTests -Drat.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -23,6 +23,61 @@ source_dir=${1}/java
 cpp_build_dir=${2}/cpp/${ARROW_BUILD_TYPE:-debug}
 with_docs=${3:-false}
 
+if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
+  # Since some files for s390_64 are not available at maven central,
+  # download pre-build files from bintray and install them explicitly
+  mvn_install="mvn install:install-file"
+  wget="wget"
+  bintray_base_url="https://dl.bintray.com/apache/arrow"
+
+  bintray_dir="flatc-binary"
+  grp="com.github.icexelloss"
+  artifact="flatc-linux-s390_64"
+  ver="1.9.0"
+  extension="exe"
+  target=${artifact}-${ver}.${extension}
+  ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
+  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+
+  bintray_dir="protoc-binary"
+  grp="com.google.protobuf"
+  artifact="protoc"
+  ver="3.7.1"
+  cls="linux-s390_64"
+  extension="exe"
+  target=${artifact}-${ver}-${cls}.${extension}
+  ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
+  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${cls} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+  # protoc requires libprotoc.so.18
+  ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/libprotoc.so.18
+  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:`pwd`
+
+  bintray_dir="protoc-gen-grpc-java-binary"
+  grp="io.grpc"
+  artifact="protoc-gen-grpc-java"
+  ver="1.30.2"
+  cls="linux-s390_64"
+  extension="exe"
+  target=${artifact}-${ver}-${cls}.${extension}
+  ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
+  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${cls} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+
+  bintray_dir="netty-binary"
+  grp="io.netty"
+  artifact="netty-transport-native-unix-common"
+  ver="4.1.48.Final"
+  cls="linux-s390_64"
+  extension="jar"
+  target=${artifact}-${ver}-${cls}.${extension}
+  ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
+  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${cls} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+  artifact="netty-transport-native-epoll"
+  extension="jar"
+  target=${artifact}-${ver}-${cls}.${extension}
+  ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
+  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${cls} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+fi
+
 mvn="mvn -B -DskipTests -Drat.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 # Use `2 * ncores` threads
 mvn="${mvn} -T 2C"

--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -31,51 +31,51 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   bintray_base_url="https://dl.bintray.com/apache/arrow"
 
   bintray_dir="flatc-binary"
-  grp="com.github.icexelloss"
+  group="com.github.icexelloss"
   artifact="flatc-linux-s390_64"
   ver="1.9.0"
   extension="exe"
   target=${artifact}-${ver}.${extension}
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
-  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+  ${mvn_install} -DgroupId=${group} -DartifactId=${artifact} -Dversion=${ver} -Dpackaging=${extension} -Dfile=$(pwd)/${target}
 
   bintray_dir="protoc-binary"
-  grp="com.google.protobuf"
+  group="com.google.protobuf"
   artifact="protoc"
   ver="3.7.1"
-  cls="linux-s390_64"
+  classifier="linux-s390_64"
   extension="exe"
-  target=${artifact}-${ver}-${cls}.${extension}
+  target=${artifact}-${ver}-${classifier}.${extension}
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
-  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${cls} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+  ${mvn_install} -DgroupId=${group} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${classifier} -Dpackaging=${extension} -Dfile=$(pwd)/${target}
   # protoc requires libprotoc.so.18
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/libprotoc.so.18
-  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:`pwd`
+  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)
 
-  bintray_dir="protoc-gen-grpc-java-binary"
-  grp="io.grpc"
-  artifact="protoc-gen-grpc-java"
+  bintray_dir="protoc-gen-groupc-java-binary"
+  group="io.groupc"
+  artifact="protoc-gen-groupc-java"
   ver="1.30.2"
-  cls="linux-s390_64"
+  classifier="linux-s390_64"
   extension="exe"
-  target=${artifact}-${ver}-${cls}.${extension}
+  target=${artifact}-${ver}-${classifier}.${extension}
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
-  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${cls} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+  ${mvn_install} -DgroupId=${group} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${classifier} -Dpackaging=${extension} -Dfile=$(pwd)/${target}
 
   bintray_dir="netty-binary"
-  grp="io.netty"
+  group="io.netty"
   artifact="netty-transport-native-unix-common"
   ver="4.1.48.Final"
-  cls="linux-s390_64"
+  classifier="linux-s390_64"
   extension="jar"
-  target=${artifact}-${ver}-${cls}.${extension}
+  target=${artifact}-${ver}-${classifier}.${extension}
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
-  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${cls} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+  ${mvn_install} -DgroupId=${group} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${classifier} -Dpackaging=${extension} -Dfile=$(pwd)/${target}
   artifact="netty-transport-native-epoll"
   extension="jar"
-  target=${artifact}-${ver}-${cls}.${extension}
+  target=${artifact}-${ver}-${classifier}.${extension}
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/${target}
-  ${mvn_install} -DgroupId=${grp} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${cls} -Dpackaging=${extension} -Dfile=`pwd`/${target}
+  ${mvn_install} -DgroupId=${group} -DartifactId=${artifact} -Dversion=${ver} -Dclassifier=${classifier} -Dpackaging=${extension} -Dfile=$(pwd)/${target}
 fi
 
 mvn="mvn -B -DskipTests -Drat.skip=true -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -193,7 +193,7 @@
           <target>1.8</target>
           <maxmem>2048m</maxmem>
           <useIncrementalCompilation>false</useIncrementalCompilation>
-          <fork>false</fork>
+          <fork>true</fork>
         </configuration>
       </plugin>
       <plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -193,7 +193,7 @@
           <target>1.8</target>
           <maxmem>2048m</maxmem>
           <useIncrementalCompilation>false</useIncrementalCompilation>
-          <fork>true</fork>
+          <fork>false</fork>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
This PR adds a new test job for big-endian Java environment to TravisCI. It still keeps as 
```
   allow_failures:
     - arch: s390x
```