### PR TITLE
ARROW-10106: [FlightRPC][Java] Expose onIsReady() callback

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/BackpressureStrategy.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/BackpressureStrategy.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Helper interface to dynamically handle backpressure when implementing FlightProducers.
+ */
+public interface BackpressureStrategy {
+  /**
+   * The state of the client after a call to waitForListener.
+   */
+  enum WaitResult {
+    /**
+     * Listener is ready.
+     */
+    READY,
+
+    /**
+     * Listener was cancelled by the client.
+     */
+    CANCELLED,
+
+    /**
+     * Timed out waiting for the listener to change state.
+     */
+    TIMEOUT
+  }
+
+  /**
+   * Set up operations to work against the given listener.
+   *
+   * This will be called exactly once and before any calls to {@link #waitForListener(long)}.
+   * @param listener The listener this strategy applies to.
+   */
+  void register(FlightProducer.ServerStreamListener listener);
+
+  /**
+   * Waits for the listener to be ready or cancelled up to the given timeout.
+   *
+   * @param timeout The timeout in milliseconds. Infinite if timeout is <= 0.
+   * @return The result of the wait.
+   */
+  WaitResult waitForListener(long timeout);
+
+  /**
+   * A back pressure strategy that blocks uses callbacks to notify when the client is ready or cancelled.
+   */
+  class CallbackBackpressureStrategy implements BackpressureStrategy {
+    private final Object lock = new Object();
+    private FlightProducer.ServerStreamListener listener;
+
+    @Override
+    public void register(FlightProducer.ServerStreamListener listener) {
+      this.listener = listener;
+      listener.setOnReadyHandler(this::onReadyOrCancel);
+      listener.setOnCancelHandler(this::onReadyOrCancel);
+    }
+
+    @Override
+    public WaitResult waitForListener(long timeout) {
+      Preconditions.checkNotNull(listener);
+      final long startTime = System.currentTimeMillis();
+      synchronized (lock) {
+        while (!listener.isReady() && !listener.isCancelled()) {
+          try {
+            lock.wait(timeout);
+            if (System.currentTimeMillis() > startTime + timeout) {
+              return WaitResult.TIMEOUT;
+            }
+          } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            return WaitResult.CANCELLED;
+          }
+        }
+
+        if (listener.isReady()) {
+          return WaitResult.READY;
+        } else if (listener.isCancelled()) {
+          return WaitResult.CANCELLED;
+        } else if (System.currentTimeMillis() > startTime + timeout) {
+          return WaitResult.TIMEOUT;
+        }
+        throw new RuntimeException("Invalid state when waiting for listener.");
+      }
+    }
+
+    void onReadyOrCancel() {
+      synchronized (lock) {
+        lock.notifyAll();
+      }
+    }
+  }
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/BackpressureStrategy.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/BackpressureStrategy.java
@@ -17,6 +17,8 @@
 
 package org.apache.arrow.flight;
 
+import org.apache.arrow.vector.VectorSchemaRoot;
+
 import com.google.common.base.Preconditions;
 
 /**
@@ -46,7 +48,8 @@ public interface BackpressureStrategy {
   /**
    * Set up operations to work against the given listener.
    *
-   * This will be called exactly once and before any calls to {@link #waitForListener(long)}.
+   * This must be called exactly once and before any calls to {@link #waitForListener(long)} and
+   * {@link OutboundStreamListener#start(VectorSchemaRoot)}
    * @param listener The listener this strategy applies to.
    */
   void register(FlightProducer.ServerStreamListener listener);
