### PR TITLE
ARROW-10030: [Rust] Add support for `FromIter` and `IntoIter` for primitive types

### DIFF
--- a/rust/arrow/benches/cast_kernels.rs
+++ b/rust/arrow/benches/cast_kernels.rs
@@ -29,100 +29,121 @@ use arrow::array::*;
 use arrow::compute::cast;
 use arrow::datatypes::*;
 
-// cast array from specified primitive array type to desired data type
-fn cast_array<FROM>(size: usize, to_type: DataType)
+fn build_array<FROM>(size: usize) -> ArrayRef
 where
     FROM: ArrowNumericType,
     Standard: Distribution<FROM::Native>,
-    PrimitiveArray<FROM>: std::convert::From<Vec<FROM::Native>>,
+    PrimitiveArray<FROM>: std::convert::From<Vec<Option<FROM::Native>>>,
 {
-    let array = Arc::new(PrimitiveArray::<FROM>::from(vec![
-        random::<FROM::Native>();
-        size
-    ])) as ArrayRef;
-    criterion::black_box(cast(&array, &to_type).unwrap());
+    let values = (0..size)
+        .map(|_| {
+            // 10% nulls, i.e. dense.
+            if random::<f64>() < 0.1 {
+                None
+            } else {
+                Some(random::<FROM::Native>())
+            }
+        })
+        .collect();
+
+    Arc::new(PrimitiveArray::<FROM>::from(values))
 }
 
-// cast timestamp array from specified primitive array type to desired data type
-fn cast_timestamp_array<FROM>(size: usize, to_type: DataType)
+fn build_timestamp_array<FROM>(size: usize) -> ArrayRef
 where
     FROM: ArrowTimestampType,
