### PR TITLE
ARROW-10381: [Rust] Generalized Ordering for inter-array comparisons

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -106,5 +106,9 @@ name = "length_kernel"
 harness = false
 
 [[bench]]
+name = "sort_kernel"
+harness = false
+
+[[bench]]
 name = "csv_writer"
 harness = false

--- a/rust/arrow/benches/sort_kernel.rs
+++ b/rust/arrow/benches/sort_kernel.rs
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+use rand::Rng;
+use std::sync::Arc;
+
+extern crate arrow;
+
+use arrow::array::*;
+use arrow::compute::kernels::sort::{lexsort, SortColumn};
+
+fn create_array(size: usize, with_nulls: bool) -> ArrayRef {
+    // use random numbers to avoid spurious compiler optimizations wrt to branching
+    let mut rng = rand::thread_rng();
+    let mut builder = Float32Builder::new(size);
+
+    for _ in 0..size {
+        if with_nulls && rng.gen::<f32>() > 0.5 {
+            builder.append_null().unwrap();
+        } else {
+            builder.append_value(rng.gen()).unwrap();
+        }
+    }
+    Arc::new(builder.finish())
+}
+
+fn bench_sort(arr_a: &ArrayRef, array_b: &ArrayRef) {
+    let columns = vec![
+        SortColumn {
+            values: arr_a.clone(),
+            options: None,
+        },
+        SortColumn {
+            values: array_b.clone(),
+            options: None,
+        },
+    ];
+
+    criterion::black_box(lexsort(&columns).unwrap());
+}
+
+fn add_benchmark(c: &mut Criterion) {
+    let arr_a = create_array(2u64.pow(10) as usize, false);
+    let arr_b = create_array(2u64.pow(10) as usize, false);
+
+    c.bench_function("sort 2^10", |b| b.iter(|| bench_sort(&arr_a, &arr_b)));
+
+    let arr_a = create_array(2u64.pow(12) as usize, false);
+    let arr_b = create_array(2u64.pow(12) as usize, false);
+
+    c.bench_function("sort 2^12", |b| b.iter(|| bench_sort(&arr_a, &arr_b)));
+
+    let arr_a = create_array(2u64.pow(10) as usize, true);
+    let arr_b = create_array(2u64.pow(10) as usize, true);
+
+    c.bench_function("sort nulls 2^10", |b| b.iter(|| bench_sort(&arr_a, &arr_b)));
+
+    let arr_a = create_array(2u64.pow(12) as usize, true);
+    let arr_b = create_array(2u64.pow(12) as usize, true);
+
+    c.bench_function("sort nulls 2^12", |b| b.iter(|| bench_sort(&arr_a, &arr_b)));
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/rust/arrow/src/array/mod.rs
+++ b/rust/arrow/src/array/mod.rs
@@ -249,9 +249,9 @@ pub use self::iterator::*;
 pub use self::equal::ArrayEqual;
 pub use self::equal::JsonEqual;
 
-// --------------------- Sortable Array ---------------------
+// --------------------- Array's values comparison ---------------------
 
-pub use self::ord::{as_ordarray, OrdArray};
+pub use self::ord::{build_compare, DynComparator};
 
 // --------------------- Array downcast helper functions ---------------------
 

--- a/rust/arrow/src/array/ord.rs
+++ b/rust/arrow/src/array/ord.rs
@@ -26,7 +26,7 @@ use crate::error::{ArrowError, Result};
 
 use num::Float;
 
-/// The public interface to compare values from arrays in a dynamically-typed fashion.
+/// Compare the values at two arbitrary indices in two arrays.
 pub type DynComparator<'a> = Box<dyn Fn(usize, usize) -> Ordering + 'a>;
 
 /// compares two floats, placing NaNs at last
@@ -212,10 +212,20 @@ pub fn build_compare<'a>(left: &'a Array, right: &'a Array) -> Result<DynCompara
                 (Int16, Int16) => compare_dict_string::<Int16Type>(left, right),
                 (Int32, Int32) => compare_dict_string::<Int32Type>(left, right),
                 (Int64, Int64) => compare_dict_string::<Int64Type>(left, right),
-                _ => todo!(),
+                (lhs, _) => {
+                    return Err(ArrowError::InvalidArgumentError(format!(
+                        "Dictionaries do not support keys of type {:?}",
+                        lhs
+                    )))
+                }
             }
         }
-        _ => todo!(),
+        (lhs, _) => {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "The data type type {:?} has no natural order",
+                lhs
+            )))
+        }
     })
 }
 

--- a/rust/arrow/src/array/ord.rs
+++ b/rust/arrow/src/array/ord.rs
@@ -15,297 +15,259 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//! Defines trait for array element comparison
+//! Contains functions and function factories to compare arrays.
 
 use std::cmp::Ordering;
 
 use crate::array::*;
+use crate::datatypes::TimeUnit;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 
-use TimeUnit::*;
+use num::Float;
 
