### PR TITLE
ARROW-10237: [C++] Duplicate dict values cause corrupt parquet

### DIFF
--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -75,6 +75,12 @@ class ARROW_EXPORT DictionaryArray : public Array {
       const std::shared_ptr<DataType>& type, const std::shared_ptr<Array>& indices,
       const std::shared_ptr<Array>& dictionary);
 
+  static Result<std::shared_ptr<Array>> FromArrays(
+      const std::shared_ptr<Array>& indices, const std::shared_ptr<Array>& dictionary) {
+    return FromArrays(::arrow::dictionary(indices->type(), dictionary->type()), indices,
+                      dictionary);
+  }
+
   /// \brief Transpose this DictionaryArray
   ///
   /// This method constructs a new dictionary array with the given dictionary

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2692,21 +2692,34 @@ TEST(TestArrowReadWrite, DictionaryColumnChunkedWrite) {
 TEST(TestArrowReadWrite, NonUniqueDictionaryValues) {
   // ARROW-10237
   auto dict_with_dupes = ArrayFromJSON(::arrow::utf8(), R"(["a", "a", "b"])");
-  auto indices = ArrayFromJSON(::arrow::int32(), R"([0, 1, 0, 1])");
-  ASSERT_OK_AND_ASSIGN(auto encoded,
-                       ::arrow::DictionaryArray::FromArrays(indices, dict_with_dupes));
-  auto plain = ArrayFromJSON(::arrow::utf8(), R"(["a", "a", "a", "a"])");
+  // test with all valid 4-long `indices`
+  for (int i = 0; i < 4 * 4 * 4 * 4; ++i) {
+    int j = i;
+    ASSERT_OK_AND_ASSIGN(
+        auto indices,
+        ArrayFromBuilderVisitor(::arrow::int32(), 4, [&](::arrow::Int32Builder* b) {
+          if (j % 4 < dict_with_dupes->length()) {
+            b->UnsafeAppend(j % 4);
+          } else {
+            b->UnsafeAppendNull();
+          }
+          j /= 4;
+        }));
+    ASSERT_OK_AND_ASSIGN(auto plain, ::arrow::compute::Take(*dict_with_dupes, *indices));
+    ASSERT_OK_AND_ASSIGN(auto encoded,
+                         ::arrow::DictionaryArray::FromArrays(indices, dict_with_dupes));
 
-  auto table = Table::Make(::arrow::schema({::arrow::field("d", encoded->type())}),
-                           ::arrow::ArrayVector{encoded});
+    auto table = Table::Make(::arrow::schema({::arrow::field("d", encoded->type())}),
+                             ::arrow::ArrayVector{encoded});
 
-  ASSERT_OK(table->ValidateFull());
+    ASSERT_OK(table->ValidateFull());
 
-  std::shared_ptr<Table> round_tripped;
-  ASSERT_NO_FATAL_FAILURE(DoSimpleRoundtrip(table, true, 20, {}, &round_tripped));
+    std::shared_ptr<Table> round_tripped;
+    ASSERT_NO_FATAL_FAILURE(DoSimpleRoundtrip(table, true, 20, {}, &round_tripped));
 
-  ASSERT_OK(round_tripped->ValidateFull());
-  ::arrow::AssertArraysEqual(*plain, *round_tripped->column(0)->chunk(0), true);
+    ASSERT_OK(round_tripped->ValidateFull());
+    ::arrow::AssertArraysEqual(*plain, *round_tripped->column(0)->chunk(0), true);
+  }
 }
 
 TEST(TestArrowWrite, CheckChunkSize) {


### PR DESCRIPTION
Fix suggested by @pitrou 