### PR TITLE
ARROW-10101: [WIP][Java] initial Tensor proof-of-concept

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -676,6 +676,7 @@
     <module>performance</module>
     <module>algorithm</module>
     <module>adapter/avro</module>
+    <module>tensor</module>
   </modules>
 
   <profiles>

--- a/java/tensor/pom.xml
+++ b/java/tensor/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for additional
+  information regarding copyright ownership. The ASF licenses this file to
+  You under the Apache License, Version 2.0 (the "License"); you may not use
+  this file except in compliance with the License. You may obtain a copy of
+  the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required
+  by applicable law or agreed to in writing, software distributed under the
+  License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
+  OF ANY KIND, either express or implied. See the License for the specific
+  language governing permissions and limitations under the License. -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.arrow</groupId>
+    <artifactId>arrow-java-root</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>arrow-tensor</artifactId>
+  <name>Arrow Tensor</name>
+  <description>(Experimental/Contrib) Arrow tensor implementation.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.flatbuffers</groupId>
+      <artifactId>flatbuffers-java</artifactId>
+      <version>${dep.fbs.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-format</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-memory-netty</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.arrow</groupId>
+      <artifactId>arrow-vector</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+  </build>
+</project>

--- a/java/tensor/src/main/java/org/apache/arrow/tensor/BaseTensor.java
+++ b/java/tensor/src/main/java/org/apache/arrow/tensor/BaseTensor.java
@@ -1,0 +1,431 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.tensor;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.apache.arrow.flatbuf.Buffer;
+import org.apache.arrow.flatbuf.Message;
+import org.apache.arrow.flatbuf.MessageHeader;
+import org.apache.arrow.flatbuf.Tensor;
+import org.apache.arrow.flatbuf.TensorDim;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.ipc.ReadChannel;
+import org.apache.arrow.vector.ipc.WriteChannel;
+import org.apache.arrow.vector.ipc.message.IpcOption;
+import org.apache.arrow.vector.ipc.message.MessageMetadataResult;
+import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+import com.google.flatbuffers.FlatBufferBuilder;
+
+/** Base class for fixed-width dense tensors. */
+public abstract class BaseTensor implements AutoCloseable {
+  BufferAllocator allocator;
+  ArrowType type;
+  byte typeWidth;
+  long[] shape;
+  String[] names;
+  long[] strides;
+  ArrowBuf data;
+
+  protected BaseTensor(BufferAllocator allocator, ArrowType type,
+                       byte typeWidth, long[] shape, String[] names, long[] strides) {
+    this.allocator = Objects.requireNonNull(allocator);
+    this.type = type;
+    this.typeWidth = typeWidth;
+    this.shape = Objects.requireNonNull(shape);
+    this.names = names;
+    this.strides = Objects.requireNonNull(strides);
+    // TODO: make a defensive copy of arrays
+
+    for (int i = 0; i < strides.length; i++) {
+      Preconditions.checkArgument(strides[i] >= typeWidth,
+          "%sth stride %s must be at least type width %s", i, strides[i], typeWidth);
+    }
+    Preconditions.checkArgument(names == null || (shape.length == names.length),
+        "Dimensions must match names");
+
+    // Don't allocate until we pass preconditions
+    final long bufferSize = minBufferSize(shape, strides);
+    this.data = allocator.buffer(bufferSize);
+    data.writerIndex(bufferSize);
+  }
+
+  /** Compute the minimum buffer size for the given tensor layout. */
+  public static long minBufferSize(long[] shape, long[] strides) {
+    Preconditions.checkArgument(shape.length == strides.length,
+        "Dimensions (%s) must match strides (%s)", shape.length, strides.length);
+    long maxStride = 0;
+    int maxStrideIndex = 0;
+    for (int i = 0; i < strides.length; i++) {
+      if (strides[i] > maxStride) {
+        maxStride = strides[i];
+        maxStrideIndex = i;
+      }
+    }
+    return maxStride * shape[maxStrideIndex];
+  }
+
+  /** Compute strides for a row-major tensor. */
+  public static long[] rowMajorStrides(byte typeWidth, long[] shape) {
+    long[] result = new long[shape.length];
+    long stride = typeWidth;
+    for (int i = shape.length - 1; i >= 0; i--) {
+      result[i] = stride;
+      stride *= shape[i];
+    }
+    return result;
+  }
+
+  /** Compute strides for a row-major tensor. */
+  public static long[] columnMajorStrides(byte typeWidth, long[] shape) {
+    long[] result = new long[shape.length];
+    long stride = typeWidth;
+    for (int i = 0; i < shape.length; i++) {
+      result[i] = stride;
+      stride *= shape[i];
+    }
+    return result;
+  }
+
+  protected void checkClosed() {
+    if (shape.length > 0 && data.capacity() == 0) {
+      throw new IllegalStateException("Operation on closed tensor");
+    }
+  }
+
+  /** Get the Arrow type of the tensor elements. */
+  public ArrowType getType() {
+    return type;
+  }
+
+  /** Get the type width of the tensor elements. */
+  public byte getTypeWidth() {
+    return typeWidth;
+  }
+
+  /** Get the tensor dimensions. */
+  public long[] getShape() {
+    return shape;
+  }
+
+  /** Get the tensor element names. May be null. Individual names may also be null. */
+  public String[] getNames() {
+    return names;
+  }
+
+  /** Get the tensor strides. */
+  public long[] getStrides() {
+    return strides;
+  }
+
+  /** Get the tensor data buffer. */
+  public ArrowBuf getDataBuffer() {
+    return data;
+  }
+
+  /** Check if the tensor is in row-major (C) layout. */
+  public boolean isRowMajor() {
+    return Arrays.equals(rowMajorStrides(typeWidth, shape), strides);
+  }
+
+  /** Check if the tensor is in column-major (FORTRAN) layout. */
+  public boolean isColumnMajor() {
+    return Arrays.equals(columnMajorStrides(typeWidth, shape), strides);
+  }
+
+  /** Get the number of tensor elements. */
+  public long getElementCount() {
+    long result = shape.length > 0 ? 1 : 0;
+    for (long dim : shape) {
+      result *= dim;
+    }
+    return result;
+  }
+
+  /** Get the index into the data buffer for the given index. */
+  public int getElementIndex(long[] indices) {
+    Preconditions.checkArgument(indices.length == strides.length,
+        "Indices (%s) must match strides (%s)", indices.length, strides.length);
+    int index = 0;
+    for (int i = 0; i < indices.length; i++) {
+      long subIndex = indices[i];
+      if (subIndex < 0 || subIndex >= shape[i]) {
+        throw new IndexOutOfBoundsException(
+            String.format("%d th index %d is out of bounds (max %d)", i, subIndex, shape[i]));
+      }
+      index += subIndex * strides[i];
+    }
+    return index;
+  }
+
+  /** Check if the given tensor has the same layout (dimensions and strides) as this tensor. */
+  public boolean hasSameLayoutAs(BaseTensor other) {
+    return typeWidth == other.typeWidth && Arrays.equals(shape, other.shape) && Arrays.equals(strides, other.strides);
+  }
+
+  /** Set the tensor elements to zero. */
+  public void zeroTensor() {
+    data.setZero(0, data.capacity());
+  }
+
+  /** Transfer the tensor buffer to the target. Afterwards, this tensor will be invalid. */
+  public void transferTo(BaseTensor target) {
+    if (!hasSameLayoutAs(target)) {
+      throw new UnsupportedOperationException("Cannot transfer to tensor of different layout");
+    }
+    target.clear();
+    target.data = data.getReferenceManager().transferOwnership(data, target.allocator).getTransferredBuffer();
+    clear();
+  }
+
+  /** Get the given tensor element as an object. */
+  abstract Object getObject(long[] indices);
+
+  /** Free the tensor buffer. */
+  public void clear() {
+    data.getReferenceManager().release();
+    data = allocator.getEmpty();
+  }
+
+  /** Construct the FlatBuffer metadata for this tensor. */
+  public int getTensor(FlatBufferBuilder builder) {
+    int typeOffset = type.getType(builder);
+
+    int[] nameOffsets = names == null ? null : new int[names.length];
+    if (nameOffsets != null) {
+      for (int i = 0; i < names.length; i++) {
+        nameOffsets[i] = builder.createString(names[i]);
+      }
+    }
+    int[] dimOffsets = new int[shape.length];
+    for (int i = 0; i < shape.length; i++) {
+      TensorDim.startTensorDim(builder);
+      TensorDim.addSize(builder, shape[i]);
+      if (nameOffsets != null) {
+        TensorDim.addName(builder, nameOffsets[i]);
+      }
+      dimOffsets[i] = TensorDim.endTensorDim(builder);
+    }
+
+    int shapeOffset = Tensor.createShapeVector(builder, dimOffsets);
+    int stridesOffset = Tensor.createStridesVector(builder, strides);
+
+    Tensor.startTensor(builder);
+    Tensor.addType(builder, typeOffset);
+    Tensor.addTypeType(builder, type.getTypeID().getFlatbufID());
+    Tensor.addShape(builder, shapeOffset);
+    Tensor.addStrides(builder, stridesOffset);
+    Tensor.addData(builder, Buffer.createBuffer(builder, 0, data.capacity()));
+    return Tensor.endTensor(builder);
+  }
+
+  /** Get the IPC messsage-encapsulated metadata for this tensor as a ByteBuffer. */
+  public ByteBuffer getAsMessage(IpcOption option) {
+    FlatBufferBuilder builder = new FlatBufferBuilder();
+    int tensorOffset = getTensor(builder);
+    long bodyLength = minBufferSize(shape, strides);
+    return MessageSerializer.serializeMessage(builder, MessageHeader.Tensor, tensorOffset, bodyLength, option);
+  }
+
+  /** Serialize this tensor to the given channel. */
+  public void write(WriteChannel out, IpcOption option) throws IOException {
+    ByteBuffer header = getAsMessage(option);
+    MessageSerializer.writeMessageBuffer(out, header.remaining(), header, option);
+    out.write(data);
+    out.align();
+  }
+
+  /** Deserialize a tensor from the given channel. */
+  public static BaseTensor read(ReadChannel in, BufferAllocator allocator) throws IOException {
+    MessageMetadataResult result = MessageSerializer.readMessage(in);
+    if (result == null) {
+      throw new IOException("Unexpected end of input when reading Tensor");
+    }
+    if (result.getMessage().headerType() != MessageHeader.Tensor) {
+      throw new IOException("Expected tensor but header was " + result.getMessage().headerType());
+    }
+    Message message = result.getMessage();
+    long bodyLength = result.getMessageBodyLength();
+    ArrowBuf bodyBuffer = MessageSerializer.readMessageBody(in, bodyLength, allocator);
+    return read(message, bodyBuffer);
+  }
+
+  /** Deserialize a tensor from the IPC message and body. */
+  public static BaseTensor read(Message message, ArrowBuf body) throws IOException {
+    if (message.headerType() != MessageHeader.Tensor) {
+      throw new IOException("Expected tensor but header was " + message.headerType());
+    }
+    Tensor tensorFb = (Tensor) message.header(new Tensor());
+    if (tensorFb == null) {
+      throw new IOException("Tensor metadata not present in message");
+    }
+    return read(tensorFb, body);
+  }
+
+  /** Deserialize a tensor from the tensor metadata and body. */
+  private static BaseTensor read(Tensor tensorFb, ArrowBuf body) {
+    long[] dims = new long[tensorFb.shapeLength()];
+    String[] names = new String[tensorFb.shapeLength()];
+    boolean hasNames = false;
+    long[] strides = new long[tensorFb.stridesLength()];
+    for (int i = 0; i < strides.length; i++) {
+      strides[i] = tensorFb.strides(i);
+    }
+    TensorDim dim = new TensorDim();
+    for (int i = 0; i < dims.length; i++) {
+      tensorFb.shape(dim, i);
+      if (dim.name() != null) {
+        names[i] = dim.name();
+        hasNames = true;
+      }
+      dims[i] = Math.toIntExact(dim.size()); // TODO:
+    }
+    final BaseTensor result = ArrowType.getTypeForField(tensorFb)
+        .accept(new MakeTensorForArrowType(body, dims, hasNames, names, strides));
+    result.clear();
+    result.data = body;
+    return result;
+  }
+
+  @Override
+  public void close() {
+    clear();
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder buf = new StringBuilder();
+    buf.append(getClass().getSimpleName());
+    buf.append('[');
+    for (int i = 0; i < shape.length; i++) {
+      buf.append(shape[i]);
+      if (i < shape.length - 1) {
+        buf.append(", ");
+      }
+    }
+    buf.append(']');
+    return buf.toString();
+  }
+
+  private static class MakeTensorForArrowType extends ArrowType.PrimitiveTypeVisitor<BaseTensor> {
+    private final ArrowBuf body;
+    private final long[] dims;
+    private final boolean hasNames;
+    private final String[] names;
+    private final long[] strides;
+
+    MakeTensorForArrowType(ArrowBuf body, long[] dims, boolean hasNames, String[] names, long[] strides) {
+      this.body = body;
+      this.dims = dims;
+      this.hasNames = hasNames;
+      this.names = names;
+      this.strides = strides;
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Null type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Int type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.FloatingPoint type) {
+      switch (type.getPrecision()) {
+        case HALF:
+          throw new UnsupportedOperationException();
+        case SINGLE:
+          throw new UnsupportedOperationException();
+        case DOUBLE:
+          return new Float8Tensor(body.getReferenceManager().getAllocator(), dims, hasNames ? names : null, strides);
+        default:
+          throw new UnsupportedOperationException();
+      }
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Utf8 type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.LargeUtf8 type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Binary type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.LargeBinary type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.FixedSizeBinary type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Bool type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Decimal type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Date type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Time type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Timestamp type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Interval type) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BaseTensor visit(ArrowType.Duration type) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/java/tensor/src/main/java/org/apache/arrow/tensor/Float8Tensor.java
+++ b/java/tensor/src/main/java/org/apache/arrow/tensor/Float8Tensor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.tensor;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+
+/** A tensor of doubles. */
+public class Float8Tensor extends BaseTensor {
+  public static final byte TYPE_WIDTH = 8;
+  public static final ArrowType TYPE = new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+
+  public Float8Tensor(BufferAllocator allocator, long[] shape, String[] names, long[] strides) {
+    super(allocator, TYPE, TYPE_WIDTH, shape, names, strides);
+  }
+
+  @Override
+  Object getObject(long[] indices) {
+    return get(indices);
+  }
+
+  double get(long[] indices) {
+    checkClosed();
+    return data.getDouble(getElementIndex(indices));
+  }
+
+  void set(long[] indices, double value) {
+    checkClosed();
+    data.setDouble(getElementIndex(indices), value);
+  }
+
+  void copyFrom(double[] source) {
+    long expectedElements = getElementCount();
+    Preconditions.checkArgument(expectedElements == source.length,
+        "Cannot copy tensor of %s elements to array of %s elements", expectedElements, source.length);
+    int offset = 0;
+    for (double value : source) {
+      data.setDouble(offset, value);
+      offset += typeWidth;
+    }
+  }
+
+  void copyTo(double[] target) {
+    long expectedElements = getElementCount();
+    Preconditions.checkArgument(expectedElements == target.length,
+        "Cannot copy tensor of %s elements to array of %s elements", expectedElements, target.length);
+    int offset = 0;
+    for (int i = 0; i < expectedElements; i++) {
+      target[i] = data.getDouble(offset);
+      offset += typeWidth;
+    }
+  }
+}

--- a/java/tensor/src/test/java/org/apache/arrow/tensor/TestBaseTensor.java
+++ b/java/tensor/src/test/java/org/apache/arrow/tensor/TestBaseTensor.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.tensor;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+public class TestBaseTensor {
+  @Test
+  public void rowMajorStrides() {
+    assertArrayEquals(new long[]{4}, BaseTensor.rowMajorStrides((byte) 4, new long[]{2}));
+    assertArrayEquals(new long[]{12, 4}, BaseTensor.rowMajorStrides((byte) 4, new long[]{2, 3}));
+    assertArrayEquals(new long[]{60, 20, 4}, BaseTensor.rowMajorStrides((byte) 4, new long[]{2, 3, 5}));
+  }
+
+  @Test
+  public void columnMajorStrides() {
+    assertArrayEquals(new long[]{4}, BaseTensor.columnMajorStrides((byte) 4, new long[]{2}));
+    assertArrayEquals(new long[]{4, 8}, BaseTensor.columnMajorStrides((byte) 4, new long[]{2, 3}));
+    assertArrayEquals(new long[]{4, 8, 24}, BaseTensor.columnMajorStrides((byte) 4, new long[]{2, 3, 5}));
+  }
+}

--- a/java/tensor/src/test/java/org/apache/arrow/tensor/TestFloatTensor.java
+++ b/java/tensor/src/test/java/org/apache/arrow/tensor/TestFloatTensor.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.tensor;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestFloatTensor {
+  private static final double EPSILON = 1e-6;
+  private BufferAllocator allocator;
+
+  @Before
+  public void setUp() {
+    allocator = new RootAllocator(Integer.MAX_VALUE);
+  }
+
+  @After
+  public void tearDown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testConstructorValidation() {
+    IllegalArgumentException err;
+    err = assertThrows(IllegalArgumentException.class,
+        () -> new Float8Tensor(allocator, new long[]{1}, null, new long[]{}));
+    assertTrue(err.toString(), err.getMessage().contains("Dimensions (1) must match strides (0)"));
+
+    err = assertThrows(IllegalArgumentException.class,
+        () -> new Float8Tensor(allocator, new long[]{1}, new String[]{}, new long[]{8}));
+    assertTrue(err.toString(), err.getMessage().contains("Dimensions must match names"));
+
+    err = assertThrows(IllegalArgumentException.class,
+        () -> new Float8Tensor(allocator, new long[]{1}, new String[]{"foo"}, new long[]{4}));
+    assertTrue(err.toString(), err.getMessage().contains("0th stride 4 must be at least type width 8"));
+  }
+
+  @Test
+  public void testGetters() {
+    long[] shape = new long[]{2, 3, 4};
+    String[] names = new String[]{"x", "y", "z"};
+    long[] rowStrides = BaseTensor.rowMajorStrides(Float8Tensor.TYPE_WIDTH, shape);
+    long[] columnStrides = BaseTensor.columnMajorStrides(Float8Tensor.TYPE_WIDTH, shape);
+    try (Float8Tensor tensor1 = new Float8Tensor(allocator, shape, names, rowStrides);
+         Float8Tensor tensor2 = new Float8Tensor(allocator, shape, null, rowStrides);
+         Float8Tensor tensor3 = new Float8Tensor(allocator, shape, null, columnStrides)) {
+      assertEquals("Float8Tensor[2, 3, 4]", tensor1.toString());
+      assertEquals(Float8Tensor.TYPE_WIDTH, tensor1.getTypeWidth());
+      assertArrayEquals(shape, tensor1.getShape());
+      assertArrayEquals(names, tensor1.getNames());
+      assertArrayEquals(rowStrides, tensor1.getStrides());
+      assertEquals(24, tensor1.getElementCount());
+      assertTrue(tensor1.hasSameLayoutAs(tensor1));
+      assertTrue(tensor1.hasSameLayoutAs(tensor2));
+      assertTrue(tensor2.hasSameLayoutAs(tensor1));
+      assertFalse(tensor1.hasSameLayoutAs(tensor3));
+
+      assertTrue(tensor2.isRowMajor());
+      assertFalse(tensor2.isColumnMajor());
+      assertFalse(tensor3.isRowMajor());
+      assertTrue(tensor3.isColumnMajor());
+    }
+  }
+
+  @Test
+  public void testGetSet() {
+    long[] shape = new long[]{2, 3, 4};
+    long[] strides = BaseTensor.rowMajorStrides(Float8Tensor.TYPE_WIDTH, shape);
+    try (Float8Tensor tensor = new Float8Tensor(allocator, shape, null, strides)) {
+      assertThrows(IllegalArgumentException.class, () -> tensor.get(new long[]{-1}));
+      assertThrows(IllegalArgumentException.class, () -> tensor.get(new long[]{0, 0, 0, 0}));
+      assertThrows(IndexOutOfBoundsException.class, () -> tensor.get(new long[]{-1, 0, 0}));
+      assertThrows(IndexOutOfBoundsException.class, () -> tensor.get(new long[]{0, 5, 2}));
+
+      assertEquals(64, tensor.getElementIndex(new long[]{0, 2, 0}));
+      assertEquals(0.0, tensor.get(new long[]{0, 2, 0}), EPSILON);
+      assertEquals(0.0, (Double) tensor.getObject(new long[]{0, 2, 0}), EPSILON);
+      tensor.set(new long[]{0, 2, 0}, 1.0);
+      assertEquals(1.0, tensor.get(new long[]{0, 2, 0}), EPSILON);
+      assertEquals(1.0, tensor.getDataBuffer().getDouble(64), EPSILON);
+    }
+    Float8Tensor tensor = new Float8Tensor(allocator, shape, null, strides);
+    tensor.close();
+    assertThrows(IllegalStateException.class, () -> tensor.get(new long[0]));
+  }
+
+  @Test
+  public void testZeroTensor() {
+    long[] shape = new long[]{2, 3, 4};
+    long[] strides = BaseTensor.rowMajorStrides(Float8Tensor.TYPE_WIDTH, shape);
+    try (Float8Tensor tensor = new Float8Tensor(allocator, shape, null, strides)) {
+      assertEquals(64, tensor.getElementIndex(new long[]{0, 2, 0}));
+      tensor.set(new long[]{0, 2, 0}, 1.0);
+      assertEquals(1.0, tensor.get(new long[]{0, 2, 0}), EPSILON);
+      assertEquals(1.0, tensor.getDataBuffer().getDouble(64), EPSILON);
+      tensor.zeroTensor();
+      assertEquals(0.0, tensor.get(new long[]{0, 2, 0}), EPSILON);
+      assertEquals(0.0, tensor.getDataBuffer().getDouble(64), EPSILON);
+    }
+  }
+
+  @Test
+  public void testTransferTo() {
+    long[] shape = new long[]{2, 3, 4};
+    long[] rowStrides = BaseTensor.rowMajorStrides(Float8Tensor.TYPE_WIDTH, shape);
+    long[] colStrides = BaseTensor.columnMajorStrides(Float8Tensor.TYPE_WIDTH, shape);
+    BufferAllocator allocator2 = allocator.newChildAllocator("child", 0, allocator.getLimit());
+    try (Float8Tensor tensor1 = new Float8Tensor(allocator2, shape, null, rowStrides);
+         Float8Tensor tensor2 = new Float8Tensor(allocator, shape, null, rowStrides);
+         Float8Tensor tensor3 = new Float8Tensor(allocator, shape, null, colStrides)) {
+      long[] indices = {0, 0, 0};
+      tensor1.set(indices, 5.0);
+      tensor1.transferTo(tensor2);
+      allocator2.close();
+      assertThrows(IllegalStateException.class, () -> tensor1.get(indices));
+      assertEquals(5.0, tensor2.get(indices), 5.0);
+
+      assertThrows(UnsupportedOperationException.class, () -> tensor2.transferTo(tensor3));
+    }
+  }
+
+  @Test
+  public void testCopyToFrom() {
+    long[] shape = new long[]{2, 3};
+    long[] rowStrides = BaseTensor.rowMajorStrides(Float8Tensor.TYPE_WIDTH, shape);
+    double[] rowMajorSource = new double[] {1, 2, 3, 4, 5, 6};
+    double[] target = new double[6];
+    try (Float8Tensor tensor = new Float8Tensor(allocator, shape, null, rowStrides)) {
+      tensor.copyFrom(rowMajorSource);
+      assertEquals(1.0, tensor.get(new long[]{0, 0}), EPSILON);
+      assertEquals(2.0, tensor.get(new long[]{0, 1}), EPSILON);
+      assertEquals(3.0, tensor.get(new long[]{0, 2}), EPSILON);
+      assertEquals(4.0, tensor.get(new long[]{1, 0}), EPSILON);
+      assertEquals(5.0, tensor.get(new long[]{1, 1}), EPSILON);
+      assertEquals(6.0, tensor.get(new long[]{1, 2}), EPSILON);
+      tensor.copyTo(target);
+      assertArrayEquals(rowMajorSource, target, EPSILON);
+    }
+  }
+}

--- a/java/tensor/src/test/java/org/apache/arrow/tensor/TestRoundTrip.java
+++ b/java/tensor/src/test/java/org/apache/arrow/tensor/TestRoundTrip.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.tensor;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.channels.Channels;
+
+import org.apache.arrow.flatbuf.Message;
+import org.apache.arrow.flatbuf.MessageHeader;
+import org.apache.arrow.flatbuf.Tensor;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.ipc.ReadChannel;
+import org.apache.arrow.vector.ipc.WriteChannel;
+import org.apache.arrow.vector.ipc.message.IpcOption;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestRoundTrip {
+  private static final double EPSILON = 1e-6;
+  private BufferAllocator allocator;
+
+  @Before
+  public void setUp() {
+    allocator = new RootAllocator(Integer.MAX_VALUE);
+  }
+
+  @After
+  public void tearDown() {
+    allocator.close();
+  }
+
+  @Test
+  public void testMetadata() {
+    long[] shape = new long[]{2, 3};
+    long[] rowStrides = BaseTensor.rowMajorStrides(Float8Tensor.TYPE_WIDTH, shape);
+    double[] rowMajorSource = new double[] {1, 2, 3, 4, 5, 6};
+    try (Float8Tensor tensor = new Float8Tensor(allocator, shape, null, rowStrides)) {
+      tensor.copyFrom(rowMajorSource);
+      final Message msg = Message.getRootAsMessage(tensor.getAsMessage(new IpcOption()));
+      assertEquals(MessageHeader.Tensor, msg.headerType());
+      final Tensor tensorMeta = (Tensor) msg.header(new Tensor());
+      assertNotNull(tensorMeta);
+      assertEquals(tensor.getShape().length, tensorMeta.shapeLength());
+      assertEquals(tensor.getStrides().length, tensorMeta.stridesLength());
+      assertTrue(msg.bodyLength() >= BaseTensor.minBufferSize(tensor.getShape(), tensor.getStrides()));
+    }
+  }
+
+  @Test
+  public void testRoundTrip() throws IOException {
+    long[] shape = new long[]{2, 3};
+    long[] rowStrides = BaseTensor.rowMajorStrides(Float8Tensor.TYPE_WIDTH, shape);
+    double[] rowMajorSource = new double[] {1, 2, 3, 4, 5, 6};
+
+    final ByteArrayOutputStream buf = new ByteArrayOutputStream();
+    try (Float8Tensor tensor = new Float8Tensor(allocator, shape, null, rowStrides)) {
+      tensor.copyFrom(rowMajorSource);
+      try (final WriteChannel ch = new WriteChannel(Channels.newChannel(buf))) {
+        tensor.write(ch, new IpcOption());
+      }
+    }
+    try (final ReadChannel ch = new ReadChannel(Channels.newChannel(new ByteArrayInputStream(buf.toByteArray())))) {
+      try (final Float8Tensor tensor = (Float8Tensor) BaseTensor.read(ch, allocator)) {
+        double[] target = new double[rowMajorSource.length];
+        tensor.copyTo(target);
+        assertArrayEquals(rowMajorSource, target, EPSILON);
+      }
+    }
+  }
+}

--- a/java/vector/src/main/codegen/data/MessagesWithTypes.tdd
+++ b/java/vector/src/main/codegen/data/MessagesWithTypes.tdd
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data: {
-    # TODO:  Rename to ~valueVectorModesAndTypes for clarity.
-    vv:                       tdd(../data/ValueVectorTypes.tdd),
-    arrowTypes:               tdd(../data/ArrowTypes.tdd)
-    messagesWithTypes:        tdd(../data/MessagesWithTypes.tdd)
-
-}
-freemarkerLinks: {
-    includes: includes/
+{
+  messages: [
+    {
+      name: "Field"
+    },
+    {
+      name: "Tensor"
+    }
+  ]
 }

--- a/java/vector/src/main/codegen/templates/ArrowType.java
+++ b/java/vector/src/main/codegen/templates/ArrowType.java
@@ -308,7 +308,8 @@ public abstract class ArrowType {
 
   private static final int defaultDecimalBitWidth = 128;
 
-  public static org.apache.arrow.vector.types.pojo.ArrowType getTypeForField(org.apache.arrow.flatbuf.Field field) {
+  <#list messagesWithTypes.messages as messageType>
+  public static org.apache.arrow.vector.types.pojo.ArrowType getTypeForField(org.apache.arrow.flatbuf.${messageType.name} field) {
     switch(field.typeType()) {
     <#list arrowTypes.types as type>
     <#assign name = type.name?remove_ending("_")>
@@ -339,6 +340,7 @@ public abstract class ArrowType {
       throw new UnsupportedOperationException("Unsupported type: " + field.typeType());
     }
   }
+  </#list>
 
   public static Int getInt(org.apache.arrow.flatbuf.Field field) {
     org.apache.arrow.flatbuf.Int intType = (org.apache.arrow.flatbuf.Int) field.type(new org.apache.arrow.flatbuf.Int());


### PR DESCRIPTION
This is an attempt at a Tensor contrib module. It hard-codes a single implementation for doubles only. If the overall API looks OK, I could then apply the FreeMarker templates (like the Vector module) and generate implementations for all the fixed-width types, and set up integration tests. I'd also like to implement a set of pre-defined extension types for Tensor columns.

- [ ] Should this just go in the vector module?
- [ ] Do we need other operations?
- [ ] Refactor out the IPC code into its own class
- [ ] Refactor out a base interface or class
- [ ] Add tensors to integration tests