### PR TITLE
ARROW-10125: [R] Int64 downcast check doesn't consider all chunks

### DIFF
--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -950,14 +950,14 @@ class Converter_Null : public Converter {
 };
 
 bool ArraysCanFitInteger(ArrayVector arrays) {
-  bool out = false;
+  bool all_can_fit = true;
   auto i32 = arrow::int32();
   for (const auto& array : arrays) {
-    if (!out) {
-      out = arrow::IntegersCanFit(arrow::Datum(array), *i32).ok();
+    if (all_can_fit) {
+      all_can_fit = arrow::IntegersCanFit(arrow::Datum(array), *i32).ok();
     }
   }
-  return out;
+  return all_can_fit;
 }
 
 std::shared_ptr<Converter> Converter::Make(const std::shared_ptr<DataType>& type,

--- a/r/tests/testthat/test-chunked-array.R
+++ b/r/tests/testthat/test-chunked-array.R
@@ -158,6 +158,13 @@ test_that("ChunkedArray supports POSIXct (ARROW-3716)", {
 test_that("ChunkedArray supports integer64 (ARROW-3716)", {
   x <- bit64::as.integer64(1:10) + MAX_INT
   expect_chunked_roundtrip(list(x, x), int64())
+  # Also with a first chunk that would downcast
+  zero <- Array$create(0L)$cast(int64())
+  expect_type_equal(zero, int64())
+  ca <- ChunkedArray$create(zero, x)
+  expect_type_equal(ca, int64())
+  expect_is(as.vector(ca), "integer64")
+  expect_identical(as.vector(ca), c(bit64::as.integer64(0L), x))
 })
 
 test_that("ChunkedArray supports difftime", {


### PR DESCRIPTION
The ArraysCanFitInteger function was erroneously exiting the loop over all chunks early after the first `true` was found, rather than bailing on the first `false`. All chunks need to fit in order to be able to downcast.