### PR TITLE
ARROW-10150: [C++] Fix crashes on invalid Parquet file

### DIFF
--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -693,10 +693,12 @@ Status ApplyOriginalStorageMetadata(const Field& origin_field, SchemaField* infe
   auto origin_type = origin_field.type();
   auto inferred_type = inferred->field->type();
 
-  if (inferred_type->id() == ::arrow::Type::TIMESTAMP) {
+  if (origin_type->id() == ::arrow::Type::TIMESTAMP &&
+      inferred_type->id() == ::arrow::Type::TIMESTAMP) {
     // Restore time zone, if any
-    const auto& ts_type = static_cast<const ::arrow::TimestampType&>(*inferred_type);
-    const auto& ts_origin_type = static_cast<const ::arrow::TimestampType&>(*origin_type);
+    const auto& ts_type = checked_cast<const ::arrow::TimestampType&>(*inferred_type);
+    const auto& ts_origin_type =
+        checked_cast<const ::arrow::TimestampType&>(*origin_type);
 
     // If the unit is the same and the data is tz-aware, then set the original
     // time zone, since Parquet has no native storage for timezones
@@ -710,7 +712,7 @@ Status ApplyOriginalStorageMetadata(const Field& origin_field, SchemaField* infe
       inferred_type->id() != ::arrow::Type::DICTIONARY &&
       IsDictionaryReadSupported(*inferred_type)) {
     const auto& dict_origin_type =
-        static_cast<const ::arrow::DictionaryType&>(*origin_type);
+        checked_cast<const ::arrow::DictionaryType&>(*origin_type);
     inferred->field = inferred->field->WithType(
         ::arrow::dictionary(::arrow::int32(), inferred_type, dict_origin_type.ordered()));
   }

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -463,6 +463,10 @@ std::shared_ptr<Buffer> SerializedPageReader::DecompressIfNeeded(
   if (decompressor_ == nullptr) {
     return page_buffer;
   }
+  if (compressed_len < levels_byte_len || uncompressed_len < levels_byte_len) {
+    throw ParquetException("Invalid page header");
+  }
+
   // Grow the uncompressed buffer if we need to.
   if (uncompressed_len > static_cast<int>(decompression_buffer_->size())) {
     PARQUET_THROW_NOT_OK(decompression_buffer_->Resize(uncompressed_len, false));


### PR DESCRIPTION
Found by OSS-Fuzz. Should fix the following issues:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26064
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26065
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26067
