### PR TITLE
ARROW-9877: [C++] Fix homebrew-cpp build fail on AVX512

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -49,7 +49,8 @@ if(ARROW_CPU_FLAG STREQUAL "x86")
     set(ARROW_AVX2_FLAG "-march=haswell")
     # skylake-avx512 consists of AVX512F,AVX512BW,AVX512VL,AVX512CD,AVX512DQ
     set(ARROW_AVX512_FLAG "-march=skylake-avx512 -mbmi2")
-    # Append the avx512 subset option also, fix issue ARROW-9877
+    # Append the avx2/avx512 subset option also, fix issue ARROW-9877 for homebrew-cpp
+    set(ARROW_AVX2_FLAG "${ARROW_AVX2_FLAG} -mavx2")
     set(ARROW_AVX512_FLAG
         "${ARROW_AVX512_FLAG} -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw")
     check_cxx_compiler_flag(${ARROW_SSE4_2_FLAG} CXX_SUPPORTS_SSE4_2)

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -47,8 +47,8 @@ if(ARROW_CPU_FLAG STREQUAL "x86")
   else()
     set(ARROW_SSE4_2_FLAG "-msse4.2")
     set(ARROW_AVX2_FLAG "-mavx2")
-    # skylake-avx512 consists of AVX512F,AVX512BW,AVX512VL,AVX512CD,AVX512DQ
-    set(ARROW_AVX512_FLAG "-march=skylake-avx512 -mbmi2")
+    # Typical AVX512 subsets consists of AVX512F, AVX512BW, AVX512VL, AVX512CD, AVX512DQ
+    set(ARROW_AVX512_FLAG "-mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mbmi2")
     check_cxx_compiler_flag(${ARROW_SSE4_2_FLAG} CXX_SUPPORTS_SSE4_2)
   endif()
   check_cxx_compiler_flag(${ARROW_AVX2_FLAG} CXX_SUPPORTS_AVX2)

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -48,10 +48,10 @@ if(ARROW_CPU_FLAG STREQUAL "x86")
     set(ARROW_SSE4_2_FLAG "-msse4.2")
     set(ARROW_AVX2_FLAG "-march=haswell")
     # skylake-avx512 consists of AVX512F,AVX512BW,AVX512VL,AVX512CD,AVX512DQ
-    # Append the avx512 subset option also, see issue ARROW-9877
+    set(ARROW_AVX512_FLAG "-march=skylake-avx512 -mbmi2")
+    # Append the avx512 subset option also, fix issue ARROW-9877
     set(ARROW_AVX512_FLAG
-        "-march=skylake-avx512 -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mbmi2"
-    )
+        "${ARROW_AVX512_FLAG} -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw")
     check_cxx_compiler_flag(${ARROW_SSE4_2_FLAG} CXX_SUPPORTS_SSE4_2)
   endif()
   check_cxx_compiler_flag(${ARROW_AVX2_FLAG} CXX_SUPPORTS_AVX2)

--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -46,9 +46,12 @@ if(ARROW_CPU_FLAG STREQUAL "x86")
     set(CXX_SUPPORTS_SSE4_2 TRUE)
   else()
     set(ARROW_SSE4_2_FLAG "-msse4.2")
