### PR TITLE
ARROW-10238: [C#] List<Struct> is broken

### DIFF
--- a/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
+++ b/csharp/src/Apache.Arrow/Ipc/MessageSerializer.cs
@@ -140,11 +140,11 @@ namespace Apache.Arrow.Ipc
                 case Flatbuf.Type.Binary:
                     return Types.BinaryType.Default;
                 case Flatbuf.Type.List:
-                    if (field.ChildrenLength != 1)
+                    if (childFields == null || childFields.Length != 1)
                     {
-                        throw new InvalidDataException($"List type must have only one child.");
+                        throw new InvalidDataException($"List type must have exactly one child.");
                     }
-                    return new Types.ListType(GetFieldArrowType(field.Children(0).GetValueOrDefault()));
+                    return new Types.ListType(childFields[0]);
                 case Flatbuf.Type.Struct_:
                     Debug.Assert(childFields != null);
                     return new Types.StructType(childFields);

--- a/csharp/test/Apache.Arrow.Tests/ArrayTypeComparer.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrayTypeComparer.cs
@@ -1,0 +1,121 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics;
+using Apache.Arrow.Types;
+using Xunit;
+
+namespace Apache.Arrow.Tests
+{
+    public class ArrayTypeComparer :
+        IArrowTypeVisitor<TimestampType>,
+        IArrowTypeVisitor<Date32Type>,
+        IArrowTypeVisitor<Date64Type>,
+        IArrowTypeVisitor<Time32Type>,
+        IArrowTypeVisitor<Time64Type>,
+        IArrowTypeVisitor<FixedSizeBinaryType>,
+        IArrowTypeVisitor<ListType>,
+        IArrowTypeVisitor<StructType>
+    {
+        private readonly IArrowType _expectedType;
+
+        public ArrayTypeComparer(IArrowType expectedType)
+        {
+            Debug.Assert(expectedType != null);
+            _expectedType = expectedType;
+        }
+
+        public void Visit(TimestampType actualType)
+        {
+            Assert.IsAssignableFrom<TimestampType>(_expectedType);
+
+            var expectedType = (TimestampType)_expectedType;
+
+            Assert.Equal(expectedType.Timezone, actualType.Timezone);
+            Assert.Equal(expectedType.Unit, actualType.Unit);
+        }
+
+        public void Visit(Date32Type actualType)
+        {
+            Assert.IsAssignableFrom<Date32Type>(_expectedType);
+            var expectedType = (Date32Type)_expectedType;
+
+            Assert.Equal(expectedType.Unit, actualType.Unit);
+        }
+
+        public void Visit(Date64Type actualType)
+        {
+            Assert.IsAssignableFrom<Date64Type>(_expectedType);
+            var expectedType = (Date64Type)_expectedType;
+
+            Assert.Equal(expectedType.Unit, actualType.Unit);
+        }
+
+        public void Visit(Time32Type actualType)
+        {
+            Assert.IsAssignableFrom<Time32Type>(_expectedType);
+            var expectedType = (Time32Type)_expectedType;
+
+            Assert.Equal(expectedType.Unit, actualType.Unit);
+        }
+
+        public void Visit(Time64Type actualType)
+        {
+            Assert.IsAssignableFrom<Time64Type>(_expectedType);
+            var expectedType = (Time64Type)_expectedType;
+
+            Assert.Equal(expectedType.Unit, actualType.Unit);
+        }
+
+        public void Visit(FixedSizeBinaryType actualType)
+        {
+            Assert.IsAssignableFrom<FixedSizeBinaryType>(_expectedType);
+            var expectedType = (FixedSizeBinaryType)_expectedType;
+
+            Assert.Equal(expectedType.ByteWidth, actualType.ByteWidth);
+        }
+
+        public void Visit(ListType actualType)
+        {
+            Assert.IsAssignableFrom<ListType>(_expectedType);
+            var expectedType = (ListType)_expectedType;
+
+            CompareNested(expectedType, actualType);
+        }
+
+        public void Visit(StructType actualType)
+        {
+            Assert.IsAssignableFrom<StructType>(_expectedType);
+            var expectedType = (StructType)_expectedType;
+
+            CompareNested(expectedType, actualType);
+        }
+
+        private static void CompareNested(NestedType expectedType, NestedType actualType)
+        {
+            Assert.Equal(expectedType.Fields.Count, actualType.Fields.Count);
+
+            for (int i = 0; i < expectedType.Fields.Count; i++)
+            {
+                FieldComparer.Compare(expectedType.Fields[i], actualType.Fields[i]);
+            }
+        }
+
+        public void Visit(IArrowType actualType)
+        {
+            Assert.IsAssignableFrom(actualType.GetType(), _expectedType);
+        }
+    }
+}

--- a/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowReaderVerifier.cs
@@ -16,7 +16,6 @@
 using Apache.Arrow.Ipc;
 using Apache.Arrow.Types;
 using System;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
@@ -47,7 +46,7 @@ namespace Apache.Arrow.Tests
 
         public static void CompareBatches(RecordBatch expectedBatch, RecordBatch actualBatch)
         {
-            Assert.True(SchemaComparer.Equals(expectedBatch.Schema, actualBatch.Schema));
+            SchemaComparer.Compare(expectedBatch.Schema, actualBatch.Schema);
             Assert.Equal(expectedBatch.Length, actualBatch.Length);
             Assert.Equal(expectedBatch.ColumnCount, actualBatch.ColumnCount);
 
@@ -57,78 +56,6 @@ namespace Apache.Arrow.Tests
                 IArrowArray actualArray = actualBatch.Arrays.ElementAt(i);
 
                 actualArray.Accept(new ArrayComparer(expectedArray));
-            }
-        }
-
-        private class ArrayTypeComparer :
-            IArrowTypeVisitor<TimestampType>,
-            IArrowTypeVisitor<Date32Type>,
-            IArrowTypeVisitor<Date64Type>,
-            IArrowTypeVisitor<Time32Type>,
-            IArrowTypeVisitor<Time64Type>,
-            IArrowTypeVisitor<FixedSizeBinaryType>
-        {
-            private readonly IArrowType _expectedType;
-
-            public ArrayTypeComparer(IArrowType expectedType)
-            {
-                Debug.Assert(expectedType != null);
-                _expectedType = expectedType;
-            }
-
-            public void Visit(TimestampType actualType)
-            {
-                Assert.IsAssignableFrom<TimestampType>(_expectedType);
-
-                var expectedType = (TimestampType)_expectedType;
-
-                Assert.Equal(expectedType.Timezone, actualType.Timezone);
-                Assert.Equal(expectedType.Unit, actualType.Unit);
-            }
-
-            public void Visit(Date32Type actualType)
-            {
-                Assert.IsAssignableFrom<Date32Type>(_expectedType);
-                var expectedType = (Date32Type)_expectedType;
-
-                Assert.Equal(expectedType.Unit, actualType.Unit);
-            }
-
-            public void Visit(Date64Type actualType)
-            {
-                Assert.IsAssignableFrom<Date64Type>(_expectedType);
-                var expectedType = (Date64Type)_expectedType;
-
-                Assert.Equal(expectedType.Unit, actualType.Unit);
-            }
-
-            public void Visit(Time32Type actualType)
-            {
-                Assert.IsAssignableFrom<Time32Type>(_expectedType);
-                var expectedType = (Time32Type)_expectedType;
-
-                Assert.Equal(expectedType.Unit, actualType.Unit);
-            }
-
-            public void Visit(Time64Type actualType)
-            {
-                Assert.IsAssignableFrom<Time64Type>(_expectedType);
-                var expectedType = (Time64Type)_expectedType;
-
-                Assert.Equal(expectedType.Unit, actualType.Unit);
-            }
-
-            public void Visit(FixedSizeBinaryType actualType)
-            {
-                Assert.IsAssignableFrom<FixedSizeBinaryType>(_expectedType);
-                var expectedType = (FixedSizeBinaryType)_expectedType;
-
-                Assert.Equal(expectedType.ByteWidth, actualType.ByteWidth);
-            }
-
-            public void Visit(IArrowType actualType)
-            {
-                Assert.IsAssignableFrom(actualType.GetType(), _expectedType);
             }
         }
 
