### PR TITLE
ARROW-9900: [Rust][DataFusion] Switch from Box -> Arc in LogicalPlanNode

### DIFF
--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -765,7 +765,7 @@ pub enum LogicalPlan {
         /// The list of expressions
         expr: Vec<Expr>,
         /// The incoming logical plan
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         /// The schema description of the output
         schema: Box<Schema>,
     },
@@ -781,13 +781,13 @@ pub enum LogicalPlan {
         /// The predicate expression, which must have Boolean type.
         predicate: Expr,
         /// The incoming logical plan
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
     },
     /// Aggregates its input based on a set of grouping and aggregate
     /// expressions (e.g. SUM).
     Aggregate {
         /// The incoming logical plan
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         /// Grouping expressions
         group_expr: Vec<Expr>,
         /// Aggregate expressions
@@ -800,7 +800,7 @@ pub enum LogicalPlan {
         /// The sort expressions
         expr: Vec<Expr>,
         /// The incoming logical plan
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
     },
     /// Produces rows from a table that has been registered on a
     /// context
@@ -863,7 +863,7 @@ pub enum LogicalPlan {
         /// The limit
         n: usize,
         /// The logical plan
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
     },
     /// Creates an external table.
     CreateExternalTable {
@@ -884,7 +884,7 @@ pub enum LogicalPlan {
         /// Should extra (detailed, intermediate plans) be included?
         verbose: bool,
         /// The logical plan that is being EXPLAIN'd
-        plan: Box<LogicalPlan>,
+        plan: Arc<LogicalPlan>,
         /// Represent the various stages plans have gone through
         stringified_plans: Vec<StringifiedPlan>,
         /// The output schema of the explain (2 columns of text)
@@ -1195,7 +1195,7 @@ impl LogicalPlanBuilder {
 
         Ok(Self::from(&LogicalPlan::Projection {
             expr: projected_expr,
-            input: Box::new(self.plan.clone()),
+            input: Arc::new(self.plan.clone()),
             schema: Box::new(schema),
         }))
     }
@@ -1204,7 +1204,7 @@ impl LogicalPlanBuilder {
     pub fn filter(&self, expr: Expr) -> Result<Self> {
         Ok(Self::from(&LogicalPlan::Filter {
             predicate: expr,
-            input: Box::new(self.plan.clone()),
+            input: Arc::new(self.plan.clone()),
         }))
     }
 
@@ -1212,7 +1212,7 @@ impl LogicalPlanBuilder {
     pub fn limit(&self, n: usize) -> Result<Self> {
         Ok(Self::from(&LogicalPlan::Limit {
             n,
-            input: Box::new(self.plan.clone()),
+            input: Arc::new(self.plan.clone()),
         }))
     }
 
@@ -1220,7 +1220,7 @@ impl LogicalPlanBuilder {
     pub fn sort(&self, expr: Vec<Expr>) -> Result<Self> {
         Ok(Self::from(&LogicalPlan::Sort {
             expr,
-            input: Box::new(self.plan.clone()),
+            input: Arc::new(self.plan.clone()),
         }))
     }
 
@@ -1232,7 +1232,7 @@ impl LogicalPlanBuilder {
         let aggr_schema = Schema::new(exprlist_to_fields(&all_expr, self.plan.schema())?);
 
         Ok(Self::from(&LogicalPlan::Aggregate {
-            input: Box::new(self.plan.clone()),
+            input: Arc::new(self.plan.clone()),
             group_expr,
             aggr_expr,
             schema: Box::new(aggr_schema),
@@ -1250,7 +1250,7 @@ impl LogicalPlanBuilder {
 
         Ok(Self::from(&LogicalPlan::Explain {
             verbose,
-            plan: Box::new(self.plan.clone()),
+            plan: Arc::new(self.plan.clone()),
             stringified_plans,
             schema,
         }))

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -19,7 +19,10 @@ use crate::logical_plan::Expr;
 use crate::logical_plan::{and, LogicalPlan};
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    sync::Arc,
+};
 
 /// Filter Push Down optimizer rule pushes filter clauses down the plan
 ///
@@ -268,7 +271,7 @@ fn optimize_plan(
     if let Some(expr) = new_filters.get(&depth) {
         return Ok(LogicalPlan::Filter {
             predicate: expr.clone(),
-            input: Box::new(new_plan),
+            input: Arc::new(new_plan),
         });
     } else {
         Ok(new_plan)

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -24,7 +24,7 @@ use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
 use arrow::datatypes::{Field, Schema};
 use arrow::error::Result as ArrowResult;
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 use utils::optimize_explain;
 
 /// Optimizer that removes unused projections and aggregations from plans
@@ -153,7 +153,7 @@ fn optimize_plan(
             } else {
                 Ok(LogicalPlan::Projection {
                     expr: new_expr,
-                    input: Box::new(new_input),
+                    input: Arc::new(new_input),
                     schema: Box::new(Schema::new(new_fields)),
                 })
             }
@@ -203,7 +203,7 @@ fn optimize_plan(
             Ok(LogicalPlan::Aggregate {
                 group_expr: group_expr.clone(),
                 aggr_expr: new_aggr_expr,
-                input: Box::new(optimize_plan(
+                input: Arc::new(optimize_plan(
                     optimizer,
                     &input,
                     &new_required_columns,

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -17,7 +17,7 @@
 
 //! Collection of utility functions that are leveraged by the query optimizer rules
 
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 
 use arrow::datatypes::Schema;
 
@@ -82,7 +82,7 @@ pub fn optimize_explain(
     // These are the fields of LogicalPlan::Explain It might be nice
     // to transform that enum Variant into its own struct and avoid
     // passing the fields individually
-    let plan = Box::new(optimizer.optimize(plan)?);
+    let plan = Arc::new(optimizer.optimize(plan)?);
     let mut stringified_plans = stringified_plans.clone();
     let optimizer_name = optimizer.name().into();
     stringified_plans.push(StringifiedPlan::new(
@@ -154,28 +154,28 @@ pub fn from_plan(
     match plan {
         LogicalPlan::Projection { schema, .. } => Ok(LogicalPlan::Projection {
             expr: expr.clone(),
-            input: Box::new(inputs[0].clone()),
+            input: Arc::new(inputs[0].clone()),
             schema: schema.clone(),
         }),
         LogicalPlan::Filter { .. } => Ok(LogicalPlan::Filter {
             predicate: expr[0].clone(),
-            input: Box::new(inputs[0].clone()),
+            input: Arc::new(inputs[0].clone()),
         }),
         LogicalPlan::Aggregate {
             group_expr, schema, ..
         } => Ok(LogicalPlan::Aggregate {
             group_expr: expr[0..group_expr.len()].to_vec(),
             aggr_expr: expr[group_expr.len()..].to_vec(),
-            input: Box::new(inputs[0].clone()),
+            input: Arc::new(inputs[0].clone()),
             schema: schema.clone(),
         }),
         LogicalPlan::Sort { .. } => Ok(LogicalPlan::Sort {
             expr: expr.clone(),
-            input: Box::new(inputs[0].clone()),
+            input: Arc::new(inputs[0].clone()),
         }),
         LogicalPlan::Limit { n, .. } => Ok(LogicalPlan::Limit {
             n: *n,
-            input: Box::new(inputs[0].clone()),
+            input: Arc::new(inputs[0].clone()),
         }),
         LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::TableScan { .. }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -154,7 +154,7 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
         )];
 
         let schema = LogicalPlan::explain_schema();
-        let plan = Box::new(plan);
+        let plan = Arc::new(plan);
 
         Ok(LogicalPlan::Explain {
             verbose,


### PR DESCRIPTION
The idea is to continue to simplify the code and improve performance: the inputs to nodes are often copied and using Box requires unnecessary deep copies

I view this as another step towards having LogicalPlan's be made up of `Arc<dyn LogicalPlanNode>` to mirror how `ExecutionPlan`s work