### PR TITLE
ARROW-10428: [FlightRPC][Java] Add support for HTTP cookies

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
@@ -36,6 +36,10 @@ import org.slf4j.LoggerFactory;
  * A client middleware for receiving and sending cookie information.
  * Note that this class will not persist permanent cookies beyond the lifetime
  * of this session.
+ *
+ * This middleware will automatically remove cookies that have expired.
+ * <b>Note</b>: Negative max-age values currently do not get marked as expired due to
+ * a JDK issue. Use max-age=0 to explicitly remove an existing cookie.
  */
 public class ClientCookieMiddleware implements FlightClientMiddleware {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClientCookieMiddleware.class);

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.client;
+
+import java.net.HttpCookie;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.CallInfo;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.FlightClientMiddleware;
+import org.apache.arrow.util.VisibleForTesting;
+
+/**
+ * A client middleware for receiving and sending cookie information.
+ * Note that this class will not persist permanent cookies beyond the lifetime
+ * of this session.
+ */
+public class ClientCookieMiddleware implements FlightClientMiddleware {
+  private static final String SET_COOKIE_HEADER = "Set-Cookie";
+  private static final String SET_COOKIE2_HEADER = "Set-Cookie2";
+  private static final String COOKIE_HEADER = "Cookie";
+
+  // Use a map to track the most recent version of a cookie from the server.
+  // Note that cookie names are case-sensitive (but header names aren't).
+  private Map<String, HttpCookie> cookies = new HashMap<>();
+
+  public ClientCookieMiddleware() {
+  }
+
+  /**
+   * Factory used within FlightClient.
+   */
+  public static class Factory implements FlightClientMiddleware.Factory {
+    @Override
+    public ClientCookieMiddleware onCallStarted(CallInfo info) {
+      return new ClientCookieMiddleware();
+    }
+  }
+
+  @Override
+  public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
+    final String cookieValue = calculateCookieString();
+    if (!cookieValue.isEmpty()) {
+      outgoingHeaders.insert(COOKIE_HEADER, cookieValue);
+    }
+  }
+
+  @Override
+  public void onHeadersReceived(CallHeaders incomingHeaders) {
+    // Note: A cookie defined once will continue to be used in all subsequent
+    // requests on the client instance. The server can send the same cookie again
+    // with a different value and the client will use the new value in future requests.
+    // The server can also update a cookie to have an Expiry in the past or negative age
+    // to signal that the client should stop using the cookie immediately.
+    final Consumer<String> handleSetCookieHeader = (headerValue) -> {
+      final List<HttpCookie> parsedCookies = HttpCookie.parse(headerValue);
+      parsedCookies.forEach(parsedCookie -> cookies.put(parsedCookie.getName(), parsedCookie));
+    };
+    incomingHeaders.getAll(SET_COOKIE_HEADER).forEach(handleSetCookieHeader);
+    incomingHeaders.getAll(SET_COOKIE2_HEADER).forEach(handleSetCookieHeader);
+  }
+
+  @Override
+  public void onCallCompleted(CallStatus status) {
+
+  }
+
+  @VisibleForTesting
+  String calculateCookieString() {
+    // Discard expired cookies.
+    cookies.entrySet().removeIf(cookieEntry -> cookieEntry.getValue().hasExpired());
+
+    // Cookie header value format:
+    // <cookie-name1>=<cookie-value1>[; <cookie-name2>=<cookie-value2; ...]
+    return cookies.entrySet().stream()
+        .map(cookie -> cookie.getValue().toString())
+        .collect(Collectors.joining("; "));
+  }
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
@@ -19,6 +19,7 @@ package org.apache.arrow.flight.client;
 
 import java.net.HttpCookie;
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
@@ -72,7 +73,14 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
       newCookieHeaderValues.forEach(headerValue -> {
         try {
           final List<HttpCookie> parsedCookies = HttpCookie.parse(headerValue);
-          parsedCookies.forEach(parsedCookie -> cookies.put(parsedCookie.getName(), parsedCookie));
+          parsedCookies.forEach(parsedCookie -> {
+            final String cookieNameLc = parsedCookie.getName().toLowerCase(Locale.ENGLISH);
+            if (parsedCookie.hasExpired()) {
+              cookies.remove(cookieNameLc);
+            } else {
+              cookies.put(parsedCookie.getName().toLowerCase(Locale.ENGLISH), parsedCookie);
+            }
+          });
         } catch (IllegalArgumentException ex) {
           LOGGER.warn("Skipping incorrectly formatted Set-Cookie header with value '{}'.", headerValue);
         }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
@@ -48,13 +48,19 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
    * Factory used within FlightClient.
    */
   public static class Factory implements FlightClientMiddleware.Factory {
+    public ClientCookieMiddleware getClientCookieMiddleware() {
+      return clientCookieMiddleware;
+    }
+
+    private ClientCookieMiddleware clientCookieMiddleware;
     // Use a map to track the most recent version of a cookie from the server.
     // Note that cookie names are case-sensitive (but header names aren't).
     private ConcurrentMap<String, HttpCookie> cookies = new ConcurrentHashMap<>();
 
     @Override
     public ClientCookieMiddleware onCallStarted(CallInfo info) {
-      return new ClientCookieMiddleware(this);
+      this.clientCookieMiddleware = new ClientCookieMiddleware(this);
+      return this.clientCookieMiddleware;
     }
   }
 
@@ -79,9 +85,7 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
     };
     final Iterable<String> setCookieHeaders = incomingHeaders.getAll(SET_COOKIE_HEADER);
     if (setCookieHeaders != null) {
-      for (String cookieHeader : setCookieHeaders) {
-        handleSetCookieHeader.accept(cookieHeader);
-      }
+      setCookieHeaders.forEach(handleSetCookieHeader);
     }
   }
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientCookieMiddleware.java
@@ -40,7 +40,8 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
   private static final String COOKIE_HEADER = "Cookie";
   private final Factory factory;
 
