### PR TITLE
ARROW-9271: [R] Preserve data frame metadata in round trip

### DIFF
--- a/r/R/dataset-write.R
+++ b/r/R/dataset-write.R
@@ -69,6 +69,11 @@ write_dataset <- function(dataset,
   }
   if (inherits(dataset, c("data.frame", "RecordBatch", "Table"))) {
     force(partitioning) # get the group_vars before we replace the object
+    if (inherits(dataset, "grouped_df")) {
+      # Drop the grouping metadata before writing; we've already consumed it
+      # now to construct `partitioning` and don't want it in the metadata$r
+      dataset <- dplyr::ungroup(dataset)
+    }
     dataset <- InMemoryDataset$create(dataset)
   }
   if (!inherits(dataset, "Dataset")) {

--- a/r/R/record-batch.R
+++ b/r/R/record-batch.R
@@ -278,7 +278,10 @@ as.data.frame.RecordBatch <- function(x, row.names = NULL, optional = FALSE, ...
 apply_arrow_r_metadata <- function(x, r_metadata) {
   tryCatch({
     if (!is.null(r_metadata$attributes)) {
-      attributes(x) <- r_metadata$attributes
+      attributes(x)[names(r_metadata$attributes)] <- r_metadata$attributes
+      if (inherits(x, "POSIXlt")) {
+        attr(x, "row.names") <- NULL
+      }
     }
 
     columns_metadata <- r_metadata$columns

--- a/r/R/record-batch.R
+++ b/r/R/record-batch.R
@@ -279,9 +279,6 @@ apply_arrow_r_metadata <- function(x, r_metadata) {
   tryCatch({
     if (!is.null(r_metadata$attributes)) {
       attributes(x)[names(r_metadata$attributes)] <- r_metadata$attributes
-      if (inherits(x, "POSIXlt")) {
-        attr(x, "row.names") <- NULL
-      }
     }
 
     columns_metadata <- r_metadata$columns

--- a/r/R/record-batch.R
+++ b/r/R/record-batch.R
@@ -279,6 +279,13 @@ apply_arrow_r_metadata <- function(x, r_metadata) {
   tryCatch({
     if (!is.null(r_metadata$attributes)) {
       attributes(x)[names(r_metadata$attributes)] <- r_metadata$attributes
+      if (inherits(x, "POSIXlt")) {
+        # We store POSIXlt as a StructArray, which is translated back to R
+        # as a data.frame, but while data frames have a row.names = c(NA, nrow(x))
+        # attribute, POSIXlt does not, so since this is now no longer an object
+        # of class data.frame, remove the extraneous attribute
+        attr(x, "row.names") <- NULL
+      }
     }
 
     columns_metadata <- r_metadata$columns

--- a/r/R/table.R
+++ b/r/R/table.R
@@ -212,6 +212,8 @@ arrow_attributes <- function(x, only_top_level = FALSE) {
     }
   } else if (length(att)) {
     list(attributes = att, columns = NULL)
+  } else {
+    NULL
   }
 }
 

--- a/r/R/table.R
+++ b/r/R/table.R
@@ -185,22 +185,25 @@ Table <- R6Class("Table", inherit = ArrowObject,
   )
 )
 
-bad_attributes <- function(x) {
-  UseMethod("bad_attributes")
-}
-
-bad_attributes.default <- function(x) character()
-bad_attributes.data.frame <- function(x) c("class", "row.names", "names")
-bad_attributes.factor <- function(x) c("class", "levels")
-bad_attributes.Date <- function(x) "class"
-bad_attributes.integer64 <- function(x) "class"
-bad_attributes.POSIXct <- function(x) c("class", "tzone")
-bad_attributes.hms <- function(x) c("class", "units")
-bad_attributes.difftime <- function(x) c("class", "units")
-
 arrow_attributes <- function(x, only_top_level = FALSE) {
   att <- attributes(x)
-  att <- att[setdiff(names(att), bad_attributes(x))]
+
+  removed_attributes <- character()
+  if (identical(class(x), c("tbl_df", "tbl", "data.frame"))) {
+    removed_attributes <- c("class", "row.names", "names")
+  } else if (inherits(x, "data.frame")) {
+    removed_attributes <- c("row.names", "names")
+  } else if (inherits(x, "factor")) {
+    removed_attributes <- c("class", "levels")
+  } else if (inherits(x, "integer64") || inherits(x, "Date")) {
+    removed_attributes <- c("class")
+  } else if (inherits(x, "POSIXct")) {
+    removed_attributes <- c("class", "tzone")
+  } else if (inherits(x, "hms") || inherits(x, "difftime")) {
+    removed_attributes <- c("class", "units")
+  }
+
+  att <- att[setdiff(names(att), removed_attributes)]
   if (isTRUE(only_top_level)) {
     return(att)
   }

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -127,6 +127,7 @@ struct symbols {
   static SEXP ptype;
   static SEXP byte_width;
   static SEXP list_size;
+  static SEXP arrow_attributes;
 };
 
 struct data {

--- a/r/src/symbols.cpp
+++ b/r/src/symbols.cpp
@@ -30,6 +30,7 @@ SEXP symbols::as_list = Rf_install("as.list");
 SEXP symbols::ptype = Rf_install("ptype");
 SEXP symbols::byte_width = Rf_install("byte_width");
 SEXP symbols::list_size = Rf_install("list_size");
+SEXP symbols::arrow_attributes = Rf_install("arrow_attributes");
 
 // persistently protect `x` and return it
 SEXP precious(SEXP x) {

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -890,6 +890,7 @@ test_that("Dataset writing: from data.frame", {
       select(string = chr, integer = int) %>%
       filter(integer > 6 & integer < 11) %>%
       collect() %>%
+      ungroup() %>%
       summarize(mean = mean(integer)),
     df1 %>%
       select(string = chr, integer = int) %>%

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -890,7 +890,6 @@ test_that("Dataset writing: from data.frame", {
       select(string = chr, integer = int) %>%
       filter(integer > 6 & integer < 11) %>%
       collect() %>%
-      ungroup() %>%
       summarize(mean = mean(integer)),
     df1 %>%
       select(string = chr, integer = int) %>%

--- a/r/tests/testthat/test-metadata.R
+++ b/r/tests/testthat/test-metadata.R
@@ -126,3 +126,9 @@ test_that("Date/time type roundtrip", {
   expect_is(rb$schema$posixlt$type, "StructType")
   expect_identical(as.data.frame(rb), example_with_times)
 })
+
+test_that("metadata keeps attribute of top level data frame", {
+  df <- structure(data.frame(x = 1, y = 2), foo = "bar")
+  tab <- Table$create(df)
+  expect_equal(attr(as.data.frame(tab), "foo"), "bar")
+})

--- a/r/tests/testthat/test-metadata.R
+++ b/r/tests/testthat/test-metadata.R
@@ -61,6 +61,7 @@ test_that("Table R metadata", {
 test_that("R metadata is not stored for types that map to Arrow types (factor, Date, etc.)", {
   tab <- Table$create(example_data[1:6])
   expect_null(tab$metadata$r)
+
   expect_null(Table$create(example_with_times[1:3])$metadata$r)
 })
 
@@ -124,7 +125,7 @@ test_that("haven types roundtrip via feather", {
 test_that("Date/time type roundtrip", {
   rb <- record_batch(example_with_times)
   expect_is(rb$schema$posixlt$type, "StructType")
-  expect_identical(as.data.frame(rb), example_with_times)
+  expect_equal(as.data.frame(rb), example_with_times)
 })
 
 test_that("metadata keeps attribute of top level data frame", {

--- a/r/tests/testthat/test-metadata.R
+++ b/r/tests/testthat/test-metadata.R
@@ -125,11 +125,12 @@ test_that("haven types roundtrip via feather", {
 test_that("Date/time type roundtrip", {
   rb <- record_batch(example_with_times)
   expect_is(rb$schema$posixlt$type, "StructType")
-  expect_equal(as.data.frame(rb), example_with_times)
+  expect_identical(as.data.frame(rb), example_with_times)
 })
 
 test_that("metadata keeps attribute of top level data frame", {
   df <- structure(data.frame(x = 1, y = 2), foo = "bar")
   tab <- Table$create(df)
-  expect_equal(attr(as.data.frame(tab), "foo"), "bar")
+  expect_identical(attr(as.data.frame(tab), "foo"), "bar")
+  expect_identical(as.data.frame(tab), df)
 })


### PR DESCRIPTION
Simplified the internal code and moved some things to the R layer. This should make it easier to alter which attribute is kept for various types. 