### PR TITLE
ARROW-8426: [Rust] [Parquet] Add support for writing dictionary types

### DIFF
--- a/rust/arrow/src/datatypes.rs
+++ b/rust/arrow/src/datatypes.rs
@@ -181,8 +181,8 @@ pub struct Field {
     name: String,
     data_type: DataType,
     nullable: bool,
-    dict_id: i64,
-    dict_is_ordered: bool,
+    pub(crate) dict_id: i64,
+    pub(crate) dict_is_ordered: bool,
 }
 
 pub trait ArrowNativeType:

--- a/rust/parquet/src/arrow/schema.rs
+++ b/rust/parquet/src/arrow/schema.rs
@@ -1396,16 +1396,16 @@ mod tests {
                 // Field::new("c28", DataType::Duration(TimeUnit::Millisecond), false),
                 // Field::new("c29", DataType::Duration(TimeUnit::Microsecond), false),
                 // Field::new("c30", DataType::Duration(TimeUnit::Nanosecond), false),
-                // Field::new_dict(
-                //     "c31",
-                //     DataType::Dictionary(
-                //         Box::new(DataType::Int32),
-                //         Box::new(DataType::Utf8),
-                //     ),
-                //     true,
-                //     123,
-                //     true,
-                // ),
+                Field::new_dict(
+                    "c31",
+                    DataType::Dictionary(
+                        Box::new(DataType::Int32),
+                        Box::new(DataType::Utf8),
+                    ),
+                    true,
+                    123,
+                    true,
+                ),
                 Field::new("c32", DataType::LargeBinary, true),
                 Field::new("c33", DataType::LargeUtf8, true),
                 Field::new(


### PR DESCRIPTION
In this commit, I:

- Extracted a `build_field` function for some code shared between
`schema_to_fb` and `schema_to_fb_offset` that needed to change

- Uncommented the dictionary field from the Arrow schema roundtrip test
and add a dictionary field to the IPC roundtrip test

- If a field is a dictionary field, call `add_dictionary` with the
dictionary field information on the flatbuffer field, building the
dictionary as [the C++ code does][cpp-dictionary] and describe with the
same comment

- When getting the field type for a dictionary field, use the `value_type`
as [the C++ code does][cpp-value-type] and describe with the same
comment

The tests pass because the Parquet -> Arrow conversion for dictionaries
is [already supported][parquet-to-arrow].

[cpp-dictionary]: https://github.com/apache/arrow/blob/477c1021ac013f22389baf9154fb9ad0cf814bec/cpp/src/arrow/ipc/metadata_internal.cc#L426-L440
[cpp-value-type]: https://github.com/apache/arrow/blob/477c1021ac013f22389baf9154fb9ad0cf814bec/cpp/src/arrow/ipc/metadata_internal.cc#L662-L667
[parquet-to-arrow]: https://github.com/apache/arrow/blob/477c1021ac013f22389baf9154fb9ad0cf814bec/rust/arrow/src/ipc/convert.rs#L120-L127