### PR TITLE
ARROW-10114: [R] Segfault in to_dataframe_parallel with deeply nested structs

### DIFF
--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -390,6 +390,8 @@ class Converter_Binary : public Converter {
 
     return IngestSome(array, n, ingest_one);
   }
+
+  virtual bool Parallel() const { return false; }
 };
 
 class Converter_FixedSizeBinary : public Converter {
@@ -428,6 +430,8 @@ class Converter_FixedSizeBinary : public Converter {
 
     return IngestSome(array, n, ingest_one);
   }
+
+  virtual bool Parallel() const { return false; }
 
  private:
   int byte_width_;
@@ -646,6 +650,15 @@ class Converter_Struct : public Converter {
     }
 
     return Status::OK();
+  }
+
+  virtual bool Parallel() const {
+    // this can only run in parallel if all the
+    // inner converters can
+    for (const auto& converter : converters) {
+      if (!converter->Parallel()) return false;
+    }
+    return true;
   }
 
  private:


### PR DESCRIPTION
``` r
library(arrow, warn.conflicts = FALSE)
download.file("https://gist.githubusercontent.com/mskyttner/6700d6a7fe4c3d296f449171897a3ed6/raw/9f65035b3ba6d2859c5fedffced230b6184d4149/head.jsonl", "/tmp/head.jsonl")
df <- read_json_arrow("/tmp/head.jsonl")
names(df)
#> [1] "master"            "publications"      "publication_count"
```

<sup>Created on 2020-10-09 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>