### PR TITLE
ARROW-9867: [C++][Dataset] Add FileSystemDataset::filesystem property

### DIFF
--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -253,7 +253,7 @@ Result<std::shared_ptr<Dataset>> FileSystemDatasetFactory::Finish(FinishOptions 
     fragments.push_back(fragment);
   }
 
-  return FileSystemDataset::Make(schema, root_partition_, format_, fragments);
+  return FileSystemDataset::Make(schema, root_partition_, format_, fs_, fragments);
 }
 
 }  // namespace dataset

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -93,13 +93,6 @@ Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Make(
     std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
     std::shared_ptr<FileFormat> format, std::shared_ptr<fs::FileSystem> filesystem,
     std::vector<std::shared_ptr<FileFragment>> fragments) {
-  for (const auto& fragment : fragments) {
-    if ((filesystem == nullptr && fragment->source().filesystem() != nullptr) ||
-        (filesystem != nullptr &&
-         !fragment->source().filesystem()->Equals(*filesystem))) {
-      return Status::Invalid("FileSystemDataset's filesystem differed from a fragment's");
-    }
-  }
   return std::shared_ptr<FileSystemDataset>(new FileSystemDataset(
       std::move(schema), std::move(root_partition), std::move(format),
       std::move(filesystem), std::move(fragments)));

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -82,25 +82,34 @@ Result<ScanTaskIterator> FileFragment::Scan(std::shared_ptr<ScanOptions> options
 FileSystemDataset::FileSystemDataset(std::shared_ptr<Schema> schema,
                                      std::shared_ptr<Expression> root_partition,
                                      std::shared_ptr<FileFormat> format,
+                                     std::shared_ptr<fs::FileSystem> filesystem,
                                      std::vector<std::shared_ptr<FileFragment>> fragments)
     : Dataset(std::move(schema), std::move(root_partition)),
       format_(std::move(format)),
+      filesystem_(std::move(filesystem)),
       fragments_(std::move(fragments)) {}
 
 Result<std::shared_ptr<FileSystemDataset>> FileSystemDataset::Make(
     std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-    std::shared_ptr<FileFormat> format,
+    std::shared_ptr<FileFormat> format, std::shared_ptr<fs::FileSystem> filesystem,
     std::vector<std::shared_ptr<FileFragment>> fragments) {
-  return std::shared_ptr<FileSystemDataset>(
-      new FileSystemDataset(std::move(schema), std::move(root_partition),
-                            std::move(format), std::move(fragments)));
+  for (const auto& fragment : fragments) {
+    if ((filesystem == nullptr && fragment->source().filesystem() != nullptr) ||
+        (filesystem != nullptr &&
+         !fragment->source().filesystem()->Equals(*filesystem))) {
+      return Status::Invalid("FileSystemDataset's filesystem differed from a fragment's");
+    }
+  }
+  return std::shared_ptr<FileSystemDataset>(new FileSystemDataset(
+      std::move(schema), std::move(root_partition), std::move(format),
+      std::move(filesystem), std::move(fragments)));
 }
 
 Result<std::shared_ptr<Dataset>> FileSystemDataset::ReplaceSchema(
     std::shared_ptr<Schema> schema) const {
   RETURN_NOT_OK(CheckProjectable(*schema_, *schema));
   return std::shared_ptr<Dataset>(new FileSystemDataset(
-      std::move(schema), partition_expression_, format_, fragments_));
+      std::move(schema), partition_expression_, format_, filesystem_, fragments_));
 }
 
 std::vector<std::string> FileSystemDataset::files() const {

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -195,15 +195,15 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
   /// \param[in] schema the schema of the dataset
   /// \param[in] root_partition the partition expression of the dataset
   /// \param[in] format the format of each FileFragment.
-  /// \param[in] fragments list of fragments to create the dataset from
+  /// \param[in] fragments list of fragments to create the dataset from.
   ///
-  /// Note that all fragment must be of `FileFragment` type. The type are
-  /// erased to simplify callers.
+  /// Note that fragments wrapping files resident in a differing filesystems is not
+  /// permitted; to work with multiple filesystems use a UnionDataset.
   ///
   /// \return A constructed dataset.
   static Result<std::shared_ptr<FileSystemDataset>> Make(
       std::shared_ptr<Schema> schema, std::shared_ptr<Expression> root_partition,
-      std::shared_ptr<FileFormat> format,
+      std::shared_ptr<FileFormat> format, std::shared_ptr<fs::FileSystem> filesystem,
       std::vector<std::shared_ptr<FileFragment>> fragments);
 
   /// \brief Write a dataset.
@@ -234,6 +234,9 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
   /// \brief Return the format.
   const std::shared_ptr<FileFormat>& format() const { return format_; }
 
+  /// \brief Return the filesystem. May be nullptr if the fragments wrap buffers.
+  const std::shared_ptr<fs::FileSystem>& filesystem() const { return filesystem_; }
+
   std::string ToString() const;
 
  protected:
@@ -242,9 +245,11 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
   FileSystemDataset(std::shared_ptr<Schema> schema,
                     std::shared_ptr<Expression> root_partition,
                     std::shared_ptr<FileFormat> format,
+                    std::shared_ptr<fs::FileSystem> filesystem,
                     std::vector<std::shared_ptr<FileFragment>> fragments);
 
   std::shared_ptr<FileFormat> format_;
+  std::shared_ptr<fs::FileSystem> filesystem_;
   std::vector<std::shared_ptr<FileFragment>> fragments_;
 };
 

