### PR TITLE
ARROW-10399: [R] Fix performance regression from cpp11::r_string

### DIFF
--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -292,25 +292,30 @@ struct Converter_String : public Converter {
       // need to watch for nulls
       arrow::internal::BitmapReader null_reader(array->null_bitmap_data(),
                                                 array->offset(), n);
-      for (int i = 0; i < n; i++, null_reader.Next()) {
-        if (null_reader.IsSet()) {
-          SET_STRING_ELT(data, start + i, r_string_from_view(string_array->GetView(i)));
-        } else {
-          SET_STRING_ELT(data, start + i, NA_STRING);
+      cpp11::unwind_protect([&] {
+        for (int i = 0; i < n; i++, null_reader.Next()) {
+          if (null_reader.IsSet()) {
+            SET_STRING_ELT(data, start + i, r_string_from_view(string_array->GetView(i)));
+          } else {
+            SET_STRING_ELT(data, start + i, NA_STRING);
+          }
         }
-      }
-
+      });
     } else {
-      for (int i = 0; i < n; i++) {
-        SET_STRING_ELT(data, start + i, r_string_from_view(string_array->GetView(i)));
-      }
+      cpp11::unwind_protect([&] {
+        for (int i = 0; i < n; i++) {
+          SET_STRING_ELT(data, start + i, r_string_from_view(string_array->GetView(i)));
+        }
+      });
     }
 
     return Status::OK();
   }
 
   bool Parallel() const { return false; }
-  inline SEXP r_string_from_view(const arrow::util::string_view& view) const {
+
+ private:
+  static SEXP r_string_from_view(const arrow::util::string_view& view) {
     return Rf_mkCharLenCE(view.data(), view.size(), CE_UTF8);
   }
 };

--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -294,7 +294,7 @@ struct Converter_String : public Converter {
                                                 array->offset(), n);
       for (int i = 0; i < n; i++, null_reader.Next()) {
         if (null_reader.IsSet()) {
-          SET_STRING_ELT(data, start + i, cpp11::r_string(string_array->GetString(i)));
+          SET_STRING_ELT(data, start + i, r_string_from_view(string_array->GetView(i)));
         } else {
           SET_STRING_ELT(data, start + i, NA_STRING);
         }
@@ -302,7 +302,7 @@ struct Converter_String : public Converter {
 
     } else {
       for (int i = 0; i < n; i++) {
-        SET_STRING_ELT(data, start + i, cpp11::r_string(string_array->GetString(i)));
+        SET_STRING_ELT(data, start + i, r_string_from_view(string_array->GetView(i)));
       }
     }
 
@@ -310,6 +310,9 @@ struct Converter_String : public Converter {
   }
 
   bool Parallel() const { return false; }
+  inline SEXP r_string_from_view(const arrow::util::string_view& view) const {
+    return Rf_mkCharLenCE(view.data(), view.size(), CE_UTF8);
+  }
 };
 
 class Converter_Boolean : public Converter {


### PR DESCRIPTION
@bkietz and I identified the performance regression I observed today, and by more-or-less reverting https://github.com/apache/arrow/commit/55defbf7a14896dc1a166f04f62f576179b4a1d5#diff-090c5cff4eadd62a121e85babd186c9838055d2757670971204817eb2d96211aR297-R313 (Ben suggested renaming the function and calling GetView instead of GetString), the performance regression went away.

I haven't investigated why the `cpp11::r_string` way is so significantly slower but it's worth exploring. We should also make sure we aren't inefficiently calling that elsewhere.

cc @kszucs 