-/// Trait for Arrays that can be sorted
-///
-/// Example:
-/// ```
-/// use std::cmp::Ordering;
-/// use arrow::array::*;
-/// use arrow::datatypes::*;
-///
-/// let arr: Box<dyn OrdArray> = Box::new(PrimitiveArray::<Int64Type>::from(vec![
-///     Some(-2),
-///     Some(89),
-///     Some(-64),
-///     Some(101),
-/// ]));
-///
-/// assert_eq!(arr.cmp_value(1, 2), Ordering::Greater);
-/// ```
-pub trait OrdArray {
-    /// Return ordering between array element at index i and j
-    fn cmp_value(&self, i: usize, j: usize) -> Ordering;
-}
+/// The public interface to compare values from arrays in a dynamically-typed fashion.
+pub type DynComparator<'a> = Box<dyn Fn(usize, usize) -> Ordering + 'a>;
 
-impl<T: OrdArray> OrdArray for Box<T> {
-    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
-        T::cmp_value(self, i, j)
+/// compares two floats, placing NaNs at last
+fn cmp_nans_last<T: Float>(a: &T, b: &T) -> Ordering {
+    match (a, b) {
+        (x, y) if x.is_nan() && y.is_nan() => Ordering::Equal,
+        (x, _) if x.is_nan() => Ordering::Greater,
+        (_, y) if y.is_nan() => Ordering::Less,
+        (_, _) => a.partial_cmp(b).unwrap(),
     }
 }
 
-impl<T: OrdArray> OrdArray for &T {
-    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
-        T::cmp_value(self, i, j)
-    }
-}
-
-impl<T: ArrowPrimitiveType> OrdArray for PrimitiveArray<T>
+fn compare_primitives<'a, T: ArrowPrimitiveType>(
+    left: &'a Array,
+    right: &'a Array,
+) -> DynComparator<'a>
 where
-    T::Native: std::cmp::Ord,
+    T::Native: Ord,
 {
-    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
-        self.value(i).cmp(&self.value(j))
-    }
+    let left = left.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+    let right = right.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+    Box::new(move |i, j| left.value(i).cmp(&right.value(j)))
 }
 
-impl OrdArray for StringArray {
-    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
-        self.value(i).cmp(self.value(j))
-    }
-}
-
-impl OrdArray for NullArray {
-    fn cmp_value(&self, _i: usize, _j: usize) -> Ordering {
-        Ordering::Equal
-    }
-}
-
-macro_rules! float_ord_cmp {
-    ($NAME: ident, $T: ty) => {
-        #[inline]
-        fn $NAME(a: $T, b: $T) -> Ordering {
-            if a < b {
-                return Ordering::Less;
-            }
-            if a > b {
-                return Ordering::Greater;
-            }
-
-            // convert to bits with canonical pattern for NaN
-            let a = if a.is_nan() {
-                <$T>::NAN.to_bits()
-            } else {
-                a.to_bits()
-            };
-            let b = if b.is_nan() {
-                <$T>::NAN.to_bits()
-            } else {
-                b.to_bits()
-            };
-
-            if a == b {
-                // Equal or both NaN
-                Ordering::Equal
-            } else if a < b {
-                // (-0.0, 0.0) or (!NaN, NaN)
-                Ordering::Less
-            } else {
-                // (0.0, -0.0) or (NaN, !NaN)
-                Ordering::Greater
-            }
-        }
-    };
-}
-
-float_ord_cmp!(cmp_f64, f64);
-float_ord_cmp!(cmp_f32, f32);
-
-#[repr(transparent)]
-struct Float64ArrayAsOrdArray<'a>(&'a Float64Array);
-#[repr(transparent)]
-struct Float32ArrayAsOrdArray<'a>(&'a Float32Array);
-
-impl OrdArray for Float64ArrayAsOrdArray<'_> {
-    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
-        let a: f64 = self.0.value(i);
-        let b: f64 = self.0.value(j);
-
-        cmp_f64(a, b)
-    }
-}
-
-impl OrdArray for Float32ArrayAsOrdArray<'_> {
-    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
-        let a: f32 = self.0.value(i);
-        let b: f32 = self.0.value(j);
-
-        cmp_f32(a, b)
-    }
-}
-
-fn float32_as_ord_array<'a>(array: &'a ArrayRef) -> Box<dyn OrdArray + 'a> {
-    let float_array: &Float32Array = as_primitive_array::<Float32Type>(array);
-    Box::new(Float32ArrayAsOrdArray(float_array))
-}
-
-fn float64_as_ord_array<'a>(array: &'a ArrayRef) -> Box<dyn OrdArray + 'a> {
-    let float_array: &Float64Array = as_primitive_array::<Float64Type>(array);
-    Box::new(Float64ArrayAsOrdArray(float_array))
-}
-
-struct StringDictionaryArrayAsOrdArray<'a, T: ArrowDictionaryKeyType> {
-    dict_array: &'a DictionaryArray<T>,
-    values: StringArray,
-    keys: PrimitiveArray<T>,
-}
-
-impl<T: ArrowDictionaryKeyType> OrdArray for StringDictionaryArrayAsOrdArray<'_, T> {
-    fn cmp_value(&self, i: usize, j: usize) -> Ordering {
-        let keys = &self.keys;
-        let dict = &self.values;
-
-        let key_a: T::Native = keys.value(i);
-        let key_b: T::Native = keys.value(j);
-
-        let str_a = dict.value(key_a.to_usize().unwrap());
-        let str_b = dict.value(key_b.to_usize().unwrap());
-
-        str_a.cmp(str_b)
-    }
-}
-
-fn string_dict_as_ord_array<'a, T: ArrowDictionaryKeyType>(
-    array: &'a ArrayRef,
-) -> Box<dyn OrdArray + 'a>
+fn compare_float<'a, T: ArrowPrimitiveType>(
+    left: &'a Array,
+    right: &'a Array,
+) -> DynComparator<'a>
 where
