### PR TITLE
ARROW-10041: [Rust] Added check of data type to GenericString::from.

### DIFF
--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -20,7 +20,7 @@ use crate::datatypes::*;
 use crate::util::bit_util;
 use array::{
     Array, GenericBinaryArray, GenericListArray, GenericStringArray, ListArrayOps,
-    OffsetSizeTrait,
+    OffsetSizeTrait, StringOffsetSizeTrait,
 };
 use hex::FromHex;
 use serde_json::value::Value::{Null as JNull, Object, String as JString};
@@ -141,7 +141,7 @@ impl PartialEq for BooleanArray {
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait> PartialEq for GenericStringArray<OffsetSize> {
+impl<OffsetSize: StringOffsetSizeTrait> PartialEq for GenericStringArray<OffsetSize> {
     fn eq(&self, other: &Self) -> bool {
         self.equals(other)
     }
@@ -444,7 +444,7 @@ impl<OffsetSize: OffsetSizeTrait> ArrayEqual for GenericBinaryArray<OffsetSize> 
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait> ArrayEqual for GenericStringArray<OffsetSize> {
+impl<OffsetSize: StringOffsetSizeTrait> ArrayEqual for GenericStringArray<OffsetSize> {
     fn equals(&self, other: &dyn Array) -> bool {
         if !base_equal(&self.data(), &other.data()) {
             return false;
@@ -1063,7 +1063,7 @@ impl<OffsetSize: OffsetSizeTrait> PartialEq<GenericBinaryArray<OffsetSize>> for 
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait> JsonEqual for GenericStringArray<OffsetSize> {
+impl<OffsetSize: StringOffsetSizeTrait> JsonEqual for GenericStringArray<OffsetSize> {
     fn equals_json(&self, json: &[&Value]) -> bool {
         if self.len() != json.len() {
             return false;
@@ -1077,7 +1077,9 @@ impl<OffsetSize: OffsetSizeTrait> JsonEqual for GenericStringArray<OffsetSize> {
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait> PartialEq<Value> for GenericStringArray<OffsetSize> {
+impl<OffsetSize: StringOffsetSizeTrait> PartialEq<Value>
+    for GenericStringArray<OffsetSize>
+{
     fn eq(&self, json: &Value) -> bool {
         match json {
             Value::Array(json_array) => self.equals_json_values(&json_array),
@@ -1086,7 +1088,9 @@ impl<OffsetSize: OffsetSizeTrait> PartialEq<Value> for GenericStringArray<Offset
     }
 }
 
-impl<OffsetSize: OffsetSizeTrait> PartialEq<GenericStringArray<OffsetSize>> for Value {
+impl<OffsetSize: StringOffsetSizeTrait> PartialEq<GenericStringArray<OffsetSize>>
+    for Value
+{
     fn eq(&self, arrow: &GenericStringArray<OffsetSize>) -> bool {
         match self {
             Value::Array(json_array) => arrow.equals_json_values(&json_array),
@@ -1412,7 +1416,7 @@ mod tests {
         // assert!(b_slice.equals(&*a_slice));
     }
 
-    fn test_generic_string_equal<OffsetSize: OffsetSizeTrait>(datatype: DataType) {
+    fn test_generic_string_equal<OffsetSize: StringOffsetSizeTrait>(datatype: DataType) {
         let a = GenericStringArray::<OffsetSize>::from_vec(
             vec!["hello", "world"],
             datatype.clone(),

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -160,6 +160,7 @@ pub use self::array::GenericListArray;
 pub use self::array::GenericStringArray;
 pub use self::array::OffsetSizeTrait;
 pub use self::array::PrimitiveArrayOps;
+pub use self::array::StringOffsetSizeTrait;
 
 // --------------------- Array Builder ---------------------
 

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -19,11 +19,11 @@
 
 use std::ops::Add;
 
-use crate::array::{Array, GenericStringArray, OffsetSizeTrait, PrimitiveArray};
+use crate::array::{Array, GenericStringArray, PrimitiveArray, StringOffsetSizeTrait};
 use crate::datatypes::ArrowNumericType;
 
 /// Helper macro to perform min/max of strings
-fn min_max_string<T: OffsetSizeTrait, F: Fn(&str, &str) -> bool>(
+fn min_max_string<T: StringOffsetSizeTrait, F: Fn(&str, &str) -> bool>(
     array: &GenericStringArray<T>,
     cmp: F,
 ) -> Option<&str> {
@@ -73,12 +73,16 @@ where
 }
 
 /// Returns the maximum value in the string array, according to the natural order.
-pub fn max_string<T: OffsetSizeTrait>(array: &GenericStringArray<T>) -> Option<&str> {
+pub fn max_string<T: StringOffsetSizeTrait>(
+    array: &GenericStringArray<T>,
+) -> Option<&str> {
     min_max_string(array, |a, b| a < b)
 }
 
 /// Returns the minimum value in the string array, according to the natural order.
-pub fn min_string<T: OffsetSizeTrait>(array: &GenericStringArray<T>) -> Option<&str> {
+pub fn min_string<T: StringOffsetSizeTrait>(
+    array: &GenericStringArray<T>,
+) -> Option<&str> {
     min_max_string(array, |a, b| a > b)
 }
 

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -617,7 +617,7 @@ pub fn contains_utf8<OffsetSize>(
     right: &ListArray,
 ) -> Result<BooleanArray>
 where
-    OffsetSize: OffsetSizeTrait,
+    OffsetSize: StringOffsetSizeTrait,
 {
     let left_len = left.len();
     if left_len != right.len() {


### PR DESCRIPTION
This PR fixes a bug on which GenericStringArray::from(ArrayData) was able to be created with the wrong DataType.

It also simplifies generics that use `GenericStringArray`, as they no longer need to pass the corresponding `DataType` and can instead rely on a `const` to do it for them.
