### PR TITLE
ARROW-9921: [Rust] Replace TryFrom by From in `StringArray` from `Vec<Option<&str>>` (+50%)

### DIFF
--- a/rust/arrow/benches/array_from_vec.rs
+++ b/rust/arrow/benches/array_from_vec.rs
@@ -24,6 +24,7 @@ extern crate arrow;
 use arrow::array::*;
 use arrow::buffer::Buffer;
 use arrow::datatypes::*;
+use std::convert::TryFrom;
 
 fn array_from_vec(n: usize) {
     let mut v: Vec<u8> = Vec::with_capacity(n);
@@ -36,10 +37,32 @@ fn array_from_vec(n: usize) {
     criterion::black_box(Int32Array::from(arr_data));
 }
 
+fn array_string_from_vec(n: usize) {
+    let mut v: Vec<Option<&str>> = Vec::with_capacity(n);
+    for i in 0..n {
+        if i % 2 == 0 {
+            v.push(Some("hello world"));
+        } else {
+            v.push(None);
+        }
+    }
+    criterion::black_box(StringArray::try_from(v).unwrap());
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("array_from_vec 128", |b| b.iter(|| array_from_vec(128)));
     c.bench_function("array_from_vec 256", |b| b.iter(|| array_from_vec(256)));
     c.bench_function("array_from_vec 512", |b| b.iter(|| array_from_vec(512)));
+
+    c.bench_function("array_string_from_vec 128", |b| {
+        b.iter(|| array_string_from_vec(128))
+    });
+    c.bench_function("array_string_from_vec 256", |b| {
+        b.iter(|| array_string_from_vec(256))
+    });
+    c.bench_function("array_string_from_vec 512", |b| {
+        b.iter(|| array_string_from_vec(512))
+    });
 }
 
 criterion_group!(benches, criterion_benchmark);

--- a/rust/arrow/benches/array_from_vec.rs
+++ b/rust/arrow/benches/array_from_vec.rs
@@ -24,7 +24,6 @@ extern crate arrow;
 use arrow::array::*;
 use arrow::buffer::Buffer;
 use arrow::datatypes::*;
-use std::convert::TryFrom;
 
 fn array_from_vec(n: usize) {
     let mut v: Vec<u8> = Vec::with_capacity(n);
@@ -46,7 +45,7 @@ fn array_string_from_vec(n: usize) {
             v.push(None);
         }
     }
-    criterion::black_box(StringArray::try_from(v).unwrap());
+    criterion::black_box(StringArray::from(v));
 }
 
 fn criterion_benchmark(c: &mut Criterion) {

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::any::Any;
-use std::convert::{From, TryFrom};
+use std::convert::From;
 use std::fmt;
 use std::io::Write;
 use std::iter::{FromIterator, IntoIterator};
@@ -31,7 +31,6 @@ use crate::array::equal::JsonEqual;
 use crate::buffer::{Buffer, MutableBuffer};
 use crate::datatypes::DataType::Struct;
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
 use crate::memory;
 use crate::util::bit_util;
 
@@ -1690,45 +1689,65 @@ impl From<ArrayDataRef> for FixedSizeBinaryArray {
     }
 }
 
