### PR TITLE
ARROW-10193: [Python] Segfault when converting to fixed size binary array

### DIFF
--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -447,6 +447,10 @@ class ARROW_EXPORT FixedSizeBinaryBuilder : public ArrayBuilder {
     }
   }
 
+  void UnsafeAppend(const char* value) {
+    UnsafeAppend(reinterpret_cast<const uint8_t*>(value));
+  }
+
   void UnsafeAppend(util::string_view value) {
 #ifndef NDEBUG
     CheckValueSize(static_cast<size_t>(value.size()));

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -1034,7 +1034,7 @@ Result<std::shared_ptr<ChunkedArray>> ConvertPySequence(PyObject* obj, PyObject*
     return chunked_converter->ToChunkedArray();
   } else {
     // If the converter can't overflow spare the capacity error checking on the hot-path,
-    // this improves the performance roughly by ~10 for primitive types.
+    // this improves the performance roughly by ~10% for primitive types.
     if (mask != nullptr && mask != Py_None) {
       RETURN_NOT_OK(ExtendMasked(converter.get(), seq, mask, size));
     } else {

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -764,6 +764,15 @@ def test_fixed_size_bytes_does_not_accept_varying_lengths():
         pa.array(data, type=pa.binary(4))
 
 
+def test_fixed_size_binary_length_check():
+    # ARROW-10193
+    data = [b'\x19h\r\x9e\x00\x00\x00\x00\x01\x9b\x9fA']
+    assert len(data[0]) == 12
+    ty = pa.binary(12)
+    arr = pa.array(data, type=ty)
+    assert arr.to_pylist() == data
+
+
 def test_sequence_date():
     data = [datetime.date(2000, 1, 1), None, datetime.date(1970, 1, 1),
             datetime.date(2040, 2, 26)]


### PR DESCRIPTION
```
pyarrow/tests/test_convert_builtin.py::test_fixed_size_binary_length_check ../src/arrow/array/builder_binary.cc:53:  Check failed: (size) == (byte_width_) Appending wrong size to FixedSizeBinaryBuilder
0   libarrow.200.0.0.dylib              0x000000010e7f9704 _ZN5arrow4util7CerrLog14PrintBackTraceEv + 52
1   libarrow.200.0.0.dylib              0x000000010e7f9622 _ZN5arrow4util7CerrLogD2Ev + 98
2   libarrow.200.0.0.dylib              0x000000010e7f9585 _ZN5arrow4util7CerrLogD1Ev + 21
3   libarrow.200.0.0.dylib              0x000000010e7f95ac _ZN5arrow4util7CerrLogD0Ev + 28
4   libarrow.200.0.0.dylib              0x000000010e7f9492 _ZN5arrow4util8ArrowLogD2Ev + 82
5   libarrow.200.0.0.dylib              0x000000010e7f94c5 _ZN5arrow4util8ArrowLogD1Ev + 21
6   libarrow.200.0.0.dylib              0x000000010e303ec1 _ZN5arrow22FixedSizeBinaryBuilder14CheckValueSizeEx + 209
7   libarrow.200.0.0.dylib              0x000000010e30c361 _ZN5arrow22FixedSizeBinaryBuilder12UnsafeAppendEN6nonstd7sv_lite17basic_string_viewIcNSt3__111char_traitsIcEEEE + 49
8   libarrow_python.200.0.0.dylib       0x000000010b4efa7d _ZN5arrow2py20PyPrimitiveConverterINS_19FixedSizeBinaryTypeEvE6AppendEP7_object + 813
```

The input `const char*` value gets implicitly casted to `string_view` which makes the length check fail in debug builds.