### PR TITLE
ARROW-10262: [C++] Fix TypeClass for BinaryScalar and LargeBinaryScalar

### DIFF
--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -214,7 +214,7 @@ struct ARROW_EXPORT BaseBinaryScalar : public Scalar {
 
 struct ARROW_EXPORT BinaryScalar : public BaseBinaryScalar {
   using BaseBinaryScalar::BaseBinaryScalar;
-  using TypeClass = BinaryScalar;
+  using TypeClass = BinaryType;
 
   BinaryScalar(std::shared_ptr<Buffer> value, std::shared_ptr<DataType> type)
       : BaseBinaryScalar(std::move(value), std::move(type)) {}
@@ -239,7 +239,7 @@ struct ARROW_EXPORT StringScalar : public BinaryScalar {
 
 struct ARROW_EXPORT LargeBinaryScalar : public BaseBinaryScalar {
   using BaseBinaryScalar::BaseBinaryScalar;
-  using TypeClass = LargeBinaryScalar;
+  using TypeClass = LargeBinaryType;
 
   LargeBinaryScalar(std::shared_ptr<Buffer> value, std::shared_ptr<DataType> type)
       : BaseBinaryScalar(std::move(value), std::move(type)) {}


### PR DESCRIPTION
Alias `TypeClass` in `BinaryScalar` and `LargeBinaryScalar` are seemingly typo-ed to be `BinaryScalar` and `LargeBinaryScalar`. This causes issues when using `ScalarType::TypeClass`, esp. with `TypeTrait` - i.e., compiler complains that there are no whatever members in specialized `TypeTrait<BinaryScalar>` and `TypeTrait<LargeBinaryScalar>`.

Fixing them to `BinaryType` and `LargeBinaryType`.