### PR TITLE
ARROW-9970: [Go] fix checkptr failure in sum methods

### DIFF
--- a/go/arrow/math/float64_avx2_amd64.go
+++ b/go/arrow/math/float64_avx2_amd64.go
@@ -27,13 +27,13 @@ import (
 )
 
 //go:noescape
-func _sum_float64_avx2(buf, len, res unsafe.Pointer)
+func _sum_float64_avx2(buf unsafe.Pointer, len uintptr, res unsafe.Pointer)
 
 func sum_float64_avx2(a *array.Float64) float64 {
 	buf := a.Float64Values()
 	var (
 		p1  = unsafe.Pointer(&buf[0])
-		p2  = unsafe.Pointer(uintptr(len(buf)))
+		p2  = uintptr(len(buf))
 		res float64
 	)
 	_sum_float64_avx2(p1, p2, unsafe.Pointer(&res))

--- a/go/arrow/math/float64_sse4_amd64.go
+++ b/go/arrow/math/float64_sse4_amd64.go
@@ -27,13 +27,13 @@ import (
 )
 
 //go:noescape
-func _sum_float64_sse4(buf, len, res unsafe.Pointer)
+func _sum_float64_sse4(buf unsafe.Pointer, len uintptr, res unsafe.Pointer)
 
 func sum_float64_sse4(a *array.Float64) float64 {
 	buf := a.Float64Values()
 	var (
 		p1  = unsafe.Pointer(&buf[0])
-		p2  = unsafe.Pointer(uintptr(len(buf)))
+		p2  = uintptr(len(buf))
 		res float64
 	)
 	_sum_float64_sse4(p1, p2, unsafe.Pointer(&res))

--- a/go/arrow/math/int64_avx2_amd64.go
+++ b/go/arrow/math/int64_avx2_amd64.go
@@ -27,13 +27,13 @@ import (
 )
 
 //go:noescape
-func _sum_int64_avx2(buf, len, res unsafe.Pointer)
+func _sum_int64_avx2(buf unsafe.Pointer, len uintptr, res unsafe.Pointer)
 
 func sum_int64_avx2(a *array.Int64) int64 {
 	buf := a.Int64Values()
 	var (
 		p1  = unsafe.Pointer(&buf[0])
-		p2  = unsafe.Pointer(uintptr(len(buf)))
+		p2  = uintptr(len(buf))
 		res int64
 	)
 	_sum_int64_avx2(p1, p2, unsafe.Pointer(&res))

--- a/go/arrow/math/int64_sse4_amd64.go
+++ b/go/arrow/math/int64_sse4_amd64.go
@@ -27,13 +27,13 @@ import (
 )
 
 //go:noescape
-func _sum_int64_sse4(buf, len, res unsafe.Pointer)
+func _sum_int64_sse4(buf unsafe.Pointer, len uintptr, res unsafe.Pointer)
 
 func sum_int64_sse4(a *array.Int64) int64 {
 	buf := a.Int64Values()
 	var (
 		p1  = unsafe.Pointer(&buf[0])
-		p2  = unsafe.Pointer(uintptr(len(buf)))
+		p2  = uintptr(len(buf))
 		res int64
 	)
 	_sum_int64_sse4(p1, p2, unsafe.Pointer(&res))

--- a/go/arrow/math/type_simd_amd64.go.tmpl
+++ b/go/arrow/math/type_simd_amd64.go.tmpl
@@ -27,13 +27,13 @@ import (
 {{$name := printf "%s_%s" .In.Type .D.arch}}
 {{with .In}}
 //go:noescape
-func _sum_{{$name}}(buf, len, res unsafe.Pointer)
+func _sum_{{$name}}(buf unsafe.Pointer, len uintptr, res unsafe.Pointer)
 
 func sum_{{$name}}(a *array.{{.Name}}) {{.Type}} {
 	buf := a.{{.Name}}Values()
 	var (
 		p1  = unsafe.Pointer(&buf[0])
-		p2  = unsafe.Pointer(uintptr(len(buf)))
+		p2  = uintptr(len(buf))
 		res {{.Type}}
 	)
 	_sum_{{$name}}(p1, p2, unsafe.Pointer(&res))

--- a/go/arrow/math/uint64_avx2_amd64.go
+++ b/go/arrow/math/uint64_avx2_amd64.go
@@ -27,13 +27,13 @@ import (
 )
 
 //go:noescape
-func _sum_uint64_avx2(buf, len, res unsafe.Pointer)
+func _sum_uint64_avx2(buf unsafe.Pointer, len uintptr, res unsafe.Pointer)
 
 func sum_uint64_avx2(a *array.Uint64) uint64 {
 	buf := a.Uint64Values()
 	var (
 		p1  = unsafe.Pointer(&buf[0])
-		p2  = unsafe.Pointer(uintptr(len(buf)))
+		p2  = uintptr(len(buf))
 		res uint64
 	)
 	_sum_uint64_avx2(p1, p2, unsafe.Pointer(&res))

--- a/go/arrow/math/uint64_sse4_amd64.go
+++ b/go/arrow/math/uint64_sse4_amd64.go
@@ -27,13 +27,13 @@ import (
 )
 
 //go:noescape
-func _sum_uint64_sse4(buf, len, res unsafe.Pointer)
+func _sum_uint64_sse4(buf unsafe.Pointer, len uintptr, res unsafe.Pointer)
 
 func sum_uint64_sse4(a *array.Uint64) uint64 {
 	buf := a.Uint64Values()
 	var (
 		p1  = unsafe.Pointer(&buf[0])
-		p2  = unsafe.Pointer(uintptr(len(buf)))
+		p2  = uintptr(len(buf))
 		res uint64
 	)
 	_sum_uint64_sse4(p1, p2, unsafe.Pointer(&res))


### PR DESCRIPTION
When running the unit tests for github.com/influxdata/flux with the race
detector enabled on Go 1.14 or newer, checkptr detects failures like
"fatal error: checkptr: pointer arithmetic computed bad pointer value"
which are fixed by this change.

I did not have sufficient time to identify how the Flux tests were
different from the Arrow tests -- I did look at the Arrow tests and I
did not identify a difference -- but applying this change eliminated the
checkptr failures in the Flux test suite.

One such stack trace from running `PKG_CONFIG=$PWD/pkg-config.sh $GOPATH/bin/go1.15.1 test  -race ./stdlib/universe/` against influxdata/flux@5e15be646a25767a802ee4dacd4e262c3211808d:

```
fatal error: checkptr: pointer arithmetic computed bad pointer value

goroutine 3327 [running]:
runtime.throw(0x5e7c5f2, 0x37)
	/Users/mr/sdk/go1.15.1/src/runtime/panic.go:1116 +0x72 fp=0xc000fb1c40 sp=0xc000fb1c10 pc=0x403a292
runtime.checkptrArithmetic(0x1, 0x0, 0x0, 0x0)
	/Users/mr/sdk/go1.15.1/src/runtime/checkptr.go:26 +0xd7 fp=0xc000fb1c70 sp=0xc000fb1c40 pc=0x4009af7
github.com/apache/arrow/go/arrow/math.sum_float64_avx2(0xc0040ac940, 0x0)
	/Users/mr/go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200817174511-886d87bdea78/math/float64_avx2_amd64.go:36 +0x7b fp=0xc000fb1cc0 sp=0xc000fb1c70 pc=0x48566bb
github.com/apache/arrow/go/arrow/math.Float64Funcs.Sum(...)
	/Users/mr/go/pkg/mod/github.com/apache/arrow/go/arrow@v0.0.0-20200817174511-886d87bdea78/math/float64.go:38
github.com/influxdata/flux/stdlib/universe.(*MeanAgg).DoFloat(0xc004083610, 0xc0040ac940)
	/Users/mr/go/src/github.com/influxdata/flux/stdlib/universe/mean.go:144 +0x464 fp=0xc000fb1d68 sp=0xc000fb1cc0 pc=0x48e4104
github.com/influxdata/flux/execute/executetest.AggFuncTestHelper(0xc000583800, 0x70cbf60, 0xc004083600, 0xc0040ac900, 0x5bb80e0, 0x7066010)
	/Users/mr/go/src/github.com/influxdata/flux/execute/executetest/aggregate.go:24 +0x157 fp=0xc000fb1e28 sp=0xc000fb1d68 pc=0x486c537
github.com/influxdata/flux/stdlib/universe_test.TestMean_Process.func6(0xc000583800)
	/Users/mr/go/src/github.com/influxdata/flux/stdlib/universe/mean_test.go:85 +0x119 fp=0xc000fb1ed0 sp=0xc000fb1e28 pc=0x57fff99
testing.tRunner(0xc000583800, 0xc0040a0810)
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1108 +0x203 fp=0xc000fb1fd0 sp=0xc000fb1ed0 pc=0x41b48c3
runtime.goexit()
	/Users/mr/sdk/go1.15.1/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc000fb1fd8 sp=0xc000fb1fd0 pc=0x40742c1
created by testing.(*T).Run
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1159 +0x797

goroutine 1 [chan receive]:
testing.(*T).Run(0xc000802780, 0x5e2b9d2, 0x10, 0x6c5f718, 0x1)
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1160 +0x7cf
testing.runTests.func1(0xc000802780)
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1430 +0xa7
testing.tRunner(0xc000802780, 0xc000083cc8)
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1108 +0x203
testing.runTests(0xc000c421a0, 0x814ae20, 0x9d, 0x9d, 0xbfccbe7a6d9bfac8, 0x8e116025f4, 0x8159c00, 0x0)
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1428 +0x5ab
testing.(*M).Run(0xc000f16a00, 0x0)
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1338 +0x4ec
main.main()
	_testmain.go:401 +0x237

goroutine 6 [select]:
go.opencensus.io/stats/view.(*worker).start(0xc0000a5590)
	/Users/mr/go/pkg/mod/go.opencensus.io@v0.22.3/stats/view/worker.go:154 +0x1e6
created by go.opencensus.io/stats/view.init.0
	/Users/mr/go/pkg/mod/go.opencensus.io@v0.22.3/stats/view/worker.go:32 +0x9a

goroutine 3326 [chan receive]:
testing.(*T).Run(0xc000583680, 0x5e1885d, 0x4, 0xc0040a0810, 0xc00c196000)
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1160 +0x7cf
github.com/influxdata/flux/stdlib/universe_test.TestMean_Process(0xc000583680)
	/Users/mr/go/src/github.com/influxdata/flux/stdlib/universe/mean_test.go:81 +0x2bb
testing.tRunner(0xc000583680, 0x6c5f718)
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1108 +0x203
created by testing.(*T).Run
	/Users/mr/sdk/go1.15.1/src/testing/testing.go:1159 +0x797
FAIL	github.com/influxdata/flux/stdlib/universe	16.737s
FAIL
```