### PR TITLE
ARROW-10131: [C++][Dataset][Python] Lazily parse parquet metadata

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -302,26 +302,35 @@ class ARROW_DS_EXPORT ParquetDatasetFactory : public DatasetFactory {
   Result<std::shared_ptr<Dataset>> Finish(FinishOptions options) override;
 
  protected:
-  ParquetDatasetFactory(std::shared_ptr<fs::FileSystem> fs,
-                        std::shared_ptr<ParquetFileFormat> format,
-                        std::shared_ptr<parquet::FileMetaData> metadata,
-                        std::string base_path, ParquetFactoryOptions options);
+  ParquetDatasetFactory(
+      std::shared_ptr<fs::FileSystem> filesystem,
+      std::shared_ptr<ParquetFileFormat> format,
+      std::shared_ptr<parquet::FileMetaData> metadata,
+      std::shared_ptr<parquet::arrow::SchemaManifest> manifest,
+      std::shared_ptr<Schema> physical_schema, std::string base_path,
+      ParquetFactoryOptions options,
+      std::unordered_map<std::string, std::vector<int>> path_to_row_group_ids)
+      : filesystem_(std::move(filesystem)),
+        format_(std::move(format)),
+        metadata_(std::move(metadata)),
+        manifest_(std::move(manifest)),
+        physical_schema_(std::move(physical_schema)),
+        base_path_(std::move(base_path)),
+        options_(std::move(options)),
+        path_to_row_group_ids_(std::move(path_to_row_group_ids)) {}
 
   std::shared_ptr<fs::FileSystem> filesystem_;
   std::shared_ptr<ParquetFileFormat> format_;
   std::shared_ptr<parquet::FileMetaData> metadata_;
+  std::shared_ptr<parquet::arrow::SchemaManifest> manifest_;
+  std::shared_ptr<Schema> physical_schema_;
   std::string base_path_;
   ParquetFactoryOptions options_;
-  FragmentVector fragments_;
+  std::unordered_map<std::string, std::vector<int>> path_to_row_group_ids_;
 
  private:
-  Result<std::vector<std::string>> CollectPaths(
-      const parquet::FileMetaData& metadata,
-      const parquet::ArrowReaderProperties& properties);
-
   Result<std::vector<std::shared_ptr<FileFragment>>> CollectParquetFragments(
-      const std::shared_ptr<parquet::FileMetaData>& metadata,
-      const parquet::ArrowReaderProperties& properties, const Partitioning& partitioning);
+      const Partitioning& partitioning);
 
   Result<std::shared_ptr<Schema>> PartitionSchema();
 };

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -254,6 +254,13 @@ struct ParquetFactoryOptions {
   // This is useful for partitioning which parses directory when ordering
   // is important, e.g. DirectoryPartitioning.
   std::string partition_base_dir;
+
+  // Assert that all ColumnChunk paths are consitent. The parquet spec allows for
+  // ColumnChunk data to be stored in multiple files, but ParquetDatasetFactory
+  // supports only a single file with all ColumnChunk data. If this flag is set
+  // construction of a ParquetDatasetFactory will raise an error if ColumnChunk
+  // data is not resident in a single file.
+  bool validate_column_chunk_paths = false;
 };
 
 /// \brief Create FileSystemDataset from custom `_metadata` cache file.

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -197,8 +197,7 @@ class TestParquetFileFormat : public ArrowParquetWriterMixin {
       auto expected = expected_row_groups[i];
       auto parquet_fragment = checked_pointer_cast<ParquetFileFragment>(fragments[i]);
 
-      EXPECT_EQ(parquet_fragment->row_groups(),
-                RowGroupInfo::FromIdentifiers({expected}));
+      EXPECT_EQ(parquet_fragment->row_groups(), std::vector<int>{expected});
       EXPECT_EQ(SingleBatch(parquet_fragment.get())->num_rows(), expected + 1);
     }
   }
