### PR TITLE
ARROW-8618: [C++] Clean up some redundant std::move()s

### DIFF
--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -172,7 +172,7 @@ Status WriteTask::Execute() {
 
   // TODO(bkietz) these calls to Partition() should be scattered across a TaskGroup
   for (auto maybe_batch : IteratorFromReader(batches)) {
-    ARROW_ASSIGN_OR_RAISE(auto batch, std::move(maybe_batch));
+    ARROW_ASSIGN_OR_RAISE(auto batch, maybe_batch);
     ARROW_ASSIGN_OR_RAISE(auto partitioned_batches, partitioning->Partition(batch));
     for (auto&& partitioned_batch : partitioned_batches) {
       AndExpression expr(std::move(partitioned_batch.partition_expression),
@@ -218,7 +218,7 @@ Status FileSystemDataset::Write(std::shared_ptr<Schema> schema,
 
   int i = 0;
   for (auto maybe_fragment : fragment_it) {
-    ARROW_ASSIGN_OR_RAISE(auto fragment, std::move(maybe_fragment));
+    ARROW_ASSIGN_OR_RAISE(auto fragment, maybe_fragment);
     auto task = std::make_shared<WriteTask>();
 
     task->basename = "dat_" + std::to_string(i++) + "." + format->type_name();

--- a/cpp/src/arrow/dataset/file_csv_test.cc
+++ b/cpp/src/arrow/dataset/file_csv_test.cc
@@ -76,7 +76,7 @@ TEST_F(TestCsvFileFormat, ScanRecordBatchReader) {
   int64_t row_count = 0;
 
   for (auto maybe_batch : Batches(fragment.get())) {
-    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
     row_count += batch->num_rows();
   }
 
@@ -92,7 +92,7 @@ TEST_F(TestCsvFileFormat, ScanRecordBatchReaderWithVirtualColumn) {
   int64_t row_count = 0;
 
   for (auto maybe_batch : Batches(fragment.get())) {
-    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
     AssertSchemaEqual(*batch->schema(), *schema_);
     row_count += batch->num_rows();
   }
@@ -155,12 +155,12 @@ N/A,bar
 
   ASSERT_OK_AND_ASSIGN(auto scan_task_it, scanner->Scan());
   for (auto maybe_scan_task : scan_task_it) {
-    ASSERT_OK_AND_ASSIGN(auto scan_task, std::move(maybe_scan_task));
+    ASSERT_OK_AND_ASSIGN(auto scan_task, maybe_scan_task);
     ASSERT_OK_AND_ASSIGN(auto batch_it, scan_task->Execute());
     for (auto maybe_batch : batch_it) {
       // ERROR: "f64" is not projected and reverts to inferred type,
       // breaking the comparison expression
-      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+      ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
     }
   }
 }

--- a/cpp/src/arrow/dataset/file_ipc_test.cc
+++ b/cpp/src/arrow/dataset/file_ipc_test.cc
@@ -122,7 +122,7 @@ TEST_F(TestIpcFileFormat, ScanRecordBatchReader) {
   int64_t row_count = 0;
 
   for (auto maybe_batch : Batches(fragment.get())) {
-    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
     row_count += batch->num_rows();
   }
 
@@ -139,7 +139,7 @@ TEST_F(TestIpcFileFormat, ScanRecordBatchReaderWithVirtualColumn) {
   int64_t row_count = 0;
 
   for (auto maybe_batch : Batches(fragment.get())) {
-    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
     AssertSchemaEqual(*batch->schema(), *schema_);
     row_count += batch->num_rows();
   }
@@ -221,7 +221,7 @@ TEST_F(TestIpcFileFormat, ScanRecordBatchReaderProjected) {
   int64_t row_count = 0;
 
   for (auto maybe_batch : Batches(fragment.get())) {
-    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
     row_count += batch->num_rows();
     AssertSchemaEqual(*batch->schema(), *expected_schema,
                       /*check_metadata=*/false);
@@ -268,7 +268,7 @@ TEST_F(TestIpcFileFormat, ScanRecordBatchReaderProjectedMissingCols) {
     int64_t row_count = 0;
 
     for (auto maybe_batch : Batches(fragment.get())) {
-      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+      ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
       row_count += batch->num_rows();
       AssertSchemaEqual(*batch->schema(), *expected_schema,
                         /*check_metadata=*/false);

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -172,7 +172,7 @@ class TestParquetFileFormat : public ArrowParquetWriterMixin {
     int64_t actual_batches = 0;
 
     for (auto maybe_batch : Batches(fragment)) {
-      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+      ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
       actual_rows += batch->num_rows();
       ++actual_batches;
     }
@@ -220,7 +220,7 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReader) {
   int64_t row_count = 0;
 
   for (auto maybe_batch : Batches(fragment.get())) {
-    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
     row_count += batch->num_rows();
   }
 
@@ -244,10 +244,10 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderDictEncoded) {
   Schema expected_schema({field("utf8", dictionary(int32(), utf8()))});
 
   for (auto maybe_task : scan_task_it) {
-    ASSERT_OK_AND_ASSIGN(auto task, std::move(maybe_task));
+    ASSERT_OK_AND_ASSIGN(auto task, maybe_task);
     ASSERT_OK_AND_ASSIGN(auto rb_it, task->Execute());
     for (auto maybe_batch : rb_it) {
-      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+      ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
       row_count += batch->num_rows();
       AssertSchemaEqual(*batch->schema(), expected_schema, /* check_metadata = */ false);
     }
@@ -289,7 +289,7 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjected) {
   int64_t row_count = 0;
 
   for (auto maybe_batch : Batches(fragment.get())) {
-    ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+    ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
     row_count += batch->num_rows();
     AssertSchemaEqual(*batch->schema(), *expected_schema,
                       /*check_metadata=*/false);
@@ -336,7 +336,7 @@ TEST_F(TestParquetFileFormat, ScanRecordBatchReaderProjectedMissingCols) {
     int64_t row_count = 0;
 
     for (auto maybe_batch : Batches(fragment.get())) {
-      ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+      ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
       row_count += batch->num_rows();
       AssertSchemaEqual(*batch->schema(), *expected_schema,
                         /*check_metadata=*/false);

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -202,7 +202,7 @@ Result<std::shared_ptr<Table>> Scanner::ToTable() {
 
   size_t scan_task_id = 0;
   for (auto maybe_scan_task : scan_task_it) {
-    ARROW_ASSIGN_OR_RAISE(auto scan_task, std::move(maybe_scan_task));
+    ARROW_ASSIGN_OR_RAISE(auto scan_task, maybe_scan_task);
 
     auto id = scan_task_id++;
     task_group->Append([state, id, scan_task] {

--- a/cpp/src/arrow/dataset/test_util.h
+++ b/cpp/src/arrow/dataset/test_util.h
@@ -772,7 +772,7 @@ class WriteFileSystemDatasetMixin : public MakeFileSystemDatasetMixin {
                 testing::UnorderedElementsAreArray(files));
 
     for (auto maybe_fragment : written_->GetFragments()) {
-      ASSERT_OK_AND_ASSIGN(auto fragment, std::move(maybe_fragment));
+      ASSERT_OK_AND_ASSIGN(auto fragment, maybe_fragment);
 
       ASSERT_OK_AND_ASSIGN(auto actual_physical_schema, fragment->ReadPhysicalSchema());
       AssertSchemaEqual(*expected_physical_schema_, *actual_physical_schema,
@@ -794,7 +794,7 @@ class WriteFileSystemDatasetMixin : public MakeFileSystemDatasetMixin {
 
       for (auto maybe_batch :
            IteratorFromReader(std::make_shared<TableBatchReader>(*actual_table))) {
-        ASSERT_OK_AND_ASSIGN(auto batch, std::move(maybe_batch));
+        ASSERT_OK_AND_ASSIGN(auto batch, maybe_batch);
         ASSERT_OK_AND_ASSIGN(actual_struct, batch->ToStructArray());
       }
 

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -187,7 +187,8 @@ Result<std::shared_ptr<Buffer>> ReadRangeCache::Read(ReadRange range) {
         return entry.range.offset + entry.range.length < range.offset + range.length;
       });
   if (it != impl_->entries.end() && it->range.Contains(range)) {
-    ARROW_ASSIGN_OR_RAISE(auto buf, std::move(it->future).result());
+    auto maybe_buf = it->future.result();
+    ARROW_ASSIGN_OR_RAISE(auto buf, maybe_buf);
     return SliceBuffer(std::move(buf), range.offset - it->range.offset, range.length);
   }
   return Status::Invalid("ReadRangeCache did not find matching cache entry");

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -187,7 +187,7 @@ Result<std::shared_ptr<Buffer>> ReadRangeCache::Read(ReadRange range) {
         return entry.range.offset + entry.range.length < range.offset + range.length;
       });
   if (it != impl_->entries.end() && it->range.Contains(range)) {
-    ARROW_ASSIGN_OR_RAISE(auto buf, it->future.result());
+    ARROW_ASSIGN_OR_RAISE(auto buf, std::move(it->future).result());
     return SliceBuffer(std::move(buf), range.offset - it->range.offset, range.length);
   }
   return Status::Invalid("ReadRangeCache did not find matching cache entry");

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -187,8 +187,7 @@ Result<std::shared_ptr<Buffer>> ReadRangeCache::Read(ReadRange range) {
         return entry.range.offset + entry.range.length < range.offset + range.length;
       });
   if (it != impl_->entries.end() && it->range.Contains(range)) {
-    auto maybe_buf = it->future.result();
-    ARROW_ASSIGN_OR_RAISE(auto buf, maybe_buf);
+    ARROW_ASSIGN_OR_RAISE(auto buf, it->future.result());
     return SliceBuffer(std::move(buf), range.offset - it->range.offset, range.length);
   }
   return Status::Invalid("ReadRangeCache did not find matching cache entry");

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -427,7 +427,7 @@ class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
 #define ARROW_ASSIGN_OR_RAISE_IMPL(result_name, lhs, rexpr) \
   auto&& result_name = (rexpr);                             \
   ARROW_RETURN_NOT_OK((result_name).status());              \
-  lhs = std::move(result_name).MoveValueUnsafe();
+  lhs = std::move(result_name).ValueUnsafe();
 
 #define ARROW_ASSIGN_OR_RAISE_NAME(x, y) ARROW_CONCAT(x, y)
 

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -425,7 +425,7 @@ class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
 };
 
 #define ARROW_ASSIGN_OR_RAISE_IMPL(result_name, lhs, rexpr) \
-  auto result_name = (rexpr);                               \
+  auto&& result_name = (rexpr);                             \
   ARROW_RETURN_NOT_OK((result_name).status());              \
   lhs = std::move(result_name).MoveValueUnsafe();
 

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -108,7 +108,7 @@
   } while (false);
 
 #define ASSIGN_OR_HANDLE_ERROR_IMPL(handle_error, status_name, lhs, rexpr) \
-  auto status_name = (rexpr);                                              \
+  auto&& status_name = (rexpr);                                            \
   handle_error(status_name.status());                                      \
   lhs = std::move(status_name).ValueOrDie();
 

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -110,7 +110,7 @@
 #define ASSIGN_OR_HANDLE_ERROR_IMPL(handle_error, status_name, lhs, rexpr) \
   auto&& status_name = (rexpr);                                            \
   handle_error(status_name.status());                                      \
-  lhs = std::move(status_name).ValueUnsafe();
+  lhs = std::move(status_name).ValueOrDie();
 
 #define ASSERT_OK_AND_ASSIGN(lhs, rexpr) \
   ASSIGN_OR_HANDLE_ERROR_IMPL(           \

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -110,7 +110,7 @@
 #define ASSIGN_OR_HANDLE_ERROR_IMPL(handle_error, status_name, lhs, rexpr) \
   auto&& status_name = (rexpr);                                            \
   handle_error(status_name.status());                                      \
-  lhs = std::move(status_name).ValueOrDie();
+  lhs = std::move(status_name).ValueUnsafe();
 
 #define ASSERT_OK_AND_ASSIGN(lhs, rexpr) \
   ASSIGN_OR_HANDLE_ERROR_IMPL(           \

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -154,7 +154,7 @@ class Iterator : public util::EqualityComparable<Iterator<T>> {
   Result<std::vector<T>> ToVector() {
     std::vector<T> out;
     for (auto maybe_element : *this) {
-      ARROW_ASSIGN_OR_RAISE(auto element, std::move(maybe_element));
+      ARROW_ASSIGN_OR_RAISE(auto element, maybe_element);
       out.push_back(std::move(element));
     }
     // ARROW-8193: On gcc-4.8 without the explicit move it tries to use the
@@ -489,7 +489,7 @@ class ReadaheadIterator {
 
     ARROW_RETURN_NOT_OK(queue_->Append(MakePromise()));
 
-    ARROW_ASSIGN_OR_RAISE(auto out, std::move(it_promise->out_));
+    ARROW_ASSIGN_OR_RAISE(auto out, it_promise->out_);
     if (out == IterationTraits<T>::End()) {
       done_ = true;
     }

--- a/cpp/src/arrow/util/iterator_test.cc
+++ b/cpp/src/arrow/util/iterator_test.cc
@@ -208,7 +208,7 @@ TEST(TestVectorIterator, RangeForLoop) {
   // also works with move only types
   ints_it = ints.begin();
   for (auto maybe_i_ptr : MakeVectorIterator(std::move(intptrs))) {
-    ASSERT_OK_AND_ASSIGN(std::unique_ptr<TestInt> i_ptr, std::move(maybe_i_ptr));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<TestInt> i_ptr, maybe_i_ptr);
     ASSERT_EQ(*i_ptr, *ints_it++);
   }
   ASSERT_EQ(ints_it, ints.end());


### PR DESCRIPTION
ARROW_ASSIGN_OR_RAISE and friends move their RHS, so calling move on those is unnecessary.