### PR TITLE
ARROW-10336: [Rust] Added FromIter and ToIter for string arrays

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1496,7 +1496,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         }
     }
 
-    fn from_list(v: GenericListArray<OffsetSize>, data_type: DataType) -> Self {
+    fn from_list(v: GenericListArray<OffsetSize>) -> Self {
         assert_eq!(
             v.data().child_data()[0].child_data().len(),
             0,
@@ -1509,7 +1509,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
             "StringArray can only be created from List<u8> arrays, mismatched data types."
         );
 
-        let mut builder = ArrayData::builder(data_type)
+        let mut builder = ArrayData::builder(OffsetSize::DATA_TYPE)
             .len(v.len())
             .add_buffer(v.data_ref().buffers()[0].clone())
             .add_buffer(v.data_ref().child_data()[0].buffers()[0].clone());
@@ -1523,7 +1523,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         Self::from(data)
     }
 
-    pub(crate) fn from_vec(v: Vec<&str>, data_type: DataType) -> Self {
+    pub(crate) fn from_vec(v: Vec<&str>) -> Self {
         let mut offsets = Vec::with_capacity(v.len() + 1);
         let mut values = Vec::new();
         let mut length_so_far = OffsetSize::zero();
@@ -1533,7 +1533,7 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
             offsets.push(length_so_far);
             values.extend_from_slice(s.as_bytes());
         }
-        let array_data = ArrayData::builder(data_type)
+        let array_data = ArrayData::builder(OffsetSize::DATA_TYPE)
             .len(v.len())
             .add_buffer(Buffer::from(offsets.to_byte_slice()))
             .add_buffer(Buffer::from(&values[..]))
@@ -1541,14 +1541,29 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
         Self::from(array_data)
     }
 
-    pub(crate) fn from_opt_vec(v: Vec<Option<&str>>, data_type: DataType) -> Self {
-        let mut offsets = Vec::with_capacity(v.len() + 1);
+    pub(crate) fn from_opt_vec(v: Vec<Option<&str>>) -> Self {
+        GenericStringArray::from_iter(v)
+    }
+}
+
+impl<'a, Ptr, OffsetSize: StringOffsetSizeTrait> FromIterator<Ptr>
+    for GenericStringArray<OffsetSize>
+where
+    Ptr: Borrow<Option<&'a str>>,
+{
+    fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let (_, data_len) = iter.size_hint();
+        let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
+
+        let mut offsets = Vec::with_capacity(data_len + 1);
         let mut values = Vec::new();
-        let mut null_buf = make_null_buffer(v.len());
+        let mut null_buf = make_null_buffer(data_len);
         let mut length_so_far = OffsetSize::zero();
         offsets.push(length_so_far);
-        for (i, s) in v.iter().enumerate() {
-            if let Some(s) = s {
+
+        for (i, s) in iter.enumerate() {
+            if let Some(s) = s.borrow() {
                 // set null bit
                 let null_slice = null_buf.data_mut();
                 bit_util::set_bit(null_slice, i);
@@ -1561,8 +1576,9 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
                 values.extend_from_slice(b"");
             }
         }
-        let array_data = ArrayData::builder(data_type)
-            .len(v.len())
+
+        let array_data = ArrayData::builder(OffsetSize::DATA_TYPE)
+            .len(data_len)
             .add_buffer(Buffer::from(offsets.to_byte_slice()))
             .add_buffer(Buffer::from(&values[..]))
             .null_bit_buffer(null_buf.freeze())
@@ -1649,37 +1665,37 @@ pub type LargeStringArray = GenericStringArray<i64>;
 
 impl From<ListArray> for StringArray {
     fn from(v: ListArray) -> Self {
-        StringArray::from_list(v, DataType::Utf8)
+        StringArray::from_list(v)
     }
 }
 
 impl From<LargeListArray> for LargeStringArray {
     fn from(v: LargeListArray) -> Self {
-        LargeStringArray::from_list(v, DataType::LargeUtf8)
+        LargeStringArray::from_list(v)
     }
 }
 
 impl From<Vec<&str>> for StringArray {
     fn from(v: Vec<&str>) -> Self {
-        StringArray::from_vec(v, DataType::Utf8)
+        StringArray::from_vec(v)
     }
 }
 
 impl From<Vec<&str>> for LargeStringArray {
     fn from(v: Vec<&str>) -> Self {
-        LargeStringArray::from_vec(v, DataType::LargeUtf8)
+        LargeStringArray::from_vec(v)
     }
 }
 
 impl From<Vec<Option<&str>>> for StringArray {
     fn from(v: Vec<Option<&str>>) -> Self {
-        StringArray::from_opt_vec(v, DataType::Utf8)
+        StringArray::from_opt_vec(v)
     }
 }
 
 impl From<Vec<Option<&str>>> for LargeStringArray {
     fn from(v: Vec<Option<&str>>) -> Self {
-        LargeStringArray::from_opt_vec(v, DataType::LargeUtf8)
+        LargeStringArray::from_opt_vec(v)
     }
 }
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1542,14 +1542,15 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
     }
 
     pub(crate) fn from_opt_vec(v: Vec<Option<&str>>) -> Self {
-        GenericStringArray::from_iter(v)
+        let iter = v.iter().map(|e| e.map(|e| e.to_string()));
+        GenericStringArray::from_iter(iter)
     }
 }
 
 impl<'a, Ptr, OffsetSize: StringOffsetSizeTrait> FromIterator<Ptr>
     for GenericStringArray<OffsetSize>
 where
-    Ptr: Borrow<Option<&'a str>>,
+    Ptr: Borrow<Option<String>>,
 {
     fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
         let iter = iter.into_iter();
@@ -1584,6 +1585,22 @@ where
             .null_bit_buffer(null_buf.freeze())
             .build();
         Self::from(array_data)
+    }
+}
+
+impl<'a, T: StringOffsetSizeTrait> IntoIterator for &'a GenericStringArray<T> {
+    type Item = Option<&'a str>;
+    type IntoIter = GenericStringIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        GenericStringIter::<'a, T>::new(self)
+    }
+}
+
+impl<'a, T: StringOffsetSizeTrait> GenericStringArray<T> {
+    /// constructs a new iterator
+    pub fn iter(&'a self) -> GenericStringIter<'a, T> {
+        GenericStringIter::<'a, T>::new(&self)
     }
 }
 

