### PR TITLE
ARROW-9977: [Rust] Added min/max of [Large]StringArray

### DIFF
--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -19,8 +19,41 @@
 
 use std::ops::Add;
 
-use crate::array::{Array, PrimitiveArray};
+use crate::array::{Array, LargeStringArray, PrimitiveArray, StringArray};
 use crate::datatypes::ArrowNumericType;
+
+/// Helper macro to perform min/max of strings
+macro_rules! min_max_string_helper {
+    ($array:expr, $cmp:tt) => {{
+        let null_count = $array.null_count();
+
+        if null_count == $array.len() {
+            return None
+        }
+        let mut n = "";
+        let mut has_value = false;
+        let data = $array.data();
+
+        if null_count == 0 {
+            for i in 0..data.len() {
+                let item = $array.value(i);
+                if !has_value || (&n $cmp &item) {
+                    has_value = true;
+                    n = item;
+                }
+            }
+        } else {
+            for i in 0..data.len() {
+                let item = $array.value(i);
+                if !has_value || data.is_valid(i) && (&n $cmp &item) {
+                    has_value = true;
+                    n = item;
+                }
+            }
+        }
+        Some(n)
+    }}
+}
 
 /// Returns the minimum value in the array, according to the natural order.
 pub fn min<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
@@ -36,6 +69,26 @@ where
     T: ArrowNumericType,
 {
     min_max_helper(array, |a, b| a < b)
+}
+
+/// Returns the maximum value in the string array, according to the natural order.
+pub fn max_string(array: &StringArray) -> Option<&str> {
+    min_max_string_helper!(array, <)
+}
+
+/// Returns the minimum value in the string array, according to the natural order.
+pub fn min_string(array: &StringArray) -> Option<&str> {
+    min_max_string_helper!(array, >)
+}
+
+/// Returns the minimum value in the string array, according to the natural order.
+pub fn max_large_string(array: &LargeStringArray) -> Option<&str> {
+    min_max_string_helper!(array, <)
+}
+
+/// Returns the minimum value in the string array, according to the natural order.
+pub fn min_large_string(array: &LargeStringArray) -> Option<&str> {
+    min_max_string_helper!(array, >)
 }
 
 /// Helper function to perform min/max lambda function on values from a numeric array.
@@ -148,5 +201,19 @@ mod tests {
         let a = Int32Array::from(vec![Some(5), None, None, Some(8), Some(9)]);
         assert_eq!(5, min(&a).unwrap());
         assert_eq!(9, max(&a).unwrap());
+    }
+
+    #[test]
+    fn test_string_min_max_with_nulls() {
+        let a = StringArray::from(vec![Some("b"), None, None, Some("a"), Some("c")]);
+        assert_eq!("a", min_string(&a).unwrap());
+        assert_eq!("c", max_string(&a).unwrap());
+    }
+
+    #[test]
+    fn test_string_min_max_all_nulls() {
+        let a = StringArray::from(vec![None, None]);
+        assert_eq!(None, min_string(&a));
+        assert_eq!(None, max_string(&a));
     }
 }

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -45,7 +45,7 @@ macro_rules! min_max_string_helper {
         } else {
             for i in 0..data.len() {
                 let item = $array.value(i);
-                if !has_value || data.is_valid(i) && (&n $cmp &item) {
+                if data.is_valid(i) && (!has_value || (&n $cmp &item)) {
                     has_value = true;
                     n = item;
                 }
@@ -118,7 +118,7 @@ where
         }
     } else {
         for (i, item) in m.iter().enumerate() {
-            if !has_value || data.is_valid(i) && cmp(&n, item) {
+            if data.is_valid(i) && (!has_value || cmp(&n, item)) {
                 has_value = true;
                 n = *item
             }
@@ -204,6 +204,13 @@ mod tests {
     }
 
     #[test]
+    fn test_buffer_min_max_1() {
+        let a = Int32Array::from(vec![None, None, Some(5), Some(2)]);
+        assert_eq!(Some(2), min(&a));
+        assert_eq!(Some(5), max(&a));
+    }
+
+    #[test]
     fn test_string_min_max_with_nulls() {
         let a = StringArray::from(vec![Some("b"), None, None, Some("a"), Some("c")]);
         assert_eq!("a", min_string(&a).unwrap());
@@ -215,5 +222,12 @@ mod tests {
         let a = StringArray::from(vec![None, None]);
         assert_eq!(None, min_string(&a));
         assert_eq!(None, max_string(&a));
+    }
+
+    #[test]
+    fn test_string_min_max_1() {
+        let a = StringArray::from(vec![None, None, Some("b"), Some("a")]);
+        assert_eq!(Some("a"), min_string(&a));
+        assert_eq!(Some("b"), max_string(&a));
     }
 }


### PR DESCRIPTION
Like the title says, another helper.

Note that, contrarily to horizontal operations, that we can represent as `f(&ArrayRef) -> ArrayRef`, in vertical operations like `min`, and `sum` we do not have a dynamically-typed `struct` to return, and thus need to have a function signature for each type. :(

I wonder if we could have in Rust a dynamically struct for single values, like DataFusion has `ScalarValue`.