-  public ClientCookieMiddleware(Factory factory) {
+  @VisibleForTesting
+  ClientCookieMiddleware(Factory factory) {
     this.factory = factory;
   }
 
@@ -48,19 +49,13 @@ public class ClientCookieMiddleware implements FlightClientMiddleware {
    * Factory used within FlightClient.
    */
   public static class Factory implements FlightClientMiddleware.Factory {
-    public ClientCookieMiddleware getClientCookieMiddleware() {
-      return clientCookieMiddleware;
-    }
-
-    private ClientCookieMiddleware clientCookieMiddleware;
     // Use a map to track the most recent version of a cookie from the server.
     // Note that cookie names are case-sensitive (but header names aren't).
     private ConcurrentMap<String, HttpCookie> cookies = new ConcurrentHashMap<>();
 
     @Override
     public ClientCookieMiddleware onCallStarted(CallInfo info) {
-      this.clientCookieMiddleware = new ClientCookieMiddleware(this);
-      return this.clientCookieMiddleware;
+      return new ClientCookieMiddleware(this);
     }
   }
 

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
@@ -132,8 +132,10 @@ public class TestCookieHandling {
     // Note: using max-age changes cookie version from 0->1, which quotes values.
     Assert.assertEquals("k=\"v\"", cookieMiddleware.getValidCookiesAsString());
 
+    // Note: The JDK treats Max-Age < 0 as not expired and treats 0 as expired.
+    // This violates the RFC, which states that less than zero and zero should both be expired.
     headersToSend = new ErrorFlightMetadata();
-    headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=-2");
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=0");
     cookieMiddleware = testFactory.onCallStarted(new CallInfo(FlightMethod.DO_ACTION));
     cookieMiddleware.onHeadersReceived(headersToSend);
 

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
@@ -17,10 +17,26 @@
 
 package org.apache.arrow.flight.client;
 
+import java.io.IOException;
+
 import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.CallInfo;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.Criteria;
 import org.apache.arrow.flight.ErrorFlightMetadata;
+import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightInfo;
+import org.apache.arrow.flight.FlightProducer;
+import org.apache.arrow.flight.FlightServer;
+import org.apache.arrow.flight.FlightServerMiddleware;
+import org.apache.arrow.flight.FlightTestUtil;
+import org.apache.arrow.flight.NoOpFlightProducer;
+import org.apache.arrow.flight.RequestContext;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -29,13 +45,23 @@ import org.junit.Test;
  */
 public class TestCookieHandling {
   private static final String SET_COOKIE_HEADER = "Set-Cookie";
-  private static final String SET_COOKIE2_HEADER = "Set-Cookie2";
+  private static final String COOKIE_HEADER = "Cookie";
+  private BufferAllocator allocator;
+  private FlightServer server;
+  private FlightClient client;
 
-  private ClientCookieMiddleware cookieMiddleware = new ClientCookieMiddleware();
+  private ClientCookieMiddleware.Factory factory = new ClientCookieMiddleware.Factory();
+  private ClientCookieMiddleware cookieMiddleware = new ClientCookieMiddleware(factory);
+
+  @Before
+  public void setup() throws Exception {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+    startServerAndClient();
+  }
 
   @After
   public void cleanup() {
-    cookieMiddleware = new ClientCookieMiddleware();
+    cookieMiddleware = new ClientCookieMiddleware(factory);
   }
 
   @Test
@@ -43,7 +69,7 @@ public class TestCookieHandling {
     CallHeaders headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
   }
 
   @Test
@@ -51,15 +77,15 @@ public class TestCookieHandling {
     CallHeaders headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
   }
 
   @Test
@@ -68,11 +94,11 @@ public class TestCookieHandling {
     headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=2");
     cookieMiddleware.onHeadersReceived(headersToSend);
     // Note: using max-age changes cookie version from 0->1, which quotes values.
-    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.getValidCookiesAsString());
 
     try {
       Thread.sleep(5000);
@@ -80,7 +106,7 @@ public class TestCookieHandling {
     }
 
     // Verify that the k cookie was discarded because it expired.
-    Assert.assertTrue(cookieMiddleware.calculateCookieString().isEmpty());
+    Assert.assertTrue(cookieMiddleware.getValidCookiesAsString().isEmpty());
   }
 
   @Test
@@ -89,14 +115,14 @@ public class TestCookieHandling {
     headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=2");
     cookieMiddleware.onHeadersReceived(headersToSend);
     // Note: using max-age changes cookie version from 0->1, which quotes values.
-    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=-2");
     cookieMiddleware.onHeadersReceived(headersToSend);
 
     // Verify that the k cookie was discarded because the server told the client it is expired.
-    Assert.assertTrue(cookieMiddleware.calculateCookieString().isEmpty());
+    Assert.assertTrue(cookieMiddleware.getValidCookiesAsString().isEmpty());
   }
 
   @Ignore
@@ -106,7 +132,7 @@ public class TestCookieHandling {
     headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=2");
     cookieMiddleware.onHeadersReceived(headersToSend);
     // Note: using max-age changes cookie version from 0->1, which quotes values.
-    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
 
@@ -116,7 +142,7 @@ public class TestCookieHandling {
     cookieMiddleware.onHeadersReceived(headersToSend);
 
     // Verify that the k cookie was discarded because the server told the client it is expired.
-    Assert.assertTrue(cookieMiddleware.calculateCookieString().isEmpty());
+    Assert.assertTrue(cookieMiddleware.getValidCookiesAsString().isEmpty());
   }
 
   @Test
@@ -124,12 +150,12 @@ public class TestCookieHandling {
     CallHeaders headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
 
     headersToSend = new ErrorFlightMetadata();
     headersToSend.insert(SET_COOKIE_HEADER, "k=v2");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("k=v2", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("k=v2", cookieMiddleware.getValidCookiesAsString());
   }
 
   @Test
@@ -138,27 +164,75 @@ public class TestCookieHandling {
     headersToSend.insert(SET_COOKIE_HEADER, "firstKey=firstVal");
     headersToSend.insert(SET_COOKIE_HEADER, "secondKey=secondVal");
     cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("firstKey=firstVal; secondKey=secondVal", cookieMiddleware.calculateCookieString());
+    Assert.assertEquals("firstKey=firstVal; secondKey=secondVal", cookieMiddleware.getValidCookiesAsString());
   }
 
   @Test
-  public void basicCookiesWithSetCookie2() {
-    CallHeaders headersToSend = new ErrorFlightMetadata();
-    headersToSend.insert(SET_COOKIE2_HEADER, "firstKey=firstVal");
-    cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("firstKey=firstVal", cookieMiddleware.calculateCookieString());
+  public void cookieStaysAfterMultipleRequestsEndToEnd() {
+    client.handshake();
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
+    client.listFlights(Criteria.ALL);
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
+    client.listFlights(Criteria.ALL);
+    Assert.assertEquals("k=v", cookieMiddleware.getValidCookiesAsString());
   }
 
-  @Ignore
-  @Test
-  public void multipleCookiesWithSetCookie2() {
-    // There seems to be a JDK bug with HttpCookie.parse() with multiple cookies
-    // in a Set-Cookie2 header. This is odd, because that method explictly returns a list
-    // of cookies because of Set-Cookie2.
-    // Set-Cookie2 itself is deprecated.
-    CallHeaders headersToSend = new ErrorFlightMetadata();
-    headersToSend.insert(SET_COOKIE2_HEADER, "firstKey=firstVal, secondKey=secondVal");
-    cookieMiddleware.onHeadersReceived(headersToSend);
-    Assert.assertEquals("firstKey=firstVal; secondKey=secondVal", cookieMiddleware.calculateCookieString());
+  /**
+   * A server middleware component that injects SET_COOKIE_HEADER into the outgoing headers.
+   */
+  static class SetCookieHeaderInjector implements FlightServerMiddleware {
+    private final Factory factory;
+
+    public SetCookieHeaderInjector(Factory factory) {
+      this.factory = factory;
+    }
+
+    @Override
+    public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
+      if (!factory.receivedCookieHeader) {
+        outgoingHeaders.insert(SET_COOKIE_HEADER, "k=v");
+      }
+    }
+
+    @Override
+    public void onCallCompleted(CallStatus status) {
+
+    }
+
+    @Override
+    public void onCallErrored(Throwable err) {
+
+    }
+
+    static class Factory implements FlightServerMiddleware.Factory<SetCookieHeaderInjector> {
+      private boolean receivedCookieHeader = false;
+
+      @Override
+      public SetCookieHeaderInjector onCallStarted(CallInfo info, CallHeaders incomingHeaders,
+                                                   RequestContext context) {
+        if (null != incomingHeaders.get(COOKIE_HEADER)) {
+          receivedCookieHeader = true;
+        }
+        return new SetCookieHeaderInjector(this);
+      }
+    }
+  }
+
+  private void startServerAndClient() throws IOException {
+    final FlightProducer flightProducer = new NoOpFlightProducer() {
+      public void listFlights(CallContext context, Criteria criteria,
+                              StreamListener<FlightInfo> listener) {
+        listener.onCompleted();
+      }
+    };
+
+    this.server = FlightTestUtil.getStartedServer((location) -> FlightServer
+            .builder(allocator, location, flightProducer)
+            .middleware(FlightServerMiddleware.Key.of("test"), new SetCookieHeaderInjector.Factory())
+            .build());
+
+    this.client = FlightClient.builder(allocator, server.getLocation())
+            .intercept(factory)
+            .build();
   }
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestCookieHandling.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.client;
+
+import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.ErrorFlightMetadata;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Tests for correct handling of cookies from the FlightClient using {@link ClientCookieMiddleware}.
+ */
+public class TestCookieHandling {
+  private static final String SET_COOKIE_HEADER = "Set-Cookie";
+  private static final String SET_COOKIE2_HEADER = "Set-Cookie2";
+
+  private ClientCookieMiddleware cookieMiddleware = new ClientCookieMiddleware();
+
+  @After
+  public void cleanup() {
+    cookieMiddleware = new ClientCookieMiddleware();
+  }
+
+  @Test
+  public void basicCookie() {
+    CallHeaders headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+  }
+
+  @Test
+  public void cookieStaysAfterMultipleRequests() {
+    CallHeaders headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+
+    headersToSend = new ErrorFlightMetadata();
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+
+    headersToSend = new ErrorFlightMetadata();
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+  }
+
+  @Test
+  public void cookieAutoExpires() {
+    CallHeaders headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=2");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    // Note: using max-age changes cookie version from 0->1, which quotes values.
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+
+    headersToSend = new ErrorFlightMetadata();
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+
+    try {
+      Thread.sleep(5000);
+    } catch (InterruptedException ignored) {
+    }
+
+    // Verify that the k cookie was discarded because it expired.
+    Assert.assertTrue(cookieMiddleware.calculateCookieString().isEmpty());
+  }
+
+  @Test
+  public void cookieExplicitlyExpires() {
+    CallHeaders headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=2");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    // Note: using max-age changes cookie version from 0->1, which quotes values.
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+
+    headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=-2");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+
+    // Verify that the k cookie was discarded because the server told the client it is expired.
+    Assert.assertTrue(cookieMiddleware.calculateCookieString().isEmpty());
+  }
+
+  @Ignore
+  @Test
+  public void cookieExplicitlyExpiresWithMaxAgeMinusOne() {
+    CallHeaders headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=2");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    // Note: using max-age changes cookie version from 0->1, which quotes values.
+    Assert.assertEquals("k=\"v\"", cookieMiddleware.calculateCookieString());
+
+    headersToSend = new ErrorFlightMetadata();
+
+    // The Java HttpCookie class has a bug where it uses a -1 maxAge to indicate
+    // a persistent cookie, when the RFC spec says this should mean the cookie expires immediately.
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v; Max-Age=-1");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+
+    // Verify that the k cookie was discarded because the server told the client it is expired.
+    Assert.assertTrue(cookieMiddleware.calculateCookieString().isEmpty());
+  }
+
+  @Test
+  public void changeCookieValue() {
+    CallHeaders headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("k=v", cookieMiddleware.calculateCookieString());
+
+    headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE_HEADER, "k=v2");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("k=v2", cookieMiddleware.calculateCookieString());
+  }
+
+  @Test
+  public void multipleCookiesWithSetCookie() {
+    CallHeaders headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE_HEADER, "firstKey=firstVal");
+    headersToSend.insert(SET_COOKIE_HEADER, "secondKey=secondVal");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("firstKey=firstVal; secondKey=secondVal", cookieMiddleware.calculateCookieString());
+  }
+
+  @Test
+  public void basicCookiesWithSetCookie2() {
+    CallHeaders headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE2_HEADER, "firstKey=firstVal");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("firstKey=firstVal", cookieMiddleware.calculateCookieString());
+  }
+
+  @Ignore
+  @Test
+  public void multipleCookiesWithSetCookie2() {
+    // There seems to be a JDK bug with HttpCookie.parse() with multiple cookies
+    // in a Set-Cookie2 header. This is odd, because that method explictly returns a list
+    // of cookies because of Set-Cookie2.
+    // Set-Cookie2 itself is deprecated.
+    CallHeaders headersToSend = new ErrorFlightMetadata();
+    headersToSend.insert(SET_COOKIE2_HEADER, "firstKey=firstVal, secondKey=secondVal");
+    cookieMiddleware.onHeadersReceived(headersToSend);
+    Assert.assertEquals("firstKey=firstVal; secondKey=secondVal", cookieMiddleware.calculateCookieString());
+  }
+}


### PR DESCRIPTION
Add a ClientMiddleware that can read HTTP Set-Cookie and Set-Cookie2 headers
from server responses and transmit corresponding Cookie headers