### PR TITLE
ARROW-5034: [C#] ArrowStreamWriter and ArrowFileWriter implement sync WriteRecordBatch

### DIFF
--- a/csharp/src/Apache.Arrow/Apache.Arrow.csproj
+++ b/csharp/src/Apache.Arrow/Apache.Arrow.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard1.3;netcoreapp2.1</TargetFrameworks>
@@ -37,5 +37,6 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <Compile Remove="Extensions\StreamExtensions.netstandard.cs" />
+    <Compile Remove="Extensions\TupleExtensions.netstandard.cs" />
   </ItemGroup>
 </Project>

--- a/csharp/src/Apache.Arrow/Extensions/TupleExtensions.netstandard.cs
+++ b/csharp/src/Apache.Arrow/Extensions/TupleExtensions.netstandard.cs
@@ -14,21 +14,16 @@
 // limitations under the License.
 
 using System;
-using System.IO;
 
 namespace Apache.Arrow
 {
-    // Helpers to read from Stream to Memory<byte> on netcoreapp
-    internal static partial class StreamExtensions
+    // Helpers to Deconstruct Tuples on netstandard
+    internal static partial class TupleExtensions
     {
-        public static int Read(this Stream stream, Memory<byte> buffer)
+        public static void Deconstruct<T1, T2>(this Tuple<T1, T2> value, out T1 item1, out T2 item2)
         {
-            return stream.Read(buffer.Span);
-        }
-
-        public static void Write(this Stream stream, ReadOnlyMemory<byte> buffer)
-        {
-            stream.Write(buffer.Span);
+            item1 = value.Item1;
+            item2 = value.Item2;
         }
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -212,6 +212,96 @@ namespace Apache.Arrow.Ipc
             count++;
         }
 
+        private protected void WriteRecordBatchInternal(RecordBatch recordBatch)
+        {
+            // TODO: Truncate buffers with extraneous padding / unused capacity
+
+            if (!HasWrittenSchema)
+            {
+                WriteSchema(Schema);
+                HasWrittenSchema = true;
+            }
+
+            Builder.Clear();
+
+            // Serialize field nodes
+
+            int fieldCount = Schema.Fields.Count;
+
+            Flatbuf.RecordBatch.StartNodesVector(Builder, CountAllNodes());
+
+            // flatbuffer struct vectors have to be created in reverse order
+            for (int i = fieldCount - 1; i >= 0; i--)
+            {
+                CreateSelfAndChildrenFieldNodes(recordBatch.Column(i).Data);
+            }
+
+            VectorOffset fieldNodesVectorOffset = Builder.EndVector();
+
+            // Serialize buffers
+
+            var recordBatchBuilder = new ArrowRecordBatchFlatBufferBuilder();
+            for (int i = 0; i < fieldCount; i++)
+            {
+                IArrowArray fieldArray = recordBatch.Column(i);
+                fieldArray.Accept(recordBatchBuilder);
+            }
+
+            IReadOnlyList<ArrowRecordBatchFlatBufferBuilder.Buffer> buffers = recordBatchBuilder.Buffers;
+
+            Flatbuf.RecordBatch.StartBuffersVector(Builder, buffers.Count);
+
+            // flatbuffer struct vectors have to be created in reverse order
+            for (int i = buffers.Count - 1; i >= 0; i--)
+            {
+                Flatbuf.Buffer.CreateBuffer(Builder,
+                    buffers[i].Offset, buffers[i].DataBuffer.Length);
+            }
+
+            VectorOffset buffersVectorOffset = Builder.EndVector();
+
+            // Serialize record batch
+
+            StartingWritingRecordBatch();
+
+            Offset<Flatbuf.RecordBatch> recordBatchOffset = Flatbuf.RecordBatch.CreateRecordBatch(Builder, recordBatch.Length,
+                fieldNodesVectorOffset,
+                buffersVectorOffset);
+
+            long metadataLength = WriteMessage(Flatbuf.MessageHeader.RecordBatch,
+                recordBatchOffset, recordBatchBuilder.TotalLength);
+
+            // Write buffer data
+
+            long bodyLength = 0;
+
+            for (int i = 0; i < buffers.Count; i++)
+            {
+                ArrowBuffer buffer = buffers[i].DataBuffer;
+                if (buffer.IsEmpty)
+                    continue;
+
+                WriteBuffer(buffer);
+
+                int paddedLength = checked((int)BitUtility.RoundUpToMultipleOf8(buffer.Length));
+                int padding = paddedLength - buffer.Length;
+                if (padding > 0)
+                {
+                    WritePadding(padding);
+                }
+
+                bodyLength += paddedLength;
+            }
+
+            // Write padding so the record batch message body length is a multiple of 8 bytes
+
+            int bodyPaddingLength = CalculatePadding(bodyLength);
+
+            WritePadding(bodyPaddingLength);
+
+            FinishedWritingRecordBatch(bodyLength + bodyPaddingLength, metadataLength);
+        }
+
         private protected async Task WriteRecordBatchInternalAsync(RecordBatch recordBatch,
             CancellationToken cancellationToken = default)
         {
@@ -304,6 +394,11 @@ namespace Apache.Arrow.Ipc
             FinishedWritingRecordBatch(bodyLength + bodyPaddingLength, metadataLength);
         }
 
+        private protected virtual void WriteEndInternal()
+        {
+            WriteIpcMessageLength(length: 0);
+        }
+
         private protected virtual ValueTask WriteEndInternalAsync(CancellationToken cancellationToken)
         {
             return WriteIpcMessageLengthAsync(length: 0, cancellationToken);
@@ -317,9 +412,23 @@ namespace Apache.Arrow.Ipc
         {
         }
 
+        public virtual void WriteRecordBatch(RecordBatch recordBatch)
+        {
+            WriteRecordBatchInternal(recordBatch);
+        }
+
         public virtual Task WriteRecordBatchAsync(RecordBatch recordBatch, CancellationToken cancellationToken = default)
         {
             return WriteRecordBatchInternalAsync(recordBatch, cancellationToken);
+        }
+
+        public void WriteEnd()
+        {
+            if (!HasWrittenEnd)
+            {
+                WriteEndInternal();
+                HasWrittenEnd = true;
+            }
         }
 
         public async Task WriteEndAsync(CancellationToken cancellationToken = default)
@@ -329,6 +438,11 @@ namespace Apache.Arrow.Ipc
                 await WriteEndInternalAsync(cancellationToken);
                 HasWrittenEnd = true;
             }
+        }
+
+        private void WriteBuffer(ArrowBuffer arrowBuffer)
+        {
+            BaseStream.Write(arrowBuffer.Memory);
         }
 
         private ValueTask WriteBufferAsync(ArrowBuffer arrowBuffer, CancellationToken cancellationToken = default)
@@ -391,6 +505,21 @@ namespace Apache.Arrow.Ipc
             return children;
         }
 
