### PR TITLE
ARROW-10265: [CI] Use smaller build when cache doesn't exist on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,16 @@ jobs:
           -e ARROW_USE_GLOG=OFF
           -e CMAKE_UNITY_BUILD=ON
           "
+        # We need to use smaller build when cache doesn't exist
+        # because Travis CI has "No output has been received in the
+        # last 10m0s" limitation. If we build many modules, we reach
+        # the limitation.
+        DOCKER_RUN_ARGS_NO_CACHE: >-
+          "
+          -e ARROW_BUILD_TESTS=OFF
+          -e ARROW_GANDIVA=OFF
+          -e ARROW_PARQUET=OFF
+          "
         UBUNTU: "20.04"
 
     - name: "C++ on s390x"
@@ -130,6 +140,10 @@ script:
   #   /home/travis/.travis/functions: line 109: ulimit: core file size: cannot modify limit: Operation not permitted
   - |
     ulimit -c unlimited || :
+  - |
+    if [ $(ls $TRAVIS_BUILD_DIR/.docker | wc -l) -eq 0 ]; then
+      DOCKER_RUN_ARGS="${DOCKER_RUN_ARGS} ${DOCKER_RUN_ARGS_NO_CACHE}"
+    fi
   - |
     archery docker run \
       ${DOCKER_RUN_ARGS} \

--- a/ci/docker/ubuntu-20.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-20.04-cpp.dockerfile
@@ -92,7 +92,6 @@ RUN /arrow/ci/scripts/install_minio.sh ${arch} linux latest /usr/local
 # - libprotobuf-dev only provide sources
 ENV ARROW_BUILD_TESTS=ON \
     ARROW_DEPENDENCY_SOURCE=SYSTEM \
-    ARROW_S3=ON \
     ARROW_DATASET=ON \
     ARROW_FLIGHT=OFF \
     ARROW_GANDIVA=ON \
@@ -103,6 +102,7 @@ ENV ARROW_BUILD_TESTS=ON \
     ARROW_ORC=ON \
     ARROW_PARQUET=ON \
     ARROW_PLASMA=ON \
+    ARROW_S3=ON \
     ARROW_USE_ASAN=OFF \
     ARROW_USE_CCACHE=ON \
     ARROW_USE_UBSAN=OFF \


### PR DESCRIPTION
Because Travis CI has "No output has been received in the last 10m0s"
limitation. If we build many modules, we will reach the limitation.