### PR TITLE
ARROW-8735: [Rust] [Parquet] Allow arm 32 to use soft hash implementation

### DIFF
--- a/rust/parquet/src/util/hash_util.rs
+++ b/rust/parquet/src/util/hash_util.rs
@@ -33,7 +33,7 @@ fn hash_(data: &[u8], seed: u32) -> u32 {
         }
     }
 
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
     unsafe {
         murmur_hash2_64a(data, seed as u64) as u32
     }


### PR DESCRIPTION
Minimal change to allow this to be used on arm 32 targets.

A better solution may be to utilise the crc32 instruction ala the optimised intel implementation but this is better than nothing. There should probably be a crate we could just import the hash implementation from rather than having to repeat optimisations everywhere.