### PR TITLE
ARROW-10221: [JS] Javascript toArray() method ignores nulls on some types.

### DIFF
--- a/js/src/visitor/toarray.ts
+++ b/js/src/visitor/toarray.ts
@@ -88,18 +88,6 @@ export class ToArrayVisitor extends Visitor {}
 
 /** @ignore */
 function arrayOfVector<T extends DataType>(vector: VectorType<T>): T['TArray'] {
-
-    const { type, length, stride } = vector;
-
-    // Fast case, return subarray if possible
-    switch (type.typeId) {
-        case Type.Int:
-        case Type.Float: case Type.Decimal:
-        case Type.Time: case Type.Timestamp:
-            return vector.data.values.subarray(0, length * stride);
-    }
-
-    // Otherwise if not primitive, slow copy
     return [...iteratorVisitor.visit(vector)] as T['TArray'];
 }
 


### PR DESCRIPTION
Remove fast method that ignores null values. JIRA issued filed. A better version might use the old method if the vector is guaranteed not to be nullable.