### PR TITLE
ARROW-9895: [Rust] Improve sorting kernels

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -2358,10 +2358,10 @@ impl<T: ArrowPrimitiveType> From<ArrayDataRef> for DictionaryArray<T> {
 }
 
 /// Constructs a `DictionaryArray` from an iterator of optional strings.
-impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'static str>>
+impl<'a, T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'a str>>
     for DictionaryArray<T>
 {
-    fn from_iter<I: IntoIterator<Item = Option<&'static str>>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = Option<&'a str>>>(iter: I) -> Self {
         let it = iter.into_iter();
         let (lower, _) = it.size_hint();
         let key_builder = PrimitiveBuilder::<T>::new(lower);
@@ -2386,10 +2386,10 @@ impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<Option<&'stati
 }
 
 /// Constructs a `DictionaryArray` from an iterator of strings.
-impl<T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<&'static str>
+impl<'a, T: ArrowPrimitiveType + ArrowDictionaryKeyType> FromIterator<&'a str>
     for DictionaryArray<T>
 {
-    fn from_iter<I: IntoIterator<Item = &'static str>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> Self {
         let it = iter.into_iter();
         let (lower, _) = it.size_hint();
         let key_builder = PrimitiveBuilder::<T>::new(lower);

--- a/rust/arrow/src/array/cast.rs
+++ b/rust/arrow/src/array/cast.rs
@@ -30,6 +30,16 @@ where
         .expect("Unable to downcast to primitive array")
 }
 
+/// Force downcast ArrayRef to DictionaryArray<T>
+pub fn as_dictionary_array<T>(arr: &ArrayRef) -> &DictionaryArray<T>
+where
+    T: ArrowDictionaryKeyType,
+{
+    arr.as_any()
+        .downcast_ref::<DictionaryArray<T>>()
+        .expect("Unable to downcast to dictionary array")
+}
+
 macro_rules! array_downcast_fn {
     ($name: ident, $arrty: ty, $arrty_str:expr) => {
         #[doc = "Force downcast ArrayRef to "]

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -249,5 +249,6 @@ pub use self::ord::{as_ordarray, OrdArray};
 // --------------------- Array downcast helper functions ---------------------
 
 pub use self::cast::{
-    as_boolean_array, as_null_array, as_primitive_array, as_string_array,
+    as_boolean_array, as_dictionary_array, as_null_array, as_primitive_array,
+    as_string_array,
 };

--- a/rust/arrow/src/array/ord.rs
+++ b/rust/arrow/src/array/ord.rs
@@ -42,9 +42,21 @@ use TimeUnit::*;
 ///
 /// assert_eq!(arr.cmp_value(1, 2), Ordering::Greater);
 /// ```
-pub trait OrdArray: Array {
+pub trait OrdArray {
     /// Return ordering between array element at index i and j
     fn cmp_value(&self, i: usize, j: usize) -> Ordering;
+}
+
+impl<T: OrdArray> OrdArray for Box<T> {
+    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
+        T::cmp_value(self, i, j)
+    }
+}
+
+impl<T: OrdArray> OrdArray for &T {
+    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
+        T::cmp_value(self, i, j)
+    }
 }
 
 impl<T: ArrowPrimitiveType> OrdArray for PrimitiveArray<T>
@@ -68,65 +80,232 @@ impl OrdArray for NullArray {
     }
 }
 
+macro_rules! float_ord_cmp {
+    ($NAME: ident, $T: ty) => {
+        #[inline]
+        fn $NAME(a: $T, b: $T) -> Ordering {
+            if a < b {
+                return Ordering::Less;
+            }
+            if a > b {
+                return Ordering::Greater;
+            }
+
+            // convert to bits with canonical pattern for NaN
+            let a = if a.is_nan() {
+                <$T>::NAN.to_bits()
+            } else {
+                a.to_bits()
+            };
+            let b = if b.is_nan() {
+                <$T>::NAN.to_bits()
+            } else {
+                b.to_bits()
+            };
+
+            if a == b {
+                // Equal or both NaN
+                Ordering::Equal
+            } else if a < b {
+                // (-0.0, 0.0) or (!NaN, NaN)
+                Ordering::Less
+            } else {
+                // (0.0, -0.0) or (NaN, !NaN)
+                Ordering::Greater
+            }
+        }
+    };
+}
+
+float_ord_cmp!(cmp_f64, f64);
+float_ord_cmp!(cmp_f32, f32);
+
+#[repr(transparent)]
+struct Float64ArrayAsOrdArray<'a>(&'a Float64Array);
+#[repr(transparent)]
+struct Float32ArrayAsOrdArray<'a>(&'a Float32Array);
+
+impl OrdArray for Float64ArrayAsOrdArray<'_> {
+    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
+        let a: f64 = self.0.value(i);
+        let b: f64 = self.0.value(j);
+
+        cmp_f64(a, b)
+    }
+}
+
+impl OrdArray for Float32ArrayAsOrdArray<'_> {
+    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
+        let a: f32 = self.0.value(i);
+        let b: f32 = self.0.value(j);
+
+        cmp_f32(a, b)
+    }
+}
+
+fn float32_as_ord_array<'a>(array: &'a ArrayRef) -> Box<dyn OrdArray + 'a> {
+    let float_array: &Float32Array = as_primitive_array::<Float32Type>(array);
+    Box::new(Float32ArrayAsOrdArray(float_array))
+}
+
+fn float64_as_ord_array<'a>(array: &'a ArrayRef) -> Box<dyn OrdArray + 'a> {
+    let float_array: &Float64Array = as_primitive_array::<Float64Type>(array);
+    Box::new(Float64ArrayAsOrdArray(float_array))
+}
+
+struct StringDictionaryArrayAsOrdArray<'a, T: ArrowDictionaryKeyType> {
+    dict_array: &'a DictionaryArray<T>,
+    values: StringArray,
+    keys: PrimitiveArray<T>,
+}
+
+impl<T: ArrowDictionaryKeyType> OrdArray for StringDictionaryArrayAsOrdArray<'_, T> {
+    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
+        let keys = &self.keys;
+        let dict = &self.values;
+
+        let key_a: T::Native = keys.value(i);
+        let key_b: T::Native = keys.value(j);
+
+        let str_a = dict.value(key_a.to_usize().unwrap());
+        let str_b = dict.value(key_b.to_usize().unwrap());
+
+        str_a.cmp(str_b)
+    }
+}
+
+fn string_dict_as_ord_array<'a, T: ArrowDictionaryKeyType>(
+    array: &'a ArrayRef,
+) -> Box<dyn OrdArray + 'a>
+where
+    T::Native: std::cmp::Ord,
+{
+    let dict_array = as_dictionary_array::<T>(array);
+    let keys = dict_array.keys_array();
+
+    let values = &dict_array.values();
+    let values = StringArray::from(values.data());
+
+    Box::new(StringDictionaryArrayAsOrdArray {
+        dict_array,
+        values,
+        keys,
+    })
+}
+
 /// Convert ArrayRef to OrdArray trait object
