### PR TITLE
ARROW-9925: [GLib] Add low level value readers for GArrowListArray family

### DIFF
--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -140,6 +140,53 @@ garrow_base_list_array_get_value(GArrowArray *array,
                               "parent", array,
                               NULL);
 };
+
+template <typename LIST_ARRAY_CLASS>
+GArrowArray *
+garrow_base_list_array_get_values(GArrowArray *array)
+{
+  auto arrow_array = garrow_array_get_raw(array);
+  auto arrow_list_array =
+    std::static_pointer_cast<LIST_ARRAY_CLASS>(arrow_array);
+  auto arrow_values = arrow_list_array->values();
+  return garrow_array_new_raw(&arrow_values,
+                              "array", &arrow_values,
+                              "parent", array,
+                              NULL);
+};
+
+template <typename LIST_ARRAY_CLASS>
+typename LIST_ARRAY_CLASS::offset_type
+garrow_base_list_array_get_value_offset(GArrowArray *array, gint64 i)
+{
+  auto arrow_array = garrow_array_get_raw(array);
+  auto arrow_list_array =
+    std::static_pointer_cast<LIST_ARRAY_CLASS>(arrow_array);
+  return arrow_list_array->value_offset(i);
+};
+
+template <typename LIST_ARRAY_CLASS>
+typename LIST_ARRAY_CLASS::offset_type
+garrow_base_list_array_get_value_length(GArrowArray *array, gint64 i)
+{
+  auto arrow_array = garrow_array_get_raw(array);
+  auto arrow_list_array =
+    std::static_pointer_cast<LIST_ARRAY_CLASS>(arrow_array);
+  return arrow_list_array->value_length(i);
+};
+
+template <typename LIST_ARRAY_CLASS>
+const typename LIST_ARRAY_CLASS::offset_type *
+garrow_base_list_array_get_value_offsets(GArrowArray *array, gint64 *n_offsets)
+{
+  auto arrow_array = garrow_array_get_raw(array);
+  *n_offsets = arrow_array->length() + 1;
+  auto arrow_list_array =
+    std::static_pointer_cast<LIST_ARRAY_CLASS>(arrow_array);
+  return arrow_list_array->raw_value_offsets();
+};
+
+
 G_BEGIN_DECLS
 
 static void
