### PR TITLE
ARROW-9783: [Rust] [DataFusion] Remove aggregate expression data type

### DIFF
--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -41,7 +41,7 @@ use std::sync::Arc;
 /// let mut ctx = ExecutionContext::new();
 /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
 /// let df = df.filter(col("a").lt_eq(col("b")))?
-///            .aggregate(vec![col("a")], vec![df.min(col("b"))?])?
+///            .aggregate(vec![col("a")], vec![min(col("b"))?])?
 ///            .limit(100)?;
 /// let results = df.collect();
 /// # Ok(())
@@ -101,10 +101,10 @@ pub trait DataFrame {
     /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
     ///
     /// // The following use is the equivalent of "SELECT MIN(b) GROUP BY a"
-    /// let _ = df.aggregate(vec![col("a")], vec![df.min(col("b"))?])?;
+    /// let _ = df.aggregate(vec![col("a")], vec![min(col("b"))?])?;
     ///
     /// // The following use is the equivalent of "SELECT MIN(b)"
-    /// let _ = df.aggregate(vec![], vec![df.min(col("b"))?])?;
+    /// let _ = df.aggregate(vec![], vec![min(col("b"))?])?;
     /// # Ok(())
     /// # }
     /// ```
@@ -174,19 +174,4 @@ pub trait DataFrame {
 
     /// Return the logical plan represented by this DataFrame.
     fn to_logical_plan(&self) -> LogicalPlan;
-
-    /// Create an expression to represent the min() aggregate function
-    fn min(&self, expr: Expr) -> Result<Expr>;
-
-    /// Create an expression to represent the max() aggregate function
-    fn max(&self, expr: Expr) -> Result<Expr>;
-
-    /// Create an expression to represent the sum() aggregate function
-    fn sum(&self, expr: Expr) -> Result<Expr>;
-
-    /// Create an expression to represent the avg() aggregate function
-    fn avg(&self, expr: Expr) -> Result<Expr>;
-
-    /// Create an expression to represent the count() aggregate function
-    fn count(&self, expr: Expr) -> Result<Expr>;
 }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -69,7 +69,7 @@ use crate::sql::{
 /// let mut ctx = ExecutionContext::new();
 /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
 /// let df = df.filter(col("a").lt_eq(col("b")))?
-///            .aggregate(vec![col("a")], vec![df.min(col("b"))?])?
+///            .aggregate(vec![col("a")], vec![min(col("b"))?])?
 ///            .limit(100)?;
 /// let results = df.collect();
 /// # Ok(())
@@ -928,10 +928,7 @@ mod tests {
         ]));
 
         let plan = LogicalPlanBuilder::scan("default", "test", schema.as_ref(), None)?
-            .aggregate(
-                vec![col("c1")],
-                vec![aggregate_expr("SUM", col("c2"), DataType::UInt32)],
-            )?
+            .aggregate(vec![col("c1")], vec![aggregate_expr("SUM", col("c2"))])?
             .project(vec![col("c1"), col("SUM(c2)").alias("total_salary")])?
             .build()?;
 

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -39,7 +39,7 @@
 /// let mut ctx = ExecutionContext::new();
 /// let df = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
 /// let df = df.filter(col("a").lt_eq(col("b")))?
-///            .aggregate(vec![col("a")], vec![df.min(col("b"))?])?
+///            .aggregate(vec![col("a")], vec![min(col("b"))?])?
 ///            .limit(100)?;
 /// let results = df.collect();
 /// # Ok(())

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -166,10 +166,7 @@ mod tests {
             // filter clause needs the type coercion rule applied
             .filter(col("c7").lt(lit(5_u8)))?
             .project(vec![col("c1"), col("c2")])?
-            .aggregate(
-                vec![col("c1")],
-                vec![aggregate_expr("SUM", col("c2"), DataType::Int64)],
-            )?
+            .aggregate(vec![col("c1")], vec![aggregate_expr("SUM", col("c2"))])?
             .sort(vec![col("c1")])?
             .limit(10)?
             .build()?;

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -341,11 +341,8 @@ pub fn rewrite_expression(expr: &Expr, expressions: &Vec<Expr>) -> Result<Expr> 
             return_type: return_type.clone(),
             args: expressions.clone(),
         }),
-        Expr::AggregateFunction {
-            name, return_type, ..
-        } => Ok(Expr::AggregateFunction {
+        Expr::AggregateFunction { name, .. } => Ok(Expr::AggregateFunction {
             name: name.clone(),
-            return_type: return_type.clone(),
             args: expressions.clone(),
         }),
         Expr::Cast { data_type, .. } => Ok(Expr::Cast {

--- a/rust/datafusion/src/prelude.rs
+++ b/rust/datafusion/src/prelude.rs
@@ -28,4 +28,4 @@
 pub use crate::dataframe::DataFrame;
 pub use crate::execution::context::{ExecutionConfig, ExecutionContext};
 pub use crate::execution::physical_plan::csv::CsvReadOptions;
-pub use crate::logicalplan::{col, lit};
+pub use crate::logicalplan::{avg, col, count, lit, max, min, sum};

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -486,14 +486,9 @@ impl<S: SchemaProvider> SqlToRel<S> {
                             .map(|a| self.sql_to_rex(a, schema))
                             .collect::<Result<Vec<Expr>>>()?;
 
-                        // return type is same as the argument type for these aggregate
-                        // functions
-                        let return_type = rex_args[0].get_type(schema)?.clone();
-
                         Ok(Expr::AggregateFunction {
                             name: name.clone(),
                             args: rex_args,
-                            return_type,
                         })
                     }
                     "count" => {
@@ -510,7 +505,6 @@ impl<S: SchemaProvider> SqlToRel<S> {
                         Ok(Expr::AggregateFunction {
                             name: name.clone(),
                             args: rex_args,
-                            return_type: DataType::UInt64,
                         })
                     }
                     _ => match self.schema_provider.get_function_meta(&name) {

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -228,6 +228,5 @@ pub fn max(expr: Expr) -> Expr {
     Expr::AggregateFunction {
         name: "MAX".to_owned(),
         args: vec![expr],
-        return_type: DataType::Float64,
     }
 }


### PR DESCRIPTION
This is a step towards cleaning up the handling of aggregate expressions and achieves the following:

- It is now possible to construct a logical aggregate expression without specifying a return data type, so we can now just say `min(col("foo"))` for example.
- Removes the aggregate function methods from the `DataFrame` trait since they are no longer needed
- Removes duplicate logic from `expr_to_field` that was determining the data type of expressions rather than just calling `expr.get_type`
- Removes hard-coded return types from tests
- Adds the new `min`, `max`, `avg`, `count`, `sum` functions to prelude.rs

There is more to do in the future, such as allowing custom aggregate UDFs to be defined.