### PR TITLE
ARROW-10227: [Ruby] Use a table size as the default for parquet chunk_size

### DIFF
--- a/ruby/red-parquet/lib/parquet/arrow-table-savable.rb
+++ b/ruby/red-parquet/lib/parquet/arrow-table-savable.rb
@@ -33,7 +33,7 @@ module Parquet
           properties.__send__(set_method_name, value)
         end
       end
-      chunk_size = @options[:chunk_size] || 1024 # TODO
+      chunk_size = @options[:chunk_size] || @table.n_rows
       open_raw_output_stream do |output|
         ArrowFileWriter.open(@table.schema,
                              output,


### PR DESCRIPTION
A chunk_size that is too small will cause metadata bloat in the parquet file, leading to poor read performance. Set the chunk_size to be the same value as the table size so that one file becomes one row_group.
