### PR TITLE
ARROW-10340: [Packaging][deb][RPM] Use Python 3.8 for pygit2

### DIFF
--- a/dev/tasks/linux-packages/github.linux.amd64.yml
+++ b/dev/tasks/linux-packages/github.linux.amd64.yml
@@ -74,7 +74,9 @@ jobs:
       # The tag upload took 43 minutes because of this scan, so use an
       # alternative upload script.
       - name: Set up Python
-        uses: actions/setup-python@master
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
       - name: Set up Crossbow
         run: |
           pip install \


### PR DESCRIPTION
Because pygit2 wheel for Python 3.9 isn't available yet.