### PR TITLE
ARROW-3080: [Python] Unify Arrow to Python object conversion paths

### DIFF
--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -29,4 +29,4 @@ export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 # Enable some checks inside Python itself
 export PYTHONDEVMODE=1
 
-pytest -r s --pyargs pyarrow
+pytest -r s ${PYTEST_ARGS} --pyargs pyarrow

--- a/cpp/src/arrow/python/datetime.cc
+++ b/cpp/src/arrow/python/datetime.cc
@@ -19,7 +19,6 @@
 #include <algorithm>
 #include <chrono>
 #include <iomanip>
-#include <iostream>
 
 #include "arrow/python/common.h"
 #include "arrow/python/helpers.h"

--- a/cpp/src/arrow/python/datetime.h
+++ b/cpp/src/arrow/python/datetime.h
@@ -44,9 +44,9 @@ void InitDatetime();
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyTime_to_us(PyObject* pytime) {
-  return (static_cast<int64_t>(PyDateTime_TIME_GET_HOUR(pytime)) * 3600000000LL +
-          static_cast<int64_t>(PyDateTime_TIME_GET_MINUTE(pytime)) * 60000000LL +
-          static_cast<int64_t>(PyDateTime_TIME_GET_SECOND(pytime)) * 1000000LL +
+  return (PyDateTime_TIME_GET_HOUR(pytime) * 3600000000LL +
+          PyDateTime_TIME_GET_MINUTE(pytime) * 60000000LL +
+          PyDateTime_TIME_GET_SECOND(pytime) * 1000000LL +
           PyDateTime_TIME_GET_MICROSECOND(pytime));
 }
 
@@ -77,38 +77,38 @@ ARROW_PYTHON_EXPORT
 int64_t PyDate_to_days(PyDateTime_Date* pydate);
 
 ARROW_PYTHON_EXPORT
+inline int64_t PyDate_to_s(PyDateTime_Date* pydate) {
+  return PyDate_to_days(pydate) * 86400LL;
+}
+
+ARROW_PYTHON_EXPORT
 inline int64_t PyDate_to_ms(PyDateTime_Date* pydate) {
-  return PyDate_to_days(pydate) * 24 * 3600 * 1000;
+  return PyDate_to_days(pydate) * 86400000LL;
 }
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyDateTime_to_s(PyDateTime_DateTime* pydatetime) {
-  int64_t total_seconds = 0;
-  total_seconds += PyDateTime_DATE_GET_SECOND(pydatetime);
-  total_seconds += PyDateTime_DATE_GET_MINUTE(pydatetime) * 60;
-  total_seconds += PyDateTime_DATE_GET_HOUR(pydatetime) * 3600;
-
-  return total_seconds +
-         (PyDate_to_ms(reinterpret_cast<PyDateTime_Date*>(pydatetime)) / 1000LL);
+  return (PyDate_to_s(reinterpret_cast<PyDateTime_Date*>(pydatetime)) +
+          PyDateTime_DATE_GET_HOUR(pydatetime) * 3600LL +
+          PyDateTime_DATE_GET_MINUTE(pydatetime) * 60LL +
+          PyDateTime_DATE_GET_SECOND(pydatetime));
 }
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyDateTime_to_ms(PyDateTime_DateTime* pydatetime) {
-  int64_t date_ms = PyDateTime_to_s(pydatetime) * 1000;
-  int ms = PyDateTime_DATE_GET_MICROSECOND(pydatetime) / 1000;
-  return date_ms + ms;
+  return (PyDateTime_to_s(pydatetime) * 1000LL +
+          PyDateTime_DATE_GET_MICROSECOND(pydatetime) / 1000);
 }
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyDateTime_to_us(PyDateTime_DateTime* pydatetime) {
-  int64_t ms = PyDateTime_to_s(pydatetime) * 1000;
-  int us = PyDateTime_DATE_GET_MICROSECOND(pydatetime);
-  return ms * 1000 + us;
+  return (PyDateTime_to_s(pydatetime) * 1000000LL +
+          PyDateTime_DATE_GET_MICROSECOND(pydatetime));
 }
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyDateTime_to_ns(PyDateTime_DateTime* pydatetime) {
-  return PyDateTime_to_us(pydatetime) * 1000;
+  return PyDateTime_to_us(pydatetime) * 1000LL;
 }
 
 ARROW_PYTHON_EXPORT
@@ -131,30 +131,25 @@ inline TimePoint TimePoint_from_ns(int64_t val) {
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyDelta_to_s(PyDateTime_Delta* pytimedelta) {
-  int64_t total_seconds = 0;
-  total_seconds += PyDateTime_DELTA_GET_SECONDS(pytimedelta);
-  total_seconds += PyDateTime_DELTA_GET_DAYS(pytimedelta) * 24 * 3600;
-  return total_seconds;
+  return (PyDateTime_DELTA_GET_DAYS(pytimedelta) * 86400LL +
+          PyDateTime_DELTA_GET_SECONDS(pytimedelta));
 }
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyDelta_to_ms(PyDateTime_Delta* pytimedelta) {
-  int64_t total_ms = PyDelta_to_s(pytimedelta) * 1000;
-  total_ms += PyDateTime_DELTA_GET_MICROSECONDS(pytimedelta) / 1000;
-  return total_ms;
+  return (PyDelta_to_s(pytimedelta) * 1000LL +
+          PyDateTime_DELTA_GET_MICROSECONDS(pytimedelta) / 1000);
 }
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyDelta_to_us(PyDateTime_Delta* pytimedelta) {
-  int64_t total_us = 0;
-  total_us += PyDelta_to_s(pytimedelta) * 1000 * 1000;
-  total_us += PyDateTime_DELTA_GET_MICROSECONDS(pytimedelta);
-  return total_us;
+  return (PyDelta_to_s(pytimedelta) * 1000000LL +
+          PyDateTime_DELTA_GET_MICROSECONDS(pytimedelta));
 }
 
 ARROW_PYTHON_EXPORT
 inline int64_t PyDelta_to_ns(PyDateTime_Delta* pytimedelta) {
-  return PyDelta_to_us(pytimedelta) * 1000;
+  return PyDelta_to_us(pytimedelta) * 1000LL;
 }
 
 ARROW_PYTHON_EXPORT

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -289,9 +289,7 @@ void GetPandasStaticSymbols() {
     pandas_NaT = ref.obj();
     // PyObject_Type returns a new reference but we trust that pandas.NaT will
     // outlive our use of this PyObject*
-    PyObject* nat_type = PyObject_Type(ref.obj());
-    pandas_NaTType = reinterpret_cast<PyTypeObject*>(nat_type);
-    Py_DECREF(nat_type);
+    pandas_NaTType = Py_TYPE(ref.obj());
   }
 
   // retain a reference to Timedelta

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -262,6 +262,7 @@ static std::once_flag pandas_static_initialized;
 static PyObject* pandas_NA = nullptr;
 static PyObject* pandas_NaT = nullptr;
 static PyObject* pandas_Timedelta = nullptr;
+static PyObject* pandas_Timestamp = nullptr;
 static PyTypeObject* pandas_NaTType = nullptr;
 
 void GetPandasStaticSymbols() {
@@ -288,6 +289,11 @@ void GetPandasStaticSymbols() {
   // retain a reference to Timedelta
   if (ImportFromModule(pandas.obj(), "Timedelta", &ref).ok()) {
     pandas_Timedelta = ref.obj();
+  }
+
+  // retain a reference to Timestamp
+  if (ImportFromModule(pandas.obj(), "Timestamp", &ref).ok()) {
+    pandas_Timestamp = ref.obj();
   }
 
   // if pandas.NA exists, retain a reference to it
@@ -319,6 +325,10 @@ bool PandasObjectIsNull(PyObject* obj) {
 
 bool IsPandasTimedelta(PyObject* obj) {
   return pandas_Timedelta && PyObject_IsInstance(obj, pandas_Timedelta);
+}
+
+bool IsPandasTimestamp(PyObject* obj) {
+  return pandas_Timestamp && PyObject_IsInstance(obj, pandas_Timestamp);
 }
 
 Status InvalidValue(PyObject* obj, const std::string& why) {

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -128,6 +128,14 @@ Status PyObject_StdStringStr(PyObject* obj, std::string* out) {
   return PyUnicode_AsStdString(string_ref.obj(), out);
 }
 
+Result<bool> IsModuleImported(const std::string& module_name) {
+  // PyImport_GetModuleDict returns with a borrowed reference
+  OwnedRef key(PyUnicode_FromString(module_name.c_str()));
+  auto is_imported = PyDict_Contains(PyImport_GetModuleDict(), key.obj());
+  RETURN_IF_PYERROR();
+  return is_imported;
+}
+
 Status ImportModule(const std::string& module_name, OwnedRef* ref) {
   PyObject* module = PyImport_ImportModule(module_name.c_str());
   RETURN_IF_PYERROR();

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -76,6 +76,10 @@ void InitPandasStaticData();
 ARROW_PYTHON_EXPORT
 bool PandasObjectIsNull(PyObject* obj);
 
+// \brief Check that obj is a pandas.Timedelta instance
+ARROW_PYTHON_EXPORT
+bool IsPandasTimedelta(PyObject* obj);
+
 // \brief Check whether obj is a floating-point NaN
 ARROW_PYTHON_EXPORT
 bool PyFloat_IsNaN(PyObject* obj);

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -80,6 +80,9 @@ bool PandasObjectIsNull(PyObject* obj);
 ARROW_PYTHON_EXPORT
 bool IsPandasTimedelta(PyObject* obj);
 
+// \brief Check that obj is a pandas.Timestamp instance
+bool IsPandasTimestamp(PyObject* obj);
+
 // \brief Check whether obj is a floating-point NaN
 ARROW_PYTHON_EXPORT
 bool PyFloat_IsNaN(PyObject* obj);

--- a/cpp/src/arrow/python/helpers.h
+++ b/cpp/src/arrow/python/helpers.h
@@ -51,6 +51,10 @@ ARROW_PYTHON_EXPORT Status PyFloat_AsHalf(PyObject* obj, npy_half* out);
 
 namespace internal {
 
+// \brief Check that a Python module has been already imported
+// \param[in] module_name The name of the module
+Result<bool> IsModuleImported(const std::string& module_name);
+
 // \brief Import a Python module
 // \param[in] module_name The name of the module
 // \param[out] ref The OwnedRef containing the module PyObject*

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -998,8 +998,12 @@ Result<std::shared_ptr<ChunkedArray>> ConvertPySequence(PyObject* obj, PyObject*
   PyObject* seq;
   OwnedRef tmp_seq_nanny;
 
-  // FIXME(kszucs): shouldn't import pandas unconditionally
-  internal::InitPandasStaticData();
+  ARROW_ASSIGN_OR_RAISE(auto is_pandas_imported, internal::IsModuleImported("pandas"));
+  if (is_pandas_imported) {
+    // If pandas has been already imported initialize the static pandas objects to
+    // support converting from pd.Timedelta and pd.Timestamp objects
+    internal::InitPandasStaticData();
+  }
 
   int64_t size = options.size;
   RETURN_NOT_OK(ConvertToSequenceAndInferSize(obj, &seq, &size));

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -257,7 +257,7 @@ class PyValue {
         case TimeUnit::NANO:
           // Conversion to nanoseconds can overflow -> check multiply of microseconds
           value = internal::PyDateTime_to_us(dt);
-          if (arrow::internal::MultiplyWithOverflow(value, 1000, &value)) {
+          if (arrow::internal::MultiplyWithOverflow(value, 1000LL, &value)) {
             return internal::InvalidValue(obj, "out of bounds for nanosecond resolution");
           }
           if (arrow::internal::SubtractWithOverflow(value, offset * 1000000000LL,
@@ -671,12 +671,7 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
     }                                                           \
     return AppendNdarrayTyped<TYPE, NUMPY_TYPE>(ndarray);       \
   }
-// Use internal::VisitSequence, fast for NPY_OBJECT but slower otherwise
-#define LIST_SLOW_CASE(TYPE_ID)                               \
-  case Type::TYPE_ID: {                                       \
-    return Extend(this->value_converter_.get(), value, size); \
-  }
-      LIST_SLOW_CASE(NA)
+      LIST_FAST_CASE(BOOL, BooleanType, NPY_BOOL)
       LIST_FAST_CASE(UINT8, UInt8Type, NPY_UINT8)
       LIST_FAST_CASE(INT8, Int8Type, NPY_INT8)
       LIST_FAST_CASE(UINT16, UInt16Type, NPY_UINT16)
@@ -690,24 +685,9 @@ class PyListConverter : public ListConverter<T, PyConverter, PyConverterTrait> {
       LIST_FAST_CASE(DOUBLE, DoubleType, NPY_DOUBLE)
       LIST_FAST_CASE(TIMESTAMP, TimestampType, NPY_DATETIME)
       LIST_FAST_CASE(DURATION, DurationType, NPY_TIMEDELTA)
-      LIST_SLOW_CASE(DATE32)
-      LIST_SLOW_CASE(DATE64)
-      LIST_SLOW_CASE(TIME32)
-      LIST_SLOW_CASE(TIME64)
-      LIST_SLOW_CASE(BINARY)
-      LIST_SLOW_CASE(FIXED_SIZE_BINARY)
-      LIST_SLOW_CASE(STRING)
 #undef LIST_FAST_CASE
-#undef LIST_SLOW_CASE
-      case Type::LIST: {
-        if (PyArray_DESCR(ndarray)->type_num != NPY_OBJECT) {
-          return Status::Invalid(
-              "Can only convert list types from NumPy object array input");
-        }
-        return Extend(this->value_converter_.get(), value, /*reserved=*/0);
-      }
       default: {
-        return Status::TypeError("Unknown list item type: ", value_type->ToString());
+        return Extend(this->value_converter_.get(), value, size);
       }
     }
   }

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1617,10 +1617,12 @@ tasks:
     template: docker-tests/github.linux.yml
     params:
       env:
-        PYTHON: 3.8
-        PYTEST_ARGS: "--enable-hypothesis -m hypothesis"
         HYPOTHESIS_PROFILE: ci
-      run: conda-python
+        PYARROW_TEST_HYPOTHESIS: ON
+        PYTHON: 3.8
+        # limit to execute hypothesis tests only
+        PYTEST_ARGS: "-m hypothesis"
+      run: conda-python-pandas
 
   test-debian-10-python-3:
     ci: azure

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1618,7 +1618,7 @@ tasks:
       template: docker-tests/github.linux.yml
       env:
         PYTHON: 3.8
-        PYARROW_TEST_HYPOTHESIS: ON
+        PYTEST_ARGS: "--enable-hypothesis -m hypothesis"
         HYPOTHESIS_PROFILE: ci
       run: conda-python
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1613,9 +1613,9 @@ tasks:
       run: conda-python
 
   test-conda-python-3.8-hypothesis:
+    ci: github
+    template: docker-tests/github.linux.yml
     params:
-      ci: github
-      template: docker-tests/github.linux.yml
       env:
         PYTHON: 3.8
         PYTEST_ARGS: "--enable-hypothesis -m hypothesis"

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1612,6 +1612,16 @@ tasks:
         PYTHON: 3.8
       run: conda-python
 
+  test-conda-python-3.8-hypothesis:
+    params:
+      ci: github
+      template: docker-tests/github.linux.yml
+      env:
+        PYTHON: 3.8
+        PYARROW_TEST_HYPOTHESIS: ON
+        HYPOTHESIS_PROFILE: ci
+      run: conda-python
+
   test-debian-10-python-3:
     ci: azure
     template: docker-tests/azure.linux.yml

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -28,7 +28,7 @@ from pyarrow.util import find_free_port
 
 # setup hypothesis profiles
 h.settings.register_profile('ci', max_examples=1000)
-h.settings.register_profile('dev', max_examples=10)
+h.settings.register_profile('dev', max_examples=50)
 h.settings.register_profile('debug', max_examples=10,
                             verbosity=h.Verbosity.verbose)
 

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -42,6 +42,10 @@ binary_type = st.just(pa.binary())
 string_type = st.just(pa.string())
 large_binary_type = st.just(pa.large_binary())
 large_string_type = st.just(pa.large_string())
+fixed_size_binary_type = st.builds(
+    pa.binary,
+    st.integers(min_value=0, max_value=16)
+)
 
 signed_integer_types = st.sampled_from([
     pa.int8(),
@@ -102,6 +106,7 @@ primitive_types = st.one_of(
     string_type,
     large_binary_type,
     large_string_type,
+    fixed_size_binary_type,
     numeric_types,
     temporal_types
 )
@@ -124,16 +129,48 @@ def fields(draw, type_strategy=primitive_types):
 def list_types(item_strategy=primitive_types):
     return (
         st.builds(pa.list_, item_strategy) |
-        st.builds(pa.large_list, item_strategy)
+        st.builds(pa.large_list, item_strategy) |
+        st.builds(
+            pa.list_,
+            item_strategy,
+            st.integers(min_value=0, max_value=16)
+        )
     )
 
 
-def struct_types(item_strategy=primitive_types):
-    return st.builds(pa.struct, st.lists(fields(item_strategy)))
+@st.composite
+def struct_types(draw, item_strategy=primitive_types):
+    fields_strategy = st.lists(fields(item_strategy))
+    fields_rendered = draw(fields_strategy)
+    field_names = [field.name for field in fields_rendered]
+    # check that field names are unique, see ARROW-9997
+    h.assume(len(set(field_names)) == len(field_names))
+    return pa.struct(fields_rendered)
 
 
-def complex_types(inner_strategy=primitive_types):
-    return list_types(inner_strategy) | struct_types(inner_strategy)
+def dictionary_types(key_strategy=None, value_strategy=None):
+    key_strategy = key_strategy or signed_integer_types
+    value_strategy = value_strategy or st.one_of(
+        bool_type,
+        integer_types,
+        st.sampled_from([pa.float32(), pa.float64()]),
+        binary_type,
+        string_type,
+        fixed_size_binary_type,
+    )
+    return st.builds(pa.dictionary, key_strategy, value_strategy)
+
+
+@st.composite
+def map_types(draw, key_strategy=primitive_types, item_strategy=primitive_types):
+    key_type = draw(key_strategy)
+    h.assume(not pa.types.is_null(key_type))
+    value_type = draw(item_strategy)
+    return pa.map_(key_type, value_type)
+
+
+# union type
+# extension type
 
 
 def nested_list_types(item_strategy=primitive_types, max_leaves=3):
@@ -144,19 +181,22 @@ def nested_struct_types(item_strategy=primitive_types, max_leaves=3):
     return st.recursive(item_strategy, struct_types, max_leaves=max_leaves)
 
 
-def nested_complex_types(inner_strategy=primitive_types, max_leaves=3):
-    return st.recursive(inner_strategy, complex_types, max_leaves=max_leaves)
-
-
 def schemas(type_strategy=primitive_types, max_fields=None):
     children = st.lists(fields(type_strategy), max_size=max_fields)
     return st.builds(pa.schema, children)
 
 
-complex_schemas = schemas(complex_types())
-
-
-all_types = st.one_of(primitive_types, complex_types(), nested_complex_types())
+all_types = st.deferred(
+    lambda: (
+        primitive_types |
+        list_types() |
+        struct_types() |
+        dictionary_types() |
+        map_types() |
+        list_types(all_types) |
+        struct_types(all_types)
+    )
+)
 all_fields = fields(all_types)
 all_schemas = schemas(all_types)
 
@@ -165,7 +205,21 @@ _default_array_sizes = st.integers(min_value=0, max_value=20)
 
 
 @st.composite
-def arrays(draw, type, size=None):
+def _pylist(draw, value_type, size, nullable=True):
+    arr = draw(arrays(value_type, size=size, nullable=False))
+    return arr.to_pylist()
+
+
+@st.composite
+def _pymap(draw, key_type, value_type, size, nullable=True):
+    length = draw(size)
+    keys = draw(_pylist(key_type, size=length, nullable=False))
+    values = draw(_pylist(value_type, size=length, nullable=nullable))
+    return list(zip(keys, values))
+
+
+@st.composite
+def arrays(draw, type, size=None, nullable=True):
     if isinstance(type, st.SearchStrategy):
         ty = draw(type)
     elif isinstance(type, pa.DataType):
@@ -180,38 +234,24 @@ def arrays(draw, type, size=None):
     elif not isinstance(size, int):
         raise TypeError('Size must be an integer')
 
-    shape = (size,)
-
-    if pa.types.is_list(ty) or pa.types.is_large_list(ty):
-        offsets = draw(npst.arrays(np.uint8(), shape=shape)).cumsum() // 20
-        offsets = np.insert(offsets, 0, 0, axis=0)  # prepend with zero
-        values = draw(arrays(ty.value_type, size=int(offsets.sum())))
-        if pa.types.is_large_list(ty):
-            array_type = pa.LargeListArray
-        else:
-            array_type = pa.ListArray
-        return array_type.from_arrays(offsets, values)
-
-    if pa.types.is_struct(ty):
-        h.assume(len(ty) > 0)
-        fields, child_arrays = [], []
-        for field in ty:
-            fields.append(field)
-            child_arrays.append(draw(arrays(field.type, size=size)))
-        return pa.StructArray.from_arrays(child_arrays, fields=fields)
-
-    if (pa.types.is_boolean(ty) or pa.types.is_integer(ty) or
-            pa.types.is_floating(ty)):
-        values = npst.arrays(ty.to_pandas_dtype(), shape=(size,))
-        np_arr = draw(values)
-        if pa.types.is_floating(ty):
-            # Workaround ARROW-4952: no easy way to assert array equality
-            # in a NaN-tolerant way.
-            np_arr[np.isnan(np_arr)] = -42.0
-        return pa.array(np_arr, type=ty)
-
     if pa.types.is_null(ty):
+        h.assume(nullable)
         value = st.none()
+    elif pa.types.is_boolean(ty):
+        value = st.booleans()
+    elif pa.types.is_integer(ty):
+        values = draw(npst.arrays(ty.to_pandas_dtype(), shape=(size,)))
+        return pa.array(values, type=ty)
+    elif pa.types.is_floating(ty):
+        values = draw(npst.arrays(ty.to_pandas_dtype(), shape=(size,)))
+        # Workaround ARROW-4952: no easy way to assert array equality
+        # in a NaN-tolerant way.
+        values[np.isnan(values)] = -42.0
+        return pa.array(values, type=ty)
+    elif pa.types.is_decimal(ty):
+        # TODO(kszucs): properly limit the precision
+        # value = st.decimals(places=type.scale, allow_infinity=False)
+        h.reject()
     elif pa.types.is_time(ty):
         value = st.times()
     elif pa.types.is_date(ty):
@@ -234,14 +274,34 @@ def arrays(draw, type, size=None):
         value = st.binary()
     elif pa.types.is_string(ty) or pa.types.is_large_string(ty):
         value = st.text()
-    elif pa.types.is_decimal(ty):
-        # TODO(kszucs): properly limit the precision
-        # value = st.decimals(places=type.scale, allow_infinity=False)
-        h.reject()
+    elif pa.types.is_fixed_size_binary(ty):
+        value = st.binary(min_size=ty.byte_width, max_size=ty.byte_width)
+    elif pa.types.is_list(ty):
+        value = _pylist(ty.value_type, size=size, nullable=nullable)
+    elif pa.types.is_large_list(ty):
+        value = _pylist(ty.value_type, size=size, nullable=nullable)
+    elif pa.types.is_fixed_size_list(ty):
+        value = _pylist(ty.value_type, size=ty.list_size, nullable=nullable)
+    elif pa.types.is_dictionary(ty):
+        values = _pylist(ty.value_type, size=size, nullable=nullable)
+        return pa.array(draw(values), type=ty)
+    elif pa.types.is_map(ty):
+        value = _pymap(ty.key_type, ty.item_type, size=_default_array_sizes,
+                       nullable=nullable)
+    elif pa.types.is_struct(ty):
+        h.assume(len(ty) > 0)
+        fields, child_arrays = [], []
+        for field in ty:
+            fields.append(field)
+            child_arrays.append(draw(arrays(field.type, size=size)))
+        return pa.StructArray.from_arrays(child_arrays, fields=fields)
     else:
         raise NotImplementedError(ty)
 
+    if nullable:
+        value = st.one_of(st.none(), value)
     values = st.lists(value, min_size=size, max_size=size)
+
     return pa.array(draw(values), type=ty)
 
 

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1950,7 +1950,7 @@ def test_dictionary_from_strings():
     ('s', datetime.timedelta(seconds=-2147483000)),
     ('ms', datetime.timedelta(milliseconds=-2147483000)),
     ('us', datetime.timedelta(microseconds=-2147483000)),
-    ('ns', datetime.timedelta(microseconds=-2147483000))
+    ('ns', datetime.timedelta(microseconds=-2147483))
 ])
 def test_duration_array_roundtrip_corner_cases(unit, expected):
     # Corner case discovered by hypothesis: there were implicit conversions to

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -387,7 +387,6 @@ def test_broken_integers(seq):
 
 
 def test_numpy_scalars_mixed_type():
-
     # ARROW-4324
     data = [np.int32(10), np.float32(0.5)]
     arr = pa.array(data)
@@ -625,6 +624,50 @@ def test_multidimensional_ndarray_as_nested_list():
                         type=expected_type)
 
     assert result.equals(expected)
+
+
+@pytest.mark.parametrize(('data', 'value_type'), [
+    ([True, False], pa.bool_()),
+    ([None, None], pa.null()),
+    ([1, 2, None], pa.int8()),
+    ([1, 2., 3., None], pa.float32()),
+    ([datetime.date.today(), None], pa.date32()),
+    ([None, datetime.date.today()], pa.date64()),
+    ([datetime.time(1, 1, 1), None], pa.time32('s')),
+    ([None, datetime.time(2, 2, 2)], pa.time64('us')),
+    ([datetime.datetime.now(), None], pa.timestamp('us')),
+    ([datetime.timedelta(seconds=10)], pa.duration('s')),
+    ([b"a", b"b"], pa.binary()),
+    ([b"aaa", b"bbb", b"ccc"], pa.binary(3)),
+    ([b"a", b"b", b"c"], pa.large_binary()),
+    (["a", "b", "c"], pa.string()),
+    (["a", "b", "c"], pa.large_string()),
+    (
+        [{"a": 1, "b": 2}, None, {"a": 5, "b": None}],
+        pa.struct([('a', pa.int8()), ('b', pa.int16())])
+    )
+])
+def test_list_array_from_object_ndarray(data, value_type):
+    ty = pa.list_(value_type)
+    ndarray = np.array(data, dtype=object)
+    arr = pa.array([ndarray], type=ty)
+    assert arr.type.equals(ty)
+    assert arr.to_pylist() == [data]
+
+
+@pytest.mark.parametrize(('data', 'value_type'), [
+    ([[1, 2], [3]], pa.list_(pa.int64())),
+    ([[1, 2], [3, 4]], pa.list_(pa.int64(), 2)),
+    ([[1], [2, 3]], pa.large_list(pa.int64()))
+])
+def test_nested_list_array_from_object_ndarray(data, value_type):
+    ndarray = np.empty(len(data), dtype=object)
+    ndarray[:] = [np.array(item, dtype=object) for item in data]
+
+    ty = pa.list_(value_type)
+    arr = pa.array([ndarray], type=ty)
+    assert arr.type.equals(ty)
+    assert arr.to_pylist() == [data]
 
 
 def test_array_ignore_nan_from_pandas():

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -1957,7 +1957,8 @@ def test_duration_array_roundtrip_corner_cases(unit):
 
 @pytest.mark.pandas
 def test_duration_array_roundtrip_nanosecond_resolution_pandas_timedelta():
-    # corner case discovered by hypothesis
+    # corner case discovered by hypothesis:
+    # preserving the nanoseconds on conversion from a list of Timedelta objects
     import pandas as pd
     ty = pa.duration('ns')
     arr = pa.array([9223371273709551616], type=ty)

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -26,7 +26,6 @@ from datetime import date, datetime, time, timedelta, timezone
 from distutils.version import LooseVersion
 
 import hypothesis as h
-import hypothesis.extra.pandas as pdst
 import hypothesis.extra.pytz as tzst
 import hypothesis.strategies as st
 import numpy as np

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -26,6 +26,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from distutils.version import LooseVersion
 
 import hypothesis as h
+import hypothesis.extra.pandas as pdst
 import hypothesis.extra.pytz as tzst
 import hypothesis.strategies as st
 import numpy as np
@@ -35,6 +36,7 @@ import pytz
 
 from pyarrow.pandas_compat import get_logical_type, _pandas_api
 from pyarrow.tests.util import random_ascii, rands
+import pyarrow.tests.strategies as past
 
 import pyarrow as pa
 try:
@@ -2832,6 +2834,17 @@ def test_convert_unsupported_type_error_message():
         msg = 'Conversion failed for column a with type (period|object)'
         with pytest.raises((TypeError, ValueError), match=msg):
             pa.Table.from_pandas(df)
+
+
+# ----------------------------------------------------------------------
+# Hypothesis tests
+
+
+@h.given(past.arrays(past.pandas_compatible_types))
+def test_array_to_pandas_roundtrip(arr):
+    s = arr.to_pandas()
+    restored = pa.array(s, type=arr.type, from_pandas=True)
+    assert restored.equals(arr)
 
 
 # ----------------------------------------------------------------------

--- a/python/pyarrow/tests/test_strategies.py
+++ b/python/pyarrow/tests/test_strategies.py
@@ -41,6 +41,11 @@ def test_arrays(array):
     assert isinstance(array, pa.lib.Array)
 
 
+@h.given(past.arrays(past.primitive_types, nullable=False))
+def test_array_nullability(array):
+    assert array.null_count == 0
+
+
 @h.given(past.all_chunked_arrays)
 def test_chunked_arrays(chunked_array):
     assert isinstance(chunked_array, pa.lib.ChunkedArray)


### PR DESCRIPTION
This issue is more about the testing since we recently had a refactor targeting the arrow to python conversion paths: https://issues.apache.org/jira/browse/ARROW-9017