### PR TITLE
ARROW-9698: [C++] Remove -DNDEBUG flag leak in .pc file

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -533,12 +533,6 @@ else()
   message(FATAL_ERROR "Unknown build type: ${CMAKE_BUILD_TYPE}")
 endif()
 
-if("${CMAKE_CXX_FLAGS}" MATCHES "-DNDEBUG")
-  set(ARROW_DEFINITION_FLAGS "-DNDEBUG")
-else()
-  set(ARROW_DEFINITION_FLAGS "")
-endif()
-
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}")
 
 # ----------------------------------------------------------------------

--- a/cpp/src/arrow/arrow.pc.in
+++ b/cpp/src/arrow/arrow.pc.in
@@ -26,4 +26,4 @@ Name: Apache Arrow
 Description: Arrow is a set of technologies that enable big-data systems to process and move data fast.
 Version: @ARROW_VERSION@
 Libs: -L${libdir} -larrow
-Cflags: -I${includedir} @ARROW_DEFINITION_FLAGS@
+Cflags: -I${includedir}

--- a/cpp/src/arrow/util/trie.h
+++ b/cpp/src/arrow/util/trie.h
@@ -103,9 +103,7 @@ class SmallString {
   uint8_t length_;
   char data_[N];
 
-#ifndef NDEBUG
   void CheckSize(size_t n) { assert(n <= N); }
-#endif
 };
 
 template <uint8_t N>


### PR DESCRIPTION
This change eliminates the need to include the -DNDEBUG flag in arrow's .pc file, which leaks into downstream projects' builds unexpectedly. The CheckSize function definition is now included in both debug and release builds, though it will no-op in release builds (as expected). The flag is no longer required as a means to make the ABI consistent across build types for downstream projects, and so it is now removed.