### PR TITLE
PARQUET-1904: [C++] Export file_offset in RowGroupMetaData

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -485,6 +485,8 @@ int64_t RowGroupMetaData::num_rows() const { return impl_->num_rows(); }
 
 int64_t RowGroupMetaData::total_byte_size() const { return impl_->total_byte_size(); }
 
+int64_t RowGroupMetaData::file_offset() const { return impl_->file_offset(); }
+
 const SchemaDescriptor* RowGroupMetaData::schema() const { return impl_->schema(); }
 
 std::unique_ptr<ColumnChunkMetaData> RowGroupMetaData::ColumnChunk(int i) const {

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -210,6 +210,8 @@ class PARQUET_EXPORT RowGroupMetaData {
 
   /// \brief Total byte size of all the uncompressed column data in this row group.
   int64_t total_byte_size() const;
+  /// \brief Offset into file at which this row group begins.
+  int64_t file_offset() const;
   // Return const-pointer to make it clear that this object is not to be copied
   const SchemaDescriptor* schema() const;
   // Indicate if all of the RowGroup's ColumnChunks can be decompressed.

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -213,7 +213,7 @@ class PARQUET_EXPORT RowGroupMetaData {
 
   /// \brief Byte offset from beginning of file to first page (data or
   /// dictionary) in this row group
-
+  ///
   /// The file_offset field that this method exposes is optional. This method
   /// will return 0 if that field is not set to a meaningful value.
   int64_t file_offset() const;

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -210,7 +210,11 @@ class PARQUET_EXPORT RowGroupMetaData {
 
   /// \brief Total byte size of all the uncompressed column data in this row group.
   int64_t total_byte_size() const;
-  /// \brief Offset into file at which this row group begins.
+
+  // The file_offset field that this method exposes is optional. This method
+  // will return 0 if that field is not set to a meaningful value.
+  /// \brief Byte offset from beginning of file to first page (data or
+  /// dictionary) in this row group
   int64_t file_offset() const;
   // Return const-pointer to make it clear that this object is not to be copied
   const SchemaDescriptor* schema() const;

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -211,10 +211,11 @@ class PARQUET_EXPORT RowGroupMetaData {
   /// \brief Total byte size of all the uncompressed column data in this row group.
   int64_t total_byte_size() const;
 
-  // The file_offset field that this method exposes is optional. This method
-  // will return 0 if that field is not set to a meaningful value.
   /// \brief Byte offset from beginning of file to first page (data or
   /// dictionary) in this row group
+
+  /// The file_offset field that this method exposes is optional. This method
+  /// will return 0 if that field is not set to a meaningful value.
   int64_t file_offset() const;
   // Return const-pointer to make it clear that this object is not to be copied
   const SchemaDescriptor* schema() const;


### PR DESCRIPTION
Export the file_offset field (which already exists in RowGroupMetaDataImpl) in RowGroupMetaData.