### PR TITLE
ARROW-9318: [C++] Two level cache with expiraton

### DIFF
--- a/cpp/src/arrow/util/concurrent_map.h
+++ b/cpp/src/arrow/util/concurrent_map.h
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <functional>
+#include <unordered_map>
+#include <utility>
+
+#include "arrow/util/mutex.h"
+
+namespace arrow {
+namespace util {
+
+template <typename K, typename V>
+class ConcurrentMap {
+ public:
+  void Insert(const K& key, const V& value) {
+    auto lock = mutex_.Lock();
+    map_.insert({key, value});
+  }
+
+  template <typename ValueFunc>
+  V GetOrInsert(const K& key, ValueFunc&& compute_value_func) {
+    auto lock = mutex_.Lock();
+    auto it = map_.find(key);
+    if (it == map_.end()) {
+      auto pair = map_.emplace(key, compute_value_func());
+      it = pair.first;
+    }
+    return it->second;
+  }
+
+  void Erase(const K& key) {
+    auto lock = mutex_.Lock();
+    map_.erase(key);
+  }
+
+  void Clear() {
+    auto lock = mutex_.Lock();
+    map_.clear();
+  }
+
+  size_t size() const {
+    auto lock = mutex_.Lock();
+    return map_.size();
+  }
+
+ private:
+  std::unordered_map<K, V> map_;
+  mutable arrow::util::Mutex mutex_;
+};
+
+}  // namespace util
+}  // namespace arrow

