### PR TITLE
ARROW-10037: [C++] Workaround to force find AWS SDK to look for shared libraries

### DIFF
--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -89,7 +89,7 @@ pushd cpp\build
 @rem and enable runtime assertions.
 
 cmake -G "%GENERATOR%" %CMAKE_ARGS% ^
-      -DARROW_BOOST_USE_SHARED=OFF ^
+      -DARROW_BOOST_USE_SHARED=ON ^
       -DARROW_BUILD_EXAMPLES=ON ^
       -DARROW_BUILD_STATIC=OFF ^
       -DARROW_BUILD_TESTS=ON ^

--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -62,7 +62,6 @@ if "%JOB%" NEQ "Build_Debug" (
     --file=ci\conda_env_python.yml ^
     %CONDA_PACKAGES%  ^
     "cmake=3.17" ^
-    "boost-cpp<1.70" ^
     "ninja" ^
     "nomkl" ^
     "pandas" ^

--- a/ci/conda_env_cpp.yml
+++ b/ci/conda_env_cpp.yml
@@ -17,7 +17,7 @@
 
 aws-sdk-cpp
 benchmark=1.4.1
-boost-cpp>=1.68.0
+boost-cpp>=1.72.0
 brotli
 bzip2
 c-ares

--- a/ci/conda_env_cpp.yml
+++ b/ci/conda_env_cpp.yml
@@ -17,7 +17,7 @@
 
 aws-sdk-cpp
 benchmark=1.4.1
-boost-cpp>=1.72.0
+boost-cpp>=1.68.0
 brotli
 bzip2
 c-ares

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2675,29 +2675,35 @@ endmacro()
 if(ARROW_S3)
   # See https://aws.amazon.com/blogs/developer/developer-experience-of-the-aws-sdk-for-c-now-simplified-by-cmake/
 
+  # Workaround to force AWS cmake configuration to look for shared libraries
+  if(DEFINED ENV{CONDA_PREFIX})
+    set(BUILD_SHARED_LIBS "ON")
+  endif()
+
   # Need to customize the find_package() call, so cannot call resolve_dependency()
   if(AWSSDK_SOURCE STREQUAL "AUTO")
-    set(BUILD_SHARED_LIBS "ON")
+
     find_package(AWSSDK
                  COMPONENTS config
                             s3
                             transfer
                             identity-management
                             sts)
-    unset(BUILD_SHARED_LIBS)
     if(NOT AWSSDK_FOUND)
       build_awssdk()
     endif()
   elseif(AWSSDK_SOURCE STREQUAL "BUNDLED")
     build_awssdk()
   elseif(AWSSDK_SOURCE STREQUAL "SYSTEM")
-    set(BUILD_SHARED_LIBS "ON")
     find_package(AWSSDK REQUIRED
                  COMPONENTS config
                             s3
                             transfer
                             identity-management
                             sts)
+  endif()
+
+  if(DEFINED ENV{CONDA_PREFIX})
     unset(BUILD_SHARED_LIBS)
   endif()
 

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2677,6 +2677,12 @@ if(ARROW_S3)
 
   # Workaround to force AWS cmake configuration to look for shared libraries
   if(DEFINED ENV{CONDA_PREFIX})
+    if (DEFINED BUILD_SHARED_LIBS)
+      set(BUILD_SHARED_LIBS_WAS_SET TRUE)
+      set(BUILD_SHARED_LIBS_VALUE ${BUILD_SHARED_LIBS})
+    else()
+      set(BUILD_SHARED_LIBS_WAS_SET FALSE)
+    endif()
     set(BUILD_SHARED_LIBS "ON")
   endif()
 
@@ -2702,8 +2708,13 @@ if(ARROW_S3)
                             sts)
   endif()
 
+  # Restore previous value of BUILD_SHARED_LIBS
   if(DEFINED ENV{CONDA_PREFIX})
-    unset(BUILD_SHARED_LIBS)
+    if (BUILD_SHARED_LIBS_WAS_SET)
+      set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_VALUE})
+    else()
+      unset(BUILD_SHARED_LIBS)
+    endif()
   endif()
 
   include_directories(SYSTEM ${AWSSDK_INCLUDE_DIR})

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2682,7 +2682,6 @@ if(ARROW_S3)
 
   # Need to customize the find_package() call, so cannot call resolve_dependency()
   if(AWSSDK_SOURCE STREQUAL "AUTO")
-
     find_package(AWSSDK
                  COMPONENTS config
                             s3

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2677,24 +2677,28 @@ if(ARROW_S3)
 
   # Need to customize the find_package() call, so cannot call resolve_dependency()
   if(AWSSDK_SOURCE STREQUAL "AUTO")
+    set(BUILD_SHARED_LIBS "ON")
     find_package(AWSSDK
                  COMPONENTS config
                             s3
                             transfer
                             identity-management
                             sts)
+    unset(BUILD_SHARED_LIBS)
     if(NOT AWSSDK_FOUND)
       build_awssdk()
     endif()
   elseif(AWSSDK_SOURCE STREQUAL "BUNDLED")
     build_awssdk()
   elseif(AWSSDK_SOURCE STREQUAL "SYSTEM")
+    set(BUILD_SHARED_LIBS "ON")
     find_package(AWSSDK REQUIRED
                  COMPONENTS config
                             s3
                             transfer
                             identity-management
                             sts)
+    unset(BUILD_SHARED_LIBS)
   endif()
 
   include_directories(SYSTEM ${AWSSDK_INCLUDE_DIR})

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2677,7 +2677,7 @@ if(ARROW_S3)
 
   # Workaround to force AWS cmake configuration to look for shared libraries
   if(DEFINED ENV{CONDA_PREFIX})
-    if (DEFINED BUILD_SHARED_LIBS)
+    if(DEFINED BUILD_SHARED_LIBS)
       set(BUILD_SHARED_LIBS_WAS_SET TRUE)
       set(BUILD_SHARED_LIBS_VALUE ${BUILD_SHARED_LIBS})
     else()
@@ -2710,7 +2710,7 @@ if(ARROW_S3)
 
   # Restore previous value of BUILD_SHARED_LIBS
   if(DEFINED ENV{CONDA_PREFIX})
-    if (BUILD_SHARED_LIBS_WAS_SET)
+    if(BUILD_SHARED_LIBS_WAS_SET)
       set(BUILD_SHARED_LIBS ${BUILD_SHARED_LIBS_VALUE})
     else()
       unset(BUILD_SHARED_LIBS)


### PR DESCRIPTION
Since the recent conda forge feedstock update find aws sdk fails to locate the proper aws sdk cmake files: https://github.com/apache/arrow/runs/1131824712#step:8:3700