### PR TITLE
ARROW-9729: [Java] Disable Error Prone when project is imported into …

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -748,6 +748,9 @@
       <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
       <activation>
         <jdk>1.8</jdk>
+        <property>
+           <name>!m2e.version</name>
+        </property>
       </activation>
       <build>
         <plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -370,16 +370,7 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.6.2</version>
           <configuration>
-            <compilerArgs>
-              <arg>-XDcompilePolicy=simple</arg>
-              <arg>-Xplugin:ErrorProne</arg>
-            </compilerArgs>
             <annotationProcessorPaths>
-              <path>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>2.4.0</version>
-              </path>
               <path>
                 <groupId>org.immutables</groupId>
                 <artifactId>value</artifactId>
@@ -717,9 +708,44 @@
       </properties>
     </profile>
 
-    <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
     <profile>
-      <id>jdk8</id>
+      <id>error-prone</id>
+      <!-- 
+           Do not activate Error Prone while running with Eclipse/M2E as it causes incompatibilities
+           with other annotation processors.
+           See https://github.com/jbosstools/m2e-apt/issues/62 for details
+      -->
+      <activation>
+        <property>
+           <name>!m2e.version</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <compilerArgs combine.children="append">
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xplugin:ErrorProne</arg>
+              </compilerArgs>
+              <annotationProcessorPaths combine.children="append">
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>2.4.0</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>error-prone-jdk8</id>
+      <!-- using github.com/google/error-prone-javac is required when running on JDK 8 -->
       <activation>
         <jdk>1.8</jdk>
       </activation>


### PR DESCRIPTION
…Eclipse

An incompatibility between Eclipse/m2e-apt plugin and Error Prone causes
other annotation processors to not work. It results in compilation
issues because some classes are not automatically generated.

Move Error Prone global configuration into a new profile which is
automatically enabled except when imported by Eclipse.