### PR TITLE
ARROW-10286: [C++][FlightRPC] Make CMake output less confusing

### DIFF
--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -69,34 +69,43 @@ string(REPLACE "-Werror " " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 # Probe the version of gRPC being used to see if it supports disabling server
 # verification when using TLS.
-message(STATUS "Checking support for TlsCredentialsOptions...")
-get_property(CURRENT_INCLUDE_DIRECTORIES
-             DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-             PROPERTY INCLUDE_DIRECTORIES)
-try_compile(HAS_GRPC_132 ${CMAKE_CURRENT_BINARY_DIR}/try_compile SOURCES
-            "${CMAKE_CURRENT_SOURCE_DIR}/try_compile/check_tls_opts_132.cc"
-            CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${CURRENT_INCLUDE_DIRECTORIES}"
-            LINK_LIBRARIES gRPC::grpc
-            OUTPUT_VARIABLE TSL_CREDENTIALS_OPTIONS_CHECK_OUTPUT CXX_STANDARD 11)
-
-if(HAS_GRPC_132)
-  message(STATUS "TlsCredentialsOptions found in grpc::experimental.")
-  add_definitions(-DGRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS=grpc::experimental)
-else()
-  message(STATUS "TlsCredentialsOptions not found in grpc::experimental.")
-  message(STATUS "Build output: ${TSL_CREDENTIALS_OPTIONS_CHECK_OUTPUT}")
-
-  try_compile(HAS_GRPC_127 ${CMAKE_CURRENT_BINARY_DIR}/try_compile SOURCES
-              "${CMAKE_CURRENT_SOURCE_DIR}/try_compile/check_tls_opts_127.cc"
+if(NOT DEFINED HAS_GRPC_132)
+  message(STATUS "Checking support for TlsCredentialsOptions...")
+  get_property(CURRENT_INCLUDE_DIRECTORIES
+               DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+               PROPERTY INCLUDE_DIRECTORIES)
+  try_compile(HAS_GRPC_132 ${CMAKE_CURRENT_BINARY_DIR}/try_compile SOURCES
+              "${CMAKE_CURRENT_SOURCE_DIR}/try_compile/check_tls_opts_132.cc"
               CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${CURRENT_INCLUDE_DIRECTORIES}"
+              LINK_LIBRARIES gRPC::grpc
               OUTPUT_VARIABLE TSL_CREDENTIALS_OPTIONS_CHECK_OUTPUT CXX_STANDARD 11)
 
-  if(HAS_GRPC_127)
-    message(STATUS "TlsCredentialsOptions found in grpc_impl::experimental.")
-    add_definitions(-DGRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS=grpc_impl::experimental)
+  if(HAS_GRPC_132)
+    message(STATUS "TlsCredentialsOptions found in grpc::experimental.")
+    add_definitions(-DGRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS=grpc::experimental)
   else()
-    message(STATUS "TlsCredentialsOptions not found in grpc_impl::experimental.")
-    message(STATUS "Build output: ${TSL_CREDENTIALS_OPTIONS_CHECK_OUTPUT}")
+    message(STATUS "TlsCredentialsOptions not found in grpc::experimental.")
+    message(DEBUG "Build output:")
+    list(APPEND CMAKE_MESSAGE_INDENT "check_tls_opts_132.cc: ")
+    message(DEBUG ${TSL_CREDENTIALS_OPTIONS_CHECK_OUTPUT})
+    list(POP_BACK CMAKE_MESSAGE_INDENT)
+
+    try_compile(HAS_GRPC_127 ${CMAKE_CURRENT_BINARY_DIR}/try_compile SOURCES
+                "${CMAKE_CURRENT_SOURCE_DIR}/try_compile/check_tls_opts_127.cc"
+                CMAKE_FLAGS "-DINCLUDE_DIRECTORIES=${CURRENT_INCLUDE_DIRECTORIES}"
+                OUTPUT_VARIABLE TSL_CREDENTIALS_OPTIONS_CHECK_OUTPUT CXX_STANDARD 11)
+
+    if(HAS_GRPC_127)
+      message(STATUS "TlsCredentialsOptions found in grpc_impl::experimental.")
+      add_definitions(
+        -DGRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS=grpc_impl::experimental)
+    else()
+      message(STATUS "TlsCredentialsOptions not found in grpc_impl::experimental.")
+      message(DEBUG "Build output:")
+      list(APPEND CMAKE_MESSAGE_INDENT "check_tls_opts_127.cc: ")
+      message(DEBUG ${TSL_CREDENTIALS_OPTIONS_CHECK_OUTPUT})
+      list(POP_BACK CMAKE_MESSAGE_INDENT)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
- Check `DEFINED` to avoid re-running the check on every CMake invocation
- Log compiler output at DEBUG level to avoid dumping it by default
- Use CMAKE_MESSAGE_INDENT to make it clearer that this is the output of a subcommand