+        private Offset<Flatbuf.Schema> WriteSchema(Schema schema)
+        {
+            Builder.Clear();
+
+            // Build schema
+
+            Offset<Flatbuf.Schema> schemaOffset = SerializeSchema(schema);
+
+            // Build message
+
+            WriteMessage(Flatbuf.MessageHeader.Schema, schemaOffset, 0);
+
+            return schemaOffset;
+        }
+
         private async ValueTask<Offset<Flatbuf.Schema>> WriteSchemaAsync(Schema schema, CancellationToken cancellationToken)
         {
             Builder.Clear();
@@ -405,6 +534,36 @@ namespace Apache.Arrow.Ipc
                 .ConfigureAwait(false);
 
             return schemaOffset;
+        }
+
+        /// <summary>
+        /// Writes the message to the <see cref="BaseStream"/>.
+        /// </summary>
+        /// <returns>
+        /// The number of bytes written to the stream.
+        /// </returns>
+        private long WriteMessage<T>(
+            Flatbuf.MessageHeader headerType, Offset<T> headerOffset, int bodyLength)
+            where T : struct
+        {
+            Offset<Flatbuf.Message> messageOffset = Flatbuf.Message.CreateMessage(
+                Builder, CurrentMetadataVersion, headerType, headerOffset.Value,
+                bodyLength);
+
+            Builder.Finish(messageOffset.Value);
+
+            ReadOnlyMemory<byte> messageData = Builder.DataBuffer.ToReadOnlyMemory(Builder.DataBuffer.Position, Builder.Offset);
+            int messagePaddingLength = CalculatePadding(_options.SizeOfIpcLength + messageData.Length);
+
+            WriteIpcMessageLength(messageData.Length + messagePaddingLength);
+
+            BaseStream.Write(messageData);
+            WritePadding(messagePaddingLength);
+
+            checked
+            {
+                return _options.SizeOfIpcLength + messageData.Length + messagePaddingLength;
+            }
         }
 
         /// <summary>
