### PR TITLE
ARROW-9758 [Rust] [DataFusion] Rename PhysicalPlannerImpl to DefaultPhysicalPlanner

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -37,7 +37,7 @@ use crate::execution::dataframe_impl::DataFrameImpl;
 use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::csv::CsvReadOptions;
 use crate::execution::physical_plan::merge::MergeExec;
-use crate::execution::physical_plan::planner::PhysicalPlannerImpl;
+use crate::execution::physical_plan::planner::DefaultPhysicalPlanner;
 use crate::execution::physical_plan::scalar_functions;
 use crate::execution::physical_plan::udf::ScalarFunction;
 use crate::execution::physical_plan::ExecutionPlan;
@@ -361,7 +361,7 @@ impl ExecutionContext {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let planner: Arc<dyn PhysicalPlanner> = match self.config().physical_planner {
             Some(planner) => planner,
-            None => Arc::new(PhysicalPlannerImpl::default()),
+            None => Arc::new(DefaultPhysicalPlanner::default()),
         };
         planner.create_physical_plan(logical_plan, self.state.clone())
     }

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -33,7 +33,8 @@ use arrow::{
 };
 use udf::ScalarFunction;
 
-/// Physical query planner
+/// Physical query planner that converts a `LogicalPlan` to an
+/// `ExecutionPlan` suitable for execution.
 pub trait PhysicalPlanner {
     /// Create a physical plan from a logical plan
     fn create_physical_plan(

--- a/rust/datafusion/src/execution/physical_plan/planner.rs
+++ b/rust/datafusion/src/execution/physical_plan/planner.rs
@@ -43,17 +43,18 @@ use crate::logicalplan::{Expr, LogicalPlan, PlanType, StringifiedPlan};
 use arrow::compute::SortOptions;
 use arrow::datatypes::Schema;
 
-/// Default physical query planner
-pub struct PhysicalPlannerImpl {}
+/// Default single node physical query planner that converts a
+/// `LogicalPlan` to an `ExecutionPlan` suitable for execution.
+pub struct DefaultPhysicalPlanner {}
 
-impl Default for PhysicalPlannerImpl {
+impl Default for DefaultPhysicalPlanner {
     /// Create an implementation of the physical planner
     fn default() -> Self {
         Self {}
     }
 }
 
-impl PhysicalPlanner for PhysicalPlannerImpl {
+impl PhysicalPlanner for DefaultPhysicalPlanner {
     /// Create a physical plan from a logical plan
     fn create_physical_plan(
         &self,
@@ -326,7 +327,7 @@ impl PhysicalPlanner for PhysicalPlannerImpl {
     }
 }
 
-impl PhysicalPlannerImpl {
+impl DefaultPhysicalPlanner {
     /// Create a physical expression from a logical expression
     pub fn create_physical_expr(
         &self,


### PR DESCRIPTION
Proposed follow up to  https://github.com/apache/arrow/pull/7975 -- rename `PhysicalPlannerImpl` to `DefaultPhysicalPlanner` to better describe what it is and that the design allows for more than one.

I considered a more specific name like `SingleNodeMultiThreadedPlanner` but I felt a lot of that was a function of the Physical nodes that got created rather than the planner itself. 