### PR TITLE
ARROW-9816: [C++] Escape quotes in config.h

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2716,6 +2716,6 @@ message(STATUS "All bundled static libraries: ${ARROW_BUNDLED_STATIC_LIBS}")
 
 # Write out the package configurations.
 
-configure_file("src/arrow/util/config.h.cmake" "src/arrow/util/config.h")
+configure_file("src/arrow/util/config.h.cmake" "src/arrow/util/config.h" ESCAPE_QUOTES)
 install(FILES "${ARROW_BINARY_DIR}/src/arrow/util/config.h"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/arrow/util")


### PR DESCRIPTION
We should use `ESCAPE_QUOTES` when generating `config.h` so that quotes in e.g. `CXXFLAGS` are handled properly.