### PR TITLE
ARROW-10147: [Python] Pandas metadata fails if index name not JSON-serializable

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -466,11 +466,20 @@ def _get_index_level(df, name):
     return df.index.get_level_values(key)
 
 
+def _level_name(name):
+    # preserve type when default serializable, otherwise str it
+    try:
+        json.dumps(name)
+        return name
+    except TypeError:
+        return str(name)
+
+
 def _get_range_index_descriptor(level):
     # public start/stop/step attributes added in pandas 0.25.0
     return {
         'kind': 'range',
-        'name': level.name,
+        'name': _level_name(level.name),
         'start': _pandas_api.get_rangeindex_attribute(level, 'start'),
         'stop': _pandas_api.get_rangeindex_attribute(level, 'stop'),
         'step': _pandas_api.get_rangeindex_attribute(level, 'step')

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4045,6 +4045,20 @@ def test_metadata_compat_missing_field_name():
     tm.assert_frame_equal(result, expected, check_like=True)
 
 
+def test_metadata_index_name_not_json_serializable():
+    name = np.int64(6)  # not json serializable by default
+    table = pa.table(pd.DataFrame(index=pd.RangeIndex(0, 4, name=name)))
+    metadata = table.schema.pandas_metadata
+    assert metadata['index_columns'][0]['name'] == '6'
+
+
+def test_metadata_index_name_is_json_serializable():
+    name = 6  # json serializable by default
+    table = pa.table(pd.DataFrame(index=pd.RangeIndex(0, 4, name=name)))
+    metadata = table.schema.pandas_metadata
+    assert metadata['index_columns'][0]['name'] == 6
+
+
 def make_df_with_timestamps():
     # Some of the milliseconds timestamps deliberately don't fit in the range
     # that is possible with nanosecond timestamps.


### PR DESCRIPTION
See: https://issues.apache.org/jira/browse/ARROW-10147

Before:

```
>>> import numpy as np
>>> import pyarrow as pa
>>> import pandas as pd
>>> idx = pd.RangeIndex(0, 4, name=np.int64(6))
>>> df = pd.DataFrame(index=idx)
>>> pa.table(df)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyarrow/table.pxi", line 2042, in pyarrow.lib.table
    return Table.from_pandas(data, schema=schema, nthreads=nthreads)
  File "pyarrow/table.pxi", line 1394, in pyarrow.lib.Table.from_pandas
    arrays, schema = dataframe_to_arrays(
  File "/Users/diana/workspace/arrow/python/pyarrow/pandas_compat.py", line 604, in dataframe_to_arrays
    pandas_metadata = construct_metadata(df, column_names, index_columns,
  File "/Users/diana/workspace/arrow/python/pyarrow/pandas_compat.py", line 237, in construct_metadata
    b'pandas': json.dumps({
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/Library/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type int64 is not JSON serializable
```

After:

```
>>> import numpy as np
>>> import pyarrow as pa
>>> import pandas as pd
>>> idx = pd.RangeIndex(0, 4, name=np.int64(6))
>>> df = pd.DataFrame(index=idx)
>>> table = pa.table(df)
>>> metadata = table.schema.pandas_metadata
>>> import pprint
>>> pprint.pprint(metadata)
{'column_indexes': [{'field_name': None,
                     'metadata': None,
                     'name': None,
                     'numpy_type': 'object',
                     'pandas_type': 'empty'}],
 'columns': [],
 'creator': {'library': 'pyarrow',
             'version': '2.0.0.dev381+g06830c954.d20201001'},
 'index_columns': [{'kind': 'range',
                    'name': '6',
                    'start': 0,
                    'step': 1,
                    'stop': 4}],
 'pandas_version': '1.1.2'}
```