### PR TITLE
ARROW-9874: [C++] Add sink-owning version of IPC writers

### DIFF
--- a/c_glib/arrow-glib/writer.cpp
+++ b/c_glib/arrow-glib/writer.cpp
@@ -235,10 +235,10 @@ garrow_record_batch_stream_writer_new(GArrowOutputStream *sink,
                                       GArrowSchema *schema,
                                       GError **error)
 {
-  auto arrow_sink = garrow_output_stream_get_raw(sink).get();
+  auto arrow_sink = garrow_output_stream_get_raw(sink);
   auto arrow_schema = garrow_schema_get_raw(schema);
   auto arrow_writer_result =
-    arrow::ipc::NewStreamWriter(arrow_sink, arrow_schema);
+    arrow::ipc::MakeStreamWriter(arrow_sink, arrow_schema);
   if (garrow::check(error,
                     arrow_writer_result,
                     "[record-batch-stream-writer][open]")) {
@@ -280,11 +280,11 @@ garrow_record_batch_file_writer_new(GArrowOutputStream *sink,
                        GArrowSchema *schema,
                        GError **error)
 {
-  auto arrow_sink = garrow_output_stream_get_raw(sink).get();
+  auto arrow_sink = garrow_output_stream_get_raw(sink);
   auto arrow_schema = garrow_schema_get_raw(schema);
   std::shared_ptr<arrow::ipc::RecordBatchWriter> arrow_writer;
   auto arrow_writer_result =
-    arrow::ipc::NewFileWriter(arrow_sink, arrow_schema);
+    arrow::ipc::MakeFileWriter(arrow_sink, arrow_schema);
   if (garrow::check(error,
                     arrow_writer_result,
                     "[record-batch-file-writer][open]")) {

--- a/cpp/examples/minimal_build/example.cc
+++ b/cpp/examples/minimal_build/example.cc
@@ -52,8 +52,8 @@ Status RunMain(int argc, char** argv) {
   ARROW_ASSIGN_OR_RAISE(auto output_file,
                         arrow::io::FileOutputStream::Open(arrow_filename));
   ARROW_ASSIGN_OR_RAISE(auto batch_writer,
-                        arrow::ipc::NewFileWriter(output_file.get(),
-                                                  table->schema()));
+                        arrow::ipc::MakeFileWriter(output_file.get(),
+                                                   table->schema()));
   ARROW_RETURN_NOT_OK(batch_writer->WriteTable(*table));
   ARROW_RETURN_NOT_OK(batch_writer->Close());
 

--- a/cpp/examples/minimal_build/example.cc
+++ b/cpp/examples/minimal_build/example.cc
@@ -52,7 +52,7 @@ Status RunMain(int argc, char** argv) {
   ARROW_ASSIGN_OR_RAISE(auto output_file,
                         arrow::io::FileOutputStream::Open(arrow_filename));
   ARROW_ASSIGN_OR_RAISE(auto batch_writer,
-                        arrow::ipc::MakeFileWriter(output_file.get(),
+                        arrow::ipc::MakeFileWriter(output_file,
                                                    table->schema()));
   ARROW_RETURN_NOT_OK(batch_writer->WriteTable(*table));
   ARROW_RETURN_NOT_OK(batch_writer->Close());

--- a/cpp/src/arrow/dataset/file_ipc.cc
+++ b/cpp/src/arrow/dataset/file_ipc.cc
@@ -161,7 +161,7 @@ Result<ScanTaskIterator> IpcFileFormat::ScanFile(std::shared_ptr<ScanOptions> op
 
 Status IpcFileFormat::WriteFragment(RecordBatchReader* batches,
                                     io::OutputStream* destination) const {
-  ARROW_ASSIGN_OR_RAISE(auto writer, ipc::NewFileWriter(destination, batches->schema()));
+  ARROW_ASSIGN_OR_RAISE(auto writer, ipc::MakeFileWriter(destination, batches->schema()));
 
   for (;;) {
     ARROW_ASSIGN_OR_RAISE(auto batch, batches->Next());

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -48,7 +48,7 @@ class ArrowIpcWriterMixin : public ::testing::Test {
   std::shared_ptr<Buffer> Write(RecordBatchReader* reader) {
     EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create());
 
-    EXPECT_OK_AND_ASSIGN(auto writer, ipc::NewFileWriter(sink.get(), reader->schema()));
+    EXPECT_OK_AND_ASSIGN(auto writer, ipc::MakeFileWriter(sink, reader->schema()));
 
     std::vector<std::shared_ptr<RecordBatch>> batches;
     ARROW_EXPECT_OK(reader->ReadAll(&batches));
@@ -64,7 +64,7 @@ class ArrowIpcWriterMixin : public ::testing::Test {
 
   std::shared_ptr<Buffer> Write(const Table& table) {
     EXPECT_OK_AND_ASSIGN(auto sink, io::BufferOutputStream::Create());
-    EXPECT_OK_AND_ASSIGN(auto writer, ipc::NewFileWriter(sink.get(), table.schema()));
+    EXPECT_OK_AND_ASSIGN(auto writer, ipc::MakeFileWriter(sink, table.schema()));
 
     ARROW_EXPECT_OK(writer->WriteTable(table));
 

--- a/cpp/src/arrow/dataset/filter.cc
+++ b/cpp/src/arrow/dataset/filter.cc
@@ -1408,7 +1408,7 @@ struct SerializeImpl {
     ARROW_ASSIGN_OR_RAISE(auto array, SerializeImpl{}.ToArray(expr));
     ARROW_ASSIGN_OR_RAISE(auto batch, RecordBatch::FromStructArray(array));
     ARROW_ASSIGN_OR_RAISE(auto stream, io::BufferOutputStream::Create());
-    ARROW_ASSIGN_OR_RAISE(auto writer, ipc::NewFileWriter(stream.get(), batch->schema()));
+    ARROW_ASSIGN_OR_RAISE(auto writer, ipc::MakeFileWriter(stream, batch->schema()));
     RETURN_NOT_OK(writer->WriteRecordBatch(*batch));
     RETURN_NOT_OK(writer->Close());
     return stream->Finish();

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -799,7 +799,7 @@ Status WriteTable(const Table& table, io::OutputStream* dst,
     ipc_options.compression_level = properties.compression_level;
 
     std::shared_ptr<RecordBatchWriter> writer;
-    ARROW_ASSIGN_OR_RAISE(writer, NewFileWriter(dst, table.schema(), ipc_options));
+    ARROW_ASSIGN_OR_RAISE(writer, MakeFileWriter(dst, table.schema(), ipc_options));
     RETURN_NOT_OK(writer->WriteTable(table, properties.chunksize));
     return writer->Close();
   }

--- a/cpp/src/arrow/ipc/file_to_stream.cc
+++ b/cpp/src/arrow/ipc/file_to_stream.cc
@@ -39,8 +39,8 @@ Status ConvertToStream(const char* path) {
 
   ARROW_ASSIGN_OR_RAISE(auto in_file, io::ReadableFile::Open(path));
   ARROW_ASSIGN_OR_RAISE(auto reader, ipc::RecordBatchFileReader::Open(in_file.get()));
-  ARROW_ASSIGN_OR_RAISE(auto writer, ipc::NewStreamWriter(&sink, reader->schema(),
-                                                          IpcWriteOptions::Defaults()));
+  ARROW_ASSIGN_OR_RAISE(auto writer, ipc::MakeStreamWriter(&sink, reader->schema(),
+                                                           IpcWriteOptions::Defaults()));
   for (int i = 0; i < reader->num_record_batches(); ++i) {
     ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> chunk, reader->ReadRecordBatch(i));
     RETURN_NOT_OK(writer->WriteRecordBatch(*chunk));

--- a/cpp/src/arrow/ipc/generate_fuzz_corpus.cc
+++ b/cpp/src/arrow/ipc/generate_fuzz_corpus.cc
@@ -99,9 +99,9 @@ Result<std::shared_ptr<Buffer>> SerializeRecordBatch(
   ARROW_ASSIGN_OR_RAISE(auto sink, io::BufferOutputStream::Create(1024));
   std::shared_ptr<RecordBatchWriter> writer;
   if (is_stream_format) {
-    ARROW_ASSIGN_OR_RAISE(writer, NewStreamWriter(sink.get(), batch->schema()));
+    ARROW_ASSIGN_OR_RAISE(writer, MakeStreamWriter(sink, batch->schema()));
   } else {
-    ARROW_ASSIGN_OR_RAISE(writer, NewFileWriter(sink.get(), batch->schema()));
+    ARROW_ASSIGN_OR_RAISE(writer, MakeFileWriter(sink, batch->schema()));
   }
   RETURN_NOT_OK(writer->WriteRecordBatch(*batch));
   RETURN_NOT_OK(writer->Close());

--- a/cpp/src/arrow/ipc/read_write_benchmark.cc
+++ b/cpp/src/arrow/ipc/read_write_benchmark.cc
@@ -100,7 +100,7 @@ static void ReadFile(benchmark::State& state) {  // NOLINT non-const reference
     auto record_batch = MakeRecordBatch(kTotalSize, state.range(0));
 
     io::BufferOutputStream stream(buffer);
-    auto writer = *ipc::NewFileWriter(&stream, record_batch->schema(), options);
+    auto writer = *ipc::MakeFileWriter(&stream, record_batch->schema(), options);
     ABORT_NOT_OK(writer->WriteRecordBatch(*record_batch));
     ABORT_NOT_OK(writer->Close());
     ABORT_NOT_OK(stream.Close());
@@ -131,7 +131,7 @@ static void ReadStream(benchmark::State& state) {  // NOLINT non-const reference
 
     io::BufferOutputStream stream(buffer);
 
-    auto writer_result = ipc::NewStreamWriter(&stream, record_batch->schema(), options);
+    auto writer_result = ipc::MakeStreamWriter(&stream, record_batch->schema(), options);
     ABORT_NOT_OK(writer_result);
     auto writer = *writer_result;
     ABORT_NOT_OK(writer->WriteRecordBatch(*record_batch));
@@ -167,7 +167,7 @@ static void DecodeStream(benchmark::State& state) {  // NOLINT non-const referen
 
   io::BufferOutputStream stream(buffer);
 
-  auto writer_result = ipc::NewStreamWriter(&stream, record_batch->schema(), options);
+  auto writer_result = ipc::MakeStreamWriter(&stream, record_batch->schema(), options);
   ABORT_NOT_OK(writer_result);
   auto writer = *writer_result;
   ABORT_NOT_OK(writer->WriteRecordBatch(*record_batch));

--- a/cpp/src/arrow/ipc/stream_to_file.cc
+++ b/cpp/src/arrow/ipc/stream_to_file.cc
@@ -38,7 +38,7 @@ Status ConvertToFile() {
 
   ARROW_ASSIGN_OR_RAISE(auto reader, RecordBatchStreamReader::Open(&input));
   ARROW_ASSIGN_OR_RAISE(
-      auto writer, NewFileWriter(&sink, reader->schema(), IpcWriteOptions::Defaults()));
+      auto writer, MakeFileWriter(&sink, reader->schema(), IpcWriteOptions::Defaults()));
   std::shared_ptr<RecordBatch> batch;
   while (true) {
     ARROW_ASSIGN_OR_RAISE(batch, reader->Next());

--- a/cpp/src/arrow/ipc/writer.h
+++ b/cpp/src/arrow/ipc/writer.h
@@ -97,6 +97,24 @@ class ARROW_EXPORT RecordBatchWriter {
 /// \param[in] options options for serialization
 /// \return Result<std::shared_ptr<RecordBatchWriter>>
 ARROW_EXPORT
+Result<std::shared_ptr<RecordBatchWriter>> MakeStreamWriter(
+    io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
+    const IpcWriteOptions& options = IpcWriteOptions::Defaults());
+
+/// Create a new IPC stream writer from stream sink and schema. User is
+/// responsible for closing the actual OutputStream.
+///
+/// \param[in] sink output stream to write to
+/// \param[in] schema the schema of the record batches to be written
+/// \param[in] options options for serialization
+/// \return Result<std::shared_ptr<RecordBatchWriter>>
+ARROW_EXPORT
+Result<std::shared_ptr<RecordBatchWriter>> MakeStreamWriter(
+    std::shared_ptr<io::OutputStream> sink, const std::shared_ptr<Schema>& schema,
+    const IpcWriteOptions& options = IpcWriteOptions::Defaults());
+
+ARROW_DEPRECATED("Use MakeStreamWriter")
+ARROW_EXPORT
 Result<std::shared_ptr<RecordBatchWriter>> NewStreamWriter(
     io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
     const IpcWriteOptions& options = IpcWriteOptions::Defaults());
@@ -108,6 +126,26 @@ Result<std::shared_ptr<RecordBatchWriter>> NewStreamWriter(
 /// \param[in] options options for serialization, optional
 /// \param[in] metadata custom metadata for File Footer, optional
 /// \return Result<std::shared_ptr<RecordBatchWriter>>
+ARROW_EXPORT
+Result<std::shared_ptr<RecordBatchWriter>> MakeFileWriter(
+    io::OutputStream* sink, const std::shared_ptr<Schema>& schema,
+    const IpcWriteOptions& options = IpcWriteOptions::Defaults(),
+    const std::shared_ptr<const KeyValueMetadata>& metadata = NULLPTR);
+
+/// Create a new IPC file writer from stream sink and schema
+///
+/// \param[in] sink output stream to write to
+/// \param[in] schema the schema of the record batches to be written
+/// \param[in] options options for serialization, optional
+/// \param[in] metadata custom metadata for File Footer, optional
+/// \return Result<std::shared_ptr<RecordBatchWriter>>
+ARROW_EXPORT
+Result<std::shared_ptr<RecordBatchWriter>> MakeFileWriter(
+    std::shared_ptr<io::OutputStream> sink, const std::shared_ptr<Schema>& schema,
+    const IpcWriteOptions& options = IpcWriteOptions::Defaults(),
+    const std::shared_ptr<const KeyValueMetadata>& metadata = NULLPTR);
+
+ARROW_DEPRECATED("Use MakeFileWriter")
 ARROW_EXPORT
 Result<std::shared_ptr<RecordBatchWriter>> NewFileWriter(
     io::OutputStream* sink, const std::shared_ptr<Schema>& schema,

--- a/cpp/src/arrow/testing/json_integration_test.cc
+++ b/cpp/src/arrow/testing/json_integration_test.cc
@@ -84,8 +84,8 @@ static Status ConvertJsonToArrow(const std::string& json_path,
               << reader->schema()->ToString(/* show_metadata = */ true) << std::endl;
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto writer, ipc::NewFileWriter(out_file.get(), reader->schema(),
-                                                        IpcWriteOptions::Defaults()));
+  ARROW_ASSIGN_OR_RAISE(auto writer, ipc::MakeFileWriter(out_file, reader->schema(),
+                                                         IpcWriteOptions::Defaults()));
   for (int i = 0; i < reader->num_record_batches(); ++i) {
     std::shared_ptr<RecordBatch> batch;
     RETURN_NOT_OK(reader->ReadRecordBatch(i, &batch));

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1397,12 +1397,12 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
             unique_ptr[CMessageReader] message_reader,
             const CIpcReadOptions& options)
 
-    CResult[shared_ptr[CRecordBatchWriter]] NewStreamWriter(
-        COutputStream* sink, const shared_ptr[CSchema]& schema,
+    CResult[shared_ptr[CRecordBatchWriter]] MakeStreamWriter(
+        shared_ptr[COutputStream] sink, const shared_ptr[CSchema]& schema,
         CIpcWriteOptions& options)
 
-    CResult[shared_ptr[CRecordBatchWriter]] NewFileWriter(
-        COutputStream* sink, const shared_ptr[CSchema]& schema,
+    CResult[shared_ptr[CRecordBatchWriter]] MakeFileWriter(
+        shared_ptr[COutputStream] sink, const shared_ptr[CSchema]& schema,
         CIpcWriteOptions& options)
 
     cdef cppclass CRecordBatchFileReader \

--- a/r/src/recordbatchwriter.cpp
+++ b/r/src/recordbatchwriter.cpp
@@ -48,7 +48,7 @@ std::shared_ptr<arrow::ipc::RecordBatchWriter> ipc___RecordBatchFileWriter__Open
   auto options = arrow::ipc::IpcWriteOptions::Defaults();
   options.write_legacy_ipc_format = use_legacy_format;
   options.metadata_version = metadata_version;
-  return ValueOrStop(arrow::ipc::NewFileWriter(stream.get(), schema, options));
+  return ValueOrStop(arrow::ipc::MakeFileWriter(stream, schema, options));
 }
 
 // [[arrow::export]]
@@ -59,7 +59,7 @@ std::shared_ptr<arrow::ipc::RecordBatchWriter> ipc___RecordBatchStreamWriter__Op
   auto options = arrow::ipc::IpcWriteOptions::Defaults();
   options.write_legacy_ipc_format = use_legacy_format;
   options.metadata_version = metadata_version;
-  return ValueOrStop(NewStreamWriter(stream.get(), schema, options));
+  return ValueOrStop(MakeStreamWriter(stream, schema, options));
 }
 
 #endif


### PR DESCRIPTION
Also rename `New(File|Stream)Writer` to `Make(File|Stream)Writer`