### PR TITLE
ARROW-10065: [Rust] Simplify code (+500, -1k)

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1468,7 +1468,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericStringArray<OffsetSize> {
         Self::from(data)
     }
 
-    fn from_vec(v: Vec<&str>, data_type: DataType) -> Self {
+    pub(crate) fn from_vec(v: Vec<&str>, data_type: DataType) -> Self {
         let mut offsets = Vec::with_capacity(v.len() + 1);
         let mut values = Vec::new();
         let mut length_so_far = OffsetSize::zero();
@@ -1486,7 +1486,7 @@ impl<OffsetSize: OffsetSizeTrait> GenericStringArray<OffsetSize> {
         Self::from(array_data)
     }
 
-    fn from_opt_vec(v: Vec<Option<&str>>, data_type: DataType) -> Self {
+    pub(crate) fn from_opt_vec(v: Vec<Option<&str>>, data_type: DataType) -> Self {
         let mut offsets = Vec::with_capacity(v.len() + 1);
         let mut values = Vec::new();
         let mut null_buf = make_null_buffer(v.len());

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1071,15 +1071,15 @@ impl<OffsetSize: OffsetSizeTrait> ListArrayOps<OffsetSize>
 }
 
 /// A list array where each element is a variable-sized sequence of values with the same
-/// type.
+/// type whose memory offsets between elements are represented by a i32.
 pub type ListArray = GenericListArray<i32>;
 
 /// A list array where each element is a variable-sized sequence of values with the same
-/// type.
+/// type whose memory offsets between elements are represented by a i64.
 pub type LargeListArray = GenericListArray<i64>;
 
 /// A list array where each element is a fixed-size sequence of values with the same
-/// type.
+/// type whose maximum length is represented by a i32.
 pub struct FixedSizeListArray {
     data: ArrayDataRef,
     values: ArrayRef,
@@ -1356,12 +1356,10 @@ impl<OffsetSize: OffsetSizeTrait> From<ArrayDataRef> for GenericBinaryArray<Offs
     }
 }
 
-/// A list array where each element is a variable-sized sequence of values with the same
-/// type.
+/// An array where each element is a byte whose maximum length is represented by a i32.
 pub type BinaryArray = GenericBinaryArray<i32>;
 
-/// A list array where each element is a variable-sized sequence of values with the same
-/// type.
+/// An array where each element is a byte whose maximum length is represented by a i64.
 pub type LargeBinaryArray = GenericBinaryArray<i64>;
 
 impl From<Vec<&[u8]>> for BinaryArray {
@@ -1532,12 +1530,12 @@ impl<OffsetSize: OffsetSizeTrait> ListArrayOps<OffsetSize>
     }
 }
 
-/// A string array where each element is a variable-sized sequence of bytes and whose offsets
-/// between are then as i32
+/// An array where each element is a variable-sized sequence of bytes representing a string
+/// whose maximum length (in bytes) is represented by a i32.
 pub type StringArray = GenericStringArray<i32>;
 
-/// A string array where each element is a variable-sized sequence of bytes and whose offsets
-/// between are then as i64
+/// An array where each element is a variable-sized sequence of bytes representing a string
+/// whose maximum length (in bytes) is represented by a i64.
 pub type LargeStringArray = GenericStringArray<i64>;
 
 impl From<ListArray> for StringArray {

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -1412,40 +1412,50 @@ mod tests {
         // assert!(b_slice.equals(&*a_slice));
     }
 
-    #[test]
-    fn test_string_equal() {
-        let a = StringArray::from(vec!["hello", "world"]);
-        let b = StringArray::from(vec!["hello", "world"]);
+    fn test_generic_string_equal<OffsetSize: OffsetSizeTrait>(datatype: DataType) {
+        let a = GenericStringArray::<OffsetSize>::from_vec(
+            vec!["hello", "world"],
+            datatype.clone(),
+        );
+        let b = GenericStringArray::<OffsetSize>::from_vec(
+            vec!["hello", "world"],
+            datatype.clone(),
+        );
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        let b = StringArray::from(vec!["hello", "arrow"]);
+        let b = GenericStringArray::<OffsetSize>::from_vec(
+            vec!["hello", "arrow"],
+            datatype.clone(),
+        );
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
         // Test the case where null_count > 0
 
-        let a =
-            StringArray::from(vec![Some("hello"), None, None, Some("world"), None, None]);
+        let a = GenericStringArray::<OffsetSize>::from_opt_vec(
+            vec![Some("hello"), None, None, Some("world"), None, None],
+            datatype.clone(),
+        );
 
-        let b =
-            StringArray::from(vec![Some("hello"), None, None, Some("world"), None, None]);
+        let b = GenericStringArray::<OffsetSize>::from_opt_vec(
+            vec![Some("hello"), None, None, Some("world"), None, None],
+            datatype.clone(),
+        );
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        let b = StringArray::from(vec![
-            Some("hello"),
-            Some("foo"),
-            None,
-            Some("world"),
-            None,
-            None,
-        ]);
+        let b = GenericStringArray::<OffsetSize>::from_opt_vec(
+            vec![Some("hello"), Some("foo"), None, Some("world"), None, None],
+            datatype.clone(),
+        );
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
-        let b =
-            StringArray::from(vec![Some("hello"), None, None, Some("arrow"), None, None]);
+        let b = GenericStringArray::<OffsetSize>::from_opt_vec(
+            vec![Some("hello"), None, None, Some("arrow"), None, None],
+            datatype.clone(),
+        );
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
@@ -1468,76 +1478,13 @@ mod tests {
     }
 
     #[test]
+    fn test_string_equal() {
+        test_generic_string_equal::<i32>(DataType::Utf8)
+    }
+
+    #[test]
     fn test_large_string_equal() {
-        let a = LargeStringArray::from(vec!["hello", "world"]);
-        let b = LargeStringArray::from(vec!["hello", "world"]);
-        assert!(a.equals(&b));
-        assert!(b.equals(&a));
-
-        let b = LargeStringArray::from(vec!["hello", "arrow"]);
-        assert!(!a.equals(&b));
-        assert!(!b.equals(&a));
-
-        // Test the case where null_count > 0
-
-        let a = LargeStringArray::from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("world"),
-            None,
-            None,
-        ]);
-
-        let b = LargeStringArray::from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("world"),
-            None,
-            None,
-        ]);
-        assert!(a.equals(&b));
-        assert!(b.equals(&a));
-
-        let b = LargeStringArray::from(vec![
-            Some("hello"),
-            Some("foo"),
-            None,
-            Some("world"),
-            None,
-            None,
-        ]);
-        assert!(!a.equals(&b));
-        assert!(!b.equals(&a));
-
-        let b = LargeStringArray::from(vec![
-            Some("hello"),
-            None,
-            None,
-            Some("arrow"),
-            None,
-            None,
-        ]);
-        assert!(!a.equals(&b));
-        assert!(!b.equals(&a));
-
-        // Test the case where offset != 0
-
-        let a_slice = a.slice(0, 3);
-        let b_slice = b.slice(0, 3);
-        assert!(a_slice.equals(&*b_slice));
-        assert!(b_slice.equals(&*a_slice));
-
-        let a_slice = a.slice(0, 5);
-        let b_slice = b.slice(0, 5);
-        assert!(!a_slice.equals(&*b_slice));
-        assert!(!b_slice.equals(&*a_slice));
-
-        let a_slice = a.slice(4, 1);
-        let b_slice = b.slice(4, 1);
-        assert!(a_slice.equals(&*b_slice));
-        assert!(b_slice.equals(&*a_slice));
+        test_generic_string_equal::<i64>(DataType::LargeUtf8)
     }
 
     #[test]

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -158,6 +158,7 @@ pub type DurationNanosecondArray = PrimitiveArray<DurationNanosecondType>;
 pub use self::array::GenericBinaryArray;
 pub use self::array::GenericListArray;
 pub use self::array::GenericStringArray;
