### PR TITLE
ARROW-10390: [Rust][Parquet] Ensure it is possible to create custom parquet writers

### DIFF
--- a/rust/parquet/src/file/writer.rs
+++ b/rust/parquet/src/file/writer.rs
@@ -40,7 +40,7 @@ use crate::file::{
 use crate::schema::types::{self, SchemaDescPtr, SchemaDescriptor, TypePtr};
 use crate::util::io::{FileSink, Position};
 
-// Exposed publically so client code can implement ParquetWriter
+// Exposed publically so client code can implement [`ParquetWriter`]
 pub use crate::util::io::TryClone;
 
 // ----------------------------------------------------------------------

--- a/rust/parquet/src/file/writer.rs
+++ b/rust/parquet/src/file/writer.rs
@@ -40,6 +40,9 @@ use crate::file::{
 use crate::schema::types::{self, SchemaDescPtr, SchemaDescriptor, TypePtr};
 use crate::util::io::{FileSink, Position};
 
+// Exposed publically so client code can implement ParquetWriter
+pub use crate::util::io::TryClone;
+
 // ----------------------------------------------------------------------
 // APIs for file & row group writers
 
@@ -114,7 +117,6 @@ pub trait RowGroupWriter {
 // ----------------------------------------------------------------------
 // Serialized impl for file & row group writers
 
-pub use crate::util::io::TryClone;
 pub trait ParquetWriter: Write + Seek + TryClone {}
 impl<T: Write + Seek + TryClone> ParquetWriter for T {}
 

--- a/rust/parquet/src/file/writer.rs
+++ b/rust/parquet/src/file/writer.rs
@@ -38,7 +38,7 @@ use crate::file::{
     statistics::to_thrift as statistics_to_thrift, FOOTER_SIZE, PARQUET_MAGIC,
 };
 use crate::schema::types::{self, SchemaDescPtr, SchemaDescriptor, TypePtr};
-use crate::util::io::{FileSink, Position, TryClone};
+use crate::util::io::{FileSink, Position};
 
 // ----------------------------------------------------------------------
 // APIs for file & row group writers
@@ -114,6 +114,7 @@ pub trait RowGroupWriter {
 // ----------------------------------------------------------------------
 // Serialized impl for file & row group writers
 
+pub use crate::util::io::TryClone;
 pub trait ParquetWriter: Write + Seek + TryClone {}
 impl<T: Write + Seek + TryClone> ParquetWriter for T {}
 

--- a/rust/parquet/tests/custom_writer.rs
+++ b/rust/parquet/tests/custom_writer.rs
@@ -1,0 +1,78 @@
+use std::{io::{SeekFrom, prelude::*}, rc::Rc, fs};
+use std::fs::File;
+
+use std::env;
+use parquet::{schema::types, basic::Repetition, file::properties::WriterProperties, file::writer::SerializedFileWriter};
+use parquet::util::io::TryClone;
+
+
+// Test creating some sort of custom writer to ensure the
+// appropriate traits are exposed
+struct CustomWriter {
+    file: File,
+}
+
+impl Write for CustomWriter{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.file.write(buf)
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.file.flush()
+    }
+
+}
+
+impl Seek for CustomWriter {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.file.seek(pos)
+    }
+
+}
+
+impl TryClone for CustomWriter {
+    fn try_clone(&self) -> std::io::Result<Self> {
+        use std::io::{Error, ErrorKind};
+        Err(Error::new(ErrorKind::Other, "Clone not supported"))
+    }
+
+}
+
+#[test]
+fn test_custom_writer() {
+    let schema = Rc::new(
+        types::Type::group_type_builder("schema")
+            .with_fields(&mut vec![Rc::new(
+                types::Type::primitive_type_builder("col1", types::Type::INT32)
+                    .with_repetition(Repetition::REQUIRED)
+                    .build()
+                    .unwrap(),
+            )])
+            .build()
+            .unwrap(),
+    );
+    let props = Rc::new(WriterProperties::builder().build());
+
+
+
+    let file = get_temp_file("test_custom_file_writer", &[]);
+    let writer = CustomWriter { file };
+
+    // test is that this file can be created
+    let mut file_writer =
+        SerializedFileWriter::new(writer, schema, props).unwrap();
+    file_writer.close().unwrap();
+}
+
+
+/// Returns file handle for a temp file in 'target' directory with a provided content
+pub fn get_temp_file(file_name: &str, content: &[u8]) -> fs::File {
+    // build tmp path to a file in "target/debug/testdata"
+    let mut path_buf = env::current_dir().unwrap();
+    path_buf.push("target");
+    path_buf.push("debug");
+    path_buf.push("testdata");
+    fs::create_dir_all(&path_buf).unwrap();
+    path_buf.push(file_name);
+
+    File::create(path_buf).unwrap()
+}

--- a/rust/parquet/tests/custom_writer.rs
+++ b/rust/parquet/tests/custom_writer.rs
@@ -1,3 +1,20 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 use std::fs::File;
 use std::{
     fs,


### PR DESCRIPTION
As of https://github.com/apache/arrow/pull/8300, it no longer appears possible to implement a `ParquetWriter` to provide a custom writer because it is not possible to implement the trait as `TryClone` is not publicly exported. 

This PR publically exports that trait and adds an end to end test demonstrating it is possible to create a custom writer

Here is what happens if you try and use `TryClone` on master

```
error[E0603]: module `util` is private
  --> delorean_parquet/src/writer.rs:11:5
   |
11 |     util::io::TryClone,
   |     ^^^^ private module
   |
note: the module `util` is defined here
  --> /Users/alamb/.cargo/git/checkouts/arrow-3a9cfebb6b7b2bdc/7155cd5/rust/parquet/src/lib.rs:39:1
   |
39 | mod util;
   | ^^^^^^^^^

```