### PR TITLE
ARROW-9922: [Rust] Add StructArray::TryFrom (+40%)

### DIFF
--- a/rust/arrow/benches/array_from_vec.rs
+++ b/rust/arrow/benches/array_from_vec.rs
@@ -48,6 +48,68 @@ fn array_string_from_vec(n: usize) {
     criterion::black_box(StringArray::from(v));
 }
 
+fn struct_array_values(n: usize) -> (Field, Vec<Option<&'static str>>, Field, Vec<Option<i32>>) {
+    let mut strings: Vec<Option<&str>> = Vec::with_capacity(n);
+    let mut ints: Vec<Option<i32>> = Vec::with_capacity(n);
+    for _ in 0..n / 4 {
+        strings.extend_from_slice(&[Some("joe"), None, None, Some("mark")]);
+        ints.extend_from_slice(&[Some(1), Some(2), None, Some(4)]);
+    }
+    (Field::new("f1", DataType::Utf8, false),
+     strings, Field::new("f2", DataType::Int32, false), ints)
+}
+
+fn struct_array_from_vec(field1: &Field, strings: &Vec<Option<&str>>, field2: &Field, ints: &Vec<Option<i32>>) {
+
+    criterion::black_box({
+        let len = strings.len();
+        // this cheats a bit, as the compiler knows the that they will be strings and i32, but well
+        let string_builder = StringBuilder::new(len);
+        let int_builder = Int32Builder::new(len);
+
+        let mut fields = Vec::new();
+        let mut field_builders = Vec::new();
+        fields.push(field1.clone());
+        field_builders.push(Box::new(string_builder) as Box<dyn ArrayBuilder>);
+        fields.push(field2.clone());
+        field_builders.push(Box::new(int_builder) as Box<dyn ArrayBuilder>);
+
+        let mut builder = StructBuilder::new(fields, field_builders);
+        assert_eq!(2, builder.num_fields());
+
+        let string_builder = builder
+            .field_builder::<StringBuilder>(0)
+            .expect("builder at field 0 should be string builder");
+        for string in strings {
+            if string.is_some() {
+                string_builder.append_value(string.unwrap()).unwrap();
+            } else {
+                string_builder.append_null().unwrap();
+            }
+        }
+
+        let int_builder = builder
+            .field_builder::<Int32Builder>(1)
+            .expect("builder at field 1 should be int builder");
+        for int in ints {
+            if int.is_some() {
+                int_builder.append_value(int.unwrap()).unwrap();
+            } else {
+                int_builder.append_null().unwrap();
+            }
+        }
+
+        for _ in 0..len / 4 {
+            builder.append(true).unwrap();
+            builder.append(true).unwrap();
+            builder.append_null().unwrap();
+            builder.append(true).unwrap();
+        }
+
+        builder.finish();
+    });
+}
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("array_from_vec 128", |b| b.iter(|| array_from_vec(128)));
     c.bench_function("array_from_vec 256", |b| b.iter(|| array_from_vec(256)));
@@ -61,6 +123,26 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
     c.bench_function("array_string_from_vec 512", |b| {
         b.iter(|| array_string_from_vec(512))
+    });
+
+    let (field1, strings, field2, ints) = struct_array_values(128);
+    c.bench_function("struct_array_from_vec 128", |b| {
+        b.iter(|| struct_array_from_vec(&field1, &strings, &field2, &ints))
+    });
+
+    let (field1, strings, field2, ints) = struct_array_values(256);
+    c.bench_function("struct_array_from_vec 256", |b| {
+        b.iter(|| struct_array_from_vec(&field1, &strings, &field2, &ints))
+    });
+
+    let (field1, strings, field2, ints) = struct_array_values(512);
+    c.bench_function("struct_array_from_vec 512", |b| {
+        b.iter(|| struct_array_from_vec(&field1, &strings, &field2, &ints))
+    });
+
+    let (field1, strings, field2, ints) = struct_array_values(1024);
+    c.bench_function("struct_array_from_vec 1024", |b| {
+        b.iter(|| struct_array_from_vec(&field1, &strings, &field2, &ints))
     });
 }
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use std::any::Any;
-use std::convert::From;
+use std::convert::{From, TryFrom};
 use std::fmt;
 use std::io::Write;
 use std::iter::{FromIterator, IntoIterator};
