### PR TITLE
ARROW-10085: [C++] Fix S3 region resolution on Windows

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -459,22 +459,20 @@ class S3Client : public Aws::S3::S3Client {
   }
 };
 
-// In AWS SDK < 1.8, Aws::Client::ClientConfiguration is a bool.
-// In AWS SDK >= 1.8, it's a Aws::Client::FollowRedirectsPolicy scoped enum.
-static constexpr bool HaveLegacyFollowRedirects =
-    std::is_same<bool,
-                 decltype(Aws::Client::ClientConfiguration().followRedirects)>::value;
-
-template <typename Config = Aws::Client::ClientConfiguration>
-void DisableRedirects(
-    typename std::enable_if<HaveLegacyFollowRedirects, Config*>::type config) {
-  config->followRedirects = false;
+// In AWS SDK < 1.8, Aws::Client::ClientConfiguration::followRedirects is a bool.
+template <bool Never = false>
+void DisableRedirectsImpl(bool* followRedirects) {
+  *followRedirects = false;
 }
 
-template <typename Config = Aws::Client::ClientConfiguration>
-void DisableRedirects(
-    typename std::enable_if<!HaveLegacyFollowRedirects, Config*>::type config) {
-  config->followRedirects = decltype(config->followRedirects)::NEVER;
+// In AWS SDK >= 1.8, it's a Aws::Client::FollowRedirectsPolicy scoped enum.
+template <typename PolicyEnum, PolicyEnum Never = PolicyEnum::NEVER>
+void DisableRedirectsImpl(PolicyEnum* followRedirects) {
+  *followRedirects = Never;
+}
+
+void DisableRedirects(Aws::Client::ClientConfiguration* c) {
+  DisableRedirectsImpl(&c->followRedirects);
 }
 
 class ClientBuilder {

--- a/cpp/src/arrow/filesystem/s3fs_test.cc
+++ b/cpp/src/arrow/filesystem/s3fs_test.cc
@@ -303,6 +303,10 @@ TEST_F(S3FileSystemRegionTest, Default) {
   ASSERT_EQ(s3fs->region(), "us-east-1");
 }
 
+// Skipped on Windows, as the AWS SDK ignores runtime environment changes:
+// https://github.com/aws/aws-sdk-cpp/issues/1476
+
+#ifndef _WIN32
 TEST_F(S3FileSystemRegionTest, EnvironmentVariable) {
   // Region override with environment variable (AWS SDK >= 1.8)
   EnvVarGuard region_guard("AWS_DEFAULT_REGION", "eu-north-1");
@@ -316,6 +320,7 @@ TEST_F(S3FileSystemRegionTest, EnvironmentVariable) {
     ASSERT_EQ(s3fs->region(), "us-east-1");
   }
 }
+#endif
 
 ////////////////////////////////////////////////////////////////////////////
 // Basic test for the Minio test server.


### PR DESCRIPTION
Avoid trying to following redirects when resolving a region, as that can fail
(at least on Windows with certain AWS SDK versions).

Also skip a test that's failing because of a bug in the AWS SDK on Windows.