### PR TITLE
ARROW-9753: [Rust] [DataFusion] Remove use of Mutex from DataFusion Partition trait

### DIFF
--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -456,7 +456,7 @@ mod tests {
             let file =
                 File::open(format!("target/debug/testdata/{}.arrow_file", "arrow"))
                     .unwrap();
-            let mut reader = FileReader::try_new(file).unwrap();
+            let reader = FileReader::try_new(file).unwrap();
             while let Ok(Some(read_batch)) = reader.next_batch() {
                 read_batch
                     .columns()
@@ -503,7 +503,7 @@ mod tests {
 
         {
             let file = File::open("target/debug/testdata/nulls.arrow_file").unwrap();
-            let mut reader = FileReader::try_new(file).unwrap();
+            let reader = FileReader::try_new(file).unwrap();
             while let Ok(Some(read_batch)) = reader.next_batch() {
                 read_batch
                     .columns()
@@ -537,7 +537,7 @@ mod tests {
             ))
             .unwrap();
 
-            let mut reader = FileReader::try_new(file).unwrap();
+            let reader = FileReader::try_new(file).unwrap();
 
             // read and rewrite the file to a temp location
             {
@@ -580,7 +580,7 @@ mod tests {
             ))
             .unwrap();
 
-            let mut reader = StreamReader::try_new(file).unwrap();
+            let reader = StreamReader::try_new(file).unwrap();
 
             // read and rewrite the stream to a temp location
             {

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -225,7 +225,7 @@ pub trait RecordBatchReader {
     fn schema(&self) -> SchemaRef;
 
     /// Reads the next `RecordBatch`.
-    fn next_batch(&mut self) -> Result<Option<RecordBatch>>;
+    fn next_batch(&self) -> Result<Option<RecordBatch>>;
 }
 
 #[cfg(test)]

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -62,7 +62,6 @@ impl MemTable {
         let mut data: Vec<Vec<RecordBatch>> = Vec::with_capacity(partitions.len());
         for partition in &partitions {
             let it = partition.execute()?;
-            let mut it = it.lock().unwrap();
             let mut partition_batches = vec![];
             while let Ok(Some(batch)) = it.next_batch() {
                 partition_batches.push(batch);
@@ -149,7 +148,7 @@ mod tests {
         // scan with projection
         let partitions = provider.scan(&Some(vec![2, 1]), 1024).unwrap();
         let it = partitions[0].execute().unwrap();
-        let batch2 = it.lock().unwrap().next_batch().unwrap().unwrap();
+        let batch2 = it.next_batch().unwrap().unwrap();
         assert_eq!(2, batch2.schema().fields().len());
         assert_eq!("c", batch2.schema().field(0).name());
         assert_eq!("b", batch2.schema().field(1).name());
@@ -178,7 +177,7 @@ mod tests {
 
         let partitions = provider.scan(&None, 1024).unwrap();
         let it = partitions[0].execute().unwrap();
-        let batch1 = it.lock().unwrap().next_batch().unwrap().unwrap();
+        let batch1 = it.next_batch().unwrap().unwrap();
         assert_eq!(3, batch1.schema().fields().len());
         assert_eq!(3, batch1.num_columns());
     }

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -81,7 +81,6 @@ mod tests {
         let projection = None;
         let scan = table.scan(&projection, 2).unwrap();
         let it = scan[0].execute().unwrap();
-        let mut it = it.lock().unwrap();
 
         let mut count = 0;
         while let Some(batch) = it.next_batch().unwrap() {
@@ -123,7 +122,6 @@ mod tests {
         let projection = None;
         let scan = table.scan(&projection, 1024).unwrap();
         let it = scan[0].execute().unwrap();
-        let mut it = it.lock().unwrap();
         let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(11, batch.num_columns());
@@ -137,7 +135,6 @@ mod tests {
         let projection = Some(vec![1]);
         let scan = table.scan(&projection, 1024).unwrap();
         let it = scan[0].execute().unwrap();
-        let mut it = it.lock().unwrap();
         let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());
@@ -166,7 +163,6 @@ mod tests {
         let projection = Some(vec![0]);
         let scan = table.scan(&projection, 1024).unwrap();
         let it = scan[0].execute().unwrap();
-        let mut it = it.lock().unwrap();
         let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());
@@ -192,7 +188,6 @@ mod tests {
         let projection = Some(vec![10]);
         let scan = table.scan(&projection, 1024).unwrap();
         let it = scan[0].execute().unwrap();
-        let mut it = it.lock().unwrap();
         let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());
@@ -218,7 +213,6 @@ mod tests {
         let projection = Some(vec![6]);
         let scan = table.scan(&projection, 1024).unwrap();
         let it = scan[0].execute().unwrap();
-        let mut it = it.lock().unwrap();
         let batch = it.next_batch().unwrap().unwrap();
         assert_eq!(1, batch.num_columns());
         assert_eq!(8, batch.num_rows());
@@ -246,7 +240,6 @@ mod tests {
         let projection = Some(vec![7]);
         let scan = table.scan(&projection, 1024).unwrap();
         let it = scan[0].execute().unwrap();
-        let mut it = it.lock().unwrap();
         let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());
@@ -275,7 +268,6 @@ mod tests {
         let projection = Some(vec![9]);
         let scan = table.scan(&projection, 1024).unwrap();
         let it = scan[0].execute().unwrap();
-        let mut it = it.lock().unwrap();
         let batch = it.next_batch().unwrap().unwrap();
 
         assert_eq!(1, batch.num_columns());

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -655,7 +655,6 @@ impl ExecutionContext {
                     let file = fs::File::create(path)?;
                     let mut writer = csv::Writer::new(file);
                     let reader = p.execute()?;
-                    let mut reader = reader.lock().unwrap();
                     loop {
                         match reader.next_batch() {
                             Ok(Some(batch)) => {

--- a/rust/datafusion/src/execution/physical_plan/explain.rs
+++ b/rust/datafusion/src/execution/physical_plan/explain.rs
@@ -28,7 +28,7 @@ use arrow::{
     record_batch::{RecordBatch, RecordBatchReader},
 };
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /// Explain execution plan operator. This operator contains the string
 /// values of the various plans it has when it is created, and passes
@@ -74,7 +74,7 @@ struct ExplainPartition {
 }
 
 impl Partition for ExplainPartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
+    fn execute(&self) -> Result<Arc<dyn RecordBatchReader + Send + Sync>> {
         let mut type_builder = StringArray::builder(self.stringified_plans.len());
         let mut plan_builder = StringArray::builder(self.stringified_plans.len());
 
@@ -91,9 +91,9 @@ impl Partition for ExplainPartition {
             ],
         )?;
 
-        Ok(Arc::new(Mutex::new(RecordBatchIterator::new(
+        Ok(Arc::new(RecordBatchIterator::new(
             self.schema.clone(),
             vec![Arc::new(record_batch)],
-        ))))
+        )))
     }
 }

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -18,7 +18,7 @@
 //! Defines the merge plan for executing partitions in parallel and then merging the results
 //! into a single partition
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use crate::error::{ExecutionError, Result};
@@ -99,7 +99,7 @@ fn collect_from_thread(
 }
 
 impl Partition for MergePartition {
-    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
+    fn execute(&self) -> Result<Arc<dyn RecordBatchReader + Send + Sync>> {
         match self.partitions.len() {
             0 => Err(ExecutionError::General(
                 "MergeExec requires at least one input partition".to_owned(),
@@ -134,10 +134,10 @@ impl Partition for MergePartition {
                     collect_from_thread(thread, &mut combined_results)?;
                 }
 
-                Ok(Arc::new(Mutex::new(RecordBatchIterator::new(
+                Ok(Arc::new(RecordBatchIterator::new(
                     self.schema.clone(),
                     combined_results,
-                ))))
+                )))
             }
         }
     }

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -20,7 +20,7 @@
 use std::cell::RefCell;
 use std::fmt::{Debug, Display};
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::error::Result;
 use crate::logicalplan::ScalarValue;
@@ -39,7 +39,7 @@ pub trait ExecutionPlan: Debug {
 /// Represents a partition of an execution plan that can be executed on a thread
 pub trait Partition: Send + Sync + Debug {
     /// Execute this partition and return an iterator over RecordBatch
-    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>;
+    fn execute(&self) -> Result<Arc<dyn RecordBatchReader + Send + Sync>>;
 }
 
 /// Expression that can be evaluated against a RecordBatch

--- a/rust/datafusion/src/execution/physical_plan/sort.rs
+++ b/rust/datafusion/src/execution/physical_plan/sort.rs
@@ -17,7 +17,7 @@
 
 //! Defines the SORT plan
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use arrow::array::ArrayRef;
 pub use arrow::compute::SortOptions;
@@ -85,7 +85,7 @@ struct SortPartition {
 
 impl Partition for SortPartition {
     /// Execute the sort
-    fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
+    fn execute(&self) -> Result<Arc<dyn RecordBatchReader + Send + Sync>> {
         // sort needs to operate on a single partition currently
         let merge =
             MergeExec::new(self.schema.clone(), self.input.clone(), self.concurrency);
@@ -142,10 +142,10 @@ impl Partition for SortPartition {
                 .collect::<Result<Vec<ArrayRef>>>()?,
         )?;
 
-        Ok(Arc::new(Mutex::new(RecordBatchIterator::new(
+        Ok(Arc::new(RecordBatchIterator::new(
             self.schema.clone(),
             vec![Arc::new(sorted_batch)],
-        ))))
+        )))
     }
 }
 

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -33,7 +33,7 @@ fn main() -> Result<()> {
 
     let f = File::open(filename)?;
     let reader = BufReader::new(f);
-    let mut reader = FileReader::try_new(reader)?;
+    let reader = FileReader::try_new(reader)?;
     let schema = reader.schema();
 
     let mut writer = StreamWriter::try_new(io::stdout(), &schema)?;

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -423,7 +423,7 @@ fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()>
     }
 
     let arrow_file = File::open(arrow_name)?;
-    let mut reader = FileReader::try_new(arrow_file)?;
+    let reader = FileReader::try_new(arrow_file)?;
 
     let mut fields = vec![];
     for f in reader.schema().fields() {
@@ -458,7 +458,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
 
     // open Arrow file
     let arrow_file = File::open(arrow_name)?;
-    let mut arrow_reader = FileReader::try_new(arrow_file)?;
+    let arrow_reader = FileReader::try_new(arrow_file)?;
     let arrow_schema = arrow_reader.schema().as_ref().to_owned();
 
     // compare schemas

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     eprintln!("{:?}", args);
 
-    let mut arrow_stream_reader = StreamReader::try_new(io::stdin())?;
+    let arrow_stream_reader = StreamReader::try_new(io::stdin())?;
     let schema = arrow_stream_reader.schema();
 
     let mut writer = FileWriter::try_new(io::stdout(), &schema)?;


### PR DESCRIPTION
This PR modifies the DataFusion Partition trait, changing this method ...

```rust
fn execute(&self) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>;
```

to

```rust
fn execute(&self) -> Result<Arc<dyn RecordBatchReader + Send + Sync>>;
```

This is a cleaner API in my opinion and removes the overhead of a mutex lock per batch per operator, which is often redundant since many operators do not contain mutable state.

This does affect the core arrow and parquet crates as well, removing the `&mut self` requirement from `ArrayReader`, for example, in preference of using `Rc<RefCell<_>>` within the reader.

I ran the TPC-H query 1 benchmark (scale factor 100) before and after these changes and saw no noticeable difference in performance (20.6 seconds).

I think these changes are also a good step towards being able to adopt async as well.