### PR TITLE
ARROW-10046: [Rust] [DataFusion] Made `RecordBatchReader` implement Iterator

### DIFF
--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -315,7 +315,7 @@ impl<R: Read> Reader<R> {
 
     /// Read the next batch of rows
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Result<Option<RecordBatch>> {
+    pub fn next(&mut self) -> Option<Result<RecordBatch>> {
         // read a batch of rows into memory
         let mut rows: Vec<StringRecord> = Vec::with_capacity(self.batch_size);
         for i in 0..self.batch_size {
@@ -324,11 +324,11 @@ impl<R: Read> Reader<R> {
                     rows.push(r);
                 }
                 Some(Err(e)) => {
-                    return Err(ArrowError::ParseError(format!(
+                    return Some(Err(ArrowError::ParseError(format!(
                         "Error parsing line {}: {:?}",
                         self.line_number + i,
                         e
-                    )));
+                    ))));
                 }
                 None => break,
             }
@@ -336,7 +336,7 @@ impl<R: Read> Reader<R> {
 
         // return early if no data was loaded
         if rows.is_empty() {
-            return Ok(None);
+            return None;
         }
 
         let projection: Vec<usize> = match self.projection {
@@ -409,7 +409,7 @@ impl<R: Read> Reader<R> {
 
         let projected_schema = Arc::new(Schema::new(projected_fields));
 
-        arrays.and_then(|arr| RecordBatch::try_new(projected_schema, arr).map(Some))
+        Some(arrays.and_then(|arr| RecordBatch::try_new(projected_schema, arr)))
     }
 
     fn build_primitive_array<T: ArrowPrimitiveType>(
@@ -445,6 +445,14 @@ impl<R: Read> Reader<R> {
             }
         }
         Ok(Arc::new(builder.finish()))
+    }
+}
+
+impl<R: Read> Iterator for Reader<R> {
+    type Item = Result<RecordBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next()
     }
 }
 
@@ -832,11 +840,14 @@ mod tests {
 
         let mut csv = builder.build(file).unwrap();
         match csv.next() {
-            Err(e) => assert_eq!(
-                "ParseError(\"Error while parsing value 4.x4 for column 1 at line 4\")",
-                format!("{:?}", e)
-            ),
-            Ok(_) => panic!("should have failed"),
+            Some(e) => match e {
+                Err(e) => assert_eq!(
+                    "ParseError(\"Error while parsing value 4.x4 for column 1 at line 4\")",
+                    format!("{:?}", e)
+                ),
+                Ok(_) => panic!("should have failed"),
+            }
+            None => panic!("should have failed"),
         }
     }
 

--- a/rust/arrow/src/ipc/reader.rs
+++ b/rust/arrow/src/ipc/reader.rs
@@ -414,7 +414,7 @@ pub fn read_record_batch(
     batch: ipc::RecordBatch,
     schema: SchemaRef,
     dictionaries: &[Option<ArrayRef>],
-) -> Result<Option<RecordBatch>> {
+) -> Result<RecordBatch> {
     let buffers = batch.buffers().ok_or_else(|| {
         ArrowError::IoError("Unable to get buffers from IPC RecordBatch".to_string())
     })?;
@@ -442,7 +442,7 @@ pub fn read_record_batch(
         arrays.push(triple.0);
     }
 
-    RecordBatch::try_new(schema, arrays).map(Some)
+    RecordBatch::try_new(schema, arrays)
 }
 
 // Linear search for the first dictionary field with a dictionary id.
@@ -592,8 +592,7 @@ impl<R: Read + Seek> FileReader<R> {
                                     batch.data().unwrap(),
                                     Arc::new(schema),
                                     &dictionaries_by_field,
-                                )?
-                                .unwrap();
+                                )?;
                                 Some(record_batch.column(0).clone())
                             }
                             _ => None,
@@ -662,6 +661,67 @@ impl<R: Read + Seek> FileReader<R> {
             Ok(())
         }
     }
