### PR TITLE
ARROW-10171: [Rust] [DataFusion] Added ExecutionContext::From<ExecutionContextState>

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -114,11 +114,6 @@ impl ExecutionContext {
         ctx
     }
 
-    /// Create a context from existing context state
-    pub(crate) fn from(state: ExecutionContextState) -> Self {
-        Self { state }
-    }
-
     /// Get the configuration of this execution context
     pub fn config(&self) -> &ExecutionConfig {
         &self.state.config
@@ -376,6 +371,12 @@ impl ExecutionContext {
     /// get the registry, that allows to construct logical expressions of UDFs
     pub fn registry(&self) -> &dyn FunctionRegistry {
         &self.state
+    }
+}
+
+impl From<ExecutionContextState> for ExecutionContext {
+    fn from(state: ExecutionContextState) -> Self {
+        ExecutionContext { state }
     }
 }
 


### PR DESCRIPTION
This makes this initialization public, which is natural as `ExecutionContext` only attribute is `ExecutionContextState`.