### PR TITLE
ARROW-10320 [Rust] [DataFusion] Migrated from batch iterators to batch streams.

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -55,13 +55,13 @@ paste = "0.1"
 num_cpus = "1.13.0"
 chrono = "0.4"
 async-trait = "0.1.41"
+futures = "0.3"
 tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded"] }
 
 [dev-dependencies]
 rand = "0.7"
 criterion = "0.3"
 tempfile = "3"
-futures = "0.3"
 prost = "0.6"
 arrow-flight = { path = "../arrow-flight", version = "3.0.0-SNAPSHOT" }
 tonic = "0.3"

--- a/rust/datafusion/src/datasource/memory.rs
+++ b/rust/datafusion/src/datasource/memory.rs
@@ -22,15 +22,13 @@
 use std::sync::Arc;
 
 use arrow::datatypes::{Field, Schema, SchemaRef};
-use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 
 use crate::datasource::TableProvider;
 use crate::error::{ExecutionError, Result};
+use crate::physical_plan::common;
 use crate::physical_plan::memory::MemoryExec;
 use crate::physical_plan::ExecutionPlan;
-
-use tokio::task::{self, JoinHandle};
 
 /// In-memory table
 pub struct MemTable {
@@ -63,19 +61,20 @@ impl MemTable {
         let exec = t.scan(&None, batch_size)?;
         let partition_count = exec.output_partitioning().partition_count();
 
-        let mut tasks = Vec::with_capacity(partition_count);
-        for partition in 0..partition_count {
-            let exec = exec.clone();
-            let task: JoinHandle<Result<Vec<RecordBatch>>> = task::spawn(async move {
-                let it = exec.execute(partition).await?;
-                it.into_iter()
-                    .collect::<ArrowResult<Vec<RecordBatch>>>()
-                    .map_err(ExecutionError::from)
-            });
-            tasks.push(task)
-        }
+        let tasks = (0..partition_count)
+            .map(|part_i| {
+                let exec = exec.clone();
+                tokio::spawn(async move {
+                    let stream = exec.execute(part_i).await?;
+                    common::collect(stream).await
+                })
+            })
+            // this collect *is needed* so that the join below can
+            // switch between tasks
+            .collect::<Vec<_>>();
 
-        let mut data: Vec<Vec<RecordBatch>> = Vec::with_capacity(partition_count);
+        let mut data: Vec<Vec<RecordBatch>> =
+            Vec::with_capacity(exec.output_partitioning().partition_count());
         for task in tasks {
             let result = task.await.expect("MemTable::load could not join task")?;
             data.push(result);
@@ -135,6 +134,7 @@ mod tests {
     use super::*;
     use arrow::array::Int32Array;
     use arrow::datatypes::{DataType, Field, Schema};
+    use futures::StreamExt;
 
     #[tokio::test]
     async fn test_with_projection() -> Result<()> {
@@ -158,7 +158,7 @@ mod tests {
         // scan with projection
         let exec = provider.scan(&Some(vec![2, 1]), 1024)?;
         let mut it = exec.execute(0).await?;
-        let batch2 = it.next().unwrap()?;
+        let batch2 = it.next().await.unwrap()?;
         assert_eq!(2, batch2.schema().fields().len());
         assert_eq!("c", batch2.schema().field(0).name());
         assert_eq!("b", batch2.schema().field(1).name());
@@ -188,7 +188,7 @@ mod tests {
 
         let exec = provider.scan(&None, 1024)?;
         let mut it = exec.execute(0).await?;
-        let batch1 = it.next().unwrap()?;
+        let batch1 = it.next().await.unwrap()?;
         assert_eq!(3, batch1.schema().fields().len());
         assert_eq!(3, batch1.num_columns());
 

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -19,6 +19,10 @@
 
 use std::any::Any;
 use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use futures::stream::{Stream, StreamExt, TryStreamExt};
+use futures::FutureExt;
 
 use crate::error::{ExecutionError, Result};
 use crate::physical_plan::{Accumulator, AggregateExpr};
@@ -27,7 +31,7 @@ use crate::physical_plan::{Distribution, ExecutionPlan, Partitioning, PhysicalEx
 use crate::arrow::array::PrimitiveArrayOps;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
-use arrow::record_batch::{RecordBatch, RecordBatchReader};
+use arrow::record_batch::RecordBatch;
 use arrow::{
     array::{
         ArrayRef, Int16Array, Int32Array, Int64Array, Int8Array, StringArray,
@@ -39,7 +43,8 @@ use arrow::{
 use fnv::FnvHashMap;
 
 use super::{
-    common, expressions::Column, group_scalar::GroupByScalar, SendableRecordBatchReader,
+    common, expressions::Column, group_scalar::GroupByScalar, RecordBatchStream,
+    SendableRecordBatchStream,
 };
 
 use async_trait::async_trait;
@@ -145,19 +150,19 @@ impl ExecutionPlan for HashAggregateExec {
         self.input.output_partitioning()
     }
 
-    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchReader> {
+    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
         let input = self.input.execute(partition).await?;
         let group_expr = self.group_expr.iter().map(|x| x.0.clone()).collect();
 
         if self.group_expr.is_empty() {
-            Ok(Box::new(HashAggregateIterator::new(
+            Ok(Box::pin(HashAggregateStream::new(
                 self.mode,
                 self.schema.clone(),
                 self.aggr_expr.clone(),
                 input,
             )))
         } else {
-            Ok(Box::new(GroupedHashAggregateIterator::new(
+            Ok(Box::pin(GroupedHashAggregateStream::new(
                 self.mode.clone(),
                 self.schema.clone(),
                 group_expr,
@@ -210,12 +215,12 @@ Example: average
 * Once all N record batches arrive, `merge` is performed, which builds a RecordBatch with N rows and 2 columns.
 * Finally, `get_value` returns an array with one entry computed from the state
 */
-struct GroupedHashAggregateIterator {
+struct GroupedHashAggregateStream {
     mode: AggregateMode,
     schema: SchemaRef,
     group_expr: Vec<Arc<dyn PhysicalExpr>>,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
-    input: SendableRecordBatchReader,
+    input: SendableRecordBatchStream,
     finished: bool,
 }
 
@@ -223,12 +228,12 @@ fn group_aggregate_batch(
     mode: &AggregateMode,
     group_expr: &Vec<Arc<dyn PhysicalExpr>>,
     aggr_expr: &Vec<Arc<dyn AggregateExpr>>,
-    batch: &RecordBatch,
-    accumulators: &mut FnvHashMap<Vec<GroupByScalar>, (AccumulatorSet, Box<Vec<u32>>)>,
+    batch: RecordBatch,
+    mut accumulators: Accumulators,
     aggregate_expressions: &Vec<Vec<Arc<dyn PhysicalExpr>>>,
-) -> Result<()> {
+) -> Result<Accumulators> {
     // evaluate the grouping expressions
-    let group_values = evaluate(group_expr, batch)?;
+    let group_values = evaluate(group_expr, &batch)?;
 
     // evaluate the aggregation expressions.
     // We could evaluate them after the `take`, but since we need to evaluate all
@@ -307,19 +312,20 @@ fn group_aggregate_batch(
                 // 2.5
                 .and(Ok(indices.clear()))
         })
-        .collect::<Result<()>>()
+        .collect::<Result<()>>()?;
+    Ok(accumulators)
 }
 
-impl GroupedHashAggregateIterator {
-    /// Create a new HashAggregateIterator
+impl GroupedHashAggregateStream {
+    /// Create a new HashAggregateStream
     pub fn new(
         mode: AggregateMode,
         schema: SchemaRef,
         group_expr: Vec<Arc<dyn PhysicalExpr>>,
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
-        input: SendableRecordBatchReader,
+        input: SendableRecordBatchStream,
     ) -> Self {
-        GroupedHashAggregateIterator {
+        GroupedHashAggregateStream {
             mode,
             schema,
             group_expr,
@@ -331,72 +337,74 @@ impl GroupedHashAggregateIterator {
 }
 
 type AccumulatorSet = Vec<Box<dyn Accumulator>>;
+type Accumulators = FnvHashMap<Vec<GroupByScalar>, (AccumulatorSet, Box<Vec<u32>>)>;
 
-impl Iterator for GroupedHashAggregateIterator {
+impl Stream for GroupedHashAggregateStream {
     type Item = ArrowResult<RecordBatch>;
 
-    fn next(&mut self) -> Option<Self::Item> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         if self.finished {
-            return None;
+            return Poll::Ready(None);
         }
 
         // return single batch
         self.finished = true;
 
-        let mode = &self.mode;
-        let group_expr = &self.group_expr;
-        let aggr_expr = &self.aggr_expr;
+        let mode = self.mode.clone();
+        let group_expr = self.group_expr.clone();
+        let aggr_expr = self.aggr_expr.clone();
+        let schema = self.schema.clone();
 
         // the expressions to evaluate the batch, one vec of expressions per aggregation
         let aggregate_expressions = match aggregate_expressions(&aggr_expr, &mode) {
             Ok(e) => e,
-            Err(e) => return Some(Err(ExecutionError::into_arrow_external_error(e))),
+            Err(e) => {
+                return Poll::Ready(Some(Err(ExecutionError::into_arrow_external_error(
+                    e,
+                ))))
+            }
         };
 
         // mapping key -> (set of accumulators, indices of the key in the batch)
         // * the indexes are updated at each row
         // * the accumulators are updated at the end of each batch
         // * the indexes are `clear`ed at the end of each batch
-        let mut accumulators: FnvHashMap<
-            Vec<GroupByScalar>,
-            (AccumulatorSet, Box<Vec<u32>>),
-        > = FnvHashMap::default();
+        //let mut accumulators: Accumulators = FnvHashMap::default();
 
         // iterate over all input batches and update the accumulators
-        match self
-            .input
-            .as_mut()
-            .into_iter()
-            .map(|batch| {
+        let future = self.input.as_mut().try_fold(
+            Accumulators::default(),
+            |accumulators, batch| async {
                 group_aggregate_batch(
                     &mode,
                     &group_expr,
                     &aggr_expr,
-                    &batch?,
-                    &mut accumulators,
+                    batch,
+                    accumulators,
                     &aggregate_expressions,
                 )
                 .map_err(ExecutionError::into_arrow_external_error)
-            })
-            .collect::<ArrowResult<()>>()
-        {
-            Err(e) => return Some(Err(e)),
-            Ok(_) => {}
-        }
+            },
+        );
 
-        Some(
-            create_batch_from_map(
-                &self.mode,
-                &accumulators,
-                self.group_expr.len(),
-                &self.schema,
-            )
-            .map_err(ExecutionError::into_arrow_external_error),
-        )
+        let future = future.map(|accumulators| match accumulators {
+            Ok(accumulators) => {
+                create_batch_from_map(&mode, &accumulators, group_expr.len(), &schema)
+            }
+            Err(e) => Err(e),
+        });
+
+        // send the stream to the heap, so that it outlives this function.
+        let mut combined = Box::pin(future.into_stream());
+
+        combined.poll_next_unpin(cx)
     }
 }
 
-impl RecordBatchReader for GroupedHashAggregateIterator {
+impl RecordBatchStream for GroupedHashAggregateStream {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
@@ -456,23 +464,23 @@ fn aggregate_expressions(
     }
 }
 
-struct HashAggregateIterator {
+struct HashAggregateStream {
     mode: AggregateMode,
     schema: SchemaRef,
     aggr_expr: Vec<Arc<dyn AggregateExpr>>,
-    input: SendableRecordBatchReader,
+    input: SendableRecordBatchStream,
     finished: bool,
 }
 
-impl HashAggregateIterator {
-    /// Create a new HashAggregateIterator
+impl HashAggregateStream {
+    /// Create a new HashAggregateStream
     pub fn new(
         mode: AggregateMode,
         schema: SchemaRef,
         aggr_expr: Vec<Arc<dyn AggregateExpr>>,
-        input: SendableRecordBatchReader,
+        input: SendableRecordBatchStream,
     ) -> Self {
-        HashAggregateIterator {
+        HashAggregateStream {
             mode,
             schema,
             aggr_expr,
@@ -485,9 +493,9 @@ impl HashAggregateIterator {
 fn aggregate_batch(
     mode: &AggregateMode,
     batch: &RecordBatch,
-    accumulators: &mut AccumulatorSet,
+    accumulators: AccumulatorSet,
     expressions: &Vec<Vec<Arc<dyn PhysicalExpr>>>,
-) -> Result<()> {
+) -> Result<AccumulatorSet> {
     // 1.1 iterate accumulators and respective expressions together
     // 1.2 evaluate expressions
     // 1.3 update / merge accumulators with the expressions' values
@@ -496,7 +504,7 @@ fn aggregate_batch(
     accumulators
         .into_iter()
         .zip(expressions)
-        .map(|(accum, expr)| {
+        .map(|(mut accum, expr)| {
             // 1.2
             let values = &expr
                 .iter()
@@ -505,62 +513,88 @@ fn aggregate_batch(
 
             // 1.3
             match mode {
-                AggregateMode::Partial => accum.update_batch(values),
-                AggregateMode::Final => accum.merge_batch(values),
+                AggregateMode::Partial => {
+                    accum.update_batch(values)?;
+                }
+                AggregateMode::Final => {
+                    accum.merge_batch(values)?;
+                }
             }
+            Ok(accum)
         })
-        .collect::<Result<()>>()
+        .collect::<Result<Vec<_>>>()
 }
 
-impl Iterator for HashAggregateIterator {
+impl Stream for HashAggregateStream {
     type Item = ArrowResult<RecordBatch>;
 
-    fn next(&mut self) -> Option<Self::Item> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         if self.finished {
-            return None;
+            return Poll::Ready(None);
         }
 
         // return single batch
         self.finished = true;
 
-        let mut accumulators = match create_accumulators(&self.aggr_expr) {
+        let accumulators = match create_accumulators(&self.aggr_expr) {
             Ok(e) => e,
-            Err(e) => return Some(Err(ExecutionError::into_arrow_external_error(e))),
+            Err(e) => {
+                return Poll::Ready(Some(Err(ExecutionError::into_arrow_external_error(
+                    e,
+                ))))
+            }
         };
 
         let expressions = match aggregate_expressions(&self.aggr_expr, &self.mode) {
             Ok(e) => e,
-            Err(e) => return Some(Err(ExecutionError::into_arrow_external_error(e))),
+            Err(e) => {
+                return Poll::Ready(Some(Err(ExecutionError::into_arrow_external_error(
+                    e,
+                ))))
+            }
         };
+        let expressions = Arc::new(expressions);
 
         let mode = self.mode;
         let schema = self.schema();
 
         // 1 for each batch, update / merge accumulators with the expressions' values
-        match self
+        // future is ready when all batches are computed
+        let future = self
             .input
             .as_mut()
-            .into_iter()
-            .map(|batch| {
-                aggregate_batch(&mode, &batch?, &mut accumulators, &expressions)
-                    .map_err(ExecutionError::into_arrow_external_error)
-            })
-            .collect::<ArrowResult<()>>()
-        {
-            Err(e) => return Some(Err(e)),
-            Ok(_) => {}
-        }
+            .try_fold(
+                // pass the expressions on every fold to handle closures' mutability
+                (accumulators, expressions),
+                |(acc, expr), batch| async move {
+                    aggregate_batch(&mode, &batch, acc, &expr)
+                        .map_err(ExecutionError::into_arrow_external_error)
+                        .map(|agg| (agg, expr))
+                },
+            )
+            // pick the accumulators (disregard the expressions)
+            .map(|e| e.map(|e| e.0));
 
-        // 2 convert values to a record batch
-        Some(
-            finalize_aggregation(&accumulators, &mode)
-                .map_err(ExecutionError::into_arrow_external_error)
-                .and_then(|columns| RecordBatch::try_new(schema.clone(), columns)),
-        )
+        let future = future.map(|b| {
+            match b {
+                Err(e) => return Err(e),
+                Ok(acc) => {
+                    // 2 convert values to a record batch
+                    finalize_aggregation(&acc, &mode)
+                        .map_err(ExecutionError::into_arrow_external_error)
+                        .and_then(|columns| RecordBatch::try_new(schema.clone(), columns))
+                }
+            }
+        });
+
+        Box::pin(future.into_stream()).poll_next_unpin(cx)
     }
 }
 
-impl RecordBatchReader for HashAggregateIterator {
+impl RecordBatchStream for HashAggregateStream {
     fn schema(&self) -> SchemaRef {
         self.schema.clone()
     }
@@ -580,10 +614,10 @@ fn concatenate(arrays: Vec<Vec<ArrayRef>>) -> ArrowResult<Vec<ArrayRef>> {
 /// Create a RecordBatch with all group keys and accumulator' states or values.
 fn create_batch_from_map(
     mode: &AggregateMode,
-    accumulators: &FnvHashMap<Vec<GroupByScalar>, (AccumulatorSet, Box<Vec<u32>>)>,
+    accumulators: &Accumulators,
     num_group_expr: usize,
     output_schema: &Schema,
-) -> Result<RecordBatch> {
+) -> ArrowResult<RecordBatch> {
     // 1. for each key
     // 2. create single-row ArrayRef with all group expressions
     // 3. create single-row ArrayRef with all aggregate states or values
@@ -618,7 +652,7 @@ fn create_batch_from_map(
             Ok(groups)
         })
         // 4.
-        .collect::<Result<Vec<Vec<ArrayRef>>>>()?;
+        .collect::<ArrowResult<Vec<Vec<ArrayRef>>>>()?;
 
     let batch = if arrays.len() != 0 {
         // 5.
@@ -787,7 +821,7 @@ mod tests {
             input,
         )?);
 
-        let result = common::collect(partial_aggregate.execute(0).await?)?;
+        let result = common::collect(partial_aggregate.execute(0).await?).await?;
 
         let keys = result[0]
             .column(0)
@@ -826,7 +860,7 @@ mod tests {
             merge,
         )?);
 
-        let result = common::collect(merged_aggregate.execute(0).await?)?;
+        let result = common::collect(merged_aggregate.execute(0).await?).await?;
         assert_eq!(result.len(), 1);
 
         let batch = &result[0];

--- a/rust/datafusion/src/physical_plan/merge.rs
+++ b/rust/datafusion/src/physical_plan/merge.rs
@@ -19,17 +19,18 @@
 //! into a single partition
 
 use std::any::Any;
+use std::iter::Iterator;
 use std::sync::Arc;
 
+use super::common;
 use crate::error::{ExecutionError, Result};
-use crate::physical_plan::common::RecordBatchIterator;
+use crate::physical_plan::ExecutionPlan;
 use crate::physical_plan::Partitioning;
-use crate::physical_plan::{common, ExecutionPlan};
 
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 
-use super::SendableRecordBatchReader;
+use super::SendableRecordBatchStream;
 
 use async_trait::async_trait;
 use tokio;
@@ -81,7 +82,7 @@ impl ExecutionPlan for MergeExec {
         }
     }
 
-    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchReader> {
+    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
         // MergeExec produces a single partition
         if 0 != partition {
             return Err(ExecutionError::General(format!(
@@ -104,8 +105,8 @@ impl ExecutionPlan for MergeExec {
                     .map(|part_i| {
                         let input = self.input.clone();
                         tokio::spawn(async move {
-                            let it = input.execute(part_i).await?;
-                            common::collect(it)
+                            let stream = input.execute(part_i).await?;
+                            common::collect(stream).await
                         })
                     })
                     // this collect *is needed* so that the join below can
@@ -120,7 +121,7 @@ impl ExecutionPlan for MergeExec {
                     }
                 }
 
-                Ok(Box::new(RecordBatchIterator::new(
+                Ok(Box::pin(common::SizedRecordBatchStream::new(
                     self.input.schema(),
                     combined_results,
                 )))
@@ -158,7 +159,7 @@ mod tests {
 
         // the result should contain 4 batches (one per input partition)
         let iter = merge.execute(0).await?;
-        let batches = common::collect(iter)?;
+        let batches = common::collect(iter).await?;
         assert_eq!(batches.len(), num_partitions);
 
         // there should be a total of 100 rows

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -553,7 +553,7 @@ mod tests {
     use crate::physical_plan::{csv::CsvReadOptions, expressions, Partitioning};
     use crate::{
         logical_plan::{col, lit, sum, LogicalPlanBuilder},
-        physical_plan::SendableRecordBatchReader,
+        physical_plan::SendableRecordBatchStream,
     };
     use crate::{prelude::ExecutionConfig, test::arrow_testdata_path};
     use arrow::datatypes::{DataType, Field, SchemaRef};
@@ -804,7 +804,7 @@ mod tests {
             unimplemented!("NoOpExecutionPlan::with_new_children");
         }
 
-        async fn execute(&self, _partition: usize) -> Result<SendableRecordBatchReader> {
+        async fn execute(&self, _partition: usize) -> Result<SendableRecordBatchStream> {
             unimplemented!("NoOpExecutionPlan::execute");
         }
     }


### PR DESCRIPTION
Recently, we introduced `async` to `execute`. This allowed us to parallelize multiple partitions as we denote an execution of a part (of a partition) as the unit of work. However, a part is often a large task composing multiple batches and steps.

This PR makes all our execution nodes return a dynamically-typed [`Stream<Item = ArrowResult<RecordBatch>>`](https://docs.rs/futures/0.3.6/futures/stream/trait.Stream.html) instead of an Iterator. For reference, a Stream is an iterator of futures, which in this case is a future of a `Result<RecordBatch>`.

This effectively breaks the execution in smaller units of work (on which an individual unit is an operation returns a `Result<RecordBatch>`) allowing each task to chew smaller bits.

This adds `futures` as a direct dependency of DataFusion (it was only a dev-dependency).

This leads to a +2% degradation in aggregates in micro benchmarking, which IMO is expected given that there is more context switching to handle. However, I expect (hope?) this to be independent of the number of batches and partitions, and be offset by any async work we perform to our sources (readers) and sinks (writers).

I did not take the time to optimize - the primary goal was to implement the idea, have it compile and pass tests, and have some discussion about it. I expect that we should be able to replace some of our operations by `join_all`, thereby scheduling multiple tasks at once (instead of waiting one by one).

<details>
 <summary>Benchmarks</summary>

Aggregates:
```
aggregate_query_no_group_by 15 12                                                                            
                        time:   [782.11 us 784.12 us 786.19 us]
                        change: [+1.1421% +2.5252% +3.8963%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

aggregate_query_group_by 15 12                                                                            
                        time:   [5.8751 ms 5.9206 ms 5.9679 ms]
                        change: [+1.0645% +2.0027% +3.0333%] (p = 0.00 < 0.05)
                        Performance has regressed.

aggregate_query_group_by_with_filter 15 12                                                                             
                        time:   [2.7652 ms 2.7983 ms 2.8340 ms]
                        change: [+0.3278% +1.8981% +3.3819%] (p = 0.02 < 0.05)
                        Change within noise threshold.
```

Math:
```
sqrt_20_9               time:   [6.9844 ms 7.0582 ms 7.1363 ms]                      
                        change: [+0.0557% +1.5625% +3.0408%] (p = 0.05 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

sqrt_20_12              time:   [2.8350 ms 2.9504 ms 3.1204 ms]                        
                        change: [+3.8751% +8.2857% +14.671%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

sqrt_22_12              time:   [14.888 ms 15.242 ms 15.620 ms]                       
                        change: [+7.6388% +10.709% +14.098%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

sqrt_22_14              time:   [23.710 ms 23.817 ms 23.953 ms]                       
                        change: [-4.3401% -3.1824% -2.0952%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
```
</details>

I admit that this is a bit outside my comfort zone, and someone with more experience in `async/await` could be of help.

IMO this would integrate very nicely with ARROW-10307, ARROW-9275, I _think_ it would also help ARROW-9707, and I _think_ that it also opens the possibility consuming / producing batches from/to sources and sinks from arrow-flight / IPC