-    Standard: Distribution<i64>,
+    Standard: Distribution<FROM::Native>,
 {
-    let array = Arc::new(PrimitiveArray::<FROM>::from_vec(
-        vec![random::<i64>(); size],
-        None,
-    )) as ArrayRef;
-    criterion::black_box(cast(&array, &to_type).unwrap());
+    let values = (0..size)
+        .map(|_| {
+            if random::<f64>() < 0.5 {
+                None
+            } else {
+                Some(random::<i64>())
+            }
+        })
+        .collect::<Vec<Option<i64>>>();
+
+    Arc::new(PrimitiveArray::<FROM>::from_opt_vec(values, None))
+}
+
+// cast array from specified primitive array type to desired data type
+fn cast_array(array: &ArrayRef, to_type: DataType) {
+    criterion::black_box(cast(array, &to_type).unwrap());
 }
 
 fn add_benchmark(c: &mut Criterion) {
+    let i32_array = build_array::<Int32Type>(512);
+    let i64_array = build_array::<Int64Type>(512);
+    let f32_array = build_array::<Float32Type>(512);
+    let f64_array = build_array::<Float64Type>(512);
+    let date64_array = build_array::<Date64Type>(512);
+    let date32_array = build_array::<Date32Type>(512);
+    let time32s_array = build_array::<Time32SecondType>(512);
+    let time64ns_array = build_array::<Time64NanosecondType>(512);
+    let time_ns_array = build_timestamp_array::<TimestampNanosecondType>(512);
+    let time_ms_array = build_timestamp_array::<TimestampMillisecondType>(512);
+
     c.bench_function("cast int32 to int32 512", |b| {
-        b.iter(|| cast_array::<Int32Type>(512, DataType::Int32))
+        b.iter(|| cast_array(&i32_array, DataType::Int32))
     });
     c.bench_function("cast int32 to uint32 512", |b| {
-        b.iter(|| cast_array::<Int32Type>(512, DataType::UInt32))
+        b.iter(|| cast_array(&i32_array, DataType::UInt32))
     });
     c.bench_function("cast int32 to float32 512", |b| {
-        b.iter(|| cast_array::<Int32Type>(512, DataType::Float32))
+        b.iter(|| cast_array(&i32_array, DataType::Float32))
     });
     c.bench_function("cast int32 to float64 512", |b| {
-        b.iter(|| cast_array::<Int32Type>(512, DataType::Float64))
+        b.iter(|| cast_array(&i32_array, DataType::Float64))
     });
     c.bench_function("cast int32 to int64 512", |b| {
-        b.iter(|| cast_array::<Int32Type>(512, DataType::Int64))
+        b.iter(|| cast_array(&i32_array, DataType::Int64))
     });
     c.bench_function("cast float32 to int32 512", |b| {
-        b.iter(|| cast_array::<Float32Type>(512, DataType::Int32))
+        b.iter(|| cast_array(&f32_array, DataType::Int32))
     });
     c.bench_function("cast float64 to float32 512", |b| {
-        b.iter(|| cast_array::<Float64Type>(512, DataType::Float32))
+        b.iter(|| cast_array(&f64_array, DataType::Float32))
     });
     c.bench_function("cast float64 to uint64 512", |b| {
-        b.iter(|| cast_array::<Float64Type>(512, DataType::UInt64))
+        b.iter(|| cast_array(&f64_array, DataType::UInt64))
     });
     c.bench_function("cast int64 to int32 512", |b| {
-        b.iter(|| cast_array::<Int64Type>(512, DataType::Int32))
+        b.iter(|| cast_array(&i64_array, DataType::Int32))
     });
     c.bench_function("cast date64 to date32 512", |b| {
-        b.iter(|| cast_array::<Date64Type>(512, DataType::Date32(DateUnit::Day)))
+        b.iter(|| cast_array(&date64_array, DataType::Date32(DateUnit::Day)))
     });
     c.bench_function("cast date32 to date64 512", |b| {
-        b.iter(|| cast_array::<Date32Type>(512, DataType::Date64(DateUnit::Millisecond)))
+        b.iter(|| cast_array(&date32_array, DataType::Date64(DateUnit::Millisecond)))
     });
     c.bench_function("cast time32s to time32ms 512", |b| {
-        b.iter(|| {
-            cast_array::<Time32SecondType>(512, DataType::Time32(TimeUnit::Millisecond))
-        })
+        b.iter(|| cast_array(&time32s_array, DataType::Time32(TimeUnit::Millisecond)))
     });
     c.bench_function("cast time32s to time64us 512", |b| {
-        b.iter(|| {
-            cast_array::<Time32SecondType>(512, DataType::Time64(TimeUnit::Microsecond))
-        })
+        b.iter(|| cast_array(&time32s_array, DataType::Time64(TimeUnit::Microsecond)))
     });
     c.bench_function("cast time64ns to time32s 512", |b| {
-        b.iter(|| {
-            cast_array::<Time64NanosecondType>(512, DataType::Time32(TimeUnit::Second))
-        })
+        b.iter(|| cast_array(&time64ns_array, DataType::Time32(TimeUnit::Second)))
     });
     c.bench_function("cast timestamp_ns to timestamp_s 512", |b| {
         b.iter(|| {
-            cast_timestamp_array::<TimestampNanosecondType>(
-                512,
+            cast_array(
+                &time_ns_array,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
             )
         })
     });
     c.bench_function("cast timestamp_ms to timestamp_ns 512", |b| {
         b.iter(|| {
-            cast_timestamp_array::<TimestampMillisecondType>(
-                512,
+            cast_array(
+                &time_ms_array,
                 DataType::Timestamp(TimeUnit::Nanosecond, None),
             )
         })
     });
     c.bench_function("cast timestamp_ms to i64 512", |b| {
-        b.iter(|| cast_timestamp_array::<TimestampMillisecondType>(512, DataType::Int64))
+        b.iter(|| cast_array(&time_ms_array, DataType::Int64))
     });
 }
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -17,6 +17,7 @@
 
 use std::any::Any;
 use std::convert::{From, TryFrom};
+use std::borrow::Borrow;
 use std::fmt;
 use std::io::Write;
 use std::iter::{FromIterator, IntoIterator};
@@ -693,6 +694,61 @@ impl fmt::Debug for PrimitiveArray<BooleanType> {
     }
 }
 
+impl<'a, T: ArrowPrimitiveType> IntoIterator for &'a PrimitiveArray<T> {
+    type Item = Option<<T as ArrowPrimitiveType>::Native>;
+    type IntoIter = PrimitiveIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        PrimitiveIter::<'a, T>::new(self)
+    }
+}
+
+impl<'a, T: ArrowPrimitiveType> PrimitiveArray<T> {
+    /// constructs a new iterator
+    pub fn iter(&'a self) -> PrimitiveIter<'a, T> {
+        PrimitiveIter::<'a, T>::new(&self)
+    }
+}
+
+impl<T: ArrowPrimitiveType, Ptr: Borrow<Option<<T as ArrowPrimitiveType>::Native>>>
+    FromIterator<Ptr> for PrimitiveArray<T>
+{
+    fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let (_, data_len) = iter.size_hint();
+        let data_len = data_len.unwrap(); // panic if no upper bound.
+
+        let num_bytes = bit_util::ceil(data_len, 8);
+        let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);
+        let mut val_buf = MutableBuffer::new(
+            data_len * mem::size_of::<<T as ArrowPrimitiveType>::Native>(),
+        );
+
+        let null = vec![0; mem::size_of::<<T as ArrowPrimitiveType>::Native>()];
+
+        let null_slice = null_buf.data_mut();
+        iter.enumerate().for_each(|(i, item)| {
+            if let Some(a) = item.borrow() {
+                bit_util::set_bit(null_slice, i);
+                val_buf.write_all(a.to_byte_slice()).unwrap();
+            } else {
+                val_buf.write_all(&null).unwrap();
+            }
+        });
+
+        let data = ArrayData::new(
+            T::get_data_type(),
+            data_len,
+            None,
+            Some(null_buf.freeze()),
+            0,
+            vec![val_buf.freeze()],
+            vec![],
+        );
+        PrimitiveArray::from(Arc::new(data))
+    }
+}
+
 // TODO: the macro is needed here because we'd get "conflicting implementations" error
 // otherwise with both `From<Vec<T::Native>>` and `From<Vec<Option<T::Native>>>`.
 // We should revisit this in future.
