### PR TITLE
ARROW-10204: [Rust] Filter kernel should only count bits in valid range

### DIFF
--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -240,7 +240,7 @@ impl FilterContext {
         }
         let filter_mask: Vec<u64> = (0..64).map(|x| 1u64 << x).collect();
         let filter_bytes = filter_array.data_ref().buffers()[0].data();
-        let filtered_count = bit_util::count_set_bits(filter_bytes);
+        let filtered_count = bit_util::count_set_bits_offset(filter_bytes, 0, filter_array.len());
 
         // transmute filter_bytes to &[u64]
         let mut u64_buffer = MutableBuffer::new(filter_bytes.len());

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -240,7 +240,8 @@ impl FilterContext {
         }
         let filter_mask: Vec<u64> = (0..64).map(|x| 1u64 << x).collect();
         let filter_bytes = filter_array.data_ref().buffers()[0].data();
-        let filtered_count = bit_util::count_set_bits_offset(filter_bytes, 0, filter_array.len());
+        let filtered_count =
+            bit_util::count_set_bits_offset(filter_bytes, 0, filter_array.len());
 
         // transmute filter_bytes to &[u64]
         let mut u64_buffer = MutableBuffer::new(filter_bytes.len());


### PR DESCRIPTION
This caused a test failure in `aggregate_grouped_empty` when the `simd` feature is enabled. One could argue that it's an error in the compare kernel to set bits outside of the array len, but only taking the valid range into account solves that problem neatly.