### PR TITLE
ARROW-10060: [Rust] [DataFusion] Fixed error on which Err were discarded in MergeExec.

### DIFF
--- a/rust/datafusion/src/physical_plan/merge.rs
+++ b/rust/datafusion/src/physical_plan/merge.rs
@@ -111,9 +111,9 @@ impl ExecutionPlan for MergeExec {
                             let mut batches = vec![];
                             for partition in chunk {
                                 let it = input.execute(partition)?;
-                                common::collect(it).iter().for_each(|b| {
-                                    b.iter().for_each(|b| batches.push(b.clone()))
-                                });
+                                common::collect(it)?
+                                    .iter()
+                                    .for_each(|b| batches.push(b.clone()));
                             }
                             Ok(batches)
                         })


### PR DESCRIPTION
Just found this sneaky error while working on UDAFs...