### PR TITLE
ARROW-9739: [CI][Ruby] Don't install gem documents

### DIFF
--- a/ci/docker/linux-apt-c-glib.dockerfile
+++ b/ci/docker/linux-apt-c-glib.dockerfile
@@ -54,7 +54,7 @@ RUN luarocks install lgi
 # ERROR: Command errored out with exit status 1: /usr/bin/python3 /usr/share/python-wheels/pep517-0.7.0-py2.py3-none-any.whl/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpsk4jveay Check the logs for full command output.
 RUN (python3 -m pip install meson || \
          python3 -m pip install --no-use-pep517 meson) && \
-    gem install bundler
+    gem install --no-document bundler
 
 COPY c_glib/Gemfile /arrow/c_glib/
 RUN bundle install --gemfile /arrow/c_glib/Gemfile

--- a/ci/docker/linux-apt-docs.dockerfile
+++ b/ci/docker/linux-apt-docs.dockerfile
@@ -77,7 +77,7 @@ RUN pip install \
         sphinx_rtd_theme
 
 COPY c_glib/Gemfile /arrow/c_glib/
-RUN gem install bundler && \
+RUN gem install --no-document bundler && \
     bundle install --gemfile /arrow/c_glib/Gemfile
 
 COPY ci/scripts/r_deps.sh /arrow/ci/scripts/

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -399,7 +399,7 @@ test_glib() {
   export GI_TYPELIB_PATH=$ARROW_HOME/lib/girepository-1.0:$GI_TYPELIB_PATH
 
   if ! bundle --version; then
-    gem install bundler
+    gem install --no-document bundler
   fi
 
   bundle install --path vendor/bundle


### PR DESCRIPTION
Don't install gem documents in Docker environment to reduce size and time in building and pulling.

 More detail can be found at
 https://guides.rubygems.org/command-reference/#installupdate-options-2

 Signed-off-by: Pratik raj <rajpratik71@gmail.com>