### PR TITLE
ARROW-9753: [Rust] [DataFusion] Replaced Arc<Mutex<>> by Box<>

### DIFF
--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -83,7 +83,6 @@ mod tests {
         let projection = None;
         let exec = table.scan(&projection, 2)?;
         let it = exec.execute(0).await?;
-        let mut it = it.lock().unwrap();
 
         let count = it
             .into_iter()
@@ -304,8 +303,7 @@ mod tests {
         projection: &Option<Vec<usize>>,
     ) -> Result<RecordBatch> {
         let exec = table.scan(projection, 1024)?;
-        let it = exec.execute(0).await?;
-        let mut it = it.lock().expect("failed to lock mutex");
+        let mut it = exec.execute(0).await?;
         it.next()
             .expect("should have received at least one batch")
             .map_err(|e| e.into())

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -360,10 +360,9 @@ impl ExecutionContext {
             let plan = plan.clone();
             let filename = format!("part-{}.csv", i);
             let path = Path::new(&path).join(&filename);
-            let file = fs::File::create(path).unwrap();
+            let file = fs::File::create(path)?;
             let mut writer = csv::Writer::new(file);
-            let reader = plan.execute(i).await.unwrap();
-            let mut reader = reader.lock().unwrap();
+            let reader = plan.execute(i).await?;
 
             reader
                 .into_iter()

--- a/rust/datafusion/src/physical_plan/common.rs
+++ b/rust/datafusion/src/physical_plan/common.rs
@@ -19,8 +19,9 @@
 
 use std::fs;
 use std::fs::metadata;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
+use super::Source;
 use crate::error::{ExecutionError, Result};
 
 use array::{
@@ -74,12 +75,8 @@ impl RecordBatchReader for RecordBatchIterator {
 }
 
 /// Create a vector of record batches from an iterator
-pub fn collect(
-    it: Arc<Mutex<dyn RecordBatchReader + Send + Sync>>,
-) -> Result<Vec<RecordBatch>> {
-    it.lock()
-        .unwrap()
-        .into_iter()
+pub fn collect(it: Source) -> Result<Vec<RecordBatch>> {
+    it.into_iter()
         .collect::<ArrowResult<Vec<_>>>()
         .map_err(|e| ExecutionError::from(e))
 }

--- a/rust/datafusion/src/physical_plan/memory.rs
+++ b/rust/datafusion/src/physical_plan/memory.rs
@@ -18,7 +18,7 @@
 //! Execution plan for reading in-memory batches of data
 
 use std::any::Any;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::error::{ExecutionError, Result};
 use crate::physical_plan::{ExecutionPlan, Partitioning};
@@ -26,6 +26,7 @@ use arrow::datatypes::SchemaRef;
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::{RecordBatch, RecordBatchReader};
 
+use super::Source;
 use async_trait::async_trait;
 
 /// Execution plan for reading in-memory batches of data
@@ -71,15 +72,12 @@ impl ExecutionPlan for MemoryExec {
         )))
     }
 
-    async fn execute(
-        &self,
-        partition: usize,
-    ) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
-        Ok(Arc::new(Mutex::new(MemoryIterator::try_new(
+    async fn execute(&self, partition: usize) -> Result<Source> {
+        Ok(Box::new(MemoryIterator::try_new(
             self.partitions[partition].clone(),
             self.schema.clone(),
             self.projection.clone(),
-        )?)))
+        )?))
     }
 }
 

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -21,7 +21,7 @@ use std::any::Any;
 use std::cell::RefCell;
 use std::fmt::{Debug, Display};
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::execution::context::ExecutionContextState;
 use crate::logical_plan::LogicalPlan;
@@ -31,6 +31,7 @@ use arrow::record_batch::{RecordBatch, RecordBatchReader};
 use arrow::{array::ArrayRef, datatypes::Field};
 
 use async_trait::async_trait;
+type Source = Box<dyn RecordBatchReader + Send>;
 
 /// Physical query planner that converts a `LogicalPlan` to an
 /// `ExecutionPlan` suitable for execution.
@@ -67,11 +68,9 @@ pub trait ExecutionPlan: Debug + Send + Sync {
         &self,
         children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>>;
-    /// Execute one partition and return an iterator over RecordBatch
-    async fn execute(
-        &self,
-        partition: usize,
-    ) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>>;
+
+    /// creates an iterator
+    async fn execute(&self, partition: usize) -> Result<Source>;
 }
 
 /// Partitioning schemes supported by operators.

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -546,16 +546,16 @@ impl ExtensionPlanner for DefaultExtensionPlanner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::logical_plan::{col, lit, sum, LogicalPlanBuilder};
     use crate::physical_plan::{csv::CsvReadOptions, expressions, Partitioning};
-    use crate::{prelude::ExecutionConfig, test::arrow_testdata_path};
-    use arrow::{
-        datatypes::{DataType, Field, SchemaRef},
-        record_batch::RecordBatchReader,
+    use crate::{
+        logical_plan::{col, lit, sum, LogicalPlanBuilder},
+        physical_plan::Source,
     };
+    use crate::{prelude::ExecutionConfig, test::arrow_testdata_path};
+    use arrow::datatypes::{DataType, Field, SchemaRef};
     use async_trait::async_trait;
     use fmt::Debug;
-    use std::{any::Any, collections::HashMap, fmt, sync::Mutex};
+    use std::{any::Any, collections::HashMap, fmt};
 
     fn make_ctx_state() -> ExecutionContextState {
         ExecutionContextState {
@@ -800,11 +800,7 @@ mod tests {
             unimplemented!("NoOpExecutionPlan::with_new_children");
         }
 
-        /// Execute one partition and return an iterator over RecordBatch
-        async fn execute(
-            &self,
-            _partition: usize,
-        ) -> Result<Arc<Mutex<dyn RecordBatchReader + Send + Sync>>> {
+        async fn execute(&self, _partition: usize) -> Result<Source> {
             unimplemented!("NoOpExecutionPlan::execute");
         }
     }


### PR DESCRIPTION
This PR is built on top of #8225 and Replaces `Arc<Mutex<dyn ...>>` by `Box<dyn ...>`.

In the TopK example, I had to move some functions away from the `impl`. This is because `self` cannot be borrowed as mutable and immutable at the same time, and, during iteration, it was being borrowed as mutable (to update the BTree) and as immutable (to access the `input`). There is probably a better way of achieving this e.g. via interior mutability.
