### PR TITLE
ARROW-6043: [Python] Array equals returns incorrectly if NaNs are in arrays

### DIFF
--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -82,7 +82,7 @@ Result<std::shared_ptr<ChunkedArray>> ChunkedArray::Make(ArrayVector chunks,
   return std::make_shared<ChunkedArray>(std::move(chunks), std::move(type));
 }
 
-bool ChunkedArray::Equals(const ChunkedArray& other) const {
+bool ChunkedArray::Equals(const ChunkedArray& other, const EqualOptions& options) const {
   if (length_ != other.length()) {
     return false;
   }
@@ -98,9 +98,9 @@ bool ChunkedArray::Equals(const ChunkedArray& other) const {
   // the underlying data independently of the chunk size.
   return internal::ApplyBinaryChunked(
              *this, other,
-             [](const Array& left_piece, const Array& right_piece,
-                int64_t ARROW_ARG_UNUSED(position)) {
-               if (!left_piece.Equals(right_piece)) {
+             [options](const Array& left_piece, const Array& right_piece,
+                       int64_t ARROW_ARG_UNUSED(position)) {
+               if (!left_piece.Equals(right_piece, options)) {
                  return Status::Invalid("Unequal piece");
                }
                return Status::OK();
@@ -108,14 +108,15 @@ bool ChunkedArray::Equals(const ChunkedArray& other) const {
       .ok();
 }
 
-bool ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other) const {
+bool ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other,
+                          const EqualOptions& options) const {
   if (this == other.get()) {
     return true;
   }
   if (!other) {
     return false;
   }
-  return Equals(*other.get());
+  return Equals(*other.get(), options);
 }
 
 std::shared_ptr<ChunkedArray> ChunkedArray::Slice(int64_t offset, int64_t length) const {

--- a/cpp/src/arrow/chunked_array.h
+++ b/cpp/src/arrow/chunked_array.h
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/compare.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
@@ -130,9 +131,11 @@ class ARROW_EXPORT ChunkedArray {
   ///
   /// Two chunked arrays can be equal only if they have equal datatypes.
   /// However, they may be equal even if they have different chunkings.
-  bool Equals(const ChunkedArray& other) const;
+  bool Equals(const ChunkedArray& other,
+              const EqualOptions& = EqualOptions::Defaults()) const;
   /// \brief Determine if two chunked arrays are equal.
-  bool Equals(const std::shared_ptr<ChunkedArray>& other) const;
+  bool Equals(const std::shared_ptr<ChunkedArray>& other,
+              const EqualOptions& = EqualOptions::Defaults()) const;
 
   /// \return PrettyPrint representation suitable for debugging
   std::string ToString() const;

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -71,11 +71,22 @@ class EqualOptions {
     return res;
   }
 
+  /// Whether or not to check metadata objects for equality.
+  bool check_metadata() const { return check_metadata_; }
+
+  /// Return a new EqualOptions object with the "check_metadata" property changed.
+  EqualOptions check_metadata(bool v) const {
+    auto res = EqualOptions(*this);
+    res.check_metadata_ = v;
+    return res;
+  }
+
   static EqualOptions Defaults() { return EqualOptions(); }
 
  protected:
   double atol_ = kDefaultAbsoluteTolerance;
   bool nans_equal_ = false;
+  bool check_metadata_ = true;
   std::ostream* diff_sink_ = NULLPTR;
 };
 

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -86,7 +86,7 @@ class EqualOptions {
  protected:
   double atol_ = kDefaultAbsoluteTolerance;
   bool nans_equal_ = false;
-  bool check_metadata_ = true;
+  bool check_metadata_ = false;
   std::ostream* diff_sink_ = NULLPTR;
 };
 

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -216,6 +216,24 @@ bool RecordBatch::Equals(const RecordBatch& other, bool check_metadata) const {
   return true;
 }
 
+bool RecordBatch::Equals(const RecordBatch& other, const EqualOptions& options) const {
+  if (num_columns() != other.num_columns() || num_rows_ != other.num_rows()) {
+    return false;
+  }
+
+  if (!schema_->Equals(*other.schema(), /*check_metadata=*/options.check_metadata())) {
+    return false;
+  }
+
+  for (int i = 0; i < num_columns(); ++i) {
+    if (!column(i)->Equals(other.column(i), options)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool RecordBatch::ApproxEquals(const RecordBatch& other) const {
   if (num_columns() != other.num_columns() || num_rows_ != other.num_rows()) {
     return false;

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -22,6 +22,7 @@
 #include <string>
 #include <vector>
 
+#include "arrow/compare.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
@@ -80,7 +81,10 @@ class ARROW_EXPORT RecordBatch {
   /// \param[in] other the RecordBatch to compare with
   /// \param[in] check_metadata if true, check that Schema metadata is the same
   /// \return true if batches are equal
-  bool Equals(const RecordBatch& other, bool check_metadata = false) const;
+  bool Equals(const RecordBatch& other, bool check_metadata) const;
+
+  bool Equals(const RecordBatch& other,
+              const EqualOptions& options = EqualOptions::Defaults()) const;
 
   /// \brief Determine if two record batches are approximately equal
   bool ApproxEquals(const RecordBatch& other) const;

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -534,6 +534,25 @@ bool Table::Equals(const Table& other, bool check_metadata) const {
   return true;
 }
 
+bool Table::Equals(const Table& other, const EqualOptions& options) const {
+  if (this == &other) {
+    return true;
+  }
+  if (!schema_->Equals(*other.schema(), options.check_metadata())) {
+    return false;
+  }
+  if (this->num_columns() != other.num_columns()) {
+    return false;
+  }
+
+  for (int i = 0; i < this->num_columns(); i++) {
+    if (!this->column(i)->Equals(other.column(i), options)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 Result<std::shared_ptr<Table>> Table::CombineChunks(MemoryPool* pool) const {
   const int ncolumns = num_columns();
   std::vector<std::shared_ptr<ChunkedArray>> compacted_columns(ncolumns);

--- a/cpp/src/arrow/table.h
+++ b/cpp/src/arrow/table.h
@@ -197,7 +197,10 @@ class ARROW_EXPORT Table {
   ///
   /// Two tables can be equal only if they have equal schemas.
   /// However, they may be equal even if they have different chunkings.
-  bool Equals(const Table& other, bool check_metadata = false) const;
+  bool Equals(const Table& other, bool check_metadata) const;
+
+  bool Equals(const Table& other,
+              const EqualOptions& options = EqualOptions::Defaults()) const;
 
   /// \brief Make a new table by combining the chunks this table has.
   ///

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1009,7 +1009,8 @@ cdef class Array(_PandasConvertible):
             return NotImplemented
 
     def equals(Array self, Array other):
-        return self.ap.Equals(deref(other.ap))
+        cdef CEqualOptions options = CEqualOptions.Defaults()
+        return self.ap.Equals(deref(other.ap), options.nans_equal(True))
 
     def __len__(self):
         return self.length()

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1008,9 +1008,12 @@ cdef class Array(_PandasConvertible):
         except TypeError:
             return NotImplemented
 
-    def equals(Array self, Array other):
+    def equals(Array self, Array other, *, bint check_metadata=False,
+               bint nans_equal=True):
         cdef CEqualOptions options = CEqualOptions.Defaults()
-        return self.ap.Equals(deref(other.ap), options.nans_equal(True))
+        options = (options.nans_equal(nans_equal)
+                          .check_metadata(check_metadata))
+        return self.ap.Equals(deref(other.ap), options)
 
     def __len__(self):
         return self.length()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -181,9 +181,11 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         @staticmethod
         CEqualOptions Defaults()
         CEqualOptions nans_equal(c_bool v) const
+        CEqualOptions check_metadata(c_bool v) const
         CEqualOptions atol(double v) const
         double atol() const
         c_bool nans_equal() const
+        c_bool check_metadata() const
 
     cdef cppclass CArray" arrow::Array":
         shared_ptr[CDataType] type()
@@ -696,7 +698,8 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int64_t length()
         int64_t null_count()
         int num_chunks()
-        c_bool Equals(const CChunkedArray& other)
+
+        c_bool Equals(const CChunkedArray& other, const CEqualOptions& options)
 
         shared_ptr[CArray] chunk(int i)
         shared_ptr[CDataType] type()
@@ -718,7 +721,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CResult[shared_ptr[CRecordBatch]] FromStructArray(
             const shared_ptr[CArray]& array)
 
-        c_bool Equals(const CRecordBatch& other, c_bool check_metadata)
+        c_bool Equals(const CRecordBatch& other, const CEqualOptions& options)
 
         shared_ptr[CSchema] schema()
         shared_ptr[CArray] column(int i)
@@ -760,7 +763,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         int num_columns()
         int64_t num_rows()
 
-        c_bool Equals(const CTable& other, c_bool check_metadata)
+        c_bool Equals(const CTable& other, const CEqualOptions& options)
 
         shared_ptr[CSchema] schema()
         shared_ptr[CChunkedArray] column(int i)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -177,6 +177,14 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
             int64_t null_count,
             int64_t offset)
 
+    cdef cppclass CEqualOptions" arrow::EqualOptions":
+        @staticmethod
+        CEqualOptions Defaults()
+        CEqualOptions nans_equal(c_bool v) const
+        CEqualOptions atol(double v) const
+        double atol() const
+        c_bool nans_equal() const
+
     cdef cppclass CArray" arrow::Array":
         shared_ptr[CDataType] type()
 
@@ -190,7 +198,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         CResult[shared_ptr[CScalar]] GetScalar(int64_t i) const
 
         c_string Diff(const CArray& other)
-        c_bool Equals(const CArray& arr)
+        c_bool Equals(const CArray& arr, const CEqualOptions&) const
         c_bool IsNull(int i)
 
         shared_ptr[CArrayData] data()

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -194,7 +194,8 @@ cdef class ChunkedArray(_PandasConvertible):
         """
         return _pc().fill_null(self, fill_value)
 
-    def equals(self, ChunkedArray other):
+    def equals(self, ChunkedArray other, *, bint check_metadata=True,
+               bint nans_equal=True):
         """
         Return whether the contents of two chunked arrays are equal.
 
@@ -210,13 +211,16 @@ cdef class ChunkedArray(_PandasConvertible):
         cdef:
             CChunkedArray* this_arr = self.chunked_array
             CChunkedArray* other_arr = other.chunked_array
+            CEqualOptions options = CEqualOptions.Defaults()
             c_bool result
 
         if other is None:
             return False
 
+        options = (options.nans_equal(nans_equal)
+                          .check_metadata(check_metadata))
         with nogil:
-            result = this_arr.Equals(deref(other_arr))
+            result = this_arr.Equals(deref(other_arr), options)
 
         return result
 
@@ -786,7 +790,8 @@ cdef class RecordBatch(_PandasConvertible):
         """
         return _pc().filter(self, mask, null_selection_behavior)
 
-    def equals(self, object other, bint check_metadata=False):
+    def equals(self, RecordBatch other, *, bint check_metadata=False,
+               bint nans_equal=True):
         """
         Check if contents of two record batches are equal.
 
@@ -804,13 +809,16 @@ cdef class RecordBatch(_PandasConvertible):
         cdef:
             CRecordBatch* this_batch = self.batch
             shared_ptr[CRecordBatch] other_batch = pyarrow_unwrap_batch(other)
+            CEqualOptions options = CEqualOptions.Defaults()
             c_bool result
 
         if not other_batch:
             return False
 
+        options = (options.nans_equal(nans_equal)
+                          .check_metadata(check_metadata))
         with nogil:
-            result = this_batch.Equals(deref(other_batch), check_metadata)
+            result = this_batch.Equals(deref(other_batch), options)
 
         return result
 
@@ -1272,7 +1280,8 @@ cdef class Table(_PandasConvertible):
         except TypeError:
             return NotImplemented
 
-    def equals(self, Table other, bint check_metadata=False):
+    def equals(self, Table other, *, bint check_metadata=False,
+               bint nans_equal=True):
         """
         Check if contents of two tables are equal.
 
@@ -1290,13 +1299,16 @@ cdef class Table(_PandasConvertible):
         cdef:
             CTable* this_table = self.table
             CTable* other_table = other.table
+            CEqualOptions options = CEqualOptions.Defaults()
             c_bool result
 
         if other is None:
             return False
 
+        options = (options.nans_equal(nans_equal)
+                          .check_metadata(check_metadata))
         with nogil:
-            result = this_table.Equals(deref(other_table), check_metadata)
+            result = this_table.Equals(deref(other_table), options)
 
         return result
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -307,6 +307,15 @@ def test_nulls(ty):
         assert arr.type == ty
 
 
+def test_array_equals_with_nulls():
+    data = [0, 1, np.nan, None, 4]
+    arr1 = pa.array(data)
+    arr2 = pa.array(data)
+    arr3 = pa.array([0, 1, 0, 0, 4])
+    assert arr1.equals(arr2) is True
+    assert arr1.equals(arr3) is False
+
+
 def test_array_from_scalar():
     today = datetime.date.today()
     now = datetime.datetime.now()


### PR DESCRIPTION
Expose `EqualOptions` and set nans_equal to True. We should probably reduce `Array::Equals` to data structure equality and move the ArrayEquals implementation to the comparison kernels.