### PR TITLE
ARROW-9520: [Rust] [DataFusion] Add support for aliased aggregate exprs

### DIFF
--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -481,12 +481,7 @@ impl DefaultPhysicalPlanner {
                     .iter()
                     .map(|e| self.create_physical_expr(e, input_schema, ctx_state))
                     .collect::<Result<Vec<_>>>()?;
-                aggregates::create_aggregate_expr(
-                    fun,
-                    &args,
-                    input_schema,
-                    name,
-                )
+                aggregates::create_aggregate_expr(fun, &args, input_schema, name)
             }
             Expr::AggregateUDF { fun, args, .. } => {
                 let args = args
@@ -494,12 +489,7 @@ impl DefaultPhysicalPlanner {
                     .map(|e| self.create_physical_expr(e, input_schema, ctx_state))
                     .collect::<Result<Vec<_>>>()?;
 
-                udaf::create_aggregate_expr(
-                    fun,
-                    &args,
-                    input_schema,
-                    name,
-                )
+                udaf::create_aggregate_expr(fun, &args, input_schema, name)
             }
             other => Err(ExecutionError::General(format!(
                 "Invalid aggregate expression '{:?}'",

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -591,6 +591,7 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
 fn is_aggregate_expr(e: &Expr) -> bool {
     match e {
         Expr::AggregateFunction { .. } | Expr::AggregateUDF { .. } => true,
+        Expr::Alias(expr, _) => is_aggregate_expr(expr), 
         _ => false,
     }
 }

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -591,7 +591,7 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
 fn is_aggregate_expr(e: &Expr) -> bool {
     match e {
         Expr::AggregateFunction { .. } | Expr::AggregateUDF { .. } => true,
-        Expr::Alias(expr, _) => is_aggregate_expr(expr), 
+        Expr::Alias(expr, _) => is_aggregate_expr(expr),
         _ => false,
     }
 }

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -401,6 +401,18 @@ async fn csv_query_group_by_int_count() -> Result<()> {
 }
 
 #[tokio::test]
+async fn csv_query_group_with_aliased_aggregate() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv(&mut ctx)?;
+    let sql = "SELECT c1, count(c12) AS count FROM aggregate_test_100 GROUP BY c1";
+    let mut actual = execute(&mut ctx, sql).await;
+    actual.sort();
+    let expected = "\"a\"\t21\n\"b\"\t19\n\"c\"\t21\n\"d\"\t18\n\"e\"\t21".to_string();
+    assert_eq!(expected, actual.join("\n"));
+    Ok(())
+}
+
+#[tokio::test]
 async fn csv_query_group_by_string_min_max() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     register_aggregate_csv(&mut ctx)?;


### PR DESCRIPTION
First attempt at contributing to Arrow/DataFusion, just fixing this small issue around aliased aggregate columns. Please let me know if this isn't an ideal implementation!