### PR TITLE
ARROW-9919: [Rust][DataFusion] Speedup math operations by 15%+

### DIFF
--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -115,7 +115,7 @@ pub use self::array::StructArray;
 pub use self::null::NullArray;
 pub use self::union::UnionArray;
 
-pub(crate) use self::array::make_array;
+pub use self::array::make_array;
 
 pub type BooleanArray = PrimitiveArray<BooleanType>;
 pub type Int8Array = PrimitiveArray<Int8Type>;

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -70,3 +70,7 @@ harness = false
 [[bench]]
 name = "sort_limit_query_sql"
 harness = false
+
+[[bench]]
+name = "math_query_sql"
+harness = false

--- a/rust/datafusion/benches/math_query_sql.rs
+++ b/rust/datafusion/benches/math_query_sql.rs
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+use std::sync::Arc;
+
+extern crate arrow;
+extern crate datafusion;
+
+use arrow::{
+    array::{Float32Array, Float64Array},
+    datatypes::{DataType, Field, Schema},
+    record_batch::RecordBatch,
+};
+use datafusion::error::Result;
+
+use datafusion::datasource::MemTable;
+use datafusion::execution::context::ExecutionContext;
+
+fn query(ctx: &mut ExecutionContext, sql: &str) {
+    // execute the query
+    let df = ctx.sql(&sql).unwrap();
+    let results = df.collect().unwrap();
+
+    // display the relation
+    for _batch in results {}
+}
+
+fn create_context(array_len: usize, batch_size: usize) -> Result<ExecutionContext> {
+    // define a schema.
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("f32", DataType::Float32, false),
+        Field::new("f64", DataType::Float64, false),
+    ]));
+
+    // define data.
+    let batches = (0..array_len / batch_size)
+        .map(|i| {
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Float32Array::from(vec![i as f32; batch_size])),
+                    Arc::new(Float64Array::from(vec![i as f64; batch_size])),
+                ],
+            )
+            .unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    let mut ctx = ExecutionContext::new();
+
+    // declare a table in memory. In spark API, this corresponds to createDataFrame(...).
+    let provider = MemTable::new(schema, vec![batches])?;
+    ctx.register_table("t", Box::new(provider));
+
+    Ok(ctx)
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("sqrt_20_12", |b| {
+        let array_len = 1048576; // 2^20
+        let batch_size = 4096; // 2^12
+        let mut ctx = create_context(array_len, batch_size).unwrap();
+        b.iter(|| query(&mut ctx, "SELECT sqrt(f32) FROM t"))
+    });
+
+    c.bench_function("sqrt_22_12", |b| {
+        let array_len = 4194304; // 2^22
+        let batch_size = 4096; // 2^12
+        let mut ctx = create_context(array_len, batch_size).unwrap();
+        b.iter(|| query(&mut ctx, "SELECT sqrt(f32) FROM t"))
+    });
+
+    c.bench_function("sqrt_22_14", |b| {
+        let array_len = 4194304; // 2^22
+        let batch_size = 16384; // 2^14
+        let mut ctx = create_context(array_len, batch_size).unwrap();
+        b.iter(|| query(&mut ctx, "SELECT sqrt(f32) FROM t"))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
This PR improves speed of all math operations by 15% (on default batch size), and changes how these operations scale with batch size (to be faster).

See main issue here: ARROW-9918

This has a big contribution from @yordan-pavlov, that initially reported the issue on ARROW-8908 for literal arrays.

Benchmarks (on my computer, before and after the second commit):

```
sqrt_20_12              time:   [34.422 ms 34.503 ms 34.584 ms]                       
                        change: [-16.333% -16.055% -15.806%] (p = 0.00 < 0.05)
                        Performance has improved.

sqrt_22_12              time:   [150.13 ms 150.79 ms 151.42 ms]                       
                        change: [-16.281% -15.488% -14.779%] (p = 0.00 < 0.05)
                        Performance has improved.

sqrt_22_14              time:   [151.45 ms 151.68 ms 151.90 ms]                       
                        change: [-18.233% -16.919% -15.888%] (p = 0.00 < 0.05)
                        Performance has improved.
```