### PR TITLE
ARROW-10287: [C++] Avoid std::random_device

### DIFF
--- a/cpp/src/arrow/io/slow.cc
+++ b/cpp/src/arrow/io/slow.cc
@@ -28,6 +28,7 @@
 #include "arrow/io/util_internal.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/util/io_util.h"
 #include "arrow/util/logging.h"
 
 namespace arrow {
@@ -64,8 +65,8 @@ void LatencyGenerator::Sleep() {
 }
 
 std::shared_ptr<LatencyGenerator> LatencyGenerator::Make(double average_latency) {
-  auto seed = static_cast<int32_t>(std::random_device()());
-  return std::make_shared<LatencyGeneratorImpl>(average_latency, seed);
+  return std::make_shared<LatencyGeneratorImpl>(average_latency,
+                                                ::arrow::internal::GetRandomSeed());
 }
 
 std::shared_ptr<LatencyGenerator> LatencyGenerator::Make(double average_latency,

--- a/cpp/src/arrow/io/slow.cc
+++ b/cpp/src/arrow/io/slow.cc
@@ -65,8 +65,8 @@ void LatencyGenerator::Sleep() {
 }
 
 std::shared_ptr<LatencyGenerator> LatencyGenerator::Make(double average_latency) {
-  return std::make_shared<LatencyGeneratorImpl>(average_latency,
-                                                ::arrow::internal::GetRandomSeed());
+  return std::make_shared<LatencyGeneratorImpl>(
+      average_latency, static_cast<int32_t>(::arrow::internal::GetRandomSeed()));
 }
 
 std::shared_ptr<LatencyGenerator> LatencyGenerator::Make(double average_latency,

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -34,7 +34,7 @@ class Array;
 
 namespace random {
 
-using SeedType = std::random_device::result_type;
+using SeedType = int32_t;
 constexpr SeedType kSeedMax = std::numeric_limits<SeedType>::max();
 
 class ARROW_TESTING_EXPORT RandomArrayGenerator {

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1467,14 +1467,8 @@ std::vector<NativePathString> GetPlatformTemporaryDirs() {
 
 std::string MakeRandomName(int num_chars) {
   static const std::string chars = "0123456789abcdefghijklmnopqrstuvwxyz";
-#ifdef ARROW_VALGRIND
-  // Valgrind can crash, hang or enter an infinite loop on std::random_device,
-  // use a PRNG instead.
-  static std::random_device::result_type seed = 42;
-  std::default_random_engine gen(seed++);
-#else
-  std::random_device gen;
-#endif
+  std::default_random_engine gen(
+      static_cast<std::default_random_engine::result_type>(GetRandomSeed()));
   std::uniform_int_distribution<int> dist(0, static_cast<int>(chars.length() - 1));
 
   std::string s;
@@ -1484,6 +1478,7 @@ std::string MakeRandomName(int num_chars) {
   }
   return s;
 }
+
 }  // namespace
 
 Result<std::unique_ptr<TemporaryDir>> TemporaryDir::Make(const std::string& prefix) {
@@ -1591,6 +1586,31 @@ Result<SignalHandler> SetSignalHandler(int signum, const SignalHandler& handler)
   return SignalHandler(cb);
 #endif
   return Status::OK();
+}
+
+namespace {
+
+std::mt19937_64 GetSeedGenerator() {
+  // Initialize Mersenne Twister PRNG with a true random seed.
+#ifdef ARROW_VALGRIND
+  // Valgrind can crash, hang or enter an infinite loop on std::random_device,
+  // use a hardcoded initializer instead.
+  std::mt19937_64 seed_gen(reinterpret_cast<uintptr_t>(&GetSeedGenerator));
+#else
+  std::random_device true_random;
+  std::mt19937_64 seed_gen(static_cast<uint64_t>(true_random()) ^
+                           (static_cast<uint64_t>(true_random()) << 32));
+#endif
+  return seed_gen;
+}
+
+}  // namespace
+
+int64_t GetRandomSeed() {
+  // The process-global seed generator to aims to avoid calling std::random_device
+  // unless truly necessary (it can block on some systems, see ARROW-10287).
+  static auto seed_gen = GetSeedGenerator();
+  return static_cast<int64_t>(seed_gen());
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1594,8 +1594,12 @@ std::mt19937_64 GetSeedGenerator() {
   // Initialize Mersenne Twister PRNG with a true random seed.
 #ifdef ARROW_VALGRIND
   // Valgrind can crash, hang or enter an infinite loop on std::random_device,
-  // use a hardcoded initializer instead.
-  std::mt19937_64 seed_gen(reinterpret_cast<uintptr_t>(&GetSeedGenerator));
+  // use a crude initializer instead.
+  // Make sure to mix in process id to avoid clashes when parallel testing.
+  const uint8_t dummy = 0;
+  ARROW_UNUSED(dummy);
+  std::mt19937_64 seed_gen(reinterpret_cast<uintptr_t>(&dummy) ^
+                           static_cast<uintptr_t>(getpid()));
 #else
   std::random_device true_random;
   std::mt19937_64 seed_gen(static_cast<uint64_t>(true_random()) ^

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -347,11 +347,21 @@ class ARROW_EXPORT SignalHandler {
 /// \brief Return the current handler for the given signal number.
 ARROW_EXPORT
 Result<SignalHandler> GetSignalHandler(int signum);
+
 /// \brief Set a new handler for the given signal number.
 ///
 /// The old signal handler is returned.
 ARROW_EXPORT
 Result<SignalHandler> SetSignalHandler(int signum, const SignalHandler& handler);
+
+/// \brief Get an unpredictable random seed
+///
+/// This function may be slightly costly, so should only be used to initialize
+/// a PRNG, not to generate a large amount of random numbers.
+/// It is better to use this function rather than std::random_device, unless
+/// absolutely necessary (e.g. to generate a cryptographic secret).
+ARROW_EXPORT
+int64_t GetRandomSeed();
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -30,6 +30,7 @@
 #include "arrow/type.h"
 #include "arrow/util/bit_stream_utils.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/io_util.h"
 #include "arrow/util/rle_encoding.h"
 
 namespace arrow {
@@ -418,14 +419,12 @@ TEST(BitRle, Random) {
   std::vector<int> values(ngroups + max_group_size);
 
   // prng setup
-  std::random_device rd;
+  const auto seed = ::arrow::internal::GetRandomSeed();
+  std::default_random_engine gen(seed);
   std::uniform_int_distribution<int> dist(1, 20);
 
   for (int iter = 0; iter < niters; ++iter) {
     // generate a seed with device entropy
-    uint32_t seed = rd();
-    std::mt19937 gen(seed);
-
     bool parity = 0;
     values.resize(0);
 

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -420,7 +420,8 @@ TEST(BitRle, Random) {
 
   // prng setup
   const auto seed = ::arrow::internal::GetRandomSeed();
-  std::default_random_engine gen(seed);
+  std::default_random_engine gen(
+      static_cast<std::default_random_engine::result_type>(seed));
   std::uniform_int_distribution<int> dist(1, 20);
 
   for (int iter = 0; iter < niters; ++iter) {

--- a/cpp/src/gandiva/random_generator_holder.h
+++ b/cpp/src/gandiva/random_generator_holder.h
@@ -21,6 +21,7 @@
 #include <random>
 
 #include "arrow/status.h"
+#include "arrow/util/io_util.h"
 
 #include "gandiva/function_holder.h"
 #include "gandiva/node.h"
@@ -46,8 +47,7 @@ class GANDIVA_EXPORT RandomGeneratorHolder : public FunctionHolder {
   }
 
   RandomGeneratorHolder() : distribution_(0, 1) {
-    std::random_device rd;
-    generator_.seed(rd());
+    generator_.seed(::arrow::internal::GetRandomSeed());
   }
 
   std::mt19937_64 generator_;

--- a/cpp/src/gandiva/tests/generate_data.h
+++ b/cpp/src/gandiva/tests/generate_data.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "arrow/util/decimal.h"
+#include "arrow/util/io_util.h"
 
 #pragma once
 
@@ -35,18 +36,13 @@ class DataGenerator {
 
 class Random {
  public:
-  explicit Random(uint32_t seed = 100) : seed_(seed) {}
+  Random() : gen_(::arrow::internal::GetRandomSeed()) {}
+  explicit Random(uint64_t seed) : gen_(seed) {}
 
-  // This is 3 times faster than random_device
-#ifndef _MSC_VER
-  int32_t next() { return rand_r(&seed_); }
-#else
-  int32_t next() { return random_dev_(); }
-#endif
+  int32_t next() { return gen_(); }
 
  private:
-  uint32_t seed_;
-  std::random_device random_dev_;
+  std::default_random_engine gen_;
 };
 
 class Int32DataGenerator : public DataGenerator<int32_t> {


### PR DESCRIPTION
std::random_device may block on some systems, even for long times.