### PR TITLE
ARROW-10040: [Rust] Add slice that realigns Buffer

### DIFF
--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -225,10 +225,8 @@ fn take_boolean(values: &ArrayRef, indices: &UInt32Array) -> Result<ArrayRef> {
         let index = indices.value(i) as usize;
         if array.is_null(index) {
             bit_util::unset_bit(null_slice, i);
-        } else {
-            if array.value(index) {
-                bit_util::set_bit(val_slice, i);
-            }
+        } else if array.value(index) {
+            bit_util::set_bit(val_slice, i);
         }
     });
 

--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -351,9 +351,9 @@ mod tests {
             unsafe {
                 set_bits_raw(buf.as_mut_ptr(), start, end);
             }
-            for i in start..end {
+            (start..end).for_each(|i| {
                 expected[i] = true;
-            }
+            });
         }
 
         let raw_ptr = buf.as_ptr();


### PR DESCRIPTION
Has the consequence of removing the alignment limit on bool kernels.
It however comes at the cost of slower buffer manipulation.