### PR TITLE
ARROW-9936: [Python] Fix / test relative file paths in pyarrow.parquet

### DIFF
--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -27,6 +27,7 @@ import pytest
 import pyarrow as pa
 import pyarrow.csv
 import pyarrow.fs as fs
+from pyarrow.tests.util import change_cwd
 
 try:
     import pandas as pd
@@ -41,16 +42,6 @@ except ImportError:
 # Marks all of the tests in this module
 # Ignore these with pytest ... -m 'not dataset'
 pytestmark = pytest.mark.dataset
-
-
-@contextlib.contextmanager
-def change_cwd(path):
-    curdir = os.getcwd()
-    os.chdir(str(path))
-    try:
-        yield
-    finally:
-        os.chdir(curdir)
 
 
 def _generate_data(n):

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -210,3 +210,13 @@ def changed_environ(name, value):
             del os.environ[name]
         else:
             os.environ[name] = orig_value
+
+
+@contextlib.contextmanager
+def change_cwd(path):
+    curdir = os.getcwd()
+    os.chdir(str(path))
+    try:
+        yield
+    finally:
+        os.chdir(curdir)


### PR DESCRIPTION
This copies some of the logic we developed in pyarrow/dataset.py to the new filesystem helpers to ensure we properly handle local paths there as well (we should follow-up with cleaning up dataset.py and reusing the pyarrow/fs.py helpers, though)