### PR TITLE
ARROW-9873: [C++][Compute] Optimize mode kernel for integers in small value range

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_mode.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -27,7 +27,7 @@ namespace aggregate {
 namespace {
 
 template <typename ArrayType, typename Visitor>
-inline void VisitArrayInline(const ArrayType& array, Visitor&& visitor) {
+inline void VisitArrayNonNullValuesInline(const ArrayType& array, Visitor&& visitor) {
   if (array.length() == array.null_count()) {
     return;
   }
@@ -57,7 +57,7 @@ enable_if_t<std::is_floating_point<CType>::value, CounterMap<CType>> CountValues
   CounterMap<CType> value_counts_map;
 
   nan_count = 0;
-  VisitArrayInline(array, [&](CType value) {
+  VisitArrayNonNullValuesInline(array, [&](CType value) {
     if (std::isnan(value)) {
       ++nan_count;
     } else {
@@ -74,7 +74,7 @@ enable_if_t<!std::is_floating_point<CType>::value, CounterMap<CType>> CountValue
     const ArrayType& array) {
   CounterMap<CType> value_counts_map;
 
-  VisitArrayInline(array, [&](CType value) { ++value_counts_map[value]; });
+  VisitArrayNonNullValuesInline(array, [&](CType value) { ++value_counts_map[value]; });
 
   return value_counts_map;
 }
@@ -86,7 +86,8 @@ CounterMap<CType> CountValuesByVector(const ArrayType& array, CType min, CType m
   DCHECK(range >= 0 && range < 64 * 1024 * 1024);
 
   std::vector<int64_t> value_counts_vector(range + 1);
-  VisitArrayInline(array, [&](CType value) { ++value_counts_vector[value - min]; });
+  VisitArrayNonNullValuesInline(array,
+                                [&](CType value) { ++value_counts_vector[value - min]; });
 
   // Transfer value counts to a map to be consistent with other chunks
   CounterMap<CType> value_counts_map(range + 1);
@@ -112,7 +113,7 @@ CounterMap<CType> CountValuesByMapOrVector(const ArrayType& array) {
     CType min = std::numeric_limits<CType>::max();
     CType max = std::numeric_limits<CType>::min();
 
-    VisitArrayInline(array, [&](CType value) {
+    VisitArrayNonNullValuesInline(array, [&](CType value) {
       min = std::min(min, value);
       max = std::max(max, value);
     });

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -730,14 +730,15 @@ TYPED_TEST(TestRandomNumericMinMaxKernel, RandomArrayMinMax) {
 // Mode
 //
 
-template <typename ArrowType>
+template <typename T>
 class TestPrimitiveModeKernel : public ::testing::Test {
+ public:
+  using ArrowType = T;
   using Traits = TypeTraits<ArrowType>;
   using c_type = typename ArrowType::c_type;
   using ModeType = typename Traits::ScalarType;
   using CountType = typename TypeTraits<Int64Type>::ScalarType;
 
- public:
   void AssertModeIs(const Datum& array, c_type expected_mode, int64_t expected_count) {
     ASSERT_OK_AND_ASSIGN(Datum out, Mode(array));
     const StructScalar& value = out.scalar_as<StructScalar>();
@@ -798,6 +799,8 @@ class TestBooleanModeKernel : public TestPrimitiveModeKernel<BooleanType> {};
 
 class TestInt8ModeKernelValueRange : public TestPrimitiveModeKernel<Int8Type> {};
 
+class TestInt32ModeKernel : public TestPrimitiveModeKernel<Int32Type> {};
+
 TEST_F(TestBooleanModeKernel, Basics) {
   this->AssertModeIs("[false, false]", false, 2);
   this->AssertModeIs("[false, false, true, true, true]", true, 3);
@@ -843,51 +846,72 @@ TEST_F(TestInt8ModeKernelValueRange, Basics) {
   this->AssertModeIs("[127, 127, 127]", 127, 3);
 }
 
-class TestCountingModeKernel : public ::testing::Test {};
+template <typename ArrowType>
+struct ModeResult {
+  using T = typename ArrowType::c_type;
 
-// Test counting based mode kernel (long integer array with small value range)
-TEST_F(TestCountingModeKernel, RandomArrayMode) {
-  using ArrowType = Int32Type;
+  T mode = std::numeric_limits<T>::min();
+  int64_t count = 0;
+};
+
+template <typename ArrowType>
+ModeResult<ArrowType> NaiveMode(const Array& array) {
   using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
   using CTYPE = typename ArrowType::c_type;
-  using ModeType = typename TypeTraits<ArrowType>::ScalarType;
-  using CountType = typename TypeTraits<Int64Type>::ScalarType;
 
-  auto rand = random::RandomArrayGenerator(0x5487655);
-  // 256K items within -100 ~ 100, 10% null
-  auto array = rand.Numeric<ArrowType>(256 * 1024, -100, 100, 0.1);
-  ASSERT_OK_AND_ASSIGN(Datum out, Mode(array));
-  const StructScalar& value = out.scalar_as<StructScalar>();
-  const auto& out_mode = checked_cast<const ModeType&>(*value.value[0]);
-  const auto& out_count = checked_cast<const CountType&>(*value.value[1]);
-
-  // caculate mode naively
   std::unordered_map<CTYPE, int64_t> value_counts;
-  const auto& array_numeric = reinterpret_cast<const ArrayType&>(*array);
+
+  const auto& array_numeric = reinterpret_cast<const ArrayType&>(array);
   const auto values = array_numeric.raw_values();
-  internal::BitmapReader reader(array->null_bitmap_data(), array->offset(),
-                                array->length());
-  for (int64_t i = 0; i < array->length(); ++i) {
+  internal::BitmapReader reader(array.null_bitmap_data(), array.offset(), array.length());
+  for (int64_t i = 0; i < array.length(); ++i) {
     if (reader.IsSet()) {
       ++value_counts[values[i]];
     }
     reader.Next();
   }
 
-  CTYPE expected_mode = std::numeric_limits<CTYPE>::min();
-  int64_t expected_count = 0;
+  ModeResult<ArrowType> result;
   for (const auto& value_count : value_counts) {
     auto value = value_count.first;
     auto count = value_count.second;
-    if (count > expected_count || (count == expected_count && value < expected_mode)) {
-      expected_count = count;
-      expected_mode = value;
+    if (count > result.count || (count == result.count && value < result.mode)) {
+      result.count = count;
+      result.mode = value;
     }
   }
 
-  // validate mode
-  ASSERT_EQ(expected_mode, out_mode.value);
-  ASSERT_EQ(expected_count, out_count.value);
+  return result;
+}
+
+template <typename ArrowType, typename CTYPE = typename ArrowType::c_type>
+void CheckModeWithRange(CTYPE range_min, CTYPE range_max) {
+  using ModeScalar = typename TypeTraits<ArrowType>::ScalarType;
+  using CountScalar = typename TypeTraits<Int64Type>::ScalarType;
+
+  auto rand = random::RandomArrayGenerator(0x5487655);
+  // 32K items (>= counting mode cutoff) within range, 10% null
+  auto array = rand.Numeric<ArrowType>(32 * 1024, range_min, range_max, 0.1);
+
+  auto expected = NaiveMode<ArrowType>(*array);
+  ASSERT_OK_AND_ASSIGN(Datum out, Mode(array));
+  const StructScalar& value = out.scalar_as<StructScalar>();
+
+  ASSERT_TRUE(value.is_valid);
+  const auto& out_mode = checked_cast<const ModeScalar&>(*value.value[0]);
+  const auto& out_count = checked_cast<const CountScalar&>(*value.value[1]);
+  ASSERT_EQ(out_mode.value, expected.mode);
+  ASSERT_EQ(out_count.value, expected.count);
+}
+
+TEST_F(TestInt32ModeKernel, SmallValueRange) {
+  // Small value range => should exercise counter-based Mode implementation
+  CheckModeWithRange<ArrowType>(-100, 100);
+}
+
+TEST_F(TestInt32ModeKernel, LargeValueRange) {
+  // Large value range => should exercise hashmap-based Mode implementation
+  CheckModeWithRange<ArrowType>(-10000000, 10000000);
 }
 
 }  // namespace compute


### PR DESCRIPTION
For int16/32/64 arrays with reasonable length, scan the array to find
min/max values first. If (max-min) is within some threshold, instead
of general hashmap, using a value indexed array can improve performance
significantly.

To be compatible with chunked array, value count array is transferred to
hashmap before merging with others. This is an overhead for short array.
Finding min/max may also introduce performance penalty in some cases.

Please note it's hard to benefit all use cases. By applying this patch:
- about 2x performance uplift for integers in small value range
- no obvious performance drop for normal cases
- non-trivial performance drop in some cases
  * 40% drop for short int8 array (8k length)
  * 10% drop for sparse array (few distinct values, big value gap)