### PR TITLE
ARROW-10086: [Rust] Renamed min/max_large_string kernels

### DIFF
--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -581,12 +581,9 @@ fn min_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::Utf8 => {
             typed_min_max_batch_string!(values, StringArray, Utf8, min_string)
         }
-        DataType::LargeUtf8 => typed_min_max_batch_string!(
-            values,
-            LargeStringArray,
-            LargeUtf8,
-            min_large_string
-        ),
+        DataType::LargeUtf8 => {
+            typed_min_max_batch_string!(values, LargeStringArray, LargeUtf8, min_string)
+        }
         _ => min_max_batch!(values, min),
     })
 }
@@ -597,12 +594,9 @@ fn max_batch(values: &ArrayRef) -> Result<ScalarValue> {
         DataType::Utf8 => {
             typed_min_max_batch_string!(values, StringArray, Utf8, max_string)
         }
-        DataType::LargeUtf8 => typed_min_max_batch_string!(
-            values,
-            LargeStringArray,
-            LargeUtf8,
-            max_large_string
-        ),
+        DataType::LargeUtf8 => {
+            typed_min_max_batch_string!(values, LargeStringArray, LargeUtf8, max_string)
+        }
         _ => min_max_batch!(values, max),
     })
 }


### PR DESCRIPTION
With the new representation of string arrays as generics, we no longer need to give different names to kernels. This PR addresses this (and makes the implementation to be a generic instead of a macro, equivalent to the implementation for primitive types).