### PR TITLE
ARROW-9794: [C++] Add IsVendor API for CpuInfo

### DIFF
--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -225,10 +225,10 @@ bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name,
   // HEX of "AuthenticAMD": 41757468 656E7469 63414D44
   if (cpu_info[1] == 0x756e6547 && cpu_info[2] == 0x49656e69 &&
       cpu_info[3] == 0x6c65746e) {
-    *vendor = CpuInfo::VENDOR_INTEL;
+    *vendor = CpuInfo::Vendor::Intel;
   } else if (cpu_info[1] == 0x68747541 && cpu_info[2] == 0x69746e65 &&
              cpu_info[3] == 0x444d4163) {
-    *vendor = CpuInfo::VENDOR_AMD;
+    *vendor = CpuInfo::Vendor::AMD;
   }
 
   if (highest_valid_id <= register_EAX_id) return false;
@@ -281,7 +281,7 @@ CpuInfo::CpuInfo()
     : hardware_flags_(0),
       num_cores_(1),
       model_name_("unknown"),
-      vendor_(VENDOR_UNKNOWN) {}
+      vendor_(Vendor::Unknown) {}
 
 std::unique_ptr<CpuInfo> g_cpu_info;
 static std::once_flag cpuinfo_initialized;
@@ -337,9 +337,9 @@ void CpuInfo::Init() {
         model_name_ = value;
       } else if (name.compare("vendor_id") == 0) {
         if (value.compare("GenuineIntel") == 0) {
-          vendor_ = VENDOR_INTEL;
+          vendor_ = Vendor::Intel;
         } else if (value.compare("AuthenticAMD") == 0) {
-          vendor_ = VENDOR_AMD;
+          vendor_ = Vendor::AMD;
         }
       }
     }

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -207,8 +207,9 @@ bool RetrieveCacheSize(int64_t* cache_sizes) {
 }
 
 // Source: https://en.wikipedia.org/wiki/CPUID
-bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name) {
-  if (!hardware_flags || !model_name) {
+bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name,
+                     CpuInfo::Vendor* vendor) {
+  if (!hardware_flags || !model_name || !vendor) {
     return false;
   }
   int register_EAX_id = 1;
@@ -220,6 +221,15 @@ bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name) {
   // Get highest valid id
   __cpuid(cpu_info.data(), 0);
   highest_valid_id = cpu_info[0];
+  // HEX of "GenuineIntel": 47656E75 696E6549 6E74656C
+  // HEX of "AuthenticAMD": 41757468 656E7469 63414D44
+  if (cpu_info[1] == 0x756e6547 && cpu_info[2] == 0x49656e69 &&
+      cpu_info[3] == 0x6c65746e) {
+    *vendor = CpuInfo::VENDOR_INTEL;
+  } else if (cpu_info[1] == 0x68747541 && cpu_info[2] == 0x69746e65 &&
+             cpu_info[3] == 0x444d4163) {
+    *vendor = CpuInfo::VENDOR_AMD;
+  }
 
   if (highest_valid_id <= register_EAX_id) return false;
 
@@ -267,7 +277,11 @@ bool RetrieveCPUInfo(int64_t* hardware_flags, std::string* model_name) {
 }
 #endif
 
-CpuInfo::CpuInfo() : hardware_flags_(0), num_cores_(1), model_name_("unknown") {}
+CpuInfo::CpuInfo()
+    : hardware_flags_(0),
+      num_cores_(1),
+      model_name_("unknown"),
+      vendor_(VENDOR_UNKNOWN) {}
 
 std::unique_ptr<CpuInfo> g_cpu_info;
 static std::once_flag cpuinfo_initialized;
@@ -321,6 +335,12 @@ void CpuInfo::Init() {
         ++num_cores;
       } else if (name.compare("model name") == 0) {
         model_name_ = value;
+      } else if (name.compare("vendor_id") == 0) {
+        if (value.compare("GenuineIntel") == 0) {
+          vendor_ = VENDOR_INTEL;
+        } else if (value.compare("AuthenticAMD") == 0) {
+          vendor_ = VENDOR_AMD;
+        }
       }
     }
   }
