### PR TITLE
ARROW-9815: [Rust][DataFusion] Remove the use of Arc/Mutex to protect plan time structures

### DIFF
--- a/rust/datafusion/src/datasource/datasource.rs
+++ b/rust/datafusion/src/datasource/datasource.rs
@@ -28,8 +28,7 @@ pub trait TableProvider {
     /// Get a reference to the schema for this table
     fn schema(&self) -> SchemaRef;
 
-    /// Perform a scan of a table and return a sequence of iterators over the data (one
-    /// iterator per partition)
+    /// Create an ExecutionPlan that will scan the table.
     fn scan(
         &self,
         projection: &Option<Vec<usize>>,

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -17,7 +17,7 @@
 
 //! Implementation of DataFrame API
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::arrow::record_batch::RecordBatch;
 use crate::dataframe::*;
@@ -28,13 +28,13 @@ use arrow::datatypes::Schema;
 
 /// Implementation of DataFrame API
 pub struct DataFrameImpl {
-    ctx_state: Arc<Mutex<ExecutionContextState>>,
+    ctx_state: ExecutionContextState,
     plan: LogicalPlan,
 }
 
 impl DataFrameImpl {
     /// Create a new Table based on an existing logical plan
-    pub fn new(ctx_state: Arc<Mutex<ExecutionContextState>>, plan: &LogicalPlan) -> Self {
+    pub fn new(ctx_state: ExecutionContextState, plan: &LogicalPlan) -> Self {
         Self {
             ctx_state,
             plan: plan.clone(),

--- a/rust/datafusion/src/execution/physical_plan/planner.rs
+++ b/rust/datafusion/src/execution/physical_plan/planner.rs
@@ -345,23 +345,19 @@ impl DefaultPhysicalPlanner {
             }
             Expr::Literal(value) => Ok(Arc::new(Literal::new(value.clone()))),
             Expr::BinaryExpr { left, op, right } => {
-                let lhs =
-                    self.create_physical_expr(left, input_schema, ctx_state.clone())?;
-                let rhs =
-                    self.create_physical_expr(right, input_schema, ctx_state.clone())?;
+                let lhs = self.create_physical_expr(left, input_schema, ctx_state)?;
+                let rhs = self.create_physical_expr(right, input_schema, ctx_state)?;
                 binary(lhs, op.clone(), rhs, input_schema)
             }
             Expr::Cast { expr, data_type } => expressions::cast(
-                self.create_physical_expr(expr, input_schema, ctx_state.clone())?,
+                self.create_physical_expr(expr, input_schema, ctx_state)?,
                 input_schema,
                 data_type.clone(),
             ),
             Expr::ScalarFunction { fun, args } => {
                 let physical_args = args
                     .iter()
-                    .map(|e| {
-                        self.create_physical_expr(e, input_schema, ctx_state.clone())
-                    })
+                    .map(|e| self.create_physical_expr(e, input_schema, ctx_state))
                     .collect::<Result<Vec<_>>>()?;
                 functions::create_physical_expr(fun, &physical_args, input_schema)
             }
@@ -376,7 +372,7 @@ impl DefaultPhysicalPlanner {
                         physical_args.push(self.create_physical_expr(
                             e,
                             input_schema,
-                            ctx_state.clone(),
+                            ctx_state,
                         )?);
                     }
                     Ok(Arc::new(ScalarFunctionExpr::new(


### PR DESCRIPTION
This is a continuation of the work started in https://github.com/apache/arrow/pull/8031 to clean up the `ExecutionContext` interface

Specifically, the `ExecutionContext` is used during *planning time* (not *execution time*) and thus using a `Mutex/Arc` seemed to make the code more complicated as well as suggest that they could be shared by multiple threads (which they are not). 

This PR also removes several deep copies of structures, which helps readability (and likely performance in some tiny amount)