### PR TITLE
ARROW-9971: [Rust] Improve speed of `take` by 2x-3x (change scaling with batch size)

### DIFF
--- a/rust/arrow/benches/take_kernels.rs
+++ b/rust/arrow/benches/take_kernels.rs
@@ -18,7 +18,7 @@
 #[macro_use]
 extern crate criterion;
 use criterion::Criterion;
-use rand;
+
 use rand::distributions::{Alphanumeric, Distribution, Standard};
 use rand::prelude::random;
 use rand::Rng;

--- a/rust/arrow/benches/take_kernels.rs
+++ b/rust/arrow/benches/take_kernels.rs
@@ -18,7 +18,8 @@
 #[macro_use]
 extern crate criterion;
 use criterion::Criterion;
-use rand::distributions::{Distribution, Standard};
+use rand;
+use rand::distributions::{Alphanumeric, Distribution, Standard};
 use rand::prelude::random;
 use rand::Rng;
 
@@ -40,6 +41,21 @@ where
     Arc::new(PrimitiveArray::<T>::from(vec![random::<T::Native>(); size])) as ArrayRef
 }
 
+fn create_strings(size: usize) -> ArrayRef {
+    let v = (0..size)
+        .map(|_| {
+            rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(5)
+                .collect::<String>()
+        })
+        .collect::<Vec<_>>();
+
+    Arc::new(StringArray::from(
+        v.iter().map(|x| &**x).collect::<Vec<&str>>(),
+    ))
+}
+
 fn create_random_index(size: usize) -> UInt32Array {
     let mut rng = rand::thread_rng();
     let ints = Int32Array::from(vec![rng.gen_range(-24i32, size as i32); size]);
@@ -51,46 +67,41 @@ fn create_random_index(size: usize) -> UInt32Array {
     )
 }
 
