### PR TITLE
ARROW-10422: [Rust] Removed unused trait BinaryArrayBuilder

### DIFF
--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -1270,14 +1270,6 @@ pub struct FixedSizeBinaryBuilder {
     builder: FixedSizeListBuilder<UInt8Builder>,
 }
 
-pub trait BinaryArrayBuilder: ArrayBuilder {}
-
-impl BinaryArrayBuilder for BinaryBuilder {}
-impl BinaryArrayBuilder for StringBuilder {}
-impl BinaryArrayBuilder for LargeStringBuilder {}
-impl BinaryArrayBuilder for LargeBinaryBuilder {}
-impl BinaryArrayBuilder for FixedSizeBinaryBuilder {}
-
 impl ArrayBuilder for BinaryBuilder {
     /// Returns the builder as a non-mutable `Any` reference.
     fn as_any(&self) -> &Any {


### PR DESCRIPTION
I do not know why the trait exists, but it does not seem to be useful, as it contains no implementations on it.