### PR TITLE
ARROW-9813: [C++] Disable semantic interposition

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -283,6 +283,13 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set(CXX_ONLY_FLAGS "${CXX_ONLY_FLAGS} -Wno-noexcept-type")
   endif()
 
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.2")
+    # Disabling semantic interposition allows faster calling conventions
+    # when calling global functions internally, and can also help inlining.
+    # See https://stackoverflow.com/questions/35745543/new-option-in-gcc-5-3-fno-semantic-interposition
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -fno-semantic-interposition")
+  endif()
+
   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "4.9")
     # Add colors when paired with ninja
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")


### PR DESCRIPTION
By default, gcc enables "semantic interposition" which allows overriding a symbol using LD_PRELOAD tricks (for example).  Disabling it allows faster calling conventions when calling global functions internally, and can also help inlining.

Basically, doing this shouldn't cause any harm, and could in some circumstances improve performance.  A quick look at Arrow shared library sizes suggests code size is only minimally reduced.