### PR TITLE
ARROW-10266: [CI][macOS] Ensure using Python 3.8 with Homebrew

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -116,7 +116,7 @@ jobs:
         run: archery docker push ${{ matrix.image }}
 
   macos:
-    name: AMD64 MacOS 10.15 Python 3.7
+    name: AMD64 MacOS 10.15 Python 3
     runs-on: macos-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     env:
@@ -150,8 +150,9 @@ jobs:
           brew update --preinstall
           brew bundle --file=cpp/Brewfile
           brew install coreutils python
-          pip3 install -r python/requirements-build.txt \
-                       -r python/requirements-test.txt
+          python3 -mpip install \
+            -r python/requirements-build.txt \
+            -r python/requirements-test.txt
       - name: Build
         shell: bash
         run: |


### PR DESCRIPTION
/usr/local/bin/python3 is a symbolic link to python3.8 but
/usr/local/bin/pip3 is a symbolic link to pip3.9 not pip3.8. We should
use the same Python with pip.