@@ -209,7 +136,7 @@ namespace Apache.Arrow.Tests
 
                 var expectedArray = (BinaryArray)_expectedArray;
 
-                _arrayTypeComparer.Visit(actualArray.Data.DataType);
+                actualArray.Data.DataType.Accept(_arrayTypeComparer);
 
                 Assert.Equal(expectedArray.Length, actualArray.Length);
                 Assert.Equal(expectedArray.NullCount, actualArray.NullCount);
@@ -226,7 +153,7 @@ namespace Apache.Arrow.Tests
                 Assert.IsAssignableFrom<PrimitiveArray<T>>(_expectedArray);
                 PrimitiveArray<T> expectedArray = (PrimitiveArray<T>)_expectedArray;
 
-                _arrayTypeComparer.Visit(actualArray.Data.DataType);
+                actualArray.Data.DataType.Accept(_arrayTypeComparer);
 
                 Assert.Equal(expectedArray.Length, actualArray.Length);
                 Assert.Equal(expectedArray.NullCount, actualArray.NullCount);
@@ -241,7 +168,7 @@ namespace Apache.Arrow.Tests
                 Assert.IsAssignableFrom<BooleanArray>(_expectedArray);
                 BooleanArray expectedArray = (BooleanArray)_expectedArray;
 
