### PR TITLE
ARROW-10202: [CI][Windows] Use sf.net mirror for MSYS2

### DIFF
--- a/ci/scripts/msys2_system_upgrade_phase1.sh
+++ b/ci/scripts/msys2_system_upgrade_phase1.sh
@@ -20,6 +20,9 @@
 set -eux
 
 # https://www.msys2.org/news/#2020-06-29-new-packagers
+msys2_repo_base_url=https://repo.msys2.org/msys
+# Mirror
+msys2_repo_base_url=https://sourceforge.net/projects/msys2/files/REPOS/MSYS2
 msys2_keyring_pkg=msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
 for suffix in "" ".sig"; do
   curl \
@@ -27,7 +30,7 @@ for suffix in "" ".sig"; do
     --remote-name \
     --show-error \
     --silent \
-    https://repo.msys2.org/msys/x86_64/${msys2_keyring_pkg}${suffix}
+    ${msys2_repo_base_url}/x86_64/${msys2_keyring_pkg}${suffix}
 done
 pacman-key --verify ${msys2_keyring_pkg}.sig
 pacman \

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -33,9 +33,8 @@ if [ "$RTOOLS_VERSION" = "35" ]; then
   curl -OSsL "${msys2_repo_base_url}/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz && rm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
   # Disable http://repo.msys2.org/ temporary.
-  sed -i -e 's,^\(Server = http://repo.msys2.org\)/,#\1,g' \
-    /etc/pacman.d/mirrorlist.*
-  cat /etc/pacman.d/mirrorlist.*
+  sed -i -e "s,^Server = http://repo\.msys2\.org/msys,Server = ${msys2_repo_base_url},g" \
+    /etc/pacman.conf
   cat /etc/pacman.conf
   pacman --noconfirm -Scc
   pacman --noconfirm -Syy --verbose --debug

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -35,6 +35,8 @@ if [ "$RTOOLS_VERSION" = "35" ]; then
   # Disable http://repo.msys2.org/ temporary.
   sed -i -e 's,^\(Server = http://repo.msys2.org\)/,#\1,g' \
     /etc/pacman.d/mirrorlist.*
+  cat /etc/pacman.d/mirrorlist.*
+  cat /etc/pacman.conf
   pacman --noconfirm -Scc
   pacman --noconfirm -Syy --verbose --debug
   # lib-4.9.3 is for libraries compiled with gcc 4.9 (Rtools 3.5)

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -36,7 +36,7 @@ if [ "$RTOOLS_VERSION" = "35" ]; then
   sed -i -e 's,^\(Server = http://repo.msys2.org\)/,#\1,g' \
     /etc/pacman.d/mirrorlist.*
   pacman --noconfirm -Scc
-  pacman --noconfirm -Syy
+  pacman --noconfirm -Syy --verbose --debug
   # lib-4.9.3 is for libraries compiled with gcc 4.9 (Rtools 3.5)
   RWINLIB_LIB_DIR="lib-4.9.3"
 else

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -32,6 +32,7 @@ if [ "$RTOOLS_VERSION" = "35" ]; then
   msys2_repo_base_url=https://sourceforge.net/projects/msys2/files/REPOS/MSYS2
   curl -OSsL "${msys2_repo_base_url}/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz && rm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
+  cat /etc/pacman.d/mirrorlist.msys
   pacman --noconfirm -Scc
   pacman --noconfirm -Syy
   # lib-4.9.3 is for libraries compiled with gcc 4.9 (Rtools 3.5)

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -32,12 +32,11 @@ if [ "$RTOOLS_VERSION" = "35" ]; then
   msys2_repo_base_url=https://sourceforge.net/projects/msys2/files/REPOS/MSYS2
   curl -OSsL "${msys2_repo_base_url}/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz && rm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
-  # Disable http://repo.msys2.org/ temporary.
+  # Use sf.net instead of http://repo.msys2.org/ temporary.
   sed -i -e "s,^Server = http://repo\.msys2\.org/msys,Server = ${msys2_repo_base_url},g" \
     /etc/pacman.conf
-  cat /etc/pacman.conf
   pacman --noconfirm -Scc
-  pacman --noconfirm -Syy --verbose --debug
+  pacman --noconfirm -Syy
   # lib-4.9.3 is for libraries compiled with gcc 4.9 (Rtools 3.5)
   RWINLIB_LIB_DIR="lib-4.9.3"
 else

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -30,7 +30,7 @@ if [ "$RTOOLS_VERSION" = "35" ]; then
   msys2_repo_base_url=https://repo.msys2.org/msys
   # Mirror
   msys2_repo_base_url=https://sourceforge.net/projects/msys2/files/REPOS/MSYS2
-  curl -OSsl "${msys2_repo_base_url}/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  curl -OSsL "${msys2_repo_base_url}/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz && rm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
   pacman --noconfirm -Scc
   pacman --noconfirm -Syy

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -32,7 +32,9 @@ if [ "$RTOOLS_VERSION" = "35" ]; then
   msys2_repo_base_url=https://sourceforge.net/projects/msys2/files/REPOS/MSYS2
   curl -OSsL "${msys2_repo_base_url}/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz && rm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
-  cat /etc/pacman.d/mirrorlist.msys
+  # Disable http://repo.msys2.org/ temporary.
+  sed -i -e 's,^\(Server = http://repo.msys2.org\)/,#\1,g' \
+    /etc/pacman.d/mirrorlist.*
   pacman --noconfirm -Scc
   pacman --noconfirm -Syy
   # lib-4.9.3 is for libraries compiled with gcc 4.9 (Rtools 3.5)

--- a/ci/scripts/r_windows_build.sh
+++ b/ci/scripts/r_windows_build.sh
@@ -27,7 +27,10 @@ if [ "$RTOOLS_VERSION" = "35" ]; then
   # Use rtools-backports if building with rtools35
   curl https://raw.githubusercontent.com/r-windows/rtools-backports/master/pacman.conf > /etc/pacman.conf
   # Update keys: https://www.msys2.org/news/#2020-06-29-new-packagers
-  curl -OSsl "http://repo.msys2.org/msys/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
+  msys2_repo_base_url=https://repo.msys2.org/msys
+  # Mirror
+  msys2_repo_base_url=https://sourceforge.net/projects/msys2/files/REPOS/MSYS2
+  curl -OSsl "${msys2_repo_base_url}/x86_64/msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz"
   pacman -U --noconfirm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz && rm msys2-keyring-r21.b39fb11-1-any.pkg.tar.xz
   pacman --noconfirm -Scc
   pacman --noconfirm -Syy


### PR DESCRIPTION
Because repo.msys2.org is still down.