### PR TITLE
ARROW-10189: [Doc] Fixed typo in C-Data interface example

### DIFF
--- a/docs/source/format/CDataInterface.rst
+++ b/docs/source/format/CDataInterface.rst
@@ -686,7 +686,7 @@ release callback is trivial.
    void export_int32_type(struct ArrowSchema* schema) {
       *schema = (struct ArrowSchema) {
          // Type description
-         .format = "l",
+         .format = "i",
          .name = "",
          .metadata = NULL,
          .flags = 0,


### PR DESCRIPTION
This fixes a small typo in the example provided in the C data interface on which the [specification](https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings) uses `"i"` of india to represent i32, but the [example](https://arrow.apache.org/docs/format/CDataInterface.html#exporting-a-simple-int32-array) uses `"l"` of lima to represent i32.