### PR TITLE
ARROW-11465: [C++] Parquet file writer snapshot API and proper ColumnChunk.file_path utilization

### DIFF
--- a/cpp/src/arrow/io/file.h
+++ b/cpp/src/arrow/io/file.h
@@ -217,5 +217,33 @@ class ARROW_EXPORT MemoryMappedFile : public ReadWriteFileInterface {
   std::shared_ptr<MemoryMap> memory_map_;
 };
 
+class ARROW_EXPORT MultiReadableFile : public MultiFileProvider<RandomAccessFile> {
+ public:
+  MultiReadableFile(const std::string& default_file_path,
+                    MemoryPool* pool = arrow::default_memory_pool());
+
+ protected:
+  arrow::Result<std::shared_ptr<RandomAccessFile>> OpenFile(
+      const std::string& path) override;
+};
+
+template <class FILE>
+class SingleFile : public MultiFileProvider<FILE> {
+ public:
+  SingleFile(std::shared_ptr<FILE> default_file,
+             MemoryPool* pool = arrow::default_memory_pool())
+      : MultiFileProvider<FILE>(std::move(default_file)) {}
+
+ protected:
+  Result<std::shared_ptr<FILE>> OpenFile(const std::string& path) override {
+    return {Status::NotImplemented("Single file provider doesn't allow for sub files")};
+  };
+};
+
+template <class FILE>
+std::shared_ptr<MultiFileProvider<FILE>> AsMultiFileProvider(std::shared_ptr<FILE> file) {
+  return std::make_shared<SingleFile<FILE>>(std::move(file));
+}
+
 }  // namespace io
 }  // namespace arrow

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -280,6 +280,12 @@ class PARQUET_EXPORT FileReaderBuilder {
                        const ReaderProperties& properties = default_reader_properties(),
                        std::shared_ptr<FileMetaData> metadata = NULLPTR);
 
+  ::arrow::Status Open(
+      std::shared_ptr<::arrow::io::MultiFileProvider<::arrow::io::RandomAccessFile>>
+          multi_file,
+      const ReaderProperties& properties = default_reader_properties(),
+      std::shared_ptr<FileMetaData> metadata = NULLPTR);
+
   ParquetFileReader* raw_reader() { return raw_reader_.get(); }
 
   /// Set Arrow MemoryPool for memory allocation
