### PR TITLE
ARROW-9709: [Java] Test cases in arrow-vector takes care of endianness

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/ipc/message/MessageSerializer.java
@@ -75,7 +75,7 @@ public class MessageSerializer {
   }
 
   /**
-   * Convert an integer to a 4 byte array.
+   * Convert an integer to a little endian 4 byte array.
    *
    * @param value integer value input
    * @param bytes existing byte array with minimum length of 4 to contain the conversion output
@@ -88,7 +88,7 @@ public class MessageSerializer {
   }
 
   /**
-   * Convert a long to a 8 byte array.
+   * Convert a long to a little-endian 8 byte array.
    *
    * @param value long value input
    * @param bytes existing byte array with minimum length of 8 to contain the conversion output

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/MessageSerializerTest.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/MessageSerializerTest.java
@@ -84,7 +84,7 @@ public class MessageSerializerTest {
     WriteChannel out = new WriteChannel(Channels.newChannel(outputStream));
 
     // This is not a valid Arrow Message, only to test writing and alignment
-    ByteBuffer buffer = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
+    ByteBuffer buffer = ByteBuffer.allocate(8).order(ByteOrder.nativeOrder());
     buffer.putInt(1);
     buffer.putInt(2);
     buffer.flip();
@@ -100,19 +100,25 @@ public class MessageSerializerTest {
 
     ByteArrayInputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
     ReadChannel in = new ReadChannel(Channels.newChannel(inputStream));
-    ByteBuffer result = ByteBuffer.allocate(32).order(ByteOrder.LITTLE_ENDIAN);
+    ByteBuffer result = ByteBuffer.allocate(32).order(ByteOrder.nativeOrder());
     in.readFully(result);
     result.rewind();
 
     // First message continuation, size, and 2 int values
     assertEquals(MessageSerializer.IPC_CONTINUATION_TOKEN, result.getInt());
+    // mesage length is represented in little endian
+    result.order(ByteOrder.LITTLE_ENDIAN);
     assertEquals(8, result.getInt());
+    result.order(ByteOrder.nativeOrder());
     assertEquals(1, result.getInt());
     assertEquals(2, result.getInt());
 
     // Second message continuation, size, 1 int value and 4 bytes padding
     assertEquals(MessageSerializer.IPC_CONTINUATION_TOKEN, result.getInt());
+    // mesage length is represented in little endian
+    result.order(ByteOrder.LITTLE_ENDIAN);
     assertEquals(8, result.getInt());
+    result.order(ByteOrder.nativeOrder());
     assertEquals(3, result.getInt());
     assertEquals(0, result.getInt());
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -716,7 +716,7 @@ public class TestArrowReaderWriter {
 
   @Test
   public void testChannelReadFully() throws IOException {
-    final ByteBuffer buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+    final ByteBuffer buf = ByteBuffer.allocate(4).order(ByteOrder.nativeOrder());
     buf.putInt(200);
     buf.rewind();
 
@@ -737,7 +737,7 @@ public class TestArrowReaderWriter {
 
   @Test
   public void testChannelReadFullyEos() throws IOException {
-    final ByteBuffer buf = ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN);
+    final ByteBuffer buf = ByteBuffer.allocate(4).order(ByteOrder.nativeOrder());
     buf.putInt(10);
     buf.rewind();
 


### PR DESCRIPTION
This PR aims to correctly take care of endianness in test cases in arrow-vector. In the current code, they assume only a little-endian platform.