### PR TITLE
ARROW-10217: [CI] Run fewer GitHub Actions jobs 

### DIFF
--- a/.github/workflows/dev_labeler.yml
+++ b/.github/workflows/dev_labeler.yml
@@ -16,8 +16,10 @@
 # under the License.
 
 name: PR labeler
-on:
-- pull_request_target
+on: pull_request_target
+  types: [opened, reopened]
+  paths:
+    - 'rust/**'
 
 jobs:
   assign-rust-labels:

--- a/.github/workflows/dev_labeler/labeler.yml
+++ b/.github/workflows/dev_labeler/labeler.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 lang-rust:
-  - rust/**
+  - rust/**/*
 
 datafusion:
-  - rust/datafusion/**
+  - rust/datafusion/**/*

--- a/.github/workflows/dev_labeler/labeler.yml
+++ b/.github/workflows/dev_labeler/labeler.yml
@@ -16,7 +16,7 @@
 # under the License.
 
 lang-rust:
-  - rust/**/*
+  - rust/**
 
-datafusion: 
-  - rust/datafusion/**/*
+datafusion:
+  - rust/datafusion/**

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: ["3.6", "4.0"]
+        r: ["3.6"]
         ubuntu: [18.04]
     env:
       R: ${{ matrix.r }}
@@ -100,7 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         # See https://hub.docker.com/r/rstudio/r-base
-        r_version: ["3.6", "4.0"]
+        r_version: ["4.0"]
         r_image:
           - centos7
     env:


### PR DESCRIPTION
* Only run the pull-request-labeler if the relevant paths are modified and only on opening/reopening a PR
* Cut 2 R builds from the matrix