### PR TITLE
ARROW-9966: [Rust] Speedup kernels for sum,min,max by 10%-60%

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -62,6 +62,10 @@ flate2 = "1"
 tempfile = "3"
 
 [[bench]]
+name = "aggregate_kernels"
+harness = false
+
+[[bench]]
 name = "array_from_vec"
 harness = false
 

--- a/rust/arrow/benches/aggregate_kernels.rs
+++ b/rust/arrow/benches/aggregate_kernels.rs
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+use std::sync::Arc;
+
+extern crate arrow;
+
+use arrow::array::*;
+use arrow::compute::kernels::aggregate::*;
+
+fn create_array(size: usize, with_nulls: bool) -> ArrayRef {
+    let mut builder = Float32Builder::new(size);
+
+    for i in 0..size {
+        if with_nulls && i % 2 == 0 {
+            builder.append_null().unwrap();
+        } else {
+            builder.append_value(1.0 + 1.0 * i as f32).unwrap();
+        }
+    }
+    Arc::new(builder.finish())
+}
+
+fn bench_sum(arr_a: &ArrayRef) {
+    let arr_a = arr_a.as_any().downcast_ref::<Float32Array>().unwrap();
+    criterion::black_box(sum(&arr_a).unwrap());
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    let arr_a = create_array(512, false);
+
+    c.bench_function("sum 512", |b| b.iter(|| bench_sum(&arr_a)));
+
+    let arr_a = create_array(512, true);
+
+    c.bench_function("sum nulls 512", |b| b.iter(|| bench_sum(&arr_a)));
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/rust/arrow/benches/arithmetic_kernels.rs
+++ b/rust/arrow/benches/arithmetic_kernels.rs
@@ -24,7 +24,6 @@ use std::sync::Arc;
 extern crate arrow;
 
 use arrow::array::*;
-use arrow::compute::kernels::aggregate::*;
 use arrow::compute::kernels::arithmetic::*;
 use arrow::compute::kernels::limit::*;
 
@@ -60,11 +59,6 @@ fn bench_divide(arr_a: &ArrayRef, arr_b: &ArrayRef) {
     criterion::black_box(divide(&arr_a, &arr_b).unwrap());
 }
 
-fn bench_sum(arr_a: &ArrayRef) {
-    let arr_a = arr_a.as_any().downcast_ref::<Float32Array>().unwrap();
-    criterion::black_box(sum(&arr_a).unwrap());
-}
-
 fn bench_limit(arr_a: &ArrayRef, max: usize) {
     criterion::black_box(limit(arr_a, max).unwrap());
 }
@@ -81,7 +75,6 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_multiply(&arr_a, &arr_b))
     });
     c.bench_function("divide 512", |b| b.iter(|| bench_divide(&arr_a, &arr_b)));
-    c.bench_function("sum 512", |b| b.iter(|| bench_sum(&arr_a)));
     c.bench_function("limit 512, 512", |b| b.iter(|| bench_limit(&arr_a, 512)));
 }
 

--- a/rust/arrow/benches/arithmetic_kernels.rs
+++ b/rust/arrow/benches/arithmetic_kernels.rs
@@ -28,55 +28,61 @@ use arrow::compute::kernels::aggregate::*;
 use arrow::compute::kernels::arithmetic::*;
 use arrow::compute::kernels::limit::*;
 
