### PR TITLE
ARROW-9862: [Java] Enable UnsafeDirectLittleEndian on a big-endian platform

### DIFF
--- a/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -33,7 +33,6 @@ import io.netty.util.internal.PlatformDependent;
 public class UnsafeDirectLittleEndian extends WrappedByteBuf {
 
   public static final boolean ASSERT_ENABLED;
-  private static final boolean NATIVE_ORDER = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
   private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
 
   static {
@@ -60,9 +59,6 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
 
   private UnsafeDirectLittleEndian(AbstractByteBuf buf, boolean fake) {
     super(buf);
-    if (!NATIVE_ORDER || buf.order() != ByteOrder.BIG_ENDIAN) {
-      throw new IllegalStateException("Arrow only runs on LittleEndian systems.");
-    }
 
     this.wrapped = buf;
     this.memoryAddress = buf.memoryAddress();

--- a/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -167,66 +167,6 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
   }
 
   @Override
-  public short readShort() {
-    if (wrapped.readerIndex > wrapped.writerIndex - 2) {
-      throw new IndexOutOfBoundsException();
-    }
-    short value = getShort(wrapped.readerIndex);
-    wrapped.readerIndex += 2;
-    return value;
-  }
-
-  @Override
-  public int readInt() {
-    if (wrapped.readerIndex > wrapped.writerIndex - 4) {
-      throw new IndexOutOfBoundsException();
-    }
-    int value = getInt(wrapped.readerIndex);
-    wrapped.readerIndex += 4;
-    return value;
-  }
-
-  @Override
-  public long readLong() {
-    if (wrapped.readerIndex > wrapped.writerIndex - 8) {
-      throw new IndexOutOfBoundsException();
-    }
-    long value = getLong(wrapped.readerIndex);
-    wrapped.readerIndex += 8;
-    return value;
-  }
-
-  @Override
-  public char readChar() {
-    if (wrapped.readerIndex > wrapped.writerIndex - 2) {
-      throw new IndexOutOfBoundsException();
-    }
-    char value = getChar(wrapped.readerIndex);
-    wrapped.readerIndex += 2;
-    return value;
-  }
-
-  @Override
-  public float readFloat() {
-    if (wrapped.readerIndex > wrapped.writerIndex - 4) {
-      throw new IndexOutOfBoundsException();
-    }
-    float value = getFloat(wrapped.readerIndex);
-    wrapped.readerIndex += 4;
-    return value;
-  }
-
-  @Override
-  public double readDouble() {
-    if (wrapped.readerIndex > wrapped.writerIndex - 8) {
-      throw new IndexOutOfBoundsException();
-    }
-    double value = getDouble(wrapped.readerIndex);
-    wrapped.readerIndex += 8;
-    return value;
-  }
-
-  @Override
   public ByteBuf writeShort(int value) {
     wrapped.ensureWritable(2);
     setShort_(wrapped.writerIndex, value);

--- a/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -59,9 +59,6 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
 
   private UnsafeDirectLittleEndian(AbstractByteBuf buf, boolean fake) {
     super(buf);
-    if (buf.order() != ByteOrder.nativeOrder()) {
-      throw new IllegalStateException("ByteOrder of ByteBuf is different from the system endian.");
-    }
 
     this.wrapped = buf;
     this.memoryAddress = buf.memoryAddress();

--- a/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -59,6 +59,9 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
 
   private UnsafeDirectLittleEndian(AbstractByteBuf buf, boolean fake) {
     super(buf);
+    if (buf.order() != ByteOrder.nativeOrder()) {
+      throw new IllegalStateException("ByteOrder of ByteBuf is different from the system endian.");
+    }
 
     this.wrapped = buf;
     this.memoryAddress = buf.memoryAddress();

--- a/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty/src/main/java/io/netty/buffer/UnsafeDirectLittleEndian.java
@@ -167,6 +167,66 @@ public class UnsafeDirectLittleEndian extends WrappedByteBuf {
   }
 
   @Override
+  public short readShort() {
+    if (wrapped.readerIndex > wrapped.writerIndex - 2) {
+      throw new IndexOutOfBoundsException();
+    }
+    short value = getShort(wrapped.readerIndex);
+    wrapped.readerIndex += 2;
+    return value;
+  }
+
+  @Override
+  public int readInt() {
+    if (wrapped.readerIndex > wrapped.writerIndex - 4) {
+      throw new IndexOutOfBoundsException();
+    }
+    int value = getInt(wrapped.readerIndex);
+    wrapped.readerIndex += 4;
+    return value;
+  }
+
+  @Override
+  public long readLong() {
+    if (wrapped.readerIndex > wrapped.writerIndex - 8) {
+      throw new IndexOutOfBoundsException();
+    }
+    long value = getLong(wrapped.readerIndex);
+    wrapped.readerIndex += 8;
+    return value;
+  }
+
+  @Override
+  public char readChar() {
+    if (wrapped.readerIndex > wrapped.writerIndex - 2) {
+      throw new IndexOutOfBoundsException();
+    }
+    char value = getChar(wrapped.readerIndex);
+    wrapped.readerIndex += 2;
+    return value;
+  }
+
+  @Override
+  public float readFloat() {
+    if (wrapped.readerIndex > wrapped.writerIndex - 4) {
+      throw new IndexOutOfBoundsException();
+    }
+    float value = getFloat(wrapped.readerIndex);
+    wrapped.readerIndex += 4;
+    return value;
+  }
+
+  @Override
+  public double readDouble() {
+    if (wrapped.readerIndex > wrapped.writerIndex - 8) {
+      throw new IndexOutOfBoundsException();
+    }
+    double value = getDouble(wrapped.readerIndex);
+    wrapped.readerIndex += 8;
+    return value;
+  }
+
+  @Override
   public ByteBuf writeShort(int value) {
     wrapped.ensureWritable(2);
     setShort_(wrapped.writerIndex, value);

--- a/java/memory/memory-netty/src/test/java/io/netty/buffer/TestUnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty/src/test/java/io/netty/buffer/TestUnsafeDirectLittleEndian.java
@@ -74,25 +74,4 @@ public class TestUnsafeDirectLittleEndian {
       e.printStackTrace();
     }
   }
-
-  @Test
-  public void testPrimitiveWriteRead() {
-    ByteBuf byteBuf = Unpooled.directBuffer(32);
-    UnsafeDirectLittleEndian unsafeDirect = new UnsafeDirectLittleEndian(new LargeBuffer(byteBuf));
-
-    unsafeDirect.clear();
-    unsafeDirect.writeShort(-2); // 0xFFFE
-    unsafeDirect.writeChar(65533); // 0xFFFD
-    unsafeDirect.writeInt(-66052); // 0xFFFE FDFC
-    unsafeDirect.writeLong(-4295098372L); // 0xFFFF FFFE FFFD FFFC
-    unsafeDirect.writeFloat(1.23F);
-    unsafeDirect.writeDouble(1.234567D);
-
-    assertEquals(-2, unsafeDirect.readShort());
-    assertEquals((char) 65533, unsafeDirect.readChar());
-    assertEquals(-66052, unsafeDirect.readInt());
-    assertEquals(-4295098372L, unsafeDirect.readLong());
-    assertEquals(1.23F, unsafeDirect.readFloat(), 0.0);
-    assertEquals(1.234567D, unsafeDirect.readDouble(), 0.0);
-  }
 }

--- a/java/memory/memory-netty/src/test/java/io/netty/buffer/TestUnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty/src/test/java/io/netty/buffer/TestUnsafeDirectLittleEndian.java
@@ -64,12 +64,12 @@ public class TestUnsafeDirectLittleEndian {
     assertEquals(1.234567D, unsafeDirect.getDouble(40), 0.0);
     assertEquals(-1.234567D, unsafeDirect.getDouble(48), 0.0);
 
-    byte[] inBytes = "12345".getBytes(StandardCharsets.UTF_8);
+    byte[] inBytes = "1234567".getBytes(StandardCharsets.UTF_8);
     try (ByteArrayInputStream bais = new ByteArrayInputStream(inBytes);
          ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-      assertEquals(3, unsafeDirect.setBytes(56, bais, 3));
-      unsafeDirect.getBytes(56, baos, 3);
-      assertEquals("123", baos.toString(StandardCharsets.UTF_8));
+      assertEquals(5, unsafeDirect.setBytes(56, bais, 5));
+      unsafeDirect.getBytes(56, baos, 5);
+      assertEquals("12345", new String(baos.toByteArray(), StandardCharsets.UTF_8));
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/java/memory/memory-netty/src/test/java/io/netty/buffer/TestUnsafeDirectLittleEndian.java
+++ b/java/memory/memory-netty/src/test/java/io/netty/buffer/TestUnsafeDirectLittleEndian.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.netty.buffer;
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Test;
+
+public class TestUnsafeDirectLittleEndian {
+  private static final boolean LITTLE_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN;
+
+  @Test
+  public void testPrimitiveGetSet() {
+    ByteBuf byteBuf = Unpooled.directBuffer(64);
+    UnsafeDirectLittleEndian unsafeDirect = new UnsafeDirectLittleEndian(new LargeBuffer(byteBuf));
+
+    unsafeDirect.setByte(0, Byte.MAX_VALUE);
+    unsafeDirect.setByte(1, -1); // 0xFF
+    unsafeDirect.setShort(2, Short.MAX_VALUE);
+    unsafeDirect.setShort(4, -2); // 0xFFFE
+    unsafeDirect.setInt(8, Integer.MAX_VALUE);
+    unsafeDirect.setInt(12, -66052); // 0xFFFE FDFC
+    unsafeDirect.setLong(16, Long.MAX_VALUE);
+    unsafeDirect.setLong(24, -4295098372L); // 0xFFFF FFFE FFFD FFFC
+    unsafeDirect.setFloat(32, 1.23F);
+    unsafeDirect.setFloat(36, -1.23F);
+    unsafeDirect.setDouble(40, 1.234567D);
+    unsafeDirect.setDouble(48, -1.234567D);
+
+    assertEquals(Byte.MAX_VALUE, unsafeDirect.getByte(0));
+    assertEquals(-1, unsafeDirect.getByte(1));
+    assertEquals(Short.MAX_VALUE, unsafeDirect.getShort(2));
+    assertEquals(-2, unsafeDirect.getShort(4));
+    assertEquals((char) 65534, unsafeDirect.getChar(4));
+    assertEquals(Integer.MAX_VALUE, unsafeDirect.getInt(8));
+    assertEquals(-66052, unsafeDirect.getInt(12));
+    assertEquals(4294901244L, unsafeDirect.getUnsignedInt(12));
+    assertEquals(Long.MAX_VALUE, unsafeDirect.getLong(16));
+    assertEquals(-4295098372L, unsafeDirect.getLong(24));
+    assertEquals(1.23F, unsafeDirect.getFloat(32), 0.0);
+    assertEquals(-1.23F, unsafeDirect.getFloat(36), 0.0);
+    assertEquals(1.234567D, unsafeDirect.getDouble(40), 0.0);
+    assertEquals(-1.234567D, unsafeDirect.getDouble(48), 0.0);
+
+    byte[] inBytes = "12345".getBytes(StandardCharsets.UTF_8);
+    try (ByteArrayInputStream bais = new ByteArrayInputStream(inBytes);
+         ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+      assertEquals(3, unsafeDirect.setBytes(56, bais, 3));
+      unsafeDirect.getBytes(56, baos, 3);
+      assertEquals("123", baos.toString(StandardCharsets.UTF_8));
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Test
+  public void testPrimitiveWriteRead() {
+    ByteBuf byteBuf = Unpooled.directBuffer(32);
+    UnsafeDirectLittleEndian unsafeDirect = new UnsafeDirectLittleEndian(new LargeBuffer(byteBuf));
+
+    unsafeDirect.clear();
+    unsafeDirect.writeShort(-2); // 0xFFFE
+    unsafeDirect.writeChar(65533); // 0xFFFD
+    unsafeDirect.writeInt(-66052); // 0xFFFE FDFC
+    unsafeDirect.writeLong(-4295098372L); // 0xFFFF FFFE FFFD FFFC
+    unsafeDirect.writeFloat(1.23F);
+    unsafeDirect.writeDouble(1.234567D);
+
+    assertEquals(-2, unsafeDirect.readShort());
+    assertEquals((char) 65533, unsafeDirect.readChar());
+    assertEquals(-66052, unsafeDirect.readInt());
+    assertEquals(-4295098372L, unsafeDirect.readLong());
+    assertEquals(1.23F, unsafeDirect.readFloat(), 0.0);
+    assertEquals(1.234567D, unsafeDirect.readDouble(), 0.0);
+  }
+}


### PR DESCRIPTION
This PR enables `UnsafeDirectLittleEndian` class by removing to throw an exception on a big-endian platform. This is because this class originally supports primitive data types (up to 64-bit) in a native-endianness.