### PR TITLE
ARROW-10167: [Rust] [DataFusion] Support DictionaryArray in sql.rs tests, by using standard pretty printer

### DIFF
--- a/rust/arrow/src/util/pretty.rs
+++ b/rust/arrow/src/util/pretty.rs
@@ -92,6 +92,7 @@ pub fn array_value_to_string(column: &array::ArrayRef, row: usize) -> Result<Str
     match column.data_type() {
         DataType::Utf8 => make_string!(array::StringArray, column, row),
         DataType::Boolean => make_string!(array::BooleanArray, column, row),
+        DataType::Int8 => make_string!(array::Int8Array, column, row),
         DataType::Int16 => make_string!(array::Int16Array, column, row),
         DataType::Int32 => make_string!(array::Int32Array, column, row),
         DataType::Int64 => make_string!(array::Int64Array, column, row),


### PR DESCRIPTION
This PR removes (most of) the special case pretty printing code in DataFusion's sql integration test, `sql.rs` in favor of the standard pretty printer in `arrow::utils::pretty` and in the process adds support for DictionaryArray printing as well as standardizing how tests are run and output is compared.

I am working on adding support for `DictionaryArray` in DataFusion (and thus want to add tests to sql.rs). This specific PR's changes are larger than strictly necessary, but I felt it made it easier to write new tests in sql.rs. However,  if people prefer, I could instead add a special case for `DictionaryArray` in `array_str` and accomplish my goal with a much smaller PR

Note: I found that using `Vec<Vec<String>>` to encode expected results rather than a `String` retains the nice property that differences to expected output are shown reasonably in the test output. For example:

```
---- csv_query_cast_literal stdout ----
thread 'csv_query_cast_literal' panicked at 'assertion failed: `(left == right)`
  left: `[["0.9294097332465232", "1.0"], ["0.3114712539863804", "1.0"]]`,
 right: `[["0.9294097332465232", "1"], ["0.3114712539863804", "1"]]`', datafusion/tests/sql.rs:502:5
```