@@ -713,34 +769,7 @@ macro_rules! def_numeric_from_vec {
             for PrimitiveArray<$ty>
         {
             fn from(data: Vec<Option<<$ty as ArrowPrimitiveType>::Native>>) -> Self {
-                let data_len = data.len();
-                let mut null_buf = make_null_buffer(data_len);
-                let mut val_buf = MutableBuffer::new(
-                    data_len * mem::size_of::<<$ty as ArrowPrimitiveType>::Native>(),
-                );
-
-                {
-                    let null =
-                        vec![0; mem::size_of::<<$ty as ArrowPrimitiveType>::Native>()];
-                    let null_slice = null_buf.data_mut();
-                    for (i, v) in data.iter().enumerate() {
-                        if let Some(n) = v {
-                            bit_util::set_bit(null_slice, i);
-                            // unwrap() in the following should be safe here since we've
-                            // made sure enough space is allocated for the values.
-                            val_buf.write_all(&n.to_byte_slice()).unwrap();
-                        } else {
-                            val_buf.write_all(&null).unwrap();
-                        }
-                    }
-                }
-
-                let array_data = ArrayData::builder($ty::get_data_type())
-                    .len(data_len)
-                    .add_buffer(val_buf.freeze())
-                    .null_bit_buffer(null_buf.freeze())
-                    .build();
-                PrimitiveArray::from(array_data)
+                PrimitiveArray::from_iter(data.iter())
             }
         }
     };

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -16,8 +16,8 @@
 // under the License.
 
 use std::any::Any;
