### PR TITLE
ARROW-9941: [Python] Better string representation for extension types

### DIFF
--- a/cpp/src/arrow/python/extension_type.cc
+++ b/cpp/src/arrow/python/extension_type.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <memory>
+#include <sstream>
 #include <utility>
 
 #include "arrow/python/extension_type.h"
@@ -70,6 +71,16 @@ PyObject* DeserializeExtInstance(PyObject* type_class,
 }  // namespace
 
 static const char* kExtensionName = "arrow.py_extension_type";
+
+std::string PyExtensionType::ToString() const {
+  PyAcquireGIL lock;
+
+  std::stringstream ss;
+  OwnedRef instance(GetInstance());
+  ss << "extension<" << this->extension_name() << "<" << Py_TYPE(instance.obj())->tp_name
+     << ">>";
+  return ss.str();
+}
 
 PyExtensionType::PyExtensionType(std::shared_ptr<DataType> storage_type, PyObject* typ,
                                  PyObject* inst)

--- a/cpp/src/arrow/python/extension_type.h
+++ b/cpp/src/arrow/python/extension_type.h
@@ -33,6 +33,8 @@ class ARROW_PYTHON_EXPORT PyExtensionType : public ExtensionType {
   // Implement extensionType API
   std::string extension_name() const override { return extension_name_; }
 
+  std::string ToString() const override;
+
   bool ExtensionEquals(const ExtensionType& other) const override;
 
   std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override;

--- a/docs/source/developers/python.rst
+++ b/docs/source/developers/python.rst
@@ -34,6 +34,11 @@ We follow a similar PEP8-like coding style to the `pandas project
 
 .. code-block:: shell
 
+   pip install -e arrow/dev/archery
+   pip install -r arrow/dev/archery/requirements-lint.txt
+
+.. code-block:: shell
+
    archery lint --python
 
 Some of the issues can be automatically fixed by passing the ``--fix`` option:

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -95,6 +95,18 @@ def test_ext_type_basics():
     assert ty.extension_name == "arrow.py_extension_type"
 
 
+def test_ext_type_str():
+    ty = IntegerType()
+    expected = "extension<arrow.py_extension_type<IntegerType>>"
+    assert str(ty) == expected
+    assert pa.DataType.__str__(ty) == expected
+
+
+def test_ext_type_repr():
+    ty = IntegerType()
+    assert repr(ty) == "IntegerType(DataType(int64))"
+
+
 def test_ext_type__lifetime():
     ty = UuidType()
     wr = weakref.ref(ty)

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -697,6 +697,10 @@ cdef class ExtensionType(BaseExtensionType):
         else:
             return NotImplemented
 
+    def __repr__(self):
+        fmt = '{0.__class__.__name__}({1})'
+        return fmt.format(self, repr(self.storage_type))
+
     def __arrow_ext_serialize__(self):
         """
         Serialized representation of metadata to reconstruct the type object.


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/ARROW-9941

Before:

```
>>> ty
IntegerType(extension<arrow.py_extension_type>)
>>> str(ty)
'extension<arrow.py_extension_type>'
>>> repr(ty)
'IntegerType(extension<arrow.py_extension_type>)'
>>> pa.DataType.__str__(ty)
'extension<arrow.py_extension_type>'
```

After:

```
>>> ty
IntegerType(DataType(int64))
>>> str(ty)
'extension<arrow.py_extension_type<IntegerType>>'
>>> repr(ty)
'IntegerType(DataType(int64))'
>>> pa.DataType.__str__(ty)
'extension<arrow.py_extension_type<IntegerType>>'
```