### PR TITLE
ARROW-10148: [Rust] Improved rust/lib.rs that is shown in docs.rs

### DIFF
--- a/rust/arrow/README.md
+++ b/rust/arrow/README.md
@@ -25,75 +25,20 @@ This crate contains a native Rust implementation of the [Arrow columnar format](
 
 ## Developer's guide
 
-Here you can find general information about this crate's content and its organization.
+Refer to [lib.rs](src/lib.rs) for an introduction to this crate and current functionality.
 
-### DataType, Field, Schema and RecordBatch
+### How to run the tests
 
-Every array in Arrow has a data type, that specifies how the data should be layed in memory and casted, and an optional null bitmap, that specifies whether each value is null or not.
-Thus, a central enum of this crate is `arrow::datatypes::DataType`, that contains the set of valid
-DataTypes in the specification. For example, `arrow::datatypes::DataType::Utf8`.
+The tests of this crate depend on two environment variables to be defined.
+Assuming that you are in this crates' current directory:
 
-Many (but not all) data types have an associated Rust native type. The trait that represents 
-this relationship is `arrow::datatypes::ArrowNativeType`, that most native types implement.
-
-`arrow::datatypes::Field` is a struct that contains an arrays' metadata (datatype and whether its values
-can be null), and a name. `arrow::datatypes::Schema` is a vector of fields with optional metadata.
-
-Finally, `arrow::record_batch::RecordBatch` is a struct with a `Schema` and a vector of `Array`s all with the same `len`. A record batch is the highest order struct that this crate currently offers.
-
-### Array
-
-The central trait of this package is `arrow::array::Array`, a dynamically-typed trait that
-can be downcasted to specific implementations, such as `arrow::array::UInt32Array`.
-
-`Array` has `Array::len()`, `Array::data_type()`, and nullability of each of its entries, that can be obtained via `Array::is_null(index)`. To downcast an `Array` to a specific implementation, you can use
-
-```rust
-let specific_array = array.as_any().downcast_ref<UInt32Array>().unwrap();
+```bash
+export PARQUET_TEST_DATA=../../cpp/submodules/parquet-testing/data
+export ARROW_TEST_DATA=../../testing/data
+cargo test
 ```
 
-Once downcasted, it offers two calls to retrieve specific values (and nullability):
-
-```rust
-let is_null_0: bool = specifcic_array.is_null(0)
-let value_at_0: u32 = specifcic_array.value(0)
-```
-
-### Memory and Buffers
-
-You can access the whole buffer of an `Array` via `Array::data()`, which returns an `arrow::data::ArrayData`. This struct holds the array's `DataType`, `arrow::buffer::Buffer`s, and `childs` (which are themselves `ArrayData`).
-
-The central structs that array implementations use to allocate and refer to memory
-aligned according to the specification are the `arrow::buffer::Buffer` and `arrow::buffer::MutableBuffer`.
-These are the lowest abstractions of this crate, and are used throughout the crate to 
-efficiently allocate, write, read and deallocate memory.
-
-This implementation uses a architecture-dependent alignment of sizes that are multiples of 64 bytes.
-
-### Compute
-
-This crate offers many operations (called kernels) to operate on `Array`s, that you can find at `arrow::compute::kernels`.
-
-## Status
-
-The current status is:
-
-- [x] Primitive Arrays
-- [x] List Arrays
-- [x] Struct Arrays
-- [x] CSV Reader
-- [X] CSV Writer
-- [X] JSON Reader
-- [ ] Parquet Reader
-- [ ] Parquet Writer
-- [X] Arrow IPC
-- [ ] Interop tests with other implementations
-
-- operations
-  - string
-    - [x] length
-    - [x] substring
-    - [x] take
+runs all the tests.
 
 ## Examples
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1386,7 +1386,7 @@ impl From<LargeListArray> for LargeBinaryArray {
     }
 }
 
-/// Generic struct for [Large]StringArray
+/// Generic struct for \[Large\]StringArray
 pub struct GenericStringArray<OffsetSize> {
     data: ArrayDataRef,
     value_offsets: RawPtrBox<OffsetSize>,

--- a/rust/arrow/src/compute/kernels/substring.rs
+++ b/rust/arrow/src/compute/kernels/substring.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines kernel to extract a substring of a [Large]StringArray
+//! Defines kernel to extract a substring of a \[Large\]StringArray
 
 use crate::{array::*, buffer::Buffer, datatypes::ToByteSlice};
 use crate::{
@@ -92,7 +92,7 @@ fn substring1<OffsetSize: OffsetSizeTrait>(
 
 /// Returns an ArrayRef with a substring starting from `start` and with optional length `length` of each of the elements in `array`.
 /// `start` can be negative, in which case the start counts from the end of the string.
-/// this function errors when the passed array is not a [Large]String array.
+/// this function errors when the passed array is not a \[Large\]String array.
 pub fn substring(array: &Array, start: i64, length: &Option<u64>) -> Result<ArrayRef> {
     match array.data_type() {
         DataType::LargeUtf8 => substring1(

--- a/rust/arrow/src/ipc/gen/Message.rs
+++ b/rust/arrow/src/ipc/gen/Message.rs
@@ -228,7 +228,7 @@ pub struct MessageHeaderUnionTableOffset {}
 /// Metadata about a field at some level of a nested type tree (but not
 /// its children).
 ///
-/// For example, a List<Int16> with values [[1, 2, 3], null, [4], [5, 6], null]
+/// For example, a List<Int16> with values `[[1, 2, 3], null, [4], [5, 6], null]`
 /// would have {length: 5, null_count: 2} for its List node, and {length: 6,
 /// null_count: 0} for its Int16 node, as separate FieldNode structs
 // struct FieldNode, aligned to 8

--- a/rust/arrow/src/ipc/gen/Schema.rs
+++ b/rust/arrow/src/ipc/gen/Schema.rs
@@ -1097,11 +1097,11 @@ pub enum MapOffset {}
 /// not enforced.
 ///
 /// Map
-/// 
+///
 ///   - `child[0] entries: Struct`
 ///     - `child[0] key: K`
 ///     - `child[1] value: V`
-/// 
+///
 /// Neither the "entries" field nor the "key" field may be nullable.
 ///
 /// The metadata is structured so that Arrow systems without special handling

--- a/rust/arrow/src/ipc/gen/Schema.rs
+++ b/rust/arrow/src/ipc/gen/Schema.rs
@@ -1097,10 +1097,11 @@ pub enum MapOffset {}
 /// not enforced.
 ///
 /// Map
-///   - child[0] entries: Struct
-///     - child[0] key: K
-///     - child[1] value: V
-///
+/// 
+///   - `child[0] entries: Struct`
+///     - `child[0] key: K`
+///     - `child[1] value: V`
+/// 
 /// Neither the "entries" field nor the "key" field may be nullable.
 ///
 /// The metadata is structured so that Arrow systems without special handling
@@ -1186,7 +1187,7 @@ pub enum UnionOffset {}
 /// A union is a complex type with children in Field
 /// By default ids in the type vector refer to the offsets in the children
 /// optionally typeIds provides an indirection between the child offset and the type id
-/// for each child typeIds[offset] is the id used in the type vector
+/// for each child `typeIds[offset]` is the id used in the type vector
 pub struct Union<'a> {
     pub _tab: flatbuffers::Table<'a>,
 }

--- a/rust/arrow/src/ipc/gen/SparseTensor.rs
+++ b/rust/arrow/src/ipc/gen/SparseTensor.rs
@@ -389,7 +389,7 @@ impl<'a> SparseMatrixIndexCSX<'a> {
     }
     /// indptrBuffer stores the location and size of indptr array that
     /// represents the range of the rows.
-    /// The i-th row spans from indptr[i] to indptr[i+1] in the data.
+    /// The i-th row spans from `indptr[i]` to `indptr[i+1]` in the data.
     /// The length of this array is 1 + (the number of rows), and the type
     /// of index value is long.
     ///
@@ -581,7 +581,7 @@ impl<'a> SparseTensorIndexCSF<'a> {
     pub const VT_AXISORDER: flatbuffers::VOffsetT = 12;
 
     /// CSF is a generalization of compressed sparse row (CSR) index.
-    /// See [smith2017knl]: http://shaden.io/pub-files/smith2017knl.pdf
+    /// See [smith2017knl](http://shaden.io/pub-files/smith2017knl.pdf)
     ///
     /// CSF index recursively compresses each dimension of a tensor into a set
     /// of prefix trees. Each path from a root to leaf forms one tensor
@@ -621,9 +621,9 @@ impl<'a> SparseTensorIndexCSF<'a> {
     }
     /// indptrBuffers stores the sparsity structure.
     /// Each two consecutive dimensions in a tensor correspond to a buffer in
-    /// indptrBuffers. A pair of consecutive values at indptrBuffers[dim][i]
-    /// and indptrBuffers[dim][i + 1] signify a range of nodes in
-    /// indicesBuffers[dim + 1] who are children of indicesBuffers[dim][i] node.
+    /// indptrBuffers. A pair of consecutive values at `indptrBuffers[dim][i]`
+    /// and `indptrBuffers[dim][i + 1]` signify a range of nodes in
+    /// `indicesBuffers[dim + 1]` who are children of `indicesBuffers[dim][i]` node.
     ///
     /// For example, the indptrBuffers for the above X is:
     ///

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -29,7 +29,7 @@
 //!
 //! The central trait of this package is the dynamically-typed [`Array`](array::Array) that
 //! represents a fixed-sized, immutable, Send + Sync Array of nullable elements. An example of such an array is [`UInt32Array`](array::UInt32Array).
-//! One way to think about an arrow [`Array`](array::Array) isa `Arc<[Option<T>; len]>` where T can be anything ranging from an integer to a string, or even
+//! One way to think about an arrow [`Array`](array::Array) is a `Arc<[Option<T>; len]>` where T can be anything ranging from an integer to a string, or even
 //! another [`Array`](array::Array).
 //!
 //! [`Arrays`](array::Array) have [`len()`](array::Array::len), [`data_type()`](array::Array::data_type), and the nullability of each of its elements,
@@ -79,12 +79,12 @@
 //!
 //! ## Field, Schema and RecordBatch
 //!
-//! [`Field`](datatypes::Field) is a struct that contains an arrays' metadata (datatype and whether its values
-//! can be null), and a name. [`Schema`](datatypes::Schema) is a vector of fields with optional metadata, and together with
+//! [`Field`](datatypes::Field) is a struct that contains an array's metadata (datatype and whether its values
+//! can be null), and a name. [`Schema`](datatypes::Schema) is a vector of fields with optional metadata. 
 //! Together, they form the basis of a schematic representation of a group of [`Arrays`](array::Array).
 //!
 //! In fact, [`RecordBatch`](record_batch::RecordBatch) is a struct with a [`Schema`](datatypes::Schema) and a vector of
-//! [`Array`](array::Array)s, all with the same `len`. A record batch is the highest order struct that this crate currently offersm
+//! [`Array`](array::Array)s, all with the same `len`. A record batch is the highest order struct that this crate currently offers
 //! and is broadly used to represent a table where each column in an `Array`.
 //!
 //! ## Compute
@@ -99,6 +99,8 @@
 //! * All arrow primitive types, such as [`Int32Array`](array::UInt8Array), [`BooleanArray`](array::BooleanArray) and [`Float64Array`](array::Float64Array).
 //! * All arrow variable length types, such as [`StringArray`](array::StringArray) and [`BinaryArray`](array::BinaryArray)
 //! * All composite types such as [`StructArray`](array::StructArray) and [`ListArray`](array::ListArray)
+//! * Dictionary types  [`DictionaryArray`](array::DictionaryArray) 
+
 //!
 //! This crate also implements many common vertical operations:
 //! * all mathematical binary operators, such as [`subtract`](compute::kernels::arithmetic::subtract)

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -27,13 +27,13 @@
 //!
 //! ## Array
 //!
-//! The central trait of this package is the dynamically-typed trait [`Array`](array::Array) that
-//! can be downcasted to specific implementations, such as [`UInt32Array`](array::UInt32Array).
+//! The central trait of this package is the dynamically-typed [`Array`](array::Array) that
+//! represents a fixed-sized, immutable, Send + Sync Array of nullable elements. An example of such an array is [`UInt32Array`](array::UInt32Array).
+//! One way to think about an arrow [`Array`](array::Array) isa `Arc<[Option<T>; len]>` where T can be anything ranging from an integer to a string, or even
+//! another [`Array`](array::Array).
 //!
-//! Every specific array implementation in this crate is immutable and thread safe (Sync + Send).
-//!
-//! [`Array`](array::Array) has [`len()`](array::Array::len), [`data_type()`](array::Array::data_type), and nullability of each of its entries,
-//! that can be obtained via [`is_null(index)`](array::Array::is_null). To downcast an [`Array`](array::Array) to a specific implementation, you can use
+//! [`Arrays`](array::Array) have [`len()`](array::Array::len), [`data_type()`](array::Array::data_type), and the nullability of each of its elements,
+//! can be obtained via [`is_null(index)`](array::Array::is_null). To downcast an [`Array`](array::Array) to a specific implementation, you can use
 //!
 //! ```rust
 //! use arrow::array::{Array, PrimitiveArrayOps, UInt32Array};
