### PR TITLE
ARROW-10071: [R] segfault with ArrowObject from previous session, or saved

### DIFF
--- a/cpp/src/arrow/util/nameof.h
+++ b/cpp/src/arrow/util/nameof.h
@@ -1,0 +1,86 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <string>
+
+namespace arrow {
+namespace util {
+namespace detail {
+
+#ifdef _MSC_VER
+#define ARROW_PRETTY_FUNCTION __FUNCSIG__
+#else
+#define ARROW_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#endif
+
+template <typename T>
+constexpr const char* raw() {
+  return ARROW_PRETTY_FUNCTION;
+}
+
+template <typename T>
+constexpr size_t raw_sizeof() {
+  return sizeof(ARROW_PRETTY_FUNCTION);
+}
+
+#undef ARROW_PRETTY_FUNCTION
+
+constexpr bool starts_with(char const* haystack, char const* needle) {
+  return needle[0] == '\0' ||
+         (haystack[0] == needle[0] && starts_with(haystack + 1, needle + 1));
+}
+
+constexpr std::size_t search(char const* haystack, char const* needle) {
+  return haystack[0] == '\0' || starts_with(haystack, needle)
+             ? 0
+             : search(haystack + 1, needle) + 1;
+}
+
+constexpr auto typename_prefix = search(raw<void>(), "void");
+
+template <typename T>
+constexpr size_t struct_class_prefix() {
+#ifdef _MSC_VER
+  return starts_with(raw<T>() + typename_prefix, "struct ")
+             ? 7
+             : starts_with(raw<T>() + typename_prefix, "class ") ? 6 : 0;
+#else
+  return 0;
+#endif
+}
+
+template <typename T>
+constexpr size_t typename_length() {
+  // raw_sizeof<T>() - raw_sizeof<void>() == (length of T's name) - strlen("void")
+  // (length of T's name) == raw_sizeof<T>() - raw_sizeof<void>() + strlen("void")
+  return raw_sizeof<T>() - raw_sizeof<void>() + 4;
+}
+
+template <typename T>
+constexpr const char* typename_begin() {
+  return raw<T>() + struct_class_prefix<T>() + typename_prefix;
+}
+
+}  // namespace detail
+
+template <typename T>
+std::string nameof() {
+  return {detail::typename_begin<T>(), detail::typename_length<T>()};
+}
+
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/arrow/util/nameof.h
+++ b/cpp/src/arrow/util/nameof.h
@@ -28,12 +28,12 @@ namespace detail {
 #endif
 
 template <typename T>
-constexpr const char* raw() {
+const char* raw() {
   return ARROW_PRETTY_FUNCTION;
 }
 
 template <typename T>
-constexpr size_t raw_sizeof() {
+size_t raw_sizeof() {
   return sizeof(ARROW_PRETTY_FUNCTION);
 }
 
@@ -44,16 +44,16 @@ constexpr bool starts_with(char const* haystack, char const* needle) {
          (haystack[0] == needle[0] && starts_with(haystack + 1, needle + 1));
 }
 
-constexpr std::size_t search(char const* haystack, char const* needle) {
+constexpr size_t search(char const* haystack, char const* needle) {
   return haystack[0] == '\0' || starts_with(haystack, needle)
              ? 0
              : search(haystack + 1, needle) + 1;
 }
 
-constexpr auto typename_prefix = search(raw<void>(), "void");
+const size_t typename_prefix = search(raw<void>(), "void");
 
 template <typename T>
-constexpr size_t struct_class_prefix() {
+size_t struct_class_prefix() {
 #ifdef _MSC_VER
   return starts_with(raw<T>() + typename_prefix, "struct ")
              ? 7
@@ -64,14 +64,14 @@ constexpr size_t struct_class_prefix() {
 }
 
 template <typename T>
-constexpr size_t typename_length() {
+size_t typename_length() {
   // raw_sizeof<T>() - raw_sizeof<void>() == (length of T's name) - strlen("void")
   // (length of T's name) == raw_sizeof<T>() - raw_sizeof<void>() + strlen("void")
   return raw_sizeof<T>() - raw_sizeof<void>() + 4;
 }
 
 template <typename T>
-constexpr const char* typename_begin() {
+const char* typename_begin() {
   return raw<T>() + struct_class_prefix<T>() + typename_prefix;
 }
 

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -16,11 +16,14 @@
 // under the License.
 
 #include <cstring>  // for strlen
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
 #undef Free
+
+#include "arrow/util/nameof.h"
 
 namespace cpp11 {
 
@@ -158,7 +161,8 @@ struct ns {
 template <typename Pointer>
 Pointer r6_to_pointer(SEXP self) {
   if (!Rf_inherits(self, "ArrowObject")) {
-    std::string type_name = typeid(typename std::remove_pointer<Pointer>::type).name();
+    std::string type_name =
+        arrow::util::nameof<typename std::remove_pointer<Pointer>::type>();
     cpp11::stop("Invalid R object for %s, must be an ArrowObject", type_name.c_str());
   }
   void* p = R_ExternalPtrAddr(Rf_findVarInFrame(self, arrow::r::symbols::xp));

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -16,7 +16,6 @@
 // under the License.
 
 #include <cstring>  // for strlen
-#include <iostream>
 #include <limits>
 #include <memory>
 #include <utility>

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -157,13 +157,14 @@ struct ns {
 
 template <typename Pointer>
 Pointer r6_to_pointer(SEXP self) {
+  if (!Rf_inherits(self, "ArrowObject")) {
+    std::string type_name = typeid(typename std::remove_pointer<Pointer>::type).name();
+    cpp11::stop("Invalid R object for %s, must be an ArrowObject", type_name.c_str());
+  }
   void* p = R_ExternalPtrAddr(Rf_findVarInFrame(self, arrow::r::symbols::xp));
   if (p == nullptr) {
     SEXP klass = Rf_getAttrib(self, R_ClassSymbol);
-    std::string first_class(Rf_isNull(klass) ? "ArrowObject"
-                                             : CHAR(STRING_ELT(klass, 0)));
-
-    cpp11::stop("Invalid <%s>, external pointer to null", first_class.c_str());
+    cpp11::stop("Invalid <%s>, external pointer to null", CHAR(STRING_ELT(klass, 0)));
   }
   return reinterpret_cast<Pointer>(p);
 }

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -157,8 +157,15 @@ struct ns {
 
 template <typename Pointer>
 Pointer r6_to_pointer(SEXP self) {
-  return reinterpret_cast<Pointer>(
-      R_ExternalPtrAddr(Rf_findVarInFrame(self, arrow::r::symbols::xp)));
+  void* p = R_ExternalPtrAddr(Rf_findVarInFrame(self, arrow::r::symbols::xp));
+  if (p == nullptr) {
+    SEXP klass = Rf_getAttrib(self, R_ClassSymbol);
+    std::string first_class(Rf_isNull(klass) ? "ArrowObject"
+                                             : CHAR(STRING_ELT(klass, 0)));
+
+    cpp11::stop("Invalid <%s>, external pointer to null", first_class.c_str());
+  }
+  return reinterpret_cast<Pointer>(p);
 }
 
 // T is either std::shared_ptr<U> or std::unique_ptr<U>

--- a/r/tests/testthat/test-arrow.R
+++ b/r/tests/testthat/test-arrow.R
@@ -47,3 +47,12 @@ r_only({
     )
   })
 })
+
+test_that("arrow gracefully fails to load objects from other sessions (ARROW-10071)", {
+  a <- Array$create(1:10)
+  tf <- tempfile(); on.exit(unlink(tf))
+  saveRDS(a, tf)
+
+  b <- readRDS(tf)
+  expect_error(b$length(), "Invalid <Array>")
+})

--- a/r/tests/testthat/test-arrow.R
+++ b/r/tests/testthat/test-arrow.R
@@ -56,3 +56,7 @@ test_that("arrow gracefully fails to load objects from other sessions (ARROW-100
   b <- readRDS(tf)
   expect_error(b$length(), "Invalid <Array>")
 })
+
+test_that("check for an ArrowObject in functions use std::shared_ptr", {
+  expect_error(Array__length(1), "Invalid R object")
+})


### PR DESCRIPTION
``` r
library(arrow, warn.conflicts = FALSE)

a <- Array$create(1:10)
tf <- tempfile()
saveRDS(a, tf)

b <- readRDS(tf)
b$length()
#> Error in Array__length(self): Invalid <Array>, external pointer to null
```

<sup>Created on 2020-09-23 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>