### PR TITLE
ARROW-9762: [Rust] [DataFusion] ExecutionContext::sql now returns DataFrame

### DIFF
--- a/rust/datafusion/benches/aggregate_query_sql.rs
+++ b/rust/datafusion/benches/aggregate_query_sql.rs
@@ -32,7 +32,8 @@ use datafusion::execution::context::ExecutionContext;
 
 fn aggregate_query(ctx: &mut ExecutionContext, sql: &str) {
     // execute the query
-    let results = ctx.sql(&sql).unwrap();
+    let df = ctx.sql(&sql).unwrap();
+    let results = df.collect().unwrap();
 
     // display the relation
     for _batch in results {}

--- a/rust/datafusion/examples/csv_sql.rs
+++ b/rust/datafusion/examples/csv_sql.rs
@@ -36,12 +36,13 @@ fn main() -> Result<()> {
     )?;
 
     // execute the query
-    let results = ctx.sql(
+    let df = ctx.sql(
         "SELECT c1, MIN(c12), MAX(c12) \
         FROM aggregate_test_100 \
         WHERE c11 > 0.1 AND c11 < 0.9 \
         GROUP BY c1",
     )?;
+    let results = df.collect()?;
 
     // print the results
     pretty::print_batches(&results)?;

--- a/rust/datafusion/examples/parquet_sql.rs
+++ b/rust/datafusion/examples/parquet_sql.rs
@@ -36,11 +36,12 @@ fn main() -> Result<()> {
     )?;
 
     // execute the query
-    let results = ctx.sql(
+    let df = ctx.sql(
         "SELECT int_col, double_col, CAST(date_string_col as VARCHAR) \
         FROM alltypes_plain \
         WHERE id > 1 AND tinyint_col < double_col",
     )?;
+    let results = df.collect()?;
 
     // print the results
     pretty::print_batches(&results)?;

--- a/rust/datafusion/src/bin/repl.rs
+++ b/rust/datafusion/src/bin/repl.rs
@@ -103,7 +103,8 @@ fn is_exit_command(line: &str) -> bool {
 fn exec_and_print(ctx: &mut ExecutionContext, sql: String) -> Result<()> {
     let now = Instant::now();
 
-    let results = ctx.sql(&sql)?;
+    let df = ctx.sql(&sql)?;
+    let results = df.collect()?;
 
     if results.is_empty() {
         println!(

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -104,9 +104,13 @@ impl DataFrame for DataFrameImpl {
         self.plan.clone()
     }
 
+    // Convert the logical plan represented by this DataFrame into a physical plan and
+    // execute it
     fn collect(&self) -> Result<Vec<RecordBatch>> {
-        let mut ctx = ExecutionContext::from(self.ctx_state.clone());
-        ctx.collect_plan(&self.plan.clone())
+        let ctx = ExecutionContext::from(self.ctx_state.clone());
+        let plan = ctx.optimize(&self.plan)?;
+        let plan = ctx.create_physical_plan(&plan)?;
+        Ok(ctx.collect(plan.as_ref())?)
     }
 
     /// Returns the schema from the logical plan


### PR DESCRIPTION
I need this change so that I can have Ballista use the DataFusion DataFrame trait and start testing the extension points for the physical planner.