### PR TITLE
ARROW-10273: [CI][Homebrew] Fix "brew audit" usage

### DIFF
--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -24,6 +24,8 @@ class ApacheArrow < Formula
 
   def install
     ENV.cxx11
+    # link against system libc++ instead of llvm provided libc++
+    ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
     args = %W[
       -DARROW_FLIGHT=ON
       -DARROW_GANDIVA=ON

--- a/dev/tasks/homebrew-formulae/travis.osx.yml
+++ b/dev/tasks/homebrew-formulae/travis.osx.yml
@@ -42,7 +42,8 @@ before_script:
 - brew unlink python@2
 - brew config
 - brew doctor || true
-- brew audit $ARROW_FORMULA
+- cp $ARROW_FORMULA $(brew --repository homebrew/core)/Formula/apache-arrow.rb
 script:
-- brew install -v --HEAD $ARROW_FORMULA
-- brew test $ARROW_FORMULA
+- brew install -v --HEAD apache-arrow
+- brew test apache-arrow
+- brew audit --strict apache-arrow


### PR DESCRIPTION
It should be ran against installed formula.