### PR TITLE
ARROW-10319: [Go][Flight] Add context to flight client auth handler

### DIFF
--- a/go/arrow/flight/client.go
+++ b/go/arrow/flight/client.go
@@ -80,7 +80,7 @@ func (c *client) Authenticate(ctx context.Context, opts ...grpc.CallOption) erro
 		return err
 	}
 
-	return c.authHandler.Authenticate(&clientAuthConn{stream})
+	return c.authHandler.Authenticate(ctx, &clientAuthConn{stream})
 }
 
 func (c *client) Close() error {


### PR DESCRIPTION
During my usage I found that if i wanted to reuse an existing flight client that required authentication, it was difficult to reuse the auth handler since there wasn't a way to tell which goroutine / which auth made a particular request. By passing the context to the client auth handler it allows passing information to the auth handler via the context which could then be utilized by consumers in order to reuse a auth handler so that an entire flight client could be shared across multiple goroutines if desired. 

Corresponding unit test is updated as well.