+
+    fn maybe_next(&mut self) -> Result<Option<RecordBatch>> {
+        let block = self.blocks[self.current_block];
+        self.current_block += 1;
+
+        // read length
+        self.reader.seek(SeekFrom::Start(block.offset() as u64))?;
+        let mut meta_buf = [0; 4];
+        self.reader.read_exact(&mut meta_buf)?;
+        if meta_buf == CONTINUATION_MARKER {
+            // continuation marker encountered, read message next
+            self.reader.read_exact(&mut meta_buf)?;
+        }
+        let meta_len = i32::from_le_bytes(meta_buf);
+
+        let mut block_data = vec![0; meta_len as usize];
+        self.reader.read_exact(&mut block_data)?;
+
+        let message = ipc::get_root_as_message(&block_data[..]);
+
+        // some old test data's footer metadata is not set, so we account for that
+        if self.metadata_version != ipc::MetadataVersion::V1
+            && message.version() != self.metadata_version
+        {
+            return Err(ArrowError::IoError(
+                "Could not read IPC message as metadata versions mismatch".to_string(),
+            ));
+        }
+
+        match message.header_type() {
+            ipc::MessageHeader::Schema => Err(ArrowError::IoError(
+                "Not expecting a schema when messages are read".to_string(),
+            )),
+            ipc::MessageHeader::RecordBatch => {
+                let batch = message.header_as_record_batch().ok_or_else(|| {
+                    ArrowError::IoError(
+                        "Unable to read IPC message as record batch".to_string(),
+                    )
+                })?;
+                // read the block that makes up the record batch into a buffer
+                let mut buf = vec![0; block.bodyLength() as usize];
+                self.reader.seek(SeekFrom::Start(
+                    block.offset() as u64 + block.metaDataLength() as u64,
+                ))?;
+                self.reader.read_exact(&mut buf)?;
+
+                read_record_batch(
+                    &buf,
+                    batch,
+                    self.schema(),
+                    &self.dictionaries_by_field,
+                ).map(Some)
+            }
+            ipc::MessageHeader::NONE => {
+                Ok(None)
+            }
+            t => Err(ArrowError::IoError(format!(
+                "Reading types other than record batches not yet supported, unable to read {:?}", t
+            ))),
+        }
+    }
 }
 
 impl<R: Read + Seek> RecordBatchReader for FileReader<R> {
@@ -669,70 +729,17 @@ impl<R: Read + Seek> RecordBatchReader for FileReader<R> {
         self.schema.clone()
     }
 
-    fn next_batch(&mut self) -> Result<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> Option<Result<RecordBatch>> {
         // get current block
         if self.current_block < self.total_blocks {
-            let block = self.blocks[self.current_block];
-            self.current_block += 1;
-
-            // read length
-            self.reader.seek(SeekFrom::Start(block.offset() as u64))?;
-            let mut meta_buf = [0; 4];
-            self.reader.read_exact(&mut meta_buf)?;
-            if meta_buf == CONTINUATION_MARKER {
-                // continuation marker encountered, read message next
-                self.reader.read_exact(&mut meta_buf)?;
-            }
-            let meta_len = i32::from_le_bytes(meta_buf);
-
-            let mut block_data = vec![0; meta_len as usize];
-            self.reader.read_exact(&mut block_data)?;
-
-            let message = ipc::get_root_as_message(&block_data[..]);
-
-            // some old test data's footer metadata is not set, so we account for that
-            if self.metadata_version != ipc::MetadataVersion::V1
-                && message.version() != self.metadata_version
-            {
-                return Err(ArrowError::IoError(
-                    "Could not read IPC message as metadata versions mismatch"
-                        .to_string(),
-                ));
-            }
-
-            match message.header_type() {
-                ipc::MessageHeader::Schema => Err(ArrowError::IoError(
-                    "Not expecting a schema when messages are read".to_string(),
-                )),
-                ipc::MessageHeader::RecordBatch => {
-                    let batch = message.header_as_record_batch().ok_or_else(|| {
-                        ArrowError::IoError(
-                            "Unable to read IPC message as record batch".to_string(),
-                        )
-                    })?;
-                    // read the block that makes up the record batch into a buffer
-                    let mut buf = vec![0; block.bodyLength() as usize];
-                    self.reader.seek(SeekFrom::Start(
-                        block.offset() as u64 + block.metaDataLength() as u64,
-                    ))?;
-                    self.reader.read_exact(&mut buf)?;
-
-                    read_record_batch(
-                        &buf,
-                        batch,
-                        self.schema(),
-                        &self.dictionaries_by_field,
-                    )
-                }
-                ipc::MessageHeader::NONE => {
-                    Ok(None)
-                }
-                t => Err(ArrowError::IoError(format!(
-                    "Reading types other than record batches not yet supported, unable to read {:?}", t
-                ))),
+            let result = self.maybe_next();
+            match result {
+                Ok(Some(e)) => Some(Ok(e)),
+                Ok(None) => None,
+                Err(error) => Some(Err(error)),
             }
         } else {
-            Ok(None)
+            None
         }
     }
 }
@@ -805,14 +812,8 @@ impl<R: Read> StreamReader<R> {
     pub fn is_finished(&self) -> bool {
         self.finished
     }
-}
 
-impl<R: Read> RecordBatchReader for StreamReader<R> {
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
-
-    fn next_batch(&mut self) -> Result<Option<RecordBatch>> {
+    fn maybe_next(&mut self) -> Result<Option<RecordBatch>> {
         if self.finished {
             return Ok(None);
         }
@@ -869,7 +870,7 @@ impl<R: Read> RecordBatchReader for StreamReader<R> {
                 let mut buf = vec![0; message.bodyLength() as usize];
                 self.reader.read_exact(&mut buf)?;
 
-                read_record_batch(&buf, batch, self.schema(), &self.dictionaries_by_field)
+                read_record_batch(&buf, batch, self.schema(), &self.dictionaries_by_field).map(Some)
             }
             ipc::MessageHeader::NONE => {
                 Ok(None)
@@ -877,6 +878,20 @@ impl<R: Read> RecordBatchReader for StreamReader<R> {
             t => Err(ArrowError::IoError(
                 format!("Reading types other than record batches not yet supported, unable to read {:?} ", t)
             )),
+        }
+    }
+}
+
+impl<R: Read> RecordBatchReader for StreamReader<R> {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn next_batch(&mut self) -> Option<Result<RecordBatch>> {
+        match self.maybe_next() {
+            Ok(Some(e)) => Some(Ok(e)),
+            Ok(None) => None,
+            Err(error) => Some(Err(error)),
         }
     }
 }
@@ -945,7 +960,7 @@ mod tests {
             let arrow_json = read_gzip_json(path);
             assert!(arrow_json.equals_reader(&mut reader));
             // the next batch must be empty
-            assert!(reader.next_batch().unwrap().is_none());
+            assert!(reader.next_batch().is_none());
             // the stream must indicate that it's finished
             assert!(reader.is_finished());
         });
@@ -976,7 +991,7 @@ mod tests {
         // read stream back
         let file = File::open("target/debug/testdata/float.stream").unwrap();
         let mut reader = StreamReader::try_new(file).unwrap();
-        while let Some(batch) = reader.next_batch().unwrap() {
+        while let Some(Ok(batch)) = reader.next_batch() {
             assert!(
                 batch
                     .column(0)

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -633,7 +633,7 @@ mod tests {
                 File::open(format!("target/debug/testdata/{}.arrow_file", "arrow"))
                     .unwrap();
             let mut reader = FileReader::try_new(file).unwrap();
-            while let Ok(Some(read_batch)) = reader.next_batch() {
+            while let Some(Ok(read_batch)) = reader.next_batch() {
                 read_batch
                     .columns()
                     .iter()
@@ -680,7 +680,7 @@ mod tests {
         {
             let file = File::open("target/debug/testdata/nulls.arrow_file").unwrap();
             let mut reader = FileReader::try_new(file).unwrap();
-            while let Ok(Some(read_batch)) = reader.next_batch() {
+            while let Some(Ok(read_batch)) = reader.next_batch() {
                 read_batch
                     .columns()
                     .iter()
@@ -721,7 +721,7 @@ mod tests {
                     File::create(format!("target/debug/testdata/{}.arrow_file", path))
                         .unwrap();
                 let mut writer = FileWriter::try_new(file, &reader.schema()).unwrap();
-                while let Ok(Some(batch)) = reader.next_batch() {
+                while let Some(Ok(batch)) = reader.next_batch() {
                     writer.write(&batch).unwrap();
                 }
                 writer.finish().unwrap();
@@ -763,7 +763,7 @@ mod tests {
                 let file = File::create(format!("target/debug/testdata/{}.stream", path))
                     .unwrap();
                 let mut writer = StreamWriter::try_new(file, &reader.schema()).unwrap();
-                while let Ok(Some(batch)) = reader.next_batch() {
+                while let Some(Ok(batch)) = reader.next_batch() {
                     writer.write(&batch).unwrap();
                 }
                 writer.finish().unwrap();

--- a/rust/arrow/src/ipc/writer.rs
+++ b/rust/arrow/src/ipc/writer.rs
@@ -593,7 +593,6 @@ mod tests {
     use crate::array::*;
     use crate::datatypes::Field;
     use crate::ipc::reader::*;
-    use crate::record_batch::RecordBatchReader;
     use crate::util::integration_util::*;
     use std::env;
     use std::fs::File;
@@ -633,7 +632,7 @@ mod tests {
                 File::open(format!("target/debug/testdata/{}.arrow_file", "arrow"))
                     .unwrap();
             let mut reader = FileReader::try_new(file).unwrap();
-            while let Some(Ok(read_batch)) = reader.next_batch() {
+            while let Some(Ok(read_batch)) = reader.next() {
                 read_batch
                     .columns()
                     .iter()
@@ -679,9 +678,10 @@ mod tests {
 
         {
             let file = File::open("target/debug/testdata/nulls.arrow_file").unwrap();
-            let mut reader = FileReader::try_new(file).unwrap();
-            while let Some(Ok(read_batch)) = reader.next_batch() {
-                read_batch
+            let reader = FileReader::try_new(file).unwrap();
+            reader.for_each(|maybe_batch| {
+                maybe_batch
+                    .unwrap()
                     .columns()
                     .iter()
                     .zip(batch.columns())
@@ -690,7 +690,7 @@ mod tests {
                         assert_eq!(a.len(), b.len());
                         assert_eq!(a.null_count(), b.null_count());
                     });
-            }
+            });
         }
     }
 
@@ -721,7 +721,7 @@ mod tests {
                     File::create(format!("target/debug/testdata/{}.arrow_file", path))
                         .unwrap();
                 let mut writer = FileWriter::try_new(file, &reader.schema()).unwrap();
-                while let Some(Ok(batch)) = reader.next_batch() {
+                while let Some(Ok(batch)) = reader.next() {
                     writer.write(&batch).unwrap();
                 }
                 writer.finish().unwrap();
@@ -756,16 +756,16 @@ mod tests {
             ))
             .unwrap();
 
-            let mut reader = StreamReader::try_new(file).unwrap();
+            let reader = StreamReader::try_new(file).unwrap();
 
             // read and rewrite the stream to a temp location
             {
                 let file = File::create(format!("target/debug/testdata/{}.stream", path))
                     .unwrap();
                 let mut writer = StreamWriter::try_new(file, &reader.schema()).unwrap();
-                while let Some(Ok(batch)) = reader.next_batch() {
-                    writer.write(&batch).unwrap();
-                }
+                reader.for_each(|batch| {
+                    writer.write(&batch.unwrap()).unwrap();
+                });
                 writer.finish().unwrap();
             }
 

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -217,15 +217,12 @@ impl Into<StructArray> for RecordBatch {
 }
 
 /// Trait for types that can read `RecordBatch`'s.
-pub trait RecordBatchReader {
+pub trait RecordBatchReader: Iterator<Item = Result<RecordBatch>> {
     /// Returns the schema of this `RecordBatchReader`.
     ///
     /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
     /// reader should have the same schema as returned from this method.
     fn schema(&self) -> SchemaRef;
-
-    /// Reads the next `RecordBatch`.
-    fn next_batch(&mut self) -> Option<Result<RecordBatch>>;
 }
 
 #[cfg(test)]

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -223,6 +223,15 @@ pub trait RecordBatchReader: Iterator<Item = Result<RecordBatch>> {
     /// Implementation of this trait should guarantee that all `RecordBatch`'s returned by this
     /// reader should have the same schema as returned from this method.
     fn schema(&self) -> SchemaRef;
+
+    /// Reads the next `RecordBatch`.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This method is deprecated in favour of `next` from the trait Iterator."
+    )]
+    fn next_batch(&mut self) -> Result<Option<RecordBatch>> {
+        self.next().transpose()
+    }
 }
 
 #[cfg(test)]

--- a/rust/arrow/src/record_batch.rs
+++ b/rust/arrow/src/record_batch.rs
@@ -225,7 +225,7 @@ pub trait RecordBatchReader {
     fn schema(&self) -> SchemaRef;
 
     /// Reads the next `RecordBatch`.
-    fn next_batch(&mut self) -> Result<Option<RecordBatch>>;
+    fn next_batch(&mut self) -> Option<Result<RecordBatch>>;
 }
 
 #[cfg(test)]

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -78,7 +78,7 @@ impl ArrowJson {
             return false;
         }
         self.batches.iter().all(|col| {
-            let batch = reader.next_batch();
+            let batch = reader.next();
             match batch {
                 Some(Ok(batch)) => col.equals_batch(&batch),
                 _ => false,

--- a/rust/arrow/src/util/integration_util.rs
+++ b/rust/arrow/src/util/integration_util.rs
@@ -80,7 +80,7 @@ impl ArrowJson {
         self.batches.iter().all(|col| {
             let batch = reader.next_batch();
             match batch {
-                Ok(Some(batch)) => col.equals_batch(&batch),
+                Some(Ok(batch)) => col.equals_batch(&batch),
                 _ => false,
             }
         })

--- a/rust/datafusion/examples/flight_client.rs
+++ b/rust/datafusion/examples/flight_client.rs
@@ -62,8 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut results = vec![];
     while let Some(flight_data) = stream.message().await? {
         // the unwrap is infallible and thus safe
-        let record_batch =
-            flight_data_to_arrow_batch(&flight_data, schema.clone())?.unwrap();
+        let record_batch = flight_data_to_arrow_batch(&flight_data, schema.clone()).unwrap()?;
         results.push(record_batch);
     }
 

--- a/rust/datafusion/examples/flight_client.rs
+++ b/rust/datafusion/examples/flight_client.rs
@@ -62,7 +62,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut results = vec![];
     while let Some(flight_data) = stream.message().await? {
         // the unwrap is infallible and thus safe
-        let record_batch = flight_data_to_arrow_batch(&flight_data, schema.clone()).unwrap()?;
+        let record_batch =
+            flight_data_to_arrow_batch(&flight_data, schema.clone()).unwrap()?;
         results.push(record_batch);
     }
 

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -22,6 +22,7 @@
 use std::sync::Arc;
 
 use arrow::datatypes::{Field, Schema, SchemaRef};
+use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 
 use crate::datasource::TableProvider;
@@ -64,10 +65,7 @@ impl MemTable {
         for partition in 0..exec.output_partitioning().partition_count() {
             let it = exec.execute(partition).await?;
             let mut it = it.lock().unwrap();
-            let mut partition_batches = vec![];
-            while let Some(Ok(batch)) = it.next_batch() {
-                partition_batches.push(batch);
-            }
+            let partition_batches = it.into_iter().collect::<ArrowResult<Vec<_>>>()?;
             data.push(partition_batches);
         }
 
@@ -148,7 +146,7 @@ mod tests {
         // scan with projection
         let exec = provider.scan(&Some(vec![2, 1]), 1024)?;
         let it = exec.execute(0).await?;
-        let batch2 = it.lock().expect("mutex lock").next_batch().unwrap()?;
+        let batch2 = it.lock().expect("mutex lock").next().unwrap()?;
         assert_eq!(2, batch2.schema().fields().len());
         assert_eq!("c", batch2.schema().field(0).name());
         assert_eq!("b", batch2.schema().field(1).name());
@@ -178,7 +176,7 @@ mod tests {
 
         let exec = provider.scan(&None, 1024)?;
         let it = exec.execute(0).await?;
-        let batch1 = it.lock().expect("mutex lock").next_batch().unwrap()?;
+        let batch1 = it.lock().expect("mutex lock").next().unwrap()?;
         assert_eq!(3, batch1.schema().fields().len());
         assert_eq!(3, batch1.num_columns());
 

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -65,7 +65,7 @@ impl MemTable {
             let it = exec.execute(partition).await?;
             let mut it = it.lock().unwrap();
             let mut partition_batches = vec![];
-            while let Ok(Some(batch)) = it.next_batch() {
+            while let Some(Ok(batch)) = it.next_batch() {
                 partition_batches.push(batch);
             }
             data.push(partition_batches);
@@ -148,7 +148,7 @@ mod tests {
         // scan with projection
         let exec = provider.scan(&Some(vec![2, 1]), 1024)?;
         let it = exec.execute(0).await?;
-        let batch2 = it.lock().expect("mutex lock").next_batch()?.unwrap();
+        let batch2 = it.lock().expect("mutex lock").next_batch().unwrap()?;
         assert_eq!(2, batch2.schema().fields().len());
         assert_eq!("c", batch2.schema().field(0).name());
         assert_eq!("b", batch2.schema().field(1).name());
@@ -178,7 +178,7 @@ mod tests {
 
         let exec = provider.scan(&None, 1024)?;
         let it = exec.execute(0).await?;
-        let batch1 = it.lock().expect("mutex lock").next_batch()?.unwrap();
+        let batch1 = it.lock().expect("mutex lock").next_batch().unwrap()?;
         assert_eq!(3, batch1.schema().fields().len());
         assert_eq!(3, batch1.num_columns());
 

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -85,12 +85,14 @@ mod tests {
         let it = exec.execute(0).await?;
         let mut it = it.lock().unwrap();
 
-        let mut count = 0;
-        while let Some(Ok(batch)) = it.next_batch() {
-            assert_eq!(11, batch.num_columns());
-            assert_eq!(2, batch.num_rows());
-            count += 1;
-        }
+        let count = it
+            .into_iter()
+            .map(|batch| {
+                let batch = batch.unwrap();
+                assert_eq!(11, batch.num_columns());
+                assert_eq!(2, batch.num_rows());
+            })
+            .count();
 
         // we should have seen 4 batches of 2 rows
         assert_eq!(4, count);
@@ -304,7 +306,7 @@ mod tests {
         let exec = table.scan(projection, 1024)?;
         let it = exec.execute(0).await?;
         let mut it = it.lock().expect("failed to lock mutex");
-        it.next_batch()
+        it.next()
             .expect("should have received at least one batch")
             .map_err(|e| e.into())
     }

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -86,7 +86,7 @@ mod tests {
         let mut it = it.lock().unwrap();
 
         let mut count = 0;
-        while let Some(batch) = it.next_batch()? {
+        while let Some(Ok(batch)) = it.next_batch() {
             assert_eq!(11, batch.num_columns());
             assert_eq!(2, batch.num_rows());
             count += 1;
@@ -304,8 +304,8 @@ mod tests {
         let exec = table.scan(projection, 1024)?;
         let it = exec.execute(0).await?;
         let mut it = it.lock().expect("failed to lock mutex");
-        Ok(it
-            .next_batch()?
-            .expect("should have received at least one batch"))
+        it.next_batch()
+            .expect("should have received at least one batch")
+            .map_err(|e| e.into())
     }
 }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 
 use arrow::csv;
 use arrow::datatypes::*;
+use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 
 use crate::datasource::csv::CsvFile;
@@ -363,15 +364,12 @@ impl ExecutionContext {
             let mut writer = csv::Writer::new(file);
             let reader = plan.execute(i).await.unwrap();
             let mut reader = reader.lock().unwrap();
-            loop {
-                match reader.next_batch() {
-                    Some(Ok(batch)) => {
-                        writer.write(&batch)?;
-                    }
-                    None => break,
-                    Some(Err(e)) => return Err(ExecutionError::from(e)),
-                }
-            }
+
+            reader
+                .into_iter()
+                .map(|batch| writer.write(&batch?))
+                .collect::<ArrowResult<_>>()
+                .map_err(|e| ExecutionError::from(e))?
         }
         Ok(())
     }

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -365,13 +365,14 @@ impl ExecutionContext {
             let mut reader = reader.lock().unwrap();
             loop {
                 match reader.next_batch() {
-                    Ok(Some(batch)) => writer.write(&batch).unwrap(),
-                    Ok(None) => break,
-                    Err(e) => return Err(ExecutionError::from(e)),
+                    Some(Ok(batch)) => {
+                        writer.write(&batch)?;
+                    }
+                    None => break,
+                    Some(Err(e)) => return Err(ExecutionError::from(e)),
                 }
             }
         }
-
         Ok(())
     }
 

--- a/rust/datafusion/src/physical_plan/common.rs
+++ b/rust/datafusion/src/physical_plan/common.rs
@@ -59,12 +59,12 @@ impl RecordBatchReader for RecordBatchIterator {
         self.schema.clone()
     }
 
-    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
         if self.index < self.batches.len() {
             self.index += 1;
-            Ok(Some(self.batches[self.index - 1].as_ref().clone()))
+            Some(Ok(self.batches[self.index - 1].as_ref().clone()))
         } else {
-            Ok(None)
+            None
         }
     }
 }
@@ -77,14 +77,14 @@ pub fn collect(
     let mut results: Vec<RecordBatch> = vec![];
     loop {
         match reader.next_batch() {
-            Ok(Some(batch)) => {
+            Some(Ok(batch)) => {
                 results.push(batch);
             }
-            Ok(None) => {
+            None => {
                 // end of result set
                 return Ok(results);
             }
-            Err(e) => return Err(ExecutionError::from(e)),
+            Some(Err(e)) => return Err(ExecutionError::from(e)),
         }
     }
 }

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -269,8 +269,8 @@ impl RecordBatchReader for CsvIterator {
     }
 
     /// Get the next RecordBatch
-    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
-        Ok(self.reader.next()?)
+    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
+        self.reader.next()
     }
 }
 
@@ -296,7 +296,7 @@ mod tests {
         assert_eq!(3, csv.schema().fields().len());
         let it = csv.execute(0).await?;
         let mut it = it.lock().unwrap();
-        let batch = it.next_batch()?.unwrap();
+        let batch = it.next_batch().unwrap()?;
         assert_eq!(3, batch.num_columns());
         let batch_schema = batch.schema();
         assert_eq!(3, batch_schema.fields().len());
@@ -319,7 +319,7 @@ mod tests {
         assert_eq!(13, csv.schema().fields().len());
         let it = csv.execute(0).await?;
         let mut it = it.lock().unwrap();
-        let batch = it.next_batch()?.unwrap();
+        let batch = it.next_batch().unwrap()?;
         assert_eq!(13, batch.num_columns());
         let batch_schema = batch.schema();
         assert_eq!(13, batch_schema.fields().len());

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -262,15 +262,18 @@ impl CsvIterator {
     }
 }
 
+impl Iterator for CsvIterator {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.reader.next()
+    }
+}
+
 impl RecordBatchReader for CsvIterator {
     /// Get the schema
     fn schema(&self) -> SchemaRef {
         self.reader.schema()
-    }
-
-    /// Get the next RecordBatch
-    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
-        self.reader.next()
     }
 }
 
@@ -296,7 +299,7 @@ mod tests {
         assert_eq!(3, csv.schema().fields().len());
         let it = csv.execute(0).await?;
         let mut it = it.lock().unwrap();
-        let batch = it.next_batch().unwrap()?;
+        let batch = it.next().unwrap()?;
         assert_eq!(3, batch.num_columns());
         let batch_schema = batch.schema();
         assert_eq!(3, batch_schema.fields().len());
@@ -319,7 +322,7 @@ mod tests {
         assert_eq!(13, csv.schema().fields().len());
         let it = csv.execute(0).await?;
         let mut it = it.lock().unwrap();
-        let batch = it.next_batch().unwrap()?;
+        let batch = it.next().unwrap()?;
         assert_eq!(13, batch.num_columns());
         let batch_schema = batch.schema();
         assert_eq!(13, batch_schema.fields().len());

--- a/rust/datafusion/src/physical_plan/filter.rs
+++ b/rust/datafusion/src/physical_plan/filter.rs
@@ -127,37 +127,43 @@ impl RecordBatchReader for FilterExecIter {
     }
 
     /// Get the next batch
-    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
         let mut input = self.input.lock().unwrap();
-        match input.next_batch()? {
-            Some(batch) => {
+        match input.next_batch() {
+            Some(Ok(batch)) => {
                 // evaluate the filter predicate to get a boolean array indicating which rows
                 // to include in the output
-                let result = self
-                    .predicate
-                    .evaluate(&batch)
-                    .map_err(ExecutionError::into_arrow_external_error)?;
-
-                if let Some(f) = result.as_any().downcast_ref::<BooleanArray>() {
-                    // filter each array
-                    let mut filtered_arrays = Vec::with_capacity(batch.num_columns());
-                    for i in 0..batch.num_columns() {
-                        let array = batch.column(i);
-                        let filtered_array = filter(array.as_ref(), f)?;
-                        filtered_arrays.push(filtered_array);
-                    }
-                    Ok(Some(RecordBatch::try_new(
-                        batch.schema().clone(),
-                        filtered_arrays,
-                    )?))
-                } else {
-                    Err(ExecutionError::InternalError(
-                        "Filter predicate evaluated to non-boolean value".to_string(),
-                    )
-                    .into_arrow_external_error())
-                }
+                Some(
+                    self.predicate
+                        .evaluate(&batch)
+                        .map_err(ExecutionError::into_arrow_external_error)
+                        .and_then(|array| {
+                            array
+                                .as_any()
+                                .downcast_ref::<BooleanArray>()
+                                .ok_or(
+                                    ExecutionError::InternalError(
+                                        "Filter predicate evaluated to non-boolean value"
+                                            .to_string(),
+                                    )
+                                    .into_arrow_external_error(),
+                                )
+                                // apply predicate to each column
+                                .and_then(|predicate| {
+                                    batch
+                                        .columns()
+                                        .iter()
+                                        .map(|column| filter(column.as_ref(), predicate))
+                                        .collect::<ArrowResult<Vec<_>>>()
+                                })
+                        })
+                        // build RecordBatch
+                        .and_then(|columns| {
+                            RecordBatch::try_new(batch.schema().clone(), columns)
+                        }),
+                )
             }
-            None => Ok(None),
+            other => other,
         }
     }
 }

--- a/rust/datafusion/src/physical_plan/filter.rs
+++ b/rust/datafusion/src/physical_plan/filter.rs
@@ -120,16 +120,13 @@ struct FilterExecIter {
     input: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
 }
 
-impl RecordBatchReader for FilterExecIter {
-    /// Get the schema
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
+impl Iterator for FilterExecIter {
+    type Item = ArrowResult<RecordBatch>;
 
     /// Get the next batch
-    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
+    fn next(&mut self) -> Option<ArrowResult<RecordBatch>> {
         let mut input = self.input.lock().unwrap();
-        match input.next_batch() {
+        match input.next() {
             Some(Ok(batch)) => {
                 // evaluate the filter predicate to get a boolean array indicating which rows
                 // to include in the output
@@ -165,6 +162,13 @@ impl RecordBatchReader for FilterExecIter {
             }
             other => other,
         }
+    }
+}
+
+impl RecordBatchReader for FilterExecIter {
+    /// Get the schema
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
     }
 }
 

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -240,6 +240,103 @@ impl GroupedHashAggregateIterator {
             finished: false,
         }
     }
+
+    fn aggregate_batch(
+        &self,
+        batch: &RecordBatch,
+        accumulators: &mut FnvHashMap<
+            Vec<GroupByScalar>,
+            (AccumulatorSet, Box<Vec<u32>>),
+        >,
+        aggregate_expressions: &Vec<Vec<Arc<dyn PhysicalExpr>>>,
+    ) -> Result<()> {
+        // evaluate the grouping expressions
+        let group_values = evaluate(&self.group_expr, batch)?;
+
+        // evaluate the aggregation expressions.
+        // We could evaluate them after the `take`, but since we need to evaluate all
+        // of them anyways, it is more performant to do it while they are together.
+        let aggr_input_values = evaluate_many(aggregate_expressions, &batch)?;
+
+        // create vector large enough to hold the grouping key
+        // this is an optimization to avoid allocating `key` on every row.
+        // it will be overwritten on every iteration of the loop below
+        let mut key = Vec::with_capacity(group_values.len());
+        for _ in 0..group_values.len() {
+            key.push(GroupByScalar::UInt32(0));
+        }
+
+        // 1.1 construct the key from the group values
+        // 1.2 construct the mapping key if it does not exist
+        // 1.3 add the row' index to `indices`
+        for row in 0..batch.num_rows() {
+            // 1.1
+            create_key(&group_values, row, &mut key)
+                .map_err(ExecutionError::into_arrow_external_error)?;
+
+            match accumulators.get_mut(&key) {
+                // 1.2
+                None => {
+                    let accumulator_set = create_accumulators(&self.aggr_expr)
+                        .map_err(ExecutionError::into_arrow_external_error)?;
+
+                    accumulators.insert(
+                        key.clone(),
+                        (accumulator_set, Box::new(vec![row as u32])),
+                    );
+                }
+                // 1.3
+                Some((_, v)) => v.push(row as u32),
+            }
+        }
+
+        // 2.1 for each key
+        // 2.2 for each aggregation
+        // 2.3 `take` from each of its arrays the keys' values
+        // 2.4 update / merge the accumulator with the values
+        // 2.5 clear indices
+        accumulators
+            .iter_mut()
+            // 2.1
+            .map(|(_, (accumulator_set, indices))| {
+                // 2.2
+                accumulator_set
+                    .iter()
+                    .zip(&aggr_input_values)
+                    .into_iter()
+                    .map(|(accumulator, aggr_array)| {
+                        (
+                            accumulator,
+                            aggr_array
+                                .iter()
+                                .map(|array| {
+                                    // 2.3
+                                    compute::take(
+                                        array,
+                                        &UInt32Array::from(*indices.clone()),
+                                        None, // None: no index check
+                                    )
+                                    .unwrap()
+                                })
+                                .collect::<Vec<ArrayRef>>(),
+                        )
+                    })
+                    // 2.4
+                    .map(|(accumulator, values)| match self.mode {
+                        AggregateMode::Partial => {
+                            accumulator.borrow_mut().update_batch(&values)
+                        }
+                        AggregateMode::Final => {
+                            // note: the aggregation here is over states, not values, thus the merge
+                            accumulator.borrow_mut().merge_batch(&values)
+                        }
+                    })
+                    .collect::<Result<()>>()
+                    // 2.5
+                    .and(Ok(indices.clear()))
+            })
+            .collect::<Result<()>>()
+    }
 }
 
 type AccumulatorSet = Vec<Rc<RefCell<dyn Accumulator>>>;
@@ -249,17 +346,20 @@ impl RecordBatchReader for GroupedHashAggregateIterator {
         self.schema.clone()
     }
 
-    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
         if self.finished {
-            return Ok(None);
+            return None;
         }
 
         // return single batch
         self.finished = true;
 
         // the expressions to evaluate the batch, one vec of expressions per aggregation
-        let aggregate_expressions = aggregate_expressions(&self.aggr_expr, &self.mode)
-            .map_err(ExecutionError::into_arrow_external_error)?;
+        let aggregate_expressions =
+            match aggregate_expressions(&self.aggr_expr, &self.mode) {
+                Ok(e) => e,
+                Err(e) => return Some(Err(ExecutionError::into_arrow_external_error(e))),
+            };
 
         // mapping key -> (set of accumulators, indices of the key in the batch)
         // * the indexes are updated at each row
@@ -274,107 +374,24 @@ impl RecordBatchReader for GroupedHashAggregateIterator {
         let mut input = self.input.lock().unwrap();
 
         // iterate over input and perform aggregation
-        while let Some(batch) = &input.next_batch()? {
-            // evaluate the grouping expressions
-            let group_values = evaluate(&self.group_expr, batch)
-                .map_err(ExecutionError::into_arrow_external_error)?;
-
-            // evaluate the aggregation expressions.
-            // We could evaluate them after the `take`, but since we need to evaluate all
-            // of them anyways, it is more performant to do it while they are together.
-            let aggr_input_values = evaluate_many(&aggregate_expressions, &batch)
-                .map_err(ExecutionError::into_arrow_external_error)?;
-
-            // create vector large enough to hold the grouping key
-            // this is an optimization to avoid allocating `key` on every row.
-            // it will be overwritten on every iteration of the loop below
-            let mut key = Vec::with_capacity(group_values.len());
-            for _ in 0..group_values.len() {
-                key.push(GroupByScalar::UInt32(0));
+        while let Some(batch) = input.next_batch() {
+            match batch.map(|batch| {
+                self.aggregate_batch(&batch, &mut accumulators, &aggregate_expressions)
+            }) {
+                Err(e) => return Some(Err(e)),
+                Ok(_) => {}
             }
-
-            // 1.1 construct the key from the group values
-            // 1.2 construct the mapping key if it does not exist
-            // 1.3 add the row' index to `indices`
-            for row in 0..batch.num_rows() {
-                // 1.1
-                create_key(&group_values, row, &mut key)
-                    .map_err(ExecutionError::into_arrow_external_error)?;
-
-                match accumulators.get_mut(&key) {
-                    // 1.2
-                    None => {
-                        let accumulator_set = create_accumulators(&self.aggr_expr)
-                            .map_err(ExecutionError::into_arrow_external_error)?;
-
-                        accumulators.insert(
-                            key.clone(),
-                            (accumulator_set, Box::new(vec![row as u32])),
-                        );
-                    }
-                    // 1.3
-                    Some((_, v)) => v.push(row as u32),
-                }
-            }
-
-            // 2.1 for each key
-            // 2.2 for each aggregation
-            // 2.3 `take` from each of its arrays the keys' values
-            // 2.4 update / merge the accumulator with the values
-            // 2.5 clear indices
-            accumulators
-                .iter_mut()
-                // 2.1
-                .map(|(_, (accumulator_set, indices))| {
-                    // 2.2
-                    accumulator_set
-                        .iter()
-                        .zip(&aggr_input_values)
-                        .into_iter()
-                        .map(|(accumulator, aggr_array)| {
-                            (
-                                accumulator,
-                                aggr_array
-                                    .iter()
-                                    .map(|array| {
-                                        // 2.3
-                                        compute::take(
-                                            array,
-                                            &UInt32Array::from(*indices.clone()),
-                                            None, // None: no index check
-                                        )
-                                        .unwrap()
-                                    })
-                                    .collect::<Vec<ArrayRef>>(),
-                            )
-                        })
-                        // 2.4
-                        .map(|(accumulator, values)| match self.mode {
-                            AggregateMode::Partial => {
-                                accumulator.borrow_mut().update_batch(&values)
-                            }
-                            AggregateMode::Final => {
-                                // note: the aggregation here is over states, not values, thus the merge
-                                accumulator.borrow_mut().merge_batch(&values)
-                            }
-                        })
-                        .collect::<Result<()>>()
-                        // 2.5
-                        .and(Ok(indices.clear()))
-                })
-                .collect::<Result<()>>()
-                .map_err(ExecutionError::into_arrow_external_error)?;
         }
 
-        let batch = create_batch_from_map(
-            &self.mode,
-            &accumulators,
-            self.group_expr.len(),
-            &self.schema,
+        Some(
+            create_batch_from_map(
+                &self.mode,
+                &accumulators,
+                self.group_expr.len(),
+                &self.schema,
+            )
+            .map_err(ExecutionError::into_arrow_external_error),
         )
-        .map_err(ExecutionError::into_arrow_external_error)?;
-
-        Ok(Some(batch))
     }
 }
 
@@ -456,6 +473,36 @@ impl HashAggregateIterator {
             finished: false,
         }
     }
+
+    fn aggregate_batch(
+        &self,
+        batch: &RecordBatch,
+        accumulators: &AccumulatorSet,
+        expressions: &Vec<Vec<Arc<dyn PhysicalExpr>>>,
+    ) -> Result<()> {
+        // 1.1 iterate accumulators and respective expressions together
+        // 1.2 evaluate expressions
+        // 1.3 update / merge accumulators with the expressions' values
+
+        // 1.1
+        accumulators
+            .iter()
+            .zip(expressions)
+            .map(|(accum, expr)| {
+                // 1.2
+                let values = &expr
+                    .iter()
+                    .map(|e| e.evaluate(batch))
+                    .collect::<Result<Vec<_>>>()?;
+
+                // 1.3
+                match self.mode {
+                    AggregateMode::Partial => accum.borrow_mut().update_batch(values),
+                    AggregateMode::Final => accum.borrow_mut().merge_batch(values),
+                }
+            })
+            .collect::<Result<()>>()
+    }
 }
 
 impl RecordBatchReader for HashAggregateIterator {
@@ -463,55 +510,43 @@ impl RecordBatchReader for HashAggregateIterator {
         self.schema.clone()
     }
 
-    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
         if self.finished {
-            return Ok(None);
+            return None;
         }
 
         // return single batch
         self.finished = true;
 
-        let accumulators = create_accumulators(&self.aggr_expr)
-            .map_err(ExecutionError::into_arrow_external_error)?;
+        let accumulators = match create_accumulators(&self.aggr_expr) {
+            Ok(e) => e,
+            Err(e) => return Some(Err(ExecutionError::into_arrow_external_error(e))),
+        };
 
-        let expressions = aggregate_expressions(&self.aggr_expr, &self.mode)
-            .map_err(ExecutionError::into_arrow_external_error)?;
+        let expressions = match aggregate_expressions(&self.aggr_expr, &self.mode) {
+            Ok(e) => e,
+            Err(e) => return Some(Err(ExecutionError::into_arrow_external_error(e))),
+        };
 
         let mut input = self.input.lock().unwrap();
 
-        // 1 for each batch:
-        // 1.1 iterate accumulators and respective expressions together
-        // 1.2 evaluate expressions
-        // 1.3 update / merge accumulators with the expressions' values
+        // 1 for each batch, update / merge accumulators with the expressions' values
         // 2 convert values to a record batch
-        while let Some(batch) = input.next_batch()? {
-            // 1.1
-            accumulators
-                .iter()
-                .zip(&expressions)
-                .map(|(accum, expr)| {
-                    // 1.2
-                    let values = &expr
-                        .iter()
-                        .map(|e| e.evaluate(&batch))
-                        .collect::<Result<Vec<_>>>()?;
-
-                    // 1.3
-                    match self.mode {
-                        AggregateMode::Partial => accum.borrow_mut().update_batch(values),
-                        AggregateMode::Final => accum.borrow_mut().merge_batch(values),
-                    }
-                })
-                .collect::<Result<()>>()
-                .map_err(ExecutionError::into_arrow_external_error)?;
+        while let Some(batch) = input.next_batch() {
+            match batch
+                .map(|batch| self.aggregate_batch(&batch, &accumulators, &expressions))
+            {
+                Err(e) => return Some(Err(e)),
+                Ok(_) => {}
+            }
         }
 
         // 2
-        let columns = finalize_aggregation(&accumulators, &self.mode)
-            .map_err(ExecutionError::into_arrow_external_error)?;
-
-        let batch = RecordBatch::try_new(self.schema.clone(), columns)?;
-        Ok(Some(batch))
+        Some(
+            finalize_aggregation(&accumulators, &self.mode)
+                .map_err(ExecutionError::into_arrow_external_error)
+                .and_then(|columns| RecordBatch::try_new(self.schema.clone(), columns)),
+        )
     }
 }
 

--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -202,7 +202,7 @@ fn collect_with_limit(
     let mut reader = reader.lock().unwrap();
     let mut results: Vec<RecordBatch> = vec![];
     loop {
-        match reader.next_batch() {
+        match reader.next() {
             Some(Ok(batch)) => {
                 let capacity = limit - count;
                 if batch.num_rows() <= capacity {

--- a/rust/datafusion/src/physical_plan/limit.rs
+++ b/rust/datafusion/src/physical_plan/limit.rs
@@ -203,7 +203,7 @@ fn collect_with_limit(
     let mut results: Vec<RecordBatch> = vec![];
     loop {
         match reader.next_batch() {
-            Ok(Some(batch)) => {
+            Some(Ok(batch)) => {
                 let capacity = limit - count;
                 if batch.num_rows() <= capacity {
                     count += batch.num_rows();
@@ -217,11 +217,10 @@ fn collect_with_limit(
                     return Ok(results);
                 }
             }
-            Ok(None) => {
-                // end of result set
+            None => {
                 return Ok(results);
             }
-            Err(e) => return Err(ExecutionError::from(e)),
+            Some(Err(e)) => return Err(ExecutionError::from(e)),
         }
     }
 }

--- a/rust/datafusion/src/physical_plan/memory.rs
+++ b/rust/datafusion/src/physical_plan/memory.rs
@@ -126,14 +126,10 @@ impl MemoryIterator {
     }
 }
 
-impl RecordBatchReader for MemoryIterator {
-    /// Get the schema
-    fn schema(&self) -> SchemaRef {
-        self.schema.clone()
-    }
+impl Iterator for MemoryIterator {
+    type Item = ArrowResult<RecordBatch>;
 
-    /// Get the next RecordBatch
-    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
+    fn next(&mut self) -> Option<Self::Item> {
         if self.index < self.data.len() {
             self.index += 1;
             let batch = &self.data[self.index - 1];
@@ -148,5 +144,12 @@ impl RecordBatchReader for MemoryIterator {
         } else {
             None
         }
+    }
+}
+
+impl RecordBatchReader for MemoryIterator {
+    /// Get the schema
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
     }
 }

--- a/rust/datafusion/src/physical_plan/memory.rs
+++ b/rust/datafusion/src/physical_plan/memory.rs
@@ -133,20 +133,20 @@ impl RecordBatchReader for MemoryIterator {
     }
 
     /// Get the next RecordBatch
-    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
+    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
         if self.index < self.data.len() {
             self.index += 1;
             let batch = &self.data[self.index - 1];
             // apply projection
             match &self.projection {
-                Some(columns) => Ok(Some(RecordBatch::try_new(
+                Some(columns) => Some(RecordBatch::try_new(
                     self.schema.clone(),
                     columns.iter().map(|i| batch.column(*i).clone()).collect(),
-                )?)),
-                None => Ok(Some(batch.clone())),
+                )),
+                None => Some(Ok(batch.clone())),
             }
         } else {
-            Ok(None)
+            None
         }
     }
 }

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -22,7 +22,6 @@ use std::io::{self, BufReader};
 use arrow::error::Result;
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::StreamWriter;
-use arrow::record_batch::RecordBatchReader;
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
@@ -33,14 +32,17 @@ fn main() -> Result<()> {
 
     let f = File::open(filename)?;
     let reader = BufReader::new(f);
-    let mut reader = FileReader::try_new(reader)?;
+    let reader = FileReader::try_new(reader)?;
     let schema = reader.schema();
 
     let mut writer = StreamWriter::try_new(io::stdout(), &schema)?;
 
-    while let Some(Ok(batch)) = reader.next_batch() {
-        writer.write(&batch)?;
-    }
+    reader
+        .map(|batch| {
+            let batch = batch?;
+            writer.write(&batch)
+        })
+        .collect::<Result<()>>()?;
     writer.finish()?;
 
     eprintln!("Completed without error");

--- a/rust/integration-testing/src/bin/arrow-file-to-stream.rs
+++ b/rust/integration-testing/src/bin/arrow-file-to-stream.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
 
     let mut writer = StreamWriter::try_new(io::stdout(), &schema)?;
 
-    while let Some(batch) = reader.next_batch()? {
+    while let Some(Ok(batch)) = reader.next_batch() {
         writer.write(&batch)?;
     }
     writer.finish()?;

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -25,7 +25,7 @@ use arrow::datatypes::{DataType, DateUnit, IntervalUnit, Schema};
 use arrow::error::{ArrowError, Result};
 use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
-use arrow::record_batch::{RecordBatch, RecordBatchReader};
+use arrow::record_batch::RecordBatch;
 
 use hex::decode;
 use std::env;
@@ -423,7 +423,7 @@ fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()>
     }
 
     let arrow_file = File::open(arrow_name)?;
-    let mut reader = FileReader::try_new(arrow_file)?;
+    let reader = FileReader::try_new(arrow_file)?;
 
     let mut fields = vec![];
     for f in reader.schema().fields() {
@@ -431,10 +431,9 @@ fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()>
     }
     let schema = ArrowJsonSchema { fields };
 
-    let mut batches = vec![];
-    while let Some(Ok(batch)) = reader.next_batch() {
-        batches.push(ArrowJsonBatch::from_batch(&batch));
-    }
+    let batches = reader
+        .map(|batch| Ok(ArrowJsonBatch::from_batch(&batch?)))
+        .collect::<Result<Vec<_>>>()?;
 
     let arrow_json = ArrowJson {
         schema,
@@ -483,7 +482,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
     }
 
     for json_batch in &json_batches {
-        if let Some(Ok(arrow_batch)) = arrow_reader.next_batch() {
+        if let Some(Ok(arrow_batch)) = arrow_reader.next() {
             // compare batches
             assert!(arrow_batch.num_columns() == json_batch.num_columns());
             assert!(arrow_batch.num_rows() == json_batch.num_rows());
@@ -500,7 +499,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
         }
     }
 
-    if arrow_reader.next_batch().is_some() {
+    if arrow_reader.next().is_some() {
         return Err(ArrowError::ComputeError(
             "no more json batches left".to_owned(),
         ));

--- a/rust/integration-testing/src/bin/arrow-json-integration-test.rs
+++ b/rust/integration-testing/src/bin/arrow-json-integration-test.rs
@@ -432,7 +432,7 @@ fn arrow_to_json(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()>
     let schema = ArrowJsonSchema { fields };
 
     let mut batches = vec![];
-    while let Ok(Some(batch)) = reader.next_batch() {
+    while let Some(Ok(batch)) = reader.next_batch() {
         batches.push(ArrowJsonBatch::from_batch(&batch));
     }
 
@@ -483,7 +483,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
     }
 
     for json_batch in &json_batches {
-        if let Some(arrow_batch) = arrow_reader.next_batch()? {
+        if let Some(Ok(arrow_batch)) = arrow_reader.next_batch() {
             // compare batches
             assert!(arrow_batch.num_columns() == json_batch.num_columns());
             assert!(arrow_batch.num_rows() == json_batch.num_rows());
@@ -500,7 +500,7 @@ fn validate(arrow_name: &str, json_name: &str, verbose: bool) -> Result<()> {
         }
     }
 
-    if arrow_reader.next_batch()?.is_some() {
+    if arrow_reader.next_batch().is_some() {
         return Err(ArrowError::ComputeError(
             "no more json batches left".to_owned(),
         ));

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
 
     let mut writer = FileWriter::try_new(io::stdout(), &schema)?;
 
-    while let Some(batch) = arrow_stream_reader.next_batch()? {
+    while let Some(Ok(batch)) = arrow_stream_reader.next_batch() {
         writer.write(&batch)?;
     }
     writer.finish()?;

--- a/rust/integration-testing/src/bin/arrow-stream-to-file.rs
+++ b/rust/integration-testing/src/bin/arrow-stream-to-file.rs
@@ -21,20 +21,19 @@ use std::io;
 use arrow::error::Result;
 use arrow::ipc::reader::StreamReader;
 use arrow::ipc::writer::FileWriter;
-use arrow::record_batch::RecordBatchReader;
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     eprintln!("{:?}", args);
 
-    let mut arrow_stream_reader = StreamReader::try_new(io::stdin())?;
+    let arrow_stream_reader = StreamReader::try_new(io::stdin())?;
     let schema = arrow_stream_reader.schema();
 
     let mut writer = FileWriter::try_new(io::stdout(), &schema)?;
 
-    while let Some(Ok(batch)) = arrow_stream_reader.next_batch() {
-        writer.write(&batch)?;
-    }
+    arrow_stream_reader
+        .map(|batch| writer.write(&batch?))
+        .collect::<Result<_>>()?;
     writer.finish()?;
 
     eprintln!("Completed without error");

--- a/rust/parquet/src/arrow/arrow_reader.rs
+++ b/rust/parquet/src/arrow/arrow_reader.rs
@@ -22,10 +22,10 @@ use crate::arrow::schema::parquet_to_arrow_schema;
 use crate::arrow::schema::parquet_to_arrow_schema_by_columns;
 use crate::errors::{ParquetError, Result};
 use crate::file::reader::FileReader;
-use arrow::array::StructArray;
 use arrow::datatypes::{DataType as ArrowType, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
+use arrow::{array::StructArray, error::ArrowError};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -148,32 +148,33 @@ impl RecordBatchReader for ParquetRecordBatchReader {
         self.schema.clone()
     }
 
-    fn next_batch(&mut self) -> ArrowResult<Option<RecordBatch>> {
-        self.array_reader
-            .next_batch(self.batch_size)
-            .map_err(|err| err.into())
-            .and_then(|array| {
-                array
-                    .as_any()
-                    .downcast_ref::<StructArray>()
-                    .ok_or_else(|| {
-                        general_err!("Struct array reader should return struct array")
-                            .into()
-                    })
-                    .and_then(|struct_array| {
-                        RecordBatch::try_new(
-                            self.schema.clone(),
-                            struct_array.columns_ref(),
+    fn next_batch(&mut self) -> Option<ArrowResult<RecordBatch>> {
+        match self.array_reader.next_batch(self.batch_size) {
+            Err(error) => Some(Err(error.into())),
+            Ok(array) => {
+                let struct_array =
+                    array.as_any().downcast_ref::<StructArray>().ok_or_else(|| {
+                        ArrowError::ParquetError(
+                            "Struct array reader should return struct array".to_string(),
                         )
-                    })
-            })
-            .map(|record_batch| {
-                if record_batch.num_rows() > 0 {
-                    Some(record_batch)
-                } else {
-                    None
+                    });
+                match struct_array {
+                    Err(err) => Some(Err(err)),
+                    Ok(e) => {
+                        match RecordBatch::try_new(self.schema.clone(), e.columns_ref()) {
+                            Err(err) => Some(Err(err)),
+                            Ok(record_batch) => {
+                                if record_batch.num_rows() > 0 {
+                                    Some(Ok(record_batch))
+                                } else {
+                                    None
+                                }
+                            }
+                        }
+                    }
                 }
-            })
+            }
+        }
     }
 }
 
@@ -472,7 +473,7 @@ mod tests {
         for i in 0..opts.num_iterations {
             let start = i * opts.record_batch_size;
 
-            let batch = record_reader.next_batch().unwrap();
+            let batch = record_reader.next_batch();
             if start < expected_data.len() {
                 let end = min(start + opts.record_batch_size, expected_data.len());
                 assert!(batch.is_some());
@@ -483,6 +484,7 @@ mod tests {
                 assert_eq!(
                     &converter.convert(data).unwrap(),
                     batch
+                        .unwrap()
                         .unwrap()
                         .column(0)
                         .as_any()
@@ -555,8 +557,7 @@ mod tests {
         for i in 0..20 {
             let array: Option<StructArray> = record_batch_reader
                 .next_batch()
-                .expect("Failed to read record batch!")
-                .map(|r| r.into());
+                .map(|r| r.expect("Failed to read record batch!").into());
 
             let (start, end) = (i * 60 as usize, (i + 1) * 60 as usize);
 

--- a/rust/parquet/src/arrow/mod.rs
+++ b/rust/parquet/src/arrow/mod.rs
@@ -39,8 +39,8 @@
 //!
 //! let mut record_batch_reader = arrow_reader.get_record_reader(2048).unwrap();
 //!
-//! loop {
-//!    let record_batch = record_batch_reader.next_batch().unwrap().unwrap();
+//! for maybe_record_batch in record_batch_reader {
+//!    let record_batch = maybe_record_batch.unwrap();
 //!    if record_batch.num_rows() > 0 {
 //!        println!("Read {} records.", record_batch.num_rows());
 //!    } else {


### PR DESCRIPTION
This is a proposal to change how we programmatically iterate over record batches in arrow and datafusion.

Instead of 

```rust
pub fn collect(
    it: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
) -> Result<Vec<RecordBatch>> {
    let mut reader = it.lock().unwrap();
    let mut results: Vec<RecordBatch> = vec![];
    loop {
        match reader.next_batch() {
            Ok(Some(batch)) => {
                results.push(batch);
            }
            Ok(None) => {
                // end of result set
                return Ok(results);
            }
            Err(e) => return Err(ExecutionError::from(e)),
        }
    }
}
```

use 

```rust
pub fn collect(
    it: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
) -> Result<Vec<RecordBatch>> {
    it.lock()
        .unwrap()
        .into_iter()
        .collect::<ArrowResult<Vec<_>>>()
        .map_err(|e| ExecutionError::from(e))
}
```

I.e. via the `Iterator` trait.

This allow us to write more expressive code, as well as offer a well documented and popular API to our users (Iterator).

Finally, this change also opens the possibility to implement `future::Stream`, the async version of `Iterator`.