@@ -446,6 +605,23 @@ namespace Apache.Arrow.Ipc
             await BaseStream.WriteAsync(segment, cancellationToken).ConfigureAwait(false);
         }
 
+        private void WriteIpcMessageLength(int length)
+        {
+            Buffers.RentReturn(_options.SizeOfIpcLength, (buffer) =>
+            {
+                Memory<byte> currentBufferPosition = buffer;
+                if (!_options.WriteLegacyIpcFormat)
+                {
+                    BinaryPrimitives.WriteInt32LittleEndian(
+                        currentBufferPosition.Span, MessageSerializer.IpcContinuationToken);
+                    currentBufferPosition = currentBufferPosition.Slice(sizeof(int));
+                }
+
+                BinaryPrimitives.WriteInt32LittleEndian(currentBufferPosition.Span, length);
+                BaseStream.Write(buffer);
+            });
+        }
+
         private async ValueTask WriteIpcMessageLengthAsync(int length, CancellationToken cancellationToken)
         {
             await Buffers.RentReturnAsync(_options.SizeOfIpcLength, async (buffer) =>
@@ -469,6 +645,14 @@ namespace Apache.Arrow.Ipc
             checked
             {
                 return (int)result;
+            }
+        }
+
+        private protected void WritePadding(int length)
+        {
+            if (length > 0)
+            {
+                BaseStream.Write(s_padding.AsMemory(0, Math.Min(s_padding.Length, length)));
             }
         }
 

--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
@@ -56,7 +56,41 @@ namespace Apache.Arrow.Tests
         }
 
         [Fact]
-        public async Task CanWriteToNetworkStream()
+        public void CanWriteToNetworkStream()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+
+            const int port = 32153;
+            TcpListener listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+
+            using (TcpClient sender = new TcpClient())
+            {
+                sender.Connect(IPAddress.Loopback, port);
+                NetworkStream stream = sender.GetStream();
+
+                using (var writer = new ArrowStreamWriter(stream, originalBatch.Schema))
+                {
+                    writer.WriteRecordBatch(originalBatch);
+                    writer.WriteEnd();
+
+                    stream.Flush();
+                }
+            }
+
+            using (TcpClient receiver = listener.AcceptTcpClient())
+            {
+                NetworkStream stream = receiver.GetStream();
+                using (var reader = new ArrowStreamReader(stream))
+                {
+                    RecordBatch newBatch = reader.ReadNextRecordBatch();
+                    ArrowReaderVerifier.CompareBatches(originalBatch, newBatch);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CanWriteToNetworkStreamAsync()
         {
             RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
 
@@ -90,15 +124,23 @@ namespace Apache.Arrow.Tests
         }
 
         [Fact]
-        public async Task WriteEmptyBatch()
+        public void WriteEmptyBatch()
         {
             RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 0);
 
-            await TestRoundTripRecordBatch(originalBatch);
+            TestRoundTripRecordBatch(originalBatch);
         }
 
         [Fact]
-        public async Task WriteBatchWithNulls()
+        public async Task WriteEmptyBatchAsync()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 0);
+
+            await TestRoundTripRecordBatchAsync(originalBatch);
+        }
+
+        [Fact]
+        public void WriteBatchWithNulls()
         {
             RecordBatch originalBatch = new RecordBatch.Builder()
                 .Append("Column1", false, col => col.Int32(array => array.AppendRange(Enumerable.Range(0, 10))))
@@ -122,10 +164,59 @@ namespace Apache.Arrow.Tests
                     offset: 0))
                 .Build();
 
