### PR TITLE
ARROW-10130: [C++][Dataset] Ensure ParquetFileFragment::SplitByRowGroup preserves the 'has_complete_metadata' status

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -569,7 +569,7 @@ Result<FragmentVector> ParquetFileFragment::SplitByRowGroup(
   for (auto&& row_group : row_groups) {
     ARROW_ASSIGN_OR_RAISE(*fragment++,
                           parquet_format_.MakeFragment(source_, partition_expression(),
-                                                       {std::move(row_group)}));
+                                                       {std::move(row_group)}, physical_schema_));
   }
 
   return fragments;

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -567,9 +567,9 @@ Result<FragmentVector> ParquetFileFragment::SplitByRowGroup(
   FragmentVector fragments(row_groups.size());
   auto fragment = fragments.begin();
   for (auto&& row_group : row_groups) {
-    ARROW_ASSIGN_OR_RAISE(*fragment++,
-                          parquet_format_.MakeFragment(source_, partition_expression(),
-                                                       {std::move(row_group)}, physical_schema_));
+    ARROW_ASSIGN_OR_RAISE(*fragment++, parquet_format_.MakeFragment(
+                                           source_, partition_expression(),
+                                           {std::move(row_group)}, physical_schema_));
   }
 
   return fragments;

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -2055,6 +2055,11 @@ def test_parquet_dataset_lazy_filtering(tempdir, open_logging_fs):
     with assert_opens([]):
         fragments[0].split_by_row_group(ds.field("f1") > 15)
 
+    # ensuring metadata of splitted fragment should also not open any file
+    with assert_opens([]):
+        rg_fragments = fragments[0].split_by_row_group()
+        rg_fragments[0].ensure_complete_metadata()
+
     # FIXME(bkietz) on Windows this results in FileNotFoundErrors.
     # but actually scanning does open files
     # with assert_opens([f.path for f in fragments]):


### PR DESCRIPTION
By also passing the physical_schema, the ParquetFileFragment constructor will set `has_complete_metadata_` if the statistics are present in the row group infos.