### PR TITLE
ARROW-10003: [C++] Create parent dir for any destination fs in CopyFiles

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <sstream>
-#include <unordered_set>
 #include <utility>
 
 #include "arrow/filesystem/filesystem.h"

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <algorithm>
 #include <sstream>
 #include <utility>
 

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -496,11 +496,9 @@ Status CopyFiles(const std::shared_ptr<FileSystem>& source_fs,
   }
 
   dirs = internal::MinimalCreateDirSet(std::move(dirs));
-
   RETURN_NOT_OK(::arrow::internal::OptionalParallelFor(
-      use_threads, static_cast<int>(dirs.size()), [&](int i) {
-        return dirs[i].empty() ? Status::OK() : destination_fs->CreateDir(dirs[i]);
-      }));
+      use_threads, static_cast<int>(dirs.size()),
+      [&](int i) { return destination_fs->CreateDir(dirs[i]); }));
 
   return CopyFiles(sources, destinations, chunk_size, use_threads);
 }

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -496,19 +496,7 @@ Status CopyFiles(const std::shared_ptr<FileSystem>& source_fs,
     }
   }
 
-  // remove directories with descendants since recursive directory creation will create
-  // them automatically
-  std::sort(dirs.begin(), dirs.end());
-  for (auto ancestor = dirs.begin(); ancestor != dirs.end(); ++ancestor) {
-    auto descendants_end = ancestor + 1;
-
-    while (descendants_end != dirs.end() &&
-           internal::IsAncestorOf(*ancestor, *descendants_end)) {
-      ++descendants_end;
-    }
-
-    dirs.erase(ancestor, descendants_end - 1);
-  }
+  dirs = internal::MinimalCreateDirSet(std::move(dirs));
 
   RETURN_NOT_OK(::arrow::internal::OptionalParallelFor(
       use_threads, static_cast<int>(dirs.size()), [&](int i) {

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -131,7 +131,7 @@ struct ARROW_EXPORT FileSelector {
   /// The maximum number of subdirectories to recurse into.
   int32_t max_recursion = INT32_MAX;
 
-  FileSelector() {}
+  FileSelector() = default;
 };
 
 /// \brief FileSystem, path pair
@@ -397,12 +397,21 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
 ///
 /// If a source and destination are resident in the same FileSystem FileSystem::CopyFile
 /// will be used, otherwise the file will be opened as a stream in both FileSystems and
-/// chunks copied from the source to the destination. Parent directories will be created.
+/// chunks copied from the source to the destination. No directories will be created.
 ARROW_EXPORT
 Status CopyFiles(const std::vector<FileLocator>& sources,
                  const std::vector<FileLocator>& destinations,
-                 int64_t chunk_size = 1024 * 1024, bool use_threads = true,
-                 bool create_directories = false);
+                 int64_t chunk_size = 1024 * 1024, bool use_threads = true);
+
+/// \brief Copy selected files, including from one FileSystem to another
+///
+/// Directories will be created under the destination base directory as needed.
+ARROW_EXPORT
+Status CopyFiles(const std::shared_ptr<FileSystem>& source_fs,
+                 const FileSelector& source_sel,
+                 const std::shared_ptr<FileSystem>& destination_fs,
+                 const std::string& destination_base_dir,
+                 int64_t chunk_size = 1024 * 1024, bool use_threads = true);
 
 struct FileSystemGlobalOptions {
   /// Path to a single PEM file holding all TLS CA certificates

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -393,7 +393,11 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
 
 /// @}
 
-/// \brief Copy files from one FileSystem to another
+/// \brief Copy files, including from one FileSystem to another
+///
+/// If a source and destination are resident in the same FileSystem FileSystem::CopyFile
+/// will be used, otherwise the file will be opened as a stream in both FileSystems and
+/// chunks copied from the source to the destination. Parent directories will be created.
 ARROW_EXPORT
 Status CopyFiles(const std::vector<FileLocator>& sources,
                  const std::vector<FileLocator>& destinations,

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -125,13 +125,13 @@ struct ARROW_EXPORT FileSelector {
   std::string base_dir;
   /// The behavior if `base_dir` isn't found in the filesystem.  If false,
   /// an error is returned.  If true, an empty selection is returned.
-  bool allow_not_found = false;
+  bool allow_not_found;
   /// Whether to recurse into subdirectories.
-  bool recursive = false;
+  bool recursive;
   /// The maximum number of subdirectories to recurse into.
-  int32_t max_recursion = INT32_MAX;
+  int32_t max_recursion;
 
-  FileSelector() = default;
+  FileSelector() : allow_not_found(false), recursive(false), max_recursion(INT32_MAX) {}
 };
 
 /// \brief FileSystem, path pair

--- a/cpp/src/arrow/filesystem/filesystem.h
+++ b/cpp/src/arrow/filesystem/filesystem.h
@@ -401,7 +401,8 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriOrPath(
 ARROW_EXPORT
 Status CopyFiles(const std::vector<FileLocator>& sources,
                  const std::vector<FileLocator>& destinations,
-                 int64_t chunk_size = 1024 * 1024, bool use_threads = true);
+                 int64_t chunk_size = 1024 * 1024, bool use_threads = true,
+                 bool create_directories = false);
 
 struct FileSystemGlobalOptions {
   /// Path to a single PEM file holding all TLS CA certificates

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -599,13 +599,16 @@ TEST_F(TestSubTreeFileSystem, CopyFiles) {
   CreateFile("ab", "ab");
   CreateFile("cd", "cd");
   CreateFile("ef", "ef");
+  CreateFile("same", "same");
 
   ASSERT_OK(fs_->CreateDir("sub/copy"));
   auto dest_fs = std::make_shared<SubTreeFileSystem>("sub/copy", fs_);
 
-  ASSERT_OK(
-      CopyFiles({{subfs_, "ab"}, {subfs_, "cd"}, {subfs_, "ef"}},
-                {{dest_fs, "AB/ab"}, {dest_fs, "CD/CD/cd"}, {dest_fs, "EF/EF/EF/ef"}}));
+  ASSERT_OK(CopyFiles({{subfs_, "ab"}, {subfs_, "cd"}, {subfs_, "ef"}, {subfs_, "same"}},
+                      {{dest_fs, "AB/ab"},
+                       {dest_fs, "CD/CD/cd"},
+                       {dest_fs, "EF/EF/EF/ef"},
+                       {subfs_, "same_copy/same"}}));
 
   CheckFiles({
       {"sub/copy/AB/ab", time_, "ab"},
@@ -614,6 +617,8 @@ TEST_F(TestSubTreeFileSystem, CopyFiles) {
       {"sub/tree/ab", time_, "ab"},
       {"sub/tree/cd", time_, "cd"},
       {"sub/tree/ef", time_, "ef"},
+      {"sub/tree/same", time_, "same"},
+      {"sub/tree/same_copy/same", time_, "same"},
   });
 }
 

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -188,6 +188,16 @@ TEST(PathUtil, RemoveLeadingSlash) {
   ASSERT_EQ("abc/def/", std::string(RemoveLeadingSlash("//abc/def/")));
 }
 
+TEST(PathUtil, IsAncestorOf) {
+  ASSERT_TRUE(IsAncestorOf("", ""));
+  ASSERT_TRUE(IsAncestorOf("", "/hello"));
+  ASSERT_TRUE(IsAncestorOf("/hello", "/hello"));
+  ASSERT_FALSE(IsAncestorOf("/hello", "/world"));
+  ASSERT_TRUE(IsAncestorOf("/hello", "/hello/world"));
+  ASSERT_TRUE(IsAncestorOf("/hello", "/hello/world/how/are/you"));
+  ASSERT_FALSE(IsAncestorOf("/hello/w", "/hello/world"));
+}
+
 TEST(PathUtil, MakeAbstractPathRelative) {
   ASSERT_OK_AND_EQ("", MakeAbstractPathRelative("/", "/"));
   ASSERT_OK_AND_EQ("foo/bar", MakeAbstractPathRelative("/", "/foo/bar"));
@@ -221,6 +231,18 @@ TEST(PathUtil, AncestorsFromBasePath) {
   ASSERT_EQ(AncestorsFromBasePath("foo", "foo/bar/baz"), V({"foo/bar"}));
   ASSERT_EQ(AncestorsFromBasePath("foo", "foo/bar/baz/quux"),
             V({"foo/bar", "foo/bar/baz"}));
+}
+
+TEST(PathUtil, MinimalCreateDirSet) {
+  using V = std::vector<std::string>;
+
+  ASSERT_EQ(MinimalCreateDirSet({}), V{});
+  ASSERT_EQ(MinimalCreateDirSet({"foo"}), V{"foo"});
+  ASSERT_EQ(MinimalCreateDirSet({"foo", "foo/bar"}), V{"foo/bar"});
+  ASSERT_EQ(MinimalCreateDirSet({"foo", "foo/bar/baz"}), V{"foo/bar/baz"});
+  ASSERT_EQ(MinimalCreateDirSet({"foo", "foo/bar", "foo/bar"}), V{"foo/bar"});
+  ASSERT_EQ(MinimalCreateDirSet({"foo", "foo/bar", "foo", "foo/baz", "foo/baz/quux"}),
+            V({"foo/bar", "foo/baz/quux"}));
 }
 
 TEST(PathUtil, ToBackslashes) {

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -596,31 +596,28 @@ TEST_F(TestSubTreeFileSystem, CopyFile) {
 }
 
 TEST_F(TestSubTreeFileSystem, CopyFiles) {
-  CreateFile("ab", "ab");
-  CreateFile("cd", "cd");
-  CreateFile("ef", "ef");
-  CreateFile("same", "same");
+  ASSERT_OK(subfs_->CreateDir("AB"));
+  ASSERT_OK(subfs_->CreateDir("CD/CD"));
+  ASSERT_OK(subfs_->CreateDir("EF/EF/EF"));
+
+  CreateFile("AB/ab", "ab");
+  CreateFile("CD/CD/cd", "cd");
+  CreateFile("EF/EF/EF/ef", "ef");
 
   ASSERT_OK(fs_->CreateDir("sub/copy"));
   auto dest_fs = std::make_shared<SubTreeFileSystem>("sub/copy", fs_);
 
-  ASSERT_OK(CopyFiles({{subfs_, "ab"}, {subfs_, "cd"}, {subfs_, "ef"}, {subfs_, "same"}},
-                      {{dest_fs, "AB/ab"},
-                       {dest_fs, "CD/CD/cd"},
-                       {dest_fs, "EF/EF/EF/ef"},
-                       {subfs_, "same_copy/same"}},
-                      /*chunk_size=*/16, /*use_threads=*/true,
-                      /*create_directories=*/true));
+  FileSelector sel;
+  sel.recursive = true;
+  ASSERT_OK(CopyFiles(subfs_, sel, dest_fs, ""));
 
   CheckFiles({
       {"sub/copy/AB/ab", time_, "ab"},
       {"sub/copy/CD/CD/cd", time_, "cd"},
       {"sub/copy/EF/EF/EF/ef", time_, "ef"},
-      {"sub/tree/ab", time_, "ab"},
-      {"sub/tree/cd", time_, "cd"},
-      {"sub/tree/ef", time_, "ef"},
-      {"sub/tree/same", time_, "same"},
-      {"sub/tree/same_copy/same", time_, "same"},
+      {"sub/tree/AB/ab", time_, "ab"},
+      {"sub/tree/CD/CD/cd", time_, "cd"},
+      {"sub/tree/EF/EF/EF/ef", time_, "ef"},
   });
 }
 

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -243,6 +243,9 @@ TEST(PathUtil, MinimalCreateDirSet) {
   ASSERT_EQ(MinimalCreateDirSet({"foo", "foo/bar", "foo/bar"}), V{"foo/bar"});
   ASSERT_EQ(MinimalCreateDirSet({"foo", "foo/bar", "foo", "foo/baz", "foo/baz/quux"}),
             V({"foo/bar", "foo/baz/quux"}));
+
+  ASSERT_EQ(MinimalCreateDirSet({""}), V{});
+  ASSERT_EQ(MinimalCreateDirSet({"", "/foo"}), V{"/foo"});
 }
 
 TEST(PathUtil, ToBackslashes) {

--- a/cpp/src/arrow/filesystem/filesystem_test.cc
+++ b/cpp/src/arrow/filesystem/filesystem_test.cc
@@ -608,7 +608,9 @@ TEST_F(TestSubTreeFileSystem, CopyFiles) {
                       {{dest_fs, "AB/ab"},
                        {dest_fs, "CD/CD/cd"},
                        {dest_fs, "EF/EF/EF/ef"},
-                       {subfs_, "same_copy/same"}}));
+                       {subfs_, "same_copy/same"}},
+                      /*chunk_size=*/16, /*use_threads=*/true,
+                      /*create_directories=*/true));
 
   CheckFiles({
       {"sub/copy/AB/ab", time_, "ab"},

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -227,6 +227,11 @@ std::vector<std::string> MinimalCreateDirSet(std::vector<std::string> dirs) {
     ancestor = dirs.erase(ancestor, descendants_end - 1);
   }
 
+  // the root directory need not be created
+  if (dirs.size() == 1 && IsAncestorOf(dirs[0], "")) {
+    return {};
+  }
+
   return dirs;
 }
 

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <algorithm>
+
 #include "arrow/filesystem/path_util.h"
 #include "arrow/result.h"
 #include "arrow/status.h"

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -168,6 +168,11 @@ bool IsAncestorOf(util::string_view ancestor, util::string_view descendant) {
 
   descendant.remove_prefix(ancestor.size());
 
+  if (descendant.empty()) {
+    // "/hello" is an ancestor of "/hello"
+    return true;
+  }
+
   // "/hello/w" is not an ancestor of "/hello/world"
   return descendant.starts_with(std::string{kSep});
 }
@@ -203,6 +208,24 @@ std::vector<std::string> AncestorsFromBasePath(util::string_view base_path,
     }
   }
   return ancestry;
+}
+
+std::vector<std::string> MinimalCreateDirSet(std::vector<std::string> dirs) {
+  std::sort(dirs.begin(), dirs.end());
+
+  for (auto ancestor = dirs.begin(); ancestor != dirs.end(); ++ancestor) {
+    auto descendant = ancestor;
+    auto descendants_end = descendant + 1;
+
+    while (descendants_end != dirs.end() && IsAncestorOf(*descendant, *descendants_end)) {
+      ++descendant;
+      ++descendants_end;
+    }
+
+    ancestor = dirs.erase(ancestor, descendants_end - 1);
+  }
+
+  return dirs;
 }
 
 std::string ToBackslashes(util::string_view v) {

--- a/cpp/src/arrow/filesystem/path_util.h
+++ b/cpp/src/arrow/filesystem/path_util.h
@@ -87,6 +87,12 @@ ARROW_EXPORT
 std::vector<std::string> AncestorsFromBasePath(util::string_view base_path,
                                                util::string_view descendant);
 
+/// Given a vector of paths of directories which must be created, produce a the minimal
+/// subset for passing to CreateDir(recursive=true) by removing redundant parent
+/// directories
+ARROW_EXPORT
+std::vector<std::string> MinimalCreateDirSet(std::vector<std::string> dirs);
+
 // Join the components of an abstract path.
 template <class StringIt>
 std::string JoinAbstractPath(StringIt it, StringIt end) {

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -928,8 +928,8 @@ fs___FileSystemFromUri <- function(path){
     .Call(`_arrow_fs___FileSystemFromUri` , path)
 }
 
-fs___CopyFiles <- function(src_fs, src_paths, dest_fs, dest_paths, chunk_size, use_threads){
-    invisible(.Call(`_arrow_fs___CopyFiles` , src_fs, src_paths, dest_fs, dest_paths, chunk_size, use_threads))
+fs___CopyFiles <- function(source_fs, source_sel, destination_fs, destination_base_dir, chunk_size, use_threads){
+    invisible(.Call(`_arrow_fs___CopyFiles` , source_fs, source_sel, destination_fs, destination_base_dir, chunk_size, use_threads))
 }
 
 fs___EnsureS3Initialized <- function(){

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -309,10 +309,11 @@ SubTreeFileSystem$create <- function(base_path, base_fs) {
 #' @param chunk_size The maximum size of block to read before flushing
 #' to the destination file. A larger chunk_size will use more memory while
 #' copying but may help accommodate high latency FileSystems.
+#' @param create_directories Create parent directories of destination files.
 copy_files <- function(src_fs, src_paths, dest_fs, dest_paths,
-                       chunk_size = 1024L * 1024L) {
+                       chunk_size = 1024L * 1024L, create_directories = TRUE) {
   fs___CopyFiles(src_fs, src_paths, dest_fs, dest_paths,
-                 chunk_size, option_use_threads())
+                 chunk_size, option_use_threads(), create_directories)
 }
 
 clean_path_abs <- function(path) {

--- a/r/R/filesystem.R
+++ b/r/R/filesystem.R
@@ -300,20 +300,28 @@ SubTreeFileSystem$create <- function(base_path, base_fs) {
   shared_ptr(SubTreeFileSystem, xp)
 }
 
-#' Copy files between FileSystems
+#' Copy files, including between FileSystems
 #'
 #' @param src_fs The FileSystem from which files will be copied.
-#' @param src_paths The paths of files to be copied.
+#' @param src_sel A FileSelector indicating which files should be copied.
+#' A string may also be passed, which is used as the base dir for recursive
+#' selection.
 #' @param dest_fs The FileSystem into which files will be copied.
-#' @param dest_paths Where the copied files should be placed.
+#' @param dest_base_dir Where the copied files should be placed.
+#' Directories will be created as necessary.
 #' @param chunk_size The maximum size of block to read before flushing
 #' to the destination file. A larger chunk_size will use more memory while
 #' copying but may help accommodate high latency FileSystems.
-#' @param create_directories Create parent directories of destination files.
-copy_files <- function(src_fs, src_paths, dest_fs, dest_paths,
-                       chunk_size = 1024L * 1024L, create_directories = TRUE) {
-  fs___CopyFiles(src_fs, src_paths, dest_fs, dest_paths,
-                 chunk_size, option_use_threads(), create_directories)
+copy_files <- function(src_fs = LocalFileSystem$create(),
+                       src_sel,
+                       dest_fs = LocalFileSystem$create(),
+                       dest_base_dir,
+                       chunk_size = 1024L * 1024L) {
+  if (!inherits(src_sel, "FileSelector")) {
+    src_sel <- FileSelector$create(src_sel, recursive = TRUE)
+  }
+  fs___CopyFiles(src_fs, src_sel, dest_fs, dest_base_dir,
+                 chunk_size, option_use_threads())
 }
 
 clean_path_abs <- function(path) {

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -3610,21 +3610,21 @@ extern "C" SEXP _arrow_fs___FileSystemFromUri(SEXP path_sexp){
 
 // filesystem.cpp
 #if defined(ARROW_R_WITH_ARROW)
-void fs___CopyFiles(const std::shared_ptr<fs::FileSystem>& src_fs, const std::vector<std::string>& src_paths, const std::shared_ptr<fs::FileSystem>& dest_fs, const std::vector<std::string>& dest_paths, int64_t chunk_size, bool use_threads);
-extern "C" SEXP _arrow_fs___CopyFiles(SEXP src_fs_sexp, SEXP src_paths_sexp, SEXP dest_fs_sexp, SEXP dest_paths_sexp, SEXP chunk_size_sexp, SEXP use_threads_sexp){
+void fs___CopyFiles(const std::shared_ptr<fs::FileSystem>& source_fs, const std::shared_ptr<fs::FileSelector>& source_sel, const std::shared_ptr<fs::FileSystem>& destination_fs, const std::string& destination_base_dir, int64_t chunk_size, bool use_threads);
+extern "C" SEXP _arrow_fs___CopyFiles(SEXP source_fs_sexp, SEXP source_sel_sexp, SEXP destination_fs_sexp, SEXP destination_base_dir_sexp, SEXP chunk_size_sexp, SEXP use_threads_sexp){
 BEGIN_CPP11
-	arrow::r::Input<const std::shared_ptr<fs::FileSystem>&>::type src_fs(src_fs_sexp);
-	arrow::r::Input<const std::vector<std::string>&>::type src_paths(src_paths_sexp);
-	arrow::r::Input<const std::shared_ptr<fs::FileSystem>&>::type dest_fs(dest_fs_sexp);
-	arrow::r::Input<const std::vector<std::string>&>::type dest_paths(dest_paths_sexp);
+	arrow::r::Input<const std::shared_ptr<fs::FileSystem>&>::type source_fs(source_fs_sexp);
+	arrow::r::Input<const std::shared_ptr<fs::FileSelector>&>::type source_sel(source_sel_sexp);
+	arrow::r::Input<const std::shared_ptr<fs::FileSystem>&>::type destination_fs(destination_fs_sexp);
+	arrow::r::Input<const std::string&>::type destination_base_dir(destination_base_dir_sexp);
 	arrow::r::Input<int64_t>::type chunk_size(chunk_size_sexp);
 	arrow::r::Input<bool>::type use_threads(use_threads_sexp);
-	fs___CopyFiles(src_fs, src_paths, dest_fs, dest_paths, chunk_size, use_threads);
+	fs___CopyFiles(source_fs, source_sel, destination_fs, destination_base_dir, chunk_size, use_threads);
 	return R_NilValue;
 END_CPP11
 }
 #else
-extern "C" SEXP _arrow_fs___CopyFiles(SEXP src_fs_sexp, SEXP src_paths_sexp, SEXP dest_fs_sexp, SEXP dest_paths_sexp, SEXP chunk_size_sexp, SEXP use_threads_sexp){
+extern "C" SEXP _arrow_fs___CopyFiles(SEXP source_fs_sexp, SEXP source_sel_sexp, SEXP destination_fs_sexp, SEXP destination_base_dir_sexp, SEXP chunk_size_sexp, SEXP use_threads_sexp){
 	Rf_error("Cannot call fs___CopyFiles(). Please use arrow::install_arrow() to install required runtime libraries. ");
 }
 #endif

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -235,7 +235,7 @@ void fs___CopyFiles(const std::shared_ptr<fs::FileSystem>& src_fs,
                     const std::vector<std::string>& src_paths,
                     const std::shared_ptr<fs::FileSystem>& dest_fs,
                     const std::vector<std::string>& dest_paths, int64_t chunk_size,
-                    bool use_threads) {
+                    bool use_threads, bool create_directories) {
   std::vector<fs::FileLocator> sources(src_paths.size()), destinations(dest_paths.size());
 
   for (size_t i = 0; i < src_paths.size(); ++i) {
@@ -243,7 +243,8 @@ void fs___CopyFiles(const std::shared_ptr<fs::FileSystem>& src_fs,
     destinations[i] = {dest_fs, dest_paths[i]};
   }
 
-  StopIfNotOk(fs::CopyFiles(sources, destinations, chunk_size, use_threads));
+  StopIfNotOk(
+      fs::CopyFiles(sources, destinations, chunk_size, use_threads, create_directories));
 }
 
 #endif

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -231,12 +231,12 @@ cpp11::writable::list fs___FileSystemFromUri(const std::string& path) {
 }
 
 // [[arrow::export]]
-void fs___CopyFiles(const std::shared_ptr<FileSystem>& source_fs,
-                    const FileSelector& source_sel,
-                    const std::shared_ptr<FileSystem>& destination_fs,
+void fs___CopyFiles(const std::shared_ptr<fs::FileSystem>& source_fs,
+                    const std::shared_ptr<fs::FileSelector>& source_sel,
+                    const std::shared_ptr<fs::FileSystem>& destination_fs,
                     const std::string& destination_base_dir,
                     int64_t chunk_size = 1024 * 1024, bool use_threads = true) {
-  StopIfNotOk(fs::CopyFiles(source_fs, source_sel, destination_fs, destination_base_dir,
+  StopIfNotOk(fs::CopyFiles(source_fs, *source_sel, destination_fs, destination_base_dir,
                             chunk_size, use_threads));
 }
 

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -231,20 +231,13 @@ cpp11::writable::list fs___FileSystemFromUri(const std::string& path) {
 }
 
 // [[arrow::export]]
-void fs___CopyFiles(const std::shared_ptr<fs::FileSystem>& src_fs,
-                    const std::vector<std::string>& src_paths,
-                    const std::shared_ptr<fs::FileSystem>& dest_fs,
-                    const std::vector<std::string>& dest_paths, int64_t chunk_size,
-                    bool use_threads, bool create_directories) {
-  std::vector<fs::FileLocator> sources(src_paths.size()), destinations(dest_paths.size());
-
-  for (size_t i = 0; i < src_paths.size(); ++i) {
-    sources[i] = {src_fs, src_paths[i]};
-    destinations[i] = {dest_fs, dest_paths[i]};
-  }
-
-  StopIfNotOk(
-      fs::CopyFiles(sources, destinations, chunk_size, use_threads, create_directories));
+void fs___CopyFiles(const std::shared_ptr<FileSystem>& source_fs,
+                    const FileSelector& source_sel,
+                    const std::shared_ptr<FileSystem>& destination_fs,
+                    const std::string& destination_base_dir,
+                    int64_t chunk_size = 1024 * 1024, bool use_threads = true) {
+  StopIfNotOk(fs::CopyFiles(source_fs, source_sel, destination_fs, destination_base_dir,
+                            chunk_size, use_threads));
 }
 
 #endif


### PR DESCRIPTION
Previously only the parent directories of files to be copied to a different filesystem were created.