@@ -72,8 +72,8 @@
 //!
 //! Data in [`Array`](array::Array) is stored in [`ArrayData`](array::data::ArrayData), that in turn
 //! is a collection of other [`ArrayData`](array::data::ArrayData) and [`Buffers`](buffer::Buffer).
-//! [`Buffers`](buffer::Buffer) is the central that array implementations use to allocate and point to memory.
-//! The [`MutableBuffer`](buffer::MutableBuffer) is the mutable counter-part of
+//! [`Buffers`](buffer::Buffer) is the central struct that array implementations use keep allocated memory and pointers.
+//! The [`MutableBuffer`](buffer::MutableBuffer) is the mutable counter-part of[`Buffer`](buffer::Buffer).
 //! These are the lowest abstractions of this crate, and are used throughout the crate to
 //! efficiently allocate, write, read and deallocate memory.
 //!
@@ -81,14 +81,16 @@
 //!
 //! [`Field`](datatypes::Field) is a struct that contains an arrays' metadata (datatype and whether its values
 //! can be null), and a name. [`Schema`](datatypes::Schema) is a vector of fields with optional metadata, and together with
+//! Together, they form the basis of a schematic representation of a group of [`Arrays`](array::Array).
 //!
-//! Finally, [`RecordBatch`](record_batch::RecordBatch) is a struct with a [`Schema`](datatypes::Schema) and a vector of
-//! [`Array`](array::Array)s, all with the same `len`. A record batch is the highest order struct that this crate currently offers.
+//! In fact, [`RecordBatch`](record_batch::RecordBatch) is a struct with a [`Schema`](datatypes::Schema) and a vector of
+//! [`Array`](array::Array)s, all with the same `len`. A record batch is the highest order struct that this crate currently offersm
+//! and is broadly used to represent a table where each column in an `Array`.
 //!
 //! ## Compute
 //!
 //! This crate offers many operations (called kernels) to operate on `Array`s, that you can find at [compute::kernels].
