### PR TITLE
ARROW-9775: [C++] Automatic S3 region selection

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -95,10 +95,12 @@ struct ARROW_EXPORT S3Options {
   /// This is recommended if you use the standard AWS environment variables
   /// and/or configuration file.
   static S3Options Defaults();
+
   /// \brief Initialize with anonymous credentials.
   ///
   /// This will only let you access public buckets.
   static S3Options Anonymous();
+
   /// \brief Initialize with explicit access and secret key.
   ///
   /// Optionally, a session token may also be provided for temporary credentials
@@ -106,11 +108,13 @@ struct ARROW_EXPORT S3Options {
   static S3Options FromAccessKey(const std::string& access_key,
                                  const std::string& secret_key,
                                  const std::string& session_token = "");
+
   /// \brief Initialize from an assumed role.
   static S3Options FromAssumeRole(
       const std::string& role_arn, const std::string& session_name = "",
       const std::string& external_id = "", int load_frequency = 900,
       const std::shared_ptr<Aws::STS::STSClient>& stsClient = NULLPTR);
+
   static Result<S3Options> FromUri(const ::arrow::internal::Uri& uri,
                                    std::string* out_path = NULLPTR);
   static Result<S3Options> FromUri(const std::string& uri,
@@ -215,6 +219,9 @@ Status EnsureS3Initialized();
 /// Shutdown the S3 APIs.
 ARROW_EXPORT
 Status FinalizeS3();
+
+ARROW_EXPORT
+Result<std::string> ResolveBucketRegion(const std::string& bucket);
 
 }  // namespace fs
 }  // namespace arrow

--- a/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_narrative_test.cc
@@ -43,7 +43,7 @@ DEFINE_string(access_key, "", "S3 access key");
 DEFINE_string(secret_key, "", "S3 secret key");
 
 DEFINE_string(bucket, "", "bucket name");
-DEFINE_string(region, arrow::fs::kS3DefaultRegion, "AWS region");
+DEFINE_string(region, "", "AWS region");
 DEFINE_string(endpoint, "", "Endpoint override (e.g. '127.0.0.1:9000')");
 DEFINE_string(scheme, "https", "Connection scheme");
 
@@ -200,6 +200,10 @@ void TestMain(int argc, char** argv) {
                           ? S3LogLevel::Debug
                           : (FLAGS_verbose ? S3LogLevel::Warn : S3LogLevel::Fatal);
   ASSERT_OK(InitializeS3(options));
+
+  if (FLAGS_region.empty()) {
+    ASSERT_OK_AND_ASSIGN(FLAGS_region, ResolveBucketRegion(FLAGS_bucket));
+  }
 
   if (FLAGS_clear) {
     ClearBucket(argc, argv);

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -22,7 +22,7 @@
 #include <type_traits>
 #include <vector>
 
-#include "arrow/type_fwd.h"
+#include "arrow/type.h"
 #include "arrow/util/bit_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/atomic_shared_ptr.h
+++ b/cpp/src/arrow/util/atomic_shared_ptr.h
@@ -47,13 +47,13 @@ using enable_if_atomic_load_shared_ptr_unavailable =
     enable_if_t<!is_atomic_load_shared_ptr_available<T>::value, T>;
 
 template <class T>
-inline enable_if_atomic_load_shared_ptr_available<std::shared_ptr<T>> atomic_load(
+enable_if_atomic_load_shared_ptr_available<std::shared_ptr<T>> atomic_load(
     const std::shared_ptr<T>* p) {
   return std::atomic_load(p);
 }
 
 template <class T>
-inline enable_if_atomic_load_shared_ptr_unavailable<std::shared_ptr<T>> atomic_load(
+enable_if_atomic_load_shared_ptr_unavailable<std::shared_ptr<T>> atomic_load(
     const std::shared_ptr<T>* p) {
   return *p;
 }
@@ -76,28 +76,26 @@ using enable_if_atomic_store_shared_ptr_unavailable =
     enable_if_t<!is_atomic_store_shared_ptr_available<T>::value, T>;
 
 template <class T>
-inline void atomic_store(
-    enable_if_atomic_store_shared_ptr_available<std::shared_ptr<T>*> p,
-    std::shared_ptr<T> r) {
+void atomic_store(enable_if_atomic_store_shared_ptr_available<std::shared_ptr<T>*> p,
+                  std::shared_ptr<T> r) {
   std::atomic_store(p, std::move(r));
 }
 
 template <class T>
-inline void atomic_store(
-    enable_if_atomic_store_shared_ptr_unavailable<std::shared_ptr<T>*> p,
-    std::shared_ptr<T> r) {
+void atomic_store(enable_if_atomic_store_shared_ptr_unavailable<std::shared_ptr<T>*> p,
+                  std::shared_ptr<T> r) {
   *p = r;
 }
 
 template <class T>
-inline bool atomic_compare_exchange_strong(
+bool atomic_compare_exchange_strong(
     enable_if_atomic_store_shared_ptr_available<std::shared_ptr<T>*> p,
     std::shared_ptr<T>* expected, std::shared_ptr<T> desired) {
   return std::atomic_compare_exchange_strong(p, expected, std::move(desired));
 }
 
 template <class T>
-inline bool atomic_compare_exchange_strong(
+bool atomic_compare_exchange_strong(
     enable_if_atomic_store_shared_ptr_unavailable<std::shared_ptr<T>*> p,
     std::shared_ptr<T>* expected, std::shared_ptr<T> desired) {
   if (*p == *expected) {

--- a/cpp/src/arrow/util/atomic_shared_ptr.h
+++ b/cpp/src/arrow/util/atomic_shared_ptr.h
@@ -89,5 +89,25 @@ inline void atomic_store(
   *p = r;
 }
 
+template <class T>
+inline bool atomic_compare_exchange_strong(
+    enable_if_atomic_store_shared_ptr_available<std::shared_ptr<T>*> p,
+    std::shared_ptr<T>* expected, std::shared_ptr<T> desired) {
+  return std::atomic_compare_exchange_strong(p, expected, std::move(desired));
+}
+
+template <class T>
+inline bool atomic_compare_exchange_strong(
+    enable_if_atomic_store_shared_ptr_unavailable<std::shared_ptr<T>*> p,
+    std::shared_ptr<T>* expected, std::shared_ptr<T> desired) {
+  if (*p == *expected) {
+    *p = std::move(desired);
+    return true;
+  } else {
+    *expected = *p;
+    return false;
+  }
+}
+
 }  // namespace internal
 }  // namespace arrow

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -212,3 +212,10 @@ cdef class S3FileSystem(FileSystem):
                 background_writes=opts.background_writes
             ),)
         )
+
+    @property
+    def region(self):
+        """
+        The AWS region this filesystem connects to.
+        """
+        return frombytes(self.s3fs.options().region)


### PR DESCRIPTION
Once looked up, the region of a given bucket is cached for the lifetime of the process.
(the cache size is unbounded, which shouldn't be a problem in practice)

S3Options::FromUri() now resolves the region for the bucket if it wasn't given as a Uri query parameter.