### PR TITLE
ARROW-9338: [Rust]  Add clippy instructions

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -66,6 +66,25 @@ and check for lint issues:
 cargo +stable fmt --all -- --check
 ```
 
+## Clippy Lints
+
+We recommend using `clippy` for checking lints during development. While we do not yet enforce `clippy` checks, we recommend not introducing new `clippy` errors or warnings.
+
+Run the following to check for clippy lints.
+
+```
+cargo clippy
+```
+
+If you use Visual Studio Code with the `rust-analyzer` plugin, you can enable `clippy` to run each time you save a file. See https://users.rust-lang.org/t/how-to-use-clippy-in-vs-code-with-rust-analyzer/41881.
+
+One of the concerns with `clippy` is that it often produces a lot of false positives, or that some recommendations may hurt readability. We do not have a policy of which lints are ignored, but if you disagree with a `clippy` lint, you may disable the lint and briefly justify it.
+
+Search for `allow(clippy::` in the codebase to identify lints that are ignored/allowed. We currently prefer ignoring lints on the lowest unit possible.
+* If you are introducing a line that returns a lint warning or error, you may disable the lint on that line.
+* If you have several lints on a function or module, you may disable the lint on the function or module.
+* If a lint is pervasive across multiple modules, you may disable it at the crate level.
+
 ## CI and Dockerized builds
 
 There are currently multiple CI systems that build the project and they all use the same docker image. It is possible to run the same build locally.


### PR DESCRIPTION
Add instructions on how to run `clippy` locally. 