-use std::convert::{From, TryFrom};
 use std::borrow::Borrow;
+use std::convert::{From, TryFrom};
 use std::fmt;
 use std::io::Write;
 use std::iter::{FromIterator, IntoIterator};

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -716,7 +716,7 @@ impl<T: ArrowPrimitiveType, Ptr: Borrow<Option<<T as ArrowPrimitiveType>::Native
     fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (_, data_len) = iter.size_hint();
-        let data_len = data_len.unwrap(); // panic if no upper bound.
+        let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
 
         let num_bytes = bit_util::ceil(data_len, 8);
         let mut null_buf = MutableBuffer::new(num_bytes).with_bitset(num_bytes, false);

--- a/rust/arrow/src/array/iterator.rs
+++ b/rust/arrow/src/array/iterator.rs
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::datatypes::ArrowPrimitiveType;
+
+use super::{Array, PrimitiveArray, PrimitiveArrayOps};
+
+/// an iterator that returns Some(T) or None, that can be used on any non-boolean PrimitiveArray
+#[derive(Debug)]
+pub struct PrimitiveIter<'a, T: ArrowPrimitiveType> {
+    array: &'a PrimitiveArray<T>,
+    i: usize,
+    len: usize,
+}
+
+impl<'a, T: ArrowPrimitiveType> PrimitiveIter<'a, T> {
+    /// create a new iterator
+    pub fn new(array: &'a PrimitiveArray<T>) -> Self {
+        PrimitiveIter::<T> {
+            array,
+            i: 0,
+            len: array.len(),
+        }
+    }
+}
+
+impl<'a, T: ArrowPrimitiveType> std::iter::Iterator for PrimitiveIter<'a, T> {
+    type Item = Option<T::Native>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let i = self.i;
+        if i >= self.len {
+            None
+        } else if self.array.is_null(i) {
+            self.i += 1;
+            Some(None)
+        } else {
+            self.i += 1;
+            Some(Some(self.array.value(i)))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::array::{ArrayRef, Int32Array};
+
+    #[test]
+    fn test_primitive_array_iter_round_trip() {
+        let array = Int32Array::from(vec![Some(0), None, Some(2), None, Some(4)]);
+        let array = Arc::new(array) as ArrayRef;
+
+        let array = array.as_any().downcast_ref::<Int32Array>().unwrap();
+
+        // to and from iter, with a +1
+        let result: Int32Array =
+            array.iter().map(|e| e.and_then(|e| Some(e + 1))).collect();
+
+        let expected = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        assert_eq!(result, expected);
+    }
+}

--- a/rust/arrow/src/array/iterator.rs
+++ b/rust/arrow/src/array/iterator.rs
@@ -59,6 +59,9 @@ impl<'a, T: ArrowPrimitiveType> std::iter::Iterator for PrimitiveIter<'a, T> {
     }
 }
 
+/// all arrays have known size.
+impl<'a, T: ArrowPrimitiveType> std::iter::ExactSizeIterator for PrimitiveIter<'a, T> {}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -87,6 +87,7 @@ mod builder;
 mod cast;
 mod data;
 mod equal;
+mod iterator;
 mod null;
 mod ord;
 mod union;
@@ -238,6 +239,10 @@ pub type DurationSecondBuilder = PrimitiveBuilder<DurationSecondType>;
 pub type DurationMillisecondBuilder = PrimitiveBuilder<DurationMillisecondType>;
 pub type DurationMicrosecondBuilder = PrimitiveBuilder<DurationMicrosecondType>;
 pub type DurationNanosecondBuilder = PrimitiveBuilder<DurationNanosecondType>;
