### PR TITLE
ARROW-9844: [CI] Add Go build job on s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,13 @@ jobs:
         UBUNTU: "20.04"
         cares_SOURCE: "BUNDLED"
         gRPC_SOURCE: "BUNDLED"
+    - name: "Go on s390x"
+      os: linux
+      arch: s390x
+      env:
+        ARCH: s390x
+        ARROW_CI_MODULES: "GO"
+        DOCKER_IMAGE_ID: debian-go
   allow_failures:
     - arch: s390x
 

--- a/go/arrow/internal/cpu/cpu_s390x.go
+++ b/go/arrow/internal/cpu/cpu_s390x.go
@@ -1,0 +1,7 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cpu
+
+const CacheLineSize = 256


### PR DESCRIPTION
As suggested by @kou in https://github.com/apache/arrow/pull/8011, this will add a Travis CI job for Go on s390x.