### PR TITLE
ARROW-9660: [C++] Revamp dictionary association in IPC

### DIFF
--- a/cpp/src/arrow/flight/internal.cc
+++ b/cpp/src/arrow/flight/internal.cc
@@ -465,11 +465,9 @@ Status FromProto(const pb::SchemaResult& pb_result, std::string* result) {
 }
 
 Status SchemaToString(const Schema& schema, std::string* out) {
-  // TODO(wesm): Do we care about better memory efficiency here?
   ipc::DictionaryMemo unused_dict_memo;
-  ARROW_ASSIGN_OR_RAISE(
-      std::shared_ptr<Buffer> serialized_schema,
-      ipc::SerializeSchema(schema, &unused_dict_memo, default_memory_pool()));
+  ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> serialized_schema,
+                        ipc::SerializeSchema(schema));
   *out = std::string(reinterpret_cast<const char*>(serialized_schema->data()),
                      static_cast<size_t>(serialized_schema->size()));
   return Status::OK();

--- a/cpp/src/arrow/flight/perf_server.cc
+++ b/cpp/src/arrow/flight/perf_server.cc
@@ -66,6 +66,7 @@ class PerfDataStream : public FlightDataStream {
         total_records_(total_records),
         records_sent_(0),
         schema_(schema),
+        mapper_(*schema),
         arrays_(arrays) {
     batch_ = RecordBatch::Make(schema, batch_length_, arrays_);
   }
@@ -73,8 +74,7 @@ class PerfDataStream : public FlightDataStream {
   std::shared_ptr<Schema> schema() override { return schema_; }
 
   Status GetSchemaPayload(FlightPayload* payload) override {
-    return ipc::GetSchemaPayload(*schema_, ipc_options_, &dictionary_memo_,
-                                 &payload->ipc_message);
+    return ipc::GetSchemaPayload(*schema_, ipc_options_, mapper_, &payload->ipc_message);
   }
 
   Status Next(FlightPayload* payload) override {
@@ -112,7 +112,7 @@ class PerfDataStream : public FlightDataStream {
   const int64_t total_records_;
   int64_t records_sent_;
   std::shared_ptr<Schema> schema_;
-  ipc::DictionaryMemo dictionary_memo_;
+  ipc::DictionaryFieldMapper mapper_;
   ipc::IpcWriteOptions ipc_options_;
   std::shared_ptr<RecordBatch> batch_;
   ArrayVector arrays_;

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -596,7 +596,7 @@ TEST_F(TestCudaArrowIpc, DictionaryWriteRead) {
   ASSERT_OK(ipc::test::MakeDictionary(&batch));
 
   ipc::DictionaryMemo dictionary_memo;
-  ASSERT_OK(ipc::CollectDictionaries(*batch, &dictionary_memo));
+  ASSERT_OK(ipc::internal::CollectDictionaries(*batch, &dictionary_memo));
 
   std::shared_ptr<CudaBuffer> device_serialized;
   ASSERT_OK_AND_ASSIGN(device_serialized, SerializeRecordBatch(*batch, context_.get()));

--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -46,6 +46,8 @@ using internal::checked_cast;
 
 namespace ipc {
 
+using internal::FieldPosition;
+
 // ----------------------------------------------------------------------
 // DictionaryFieldMapper implementation
 

--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -30,6 +31,14 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging.h"
+
+namespace std {
+template <>
+struct hash<arrow::FieldPath> {
+  size_t operator()(const arrow::FieldPath& path) const { return path.hash(); }
+};
+}  // namespace std
 
 namespace arrow {
 
@@ -38,163 +47,204 @@ using internal::checked_cast;
 namespace ipc {
 
 // ----------------------------------------------------------------------
+// DictionaryFieldMapper implementation
 
-DictionaryMemo::DictionaryMemo() {}
+struct DictionaryFieldMapper::Impl {
+  using FieldPathMap = std::unordered_map<FieldPath, int64_t>;
 
-Status DictionaryMemo::GetDictionaryType(int64_t id,
-                                         std::shared_ptr<DataType>* type) const {
-  auto it = id_to_type_.find(id);
-  if (it == id_to_type_.end()) {
+  FieldPathMap field_path_to_id;
+
+  void ImportSchema(const Schema& schema) {
+    ImportFields(FieldPosition(), schema.fields());
+  }
+
+  Status AddSchemaFields(const Schema& schema) {
+    if (!field_path_to_id.empty()) {
+      return Status::Invalid("Non-empty DictionaryFieldMapper");
+    }
+    ImportSchema(schema);
+    return Status::OK();
+  }
+
+  Status AddField(int64_t id, std::vector<int> field_path) {
+    const auto pair = field_path_to_id.emplace(FieldPath(std::move(field_path)), id);
+    if (!pair.second) {
+      return Status::KeyError("Field already mapped to id");
+    }
+    return Status::OK();
+  }
+
+  Result<int64_t> GetFieldId(std::vector<int> field_path) const {
+    const auto it = field_path_to_id.find(FieldPath(std::move(field_path)));
+    if (it == field_path_to_id.end()) {
+      return Status::KeyError("Dictionary field not found");
+    }
+    return it->second;
+  }
+
+  int num_fields() const { return static_cast<int>(field_path_to_id.size()); }
+
+ private:
+  void ImportFields(const FieldPosition& pos,
+                    const std::vector<std::shared_ptr<Field>>& fields) {
+    for (int i = 0; i < static_cast<int>(fields.size()); ++i) {
+      ImportField(pos.child(i), *fields[i]);
+    }
+  }
+
+  void ImportField(const FieldPosition& pos, const Field& field) {
+    const DataType* type = field.type().get();
+    if (type->id() == Type::EXTENSION) {
+      type = checked_cast<const ExtensionType&>(*type).storage_type().get();
+    }
+    if (type->id() == Type::DICTIONARY) {
+      InsertPath(pos);
+      // Import nested dictionaries
+      ImportFields(pos,
+                   checked_cast<const DictionaryType&>(*type).value_type()->fields());
+    } else {
+      ImportFields(pos, type->fields());
+    }
+  }
+
+  void InsertPath(const FieldPosition& pos) {
+    const int64_t id = field_path_to_id.size();
+    const auto pair = field_path_to_id.emplace(FieldPath(pos.path()), id);
+    DCHECK(pair.second);  // was inserted
+    ARROW_UNUSED(pair);
+  }
+};
+
+DictionaryFieldMapper::DictionaryFieldMapper() : impl_(new Impl) {}
+
+DictionaryFieldMapper::DictionaryFieldMapper(const Schema& schema) : impl_(new Impl) {
+  impl_->ImportSchema(schema);
+}
+
+DictionaryFieldMapper::~DictionaryFieldMapper() {}
+
+Status DictionaryFieldMapper::AddSchemaFields(const Schema& schema) {
+  return impl_->AddSchemaFields(schema);
+}
+
+Status DictionaryFieldMapper::AddField(int64_t id, std::vector<int> field_path) {
+  return impl_->AddField(id, std::move(field_path));
+}
+
+Result<int64_t> DictionaryFieldMapper::GetFieldId(std::vector<int> field_path) const {
+  return impl_->GetFieldId(std::move(field_path));
+}
+
+int DictionaryFieldMapper::num_fields() const { return impl_->num_fields(); }
+
+// ----------------------------------------------------------------------
+// DictionaryMemo implementation
+
+struct DictionaryMemo::Impl {
+  // Map of dictionary id to dictionary array
+  std::unordered_map<int64_t, std::shared_ptr<ArrayData>> id_to_dictionary_;
+  std::unordered_map<int64_t, std::shared_ptr<DataType>> id_to_type_;
+  DictionaryFieldMapper mapper_;
+};
+
+DictionaryMemo::DictionaryMemo() : impl_(new Impl()) {}
+
+DictionaryMemo::~DictionaryMemo() {}
+
+DictionaryFieldMapper& DictionaryMemo::fields() { return impl_->mapper_; }
+
+const DictionaryFieldMapper& DictionaryMemo::fields() const { return impl_->mapper_; }
+
+Result<std::shared_ptr<DataType>> DictionaryMemo::GetDictionaryType(int64_t id) const {
+  const auto it = impl_->id_to_type_.find(id);
+  if (it == impl_->id_to_type_.end()) {
     return Status::KeyError("No record of dictionary type with id ", id);
   }
-  *type = it->second;
-  return Status::OK();
+  return it->second;
 }
 
 // Returns KeyError if dictionary not found
-Status DictionaryMemo::GetDictionary(int64_t id,
-                                     std::shared_ptr<Array>* dictionary) const {
-  auto it = id_to_dictionary_.find(id);
-  if (it == id_to_dictionary_.end()) {
+Result<std::shared_ptr<ArrayData>> DictionaryMemo::GetDictionary(int64_t id) const {
+  const auto it = impl_->id_to_dictionary_.find(id);
+  if (it == impl_->id_to_dictionary_.end()) {
     return Status::KeyError("Dictionary with id ", id, " not found");
   }
-  *dictionary = it->second;
-  return Status::OK();
+  return it->second;
 }
 
-Status DictionaryMemo::AddFieldInternal(int64_t id, const std::shared_ptr<Field>& field) {
-  field_to_id_[field.get()] = id;
-
-  auto field_type = field->type();
-  if (field_type->id() == Type::EXTENSION) {
-    field_type = checked_cast<const ExtensionType&>(*field_type).storage_type();
-  }
-  if (field_type->id() != Type::DICTIONARY) {
-    return Status::Invalid("Field type was not DictionaryType: ", field_type->ToString());
-  }
-
-  std::shared_ptr<DataType> value_type =
-      checked_cast<const DictionaryType&>(*field_type).value_type();
-
-  // Add the value type for the dictionary
-  auto it = id_to_type_.find(id);
-  if (it != id_to_type_.end()) {
-    if (!it->second->Equals(*value_type)) {
-      return Status::Invalid("Field with dictionary id 0 seen but had type ",
-                             it->second->ToString(), "and not ", value_type->ToString());
-    }
-  } else {
-    // Newly-observed dictionary id
-    id_to_type_[id] = value_type;
+Status DictionaryMemo::AddDictionaryType(int64_t id,
+                                         const std::shared_ptr<DataType>& type) {
+  // AddDictionaryType expects the dict value type
+  DCHECK_NE(type->id(), Type::DICTIONARY);
+  const auto pair = impl_->id_to_type_.emplace(id, type);
+  if (!pair.second && !pair.first->second->Equals(*type)) {
+    return Status::KeyError("Conflicting dictionary types for id ", id);
   }
   return Status::OK();
-}
-
-Status DictionaryMemo::GetOrAssignId(const std::shared_ptr<Field>& field, int64_t* out) {
-  auto it = field_to_id_.find(field.get());
-  if (it != field_to_id_.end()) {
-    // Field already observed, return the id
-    *out = it->second;
-  } else {
-    int64_t new_id = *out = static_cast<int64_t>(field_to_id_.size());
-    RETURN_NOT_OK(AddFieldInternal(new_id, field));
-  }
-  return Status::OK();
-}
-
-Status DictionaryMemo::AddField(int64_t id, const std::shared_ptr<Field>& field) {
-  auto it = field_to_id_.find(field.get());
-  if (it != field_to_id_.end()) {
-    return Status::KeyError("Field is already in memo: ", field->ToString());
-  } else {
-    RETURN_NOT_OK(AddFieldInternal(id, field));
-    return Status::OK();
-  }
-}
-
-Status DictionaryMemo::GetId(const Field* field, int64_t* id) const {
-  auto it = field_to_id_.find(field);
-  if (it != field_to_id_.end()) {
-    // Field recorded, return the id
-    *id = it->second;
-    return Status::OK();
-  } else {
-    return Status::KeyError("Field with memory address ",
-                            reinterpret_cast<int64_t>(field), " not found");
-  }
-}
-
-bool DictionaryMemo::HasDictionary(const Field& field) const {
-  auto it = field_to_id_.find(&field);
-  return it != field_to_id_.end();
 }
 
 bool DictionaryMemo::HasDictionary(int64_t id) const {
-  auto it = id_to_dictionary_.find(id);
-  return it != id_to_dictionary_.end();
+  const auto it = impl_->id_to_dictionary_.find(id);
+  return it != impl_->id_to_dictionary_.end();
 }
 
 Status DictionaryMemo::AddDictionary(int64_t id,
-                                     const std::shared_ptr<Array>& dictionary) {
+                                     const std::shared_ptr<ArrayData>& dictionary) {
   if (HasDictionary(id)) {
     return Status::KeyError("Dictionary with id ", id, " already exists");
   }
-  id_to_dictionary_[id] = dictionary;
+  impl_->id_to_dictionary_[id] = dictionary;
   return Status::OK();
 }
 
 Status DictionaryMemo::AddDictionaryDelta(int64_t id,
-                                          const std::shared_ptr<Array>& dictionary,
+                                          const std::shared_ptr<ArrayData>& dictionary,
                                           MemoryPool* pool) {
-  std::shared_ptr<Array> originalDict, combinedDict;
-  RETURN_NOT_OK(GetDictionary(id, &originalDict));
-  ArrayVector dictsToCombine{originalDict, dictionary};
-  ARROW_ASSIGN_OR_RAISE(combinedDict, Concatenate(dictsToCombine, pool));
-  id_to_dictionary_[id] = combinedDict;
+  ARROW_ASSIGN_OR_RAISE(auto original_dict, GetDictionary(id));
+
+  // XXX This won't work if there is an unresolved nested dictionary.
+  // We could expose a ArrayData concatenation API, but then we wouldn't be able
+  // to validate below.
+  ArrayVector to_combine{MakeArray(original_dict), MakeArray(dictionary)};
+
+  // Validate the dictionaries for safe concatenation
+  for (const auto& array : to_combine) {
+    RETURN_NOT_OK(array->Validate());
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto combined_dict, Concatenate(to_combine, pool));
+  impl_->id_to_dictionary_[id] = combined_dict->data();
   return Status::OK();
 }
 
-Status DictionaryMemo::AddOrReplaceDictionary(int64_t id,
-                                              const std::shared_ptr<Array>& dictionary) {
-  id_to_dictionary_[id] = dictionary;
+Status DictionaryMemo::AddOrReplaceDictionary(
+    int64_t id, const std::shared_ptr<ArrayData>& dictionary) {
+  impl_->id_to_dictionary_[id] = dictionary;
   return Status::OK();
-}
-
-DictionaryMemo::DictionaryVector DictionaryMemo::dictionaries() const {
-  // Sort dictionaries by ascending id.   This ensures that, in the case
-  // of nested dictionaries, inner dictionaries are emitted before outer
-  // dictionaries.
-  // XXX This shouldn't be required.  On the IPC write path, the
-  // DictionaryMemo only needs to store a vector of dictionaries
-  // (by-id lookups are only needed on the IPC read path).
-  using DictEntry = typename DictionaryVector::value_type;
-
-  std::vector<DictEntry> dict_entries(id_to_dictionary_.size());
-  std::copy(id_to_dictionary_.begin(), id_to_dictionary_.end(), dict_entries.begin());
-
-  const auto compare_entries = [](const DictEntry& l, const DictEntry& r) {
-    return l.first < r.first;
-  };
-  std::sort(dict_entries.begin(), dict_entries.end(), compare_entries);
-  return dict_entries;
 }
 
 // ----------------------------------------------------------------------
 // CollectDictionaries implementation
 
-struct DictionaryCollector {
-  DictionaryMemo* dictionary_memo_;
+namespace {
 
-  Status WalkChildren(const DataType& type, const Array& array) {
+struct DictionaryCollector {
+  const DictionaryFieldMapper& mapper_;
+  DictionaryVector dictionaries_;
+
+  Status WalkChildren(const FieldPosition& position, const DataType& type,
+                      const Array& array) {
     for (int i = 0; i < type.num_fields(); ++i) {
       auto boxed_child = MakeArray(array.data()->child_data[i]);
-      RETURN_NOT_OK(Visit(type.field(i), boxed_child.get()));
+      RETURN_NOT_OK(Visit(position.child(i), type.field(i), boxed_child.get()));
     }
     return Status::OK();
   }
 
-  Status Visit(const std::shared_ptr<Field>& field, const Array* array) {
+  Status Visit(const FieldPosition& position, const std::shared_ptr<Field>& field,
+               const Array* array) {
     const DataType* type = array->type().get();
+
     if (type->id() == Type::EXTENSION) {
       type = checked_cast<const ExtensionType&>(*type).storage_type().get();
       array = checked_cast<const ExtensionArray&>(*array).storage().get();
@@ -202,31 +252,90 @@ struct DictionaryCollector {
     if (type->id() == Type::DICTIONARY) {
       const auto& dict_array = checked_cast<const DictionaryArray&>(*array);
       auto dictionary = dict_array.dictionary();
-      int64_t id = -1;
-      RETURN_NOT_OK(dictionary_memo_->GetOrAssignId(field, &id));
-      RETURN_NOT_OK(dictionary_memo_->AddDictionary(id, dictionary));
 
-      // Traverse the dictionary to gather any nested dictionaries
+      // Traverse the dictionary to first gather any nested dictionaries
+      // (so that they appear in the output before their parent)
       const auto& dict_type = checked_cast<const DictionaryType&>(*type);
-      RETURN_NOT_OK(WalkChildren(*dict_type.value_type(), *dictionary));
+      RETURN_NOT_OK(WalkChildren(position, *dict_type.value_type(), *dictionary));
+
+      // Then record the dictionary itself
+      ARROW_ASSIGN_OR_RAISE(int64_t id, mapper_.GetFieldId(position.path()));
+      dictionaries_.emplace_back(id, dictionary);
     } else {
-      RETURN_NOT_OK(WalkChildren(*type, *array));
+      RETURN_NOT_OK(WalkChildren(position, *type, *array));
     }
     return Status::OK();
   }
 
   Status Collect(const RecordBatch& batch) {
+    FieldPosition position;
     const Schema& schema = *batch.schema();
+    dictionaries_.reserve(mapper_.num_fields());
+
     for (int i = 0; i < schema.num_fields(); ++i) {
-      RETURN_NOT_OK(Visit(schema.field(i), batch.column(i).get()));
+      RETURN_NOT_OK(Visit(position.child(i), schema.field(i), batch.column(i).get()));
     }
     return Status::OK();
   }
 };
 
+struct DictionaryResolver {
+  const DictionaryMemo& memo;
+
+  Status VisitChildren(const ArrayDataVector& data_vector, FieldPosition parent_pos) {
+    int i = 0;
+    for (const auto& data : data_vector) {
+      // Some data entries may be missing if reading only a subset of the schema
+      if (data != nullptr) {
+        RETURN_NOT_OK(VisitField(parent_pos.child(i), data.get()));
+      }
+      ++i;
+    }
+    return Status::OK();
+  }
+
+  Status VisitField(FieldPosition field_pos, ArrayData* data) {
+    const DataType* type = data->type.get();
+    if (type->id() == Type::EXTENSION) {
+      type = checked_cast<const ExtensionType&>(*type).storage_type().get();
+    }
+    if (type->id() == Type::DICTIONARY) {
+      ARROW_ASSIGN_OR_RAISE(const int64_t id, memo.fields().GetFieldId(field_pos.path()));
+      ARROW_ASSIGN_OR_RAISE(data->dictionary, memo.GetDictionary(id));
+      // Resolve nested dictionary data
+      RETURN_NOT_OK(VisitField(field_pos, data->dictionary.get()));
+    }
+    // Resolve child data
+    return VisitChildren(data->child_data, field_pos);
+  }
+};
+
+}  // namespace
+
+Result<DictionaryVector> CollectDictionaries(const RecordBatch& batch,
+                                             const DictionaryFieldMapper& mapper) {
+  DictionaryCollector collector{mapper, {}};
+  RETURN_NOT_OK(collector.Collect(batch));
+  return std::move(collector.dictionaries_);
+}
+
+namespace internal {
+
 Status CollectDictionaries(const RecordBatch& batch, DictionaryMemo* memo) {
-  DictionaryCollector collector{memo};
-  return collector.Collect(batch);
+  RETURN_NOT_OK(memo->fields().AddSchemaFields(*batch.schema()));
+  ARROW_ASSIGN_OR_RAISE(const auto dictionaries,
+                        CollectDictionaries(batch, memo->fields()));
+  for (const auto& pair : dictionaries) {
+    RETURN_NOT_OK(memo->AddDictionary(pair.first, pair.second->data()));
+  }
+  return Status::OK();
+}
+
+}  // namespace internal
+
+Status ResolveDictionaries(const ArrayDataVector& columns, const DictionaryMemo& memo) {
+  DictionaryResolver resolver{memo};
+  return resolver.VisitChildren(columns, FieldPosition());
 }
 
 }  // namespace ipc

--- a/cpp/src/arrow/ipc/dictionary.h
+++ b/cpp/src/arrow/ipc/dictionary.h
@@ -21,96 +21,145 @@
 
 #include <cstdint>
 #include <memory>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
-#include "arrow/memory_pool.h"
+#include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
-
-class Array;
-class DataType;
-class Field;
-class RecordBatch;
-
 namespace ipc {
 
-/// \brief Memoization data structure for assigning id numbers to
-/// dictionaries and tracking their current state through possible
-/// deltas in an IPC stream
+class FieldPosition {
+ public:
+  FieldPosition() : parent_(NULLPTR), index_(-1), depth_(0) {}
+
+  FieldPosition child(int index) const { return {this, index}; }
+
+  std::vector<int> path() const {
+    std::vector<int> path(depth_);
+    const FieldPosition* cur = this;
+    for (int i = depth_ - 1; i >= 0; --i) {
+      path[i] = cur->index_;
+      cur = cur->parent_;
+    }
+    return path;
+  }
+
+ protected:
+  FieldPosition(const FieldPosition* parent, int index)
+      : parent_(parent), index_(index), depth_(parent->depth_ + 1) {}
+
+  const FieldPosition* parent_;
+  int index_;
+  int depth_;
+};
+
+/// \brief Map fields in a schema to dictionary ids
+///
+/// The mapping is structural, i.e. the field path (as a vector of indices)
+/// is associated to the dictionary id.
+class ARROW_EXPORT DictionaryFieldMapper {
+ public:
+  DictionaryFieldMapper();
+  explicit DictionaryFieldMapper(const Schema& schema);
+  ~DictionaryFieldMapper();
+
+  Status AddSchemaFields(const Schema& schema);
+  Status AddField(int64_t id, std::vector<int> field_path);
+
+  Result<int64_t> GetFieldId(std::vector<int> field_path) const;
+
+  int num_fields() const;
+
+ private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+using DictionaryVector = std::vector<std::pair<int64_t, std::shared_ptr<Array>>>;
+
+/// \brief Memoization data structure for reading dictionaries from IPC streams
+///
+/// This structure tracks the following associations:
+/// - field position (structural) -> dictionary id
+/// - dictionary id -> value type
+/// - dictionary id -> dictionary (value) data
+///
+/// Together, they allow resolving dictionary data when reading an IPC stream,
+/// using metadata recorded in the schema message and data recorded in the
+/// dictionary batch messages (see ResolveDictionaries).
+///
+/// This structure isn't useful for writing an IPC stream, where only
+/// DictionaryFieldMapper is necessary.
 class ARROW_EXPORT DictionaryMemo {
  public:
-  using DictionaryVector = std::vector<std::pair<int64_t, std::shared_ptr<Array>>>;
-
   DictionaryMemo();
-  DictionaryMemo(DictionaryMemo&&) = default;
-  DictionaryMemo& operator=(DictionaryMemo&&) = default;
+  ~DictionaryMemo();
+
+  DictionaryFieldMapper& fields();
+  const DictionaryFieldMapper& fields() const;
 
   /// \brief Return current dictionary corresponding to a particular
   /// id. Returns KeyError if id not found
-  Status GetDictionary(int64_t id, std::shared_ptr<Array>* dictionary) const;
+  Result<std::shared_ptr<ArrayData>> GetDictionary(int64_t id) const;
 
   /// \brief Return dictionary value type corresponding to a
-  /// particular dictionary id. This permits multiple fields to
-  /// reference the same dictionary in IPC and JSON
-  Status GetDictionaryType(int64_t id, std::shared_ptr<DataType>* type) const;
-
-  /// \brief Return id for dictionary, computing new id if necessary
-  Status GetOrAssignId(const std::shared_ptr<Field>& field, int64_t* out);
-
-  /// \brief Return id for dictionary if it exists, otherwise return
-  /// KeyError
-  Status GetId(const Field* type, int64_t* id) const;
-
-  /// \brief Return true if dictionary for type is in this memo
-  bool HasDictionary(const Field& type) const;
+  /// particular dictionary id.
+  Result<std::shared_ptr<DataType>> GetDictionaryType(int64_t id) const;
 
   /// \brief Return true if we have a dictionary for the input id
   bool HasDictionary(int64_t id) const;
 
-  /// \brief Add field to the memo, return KeyError if already present
-  Status AddField(int64_t id, const std::shared_ptr<Field>& field);
+  /// \brief Add a dictionary value type to the memo with a particular id.
+  /// Returns KeyError if a different type is already registered with the same id.
+  Status AddDictionaryType(int64_t id, const std::shared_ptr<DataType>& type);
 
   /// \brief Add a dictionary to the memo with a particular id. Returns
   /// KeyError if that dictionary already exists
-  Status AddDictionary(int64_t id, const std::shared_ptr<Array>& dictionary);
+  Status AddDictionary(int64_t id, const std::shared_ptr<ArrayData>& dictionary);
 
   /// \brief Append a dictionary delta to the memo with a particular id. Returns
   /// KeyError if that dictionary does not exists
-  Status AddDictionaryDelta(int64_t id, const std::shared_ptr<Array>& dictionary,
+  Status AddDictionaryDelta(int64_t id, const std::shared_ptr<ArrayData>& dictionary,
                             MemoryPool* pool);
 
   /// \brief Add a dictionary to the memo if it does not have one with the id,
   /// otherwise, replace the dictionary with the new one.
-  Status AddOrReplaceDictionary(int64_t id, const std::shared_ptr<Array>& dictionary);
-
-  /// \brief The stored dictionaries, in ascending id order.
-  DictionaryVector dictionaries() const;
-
-  /// \brief The number of fields tracked in the memo
-  int num_fields() const { return static_cast<int>(field_to_id_.size()); }
-  int num_dictionaries() const { return static_cast<int>(id_to_dictionary_.size()); }
+  Status AddOrReplaceDictionary(int64_t id, const std::shared_ptr<ArrayData>& dictionary);
 
  private:
-  Status AddFieldInternal(int64_t id, const std::shared_ptr<Field>& field);
-
-  // Dictionary memory addresses, to track whether a particular
-  // dictionary-encoded field has been seen before
-  std::unordered_map<const Field*, int64_t> field_to_id_;
-
-  // Map of dictionary id to dictionary array
-  std::unordered_map<int64_t, std::shared_ptr<Array>> id_to_dictionary_;
-  std::unordered_map<int64_t, std::shared_ptr<DataType>> id_to_type_;
-
-  ARROW_DISALLOW_COPY_AND_ASSIGN(DictionaryMemo);
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
 };
 
+// For writing: collect dictionary entries to write to the IPC stream, in order
+// (i.e. inner dictionaries before dependent outer dictionaries).
+ARROW_EXPORT
+Result<DictionaryVector> CollectDictionaries(const RecordBatch& batch,
+                                             const DictionaryFieldMapper& mapper);
+
+// For reading: resolve all dictionaries in columns, according to the field
+// mapping and dictionary arrays stored in memo.
+// Columns may be sparse, i.e. some entries may be left null
+// (e.g. if an inclusion mask was used).
+ARROW_EXPORT
+Status ResolveDictionaries(const ArrayDataVector& columns, const DictionaryMemo& memo);
+
+namespace internal {
+
+// Like CollectDictionaries above, but uses the memo's DictionaryFieldMapper
+// and all collected dictionaries are added to the memo using AddDictionary.
+//
+// This is used as a shortcut in some roundtripping tests (to avoid emitting
+// any actual dictionary batches).
 ARROW_EXPORT
 Status CollectDictionaries(const RecordBatch& batch, DictionaryMemo* memo);
+
+}  // namespace internal
 
 }  // namespace ipc
 }  // namespace arrow

--- a/cpp/src/arrow/ipc/dictionary.h
+++ b/cpp/src/arrow/ipc/dictionary.h
@@ -33,6 +33,8 @@
 namespace arrow {
 namespace ipc {
 
+namespace internal {
+
 class FieldPosition {
  public:
   FieldPosition() : parent_(NULLPTR), index_(-1), depth_(0) {}
@@ -58,10 +60,13 @@ class FieldPosition {
   int depth_;
 };
 
+}  // namespace internal
+
 /// \brief Map fields in a schema to dictionary ids
 ///
 /// The mapping is structural, i.e. the field path (as a vector of indices)
-/// is associated to the dictionary id.
+/// is associated to the dictionary id.  A dictionary id may be associated
+/// to multiple fields.
 class ARROW_EXPORT DictionaryFieldMapper {
  public:
   DictionaryFieldMapper();

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -75,6 +75,7 @@ class TestFeatherBase {
     DoWrite(*table);
     std::shared_ptr<Table> result;
     ASSERT_OK(reader_->Read(&result));
+    ASSERT_OK(result->ValidateFull());
     if (table->num_rows() > 0) {
       AssertTablesEqual(*table, *result);
     } else {
@@ -101,6 +102,7 @@ class TestFeatherBase {
 
     std::shared_ptr<Table> read_table;
     ASSERT_OK(reader_->Read(&read_table));
+    ASSERT_OK(read_table->ValidateFull());
     AssertTablesEqual(*table, *read_table);
   }
 
@@ -329,23 +331,25 @@ namespace {
 
 const std::vector<test::MakeRecordBatch*> kBatchCases = {
     &ipc::test::MakeIntRecordBatch,
-    &ipc::test::MakeBooleanBatch,
-    &ipc::test::MakeFloatBatch,
     &ipc::test::MakeListRecordBatch,
+    &ipc::test::MakeFixedSizeListRecordBatch,
     &ipc::test::MakeNonNullRecordBatch,
     &ipc::test::MakeDeeplyNestedList,
     &ipc::test::MakeStringTypesRecordBatchWithNulls,
     &ipc::test::MakeStruct,
     &ipc::test::MakeUnion,
     &ipc::test::MakeDictionary,
-    &ipc::test::MakeDictionaryFlat,
     &ipc::test::MakeNestedDictionary,
+    &ipc::test::MakeMap,
+    &ipc::test::MakeMapOfDictionary,
     &ipc::test::MakeDates,
     &ipc::test::MakeTimestamps,
     &ipc::test::MakeTimes,
     &ipc::test::MakeFWBinary,
     &ipc::test::MakeNull,
     &ipc::test::MakeDecimal,
+    &ipc::test::MakeBooleanBatch,
+    &ipc::test::MakeFloatBatch,
     &ipc::test::MakeIntervals};
 
 }  // namespace

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -48,6 +48,7 @@ namespace flatbuf = org::apache::arrow::flatbuf;
 
 namespace ipc {
 
+class DictionaryFieldMapper;
 class DictionaryMemo;
 
 namespace internal {
@@ -166,13 +167,7 @@ static inline Status VerifyMessage(const uint8_t* data, int64_t size,
 }
 
 // Serialize arrow::Schema as a Flatbuffer
-//
-// \param[in] schema a Schema instance
-// \param[in,out] dictionary_memo class for tracking dictionaries and assigning
-// dictionary ids
-// \param[out] out the serialized arrow::Buffer
-// \return Status outcome
-Status WriteSchemaMessage(const Schema& schema, DictionaryMemo* dictionary_memo,
+Status WriteSchemaMessage(const Schema& schema, const DictionaryFieldMapper& mapper,
                           const IpcWriteOptions& options, std::shared_ptr<Buffer>* out);
 
 // This function is used in a unit test

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -223,11 +223,10 @@ class TestSchemaMetadata : public ::testing::Test {
   void SetUp() {}
 
   void CheckSchemaRoundtrip(const Schema& schema) {
-    DictionaryMemo in_memo, out_memo;
-    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Buffer> buffer,
-                         SerializeSchema(schema, &out_memo, default_memory_pool()));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Buffer> buffer, SerializeSchema(schema));
 
     io::BufferReader reader(buffer);
+    DictionaryMemo in_memo;
     ASSERT_OK_AND_ASSIGN(auto actual_schema, ReadSchema(&reader, &in_memo));
     AssertSchemaEqual(schema, *actual_schema);
   }
@@ -334,6 +333,7 @@ TEST_F(TestSchemaMetadata, MetadataVersionForwardCompatibility) {
 const std::vector<test::MakeRecordBatch*> kBatchCases = {
     &MakeIntRecordBatch,
     &MakeListRecordBatch,
+    &MakeFixedSizeListRecordBatch,
     &MakeNonNullRecordBatch,
     &MakeZeroLengthRecordBatch,
     &MakeDeeplyNestedList,
@@ -342,6 +342,8 @@ const std::vector<test::MakeRecordBatch*> kBatchCases = {
     &MakeUnion,
     &MakeDictionary,
     &MakeNestedDictionary,
+    &MakeMap,
+    &MakeMapOfDictionary,
     &MakeDates,
     &MakeTimestamps,
     &MakeTimes,
@@ -372,15 +374,13 @@ class IpcTestFixture : public io::MemoryMapFixture, public ExtensionTypesMixin {
  public:
   void SetUp() { options_ = IpcWriteOptions::Defaults(); }
 
-  void DoSchemaRoundTrip(const Schema& schema, DictionaryMemo* out_memo,
-                         std::shared_ptr<Schema>* result) {
+  void DoSchemaRoundTrip(const Schema& schema, std::shared_ptr<Schema>* result) {
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<Buffer> serialized_schema,
-                         SerializeSchema(schema, out_memo, options_.memory_pool));
+                         SerializeSchema(schema, options_.memory_pool));
 
     DictionaryMemo in_memo;
     io::BufferReader buf_reader(serialized_schema);
     ASSERT_OK_AND_ASSIGN(*result, ReadSchema(&buf_reader, &in_memo));
-    ASSERT_EQ(out_memo->num_fields(), in_memo.num_fields());
   }
 
   Result<std::shared_ptr<RecordBatch>> DoStandardRoundTrip(
@@ -437,13 +437,12 @@ class IpcTestFixture : public io::MemoryMapFixture, public ExtensionTypesMixin {
     ASSERT_OK_AND_ASSIGN(mmap_,
                          io::MemoryMapFixture::InitMemoryMap(buffer_size, ss.str()));
 
-    DictionaryMemo dictionary_memo;
-
     std::shared_ptr<Schema> schema_result;
-    DoSchemaRoundTrip(*batch.schema(), &dictionary_memo, &schema_result);
+    DoSchemaRoundTrip(*batch.schema(), &schema_result);
     ASSERT_TRUE(batch.schema()->Equals(*schema_result));
 
-    ASSERT_OK(CollectDictionaries(batch, &dictionary_memo));
+    DictionaryMemo dictionary_memo;
+    ASSERT_OK(::arrow::ipc::internal::CollectDictionaries(batch, &dictionary_memo));
 
     ASSERT_OK_AND_ASSIGN(
         auto result, DoStandardRoundTrip(batch, options, &dictionary_memo, read_options));
@@ -1333,8 +1332,9 @@ class DictionaryBatchHelper {
 
     // write schema
     IpcPayload payload;
-    RETURN_NOT_OK(GetSchemaPayload(schema_, IpcWriteOptions::Defaults(),
-                                   &dictionary_memo_, &payload));
+    DictionaryFieldMapper mapper(schema_);
+    RETURN_NOT_OK(
+        GetSchemaPayload(schema_, IpcWriteOptions::Defaults(), mapper, &payload));
     return payload_writer_->WritePayload(payload);
   }
 
@@ -1369,7 +1369,6 @@ class DictionaryBatchHelper {
 
   std::unique_ptr<internal::IpcPayloadWriter> payload_writer_;
   const Schema& schema_;
-  DictionaryMemo dictionary_memo_;
   std::shared_ptr<ResizableBuffer> buffer_;
   std::unique_ptr<io::BufferOutputStream> sink_;
 };
@@ -2145,41 +2144,106 @@ TEST(TestStreamDecoder, NextRequiredSize) {
 }
 
 // ----------------------------------------------------------------------
-// DictionaryMemo miscellanea
+// Miscellanea
 
-TEST(TestDictionaryMemo, ReusedDictionaries) {
+TEST(FieldPosition, Basics) {
+  FieldPosition pos;
+  ASSERT_EQ(pos.path(), std::vector<int>{});
+  {
+    auto child = pos.child(6);
+    ASSERT_EQ(child.path(), std::vector<int>{6});
+    auto grand_child = child.child(42);
+    ASSERT_EQ(grand_child.path(), (std::vector<int>{6, 42}));
+  }
+  {
+    auto child = pos.child(12);
+    ASSERT_EQ(child.path(), std::vector<int>{12});
+  }
+}
+
+TEST(DictionaryFieldMapper, Basics) {
+  DictionaryFieldMapper mapper;
+
+  ASSERT_EQ(mapper.num_fields(), 0);
+
+  ASSERT_OK(mapper.AddField(42, {0, 1}));
+  ASSERT_OK(mapper.AddField(43, {0, 2}));
+  ASSERT_OK(mapper.AddField(44, {0, 1, 3}));
+  ASSERT_EQ(mapper.num_fields(), 3);
+
+  ASSERT_OK_AND_EQ(42, mapper.GetFieldId({0, 1}));
+  ASSERT_OK_AND_EQ(43, mapper.GetFieldId({0, 2}));
+  ASSERT_OK_AND_EQ(44, mapper.GetFieldId({0, 1, 3}));
+  ASSERT_RAISES(KeyError, mapper.GetFieldId({}));
+  ASSERT_RAISES(KeyError, mapper.GetFieldId({0}));
+  ASSERT_RAISES(KeyError, mapper.GetFieldId({0, 1, 2}));
+  ASSERT_RAISES(KeyError, mapper.GetFieldId({1}));
+
+  ASSERT_OK(mapper.AddField(41, {}));
+  ASSERT_EQ(mapper.num_fields(), 4);
+  ASSERT_OK_AND_EQ(41, mapper.GetFieldId({}));
+  ASSERT_OK_AND_EQ(42, mapper.GetFieldId({0, 1}));
+
+  // Duplicated dictionary ids are allowed
+  ASSERT_OK(mapper.AddField(42, {4, 5, 6}));
+  ASSERT_EQ(mapper.num_fields(), 5);
+  ASSERT_OK_AND_EQ(42, mapper.GetFieldId({0, 1}));
+  ASSERT_OK_AND_EQ(42, mapper.GetFieldId({4, 5, 6}));
+
+  // Duplicated fields paths are not
+  ASSERT_RAISES(KeyError, mapper.AddField(46, {0, 1}));
+}
+
+TEST(DictionaryFieldMapper, FromSchema) {
+  auto f0 = field("f0", int8());
+  auto f1 =
+      field("f1", struct_({field("a", null()), field("b", dictionary(int8(), utf8()))}));
+  auto f2 = field("f2", dictionary(int32(), list(dictionary(int8(), utf8()))));
+
+  Schema schema({f0, f1, f2});
+  DictionaryFieldMapper mapper(schema);
+
+  ASSERT_EQ(mapper.num_fields(), 3);
+  std::unordered_set<int64_t> ids;
+  for (const auto& path : std::vector<std::vector<int>>{{1, 1}, {2}, {2, 0}}) {
+    ASSERT_OK_AND_ASSIGN(const int64_t id, mapper.GetFieldId(path));
+    ids.insert(id);
+  }
+  ASSERT_EQ(ids.size(), 3);  // All ids are distinct
+}
+
+static void AssertMemoDictionaryType(const DictionaryMemo& memo, int64_t id,
+                                     const std::shared_ptr<DataType>& expected) {
+  ASSERT_OK_AND_ASSIGN(const auto actual, memo.GetDictionaryType(id));
+  AssertTypeEqual(*expected, *actual);
+}
+
+TEST(DictionaryMemo, AddDictionaryType) {
   DictionaryMemo memo;
+  std::shared_ptr<DataType> type;
 
-  std::shared_ptr<Field> field1 = field("a", dictionary(int8(), utf8()));
-  std::shared_ptr<Field> field2 = field("b", dictionary(int16(), utf8()));
+  ASSERT_RAISES(KeyError, memo.GetDictionaryType(42));
 
-  // Two fields referencing the same dictionary_id
-  int64_t dictionary_id = 0;
-  auto dict = ArrayFromJSON(utf8(), "[\"foo\", \"bar\", \"baz\"]");
+  ASSERT_OK(memo.AddDictionaryType(42, utf8()));
+  ASSERT_OK(memo.AddDictionaryType(43, large_binary()));
+  AssertMemoDictionaryType(memo, 42, utf8());
+  AssertMemoDictionaryType(memo, 43, large_binary());
 
-  ASSERT_OK(memo.AddField(dictionary_id, field1));
-  ASSERT_OK(memo.AddField(dictionary_id, field2));
+  // Re-adding same type with different id
+  ASSERT_OK(memo.AddDictionaryType(44, utf8()));
+  AssertMemoDictionaryType(memo, 42, utf8());
+  AssertMemoDictionaryType(memo, 44, utf8());
 
-  std::shared_ptr<DataType> value_type;
-  ASSERT_OK(memo.GetDictionaryType(dictionary_id, &value_type));
-  ASSERT_TRUE(value_type->Equals(*utf8()));
+  // Re-adding same type with same id
+  ASSERT_OK(memo.AddDictionaryType(42, utf8()));
+  AssertMemoDictionaryType(memo, 42, utf8());
+  AssertMemoDictionaryType(memo, 44, utf8());
 
-  ASSERT_FALSE(memo.HasDictionary(dictionary_id));
-  ASSERT_OK(memo.AddDictionary(dictionary_id, dict));
-  ASSERT_TRUE(memo.HasDictionary(dictionary_id));
-
-  ASSERT_EQ(2, memo.num_fields());
-  ASSERT_EQ(1, memo.num_dictionaries());
-
-  ASSERT_TRUE(memo.HasDictionary(*field1));
-  ASSERT_TRUE(memo.HasDictionary(*field2));
-
-  int64_t returned_id = -1;
-  ASSERT_OK(memo.GetId(field1.get(), &returned_id));
-  ASSERT_EQ(0, returned_id);
-  returned_id = -1;
-  ASSERT_OK(memo.GetId(field2.get(), &returned_id));
-  ASSERT_EQ(0, returned_id);
+  // Trying to add different type with same id
+  ASSERT_RAISES(KeyError, memo.AddDictionaryType(42, large_utf8()));
+  AssertMemoDictionaryType(memo, 42, utf8());
+  AssertMemoDictionaryType(memo, 43, large_binary());
+  AssertMemoDictionaryType(memo, 44, utf8());
 }
 
 }  // namespace test

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -59,6 +59,9 @@ using internal::checked_cast;
 using internal::GetByteWidth;
 
 namespace ipc {
+
+using internal::FieldPosition;
+
 namespace test {
 
 using BatchVector = std::vector<std::shared_ptr<RecordBatch>>;

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -110,13 +110,11 @@ Status InvalidMessageType(MessageType expected, MessageType actual) {
 class ArrayLoader {
  public:
   explicit ArrayLoader(const flatbuf::RecordBatch* metadata,
-                       MetadataVersion metadata_version,
-                       const DictionaryMemo* dictionary_memo,
-                       const IpcReadOptions& options, io::RandomAccessFile* file)
+                       MetadataVersion metadata_version, const IpcReadOptions& options,
+                       io::RandomAccessFile* file)
       : metadata_(metadata),
         metadata_version_(metadata_version),
         file_(file),
-        dictionary_memo_(dictionary_memo),
         max_recursion_depth_(options.max_recursion_depth) {}
 
   Status ReadBuffer(int64_t offset, int64_t length, std::shared_ptr<Buffer>* out) {
@@ -244,15 +242,15 @@ class ArrayLoader {
     return LoadChildren(type.fields());
   }
 
-  Status LoadChildren(std::vector<std::shared_ptr<Field>> child_fields) {
+  Status LoadChildren(const std::vector<std::shared_ptr<Field>>& child_fields) {
     ArrayData* parent = out_;
-    parent->child_data.reserve(static_cast<int>(child_fields.size()));
-    for (const auto& child_field : child_fields) {
-      auto field_array = std::make_shared<ArrayData>();
+
+    parent->child_data.resize(child_fields.size());
+    for (int i = 0; i < static_cast<int>(child_fields.size()); ++i) {
+      parent->child_data[i] = std::make_shared<ArrayData>();
       --max_recursion_depth_;
-      RETURN_NOT_OK(Load(child_field.get(), field_array.get()));
+      RETURN_NOT_OK(Load(child_fields[i].get(), parent->child_data[i].get()));
       ++max_recursion_depth_;
-      parent->child_data.emplace_back(field_array);
     }
     out_ = parent;
     return Status::OK();
@@ -348,16 +346,8 @@ class ArrayLoader {
   }
 
   Status Visit(const DictionaryType& type) {
-    RETURN_NOT_OK(LoadType(*type.index_type()));
-
-    // Look up dictionary
-    int64_t id = -1;
-    RETURN_NOT_OK(dictionary_memo_->GetId(field_, &id));
-
-    std::shared_ptr<Array> boxed_dict;
-    RETURN_NOT_OK(dictionary_memo_->GetDictionary(id, &boxed_dict));
-    out_->dictionary = boxed_dict->data();
-    return Status::OK();
+    // out_->dictionary will be filled later in ResolveDictionaries()
+    return LoadType(*type.index_type());
   }
 
   Status Visit(const ExtensionType& type) { return LoadType(*type.storage_type()); }
@@ -366,7 +356,6 @@ class ArrayLoader {
   const flatbuf::RecordBatch* metadata_;
   const MetadataVersion metadata_version_;
   io::RandomAccessFile* file_;
-  const DictionaryMemo* dictionary_memo_;
   int max_recursion_depth_;
   int buffer_index_ = 0;
   int field_index_ = 0;
@@ -410,11 +399,11 @@ Result<std::shared_ptr<Buffer>> DecompressBuffer(const std::shared_ptr<Buffer>& 
 }
 
 Status DecompressBuffers(Compression::type compression, const IpcReadOptions& options,
-                         std::vector<std::shared_ptr<ArrayData>>* fields) {
+                         ArrayDataVector* fields) {
   struct BufferAccumulator {
     using BufferPtrVector = std::vector<std::shared_ptr<Buffer>*>;
 
-    void AppendFrom(const std::vector<std::shared_ptr<ArrayData>>& fields) {
+    void AppendFrom(const ArrayDataVector& fields) {
       for (const auto& field : fields) {
         for (auto& buffer : field->buffers) {
           buffers_.push_back(&buffer);
@@ -423,7 +412,7 @@ Status DecompressBuffers(Compression::type compression, const IpcReadOptions& op
       }
     }
 
-    BufferPtrVector Get(const std::vector<std::shared_ptr<ArrayData>>& fields) && {
+    BufferPtrVector Get(const ArrayDataVector& fields) && {
       AppendFrom(fields);
       return std::move(buffers_);
     }
@@ -431,7 +420,7 @@ Status DecompressBuffers(Compression::type compression, const IpcReadOptions& op
     BufferPtrVector buffers_;
   };
 
-  // flatten all buffers
+  // Flatten all buffers
   auto buffers = BufferAccumulator{}.Get(*fields);
 
   std::unique_ptr<util::Codec> codec;
@@ -447,37 +436,54 @@ Status DecompressBuffers(Compression::type compression, const IpcReadOptions& op
 
 Result<std::shared_ptr<RecordBatch>> LoadRecordBatchSubset(
     const flatbuf::RecordBatch* metadata, const std::shared_ptr<Schema>& schema,
-    const std::vector<bool>& inclusion_mask, const DictionaryMemo* dictionary_memo,
+    const std::vector<bool>* inclusion_mask, const DictionaryMemo* dictionary_memo,
     const IpcReadOptions& options, MetadataVersion metadata_version,
     Compression::type compression, io::RandomAccessFile* file) {
-  ArrayLoader loader(metadata, metadata_version, dictionary_memo, options, file);
+  ArrayLoader loader(metadata, metadata_version, options, file);
 
-  std::vector<std::shared_ptr<ArrayData>> field_data;
-  std::vector<std::shared_ptr<Field>> schema_fields;
+  ArrayDataVector columns(schema->num_fields());
+  ArrayDataVector filtered_columns;
+  FieldVector filtered_fields;
+  std::shared_ptr<Schema> filtered_schema;
 
   for (int i = 0; i < schema->num_fields(); ++i) {
-    if (inclusion_mask[i]) {
+    const Field& field = *schema->field(i);
+    if (!inclusion_mask || (*inclusion_mask)[i]) {
       // Read field
-      auto arr = std::make_shared<ArrayData>();
-      RETURN_NOT_OK(loader.Load(schema->field(i).get(), arr.get()));
-      if (metadata->length() != arr->length) {
+      auto column = std::make_shared<ArrayData>();
+      RETURN_NOT_OK(loader.Load(&field, column.get()));
+      if (metadata->length() != column->length) {
         return Status::IOError("Array length did not match record batch length");
       }
-      field_data.emplace_back(std::move(arr));
-      schema_fields.emplace_back(schema->field(i));
+      columns[i] = std::move(column);
+      if (inclusion_mask) {
+        filtered_columns.push_back(columns[i]);
+        filtered_fields.push_back(schema->field(i));
+      }
     } else {
       // Skip field. This logic must be executed to advance the state of the
       // loader to the next field
-      RETURN_NOT_OK(loader.SkipField(schema->field(i).get()));
+      RETURN_NOT_OK(loader.SkipField(&field));
     }
   }
 
+  // Dictionary resolution needs to happen on the unfiltered columns,
+  // because fields are mapped structurally (by path in the original schema).
+  RETURN_NOT_OK(ResolveDictionaries(columns, *dictionary_memo));
+
+  if (inclusion_mask) {
+    filtered_schema = ::arrow::schema(std::move(filtered_fields), schema->metadata());
+    columns.clear();
+  } else {
+    filtered_schema = schema;
+    filtered_columns = std::move(columns);
+  }
   if (compression != Compression::UNCOMPRESSED) {
-    RETURN_NOT_OK(DecompressBuffers(compression, options, &field_data));
+    RETURN_NOT_OK(DecompressBuffers(compression, options, &filtered_columns));
   }
 
-  return RecordBatch::Make(::arrow::schema(std::move(schema_fields), schema->metadata()),
-                           metadata->length(), std::move(field_data));
+  return RecordBatch::Make(filtered_schema, metadata->length(),
+                           std::move(filtered_columns));
 }
 
 Result<std::shared_ptr<RecordBatch>> LoadRecordBatch(
@@ -486,24 +492,12 @@ Result<std::shared_ptr<RecordBatch>> LoadRecordBatch(
     const IpcReadOptions& options, MetadataVersion metadata_version,
     Compression::type compression, io::RandomAccessFile* file) {
   if (inclusion_mask.size() > 0) {
-    return LoadRecordBatchSubset(metadata, schema, inclusion_mask, dictionary_memo,
+    return LoadRecordBatchSubset(metadata, schema, &inclusion_mask, dictionary_memo,
                                  options, metadata_version, compression, file);
+  } else {
+    return LoadRecordBatchSubset(metadata, schema, nullptr, dictionary_memo, options,
+                                 metadata_version, compression, file);
   }
-
-  ArrayLoader loader(metadata, metadata_version, dictionary_memo, options, file);
-  std::vector<std::shared_ptr<ArrayData>> arrays(schema->num_fields());
-  for (int i = 0; i < schema->num_fields(); ++i) {
-    auto arr = std::make_shared<ArrayData>();
-    RETURN_NOT_OK(loader.Load(schema->field(i).get(), arr.get()));
-    if (metadata->length() != arr->length) {
-      return Status::IOError("Array length did not match record batch length");
-    }
-    arrays[i] = std::move(arr);
-  }
-  if (compression != Compression::UNCOMPRESSED) {
-    RETURN_NOT_OK(DecompressBuffers(compression, options, &arrays));
-  }
-  return RecordBatch::Make(schema, metadata->length(), std::move(arrays));
 }
 
 // ----------------------------------------------------------------------
@@ -700,43 +694,35 @@ Status ReadDictionary(const Buffer& metadata, DictionaryMemo* dictionary_memo,
 
   int64_t id = dictionary_batch->id();
 
-  // Look up the field, which must have been added to the
+  // Look up the dictionary value type, which must have been added to the
   // DictionaryMemo already prior to invoking this function
-  std::shared_ptr<DataType> value_type;
-  RETURN_NOT_OK(dictionary_memo->GetDictionaryType(id, &value_type));
+  ARROW_ASSIGN_OR_RAISE(auto value_type, dictionary_memo->GetDictionaryType(id));
 
-  auto value_field = ::arrow::field("dummy", value_type);
+  // Load the dictionary data from the dictionary batch
+  ArrayLoader loader(batch_meta, internal::GetMetadataVersion(message->version()),
+                     options, file);
+  auto dict_data = std::make_shared<ArrayData>();
+  Field dummy_field("", value_type);
+  RETURN_NOT_OK(loader.Load(&dummy_field, dict_data.get()));
 
-  std::shared_ptr<RecordBatch> batch;
-  ARROW_ASSIGN_OR_RAISE(
-      batch, LoadRecordBatch(batch_meta, ::arrow::schema({value_field}),
-                             /*field_inclusion_mask=*/{}, dictionary_memo, options,
-                             internal::GetMetadataVersion(message->version()),
-                             compression, file));
-  if (batch->num_columns() != 1) {
-    return Status::Invalid("Dictionary record batch must only contain one field");
+  if (compression != Compression::UNCOMPRESSED) {
+    ArrayDataVector dict_fields{dict_data};
+    RETURN_NOT_OK(DecompressBuffers(compression, options, &dict_fields));
   }
-  auto dictionary = batch->column(0);
-  // Validate the dictionary for safe delta concatenation
-  RETURN_NOT_OK(dictionary->Validate());
+
   if (dictionary_batch->isDelta()) {
-    return dictionary_memo->AddDictionaryDelta(id, dictionary, options.memory_pool);
+    return dictionary_memo->AddDictionaryDelta(id, dict_data, options.memory_pool);
   }
-  return dictionary_memo->AddOrReplaceDictionary(id, dictionary);
+  return dictionary_memo->AddOrReplaceDictionary(id, dict_data);
 }
 
-Status ParseDictionary(const Message& message, DictionaryMemo* dictionary_memo,
-                       const IpcReadOptions& options) {
+Status ReadDictionary(const Message& message, DictionaryMemo* dictionary_memo,
+                      const IpcReadOptions& options) {
   // Only invoke this method if we already know we have a dictionary message
   DCHECK_EQ(message.type(), MessageType::DICTIONARY_BATCH);
   CHECK_HAS_BODY(message);
   ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message.body()));
   return ReadDictionary(*message.metadata(), dictionary_memo, options, reader.get());
-}
-
-Status UpdateDictionaries(const Message& message, DictionaryMemo* dictionary_memo,
-                          const IpcReadOptions& options) {
-  return ParseDictionary(message, dictionary_memo, options);
 }
 
 // ----------------------------------------------------------------------
@@ -777,7 +763,7 @@ class RecordBatchStreamReaderImpl : public RecordBatchStreamReader {
     ARROW_ASSIGN_OR_RAISE(message, message_reader_->ReadNextMessage());
 
     while (message != nullptr && message->type() == MessageType::DICTIONARY_BATCH) {
-      RETURN_NOT_OK(UpdateDictionaries(*message, &dictionary_memo_, options_));
+      RETURN_NOT_OK(ReadDictionary(*message, &dictionary_memo_, options_));
       ARROW_ASSIGN_OR_RAISE(message, message_reader_->ReadNextMessage());
     }
 
@@ -804,7 +790,8 @@ class RecordBatchStreamReaderImpl : public RecordBatchStreamReader {
 
     // TODO(wesm): In future, we may want to reconcile the ids in the stream with
     // those found in the schema
-    for (int i = 0; i < dictionary_memo_.num_fields(); ++i) {
+    const auto num_dicts = dictionary_memo_.fields().num_fields();
+    for (int i = 0; i < num_dicts; ++i) {
       ARROW_ASSIGN_OR_RAISE(message, message_reader_->ReadNextMessage());
       if (!message) {
         if (i == 0) {
@@ -819,16 +806,15 @@ class RecordBatchStreamReaderImpl : public RecordBatchStreamReader {
           // ARROW-6126, the stream terminated before receiving the expected
           // number of dictionaries
           return Status::Invalid("IPC stream ended without reading the expected number (",
-                                 dictionary_memo_.num_fields(), ") of dictionaries");
+                                 num_dicts, ") of dictionaries");
         }
       }
 
       if (message->type() != MessageType::DICTIONARY_BATCH) {
-        return Status::Invalid("IPC stream did not have the expected number (",
-                               dictionary_memo_.num_fields(),
+        return Status::Invalid("IPC stream did not have the expected number (", num_dicts,
                                ") of dictionaries at the start of the stream");
       }
-      RETURN_NOT_OK(ParseDictionary(*message, &dictionary_memo_, options_));
+      RETURN_NOT_OK(ReadDictionary(*message, &dictionary_memo_, options_));
     }
 
     have_read_initial_dictionaries_ = true;
@@ -1139,7 +1125,7 @@ class StreamDecoder::StreamDecoderImpl : public MessageDecoderListener {
     RETURN_NOT_OK(UnpackSchemaMessage(*message, options_, &dictionary_memo_, &schema_,
                                       &out_schema_, &field_inclusion_mask_));
 
-    n_required_dictionaries_ = dictionary_memo_.num_fields();
+    n_required_dictionaries_ = dictionary_memo_.fields().num_fields();
     if (n_required_dictionaries_ == 0) {
       state_ = State::RECORD_BATCHES;
       RETURN_NOT_OK(listener_->OnSchemaDecoded(schema_));
@@ -1152,10 +1138,10 @@ class StreamDecoder::StreamDecoderImpl : public MessageDecoderListener {
   Status OnInitialDictionaryMessageDecoded(std::unique_ptr<Message> message) {
     if (message->type() != MessageType::DICTIONARY_BATCH) {
       return Status::Invalid("IPC stream did not have the expected number (",
-                             dictionary_memo_.num_fields(),
+                             dictionary_memo_.fields().num_fields(),
                              ") of dictionaries at the start of the stream");
     }
-    RETURN_NOT_OK(ParseDictionary(*message, &dictionary_memo_, options_));
+    RETURN_NOT_OK(ReadDictionary(*message, &dictionary_memo_, options_));
     n_required_dictionaries_--;
     if (n_required_dictionaries_ == 0) {
       state_ = State::RECORD_BATCHES;
@@ -1166,7 +1152,7 @@ class StreamDecoder::StreamDecoderImpl : public MessageDecoderListener {
 
   Status OnRecordBatchMessageDecoded(std::unique_ptr<Message> message) {
     if (message->type() == MessageType::DICTIONARY_BATCH) {
-      return UpdateDictionaries(*message, &dictionary_memo_, options_);
+      return ReadDictionary(*message, &dictionary_memo_, options_);
     } else {
       CHECK_HAS_BODY(*message);
       ARROW_ASSIGN_OR_RAISE(auto reader, Buffer::GetReader(message->body()));

--- a/cpp/src/arrow/ipc/test_common.h
+++ b/cpp/src/arrow/ipc/test_common.h
@@ -54,11 +54,6 @@ Status MakeRandomLargeListArray(const std::shared_ptr<Array>& child_array, int n
                                 std::shared_ptr<Array>* out);
 
 ARROW_TESTING_EXPORT
-Status MakeRandomMapArray(const std::shared_ptr<Array>& child_array, int num_lists,
-                          bool include_nulls, MemoryPool* pool,
-                          std::shared_ptr<Array>* out);
-
-ARROW_TESTING_EXPORT
 Status MakeRandomBooleanArray(const int length, bool include_nulls,
                               std::shared_ptr<Array>* out);
 
@@ -132,6 +127,12 @@ Status MakeDictionaryFlat(std::shared_ptr<RecordBatch>* out);
 
 ARROW_TESTING_EXPORT
 Status MakeNestedDictionary(std::shared_ptr<RecordBatch>* out);
+
+ARROW_TESTING_EXPORT
+Status MakeMap(std::shared_ptr<RecordBatch>* out);
+
+ARROW_TESTING_EXPORT
+Status MakeMapOfDictionary(std::shared_ptr<RecordBatch>* out);
 
 ARROW_TESTING_EXPORT
 Status MakeDates(std::shared_ptr<RecordBatch>* out);

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -166,12 +166,10 @@ Status SerializeRecordBatch(const RecordBatch& batch, const IpcWriteOptions& opt
 /// \brief Serialize schema as encapsulated IPC message
 ///
 /// \param[in] schema the schema to write
-/// \param[in] dictionary_memo a DictionaryMemo for recording dictionary ids
 /// \param[in] pool a MemoryPool to allocate memory from
 /// \return the serialized schema
 ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> SerializeSchema(const Schema& schema,
-                                                DictionaryMemo* dictionary_memo,
                                                 MemoryPool* pool = default_memory_pool());
 
 /// \brief Write multiple record batches to OutputStream, including schema
@@ -280,12 +278,12 @@ Status WriteSparseTensor(const SparseTensor& sparse_tensor, io::OutputStream* ds
 /// \brief Compute IpcPayload for the given schema
 /// \param[in] schema the Schema that is being serialized
 /// \param[in] options options for serialization
-/// \param[in,out] dictionary_memo class to populate with assigned dictionary ids
+/// \param[in] mapper object mapping dictionary fields to dictionary ids
 /// \param[out] out the returned vector of IpcPayloads
 /// \return Status
 ARROW_EXPORT
 Status GetSchemaPayload(const Schema& schema, const IpcWriteOptions& options,
-                        DictionaryMemo* dictionary_memo, IpcPayload* out);
+                        const DictionaryFieldMapper& mapper, IpcPayload* out);
 
 /// \brief Compute IpcPayload for a dictionary
 /// \param[in] id the dictionary id

--- a/cpp/src/arrow/python/flight.cc
+++ b/cpp/src/arrow/python/flight.cc
@@ -232,7 +232,7 @@ Status PyFlightDataStream::Next(FlightPayload* payload) { return stream_->Next(p
 PyGeneratorFlightDataStream::PyGeneratorFlightDataStream(
     PyObject* generator, std::shared_ptr<arrow::Schema> schema,
     PyGeneratorFlightDataStreamCallback callback, const ipc::IpcWriteOptions& options)
-    : schema_(schema), options_(options), callback_(callback) {
+    : schema_(schema), mapper_(*schema_), options_(options), callback_(callback) {
   Py_INCREF(generator);
   generator_.reset(generator);
 }
@@ -240,8 +240,7 @@ PyGeneratorFlightDataStream::PyGeneratorFlightDataStream(
 std::shared_ptr<Schema> PyGeneratorFlightDataStream::schema() { return schema_; }
 
 Status PyGeneratorFlightDataStream::GetSchemaPayload(FlightPayload* payload) {
-  return ipc::GetSchemaPayload(*schema_, options_, &dictionary_memo_,
-                               &payload->ipc_message);
+  return ipc::GetSchemaPayload(*schema_, options_, mapper_, &payload->ipc_message);
 }
 
 Status PyGeneratorFlightDataStream::Next(FlightPayload* payload) {

--- a/cpp/src/arrow/python/flight.h
+++ b/cpp/src/arrow/python/flight.h
@@ -328,7 +328,7 @@ class ARROW_PYFLIGHT_EXPORT PyGeneratorFlightDataStream
  private:
   OwnedRefNoGIL generator_;
   std::shared_ptr<arrow::Schema> schema_;
-  ipc::DictionaryMemo dictionary_memo_;
+  ipc::DictionaryFieldMapper mapper_;
   ipc::IpcWriteOptions options_;
   PyGeneratorFlightDataStreamCallback callback_;
 };

--- a/cpp/src/arrow/testing/json_internal.cc
+++ b/cpp/src/arrow/testing/json_internal.cc
@@ -35,6 +35,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
+#include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
@@ -47,26 +48,27 @@
 #include "arrow/visitor_inline.h"
 
 namespace arrow {
+
+using internal::checked_cast;
+using internal::ParseValue;
+
+using ipc::DictionaryFieldMapper;
+using ipc::DictionaryMemo;
+using ipc::FieldPosition;
+
+namespace testing {
+namespace json {
+
 namespace {
+
 constexpr char kData[] = "DATA";
 constexpr char kDays[] = "days";
 constexpr char kDayTime[] = "DAY_TIME";
 constexpr char kDuration[] = "duration";
 constexpr char kMilliseconds[] = "milliseconds";
 constexpr char kYearMonth[] = "YEAR_MONTH";
-}  // namespace
 
-class MemoryPool;
-
-using internal::checked_cast;
-using internal::ParseValue;
-
-namespace testing {
-namespace json {
-
-using ::arrow::ipc::DictionaryMemo;
-
-static std::string GetFloatingPrecisionName(FloatingPointType::Precision precision) {
+std::string GetFloatingPrecisionName(FloatingPointType::Precision precision) {
   switch (precision) {
     case FloatingPointType::HALF:
       return "HALF";
@@ -80,7 +82,7 @@ static std::string GetFloatingPrecisionName(FloatingPointType::Precision precisi
   return "UNKNOWN";
 }
 
-static std::string GetTimeUnitName(TimeUnit::type unit) {
+std::string GetTimeUnitName(TimeUnit::type unit) {
   switch (unit) {
     case TimeUnit::SECOND:
       return "SECOND";
@@ -98,17 +100,21 @@ static std::string GetTimeUnitName(TimeUnit::type unit) {
 
 class SchemaWriter {
  public:
-  explicit SchemaWriter(const Schema& schema, DictionaryMemo* dictionary_memo,
+  explicit SchemaWriter(const Schema& schema, const DictionaryFieldMapper& mapper,
                         RjWriter* writer)
-      : schema_(schema), dictionary_memo_(dictionary_memo), writer_(writer) {}
+      : schema_(schema), mapper_(mapper), writer_(writer) {}
 
   Status Write() {
     writer_->Key("schema");
     writer_->StartObject();
     writer_->Key("fields");
     writer_->StartArray();
+
+    FieldPosition field_pos;
+    int i = 0;
     for (const std::shared_ptr<Field>& field : schema_.fields()) {
-      RETURN_NOT_OK(VisitField(field));
+      RETURN_NOT_OK(VisitField(field, field_pos.child(i)));
+      ++i;
     }
     writer_->EndArray();
     WriteKeyValueMetadata(schema_.metadata());
@@ -168,7 +174,7 @@ class SchemaWriter {
     return Status::OK();
   }
 
-  Status VisitField(const std::shared_ptr<Field>& field) {
+  Status VisitField(const std::shared_ptr<Field>& field, FieldPosition field_pos) {
     writer_->StartObject();
 
     writer_->Key("name");
@@ -196,12 +202,12 @@ class SchemaWriter {
       const auto& dict_type = checked_cast<const DictionaryType&>(*type);
       // Ensure we visit child fields first so that, in the case of nested
       // dictionaries, inner dictionaries get a smaller id than outer dictionaries.
-      RETURN_NOT_OK(WriteChildren(dict_type.value_type()->fields()));
-      int64_t dictionary_id = -1;
-      RETURN_NOT_OK(dictionary_memo_->GetOrAssignId(field, &dictionary_id));
+      RETURN_NOT_OK(WriteChildren(dict_type.value_type()->fields(), field_pos));
+      ARROW_ASSIGN_OR_RAISE(const int64_t dictionary_id,
+                            mapper_.GetFieldId(field_pos.path()));
       RETURN_NOT_OK(WriteDictionaryMetadata(dictionary_id, dict_type));
     } else {
-      RETURN_NOT_OK(WriteChildren(type->fields()));
+      RETURN_NOT_OK(WriteChildren(type->fields(), field_pos));
     }
 
     WriteKeyValueMetadata(field->metadata(), additional_metadata);
@@ -220,7 +226,7 @@ class SchemaWriter {
 
   void WriteTypeMetadata(const MapType& type) {
     writer_->Key("keysSorted");
-    writer_->Int(type.keys_sorted());
+    writer_->Bool(type.keys_sorted());
   }
 
   void WriteTypeMetadata(const IntegerType& type) {
@@ -338,11 +344,14 @@ class SchemaWriter {
     return Status::OK();
   }
 
-  Status WriteChildren(const std::vector<std::shared_ptr<Field>>& children) {
+  Status WriteChildren(const std::vector<std::shared_ptr<Field>>& children,
+                       FieldPosition field_pos) {
     writer_->Key("children");
     writer_->StartArray();
+    int i = 0;
     for (const std::shared_ptr<Field>& field : children) {
-      RETURN_NOT_OK(VisitField(field));
+      RETURN_NOT_OK(VisitField(field, field_pos.child(i)));
+      ++i;
     }
     writer_->EndArray();
     return Status::OK();
@@ -411,7 +420,7 @@ class SchemaWriter {
 
  private:
   const Schema& schema_;
-  DictionaryMemo* dictionary_memo_;
+  const DictionaryFieldMapper& mapper_;
   RjWriter* writer_;
 };
 
@@ -686,38 +695,60 @@ class ArrayWriter {
   RjWriter* writer_;
 };
 
-static Status GetObjectInt(const RjObject& obj, const std::string& key, int* out) {
+Result<TimeUnit::type> GetUnitFromString(const std::string& unit_str) {
+  if (unit_str == "SECOND") {
+    return TimeUnit::SECOND;
+  } else if (unit_str == "MILLISECOND") {
+    return TimeUnit::MILLI;
+  } else if (unit_str == "MICROSECOND") {
+    return TimeUnit::MICRO;
+  } else if (unit_str == "NANOSECOND") {
+    return TimeUnit::NANO;
+  } else {
+    return Status::Invalid("Invalid time unit: ", unit_str);
+  }
+}
+
+template <typename IntType = int>
+Result<IntType> GetMemberInt(const RjObject& obj, const std::string& key) {
   const auto& it = obj.FindMember(key);
   RETURN_NOT_INT(key, it, obj);
-  *out = it->value.GetInt();
-  return Status::OK();
+  return static_cast<IntType>(it->value.GetInt64());
 }
 
-static Status GetObjectBool(const RjObject& obj, const std::string& key, bool* out) {
+Result<bool> GetMemberBool(const RjObject& obj, const std::string& key) {
   const auto& it = obj.FindMember(key);
   RETURN_NOT_BOOL(key, it, obj);
-  *out = it->value.GetBool();
-  return Status::OK();
+  return it->value.GetBool();
 }
 
-static Status GetObjectString(const RjObject& obj, const std::string& key,
-                              std::string* out) {
+Result<std::string> GetMemberString(const RjObject& obj, const std::string& key) {
   const auto& it = obj.FindMember(key);
   RETURN_NOT_STRING(key, it, obj);
-  *out = it->value.GetString();
-  return Status::OK();
+  return it->value.GetString();
 }
 
-static Status GetInteger(const rj::Value::ConstObject& json_type,
-                         std::shared_ptr<DataType>* type) {
-  const auto& it_bit_width = json_type.FindMember("bitWidth");
-  RETURN_NOT_INT("bitWidth", it_bit_width, json_type);
+Result<const RjObject> GetMemberObject(const RjObject& obj, const std::string& key) {
+  const auto& it = obj.FindMember(key);
+  RETURN_NOT_OBJECT(key, it, obj);
+  return it->value.GetObject();
+}
 
-  const auto& it_is_signed = json_type.FindMember("isSigned");
-  RETURN_NOT_BOOL("isSigned", it_is_signed, json_type);
+Result<const RjArray> GetMemberArray(const RjObject& obj, const std::string& key) {
+  const auto& it = obj.FindMember(key);
+  RETURN_NOT_ARRAY(key, it, obj);
+  return it->value.GetArray();
+}
 
-  bool is_signed = it_is_signed->value.GetBool();
-  int bit_width = it_bit_width->value.GetInt();
+Result<TimeUnit::type> GetMemberTimeUnit(const RjObject& obj, const std::string& key) {
+  ARROW_ASSIGN_OR_RAISE(const auto unit_str, GetMemberString(obj, key));
+  return GetUnitFromString(unit_str);
+}
+
+Status GetInteger(const rj::Value::ConstObject& json_type,
+                  std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const bool is_signed, GetMemberBool(json_type, "isSigned"));
+  ARROW_ASSIGN_OR_RAISE(const int bit_width, GetMemberInt<int>(json_type, "bitWidth"));
 
   switch (bit_width) {
     case 8:
@@ -738,12 +769,8 @@ static Status GetInteger(const rj::Value::ConstObject& json_type,
   return Status::OK();
 }
 
-static Status GetFloatingPoint(const RjObject& json_type,
-                               std::shared_ptr<DataType>* type) {
-  const auto& it_precision = json_type.FindMember("precision");
-  RETURN_NOT_STRING("precision", it_precision, json_type);
-
-  std::string precision = it_precision->value.GetString();
+Status GetFloatingPoint(const RjObject& json_type, std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const auto precision, GetMemberString(json_type, "precision"));
 
   if (precision == "DOUBLE") {
     *type = float64();
@@ -757,61 +784,48 @@ static Status GetFloatingPoint(const RjObject& json_type,
   return Status::OK();
 }
 
-static Status GetMap(const RjObject& json_type,
-                     const std::vector<std::shared_ptr<Field>>& children,
-                     std::shared_ptr<DataType>* type) {
+Status GetMap(const RjObject& json_type,
+              const std::vector<std::shared_ptr<Field>>& children,
+              std::shared_ptr<DataType>* type) {
   if (children.size() != 1) {
     return Status::Invalid("Map must have exactly one child");
   }
 
-  const auto& it_keys_sorted = json_type.FindMember("keysSorted");
-  RETURN_NOT_BOOL("keysSorted", it_keys_sorted, json_type);
-  bool keys_sorted = it_keys_sorted->value.GetBool();
-
+  ARROW_ASSIGN_OR_RAISE(const bool keys_sorted, GetMemberBool(json_type, "keysSorted"));
   return MapType::Make(children[0], keys_sorted).Value(type);
 }
 
-static Status GetFixedSizeBinary(const RjObject& json_type,
-                                 std::shared_ptr<DataType>* type) {
-  const auto& it_byte_width = json_type.FindMember("byteWidth");
-  RETURN_NOT_INT("byteWidth", it_byte_width, json_type);
-
-  int32_t byte_width = it_byte_width->value.GetInt();
+Status GetFixedSizeBinary(const RjObject& json_type, std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const int32_t byte_width,
+                        GetMemberInt<int32_t>(json_type, "byteWidth"));
   *type = fixed_size_binary(byte_width);
   return Status::OK();
 }
 
-static Status GetFixedSizeList(const RjObject& json_type,
-                               const std::vector<std::shared_ptr<Field>>& children,
-                               std::shared_ptr<DataType>* type) {
+Status GetFixedSizeList(const RjObject& json_type,
+                        const std::vector<std::shared_ptr<Field>>& children,
+                        std::shared_ptr<DataType>* type) {
   if (children.size() != 1) {
     return Status::Invalid("FixedSizeList must have exactly one child");
   }
 
-  const auto& it_list_size = json_type.FindMember("listSize");
-  RETURN_NOT_INT("listSize", it_list_size, json_type);
-
-  int32_t list_size = it_list_size->value.GetInt();
+  ARROW_ASSIGN_OR_RAISE(const int32_t list_size,
+                        GetMemberInt<int32_t>(json_type, "listSize"));
   *type = fixed_size_list(children[0], list_size);
   return Status::OK();
 }
 
-static Status GetDecimal(const RjObject& json_type, std::shared_ptr<DataType>* type) {
-  const auto& it_precision = json_type.FindMember("precision");
-  const auto& it_scale = json_type.FindMember("scale");
+Status GetDecimal(const RjObject& json_type, std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const int32_t precision,
+                        GetMemberInt<int32_t>(json_type, "precision"));
+  ARROW_ASSIGN_OR_RAISE(const int32_t scale, GetMemberInt<int32_t>(json_type, "scale"));
 
-  RETURN_NOT_INT("precision", it_precision, json_type);
-  RETURN_NOT_INT("scale", it_scale, json_type);
-
-  *type = decimal(it_precision->value.GetInt(), it_scale->value.GetInt());
+  *type = decimal(precision, scale);
   return Status::OK();
 }
 
-static Status GetDate(const RjObject& json_type, std::shared_ptr<DataType>* type) {
-  const auto& it_unit = json_type.FindMember("unit");
-  RETURN_NOT_STRING("unit", it_unit, json_type);
-
-  std::string unit_str = it_unit->value.GetString();
+Status GetDate(const RjObject& json_type, std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const auto unit_str, GetMemberString(json_type, "unit"));
 
   if (unit_str == "DAY") {
     *type = date32();
@@ -823,14 +837,9 @@ static Status GetDate(const RjObject& json_type, std::shared_ptr<DataType>* type
   return Status::OK();
 }
 
-static Status GetTime(const RjObject& json_type, std::shared_ptr<DataType>* type) {
-  const auto& it_unit = json_type.FindMember("unit");
-  RETURN_NOT_STRING("unit", it_unit, json_type);
-
-  const auto& it_bit_width = json_type.FindMember("bitWidth");
-  RETURN_NOT_INT("bitWidth", it_bit_width, json_type);
-
-  std::string unit_str = it_unit->value.GetString();
+Status GetTime(const RjObject& json_type, std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const auto unit_str, GetMemberString(json_type, "unit"));
+  ARROW_ASSIGN_OR_RAISE(const int bit_width, GetMemberInt<int>(json_type, "bitWidth"));
 
   if (unit_str == "SECOND") {
     *type = time32(TimeUnit::SECOND);
@@ -846,7 +855,6 @@ static Status GetTime(const RjObject& json_type, std::shared_ptr<DataType>* type
 
   const auto& fw_type = checked_cast<const FixedWidthType&>(**type);
 
-  int bit_width = it_bit_width->value.GetInt();
   if (bit_width != fw_type.bit_width()) {
     return Status::Invalid("Indicated bit width does not match unit");
   }
@@ -854,79 +862,45 @@ static Status GetTime(const RjObject& json_type, std::shared_ptr<DataType>* type
   return Status::OK();
 }
 
-static Status GetUnitFromString(const std::string& unit_str, TimeUnit::type* unit) {
-  if (unit_str == "SECOND") {
-    *unit = TimeUnit::SECOND;
-  } else if (unit_str == "MILLISECOND") {
-    *unit = TimeUnit::MILLI;
-  } else if (unit_str == "MICROSECOND") {
-    *unit = TimeUnit::MICRO;
-  } else if (unit_str == "NANOSECOND") {
-    *unit = TimeUnit::NANO;
-  } else {
-    return Status::Invalid("Invalid time unit: ", unit_str);
-  }
-  return Status::OK();
-}
-
-static Status GetDuration(const RjObject& json_type, std::shared_ptr<DataType>* type) {
-  const auto& it_unit = json_type.FindMember("unit");
-  RETURN_NOT_STRING("unit", it_unit, json_type);
-
-  std::string unit_str = it_unit->value.GetString();
-
-  TimeUnit::type unit;
-  RETURN_NOT_OK(GetUnitFromString(unit_str, &unit));
-
+Status GetDuration(const RjObject& json_type, std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const TimeUnit::type unit, GetMemberTimeUnit(json_type, "unit"));
   *type = duration(unit);
-
   return Status::OK();
 }
 
-static Status GetTimestamp(const RjObject& json_type, std::shared_ptr<DataType>* type) {
-  const auto& it_unit = json_type.FindMember("unit");
-  RETURN_NOT_STRING("unit", it_unit, json_type);
-
-  std::string unit_str = it_unit->value.GetString();
-
-  TimeUnit::type unit;
-  RETURN_NOT_OK(GetUnitFromString(unit_str, &unit));
+Status GetTimestamp(const RjObject& json_type, std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const TimeUnit::type unit, GetMemberTimeUnit(json_type, "unit"));
 
   const auto& it_tz = json_type.FindMember("timezone");
   if (it_tz == json_type.MemberEnd()) {
     *type = timestamp(unit);
   } else {
+    RETURN_NOT_STRING("timezone", it_tz, json_type);
     *type = timestamp(unit, it_tz->value.GetString());
   }
 
   return Status::OK();
 }
 
-static Status GetInterval(const RjObject& json_type, std::shared_ptr<DataType>* type) {
-  const auto& it_unit = json_type.FindMember("unit");
-  RETURN_NOT_STRING("unit", it_unit, json_type);
+Status GetInterval(const RjObject& json_type, std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const auto unit_str, GetMemberString(json_type, "unit"));
 
-  std::string unit_name = it_unit->value.GetString();
-
-  if (unit_name == kDayTime) {
+  if (unit_str == kDayTime) {
     *type = day_time_interval();
-  } else if (unit_name == kYearMonth) {
+  } else if (unit_str == kYearMonth) {
     *type = month_interval();
   } else {
-    return Status::Invalid("Invalid interval unit: " + unit_name);
+    return Status::Invalid("Invalid interval unit: " + unit_str);
   }
   return Status::OK();
 }
 
-static Status GetUnion(const RjObject& json_type,
-                       const std::vector<std::shared_ptr<Field>>& children,
-                       std::shared_ptr<DataType>* type) {
-  const auto& it_mode = json_type.FindMember("mode");
-  RETURN_NOT_STRING("mode", it_mode, json_type);
+Status GetUnion(const RjObject& json_type,
+                const std::vector<std::shared_ptr<Field>>& children,
+                std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const auto mode_str, GetMemberString(json_type, "mode"));
 
-  std::string mode_str = it_mode->value.GetString();
   UnionMode::type mode;
-
   if (mode_str == "SPARSE") {
     mode = UnionMode::SPARSE;
   } else if (mode_str == "DENSE") {
@@ -935,14 +909,14 @@ static Status GetUnion(const RjObject& json_type,
     return Status::Invalid("Invalid union mode: ", mode_str);
   }
 
-  const auto& it_type_codes = json_type.FindMember("typeIds");
-  RETURN_NOT_ARRAY("typeIds", it_type_codes, json_type);
+  ARROW_ASSIGN_OR_RAISE(const auto json_type_codes, GetMemberArray(json_type, "typeIds"));
 
   std::vector<int8_t> type_codes;
-  const auto& id_array = it_type_codes->value.GetArray();
-  type_codes.reserve(id_array.Size());
-  for (const rj::Value& val : id_array) {
-    DCHECK(val.IsInt());
+  type_codes.reserve(json_type_codes.Size());
+  for (const rj::Value& val : json_type_codes) {
+    if (!val.IsInt()) {
+      return Status::Invalid("Union type codes must be integers");
+    }
     type_codes.push_back(static_cast<int8_t>(val.GetInt()));
   }
 
@@ -955,13 +929,10 @@ static Status GetUnion(const RjObject& json_type,
   return Status::OK();
 }
 
-static Status GetType(const RjObject& json_type,
-                      const std::vector<std::shared_ptr<Field>>& children,
-                      std::shared_ptr<DataType>* type) {
-  const auto& it_type_name = json_type.FindMember("name");
-  RETURN_NOT_STRING("name", it_type_name, json_type);
-
-  std::string type_name = it_type_name->value.GetString();
+Status GetType(const RjObject& json_type,
+               const std::vector<std::shared_ptr<Field>>& children,
+               std::shared_ptr<DataType>* type) {
+  ARROW_ASSIGN_OR_RAISE(const auto type_name, GetMemberString(json_type, "name"));
 
   if (type_name == "int") {
     return GetInteger(json_type, type);
@@ -1017,35 +988,28 @@ static Status GetType(const RjObject& json_type,
   return Status::OK();
 }
 
-static Status GetField(const rj::Value& obj, DictionaryMemo* dictionary_memo,
-                       std::shared_ptr<Field>* field);
+Status GetField(const rj::Value& obj, FieldPosition field_pos,
+                DictionaryMemo* dictionary_memo, std::shared_ptr<Field>* field);
 
-static Status GetFieldsFromArray(const rj::Value& obj, DictionaryMemo* dictionary_memo,
-                                 std::vector<std::shared_ptr<Field>>* fields) {
-  const auto& values = obj.GetArray();
-
-  fields->resize(values.Size());
-  for (rj::SizeType i = 0; i < fields->size(); ++i) {
-    RETURN_NOT_OK(GetField(values[i], dictionary_memo, &(*fields)[i]));
+Status GetFieldsFromArray(const RjArray& json_fields, FieldPosition parent_pos,
+                          DictionaryMemo* dictionary_memo,
+                          std::vector<std::shared_ptr<Field>>* fields) {
+  fields->resize(json_fields.Size());
+  for (rj::SizeType i = 0; i < json_fields.Size(); ++i) {
+    RETURN_NOT_OK(GetField(json_fields[i], parent_pos.child(static_cast<int>(i)),
+                           dictionary_memo, &(*fields)[i]));
   }
   return Status::OK();
 }
 
-static Status ParseDictionary(const RjObject& obj, int64_t* id, bool* is_ordered,
-                              std::shared_ptr<DataType>* index_type) {
-  int32_t int32_id;
-  RETURN_NOT_OK(GetObjectInt(obj, "id", &int32_id));
-  *id = int32_id;
+Status ParseDictionary(const RjObject& obj, int64_t* id, bool* is_ordered,
+                       std::shared_ptr<DataType>* index_type) {
+  ARROW_ASSIGN_OR_RAISE(*id, GetMemberInt<int64_t>(obj, "id"));
+  ARROW_ASSIGN_OR_RAISE(*is_ordered, GetMemberBool(obj, "isOrdered"));
 
-  RETURN_NOT_OK(GetObjectBool(obj, "isOrdered", is_ordered));
+  ARROW_ASSIGN_OR_RAISE(const auto json_index_type, GetMemberObject(obj, "indexType"));
 
-  const auto& it_index_type = obj.FindMember("indexType");
-  RETURN_NOT_OBJECT("indexType", it_index_type, obj);
-
-  const auto& json_index_type = it_index_type->value.GetObject();
-
-  std::string type_name;
-  RETURN_NOT_OK(GetObjectString(json_index_type, "name", &type_name));
+  ARROW_ASSIGN_OR_RAISE(const auto type_name, GetMemberString(json_index_type, "name"));
   if (type_name != "int") {
     return Status::Invalid("Dictionary indices can only be integers");
   }
@@ -1053,66 +1017,56 @@ static Status ParseDictionary(const RjObject& obj, int64_t* id, bool* is_ordered
 }
 
 template <typename FieldOrStruct>
-static Status GetKeyValueMetadata(const FieldOrStruct& field_or_struct,
-                                  std::shared_ptr<KeyValueMetadata>* out) {
+Status GetKeyValueMetadata(const FieldOrStruct& field_or_struct,
+                           std::shared_ptr<KeyValueMetadata>* out) {
   out->reset(new KeyValueMetadata);
   auto it = field_or_struct.FindMember("metadata");
-  if (it == field_or_struct.MemberEnd()) {
+  if (it == field_or_struct.MemberEnd() || it->value.IsNull()) {
     return Status::OK();
   }
-
-  if (it->value.IsNull()) {
-    return Status::OK();
-  }
-
   if (!it->value.IsArray()) {
     return Status::Invalid("Metadata was not a JSON array");
   }
-  const auto& key_value_pairs = it->value.GetArray();
 
-  for (auto it = key_value_pairs.Begin(); it != key_value_pairs.End(); ++it) {
-    if (!it->IsObject()) {
+  for (const auto& val : it->value.GetArray()) {
+    if (!val.IsObject()) {
       return Status::Invalid("Metadata KeyValue was not a JSON object");
     }
-    const auto& key_value_pair = it->GetObject();
+    const auto& key_value_pair = val.GetObject();
 
-    std::string key, value;
-    RETURN_NOT_OK(GetObjectString(key_value_pair, "key", &key));
-    RETURN_NOT_OK(GetObjectString(key_value_pair, "value", &value));
+    ARROW_ASSIGN_OR_RAISE(const auto key, GetMemberString(key_value_pair, "key"));
+    ARROW_ASSIGN_OR_RAISE(const auto value, GetMemberString(key_value_pair, "value"));
 
     (*out)->Append(std::move(key), std::move(value));
   }
   return Status::OK();
 }
 
-static Status GetField(const rj::Value& obj, DictionaryMemo* dictionary_memo,
-                       std::shared_ptr<Field>* field) {
+Status GetField(const rj::Value& obj, FieldPosition field_pos,
+                DictionaryMemo* dictionary_memo, std::shared_ptr<Field>* field) {
   if (!obj.IsObject()) {
     return Status::Invalid("Field was not a JSON object");
   }
   const auto& json_field = obj.GetObject();
 
-  std::string name;
-  bool nullable;
-  RETURN_NOT_OK(GetObjectString(json_field, "name", &name));
-  RETURN_NOT_OK(GetObjectBool(json_field, "nullable", &nullable));
-
   std::shared_ptr<DataType> type;
-  const auto& it_type = json_field.FindMember("type");
-  RETURN_NOT_OBJECT("type", it_type, json_field);
 
-  const auto& it_children = json_field.FindMember("children");
-  RETURN_NOT_ARRAY("children", it_children, json_field);
+  ARROW_ASSIGN_OR_RAISE(const auto name, GetMemberString(json_field, "name"));
+  ARROW_ASSIGN_OR_RAISE(const bool nullable, GetMemberBool(json_field, "nullable"));
+
+  ARROW_ASSIGN_OR_RAISE(const auto json_type, GetMemberObject(json_field, "type"));
+  ARROW_ASSIGN_OR_RAISE(const auto json_children, GetMemberArray(json_field, "children"));
 
   std::vector<std::shared_ptr<Field>> children;
-  RETURN_NOT_OK(GetFieldsFromArray(it_children->value, dictionary_memo, &children));
-  RETURN_NOT_OK(GetType(it_type->value.GetObject(), children, &type));
+  RETURN_NOT_OK(GetFieldsFromArray(json_children, field_pos, dictionary_memo, &children));
+  RETURN_NOT_OK(GetType(json_type, children, &type));
 
   std::shared_ptr<KeyValueMetadata> metadata;
   RETURN_NOT_OK(GetKeyValueMetadata(json_field, &metadata));
 
   // Is it a dictionary type?
   int64_t dictionary_id = -1;
+  std::shared_ptr<DataType> dict_value_type;
   const auto& it_dictionary = json_field.FindMember("dictionary");
   if (dictionary_memo != nullptr && it_dictionary != json_field.MemberEnd()) {
     // Parse dictionary id in JSON and add dictionary field to the
@@ -1123,6 +1077,7 @@ static Status GetField(const rj::Value& obj, DictionaryMemo* dictionary_memo,
     RETURN_NOT_OK(ParseDictionary(it_dictionary->value.GetObject(), &dictionary_id,
                                   &is_ordered, &index_type));
 
+    dict_value_type = type;
     type = ::arrow::dictionary(index_type, type, is_ordered);
   }
 
@@ -1151,7 +1106,8 @@ static Status GetField(const rj::Value& obj, DictionaryMemo* dictionary_memo,
   // Create field
   *field = ::arrow::field(name, type, nullable, metadata);
   if (dictionary_id != -1) {
-    RETURN_NOT_OK(dictionary_memo->AddField(dictionary_id, *field));
+    RETURN_NOT_OK(dictionary_memo->fields().AddField(dictionary_id, field_pos.path()));
+    RETURN_NOT_OK(dictionary_memo->AddDictionaryType(dictionary_id, dict_value_type));
   }
 
   return Status::OK();
@@ -1192,36 +1148,40 @@ enable_if_physical_floating_point<T, typename T::c_type> UnboxValue(
 
 class ArrayReader {
  public:
-  ArrayReader(const RjObject& obj, MemoryPool* pool, const std::shared_ptr<Field>& field,
-              DictionaryMemo* dictionary_memo)
-      : obj_(obj),
-        pool_(pool),
-        field_(field),
-        type_(field->type()),
-        dictionary_memo_(dictionary_memo),
-        dictionary_id_(-1) {}
+  ArrayReader(const RjObject& obj, MemoryPool* pool, const std::shared_ptr<Field>& field)
+      : obj_(obj), pool_(pool), field_(field), type_(field->type()) {}
+
+  template <typename BuilderType>
+  Status FinishBuilder(BuilderType* builder) {
+    std::shared_ptr<Array> array;
+    RETURN_NOT_OK(builder->Finish(&array));
+    data_ = array->data();
+    return Status::OK();
+  }
+
+  Result<const RjArray> GetDataArray(const RjObject& obj) {
+    ARROW_ASSIGN_OR_RAISE(const auto json_data_arr, GetMemberArray(obj, kData));
+    if (static_cast<int32_t>(json_data_arr.Size()) != length_) {
+      return Status::Invalid("JSON DATA array size differs from advertised array length");
+    }
+    return json_data_arr;
+  }
 
   template <typename T>
   enable_if_has_c_type<T, Status> Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(type_, pool_);
 
-    const auto& json_data = obj_.FindMember(kData);
-    RETURN_NOT_ARRAY(kData, json_data, obj_);
+    ARROW_ASSIGN_OR_RAISE(const auto json_data_arr, GetDataArray(obj_));
 
-    const auto& json_data_arr = json_data->value.GetArray();
-
-    DCHECK_EQ(static_cast<int32_t>(json_data_arr.Size()), length_);
     for (int i = 0; i < length_; ++i) {
       if (!is_valid_[i]) {
         RETURN_NOT_OK(builder.AppendNull());
         continue;
       }
-
       const rj::Value& val = json_data_arr[i];
       RETURN_NOT_OK(builder.Append(UnboxValue<T>(val)));
     }
-
-    return builder.Finish(&result_);
+    return FinishBuilder(&builder);
   }
 
   template <typename T>
@@ -1229,19 +1189,13 @@ class ArrayReader {
     typename TypeTraits<T>::BuilderType builder(pool_);
     using offset_type = typename T::offset_type;
 
-    const auto& json_data = obj_.FindMember(kData);
-    RETURN_NOT_ARRAY(kData, json_data, obj_);
-
-    const auto& json_data_arr = json_data->value.GetArray();
-
-    DCHECK_EQ(static_cast<int32_t>(json_data_arr.Size()), length_);
+    ARROW_ASSIGN_OR_RAISE(const auto json_data_arr, GetDataArray(obj_));
 
     for (int i = 0; i < length_; ++i) {
       if (!is_valid_[i]) {
         RETURN_NOT_OK(builder.AppendNull());
         continue;
       }
-
       const rj::Value& val = json_data_arr[i];
       DCHECK(val.IsString());
 
@@ -1266,20 +1220,13 @@ class ArrayReader {
             builder.Append(byte_buffer_data, static_cast<offset_type>(value_len)));
       }
     }
-
-    return builder.Finish(&result_);
+    return FinishBuilder(&builder);
   }
 
   Status Visit(const DayTimeIntervalType& type) {
     DayTimeIntervalBuilder builder(pool_);
 
-    const auto& json_data = obj_.FindMember(kData);
-    RETURN_NOT_ARRAY(kData, json_data, obj_);
-
-    const auto& json_data_arr = json_data->value.GetArray();
-
-    DCHECK_EQ(static_cast<int32_t>(json_data_arr.Size()), length_)
-        << "data length: " << json_data_arr.Size() << " != length_: " << length_;
+    ARROW_ASSIGN_OR_RAISE(const auto json_data_arr, GetDataArray(obj_));
 
     for (int i = 0; i < length_; ++i) {
       if (!is_valid_[i]) {
@@ -1294,7 +1241,7 @@ class ArrayReader {
       dm.milliseconds = val[kMilliseconds].GetInt();
       RETURN_NOT_OK(builder.Append(dm));
     }
-    return builder.Finish(&result_);
+    return FinishBuilder(&builder);
   }
 
   template <typename T>
@@ -1302,12 +1249,8 @@ class ArrayReader {
   Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(type_, pool_);
 
-    const auto& json_data = obj_.FindMember(kData);
-    RETURN_NOT_ARRAY(kData, json_data, obj_);
+    ARROW_ASSIGN_OR_RAISE(const auto json_data_arr, GetDataArray(obj_));
 
-    const auto& json_data_arr = json_data->value.GetArray();
-
-    DCHECK_EQ(static_cast<int32_t>(json_data_arr.Size()), length_);
     int32_t byte_width = type.byte_width();
 
     // Allocate space for parsed values
@@ -1334,19 +1277,14 @@ class ArrayReader {
         RETURN_NOT_OK(builder.Append(byte_buffer_data));
       }
     }
-    return builder.Finish(&result_);
+    return FinishBuilder(&builder);
   }
 
   template <typename T>
   enable_if_decimal<T, Status> Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(type_, pool_);
 
-    const auto& json_data = obj_.FindMember(kData);
-    RETURN_NOT_ARRAY(kData, json_data, obj_);
-
-    const auto& json_data_arr = json_data->value.GetArray();
-
-    DCHECK_EQ(static_cast<int32_t>(json_data_arr.Size()), length_);
+    ARROW_ASSIGN_OR_RAISE(const auto json_data_arr, GetDataArray(obj_));
 
     for (int i = 0; i < length_; ++i) {
       if (!is_valid_[i]) {
@@ -1363,7 +1301,8 @@ class ArrayReader {
         RETURN_NOT_OK(builder.Append(value));
       }
     }
-    return builder.Finish(&result_);
+
+    return FinishBuilder(&builder);
   }
 
   template <typename T>
@@ -1386,7 +1325,6 @@ class ArrayReader {
     } else {
       // Read 64-bit integers as strings, as JSON numbers cannot represent
       // them exactly.
-
       for (int i = 0; i < length; ++i) {
         const rj::Value& val = json_array[i];
         DCHECK(val.IsString());
@@ -1403,174 +1341,137 @@ class ArrayReader {
   }
 
   template <typename T>
-  Status CreateList(const std::shared_ptr<DataType>& type, std::shared_ptr<Array>* out) {
+  Status CreateList(const std::shared_ptr<DataType>& type) {
     using offset_type = typename T::offset_type;
-    using ArrayType = typename TypeTraits<T>::ArrayType;
 
-    int32_t null_count = 0;
-    std::shared_ptr<Buffer> validity_buffer;
-    RETURN_NOT_OK(GetValidityBuffer(is_valid_, &null_count, &validity_buffer));
+    RETURN_NOT_OK(InitializeData(2));
 
-    const auto& json_offsets = obj_.FindMember("OFFSET");
-    RETURN_NOT_ARRAY("OFFSET", json_offsets, obj_);
-    std::shared_ptr<Buffer> offsets_buffer;
-    RETURN_NOT_OK(GetIntArray<offset_type>(json_offsets->value.GetArray(), length_ + 1,
-                                           &offsets_buffer));
-
-    std::vector<std::shared_ptr<Array>> children;
-    RETURN_NOT_OK(GetChildren(obj_, *type, &children));
-    DCHECK_EQ(children.size(), 1);
-
-    out->reset(new ArrayType(type, length_, offsets_buffer, children[0], validity_buffer,
-                             null_count));
+    RETURN_NOT_OK(GetNullBitmap());
+    ARROW_ASSIGN_OR_RAISE(const auto json_offsets, GetMemberArray(obj_, "OFFSET"));
+    RETURN_NOT_OK(
+        GetIntArray<offset_type>(json_offsets, length_ + 1, &data_->buffers[1]));
+    RETURN_NOT_OK(GetChildren(obj_, *type));
     return Status::OK();
   }
 
   template <typename T>
   enable_if_var_size_list<T, Status> Visit(const T& type) {
-    return CreateList<T>(type_, &result_);
+    return CreateList<T>(type_);
   }
 
   Status Visit(const MapType& type) {
     auto list_type = std::make_shared<ListType>(type.value_field());
-    std::shared_ptr<Array> list_array;
-    RETURN_NOT_OK(CreateList<ListType>(list_type, &list_array));
-    auto map_data = list_array->data();
-    map_data->type = type_;
-    result_ = std::make_shared<MapArray>(map_data);
+    RETURN_NOT_OK(CreateList<ListType>(list_type));
+    data_->type = type_;
     return Status::OK();
   }
 
   Status Visit(const FixedSizeListType& type) {
-    int32_t null_count = 0;
-    std::shared_ptr<Buffer> validity_buffer;
-    RETURN_NOT_OK(GetValidityBuffer(is_valid_, &null_count, &validity_buffer));
+    RETURN_NOT_OK(InitializeData(1));
+    RETURN_NOT_OK(GetNullBitmap());
 
-    std::vector<std::shared_ptr<Array>> children;
-    RETURN_NOT_OK(GetChildren(obj_, type, &children));
-    DCHECK_EQ(children.size(), 1);
-    DCHECK_EQ(children[0]->length(), type.list_size() * length_);
-
-    result_ = std::make_shared<FixedSizeListArray>(type_, length_, children[0],
-                                                   validity_buffer, null_count);
-
+    RETURN_NOT_OK(GetChildren(obj_, type));
+    DCHECK_EQ(data_->child_data[0]->length, type.list_size() * length_);
     return Status::OK();
   }
 
   Status Visit(const StructType& type) {
-    int32_t null_count = 0;
-    std::shared_ptr<Buffer> validity_buffer;
-    RETURN_NOT_OK(GetValidityBuffer(is_valid_, &null_count, &validity_buffer));
+    RETURN_NOT_OK(InitializeData(1));
 
-    std::vector<std::shared_ptr<Array>> fields;
-    RETURN_NOT_OK(GetChildren(obj_, type, &fields));
-
-    result_ = std::make_shared<StructArray>(type_, length_, fields, validity_buffer,
-                                            null_count);
-
+    RETURN_NOT_OK(GetNullBitmap());
+    RETURN_NOT_OK(GetChildren(obj_, type));
     return Status::OK();
   }
 
-  Status Visit(const UnionType& type) {
-    std::shared_ptr<Buffer> type_id_buffer;
+  Status GetUnionTypeIds() {
+    ARROW_ASSIGN_OR_RAISE(const auto json_type_ids, GetMemberArray(obj_, "TYPE_ID"));
+    return GetIntArray<uint8_t>(json_type_ids, length_, &data_->buffers[1]);
+  }
 
-    const auto& json_type_ids = obj_.FindMember("TYPE_ID");
-    RETURN_NOT_ARRAY("TYPE_ID", json_type_ids, obj_);
-    RETURN_NOT_OK(
-        GetIntArray<uint8_t>(json_type_ids->value.GetArray(), length_, &type_id_buffer));
+  Status Visit(const SparseUnionType& type) {
+    RETURN_NOT_OK(InitializeData(2));
 
-    std::vector<std::shared_ptr<Array>> children;
-    RETURN_NOT_OK(GetChildren(obj_, type, &children));
-
-    if (type.mode() == UnionMode::SPARSE) {
-      result_ =
-          std::make_shared<SparseUnionArray>(type_, length_, children, type_id_buffer);
-    } else {
-      const auto& json_offsets = obj_.FindMember("OFFSET");
-      RETURN_NOT_ARRAY("OFFSET", json_offsets, obj_);
-
-      std::shared_ptr<Buffer> offsets_buffer;
-      RETURN_NOT_OK(
-          GetIntArray<int32_t>(json_offsets->value.GetArray(), length_, &offsets_buffer));
-
-      result_ = std::make_shared<DenseUnionArray>(type_, length_, children,
-                                                  type_id_buffer, offsets_buffer);
-    }
-
+    RETURN_NOT_OK(GetNullBitmap());
+    RETURN_NOT_OK(GetUnionTypeIds());
+    RETURN_NOT_OK(GetChildren(obj_, type));
     return Status::OK();
+  }
+
+  Status Visit(const DenseUnionType& type) {
+    RETURN_NOT_OK(InitializeData(3));
+
+    RETURN_NOT_OK(GetNullBitmap());
+    RETURN_NOT_OK(GetUnionTypeIds());
+    RETURN_NOT_OK(GetChildren(obj_, type));
+
+    ARROW_ASSIGN_OR_RAISE(const auto json_offsets, GetMemberArray(obj_, "OFFSET"));
+    return GetIntArray<int32_t>(json_offsets, length_, &data_->buffers[2]);
   }
 
   Status Visit(const NullType& type) {
-    result_ = std::make_shared<NullArray>(length_);
+    data_ = std::make_shared<NullArray>(length_)->data();
     return Status::OK();
   }
 
   Status Visit(const DictionaryType& type) {
-    std::shared_ptr<Array> indices;
+    ArrayReader parser(obj_, pool_, ::arrow::field("indices", type.index_type()));
+    ARROW_ASSIGN_OR_RAISE(data_, parser.Parse());
 
-    ArrayReader parser(obj_, pool_, ::arrow::field("indices", type.index_type()),
-                       dictionary_memo_);
-    RETURN_NOT_OK(parser.Parse(&indices));
-
-    RETURN_NOT_OK(LookupDictionaryId(field_));
-    std::shared_ptr<Array> dictionary;
-    RETURN_NOT_OK(dictionary_memo_->GetDictionary(dictionary_id_, &dictionary));
-
-    result_ = std::make_shared<DictionaryArray>(field_->type(), indices, dictionary);
+    data_->type = field_->type();
+    // data_->dictionary will be filled later by ResolveDictionaries()
     return Status::OK();
   }
 
   Status Visit(const ExtensionType& type) {
-    std::shared_ptr<Array> storage_array;
-
-    ArrayReader parser(obj_, pool_, field_->WithType(type.storage_type()),
-                       dictionary_memo_);
+    ArrayReader parser(obj_, pool_, field_->WithType(type.storage_type()));
+    ARROW_ASSIGN_OR_RAISE(data_, parser.Parse());
+    data_->type = type_;
     // If the storage array is a dictionary array, lookup its dictionary id
     // using the extension field.
     // (the field is looked up by pointer, so the Field instance constructed
     //  above wouldn't work)
-    if (parser.type_->id() == Type::DICTIONARY) {
-      RETURN_NOT_OK(parser.LookupDictionaryId(field_));
-    }
-    RETURN_NOT_OK(parser.Parse(&storage_array));
-    result_ = std::make_shared<ExtensionArray>(type_, storage_array);
     return Status::OK();
   }
 
-  Status GetValidityBuffer(const std::vector<bool>& is_valid, int32_t* null_count,
-                           std::shared_ptr<Buffer>* validity_buffer) {
-    int length = static_cast<int>(is_valid.size());
+  Status InitializeData(int num_buffers) {
+    data_ = std::make_shared<ArrayData>(type_, length_);
+    data_->buffers.resize(num_buffers);
+    return Status::OK();
+  }
 
-    ARROW_ASSIGN_OR_RAISE(auto out_buffer, AllocateEmptyBitmap(length, pool_));
-    uint8_t* bitmap = out_buffer->mutable_data();
+  Status GetNullBitmap() {
+    const int64_t length = static_cast<int64_t>(is_valid_.size());
 
-    *null_count = 0;
-    for (int i = 0; i < length; ++i) {
-      if (!is_valid[i]) {
-        ++(*null_count);
-        continue;
+    ARROW_ASSIGN_OR_RAISE(data_->buffers[0], AllocateEmptyBitmap(length, pool_));
+    uint8_t* bitmap = data_->buffers[0]->mutable_data();
+
+    data_->null_count = 0;
+    for (int64_t i = 0; i < length; ++i) {
+      if (is_valid_[i]) {
+        BitUtil::SetBit(bitmap, i);
+      } else {
+        ++data_->null_count;
       }
-      BitUtil::SetBit(bitmap, i);
+    }
+    if (data_->null_count == 0) {
+      data_->buffers[0].reset();
     }
 
-    *validity_buffer = out_buffer;
     return Status::OK();
   }
+  Status GetChildren(const RjObject& obj, const DataType& type) {
+    ARROW_ASSIGN_OR_RAISE(const auto json_children, GetMemberArray(obj, "children"));
 
-  Status GetChildren(const RjObject& obj, const DataType& type,
-                     std::vector<std::shared_ptr<Array>>* array) {
-    const auto& json_children = obj.FindMember("children");
-    RETURN_NOT_ARRAY("children", json_children, obj);
-    const auto& json_children_arr = json_children->value.GetArray();
-
-    if (type.num_fields() != static_cast<int>(json_children_arr.Size())) {
+    if (type.num_fields() != static_cast<int>(json_children.Size())) {
       return Status::Invalid("Expected ", type.num_fields(), " children, but got ",
-                             json_children_arr.Size());
+                             json_children.Size());
     }
 
-    for (int i = 0; i < static_cast<int>(json_children_arr.Size()); ++i) {
-      const rj::Value& json_child = json_children_arr[i];
+    data_->child_data.resize(type.num_fields());
+    for (int i = 0; i < type.num_fields(); ++i) {
+      const rj::Value& json_child = json_children[i];
       DCHECK(json_child.IsObject());
+      const auto& child_obj = json_child.GetObject();
 
       std::shared_ptr<Field> child_field = type.field(i);
 
@@ -1578,20 +1479,18 @@ class ArrayReader {
       RETURN_NOT_STRING("name", it, json_child);
 
       DCHECK_EQ(it->value.GetString(), child_field->name());
-      std::shared_ptr<Array> child;
-      RETURN_NOT_OK(
-          ReadArray(pool_, json_children_arr[i], child_field, dictionary_memo_, &child));
-      array->emplace_back(child);
+      ArrayReader child_reader(child_obj, pool_, child_field);
+      ARROW_ASSIGN_OR_RAISE(data_->child_data[i], child_reader.Parse());
     }
 
     return Status::OK();
   }
 
   Status ParseValidityBitmap() {
-    const auto& json_valid_iter = obj_.FindMember("VALIDITY");
-    RETURN_NOT_ARRAY("VALIDITY", json_valid_iter, obj_);
-    const auto& json_validity = json_valid_iter->value.GetArray();
-    DCHECK_EQ(static_cast<int>(json_validity.Size()), length_);
+    ARROW_ASSIGN_OR_RAISE(const auto json_validity, GetMemberArray(obj_, "VALIDITY"));
+    if (static_cast<int>(json_validity.Size()) != length_) {
+      return Status::Invalid("JSON VALIDITY size differs from advertised array length");
+    }
     is_valid_.reserve(json_validity.Size());
     for (const rj::Value& val : json_validity) {
       DCHECK(val.IsInt());
@@ -1600,8 +1499,8 @@ class ArrayReader {
     return Status::OK();
   }
 
-  Status Parse(std::shared_ptr<Array>* out) {
-    RETURN_NOT_OK(GetObjectInt(obj_, "count", &length_));
+  Result<std::shared_ptr<ArrayData>> Parse() {
+    ARROW_ASSIGN_OR_RAISE(length_, GetMemberInt<int32_t>(obj_, "count"));
 
     if (::arrow::internal::HasValidityBitmap(type_->id())) {
       // Null and union types don't have a validity bitmap
@@ -1609,16 +1508,7 @@ class ArrayReader {
     }
 
     RETURN_NOT_OK(VisitTypeInline(*type_, this));
-
-    *out = result_;
-    return Status::OK();
-  }
-
-  Status LookupDictionaryId(const std::shared_ptr<Field>& field) {
-    if (dictionary_id_ == -1) {
-      RETURN_NOT_OK(dictionary_memo_->GetId(field.get(), &dictionary_id_));
-    }
-    return Status::OK();
+    return data_;
   }
 
  private:
@@ -1626,47 +1516,51 @@ class ArrayReader {
   MemoryPool* pool_;
   std::shared_ptr<Field> field_;
   std::shared_ptr<DataType> type_;
-  DictionaryMemo* dictionary_memo_;
-  int64_t dictionary_id_;
 
   // Parsed common attributes
   std::vector<bool> is_valid_;
   int32_t length_;
-  std::shared_ptr<Array> result_;
+  std::shared_ptr<ArrayData> data_;
 };
 
-Status WriteSchema(const Schema& schema, DictionaryMemo* dictionary_memo,
-                   RjWriter* json_writer) {
-  SchemaWriter converter(schema, dictionary_memo, json_writer);
-  return converter.Write();
-}
-
-static Status ReadDictionary(const RjObject& obj, MemoryPool* pool,
-                             DictionaryMemo* dictionary_memo) {
-  int id;
-  RETURN_NOT_OK(GetObjectInt(obj, "id", &id));
-
-  const auto& it_data = obj.FindMember("data");
-  RETURN_NOT_OBJECT("data", it_data, obj);
-
-  std::shared_ptr<DataType> value_type;
-  RETURN_NOT_OK(dictionary_memo->GetDictionaryType(id, &value_type));
-  auto value_field = ::arrow::field("dummy", value_type);
-
-  // We need a placeholder schema to read the record, because the dictionary
-  // is embedded in a record batch with a single column.
-  std::shared_ptr<RecordBatch> batch;
-  RETURN_NOT_OK(ReadRecordBatch(it_data->value, ::arrow::schema({value_field}),
-                                dictionary_memo, pool, &batch));
-
-  if (batch->num_columns() != 1) {
-    return Status::Invalid("Dictionary record batch must only contain one field");
+Result<std::shared_ptr<ArrayData>> ReadArrayData(MemoryPool* pool,
+                                                 const rj::Value& json_array,
+                                                 const std::shared_ptr<Field>& field) {
+  if (!json_array.IsObject()) {
+    return Status::Invalid("Array element was not a JSON object");
   }
-  return dictionary_memo->AddDictionary(id, batch->column(0));
+  auto obj = json_array.GetObject();
+  ArrayReader parser(obj, pool, field);
+  return parser.Parse();
 }
 
-static Status ReadDictionaries(const rj::Value& doc, MemoryPool* pool,
-                               DictionaryMemo* dictionary_memo) {
+Status ReadDictionary(const RjObject& obj, MemoryPool* pool,
+                      DictionaryMemo* dictionary_memo) {
+  ARROW_ASSIGN_OR_RAISE(int64_t dictionary_id, GetMemberInt<int64_t>(obj, "id"));
+
+  ARROW_ASSIGN_OR_RAISE(const auto batch_obj, GetMemberObject(obj, "data"));
+
+  ARROW_ASSIGN_OR_RAISE(auto value_type,
+                        dictionary_memo->GetDictionaryType(dictionary_id));
+
+  ARROW_ASSIGN_OR_RAISE(const int64_t num_rows,
+                        GetMemberInt<int64_t>(batch_obj, "count"));
+  ARROW_ASSIGN_OR_RAISE(const auto json_columns, GetMemberArray(batch_obj, "columns"));
+  if (json_columns.Size() != 1) {
+    return Status::Invalid("Dictionary batch must contain only one column");
+  }
+
+  ARROW_ASSIGN_OR_RAISE(auto dict_data,
+                        ReadArrayData(pool, json_columns[0], field("dummy", value_type)));
+  if (num_rows != dict_data->length) {
+    return Status::Invalid("Dictionary batch length mismatch: advertised (", num_rows,
+                           ") != actual (", dict_data->length, ")");
+  }
+  return dictionary_memo->AddDictionary(dictionary_id, dict_data);
+}
+
+Status ReadDictionaries(const rj::Value& doc, MemoryPool* pool,
+                        DictionaryMemo* dictionary_memo) {
   auto it = doc.FindMember("dictionaries");
   if (it == doc.MemberEnd()) {
     // No dictionaries
@@ -1683,25 +1577,34 @@ static Status ReadDictionaries(const rj::Value& doc, MemoryPool* pool,
   return Status::OK();
 }
 
+}  // namespace
+
 Status ReadSchema(const rj::Value& json_schema, MemoryPool* pool,
                   DictionaryMemo* dictionary_memo, std::shared_ptr<Schema>* schema) {
-  auto it = json_schema.FindMember("schema");
-  RETURN_NOT_OBJECT("schema", it, json_schema);
-  const auto& obj_schema = it->value.GetObject();
+  DCHECK(json_schema.IsObject());
+  ARROW_ASSIGN_OR_RAISE(const auto obj_schema,
+                        GetMemberObject(json_schema.GetObject(), "schema"));
 
-  const auto& it_fields = obj_schema.FindMember("fields");
-  RETURN_NOT_ARRAY("fields", it_fields, obj_schema);
+  ARROW_ASSIGN_OR_RAISE(const auto json_fields, GetMemberArray(obj_schema, "fields"));
 
   std::shared_ptr<KeyValueMetadata> metadata;
   RETURN_NOT_OK(GetKeyValueMetadata(obj_schema, &metadata));
 
   std::vector<std::shared_ptr<Field>> fields;
-  RETURN_NOT_OK(GetFieldsFromArray(it_fields->value, dictionary_memo, &fields));
+  RETURN_NOT_OK(
+      GetFieldsFromArray(json_fields, FieldPosition(), dictionary_memo, &fields));
 
   // Read the dictionaries (if any) and cache in the memo
   RETURN_NOT_OK(ReadDictionaries(json_schema, pool, dictionary_memo));
 
   *schema = ::arrow::schema(fields, metadata);
+  return Status::OK();
+}
+
+Status ReadArray(MemoryPool* pool, const rj::Value& json_array,
+                 const std::shared_ptr<Field>& field, std::shared_ptr<Array>* out) {
+  ARROW_ASSIGN_OR_RAISE(auto data, ReadArrayData(pool, json_array, field));
+  *out = MakeArray(data);
   return Status::OK();
 }
 
@@ -1711,22 +1614,27 @@ Status ReadRecordBatch(const rj::Value& json_obj, const std::shared_ptr<Schema>&
   DCHECK(json_obj.IsObject());
   const auto& batch_obj = json_obj.GetObject();
 
-  auto it = batch_obj.FindMember("count");
-  RETURN_NOT_INT("count", it, batch_obj);
-  int32_t num_rows = static_cast<int32_t>(it->value.GetInt());
+  ARROW_ASSIGN_OR_RAISE(const int64_t num_rows,
+                        GetMemberInt<int64_t>(batch_obj, "count"));
 
-  it = batch_obj.FindMember("columns");
-  RETURN_NOT_ARRAY("columns", it, batch_obj);
-  const auto& json_columns = it->value.GetArray();
+  ARROW_ASSIGN_OR_RAISE(const auto json_columns, GetMemberArray(batch_obj, "columns"));
 
-  std::vector<std::shared_ptr<Array>> columns(json_columns.Size());
+  ArrayDataVector columns(json_columns.Size());
   for (int i = 0; i < static_cast<int>(columns.size()); ++i) {
-    RETURN_NOT_OK(
-        ReadArray(pool, json_columns[i], schema->field(i), dictionary_memo, &columns[i]));
+    ARROW_ASSIGN_OR_RAISE(columns[i],
+                          ReadArrayData(pool, json_columns[i], schema->field(i)));
   }
+
+  RETURN_NOT_OK(ResolveDictionaries(columns, *dictionary_memo));
 
   *batch = RecordBatch::Make(schema, num_rows, columns);
   return Status::OK();
+}
+
+Status WriteSchema(const Schema& schema, const DictionaryFieldMapper& mapper,
+                   RjWriter* json_writer) {
+  SchemaWriter converter(schema, mapper, json_writer);
+  return converter.Write();
 }
 
 Status WriteDictionary(int64_t id, const std::shared_ptr<Array>& dictionary,
@@ -1770,37 +1678,6 @@ Status WriteRecordBatch(const RecordBatch& batch, RjWriter* writer) {
 Status WriteArray(const std::string& name, const Array& array, RjWriter* json_writer) {
   ArrayWriter converter(name, array, json_writer);
   return converter.Write();
-}
-
-Status ReadArray(MemoryPool* pool, const rj::Value& json_array,
-                 const std::shared_ptr<Field>& field, DictionaryMemo* dictionary_memo,
-                 std::shared_ptr<Array>* out) {
-  if (!json_array.IsObject()) {
-    return Status::Invalid("Array element was not a JSON object");
-  }
-  auto obj = json_array.GetObject();
-  ArrayReader parser(obj, pool, field, dictionary_memo);
-  return parser.Parse(out);
-}
-
-Status ReadArray(MemoryPool* pool, const rj::Value& json_array, const Schema& schema,
-                 DictionaryMemo* dictionary_memo, std::shared_ptr<Array>* array) {
-  if (!json_array.IsObject()) {
-    return Status::Invalid("Element was not a JSON object");
-  }
-
-  const auto& json_obj = json_array.GetObject();
-
-  const auto& it_name = json_obj.FindMember("name");
-  RETURN_NOT_STRING("name", it_name, json_obj);
-
-  std::string name = it_name->value.GetString();
-  std::shared_ptr<Field> result = schema.GetFieldByName(name);
-  if (result == nullptr) {
-    return Status::KeyError("Field named ", name, " not found in schema");
-  }
-
-  return ReadArray(pool, json_array, result, dictionary_memo, array);
 }
 
 }  // namespace json

--- a/cpp/src/arrow/testing/json_internal.cc
+++ b/cpp/src/arrow/testing/json_internal.cc
@@ -54,7 +54,7 @@ using internal::ParseValue;
 
 using ipc::DictionaryFieldMapper;
 using ipc::DictionaryMemo;
-using ipc::FieldPosition;
+using ipc::internal::FieldPosition;
 
 namespace testing {
 namespace json {

--- a/cpp/src/arrow/testing/json_internal.h
+++ b/cpp/src/arrow/testing/json_internal.h
@@ -84,6 +84,7 @@ class Schema;
 
 namespace ipc {
 
+class DictionaryFieldMapper;
 class DictionaryMemo;
 
 }  // namespace ipc
@@ -93,7 +94,7 @@ namespace json {
 
 /// \brief Append integration test Schema format to rapidjson writer
 ARROW_TESTING_EXPORT
-Status WriteSchema(const Schema& schema, ipc::DictionaryMemo* dict_memo,
+Status WriteSchema(const Schema& schema, const ipc::DictionaryFieldMapper& mapper,
                    RjWriter* writer);
 
 ARROW_TESTING_EXPORT
@@ -115,14 +116,10 @@ Status ReadRecordBatch(const rj::Value& json_obj, const std::shared_ptr<Schema>&
                        ipc::DictionaryMemo* dict_memo, MemoryPool* pool,
                        std::shared_ptr<RecordBatch>* batch);
 
+// NOTE: Doesn't work with dictionary arrays, use ReadRecordBatch instead.
 ARROW_TESTING_EXPORT
 Status ReadArray(MemoryPool* pool, const rj::Value& json_obj,
-                 const std::shared_ptr<Field>& type, ipc::DictionaryMemo* dict_memo,
-                 std::shared_ptr<Array>* array);
-
-ARROW_TESTING_EXPORT
-Status ReadArray(MemoryPool* pool, const rj::Value& json_obj, const Schema& schema,
-                 ipc::DictionaryMemo* dict_memo, std::shared_ptr<Array>* array);
+                 const std::shared_ptr<Field>& type, std::shared_ptr<Array>* array);
 
 }  // namespace json
 }  // namespace testing

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -763,9 +763,8 @@ Status GetSchemaMetadata(const ::arrow::Schema& schema, ::arrow::MemoryPool* poo
     result = ::arrow::key_value_metadata({}, {});
   }
 
-  ::arrow::ipc::DictionaryMemo dict_memo;
   ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Buffer> serialized,
-                        ::arrow::ipc::SerializeSchema(schema, &dict_memo, pool));
+                        ::arrow::ipc::SerializeSchema(schema, pool));
 
   // The serialized schema is not UTF-8, which is required for Thrift
   std::string schema_as_string = serialized->ToString();

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1441,8 +1441,7 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
         const CIpcReadOptions& options)
 
     CResult[shared_ptr[CBuffer]] SerializeSchema(
-        const CSchema& schema, CDictionaryMemo* dictionary_memo,
-        CMemoryPool* pool)
+        const CSchema& schema, CMemoryPool* pool)
 
     CResult[shared_ptr[CBuffer]] SerializeRecordBatch(
         const CRecordBatch& schema, const CIpcWriteOptions& options)

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -1498,7 +1498,7 @@ cdef class Schema(_Weakrefable):
 
         return pyarrow_wrap_schema(c_schema)
 
-    def serialize(self, DictionaryMemo dictionary_memo=None, memory_pool=None):
+    def serialize(self, memory_pool=None):
         """
         Write Schema to Buffer as encapsulated IPC message
 
@@ -1506,10 +1506,6 @@ cdef class Schema(_Weakrefable):
         ----------
         memory_pool : MemoryPool, default None
             Uses default memory pool if not specified
-        dictionary_memo : DictionaryMemo, optional
-            If schema contains dictionaries, must pass a
-            DictionaryMemo to be able to deserialize RecordBatch
-            objects
 
         Returns
         -------
@@ -1518,17 +1514,10 @@ cdef class Schema(_Weakrefable):
         cdef:
             shared_ptr[CBuffer] buffer
             CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)
-            CDictionaryMemo temp_memo
-            CDictionaryMemo* arg_dict_memo
-
-        if dictionary_memo is not None:
-            arg_dict_memo = dictionary_memo.memo
-        else:
-            arg_dict_memo = &temp_memo
 
         with nogil:
             buffer = GetResultValue(SerializeSchema(deref(self.schema),
-                                                    arg_dict_memo, pool))
+                                                    pool))
         return pyarrow_wrap_buffer(buffer)
 
     def remove_metadata(self):

--- a/r/src/recordbatch.cpp
+++ b/r/src/recordbatch.cpp
@@ -168,6 +168,7 @@ std::shared_ptr<arrow::RecordBatch> ipc___ReadRecordBatch__InputStream__Schema(
     const std::shared_ptr<arrow::Schema>& schema) {
   // TODO: promote to function arg
   arrow::ipc::DictionaryMemo memo;
+  StopIfNotOk(memo.fields().AddSchemaFields(*schema));
   return ValueOrStop(arrow::ipc::ReadRecordBatch(
       schema, &memo, arrow::ipc::IpcReadOptions::Defaults(), stream.get()));
 }

--- a/r/src/schema.cpp
+++ b/r/src/schema.cpp
@@ -18,7 +18,6 @@
 #include "./arrow_types.h"
 
 #if defined(ARROW_R_WITH_ARROW)
-#include <arrow/ipc/reader.h>
 #include <arrow/ipc/writer.h>
 #include <arrow/type.h>
 #include <arrow/util/key_value_metadata.h>
@@ -108,8 +107,7 @@ std::shared_ptr<arrow::Schema> Schema__WithMetadata(
 
 // [[arrow::export]]
 cpp11::writable::raws Schema__serialize(const std::shared_ptr<arrow::Schema>& schema) {
-  arrow::ipc::DictionaryMemo empty_memo;
-  auto out = ValueOrStop(arrow::ipc::SerializeSchema(*schema, &empty_memo));
+  auto out = ValueOrStop(arrow::ipc::SerializeSchema(*schema));
   auto n = out->size();
   return cpp11::writable::raws(out->data(), out->data() + n);
 }


### PR DESCRIPTION
When mapping schema or record batch fields to dictionary ids, we used to match using the `Field` object pointer, which was excessively fragile (and actually failed when dictionaries were embedded in maps).

This PR instead establishes an association between the structural field position (i.e. its path inside the schema or batch) to the dictionary id.

It also defers dictionary resolution, on the IPC read path, to when a record batch is read, which is more robust when nested dictionaries are encountered (in particular, it shouldn't be necessary anymore to emit dictionary batches in dependency order in an IPC stream, though we still do it to make life easier for other implementations).

Still, some situations are probably not supported, in particular dictionary deltas over nested dictionaries (because we validate such deltas even though their inner dictionaries have not been resolved).