### PR TITLE
ARROW-9904: [C++] Unroll the loop of CountSetBits.

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -234,6 +234,9 @@ TEST_F(TestArray, SliceRecomputeNullCount) {
   slice = array->Slice(4);
   ASSERT_EQ(4, slice->null_count());
 
+  auto slice2 = slice->Slice(0);
+  ASSERT_EQ(4, slice2->null_count());
+
   slice = array->Slice(0);
   ASSERT_EQ(5, slice->null_count());
 

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -100,6 +100,8 @@ std::shared_ptr<ArrayData> ArrayData::Slice(int64_t off, int64_t len) const {
   copy->offset = off;
   if (null_count == length) {
     copy->null_count = len;
+  } else if (off == offset && len == length) {  // A copy of current.
+    copy->null_count = null_count.load();
   } else {
     copy->null_count = null_count != 0 ? kUnknownNullCount : 0;
   }

--- a/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
@@ -405,7 +405,7 @@ static void CountKernelBenchInt64(benchmark::State& state) {
   auto array = rand.Numeric<Int64Type>(array_size, -100, 100, args.null_proportion);
 
   for (auto _ : state) {
-    ABORT_NOT_OK(Count(array).status());
+    ABORT_NOT_OK(Count(array->Slice(1, array_size)).status());
   }
 }
 BENCHMARK(CountKernelBenchInt64)->Args({1 * 1024 * 1024, 2});  // 1M with 50% null.

--- a/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
@@ -398,5 +398,17 @@ MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt16, Int16Type);
 MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt32, Int32Type);
 MINMAX_KERNEL_BENCHMARK(MinMaxKernelInt64, Int64Type);
 
+static void CountKernelBenchInt64(benchmark::State& state) {
+  RegressionArgs args(state);
+  const int64_t array_size = args.size / sizeof(int64_t);
+  auto rand = random::RandomArrayGenerator(1923);
+  auto array = rand.Numeric<Int64Type>(array_size, -100, 100, args.null_proportion);
+
+  for (auto _ : state) {
+    ABORT_NOT_OK(Count(array).status());
+  }
+}
+BENCHMARK(CountKernelBenchInt64)->Args({1 * 1024 * 1024, 2});  // 1M with 50% null.
+
 }  // namespace compute
 }  // namespace arrow


### PR DESCRIPTION
1. Unroll the loop of CountSetBits to generate parallel instructions.
2. Add count benchmark

Signed-off-by: Frank Du <frank.du@intel.com>