### PR TITLE
ARROW-9815 [Rust] [DataFusion] Fixed deadlock caused by accessing the scalar functions' registry.

### DIFF
--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -40,7 +40,7 @@ pub trait PhysicalPlanner {
     fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,
-        ctx_state: Arc<Mutex<ExecutionContextState>>,
+        ctx_state: &ExecutionContextState,
     ) -> Result<Arc<dyn ExecutionPlan>>;
 }
 

--- a/rust/datafusion/src/execution/physical_plan/planner.rs
+++ b/rust/datafusion/src/execution/physical_plan/planner.rs
@@ -17,7 +17,7 @@
 
 //! Physical query planner
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::error::{ExecutionError, Result};
 use crate::execution::context::ExecutionContextState;
@@ -59,27 +59,16 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
     fn create_physical_plan(
         &self,
         logical_plan: &LogicalPlan,
-        ctx_state: Arc<Mutex<ExecutionContextState>>,
+        ctx_state: &ExecutionContextState,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let batch_size = ctx_state
-            .lock()
-            .expect("failed to lock mutex")
-            .config
-            .batch_size;
+        let batch_size = ctx_state.config.batch_size;
 
         match logical_plan {
             LogicalPlan::TableScan {
                 table_name,
                 projection,
                 ..
-            } => match ctx_state
-                .lock()
-                .expect("failed to lock mutex")
-                .datasources
-                .lock()
-                .expect("failed to lock mutex")
-                .get(table_name)
-            {
+            } => match ctx_state.datasources.get(table_name) {
                 Some(provider) => {
                     let partitions = provider.scan(projection, batch_size)?;
                     if partitions.is_empty() {
@@ -139,17 +128,13 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                 batch_size,
             )?)),
             LogicalPlan::Projection { input, expr, .. } => {
-                let input = self.create_physical_plan(input, ctx_state.clone())?;
+                let input = self.create_physical_plan(input, ctx_state)?;
                 let input_schema = input.as_ref().schema().clone();
                 let runtime_expr = expr
                     .iter()
                     .map(|e| {
                         tuple_err((
-                            self.create_physical_expr(
-                                e,
-                                &input_schema,
-                                ctx_state.clone(),
-                            ),
+                            self.create_physical_expr(e, &input_schema, &ctx_state),
                             e.name(&input_schema),
                         ))
                     })
@@ -163,18 +148,14 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                 ..
             } => {
                 // Initially need to perform the aggregate and then merge the partitions
-                let input = self.create_physical_plan(input, ctx_state.clone())?;
+                let input = self.create_physical_plan(input, ctx_state)?;
                 let input_schema = input.as_ref().schema().clone();
 
                 let groups = group_expr
                     .iter()
                     .map(|e| {
                         tuple_err((
-                            self.create_physical_expr(
-                                e,
-                                &input_schema,
-                                ctx_state.clone(),
-                            ),
+                            self.create_physical_expr(e, &input_schema, ctx_state),
                             e.name(&input_schema),
                         ))
                     })
@@ -183,11 +164,7 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                     .iter()
                     .map(|e| {
                         tuple_err((
-                            self.create_aggregate_expr(
-                                e,
-                                &input_schema,
-                                ctx_state.clone(),
-                            ),
+                            self.create_aggregate_expr(e, &input_schema, ctx_state),
                             e.name(&input_schema),
                         ))
                     })
@@ -209,11 +186,7 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                 let merge = Arc::new(MergeExec::new(
                     schema.clone(),
                     partitions,
-                    ctx_state
-                        .lock()
-                        .expect("failed to lock mutex")
-                        .config
-                        .concurrency,
+                    ctx_state.config.concurrency,
                 ));
 
                 // construct the expressions for the final aggregation
@@ -241,17 +214,14 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
             LogicalPlan::Filter {
                 input, predicate, ..
             } => {
-                let input = self.create_physical_plan(input, ctx_state.clone())?;
+                let input = self.create_physical_plan(input, ctx_state)?;
                 let input_schema = input.as_ref().schema().clone();
-                let runtime_expr = self.create_physical_expr(
-                    predicate,
-                    &input_schema,
-                    ctx_state.clone(),
-                )?;
+                let runtime_expr =
+                    self.create_physical_expr(predicate, &input_schema, ctx_state)?;
                 Ok(Arc::new(FilterExec::try_new(runtime_expr, input)?))
             }
             LogicalPlan::Sort { expr, input, .. } => {
-                let input = self.create_physical_plan(input, ctx_state.clone())?;
+                let input = self.create_physical_plan(input, ctx_state)?;
                 let input_schema = input.as_ref().schema().clone();
 
                 let sort_expr = expr
@@ -268,7 +238,7 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                                 descending: !*asc,
                                 nulls_first: *nulls_first,
                             },
-                            ctx_state.clone(),
+                            ctx_state,
                         ),
                         _ => Err(ExecutionError::ExecutionError(
                             "Sort only accepts sort expressions".to_string(),
@@ -279,26 +249,18 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                 Ok(Arc::new(SortExec::try_new(
                     sort_expr,
                     input,
-                    ctx_state
-                        .lock()
-                        .expect("failed to lock mutex")
-                        .config
-                        .concurrency,
+                    ctx_state.config.concurrency,
                 )?))
             }
             LogicalPlan::Limit { input, n, .. } => {
-                let input = self.create_physical_plan(input, ctx_state.clone())?;
+                let input = self.create_physical_plan(input, ctx_state)?;
                 let input_schema = input.as_ref().schema().clone();
 
                 Ok(Arc::new(GlobalLimitExec::new(
                     input_schema.clone(),
                     input.partitions()?,
                     *n,
-                    ctx_state
-                        .lock()
-                        .expect("failed to lock mutex")
-                        .config
-                        .concurrency,
+                    ctx_state.config.concurrency,
                 )))
             }
             LogicalPlan::Explain {
@@ -307,7 +269,7 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                 stringified_plans,
                 schema,
             } => {
-                let input = self.create_physical_plan(plan, ctx_state.clone())?;
+                let input = self.create_physical_plan(plan, ctx_state)?;
 
                 let mut stringified_plans = stringified_plans
                     .iter()
@@ -338,11 +300,11 @@ impl DefaultPhysicalPlanner {
         &self,
         e: &Expr,
         input_schema: &Schema,
-        ctx_state: Arc<Mutex<ExecutionContextState>>,
+        ctx_state: &ExecutionContextState,
     ) -> Result<Arc<dyn PhysicalExpr>> {
         match e {
             Expr::Alias(expr, ..) => {
-                Ok(self.create_physical_expr(expr, input_schema, ctx_state.clone())?)
+                Ok(self.create_physical_expr(expr, input_schema, ctx_state)?)
             }
             Expr::Column(name) => {
                 // check that name exists
@@ -351,12 +313,12 @@ impl DefaultPhysicalPlanner {
             }
             Expr::Literal(value) => Ok(Arc::new(Literal::new(value.clone()))),
             Expr::BinaryExpr { left, op, right } => Ok(Arc::new(BinaryExpr::new(
-                self.create_physical_expr(left, input_schema, ctx_state.clone())?,
+                self.create_physical_expr(left, input_schema, ctx_state)?,
                 op.clone(),
-                self.create_physical_expr(right, input_schema, ctx_state.clone())?,
+                self.create_physical_expr(right, input_schema, ctx_state)?,
             ))),
             Expr::Cast { expr, data_type } => Ok(Arc::new(CastExpr::try_new(
-                self.create_physical_expr(expr, input_schema, ctx_state.clone())?,
+                self.create_physical_expr(expr, input_schema, ctx_state)?,
                 input_schema,
                 data_type.clone(),
             )?)),
@@ -364,38 +326,28 @@ impl DefaultPhysicalPlanner {
                 name,
                 args,
                 return_type,
-            } => {
-                let functions = ctx_state
-                    .lock()
-                    .expect("failed to lock mutex")
-                    .scalar_functions
-                    .lock()
-                    .expect("Unable to lock mutex")
-                    .clone();
-
-                match functions.get(name) {
-                    Some(f) => {
-                        let mut physical_args = vec![];
-                        for e in args {
-                            physical_args.push(self.create_physical_expr(
-                                e,
-                                input_schema,
-                                ctx_state.clone(),
-                            )?);
-                        }
-                        Ok(Arc::new(ScalarFunctionExpr::new(
-                            name,
-                            Box::new(f.fun.clone()),
-                            physical_args,
-                            return_type,
-                        )))
+            } => match ctx_state.scalar_functions.get(name) {
+                Some(f) => {
+                    let mut physical_args = vec![];
+                    for e in args {
+                        physical_args.push(self.create_physical_expr(
+                            e,
+                            input_schema,
+                            ctx_state.clone(),
+                        )?);
                     }
-                    _ => Err(ExecutionError::General(format!(
-                        "Invalid scalar function '{:?}'",
-                        name
-                    ))),
+                    Ok(Arc::new(ScalarFunctionExpr::new(
+                        name,
+                        Box::new(f.fun.clone()),
+                        physical_args,
+                        return_type,
+                    )))
                 }
-            }
+                _ => Err(ExecutionError::General(format!(
+                    "Invalid scalar function '{:?}'",
+                    name
+                ))),
+            },
             other => Err(ExecutionError::NotImplemented(format!(
                 "Physical plan does not support logical expression {:?}",
                 other
@@ -408,7 +360,7 @@ impl DefaultPhysicalPlanner {
         &self,
         e: &Expr,
         input_schema: &Schema,
-        ctx_state: Arc<Mutex<ExecutionContextState>>,
+        ctx_state: &ExecutionContextState,
     ) -> Result<Arc<dyn AggregateExpr>> {
         match e {
             Expr::AggregateFunction { name, args, .. } => {
@@ -416,27 +368,27 @@ impl DefaultPhysicalPlanner {
                     "sum" => Ok(Arc::new(Sum::new(self.create_physical_expr(
                         &args[0],
                         input_schema,
-                        ctx_state.clone(),
+                        ctx_state,
                     )?))),
                     "avg" => Ok(Arc::new(Avg::new(self.create_physical_expr(
                         &args[0],
                         input_schema,
-                        ctx_state.clone(),
+                        ctx_state,
                     )?))),
                     "max" => Ok(Arc::new(Max::new(self.create_physical_expr(
                         &args[0],
                         input_schema,
-                        ctx_state.clone(),
+                        ctx_state,
                     )?))),
                     "min" => Ok(Arc::new(Min::new(self.create_physical_expr(
                         &args[0],
                         input_schema,
-                        ctx_state.clone(),
+                        ctx_state,
                     )?))),
                     "count" => Ok(Arc::new(Count::new(self.create_physical_expr(
                         &args[0],
                         input_schema,
-                        ctx_state.clone(),
+                        ctx_state,
                     )?))),
                     other => Err(ExecutionError::NotImplemented(format!(
                         "Unsupported aggregate function '{}'",
@@ -457,10 +409,10 @@ impl DefaultPhysicalPlanner {
         e: &Expr,
         input_schema: &Schema,
         options: SortOptions,
-        ctx_state: Arc<Mutex<ExecutionContextState>>,
+        ctx_state: &ExecutionContextState,
     ) -> Result<PhysicalSortExpr> {
         Ok(PhysicalSortExpr {
-            expr: self.create_physical_expr(e, input_schema, ctx_state.clone())?,
+            expr: self.create_physical_expr(e, input_schema, ctx_state)?,
             options: options,
         })
     }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -47,13 +47,13 @@ pub trait SchemaProvider {
 }
 
 /// SQL query planner
-pub struct SqlToRel<S: SchemaProvider> {
-    schema_provider: S,
+pub struct SqlToRel<'a, S: SchemaProvider> {
+    schema_provider: &'a S,
 }
 
-impl<S: SchemaProvider> SqlToRel<S> {
+impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
     /// Create a new query planner
-    pub fn new(schema_provider: S) -> Self {
+    pub fn new(schema_provider: &'a S) -> Self {
         SqlToRel { schema_provider }
     }
 
@@ -854,7 +854,7 @@ mod tests {
     }
 
     fn logical_plan(sql: &str) -> Result<LogicalPlan> {
-        let planner = SqlToRel::new(MockSchemaProvider {});
+        let planner = SqlToRel::new(&MockSchemaProvider {});
         let ast = DFParser::parse_sql(&sql).unwrap();
         planner.statement_to_plan(&ast[0])
     }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -201,6 +201,7 @@ fn csv_query_avg_sqrt() -> Result<()> {
     Ok(())
 }
 
+// this query used to deadlock due to the call udf(udf())
 #[test]
 fn csv_query_sqrt_sqrt() -> Result<()> {
     let mut ctx = create_ctx()?;

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -201,6 +201,18 @@ fn csv_query_avg_sqrt() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn csv_query_sqrt_sqrt() -> Result<()> {
+    let mut ctx = create_ctx()?;
+    register_aggregate_csv(&mut ctx)?;
+    let sql = "SELECT sqrt(sqrt(c12)) FROM aggregate_test_100 LIMIT 1";
+    let actual = execute(&mut ctx, sql);
+    // sqrt(sqrt(c12=0.9294097332465232)) = 0.9818650561397431
+    let expected = "0.9818650561397431".to_string();
+    assert_eq!(actual.join("\n"), expected);
+    Ok(())
+}
+
 fn create_ctx() -> Result<ExecutionContext> {
     let mut ctx = ExecutionContext::new();
 


### PR DESCRIPTION
@andygrove and @alamb , I have no formal training in thread and mutex management, so I am not certain about this proposal or the following explanation:

My understanding is that because the result of

```
ctx_state
                .lock()
                .expect("failed to lock mutex")
                .scalar_functions
                .lock()
                .expect("failed to lock mutex")
                .get(name)
```

is of temporary lifetime, using this in `match` blocks any access to `scalar_functions` until we leave the match, which deadlocks when we recursively call the function. Here I just cloned `.scalar_functions` so that we allow the lock to be released.

I may also be dead wrong on every word that I wrote above.

This does work, but if you could validate my reasoning above, I would appreciate very much!

Note that we are also doing the same for `.datasources` in this file, which I suspect will also deadlock if when we have a plan with two sources. I did not touch that as I do not know the idiom/pattern to address this (locking within recursions).



An alternative solution for this is to not make `PhysicalPlanner::create_physical_plan` recursive, and instead call a recursive function (with all the current logic of `create_physical_plan`) with references to `datasources` and `scalar_functions`, so that they can be used recursively (and we do not have to lock on every recursion.
