### PR TITLE
[C++][Build] Fix build error on s390x

### DIFF
--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -848,7 +848,7 @@ BasicDecimal256::BasicDecimal256(const uint8_t* bytes)
           std::array<uint64_t, 4>({reinterpret_cast<const uint64_t*>(bytes)[3],
                                    reinterpret_cast<const uint64_t*>(bytes)[2],
                                    reinterpret_cast<const uint64_t*>(bytes)[1],
-                                   reinterpret_cast<const uint64_t*>(bytes)[0]})) {
+                                   reinterpret_cast<const uint64_t*>(bytes)[0]})) {}
 #endif
 
 BasicDecimal256& BasicDecimal256::Negate() {

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -881,10 +881,10 @@ void BasicDecimal256::ToBytes(uint8_t* out) const {
   reinterpret_cast<int64_t*>(out)[2] = little_endian_array_[2];
   reinterpret_cast<int64_t*>(out)[3] = little_endian_array_[3];
 #else
-    reinterpret_cast<int64_t*>(out)[0] = little_endian_array_[3];
-    reinterpret_cast<int64_t*>(out)[1] = little_endian_array_[2];
-    reinterpret_cast<int64_t*>(out)[2] = little_endian_array_[1];
-    reinterpret_cast<int64_t*>(out)[3] = little_endian_array_[0];
+  reinterpret_cast<int64_t*>(out)[0] = little_endian_array_[3];
+  reinterpret_cast<int64_t*>(out)[1] = little_endian_array_[2];
+  reinterpret_cast<int64_t*>(out)[2] = little_endian_array_[1];
+  reinterpret_cast<int64_t*>(out)[3] = little_endian_array_[0];
 #endif
 }
 


### PR DESCRIPTION
This PR fixes the build failure on TravisCI on s390x like https://travis-ci.org/github/apache/arrow/jobs/740310320#L1832

```
cd /build/cpp/src/gandiva/precompiled && /usr/lib/llvm-10/bin/clang-10 -std=c++11 -DGANDIVA_IR -DNDEBUG -DARROW_STATIC -DGANDIVA_STATIC -fno-use-cxa-atexit -emit-llvm -O3 -c /arrow/cpp/src/arrow/util/basic_decimal.cc -o /build/cpp/src/gandiva/precompiled/basic_decimal.bc -I/arrow/cpp/src -I/build/cpp/src
/arrow/cpp/src/arrow/util/basic_decimal.cc:854:44: error: function definition is not allowed here
BasicDecimal256& BasicDecimal256::Negate() {
                                           ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:863:41: error: function definition is not allowed here
BasicDecimal256& BasicDecimal256::Abs() { return *this < 0 ? Negate() : *this; }
                                        ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:865:65: error: function definition is not allowed here
BasicDecimal256 BasicDecimal256::Abs(const BasicDecimal256& in) {
                                                                ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:870:58: error: function definition is not allowed here
std::array<uint8_t, 32> BasicDecimal256::ToBytes() const {
                                                         ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:876:51: error: function definition is not allowed here
void BasicDecimal256::ToBytes(uint8_t* out) const {
                                                  ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:891:76: error: function definition is not allowed here
BasicDecimal256& BasicDecimal256::operator*=(const BasicDecimal256& right) {
                                                                           ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:910:68: error: function definition is not allowed here
                                       BasicDecimal256* out) const {
                                                                   ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:918:86: error: function definition is not allowed here
BasicDecimal256 operator*(const BasicDecimal256& left, const BasicDecimal256& right) {
                                                                                     ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:924:75: error: function definition is not allowed here
bool operator<(const BasicDecimal256& left, const BasicDecimal256& right) {
                                                                          ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:933:22: error: expected '}'
}  // namespace arrow
                     ^
/arrow/cpp/src/arrow/util/basic_decimal.cc:36:17: note: to match this '{'
namespace arrow {
                ^
10 errors generated.
```