@@ -341,7 +361,7 @@ void CpuInfo::Init() {
   if (!RetrieveCacheSize(cache_sizes_)) {
     SetDefaultCacheSize();
   }
-  RetrieveCPUInfo(&hardware_flags_, &model_name_);
+  RetrieveCPUInfo(&hardware_flags_, &model_name_, &vendor_);
 #else
   SetDefaultCacheSize();
 #endif

--- a/cpp/src/arrow/util/cpu_info.h
+++ b/cpp/src/arrow/util/cpu_info.h
@@ -59,6 +59,12 @@ class ARROW_EXPORT CpuInfo {
     L3_CACHE = 2,
   };
 
+  enum Vendor {
+    VENDOR_UNKNOWN = 0,
+    VENDOR_INTEL,
+    VENDOR_AMD,
+  };
+
   /// The SIMD level set by user
   enum UserSimdLevel {
     USER_SIMD_NONE = 0,
@@ -101,6 +107,8 @@ class ARROW_EXPORT CpuInfo {
   /// Returns the model name of the cpu (e.g. Intel i7-2600)
   std::string model_name();
 
+  bool IsVendor(Vendor vendor) const { return vendor == vendor_; }
+
  private:
   CpuInfo();
 
@@ -118,6 +126,7 @@ class ARROW_EXPORT CpuInfo {
   int64_t cycles_per_ms_;
   int num_cores_;
   std::string model_name_;
+  Vendor vendor_;
 };
 
 }  // namespace internal

--- a/cpp/src/arrow/util/cpu_info.h
+++ b/cpp/src/arrow/util/cpu_info.h
@@ -104,7 +104,7 @@ class ARROW_EXPORT CpuInfo {
   std::string model_name();
 
   /// Returns the vendor of the cpu.
-  Vendor vendor() const { return vendor_; };
+  Vendor vendor() const { return vendor_; }
 
  private:
   CpuInfo();

--- a/cpp/src/arrow/util/cpu_info.h
+++ b/cpp/src/arrow/util/cpu_info.h
@@ -84,7 +84,7 @@ class ARROW_EXPORT CpuInfo {
   /// Returns all the flags for this cpu
   int64_t hardware_flags();
 
-  /// Returns whether of not the cpu supports all the flags
+  /// Returns whether or not the cpu supports all the flags
   bool IsSupported(int64_t flags) const { return (hardware_flags_ & flags) == flags; }
 
   /// \brief The processor supports SSE4.2 and the Arrow libraries are built
@@ -107,6 +107,7 @@ class ARROW_EXPORT CpuInfo {
   /// Returns the model name of the cpu (e.g. Intel i7-2600)
   std::string model_name();
 
+  /// Returns whether or not the cpu is provided by this vendor.
   bool IsVendor(Vendor vendor) const { return vendor == vendor_; }
 
  private:

--- a/cpp/src/arrow/util/cpu_info.h
+++ b/cpp/src/arrow/util/cpu_info.h
@@ -59,11 +59,7 @@ class ARROW_EXPORT CpuInfo {
     L3_CACHE = 2,
   };
 
-  enum Vendor {
-    VENDOR_UNKNOWN = 0,
-    VENDOR_INTEL,
-    VENDOR_AMD,
-  };
+  enum class Vendor : int { Unknown = 0, Intel, AMD };
 
   /// The SIMD level set by user
   enum UserSimdLevel {
@@ -107,8 +103,8 @@ class ARROW_EXPORT CpuInfo {
   /// Returns the model name of the cpu (e.g. Intel i7-2600)
   std::string model_name();
 
-  /// Returns whether or not the cpu is provided by this vendor.
-  bool IsVendor(Vendor vendor) const { return vendor == vendor_; }
+  /// Returns the vendor of the cpu.
+  Vendor vendor() const { return vendor_; };
 
  private:
   CpuInfo();


### PR DESCRIPTION
Usage: cpu_info->vendor() == CpuInfo::Vendor::Intel

Signed-off-by: Frank Du <frank.du@intel.com>