### PR TITLE
ARROW-9950: [Rust] [DataFusion] Made UDFs usable without a registry

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -36,7 +36,7 @@ use crate::datasource::parquet::ParquetTable;
 use crate::datasource::TableProvider;
 use crate::error::{ExecutionError, Result};
 use crate::execution::dataframe_impl::DataFrameImpl;
-use crate::logical_plan::{Expr, FunctionRegistry, LogicalPlan, LogicalPlanBuilder};
+use crate::logical_plan::{FunctionRegistry, LogicalPlan, LogicalPlanBuilder};
 use crate::optimizer::filter_push_down::FilterPushDown;
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::projection_push_down::ProjectionPushDown;
@@ -481,17 +481,14 @@ impl FunctionRegistry for ExecutionContextState {
         self.scalar_functions.keys().cloned().collect()
     }
 
-    fn udf(&self, name: &str, args: Vec<Expr>) -> Result<Expr> {
+    fn udf(&self, name: &str) -> Result<&ScalarUDF> {
         let result = self.scalar_functions.get(name);
         if result.is_none() {
             Err(ExecutionError::General(
                 format!("There is no UDF named \"{}\" in the registry", name).to_string(),
             ))
         } else {
-            Ok(Expr::ScalarUDF {
-                fun: result.unwrap().clone(),
-                args,
-            })
+            Ok(result.unwrap())
         }
     }
 }
@@ -1051,7 +1048,7 @@ mod tests {
             .project(vec![
                 col("a"),
                 col("b"),
-                ctx.registry().udf("my_add", vec![col("a"), col("b")])?,
+                ctx.registry().udf("my_add")?.call(vec![col("a"), col("b")]),
             ])?
             .build()?;
 

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -259,7 +259,7 @@ mod tests {
 
         let f = df.registry();
 
-        let df = df.select(vec![f.udf("my_fn", vec![col("c12")])?])?;
+        let df = df.select(vec![f.udf("my_fn")?.call(vec![col("c12")])])?;
         let plan = df.to_logical_plan();
 
         // build query using SQL

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -1133,8 +1133,8 @@ pub trait FunctionRegistry {
     /// Set of all available udfs.
     fn udfs(&self) -> HashSet<String>;
 
-    /// Constructs a logical expression with a call to the udf.
-    fn udf(&self, name: &str, args: Vec<Expr>) -> Result<Expr>;
+    /// Returns a reference to the udf named `name`.
+    fn udf(&self, name: &str) -> Result<&ScalarUDF>;
 }
 
 /// Builder for logical plans

--- a/rust/datafusion/src/physical_plan/udf.rs
+++ b/rust/datafusion/src/physical_plan/udf.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use arrow::datatypes::Schema;
 
 use crate::error::Result;
-use crate::physical_plan::PhysicalExpr;
+use crate::{logical_plan::Expr, physical_plan::PhysicalExpr};
 
 use super::{
     functions::{
@@ -69,6 +69,15 @@ impl ScalarUDF {
             signature: signature.clone(),
             return_type: return_type.clone(),
             fun: fun.clone(),
+        }
+    }
+
+    /// creates a logical expression with a call of the UDF
+    /// This utility allows using the UDF without requiring access to the registry.
+    pub fn call(&self, args: Vec<Expr>) -> Expr {
+        Expr::ScalarUDF {
+            fun: Arc::new(self.clone()),
+            args,
         }
     }
 }


### PR DESCRIPTION
This functionality is relevant for the DataFrame API only.

Sometimes a UDF declaration happens during planning, and it is expressive when the user can use it directly, without first register it in the execution context's registry and accessing the registry to plan it.

This PR proposes that, given a UDF `pow: ScalarUDF` named `"pow"`, users can (logically) plan it directly:

```rust
// plan a call
let expr = pow.call(vec![col("a"), col("b")]);
```

or register it (as before)

```rust
// register it
ctx.register_udf(pow);
```

or plan it from the registry (as before):

```rust
// access it from the registry via its name, when `pow` is not in scope
let pow = df.registry().udf("pow")?;

// plan a call
let expr = pow.call(vec![col("a"), col("b")]);
```

I changed the signature of the registry from `.udf(name, args) -> Expr` to `.udf(name) -> ScalarUDF`, so that the API to call UDFs is the same regardless of whether we take it from the registry or use it directly `call(args)`. IMO it also makes it a bit more expressive that we are calling the `udf`.