### PR TITLE
ARROW-9852: [C++] Validate dictionaries fully when combining deltas

### DIFF
--- a/cpp/src/arrow/ipc/dictionary.h
+++ b/cpp/src/arrow/ipc/dictionary.h
@@ -110,7 +110,7 @@ class ARROW_EXPORT DictionaryMemo {
 
   /// \brief Return current dictionary corresponding to a particular
   /// id. Returns KeyError if id not found
-  Result<std::shared_ptr<ArrayData>> GetDictionary(int64_t id) const;
+  Result<std::shared_ptr<ArrayData>> GetDictionary(int64_t id, MemoryPool* pool) const;
 
   /// \brief Return dictionary value type corresponding to a
   /// particular dictionary id.
@@ -129,8 +129,7 @@ class ARROW_EXPORT DictionaryMemo {
 
   /// \brief Append a dictionary delta to the memo with a particular id. Returns
   /// KeyError if that dictionary does not exists
-  Status AddDictionaryDelta(int64_t id, const std::shared_ptr<ArrayData>& dictionary,
-                            MemoryPool* pool);
+  Status AddDictionaryDelta(int64_t id, const std::shared_ptr<ArrayData>& dictionary);
 
   /// \brief Add a dictionary to the memo if it does not have one with the id,
   /// otherwise, replace the dictionary with the new one.
@@ -152,7 +151,8 @@ Result<DictionaryVector> CollectDictionaries(const RecordBatch& batch,
 // Columns may be sparse, i.e. some entries may be left null
 // (e.g. if an inclusion mask was used).
 ARROW_EXPORT
-Status ResolveDictionaries(const ArrayDataVector& columns, const DictionaryMemo& memo);
+Status ResolveDictionaries(const ArrayDataVector& columns, const DictionaryMemo& memo,
+                           MemoryPool* pool);
 
 namespace internal {
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -469,7 +469,7 @@ Result<std::shared_ptr<RecordBatch>> LoadRecordBatchSubset(
 
   // Dictionary resolution needs to happen on the unfiltered columns,
   // because fields are mapped structurally (by path in the original schema).
-  RETURN_NOT_OK(ResolveDictionaries(columns, *dictionary_memo));
+  RETURN_NOT_OK(ResolveDictionaries(columns, *dictionary_memo, options.memory_pool));
 
   if (inclusion_mask) {
     filtered_schema = ::arrow::schema(std::move(filtered_fields), schema->metadata());
@@ -711,7 +711,7 @@ Status ReadDictionary(const Buffer& metadata, DictionaryMemo* dictionary_memo,
   }
 
   if (dictionary_batch->isDelta()) {
-    return dictionary_memo->AddDictionaryDelta(id, dict_data, options.memory_pool);
+    return dictionary_memo->AddDictionaryDelta(id, dict_data);
   }
   return dictionary_memo->AddOrReplaceDictionary(id, dict_data);
 }

--- a/cpp/src/arrow/testing/json_internal.cc
+++ b/cpp/src/arrow/testing/json_internal.cc
@@ -1625,7 +1625,7 @@ Status ReadRecordBatch(const rj::Value& json_obj, const std::shared_ptr<Schema>&
                           ReadArrayData(pool, json_columns[i], schema->field(i)));
   }
 
-  RETURN_NOT_OK(ResolveDictionaries(columns, *dictionary_memo));
+  RETURN_NOT_OK(ResolveDictionaries(columns, *dictionary_memo, pool));
 
   *batch = RecordBatch::Make(schema, num_rows, columns);
   return Status::OK();


### PR DESCRIPTION
We need O(N) validation of dictionaries when combining deltas, because array concatenation may involve arbitrary reads (for example, nested dictionaries are compared for equality when concatenating).
    
For the common case where no deltas are encountered, full validation is not required.

Also, concatenation and validation are now performed at dictionary resolution time, rather than when reading the dictionary batches.
    
Found by OSS-Fuzz.
