### PR TITLE
ARROW-10197: [python][Gandiva] Execute expression on filtered data

### DIFF
--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -156,7 +156,7 @@ cdef class Projector(_Weakrefable):
 
     def evaluate(self, RecordBatch batch, SelectionVector selection=None):
         cdef vector[shared_ptr[CArray]] results
-        if selection == None:
+        if selection is None:
             check_status(self.projector.get().Evaluate(
                 batch.sp_batch.get()[0], self.pool.pool, &results))
         else:
@@ -404,7 +404,8 @@ cdef class TreeExprBuilder(_Weakrefable):
             condition.node)
         return Condition.create(r)
 
-cpdef make_projector(Schema schema, children, MemoryPool pool, str selection_mode="NONE"):
+cpdef make_projector(Schema schema, children, MemoryPool pool,
+        str selection_mode = "NONE"):
     cdef c_vector[shared_ptr[CExpression]] c_children
     cdef Expression child
     for child in children:

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -405,7 +405,7 @@ cdef class TreeExprBuilder(_Weakrefable):
         return Condition.create(r)
 
 cpdef make_projector(Schema schema, children, MemoryPool pool,
-        str selection_mode = "NONE"):
+                     str selection_mode="NONE"):
     cdef c_vector[shared_ptr[CExpression]] c_children
     cdef Expression child
     for child in children:

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -78,7 +78,6 @@ from pyarrow.includes.libgandiva cimport (
     CFunctionSignature,
     GetRegisteredFunctionSignatures)
 
-
 cdef class Node(_Weakrefable):
     cdef:
         shared_ptr[CNode] node
@@ -180,10 +179,13 @@ cdef class Projector(_Weakrefable):
             arrays.append(pyarrow_wrap_array(result))
         return arrays
 
-    def evaluate_with_selection(self, RecordBatch batch, SelectionVector selection):
+    def evaluate_with_selection(self, RecordBatch batch,
+                                SelectionVector selection):
         cdef vector[shared_ptr[CArray]] results
-        check_status(self.projector.get().Evaluate(
-            batch.sp_batch.get()[0], selection.selection_vector.get(), self.pool.pool, &results))
+        check_status(
+            self.projector.get().Evaluate(
+                batch.sp_batch.get()[0], selection.selection_vector.get(),
+                self.pool.pool, &results))
 
         cdef shared_ptr[CArray] result
         arrays = []
@@ -435,7 +437,8 @@ cpdef make_projector(Schema schema, children, MemoryPool pool):
                                 &result))
     return Projector.create(result, pool)
 
-cpdef make_projector_with_mode(Schema schema, children, str selection_mode, MemoryPool pool):
+cpdef make_projector_with_mode(Schema schema, children,
+                               str selection_mode, MemoryPool pool):
     cdef c_vector[shared_ptr[CExpression]] c_children
     cdef Expression child
     for child in children:
