### PR TITLE
ARROW-9710: [C++] Improve performance of Decimal128::ToString by 10x, and make the implementation reusable for Decimal256.

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -861,10 +861,10 @@ void AddBinaryLength(FunctionRegistry* registry) {
       applicator::ScalarUnaryNotNull<Int32Type, StringType, BinaryLength>::Exec;
   ArrayKernelExec exec_offset_64 =
       applicator::ScalarUnaryNotNull<Int64Type, LargeStringType, BinaryLength>::Exec;
-  for (const auto input_type : {binary(), utf8()}) {
+  for (const auto& input_type : {binary(), utf8()}) {
     DCHECK_OK(func->AddKernel({input_type}, int32(), exec_offset_32));
   }
-  for (const auto input_type : {large_binary(), large_utf8()}) {
+  for (const auto& input_type : {large_binary(), large_utf8()}) {
     DCHECK_OK(func->AddKernel({input_type}, int64(), exec_offset_64));
   }
   DCHECK_OK(registry->AddFunction(std::move(func)));

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -294,19 +294,25 @@ static void AdjustIntegerStringWithScale(int32_t scale, std::string* str) {
 
   /// Note that the -6 is taken from the Java BigDecimal documentation.
   if (scale < 0 || adjusted_exponent < -6) {
-    // Example 1:
-    // Precondition: *str = "123", is_negative_offset = 0, num_digits = 3, scale = -2,
-    // adjusted_exponent = 4 After inserting decimal point: *str = "1.23" After appending
-    // exponent: *str = "1.23E4" Example 2: Precondition: *str = "-123",
-    // is_negative_offset = 1, num_digits = 3, scale = 9, adjusted_exponent = -7 After
-    // inserting decimal point: *str = "-1.23" After appending exponent: *str = "-1.23E-7"
-    str->insert(str->begin() + 1 + is_negative_offset, '.');
-    str->push_back('E');
     // Use stringstream only for printing the exponent integer. It should be short
     // enough to avoid memory allocations.
     std::stringstream buf;
     buf << std::showpos << adjusted_exponent;
-    *str += buf.str();
+    std::string exponent_str = buf.str();
+    str->reserve(str->size() + 2 + exponent_str.size());
+    // Example 1:
+    // Precondition: *str = "123", is_negative_offset = 0, num_digits = 3, scale = -2,
+    //               adjusted_exponent = 4
+    // After inserting decimal point: *str = "1.23"
+    // After appending exponent: *str = "1.23E4"
+    // Example 2:
+    // Precondition: *str = "-123", is_negative_offset = 1, num_digits = 3, scale = 9,
+    //               adjusted_exponent = -7
+    // After inserting decimal point: *str = "-1.23"
+    // After appending exponent: *str = "-1.23E-7"
+    str->insert(str->begin() + 1 + is_negative_offset, '.');
+    str->push_back('E');
+    *str += exponent_str;
     return;
   }
 

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -198,7 +198,7 @@ double Decimal128::ToDouble(int32_t scale) const {
 template <size_t n>
 static void AppendLittleEndianArrayToString(const std::array<uint64_t, n>& array,
                                             std::string* result) {
-  static_assert(n > 0);
+  static_assert(n > 0, "Array size must be positive");
   size_t most_significant_elem_idx = n - 1;
   while (array[most_significant_elem_idx] == 0) {
     if (most_significant_elem_idx == 0) {

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -45,10 +45,6 @@ Decimal128::Decimal128(const std::string& str) : Decimal128() {
   *this = Decimal128::FromString(str).ValueOrDie();
 }
 
-static const Decimal128 kTenTo36(static_cast<int64_t>(0xC097CE7BC90715),
-                                 0xB34B9F1000000000);
-static const Decimal128 kTenTo18(0xDE0B6B3A7640000);
-
 static constexpr auto kInt64DecimalDigits =
     static_cast<size_t>(std::numeric_limits<int64_t>::digits10);
 

--- a/cpp/src/arrow/util/decimal_benchmark.cc
+++ b/cpp/src/arrow/util/decimal_benchmark.cc
@@ -26,19 +26,51 @@
 namespace arrow {
 namespace Decimal {
 
-static void FromString(benchmark::State& state) {  // NOLINT non-const reference
-  std::vector<std::string> values = {"0",
-                                     "1.23",
-                                     "12.345e6",
-                                     "-12.345e-6",
-                                     "123456789.123456789",
-                                     "1231234567890.451234567890"};
+static const std::vector<std::string>& GetValuesAsString() {
+  static const std::vector<std::string>* values =
+      new std::vector<std::string>{"0",
+                                   "1.23",
+                                   "12.345e6",
+                                   "-12.345e-6",
+                                   "123456789.123456789",
+                                   "1231234567890.451234567890"};
+  return *values;
+}
 
+static std::vector<std::pair<Decimal128, int32_t>> BuildDecimalValuesAndScales() {
+  const std::vector<std::string>& value_strs = GetValuesAsString();
+  std::vector<std::pair<Decimal128, int32_t>> result(value_strs.size());
+  for (size_t i = 0; i < value_strs.size(); ++i) {
+    int32_t precision;
+    Decimal128::FromString(value_strs[i], &result[i].first, &result[i].second,
+                           &precision);
+  }
+  return result;
+}
+
+static const std::vector<std::pair<Decimal128, int32_t>>& GetDecimalValuesAndScales() {
+  static const auto* values =
+      new std::vector<std::pair<Decimal128, int32_t>>(BuildDecimalValuesAndScales());
+  return *values;
+}
+
+static void FromString(benchmark::State& state) {  // NOLINT non-const reference
+  const std::vector<std::string>& values = GetValuesAsString();
   for (auto _ : state) {
     for (const auto& value : values) {
       Decimal128 dec;
       int32_t scale, precision;
       benchmark::DoNotOptimize(Decimal128::FromString(value, &dec, &scale, &precision));
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * values.size());
+}
+
+static void ToString(benchmark::State& state) {  // NOLINT non-const reference
+  const auto& values = GetDecimalValuesAndScales();
+  for (auto _ : state) {
+    for (const auto& item : values) {
+      benchmark::DoNotOptimize(item.first.ToString(item.second));
     }
   }
   state.SetItemsProcessed(state.iterations() * values.size());
@@ -158,6 +190,7 @@ static void BinaryBitOp(benchmark::State& state) {  // NOLINT non-const referenc
 }
 
 BENCHMARK(FromString);
+BENCHMARK(ToString);
 BENCHMARK(BinaryMathOp);
 BENCHMARK(BinaryMathOpAggregate);
 BENCHMARK(BinaryCompareOp);

--- a/cpp/src/arrow/util/decimal_benchmark.cc
+++ b/cpp/src/arrow/util/decimal_benchmark.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "arrow/util/decimal.h"
+#include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {
@@ -46,8 +47,8 @@ static std::vector<DecimalValueAndScale> GetDecimalValuesAndScales() {
   std::vector<DecimalValueAndScale> result(value_strs.size());
   for (size_t i = 0; i < value_strs.size(); ++i) {
     int32_t precision;
-    Decimal128::FromString(value_strs[i], &result[i].decimal, &result[i].scale,
-                           &precision);
+    ARROW_CHECK_OK(Decimal128::FromString(value_strs[i], &result[i].decimal,
+                                          &result[i].scale, &precision));
   }
   return result;
 }

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -106,6 +106,33 @@ TEST(DecimalTest, TestFromDecimalString128) {
   ASSERT_NE(result.high_bits(), 0);
 }
 
+TEST(DecimalTest, TestStringRoundTrip) {
+  static constexpr uint64_t kTestBits[] = {
+      0,
+      1,
+      999,
+      1000,
+      std::numeric_limits<int32_t>::max(),
+      (1ull << 31),
+      std::numeric_limits<uint32_t>::max(),
+      (1ull << 32),
+      std::numeric_limits<int64_t>::max(),
+      (1ull << 63),
+      std::numeric_limits<uint64_t>::max(),
+  };
+  static constexpr int32_t kScales[] = {-10, -1, 0, 1, 10};
+  for (uint64_t high_bits : kTestBits) {
+    for (uint64_t low_bits : kTestBits) {
+      Decimal128 decimal(high_bits, low_bits);
+      for (int32_t scale : kScales) {
+        std::string str = decimal.ToString(scale);
+        ASSERT_OK_AND_ASSIGN(Decimal128 result, Decimal128::FromString(str));
+        EXPECT_EQ(decimal, result);
+      }
+    }
+  }
+}
+
 TEST(DecimalTest, TestDecimal32SignedRoundTrip) {
   Decimal128 expected("-3402692");
 

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -45,13 +45,6 @@ class DecimalTestFixture : public ::testing::Test {
   std::string string_value_;
 };
 
-TEST_F(DecimalTestFixture, TestToString) {
-  Decimal128 decimal(this->integer_value_);
-  int32_t scale = 5;
-  std::string result = decimal.ToString(scale);
-  ASSERT_EQ(result, this->string_value_);
-}
-
 TEST_F(DecimalTestFixture, TestFromString) {
   Decimal128 expected(this->integer_value_);
   Decimal128 result;
@@ -318,10 +311,10 @@ TEST(Decimal128Test, PrintMinValue) {
   ASSERT_EQ(string_value, printed_value);
 }
 
-class Decimal128PrintingTest
+class Decimal128ToStringTest
     : public ::testing::TestWithParam<std::tuple<int32_t, int32_t, std::string>> {};
 
-TEST_P(Decimal128PrintingTest, Print) {
+TEST_P(Decimal128ToStringTest, ToString) {
   int32_t test_value;
   int32_t scale;
   std::string expected_string;
@@ -331,15 +324,24 @@ TEST_P(Decimal128PrintingTest, Print) {
   ASSERT_EQ(expected_string, printed_value);
 }
 
-INSTANTIATE_TEST_SUITE_P(Decimal128PrintingTest, Decimal128PrintingTest,
-                         ::testing::Values(std::make_tuple(123, 1, "12.3"),
-                                           std::make_tuple(123, 5, "0.00123"),
-                                           std::make_tuple(123, 10, "1.23E-8"),
-                                           std::make_tuple(123, -1, "1.23E+3"),
-                                           std::make_tuple(-123, -1, "-1.23E+3"),
-                                           std::make_tuple(123, -3, "1.23E+5"),
-                                           std::make_tuple(-123, -3, "-1.23E+5"),
-                                           std::make_tuple(12345, -3, "1.2345E+7")));
+INSTANTIATE_TEST_SUITE_P(
+    Decimal128ToStringTest, Decimal128ToStringTest,
+    ::testing::Values(
+        std::make_tuple(0, -1, "0.E+1"), std::make_tuple(0, 0, "0"),
+        std::make_tuple(0, 1, "0.0"), std::make_tuple(0, 6, "0.000000"),
+        std::make_tuple(2, 7, "2.E-7"), std::make_tuple(2, -1, "2.E+1"),
+        std::make_tuple(2, 0, "2"), std::make_tuple(2, 1, "0.2"),
+        std::make_tuple(2, 6, "0.000002"), std::make_tuple(-2, 7, "-2.E-7"),
+        std::make_tuple(-2, 7, "-2.E-7"), std::make_tuple(-2, -1, "-2.E+1"),
+        std::make_tuple(-2, 0, "-2"), std::make_tuple(-2, 1, "-0.2"),
+        std::make_tuple(-2, 6, "-0.000002"), std::make_tuple(-2, 7, "-2.E-7"),
+        std::make_tuple(123, -3, "1.23E+5"), std::make_tuple(123, -1, "1.23E+3"),
+        std::make_tuple(123, 1, "12.3"), std::make_tuple(123, 5, "0.00123"),
+        std::make_tuple(123, 8, "0.00000123"), std::make_tuple(123, 9, "1.23E-7"),
+        std::make_tuple(123, 10, "1.23E-8"), std::make_tuple(-123, -3, "-1.23E+5"),
+        std::make_tuple(-123, -1, "-1.23E+3"), std::make_tuple(-123, 1, "-12.3"),
+        std::make_tuple(-123, 5, "-0.00123"), std::make_tuple(-123, 8, "-0.00000123"),
+        std::make_tuple(-123, 9, "-1.23E-7"), std::make_tuple(-123, 10, "-1.23E-8")));
 
 class Decimal128ParsingTest
     : public ::testing::TestWithParam<std::tuple<std::string, uint64_t, int32_t>> {};
@@ -732,15 +734,6 @@ TEST_F(TestDecimalToRealDouble, Precision) {
 }
 
 #endif  // __MINGW32__
-
-TEST(Decimal128Test, TestSmallNumberFormat) {
-  Decimal128 value("0.2");
-  std::string expected("0.2");
-
-  const int32_t scale = 1;
-  std::string result = value.ToString(scale);
-  ASSERT_EQ(expected, result);
-}
 
 TEST(Decimal128Test, TestNoDecimalPointExponential) {
   Decimal128 value;

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -116,6 +116,8 @@ TEST(DecimalTest, TestStringRoundTrip) {
   static constexpr int32_t kScales[] = {-10, -1, 0, 1, 10};
   for (uint64_t high_bits : kTestBits) {
     for (uint64_t low_bits : kTestBits) {
+      // When high_bits = 1ull << 63 or std::numeric_limits<uint64_t>::max(), decimal is
+      // negative.
       Decimal128 decimal(high_bits, low_bits);
       for (int32_t scale : kScales) {
         std::string str = decimal.ToString(scale);
@@ -311,37 +313,88 @@ TEST(Decimal128Test, PrintMinValue) {
   ASSERT_EQ(string_value, printed_value);
 }
 
-class Decimal128ToStringTest
-    : public ::testing::TestWithParam<std::tuple<int32_t, int32_t, std::string>> {};
-
-TEST_P(Decimal128ToStringTest, ToString) {
-  int32_t test_value;
+struct ToStringTestData {
+  int64_t test_value;
   int32_t scale;
   std::string expected_string;
-  std::tie(test_value, scale, expected_string) = GetParam();
-  const Decimal128 value(test_value);
-  const std::string printed_value = value.ToString(scale);
-  ASSERT_EQ(expected_string, printed_value);
+};
+
+static const ToStringTestData kToStringTestData[] = {
+    {0, -1, "0.E+1"},
+    {0, 0, "0"},
+    {0, 1, "0.0"},
+    {0, 6, "0.000000"},
+    {2, 7, "2.E-7"},
+    {2, -1, "2.E+1"},
+    {2, 0, "2"},
+    {2, 1, "0.2"},
+    {2, 6, "0.000002"},
+    {-2, 7, "-2.E-7"},
+    {-2, 7, "-2.E-7"},
+    {-2, -1, "-2.E+1"},
+    {-2, 0, "-2"},
+    {-2, 1, "-0.2"},
+    {-2, 6, "-0.000002"},
+    {-2, 7, "-2.E-7"},
+    {123, -3, "1.23E+5"},
+    {123, -1, "1.23E+3"},
+    {123, 1, "12.3"},
+    {123, 0, "123"},
+    {123, 5, "0.00123"},
+    {123, 8, "0.00000123"},
+    {123, 9, "1.23E-7"},
+    {123, 10, "1.23E-8"},
+    {-123, -3, "-1.23E+5"},
+    {-123, -1, "-1.23E+3"},
+    {-123, 1, "-12.3"},
+    {-123, 0, "-123"},
+    {-123, 5, "-0.00123"},
+    {-123, 8, "-0.00000123"},
+    {-123, 9, "-1.23E-7"},
+    {-123, 10, "-1.23E-8"},
+    {1000000000, -3, "1.000000000E+12"},
+    {1000000000, -1, "1.000000000E+10"},
+    {1000000000, 0, "1000000000"},
+    {1000000000, 1, "100000000.0"},
+    {1000000000, 5, "10000.00000"},
+    {1000000000, 15, "0.000001000000000"},
+    {1000000000, 16, "1.000000000E-7"},
+    {1000000000, 17, "1.000000000E-8"},
+    {-1000000000, -3, "-1.000000000E+12"},
+    {-1000000000, -1, "-1.000000000E+10"},
+    {-1000000000, 0, "-1000000000"},
+    {-1000000000, 1, "-100000000.0"},
+    {-1000000000, 5, "-10000.00000"},
+    {-1000000000, 15, "-0.000001000000000"},
+    {-1000000000, 16, "-1.000000000E-7"},
+    {-1000000000, 17, "-1.000000000E-8"},
+    {1234567890123456789LL, -3, "1.234567890123456789E+21"},
+    {1234567890123456789LL, -1, "1.234567890123456789E+19"},
+    {1234567890123456789LL, 0, "1234567890123456789"},
+    {1234567890123456789LL, 1, "123456789012345678.9"},
+    {1234567890123456789LL, 5, "12345678901234.56789"},
+    {1234567890123456789LL, 24, "0.000001234567890123456789"},
+    {1234567890123456789LL, 25, "1.234567890123456789E-7"},
+    {-1234567890123456789LL, -3, "-1.234567890123456789E+21"},
+    {-1234567890123456789LL, -1, "-1.234567890123456789E+19"},
+    {-1234567890123456789LL, 0, "-1234567890123456789"},
+    {-1234567890123456789LL, 1, "-123456789012345678.9"},
+    {-1234567890123456789LL, 5, "-12345678901234.56789"},
+    {-1234567890123456789LL, 24, "-0.000001234567890123456789"},
+    {-1234567890123456789LL, 25, "-1.234567890123456789E-7"},
+};
+
+class Decimal128ToStringTest : public ::testing::TestWithParam<ToStringTestData> {};
+
+TEST_P(Decimal128ToStringTest, ToString) {
+  const ToStringTestData& data = GetParam();
+  const Decimal128 value(data.test_value);
+  const std::string printed_value = value.ToString(data.scale);
+  ASSERT_EQ(data.expected_string, printed_value);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    Decimal128ToStringTest, Decimal128ToStringTest,
-    ::testing::Values(
-        std::make_tuple(0, -1, "0.E+1"), std::make_tuple(0, 0, "0"),
-        std::make_tuple(0, 1, "0.0"), std::make_tuple(0, 6, "0.000000"),
-        std::make_tuple(2, 7, "2.E-7"), std::make_tuple(2, -1, "2.E+1"),
-        std::make_tuple(2, 0, "2"), std::make_tuple(2, 1, "0.2"),
-        std::make_tuple(2, 6, "0.000002"), std::make_tuple(-2, 7, "-2.E-7"),
-        std::make_tuple(-2, 7, "-2.E-7"), std::make_tuple(-2, -1, "-2.E+1"),
-        std::make_tuple(-2, 0, "-2"), std::make_tuple(-2, 1, "-0.2"),
-        std::make_tuple(-2, 6, "-0.000002"), std::make_tuple(-2, 7, "-2.E-7"),
-        std::make_tuple(123, -3, "1.23E+5"), std::make_tuple(123, -1, "1.23E+3"),
-        std::make_tuple(123, 1, "12.3"), std::make_tuple(123, 5, "0.00123"),
-        std::make_tuple(123, 8, "0.00000123"), std::make_tuple(123, 9, "1.23E-7"),
-        std::make_tuple(123, 10, "1.23E-8"), std::make_tuple(-123, -3, "-1.23E+5"),
-        std::make_tuple(-123, -1, "-1.23E+3"), std::make_tuple(-123, 1, "-12.3"),
-        std::make_tuple(-123, 5, "-0.00123"), std::make_tuple(-123, 8, "-0.00000123"),
-        std::make_tuple(-123, 9, "-1.23E-7"), std::make_tuple(-123, 10, "-1.23E-8")));
+INSTANTIATE_TEST_SUITE_P(Decimal128ToStringTest, Decimal128ToStringTest,
+                         ::testing::ValuesIn(kToStringTestData));
 
 class Decimal128ParsingTest
     : public ::testing::TestWithParam<std::tuple<std::string, uint64_t, int32_t>> {};


### PR DESCRIPTION
Added a benchmark to decimal_benchmark.

```
Running release/arrow-decimal-benchmark
Run on (12 X 4500 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1024 KiB (x6)
  L3 Unified 8448 KiB (x1)
Load Average: 0.23, 0.22, 0.23
----------------------------------------------------------------------------------
Benchmark                        Time             CPU   Iterations UserCounters...
----------------------------------------------------------------------------------
ToString (before)             2205 ns         2205 ns       321603 items_per_second=2.72094M/s
ToString (after)               216 ns          216 ns      3235082 items_per_second=27.7865M/s
```
