### PR TITLE
ARROW-10063: [Archery][CI] Fetch main branch in archery build only when it is a pull request

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Git Fixup
+        if: ${{ github.event_name == 'pull_request' }}
         shell: bash
         run: git branch master origin/master
       - name: Free Up Disk Space


### PR DESCRIPTION
Arrow's git data for the main branch is required to test the release curation scripts.

While the build properly works from pull requests it is failing on the main branch since the requested branch already exists: https://github.com/apache/arrow/runs/1148584775