-impl<'a> From<Vec<&'a str>> for StringArray {
-    fn from(v: Vec<&'a str>) -> Self {
-        let mut offsets = Vec::with_capacity(v.len() + 1);
-        let mut values = Vec::new();
-        let mut length_so_far = 0;
-        offsets.push(length_so_far);
-        for s in &v {
-            length_so_far += s.len() as i32;
-            offsets.push(length_so_far as i32);
-            values.extend_from_slice(s.as_bytes());
+macro_rules! def_string_from_vec {
+    ( $ty:ident, $native_ty:ident, $DATATYPE:expr ) => {
+        impl<'a> From<Vec<&'a str>> for $ty {
+            fn from(v: Vec<&'a str>) -> Self {
+                let mut offsets = Vec::with_capacity(v.len() + 1);
+                let mut values = Vec::new();
+                let mut length_so_far = 0;
+                offsets.push(length_so_far);
+                for s in &v {
+                    length_so_far += s.len() as $native_ty;
+                    offsets.push(length_so_far as $native_ty);
+                    values.extend_from_slice(s.as_bytes());
+                }
+                let array_data = ArrayData::builder($DATATYPE)
+                    .len(v.len())
+                    .add_buffer(Buffer::from(offsets.to_byte_slice()))
+                    .add_buffer(Buffer::from(&values[..]))
+                    .build();
+                $ty::from(array_data)
+            }
         }
-        let array_data = ArrayData::builder(DataType::Utf8)
-            .len(v.len())
-            .add_buffer(Buffer::from(offsets.to_byte_slice()))
-            .add_buffer(Buffer::from(&values[..]))
-            .build();
-        StringArray::from(array_data)
-    }
+
+        impl<'a> From<Vec<Option<&'a str>>> for $ty {
+            fn from(v: Vec<Option<&'a str>>) -> Self {
+                let mut offsets = Vec::with_capacity(v.len() + 1);
+                let mut values = Vec::new();
+                let num_bytes = bit_util::ceil(v.len(), 8);
+                let mut null_buf =
+                    MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
+                let mut length_so_far = 0;
+                offsets.push(length_so_far);
+                for (i, s) in v.iter().enumerate() {
+                    if let Some(s) = s {
+                        // set null bit
+                        let null_slice = null_buf.data_mut();
+                        bit_util::set_bit(null_slice, i);
+
+                        length_so_far += s.len() as $native_ty;
+                        offsets.push(length_so_far as $native_ty);
+                        values.extend_from_slice(s.as_bytes());
+                    } else {
+                        offsets.push(length_so_far);
+                        values.extend_from_slice("".as_bytes());
+                    }
+                }
+                let array_data = ArrayData::builder($DATATYPE)
+                    .len(v.len())
+                    .add_buffer(Buffer::from(offsets.to_byte_slice()))
+                    .add_buffer(Buffer::from(&values[..]))
+                    .null_bit_buffer(null_buf.freeze())
+                    .build();
+                $ty::from(array_data)
+            }
+        }
+    };
 }
 
-impl<'a> From<Vec<&'a str>> for LargeStringArray {
-    fn from(v: Vec<&'a str>) -> Self {
-        let mut offsets = Vec::with_capacity(v.len() + 1);
-        let mut values = Vec::new();
-        let mut length_so_far = 0;
-        offsets.push(length_so_far);
-        for s in &v {
-            length_so_far += s.len() as i64;
-            offsets.push(length_so_far as i64);
-            values.extend_from_slice(s.as_bytes());
-        }
-        let array_data = ArrayData::builder(DataType::LargeUtf8)
-            .len(v.len())
-            .add_buffer(Buffer::from(offsets.to_byte_slice()))
-            .add_buffer(Buffer::from(&values[..]))
-            .build();
-        LargeStringArray::from(array_data)
-    }
-}
+def_string_from_vec!(StringArray, i32, DataType::Utf8);
+def_string_from_vec!(LargeStringArray, i64, DataType::LargeUtf8);
 
 impl From<Vec<&[u8]>> for BinaryArray {
     fn from(v: Vec<&[u8]>) -> Self {
@@ -1767,38 +1786,6 @@ impl From<Vec<&[u8]>> for LargeBinaryArray {
             .add_buffer(Buffer::from(&values[..]))
             .build();
         LargeBinaryArray::from(array_data)
-    }
-}
-
-impl<'a> TryFrom<Vec<Option<&'a str>>> for StringArray {
-    type Error = ArrowError;
-
-    fn try_from(v: Vec<Option<&'a str>>) -> Result<Self> {
-        let mut builder = StringBuilder::new(v.len());
-        for val in v {
-            if let Some(s) = val {
-                builder.append_value(s)?;
-            } else {
-                builder.append(false)?;
-            }
-        }
-        Ok(builder.finish())
-    }
-}
-
-impl<'a> TryFrom<Vec<Option<&'a str>>> for LargeStringArray {
-    type Error = ArrowError;
-
-    fn try_from(v: Vec<Option<&'a str>>) -> Result<Self> {
-        let mut builder = LargeStringBuilder::new(v.len());
-        for val in v {
-            if let Some(s) = val {
-                builder.append_value(s)?;
-            } else {
-                builder.append(false)?;
-            }
-        }
-        Ok(builder.finish())
     }
 }
 

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -2316,7 +2316,7 @@ where
     /// use arrow::array::{StringArray, StringDictionaryBuilder, PrimitiveBuilder};
     /// use std::convert::TryFrom;
     ///
-    /// let dictionary_values = StringArray::try_from(vec![None, Some("abc"), Some("def")]).unwrap();
+    /// let dictionary_values = StringArray::from(vec![None, Some("abc"), Some("def")]);
     ///
     /// let mut builder = StringDictionaryBuilder::new_with_dictionary(PrimitiveBuilder::<Int16Type>::new(3), &dictionary_values).unwrap();
     /// builder.append("def").unwrap();
@@ -2449,7 +2449,6 @@ mod tests {
 
     use crate::array::Array;
     use crate::bitmap::Bitmap;
-    use std::convert::TryFrom;
 
     #[test]
     fn test_builder_i32_empty() {
@@ -3465,8 +3464,7 @@ mod tests {
 
     #[test]
     fn test_string_dictionary_builder_with_existing_dictionary() {
-        let dictionary =
-            StringArray::try_from(vec![None, Some("def"), Some("abc")]).unwrap();
+        let dictionary = StringArray::from(vec![None, Some("def"), Some("abc")]);
 
         let key_builder = PrimitiveBuilder::<Int8Type>::new(6);
         let mut builder =
@@ -3496,7 +3494,8 @@ mod tests {
 
     #[test]
     fn test_string_dictionary_builder_with_reserved_null_value() {
-        let dictionary = StringArray::try_from(vec![None]).unwrap();
+        let dictionary: Vec<Option<&str>> = vec![None];
+        let dictionary = StringArray::from(dictionary);
 
         let key_builder = PrimitiveBuilder::<Int16Type>::new(4);
         let mut builder =
@@ -3807,14 +3806,14 @@ mod tests {
         builder.append(true)?;
         builder.append(false)?;
 
-        let string_array = StringArray::try_from(vec![
+        let string_array = StringArray::from(vec![
             Some("alpha"),
             Some("beta"),
             None,
             Some("gamma"),
             Some("delta"),
             None,
-        ])?;
+        ]);
         let list_value_offsets = Buffer::from(&[0, 2, 3, 6].to_byte_slice());
         let list_data = ArrayData::new(
             DataType::List(Box::new(DataType::Utf8)),
@@ -3833,7 +3832,7 @@ mod tests {
         ])?;
         let finished = builder.finish();
 
-        let expected_string_array = StringArray::try_from(vec![
+        let expected_string_array = StringArray::from(vec![
             Some("Hello"),
             Some("Arrow"),
             // list_array
@@ -3849,7 +3848,7 @@ mod tests {
             Some("delta"),
             None,
             // slice(0, 0) returns nothing
-        ])?;
+        ]);
         let list_value_offsets = Buffer::from(&[0, 2, 2, 4, 5, 8, 9, 12].to_byte_slice());
         let expected_list_data = ArrayData::new(
             DataType::List(Box::new(DataType::Utf8)),

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -1543,8 +1543,6 @@ impl PartialEq<Value> for NullArray {
 mod tests {
     use super::*;
 
-    use std::convert::TryFrom;
-
     use crate::error::Result;
 
     #[test]
@@ -1795,49 +1793,27 @@ mod tests {
 
         // Test the case where null_count > 0
 
-        let a = StringArray::try_from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("world"),
-            None,
-            None,
-        ])
-        .unwrap();
+        let a =
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None, None]);
 
-        let b = StringArray::try_from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("world"),
-            None,
-            None,
-        ])
-        .unwrap();
+        let b =
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None, None]);
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        let b = StringArray::try_from(vec![
+        let b = StringArray::from(vec![
             Some("hello"),
             Some("foo"),
             None,
             Some("world"),
             None,
             None,
-        ])
-        .unwrap();
+        ]);
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
-        let b = StringArray::try_from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("arrow"),
-            None,
-            None,
-        ])
-        .unwrap();
+        let b =
+            StringArray::from(vec![Some("hello"), None, None, Some("arrow"), None, None]);
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
@@ -1872,49 +1848,45 @@ mod tests {
 
         // Test the case where null_count > 0
 
-        let a = LargeStringArray::try_from(vec![
+        let a = LargeStringArray::from(vec![
             Some("hello"),
             None,
             None,
             Some("world"),
             None,
             None,
-        ])
-        .unwrap();
+        ]);
 
-        let b = LargeStringArray::try_from(vec![
+        let b = LargeStringArray::from(vec![
             Some("hello"),
             None,
             None,
             Some("world"),
             None,
             None,
-        ])
-        .unwrap();
+        ]);
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        let b = LargeStringArray::try_from(vec![
+        let b = LargeStringArray::from(vec![
             Some("hello"),
             Some("foo"),
             None,
             Some("world"),
             None,
             None,
-        ])
-        .unwrap();
+        ]);
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
-        let b = LargeStringArray::try_from(vec![
+        let b = LargeStringArray::from(vec![
             Some("hello"),
             None,
             None,
             Some("arrow"),
             None,
             None,
-        ])
-        .unwrap();
+        ]);
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
@@ -2201,15 +2173,8 @@ mod tests {
     #[test]
     fn test_string_json_equal() {
         // Test the equal case
-        let arrow_array = StringArray::try_from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("world"),
-            None,
-            None,
-        ])
-        .unwrap();
+        let arrow_array =
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None, None]);
         let json_array: Value = serde_json::from_str(
             r#"
             [
@@ -2227,15 +2192,8 @@ mod tests {
         assert!(json_array.eq(&arrow_array));
 
         // Test unequal case
-        let arrow_array = StringArray::try_from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("world"),
-            None,
-            None,
-        ])
-        .unwrap();
+        let arrow_array =
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None, None]);
         let json_array: Value = serde_json::from_str(
             r#"
             [
@@ -2254,8 +2212,7 @@ mod tests {
 
         // Test unequal length case
         let arrow_array =
-            StringArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
-                .unwrap();
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None]);
         let json_array: Value = serde_json::from_str(
             r#"
             [
@@ -2274,8 +2231,7 @@ mod tests {
 
         // Test incorrect type case
         let arrow_array =
-            StringArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
-                .unwrap();
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None]);
         let json_array: Value = serde_json::from_str(
             r#"
             {
@@ -2289,8 +2245,7 @@ mod tests {
 
         // Test incorrect value type case
         let arrow_array =
-            StringArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
-                .unwrap();
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None]);
         let json_array: Value = serde_json::from_str(
             r#"
             [
@@ -2311,15 +2266,8 @@ mod tests {
     #[test]
     fn test_binary_json_equal() {
         // Test the equal case
-        let arrow_array = StringArray::try_from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("world"),
-            None,
-            None,
-        ])
-        .unwrap();
+        let arrow_array =
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None, None]);
         let arrow_array = BinaryArray::from(arrow_array.data());
         let json_array: Value = serde_json::from_str(
             r#"
@@ -2338,15 +2286,8 @@ mod tests {
         assert!(json_array.eq(&arrow_array));
 
         // Test unequal case
-        let arrow_array = StringArray::try_from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("world"),
-            None,
-            None,
-        ])
-        .unwrap();
+        let arrow_array =
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None, None]);
         let json_array: Value = serde_json::from_str(
             r#"
             [
@@ -2365,8 +2306,7 @@ mod tests {
 
         // Test unequal length case
         let arrow_array =
-            StringArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
-                .unwrap();
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None]);
         let json_array: Value = serde_json::from_str(
             r#"
             [
@@ -2385,8 +2325,7 @@ mod tests {
 
         // Test incorrect type case
         let arrow_array =
-            StringArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
-                .unwrap();
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None]);
         let json_array: Value = serde_json::from_str(
             r#"
             {
@@ -2400,8 +2339,7 @@ mod tests {
 
         // Test incorrect value type case
         let arrow_array =
-            StringArray::try_from(vec![Some("hello"), None, None, Some("world"), None])
-                .unwrap();
+            StringArray::from(vec![Some("hello"), None, None, Some("world"), None]);
         let json_array: Value = serde_json::from_str(
             r#"
             [

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -134,7 +134,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::TryFrom;
     use std::sync::Arc;
 
     #[test]
@@ -152,10 +151,11 @@ mod tests {
                 Some(2),
                 None,
             ])) as ArrayRef,
-            Arc::new(
-                StringArray::try_from(vec![Some("hello"), Some("bar"), Some("world")])
-                    .expect("Unable to create string array"),
-            ) as ArrayRef,
+            Arc::new(StringArray::from(vec![
+                Some("hello"),
+                Some("bar"),
+                Some("world"),
+            ])) as ArrayRef,
         ]);
         assert!(re.is_err());
         Ok(())
@@ -164,31 +164,27 @@ mod tests {
     #[test]
     fn test_concat_string_arrays() -> Result<()> {
         let arr = concat(&vec![
-            Arc::new(
-                StringArray::try_from(vec![Some("hello"), Some("world")])
-                    .expect("Unable to create string array"),
-            ) as ArrayRef,
+            Arc::new(StringArray::from(vec![Some("hello"), Some("world")])) as ArrayRef,
             Arc::new(StringArray::from(vec!["1", "2", "3", "4", "6"])).slice(1, 3),
-            Arc::new(
-                StringArray::try_from(vec![Some("foo"), Some("bar"), None, Some("baz")])
-                    .expect("Unable to create string array"),
-            ) as ArrayRef,
-        ])?;
-
-        let expected_output = Arc::new(
-            StringArray::try_from(vec![
-                Some("hello"),
-                Some("world"),
-                Some("2"),
-                Some("3"),
-                Some("4"),
+            Arc::new(StringArray::from(vec![
                 Some("foo"),
                 Some("bar"),
                 None,
                 Some("baz"),
-            ])
-            .expect("Unable to create string array"),
-        ) as ArrayRef;
+            ])) as ArrayRef,
+        ])?;
+
+        let expected_output = Arc::new(StringArray::from(vec![
+            Some("hello"),
+            Some("world"),
+            Some("2"),
+            Some("3"),
+            Some("4"),
+            Some("foo"),
+            Some("bar"),
+            None,
+            Some("baz"),
+        ])) as ArrayRef;
 
         assert!(
             arr.equals(&(*expected_output)),

--- a/rust/arrow/src/compute/kernels/length.rs
+++ b/rust/arrow/src/compute/kernels/length.rs
@@ -141,11 +141,8 @@ mod tests {
 
         assert_eq!(4096, result.len()); // 2^12
 
-        let mut builder = UInt32Builder::new(expected.len());
-        for e in expected {
-            builder.append_value(e)?
-        }
-        assert_eq!(builder.finish(), result);
+        let expected: UInt32Array = expected.into();
+        assert_eq!(expected, result);
         Ok(())
     }
 
@@ -162,12 +159,7 @@ mod tests {
         let a = length(&array)?;
         assert_eq!(a.len(), array.len());
 
-        let mut expected = UInt32Builder::new(4);
-        expected.append_value(3)?;
-        expected.append_null()?;
-        expected.append_value(5)?;
-        expected.append_value(4)?;
-        let expected = expected.finish();
+        let expected: UInt32Array = vec![Some(3), None, Some(5), Some(4)].into();
 
         assert_eq!(expected.data(), a.data());
         Ok(())
@@ -176,9 +168,7 @@ mod tests {
     /// Tests that length is not valid for u64.
     #[test]
     fn wrong_type() -> Result<()> {
-        let mut builder = UInt64Builder::new(1);
-        builder.append_value(1)?;
-        let array = builder.finish();
+        let array: UInt64Array = vec![1u64].into();
 
         assert!(length(&array).is_err());
         Ok(())

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -257,13 +257,13 @@ pub struct SortColumn {
 ///         options: None,
 ///     },
 ///     SortColumn {
-///         values: Arc::new(StringArray::try_from(vec![
+///         values: Arc::new(StringArray::from(vec![
 ///             Some("hello"),
 ///             Some("world"),
 ///             Some(","),
 ///             Some("foobar"),
 ///             Some("!"),
-///         ]).unwrap()) as ArrayRef,
+///         ])) as ArrayRef,
 ///         options: Some(SortOptions {
 ///             descending: true,
 ///             nulls_first: false,
@@ -373,7 +373,7 @@ pub fn lexsort_to_indices(columns: &[SortColumn]) -> Result<UInt32Array> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{convert::TryFrom, sync::Arc};
+    use std::sync::Arc;
 
     fn test_sort_to_indices_primitive_arrays<T>(
         data: Vec<Option<T::Native>>,
@@ -409,7 +409,7 @@ mod tests {
         options: Option<SortOptions>,
         expected_data: Vec<u32>,
     ) {
-        let output = StringArray::try_from(data).expect("Unable to create string array");
+        let output = StringArray::from(data);
         let expected = UInt32Array::from(expected_data);
         let output = sort_to_indices(&(Arc::new(output) as ArrayRef), options).unwrap();
         assert!(output.equals(&expected))
@@ -420,9 +420,8 @@ mod tests {
         options: Option<SortOptions>,
         expected_data: Vec<Option<&str>>,
     ) {
-        let output = StringArray::try_from(data).expect("Unable to create string array");
-        let expected =
-            StringArray::try_from(expected_data).expect("Unable to create string array");
+        let output = StringArray::from(data);
+        let expected = StringArray::from(expected_data);
         let output = sort(&(Arc::new(output) as ArrayRef), options).unwrap();
         let output = output.as_any().downcast_ref::<StringArray>().unwrap();
         assert!(output.equals(&expected))
@@ -984,10 +983,7 @@ mod tests {
                 options: None,
             },
             SortColumn {
-                values: Arc::new(
-                    StringArray::try_from(vec![Some("foo")])
-                        .expect("Unable to create string array"),
-                ) as ArrayRef,
+                values: Arc::new(StringArray::from(vec![Some("foo")])) as ArrayRef,
                 options: None,
             },
         ];
@@ -1065,15 +1061,12 @@ mod tests {
                 }),
             },
             SortColumn {
-                values: Arc::new(
-                    StringArray::try_from(vec![
-                        Some("foo"),
-                        Some("9"),
-                        Some("7"),
-                        Some("bar"),
-                    ])
-                    .expect("Unable to create string array"),
-                ) as ArrayRef,
+                values: Arc::new(StringArray::from(vec![
+                    Some("foo"),
+                    Some("9"),
+                    Some("7"),
+                    Some("bar"),
+                ])) as ArrayRef,
                 options: Some(SortOptions {
                     descending: true,
                     nulls_first: true,
@@ -1087,15 +1080,12 @@ mod tests {
                 Some(0),
                 Some(-1),
             ])) as ArrayRef,
-            Arc::new(
-                StringArray::try_from(vec![
-                    Some("9"),
-                    Some("foo"),
-                    Some("bar"),
-                    Some("7"),
-                ])
-                .expect("Unable to create string array"),
-            ) as ArrayRef,
+            Arc::new(StringArray::from(vec![
+                Some("9"),
+                Some("foo"),
+                Some("bar"),
+                Some("7"),
+            ])) as ArrayRef,
         ];
         test_lex_sort_arrays(input, expected);
 
@@ -1114,15 +1104,12 @@ mod tests {
                 }),
             },
             SortColumn {
-                values: Arc::new(
-                    StringArray::try_from(vec![
-                        Some("foo"),
-                        Some("world"),
-                        Some("hello"),
-                        None,
-                    ])
-                    .expect("Unable to create string array"),
-                ) as ArrayRef,
+                values: Arc::new(StringArray::from(vec![
+                    Some("foo"),
+                    Some("world"),
+                    Some("hello"),
+                    None,
+                ])) as ArrayRef,
                 options: Some(SortOptions {
                     descending: true,
                     nulls_first: true,
@@ -1136,15 +1123,12 @@ mod tests {
                 Some(2),
                 Some(-1),
             ])) as ArrayRef,
-            Arc::new(
-                StringArray::try_from(vec![
-                    None,
-                    Some("foo"),
-                    Some("hello"),
-                    Some("world"),
-                ])
-                .expect("Unable to create string array"),
-            ) as ArrayRef,
+            Arc::new(StringArray::from(vec![
+                None,
+                Some("foo"),
+                Some("hello"),
+                Some("world"),
+            ])) as ArrayRef,
         ];
         test_lex_sort_arrays(input, expected);
 
@@ -1163,15 +1147,12 @@ mod tests {
                 }),
             },
             SortColumn {
-                values: Arc::new(
-                    StringArray::try_from(vec![
-                        Some("foo"),
-                        Some("world"),
-                        Some("hello"),
-                        None,
-                    ])
-                    .expect("Unable to create string array"),
-                ) as ArrayRef,
+                values: Arc::new(StringArray::from(vec![
+                    Some("foo"),
+                    Some("world"),
+                    Some("hello"),
+                    None,
+                ])) as ArrayRef,
                 options: Some(SortOptions {
                     descending: true,
                     nulls_first: false,
@@ -1185,15 +1166,12 @@ mod tests {
                 None,
                 None,
             ])) as ArrayRef,
-            Arc::new(
-                StringArray::try_from(vec![
-                    Some("hello"),
-                    Some("world"),
-                    Some("foo"),
-                    None,
-                ])
-                .expect("Unable to create string array"),
-            ) as ArrayRef,
+            Arc::new(StringArray::from(vec![
+                Some("hello"),
+                Some("world"),
+                Some("foo"),
+                None,
+            ])) as ArrayRef,
         ];
         test_lex_sort_arrays(input, expected);
 
@@ -1213,16 +1191,13 @@ mod tests {
                 }),
             },
             SortColumn {
-                values: Arc::new(
-                    StringArray::try_from(vec![
-                        Some("foo"),
-                        Some("bar"),
-                        Some("world"),
-                        Some("hello"),
-                        None,
-                    ])
-                    .expect("Unable to create string array"),
-                ) as ArrayRef,
+                values: Arc::new(StringArray::from(vec![
+                    Some("foo"),
+                    Some("bar"),
+                    Some("world"),
+                    Some("hello"),
+                    None,
+                ])) as ArrayRef,
                 options: Some(SortOptions {
                     descending: true,
                     nulls_first: true,
@@ -1237,16 +1212,13 @@ mod tests {
                 None,
                 None,
             ])) as ArrayRef,
-            Arc::new(
-                StringArray::try_from(vec![
-                    Some("hello"),
-                    Some("bar"),
-                    Some("world"),
-                    None,
-                    Some("foo"),
-                ])
-                .expect("Unable to create string array"),
-            ) as ArrayRef,
+            Arc::new(StringArray::from(vec![
+                Some("hello"),
+                Some("bar"),
+                Some("world"),
+                None,
+                Some("foo"),
+            ])) as ArrayRef,
         ];
         test_lex_sort_arrays(input, expected);
     }

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -279,7 +279,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::convert::TryFrom;
 
     fn test_take_primitive_arrays<'a, T>(
         data: Vec<Option<T::Native>>,
@@ -739,7 +738,7 @@ mod tests {
         let result_values: StringArray = result.values().data().into();
 
         // dictionary values should stay the same
-        let expected_values = StringArray::try_from(vec!["foo", "bar", ""]).unwrap();
+        let expected_values = StringArray::from(vec!["foo", "bar", ""]);
         assert_eq!(&expected_values, dict_values);
         assert_eq!(&expected_values, &result_values);
 

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -540,7 +540,6 @@ fn json_from_fixed_size_list_col(
 mod tests {
     use super::*;
 
-    use std::convert::TryFrom;
     use std::fs::File;
     use std::io::Read;
     use std::sync::Arc;
@@ -732,7 +731,7 @@ mod tests {
             vec![None, None, Some(-6473623571954960143)],
             nanos_tz,
         );
-        let utf8s = StringArray::try_from(vec![Some("aa"), None, Some("bbb")]).unwrap();
+        let utf8s = StringArray::from(vec![Some("aa"), None, Some("bbb")]);
 
         let value_data = Int32Array::from(vec![None, Some(2), None, None]);
         let value_offsets = Buffer::from(&[0, 3, 4, 4].to_byte_slice());
@@ -745,8 +744,7 @@ mod tests {
         let lists = ListArray::from(list_data);
 
         let structs_int32s = Int32Array::from(vec![None, Some(-2), None]);
-        let structs_utf8s =
-            StringArray::try_from(vec![None, None, Some("aaaaaa")]).unwrap();
+        let structs_utf8s = StringArray::from(vec![None, None, Some("aaaaaa")]);
         let structs = StructArray::from(vec![
             (
                 Field::new("int32s", DataType::Int32, true),


### PR DESCRIPTION
This PR:

* adds a benchmark to StringArray's `try_from(Vec<Option<&str>>)`
* Replaces `TryFrom` by `From`
* improves performance by 50% by not using `StringBuilder`
* adds the same functionality to `LargeStringArray` (through a macro)

Benchmarks on my computer:
```
array_string_from_vec 128                                                                             
                        time:   [3.4717 us 3.4818 us 3.4928 us]
                        change: [-52.364% -51.639% -50.913%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

array_string_from_vec 256                                                                             
                        time:   [4.9325 us 4.9397 us 4.9475 us]
                        change: [-52.324% -51.120% -50.268%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe

array_string_from_vec 512                                                                             
                        time:   [7.3873 us 7.4032 us 7.4204 us]
                        change: [-51.805% -51.144% -50.502%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe
```