### PR TITLE
ARROW-9887: [Rust] [DataFusion] Added support for complex return types for built-in functions

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -39,7 +39,6 @@ use crate::execution::physical_plan::common;
 use crate::execution::physical_plan::csv::CsvReadOptions;
 use crate::execution::physical_plan::merge::MergeExec;
 use crate::execution::physical_plan::planner::DefaultPhysicalPlanner;
-use crate::execution::physical_plan::scalar_functions;
 use crate::execution::physical_plan::udf::ScalarFunction;
 use crate::execution::physical_plan::ExecutionPlan;
 use crate::execution::physical_plan::PhysicalPlanner;
@@ -105,16 +104,13 @@ impl ExecutionContext {
 
     /// Create a new execution context using the provided configuration
     pub fn with_config(config: ExecutionConfig) -> Self {
-        let mut ctx = Self {
+        let ctx = Self {
             state: Arc::new(Mutex::new(ExecutionContextState {
                 datasources: HashMap::new(),
                 scalar_functions: HashMap::new(),
                 config,
             })),
         };
-        for udf in scalar_functions() {
-            ctx.register_udf(udf);
-        }
         ctx
     }
 

--- a/rust/datafusion/src/execution/physical_plan/expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/expressions.rs
@@ -1361,7 +1361,7 @@ pub struct CastExpr {
 }
 
 /// Determine if a DataType is numeric or not
-fn is_numeric(dt: &DataType) -> bool {
+pub fn is_numeric(dt: &DataType) -> bool {
     match dt {
         DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => true,
         DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => true,

--- a/rust/datafusion/src/execution/physical_plan/functions.rs
+++ b/rust/datafusion/src/execution/physical_plan/functions.rs
@@ -1,0 +1,319 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Declaration of built-in (scalar) functions.
+//! This module contains built-in functions' enumeration and metadata.
+//!
+//! Generally, a function has:
+//! * a set of valid argument types
+//! * a return type function of an incoming argument types
+//! * the computation valid for all sets of valid argument types
+//!
+//! * Argument types: the number of arguments and set of valid types. For example, [[f32, f32], [f64, f64]] is a function of two arguments only accepting f32 or f64 on each of its arguments.
+//! * Return type: a function `(arg_types) -> return_type`. E.g. for sqrt, ([f32]) -> f32, ([f64]) -> f64.
+//!
+//! Currently, this implementation supports only a single argument and a single signature.
+//!
+//! This module also has a set of coercion rules to improve user experience: if an argument i32 is passed
+//! to a function that supports f64, it is coerced to f64.
+
+use super::{
+    expressions::{cast, is_numeric},
+    PhysicalExpr,
+};
+use crate::error::{ExecutionError, Result};
+use crate::execution::physical_plan::math_expressions;
+use crate::execution::physical_plan::udf;
+use arrow::{
+    compute::kernels::length::length,
+    datatypes::{DataType, Schema},
+};
+use std::{fmt, str::FromStr, sync::Arc};
+use udf::ScalarUdf;
+
+/// Enum of all built-in scalar functions
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScalarFunction {
+    /// sqrt
+    Sqrt,
+    /// sin
+    Sin,
+    /// cos
+    Cos,
+    /// tan
+    Tan,
+    /// asin
+    Asin,
+    /// acos
+    Acos,
+    /// atan
+    Atan,
+    /// exp
+    Exp,
+    /// log, also known as ln
+    Log,
+    /// log2
+    Log2,
+    /// log10
+    Log10,
+    /// floor
+    Floor,
+    /// ceil
+    Ceil,
+    /// round
+    Round,
+    /// trunc
+    Trunc,
+    /// abs
+    Abs,
+    /// signum
+    Signum,
+    /// length
+    Length,
+}
+
+impl fmt::Display for ScalarFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // lowercase of the debug.
+        write!(f, "{}", format!("{:?}", self).to_lowercase())
+    }
+}
+
+impl FromStr for ScalarFunction {
+    type Err = ExecutionError;
+    fn from_str(name: &str) -> Result<ScalarFunction> {
+        Ok(match name {
+            "sqrt" => ScalarFunction::Sqrt,
+            "sin" => ScalarFunction::Sin,
+            "cos" => ScalarFunction::Cos,
+            "tan" => ScalarFunction::Tan,
+            "asin" => ScalarFunction::Asin,
+            "acos" => ScalarFunction::Acos,
+            "atan" => ScalarFunction::Atan,
+            "exp" => ScalarFunction::Exp,
+            "log" => ScalarFunction::Log,
+            "log2" => ScalarFunction::Log2,
+            "log10" => ScalarFunction::Log10,
+            "floor" => ScalarFunction::Floor,
+            "ceil" => ScalarFunction::Ceil,
+            "round" => ScalarFunction::Round,
+            "truc" => ScalarFunction::Trunc,
+            "abs" => ScalarFunction::Abs,
+            "signum" => ScalarFunction::Signum,
+            "length" => ScalarFunction::Length,
+            _ => {
+                return Err(ExecutionError::General(format!(
+                    "There is no built-in function named {}",
+                    name
+                )))
+            }
+        })
+    }
+}
+
+/// Returns the datatype of the scalar function
+pub fn return_type(fun: &ScalarFunction, arg_types: &Vec<DataType>) -> Result<DataType> {
+    // Note that this function *must* return the same type that the respective physical expression returns
+    // or the execution panics.
+
+    if arg_types.len() != 1 {
+        // for now, every function expects a single argument, and thus this is enough
+        return Err(ExecutionError::General(format!(
+            "The function \"{}\" expected 1 argument, but received \"{}\"",
+            fun,
+            arg_types.len()
+        )));
+    }
+
+    // verify that this is a valid type for this function
+    coerce(fun, &arg_types[0])?;
+
+    // the return type after coercion.
+    // for now, this is type-independent, but there will be built-in functions whose return type
+    // depends on the incoming type.
+    match fun {
+        ScalarFunction::Length => Ok(DataType::UInt32),
+        _ => Ok(DataType::Float64),
+    }
+}
+
+/// Create a physical (function) expression.
+/// This function errors when `args`' can't be coerced to a valid argument type of the function.
+pub fn function(
+    fun: &ScalarFunction,
+    args: &Vec<Arc<dyn PhysicalExpr>>,
+    input_schema: &Schema,
+) -> Result<Arc<dyn PhysicalExpr>> {
+    let fun_expr: ScalarUdf = Arc::new(match fun {
+        ScalarFunction::Sqrt => math_expressions::sqrt,
+        ScalarFunction::Sin => math_expressions::sin,
+        ScalarFunction::Cos => math_expressions::cos,
+        ScalarFunction::Tan => math_expressions::tan,
+        ScalarFunction::Asin => math_expressions::asin,
+        ScalarFunction::Acos => math_expressions::acos,
+        ScalarFunction::Atan => math_expressions::atan,
+        ScalarFunction::Exp => math_expressions::exp,
+        ScalarFunction::Log => math_expressions::ln,
+        ScalarFunction::Log2 => math_expressions::log2,
+        ScalarFunction::Log10 => math_expressions::log10,
+        ScalarFunction::Floor => math_expressions::floor,
+        ScalarFunction::Ceil => math_expressions::ceil,
+        ScalarFunction::Round => math_expressions::round,
+        ScalarFunction::Trunc => math_expressions::trunc,
+        ScalarFunction::Abs => math_expressions::abs,
+        ScalarFunction::Signum => math_expressions::signum,
+        ScalarFunction::Length => |args| Ok(Arc::new(length(args[0].as_ref())?)),
+    });
+    let data_types = args
+        .iter()
+        .map(|e| e.data_type(input_schema))
+        .collect::<Result<Vec<_>>>()?;
+
+    // coerce type
+    // for now, this supports a single type.
+    assert!(args.len() == 1);
+    assert!(data_types.len() == 1);
+    let arg_type = coerce(fun, &data_types[0])?;
+    let args = vec![cast(args[0].clone(), input_schema, arg_type.clone())?];
+
+    Ok(Arc::new(udf::ScalarFunctionExpr::new(
+        &format!("{}", fun),
+        fun_expr,
+        args,
+        &return_type(&fun, &vec![arg_type])?,
+    )))
+}
+
+/// the type supported by the function `fun`.
+fn valid_type(fun: &ScalarFunction) -> DataType {
+    // note: the physical expression must accept the type returned by this function or the execution panics.
+
+    // for now, the list is small, as we do not have many built-in functions.
+    match fun {
+        ScalarFunction::Length => DataType::Utf8,
+        // math expressions expect f64
+        _ => DataType::Float64,
+    }
+}
+
+/// coercion rules for all built-in functions.
+/// Returns a DataType coerced from `arg_type` that is accepted by `fun`.
+/// Errors when `arg_type` can't be coerced to a valid return type of `fun`.
+fn coerce(fun: &ScalarFunction, arg_type: &DataType) -> Result<DataType> {
+    let valid_type = valid_type(fun);
+    if *arg_type == valid_type {
+        // same type => all good
+        return Ok(arg_type.clone());
+    }
+    match fun {
+        ScalarFunction::Length => match arg_type {
+            // cast does not support LargeUtf8 -> Utf8 yet: every type errors.
+            _ => Err(ExecutionError::General(
+                format!(
+                    "The function '{}' can't evaluate type '{:?}'",
+                    fun, arg_type
+                )
+                .to_string(),
+            )),
+        },
+        // all other numerical types: float64
+        _ => {
+            if is_numeric(arg_type) {
+                Ok(DataType::Float64)
+            } else {
+                Err(ExecutionError::General(
+                    format!(
+                        "The function '{}' can't evaluate type '{:?}'",
+                        fun, arg_type
+                    )
+                    .to_string(),
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        error::Result, execution::physical_plan::expressions::lit,
+        logicalplan::ScalarValue,
+    };
+    use arrow::{
+        array::{ArrayRef, Float64Array, Int32Array},
+        datatypes::Field,
+        record_batch::RecordBatch,
+    };
+
+    #[test]
+    fn test_coerce_math() -> Result<()> {
+        // valid cases
+        let cases = vec![
+            // (observed, expected coercion to)
+            (DataType::Float64, DataType::Float64),
+            (DataType::Float32, DataType::Float64),
+            (DataType::Int8, DataType::Float64),
+            (DataType::UInt32, DataType::Float64),
+        ];
+        for case in cases {
+            let result = coerce(&ScalarFunction::Sqrt, &case.0)?;
+            assert_eq!(result, case.1)
+        }
+        // invalid math types
+        let cases = vec![DataType::Utf8, DataType::Boolean, DataType::LargeUtf8];
+        for case in cases {
+            let result = coerce(&ScalarFunction::Sqrt, &case);
+            assert!(result.is_err())
+        }
+        Ok(())
+    }
+
+    fn generic_test_math(value: ScalarValue) -> Result<()> {
+        // any type works here: we evaluate against a literal of `value`
+        let schema = Schema::new(vec![Field::new("a", DataType::Int32, false)]);
+        let columns: Vec<ArrayRef> = vec![Arc::new(Int32Array::from(vec![1]))];
+
+        let arg = lit(value);
+
+        let expr = function(&ScalarFunction::Exp, &vec![arg], &schema)?;
+
+        // type is correct
+        assert_eq!(expr.data_type(&schema)?, DataType::Float64);
+
+        // evaluate works
+        let result =
+            expr.evaluate(&RecordBatch::try_new(Arc::new(schema.clone()), columns)?)?;
+
+        // downcast works
+        let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
+
+        // value is correct
+        assert_eq!(format!("{}", result.value(0)), "2.718281828459045"); // = exp(1)
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_math_function() -> Result<()> {
+        generic_test_math(ScalarValue::Int32(1i32))?;
+        generic_test_math(ScalarValue::UInt32(1u32))?;
+        generic_test_math(ScalarValue::Float64(1f64))?;
+        generic_test_math(ScalarValue::Float32(1f32))?;
+        Ok(())
+    }
+}

--- a/rust/datafusion/src/execution/physical_plan/functions.rs
+++ b/rust/datafusion/src/execution/physical_plan/functions.rs
@@ -158,7 +158,7 @@ pub fn return_type(fun: &ScalarFunction, arg_types: &Vec<DataType>) -> Result<Da
 
 /// Create a physical (function) expression.
 /// This function errors when `args`' can't be coerced to a valid argument type of the function.
-pub fn function(
+pub fn create_physical_expr(
     fun: &ScalarFunction,
     args: &Vec<Arc<dyn PhysicalExpr>>,
     input_schema: &Schema,
@@ -231,7 +231,7 @@ mod tests {
 
         let arg = lit(value);
 
-        let expr = function(&ScalarFunction::Exp, &vec![arg], &schema)?;
+        let expr = create_physical_expr(&ScalarFunction::Exp, &vec![arg], &schema)?;
 
         // type is correct
         assert_eq!(expr.data_type(&schema)?, DataType::Float64);

--- a/rust/datafusion/src/execution/physical_plan/functions.rs
+++ b/rust/datafusion/src/execution/physical_plan/functions.rs
@@ -46,16 +46,16 @@ use udf::ScalarUdf;
 /// A function's signature, which defines the function's supported argument types.
 #[derive(Debug)]
 pub enum Signature {
-    /// arbitrary number of arguments of an uniform type out of a list of valid types
-    // A function such as `concat` is `Many(vec![DataType::Utf8, DataType::LargeUtf8])`
-    Many(Vec<DataType>),
-    /// arbitrary number of arguments of an arbitrary but uniform type
-    // A function such as `array` is `ManyUniform`
+    /// arbitrary number of arguments of an common type out of a list of valid types
+    // A function such as `concat` is `Variadic(vec![DataType::Utf8, DataType::LargeUtf8])`
+    Variadic(Vec<DataType>),
+    /// arbitrary number of arguments of an arbitrary but equal type
+    // A function such as `array` is `VariadicEqual`
     // The first argument decides the type used for coercion
-    ManyUniform,
-    /// fixed number of arguments of an uniform type out of a list of valid types
-    // A function of one argument of f64 is `Fixed(1, vec![DataType::Float64])`
-    // A function of two arguments of f64 or f32 is `Fixed(1, vec![DataType::Float32, DataType::Float64])`
+    VariadicEqual,
+    /// fixed number of arguments of an arbitrary but equal type out of a list of valid types
+    // A function of one argument of f64 is `Uniform(1, vec![DataType::Float64])`
+    // A function of two arguments of f64 or f32 is `Uniform(1, vec![DataType::Float32, DataType::Float64])`
     Uniform(usize, Vec<DataType>),
 }
 

--- a/rust/datafusion/src/execution/physical_plan/math_expressions.rs
+++ b/rust/datafusion/src/execution/physical_plan/math_expressions.rs
@@ -17,102 +17,52 @@
 
 //! Math expressions
 
-use crate::error::ExecutionError;
-use crate::execution::physical_plan::udf::ScalarFunction;
+use crate::error::{ExecutionError, Result};
 
 use arrow::array::{Array, ArrayRef, Float64Array, Float64Builder};
-use arrow::datatypes::DataType;
 
 use std::sync::Arc;
 
 macro_rules! math_unary_function {
     ($NAME:expr, $FUNC:ident) => {
-        ScalarFunction::new(
-            $NAME,
-            vec![DataType::Float64],
-            DataType::Float64,
-            Arc::new(|args: &[ArrayRef]| {
-                let n = &args[0].as_any().downcast_ref::<Float64Array>();
-                match n {
-                    Some(array) => {
-                        let mut builder = Float64Builder::new(array.len());
-                        for i in 0..array.len() {
-                            if array.is_null(i) {
-                                builder.append_null()?;
-                            } else {
-                                builder.append_value(array.value(i).$FUNC())?;
-                            }
+        /// mathematical function
+        pub fn $FUNC(args: &[ArrayRef]) -> Result<ArrayRef> {
+            let n = &args[0].as_any().downcast_ref::<Float64Array>();
+            match n {
+                Some(array) => {
+                    let mut builder = Float64Builder::new(array.len());
+                    for i in 0..array.len() {
+                        if array.is_null(i) {
+                            builder.append_null()?;
+                        } else {
+                            builder.append_value(array.value(i).$FUNC())?;
                         }
-                        Ok(Arc::new(builder.finish()))
                     }
-                    _ => Err(ExecutionError::General(format!(
-                        "Invalid data type for {}",
-                        $NAME
-                    ))),
+                    Ok(Arc::new(builder.finish()))
                 }
-            }),
-        )
+                _ => Err(ExecutionError::General(format!(
+                    "Invalid data type for {}",
+                    $NAME
+                ))),
+            }
+        }
     };
 }
 
-/// vector of math scalar functions
-pub fn scalar_functions() -> Vec<ScalarFunction> {
-    vec![
-        math_unary_function!("sqrt", sqrt),
-        math_unary_function!("sin", sin),
-        math_unary_function!("cos", cos),
-        math_unary_function!("tan", tan),
-        math_unary_function!("asin", asin),
-        math_unary_function!("acos", acos),
-        math_unary_function!("atan", atan),
-        math_unary_function!("floor", floor),
-        math_unary_function!("ceil", ceil),
-        math_unary_function!("round", round),
-        math_unary_function!("trunc", trunc),
-        math_unary_function!("abs", abs),
-        math_unary_function!("signum", signum),
-        math_unary_function!("exp", exp),
-        math_unary_function!("log", ln),
-        math_unary_function!("log2", log2),
-        math_unary_function!("log10", log10),
-    ]
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::error::Result;
-    use crate::{
-        execution::context::ExecutionContext,
-        logicalplan::{col, sqrt, LogicalPlanBuilder},
-    };
-    use arrow::datatypes::{Field, Schema};
-
-    #[test]
-    fn cast_i8_input() -> Result<()> {
-        let schema = Schema::new(vec![Field::new("c0", DataType::Int8, true)]);
-        let plan = LogicalPlanBuilder::scan("", "", &schema, None)?
-            .project(vec![sqrt(col("c0"))])?
-            .build()?;
-        let ctx = ExecutionContext::new();
-        let plan = ctx.optimize(&plan)?;
-        let expected = "Projection: sqrt(CAST(#c0 AS Float64))\
-        \n  TableScan:  projection=Some([0])";
-        assert_eq!(format!("{:?}", plan), expected);
-        Ok(())
-    }
-
-    #[test]
-    fn no_cast_f64_input() -> Result<()> {
-        let schema = Schema::new(vec![Field::new("c0", DataType::Float64, true)]);
-        let plan = LogicalPlanBuilder::scan("", "", &schema, None)?
-            .project(vec![sqrt(col("c0"))])?
-            .build()?;
-        let ctx = ExecutionContext::new();
-        let plan = ctx.optimize(&plan)?;
-        let expected = "Projection: sqrt(#c0)\
-        \n  TableScan:  projection=Some([0])";
-        assert_eq!(format!("{:?}", plan), expected);
-        Ok(())
-    }
-}
+math_unary_function!("sqrt", sqrt);
+math_unary_function!("sin", sin);
+math_unary_function!("cos", cos);
+math_unary_function!("tan", tan);
+math_unary_function!("asin", asin);
+math_unary_function!("acos", acos);
+math_unary_function!("atan", atan);
+math_unary_function!("floor", floor);
+math_unary_function!("ceil", ceil);
+math_unary_function!("round", round);
+math_unary_function!("trunc", trunc);
+math_unary_function!("abs", abs);
+math_unary_function!("signum", signum);
+math_unary_function!("exp", exp);
+math_unary_function!("log", ln);
+math_unary_function!("log2", log2);
+math_unary_function!("log10", log10);

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -145,4 +145,5 @@ pub mod parquet;
 pub mod planner;
 pub mod projection;
 pub mod sort;
+pub mod type_coercion;
 pub mod udf;

--- a/rust/datafusion/src/execution/physical_plan/mod.rs
+++ b/rust/datafusion/src/execution/physical_plan/mod.rs
@@ -27,11 +27,7 @@ use crate::execution::context::ExecutionContextState;
 use crate::logicalplan::{LogicalPlan, ScalarValue};
 use arrow::array::ArrayRef;
 use arrow::datatypes::{DataType, Schema, SchemaRef};
-use arrow::{
-    compute::kernels::length::length,
-    record_batch::{RecordBatch, RecordBatchReader},
-};
-use udf::ScalarFunction;
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
 /// Physical query planner that converts a `LogicalPlan` to an
 /// `ExecutionPlan` suitable for execution.
@@ -134,23 +130,12 @@ pub trait Accumulator: Debug {
     fn get_value(&self) -> Result<Option<ScalarValue>>;
 }
 
-/// Vector of scalar functions declared in this module
-pub fn scalar_functions() -> Vec<ScalarFunction> {
-    let mut udfs = vec![ScalarFunction::new(
-        "length",
-        vec![DataType::Utf8],
-        DataType::UInt32,
-        Arc::new(|args: &[ArrayRef]| Ok(Arc::new(length(args[0].as_ref())?))),
-    )];
-    udfs.append(&mut math_expressions::scalar_functions());
-    udfs
-}
-
 pub mod common;
 pub mod csv;
 pub mod explain;
 pub mod expressions;
 pub mod filter;
+pub mod functions;
 pub mod hash_aggregate;
 pub mod limit;
 pub mod math_expressions;

--- a/rust/datafusion/src/execution/physical_plan/planner.rs
+++ b/rust/datafusion/src/execution/physical_plan/planner.rs
@@ -357,17 +357,13 @@ impl DefaultPhysicalPlanner {
                 data_type.clone(),
             ),
             Expr::ScalarFunction { fun, args } => {
-                let mut physical_args = vec![];
-                let mut types = Vec::with_capacity(args.len());
-                for e in args {
-                    physical_args.push(self.create_physical_expr(
-                        e,
-                        input_schema,
-                        ctx_state.clone(),
-                    )?);
-                    types.push(e.get_type(input_schema)?)
-                }
-                functions::function(fun, &physical_args, input_schema)
+                let physical_args = args
+                    .iter()
+                    .map(|e| {
+                        self.create_physical_expr(e, input_schema, ctx_state.clone())
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                functions::create_physical_expr(fun, &physical_args, input_schema)
             }
             Expr::ScalarUDF {
                 name,

--- a/rust/datafusion/src/execution/physical_plan/type_coercion.rs
+++ b/rust/datafusion/src/execution/physical_plan/type_coercion.rs
@@ -52,7 +52,7 @@ pub fn data_types(
     signature: &Signature,
 ) -> Result<Vec<DataType>> {
     let valid_types = match signature {
-        Signature::Many(valid_types) => valid_types
+        Signature::Variadic(valid_types) => valid_types
             .iter()
             .map(|valid_type| current_types.iter().map(|_| valid_type.clone()).collect())
             .collect(),
@@ -60,7 +60,7 @@ pub fn data_types(
             .iter()
             .map(|valid_type| (0..*number).map(|_| valid_type.clone()).collect())
             .collect(),
-        Signature::ManyUniform => {
+        Signature::VariadicEqual => {
             // one entry with the same len as current_types, whose type is `current_types[0]`.
             vec![current_types
                 .iter()
@@ -215,13 +215,13 @@ mod tests {
             // u32 -> f32
             case(
                 vec![DataType::UInt32, DataType::UInt32],
-                Signature::Many(vec![DataType::Float32]),
+                Signature::Variadic(vec![DataType::Float32]),
                 vec![DataType::Float32, DataType::Float32],
             )?,
             // u32 -> f32
             case(
                 vec![DataType::Float32, DataType::UInt32],
-                Signature::ManyUniform,
+                Signature::VariadicEqual,
                 vec![DataType::Float32, DataType::Float32],
             )?,
         ];
@@ -243,13 +243,13 @@ mod tests {
             // u32 and bool are not uniform
             case(
                 vec![DataType::UInt32, DataType::Boolean],
-                Signature::ManyUniform,
+                Signature::VariadicEqual,
                 vec![],
             )?,
             // bool is not castable to u32
             case(
                 vec![DataType::Boolean, DataType::Boolean],
-                Signature::Many(vec![DataType::UInt32]),
+                Signature::Variadic(vec![DataType::UInt32]),
                 vec![],
             )?,
         ];

--- a/rust/datafusion/src/execution/physical_plan/type_coercion.rs
+++ b/rust/datafusion/src/execution/physical_plan/type_coercion.rs
@@ -1,0 +1,268 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Type coercion rules for functions with multiple valid signatures
+
+use std::sync::Arc;
+
+use arrow::datatypes::{DataType, Schema};
+
+use super::{functions::Signature, PhysicalExpr};
+use crate::error::{ExecutionError, Result};
+use crate::execution::physical_plan::expressions::{cast, numerical_coercion};
+use crate::logicalplan::Operator;
+
+/// Returns expressions constructed by casting `expressions` to types compatible with `signatures`.
+pub fn coerce(
+    expressions: &Vec<Arc<dyn PhysicalExpr>>,
+    schema: &Schema,
+    signature: &Signature,
+) -> Result<Vec<Arc<dyn PhysicalExpr>>> {
+    let current_types = expressions
+        .iter()
+        .map(|e| e.data_type(schema))
+        .collect::<Result<Vec<_>>>()?;
+
+    let new_types = data_types(&current_types, signature)?;
+
+    expressions
+        .iter()
+        .enumerate()
+        .map(|(i, expr)| cast(expr.clone(), &schema, new_types[i].clone()))
+        .collect::<Result<Vec<_>>>()
+}
+
+/// returns the data types that each argument must be casted to match the `signature`.
+pub fn data_types(
+    current_types: &Vec<DataType>,
+    signature: &Signature,
+) -> Result<Vec<DataType>> {
+    let valid_types = match signature {
+        Signature::Many(valid_types) => valid_types
+            .iter()
+            .map(|valid_type| current_types.iter().map(|_| valid_type.clone()).collect())
+            .collect(),
+        Signature::Uniform(number, valid_types) => valid_types
+            .iter()
+            .map(|valid_type| (0..*number).map(|_| valid_type.clone()).collect())
+            .collect(),
+        Signature::ManyUniform => {
+            // one entry with the same len as current_types, whose type is `current_types[0]`.
+            vec![current_types
+                .iter()
+                .map(|_| current_types[0].clone())
+                .collect()]
+        }
+    };
+
+    if valid_types.contains(current_types) {
+        return Ok(current_types.clone());
+    }
+
+    for valid_types in valid_types {
+        if let Some(types) = maybe_data_types(&valid_types, &current_types) {
+            return Ok(types);
+        }
+    }
+
+    // none possible -> Error
+    Err(ExecutionError::General(format!(
+        "Coercion from {:?} to the signature {:?} failed.",
+        current_types, signature
+    )))
+}
+
+/// Try to coerce current_types into valid_types.
+fn maybe_data_types(
+    valid_types: &Vec<DataType>,
+    current_types: &Vec<DataType>,
+) -> Option<Vec<DataType>> {
+    if valid_types.len() != current_types.len() {
+        return None;
+    }
+
+    let mut new_type = Vec::with_capacity(valid_types.len());
+    for (i, valid_type) in valid_types.iter().enumerate() {
+        let current_type = &current_types[i];
+
+        if current_type == valid_type {
+            new_type.push(current_type.clone())
+        } else {
+            // attempt to coerce using numerical coercion
+            // todo: also try string coercion.
+            if let Ok(cast_to_type) = numerical_coercion(
+                &current_type,
+                // assume that the function behaves like plus
+                // plus is not special here; this function is just trying its best...
+                &Operator::Plus,
+                valid_type,
+            ) {
+                new_type.push(cast_to_type)
+            } else {
+                // not possible
+                return None;
+            }
+        }
+    }
+    Some(new_type)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::execution::physical_plan::expressions::col;
+    use arrow::datatypes::{DataType, Field, Schema};
+
+    #[test]
+    fn test_maybe_data_types() -> Result<()> {
+        // this vec contains: arg1, arg2, expected result
+        let cases = vec![
+            // 2 entries, same values
+            (
+                vec![DataType::UInt8, DataType::UInt16],
+                vec![DataType::UInt8, DataType::UInt16],
+                Some(vec![DataType::UInt8, DataType::UInt16]),
+            ),
+            // 2 entries, can coerse values
+            (
+                vec![DataType::UInt16, DataType::UInt16],
+                vec![DataType::UInt8, DataType::UInt16],
+                Some(vec![DataType::UInt16, DataType::UInt16]),
+            ),
+            // 0 entries, all good
+            (vec![], vec![], Some(vec![])),
+            // 2 entries, can't coerce
+            (
+                vec![DataType::Boolean, DataType::UInt16],
+                vec![DataType::UInt8, DataType::UInt16],
+                None,
+            ),
+            // u32 -> u16 is possible
+            (
+                vec![DataType::Boolean, DataType::UInt32],
+                vec![DataType::Boolean, DataType::UInt16],
+                Some(vec![DataType::Boolean, DataType::UInt32]),
+            ),
+        ];
+
+        for case in cases {
+            assert_eq!(maybe_data_types(&case.0, &case.1), case.2)
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_coerce() -> Result<()> {
+        // create a schema
+        let schema = |t: Vec<DataType>| {
+            Schema::new(
+                t.iter()
+                    .enumerate()
+                    .map(|(i, t)| Field::new(&*format!("c{}", i), t.clone(), true))
+                    .collect(),
+            )
+        };
+
+        // create a vector of expressions
+        let expressions = |t: Vec<DataType>, schema| -> Result<Vec<_>> {
+            t.iter()
+                .enumerate()
+                .map(|(i, t)| cast(col(&format!("c{}", i)), &schema, t.clone()))
+                .collect::<Result<Vec<_>>>()
+        };
+
+        // create a case: input + expected result
+        let case =
+            |observed: Vec<DataType>, valid, expected: Vec<DataType>| -> Result<_> {
+                let schema = schema(observed.clone());
+                let expr = expressions(observed, schema.clone())?;
+                let expected = expressions(expected, schema.clone())?;
+                Ok((expr.clone(), schema, valid, expected))
+            };
+
+        let cases = vec![
+            // u16 -> u32
+            case(
+                vec![DataType::UInt16],
+                Signature::Uniform(1, vec![DataType::UInt32]),
+                vec![DataType::UInt32],
+            )?,
+            // same type
+            case(
+                vec![DataType::UInt32, DataType::UInt32],
+                Signature::Uniform(2, vec![DataType::UInt32]),
+                vec![DataType::UInt32, DataType::UInt32],
+            )?,
+            case(
+                vec![DataType::UInt32],
+                Signature::Uniform(1, vec![DataType::Float32, DataType::Float64]),
+                vec![DataType::Float32],
+            )?,
+            // u32 -> f32
+            case(
+                vec![DataType::UInt32, DataType::UInt32],
+                Signature::Many(vec![DataType::Float32]),
+                vec![DataType::Float32, DataType::Float32],
+            )?,
+            // u32 -> f32
+            case(
+                vec![DataType::Float32, DataType::UInt32],
+                Signature::ManyUniform,
+                vec![DataType::Float32, DataType::Float32],
+            )?,
+        ];
+
+        for case in cases {
+            let observed = format!("{:?}", coerce(&case.0, &case.1, &case.2)?);
+            let expected = format!("{:?}", case.3);
+            assert_eq!(observed, expected);
+        }
+
+        // now cases that are expected to fail
+        let cases = vec![
+            // we do not know how to cast bool to UInt16 => fail
+            case(
+                vec![DataType::Boolean],
+                Signature::Uniform(1, vec![DataType::UInt16]),
+                vec![],
+            )?,
+            // u32 and bool are not uniform
+            case(
+                vec![DataType::UInt32, DataType::Boolean],
+                Signature::ManyUniform,
+                vec![],
+            )?,
+            // bool is not castable to u32
+            case(
+                vec![DataType::Boolean, DataType::Boolean],
+                Signature::Many(vec![DataType::UInt32]),
+                vec![],
+            )?,
+        ];
+
+        for case in cases {
+            if let Ok(_) = coerce(&case.0, &case.1, &case.2) {
+                return Err(ExecutionError::General(format!(
+                    "Error was expected in {:?}",
+                    case
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/rust/datafusion/src/execution/physical_plan/udf.rs
+++ b/rust/datafusion/src/execution/physical_plan/udf.rs
@@ -87,7 +87,7 @@ impl ScalarFunction {
 
 /// Scalar UDF Physical Expression
 pub struct ScalarFunctionExpr {
-    fun: Box<ScalarUdf>,
+    fun: ScalarUdf,
     name: String,
     args: Vec<Arc<dyn PhysicalExpr>>,
     return_type: DataType,
@@ -108,7 +108,7 @@ impl ScalarFunctionExpr {
     /// Create a new Scalar function
     pub fn new(
         name: &str,
-        fun: Box<ScalarUdf>,
+        fun: ScalarUdf,
         args: Vec<Arc<dyn PhysicalExpr>>,
         return_type: &DataType,
     ) -> Self {

--- a/rust/datafusion/src/optimizer/type_coercion.rs
+++ b/rust/datafusion/src/optimizer/type_coercion.rs
@@ -64,7 +64,7 @@ where
 
         // modify `expressions` by introducing casts when necessary
         match expr {
-            Expr::ScalarFunction { name, .. } => {
+            Expr::ScalarUDF { name, .. } => {
                 // cast the inputs of scalar functions to the appropriate type where possible
                 match self.scalar_functions.lookup(name) {
                     Some(func_meta) => {

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -201,6 +201,30 @@ fn csv_query_avg_sqrt() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn csv_query_sqrt_f32() -> Result<()> {
+    let mut ctx = create_ctx()?;
+    register_aggregate_csv(&mut ctx)?;
+    // sqrt(f32)'s plan passes
+    let sql = "SELECT avg(sqrt(c11)) FROM aggregate_test_100";
+    let mut actual = execute(&mut ctx, sql);
+    actual.sort();
+    let expected = "0.6584408483418833".to_string();
+    assert_eq!(actual.join("\n"), expected);
+    Ok(())
+}
+
+#[test]
+fn csv_query_error() -> Result<()> {
+    // sin(utf8) should error
+    let mut ctx = create_ctx()?;
+    register_aggregate_csv(&mut ctx)?;
+    let sql = "SELECT sin(c1) FROM aggregate_test_100";
+    let plan = ctx.create_logical_plan(&sql);
+    assert!(plan.is_err());
+    Ok(())
+}
+
 // this query used to deadlock due to the call udf(udf())
 #[test]
 fn csv_query_sqrt_sqrt() -> Result<()> {


### PR DESCRIPTION
@alamb and @andygrove , I was able to split #8032 in two, so that they address different problems. This PR is specific to the problem that we have been discussing in #7967. It offers a solution that covers the three main cases:

* single return type, such as `sqrt -> f64`
* finite set of return types, such as `concat` (utf8 and largeUTF8)
* potentially infinite set of return types, such as `array` (Array of any primitive or non-primitive type)

I believe that this implementation is closer to option 1 that @alamb enumerated here. It is so because so far I was unable to offer an implementation for option 3, because functions such as `array` have an arbitrary return type (it can be any valid type, primitive or non-primitive), and thus we can't write them as `array_TYPE` as the number of cases is potentially large.

---------------

This PR is exclusive to *built-in functions* of variable return type and it does not care about UDFs. It addresses a limitation of our current logical planning, that has been thoroughly discussed in #8032 and #7967, that logical planning needs to specify a specific return type when planning usage of UDFs and built-in functions (details below).

Notation: `return type function`: a function mapping the functions' argument types to its return type. E.g. `(utf8) -> utf8; (LargeUtf8) -> LargeUtf8;` is an example of the signature of a typical one argument string function.

The primary difference between built-ins and UDFs is that built-in's return type function is always known (hard-coded), while the return type function of a UDF is known by accessing the registry where it is registered on (it is a non-static closure).

This PR is required to address an incompatibility of the following requirements that I gathered from discussions between @alamb, @andygrove and @jorgecarleitao:

1. we want to have typing information during logical planning (see [here](https://docs.google.com/document/d/1Kzz642ScizeKXmVE1bBlbLvR663BKQaGqVIyy9cAscY/edit?disco=AAAAJ4XOjHk))
2. we want to have functions that require their return type to depend on their input. Examples include `array` (any type to any other type) and `concatenate` (`utf8 -> utf8`, `largeutf8 -> largeutf8`), and many others (see [here](https://github.com/apache/arrow/pull/7967#issuecomment-682832105))
3. we would like users to plan built-in functions without accessing the registry (see [here](https://github.com/apache/arrow/pull/8032#issuecomment-679327189) and mailing list)
4. a UDFs return type function needs to be retrieved from the registry (`ExecutionContextState`).
5. Currently, all our built-in functions are declared as UDFs and registered on the registry when the context is initialized.

These points are incompatible because:

* 1. and 2. requires access to built-in function's return type function during planning
* 4. and 5. requires access the registry to know the built-in's return type
* 3. forbids us from accessing the registry during planning

This PR solves this incompatibility by leveraging the following:

* builtin functions have a well declared return type during planning, since they are part of the source code
* builtin functions do not need to be in our function's registry

The first commit in this PR makes the existing logical node `Expr::ScalarFunction` to be exclusive for built-in functions, and moves our UDF planning logic to a new node named `Expr::ScalarUDF`. It also makes the planning of built-in functions to no longer require access the registry.

The second commit in this PR introduces the necessary functionality for built-in functions to support all types of complex signatures. Examples of usage of this functionality are in the following PRs:

1. add support for math functions that accept f32: https://github.com/jorgecarleitao/arrow/pull/4/files
2. add `concat`, of an arbitrary number of arguments of type utf8: https://github.com/jorgecarleitao/arrow/pull/5/files
3. add `array` function, supporting an arbitrary number of arguments with uniform types: https://github.com/jorgecarleitao/arrow/pull/6/files
