### PR TITLE
ARROW-9979: [Rust] Fix arrow crate clippy lints

### DIFF
--- a/rust/arrow/benches/buffer_bit_ops.rs
+++ b/rust/arrow/benches/buffer_bit_ops.rs
@@ -97,7 +97,7 @@ where
 
     result_chunks
         .into_remainder()
-        .into_iter()
+        .iter_mut()
         .zip(
             left_chunks
                 .remainder()

--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -30,7 +30,7 @@ use arrow::compute::cast;
 use arrow::datatypes::*;
 
 // cast array from specified primitive array type to desired data type
-fn cast_array<FROM>(size: usize, to_type: DataType) -> ()
+fn cast_array<FROM>(size: usize, to_type: DataType)
 where
     FROM: ArrowNumericType,
     Standard: Distribution<FROM::Native>,
@@ -44,7 +44,7 @@ where
 }
 
 // cast timestamp array from specified primitive array type to desired data type
-fn cast_timestamp_array<FROM>(size: usize, to_type: DataType) -> ()
+fn cast_timestamp_array<FROM>(size: usize, to_type: DataType)
 where
     FROM: ArrowTimestampType,
     Standard: Distribution<i64>,

--- a/rust/arrow/benches/csv_writer.rs
+++ b/rust/arrow/benches/csv_writer.rs
@@ -65,7 +65,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench(
         "record_batches_to_csv",
         Benchmark::new("record_batches_to_csv", move |b| {
-            b.iter(|| record_batches_to_csv())
+            b.iter(record_batches_to_csv)
         }),
     );
 }

--- a/rust/arrow/benches/length_kernel.rs
+++ b/rust/arrow/benches/length_kernel.rs
@@ -42,7 +42,7 @@ fn bench_length() {
 }
 
 fn add_benchmark(c: &mut Criterion) {
-    c.bench_function("length", |b| b.iter(|| bench_length()));
+    c.bench_function("length", |b| b.iter(bench_length));
 }
 
 criterion_group!(benches, add_benchmark);

--- a/rust/arrow/benches/take_kernels.rs
+++ b/rust/arrow/benches/take_kernels.rs
@@ -51,7 +51,7 @@ fn create_random_index(size: usize) -> UInt32Array {
     )
 }
 
-fn take_numeric<T>(size: usize, index_len: usize) -> ()
+fn take_numeric<T>(size: usize, index_len: usize)
 where
     T: ArrowNumericType,
     Standard: Distribution<T::Native>,
@@ -63,7 +63,7 @@ where
     criterion::black_box(take(&array, &index, None).unwrap());
 }
 