-                _arrayTypeComparer.Visit(actualArray.Data.DataType);
+                actualArray.Data.DataType.Accept(_arrayTypeComparer);
 
                 Assert.Equal(expectedArray.Length, actualArray.Length);
                 Assert.Equal(expectedArray.NullCount, actualArray.NullCount);
@@ -258,7 +185,7 @@ namespace Apache.Arrow.Tests
                 Assert.IsAssignableFrom<ListArray>(_expectedArray);
                 ListArray expectedArray = (ListArray)_expectedArray;
 
-                _arrayTypeComparer.Visit(actualArray.Data.DataType);
+                actualArray.Data.DataType.Accept(_arrayTypeComparer);
 
                 Assert.Equal(expectedArray.Length, actualArray.Length);
                 Assert.Equal(expectedArray.NullCount, actualArray.NullCount);

--- a/csharp/test/Apache.Arrow.Tests/FieldComparer.cs
+++ b/csharp/test/Apache.Arrow.Tests/FieldComparer.cs
@@ -20,26 +20,6 @@ namespace Apache.Arrow.Tests
 {
     public class FieldComparer
     {
-        public static bool Equals(Field f1, Field f2)
-        {
-            if (ReferenceEquals(f1, f2))
-            {
-                return true;
-            }
-            if (f2 != null && f1 != null && f1.Name == f2.Name && f1.IsNullable == f2.IsNullable &&
-                f1.DataType.TypeId == f2.DataType.TypeId && f1.HasMetadata == f2.HasMetadata)
-            {
-                if (f1.HasMetadata && f2.HasMetadata)
-                {
-                    return f1.Metadata.Keys.Count() == f2.Metadata.Keys.Count() &&
-                           f1.Metadata.Keys.All(k => f2.Metadata.ContainsKey(k) && f1.Metadata[k] == f2.Metadata[k]) &&
-                           f2.Metadata.Keys.All(k => f1.Metadata.ContainsKey(k) && f2.Metadata[k] == f1.Metadata[k]);
-                }
-                return true;
-            }
-            return false;
-        }
-
         public static void Compare(Field expected, Field actual)
         {
             if (ReferenceEquals(expected, actual))

--- a/csharp/test/Apache.Arrow.Tests/FieldComparer.cs
+++ b/csharp/test/Apache.Arrow.Tests/FieldComparer.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System.Linq;
+using Xunit;
 
 namespace Apache.Arrow.Tests
 {
@@ -37,6 +38,27 @@ namespace Apache.Arrow.Tests
                 return true;
             }
             return false;
+        }
+
+        public static void Compare(Field expected, Field actual)
+        {
+            if (ReferenceEquals(expected, actual))
+            {
+                return;
+            }
+
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.IsNullable, actual.IsNullable);
+
+            Assert.Equal(expected.HasMetadata, actual.HasMetadata);
+            if (expected.HasMetadata)
+            {
+                Assert.Equal(expected.Metadata.Keys.Count(), actual.Metadata.Keys.Count());
+                Assert.True(expected.Metadata.Keys.All(k => actual.Metadata.ContainsKey(k) && expected.Metadata[k] == actual.Metadata[k]));
+                Assert.True(actual.Metadata.Keys.All(k => expected.Metadata.ContainsKey(k) && actual.Metadata[k] == expected.Metadata[k]));
+            }
+
+            actual.DataType.Accept(new ArrayTypeComparer(expected.DataType));
         }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/SchemaBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/SchemaBuilderTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Apache.Arrow.Tests
 {
@@ -124,9 +125,9 @@ namespace Apache.Arrow.Tests
                 Assert.True(metadata1.Keys.SequenceEqual(schema1.Metadata.Keys) && metadata1.Values.SequenceEqual(schema1.Metadata.Values));
                 Assert.True(metadata0.Keys.SequenceEqual(schema2.Metadata.Keys) && metadata0.Values.SequenceEqual(schema2.Metadata.Values));
                 SchemaComparer.Compare(schema0, schema2);
-                Assert.False(SchemaComparer.Equals(schema0, schema1));
-                Assert.False(SchemaComparer.Equals(schema2, schema1));
-                Assert.False(SchemaComparer.Equals(schema2, schema3));
+                Assert.Throws<EqualException>(() => SchemaComparer.Compare(schema0, schema1));
+                Assert.Throws<EqualException>(() => SchemaComparer.Compare(schema2, schema1));
+                Assert.Throws<EqualException>(() => SchemaComparer.Compare(schema2, schema3));
             }
 
             [Theory]

--- a/csharp/test/Apache.Arrow.Tests/SchemaBuilderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/SchemaBuilderTests.cs
@@ -123,7 +123,7 @@ namespace Apache.Arrow.Tests
                 Assert.True(metadata0.Keys.SequenceEqual(schema0.Metadata.Keys) && metadata0.Values.SequenceEqual(schema0.Metadata.Values));
                 Assert.True(metadata1.Keys.SequenceEqual(schema1.Metadata.Keys) && metadata1.Values.SequenceEqual(schema1.Metadata.Values));
                 Assert.True(metadata0.Keys.SequenceEqual(schema2.Metadata.Keys) && metadata0.Values.SequenceEqual(schema2.Metadata.Values));
-                Assert.True(SchemaComparer.Equals(schema0, schema2));
+                SchemaComparer.Compare(schema0, schema2);
                 Assert.False(SchemaComparer.Equals(schema0, schema1));
                 Assert.False(SchemaComparer.Equals(schema2, schema1));
                 Assert.False(SchemaComparer.Equals(schema2, schema3));

--- a/csharp/test/Apache.Arrow.Tests/SchemaComparer.cs
+++ b/csharp/test/Apache.Arrow.Tests/SchemaComparer.cs
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 using System.Linq;
+using Xunit;
 
 namespace Apache.Arrow.Tests
 {
@@ -43,6 +44,29 @@ namespace Apache.Arrow.Tests
                        s2.Metadata.Keys.All(k => s1.Metadata.ContainsKey(k) && s2.Metadata[k] == s1.Metadata[k]);
             }
             return true;
+        }
+
+        public static void Compare(Schema expected, Schema actual)
+        {
+            if (ReferenceEquals(expected, actual))
+            {
+                return;
+            }
+
+            Assert.Equal(expected.HasMetadata, actual.HasMetadata);
+            if (expected.HasMetadata)
+            {
+                Assert.Equal(expected.Metadata.Keys.Count(), actual.Metadata.Keys.Count());
+                Assert.True(expected.Metadata.Keys.All(k => actual.Metadata.ContainsKey(k) && expected.Metadata[k] == actual.Metadata[k]));
+                Assert.True(actual.Metadata.Keys.All(k => expected.Metadata.ContainsKey(k) && actual.Metadata[k] == expected.Metadata[k]));
+            }
+
+            Assert.Equal(expected.Fields.Count, actual.Fields.Count);
+            Assert.True(expected.Fields.Keys.All(k => actual.Fields.ContainsKey(k)));
+            foreach (string name in expected.Fields.Keys)
+            {
+                FieldComparer.Compare(expected.Fields[name], actual.Fields[name]);
+            }
         }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/SchemaComparer.cs
