### PR TITLE
ARROW-10040: [Rust] Iterate over and combine boolean buffers with arbitrary offsets

### DIFF
--- a/rust/arrow/benches/buffer_bit_ops.rs
+++ b/rust/arrow/benches/buffer_bit_ops.rs
@@ -22,13 +22,6 @@ use criterion::Criterion;
 extern crate arrow;
 
 use arrow::buffer::{Buffer, MutableBuffer};
-use arrow::error::ArrowError;
-use arrow::error::Result;
-#[cfg(feature = "simd")]
-use arrow::util::bit_util;
-use std::borrow::BorrowMut;
-#[cfg(feature = "simd")]
-use std::slice::{from_raw_parts, from_raw_parts_mut};
 
 ///  Helper function to create arrays
 fn create_buffer(size: usize) -> Buffer {
@@ -41,146 +34,15 @@ fn create_buffer(size: usize) -> Buffer {
     result.freeze()
 }
 
-fn bench_and_current_impl(left: &Buffer, right: &Buffer) {
+fn bench_buffer_and(left: &Buffer, right: &Buffer) {
     criterion::black_box((left & right).unwrap());
-}
-
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-fn bench_and_packed_simd_chunked_exact(left: &Buffer, right: &Buffer) {
-    criterion::black_box(
-        bitwise_bin_op_simd_helper(&left, &right, |a, b| a & b).unwrap(),
-    );
-}
-
-fn bench_and_chunked_exact(left: &Buffer, right: &Buffer) {
-    criterion::black_box(
-        bitwise_bin_op_autovec_chunked_helper(&left, &right, |a, b| a & b).unwrap(),
-    );
-}
-
-fn bench_and_autovec(left: &Buffer, right: &Buffer) {
-    criterion::black_box(
-        bitwise_bin_op_autovec_helper(&left, &right, |a, b| a & b).unwrap(),
-    );
-}
-
-const AUTOVEC_LANES: usize = 64;
-
-fn bitwise_bin_op_autovec_chunked_helper<F>(
-    left: &Buffer,
-    right: &Buffer,
-    op: F,
-) -> Result<Buffer>
-where
-    F: Fn(u8, u8) -> u8,
-{
-    if left.len() != right.len() {
-        return Err(ArrowError::ComputeError(
-            "Buffers must be the same size to apply Bitwise AND.".to_string(),
-        ));
-    }
-
-    let mut result = MutableBuffer::new(left.len()).with_bitset(left.len(), false);
-
-    let mut left_chunks = left.data().chunks_exact(AUTOVEC_LANES);
-    let mut right_chunks = right.data().chunks_exact(AUTOVEC_LANES);
-    let mut result_chunks = result.data_mut().chunks_exact_mut(AUTOVEC_LANES);
-
-    result_chunks
-        .borrow_mut()
-        .zip(left_chunks.borrow_mut().zip(right_chunks.borrow_mut()))
-        .for_each(|(res, (left, right))| {
-            for i in 0..AUTOVEC_LANES {
-                res[i] = op(left[i], right[i]);
-            }
-        });
-
-    result_chunks
-        .into_remainder()
-        .iter_mut()
-        .zip(
-            left_chunks
-                .remainder()
-                .iter()
-                .zip(right_chunks.remainder().iter()),
-        )
-        .for_each(|(res, (left, right))| {
-            *res = op(*left, *right);
-        });
-
-    Ok(result.freeze())
-}
-
-fn bitwise_bin_op_autovec_helper<F>(
-    left: &Buffer,
-    right: &Buffer,
-    op: F,
-) -> Result<Buffer>
-where
-    F: Fn(u8, u8) -> u8,
-{
-    if left.len() != right.len() {
-        return Err(ArrowError::ComputeError(
-            "Buffers must be the same size to apply Bitwise AND.".to_string(),
-        ));
-    }
-
-    let mut result = MutableBuffer::new(left.len()).with_bitset(left.len(), false);
-
-    result
-        .data_mut()
-        .iter_mut()
-        .zip(left.data().iter().zip(right.data().iter()))
-        .for_each(|(res, (left, right))| {
-            *res = op(*left, *right);
-        });
-
-    Ok(result.freeze())
-}
-
-///  Helper function for SIMD `BitAnd` and `BitOr` implementations
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-fn bitwise_bin_op_simd_helper<F>(left: &Buffer, right: &Buffer, op: F) -> Result<Buffer>
-where
-    F: Fn(packed_simd::u8x64, packed_simd::u8x64) -> packed_simd::u8x64,
-{
-    if left.len() != right.len() {
-        return Err(ArrowError::ComputeError(
-            "Buffers must be the same size to apply Bitwise AND.".to_string(),
-        ));
-    }
-
-    let mut result = MutableBuffer::new(left.len()).with_bitset(left.len(), false);
-    let lanes = packed_simd::u8x64::lanes();
-    for i in (0..left.len()).step_by(lanes) {
-        let left_data = unsafe { from_raw_parts(left.raw_data().add(i), lanes) };
-        let right_data = unsafe { from_raw_parts(right.raw_data().add(i), lanes) };
-        let result_slice: &mut [u8] = unsafe {
-            from_raw_parts_mut((result.data_mut().as_mut_ptr() as *mut u8).add(i), lanes)
-        };
-        unsafe {
-            bit_util::bitwise_bin_op_simd(&left_data, &right_data, result_slice, &op)
-        };
-    }
-
-    Ok(result.freeze())
 }
 
 fn bit_ops_benchmark(c: &mut Criterion) {
     let left = create_buffer(512);
     let right = create_buffer(512);
-    c.bench_function("buffer_bit_ops and current impl", |b| {
-        b.iter(|| bench_and_current_impl(&left, &right))
-    });
-    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    c.bench_function("buffer_bit_ops and packed simd", |b| {
-        b.iter(|| bench_and_packed_simd_chunked_exact(&left, &right))
-    });
-    c.bench_function("buffer_bit_ops and chunked autovec", |b| {
-        b.iter(|| bench_and_chunked_exact(&left, &right))
-    });
-    c.bench_function("buffer_bit_ops and autovec", |b| {
-        b.iter(|| bench_and_autovec(&left, &right))
+    c.bench_function("buffer_bit_ops and", |b| {
+        b.iter(|| bench_buffer_and(&left, &right))
     });
 }
 

--- a/rust/arrow/benches/buffer_bit_ops.rs
+++ b/rust/arrow/benches/buffer_bit_ops.rs
@@ -21,12 +21,15 @@ use criterion::Criterion;
 
 extern crate arrow;
 
+use arrow::bitmap::Bitmap;
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::error::ArrowError;
 use arrow::error::Result;
 #[cfg(feature = "simd")]
 use arrow::util::bit_util;
+use arrow::util::bit_util::ceil;
 use std::borrow::BorrowMut;
+use std::io::Write;
 #[cfg(feature = "simd")]
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 

--- a/rust/arrow/benches/buffer_bit_ops.rs
+++ b/rust/arrow/benches/buffer_bit_ops.rs
@@ -21,15 +21,12 @@ use criterion::Criterion;
 
 extern crate arrow;
 
-use arrow::bitmap::Bitmap;
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::error::ArrowError;
 use arrow::error::Result;
 #[cfg(feature = "simd")]
 use arrow::util::bit_util;
-use arrow::util::bit_util::ceil;
 use std::borrow::BorrowMut;
-use std::io::Write;
 #[cfg(feature = "simd")]
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1907,15 +1907,16 @@ impl TryFrom<Vec<(&str, ArrayRef)>> for StructArray {
         let mut null: Option<Buffer> = None;
         for (field_name, array) in values {
             let child_datum = array.data();
+            let child_datum_len = child_datum.len();
             if let Some(len) = len {
-                if len != child_datum.len() {
+                if len != child_datum_len {
                     return Err(ArrowError::InvalidArgumentError(
                         format!("Array of field \"{}\" has length {}, but previous elements have length {}.
-                        All arrays in every entry in a struct array must have the same length.", field_name, child_datum.len(), len)
+                        All arrays in every entry in a struct array must have the same length.", field_name, child_datum_len, len)
                     ));
                 }
             } else {
-                len = Some(child_datum.len())
+                len = Some(child_datum_len)
             }
             child_data.push(child_datum.clone());
             fields.push(Field::new(
@@ -1926,7 +1927,7 @@ impl TryFrom<Vec<(&str, ArrayRef)>> for StructArray {
 
             if let Some(child_null_buffer) = child_datum.null_buffer() {
                 null = Some(if let Some(null_buffer) = &null {
-                    buffer_bin_or(null_buffer, 0, child_null_buffer, 0, null_buffer.len())
+                    buffer_bin_or(null_buffer, 0, child_null_buffer, 0, child_datum_len)
                 } else {
                     child_null_buffer.clone()
                 });

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -455,20 +455,23 @@ where
 
 pub(super) fn buffer_bin_and(
     left: &Buffer,
-    left_offset: usize,
+    left_offset_in_bits: usize,
     right: &Buffer,
-    right_offset: usize,
-    len: usize,
+    right_offset_in_bits: usize,
+    len_in_bits: usize,
 ) -> Buffer {
     // SIMD implementation if available and byte-aligned
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    if left_offset % 8 == 0 && right_offset % 8 == 0 && len % 8 == 0 {
+    if left_offset_in_bits % 8 == 0
+        && right_offset_in_bits % 8 == 0
+        && len_in_bits % 8 == 0
+    {
         return bitwise_bin_op_simd_helper(
             &left,
-            left_offset,
+            left_offset_in_bits / 8,
             &right,
-            right_offset,
-            len,
+            right_offset_in_bits / 8,
+            len_in_bits / 8,
             |a, b| a & b,
             |a, b| a & b,
         );
@@ -476,7 +479,14 @@ pub(super) fn buffer_bin_and(
     // Default implementation
     #[allow(unreachable_code)]
     {
-        bitwise_bin_op_helper(&left, left_offset, right, right_offset, len, |a, b| a & b)
+        bitwise_bin_op_helper(
+            &left,
+            left_offset_in_bits,
+            right,
+            right_offset_in_bits,
+            len_in_bits,
+            |a, b| a & b,
+        )
     }
 }
 

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -399,7 +399,7 @@ where
 {
     // reserve capacity and set length so we can get a typed view of u64 chunks
     let mut result =
-        MutableBuffer::new(ceil(len_in_bits, 8)).with_bitset(len_in_bits / 64, false);
+        MutableBuffer::new(ceil(len_in_bits, 8)).with_bitset(len_in_bits / 64 * 8, false);
 
     let left_chunks = left.bit_chunks(left_offset_in_bits, len_in_bits);
     let right_chunks = right.bit_chunks(right_offset_in_bits, len_in_bits);
@@ -432,7 +432,7 @@ where
 {
     // reserve capacity and set length so we can get a typed view of u64 chunks
     let mut result =
-        MutableBuffer::new(ceil(len_in_bits, 8)).with_bitset(len_in_bits / 64, false);
+        MutableBuffer::new(ceil(len_in_bits, 8)).with_bitset(len_in_bits / 64 * 8, false);
 
     let left_chunks = left.bit_chunks(offset_in_bits, len_in_bits);
     let result_chunks = result.typed_data_mut::<u64>().iter_mut();

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -302,7 +302,11 @@ impl<T: AsRef<[u8]>> From<T> for Buffer {
     }
 }
 
-///  Helper function for binary SIMD operations like `BitAnd` and `BitOr`.
+/// Apply a bitwise operation `simd_op` / `scalar_op` to two inputs using simd instructions and return the result as a Buffer.
+/// The `simd_op` functions gets applied on chunks of 64 bytes (512 bits) at a time
+/// and the `scalar_op` gets applied to remaining bytes.
+/// Contrary to the non-simd version `bitwise_bin_op_helper`, the offset and length is specified in bytes
+/// and this version does not support operations starting at arbitrary bit offsets.
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 fn bitwise_bin_op_simd_helper<F_SIMD, F_SCALAR>(
     left: &Buffer,
@@ -347,7 +351,11 @@ where
     result.freeze()
 }
 
-///  Helper function for unary SIMD operations like `BitNot`.
+/// Apply a bitwise operation `simd_op` / `scalar_op` to one input using simd instructions and return the result as a Buffer.
+/// The `simd_op` functions gets applied on chunks of 64 bytes (512 bits) at a time
+/// and the `scalar_op` gets applied to remaining bytes.
+/// Contrary to the non-simd version `bitwise_unary_op_helper`, the offset and length is specified in bytes
+/// and this version does not support operations starting at arbitrary bit offsets.
 #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
 fn bitwise_unary_op_simd_helper<F_SIMD, F_SCALAR>(
     left: &Buffer,
@@ -386,6 +394,8 @@ where
     result.freeze()
 }
 
+/// Apply a bitwise operation `op` to two inputs and return the result as a Buffer.
+/// The inputs are treated as bitmaps, meaning that offsets and length are specified in number of bits.
 fn bitwise_bin_op_helper<F>(
     left: &Buffer,
     left_offset_in_bits: usize,
@@ -421,6 +431,8 @@ where
     result.freeze()
 }
 
+/// Apply a bitwise operation `op` to one input and return the result as a Buffer.
+/// The input is treated as a bitmap, meaning that offset and length are specified in number of bits.
 fn bitwise_unary_op_helper<F>(
     left: &Buffer,
     offset_in_bits: usize,

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -34,7 +34,9 @@ use std::sync::Arc;
 use crate::datatypes::ArrowNativeType;
 use crate::error::{ArrowError, Result};
 use crate::memory;
+use crate::util::bit_chunk_iterator::BitChunks;
 use crate::util::bit_util;
+use crate::util::bit_util::ceil;
 #[cfg(feature = "simd")]
 use std::borrow::BorrowMut;
 
@@ -254,6 +256,21 @@ impl Buffer {
         )
     }
 
+    /// Returns a slice of this buffer starting at a certain bit offset.
+    /// If the offset is byte-aligned the returned buffer is a shallow clone,
+    /// otherwise a new buffer is allocated and filled with a copy of the bits in the range.
+    pub fn bit_slice(&self, offset: usize, len: usize) -> Self {
+        if offset % 8 == 0 && len % 8 == 0 {
+            return self.slice(offset / 8);
+        }
+
+        bitwise_unary_op_helper(&self, offset, len, |a| a)
+    }
+
+    pub fn bit_chunks(&self, offset: usize, len: usize) -> BitChunks {
+        BitChunks::new(&self, offset, len)
+    }
+
     /// Returns an empty buffer.
     pub fn empty() -> Self {
         unsafe { Self::from_raw_parts(BUFFER_INIT.as_ptr() as _, 0, 0) }
@@ -280,7 +297,7 @@ impl<T: AsRef<[u8]>> From<T> for Buffer {
         let buffer = memory::allocate_aligned(capacity);
         unsafe {
             memory::memcpy(buffer, slice.as_ptr(), len);
-            Buffer::from_raw_parts(buffer, len, capacity)
+            Buffer::build_with_arguments(buffer, len, capacity, true)
         }
     }
 }
@@ -371,50 +388,67 @@ where
 
 fn bitwise_bin_op_helper<F>(
     left: &Buffer,
-    left_offset: usize,
+    left_offset_in_bits: usize,
     right: &Buffer,
-    right_offset: usize,
-    len: usize,
+    right_offset_in_bits: usize,
+    len_in_bits: usize,
     op: F,
 ) -> Buffer
 where
-    F: Fn(u8, u8) -> u8,
+    F: Fn(u64, u64) -> u64,
 {
-    let mut result = MutableBuffer::new(len).with_bitset(len, false);
+    // reserve capacity and set length so we can get a typed view of u64 chunks
+    let mut result =
+        MutableBuffer::new(ceil(len_in_bits, 8)).with_bitset(len_in_bits / 64, false);
 
-    result
-        .data_mut()
-        .iter_mut()
-        .zip(
-            left.data()[left_offset..]
-                .iter()
-                .zip(right.data()[right_offset..].iter()),
-        )
+    let left_chunks = left.bit_chunks(left_offset_in_bits, len_in_bits);
+    let right_chunks = right.bit_chunks(right_offset_in_bits, len_in_bits);
+    let result_chunks = result.typed_data_mut::<u64>().iter_mut();
+
+    result_chunks
+        .zip(left_chunks.iter().zip(right_chunks.iter()))
         .for_each(|(res, (left, right))| {
-            *res = op(*left, *right);
+            *res = op(left, right);
         });
+
+    let remainder_bytes = ceil(left_chunks.remainder_len(), 8);
+    let rem = op(left_chunks.remainder_bits(), right_chunks.remainder_bits());
+    let rem = &rem.to_le_bytes()[0..remainder_bytes];
+    result
+        .write_all(rem)
+        .expect("not enough capacity in buffer");
 
     result.freeze()
 }
 
 fn bitwise_unary_op_helper<F>(
     left: &Buffer,
-    left_offset: usize,
-    len: usize,
+    offset_in_bits: usize,
+    len_in_bits: usize,
     op: F,
 ) -> Buffer
 where
-    F: Fn(u8) -> u8,
+    F: Fn(u64) -> u64,
 {
-    let mut result = MutableBuffer::new(len).with_bitset(len, false);
+    // reserve capacity and set length so we can get a typed view of u64 chunks
+    let mut result =
+        MutableBuffer::new(ceil(len_in_bits, 8)).with_bitset(len_in_bits / 64, false);
 
-    result
-        .data_mut()
-        .iter_mut()
-        .zip(left.data()[left_offset..].iter())
+    let left_chunks = left.bit_chunks(offset_in_bits, len_in_bits);
+    let result_chunks = result.typed_data_mut::<u64>().iter_mut();
+
+    result_chunks
+        .zip(left_chunks.iter())
         .for_each(|(res, left)| {
-            *res = op(*left);
+            *res = op(left);
         });
+
+    let remainder_bytes = ceil(left_chunks.remainder_len(), 8);
+    let rem = op(left_chunks.remainder_bits());
+    let rem = &rem.to_le_bytes()[0..remainder_bytes];
+    result
+        .write_all(rem)
+        .expect("not enough capacity in buffer");
 
     result.freeze()
 }
@@ -426,9 +460,9 @@ pub(super) fn buffer_bin_and(
     right_offset: usize,
     len: usize,
 ) -> Buffer {
-    // SIMD implementation if available
+    // SIMD implementation if available and byte-aligned
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    {
+    if left_offset % 8 == 0 && right_offset % 8 == 0 && len % 8 == 0 {
         return bitwise_bin_op_simd_helper(
             &left,
             left_offset,
@@ -448,20 +482,23 @@ pub(super) fn buffer_bin_and(
 
 pub(super) fn buffer_bin_or(
     left: &Buffer,
-    left_offset: usize,
+    left_offset_in_bits: usize,
     right: &Buffer,
-    right_offset: usize,
-    len: usize,
+    right_offset_in_bits: usize,
+    len_in_bits: usize,
 ) -> Buffer {
-    // SIMD implementation if available
+    // SIMD implementation if available and byte-aligned
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
+    if left_offset_in_bits % 8 == 0
+        && right_offset_in_bits % 8 == 0
+        && len_in_bits % 8 == 0
     {
         return bitwise_bin_op_simd_helper(
             &left,
-            left_offset,
+            left_offset_in_bits / 8,
             &right,
-            right_offset,
-            len,
+            right_offset_in_bits / 8,
+            len_in_bits / 8,
             |a, b| a | b,
             |a, b| a | b,
         );
@@ -469,20 +506,37 @@ pub(super) fn buffer_bin_or(
     // Default implementation
     #[allow(unreachable_code)]
     {
-        bitwise_bin_op_helper(&left, left_offset, right, right_offset, len, |a, b| a | b)
+        bitwise_bin_op_helper(
+            &left,
+            left_offset_in_bits,
+            right,
+            right_offset_in_bits,
+            len_in_bits,
+            |a, b| a | b,
+        )
     }
 }
 
-pub(super) fn buffer_unary_not(left: &Buffer, left_offset: usize, len: usize) -> Buffer {
-    // SIMD implementation if available
+pub(super) fn buffer_unary_not(
+    left: &Buffer,
+    offset_in_bits: usize,
+    len_in_bits: usize,
+) -> Buffer {
+    // SIMD implementation if available and byte-aligned
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
-    {
-        return bitwise_unary_op_simd_helper(&left, left_offset, len, |a| !a, |a| !a);
+    if offset_in_bits % 8 == 0 && len_in_bits % 8 == 0 {
+        return bitwise_unary_op_simd_helper(
+            &left,
+            offset_in_bits / 8,
+            len_in_bits / 8,
+            |a| !a,
+            |a| !a,
+        );
     }
     // Default implementation
     #[allow(unreachable_code)]
     {
-        bitwise_unary_op_helper(&left, left_offset, len, |a| !a)
+        bitwise_unary_op_helper(&left, offset_in_bits, len_in_bits, |a| !a)
     }
 }
 
@@ -496,7 +550,8 @@ impl<'a, 'b> BitAnd<&'b Buffer> for &'a Buffer {
             ));
         }
 
-        Ok(buffer_bin_and(&self, 0, &rhs, 0, self.len()))
+        let len_in_bits = self.len() * 8;
+        Ok(buffer_bin_and(&self, 0, &rhs, 0, len_in_bits))
     }
 }
 
@@ -510,7 +565,9 @@ impl<'a, 'b> BitOr<&'b Buffer> for &'a Buffer {
             ));
         }
 
-        Ok(buffer_bin_or(&self, 0, &rhs, 0, self.len()))
+        let len_in_bits = self.len() * 8;
+
+        Ok(buffer_bin_or(&self, 0, &rhs, 0, len_in_bits))
     }
 }
 
@@ -518,7 +575,8 @@ impl Not for &Buffer {
     type Output = Buffer;
 
     fn not(self) -> Buffer {
-        buffer_unary_not(&self, 0, self.len())
+        let len_in_bits = self.len() * 8;
+        buffer_unary_not(&self, 0, len_in_bits)
     }
 }
 

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -76,29 +76,21 @@ pub(super) fn compare_option_bitmap(
     let left = left_data.null_buffer();
     let right = right_data.null_buffer();
 
-    if (left.is_some() && left_offset_in_bits % 8 != 0)
-        || (right.is_some() && right_offset_in_bits % 8 != 0)
-    {
-        return Err(ArrowError::ComputeError(
-            "Cannot compare option bitmaps that are not byte-aligned.".to_string(),
-        ));
-    }
-
-    let left_offset = left_offset_in_bits / 8;
-    let right_offset = right_offset_in_bits / 8;
-
     match left {
         None => match right {
             None => Ok(None),
-            Some(r) => Ok(Some(r.slice(right_offset))),
+            Some(r) => Ok(Some(r.bit_slice(right_offset_in_bits, len_in_bits))),
         },
         Some(l) => match right {
-            None => Ok(Some(l.slice(left_offset))),
+            None => Ok(Some(l.bit_slice(left_offset_in_bits, len_in_bits))),
 
-            Some(r) => {
-                let len = ceil(len_in_bits, 8);
-                Ok(Some(buffer_bin_or(&l, left_offset, &r, right_offset, len)))
-            }
+            Some(r) => Ok(Some(buffer_bin_or(
+                &l,
+                left_offset_in_bits,
+                &r,
+                right_offset_in_bits,
+                len_in_bits,
+            ))),
         },
     }
 }

--- a/rust/arrow/src/compute/util.rs
+++ b/rust/arrow/src/compute/util.rs
@@ -23,8 +23,7 @@ use crate::bitmap::Bitmap;
 use crate::buffer::{buffer_bin_and, buffer_bin_or, Buffer};
 #[cfg(feature = "simd")]
 use crate::datatypes::*;
-use crate::error::{ArrowError, Result};
-use crate::util::bit_util::ceil;
+use crate::error::Result;
 #[cfg(feature = "simd")]
 use num::One;
 #[cfg(feature = "simd")]
@@ -44,29 +43,21 @@ pub(super) fn combine_option_bitmap(
     let left = left_data.null_buffer();
     let right = right_data.null_buffer();
 
-    if (left.is_some() && left_offset_in_bits % 8 != 0)
-        || (right.is_some() && right_offset_in_bits % 8 != 0)
-    {
-        return Err(ArrowError::ComputeError(
-            "Cannot combine option bitmaps that are not byte-aligned.".to_string(),
-        ));
-    }
-
-    let left_offset = left_offset_in_bits / 8;
-    let right_offset = right_offset_in_bits / 8;
-
     match left {
         None => match right {
             None => Ok(None),
-            Some(r) => Ok(Some(r.slice(right_offset))),
+            Some(r) => Ok(Some(r.bit_slice(right_offset_in_bits, len_in_bits))),
         },
         Some(l) => match right {
-            None => Ok(Some(l.slice(left_offset))),
+            None => Ok(Some(l.bit_slice(left_offset_in_bits, len_in_bits))),
 
-            Some(r) => {
-                let len = ceil(len_in_bits, 8);
-                Ok(Some(buffer_bin_and(&l, left_offset, &r, right_offset, len)))
-            }
+            Some(r) => Ok(Some(buffer_bin_and(
+                &l,
+                left_offset_in_bits,
+                &r,
+                right_offset_in_bits,
+                len_in_bits,
+            ))),
         },
     }
 }

--- a/rust/arrow/src/util/bit_chunk_iterator.rs
+++ b/rust/arrow/src/util/bit_chunk_iterator.rs
@@ -1,0 +1,227 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+use crate::buffer::Buffer;
+use crate::util::bit_util::ceil;
+use std::fmt::Debug;
+
+#[derive(Debug)]
+pub struct BitChunks<'a> {
+    buffer: &'a Buffer,
+    raw_data: *const u8,
+    offset: usize,
+    chunk_len: usize,
+    remainder_len: usize,
+}
+
+impl<'a> BitChunks<'a> {
+    pub fn new(buffer: &'a Buffer, offset: usize, len: usize) -> Self {
+        assert!(ceil(offset + len, 8) <= buffer.len() * 8);
+
+        let byte_offset = offset / 8;
+        let offset = offset % 8;
+
+        let raw_data = unsafe { buffer.raw_data().add(byte_offset) };
+
+        let chunk_bits = 64;
+
+        let chunk_len = len / chunk_bits;
+        let remainder_len = len & (chunk_bits - 1);
+
+        BitChunks::<'a> {
+            buffer: &buffer,
+            raw_data,
+            offset,
+            chunk_len,
+            remainder_len,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct BitChunkIterator<'a> {
+    buffer: &'a Buffer,
+    raw_data: *const u8,
+    offset: usize,
+    chunk_len: usize,
+    index: usize,
+}
+
+impl<'a> BitChunks<'a> {
+    pub fn remainder_len(&self) -> usize {
+        self.remainder_len
+    }
+
+    pub fn remainder_bits(&self) -> u64 {
+        let bit_len = self.remainder_len;
+        if bit_len == 0 {
+            0
+        } else {
+            let byte_len = ceil(bit_len, 8);
+
+            let mut bits = 0;
+            for i in 0..byte_len {
+                let byte = unsafe {
+                    std::ptr::read(
+                        self.raw_data
+                            .add(self.chunk_len * std::mem::size_of::<u64>() + i),
+                    )
+                };
+                bits |= (byte as u64) << (i * 8);
+            }
+
+            let offset = self.offset as u64;
+
+            (bits >> offset) & ((1 << bit_len) - 1)
+        }
+    }
+
+    pub fn remainder_bytes(&self) -> [u8; 8] {
+        let bit_len = self.remainder_len;
+        if bit_len == 0 {
+            [0_u8; 8]
+        } else {
+            self.remainder_bits().to_le_bytes()
+        }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> BitChunkIterator<'a> {
+        BitChunkIterator::<'a> {
+            buffer: self.buffer,
+            raw_data: self.raw_data,
+            offset: self.offset,
+            chunk_len: self.chunk_len,
+            index: 0,
+        }
+    }
+}
+
+impl<'a> IntoIterator for BitChunks<'a> {
+    type Item = u64;
+    type IntoIter = BitChunkIterator<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl Iterator for BitChunkIterator<'_> {
+    type Item = u64;
+
+    fn next(&mut self) -> Option<u64> {
+        if self.index >= self.chunk_len {
+            return None;
+        }
+
+        // cast to *const u64 should be fine since we are using read_unaligned
+        #[allow(clippy::cast_ptr_alignment)]
+        let current = unsafe {
+            std::ptr::read_unaligned((self.raw_data as *const u64).add(self.index))
+        };
+
+        let combined = if self.offset == 0 {
+            current
+        } else {
+            // cast to *const u64 should be fine since we are using read_unaligned
+            #[allow(clippy::cast_ptr_alignment)]
+            let next = unsafe {
+                std::ptr::read_unaligned(
+                    (self.raw_data as *const u64).add(self.index + 1),
+                )
+            };
+            current >> self.offset
+                | (next & ((1 << self.offset) - 1)) << (64 - self.offset)
+        };
+
+        self.index += 1;
+
+        Some(combined)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (
+            self.chunk_len - self.index,
+            Some(self.chunk_len - self.index),
+        )
+    }
+}
+
+impl ExactSizeIterator for BitChunkIterator<'_> {
+    fn len(&self) -> usize {
+        self.chunk_len - self.index
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::buffer::Buffer;
+
+    #[test]
+    fn test_iter_aligned() {
+        let input: &[u8] = &[0, 1, 2, 3, 4, 5, 6, 7];
+        let buffer: Buffer = Buffer::from(input);
+
+        let bitchunks = buffer.bit_chunks(0, 64);
+        let result = bitchunks.into_iter().collect::<Vec<_>>();
+
+        assert_eq!(vec![0x0706050403020100], result);
+    }
+
+    #[test]
+    fn test_iter_unaligned() {
+        let input: &[u8] = &[
+            0b00000000, 0b00000001, 0b00000010, 0b00000100, 0b00001000, 0b00010000,
+            0b00100000, 0b01000000, 0b11111111,
+        ];
+        let buffer: Buffer = Buffer::from(input);
+
+        let bitchunks = buffer.bit_chunks(4, 64);
+
+        assert_eq!(0, bitchunks.remainder_len());
+        assert_eq!(0, bitchunks.remainder_bits());
+
+        let result = bitchunks.into_iter().collect::<Vec<_>>();
+
+        //assert_eq!(vec![0b00010000, 0b00100000, 0b01000000, 0b10000000, 0b00000000, 0b00000001, 0b00000010, 0b11110100], result);
+        assert_eq!(
+            vec![0b1111010000000010000000010000000010000000010000000010000000010000],
+            result
+        );
+    }
+
+    #[test]
+    fn test_iter_unaligned_remainder_1_byte() {
+        let input: &[u8] = &[
+            0b00000000, 0b00000001, 0b00000010, 0b00000100, 0b00001000, 0b00010000,
+            0b00100000, 0b01000000, 0b11111111,
+        ];
+        let buffer: Buffer = Buffer::from(input);
+
+        let bitchunks = buffer.bit_chunks(4, 66);
+
+        assert_eq!(2, bitchunks.remainder_len());
+        assert_eq!(0b00000011, bitchunks.remainder_bits());
+
+        let result = bitchunks.into_iter().collect::<Vec<_>>();
+
+        //assert_eq!(vec![0b00010000, 0b00100000, 0b01000000, 0b10000000, 0b00000000, 0b00000001, 0b00000010, 0b11110100], result);
+        assert_eq!(
+            vec![0b1111010000000010000000010000000010000000010000000010000000010000],
+            result
+        );
+    }
+}

--- a/rust/arrow/src/util/bit_chunk_iterator.rs
+++ b/rust/arrow/src/util/bit_chunk_iterator.rs
@@ -61,10 +61,12 @@ pub struct BitChunkIterator<'a> {
 }
 
 impl<'a> BitChunks<'a> {
+    #[inline]
     pub fn remainder_len(&self) -> usize {
         self.remainder_len
     }
 
+    #[inline]
     pub fn remainder_bits(&self) -> u64 {
         let bit_len = self.remainder_len;
         if bit_len == 0 {
@@ -86,15 +88,6 @@ impl<'a> BitChunks<'a> {
             let offset = self.offset as u64;
 
             (bits >> offset) & ((1 << bit_len) - 1)
-        }
-    }
-
-    pub fn remainder_bytes(&self) -> [u8; 8] {
-        let bit_len = self.remainder_len;
-        if bit_len == 0 {
-            [0_u8; 8]
-        } else {
-            self.remainder_bits().to_le_bytes()
         }
     }
 
@@ -122,6 +115,7 @@ impl<'a> IntoIterator for BitChunks<'a> {
 impl Iterator for BitChunkIterator<'_> {
     type Item = u64;
 
+    #[inline]
     fn next(&mut self) -> Option<u64> {
         if self.index >= self.chunk_len {
             return None;
@@ -152,6 +146,7 @@ impl Iterator for BitChunkIterator<'_> {
         Some(combined)
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (
             self.chunk_len - self.index,
@@ -161,6 +156,7 @@ impl Iterator for BitChunkIterator<'_> {
 }
 
 impl ExactSizeIterator for BitChunkIterator<'_> {
+    #[inline]
     fn len(&self) -> usize {
         self.chunk_len - self.index
     }

--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -43,7 +43,7 @@ pub fn round_upto_multiple_of_64(num: usize) -> usize {
 
 /// Returns the nearest multiple of `factor` that is `>=` than `num`. Here `factor` must
 /// be a power of 2.
-fn round_upto_power_of_2(num: usize, factor: usize) -> usize {
+pub fn round_upto_power_of_2(num: usize, factor: usize) -> usize {
     debug_assert!(factor > 0 && (factor & (factor - 1)) == 0);
     (num + (factor - 1)) & !(factor - 1)
 }

--- a/rust/arrow/src/util/mod.rs
+++ b/rust/arrow/src/util/mod.rs
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+pub mod bit_chunk_iterator;
 pub mod bit_util;
 pub mod integration_util;
 #[cfg(feature = "prettyprint")]


### PR DESCRIPTION
@nevi-me this is the chunked iterator based approach i mentioned in #8223 

I'm not fully satisfied with the solution yet:

 - I'd prefer to move all the bit-based functions into `Bitmap`, but creating a `Bitmap` from a `&Buffer` would involve cloning an `Arc`.
 - I need to do some benchmarking about how much the `packed_simd` implementation actually helps. If it's not a big difference I'd propose to remove it to simplify the code.