### PR TITLE
ARROW-8426: [Rust] [Parquet] - Add more support for converting Dicts

### DIFF
--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -29,7 +29,7 @@ use crate::util::bit_util;
 /// An generic representation of Arrow array data which encapsulates common attributes and
 /// operations for Arrow array. Specific operations for different arrays types (e.g.,
 /// primitive, list, struct) are implemented in `Array`.
-#[derive(PartialEq, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct ArrayData {
     /// The data type for this array data
     data_type: DataType,
@@ -207,6 +207,61 @@ impl ArrayData {
 
         size
     }
+}
+
+impl PartialEq for ArrayData {
+    fn eq(&self, other: &Self) -> bool {
+        assert_eq!(
+            self.data_type(),
+            other.data_type(),
+            "Data types not the same"
+        );
+        assert_eq!(self.len(), other.len(), "Lengths not the same");
+        // TODO: when adding tests for this, test that we can compare with arrays that have offsets
+        assert_eq!(self.offset(), other.offset(), "Offsets not the same");
+        assert_eq!(self.null_count(), other.null_count());
+        // compare buffers excluding padding
+        let self_buffers = self.buffers();
+        let other_buffers = other.buffers();
+        assert_eq!(self_buffers.len(), other_buffers.len());
+        self_buffers.iter().zip(other_buffers).for_each(|(s, o)| {
+            compare_buffer_regions(
+                s,
+                self.offset(), // TODO mul by data length
+                o,
+                other.offset(), // TODO mul by data len
+            );
+        });
+        // assert_eq!(self.buffers(), other.buffers());
+
+        assert_eq!(self.child_data(), other.child_data());
+        // null arrays can skip the null bitmap, thus only compare if there are no nulls
+        if self.null_count() != 0 || other.null_count() != 0 {
+            compare_buffer_regions(
+                self.null_buffer().unwrap(),
+                self.offset(),
+                other.null_buffer().unwrap(),
+                other.offset(),
+            )
+        }
+        true
+    }
+}
+
+/// A helper to compare buffer regions of 2 buffers.
+/// Compares the length of the shorter buffer.
+fn compare_buffer_regions(
+    left: &Buffer,
+    left_offset: usize,
+    right: &Buffer,
+    right_offset: usize,
+) {
+    // for convenience, we assume that the buffer lengths are only unequal if one has padding,
+    // so we take the shorter length so we can discard the padding from the longer length
+    let shorter_len = left.len().min(right.len());
+    let s_sliced = left.bit_slice(left_offset, shorter_len);
+    let o_sliced = right.bit_slice(right_offset, shorter_len);
+    assert_eq!(s_sliced, o_sliced);
 }
 
 /// Builder for `ArrayData` type

--- a/rust/arrow/src/ipc/convert.rs
+++ b/rust/arrow/src/ipc/convert.rs
@@ -641,17 +641,23 @@ pub(crate) fn get_fb_dictionary<'a: 'b, 'b>(
     fbb: &mut FlatBufferBuilder<'a>,
 ) -> WIPOffset<ipc::DictionaryEncoding<'b>> {
     // We assume that the dictionary index type (as an integer) has already been
-    // validated elsewhere, and can safely assume we are dealing with signed
-    // integers
+    // validated elsewhere, and can safely assume we are dealing with integers
     let mut index_builder = ipc::IntBuilder::new(fbb);
-    index_builder.add_is_signed(true);
+
     match *index_type {
-        Int8 => index_builder.add_bitWidth(8),
-        Int16 => index_builder.add_bitWidth(16),
-        Int32 => index_builder.add_bitWidth(32),
-        Int64 => index_builder.add_bitWidth(64),
+        Int8 | Int16 | Int32 | Int64 => index_builder.add_is_signed(true),
+        UInt8 | UInt16 | UInt32 | UInt64 => index_builder.add_is_signed(false),
         _ => {}
     }
+
+    match *index_type {
+        Int8 | UInt8 => index_builder.add_bitWidth(8),
+        Int16 | UInt16 => index_builder.add_bitWidth(16),
+        Int32 | UInt32 => index_builder.add_bitWidth(32),
+        Int64 | UInt64 => index_builder.add_bitWidth(64),
+        _ => {}
+    }
+
     let index_builder = index_builder.finish();
 
     let mut builder = ipc::DictionaryEncodingBuilder::new(fbb);
@@ -768,6 +774,16 @@ mod tests {
                     DataType::Dictionary(
                         Box::new(DataType::Int32),
                         Box::new(DataType::Utf8),
+                    ),
+                    true,
+                    123,
+                    true,
+                ),
+                Field::new_dict(
+                    "dictionary<uint8, uint32>",
+                    DataType::Dictionary(
+                        Box::new(DataType::UInt8),
+                        Box::new(DataType::UInt32),
                     ),
                     true,
                     123,

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -1489,58 +1489,11 @@ impl<'a> ArrayReaderBuilder {
                             page_iterator, column_desc, converter
                         )?))
                     } else if let Some(ArrowType::Dictionary(key_type, _)) = arrow_type {
-                        match **key_type {
-                            ArrowType::Int8 => {
-                                let converter =
-                                    DictionaryConverter::new(DictionaryArrayConverter {});
-
-                                Ok(Box::new(ComplexObjectArrayReader::<
-                                    ByteArrayType,
-                                    DictionaryConverter<ArrowInt8Type>,
-                                >::new(
-                                    page_iterator, column_desc, converter
-                                )?))
-                            }
-                            ArrowType::Int16 => {
-                                let converter =
-                                    DictionaryConverter::new(DictionaryArrayConverter {});
-
-                                Ok(Box::new(ComplexObjectArrayReader::<
-                                    ByteArrayType,
-                                    DictionaryConverter<ArrowInt16Type>,
-                                >::new(
-                                    page_iterator, column_desc, converter
-                                )?))
-                            }
-                            ArrowType::Int32 => {
-                                let converter =
-                                    DictionaryConverter::new(DictionaryArrayConverter {});
-
-                                Ok(Box::new(ComplexObjectArrayReader::<
-                                    ByteArrayType,
-                                    DictionaryConverter<ArrowInt32Type>,
-                                >::new(
-                                    page_iterator, column_desc, converter
-                                )?))
-                            }
-                            ArrowType::Int64 => {
-                                let converter =
-                                    DictionaryConverter::new(DictionaryArrayConverter {});
-
-                                Ok(Box::new(ComplexObjectArrayReader::<
-                                    ByteArrayType,
-                                    DictionaryConverter<ArrowInt64Type>,
-                                >::new(
-                                    page_iterator, column_desc, converter
-                                )?))
-                            }
-                            ref other => {
-                                return Err(general_err!(
-                                    "Invalid/Unsupported index type for dictionary: {:?}",
-                                    other
-                                ))
-                            }
-                        }
+                        self.build_for_string_dictionary_type_inner(
+                            &*key_type,
+                            page_iterator,
+                            column_desc,
+                        )
                     } else {
                         let converter = Utf8Converter::new(Utf8ArrayConverter {});
                         Ok(Box::new(ComplexObjectArrayReader::<
@@ -1589,6 +1542,62 @@ impl<'a> ArrayReaderBuilder {
                 >::new(
                     page_iterator, column_desc, converter
                 )?))
+            }
+        }
+    }
+
+    fn build_for_string_dictionary_type_inner(
+        &self,
+        key_type: &ArrowType,
+        page_iterator: Box<dyn PageIterator>,
+        column_desc: ColumnDescPtr,
+    ) -> Result<Box<dyn ArrayReader>> {
+        match key_type {
+            ArrowType::Int8 => {
+                let converter = DictionaryConverter::new(DictionaryArrayConverter {});
+
+                Ok(Box::new(ComplexObjectArrayReader::<
+                    ByteArrayType,
+                    DictionaryConverter<ArrowInt8Type>,
+                >::new(
+                    page_iterator, column_desc, converter
+                )?))
+            }
+            ArrowType::Int16 => {
+                let converter = DictionaryConverter::new(DictionaryArrayConverter {});
+
+                Ok(Box::new(ComplexObjectArrayReader::<
+                    ByteArrayType,
+                    DictionaryConverter<ArrowInt16Type>,
+                >::new(
+                    page_iterator, column_desc, converter
+                )?))
+            }
+            ArrowType::Int32 => {
+                let converter = DictionaryConverter::new(DictionaryArrayConverter {});
+
+                Ok(Box::new(ComplexObjectArrayReader::<
+                    ByteArrayType,
+                    DictionaryConverter<ArrowInt32Type>,
+                >::new(
+                    page_iterator, column_desc, converter
+                )?))
+            }
+            ArrowType::Int64 => {
+                let converter = DictionaryConverter::new(DictionaryArrayConverter {});
+
+                Ok(Box::new(ComplexObjectArrayReader::<
+                    ByteArrayType,
+                    DictionaryConverter<ArrowInt64Type>,
+                >::new(
+                    page_iterator, column_desc, converter
+                )?))
+            }
+            ref other => {
+                return Err(general_err!(
+                    "Invalid/Unsupported index type for dictionary: {:?}",
+                    other
+                ))
             }
         }
     }

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -1488,8 +1488,7 @@ impl<'a> ArrayReaderBuilder {
                         >::new(
                             page_iterator, column_desc, converter
                         )?))
