### PR TITLE
ARROW-10383: [Doc] fix typos

### DIFF
--- a/docs/source/developers/archery.rst
+++ b/docs/source/developers/archery.rst
@@ -27,7 +27,7 @@ Installation
 ------------
 
 Archery requires Python 3.5 or later. It is recommended to install archery in
-*editable* mode with the ``-e`` flag to automatically update the intallation
+*editable* mode with the ``-e`` flag to automatically update the installation
 when pulling the Arrow repository.
 
 .. code:: bash

--- a/docs/source/developers/contributing.rst
+++ b/docs/source/developers/contributing.rst
@@ -312,8 +312,8 @@ From time to time the community has discussions on specific types of features
 and improvements that they expect to support.  This section outlines decisions
 that have been made in this regard.
 
-Endianess
-+++++++++
+Endianness
+++++++++++
 
 The Arrow format allows setting endianness.  Due to the popularity of
 little endian architectures most of implementation assume little endian by

--- a/docs/source/developers/docker.rst
+++ b/docs/source/developers/docker.rst
@@ -123,7 +123,7 @@ can be useful to skip the build phases:
 
     # if the second run tries the build the image again and none of the files
     # referenced in the relevant dockerfile have changed, then it indicates a
-    # cache miss caused by the issue desribed above
+    # cache miss caused by the issue described above
     archery docker run conda-python
 
     # since the image is properly built with the first command, there is no

--- a/docs/source/java/vector.rst
+++ b/docs/source/java/vector.rst
@@ -120,7 +120,7 @@ Some points to note about the steps above:
 
 * For fixed width vectors (e.g. IntVector), we can set values at different indices in arbitrary orders.
   For variable width vectors (e.g. VarCharVector), however, we must set values in non-decreasing order of the
-  indices. Otherwise, the values after the set positiion will become invalid. For example, suppose we use the
+  indices. Otherwise, the values after the set position will become invalid. For example, suppose we use the
   following statements to populate a variable width vector:
 
 .. code-block:: Java

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -46,7 +46,7 @@ For those familiar with the existing :class:`pyarrow.parquet.ParquetDataset` for
 reading Parquet datasets: ``pyarrow.dataset``'s goal is similar but not specific
 to the Parquet format and not tied to Python: the same datasets API is exposed
 in the R bindings or Arrow. In addition ``pyarrow.dataset`` boasts improved
-perfomance and new features (e.g. filtering within files rather than only on
+performance and new features (e.g. filtering within files rather than only on
 partition keys).
 
 


### PR DESCRIPTION
This PR fixes typos in files under `docs` directory.