### PR TITLE
ARROW-10208: [C++] Fix split string kernels on sliced input

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -923,8 +923,6 @@ struct SplitBaseTransform {
       ListOffsetsBuilderType list_offsets_builder(ctx->memory_pool());
       KERNEL_RETURN_IF_ERROR(ctx, list_offsets_builder.Resize(input_nstrings));
       ArrayData* output_list = out->mutable_array();
-      // // we use the same null values
-      output_list->buffers[0] = input.buffers[0];
       // initial value
       KERNEL_RETURN_IF_ERROR(
           ctx, list_offsets_builder.Append(static_cast<list_offset_type>(0)));
@@ -986,6 +984,7 @@ struct SplitPatternTransform : SplitBaseTransform<Type, ListType, SplitPatternOp
     }
     return Status::OK();
   }
+
   static bool Find(const uint8_t* begin, const uint8_t* end,
                    const uint8_t** separator_begin, const uint8_t** separator_end,
                    const SplitPatternOptions& options) {
@@ -1004,6 +1003,7 @@ struct SplitPatternTransform : SplitBaseTransform<Type, ListType, SplitPatternOp
     }
     return false;
   }
+
   static bool FindReverse(const uint8_t* begin, const uint8_t* end,
                           const uint8_t** separator_begin, const uint8_t** separator_end,
                           const SplitPatternOptions& options) {

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -339,10 +339,8 @@ TYPED_TEST(TestStringKernels, SplitBasics) {
   // basics
   this->CheckUnary("split_pattern", R"(["foo bar", "foo"])", list(this->type()),
                    R"([["foo", "bar"], ["foo"]])", &options);
-  // TODO: enable test when the following issue is fixed:
-  // https://issues.apache.org/jira/browse/ARROW-10208
-  // this->CheckUnary("split_pattern", R"(["foo bar", "foo", null])", list(this->type()),
-  //                  R"([["foo", "bar"], ["foo"], null])", &options);
+  this->CheckUnary("split_pattern", R"(["foo bar", "foo", null])", list(this->type()),
+                   R"([["foo", "bar"], ["foo"], null])", &options);
   // edgy cases
   this->CheckUnary("split_pattern", R"(["f  o o "])", list(this->type()),
                    R"([["f", "", "o", "o", ""]])", &options);


### PR DESCRIPTION
Nulls were propagated incorrectly.  We can simply let the kernel machinery do this for us.