### PR TITLE
ARROW-9957: [Rust] Replace tempdir with tempfile

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -57,7 +57,7 @@ chrono = "0.4"
 
 [dev-dependencies]
 criterion = "0.3"
-tempdir = "0.3"
+tempfile = "3"
 futures = "0.3"
 prost = "0.6"
 tokio = { version = "0.2", features = ["macros"] }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -546,7 +546,7 @@ mod tests {
 
     #[test]
     fn create_variable_expr() -> Result<()> {
-        let tmp_dir = TempDir::new("variable_expr")?;
+        let tmp_dir = TempDir::new()?;
         let partition_count = 4;
         let mut ctx = create_ctx(&tmp_dir, partition_count)?;
 
@@ -1032,7 +1032,7 @@ mod tests {
     fn send_context_to_threads() -> Result<()> {
         // ensure ExecutionContexts can be used in a multi-threaded
         // environment. Usecase is for concurrent planing.
-        let tmp_dir = TempDir::new("send_context_to_threads")?;
+        let tmp_dir = TempDir::new()?;
         let partition_count = 4;
         let ctx = Arc::new(Mutex::new(create_ctx(&tmp_dir, partition_count)?));
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -522,7 +522,7 @@ mod tests {
     use arrow::compute::add;
     use std::fs::File;
     use std::{io::prelude::*, sync::Mutex};
-    use tempdir::TempDir;
+    use tempfile::TempDir;
     use test::*;
 
     #[test]
@@ -584,7 +584,7 @@ mod tests {
 
     #[test]
     fn parallel_query_with_filter() -> Result<()> {
-        let tmp_dir = TempDir::new("parallel_query_with_filter")?;
+        let tmp_dir = TempDir::new()?;
         let partition_count = 4;
         let mut ctx = create_ctx(&tmp_dir, partition_count)?;
 
@@ -607,7 +607,7 @@ mod tests {
 
     #[test]
     fn projection_on_table_scan() -> Result<()> {
-        let tmp_dir = TempDir::new("projection_on_table_scan")?;
+        let tmp_dir = TempDir::new()?;
         let partition_count = 4;
         let mut ctx = create_ctx(&tmp_dir, partition_count)?;
 
@@ -651,7 +651,7 @@ mod tests {
 
     #[test]
     fn preserve_nullability_on_projection() -> Result<()> {
-        let tmp_dir = TempDir::new("execute")?;
+        let tmp_dir = TempDir::new()?;
         let ctx = create_ctx(&tmp_dir, 1)?;
 
         let schema = ctx.state.datasources.get("test").unwrap().schema();
@@ -932,7 +932,7 @@ mod tests {
 
     #[test]
     fn aggregate_with_alias() -> Result<()> {
-        let tmp_dir = TempDir::new("execute")?;
+        let tmp_dir = TempDir::new()?;
         let ctx = create_ctx(&tmp_dir, 1)?;
 
         let schema = Arc::new(Schema::new(vec![
@@ -959,7 +959,7 @@ mod tests {
     #[test]
     fn write_csv_results() -> Result<()> {
         // create partitioned input file and context
-        let tmp_dir = TempDir::new("write_csv_results_temp")?;
+        let tmp_dir = TempDir::new()?;
         let mut ctx = create_ctx(&tmp_dir, 4)?;
 
         // execute a simple query and write the results to CSV
@@ -1005,7 +1005,7 @@ mod tests {
 
     #[test]
     fn query_csv_with_custom_partition_extension() -> Result<()> {
-        let tmp_dir = TempDir::new("query_csv_with_custom_partition_extension")?;
+        let tmp_dir = TempDir::new()?;
 
         // The main stipulation of this test: use a file extension that isn't .csv.
         let file_extension = ".tst";
@@ -1204,7 +1204,7 @@ mod tests {
 
     /// Execute SQL and return results
     fn execute(sql: &str, partition_count: usize) -> Result<Vec<RecordBatch>> {
-        let tmp_dir = TempDir::new("execute")?;
+        let tmp_dir = TempDir::new()?;
         let mut ctx = create_ctx(&tmp_dir, partition_count)?;
         collect(&mut ctx, sql)
     }

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -30,7 +30,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::io::{BufReader, BufWriter};
 use std::sync::Arc;
-use tempdir::TempDir;
+use tempfile::TempDir;
 
 pub fn create_table_dual() -> Box<dyn TableProvider + Send + Sync> {
     let dual_schema = Arc::new(Schema::new(vec![
@@ -65,7 +65,7 @@ pub fn create_partitioned_csv(filename: &str, partitions: usize) -> Result<Strin
     let testdata = arrow_testdata_path();
     let path = format!("{}/csv/{}", testdata, filename);
 
-    let tmp_dir = TempDir::new("create_partitioned_csv")?;
+    let tmp_dir = TempDir::new()?;
 
     let mut writers = vec![];
     for i in 0..partitions {


### PR DESCRIPTION
tempdir is deprecated (https://crates.io/crates/tempdir)