### PR TITLE
ARROW-10038: [C++] Spawn thread pool threads lazily

### DIFF
--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -51,6 +51,10 @@ struct ThreadPool::State {
 
   // Desired number of threads
   int desired_capacity_ = 0;
+
+  // Number of threads ready to execute a task immediately
+  int ready_count_ = 0;
+
   // Are we shutting down?
   bool please_shutdown_ = false;
   bool quick_shutdown_ = false;
@@ -71,6 +75,7 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
     return state->workers_.size() > static_cast<size_t>(state->desired_capacity_);
   };
 
+  ++state->ready_count_;
   while (true) {
     // By the time this thread is started, some tasks may have been pushed
     // or shutdown could even have been requested.  So we only wait on the
@@ -83,6 +88,8 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
       if (should_secede()) {
         break;
       }
+      --state->ready_count_;
+      DCHECK_GE(state->ready_count_, 0);
       {
         FnOnce<void()> task = std::move(state->pending_tasks_.front());
         state->pending_tasks_.pop_front();
@@ -90,6 +97,7 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
         std::move(task)();
       }
       lock.lock();
+      ++state->ready_count_;
     }
     // Now either the queue is empty *or* a quick shutdown was requested
     if (state->please_shutdown_ || should_secede()) {
@@ -98,6 +106,8 @@ static void WorkerLoop(std::shared_ptr<ThreadPool::State> state,
     // Wait for next wakeup
     state->cv_.wait(lock);
   }
+  --state->ready_count_;
+  DCHECK_GE(state->ready_count_, 0);
 
   // We're done.  Move our thread object to the trashcan of finished
   // workers.  This has two motivations:
@@ -168,11 +178,14 @@ Status ThreadPool::SetCapacity(int threads) {
   CollectFinishedWorkersUnlocked();
 
   state_->desired_capacity_ = threads;
-  int diff = static_cast<int>(threads - state_->workers_.size());
-  if (diff > 0) {
-    LaunchWorkersUnlocked(diff);
-  } else if (diff < 0) {
-    // Wake threads to ask them to stop
+  // See if we need to increase or decrease the number of running threads
+  const int required = std::min(static_cast<int>(state_->pending_tasks_.size()),
+                                threads - static_cast<int>(state_->workers_.size()));
+  if (required > 0) {
+    // Some tasks are pending, spawn the number of needed threads immediately
+    LaunchWorkersUnlocked(required);
+  } else if (required < 0) {
+    // Excess threads are running, wake them so that they stop
     state_->cv_.notify_all();
   }
   return Status::OK();
@@ -207,6 +220,7 @@ Status ThreadPool::Shutdown(bool wait) {
     state_->pending_tasks_.clear();
   }
   CollectFinishedWorkersUnlocked();
+  DCHECK_EQ(state_->ready_count_, 0);
   return Status::OK();
 }
 
@@ -236,6 +250,12 @@ Status ThreadPool::SpawnReal(TaskHints hints, FnOnce<void()> task) {
       return Status::Invalid("operation forbidden during or after shutdown");
     }
     CollectFinishedWorkersUnlocked();
+    if (state_->desired_capacity_ > static_cast<int>(state_->workers_.size()) &&
+        state_->ready_count_ == 0) {
+      // Pool capacity is not full and no workers are ready to execute the task,
+      // spawn one more thread.
+      LaunchWorkersUnlocked(/*threads=*/1);
+    }
     state_->pending_tasks_.push_back(std::move(task));
   }
   state_->cv_.notify_one();

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -142,8 +142,12 @@ class ARROW_EXPORT ThreadPool : public Executor {
   int GetCapacity() override;
 
   // Dynamically change the number of worker threads.
-  // This function returns quickly, but it may take more time before the
-  // thread count is fully adjusted.
+  //
+  // This function always returns immediately.
+  // If fewer threads are running than this number, new threads are spawned
+  // on-demand when needed for task execution.
+  // If more threads are running than this number, excess threads are reaped
+  // as soon as possible.
   Status SetCapacity(int threads);
 
   // Heuristic for the default capacity of a thread pool for CPU-bound tasks.


### PR DESCRIPTION
Thread pool threads are not spawned until necessary to execute a pending task.