### PR TITLE
ARROW-10300: [Rust] Improve documentation for TPC-H benchmark

### DIFF
--- a/rust/benchmarks/README.md
+++ b/rust/benchmarks/README.md
@@ -52,9 +52,41 @@ The benchmark can then be run (assuming the data created from `dbgen` is in `/mn
 cargo run --release --bin tpch -- --iterations 3 --path /mnt/tpch-dbgen --format tbl --query 1 --batch-size 4096
 ```
 
-The benchmark program also supports CSV and Parquet input file formats. This crate does not currently provide a method
-for converting the generated tbl format to CSV or Parquet so it is necessary to use other tools to perform this
-conversion.
+The benchmark program also supports CSV and Parquet input file formats.
+
+This crate does not currently provide a method for converting the generated tbl format to CSV or Parquet so it is 
+necessary to use other tools to perform this conversion.
+
+One option is to use the following Docker image to perform the conversion from `tbl` files to CSV or Parquet.
+
+```bash
+docker run -it ballistacompute/spark-benchmarks:0.4.0-SNAPSHOT 
+  -h, --help   Show help message
+
+Subcommand: convert-tpch
+  -i, --input  <arg>
+      --input-format  <arg>
+  -o, --output  <arg>
+      --output-format  <arg>
+  -p, --partitions  <arg>
+  -h, --help                   Show help message
+```
+
+Note that it is necessary to mount volumes into the Docker container as appropriate so that the file conversion process
+can access files on the host system.
+
+Here is a full example that assumes that data is stored in the `/mnt` path on the host system.
+
+```bash
+docker run -v /mnt:/mnt -it ballistacompute/spark-benchmarks:0.4.0-SNAPSHOT \
+  convert-tpch \
+  --input /mnt/tpch/csv \
+  --input-format tbl \
+  --output /mnt/tpch/parquet \
+  --output-format parquet \
+  --partitions 64
+```
+
 
 ## NYC Taxi Benchmark
 

--- a/rust/benchmarks/README.md
+++ b/rust/benchmarks/README.md
@@ -33,7 +33,7 @@ These benchmarks are derived from the [TPC-H][1] benchmark.
 Data for this benchmark can be generated using the [tpch-dbgen][2] command-line tool. Run the following commands to
 clone the repository and build the source code.
 
-```
+```bash
 git clone git@github.com:databricks/tpch-dbgen.git
 cd tpch-dbgen
 make
@@ -42,7 +42,7 @@ make
 Data can now be generated with the following command. Note that `-s 1` means use Scale Factor 1 or ~1 GB of
 data. This value can be increased to generate larger data sets.
 
-```
+```bash
 ./dbgen -vf -s 1
 ```
 

--- a/rust/benchmarks/README.md
+++ b/rust/benchmarks/README.md
@@ -28,16 +28,22 @@ crates as well.
 
 ## Benchmark derived from TPC-H
 
-These benchmarks are derived from the [TPC-H](http://www.tpc.org/tpch/) benchmark.
+These benchmarks are derived from the [TPC-H][1] benchmark.
 
-Data for this benchmark can be generated using the
-[tpch-dbgen](https://github.com/databricks/tpch-dbgen) tool with a
-command such as the following (`-s 1` means use Scale Factor 1 or ~1 GB of
-data, replace the 1 to change datasize).
+Data for this benchmark can be generated using the [tpch-dbgen][2] command-line tool. Run the following commands to
+clone the repository and build the source code.
 
 ```
-cd /mnt/tpch-dbgen
-dbgen -vf -s 1
+git clone git@github.com:databricks/tpch-dbgen.git
+cd tpch-dbgen
+make
+```
+
+Data can now be generated with the following command. Note that `-s 1` means use Scale Factor 1 or ~1 GB of
+data. This value can be increased to generate larger data sets.
+
+```
+./dbgen -vf -s 1
 ```
 
 The benchmark can then be run (assuming the data created from `dbgen` is in `/mnt/tpch-dbgen`) with a command such as:
@@ -46,12 +52,13 @@ The benchmark can then be run (assuming the data created from `dbgen` is in `/mn
 cargo run --release --bin tpch -- --iterations 3 --path /mnt/tpch-dbgen --format tbl --query 1 --batch-size 4096
 ```
 
-The benchmark program also supports csv and parquet file formats
-
+The benchmark program also supports CSV and Parquet input file formats. This crate does not currently provide a method
+for converting the generated tbl format to CSV or Parquet so it is necessary to use other tools to perform this
+conversion.
 
 ## NYC Taxi Benchmark
 
-These benchmarks are based on the [New York Taxi and Limousine Commission](https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page) data set.
+These benchmarks are based on the [New York Taxi and Limousine Commission][3] data set.
 
 ```bash
 cargo run --release --bin nyctaxi -- --iterations 3 --path /mnt/nyctaxi/csv --format csv --batch-size 4096
@@ -66,3 +73,7 @@ Query 'fare_amt_by_passenger' iteration 0 took 7138 ms
 Query 'fare_amt_by_passenger' iteration 1 took 7599 ms
 Query 'fare_amt_by_passenger' iteration 2 took 7969 ms
 ```
+
+[1]: http://www.tpc.org/tpch/
+[2]: https://github.com/databricks/tpch-dbgen
+[3]: https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page


### PR DESCRIPTION
The main change in this PR is adding documentation for converting `tbl` files to CSV and Parquet using a public Docker image from the Ballista project [1]. This is a short term solution until we can provide a utility within the Arrow Rust project and I filed 
https://issues.apache.org/jira/browse/ARROW-10464 for the longer-term solution.

[1] https://github.com/ballista-compute/ballista