### PR TITLE
WIP: [C++] Get rid of code duplication in Decimal##bit_width

### DIFF
--- a/cpp/src/arrow/array/array_decimal.cc
+++ b/cpp/src/arrow/array/array_decimal.cc
@@ -32,32 +32,21 @@ namespace arrow {
 
 using internal::checked_cast;
 
-// ----------------------------------------------------------------------
-// Decimal128
 
-Decimal128Array::Decimal128Array(const std::shared_ptr<ArrayData>& data)
+template<uint32_t width>
+BaseDecimalArray<width>::BaseDecimalArray(const std::shared_ptr<ArrayData>& data)
     : FixedSizeBinaryArray(data) {
-  ARROW_CHECK_EQ(data->type->id(), Type::DECIMAL128);
+  ARROW_CHECK_EQ(data->type->id(), DecimalArrayHelper<width>::id);
 }
 
-std::string Decimal128Array::FormatValue(int64_t i) const {
-  const auto& type_ = checked_cast<const Decimal128Type&>(*type());
-  const Decimal128 value(GetValue(i));
+template<uint32_t width>
+std::string BaseDecimalArray<width>::FormatValue(int64_t i) const {
+  const auto& type_ = checked_cast<const typename DecimalArrayHelper<width>::type&>(*type());
+  const typename DecimalArrayHelper<width>::value_type value(GetValue(i));
   return value.ToString(type_.scale());
 }
 
-// ----------------------------------------------------------------------
-// Decimal256
-
-Decimal256Array::Decimal256Array(const std::shared_ptr<ArrayData>& data)
-    : FixedSizeBinaryArray(data) {
-  ARROW_CHECK_EQ(data->type->id(), Type::DECIMAL256);
-}
-
-std::string Decimal256Array::FormatValue(int64_t i) const {
-  const auto& type_ = checked_cast<const Decimal256Type&>(*type());
-  const Decimal256 value(GetValue(i));
-  return value.ToString(type_.scale());
-}
+template class BaseDecimalArray<128>;
+template class BaseDecimalArray<256>;
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/array_decimal.cc
+++ b/cpp/src/arrow/array/array_decimal.cc
@@ -36,13 +36,13 @@ using internal::checked_cast;
 template<uint32_t width>
 BaseDecimalArray<width>::BaseDecimalArray(const std::shared_ptr<ArrayData>& data)
     : FixedSizeBinaryArray(data) {
-  ARROW_CHECK_EQ(data->type->id(), DecimalArrayHelper<width>::id);
+  ARROW_CHECK_EQ(data->type->id(), DecimalTypeTraits<width>::Id);
 }
 
 template<uint32_t width>
 std::string BaseDecimalArray<width>::FormatValue(int64_t i) const {
-  const auto& type_ = checked_cast<const typename DecimalArrayHelper<width>::type&>(*type());
-  const typename DecimalArrayHelper<width>::value_type value(GetValue(i));
+  const auto& type_ = checked_cast<const typename DecimalTypeTraits<width>::TypeClass&>(*type());
+  const typename DecimalTypeTraits<width>::ValueType value(GetValue(i));
   return value.ToString(type_.scale());
 }
 

--- a/cpp/src/arrow/array/array_decimal.h
+++ b/cpp/src/arrow/array/array_decimal.h
@@ -22,34 +22,18 @@
 #include <string>
 
 #include "arrow/array/array_binary.h"
+#include "arrow/util/decimal_type_traits.h"
 #include "arrow/array/data.h"
 #include "arrow/type.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 
-
-template<uint32_t width>
-struct DecimalArrayHelper;
-
-#define DECL_DECIMAL_TYPES_HELPER(width)                 \
-template<>                                               \
-struct DecimalArrayHelper<width> {                       \
-  static constexpr Type::type id = Type::DECIMAL##width; \
-  using type = Decimal##width##Type;                     \
-  using value_type = Decimal##width;                     \
-};
-
-DECL_DECIMAL_TYPES_HELPER(128)
-DECL_DECIMAL_TYPES_HELPER(256)
-
-#undef DECL_DECIMAL_TYPES_HELPER
-
 /// Template Array class for decimal data
 template<uint32_t width>
 class BaseDecimalArray : public FixedSizeBinaryArray {
  public:
-  using TypeClass = typename DecimalArrayHelper<width>::type;
+  using TypeClass = typename DecimalTypeTraits<width>::TypeClass;
 
   using FixedSizeBinaryArray::FixedSizeBinaryArray;
 
@@ -59,15 +43,15 @@ class BaseDecimalArray : public FixedSizeBinaryArray {
   std::string FormatValue(int64_t i) const;
 };
 
-#define DECIMAL_ARRAY_DECL(width)                                           \
-class ARROW_EXPORT Decimal##width##Array : public BaseDecimalArray<width> { \
-  using BaseDecimalArray<width>::BaseDecimalArray;                          \
+/// Array class for decimal 128-bit data                                       
+class ARROW_EXPORT Decimal128Array : public BaseDecimalArray<128> { 
+  using BaseDecimalArray<128>::BaseDecimalArray;                          
 };
 
-DECIMAL_ARRAY_DECL(128)
-DECIMAL_ARRAY_DECL(256)
-
-#undef DECIMAL_ARRAY_DECL
+/// Array class for decimal 256-bit data
+class ARROW_EXPORT Decimal256Array : public BaseDecimalArray<256> { 
+  using BaseDecimalArray<256>::BaseDecimalArray;                          
+};
 
 // Backward compatibility
 using DecimalArray = Decimal128Array;

--- a/cpp/src/arrow/array/array_decimal.h
+++ b/cpp/src/arrow/array/array_decimal.h
@@ -28,39 +28,49 @@
 
 namespace arrow {
 
-// ----------------------------------------------------------------------
-// Decimal128Array
 
-/// Concrete Array class for 128-bit decimal data
-class ARROW_EXPORT Decimal128Array : public FixedSizeBinaryArray {
+template<uint32_t width>
+struct DecimalArrayHelper;
+
+#define DECL_DECIMAL_TYPES_HELPER(width)                 \
+template<>                                               \
+struct DecimalArrayHelper<width> {                       \
+  static constexpr Type::type id = Type::DECIMAL##width; \
+  using type = Decimal##width##Type;                     \
+  using value_type = Decimal##width;                     \
+};
+
+DECL_DECIMAL_TYPES_HELPER(128)
+DECL_DECIMAL_TYPES_HELPER(256)
+
+#undef DECL_DECIMAL_TYPES_HELPER
+
+/// Template Array class for decimal data
+template<uint32_t width>
+class BaseDecimalArray : public FixedSizeBinaryArray {
  public:
-  using TypeClass = Decimal128Type;
+  using TypeClass = typename DecimalArrayHelper<width>::type;
 
   using FixedSizeBinaryArray::FixedSizeBinaryArray;
 
-  /// \brief Construct Decimal128Array from ArrayData instance
-  explicit Decimal128Array(const std::shared_ptr<ArrayData>& data);
+  /// \brief Construct DecimalArray from ArrayData instance
+  explicit BaseDecimalArray(const std::shared_ptr<ArrayData>& data);
 
   std::string FormatValue(int64_t i) const;
 };
+
+#define DECIMAL_ARRAY_DECL(width)                                           \
+class ARROW_EXPORT Decimal##width##Array : public BaseDecimalArray<width> { \
+  using BaseDecimalArray<width>::BaseDecimalArray;                          \
+};
+
+DECIMAL_ARRAY_DECL(128)
+DECIMAL_ARRAY_DECL(256)
+
+#undef DECIMAL_ARRAY_DECL
 
 // Backward compatibility
 using DecimalArray = Decimal128Array;
 
-// ----------------------------------------------------------------------
-// Decimal256Array
-
-/// Concrete Array class for 256-bit decimal data
-class ARROW_EXPORT Decimal256Array : public FixedSizeBinaryArray {
- public:
-  using TypeClass = Decimal256Type;
-
-  using FixedSizeBinaryArray::FixedSizeBinaryArray;
-
-  /// \brief Construct Decimal256Array from ArrayData instance
-  explicit Decimal256Array(const std::shared_ptr<ArrayData>& data);
-
-  std::string FormatValue(int64_t i) const;
-};
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_decimal.cc
+++ b/cpp/src/arrow/array/builder_decimal.cc
@@ -33,30 +33,35 @@ class Buffer;
 class MemoryPool;
 
 // ----------------------------------------------------------------------
-// Decimal128Builder
+// BaseDecimalBuilder
 
-Decimal128Builder::Decimal128Builder(const std::shared_ptr<DataType>& type,
+template<uint32_t width>
+BaseDecimalBuilder<width>::BaseDecimalBuilder(const std::shared_ptr<DataType>& type,
                                      MemoryPool* pool)
     : FixedSizeBinaryBuilder(type, pool),
-      decimal_type_(internal::checked_pointer_cast<Decimal128Type>(type)) {}
+      decimal_type_(internal::checked_pointer_cast<typename DecimalBuilderHelper<width>::type>(type)) {}
 
-Status Decimal128Builder::Append(Decimal128 value) {
+template<uint32_t width>
+Status BaseDecimalBuilder<width>::Append(typename DecimalBuilderHelper<width>::value_type value) {
   RETURN_NOT_OK(FixedSizeBinaryBuilder::Reserve(1));
   UnsafeAppend(value);
   return Status::OK();
 }
 
-void Decimal128Builder::UnsafeAppend(Decimal128 value) {
+template<uint32_t width>
+void BaseDecimalBuilder<width>::UnsafeAppend(typename DecimalBuilderHelper<width>::value_type value) {
   value.ToBytes(GetMutableValue(length()));
-  byte_builder_.UnsafeAdvance(16);
+  byte_builder_.UnsafeAdvance((width >> 3));
   UnsafeAppendToBitmap(true);
 }
 
-void Decimal128Builder::UnsafeAppend(util::string_view value) {
+template<uint32_t width>
+void BaseDecimalBuilder<width>::UnsafeAppend(util::string_view value) {
   FixedSizeBinaryBuilder::UnsafeAppend(value);
 }
 
-Status Decimal128Builder::FinishInternal(std::shared_ptr<ArrayData>* out) {
+template<uint32_t width>
+Status BaseDecimalBuilder<width>::FinishInternal(std::shared_ptr<ArrayData>* out) {
   std::shared_ptr<Buffer> data;
   RETURN_NOT_OK(byte_builder_.Finish(&data));
   std::shared_ptr<Buffer> null_bitmap;
@@ -67,39 +72,8 @@ Status Decimal128Builder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   return Status::OK();
 }
 
-// ----------------------------------------------------------------------
-// Decimal256Builder
-
-Decimal256Builder::Decimal256Builder(const std::shared_ptr<DataType>& type,
-                                     MemoryPool* pool)
-    : FixedSizeBinaryBuilder(type, pool),
-      decimal_type_(internal::checked_pointer_cast<Decimal256Type>(type)) {}
-
-Status Decimal256Builder::Append(Decimal256 value) {
-  RETURN_NOT_OK(FixedSizeBinaryBuilder::Reserve(1));
-  UnsafeAppend(value);
-  return Status::OK();
-}
-
-void Decimal256Builder::UnsafeAppend(Decimal256 value) {
-  value.ToBytes(GetMutableValue(length()));
-  byte_builder_.UnsafeAdvance(32);
-  UnsafeAppendToBitmap(true);
-}
-
-void Decimal256Builder::UnsafeAppend(util::string_view value) {
-  FixedSizeBinaryBuilder::UnsafeAppend(value);
-}
-
-Status Decimal256Builder::FinishInternal(std::shared_ptr<ArrayData>* out) {
-  std::shared_ptr<Buffer> data;
-  RETURN_NOT_OK(byte_builder_.Finish(&data));
-  std::shared_ptr<Buffer> null_bitmap;
-  RETURN_NOT_OK(null_bitmap_builder_.Finish(&null_bitmap));
-
-  *out = ArrayData::Make(type(), length_, {null_bitmap, data}, null_count_);
-  capacity_ = length_ = null_count_ = 0;
-  return Status::OK();
-}
+// Instantiate template classes to have methods of it
+template class BaseDecimalBuilder<128>;
+template class BaseDecimalBuilder<256>;
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_decimal.cc
+++ b/cpp/src/arrow/array/builder_decimal.cc
@@ -39,17 +39,17 @@ template<uint32_t width>
 BaseDecimalBuilder<width>::BaseDecimalBuilder(const std::shared_ptr<DataType>& type,
                                      MemoryPool* pool)
     : FixedSizeBinaryBuilder(type, pool),
-      decimal_type_(internal::checked_pointer_cast<typename DecimalBuilderHelper<width>::type>(type)) {}
+      decimal_type_(internal::checked_pointer_cast<typename DecimalTypeTraits<width>::TypeClass>(type)) {}
 
 template<uint32_t width>
-Status BaseDecimalBuilder<width>::Append(typename DecimalBuilderHelper<width>::value_type value) {
+Status BaseDecimalBuilder<width>::Append(typename DecimalTypeTraits<width>::ValueType value) {
   RETURN_NOT_OK(FixedSizeBinaryBuilder::Reserve(1));
   UnsafeAppend(value);
   return Status::OK();
 }
 
 template<uint32_t width>
-void BaseDecimalBuilder<width>::UnsafeAppend(typename DecimalBuilderHelper<width>::value_type value) {
+void BaseDecimalBuilder<width>::UnsafeAppend(typename DecimalTypeTraits<width>::ValueType value) {
   value.ToBytes(GetMutableValue(length()));
   byte_builder_.UnsafeAdvance((width >> 3));
   UnsafeAppendToBitmap(true);

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -36,6 +36,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/compare.h"
 #include "arrow/util/decimal.h"
+#include "arrow/util/decimal_type_traits.h"
 #include "arrow/util/string_view.h"
 #include "arrow/util/visibility.h"
 
@@ -336,26 +337,24 @@ struct ARROW_EXPORT DurationScalar : public TemporalScalar<DurationType> {
   using TemporalScalar<DurationType>::TemporalScalar;
 };
 
-struct ARROW_EXPORT Decimal128Scalar : public Scalar {
+template<uint32_t width>
+struct BaseDecimalScalar : public Scalar {
   using Scalar::Scalar;
-  using TypeClass = Decimal128Type;
-  using ValueType = Decimal128;
+  using TypeClass = typename DecimalTypeTraits<width>::TypeClass;
+  using ValueType = typename DecimalTypeTraits<width>::ValueType;
 
-  Decimal128Scalar(Decimal128 value, std::shared_ptr<DataType> type)
+  BaseDecimalScalar(ValueType value, std::shared_ptr<DataType> type)
       : Scalar(std::move(type), true), value(value) {}
 
-  Decimal128 value;
+  ValueType value;
 };
 
-struct ARROW_EXPORT Decimal256Scalar : public Scalar {
-  using Scalar::Scalar;
-  using TypeClass = Decimal256Type;
-  using ValueType = Decimal256;
+struct ARROW_EXPORT Decimal128Scalar : public BaseDecimalScalar<128> {
+  using BaseDecimalScalar<128>::BaseDecimalScalar;
+};
 
-  Decimal256Scalar(Decimal256 value, std::shared_ptr<DataType> type)
-      : Scalar(std::move(type), true), value(value) {}
-
-  Decimal256 value;
+struct ARROW_EXPORT Decimal256Scalar : public BaseDecimalScalar<256> {
+  using BaseDecimalScalar<256>::BaseDecimalScalar;
 };
 
 struct ARROW_EXPORT BaseListScalar : public Scalar {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -753,9 +753,12 @@ std::vector<std::shared_ptr<Field>> StructType::GetAllFieldsByName(
 template<uint32_t width>
 struct DecimalTypeHelper;
 
-#define DECIMAL_TYPE_HELPER_DECL(width) \
-template<> \
-struct DecimalTypeHelper<width> { using type = Decimal##width##Type; };
+#define DECIMAL_TYPE_HELPER_DECL(width)                  \
+template<>                                               \
+struct DecimalTypeHelper<width> {                        \
+  static constexpr Type::type id = Type::DECIMAL##width; \
+  using type = Decimal##width##Type;                     \
+};
 
 DECIMAL_TYPE_HELPER_DECL(128)
 DECIMAL_TYPE_HELPER_DECL(256)
@@ -765,7 +768,7 @@ DECIMAL_TYPE_HELPER_DECL(256)
 
 template<uint32_t width>
 BaseDecimalType<width>::BaseDecimalType(int32_t precision, int32_t scale)
-    : DecimalType(type_id, (width >> 3), precision, scale) {
+    : DecimalType(DecimalTypeHelper<width>::id, (width >> 3), precision, scale) {
   ARROW_CHECK_GE(precision, kMinPrecision);
   ARROW_CHECK_LE(precision, kMaxPrecision);
 }

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2149,15 +2149,13 @@ std::shared_ptr<DataType> decimal(int32_t precision, int32_t scale) {
                                                     : decimal256(precision, scale);
 }
 
-#define DECIMAL_BUILDER_DECL(width)                                          \
-std::shared_ptr<DataType> decimal##width(int32_t precision, int32_t scale) { \
-  return std::make_shared<Decimal##width##Type>(precision, scale);           \
+std::shared_ptr<DataType> decimal128(int32_t precision, int32_t scale) {
+  return std::make_shared<Decimal128Type>(precision, scale);
 }
 
-DECIMAL_BUILDER_DECL(128)
-DECIMAL_BUILDER_DECL(256)
-
-#undef DECIMAL_BUILDER_DECL
+std::shared_ptr<DataType> decimal256(int32_t precision, int32_t scale) {
+  return std::make_shared<Decimal256Type>(precision, scale);
+}
 
 template<uint32_t width>
 std::string BaseDecimalType<width>::ToString() const {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -876,7 +876,6 @@ class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
   int32_t scale_;
 };
 
-
 /// \brief Template type class for decimal data
 template<uint32_t width>
 class BaseDecimalType : public DecimalType {
@@ -896,16 +895,19 @@ class BaseDecimalType : public DecimalType {
   static constexpr int32_t kMaxPrecision = DecimalMeta<width>::max_precision;
 };
 
-#define DECIMAL_TYPE_DECL(width)                                             \
-class ARROW_EXPORT Decimal##width##Type : public BaseDecimalType<width> {    \
-  public: static constexpr Type::type type_id = Type::DECIMAL##width;        \
-          using BaseDecimalType<width>::BaseDecimalType;                     \
+/// \brief Concrete type class for decimal 128-bit data
+class ARROW_EXPORT Decimal128Type : public BaseDecimalType<128> {
+public:
+  static constexpr Type::type type_id = Type::DECIMAL128;
+  using BaseDecimalType<128>::BaseDecimalType;
 };
 
-DECIMAL_TYPE_DECL(128)
-DECIMAL_TYPE_DECL(256)
-
-#undef DECIMAL_TYPE_DECL
+/// \brief Concrete type class for decimal 256-bit data
+class ARROW_EXPORT Decimal256Type : public BaseDecimalType<256> {
+public:
+  static constexpr Type::type type_id = Type::DECIMAL256;
+  using BaseDecimalType<256>::BaseDecimalType;
+};
 
 /// \brief Concrete type class for union data
 class ARROW_EXPORT UnionType : public NestedType {

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -879,7 +879,7 @@ class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
 
 /// \brief Template type class for decimal data
 template<uint32_t width>
-class ARROW_EXPORT BaseDecimalType : public DecimalType {
+class BaseDecimalType : public DecimalType {
  public:
   static constexpr const char* type_name() { return DecimalMeta<width>::name; }
 

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -33,6 +33,7 @@
 #include "arrow/util/macros.h"
 #include "arrow/util/variant.h"
 #include "arrow/util/visibility.h"
+#include "arrow/util/decimal_meta.h"
 #include "arrow/visitor.h"  // IWYU pragma: keep
 
 namespace arrow {
@@ -875,45 +876,36 @@ class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
   int32_t scale_;
 };
 
-/// \brief Concrete type class for 128-bit decimal data
-class ARROW_EXPORT Decimal128Type : public DecimalType {
+
+/// \brief Template type class for decimal data
+template<uint32_t width>
+class ARROW_EXPORT BaseDecimalType : public DecimalType {
  public:
-  static constexpr Type::type type_id = Type::DECIMAL128;
+  static constexpr const char* type_name() { return DecimalMeta<width>::name; }
 
-  static constexpr const char* type_name() { return "decimal"; }
+  /// BaseDecimalType constructor that aborts on invalid input.
+  explicit BaseDecimalType(int32_t precision, int32_t scale);
 
-  /// Decimal128Type constructor that aborts on invalid input.
-  explicit Decimal128Type(int32_t precision, int32_t scale);
-
-  /// Decimal128Type constructor that returns an error on invalid input.
+  /// BaseDecimalType constructor that returns an error on invalid input.
   static Result<std::shared_ptr<DataType>> Make(int32_t precision, int32_t scale);
 
   std::string ToString() const override;
-  std::string name() const override { return "decimal"; }
+  std::string name() const override { return DecimalMeta<width>::name; }
 
   static constexpr int32_t kMinPrecision = 1;
-  static constexpr int32_t kMaxPrecision = 38;
+  static constexpr int32_t kMaxPrecision = DecimalMeta<width>::max_precision;
 };
 
-/// \brief Concrete type class for 256-bit decimal data
-class ARROW_EXPORT Decimal256Type : public DecimalType {
- public:
-  static constexpr Type::type type_id = Type::DECIMAL256;
-
-  static constexpr const char* type_name() { return "decimal256"; }
-
-  /// Decimal256Type constructor that aborts on invalid input.
-  explicit Decimal256Type(int32_t precision, int32_t scale);
-
-  /// Decimal256Type constructor that returns an error on invalid input.
-  static Result<std::shared_ptr<DataType>> Make(int32_t precision, int32_t scale);
-
-  std::string ToString() const override;
-  std::string name() const override { return "decimal256"; }
-
-  static constexpr int32_t kMinPrecision = 1;
-  static constexpr int32_t kMaxPrecision = 76;
+#define DECIMAL_TYPE_DECL(width)                                             \
+class ARROW_EXPORT Decimal##width##Type : public BaseDecimalType<width> {    \
+  public: static constexpr Type::type type_id = Type::DECIMAL##width;        \
+          using BaseDecimalType<width>::BaseDecimalType;                     \
 };
+
+DECIMAL_TYPE_DECL(128)
+DECIMAL_TYPE_DECL(256)
+
+#undef DECIMAL_TYPE_DECL
 
 /// \brief Concrete type class for union data
 class ARROW_EXPORT UnionType : public NestedType {

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -149,7 +149,7 @@ class Decimal##width;           \
 class Decimal##width##Type;     \
 class Decimal##width##Array;    \
 class Decimal##width##Builder;  \
-class Decimal##width##Scalar;
+struct Decimal##width##Scalar;
 
 DECIMAL_DECL(128)
 DECIMAL_DECL(256)

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -142,17 +142,20 @@ class StructArray;
 class StructBuilder;
 struct StructScalar;
 
-class Decimal128;
-class Decimal256;
 class DecimalType;
-class Decimal128Type;
-class Decimal256Type;
-class Decimal128Array;
-class Decimal256Array;
-class Decimal128Builder;
-class Decimal256Builder;
-struct Decimal128Scalar;
-struct Decimal256Scalar;
+
+#define DECIMAL_DECL(width)     \
+class Decimal##width;           \
+class Decimal##width##Type;     \
+class Decimal##width##Array;    \
+class Decimal##width##Builder;  \
+class Decimal##width##Scalar;
+
+DECIMAL_DECL(128)
+DECIMAL_DECL(256)
+
+#undef DECIMAL_DECL
+
 
 struct UnionMode {
   enum type { SPARSE, DENSE };

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -281,21 +281,20 @@ struct TypeTraits<HalfFloatType> {
   static inline std::shared_ptr<DataType> type_singleton() { return float16(); }
 };
 
-template <>
-struct TypeTraits<Decimal128Type> {
-  using ArrayType = Decimal128Array;
-  using BuilderType = Decimal128Builder;
-  using ScalarType = Decimal128Scalar;
-  constexpr static bool is_parameter_free = false;
+
+#define DECIMAL_TYPE_TRAITS_DEF(width)             \
+template <>                                        \
+struct TypeTraits<Decimal##width##Type> {          \
+  using ArrayType = Decimal##width##Array;         \
+  using BuilderType = Decimal##width##Builder;     \
+  using ScalarType = Decimal##width##Scalar;       \
+  constexpr static bool is_parameter_free = false; \
 };
 
-template <>
-struct TypeTraits<Decimal256Type> {
-  using ArrayType = Decimal256Array;
-  using BuilderType = Decimal256Builder;
-  using ScalarType = Decimal256Scalar;
-  constexpr static bool is_parameter_free = false;
-};
+DECIMAL_TYPE_TRAITS_DEF(128)
+DECIMAL_TYPE_TRAITS_DEF(256)
+
+#undef DECIMAL_TYPE_TRAITS_DEF
 
 template <>
 struct TypeTraits<BinaryType> {

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -789,7 +789,7 @@ BasicDecimal256::BasicDecimal256(const uint8_t* bytes)
           std::array<uint64_t, 4>({reinterpret_cast<const uint64_t*>(bytes)[3],
                                    reinterpret_cast<const uint64_t*>(bytes)[2],
                                    reinterpret_cast<const uint64_t*>(bytes)[1],
-                                   reinterpret_cast<const uint64_t*>(bytes)[0]})) {
+                                   reinterpret_cast<const uint64_t*>(bytes)[0]})) {}
 #endif
 
 BasicDecimal256& BasicDecimal256::Negate() {

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -30,6 +30,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/int128_internal.h"
 #include "arrow/util/int_util_internal.h"
+#include "arrow/util/decimal_meta.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 
@@ -175,7 +176,7 @@ BasicDecimal128 BasicDecimal128::Abs(const BasicDecimal128& in) {
 
 bool BasicDecimal128::FitsInPrecision(int32_t precision) const {
   DCHECK_GT(precision, 0);
-  DCHECK_LE(precision, 38);
+  DCHECK_LE(precision, DecimalMeta<128>::max_precision);
   return BasicDecimal128::Abs(*this) < ScaleMultipliers[precision];
 }
 
@@ -699,7 +700,7 @@ DecimalStatus BasicDecimal128::Rescale(int32_t original_scale, int32_t new_scale
   const int32_t abs_delta_scale = std::abs(delta_scale);
 
   DCHECK_GE(abs_delta_scale, 1);
-  DCHECK_LE(abs_delta_scale, 38);
+  DCHECK_LE(abs_delta_scale, DecimalMeta<128>::max_precision);
 
   BasicDecimal128 result(*this);
   const bool rescale_would_cause_data_loss =
@@ -716,7 +717,7 @@ DecimalStatus BasicDecimal128::Rescale(int32_t original_scale, int32_t new_scale
 void BasicDecimal128::GetWholeAndFraction(int scale, BasicDecimal128* whole,
                                           BasicDecimal128* fraction) const {
   DCHECK_GE(scale, 0);
-  DCHECK_LE(scale, 38);
+  DCHECK_LE(scale, DecimalMeta<128>::max_precision);
 
   BasicDecimal128 multiplier(ScaleMultipliers[scale]);
   auto s = Divide(multiplier, whole, fraction);
@@ -725,7 +726,7 @@ void BasicDecimal128::GetWholeAndFraction(int scale, BasicDecimal128* whole,
 
 const BasicDecimal128& BasicDecimal128::GetScaleMultiplier(int32_t scale) {
   DCHECK_GE(scale, 0);
-  DCHECK_LE(scale, 38);
+  DCHECK_LE(scale, DecimalMeta<128>::max_precision);
 
   return ScaleMultipliers[scale];
 }
@@ -734,14 +735,14 @@ const BasicDecimal128& BasicDecimal128::GetMaxValue() { return kMaxValue; }
 
 BasicDecimal128 BasicDecimal128::IncreaseScaleBy(int32_t increase_by) const {
   DCHECK_GE(increase_by, 0);
-  DCHECK_LE(increase_by, 38);
+  DCHECK_LE(increase_by, DecimalMeta<128>::max_precision);
 
   return (*this) * ScaleMultipliers[increase_by];
 }
 
 BasicDecimal128 BasicDecimal128::ReduceScaleBy(int32_t reduce_by, bool round) const {
   DCHECK_GE(reduce_by, 0);
-  DCHECK_LE(reduce_by, 38);
+  DCHECK_LE(reduce_by, DecimalMeta<128>::max_precision);
 
   if (reduce_by == 0) {
     return *this;

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <type_traits>
 
+#include "arrow/util/decimal_meta.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/type_traits.h"
 #include "arrow/util/visibility.h"
@@ -35,6 +36,7 @@ enum class DecimalStatus {
   kOverflow,
   kRescaleDataLoss,
 };
+
 
 /// Represents a signed 128-bit integer in two's complement.
 ///

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -23,7 +23,6 @@
 #include <string>
 #include <type_traits>
 
-#include "arrow/util/decimal_meta.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/type_traits.h"
 #include "arrow/util/visibility.h"
@@ -36,7 +35,6 @@ enum class DecimalStatus {
   kOverflow,
   kRescaleDataLoss,
 };
-
 
 /// Represents a signed 128-bit integer in two's complement.
 ///

--- a/cpp/src/arrow/util/decimal_meta.h
+++ b/cpp/src/arrow/util/decimal_meta.h
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+template<uint32_t width>
+struct DecimalMeta;
+
+template<>
+struct DecimalMeta<128> {
+  static constexpr const char* name = "decimal";
+  static constexpr int32_t max_precision = 38;
+};
+
+template<>
+struct DecimalMeta<256> {
+  static constexpr const char* name = "decimal256";
+  static constexpr int32_t max_precision = 76;
+};

--- a/cpp/src/arrow/util/decimal_type_traits.h
+++ b/cpp/src/arrow/util/decimal_type_traits.h
@@ -17,21 +17,25 @@
 
 #pragma once
 
+#include "arrow/type_fwd.h"
+
 namespace arrow {
 
 template<uint32_t width>
-struct DecimalMeta;
+struct DecimalTypeTraits;
 
-template<>
-struct DecimalMeta<128> {
-  static constexpr const char* name = "decimal";
-  static constexpr int32_t max_precision = 38;
+#define DECIMAL_TYPE_TRAITS_DECL(width)                  \
+template<>                                               \
+struct DecimalTypeTraits<width> {                        \
+  static constexpr Type::type Id = Type::DECIMAL##width; \
+  using ArrayType = Decimal##width##Array;               \
+  using BuilderType = Decimal##width##Builder;           \
+  using ScalarType = Decimal##width##Scalar;             \
+  using TypeClass = Decimal##width##Type;                \
+  using ValueType = Decimal##width;                      \
 };
 
-template<>
-struct DecimalMeta<256> {
-  static constexpr const char* name = "decimal256";
-  static constexpr int32_t max_precision = 76;
-};
+DECIMAL_TYPE_TRAITS_DECL(128)
+DECIMAL_TYPE_TRAITS_DECL(256)
 
 }  // namespace arrow


### PR DESCRIPTION
PR to get rid of code duplication while declaring new `Decimal##BIT_WIDTH##Type`. Since there is a plans to add support for lower bit Decimals also, I think Decimal256 branch is the best place to decide how we want to define the mechanism of adding support for new Decimal types without a lot of code duplications.

There are probably some places where we can remove redundant defines and template help structures, so this is just a draft PR to have a base for discussion.