### PR TITLE
ARROW-9757: [Rust] [DataFusion] Add prelude.rs

### DIFF
--- a/rust/datafusion/examples/csv_sql.rs
+++ b/rust/datafusion/examples/csv_sql.rs
@@ -17,9 +17,8 @@
 
 use arrow::util::pretty;
 
-use datafusion::datasource::csv::CsvReadOptions;
 use datafusion::error::Result;
-use datafusion::ExecutionContext;
+use datafusion::prelude::*;
 
 /// This example demonstrates executing a simple query against an Arrow data source (CSV) and
 /// fetching results

--- a/rust/datafusion/examples/dataframe.rs
+++ b/rust/datafusion/examples/dataframe.rs
@@ -16,9 +16,9 @@
 // under the License.
 
 use arrow::util::pretty;
+
 use datafusion::error::Result;
-use datafusion::logicalplan::{col, lit};
-use datafusion::ExecutionContext;
+use datafusion::prelude::*;
 
 /// This example demonstrates executing a simple query against an Arrow data source (Parquet) and
 /// fetching results, using the DataFrame trait

--- a/rust/datafusion/examples/flight_server.rs
+++ b/rust/datafusion/examples/flight_server.rs
@@ -23,7 +23,7 @@ use tonic::{Request, Response, Status, Streaming};
 
 use datafusion::datasource::parquet::ParquetTable;
 use datafusion::datasource::TableProvider;