--- a/cpp/src/arrow/dataset/file_base.h
+++ b/cpp/src/arrow/dataset/file_base.h
@@ -195,9 +195,11 @@ class ARROW_DS_EXPORT FileSystemDataset : public Dataset {
   /// \param[in] schema the schema of the dataset
   /// \param[in] root_partition the partition expression of the dataset
   /// \param[in] format the format of each FileFragment.
+  /// \param[in] filesystem the filesystem of each FileFragment, or nullptr if the
+  ///            fragments wrap buffers.
   /// \param[in] fragments list of fragments to create the dataset from.
   ///
-  /// Note that fragments wrapping files resident in a differing filesystems is not
+  /// Note that fragments wrapping files resident in differing filesystems are not
   /// permitted; to work with multiple filesystems use a UnionDataset.
   ///
   /// \return A constructed dataset.

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -760,7 +760,7 @@ Result<std::shared_ptr<Dataset>> ParquetDatasetFactory::Finish(FinishOptions opt
   auto properties = MakeArrowReaderProperties(*format_, *metadata_);
   ARROW_ASSIGN_OR_RAISE(auto fragments,
                         CollectParquetFragments(*metadata_, properties, *partitioning));
-  return FileSystemDataset::Make(std::move(schema), scalar(true), format_,
+  return FileSystemDataset::Make(std::move(schema), scalar(true), format_, filesystem_,
                                  std::move(fragments));
 }
 

--- a/cpp/src/arrow/dataset/file_test.cc
+++ b/cpp/src/arrow/dataset/file_test.cc
@@ -98,7 +98,7 @@ TEST_F(TestFileSystemDataset, ReplaceSchema) {
   auto schm = schema({field("i32", int32()), field("f64", float64())});
   auto format = std::make_shared<DummyFileFormat>(schm);
   ASSERT_OK_AND_ASSIGN(auto dataset,
-                       FileSystemDataset::Make(schm, scalar(true), format, {}));
+                       FileSystemDataset::Make(schm, scalar(true), format, nullptr, {}));
 
   // drop field
   ASSERT_OK(dataset->ReplaceSchema(schema({field("i32", int32())})).status());

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -317,7 +317,7 @@ struct MakeFileSystemDatasetMixin {
       fragments.push_back(std::move(fragment));
     }
 
-    ASSERT_OK_AND_ASSIGN(dataset_, FileSystemDataset::Make(s, root_partition, format,
+    ASSERT_OK_AND_ASSIGN(dataset_, FileSystemDataset::Make(s, root_partition, format, fs_,
                                                            std::move(fragments)));
   }
 

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -245,10 +245,12 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             shared_ptr[CSchema] schema,
             shared_ptr[CExpression] source_partition,
             shared_ptr[CFileFormat] format,
+            shared_ptr[CFileSystem] filesystem,
             vector[shared_ptr[CFileFragment]] fragments)
         c_string type()
         vector[c_string] files()
         const shared_ptr[CFileFormat]& format() const
+        const shared_ptr[CFileSystem]& filesystem() const
 
     cdef cppclass CParquetFileFormatReaderOptions \
             "arrow::dataset::ParquetFileFormat::ReaderOptions":

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1408,9 +1408,9 @@ class _ParquetDatasetV2:
             if not _is_path_like(path_or_paths):
                 fragment = parquet_format.make_fragment(path_or_paths)
                 self._dataset = ds.FileSystemDataset(
-                    fragment.filesystem,
                     [fragment], schema=fragment.physical_schema,
-                    format=parquet_format
+                    format=parquet_format,
+                    filesystem=fragment.filesystem
                 )
                 return
 

--- a/python/pyarrow/parquet.py
+++ b/python/pyarrow/parquet.py
@@ -1408,6 +1408,7 @@ class _ParquetDatasetV2:
             if not _is_path_like(path_or_paths):
                 fragment = parquet_format.make_fragment(path_or_paths)
                 self._dataset = ds.FileSystemDataset(
+                    fragment.filesystem,
                     [fragment], schema=fragment.physical_schema,
                     format=parquet_format
                 )

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -235,8 +235,8 @@ def test_filesystem_dataset(mockfs):
     root_partition = ds.field('level') == ds.scalar(1337)
 
     dataset_from_fragments = ds.FileSystemDataset(
-        mockfs, fragments, schema=schema, format=file_format,
-        root_partition=root_partition,
+        fragments, schema=schema, format=file_format,
+        filesystem=mockfs, root_partition=root_partition,
     )
     dataset_from_paths = ds.FileSystemDataset.from_paths(
         paths, schema=schema, format=file_format, filesystem=mockfs,
@@ -268,7 +268,7 @@ def test_filesystem_dataset(mockfs):
 
     # the root_partition keyword has a default
     dataset = ds.FileSystemDataset(
-        mockfs, fragments, schema=schema, format=file_format
+        fragments, schema=schema, format=file_format, filesystem=mockfs
     )
     assert dataset.partition_expression.equals(ds.scalar(True))
 
@@ -282,10 +282,10 @@ def test_filesystem_dataset(mockfs):
 
     # validation of required arguments
     with pytest.raises(TypeError, match="incorrect type"):
-        ds.FileSystemDataset(mockfs, fragments, file_format, schema)
+        ds.FileSystemDataset(fragments, file_format, schema)
     # validation of root_partition
     with pytest.raises(TypeError, match="incorrect type"):
-        ds.FileSystemDataset(mockfs, fragments, schema=schema,
+        ds.FileSystemDataset(fragments, schema=schema,
                              format=file_format, root_partition=1)
     # missing required argument in from_paths
     with pytest.raises(TypeError, match="incorrect type"):

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -235,7 +235,7 @@ def test_filesystem_dataset(mockfs):
     root_partition = ds.field('level') == ds.scalar(1337)
 
     dataset_from_fragments = ds.FileSystemDataset(
-        fragments, schema=schema, format=file_format,
+        mockfs, fragments, schema=schema, format=file_format,
         root_partition=root_partition,
     )
     dataset_from_paths = ds.FileSystemDataset.from_paths(
@@ -268,7 +268,7 @@ def test_filesystem_dataset(mockfs):
 
     # the root_partition keyword has a default
     dataset = ds.FileSystemDataset(
-        fragments, schema=schema, format=file_format
+        mockfs, fragments, schema=schema, format=file_format
     )
     assert dataset.partition_expression.equals(ds.scalar(True))
 
@@ -282,11 +282,11 @@ def test_filesystem_dataset(mockfs):
 
     # validation of required arguments
     with pytest.raises(TypeError, match="incorrect type"):
-        ds.FileSystemDataset(fragments, file_format, schema)
+        ds.FileSystemDataset(mockfs, fragments, file_format, schema)
     # validation of root_partition
     with pytest.raises(TypeError, match="incorrect type"):
-        ds.FileSystemDataset(fragments, schema=schema, format=file_format,
-                             root_partition=1)
+        ds.FileSystemDataset(mockfs, fragments, schema=schema,
+                             format=file_format, root_partition=1)
     # missing required argument in from_paths
     with pytest.raises(TypeError, match="incorrect type"):
         ds.FileSystemDataset.from_paths(fragments, format=file_format)

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -356,6 +356,10 @@ dataset___FileSystemDataset__format <- function(dataset){
     .Call(`_arrow_dataset___FileSystemDataset__format` , dataset)
 }
 
+dataset___FileSystemDataset__filesystem <- function(dataset){
+    .Call(`_arrow_dataset___FileSystemDataset__filesystem` , dataset)
+}
+
 dataset___FileSystemDataset__files <- function(dataset){
     .Call(`_arrow_dataset___FileSystemDataset__files` , dataset)
 }

--- a/r/R/dataset.R
+++ b/r/R/dataset.R
@@ -231,6 +231,11 @@ FileSystemDataset <- R6Class("FileSystemDataset", inherit = Dataset,
     format = function() {
       shared_ptr(FileFormat, dataset___FileSystemDataset__format(self))$..dispatch()
     },
+    # @description
+    # Return the filesystem of files in this `Dataset`
+    filesystem = function() {
+      shared_ptr(FileSystem, dataset___FileSystemDataset__filesystem(self))$..dispatch()
+    },
     num_rows = function() {
       if (inherits(self$format, "ParquetFileFormat")) {
         # It's generally fast enough to skim the files directly

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1397,6 +1397,21 @@ extern "C" SEXP _arrow_dataset___FileSystemDataset__format(SEXP dataset_sexp){
 
 // dataset.cpp
 #if defined(ARROW_R_WITH_ARROW)
+std::shared_ptr<fs::FileSystem> dataset___FileSystemDataset__filesystem(const std::shared_ptr<ds::FileSystemDataset>& dataset);
+extern "C" SEXP _arrow_dataset___FileSystemDataset__filesystem(SEXP dataset_sexp){
+BEGIN_CPP11
+	arrow::r::Input<const std::shared_ptr<ds::FileSystemDataset>&>::type dataset(dataset_sexp);
+	return cpp11::as_sexp(dataset___FileSystemDataset__filesystem(dataset));
+END_CPP11
+}
+#else
+extern "C" SEXP _arrow_dataset___FileSystemDataset__filesystem(SEXP dataset_sexp){
+	Rf_error("Cannot call dataset___FileSystemDataset__filesystem(). Please use arrow::install_arrow() to install required runtime libraries. ");
+}
+#endif
+
+// dataset.cpp
+#if defined(ARROW_R_WITH_ARROW)
 std::vector<std::string> dataset___FileSystemDataset__files(const std::shared_ptr<ds::FileSystemDataset>& dataset);
 extern "C" SEXP _arrow_dataset___FileSystemDataset__files(SEXP dataset_sexp){
 BEGIN_CPP11
@@ -6053,6 +6068,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_dataset___InMemoryDataset__create", (DL_FUNC) &_arrow_dataset___InMemoryDataset__create, 1}, 
 		{ "_arrow_dataset___UnionDataset__children", (DL_FUNC) &_arrow_dataset___UnionDataset__children, 1}, 
 		{ "_arrow_dataset___FileSystemDataset__format", (DL_FUNC) &_arrow_dataset___FileSystemDataset__format, 1}, 
+		{ "_arrow_dataset___FileSystemDataset__filesystem", (DL_FUNC) &_arrow_dataset___FileSystemDataset__filesystem, 1}, 
 		{ "_arrow_dataset___FileSystemDataset__files", (DL_FUNC) &_arrow_dataset___FileSystemDataset__files, 1}, 
 		{ "_arrow_dataset___DatasetFactory__Finish1", (DL_FUNC) &_arrow_dataset___DatasetFactory__Finish1, 2}, 
 		{ "_arrow_dataset___DatasetFactory__Finish2", (DL_FUNC) &_arrow_dataset___DatasetFactory__Finish2, 2}, 

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -78,6 +78,12 @@ std::shared_ptr<ds::FileFormat> dataset___FileSystemDataset__format(
 }
 
 // [[arrow::export]]
+std::shared_ptr<fs::FileSystem> dataset___FileSystemDataset__filesystem(
+    const std::shared_ptr<ds::FileSystemDataset>& dataset) {
+  return dataset->filesystem();
+}
+
+// [[arrow::export]]
 std::vector<std::string> dataset___FileSystemDataset__files(
     const std::shared_ptr<ds::FileSystemDataset>& dataset) {
   return dataset->files();

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -88,6 +88,8 @@ test_that("Setup (putting data in the dir)", {
 
 test_that("Simple interface for datasets", {
   ds <- open_dataset(dataset_dir, partitioning = schema(part = uint8()))
+  expect_is(ds$format, "ParquetFileFormat")
+  expect_is(ds$filesystem, "LocalFileSystem")
   expect_is(ds, "Dataset")
   expect_equivalent(
     ds %>%
@@ -223,6 +225,8 @@ test_that("Partitioning inference", {
 
 test_that("IPC/Feather format data", {
   ds <- open_dataset(ipc_dir, partitioning = "part", format = "feather")
+  expect_is(ds$format, "IpcFileFormat")
+  expect_is(ds$filesystem, "LocalFileSystem")
   expect_identical(names(ds), c(names(df1), "part"))
   expect_warning(
     expect_identical(dim(ds), c(NA, 7L))
@@ -249,6 +253,8 @@ test_that("IPC/Feather format data", {
 
 test_that("CSV dataset", {
   ds <- open_dataset(csv_dir, partitioning = "part", format = "csv")
+  expect_is(ds$format, "CsvFileFormat")
+  expect_is(ds$filesystem, "LocalFileSystem")
   expect_identical(names(ds), c(names(df1), "part"))
   expect_warning(
     expect_identical(dim(ds), c(NA, 7L))


### PR DESCRIPTION
In addition, the constructor now ensures that all fragments in a file system dataset belong to the provided filesystem.