### PR TITLE
ARROW-10271: [Rust] Update dependencies

### DIFF
--- a/rust/arrow-flight/Cargo.toml
+++ b/rust/arrow-flight/Cargo.toml
@@ -27,7 +27,7 @@ license = "Apache-2.0"
 
 [dependencies]
 arrow = { path = "../arrow", version = "2.0.0-SNAPSHOT" }
-tonic = "0.2"
+tonic = "0.3"
 bytes = "0.5"
 prost = "0.6"
 prost-derive = "0.6"
@@ -35,10 +35,10 @@ tokio = {version = "0.2", features = ["macros"]}
 futures = { version = "0.3", default-features = false, features = ["alloc"]}
 
 [build-dependencies]
-tonic-build = "0.2"
+tonic-build = "0.3"
 # Pin specific version of the tonic-build dependencies to avoid auto-generated
 # (and checked in) arrow.flight.protocol.rs from changing
-proc-macro2 = "=1.0.18"
+proc-macro2 = "=1.0.24"
 
 #[lib]
 #name = "flight"

--- a/rust/arrow-flight/src/arrow.flight.protocol.rs
+++ b/rust/arrow-flight/src/arrow.flight.protocol.rs
@@ -632,7 +632,6 @@ pub mod flight_service_server {
     #[doc = " accessed using the Arrow Flight Protocol. Additionally, a flight service"]
     #[doc = " can expose a set of actions that are available."]
     #[derive(Debug)]
-    #[doc(hidden)]
     pub struct FlightServiceServer<T: FlightService> {
         inner: _Inner<T>,
     }
@@ -687,7 +686,7 @@ pub mod flight_service_server {
                             >,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.handshake(request).await };
+                            let fut = async move { (*inner).handshake(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -725,7 +724,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Criteria>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.list_flights(request).await };
+                            let fut = async move { (*inner).list_flights(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -760,7 +759,8 @@ pub mod flight_service_server {
                             request: tonic::Request<super::FlightDescriptor>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.get_flight_info(request).await };
+                            let fut =
+                                async move { (*inner).get_flight_info(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -795,7 +795,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::FlightDescriptor>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.get_schema(request).await };
+                            let fut = async move { (*inner).get_schema(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -833,7 +833,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Ticket>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.do_get(request).await };
+                            let fut = async move { (*inner).do_get(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -871,7 +871,7 @@ pub mod flight_service_server {
                             request: tonic::Request<tonic::Streaming<super::FlightData>>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.do_put(request).await };
+                            let fut = async move { (*inner).do_put(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -909,7 +909,7 @@ pub mod flight_service_server {
                             request: tonic::Request<tonic::Streaming<super::FlightData>>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.do_exchange(request).await };
+                            let fut = async move { (*inner).do_exchange(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -947,7 +947,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Action>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.do_action(request).await };
+                            let fut = async move { (*inner).do_action(request).await };
                             Box::pin(fut)
                         }
                     }
@@ -985,7 +985,7 @@ pub mod flight_service_server {
                             request: tonic::Request<super::Empty>,
                         ) -> Self::Future {
                             let inner = self.0.clone();
-                            let fut = async move { inner.list_actions(request).await };
+                            let fut = async move { (*inner).list_actions(request).await };
                             Box::pin(fut)
                         }
                     }

--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -39,13 +39,13 @@ path = "src/lib.rs"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = { version = "1.0", features = ["preserve_order"] }
-indexmap = "1.4"
+indexmap = "1.6"
 rand = "0.7"
 csv = "1.1"
 num = "0.3"
 regex = "1.3"
 lazy_static = "1.4"
-packed_simd = { version = "0.3", optional = true }
+packed_simd = { version = "0.3.4", optional = true, package = "packed_simd_2" }
 chrono = "0.4"
 flatbuffers = "0.6"
 hex = "0.4"

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -54,7 +54,7 @@ crossbeam = "0.7"
 paste = "0.1"
 num_cpus = "1.13.0"
 chrono = "0.4"
-async-trait = "0.1.36"
+async-trait = "0.1.41"
 tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded"] }
 
 [dev-dependencies]
@@ -64,7 +64,7 @@ tempfile = "3"
 futures = "0.3"
 prost = "0.6"
 arrow-flight = { path = "../arrow-flight", version = "2.0.0-SNAPSHOT" }
-tonic = "0.2"
+tonic = "0.3"
 
 [[bench]]
 name = "aggregate_query_sql"

--- a/rust/parquet_derive/Cargo.toml
+++ b/rust/parquet_derive/Cargo.toml
@@ -18,6 +18,8 @@
 [package]
 name = "parquet_derive"
 version = "2.0.0-SNAPSHOT"
+homepage = "https://github.com/apache/arrow"
+repository = "https://github.com/apache/arrow"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "parquet" ]
 edition = "2018"
@@ -31,7 +33,7 @@ bigdecimal = []
 uuid = []
 
 [dependencies]
-proc-macro2 = "1.0.8"
-quote = "1.0.2"
-syn = { version = "1.0.14", features = ["full", "extra-traits"] }
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = { version = "1.0", features = ["full", "extra-traits"] }
 parquet = { path = "../parquet", version = "2.0.0-SNAPSHOT" }

--- a/rust/parquet_derive/Cargo.toml
+++ b/rust/parquet_derive/Cargo.toml
@@ -18,8 +18,6 @@
 [package]
 name = "parquet_derive"
 version = "2.0.0-SNAPSHOT"
-homepage = "https://github.com/apache/arrow"
-repository = "https://github.com/apache/arrow"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "parquet" ]
 edition = "2018"

--- a/rust/parquet_derive/src/parquet_field.rs
+++ b/rust/parquet_derive/src/parquet_field.rs
@@ -690,7 +690,7 @@ mod test {
                 "u8",
                 "bool",
                 "std :: string :: String",
-                "std :: result :: Result < ( ) , ( ) >"
+                "std :: result :: Result < () , () >"
             ]
         )
     }

--- a/rust/parquet_derive_test/Cargo.toml
+++ b/rust/parquet_derive_test/Cargo.toml
@@ -18,6 +18,8 @@
 [package]
 name = "parquet_derive_test"
 version = "2.0.0-SNAPSHOT"
+homepage = "https://github.com/apache/arrow"
+repository = "https://github.com/apache/arrow"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "parquet" ]
 edition = "2018"

--- a/rust/parquet_derive_test/Cargo.toml
+++ b/rust/parquet_derive_test/Cargo.toml
@@ -18,8 +18,6 @@
 [package]
 name = "parquet_derive_test"
 version = "2.0.0-SNAPSHOT"
-homepage = "https://github.com/apache/arrow"
-repository = "https://github.com/apache/arrow"
 authors = ["Apache Arrow <dev@arrow.apache.org>"]
 keywords = [ "parquet" ]
 edition = "2018"


### PR DESCRIPTION
Tested by running tests, benchmarks and examples.
Did this with `simd` on and off

The main one here is `packed_simd` > `packed_simd_2`,
as the former is broken on recent nightlies