### PR TITLE
ARROW-10375 [Rust] Removed PrimitiveArrayOps

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -411,6 +411,23 @@ pub struct PrimitiveArray<T: ArrowPrimitiveType> {
     raw_values: RawPtrBox<T::Native>,
 }
 
+impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
+    /// Returns a `Buffer` holding all the values of this array.
+    ///
+    /// Note this doesn't take the offset of this array into account.
+    pub fn values(&self) -> Buffer {
+        self.data.buffers()[0].clone()
+    }
+
+    /// Returns the primitive value at index `i`.
+    ///
+    /// Note this doesn't do any bound checking, for performance reason.
+    pub fn value(&self, i: usize) -> T::Native {
+        let offset = i + self.offset();
+        unsafe { T::index(self.raw_values.get(), offset) }
+    }
+}
+
 impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
     fn as_any(&self) -> &Any {
         self
@@ -475,17 +492,6 @@ impl<T: ArrowNumericType> PrimitiveArray<T> {
     // Returns a new primitive array builder
     pub fn builder(capacity: usize) -> PrimitiveBuilder<T> {
         PrimitiveBuilder::<T>::new(capacity)
-    }
-}
-
-impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
-    pub fn values(&self) -> Buffer {
-        self.data.buffers()[0].clone()
-    }
-
-    pub fn value(&self, i: usize) -> T::Native {
-        let offset = i + self.offset();
-        unsafe { T::index(self.raw_values.get(), offset) }
     }
 }
 

--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -411,30 +411,6 @@ pub struct PrimitiveArray<T: ArrowPrimitiveType> {
     raw_values: RawPtrBox<T::Native>,
 }
 