-//! We have both vertial and horizontal operations, and some of them have an SIMD implementation.
+//! It has both vertial and horizontal operations, and some of them have an SIMD implementation.
 //!
 //! ## Status
 //!
@@ -107,12 +109,13 @@
 //! * [`sort`](compute::kernels::sort::sort)
 //! * some string operators such as [`substring`](compute::kernels::substring::substring) and [`length`](compute::kernels::length::length)
 //!
-//! as well as some horizontal operations such as
+//! as well as some horizontal operations, such as
 //!
 //! * [`min`](compute::kernels::aggregate::min) and [`max`](compute::kernels::aggregate::max)
 //! * [`sum`](compute::kernels::aggregate::sum)
 //!
 //! Finally, this crate implements some readers and writers to different formats:
+//!
 //! * json: [reader](json::reader::Reader)
 //! * csv: [reader](csv::reader::Reader) and [writer](csv::writer::Writer)
 //! * ipc: [reader](ipc::reader::StreamReader) and [writer](ipc::writer::FileWriter)

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -80,7 +80,7 @@
 //! ## Field, Schema and RecordBatch
 //!
 //! [`Field`](datatypes::Field) is a struct that contains an array's metadata (datatype and whether its values
-//! can be null), and a name. [`Schema`](datatypes::Schema) is a vector of fields with optional metadata. 
+//! can be null), and a name. [`Schema`](datatypes::Schema) is a vector of fields with optional metadata.
 //! Together, they form the basis of a schematic representation of a group of [`Arrays`](array::Array).
 //!
 //! In fact, [`RecordBatch`](record_batch::RecordBatch) is a struct with a [`Schema`](datatypes::Schema) and a vector of
