### PR TITLE
ARROW-9464: [Rust] [DataFusion] Physical plan optimization rule to insert MergeExec when needed

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -339,7 +339,6 @@ impl ExecutionContext {
             _ => {
                 // merge into a single partition
                 let plan = MergeExec::new(
-                    plan.schema().clone(),
                     plan.clone(),
                     self.state
                         .lock()

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -189,6 +189,21 @@ impl ExecutionPlan for CsvExec {
         Partitioning::UnknownPartitioning(self.filenames.len())
     }
 
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        // this is a leaf node and has no children
+        vec![]
+    }
+
+    fn with_new_children(
+        &self,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Err(ExecutionError::General(format!(
+            "Children cannot be replaced in {:?}",
+            self
+        )))
+    }
+
     fn execute(
         &self,
         partition: usize,

--- a/rust/datafusion/src/execution/physical_plan/csv.rs
+++ b/rust/datafusion/src/execution/physical_plan/csv.rs
@@ -103,7 +103,7 @@ impl<'a> CsvReadOptions<'a> {
 }
 
 /// Execution plan for scanning a CSV file
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CsvExec {
     /// Path to directory containing partitioned CSV files with the same schema
     path: String,
@@ -196,12 +196,16 @@ impl ExecutionPlan for CsvExec {
 
     fn with_new_children(
         &self,
-        _: Vec<Arc<dyn ExecutionPlan>>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Err(ExecutionError::General(format!(
-            "Children cannot be replaced in {:?}",
-            self
-        )))
+        if children.is_empty() {
+            Ok(Arc::new(self.clone()))
+        } else {
+            Err(ExecutionError::General(format!(
+                "Children cannot be replaced in {:?}",
+                self
+            )))
+        }
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/explain.rs
+++ b/rust/datafusion/src/execution/physical_plan/explain.rs
@@ -81,7 +81,12 @@ impl ExecutionPlan for ExplainExec {
         &self,
         partition: usize,
     ) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
-        assert_eq!(0, partition);
+        if 0 != partition {
+            return Err(ExecutionError::General(format!(
+                "ExplainExec invalid partition {}",
+                partition
+            )));
+        }
 
         let mut type_builder = StringArray::builder(self.stringified_plans.len());
         let mut plan_builder = StringArray::builder(self.stringified_plans.len());

--- a/rust/datafusion/src/execution/physical_plan/explain.rs
+++ b/rust/datafusion/src/execution/physical_plan/explain.rs
@@ -17,7 +17,7 @@
 
 //! Defines the EXPLAIN operator
 
-use crate::error::Result;
+use crate::error::{ExecutionError, Result};
 use crate::{
     execution::physical_plan::{common::RecordBatchIterator, ExecutionPlan},
     logicalplan::StringifiedPlan,
@@ -58,11 +58,25 @@ impl ExecutionPlan for ExplainExec {
         self.schema.clone()
     }
 
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        // this is a leaf node and has no children
+        vec![]
+    }
+
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
     }
 
+    fn with_new_children(
+        &self,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Err(ExecutionError::General(format!(
+            "Children cannot be replaced in {:?}",
+            self
+        )))
+    }
     fn execute(
         &self,
         partition: usize,

--- a/rust/datafusion/src/execution/physical_plan/explain.rs
+++ b/rust/datafusion/src/execution/physical_plan/explain.rs
@@ -34,7 +34,7 @@ use std::sync::{Arc, Mutex};
 /// Explain execution plan operator. This operator contains the string
 /// values of the various plans it has when it is created, and passes
 /// them to its output.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ExplainExec {
     /// The schema that this exec plan node outputs
     schema: SchemaRef,
@@ -70,12 +70,16 @@ impl ExecutionPlan for ExplainExec {
 
     fn with_new_children(
         &self,
-        _: Vec<Arc<dyn ExecutionPlan>>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Err(ExecutionError::General(format!(
-            "Children cannot be replaced in {:?}",
-            self
-        )))
+        if children.is_empty() {
+            Ok(Arc::new(self.clone()))
+        } else {
+            Err(ExecutionError::General(format!(
+                "Children cannot be replaced in {:?}",
+                self
+            )))
+        }
     }
     fn execute(
         &self,

--- a/rust/datafusion/src/execution/physical_plan/filter.rs
+++ b/rust/datafusion/src/execution/physical_plan/filter.rs
@@ -64,9 +64,24 @@ impl ExecutionPlan for FilterExec {
         self.input.schema()
     }
 
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         self.input.output_partitioning()
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        assert_eq!(1, children.len());
+        Ok(Arc::new(FilterExec::try_new(
+            self.predicate.clone(),
+            children[0].clone(),
+        )?))
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/filter.rs
+++ b/rust/datafusion/src/execution/physical_plan/filter.rs
@@ -77,11 +77,15 @@ impl ExecutionPlan for FilterExec {
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        assert_eq!(1, children.len());
-        Ok(Arc::new(FilterExec::try_new(
-            self.predicate.clone(),
-            children[0].clone(),
-        )?))
+        match children.len() {
+            1 => Ok(Arc::new(FilterExec::try_new(
+                self.predicate.clone(),
+                children[0].clone(),
+            )?)),
+            _ => Err(ExecutionError::General(
+                "FilterExec wrong number of children".to_string(),
+            )),
+        }
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -23,7 +23,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::{
-    Accumulator, AggregateExpr, ExecutionPlan, Partitioning, PhysicalExpr,
+    Accumulator, AggregateExpr, Distribution, ExecutionPlan, Partitioning, PhysicalExpr,
 };
 
 use arrow::array::{
@@ -44,11 +44,21 @@ use crate::execution::physical_plan::expressions::col;
 use crate::logicalplan::ScalarValue;
 use fnv::FnvHashMap;
 
+/// Hash aggregate modes
+#[derive(Debug, Copy, Clone)]
+pub enum AggregateMode {
+    /// Partial aggregate that can be applied in parallel across input partitions
+    Partial,
+    /// Final aggregate that produces a single partition of output
+    Final,
+}
+
 /// Hash aggregate execution plan
 #[derive(Debug)]
 pub struct HashAggregateExec {
-    group_expr: Vec<Arc<dyn PhysicalExpr>>,
-    aggr_expr: Vec<Arc<dyn AggregateExpr>>,
+    mode: AggregateMode,
+    group_expr: Vec<(Arc<dyn PhysicalExpr>, String)>,
+    aggr_expr: Vec<(Arc<dyn AggregateExpr>, String)>,
     input: Arc<dyn ExecutionPlan>,
     schema: SchemaRef,
 }
@@ -56,6 +66,7 @@ pub struct HashAggregateExec {
 impl HashAggregateExec {
     /// Create a new hash aggregate execution plan
     pub fn try_new(
+        mode: AggregateMode,
         group_expr: Vec<(Arc<dyn PhysicalExpr>, String)>,
         aggr_expr: Vec<(Arc<dyn AggregateExpr>, String)>,
         input: Arc<dyn ExecutionPlan>,
@@ -80,8 +91,9 @@ impl HashAggregateExec {
         let schema = Arc::new(Schema::new(fields));
 
         Ok(HashAggregateExec {
-            group_expr: group_expr.iter().map(|x| x.0.clone()).collect(),
-            aggr_expr: aggr_expr.iter().map(|x| x.0.clone()).collect(),
+            mode,
+            group_expr,
+            aggr_expr,
             input,
             schema,
         })
@@ -99,7 +111,7 @@ impl HashAggregateExec {
             .collect();
 
         let final_aggr: Vec<Arc<dyn AggregateExpr>> = (0..self.aggr_expr.len())
-            .map(|i| self.aggr_expr[i].create_reducer(&agg_names[i]))
+            .map(|i| self.aggr_expr[i].0.create_reducer(&agg_names[i]))
             .collect();
 
         (final_group, final_aggr)
@@ -109,6 +121,17 @@ impl HashAggregateExec {
 impl ExecutionPlan for HashAggregateExec {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    fn required_child_distribution(&self) -> Distribution {
+        match &self.mode {
+            AggregateMode::Partial => Distribution::UnspecifiedDistribution,
+            AggregateMode::Final => Distribution::SinglePartition,
+        }
     }
 
     /// Get the output partitioning of this plan
@@ -121,20 +144,35 @@ impl ExecutionPlan for HashAggregateExec {
         partition: usize,
     ) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         let input = self.input.execute(partition)?;
+        let group_expr = self.group_expr.iter().map(|x| x.0.clone()).collect();
+        let aggr_expr = self.aggr_expr.iter().map(|x| x.0.clone()).collect();
         if self.group_expr.is_empty() {
             Ok(Arc::new(Mutex::new(HashAggregateIterator::new(
                 self.schema.clone(),
-                self.aggr_expr.clone(),
+                aggr_expr,
                 input,
             ))))
         } else {
             Ok(Arc::new(Mutex::new(GroupedHashAggregateIterator::new(
                 self.schema.clone(),
-                self.group_expr.clone(),
-                self.aggr_expr.clone(),
+                group_expr,
+                aggr_expr,
                 input,
             ))))
         }
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        assert_eq!(1, children.len());
+        Ok(Arc::new(HashAggregateExec::try_new(
+            self.mode,
+            self.group_expr.clone(),
+            self.aggr_expr.clone(),
+            children[0].clone(),
+        )?))
     }
 }
 
@@ -689,23 +727,23 @@ mod tests {
         let aggregates: Vec<(Arc<dyn AggregateExpr>, String)> =
             vec![(sum(col("c4")), "SUM(c4)".to_string())];
 
-        let partition_aggregate = Arc::new(HashAggregateExec::try_new(
+        let partial_aggregate = Arc::new(HashAggregateExec::try_new(
+            AggregateMode::Partial,
             groups.clone(),
             aggregates.clone(),
             Arc::new(csv),
         )?);
 
-        let schema = partition_aggregate.schema();
-
         // construct the expressions for the final aggregation
-        let (final_group, final_aggr) = partition_aggregate.make_final_expr(
+        let (final_group, final_aggr) = partial_aggregate.make_final_expr(
             groups.iter().map(|x| x.1.clone()).collect(),
             aggregates.iter().map(|x| x.1.clone()).collect(),
         );
 
-        let merge = Arc::new(MergeExec::new(schema.clone(), partition_aggregate, 2));
+        let merge = Arc::new(MergeExec::new(partial_aggregate, 2));
 
         let merged_aggregate = Arc::new(HashAggregateExec::try_new(
+            AggregateMode::Final,
             final_group
                 .iter()
                 .enumerate()

--- a/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/execution/physical_plan/hash_aggregate.rs
@@ -166,13 +166,17 @@ impl ExecutionPlan for HashAggregateExec {
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        assert_eq!(1, children.len());
-        Ok(Arc::new(HashAggregateExec::try_new(
-            self.mode,
-            self.group_expr.clone(),
-            self.aggr_expr.clone(),
-            children[0].clone(),
-        )?))
+        match children.len() {
+            1 => Ok(Arc::new(HashAggregateExec::try_new(
+                self.mode,
+                self.group_expr.clone(),
+                self.aggr_expr.clone(),
+                children[0].clone(),
+            )?)),
+            _ => Err(ExecutionError::General(
+                "HashAggregateExec wrong number of children".to_string(),
+            )),
+        }
     }
 }
 

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -20,10 +20,8 @@
 use std::sync::{Arc, Mutex};
 
 use crate::error::{ExecutionError, Result};
-use crate::execution::physical_plan::common::{self, RecordBatchIterator};
 use crate::execution::physical_plan::memory::MemoryIterator;
-use crate::execution::physical_plan::merge::MergeExec;
-use crate::execution::physical_plan::{ExecutionPlan, Partitioning};
+use crate::execution::physical_plan::{Distribution, ExecutionPlan, Partitioning};
 use arrow::array::ArrayRef;
 use arrow::compute::limit;
 use arrow::datatypes::SchemaRef;
@@ -32,9 +30,7 @@ use arrow::record_batch::{RecordBatch, RecordBatchReader};
 /// Limit execution plan
 #[derive(Debug)]
 pub struct GlobalLimitExec {
-    /// Input schema
-    schema: SchemaRef,
-    /// Input partitions
+    /// Input execution plan
     input: Arc<dyn ExecutionPlan>,
     /// Maximum number of rows to return
     limit: usize,
@@ -44,14 +40,8 @@ pub struct GlobalLimitExec {
 
 impl GlobalLimitExec {
     /// Create a new MergeExec
-    pub fn new(
-        schema: SchemaRef,
-        input: Arc<dyn ExecutionPlan>,
-        limit: usize,
-        concurrency: usize,
-    ) -> Self {
+    pub fn new(input: Arc<dyn ExecutionPlan>, limit: usize, concurrency: usize) -> Self {
         GlobalLimitExec {
-            schema,
             input,
             limit,
             concurrency,
@@ -61,7 +51,15 @@ impl GlobalLimitExec {
 
 impl ExecutionPlan for GlobalLimitExec {
     fn schema(&self) -> SchemaRef {
-        self.schema.clone()
+        self.input.schema()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
+    fn required_child_distribution(&self) -> Distribution {
+        Distribution::SinglePartition
     }
 
     /// Get the output partitioning of this plan
@@ -69,68 +67,48 @@ impl ExecutionPlan for GlobalLimitExec {
         Partitioning::UnknownPartitioning(1)
     }
 
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        assert_eq!(1, children.len());
+        Ok(Arc::new(GlobalLimitExec::new(
+            children[0].clone(),
+            self.limit,
+            self.concurrency,
+        )))
+    }
+
     fn execute(
         &self,
         partition: usize,
     ) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
-        // GlobalLimitExec has a single partition
+        // GlobalLimitExec has a single output partition
         assert_eq!(0, partition);
 
-        // apply limit in parallel across all input partitions
-        let local_limit = Arc::new(LocalLimitExec::new(
-            self.input.clone(),
-            self.schema.clone(),
-            self.limit,
-        ));
+        // GlobalLimitExec requires a single input partition
+        assert_eq!(1, self.input.output_partitioning().partition_count());
 
-        // limit needs to collapse inputs down to a single partition
-        let merge = MergeExec::new(self.schema.clone(), local_limit, self.concurrency);
-        // MergeExec must always produce a single partition
-        assert_eq!(1, merge.output_partitioning().partition_count());
-        let it = merge.execute(0)?;
-        let batches = common::collect(it)?;
-
-        // apply the limit to the output
-        let mut combined_results: Vec<Arc<RecordBatch>> = vec![];
-        let mut count = 0;
-        for batch in batches {
-            let capacity = self.limit - count;
-            if batch.num_rows() <= capacity {
-                count += batch.num_rows();
-                combined_results.push(Arc::new(batch.clone()))
-            } else {
-                let batch = truncate_batch(&batch, capacity)?;
-                count += batch.num_rows();
-                combined_results.push(Arc::new(batch.clone()))
-            }
-            if count == self.limit {
-                break;
-            }
-        }
-
-        Ok(Arc::new(Mutex::new(RecordBatchIterator::new(
-            self.schema.clone(),
-            combined_results,
-        ))))
+        let it = self.input.execute(0)?;
+        Ok(Arc::new(Mutex::new(MemoryIterator::try_new(
+            collect_with_limit(it, self.limit)?,
+            self.input.schema(),
+            None,
+        )?)))
     }
 }
 
-/// LocalLimitExec applies a limit so a single partition
+/// LocalLimitExec applies a limit to a single partition
 #[derive(Debug)]
 pub struct LocalLimitExec {
     input: Arc<dyn ExecutionPlan>,
-    schema: SchemaRef,
     limit: usize,
 }
 
 impl LocalLimitExec {
     /// Create a new LocalLimitExec partition
-    pub fn new(input: Arc<dyn ExecutionPlan>, schema: SchemaRef, limit: usize) -> Self {
-        Self {
-            input,
-            schema,
-            limit,
-        }
+    pub fn new(input: Arc<dyn ExecutionPlan>, limit: usize) -> Self {
+        Self { input, limit }
     }
 }
 
@@ -139,8 +117,23 @@ impl ExecutionPlan for LocalLimitExec {
         self.input.schema()
     }
 
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
     fn output_partitioning(&self) -> Partitioning {
         self.input.output_partitioning()
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        assert_eq!(1, children.len());
+        Ok(Arc::new(LocalLimitExec::new(
+            children[0].clone(),
+            self.limit,
+        )))
     }
 
     fn execute(
@@ -150,7 +143,7 @@ impl ExecutionPlan for LocalLimitExec {
         let it = self.input.execute(partition)?;
         Ok(Arc::new(Mutex::new(MemoryIterator::try_new(
             collect_with_limit(it, self.limit)?,
-            self.schema.clone(),
+            self.input.schema(),
             None,
         )?)))
     }
@@ -207,6 +200,7 @@ mod tests {
     use super::*;
     use crate::execution::physical_plan::common;
     use crate::execution::physical_plan::csv::{CsvExec, CsvReadOptions};
+    use crate::execution::physical_plan::merge::MergeExec;
     use crate::test;
 
     #[test]
@@ -223,7 +217,8 @@ mod tests {
         // input should have 4 partitions
         assert_eq!(csv.output_partitioning().partition_count(), num_partitions);
 
-        let limit = GlobalLimitExec::new(schema.clone(), Arc::new(csv), 7, 2);
+        let limit =
+            GlobalLimitExec::new(Arc::new(MergeExec::new(Arc::new(csv), 2)), 7, 2);
 
         // the result should contain 4 batches (one per input partition)
         let iter = limit.execute(0)?;

--- a/rust/datafusion/src/execution/physical_plan/limit.rs
+++ b/rust/datafusion/src/execution/physical_plan/limit.rs
@@ -71,12 +71,16 @@ impl ExecutionPlan for GlobalLimitExec {
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        assert_eq!(1, children.len());
-        Ok(Arc::new(GlobalLimitExec::new(
-            children[0].clone(),
-            self.limit,
-            self.concurrency,
-        )))
+        match children.len() {
+            1 => Ok(Arc::new(GlobalLimitExec::new(
+                children[0].clone(),
+                self.limit,
+                self.concurrency,
+            ))),
+            _ => Err(ExecutionError::General(
+                "GlobalLimitExec wrong number of children".to_string(),
+            )),
+        }
     }
 
     fn execute(
@@ -138,11 +142,15 @@ impl ExecutionPlan for LocalLimitExec {
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        assert_eq!(1, children.len());
-        Ok(Arc::new(LocalLimitExec::new(
-            children[0].clone(),
-            self.limit,
-        )))
+        match children.len() {
+            1 => Ok(Arc::new(LocalLimitExec::new(
+                children[0].clone(),
+                self.limit,
+            ))),
+            _ => Err(ExecutionError::General(
+                "LocalLimitExec wrong number of children".to_string(),
+            )),
+        }
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/memory.rs
+++ b/rust/datafusion/src/execution/physical_plan/memory.rs
@@ -19,7 +19,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use crate::error::Result;
+use crate::error::{ExecutionError, Result};
 use crate::execution::physical_plan::{ExecutionPlan, Partitioning};
 use arrow::datatypes::SchemaRef;
 use arrow::error::Result as ArrowResult;
@@ -42,9 +42,24 @@ impl ExecutionPlan for MemoryExec {
         self.schema.clone()
     }
 
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        // this is a leaf node and has no children
+        vec![]
+    }
+
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(self.partitions.len())
+    }
+
+    fn with_new_children(
+        &self,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Err(ExecutionError::General(format!(
+            "Children cannot be replaced in {:?}",
+            self
+        )))
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -67,11 +67,15 @@ impl ExecutionPlan for MergeExec {
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        assert_eq!(1, children.len());
-        Ok(Arc::new(MergeExec::new(
-            children[0].clone(),
-            self.concurrency,
-        )))
+        match children.len() {
+            1 => Ok(Arc::new(MergeExec::new(
+                children[0].clone(),
+                self.concurrency,
+            ))),
+            _ => Err(ExecutionError::General(
+                "MergeExec wrong number of children".to_string(),
+            )),
+        }
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/merge.rs
+++ b/rust/datafusion/src/execution/physical_plan/merge.rs
@@ -79,7 +79,12 @@ impl ExecutionPlan for MergeExec {
         partition: usize,
     ) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         // MergeExec produces a single partition
-        assert_eq!(0, partition);
+        if 0 != partition {
+            return Err(ExecutionError::General(format!(
+                "MergeExec invalid partition {}",
+                partition
+            )));
+        }
 
         let input_partitions = self.input.output_partitioning().partition_count();
         match input_partitions {

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -54,9 +54,12 @@ pub trait ExecutionPlan: Debug + Send + Sync {
     fn required_child_distribution(&self) -> Distribution {
         Distribution::UnspecifiedDistribution
     }
-    /// Get the children of this plan
+    /// Get a list of child execution plans that provide the input for this plan. The returned list
+    /// will be empty for leaf nodes, will contain a single value for unary nodes, or two
+    /// values for binary nodes (such as joins).
     fn children(&self) -> Vec<Arc<dyn ExecutionPlan>>;
-    /// Replace the children of this execution plan
+    /// Returns a new plan where all children were replaced by new plans.
+    /// The size of `children` must be equal to the size of `ExecutionPlan::children()`.
     fn with_new_children(
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -50,6 +50,17 @@ pub trait ExecutionPlan: Debug + Send + Sync {
     fn schema(&self) -> SchemaRef;
     /// Specifies the output partitioning scheme of this plan
     fn output_partitioning(&self) -> Partitioning;
+    /// Specifies the data distribution requirements of all the children for this operator
+    fn required_child_distribution(&self) -> Distribution {
+        Distribution::UnspecifiedDistribution
+    }
+    /// Get the children of this plan
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>>;
+    /// Replace the children of this execution plan
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>>;
     /// Execute one partition and return an iterator over RecordBatch
     fn execute(
         &self,
@@ -72,6 +83,15 @@ impl Partitioning {
             UnknownPartitioning(n) => *n,
         }
     }
+}
+
+/// Distribution schemes
+#[derive(Debug, Clone)]
+pub enum Distribution {
+    /// Unspecified distribution
+    UnspecifiedDistribution,
+    /// A single partition is required
+    SinglePartition,
 }
 
 /// Expression that can be evaluated against a RecordBatch

--- a/rust/datafusion/src/execution/physical_plan/parquet.rs
+++ b/rust/datafusion/src/execution/physical_plan/parquet.rs
@@ -35,7 +35,7 @@ use fmt::Debug;
 use parquet::arrow::{ArrowReader, ParquetFileArrowReader};
 
 /// Execution plan for scanning a Parquet file
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParquetExec {
     /// Path to directory containing partitioned Parquet files with the same schema
     filenames: Vec<String>,
@@ -103,12 +103,16 @@ impl ExecutionPlan for ParquetExec {
 
     fn with_new_children(
         &self,
-        _: Vec<Arc<dyn ExecutionPlan>>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Err(ExecutionError::General(format!(
-            "Children cannot be replaced in {:?}",
-            self
-        )))
+        if children.is_empty() {
+            Ok(Arc::new(self.clone()))
+        } else {
+            Err(ExecutionError::General(format!(
+                "Children cannot be replaced in {:?}",
+                self
+            )))
+        }
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/parquet.rs
+++ b/rust/datafusion/src/execution/physical_plan/parquet.rs
@@ -91,9 +91,24 @@ impl ExecutionPlan for ParquetExec {
         self.schema.clone()
     }
 
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        // this is a leaf node and has no children
+        vec![]
+    }
+
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(self.filenames.len())
+    }
+
+    fn with_new_children(
+        &self,
+        _: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Err(ExecutionError::General(format!(
+            "Children cannot be replaced in {:?}",
+            self
+        )))
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/planner.rs
+++ b/rust/datafusion/src/execution/physical_plan/planner.rs
@@ -24,19 +24,19 @@ use crate::error::{ExecutionError, Result};
 use crate::execution::context::ExecutionContextState;
 use crate::execution::physical_plan::csv::{CsvExec, CsvReadOptions};
 use crate::execution::physical_plan::explain::ExplainExec;
-use crate::execution::physical_plan::expressions;
 use crate::execution::physical_plan::expressions::{
     Avg, Column, Count, Literal, Max, Min, PhysicalSortExpr, Sum,
 };
 use crate::execution::physical_plan::filter::FilterExec;
-use crate::execution::physical_plan::hash_aggregate::HashAggregateExec;
-use crate::execution::physical_plan::limit::GlobalLimitExec;
+use crate::execution::physical_plan::hash_aggregate::{AggregateMode, HashAggregateExec};
+use crate::execution::physical_plan::limit::{GlobalLimitExec, LocalLimitExec};
 use crate::execution::physical_plan::memory::MemoryExec;
 use crate::execution::physical_plan::merge::MergeExec;
 use crate::execution::physical_plan::parquet::ParquetExec;
 use crate::execution::physical_plan::projection::ProjectionExec;
 use crate::execution::physical_plan::sort::SortExec;
 use crate::execution::physical_plan::udf::ScalarFunctionExpr;
+use crate::execution::physical_plan::{expressions, Distribution};
 use crate::execution::physical_plan::{
     AggregateExpr, ExecutionPlan, PhysicalExpr, PhysicalPlanner,
 };
@@ -58,6 +58,55 @@ impl Default for DefaultPhysicalPlanner {
 impl PhysicalPlanner for DefaultPhysicalPlanner {
     /// Create a physical plan from a logical plan
     fn create_physical_plan(
+        &self,
+        logical_plan: &LogicalPlan,
+        ctx_state: &ExecutionContextState,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let plan = self.create_initial_plan(logical_plan, ctx_state)?;
+        self.optimize_plan(plan, ctx_state)
+    }
+}
+
+impl DefaultPhysicalPlanner {
+    /// Create a physical plan from a logical plan
+    fn optimize_plan(
+        &self,
+        plan: Arc<dyn ExecutionPlan>,
+        ctx_state: &ExecutionContextState,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let children = plan
+            .children()
+            .iter()
+            .map(|child| self.optimize_plan(child.clone(), ctx_state))
+            .collect::<Result<Vec<_>>>()?;
+
+        if children.len() == 0 {
+            // leaf node, children cannot be replaced
+            Ok(plan.clone())
+        } else {
+            match plan.required_child_distribution() {
+                Distribution::UnspecifiedDistribution => plan.with_new_children(children),
+                Distribution::SinglePartition => plan.with_new_children(
+                    children
+                        .iter()
+                        .map(|child| {
+                            if child.output_partitioning().partition_count() == 1 {
+                                child.clone()
+                            } else {
+                                Arc::new(MergeExec::new(
+                                    child.clone(),
+                                    ctx_state.config.concurrency,
+                                ))
+                            }
+                        })
+                        .collect(),
+                ),
+            }
+        }
+    }
+
+    /// Create a physical plan from a logical plan
+    fn create_initial_plan(
         &self,
         logical_plan: &LogicalPlan,
         ctx_state: &ExecutionContextState,
@@ -153,12 +202,11 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                     .collect::<Result<Vec<_>>>()?;
 
                 let initial_aggr = HashAggregateExec::try_new(
+                    AggregateMode::Partial,
                     groups.clone(),
                     aggregates.clone(),
                     input,
                 )?;
-
-                let schema = initial_aggr.schema();
 
                 if initial_aggr.output_partitioning().partition_count() == 1 {
                     return Ok(Arc::new(initial_aggr));
@@ -166,7 +214,6 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
 
                 let initial_aggr = Arc::new(initial_aggr);
                 let merge = Arc::new(MergeExec::new(
-                    schema.clone(),
                     initial_aggr.clone(),
                     ctx_state.config.concurrency,
                 ));
@@ -180,6 +227,7 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                 // construct a second aggregation, keeping the final column name equal to the first aggregation
                 // and the expressions corresponding to the respective aggregate
                 Ok(Arc::new(HashAggregateExec::try_new(
+                    AggregateMode::Final,
                     final_group
                         .iter()
                         .enumerate()
@@ -204,6 +252,14 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
             }
             LogicalPlan::Sort { expr, input, .. } => {
                 let input = self.create_physical_plan(input, ctx_state)?;
+
+                // sort requires a single partition for input
+                let input = if input.output_partitioning().partition_count() == 1 {
+                    input
+                } else {
+                    Arc::new(MergeExec::new(input, ctx_state.config.concurrency))
+                };
+
                 let input_schema = input.as_ref().schema().clone();
 
                 let sort_expr = expr
@@ -235,13 +291,23 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
                 )?))
             }
             LogicalPlan::Limit { input, n, .. } => {
+                let limit = *n;
                 let input = self.create_physical_plan(input, ctx_state)?;
-                let input_schema = input.as_ref().schema().clone();
+
+                // GlobalLimitExec requires a single partition for input
+                let input = if input.output_partitioning().partition_count() == 1 {
+                    input
+                } else {
+                    // Apply a LocalLimitExec to each partition, then merge into a single partition
+                    Arc::new(MergeExec::new(
+                        Arc::new(LocalLimitExec::new(input, limit)),
+                        ctx_state.config.concurrency,
+                    ))
+                };
 
                 Ok(Arc::new(GlobalLimitExec::new(
-                    input_schema.clone(),
                     input,
-                    *n,
+                    limit,
                     ctx_state.config.concurrency,
                 )))
             }
@@ -274,9 +340,7 @@ impl PhysicalPlanner for DefaultPhysicalPlanner {
             )),
         }
     }
-}
 
-impl DefaultPhysicalPlanner {
     /// Create a physical expression from a logical expression
     pub fn create_physical_expr(
         &self,

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -31,7 +31,7 @@ use arrow::record_batch::{RecordBatch, RecordBatchReader};
 /// Execution plan for a projection
 #[derive(Debug)]
 pub struct ProjectionExec {
-    /// The projection expressions
+    /// The projection expressions stored as tuples of (expression, output column name)
     expr: Vec<(Arc<dyn PhysicalExpr>, String)>,
     /// The schema once the projection has been applied to the input
     schema: SchemaRef,

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -32,7 +32,7 @@ use arrow::record_batch::{RecordBatch, RecordBatchReader};
 #[derive(Debug)]
 pub struct ProjectionExec {
     /// The projection expressions
-    expr: Vec<Arc<dyn PhysicalExpr>>,
+    expr: Vec<(Arc<dyn PhysicalExpr>, String)>,
     /// The schema once the projection has been applied to the input
     schema: SchemaRef,
     /// The input plan
@@ -61,7 +61,7 @@ impl ProjectionExec {
         let schema = Arc::new(Schema::new(fields?));
 
         Ok(Self {
-            expr: expr.iter().map(|x| x.0.clone()).collect(),
+            expr,
             schema,
             input: input.clone(),
         })
@@ -74,9 +74,24 @@ impl ExecutionPlan for ProjectionExec {
         self.schema.clone()
     }
 
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         self.input.output_partitioning()
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        assert_eq!(1, children.len());
+        Ok(Arc::new(ProjectionExec::try_new(
+            self.expr.clone(),
+            children[0].clone(),
+        )?))
     }
 
     fn execute(
@@ -85,7 +100,7 @@ impl ExecutionPlan for ProjectionExec {
     ) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
         Ok(Arc::new(Mutex::new(ProjectionIterator {
             schema: self.schema.clone(),
-            expr: self.expr.clone(),
+            expr: self.expr.iter().map(|x| x.0.clone()).collect(),
             input: self.input.execute(partition)?,
         })))
     }

--- a/rust/datafusion/src/execution/physical_plan/projection.rs
+++ b/rust/datafusion/src/execution/physical_plan/projection.rs
@@ -87,11 +87,15 @@ impl ExecutionPlan for ProjectionExec {
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        assert_eq!(1, children.len());
-        Ok(Arc::new(ProjectionExec::try_new(
-            self.expr.clone(),
-            children[0].clone(),
-        )?))
+        match children.len() {
+            1 => Ok(Arc::new(ProjectionExec::try_new(
+                self.expr.clone(),
+                children[0].clone(),
+            )?)),
+            _ => Err(ExecutionError::General(
+                "ProjectionExec wrong number of children".to_string(),
+            )),
+        }
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/sort.rs
+++ b/rust/datafusion/src/execution/physical_plan/sort.rs
@@ -80,12 +80,16 @@ impl ExecutionPlan for SortExec {
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        assert_eq!(1, children.len());
-        Ok(Arc::new(SortExec::try_new(
-            self.expr.clone(),
-            children[0].clone(),
-            self.concurrency,
-        )?))
+        match children.len() {
+            1 => Ok(Arc::new(SortExec::try_new(
+                self.expr.clone(),
+                children[0].clone(),
+                self.concurrency,
+            )?)),
+            _ => Err(ExecutionError::General(
+                "SortExec wrong number of children".to_string(),
+            )),
+        }
     }
 
     fn execute(

--- a/rust/datafusion/src/execution/physical_plan/sort.rs
+++ b/rust/datafusion/src/execution/physical_plan/sort.rs
@@ -28,14 +28,16 @@ use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use crate::error::Result;
 use crate::execution::physical_plan::common::RecordBatchIterator;
 use crate::execution::physical_plan::expressions::PhysicalSortExpr;
-use crate::execution::physical_plan::merge::MergeExec;
-use crate::execution::physical_plan::{common, ExecutionPlan, Partitioning};
+use crate::execution::physical_plan::{
+    common, Distribution, ExecutionPlan, Partitioning,
+};
 
 /// Sort execution plan
 #[derive(Debug)]
 pub struct SortExec {
     /// Input schema
     input: Arc<dyn ExecutionPlan>,
+    /// Sort expressions
     expr: Vec<PhysicalSortExpr>,
     /// Number of threads to execute input partitions on before combining into a single partition
     concurrency: usize,
@@ -61,9 +63,29 @@ impl ExecutionPlan for SortExec {
         self.input.schema().clone()
     }
 
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.input.clone()]
+    }
+
     /// Get the output partitioning of this plan
     fn output_partitioning(&self) -> Partitioning {
         Partitioning::UnknownPartitioning(1)
+    }
+
+    fn required_child_distribution(&self) -> Distribution {
+        Distribution::SinglePartition
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        assert_eq!(1, children.len());
+        Ok(Arc::new(SortExec::try_new(
+            self.expr.clone(),
+            children[0].clone(),
+            self.concurrency,
+        )?))
     }
 
     fn execute(
@@ -73,10 +95,8 @@ impl ExecutionPlan for SortExec {
         assert_eq!(0, partition);
 
         // sort needs to operate on a single partition currently
-        let merge = MergeExec::new(self.schema(), self.input.clone(), self.concurrency);
-        // MergeExec must always produce a single partition
-        assert_eq!(1, merge.output_partitioning().partition_count());
-        let it = merge.execute(0)?;
+        assert_eq!(1, self.input.output_partitioning().partition_count());
+        let it = self.input.execute(0)?;
         let batches = common::collect(it)?;
 
         // combine all record batches into one for each column
@@ -138,6 +158,7 @@ mod tests {
     use super::*;
     use crate::execution::physical_plan::csv::{CsvExec, CsvReadOptions};
     use crate::execution::physical_plan::expressions::col;
+    use crate::execution::physical_plan::merge::MergeExec;
     use crate::test;
     use arrow::array::*;
     use arrow::datatypes::*;
@@ -168,7 +189,7 @@ mod tests {
                     options: SortOptions::default(),
                 },
             ],
-            Arc::new(csv),
+            Arc::new(MergeExec::new(Arc::new(csv), 2)),
             2,
         )?);
 


### PR DESCRIPTION
This PR adds the first physical optimization rule, to insert explicit MergeExec nodes into the physical plan when operators require a single partition of input (such as GlobalLimitExec, SortExec, HashAggregateExec in final mode).

This removes the merging logic from the operators, making them more easily re-usable in different contexts (such as in a distributed query engine, which could provide its own planner and/or optimization rules).