-/// Common operations for primitive types, including numeric types and boolean type.
-pub trait PrimitiveArrayOps<T: ArrowPrimitiveType> {
-    /// Returns a `Buffer` holding all the values of this array.
-    ///
-    /// Note this doesn't take the offset of this array into account.
-    fn values(&self) -> Buffer;
-
-    /// Returns the primitive value at index `i`.
-    ///
-    /// Note this doesn't do any bound checking, for performance reason.
-    fn value(&self, i: usize) -> T::Native;
-}
-
-impl<T: ArrowPrimitiveType> PrimitiveArrayOps<T> for PrimitiveArray<T> {
-    fn values(&self) -> Buffer {
-        self.data.buffers()[0].clone()
-    }
-
-    fn value(&self, i: usize) -> T::Native {
-        let offset = i + self.offset();
-        unsafe { T::index(self.raw_values.get(), offset) }
-    }
-}
-
 impl<T: ArrowPrimitiveType> Array for PrimitiveArray<T> {
     fn as_any(&self) -> &Any {
         self
@@ -499,6 +475,17 @@ impl<T: ArrowNumericType> PrimitiveArray<T> {
     // Returns a new primitive array builder
     pub fn builder(capacity: usize) -> PrimitiveBuilder<T> {
         PrimitiveBuilder::<T>::new(capacity)
+    }
+}
+
+impl<T: ArrowPrimitiveType> PrimitiveArray<T> {
+    pub fn values(&self) -> Buffer {
+        self.data.buffers()[0].clone()
+    }
+
+    pub fn value(&self, i: usize) -> T::Native {
+        let offset = i + self.offset();
+        unsafe { T::index(self.raw_values.get(), offset) }
     }
 }
 

--- a/rust/arrow/src/array/iterator.rs
+++ b/rust/arrow/src/array/iterator.rs
@@ -17,7 +17,7 @@
 
 use crate::datatypes::ArrowPrimitiveType;
 
-use super::{Array, PrimitiveArray, PrimitiveArrayOps};
+use super::{Array, PrimitiveArray};
 
 /// an iterator that returns Some(T) or None, that can be used on any non-boolean PrimitiveArray
 #[derive(Debug)]

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -160,7 +160,6 @@ pub use self::array::GenericBinaryArray;
 pub use self::array::GenericListArray;
 pub use self::array::GenericStringArray;
 pub use self::array::OffsetSizeTrait;
-pub use self::array::PrimitiveArrayOps;
 pub use self::array::StringOffsetSizeTrait;
 
 // --------------------- Array Builder ---------------------

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -49,7 +49,7 @@
 //! ```
 //! extern crate arrow;
 //!
-//! use arrow::array::{Int16Array, PrimitiveArrayOps};
+//! use arrow::array::Int16Array;
 //!
 //! // Create a new builder with a capacity of 100
 //! let mut builder = Int16Array::builder(100);

--- a/rust/arrow/src/compute/kernels/boolean.rs
+++ b/rust/arrow/src/compute/kernels/boolean.rs
@@ -153,7 +153,6 @@ pub fn is_not_null(input: &ArrayRef) -> Result<BooleanArray> {
 mod tests {
     use super::*;
     use crate::array::Int32Array;
-    use crate::array::PrimitiveArrayOps;
 
     #[test]
     fn test_bool_array_and() {

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -17,7 +17,6 @@
 
 //! Defines miscellaneous array kernels.
 
-use crate::array::PrimitiveArrayOps;
 use crate::array::*;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -409,7 +409,7 @@ pub struct SortColumn {
 /// ```
 /// use std::convert::From;
 /// use std::sync::Arc;
-/// use arrow::array::{ArrayRef, StringArray, PrimitiveArray, PrimitiveArrayOps, as_primitive_array};
+/// use arrow::array::{ArrayRef, StringArray, PrimitiveArray, as_primitive_array};
 /// use arrow::compute::kernels::sort::{SortColumn, SortOptions, lexsort};
 /// use arrow::datatypes::Int64Type;
 ///

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -36,7 +36,7 @@
 //! can be obtained via [`is_null(index)`](array::Array::is_null). To downcast an [`Array`](array::Array) to a specific implementation, you can use
 //!
 //! ```rust
-//! use arrow::array::{Array, PrimitiveArrayOps, UInt32Array};
+//! use arrow::array::{Array, UInt32Array};
 //! let array = UInt32Array::from(vec![Some(1), None, Some(3)]);
 //! assert_eq!(array.len(), 3);
 //! assert_eq!(array.value(0), 1);
@@ -61,7 +61,7 @@
 //!
 //! ```rust
 //! # use std::sync::Arc;
-//! # use arrow::array::{UInt32Array, ArrayRef, PrimitiveArrayOps};
+//! # use arrow::array::{UInt32Array, ArrayRef};
 //! # let array = UInt32Array::from(vec![Some(1), None, Some(3)]);
 //! # let array: ArrayRef = Arc::new(array);
 //! let array = array.as_any().downcast_ref::<UInt32Array>().unwrap();

--- a/rust/arrow/src/util/display.rs
+++ b/rust/arrow/src/util/display.rs
@@ -20,7 +20,7 @@
 //! record batch pretty printing.
 
 use crate::array;
-use crate::array::{Array, PrimitiveArrayOps};
+use crate::array::Array;
 use crate::datatypes::{
     ArrowNativeType, ArrowPrimitiveType, DataType, Int16Type, Int32Type, Int64Type,
     Int8Type, TimeUnit, UInt16Type, UInt32Type, UInt64Type, UInt8Type,

--- a/rust/datafusion/examples/simple_udaf.rs
+++ b/rust/datafusion/examples/simple_udaf.rs
@@ -18,8 +18,8 @@
 /// In this example we will declare a single-type, single return type UDAF that computes the geometric mean.
 /// The geometric mean is described here: https://en.wikipedia.org/wiki/Geometric_mean
 use arrow::{
-    array::Float32Array, array::Float64Array, array::PrimitiveArrayOps,
-    datatypes::DataType, record_batch::RecordBatch,
+    array::Float32Array, array::Float64Array, datatypes::DataType,
+    record_batch::RecordBatch,
 };
 
 use datafusion::{error::Result, logical_plan::create_udaf, physical_plan::Accumulator};

--- a/rust/datafusion/examples/simple_udf.rs
+++ b/rust/datafusion/examples/simple_udf.rs
@@ -17,7 +17,7 @@
 
 use arrow::{
     array::{
-        Array, ArrayRef, Float32Array, Float64Array, Float64Builder, PrimitiveArrayOps,
+        Array, ArrayRef, Float32Array, Float64Array, Float64Builder,
     },
     datatypes::DataType,
     record_batch::RecordBatch,

--- a/rust/datafusion/examples/simple_udf.rs
+++ b/rust/datafusion/examples/simple_udf.rs
@@ -16,9 +16,7 @@
 // under the License.
 
 use arrow::{
-    array::{
-        Array, ArrayRef, Float32Array, Float64Array, Float64Builder,
-    },
+    array::{Array, ArrayRef, Float32Array, Float64Array, Float64Builder},
     datatypes::DataType,
     record_batch::RecordBatch,
     util::pretty,

--- a/rust/datafusion/src/datasource/parquet.rs
+++ b/rust/datafusion/src/datasource/parquet.rs
@@ -69,7 +69,6 @@ impl TableProvider for ParquetTable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow::array::PrimitiveArrayOps;
     use arrow::array::{
         BinaryArray, BooleanArray, Float32Array, Float64Array, Int32Array,
         TimestampNanosecondArray,

--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -534,9 +534,7 @@ mod tests {
         datasource::MemTable, logical_plan::create_udaf,
         physical_plan::expressions::AvgAccumulator,
     };
-    use arrow::array::{
-        ArrayRef, Float64Array, Int32Array, PrimitiveArrayOps, StringArray,
-    };
+    use arrow::array::{ArrayRef, Float64Array, Int32Array, StringArray};
     use arrow::compute::add;
     use std::fs::File;
     use std::thread::{self, JoinHandle};

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1703,8 +1703,8 @@ mod tests {
     use arrow::datatypes::*;
     use arrow::{
         array::{
-            LargeStringArray, PrimitiveArray, PrimitiveArrayOps, PrimitiveBuilder,
-            StringArray, StringDictionaryBuilder, Time64NanosecondArray,
+            LargeStringArray, PrimitiveArray, PrimitiveBuilder, StringArray,
+            StringDictionaryBuilder, Time64NanosecondArray,
         },
         util::display::array_value_to_string,
     };

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -362,10 +362,7 @@ mod tests {
     use super::*;
     use crate::{error::Result, physical_plan::expressions::lit, scalar::ScalarValue};
     use arrow::{
-        array::{
-            ArrayRef, FixedSizeListArray, Float64Array, Int32Array, PrimitiveArrayOps,
-            StringArray,
-        },
+        array::{ArrayRef, FixedSizeListArray, Float64Array, Int32Array, StringArray},
         datatypes::Field,
         record_batch::RecordBatch,
     };

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -28,7 +28,6 @@ use crate::error::{DataFusionError, Result};
 use crate::physical_plan::{Accumulator, AggregateExpr};
 use crate::physical_plan::{Distribution, ExecutionPlan, Partitioning, PhysicalExpr};
 
-use crate::arrow::array::PrimitiveArrayOps;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;

--- a/rust/datafusion/src/physical_plan/math_expressions.rs
+++ b/rust/datafusion/src/physical_plan/math_expressions.rs
@@ -19,9 +19,7 @@
 
 use std::sync::Arc;
 
-use arrow::array::{
-    make_array, Array, ArrayData, ArrayRef, Float32Array, Float64Array, PrimitiveArrayOps,
-};
+use arrow::array::{make_array, Array, ArrayData, ArrayRef, Float32Array, Float64Array};
 use arrow::buffer::Buffer;
 use arrow::datatypes::{DataType, ToByteSlice};
 

--- a/rust/datafusion/src/scalar.rs
+++ b/rust/datafusion/src/scalar.rs
@@ -28,10 +28,7 @@ use arrow::array::{
     Int16Builder, Int32Builder, Int64Builder, Int8Builder, ListBuilder, UInt16Builder,
     UInt32Builder, UInt64Builder, UInt8Builder,
 };
-use arrow::{
-    array::{ArrayRef, PrimitiveArrayOps},
-    datatypes::DataType,
-};
+use arrow::{array::ArrayRef, datatypes::DataType};
 
 use crate::error::{DataFusionError, Result};
 

--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -23,7 +23,6 @@ use crate::execution::context::ExecutionContext;
 use crate::logical_plan::{LogicalPlan, LogicalPlanBuilder};
 use crate::physical_plan::ExecutionPlan;
 use arrow::array;
-use arrow::array::PrimitiveArrayOps;
 use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::record_batch::RecordBatch;
 use std::env;

--- a/rust/datafusion/tests/user_defined_plan.rs
+++ b/rust/datafusion/tests/user_defined_plan.rs
@@ -61,7 +61,7 @@
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 
 use arrow::{
-    array::{Int64Array, PrimitiveArrayOps, StringArray},
+    array::{Int64Array, StringArray},
     datatypes::SchemaRef,
     error::ArrowError,
     record_batch::RecordBatch,


### PR DESCRIPTION
A simplification to the Arrow crate, since it is no longer needed, now that we no longer have specialization.