### PR TITLE
ARROW-9965: [Java] Improve performance of BaseFixedWidthVector.setSafe by optimizing capacity calculations

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -194,11 +194,11 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     actualValueCapacity = Math.min(getValueBufferValueCapacity(), getValidityBufferValueCapacity());
   }
 
-  private int getValueBufferValueCapacity() {
+  protected int getValueBufferValueCapacity() {
     return capAtMaxInt(valueBuffer.capacity() / typeWidth);
   }
 
-  private int getValidityBufferValueCapacity() {
+  protected int getValidityBufferValueCapacity() {
     return capAtMaxInt(validityBuffer.capacity() * 8);
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseFixedWidthVector.java
@@ -48,7 +48,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
         implements FixedWidthVector, FieldVector, VectorDefinitionSetter {
   private final int typeWidth;
 
-  protected int lastTargetValueCapacity;
+  protected int lastValueCapacity;
   protected int actualValueCapacity;
 
   protected final Field field;
@@ -72,7 +72,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     allocationMonitor = 0;
     validityBuffer = allocator.getEmpty();
     valueBuffer = allocator.getEmpty();
-    lastTargetValueCapacity = INITIAL_VALUE_ALLOCATION;
+    lastValueCapacity = INITIAL_VALUE_ALLOCATION;
     refreshValueCapacity();
   }
 
@@ -174,7 +174,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   @Override
   public void setInitialCapacity(int valueCount) {
     computeAndCheckBufferSize(valueCount);
-    lastTargetValueCapacity = valueCount;
+    lastValueCapacity = valueCount;
   }
 
   /**
@@ -271,7 +271,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
    */
   @Override
   public void allocateNew() {
-    allocateNew(lastTargetValueCapacity);
+    allocateNew(lastValueCapacity);
   }
 
   /**
@@ -285,7 +285,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   @Override
   public boolean allocateNewSafe() {
     try {
-      allocateNew(lastTargetValueCapacity);
+      allocateNew(lastValueCapacity);
       return true;
     } catch (Exception e) {
       return false;
@@ -342,7 +342,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     zeroVector();
 
     refreshValueCapacity();
-    lastTargetValueCapacity = getValueCapacity();
+    lastValueCapacity = getValueCapacity();
   }
 
   /**
@@ -432,8 +432,8 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
   public void reAlloc() {
     int targetValueCount = getValueCapacity() * 2;
     if (targetValueCount == 0) {
-      if (lastTargetValueCapacity > 0) {
-        targetValueCount = lastTargetValueCapacity;
+      if (lastValueCapacity > 0) {
+        targetValueCount = lastValueCapacity;
       } else {
         targetValueCount = INITIAL_VALUE_ALLOCATION * 2;
       }
@@ -454,7 +454,7 @@ public abstract class BaseFixedWidthVector extends BaseValueVector
     validityBuffer = newValidityBuffer;
 
     refreshValueCapacity();
-    lastTargetValueCapacity = getValueCapacity();
+    lastValueCapacity = getValueCapacity();
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -121,7 +121,15 @@ public final class BitVector extends BaseFixedWidthVector {
 
   @Override
   protected void refreshValueCapacity() {
-    actualValueCapacity = capAtMaxInt(validityBuffer.capacity() * 8);
+    actualValueCapacity = Math.min(getValueBufferValueCapacity(), getValidityBufferValueCapacity());
+  }
+
+  private int getValueBufferValueCapacity() {
+    return capAtMaxInt(valueBuffer.capacity() * 8);
+  }
+
+  private int getValidityBufferValueCapacity() {
+    return capAtMaxInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -120,16 +120,8 @@ public final class BitVector extends BaseFixedWidthVector {
   }
 
   @Override
-  protected void refreshValueCapacity() {
-    actualValueCapacity = Math.min(getValueBufferValueCapacity(), getValidityBufferValueCapacity());
-  }
-
-  private int getValueBufferValueCapacity() {
+  protected int getValueBufferValueCapacity() {
     return capAtMaxInt(valueBuffer.capacity() * 8);
-  }
-
-  private int getValidityBufferValueCapacity() {
-    return capAtMaxInt(validityBuffer.capacity() * 8);
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -119,16 +119,6 @@ public final class BitVector extends BaseFixedWidthVector {
     lastValueCapacity = valueCount;
   }
 
-  /**
-   * Get the current value capacity for the vector.
-   *
-   * @return number of elements that vector can hold.
-   */
-  @Override
-  public int getValueCapacity() {
-    return actualValueCapacity;
-  }
-
   @Override
   protected void refreshValueCapacity() {
     actualValueCapacity = capAtMaxInt(validityBuffer.capacity() * 8);

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -116,7 +116,7 @@ public final class BitVector extends BaseFixedWidthVector {
     if (size * 2 > MAX_ALLOCATION_SIZE) {
       throw new OversizedAllocationException("Requested amount of memory is more than max allowed");
     }
-    lastTargetValueCapacity = valueCount;
+    lastValueCapacity = valueCount;
   }
 
   /**

--- a/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BitVector.java
@@ -116,7 +116,7 @@ public final class BitVector extends BaseFixedWidthVector {
     if (size * 2 > MAX_ALLOCATION_SIZE) {
       throw new OversizedAllocationException("Requested amount of memory is more than max allowed");
     }
-    lastValueCapacity = valueCount;
+    lastTargetValueCapacity = valueCount;
   }
 
   /**
@@ -126,7 +126,12 @@ public final class BitVector extends BaseFixedWidthVector {
    */
   @Override
   public int getValueCapacity() {
-    return capAtMaxInt(validityBuffer.capacity() * 8);
+    return actualValueCapacity;
+  }
+
+  @Override
+  protected void refreshValueCapacity() {
+    actualValueCapacity = capAtMaxInt(validityBuffer.capacity() * 8);
   }
 
   /**
@@ -171,6 +176,7 @@ public final class BitVector extends BaseFixedWidthVector {
             validityBuffer, target.validityBuffer);
     target.valueBuffer = splitAndTransferBuffer(startIndex, length, target,
             valueBuffer, target.valueBuffer);
+    target.refreshValueCapacity();
 
     target.setValueCount(length);
   }


### PR DESCRIPTION
It turns out that setSafe performs a very expensive integer division when trying to compute buffer capacity; specifically, it divides by the field size, which isn't hardcoded. Although it is typically a power of 2, this doesn't compile down to a bitshift.

Special-casing and forcing a bitshift operation results in a ~300% increase in benchmarks that use a hot loop to set Arrow vectors. We have a similar use-case in an internal data-intensive service.

Benchmark results with arrow.enable_unsafe_memory_access=true

Before:
```
Benchmark Mode Cnt Score Error Units
IntBenchmarks.setIntDirectly avgt 15 9.563 ± 0.335 us/op
IntBenchmarks.setWithValueHolder avgt 15 9.266 ± 0.064 us/op
IntBenchmarks.setWithWriter avgt 15 18.806 ± 0.154 us/op
```

After:
```
Benchmark Mode Cnt Score Error Units
IntBenchmarks.setIntDirectly avgt 15 3.490 ± 0.175 us/op
IntBenchmarks.setWithValueHolder avgt 15 3.806 ± 0.015 us/op
IntBenchmarks.setWithWriter avgt 15 5.490 ± 0.304 us/op
```

See https://issues.apache.org/jira/browse/ARROW-9965 for further benchmarks, and an analysis of the root cause of the slowdown.