### PR TITLE
ARROW-10451: [Rust] Add support for merge-sort

### DIFF
--- a/rust/arrow/examples/merge_sort.rs
+++ b/rust/arrow/examples/merge_sort.rs
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+///! Example demonstrating a merge sort of two un-sorted arrays
+use std::sync::Arc;
+
+extern crate arrow;
+
+use arrow::compute;
+use arrow::error::Result;
+use arrow::{
+    array::{ArrayRef, UInt32Array},
+    compute::SortOptions,
+};
+
+fn main() -> Result<()> {
+    // the arrays
+    let array1 = Arc::new(UInt32Array::from(vec![1, 4, 2])) as ArrayRef;
+    let array2 = Arc::new(UInt32Array::from(vec![6, 3, 5])) as ArrayRef;
+
+    // the sort options we are using
+    let options = SortOptions::default();
+
+    // the expectation
+    let expected = UInt32Array::from(vec![1, 2, 3, 4, 5, 6]);
+
+    // step 1: sort each of the arrays
+    let array1 = compute::sort(&array1, Some(options))?;
+    let array2 = compute::sort(&array2, Some(options))?;
+
+    // step 2: compute how to merge them (which side to take at every index)
+    let is_left = compute::merge_indices(
+        &[array1.clone()],
+        &[array2.clone()],
+        &[SortOptions::default()],
+    )?;
+
+    // step 3: merge them
+    let result = compute::merge(array1.as_ref(), array2.as_ref(), &is_left)?;
+
+    // verify result
+    let result = result.as_any().downcast_ref::<UInt32Array>().unwrap();
+
+    assert_eq!(&expected, result);
+    Ok(())
+}

