### PR TITLE
ARROW-10224: [Python] Add support for Python 3.9 except macOS wheel and Windows wheel

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -778,6 +778,8 @@ if(MSVC AND ARROW_USE_STATIC_CRT)
   set(Boost_USE_STATIC_RUNTIME ON)
 endif()
 set(Boost_ADDITIONAL_VERSIONS
+    "1.74.0"
+    "1.74"
     "1.73.0"
     "1.73"
     "1.72.0"

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -631,7 +631,7 @@ IMPORT_TESTS
 }
 
 test_linux_wheels() {
-  local py_arches="3.5m 3.6m 3.7m 3.8"
+  local py_arches="3.5m 3.6m 3.7m 3.8 3.9"
   local manylinuxes="1 2010 2014"
 
   for py_arch in ${py_arches}; do

--- a/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.6.____cpython.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.5'
+- '7'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -23,7 +23,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.5'
+- '7'
 docker_image:
 - condaforge/linux-anvil-aarch64
 gflags:
@@ -31,7 +31,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -39,7 +39,7 @@ lz4_c:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -55,11 +55,16 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.7.____cpython.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.5'
+- '7'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -23,7 +23,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.5'
+- '7'
 docker_image:
 - condaforge/linux-anvil-aarch64
 gflags:
@@ -31,7 +31,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -39,7 +39,7 @@ lz4_c:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -55,11 +55,16 @@ pin_run_as_build:
 python:
 - 3.7.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.8.____cpython.yaml
@@ -1,7 +1,7 @@
 BUILD:
 - aarch64-conda_cos7-linux-gnu
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -9,7 +9,7 @@ bzip2:
 c_compiler:
 - gcc
 c_compiler_version:
-- '7.5'
+- '7'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -23,7 +23,7 @@ cuda_compiler_version:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7.5'
+- '7'
 docker_image:
 - condaforge/linux-anvil-aarch64
 gflags:
@@ -31,7 +31,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -39,7 +39,7 @@ lz4_c:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -55,11 +55,16 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.9.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_aarch64_python3.9.____cpython.yaml
@@ -1,3 +1,5 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 aws_sdk_cpp:
 - 1.8.63
 boost_cpp:
@@ -8,12 +10,14 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '7'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
-- conda-forge,defaults
+- conda-forge
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- nvcc
 cuda_compiler_version:
 - None
 cxx_compiler:
@@ -21,7 +25,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-aarch64
 gflags:
 - '2.2'
 glog:
@@ -33,7 +37,7 @@ libprotobuf:
 lz4_c:
 - 1.9.2
 numpy:
-- '1.16'
+- '1.19'
 orc:
 - 1.6.5
 pin_run_as_build:
@@ -49,18 +53,16 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.9.* *_cpython
 re2:
 - 2020.10.01
 snappy:
 - '1'
 target_platform:
-- linux-64
+- linux-aarch64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cuda_compiler_version
-  - docker_image
 - - numpy
   - python
 zlib:

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.6.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -27,7 +27,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -35,7 +35,7 @@ lz4_c:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -51,14 +51,18 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.7.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -27,7 +27,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -35,7 +35,7 @@ lz4_c:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -51,14 +51,18 @@ pin_run_as_build:
 python:
 - 3.7.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.8.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -27,7 +27,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -35,7 +35,7 @@ lz4_c:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -51,14 +51,18 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.9.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_version9.2python3.9.____cpython.yaml
@@ -15,13 +15,13 @@ channel_targets:
 cuda_compiler:
 - nvcc
 cuda_compiler_version:
-- None
+- '9.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
 - '7'
 docker_image:
-- condaforge/linux-anvil-comp7
+- condaforge/linux-anvil-cuda:9.2
 gflags:
 - '2.2'
 glog:
@@ -33,7 +33,7 @@ libprotobuf:
 lz4_c:
 - 1.9.2
 numpy:
-- '1.16'
+- '1.19'
 orc:
 - 1.6.5
 pin_run_as_build:
@@ -49,7 +49,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.9.* *_cpython
 re2:
 - 2020.10.01
 snappy:

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.6.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -27,7 +27,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -35,7 +35,7 @@ lz4_c:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -51,14 +51,18 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.8.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -27,7 +27,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -35,7 +35,7 @@ lz4_c:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -51,14 +51,18 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - linux-64
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - cuda_compiler_version
   - docker_image
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.9.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/linux_cuda_compiler_versionNonepython3.9.____cpython.yaml
@@ -33,7 +33,7 @@ libprotobuf:
 lz4_c:
 - 1.9.2
 numpy:
-- '1.16'
+- '1.19'
 orc:
 - 1.6.5
 pin_run_as_build:
@@ -49,7 +49,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.9.* *_cpython
 re2:
 - 2020.10.01
 snappy:

--- a/dev/tasks/conda-recipes/.ci_support/osx_python3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/osx_python3.6.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -25,7 +25,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -35,7 +35,7 @@ macos_machine:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -51,11 +51,16 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/osx_python3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/osx_python3.7.____cpython.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '10.9'
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -25,7 +25,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -35,7 +35,7 @@ macos_machine:
 numpy:
 - '1.16'
 orc:
-- 1.6.4
+- 1.6.5
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -49,13 +49,18 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.8.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - osx-64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/osx_python3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/osx_python3.8.____cpython.yaml
@@ -33,7 +33,7 @@ lz4_c:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.16'
+- '1.17.3'
 orc:
 - 1.6.4
 pin_run_as_build:

--- a/dev/tasks/conda-recipes/.ci_support/osx_python3.9.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/osx_python3.9.____cpython.yaml
@@ -1,3 +1,5 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 aws_sdk_cpp:
 - 1.8.63
 boost_cpp:
@@ -5,23 +7,19 @@ boost_cpp:
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '7'
+- '10'
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- nvcc
 cuda_compiler_version:
 - None
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- '10'
 gflags:
 - '2.2'
 glog:
@@ -32,8 +30,10 @@ libprotobuf:
 - '3.13'
 lz4_c:
 - 1.9.2
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.16'
+- '1.19'
 orc:
 - 1.6.5
 pin_run_as_build:
@@ -49,18 +49,16 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.9.* *_cpython
 re2:
 - 2020.10.01
 snappy:
 - '1'
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - cuda_compiler_version
-  - docker_image
 - - numpy
   - python
 zlib:

--- a/dev/tasks/conda-recipes/.ci_support/win_python3.6.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/win_python3.6.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -19,7 +19,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -41,11 +41,14 @@ pin_run_as_build:
 python:
 - 3.6.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - win-64
+zip_keys:
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/win_python3.7.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/win_python3.7.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -19,7 +19,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -41,11 +41,14 @@ pin_run_as_build:
 python:
 - 3.7.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - win-64
+zip_keys:
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/win_python3.8.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/win_python3.8.____cpython.yaml
@@ -1,5 +1,5 @@
 aws_sdk_cpp:
-- 1.8.54
+- 1.8.63
 boost_cpp:
 - 1.74.0
 bzip2:
@@ -19,7 +19,7 @@ gflags:
 glog:
 - 0.4.0
 grpc_cpp:
-- '1.30'
+- '1.32'
 libprotobuf:
 - '3.13'
 lz4_c:
@@ -41,11 +41,14 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 re2:
-- 2020.08.01
+- 2020.10.01
 snappy:
 - '1'
 target_platform:
 - win-64
+zip_keys:
+- - numpy
+  - python
 zlib:
 - '1.2'
 zstd:

--- a/dev/tasks/conda-recipes/.ci_support/win_python3.9.____cpython.yaml
+++ b/dev/tasks/conda-recipes/.ci_support/win_python3.9.____cpython.yaml
@@ -5,23 +5,15 @@ boost_cpp:
 bzip2:
 - '1'
 c_compiler:
-- gcc
-c_compiler_version:
-- '7'
+- vs2017
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-cuda_compiler:
-- nvcc
 cuda_compiler_version:
 - None
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '7'
-docker_image:
-- condaforge/linux-anvil-comp7
+- vs2017
 gflags:
 - '2.2'
 glog:
@@ -33,9 +25,7 @@ libprotobuf:
 lz4_c:
 - 1.9.2
 numpy:
-- '1.16'
-orc:
-- 1.6.5
+- '1.19'
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
@@ -49,18 +39,14 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.9.* *_cpython
 re2:
 - 2020.10.01
 snappy:
 - '1'
 target_platform:
-- linux-64
+- win-64
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
-- - cuda_compiler_version
-  - docker_image
 - - numpy
   - python
 zlib:

--- a/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
+++ b/dev/tasks/conda-recipes/arrow-cpp/meta.yaml
@@ -179,7 +179,7 @@ outputs:
       host:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
         - cython
-        - numpy 1.16.*
+        - numpy
         - python
         - setuptools
         - setuptools_scm
@@ -244,7 +244,7 @@ outputs:
         - {{ pin_subpackage('arrow-cpp', exact=True) }}
         - {{ pin_subpackage('pyarrow', exact=True) }}
         - cython
-        - numpy 1.16.*
+        - numpy
         - python
         - setuptools
         - setuptools_scm

--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Setup Archery
         run: pip install -e arrow/dev/archery[docker]
       - name: Execute Docker Build

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -178,6 +178,15 @@ tasks:
       - arrow-cpp-{no_rc_version}-py38(h[a-z0-9]+)_0_cpu.tar.bz2
       - pyarrow-{no_rc_version}-py38(h[a-z0-9]+)_0_cpu.tar.bz2
 
+  conda-linux-gcc-py39-cpu:
+    ci: azure
+    template: conda-recipes/azure.linux.yml
+    params:
+      config: linux_cuda_compiler_versionNonepython3.9.____cpython
+    artifacts:
+      - arrow-cpp-{no_rc_version}-py39(h[a-z0-9]+)_0_cpu.tar.bz2
+      - pyarrow-{no_rc_version}-py39(h[a-z0-9]+)_0_cpu.tar.bz2
+
   conda-linux-gcc-py36-cuda:
     ci: azure
     template: conda-recipes/azure.linux.yml
@@ -205,6 +214,15 @@ tasks:
       - arrow-cpp-{no_rc_version}-py38(h[a-z0-9]+)_0_cuda.tar.bz2
       - pyarrow-{no_rc_version}-py38(h[a-z0-9]+)_0_cuda.tar.bz2
 
+  conda-linux-gcc-py39-cuda:
+    ci: azure
+    template: conda-recipes/azure.linux.yml
+    params:
+      config: linux_cuda_compiler_version9.2python3.9.____cpython
+    artifacts:
+      - arrow-cpp-{no_rc_version}-py39(h[a-z0-9]+)_0_cuda.tar.bz2
+      - pyarrow-{no_rc_version}-py39(h[a-z0-9]+)_0_cuda.tar.bz2
+
   conda-linux-gcc-py36-aarch64:
     ci: drone
     template: conda-recipes/drone.yml
@@ -231,6 +249,15 @@ tasks:
     artifacts:
       - arrow-cpp-{no_rc_version}-py38(h[a-z0-9]+)_0_cpu.tar.bz2
       - pyarrow-{no_rc_version}-py38(h[a-z0-9]+)_0_cpu.tar.bz2
+
+  conda-linux-gcc-py39-aarch64:
+    ci: drone
+    template: conda-recipes/drone.yml
+    params:
+      config: linux_aarch64_python3.9.____cpython
+    artifacts:
+      - arrow-cpp-{no_rc_version}-py39(h[a-z0-9]+)_0_cpu.tar.bz2
+      - pyarrow-{no_rc_version}-py39(h[a-z0-9]+)_0_cpu.tar.bz2
 
   ############################## Conda OSX ####################################
 
@@ -338,6 +365,20 @@ tasks:
     artifacts:
       - pyarrow-{no_rc_version}-cp38-cp38-manylinux1_x86_64.whl
 
+  wheel-manylinux1-cp39:
+    ci: azure
+    template: python-wheels/azure.linux.yml
+    params:
+      python_version: 3.9
+      unicode_width: 16
+      wheel_tag: manylinux1
+      wheel_dir: manylinux1
+      test_docker_images:
+        - python:3.9
+      test_remove_system_libs: true
+    artifacts:
+      - pyarrow-{no_rc_version}-cp39-cp39-manylinux1_x86_64.whl
+
   wheel-manylinux2010-cp36m:
     ci: azure
     template: python-wheels/azure.linux.yml
@@ -380,6 +421,20 @@ tasks:
     artifacts:
       - pyarrow-{no_rc_version}-cp38-cp38-manylinux2010_x86_64.whl
 
+  wheel-manylinux2010-cp39:
+    ci: azure
+    template: python-wheels/azure.linux.yml
+    params:
+      python_version: 3.9
+      unicode_width: 16
+      wheel_tag: manylinux2010
+      wheel_dir: manylinux201x
+      test_docker_images:
+        - python:3.9
+      test_remove_system_libs: true
+    artifacts:
+      - pyarrow-{no_rc_version}-cp39-cp39-manylinux2010_x86_64.whl
+
   wheel-manylinux2014-cp36m:
     ci: azure
     template: python-wheels/azure.linux.yml
@@ -421,6 +476,20 @@ tasks:
       test_remove_system_libs: true
     artifacts:
       - pyarrow-{no_rc_version}-cp38-cp38-manylinux2014_x86_64.whl
+
+  wheel-manylinux2014-cp39:
+    ci: azure
+    template: python-wheels/azure.linux.yml
+    params:
+      python_version: 3.9
+      unicode_width: 16
+      wheel_tag: manylinux2014
+      wheel_dir: manylinux201x
+      test_docker_images:
+        - python:3.9
+      test_remove_system_libs: true
+    artifacts:
+      - pyarrow-{no_rc_version}-cp39-cp39-manylinux2014_x86_64.whl
 
   ############################## Wheel OSX ####################################
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -472,7 +472,7 @@ services:
     #   docker-compose run --rm conda-python
     # Parameters:
     #   ARCH: amd64, arm32v7
-    #   PYTHON: 3.6, 3.7, 3.8
+    #   PYTHON: 3.6, 3.7, 3.8, 3.9
     image: ${REPO}:${ARCH}-conda-python-${PYTHON}
     build:
       context: .

--- a/python/manylinux1/Dockerfile-x86_64_base
+++ b/python/manylinux1/Dockerfile-x86_64_base
@@ -17,7 +17,7 @@
 
 # See https://quay.io/repository/pypa/manylinux1_x86_64?tab=tags
 # to update base image.
-FROM quay.io/pypa/manylinux1_x86_64:2020-03-07-9c5ba95
+FROM quay.io/pypa/manylinux1_x86_64:2020-12-11-df302d3
 
 # Install dependencies
 RUN yum install -y xz ccache flex && yum clean all
@@ -89,7 +89,7 @@ RUN /build_glog.sh
 ENV GLOG_HOME /usr/local
 
 WORKDIR /
-RUN git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout 68a4af043e2adb0d9353d4a0e1f3d871203237aa
+RUN git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout 8882150df6529658700b66bec124dfb77eefca26
 # Remove unneeded Python versions
 RUN rm -rf /opt/_internal/cpython-2.7.*
 

--- a/python/manylinux1/Dockerfile-x86_64_ubuntu
+++ b/python/manylinux1/Dockerfile-x86_64_ubuntu
@@ -34,7 +34,7 @@ ADD scripts/install_cmake.sh /
 RUN /install_cmake.sh
 
 WORKDIR /
-RUN git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout 68a4af043e2adb0d9353d4a0e1f3d871203237aa
+RUN git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout 8882150df6529658700b66bec124dfb77eefca26
 
 ADD scripts/build_openssl.sh /
 RUN /build_openssl.sh

--- a/python/manylinux1/build_arrow.sh
+++ b/python/manylinux1/build_arrow.sh
@@ -62,7 +62,7 @@ export PYARROW_CMAKE_OPTIONS='-DTHRIFT_HOME=/usr -DBoost_NAMESPACE=arrow_boost -
 mkdir -p /io/dist
 
 # Must pass PYTHON_VERSION env variable
-# possible values are: 3.6 3.7 3.8
+# possible values are: 3.6 3.7 3.8 3.9
 
 UNICODE_WIDTH=32  # Dummy value, irrelevant for Python 3
 CPYTHON_PATH="$(cpython_path ${PYTHON_VERSION} ${UNICODE_WIDTH})"

--- a/python/manylinux201x/Dockerfile-x86_64_base_2010
+++ b/python/manylinux201x/Dockerfile-x86_64_base_2010
@@ -17,7 +17,7 @@
 
 # See https://quay.io/repository/pypa/manylinux2010_x86_64?tab=tags
 # to update base image.
-FROM quay.io/pypa/manylinux2010_x86_64:2020-03-07-1825e8f
+FROM quay.io/pypa/manylinux2010_x86_64:2020-12-10-f10f3bb
 
 # Install build dependencies
 RUN yum install -y xz bison ccache flex wget
@@ -32,7 +32,7 @@ ADD scripts/build_zlib.sh /
 RUN /build_zlib.sh
 
 WORKDIR /
-RUN git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout 68a4af043e2adb0d9353d4a0e1f3d871203237aa
+RUN git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout 8882150df6529658700b66bec124dfb77eefca26
 # Remove unneeded Python versions
 RUN rm -rf /opt/_internal/cpython-2.7.*
 

--- a/python/manylinux201x/Dockerfile-x86_64_base_2014
+++ b/python/manylinux201x/Dockerfile-x86_64_base_2014
@@ -17,7 +17,7 @@
 
 # See https://quay.io/repository/pypa/manylinux2014_x86_64?tab=tags
 # to update base image.
-FROM quay.io/pypa/manylinux2014_x86_64:2020-03-07-06139da
+FROM quay.io/pypa/manylinux2014_x86_64:2020-12-10-c7182d6
 
 # Install build dependencies
 RUN yum install -y xz bison ccache flex wget
@@ -32,7 +32,7 @@ ADD scripts/build_zlib.sh /
 RUN /build_zlib.sh
 
 WORKDIR /
-RUN git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout 68a4af043e2adb0d9353d4a0e1f3d871203237aa
+RUN git clone https://github.com/matthew-brett/multibuild.git && cd multibuild && git checkout 8882150df6529658700b66bec124dfb77eefca26
 # Remove unneeded Python versions
 RUN rm -rf /opt/_internal/cpython-2.7.*
 

--- a/python/manylinux201x/build_arrow.sh
+++ b/python/manylinux201x/build_arrow.sh
@@ -62,7 +62,7 @@ export PKG_CONFIG_PATH=/usr/lib/pkgconfig:/arrow-dist/lib/pkgconfig
 mkdir -p /io/dist
 
 # Must pass PYTHON_VERSION env variable
-# possible values are: 3.6 3.7 3.8
+# possible values are: 3.6 3.7 3.8 3.9
 
 UNICODE_WIDTH=32  # Dummy value, irrelevant for Python 3
 CPYTHON_PATH="$(cpython_path ${PYTHON_VERSION} ${UNICODE_WIDTH})"

--- a/python/manylinux201x/scripts/install_cmake.sh
+++ b/python/manylinux201x/scripts/install_cmake.sh
@@ -18,6 +18,6 @@
 
 export CMAKE_VERSION=3.18.2.post1
 /opt/python/cp37-cp37m/bin/pip install cmake==${CMAKE_VERSION} ninja
-ln -s /opt/python/cp37-cp37m/bin/cmake /usr/local/bin/cmake
-ln -s /opt/python/cp37-cp37m/bin/ninja /usr/local/bin/ninja
+ln -fs /opt/python/cp37-cp37m/bin/cmake /usr/local/bin/cmake
+ln -fs /opt/python/cp37-cp37m/bin/ninja /usr/local/bin/ninja
 strip /opt/_internal/cpython-3.*/lib/python3.7/site-packages/cmake/data/bin/*

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1467,6 +1467,8 @@ class TestConvertDateTimeLikeTypes:
         expected = pd.Series([None, date(1991, 1, 1), None])
         assert pa.Array.from_pandas(expected).equals(result)
 
+    @pytest.mark.skipif('1.16.0' <= LooseVersion(np.__version__) < '1.16.1',
+                        reason='Until numpy/numpy#12745 is resolved')
     def test_fixed_offset_timezone(self):
         df = pd.DataFrame({
             'a': [
@@ -2830,7 +2832,7 @@ def _check_serialize_components_roundtrip(pd_obj):
         tm.assert_series_equal(pd_obj, deserialized)
 
 
-@pytest.mark.skipif(LooseVersion(np.__version__) >= '0.16',
+@pytest.mark.skipif('1.16.0' <= LooseVersion(np.__version__) < '1.16.1',
                     reason='Until numpy/numpy#12745 is resolved')
 def test_serialize_deserialize_pandas():
     # ARROW-1784, serialize and deserialize DataFrame by decomposing

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -19,7 +19,9 @@
 requires = [
     "cython >= 0.29",
     "numpy==1.14.5; python_version<'3.7'",
-    "numpy==1.16.0; python_version>='3.7'",
+    "numpy==1.16.0; python_version=='3.7'",
+    "numpy==1.17.3; python_version=='3.8'",
+    "numpy==1.19.3; python_version>='3.9'",
     "setuptools",
     "setuptools_scm",
     "wheel"

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,5 +1,7 @@
 cython>=0.29.11
-numpy==1.14.5; python_version < "3.8"
-numpy==1.17.3; python_version >= "3.8"
+numpy==1.14.5; python_version < "3.7"
+numpy==1.16.0; python_version == "3.7"
+numpy==1.17.3; python_version == "3.8"
+numpy==1.19.3; python_version >= "3.9"
 setuptools_scm
 wheel

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -1,8 +1,10 @@
 cffi
 cython
 hypothesis
-numpy==1.14.5; python_version < "3.8"
-numpy==1.17.3; python_version >= "3.8"
+numpy==1.14.5; python_version < "3.7"
+numpy==1.16.0; python_version == "3.7"
+numpy==1.17.3; python_version == "3.8"
+numpy==1.19.3; python_version >= "3.9"
 pandas<1.1.0; python_version < "3.8"
 pandas; python_version >= "3.8"
 pickle5; python_version == "3.6" or python_version == "3.7"

--- a/python/setup.py
+++ b/python/setup.py
@@ -627,6 +627,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
     license='Apache License, Version 2.0',
     maintainer='Apache Arrow Developers',


### PR DESCRIPTION
Adds support and testing for Python 3.9. I am looking for review as this change may have touched too many things, but I'm also looking to get the CI to test all the different environments.

H/T: @kou, the documentation and #5685 for helping me get this off the ground.