-fn take_boolean(size: usize, index_len: usize) -> () {
+fn take_boolean(size: usize, index_len: usize) {
     let array = Arc::new(BooleanArray::from(vec![random::<bool>(); size])) as ArrayRef;
     let index = create_random_index(index_len);
     criterion::black_box(take(&array, &index, None).unwrap());

--- a/rust/arrow/examples/builders.rs
+++ b/rust/arrow/examples/builders.rs
@@ -100,10 +100,10 @@ fn main() {
 
     // Construct a list array from the above two
     let list_data_type = DataType::List(Box::new(DataType::Int32));
-    let list_data = ArrayData::builder(list_data_type.clone())
+    let list_data = ArrayData::builder(list_data_type)
         .len(3)
-        .add_buffer(value_offsets.clone())
-        .add_child_data(value_data.clone())
+        .add_buffer(value_offsets)
+        .add_child_data(value_data)
         .build();
     let list_array = ListArray::from(list_data);
 

--- a/rust/arrow/examples/read_csv.rs
+++ b/rust/arrow/examples/read_csv.rs
@@ -36,10 +36,10 @@ fn main() -> Result<()> {
     let file = File::open("test/data/uk_cities.csv").unwrap();
 
     let mut csv = csv::Reader::new(file, Arc::new(schema), false, None, 1024, None);
-    let batch = csv.next().unwrap().unwrap();
+    let _batch = csv.next().unwrap().unwrap();
     #[cfg(feature = "prettyprint")]
     {
-        print_batches(&[batch]).unwrap();
+        print_batches(&[_batch]).unwrap();
     }
     Ok(())
 }

--- a/rust/arrow/examples/read_csv.rs
+++ b/rust/arrow/examples/read_csv.rs
@@ -36,10 +36,10 @@ fn main() -> Result<()> {
     let file = File::open("test/data/uk_cities.csv").unwrap();
 
     let mut csv = csv::Reader::new(file, Arc::new(schema), false, None, 1024, None);
-    let _batch = csv.next().unwrap().unwrap();
+    let batch = csv.next().unwrap().unwrap();
     #[cfg(feature = "prettyprint")]
     {
-        print_batches(&vec![_batch]).unwrap();
+        print_batches(&[batch]).unwrap();
     }
     Ok(())
 }

--- a/rust/arrow/examples/read_csv_infer_schema.rs
+++ b/rust/arrow/examples/read_csv_infer_schema.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
     let _batch = csv.next().unwrap().unwrap();
     #[cfg(feature = "prettyprint")]
     {
-        print_batches(&vec![_batch]).unwrap();
+        print_batches(&[_batch]).unwrap();
     }
     Ok(())
 }

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -3212,9 +3212,9 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type = DataType::FixedSizeList(Box::new(DataType::Int32), 3);
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(3)
-            .add_child_data(value_data.clone())
+            .add_child_data(value_data)
             .build();
         FixedSizeListArray::from(list_data);
     }
@@ -3243,9 +3243,9 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type = DataType::List(Box::new(DataType::Int32));
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(9)
-            .add_buffer(value_offsets.clone())
+            .add_buffer(value_offsets)
             .add_child_data(value_data.clone())
             .null_bit_buffer(Buffer::from(null_bits))
             .build();
@@ -3307,9 +3307,9 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type = DataType::LargeList(Box::new(DataType::Int32));
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(9)
-            .add_buffer(value_offsets.clone())
+            .add_buffer(value_offsets)
             .add_child_data(value_data.clone())
             .null_bit_buffer(Buffer::from(null_bits))
             .build();
@@ -3369,7 +3369,7 @@ mod tests {
 
         // Construct a fixed size list array from the above two
         let list_data_type = DataType::FixedSizeList(Box::new(DataType::Int32), 2);
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(5)
             .add_child_data(value_data.clone())
             .null_bit_buffer(Buffer::from(null_bits))
@@ -3449,10 +3449,10 @@ mod tests {
         let value_offsets = Buffer::from(&[2, 2, 5, 7].to_byte_slice());
 
         let list_data_type = DataType::List(Box::new(DataType::Int32));
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(3)
-            .add_buffer(value_offsets.clone())
-            .add_child_data(value_data.clone())
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
             .build();
         ListArray::from(list_data);
     }
@@ -4077,9 +4077,9 @@ mod tests {
             .build();
 
         let list_data_type = DataType::List(Box::new(DataType::Int32));
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .add_buffer(buf2)
-            .add_child_data(value_data.clone())
+            .add_child_data(value_data)
             .build();
         ListArray::from(list_data);
     }

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -2531,8 +2531,8 @@ mod tests {
     #[test]
     fn test_append_slice() {
         let mut b = UInt8BufferBuilder::new(0);
-        b.append_slice("Hello, ".as_bytes()).unwrap();
-        b.append_slice("World!".as_bytes()).unwrap();
+        b.append_slice(b"Hello, ").unwrap();
+        b.append_slice(b"World!").unwrap();
         let buffer = b.finish();
         assert_eq!(13, buffer.len());
 
@@ -3099,9 +3099,7 @@ mod tests {
         builder.append_byte(b'd').unwrap();
         builder.append(true).unwrap();
 
-        let array = builder.finish();
-
-        let binary_array = BinaryArray::from(array);
+        let binary_array = builder.finish();
 
         assert_eq!(3, binary_array.len());
         assert_eq!(0, binary_array.null_count());
@@ -3130,9 +3128,7 @@ mod tests {
         builder.append_byte(b'd').unwrap();
         builder.append(true).unwrap();
 
-        let array = builder.finish();
-
-        let binary_array = LargeBinaryArray::from(array);
+        let binary_array = builder.finish();
 
         assert_eq!(3, binary_array.len());
         assert_eq!(0, binary_array.null_count());
@@ -3151,9 +3147,7 @@ mod tests {
         builder.append(true).unwrap();
         builder.append_value("world").unwrap();
 
-        let array = builder.finish();
-
-        let string_array = StringArray::from(array);
+        let string_array = builder.finish();
 
         assert_eq!(3, string_array.len());
         assert_eq!(0, string_array.null_count());
@@ -3210,9 +3204,7 @@ mod tests {
         builder.append(true).unwrap();
         builder.append_value("world").unwrap();
 
-        let array = builder.finish();
-
-        let string_array = StringArray::from(array);
+        let string_array = builder.finish();
 
         assert_eq!(3, string_array.len());
         assert_eq!(0, string_array.null_count());
@@ -3274,7 +3266,7 @@ mod tests {
             .null_count(2)
             .null_bit_buffer(Buffer::from(&[9_u8]))
             .add_buffer(Buffer::from(&[0, 3, 3, 3, 7].to_byte_slice()))
-            .add_buffer(Buffer::from("joemark".as_bytes()))
+            .add_buffer(Buffer::from(b"joemark"))
             .build();
 
         let expected_int_data = ArrayData::builder(DataType::Int32)

--- a/rust/arrow/src/array/union.rs
+++ b/rust/arrow/src/array/union.rs
@@ -657,7 +657,7 @@ mod tests {
         // Check type ids
         assert_eq!(
             union.data().buffers()[0],
-            Buffer::from(&expected_type_ids.clone().to_byte_slice())
+            Buffer::from(&expected_type_ids.to_byte_slice())
         );
         for (i, id) in expected_type_ids.iter().enumerate() {
             assert_eq!(id, &union.type_id(i));
@@ -666,7 +666,7 @@ mod tests {
         // Check offsets
         assert_eq!(
             union.data().buffers()[1],
-            Buffer::from(expected_value_offsets.clone().to_byte_slice())
+            Buffer::from(expected_value_offsets.to_byte_slice())
         );
         for (i, id) in expected_value_offsets.iter().enumerate() {
             assert_eq!(&union.value_offset(i), id);
@@ -951,7 +951,7 @@ mod tests {
             .downcast_ref::<Float64Array>()
             .unwrap()
             .value(0);
-        assert_eq!(10.0, value);
+        assert!(10.0 - value < f64::EPSILON);
 
         let slot = array.value(4);
         let value = slot
@@ -983,7 +983,7 @@ mod tests {
 
         // Check type ids
         assert_eq!(
-            Buffer::from(&expected_type_ids.clone().to_byte_slice()),
+            Buffer::from(&expected_type_ids.to_byte_slice()),
             union.data().buffers()[0]
         );
         for (i, id) in expected_type_ids.iter().enumerate() {
@@ -1034,7 +1034,7 @@ mod tests {
 
         // Check type ids
         assert_eq!(
-            Buffer::from(&expected_type_ids.clone().to_byte_slice()),
+            Buffer::from(&expected_type_ids.to_byte_slice()),
             union.data().buffers()[0]
         );
         for (i, id) in expected_type_ids.iter().enumerate() {
@@ -1064,7 +1064,7 @@ mod tests {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
-                    assert_eq!(value, 3_f64);
+                    assert!(value - 3_f64 < f64::EPSILON);
                 }
                 3 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -1076,7 +1076,7 @@ mod tests {
                     let slot = slot.as_any().downcast_ref::<Float64Array>().unwrap();
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
-                    assert_eq!(5_f64, value);
+                    assert!(5_f64 - value < f64::EPSILON);
                 }
                 5 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -1109,7 +1109,7 @@ mod tests {
 
         // Check type ids
         assert_eq!(
-            Buffer::from(&expected_type_ids.clone().to_byte_slice()),
+            Buffer::from(&expected_type_ids.to_byte_slice()),
             union.data().buffers()[0]
         );
         for (i, id) in expected_type_ids.iter().enumerate() {
@@ -1142,7 +1142,7 @@ mod tests {
                     assert_eq!(false, union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
-                    assert_eq!(value, 3_f64);
+                    assert!(value - 3_f64 < f64::EPSILON);
                 }
                 4 => {
                     let slot = slot.as_any().downcast_ref::<Int32Array>().unwrap();
@@ -1187,7 +1187,7 @@ mod tests {
                     assert_eq!(false, new_union.is_null(i));
                     assert_eq!(slot.len(), 1);
                     let value = slot.value(0);
-                    assert_eq!(value, 3_f64);
+                    assert!(value - 3_f64 < f64::EPSILON);
                 }
                 3 => assert!(new_union.is_null(i)),
                 4 => {

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -111,7 +111,7 @@ mod tests {
     #[test]
     fn test_primitive_array_float_sum() {
         let a = Float64Array::from(vec![1.1, 2.2, 3.3, 4.4, 5.5]);
-        assert_eq!(16.5, sum(&a).unwrap());
+        assert!(16.5 - sum(&a).unwrap() < f64::EPSILON);
     }
 
     #[test]

--- a/rust/arrow/src/compute/kernels/arithmetic.rs
+++ b/rust/arrow/src/compute/kernels/arithmetic.rs
@@ -487,9 +487,9 @@ mod tests {
         let a = Float64Array::from(vec![15.0, 15.0, 8.0]);
         let b = Float64Array::from(vec![5.0, 6.0, 8.0]);
         let c = divide(&a, &b).unwrap();
-        assert_eq!(3.0, c.value(0));
-        assert_eq!(2.5, c.value(1));
-        assert_eq!(1.0, c.value(2));
+        assert!(3.0 - c.value(0) < f64::EPSILON);
+        assert!(2.5 - c.value(1) < f64::EPSILON);
+        assert!(1.0 - c.value(2) < f64::EPSILON);
     }
 
     #[test]

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -766,11 +766,11 @@ mod tests {
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Float64).unwrap();
         let c = b.as_any().downcast_ref::<Float64Array>().unwrap();
-        assert_eq!(5.0, c.value(0));
-        assert_eq!(6.0, c.value(1));
-        assert_eq!(7.0, c.value(2));
-        assert_eq!(8.0, c.value(3));
-        assert_eq!(9.0, c.value(4));
+        assert!(5.0 - c.value(0) < f64::EPSILON);
+        assert!(6.0 - c.value(1) < f64::EPSILON);
+        assert!(7.0 - c.value(2) < f64::EPSILON);
+        assert!(8.0 - c.value(3) < f64::EPSILON);
+        assert!(9.0 - c.value(4) < f64::EPSILON);
     }
 
     #[test]
@@ -891,10 +891,10 @@ mod tests {
         let values = arr.values();
         let c = values.as_any().downcast_ref::<Float64Array>().unwrap();
         assert_eq!(1, c.null_count());
-        assert_eq!(7.0, c.value(0));
-        assert_eq!(8.0, c.value(1));
+        assert!(7.0 - c.value(0) < f64::EPSILON);
+        assert!(8.0 - c.value(1) < f64::EPSILON);
         assert_eq!(false, c.is_valid(2));
-        assert_eq!(10.0, c.value(3));
+        assert!(10.0 - c.value(3) < f64::EPSILON);
     }
 
     #[test]
@@ -927,8 +927,8 @@ mod tests {
         let array = Arc::new(a) as ArrayRef;
         let b = cast(&array, &DataType::Float64).unwrap();
         let c = b.as_any().downcast_ref::<Float64Array>().unwrap();
-        assert_eq!(1.0, c.value(0));
-        assert_eq!(0.0, c.value(1));
+        assert!(1.0 - c.value(0) < f64::EPSILON);
+        assert!(0.0 - c.value(1) < f64::EPSILON);
         assert_eq!(false, c.is_valid(2));
     }
 
@@ -951,10 +951,10 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type = DataType::List(Box::new(DataType::Int32));
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(3)
-            .add_buffer(value_offsets.clone())
-            .add_child_data(value_data.clone())
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
             .build();
         let list_array = Arc::new(ListArray::from(list_data)) as ArrayRef;
 
@@ -1006,10 +1006,10 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type = DataType::List(Box::new(DataType::Int32));
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(3)
-            .add_buffer(value_offsets.clone())
-            .add_child_data(value_data.clone())
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
             .build();
         let list_array = Arc::new(ListArray::from(list_data)) as ArrayRef;
 
@@ -1131,7 +1131,7 @@ mod tests {
             std::u32::MAX as f64,
             std::u64::MAX as f64,
         ];
-        let f64_array: ArrayRef = Arc::new(Float64Array::from(f64_values.clone()));
+        let f64_array: ArrayRef = Arc::new(Float64Array::from(f64_values));
 
         let f64_expected = vec![
             "-9223372036854776000.0",
@@ -1275,7 +1275,7 @@ mod tests {
             std::u32::MAX as f32,
             std::u32::MAX as f32,
         ];
-        let f32_array: ArrayRef = Arc::new(Float32Array::from(f32_values.clone()));
+        let f32_array: ArrayRef = Arc::new(Float32Array::from(f32_values));
 
         let f64_expected = vec![
             "-2147483648.0",
@@ -1407,7 +1407,7 @@ mod tests {
             std::u32::MAX as u64,
             std::u64::MAX,
         ];
-        let u64_array: ArrayRef = Arc::new(UInt64Array::from(u64_values.clone()));
+        let u64_array: ArrayRef = Arc::new(UInt64Array::from(u64_values));
 
         let f64_expected = vec![
             "0.0",
@@ -1491,7 +1491,7 @@ mod tests {
             std::u16::MAX as u32,
             std::u32::MAX as u32,
         ];
-        let u32_array: ArrayRef = Arc::new(UInt32Array::from(u32_values.clone()));
+        let u32_array: ArrayRef = Arc::new(UInt32Array::from(u32_values));
 
         let f64_expected = vec!["0.0", "255.0", "65535.0", "4294967295.0"];
         assert_eq!(
@@ -1557,7 +1557,7 @@ mod tests {
     #[test]
     fn test_cast_from_uint16() {
         let u16_values: Vec<u16> = vec![0, std::u8::MAX as u16, std::u16::MAX as u16];
-        let u16_array: ArrayRef = Arc::new(UInt16Array::from(u16_values.clone()));
+        let u16_array: ArrayRef = Arc::new(UInt16Array::from(u16_values));
 
         let f64_expected = vec!["0.0", "255.0", "65535.0"];
         assert_eq!(
@@ -1623,7 +1623,7 @@ mod tests {
     #[test]
     fn test_cast_from_uint8() {
         let u8_values: Vec<u8> = vec![0, std::u8::MAX];
-        let u8_array: ArrayRef = Arc::new(UInt8Array::from(u8_values.clone()));
+        let u8_array: ArrayRef = Arc::new(UInt8Array::from(u8_values));
 
         let f64_expected = vec!["0.0", "255.0"];
         assert_eq!(
@@ -1699,7 +1699,7 @@ mod tests {
             std::i32::MAX as i64,
             std::i64::MAX,
         ];
-        let i64_array: ArrayRef = Arc::new(Int64Array::from(i64_values.clone()));
+        let i64_array: ArrayRef = Arc::new(Int64Array::from(i64_values));
 
         let f64_expected = vec![
             "-9223372036854776000.0",
@@ -1841,7 +1841,7 @@ mod tests {
             std::i16::MAX as i32,
             std::i32::MAX as i32,
         ];
-        let i32_array: ArrayRef = Arc::new(Int32Array::from(i32_values.clone()));
+        let i32_array: ArrayRef = Arc::new(Int32Array::from(i32_values));
 
         let f64_expected = vec![
             "-2147483648.0",
@@ -1919,7 +1919,7 @@ mod tests {
             std::i8::MAX as i16,
             std::i16::MAX,
         ];
-        let i16_array: ArrayRef = Arc::new(Int16Array::from(i16_values.clone()));
+        let i16_array: ArrayRef = Arc::new(Int16Array::from(i16_values));
 
         let f64_expected = vec!["-32768.0", "-128.0", "0.0", "127.0", "32767.0"];
         assert_eq!(
@@ -1985,7 +1985,7 @@ mod tests {
     #[test]
     fn test_cast_from_int8() {
         let i8_values: Vec<i8> = vec![std::i8::MIN, 0, std::i8::MAX];
-        let i8_array: ArrayRef = Arc::new(Int8Array::from(i8_values.clone()));
+        let i8_array: ArrayRef = Arc::new(Int8Array::from(i8_values));
 
         let f64_expected = vec!["-128.0", "0.0", "127.0"];
         assert_eq!(

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -138,14 +138,14 @@ mod tests {
 
     #[test]
     fn test_concat_empty_vec() -> Result<()> {
-        let re = concat(&vec![]);
+        let re = concat(&[]);
         assert!(re.is_err());
         Ok(())
     }
 
     #[test]
     fn test_concat_incompatible_datatypes() -> Result<()> {
-        let re = concat(&vec![
+        let re = concat(&[
             Arc::new(PrimitiveArray::<Int64Type>::from(vec![
                 Some(-1),
                 Some(2),
@@ -163,7 +163,7 @@ mod tests {
 
     #[test]
     fn test_concat_string_arrays() -> Result<()> {
-        let arr = concat(&vec![
+        let arr = concat(&[
             Arc::new(StringArray::from(vec![Some("hello"), Some("world")])) as ArrayRef,
             Arc::new(StringArray::from(vec!["1", "2", "3", "4", "6"])).slice(1, 3),
             Arc::new(StringArray::from(vec![
@@ -198,7 +198,7 @@ mod tests {
 
     #[test]
     fn test_concat_primitive_arrays() -> Result<()> {
-        let arr = concat(&vec![
+        let arr = concat(&[
             Arc::new(PrimitiveArray::<Int64Type>::from(vec![
                 Some(-1),
                 Some(-1),
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn test_concat_boolean_primitive_arrays() -> Result<()> {
-        let arr = concat(&vec![
+        let arr = concat(&[
             Arc::new(PrimitiveArray::<BooleanType>::from(vec![
                 Some(true),
                 Some(true),

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -597,9 +597,8 @@ mod tests {
     #[test]
     fn test_filter_array_low_density() {
         // this test exercises the all 0's branch of the filter algorithm
-        let mut data_values = (1..=65).into_iter().collect::<Vec<i32>>();
+        let mut data_values = (1..=65).collect::<Vec<i32>>();
         let mut filter_values = (1..=65)
-            .into_iter()
             .map(|i| match i % 65 {
                 0 => true,
                 _ => false,
@@ -620,9 +619,8 @@ mod tests {
     #[test]
     fn test_filter_array_high_density() {
         // this test exercises the all 1's branch of the filter algorithm
-        let mut data_values = (1..=65).into_iter().map(|x| Some(x)).collect::<Vec<_>>();
+        let mut data_values = (1..=65).map(Some).collect::<Vec<_>>();
         let mut filter_values = (1..=65)
-            .into_iter()
             .map(|i| match i % 65 {
                 0 => false,
                 _ => true,
@@ -687,7 +685,7 @@ mod tests {
     #[test]
     fn test_filter_dictionary_array() {
         let values = vec![Some("hello"), None, Some("world"), Some("!")];
-        let a: Int8DictionaryArray = values.iter().map(|&x| x).collect();
+        let a: Int8DictionaryArray = values.iter().copied().collect();
         let b = BooleanArray::from(vec![false, true, true, false]);
         let c = filter(&a, &b).unwrap();
         let d = c

--- a/rust/arrow/src/compute/kernels/limit.rs
+++ b/rust/arrow/src/compute/kernels/limit.rs
@@ -111,10 +111,10 @@ mod tests {
 
         // Construct a list array from the above two
         let list_data_type = DataType::List(Box::new(DataType::Int32));
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(9)
-            .add_buffer(value_offsets.clone())
-            .add_child_data(value_data.clone())
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
             .null_bit_buffer(Buffer::from(null_bits))
             .build();
         let list_array: ArrayRef = Arc::new(ListArray::from(list_data));

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -280,7 +280,7 @@ where
 mod tests {
     use super::*;
 
-    fn test_take_primitive_arrays<'a, T>(
+    fn test_take_primitive_arrays<T>(
         data: Vec<Option<T::Native>>,
         index: &UInt32Array,
         options: Option<TakeOptions>,
@@ -482,7 +482,7 @@ mod tests {
         // construct offsets
         let expected_offsets = Buffer::from(&[0, 2, 2, 5, 7, 10].to_byte_slice());
         // construct list array from the two
-        let expected_list_data = ArrayData::builder(list_data_type.clone())
+        let expected_list_data = ArrayData::builder(list_data_type)
             .len(5)
             .null_count(1)
             // null buffer remains the same as only the indices have nulls
@@ -546,7 +546,7 @@ mod tests {
         // construct offsets
         let expected_offsets = Buffer::from(&[0, 1, 1, 4, 6, 9].to_byte_slice());
         // construct list array from the two
-        let expected_list_data = ArrayData::builder(list_data_type.clone())
+        let expected_list_data = ArrayData::builder(list_data_type)
             .len(5)
             .null_count(1)
             // null buffer remains the same as only the indices have nulls
@@ -612,7 +612,7 @@ mod tests {
         bit_util::set_bit(&mut null_bits, 2);
         bit_util::set_bit(&mut null_bits, 3);
         bit_util::set_bit(&mut null_bits, 4);
-        let expected_list_data = ArrayData::builder(list_data_type.clone())
+        let expected_list_data = ArrayData::builder(list_data_type)
             .len(5)
             .null_count(2)
             // null buffer must be recalculated as both values and indices have nulls

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -231,10 +231,10 @@ mod tests {
         let value_data = Int32Array::from((0..10).collect::<Vec<i32>>()).data();
         let value_offsets = Buffer::from(&[0, 2, 5, 10].to_byte_slice());
         let list_data_type = DataType::List(Box::new(DataType::Int32));
-        let list_data = ArrayData::builder(list_data_type.clone())
+        let list_data = ArrayData::builder(list_data_type)
             .len(3)
-            .add_buffer(value_offsets.clone())
-            .add_child_data(value_data.clone())
+            .add_buffer(value_offsets)
+            .add_child_data(value_data)
             .build();
         let array = Arc::new(ListArray::from(list_data)) as ArrayRef;
         let index = UInt32Array::from(vec![2, 0]);

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -621,7 +621,7 @@ mod tests {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert_eq!(57.653484, lat.value(0));
+        assert!(57.653484 - lat.value(0) < f64::EPSILON);
 
         // access data from a string array (ListArray<u8>)
         let city = batch
@@ -683,7 +683,7 @@ mod tests {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert_eq!(57.653484, lat.value(0));
+        assert!(57.653484 - lat.value(0) < f64::EPSILON);
 
         // access data from a string array (ListArray<u8>)
         let city = batch
@@ -721,7 +721,7 @@ mod tests {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert_eq!(57.653484, lat.value(0));
+        assert!(57.653484 - lat.value(0) < f64::EPSILON);
 
         // access data from a string array (ListArray<u8>)
         let city = batch
@@ -749,7 +749,7 @@ mod tests {
             Field::new("city", DataType::Utf8, false),
             Field::new("lat", DataType::Float64, false),
         ]));
-        assert_eq!(projected_schema.clone(), csv.schema());
+        assert_eq!(projected_schema, csv.schema());
         let batch = csv.next().unwrap().unwrap();
         assert_eq!(projected_schema, batch.schema());
         assert_eq!(37, batch.num_rows());
@@ -867,7 +867,7 @@ mod tests {
         writeln!(csv4, "10,\"foo\",")?;
 
         let schema = infer_schema_from_files(
-            &vec![
+            &[
                 csv3.path().to_str().unwrap().to_string(),
                 csv1.path().to_str().unwrap().to_string(),
                 csv2.path().to_str().unwrap().to_string(),

--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -1621,7 +1621,6 @@ pub type SchemaRef = Arc<Schema>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json;
     use serde_json::Number;
     use serde_json::Value::{Bool, Number as VNumber};
     use std::f32::NAN;
@@ -2461,7 +2460,7 @@ mod tests {
 
     #[test]
     fn test_schema_merge() -> Result<()> {
-        let merged = Schema::try_merge(&vec![
+        let merged = Schema::try_merge(&[
             Schema::new(vec![
                 Field::new("first_name", DataType::Utf8, false),
                 Field::new("last_name", DataType::Utf8, false),
@@ -2520,7 +2519,7 @@ mod tests {
 
         // support merge union fields
         assert_eq!(
-            Schema::try_merge(&vec![
+            Schema::try_merge(&[
                 Schema::new(vec![Field::new(
                     "c1",
                     DataType::Union(vec![
@@ -2550,17 +2549,17 @@ mod tests {
         );
 
         // incompatible field should throw error
-        assert!(Schema::try_merge(&vec![
+        assert!(Schema::try_merge(&[
             Schema::new(vec![
                 Field::new("first_name", DataType::Utf8, false),
                 Field::new("last_name", DataType::Utf8, false),
             ]),
-            Schema::new(vec![Field::new("last_name", DataType::Int64, false),]),
+            Schema::new(vec![Field::new("last_name", DataType::Int64, false),])
         ])
         .is_err());
 
         // incompatible metadata should throw error
-        assert!(Schema::try_merge(&vec![
+        assert!(Schema::try_merge(&[
             Schema::new_with_metadata(
                 vec![Field::new("first_name", DataType::Utf8, false)],
                 [("foo".to_string(), "bar".to_string()),]
@@ -2574,7 +2573,7 @@ mod tests {
                     .iter()
                     .cloned()
                     .collect::<HashMap<String, String>>()
-            ),
+            )
         ])
         .is_err());
 

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -165,7 +165,7 @@ pub fn fb_to_schema(fb: ipc::Schema) -> Schema {
 /// Deserialize an IPC message into a schema
 pub fn schema_from_bytes(bytes: &[u8]) -> Option<Schema> {
     let ipc = ipc::get_root_as_message(bytes);
-    ipc.header_as_schema().map(|schema| fb_to_schema(schema))
+    ipc.header_as_schema().map(fb_to_schema)
 }
 
 /// Get the Arrow data type from the flatbuffer Field table

--- a/rust/arrow/src/ipc/gen/mod.rs
+++ b/rust/arrow/src/ipc/gen/mod.rs
@@ -19,8 +19,13 @@
 
 #![allow(non_snake_case)]
 
+#[allow(clippy::all)]
 pub mod File;
+#[allow(clippy::all)]
 pub mod Message;
+#[allow(clippy::all)]
 pub mod Schema;
+#[allow(clippy::all)]
 pub mod SparseTensor;
+#[allow(clippy::all)]
 pub mod Tensor;

--- a/rust/arrow/src/ipc/mod.rs
+++ b/rust/arrow/src/ipc/mod.rs
@@ -22,6 +22,11 @@ pub mod convert;
 pub mod reader;
 pub mod writer;
 
+#[allow(clippy::redundant_closure)]
+#[allow(clippy::needless_lifetimes)]
+#[allow(clippy::extra_unused_lifetimes)]
+#[allow(clippy::redundant_static_lifetimes)]
+#[allow(clippy::redundant_field_names)]
 pub mod gen;
 
 pub use self::gen::File::*;

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -442,7 +442,7 @@ pub fn read_record_batch(
         arrays.push(triple.0);
     }
 
-    RecordBatch::try_new(schema, arrays).map(|batch| Some(batch))
+    RecordBatch::try_new(schema, arrays).map(Some)
 }
 
 // Linear search for the first dictionary field with a dictionary id.

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -401,7 +401,7 @@ fn write_buffer(
 }
 
 /// Calculate an 8-byte boundary and return the number of bytes needed to pad to 8 bytes
-fn pad_to_8<'a>(len: u32) -> usize {
+fn pad_to_8(len: u32) -> usize {
     match len % 8 {
         0 => 0 as usize,
         v => 8 - v as usize,

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -908,8 +908,8 @@ mod tests {
             .as_any()
             .downcast_ref::<Float64Array>()
             .unwrap();
-        assert_eq!(2.0, bb.value(0));
-        assert_eq!(-3.5, bb.value(1));
+        assert!(2.0 - bb.value(0) < f64::EPSILON);
+        assert!(-3.5 - bb.value(1) < f64::EPSILON);
         let cc = batch
             .column(c.0)
             .as_any()
@@ -1031,8 +1031,8 @@ mod tests {
             .as_any()
             .downcast_ref::<Float32Array>()
             .unwrap();
-        assert_eq!(2.0, bb.value(0));
-        assert_eq!(-3.5, bb.value(1));
+        assert!(2.0 - bb.value(0) < f32::EPSILON);
+        assert!(-3.5 - bb.value(1) < f32::EPSILON);
     }
 
     #[test]
@@ -1057,7 +1057,7 @@ mod tests {
             Field::new("a", DataType::Int32, false),
             Field::new("c", DataType::Boolean, false),
         ]));
-        assert_eq!(reader_schema.clone(), expected_schema);
+        assert_eq!(reader_schema, expected_schema);
 
         let batch = reader.next().unwrap().unwrap();
 
@@ -1119,8 +1119,8 @@ mod tests {
         let bb = bb.values();
         let bb = bb.as_any().downcast_ref::<Float64Array>().unwrap();
         assert_eq!(9, bb.len());
-        assert_eq!(2.0, bb.value(0));
-        assert_eq!(-6.1, bb.value(5));
+        assert!(2.0 - bb.value(0) < f64::EPSILON);
+        assert!(-6.1 - bb.value(5) < f64::EPSILON);
         assert_eq!(false, bb.is_valid(7));
 
         let cc = batch
@@ -1215,7 +1215,7 @@ mod tests {
             let bb = bb.values();
             let bb = bb.as_any().downcast_ref::<Float64Array>().unwrap();
             assert_eq!(10, bb.len());
-            assert_eq!(4.0, bb.value(9));
+            assert!(4.0 - bb.value(9) < f64::EPSILON);
 
             let cc = batch
                 .column(c.0)

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -26,6 +26,7 @@
 #![allow(non_camel_case_types)]
 #![allow(bare_trait_objects)]
 #![warn(missing_debug_implementations)]
+#![deny(clippy::redundant_clone)]
 
 pub mod array;
 pub mod bitmap;
@@ -34,11 +35,6 @@ pub mod compute;
 pub mod csv;
 pub mod datatypes;
 pub mod error;
-#[allow(clippy::redundant_closure)]
-#[allow(clippy::needless_lifetimes)]
-#[allow(clippy::extra_unused_lifetimes)]
-#[allow(clippy::redundant_static_lifetimes)]
-#[allow(clippy::redundant_field_names)]
 pub mod ipc;
 pub mod json;
 pub mod memory;

--- a/rust/arrow/src/tensor.rs
+++ b/rust/arrow/src/tensor.rs
@@ -227,15 +227,15 @@ mod tests {
     fn test_compute_row_major_strides() {
         assert_eq!(
             vec![48, 8],
-            compute_row_major_strides::<Int64Type>(&vec![4_usize, 6])
+            compute_row_major_strides::<Int64Type>(&[4_usize, 6])
         );
         assert_eq!(
             vec![24, 4],
-            compute_row_major_strides::<Int32Type>(&vec![4_usize, 6])
+            compute_row_major_strides::<Int32Type>(&[4_usize, 6])
         );
         assert_eq!(
             vec![6, 1],
-            compute_row_major_strides::<Int8Type>(&vec![4_usize, 6])
+            compute_row_major_strides::<Int8Type>(&[4_usize, 6])
         );
     }
 
@@ -243,15 +243,15 @@ mod tests {
     fn test_compute_column_major_strides() {
         assert_eq!(
             vec![8, 32],
-            compute_column_major_strides::<Int64Type>(&vec![4_usize, 6])
+            compute_column_major_strides::<Int64Type>(&[4_usize, 6])
         );
         assert_eq!(
             vec![4, 16],
-            compute_column_major_strides::<Int32Type>(&vec![4_usize, 6])
+            compute_column_major_strides::<Int32Type>(&[4_usize, 6])
         );
         assert_eq!(
             vec![1, 4],
-            compute_column_major_strides::<Int8Type>(&vec![4_usize, 6])
+            compute_column_major_strides::<Int8Type>(&[4_usize, 6])
         );
     }
 

--- a/rust/arrow/src/util/pretty.rs
+++ b/rust/arrow/src/util/pretty.rs
@@ -148,14 +148,14 @@ mod tests {
 
         // define data.
         let batch = RecordBatch::try_new(
-            schema.clone(),
+            schema,
             vec![
                 Arc::new(array::StringArray::from(vec!["a", "b", "c", "d"])),
                 Arc::new(array::Int32Array::from(vec![1, 10, 10, 100])),
             ],
         )?;
 
-        let table = pretty_format_batches(&vec![batch])?;
+        let table = pretty_format_batches(&[batch])?;
 
         let expected = vec![
             "+---+-----+",

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -85,14 +85,14 @@ pub fn create_partitioned_csv(filename: &str, partitions: usize) -> Result<Strin
         if i == 0 {
             // write header to all partitions
             for w in writers.iter_mut() {
-                w.write(line.as_bytes()).unwrap();
-                w.write(b"\n").unwrap();
+                w.write_all(line.as_bytes()).unwrap();
+                w.write_all(b"\n").unwrap();
             }
         } else {
             // write data line to single partition
             let partition = i % partitions;
-            writers[partition].write(line.as_bytes()).unwrap();
-            writers[partition].write(b"\n").unwrap();
+            writers[partition].write_all(line.as_bytes()).unwrap();
+            writers[partition].write_all(b"\n").unwrap();
         }
 
         i += 1;

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -500,7 +500,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
         }
     }
 
-    if let Some(_) = arrow_reader.next_batch()? {
+    if arrow_reader.next_batch()?.is_some() {
         return Err(ArrowError::ComputeError(
             "no more json batches left".to_owned(),
         ));


### PR DESCRIPTION
This fixes a lot of clippy errors and warnings. We currently have over 600 such, and they tend to cause a lot of noise while working.

This PR only includes changes to arrow, one change to datafusion and integration testing. I've left parquet out to potentially open a separare PR.

Thoughts @andygrove @alamb @jorgecarleitao @paddyhoran?