@@ -28,11 +28,14 @@ use chrono::prelude::*;
 use super::*;
 use crate::array::builder::StringDictionaryBuilder;
 use crate::array::equal::JsonEqual;
-use crate::buffer::{Buffer, MutableBuffer};
+use crate::buffer::{buffer_bin_or, Buffer, MutableBuffer};
 use crate::datatypes::DataType::Struct;
 use crate::datatypes::*;
 use crate::memory;
-use crate::util::bit_util;
+use crate::{
+    error::{ArrowError, Result},
+    util::bit_util,
+};
 
 /// Number of seconds in a day
 const SECONDS_IN_DAY: i64 = 86_400;
@@ -358,6 +361,13 @@ fn slice_data(data: &ArrayDataRef, mut offset: usize, length: usize) -> ArrayDat
     };
 
     Arc::new(new_data)
+}
+
+// creates a new MutableBuffer initializes all falsed
+// this is useful to populate null bitmaps
+fn make_null_buffer(len: usize) -> MutableBuffer {
+    let num_bytes = bit_util::ceil(len, 8);
+    MutableBuffer::new(num_bytes).with_bitset(num_bytes, false)
 }
 
 /// ----------------------------------------------------------------------------
@@ -703,9 +713,7 @@ macro_rules! def_numeric_from_vec {
         {
             fn from(data: Vec<Option<<$ty as ArrowPrimitiveType>::Native>>) -> Self {
                 let data_len = data.len();
-                let num_bytes = bit_util::ceil(data_len, 8);
-                let mut null_buf =
-                    MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
+                let mut null_buf = make_null_buffer(data_len);
                 let mut val_buf = MutableBuffer::new(
                     data_len * mem::size_of::<<$ty as ArrowPrimitiveType>::Native>(),
                 );
@@ -780,8 +788,7 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
     pub fn from_opt_vec(data: Vec<Option<i64>>, timezone: Option<Arc<String>>) -> Self {
         // TODO: duplicated from def_numeric_from_vec! macro, it looks possible to convert to generic
         let data_len = data.len();
-        let num_bytes = bit_util::ceil(data_len, 8);
-        let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
+        let mut null_buf = make_null_buffer(data_len);
         let mut val_buf = MutableBuffer::new(data_len * mem::size_of::<i64>());
 
         {
@@ -812,8 +819,7 @@ impl<T: ArrowTimestampType> PrimitiveArray<T> {
 /// Constructs a boolean array from a vector. Should only be used for testing.
 impl From<Vec<bool>> for BooleanArray {
     fn from(data: Vec<bool>) -> Self {
-        let num_byte = bit_util::ceil(data.len(), 8);
-        let mut mut_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, false);
+        let mut mut_buf = make_null_buffer(data.len());
         {
             let mut_slice = mut_buf.data_mut();
             for (i, b) in data.iter().enumerate() {
@@ -834,7 +840,7 @@ impl From<Vec<Option<bool>>> for BooleanArray {
     fn from(data: Vec<Option<bool>>) -> Self {
         let data_len = data.len();
         let num_byte = bit_util::ceil(data_len, 8);
-        let mut null_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, false);
+        let mut null_buf = make_null_buffer(data.len());
         let mut val_buf = MutableBuffer::new(num_byte).with_bitset(num_byte, false);
 
         {
@@ -1642,9 +1648,7 @@ macro_rules! def_string_from_vec {
             fn from(v: Vec<Option<&'a str>>) -> Self {
                 let mut offsets = Vec::with_capacity(v.len() + 1);
                 let mut values = Vec::new();
-                let num_bytes = bit_util::ceil(v.len(), 8);
-                let mut null_buf =
-                    MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
+                let mut null_buf = make_null_buffer(v.len());
                 let mut length_so_far = 0;
                 offsets.push(length_so_far);
                 for (i, s) in v.iter().enumerate() {
@@ -1999,6 +2003,67 @@ impl From<ArrayDataRef> for StructArray {
             boxed_fields.push(make_array(child_data));
         }
         Self { data, boxed_fields }
+    }
+}
+
+impl TryFrom<Vec<(&str, ArrayRef)>> for StructArray {
+    type Error = ArrowError;
+
+    /// builds a StructArray from a vector of names and arrays.
+    /// This errors if the values have a different length.
+    /// An entry is set to Null when all values are null.
+    fn try_from(values: Vec<(&str, ArrayRef)>) -> Result<Self> {
+        let values_len = values.len();
+
+        // these will be populated
+        let mut fields = Vec::with_capacity(values_len);
+        let mut child_data = Vec::with_capacity(values_len);
+
+        // len: the size of the arrays.
+        let mut len: Option<usize> = None;
+        // null: the null mask of the arrays.
+        let mut null: Option<Buffer> = None;
+        for (field_name, array) in values {
+            let child_datum = array.data();
+            if let Some(len) = len {
+                if len != child_datum.len() {
+                    return Err(ArrowError::InvalidArgumentError(
+                        format!("Array of field \"{}\" has length {}, but previous elements have length {}. 
+                        All arrays in every entry in a struct array must have the same length.", field_name, child_datum.len(), len)
+                    ));
+                }
+            } else {
+                len = Some(child_datum.len())
+            }
+            child_data.push(child_datum.clone());
+            fields.push(Field::new(
+                field_name,
+                array.data_type().clone(),
+                child_datum.null_buffer().is_some(),
+            ));
+
+            if let Some(child_null_buffer) = child_datum.null_buffer() {
+                null = Some(if let Some(null_buffer) = &null {
+                    buffer_bin_or(null_buffer, 0, child_null_buffer, 0, null_buffer.len())
+                } else {
+                    child_null_buffer.clone()
+                });
+            } else if null.is_some() {
+                // when one of the fields has no nulls, them there is no null in the array
+                null = None;
+            }
+        }
+        let len = len.unwrap();
+
+        let mut builder = ArrayData::builder(DataType::Struct(fields.clone()))
+            .len(len)
+            .child_data(child_data);
+        if let Some(null_buffer) = null {
+            let null_count = len - bit_util::count_set_bits(null_buffer.data());
+            builder = builder.null_count(null_count).null_bit_buffer(null_buffer);
+        }
+
+        Ok(StructArray::from(builder.build()))
     }
 }
 
@@ -2382,7 +2447,7 @@ mod tests {
 
     use crate::buffer::Buffer;
     use crate::datatypes::{DataType, Field};
-    use crate::memory;
+    use crate::{bitmap::Bitmap, memory};
 
     #[test]
     fn test_primitive_array_from_vec() {
@@ -3856,6 +3921,92 @@ mod tests {
         assert_eq!(4, struct_array.len());
         assert_eq!(0, struct_array.null_count());
         assert_eq!(0, struct_array.offset());
+    }
+
+    /// validates that the in-memory representation follows [the spec](https://arrow.apache.org/docs/format/Columnar.html#struct-layout)
+    #[test]
+    fn test_struct_array_from_vec() {
+        let strings: ArrayRef = Arc::new(StringArray::from(vec![
+            Some("joe"),
+            None,
+            None,
+            Some("mark"),
+        ]));
+        let ints: ArrayRef =
+            Arc::new(Int32Array::from(vec![Some(1), Some(2), None, Some(4)]));
+
+        let arr =
+            StructArray::try_from(vec![("f1", strings.clone()), ("f2", ints.clone())])
+                .unwrap();
+
+        let struct_data = arr.data();
+        assert_eq!(4, struct_data.len());
+        assert_eq!(1, struct_data.null_count());
+        assert_eq!(
+            // 00001011
+            &Some(Bitmap::from(Buffer::from(&[11_u8]))),
+            struct_data.null_bitmap()
+        );
+
+        let expected_string_data = ArrayData::builder(DataType::Utf8)
+            .len(4)
+            .null_count(2)
+            .null_bit_buffer(Buffer::from(&[9_u8]))
+            .add_buffer(Buffer::from(&[0, 3, 3, 3, 7].to_byte_slice()))
+            .add_buffer(Buffer::from("joemark".as_bytes()))
+            .build();
+
+        let expected_int_data = ArrayData::builder(DataType::Int32)
+            .len(4)
+            .null_count(1)
+            .null_bit_buffer(Buffer::from(&[11_u8]))
+            .add_buffer(Buffer::from(&[1, 2, 0, 4].to_byte_slice()))
+            .build();
+
+        assert_eq!(expected_string_data, arr.column(0).data());
+
+        // TODO: implement equality for ArrayData
+        assert_eq!(expected_int_data.len(), arr.column(1).data().len());
+        assert_eq!(
+            expected_int_data.null_count(),
+            arr.column(1).data().null_count()
+        );
+        assert_eq!(
+            expected_int_data.null_bitmap(),
+            arr.column(1).data().null_bitmap()
+        );
+        let expected_value_buf = expected_int_data.buffers()[0].clone();
+        let actual_value_buf = arr.column(1).data().buffers()[0].clone();
+        for i in 0..expected_int_data.len() {
+            if !expected_int_data.is_null(i) {
+                assert_eq!(
+                    expected_value_buf.data()[i * 4..(i + 1) * 4],
+                    actual_value_buf.data()[i * 4..(i + 1) * 4]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_struct_array_from_vec_error() {
+        let strings: ArrayRef = Arc::new(StringArray::from(vec![
+            Some("joe"),
+            None,
+            None,
+            // 3 elements, not 4
+        ]));
+        let ints: ArrayRef =
+            Arc::new(Int32Array::from(vec![Some(1), Some(2), None, Some(4)]));
+
+        let arr =
+            StructArray::try_from(vec![("f1", strings.clone()), ("f2", ints.clone())]);
+
+        match arr {
+            Err(ArrowError::InvalidArgumentError(e)) => {
+                assert!(e.starts_with("Array of field \"f2\" has length 4, but previous elements have length 3."));
+            }
+            _ => assert!(false, "This test got an unexpected error type"),
+        };
     }
 
     #[test]

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -2055,7 +2055,7 @@ impl TryFrom<Vec<(&str, ArrayRef)>> for StructArray {
         }
         let len = len.unwrap();
 
-        let mut builder = ArrayData::builder(DataType::Struct(fields.clone()))
+        let mut builder = ArrayData::builder(DataType::Struct(fields))
             .len(len)
             .child_data(child_data);
         if let Some(null_buffer) = null {


### PR DESCRIPTION
The core problem that this PR addresses is the construction of a `StructArray`, whose spec can be found [here](https://arrow.apache.org/docs/format/Columnar.html#struct-layout).

The current API to build a `StructArray` of 4 entries of fixed type is (part of a test):

```rust
let string_builder = StringBuilder::new(4);
let int_builder = Int32Builder::new(4);

let mut fields = Vec::new();
let mut field_builders = Vec::new();
fields.push(Field::new("f1", DataType::Utf8, false));
field_builders.push(Box::new(string_builder) as Box<ArrayBuilder>);
fields.push(Field::new("f2", DataType::Int32, false));
field_builders.push(Box::new(int_builder) as Box<ArrayBuilder>);

let mut builder = StructBuilder::new(fields, field_builders);
assert_eq!(2, builder.num_fields());

let string_builder = builder
    .field_builder::<StringBuilder>(0)
    .expect("builder at field 0 should be string builder");
string_builder.append_value("joe").unwrap();
string_builder.append_null().unwrap();
string_builder.append_null().unwrap();
string_builder.append_value("mark").unwrap();

let int_builder = builder
    .field_builder::<Int32Builder>(1)
    .expect("builder at field 1 should be int builder");
int_builder.append_value(1).unwrap();
int_builder.append_value(2).unwrap();
int_builder.append_null().unwrap();
int_builder.append_value(4).unwrap();

builder.append(true).unwrap();
builder.append(true).unwrap();
builder.append_null().unwrap();
builder.append(true).unwrap();

let arr = builder.finish();
```

This PR's proposal for the same array:

```rust
let strings: ArrayRef = Arc::new(StringArray::from(vec![
    Some("joe"),
    None,
    None,
    Some("mark"),
]));
let ints: ArrayRef = Arc::new(Int32Array::from(vec![Some(1), Some(2), None, Some(4)]));

let arr = StructArray::try_from(vec![("f1", strings.clone()), ("f2", ints.clone())]).unwrap();
```

Note that:

* There is no `Field`, only name: the attributes (type and nullability) are obtained from the `ArrayData`'s itself, and thus there a guarantee that the field's attributes are aligned with the Data.
* The implementation is dynamically typed: the type is obtained from `Array::data_type`, instead of having to match Field's datatype to each field' builders
* `Option` is used to specify whether the quantity is null or not

The construction uses an OR on the entry's null bitmaps to decide whether the struct null bitmap is null at a given index. I.e. the third index of the example in [the spec](https://arrow.apache.org/docs/format/Columnar.html#struct-layout) is obtained by checking if all fields are null at that index.

There is an edge case, that this constructor is unable to build (and the user needs to use the other `From`): a struct with a `0` at position X and all field's bitmap at position X to be `1`:

```
# array of 1 entry:
bitmap struct = [0]
bitmap field1 = [1]
bitmap field2 = [1]
```

this is because, in this `TryFrom`, the bitmap of the struct is computed from a bitwise `or` of the field's entries.

IMO this is a non-issue because a `null` in the struct already implies an `unspecified` value on every field and thus that field's value is already assumed to be undefined. However, this is important to mention as a round-trip with this case will fail: in the example above, `bitmap struct` will have a `1`.

Finally, this has a performance improvement of 40%.

<details>
  <summary>Benchmark results</summary>

```
git checkout HEAD^ && cargo bench --bench array_from_vec -- struct_array_from_vec && git checkout no_builder1 && cargo bench --bench array_from_vec -- struct_array_from_vec
```

```
struct_array_from_vec 128                                                                             
                        time:   [7.7464 us 7.7586 us 7.7731 us]
                        change: [-39.227% -38.313% -37.128%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

struct_array_from_vec 256                                                                             
                        time:   [9.3386 us 9.3611 us 9.3896 us]
                        change: [-45.035% -44.498% -43.914%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  7 (7.00%) high severe

struct_array_from_vec 512                                                                             
                        time:   [13.107 us 13.148 us 13.199 us]
                        change: [-49.213% -48.705% -48.208%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  10 (10.00%) high severe

struct_array_from_vec 1024                                                                             
                        time:   [20.036 us 20.061 us 20.087 us]
                        change: [-54.254% -53.479% -52.776%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe
```
</details>

## Final note:

The general direction that I am heading with this is to minimize the usage of builders. My issue with builders is that they are statically typed and perform incremental changes, but almost all our operations are dynamically typed and in bulk: batch read, batch write, etc. As such, it is often faster (and much simpler from UX's perspective) to create a `Vec<Option<_>>` and use it to create an Arrow Array.

FYI @nevi-me @andygrove @alamb 