+++ b/csharp/test/Apache.Arrow.Tests/SchemaComparer.cs
@@ -20,32 +20,6 @@ namespace Apache.Arrow.Tests
 {
     public class SchemaComparer
     {
-        public static bool Equals(Schema s1, Schema s2)
-        {
-            if (ReferenceEquals(s1, s2))
-            {
-                return true;
-            }
-            if (s2 == null || s1 == null || s1.HasMetadata != s2.HasMetadata || s1.Fields.Count != s2.Fields.Count)
-            {
-                return false;
-            }
-
-            if (!s1.Fields.Keys.All(k => s2.Fields.ContainsKey(k) && FieldComparer.Equals(s1.Fields[k], s2.Fields[k])) ||
-                !s2.Fields.Keys.All(k => s1.Fields.ContainsKey(k) && FieldComparer.Equals(s2.Fields[k], s1.Fields[k])))
-            {
-                return false;
-            }
-
-            if (s1.HasMetadata && s2.HasMetadata)
-            {
-                return s1.Metadata.Keys.Count() == s2.Metadata.Keys.Count() &&
-                       s1.Metadata.Keys.All(k => s2.Metadata.ContainsKey(k) && s1.Metadata[k] == s2.Metadata[k]) &&
-                       s2.Metadata.Keys.All(k => s1.Metadata.ContainsKey(k) && s2.Metadata[k] == s1.Metadata[k]);
-            }
-            return true;
-        }
-
         public static void Compare(Schema expected, Schema actual)
         {
             if (ReferenceEquals(expected, actual))

--- a/csharp/test/Apache.Arrow.Tests/TypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/TypeTests.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Apache.Arrow.Tests
 {
@@ -46,8 +47,8 @@ namespace Apache.Arrow.Tests
             Field f0_with_meta = new Field.Builder().Name("f0").DataType(Int32Type.Default).Nullable(true).Metadata("a", "1").Metadata("b", "2").Build();
 
             FieldComparer.Compare(f0_nullable, f0_other);
-            Assert.False(FieldComparer.Equals(f0_nullable, f0_nonnullable));
-            Assert.False(FieldComparer.Equals(f0_nullable, f0_with_meta));
+            Assert.Throws<EqualException>(() => FieldComparer.Compare(f0_nullable, f0_nonnullable));
+            Assert.Throws<EqualException>(() => FieldComparer.Compare(f0_nullable, f0_with_meta));
         }
 
         [Fact]

--- a/csharp/test/Apache.Arrow.Tests/TypeTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/TypeTests.cs
@@ -45,7 +45,7 @@ namespace Apache.Arrow.Tests
             Field f0_other = new Field.Builder().Name("f0").DataType(Int32Type.Default).Build();
             Field f0_with_meta = new Field.Builder().Name("f0").DataType(Int32Type.Default).Nullable(true).Metadata("a", "1").Metadata("b", "2").Build();
 
-            Assert.True(FieldComparer.Equals(f0_nullable, f0_other));
+            FieldComparer.Compare(f0_nullable, f0_other);
             Assert.False(FieldComparer.Equals(f0_nullable, f0_nonnullable));
             Assert.False(FieldComparer.Equals(f0_nullable, f0_with_meta));
         }
@@ -58,7 +58,7 @@ namespace Apache.Arrow.Tests
             Field f0_nullable = new Field.Builder().Name("f0").DataType(Int32Type.Default).Metadata(metadata).Build();
             Field f1_nullable = new Field.Builder().Name("f0").DataType(Int32Type.Default).Metadata(metadata1).Build();
             Assert.True(metadata.Keys.SequenceEqual(f0_nullable.Metadata.Keys) && metadata.Values.SequenceEqual(f0_nullable.Metadata.Values));
-            Assert.True(FieldComparer.Equals(f0_nullable, f1_nullable));
+            FieldComparer.Compare(f0_nullable, f1_nullable);
         }
 
         [Fact]
@@ -73,9 +73,9 @@ namespace Apache.Arrow.Tests
             StructType struct_type = new StructType(fields);
 
             var structFields = struct_type.Fields;
-            Assert.True(FieldComparer.Equals(structFields.ElementAt(0), f0_nullable));
-            Assert.True(FieldComparer.Equals(structFields.ElementAt(1), f1_nullable));
-            Assert.True(FieldComparer.Equals(structFields.ElementAt(2), f2_nullable));
+            FieldComparer.Compare(structFields.ElementAt(0), f0_nullable);
+            FieldComparer.Compare(structFields.ElementAt(1), f1_nullable);
+            FieldComparer.Compare(structFields.ElementAt(2), f2_nullable);
         }
 
         [Fact]