-            await TestRoundTripRecordBatch(originalBatch);
+            TestRoundTripRecordBatch(originalBatch);
         }
 
-        private static async Task TestRoundTripRecordBatch(RecordBatch originalBatch, IpcOptions options = null)
+        [Fact]
+        public async Task WriteBatchWithNullsAsync()
+        {
+            RecordBatch originalBatch = new RecordBatch.Builder()
+                .Append("Column1", false, col => col.Int32(array => array.AppendRange(Enumerable.Range(0, 10))))
+                .Append("Column2", true, new Int32Array(
+                    valueBuffer: new ArrowBuffer.Builder<int>().AppendRange(Enumerable.Range(0, 10)).Build(),
+                    nullBitmapBuffer: new ArrowBuffer.Builder<byte>().Append(0xfd).Append(0xff).Build(),
+                    length: 10,
+                    nullCount: 2,
+                    offset: 0))
+                .Append("Column3", true, new Int32Array(
+                    valueBuffer: new ArrowBuffer.Builder<int>().AppendRange(Enumerable.Range(0, 10)).Build(),
+                    nullBitmapBuffer: new ArrowBuffer.Builder<byte>().Append(0x00).Append(0x00).Build(),
+                    length: 10,
+                    nullCount: 10,
+                    offset: 0))
+                .Append("NullableBooleanColumn", true, new BooleanArray(
+                    valueBuffer: new ArrowBuffer.Builder<byte>().Append(0xfd).Append(0xff).Build(),
+                    nullBitmapBuffer: new ArrowBuffer.Builder<byte>().Append(0xed).Append(0xff).Build(),
+                    length: 10,
+                    nullCount: 3,
+                    offset: 0))
+                .Build();
+
+            await TestRoundTripRecordBatchAsync(originalBatch);
+        }
+
+        private static void TestRoundTripRecordBatch(RecordBatch originalBatch, IpcOptions options = null)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (var writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true, options))
+                {
+                    writer.WriteRecordBatch(originalBatch);
+                    writer.WriteEnd();
+                }
+
+                stream.Position = 0;
+
+                using (var reader = new ArrowStreamReader(stream))
+                {
+                    RecordBatch newBatch = reader.ReadNextRecordBatch();
+                    ArrowReaderVerifier.CompareBatches(originalBatch, newBatch);
+                }
+            }
+        }
+
+
+        private static async Task TestRoundTripRecordBatchAsync(RecordBatch originalBatch, IpcOptions options = null)
         {
             using (MemoryStream stream = new MemoryStream())
             {
@@ -146,7 +237,7 @@ namespace Apache.Arrow.Tests
         }
 
         [Fact]
-        public async Task WriteBatchWithCorrectPadding()
+        public void WriteBatchWithCorrectPadding()
         {
             byte value1 = 0x04;
             byte value2 = 0x14;
@@ -172,7 +263,73 @@ namespace Apache.Arrow.Tests
                 },
                 length: 1);
 
