### PR TITLE
ARROW-9800: [Rust][Parquet] Remove println! when writing column statistics

### DIFF
--- a/rust/parquet/src/column/writer.rs
+++ b/rust/parquet/src/column/writer.rs
@@ -57,7 +57,6 @@ pub enum Level {
 macro_rules! gen_stats_section {
     ($physical_ty: ty, $stat_fn: ident, $min: ident, $max: ident, $distinct: ident, $nulls: ident) => {{
         let min = $min.as_ref().and_then(|v| {
-            println!("min: {:?} {}", &v.as_bytes(), v.as_bytes().len());
             Some(read_num_bytes!(
                 $physical_ty,
                 v.as_bytes().len(),
@@ -65,7 +64,6 @@ macro_rules! gen_stats_section {
             ))
         });
         let max = $max.as_ref().and_then(|v| {
-            println!("max: {:?} {}", &v.as_bytes(), v.as_bytes().len());
             Some(read_num_bytes!(
                 $physical_ty,
                 v.as_bytes().len(),


### PR DESCRIPTION
Prior to this PR,  the following output is printed during local execution of a test:

```
min: [0] 1
max: [1] 1
min: [0] 1
max: [1] 1
min: [0] 1
max: [1] 1
min: [0] 1
max: [1] 1
min: [0] 1
max: [1] 1
min: [0] 1
max: [1] 1
```
It appears to have been introduced in https://github.com/apache/arrow/commit/12b30dda1a23bad70e5b11b8cef845d0effd01d4 / https://github.com/apache/arrow/pull/7622, likely mistakenly. FYI @zeevm and @sunchao 