@@ -60,7 +63,7 @@ public interface BackpressureStrategy {
   WaitResult waitForListener(long timeout);
 
   /**
-   * A back pressure strategy that blocks uses callbacks to notify when the client is ready or cancelled.
+   * A back pressure strategy that uses callbacks to notify when the client is ready or cancelled.
    */
   class CallbackBackpressureStrategy implements BackpressureStrategy {
     private final Object lock = new Object();

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/BackpressureStrategy.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/BackpressureStrategy.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 
 /**
  * Helper interface to dynamically handle backpressure when implementing FlightProducers.
+ * This must only be used in FlightProducer implementations that are non-blocking.
  */
 public interface BackpressureStrategy {
   /**

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
@@ -89,13 +89,11 @@ class FlightService extends FlightServiceImplBase {
         (ServerCallStreamObserver<ArrowMessage>) responseObserverSimple;
 
     final GetListener listener = new GetListener(responseObserver, this::handleExceptionWithMiddleware);
-    executors.submit(() -> {
-      try {
-        producer.getStream(makeContext(responseObserver), new Ticket(ticket), listener);
-      } catch (Exception ex) {
-        listener.error(ex);
-      }
-    });
+    try {
+      producer.getStream(makeContext(responseObserver), new Ticket(ticket), listener);
+    } catch (Exception ex) {
+      listener.error(ex);
+    }
     // Do NOT call GetListener#completed, as the implementation of getStream may be asynchronous
   }
 
@@ -150,7 +148,6 @@ class FlightService extends FlightServiceImplBase {
     }
 
     private void onReady() {
-      logger.debug("Stream is ready for new messages.");
       if (onReadyHandler != null) {
         onReadyHandler.run();
       }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
@@ -35,7 +35,6 @@ import org.apache.arrow.flight.impl.Flight;
 import org.apache.arrow.flight.impl.FlightServiceGrpc.FlightServiceImplBase;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.AutoCloseables;
-import org.apache.arrow.vector.VectorUnloader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,12 +87,15 @@ class FlightService extends FlightServiceImplBase {
   public void doGetCustom(Flight.Ticket ticket, StreamObserver<ArrowMessage> responseObserverSimple) {
     final ServerCallStreamObserver<ArrowMessage> responseObserver =
         (ServerCallStreamObserver<ArrowMessage>) responseObserverSimple;
+
     final GetListener listener = new GetListener(responseObserver, this::handleExceptionWithMiddleware);
-    try {
-      producer.getStream(makeContext(responseObserver), new Ticket(ticket), listener);
-    } catch (Exception ex) {
-      listener.error(ex);
-    }
+    executors.submit(() -> {
+      try {
+        producer.getStream(makeContext(responseObserver), new Ticket(ticket), listener);
+      } catch (Exception ex) {
+        listener.error(ex);
+      }
+    });
     // Do NOT call GetListener#completed, as the implementation of getStream may be asynchronous
   }
 
@@ -127,8 +129,7 @@ class FlightService extends FlightServiceImplBase {
     private ServerCallStreamObserver<ArrowMessage> responseObserver;
     private final Consumer<Throwable> errorHandler;
     private Runnable onCancelHandler = null;
-    // null until stream started
-    private volatile VectorUnloader unloader;
+    private Runnable onReadyHandler = null;
     private boolean completed;
 
     public GetListener(ServerCallStreamObserver<ArrowMessage> responseObserver, Consumer<Throwable> errorHandler) {
@@ -137,6 +138,7 @@ class FlightService extends FlightServiceImplBase {
       this.completed = false;
       this.responseObserver = responseObserver;
       this.responseObserver.setOnCancelHandler(this::onCancel);
+      this.responseObserver.setOnReadyHandler(this::onReady);
       this.responseObserver.disableAutoInboundFlowControl();
     }
 
@@ -147,9 +149,21 @@ class FlightService extends FlightServiceImplBase {
       }
     }
 
+    private void onReady() {
+      logger.debug("Stream is ready for new messages.");
+      if (onReadyHandler != null) {
+        onReadyHandler.run();
+      }
+    }
+
     @Override
     public void setOnCancelHandler(Runnable handler) {
       this.onCancelHandler = handler;
+    }
+
+    @Override
+    public void setOnReadyHandler(Runnable handler) {
+      this.onReadyHandler = handler;
     }
 
     @Override

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
@@ -37,12 +37,13 @@ public interface OutboundStreamListener {
   boolean isReady();
 
   /**
-   * Set a callback for when the listener is ready for new calls to putNext(), i.e. {@link #isReady()} ()}
+   * Set a callback for when the listener is ready for new calls to putNext(), i.e. {@link #isReady()}
    * has become true.
    *
-   * <p>Note that this callback may only be called some time after {@link #isReady()} ()} becomes true, and may never
+   * <p>Note that this callback may only be called some time after {@link #isReady()} becomes true, and may never
    * be called if all executor threads on the server are busy, or the RPC method body is implemented in a blocking
-   * fashion.
+   * fashion. Note that isReady() must still be checked after the callback is run as it may have been run
+   * spuriously.
    */
   default void setOnReadyHandler(Runnable handler) {
     throw new UnsupportedOperationException("Not yet implemented.");

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
@@ -37,6 +37,18 @@ public interface OutboundStreamListener {
   boolean isReady();
 
   /**
+   * Set a callback for when the client cancels is ready for new calls to putNext(), i.e. {@link #isReady()} ()}
+   * has become true.
+   *
+   * <p>Note that this callback may only be called some time after {@link #isReady()} ()} becomes true, and may never
+   * be called if all executor threads on the server are busy, or the RPC method body is implemented in a blocking
+   * fashion.
+   */
+  default void setOnReadyHandler(Runnable handler) {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  /**
    * Start sending data, using the schema of the given {@link VectorSchemaRoot}.
    *
    * <p>This method must be called before all others, except {@link #putMetadata(ArrowBuf)}.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListener.java
@@ -37,7 +37,7 @@ public interface OutboundStreamListener {
   boolean isReady();
 
   /**
-   * Set a callback for when the client cancels is ready for new calls to putNext(), i.e. {@link #isReady()} ()}
+   * Set a callback for when the listener is ready for new calls to putNext(), i.e. {@link #isReady()} ()}
    * has become true.
    *
    * <p>Note that this callback may only be called some time after {@link #isReady()} ()} becomes true, and may never

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListenerImpl.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/OutboundStreamListenerImpl.java
@@ -49,6 +49,11 @@ abstract class OutboundStreamListenerImpl implements OutboundStreamListener {
   }
 
   @Override
+  public void setOnReadyHandler(Runnable handler) {
+    responseObserver.setOnReadyHandler(handler);
+  }
+
+  @Override
   public void start(VectorSchemaRoot root, DictionaryProvider dictionaries, IpcOption option) {
     this.option = option;
     try {

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBackPressure.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestBackPressure.java
@@ -18,6 +18,7 @@
 package org.apache.arrow.flight;
 
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 
 import org.apache.arrow.flight.perf.PerformanceTestServer;
 import org.apache.arrow.flight.perf.TestPerf;
@@ -43,10 +44,47 @@ public class TestBackPressure {
   @Ignore
   @Test
   public void ensureIndependentSteams() throws Exception {
+    ensureIndependentSteams((b) -> (location -> new PerformanceTestServer(b, location)));
+  }
+
+  /**
+   * Make sure that failing to consume one stream doesn't block other streams.
+   */
+  @Ignore
+  @Test
+  public void ensureIndependentSteamsWithCallbacks() throws Exception {
+    ensureIndependentSteams((b) -> (location -> new PerformanceTestServer(b, location,
+        new BackpressureStrategy.CallbackBackpressureStrategy())));
+  }
+
+  /**
+   * Test to make sure stream doesn't go faster than the consumer is consuming.
+   */
+  @Ignore
+  @Test
+  public void ensureWaitUntilProceed() throws Exception {
+    ensureWaitUntilProceed(new PollingBackpressureStrategy());
+  }
+
+  /**
+   * Test to make sure stream doesn't go faster than the consumer is consuming using a callback-based
+   * backpressure strategy.
+   */
+  @Ignore
+  @Test
+  public void ensureWaitUntilProceedWithCallbacks() throws Exception {
+    ensureWaitUntilProceed(new RecordingCallbackBackpressureStrategy());
+  }
+
+  /**
+   * Make sure that failing to consume one stream doesn't block other streams.
+   */
+  private static void ensureIndependentSteams(Function<BufferAllocator, Function<Location, PerformanceTestServer>>
+                                                  serverConstructor) throws Exception {
     try (
         final BufferAllocator a = new RootAllocator(Long.MAX_VALUE);
         final PerformanceTestServer server = FlightTestUtil.getStartedServer(
-            (location) -> (new PerformanceTestServer(a, location)));
+            (location) -> (serverConstructor.apply(a).apply(location)));
         final FlightClient client = FlightClient.builder(a, server.getLocation()).build()
     ) {
       try (FlightStream fs1 = client.getStream(client.getInfo(
@@ -73,9 +111,7 @@ public class TestBackPressure {
   /**
    * Make sure that a stream doesn't go faster than the consumer is consuming.
    */
-  @Ignore
-  @Test
-  public void ensureWaitUntilProceed() throws Exception {
+  private static void ensureWaitUntilProceed(SleepTimeRecordingBackpressureStrategy bpStrategy) throws Exception {
     // request some values.
     final long wait = 3000;
     final long epsilon = 1000;
@@ -88,19 +124,14 @@ public class TestBackPressure {
         @Override
         public void getStream(CallContext context, Ticket ticket,
             ServerStreamListener listener) {
+          bpStrategy.register(listener);
+
           int batches = 0;
           final Schema pojoSchema = new Schema(ImmutableList.of(Field.nullable("a", MinorType.BIGINT.getType())));
           try (VectorSchemaRoot root = VectorSchemaRoot.create(pojoSchema, allocator)) {
             listener.start(root);
             while (true) {
-              while (!listener.isReady()) {
-                try {
-                  Thread.sleep(1);
-                  sleepTime.addAndGet(1L);
-                } catch (InterruptedException ignore) {
-                }
-              }
-
+              bpStrategy.waitForListener(0);
               if (batches > 100) {
                 root.clear();
                 listener.completed();
@@ -137,8 +168,8 @@ public class TestBackPressure {
         }
         long expected = wait - epsilon;
         Assert.assertTrue(
-            String.format("Expected a sleep of at least %dms but only slept for %d", expected, sleepTime.get()),
-            sleepTime.get() > expected);
+            String.format("Expected a sleep of at least %dms but only slept for %d", expected,
+                bpStrategy.getSleepTime()), bpStrategy.getSleepTime() > expected);
 
       }
     }
@@ -156,6 +187,66 @@ public class TestBackPressure {
     while (batches > 0 && stream.next()) {
       root.clear();
       batches--;
+    }
+  }
+
+  private interface SleepTimeRecordingBackpressureStrategy extends BackpressureStrategy {
+    /**
+     * Returns the total time spent waiting on the listener to be ready.
+     * @return the total time spent waiting on the listener to be ready.
+     */
+    long getSleepTime();
+  }
+
+  /**
+   * Implementation of a backpressure strategy that polls on isReady and records amount of time spent in Thread.sleep().
+   */
+  private static class PollingBackpressureStrategy implements SleepTimeRecordingBackpressureStrategy {
+    private final AtomicLong sleepTime = new AtomicLong(0);
+    private FlightProducer.ServerStreamListener listener;
+
+    @Override
+    public long getSleepTime() {
+      return sleepTime.get();
+    }
+
+    @Override
+    public void register(FlightProducer.ServerStreamListener listener) {
+      this.listener = listener;
+    }
+
+    @Override
+    public WaitResult waitForListener(long timeout) {
+      while (!listener.isReady()) {
+        try {
+          Thread.sleep(1);
+          sleepTime.addAndGet(1L);
+        } catch (InterruptedException ignore) {
+        }
+      }
+      return WaitResult.READY;
+    }
+  }
+
+  /**
+   * Implementation of a backpressure strategy that polls on uses callbacks to detect changes in client readiness state
+   * and records spent time waiting.
+   */
+  private static class RecordingCallbackBackpressureStrategy extends BackpressureStrategy.CallbackBackpressureStrategy
+      implements SleepTimeRecordingBackpressureStrategy {
+    private final AtomicLong sleepTime = new AtomicLong(0);
+
+    @Override
+    public long getSleepTime() {
+      return sleepTime.get();
+    }
+
+    @Override
+    public WaitResult waitForListener(long timeout) {
+      final long startTime = System.currentTimeMillis();
+      final WaitResult result = super.waitForListener(timeout);
+      sleepTime.addAndGet(System.currentTimeMillis() - startTime);
+      return result;
     }
   }
 }


### PR DESCRIPTION
Expose onIsReady() callback on OutboundStreamListener

- Add callback to run when the client is ready to receive new data during getStream.
- This removes the need for FlightProducers to implement polling code on isReady.