### PR TITLE
ARROW-10181: [Rust] Skip compiling one test on 32 bit ARM architecture

### DIFF
--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -409,6 +409,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64")))]
     fn test_ceil() {
         assert_eq!(ceil(0, 1), 0);
         assert_eq!(ceil(1, 1), 1);


### PR DESCRIPTION
This PR allows the tests to be compiled on 32-bit ARM (e.g. Raspberry Pi).