### PR TITLE
ARROW-10256: [C++][Flight] Disable -Werror carefully

### DIFF
--- a/cpp/build-support/run-test.sh
+++ b/cpp/build-support/run-test.sh
@@ -96,7 +96,7 @@ function run_test() {
   # even when retries are successful.
   rm -f $XMLFILE
 
-  $TEST_EXECUTABLE "$@" 2>&1 $LOGFILE.raw
+  $TEST_EXECUTABLE "$@" > $LOGFILE.raw 2>&1
   STATUS=$?
   cat $LOGFILE.raw \
     | ${PYTHON:-python} $ROOT/build-support/asan_symbolize.py \

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -65,7 +65,7 @@ add_custom_target(flight_grpc_gen ALL DEPENDS ${FLIGHT_GENERATED_PROTO_FILES})
 # way to pass -isystem $GRPC_INCLUDE_DIR instead of -I$GRPC_INCLUDE_DIR
 set(CMAKE_CXX_FLAGS_BACKUP "${CMAKE_CXX_FLAGS}")
 string(REPLACE "/WX" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-string(REPLACE "-Werror" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+string(REPLACE "-Werror " " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 # Probe the version of gRPC being used to see if it supports disabling server
 # verification when using TLS.

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -40,7 +40,10 @@
 %define use_gandiva (%{_centos_ver} >= 8 && %{_arch} != "aarch64")
 %define use_ninja (%{_centos_ver} >= 8)
 %define use_parquet (%{_centos_ver} >= 7)
-%define use_s3 (%{_centos_ver} >= 8)
+# TODO: Enable this. This works on local but is fragile on GitHub Actions and
+# Travis CI.
+# %define use_s3 (%{_centos_ver} >= 8)
+%define use_s3 0
 
 %define use_glib (%{_centos_ver} >= 7)
 %define use_meson (%{_centos_ver} >= 8)


### PR DESCRIPTION
If we replace "-Werror" with "", "-Werror=SOMETHING" is
"=SOMETHING". "=SOMETHING" always causes build error because
"=SOMETHING" is treated as an input file.

For example, CentOS 8 RPM build uses "-Werror=format-security".