### PR TITLE
Refactor BasicDecimal128 Multiplication to use unsigned helper

### DIFF
--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -249,7 +249,7 @@ BasicDecimal128& BasicDecimal128::operator>>=(uint32_t bits) {
 
 namespace {
 
-void extendAndMultiplyUint64(uint64_t x, uint64_t y, uint64_t* hi, uint64_t* lo) {
+void ExtendAndMultiplyUint64(uint64_t x, uint64_t y, uint64_t* hi, uint64_t* lo) {
   const uint64_t x_lo = x & kIntMask;
   const uint64_t y_lo = y & kIntMask;
   const uint64_t x_hi = x >> 32;
@@ -270,9 +270,9 @@ void extendAndMultiplyUint64(uint64_t x, uint64_t y, uint64_t* hi, uint64_t* lo)
   *lo = (v << 32) + t_lo;
 }
 
-void multiplyUint128(uint64_t x_hi, uint64_t x_lo, uint64_t y_hi, uint64_t y_lo,
+void MultiplyUint128(uint64_t x_hi, uint64_t x_lo, uint64_t y_hi, uint64_t y_lo,
                      uint64_t* hi, uint64_t* lo) {
-  extendAndMultiplyUint64(x_lo, y_lo, hi, lo);
+  ExtendAndMultiplyUint64(x_lo, y_lo, hi, lo);
   *hi += (x_hi * y_lo) + (x_lo * y_hi);
 }
 
@@ -285,7 +285,7 @@ BasicDecimal128& BasicDecimal128::operator*=(const BasicDecimal128& right) {
   BasicDecimal128 x = BasicDecimal128::Abs(*this);
   BasicDecimal128 y = BasicDecimal128::Abs(right);
   uint64_t hi;
-  multiplyUint128(x.high_bits(), x.low_bits(), y.high_bits(), y.low_bits(), &hi,
+  MultiplyUint128(x.high_bits(), x.low_bits(), y.high_bits(), y.low_bits(), &hi,
                   &low_bits_);
   high_bits_ = hi;
   if (negate) {

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -120,7 +120,6 @@ static const BasicDecimal128 ScaleMultipliersHalf[] = {
     BasicDecimal128(2710505431213761085LL, 343699775700336640ULL)};
 
 static constexpr uint64_t kIntMask = 0xFFFFFFFF;
-static constexpr auto kCarryBit = static_cast<uint64_t>(1) << static_cast<uint64_t>(32);
 
 // same as ScaleMultipliers[38] - 1
 static constexpr BasicDecimal128 kMaxValue =

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -250,21 +250,21 @@ BasicDecimal128& BasicDecimal128::operator>>=(uint32_t bits) {
 namespace {
 
 void extendAndMultiplyUint64(uint64_t x, uint64_t y, uint64_t* hi, uint64_t* lo) {
-  uint64_t x_lo = x & kIntMask;
-  uint64_t y_lo = y & kIntMask;
-  uint64_t x_hi = x >> 32;
-  uint64_t y_hi = y >> 32;
+  const uint64_t x_lo = x & kIntMask;
+  const uint64_t y_lo = y & kIntMask;
+  const uint64_t x_hi = x >> 32;
+  const uint64_t y_hi = y >> 32;
 
-  uint64_t t = x_lo * y_lo;
-  uint64_t t_lo = t & kIntMask;
-  uint64_t t_hi = t >> 32;
+  const uint64_t t = x_lo * y_lo;
+  const uint64_t t_lo = t & kIntMask;
+  const uint64_t t_hi = t >> 32;
 
-  uint64_t u = x_hi * y_lo + t_hi;
-  uint64_t u_lo = u & kIntMask;
-  uint64_t u_hi = u >> 32;
+  const uint64_t u = x_hi * y_lo + t_hi;
+  const uint64_t u_lo = u & kIntMask;
+  const uint64_t u_hi = u >> 32;
 
-  uint64_t v = x_lo * y_hi + u_lo;
-  uint64_t v_hi = v >> 32;
+  const uint64_t v = x_lo * y_hi + u_lo;
+  const uint64_t v_hi = v >> 32;
 
   *hi = x_hi * y_hi + u_hi + v_hi;
   *lo = (v << 32) + t_lo;
@@ -281,7 +281,7 @@ void multiplyUint128(uint64_t x_hi, uint64_t x_lo, uint64_t y_hi, uint64_t y_lo,
 BasicDecimal128& BasicDecimal128::operator*=(const BasicDecimal128& right) {
   // Since the max value of BasicDecimal128 is supposed to be 1e38 - 1 and the
   // min the negation taking the absolute values here should always be safe.
-  bool negate = Sign() != right.Sign();
+  const bool negate = Sign() != right.Sign();
   BasicDecimal128 x = BasicDecimal128::Abs(*this);
   BasicDecimal128 y = BasicDecimal128::Abs(right);
   uint64_t hi;

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -120,6 +120,7 @@ static const BasicDecimal128 ScaleMultipliersHalf[] = {
     BasicDecimal128(2710505431213761085LL, 343699775700336640ULL)};
 
 static constexpr uint64_t kIntMask = 0xFFFFFFFF;
+static constexpr uint64_t kInt64Mask = 0xFFFFFFFFFFFFFFFF;
 
 // same as ScaleMultipliers[38] - 1
 static constexpr BasicDecimal128 kMaxValue =
@@ -250,6 +251,11 @@ BasicDecimal128& BasicDecimal128::operator>>=(uint32_t bits) {
 namespace {
 
 void ExtendAndMultiplyUint64(uint64_t x, uint64_t y, uint64_t* hi, uint64_t* lo) {
+#ifdef __SIZEOF_INT128__
+   __uint128_t r = static_cast<__uint128_t>(x) * y;
+  *lo = r & 0xffffffffffffffff;
+  *hi = r >> 64;
+#else
   const uint64_t x_lo = x & kIntMask;
   const uint64_t y_lo = y & kIntMask;
   const uint64_t x_hi = x >> 32;
@@ -268,12 +274,21 @@ void ExtendAndMultiplyUint64(uint64_t x, uint64_t y, uint64_t* hi, uint64_t* lo)
 
   *hi = x_hi * y_hi + u_hi + v_hi;
   *lo = (v << 32) + t_lo;
+#endif
 }
 
 void MultiplyUint128(uint64_t x_hi, uint64_t x_lo, uint64_t y_hi, uint64_t y_lo,
                      uint64_t* hi, uint64_t* lo) {
+#ifdef __SIZEOF_INT128__
+  __uint128_t x = (static_cast<__uint128_t>(x_hi) >> 64) + x_lo;
+  __uint128_t y = (static_cast<__uint128_t>(y_hi) >> 64) + y_lo;
+  __uint128_t r = x * y;
+  *lo = r & kInt64Mask;
+  *hi = r >> 64;
+#else
   ExtendAndMultiplyUint64(x_lo, y_lo, hi, lo);
   *hi += (x_hi * y_lo) + (x_lo * y_hi);
+#endif
 }
 
 }  // namespace

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -249,7 +249,7 @@ BasicDecimal128& BasicDecimal128::operator>>=(uint32_t bits) {
 
 namespace {
 
-void extendAndMultiplyUint64(uint64_t x, uint64_t y, uint64_t *hi, uint64_t *lo) {
+void extendAndMultiplyUint64(uint64_t x, uint64_t y, uint64_t* hi, uint64_t* lo) {
   uint64_t x_lo = x & kIntMask;
   uint64_t y_lo = y & kIntMask;
   uint64_t x_hi = x >> 32;
@@ -271,7 +271,7 @@ void extendAndMultiplyUint64(uint64_t x, uint64_t y, uint64_t *hi, uint64_t *lo)
 }
 
 void multiplyUint128(uint64_t x_hi, uint64_t x_lo, uint64_t y_hi, uint64_t y_lo,
-             uint64_t* hi, uint64_t* lo) {
+                     uint64_t* hi, uint64_t* lo) {
   extendAndMultiplyUint64(x_lo, y_lo, hi, lo);
   *hi += (x_hi * y_lo) + (x_lo * y_hi);
 }
@@ -285,7 +285,8 @@ BasicDecimal128& BasicDecimal128::operator*=(const BasicDecimal128& right) {
   BasicDecimal128 x = BasicDecimal128::Abs(*this);
   BasicDecimal128 y = BasicDecimal128::Abs(right);
   uint64_t hi;
-  multiplyUint128(x.high_bits(), x.low_bits(), y.high_bits(), y.low_bits(), &hi, &low_bits_);
+  multiplyUint128(x.high_bits(), x.low_bits(), y.high_bits(), y.low_bits(), &hi,
+                  &low_bits_);
   high_bits_ = hi;
   if (negate) {
     Negate();

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -281,7 +281,7 @@ void multiplyUint128(uint64_t x_hi, uint64_t x_lo, uint64_t y_hi, uint64_t y_lo,
 
 BasicDecimal128& BasicDecimal128::operator*=(const BasicDecimal128& right) {
   // Since the max value of BasicDecimal128 is supposed to be 1e38 - 1 and the
-  // min the negation,, taking the absolute values here should always be safe.
+  // min the negation taking the absolute values here should always be safe.
   bool negate = Sign() != right.Sign();
   BasicDecimal128 x = BasicDecimal128::Abs(*this);
   BasicDecimal128 y = BasicDecimal128::Abs(right);


### PR DESCRIPTION
This should handle all no overflow behavior fine, but it's less clear to me what the appropriate behavior should be if overflow could occur. If we're assuming it can be UB then I believe this change is correct, otherwise some revision may be needed.

Additionally I'm assuming that BasicDecimal128 will never be constructed with a value greater than the given max/min, I'm not sure how valid this assumption is and how it's enforced.