### PR TITLE
ARROW-10064: [C++] Resolve compile warnings on Apple Clang 12

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -1154,7 +1154,7 @@ Status GetKeyValueMetadata(const KVVector* fb_metadata,
   auto metadata = std::make_shared<KeyValueMetadata>();
 
   metadata->reserve(fb_metadata->size());
-  for (const auto& pair : *fb_metadata) {
+  for (const auto pair : *fb_metadata) {
     CHECK_FLATBUFFERS_NOT_NULL(pair->key(), "custom_metadata.key");
     CHECK_FLATBUFFERS_NOT_NULL(pair->value(), "custom_metadata.value");
     metadata->Append(pair->key()->str(), pair->value()->str());

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -169,7 +169,7 @@ std::string Uri::path() const {
     ss << "/";
   }
   bool first = true;
-  for (const auto seg : segments) {
+  for (const auto& seg : segments) {
     if (!first) {
       ss << "/";
     }


### PR DESCRIPTION
```
../src/arrow/util/uri.cc:172:19: error: loop variable 'seg' of type 'const nonstd::sv_lite::basic_string_view<char, std::__1::char_traits<char> >' creates a copy from type 'const nonstd::sv_lite::basic_string_view<char, std::__1::char_traits<char> >' [-Werror,-Wrange-loop-analysis]
  for (const auto seg : segments) {
                  ^
../src/arrow/util/uri.cc:172:8: note: use reference type 'const nonstd::sv_lite::basic_string_view<char, std::__1::char_traits<char> > &' to prevent copying
  for (const auto seg : segments) {
       ^~~~~~~~~~~~~~~~
                  & 
```

and

```
../src/arrow/ipc/metadata_internal.cc:1157:20: error: loop variable 'pair' is always a copy because the range of type 'const arrow::ipc::internal::KVVector' (aka 'const Vector<Offset<flatbuf::KeyValue> >') does not return a reference [-Werror,-Wrange-loo
p-analysis]
  for (const auto& pair : *fb_metadata) {
                   ^
../src/arrow/ipc/metadata_internal.cc:1157:8: note: use non-reference type 'const org::apache::arrow::flatbuf::KeyValue *'
  for (const auto& pair : *fb_metadata) {
       ^~~~~~~~~~~~~~~~~~
```