-use datafusion::execution::context::ExecutionContext;
+use datafusion::prelude::*;
 
 use arrow_flight::{
     flight_service_server::FlightService, flight_service_server::FlightServiceServer,

--- a/rust/datafusion/examples/memory_table_api.rs
+++ b/rust/datafusion/examples/memory_table_api.rs
@@ -25,8 +25,7 @@ use arrow::util::pretty;
 
 use datafusion::datasource::MemTable;
 use datafusion::error::Result;
-use datafusion::execution::context::ExecutionContext;
-use datafusion::logicalplan::{col, lit};
+use datafusion::prelude::*;
 
 /// This example demonstrates basic uses of the Table API on an in-memory table
 fn main() -> Result<()> {

--- a/rust/datafusion/examples/parquet_sql.rs
+++ b/rust/datafusion/examples/parquet_sql.rs
@@ -16,8 +16,9 @@
 // under the License.
 
 use arrow::util::pretty;
+
 use datafusion::error::Result;
-use datafusion::execution::context::ExecutionContext;
+use datafusion::prelude::*;
 
 /// This example demonstrates executing a simple query against an Arrow data source (Parquet) and
 /// fetching results

--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -35,10 +35,8 @@ use std::sync::Arc;
 /// The query can be executed by calling the `collect` method.
 ///
 /// ```
-/// # use datafusion::ExecutionContext;
+/// # use datafusion::prelude::*;
 /// # use datafusion::error::Result;
-/// # use datafusion::execution::physical_plan::csv::CsvReadOptions;
-/// # use datafusion::logicalplan::col;
 /// # fn main() -> Result<()> {
 /// let mut ctx = ExecutionContext::new();
 /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
@@ -54,9 +52,8 @@ pub trait DataFrame {
     /// specified columns.
     ///
     /// ```
-    /// # use datafusion::ExecutionContext;
+    /// # use datafusion::prelude::*;
     /// # use datafusion::error::Result;
-    /// # use datafusion::execution::physical_plan::csv::CsvReadOptions;
     /// # fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
@@ -69,10 +66,8 @@ pub trait DataFrame {
     /// Create a projection based on arbitrary expressions.
     ///
     /// ```
-    /// # use datafusion::ExecutionContext;
+    /// # use datafusion::prelude::*;
     /// # use datafusion::error::Result;
-    /// # use datafusion::execution::physical_plan::csv::CsvReadOptions;
-    /// # use datafusion::logicalplan::col;
     /// # fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
@@ -85,10 +80,8 @@ pub trait DataFrame {
     /// Filter a DataFrame to only include rows that match the specified filter expression.
     ///
     /// ```
-    /// # use datafusion::ExecutionContext;
+    /// # use datafusion::prelude::*;
     /// # use datafusion::error::Result;
-    /// # use datafusion::execution::physical_plan::csv::CsvReadOptions;
-    /// # use datafusion::logicalplan::col;
     /// # fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
@@ -101,10 +94,8 @@ pub trait DataFrame {
     /// Perform an aggregate query with optional grouping expressions.
     ///
     /// ```
-    /// # use datafusion::ExecutionContext;
+    /// # use datafusion::prelude::*;
     /// # use datafusion::error::Result;
-    /// # use datafusion::execution::physical_plan::csv::CsvReadOptions;
-    /// # use datafusion::logicalplan::col;
     /// # fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
@@ -126,10 +117,8 @@ pub trait DataFrame {
     /// Limit the number of rows returned from this DataFrame.
     ///
     /// ```
-    /// # use datafusion::ExecutionContext;
+    /// # use datafusion::prelude::*;
     /// # use datafusion::error::Result;
-    /// # use datafusion::execution::physical_plan::csv::CsvReadOptions;
-    /// # use datafusion::logicalplan::col;
     /// # fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
@@ -143,10 +132,8 @@ pub trait DataFrame {
     /// a sort expression by calling its [sort](../logicalplan/enum.Expr.html#method.sort) method.
     ///
     /// ```
-    /// # use datafusion::ExecutionContext;
+    /// # use datafusion::prelude::*;
     /// # use datafusion::error::Result;
-    /// # use datafusion::execution::physical_plan::csv::CsvReadOptions;
-    /// # use datafusion::logicalplan::col;
     /// # fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
@@ -159,10 +146,8 @@ pub trait DataFrame {
     /// Executes this DataFrame and collects all results into a vector of RecordBatch.
     ///
     /// ```
-    /// # use datafusion::ExecutionContext;
+    /// # use datafusion::prelude::*;
     /// # use datafusion::error::Result;
-    /// # use datafusion::execution::physical_plan::csv::CsvReadOptions;
-    /// # use datafusion::logicalplan::col;
     /// # fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
@@ -176,10 +161,8 @@ pub trait DataFrame {
     /// where each column has a name, data type, and nullability attribute.
 
     /// ```
-    /// # use datafusion::ExecutionContext;
+    /// # use datafusion::prelude::*;
     /// # use datafusion::error::Result;
-    /// # use datafusion::execution::physical_plan::csv::CsvReadOptions;
-    /// # use datafusion::logicalplan::col;
     /// # fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -60,31 +60,34 @@ use crate::sql::{
 /// * Execution a SQL query
 ///
 /// The following example demonstrates how to use the context to execute a query against a CSV
-/// data source:
+/// data source using the DataFrame API:
 ///
 /// ```
-/// use datafusion::ExecutionContext;
-/// use datafusion::execution::physical_plan::csv::CsvReadOptions;
-/// use datafusion::logicalplan::col;
-///
+/// use datafusion::prelude::*;
+/// # use datafusion::error::Result;
+/// # fn main() -> Result<()> {
 /// let mut ctx = ExecutionContext::new();
-/// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new()).unwrap();
-/// let df = df.filter(col("a").lt_eq(col("b"))).unwrap()
-///            .aggregate(vec![col("a")], vec![df.min(col("b")).unwrap()]).unwrap()
-///            .limit(100).unwrap();
+/// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
+/// let df = df.filter(col("a").lt_eq(col("b")))?
+///            .aggregate(vec![col("a")], vec![df.min(col("b"))?])?
+///            .limit(100)?;
 /// let results = df.collect();
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// The following example demonstrates how to execute the same query using SQL:
 ///
 /// ```
-/// use datafusion::ExecutionContext;
-/// use datafusion::execution::physical_plan::csv::CsvReadOptions;
-/// use datafusion::logicalplan::col;
+/// use datafusion::prelude::*;
 ///
+/// # use datafusion::error::Result;
+/// # fn main() -> Result<()> {
 /// let mut ctx = ExecutionContext::new();
-/// ctx.register_csv("example", "tests/example.csv", CsvReadOptions::new()).unwrap();
-/// let results = ctx.sql("SELECT a, MIN(b) FROM example GROUP BY a LIMIT 100").unwrap();
+/// ctx.register_csv("example", "tests/example.csv", CsvReadOptions::new())?;
+/// let results = ctx.sql("SELECT a, MIN(b) FROM example GROUP BY a LIMIT 100")?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct ExecutionContext {
     /// Internal state for the context

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -15,17 +15,46 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#![warn(missing_docs)]
+
 //! DataFusion is an extensible query execution framework that uses
 //! Apache Arrow as the memory model.
 //!
-//! DataFusion supports both SQL and a Table/DataFrame-style API for building logical query plans
+//! DataFusion supports both SQL and a DataFrame API for building logical query plans
 //! and also provides a query optimizer and execution engine capable of parallel execution
 //! against partitioned data sources (CSV and Parquet) using threads.
 //!
 //! DataFusion currently supports simple projection, selection, and aggregate queries.
-
-#![warn(missing_docs)]
-
+//!
+/// [ExecutionContext](../execution/context/struct.ExecutionContext.html) is the main interface
+/// for executing queries with DataFusion.
+///
+/// The following example demonstrates how to use the context to execute a query against a CSV
+/// data source using the DataFrame API:
+///
+/// ```
+/// # use datafusion::prelude::*;
+/// # use datafusion::error::Result;
+/// # fn main() -> Result<()> {
+/// let mut ctx = ExecutionContext::new();
+/// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
+/// let df = df.filter(col("a").lt_eq(col("b")))?
+///            .aggregate(vec![col("a")], vec![df.min(col("b"))?])?
+///            .limit(100)?;
+/// let results = df.collect();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// The following example demonstrates how to execute the same query using SQL:
+///
+/// ```
+/// use datafusion::prelude::*;
+///
+/// let mut ctx = ExecutionContext::new();
+/// ctx.register_csv("example", "tests/example.csv", CsvReadOptions::new()).unwrap();
+/// let results = ctx.sql("SELECT a, MIN(b) FROM example GROUP BY a LIMIT 100").unwrap();
+/// ```
 extern crate arrow;
 extern crate sqlparser;
 
@@ -35,9 +64,8 @@ pub mod error;
 pub mod execution;
 pub mod logicalplan;
 pub mod optimizer;
+pub mod prelude;
 pub mod sql;
-
-pub use execution::context::ExecutionContext;
 
 #[cfg(test)]
 pub mod test;

--- a/rust/datafusion/src/prelude.rs
+++ b/rust/datafusion/src/prelude.rs
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.pub},
+
+//! A "prelude" for users of the datafusion crate.
+//!
+//! Like the standard library's prelude, this module simplifies importing of
+//! common items. Unlike the standard prelude, the contents of this module must
+//! be imported manually:
+//!
+//! ```
+//! use datafusion::prelude::*;
+//! ```
+
+pub use crate::dataframe::DataFrame;
+pub use crate::execution::context::{ExecutionConfig, ExecutionContext};
+pub use crate::execution::physical_plan::csv::CsvReadOptions;
+pub use crate::logicalplan::{col, lit};


### PR DESCRIPTION
Users can now just add `use datafusion::prelude::*;` to bring in some key items such as `ExecutionContext` to make it easier to get started.

Rustdocs updated and improved as well.