### PR TITLE
ARROW-9850:[Go] Defer should not be used inside a loop

### DIFF
--- a/go/arrow/ipc/cmd/arrow-cat/main.go
+++ b/go/arrow/ipc/cmd/arrow-cat/main.go
@@ -95,7 +95,6 @@ func processStream(w io.Writer, rin io.Reader) error {
 			}
 			return err
 		}
-		defer r.Release()
 
 		n := 0
 		for r.Next() {
@@ -106,6 +105,7 @@ func processStream(w io.Writer, rin io.Reader) error {
 				fmt.Fprintf(w, "  col[%d] %q: %v\n", i, rec.ColumnName(i), col)
 			}
 		}
+		r.Release()
 	}
 	return nil
 }
@@ -158,11 +158,11 @@ func processFile(w io.Writer, fname string) error {
 		if err != nil {
 			return err
 		}
-		defer rec.Release()
 
 		for i, col := range rec.Columns() {
 			fmt.Fprintf(w, "  col[%d] %q: %v\n", i, rec.ColumnName(i), col)
 		}
+		rec.Release()
 	}
 
 	return nil

--- a/go/arrow/ipc/cmd/arrow-ls/main.go
+++ b/go/arrow/ipc/cmd/arrow-ls/main.go
@@ -94,7 +94,6 @@ func processStream(w io.Writer, rin io.Reader) error {
 			}
 			return err
 		}
-		defer r.Release()
 
 		fmt.Fprintf(w, "%v\n", r.Schema())
 
@@ -103,6 +102,7 @@ func processStream(w io.Writer, rin io.Reader) error {
 			nrecs++
 		}
 		fmt.Fprintf(w, "records: %d\n", nrecs)
+		r.Release()
 	}
 	return nil
 }

--- a/go/arrow/ipc/file_reader.go
+++ b/go/arrow/ipc/file_reader.go
@@ -152,9 +152,9 @@ func (f *FileReader) readSchema() error {
 		if err != nil {
 			return err
 		}
-		defer msg.Release()
 
 		id, dict, err := readDictionary(msg.meta, f.fields, f.r)
+		msg.Release()
 		if err != nil {
 			return xerrors.Errorf("arrow/ipc: could not read dictionary %d from file: %w", i, err)
 		}


### PR DESCRIPTION
As is described in the second section in https://blog.learngoprogramming.com/gotchas-of-defer-in-go-1-8d070894cb01

defer inside the loop may cause unforeseen problems.