### PR TITLE
ARROW-9790: [Rust][Parquet] Fix PrimitiveArrayReader boundary conditions

### DIFF
--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -136,10 +136,8 @@ impl<T: DataType> ArrayReader for PrimitiveArrayReader<T> {
         while records_read < batch_size {
             let records_to_read = batch_size - records_read;
 
+            // NB can be 0 if at end of page
             let records_read_once = self.record_reader.read_records(records_to_read)?;
-            if records_read_once == 0 {
-                break; // record reader has no record
-            }
             records_read = records_read + records_read_once;
 
             // Record reader exhausted

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -304,6 +304,45 @@ mod tests {
         >(2, 100, 2, message_type, 15, 50, converter);
     }
 
+    #[test]
+    fn test_bool_single_column_reader_test_batch_size_divides_into_row_group_size() {
+        let message_type = "
+        message test_schema {
+          REQUIRED BOOLEAN leaf;
+        }
+        ";
+
+        // Use a batch size (5) so batches to fall on
+        // row group boundaries (25 rows in 3 row groups --> row
+        // groups of 10, 10, and 5) to test edge refilling edge cases.
+        let converter = FromConverter::new();
+        single_column_reader_test::<
+            BoolType,
+            BooleanArray,
+            FromConverter<Vec<Option<bool>>, BooleanArray>,
+            BoolType,
+        >(3, 25, 2, message_type, 5, 50, converter);
+    }
+
+    #[test]
+    fn test_bool_single_column_reader_test_batch_size_divides_into_row_group_size2() {
+        let message_type = "
+        message test_schema {
+          REQUIRED BOOLEAN leaf;
+        }
+        ";
+
+        // Ensure that every batch size (25) falls exactly a row group
+        // boundary (25 in this case) to test edge case.
+        let converter = FromConverter::new();
+        single_column_reader_test::<
+            BoolType,
+            BooleanArray,
+            FromConverter<Vec<Option<bool>>, BooleanArray>,
+            BoolType,
+        >(4, 100, 2, message_type, 25, 50, converter);
+    }
+
     struct RandFixedLenGen {}
 
     impl RandGen<FixedLenByteArrayType> for RandFixedLenGen {


### PR DESCRIPTION
When I was reading a parquet file into `RecordBatches` using `ParquetFileArrowReader` that had row groups that were 100,000 rows in length with a batch size of 60,000, after reading 300,000 rows successfully, I started seeing this error

```
 ParquetError("Parquet error: Not all children array length are the same!")
```

Upon investigation, I found that when reading with `ParquetFileArrowReader`, if the parquet input file has multiple row groups, and if a batch happens to end at the end of a row group for Int or Float, no subsequent row groups are read

Visually:

```
+-----+
| RG1 |
|     |
+-----+  <-- If a batch ends exactly at the end of this row group (page), RG2 is never read
+-----+
| RG2 |
|     |
+-----+
```

I traced the issue down to a bug in `PrimitiveArrayReader` where it mistakenly interprets reading `0` rows from a page reader as being at the end of the column.

This bug appears *not* to be present in the initial implementation #5378 -- FYI @andygrove  and @liurenjie1024 (the test harness in this file is awesome, btw), but was introduced in https://github.com/apache/arrow/pull/7140. I will do some more investigating to ensure the test case described in that ticket is handled