### PR TITLE
ARROW-10034: [Rust] Fix Rust build on master

### DIFF
--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -19,41 +19,8 @@
 
 use std::ops::Add;
 
-use crate::array::{Array, LargeStringArray, PrimitiveArray, StringArray};
+use crate::array::{Array, PrimitiveArray};
 use crate::datatypes::ArrowNumericType;
-
-/// Helper macro to perform min/max of strings
-macro_rules! min_max_string_helper {
-    ($array:expr, $cmp:tt) => {{
-        let null_count = $array.null_count();
-
-        if null_count == $array.len() {
-            return None
-        }
-        let mut n = "";
-        let mut has_value = false;
-        let data = $array.data();
-
-        if null_count == 0 {
-            for i in 0..data.len() {
-                let item = $array.value(i);
-                if !has_value || (&n $cmp &item) {
-                    has_value = true;
-                    n = item;
-                }
-            }
-        } else {
-            for i in 0..data.len() {
-                let item = $array.value(i);
-                if data.is_valid(i) && (!has_value || (&n $cmp &item)) {
-                    has_value = true;
-                    n = item;
-                }
-            }
-        }
-        Some(n)
-    }}
-}
 
 /// Returns the minimum value in the array, according to the natural order.
 pub fn min<T>(array: &PrimitiveArray<T>) -> Option<T::Native>
@@ -69,26 +36,6 @@ where
     T: ArrowNumericType,
 {
     min_max_helper(array, |a, b| a < b)
-}
-
-/// Returns the maximum value in the string array, according to the natural order.
-pub fn max_string(array: &StringArray) -> Option<&str> {
-    min_max_string_helper!(array, <)
-}
-
-/// Returns the minimum value in the string array, according to the natural order.
-pub fn min_string(array: &StringArray) -> Option<&str> {
-    min_max_string_helper!(array, >)
-}
-
-/// Returns the minimum value in the string array, according to the natural order.
-pub fn max_large_string(array: &LargeStringArray) -> Option<&str> {
-    min_max_string_helper!(array, <)
-}
-
-/// Returns the minimum value in the string array, according to the natural order.
-pub fn min_large_string(array: &LargeStringArray) -> Option<&str> {
-    min_max_string_helper!(array, >)
 }
 
 /// Helper function to perform min/max lambda function on values from a numeric array.
@@ -118,7 +65,7 @@ where
         }
     } else {
         for (i, item) in m.iter().enumerate() {
-            if data.is_valid(i) && (!has_value || cmp(&n, item)) {
+            if !has_value || data.is_valid(i) && cmp(&n, item) {
                 has_value = true;
                 n = *item
             }
@@ -201,33 +148,5 @@ mod tests {
         let a = Int32Array::from(vec![Some(5), None, None, Some(8), Some(9)]);
         assert_eq!(5, min(&a).unwrap());
         assert_eq!(9, max(&a).unwrap());
-    }
-
-    #[test]
-    fn test_buffer_min_max_1() {
-        let a = Int32Array::from(vec![None, None, Some(5), Some(2)]);
-        assert_eq!(Some(2), min(&a));
-        assert_eq!(Some(5), max(&a));
-    }
-
-    #[test]
-    fn test_string_min_max_with_nulls() {
-        let a = StringArray::from(vec![Some("b"), None, None, Some("a"), Some("c")]);
-        assert_eq!("a", min_string(&a).unwrap());
-        assert_eq!("c", max_string(&a).unwrap());
-    }
-
-    #[test]
-    fn test_string_min_max_all_nulls() {
-        let a = StringArray::from(vec![None, None]);
-        assert_eq!(None, min_string(&a));
-        assert_eq!(None, max_string(&a));
-    }
-
-    #[test]
-    fn test_string_min_max_1() {
-        let a = StringArray::from(vec![None, None, Some("b"), Some("a")]);
-        assert_eq!(Some("a"), min_string(&a));
-        assert_eq!(Some("b"), max_string(&a));
     }
 }

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -185,7 +185,7 @@ pub fn exprlist_to_fields(expr: &[Expr], input_schema: &Schema) -> Result<Vec<Fi
 /// # use datafusion::logical_plan::Expr;
 /// # use datafusion::error::Result;
 /// # fn main() -> Result<()> {
-/// let expr = Expr::Column("c1".to_string()).plus(Expr::Column("c2".to_string()));
+/// let expr = Expr::Column("c1".to_string()) + Expr::Column("c2".to_string());
 /// println!("{:?}", expr);
 /// # Ok(())
 /// # }


### PR DESCRIPTION
Reverts ARROW-9977 and fixes one other conflict.

I was seeing compilation errors like this:

```
error[E0599]: no method named `value` found for reference `&array::array::StringArray` in the current scope
  --> arrow/src/compute/kernels/aggregate.rs:39:35
   |
39 |                 let item = $array.value(i);
   |                                   ^^^^^ method not found in `&array::array::StringArray`
```