### PR TITLE
ARROW-9899: [Rust] [DataFusion] Switch from Box<Schema> --> SchemaRef (Arc<Schema>) to be consistent with the rest of Arrow

### DIFF
--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -60,7 +60,7 @@ fn get_projected_schema(
     projection: &Option<Vec<usize>>,
     required_columns: &HashSet<String>,
     has_projection: bool,
-) -> Result<(Vec<usize>, Schema)> {
+) -> Result<(Vec<usize>, SchemaRef)> {
     if projection.is_some() {
         return Err(ExecutionError::General(
             "Cannot run projection push-down rule more than once".to_string(),
@@ -103,7 +103,7 @@ fn get_projected_schema(
         projected_fields.push(schema.fields()[*i].clone());
     }
 
-    Ok((projection, Schema::new(projected_fields)))
+    Ok((projection, SchemaRef::new(Schema::new(projected_fields))))
 }
 
 /// Recursively transverses the logical plan removing expressions and that are not needed.
@@ -234,7 +234,7 @@ fn optimize_plan(
                 table_name: table_name.to_string(),
                 table_schema: table_schema.clone(),
                 projection: Some(projection),
-                projected_schema: SchemaRef::new(projected_schema),
+                projected_schema: projected_schema,
             })
         }
         LogicalPlan::InMemoryScan {
@@ -253,7 +253,7 @@ fn optimize_plan(
                 data: data.clone(),
                 schema: schema.clone(),
                 projection: Some(projection),
-                projected_schema: SchemaRef::new(projected_schema),
+                projected_schema: projected_schema,
             })
         }
         LogicalPlan::CsvScan {
@@ -277,7 +277,7 @@ fn optimize_plan(
                 schema: schema.clone(),
                 delimiter: *delimiter,
                 projection: Some(projection),
-                projected_schema: SchemaRef::new(projected_schema),
+                projected_schema: projected_schema,
             })
         }
         LogicalPlan::ParquetScan {
@@ -297,7 +297,7 @@ fn optimize_plan(
                 path: path.to_owned(),
                 schema: schema.clone(),
                 projection: Some(projection),
-                projected_schema: SchemaRef::new(projected_schema),
+                projected_schema: projected_schema,
             })
         }
         LogicalPlan::Explain {

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -22,7 +22,7 @@ use crate::error::{ExecutionError, Result};
 use crate::logical_plan::LogicalPlan;
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
-use arrow::datatypes::{Field, Schema};
+use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use std::{collections::HashSet, sync::Arc};
 use utils::optimize_explain;
@@ -154,7 +154,7 @@ fn optimize_plan(
                 Ok(LogicalPlan::Projection {
                     expr: new_expr,
                     input: Arc::new(new_input),
-                    schema: Box::new(Schema::new(new_fields)),
+                    schema: SchemaRef::new(Schema::new(new_fields)),
                 })
             }
         }
@@ -209,7 +209,7 @@ fn optimize_plan(
                     &new_required_columns,
                     true,
                 )?),
-                schema: Box::new(new_schema),
+                schema: SchemaRef::new(new_schema),
             })
         }
         // scans:
@@ -234,7 +234,7 @@ fn optimize_plan(
                 table_name: table_name.to_string(),
                 table_schema: table_schema.clone(),
                 projection: Some(projection),
-                projected_schema: Box::new(projected_schema),
+                projected_schema: SchemaRef::new(projected_schema),
             })
         }
         LogicalPlan::InMemoryScan {
@@ -253,7 +253,7 @@ fn optimize_plan(
                 data: data.clone(),
                 schema: schema.clone(),
                 projection: Some(projection),
-                projected_schema: Box::new(projected_schema),
+                projected_schema: SchemaRef::new(projected_schema),
             })
         }
         LogicalPlan::CsvScan {
@@ -277,7 +277,7 @@ fn optimize_plan(
                 schema: schema.clone(),
                 delimiter: *delimiter,
                 projection: Some(projection),
-                projected_schema: Box::new(projected_schema),
+                projected_schema: SchemaRef::new(projected_schema),
             })
         }
         LogicalPlan::ParquetScan {
@@ -297,7 +297,7 @@ fn optimize_plan(
                 path: path.to_owned(),
                 schema: schema.clone(),
                 projection: Some(projection),
-                projected_schema: Box::new(projected_schema),
+                projected_schema: SchemaRef::new(projected_schema),
             })
         }
         LogicalPlan::Explain {

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -19,7 +19,7 @@
 
 use std::{collections::HashSet, sync::Arc};
 
-use arrow::datatypes::Schema;
+use arrow::datatypes::{Schema, SchemaRef};
 
 use super::optimizer::OptimizerRule;
 use crate::error::{ExecutionError, Result};
@@ -89,7 +89,7 @@ pub fn optimize_explain(
         PlanType::OptimizedLogicalPlan { optimizer_name },
         format!("{:#?}", plan),
     ));
-    let schema = Box::new(schema.clone());
+    let schema = SchemaRef::new(schema.clone());
 
     Ok(LogicalPlan::Explain {
         verbose,

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -128,7 +128,7 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
             FileType::NdJson => {}
         };
 
-        let schema = Box::new(self.build_schema(&columns)?);
+        let schema = SchemaRef::new(self.build_schema(&columns)?);
 
         Ok(LogicalPlan::CreateExternalTable {
             schema,


### PR DESCRIPTION
This PR proposes using `SchemaRef` (which is an `Arc<Schema>`) instead of `Box<Schema> `inside Datafusion to be consistent with the rest of the arrow implementation, avoid so many copies, and make the code simpler.

A pretty good example of the simplification is:

*before*:
```
projected_schema: Box::new(csv.schema().as_ref().to_owned()),
```

*after*:
```
projected_schema: csv.schema().clone()),
```

This code is not only clearer to understand in my opinion, it is also likely faster (it is a clone of an `Arc` (and an increment of a refcount) rather than a clone of the actual `Schema` itself)
