### PR TITLE
ARROW-10445: [Rust] Added doubleEnded iterator to PrimitiveArrayIter

### DIFF
--- a/rust/arrow/src/array/iterator.rs
+++ b/rust/arrow/src/array/iterator.rs
@@ -20,11 +20,12 @@ use crate::datatypes::ArrowPrimitiveType;
 use super::{Array, GenericStringArray, PrimitiveArray, StringOffsetSizeTrait};
 
 /// an iterator that returns Some(T) or None, that can be used on any non-boolean PrimitiveArray
+// Note: This implementation is based on std's [Vec]s' [IntoIter].
 #[derive(Debug)]
 pub struct PrimitiveIter<'a, T: ArrowPrimitiveType> {
     array: &'a PrimitiveArray<T>,
-    i: usize,
-    len: usize,
+    current: usize,
+    current_end: usize,
 }
 
 impl<'a, T: ArrowPrimitiveType> PrimitiveIter<'a, T> {
@@ -32,8 +33,8 @@ impl<'a, T: ArrowPrimitiveType> PrimitiveIter<'a, T> {
     pub fn new(array: &'a PrimitiveArray<T>) -> Self {
         PrimitiveIter::<T> {
             array,
-            i: 0,
-            len: array.len(),
+            current: 0,
+            current_end: array.len(),
         }
     }
 }
@@ -42,20 +43,35 @@ impl<'a, T: ArrowPrimitiveType> std::iter::Iterator for PrimitiveIter<'a, T> {
     type Item = Option<T::Native>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let i = self.i;
-        if i >= self.len {
+        if self.current == self.current_end {
             None
-        } else if self.array.is_null(i) {
-            self.i += 1;
+        } else if self.array.is_null(self.current) {
+            self.current += 1;
             Some(None)
         } else {
-            self.i += 1;
-            Some(Some(self.array.value(i)))
+            let old = self.current;
+            self.current += 1;
+            Some(Some(self.array.value(old)))
         }
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.len, Some(self.len))
+        (self.array.len(), Some(self.array.len()))
+    }
+}
+
+impl<'a, T: ArrowPrimitiveType> std::iter::DoubleEndedIterator for PrimitiveIter<'a, T> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.current_end == self.current {
+            None
+        } else {
+            self.current_end -= 1;
+            Some(if self.array.is_null(self.current_end) {
+                None
+            } else {
+                Some(self.array.value(self.current_end))
+            })
+        }
     }
 }
 
@@ -130,6 +146,20 @@ mod tests {
 
         let expected = Int32Array::from(vec![Some(1), None, Some(3), None, Some(5)]);
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_double_ended() {
+        let array = Int32Array::from(vec![Some(0), None, Some(2), None, Some(4)]);
+        let mut a = array.iter();
+        assert_eq!(a.next(), Some(Some(0)));
+        assert_eq!(a.next(), Some(None));
+        assert_eq!(a.next_back(), Some(Some(4)));
+        assert_eq!(a.next_back(), Some(None));
+        assert_eq!(a.next_back(), Some(Some(2)));
+        // the two sides have met: None is returned by both
+        assert_eq!(a.next_back(), None);
+        assert_eq!(a.next(), None);
     }
 
     #[test]


### PR DESCRIPTION
This puts it in line with `array::NullIter`. This PR is complementary to #8561 (which removes `NullIter`), so that the PrimitiveArrayIterator can be reversed in the same way `NullIter` can. Together with #8561, it re-allows Dictionary keys to be iterated backwards.