@@ -297,6 +303,18 @@ class PARQUET_EXPORT FileReaderBuilder {
 
 /// \defgroup parquet-arrow-reader-factories Factory functions for Parquet Arrow readers
 ///
+/// @{
+
+/// \brief Build FileReader from an Arrow mulifile file and MemoryPool
+///
+/// Advanced settings are supported through the FileReaderBuilder class.
+PARQUET_EXPORT
+::arrow::Status OpenMultiFile(
+    std::shared_ptr<::arrow::io::MultiFileProvider<::arrow::io::RandomAccessFile>>,
+    ::arrow::MemoryPool* allocator, std::unique_ptr<FileReader>* reader);
+
+/// @}
+
 /// @{
 
 /// \brief Build FileReader from Arrow file and MemoryPool

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -282,6 +282,19 @@ class FileWriterImpl : public FileWriter {
     return Status::OK();
   }
 
+  Status Snapshot(const std::string& data_path,
+                  std::shared_ptr<::arrow::io::OutputStream> sink) override {
+    if (closed_) {
+      return Status::Invalid("Cannot snapshot a file once it's already closed");
+    }
+    if (row_group_writer_ != nullptr) {
+      PARQUET_CATCH_NOT_OK(row_group_writer_->Close());
+      row_group_writer_ = nullptr;
+    }
+    PARQUET_CATCH_NOT_OK(writer_->Snapshot(data_path, sink));
+    return sink->Close();
+  }
+
   Status Close() override {
     if (!closed_) {
       // Make idempotent

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <arrow/status.h>
+
 #include <cstdint>
 #include <memory>
 
@@ -76,6 +78,8 @@ class PARQUET_EXPORT FileWriter {
 
   virtual ::arrow::Status WriteColumnChunk(
       const std::shared_ptr<::arrow::ChunkedArray>& data) = 0;
+  virtual ::arrow::Status Snapshot(const std::string& data_path,
+                                   std::shared_ptr<::arrow::io::OutputStream> sink) = 0;
   virtual ::arrow::Status Close() = 0;
   virtual ~FileWriter();
 

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -74,6 +74,12 @@ class PARQUET_EXPORT ParquetFileReader {
         const ReaderProperties& props = default_reader_properties(),
         std::shared_ptr<FileMetaData> metadata = NULLPTR);
 
+    static std::unique_ptr<Contents> Open(
+        std::shared_ptr<::arrow::io::MultiFileProvider<::arrow::io::RandomAccessFile>>
+            source,
+        const ReaderProperties& props = default_reader_properties(),
+        std::shared_ptr<FileMetaData> metadata = NULLPTR);
+
     virtual ~Contents() = default;
     // Perform any cleanup associated with the file contents
     virtual void Close() = 0;
@@ -99,6 +105,14 @@ class PARQUET_EXPORT ParquetFileReader {
   // the responsibility of the file implementation
   static std::unique_ptr<ParquetFileReader> Open(
       std::shared_ptr<::arrow::io::RandomAccessFile> source,
+      const ReaderProperties& props = default_reader_properties(),
+      std::shared_ptr<FileMetaData> metadata = NULLPTR);
+
+  // Create a file reader instance from an Arrow file object. Thread-safety is
+  // the responsibility of the file implementation
+  static std::unique_ptr<ParquetFileReader> Open(
+      std::shared_ptr<::arrow::io::MultiFileProvider<::arrow::io::RandomAccessFile>>
+          source,
       const ReaderProperties& props = default_reader_properties(),
       std::shared_ptr<FileMetaData> metadata = NULLPTR);
 

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -138,6 +138,9 @@ class PARQUET_EXPORT ParquetFileWriter {
       schema_.Init(std::move(schema));
     }
     virtual ~Contents() {}
+
+    virtual void Snapshot(const std::string& data_path,
+                          std::shared_ptr<::arrow::io::OutputStream>& sink) = 0;
     // Perform any cleanup associated with the file contents
     virtual void Close() = 0;
 
@@ -185,6 +188,10 @@ class PARQUET_EXPORT ParquetFileWriter {
       std::shared_ptr<const KeyValueMetadata> key_value_metadata = NULLPTR);
 
   void Open(std::unique_ptr<Contents> contents);
+
+  void Snapshot(const std::string& data_path,
+                std::shared_ptr<::arrow::io::OutputStream>& sink);
+
   void Close();
 
   // Construct a RowGroupWriter for the indicated number of rows.

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -473,6 +473,8 @@ class PARQUET_EXPORT FileMetaDataBuilder {
   // Complete the Thrift structure
   std::unique_ptr<FileMetaData> Finish();
 
+  std::unique_ptr<FileMetaData> ToFileMetadata(bool finish, const std::string data_path);
+
   // crypto metadata
   std::unique_ptr<FileCryptoMetaData> GetCryptoMetaData();
 

--- a/cpp/src/parquet/platform.h
+++ b/cpp/src/parquet/platform.h
@@ -100,6 +100,7 @@ using MutableBuffer = ::arrow::MutableBuffer;
 using ResizableBuffer = ::arrow::ResizableBuffer;
 using ResizableBuffer = ::arrow::ResizableBuffer;
 using ArrowInputFile = ::arrow::io::RandomAccessFile;
+using ArrowMultiInputFile = ::arrow::io::MultiFileProvider<::arrow::io::RandomAccessFile>;
 using ArrowInputStream = ::arrow::io::InputStream;
 using ArrowOutputStream = ::arrow::io::OutputStream;
 using string_view = ::arrow::util::string_view;


### PR DESCRIPTION
This is a follow up to the thread:
https://mail-archives.apache.org/mod_mbox/arrow-dev/202009.mbox/%3cCDD00783-0FFC-4934-AA24-529FB2A44D88@yahoo.com%3e

The specific use case I am targeting is having the ability to partially read a parquet file while it's still being written to.
This is relevant for any process that is recording events over a long period of times and writing them to parquet (tracing data, logging events or any other live time series)
The solution relies on the fact that parquet specifications allows column chunk metadata to point explicitly to its location in a file which can theoretically be different from the file containing the metadata (as covered in other threads, this behavior is not fully supported by major parquet implementations).
My solution is centered around adding a method,
```
void ParquetFileWriter::Snapshot(const std::string& data_path,
                                 std::shared_ptr<::arrow::io::OutputStream>& sink) 

```
,that writes writes the metadata for the RowGroups given so far to the `sink` stream and updates all the ColumnChunk metadata `file_path` to point to `data_path`. This was intended as a minimalist change to `ParquetFileWriter`

On the reading side I implemented full support for ColumnChunk.file_path by introducing `ArrowMultiInputFile` as an alternative to `ArrowInputFile` in the `ParquetFileReader` implementation stack. In the PR implementation one can default to the current behavior by using the `SingleFile` class, have full read support for multi-file parquet in line with the specification by using `MultiReadableFile` implementation (that captures the metafile base directory and uses it as the base directory to the ColumChunk.file_path) or one can provide a separate implementation for a non-posix file system storage. 

For an example see `write_parquet_file_with_snapshot` function in reader-writer.cc that illustrates the snapshotting write while the `read_whole_file` function has been modified to read one of the snapshots (I will rollback that change and provide separate example before the merge)