@@ -506,12 +505,10 @@ TEST_F(TestParquetFileFormat, ExplicitRowGroupSelection) {
   opts_ = ScanOptions::Make(reader->schema());
 
   auto row_groups_fragment = [&](std::vector<int> row_groups) {
-    std::shared_ptr<Schema> physical_schema = nullptr;
     EXPECT_OK_AND_ASSIGN(auto fragment,
                          format_->MakeFragment(*source, scalar(true),
-                                               RowGroupInfo::FromIdentifiers(row_groups),
-                                               physical_schema));
-    return internal::checked_pointer_cast<ParquetFileFragment>(fragment);
+                                               /*physical_schema=*/nullptr, row_groups));
+    return fragment;
   };
 
   // select all row groups
@@ -522,7 +519,7 @@ TEST_F(TestParquetFileFormat, ExplicitRowGroupSelection) {
             return internal::checked_pointer_cast<ParquetFileFragment>(f);
           }));
 
-  EXPECT_EQ(all_row_groups_fragment->row_groups(), RowGroupInfo::FromCount(0));
+  EXPECT_EQ(all_row_groups_fragment->row_groups(), std::vector<int>{});
 
   ARROW_EXPECT_OK(all_row_groups_fragment->EnsureCompleteMetadata());
   CountRowsAndBatchesInScan(all_row_groups_fragment, kTotalNumRows, kNumRowGroups);
