### PR TITLE
ARROW-9784: [Rust][DataFusion] Make running TPCH benchmark repeatable

### DIFF
--- a/rust/benchmarks/README.md
+++ b/rust/benchmarks/README.md
@@ -23,17 +23,31 @@ This crate contains benchmarks based on popular public data sets and open source
 run real-world benchmarks to help with performance and scalability testing and for comparing performance with other Arrow
 implementations as well as other query engines.
 
-Currently, only DataFusion benchmarks exist, but the plan is to add benchmarks for the arrow, flight, and parquet 
-crates as well. 
+Currently, only DataFusion benchmarks exist, but the plan is to add benchmarks for the arrow, flight, and parquet
+crates as well.
 
 ## Benchmark derived from TPC-H
 
-These benchmarks are derived from the [TPC-H](http://www.tpc.org/tpch/) benchmark. Data for this benchmark can be 
-generated using [tpch-dbgen](https://github.com/databricks/tpch-dbgen).
+These benchmarks are derived from the [TPC-H](http://www.tpc.org/tpch/) benchmark.
+
+Data for this benchmark can be generated using the
+[tpch-dbgen](https://github.com/databricks/tpch-dbgen) tool with a
+command such as the following (`-s 1` means use Scale Factor 1 or ~1 GB of
+data, replace the 1 to change datasize).
+
+```
+cd /mnt/tpch-dbgen
+dbgen -vf -s 1
+```
+
+The benchmark can then be run (assuming the data created from `dbgen` is in `/mnt/tpch-dbgen`) with a command such as:
 
 ```bash
-cargo run --release --bin tpch -- --iterations 3 --path /mnt/tpch/csv --format csv --query 1 --batch-size 4096
+cargo run --release --bin tpch -- --iterations 3 --path /mnt/tpch-dbgen --format tbl --query 1 --batch-size 4096
 ```
+
+The benchmark program also supports csv and parquet file formats
+
 
 ## NYC Taxi Benchmark
 

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -73,6 +73,16 @@ fn main() -> Result<()> {
     let path = opt.path.to_str().unwrap();
 
     match opt.file_format.as_str() {
+        // dbgen creates .tbl ('|' delimited) files
+        "tbl" => {
+            let path = format!("{}/lineitem.tbl", path);
+            let schema = lineitem_schema();
+            let options = CsvReadOptions::new()
+                .schema(&schema)
+                .delimiter(b'|')
+                .file_extension(".tbl");
+            ctx.register_csv("lineitem", &path, options)?
+        }
         "csv" => {
             let path = format!("{}/lineitem", path);
             let schema = lineitem_schema();


### PR DESCRIPTION
While trying to ru the TPCH benchmark introduced in https://github.com/apache/arrow/pull/7946/files, I found that the referenced `tpch-dbgen` program did not produce files in the way that the benchmark wanted.

This PR  updates  the code/instructions to be reproducible