### PR TITLE
ARROW-9954: [Rust] [DataFusion] Made aggregates support the same signatures as functions.

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -514,7 +514,7 @@ mod tests {
 
     use super::*;
     use crate::datasource::MemTable;
-    use crate::logical_plan::{aggregate_expr, col, create_udf};
+    use crate::logical_plan::{col, create_udf, sum};
     use crate::physical_plan::functions::ScalarFunctionImplementation;
     use crate::test;
     use crate::variable::VarType;
@@ -941,7 +941,7 @@ mod tests {
         ]));
 
         let plan = LogicalPlanBuilder::scan("default", "test", schema.as_ref(), None)?
-            .aggregate(vec![col("c1")], vec![aggregate_expr("SUM", col("c2"))])?
+            .aggregate(vec![col("c1")], vec![sum(col("c2"))])?
             .project(vec![col("c1"), col("SUM(c2)").alias("total_salary")])?
             .build()?;
 

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -338,7 +338,7 @@ mod tests {
 
     use super::*;
     use crate::logical_plan::{col, lit};
-    use crate::logical_plan::{Expr, LogicalPlanBuilder};
+    use crate::logical_plan::{max, min, Expr, LogicalPlanBuilder};
     use crate::test::*;
     use arrow::datatypes::DataType;
 

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -239,8 +239,8 @@ pub fn rewrite_expression(expr: &Expr, expressions: &Vec<Expr>) -> Result<Expr> 
             fun: fun.clone(),
             args: expressions.clone(),
         }),