@@ -89,9 +89,9 @@ namespace Apache.Arrow.Tests
             List<Field> fields = new List<Field>() { f0_nullable, f1_nullable, f2_nullable };
             StructType struct_type = new StructType(fields);
 
-            Assert.True(FieldComparer.Equals(struct_type.GetFieldByName("f0"), f0_nullable));
-            Assert.True(FieldComparer.Equals(struct_type.GetFieldByName("f1"), f1_nullable));
-            Assert.True(FieldComparer.Equals(struct_type.GetFieldByName("f2"), f2_nullable));
+            FieldComparer.Compare(struct_type.GetFieldByName("f0"), f0_nullable);
+            FieldComparer.Compare(struct_type.GetFieldByName("f1"), f1_nullable);
+            FieldComparer.Compare(struct_type.GetFieldByName("f2"), f2_nullable);
             Assert.True(struct_type.GetFieldByName("not_found") == null);
         }
 
@@ -119,7 +119,7 @@ namespace Apache.Arrow.Tests
             var stringType1 = new ListType(stringField);
             var stringType2 = new ListType(StringType.Default);
 
-            Assert.True(FieldComparer.Equals(stringType1.ValueField, stringType2.ValueField));
+            FieldComparer.Compare(stringType1.ValueField, stringType2.ValueField);
             Assert.Equal(stringType1.ValueDataType.TypeId, stringType2.ValueDataType.TypeId);
         }
 


### PR DESCRIPTION
When reading the flatbuffer type information, we are reading the ListType incorrectly. We should be using the childFields parameter, like we do for StructTypes.

I also took this opportunity to redo how we compare schema information in our tests. For nested types, we need to recursively compare types all the way down.

@pgovind @HashidaTKS @chutchinson 