-                    } else if let Some(ArrowType::Dictionary(key_type, _)) = arrow_type
-                    {
+                    } else if let Some(ArrowType::Dictionary(key_type, _)) = arrow_type {
                         match **key_type {
                             ArrowType::Int8 => {
                                 let converter =

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -57,14 +57,14 @@ use arrow::util::bit_util;
 
 use crate::arrow::converter::{
     BinaryArrayConverter, BinaryConverter, BoolConverter, BooleanArrayConverter,
-    Converter, Date32Converter, FixedLenBinaryConverter, FixedSizeArrayConverter,
-    Float32Converter, Float64Converter, Int16Converter, Int32Converter, Int64Converter,
-    Int8Converter, Int96ArrayConverter, Int96Converter, LargeBinaryArrayConverter,
-    LargeBinaryConverter, LargeUtf8ArrayConverter, LargeUtf8Converter,
-    Time32MillisecondConverter, Time32SecondConverter, Time64MicrosecondConverter,
-    Time64NanosecondConverter, TimestampMicrosecondConverter,
-    TimestampMillisecondConverter, UInt16Converter, UInt32Converter, UInt64Converter,
-    UInt8Converter, Utf8ArrayConverter, Utf8Converter,
+    Converter, Date32Converter, DictionaryArrayConverter, DictionaryConverter,
+    FixedLenBinaryConverter, FixedSizeArrayConverter, Float32Converter, Float64Converter,
+    Int16Converter, Int32Converter, Int64Converter, Int8Converter, Int96ArrayConverter,
+    Int96Converter, LargeBinaryArrayConverter, LargeBinaryConverter,
+    LargeUtf8ArrayConverter, LargeUtf8Converter, Time32MillisecondConverter,
+    Time32SecondConverter, Time64MicrosecondConverter, Time64NanosecondConverter,
+    TimestampMicrosecondConverter, TimestampMillisecondConverter, UInt16Converter,
+    UInt32Converter, UInt64Converter, UInt8Converter, Utf8ArrayConverter, Utf8Converter,
 };
 use crate::arrow::record_reader::RecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
@@ -1488,6 +1488,60 @@ impl<'a> ArrayReaderBuilder {
                         >::new(
                             page_iterator, column_desc, converter
                         )?))
+                    } else if let Some(ArrowType::Dictionary(index_type, _)) = arrow_type
+                    {
+                        match **index_type {
+                            ArrowType::Int8 => {
+                                let converter =
+                                    DictionaryConverter::new(DictionaryArrayConverter {});
+
+                                Ok(Box::new(ComplexObjectArrayReader::<
+                                    ByteArrayType,
+                                    DictionaryConverter<ArrowInt8Type>,
+                                >::new(
+                                    page_iterator, column_desc, converter
+                                )?))
+                            }
+                            ArrowType::Int16 => {
+                                let converter =
+                                    DictionaryConverter::new(DictionaryArrayConverter {});
+
+                                Ok(Box::new(ComplexObjectArrayReader::<
+                                    ByteArrayType,
+                                    DictionaryConverter<ArrowInt16Type>,
+                                >::new(
+                                    page_iterator, column_desc, converter
+                                )?))
+                            }
+                            ArrowType::Int32 => {
+                                let converter =
+                                    DictionaryConverter::new(DictionaryArrayConverter {});
+
+                                Ok(Box::new(ComplexObjectArrayReader::<
+                                    ByteArrayType,
+                                    DictionaryConverter<ArrowInt32Type>,
+                                >::new(
+                                    page_iterator, column_desc, converter
+                                )?))
+                            }
+                            ArrowType::Int64 => {
+                                let converter =
+                                    DictionaryConverter::new(DictionaryArrayConverter {});
+
+                                Ok(Box::new(ComplexObjectArrayReader::<
+                                    ByteArrayType,
+                                    DictionaryConverter<ArrowInt64Type>,
+                                >::new(
+                                    page_iterator, column_desc, converter
+                                )?))
+                            }
+                            ref other => {
+                                return Err(general_err!(
+                                    "Invalid/Unsupported index type for dictionary: {:?}",
+                                    other
+                                ))
+                            }
+                        }
                     } else {
                         let converter = Utf8Converter::new(Utf8ArrayConverter {});
                         Ok(Box::new(ComplexObjectArrayReader::<

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -1581,6 +1581,10 @@ impl<'a> ArrayReaderBuilder {
             (ArrowType::Int16, ArrowInt16Type),
             (ArrowType::Int32, ArrowInt32Type),
             (ArrowType::Int64, ArrowInt64Type),
+            (ArrowType::UInt8, ArrowUInt8Type),
+            (ArrowType::UInt16, ArrowUInt16Type),
+            (ArrowType::UInt32, ArrowUInt32Type),
+            (ArrowType::UInt64, ArrowUInt64Type),
         )
     }
 

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -1488,9 +1488,9 @@ impl<'a> ArrayReaderBuilder {
                         >::new(
                             page_iterator, column_desc, converter
                         )?))