-        Expr::AggregateFunction { name, .. } => Ok(Expr::AggregateFunction {
-            name: name.clone(),
+        Expr::AggregateFunction { fun, .. } => Ok(Expr::AggregateFunction {
+            fun: fun.clone(),
             args: expressions.clone(),
         }),
         Expr::Cast { data_type, .. } => Ok(Expr::Cast {

--- a/rust/datafusion/src/physical_plan/aggregates.rs
+++ b/rust/datafusion/src/physical_plan/aggregates.rs
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Declaration of built-in (aggregate) functions.
+//! This module contains built-in aggregates' enumeration and metadata.
+//!
+//! Generally, an aggregate has:
+//! * a signature
+//! * a return type, that is a function of the incoming argument's types
+//! * the computation, that must accept each valid signature
+//!
+//! * Signature: see `Signature`
+//! * Return type: a function `(arg_types) -> return_type`. E.g. for min, ([f32]) -> f32, ([f64]) -> f64.
+
+use super::{
+    functions::Signature,
+    type_coercion::{coerce, data_types},
+    AggregateExpr, PhysicalExpr,
+};
+use crate::error::{ExecutionError, Result};
+use crate::physical_plan::expressions;
+use arrow::datatypes::{DataType, Schema};
+use expressions::{avg_return_type, sum_return_type};
+use std::{fmt, str::FromStr, sync::Arc};
+
+/// Enum of all built-in scalar functions
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AggregateFunction {
+    /// count
+    Count,
+    /// sum
+    Sum,
+    /// min
+    Min,
+    /// max
+    Max,
+    /// avg
+    Avg,
+}
+
+impl fmt::Display for AggregateFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // uppercase of the debug.
+        write!(f, "{}", format!("{:?}", self).to_uppercase())
+    }
+}
+
+impl FromStr for AggregateFunction {
+    type Err = ExecutionError;
+    fn from_str(name: &str) -> Result<AggregateFunction> {
+        Ok(match &*name.to_uppercase() {
+            "MIN" => AggregateFunction::Min,
+            "MAX" => AggregateFunction::Max,
+            "COUNT" => AggregateFunction::Count,
+            "AVG" => AggregateFunction::Avg,
+            "SUM" => AggregateFunction::Sum,
+            _ => {
+                return Err(ExecutionError::General(format!(
+                    "There is no built-in function named {}",
+                    name
+                )))
+            }
+        })
+    }
+}
+
+/// Returns the datatype of the scalar function
+pub fn return_type(
+    fun: &AggregateFunction,
+    arg_types: &Vec<DataType>,
+) -> Result<DataType> {
+    // Note that this function *must* return the same type that the respective physical expression returns
+    // or the execution panics.
+
+    // verify that this is a valid set of data types for this function
+    data_types(arg_types, &signature(fun))?;
+
+    match fun {
+        AggregateFunction::Count => Ok(DataType::UInt64),
+        AggregateFunction::Max | AggregateFunction::Min => Ok(arg_types[0].clone()),
+        AggregateFunction::Sum => sum_return_type(&arg_types[0]),
+        AggregateFunction::Avg => avg_return_type(&arg_types[0]),
+    }
+}
+
+/// Create a physical (function) expression.
+/// This function errors when `args`' can't be coerced to a valid argument type of the function.
+pub fn create_aggregate_expr(
+    fun: &AggregateFunction,
+    args: &Vec<Arc<dyn PhysicalExpr>>,
+    input_schema: &Schema,
+) -> Result<Arc<dyn AggregateExpr>> {
+    // coerce
+    let arg = coerce(args, input_schema, &signature(fun))?[0].clone();
+
+    Ok(match fun {
+        AggregateFunction::Count => expressions::count(arg),
+        AggregateFunction::Sum => expressions::sum(arg),
+        AggregateFunction::Min => expressions::min(arg),
+        AggregateFunction::Max => expressions::max(arg),
+        AggregateFunction::Avg => expressions::avg(arg),
+    })
+}
+
+/// the signatures supported by the function `fun`.
+fn signature(fun: &AggregateFunction) -> Signature {
+    // note: the physical expression must accept the type returned by this function or the execution panics.
+
+    match fun {
+        AggregateFunction::Count => Signature::Any(1),
+        AggregateFunction::Min
+        | AggregateFunction::Max
+        | AggregateFunction::Avg
+        | AggregateFunction::Sum => Signature::Uniform(
+            1,
+            vec![
+                DataType::Int8,
+                DataType::Int16,
+                DataType::Int32,
+                DataType::Int64,
+                DataType::UInt8,
+                DataType::UInt16,
+                DataType::UInt32,
+                DataType::UInt64,
+                DataType::Float32,
+                DataType::Float64,
+            ],
+        ),
+    }
+}

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -107,22 +107,27 @@ impl Sum {
     }
 }
 
+/// function return type of a sum
+pub fn sum_return_type(arg_type: &DataType) -> Result<DataType> {
+    match arg_type {
+        DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => {
+            Ok(DataType::Int64)
+        }
+        DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
+            Ok(DataType::UInt64)
+        }
+        DataType::Float32 => Ok(DataType::Float32),
+        DataType::Float64 => Ok(DataType::Float64),
+        other => Err(ExecutionError::General(format!(
+            "SUM does not support type \"{:?}\"",
+            other
+        ))),
+    }
+}
+
 impl AggregateExpr for Sum {
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
-        match self.expr.data_type(input_schema)? {
-            DataType::Int8 | DataType::Int16 | DataType::Int32 | DataType::Int64 => {
-                Ok(DataType::Int64)
-            }
-            DataType::UInt8 | DataType::UInt16 | DataType::UInt32 | DataType::UInt64 => {
-                Ok(DataType::UInt64)
-            }
-            DataType::Float32 => Ok(DataType::Float32),
-            DataType::Float64 => Ok(DataType::Float64),
-            other => Err(ExecutionError::General(format!(
-                "SUM does not support {:?}",
-                other
-            ))),
-        }
+        sum_return_type(&self.expr.data_type(input_schema)?)
     }
 
     fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
@@ -306,24 +311,29 @@ impl Avg {
     }
 }
 