--- a/cpp/src/parquet/encryption/two_level_cache_with_expiration.h
+++ b/cpp/src/parquet/encryption/two_level_cache_with_expiration.h
@@ -1,0 +1,161 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <chrono>
+#include <unordered_map>
+
+#include "arrow/util/concurrent_map.h"
+#include "arrow/util/mutex.h"
+
+namespace parquet {
+namespace encryption {
+
+using arrow::util::ConcurrentMap;
+
+namespace internal {
+
+// in miliseconds
+using TimePoint = std::chrono::system_clock::time_point;
+
+static inline TimePoint CurrentTimePoint() { return std::chrono::system_clock::now(); }
+
+template <typename E>
+class ExpiringCacheEntry {
+ public:
+  ExpiringCacheEntry() = default;
+
+  ExpiringCacheEntry(const E& cached_item, uint64_t expiration_interval_seconds)
+      : cached_item_(cached_item) {
+    expiration_timestamp_ =
+        CurrentTimePoint() + std::chrono::seconds(expiration_interval_seconds);
+  }
+
+  bool IsExpired() {
+    auto now = CurrentTimePoint();
+    return (now > expiration_timestamp_);
+  }
+
+  E cached_item() { return cached_item_; }
+
+ private:
+  TimePoint expiration_timestamp_;
+  E cached_item_;
+};
+
+// This class is to avoid the below warning when compiling KeyToolkit class with VS2015
+// warning C4503: decorated name length exceeded, name was truncated
+template <typename V>
+class ExpiringCacheMapEntry {
+ public:
+  ExpiringCacheMapEntry() = default;
+
+  explicit ExpiringCacheMapEntry(
+      std::shared_ptr<ConcurrentMap<std::string, V>> cached_item,
+      uint64_t expiration_interval_seconds)
+      : map_cache_(cached_item, expiration_interval_seconds) {}
+
+  bool IsExpired() { return map_cache_.IsExpired(); }
+
+  std::shared_ptr<ConcurrentMap<std::string, V>> cached_item() {
+    return map_cache_.cached_item();
+  }
+
+ private:
+  // ConcurrentMap object may be accessed and modified at many places at the same time,
+  // from multiple threads, or even removed from cache.
+  ExpiringCacheEntry<std::shared_ptr<ConcurrentMap<std::string, V>>> map_cache_;
+};
+
+}  // namespace internal
+
+// Two-level cache with expiration of internal caches according to token lifetime.
+// External cache is per token, internal is per string key.
+// Wrapper class around:
+//    std::unordered_map<std::string,
+//    internal::ExpiringCacheEntry<std::unordered_map<std::string, V>>>
+// This cache is safe to be shared between threads.
+template <typename V>
+class TwoLevelCacheWithExpiration {
+ public:
+  TwoLevelCacheWithExpiration() {
+    last_cache_cleanup_timestamp_ = internal::CurrentTimePoint();
+  }
+
+  std::shared_ptr<ConcurrentMap<std::string, V>> GetOrCreateInternalCache(
+      const std::string& access_token, uint64_t cache_entry_lifetime_seconds) {
+    auto lock = mutex_.Lock();
+
+    auto external_cache_entry = cache_.find(access_token);
+    if (external_cache_entry == cache_.end() ||
+        external_cache_entry->second.IsExpired()) {
+      cache_.insert({access_token, internal::ExpiringCacheMapEntry<V>(
+                                       std::shared_ptr<ConcurrentMap<std::string, V>>(
+                                           new ConcurrentMap<std::string, V>()),
+                                       cache_entry_lifetime_seconds)});
+    }
+
+    return cache_[access_token].cached_item();
+  }
+
+  void CheckCacheForExpiredTokens(uint64_t cache_cleanup_period_seconds) {
+    auto lock = mutex_.Lock();
+
+    internal::TimePoint now = internal::CurrentTimePoint();
+
+    if (now > (last_cache_cleanup_timestamp_ +
+               std::chrono::seconds(cache_cleanup_period_seconds))) {
+      RemoveExpiredEntriesNoMutex();
+      last_cache_cleanup_timestamp_ =
+          now + std::chrono::seconds(cache_cleanup_period_seconds);
+    }
+  }
+
+  void RemoveExpiredEntriesFromCache() {
+    auto lock = mutex_.Lock();
+
+    RemoveExpiredEntriesNoMutex();
+  }
+
+  void Remove(const std::string& access_token) {
+    auto lock = mutex_.Lock();
+    cache_.erase(access_token);
+  }
+
+  void Clear() {
+    auto lock = mutex_.Lock();
+    cache_.clear();
+  }
+
+ private:
+  void RemoveExpiredEntriesNoMutex() {
+    for (auto it = cache_.begin(); it != cache_.end();) {
+      if (it->second.IsExpired()) {
+        it = cache_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+  std::unordered_map<std::string, internal::ExpiringCacheMapEntry<V>> cache_;
+  internal::TimePoint last_cache_cleanup_timestamp_;
+  arrow::util::Mutex mutex_;
+};
+
+}  // namespace encryption
+}  // namespace parquet

--- a/cpp/src/parquet/encryption/two_level_cache_with_expiration_test.cc
+++ b/cpp/src/parquet/encryption/two_level_cache_with_expiration_test.cc
@@ -1,0 +1,186 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "arrow/util/concurrent_map.h"
+
+#include "parquet/encryption/two_level_cache_with_expiration.h"
+
+namespace parquet {
+namespace encryption {
+namespace test {
+
+class TwoLevelCacheWithExpirationTest : public ::testing::Test {
+ public:
+  void SetUp() {
+    // lifetime is 1s
+    std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_1s =
+        cache_.GetOrCreateInternalCache("lifetime1s", 1);
+    lifetime_1s->Insert("item1", 1);
+    lifetime_1s->Insert("item2", 2);
+
+    // lifetime is 3s
+    std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_3s =
+        cache_.GetOrCreateInternalCache("lifetime3s", 3);
+    lifetime_3s->Insert("item21", 21);
+    lifetime_3s->Insert("item22", 22);
+  }
+
+ protected:
+  void TaskInsert(int thread_no) {
+    for (int i = 0; i < 20; i++) {
+      std::string token = i % 2 == 0 ? "lifetime1s" : "lifetime3s";
+      uint64_t lifetime_ms = i % 2 == 0 ? 1 : 3;
+      std::shared_ptr<ConcurrentMap<std::string, int>> internal_cache =
+          cache_.GetOrCreateInternalCache(token, lifetime_ms);
+      std::stringstream ss;
+      ss << "item_" << thread_no << "_" << i;
+      internal_cache->Insert(ss.str(), i);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
+  void TaskClean() {
+    for (int i = 0; i < 20; i++) {
+      cache_.Clear();
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+  }
+
+  TwoLevelCacheWithExpiration<int> cache_;
+};
+
+TEST_F(TwoLevelCacheWithExpirationTest, RemoveExpiration) {
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_1s_before_expiration =
+      cache_.GetOrCreateInternalCache("lifetime1s", 1);
+  ASSERT_EQ(lifetime_1s_before_expiration->size(), 2);
+
+  // wait for 2s, we expect:
+  // lifetime_1s will be expired
+  // lifetime_3s will not be expired
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+  // now clear expired items from the cache
+  cache_.RemoveExpiredEntriesFromCache();
+
+  // lifetime_1s (with 2 items) is expired and has been removed from the cache.
+  // Now the cache create a new object which has no item.
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_1s =
+      cache_.GetOrCreateInternalCache("lifetime1s", 1);
+  ASSERT_EQ(lifetime_1s->size(), 0);
+
+  // However, lifetime_1s_before_expiration can still access normally and independently
+  // from the one in cache
+  lifetime_1s_before_expiration->Insert("item3", 3);
+  ASSERT_EQ(lifetime_1s_before_expiration->size(), 3);
+  ASSERT_EQ(lifetime_1s->size(), 0);
+
+  // lifetime_3s is not expired and still contains 2 items.
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_3s =
+      cache_.GetOrCreateInternalCache("lifetime3s", 3);
+  ASSERT_EQ(lifetime_3s->size(), 2);
+}
+
+TEST_F(TwoLevelCacheWithExpirationTest, CleanupPeriodOk) {
+  // wait for 2s, now:
+  // lifetime_1s is expired
+  // lifetime_3s isn't expired
+  std::this_thread::sleep_for(std::chrono::seconds(2));
+
+  // cleanup_period is 1s, less than or equals lifetime of both items, so the expired
+  // items will be removed from cache.
+  cache_.CheckCacheForExpiredTokens(1);
+
+  // lifetime_1s (with 2 items) is expired and has been removed from the cache.
+  // Now the cache create a new object which has no item.
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_1s =
+      cache_.GetOrCreateInternalCache("lifetime1s", 1);
+  ASSERT_EQ(lifetime_1s->size(), 0);
+
+  // lifetime_3s is not expired and still contains 2 items.
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_3s =
+      cache_.GetOrCreateInternalCache("lifetime3s", 3);
+  ASSERT_EQ(lifetime_3s->size(), 2);
+}
+
+TEST_F(TwoLevelCacheWithExpirationTest, RemoveByToken) {
+  cache_.Remove("lifetime1s");
+
+  // lifetime_1s (with 2 items) has been removed from the cache.
+  // Now the cache create a new object which has no item.
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_1s =
+      cache_.GetOrCreateInternalCache("lifetime1s", 1);
+  ASSERT_EQ(lifetime_1s->size(), 0);
+
+  // lifetime_3s is still contains 2 items.
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_3s =
+      cache_.GetOrCreateInternalCache("lifetime3s", 3);
+  ASSERT_EQ(lifetime_3s->size(), 2);
+
+  cache_.Remove("lifetime3s");
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_3s_after_removed =
+      cache_.GetOrCreateInternalCache("lifetime3s", 3);
+  ASSERT_EQ(lifetime_3s_after_removed->size(), 0);
+}
+
+TEST_F(TwoLevelCacheWithExpirationTest, RemoveAllTokens) {
+  cache_.Clear();
+
+  // All tokens has been removed from the cache.
+  // Now the cache create a new object which has no item.
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_1s =
+      cache_.GetOrCreateInternalCache("lifetime1s", 1);
+  ASSERT_EQ(lifetime_1s->size(), 0);
+
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_3s =
+      cache_.GetOrCreateInternalCache("lifetime3s", 3);
+  ASSERT_EQ(lifetime_3s->size(), 0);
+}
+
+TEST_F(TwoLevelCacheWithExpirationTest, Clear) {
+  cache_.Clear();
+
+  // All tokens has been removed from the cache.
+  // Now the cache create a new object which has no item.
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_1s =
+      cache_.GetOrCreateInternalCache("lifetime1s", 1);
+  ASSERT_EQ(lifetime_1s->size(), 0);
+
+  std::shared_ptr<ConcurrentMap<std::string, int>> lifetime_3s =
+      cache_.GetOrCreateInternalCache("lifetime3s", 3);
+  ASSERT_EQ(lifetime_3s->size(), 0);
+}
+
+TEST_F(TwoLevelCacheWithExpirationTest, MultiThread) {
+  std::vector<std::thread> insert_threads;
+  for (int i = 0; i < 10; i++) {
+    insert_threads.push_back(std::thread([this, i]() { this->TaskInsert(i); }));
+  }
+  std::thread clean_thread([this]() { this->TaskClean(); });
+
+  for (size_t i = 0; i < insert_threads.size(); i++) {
+    insert_threads[i].join();
+  }
+  clean_thread.join();
+}
+
+}  // namespace test
+}  // namespace encryption
+}  // namespace parquet


### PR DESCRIPTION
This pull partly implements the ticket ARROW-9318 and is extracted from the mother pull https://github.com/apache/arrow/pull/8023.
This part is about the cache to cache a concurrent map for each access token. Every access token has a expiration time. After this expiration time, the map in cache can be cleared by calling `void RemoveExpiredEntriesFromCache()` or `void CheckCacheForExpiredTokens(uint64_t cache_cleanup_period_seconds)`.
Usage: encryption key toolkit will use the cache to cache "key encryption key" and KMS client.
Thanks!