@@ -99,7 +99,7 @@
 //! * All arrow primitive types, such as [`Int32Array`](array::UInt8Array), [`BooleanArray`](array::BooleanArray) and [`Float64Array`](array::Float64Array).
 //! * All arrow variable length types, such as [`StringArray`](array::StringArray) and [`BinaryArray`](array::BinaryArray)
 //! * All composite types such as [`StructArray`](array::StructArray) and [`ListArray`](array::ListArray)
-//! * Dictionary types  [`DictionaryArray`](array::DictionaryArray) 
+//! * Dictionary types  [`DictionaryArray`](array::DictionaryArray)
 
 //!
 //! This crate also implements many common vertical operations:

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -57,7 +57,7 @@
 //! assert_eq!(array.data_type(), &DataType::UInt32);
 //! ```
 //!
-//! to downcast, use [`as_any()`](array::UInt32Array::as_any):
+//! to downcast, use `as_any()`:
 //!
 //! ```rust
 //! # use std::sync::Arc;

--- a/rust/arrow/src/memory.rs
+++ b/rust/arrow/src/memory.rs
@@ -201,9 +201,9 @@ pub unsafe fn reallocate(ptr: *mut u8, old_size: usize, new_size: usize) -> *mut
 ///
 /// Behavior is undefined if any of the following conditions are violated:
 ///
-/// * `src` must be [valid] for reads of `len * size_of::<T>()` bytes.
+/// * `src` must be valid for reads of `len * size_of::<T>()` bytes.
 ///
-/// * `dst` must be [valid] for writes of `len * size_of::<T>()` bytes.
+/// * `dst` must be valid for writes of `len * size_of::<T>()` bytes.
 ///
 /// * Both `src` and `dst` must be properly aligned.
 ///


### PR DESCRIPTION
This is a revamp of the landing page of Arrow's crate in docs.rs.

* Moved most documentation from README to `src/lib.rs`
* expanded documentation with implemented functionality, including links to each part in the project
* added a minimal example demonstrating basic functionality

How it looks like:

<img width="1346" alt="Screenshot 2020-09-30 at 21 27 10" src="https://user-images.githubusercontent.com/2772607/94730598-c19efd80-0363-11eb-958a-cd1d4d210e1d.png">

[current version](https://docs.rs/arrow/1.0.1/arrow/) for comparison

I moved docs from the `README` to this page, so that we do not have to maintain it in two places, and added a link in the README to the `src/lib.rc` to refer for details.
