### PR TITLE
ARROW-9990: [Rust] [DataFusion] Fixed the NOT operator

### DIFF
--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -150,6 +150,10 @@ fn create_name(e: &Expr, input_schema: &Schema) -> Result<String> {
             let expr = create_name(expr, input_schema)?;
             Ok(format!("CAST({} as {:?})", expr, data_type))
         }
+        Expr::Not(expr) => {
+            let expr = create_name(expr, input_schema)?;
+            Ok(format!("NOT {}", expr))
+        }
         Expr::ScalarFunction { fun, args, .. } => {
             create_function_name(&fun.to_string(), args, input_schema)
         }

--- a/rust/datafusion/src/logical_plan/operators.rs
+++ b/rust/datafusion/src/logical_plan/operators.rs
@@ -48,8 +48,6 @@ pub enum Operator {
     And,
     /// Logical OR, like `||`
     Or,
-    /// Logical NOT, like `!`
-    Not,
     /// Matches a wildcard pattern
     Like,
     /// Does not match a wildcard pattern
@@ -72,7 +70,6 @@ impl fmt::Display for Operator {
             Operator::Modulus => "%",
             Operator::And => "AND",
             Operator::Or => "OR",
-            Operator::Not => "NOT",
             Operator::Like => "LIKE",
             Operator::NotLike => "NOT LIKE",
         };

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1121,11 +1121,6 @@ fn common_binary_type(
                 "Modulus operator is still not supported".to_string(),
             ))
         }
-        Operator::Not => {
-            return Err(ExecutionError::InternalError(
-                "Trying to coerce a unary operator".to_string(),
-            ))
-        }
     };
 
     // re-write the error message of failed coercions to include the operator's information
@@ -1172,9 +1167,6 @@ pub fn binary_operator_data_type(
         }
         Operator::Modulus => Err(ExecutionError::NotImplemented(
             "Modulus operator is still not supported".to_string(),
-        )),
-        Operator::Not => Err(ExecutionError::InternalError(
-            "Trying to coerce a unary operator".to_string(),
         )),
     }
 }
@@ -1262,9 +1254,6 @@ impl PhysicalExpr for BinaryExpr {
             Operator::Modulus => Err(ExecutionError::NotImplemented(
                 "Modulus operator is still not supported".to_string(),
             )),
-            Operator::Not => {
-                Err(ExecutionError::General("Unsupported operator".to_string()))
-            }
         }
     }
 }
@@ -1731,20 +1720,6 @@ mod tests {
         } else {
             Err(ExecutionError::General(
                 "Coercion should have returned an ExecutionError::General".to_string(),
-            ))
-        }
-    }
-
-    #[test]
-    fn test_coersion_invalid() -> Result<()> {
-        let expr =
-            common_binary_type(&DataType::Float32, &Operator::Not, &DataType::Utf8);
-        if let Err(ExecutionError::InternalError(_)) = expr {
-            Ok(())
-        } else {
-            Err(ExecutionError::General(
-                "Coercion should have returned an ExecutionError::InternalError"
-                    .to_string(),
             ))
         }
     }

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1294,8 +1294,8 @@ impl PhysicalExpr for NotExpr {
         return Ok(DataType::Boolean);
     }
 
-    fn nullable(&self, _input_schema: &Schema) -> Result<bool> {
-        Ok(true)
+    fn nullable(&self, input_schema: &Schema) -> Result<bool> {
+        self.arg.nullable(input_schema)
     }
 
     fn evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef> {

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -493,16 +493,11 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
                     ))),
                 }?;
 
-                match operator {
-                    Operator::Not => Err(ExecutionError::InternalError(format!(
-                        "SQL unary operator \"NOT\" cannot be interpreted as a binary operator"
-                    ))),
-                    _ => Ok(Expr::BinaryExpr {
-                        left: Box::new(self.sql_to_rex(&left, &schema)?),
-                        op: operator,
-                        right: Box::new(self.sql_to_rex(&right, &schema)?),
-                    })
-                }
+                Ok(Expr::BinaryExpr {
+                    left: Box::new(self.sql_to_rex(&left, &schema)?),
+                    op: operator,
+                    right: Box::new(self.sql_to_rex(&right, &schema)?),
+                })
             }
 
             SQLExpr::Function(function) => {


### PR DESCRIPTION
This PR is built on top of #8182 

This PR fixes the operator NOT, that currently cannot be logically planned. It was also an operator that was considered a Binary, even though it accepts only a single argument.