-    T::Native: std::cmp::Ord,
+    T::Native: Float,
 {
-    let dict_array = as_dictionary_array::<T>(array);
-    let keys = dict_array.keys_array();
+    let left = left.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+    let right = right.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+    Box::new(move |i, j| cmp_nans_last(&left.value(i), &right.value(j)))
+}
 
-    let values = &dict_array.values();
-    let values = StringArray::from(values.data());
+fn compare_string<'a, T>(left: &'a Array, right: &'a Array) -> DynComparator<'a>
+where
+    T: StringOffsetSizeTrait,
+{
+    let left = left
+        .as_any()
+        .downcast_ref::<GenericStringArray<T>>()
+        .unwrap();
+    let right = right
+        .as_any()
+        .downcast_ref::<GenericStringArray<T>>()
+        .unwrap();
+    Box::new(move |i, j| left.value(i).cmp(&right.value(j)))
+}
 
-    Box::new(StringDictionaryArrayAsOrdArray {
-        dict_array,
-        values,
-        keys,
+fn compare_dict_string<'a, T>(left: &'a Array, right: &'a Array) -> DynComparator<'a>
+where
+    T: ArrowDictionaryKeyType,
+{
+    let left = left.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
+    let right = right.as_any().downcast_ref::<DictionaryArray<T>>().unwrap();
+    let left_keys = left.keys_array();
+    let right_keys = right.keys_array();
+
+    let left_values = StringArray::from(left.values().data());
+    let right_values = StringArray::from(left.values().data());
+
+    Box::new(move |i: usize, j: usize| {
+        let key_left = left_keys.value(i).to_usize().unwrap();
+        let key_right = right_keys.value(j).to_usize().unwrap();
+        let left = left_values.value(key_left);
+        let right = right_values.value(key_right);
+        left.cmp(&right)
     })
 }
 
-/// Convert ArrayRef to OrdArray trait object
-pub fn as_ordarray<'a>(values: &'a ArrayRef) -> Result<Box<OrdArray + 'a>> {
-    match values.data_type() {
-        DataType::Boolean => Ok(Box::new(as_boolean_array(&values))),
-        DataType::Utf8 => Ok(Box::new(as_string_array(&values))),
-        DataType::Null => Ok(Box::new(as_null_array(&values))),
-        DataType::Int8 => Ok(Box::new(as_primitive_array::<Int8Type>(&values))),
-        DataType::Int16 => Ok(Box::new(as_primitive_array::<Int16Type>(&values))),
-        DataType::Int32 => Ok(Box::new(as_primitive_array::<Int32Type>(&values))),
-        DataType::Int64 => Ok(Box::new(as_primitive_array::<Int64Type>(&values))),
-        DataType::UInt8 => Ok(Box::new(as_primitive_array::<UInt8Type>(&values))),
-        DataType::UInt16 => Ok(Box::new(as_primitive_array::<UInt16Type>(&values))),
-        DataType::UInt32 => Ok(Box::new(as_primitive_array::<UInt32Type>(&values))),
-        DataType::UInt64 => Ok(Box::new(as_primitive_array::<UInt64Type>(&values))),
-        DataType::Date32(_) => Ok(Box::new(as_primitive_array::<Date32Type>(&values))),
-        DataType::Date64(_) => Ok(Box::new(as_primitive_array::<Date64Type>(&values))),
-        DataType::Time32(Second) => {
-            Ok(Box::new(as_primitive_array::<Time32SecondType>(&values)))
+/// returns a comparison function that compares two values at two different positions
+/// between the two arrays.
+/// The arrays' types must be equal.
+/// # Example
+/// ```
+/// use arrow::array::{build_compare, Int32Array};
+///
+/// # fn main() -> arrow::error::Result<()> {
+/// let array1 = Int32Array::from(vec![1, 2]);
+/// let array2 = Int32Array::from(vec![3, 4]);
+///
+/// let cmp = build_compare(&array1, &array2)?;
+///
+/// // 1 (index 0 of array1) is smaller than 4 (index 1 of array2)
+/// assert_eq!(std::cmp::Ordering::Less, (cmp)(0, 1));
+/// # Ok(())
+/// # }
+/// ```
+// This is a factory of comparisons.
+// The lifetime 'a enforces that we cannot use the closure beyond any of the array's lifetime.
+pub fn build_compare<'a>(left: &'a Array, right: &'a Array) -> Result<DynComparator<'a>> {
+    use DataType::*;
+    use IntervalUnit::*;
+    use TimeUnit::*;
+    Ok(match (left.data_type(), right.data_type()) {
+        (a, b) if a != b => {
+            return Err(ArrowError::InvalidArgumentError(
+                "Can't compare arrays of different types".to_string(),
+            ));
         }
-        DataType::Time32(Millisecond) => Ok(Box::new(as_primitive_array::<
-            Time32MillisecondType,
-        >(&values))),
-        DataType::Time64(Microsecond) => Ok(Box::new(as_primitive_array::<
-            Time64MicrosecondType,
-        >(&values))),
-        DataType::Time64(Nanosecond) => Ok(Box::new(as_primitive_array::<
-            Time64NanosecondType,
-        >(&values))),
-        DataType::Timestamp(Second, _) => {
-            Ok(Box::new(as_primitive_array::<TimestampSecondType>(&values)))
+        (Boolean, Boolean) => compare_primitives::<BooleanType>(left, right),
+        (UInt8, UInt8) => compare_primitives::<UInt8Type>(left, right),
+        (UInt16, UInt16) => compare_primitives::<UInt16Type>(left, right),
+        (UInt32, UInt32) => compare_primitives::<UInt32Type>(left, right),
+        (UInt64, UInt64) => compare_primitives::<UInt64Type>(left, right),
+        (Int8, Int8) => compare_primitives::<Int8Type>(left, right),
+        (Int16, Int16) => compare_primitives::<Int16Type>(left, right),
+        (Int32, Int32) => compare_primitives::<Int32Type>(left, right),
+        (Int64, Int64) => compare_primitives::<Int64Type>(left, right),
+        (Float32, Float32) => compare_float::<Float32Type>(left, right),
+        (Float64, Float64) => compare_float::<Float64Type>(left, right),
+        (Date32(_), Date32(_)) => compare_primitives::<Date32Type>(left, right),
+        (Date64(_), Date64(_)) => compare_primitives::<Date64Type>(left, right),
+        (Time32(Second), Time32(Second)) => {
+            compare_primitives::<Time32SecondType>(left, right)
         }
-        DataType::Timestamp(Millisecond, _) => Ok(Box::new(as_primitive_array::<
-            TimestampMillisecondType,
-        >(&values))),
-        DataType::Timestamp(Microsecond, _) => Ok(Box::new(as_primitive_array::<
-            TimestampMicrosecondType,
-        >(&values))),
-        DataType::Timestamp(Nanosecond, _) => Ok(Box::new(as_primitive_array::<
-            TimestampNanosecondType,
-        >(&values))),
-        DataType::Interval(IntervalUnit::YearMonth) => Ok(Box::new(
-            as_primitive_array::<IntervalYearMonthType>(&values),
-        )),
-        DataType::Interval(IntervalUnit::DayTime) => {
-            Ok(Box::new(as_primitive_array::<IntervalDayTimeType>(&values)))
+        (Time32(Millisecond), Time32(Millisecond)) => {
+            compare_primitives::<Time32MillisecondType>(left, right)
         }
-        DataType::Duration(TimeUnit::Second) => {
-            Ok(Box::new(as_primitive_array::<DurationSecondType>(&values)))
+        (Time64(Microsecond), Time64(Microsecond)) => {
+            compare_primitives::<Time64MicrosecondType>(left, right)
         }
-        DataType::Duration(TimeUnit::Millisecond) => Ok(Box::new(as_primitive_array::<
-            DurationMillisecondType,
-        >(&values))),
-        DataType::Duration(TimeUnit::Microsecond) => Ok(Box::new(as_primitive_array::<
-            DurationMicrosecondType,
-        >(&values))),
-        DataType::Duration(TimeUnit::Nanosecond) => Ok(Box::new(as_primitive_array::<
-            DurationNanosecondType,
-        >(&values))),
-        DataType::Float32 => Ok(float32_as_ord_array(&values)),
-        DataType::Float64 => Ok(float64_as_ord_array(&values)),
-        DataType::Dictionary(key_type, value_type)
-            if *value_type.as_ref() == DataType::Utf8 =>
-        {
-            match key_type.as_ref() {
-                DataType::Int8 => Ok(string_dict_as_ord_array::<Int8Type>(values)),
-                DataType::Int16 => Ok(string_dict_as_ord_array::<Int16Type>(values)),
-                DataType::Int32 => Ok(string_dict_as_ord_array::<Int32Type>(values)),
-                DataType::Int64 => Ok(string_dict_as_ord_array::<Int64Type>(values)),
-                DataType::UInt8 => Ok(string_dict_as_ord_array::<UInt8Type>(values)),
-                DataType::UInt16 => Ok(string_dict_as_ord_array::<UInt16Type>(values)),
-                DataType::UInt32 => Ok(string_dict_as_ord_array::<UInt32Type>(values)),
-                DataType::UInt64 => Ok(string_dict_as_ord_array::<UInt64Type>(values)),
-                t => Err(ArrowError::ComputeError(format!(
-                    "Lexical Sort not supported for dictionary key type {:?}",
-                    t
-                ))),
+        (Time64(Nanosecond), Time64(Nanosecond)) => {
+            compare_primitives::<Time64NanosecondType>(left, right)
+        }
+        (Timestamp(Second, _), Timestamp(Second, _)) => {
+            compare_primitives::<TimestampSecondType>(left, right)
+        }
+        (Timestamp(Millisecond, _), Timestamp(Millisecond, _)) => {
+            compare_primitives::<TimestampMillisecondType>(left, right)
+        }
+        (Timestamp(Microsecond, _), Timestamp(Microsecond, _)) => {
+            compare_primitives::<TimestampMicrosecondType>(left, right)
+        }
+        (Timestamp(Nanosecond, _), Timestamp(Nanosecond, _)) => {
+            compare_primitives::<TimestampNanosecondType>(left, right)
+        }
+        (Interval(YearMonth), Interval(YearMonth)) => {
+            compare_primitives::<IntervalYearMonthType>(left, right)
+        }
+        (Interval(DayTime), Interval(DayTime)) => {
+            compare_primitives::<IntervalDayTimeType>(left, right)
+        }
+        (Duration(Second), Duration(Second)) => {
+            compare_primitives::<DurationSecondType>(left, right)
+        }
+        (Duration(Millisecond), Duration(Millisecond)) => {
+            compare_primitives::<DurationMillisecondType>(left, right)
+        }
+        (Duration(Microsecond), Duration(Microsecond)) => {
+            compare_primitives::<DurationMicrosecondType>(left, right)
+        }
+        (Duration(Nanosecond), Duration(Nanosecond)) => {
+            compare_primitives::<DurationNanosecondType>(left, right)
+        }
+        (Utf8, Utf8) => compare_string::<i32>(left, right),
+        (LargeUtf8, LargeUtf8) => compare_string::<i64>(left, right),
+        (
+            Dictionary(key_type_lhs, value_type_lhs),
+            Dictionary(key_type_rhs, value_type_rhs),
+        ) => {
+            if value_type_lhs.as_ref() != &DataType::Utf8
+                || value_type_rhs.as_ref() != &DataType::Utf8
+            {
+                return Err(ArrowError::InvalidArgumentError(
+                    "Arrow still does not support comparisons of non-string dictionary arrays"
+                        .to_string(),
+                ));
+            }
+            match (key_type_lhs.as_ref(), key_type_rhs.as_ref()) {
+                (a, b) if a != b => {
+                    return Err(ArrowError::InvalidArgumentError(
+                        "Can't compare arrays of different types".to_string(),
+                    ));
+                }
+                (UInt8, UInt8) => compare_dict_string::<UInt8Type>(left, right),
+                (UInt16, UInt16) => compare_dict_string::<UInt16Type>(left, right),
+                (UInt32, UInt32) => compare_dict_string::<UInt32Type>(left, right),
+                (UInt64, UInt64) => compare_dict_string::<UInt64Type>(left, right),
+                (Int8, Int8) => compare_dict_string::<Int8Type>(left, right),
+                (Int16, Int16) => compare_dict_string::<Int16Type>(left, right),
+                (Int32, Int32) => compare_dict_string::<Int32Type>(left, right),
+                (Int64, Int64) => compare_dict_string::<Int64Type>(left, right),
+                _ => todo!(),
             }
         }
-        t => Err(ArrowError::ComputeError(format!(
-            "Lexical Sort not supported for data type {:?}",
-            t
-        ))),
-    }
+        _ => todo!(),
+    })
 }
 
 #[cfg(test)]
 pub mod tests {
-    use crate::array::{as_ordarray, ArrayRef, DictionaryArray, Float64Array};
-    use crate::datatypes::Int16Type;
+    use super::*;
+    use crate::array::{Float64Array, Int32Array};
+    use crate::error::Result;
     use std::cmp::Ordering;
     use std::iter::FromIterator;
-    use std::sync::Arc;
 
     #[test]
-    fn test_float64_as_ord_array() {
-        let array = Float64Array::from(vec![1.0, 2.0, 3.0, f64::NAN]);
-        let array_ref: ArrayRef = Arc::new(array);
+    fn test_i32() -> Result<()> {
+        let array = Int32Array::from(vec![1, 2]);
 
-        let ord_array = as_ordarray(&array_ref).unwrap();
+        let cmp = build_compare(&array, &array)?;
 
-        assert_eq!(Ordering::Less, ord_array.cmp_value(0, 1));
+        assert_eq!(Ordering::Less, (cmp)(0, 1));
+        Ok(())
     }
 
     #[test]
-    fn test_dict_as_ord_array() {
+    fn test_i32_i32() -> Result<()> {
+        let array1 = Int32Array::from(vec![1]);
+        let array2 = Int32Array::from(vec![2]);
+
+        let cmp = build_compare(&array1, &array2)?;
+
+        assert_eq!(Ordering::Less, (cmp)(0, 0));
+        Ok(())
+    }
+
+    #[test]
+    fn test_f64() -> Result<()> {
+        let array = Float64Array::from(vec![1.0, 2.0]);
+
+        let cmp = build_compare(&array, &array)?;
+
+        assert_eq!(Ordering::Less, (cmp)(0, 1));
+        Ok(())
+    }
+
+    #[test]
+    fn test_dict() -> Result<()> {
         let data = vec!["a", "b", "c", "a", "a", "c", "c"];
         let array = DictionaryArray::<Int16Type>::from_iter(data.into_iter());
-        let array_ref: ArrayRef = Arc::new(array);
 
-        let ord_array = as_ordarray(&array_ref).unwrap();
+        let cmp = build_compare(&array, &array)?;
 
-        assert_eq!(Ordering::Less, ord_array.cmp_value(0, 1));
-        assert_eq!(Ordering::Equal, ord_array.cmp_value(3, 4));
-        assert_eq!(Ordering::Greater, ord_array.cmp_value(2, 3));
+        assert_eq!(Ordering::Less, (cmp)(0, 1));
+        assert_eq!(Ordering::Equal, (cmp)(3, 4));
+        assert_eq!(Ordering::Greater, (cmp)(2, 3));
+        Ok(())
     }
 }

--- a/rust/arrow/src/array/ord.rs
+++ b/rust/arrow/src/array/ord.rs
@@ -259,6 +259,27 @@ pub mod tests {
     }
 
     #[test]
+    fn test_f64_nan() -> Result<()> {
+        let array = Float64Array::from(vec![1.0, f64::NAN]);
+
+        let cmp = build_compare(&array, &array)?;
+
+        assert_eq!(Ordering::Less, (cmp)(0, 1));
+        Ok(())
+    }
+
+    #[test]
+    fn test_f64_zeros() -> Result<()> {
+        let array = Float64Array::from(vec![-0.0, 0.0]);
+
+        let cmp = build_compare(&array, &array)?;
+
+        assert_eq!(Ordering::Equal, (cmp)(0, 1));
+        assert_eq!(Ordering::Equal, (cmp)(1, 0));
+        Ok(())
+    }
+
+    #[test]
     fn test_dict() -> Result<()> {
         let data = vec!["a", "b", "c", "a", "a", "c", "c"];
         let array = DictionaryArray::<Int16Type>::from_iter(data.into_iter());

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -41,6 +41,46 @@ pub fn sort(values: &ArrayRef, options: Option<SortOptions>) -> Result<ArrayRef>
     take(values, &indices, None)
 }
 
+fn partition_nan<T: ArrowPrimitiveType>(
+    array: &ArrayRef,
+    v: Vec<u32>,
+) -> (Vec<u32>, Vec<u32>) {
+    // partition by nan for float types
+    if T::DATA_TYPE == DataType::Float32 {
+        // T::Native has no `is_nan` and thus we need to downcast
+        let array = array
+            .as_any()
+            .downcast_ref::<Float32Array>()
+            .expect("Unable to downcast array");
+        let has_nan = v.iter().any(|index| array.value(*index as usize).is_nan());
+        if has_nan {
+            v.into_iter()
+                .partition(|index| !array.value(*index as usize).is_nan())
+        } else {
+            (v, vec![])
+        }
+    } else if T::DATA_TYPE == DataType::Float64 {
+        let array = array
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .expect("Unable to downcast array");
+        let has_nan = v.iter().any(|index| array.value(*index as usize).is_nan());
+        if has_nan {
+            v.into_iter()
+                .partition(|index| !array.value(*index as usize).is_nan())
+        } else {
+            (v, vec![])
+        }
+    } else {
+        unreachable!("Partition by nan is only applicable to float types")
+    }
+}
+
+fn partition_validity(array: &ArrayRef) -> (Vec<u32>, Vec<u32>) {
+    let indices = 0..(array.len().to_u32().unwrap());
+    indices.partition(|index| array.is_valid(*index as usize))
+}
+
 /// Sort elements from `ArrayRef` into an unsigned integer (`UInt32Array`) of indices.
 /// For floating point arrays any NaN values are considered to be greater than any other non-null value
 pub fn sort_to_indices(
@@ -48,103 +88,76 @@ pub fn sort_to_indices(
     options: Option<SortOptions>,
 ) -> Result<UInt32Array> {
     let options = options.unwrap_or_default();
-    let indices = 0..(values.len().to_u32().ok_or_else(|| {
-        ArrowError::ComputeError(
-            "Sorting currently only supports u32 indices".to_string(),
-        )
-    })?);
-    // partition indices into valid (`v`) and null (`n` indices
-    // for floating point types the valid indices are further partioned into non-NaN and NaN
-    let (v, n, nan): (Vec<u32>, Vec<u32>, Vec<u32>) =
-        if values.data_type() == &DataType::Float32 {
-            let array = values
-                .as_any()
-                .downcast_ref::<Float32Array>()
-                .expect("Unable to downcast array");
-            let (v, n): (Vec<u32>, Vec<u32>) =
-                indices.partition(|index| array.is_valid(*index as usize));
-            let has_nan = v.iter().any(|index| array.value(*index as usize).is_nan());
-            let (v, nan) = if has_nan {
-                v.into_iter()
-                    .partition(|index| !array.value(*index as usize).is_nan())
-            } else {
-                (v, vec![])
-            };
-            (v, n, nan)
-        } else if values.data_type() == &DataType::Float64 {
-            let array = values
-                .as_any()
-                .downcast_ref::<Float64Array>()
-                .expect("Unable to downcast array");
-            let (v, n): (Vec<u32>, Vec<u32>) =
-                indices.partition(|index| array.is_valid(*index as usize));
-            let has_nan = v.iter().any(|index| array.value(*index as usize).is_nan());
-            let (v, nan) = if has_nan {
-                v.into_iter()
-                    .partition(|index| !array.value(*index as usize).is_nan())
-            } else {
-                (v, vec![])
-            };
-            (v, n, nan)
-        } else {
-            let (v, n) = indices.partition(|index| values.is_valid(*index as usize));
-            (v, n, vec![])
-        };
+
+    let (v, n) = partition_validity(values);
+
     match values.data_type() {
-        DataType::Boolean => sort_primitive::<BooleanType>(values, v, n, nan, &options),
-        DataType::Int8 => sort_primitive::<Int8Type>(values, v, n, nan, &options),
-        DataType::Int16 => sort_primitive::<Int16Type>(values, v, n, nan, &options),
-        DataType::Int32 => sort_primitive::<Int32Type>(values, v, n, nan, &options),
-        DataType::Int64 => sort_primitive::<Int64Type>(values, v, n, nan, &options),
-        DataType::UInt8 => sort_primitive::<UInt8Type>(values, v, n, nan, &options),
-        DataType::UInt16 => sort_primitive::<UInt16Type>(values, v, n, nan, &options),
-        DataType::UInt32 => sort_primitive::<UInt32Type>(values, v, n, nan, &options),
-        DataType::UInt64 => sort_primitive::<UInt64Type>(values, v, n, nan, &options),
-        DataType::Float32 => sort_primitive::<Float32Type>(values, v, n, nan, &options),
-        DataType::Float64 => sort_primitive::<Float64Type>(values, v, n, nan, &options),
-        DataType::Date32(_) => sort_primitive::<Date32Type>(values, v, n, nan, &options),
-        DataType::Date64(_) => sort_primitive::<Date64Type>(values, v, n, nan, &options),
+        DataType::Boolean => {
+            sort_primitive::<BooleanType>(values, v, n, vec![], &options)
+        }
+        DataType::Int8 => sort_primitive::<Int8Type>(values, v, n, vec![], &options),
+        DataType::Int16 => sort_primitive::<Int16Type>(values, v, n, vec![], &options),
+        DataType::Int32 => sort_primitive::<Int32Type>(values, v, n, vec![], &options),
+        DataType::Int64 => sort_primitive::<Int64Type>(values, v, n, vec![], &options),
+        DataType::UInt8 => sort_primitive::<UInt8Type>(values, v, n, vec![], &options),
+        DataType::UInt16 => sort_primitive::<UInt16Type>(values, v, n, vec![], &options),
+        DataType::UInt32 => sort_primitive::<UInt32Type>(values, v, n, vec![], &options),
+        DataType::UInt64 => sort_primitive::<UInt64Type>(values, v, n, vec![], &options),
+        DataType::Float32 => {
+            let (v, nan) = partition_nan::<Float32Type>(values, v);
+            sort_primitive::<Float32Type>(values, v, n, nan, &options)
+        }
+        DataType::Float64 => {
+            let (v, nan) = partition_nan::<Float64Type>(values, v);
+            sort_primitive::<Float64Type>(values, v, n, nan, &options)
+        }
+        DataType::Date32(_) => {
+            sort_primitive::<Date32Type>(values, v, n, vec![], &options)
+        }
+        DataType::Date64(_) => {
+            sort_primitive::<Date64Type>(values, v, n, vec![], &options)
+        }
         DataType::Time32(Second) => {
-            sort_primitive::<Time32SecondType>(values, v, n, nan, &options)
+            sort_primitive::<Time32SecondType>(values, v, n, vec![], &options)
         }
         DataType::Time32(Millisecond) => {
-            sort_primitive::<Time32MillisecondType>(values, v, n, nan, &options)
+            sort_primitive::<Time32MillisecondType>(values, v, n, vec![], &options)
         }
         DataType::Time64(Microsecond) => {
-            sort_primitive::<Time64MicrosecondType>(values, v, n, nan, &options)
+            sort_primitive::<Time64MicrosecondType>(values, v, n, vec![], &options)
         }
         DataType::Time64(Nanosecond) => {
-            sort_primitive::<Time64NanosecondType>(values, v, n, nan, &options)
+            sort_primitive::<Time64NanosecondType>(values, v, n, vec![], &options)
         }
         DataType::Timestamp(Second, _) => {
-            sort_primitive::<TimestampSecondType>(values, v, n, nan, &options)
+            sort_primitive::<TimestampSecondType>(values, v, n, vec![], &options)
         }
         DataType::Timestamp(Millisecond, _) => {
-            sort_primitive::<TimestampMillisecondType>(values, v, n, nan, &options)
+            sort_primitive::<TimestampMillisecondType>(values, v, n, vec![], &options)
         }
         DataType::Timestamp(Microsecond, _) => {
-            sort_primitive::<TimestampMicrosecondType>(values, v, n, nan, &options)
+            sort_primitive::<TimestampMicrosecondType>(values, v, n, vec![], &options)
         }
         DataType::Timestamp(Nanosecond, _) => {
-            sort_primitive::<TimestampNanosecondType>(values, v, n, nan, &options)
+            sort_primitive::<TimestampNanosecondType>(values, v, n, vec![], &options)
         }
         DataType::Interval(IntervalUnit::YearMonth) => {
-            sort_primitive::<IntervalYearMonthType>(values, v, n, nan, &options)
+            sort_primitive::<IntervalYearMonthType>(values, v, n, vec![], &options)
         }
         DataType::Interval(IntervalUnit::DayTime) => {
-            sort_primitive::<IntervalDayTimeType>(values, v, n, nan, &options)
+            sort_primitive::<IntervalDayTimeType>(values, v, n, vec![], &options)
         }
         DataType::Duration(TimeUnit::Second) => {
-            sort_primitive::<DurationSecondType>(values, v, n, nan, &options)
+            sort_primitive::<DurationSecondType>(values, v, n, vec![], &options)
         }
         DataType::Duration(TimeUnit::Millisecond) => {
-            sort_primitive::<DurationMillisecondType>(values, v, n, nan, &options)
+            sort_primitive::<DurationMillisecondType>(values, v, n, vec![], &options)
         }
         DataType::Duration(TimeUnit::Microsecond) => {
-            sort_primitive::<DurationMicrosecondType>(values, v, n, nan, &options)
+            sort_primitive::<DurationMicrosecondType>(values, v, n, vec![], &options)
         }
         DataType::Duration(TimeUnit::Nanosecond) => {
-            sort_primitive::<DurationNanosecondType>(values, v, n, nan, &options)
+            sort_primitive::<DurationNanosecondType>(values, v, n, vec![], &options)
         }
         DataType::Utf8 => sort_string(values, v, n, &options),
         DataType::Dictionary(key_type, value_type)

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -41,6 +41,7 @@ pub fn sort(values: &ArrayRef, options: Option<SortOptions>) -> Result<ArrayRef>
     take(values, &indices, None)
 }
 
+// partition indices into non-NaN and NaN
 fn partition_nan<T: ArrowPrimitiveType>(
     array: &ArrayRef,
     v: Vec<u32>,
@@ -76,6 +77,7 @@ fn partition_nan<T: ArrowPrimitiveType>(
     }
 }
 
+// partition indices into valid and null indices
 fn partition_validity(array: &ArrayRef) -> (Vec<u32>, Vec<u32>) {
     let indices = 0..(array.len().to_u32().unwrap());
     indices.partition(|index| array.is_valid(*index as usize))


### PR DESCRIPTION
Currently, the code on `array/ord.rs` is centered around intra-array comparison. However, this does not allow to compare values from two different arrays, which is required on e.g. merge-sort operations.

This PR:
* simplifies the code around `sort` by splitting it in smaller functions for ease of understanding (first 2 commits)
* adds a benchmark to the `sort` kernel which I used to verify that there was no performance regression  (3rd commit)
* simplifies and generalizes the code around `ord` to support comparisons between two arrays (that may be the same), 4th commit
* adds some more tests to edge cases around float comparison (nan and zeros)

There was no performance change on my computer.