+/// function return type of an average
+pub fn avg_return_type(arg_type: &DataType) -> Result<DataType> {
+    match arg_type {
+        DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Float32
+        | DataType::Float64 => Ok(DataType::Float64),
+        other => Err(ExecutionError::General(format!(
+            "AVG does not support {:?}",
+            other
+        ))),
+    }
+}
+
 impl AggregateExpr for Avg {
     fn data_type(&self, input_schema: &Schema) -> Result<DataType> {
-        match self.expr.data_type(input_schema)? {
-            DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Int64
-            | DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Float32
-            | DataType::Float64 => Ok(DataType::Float64),
-            other => Err(ExecutionError::General(format!(
-                "AVG does not support {:?}",
-                other
-            ))),
-        }
+        avg_return_type(&self.expr.data_type(input_schema)?)
     }
 
     fn nullable(&self, _input_schema: &Schema) -> Result<bool> {

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -63,6 +63,8 @@ pub enum Signature {
     Uniform(usize, Vec<DataType>),
     /// exact number of arguments of an exact type
     Exact(Vec<DataType>),
+    /// fixed number of arguments of arbitrary types
+    Any(usize),
 }
 
 /// Scalar function

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -130,6 +130,7 @@ pub trait Accumulator: Debug {
     fn get_value(&self) -> Result<Option<ScalarValue>>;
 }
 
+pub mod aggregates;
 pub mod common;
 pub mod csv;
 pub mod datetime_expressions;

--- a/rust/datafusion/src/physical_plan/type_coercion.rs
+++ b/rust/datafusion/src/physical_plan/type_coercion.rs
@@ -67,6 +67,16 @@ pub fn data_types(
                 .collect()]
         }
         Signature::Exact(valid_types) => vec![valid_types.clone()],
+        Signature::Any(number) => {
+            if current_types.len() != *number {
+                return Err(ExecutionError::General(format!(
+                    "The function expected {} arguments but received {}",
+                    number,
+                    current_types.len()
+                )));
+            }
+            vec![(0..*number).map(|i| current_types[i].clone()).collect()]
+        }
     };
 
     if valid_types.contains(current_types) {
@@ -276,6 +286,12 @@ mod tests {
                 Signature::Variadic(vec![DataType::UInt32, DataType::UInt64]),
                 vec![DataType::UInt64, DataType::UInt64],
             )?,
+            // f32 -> f32
+            case(
+                vec![DataType::Float32],
+                Signature::Any(1),
+                vec![DataType::Float32],
+            )?,
         ];
 
         for case in cases {
@@ -304,6 +320,8 @@ mod tests {
                 Signature::Variadic(vec![DataType::UInt32]),
                 vec![],
             )?,
+            // expected two arguments
+            case(vec![DataType::UInt32], Signature::Any(2), vec![])?,
         ];
 
         for case in cases {

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -20,7 +20,7 @@
 use crate::datasource::{MemTable, TableProvider};
 use crate::error::Result;
 use crate::execution::context::ExecutionContext;
-use crate::logical_plan::{Expr, LogicalPlan, LogicalPlanBuilder};
+use crate::logical_plan::{LogicalPlan, LogicalPlanBuilder};
 use crate::physical_plan::ExecutionPlan;
 use arrow::array;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
@@ -240,20 +240,6 @@ pub fn assert_fields_eq(plan: &LogicalPlan, expected: Vec<&str>) {
         .map(|f| f.name().clone())
         .collect();
     assert_eq!(actual, expected);
-}
-
-pub fn max(expr: Expr) -> Expr {
-    Expr::AggregateFunction {
-        name: "MAX".to_owned(),
-        args: vec![expr],
-    }
-}
-
-pub fn min(expr: Expr) -> Expr {
-    Expr::AggregateFunction {
-        name: "MIN".to_owned(),
-        args: vec![expr],
-    }
 }
 
 pub mod variable;


### PR DESCRIPTION
This commit makes the creation of aggregate expressions similar to the creation of built-in expressions.

This allows to share coercion rules and signatures between scalar and aggregate functions.