@@ -443,13 +446,15 @@ cpdef make_projector_with_mode(Schema schema, children, str selection_mode, Memo
     cdef shared_ptr[CProjector] result
     cdef Configuration configuration = Configuration.create()
     cdef CSelectionVector_Mode mode = _ensure_selection_mode(selection_mode)
-    check_status(Projector_Make(schema.sp_schema, c_children, mode, configuration.config,
-                                &result))
+    check_status(
+        Projector_Make(schema.sp_schema, c_children, mode,
+                       configuration.config, &result))
     return Projector.create(result, pool)
 
 cpdef make_filter(Schema schema, Condition condition):
     cdef shared_ptr[CFilter] result
-    check_status(Filter_Make(schema.sp_schema, condition.condition, &result))
+    check_status(
+        Filter_Make(schema.sp_schema, condition.condition, &result))
     return Filter.create(result)
 
 cdef class FunctionSignature(_Weakrefable):

--- a/python/pyarrow/includes/libgandiva.pxd
+++ b/python/pyarrow/includes/libgandiva.pxd
@@ -45,9 +45,12 @@ cdef extern from "gandiva/selection_vector.h" namespace "gandiva" nogil:
 
     enum CSelectionVector_Mode" gandiva::SelectionVector::Mode":
         CSelectionVector_Mode_NONE" gandiva::SelectionVector::Mode::MODE_NONE"
-        CSelectionVector_Mode_UINT16" gandiva::SelectionVector::Mode::MODE_UINT16"
-        CSelectionVector_Mode_UINT32" gandiva::SelectionVector::Mode::MODE_UINT32"
-        CSelectionVector_Mode_UINT64" gandiva::SelectionVector::Mode::MODE_UINT64"
+        CSelectionVector_Mode_UINT16" \
+                gandiva::SelectionVector::Mode::MODE_UINT16"
+        CSelectionVector_Mode_UINT32" \
+                gandiva::SelectionVector::Mode::MODE_UINT32"
+        CSelectionVector_Mode_UINT64" \
+                gandiva::SelectionVector::Mode::MODE_UINT64"
 
     cdef CStatus SelectionVector_MakeInt16\
         "gandiva::SelectionVector::MakeInt16"(
@@ -276,4 +279,3 @@ cdef extern from "gandiva/configuration.h" namespace "gandiva" nogil:
             " gandiva::ConfigurationBuilder":
         @staticmethod
         shared_ptr[CConfiguration] DefaultConfiguration()
-

--- a/python/pyarrow/includes/libgandiva.pxd
+++ b/python/pyarrow/includes/libgandiva.pxd
@@ -43,6 +43,12 @@ cdef extern from "gandiva/selection_vector.h" namespace "gandiva" nogil:
 
         shared_ptr[CArray] ToArray()
 
+    enum CSelectionVector_Mode" gandiva::SelectionVector::Mode":
+        CSelectionVector_Mode_NONE" gandiva::SelectionVector::Mode::MODE_NONE"
+        CSelectionVector_Mode_UINT16" gandiva::SelectionVector::Mode::MODE_UINT16"
+        CSelectionVector_Mode_UINT32" gandiva::SelectionVector::Mode::MODE_UINT32"
+        CSelectionVector_Mode_UINT64" gandiva::SelectionVector::Mode::MODE_UINT64"
+
     cdef CStatus SelectionVector_MakeInt16\
         "gandiva::SelectionVector::MakeInt16"(
             int64_t max_slots, CMemoryPool* pool,
@@ -57,6 +63,31 @@ cdef extern from "gandiva/selection_vector.h" namespace "gandiva" nogil:
         "gandiva::SelectionVector::MakeInt64"(
             int64_t max_slots, CMemoryPool* pool,
             shared_ptr[CSelectionVector]* selection_vector)
+
+cdef inline CSelectionVector_Mode _ensure_selection_mode(str name) except *:
+    uppercase = name.upper()
+    if uppercase == 'NONE':
+        return CSelectionVector_Mode_NONE
+    elif uppercase == 'UINT16':
+        return CSelectionVector_Mode_UINT16
+    elif uppercase == 'UINT32':
+        return CSelectionVector_Mode_UINT32
+    elif uppercase == 'UINT64':
+        return CSelectionVector_Mode_UINT64
+    else:
+        raise ValueError('Invalid value for Selection Mode: {!r}'.format(name))
+
+cdef inline str _selection_mode_name(CSelectionVector_Mode ctype):
+    if ctype == CSelectionVector_Mode_NONE:
+        return 'NONE'
+    elif ctype == CSelectionVector_Mode_UINT16:
+        return 'UINT16'
+    elif ctype == CSelectionVector_Mode_UINT32:
+        return 'UINT32'
+    elif ctype == CSelectionVector_Mode_UINT64:
+        return 'UINT64'
+    else:
+        raise RuntimeError('Unexpected CSelectionVector_Mode value')
 
 cdef extern from "gandiva/condition.h" namespace "gandiva" nogil:
 
@@ -180,11 +211,24 @@ cdef extern from "gandiva/projector.h" namespace "gandiva" nogil:
             const CRecordBatch& batch, CMemoryPool* pool,
             const CArrayVector* output)
 
+        CStatus Evaluate(
+            const CRecordBatch& batch,
+            const CSelectionVector* selection,
+            CMemoryPool* pool,
+            const CArrayVector* output)
+
         c_string DumpIR()
 
     cdef CStatus Projector_Make \
         "gandiva::Projector::Make"(
             shared_ptr[CSchema] schema, const CExpressionVector& children,
+            shared_ptr[CProjector]* projector)
+
+    cdef CStatus Projector_Make \
+        "gandiva::Projector::Make"(
+            shared_ptr[CSchema] schema, const CExpressionVector& children,
+            CSelectionVector_Mode mode,
+            shared_ptr[CConfiguration] configuration,
             shared_ptr[CProjector]* projector)
 
 cdef extern from "gandiva/filter.h" namespace "gandiva" nogil:
@@ -222,3 +266,14 @@ cdef extern from "gandiva/expression_registry.h" namespace "gandiva" nogil:
 
     cdef vector[shared_ptr[CFunctionSignature]] \
         GetRegisteredFunctionSignatures()
+
+cdef extern from "gandiva/configuration.h" namespace "gandiva" nogil:
+
+    cdef cppclass CConfiguration" gandiva::Configuration":
+        pass
+
+    cdef cppclass CConfigurationBuilder \
+            " gandiva::ConfigurationBuilder":
+        @staticmethod
+        shared_ptr[CConfiguration] DefaultConfiguration()
+

--- a/python/pyarrow/tests/test_gandiva.py
+++ b/python/pyarrow/tests/test_gandiva.py
@@ -351,14 +351,14 @@ def test_filter_project():
     filter = gandiva.make_filter(table.schema, filter_condition)
 
     # Build a projector for the expressions.
-    projector = gandiva.make_projector_with_mode(
-        table.schema, [expr], "UINT32", mpool)
+    projector = gandiva.make_projector(
+        table.schema, [expr], mpool, "UINT32")
 
     # Evaluate filter
     selection_vector = filter.evaluate(table.to_batches()[0], mpool)
 
     # Evaluate project
-    r, = projector.evaluate_with_selection(
+    r, = projector.evaluate(
         table.to_batches()[0], selection_vector)
 
     exp = pa.array([1, -21, None], pa.int32())

--- a/python/pyarrow/tests/test_gandiva.py
+++ b/python/pyarrow/tests/test_gandiva.py
@@ -316,3 +316,43 @@ def test_get_registered_function_signatures():
     assert type(signatures[0].return_type()) is pa.DataType
     assert type(signatures[0].param_types()) is list
     assert hasattr(signatures[0], "name")
+
+@pytest.mark.gandiva
+def test_filter_project():
+    import pyarrow.gandiva as gandiva
+    # Create a table with some sample data
+    array0 = pa.array([10, 12, -20, 5, 21, 29], pa.int32())
+    array1 = pa.array([5, 15, 15, 17, 12, 3], pa.int32())
+    array2 = pa.array([1, 25, 11, 30, -21, None], pa.int32())
+
+    table = pa.Table.from_arrays([array0, array1, array2], ['a', 'b', 'c'])
+
+    field_result = pa.field("res", pa.int32())
+
+    builder = gandiva.TreeExprBuilder()
+    node_a = builder.make_field(table.schema.field("a"))
+    node_b = builder.make_field(table.schema.field("b"))
+    node_c = builder.make_field(table.schema.field("c"))
+
+    greater_than_function = builder.make_function("greater_than", [node_a, node_b], pa.bool_())
+    filter_condition = builder.make_condition(greater_than_function)
+
+    project_condition = builder.make_function("less_than", [node_b, node_c], pa.bool_())
+    if_node = builder.make_if(project_condition, node_b, node_c, pa.int32())
+    expr = builder.make_expression(if_node, field_result)
+
+    # Build a filter for the expressions.
+    filter = gandiva.make_filter(table.schema, filter_condition)
+
+    # Build a projector for the expressions.
+    projector = gandiva.make_projector_with_mode(
+        table.schema, [expr], "UINT32", pa.default_memory_pool())
+
+    # Evaluate filter
+    selection_vector = filter.evaluate(table.to_batches()[0], pa.default_memory_pool())
+
+    # Evaluate project
+    r, = projector.evaluate_with_selection(table.to_batches()[0], selection_vector)
+
+    exp = pa.array([1, -21, None], pa.int32())
+    assert r.equals(exp)


### PR DESCRIPTION
This PR is to enable running queries on top of filtered data in python. For that, I extended Cython wrapper and added a unit test which is the same as a test in cpp module https://github.com/apache/arrow/blob/c5fa23ea0e15abe47b35524fa6a79c7b8c160fa0/cpp/src/gandiva/tests/filter_project_test.cc#L208