+
+// --------------------- Array Iterator ---------------------
+
+pub use self::iterator::*;
 
 // --------------------- Array Equality ---------------------
 

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -50,7 +50,7 @@ use std::sync::Arc;
 
 use csv as csv_crate;
 
-use crate::array::{ArrayRef, PrimitiveBuilder, StringBuilder};
+use crate::array::{ArrayRef, PrimitiveArray, StringBuilder};
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 use crate::record_batch::RecordBatch;
@@ -417,34 +417,38 @@ impl<R: Read> Reader<R> {
         rows: &[StringRecord],
         col_idx: usize,
     ) -> Result<ArrayRef> {
-        let mut builder = PrimitiveBuilder::<T>::new(rows.len());
         let is_boolean_type =
             *self.schema.field(col_idx).data_type() == DataType::Boolean;
-        for (row_index, row) in rows.iter().enumerate() {
-            match row.get(col_idx) {
-                Some(s) if !s.is_empty() => {
-                    let t = if is_boolean_type {
-                        s.to_lowercase().parse::<T::Native>()
-                    } else {
-                        s.parse::<T::Native>()
-                    };
-                    match t {
-                        Ok(v) => builder.append_value(v)?,
-                        Err(_) => {
-                            // TODO: we should surface the underlying error here.
-                            return Err(ArrowError::ParseError(format!(
+
+        rows.iter()
+            .enumerate()
+            .map(|(row_index, row)| {
+                match row.get(col_idx) {
+                    Some(s) => {
+                        if s.is_empty() {
+                            return Ok(None);
+                        }
+                        let parsed = if is_boolean_type {
+                            s.to_lowercase().parse::<T::Native>()
+                        } else {
+                            s.parse::<T::Native>()
+                        };
+                        match parsed {
+                            Ok(e) => Ok(Some(e)),
+                            Err(_) => Err(ArrowError::ParseError(format!(
+                                // TODO: we should surface the underlying error here.
                                 "Error while parsing value {} for column {} at line {}",
                                 s,
                                 col_idx,
                                 self.line_number + row_index
-                            )));
+                            ))),
                         }
                     }
+                    None => Ok(None),
                 }
-                _ => builder.append_null()?,
-            }
-        }
-        Ok(Arc::new(builder.finish()))
+            })
+            .collect::<Result<PrimitiveArray<T>>>()
+            .map(|e| Arc::new(e) as ArrayRef)
     }
 }
 

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -671,22 +671,15 @@ impl<R: Read> Reader<R> {
         T: ArrowNumericType,
         T::Native: num::NumCast,
     {
-        let mut builder = PrimitiveBuilder::<T>::new(rows.len());
-        for row in rows {
-            if let Some(value) = row.get(&col_name) {
-                // check that value is of expected datatype
-                match value.as_f64() {
-                    Some(v) => match num::cast::cast(v) {
-                        Some(v) => builder.append_value(v)?,
-                        None => builder.append_null()?,
-                    },
-                    None => builder.append_null()?,
-                }
-            } else {
-                builder.append_null()?;
-            }
-        }
-        Ok(Arc::new(builder.finish()))
+        Ok(Arc::new(
+            rows.iter()
+                .map(|row| {
+                    row.get(&col_name)
+                        .and_then(|value| value.as_f64())
+                        .and_then(|v| num::cast::cast(v))
+                })
+                .collect::<PrimitiveArray<T>>(),
+        ))
     }
 
     fn build_list_array<T: ArrowPrimitiveType>(

--- a/rust/arrow/src/json/reader.rs
+++ b/rust/arrow/src/json/reader.rs
@@ -676,7 +676,7 @@ impl<R: Read> Reader<R> {
                 .map(|row| {
                     row.get(&col_name)
                         .and_then(|value| value.as_f64())
-                        .and_then(|v| num::cast::cast(v))
+                        .and_then(num::cast::cast)
                 })
                 .collect::<PrimitiveArray<T>>(),
         ))


### PR DESCRIPTION
This is the associated draft implementation of a draft proposal on ARROW-10030, with associated document here: https://docs.google.com/document/d/1d6rV1WmvIH6uW-bcHKrYBSyPddrpXH8Q4CtVfFHtI04/edit



<details><summary>Benchmarks where the builder was replaced by this from for the `cast`: +5% to -25% improvement over the builder (with the same memory utilization)</summary>
<p>

```
cast int32 to int32 512 time:   [25.493 ns 25.498 ns 25.505 ns]                                     
                        change: [+1.2840% +1.7037% +2.1989%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) high mild
  11 (11.00%) high severe

cast int32 to uint32 512                                                                             
                        time:   [6.8259 us 6.8323 us 6.8390 us]
                        change: [+3.6216% +5.6472% +7.0263%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) high mild
  7 (7.00%) high severe

cast int32 to float32 512                                                                             
                        time:   [5.7733 us 5.7763 us 5.7795 us]
                        change: [-14.264% -13.671% -13.106%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe

cast int32 to float64 512                                                                             
                        time:   [5.2627 us 5.2667 us 5.2711 us]
                        change: [-23.365% -22.746% -22.147%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

cast int32 to int64 512 time:   [5.2307 us 5.2381 us 5.2438 us]                                     
                        change: [-21.490% -20.984% -20.509%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

cast float32 to int32 512                                                                             
                        time:   [6.2755 us 6.2794 us 6.2833 us]
                        change: [-10.606% -9.9724% -9.3770%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

cast float64 to float32 512                                                                             
                        time:   [6.1900 us 6.2032 us 6.2206 us]
                        change: [-14.505% -13.963% -13.416%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

cast float64 to uint64 512                                                                             
                        time:   [6.4047 us 6.4189 us 6.4347 us]
                        change: [-12.287% -11.651% -11.050%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

cast int64 to int32 512 time:   [6.3697 us 6.3913 us 6.4168 us]                                     
                        change: [+3.5998% +4.2837% +4.9649%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

cast date64 to date32 512                                                                             
                        time:   [8.4563 us 8.4631 us 8.4702 us]
                        change: [+0.2066% +0.9093% +1.6066%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) high mild
  7 (7.00%) high severe

cast date32 to date64 512                                                                             
                        time:   [8.0482 us 8.0610 us 8.0823 us]
                        change: [+0.2428% +0.8807% +1.5657%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe

cast time32s to time32ms 512                                                                             
                        time:   [2.2259 us 2.2294 us 2.2333 us]
                        change: [-2.3114% -1.6027% -0.7039%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

cast time32s to time64us 512                                                                             
                        time:   [7.8948 us 7.9060 us 7.9179 us]
                        change: [-27.022% -25.727% -24.361%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

cast time64ns to time32s 512                                                                             
                        time:   [11.546 us 11.558 us 11.571 us]
                        change: [-0.9659% -0.3235% +0.2847%] (p = 0.33 > 0.05)
                        No change in performance detected.
Found 19 outliers among 100 measurements (19.00%)
  2 (2.00%) low severe
  8 (8.00%) low mild
  1 (1.00%) high mild
  8 (8.00%) high severe

cast timestamp_ns to timestamp_s 512                                                                             
                        time:   [27.676 ns 27.690 ns 27.714 ns]
                        change: [+0.9641% +1.2917% +1.6195%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe

cast timestamp_ms to timestamp_ns 512                                                                             
                        time:   [2.8195 us 2.8238 us 2.8300 us]
                        change: [-0.4123% +0.7148% +1.6494%] (p = 0.19 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) high mild
  6 (6.00%) high severe

cast timestamp_ms to i64 512                                                                            
                        time:   [398.49 ns 399.60 ns 400.91 ns]
                        change: [-6.2549% -5.5279% -4.7295%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  5 (5.00%) high mild
  12 (12.00%) high severe
```

</p>
</details>
