### PR TITLE
[MINOR] [java][jdbc] Improve error messages for unsupported types.

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/ArrowVectorIterator.java
@@ -64,8 +64,17 @@ public class ArrowVectorIterator implements Iterator<VectorSchemaRoot>, AutoClos
   private void initialize() throws SQLException {
     // create consumers
     for (int i = 1; i <= consumers.length; i++) {
-      consumers[i - 1] = JdbcToArrowUtils.getConsumer(resultSet, i, resultSet.getMetaData().getColumnType(i),
-          null, config);
+      try {
+        consumers[i - 1] = JdbcToArrowUtils.getConsumer(resultSet, i, rsmd.getColumnType(i),
+                null, config);
+      } catch (UnsupportedOperationException e) {
+
+        String msg = "Error creating consumer for column, " +
+                rsmd.getColumnName(i) +
+                ", with data type, " +
+                rsmd.getColumnTypeName(i);
+        throw new UnsupportedOperationException(msg, e);
+      }
     }
 
     load(createVectorSchemaRoot());

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ArrayConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/ArrayConsumer.java
@@ -22,6 +22,7 @@ import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.complex.ListVector;
 
@@ -60,8 +61,10 @@ public abstract class ArrayConsumer extends BaseConsumer<ListVector> {
 
   @Override
   public void close() throws Exception {
-    this.vector.close();
-    this.delegate.close();
+    if (this.vector != null) {
+      this.vector.close();
+    }
+    AutoCloseables.close(this.delegate);
   }
 
   void ensureInnerVectorCapacity(int targetCapacity) {

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BaseConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BaseConsumer.java
@@ -43,7 +43,9 @@ public abstract class BaseConsumer<V extends ValueVector> implements JdbcConsume
 
   @Override
   public void close() throws Exception {
-    this.vector.close();
+    if (this.vector != null) {
+      this.vector.close();
+    }
   }
 
   @Override

--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BlobConsumer.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/consumer/BlobConsumer.java
@@ -22,6 +22,7 @@ import java.sql.Blob;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import org.apache.arrow.util.AutoCloseables;
 import org.apache.arrow.vector.VarBinaryVector;
 
 /**
@@ -62,7 +63,7 @@ public class BlobConsumer extends BaseConsumer<VarBinaryVector> {
 
   @Override
   public void close() throws Exception {
-    delegate.close();
+    AutoCloseables.close(delegate);
   }
 
   @Override


### PR DESCRIPTION
When the JDBC adapter creates consumers for unsupported data types we can provide
some slightly more helpful error messaging.
Additionally there were some NPE issues when the close was happening in this error
state, masking the actual exception.