### PR TITLE
ARROW-10327: [Rust] [DataFusion] Replace iterator of batches by iterator of future batch

### DIFF
--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -56,12 +56,12 @@ num_cpus = "1.13.0"
 chrono = "0.4"
 async-trait = "0.1.41"
 tokio = { version = "0.2", features = ["macros", "rt-core", "rt-threaded"] }
+futures = "0.3"
 
 [dev-dependencies]
 rand = "0.7"
 criterion = "0.3"
 tempfile = "3"
-futures = "0.3"
 prost = "0.6"
 arrow-flight = { path = "../arrow-flight", version = "2.0.0-SNAPSHOT" }
 tonic = "0.3"

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -75,6 +75,7 @@ mod tests {
         TimestampNanosecondArray,
     };
     use arrow::record_batch::RecordBatch;
+    use futures::future::join_all;
     use std::env;
 
     #[tokio::test]
@@ -84,7 +85,9 @@ mod tests {
         let exec = table.scan(&projection, 2)?;
         let it = exec.execute(0).await?;
 
-        let count = it
+        let batch = join_all(it).await;
+
+        let count = batch
             .into_iter()
             .map(|batch| {
                 let batch = batch.unwrap();
@@ -306,6 +309,7 @@ mod tests {
         let mut it = exec.execute(0).await?;
         it.next()
             .expect("should have received at least one batch")
+            .await
             .map_err(|e| e.into())
     }
 }

--- a/rust/datafusion/src/physical_plan/explain.rs
+++ b/rust/datafusion/src/physical_plan/explain.rs
@@ -20,17 +20,17 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use async_trait::async_trait;
+
+use arrow::{array::StringBuilder, datatypes::SchemaRef, record_batch::RecordBatch};
+
 use crate::error::{ExecutionError, Result};
+use crate::physical_plan::DynFutureRecordBatchIterator;
+use crate::physical_plan::Partitioning;
 use crate::{
     logical_plan::StringifiedPlan,
     physical_plan::{common::RecordBatchIterator, ExecutionPlan},
 };
-use arrow::{array::StringBuilder, datatypes::SchemaRef, record_batch::RecordBatch};
-
-use crate::physical_plan::Partitioning;
-
-use super::SendableRecordBatchReader;
-use async_trait::async_trait;
 
 /// Explain execution plan operator. This operator contains the string
 /// values of the various plans it has when it is created, and passes
@@ -89,7 +89,7 @@ impl ExecutionPlan for ExplainExec {
         }
     }
 
-    async fn execute(&self, partition: usize) -> Result<SendableRecordBatchReader> {
+    async fn execute(&self, partition: usize) -> Result<DynFutureRecordBatchIterator> {
         if 0 != partition {
             return Err(ExecutionError::General(format!(
                 "ExplainExec invalid partition {}",

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -553,7 +553,7 @@ mod tests {
     use crate::physical_plan::{csv::CsvReadOptions, expressions, Partitioning};
     use crate::{
         logical_plan::{col, lit, sum, LogicalPlanBuilder},
-        physical_plan::SendableRecordBatchReader,
+        physical_plan::DynFutureRecordBatchIterator,
     };
     use crate::{prelude::ExecutionConfig, test::arrow_testdata_path};
     use arrow::datatypes::{DataType, Field, SchemaRef};
@@ -804,7 +804,10 @@ mod tests {
             unimplemented!("NoOpExecutionPlan::with_new_children");
         }
 
-        async fn execute(&self, _partition: usize) -> Result<SendableRecordBatchReader> {
+        async fn execute(
+            &self,
+            _partition: usize,
+        ) -> Result<DynFutureRecordBatchIterator> {
             unimplemented!("NoOpExecutionPlan::execute");
         }
     }


### PR DESCRIPTION
This PR is a proposal to change our iterators over `RecordBatch` to `Future<RecordBatch>`, thereby making our compute operations over a single batch as the "unit of work".

The rational here is that our expensive operations are over record batches, which are the ones that benefit from being split in smaller units (and multi-threaded).

This PR also places some `tokio::spawn` on some ops, with the expectation that the scheduler can multi-thread them.

The micro-benchmarks are not very indicative as this affects larger sizes, but as a rough idea, I get -50% improvement for larger math projections and +5% to +20% degradation for aggregations.

The aggregations have a rough implementation where a mutex blocks the whole calculation, which may explain the result.

<details>
<summary>Benchmarks</summary>

Math
```
sqrt_20_9               time:   [7.6861 ms 7.7328 ms 7.7805 ms]                      
                        change: [+20.288% +21.552% +22.732%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

Benchmarking sqrt_20_12: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.4s, enable flat sampling, or reduce sample count to 50.
sqrt_20_12              time:   [1.7891 ms 1.7954 ms 1.8020 ms]                        
                        change: [-38.768% -37.852% -36.578%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  6 (6.00%) high mild
  4 (4.00%) high severe

sqrt_22_12              time:   [8.4315 ms 8.5324 ms 8.6348 ms]                       
                        change: [-39.677% -38.299% -36.893%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

sqrt_22_14              time:   [11.515 ms 11.759 ms 12.054 ms]                       
                        change: [-48.307% -47.200% -45.854%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe
```

Aggregates:
```
aggregate_query_no_group_by 15 12                                                                            
                        time:   [831.70 us 836.65 us 842.22 us]
                        change: [+8.0888% +9.9290% +11.904%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe

aggregate_query_group_by 15 12                                                                            
                        time:   [5.9246 ms 5.9763 ms 6.0367 ms]
                        change: [+3.1496% +4.1417% +5.1472%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

aggregate_query_group_by_with_filter 15 12                                                                             
                        time:   [3.4054 ms 3.4322 ms 3.4597 ms]
                        change: [+26.844% +27.870% +28.979%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild
```
</details>