### PR TITLE
ARROW-9266: [Python][Packaging] enable C++ S3FS in macOS wheels

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2612,8 +2612,6 @@ endif()
 # AWS SDK for C++
 
 macro(build_awssdk)
-  message(
-    FATAL_ERROR "FIXME: Building AWS C++ SDK from source will link with wrong libcrypto")
   message("Building AWS C++ SDK from source")
 
   set(AWSSDK_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/awssdk_ep-install")

--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -82,7 +82,6 @@ function build_wheel {
           -DARROW_WITH_SNAPPY=ON \
           -DARROW_WITH_ZLIB=ON \
           -DARROW_WITH_ZSTD=ON \
-          -DAWSSDK_SOURCE=SYSTEM \
           -DBOOST_SOURCE=SYSTEM \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \

--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -74,6 +74,7 @@ function build_wheel {
           -DARROW_PROTOBUF_USE_SHARED=OFF \
           -DARROW_PYTHON=ON \
           -DARROW_RPATH_ORIGIN=ON \
+          -DARROW_S3=ON \
           -DARROW_VERBOSE_THIRDPARTY_BUILD=ON \
           -DARROW_WITH_BROTLI=ON \
           -DARROW_WITH_BZ2=ON \
@@ -108,6 +109,7 @@ function build_wheel {
     export PYARROW_WITH_PLASMA=1
     export PYARROW_WITH_PARQUET=1
     export PYARROW_WITH_ORC=0
+    export PYARROW_WITH_S3=1
     export PYARROW_WITH_JEMALLOC=1
     export PYARROW_WITH_PLASMA=1
     export PYARROW_WITH_GANDIVA=0
@@ -157,6 +159,7 @@ import pyarrow.parquet
 import pyarrow.plasma
 import pyarrow.fs
 import pyarrow._hdfs
+import pyarrow._s3fs
 import pyarrow.dataset
 import pyarrow.flight
 "

--- a/dev/tasks/python-wheels/osx-build.sh
+++ b/dev/tasks/python-wheels/osx-build.sh
@@ -82,6 +82,7 @@ function build_wheel {
           -DARROW_WITH_SNAPPY=ON \
           -DARROW_WITH_ZLIB=ON \
           -DARROW_WITH_ZSTD=ON \
+          -DAWSSDK_SOURCE=SYSTEM \
           -DBOOST_SOURCE=SYSTEM \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -22,7 +22,6 @@ addons:
   homebrew:
     packages:
       - automake
-      - aws-sdk-cpp
       - bison
       - boost
       - brotli

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -21,6 +21,7 @@ language: generic
 addons:
   homebrew:
     packages:
+      - aws-sdk-cpp
       - automake
       - boost
       - brotli

--- a/dev/tasks/python-wheels/travis.osx.yml
+++ b/dev/tasks/python-wheels/travis.osx.yml
@@ -21,14 +21,16 @@ language: generic
 addons:
   homebrew:
     packages:
-      - aws-sdk-cpp
       - automake
+      - aws-sdk-cpp
+      - bison
       - boost
       - brotli
       - c-ares
       - ccache
       - cmake
       - flatbuffers
+      - flex
       - git
       - glog
       - grpc
@@ -44,8 +46,6 @@ addons:
       - thrift
       - wget
       - zstd
-      - bison
-      - flex
     update: true
 
 # don't build twice


### PR DESCRIPTION
This PR updates the osx-build.sh script to enable S3 when building the C++ dependencies and the python wheels, and updates the corresponding travis job definition to include the requisite aws-sdk-cpp dependency via homebrew.