### PR TITLE
ARROW-9756: [Rust] [DataFusion] Added support for scalar UDFs of arbitrary return types

### DIFF
--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -53,6 +53,8 @@ DataFusion includes a simple command-line interactive SQL utility. See the [CLI 
 - [x] Limit
 - [x] Aggregate
 - [x] UDFs
+  - [x] Scalar UDFs
+  - [x] Aggregate UDFs
 - [x] Common math functions
 - String functions
   - [x] Length of the string

--- a/rust/datafusion/src/datatyped.rs
+++ b/rust/datafusion/src/datatyped.rs
@@ -15,30 +15,24 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! DataFusion is an extensible query execution framework that uses
-//! Apache Arrow as the memory model.
-//!
-//! DataFusion supports both SQL and a Table/DataFrame-style API for building logical query plans
-//! and also provides a query optimizer and execution engine capable of parallel execution
-//! against partitioned data sources (CSV and Parquet) using threads.
-//!
-//! DataFusion currently supports simple projection, selection, and aggregate queries.
+//! This module contains a public trait to annotate objects that know their data type.
+// The pattern in this module follows https://stackoverflow.com/a/28664881/931303
 
-#![warn(missing_docs)]
+use crate::error::Result;
+use arrow::datatypes::{DataType, Schema};
 
-extern crate arrow;
-extern crate sqlparser;
+/// Any object that knows how to infer its resulting data type from an underlying schema
+pub trait DataTyped: AsDataTyped {
+    fn get_type(&self, input_schema: &Schema) -> Result<DataType>;
+}
 
-pub mod dataframe;
-pub mod datasource;
-mod datatyped;
-pub mod error;
-pub mod execution;
-pub mod logicalplan;
-pub mod optimizer;
-pub mod sql;
+/// Trait that allows DataTyped objects to be upcasted to DataTyped.
+pub trait AsDataTyped {
+    fn as_datatyped(&self) -> &dyn DataTyped;
+}
 
-pub use execution::context::ExecutionContext;
-
-#[cfg(test)]
-pub mod test;
+impl<T: DataTyped> AsDataTyped for T {
+    fn as_datatyped(&self) -> &dyn DataTyped {
+        self
+    }
+}

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -1049,10 +1049,7 @@ mod tests {
 
         let my_add = ScalarFunction::new(
             "my_add",
-            vec![
-                Field::new("a", DataType::Int32, true),
-                Field::new("b", DataType::Int32, true),
-            ],
+            vec![vec![DataType::Int32, DataType::Int32]],
             DataType::Int32,
             myfunc,
         );

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -516,7 +516,7 @@ impl SchemaProvider for ExecutionContextState {
             .map(|f| {
                 Arc::new(FunctionMeta::new(
                     name.to_owned(),
-                    f.args.clone(),
+                    f.arg_types.clone(),
                     f.return_type.clone(),
                     FunctionType::Scalar,
                 ))

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -94,27 +94,27 @@ impl DataFrame for DataFrameImpl {
 
     /// Create an expression to represent the min() aggregate function
     fn min(&self, expr: Expr) -> Result<Expr> {
-        self.aggregate_expr("MIN", expr)
+        self.aggregate_expr("min", expr)
     }
 
     /// Create an expression to represent the max() aggregate function
     fn max(&self, expr: Expr) -> Result<Expr> {
-        self.aggregate_expr("MAX", expr)
+        self.aggregate_expr("max", expr)
     }
 
     /// Create an expression to represent the sum() aggregate function
     fn sum(&self, expr: Expr) -> Result<Expr> {
-        self.aggregate_expr("SUM", expr)
+        self.aggregate_expr("sum", expr)
     }
 
     /// Create an expression to represent the avg() aggregate function
     fn avg(&self, expr: Expr) -> Result<Expr> {
-        self.aggregate_expr("AVG", expr)
+        self.aggregate_expr("avg", expr)
     }
 
     /// Create an expression to represent the count() aggregate function
     fn count(&self, expr: Expr) -> Result<Expr> {
-        self.aggregate_expr("COUNT", expr)
+        self.aggregate_expr("count", expr)
     }
 
     /// Convert to logical plan
@@ -218,7 +218,7 @@ mod tests {
         let plan = t2.to_logical_plan();
 
         // build same plan using SQL API
-        let sql = "SELECT c1, MIN(c12), MAX(c12), AVG(c12), SUM(c12), COUNT(c12) \
+        let sql = "SELECT c1, min(c12), max(c12), avg(c12), sum(c12), count(c12) \
                    FROM aggregate_test_100 \
                    GROUP BY c1";
         let sql_plan = create_plan(sql)?;

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -141,7 +141,10 @@ pub fn sum() -> AggregateFunction {
     AggregateFunction {
         name: "sum".to_string(),
         return_type: Arc::new(sum_return_type),
-        args: vec![common_types()],
+        arg_types: common_types()
+            .iter()
+            .map(|x| vec![x.clone()])
+            .collect::<Vec<_>>(),
         aggregate: Arc::new(Sum {}),
     }
 }
@@ -353,7 +356,10 @@ pub fn avg() -> AggregateFunction {
     AggregateFunction {
         name: "avg".to_string(),
         return_type: Arc::new(avg_return_type),
-        args: vec![common_types()],
+        arg_types: common_types()
+            .iter()
+            .map(|x| vec![x.clone()])
+            .collect::<Vec<_>>(),
         aggregate: Arc::new(Avg {}),
     }
 }
@@ -464,7 +470,10 @@ pub fn max() -> AggregateFunction {
     AggregateFunction {
         name: "max".to_string(),
         return_type: Arc::new(max_return_type),
-        args: vec![common_types()],
+        arg_types: common_types()
+            .iter()
+            .map(|x| vec![x.clone()])
+            .collect::<Vec<_>>(),
         aggregate: Arc::new(Max {}),
     }
 }
@@ -642,7 +651,10 @@ pub fn min() -> AggregateFunction {
     AggregateFunction {
         name: "min".to_string(),
         return_type: Arc::new(max_return_type),
-        args: vec![common_types()],
+        arg_types: common_types()
+            .iter()
+            .map(|x| vec![x.clone()])
+            .collect::<Vec<_>>(),
         aggregate: Arc::new(Min {}),
     }
 }
@@ -831,13 +843,16 @@ pub fn physical_count(expr: Arc<dyn PhysicalExpr>) -> Arc<dyn AggregateExpr> {
 
 /// Creates a count aggregate function
 pub fn count() -> AggregateFunction {
-    let mut types = common_types();
-    types.push(DataType::Utf8);
+    let mut types = common_types()
+        .iter()
+        .map(|x| vec![x.clone()])
+        .collect::<Vec<_>>();
+    types.push(vec![DataType::Utf8]);
 
     AggregateFunction {
         name: "count".to_string(),
         return_type: Arc::new(count_return_type),
-        args: vec![types],
+        arg_types: types,
         aggregate: Arc::new(Count {}),
     }
 }

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -64,10 +64,10 @@ impl HashAggregateExec {
 
         let mut fields = Vec::with_capacity(group_expr.len() + aggr_expr.len());
         for (expr, name) in &group_expr {
-            fields.push(Field::new(name, expr.data_type(&input_schema)?, true))
+            fields.push(Field::new(name, expr.get_type(&input_schema)?, true))
         }
         for (expr, name) in &aggr_expr {
-            fields.push(Field::new(&name, expr.data_type(&input_schema)?, true))
+            fields.push(Field::new(&name, expr.get_type(&input_schema)?, true))
         }
         let schema = Arc::new(Schema::new(fields));
 
@@ -459,7 +459,7 @@ impl RecordBatchReader for HashAggregateIterator {
         // aggregate values
         for i in 0..self.aggr_expr.len() {
             let aggr_data_type = self.aggr_expr[i]
-                .data_type(&input_schema)
+                .get_type(&input_schema)
                 .map_err(ExecutionError::into_arrow_external_error)?;
             let value = accumulators[i]
                 .borrow_mut()

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -268,7 +268,7 @@ impl RecordBatchReader for GroupedHashAggregateIterator {
                 .aggr_expr
                 .iter()
                 .map(|expr| {
-                    expr.evaluate_input(&batch)
+                    expr.evaluate(&batch)
                         .map_err(ExecutionError::into_arrow_external_error)
                 })
                 .collect::<ArrowResult<Vec<_>>>()?;
@@ -433,7 +433,7 @@ impl RecordBatchReader for HashAggregateIterator {
                 .aggr_expr
                 .iter()
                 .map(|expr| {
-                    expr.evaluate_input(&batch)
+                    expr.evaluate(&batch)
                         .map_err(ExecutionError::into_arrow_external_error)
                 })
                 .collect::<ArrowResult<Vec<_>>>()?;

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -698,7 +698,7 @@ mod tests {
 
     use super::*;
     use crate::execution::physical_plan::csv::{CsvExec, CsvReadOptions};
-    use crate::execution::physical_plan::expressions::{col, sum};
+    use crate::execution::physical_plan::expressions::{col, physical_sum};
     use crate::execution::physical_plan::merge::MergeExec;
     use crate::test;
 
@@ -716,7 +716,7 @@ mod tests {
             vec![(col("c2"), "c2".to_string())];
 
         let aggregates: Vec<(Arc<dyn AggregateExpr>, String)> =
-            vec![(sum(col("c4")), "SUM(c4)".to_string())];
+            vec![(physical_sum(col("c4")), "SUM(c4)".to_string())];
 
         let partition_aggregate = HashAggregateExec::try_new(
             groups.clone(),

--- a/rust/datafusion/src/execution/physical_plan/math_expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/math_expressions.rs
@@ -124,10 +124,7 @@ mod tests {
         let plan = ctx.optimize(&plan)?;
 
         assert_eq!(
-            *plan
-                .schema()
-                .field_with_name("sqrt(CAST(c0 as Float32))")?
-                .data_type(),
+            *plan.schema().field_with_name("sqrt(c0)")?.data_type(),
             DataType::Float32
         );
 

--- a/rust/datafusion/src/execution/physical_plan/math_expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/math_expressions.rs
@@ -21,7 +21,7 @@ use crate::error::ExecutionError;
 use crate::execution::physical_plan::udf::ScalarFunction;
 
 use arrow::array::{Array, ArrayRef, Float64Array, Float64Builder};
-use arrow::datatypes::{DataType, Field};
+use arrow::datatypes::DataType;
 
 use std::sync::Arc;
 
@@ -29,7 +29,7 @@ macro_rules! math_unary_function {
     ($NAME:expr, $FUNC:ident) => {
         ScalarFunction::new(
             $NAME,
-            vec![Field::new("n", DataType::Float64, true)],
+            vec![vec![DataType::Float64]],
             DataType::Float64,
             Arc::new(|args: &[ArrayRef]| {
                 let n = &args[0].as_any().downcast_ref::<Float64Array>();
@@ -86,7 +86,7 @@ mod tests {
         execution::context::ExecutionContext,
         logicalplan::{col, sqrt, LogicalPlanBuilder},
     };
-    use arrow::datatypes::Schema;
+    use arrow::datatypes::{Field, Schema};
 
     #[test]
     fn cast_i8_input() -> Result<()> {

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -26,7 +26,7 @@ use crate::error::Result;
 use crate::execution::context::ExecutionContextState;
 use crate::logicalplan::{LogicalPlan, ScalarValue};
 use arrow::array::ArrayRef;
-use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use arrow::datatypes::{DataType, Schema, SchemaRef};
 use arrow::{
     compute::kernels::length::length,
     record_batch::{RecordBatch, RecordBatchReader},
@@ -96,7 +96,7 @@ pub trait Accumulator: Debug {
 pub fn scalar_functions() -> Vec<ScalarFunction> {
     let mut udfs = vec![ScalarFunction::new(
         "length",
-        vec![Field::new("n", DataType::Utf8, true)],
+        vec![vec![DataType::Utf8]],
         DataType::UInt32,
         Arc::new(|args: &[ArrayRef]| Ok(Arc::new(length(args[0].as_ref())?))),
     )];

--- a/rust/datafusion/src/execution/physical_plan/planner.rs
+++ b/rust/datafusion/src/execution/physical_plan/planner.rs
@@ -355,11 +355,7 @@ impl PhysicalPlannerImpl {
                 input_schema,
                 data_type.clone(),
             )?)),
-            Expr::ScalarFunction {
-                name,
-                args,
-                return_type,
-            } => match ctx_state
+            Expr::ScalarFunction { name, args, .. } => match ctx_state
                 .lock()
                 .expect("failed to lock mutex")
                 .scalar_functions
@@ -380,7 +376,7 @@ impl PhysicalPlannerImpl {
                         name,
                         Box::new(f.fun.clone()),
                         physical_args,
-                        return_type,
+                        f.return_type.clone(),
                     )))
                 }
                 _ => Err(ExecutionError::General(format!(

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -52,7 +52,7 @@ impl ProjectionExec {
             .map(|(e, name)| {
                 Ok(Field::new(
                     name,
-                    e.data_type(&input_schema)?,
+                    e.get_type(&input_schema)?,
                     e.nullable(&input_schema)?,
                 ))
             })

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -41,7 +41,7 @@ pub struct ScalarFunction {
     /// The first dimension (0) represents specific combinations of valid argument types
     /// The second dimension (1) represents the types of each argument.
     /// For example, [[t1, t2]] is a function of 2 arguments that only accept t1 on the first arg and t2 on the second
-    pub args: Vec<Vec<DataType>>,
+    pub arg_types: Vec<Vec<DataType>>,
     /// Return type
     pub return_type: DataType,
     /// UDF implementation
@@ -52,7 +52,7 @@ impl Debug for ScalarFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ScalarFunction")
             .field("name", &self.name)
-            .field("args", &self.args)
+            .field("arg_types", &self.arg_types)
             .field("return_type", &self.return_type)
             .field("fun", &"<FUNC>")
             .finish()
@@ -63,13 +63,13 @@ impl ScalarFunction {
     /// Create a new ScalarFunction
     pub fn new(
         name: &str,
-        args: Vec<Vec<DataType>>,
+        arg_types: Vec<Vec<DataType>>,
         return_type: DataType,
         fun: ScalarUdf,
     ) -> Self {
         Self {
             name: name.to_owned(),
-            args,
+            arg_types,
             return_type,
             fun,
         }

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -20,7 +20,7 @@
 use std::fmt;
 
 use arrow::array::ArrayRef;
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Schema};
 
 use crate::error::Result;
 use crate::execution::physical_plan::PhysicalExpr;
@@ -37,8 +37,11 @@ pub type ScalarUdf = Arc<dyn Fn(&[ArrayRef]) -> Result<ArrayRef> + Send + Sync>;
 pub struct ScalarFunction {
     /// Function name
     pub name: String,
-    /// Function argument meta-data
-    pub args: Vec<Field>,
+    /// Set of valid argument types.
+    /// The first dimension (0) represents specific combinations of valid argument types
+    /// The second dimension (1) represents the types of each argument.
+    /// For example, [[t1, t2]] is a function of 2 arguments that only accept t1 on the first arg and t2 on the second
+    pub args: Vec<Vec<DataType>>,
     /// Return type
     pub return_type: DataType,
     /// UDF implementation
@@ -60,7 +63,7 @@ impl ScalarFunction {
     /// Create a new ScalarFunction
     pub fn new(
         name: &str,
-        args: Vec<Field>,
+        args: Vec<Vec<DataType>>,
         return_type: DataType,
         fun: ScalarUdf,
     ) -> Self {

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -38,6 +38,9 @@ pub struct ScalarFunction {
     /// Function name
     pub name: String,
     /// Set of valid argument types.
+    /// The first dimension (0) represents specific combinations of valid argument types
+    /// The second dimension (1) represents the types of each argument.
+    /// For example, [[t1, t2]] is a function of 2 arguments that only accept t1 on the first arg and t2 on the second
     pub arg_types: Vec<Vec<DataType>>,
     /// Return type
     pub return_type: DataType,

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -157,8 +157,6 @@ impl PhysicalExpr for ScalarFunctionExpr {
 
 /// A generic aggregate function
 /*
-This struct is
-
 An aggregate function accepts an arbitrary number of arguments, of arbitrary data types,
 and returns an arbitrary type based on the incoming types.
 
@@ -174,7 +172,7 @@ pub struct AggregateFunction {
     pub name: String,
     /// A list of arguments and their respective types. A function can accept more than one type as argument
     /// (e.g. sum(i8), sum(u8)).
-    pub args: Vec<Vec<DataType>>,
+    pub arg_types: Vec<Vec<DataType>>,
     /// Return type. This function takes
     pub return_type: ReturnType,
     /// implementation of the aggregation

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -38,9 +38,6 @@ pub struct ScalarFunction {
     /// Function name
     pub name: String,
     /// Set of valid argument types.
-    /// The first dimension (0) represents specific combinations of valid argument types
-    /// The second dimension (1) represents the types of each argument.
-    /// For example, [[t1, t2]] is a function of 2 arguments that only accept t1 on the first arg and t2 on the second
     pub arg_types: Vec<Vec<DataType>>,
     /// Return type
     pub return_type: DataType,

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -47,7 +47,10 @@ pub enum FunctionType {
 pub struct FunctionMeta {
     /// Function name
     name: String,
-    /// Function arguments. Each argument i can be one of the types of args[i], with respective priority
+    /// Function argument types
+    /// The first dimension (0) represents specific combinations of valid argument types
+    /// The second dimension (1) represents the types of each argument.
+    /// For example, [[t1, t2]] is a function of 2 arguments that only accept t1 on the first arg and t2 on the second
     arg_types: Vec<Vec<DataType>>,
     /// Function return type
     return_type: DataType,

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -48,7 +48,7 @@ pub struct FunctionMeta {
     /// Function name
     name: String,
     /// Function arguments. Each argument i can be one of the types of args[i], with respective priority
-    args: Vec<Vec<DataType>>,
+    arg_types: Vec<Vec<DataType>>,
     /// Function return type
     return_type: DataType,
     /// Function type (Scalar or Aggregate)
@@ -59,13 +59,13 @@ impl FunctionMeta {
     #[allow(missing_docs)]
     pub fn new(
         name: String,
-        args: Vec<Vec<DataType>>,
+        arg_types: Vec<Vec<DataType>>,
         return_type: DataType,
         function_type: FunctionType,
     ) -> Self {
         FunctionMeta {
             name,
-            args,
+            arg_types,
             return_type,
             function_type,
         }
@@ -75,8 +75,8 @@ impl FunctionMeta {
         &self.name
     }
     /// Getter for the arg list
-    pub fn args(&self) -> &Vec<Vec<DataType>> {
-        &self.args
+    pub fn arg_types(&self) -> &Vec<Vec<DataType>> {
+        &self.arg_types
     }
     /// Getter for the `DataType` the function returns
     pub fn return_type(&self) -> &DataType {

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -47,8 +47,8 @@ pub enum FunctionType {
 pub struct FunctionMeta {
     /// Function name
     name: String,
-    /// Function arguments
-    args: Vec<Field>,
+    /// Function arguments. Each argument i can be one of the types of args[i], with respective priority
+    args: Vec<Vec<DataType>>,
     /// Function return type
     return_type: DataType,
     /// Function type (Scalar or Aggregate)
@@ -59,7 +59,7 @@ impl FunctionMeta {
     #[allow(missing_docs)]
     pub fn new(
         name: String,
-        args: Vec<Field>,
+        args: Vec<Vec<DataType>>,
         return_type: DataType,
         function_type: FunctionType,
     ) -> Self {
@@ -75,7 +75,7 @@ impl FunctionMeta {
         &self.name
     }
     /// Getter for the arg list
-    pub fn args(&self) -> &Vec<Field> {
+    pub fn args(&self) -> &Vec<Vec<DataType>> {
         &self.args
     }
     /// Getter for the `DataType` the function returns

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -603,9 +603,18 @@ pub fn aggregate_expr(name: &str, expr: Expr, return_type: DataType) -> Expr {
     }
 }
 
-/// Create an aggregate expression
+/// Create an scalar function expression
 pub fn scalar_function(name: &str, expr: Vec<Expr>, return_type: DataType) -> Expr {
     Expr::ScalarFunction {
+        name: name.to_owned(),
+        args: expr,
+        return_type,
+    }
+}
+
+/// Create an aggregate expression
+pub fn aggregate_function(name: &str, expr: Vec<Expr>, return_type: DataType) -> Expr {
+    Expr::AggregateFunction {
         name: name.to_owned(),
         args: expr,
         return_type,

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -48,9 +48,6 @@ pub struct FunctionMeta {
     /// Function name
     name: String,
     /// Function argument types
-    /// The first dimension (0) represents specific combinations of valid argument types
-    /// The second dimension (1) represents the types of each argument.
-    /// For example, [[t1, t2]] is a function of 2 arguments that only accept t1 on the first arg and t2 on the second
     arg_types: Vec<Vec<DataType>>,
     /// Function return type
     return_type: DataType,

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -86,14 +86,14 @@ impl TypeCoercionRule {
                             .map(|e| e.get_type(schema))
                             .collect::<Result<Vec<_>>>()?;
 
-                        let new = if func_meta.args.contains(&current_types) {
+                        let new = if func_meta.arg_types.contains(&current_types) {
                             Some(expressions)
                         } else {
                             maybe_rewrite(
                                 &expressions,
                                 &current_types,
                                 &schema,
-                                &func_meta.args,
+                                &func_meta.arg_types,
                             )?
                         };
 
@@ -103,7 +103,7 @@ impl TypeCoercionRule {
                             return Err(ExecutionError::General(format!(
                                 "The scalar function '{}' requires one of the type variants {:?}, but the arguments of type '{:?}' cannot be safely casted to any of them.",
                                 func_meta.name,
-                                func_meta.args,
+                                func_meta.arg_types,
                                 current_types,
                             )));
                         }

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -170,28 +170,26 @@ fn maybe_rewrite(
     schema: &Schema,
     signature: &Vec<Vec<DataType>>,
 ) -> Result<Option<Vec<Expr>>> {
-    // for each set of valid signatures, try to coerse all expressions to one of them
-    let mut new_expressions: Option<Vec<Expr>> = None;
+    // for each set of valid signatures, try to coerce all expressions to one of them
     for valid_types in signature {
-        // for each option, try to coerse all arguments to it
-        if let Some(types) = maybe_coerse(valid_types, &current_types) {
+        // for each option, try to coerce all arguments to it
+        if let Some(types) = maybe_coerce(valid_types, &current_types) {
             // yes: let's re-write the expressions
-            new_expressions = Some(
+            return Ok(Some(
                 expressions
                     .iter()
                     .enumerate()
                     .map(|(i, expr)| expr.cast_to(&types[i], schema))
                     .collect::<Result<Vec<_>>>()?,
-            );
-            break;
+            ))
         }
         // we cannot: try the next
     }
-    Ok(new_expressions)
+    Ok(None)
 }
 
-/// Try to coerse current_types into valid_types
-fn maybe_coerse(
+/// Try to coerce current_types into valid_types
+fn maybe_coerce(
     valid_types: &Vec<DataType>,
     current_types: &Vec<DataType>,
 ) -> Option<Vec<DataType>> {

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -523,12 +523,12 @@ impl<S: SchemaProvider> SqlToRel<S> {
 
                             let mut safe_args: Vec<Expr> = vec![];
                             for i in 0..rex_args.len() {
-                                let expr = if fm.args()[i]
+                                let expr = if fm.arg_types()[i]
                                     .contains(&rex_args[i].get_type(schema)?)
                                 {
                                     rex_args[i].clone()
                                 } else {
-                                    rex_args[i].cast_to(&fm.args()[i][0], schema)?
+                                    rex_args[i].cast_to(&fm.arg_types()[i][0], schema)?
                                 };
                                 safe_args.push(expr)
                             }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -912,7 +912,7 @@ mod tests {
             let fm = Arc::new(FunctionMeta::new(
                 name.to_string(),
                 vec![valid_types],
-                DataType::Float64,
+                Arc::new(|_, _| Ok(DataType::Float64)),
                 fnc_type,
             ));
 

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -228,6 +228,6 @@ pub fn max(expr: Expr) -> Expr {
     Expr::AggregateFunction {
         name: "MAX".to_owned(),
         args: vec![expr],
-        return_type: DataType::Float64,
+        return_type: Arc::new(|_, _| Ok(DataType::Float64)),
     }
 }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -207,7 +207,7 @@ fn create_ctx() -> Result<ExecutionContext> {
     // register a custom UDF
     ctx.register_udf(ScalarFunction::new(
         "custom_sqrt",
-        vec![Field::new("n", DataType::Float64, true)],
+        vec![vec![DataType::Float64]],
         DataType::Float64,
         Arc::new(custom_sqrt),
     ));

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -290,7 +290,7 @@ fn create_ctx() -> Result<ExecutionContext> {
     ctx.register_udf(ScalarFunction::new(
         "custom_sqrt",
         vec![vec![DataType::Float64]],
-        DataType::Float64,
+        Arc::new(|_, _| Ok(DataType::Float64)),
         Arc::new(custom_sqrt),
     ));
 
@@ -302,7 +302,7 @@ fn create_ctx() -> Result<ExecutionContext> {
             vec![DataType::Float32, DataType::Float64],
             vec![DataType::Float64, DataType::Float64],
         ],
-        DataType::Float64,
+        Arc::new(|_, _| Ok(DataType::Float64)),
         Arc::new(custom_add),
     ));
 


### PR DESCRIPTION
This PR is done on top of #7971 , 

Its current runtime consequence is that all our math functions now return float32 or float64 depending on their incoming column (and use float32 for other numeric types). Its API consequences is that it allows to register UDFs of variable return types.

This PR hits both physical plans and logical plans, and abstracts a bit the typing of some of our structs. In particular, it introduces a new trait that only cares about the return datatype of an object (PhysicalExpr and LogicalExpr).