-pub fn as_ordarray(values: &ArrayRef) -> Result<&OrdArray> {
+pub fn as_ordarray<'a>(values: &'a ArrayRef) -> Result<Box<OrdArray + 'a>> {
     match values.data_type() {
-        DataType::Boolean => Ok(as_boolean_array(&values)),
-        DataType::Utf8 => Ok(as_string_array(&values)),
-        DataType::Null => Ok(as_null_array(&values)),
-        DataType::Int8 => Ok(as_primitive_array::<Int8Type>(&values)),
-        DataType::Int16 => Ok(as_primitive_array::<Int16Type>(&values)),
-        DataType::Int32 => Ok(as_primitive_array::<Int32Type>(&values)),
-        DataType::Int64 => Ok(as_primitive_array::<Int64Type>(&values)),
-        DataType::UInt8 => Ok(as_primitive_array::<UInt8Type>(&values)),
-        DataType::UInt16 => Ok(as_primitive_array::<UInt16Type>(&values)),
-        DataType::UInt32 => Ok(as_primitive_array::<UInt32Type>(&values)),
-        DataType::UInt64 => Ok(as_primitive_array::<UInt64Type>(&values)),
-        DataType::Date32(_) => Ok(as_primitive_array::<Date32Type>(&values)),
-        DataType::Date64(_) => Ok(as_primitive_array::<Date64Type>(&values)),
-        DataType::Time32(Second) => Ok(as_primitive_array::<Time32SecondType>(&values)),
-        DataType::Time32(Millisecond) => {
-            Ok(as_primitive_array::<Time32MillisecondType>(&values))
+        DataType::Boolean => Ok(Box::new(as_boolean_array(&values))),
+        DataType::Utf8 => Ok(Box::new(as_string_array(&values))),
+        DataType::Null => Ok(Box::new(as_null_array(&values))),
+        DataType::Int8 => Ok(Box::new(as_primitive_array::<Int8Type>(&values))),
+        DataType::Int16 => Ok(Box::new(as_primitive_array::<Int16Type>(&values))),
+        DataType::Int32 => Ok(Box::new(as_primitive_array::<Int32Type>(&values))),
+        DataType::Int64 => Ok(Box::new(as_primitive_array::<Int64Type>(&values))),
+        DataType::UInt8 => Ok(Box::new(as_primitive_array::<UInt8Type>(&values))),
+        DataType::UInt16 => Ok(Box::new(as_primitive_array::<UInt16Type>(&values))),
+        DataType::UInt32 => Ok(Box::new(as_primitive_array::<UInt32Type>(&values))),
+        DataType::UInt64 => Ok(Box::new(as_primitive_array::<UInt64Type>(&values))),
+        DataType::Date32(_) => Ok(Box::new(as_primitive_array::<Date32Type>(&values))),
+        DataType::Date64(_) => Ok(Box::new(as_primitive_array::<Date64Type>(&values))),
+        DataType::Time32(Second) => {
+            Ok(Box::new(as_primitive_array::<Time32SecondType>(&values)))
         }
-        DataType::Time64(Microsecond) => {
-            Ok(as_primitive_array::<Time64MicrosecondType>(&values))
-        }
-        DataType::Time64(Nanosecond) => {
-            Ok(as_primitive_array::<Time64NanosecondType>(&values))
-        }
+        DataType::Time32(Millisecond) => Ok(Box::new(as_primitive_array::<
+            Time32MillisecondType,
+        >(&values))),
+        DataType::Time64(Microsecond) => Ok(Box::new(as_primitive_array::<
+            Time64MicrosecondType,
+        >(&values))),
+        DataType::Time64(Nanosecond) => Ok(Box::new(as_primitive_array::<
+            Time64NanosecondType,
+        >(&values))),
         DataType::Timestamp(Second, _) => {
-            Ok(as_primitive_array::<TimestampSecondType>(&values))
+            Ok(Box::new(as_primitive_array::<TimestampSecondType>(&values)))
         }
-        DataType::Timestamp(Millisecond, _) => {
-            Ok(as_primitive_array::<TimestampMillisecondType>(&values))
-        }
-        DataType::Timestamp(Microsecond, _) => {
-            Ok(as_primitive_array::<TimestampMicrosecondType>(&values))
-        }
-        DataType::Timestamp(Nanosecond, _) => {
-            Ok(as_primitive_array::<TimestampNanosecondType>(&values))
-        }
-        DataType::Interval(IntervalUnit::YearMonth) => {
-            Ok(as_primitive_array::<IntervalYearMonthType>(&values))
-        }
+        DataType::Timestamp(Millisecond, _) => Ok(Box::new(as_primitive_array::<
+            TimestampMillisecondType,
+        >(&values))),
+        DataType::Timestamp(Microsecond, _) => Ok(Box::new(as_primitive_array::<
+            TimestampMicrosecondType,
+        >(&values))),
+        DataType::Timestamp(Nanosecond, _) => Ok(Box::new(as_primitive_array::<
+            TimestampNanosecondType,
+        >(&values))),
+        DataType::Interval(IntervalUnit::YearMonth) => Ok(Box::new(
+            as_primitive_array::<IntervalYearMonthType>(&values),
+        )),
         DataType::Interval(IntervalUnit::DayTime) => {
-            Ok(as_primitive_array::<IntervalDayTimeType>(&values))
+            Ok(Box::new(as_primitive_array::<IntervalDayTimeType>(&values)))
         }
         DataType::Duration(TimeUnit::Second) => {
-            Ok(as_primitive_array::<DurationSecondType>(&values))
+            Ok(Box::new(as_primitive_array::<DurationSecondType>(&values)))
         }
-        DataType::Duration(TimeUnit::Millisecond) => {
-            Ok(as_primitive_array::<DurationMillisecondType>(&values))
-        }
-        DataType::Duration(TimeUnit::Microsecond) => {
-            Ok(as_primitive_array::<DurationMicrosecondType>(&values))
-        }
-        DataType::Duration(TimeUnit::Nanosecond) => {
-            Ok(as_primitive_array::<DurationNanosecondType>(&values))
+        DataType::Duration(TimeUnit::Millisecond) => Ok(Box::new(as_primitive_array::<
+            DurationMillisecondType,
+        >(&values))),
+        DataType::Duration(TimeUnit::Microsecond) => Ok(Box::new(as_primitive_array::<
+            DurationMicrosecondType,
+        >(&values))),
+        DataType::Duration(TimeUnit::Nanosecond) => Ok(Box::new(as_primitive_array::<
+            DurationNanosecondType,
+        >(&values))),
+        DataType::Float32 => Ok(float32_as_ord_array(&values)),
+        DataType::Float64 => Ok(float64_as_ord_array(&values)),
+        DataType::Dictionary(key_type, value_type)
+            if *value_type.as_ref() == DataType::Utf8 =>
+        {
+            match key_type.as_ref() {
+                DataType::Int8 => Ok(string_dict_as_ord_array::<Int8Type>(values)),
+                DataType::Int16 => Ok(string_dict_as_ord_array::<Int16Type>(values)),
+                DataType::Int32 => Ok(string_dict_as_ord_array::<Int32Type>(values)),
+                DataType::Int64 => Ok(string_dict_as_ord_array::<Int64Type>(values)),
+                DataType::UInt8 => Ok(string_dict_as_ord_array::<UInt8Type>(values)),
+                DataType::UInt16 => Ok(string_dict_as_ord_array::<UInt16Type>(values)),
+                DataType::UInt32 => Ok(string_dict_as_ord_array::<UInt32Type>(values)),
+                DataType::UInt64 => Ok(string_dict_as_ord_array::<UInt64Type>(values)),
+                t => Err(ArrowError::ComputeError(format!(
+                    "Lexical Sort not supported for dictionary key type {:?}",
+                    t
+                ))),
+            }
         }
         t => Err(ArrowError::ComputeError(format!(
             "Lexical Sort not supported for data type {:?}",
             t
         ))),
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::array::{as_ordarray, ArrayRef, DictionaryArray, Float64Array};
+    use crate::datatypes::Int16Type;
+    use std::cmp::Ordering;
+    use std::iter::FromIterator;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_float64_as_ord_array() {
+        let array = Float64Array::from(vec![1.0, 2.0, 3.0, f64::NAN]);
+        let array_ref: ArrayRef = Arc::new(array);
+
+        let ord_array = as_ordarray(&array_ref).unwrap();
+
+        assert_eq!(Ordering::Less, ord_array.cmp_value(0, 1));
+    }
+
+    #[test]
+    fn test_dict_as_ord_array() {
+        let data = vec!["a", "b", "c", "a", "a", "c", "c"];
+        let array = DictionaryArray::<Int16Type>::from_iter(data.into_iter());
+        let array_ref: ArrayRef = Arc::new(array);
+
+        let ord_array = as_ordarray(&array_ref).unwrap();
+
+        assert_eq!(Ordering::Less, ord_array.cmp_value(0, 1));
+        assert_eq!(Ordering::Equal, ord_array.cmp_value(3, 4));
+        assert_eq!(Ordering::Greater, ord_array.cmp_value(2, 3));
     }
 }

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -24,104 +24,163 @@ use crate::compute::take;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 
+use crate::buffer::MutableBuffer;
+use num::ToPrimitive;
+use std::sync::Arc;
 use TimeUnit::*;
 
 /// Sort the `ArrayRef` using `SortOptions`.
 ///
-/// Performs a stable sort on values and indices, returning nulls after sorted valid values,
-/// while preserving the order of the nulls.
+/// Performs a stable sort on values and indices. Nulls are ordered according to the `nulls_first` flag in `options`.
+/// For floating point arrays any NaN values are considered to be greater than any other non-null value.
 ///
 /// Returns an `ArrowError::ComputeError(String)` if the array type is either unsupported by `sort_to_indices` or `take`.
 ///
-/// Null float values (e.g. f64::NAN) are sorted with non-null values, and are ordered higher than other values.
 pub fn sort(values: &ArrayRef, options: Option<SortOptions>) -> Result<ArrayRef> {
     let indices = sort_to_indices(values, options)?;
     take(values, &indices, None)
 }
 
-/// Sort elements from `ArrayRef` into an unsigned integer (`UInt32Array`) of indices
+/// Sort elements from `ArrayRef` into an unsigned integer (`UInt32Array`) of indices.
+/// For floating point arrays any NaN values are considered to be greater than any other non-null value
 pub fn sort_to_indices(
     values: &ArrayRef,
     options: Option<SortOptions>,
 ) -> Result<UInt32Array> {
     let options = options.unwrap_or_default();
-    let range = values.offset()..values.len();
-    // perform a custom range partition for floats, to account for NaN
-    let (v, n): (Vec<usize>, Vec<usize>) = if values.data_type() == &DataType::Float32 {
-        let array = values
-            .as_any()
-            .downcast_ref::<Float32Array>()
-            .expect("Unable to downcast array");
-        #[allow(clippy::cmp_nan)]
-        range.partition(|index| array.is_valid(*index) && array.value(*index) != f32::NAN)
-    } else if values.data_type() == &DataType::Float64 {
-        let array = values
-            .as_any()
-            .downcast_ref::<Float64Array>()
-            .expect("Unable to downcast array");
-        #[allow(clippy::cmp_nan)]
-        range.partition(|index| array.is_valid(*index) && array.value(*index) != f64::NAN)
-    } else {
-        range.partition(|index| values.is_valid(*index))
-    };
-    let n = n.into_iter().map(|i| i as u32).collect();
+    let indices = 0..(values.len().to_u32().ok_or_else(|| {
+        ArrowError::ComputeError(
+            "Sorting currently only supports u32 indices".to_string(),
+        )
+    })?);
+    // partition indices into valid (`v`) and null (`n` indices
+    // for floating point types the valid indices are further partioned into non-NaN and NaN
+    let (v, n, nan): (Vec<u32>, Vec<u32>, Vec<u32>) =
+        if values.data_type() == &DataType::Float32 {
+            let array = values
+                .as_any()
+                .downcast_ref::<Float32Array>()
+                .expect("Unable to downcast array");
+            let (v, n): (Vec<u32>, Vec<u32>) =
+                indices.partition(|index| array.is_valid(*index as usize));
+            let has_nan = v.iter().any(|index| array.value(*index as usize).is_nan());
+            let (v, nan) = if has_nan {
+                v.into_iter()
+                    .partition(|index| !array.value(*index as usize).is_nan())
+            } else {
+                (v, vec![])
+            };
+            (v, n, nan)
+        } else if values.data_type() == &DataType::Float64 {
+            let array = values
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .expect("Unable to downcast array");
+            let (v, n): (Vec<u32>, Vec<u32>) =
+                indices.partition(|index| array.is_valid(*index as usize));
+            let has_nan = v.iter().any(|index| array.value(*index as usize).is_nan());
+            let (v, nan) = if has_nan {
+                v.into_iter()
+                    .partition(|index| !array.value(*index as usize).is_nan())
+            } else {
+                (v, vec![])
+            };
+            (v, n, nan)
+        } else {
+            let (v, n) = indices.partition(|index| values.is_valid(*index as usize));
+            (v, n, vec![])
+        };
     match values.data_type() {
-        DataType::Boolean => sort_primitive::<BooleanType>(values, v, n, &options),
-        DataType::Int8 => sort_primitive::<Int8Type>(values, v, n, &options),
-        DataType::Int16 => sort_primitive::<Int16Type>(values, v, n, &options),
-        DataType::Int32 => sort_primitive::<Int32Type>(values, v, n, &options),
-        DataType::Int64 => sort_primitive::<Int64Type>(values, v, n, &options),
-        DataType::UInt8 => sort_primitive::<UInt8Type>(values, v, n, &options),
-        DataType::UInt16 => sort_primitive::<UInt16Type>(values, v, n, &options),
-        DataType::UInt32 => sort_primitive::<UInt32Type>(values, v, n, &options),
-        DataType::UInt64 => sort_primitive::<UInt64Type>(values, v, n, &options),
-        DataType::Float32 => sort_primitive::<Float32Type>(values, v, n, &options),
-        DataType::Float64 => sort_primitive::<Float64Type>(values, v, n, &options),
-        DataType::Date32(_) => sort_primitive::<Date32Type>(values, v, n, &options),
-        DataType::Date64(_) => sort_primitive::<Date64Type>(values, v, n, &options),
+        DataType::Boolean => sort_primitive::<BooleanType>(values, v, n, nan, &options),
+        DataType::Int8 => sort_primitive::<Int8Type>(values, v, n, nan, &options),
+        DataType::Int16 => sort_primitive::<Int16Type>(values, v, n, nan, &options),
+        DataType::Int32 => sort_primitive::<Int32Type>(values, v, n, nan, &options),
+        DataType::Int64 => sort_primitive::<Int64Type>(values, v, n, nan, &options),
+        DataType::UInt8 => sort_primitive::<UInt8Type>(values, v, n, nan, &options),
+        DataType::UInt16 => sort_primitive::<UInt16Type>(values, v, n, nan, &options),
+        DataType::UInt32 => sort_primitive::<UInt32Type>(values, v, n, nan, &options),
+        DataType::UInt64 => sort_primitive::<UInt64Type>(values, v, n, nan, &options),
+        DataType::Float32 => sort_primitive::<Float32Type>(values, v, n, nan, &options),
+        DataType::Float64 => sort_primitive::<Float64Type>(values, v, n, nan, &options),
+        DataType::Date32(_) => sort_primitive::<Date32Type>(values, v, n, nan, &options),
+        DataType::Date64(_) => sort_primitive::<Date64Type>(values, v, n, nan, &options),
         DataType::Time32(Second) => {
-            sort_primitive::<Time32SecondType>(values, v, n, &options)
+            sort_primitive::<Time32SecondType>(values, v, n, nan, &options)
         }
         DataType::Time32(Millisecond) => {
-            sort_primitive::<Time32MillisecondType>(values, v, n, &options)
+            sort_primitive::<Time32MillisecondType>(values, v, n, nan, &options)
         }
         DataType::Time64(Microsecond) => {
-            sort_primitive::<Time64MicrosecondType>(values, v, n, &options)
+            sort_primitive::<Time64MicrosecondType>(values, v, n, nan, &options)
         }
         DataType::Time64(Nanosecond) => {
-            sort_primitive::<Time64NanosecondType>(values, v, n, &options)
+            sort_primitive::<Time64NanosecondType>(values, v, n, nan, &options)
         }
         DataType::Timestamp(Second, _) => {
-            sort_primitive::<TimestampSecondType>(values, v, n, &options)
+            sort_primitive::<TimestampSecondType>(values, v, n, nan, &options)
         }
         DataType::Timestamp(Millisecond, _) => {
-            sort_primitive::<TimestampMillisecondType>(values, v, n, &options)
+            sort_primitive::<TimestampMillisecondType>(values, v, n, nan, &options)
         }
         DataType::Timestamp(Microsecond, _) => {
-            sort_primitive::<TimestampMicrosecondType>(values, v, n, &options)
+            sort_primitive::<TimestampMicrosecondType>(values, v, n, nan, &options)
         }
         DataType::Timestamp(Nanosecond, _) => {
-            sort_primitive::<TimestampNanosecondType>(values, v, n, &options)
+            sort_primitive::<TimestampNanosecondType>(values, v, n, nan, &options)
         }
         DataType::Interval(IntervalUnit::YearMonth) => {
-            sort_primitive::<IntervalYearMonthType>(values, v, n, &options)
+            sort_primitive::<IntervalYearMonthType>(values, v, n, nan, &options)
         }
         DataType::Interval(IntervalUnit::DayTime) => {
-            sort_primitive::<IntervalDayTimeType>(values, v, n, &options)
+            sort_primitive::<IntervalDayTimeType>(values, v, n, nan, &options)
         }
         DataType::Duration(TimeUnit::Second) => {
-            sort_primitive::<DurationSecondType>(values, v, n, &options)
+            sort_primitive::<DurationSecondType>(values, v, n, nan, &options)
         }
         DataType::Duration(TimeUnit::Millisecond) => {
-            sort_primitive::<DurationMillisecondType>(values, v, n, &options)
+            sort_primitive::<DurationMillisecondType>(values, v, n, nan, &options)
         }
         DataType::Duration(TimeUnit::Microsecond) => {
-            sort_primitive::<DurationMicrosecondType>(values, v, n, &options)
+            sort_primitive::<DurationMicrosecondType>(values, v, n, nan, &options)
         }
         DataType::Duration(TimeUnit::Nanosecond) => {
-            sort_primitive::<DurationNanosecondType>(values, v, n, &options)
+            sort_primitive::<DurationNanosecondType>(values, v, n, nan, &options)
         }
         DataType::Utf8 => sort_string(values, v, n, &options),
+        DataType::Dictionary(key_type, value_type)
+            if *value_type.as_ref() == DataType::Utf8 =>
+        {
+            match key_type.as_ref() {
+                DataType::Int8 => {
+                    sort_string_dictionary::<Int8Type>(values, v, n, &options)
+                }
+                DataType::Int16 => {
+                    sort_string_dictionary::<Int16Type>(values, v, n, &options)
+                }
+                DataType::Int32 => {
+                    sort_string_dictionary::<Int32Type>(values, v, n, &options)
+                }
+                DataType::Int64 => {
+                    sort_string_dictionary::<Int64Type>(values, v, n, &options)
+                }
+                DataType::UInt8 => {
+                    sort_string_dictionary::<UInt8Type>(values, v, n, &options)
+                }
+                DataType::UInt16 => {
+                    sort_string_dictionary::<UInt16Type>(values, v, n, &options)
+                }
+                DataType::UInt32 => {
+                    sort_string_dictionary::<UInt32Type>(values, v, n, &options)
+                }
+                DataType::UInt64 => {
+                    sort_string_dictionary::<UInt64Type>(values, v, n, &options)
+                }
+                t => Err(ArrowError::ComputeError(format!(
+                    "Sort not supported for dictionary key type {:?}",
+                    t
+                ))),
+            }
+        }
         t => Err(ArrowError::ComputeError(format!(
             "Sort not supported for data type {:?}",
             t
@@ -148,11 +207,12 @@ impl Default for SortOptions {
     }
 }
 
-/// Sort primitive values, excluding floats
+/// Sort primitive values
 fn sort_primitive<T>(
     values: &ArrayRef,
-    value_indices: Vec<usize>,
+    value_indices: Vec<u32>,
     null_indices: Vec<u32>,
+    nan_indices: Vec<u32>,
     options: &SortOptions,
 ) -> Result<UInt32Array>
 where
@@ -160,46 +220,154 @@ where
     T::Native: std::cmp::PartialOrd,
 {
     let values = as_primitive_array::<T>(values);
+    let descending = options.descending;
+
     // create tuples that are used for sorting
     let mut valids = value_indices
         .into_iter()
-        .map(|index| (index as u32, values.value(index)))
+        .map(|index| (index, values.value(index as usize)))
         .collect::<Vec<(u32, T::Native)>>();
+
     let mut nulls = null_indices;
-    if !options.descending {
-        valids.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or_else(|| Ordering::Greater));
+    let mut nans = nan_indices;
+
+    let valids_len = valids.len();
+    let nulls_len = nulls.len();
+    let nans_len = nans.len();
+
+    if !descending {
+        valids.sort_by(|a, b| a.1.partial_cmp(&b.1).expect("unexpected NaN"));
     } else {
-        valids.sort_by(|a, b| {
-            a.1.partial_cmp(&b.1)
-                .unwrap_or_else(|| Ordering::Greater)
-                .reverse()
-        });
+        valids.sort_by(|a, b| a.1.partial_cmp(&b.1).expect("unexpected NaN").reverse());
+        // reverse to keep a stable ordering
+        nans.reverse();
         nulls.reverse();
     }
-    // collect the order of valid tuples
-    let mut valid_indices: Vec<u32> = valids.iter().map(|tuple| tuple.0).collect();
+
+    // collect results directly into a buffer instead of a vec to avoid another aligned allocation
+    let mut result = MutableBuffer::new(values.len() * std::mem::size_of::<u32>());
+    // sets len to capacity so we can access the whole buffer as a typed slice
+    result.resize(values.len() * std::mem::size_of::<u32>())?;
+    let result_slice: &mut [u32] = result.typed_data_mut();
+
+    debug_assert_eq!(result_slice.len(), nulls_len + nans_len + valids_len);
 
     if options.nulls_first {
-        nulls.append(&mut valid_indices);
-        return Ok(UInt32Array::from(nulls));
+        result_slice[0..nulls_len].copy_from_slice(&nulls);
+        insert_valid_and_nan_values(result_slice, nulls_len, valids, nans, descending);
+    } else {
+        // nulls last
+        insert_valid_and_nan_values(result_slice, 0, valids, nans, descending);
+        result_slice[valids_len + nans_len..].copy_from_slice(nulls.as_slice())
     }
-    // no need to sort nulls as they are in the correct order already
-    valid_indices.append(&mut nulls);
 
-    Ok(UInt32Array::from(valid_indices))
+    let result_data = Arc::new(ArrayData::new(
+        DataType::UInt32,
+        values.len(),
+        Some(0),
+        None,
+        0,
+        vec![result.freeze()],
+        vec![],
+    ));
+
+    Ok(UInt32Array::from(result_data))
+}
+
+// insert valid and nan values in the correct order depending on the descending flag
+fn insert_valid_and_nan_values<T: ArrowNativeType>(
+    result_slice: &mut [u32],
+    offset: usize,
+    valids: Vec<(u32, T)>,
+    nans: Vec<u32>,
+    descending: bool,
+) {
+    let valids_len = valids.len();
+    let nans_len = nans.len();
+
+    // helper to append the index part of the valid tuples
+    let append_valids = move |dst_slice: &mut [u32]| {
+        debug_assert_eq!(dst_slice.len(), valids_len);
+        dst_slice
+            .iter_mut()
+            .zip(valids.into_iter())
+            .for_each(|(dst, src)| *dst = src.0)
+    };
+
+    // NaNs are considered greater than all number which means
+    // for descending order they come before valid numbers
+    // for ascending order they come after valid numbers
+    if descending {
+        result_slice[offset..offset + nans_len].copy_from_slice(nans.as_slice());
+        append_valids(
+            &mut result_slice[offset + nans_len..offset + nans_len + valids_len],
+        );
+    } else {
+        append_valids(&mut result_slice[offset..offset + valids_len]);
+        result_slice[offset + valids_len..offset + valids_len + nans_len]
+            .copy_from_slice(nans.as_slice());
+    }
 }
 
 /// Sort strings
 fn sort_string(
     values: &ArrayRef,
-    value_indices: Vec<usize>,
+    value_indices: Vec<u32>,
     null_indices: Vec<u32>,
     options: &SortOptions,
 ) -> Result<UInt32Array> {
     let values = as_string_array(values);
+
+    sort_string_helper(
+        values,
+        value_indices,
+        null_indices,
+        options,
+        |array, idx| array.value(idx as usize),
+    )
+}
+
+/// Sort dictionary encoded strings
+fn sort_string_dictionary<T: ArrowDictionaryKeyType>(
+    values: &ArrayRef,
+    value_indices: Vec<u32>,
+    null_indices: Vec<u32>,
+    options: &SortOptions,
+) -> Result<UInt32Array> {
+    let values: &DictionaryArray<T> = as_dictionary_array::<T>(values);
+
+    let keys: &PrimitiveArray<T> = &values.keys_array();
+
+    let dict = values.values();
+    let dict: &StringArray = as_string_array(&dict);
+
+    sort_string_helper(
+        keys,
+        value_indices,
+        null_indices,
+        options,
+        |array: &PrimitiveArray<T>, idx| -> &str {
+            let key: T::Native = array.value(idx as usize);
+            dict.value(key.to_usize().unwrap())
+        },
+    )
+}
+
+/// shared implementation between dictionary encoded and plain string arrays
+#[inline]
+fn sort_string_helper<'a, A: Array, F>(
+    values: &'a A,
+    value_indices: Vec<u32>,
+    null_indices: Vec<u32>,
+    options: &SortOptions,
+    value_fn: F,
+) -> Result<UInt32Array>
+where
+    F: Fn(&'a A, u32) -> &str,
+{
     let mut valids = value_indices
         .into_iter()
-        .map(|index| (index as u32, values.value(index)))
+        .map(|index| (index, value_fn(&values, index)))
         .collect::<Vec<(u32, &str)>>();
     let mut nulls = null_indices;
     if !options.descending {
@@ -239,7 +407,7 @@ pub struct SortColumn {
 /// Example:
 ///
 /// ```
-/// use std::convert::TryFrom;
+/// use std::convert::From;
 /// use std::sync::Arc;
 /// use arrow::array::{ArrayRef, StringArray, PrimitiveArray, as_primitive_array};
 /// use arrow::compute::kernels::sort::{SortColumn, SortOptions, lexsort};
@@ -295,7 +463,7 @@ pub fn lexsort_to_indices(columns: &[SortColumn]) -> Result<UInt32Array> {
     // convert ArrayRefs to OrdArray trait objects and perform row count check
     let flat_columns = columns
         .iter()
-        .map(|column| -> Result<(&OrdArray, SortOptions)> {
+        .map(|column| -> Result<(&Array, Box<OrdArray>, SortOptions)> {
             // row count check
             let curr_row_count = column.values.len() - column.values.offset();
             match row_count {
@@ -312,20 +480,22 @@ pub fn lexsort_to_indices(columns: &[SortColumn]) -> Result<UInt32Array> {
             }
             // flatten and convert to OrdArray
             Ok((
+                column.values.as_ref(),
                 as_ordarray(&column.values)?,
                 column.options.unwrap_or_default(),
             ))
         })
-        .collect::<Result<Vec<(&OrdArray, SortOptions)>>>()?;
+        .collect::<Result<Vec<(&Array, Box<OrdArray>, SortOptions)>>>()?;
 
     let lex_comparator = |a_idx: &usize, b_idx: &usize| -> Ordering {
         for column in flat_columns.iter() {
             let values = &column.0;
-            let sort_option = column.1;
+            let ord_array = &column.1;
+            let sort_option = column.2;
 
             match (values.is_valid(*a_idx), values.is_valid(*b_idx)) {
                 (true, true) => {
-                    match values.cmp_value(*a_idx, *b_idx) {
+                    match ord_array.cmp_value(*a_idx, *b_idx) {
                         // equal, move on to next column
                         Ordering::Equal => continue,
                         order => {
@@ -373,6 +543,8 @@ pub fn lexsort_to_indices(columns: &[SortColumn]) -> Result<UInt32Array> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
+    use std::iter::FromIterator;
     use std::sync::Arc;
 
     fn test_sort_to_indices_primitive_arrays<T>(
@@ -427,6 +599,50 @@ mod tests {
         assert!(output.equals(&expected))
     }
 
+    fn test_sort_string_dict_arrays<T: ArrowDictionaryKeyType>(
+        data: Vec<Option<&str>>,
+        options: Option<SortOptions>,
+        expected_data: Vec<Option<&str>>,
+    ) {
+        let array = DictionaryArray::<T>::from_iter(data.into_iter());
+        let array_values = array.values();
+        let dict = array_values
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Unable to get dictionary values");
+
+        let sorted = sort(&(Arc::new(array) as ArrayRef), options).unwrap();
+        let sorted = sorted
+            .as_any()
+            .downcast_ref::<DictionaryArray<T>>()
+            .unwrap();
+        let sorted_values = sorted.values();
+        let sorted_dict = sorted_values
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .expect("Unable to get dictionary values");
+        let sorted_keys = sorted.keys_array();
+
+        assert!(sorted_dict.equals(dict));
+
+        let sorted_strings = StringArray::try_from(
+            (0..sorted.len())
+                .map(|i| {
+                    if sorted.is_valid(i) {
+                        Some(sorted_dict.value(sorted_keys.value(i).to_usize().unwrap()))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<Option<&str>>>(),
+        )
+        .expect("Unable to create string array from dictionary");
+        let expected =
+            StringArray::try_from(expected_data).expect("Unable to create string array");
+
+        assert!(sorted_strings.equals(&expected))
+    }
+
     fn test_lex_sort_arrays(input: Vec<SortColumn>, expected_output: Vec<ArrayRef>) {
         let sorted = lexsort(&input).unwrap();
         let sorted2cmp = sorted.iter().map(|arr| -> Box<&dyn ArrayEqual> {
@@ -434,6 +650,12 @@ mod tests {
                 DataType::Int64 => Box::new(as_primitive_array::<Int64Type>(&arr)),
                 DataType::UInt32 => Box::new(as_primitive_array::<UInt32Type>(&arr)),
                 DataType::Utf8 => Box::new(as_string_array(&arr)),
+                DataType::Dictionary(key_type, _) => match key_type.as_ref() {
+                    DataType::Int8 => Box::new(as_dictionary_array::<Int8Type>(&arr)),
+                    DataType::Int16 => Box::new(as_dictionary_array::<Int16Type>(&arr)),
+                    DataType::Int32 => Box::new(as_dictionary_array::<Int32Type>(&arr)),
+                    _ => panic!("unexpected dictionary key type"),
+                },
                 _ => panic!("unexpected array type"),
             }
         });
@@ -746,6 +968,14 @@ mod tests {
             }),
             vec![None, None, Some(f64::NAN), Some(2.0), Some(0.0), Some(-1.0)],
         );
+        test_sort_primitive_arrays::<Float64Type>(
+            vec![Some(f64::NAN), Some(f64::NAN), Some(f64::NAN), Some(1.0)],
+            Some(SortOptions {
+                descending: true,
+                nulls_first: true,
+            }),
+            vec![Some(f64::NAN), Some(f64::NAN), Some(f64::NAN), Some(1.0)],
+        );
 
         // int8 nulls first
         test_sort_primitive_arrays::<Int8Type>(
@@ -795,6 +1025,14 @@ mod tests {
                 nulls_first: true,
             }),
             vec![None, None, Some(-1.0), Some(0.0), Some(2.0), Some(f64::NAN)],
+        );
+        test_sort_primitive_arrays::<Float64Type>(
+            vec![Some(f64::NAN), Some(f64::NAN), Some(f64::NAN), Some(1.0)],
+            Some(SortOptions {
+                descending: false,
+                nulls_first: true,
+            }),
+            vec![Some(1.0), Some(f64::NAN), Some(f64::NAN), Some(f64::NAN)],
         );
     }
 
@@ -931,6 +1169,98 @@ mod tests {
         );
 
         test_sort_string_arrays(
+            vec![
+                None,
+                Some("bad"),
+                Some("sad"),
+                None,
+                Some("glad"),
+                Some("-ad"),
+            ],
+            Some(SortOptions {
+                descending: true,
+                nulls_first: true,
+            }),
+            vec![
+                None,
+                None,
+                Some("sad"),
+                Some("glad"),
+                Some("bad"),
+                Some("-ad"),
+            ],
+        );
+    }
+
+    #[test]
+    fn test_sort_string_dicts() {
+        test_sort_string_dict_arrays::<Int8Type>(
+            vec![
+                None,
+                Some("bad"),
+                Some("sad"),
+                None,
+                Some("glad"),
+                Some("-ad"),
+            ],
+            None,
+            vec![
+                None,
+                None,
+                Some("-ad"),
+                Some("bad"),
+                Some("glad"),
+                Some("sad"),
+            ],
+        );
+
+        test_sort_string_dict_arrays::<Int16Type>(
+            vec![
+                None,
+                Some("bad"),
+                Some("sad"),
+                None,
+                Some("glad"),
+                Some("-ad"),
+            ],
+            Some(SortOptions {
+                descending: true,
+                nulls_first: false,
+            }),
+            vec![
+                Some("sad"),
+                Some("glad"),
+                Some("bad"),
+                Some("-ad"),
+                None,
+                None,
+            ],
+        );
+
+        test_sort_string_dict_arrays::<Int32Type>(
+            vec![
+                None,
+                Some("bad"),
+                Some("sad"),
+                None,
+                Some("glad"),
+                Some("-ad"),
+            ],
+            Some(SortOptions {
+                descending: false,
+                nulls_first: true,
+            }),
+            vec![
+                None,
+                None,
+                Some("-ad"),
+                Some("bad"),
+                Some("glad"),
+                Some("sad"),
+            ],
+        );
+
+        test_sort_string_dict_arrays::<Int16Type>(
             vec![
                 None,
                 Some("bad"),

--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -81,7 +81,7 @@ This library currently supports the following SQL constructs:
 * most mathematical unary and binary expressions such as `+`, `/`, `sqrt`, `tan`, `>=`.
 * `WHERE` to filter
 * `GROUP BY` together with one of the following aggregations: `MIN`, `MAX`, `COUNT`, `SUM`, `AVG`
-* `ORDER BY` together with an expression and optional `DESC`
+* `ORDER BY` together with an expression and optional `ASC` or `DESC` and also optional `NULLS FIRST` or `NULLS LAST`
 
 ## Supported Data Types
 


### PR DESCRIPTION
- sort_to_indices further splits up float64/float32 inputs into nulls/non-nan/nan, sorts the non-nan values and then concats those 3 slices according to the sort options. Nans are distinct from null and sort greater than any other valid value
- implemented a sort method for dictionary arrays with string values. this kernel checks the is_ordered flag and sorts just by the keys if it is set, it will look up the string values otherwise
- for the lexical sort use case the above kernel are not used, instead the OrdArray trait is used. To make that more flexible and allow wrapping arrays with differend ordering behavior I will make it no longer extend Array and instead only contain the cmp_value method
- string dictionary sorting is then implemented with a wrapper struct StringDictionaryArrayAsOrdArray which implements OrdArray
- NaN aware sorting of floats is then also implemented with a wrapper struct and trait implementation