### PR TITLE
ARROW-9680: [Java] Support non-nullable vectors

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -395,6 +395,7 @@
               <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
               <io.netty.tryReflectionSetAccessible>true</io.netty.tryReflectionSetAccessible>
               <user.timezone>UTC</user.timezone>
+              <arrow.enable_non_nullable_vectors>true</arrow.enable_non_nullable_vectors>
             </systemPropertyVariables>
             <!-- Note: changing the below configuration might increase the max allocation size for a vector
             which in turn can cause OOM. -->

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.vector;
 
 import static org.apache.arrow.memory.util.LargeMemoryUtil.capAtMaxInt;
+import static org.apache.arrow.vector.NonNullableVectorOption.NON_NULLABLE_VECTORS_ENABLED;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -64,7 +65,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    * @param typeWidth The width in bytes of the type.
    */
   public BaseFixedWidthVector(Field field, final BufferAllocator allocator, final int typeWidth) {
-    super(allocator);
+    super(allocator, field.isNullable());
     this.typeWidth = typeWidth;
     this.field = field;
     valueCount = 0;
@@ -182,7 +183,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    */
   @Override
   public int getValueCapacity() {
-    return Math.min(getValueBufferValueCapacity(), getValidityBufferValueCapacity());
+    int valueCapacity = getValueBufferValueCapacity();
+    return NON_NULLABLE_VECTORS_ENABLED && !nullable ? valueCapacity :
+        Math.min(valueCapacity, getValidityBufferValueCapacity());
   }
 
   private int getValueBufferValueCapacity() {
@@ -341,7 +344,8 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    * always slice for the target vector.
    */
   private void allocateValidityBuffer(final int validityBufferSize) {
-    validityBuffer = allocator.buffer(validityBufferSize);
+    validityBuffer = NON_NULLABLE_VECTORS_ENABLED && !nullable ? allocator.getEmpty() :
+        allocator.buffer(validityBufferSize);
     validityBuffer.readerIndex(0);
   }
 
@@ -369,7 +373,8 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     if (valueCount == 0) {
       return 0;
     }
-    return (valueCount * typeWidth) + getValidityBufferSizeFromCount(valueCount);
+    return (valueCount * typeWidth) +
+        (NON_NULLABLE_VECTORS_ENABLED && !nullable ? 0 : getValidityBufferSizeFromCount(valueCount));
   }
 
   /**
@@ -488,8 +493,10 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     ArrowBuf bitBuffer = ownBuffers.get(0);
     ArrowBuf dataBuffer = ownBuffers.get(1);
 
-    validityBuffer.getReferenceManager().release();
-    validityBuffer = BitVectorHelper.loadValidityBuffer(fieldNode, bitBuffer, allocator);
+    if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+      validityBuffer.getReferenceManager().release();
+      validityBuffer = BitVectorHelper.loadValidityBuffer(fieldNode, bitBuffer, allocator);
+    }
     valueBuffer.getReferenceManager().release();
     valueBuffer = dataBuffer.getReferenceManager().retain(dataBuffer, allocator);
 
@@ -520,7 +527,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
       validityBuffer.writerIndex(0);
       valueBuffer.writerIndex(0);
     } else {
-      validityBuffer.writerIndex(getValidityBufferSizeFromCount(valueCount));
+      if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+        validityBuffer.writerIndex(getValidityBufferSizeFromCount(valueCount));
+      }
       if (typeWidth == 0) {
         /* specialized handling for BitVector */
         valueBuffer.writerIndex(getValidityBufferSizeFromCount(valueCount));
@@ -621,9 +630,10 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
         if (target.validityBuffer != null) {
           target.validityBuffer.getReferenceManager().release();
         }
-        target.validityBuffer = validityBuffer.slice(firstByteSource, byteSizeTarget);
+        target.validityBuffer = NON_NULLABLE_VECTORS_ENABLED && !nullable ? allocator.getEmpty() :
+            validityBuffer.slice(firstByteSource, byteSizeTarget);
         target.validityBuffer.getReferenceManager().retain(1);
-      } else {
+      } else if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
         /* Copy data
          * When the first bit starts from the middle of a byte (offset != 0),
          * copy data from src BitVector.
@@ -681,7 +691,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    */
   @Override
   public int getNullCount() {
-    return BitVectorHelper.getNullCount(validityBuffer, valueCount);
+    return NON_NULLABLE_VECTORS_ENABLED && !nullable ? 0 : BitVectorHelper.getNullCount(validityBuffer, valueCount);
   }
 
   /**
@@ -762,7 +772,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    */
   @Override
   public boolean isNull(int index) {
-    return (isSet(index) == 0);
+    return NON_NULLABLE_VECTORS_ENABLED && !nullable ? false : (isSet(index) == 0);
   }
 
   /**
@@ -772,6 +782,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    * @return 1 if element at given index is not null, 0 otherwise
    */
   public int isSet(int index) {
+    if (NON_NULLABLE_VECTORS_ENABLED && !nullable) {
+      return 1;
+    }
     final int byteIndex = index >> 3;
     final byte b = validityBuffer.getByte(byteIndex);
     final int bitIndex = index & 7;
@@ -785,6 +798,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    */
   @Override
   public void setIndexDefined(int index) {
+    if (NON_NULLABLE_VECTORS_ENABLED && !nullable) {
+      return;
+    }
     handleSafe(index);
     BitVectorHelper.setBit(validityBuffer, index);
   }
@@ -862,6 +878,9 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    * @param index position of element
    */
   public void setNull(int index) {
+    if (NON_NULLABLE_VECTORS_ENABLED && !nullable) {
+      throw new IllegalArgumentException("The vector is non-nullable");
+    }
     handleSafe(index);
     // not really needed to set the bit to 0 as long as
     // the buffer always starts from 0.

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -59,7 +59,7 @@ public abstract class BaseValueVector implements ValueVector {
 
   protected BaseValueVector(BufferAllocator allocator, boolean nullable) {
     this.allocator = Preconditions.checkNotNull(allocator, "allocator cannot be null");
-    this.nullable = nullable;
+    this.nullable = !NonNullableVectorOption.NON_NULLABLE_VECTORS_ENABLED || nullable;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -51,8 +51,15 @@ public abstract class BaseValueVector implements ValueVector {
 
   protected final BufferAllocator allocator;
 
+  protected final boolean nullable;
+
   protected BaseValueVector(BufferAllocator allocator) {
+    this(allocator, true);
+  }
+
+  protected BaseValueVector(BufferAllocator allocator, boolean nullable) {
     this.allocator = Preconditions.checkNotNull(allocator, "allocator cannot be null");
+    this.nullable = nullable;
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.arrow.vector;
 
+import static org.apache.arrow.vector.NonNullableVectorOption.NON_NULLABLE_VECTORS_ENABLED;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.ArrowBuf;
@@ -164,7 +165,9 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
    * @param value value of element
    */
   public void set(int index, int value) {
-    BitVectorHelper.setBit(validityBuffer, index);
+    if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+      BitVectorHelper.setBit(validityBuffer, index);
+    }
     setValue(index, value);
   }
 
@@ -180,9 +183,11 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      BitVectorHelper.setBit(validityBuffer, index);
+      if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+        BitVectorHelper.setBit(validityBuffer, index);
+      }
       setValue(index, holder.value);
-    } else {
+    } else if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
       BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
@@ -194,7 +199,9 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
    * @param holder data holder for value of element
    */
   public void set(int index, IntHolder holder) {
-    BitVectorHelper.setBit(validityBuffer, index);
+    if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+      BitVectorHelper.setBit(validityBuffer, index);
+    }
     setValue(index, holder.value);
   }
 
@@ -248,7 +255,7 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
   public void set(int index, int isSet, int value) {
     if (isSet > 0) {
       set(index, value);
-    } else {
+    } else if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
       BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/IntVector.java
@@ -17,7 +17,6 @@
 
 package org.apache.arrow.vector;
 
-import static org.apache.arrow.vector.NonNullableVectorOption.NON_NULLABLE_VECTORS_ENABLED;
 import static org.apache.arrow.vector.NullCheckingForGet.NULL_CHECKING_ENABLED;
 
 import org.apache.arrow.memory.ArrowBuf;
@@ -165,7 +164,7 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
    * @param value value of element
    */
   public void set(int index, int value) {
-    if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+    if (nullable) {
       BitVectorHelper.setBit(validityBuffer, index);
     }
     setValue(index, value);
@@ -183,11 +182,11 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
     if (holder.isSet < 0) {
       throw new IllegalArgumentException();
     } else if (holder.isSet > 0) {
-      if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+      if (nullable) {
         BitVectorHelper.setBit(validityBuffer, index);
       }
       setValue(index, holder.value);
-    } else if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+    } else if (nullable) {
       BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }
@@ -199,7 +198,7 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
    * @param holder data holder for value of element
    */
   public void set(int index, IntHolder holder) {
-    if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+    if (nullable) {
       BitVectorHelper.setBit(validityBuffer, index);
     }
     setValue(index, holder.value);
@@ -255,7 +254,7 @@ public final class IntVector extends BaseFixedWidthVector implements BaseIntVect
   public void set(int index, int isSet, int value) {
     if (isSet > 0) {
       set(index, value);
-    } else if (!NON_NULLABLE_VECTORS_ENABLED || nullable) {
+    } else if (nullable) {
       BitVectorHelper.unsetBit(validityBuffer, index);
     }
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/NonNullableVectorOption.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/NonNullableVectorOption.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.vector;
+
+/**
+ * Configuration class to determine if non-nullable vectors are enabled or not.
+ *
+ * <p>
+ * Non-nullable vectors are disabled by default.  You can enable it by setting either the system property or
+ * the environmental variable to "true". The system property name is "arrow.enable_non_nullable_vectors".
+ * The environmental variable name is "ARROW_ENABLE_NON_NULLABLE_VECTORS".
+ * When both the system property and the environmental variable are set, the system property takes precedence.
+ * </p>
+ */
+public class NonNullableVectorOption {
+
+  public static final boolean NON_NULLABLE_VECTORS_ENABLED;
+  static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(NonNullableVectorOption.class);
+
+  static {
+    String envProperty = System.getenv("ARROW_ENABLE_NON_NULLABLE_VECTORS");
+    String sysProperty = System.getProperty("arrow.enable_non_nullable_vectors");
+
+    // The system property has a higher priority than the environmental variable.
+    String flagValue = sysProperty;
+    if (flagValue == null) {
+      flagValue = envProperty;
+    }
+
+    // The flag is set to true only if the system property/environmental
+    // variable is explicitly set to "true".
+    NON_NULLABLE_VECTORS_ENABLED = "true".equals(flagValue);
+    LOGGER.info("Set NON_NULLABLE_VECTORS_ENABLED to " + NON_NULLABLE_VECTORS_ENABLED);
+  }
+
+  private NonNullableVectorOption() {
+  }
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/types/pojo/FieldType.java
@@ -40,6 +40,10 @@ public class FieldType {
     return new FieldType(true, type, null, null);
   }
 
+  public static FieldType nonNullable(ArrowType type) {
+    return new FieldType(false, type, null, null);
+  }
+
   private final boolean nullable;
   private final ArrowType type;
   private final DictionaryEncoding dictionary;

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestDictionaryVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestDictionaryVector.java
@@ -381,8 +381,10 @@ public class TestDictionaryVector {
   @Test
   public void testIntEquals() {
     //test Int
-    try (final IntVector vector1 = new IntVector("int", allocator);
-         final IntVector vector2 = new IntVector("int", allocator)) {
+    try (final IntVector vector1 =
+             new IntVector("int", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
+         final IntVector vector2 =
+             new IntVector("int", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator)) {
 
       Dictionary dict1 = new Dictionary(vector1, new DictionaryEncoding(1L, false, null));
       Dictionary dict2 = new Dictionary(vector2, new DictionaryEncoding(1L, false, null));

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestOutOfMemoryForValueVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestOutOfMemoryForValueVector.java
@@ -20,6 +20,8 @@ package org.apache.arrow.vector;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.OutOfMemoryException;
 import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -54,14 +56,16 @@ public class TestOutOfMemoryForValueVector {
 
   @Test(expected = OutOfMemoryException.class)
   public void fixedWidthVectorAllocateNew() {
-    try (IntVector vector = new IntVector(EMPTY_SCHEMA_PATH, allocator)) {
+    try (IntVector vector = new IntVector(EMPTY_SCHEMA_PATH,
+        FieldType.nonNullable(Types.MinorType.INT.getType()), allocator)) {
       vector.allocateNew();
     }
   }
 
   @Test(expected = OutOfMemoryException.class)
   public void fixedWidthVectorAllocateNewCustom() {
-    try (IntVector vector = new IntVector(EMPTY_SCHEMA_PATH, allocator)) {
+    try (IntVector vector = new IntVector(EMPTY_SCHEMA_PATH,
+        FieldType.nonNullable(Types.MinorType.INT.getType()), allocator)) {
       vector.allocateNew(2342);
     }
   }

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestVectorSchemaRoot.java
@@ -31,6 +31,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.impl.UnionListWriter;
+import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -56,7 +57,8 @@ public class TestVectorSchemaRoot {
   public void testResetRowCount() {
     final int size = 20;
     try (final BitVector vec1 = new BitVector("bit", allocator);
-         final IntVector vec2 = new IntVector("int", allocator)) {
+         final IntVector vec2 =
+             new IntVector("int", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator)) {
       VectorSchemaRoot vsr = VectorSchemaRoot.of(vec1, vec2);
 
       vsr.allocateNew();
@@ -173,9 +175,10 @@ public class TestVectorSchemaRoot {
 
   @Test
   public void testRemoveVector() {
-    try (final IntVector intVector1 = new IntVector("intVector1", allocator);
-        final IntVector intVector2 = new IntVector("intVector2", allocator);
-        final IntVector intVector3 = new IntVector("intVector3", allocator);) {
+    try (final IntVector intVector1 =
+             new IntVector("intVector1", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
+         final IntVector intVector2 = new IntVector("intVector2", allocator);
+         final IntVector intVector3 = new IntVector("intVector3", allocator);) {
 
       VectorSchemaRoot original =
           new VectorSchemaRoot(Arrays.asList(intVector1, intVector2, intVector3));
@@ -193,7 +196,8 @@ public class TestVectorSchemaRoot {
 
   @Test
   public void testSlice() {
-    try (final IntVector intVector = new IntVector("intVector", allocator);
+    try (final IntVector intVector =
+             new IntVector("intVector", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
          final Float4Vector float4Vector = new Float4Vector("float4Vector", allocator)) {
       intVector.setValueCount(10);
       float4Vector.setValueCount(10);
@@ -223,7 +227,8 @@ public class TestVectorSchemaRoot {
 
   @Test(expected = IllegalArgumentException.class)
   public void testSliceWithInvalidParam() {
-    try (final IntVector intVector = new IntVector("intVector", allocator);
+    try (final IntVector intVector =
+             new IntVector("intVector", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
          final Float4Vector float4Vector = new Float4Vector("float4Vector", allocator)) {
       intVector.setValueCount(10);
       float4Vector.setValueCount(10);
@@ -239,9 +244,12 @@ public class TestVectorSchemaRoot {
 
   @Test
   public void testEquals() {
-    try (final IntVector intVector1 = new IntVector("intVector1", allocator);
-         final IntVector intVector2 = new IntVector("intVector2", allocator);
-         final IntVector intVector3 = new IntVector("intVector3", allocator);) {
+    try (final IntVector intVector1 =
+             new IntVector("intVector1", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
+         final IntVector intVector2 =
+             new IntVector("intVector2", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
+         final IntVector intVector3 =
+             new IntVector("intVector3", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);) {
 
       intVector1.setValueCount(5);
       for (int i = 0; i < 5; i++) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/compare/TestRangeEqualsVisitor.java
@@ -78,7 +78,8 @@ public class TestRangeEqualsVisitor {
 
   @Test
   public void testIntVectorEqualsWithNull() {
-    try (final IntVector vector1 = new IntVector("int", allocator);
+    try (final IntVector vector1 = new IntVector("int",
+        FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
          final IntVector vector2 = new IntVector("int", allocator)) {
 
       setVector(vector1, 1, 2);
@@ -90,8 +91,10 @@ public class TestRangeEqualsVisitor {
 
   @Test
   public void testEqualsWithTypeChange() {
-    try (final IntVector vector1 = new IntVector("vector", allocator);
-         final IntVector vector2 = new IntVector("vector", allocator);
+    try (final IntVector vector1 =
+             new IntVector("vector", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
+         final IntVector vector2 =
+             new IntVector("vector", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
          final BigIntVector vector3 = new BigIntVector("vector", allocator)) {
 
       setVector(vector1, 1, 2);
@@ -107,8 +110,10 @@ public class TestRangeEqualsVisitor {
 
   @Test
   public void testBaseFixedWidthVectorRangeEqual() {
-    try (final IntVector vector1 = new IntVector("int", allocator);
-         final IntVector vector2 = new IntVector("int", allocator)) {
+    try (final IntVector vector1 =
+             new IntVector("int", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
+         final IntVector vector2 =
+             new IntVector("int", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator)) {
 
       setVector(vector1, 1, 2, 3, 4, 5);
       setVector(vector2, 11, 2, 3, 4, 55);

--- a/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/ipc/TestArrowReaderWriter.java
@@ -69,6 +69,7 @@ import org.apache.arrow.vector.ipc.message.ArrowFieldNode;
 import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
 import org.apache.arrow.vector.ipc.message.IpcOption;
 import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.DictionaryEncoding;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -672,7 +673,7 @@ public class TestArrowReaderWriter {
   @Test
   public void testLegacyIpcBackwardsCompatibility() throws Exception {
     Schema schema = new Schema(asList(Field.nullable("field", new ArrowType.Int(32, true))));
-    IntVector vector = new IntVector("vector", allocator);
+    IntVector vector = new IntVector("vector", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
     final int valueCount = 2;
     vector.setValueCount(valueCount);
     vector.setSafe(0, 1);

--- a/java/vector/src/test/java/org/apache/arrow/vector/util/TestVectorBatchAppender.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/util/TestVectorBatchAppender.java
@@ -23,6 +23,8 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,9 +51,9 @@ public class TestVectorBatchAppender {
     final int length1 = 10;
     final int length2 = 5;
     final int length3 = 7;
-    try (IntVector target = new IntVector("", allocator);
-         IntVector delta1 = new IntVector("", allocator);
-         IntVector delta2 = new IntVector("", allocator)) {
+    try (IntVector target = new IntVector("", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
+         IntVector delta1 = new IntVector("", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
+         IntVector delta2 = new IntVector("", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator)) {
 
       target.allocateNew(length1);
       delta1.allocateNew(length2);

--- a/java/vector/src/test/java/org/apache/arrow/vector/util/TestVectorSchemaRootAppender.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/util/TestVectorSchemaRootAppender.java
@@ -28,6 +28,8 @@ import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.testing.ValueVectorDataPopulator;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.FieldType;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -111,7 +113,8 @@ public class TestVectorSchemaRootAppender {
          VarCharVector targetChild2 = new VarCharVector("t2", allocator);
          BigIntVector targetChild3 = new BigIntVector("t3", allocator);
 
-         IntVector deltaChild1 = new IntVector("d1", allocator);
+         IntVector deltaChild1 =
+             new IntVector("d1", FieldType.nonNullable(Types.MinorType.INT.getType()), allocator);
          VarCharVector deltaChild2 = new VarCharVector("d2", allocator)) {
 
       ValueVectorDataPopulator.setVector(targetChild1, 0, 1, null, 3, 4);


### PR DESCRIPTION
This issue was first discussed in the ML (https://lists.apache.org/thread.html/r480387ec9ec822f3ed30e9131109e43874a1c4d18af74ede1a7e41c5%40%3Cdev.arrow.apache.org%3E), from which we have received some feedback.

We briefly resate it here as below:

 
1. Non-nullable vectors are widely used in practice. For example, in a database engine, a column can be declared as not null, so it cannot contain null values.
2.Non-nullable vectors has significant performance advantages compared with their nullable conterparts, such as:
  1) the memory space of the validity buffer can be saved.
  2) manipulation of the validity buffer can be bypassed
  3) some if-else branches can be replaced by sequential instructions (by the JIT compiler), leading to high throughput for the CPU pipeline. 
 
We open this Jira to facilitate further discussions, and we may provide a sample PR, which will help us make a clearer decision. 