### PR TITLE
ARROW-9744: [Python] Fix build failure on aarch64

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -114,6 +114,9 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
 
   # Arm64 architectures and extensions can lead to exploding combinations.
   # So set it directly through cmake command line.
+  #
+  # If you change this, you need to change the definition in
+  # python/CMakeLists.txt too.
   define_option_string(ARROW_ARMV8_ARCH
                        "Arm64 arch and extensions"
                        "armv8-a" # Default

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -97,6 +97,11 @@ include(BuildUtils)
 # Cython generated code emits way to many warnings at CHECKIN and EVERYTHING
 set(BUILD_WARNING_LEVEL "PRODUCTION")
 
+# This must be synchronized with the definition in
+# cpp/cmake_modules/DefineOptions.cmake.
+set(ARROW_ARMV8_ARCH
+    "armv8-a"
+    CACHE STRING "Arm64 arch and extensions: armv8-a, armv8-a or armv8-a+crc+crypto")
 include(SetupCxxFlags)
 
 # Add common flags


### PR DESCRIPTION
pyarrow uses only SetupCxxFlags.cmake. It doesn't use
DefineOptions.cmake. We need to define ARROW_ARMV8_ARCH in pyarrow
too. It's defined in DefineOptions.cmake.