-fn take_numeric<T>(size: usize, index_len: usize)
-where
-    T: ArrowNumericType,
-    Standard: Distribution<T::Native>,
-    PrimitiveArray<T>: std::convert::From<Vec<T::Native>>,
-    T::Native: num::NumCast,
-{
-    let array = create_numeric::<T>(size);
-    let index = create_random_index(index_len);
-    criterion::black_box(take(&array, &index, None).unwrap());
-}
-
-fn take_boolean(size: usize, index_len: usize) {
-    let array = Arc::new(BooleanArray::from(vec![random::<bool>(); size])) as ArrayRef;
-    let index = create_random_index(index_len);
-    criterion::black_box(take(&array, &index, None).unwrap());
+fn bench_take(values: &ArrayRef, indices: &UInt32Array) {
+    criterion::black_box(take(&values, &indices, None).unwrap());
 }
 
 fn add_benchmark(c: &mut Criterion) {
-    c.bench_function("take u8 256", |b| {
-        b.iter(|| take_numeric::<UInt8Type>(256, 256))
-    });
-    c.bench_function("take u8 512", |b| {
-        b.iter(|| take_numeric::<UInt8Type>(512, 512))
-    });
-    c.bench_function("take u8 1024", |b| {
-        b.iter(|| take_numeric::<UInt8Type>(1024, 1024))
-    });
-    c.bench_function("take i32 256", |b| {
-        b.iter(|| take_numeric::<Int32Type>(256, 256))
-    });
-    c.bench_function("take i32 512", |b| {
-        b.iter(|| take_numeric::<Int32Type>(512, 512))
-    });
+    let values = create_numeric::<Int32Type>(512);
+    let indices = create_random_index(512);
+    c.bench_function("take i32 512", |b| b.iter(|| bench_take(&values, &indices)));
+    let values = create_numeric::<Int32Type>(1024);
+    let indices = create_random_index(1024);
     c.bench_function("take i32 1024", |b| {
-        b.iter(|| take_numeric::<Int32Type>(1024, 1024))
+        b.iter(|| bench_take(&values, &indices))
     });
-    c.bench_function("take bool 256", |b| b.iter(|| take_boolean(256, 256)));
-    c.bench_function("take bool 512", |b| b.iter(|| take_boolean(512, 512)));
-    c.bench_function("take bool 1024", |b| b.iter(|| take_boolean(1024, 1024)));
+
+    let values = Arc::new(BooleanArray::from(vec![random::<bool>(); 512])) as ArrayRef;
+    let indices = create_random_index(512);
+    c.bench_function("take bool 512", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = Arc::new(BooleanArray::from(vec![random::<bool>(); 1024])) as ArrayRef;
+    let indices = create_random_index(1024);
+    c.bench_function("take bool 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_strings(512);
+    let indices = create_random_index(512);
+    c.bench_function("take str 512", |b| b.iter(|| bench_take(&values, &indices)));
+
+    let values = create_strings(1024);
+    let indices = create_random_index(1024);
+    c.bench_function("take str 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
 }
 
 criterion_group!(benches, add_benchmark);

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1515,9 +1515,14 @@ impl LargeBinaryArray {
     }
 }
 
-impl StringArray {
+/// Common operations on string arrays
+pub trait StringArrayOps {
     /// Returns the element at index `i` as a string slice.
-    pub fn value(&self, i: usize) -> &str {
+    fn value(&self, i: usize) -> &str;
+}
+
+impl StringArrayOps for StringArray {
+    fn value(&self, i: usize) -> &str {
         assert!(i < self.data.len(), "StringArray out of bounds access");
         let offset = i.checked_add(self.data.offset()).unwrap();
         unsafe {
@@ -1530,16 +1535,17 @@ impl StringArray {
             std::str::from_utf8_unchecked(slice)
         }
     }
+}
 
+impl StringArray {
     /// Returns a new string array builder
     pub fn builder(capacity: usize) -> StringBuilder {
         StringBuilder::new(capacity)
     }
 }
 
-impl LargeStringArray {
-    /// Returns the element at index `i` as a string slice.
-    pub fn value(&self, i: usize) -> &str {
+impl StringArrayOps for LargeStringArray {
+    fn value(&self, i: usize) -> &str {
         assert!(i < self.data.len(), "LargeStringArray out of bounds access");
         let offset = i.checked_add(self.data.offset()).unwrap();
         unsafe {
@@ -1552,7 +1558,9 @@ impl LargeStringArray {
             std::str::from_utf8_unchecked(slice)
         }
     }
+}
 
+impl LargeStringArray {
     // Returns a new large string array builder
     pub fn builder(capacity: usize) -> LargeStringBuilder {
         LargeStringBuilder::new(capacity)

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -158,6 +158,7 @@ pub type DurationNanosecondArray = PrimitiveArray<DurationNanosecondType>;
 pub use self::array::LargeListArrayOps;
 pub use self::array::ListArrayOps;
 pub use self::array::PrimitiveArrayOps;
+pub use self::array::StringArrayOps;
 
 // --------------------- Array Builder ---------------------
 

--- a/rust/arrow/src/util/pretty.rs
+++ b/rust/arrow/src/util/pretty.rs
@@ -18,6 +18,7 @@
 //! Utilities for printing record batches
 
 use crate::array;
+use crate::array::StringArrayOps;
 use crate::datatypes::{DataType, TimeUnit};
 use crate::record_batch::RecordBatch;
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -515,7 +515,7 @@ mod tests {
     use crate::physical_plan::functions::ScalarFunctionImplementation;
     use crate::test;
     use crate::variable::VarType;
-    use arrow::array::{ArrayRef, Int32Array, StringArray};
+    use arrow::array::{ArrayRef, Int32Array, StringArray, StringArrayOps};
     use arrow::compute::add;
     use std::fs::File;
     use std::{io::prelude::*, sync::Mutex};

--- a/rust/datafusion/src/physical_plan/common.rs
+++ b/rust/datafusion/src/physical_plan/common.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex};
 use crate::error::{ExecutionError, Result};
 
 use crate::logical_plan::ScalarValue;
-use arrow::array::{self, ArrayRef};
+use arrow::array::{self, ArrayRef, StringArrayOps};
 use arrow::datatypes::{DataType, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};

--- a/rust/datafusion/src/physical_plan/datetime_expressions.rs
+++ b/rust/datafusion/src/physical_plan/datetime_expressions.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 
 use crate::error::{ExecutionError, Result};
 use arrow::{
-    array::{Array, ArrayData, ArrayRef, StringArray, TimestampNanosecondArray},
+    array::{
+        Array, ArrayData, ArrayRef, StringArray, StringArrayOps, TimestampNanosecondArray,
+    },
     buffer::Buffer,
     datatypes::{DataType, TimeUnit, ToByteSlice},
 };

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1509,7 +1509,8 @@ mod tests {
     use crate::error::Result;
     use crate::physical_plan::common::get_scalar_value;
     use arrow::array::{
-        LargeStringArray, PrimitiveArray, StringArray, Time64NanosecondArray,
+        LargeStringArray, PrimitiveArray, StringArray, StringArrayOps,
+        Time64NanosecondArray,
     };
     use arrow::datatypes::*;
 

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -341,7 +341,7 @@ mod tests {
         error::Result, logical_plan::ScalarValue, physical_plan::expressions::lit,
     };
     use arrow::{
-        array::{ArrayRef, Float64Array, Int32Array, StringArray},
+        array::{ArrayRef, Float64Array, Int32Array, StringArray, StringArrayOps},
         datatypes::Field,
         record_batch::RecordBatch,
     };

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -28,8 +28,8 @@ use crate::physical_plan::{
 
 use arrow::array::{
     ArrayBuilder, ArrayRef, Float32Array, Float64Array, Int16Array, Int32Array,
-    Int64Array, Int8Array, StringArray, UInt16Array, UInt32Array, UInt64Array,
-    UInt8Array,
+    Int64Array, Int8Array, StringArray, StringArrayOps, UInt16Array, UInt32Array,
+    UInt64Array, UInt8Array,
 };
 use arrow::array::{
     Float32Builder, Float64Builder, Int16Builder, Int32Builder, Int64Builder,

--- a/rust/datafusion/src/physical_plan/string_expressions.rs
+++ b/rust/datafusion/src/physical_plan/string_expressions.rs
@@ -18,7 +18,7 @@
 //! String expressions
 
 use crate::error::{ExecutionError, Result};
-use arrow::array::{Array, ArrayRef, StringArray, StringBuilder};
+use arrow::array::{Array, ArrayRef, StringArray, StringArrayOps, StringBuilder};
 
 macro_rules! downcast_vec {
     ($ARGS:expr, $ARRAY_TYPE:ident) => {{

--- a/rust/datafusion/tests/user_defined_plan.rs
+++ b/rust/datafusion/tests/user_defined_plan.rs
@@ -59,7 +59,7 @@
 //!
 
 use arrow::{
-    array::{Int64Array, StringArray},
+    array::{Int64Array, StringArray, StringArrayOps},
     datatypes::SchemaRef,
     error::ArrowError,
     record_batch::{RecordBatch, RecordBatchReader},

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -939,7 +939,9 @@ mod tests {
         DataPageBuilder, DataPageBuilderImpl, InMemoryPageIterator,
     };
     use crate::util::test_common::{get_test_file, make_pages};
-    use arrow::array::{Array, ArrayRef, PrimitiveArray, StringArray, StructArray};
+    use arrow::array::{
+        Array, ArrayRef, PrimitiveArray, StringArray, StringArrayOps, StructArray,
+    };
     use arrow::datatypes::{
         DataType as ArrowType, Date32Type as ArrowDate32, Field, Int32Type as ArrowInt32,
         TimestampMicrosecondType as ArrowTimestampMicrosecondType,


### PR DESCRIPTION
This PR improves the speed of the `take` kernel by using ~the dark magic~ buffers that @nevi-me thought me in another PR. 😀

Like others PRs, the first commit fixes the benchmarks:
* made them not benchmark array creation
* removed benchmark of i8 since it uses the same code as i32,i64,if32,etc.
* removed size 256 since 512 and 1024 is enough
* added benchmark of take of strings

```
git checkout c2aff01 && cargo bench --bench take_kernels && git checkout take_faster && cargo bench --bench take_kernels
```

Result on my computer:

```
take i32 512            time:   [2.9221 us 2.9282 us 2.9348 us]                          
                        change: [-46.697% -45.799% -44.703%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe

take i32 1024           time:   [5.0237 us 5.0376 us 5.0548 us]                           
                        change: [-48.840% -48.433% -48.087%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

take bool 512           time:   [2.4694 us 2.4765 us 2.4843 us]                           
                        change: [-50.789% -50.390% -50.012%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

take bool 1024          time:   [4.0698 us 4.2407 us 4.4884 us]                            
                        change: [-51.026% -49.906% -48.535%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

take str 512            time:   [8.1593 us 8.9810 us 10.114 us]                          
                        change: [-66.908% -57.395% -45.151%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) high mild
  1 (1.00%) high severe

take str 1024           time:   [12.098 us 12.151 us 12.208 us]                           
                        change: [-78.241% -75.656% -72.725%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
```