### PR TITLE
ARROW-8493: [C++][Parquet] Start populating repeated ancestor defintion

### DIFF
--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -44,7 +44,6 @@ using parquet::schema::NodePtr;
 using parquet::schema::PrimitiveNode;
 
 using ::testing::ElementsAre;
-using ::testing::HasSubstr;
 
 namespace parquet {
 
@@ -1296,7 +1295,7 @@ TEST_F(TestLevels, TestRepeatedGroups) {
   EXPECT_THAT(levels,
               ElementsAre(Levels{/*def_level=*/1, /*rep_level=*/1,
                                  /*ancestor_list_def_level*/ 1},
-                          // Def_ldevl=2 is skipped because it represents a empty list.
+                          // Def_ldevl=2 is skipped because it represents a null list.
                           Levels{/*def_level=*/3, /*rep_level=*/2,
                                  /*ancestor_list_def_level*/ 1},  // list field
                           Levels{/*def_level=*/4, /*rep_level=*/2,
@@ -1309,7 +1308,7 @@ TEST_F(TestLevels, TestRepeatedGroups) {
   EXPECT_THAT(levels,
               ElementsAre(Levels{/*def_level=*/1, /*rep_level=*/1,
                                  /*ancestor_list_def_level*/ 1},
-                          // Def_ldevl=2 is skipped because it represents a empty list.
+                          // Def_ldevl=2 is skipped because it represents a null list.
                           Levels{/*def_level=*/3, /*rep_level=*/2,
                                  /*ancestor_list_def_level*/ 1},  // list field
                           Levels{/*def_level=*/4, /*rep_level=*/2,
@@ -1330,7 +1329,7 @@ TEST_F(TestLevels, TestRepeatedGroups) {
   EXPECT_THAT(levels,
               ElementsAre(Levels{/*def_level=*/1, /*rep_level=*/1,
                                  /*ancestor_list_def_level*/ 1},
-                          // Def_ldevl=2 is skipped because it represents a empty list.
+                          // Def_ldevl=2 is skipped because it represents a null list.
                           Levels{/*def_level=*/3, /*rep_level=*/2,
                                  /*ancestor_list_def_level*/ 1},  // list field
                           Levels{/*def_level=*/3, /*rep_level=*/2,
@@ -1344,7 +1343,7 @@ TEST_F(TestLevels, ListErrors) {
         {PrimitiveNode::Make("bool", Repetition::REPEATED, ParquetType::BOOLEAN)},
         ConvertedType::LIST));
     EXPECT_TRUE(error.IsInvalid());
-    EXPECT_THAT(error.message(), HasSubstr("must not be repeated"));
+    EXPECT_EQ(error.message(), "LIST-annotated groups must not be repeated.");
   }
   {
     ::arrow::Status error = MaybeSetParquetSchema(GroupNode::Make(
@@ -1353,7 +1352,7 @@ TEST_F(TestLevels, ListErrors) {
          PrimitiveNode::Make("f2", Repetition::REPEATED, ParquetType::BOOLEAN)},
         ConvertedType::LIST));
     EXPECT_TRUE(error.IsInvalid());
-    EXPECT_THAT(error.message(), HasSubstr("must have a single child"));
+    EXPECT_EQ(error.message(), "LIST-annotated groups must have a single child.");
   }
 
   {

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -1355,7 +1355,7 @@ TEST_F(TestLevels, ListErrors) {
     ::arrow::Status error = MaybeSetParquetSchema(GroupNode::Make(
         "child_list", Repetition::REPEATED,
         {PrimitiveNode::Make("bool", Repetition::REPEATED, ParquetType::BOOLEAN)},
-        ConvertedType::LIST));
+        LogicalType::List()));
     ASSERT_RAISES(Invalid, error);
     std::string expected("LIST-annotated groups must not be repeated.");
     EXPECT_EQ(error.message().substr(0, expected.size()), expected);
@@ -1365,7 +1365,7 @@ TEST_F(TestLevels, ListErrors) {
         "child_list", Repetition::OPTIONAL,
         {PrimitiveNode::Make("f1", Repetition::REPEATED, ParquetType::BOOLEAN),
          PrimitiveNode::Make("f2", Repetition::REPEATED, ParquetType::BOOLEAN)},
-        ConvertedType::LIST));
+        LogicalType::List()));
     ASSERT_RAISES(Invalid, error);
     std::string expected("LIST-annotated groups must have a single child.");
     EXPECT_EQ(error.message().substr(0, expected.size()), expected);
@@ -1375,7 +1375,7 @@ TEST_F(TestLevels, ListErrors) {
     ::arrow::Status error = MaybeSetParquetSchema(GroupNode::Make(
         "child_list", Repetition::OPTIONAL,
         {PrimitiveNode::Make("f1", Repetition::OPTIONAL, ParquetType::BOOLEAN)},
-        ConvertedType::LIST));
+        LogicalType::List()));
     ASSERT_RAISES(Invalid, error);
     std::string expected(
         "Non-repeated nodes in a LIST-annotated group are not supported.");

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -1343,7 +1343,8 @@ TEST_F(TestLevels, ListErrors) {
         {PrimitiveNode::Make("bool", Repetition::REPEATED, ParquetType::BOOLEAN)},
         ConvertedType::LIST));
     EXPECT_TRUE(error.IsInvalid());
-    EXPECT_EQ(error.message(), "LIST-annotated groups must not be repeated.");
+    std::string expected("LIST-annotated groups must not be repeated.");
+    EXPECT_EQ(error.message().substr(0, expected.size()), expected);
   }
   {
     ::arrow::Status error = MaybeSetParquetSchema(GroupNode::Make(
@@ -1352,7 +1353,8 @@ TEST_F(TestLevels, ListErrors) {
          PrimitiveNode::Make("f2", Repetition::REPEATED, ParquetType::BOOLEAN)},
         ConvertedType::LIST));
     EXPECT_TRUE(error.IsInvalid());
-    EXPECT_EQ(error.message(), "LIST-annotated groups must have a single child.");
+    std::string expected("LIST-annotated groups must have a single child.");
+    EXPECT_EQ(error.message().substr(0, expected.size()), expected);
   }
 
   {
@@ -1361,8 +1363,9 @@ TEST_F(TestLevels, ListErrors) {
         {PrimitiveNode::Make("f1", Repetition::OPTIONAL, ParquetType::BOOLEAN)},
         ConvertedType::LIST));
     EXPECT_TRUE(error.IsInvalid());
-    EXPECT_EQ(error.message(),
-              "Non-repeated nodes in a LIST-annotated group are not supported.");
+    std::string expected(
+        "Non-repeated nodes in a LIST-annotated group are not supported.");
+    EXPECT_EQ(error.message().substr(0, expected.size()), expected);
   }
 }
 

--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -1217,8 +1217,7 @@ TEST_F(TestLevels, TestPrimitive) {
               ElementsAre(Levels{/*def_level=*/1, /*rep_level=*/1,
                                  /*ancestor_list_def_level*/ 0},  // List Field
                           Levels{/*def_level=*/1, /*rep_level=*/1,
-                                 /*ancestor_list_def_level*/ 1}  //  primitive field
-                          ));
+                                 /*ancestor_list_def_level*/ 1}));  //  primitive field
 }
 
 TEST_F(TestLevels, TestSimpleGroups) {
@@ -1279,9 +1278,7 @@ TEST_F(TestLevels, TestRepeatedGroups) {
                           Levels{/*def_level=*/3, /*rep_level=*/2,
                                  /*ancestor_list_def_level*/ 1},  // repeated field
                           Levels{/*def_level=*/3, /*rep_level=*/2,
-                                 /*ancestor_list_def_level*/ 3}  // innter field
-
-                          ));
+                                 /*ancestor_list_def_level*/ 3}));  // innter field
 
   SetParquetSchema(GroupNode::Make(
       "parent", Repetition::REPEATED,
@@ -1306,9 +1303,8 @@ TEST_F(TestLevels, TestRepeatedGroups) {
                                  /*ancestor_list_def_level*/ 3},  // inner struct field
 
                           Levels{/*def_level=*/5, /*rep_level=*/2,
-                                 /*ancestor_list_def_level*/ 3}  // f0 bool field
+                                 /*ancestor_list_def_level*/ 3}));  // f0 bool field
 
