### PR TITLE
ARROW-10066: [C++] Make sure default AWS region selection algorithm is used

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -99,8 +99,6 @@ using internal::OutcomeToStatus;
 using internal::ToAwsString;
 using internal::ToURLEncodedAwsString;
 
-const char* kS3DefaultRegion = "";
-
 static const char kSep = '/';
 
 namespace {
@@ -471,7 +469,7 @@ class ClientBuilder {
 
   Result<std::unique_ptr<S3Client>> BuildClient() {
     credentials_provider_ = options_.credentials_provider;
-    if (options_.region != kS3DefaultRegion) {
+    if (!options_.region.empty()) {
       client_config_.region = ToAwsString(options_.region);
     }
     client_config_.endpointOverride = ToAwsString(options_.endpoint_override);

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -99,7 +99,7 @@ using internal::OutcomeToStatus;
 using internal::ToAwsString;
 using internal::ToURLEncodedAwsString;
 
-const char* kS3DefaultRegion = "us-east-1";
+const char* kS3DefaultRegion = "";
 
 static const char kSep = '/';
 
@@ -465,11 +465,15 @@ class ClientBuilder {
  public:
   explicit ClientBuilder(S3Options options) : options_(std::move(options)) {}
 
+  const Aws::Client::ClientConfiguration& config() const { return client_config_; }
+
   Aws::Client::ClientConfiguration* mutable_config() { return &client_config_; }
 
   Result<std::unique_ptr<S3Client>> BuildClient() {
     credentials_provider_ = options_.credentials_provider;
-    client_config_.region = ToAwsString(options_.region);
+    if (options_.region != kS3DefaultRegion) {
+      client_config_.region = ToAwsString(options_.region);
+    }
     client_config_.endpointOverride = ToAwsString(options_.endpoint_override);
     if (options_.scheme == "http") {
       client_config_.scheme = Aws::Http::Scheme::HTTP;
@@ -1082,6 +1086,10 @@ class S3FileSystem::Impl {
 
   const S3Options& options() const { return builder_.options(); }
 
+  std::string region() const {
+    return std::string(FromAwsString(builder_.config().region));
+  }
+
   // Create a bucket.  Successful if bucket already exists.
   Status CreateBucket(const std::string& bucket) {
     S3Model::CreateBucketConfiguration config;
@@ -1477,6 +1485,8 @@ bool S3FileSystem::Equals(const FileSystem& other) const {
 }
 
 S3Options S3FileSystem::options() const { return impl_->options(); }
+
+std::string S3FileSystem::region() const { return impl_->region(); }
 
 Result<FileInfo> S3FileSystem::GetFileInfo(const std::string& s) {
   ARROW_ASSIGN_OR_RAISE(auto path, S3Path::FromString(s));

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -40,12 +40,16 @@ class STSClient;
 namespace arrow {
 namespace fs {
 
-extern ARROW_EXPORT const char* kS3DefaultRegion;
-
 /// Options for the S3FileSystem implementation.
 struct ARROW_EXPORT S3Options {
-  /// AWS region to connect to (default "us-east-1")
-  std::string region = kS3DefaultRegion;
+  /// AWS region to connect to.
+  ///
+  /// If unset, the AWS SDK will choose a default value.  The exact algorithm
+  /// depends on the SDK version.  Before 1.8, the default is hardcoded
+  /// to "us-east-1".  Since 1.8, several heuristics are used to determine
+  /// the region (environment variables, configuration profile, EC2 metadata
+  /// server).
+  std::string region;
 
   /// If non-empty, override region with a connect string such as "localhost:9000"
   // XXX perhaps instead take a URL like "http://localhost:9000"?

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -132,7 +132,7 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
 
   std::string type_name() const override { return "s3"; }
 
-  /// Return the original S3 options when constructing with filesystem
+  /// Return the original S3 options when constructing the filesystem
   S3Options options() const;
   /// Return the actual region this filesystem connects to
   std::string region() const;

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -131,7 +131,11 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   ~S3FileSystem() override;
 
   std::string type_name() const override { return "s3"; }
+
+  /// Return the original S3 options when constructing with filesystem
   S3Options options() const;
+  /// Return the actual region this filesystem connects to
+  std::string region() const;
 
   bool Equals(const FileSystem& other) const override;
 

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -184,7 +184,7 @@ TEST_F(S3OptionsTest, FromUri) {
   S3Options options;
 
   ASSERT_OK_AND_ASSIGN(options, S3Options::FromUri("s3://", &path));
-  ASSERT_EQ(options.region, kS3DefaultRegion);
+  ASSERT_EQ(options.region, "");
   ASSERT_EQ(options.scheme, "https");
   ASSERT_EQ(options.endpoint_override, "");
   ASSERT_EQ(path, "");

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -52,6 +52,7 @@
 #endif
 
 #include <aws/core/Aws.h>
+#include <aws/core/Version.h>
 #include <aws/core/auth/AWSCredentials.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
 #include <aws/core/client/RetryStrategy.h>
@@ -71,6 +72,7 @@
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
+#include "arrow/util/checked_cast.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
@@ -78,9 +80,8 @@
 namespace arrow {
 namespace fs {
 
-using ::arrow::internal::DelEnvVar;
+using ::arrow::internal::checked_pointer_cast;
 using ::arrow::internal::PlatformFilename;
-using ::arrow::internal::SetEnvVar;
 using ::arrow::internal::UriEscape;
 
 using ::arrow::fs::internal::ConnectRetryStrategy;
@@ -116,16 +117,16 @@ namespace bp = boost::process;
 
 class AwsTestMixin : public ::testing::Test {
  public:
-  void SetUp() {
-    // we set this environment variable to speed up tests by ensuring
-    // DefaultAWSCredentialsProviderChain does not query (inaccessible)
-    // EC2 metadata endpoint
-    ASSERT_OK(SetEnvVar("AWS_EC2_METADATA_DISABLED", "true"));
-  }
-  void TearDown() { ASSERT_OK(DelEnvVar("AWS_EC2_METADATA_DISABLED")); }
+  // We set this environment variable to speed up tests by ensuring
+  // DefaultAWSCredentialsProviderChain does not query (inaccessible)
+  // EC2 metadata endpoint
+  AwsTestMixin() : ec2_metadata_disabled_guard_("AWS_EC2_METADATA_DISABLED", "true") {}
+
+ private:
+  EnvVarGuard ec2_metadata_disabled_guard_;
 };
 
-class S3TestMixin : public ::testing::Test {
+class S3TestMixin : public AwsTestMixin {
  public:
   void SetUp() override {
     ASSERT_OK(minio_.Start());
@@ -198,17 +199,23 @@ TEST_F(S3OptionsTest, FromUri) {
   ASSERT_EQ(creds.GetAWSSecretKey(), "secret");
 
   ASSERT_OK_AND_ASSIGN(options, S3Options::FromUri("s3://mybucket/", &path));
-  ASSERT_EQ(options.region, kS3DefaultRegion);
+  ASSERT_NE(options.region, "");  // Some region was chosen
   ASSERT_EQ(options.scheme, "https");
   ASSERT_EQ(options.endpoint_override, "");
   ASSERT_EQ(path, "mybucket");
 
   ASSERT_OK_AND_ASSIGN(options, S3Options::FromUri("s3://mybucket/foo/bar/", &path));
-  ASSERT_EQ(options.region, kS3DefaultRegion);
+  ASSERT_NE(options.region, "");
   ASSERT_EQ(options.scheme, "https");
   ASSERT_EQ(options.endpoint_override, "");
   ASSERT_EQ(path, "mybucket/foo/bar");
 
+  // Region resolution with a well-known bucket
+  ASSERT_OK_AND_ASSIGN(
+      options, S3Options::FromUri("s3://aws-earth-mo-atmospheric-ukv-prd/", &path));
+  ASSERT_EQ(options.region, "eu-west-2");
+
+  // Explicit region override
   ASSERT_OK_AND_ASSIGN(
       options,
       S3Options::FromUri(
@@ -283,6 +290,31 @@ TEST_F(S3RegionResolutionTest, NonExistentBucket) {
   ASSERT_RAISES(IOError, maybe_region);
   ASSERT_THAT(maybe_region.status().message(),
               ::testing::HasSubstr("Bucket 'ursa-labs-non-existent-bucket' not found"));
+}
+
+////////////////////////////////////////////////////////////////////////////
+// S3FileSystem region test
+
+class S3FileSystemRegionTest : public AwsTestMixin {};
+
+TEST_F(S3FileSystemRegionTest, Default) {
+  ASSERT_OK_AND_ASSIGN(auto fs, FileSystemFromUri("s3://"));
+  auto s3fs = checked_pointer_cast<S3FileSystem>(fs);
+  ASSERT_EQ(s3fs->region(), "us-east-1");
+}
+
+TEST_F(S3FileSystemRegionTest, EnvironmentVariable) {
+  // Region override with environment variable (AWS SDK >= 1.8)
+  EnvVarGuard region_guard("AWS_DEFAULT_REGION", "eu-north-1");
+
+  ASSERT_OK_AND_ASSIGN(auto fs, FileSystemFromUri("s3://"));
+  auto s3fs = checked_pointer_cast<S3FileSystem>(fs);
+
+  if (Aws::Version::GetVersionMajor() > 1 || Aws::Version::GetVersionMinor() >= 8) {
+    ASSERT_EQ(s3fs->region(), "eu-north-1");
+  } else {
+    ASSERT_EQ(s3fs->region(), "us-east-1");
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -446,7 +446,7 @@ class ARROW_TESTING_EXPORT LocaleGuard {
   std::unique_ptr<Impl> impl_;
 };
 
-class ARROW_EXPORT EnvVarGuard {
+class ARROW_TESTING_EXPORT EnvVarGuard {
  public:
   EnvVarGuard(const std::string& name, const std::string& value);
   ~EnvVarGuard();

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -446,6 +446,17 @@ class ARROW_TESTING_EXPORT LocaleGuard {
   std::unique_ptr<Impl> impl_;
 };
 
+class ARROW_EXPORT EnvVarGuard {
+ public:
+  EnvVarGuard(const std::string& name, const std::string& value);
+  ~EnvVarGuard();
+
+ protected:
+  const std::string name_;
+  std::string old_value_;
+  bool was_set_;
+};
+
 #ifndef ARROW_LARGE_MEMORY_TESTS
 #define LARGE_MEMORY_TEST(name) DISABLED_##name
 #else

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -218,4 +218,4 @@ cdef class S3FileSystem(FileSystem):
         """
         The AWS region this filesystem connects to.
         """
-        return frombytes(self.s3fs.options().region)
+        return frombytes(self.s3fs.region())

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -164,6 +164,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         @staticmethod
         CResult[shared_ptr[CS3FileSystem]] Make(const CS3Options& options)
         CS3Options options()
+        c_string region()
 
     cdef CStatus CInitializeS3 "arrow::fs::InitializeS3"(
         const CS3GlobalOptions& options)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1321,6 +1321,8 @@ def test_s3_real_aws():
     from pyarrow.fs import S3FileSystem
     fs = S3FileSystem(anonymous=True)
     assert fs.region == 'us-east-1'  # default region
+
+    fs = S3FileSystem(anonymous=True, region='us-east-2')
     entries = fs.get_file_info(FileSelector('ursa-labs-taxi-data'))
     assert len(entries) > 0
 


### PR DESCRIPTION
When the user doesn't set an explicit region, the default algorithm from the AWS C++ SDK should be used. 
With SDK versions >= 1.8, this involves reading environment variables and potentially querying the local EC2 metadata server.