### PR TITLE
ARROW-9821: [Rust][DataFusion] Prototype design for UserDefined Logical Plan Nodes NOT FOR MERGING

### DIFF
--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -111,7 +111,7 @@ impl DataFrame for DataFrameImpl {
 
     /// Returns the schema from the logical plan
     fn schema(&self) -> &Schema {
-        self.plan.schema().as_ref()
+        self.plan.schema()
     }
 
     fn explain(&self, verbose: bool) -> Result<Arc<dyn DataFrame>> {

--- a/rust/datafusion/src/lib.rs
+++ b/rust/datafusion/src/lib.rs
@@ -63,6 +63,8 @@ pub mod datasource;
 pub mod error;
 pub mod execution;
 pub mod logicalplan;
+pub mod lp;
+mod lp_limit;
 pub mod optimizer;
 pub mod prelude;
 pub mod sql;

--- a/rust/datafusion/src/lp.rs
+++ b/rust/datafusion/src/lp.rs
@@ -1,0 +1,89 @@
+//! Prototype LogicalPlanNode interface for defining extensions for LogicalPlan nodes
+
+use crate::error::Result;
+use crate::{
+    execution::{context::ExecutionContextState, physical_plan::ExecutionPlan},
+    logicalplan::{Expr, LogicalPlan},
+};
+use arrow::datatypes::Schema;
+use core::fmt;
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+/// This defines the interface for (currently user defined)
+/// LogicalPLan nodes that can be used to extend the logic
+pub trait LogicalPlanNode {
+    /// Return  a reference to the logical plan's inputs
+    fn inputs(&self) -> Vec<&LogicalPlan>;
+
+    /// Get a reference to the logical plan's schema
+    fn schema(&self) -> &Schema;
+
+    /// returns all expressions (non-recursively) in the current logical plan node.
+    fn expressions(&self) -> Vec<Expr>;
+
+    /// A list of output columns (column names in self.schema()) for
+    /// which predicates can not be pushed below this node without
+    /// changing the output
+    fn prevent_predicate_push_down_columns(&self) -> HashSet<String> {
+        // default (safe) is all columns in the schema.
+        self.schema()
+            .fields()
+            .iter()
+            .map(|f| f.name().clone())
+            .collect()
+    }
+
+    /// Write a single line human readable string to `f` for use in explain plan
+    fn format_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result;
+
+    /// Create a clone of this node.
+    ///
+    /// Note std::Clone needs a Sized type, so we must implement a
+    /// clone that creates a node with a known Size (i.e. Box)
+    //
+    fn dyn_clone(&self) -> Box<dyn LogicalPlanNode>;
+
+    /// Create a clone of this LogicalPlanNode with inputs and expressions replaced.
+    ///
+    /// Note that exprs and inputs are in the same order as the result
+    /// of self.inputs and self.exprs.
+    ///
+    /// So, clone_from_template(exprs).exprs() == exprs
+    fn clone_from_template(
+        &self,
+        exprs: &Vec<Expr>,
+        inputs: &Vec<LogicalPlan>,
+    ) -> Box<dyn LogicalPlanNode>;
+
+    /// Create the corresponding physical scheplan for this node
+    fn create_physical_plan(
+        &self,
+        input_physical_plans: Vec<Arc<dyn ExecutionPlan>>,
+        ctx_state: Arc<Mutex<ExecutionContextState>>,
+    ) -> Result<Arc<dyn ExecutionPlan>>;
+}
+
+/// Adaptor LogicalPlanNode that can be Clone'd (needed in the current
+/// formulation of LogicalPlan)
+pub struct CloneableLogicalPlanNode {
+    /// The actual LogicalPlaNode
+    pub node: Box<dyn LogicalPlanNode>,
+}
+
+impl CloneableLogicalPlanNode {
+    /// Create a new CloneableLogicalPlanNode
+    pub fn new(node: Box<dyn LogicalPlanNode>) -> Self {
+        CloneableLogicalPlanNode { node }
+    }
+}
+
+impl Clone for CloneableLogicalPlanNode {
+    fn clone(&self) -> Self {
+        CloneableLogicalPlanNode {
+            node: self.node.dyn_clone(),
+        }
+    }
+}

--- a/rust/datafusion/src/lp_limit.rs
+++ b/rust/datafusion/src/lp_limit.rs
@@ -1,0 +1,99 @@
+//! Example of how a "User Defined logical plan node would work. Use
+//! the LogicalPlanNode trait for LimitNode
+
+use crate::error::Result;
+use crate::{
+    execution::{
+        context::ExecutionContextState,
+        physical_plan::{limit::GlobalLimitExec, ExecutionPlan},
+    },
+    logicalplan::{Expr, LogicalPlan},
+    lp::LogicalPlanNode,
+};
+use arrow::datatypes::Schema;
+use core::fmt;
+use std::sync::{Arc, Mutex};
+
+/// Produces the first `n` tuples from its input and discards the rest.
+#[derive(Clone)]
+pub struct LimitNode {
+    /// The limit
+    n: usize,
+    /// The input plan -- always exactly a single entry, but stored in
+    /// a Vector to implement `LogicalPlanNode::inputs`
+    inputs: Vec<Arc<LogicalPlan>>,
+}
+
+impl LimitNode {
+    pub fn new(n: usize, input: LogicalPlan) -> Self {
+        LimitNode {
+            n,
+            inputs: vec![Arc::new(input)],
+        }
+    }
+
+    // a limit node has a single input
+    pub fn input(&self) -> Arc<LogicalPlan> {
+        self.inputs[0].clone()
+    }
+}
+
+impl LogicalPlanNode for LimitNode {
+    // returns a reference to the inputs of this node
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        self.inputs.iter().map(|arc| arc.as_ref()).collect()
+    }
+
+    fn schema(&self) -> &Schema {
+        self.inputs[0].schema()
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        Vec::new()
+    }
+
+    /// Write a single line human readable string to `f` for use in explain plan
+    fn format_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Limit: {}", self.n)
+    }
+
+    fn dyn_clone(&self) -> Box<dyn LogicalPlanNode> {
+        Box::new(self.clone())
+    }
+
+    fn clone_from_template(
+        &self,
+        _exprs: &Vec<Expr>,
+        inputs: &Vec<LogicalPlan>,
+    ) -> Box<dyn LogicalPlanNode> {
+        let inputs = inputs.iter().map(|lp| Arc::new(lp.clone())).collect();
+
+        Box::new(LimitNode { n: self.n, inputs })
+    }
+
+    fn create_physical_plan(
+        &self,
+        input_physical_plans: Vec<Arc<dyn ExecutionPlan>>,
+        ctx_state: Arc<Mutex<ExecutionContextState>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let input_schema = self.input().as_ref().schema().clone();
+        let input_schema = Arc::new(input_schema);
+
+        assert_eq!(
+            input_physical_plans.len(),
+            1,
+            "Limit can only have a single input plan"
+        );
+
+        Ok(Arc::new(GlobalLimitExec::new(
+            input_schema,
+            input_physical_plans[0].partitions()?,
+            self.n,
+            ctx_state
+                .lock()
+                .expect("failed to lock mutex")
+                .config
+                .concurrency,
+        )))
+    }
+}

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -543,8 +543,8 @@ fn execute(ctx: &mut ExecutionContext, sql: &str) -> Vec<String> {
     let physical_schema = plan.schema().clone();
     let results = ctx.collect(plan.as_ref()).unwrap();
 
-    assert_eq!(logical_schema.as_ref(), optimized_logical_schema.as_ref());
-    assert_eq!(logical_schema.as_ref(), physical_schema.as_ref());
+    assert_eq!(logical_schema, optimized_logical_schema);
+    assert_eq!(&logical_schema, physical_schema.as_ref());
 
     result_str(&results)
 }


### PR DESCRIPTION
This PR demonstrates one approach of user defined LogicalPlan nodes could be implemented in DataFusion. The proposal can be found in https://docs.google.com/document/d/1IHCGkCuUvnE9BavkykPULn6Ugxgqc1JShT4nz1vMi7g/edit#heading=h.2nfzn4ggyl34

The major components of this PR are:
1. `LogicalPlanNode` Trait
2.  A `LogicalPlan::UserDefined` type that adapts `dyn LogicalPlanNode` objects to work in LogicalPlan
3. Ported the code for the existing `LogicalPlan::Limit` vairant to instead use the `LogicalPlanNode` trait; All tests pass