-                          ));
   ASSERT_OK_AND_ASSIGN(levels, RootToTreeLeafLevels(*manifest_, /*column_number=*/1));
   EXPECT_THAT(levels,
               ElementsAre(Levels{/*def_level=*/1, /*rep_level=*/1,
@@ -1320,9 +1316,7 @@ TEST_F(TestLevels, TestRepeatedGroups) {
                                  /*ancestor_list_def_level*/ 3},  // inner struct field
 
                           Levels{/*def_level=*/4, /*rep_level=*/2,
-                                 /*ancestor_list_def_level*/ 3}  // f1 bool field
-
-                          ));
+                                 /*ancestor_list_def_level*/ 3}));  // f1 bool field
 
   // Legacy 2-level necoding
   SetParquetSchema(GroupNode::Make(
@@ -1340,8 +1334,7 @@ TEST_F(TestLevels, TestRepeatedGroups) {
                           Levels{/*def_level=*/3, /*rep_level=*/2,
                                  /*ancestor_list_def_level*/ 1},  // list field
                           Levels{/*def_level=*/3, /*rep_level=*/2,
-                                 /*ancestor_list_def_level*/ 3}  // inner struct field
-                          ));
+                                 /*ancestor_list_def_level*/ 3}));  // inner struct field
 }
 
 TEST_F(TestLevels, ListErrors) {

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -512,7 +512,7 @@ class PARQUET_NO_EXPORT StructReader : public ColumnReaderImpl {
       : ctx_(std::move(ctx)),
         schema_field_(schema_field),
         filtered_field_(std::move(filtered_field)),
-        struct_def_level_(schema_field.definition_level),
+        struct_def_level_(schema_field.level_info.def_level),
         children_(std::move(children)) {}
 
   Status NextBatch(int64_t records_to_read, std::shared_ptr<ChunkedArray>* out) override;
@@ -713,8 +713,9 @@ Status GetReader(const SchemaField& field, const std::shared_ptr<ReaderContext>&
     std::unique_ptr<ColumnReaderImpl> child_reader;
     RETURN_NOT_OK(GetReader(*child, ctx, &child_reader));
     // Use the max definition/repetition level of the leaf here
-    out->reset(new NestedListReader(ctx, list_field, child->definition_level,
-                                    child->repetition_level, std::move(child_reader)));
+    out->reset(new NestedListReader(ctx, list_field, child->level_info.def_level,
+                                    child->level_info.rep_level,
+                                    std::move(child_reader)));
   } else if (type_id == ::arrow::Type::STRUCT) {
     std::vector<std::shared_ptr<Field>> child_fields;
     std::vector<std::unique_ptr<ColumnReaderImpl>> child_readers;

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -410,21 +410,66 @@ bool IsDictionaryReadSupported(const ArrowType& type) {
   return storage_type;
 }
 
-Status NodeToSchemaField(const Node& node, int16_t max_def_level, int16_t max_rep_level,
+struct LevelInfo {
+  int16_t def_level = 0;
+  int16_t rep_level = 0;
+  int16_t repeated_ancestor_def_level = 0;
+
+  /// Copies current levels to the schema field.
+  void Populate(SchemaField* out) {
+    out->definition_level = def_level;
+    out->repetition_level = rep_level;
+    out->repeated_ancestor_definition_level = repeated_ancestor_def_level;
+  }
+
+  /// Increments levels according to the cardinality of node.
+  void Increment(const Node& node) {
+    if (node.is_repeated()) {
+      IncrementRepeated();
+      return;
+    }
+    if (node.is_optional()) {
+      IncrementOptional();
+      return;
+    }
+  }
+
+  /// Incremetns level for a optional node.
+  void IncrementOptional() { def_level++; }
+
+  /// Increments levels for the repeated node.  Returns
+  /// the previous ancestor_list_def_level.
+  int16_t IncrementRepeated() {
+    int16_t last_repeated_ancestor = repeated_ancestor_def_level;
+
+    // Repeated fields add both a repetition and definition level. This is used
+    // to distinguish between an empty list and a list with an item in it.
+    ++rep_level;
+    ++def_level;
+    // For levels >= current_def_level it indicates the list was
+    // non-null and had at least one element.  This is important
+    // for later decoding because we need to add a slot for these
+    // values.  for levels < current_def_level no slots are added
+    // to arrays.
+    repeated_ancestor_def_level = def_level;
+    return last_repeated_ancestor;
+  }
+};
+
+Status NodeToSchemaField(const Node& node, LevelInfo current_levels,
                          SchemaTreeContext* ctx, const SchemaField* parent,
                          SchemaField* out);
 
-Status GroupToSchemaField(const GroupNode& node, int16_t max_def_level,
-                          int16_t max_rep_level, SchemaTreeContext* ctx,
-                          const SchemaField* parent, SchemaField* out);
+Status GroupToSchemaField(const GroupNode& node, LevelInfo current_levels,
+                          SchemaTreeContext* ctx, const SchemaField* parent,
+                          SchemaField* out);
 
 Status PopulateLeaf(int column_index, const std::shared_ptr<Field>& field,
-                    int16_t max_def_level, int16_t max_rep_level, SchemaTreeContext* ctx,
+                    LevelInfo current_levels, SchemaTreeContext* ctx,
                     const SchemaField* parent, SchemaField* out) {
   out->field = field;
   out->column_index = column_index;
-  out->definition_level = max_def_level;
-  out->repetition_level = max_rep_level;
+  current_levels.Populate(out);
   ctx->RecordLeaf(out);
   ctx->LinkParent(out, parent);
   return Status::OK();
@@ -442,31 +487,38 @@ std::shared_ptr<::arrow::KeyValueMetadata> FieldIdMetadata(int field_id) {
   return ::arrow::key_value_metadata({"PARQUET:field_id"}, {std::to_string(field_id)});
 }
 
-Status GroupToStruct(const GroupNode& node, int16_t current_def_level,
-                     int16_t current_rep_level, SchemaTreeContext* ctx,
-                     const SchemaField* parent, SchemaField* out) {
+Status GroupToStruct(const GroupNode& node, LevelInfo current_levels,
+                     SchemaTreeContext* ctx, const SchemaField* parent,
+                     SchemaField* out) {
   std::vector<std::shared_ptr<Field>> arrow_fields;
   out->children.resize(node.field_count());
+
+  // All level increments for the node are expected to happen by callers.
+  // This is required because repeated elements need to have there own
+  // SchemaField.
+
   for (int i = 0; i < node.field_count(); i++) {
-    RETURN_NOT_OK(NodeToSchemaField(*node.field(i), current_def_level, current_rep_level,
-                                    ctx, out, &out->children[i]));
+    RETURN_NOT_OK(
+        NodeToSchemaField(*node.field(i), current_levels, ctx, out, &out->children[i]));
     arrow_fields.push_back(out->children[i].field);
   }
   auto struct_type = ::arrow::struct_(arrow_fields);
   out->field = ::arrow::field(node.name(), struct_type, node.is_optional(),
                               FieldIdMetadata(node.field_id()));
-  out->definition_level = current_def_level;
-  out->repetition_level = current_rep_level;
+  current_levels.Populate(out);
   return Status::OK();
 }
 
-Status ListToSchemaField(const GroupNode& group, int16_t current_def_level,
-                         int16_t current_rep_level, SchemaTreeContext* ctx,
-                         const SchemaField* parent, SchemaField* out) {
+Status ListToSchemaField(const GroupNode& group, LevelInfo current_levels,
+                         SchemaTreeContext* ctx, const SchemaField* parent,
+                         SchemaField* out) {
   if (group.field_count() != 1) {
-    return Status::NotImplemented(
-        "Only LIST-annotated groups with a single child can be handled.");
+    return Status::Invalid("LIST-annotated groups must have a single child.");
   }
+  if (group.is_repeated()) {
+    return Status::Invalid("LIST-annotated groups must not be repeated.");
+  }
+  current_levels.Increment(group);
 
   out->children.resize(group.field_count());
   SchemaField* child_field = &out->children[0];
@@ -477,12 +529,11 @@ Status ListToSchemaField(const GroupNode& group, int16_t current_def_level,
   const Node& list_node = *group.field(0);
 
   if (!list_node.is_repeated()) {
-    return Status::NotImplemented(
+    return Status::Invalid(
         "Non-repeated nodes in a LIST-annotated group are not supported.");
   }
 
-  ++current_def_level;
-  ++current_rep_level;
+  int16_t repeated_ancesor_def_level = current_levels.IncrementRepeated();
   if (list_node.is_group()) {
     // Resolve 3-level encoding
     //
@@ -494,7 +545,7 @@ Status ListToSchemaField(const GroupNode& group, int16_t current_def_level,
     //
     // yields list<item: TYPE ?nullable> ?nullable
     //
-    // We distinguish the special base that we have
+    // We distinguish the special case that we have
     //
     // required/optional group name=whatever {
     //   repeated group name=array or $SOMETHING_tuple {
@@ -512,11 +563,10 @@ Status ListToSchemaField(const GroupNode& group, int16_t current_def_level,
     //   even for single child elements.
     if (list_group.field_count() == 1 && !HasStructListName(list_group)) {
       // List of primitive type
-      RETURN_NOT_OK(NodeToSchemaField(*list_group.field(0), current_def_level,
-                                      current_rep_level, ctx, out, child_field));
+      RETURN_NOT_OK(
+          NodeToSchemaField(*list_group.field(0), current_levels, ctx, out, child_field));
     } else {
-      RETURN_NOT_OK(GroupToStruct(list_group, current_def_level, current_rep_level, ctx,
-                                  out, child_field));
+      RETURN_NOT_OK(GroupToStruct(list_group, current_levels, ctx, out, child_field));
     }
   } else {
     // Two-level list encoding
@@ -530,22 +580,23 @@ Status ListToSchemaField(const GroupNode& group, int16_t current_def_level,
                     GetTypeForNode(column_index, primitive_node, ctx));
     auto item_field = ::arrow::field(list_node.name(), type, /*nullable=*/false,
                                      FieldIdMetadata(list_node.field_id()));
-    RETURN_NOT_OK(PopulateLeaf(column_index, item_field, current_def_level,
-                               current_rep_level, ctx, out, child_field));
+    RETURN_NOT_OK(
+        PopulateLeaf(column_index, item_field, current_levels, ctx, out, child_field));
   }
   out->field = ::arrow::field(group.name(), ::arrow::list(child_field->field),
                               group.is_optional(), FieldIdMetadata(group.field_id()));
-  out->definition_level = current_def_level;
-  out->repetition_level = current_rep_level;
+  current_levels.Populate(out);
+  // At this point current levels contains the def level for this list,
+  // we need to reset to the prior parent.
+  out->repeated_ancestor_definition_level = repeated_ancesor_def_level;
   return Status::OK();
 }
 
-Status GroupToSchemaField(const GroupNode& node, int16_t current_def_level,
-                          int16_t current_rep_level, SchemaTreeContext* ctx,
-                          const SchemaField* parent, SchemaField* out) {
+Status GroupToSchemaField(const GroupNode& node, LevelInfo current_levels,
+                          SchemaTreeContext* ctx, const SchemaField* parent,
+                          SchemaField* out) {
   if (node.logical_type()->is_list()) {
-    return ListToSchemaField(node, current_def_level, current_rep_level, ctx, parent,
-                             out);
+    return ListToSchemaField(node, current_levels, ctx, parent, out);
   }
   std::shared_ptr<ArrowType> type;
   if (node.is_repeated()) {
@@ -554,41 +605,36 @@ Status GroupToSchemaField(const GroupNode& node, int16_t current_def_level,
     // repeated group $NAME {
     //   r/o TYPE[0] f0
     //   r/o TYPE[1] f1
-    // }
     out->children.resize(1);
-    RETURN_NOT_OK(GroupToStruct(node, current_def_level, current_rep_level, ctx, out,
-                                &out->children[0]));
+
+    int16_t repeated_ancestor_def_level = current_levels.IncrementRepeated();
+    RETURN_NOT_OK(GroupToStruct(node, current_levels, ctx, out, &out->children[0]));
     out->field = ::arrow::field(node.name(), ::arrow::list(out->children[0].field),
-                                node.is_optional(), FieldIdMetadata(node.field_id()));
-    out->definition_level = current_def_level;
-    out->repetition_level = current_rep_level;
+                                /*nullable=*/false, FieldIdMetadata(node.field_id()));
+    current_levels.Populate(out);
+    // At this point current_levels contains this list as the def level, we need to
+    // use the previous ancenstor of thi slist.
+    out->repeated_ancestor_definition_level = repeated_ancestor_def_level;
     return Status::OK();
   } else {
-    return GroupToStruct(node, current_def_level, current_rep_level, ctx, parent, out);
+    current_levels.Increment(node);
+    return GroupToStruct(node, current_levels, ctx, parent, out);
   }
 }
 
-Status NodeToSchemaField(const Node& node, int16_t current_def_level,
-                         int16_t current_rep_level, SchemaTreeContext* ctx,
-                         const SchemaField* parent, SchemaField* out) {
+Status NodeToSchemaField(const Node& node, LevelInfo current_levels,
+                         SchemaTreeContext* ctx, const SchemaField* parent,
+                         SchemaField* out) {
   /// Workhorse function for converting a Parquet schema node to an Arrow
   /// type. Handles different conventions for nested data
-  if (node.is_optional()) {
-    ++current_def_level;
-  } else if (node.is_repeated()) {
-    // Repeated fields add both a repetition and definition level. This is used
-    // to distinguish between an empty list and a list with an item in it.
-    ++current_rep_level;
-    ++current_def_level;
-  }
 
   ctx->LinkParent(out, parent);
 
   // Now, walk the schema and create a ColumnDescriptor for each leaf node
   if (node.is_group()) {
     // A nested field, but we don't know what kind yet
-    return GroupToSchemaField(static_cast<const GroupNode&>(node), current_def_level,
-                              current_rep_level, ctx, parent, out);
+    return GroupToSchemaField(static_cast<const GroupNode&>(node), current_levels, ctx,
+                              parent, out);
   } else {
     // Either a normal flat primitive type, or a list type encoded with 1-level
     // list encoding. Note that the 3-level encoding is the form recommended by
@@ -606,23 +652,27 @@ Status NodeToSchemaField(const Node& node, int16_t current_def_level,
     if (node.is_repeated()) {
       // One-level list encoding, e.g.
       // a: repeated int32;
+      int16_t repeated_ancestor_def_level = current_levels.IncrementRepeated();
       out->children.resize(1);
       auto child_field = ::arrow::field(node.name(), type, /*nullable=*/false);
-      RETURN_NOT_OK(PopulateLeaf(column_index, child_field, current_def_level,
-                                 current_rep_level, ctx, out, &out->children[0]));
+      RETURN_NOT_OK(PopulateLeaf(column_index, child_field, current_levels, ctx, out,
+                                 &out->children[0]));
 
       out->field = ::arrow::field(node.name(), ::arrow::list(child_field),
                                   /*nullable=*/false, FieldIdMetadata(node.field_id()));
       // Is this right?
-      out->definition_level = current_def_level;
-      out->repetition_level = current_rep_level;
+      current_levels.Populate(out);
+      // At this point current_levels has consider this list the ancestor so restore
+      // the actual ancenstor.
+      out->repeated_ancestor_definition_level = repeated_ancestor_def_level;
       return Status::OK();
     } else {
+      current_levels.Increment(node);
       // A normal (required/optional) primitive node
       return PopulateLeaf(column_index,
                           ::arrow::field(node.name(), type, node.is_optional(),
                                          FieldIdMetadata(node.field_id())),
-                          current_def_level, current_rep_level, ctx, parent, out);
+                          current_levels, ctx, parent, out);
     }
   }
 }
@@ -802,7 +852,7 @@ Status SchemaManifest::Make(const SchemaDescriptor* schema,
   manifest->schema_fields.resize(schema_node.field_count());
   for (int i = 0; i < static_cast<int>(schema_node.field_count()); ++i) {
     SchemaField* out_field = &manifest->schema_fields[i];
-    RETURN_NOT_OK(NodeToSchemaField(*schema_node.field(i), 0, 0, &ctx,
+    RETURN_NOT_OK(NodeToSchemaField(*schema_node.field(i), LevelInfo(), &ctx,
                                     /*parent=*/nullptr, out_field));
 
     // TODO(wesm): as follow up to ARROW-3246, we should really pass the origin

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -488,7 +488,7 @@ Status ListToSchemaField(const GroupNode& group, LevelInfo current_levels,
         "Non-repeated nodes in a LIST-annotated group are not supported.");
   }
 
-  int16_t repeated_ancesor_def_level = current_levels.IncrementRepeated();
+  int16_t repeated_ancestor_def_level = current_levels.IncrementRepeated();
   if (list_node.is_group()) {
     // Resolve 3-level encoding
     //
@@ -543,7 +543,7 @@ Status ListToSchemaField(const GroupNode& group, LevelInfo current_levels,
   out->level_info = current_levels;
   // At this point current levels contains the def level for this list,
   // we need to reset to the prior parent.
-  out->level_info.repeated_ancestor_def_level = repeated_ancesor_def_level;
+  out->level_info.repeated_ancestor_def_level = repeated_ancestor_def_level;
   return Status::OK();
 }
 
@@ -567,6 +567,8 @@ Status GroupToSchemaField(const GroupNode& node, LevelInfo current_levels,
     RETURN_NOT_OK(GroupToStruct(node, current_levels, ctx, out, &out->children[0]));
     out->field = ::arrow::field(node.name(), ::arrow::list(out->children[0].field),
                                 /*nullable=*/false, FieldIdMetadata(node.field_id()));
+
+    ctx->LinkParent(&out->children[0], out);
     out->level_info = current_levels;
     // At this point current_levels contains this list as the def level, we need to
     // use the previous ancenstor of thi slist.

--- a/cpp/src/parquet/arrow/schema.h
+++ b/cpp/src/parquet/arrow/schema.h
@@ -28,6 +28,7 @@
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 
+#include "parquet/level_conversion.h"
 #include "parquet/platform.h"
 #include "parquet/schema.h"
 
@@ -93,17 +94,7 @@ struct PARQUET_EXPORT SchemaField {
   // Only set for leaf nodes
   int column_index = -1;
 
-  // The definition level at which the value for the field
-  // is considered not null (definition levels greater than
-  // or equal to indicate this value indicate a not-null
-  // value for the field).
-  int16_t definition_level;
-  // The repetition level corresponding to this element
-  // or the closest repeated ancestor.  Any repetition
-  // level less than this indicates either a new list OR
-  // an empty list (which is determined in conjunction
-  // definition_level).
-  int16_t repetition_level;
+  parquet::internal::LevelInfo level_info;
 
   bool IsStruct() const { return field->type()->id() == ::arrow::Type::STRUCT; }
   bool IsRepeated() const {
@@ -112,13 +103,6 @@ struct PARQUET_EXPORT SchemaField {
            field->type()->id() == ::arrow::Type::LARGE_LIST ||
            field->type()->id() == ::arrow::Type::MAP;
   }
-
-  // The definition level indicating the level at which the closest
-  // repeated ancestor was not empty.  This is used to discrimate
-  // between a value less than |definition_level|
-  // being null or excluded entirely.
-  // TODO(ARROW-8493): Populate this value.
-  int16_t repeated_ancestor_definition_level = 0;
 
   bool is_leaf() const { return column_index != -1; }
 };

--- a/cpp/src/parquet/level_conversion.h
+++ b/cpp/src/parquet/level_conversion.h
@@ -51,9 +51,9 @@ struct PARQUET_EXPORT LevelInfo {
   // or equal to indicate this value indicate a not-null
   // value for the field). For list fields definition levels
   // greater then or equal to this field indicate a present
-  // element (if the listis nullable def_level-1 indicates
-  // and empty but not-null list).
+  // , possibly null, element.
   int16_t def_level = 0;
+
   // The repetition level corresponding to this element
   // or the closest repeated ancestor.  Any repetition
   // level less than this indicates either a new list OR

--- a/cpp/src/parquet/level_conversion.h
+++ b/cpp/src/parquet/level_conversion.h
@@ -28,11 +28,11 @@ namespace internal {
 struct PARQUET_EXPORT LevelInfo {
   LevelInfo()
       : null_slot_usage(1), def_level(0), rep_level(0), repeated_ancestor_def_level(0) {}
-  LevelInfo(int32_t null_slots, int32_t definition_level, int32_t repitition_level,
+  LevelInfo(int32_t null_slots, int32_t definition_level, int32_t repetition_level,
             int32_t repeated_ancestor_definition_level)
       : null_slot_usage(null_slots),
         def_level(definition_level),
-        rep_level(repitition_level),
+        rep_level(repetition_level),
         repeated_ancestor_def_level(repeated_ancestor_definition_level) {}
 
   bool operator==(const LevelInfo& b) const {
@@ -41,30 +41,32 @@ struct PARQUET_EXPORT LevelInfo {
            repeated_ancestor_def_level == b.repeated_ancestor_def_level;
   }
 
-  // How many slots a null element consumes.
+  // How many slots an undefined but present (i.e. null element) in
+  // parquet consumes when decoding to Arrow.
+  // "Slot" is used in the same context
+  // of the Arrow specification (i.e. a value holder).
   // This is only ever >1 for descendents of
   // FixedSizeList.
   int32_t null_slot_usage = 1;
 
   // The definition level at which the value for the field
   // is considered not null (definition levels greater than
-  // or equal to indicate this value indicate a not-null
+  // or equal to this value indicate a not-null
   // value for the field). For list fields definition levels
-  // greater then or equal to this field indicate a present
-  // , possibly null, element.
+  // greater than or equal to this field indicate a present,
+  // possibly null, element.
   int16_t def_level = 0;
 
   // The repetition level corresponding to this element
   // or the closest repeated ancestor.  Any repetition
   // level less than this indicates either a new list OR
   // an empty list (which is determined in conjunction
-  // definition_level).
+  // definition levels).
   int16_t rep_level = 0;
 
   // The definition level indicating the level at which the closest
-  // repeated ancestor was not empty.  This is used to discriminate
-  // between a value less than |definition_level|
-  // being null or excluded entirely.
+  // repeated ancestor is not empty.  This is used to discriminate
+  // between a value less than |def_level| being null or excluded entirely.
   // For instance if we have an arrow schema like:
   // list(struct(f0: int)).  Then then there are the following
   // definition levels:

--- a/cpp/src/parquet/level_conversion.h
+++ b/cpp/src/parquet/level_conversion.h
@@ -41,12 +41,11 @@ struct PARQUET_EXPORT LevelInfo {
            repeated_ancestor_def_level == b.repeated_ancestor_def_level;
   }
 
-  // How many slots an undefined but present (i.e. null element) in
+  // How many slots an undefined but present (i.e. null) element in
   // parquet consumes when decoding to Arrow.
-  // "Slot" is used in the same context
-  // of the Arrow specification (i.e. a value holder).
-  // This is only ever >1 for descendents of
-  // FixedSizeList.
+  // "Slot" is used in the same context as the Arrow specification
+  // (i.e. a value holder).
+  // This is only ever >1 for descendents of FixedSizeList.
   int32_t null_slot_usage = 1;
 
   // The definition level at which the value for the field
@@ -54,14 +53,14 @@ struct PARQUET_EXPORT LevelInfo {
   // or equal to this value indicate a not-null
   // value for the field). For list fields definition levels
   // greater than or equal to this field indicate a present,
-  // possibly null, element.
+  // possibly null, child value.
   int16_t def_level = 0;
 
   // The repetition level corresponding to this element
   // or the closest repeated ancestor.  Any repetition
   // level less than this indicates either a new list OR
   // an empty list (which is determined in conjunction
-  // definition levels).
+  // with definition levels).
   int16_t rep_level = 0;
 
   // The definition level indicating the level at which the closest
@@ -70,15 +69,15 @@ struct PARQUET_EXPORT LevelInfo {
   // For instance if we have an arrow schema like:
   // list(struct(f0: int)).  Then then there are the following
   // definition levels:
-  // 0 = null list
-  // 1 = present but empty list.
-  // 2 = a null value in the list
-  // 3 = a non null struct but null integer.
-  // 4 = a present integer.
-  // When reconstructing the struct and integer Array's
+  //   0 = null list
+  //   1 = present but empty list.
+  //   2 = a null value in the list
+  //   3 = a non null struct but null integer.
+  //   4 = a present integer.
+  // When reconstructing, the struct and integer arrays'
   // repeated_ancestor_def_level would be 2.  Any
   // def_level < 2 indicates that there isn't a corresponding
-  // slot in the struct or int fields.
+  // child value in the list.
   // i.e. [null, [], [null], [{f0: null}], [{f0: 1}]]
   // has the def levels [0, 1, 2, 3, 4].  The actual
   // struct array is only of length 3: [not-set, set, set] and

--- a/cpp/src/parquet/level_conversion.h
+++ b/cpp/src/parquet/level_conversion.h
@@ -20,9 +20,116 @@
 #include <cstdint>
 
 #include "parquet/platform.h"
+#include "parquet/schema.h"
 
 namespace parquet {
 namespace internal {
+
+struct PARQUET_EXPORT LevelInfo {
+  LevelInfo()
+      : null_slot_usage(1), def_level(0), rep_level(0), repeated_ancestor_def_level(0) {}
+  LevelInfo(int32_t null_slots, int32_t definition_level, int32_t repitition_level,
+            int32_t repeated_ancestor_definition_level)
+      : null_slot_usage(null_slots),
+        def_level(definition_level),
+        rep_level(repitition_level),
+        repeated_ancestor_def_level(repeated_ancestor_definition_level) {}
+
+  bool operator==(const LevelInfo& b) const {
+    return null_slot_usage == b.null_slot_usage && def_level == b.def_level &&
+           rep_level == b.rep_level &&
+           repeated_ancestor_def_level == b.repeated_ancestor_def_level;
+  }
+
+  // How many slots a null element consumes.
+  // This is only ever >1 for descendents of
+  // FixedSizeList.
+  int32_t null_slot_usage = 1;
+
+  // The definition level at which the value for the field
+  // is considered not null (definition levels greater than
+  // or equal to indicate this value indicate a not-null
+  // value for the field). For list fields definition levels
+  // greater then or equal to this field indicate a present
+  // element (if the listis nullable def_level-1 indicates
+  // and empty but not-null list).
+  int16_t def_level = 0;
+  // The repetition level corresponding to this element
+  // or the closest repeated ancestor.  Any repetition
+  // level less than this indicates either a new list OR
+  // an empty list (which is determined in conjunction
+  // definition_level).
+  int16_t rep_level = 0;
+
+  // The definition level indicating the level at which the closest
+  // repeated ancestor was not empty.  This is used to discriminate
+  // between a value less than |definition_level|
+  // being null or excluded entirely.
+  // For instance if we have an arrow schema like:
+  // list(struct(f0: int)).  Then then there are the following
+  // definition levels:
+  // 0 = null list
+  // 1 = present but empty list.
+  // 2 = a null value in the list
+  // 3 = a non null struct but null integer.
+  // 4 = a present integer.
+  // When reconstructing the struct and integer Array's
+  // repeated_ancestor_def_level would be 2.  Any
+  // def_level < 2 indicates that there isn't a corresponding
+  // slot in the struct or int fields.
+  // i.e. [null, [], [null], [{f0: null}], [{f0: 1}]
+  // has the def levels [0, 1, 2, 3, 4].  The actual
+  // struct array is only of length 3: [not-set, set, set] and
+  // the int array is also of length 3: [N/A, null, 1].
+  //
+  int16_t repeated_ancestor_def_level = 0;
+
+  /// Increments levels according to the cardinality of node.
+  void Increment(const schema::Node& node) {
+    if (node.is_repeated()) {
+      IncrementRepeated();
+      return;
+    }
+    if (node.is_optional()) {
+      IncrementOptional();
+      return;
+    }
+  }
+
+  /// Incremetns level for a optional node.
+  void IncrementOptional() { def_level++; }
+
+  /// Increments levels for the repeated node.  Returns
+  /// the previous ancestor_list_def_level.
+  int16_t IncrementRepeated() {
+    int16_t last_repeated_ancestor = repeated_ancestor_def_level;
+
+    // Repeated fields add both a repetition and definition level. This is used
+    // to distinguish between an empty list and a list with an item in it.
+    ++rep_level;
+    ++def_level;
+    // For levels >= repeated_ancenstor_def_level it indicates the list was
+    // non-null and had at least one element.  This is important
+    // for later decoding because we need to add a slot for these
+    // values.  for levels < current_def_level no slots are added
+    // to arrays.
+    repeated_ancestor_def_level = def_level;
+    return last_repeated_ancestor;
+  }
+
+  friend std::ostream& operator<<(std::ostream& os, const LevelInfo& levels) {
+    // This print method is to silence valgrind issues.  What's printed
+    // is not important because all asserts happen directly on
+    // members.
+    os << "{def=" << levels.def_level << ", rep=" << levels.rep_level
+       << ", repeated_ancestor_def=" << levels.repeated_ancestor_def_level;
+    if (levels.null_slot_usage > 1) {
+      os << ", null_slot_usage=" << levels.null_slot_usage;
+    }
+    os << "}";
+    return os;
+  }
+};
 
 void PARQUET_EXPORT DefinitionLevelsToBitmap(
     const int16_t* def_levels, int64_t num_def_levels, const int16_t max_definition_level,

--- a/cpp/src/parquet/level_conversion.h
+++ b/cpp/src/parquet/level_conversion.h
@@ -77,7 +77,7 @@ struct PARQUET_EXPORT LevelInfo {
   // repeated_ancestor_def_level would be 2.  Any
   // def_level < 2 indicates that there isn't a corresponding
   // slot in the struct or int fields.
-  // i.e. [null, [], [null], [{f0: null}], [{f0: 1}]
+  // i.e. [null, [], [null], [{f0: null}], [{f0: 1}]]
   // has the def levels [0, 1, 2, 3, 4].  The actual
   // struct array is only of length 3: [not-set, set, set] and
   // the int array is also of length 3: [N/A, null, 1].


### PR DESCRIPTION
level

- Introduces a new struct to track levels during SchemaManifset construction.
- Also add additional check that list annotated fields aren't repeated
- Adds unit test for SchemaManifest::Make to verify rep/def/ancestor
levels.