-fn create_array(size: usize) -> Float32Array {
+fn create_array(size: usize) -> ArrayRef {
     let mut builder = Float32Builder::new(size);
-    for _i in 0..size {
-        builder.append_value(1.0).unwrap();
+    for i in 0..size {
+        builder.append_value(1.0 + 1.0 * i as f32).unwrap();
     }
-    builder.finish()
+    Arc::new(builder.finish())
 }
 
-fn bench_add(size: usize) {
-    let arr_a = create_array(size);
-    let arr_b = create_array(size);
-    criterion::black_box(add(&arr_a, &arr_b).unwrap());
+fn bench_add(arr_a: &ArrayRef, arr_b: &ArrayRef) {
+    let arr_a = arr_a.as_any().downcast_ref::<Float32Array>().unwrap();
+    let arr_b = arr_b.as_any().downcast_ref::<Float32Array>().unwrap();
+    criterion::black_box(add(arr_a, arr_b).unwrap());
 }
 
-fn bench_subtract(size: usize) {
-    let arr_a = create_array(size);
-    let arr_b = create_array(size);
+fn bench_subtract(arr_a: &ArrayRef, arr_b: &ArrayRef) {
+    let arr_a = arr_a.as_any().downcast_ref::<Float32Array>().unwrap();
+    let arr_b = arr_b.as_any().downcast_ref::<Float32Array>().unwrap();
     criterion::black_box(subtract(&arr_a, &arr_b).unwrap());
 }
 
-fn bench_multiply(size: usize) {
-    let arr_a = create_array(size);
-    let arr_b = create_array(size);
+fn bench_multiply(arr_a: &ArrayRef, arr_b: &ArrayRef) {
+    let arr_a = arr_a.as_any().downcast_ref::<Float32Array>().unwrap();
+    let arr_b = arr_b.as_any().downcast_ref::<Float32Array>().unwrap();
     criterion::black_box(multiply(&arr_a, &arr_b).unwrap());
 }
 
-fn bench_divide(size: usize) {
-    let arr_a = create_array(size);
-    let arr_b = create_array(size);
+fn bench_divide(arr_a: &ArrayRef, arr_b: &ArrayRef) {
+    let arr_a = arr_a.as_any().downcast_ref::<Float32Array>().unwrap();
+    let arr_b = arr_b.as_any().downcast_ref::<Float32Array>().unwrap();
     criterion::black_box(divide(&arr_a, &arr_b).unwrap());
 }
 
-fn bench_sum(size: usize) {
-    let arr_a = create_array(size);
+fn bench_sum(arr_a: &ArrayRef) {
+    let arr_a = arr_a.as_any().downcast_ref::<Float32Array>().unwrap();
     criterion::black_box(sum(&arr_a).unwrap());
 }
 
-fn bench_limit(size: usize, max: usize) {
-    let arr_a: ArrayRef = Arc::new(create_array(size));
-    criterion::black_box(limit(&arr_a, max).unwrap());
+fn bench_limit(arr_a: &ArrayRef, max: usize) {
+    criterion::black_box(limit(arr_a, max).unwrap());
 }
 
 fn add_benchmark(c: &mut Criterion) {
-    c.bench_function("add 512", |b| b.iter(|| bench_add(512)));
-    c.bench_function("subtract 512", |b| b.iter(|| bench_subtract(512)));
-    c.bench_function("multiply 512", |b| b.iter(|| bench_multiply(512)));
-    c.bench_function("divide 512", |b| b.iter(|| bench_divide(512)));
-    c.bench_function("sum 512", |b| b.iter(|| bench_sum(512)));
-    c.bench_function("limit 512, 512", |b| b.iter(|| bench_limit(512, 512)));
+    let arr_a = create_array(512);
+    let arr_b = create_array(512);
+
+    c.bench_function("add 512", |b| b.iter(|| bench_add(&arr_a, &arr_b)));
+    c.bench_function("subtract 512", |b| {
+        b.iter(|| bench_subtract(&arr_a, &arr_b))
+    });
+    c.bench_function("multiply 512", |b| {
+        b.iter(|| bench_multiply(&arr_a, &arr_b))
+    });
+    c.bench_function("divide 512", |b| b.iter(|| bench_divide(&arr_a, &arr_b)));
+    c.bench_function("sum 512", |b| b.iter(|| bench_sum(&arr_a)));
+    c.bench_function("limit 512, 512", |b| b.iter(|| bench_limit(&arr_a, 512)));
 }
 
 criterion_group!(benches, add_benchmark);

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -47,34 +47,31 @@ where
     let null_count = array.null_count();
 
     if null_count == array.len() {
-        None
-    } else if null_count == 0 {
+        return None;
+    }
+
+    let mut n: T::Native = T::default_value();
+    let mut has_value = false;
+    let data = array.data();
+    let m = array.value_slice(0, data.len());
+
+    if null_count == 0 {
         // optimized path for arrays without null values
-        let mut n: T::Native = T::default_value();
-        let mut has_value = false;
-        let data = array.data();
-        let m = array.value_slice(0, data.len());
         for item in m {
             if !has_value || cmp(&n, item) {
                 has_value = true;
                 n = *item
             }
         }
-        Some(n)
     } else {
-        // optimized path for arrays without null values
-        let mut n: T::Native = T::default_value();
-        let mut has_value = false;
-        let data = array.data();
-        let m = array.value_slice(0, data.len());
         for (i, item) in m.iter().enumerate() {
             if !has_value || data.is_valid(i) && cmp(&n, item) {
                 has_value = true;
                 n = *item
             }
         }
-        Some(n)
     }
+    Some(n)
 }
 
 /// Returns the sum of values in the array.
@@ -88,28 +85,26 @@ where
     let null_count = array.null_count();
 
     if null_count == array.len() {
-        None
-    } else if null_count == 0 {
+        return None;
+    }
+
+    let mut n: T::Native = T::default_value();
+    let data = array.data();
+    let m = array.value_slice(0, data.len());
+
+    if null_count == 0 {
         // optimized path for arrays without null values
-        let mut n: T::Native = T::default_value();
-        let data = array.data();
-        let m = array.value_slice(0, data.len());
-        for item in m {
+        for item in m.iter().take(data.len()) {
             n = n + *item;
         }
-        Some(n)
     } else {
-        let mut n: T::Native = T::default_value();
-        let data = array.data();
-        let m = array.value_slice(0, data.len());
-        let nulls = data.null_bitmap().as_ref().unwrap();
         for (i, item) in m.iter().enumerate() {
-            if nulls.is_set(i) {
+            if data.is_valid(i) {
                 n = n + *item;
             }
         }
-        Some(n)
     }
+    Some(n)
 }
 
 #[cfg(test)]

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -80,7 +80,7 @@ where
         let mut n: T::Native = T::default_value();
         let data = array.data();
         let m = array.value_slice(0, data.len());
-        for item in m.iter().take(data.len()) {
+        for item in m {
             n = n + *item;
         }
         Some(n)

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -102,8 +102,9 @@ where
         let mut n: T::Native = T::default_value();
         let data = array.data();
         let m = array.value_slice(0, data.len());
+        let nulls = data.null_bitmap().as_ref().unwrap();
         for (i, item) in m.iter().enumerate() {
-            if data.is_valid(i) {
+            if nulls.is_set(i) {
                 n = n + *item;
             }
         }


### PR DESCRIPTION
This PR speeds up some of the aggregations in arrow by 10-60% by simplifying their logic and overall allowing the optimizer to do its work.

The first 3 commits (up to 29754d7) simply improve the benchmark itself by:
* not taking the creation of the arrays into account, only the computation, 
* moving it to another file
* adding randomness to the data to reduce spurious results due to speculative execution and others
* add case for data with nulls, since the kernels branch out on that condition

The last 3 commits are the optimizations themselves.

```
sum 512                 time:   [535.66 ns 536.11 ns 536.57 ns]                     
                        change: [-58.421% -58.222% -57.957%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

min 512                 time:   [766.77 ns 775.85 ns 788.35 ns]                     
                        change: [-41.555% -41.017% -40.388%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

sum nulls 512           time:   [1.0968 us 1.1000 us 1.1038 us]                           
                        change: [-8.9918% -7.6232% -5.7130%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  3 (3.00%) high mild
  12 (12.00%) high severe

min nulls 512           time:   [1.3208 us 1.3242 us 1.3286 us]                           
                        change: [-11.028% -10.240% -9.4581%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
```

Command:
```
git checkout 29754d7 && cargo bench --bench aggregate_kernels && git checkout agg_arrow && cargo bench --bench aggregate_kernels
```
