### PR TITLE
ARROW-10433 [Python] Swopped the conditions for checking for fsspec filesystems

### DIFF
--- a/python/pyarrow/filesystem.py
+++ b/python/pyarrow/filesystem.py
@@ -443,10 +443,6 @@ def _ensure_filesystem(fs):
     # If the arrow filesystem was subclassed, assume it supports the full
     # interface and return it
     if not issubclass(fs_type, FileSystem):
-        for mro in inspect.getmro(fs_type):
-            if mro.__name__ == 'S3FileSystem':
-                return S3FSWrapper(fs)
-
         if "fsspec" in sys.modules:
             fsspec = sys.modules["fsspec"]
             if isinstance(fs, fsspec.AbstractFileSystem):
@@ -454,6 +450,10 @@ def _ensure_filesystem(fs):
                 # pyarrow.filesystem.FileSystem, still allow fsspec
                 # filesystems (which should be compatible with our legacy fs)
                 return fs
+
+        for mro in inspect.getmro(fs_type):
+            if mro.__name__ == 'S3FileSystem':
+                return S3FSWrapper(fs)
 
         raise OSError('Unrecognized filesystem: {}'.format(fs_type))
     else:


### PR DESCRIPTION
Since s3fs.S3FileSystem is an fsspec filesystem moving this check will
ensure that it is correctly detected as an fsspec filesystem and not
wrapped with S3FSWrapper.