### PR TITLE
ARROW-10090: [C++][Compute] Improve mode kernel

### DIFF
--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -136,7 +136,7 @@ Result<Datum> MinMax(const Datum& value,
 /// struct<mode: T, count: int64>, where T is the input type.
 /// If there is more than one such value, the smallest one is returned.
 ///
-/// \param[in] value input datum, expecting Array
+/// \param[in] value input datum, expecting Array or ChunkedArray
 /// \param[in] ctx the function execution context, optional
 /// \return resulting datum as a struct<mode: T, count: int64> scalar
 ///


### PR DESCRIPTION
- Replace naive array data visitor with optimized VisitArrayDataInline.
  It improves performance significantly.
- Add chunked array test cases.