### PR TITLE
ARROW-9778: [Rust] [DataFusion] Implement Expr.nullable() and make consistent between logical and physical plans

### DIFF
--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -990,9 +990,8 @@ impl PhysicalExpr for BinaryExpr {
         })
     }
 
-    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
-        // this is not correct
-        Ok(false)
+    fn nullable(&self, input_schema: &Schema) -> Result<bool> {
+        Ok(self.left.nullable(input_schema)? || self.right.nullable(input_schema)?)
     }
 
     fn evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef> {

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -125,6 +125,11 @@ impl AggregateExpr for Sum {
         }
     }
 
+    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
+        // null should be returned if no rows are aggregated
+        Ok(true)
+    }
+
     fn evaluate_input(&self, batch: &RecordBatch) -> Result<ArrayRef> {
         self.expr.evaluate(batch)
     }
@@ -321,6 +326,11 @@ impl AggregateExpr for Avg {
         }
     }
 
+    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
+        // null should be returned if no rows are aggregated
+        Ok(true)
+    }
+
     fn evaluate_input(&self, batch: &RecordBatch) -> Result<ArrayRef> {
         self.expr.evaluate(batch)
     }
@@ -420,6 +430,11 @@ impl Max {
 impl AggregateExpr for Max {
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
         self.expr.data_type(input_schema)
+    }
+
+    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
+        // null should be returned if no rows are aggregated
+        Ok(true)
     }
 
     fn evaluate_input(&self, batch: &RecordBatch) -> Result<ArrayRef> {
@@ -606,6 +621,11 @@ impl AggregateExpr for Min {
         self.expr.data_type(input_schema)
     }
 
+    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
+        // null should be returned if no rows are aggregated
+        Ok(true)
+    }
+
     fn evaluate_input(&self, batch: &RecordBatch) -> Result<ArrayRef> {
         self.expr.evaluate(batch)
     }