--- a/rust/arrow/src/array/equal.rs
+++ b/rust/arrow/src/array/equal.rs
@@ -1413,50 +1413,57 @@ mod tests {
         // assert!(b_slice.equals(&*a_slice));
     }
 
-    fn test_generic_string_equal<OffsetSize: StringOffsetSizeTrait>(datatype: DataType) {
-        let a = GenericStringArray::<OffsetSize>::from_vec(
-            vec!["hello", "world"],
-            datatype.clone(),
-        );
-        let b = GenericStringArray::<OffsetSize>::from_vec(
-            vec!["hello", "world"],
-            datatype.clone(),
-        );
+    fn test_generic_string_equal<OffsetSize: StringOffsetSizeTrait>() {
+        let a = GenericStringArray::<OffsetSize>::from_vec(vec!["hello", "world"]);
+        let b = GenericStringArray::<OffsetSize>::from_vec(vec!["hello", "world"]);
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        let b = GenericStringArray::<OffsetSize>::from_vec(
-            vec!["hello", "arrow"],
-            datatype.clone(),
-        );
+        let b = GenericStringArray::<OffsetSize>::from_vec(vec!["hello", "arrow"]);
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
         // Test the case where null_count > 0
 
-        let a = GenericStringArray::<OffsetSize>::from_opt_vec(
-            vec![Some("hello"), None, None, Some("world"), None, None],
-            datatype.clone(),
-        );
+        let a = GenericStringArray::<OffsetSize>::from_opt_vec(vec![
+            Some("hello"),
+            None,
+            None,
+            Some("world"),
+            None,
+            None,
+        ]);
 
-        let b = GenericStringArray::<OffsetSize>::from_opt_vec(
-            vec![Some("hello"), None, None, Some("world"), None, None],
-            datatype.clone(),
-        );
+        let b = GenericStringArray::<OffsetSize>::from_opt_vec(vec![
+            Some("hello"),
+            None,
+            None,
+            Some("world"),
+            None,
+            None,
+        ]);
         assert!(a.equals(&b));
         assert!(b.equals(&a));
 
-        let b = GenericStringArray::<OffsetSize>::from_opt_vec(
-            vec![Some("hello"), Some("foo"), None, Some("world"), None, None],
-            datatype.clone(),
-        );
+        let b = GenericStringArray::<OffsetSize>::from_opt_vec(vec![
+            Some("hello"),
+            Some("foo"),
+            None,
+            Some("world"),
+            None,
+            None,
+        ]);
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
-        let b = GenericStringArray::<OffsetSize>::from_opt_vec(
-            vec![Some("hello"), None, None, Some("arrow"), None, None],
-            datatype.clone(),
-        );
+        let b = GenericStringArray::<OffsetSize>::from_opt_vec(vec![
+            Some("hello"),
+            None,
+            None,
+            Some("arrow"),
+            None,
+            None,
+        ]);
         assert!(!a.equals(&b));
         assert!(!b.equals(&a));
 
@@ -1480,12 +1487,12 @@ mod tests {
 
     #[test]
     fn test_string_equal() {
-        test_generic_string_equal::<i32>(DataType::Utf8)
+        test_generic_string_equal::<i32>()
     }
 
     #[test]
     fn test_large_string_equal() {
-        test_generic_string_equal::<i64>(DataType::LargeUtf8)
+        test_generic_string_equal::<i64>()
     }
 
     #[test]

--- a/rust/arrow/src/array/iterator.rs
+++ b/rust/arrow/src/array/iterator.rs
@@ -17,7 +17,7 @@
 
 use crate::datatypes::ArrowPrimitiveType;
 
-use super::{Array, PrimitiveArray};
+use super::{Array, GenericStringArray, PrimitiveArray, StringOffsetSizeTrait};
 
 /// an iterator that returns Some(T) or None, that can be used on any non-boolean PrimitiveArray
 #[derive(Debug)]
@@ -62,11 +62,60 @@ impl<'a, T: ArrowPrimitiveType> std::iter::Iterator for PrimitiveIter<'a, T> {
 /// all arrays have known size.
 impl<'a, T: ArrowPrimitiveType> std::iter::ExactSizeIterator for PrimitiveIter<'a, T> {}
 
+/// an iterator that returns `Some(&str)` or `None`, for string arrays
+#[derive(Debug)]
+pub struct GenericStringIter<'a, T>
+where
+    T: StringOffsetSizeTrait,
+{
+    array: &'a GenericStringArray<T>,
+    i: usize,
+    len: usize,
+}
+
+impl<'a, T: StringOffsetSizeTrait> GenericStringIter<'a, T> {
+    /// create a new iterator
+    pub fn new(array: &'a GenericStringArray<T>) -> Self {
+        GenericStringIter::<T> {
+            array,
+            i: 0,
+            len: array.len(),
+        }
+    }
+}
+
+impl<'a, T: StringOffsetSizeTrait> std::iter::Iterator for GenericStringIter<'a, T> {
+    type Item = Option<&'a str>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let i = self.i;
+        if i >= self.len {
+            None
+        } else if self.array.is_null(i) {
+            self.i += 1;
+            Some(None)
+        } else {
+            self.i += 1;
+            Some(Some(self.array.value(i)))
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len, Some(self.len))
+    }
+}
+
+/// all arrays have known size.
+impl<'a, T: StringOffsetSizeTrait> std::iter::ExactSizeIterator
+    for GenericStringIter<'a, T>
+{
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use crate::array::{ArrayRef, Int32Array};
+    use crate::array::{ArrayRef, Int32Array, StringArray};
 
     #[test]
     fn test_primitive_array_iter_round_trip() {
@@ -80,6 +129,31 @@ mod tests {
             array.iter().map(|e| e.and_then(|e| Some(e + 1))).collect();
 
         let expected = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_string_array_iter_round_trip() {
+        let array =
+            StringArray::from(vec![Some("a"), None, Some("aaa"), None, Some("aaaaa")]);
+        let array = Arc::new(array) as ArrayRef;
+
+        let array = array.as_any().downcast_ref::<StringArray>().unwrap();
+
+        // to and from iter, with a +1
+        let result: StringArray = array
+            .iter()
+            .map(|e| {
+                e.and_then(|e| {
+                    let mut a = e.to_string();
+                    a.push_str("b");
+                    Some(a)
+                })
+            })
+            .collect();
+
+        let expected =
+            StringArray::from(vec![Some("ab"), None, Some("aaab"), None, Some("aaaaab")]);
         assert_eq!(result, expected);
     }
 }


### PR DESCRIPTION
What the title says: adds string array from and to iterators.

This PR also simplifies some of the functions around strings.
