### PR TITLE
ARROW-10331: [Rust] [DataFusion] Re-organize DataFusion errors

### DIFF
--- a/rust/datafusion/examples/flight_server.rs
+++ b/rust/datafusion/examples/flight_server.rs
@@ -178,7 +178,7 @@ impl FlightService for FlightServiceImpl {
     }
 }
 
-fn to_tonic_err(e: &datafusion::error::ExecutionError) -> Status {
+fn to_tonic_err(e: &datafusion::error::DataFusionError) -> Status {
     Status::internal(format!("{:?}", e))
 }
 

--- a/rust/datafusion/src/datasource/csv.rs
+++ b/rust/datafusion/src/datasource/csv.rs
@@ -38,7 +38,7 @@ use std::string::String;
 use std::sync::Arc;
 
 use crate::datasource::TableProvider;
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::csv::CsvExec;
 pub use crate::physical_plan::csv::CsvReadOptions;
 use crate::physical_plan::{common, ExecutionPlan};
@@ -62,7 +62,7 @@ impl CsvFile {
                 let mut filenames: Vec<String> = vec![];
                 common::build_file_list(path, &mut filenames, options.file_extension)?;
                 if filenames.is_empty() {
-                    return Err(ExecutionError::General("No files found".to_string()));
+                    return Err(DataFusionError::Plan("No files found".to_string()));
                 }
                 CsvExec::try_infer_schema(&filenames, &options)?
             }

--- a/rust/datafusion/src/error.rs
+++ b/rust/datafusion/src/error.rs
@@ -41,8 +41,6 @@ pub enum DataFusionError {
     IoError(Error),
     /// Error returned when SQL is syntatically incorrect.
     SQL(ParserError),
-    /// General error that does not fit in any of the other errors.
-    General(String),
     /// Error returned on a code branch that we know it is possible
     /// but to which we still have no implementation of.
     /// Often, these errors are tracked in our issue tracker.
@@ -70,18 +68,6 @@ impl DataFusionError {
 impl From<Error> for DataFusionError {
     fn from(e: Error) -> Self {
         DataFusionError::IoError(e)
-    }
-}
-
-impl From<String> for DataFusionError {
-    fn from(e: String) -> Self {
-        DataFusionError::General(e)
-    }
-}
-
-impl From<&'static str> for DataFusionError {
-    fn from(e: &'static str) -> Self {
-        DataFusionError::General(e.to_string())
     }
 }
 
@@ -114,7 +100,6 @@ impl Display for DataFusionError {
             DataFusionError::SQL(ref desc) => {
                 write!(f, "SQL error: {:?}", desc)
             }
-            DataFusionError::General(ref desc) => write!(f, "General error: {}", desc),
             DataFusionError::NotImplemented(ref desc) => {
                 write!(f, "This feature is not implemented: {}", desc)
             }

--- a/rust/datafusion/src/error.rs
+++ b/rust/datafusion/src/error.rs
@@ -26,102 +26,110 @@ use arrow::error::ArrowError;
 use parquet::errors::ParquetError;
 use sqlparser::parser::ParserError;
 
-/// Result type for operations that could result in an `ExecutionError`
-pub type Result<T> = result::Result<T, ExecutionError>;
+/// Result type for operations that could result in an [DataFusionError]
+pub type Result<T> = result::Result<T, DataFusionError>;
 
 /// DataFusion error
 #[derive(Debug)]
 #[allow(missing_docs)]
-pub enum ExecutionError {
-    /// Wraps an error from the Arrow crate
+pub enum DataFusionError {
+    /// Error returned by arrow.
     ArrowError(ArrowError),
     /// Wraps an error from the Parquet crate
     ParquetError(ParquetError),
     /// I/O error
     IoError(Error),
-    /// SQL parser error
-    ParserError(ParserError),
-    /// General error
+    /// Error returned when SQL is syntatically incorrect.
+    SQL(ParserError),
+    /// General error that does not fit in any of the other errors.
     General(String),
-    /// Invalid column error
-    InvalidColumn(String),
-    /// Missing functionality
+    /// Error returned on a code branch that we know it is possible
+    /// but to which we still have no implementation of.
+    /// Often, these errors are tracked in our issue tracker.
     NotImplemented(String),
-    /// Internal error
-    InternalError(String),
-    /// Query engine execution error
-    ExecutionError(String),
+    /// Error returned as a consequence of an error in DataFusion.
+    /// This error should not happen in normal usage of DataFusion.
+    // We use this error when an invariant that we were unable
+    // to make the compiler assert for us is not verified during execution.
+    Internal(String),
+    /// This error happens whenever a plan is not valid. Examples include
+    /// impossible casts, schema inference not possible and non-unique column names.
+    Plan(String),
+    /// Error returned during execution of the query.
+    /// Examples include files not found, errors in parsing certain types.
+    Execution(String),
 }
 
-impl ExecutionError {
-    /// Wraps this `ExecutionError` in arrow's `ExternalError` variant.
+impl DataFusionError {
+    /// Wraps this [DataFusionError] as an [Arrow::error::ArrowError].
     pub fn into_arrow_external_error(self) -> ArrowError {
         ArrowError::from_external_error(Box::new(self))
     }
 }
 
-impl From<Error> for ExecutionError {
+impl From<Error> for DataFusionError {
     fn from(e: Error) -> Self {
-        ExecutionError::IoError(e)
+        DataFusionError::IoError(e)
     }
 }
 
-impl From<String> for ExecutionError {
+impl From<String> for DataFusionError {
     fn from(e: String) -> Self {
-        ExecutionError::General(e)
+        DataFusionError::General(e)
     }
 }
 
-impl From<&'static str> for ExecutionError {
+impl From<&'static str> for DataFusionError {
     fn from(e: &'static str) -> Self {
-        ExecutionError::General(e.to_string())
+        DataFusionError::General(e.to_string())
     }
 }
 
-impl From<ArrowError> for ExecutionError {
+impl From<ArrowError> for DataFusionError {
     fn from(e: ArrowError) -> Self {
-        ExecutionError::ArrowError(e)
+        DataFusionError::ArrowError(e)
     }
 }
 
-impl From<ParquetError> for ExecutionError {
+impl From<ParquetError> for DataFusionError {
     fn from(e: ParquetError) -> Self {
-        ExecutionError::ParquetError(e)
+        DataFusionError::ParquetError(e)
     }
 }
 
-impl From<ParserError> for ExecutionError {
+impl From<ParserError> for DataFusionError {
     fn from(e: ParserError) -> Self {
-        ExecutionError::ParserError(e)
+        DataFusionError::SQL(e)
     }
 }
 
-impl Display for ExecutionError {
+impl Display for DataFusionError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match *self {
-            ExecutionError::ArrowError(ref desc) => write!(f, "Arrow error: {}", desc),
-            ExecutionError::ParquetError(ref desc) => {
+            DataFusionError::ArrowError(ref desc) => write!(f, "Arrow error: {}", desc),
+            DataFusionError::ParquetError(ref desc) => {
                 write!(f, "Parquet error: {}", desc)
             }
-            ExecutionError::IoError(ref desc) => write!(f, "IO error: {}", desc),
-            ExecutionError::ParserError(ref desc) => {
-                write!(f, "Parser error: {:?}", desc)
+            DataFusionError::IoError(ref desc) => write!(f, "IO error: {}", desc),
+            DataFusionError::SQL(ref desc) => {
+                write!(f, "SQL error: {:?}", desc)
             }
-            ExecutionError::General(ref desc) => write!(f, "General error: {}", desc),
-            ExecutionError::InvalidColumn(ref desc) => {
-                write!(f, "Invalid column error: {}", desc)
+            DataFusionError::General(ref desc) => write!(f, "General error: {}", desc),
+            DataFusionError::NotImplemented(ref desc) => {
+                write!(f, "This feature is not implemented: {}", desc)
             }
-            ExecutionError::NotImplemented(ref desc) => {
-                write!(f, "NotImplemented: {}", desc)
+            DataFusionError::Internal(ref desc) => {
+                write!(f, "Internal error: {}. This was likely caused by a bug in DataFusion's \
+                    code and we would welcome that you file an bug report in our issue tracker", desc)
             }
-            ExecutionError::InternalError(ref desc) => {
-                write!(f, "Internal error: {}", desc)
+            DataFusionError::Plan(ref desc) => {
+                write!(f, "Error during planning: {}", desc)
             }
-            ExecutionError::ExecutionError(ref desc) => {
+            DataFusionError::Execution(ref desc) => {
                 write!(f, "Execution error: {}", desc)
             }
         }
     }
 }
 
-impl error::Error for ExecutionError {}
+impl error::Error for DataFusionError {}

--- a/rust/datafusion/src/error.rs
+++ b/rust/datafusion/src/error.rs
@@ -19,7 +19,7 @@
 
 use std::error;
 use std::fmt::{Display, Formatter};
-use std::io::Error;
+use std::io;
 use std::result;
 
 use arrow::error::ArrowError;
@@ -37,18 +37,18 @@ pub enum DataFusionError {
     ArrowError(ArrowError),
     /// Wraps an error from the Parquet crate
     ParquetError(ParquetError),
-    /// I/O error
-    IoError(Error),
+    /// Error associated to I/O operations and associated traits.
+    IoError(io::Error),
     /// Error returned when SQL is syntatically incorrect.
     SQL(ParserError),
-    /// Error returned on a code branch that we know it is possible
-    /// but to which we still have no implementation of.
+    /// Error returned on a branch that we know it is possible
+    /// but to which we still have no implementation for.
     /// Often, these errors are tracked in our issue tracker.
     NotImplemented(String),
     /// Error returned as a consequence of an error in DataFusion.
     /// This error should not happen in normal usage of DataFusion.
-    // We use this error when an invariant that we were unable
-    // to make the compiler assert for us is not verified during execution.
+    // DataFusions has internal invariants that we are unable to ask the compiler to check for us.
+    // This error is raised when one of those invariants is not verified during execution.
     Internal(String),
     /// This error happens whenever a plan is not valid. Examples include
     /// impossible casts, schema inference not possible and non-unique column names.
@@ -65,8 +65,8 @@ impl DataFusionError {
     }
 }
 
-impl From<Error> for DataFusionError {
-    fn from(e: Error) -> Self {
+impl From<io::Error> for DataFusionError {
+    fn from(e: io::Error) -> Self {
         DataFusionError::IoError(e)
     }
 }

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -18,7 +18,7 @@
 //! Projection Push Down optimizer rule ensures that only referenced columns are
 //! loaded into memory
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::logical_plan::LogicalPlan;
 use crate::optimizer::optimizer::OptimizerRule;
 use crate::optimizer::utils;
@@ -62,7 +62,7 @@ fn get_projected_schema(
     has_projection: bool,
 ) -> Result<(Vec<usize>, SchemaRef)> {
     if projection.is_some() {
-        return Err(ExecutionError::General(
+        return Err(DataFusionError::Internal(
             "Cannot run projection push-down rule more than once".to_string(),
         ));
     }

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -22,7 +22,7 @@ use std::{collections::HashSet, sync::Arc};
 use arrow::datatypes::{Schema, SchemaRef};
 
 use super::optimizer::OptimizerRule;
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::logical_plan::{Expr, LogicalPlan, PlanType, StringifiedPlan};
 
 /// Recursively walk a list of expression trees, collecting the unique set of column
@@ -68,7 +68,7 @@ pub fn expr_to_column_names(expr: &Expr, accum: &mut HashSet<String>) -> Result<
         Expr::AggregateUDF { args, .. } => exprlist_to_column_names(args, accum),
         Expr::ScalarFunction { args, .. } => exprlist_to_column_names(args, accum),
         Expr::ScalarUDF { args, .. } => exprlist_to_column_names(args, accum),
-        Expr::Wildcard => Err(ExecutionError::General(
+        Expr::Wildcard => Err(DataFusionError::Internal(
             "Wildcard expressions are not valid in a logical query plan".to_owned(),
         )),
         Expr::Nested(e) => expr_to_column_names(e, accum),
@@ -215,7 +215,7 @@ pub fn expr_sub_expressions(expr: &Expr) -> Result<Vec<&Expr>> {
         Expr::ScalarVariable(_) => Ok(vec![]),
         Expr::Not(expr) => Ok(vec![expr]),
         Expr::Sort { expr, .. } => Ok(vec![expr]),
-        Expr::Wildcard { .. } => Err(ExecutionError::General(
+        Expr::Wildcard { .. } => Err(DataFusionError::Internal(
             "Wildcard expressions are not valid in a logical query plan".to_owned(),
         )),
         Expr::Nested(expr) => Ok(vec![expr]),
@@ -268,7 +268,7 @@ pub fn rewrite_expression(expr: &Expr, expressions: &Vec<Expr>) -> Result<Expr> 
             asc: asc.clone(),
             nulls_first: nulls_first.clone(),
         }),
-        Expr::Wildcard { .. } => Err(ExecutionError::General(
+        Expr::Wildcard { .. } => Err(DataFusionError::Internal(
             "Wildcard expressions are not valid in a logical query plan".to_owned(),
         )),
         Expr::Nested(_) => Ok(Expr::Nested(Box::new(expressions[0].clone()))),

--- a/rust/datafusion/src/physical_plan/aggregates.rs
+++ b/rust/datafusion/src/physical_plan/aggregates.rs
@@ -31,7 +31,7 @@ use super::{
     type_coercion::{coerce, data_types},
     Accumulator, AggregateExpr, PhysicalExpr,
 };
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::distinct_expressions;
 use crate::physical_plan::expressions;
 use arrow::datatypes::{DataType, Schema};
@@ -70,7 +70,7 @@ impl fmt::Display for AggregateFunction {
 }
 
 impl FromStr for AggregateFunction {
-    type Err = ExecutionError;
+    type Err = DataFusionError;
     fn from_str(name: &str) -> Result<AggregateFunction> {
         Ok(match &*name.to_uppercase() {
             "MIN" => AggregateFunction::Min,
@@ -79,7 +79,7 @@ impl FromStr for AggregateFunction {
             "AVG" => AggregateFunction::Avg,
             "SUM" => AggregateFunction::Sum,
             _ => {
-                return Err(ExecutionError::General(format!(
+                return Err(DataFusionError::Plan(format!(
                     "There is no built-in function named {}",
                     name
                 )))
@@ -142,7 +142,7 @@ pub fn create_aggregate_expr(
             Arc::new(expressions::Sum::new(arg, name, return_type))
         }
         (AggregateFunction::Sum, true) => {
-            return Err(ExecutionError::NotImplemented(
+            return Err(DataFusionError::NotImplemented(
                 "SUM(DISTINCT) aggregations are not available".to_string(),
             ));
         }
@@ -156,7 +156,7 @@ pub fn create_aggregate_expr(
             Arc::new(expressions::Avg::new(arg, name, return_type))
         }
         (AggregateFunction::Avg, true) => {
-            return Err(ExecutionError::NotImplemented(
+            return Err(DataFusionError::NotImplemented(
                 "AVG(DISTINCT) aggregations are not available".to_string(),
             ));
         }

--- a/rust/datafusion/src/physical_plan/array_expressions.rs
+++ b/rust/datafusion/src/physical_plan/array_expressions.rs
@@ -17,7 +17,7 @@
 
 //! Array expressions
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use arrow::array::*;
 use arrow::datatypes::DataType;
 use std::sync::Arc;
@@ -28,7 +28,7 @@ macro_rules! downcast_vec {
             .iter()
             .map(|e| match e.as_any().downcast_ref::<$ARRAY_TYPE>() {
                 Some(array) => Ok(array),
-                _ => Err(ExecutionError::General("failed to downcast".to_string())),
+                _ => Err(DataFusionError::Internal("failed to downcast".to_string())),
             })
     }};
 }
@@ -62,7 +62,7 @@ macro_rules! array {
 pub fn array(args: &[ArrayRef]) -> Result<ArrayRef> {
     // do not accept 0 arguments.
     if args.len() == 0 {
-        return Err(ExecutionError::InternalError(
+        return Err(DataFusionError::Internal(
             "array requires at least one argument".to_string(),
         ));
     }
@@ -81,7 +81,7 @@ pub fn array(args: &[ArrayRef]) -> Result<ArrayRef> {
         DataType::UInt16 => array!(args, UInt16Array, UInt16Builder),
         DataType::UInt32 => array!(args, UInt32Array, UInt32Builder),
         DataType::UInt64 => array!(args, UInt64Array, UInt64Builder),
-        data_type => Err(ExecutionError::NotImplemented(format!(
+        data_type => Err(DataFusionError::NotImplemented(format!(
             "Array is not implemented for type '{:?}'.",
             data_type
         ))),

--- a/rust/datafusion/src/physical_plan/common.rs
+++ b/rust/datafusion/src/physical_plan/common.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use super::{RecordBatchStream, SendableRecordBatchStream};
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 
 use array::{
     BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
@@ -84,7 +84,7 @@ pub async fn collect(stream: SendableRecordBatchStream) -> Result<Vec<RecordBatc
     stream
         .try_collect::<Vec<_>>()
         .await
-        .map_err(|e| ExecutionError::from(e))
+        .map_err(|e| DataFusionError::from(e))
 }
 
 /// Recursively build a list of files in a directory with a given extension
@@ -107,7 +107,7 @@ pub fn build_file_list(dir: &str, filenames: &mut Vec<String>, ext: &str) -> Res
                     }
                 }
             } else {
-                return Err(ExecutionError::General("Invalid path".to_string()));
+                return Err(DataFusionError::Plan("Invalid path".to_string()));
             }
         }
     }
@@ -159,12 +159,12 @@ pub fn create_batch_empty(schema: &Schema) -> ArrowResult<RecordBatch> {
             DataType::Boolean => {
                 Ok(Arc::new(BooleanArray::from(vec![] as Vec<bool>)) as ArrayRef)
             }
-            _ => Err(ExecutionError::NotImplemented(format!(
+            _ => Err(DataFusionError::NotImplemented(format!(
                 "Cannot convert datatype {:?} to array",
                 f.data_type()
             ))),
         })
         .collect::<Result<_>>()
-        .map_err(ExecutionError::into_arrow_external_error)?;
+        .map_err(DataFusionError::into_arrow_external_error)?;
     RecordBatch::try_new(Arc::new(schema.to_owned()), columns)
 }

--- a/rust/datafusion/src/physical_plan/csv.rs
+++ b/rust/datafusion/src/physical_plan/csv.rs
@@ -23,7 +23,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::ExecutionPlan;
 use crate::physical_plan::{common, Partitioning};
 use arrow::csv;
@@ -145,7 +145,7 @@ impl CsvExec {
         let mut filenames: Vec<String> = vec![];
         common::build_file_list(path, &mut filenames, file_extension.as_str())?;
         if filenames.is_empty() {
-            return Err(ExecutionError::General("No files found".to_string()));
+            return Err(DataFusionError::Execution("No files found".to_string()));
         }
 
         let schema = match options.schema {
@@ -214,7 +214,7 @@ impl ExecutionPlan for CsvExec {
         if children.is_empty() {
             Ok(Arc::new(self.clone()))
         } else {
-            Err(ExecutionError::General(format!(
+            Err(DataFusionError::Internal(format!(
                 "Children cannot be replaced in {:?}",
                 self
             )))

--- a/rust/datafusion/src/physical_plan/datetime_expressions.rs
+++ b/rust/datafusion/src/physical_plan/datetime_expressions.rs
@@ -19,7 +19,7 @@
 
 use std::sync::Arc;
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use arrow::{
     array::{Array, ArrayData, ArrayRef, StringArray, TimestampNanosecondArray},
     buffer::Buffer,
@@ -136,7 +136,7 @@ fn string_to_timestamp_nanos(s: &str) -> Result<i64> {
     // strings and we don't know which the user was trying to
     // match. Ths any of the specific error messages is likely to be
     // be more confusing than helpful
-    Err(ExecutionError::General(format!(
+    Err(DataFusionError::Execution(format!(
         "Error parsing '{}' as timestamp",
         s
     )))
@@ -148,7 +148,7 @@ fn naive_datetime_to_timestamp(s: &str, datetime: NaiveDateTime) -> Result<i64> 
     let l = Local {};
 
     match l.from_local_datetime(&datetime) {
-        LocalResult::None => Err(ExecutionError::General(format!(
+        LocalResult::None => Err(DataFusionError::Execution(format!(
             "Error parsing '{}' as timestamp: local time representation is invalid",
             s
         ))),
@@ -174,8 +174,8 @@ pub fn to_timestamp(args: &[ArrayRef]) -> Result<TimestampNanosecondArray> {
             .as_any()
             .downcast_ref::<StringArray>()
             .ok_or_else(|| {
-                ExecutionError::General(format!(
-                    "Internal error: could not cast to_timestamp input to StringArray"
+                DataFusionError::Internal(format!(
+                    "could not cast to_timestamp input to StringArray"
                 ))
             })?;
 

--- a/rust/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/rust/datafusion/src/physical_plan/distinct_expressions.rs
@@ -26,7 +26,7 @@ use arrow::datatypes::{DataType, Field};
 
 use fnv::FnvHashSet;
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::group_scalar::GroupByScalar;
 use crate::physical_plan::{Accumulator, AggregateExpr, PhysicalExpr};
 use crate::scalar::ScalarValue;
@@ -131,7 +131,7 @@ impl Accumulator for DistinctCountAccumulator {
             .iter()
             .map(|state| match state {
                 ScalarValue::List(Some(values), _) => Ok(values),
-                _ => Err(ExecutionError::InternalError(
+                _ => Err(DataFusionError::Internal(
                     "Unexpected accumulator state".to_string(),
                 )),
             })
@@ -178,7 +178,7 @@ impl Accumulator for DistinctCountAccumulator {
         match &self.count_data_type {
             DataType::UInt64 => Ok(ScalarValue::UInt64(Some(self.values.len() as u64))),
             t => {
-                return Err(ExecutionError::InternalError(format!(
+                return Err(DataFusionError::Internal(format!(
                     "Invalid data type {:?} for count distinct aggregation",
                     t
                 )))

--- a/rust/datafusion/src/physical_plan/empty.rs
+++ b/rust/datafusion/src/physical_plan/empty.rs
@@ -20,7 +20,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::memory::MemoryStream;
 use crate::physical_plan::{Distribution, ExecutionPlan, Partitioning};
 use arrow::datatypes::SchemaRef;
@@ -72,7 +72,7 @@ impl ExecutionPlan for EmptyExec {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         match children.len() {
             0 => Ok(Arc::new(EmptyExec::new(self.schema.clone()))),
-            _ => Err(ExecutionError::General(
+            _ => Err(DataFusionError::Internal(
                 "EmptyExec wrong number of children".to_string(),
             )),
         }
@@ -81,7 +81,7 @@ impl ExecutionPlan for EmptyExec {
     async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
         // GlobalLimitExec has a single output partition
         if 0 != partition {
-            return Err(ExecutionError::General(format!(
+            return Err(DataFusionError::Internal(format!(
                 "EmptyExec invalid partition {} (expected 0)",
                 partition
             )));

--- a/rust/datafusion/src/physical_plan/explain.rs
+++ b/rust/datafusion/src/physical_plan/explain.rs
@@ -20,7 +20,7 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::{
     logical_plan::StringifiedPlan,
     physical_plan::{common::SizedRecordBatchStream, ExecutionPlan},
@@ -82,7 +82,7 @@ impl ExecutionPlan for ExplainExec {
         if children.is_empty() {
             Ok(Arc::new(self.clone()))
         } else {
-            Err(ExecutionError::General(format!(
+            Err(DataFusionError::Internal(format!(
                 "Children cannot be replaced in {:?}",
                 self
             )))
@@ -91,7 +91,7 @@ impl ExecutionPlan for ExplainExec {
 
     async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
         if 0 != partition {
-            return Err(ExecutionError::General(format!(
+            return Err(DataFusionError::Internal(format!(
                 "ExplainExec invalid partition {}",
                 partition
             )));

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -33,7 +33,7 @@ use super::{
     type_coercion::{coerce, data_types},
     PhysicalExpr,
 };
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::array_expressions;
 use crate::physical_plan::datetime_expressions;
 use crate::physical_plan::math_expressions;
@@ -131,7 +131,7 @@ impl fmt::Display for BuiltinScalarFunction {
 }
 
 impl FromStr for BuiltinScalarFunction {
-    type Err = ExecutionError;
+    type Err = DataFusionError;
     fn from_str(name: &str) -> Result<BuiltinScalarFunction> {
         Ok(match name {
             "sqrt" => BuiltinScalarFunction::Sqrt,
@@ -156,7 +156,7 @@ impl FromStr for BuiltinScalarFunction {
             "to_timestamp" => BuiltinScalarFunction::ToTimestamp,
             "array" => BuiltinScalarFunction::Array,
             _ => {
-                return Err(ExecutionError::General(format!(
+                return Err(DataFusionError::Plan(format!(
                     "There is no built-in function named {}",
                     name
                 )))
@@ -179,7 +179,7 @@ pub fn return_type(
     if arg_types.len() == 0 {
         // functions currently cannot be evaluated without arguments, as they can't
         // know the number of rows to return.
-        return Err(ExecutionError::General(
+        return Err(DataFusionError::Plan(
             format!("Function '{}' requires at least one argument", fun).to_string(),
         ));
     }
@@ -193,7 +193,7 @@ pub fn return_type(
             DataType::Utf8 => DataType::Int32,
             _ => {
                 // this error is internal as `data_types` should have captured this.
-                return Err(ExecutionError::InternalError(
+                return Err(DataFusionError::Internal(
                     "The length function can only accept strings.".to_string(),
                 ));
             }
@@ -446,7 +446,7 @@ mod tests {
     fn test_concat_error() -> Result<()> {
         let result = return_type(&BuiltinScalarFunction::Concat, &vec![]);
         if let Ok(_) = result {
-            Err(ExecutionError::General(
+            Err(DataFusionError::Plan(
                 "Function 'concat' cannot accept zero arguments".to_string(),
             ))
         } else {

--- a/rust/datafusion/src/physical_plan/group_scalar.rs
+++ b/rust/datafusion/src/physical_plan/group_scalar.rs
@@ -19,7 +19,7 @@
 
 use std::convert::{From, TryFrom};
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::scalar::ScalarValue;
 
 /// Enumeration of types that can be used in a GROUP BY expression (all primitives except
@@ -38,7 +38,7 @@ pub(crate) enum GroupByScalar {
 }
 
 impl TryFrom<&ScalarValue> for GroupByScalar {
-    type Error = ExecutionError;
+    type Error = DataFusionError;
 
     fn try_from(scalar_value: &ScalarValue) -> Result<Self> {
         Ok(match scalar_value {
@@ -60,13 +60,13 @@ impl TryFrom<&ScalarValue> for GroupByScalar {
             | ScalarValue::UInt32(None)
             | ScalarValue::UInt64(None)
             | ScalarValue::Utf8(None) => {
-                return Err(ExecutionError::InternalError(format!(
+                return Err(DataFusionError::Internal(format!(
                     "Cannot convert a ScalarValue holding NULL ({:?})",
                     scalar_value
                 )));
             }
             v => {
-                return Err(ExecutionError::InternalError(format!(
+                return Err(DataFusionError::Internal(format!(
                     "Cannot convert a ScalarValue with associated DataType {:?}",
                     v.get_datatype()
                 )))
@@ -95,7 +95,7 @@ impl From<&GroupByScalar> for ScalarValue {
 mod tests {
     use super::*;
 
-    use crate::error::{ExecutionError, Result};
+    use crate::error::{DataFusionError, Result};
 
     #[test]
     fn from_scalar_holding_none() -> Result<()> {
@@ -103,7 +103,7 @@ mod tests {
         let result = GroupByScalar::try_from(&scalar_value);
 
         match result {
-            Err(ExecutionError::InternalError(error_message)) => assert_eq!(
+            Err(DataFusionError::Internal(error_message)) => assert_eq!(
                 error_message,
                 String::from("Cannot convert a ScalarValue holding NULL (Int8(NULL))")
             ),
@@ -120,7 +120,7 @@ mod tests {
         let result = GroupByScalar::try_from(&scalar_value);
 
         match result {
-            Err(ExecutionError::InternalError(error_message)) => assert_eq!(
+            Err(DataFusionError::Internal(error_message)) => assert_eq!(
                 error_message,
                 String::from(
                     "Cannot convert a ScalarValue with associated DataType Float32"

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -24,7 +24,7 @@ use std::task::{Context, Poll};
 use futures::stream::{Stream, StreamExt, TryStreamExt};
 use futures::FutureExt;
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::{Accumulator, AggregateExpr};
 use crate::physical_plan::{Distribution, ExecutionPlan, Partitioning, PhysicalExpr};
 
@@ -183,7 +183,7 @@ impl ExecutionPlan for HashAggregateExec {
                 self.aggr_expr.clone(),
                 children[0].clone(),
             )?)),
-            _ => Err(ExecutionError::General(
+            _ => Err(DataFusionError::Internal(
                 "HashAggregateExec wrong number of children".to_string(),
             )),
         }
@@ -254,13 +254,13 @@ fn group_aggregate_batch(
     for row in 0..batch.num_rows() {
         // 1.1
         create_key(&group_values, row, &mut key)
-            .map_err(ExecutionError::into_arrow_external_error)?;
+            .map_err(DataFusionError::into_arrow_external_error)?;
 
         match accumulators.get_mut(&key) {
             // 1.2
             None => {
                 let accumulator_set = create_accumulators(aggr_expr)
-                    .map_err(ExecutionError::into_arrow_external_error)?;
+                    .map_err(DataFusionError::into_arrow_external_error)?;
 
                 accumulators
                     .insert(key.clone(), (accumulator_set, Box::new(vec![row as u32])));
@@ -362,7 +362,7 @@ impl Stream for GroupedHashAggregateStream {
         let aggregate_expressions = match aggregate_expressions(&aggr_expr, &mode) {
             Ok(e) => e,
             Err(e) => {
-                return Poll::Ready(Some(Err(ExecutionError::into_arrow_external_error(
+                return Poll::Ready(Some(Err(DataFusionError::into_arrow_external_error(
                     e,
                 ))))
             }
@@ -386,7 +386,7 @@ impl Stream for GroupedHashAggregateStream {
                     accumulators,
                     &aggregate_expressions,
                 )
-                .map_err(ExecutionError::into_arrow_external_error)
+                .map_err(DataFusionError::into_arrow_external_error)
             },
         );
 
@@ -541,7 +541,7 @@ impl Stream for HashAggregateStream {
         let accumulators = match create_accumulators(&self.aggr_expr) {
             Ok(e) => e,
             Err(e) => {
-                return Poll::Ready(Some(Err(ExecutionError::into_arrow_external_error(
+                return Poll::Ready(Some(Err(DataFusionError::into_arrow_external_error(
                     e,
                 ))))
             }
@@ -550,7 +550,7 @@ impl Stream for HashAggregateStream {
         let expressions = match aggregate_expressions(&self.aggr_expr, &self.mode) {
             Ok(e) => e,
             Err(e) => {
-                return Poll::Ready(Some(Err(ExecutionError::into_arrow_external_error(
+                return Poll::Ready(Some(Err(DataFusionError::into_arrow_external_error(
                     e,
                 ))))
             }
@@ -570,7 +570,7 @@ impl Stream for HashAggregateStream {
                 (accumulators, expressions),
                 |(acc, expr), batch| async move {
                     aggregate_batch(&mode, &batch, acc, &expr)
-                        .map_err(ExecutionError::into_arrow_external_error)
+                        .map_err(DataFusionError::into_arrow_external_error)
                         .map(|agg| (agg, expr))
                 },
             )
@@ -581,7 +581,7 @@ impl Stream for HashAggregateStream {
             maybe_accumulators.map(|accumulators| {
                 // 2. convert values to a record batch
                 finalize_aggregation(&accumulators, &mode)
-                    .map_err(ExecutionError::into_arrow_external_error)
+                    .map_err(DataFusionError::into_arrow_external_error)
                     .and_then(|columns| RecordBatch::try_new(schema.clone(), columns))
             })?
         });
@@ -642,7 +642,7 @@ fn create_batch_from_map(
             // 3.
             groups.extend(
                 finalize_aggregation(accumulator_set, mode)
-                    .map_err(ExecutionError::into_arrow_external_error)?,
+                    .map_err(DataFusionError::into_arrow_external_error)?,
             );
 
             Ok(groups)
@@ -745,9 +745,10 @@ fn create_key(
                 vec[i] = GroupByScalar::Utf8(String::from(array.value(row)))
             }
             _ => {
-                return Err(ExecutionError::ExecutionError(
+                // This is internal because we should have caught this before.
+                return Err(DataFusionError::Internal(
                     "Unsupported GROUP BY data type".to_string(),
-                ))
+                ));
             }
         }
     }

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -362,9 +362,9 @@ impl Stream for GroupedHashAggregateStream {
         let aggregate_expressions = match aggregate_expressions(&aggr_expr, &mode) {
             Ok(e) => e,
             Err(e) => {
-                return Poll::Ready(Some(Err(DataFusionError::into_arrow_external_error(
-                    e,
-                ))))
+                return Poll::Ready(Some(Err(
+                    DataFusionError::into_arrow_external_error(e),
+                )))
             }
         };
 
@@ -541,18 +541,18 @@ impl Stream for HashAggregateStream {
         let accumulators = match create_accumulators(&self.aggr_expr) {
             Ok(e) => e,
             Err(e) => {
-                return Poll::Ready(Some(Err(DataFusionError::into_arrow_external_error(
-                    e,
-                ))))
+                return Poll::Ready(Some(Err(
+                    DataFusionError::into_arrow_external_error(e),
+                )))
             }
         };
 
         let expressions = match aggregate_expressions(&self.aggr_expr, &self.mode) {
             Ok(e) => e,
             Err(e) => {
-                return Poll::Ready(Some(Err(DataFusionError::into_arrow_external_error(
-                    e,
-                ))))
+                return Poll::Ready(Some(Err(
+                    DataFusionError::into_arrow_external_error(e),
+                )))
             }
         };
         let expressions = Arc::new(expressions);

--- a/rust/datafusion/src/physical_plan/math_expressions.rs
+++ b/rust/datafusion/src/physical_plan/math_expressions.rs
@@ -25,7 +25,7 @@ use arrow::array::{
 use arrow::buffer::Buffer;
 use arrow::datatypes::{DataType, ToByteSlice};
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 
 macro_rules! compute_op {
     ($ARRAY:expr, $FUNC:ident, $TYPE:ident) => {{
@@ -51,7 +51,7 @@ macro_rules! downcast_compute_op {
         let n = $ARRAY.as_any().downcast_ref::<$TYPE>();
         match n {
             Some(array) => compute_op!(array, $FUNC, $TYPE),
-            _ => Err(ExecutionError::General(format!(
+            _ => Err(DataFusionError::Internal(format!(
                 "Invalid data type for {}",
                 $NAME
             ))),
@@ -64,7 +64,7 @@ macro_rules! unary_primitive_array_op {
         match ($ARRAY).data_type() {
             DataType::Float32 => downcast_compute_op!($ARRAY, $NAME, $FUNC, Float32Array),
             DataType::Float64 => downcast_compute_op!($ARRAY, $NAME, $FUNC, Float64Array),
-            other => Err(ExecutionError::General(format!(
+            other => Err(DataFusionError::Internal(format!(
                 "Unsupported data type {:?} for function {}",
                 other, $NAME,
             ))),

--- a/rust/datafusion/src/physical_plan/memory.rs
+++ b/rust/datafusion/src/physical_plan/memory.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use super::{ExecutionPlan, Partitioning, RecordBatchStream, SendableRecordBatchStream};
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use arrow::datatypes::SchemaRef;
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
@@ -67,7 +67,7 @@ impl ExecutionPlan for MemoryExec {
         &self,
         _: Vec<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        Err(ExecutionError::General(format!(
+        Err(DataFusionError::Internal(format!(
             "Children cannot be replaced in {:?}",
             self
         )))

--- a/rust/datafusion/src/physical_plan/merge.rs
+++ b/rust/datafusion/src/physical_plan/merge.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use futures::future;
 
 use super::common;
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::ExecutionPlan;
 use crate::physical_plan::Partitioning;
 
@@ -78,7 +78,7 @@ impl ExecutionPlan for MergeExec {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         match children.len() {
             1 => Ok(Arc::new(MergeExec::new(children[0].clone()))),
-            _ => Err(ExecutionError::General(
+            _ => Err(DataFusionError::Internal(
                 "MergeExec wrong number of children".to_string(),
             )),
         }
@@ -87,7 +87,7 @@ impl ExecutionPlan for MergeExec {
     async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
         // MergeExec produces a single partition
         if 0 != partition {
-            return Err(ExecutionError::General(format!(
+            return Err(DataFusionError::Internal(format!(
                 "MergeExec invalid partition {}",
                 partition
             )));
@@ -95,7 +95,7 @@ impl ExecutionPlan for MergeExec {
 
         let input_partitions = self.input.output_partitioning().partition_count();
         match input_partitions {
-            0 => Err(ExecutionError::General(
+            0 => Err(DataFusionError::Internal(
                 "MergeExec requires at least one input partition".to_owned(),
             )),
             1 => {

--- a/rust/datafusion/src/physical_plan/projection.rs
+++ b/rust/datafusion/src/physical_plan/projection.rs
@@ -25,7 +25,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::{ExecutionPlan, Partitioning, PhysicalExpr};
 use arrow::datatypes::{Field, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
@@ -107,7 +107,7 @@ impl ExecutionPlan for ProjectionExec {
                 self.expr.clone(),
                 children[0].clone(),
             )?)),
-            _ => Err(ExecutionError::General(
+            _ => Err(DataFusionError::Internal(
                 "ProjectionExec wrong number of children".to_string(),
             )),
         }
@@ -132,7 +132,7 @@ fn batch_project(
         .map(|expr| expr.evaluate(&batch))
         .collect::<Result<Vec<_>>>()
         .map_or_else(
-            |e| Err(ExecutionError::into_arrow_external_error(e)),
+            |e| Err(DataFusionError::into_arrow_external_error(e)),
             |arrays| RecordBatch::try_new(schema.clone(), arrays),
         )
 }

--- a/rust/datafusion/src/physical_plan/sort.rs
+++ b/rust/datafusion/src/physical_plan/sort.rs
@@ -27,7 +27,7 @@ use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 
 use super::SendableRecordBatchStream;
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::common::SizedRecordBatchStream;
 use crate::physical_plan::expressions::PhysicalSortExpr;
 use crate::physical_plan::{common, Distribution, ExecutionPlan, Partitioning};
@@ -94,7 +94,7 @@ impl ExecutionPlan for SortExec {
                 children[0].clone(),
                 self.concurrency,
             )?)),
-            _ => Err(ExecutionError::General(
+            _ => Err(DataFusionError::Internal(
                 "SortExec wrong number of children".to_string(),
             )),
         }
@@ -102,7 +102,7 @@ impl ExecutionPlan for SortExec {
 
     async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
         if 0 != partition {
-            return Err(ExecutionError::General(format!(
+            return Err(DataFusionError::Internal(format!(
                 "SortExec invalid partition {}",
                 partition
             )));
@@ -110,7 +110,7 @@ impl ExecutionPlan for SortExec {
 
         // sort needs to operate on a single partition currently
         if 1 != self.input.output_partitioning().partition_count() {
-            return Err(ExecutionError::General(
+            return Err(DataFusionError::Internal(
                 "SortExec requires a single input partition".to_owned(),
             ));
         }

--- a/rust/datafusion/src/physical_plan/string_expressions.rs
+++ b/rust/datafusion/src/physical_plan/string_expressions.rs
@@ -17,7 +17,7 @@
 
 //! String expressions
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use arrow::array::{Array, ArrayRef, StringArray, StringBuilder};
 
 macro_rules! downcast_vec {
@@ -26,7 +26,7 @@ macro_rules! downcast_vec {
             .iter()
             .map(|e| match e.as_any().downcast_ref::<$ARRAY_TYPE>() {
                 Some(array) => Ok(array),
-                _ => Err(ExecutionError::General("failed to downcast".to_string())),
+                _ => Err(DataFusionError::Internal("failed to downcast".to_string())),
             })
     }};
 }
@@ -37,7 +37,7 @@ pub fn concatenate(args: &[ArrayRef]) -> Result<StringArray> {
     let args = downcast_vec!(args, StringArray).collect::<Result<Vec<&StringArray>>>()?;
     // do not accept 0 arguments.
     if args.len() == 0 {
-        return Err(ExecutionError::InternalError(
+        return Err(DataFusionError::Internal(
             "Concatenate was called with 0 arguments. It requires at least one."
                 .to_string(),
         ));

--- a/rust/datafusion/src/physical_plan/type_coercion.rs
+++ b/rust/datafusion/src/physical_plan/type_coercion.rs
@@ -34,7 +34,7 @@ use std::sync::Arc;
 use arrow::datatypes::{DataType, Schema};
 
 use super::{functions::Signature, PhysicalExpr};
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 use crate::physical_plan::expressions::cast;
 
 /// Returns `expressions` coerced to types compatible with
@@ -87,7 +87,7 @@ pub fn data_types(
         Signature::Exact(valid_types) => vec![valid_types.clone()],
         Signature::Any(number) => {
             if current_types.len() != *number {
-                return Err(ExecutionError::General(format!(
+                return Err(DataFusionError::Plan(format!(
                     "The function expected {} arguments but received {}",
                     number,
                     current_types.len()
@@ -108,7 +108,7 @@ pub fn data_types(
     }
 
     // none possible -> Error
-    Err(ExecutionError::General(format!(
+    Err(DataFusionError::Plan(format!(
         "Coercion from {:?} to the signature {:?} failed.",
         current_types, signature
     )))
@@ -347,7 +347,7 @@ mod tests {
 
         for case in cases {
             if let Ok(_) = coerce(&case.0, &case.1, &case.2) {
-                return Err(ExecutionError::General(format!(
+                return Err(DataFusionError::Plan(format!(
                     "Error was expected in {:?}",
                     case
                 )));

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -33,7 +33,7 @@ use arrow::{
     datatypes::DataType,
 };
 
-use crate::error::{ExecutionError, Result};
+use crate::error::{DataFusionError, Result};
 
 /// Represents a dynamically typed, nullable single value.
 /// This is the single-valued counter-part of arrow’s `Array`.
@@ -203,9 +203,7 @@ impl ScalarValue {
             DataType::LargeUtf8 => typed_cast!(array, index, LargeStringArray, LargeUtf8),
             DataType::List(nested_type) => {
                 let list_array = array.as_any().downcast_ref::<ListArray>().ok_or(
-                    ExecutionError::InternalError(
-                        "Failed to downcast ListArray".to_string(),
-                    ),
+                    DataFusionError::Internal("Failed to downcast ListArray".to_string()),
                 )?;
                 let value = match list_array.is_null(index) {
                     true => None,
@@ -220,7 +218,7 @@ impl ScalarValue {
                 ScalarValue::List(value, *nested_type.clone())
             }
             other => {
-                return Err(ExecutionError::NotImplemented(format!(
+                return Err(DataFusionError::NotImplemented(format!(
                     "Can't create a scalar of array of type \"{:?}\"",
                     other
                 )))
@@ -296,7 +294,7 @@ impl From<u64> for ScalarValue {
 }
 
 impl TryFrom<&DataType> for ScalarValue {
-    type Error = ExecutionError;
+    type Error = DataFusionError;
 
     fn try_from(datatype: &DataType) -> Result<Self> {
         Ok(match datatype {
@@ -317,7 +315,7 @@ impl TryFrom<&DataType> for ScalarValue {
                 ScalarValue::List(None, *nested_type.clone())
             }
             _ => {
-                return Err(ExecutionError::NotImplemented(format!(
+                return Err(DataFusionError::NotImplemented(format!(
                     "Can't create a scalar of type \"{:?}\"",
                     datatype
                 )))


### PR DESCRIPTION
This PR:

* Renamed `ExecutionError` to `DataFusionError`
* Renamed `DataFusionError::ParserError` to `DataFusionError::SQL`
* Renamed `DataFusionError::InternalError` to `DataFusionError::Internal`
* Renamed `DataFusionError::ExecutionError` to `DataFusionError::Execution`
* Adds a new error variant `DataFusionError::Plan` that is used during planning
* Removes `DataFusionError::InvalidColumn` that was not being used.
* Removes `DataFusionError::General`, replacing them by the appropriate errors
* Improves the message of `DataFusionError::Internal` to incentivize users to file a bug report when it happens
* Extended the documentation of every variant

The design behind this PR is that the error variants should correspond to what happened:

* `Internal`: a Datafusion's internal invariant was violated (e.g. downcast failed) => file a bug report
* `Plan`: planning was incorrect
* `NotImplemented`: something is not implemented and we know about it. Ideally, we should have an associated JIRA issue
* `Execution`: an error during execution. We should avoid raising these, but sometimes it is impossible.
* `IoError`: stuff related with reading and writing

I went through every error that we return in `DataFusion` and verified that it is assigned correctly to one of these variants.

I am a bit uncertain about the `ParquetError` and `ArrowError`. IMO `ArrowError` should be mapped to `DataFusionError::Execution`, as it only happens during execution, and `ParquetError` should be mapped to an `IoError`.

I also think that we should split `NotImplemented` in two: `NotImplemented` and `NotSupported` as e.g. `float16` is something that we will likely never support, while "modulus" is just not implemented yet.