@@ -530,7 +527,7 @@ TEST_F(TestParquetFileFormat, ExplicitRowGroupSelection) {
   // individual selection selects a single row group
   for (int i = 0; i < kNumRowGroups; ++i) {
     CountRowsAndBatchesInScan(row_groups_fragment({i}), i + 1, 1);
-    EXPECT_EQ(row_groups_fragment({i})->row_groups(), RowGroupInfo::FromIdentifiers({i}));
+    EXPECT_EQ(row_groups_fragment({i})->row_groups(), std::vector<int>{i});
   }
 
   for (int i = 0; i < kNumRowGroups; ++i) {

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -197,7 +197,7 @@ class TestParquetFileFormat : public ArrowParquetWriterMixin {
       auto expected = expected_row_groups[i];
       auto parquet_fragment = checked_pointer_cast<ParquetFileFragment>(fragments[i]);
 
-      EXPECT_EQ(*parquet_fragment->row_groups(),
+      EXPECT_EQ(parquet_fragment->row_groups(),
                 RowGroupInfo::FromIdentifiers({expected}));
       EXPECT_EQ(SingleBatch(parquet_fragment.get())->num_rows(), expected + 1);
     }
@@ -514,20 +514,23 @@ TEST_F(TestParquetFileFormat, ExplicitRowGroupSelection) {
     return internal::checked_pointer_cast<ParquetFileFragment>(fragment);
   };
 
-  EXPECT_OK_AND_ASSIGN(auto all_row_groups_fragment,
-                       format_->MakeFragment(*source, scalar(true)));
+  // select all row groups
+  EXPECT_OK_AND_ASSIGN(
+      auto all_row_groups_fragment,
+      format_->MakeFragment(*source, scalar(true))
+          .Map([](std::shared_ptr<FileFragment> f) {
+            return internal::checked_pointer_cast<ParquetFileFragment>(f);
+          }));
 
-  // null selection is identical to selecting all row groups
-  EXPECT_EQ(internal::checked_pointer_cast<ParquetFileFragment>(all_row_groups_fragment)
-                ->row_groups(),
-            nullptr);
+  EXPECT_EQ(all_row_groups_fragment->row_groups(), RowGroupInfo::FromCount(0));
+
+  ARROW_EXPECT_OK(all_row_groups_fragment->EnsureCompleteMetadata());
   CountRowsAndBatchesInScan(all_row_groups_fragment, kTotalNumRows, kNumRowGroups);
 
   // individual selection selects a single row group
   for (int i = 0; i < kNumRowGroups; ++i) {
     CountRowsAndBatchesInScan(row_groups_fragment({i}), i + 1, 1);
-    EXPECT_EQ(*row_groups_fragment({i})->row_groups(),
-              RowGroupInfo::FromIdentifiers({i}));
+    EXPECT_EQ(row_groups_fragment({i})->row_groups(), RowGroupInfo::FromIdentifiers({i}));
   }
 
   for (int i = 0; i < kNumRowGroups; ++i) {

--- a/cpp/src/arrow/dataset/type_fwd.h
+++ b/cpp/src/arrow/dataset/type_fwd.h
@@ -72,7 +72,7 @@ class ExpressionEvaluator;
 
 /// forward declared to facilitate scalar(true) as a default for Expression parameters
 ARROW_DS_EXPORT
-std::shared_ptr<Expression> scalar(bool);
+const std::shared_ptr<Expression>& scalar(bool);
 
 class Partitioning;
 class PartitioningFactory;

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -28,6 +28,9 @@
 
 namespace arrow {
 
+template <typename>
+struct EnsureResult;
+
 namespace internal {
 
 #if __cplusplus >= 201703L
@@ -379,7 +382,7 @@ class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
   /// Apply a function to the internally stored value to produce a new result or propagate
   /// the stored error.
   template <typename M>
-  typename std::result_of<M && (T)>::type Map(M&& m) && {
+  typename EnsureResult<typename std::result_of<M && (T)>::type>::type Map(M&& m) && {
     if (!ok()) {
       return status();
     }
@@ -389,7 +392,8 @@ class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
   /// Apply a function to the internally stored value to produce a new result or propagate
   /// the stored error.
   template <typename M>
-  typename std::result_of<M && (const T&)>::type Map(M&& m) const& {
+  typename EnsureResult<typename std::result_of<M && (const T&)>::type>::type Map(
+      M&& m) const& {
     if (!ok()) {
       return status();
     }
@@ -466,5 +470,15 @@ template <typename T>
 Result<T> ToResult(T t) {
   return Result<T>(std::move(t));
 }
+
+template <typename T>
+struct EnsureResult {
+  using type = Result<T>;
+};
+
+template <typename T>
+struct EnsureResult<Result<T>> {
+  using type = Result<T>;
+};
 
 }  // namespace arrow

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -89,9 +89,9 @@ class PARQUET_EXPORT ApplicationVersion {
     std::string build_info;
   } version;
 
-  ApplicationVersion() {}
+  ApplicationVersion() = default;
   explicit ApplicationVersion(const std::string& created_by);
-  ApplicationVersion(const std::string& application, int major, int minor, int patch);
+  ApplicationVersion(std::string application, int major, int minor, int patch);
 
   // Returns true if version is strictly less than other_version
   bool VersionLt(const ApplicationVersion& other_version) const;

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -109,6 +109,8 @@ class PARQUET_EXPORT ColumnCryptoMetaData {
   static std::unique_ptr<ColumnCryptoMetaData> Make(const uint8_t* metadata);
   ~ColumnCryptoMetaData();
 
+  bool Equals(const ColumnCryptoMetaData& other) const;
+
   std::shared_ptr<schema::ColumnPath> path_in_schema() const;
   bool encrypted_with_footer_key() const;
   const std::string& key_metadata() const;
@@ -138,6 +140,8 @@ class PARQUET_EXPORT ColumnChunkMetaData {
       std::shared_ptr<InternalFileDecryptor> file_decryptor = NULLPTR);
 
   ~ColumnChunkMetaData();
+
+  bool Equals(const ColumnChunkMetaData& other) const;
 
   // column chunk
   int64_t file_offset() const;
@@ -189,6 +193,8 @@ class PARQUET_EXPORT RowGroupMetaData {
       std::shared_ptr<InternalFileDecryptor> file_decryptor = NULLPTR);
 
   ~RowGroupMetaData();
+
+  bool Equals(const RowGroupMetaData& other) const;
 
   /// \brief The number of columns in this row group. The order must match the
   /// parent's column ordering.
@@ -243,6 +249,8 @@ class PARQUET_EXPORT FileMetaData {
       std::shared_ptr<InternalFileDecryptor> file_decryptor = NULLPTR);
 
   ~FileMetaData();
+
+  bool Equals(const FileMetaData& other) const;
 
   /// \brief The number of top-level columns in the schema.
   ///
@@ -333,6 +341,10 @@ class PARQUET_EXPORT FileMetaData {
   ///
   /// \throws ParquetException if schemas are not equal.
   void AppendRowGroups(const FileMetaData& other);
+
+  /// \brief Return a FileMetaData containing a subset of the row groups in this
+  /// FileMetaData.
+  std::shared_ptr<FileMetaData> Subset(const std::vector<int>& row_groups) const;
 
  private:
   friend FileMetaDataBuilder;

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -203,6 +203,7 @@ TEST(Metadata, TestBuildAccess) {
     f_accessors[loop_index]->set_file_path("/foo/bar/bar.parquet");
     ASSERT_EQ("/foo/bar/bar.parquet", rg2_column1->file_path());
   }
+
   // Test AppendRowGroups
   auto f_accessor_2 = GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
   f_accessor->AppendRowGroups(*f_accessor_2);
@@ -212,6 +213,14 @@ TEST(Metadata, TestBuildAccess) {
   ASSERT_EQ(ParquetVersion::PARQUET_2_0, f_accessor->version());
   ASSERT_EQ(DEFAULT_CREATED_BY, f_accessor->created_by());
   ASSERT_EQ(3, f_accessor->num_schema_elements());
+
+  // Test Subset
+  auto f_accessor_1 = f_accessor->Subset({2, 3});
+  ASSERT_TRUE(f_accessor_1->Equals(*f_accessor_2));
+
+  f_accessor_1 = f_accessor_2->Subset({0});
+  f_accessor_1->AppendRowGroups(*f_accessor->Subset({0}));
+  ASSERT_TRUE(f_accessor_1->Equals(*f_accessor->Subset({2, 0})));
 }
 
 TEST(Metadata, TestV1Version) {

--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -244,6 +244,9 @@ class PARQUET_EXPORT Statistics {
   /// \brief The full type descriptor from the column schema
   virtual const ColumnDescriptor* descr() const = 0;
 
+  /// \brief Check two Statistics for equality
+  virtual bool Equals(const Statistics& other) const = 0;
+
  protected:
   static std::shared_ptr<Statistics> Make(Type::type physical_type, const void* min,
                                           const void* max, int64_t num_values,

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -179,6 +179,7 @@ else()
   set(BUILD_OUTPUT_ROOT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${BUILD_SUBDIR_NAME}")
 endif()
 
+message(STATUS "Generator: ${CMAKE_GENERATOR}")
 message(STATUS "Build output directory: ${BUILD_OUTPUT_ROOT_DIRECTORY}")
 
 # where to put generated archives (.a files)

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -534,7 +534,6 @@ cdef class Statistics(_Weakrefable):
         ColumnChunkMetaData parent
 
     cdef inline init(self, const shared_ptr[CStatistics]& statistics,
-              ColumnChunkMetaData parent):
+                     ColumnChunkMetaData parent):
         self.statistics = statistics
         self.parent = parent
-

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -24,6 +24,7 @@ from pyarrow.includes.libarrow cimport (CChunkedArray, CSchema, CStatus,
                                         CKeyValueMetadata,
                                         CRandomAccessFile, COutputStream,
                                         TimeUnit)
+from pyarrow.lib cimport _Weakrefable
 
 
 cdef extern from "parquet/api/schema.h" namespace "parquet::schema" nogil:
@@ -240,6 +241,7 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         int64_t distinct_count() const
         int64_t num_values() const
         bint HasMinMax()
+        c_bool Equals(const CStatistics&) const
         void Reset()
         c_string EncodeMin()
         c_string EncodeMax()
@@ -288,6 +290,7 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         shared_ptr[CStatistics] statistics() const
         ParquetCompression compression() const
         const vector[ParquetEncoding]& encodings() const
+        c_bool Equals(const CColumnChunkMetaData&) const
 
         int64_t has_dictionary_page() const
         int64_t dictionary_page_offset() const
@@ -297,12 +300,14 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         int64_t total_uncompressed_size() const
 
     cdef cppclass CRowGroupMetaData" parquet::RowGroupMetaData":
+        c_bool Equals(const CRowGroupMetaData&) const
         int num_columns()
         int64_t num_rows()
         int64_t total_byte_size()
         unique_ptr[CColumnChunkMetaData] ColumnChunk(int i) const
 
     cdef cppclass CFileMetaData" parquet::FileMetaData":
+        c_bool Equals(const CFileMetaData&) const
         uint32_t size()
         int num_columns()
         int64_t num_rows()
@@ -489,3 +494,47 @@ cdef shared_ptr[ArrowWriterProperties] _create_arrow_writer_properties(
     coerce_timestamps=*,
     allow_truncated_timestamps=*,
     writer_engine_version=*) except *
+
+cdef class ParquetSchema(_Weakrefable):
+    cdef:
+        FileMetaData parent  # the FileMetaData owning the SchemaDescriptor
+        const SchemaDescriptor* schema
+
+cdef class FileMetaData(_Weakrefable):
+    cdef:
+        shared_ptr[CFileMetaData] sp_metadata
+        CFileMetaData* _metadata
+        ParquetSchema _schema
+
+    cdef inline init(self, const shared_ptr[CFileMetaData]& metadata):
+        self.sp_metadata = metadata
+        self._metadata = metadata.get()
+
+cdef class RowGroupMetaData(_Weakrefable):
+    cdef:
+        int index  # for pickling support
+        unique_ptr[CRowGroupMetaData] up_metadata
+        CRowGroupMetaData* metadata
+        FileMetaData parent
+
+cdef class ColumnChunkMetaData(_Weakrefable):
+    cdef:
+        unique_ptr[CColumnChunkMetaData] up_metadata
+        CColumnChunkMetaData* metadata
+        RowGroupMetaData parent
+
+    cdef inline init(self, RowGroupMetaData parent, int i):
+        self.up_metadata = parent.metadata.ColumnChunk(i)
+        self.metadata = self.up_metadata.get()
+        self.parent = parent
+
+cdef class Statistics(_Weakrefable):
+    cdef:
+        shared_ptr[CStatistics] statistics
+        ColumnChunkMetaData parent
+
+    cdef inline init(self, const shared_ptr[CStatistics]& statistics,
+              ColumnChunkMetaData parent):
+        self.statistics = statistics
+        self.parent = parent
+

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -380,6 +380,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             "arrow::dataset::ParquetFactoryOptions":
         CPartitioningOrFactory partitioning
         c_string partition_base_dir
+        c_bool validate_column_chunk_paths
 
     cdef cppclass CParquetDatasetFactory \
             "arrow::dataset::ParquetDatasetFactory"(CDatasetFactory):

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -230,23 +230,6 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         const CFileSource& source() const
         const shared_ptr[CFileFormat]& format() const
 
-    cdef cppclass CRowGroupInfo "arrow::dataset::RowGroupInfo":
-        CRowGroupInfo()
-        CRowGroupInfo(int id)
-        int id() const
-        int64_t num_rows() const
-        int64_t total_byte_size() const
-        bint Equals(const CRowGroupInfo& other)
-        c_bool HasMetadata() const
-        shared_ptr[CFileMetaData] file_metadata() const
-        shared_ptr[CRowGroupMetaData] metadata() const
-        shared_ptr[CSchema] schema() const
-        CResult[int] column_index(c_string) const
-        CResult[shared_ptr[CDataType]] type(int) const
-
-        @staticmethod
-        vector[CRowGroupInfo] FromIdentifiers(vector[int])
-
     cdef cppclass CParquetFileWriteOptions \
             "arrow::dataset::ParquetFileWriteOptions"(CFileWriteOptions):
         shared_ptr[WriterProperties] writer_properties
@@ -254,7 +237,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CParquetFileFragment "arrow::dataset::ParquetFileFragment"(
             CFileFragment):
-        const vector[CRowGroupInfo]& row_groups() const
+        const vector[int]& row_groups() const
+        shared_ptr[CFileMetaData] metadata() const
         CResult[vector[shared_ptr[CFragment]]] SplitByRowGroup(
             shared_ptr[CExpression] predicate)
         CResult[shared_ptr[CFragment]] SubsetWithFilter "Subset"(
@@ -304,8 +288,8 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CResult[shared_ptr[CFileFragment]] MakeFragment(
             CFileSource source,
             shared_ptr[CExpression] partition_expression,
-            vector[CRowGroupInfo] row_groups,
-            shared_ptr[CSchema] physical_schema)
+            shared_ptr[CSchema] physical_schema,
+            vector[int] row_groups)
 
     cdef cppclass CIpcFileWriteOptions \
             "arrow::dataset::IpcFileWriteOptions"(CFileWriteOptions):

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -237,8 +237,12 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         int64_t num_rows() const
         int64_t total_byte_size() const
         bint Equals(const CRowGroupInfo& other)
-        c_bool HasStatistics() const
-        shared_ptr[CStructScalar] statistics() const
+        c_bool HasMetadata() const
+        shared_ptr[CFileMetaData] file_metadata() const
+        shared_ptr[CRowGroupMetaData] metadata() const
+        shared_ptr[CSchema] schema() const
+        CResult[int] column_index(c_string) const
+        CResult[shared_ptr[CDataType]] type(int) const
 
         @staticmethod
         vector[CRowGroupInfo] FromIdentifiers(vector[int])
@@ -250,8 +254,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
 
     cdef cppclass CParquetFileFragment "arrow::dataset::ParquetFileFragment"(
             CFileFragment):
-        const vector[CRowGroupInfo]* row_groups() const
-        CResult[int] GetNumRowGroups()
+        const vector[CRowGroupInfo]& row_groups() const
         CResult[vector[shared_ptr[CFragment]]] SplitByRowGroup(
             shared_ptr[CExpression] predicate)
         CResult[shared_ptr[CFragment]] SubsetWithFilter "Subset"(

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -1097,8 +1097,6 @@ def test_fragments_parquet_subset_ids(tempdir, open_logging_fs):
     with assert_opens([]):
         assert subfrag.num_row_groups == 2
         assert subfrag.row_groups == [0, 3]
-
-        # if the original fragment has statistics -> preserve them
         assert subfrag.row_groups[0].statistics is not None
 
     # check correct scan result of subset
@@ -1126,7 +1124,6 @@ def test_fragments_parquet_subset_filter(tempdir, open_logging_fs):
     subfrag = fragment.subset(ds.field("f1") >= 1)
     with assert_opens([]):
         assert subfrag.num_row_groups == 3
-        # ensure statistics are preserved in subset (need to be read for filter)
         assert len(subfrag.row_groups) == 3
         assert subfrag.row_groups[0].statistics is not None
 


### PR DESCRIPTION
ParquetFileFragment now constructs `Expression`s from its statistics lazily; the min/max expression for a column is materialized only when a predicate references that column.

Additional changes:
- ParquetFileFragment now simply stores a parquet::FileMetaData, which is loaded opportunistically anytime IO becomes unavoidable.
- In python, accessing any RowGroup or file-level properties of ParquetFileFragment will force load of metadata (so for example `ParquetFileFragment.num_row_groups` no longer yields -1 to indicate that metadata has not been loaded).
- RowGroupInfo has been removed from C++. A python-only replacement remains for compatibility but we might want to remove that as well.
- Reduced path manipulation in ParquetDatasetFactory, including avoidance of validation of ColumnChunk paths by default.
- ParquetScanTaskIterator has been removed
- Added FileMetadata::Subset, which returns a FIleMetaData wrapping only a subset of row groups.
- Added native equality comparison between FileMetaData, RowGroupMetaData, ColumnChunkMetaData, Statistics (ARROW-4970)