@@ -789,6 +809,11 @@ impl Count {
 impl AggregateExpr for Count {
     fn data_type(&self, _input_schema: &Schema) -> Result<DataType> {
         Ok(DataType::UInt64)
+    }
+
+    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
+        // null should be returned if no rows are aggregated
+        Ok(true)
     }
 
     fn evaluate_input(&self, batch: &RecordBatch) -> Result<ArrayRef> {

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -71,7 +71,11 @@ impl HashAggregateExec {
             ))
         }
         for (expr, name) in &aggr_expr {
-            fields.push(Field::new(&name, expr.data_type(&input_schema)?, true))
+            fields.push(Field::new(
+                &name,
+                expr.data_type(&input_schema)?,
+                expr.nullable(&input_schema)?,
+            ))
         }
         let schema = Arc::new(Schema::new(fields));
 

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -64,7 +64,11 @@ impl HashAggregateExec {
 
         let mut fields = Vec::with_capacity(group_expr.len() + aggr_expr.len());
         for (expr, name) in &group_expr {
-            fields.push(Field::new(name, expr.data_type(&input_schema)?, true))
+            fields.push(Field::new(
+                name,
+                expr.data_type(&input_schema)?,
+                expr.nullable(&input_schema)?,
+            ))
         }
         for (expr, name) in &aggr_expr {
             fields.push(Field::new(&name, expr.data_type(&input_schema)?, true))

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -63,7 +63,7 @@ pub trait Partition: Send + Sync + Debug {
 pub trait PhysicalExpr: Send + Sync + Display + Debug {
     /// Get the data type of this expression, given the schema of the input
     fn data_type(&self, input_schema: &Schema) -> Result<DataType>;
-    /// Decide whehter this expression is nullable, given the schema of the input
+    /// Determine whether this expression is nullable, given the schema of the input
     fn nullable(&self, input_schema: &Schema) -> Result<bool>;
     /// Evaluate an expression against a RecordBatch
     fn evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef>;
@@ -73,6 +73,8 @@ pub trait PhysicalExpr: Send + Sync + Display + Debug {
 pub trait AggregateExpr: Send + Sync + Debug {
     /// Get the data type of this expression, given the schema of the input
     fn data_type(&self, input_schema: &Schema) -> Result<DataType>;
+    /// Determine whether this expression is nullable, given the schema of the input
+    fn nullable(&self, input_schema: &Schema) -> Result<bool>;
     /// Evaluate the expression being aggregated
     fn evaluate_input(&self, batch: &RecordBatch) -> Result<ArrayRef>;
     /// Create an accumulator for this aggregate expression

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -410,7 +410,7 @@ impl Expr {
         }
     }
 
-    /// Determine if this expression can produce null values
+    /// return true if this expression might produce null values
     pub fn nullable(&self, input_schema: &Schema) -> Result<bool> {
         match self {
             Expr::Alias(expr, _) => expr.nullable(input_schema),

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -264,21 +264,9 @@ fn create_name(e: &Expr, input_schema: &Schema) -> Result<String> {
     }
 }
 
-/// Returns the datatype of the expression given the input schema
-// note: the physical plan derived from an expression must match the datatype on this function.
-pub fn expr_to_field(e: &Expr, input_schema: &Schema) -> Result<Field> {
-    Ok(Field::new(
-        &e.name(input_schema)?,
-        e.get_type(input_schema)?,
-        e.nullable(input_schema)?,
-    ))
-}
-
 /// Create field meta-data from an expression, for use in a result set schema
 pub fn exprlist_to_fields(expr: &[Expr], input_schema: &Schema) -> Result<Vec<Field>> {
-    expr.iter()
-        .map(|e| expr_to_field(e, input_schema))
-        .collect()
+    expr.iter().map(|e| e.to_field(input_schema)).collect()
 }
 
 /// Relation expression
@@ -455,6 +443,15 @@ impl Expr {
     /// This represents how a column with this expression is named when no alias is chosen
     pub fn name(&self, input_schema: &Schema) -> Result<String> {
         create_name(self, input_schema)
+    }
+
+    /// Create a Field representing this expression
+    pub fn to_field(&self, input_schema: &Schema) -> Result<Field> {
+        Ok(Field::new(
+            &self.name(input_schema)?,
+            self.get_type(input_schema)?,
+            self.nullable(input_schema)?,
+        ))
     }
 
     /// Perform a type cast on the expression value.

--- a/rust/datafusion/src/logicalplan.rs
+++ b/rust/datafusion/src/logicalplan.rs
@@ -422,7 +422,7 @@ impl Expr {
             Expr::Cast { expr, .. } => expr.nullable(input_schema),
             Expr::ScalarFunction { .. } => Ok(true),
             Expr::AggregateFunction { .. } => Ok(true),
-            Expr::Not(_) => Ok(false),
+            Expr::Not(expr) => expr.nullable(input_schema),
             Expr::IsNull(_) => Ok(false),
             Expr::IsNotNull(_) => Ok(false),
             Expr::BinaryExpr {

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -536,9 +536,16 @@ fn register_alltypes_parquet(ctx: &mut ExecutionContext) {
 /// Execute query and return result set as tab delimited string
 fn execute(ctx: &mut ExecutionContext, sql: &str) -> Vec<String> {
     let plan = ctx.create_logical_plan(&sql).unwrap();
+    let logical_schema = plan.schema().clone();
     let plan = ctx.optimize(&plan).unwrap();
+    let optimized_logical_schema = plan.schema().clone();
     let plan = ctx.create_physical_plan(&plan).unwrap();
+    let physical_schema = plan.schema().clone();
     let results = ctx.collect(plan.as_ref()).unwrap();
+
+    assert_eq!(logical_schema.as_ref(), optimized_logical_schema.as_ref());
+    assert_eq!(logical_schema.as_ref(), physical_schema.as_ref());
+
     result_str(&results)
 }
 


### PR DESCRIPTION
- Implements `Expr.nullable()`
- Updates some PhysicalExpr nullable methods to be consistent
- Updates `sql.rs` integration test to assert that schema is same between logical and physical plans
