### PR TITLE
ARROW-10179: [Rust] Fixed error in labeler

### DIFF
--- a/.github/workflows/dev_labeler.yml
+++ b/.github/workflows/dev_labeler.yml
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+name: PR labeler
 on:
 - pull_request_target
 

--- a/.github/workflows/dev_labeler/labeler.yml
+++ b/.github/workflows/dev_labeler/labeler.yml
@@ -16,7 +16,9 @@
 # under the License.
 
 rust-lang:
-- any: ['rust/*']
+  - rust/*
+  - rust/**/*
 
-datafusion:
-- any: ['rust/datafusion/*']
+datafusion: 
+  - rust/datafusion/*
+  - rust/datafusion/**/*

--- a/.github/workflows/dev_labeler/labeler.yml
+++ b/.github/workflows/dev_labeler/labeler.yml
@@ -16,9 +16,7 @@
 # under the License.
 
 rust-lang:
-  - rust/*
   - rust/**/*
 
 datafusion: 
-  - rust/datafusion/*
   - rust/datafusion/**/*

--- a/.github/workflows/dev_labeler/labeler.yml
+++ b/.github/workflows/dev_labeler/labeler.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-rust-lang:
+lang-rust:
   - rust/**/*
 
 datafusion: 


### PR DESCRIPTION
It seems that I used a notation in the labeler that [is only supported in the master version of it](https://github.com/actions/labeler/issues/73#issuecomment-639034278), which is causing all PRs to dail. This PR fixes that. I verified it on my own fork: https://github.com/jorgecarleitao/arrow/pull/12
