### PR TITLE
ARROW-10446: [C++][Python] Roundtrip Timestamp ns with TzInfo correctly

### DIFF
--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -262,6 +262,8 @@ class PyValue {
           break;
         case TimeUnit::NANO:
           if (internal::IsPandasTimestamp(obj)) {
+            // pd.Timestamp value attribute contains the offset from unix epoch
+            // so no adjustment for timezone is need.
             OwnedRef nanos(PyObject_GetAttrString(obj, "value"));
             RETURN_IF_PYERROR();
             RETURN_NOT_OK(internal::CIntFromPython(nanos.obj(), &value));

--- a/cpp/src/arrow/python/python_to_arrow.cc
+++ b/cpp/src/arrow/python/python_to_arrow.cc
@@ -272,11 +272,13 @@ class PyValue {
               return internal::InvalidValue(obj,
                                             "out of bounds for nanosecond resolution");
             }
-          }
-          // Adjust with offset and check for overflow
-          if (arrow::internal::SubtractWithOverflow(value, offset * 1000000000LL,
-                                                    &value)) {
-            return internal::InvalidValue(obj, "out of bounds for nanosecond resolution");
+
+            // Adjust with offset and check for overflow
+            if (arrow::internal::SubtractWithOverflow(value, offset * 1000000000LL,
+                                                      &value)) {
+              return internal::InvalidValue(obj,
+                                            "out of bounds for nanosecond resolution");
+            }
           }
           break;
         default:

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2008,7 +2008,7 @@ def test_roundtrip_nanosecond_resolution_pandas_temporal_objects():
     restored = pa.array(data, type=ty)
     assert arr.equals(restored)
     assert restored.to_pylist() == [
-        pd.Timestamp(value, unit='ns', tz='US/Eastern')
+        pd.Timestamp(value, unit='ns').tz_localize("UTC").tz_convert('US/Eastern')
     ]
 
 

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2000,6 +2000,17 @@ def test_roundtrip_nanosecond_resolution_pandas_temporal_objects():
         pd.Timestamp(9223371273709551616, unit='ns')
     ]
 
+    ty = pa.timestamp('ns', tz='US/Eastern')
+    value = 1604119893000000000
+    arr = pa.array([value], type=ty)
+    data = arr.to_pylist()
+    assert isinstance(data[0], pd.Timestamp)
+    restored = pa.array(data, type=ty)
+    assert arr.equals(restored)
+    assert restored.to_pylist() == [
+        pd.Timestamp(value, unit='ns', tz='US/Eastern')
+    ]
+
 
 @h.given(past.all_arrays)
 def test_array_to_pylist_roundtrip(arr):

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2008,7 +2008,8 @@ def test_roundtrip_nanosecond_resolution_pandas_temporal_objects():
     restored = pa.array(data, type=ty)
     assert arr.equals(restored)
     assert restored.to_pylist() == [
-        pd.Timestamp(value, unit='ns').tz_localize("UTC").tz_convert('US/Eastern')
+        pd.Timestamp(value, unit='ns').tz_localize(
+            "UTC").tz_convert('US/Eastern')
     ]
 
 


### PR DESCRIPTION
The value does not need to have offset applied if getting the epoch offset from pd.Timestamp.

Discovered on a hypothesis run.