--- a/rust/arrow/src/compute/kernels/merge.rs
+++ b/rust/arrow/src/compute/kernels/merge.rs
@@ -1,0 +1,175 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Defines merge kernel for two `Array`s
+
+use std::sync::Arc;
+
+use crate::array::ArrayRef;
+use crate::{
+    array::{Array, PrimitiveArray},
+    datatypes::ArrowPrimitiveType,
+    error::{ArrowError, Result},
+};
+
+/// An iterator adapter that uses 3 iterators to build a new iterator whose elements come
+/// from the first or second based on the third.
+/// Given 3 iterators (`left`, `right`, `is_left`), on which the third one (`is_left`) is boolean,
+/// returns an iterator on which the element `i` is from the left iterator if `is_left` or from the right otherwise.
+/// The size of this iterator is given by the size of `is_left`.
+struct TakeTogether<L, R, T, C>
+where
+    L: Iterator<Item = T>,
+    R: Iterator<Item = T>,
+    C: Iterator<Item = bool>,
+{
+    left: L,
+    right: R,
+    is_left: C,
+}
+
+impl<L, R, T, C> TakeTogether<L, R, T, C>
+where
+    L: Iterator<Item = T>,
+    R: Iterator<Item = T>,
+    C: Iterator<Item = bool>,
+{
+    fn new(left: L, right: R, is_left: C) -> Self {
+        TakeTogether {
+            left,
+            right,
+            is_left,
+        }
+    }
+}
+
+impl<L, R, T, C> Iterator for TakeTogether<L, R, T, C>
+where
+    L: Iterator<Item = T>,
+    R: Iterator<Item = T>,
+    C: Iterator<Item = bool>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<L::Item> {
+        let is_left = self.is_left.next();
+        is_left.and_then(|is_left| {
+            if is_left {
+                self.left.next()
+            } else {
+                self.right.next()
+            }
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.is_left.size_hint()
+    }
+}
+
+/// Merges two primitive arrays, returning a new primitive array
+pub fn merge_primitive<T: ArrowPrimitiveType>(
+    lhs: &dyn Array,
+    rhs: &dyn Array,
+    is_left: &[bool],
+) -> PrimitiveArray<T> {
+    let lhs = lhs.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+    let rhs = rhs.as_any().downcast_ref::<PrimitiveArray<T>>().unwrap();
+    TakeTogether::new(lhs.iter(), rhs.iter(), is_left.to_owned().into_iter()).collect()
+}
+
+fn dyn_merge_primitive<T: ArrowPrimitiveType>(
+    lhs: &dyn Array,
+    rhs: &dyn Array,
+    is_left: &[bool],
+) -> Arc<Array> {
+    Arc::new(merge_primitive::<T>(lhs, rhs, is_left))
+}
+
+/// Merges two arrays by taking the values from `lhs` and `rhs` depending on `is_left` slice.
+/// `is_left` must have a length equal to the sum of the two lengths and the total number of `true`
+/// must equal the length of `lhs`.
+/// # Errors
+/// This function errors when:
+/// * the arrays are not of the same type
+/// * the sum of the lengths of each array is not equal to the length of the `is_len` slice.
+pub fn merge(lhs: &dyn Array, rhs: &dyn Array, is_left: &[bool]) -> Result<ArrayRef> {
+    use crate::datatypes::*;
+    if lhs.data_type() != rhs.data_type() {
+        return Err(ArrowError::InvalidArgumentError(format!("Take merge requires both arrays to be of the same type. lhs: {:?} != rhs: {:?}", lhs.data_type(), rhs.data_type())));
+    }
+    if lhs.len() + rhs.len() != is_left.len() {
+        return Err(ArrowError::InvalidArgumentError(format!("Take merge requires the sum of arrays' lengths to be equal to the length of the third argument. lhs: {} + rhs: {} != is_len: {}", lhs.len(), rhs.len(), is_left.len())));
+    }
+
+    Ok(match lhs.data_type() {
+        DataType::Boolean => dyn_merge_primitive::<BooleanType>(lhs, rhs, is_left),
+        DataType::Int8 => dyn_merge_primitive::<Int8Type>(lhs, rhs, is_left),
+        DataType::Int16 => dyn_merge_primitive::<Int16Type>(lhs, rhs, is_left),
+        DataType::Int32 => dyn_merge_primitive::<Int32Type>(lhs, rhs, is_left),
+        DataType::Int64 => dyn_merge_primitive::<Int64Type>(lhs, rhs, is_left),
+        DataType::UInt8 => dyn_merge_primitive::<UInt8Type>(lhs, rhs, is_left),
+        DataType::UInt16 => dyn_merge_primitive::<UInt16Type>(lhs, rhs, is_left),
+        DataType::UInt32 => dyn_merge_primitive::<UInt32Type>(lhs, rhs, is_left),
+        DataType::UInt64 => dyn_merge_primitive::<UInt64Type>(lhs, rhs, is_left),
+        DataType::Float32 => dyn_merge_primitive::<Float32Type>(lhs, rhs, is_left),
+        DataType::Float64 => dyn_merge_primitive::<Float64Type>(lhs, rhs, is_left),
+        DataType::Date32(_) => dyn_merge_primitive::<Date32Type>(lhs, rhs, is_left),
+        DataType::Date64(_) => dyn_merge_primitive::<Date64Type>(lhs, rhs, is_left),
+        DataType::Time32(_) => dyn_merge_primitive::<Time32SecondType>(lhs, rhs, is_left),
+        DataType::Time64(_) => {
+            dyn_merge_primitive::<Time64NanosecondType>(lhs, rhs, is_left)
+        }
+        DataType::Timestamp(_, _) => {
+            dyn_merge_primitive::<TimestampSecondType>(lhs, rhs, is_left)
+        }
+        DataType::Interval(_) => {
+            dyn_merge_primitive::<IntervalYearMonthType>(lhs, rhs, is_left)
+        }
+        DataType::Duration(_) => {
+            dyn_merge_primitive::<DurationSecondType>(lhs, rhs, is_left)
+        }
+        other => {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "Merge still not supported for type {:?}",
+                other
+            )))
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::array::UInt32Array;
+
+    use super::*;
+
+    #[test]
+    fn test_merge_array() -> Result<()> {
+        let array1 = UInt32Array::from(vec![1, 2, 3]);
+        let array2 = UInt32Array::from(vec![4, 5, 6]);
+        let is_left = &[true, false, true, false, true, false];
+        let expected = UInt32Array::from(vec![1, 4, 2, 5, 3, 6]);
+
+        let result = merge(&array1, &array2, is_left)?;
+
+        let result = result.as_any().downcast_ref::<UInt32Array>().unwrap();
+
+        assert_eq!(&expected, result);
+        Ok(())
+    }
+}

--- a/rust/arrow/src/compute/kernels/merge_sort.rs
+++ b/rust/arrow/src/compute/kernels/merge_sort.rs
@@ -1,0 +1,194 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Kernel to compute the indices necessary to sort-merge two arrays
+
+use std::cmp::Ordering;
+
+use crate::array::{build_compare, ArrayRef};
+use crate::{
+    compute::SortOptions,
+    error::{ArrowError, Result},
+};
+
+/// Given two sets of _ordered_ arrays, returns a bool vector denoting which of the items of the lhs and rhs are to pick from so that
+/// if we were to sort-merge the lhs and rhs arrays together, they would all be sorted according to the `options`.
+/// # Example
+/// ```
+/// use std::sync::Arc;
+/// use arrow::array::UInt32Array;
+/// use arrow::compute::SortOptions;
+/// use arrow::compute::merge_indices;
+/// # fn main() -> arrow::error::Result<()> {
+/// let a = Arc::new(UInt32Array::from(vec![None, Some(1), Some(3)]));
+/// let b = Arc::new(UInt32Array::from(vec![None, Some(2), Some(4), Some(5)]));
+/// let c = merge_indices(&[a], &[b], &[SortOptions::default()])?;
+/// // [0] false: when equal (None = None), rhs is picked
+/// // [1] true: None < 2
+/// // [2] true: 1 < 2
+/// // [3] false: 2 < 3
+/// // [4] true: 3 < 4
+/// // [5,6] false: lhs has finished => pick rhs
+/// assert_eq!(c, vec![false, true, true, false, true, false, false]);
+/// // I.e. taking `[rhs[0], lhs[0], lhs[1], rhs[1], lhs[2], rhs[2], rhs[3]]`
+/// // leads to an ordered array.
+/// # Ok(())
+/// # }
+/// ```
+/// # Errors
+/// This function errors when:
+/// * `lhs.len() != rhs.len()`
+/// * `lhs.len() == 0`
+/// * `lhs.len() != options.len()`
+/// * Arrays on `lhs` and `rhs` have no order relationship
+pub fn merge_indices(
+    lhs: &[ArrayRef],
+    rhs: &[ArrayRef],
+    options: &[SortOptions],
+) -> Result<Vec<bool>> {
+    if lhs.len() != rhs.len() {
+        return Err(ArrowError::InvalidArgumentError(format!("Merge requires lhs and rhs to have the same number of arrays. lhs has {}, rhs has {}.", lhs.len(), rhs.len())));
+    };
+    if lhs.len() == 0 {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "Merge requires lhs to have at least 1 entry."
+        )));
+    };
+    if lhs.len() != options.len() {
+        return Err(ArrowError::InvalidArgumentError(format!("Merge requires the number of sort options to equal number of columns. lhs has {} entries, options has {} entries", lhs.len(), options.len())));
+    };
+
+    // prepare the comparison function between lhs and rhs arrays
+    let cmp = lhs
+        .iter()
+        .zip(rhs.iter())
+        .map(|(l, r)| build_compare(l.as_ref(), r.as_ref()))
+        .collect::<Result<Vec<_>>>()?;
+
+    // prepare a comparison function taking into account nulls and sort options
+    let cmp = |left, right| {
+        for c in 0..lhs.len() {
+            let descending = options[c].descending;
+            let null_first = options[c].nulls_first;
+            let mut result = match (lhs[c].is_valid(left), rhs[c].is_valid(right)) {
+                (true, true) => (cmp[c])(left, right),
+                (false, true) => {
+                    if null_first {
+                        Ordering::Less
+                    } else {
+                        Ordering::Greater
+                    }
+                }
+                (true, false) => {
+                    if null_first {
+                        Ordering::Greater
+                    } else {
+                        Ordering::Less
+                    }
+                }
+                (false, false) => Ordering::Equal,
+            };
+            if descending {
+                result = result.reverse();
+            };
+            if result != Ordering::Equal {
+                // we found a relevant comparison => short-circuit and return it
+                return result;
+            }
+        }
+        Ordering::Equal
+    };
+
+    // the actual merge-sort code is from this point onwards
+    let mut left = 0; // Head of left pile.
+    let mut right = 0; // Head of right pile.
+    let max_left = lhs[0].len();
+    let max_right = rhs[0].len();
+
+    let mut result = Vec::with_capacity(lhs.len() + rhs.len());
+    while left < max_left || right < max_right {
+        let order = match (left >= max_left, right >= max_right) {
+            (true, true) => break,
+            (false, true) => Ordering::Less,
+            (true, false) => Ordering::Greater,
+            (false, false) => (cmp)(left, right),
+        };
+        let value = if order == Ordering::Less {
+            left += 1;
+            true
+        } else {
+            right += 1;
+            false
+        };
+        result.push(value)
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::array::UInt32Array;
+    use crate::error::Result;
+
+    #[test]
+    fn test_indices_other() -> Result<()> {
+        let a = Arc::new(UInt32Array::from(vec![None, Some(1), Some(2), Some(4)]));
+        let b = Arc::new(UInt32Array::from(vec![None, Some(3)]));
+        let c = merge_indices(&[a], &[b], &[SortOptions::default()])?;
+
+        // [0] false: when equal (None = None), rhs is picked
+        // [1] true: None < 3
+        // [2] true: 1 < 3
+        // [3] true: 2 < 3
+        // [4] false: 3 < 4
+        // [5] true: rhs has finished => pick lhs
+        assert_eq!(c, vec![false, true, true, true, false, true]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_indices_many() -> Result<()> {
+        let a1 = Arc::new(UInt32Array::from(vec![None, Some(1), Some(3)]));
+        let b1 = Arc::new(UInt32Array::from(vec![None, Some(2), Some(3), Some(5)]));
+        let option1 = SortOptions {
+            descending: false,
+            nulls_first: true,
+        };
+
+        let a2 = Arc::new(UInt32Array::from(vec![Some(2), Some(3), Some(5)]));
+        let b2 = Arc::new(UInt32Array::from(vec![Some(1), Some(4), Some(6), Some(6)]));
+        let option2 = SortOptions {
+            descending: true,
+            nulls_first: true,
+        };
+
+        let c = merge_indices(&[a1, a2], &[b1, b2], &[option1, option2])?;
+
+        // [0] true: (N = N, 2 > 1)
+        // [1] false: (1 < N, irrelevant)
+        // [2] true: (1 < 2, irrelevant)
+        // [3] false: (2 < 3, irrelevant)
+        // [4] false: (3 = 3, 5 < 6)
+        // [5] true: (3 < 5, irrelevant)
+        // [6] false: lhs finished
+        assert_eq!(c, vec![true, false, true, false, false, true, false]);
+        Ok(())
+    }
+}

--- a/rust/arrow/src/compute/kernels/mod.rs
+++ b/rust/arrow/src/compute/kernels/mod.rs
@@ -27,6 +27,7 @@ pub mod filter;
 pub mod length;
 pub mod limit;
 pub mod merge;
+pub mod merge_sort;
 pub mod sort;
 pub mod substring;
 pub mod take;

--- a/rust/arrow/src/compute/kernels/mod.rs
+++ b/rust/arrow/src/compute/kernels/mod.rs
@@ -26,6 +26,7 @@ pub mod concat;
 pub mod filter;
 pub mod length;
 pub mod limit;
+pub mod merge;
 pub mod sort;
 pub mod substring;
 pub mod take;

--- a/rust/arrow/src/compute/mod.rs
+++ b/rust/arrow/src/compute/mod.rs
@@ -29,6 +29,8 @@ pub use self::kernels::comparison::*;
 pub use self::kernels::concat::*;
 pub use self::kernels::filter::*;
 pub use self::kernels::limit::*;
+pub use self::kernels::merge::*;
+pub use self::kernels::merge_sort::*;
 pub use self::kernels::sort::*;
 pub use self::kernels::take::*;
 pub use self::kernels::temporal::*;


### PR DESCRIPTION
This PR adds support for merge-sorting two arrays of a common type but arbitrary sizes, optionally N arrays to make the comparison, in the same spirit as we have for `lexsort_to_indices`.

This also adds an example demonstrating the use-case.

`Merge` of two arrays can be interpreted as a combination of `take` and `concat`: the end result is an array with `len = lhs.len() + rhs.len()`, but the resulting arrays' elements are "taken" from `lhs` or `rhs` according to an indicator (`Vec<bool>`).

Since `merge` is intrinsically row-based and can't leverage continuous memory operations, the design uses the iterator pattern and an iterator adapter `TakeTogether` that takes from the left or from the right.

The general flow is:

1. sort each array independently
2. compute the order to extract elements from the `lhs` and `rhs`
3. construct a new array by taking elements from `lhs` or `rhs` according to the desired order

Note that the rational for performing a merge-sort is that it is a stable and parallelizable algorithm: step 1 above is trivially parallelizable. More info [here](https://en.wikipedia.org/wiki/Merge_sort). Note that the current implementation does not split the arrays in smaller parts. The main use-case of this kernel is to avoid `concat all arrays + sort a single array` to sort two or more arrays.