### PR TITLE
ARROW-9743: [R] Sanitize paths in open_dataset

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -23,6 +23,7 @@
 
 * Filtering a Dataset that has multiple partition keys using an `%in%` expression now faithfully returns all relevant rows
 * Datasets can now have path segments in the root directory that start with `.` or `_`; files and subdirectories starting with those prefixes are still ignored
+* `open_dataset("~/path")` now correctly expands the path
 * The `version` option to `write_parquet()` is now correctly implemented
 * An UBSAN failure in the `parquet-cpp` library has been fixed
 * For bundled Linux builds, the logic for finding `cmake` is more robust, and you can now specify a `/path/to/cmake` by setting the `CMAKE` environment variable

--- a/r/R/dataset.R
+++ b/r/R/dataset.R
@@ -307,6 +307,7 @@ DatasetFactory$create <- function(x,
       x <- fs_from_uri$path
     } else {
       filesystem <- LocalFileSystem$create()
+      x <- clean_path_abs(x)
     }
   }
   selector <- FileSelector$create(x, allow_not_found = FALSE, recursive = TRUE)


### PR DESCRIPTION
Fixes problem of path expansion (`open_dataset("~/path")` now works). Unfortunately, tests can only write to tmp, so I can't add a test that confirms this, but I did verify locally.