### PR TITLE
ARROW-10136: [Rust]: Fix null handling in StringArray and BinaryArray filtering, add BinaryArray::from_opt_vec

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1282,9 +1282,10 @@ impl<OffsetSize: OffsetSizeTrait> GenericBinaryArray<OffsetSize> {
                     bit_util::set_bit(null_slice, i);
                     length_so_far =
                         length_so_far + OffsetSize::from_usize(s.len()).unwrap();
-                    offsets.push(length_so_far);
                     values.extend_from_slice(s);
                 }
+                // always add an element in offsets
+                offsets.push(length_so_far);
             }
         }
 
@@ -3551,6 +3552,40 @@ mod tests {
             assert_eq!(binary_array1.value_offset(i), binary_array2.value_offset(i));
             assert_eq!(binary_array1.value_length(i), binary_array2.value_length(i));
         }
+    }
+
+    #[test]
+    fn test_binary_array_from_opt_vec() {
+        let values: Vec<Option<&[u8]>> =
+            vec![Some(b"one"), Some(b"two"), None, Some(b""), Some(b"three")];
+        let array = BinaryArray::from_opt_vec(values, DataType::Binary);
+        assert_eq!(array.len(), 5);
+        assert_eq!(array.value(0), b"one");
+        assert_eq!(array.value(1), b"two");
+        assert_eq!(array.value(3), b"");
+        assert_eq!(array.value(4), b"three");
+        assert_eq!(array.is_null(0), false);
+        assert_eq!(array.is_null(1), false);
+        assert_eq!(array.is_null(2), true);
+        assert_eq!(array.is_null(3), false);
+        assert_eq!(array.is_null(4), false);
+    }
+
+    #[test]
+    fn test_large_binary_array_from_opt_vec() {
+        let values: Vec<Option<&[u8]>> =
+            vec![Some(b"one"), Some(b"two"), None, Some(b""), Some(b"three")];
+        let array = LargeBinaryArray::from_opt_vec(values, DataType::LargeBinary);
+        assert_eq!(array.len(), 5);
+        assert_eq!(array.value(0), b"one");
+        assert_eq!(array.value(1), b"two");
+        assert_eq!(array.value(3), b"");
+        assert_eq!(array.value(4), b"three");
+        assert_eq!(array.is_null(0), false);
+        assert_eq!(array.is_null(1), false);
+        assert_eq!(array.is_null(2), true);
+        assert_eq!(array.is_null(3), false);
+        assert_eq!(array.is_null(4), false);
     }
 
     #[test]

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -341,7 +341,7 @@ impl FilterContext {
             }
             DataType::Binary => {
                 let input_array = array.as_any().downcast_ref::<BinaryArray>().unwrap();
-                let mut values: Vec<&[u8]> = Vec::with_capacity(self.filtered_count);
+                let mut values: Vec<Option<&[u8]>> = Vec::with_capacity(self.filtered_count);
                 for i in 0..self.filter_u64.len() {
                     // foreach u64 batch
                     let filter_batch = self.filter_u64[i];
@@ -353,7 +353,11 @@ impl FilterContext {
                         // foreach bit in batch:
                         if (filter_batch & self.filter_mask[j]) != 0 {
                             let data_index = (i * 64) + j;
-                            values.push(input_array.value(data_index));
+                            if input_array.is_null(data_index) {
+                                values.push(None)
+                            } else {
+                                values.push(Some(input_array.value(data_index)))
+                            }
                         }
                     }
                 }
@@ -361,7 +365,7 @@ impl FilterContext {
             }
             DataType::Utf8 => {
                 let input_array = array.as_any().downcast_ref::<StringArray>().unwrap();
-                let mut values: Vec<&str> = Vec::with_capacity(self.filtered_count);
+                let mut values: Vec<Option<&str>> = Vec::with_capacity(self.filtered_count);
                 for i in 0..self.filter_u64.len() {
                     // foreach u64 batch
                     let filter_batch = self.filter_u64[i];
@@ -373,7 +377,11 @@ impl FilterContext {
                         // foreach bit in batch:
                         if (filter_batch & self.filter_mask[j]) != 0 {
                             let data_index = (i * 64) + j;
-                            values.push(input_array.value(data_index));
+                            if input_array.is_null(data_index) {
+                                values.push(None)
+                            } else {
+                                values.push(Some(input_array.value(data_index)))
+                            }
                         }
                     }
                 }
@@ -666,13 +674,36 @@ mod tests {
     }
 
     #[test]
-    fn test_filter_array_with_null() {
+    fn test_filter_primative_array_with_null() {
         let a = Int32Array::from(vec![Some(5), None]);
         let b = BooleanArray::from(vec![false, true]);
         let c = filter(&a, &b).unwrap();
         let d = c.as_ref().as_any().downcast_ref::<Int32Array>().unwrap();
         assert_eq!(1, d.len());
         assert_eq!(true, d.is_null(0));
+    }
+
+    #[test]
+    fn test_filter_string_array_with_null() {
+        let a = StringArray::from(vec![Some("hello"), None, Some("world"), None]);
+        let b = BooleanArray::from(vec![true, false, false, true]);
+        let c = filter(&a, &b).unwrap();
+        let d = c.as_ref().as_any().downcast_ref::<StringArray>().unwrap();
+        assert_eq!(2, d.len());
+        assert_eq!("hello", d.value(0));
+        assert_eq!(true, d.is_null(1));
+    }
+
+    #[test]
+    fn test_filter_binary_array_with_null() {
+        let data: Vec<Option<&[u8]>> = vec![Some(b"hello"), None, Some(b"world"), None];
+        let a = BinaryArray::from(data);
+        let b = BooleanArray::from(vec![true, false, false, true]);
+        let c = filter(&a, &b).unwrap();
+        let d = c.as_ref().as_any().downcast_ref::<BinaryArray>().unwrap();
+        assert_eq!(2, d.len());
+        assert_eq!(b"hello", d.value(0));
+        assert_eq!(true, d.is_null(1));
     }
 
     #[test]

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -691,6 +691,7 @@ mod tests {
         let d = c.as_ref().as_any().downcast_ref::<StringArray>().unwrap();
         assert_eq!(2, d.len());
         assert_eq!("hello", d.value(0));
+        assert_eq!(false, d.is_null(0));
         assert_eq!(true, d.is_null(1));
     }
 
@@ -703,6 +704,7 @@ mod tests {
         let d = c.as_ref().as_any().downcast_ref::<BinaryArray>().unwrap();
         assert_eq!(2, d.len());
         assert_eq!(b"hello", d.value(0));
+        assert_eq!(false, d.is_null(0));
         assert_eq!(true, d.is_null(1));
     }
 


### PR DESCRIPTION
When I use the `filter` kernel with Null strings, any input column that was Null turns into an empty string after filtering.

```
"foo"
"bar"
NULL
```
And the filter 
```
true
true
true
```

Will result in 
```
"foo"
"bar"
""
```

Rather than
```
"foo"
"bar"
NULL
```

It appears to work fine for primitive arrays (I'll comment inline).  I also added `BinaryArray::from_opt_vec` following the model of `PrimativeArray` and `StringArray` mostly so I could write a test. 