### PR TITLE
ARROW-10151: [Python] Add support for MapArray conversion to Pandas

### DIFF
--- a/cpp/src/arrow/python/arrow_to_pandas.cc
+++ b/cpp/src/arrow/python/arrow_to_pandas.cc
@@ -830,11 +830,11 @@ Status ConvertMap(PandasOptions options, const ChunkedArray& data,
   OwnedRef key_value;
   OwnedRef item_value;
   OwnedRefNoGIL owned_numpy_keys;
-  RETURN_NOT_OK(ConvertChunkedArrayToPandas(options, flat_keys, nullptr,
-                                            owned_numpy_keys.ref()));
+  RETURN_NOT_OK(
+      ConvertChunkedArrayToPandas(options, flat_keys, nullptr, owned_numpy_keys.ref()));
   OwnedRefNoGIL owned_numpy_items;
-  RETURN_NOT_OK(ConvertChunkedArrayToPandas(options, flat_items, nullptr,
-                                            owned_numpy_items.ref()));
+  RETURN_NOT_OK(
+      ConvertChunkedArrayToPandas(options, flat_items, nullptr, owned_numpy_items.ref()));
   PyArrayObject* py_keys = reinterpret_cast<PyArrayObject*>(owned_numpy_keys.obj());
   PyArrayObject* py_items = reinterpret_cast<PyArrayObject*>(owned_numpy_items.obj());
 
@@ -882,9 +882,8 @@ Status ConvertMap(PandasOptions options, const ChunkedArray& data,
           RETURN_IF_PYERROR();
         }
 
-        *out_values = list_item.obj();
-        // Release ownership to the resulting array
-        list_item.detach();
+        // Pass ownership to the resulting array
+        *out_values = list_item.detach();
       }
       ++out_values;
     }

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2132,6 +2132,16 @@ class TestConvertListTypes:
         assert len(column_a.chunk(0)) == 2**24 - 1
         assert len(column_a.chunk(1)) == 1
 
+    def test_map_array(self):
+        data = [[(b'a', 1), (b'b', 2)],
+                None,
+                [(b'd', 4), (b'e', 5), (b'f', None)],
+                [(b'g', 7)]]
+
+        arr = pa.array(data, type=pa.map_(pa.binary(), pa.int32()))
+        s = arr.to_pandas()
+        tm.assert_series_equal(s, pd.Series(data), check_names=False)
+
 
 class TestConvertStructTypes:
     """

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2173,6 +2173,19 @@ class TestConvertListTypes:
         actual = arr.to_pandas()
         tm.assert_series_equal(actual, expected, check_names=False)
 
+    def test_map_array_dictionary_encoded(self):
+        offsets = pa.array([0, 3, 5])
+        items = pa.array(['a', 'b', 'c', 'a', 'd']).dictionary_encode()
+        keys = pa.array(list(range(len(items))))
+        arr = pa.MapArray.from_arrays(offsets, keys, items)
+
+        # Dictionary encoded values converted to dense
+        expected = pd.Series(
+            [[(0, 'a'), (1, 'b'), (2, 'c')], [(3, 'a'), (4, 'd')]])
+
+        actual = arr.to_pandas()
+        tm.assert_series_equal(actual, expected, check_names=False)
+
 
 class TestConvertStructTypes:
     """

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2138,6 +2138,8 @@ class TestConvertListTypes:
                 [(b'd', 4), (b'e', 5), (b'f', None)],
                 [(b'g', 7)]]
 
+        data = [[(b'a', 1)], [(b'b', 2)]]
+
         arr = pa.array(data, type=pa.map_(pa.binary(), pa.int32()))
         s = arr.to_pandas()
         tm.assert_series_equal(s, pd.Series(data), check_names=False)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -2132,17 +2132,46 @@ class TestConvertListTypes:
         assert len(column_a.chunk(0)) == 2**24 - 1
         assert len(column_a.chunk(1)) == 1
 
-    def test_map_array(self):
+    def test_map_array_roundtrip(self):
+        data = [[(b'a', 1), (b'b', 2)],
+                [(b'c', 3)],
+                [(b'd', 4), (b'e', 5), (b'f', 6)],
+                [(b'g', 7)]]
+
+        df = pd.DataFrame({"map": data})
+        schema = pa.schema([("map", pa.map_(pa.binary(), pa.int32()))])
+
+        _check_pandas_roundtrip(df, schema=schema)
+
+    def test_map_array_chunked(self):
+        data1 = [[(b'a', 1), (b'b', 2)],
+                 [(b'c', 3)],
+                 [(b'd', 4), (b'e', 5), (b'f', 6)],
+                 [(b'g', 7)]]
+        data2 = [[(k, v * 2) for k, v in row] for row in data1]
+
+        arr1 = pa.array(data1, type=pa.map_(pa.binary(), pa.int32()))
+        arr2 = pa.array(data2, type=pa.map_(pa.binary(), pa.int32()))
+        arr = pa.chunked_array([arr1, arr2])
+
+        expected = pd.Series(data1 + data2)
+        actual = arr.to_pandas()
+        tm.assert_series_equal(actual, expected, check_names=False)
+
+    def test_map_array_with_nulls(self):
         data = [[(b'a', 1), (b'b', 2)],
                 None,
                 [(b'd', 4), (b'e', 5), (b'f', None)],
                 [(b'g', 7)]]
 
-        data = [[(b'a', 1)], [(b'b', 2)]]
+        # None value in item array causes upcast to float
+        expected = [[(k, float(v) if v is not None else None) for k, v in row]
+                    if row is not None else None for row in data]
+        expected = pd.Series(expected)
 
         arr = pa.array(data, type=pa.map_(pa.binary(), pa.int32()))
-        s = arr.to_pandas()
-        tm.assert_series_equal(s, pd.Series(data), check_names=False)
+        actual = arr.to_pandas()
+        tm.assert_series_equal(actual, expected, check_names=False)
 
 
 class TestConvertStructTypes:


### PR DESCRIPTION
This change adds conversion for a `pyarrow.MapArray` to Pandas as a column of lists of tuples, where each tuple is a key/item pair. Unit tests were added for python to verify conversion for Pandas round-trip, chunked arrays and `MapArray` with NULL map and NULL items.