### PR TITLE
PARQUET-1935: [C++] Fix bug in WriteBatchSpaced

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2473,6 +2473,17 @@ TEST(ArrowReadWrite, ListOfStructOfList1) {
   CheckSimpleRoundtrip(table, 2);
 }
 
+TEST(ArrowReadWrite, ListWithNoValues) {
+  using ::arrow::Buffer;
+  using ::arrow::field;
+
+  auto type = list(field("item", ::arrow::int32(), /*nullable=*/false));
+  auto array = ::arrow::ArrayFromJSON(type, "[null, []]");
+  auto table = ::arrow::Table::Make(::arrow::schema({field("root", type)}), {array});
+  auto props_store_schema = ArrowWriterProperties::Builder().store_schema()->build();
+  CheckSimpleRoundtrip(table, 2, props_store_schema);
+}
+
 TEST(ArrowReadWrite, Map) {
   using ::arrow::field;
   using ::arrow::map;

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1187,6 +1187,10 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
     return values_to_write;
   }
 
+  // This method will always update the three output parameters,
+  // out_values_to_write, out_spaced_values_to_write and null_count.  Additionally
+  // it will update the validity bitmap if required (i.e. if at least one level
+  // of nullable structs directly precede the leaf node).
   void MaybeCalculateValidityBits(const int16_t* def_levels, int64_t batch_size,
                                   int64_t* out_values_to_write,
                                   int64_t* out_spaced_values_to_write,
@@ -1194,9 +1198,9 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
     if (bits_buffer_ == nullptr) {
       if (level_info_.def_level == 0) {
         // In this case def levels should be null and we only
-        // need to ouptut counts which will always be equal to
+        // need to output counts which will always be equal to
         // the batch size passed in (max def_level == 0 indicates
-        // there cannot be repeeated or null fields).
+        // there cannot be repeated or null fields).
         DCHECK_EQ(def_levels, nullptr);
         *out_values_to_write = batch_size;
         *out_spaced_values_to_write = batch_size;

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1193,6 +1193,11 @@ class TypedColumnWriterImpl : public ColumnWriterImpl, public TypedColumnWriter<
                                   int64_t* null_count) {
     if (bits_buffer_ == nullptr) {
       if (level_info_.def_level == 0) {
+        // In this case def levels should be null and we only
+        // need to ouptut counts which will always be equal to
+        // the batch size passed in (max def_level == 0 indicates
+        // there cannot be repeeated or null fields).
+        DCHECK_EQ(def_levels, nullptr);
         *out_values_to_write = batch_size;
         *out_spaced_values_to_write = batch_size;
         *null_count = 0;

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -26,6 +26,7 @@
 
 #include "parquet/column_reader.h"
 #include "parquet/column_writer.h"
+#include "parquet/file_writer.h"
 #include "parquet/metadata.h"
 #include "parquet/platform.h"
 #include "parquet/properties.h"
@@ -612,6 +613,35 @@ TYPED_TEST(TestPrimitiveWriter, DictionaryFallbackVersion1_0) {
 
 TYPED_TEST(TestPrimitiveWriter, DictionaryFallbackVersion2_0) {
   this->TestDictionaryFallbackEncoding(ParquetVersion::PARQUET_2_0);
+}
+
+TEST(TestWriter, NullValuesBuffer) {
+  std::shared_ptr<::arrow::io::BufferOutputStream> sink = CreateOutputStream();
+
+  const auto item_node = schema::PrimitiveNode::Make(
+      "item", Repetition::REQUIRED, LogicalType::Int(32, true), Type::INT32);
+  const auto list_node =
+      schema::GroupNode::Make("list", Repetition::REPEATED, {item_node});
+  const auto column_node = schema::GroupNode::Make(
+      "array_of_ints_column", Repetition::OPTIONAL, {list_node}, LogicalType::List());
+  const auto schema_node =
+      schema::GroupNode::Make("schema", Repetition::REQUIRED, {column_node});
+
+  auto file_writer = ParquetFileWriter::Open(
+      sink, std::dynamic_pointer_cast<schema::GroupNode>(schema_node));
+  auto group_writer = file_writer->AppendRowGroup();
+  auto column_writer = group_writer->NextColumn();
+  auto typed_writer = dynamic_cast<Int32Writer*>(column_writer);
+
+  const int64_t num_values = 1;
+  const int16_t def_levels[] = {0};
+  const int16_t rep_levels[] = {0};
+  const uint8_t valid_bits[] = {0};
+  const int64_t valid_bits_offset = 0;
+  const int32_t* values = nullptr;
+
+  typed_writer->WriteBatchSpaced(num_values, def_levels, rep_levels, valid_bits,
+                                 valid_bits_offset, values);
 }
 
 // PARQUET-719


### PR DESCRIPTION
The arrow code path doesn't call this method of not-null columns with no null parents, so this wasn't caught in arrow tests.

The only time we can pass through counts is if definition level happens to be zero.

Also fix some potential UBSan issues with adding offset to values.