### PR TITLE
ARROW-9815: [Rust][DataFusion] Add a trait for looking up scalar functions by name

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -28,6 +28,7 @@ use arrow::csv;
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
 
+use super::physical_plan::udf::ScalarFunctionProvider;
 use crate::dataframe::DataFrame;
 use crate::datasource::csv::CsvFile;
 use crate::datasource::parquet::ParquetTable;
@@ -106,8 +107,8 @@ impl ExecutionContext {
     pub fn with_config(config: ExecutionConfig) -> Self {
         let mut ctx = Self {
             state: Arc::new(Mutex::new(ExecutionContextState {
-                datasources: Box::new(HashMap::new()),
-                scalar_functions: Box::new(HashMap::new()),
+                datasources: HashMap::new(),
+                scalar_functions: HashMap::new(),
                 config,
             })),
         };
@@ -189,16 +190,7 @@ impl ExecutionContext {
     /// Register a scalar UDF
     pub fn register_udf(&mut self, f: ScalarFunction) {
         let mut state = self.state.lock().expect("failed to lock mutex");
-        state.scalar_functions.insert(f.name.clone(), Box::new(f));
-    }
-
-    /// Get a reference to the registered scalar functions
-    pub fn scalar_functions(&self) -> Box<HashMap<String, Box<ScalarFunction>>> {
-        self.state
-            .lock()
-            .expect("failed to lock mutex")
-            .scalar_functions
-            .clone()
+        state.scalar_functions.insert(f.name.clone(), Arc::new(f));
     }
 
     /// Creates a DataFrame for reading a CSV data source.
@@ -317,22 +309,9 @@ impl ExecutionContext {
 
     /// Optimize the logical plan by applying optimizer rules
     pub fn optimize(&self, plan: &LogicalPlan) -> Result<LogicalPlan> {
-        let rules: Vec<Box<dyn OptimizerRule>> = vec![
-            Box::new(ProjectionPushDown::new()),
-            Box::new(FilterPushDown::new()),
-            Box::new(TypeCoercionRule::new(
-                self.state
-                    .lock()
-                    .expect("failed to lock mutex")
-                    .scalar_functions
-                    .as_ref(),
-            )),
-        ];
-        let mut plan = plan.clone();
-
-        for mut rule in rules {
-            plan = rule.optimize(&plan)?;
-        }
+        let plan = ProjectionPushDown::new().optimize(&plan)?;
+        let plan = FilterPushDown::new().optimize(&plan)?;
+        let plan = TypeCoercionRule::new(self).optimize(&plan)?;
         Ok(plan)
     }
 
@@ -419,6 +398,16 @@ impl ExecutionContext {
     }
 }
 
+impl ScalarFunctionProvider for ExecutionContext {
+    fn lookup(&self, name: &str) -> Option<Arc<ScalarFunction>> {
+        self.state
+            .lock()
+            .expect("failed to lock mutex")
+            .scalar_functions
+            .lookup(name)
+    }
+}
+
 /// Configuration options for execution context
 #[derive(Clone)]
 pub struct ExecutionConfig {
@@ -469,9 +458,9 @@ impl ExecutionConfig {
 /// Execution context for registering data sources and executing queries
 pub struct ExecutionContextState {
     /// Data sources that are registered with the context
-    pub datasources: Box<HashMap<String, Box<dyn TableProvider + Send + Sync>>>,
+    pub datasources: HashMap<String, Box<dyn TableProvider + Send + Sync>>,
     /// Scalar functions that are registered with the context
-    pub scalar_functions: Box<HashMap<String, Box<ScalarFunction>>>,
+    pub scalar_functions: HashMap<String, Arc<ScalarFunction>>,
     /// Context configuration
     pub config: ExecutionConfig,
 }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -28,7 +28,7 @@ use arrow::csv;
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
 
-use super::physical_plan::udf::ScalarFunctionProvider;
+use super::physical_plan::udf::ScalarFunctionRegistry;
 use crate::dataframe::DataFrame;
 use crate::datasource::csv::CsvFile;
 use crate::datasource::parquet::ParquetTable;
@@ -398,7 +398,7 @@ impl ExecutionContext {
     }
 }
 
-impl ScalarFunctionProvider for ExecutionContext {
+impl ScalarFunctionRegistry for ExecutionContext {
     fn lookup(&self, name: &str) -> Option<Arc<ScalarFunction>> {
         self.state
             .lock()

--- a/rust/datafusion/src/execution/physical_plan/planner.rs
+++ b/rust/datafusion/src/execution/physical_plan/planner.rs
@@ -421,8 +421,8 @@ mod tests {
 
     fn plan(logical_plan: &LogicalPlan) -> Result<Arc<dyn ExecutionPlan>> {
         let ctx_state = ExecutionContextState {
-            datasources: Box::new(HashMap::new()),
-            scalar_functions: Box::new(HashMap::new()),
+            datasources: HashMap::new(),
+            scalar_functions: HashMap::new(),
             config: ExecutionConfig::new(),
         };
 

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -27,7 +27,7 @@ use crate::execution::physical_plan::PhysicalExpr;
 
 use arrow::record_batch::RecordBatch;
 use fmt::{Debug, Formatter};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 /// Scalar UDF
 pub type ScalarUdf = Arc<dyn Fn(&[ArrayRef]) -> Result<ArrayRef> + Send + Sync>;
@@ -43,6 +43,18 @@ pub struct ScalarFunction {
     pub return_type: DataType,
     /// UDF implementation
     pub fun: ScalarUdf,
+}
+
+/// Something which provides information for particular scalar functions
+pub trait ScalarFunctionProvider {
+    /// Return ScalarFunction for `name`
+    fn lookup(&self, name: &str) -> Option<Arc<ScalarFunction>>;
+}
+
+impl ScalarFunctionProvider for HashMap<String, Arc<ScalarFunction>> {
+    fn lookup(&self, name: &str) -> Option<Arc<ScalarFunction>> {
+        self.get(name).and_then(|func| Some(func.clone()))
+    }
 }
 
 impl Debug for ScalarFunction {

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -46,12 +46,12 @@ pub struct ScalarFunction {
 }
 
 /// Something which provides information for particular scalar functions
-pub trait ScalarFunctionProvider {
+pub trait ScalarFunctionRegistry {
     /// Return ScalarFunction for `name`
     fn lookup(&self, name: &str) -> Option<Arc<ScalarFunction>>;
 }
 
-impl ScalarFunctionProvider for HashMap<String, Arc<ScalarFunction>> {
+impl ScalarFunctionRegistry for HashMap<String, Arc<ScalarFunction>> {
     fn lookup(&self, name: &str) -> Option<Arc<ScalarFunction>> {
         self.get(name).and_then(|func| Some(func.clone()))
     }

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -20,14 +20,11 @@
 //! the operation `c_float + c_int` would be rewritten as `c_float + CAST(c_int AS
 //! float)`. This keeps the runtime query execution code much simpler.
 
-use std::collections::HashMap;
-use std::sync::Arc;
-
 use arrow::datatypes::Schema;
 
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::{
-    expressions::numerical_coercion, udf::ScalarFunction,
+    expressions::numerical_coercion, udf::ScalarFunctionProvider
 };
 use crate::logicalplan::Expr;
 use crate::logicalplan::{LogicalPlan, Operator};
@@ -38,17 +35,21 @@ use utils::optimize_explain;
 /// Optimizer that applies coercion rules to expressions in the logical plan.
 ///
 /// This optimizer does not alter the structure of the plan, it only changes expressions on it.
-pub struct TypeCoercionRule {
-    scalar_functions: Arc<HashMap<String, Box<ScalarFunction>>>,
+pub struct TypeCoercionRule<'a, P>
+where
+    P: ScalarFunctionProvider,
+{
+    scalar_functions: &'a P,
 }
 
-impl TypeCoercionRule {
+impl<'a, P> TypeCoercionRule<'a, P>
+where
+    P: ScalarFunctionProvider,
+{
     /// Create a new type coercion optimizer rule using meta-data about registered
     /// scalar functions
-    pub fn new(scalar_functions: &HashMap<String, Box<ScalarFunction>>) -> Self {
-        Self {
-            scalar_functions: Arc::new(scalar_functions.clone()),
-        }
+    pub fn new(scalar_functions: &'a P) -> Self {
+        Self { scalar_functions }
     }
 
     /// Rewrite an expression to include explicit CAST operations when required
@@ -65,7 +66,7 @@ impl TypeCoercionRule {
         match expr {
             Expr::ScalarFunction { name, .. } => {
                 // cast the inputs of scalar functions to the appropriate type where possible
-                match self.scalar_functions.get(name) {
+                match self.scalar_functions.lookup(name) {
                     Some(func_meta) => {
                         for i in 0..expressions.len() {
                             let field = &func_meta.args[i];
@@ -102,7 +103,10 @@ impl TypeCoercionRule {
     }
 }
 
-impl OptimizerRule for TypeCoercionRule {
+impl<'a, P> OptimizerRule for TypeCoercionRule<'a, P>
+where
+    P: ScalarFunctionProvider,
+{
     fn optimize(&mut self, plan: &LogicalPlan) -> Result<LogicalPlan> {
         match plan {
             LogicalPlan::Explain {

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -24,7 +24,7 @@ use arrow::datatypes::Schema;
 
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::{
-    expressions::numerical_coercion, udf::ScalarFunctionProvider
+    expressions::numerical_coercion, udf::ScalarFunctionRegistry,
 };
 use crate::logicalplan::Expr;
 use crate::logicalplan::{LogicalPlan, Operator};
@@ -37,14 +37,14 @@ use utils::optimize_explain;
 /// This optimizer does not alter the structure of the plan, it only changes expressions on it.
 pub struct TypeCoercionRule<'a, P>
 where
-    P: ScalarFunctionProvider,
+    P: ScalarFunctionRegistry,
 {
     scalar_functions: &'a P,
 }
 
 impl<'a, P> TypeCoercionRule<'a, P>
 where
-    P: ScalarFunctionProvider,
+    P: ScalarFunctionRegistry,
 {
     /// Create a new type coercion optimizer rule using meta-data about registered
     /// scalar functions
@@ -105,7 +105,7 @@ where
 
 impl<'a, P> OptimizerRule for TypeCoercionRule<'a, P>
 where
-    P: ScalarFunctionProvider,
+    P: ScalarFunctionRegistry,
 {
     fn optimize(&mut self, plan: &LogicalPlan) -> Result<LogicalPlan> {
         match plan {


### PR DESCRIPTION
Inspired by the conversation on https://github.com/apache/arrow/pull/8018/files, I have been bothered by the use of Arc/Mutex and the resulting code complication in ExecutionContext and LogicalPlanning.

The more I read the code, the more I am convinced that `ExecutionContextState` needs to be mutable *before* planning, but once planning has started the state is all read only (and any relevant state is copied / cloned into the `ExecutionPlan`) so the only thing Mutex/Arc are doing is making lurking bugs like ARROW-9815 more likely and requiring copies. 

This PR proposes a modest change to add a trait for looking up scalar functions by name, and thus removes the direct use of Box / HashMaps / etc in the TypeCoercion optimizer pass.

I have several other changes in mind to avoid the need for Box / Mutex entirely in ExecutionContext but I want to keep the individual PRs small.
