### PR TITLE
ARROW-9871: [C++] Add uppercase to ARROW_USER_SIMD_LEVEL

### DIFF
--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -428,15 +428,15 @@ void CpuInfo::ParseUserSimdLevel() {
 
   int level = USER_SIMD_MAX;
   // Parse the level
-  if (0 == strcmp("avx512", user)) {
+  if (0 == strcmp("AVX512", user) || 0 == strcmp("avx512", user)) {
     level = USER_SIMD_AVX512;
-  } else if (0 == strcmp("avx2", user)) {
+  } else if (0 == strcmp("AVX2", user) || 0 == strcmp("avx2", user)) {
     level = USER_SIMD_AVX2;
-  } else if (0 == strcmp("avx", user)) {
+  } else if (0 == strcmp("AVX", user) || 0 == strcmp("avx", user)) {
     level = USER_SIMD_AVX;
-  } else if (0 == strcmp("sse4_2", user)) {
+  } else if (0 == strcmp("SSE4_2", user) || 0 == strcmp("sse4_2", user)) {
     level = USER_SIMD_SSE4_2;
-  } else if (0 == strcmp("none", user)) {
+  } else if (0 == strcmp("NONE", user) || 0 == strcmp("none", user)) {
     level = USER_SIMD_NONE;
   }
 

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -39,6 +39,7 @@
 #endif
 
 #include <algorithm>
+#include <cctype>
 #include <cerrno>
 #include <cstdint>
 #include <fstream>

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -46,6 +46,8 @@
 #include <mutex>
 #include <string>
 
+#include "arrow/result.h"
+#include "arrow/util/io_util.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/string.h"
 
@@ -420,24 +422,29 @@ void CpuInfo::SetDefaultCacheSize() {
 }
 
 void CpuInfo::ParseUserSimdLevel() {
-  const char* user = std::getenv("ARROW_USER_SIMD_LEVEL");
-  if (!user) {
+  auto maybe_env_var = GetEnvVar("ARROW_USER_SIMD_LEVEL");
+  if (!maybe_env_var.ok()) {
     // No user settings
     return;
   }
+  std::string s = *std::move(maybe_env_var);
+  std::transform(s.begin(), s.end(), s.begin(),
+                 [](unsigned char c) { return std::toupper(c); });
 
   int level = USER_SIMD_MAX;
   // Parse the level
-  if (0 == strcmp("AVX512", user) || 0 == strcmp("avx512", user)) {
+  if (s == "AVX512") {
     level = USER_SIMD_AVX512;
-  } else if (0 == strcmp("AVX2", user) || 0 == strcmp("avx2", user)) {
+  } else if (s == "AVX2") {
     level = USER_SIMD_AVX2;
-  } else if (0 == strcmp("AVX", user) || 0 == strcmp("avx", user)) {
+  } else if (s == "AVX") {
     level = USER_SIMD_AVX;
-  } else if (0 == strcmp("SSE4_2", user) || 0 == strcmp("sse4_2", user)) {
+  } else if (s == "SSE4_2") {
     level = USER_SIMD_SSE4_2;
-  } else if (0 == strcmp("NONE", user) || 0 == strcmp("none", user)) {
+  } else if (s == "NONE") {
     level = USER_SIMD_NONE;
+  } else if (!s.empty()) {
+    ARROW_LOG(WARNING) << "Invalid value for ARROW_USER_SIMD_LEVEL: " << s;
   }
 
   // Disable feature as the level

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -31,6 +31,7 @@
 #endif
 
 #include "arrow/io/interfaces.h"
+#include "arrow/status.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/windows_fixup.h"


### PR DESCRIPTION
Follow the convention of ARROW_SIMD_LEVEL.

Signed-off-by: Frank Du <frank.du@intel.com>