### PR TITLE
ARROW-9949: [C++] Improve performance of Decimal128::FromString by 46%, and make the implementation reusable for Decimal256.

### DIFF
--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <array>
+#include <boost/multiprecision/cpp_int.hpp>
 #include <climits>
 #include <cmath>
 #include <cstdint>
@@ -42,6 +43,8 @@ namespace arrow {
 using internal::SafeLeftShift;
 using internal::SafeSignedAdd;
 
+using boost::multiprecision::uint128_t;
+
 Decimal128::Decimal128(const std::string& str) : Decimal128() {
   *this = Decimal128::FromString(str).ValueOrDie();
 }
@@ -49,27 +52,27 @@ Decimal128::Decimal128(const std::string& str) : Decimal128() {
 static constexpr auto kInt64DecimalDigits =
     static_cast<size_t>(std::numeric_limits<int64_t>::digits10);
 
-static constexpr int64_t kInt64PowersOfTen[kInt64DecimalDigits + 1] = {
+static constexpr uint64_t kUInt64PowersOfTen[kInt64DecimalDigits + 1] = {
     // clang-format off
-    1LL,
-    10LL,
-    100LL,
-    1000LL,
-    10000LL,
-    100000LL,
-    1000000LL,
-    10000000LL,
-    100000000LL,
-    1000000000LL,
-    10000000000LL,
-    100000000000LL,
-    1000000000000LL,
-    10000000000000LL,
-    100000000000000LL,
-    1000000000000000LL,
-    10000000000000000LL,
-    100000000000000000LL,
-    1000000000000000000LL
+    1ULL,
+    10ULL,
+    100ULL,
+    1000ULL,
+    10000ULL,
+    100000ULL,
+    1000000ULL,
+    10000000ULL,
+    100000000ULL,
+    1000000000ULL,
+    10000000000ULL,
+    100000000000ULL,
+    1000000000000ULL,
+    10000000000000ULL,
+    100000000000000ULL,
+    1000000000000000ULL,
+    10000000000000000ULL,
+    100000000000000000ULL,
+    1000000000000000000ULL
     // clang-format on
 };
 
@@ -348,35 +351,36 @@ std::string Decimal128::ToString(int32_t scale) const {
   return str;
 }
 
-// Iterates over data and for each group of kInt64DecimalDigits multiple out by
+// Iterates over input and for each group of kInt64DecimalDigits multiple out by
 // the appropriate power of 10 necessary to add source parsed as uint64 and
 // then adds the parsed value of source.
-static inline void ShiftAndAdd(const char* data, size_t length, Decimal128* out) {
-  for (size_t posn = 0; posn < length;) {
-    const size_t group_size = std::min(kInt64DecimalDigits, length - posn);
-    const int64_t multiple = kInt64PowersOfTen[group_size];
-    int64_t chunk = 0;
-    ARROW_CHECK(internal::ParseValue<Int64Type>(data + posn, group_size, &chunk));
+static inline void ShiftAndAdd(const util::string_view& input, uint64_t out[],
+                               size_t out_size) {
+  for (size_t posn = 0; posn < input.size();) {
+    const size_t group_size = std::min(kInt64DecimalDigits, input.size() - posn);
+    const uint64_t multiple = kUInt64PowersOfTen[group_size];
+    uint64_t chunk = 0;
+    ARROW_CHECK(
+        internal::ParseValue<UInt64Type>(input.data() + posn, group_size, &chunk));
 
-    *out *= multiple;
-    *out += chunk;
+    for (size_t i = 0; i < out_size; ++i) {
+      uint128_t tmp = out[i];
+      tmp *= multiple;
+      tmp += chunk;
+      out[i] = static_cast<uint64_t>(tmp);
+      chunk = static_cast<uint64_t>(tmp >> 64);
+    }
     posn += group_size;
   }
 }
 
-static void StringToInteger(const util::string_view whole_digits,
+static void StringToInteger(util::string_view whole_digits,
                             util::string_view fractional_digits, Decimal128* out) {
-  using std::size_t;
-
   DCHECK_NE(out, nullptr) << "Decimal128 output variable cannot be nullptr";
-  DCHECK_EQ(*out, 0)
-      << "When converting a string to Decimal128 the initial output must be 0";
-
-  DCHECK_GT(whole_digits.size() + fractional_digits.size(), 0)
-      << "length of parsed decimal string should be greater than 0";
-
-  ShiftAndAdd(whole_digits.data(), whole_digits.length(), out);
-  ShiftAndAdd(fractional_digits.data(), fractional_digits.length(), out);
+  std::array<uint64_t, 2> little_endian_array = {0, 0};
+  ShiftAndAdd(whole_digits, little_endian_array.data(), little_endian_array.size());
+  ShiftAndAdd(fractional_digits, little_endian_array.data(), little_endian_array.size());
+  *out = Decimal128(static_cast<int64_t>(little_endian_array[1]), little_endian_array[0]);
 }
 
 namespace {
@@ -482,7 +486,6 @@ Status Decimal128::FromString(const util::string_view& s, Decimal128* out,
   }
 
   if (out != nullptr) {
-    *out = 0;
     StringToInteger(dec.whole_digits, dec.fractional_digits, out);
     if (parsed_scale < 0) {
       *out *= GetScaleMultiplier(-parsed_scale);

--- a/cpp/src/arrow/util/int128_internal.h
+++ b/cpp/src/arrow/util/int128_internal.h
@@ -23,6 +23,13 @@
 namespace arrow {
 namespace internal {
 
+// NOTE: __int128_t and boost::multiprecision::int128_t are not interchangeable.
+// For example, __int128_t does not have any member function, and does not have
+// operator<<(std::ostream, __int128_t). On the other hand, the behavior of
+// boost::multiprecision::int128_t might be surprising with some configs (e.g.,
+// static_cast<uint64_t>(boost::multiprecision::uint128_t) might return
+// ~uint64_t{0} instead of the lower 64 bits of the input).
+// Try to minimize the usage of int128_t and uint128_t.
 #ifdef __SIZEOF_INT128__
 using int128_t = __int128_t;
 using uint128_t = __uint128_t;

--- a/cpp/src/arrow/util/int128_internal.h
+++ b/cpp/src/arrow/util/int128_internal.h
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#pragma once
+
+#ifndef __SIZEOF_INT128__
+#include <boost/multiprecision/cpp_int.hpp>
+#endif
+
+namespace arrow {
+namespace internal {
+
+#ifdef __SIZEOF_INT128__
+using int128_t = __int128_t;
+using uint128_t = __uint128_t;
+#else
+using boost::multiprecision::int128_t;
+using boost::multiprecision::uint128_t;
+#endif
+
+}  // namespace internal
+}  // namespace arrow


### PR DESCRIPTION
```
Running release/arrow-decimal-benchmark
Run on (12 X 4500 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x6)
  L1 Instruction 32 KiB (x6)
  L2 Unified 1024 KiB (x6)
  L3 Unified 8448 KiB (x1)
Load Average: 0.33, 1.08, 0.93
---------------------------------------------------------------------
Benchmark                    Time             CPU   Iterations UserCounters...
---------------------------------------------------------------------
FromString (before)        263 ns          263 ns      2666389 items_per_second=22.8378M/s
FromString (after)         180 ns          180 ns      3873651 items_per_second=33.3283M/s
```