### PR TITLE
ARROW-10408: [Java] Bump Avro to 1.10.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -38,7 +38,7 @@
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.9.0</dep.fbs.version>
     <dep.flatc.version>1.9.0</dep.flatc.version>
-    <dep.avro.version>1.9.2</dep.avro.version>
+    <dep.avro.version>1.10.0</dep.avro.version>
     <arrow.vector.classifier />
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>


### PR DESCRIPTION
Small fixes, and removes the old Joda library for good: https://github.com/apache/avro/releases/tag/release-1.10.0