### PR TITLE
ARROW-9587: [FlightRPC][Java] clean up FlightStream/DoPut

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClient.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightClient.java
@@ -321,7 +321,7 @@ public class FlightClient implements AutoCloseable {
       final ClientCallStreamObserver<ArrowMessage> observer = (ClientCallStreamObserver<ArrowMessage>)
               ClientCalls.asyncBidiStreamingCall(call, stream.asObserver());
       final ClientStreamListener writer = new PutObserver(
-          descriptor, observer, stream.completed::isDone,
+          descriptor, observer, stream.cancelled::isDone,
           () -> {
             try {
               stream.completed.get();

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightRuntimeException.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightRuntimeException.java
@@ -41,6 +41,6 @@ public class FlightRuntimeException extends RuntimeException {
   @Override
   public String toString() {
     String s = getClass().getName();
-    return String.format("%s: %s", s, status);
+    return String.format("%s: %s: %s", s, status.code(), status.description());
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
@@ -34,6 +34,7 @@ import org.apache.arrow.flight.grpc.StatusUtils;
 import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.impl.FlightServiceGrpc.FlightServiceImplBase;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.VectorUnloader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -189,24 +190,20 @@ class FlightService extends FlightServiceImplBase {
     responseObserver.disableAutoInboundFlowControl();
     responseObserver.request(1);
 
+    final StreamPipe<PutResult, Flight.PutResult> ackStream = StreamPipe
+        .wrap(responseObserver, PutResult::toProtocol, this::handleExceptionWithMiddleware);
     final FlightStream fs = new FlightStream(allocator, PENDING_REQUESTS, (String message, Throwable cause) -> {
-      responseObserver.onError(Status.CANCELLED.withCause(cause).withDescription(message).asException());
+      ackStream.onError(Status.CANCELLED.withCause(cause).withDescription(message).asException());
     }, responseObserver::request);
+    // When the ackStream is completed, the FlightStream will be closed with it
+    ackStream.setAutoCloseable(fs);
     final StreamObserver<ArrowMessage> observer = fs.asObserver();
     executors.submit(() -> {
-      final StreamPipe<PutResult, Flight.PutResult> ackStream = StreamPipe
-          .wrap(responseObserver, PutResult::toProtocol, this::handleExceptionWithMiddleware);
       try {
         producer.acceptPut(makeContext(responseObserver), fs, ackStream).run();
       } catch (Exception ex) {
         ackStream.onError(ex);
       } finally {
-        // Close this stream before telling gRPC that the call is complete. That way we don't race with server shutdown.
-        try {
-          fs.close();
-        } catch (Exception e) {
-          handleExceptionWithMiddleware(e);
-        }
         // ARROW-6136: Close the stream if and only if acceptPut hasn't closed it itself
         // We don't do this for other streams since the implementation may be asynchronous
         ackStream.ensureCompleted();
@@ -236,7 +233,7 @@ class FlightService extends FlightServiceImplBase {
    */
   private void handleExceptionWithMiddleware(Throwable t) {
     final Map<Key<?>, FlightServerMiddleware> middleware = ServerInterceptorAdapter.SERVER_MIDDLEWARE_KEY.get();
-    if (middleware == null) {
+    if (middleware == null || middleware.isEmpty()) {
       logger.error("Uncaught exception in Flight method body", t);
       return;
     }
@@ -258,14 +255,14 @@ class FlightService extends FlightServiceImplBase {
 
   /** Ensures that other resources are cleaned up when the service finishes its call.  */
   private static class ExchangeListener extends GetListener {
-    private final AutoCloseable resource;
+
+    private AutoCloseable resource;
     private boolean closed = false;
     private Runnable onCancelHandler = null;
 
-    public ExchangeListener(ServerCallStreamObserver<ArrowMessage> responseObserver, Consumer<Throwable> errorHandler,
-                            AutoCloseable resource) {
+    public ExchangeListener(ServerCallStreamObserver<ArrowMessage> responseObserver, Consumer<Throwable> errorHandler) {
       super(responseObserver, errorHandler);
-      this.resource = resource;
+      this.resource = null;
       super.setOnCancelHandler(() -> {
         try {
           if (onCancelHandler != null) {
@@ -285,7 +282,7 @@ class FlightService extends FlightServiceImplBase {
       }
       closed = true;
       try {
-        this.resource.close();
+        AutoCloseables.close(resource);
       } catch (Exception e) {
         throw CallStatus.INTERNAL
             .withCause(e)
@@ -321,19 +318,23 @@ class FlightService extends FlightServiceImplBase {
   public StreamObserver<ArrowMessage> doExchangeCustom(StreamObserver<ArrowMessage> responseObserverSimple) {
     final ServerCallStreamObserver<ArrowMessage> responseObserver =
         (ServerCallStreamObserver<ArrowMessage>) responseObserverSimple;
-    final FlightStream fs = new FlightStream(allocator, PENDING_REQUESTS, (String message, Throwable cause) -> {
-      responseObserver.onError(Status.CANCELLED.withCause(cause).withDescription(message).asException());
-    }, responseObserver::request);
-    // When service completes the call, this cleans up the FlightStream
     final ExchangeListener listener = new ExchangeListener(
         responseObserver,
-        this::handleExceptionWithMiddleware,
-        () -> {
-          // Force the stream to "complete" so it will close without incident. At this point, we don't care since
-          // we are about to end the call. (Normally it will raise an error.)
-          fs.completed.complete(null);
-          fs.close();
-        });
+        this::handleExceptionWithMiddleware);
+    final FlightStream fs = new FlightStream(
+        allocator,
+        PENDING_REQUESTS,
+        (String message, Throwable cause) -> {
+          listener.error(Status.CANCELLED.withCause(cause).withDescription(message).asException());
+        },
+        responseObserver::request);
+    // When service completes the call, this cleans up the FlightStream
+    listener.resource = () -> {
+      // Force the stream to "complete" so it will close without incident. At this point, we don't care since
+      // we are about to end the call. (Normally it will raise an error.)
+      fs.completed.complete(null);
+      fs.close();
+    };
     responseObserver.disableAutoInboundFlowControl();
     responseObserver.request(1);
     final StreamObserver<ArrowMessage> observer = fs.asObserver();

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStream.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightStream.java
@@ -55,7 +55,6 @@ import io.grpc.stub.StreamObserver;
  * An adaptor between protobuf streams and flight data streams.
  */
 public class FlightStream implements AutoCloseable {
-
   // Use AutoCloseable sentinel objects to simplify logic in #close
   private final AutoCloseable DONE = () -> {
   };
@@ -96,7 +95,6 @@ public class FlightStream implements AutoCloseable {
    */
   public FlightStream(BufferAllocator allocator, int pendingTarget, Cancellable cancellable, Requestor requestor) {
     Objects.requireNonNull(allocator);
-    Objects.requireNonNull(cancellable);
     Objects.requireNonNull(requestor);
     this.allocator = allocator;
     this.pendingTarget = pendingTarget;
@@ -168,22 +166,53 @@ public class FlightStream implements AutoCloseable {
 
   /**
    * Closes the stream (freeing any existing resources).
+   *
+   * <p>If the stream isn't complete and is cancellable, this method will cancel and drain the stream first.
    */
   public void close() throws Exception {
     final List<AutoCloseable> closeables = new ArrayList<>();
-    if (fulfilledRoot != null) {
-      closeables.add(fulfilledRoot);
+    Throwable suppressor = null;
+    if (cancellable != null) {
+      // Client-side stream. Cancel the call, to help ensure gRPC doesn't deliver a message after close() ends.
+      // On the server side, we can't rely on draining the stream , because this gRPC bug means the completion callback
+      // may never run https://github.com/grpc/grpc-java/issues/5882
+      try {
+        synchronized (cancellable) {
+          if (!cancelled.isDone()) {
+            // Only cancel if the call is not done on the gRPC side
+            cancellable.cancel("Stream closed before end", /* no exception to report */null);
+          }
+        }
+        // Drain the stream without the lock (as next() implicitly needs the lock)
+        while (next()) { }
+      } catch (FlightRuntimeException e) {
+        suppressor = e;
+      }
     }
-    closeables.add(applicationMetadata);
-    closeables.addAll(queue);
-    if (dictionaries != null) {
-      dictionaries.getDictionaryIds().forEach(id -> closeables.add(dictionaries.lookup(id).getVector()));
+    // Perform these operations under a lock. This way the observer can't enqueue new messages while we're in the
+    // middle of cleanup. This should only be a concern for server-side streams since client-side streams are drained
+    // by the lambda above.
+    synchronized (completed) {
+      try {
+        if (fulfilledRoot != null) {
+          closeables.add(fulfilledRoot);
+        }
+        closeables.add(applicationMetadata);
+        closeables.addAll(queue);
+        if (dictionaries != null) {
+          dictionaries.getDictionaryIds().forEach(id -> closeables.add(dictionaries.lookup(id).getVector()));
+        }
+        if (suppressor != null) {
+          AutoCloseables.close(suppressor, closeables);
+        } else {
+          AutoCloseables.close(closeables);
+        }
+      } finally {
+        // The value of this CompletableFuture is meaningless, only whether it's completed (or has an exception)
+        // No-op if already complete
+        completed.complete(null);
+      }
     }
-
-    AutoCloseables.close(closeables);
-    // Other code ignores the value of this CompletableFuture, only whether it's completed (or has an exception)
-    // No-op if already complete; do this after the check in the AutoCloseable lambda above
-    completed.complete(null);
   }
 
   /**
@@ -340,8 +369,22 @@ public class FlightStream implements AutoCloseable {
       super();
     }
 
+    /** Helper to add an item to the queue under the appropriate lock. */
+    private void enqueue(AutoCloseable message) {
+      synchronized (completed) {
+        if (completed.isDone()) {
+          // The stream is already closed (RPC ended), discard the message
+          AutoCloseables.closeNoChecked(message);
+        } else {
+          queue.add(message);
+        }
+      }
+    }
+
     @Override
     public void onNext(ArrowMessage msg) {
+      // Operations here have to be under a lock so that we don't add a message to the queue while in the middle of
+      // close().
       requestOutstanding();
       switch (msg.getMessageType()) {
         case NONE: {
@@ -350,7 +393,7 @@ public class FlightStream implements AutoCloseable {
             descriptor.set(new FlightDescriptor(msg.getDescriptor()));
           }
           if (msg.getApplicationMetadata() != null) {
-            queue.add(msg);
+            enqueue(msg);
           }
           break;
         }
@@ -370,31 +413,31 @@ public class FlightStream implements AutoCloseable {
           try {
             MetadataV4UnionChecker.checkRead(schema, metadataVersion);
           } catch (IOException e) {
-            queue.add(DONE_EX);
             ex = e;
+            enqueue(DONE_EX);
             break;
           }
 
-          fulfilledRoot = VectorSchemaRoot.create(schema, allocator);
-          loader = new VectorLoader(fulfilledRoot);
-          if (msg.getDescriptor() != null) {
-            descriptor.set(new FlightDescriptor(msg.getDescriptor()));
+          synchronized (completed) {
+            if (!completed.isDone()) {
+              fulfilledRoot = VectorSchemaRoot.create(schema, allocator);
+              loader = new VectorLoader(fulfilledRoot);
+              if (msg.getDescriptor() != null) {
+                descriptor.set(new FlightDescriptor(msg.getDescriptor()));
+              }
+              root.set(fulfilledRoot);
+            }
           }
-          root.set(fulfilledRoot);
           break;
         }
         case RECORD_BATCH:
         case DICTIONARY_BATCH:
-          if (!completed.isDone()) {
-            queue.add(msg);
-          } else {
-            AutoCloseables.closeNoChecked(msg);
-          }
+          enqueue(msg);
           break;
         case TENSOR:
         default:
-          queue.add(DONE_EX);
           ex = new UnsupportedOperationException("Unable to handle message of type: " + msg.getMessageType());
+          enqueue(DONE_EX);
       }
     }
 
@@ -416,11 +459,17 @@ public class FlightStream implements AutoCloseable {
 
   /**
    * Cancels sending the stream to a client.
+   *
+   * <p>Callers should drain the stream (with {@link #next()}) to ensure all messages sent before cancellation are
+   * received and to wait for the underlying transport to acknowledge cancellation.
    */
   public void cancel(String message, Throwable exception) {
-    completed.completeExceptionally(
-        CallStatus.CANCELLED.withDescription(message).withCause(exception).toRuntimeException());
+    if (cancellable == null) {
+      throw new UnsupportedOperationException("Streams cannot be cancelled that are produced by client. " +
+          "Instead, server should reject incoming messages.");
+    }
     cancellable.cancel(message, exception);
+    // Do not mark the stream as completed, as gRPC may still be delivering messages.
   }
 
   StreamObserver<ArrowMessage> asObserver() {

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestDoExchange.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestDoExchange.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -52,6 +53,7 @@ public class TestDoExchange {
   static byte[] EXCHANGE_ECHO = "echo".getBytes(StandardCharsets.UTF_8);
   static byte[] EXCHANGE_METADATA_ONLY = "only-metadata".getBytes(StandardCharsets.UTF_8);
   static byte[] EXCHANGE_TRANSFORM = "transform".getBytes(StandardCharsets.UTF_8);
+  static byte[] EXCHANGE_CANCEL = "cancel".getBytes(StandardCharsets.UTF_8);
 
   private BufferAllocator allocator;
   private FlightServer server;
@@ -247,6 +249,27 @@ public class TestDoExchange {
     }
   }
 
+  /** Have the server immediately cancel; ensure the client doesn't hang. */
+  @Test
+  public void testCancel() throws Exception {
+    try (final FlightClient.ExchangeReaderWriter stream =
+             client.doExchange(FlightDescriptor.command(EXCHANGE_CANCEL))) {
+      final FlightStream reader = stream.getReader();
+      final FlightClient.ClientStreamListener writer = stream.getWriter();
+
+      final FlightRuntimeException fre = assertThrows(FlightRuntimeException.class, reader::next);
+      assertEquals(FlightStatusCode.CANCELLED, fre.status().code());
+      assertEquals("expected", fre.status().description());
+
+      // Before, this would hang forever, because the writer checks if the stream is ready and not cancelled.
+      // However, the cancellation flag (was) only updated by reading, and the stream is never ready once the call ends.
+      // The test looks weird since normally, an application shouldn't try to write after the read fails. However,
+      // an application that isn't reading data wouldn't notice, and would instead get stuck on the write.
+      // Here, we read first to avoid a race condition in the test itself.
+      writer.putMetadata(allocator.getEmpty());
+    }
+  }
+
   static class Producer extends NoOpFlightProducer {
     private final BufferAllocator allocator;
 
@@ -266,6 +289,8 @@ public class TestDoExchange {
         echo(context, reader, writer);
       } else if (Arrays.equals(reader.getDescriptor().getCommand(), EXCHANGE_TRANSFORM)) {
         transform(context, reader, writer);
+      } else if (Arrays.equals(reader.getDescriptor().getCommand(), EXCHANGE_CANCEL)) {
+        cancel(context, reader, writer);
       } else {
         writer.error(CallStatus.UNIMPLEMENTED.withDescription("Command not implemented").toRuntimeException());
       }
@@ -390,6 +415,11 @@ public class TestDoExchange {
       count.writeInt(batches);
       writer.putMetadata(count);
       writer.completed();
+    }
+
+    /** Immediately cancel the call. */
+    private void cancel(CallContext context, FlightStream reader, ServerStreamListener writer) {
+      reader.cancel("expected", null);
     }
   }
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLeak.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestLeak.java
@@ -173,7 +173,7 @@ public class TestLeak {
         FlightStream flightStream, StreamListener<PutResult> ackStream) {
       return () -> {
         flightStream.getRoot();
-        flightStream.cancel("CANCELLED", null);
+        ackStream.onError(CallStatus.CANCELLED.withDescription("CANCELLED").toRuntimeException());
         callFinished.countDown();
         ackStream.onCompleted();
       };


### PR DESCRIPTION
- Fix a bug where writes would hang forever for DoExchange
- Make FlightRuntimeException#toString easier to read
- Have DoPut reliably clean up the FlightStream when the call ends (instead of potentially closing it after gRPC thinks the call ends - this will be important for [ARROW-9586](https://issues.apache.org/jira/browse/ARROW-9586))