### PR TITLE
ARROW-9702: [C++] Register bpacking SIMD to runtime path.

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -180,6 +180,7 @@ set(ARROW_SRCS
     util/bitmap.cc
     util/bitmap_builders.cc
     util/bitmap_ops.cc
+    util/bpacking.cc
     util/compression.cc
     util/cpu_info.cc
     util/decimal.cc
@@ -212,6 +213,21 @@ set(ARROW_SRCS
     vendored/double-conversion/fixed-dtoa.cc
     vendored/double-conversion/diy-fp.cc
     vendored/double-conversion/strtod.cc)
+
+  if(CXX_SUPPORTS_AVX2)
+    list(APPEND ARROW_SRCS util/bpacking_avx2.cc)
+    set_source_files_properties(util/bpacking_avx2.cc PROPERTIES SKIP_PRECOMPILE_HEADERS
+                                ON)
+    set_source_files_properties(util/bpacking_avx2.cc PROPERTIES COMPILE_FLAGS
+                                ${ARROW_AVX2_FLAG})
+  endif()
+  if(CXX_SUPPORTS_AVX512)
+    list(APPEND ARROW_SRCS util/bpacking_avx512.cc)
+    set_source_files_properties(util/bpacking_avx512.cc PROPERTIES
+                                SKIP_PRECOMPILE_HEADERS ON)
+    set_source_files_properties(util/bpacking_avx512.cc PROPERTIES COMPILE_FLAGS
+                                ${ARROW_AVX512_FLAG})
+  endif()
 
 if(APPLE)
   list(APPEND ARROW_SRCS vendored/datetime/ios.mm)

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -214,20 +214,19 @@ set(ARROW_SRCS
     vendored/double-conversion/diy-fp.cc
     vendored/double-conversion/strtod.cc)
 
-  if(CXX_SUPPORTS_AVX2)
-    list(APPEND ARROW_SRCS util/bpacking_avx2.cc)
-    set_source_files_properties(util/bpacking_avx2.cc PROPERTIES SKIP_PRECOMPILE_HEADERS
-                                ON)
-    set_source_files_properties(util/bpacking_avx2.cc PROPERTIES COMPILE_FLAGS
-                                ${ARROW_AVX2_FLAG})
-  endif()
-  if(CXX_SUPPORTS_AVX512)
-    list(APPEND ARROW_SRCS util/bpacking_avx512.cc)
-    set_source_files_properties(util/bpacking_avx512.cc PROPERTIES
-                                SKIP_PRECOMPILE_HEADERS ON)
-    set_source_files_properties(util/bpacking_avx512.cc PROPERTIES COMPILE_FLAGS
-                                ${ARROW_AVX512_FLAG})
-  endif()
+if(CXX_SUPPORTS_AVX2)
+  list(APPEND ARROW_SRCS util/bpacking_avx2.cc)
+  set_source_files_properties(util/bpacking_avx2.cc PROPERTIES SKIP_PRECOMPILE_HEADERS ON)
+  set_source_files_properties(util/bpacking_avx2.cc PROPERTIES COMPILE_FLAGS
+                              ${ARROW_AVX2_FLAG})
+endif()
+if(CXX_SUPPORTS_AVX512)
+  list(APPEND ARROW_SRCS util/bpacking_avx512.cc)
+  set_source_files_properties(util/bpacking_avx512.cc PROPERTIES SKIP_PRECOMPILE_HEADERS
+                              ON)
+  set_source_files_properties(util/bpacking_avx512.cc PROPERTIES COMPILE_FLAGS
+                              ${ARROW_AVX512_FLAG})
+endif()
 
 if(APPLE)
   list(APPEND ARROW_SRCS vendored/datetime/ios.mm)

--- a/cpp/src/arrow/util/bit_stream_utils.h
+++ b/cpp/src/arrow/util/bit_stream_utils.h
@@ -27,6 +27,7 @@
 #include "arrow/util/bpacking.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/ubsan.h"
 
 namespace arrow {
 namespace BitUtil {

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -1,0 +1,174 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <mutex>
+
+#include "arrow/util/bpacking.h"
+#include "arrow/util/bpacking_default.h"
+#include "arrow/util/cpu_info.h"
+#include "arrow/util/logging.h"
+
+#if defined(ARROW_HAVE_RUNTIME_AVX2)
+#include "arrow/util/bpacking_avx2.h"
+#endif
+#if defined(ARROW_HAVE_RUNTIME_AVX512)
+#include "arrow/util/bpacking_avx512.h"
+#endif
+
+namespace arrow {
+namespace internal {
+
+int unpack32_default(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
+  batch_size = batch_size / 32 * 32;
+  int num_loops = batch_size / 32;
+
+  switch (num_bits) {
+    case 0:
+      for (int i = 0; i < num_loops; ++i) in = nullunpacker32(in, out + i * 32);
+      break;
+    case 1:
+      for (int i = 0; i < num_loops; ++i) in = unpack1_32(in, out + i * 32);
+      break;
+    case 2:
+      for (int i = 0; i < num_loops; ++i) in = unpack2_32(in, out + i * 32);
+      break;
+    case 3:
+      for (int i = 0; i < num_loops; ++i) in = unpack3_32(in, out + i * 32);
+      break;
+    case 4:
+      for (int i = 0; i < num_loops; ++i) in = unpack4_32(in, out + i * 32);
+      break;
+    case 5:
+      for (int i = 0; i < num_loops; ++i) in = unpack5_32(in, out + i * 32);
+      break;
+    case 6:
+      for (int i = 0; i < num_loops; ++i) in = unpack6_32(in, out + i * 32);
+      break;
+    case 7:
+      for (int i = 0; i < num_loops; ++i) in = unpack7_32(in, out + i * 32);
+      break;
+    case 8:
+      for (int i = 0; i < num_loops; ++i) in = unpack8_32(in, out + i * 32);
+      break;
+    case 9:
+      for (int i = 0; i < num_loops; ++i) in = unpack9_32(in, out + i * 32);
+      break;
+    case 10:
+      for (int i = 0; i < num_loops; ++i) in = unpack10_32(in, out + i * 32);
+      break;
+    case 11:
+      for (int i = 0; i < num_loops; ++i) in = unpack11_32(in, out + i * 32);
+      break;
+    case 12:
+      for (int i = 0; i < num_loops; ++i) in = unpack12_32(in, out + i * 32);
+      break;
+    case 13:
+      for (int i = 0; i < num_loops; ++i) in = unpack13_32(in, out + i * 32);
+      break;
+    case 14:
+      for (int i = 0; i < num_loops; ++i) in = unpack14_32(in, out + i * 32);
+      break;
+    case 15:
+      for (int i = 0; i < num_loops; ++i) in = unpack15_32(in, out + i * 32);
+      break;
+    case 16:
+      for (int i = 0; i < num_loops; ++i) in = unpack16_32(in, out + i * 32);
+      break;
+    case 17:
+      for (int i = 0; i < num_loops; ++i) in = unpack17_32(in, out + i * 32);
+      break;
+    case 18:
+      for (int i = 0; i < num_loops; ++i) in = unpack18_32(in, out + i * 32);
+      break;
+    case 19:
+      for (int i = 0; i < num_loops; ++i) in = unpack19_32(in, out + i * 32);
+      break;
+    case 20:
+      for (int i = 0; i < num_loops; ++i) in = unpack20_32(in, out + i * 32);
+      break;
+    case 21:
+      for (int i = 0; i < num_loops; ++i) in = unpack21_32(in, out + i * 32);
+      break;
+    case 22:
+      for (int i = 0; i < num_loops; ++i) in = unpack22_32(in, out + i * 32);
+      break;
+    case 23:
+      for (int i = 0; i < num_loops; ++i) in = unpack23_32(in, out + i * 32);
+      break;
+    case 24:
+      for (int i = 0; i < num_loops; ++i) in = unpack24_32(in, out + i * 32);
+      break;
+    case 25:
+      for (int i = 0; i < num_loops; ++i) in = unpack25_32(in, out + i * 32);
+      break;
+    case 26:
+      for (int i = 0; i < num_loops; ++i) in = unpack26_32(in, out + i * 32);
+      break;
+    case 27:
+      for (int i = 0; i < num_loops; ++i) in = unpack27_32(in, out + i * 32);
+      break;
+    case 28:
+      for (int i = 0; i < num_loops; ++i) in = unpack28_32(in, out + i * 32);
+      break;
+    case 29:
+      for (int i = 0; i < num_loops; ++i) in = unpack29_32(in, out + i * 32);
+      break;
+    case 30:
+      for (int i = 0; i < num_loops; ++i) in = unpack30_32(in, out + i * 32);
+      break;
+    case 31:
+      for (int i = 0; i < num_loops; ++i) in = unpack31_32(in, out + i * 32);
+      break;
+    case 32:
+      for (int i = 0; i < num_loops; ++i) in = unpack32_32(in, out + i * 32);
+      break;
+    default:
+      DCHECK(false) << "Unsupported num_bits";
+  }
+
+  return batch_size;
+}
+
+typedef int (*unpack32_func_t)(const uint32_t* in, uint32_t* out, int batch_size,
+                               int num_bits);
+
+static std::once_flag unpack32_ptr_initialized;
+static unpack32_func_t unpack32_func_ptr = unpack32_default;
+
+static void resolve_unpack32_ptr() {
+  std::call_once(unpack32_ptr_initialized, []() {
+    auto cpu_info = arrow::internal::CpuInfo::GetInstance();
+#if defined(ARROW_HAVE_RUNTIME_AVX2)
+    if (cpu_info->IsSupported(arrow::internal::CpuInfo::AVX2)) {
+      unpack32_func_ptr = unpack32_avx2;
+    }
+#endif
+#if defined(ARROW_HAVE_RUNTIME_AVX512)
+    if (cpu_info->IsSupported(arrow::internal::CpuInfo::AVX512)) {
+      unpack32_func_ptr = unpack32_avx512;
+    }
+#endif
+  });
+}
+
+int unpack32(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
+  resolve_unpack32_ptr();
+  return unpack32_func_ptr(in, out, batch_size, num_bits);
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/bpacking.h
+++ b/cpp/src/arrow/util/bpacking.h
@@ -17,11 +17,14 @@
 
 #pragma once
 
+#include "arrow/util/visibility.h"
+
 #include <stdint.h>
 
 namespace arrow {
 namespace internal {
 
+ARROW_EXPORT
 int unpack32(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
 
 }  // namespace internal

--- a/cpp/src/arrow/util/bpacking_avx2.cc
+++ b/cpp/src/arrow/util/bpacking_avx2.cc
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/bpacking_avx2.h"
+#include "arrow/util/bpacking_avx2_generated.h"
+#include "arrow/util/logging.h"
+
+namespace arrow {
+namespace internal {
+
+int unpack32_avx2(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
+  batch_size = batch_size / 32 * 32;
+  int num_loops = batch_size / 32;
+
+  switch (num_bits) {
+    case 0:
+      for (int i = 0; i < num_loops; ++i) in = unpack0_32_avx2(in, out + i * 32);
+      break;
+    case 1:
+      for (int i = 0; i < num_loops; ++i) in = unpack1_32_avx2(in, out + i * 32);
+      break;
+    case 2:
+      for (int i = 0; i < num_loops; ++i) in = unpack2_32_avx2(in, out + i * 32);
+      break;
+    case 3:
+      for (int i = 0; i < num_loops; ++i) in = unpack3_32_avx2(in, out + i * 32);
+      break;
+    case 4:
+      for (int i = 0; i < num_loops; ++i) in = unpack4_32_avx2(in, out + i * 32);
+      break;
+    case 5:
+      for (int i = 0; i < num_loops; ++i) in = unpack5_32_avx2(in, out + i * 32);
+      break;
+    case 6:
+      for (int i = 0; i < num_loops; ++i) in = unpack6_32_avx2(in, out + i * 32);
+      break;
+    case 7:
+      for (int i = 0; i < num_loops; ++i) in = unpack7_32_avx2(in, out + i * 32);
+      break;
+    case 8:
+      for (int i = 0; i < num_loops; ++i) in = unpack8_32_avx2(in, out + i * 32);
+      break;
+    case 9:
+      for (int i = 0; i < num_loops; ++i) in = unpack9_32_avx2(in, out + i * 32);
+      break;
+    case 10:
+      for (int i = 0; i < num_loops; ++i) in = unpack10_32_avx2(in, out + i * 32);
+      break;
+    case 11:
+      for (int i = 0; i < num_loops; ++i) in = unpack11_32_avx2(in, out + i * 32);
+      break;
+    case 12:
+      for (int i = 0; i < num_loops; ++i) in = unpack12_32_avx2(in, out + i * 32);
+      break;
+    case 13:
+      for (int i = 0; i < num_loops; ++i) in = unpack13_32_avx2(in, out + i * 32);
+      break;
+    case 14:
+      for (int i = 0; i < num_loops; ++i) in = unpack14_32_avx2(in, out + i * 32);
+      break;
+    case 15:
+      for (int i = 0; i < num_loops; ++i) in = unpack15_32_avx2(in, out + i * 32);
+      break;
+    case 16:
+      for (int i = 0; i < num_loops; ++i) in = unpack16_32_avx2(in, out + i * 32);
+      break;
+    case 17:
+      for (int i = 0; i < num_loops; ++i) in = unpack17_32_avx2(in, out + i * 32);
+      break;
+    case 18:
+      for (int i = 0; i < num_loops; ++i) in = unpack18_32_avx2(in, out + i * 32);
+      break;
+    case 19:
+      for (int i = 0; i < num_loops; ++i) in = unpack19_32_avx2(in, out + i * 32);
+      break;
+    case 20:
+      for (int i = 0; i < num_loops; ++i) in = unpack20_32_avx2(in, out + i * 32);
+      break;
+    case 21:
+      for (int i = 0; i < num_loops; ++i) in = unpack21_32_avx2(in, out + i * 32);
+      break;
+    case 22:
+      for (int i = 0; i < num_loops; ++i) in = unpack22_32_avx2(in, out + i * 32);
+      break;
+    case 23:
+      for (int i = 0; i < num_loops; ++i) in = unpack23_32_avx2(in, out + i * 32);
+      break;
+    case 24:
+      for (int i = 0; i < num_loops; ++i) in = unpack24_32_avx2(in, out + i * 32);
+      break;
+    case 25:
+      for (int i = 0; i < num_loops; ++i) in = unpack25_32_avx2(in, out + i * 32);
+      break;
+    case 26:
+      for (int i = 0; i < num_loops; ++i) in = unpack26_32_avx2(in, out + i * 32);
+      break;
+    case 27:
+      for (int i = 0; i < num_loops; ++i) in = unpack27_32_avx2(in, out + i * 32);
+      break;
+    case 28:
+      for (int i = 0; i < num_loops; ++i) in = unpack28_32_avx2(in, out + i * 32);
+      break;
+    case 29:
+      for (int i = 0; i < num_loops; ++i) in = unpack29_32_avx2(in, out + i * 32);
+      break;
+    case 30:
+      for (int i = 0; i < num_loops; ++i) in = unpack30_32_avx2(in, out + i * 32);
+      break;
+    case 31:
+      for (int i = 0; i < num_loops; ++i) in = unpack31_32_avx2(in, out + i * 32);
+      break;
+    case 32:
+      for (int i = 0; i < num_loops; ++i) in = unpack32_32_avx2(in, out + i * 32);
+      break;
+    default:
+      DCHECK(false) << "Unsupported num_bits";
+  }
+
+  return batch_size;
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/bpacking_avx2.h
+++ b/cpp/src/arrow/util/bpacking_avx2.h
@@ -22,7 +22,7 @@
 namespace arrow {
 namespace internal {
 
-int unpack32(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
+int unpack32_avx2(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/bpacking_avx2_codegen.py
+++ b/cpp/src/arrow/util/bpacking_avx2_codegen.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Usage: python bpacking_avx512_codegen.py > bpacking_avx512_generated.h
+# Usage: python bpacking_avx2_codegen.py > bpacking_avx2_generated.h
 
 
 def print_unpack_bit_func(bit):
@@ -29,10 +29,10 @@ def print_unpack_bit_func(bit):
     bracket = "{"
 
     print(
-        f"inline const uint32_t* unpack{bit}_32_avx512(const uint32_t* in, uint32_t* out) {bracket}")
+        f"inline const uint32_t* unpack{bit}_32_avx2(const uint32_t* in, uint32_t* out) {bracket}")
     print("  uint32_t mask = 0x%x;" % mask)
-    print("  __m512i reg_shifts, reg_inls, reg_masks;")
-    print("  __m512i results;")
+    print("  __m256i reg_shifts, reg_inls, reg_masks;")
+    print("  __m256i results;")
 
     print("")
     for i in range(32):
@@ -52,51 +52,68 @@ def print_unpack_bit_func(bit):
             inls.append(f"in[{in_index}]")
             shift += bit
 
-    print("  reg_masks = _mm512_set1_epi32(mask);")
+    print("  reg_masks = _mm256_set1_epi32(mask);")
     print("")
-    print("  // shift the first 16 outs")
+
+    print("  // shift the first 8 outs")
     print(
-        f"  reg_shifts = _mm512_set_epi32({shifts[15]}, {shifts[14]}, {shifts[13]}, {shifts[12]},")
+        f"  reg_shifts = _mm256_set_epi32({shifts[7]}, {shifts[6]}, {shifts[5]}, {shifts[4]},")
     print(
-        f"                                {shifts[11]}, {shifts[10]}, {shifts[9]}, {shifts[8]},")
+        f"                               {shifts[3]}, {shifts[2]}, {shifts[1]}, {shifts[0]});")
+    print(f"  reg_inls = _mm256_set_epi32({inls[7]}, {inls[6]},")
+    print(f"                             {inls[5]}, {inls[4]},")
+    print(f"                             {inls[3]}, {inls[2]},")
+    print(f"                             {inls[1]}, {inls[0]});")
     print(
-        f"                                {shifts[7]}, {shifts[6]}, {shifts[5]}, {shifts[4]},")
+        "  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);")
+    print("  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);")
+    print("  out += 8;")
+    print("")
+
+    print("  // shift the second 8 outs")
     print(
-        f"                                {shifts[3]}, {shifts[2]}, {shifts[1]}, {shifts[0]});")
-    print(f"  reg_inls = _mm512_set_epi32({inls[15]}, {inls[14]},")
+        f"  reg_shifts = _mm256_set_epi32({shifts[15]}, {shifts[14]}, {shifts[13]}, {shifts[12]},")
+    print(
+        f"                                {shifts[11]}, {shifts[10]}, {shifts[9]}, {shifts[8]});")
+    print(f"  reg_inls = _mm256_set_epi32({inls[15]}, {inls[14]},")
     print(f"                              {inls[13]}, {inls[12]},")
     print(f"                              {inls[11]}, {inls[10]},")
-    print(f"                              {inls[9]}, {inls[8]},")
-    print(f"                              {inls[7]}, {inls[6]},")
-    print(f"                              {inls[5]}, {inls[4]},")
-    print(f"                              {inls[3]}, {inls[2]},")
-    print(f"                              {inls[1]}, {inls[0]});")
+    print(f"                              {inls[9]}, {inls[8]});")
     print(
-        "  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);")
-    print("  _mm512_storeu_si512(out, results);")
-    print("  out += 16;")
+        "  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);")
+    print("  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);")
+    print("  out += 8;")
     print("")
-    print("  // shift the second 16 outs")
+
+    print("  // shift the third 8 outs")
     print(
-        f"  reg_shifts = _mm512_set_epi32({shifts[31]}, {shifts[30]}, {shifts[29]}, {shifts[28]},")
-    print(
-        f"                                {shifts[27]}, {shifts[26]}, {shifts[25]}, {shifts[24]},")
-    print(
-        f"                                {shifts[23]}, {shifts[22]}, {shifts[21]}, {shifts[20]},")
+        f"  reg_shifts = _mm256_set_epi32({shifts[23]}, {shifts[22]}, {shifts[21]}, {shifts[20]},")
     print(
         f"                                {shifts[19]}, {shifts[18]}, {shifts[17]}, {shifts[16]});")
-    print(f"  reg_inls = _mm512_set_epi32({inls[31]}, {inls[30]},")
-    print(f"                              {inls[29]}, {inls[28]},")
-    print(f"                              {inls[27]}, {inls[26]},")
-    print(f"                              {inls[25]}, {inls[24]},")
-    print(f"                              {inls[23]}, {inls[22]},")
+    print(f"  reg_inls = _mm256_set_epi32({inls[23]}, {inls[22]},")
     print(f"                              {inls[21]}, {inls[20]},")
     print(f"                              {inls[19]}, {inls[18]},")
     print(f"                              {inls[17]}, {inls[16]});")
     print(
-        "  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);")
-    print("  _mm512_storeu_si512(out, results);")
-    print("  out += 16;")
+        "  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);")
+    print("  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);")
+    print("  out += 8;")
+    print("")
+
+    print("  // shift the last 8 outs")
+    print(
+        f"  reg_shifts = _mm256_set_epi32({shifts[31]}, {shifts[30]}, {shifts[29]}, {shifts[28]},")
+    print(
+        f"                                {shifts[27]}, {shifts[26]}, {shifts[25]}, {shifts[24]});")
+    print(f"  reg_inls = _mm256_set_epi32({inls[31]}, {inls[30]},")
+    print(f"                              {inls[29]}, {inls[28]},")
+    print(f"                              {inls[27]}, {inls[26]},")
+    print(f"                              {inls[25]}, {inls[24]});")
+    print(
+        "  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);")
+    print("  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);")
+    print("  out += 8;")
+
     print("")
     print(f"  in += {bit};")
     print("")
@@ -106,7 +123,7 @@ def print_unpack_bit_func(bit):
 
 def print_unpack_bit0_func():
     print(
-        "inline const uint32_t* unpack0_32_avx512(const uint32_t* in, uint32_t* out) {")
+        "inline const uint32_t* unpack0_32_avx2(const uint32_t* in, uint32_t* out) {")
     print("  memset(out, 0x0, 32 * sizeof(*out));")
     print("  out += 32;")
     print("")
@@ -116,7 +133,7 @@ def print_unpack_bit0_func():
 
 def print_unpack_bit32_func():
     print(
-        "inline const uint32_t* unpack32_32_avx512(const uint32_t* in, uint32_t* out) {")
+        "inline const uint32_t* unpack32_32_avx2(const uint32_t* in, uint32_t* out) {")
     print("  memcpy(out, in, 32 * sizeof(*out));")
     print("  in += 32;")
     print("  out += 32;")

--- a/cpp/src/arrow/util/bpacking_avx2_codegen.py
+++ b/cpp/src/arrow/util/bpacking_avx2_codegen.py
@@ -41,7 +41,7 @@ def print_unpack_bit_func(bit):
             inls.append(f"in[{in_index}]")
             in_index += 1
             shift = 0
-        elif shift + bit > 32:  # croos the boundary
+        elif shift + bit > 32:  # cross the boundary
             inls.append(
                 f"in[{in_index}] >> {shift} | in[{in_index + 1}] << {32 - shift}")
             in_index += 1

--- a/cpp/src/arrow/util/bpacking_avx2_codegen.py
+++ b/cpp/src/arrow/util/bpacking_avx2_codegen.py
@@ -29,7 +29,7 @@ def print_unpack_bit_func(bit):
     bracket = "{"
 
     print(
-        f"inline const uint32_t* unpack{bit}_32_avx2(const uint32_t* in, uint32_t* out) {bracket}")
+        f"inline static const uint32_t* unpack{bit}_32_avx2(const uint32_t* in, uint32_t* out) {bracket}")
     print("  uint32_t mask = 0x%x;" % mask)
     print("  __m256i reg_shifts, reg_inls, reg_masks;")
     print("  __m256i results;")
@@ -123,7 +123,7 @@ def print_unpack_bit_func(bit):
 
 def print_unpack_bit0_func():
     print(
-        "inline const uint32_t* unpack0_32_avx2(const uint32_t* in, uint32_t* out) {")
+        "inline static const uint32_t* unpack0_32_avx2(const uint32_t* in, uint32_t* out) {")
     print("  memset(out, 0x0, 32 * sizeof(*out));")
     print("  out += 32;")
     print("")
@@ -133,7 +133,7 @@ def print_unpack_bit0_func():
 
 def print_unpack_bit32_func():
     print(
-        "inline const uint32_t* unpack32_32_avx2(const uint32_t* in, uint32_t* out) {")
+        "inline static const uint32_t* unpack32_32_avx2(const uint32_t* in, uint32_t* out) {")
     print("  memcpy(out, in, 32 * sizeof(*out));")
     print("  in += 32;")
     print("  out += 32;")

--- a/cpp/src/arrow/util/bpacking_avx2_generated.h
+++ b/cpp/src/arrow/util/bpacking_avx2_generated.h
@@ -38,7 +38,7 @@ inline const uint32_t* unpack0_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -94,7 +94,7 @@ inline const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -150,7 +150,7 @@ inline const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -206,7 +206,7 @@ inline const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xf;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -262,7 +262,7 @@ inline const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1f;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -318,7 +318,7 @@ inline const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3f;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -374,7 +374,7 @@ inline const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7f;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -430,7 +430,7 @@ inline const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -486,7 +486,7 @@ inline const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1ff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -542,7 +542,7 @@ inline const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3ff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -598,7 +598,7 @@ inline const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7ff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -654,7 +654,7 @@ inline const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xfff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -710,7 +710,7 @@ inline const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1fff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -766,7 +766,7 @@ inline const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3fff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -822,7 +822,7 @@ inline const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7fff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -878,7 +878,7 @@ inline const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -934,7 +934,7 @@ inline const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1ffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -990,7 +990,7 @@ inline const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3ffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1046,7 +1046,7 @@ inline const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7ffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1102,7 +1102,7 @@ inline const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xfffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1158,7 +1158,7 @@ inline const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1fffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1214,7 +1214,7 @@ inline const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3fffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1270,7 +1270,7 @@ inline const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7fffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1326,7 +1326,7 @@ inline const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1382,7 +1382,7 @@ inline const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1ffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1438,7 +1438,7 @@ inline const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3ffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1494,7 +1494,7 @@ inline const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7ffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1550,7 +1550,7 @@ inline const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xfffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1606,7 +1606,7 @@ inline const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1fffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1662,7 +1662,7 @@ inline const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3fffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;
@@ -1718,7 +1718,7 @@ inline const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack31_32_avx2(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack31_32_avx2(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7fffffff;
   __m256i reg_shifts, reg_inls, reg_masks;
   __m256i results;

--- a/cpp/src/arrow/util/bpacking_avx2_generated.h
+++ b/cpp/src/arrow/util/bpacking_avx2_generated.h
@@ -1,0 +1,1786 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// Automatically generated file; DO NOT EDIT.
+
+#pragma once
+
+#include <stdint.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
+#include <immintrin.h>
+#endif
+
+namespace arrow {
+namespace internal {
+
+inline const uint32_t* unpack0_32_avx2(const uint32_t* in, uint32_t* out) {
+  memset(out, 0x0, 32 * sizeof(*out));
+  out += 32;
+
+  return in;
+}
+
+inline const uint32_t* unpack1_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x1;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(7, 6, 5, 4,
+                               3, 2, 1, 0);
+  reg_inls = _mm256_set_epi32(in[0], in[0],
+                             in[0], in[0],
+                             in[0], in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(15, 14, 13, 12,
+                                11, 10, 9, 8);
+  reg_inls = _mm256_set_epi32(in[0], in[0],
+                              in[0], in[0],
+                              in[0], in[0],
+                              in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(23, 22, 21, 20,
+                                19, 18, 17, 16);
+  reg_inls = _mm256_set_epi32(in[0], in[0],
+                              in[0], in[0],
+                              in[0], in[0],
+                              in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(31, 30, 29, 28,
+                                27, 26, 25, 24);
+  reg_inls = _mm256_set_epi32(in[0], in[0],
+                              in[0], in[0],
+                              in[0], in[0],
+                              in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 1;
+
+  return in;
+}
+
+inline const uint32_t* unpack2_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x3;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(14, 12, 10, 8,
+                               6, 4, 2, 0);
+  reg_inls = _mm256_set_epi32(in[0], in[0],
+                             in[0], in[0],
+                             in[0], in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(30, 28, 26, 24,
+                                22, 20, 18, 16);
+  reg_inls = _mm256_set_epi32(in[0], in[0],
+                              in[0], in[0],
+                              in[0], in[0],
+                              in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(14, 12, 10, 8,
+                                6, 4, 2, 0);
+  reg_inls = _mm256_set_epi32(in[1], in[1],
+                              in[1], in[1],
+                              in[1], in[1],
+                              in[1], in[1]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(30, 28, 26, 24,
+                                22, 20, 18, 16);
+  reg_inls = _mm256_set_epi32(in[1], in[1],
+                              in[1], in[1],
+                              in[1], in[1],
+                              in[1], in[1]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 2;
+
+  return in;
+}
+
+inline const uint32_t* unpack3_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x7;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(21, 18, 15, 12,
+                               9, 6, 3, 0);
+  reg_inls = _mm256_set_epi32(in[0], in[0],
+                             in[0], in[0],
+                             in[0], in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(13, 10, 7, 4,
+                                1, 0, 27, 24);
+  reg_inls = _mm256_set_epi32(in[1], in[1],
+                              in[1], in[1],
+                              in[1], in[0] >> 30 | in[1] << 2,
+                              in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(5, 2, 0, 28,
+                                25, 22, 19, 16);
+  reg_inls = _mm256_set_epi32(in[2], in[2],
+                              in[1] >> 31 | in[2] << 1, in[1],
+                              in[1], in[1],
+                              in[1], in[1]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(29, 26, 23, 20,
+                                17, 14, 11, 8);
+  reg_inls = _mm256_set_epi32(in[2], in[2],
+                              in[2], in[2],
+                              in[2], in[2],
+                              in[2], in[2]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 3;
+
+  return in;
+}
+
+inline const uint32_t* unpack4_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0xf;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(28, 24, 20, 16,
+                               12, 8, 4, 0);
+  reg_inls = _mm256_set_epi32(in[0], in[0],
+                             in[0], in[0],
+                             in[0], in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(28, 24, 20, 16,
+                                12, 8, 4, 0);
+  reg_inls = _mm256_set_epi32(in[1], in[1],
+                              in[1], in[1],
+                              in[1], in[1],
+                              in[1], in[1]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(28, 24, 20, 16,
+                                12, 8, 4, 0);
+  reg_inls = _mm256_set_epi32(in[2], in[2],
+                              in[2], in[2],
+                              in[2], in[2],
+                              in[2], in[2]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(28, 24, 20, 16,
+                                12, 8, 4, 0);
+  reg_inls = _mm256_set_epi32(in[3], in[3],
+                              in[3], in[3],
+                              in[3], in[3],
+                              in[3], in[3]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 4;
+
+  return in;
+}
+
+inline const uint32_t* unpack5_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x1f;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(3, 0, 25, 20,
+                               15, 10, 5, 0);
+  reg_inls = _mm256_set_epi32(in[1], in[0] >> 30 | in[1] << 2,
+                             in[0], in[0],
+                             in[0], in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(11, 6, 1, 0,
+                                23, 18, 13, 8);
+  reg_inls = _mm256_set_epi32(in[2], in[2],
+                              in[2], in[1] >> 28 | in[2] << 4,
+                              in[1], in[1],
+                              in[1], in[1]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(19, 14, 9, 4,
+                                0, 26, 21, 16);
+  reg_inls = _mm256_set_epi32(in[3], in[3],
+                              in[3], in[3],
+                              in[2] >> 31 | in[3] << 1, in[2],
+                              in[2], in[2]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(27, 22, 17, 12,
+                                7, 2, 0, 24);
+  reg_inls = _mm256_set_epi32(in[4], in[4],
+                              in[4], in[4],
+                              in[4], in[4],
+                              in[3] >> 29 | in[4] << 3, in[3]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 5;
+
+  return in;
+}
+
+inline const uint32_t* unpack6_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x3f;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(10, 4, 0, 24,
+                               18, 12, 6, 0);
+  reg_inls = _mm256_set_epi32(in[1], in[1],
+                             in[0] >> 30 | in[1] << 2, in[0],
+                             in[0], in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(26, 20, 14, 8,
+                                2, 0, 22, 16);
+  reg_inls = _mm256_set_epi32(in[2], in[2],
+                              in[2], in[2],
+                              in[2], in[1] >> 28 | in[2] << 4,
+                              in[1], in[1]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(10, 4, 0, 24,
+                                18, 12, 6, 0);
+  reg_inls = _mm256_set_epi32(in[4], in[4],
+                              in[3] >> 30 | in[4] << 2, in[3],
+                              in[3], in[3],
+                              in[3], in[3]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(26, 20, 14, 8,
+                                2, 0, 22, 16);
+  reg_inls = _mm256_set_epi32(in[5], in[5],
+                              in[5], in[5],
+                              in[5], in[4] >> 28 | in[5] << 4,
+                              in[4], in[4]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 6;
+
+  return in;
+}
+
+inline const uint32_t* unpack7_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x7f;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(17, 10, 3, 0,
+                               21, 14, 7, 0);
+  reg_inls = _mm256_set_epi32(in[1], in[1],
+                             in[1], in[0] >> 28 | in[1] << 4,
+                             in[0], in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(9, 2, 0, 20,
+                                13, 6, 0, 24);
+  reg_inls = _mm256_set_epi32(in[3], in[3],
+                              in[2] >> 27 | in[3] << 5, in[2],
+                              in[2], in[2],
+                              in[1] >> 31 | in[2] << 1, in[1]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(1, 0, 19, 12,
+                                5, 0, 23, 16);
+  reg_inls = _mm256_set_epi32(in[5], in[4] >> 26 | in[5] << 6,
+                              in[4], in[4],
+                              in[4], in[3] >> 30 | in[4] << 2,
+                              in[3], in[3]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(25, 18, 11, 4,
+                                0, 22, 15, 8);
+  reg_inls = _mm256_set_epi32(in[6], in[6],
+                              in[6], in[6],
+                              in[5] >> 29 | in[6] << 3, in[5],
+                              in[5], in[5]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 7;
+
+  return in;
+}
+
+inline const uint32_t* unpack8_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0xff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(24, 16, 8, 0,
+                               24, 16, 8, 0);
+  reg_inls = _mm256_set_epi32(in[1], in[1],
+                             in[1], in[1],
+                             in[0], in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(24, 16, 8, 0,
+                                24, 16, 8, 0);
+  reg_inls = _mm256_set_epi32(in[3], in[3],
+                              in[3], in[3],
+                              in[2], in[2],
+                              in[2], in[2]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(24, 16, 8, 0,
+                                24, 16, 8, 0);
+  reg_inls = _mm256_set_epi32(in[5], in[5],
+                              in[5], in[5],
+                              in[4], in[4],
+                              in[4], in[4]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(24, 16, 8, 0,
+                                24, 16, 8, 0);
+  reg_inls = _mm256_set_epi32(in[7], in[7],
+                              in[7], in[7],
+                              in[6], in[6],
+                              in[6], in[6]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 8;
+
+  return in;
+}
+
+inline const uint32_t* unpack9_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x1ff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 22, 13, 4,
+                               0, 18, 9, 0);
+  reg_inls = _mm256_set_epi32(in[1] >> 31 | in[2] << 1, in[1],
+                             in[1], in[1],
+                             in[0] >> 27 | in[1] << 5, in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(7, 0, 21, 12,
+                                3, 0, 17, 8);
+  reg_inls = _mm256_set_epi32(in[4], in[3] >> 30 | in[4] << 2,
+                              in[3], in[3],
+                              in[3], in[2] >> 26 | in[3] << 6,
+                              in[2], in[2]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(15, 6, 0, 20,
+                                11, 2, 0, 16);
+  reg_inls = _mm256_set_epi32(in[6], in[6],
+                              in[5] >> 29 | in[6] << 3, in[5],
+                              in[5], in[5],
+                              in[4] >> 25 | in[5] << 7, in[4]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(23, 14, 5, 0,
+                                19, 10, 1, 0);
+  reg_inls = _mm256_set_epi32(in[8], in[8],
+                              in[8], in[7] >> 28 | in[8] << 4,
+                              in[7], in[7],
+                              in[7], in[6] >> 24 | in[7] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 9;
+
+  return in;
+}
+
+inline const uint32_t* unpack10_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x3ff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(6, 0, 18, 8,
+                               0, 20, 10, 0);
+  reg_inls = _mm256_set_epi32(in[2], in[1] >> 28 | in[2] << 4,
+                             in[1], in[1],
+                             in[0] >> 30 | in[1] << 2, in[0],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(22, 12, 2, 0,
+                                14, 4, 0, 16);
+  reg_inls = _mm256_set_epi32(in[4], in[4],
+                              in[4], in[3] >> 24 | in[4] << 8,
+                              in[3], in[3],
+                              in[2] >> 26 | in[3] << 6, in[2]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(6, 0, 18, 8,
+                                0, 20, 10, 0);
+  reg_inls = _mm256_set_epi32(in[7], in[6] >> 28 | in[7] << 4,
+                              in[6], in[6],
+                              in[5] >> 30 | in[6] << 2, in[5],
+                              in[5], in[5]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(22, 12, 2, 0,
+                                14, 4, 0, 16);
+  reg_inls = _mm256_set_epi32(in[9], in[9],
+                              in[9], in[8] >> 24 | in[9] << 8,
+                              in[8], in[8],
+                              in[7] >> 26 | in[8] << 6, in[7]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 10;
+
+  return in;
+}
+
+inline const uint32_t* unpack11_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x7ff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(13, 2, 0, 12,
+                               1, 0, 11, 0);
+  reg_inls = _mm256_set_epi32(in[2], in[2],
+                             in[1] >> 23 | in[2] << 9, in[1],
+                             in[1], in[0] >> 22 | in[1] << 10,
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(5, 0, 15, 4,
+                                0, 14, 3, 0);
+  reg_inls = _mm256_set_epi32(in[5], in[4] >> 26 | in[5] << 6,
+                              in[4], in[4],
+                              in[3] >> 25 | in[4] << 7, in[3],
+                              in[3], in[2] >> 24 | in[3] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 18, 7, 0,
+                                17, 6, 0, 16);
+  reg_inls = _mm256_set_epi32(in[7] >> 29 | in[8] << 3, in[7],
+                              in[7], in[6] >> 28 | in[7] << 4,
+                              in[6], in[6],
+                              in[5] >> 27 | in[6] << 5, in[5]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(21, 10, 0, 20,
+                                9, 0, 19, 8);
+  reg_inls = _mm256_set_epi32(in[10], in[10],
+                              in[9] >> 31 | in[10] << 1, in[9],
+                              in[9], in[8] >> 30 | in[9] << 2,
+                              in[8], in[8]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 11;
+
+  return in;
+}
+
+inline const uint32_t* unpack12_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0xfff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(20, 8, 0, 16,
+                               4, 0, 12, 0);
+  reg_inls = _mm256_set_epi32(in[2], in[2],
+                             in[1] >> 28 | in[2] << 4, in[1],
+                             in[1], in[0] >> 24 | in[1] << 8,
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(20, 8, 0, 16,
+                                4, 0, 12, 0);
+  reg_inls = _mm256_set_epi32(in[5], in[5],
+                              in[4] >> 28 | in[5] << 4, in[4],
+                              in[4], in[3] >> 24 | in[4] << 8,
+                              in[3], in[3]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(20, 8, 0, 16,
+                                4, 0, 12, 0);
+  reg_inls = _mm256_set_epi32(in[8], in[8],
+                              in[7] >> 28 | in[8] << 4, in[7],
+                              in[7], in[6] >> 24 | in[7] << 8,
+                              in[6], in[6]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(20, 8, 0, 16,
+                                4, 0, 12, 0);
+  reg_inls = _mm256_set_epi32(in[11], in[11],
+                              in[10] >> 28 | in[11] << 4, in[10],
+                              in[10], in[9] >> 24 | in[10] << 8,
+                              in[9], in[9]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 12;
+
+  return in;
+}
+
+inline const uint32_t* unpack13_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x1fff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 14, 1, 0,
+                               7, 0, 13, 0);
+  reg_inls = _mm256_set_epi32(in[2] >> 27 | in[3] << 5, in[2],
+                             in[2], in[1] >> 20 | in[2] << 12,
+                             in[1], in[0] >> 26 | in[1] << 6,
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(3, 0, 9, 0,
+                                15, 2, 0, 8);
+  reg_inls = _mm256_set_epi32(in[6], in[5] >> 22 | in[6] << 10,
+                              in[5], in[4] >> 28 | in[5] << 4,
+                              in[4], in[4],
+                              in[3] >> 21 | in[4] << 11, in[3]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(11, 0, 17, 4,
+                                0, 10, 0, 16);
+  reg_inls = _mm256_set_epi32(in[9], in[8] >> 30 | in[9] << 2,
+                              in[8], in[8],
+                              in[7] >> 23 | in[8] << 9, in[7],
+                              in[6] >> 29 | in[7] << 3, in[6]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(19, 6, 0, 12,
+                                0, 18, 5, 0);
+  reg_inls = _mm256_set_epi32(in[12], in[12],
+                              in[11] >> 25 | in[12] << 7, in[11],
+                              in[10] >> 31 | in[11] << 1, in[10],
+                              in[10], in[9] >> 24 | in[10] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 13;
+
+  return in;
+}
+
+inline const uint32_t* unpack14_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x3fff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(2, 0, 6, 0,
+                               10, 0, 14, 0);
+  reg_inls = _mm256_set_epi32(in[3], in[2] >> 20 | in[3] << 12,
+                             in[2], in[1] >> 24 | in[2] << 8,
+                             in[1], in[0] >> 28 | in[1] << 4,
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(18, 4, 0, 8,
+                                0, 12, 0, 16);
+  reg_inls = _mm256_set_epi32(in[6], in[6],
+                              in[5] >> 22 | in[6] << 10, in[5],
+                              in[4] >> 26 | in[5] << 6, in[4],
+                              in[3] >> 30 | in[4] << 2, in[3]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(2, 0, 6, 0,
+                                10, 0, 14, 0);
+  reg_inls = _mm256_set_epi32(in[10], in[9] >> 20 | in[10] << 12,
+                              in[9], in[8] >> 24 | in[9] << 8,
+                              in[8], in[7] >> 28 | in[8] << 4,
+                              in[7], in[7]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(18, 4, 0, 8,
+                                0, 12, 0, 16);
+  reg_inls = _mm256_set_epi32(in[13], in[13],
+                              in[12] >> 22 | in[13] << 10, in[12],
+                              in[11] >> 26 | in[12] << 6, in[11],
+                              in[10] >> 30 | in[11] << 2, in[10]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 14;
+
+  return in;
+}
+
+inline const uint32_t* unpack15_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x7fff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(9, 0, 11, 0,
+                               13, 0, 15, 0);
+  reg_inls = _mm256_set_epi32(in[3], in[2] >> 26 | in[3] << 6,
+                             in[2], in[1] >> 28 | in[2] << 4,
+                             in[1], in[0] >> 30 | in[1] << 2,
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(1, 0, 3, 0,
+                                5, 0, 7, 0);
+  reg_inls = _mm256_set_epi32(in[7], in[6] >> 18 | in[7] << 14,
+                              in[6], in[5] >> 20 | in[6] << 12,
+                              in[5], in[4] >> 22 | in[5] << 10,
+                              in[4], in[3] >> 24 | in[4] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 10, 0, 12,
+                                0, 14, 0, 16);
+  reg_inls = _mm256_set_epi32(in[10] >> 25 | in[11] << 7, in[10],
+                              in[9] >> 27 | in[10] << 5, in[9],
+                              in[8] >> 29 | in[9] << 3, in[8],
+                              in[7] >> 31 | in[8] << 1, in[7]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(17, 2, 0, 4,
+                                0, 6, 0, 8);
+  reg_inls = _mm256_set_epi32(in[14], in[14],
+                              in[13] >> 19 | in[14] << 13, in[13],
+                              in[12] >> 21 | in[13] << 11, in[12],
+                              in[11] >> 23 | in[12] << 9, in[11]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 15;
+
+  return in;
+}
+
+inline const uint32_t* unpack16_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0xffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(16, 0, 16, 0,
+                               16, 0, 16, 0);
+  reg_inls = _mm256_set_epi32(in[3], in[3],
+                             in[2], in[2],
+                             in[1], in[1],
+                             in[0], in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(16, 0, 16, 0,
+                                16, 0, 16, 0);
+  reg_inls = _mm256_set_epi32(in[7], in[7],
+                              in[6], in[6],
+                              in[5], in[5],
+                              in[4], in[4]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(16, 0, 16, 0,
+                                16, 0, 16, 0);
+  reg_inls = _mm256_set_epi32(in[11], in[11],
+                              in[10], in[10],
+                              in[9], in[9],
+                              in[8], in[8]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(16, 0, 16, 0,
+                                16, 0, 16, 0);
+  reg_inls = _mm256_set_epi32(in[15], in[15],
+                              in[14], in[14],
+                              in[13], in[13],
+                              in[12], in[12]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 16;
+
+  return in;
+}
+
+inline const uint32_t* unpack17_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x1ffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 6, 0, 4,
+                               0, 2, 0, 0);
+  reg_inls = _mm256_set_epi32(in[3] >> 23 | in[4] << 9, in[3],
+                             in[2] >> 21 | in[3] << 11, in[2],
+                             in[1] >> 19 | in[2] << 13, in[1],
+                             in[0] >> 17 | in[1] << 15, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(0, 14, 0, 12,
+                                0, 10, 0, 8);
+  reg_inls = _mm256_set_epi32(in[7] >> 31 | in[8] << 1, in[7],
+                              in[6] >> 29 | in[7] << 3, in[6],
+                              in[5] >> 27 | in[6] << 5, in[5],
+                              in[4] >> 25 | in[5] << 7, in[4]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(7, 0, 5, 0,
+                                3, 0, 1, 0);
+  reg_inls = _mm256_set_epi32(in[12], in[11] >> 22 | in[12] << 10,
+                              in[11], in[10] >> 20 | in[11] << 12,
+                              in[10], in[9] >> 18 | in[10] << 14,
+                              in[9], in[8] >> 16 | in[9] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(15, 0, 13, 0,
+                                11, 0, 9, 0);
+  reg_inls = _mm256_set_epi32(in[16], in[15] >> 30 | in[16] << 2,
+                              in[15], in[14] >> 28 | in[15] << 4,
+                              in[14], in[13] >> 26 | in[14] << 6,
+                              in[13], in[12] >> 24 | in[13] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 17;
+
+  return in;
+}
+
+inline const uint32_t* unpack18_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x3ffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 12, 0, 8,
+                               0, 4, 0, 0);
+  reg_inls = _mm256_set_epi32(in[3] >> 30 | in[4] << 2, in[3],
+                             in[2] >> 26 | in[3] << 6, in[2],
+                             in[1] >> 22 | in[2] << 10, in[1],
+                             in[0] >> 18 | in[1] << 14, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(14, 0, 10, 0,
+                                6, 0, 2, 0);
+  reg_inls = _mm256_set_epi32(in[8], in[7] >> 28 | in[8] << 4,
+                              in[7], in[6] >> 24 | in[7] << 8,
+                              in[6], in[5] >> 20 | in[6] << 12,
+                              in[5], in[4] >> 16 | in[5] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 12, 0, 8,
+                                0, 4, 0, 0);
+  reg_inls = _mm256_set_epi32(in[12] >> 30 | in[13] << 2, in[12],
+                              in[11] >> 26 | in[12] << 6, in[11],
+                              in[10] >> 22 | in[11] << 10, in[10],
+                              in[9] >> 18 | in[10] << 14, in[9]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(14, 0, 10, 0,
+                                6, 0, 2, 0);
+  reg_inls = _mm256_set_epi32(in[17], in[16] >> 28 | in[17] << 4,
+                              in[16], in[15] >> 24 | in[16] << 8,
+                              in[15], in[14] >> 20 | in[15] << 12,
+                              in[14], in[13] >> 16 | in[14] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 18;
+
+  return in;
+}
+
+inline const uint32_t* unpack19_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x7ffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(5, 0, 0, 12,
+                               0, 6, 0, 0);
+  reg_inls = _mm256_set_epi32(in[4], in[3] >> 18 | in[4] << 14,
+                             in[2] >> 31 | in[3] << 1, in[2],
+                             in[1] >> 25 | in[2] << 7, in[1],
+                             in[0] >> 19 | in[1] << 13, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(0, 10, 0, 4,
+                                0, 0, 11, 0);
+  reg_inls = _mm256_set_epi32(in[8] >> 29 | in[9] << 3, in[8],
+                              in[7] >> 23 | in[8] << 9, in[7],
+                              in[6] >> 17 | in[7] << 15, in[5] >> 30 | in[6] << 2,
+                              in[5], in[4] >> 24 | in[5] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 2, 0, 0,
+                                9, 0, 3, 0);
+  reg_inls = _mm256_set_epi32(in[13] >> 21 | in[14] << 11, in[13],
+                              in[12] >> 15 | in[13] << 17, in[11] >> 28 | in[12] << 4,
+                              in[11], in[10] >> 22 | in[11] << 10,
+                              in[10], in[9] >> 16 | in[10] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(13, 0, 7, 0,
+                                1, 0, 0, 8);
+  reg_inls = _mm256_set_epi32(in[18], in[17] >> 26 | in[18] << 6,
+                              in[17], in[16] >> 20 | in[17] << 12,
+                              in[16], in[15] >> 14 | in[16] << 18,
+                              in[14] >> 27 | in[15] << 5, in[14]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 19;
+
+  return in;
+}
+
+inline const uint32_t* unpack20_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0xfffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(12, 0, 4, 0,
+                               0, 8, 0, 0);
+  reg_inls = _mm256_set_epi32(in[4], in[3] >> 24 | in[4] << 8,
+                             in[3], in[2] >> 16 | in[3] << 16,
+                             in[1] >> 28 | in[2] << 4, in[1],
+                             in[0] >> 20 | in[1] << 12, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(12, 0, 4, 0,
+                                0, 8, 0, 0);
+  reg_inls = _mm256_set_epi32(in[9], in[8] >> 24 | in[9] << 8,
+                              in[8], in[7] >> 16 | in[8] << 16,
+                              in[6] >> 28 | in[7] << 4, in[6],
+                              in[5] >> 20 | in[6] << 12, in[5]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(12, 0, 4, 0,
+                                0, 8, 0, 0);
+  reg_inls = _mm256_set_epi32(in[14], in[13] >> 24 | in[14] << 8,
+                              in[13], in[12] >> 16 | in[13] << 16,
+                              in[11] >> 28 | in[12] << 4, in[11],
+                              in[10] >> 20 | in[11] << 12, in[10]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(12, 0, 4, 0,
+                                0, 8, 0, 0);
+  reg_inls = _mm256_set_epi32(in[19], in[18] >> 24 | in[19] << 8,
+                              in[18], in[17] >> 16 | in[18] << 16,
+                              in[16] >> 28 | in[17] << 4, in[16],
+                              in[15] >> 20 | in[16] << 12, in[15]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 20;
+
+  return in;
+}
+
+inline const uint32_t* unpack21_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x1fffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 9, 0,
+                               0, 10, 0, 0);
+  reg_inls = _mm256_set_epi32(in[4] >> 19 | in[5] << 13, in[3] >> 30 | in[4] << 2,
+                             in[3], in[2] >> 20 | in[3] << 12,
+                             in[1] >> 31 | in[2] << 1, in[1],
+                             in[0] >> 21 | in[1] << 11, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(0, 6, 0, 0,
+                                7, 0, 0, 8);
+  reg_inls = _mm256_set_epi32(in[9] >> 27 | in[10] << 5, in[9],
+                              in[8] >> 17 | in[9] << 15, in[7] >> 28 | in[8] << 4,
+                              in[7], in[6] >> 18 | in[7] << 14,
+                              in[5] >> 29 | in[6] << 3, in[5]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(3, 0, 0, 4,
+                                0, 0, 5, 0);
+  reg_inls = _mm256_set_epi32(in[15], in[14] >> 14 | in[15] << 18,
+                              in[13] >> 25 | in[14] << 7, in[13],
+                              in[12] >> 15 | in[13] << 17, in[11] >> 26 | in[12] << 6,
+                              in[11], in[10] >> 16 | in[11] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(11, 0, 1, 0,
+                                0, 2, 0, 0);
+  reg_inls = _mm256_set_epi32(in[20], in[19] >> 22 | in[20] << 10,
+                              in[19], in[18] >> 12 | in[19] << 20,
+                              in[17] >> 23 | in[18] << 9, in[17],
+                              in[16] >> 13 | in[17] << 19, in[15] >> 24 | in[16] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 21;
+
+  return in;
+}
+
+inline const uint32_t* unpack22_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x3fffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 4, 0, 0,
+                               2, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[4] >> 26 | in[5] << 6, in[4],
+                             in[3] >> 14 | in[4] << 18, in[2] >> 24 | in[3] << 8,
+                             in[2], in[1] >> 12 | in[2] << 20,
+                             in[0] >> 22 | in[1] << 10, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(10, 0, 0, 8,
+                                0, 0, 6, 0);
+  reg_inls = _mm256_set_epi32(in[10], in[9] >> 20 | in[10] << 12,
+                              in[8] >> 30 | in[9] << 2, in[8],
+                              in[7] >> 18 | in[8] << 14, in[6] >> 28 | in[7] << 4,
+                              in[6], in[5] >> 16 | in[6] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 4, 0, 0,
+                                2, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[15] >> 26 | in[16] << 6, in[15],
+                              in[14] >> 14 | in[15] << 18, in[13] >> 24 | in[14] << 8,
+                              in[13], in[12] >> 12 | in[13] << 20,
+                              in[11] >> 22 | in[12] << 10, in[11]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(10, 0, 0, 8,
+                                0, 0, 6, 0);
+  reg_inls = _mm256_set_epi32(in[21], in[20] >> 20 | in[21] << 12,
+                              in[19] >> 30 | in[20] << 2, in[19],
+                              in[18] >> 18 | in[19] << 14, in[17] >> 28 | in[18] << 4,
+                              in[17], in[16] >> 16 | in[17] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 22;
+
+  return in;
+}
+
+inline const uint32_t* unpack23_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x7fffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(1, 0, 0, 0,
+                               5, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[5], in[4] >> 10 | in[5] << 22,
+                             in[3] >> 19 | in[4] << 13, in[2] >> 28 | in[3] << 4,
+                             in[2], in[1] >> 14 | in[2] << 18,
+                             in[0] >> 23 | in[1] << 9, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(0, 2, 0, 0,
+                                0, 6, 0, 0);
+  reg_inls = _mm256_set_epi32(in[10] >> 25 | in[11] << 7, in[10],
+                              in[9] >> 11 | in[10] << 21, in[8] >> 20 | in[9] << 12,
+                              in[7] >> 29 | in[8] << 3, in[7],
+                              in[6] >> 15 | in[7] << 17, in[5] >> 24 | in[6] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 3, 0,
+                                0, 0, 7, 0);
+  reg_inls = _mm256_set_epi32(in[16] >> 17 | in[17] << 15, in[15] >> 26 | in[16] << 6,
+                              in[15], in[14] >> 12 | in[15] << 20,
+                              in[13] >> 21 | in[14] << 11, in[12] >> 30 | in[13] << 2,
+                              in[12], in[11] >> 16 | in[12] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(9, 0, 0, 4,
+                                0, 0, 0, 8);
+  reg_inls = _mm256_set_epi32(in[22], in[21] >> 18 | in[22] << 14,
+                              in[20] >> 27 | in[21] << 5, in[20],
+                              in[19] >> 13 | in[20] << 19, in[18] >> 22 | in[19] << 10,
+                              in[17] >> 31 | in[18] << 1, in[17]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 23;
+
+  return in;
+}
+
+inline const uint32_t* unpack24_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0xffffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(8, 0, 0, 0,
+                               8, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[5], in[4] >> 16 | in[5] << 16,
+                             in[3] >> 24 | in[4] << 8, in[3],
+                             in[2], in[1] >> 16 | in[2] << 16,
+                             in[0] >> 24 | in[1] << 8, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(8, 0, 0, 0,
+                                8, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[11], in[10] >> 16 | in[11] << 16,
+                              in[9] >> 24 | in[10] << 8, in[9],
+                              in[8], in[7] >> 16 | in[8] << 16,
+                              in[6] >> 24 | in[7] << 8, in[6]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(8, 0, 0, 0,
+                                8, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[17], in[16] >> 16 | in[17] << 16,
+                              in[15] >> 24 | in[16] << 8, in[15],
+                              in[14], in[13] >> 16 | in[14] << 16,
+                              in[12] >> 24 | in[13] << 8, in[12]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(8, 0, 0, 0,
+                                8, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[23], in[22] >> 16 | in[23] << 16,
+                              in[21] >> 24 | in[22] << 8, in[21],
+                              in[20], in[19] >> 16 | in[20] << 16,
+                              in[18] >> 24 | in[19] << 8, in[18]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 24;
+
+  return in;
+}
+
+inline const uint32_t* unpack25_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x1ffffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 4,
+                               0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[5] >> 15 | in[6] << 17, in[4] >> 22 | in[5] << 10,
+                             in[3] >> 29 | in[4] << 3, in[3],
+                             in[2] >> 11 | in[3] << 21, in[1] >> 18 | in[2] << 14,
+                             in[0] >> 25 | in[1] << 7, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 5, 0,
+                                0, 0, 1, 0);
+  reg_inls = _mm256_set_epi32(in[11] >> 23 | in[12] << 9, in[10] >> 30 | in[11] << 2,
+                              in[10], in[9] >> 12 | in[10] << 20,
+                              in[8] >> 19 | in[9] << 13, in[7] >> 26 | in[8] << 6,
+                              in[7], in[6] >> 8 | in[7] << 24);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 6, 0, 0,
+                                0, 2, 0, 0);
+  reg_inls = _mm256_set_epi32(in[17] >> 31 | in[18] << 1, in[17],
+                              in[16] >> 13 | in[17] << 19, in[15] >> 20 | in[16] << 12,
+                              in[14] >> 27 | in[15] << 5, in[14],
+                              in[13] >> 9 | in[14] << 23, in[12] >> 16 | in[13] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(7, 0, 0, 0,
+                                3, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[24], in[23] >> 14 | in[24] << 18,
+                              in[22] >> 21 | in[23] << 11, in[21] >> 28 | in[22] << 4,
+                              in[21], in[20] >> 10 | in[21] << 22,
+                              in[19] >> 17 | in[20] << 15, in[18] >> 24 | in[19] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 25;
+
+  return in;
+}
+
+inline const uint32_t* unpack26_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x3ffffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 2, 0,
+                               0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[5] >> 22 | in[6] << 10, in[4] >> 28 | in[5] << 4,
+                             in[4], in[3] >> 8 | in[4] << 24,
+                             in[2] >> 14 | in[3] << 18, in[1] >> 20 | in[2] << 12,
+                             in[0] >> 26 | in[1] << 6, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(6, 0, 0, 0,
+                                0, 4, 0, 0);
+  reg_inls = _mm256_set_epi32(in[12], in[11] >> 12 | in[12] << 20,
+                              in[10] >> 18 | in[11] << 14, in[9] >> 24 | in[10] << 8,
+                              in[8] >> 30 | in[9] << 2, in[8],
+                              in[7] >> 10 | in[8] << 22, in[6] >> 16 | in[7] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 2, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[18] >> 22 | in[19] << 10, in[17] >> 28 | in[18] << 4,
+                              in[17], in[16] >> 8 | in[17] << 24,
+                              in[15] >> 14 | in[16] << 18, in[14] >> 20 | in[15] << 12,
+                              in[13] >> 26 | in[14] << 6, in[13]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(6, 0, 0, 0,
+                                0, 4, 0, 0);
+  reg_inls = _mm256_set_epi32(in[25], in[24] >> 12 | in[25] << 20,
+                              in[23] >> 18 | in[24] << 14, in[22] >> 24 | in[23] << 8,
+                              in[21] >> 30 | in[22] << 2, in[21],
+                              in[20] >> 10 | in[21] << 22, in[19] >> 16 | in[20] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 26;
+
+  return in;
+}
+
+inline const uint32_t* unpack27_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x7ffffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 2, 0, 0,
+                               0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[5] >> 29 | in[6] << 3, in[5],
+                             in[4] >> 7 | in[5] << 25, in[3] >> 12 | in[4] << 20,
+                             in[2] >> 17 | in[3] << 15, in[1] >> 22 | in[2] << 10,
+                             in[0] >> 27 | in[1] << 5, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 4,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[12] >> 21 | in[13] << 11, in[11] >> 26 | in[12] << 6,
+                              in[10] >> 31 | in[11] << 1, in[10],
+                              in[9] >> 9 | in[10] << 23, in[8] >> 14 | in[9] << 18,
+                              in[7] >> 19 | in[8] << 13, in[6] >> 24 | in[7] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
+                                1, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[19] >> 13 | in[20] << 19, in[18] >> 18 | in[19] << 14,
+                              in[17] >> 23 | in[18] << 9, in[16] >> 28 | in[17] << 4,
+                              in[16], in[15] >> 6 | in[16] << 26,
+                              in[14] >> 11 | in[15] << 21, in[13] >> 16 | in[14] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(5, 0, 0, 0,
+                                0, 0, 3, 0);
+  reg_inls = _mm256_set_epi32(in[26], in[25] >> 10 | in[26] << 22,
+                              in[24] >> 15 | in[25] << 17, in[23] >> 20 | in[24] << 12,
+                              in[22] >> 25 | in[23] << 7, in[21] >> 30 | in[22] << 2,
+                              in[21], in[20] >> 8 | in[21] << 24);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 27;
+
+  return in;
+}
+
+inline const uint32_t* unpack28_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0xfffffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(4, 0, 0, 0,
+                               0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[6], in[5] >> 8 | in[6] << 24,
+                             in[4] >> 12 | in[5] << 20, in[3] >> 16 | in[4] << 16,
+                             in[2] >> 20 | in[3] << 12, in[1] >> 24 | in[2] << 8,
+                             in[0] >> 28 | in[1] << 4, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(4, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[13], in[12] >> 8 | in[13] << 24,
+                              in[11] >> 12 | in[12] << 20, in[10] >> 16 | in[11] << 16,
+                              in[9] >> 20 | in[10] << 12, in[8] >> 24 | in[9] << 8,
+                              in[7] >> 28 | in[8] << 4, in[7]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(4, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[20], in[19] >> 8 | in[20] << 24,
+                              in[18] >> 12 | in[19] << 20, in[17] >> 16 | in[18] << 16,
+                              in[16] >> 20 | in[17] << 12, in[15] >> 24 | in[16] << 8,
+                              in[14] >> 28 | in[15] << 4, in[14]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(4, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[27], in[26] >> 8 | in[27] << 24,
+                              in[25] >> 12 | in[26] << 20, in[24] >> 16 | in[25] << 16,
+                              in[23] >> 20 | in[24] << 12, in[22] >> 24 | in[23] << 8,
+                              in[21] >> 28 | in[22] << 4, in[21]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 28;
+
+  return in;
+}
+
+inline const uint32_t* unpack29_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x1fffffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
+                               0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[6] >> 11 | in[7] << 21, in[5] >> 14 | in[6] << 18,
+                             in[4] >> 17 | in[5] << 15, in[3] >> 20 | in[4] << 12,
+                             in[2] >> 23 | in[3] << 9, in[1] >> 26 | in[2] << 6,
+                             in[0] >> 29 | in[1] << 3, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
+                                0, 2, 0, 0);
+  reg_inls = _mm256_set_epi32(in[13] >> 19 | in[14] << 13, in[12] >> 22 | in[13] << 10,
+                              in[11] >> 25 | in[12] << 7, in[10] >> 28 | in[11] << 4,
+                              in[9] >> 31 | in[10] << 1, in[9],
+                              in[8] >> 5 | in[9] << 27, in[7] >> 8 | in[8] << 24);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 1, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[20] >> 27 | in[21] << 5, in[19] >> 30 | in[20] << 2,
+                              in[19], in[18] >> 4 | in[19] << 28,
+                              in[17] >> 7 | in[18] << 25, in[16] >> 10 | in[17] << 22,
+                              in[15] >> 13 | in[16] << 19, in[14] >> 16 | in[15] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(3, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[28], in[27] >> 6 | in[28] << 26,
+                              in[26] >> 9 | in[27] << 23, in[25] >> 12 | in[26] << 20,
+                              in[24] >> 15 | in[25] << 17, in[23] >> 18 | in[24] << 14,
+                              in[22] >> 21 | in[23] << 11, in[21] >> 24 | in[22] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 29;
+
+  return in;
+}
+
+inline const uint32_t* unpack30_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x3fffffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
+                               0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[6] >> 18 | in[7] << 14, in[5] >> 20 | in[6] << 12,
+                             in[4] >> 22 | in[5] << 10, in[3] >> 24 | in[4] << 8,
+                             in[2] >> 26 | in[3] << 6, in[1] >> 28 | in[2] << 4,
+                             in[0] >> 30 | in[1] << 2, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(2, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[14], in[13] >> 4 | in[14] << 28,
+                              in[12] >> 6 | in[13] << 26, in[11] >> 8 | in[12] << 24,
+                              in[10] >> 10 | in[11] << 22, in[9] >> 12 | in[10] << 20,
+                              in[8] >> 14 | in[9] << 18, in[7] >> 16 | in[8] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[21] >> 18 | in[22] << 14, in[20] >> 20 | in[21] << 12,
+                              in[19] >> 22 | in[20] << 10, in[18] >> 24 | in[19] << 8,
+                              in[17] >> 26 | in[18] << 6, in[16] >> 28 | in[17] << 4,
+                              in[15] >> 30 | in[16] << 2, in[15]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(2, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[29], in[28] >> 4 | in[29] << 28,
+                              in[27] >> 6 | in[28] << 26, in[26] >> 8 | in[27] << 24,
+                              in[25] >> 10 | in[26] << 22, in[24] >> 12 | in[25] << 20,
+                              in[23] >> 14 | in[24] << 18, in[22] >> 16 | in[23] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 30;
+
+  return in;
+}
+
+inline const uint32_t* unpack31_32_avx2(const uint32_t* in, uint32_t* out) {
+  uint32_t mask = 0x7fffffff;
+  __m256i reg_shifts, reg_inls, reg_masks;
+  __m256i results;
+
+  reg_masks = _mm256_set1_epi32(mask);
+
+  // shift the first 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
+                               0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[6] >> 25 | in[7] << 7, in[5] >> 26 | in[6] << 6,
+                             in[4] >> 27 | in[5] << 5, in[3] >> 28 | in[4] << 4,
+                             in[2] >> 29 | in[3] << 3, in[1] >> 30 | in[2] << 2,
+                             in[0] >> 31 | in[1] << 1, in[0]);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the second 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[14] >> 17 | in[15] << 15, in[13] >> 18 | in[14] << 14,
+                              in[12] >> 19 | in[13] << 13, in[11] >> 20 | in[12] << 12,
+                              in[10] >> 21 | in[11] << 11, in[9] >> 22 | in[10] << 10,
+                              in[8] >> 23 | in[9] << 9, in[7] >> 24 | in[8] << 8);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the third 8 outs
+  reg_shifts = _mm256_set_epi32(0, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[22] >> 9 | in[23] << 23, in[21] >> 10 | in[22] << 22,
+                              in[20] >> 11 | in[21] << 21, in[19] >> 12 | in[20] << 20,
+                              in[18] >> 13 | in[19] << 19, in[17] >> 14 | in[18] << 18,
+                              in[16] >> 15 | in[17] << 17, in[15] >> 16 | in[16] << 16);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  // shift the last 8 outs
+  reg_shifts = _mm256_set_epi32(1, 0, 0, 0,
+                                0, 0, 0, 0);
+  reg_inls = _mm256_set_epi32(in[30], in[29] >> 2 | in[30] << 30,
+                              in[28] >> 3 | in[29] << 29, in[27] >> 4 | in[28] << 28,
+                              in[26] >> 5 | in[27] << 27, in[25] >> 6 | in[26] << 26,
+                              in[24] >> 7 | in[25] << 25, in[23] >> 8 | in[24] << 24);
+  results = _mm256_and_si256(_mm256_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm256_storeu_si256(reinterpret_cast<__m256i*>(out), results);
+  out += 8;
+
+  in += 31;
+
+  return in;
+}
+
+inline const uint32_t* unpack32_32_avx2(const uint32_t* in, uint32_t* out) {
+  memcpy(out, in, 32 * sizeof(*out));
+  in += 32;
+  out += 32;
+
+  return in;
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/bpacking_avx512.cc
+++ b/cpp/src/arrow/util/bpacking_avx512.cc
@@ -1,0 +1,137 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/bpacking_avx512.h"
+#include "arrow/util/bpacking_avx512_generated.h"
+#include "arrow/util/logging.h"
+
+namespace arrow {
+namespace internal {
+
+int unpack32_avx512(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
+  batch_size = batch_size / 32 * 32;
+  int num_loops = batch_size / 32;
+
+  switch (num_bits) {
+    case 0:
+      for (int i = 0; i < num_loops; ++i) in = unpack0_32_avx512(in, out + i * 32);
+      break;
+    case 1:
+      for (int i = 0; i < num_loops; ++i) in = unpack1_32_avx512(in, out + i * 32);
+      break;
+    case 2:
+      for (int i = 0; i < num_loops; ++i) in = unpack2_32_avx512(in, out + i * 32);
+      break;
+    case 3:
+      for (int i = 0; i < num_loops; ++i) in = unpack3_32_avx512(in, out + i * 32);
+      break;
+    case 4:
+      for (int i = 0; i < num_loops; ++i) in = unpack4_32_avx512(in, out + i * 32);
+      break;
+    case 5:
+      for (int i = 0; i < num_loops; ++i) in = unpack5_32_avx512(in, out + i * 32);
+      break;
+    case 6:
+      for (int i = 0; i < num_loops; ++i) in = unpack6_32_avx512(in, out + i * 32);
+      break;
+    case 7:
+      for (int i = 0; i < num_loops; ++i) in = unpack7_32_avx512(in, out + i * 32);
+      break;
+    case 8:
+      for (int i = 0; i < num_loops; ++i) in = unpack8_32_avx512(in, out + i * 32);
+      break;
+    case 9:
+      for (int i = 0; i < num_loops; ++i) in = unpack9_32_avx512(in, out + i * 32);
+      break;
+    case 10:
+      for (int i = 0; i < num_loops; ++i) in = unpack10_32_avx512(in, out + i * 32);
+      break;
+    case 11:
+      for (int i = 0; i < num_loops; ++i) in = unpack11_32_avx512(in, out + i * 32);
+      break;
+    case 12:
+      for (int i = 0; i < num_loops; ++i) in = unpack12_32_avx512(in, out + i * 32);
+      break;
+    case 13:
+      for (int i = 0; i < num_loops; ++i) in = unpack13_32_avx512(in, out + i * 32);
+      break;
+    case 14:
+      for (int i = 0; i < num_loops; ++i) in = unpack14_32_avx512(in, out + i * 32);
+      break;
+    case 15:
+      for (int i = 0; i < num_loops; ++i) in = unpack15_32_avx512(in, out + i * 32);
+      break;
+    case 16:
+      for (int i = 0; i < num_loops; ++i) in = unpack16_32_avx512(in, out + i * 32);
+      break;
+    case 17:
+      for (int i = 0; i < num_loops; ++i) in = unpack17_32_avx512(in, out + i * 32);
+      break;
+    case 18:
+      for (int i = 0; i < num_loops; ++i) in = unpack18_32_avx512(in, out + i * 32);
+      break;
+    case 19:
+      for (int i = 0; i < num_loops; ++i) in = unpack19_32_avx512(in, out + i * 32);
+      break;
+    case 20:
+      for (int i = 0; i < num_loops; ++i) in = unpack20_32_avx512(in, out + i * 32);
+      break;
+    case 21:
+      for (int i = 0; i < num_loops; ++i) in = unpack21_32_avx512(in, out + i * 32);
+      break;
+    case 22:
+      for (int i = 0; i < num_loops; ++i) in = unpack22_32_avx512(in, out + i * 32);
+      break;
+    case 23:
+      for (int i = 0; i < num_loops; ++i) in = unpack23_32_avx512(in, out + i * 32);
+      break;
+    case 24:
+      for (int i = 0; i < num_loops; ++i) in = unpack24_32_avx512(in, out + i * 32);
+      break;
+    case 25:
+      for (int i = 0; i < num_loops; ++i) in = unpack25_32_avx512(in, out + i * 32);
+      break;
+    case 26:
+      for (int i = 0; i < num_loops; ++i) in = unpack26_32_avx512(in, out + i * 32);
+      break;
+    case 27:
+      for (int i = 0; i < num_loops; ++i) in = unpack27_32_avx512(in, out + i * 32);
+      break;
+    case 28:
+      for (int i = 0; i < num_loops; ++i) in = unpack28_32_avx512(in, out + i * 32);
+      break;
+    case 29:
+      for (int i = 0; i < num_loops; ++i) in = unpack29_32_avx512(in, out + i * 32);
+      break;
+    case 30:
+      for (int i = 0; i < num_loops; ++i) in = unpack30_32_avx512(in, out + i * 32);
+      break;
+    case 31:
+      for (int i = 0; i < num_loops; ++i) in = unpack31_32_avx512(in, out + i * 32);
+      break;
+    case 32:
+      for (int i = 0; i < num_loops; ++i) in = unpack32_32_avx512(in, out + i * 32);
+      break;
+    default:
+      DCHECK(false) << "Unsupported num_bits";
+  }
+
+  return batch_size;
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/bpacking_avx512.h
+++ b/cpp/src/arrow/util/bpacking_avx512.h
@@ -22,7 +22,7 @@
 namespace arrow {
 namespace internal {
 
-int unpack32(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
+int unpack32_avx512(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/bpacking_avx512_codegen.py
+++ b/cpp/src/arrow/util/bpacking_avx512_codegen.py
@@ -29,7 +29,7 @@ def print_unpack_bit_func(bit):
     bracket = "{"
 
     print(
-        f"inline const uint32_t* unpack{bit}_32_avx512(const uint32_t* in, uint32_t* out) {bracket}")
+        f"inline static const uint32_t* unpack{bit}_32_avx512(const uint32_t* in, uint32_t* out) {bracket}")
     print("  uint32_t mask = 0x%x;" % mask)
     print("  __m512i reg_shifts, reg_inls, reg_masks;")
     print("  __m512i results;")
@@ -106,7 +106,7 @@ def print_unpack_bit_func(bit):
 
 def print_unpack_bit0_func():
     print(
-        "inline const uint32_t* unpack0_32_avx512(const uint32_t* in, uint32_t* out) {")
+        "inline static const uint32_t* unpack0_32_avx512(const uint32_t* in, uint32_t* out) {")
     print("  memset(out, 0x0, 32 * sizeof(*out));")
     print("  out += 32;")
     print("")
@@ -116,7 +116,7 @@ def print_unpack_bit0_func():
 
 def print_unpack_bit32_func():
     print(
-        "inline const uint32_t* unpack32_32_avx512(const uint32_t* in, uint32_t* out) {")
+        "inline static const uint32_t* unpack32_32_avx512(const uint32_t* in, uint32_t* out) {")
     print("  memcpy(out, in, 32 * sizeof(*out));")
     print("  in += 32;")
     print("  out += 32;")

--- a/cpp/src/arrow/util/bpacking_avx512_codegen.py
+++ b/cpp/src/arrow/util/bpacking_avx512_codegen.py
@@ -41,7 +41,7 @@ def print_unpack_bit_func(bit):
             inls.append(f"in[{in_index}]")
             in_index += 1
             shift = 0
-        elif shift + bit > 32:  # croos the boundary
+        elif shift + bit > 32:  # cross the boundary
             inls.append(
                 f"in[{in_index}] >> {shift} | in[{in_index + 1}] << {32 - shift}")
             in_index += 1

--- a/cpp/src/arrow/util/bpacking_avx512_generated.h
+++ b/cpp/src/arrow/util/bpacking_avx512_generated.h
@@ -31,14 +31,14 @@
 namespace arrow {
 namespace internal {
 
-inline const uint32_t* unpack0_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack0_32_avx512(const uint32_t* in, uint32_t* out) {
   memset(out, 0x0, 32 * sizeof(*out));
   out += 32;
 
   return in;
 }
 
-inline const uint32_t* unpack1_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack1_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -84,7 +84,7 @@ inline const uint32_t* unpack1_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack2_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack2_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -130,7 +130,7 @@ inline const uint32_t* unpack2_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack3_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack3_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -176,7 +176,7 @@ inline const uint32_t* unpack3_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack4_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack4_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xf;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -222,7 +222,7 @@ inline const uint32_t* unpack4_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack5_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack5_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1f;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -268,7 +268,7 @@ inline const uint32_t* unpack5_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack6_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack6_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3f;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -314,7 +314,7 @@ inline const uint32_t* unpack6_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack7_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack7_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7f;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -360,7 +360,7 @@ inline const uint32_t* unpack7_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack8_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack8_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -406,7 +406,7 @@ inline const uint32_t* unpack8_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack9_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack9_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1ff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -452,7 +452,7 @@ inline const uint32_t* unpack9_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack10_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack10_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3ff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -498,7 +498,7 @@ inline const uint32_t* unpack10_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack11_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack11_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7ff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -544,7 +544,7 @@ inline const uint32_t* unpack11_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack12_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack12_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xfff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -590,7 +590,7 @@ inline const uint32_t* unpack12_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack13_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack13_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1fff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -636,7 +636,7 @@ inline const uint32_t* unpack13_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack14_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack14_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3fff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -682,7 +682,7 @@ inline const uint32_t* unpack14_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack15_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack15_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7fff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -728,7 +728,7 @@ inline const uint32_t* unpack15_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack16_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack16_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -774,7 +774,7 @@ inline const uint32_t* unpack16_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack17_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack17_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1ffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -820,7 +820,7 @@ inline const uint32_t* unpack17_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack18_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack18_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3ffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -866,7 +866,7 @@ inline const uint32_t* unpack18_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack19_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack19_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7ffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -912,7 +912,7 @@ inline const uint32_t* unpack19_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack20_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack20_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xfffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -958,7 +958,7 @@ inline const uint32_t* unpack20_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack21_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack21_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1fffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1004,7 +1004,7 @@ inline const uint32_t* unpack21_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack22_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack22_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3fffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1050,7 +1050,7 @@ inline const uint32_t* unpack22_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack23_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack23_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7fffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1096,7 +1096,7 @@ inline const uint32_t* unpack23_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack24_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack24_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1142,7 +1142,7 @@ inline const uint32_t* unpack24_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack25_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack25_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1ffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1188,7 +1188,7 @@ inline const uint32_t* unpack25_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack26_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack26_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3ffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1234,7 +1234,7 @@ inline const uint32_t* unpack26_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack27_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack27_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7ffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1280,7 +1280,7 @@ inline const uint32_t* unpack27_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack28_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack28_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xfffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1326,7 +1326,7 @@ inline const uint32_t* unpack28_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack29_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack29_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1fffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1372,7 +1372,7 @@ inline const uint32_t* unpack29_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack30_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack30_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3fffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1418,7 +1418,7 @@ inline const uint32_t* unpack30_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack31_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack31_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7fffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
   __m512i results;
@@ -1464,7 +1464,7 @@ inline const uint32_t* unpack31_32_avx512(const uint32_t* in, uint32_t* out) {
   return in;
 }
 
-inline const uint32_t* unpack32_32_avx512(const uint32_t* in, uint32_t* out) {
+inline static const uint32_t* unpack32_32_avx512(const uint32_t* in, uint32_t* out) {
   memcpy(out, in, 32 * sizeof(*out));
   in += 32;
   out += 32;

--- a/cpp/src/arrow/util/bpacking_avx512_generated.h
+++ b/cpp/src/arrow/util/bpacking_avx512_generated.h
@@ -19,22 +19,29 @@
 
 #pragma once
 
+#include <stdint.h>
+#include <string.h>
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#else
 #include <immintrin.h>
+#endif
 
 namespace arrow {
 namespace internal {
 
-inline const uint32_t* nullunpacker32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack0_32_avx512(const uint32_t* in, uint32_t* out) {
   memset(out, 0x0, 32 * sizeof(*out));
   out += 32;
 
   return in;
 }
 
-inline const uint32_t* unpack1_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack1_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -51,7 +58,9 @@ inline const uint32_t* unpack1_32(const uint32_t* in, uint32_t* out) {
                               in[0], in[0],
                               in[0], in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(31, 30, 29, 28,
@@ -66,19 +75,19 @@ inline const uint32_t* unpack1_32(const uint32_t* in, uint32_t* out) {
                               in[0], in[0],
                               in[0], in[0],
                               in[0], in[0]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 1;
 
   return in;
 }
 
-inline const uint32_t* unpack2_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack2_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -95,7 +104,9 @@ inline const uint32_t* unpack2_32(const uint32_t* in, uint32_t* out) {
                               in[0], in[0],
                               in[0], in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(30, 28, 26, 24,
@@ -110,19 +121,19 @@ inline const uint32_t* unpack2_32(const uint32_t* in, uint32_t* out) {
                               in[1], in[1],
                               in[1], in[1],
                               in[1], in[1]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 2;
 
   return in;
 }
 
-inline const uint32_t* unpack3_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack3_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -139,7 +150,9 @@ inline const uint32_t* unpack3_32(const uint32_t* in, uint32_t* out) {
                               in[0], in[0],
                               in[0], in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(29, 26, 23, 20,
@@ -154,19 +167,19 @@ inline const uint32_t* unpack3_32(const uint32_t* in, uint32_t* out) {
                               in[1] >> 31 | in[2] << 1, in[1],
                               in[1], in[1],
                               in[1], in[1]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 3;
 
   return in;
 }
 
-inline const uint32_t* unpack4_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack4_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xf;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -183,7 +196,9 @@ inline const uint32_t* unpack4_32(const uint32_t* in, uint32_t* out) {
                               in[0], in[0],
                               in[0], in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(28, 24, 20, 16,
@@ -198,19 +213,19 @@ inline const uint32_t* unpack4_32(const uint32_t* in, uint32_t* out) {
                               in[2], in[2],
                               in[2], in[2],
                               in[2], in[2]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 4;
 
   return in;
 }
 
-inline const uint32_t* unpack5_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack5_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1f;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -227,7 +242,9 @@ inline const uint32_t* unpack5_32(const uint32_t* in, uint32_t* out) {
                               in[0], in[0],
                               in[0], in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(27, 22, 17, 12,
@@ -242,19 +259,19 @@ inline const uint32_t* unpack5_32(const uint32_t* in, uint32_t* out) {
                               in[3], in[3],
                               in[2] >> 31 | in[3] << 1, in[2],
                               in[2], in[2]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 5;
 
   return in;
 }
 
-inline const uint32_t* unpack6_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack6_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3f;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -271,7 +288,9 @@ inline const uint32_t* unpack6_32(const uint32_t* in, uint32_t* out) {
                               in[0] >> 30 | in[1] << 2, in[0],
                               in[0], in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(26, 20, 14, 8,
@@ -286,19 +305,19 @@ inline const uint32_t* unpack6_32(const uint32_t* in, uint32_t* out) {
                               in[3] >> 30 | in[4] << 2, in[3],
                               in[3], in[3],
                               in[3], in[3]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 6;
 
   return in;
 }
 
-inline const uint32_t* unpack7_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack7_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7f;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -315,7 +334,9 @@ inline const uint32_t* unpack7_32(const uint32_t* in, uint32_t* out) {
                               in[1], in[0] >> 28 | in[1] << 4,
                               in[0], in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(25, 18, 11, 4,
@@ -330,19 +351,19 @@ inline const uint32_t* unpack7_32(const uint32_t* in, uint32_t* out) {
                               in[4], in[4],
                               in[4], in[3] >> 30 | in[4] << 2,
                               in[3], in[3]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 7;
 
   return in;
 }
 
-inline const uint32_t* unpack8_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack8_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -359,7 +380,9 @@ inline const uint32_t* unpack8_32(const uint32_t* in, uint32_t* out) {
                               in[1], in[1],
                               in[0], in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(24, 16, 8, 0,
@@ -374,19 +397,19 @@ inline const uint32_t* unpack8_32(const uint32_t* in, uint32_t* out) {
                               in[5], in[5],
                               in[4], in[4],
                               in[4], in[4]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 8;
 
   return in;
 }
 
-inline const uint32_t* unpack9_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack9_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1ff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -403,7 +426,9 @@ inline const uint32_t* unpack9_32(const uint32_t* in, uint32_t* out) {
                               in[1], in[1],
                               in[0] >> 27 | in[1] << 5, in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(23, 14, 5, 0,
@@ -418,19 +443,19 @@ inline const uint32_t* unpack9_32(const uint32_t* in, uint32_t* out) {
                               in[5] >> 29 | in[6] << 3, in[5],
                               in[5], in[5],
                               in[4] >> 25 | in[5] << 7, in[4]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 9;
 
   return in;
 }
 
-inline const uint32_t* unpack10_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack10_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3ff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -447,7 +472,9 @@ inline const uint32_t* unpack10_32(const uint32_t* in, uint32_t* out) {
                               in[1], in[1],
                               in[0] >> 30 | in[1] << 2, in[0],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(22, 12, 2, 0,
@@ -462,19 +489,19 @@ inline const uint32_t* unpack10_32(const uint32_t* in, uint32_t* out) {
                               in[6], in[6],
                               in[5] >> 30 | in[6] << 2, in[5],
                               in[5], in[5]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 10;
 
   return in;
 }
 
-inline const uint32_t* unpack11_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack11_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7ff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -491,7 +518,9 @@ inline const uint32_t* unpack11_32(const uint32_t* in, uint32_t* out) {
                               in[1] >> 23 | in[2] << 9, in[1],
                               in[1], in[0] >> 22 | in[1] << 10,
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(21, 10, 0, 20,
@@ -506,19 +535,19 @@ inline const uint32_t* unpack11_32(const uint32_t* in, uint32_t* out) {
                               in[7], in[6] >> 28 | in[7] << 4,
                               in[6], in[6],
                               in[5] >> 27 | in[6] << 5, in[5]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 11;
 
   return in;
 }
 
-inline const uint32_t* unpack12_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack12_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xfff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -535,7 +564,9 @@ inline const uint32_t* unpack12_32(const uint32_t* in, uint32_t* out) {
                               in[1] >> 28 | in[2] << 4, in[1],
                               in[1], in[0] >> 24 | in[1] << 8,
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(20, 8, 0, 16,
@@ -550,19 +581,19 @@ inline const uint32_t* unpack12_32(const uint32_t* in, uint32_t* out) {
                               in[7] >> 28 | in[8] << 4, in[7],
                               in[7], in[6] >> 24 | in[7] << 8,
                               in[6], in[6]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 12;
 
   return in;
 }
 
-inline const uint32_t* unpack13_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack13_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1fff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -579,7 +610,9 @@ inline const uint32_t* unpack13_32(const uint32_t* in, uint32_t* out) {
                               in[2], in[1] >> 20 | in[2] << 12,
                               in[1], in[0] >> 26 | in[1] << 6,
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(19, 6, 0, 12,
@@ -594,19 +627,19 @@ inline const uint32_t* unpack13_32(const uint32_t* in, uint32_t* out) {
                               in[8], in[8],
                               in[7] >> 23 | in[8] << 9, in[7],
                               in[6] >> 29 | in[7] << 3, in[6]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 13;
 
   return in;
 }
 
-inline const uint32_t* unpack14_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack14_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3fff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -623,7 +656,9 @@ inline const uint32_t* unpack14_32(const uint32_t* in, uint32_t* out) {
                               in[2], in[1] >> 24 | in[2] << 8,
                               in[1], in[0] >> 28 | in[1] << 4,
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(18, 4, 0, 8,
@@ -638,19 +673,19 @@ inline const uint32_t* unpack14_32(const uint32_t* in, uint32_t* out) {
                               in[9], in[8] >> 24 | in[9] << 8,
                               in[8], in[7] >> 28 | in[8] << 4,
                               in[7], in[7]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 14;
 
   return in;
 }
 
-inline const uint32_t* unpack15_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack15_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7fff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -667,7 +702,9 @@ inline const uint32_t* unpack15_32(const uint32_t* in, uint32_t* out) {
                               in[2], in[1] >> 28 | in[2] << 4,
                               in[1], in[0] >> 30 | in[1] << 2,
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(17, 2, 0, 4,
@@ -682,19 +719,19 @@ inline const uint32_t* unpack15_32(const uint32_t* in, uint32_t* out) {
                               in[9] >> 27 | in[10] << 5, in[9],
                               in[8] >> 29 | in[9] << 3, in[8],
                               in[7] >> 31 | in[8] << 1, in[7]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 15;
 
   return in;
 }
 
-inline const uint32_t* unpack16_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack16_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -711,7 +748,9 @@ inline const uint32_t* unpack16_32(const uint32_t* in, uint32_t* out) {
                               in[2], in[2],
                               in[1], in[1],
                               in[0], in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(16, 0, 16, 0,
@@ -726,19 +765,19 @@ inline const uint32_t* unpack16_32(const uint32_t* in, uint32_t* out) {
                               in[10], in[10],
                               in[9], in[9],
                               in[8], in[8]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 16;
 
   return in;
 }
 
-inline const uint32_t* unpack17_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack17_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1ffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -755,7 +794,9 @@ inline const uint32_t* unpack17_32(const uint32_t* in, uint32_t* out) {
                               in[2] >> 21 | in[3] << 11, in[2],
                               in[1] >> 19 | in[2] << 13, in[1],
                               in[0] >> 17 | in[1] << 15, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(15, 0, 13, 0,
@@ -770,19 +811,19 @@ inline const uint32_t* unpack17_32(const uint32_t* in, uint32_t* out) {
                               in[11], in[10] >> 20 | in[11] << 12,
                               in[10], in[9] >> 18 | in[10] << 14,
                               in[9], in[8] >> 16 | in[9] << 16);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 17;
 
   return in;
 }
 
-inline const uint32_t* unpack18_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack18_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3ffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -799,7 +840,9 @@ inline const uint32_t* unpack18_32(const uint32_t* in, uint32_t* out) {
                               in[2] >> 26 | in[3] << 6, in[2],
                               in[1] >> 22 | in[2] << 10, in[1],
                               in[0] >> 18 | in[1] << 14, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(14, 0, 10, 0,
@@ -814,19 +857,19 @@ inline const uint32_t* unpack18_32(const uint32_t* in, uint32_t* out) {
                               in[11] >> 26 | in[12] << 6, in[11],
                               in[10] >> 22 | in[11] << 10, in[10],
                               in[9] >> 18 | in[10] << 14, in[9]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 18;
 
   return in;
 }
 
-inline const uint32_t* unpack19_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack19_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7ffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -843,7 +886,9 @@ inline const uint32_t* unpack19_32(const uint32_t* in, uint32_t* out) {
                               in[2] >> 31 | in[3] << 1, in[2],
                               in[1] >> 25 | in[2] << 7, in[1],
                               in[0] >> 19 | in[1] << 13, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(13, 0, 7, 0,
@@ -858,19 +903,19 @@ inline const uint32_t* unpack19_32(const uint32_t* in, uint32_t* out) {
                               in[12] >> 15 | in[13] << 17, in[11] >> 28 | in[12] << 4,
                               in[11], in[10] >> 22 | in[11] << 10,
                               in[10], in[9] >> 16 | in[10] << 16);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 19;
 
   return in;
 }
 
-inline const uint32_t* unpack20_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack20_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xfffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -887,7 +932,9 @@ inline const uint32_t* unpack20_32(const uint32_t* in, uint32_t* out) {
                               in[3], in[2] >> 16 | in[3] << 16,
                               in[1] >> 28 | in[2] << 4, in[1],
                               in[0] >> 20 | in[1] << 12, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(12, 0, 4, 0,
@@ -902,19 +949,19 @@ inline const uint32_t* unpack20_32(const uint32_t* in, uint32_t* out) {
                               in[13], in[12] >> 16 | in[13] << 16,
                               in[11] >> 28 | in[12] << 4, in[11],
                               in[10] >> 20 | in[11] << 12, in[10]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 20;
 
   return in;
 }
 
-inline const uint32_t* unpack21_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack21_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1fffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -931,7 +978,9 @@ inline const uint32_t* unpack21_32(const uint32_t* in, uint32_t* out) {
                               in[3], in[2] >> 20 | in[3] << 12,
                               in[1] >> 31 | in[2] << 1, in[1],
                               in[0] >> 21 | in[1] << 11, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(11, 0, 1, 0,
@@ -946,19 +995,19 @@ inline const uint32_t* unpack21_32(const uint32_t* in, uint32_t* out) {
                               in[13] >> 25 | in[14] << 7, in[13],
                               in[12] >> 15 | in[13] << 17, in[11] >> 26 | in[12] << 6,
                               in[11], in[10] >> 16 | in[11] << 16);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 21;
 
   return in;
 }
 
-inline const uint32_t* unpack22_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack22_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3fffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -975,7 +1024,9 @@ inline const uint32_t* unpack22_32(const uint32_t* in, uint32_t* out) {
                               in[3] >> 14 | in[4] << 18, in[2] >> 24 | in[3] << 8,
                               in[2], in[1] >> 12 | in[2] << 20,
                               in[0] >> 22 | in[1] << 10, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(10, 0, 0, 8,
@@ -990,19 +1041,19 @@ inline const uint32_t* unpack22_32(const uint32_t* in, uint32_t* out) {
                               in[14] >> 14 | in[15] << 18, in[13] >> 24 | in[14] << 8,
                               in[13], in[12] >> 12 | in[13] << 20,
                               in[11] >> 22 | in[12] << 10, in[11]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 22;
 
   return in;
 }
 
-inline const uint32_t* unpack23_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack23_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7fffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -1019,7 +1070,9 @@ inline const uint32_t* unpack23_32(const uint32_t* in, uint32_t* out) {
                               in[3] >> 19 | in[4] << 13, in[2] >> 28 | in[3] << 4,
                               in[2], in[1] >> 14 | in[2] << 18,
                               in[0] >> 23 | in[1] << 9, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(9, 0, 0, 4,
@@ -1034,19 +1087,19 @@ inline const uint32_t* unpack23_32(const uint32_t* in, uint32_t* out) {
                               in[15], in[14] >> 12 | in[15] << 20,
                               in[13] >> 21 | in[14] << 11, in[12] >> 30 | in[13] << 2,
                               in[12], in[11] >> 16 | in[12] << 16);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 23;
 
   return in;
 }
 
-inline const uint32_t* unpack24_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack24_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -1063,7 +1116,9 @@ inline const uint32_t* unpack24_32(const uint32_t* in, uint32_t* out) {
                               in[3] >> 24 | in[4] << 8, in[3],
                               in[2], in[1] >> 16 | in[2] << 16,
                               in[0] >> 24 | in[1] << 8, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(8, 0, 0, 0,
@@ -1078,19 +1133,19 @@ inline const uint32_t* unpack24_32(const uint32_t* in, uint32_t* out) {
                               in[15] >> 24 | in[16] << 8, in[15],
                               in[14], in[13] >> 16 | in[14] << 16,
                               in[12] >> 24 | in[13] << 8, in[12]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 24;
 
   return in;
 }
 
-inline const uint32_t* unpack25_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack25_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1ffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -1107,7 +1162,9 @@ inline const uint32_t* unpack25_32(const uint32_t* in, uint32_t* out) {
                               in[3] >> 29 | in[4] << 3, in[3],
                               in[2] >> 11 | in[3] << 21, in[1] >> 18 | in[2] << 14,
                               in[0] >> 25 | in[1] << 7, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(7, 0, 0, 0,
@@ -1122,19 +1179,19 @@ inline const uint32_t* unpack25_32(const uint32_t* in, uint32_t* out) {
                               in[16] >> 13 | in[17] << 19, in[15] >> 20 | in[16] << 12,
                               in[14] >> 27 | in[15] << 5, in[14],
                               in[13] >> 9 | in[14] << 23, in[12] >> 16 | in[13] << 16);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 25;
 
   return in;
 }
 
-inline const uint32_t* unpack26_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack26_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3ffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -1151,7 +1208,9 @@ inline const uint32_t* unpack26_32(const uint32_t* in, uint32_t* out) {
                               in[4], in[3] >> 8 | in[4] << 24,
                               in[2] >> 14 | in[3] << 18, in[1] >> 20 | in[2] << 12,
                               in[0] >> 26 | in[1] << 6, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(6, 0, 0, 0,
@@ -1166,19 +1225,19 @@ inline const uint32_t* unpack26_32(const uint32_t* in, uint32_t* out) {
                               in[17], in[16] >> 8 | in[17] << 24,
                               in[15] >> 14 | in[16] << 18, in[14] >> 20 | in[15] << 12,
                               in[13] >> 26 | in[14] << 6, in[13]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 26;
 
   return in;
 }
 
-inline const uint32_t* unpack27_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack27_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7ffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -1195,7 +1254,9 @@ inline const uint32_t* unpack27_32(const uint32_t* in, uint32_t* out) {
                               in[4] >> 7 | in[5] << 25, in[3] >> 12 | in[4] << 20,
                               in[2] >> 17 | in[3] << 15, in[1] >> 22 | in[2] << 10,
                               in[0] >> 27 | in[1] << 5, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(5, 0, 0, 0,
@@ -1210,19 +1271,19 @@ inline const uint32_t* unpack27_32(const uint32_t* in, uint32_t* out) {
                               in[17] >> 23 | in[18] << 9, in[16] >> 28 | in[17] << 4,
                               in[16], in[15] >> 6 | in[16] << 26,
                               in[14] >> 11 | in[15] << 21, in[13] >> 16 | in[14] << 16);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 27;
 
   return in;
 }
 
-inline const uint32_t* unpack28_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack28_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0xfffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -1239,7 +1300,9 @@ inline const uint32_t* unpack28_32(const uint32_t* in, uint32_t* out) {
                               in[4] >> 12 | in[5] << 20, in[3] >> 16 | in[4] << 16,
                               in[2] >> 20 | in[3] << 12, in[1] >> 24 | in[2] << 8,
                               in[0] >> 28 | in[1] << 4, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(4, 0, 0, 0,
@@ -1254,19 +1317,19 @@ inline const uint32_t* unpack28_32(const uint32_t* in, uint32_t* out) {
                               in[18] >> 12 | in[19] << 20, in[17] >> 16 | in[18] << 16,
                               in[16] >> 20 | in[17] << 12, in[15] >> 24 | in[16] << 8,
                               in[14] >> 28 | in[15] << 4, in[14]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 28;
 
   return in;
 }
 
-inline const uint32_t* unpack29_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack29_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x1fffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -1283,7 +1346,9 @@ inline const uint32_t* unpack29_32(const uint32_t* in, uint32_t* out) {
                               in[4] >> 17 | in[5] << 15, in[3] >> 20 | in[4] << 12,
                               in[2] >> 23 | in[3] << 9, in[1] >> 26 | in[2] << 6,
                               in[0] >> 29 | in[1] << 3, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(3, 0, 0, 0,
@@ -1298,19 +1363,19 @@ inline const uint32_t* unpack29_32(const uint32_t* in, uint32_t* out) {
                               in[19], in[18] >> 4 | in[19] << 28,
                               in[17] >> 7 | in[18] << 25, in[16] >> 10 | in[17] << 22,
                               in[15] >> 13 | in[16] << 19, in[14] >> 16 | in[15] << 16);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 29;
 
   return in;
 }
 
-inline const uint32_t* unpack30_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack30_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x3fffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -1327,7 +1392,9 @@ inline const uint32_t* unpack30_32(const uint32_t* in, uint32_t* out) {
                               in[4] >> 22 | in[5] << 10, in[3] >> 24 | in[4] << 8,
                               in[2] >> 26 | in[3] << 6, in[1] >> 28 | in[2] << 4,
                               in[0] >> 30 | in[1] << 2, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(2, 0, 0, 0,
@@ -1342,19 +1409,19 @@ inline const uint32_t* unpack30_32(const uint32_t* in, uint32_t* out) {
                               in[19] >> 22 | in[20] << 10, in[18] >> 24 | in[19] << 8,
                               in[17] >> 26 | in[18] << 6, in[16] >> 28 | in[17] << 4,
                               in[15] >> 30 | in[16] << 2, in[15]);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 30;
 
   return in;
 }
 
-inline const uint32_t* unpack31_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack31_32_avx512(const uint32_t* in, uint32_t* out) {
   uint32_t mask = 0x7fffffff;
   __m512i reg_shifts, reg_inls, reg_masks;
-  __m512i results[2];
+  __m512i results;
 
   reg_masks = _mm512_set1_epi32(mask);
 
@@ -1371,7 +1438,9 @@ inline const uint32_t* unpack31_32(const uint32_t* in, uint32_t* out) {
                               in[4] >> 27 | in[5] << 5, in[3] >> 28 | in[4] << 4,
                               in[2] >> 29 | in[3] << 3, in[1] >> 30 | in[2] << 2,
                               in[0] >> 31 | in[1] << 1, in[0]);
-  results[0] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
   // shift the second 16 outs
   reg_shifts = _mm512_set_epi32(1, 0, 0, 0,
@@ -1386,16 +1455,16 @@ inline const uint32_t* unpack31_32(const uint32_t* in, uint32_t* out) {
                               in[20] >> 11 | in[21] << 21, in[19] >> 12 | in[20] << 20,
                               in[18] >> 13 | in[19] << 19, in[17] >> 14 | in[18] << 18,
                               in[16] >> 15 | in[17] << 17, in[15] >> 16 | in[16] << 16);
-  results[1] = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  results = _mm512_and_epi32(_mm512_srlv_epi32(reg_inls, reg_shifts), reg_masks);
+  _mm512_storeu_si512(out, results);
+  out += 16;
 
-  memcpy(out, &results, 32 * sizeof(*out));
-  out += 32;
   in += 31;
 
   return in;
 }
 
-inline const uint32_t* unpack32_32(const uint32_t* in, uint32_t* out) {
+inline const uint32_t* unpack32_32_avx512(const uint32_t* in, uint32_t* out) {
   memcpy(out, in, 32 * sizeof(*out));
   in += 32;
   out += 32;

--- a/cpp/src/arrow/util/bpacking_default.h
+++ b/cpp/src/arrow/util/bpacking_default.h
@@ -26,6 +26,9 @@
 
 #pragma once
 
+#include "arrow/util/bit_util.h"
+#include "arrow/util/ubsan.h"
+
 namespace arrow {
 namespace internal {
 

--- a/cpp/src/arrow/util/dispatch.h
+++ b/cpp/src/arrow/util/dispatch.h
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "arrow/util/cpu_info.h"
+
+namespace arrow {
+namespace internal {
+
+struct DispatchLevel {
+  enum type { NONE = 0, SSE4_2, AVX2, AVX512, NEON, MAX };
+};
+
+template <typename FunctionType>
+class DynamicDispatch {
+  using FunctionIntance = std::pair<DispatchLevel::type, FunctionType>;
+
+ public:
+  // Provide all SIMD instances implemented
+  virtual std::vector<FunctionIntance> Implementations() = 0;
+
+  // Reslove the highest SIMD function of host CPU
+  void Reslove() {
+    FunctionIntance cur = {DispatchLevel::NONE, NULL};
+    auto instances = Implementations();
+
+    for (const auto& i : instances) {
+      if (i.first >= cur.first && IsSupported(i.first)) {
+        // Higher(or same) level than current
+        cur = i;
+      }
+    }
+
+    func = cur.second;
+  }
+
+  FunctionType func;
+
+ private:
+  bool IsSupported(DispatchLevel::type level) {
+    auto cpu_info = arrow::internal::CpuInfo::GetInstance();
+
+    switch (level) {
+      case DispatchLevel::NONE:
+        return true;
+      case DispatchLevel::SSE4_2:
+        return cpu_info->IsSupported(CpuInfo::SSE4_2);
+      case DispatchLevel::AVX2:
+        return cpu_info->IsSupported(CpuInfo::AVX2);
+      case DispatchLevel::AVX512:
+        return cpu_info->IsSupported(CpuInfo::AVX512);
+      default:
+        return false;
+    }
+  }
+};
+
+}  // namespace internal
+}  // namespace arrow


### PR DESCRIPTION
1. Add AVX2 version for unpack32.
2. Add dynamic dispatch facility.
3. Pick the SIMD path at runtime by the CPU feature.

Signed-off-by: Frank Du <frank.du@intel.com>