### PR TITLE
ARROW-10015: [Rust] Simd aggregate kernels

### DIFF
--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -780,6 +780,18 @@ async fn csv_query_external_table_count() {
 }
 
 #[tokio::test]
+async fn csv_query_external_table_sum() {
+    let mut ctx = ExecutionContext::new();
+    // cast smallint and int to bigint to avoid overflow during calculation
+    register_aggregate_csv_by_sql(&mut ctx).await;
+    let sql =
+        "SELECT SUM(CAST(c7 AS BIGINT)), SUM(CAST(c8 AS BIGINT)) FROM aggregate_test_100";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["13060", "3017641"]];
+    assert_eq!(expected, actual);
+}
+
+#[tokio::test]
 async fn csv_query_count_star() {
     let mut ctx = ExecutionContext::new();
     register_aggregate_csv_by_sql(&mut ctx).await;


### PR DESCRIPTION
Built on top of [ARROW-10040][1] (#8262)

Benchmarks (run on a Ryzen 3700U laptop with some thermal problems)

Current master without simd:

```
$ cargo bench  --bench aggregate_kernels
sum 512                 time:   [3.9652 us 3.9722 us 3.9819 us]                     
                        change: [-0.2270% -0.0896% +0.0672%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe

sum nulls 512           time:   [9.4577 us 9.4796 us 9.5112 us]                           
                        change: [+2.9175% +3.1309% +3.3937%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
```

This branch without simd (speedup probably due to accessing the data via a slice):

```
sum 512                 time:   [1.1066 us 1.1113 us 1.1168 us]                     
                        change: [-72.648% -72.480% -72.310%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) high mild
  6 (6.00%) high severe

sum nulls 512           time:   [1.3279 us 1.3364 us 1.3469 us]                           
                        change: [-86.326% -86.209% -86.085%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  4 (4.00%) high mild
  16 (16.00%) high severe
```

This branch with simd:

```
sum 512                 time:   [108.58 ns 109.47 ns 110.57 ns]                    
                        change: [-90.164% -90.033% -89.850%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe

sum nulls 512           time:   [249.95 ns 250.50 ns 251.06 ns]                          
                        change: [-81.420% -81.281% -81.157%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
```


 [1]: https://issues.apache.org/jira/browse/ARROW-10040