-                    } else if let Some(ArrowType::Dictionary(index_type, _)) = arrow_type
+                    } else if let Some(ArrowType::Dictionary(key_type, _)) = arrow_type
                     {
-                        match **index_type {
+                        match **key_type {
                             ArrowType::Int8 => {
                                 let converter =
                                     DictionaryConverter::new(DictionaryArrayConverter {});

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -1552,54 +1552,36 @@ impl<'a> ArrayReaderBuilder {
         page_iterator: Box<dyn PageIterator>,
         column_desc: ColumnDescPtr,
     ) -> Result<Box<dyn ArrayReader>> {
-        match key_type {
-            ArrowType::Int8 => {
-                let converter = DictionaryConverter::new(DictionaryArrayConverter {});
+        macro_rules! convert_string_dictionary {
+            ($(($kt: pat, $at: ident),)*) => (
+                match key_type {
+                    $($kt => {
+                        let converter = DictionaryConverter::new(DictionaryArrayConverter {});
 
-                Ok(Box::new(ComplexObjectArrayReader::<
-                    ByteArrayType,
-                    DictionaryConverter<ArrowInt8Type>,
-                >::new(
-                    page_iterator, column_desc, converter
-                )?))
-            }
-            ArrowType::Int16 => {
-                let converter = DictionaryConverter::new(DictionaryArrayConverter {});
+                        Ok(Box::new(ComplexObjectArrayReader::<
+                            ByteArrayType,
+                            DictionaryConverter<$at>,
+                        >::new(
+                            page_iterator, column_desc, converter
+                        )?))
 
-                Ok(Box::new(ComplexObjectArrayReader::<
-                    ByteArrayType,
-                    DictionaryConverter<ArrowInt16Type>,
-                >::new(
-                    page_iterator, column_desc, converter
-                )?))
-            }
-            ArrowType::Int32 => {
-                let converter = DictionaryConverter::new(DictionaryArrayConverter {});
-
-                Ok(Box::new(ComplexObjectArrayReader::<
-                    ByteArrayType,
-                    DictionaryConverter<ArrowInt32Type>,
-                >::new(
-                    page_iterator, column_desc, converter
-                )?))
-            }
-            ArrowType::Int64 => {
-                let converter = DictionaryConverter::new(DictionaryArrayConverter {});
-
-                Ok(Box::new(ComplexObjectArrayReader::<
-                    ByteArrayType,
-                    DictionaryConverter<ArrowInt64Type>,
-                >::new(
-                    page_iterator, column_desc, converter
-                )?))
-            }
-            ref other => {
-                return Err(general_err!(
-                    "Invalid/Unsupported index type for dictionary: {:?}",
-                    other
-                ))
-            }
+                    })*
+                    ref other => {
+                        return Err(general_err!(
+                            "Invalid/Unsupported index type for dictionary: {:?}",
+                            other
+                        ))
+                    }
+                }
+            );
         }
+
+        convert_string_dictionary!(
+            (ArrowType::Int8, ArrowInt8Type),
+            (ArrowType::Int16, ArrowInt16Type),
+            (ArrowType::Int32, ArrowInt32Type),
+            (ArrowType::Int64, ArrowInt64Type),
+        )
     }
 
     /// Constructs struct array reader without considering repetition.

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -492,7 +492,6 @@ where
             data_buffer.into_iter().map(Some).collect()
         };
 
-        // TODO: I did this quickly without thinking through it, there might be edge cases to consider
         let mut array = self.converter.convert(data)?;
 
         if let ArrowType::Dictionary(_, _) = self.data_type {

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -453,12 +453,13 @@ where
         };
 
         // TODO: I did this quickly without thinking through it, there might be edge cases to consider
-        let array = self.converter.convert(data)?;
+        let mut array = self.converter.convert(data)?;
 
-        Ok(match self.data_type {
-            ArrowType::Dictionary(_, _) => arrow::compute::cast(&array, &self.data_type)?,
-            _ => array,
-        })
+        if let ArrowType::Dictionary(_, _) = self.data_type {
+            array = arrow::compute::cast(&array, &self.data_type)?;
+        }
+
+        Ok(array)
     }
 
     fn get_def_levels(&self) -> Option<&[i16]> {

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -34,19 +34,19 @@ use arrow::array::{
 use arrow::buffer::{Buffer, MutableBuffer};
 use arrow::datatypes::{
     BooleanType as ArrowBooleanType, DataType as ArrowType,
-    Date32Type as ArrowDate32Type, Date64Type as ArrowDate64Type, DateUnit,
+    Date32Type as ArrowDate32Type, Date64Type as ArrowDate64Type,
     DurationMicrosecondType as ArrowDurationMicrosecondType,
     DurationMillisecondType as ArrowDurationMillisecondType,
     DurationNanosecondType as ArrowDurationNanosecondType,
     DurationSecondType as ArrowDurationSecondType, Field,
     Float32Type as ArrowFloat32Type, Float64Type as ArrowFloat64Type,
     Int16Type as ArrowInt16Type, Int32Type as ArrowInt32Type,
-    Int64Type as ArrowInt64Type, Int8Type as ArrowInt8Type, IntervalUnit, Schema,
+    Int64Type as ArrowInt64Type, Int8Type as ArrowInt8Type, Schema,
     Time32MillisecondType as ArrowTime32MillisecondType,
     Time32SecondType as ArrowTime32SecondType,
     Time64MicrosecondType as ArrowTime64MicrosecondType,
-    Time64NanosecondType as ArrowTime64NanosecondType, TimeUnit,
-    TimeUnit as ArrowTimeUnit, TimestampMicrosecondType as ArrowTimestampMicrosecondType,
+    Time64NanosecondType as ArrowTime64NanosecondType, TimeUnit as ArrowTimeUnit,
+    TimestampMicrosecondType as ArrowTimestampMicrosecondType,
     TimestampMillisecondType as ArrowTimestampMillisecondType,
     TimestampNanosecondType as ArrowTimestampNanosecondType,
     TimestampSecondType as ArrowTimestampSecondType, ToByteSlice,
@@ -57,15 +57,10 @@ use arrow::util::bit_util;
 
 use crate::arrow::converter::{
     BinaryArrayConverter, BinaryConverter, BoolConverter, BooleanArrayConverter,
-    Converter, Date32Converter, DictionaryArrayConverter, FixedLenBinaryConverter,
-    FixedSizeArrayConverter, Float32Converter, Float64Converter, Int16Converter,
-    Int32Converter, Int64Converter, Int8Converter, Int96ArrayConverter, Int96Converter,
-    LargeBinaryArrayConverter, LargeBinaryConverter, LargeUtf8ArrayConverter,
-    LargeUtf8Converter, PrimitiveDictionaryConverter, StringDictionaryArrayConverter,
-    StringDictionaryConverter, Time32MillisecondConverter, Time32SecondConverter,
-    Time64MicrosecondConverter, Time64NanosecondConverter, TimestampMicrosecondConverter,
-    TimestampMillisecondConverter, UInt16Converter, UInt32Converter, UInt64Converter,
-    UInt8Converter, Utf8ArrayConverter, Utf8Converter,
+    Converter, FixedLenBinaryConverter, FixedSizeArrayConverter, Float32Converter,
+    Float64Converter, Int32Converter, Int64Converter, Int96ArrayConverter,
+    Int96Converter, LargeBinaryArrayConverter, LargeBinaryConverter,
+    LargeUtf8ArrayConverter, LargeUtf8Converter, Utf8ArrayConverter, Utf8Converter,
 };
 use crate::arrow::record_reader::RecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
@@ -213,10 +208,15 @@ impl<T: DataType> PrimitiveArrayReader<T> {
     pub fn new(
         mut pages: Box<dyn PageIterator>,
         column_desc: ColumnDescPtr,
+        arrow_type: Option<ArrowType>,
     ) -> Result<Self> {
-        let data_type = parquet_to_arrow_field(column_desc.as_ref())?
-            .data_type()
-            .clone();
+        // Check if Arrow type is specified, else create it from Parquet type
+        let data_type = match arrow_type {
+            Some(t) => t,
+            None => parquet_to_arrow_field(column_desc.as_ref())?
+                .data_type()
+                .clone(),
+        };
 
         let mut record_reader = RecordReader::<T>::new(column_desc.clone());
         if let Some(page_reader) = pages.next() {
@@ -268,90 +268,39 @@ impl<T: DataType> ArrayReader for PrimitiveArrayReader<T> {
             }
         }
 
-        // convert to arrays
+        // Convert to arrays by using the Parquet phyisical type.
+        // The physical types are then cast to Arrow types if necessary
         let array =
-            match (&self.data_type, T::get_physical_type()) {
-                (ArrowType::Boolean, PhysicalType::BOOLEAN) => {
-                    BoolConverter::new(BooleanArrayConverter {})
-                        .convert(self.record_reader.cast::<BoolType>())
-                }
-                (ArrowType::Int8, PhysicalType::INT32) => {
-                    Int8Converter::new().convert(self.record_reader.cast::<Int32Type>())
-                }
-                (ArrowType::Int16, PhysicalType::INT32) => {
-                    Int16Converter::new().convert(self.record_reader.cast::<Int32Type>())
-                }
-                (ArrowType::Int32, PhysicalType::INT32) => {
+            match T::get_physical_type() {
+                PhysicalType::BOOLEAN => BoolConverter::new(BooleanArrayConverter {})
+                    .convert(self.record_reader.cast::<BoolType>()),
+                PhysicalType::INT32 => {
+                    // TODO: the cast is a no-op, but we should remove it
                     Int32Converter::new().convert(self.record_reader.cast::<Int32Type>())
                 }
-                (ArrowType::UInt8, PhysicalType::INT32) => {
-                    UInt8Converter::new().convert(self.record_reader.cast::<Int32Type>())
-                }
-                (ArrowType::UInt16, PhysicalType::INT32) => {
-                    UInt16Converter::new().convert(self.record_reader.cast::<Int32Type>())
-                }
-                (ArrowType::UInt32, PhysicalType::INT32) => {
-                    UInt32Converter::new().convert(self.record_reader.cast::<Int32Type>())
-                }
-                (ArrowType::Int64, PhysicalType::INT64) => {
+                PhysicalType::INT64 => {
                     Int64Converter::new().convert(self.record_reader.cast::<Int64Type>())
                 }
-                (ArrowType::UInt64, PhysicalType::INT64) => {
-                    UInt64Converter::new().convert(self.record_reader.cast::<Int64Type>())
-                }
-                (ArrowType::Float32, PhysicalType::FLOAT) => Float32Converter::new()
+                PhysicalType::FLOAT => Float32Converter::new()
                     .convert(self.record_reader.cast::<FloatType>()),
-                (ArrowType::Float64, PhysicalType::DOUBLE) => Float64Converter::new()
+                PhysicalType::DOUBLE => Float64Converter::new()
                     .convert(self.record_reader.cast::<DoubleType>()),
-                (ArrowType::Timestamp(unit, _), PhysicalType::INT64) => match unit {
-                    TimeUnit::Millisecond => TimestampMillisecondConverter::new()
-                        .convert(self.record_reader.cast::<Int64Type>()),
-                    TimeUnit::Microsecond => TimestampMicrosecondConverter::new()
-                        .convert(self.record_reader.cast::<Int64Type>()),
-                    _ => Err(general_err!("No conversion from parquet type to arrow type for timestamp with unit {:?}", unit)),
-                },
-                (ArrowType::Date32(unit), PhysicalType::INT32) => match unit {
-                    DateUnit::Day => Date32Converter::new()
-                        .convert(self.record_reader.cast::<Int32Type>()),
-                    _ => Err(general_err!("No conversion from parquet type to arrow type for date with unit {:?}", unit)),
+                PhysicalType::INT96
+                | PhysicalType::BYTE_ARRAY
+                | PhysicalType::FIXED_LEN_BYTE_ARRAY => {
+                    // TODO: we could use unreachable!() as this is a private fn
+                    Err(general_err!(
+                        "Cannot read primitive array with a complex physical type"
+                    ))
                 }
-                (ArrowType::Time32(unit), PhysicalType::INT32) => {
-                    match unit {
-                        TimeUnit::Second => {
-                            Time32SecondConverter::new().convert(self.record_reader.cast::<Int32Type>())
-                        }
-                        TimeUnit::Millisecond => {
-                            Time32MillisecondConverter::new().convert(self.record_reader.cast::<Int32Type>())
-                        }
-                        _ => Err(general_err!("Invalid or unsupported arrow array with datatype {:?}", self.get_data_type()))
-                    }
-                }
-                (ArrowType::Time64(unit), PhysicalType::INT64) => {
-                    match unit {
-                        TimeUnit::Microsecond => {
-                            Time64MicrosecondConverter::new().convert(self.record_reader.cast::<Int64Type>())
-                        }
-                        TimeUnit::Nanosecond => {
-                            Time64NanosecondConverter::new().convert(self.record_reader.cast::<Int64Type>())
-                        }
-                        _ => Err(general_err!("Invalid or unsupported arrow array with datatype {:?}", self.get_data_type()))
-                    }
-                }
-                (ArrowType::Interval(IntervalUnit::YearMonth), PhysicalType::INT32) => {
-                    UInt32Converter::new().convert(self.record_reader.cast::<Int32Type>())
-                }
-                (ArrowType::Interval(IntervalUnit::DayTime), PhysicalType::INT64) => {
-                    UInt64Converter::new().convert(self.record_reader.cast::<Int64Type>())
-                }
-                (ArrowType::Duration(_), PhysicalType::INT64) => {
-                    UInt64Converter::new().convert(self.record_reader.cast::<Int64Type>())
-                }
-                (arrow_type, physical_type) => Err(general_err!(
-                    "Reading {:?} type from parquet {:?} is not supported yet.",
-                    arrow_type,
-                    physical_type
-                )),
             }?;
+
+        // cast to Arrow type
+        // TODO: we need to check if it's fine for this to be fallible.
+        // My assumption is that we can't get to an illegal cast as we can only
+        // generate types that are supported, because we'd have gotten them from
+        // the metadata which was written to the Parquet sink
+        let array = arrow::compute::cast(&array, self.get_data_type())?;
 
         // save definition and repetition buffers
         self.def_levels_buffer = self.record_reader.consume_def_levels()?;
@@ -504,7 +453,13 @@ where
             data_buffer.into_iter().map(Some).collect()
         };
 
-        self.converter.convert(data)
+        // TODO: I did this quickly without thinking through it, there might be edge cases to consider
+        let array = self.converter.convert(data)?;
+
+        Ok(match self.data_type {
+            ArrowType::Dictionary(_, _) => arrow::compute::cast(&array, &self.data_type)?,
+            _ => array,
+        })
     }
 
     fn get_def_levels(&self) -> Option<&[i16]> {
@@ -525,10 +480,14 @@ where
         pages: Box<dyn PageIterator>,
         column_desc: ColumnDescPtr,
         converter: C,
+        arrow_type: Option<ArrowType>,
     ) -> Result<Self> {
-        let data_type = parquet_to_arrow_field(column_desc.as_ref())?
-            .data_type()
-            .clone();
+        let data_type = match arrow_type {
+            Some(t) => t,
+            None => parquet_to_arrow_field(column_desc.as_ref())?
+                .data_type()
+                .clone(),
+        };
 
         Ok(Self {
             data_type,
@@ -1438,236 +1397,134 @@ impl<'a> ArrayReaderBuilder {
             .arrow_schema
             .field_with_name(cur_type.name())
             .ok()
-            .map(|f| f.data_type());
+            .map(|f| f.data_type())
+            .cloned();
 
-        if let Some(ArrowType::Dictionary(key_type, value_type)) = arrow_type {
-            match cur_type.get_physical_type() {
-                PhysicalType::BYTE_ARRAY => {
-                    let logical_type = cur_type.get_basic_info().logical_type();
-                    if logical_type == LogicalType::UTF8 {
-                        self.build_for_string_dictionary_type_inner(
-                            &*key_type,
-                            page_iterator,
-                            column_desc,
-                        )
-                    } else {
-                        panic!("logical type not handled yet: {:?}", logical_type);
-                    }
-                }
-                PhysicalType::INT32 => {
-                    if let ArrowType::UInt8 = **key_type {
-                        if let ArrowType::UInt32 = **value_type {
-                            let converter = PrimitiveDictionaryConverter::<
-                                ArrowUInt8Type,
-                                ArrowUInt32Type,
-                            >::new(
-                                DictionaryArrayConverter::new()
-                            );
-                            return Ok(Box::new(
-                                ComplexObjectArrayReader::<Int32Type, _>::new(
-                                    page_iterator,
-                                    column_desc,
-                                    converter,
-                                )?,
-                            ));
-                        } else if let ArrowType::Int32 = **value_type {
-                            let converter = PrimitiveDictionaryConverter::<
-                                ArrowUInt8Type,
-                                ArrowInt32Type,
-                            >::new(
-                                DictionaryArrayConverter::new()
-                            );
-                            return Ok(Box::new(
-                                ComplexObjectArrayReader::<Int32Type, _>::new(
-                                    page_iterator,
-                                    column_desc,
-                                    converter,
-                                )?,
-                            ));
-                        } else {
-                            panic!("byeagain");
-                        }
-                    } else if let ArrowType::UInt16 = **key_type {
-                        if let ArrowType::UInt32 = **value_type {
-                            let converter = PrimitiveDictionaryConverter::<
-                                ArrowUInt16Type,
-                                ArrowUInt32Type,
-                            >::new(
-                                DictionaryArrayConverter::new()
-                            );
-                            return Ok(Box::new(
-                                ComplexObjectArrayReader::<Int32Type, _>::new(
-                                    page_iterator,
-                                    column_desc,
-                                    converter,
-                                )?,
-                            ));
-                        } else if let ArrowType::Int32 = **value_type {
-                            let converter = PrimitiveDictionaryConverter::<
-                                ArrowUInt16Type,
-                                ArrowInt32Type,
-                            >::new(
-                                DictionaryArrayConverter::new()
-                            );
-                            return Ok(Box::new(
-                                ComplexObjectArrayReader::<Int32Type, _>::new(
-                                    page_iterator,
-                                    column_desc,
-                                    converter,
-                                )?,
-                            ));
-                        } else {
-                            panic!("byeagain");
-                        }
-                    } else {
-                        panic!("bye");
-                    }
-                    unimplemented!();
-                }
-                other => panic!("physical type not handled yet: {:?}", other),
-            }
-        } else {
-            match cur_type.get_physical_type() {
-                PhysicalType::BOOLEAN => Ok(Box::new(
-                    PrimitiveArrayReader::<BoolType>::new(page_iterator, column_desc)?,
-                )),
-                PhysicalType::INT32 => {
-                    if let Some(ArrowType::Null) = arrow_type {
-                        Ok(Box::new(NullArrayReader::<Int32Type>::new(
-                            page_iterator,
-                            column_desc,
-                        )?))
-                    } else {
-                        Ok(Box::new(PrimitiveArrayReader::<Int32Type>::new(
-                            page_iterator,
-                            column_desc,
-                        )?))
-                    }
-                }
-                PhysicalType::INT64 => Ok(Box::new(
-                    PrimitiveArrayReader::<Int64Type>::new(page_iterator, column_desc)?,
-                )),
-                PhysicalType::INT96 => {
-                    let converter = Int96Converter::new(Int96ArrayConverter {});
-                    Ok(Box::new(ComplexObjectArrayReader::<
-                        Int96Type,
-                        Int96Converter,
-                    >::new(
-                        page_iterator, column_desc, converter
+        match cur_type.get_physical_type() {
+            PhysicalType::BOOLEAN => Ok(Box::new(PrimitiveArrayReader::<BoolType>::new(
+                page_iterator,
+                column_desc,
+                arrow_type,
+            )?)),
+            PhysicalType::INT32 => {
+                if let Some(ArrowType::Null) = arrow_type {
+                    Ok(Box::new(NullArrayReader::<Int32Type>::new(
+                        page_iterator,
+                        column_desc,
+                    )?))
+                } else {
+                    Ok(Box::new(PrimitiveArrayReader::<Int32Type>::new(
+                        page_iterator,
+                        column_desc,
+                        arrow_type,
                     )?))
                 }
-                PhysicalType::FLOAT => Ok(Box::new(
-                    PrimitiveArrayReader::<FloatType>::new(page_iterator, column_desc)?,
-                )),
-                PhysicalType::DOUBLE => Ok(Box::new(
-                    PrimitiveArrayReader::<DoubleType>::new(page_iterator, column_desc)?,
-                )),
-                PhysicalType::BYTE_ARRAY => {
-                    if cur_type.get_basic_info().logical_type() == LogicalType::UTF8 {
-                        if let Some(ArrowType::LargeUtf8) = arrow_type {
-                            let converter =
-                                LargeUtf8Converter::new(LargeUtf8ArrayConverter {});
-                            Ok(Box::new(ComplexObjectArrayReader::<
-                                ByteArrayType,
-                                LargeUtf8Converter,
-                            >::new(
-                                page_iterator, column_desc, converter
-                            )?))
-                        } else if let Some(ArrowType::Dictionary(_, _)) = arrow_type {
-                            unreachable!();
-                        } else {
-                            let converter = Utf8Converter::new(Utf8ArrayConverter {});
-                            Ok(Box::new(ComplexObjectArrayReader::<
-                                ByteArrayType,
-                                Utf8Converter,
-                            >::new(
-                                page_iterator, column_desc, converter
-                            )?))
-                        }
-                    } else if let Some(ArrowType::LargeBinary) = arrow_type {
+            }
+            PhysicalType::INT64 => Ok(Box::new(PrimitiveArrayReader::<Int64Type>::new(
+                page_iterator,
+                column_desc,
+                arrow_type,
+            )?)),
+            PhysicalType::INT96 => {
+                let converter = Int96Converter::new(Int96ArrayConverter {});
+                Ok(Box::new(ComplexObjectArrayReader::<
+                    Int96Type,
+                    Int96Converter,
+                >::new(
+                    page_iterator,
+                    column_desc,
+                    converter,
+                    arrow_type,
+                )?))
+            }
+            PhysicalType::FLOAT => Ok(Box::new(PrimitiveArrayReader::<FloatType>::new(
+                page_iterator,
+                column_desc,
+                arrow_type,
+            )?)),
+            PhysicalType::DOUBLE => {
+                Ok(Box::new(PrimitiveArrayReader::<DoubleType>::new(
+                    page_iterator,
+                    column_desc,
+                    arrow_type,
+                )?))
+            }
+            PhysicalType::BYTE_ARRAY => {
+                if cur_type.get_basic_info().logical_type() == LogicalType::UTF8 {
+                    if let Some(ArrowType::LargeUtf8) = arrow_type {
                         let converter =
-                            LargeBinaryConverter::new(LargeBinaryArrayConverter {});
+                            LargeUtf8Converter::new(LargeUtf8ArrayConverter {});
                         Ok(Box::new(ComplexObjectArrayReader::<
                             ByteArrayType,
-                            LargeBinaryConverter,
+                            LargeUtf8Converter,
                         >::new(
-                            page_iterator, column_desc, converter
+                            page_iterator,
+                            column_desc,
+                            converter,
+                            arrow_type,
                         )?))
                     } else {
-                        let converter = BinaryConverter::new(BinaryArrayConverter {});
+                        let converter = Utf8Converter::new(Utf8ArrayConverter {});
                         Ok(Box::new(ComplexObjectArrayReader::<
                             ByteArrayType,
-                            BinaryConverter,
+                            Utf8Converter,
                         >::new(
-                            page_iterator, column_desc, converter
+                            page_iterator,
+                            column_desc,
+                            converter,
+                            arrow_type,
                         )?))
                     }
-                }
-                PhysicalType::FIXED_LEN_BYTE_ARRAY => {
-                    let byte_width = match *cur_type {
-                        Type::PrimitiveType {
-                            ref type_length, ..
-                        } => *type_length,
-                        _ => {
-                            return Err(ArrowError(
-                                "Expected a physical type, not a group type".to_string(),
-                            ))
-                        }
-                    };
-                    let converter = FixedLenBinaryConverter::new(
-                        FixedSizeArrayConverter::new(byte_width),
-                    );
+                } else if let Some(ArrowType::LargeBinary) = arrow_type {
+                    let converter =
+                        LargeBinaryConverter::new(LargeBinaryArrayConverter {});
                     Ok(Box::new(ComplexObjectArrayReader::<
-                        FixedLenByteArrayType,
-                        FixedLenBinaryConverter,
+                        ByteArrayType,
+                        LargeBinaryConverter,
                     >::new(
-                        page_iterator, column_desc, converter
+                        page_iterator,
+                        column_desc,
+                        converter,
+                        arrow_type,
+                    )?))
+                } else {
+                    let converter = BinaryConverter::new(BinaryArrayConverter {});
+                    Ok(Box::new(ComplexObjectArrayReader::<
+                        ByteArrayType,
+                        BinaryConverter,
+                    >::new(
+                        page_iterator,
+                        column_desc,
+                        converter,
+                        arrow_type,
                     )?))
                 }
             }
-        }
-    }
-
-    fn build_for_string_dictionary_type_inner(
-        &self,
-        key_type: &ArrowType,
-        page_iterator: Box<dyn PageIterator>,
-        column_desc: ColumnDescPtr,
-    ) -> Result<Box<dyn ArrayReader>> {
-        macro_rules! convert_string_dictionary {
-            ($(($kt: pat, $at: ident),)*) => (
-                match key_type {
-                    $($kt => {
-                        let converter = StringDictionaryConverter::new(StringDictionaryArrayConverter {});
-
-                        Ok(Box::new(ComplexObjectArrayReader::<
-                            ByteArrayType,
-                            StringDictionaryConverter<$at>,
-                        >::new(
-                            page_iterator, column_desc, converter
-                        )?))
-
-                    })*
-                    ref other => {
-                        return Err(general_err!(
-                            "Invalid/Unsupported index type for dictionary: {:?}",
-                            other
+            PhysicalType::FIXED_LEN_BYTE_ARRAY => {
+                let byte_width = match *cur_type {
+                    Type::PrimitiveType {
+                        ref type_length, ..
+                    } => *type_length,
+                    _ => {
+                        return Err(ArrowError(
+                            "Expected a physical type, not a group type".to_string(),
                         ))
                     }
-                }
-            );
+                };
+                let converter = FixedLenBinaryConverter::new(
+                    FixedSizeArrayConverter::new(byte_width),
+                );
+                Ok(Box::new(ComplexObjectArrayReader::<
+                    FixedLenByteArrayType,
+                    FixedLenBinaryConverter,
+                >::new(
+                    page_iterator,
+                    column_desc,
+                    converter,
+                    arrow_type,
+                )?))
+            }
         }
-
-        convert_string_dictionary!(
-            (ArrowType::Int8, ArrowInt8Type),
-            (ArrowType::Int16, ArrowInt16Type),
-            (ArrowType::Int32, ArrowInt32Type),
-            (ArrowType::Int64, ArrowInt64Type),
-            (ArrowType::UInt8, ArrowUInt8Type),
-            (ArrowType::UInt16, ArrowUInt16Type),
-            (ArrowType::UInt32, ArrowUInt32Type),
-            (ArrowType::UInt64, ArrowUInt64Type),
-        )
     }
 
     /// Constructs struct array reader without considering repetition.
@@ -1801,9 +1658,12 @@ mod tests {
         let column_desc = schema.column(0);
         let page_iterator = EmptyPageIterator::new(schema);
 
-        let mut array_reader =
-            PrimitiveArrayReader::<Int32Type>::new(Box::new(page_iterator), column_desc)
-                .unwrap();
+        let mut array_reader = PrimitiveArrayReader::<Int32Type>::new(
+            Box::new(page_iterator),
+            column_desc,
+            None,
+        )
+        .unwrap();
 
         // expect no values to be read
         let array = array_reader.next_batch(50).unwrap();
@@ -1848,6 +1708,7 @@ mod tests {
             let mut array_reader = PrimitiveArrayReader::<Int32Type>::new(
                 Box::new(page_iterator),
                 column_desc,
+                None,
             )
             .unwrap();
 
@@ -1931,6 +1792,7 @@ mod tests {
                 let mut array_reader = PrimitiveArrayReader::<$arrow_parquet_type>::new(
                     Box::new(page_iterator),
                     column_desc.clone(),
+                    None,
                 )
                 .expect("Unable to get array reader");
 
@@ -2064,6 +1926,7 @@ mod tests {
             let mut array_reader = PrimitiveArrayReader::<Int32Type>::new(
                 Box::new(page_iterator),
                 column_desc,
+                None,
             )
             .unwrap();
 
@@ -2177,6 +2040,7 @@ mod tests {
                 Box::new(page_iterator),
                 column_desc,
                 converter,
+                None,
             )
             .unwrap();
 

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -288,10 +288,9 @@ impl<T: DataType> ArrayReader for PrimitiveArrayReader<T> {
                 PhysicalType::INT96
                 | PhysicalType::BYTE_ARRAY
                 | PhysicalType::FIXED_LEN_BYTE_ARRAY => {
-                    // TODO: we could use unreachable!() as this is a private fn
-                    Err(general_err!(
-                        "Cannot read primitive array with a complex physical type"
-                    ))
+                    unreachable!(
+                        "PrimitiveArrayReaders don't support complex physical types"
+                    );
                 }
             }?;
 

--- a/rust/parquet/src/arrow/array_reader.rs
+++ b/rust/parquet/src/arrow/array_reader.rs
@@ -61,11 +61,11 @@ use crate::arrow::converter::{
     FixedSizeArrayConverter, Float32Converter, Float64Converter, Int16Converter,
     Int32Converter, Int64Converter, Int8Converter, Int96ArrayConverter, Int96Converter,
     LargeBinaryArrayConverter, LargeBinaryConverter, LargeUtf8ArrayConverter,
-    LargeUtf8Converter, StringDictionaryArrayConverter, StringDictionaryConverter,
-    Time32MillisecondConverter, Time32SecondConverter, Time64MicrosecondConverter,
-    Time64NanosecondConverter, TimestampMicrosecondConverter,
+    LargeUtf8Converter, PrimitiveDictionaryConverter, StringDictionaryArrayConverter,
+    StringDictionaryConverter, Time32MillisecondConverter, Time32SecondConverter,
+    Time64MicrosecondConverter, Time64NanosecondConverter, TimestampMicrosecondConverter,
     TimestampMillisecondConverter, UInt16Converter, UInt32Converter, UInt64Converter,
-    UInt8Converter, Utf8ArrayConverter, Utf8Converter, PrimitiveDictionaryConverter,
+    UInt8Converter, Utf8ArrayConverter, Utf8Converter,
 };
 use crate::arrow::record_reader::RecordReader;
 use crate::arrow::schema::parquet_to_arrow_field;
@@ -1457,10 +1457,12 @@ impl<'a> ArrayReaderBuilder {
                 PhysicalType::INT32 => {
                     if let ArrowType::UInt8 = **key_type {
                         if let ArrowType::UInt32 = **value_type {
-                            let converter =
-                                PrimitiveDictionaryConverter::<ArrowUInt8Type, ArrowUInt32Type>::new(
-                                    DictionaryArrayConverter::new(),
-                                );
+                            let converter = PrimitiveDictionaryConverter::<
+                                ArrowUInt8Type,
+                                ArrowUInt32Type,
+                            >::new(
+                                DictionaryArrayConverter::new()
+                            );
                             return Ok(Box::new(
                                 ComplexObjectArrayReader::<Int32Type, _>::new(
                                     page_iterator,
@@ -1469,10 +1471,12 @@ impl<'a> ArrayReaderBuilder {
                                 )?,
                             ));
                         } else if let ArrowType::Int32 = **value_type {
-                            let converter =
-                                PrimitiveDictionaryConverter::<ArrowUInt8Type, ArrowInt32Type>::new(
-                                    DictionaryArrayConverter::new(),
-                                );
+                            let converter = PrimitiveDictionaryConverter::<
+                                ArrowUInt8Type,
+                                ArrowInt32Type,
+                            >::new(
+                                DictionaryArrayConverter::new()
+                            );
                             return Ok(Box::new(
                                 ComplexObjectArrayReader::<Int32Type, _>::new(
                                     page_iterator,
@@ -1484,12 +1488,13 @@ impl<'a> ArrayReaderBuilder {
                             panic!("byeagain");
                         }
                     } else if let ArrowType::UInt16 = **key_type {
-
                         if let ArrowType::UInt32 = **value_type {
-                            let converter =
-                                PrimitiveDictionaryConverter::<ArrowUInt16Type, ArrowUInt32Type>::new(
-                                    DictionaryArrayConverter::new(),
-                                );
+                            let converter = PrimitiveDictionaryConverter::<
+                                ArrowUInt16Type,
+                                ArrowUInt32Type,
+                            >::new(
+                                DictionaryArrayConverter::new()
+                            );
                             return Ok(Box::new(
                                 ComplexObjectArrayReader::<Int32Type, _>::new(
                                     page_iterator,
@@ -1498,10 +1503,12 @@ impl<'a> ArrayReaderBuilder {
                                 )?,
                             ));
                         } else if let ArrowType::Int32 = **value_type {
-                            let converter =
-                                PrimitiveDictionaryConverter::<ArrowUInt16Type, ArrowInt32Type>::new(
-                                    DictionaryArrayConverter::new(),
-                                );
+                            let converter = PrimitiveDictionaryConverter::<
+                                ArrowUInt16Type,
+                                ArrowInt32Type,
+                            >::new(
+                                DictionaryArrayConverter::new()
+                            );
                             return Ok(Box::new(
                                 ComplexObjectArrayReader::<Int32Type, _>::new(
                                     page_iterator,

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -1301,8 +1301,7 @@ mod tests {
             .collect();
 
         // build a record batch
-        let expected_batch =
-            RecordBatch::try_new(schema.clone(), vec![Arc::new(d)]).unwrap();
+        let expected_batch = RecordBatch::try_new(schema, vec![Arc::new(d)]).unwrap();
 
         roundtrip(
             "test_arrow_writer_string_dictionary.parquet",
@@ -1332,8 +1331,7 @@ mod tests {
         let d = builder.finish();
 
         // build a record batch
-        let expected_batch =
-            RecordBatch::try_new(schema.clone(), vec![Arc::new(d)]).unwrap();
+        let expected_batch = RecordBatch::try_new(schema, vec![Arc::new(d)]).unwrap();
 
         roundtrip(
             "test_arrow_writer_primitive_dictionary.parquet",
@@ -1359,8 +1357,7 @@ mod tests {
             .collect();
 
         // build a record batch
-        let expected_batch =
-            RecordBatch::try_new(schema.clone(), vec![Arc::new(d)]).unwrap();
+        let expected_batch = RecordBatch::try_new(schema, vec![Arc::new(d)]).unwrap();
 
         roundtrip(
             "test_arrow_writer_string_dictionary_unsigned_index.parquet",

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -1255,4 +1255,31 @@ mod tests {
 
         roundtrip("test_arrow_writer_dictionary.parquet", expected_batch);
     }
+
+    #[test]
+    fn arrow_writer_string_dictionary_unsigned_index() {
+        // define schema
+        let schema = Arc::new(Schema::new(vec![Field::new_dict(
+            "dictionary",
+            DataType::Dictionary(Box::new(DataType::UInt8), Box::new(DataType::Utf8)),
+            true,
+            42,
+            true,
+        )]));
+
+        // create some data
+        let d: UInt8DictionaryArray = [Some("alpha"), None, Some("beta"), Some("alpha")]
+            .iter()
+            .copied()
+            .collect();
+
+        // build a record batch
+        let expected_batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(d)]).unwrap();
+
+        roundtrip(
+            "test_arrow_writer_string_dictionary_unsigned_index.parquet",
+            expected_batch,
+        );
+    }
 }

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -1191,7 +1191,8 @@ mod tests {
             ["alpha", "beta", "alpha"].iter().copied().collect();
 
         // build a record batch
-        let expected_batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(d)]).unwrap();
+        let expected_batch =
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(d)]).unwrap();
 
         // write to parquet
         let file = get_temp_file("test_arrow_writer_dictionary.parquet", &[]);

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -1174,7 +1174,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Dictionary support isn't correct yet - child_data buffers don't match
     fn arrow_writer_dictionary() {
         // define schema
         let schema = Arc::new(Schema::new(vec![Field::new_dict(
@@ -1194,35 +1193,6 @@ mod tests {
         let expected_batch =
             RecordBatch::try_new(schema.clone(), vec![Arc::new(d)]).unwrap();
 
-        // write to parquet
-        let file = get_temp_file("test_arrow_writer_dictionary.parquet", &[]);
-        let mut writer =
-            ArrowWriter::try_new(file.try_clone().unwrap(), schema, None).unwrap();
-        writer.write(&expected_batch).unwrap();
-        writer.close().unwrap();
-
-        // read from parquet
-        let reader = SerializedFileReader::new(file).unwrap();
-        let mut arrow_reader = ParquetFileArrowReader::new(Rc::new(reader));
-        let mut record_batch_reader = arrow_reader.get_record_reader(1024).unwrap();
-
-        let actual_batch = record_batch_reader.next().unwrap().unwrap();
-
-        for i in 0..expected_batch.num_columns() {
-            let expected_data = expected_batch.column(i).data();
-            let actual_data = actual_batch.column(i).data();
-
-            assert_eq!(expected_data.data_type(), actual_data.data_type());
-            assert_eq!(expected_data.len(), actual_data.len());
-            assert_eq!(expected_data.null_count(), actual_data.null_count());
-            assert_eq!(expected_data.offset(), actual_data.offset());
-            assert_eq!(expected_data.buffers(), actual_data.buffers());
-            assert_eq!(expected_data.child_data(), actual_data.child_data());
-            // Null counts should be the same, not necessarily bitmaps
-            // A null bitmap is optional if an array has no nulls
-            if expected_data.null_count() != 0 {
-                assert_eq!(expected_data.null_bitmap(), actual_data.null_bitmap());
-            }
-        }
+        roundtrip("test_arrow_writer_dictionary.parquet", expected_batch);
     }
 }

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -195,7 +195,8 @@ fn write_leaves(
                 .downcast_ref::<arrow_array::StringArray>()
                 .unwrap();
 
-            // TODO: This removes NULL values; what _should_ be done?
+            // This removes NULL values from the NullableIter, but they're encoded by the levels,
+            // so that's fine.
             // FIXME: Don't use `as`
             let materialized: Vec<_> = keys
                 .flatten()
@@ -1183,9 +1184,10 @@ mod tests {
         )]));
 
         // create some data
-        use Int32DictionaryArray;
-        let d: Int32DictionaryArray =
-            ["alpha", "beta", "alpha"].iter().copied().collect();
+        let d: Int32DictionaryArray = [Some("alpha"), None, Some("beta"), Some("alpha")]
+            .iter()
+            .copied()
+            .collect();
 
         // build a record batch
         let expected_batch =

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -206,7 +206,7 @@ fn write_leaves(
             //
 
             let mut col_writer = get_col_writer(&mut row_group_writer)?;
-            let levels = levels.pop().unwrap();
+            let levels = levels.pop().expect("Levels exhausted");
 
             use ColumnWriter::*;
             match (&mut col_writer, &**v) {

--- a/rust/parquet/src/arrow/arrow_writer.rs
+++ b/rust/parquet/src/arrow/arrow_writer.rs
@@ -193,7 +193,7 @@ fn write_leaves(
                 ($($kt: pat, $vt: pat, $w: ident => $kat: ty, $vat: ty,)*) => (
                     match (&**key_type, &**value_type, &mut col_writer) {
                         $(($kt, $vt, $w(writer)) => write_dict::<$kat, $vat, _>(array, writer, levels),)*
-                        (kt, vt, _) => panic!("Don't know how to write dictionary of <{:?}, {:?}>", kt, vt),
+                        (kt, vt, _) => unreachable!("Shouldn't be attempting to write dictionary of <{:?}, {:?}>", kt, vt),
                     }
                 );
             }

--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -274,7 +274,7 @@ impl<K: ArrowDictionaryKeyType> Converter<Vec<Option<ByteArray>>, DictionaryArra
         for v in source {
             match v {
                 Some(array) => {
-                    builder.append(array.as_utf8()?)?;
+                    let _ = builder.append(array.as_utf8()?)?;
                 }
                 None => builder.append_null()?,
             }

--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -15,25 +15,20 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use crate::arrow::record_reader::RecordReader;
 use crate::data_type::{ByteArray, DataType, Int96};
 // TODO: clean up imports (best done when there are few moving parts)
 use arrow::array::{
-    Array, ArrayRef, BinaryBuilder, BooleanArray, BooleanBufferBuilder,
-    BufferBuilderTrait, FixedSizeBinaryBuilder, LargeBinaryBuilder, LargeStringBuilder,
-    PrimitiveBuilder, PrimitiveDictionaryBuilder, StringBuilder, StringDictionaryBuilder,
-    TimestampNanosecondBuilder,
+    Array, ArrayRef, BinaryBuilder, FixedSizeBinaryBuilder, LargeBinaryBuilder,
+    LargeStringBuilder, PrimitiveBuilder, PrimitiveDictionaryBuilder, StringBuilder,
+    StringDictionaryBuilder, TimestampNanosecondBuilder,
 };
 use arrow::compute::cast;
 use std::convert::From;
 use std::sync::Arc;
 
 use crate::errors::Result;
-use arrow::datatypes::{
-    ArrowDictionaryKeyType, ArrowPrimitiveType, DataType as ArrowDataType,
-};
+use arrow::datatypes::{ArrowDictionaryKeyType, ArrowPrimitiveType};
 
-use arrow::array::ArrayDataBuilder;
 use arrow::array::{
     BinaryArray, DictionaryArray, FixedSizeBinaryArray, LargeBinaryArray,
     LargeStringArray, PrimitiveArray, StringArray, TimestampNanosecondArray,
@@ -50,84 +45,6 @@ pub trait Converter<S, T> {
     /// It will consume record reader's data, but will not reset record reader's
     /// state.
     fn convert(&self, source: S) -> Result<T>;
-}
-
-/// Cast converter first converts record reader's buffer to arrow's
-/// `PrimitiveArray<ArrowSourceType>`, then casts it to `PrimitiveArray<ArrowTargetType>`.
-pub struct CastConverter<ParquetType, ArrowSourceType, ArrowTargetType> {
-    _parquet_marker: PhantomData<ParquetType>,
-    _arrow_source_marker: PhantomData<ArrowSourceType>,
-    _arrow_target_marker: PhantomData<ArrowTargetType>,
-}
-
-impl<ParquetType, ArrowSourceType, ArrowTargetType>
-    CastConverter<ParquetType, ArrowSourceType, ArrowTargetType>
-where
-    ParquetType: DataType,
-    ArrowSourceType: ArrowPrimitiveType,
-    ArrowTargetType: ArrowPrimitiveType,
-{
-    pub fn new() -> Self {
-        Self {
-            _parquet_marker: PhantomData,
-            _arrow_source_marker: PhantomData,
-            _arrow_target_marker: PhantomData,
-        }
-    }
-}
-
-impl<ParquetType, ArrowSourceType, ArrowTargetType>
-    Converter<&mut RecordReader<ParquetType>, ArrayRef>
-    for CastConverter<ParquetType, ArrowSourceType, ArrowTargetType>
-where
-    ParquetType: DataType,
-    ArrowSourceType: ArrowPrimitiveType,
-    ArrowTargetType: ArrowPrimitiveType,
-{
-    fn convert(&self, record_reader: &mut RecordReader<ParquetType>) -> Result<ArrayRef> {
-        let record_data = record_reader.consume_record_data();
-
-        let mut array_data = ArrayDataBuilder::new(ArrowSourceType::DATA_TYPE)
-            .len(record_reader.num_values())
-            .add_buffer(record_data?);
-
-        if let Some(b) = record_reader.consume_bitmap_buffer()? {
-            array_data = array_data.null_bit_buffer(b);
-        }
-
-        let primitive_array: ArrayRef =
-            Arc::new(PrimitiveArray::<ArrowSourceType>::from(array_data.build()));
-
-        // TODO: We should make this cast redundant in favour of 1 cast to rule them all
-        // Ok(cast(&primitive_array, &ArrowTargetType::DATA_TYPE)?)
-        Ok(primitive_array)
-    }
-}
-
-pub struct BooleanArrayConverter {}
-
-impl<T: DataType> Converter<&mut RecordReader<T>, BooleanArray>
-    for BooleanArrayConverter
-{
-    fn convert(&self, record_reader: &mut RecordReader<T>) -> Result<BooleanArray> {
-        let record_data = record_reader.consume_record_data()?;
-
-        let mut boolean_buffer = BooleanBufferBuilder::new(record_data.len());
-
-        for e in record_data.data() {
-            boolean_buffer.append(*e > 0)?;
-        }
-
-        let mut array_data = ArrayDataBuilder::new(ArrowDataType::Boolean)
-            .len(record_data.len())
-            .add_buffer(boolean_buffer.finish());
-
-        if let Some(b) = record_reader.consume_bitmap_buffer()? {
-            array_data = array_data.null_bit_buffer(b);
-        }
-
-        Ok(BooleanArray::from(array_data.build()))
-    }
 }
 
 pub struct FixedSizeArrayConverter {
@@ -330,8 +247,6 @@ where
     }
 }
 
-pub type BoolConverter<'a, T> =
-    ArrayRefConverter<&'a mut RecordReader<T>, BooleanArray, BooleanArrayConverter>;
 pub type Utf8Converter =
     ArrayRefConverter<Vec<Option<ByteArray>>, StringArray, Utf8ArrayConverter>;
 pub type LargeUtf8Converter =
@@ -422,124 +337,5 @@ where
         self.converter
             .convert(source)
             .map(|array| Arc::new(array) as ArrayRef)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::arrow::record_reader::RecordReader;
-    use crate::basic::Encoding;
-    use crate::schema::parser::parse_message_type;
-    use crate::schema::types::SchemaDescriptor;
-    use crate::util::test_common::page_util::InMemoryPageReader;
-    use crate::util::test_common::page_util::{DataPageBuilder, DataPageBuilderImpl};
-    use arrow::array::ArrayEqual;
-    use arrow::array::PrimitiveArray;
-    use arrow::datatypes::{Date32Type, Int16Type, Int32Type};
-    use std::rc::Rc;
-
-    macro_rules! converter_arrow_source_target {
-        ($raw_data:expr, $physical_type:expr, $result_arrow_type:ty, $converter:ty) => {{
-            // Construct record reader
-            let mut record_reader = {
-                // Construct column schema
-                let message_type = &format!(
-                    "
-                message test_schema {{
-                OPTIONAL {} leaf;
-                }}
-                ",
-                    $physical_type
-                );
-
-                let def_levels = [1i16, 0i16, 1i16, 1i16];
-                build_record_reader(
-                    message_type,
-                    &[1, 2, 3],
-                    0i16,
-                    None,
-                    1i16,
-                    Some(&def_levels),
-                    10,
-                )
-            };
-
-            let array = <$converter>::new().convert(&mut record_reader).unwrap();
-            let array = array
-                .as_any()
-                .downcast_ref::<PrimitiveArray<$result_arrow_type>>()
-                .unwrap();
-
-            assert!(array.equals(&PrimitiveArray::<$result_arrow_type>::from($raw_data)));
-        }};
-    }
-
-    #[test]
-    #[ignore = "We need to look at whether this is still relevant after we refactor out the casts"]
-    fn test_converter_arrow_source_i16_target_i32() {
-        // TODO: this fails if we remove the cast here on converter. Is it still relevant?
-        // I'd favour removing these Parquet::PHYSICAL > Arrow::DataType, so we can do it in 1 pleace.
-        let raw_data = vec![Some(1i16), None, Some(2i16), Some(3i16)];
-        converter_arrow_source_target!(raw_data, "INT32", Int16Type, CastConverter<ParquetInt32Type, Int32Type, Int16Type>)
-    }
-
-    #[test]
-    fn test_converter_arrow_source_i32_target_date32() {
-        let raw_data = vec![Some(1i32), None, Some(2i32), Some(3i32)];
-        converter_arrow_source_target!(raw_data, "INT32", Date32Type, CastConverter<ParquetInt32Type, Date32Type, Date32Type>)
-    }
-
-    #[test]
-    fn test_converter_arrow_source_i32_target_i32() {
-        let raw_data = vec![Some(1i32), None, Some(2i32), Some(3i32)];
-        converter_arrow_source_target!(raw_data, "INT32", Int32Type, CastConverter<ParquetInt32Type, Int32Type, Int32Type>)
-    }
-
-    fn build_record_reader<T: DataType>(
-        message_type: &str,
-        values: &[T::T],
-        max_rep_level: i16,
-        rep_levels: Option<&[i16]>,
-        max_def_level: i16,
-        def_levels: Option<&[i16]>,
-        num_records: usize,
-    ) -> RecordReader<T> {
-        let desc = parse_message_type(message_type)
-            .map(|t| SchemaDescriptor::new(Rc::new(t)))
-            .map(|s| s.column(0))
-            .unwrap();
-
-        let mut record_reader = RecordReader::<T>::new(desc.clone());
-
-        // Prepare record reader
-        let mut pb = DataPageBuilderImpl::new(desc, 4, true);
-        if rep_levels.is_some() {
-            pb.add_rep_levels(
-                max_rep_level,
-                match rep_levels {
-                    Some(a) => a,
-                    _ => unreachable!(),
-                },
-            );
-        }
-        if def_levels.is_some() {
-            pb.add_def_levels(
-                max_def_level,
-                match def_levels {
-                    Some(a) => a,
-                    _ => unreachable!(),
-                },
-            );
-        }
-        pb.add_values::<T>(Encoding::PLAIN, &values);
-        let page = pb.consume();
-
-        let page_reader = Box::new(InMemoryPageReader::new(vec![page]));
-        record_reader.set_page_reader(page_reader).unwrap();
-
-        record_reader.read_records(num_records).unwrap();
-
-        record_reader
     }
 }

--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -42,7 +42,7 @@ use arrow::datatypes::{
 use arrow::array::ArrayDataBuilder;
 use arrow::array::{
     BinaryArray, DictionaryArray, FixedSizeBinaryArray, LargeBinaryArray,
-    LargeStringArray, PrimitiveArray, PrimitiveArrayOps, StringArray,
+    LargeStringArray, PrimitiveArray, StringArray,
     TimestampNanosecondArray,
 };
 use std::marker::PhantomData;
@@ -325,7 +325,7 @@ where
 
         let source_array: Arc<dyn Array> =
             Arc::new(PrimitiveArray::<DictValueSourceType>::from(source));
-        let target_array = cast(&source_array, &DictValueTargetType::get_data_type())?;
+        let target_array = cast(&source_array, &DictValueTargetType::DATA_TYPE)?;
         let target = target_array
             .as_any()
             .downcast_ref::<PrimitiveArray<DictValueTargetType>>()

--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -42,8 +42,7 @@ use arrow::datatypes::{
 use arrow::array::ArrayDataBuilder;
 use arrow::array::{
     BinaryArray, DictionaryArray, FixedSizeBinaryArray, LargeBinaryArray,
-    LargeStringArray, PrimitiveArray, StringArray,
-    TimestampNanosecondArray,
+    LargeStringArray, PrimitiveArray, StringArray, TimestampNanosecondArray,
 };
 use std::marker::PhantomData;
 

--- a/rust/parquet/src/arrow/converter.rs
+++ b/rust/parquet/src/arrow/converter.rs
@@ -111,7 +111,9 @@ where
         let primitive_array: ArrayRef =
             Arc::new(PrimitiveArray::<ArrowSourceType>::from(array_data.build()));
 
-        Ok(cast(&primitive_array, &ArrowTargetType::DATA_TYPE)?)
+        // TODO: We should make this cast redundant in favour of 1 cast to rule them all
+        // Ok(cast(&primitive_array, &ArrowTargetType::DATA_TYPE)?)
+        Ok(primitive_array)
     }
 }
 
@@ -347,6 +349,7 @@ pub type BoolConverter<'a> = ArrayRefConverter<
     BooleanArray,
     BooleanArrayConverter,
 >;
+// TODO: intuition tells me that removing many of these converters could help us consolidate where we cast
 pub type Int8Converter = CastConverter<ParquetInt32Type, Int32Type, Int8Type>;
 pub type UInt8Converter = CastConverter<ParquetInt32Type, Int32Type, UInt8Type>;
 pub type Int16Converter = CastConverter<ParquetInt32Type, Int32Type, Int16Type>;
@@ -515,7 +518,10 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "We need to look at whether this is still relevant after we refactor out the casts"]
     fn test_converter_arrow_source_i16_target_i32() {
+        // TODO: this fails if we remove the cast here on converter. Is it still relevant?
+        // I'd favour removing these Parquet::PHYSICAL > Arrow::DataType, so we can do it in 1 pleace.
         let raw_data = vec![Some(1i16), None, Some(2i16), Some(3i16)];
         converter_arrow_source_target!(raw_data, "INT32", Int16Type, Int16Converter)
     }

--- a/rust/parquet/src/arrow/record_reader.rs
+++ b/rust/parquet/src/arrow/record_reader.rs
@@ -124,26 +124,6 @@ impl<T: DataType> RecordReader<T> {
         }
     }
 
-    pub(crate) fn cast<U: DataType>(&mut self) -> &mut RecordReader<U> {
-        trait CastRecordReader<T: DataType, U: DataType> {
-            fn cast(&mut self) -> &mut RecordReader<U>;
-        }
-
-        impl<T: DataType, U: DataType> CastRecordReader<T, U> for RecordReader<T> {
-            default fn cast(&mut self) -> &mut RecordReader<U> {
-                panic!("Attempted to cast RecordReader to the wrong type")
-            }
-        }
-
-        impl<T: DataType> CastRecordReader<T, T> for RecordReader<T> {
-            fn cast(&mut self) -> &mut RecordReader<T> {
-                self
-            }
-        }
-
-        CastRecordReader::<T, U>::cast(self)
-    }
-
     /// Set the current page reader.
     pub fn set_page_reader(&mut self, page_reader: Box<PageReader>) -> Result<()> {
         self.column_reader =


### PR DESCRIPTION
This adds more support for:

- When converting Arrow -> Parquet containing an Arrow Dictionary,
materialize the Dictionary values and send to Parquet to be encoded with
a dictionary or not according to the Parquet settings (deliberately not supporting
converting an Arrow Dictionary directly to Parquet DictEncoding, and right now this only supports String dictionaries)
- When converting Parquet -> Arrow, noticing that the Arrow schema
metadata in a Parquet file has a Dictionary type and converting the data
to an Arrow dictionary (right now this only supports String dictionaries)

I'm not sure if this is in a good enough state to merge or not yet, please let me know @nevi-me !