-            await TestRoundTripRecordBatch(batch);
+            TestRoundTripRecordBatch(batch);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (var writer = new ArrowStreamWriter(stream, batch.Schema, leaveOpen: true))
+                {
+                    writer.WriteRecordBatch(batch);
+                    writer.WriteEnd();
+                }
+
+                byte[] writtenBytes = stream.ToArray();
+
+                // ensure that the data buffers at the end are 8-byte aligned
+                Assert.Equal(value1, writtenBytes[writtenBytes.Length - 24]);
+                Assert.Equal(value1, writtenBytes[writtenBytes.Length - 23]);
+                for (int i = 22; i > 16; i--)
+                {
+                    Assert.Equal(0, writtenBytes[writtenBytes.Length - i]);
+                }
+
+                Assert.Equal(value2, writtenBytes[writtenBytes.Length - 16]);
+                Assert.Equal(value2, writtenBytes[writtenBytes.Length - 15]);
+                for (int i = 14; i > 8; i--)
+                {
+                    Assert.Equal(0, writtenBytes[writtenBytes.Length - i]);
+                }
+
+                // verify the EOS is written correctly
+                for (int i = 8; i > 4; i--)
+                {
+                    Assert.Equal(0xFF, writtenBytes[writtenBytes.Length - i]);
+                }
+                for (int i = 4; i > 0; i--)
+                {
+                    Assert.Equal(0x00, writtenBytes[writtenBytes.Length - i]);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task WriteBatchWithCorrectPaddingAsync()
+        {
+            byte value1 = 0x04;
+            byte value2 = 0x14;
+            var batch = new RecordBatch(
+                new Schema.Builder()
+                    .Field(f => f.Name("age").DataType(Int32Type.Default))
+                    .Field(f => f.Name("characterCount").DataType(Int32Type.Default))
+                    .Build(),
+                new IArrowArray[]
+                {
+                    new Int32Array(
+                        new ArrowBuffer(new byte[] { value1, value1, 0x00, 0x00 }),
+                        ArrowBuffer.Empty,
+                        length: 1,
+                        nullCount: 0,
+                        offset: 0),
+                    new Int32Array(
+                        new ArrowBuffer(new byte[] { value2, value2, 0x00, 0x00 }),
+                        ArrowBuffer.Empty,
+                        length: 1,
+                        nullCount: 0,
+                        offset: 0)
+                },
+                length: 1);
+
+            await TestRoundTripRecordBatchAsync(batch);
 
             using (MemoryStream stream = new MemoryStream())
             {
@@ -212,16 +369,64 @@ namespace Apache.Arrow.Tests
         }
 
         [Fact]
-        public async Task LegacyIpcFormatRoundTrips()
+        public void LegacyIpcFormatRoundTrips()
         {
             RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
-            await TestRoundTripRecordBatch(originalBatch, new IpcOptions() { WriteLegacyIpcFormat = true });
+            TestRoundTripRecordBatch(originalBatch, new IpcOptions() { WriteLegacyIpcFormat = true });
+        }
+
+
+        [Fact]
+        public async Task LegacyIpcFormatRoundTripsAsync()
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+            await TestRoundTripRecordBatchAsync(originalBatch, new IpcOptions() { WriteLegacyIpcFormat = true });
         }
 
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public async Task WriteLegacyIpcFormat(bool writeLegacyIpcFormat)
+        public void WriteLegacyIpcFormat(bool writeLegacyIpcFormat)
+        {
+            RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+            var options = new IpcOptions() { WriteLegacyIpcFormat = writeLegacyIpcFormat };
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                using (var writer = new ArrowStreamWriter(stream, originalBatch.Schema, leaveOpen: true, options))
+                {
+                    writer.WriteRecordBatch(originalBatch);
+                    writer.WriteEnd();
+                }
+
+                stream.Position = 0;
+
+                // ensure the continuation is written correctly
+                byte[] buffer = stream.ToArray();
+                int messageLength = BinaryPrimitives.ReadInt32LittleEndian(buffer);
+                int endOfBuffer1 = BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(buffer.Length - 8));
+                int endOfBuffer2 = BinaryPrimitives.ReadInt32LittleEndian(buffer.AsSpan(buffer.Length - 4));
+                if (writeLegacyIpcFormat)
+                {
+                    // the legacy IPC format doesn't have a continuation token at the start
+                    Assert.NotEqual(-1, messageLength);
+                    Assert.NotEqual(-1, endOfBuffer1);
+                }
+                else
+                {
+                    // the latest IPC format has a continuation token at the start
+                    Assert.Equal(-1, messageLength);
+                    Assert.Equal(-1, endOfBuffer1);
+                }
+
+                Assert.Equal(0, endOfBuffer2);
+            }
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WriteLegacyIpcFormatAsync(bool writeLegacyIpcFormat)
         {
             RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100);
             var options = new IpcOptions() { WriteLegacyIpcFormat = writeLegacyIpcFormat };


### PR DESCRIPTION
`ArrowStreamWriter` and `ArrowFileWriter` currently only supports an `WriteRecordBatchAsync`.  This PR implements a synced version of it.  All the logic has been reused and all `async` calls have been replaced with `sync` counterparts.