### PR TITLE
ARROW-9946: [R] Check `sink` argument class in `ParquetFileWriter`

### DIFF
--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -359,6 +359,13 @@ ParquetWriterProperties$create <- function(table,
 #' - `sink` An [arrow::io::OutputStream][OutputStream]
 #' - `properties` An instance of [ParquetWriterProperties]
 #' - `arrow_properties` An instance of `ParquetArrowWriterProperties`
+#'
+#' @section Methods:
+#'
+#' - `WriteTable` Write a [Table] to `sink`
+#' - `Close` Close the writer. Note: does not close the `sink`.
+#'   [arrow::io::OutputStream][OutputStream] has its own `close()` method.
+#'
 #' @export
 #' @include arrow-package.R
 ParquetFileWriter <- R6Class("ParquetFileWriter", inherit = ArrowObject,
@@ -373,6 +380,9 @@ ParquetFileWriter$create <- function(schema,
                                      sink,
                                      properties = ParquetWriterProperties$create(),
                                      arrow_properties = ParquetArrowWriterProperties$create()) {
+  if (!inherits(sink, "OutputStream")) {
+    abort("ParquetFileWriter sink must be an FileOutputStream or BufferOutputStream")
+  }
   shared_ptr(
     ParquetFileWriter,
     parquet___arrow___ParquetFileWriter__Open(schema, sink, properties, arrow_properties)

--- a/r/R/parquet.R
+++ b/r/R/parquet.R
@@ -380,9 +380,7 @@ ParquetFileWriter$create <- function(schema,
                                      sink,
                                      properties = ParquetWriterProperties$create(),
                                      arrow_properties = ParquetArrowWriterProperties$create()) {
-  if (!inherits(sink, "OutputStream")) {
-    abort("ParquetFileWriter sink must be an FileOutputStream or BufferOutputStream")
-  }
+  assert_is(sink, "OutputStream")
   shared_ptr(
     ParquetFileWriter,
     parquet___arrow___ParquetFileWriter__Open(schema, sink, properties, arrow_properties)

--- a/r/man/ParquetFileWriter.Rd
+++ b/r/man/ParquetFileWriter.Rd
@@ -20,3 +20,12 @@ takes the following arguments:
 }
 }
 
+\section{Methods}{
+
+\itemize{
+\item \code{WriteTable} Write a \link{Table} to \code{sink}
+\item \code{Close} Close the writer. Note: does not close the \code{sink}.
+\link[=OutputStream]{arrow::io::OutputStream} has its own \code{close()} method.
+}
+}
+

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -191,3 +191,12 @@ test_that("write_parquet() handles version argument", {
     expect_error(write_parquet(df, tf, version = .x))
   })
 })
+
+test_that("ParquetFileWriter raises an error for non-OutputStream sink", {
+  sch = schema(a = float32())
+  # ARROW-9946
+  expect_error(
+    ParquetFileWriter$create(schema = sch, sink = tempfile()),
+    regex = "OutputStream"
+  )
+})


### PR DESCRIPTION
Fixes and documentation discussed in https://issues.apache.org/jira/browse/ARROW-9946