@@ -277,6 +324,70 @@ garrow_list_array_get_value(GArrowListArray *array,
 {
   return garrow_base_list_array_get_value<arrow::ListArray>(
     GARROW_ARRAY(array), i);
+}
+
+/**
+ * garrow_list_array_get_values:
+ * @array: A #GArrowListArray.
+ *
+ * Returns: (transfer full): The array containing the list's values.
+ *
+ * Since: 2.0.0
+ */
+GArrowArray *
+garrow_list_array_get_values(GArrowListArray *array)
+{
+  return garrow_base_list_array_get_values<arrow::ListArray>(
+    GARROW_ARRAY(array));
+}
+
+/**
+ * garrow_list_array_get_offset:
+ * @array: A #GArrowListArray.
+ * @i: The index of the offset of the target value.
+ *
+ * Returns: The target offset in the array containing the list's values.
+ *
+ * Since: 2.0.0
+ */
+gint32
+garrow_list_array_get_value_offset(GArrowListArray *array, gint64 i)
+{
+  return garrow_base_list_array_get_value_offset<arrow::ListArray>(
+    GARROW_ARRAY(array), i);
+}
+
+/**
+ * garrow_list_array_get_value_length:
+ * @array: A #GArrowListArray.
+ * @i: The index of the length of the target value.
+ *
+ * Returns: The target length in the array containing the list's values.
+ *
+ * Since: 2.0.0
+ */
+gint32
+garrow_list_array_get_value_length(GArrowListArray *array, gint64 i)
+{
+  return garrow_base_list_array_get_value_length<arrow::ListArray>(
+    GARROW_ARRAY(array), i);
+}
+
+/**
+ * garrow_list_array_get_value_offsets:
+ * @array: A #GArrowListArray.
+ * @n_offsets: The number of offsets to be returned.
+ *
+ * Returns: (array length=n_offsets): The target offsets in the array
+ * containing the list's values.
+ *
+ * Since: 2.0.0
+ */
+const gint32 *
+garrow_list_array_get_value_offsets(GArrowListArray *array, gint64 *n_offsets)
+{
+  return garrow_base_list_array_get_value_offsets<arrow::ListArray>(
+    GARROW_ARRAY(array), n_offsets);
 }
 
 
@@ -432,6 +543,71 @@ garrow_large_list_array_get_value(GArrowLargeListArray *array,
   return garrow_base_list_array_get_value<arrow::LargeListArray>(
     GARROW_ARRAY(array),
     i);
+}
+
+/**
+ * garrow_large_list_array_get_values:
+ * @array: A #GArrowLargeListArray.
+ *
+ * Returns: (transfer full): The array containing the list's values.
+ *
+ * Since: 2.0.0
+ */
+GArrowArray *
+garrow_large_list_array_get_values(GArrowLargeListArray *array)
+{
+  return garrow_base_list_array_get_values<arrow::LargeListArray>(
+    GARROW_ARRAY(array));
+}
+
+/**
+ * garrow_large_list_array_get_value_offset:
+ * @array: A #GArrowLargeListArray.
+ * @i: The index of the offset of the target value.
+ *
+ * Returns: The target offset in the array containing the list's values.
+ *
+ * Since: 2.0.0
+ */
+gint64
+garrow_large_list_array_get_value_offset(GArrowLargeListArray *array, gint64 i)
+{
+  return garrow_base_list_array_get_value_offset<arrow::LargeListArray>(
+    GARROW_ARRAY(array), i);
+}
+
+/**
+ * garrow_large_list_array_get_length:
+ * @array: A #GArrowLargeListArray.
+ * @i: The index of the length of the target value.
+ *
+ * Returns: The target length in the array containing the list's values.
+ *
+ * Since: 2.0.0
+ */
+gint64
+garrow_large_list_array_get_value_length(GArrowLargeListArray *array, gint64 i)
+{
+  return garrow_base_list_array_get_value_length<arrow::LargeListArray>(
+    GARROW_ARRAY(array), i);
+}
+
+/**
+ * garrow_large_list_array_get_value_offsets:
+ * @array: A #GArrowLargeListArray.
+ * @n_offsets: The number of offsets to be returned.
+ *
+ * Returns: (array length=n_offsets): The target offsets in the array
+ * containing the list's values.
+ *
+ * Since: 2.0.0
+ */
+const gint64 *
+garrow_large_list_array_get_value_offsets(GArrowLargeListArray *array,
+                                          gint64 *n_offsets)
+{
+  return garrow_base_list_array_get_value_offsets<arrow::LargeListArray>(
+    GARROW_ARRAY(array), n_offsets);
 }
 
 

--- a/c_glib/arrow-glib/composite-array.h
+++ b/c_glib/arrow-glib/composite-array.h
@@ -47,6 +47,18 @@ GArrowListArray *garrow_list_array_new(GArrowDataType *data_type,
 GArrowDataType *garrow_list_array_get_value_type(GArrowListArray *array);
 GArrowArray *garrow_list_array_get_value(GArrowListArray *array,
                                          gint64 i);
+GARROW_AVAILABLE_IN_2_0
+GArrowArray *garrow_list_array_get_values(GArrowListArray *array);
+GARROW_AVAILABLE_IN_2_0
+gint32 garrow_list_array_get_value_offset(GArrowListArray *array,
+                                          gint64 i);
+GARROW_AVAILABLE_IN_2_0
+gint32 garrow_list_array_get_value_length(GArrowListArray *array,
+                                          gint64 i);
+GARROW_AVAILABLE_IN_2_0
+const gint32 *
+garrow_list_array_get_value_offsets(GArrowListArray *array,
+                                    gint64 *n_offsets);
 
 
 #define GARROW_TYPE_LARGE_LIST_ARRAY (garrow_large_list_array_get_type())
@@ -73,6 +85,18 @@ GArrowDataType *garrow_large_list_array_get_value_type(GArrowLargeListArray *arr
 GARROW_AVAILABLE_IN_0_16
 GArrowArray *garrow_large_list_array_get_value(GArrowLargeListArray *array,
                                                gint64 i);
+GARROW_AVAILABLE_IN_2_0
+GArrowArray *garrow_large_list_array_get_values(GArrowLargeListArray *array);
+GARROW_AVAILABLE_IN_2_0
+gint64 garrow_large_list_array_get_value_offset(GArrowLargeListArray *array,
+                                                gint64 i);
+GARROW_AVAILABLE_IN_2_0
+gint64 garrow_large_list_array_get_value_length(GArrowLargeListArray *array,
+                                                gint64 i);
+GARROW_AVAILABLE_IN_2_0
+const gint64 *
+garrow_large_list_array_get_value_offsets(GArrowLargeListArray *array,
+                                          gint64 *n_offsets);
 
 
 #define GARROW_TYPE_STRUCT_ARRAY (garrow_struct_array_get_type())

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -300,7 +300,7 @@ garrow_function_find(const gchar *name)
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: (nullable) (transfer full):
- *   A return value of the execution as #GArrowData on success, %NULL on error.
+ *   A return value of the execution as #GArrowDatum on success, %NULL on error.
  *
  * Since: 1.0.0
  */

--- a/c_glib/doc/arrow-glib/arrow-glib-docs.xml
+++ b/c_glib/doc/arrow-glib/arrow-glib-docs.xml
@@ -179,6 +179,10 @@
     <title>Index of deprecated API</title>
     <xi:include href="xml/api-index-deprecated.xml"><xi:fallback /></xi:include>
   </index>
+  <index id="api-index-2-0-0" role="2.0.0">
+    <title>Index of new symbols in 2.0.0</title>
+    <xi:include href="xml/api-index-2.0.0.xml"><xi:fallback /></xi:include>
+  </index>
   <index id="api-index-1-0-0" role="1.0.0">
     <title>Index of new symbols in 1.0.0</title>
     <xi:include href="xml/api-index-1.0.0.xml"><xi:fallback /></xi:include>

--- a/c_glib/test/test-large-list-array.rb
+++ b/c_glib/test/test-large-list-array.rb
@@ -36,21 +36,11 @@ class TestLargeListArray < Test::Unit::TestCase
   end
 
   def test_value
-    field = Arrow::Field.new("value", Arrow::Int64DataType.new)
-    data_type = Arrow::LargeListDataType.new(field)
-    builder = Arrow::LargeListArrayBuilder.new(data_type)
-    value_builder = builder.value_builder
-
-    builder.append_value
-    value_builder.append_value(-29)
-    value_builder.append_value(29)
-
-    builder.append_value
-    value_builder.append_value(-1)
-    value_builder.append_value(0)
-    value_builder.append_value(1)
-
-    array = builder.finish
+    array = build_large_list_array(Arrow::Int8DataType.new,
+                                   [
+                                     [-29, 29],
+                                     [-1, 0, 1],
+                                   ])
     value = array.get_value(1)
     assert_equal([-1, 0, 1],
                  value.length.times.collect {|i| value.get_value(i)})
@@ -62,5 +52,47 @@ class TestLargeListArray < Test::Unit::TestCase
     builder = Arrow::LargeListArrayBuilder.new(data_type)
     array = builder.finish
     assert_equal(Arrow::Int64DataType.new, array.value_type)
+  end
+
+
+  def test_values
+    array = build_large_list_array(Arrow::Int8DataType.new,
+                                   [
+                                     [-29, 29],
+                                     [-1, 0, 1],
+                                   ])
+    values = array.values
+    assert_equal([-29, 29, -1, 0, 1],
+                 values.length.times.collect {|i| values.get_value(i)})
+  end
+
+  def test_value_offset
+    array = build_large_list_array(Arrow::Int8DataType.new,
+                                   [
+                                     [-29, 29],
+                                     [-1, 0, 1],
+                                   ])
+    assert_equal([0, 2],
+                 array.length.times.collect {|i| array.get_value_offset(i)})
+  end
+
+  def test_value_length
+    array = build_large_list_array(Arrow::Int8DataType.new,
+                                   [
+                                     [-29, 29],
+                                     [-1, 0, 1],
+                                   ])
+    assert_equal([2, 3],
+                 array.length.times.collect {|i| array.get_value_length(i)})
+  end
+
+  def test_value_offsets
+    array = build_large_list_array(Arrow::Int8DataType.new,
+                             [
+                               [-29, 29],
+                               [-1, 0, 1],
+                             ])
+    assert_equal([0, 2, 5],
+                 array.value_offsets)
   end
 end

--- a/c_glib/test/test-list-array.rb
+++ b/c_glib/test/test-list-array.rb
@@ -36,21 +36,11 @@ class TestListArray < Test::Unit::TestCase
   end
 
   def test_value
-    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
-    data_type = Arrow::ListDataType.new(field)
-    builder = Arrow::ListArrayBuilder.new(data_type)
-    value_builder = builder.value_builder
-
-    builder.append_value
-    value_builder.append_value(-29)
-    value_builder.append_value(29)
-
-    builder.append_value
-    value_builder.append_value(-1)
-    value_builder.append_value(0)
-    value_builder.append_value(1)
-
-    array = builder.finish
+    array = build_list_array(Arrow::Int8DataType.new,
+                             [
+                               [-29, 29],
+                               [-1, 0, 1],
+                             ])
     value = array.get_value(1)
     assert_equal([-1, 0, 1],
                  value.length.times.collect {|i| value.get_value(i)})
@@ -62,5 +52,46 @@ class TestListArray < Test::Unit::TestCase
     builder = Arrow::ListArrayBuilder.new(data_type)
     array = builder.finish
     assert_equal(Arrow::Int8DataType.new, array.value_type)
+  end
+
+  def test_values
+    array = build_list_array(Arrow::Int8DataType.new,
+                             [
+                               [-29, 29],
+                               [-1, 0, 1],
+                             ])
+    values = array.values
+    assert_equal([-29, 29, -1, 0, 1],
+                 values.length.times.collect {|i| values.get_value(i)})
+  end
+
+  def test_value_offset
+    array = build_list_array(Arrow::Int8DataType.new,
+                             [
+                               [-29, 29],
+                               [-1, 0, 1],
+                             ])
+    assert_equal([0, 2],
+                 array.length.times.collect {|i| array.get_value_offset(i)})
+  end
+
+  def test_value_length
+    array = build_list_array(Arrow::Int8DataType.new,
+                             [
+                               [-29, 29],
+                               [-1, 0, 1],
+                             ])
+    assert_equal([2, 3],
+                 array.length.times.collect {|i| array.get_value_length(i)})
+  end
+
+  def test_value_offsets
+    array = build_list_array(Arrow::Int8DataType.new,
+                             [
+                               [-29, 29],
+                               [-1, 0, 1],
+                             ])
+    assert_equal([0, 2, 5],
+                 array.value_offsets)
   end
 end


### PR DESCRIPTION
We can add
"GArrowBuffer *
garrow_list_array_get_value_offsets_buffer(GArrowListArray *array)" as
follow-up work.