### PR TITLE
ARROW-10169: [Rust] Pretty print null PrimitiveTypes as empty strings

### DIFF
--- a/rust/arrow/src/util/pretty.rs
+++ b/rust/arrow/src/util/pretty.rs
@@ -86,12 +86,7 @@ macro_rules! make_string {
 /// Get the value at the given row in an array as a string
 fn array_value_to_string(column: array::ArrayRef, row: usize) -> Result<String> {
     match column.data_type() {
-        DataType::Utf8 => Ok(column
-            .as_any()
-            .downcast_ref::<array::StringArray>()
-            .unwrap()
-            .value(row)
-            .to_string()),
+        DataType::Utf8 => make_string!(array::StringArray, column, row),
         DataType::Boolean => make_string!(array::BooleanArray, column, row),
         DataType::Int16 => make_string!(array::Int16Array, column, row),
         DataType::Int32 => make_string!(array::Int32Array, column, row),

--- a/rust/arrow/src/util/pretty.rs
+++ b/rust/arrow/src/util/pretty.rs
@@ -18,7 +18,7 @@
 //! Utilities for printing record batches
 
 use crate::array;
-use crate::array::PrimitiveArrayOps;
+use crate::array::{Array, PrimitiveArrayOps};
 use crate::datatypes::{DataType, TimeUnit};
 use crate::record_batch::RecordBatch;
 


### PR DESCRIPTION
Null values should be printed as "" when pretty printing. Prior to this PR, , null values in primitive arrays  were rendered as the type's default value as pointed out by @jhorstmann  on https://github.com/apache/arrow/pull/8331#issuecomment-702964608
