### PR TITLE
ARROW-10455: [Rust] [CI] Fixed error in caching files

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .docker
-          key: debian-10-rust-${{ hashFiles('rust/**.rs') }}
+          key: debian-10-rust-${{ hashFiles('rust/**/**.rs', 'rust/**/Cargo.toml') }}
           restore-keys: debian-10-rust-
       - name: Setup Python
         uses: actions/setup-python@v1
@@ -118,7 +118,7 @@ jobs:
         uses: actions/cache@v1
         with:
           path: rust/target
-          key: windows-rust-${{ hashFiles('rust/**.rs') }}
+          key: windows-rust-${{ hashFiles('rust/**/**.rs', 'rust/**/Cargo.toml') }}
           restore-keys: windows-rust-
       - name: Build
         shell: bash

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -118,8 +118,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: rust/target
-          key: windows-rust-${{ hashFiles('rust/**/**.rs', 'rust/**/Cargo.toml') }}
-          restore-keys: windows-rust-
+          key: windows-rust-v1-${{ hashFiles('rust/**/**.rs', 'rust/**/Cargo.toml') }}
+          restore-keys: windows-rust-v1-
       - name: Build
         shell: bash
         run: ci/scripts/rust_build.sh $(pwd) $(pwd)/build


### PR DESCRIPTION
This PR fixes two errors:

1. `hashFiles` was not picking any file, thereby not differentiating cache keys.
2. `hashFiles` was not considering `Cargo.toml`, an important file in rust (like `package.json` in npm or `setup.py` in Python)