+pub use self::array::OffsetSizeTrait;
 pub use self::array::PrimitiveArrayOps;
 
 // --------------------- Array Builder ---------------------

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -155,10 +155,10 @@ pub type DurationMillisecondArray = PrimitiveArray<DurationMillisecondType>;
 pub type DurationMicrosecondArray = PrimitiveArray<DurationMicrosecondType>;
 pub type DurationNanosecondArray = PrimitiveArray<DurationNanosecondType>;
 
-pub use self::array::LargeListArrayOps;
-pub use self::array::ListArrayOps;
+pub use self::array::GenericBinaryArray;
+pub use self::array::GenericListArray;
+pub use self::array::GenericStringArray;
 pub use self::array::PrimitiveArrayOps;
-pub use self::array::StringArrayOps;
 
 // --------------------- Array Builder ---------------------
 

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -19,9 +19,7 @@
 
 use std::ops::Add;
 
-use crate::array::{
-    Array, LargeStringArray, PrimitiveArray, StringArray, StringArrayOps,
-};
+use crate::array::{Array, LargeStringArray, PrimitiveArray, StringArray};
 use crate::datatypes::ArrowNumericType;
 
 /// Helper macro to perform min/max of strings

--- a/rust/arrow/src/compute/kernels/concat.rs
+++ b/rust/arrow/src/compute/kernels/concat.rs
@@ -53,7 +53,7 @@ pub fn concat(array_list: &[ArrayRef]) -> Result<ArrayRef> {
 
     match array_data_list[0].data_type() {
         DataType::Utf8 => {
-            let mut builder = StringArray::builder(0);
+            let mut builder = StringBuilder::new(0);
             builder.append_data(array_data_list)?;
             Ok(ArrayBuilder::finish(&mut builder))
         }

--- a/rust/arrow/src/compute/kernels/take.rs
+++ b/rust/arrow/src/compute/kernels/take.rs
@@ -107,12 +107,8 @@ pub fn take(
         DataType::Duration(TimeUnit::Nanosecond) => {
             take_primitive::<DurationNanosecondType>(values, indices)
         }
-        DataType::Utf8 => {
-            take_string::<i32, StringArray>(values, indices, DataType::Utf8)
-        }
-        DataType::LargeUtf8 => {
-            take_string::<i64, LargeStringArray>(values, indices, DataType::LargeUtf8)
-        }
+        DataType::Utf8 => take_string::<i32>(values, indices, DataType::Utf8),
+        DataType::LargeUtf8 => take_string::<i64>(values, indices, DataType::LargeUtf8),
         DataType::List(_) => take_list(values, indices),
         DataType::Struct(fields) => {
             let struct_: &StructArray =
@@ -250,19 +246,19 @@ fn take_boolean(values: &ArrayRef, indices: &UInt32Array) -> Result<ArrayRef> {
 }
 
 /// `take` implementation for string arrays
-fn take_string<T>(
+fn take_string<OffsetSize>(
     values: &ArrayRef,
     indices: &UInt32Array,
     data_type: DataType,
 ) -> Result<ArrayRef>
 where
-    T: Zero + AddAssign + ToByteSlice + ArrowNativeType,
+    OffsetSize: Zero + AddAssign + OffsetSizeTrait,
 {
     let data_len = indices.len();
 
     let array = values
         .as_any()
-        .downcast_ref::<GenericStringArray<T>>()
+        .downcast_ref::<GenericStringArray<OffsetSize>>()
         .unwrap();
 
     let num_bytes = bit_util::ceil(data_len, 8);
@@ -271,7 +267,7 @@ where
 
     let mut offsets = Vec::with_capacity(data_len + 1);
     let mut values = Vec::with_capacity(data_len);
-    let mut length_so_far = T::zero();
+    let mut length_so_far = OffsetSize::zero();
 
     offsets.push(length_so_far);
     for i in 0..data_len {
@@ -280,7 +276,7 @@ where
         if array.is_valid(index) && indices.is_valid(i) {
             let s = array.value(index);
 
-            length_so_far += T::from_usize(s.len()).unwrap();
+            length_so_far += OffsetSize::from_usize(s.len()).unwrap();
             values.extend_from_slice(s.as_bytes());
         } else {
             // set null bit
@@ -300,7 +296,7 @@ where
         .add_buffer(Buffer::from(offsets.to_byte_slice()))
         .add_buffer(Buffer::from(&values[..]))
         .build();
-    Ok(Arc::new(GenericStringArray::<T>::from(data)))
+    Ok(Arc::new(GenericStringArray::<OffsetSize>::from(data)))
 }
 
 /// `take` implementation for list arrays

--- a/rust/arrow/src/util/pretty.rs
+++ b/rust/arrow/src/util/pretty.rs
@@ -18,7 +18,7 @@
 //! Utilities for printing record batches
 
 use crate::array;
-use crate::array::{PrimitiveArrayOps, StringArrayOps};
+use crate::array::PrimitiveArrayOps;
 use crate::datatypes::{DataType, TimeUnit};
 use crate::record_batch::RecordBatch;
 

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -517,7 +517,6 @@ mod tests {
     use crate::variable::VarType;
     use arrow::array::{
         ArrayRef, Float64Array, Int32Array, PrimitiveArrayOps, StringArray,
-        StringArrayOps,
     };
     use arrow::compute::add;
     use std::fs::File;

--- a/rust/datafusion/src/physical_plan/datetime_expressions.rs
+++ b/rust/datafusion/src/physical_plan/datetime_expressions.rs
@@ -21,9 +21,7 @@ use std::sync::Arc;
 
 use crate::error::{ExecutionError, Result};
 use arrow::{
-    array::{
-        Array, ArrayData, ArrayRef, StringArray, StringArrayOps, TimestampNanosecondArray,
-    },
+    array::{Array, ArrayData, ArrayRef, StringArray, TimestampNanosecondArray},
     buffer::Buffer,
     datatypes::{DataType, TimeUnit, ToByteSlice},
 };
@@ -211,7 +209,7 @@ pub fn to_timestamp(args: &[ArrayRef]) -> Result<TimestampNanosecondArray> {
 mod tests {
     use std::sync::Arc;
 
-    use arrow::array::Int64Array;
+    use arrow::array::{Int64Array, StringBuilder};
 
     use super::*;
 
@@ -361,7 +359,7 @@ mod tests {
     fn to_timestamp_arrays_and_nulls() -> Result<()> {
         // ensure that arrow array implementation is wired up and handles nulls correctly
 
-        let mut string_builder = StringArray::builder(2);
+        let mut string_builder = StringBuilder::new(2);
         let mut ts_builder = TimestampNanosecondArray::builder(2);
 
         string_builder.append_value("2020-09-08T13:42:29.190855Z")?;

--- a/rust/datafusion/src/physical_plan/explain.rs
+++ b/rust/datafusion/src/physical_plan/explain.rs
@@ -23,7 +23,7 @@ use crate::{
     physical_plan::{common::RecordBatchIterator, ExecutionPlan},
 };
 use arrow::{
-    array::StringArray,
+    array::StringBuilder,
     datatypes::SchemaRef,
     record_batch::{RecordBatch, RecordBatchReader},
 };
@@ -92,8 +92,8 @@ impl ExecutionPlan for ExplainExec {
             )));
         }
 
-        let mut type_builder = StringArray::builder(self.stringified_plans.len());
-        let mut plan_builder = StringArray::builder(self.stringified_plans.len());
+        let mut type_builder = StringBuilder::new(self.stringified_plans.len());
+        let mut plan_builder = StringBuilder::new(self.stringified_plans.len());
 
         for p in &self.stringified_plans {
             type_builder.append_value(&String::from(&p.plan_type))?;

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1604,7 +1604,7 @@ mod tests {
     use super::*;
     use crate::error::Result;
     use arrow::array::{
-        LargeStringArray, PrimitiveArray, PrimitiveArrayOps, StringArray, StringArrayOps,
+        LargeStringArray, PrimitiveArray, PrimitiveArrayOps, StringArray,
         Time64NanosecondArray,
     };
     use arrow::datatypes::*;

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -353,7 +353,7 @@ mod tests {
     use arrow::{
         array::{
             ArrayRef, FixedSizeListArray, Float64Array, Int32Array, PrimitiveArrayOps,
-            StringArray, StringArrayOps,
+            StringArray,
         },
         datatypes::Field,
         record_batch::RecordBatch,

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -25,7 +25,7 @@ use crate::error::{ExecutionError, Result};
 use crate::physical_plan::{Accumulator, AggregateExpr};
 use crate::physical_plan::{Distribution, ExecutionPlan, Partitioning, PhysicalExpr};
 
-use crate::arrow::array::{PrimitiveArrayOps, StringArrayOps};
+use crate::arrow::array::PrimitiveArrayOps;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};

--- a/rust/datafusion/src/physical_plan/string_expressions.rs
+++ b/rust/datafusion/src/physical_plan/string_expressions.rs
@@ -18,7 +18,7 @@
 //! String expressions
 
 use crate::error::{ExecutionError, Result};
-use arrow::array::{Array, ArrayRef, StringArray, StringArrayOps, StringBuilder};
+use arrow::array::{Array, ArrayRef, StringArray, StringBuilder};
 
 macro_rules! downcast_vec {
     ($ARGS:expr, $ARRAY_TYPE:ident) => {{

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -25,7 +25,7 @@ use arrow::array::{
     UInt8Array,
 };
 use arrow::{
-    array::{ArrayRef, PrimitiveArrayOps, StringArrayOps},
+    array::{ArrayRef, PrimitiveArrayOps},
     datatypes::DataType,
 };
 

--- a/rust/datafusion/tests/user_defined_plan.rs
+++ b/rust/datafusion/tests/user_defined_plan.rs
@@ -59,7 +59,8 @@
 //!
 
 use arrow::{
-    array::{Int64Array, PrimitiveArrayOps, StringArray, StringArrayOps},
+    array::StringBuilder,
+    array::{Int64Array, PrimitiveArrayOps, StringArray},
     datatypes::SchemaRef,
     error::ArrowError,
     record_batch::{RecordBatch, RecordBatchReader},
@@ -488,7 +489,7 @@ impl RecordBatchReader for TopKReader {
         }
 
         let mut revenue_builder = Int64Array::builder(self.top_values.len());
-        let mut customer_id_builder = StringArray::builder(self.top_values.len());
+        let mut customer_id_builder = StringBuilder::new(self.top_values.len());
 
         // make output by walking over the map backwards (so values are descending)
         for (revenue, customer_id) in self.top_values.iter().rev() {

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -939,9 +939,7 @@ mod tests {
         DataPageBuilder, DataPageBuilderImpl, InMemoryPageIterator,
     };
     use crate::util::test_common::{get_test_file, make_pages};
-    use arrow::array::{
-        Array, ArrayRef, PrimitiveArray, StringArray, StringArrayOps, StructArray,
-    };
+    use arrow::array::{Array, ArrayRef, PrimitiveArray, StringArray, StructArray};
     use arrow::datatypes::{
         DataType as ArrowType, Date32Type as ArrowDate32, Field, Int32Type as ArrowInt32,
         TimestampMicrosecondType as ArrowTimestampMicrosecondType,


### PR DESCRIPTION
This is a major internal simplification of Rust's code base, with no change of functionality apart of the no longer needed `StringArrayOps` that this PR removes.

The main idea behind this PR is that when we have array types that implement `i32` and `i64` (large), we can declare them as a generic struct of the form

```rust
pub struct GenericXArray<OffsetSize>
```

as they have a uniform representation under the trait. Specifically:

* `[Large]BinaryArray`'s represents `[u8]`
* `[Large]ListArray`'s represents `[ArrayRef]`
* `[Large]StringArray`'s represents `[&str]`

This PR does this for

```rust
pub struct GenericBinaryArray<OffsetSize>
pub struct GenericStringArray<OffsetSize>
pub struct GenericListArray<OffsetSize>
```

where `OffsetSize` is either `i64` or `i32`.

The actual arrays are then implemented as

```rust
pub type BinaryArray = GenericBinaryArray<i32>;
pub type LargeBinaryArray = GenericBinaryArray<i64>;

pub type ListArray = GenericListArray<i32>;
pub type LargeListArray = GenericListArray<i64>;

pub type StringArray = GenericStringArray<i32>;
pub type LargeStringArray = GenericStringArray<i64>;
```

This leads to a massive removal of code. Since all of this is statically typed, the actual work is done by the compiler and we just have less code to maintain.

There is more code that continues to be duplicated on `equal.rs`, but I decided to leave that to a separate PR.

FYI @nevi-me @paddyhoran @andygrove 