-    set(ARROW_AVX2_FLAG "-mavx2")
-    # Typical AVX512 subsets consists of AVX512F, AVX512BW, AVX512VL, AVX512CD, AVX512DQ
-    set(ARROW_AVX512_FLAG "-mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mbmi2")
+    set(ARROW_AVX2_FLAG "-march=haswell")
+    # skylake-avx512 consists of AVX512F,AVX512BW,AVX512VL,AVX512CD,AVX512DQ
+    # Append the avx512 subset option also, see issue ARROW-9877
+    set(ARROW_AVX512_FLAG
+        "-march=skylake-avx512 -mavx512f -mavx512cd -mavx512vl -mavx512dq -mavx512bw -mbmi2"
+    )
     check_cxx_compiler_flag(${ARROW_SSE4_2_FLAG} CXX_SUPPORTS_SSE4_2)
   endif()
   check_cxx_compiler_flag(${ARROW_AVX2_FLAG} CXX_SUPPORTS_AVX2)

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -126,10 +126,12 @@ static struct {
   int64_t flag;
 } flag_mappings[] = {
 #if (defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64))
-    {"ssse3", CpuInfo::SSSE3},    {"sse4_1", CpuInfo::SSE4_1},
-    {"sse4_2", CpuInfo::SSE4_2},  {"popcnt", CpuInfo::POPCNT},
-    {"avx", CpuInfo::AVX},        {"avx2", CpuInfo::AVX2},
-    {"avx512f", CpuInfo::AVX512}, {"bmi1", CpuInfo::BMI1},
+    {"ssse3", CpuInfo::SSSE3},       {"sse4_1", CpuInfo::SSE4_1},
+    {"sse4_2", CpuInfo::SSE4_2},     {"popcnt", CpuInfo::POPCNT},
+    {"avx", CpuInfo::AVX},           {"avx2", CpuInfo::AVX2},
+    {"avx512f", CpuInfo::AVX512F},   {"avx512cd", CpuInfo::AVX512CD},
+    {"avx512vl", CpuInfo::AVX512VL}, {"avx512dq", CpuInfo::AVX512DQ},
+    {"avx512bw", CpuInfo::AVX512BW}, {"bmi1", CpuInfo::BMI1},
     {"bmi2", CpuInfo::BMI2},
 #endif
 #if defined(__aarch64__)
@@ -254,7 +256,11 @@ bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name) {
     if (features_EBX[3]) *hardware_flags |= CpuInfo::BMI1;
     if (features_EBX[5]) *hardware_flags |= CpuInfo::AVX2;
     if (features_EBX[8]) *hardware_flags |= CpuInfo::BMI2;
-    if (features_EBX[16]) *hardware_flags |= CpuInfo::AVX512;
+    if (features_EBX[16]) *hardware_flags |= CpuInfo::AVX512F;
+    if (features_EBX[17]) *hardware_flags |= CpuInfo::AVX512DQ;
+    if (features_EBX[28]) *hardware_flags |= CpuInfo::AVX512CD;
+    if (features_EBX[30]) *hardware_flags |= CpuInfo::AVX512BW;
+    if (features_EBX[31]) *hardware_flags |= CpuInfo::AVX512VL;
   }
 
   return true;

--- a/cpp/src/arrow/util/cpu_info.h
+++ b/cpp/src/arrow/util/cpu_info.h
@@ -41,9 +41,16 @@ class ARROW_EXPORT CpuInfo {
   static constexpr int64_t ASIMD = (1 << 5);
   static constexpr int64_t AVX = (1 << 6);
   static constexpr int64_t AVX2 = (1 << 7);
-  static constexpr int64_t AVX512 = (1 << 8);
-  static constexpr int64_t BMI1 = (1 << 9);
-  static constexpr int64_t BMI2 = (1 << 10);
+  static constexpr int64_t AVX512F = (1 << 8);
+  static constexpr int64_t AVX512CD = (1 << 9);
+  static constexpr int64_t AVX512VL = (1 << 10);
+  static constexpr int64_t AVX512DQ = (1 << 11);
+  static constexpr int64_t AVX512BW = (1 << 12);
+  static constexpr int64_t BMI1 = (1 << 13);
+  static constexpr int64_t BMI2 = (1 << 14);
+
+  /// Typical AVX512 subsets consists of AVX512F,AVX512BW,AVX512VL,AVX512CD,AVX512DQ
+  static constexpr int64_t AVX512 = AVX512F | AVX512CD | AVX512VL | AVX512DQ | AVX512BW;
 
   /// Cache enums for L1 (data), L2 and L3
   enum CacheLevel {
@@ -71,8 +78,8 @@ class ARROW_EXPORT CpuInfo {
   /// Returns all the flags for this cpu
   int64_t hardware_flags();
 
-  /// Returns whether of not the cpu supports this flag
-  bool IsSupported(int64_t flag) const { return (hardware_flags_ & flag) != 0; }
+  /// Returns whether of not the cpu supports the flags
+  bool IsSupported(int64_t flags) const { return (hardware_flags_ & flags) == flags; }
 
   /// \brief The processor supports SSE4.2 and the Arrow libraries are built
   /// with support for it

--- a/cpp/src/arrow/util/cpu_info.h
+++ b/cpp/src/arrow/util/cpu_info.h
@@ -78,7 +78,7 @@ class ARROW_EXPORT CpuInfo {
   /// Returns all the flags for this cpu
   int64_t hardware_flags();
 
-  /// Returns whether of not the cpu supports the flags
+  /// Returns whether of not the cpu supports all the flags
   bool IsSupported(int64_t flags) const { return (hardware_flags_ & flags) == flags; }
 
   /// \brief The processor supports SSE4.2 and the Arrow libraries are built


### PR DESCRIPTION
Apple Clang cannot unzip "-march=skylake-avx512" exactly.

Also fix AVX512 detect to include AVX512F, AVX512BW, AVX512VL, AVX512CD, AVX512DQ

Signed-off-by: Frank Du <frank.du@intel.com>