### PR TITLE
ARROW-10468: [C++][Compute] Provide KernelExecutor instead of FunctionExecutor

### DIFF
--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -65,4 +65,6 @@ add_arrow_compute_test(internals_test
                        kernel_test.cc
                        registry_test.cc)
 
+add_arrow_benchmark(function_benchmark PREFIX "arrow-compute")
+
 add_subdirectory(kernels)

--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -163,7 +163,7 @@ bool CastFunction::CanCastTo(const DataType& out_type) const {
   return impl_->in_types.find(static_cast<int>(out_type.id())) != impl_->in_types.end();
 }
 
-Result<const ScalarKernel*> CastFunction::DispatchExact(
+Result<const Kernel*> CastFunction::DispatchExact(
     const std::vector<ValueDescr>& values) const {
   const int passed_num_args = static_cast<int>(values.size());
 

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -98,7 +98,7 @@ class CastFunction : public ScalarFunction {
 
   bool CanCastTo(const DataType& out_type) const;
 
-  Result<const ScalarKernel*> DispatchExact(
+  Result<const Kernel*> DispatchExact(
       const std::vector<ValueDescr>& values) const override;
 
  private:

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -106,21 +106,18 @@ class ARROW_EXPORT KernelExecutor {
  public:
   virtual ~KernelExecutor() = default;
 
+  virtual Status Init(KernelContext*, KernelInitArgs) = 0;
+
   /// XXX: Better configurability for listener
   /// Not thread-safe
   virtual Status Execute(const std::vector<Datum>& args, ExecListener* listener) = 0;
 
-  virtual ValueDescr output_descr() const = 0;
-
   virtual Datum WrapResults(const std::vector<Datum>& args,
                             const std::vector<Datum>& outputs) = 0;
 
-  static Result<std::unique_ptr<KernelExecutor>> MakeScalar(ExecContext* ctx,
-                                                            KernelInitArgs);
-  static Result<std::unique_ptr<KernelExecutor>> MakeVector(ExecContext* ctx,
-                                                            KernelInitArgs);
-  static Result<std::unique_ptr<KernelExecutor>> MakeScalarAggregate(ExecContext* ctx,
-                                                                     KernelInitArgs);
+  static std::unique_ptr<KernelExecutor> MakeScalar();
+  static std::unique_ptr<KernelExecutor> MakeVector();
+  static std::unique_ptr<KernelExecutor> MakeScalarAggregate();
 };
 
 /// \brief Populate validity bitmap with the intersection of the nullity of the

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -102,9 +102,9 @@ class DatumAccumulator : public ExecListener {
 /// inputs will be split into non-chunked ExecBatch values for execution
 Status CheckAllValues(const std::vector<Datum>& values);
 
-class ARROW_EXPORT FunctionExecutor {
+class ARROW_EXPORT KernelExecutor {
  public:
-  virtual ~FunctionExecutor() = default;
+  virtual ~KernelExecutor() = default;
 
   /// XXX: Better configurability for listener
   /// Not thread-safe
@@ -115,9 +115,12 @@ class ARROW_EXPORT FunctionExecutor {
   virtual Datum WrapResults(const std::vector<Datum>& args,
                             const std::vector<Datum>& outputs) = 0;
 
-  static Result<std::unique_ptr<FunctionExecutor>> Make(ExecContext* ctx,
-                                                        const Function* func,
-                                                        const FunctionOptions* options);
+  static Result<std::unique_ptr<KernelExecutor>> MakeScalar(ExecContext* ctx,
+                                                            KernelInitArgs);
+  static Result<std::unique_ptr<KernelExecutor>> MakeVector(ExecContext* ctx,
+                                                            KernelInitArgs);
+  static Result<std::unique_ptr<KernelExecutor>> MakeScalarAggregate(ExecContext* ctx,
+                                                                     KernelInitArgs);
 };
 
 /// \brief Populate validity bitmap with the intersection of the nullity of the

--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -155,6 +155,13 @@ class ARROW_EXPORT Function {
   /// \brief Returns the number of registered kernels for this function.
   virtual int num_kernels() const = 0;
 
+  /// \brief Return a kernel that can execute the function given the exact
+  /// argument types (without implicit type casts or scalar->array promotions).
+  ///
+  /// NB: This function is overridden in CastFunction.
+  virtual Result<const Kernel*> DispatchExact(
+      const std::vector<ValueDescr>& values) const = 0;
+
   /// \brief Execute the function eagerly with the passed input arguments with
   /// kernel dispatch, batch iteration, and memory allocation details taken
   /// care of.
@@ -241,12 +248,8 @@ class ARROW_EXPORT ScalarFunction : public detail::FunctionImpl<ScalarKernel> {
   /// kernel's signature does not match the function's arity.
   Status AddKernel(ScalarKernel kernel);
 
-  /// \brief Return a kernel that can execute the function given the exact
-  /// argument types (without implicit type casts or scalar->array promotions).
-  ///
-  /// NB: This function is overridden in CastFunction.
-  virtual Result<const ScalarKernel*> DispatchExact(
-      const std::vector<ValueDescr>& values) const;
+  Result<const Kernel*> DispatchExact(
+      const std::vector<ValueDescr>& values) const override;
 };
 
 /// \brief A function that executes general array operations that may yield
@@ -272,9 +275,8 @@ class ARROW_EXPORT VectorFunction : public detail::FunctionImpl<VectorKernel> {
   /// kernel's signature does not match the function's arity.
   Status AddKernel(VectorKernel kernel);
 
-  /// \brief Return a kernel that can execute the function given the exact
-  /// argument types (without implicit type casts or scalar->array promotions)
-  Result<const VectorKernel*> DispatchExact(const std::vector<ValueDescr>& values) const;
+  Result<const Kernel*> DispatchExact(
+      const std::vector<ValueDescr>& values) const override;
 };
 
 class ARROW_EXPORT ScalarAggregateFunction
@@ -291,10 +293,8 @@ class ARROW_EXPORT ScalarAggregateFunction
   /// kernel's signature does not match the function's arity.
   Status AddKernel(ScalarAggregateKernel kernel);
 
-  /// \brief Return a kernel that can execute the function given the exact
-  /// argument types (without implicit type casts or scalar->array promotions)
-  Result<const ScalarAggregateKernel*> DispatchExact(
-      const std::vector<ValueDescr>& values) const;
+  Result<const Kernel*> DispatchExact(
+      const std::vector<ValueDescr>& values) const override;
 };
 
 /// \brief A function that dispatches to other functions. Must implement
@@ -308,6 +308,10 @@ class ARROW_EXPORT MetaFunction : public Function {
 
   Result<Datum> Execute(const std::vector<Datum>& args, const FunctionOptions* options,
                         ExecContext* ctx) const override;
+
+  Result<const Kernel*> DispatchExact(const std::vector<ValueDescr>&) const override {
+    return Status::NotImplemented("DispatchExact for a MetaFunction's Kernels");
+  }
 
  protected:
   virtual Result<Datum> ExecuteImpl(const std::vector<Datum>& args,

--- a/cpp/src/arrow/compute/function_benchmark.cc
+++ b/cpp/src/arrow/compute/function_benchmark.cc
@@ -1,0 +1,116 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include "arrow/array/array_base.h"
+#include "arrow/compute/api.h"
+#include "arrow/memory_pool.h"
+#include "arrow/scalar.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/util/benchmark_util.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+
+namespace compute {
+
+constexpr int32_t kSeed = 0xfede4a7e;
+constexpr int64_t kScalarCount = 1 << 10;
+
+inline ScalarVector ToScalars(std::shared_ptr<Array> arr) {
+  ScalarVector scalars{static_cast<size_t>(arr->length())};
+  int64_t i = 0;
+  for (auto& scalar : scalars) {
+    scalar = arr->GetScalar(i++).ValueOrDie();
+  }
+  return scalars;
+}
+
+void BM_CastDispatch(benchmark::State& state) {  // NOLINT non-const reference
+  // Repeatedly invoke a trivial Cast: the main cost should be dispatch
+  random::RandomArrayGenerator rag(kSeed);
+
+  auto int_scalars = ToScalars(rag.Int64(kScalarCount, 0, 1 << 20));
+
+  auto double_type = float64();
+  for (auto _ : state) {
+    Datum timestamp_scalar;
+    for (Datum int_scalar : int_scalars) {
+      ASSERT_OK_AND_ASSIGN(timestamp_scalar, Cast(int_scalar, double_type));
+    }
+    benchmark::DoNotOptimize(timestamp_scalar);
+  }
+
+  state.SetItemsProcessed(state.iterations() * kScalarCount);
+}
+
+void BM_CastDispatchBaseline(benchmark::State& state) {  // NOLINT non-const reference
+  // Repeatedly invoke a trivial Cast with all dispatch outside the hot loop
+  random::RandomArrayGenerator rag(kSeed);
+
+  auto int_scalars = ToScalars(rag.Int64(kScalarCount, 0, 1 << 20));
+
+  auto double_type = float64();
+  CastOptions cast_options;
+  cast_options.to_type = double_type;
+  ASSERT_OK_AND_ASSIGN(auto cast_function, GetCastFunction(double_type));
+  ASSERT_OK_AND_ASSIGN(auto cast_kernel,
+                       cast_function->DispatchExact({int_scalars[0]->type}));
+
+  ExecContext exec_context;
+  KernelContext kernel_context(&exec_context);
+  auto cast_state =
+      cast_kernel->init(&kernel_context, {cast_kernel, {double_type}, &cast_options});
+  ABORT_NOT_OK(kernel_context.status());
+  kernel_context.SetState(cast_state.get());
+
+  for (auto _ : state) {
+    Datum timestamp_scalar = MakeNullScalar(double_type);
+    for (Datum int_scalar : int_scalars) {
+      cast_kernel->exec(&kernel_context, {{std::move(int_scalar)}, 1}, &timestamp_scalar);
+      ABORT_NOT_OK(kernel_context.status());
+    }
+    benchmark::DoNotOptimize(timestamp_scalar);
+  }
+
+  state.SetItemsProcessed(state.iterations() * kScalarCount);
+}
+
+void BM_AddDispatch(benchmark::State& state) {  // NOLINT non-const reference
+  ExecContext exec_context;
+  KernelContext kernel_context(&exec_context);
+
+  for (auto _ : state) {
+    ASSERT_OK_AND_ASSIGN(auto add_function, GetFunctionRegistry()->GetFunction("add"));
+    ASSERT_OK_AND_ASSIGN(auto add_kernel,
+                         checked_cast<const ScalarFunction&>(*add_function)
+                             .DispatchExact({int64(), int64()}));
+    benchmark::DoNotOptimize(add_kernel);
+  }
+
+  state.SetItemsProcessed(state.iterations());
+}
+
+BENCHMARK(BM_CastDispatch)->MinTime(1.0);
+BENCHMARK(BM_CastDispatchBaseline)->MinTime(1.0);
+BENCHMARK(BM_AddDispatch)->MinTime(1.0);
+
+}  // namespace compute
+}  // namespace arrow

--- a/cpp/src/arrow/compute/function_benchmark.cc
+++ b/cpp/src/arrow/compute/function_benchmark.cc
@@ -73,6 +73,7 @@ void BM_CastDispatchBaseline(benchmark::State& state) {  // NOLINT non-const ref
   ASSERT_OK_AND_ASSIGN(auto cast_function, GetCastFunction(double_type));
   ASSERT_OK_AND_ASSIGN(auto cast_kernel,
                        cast_function->DispatchExact({int_scalars[0]->type}));
+  const auto& exec = static_cast<const ScalarKernel*>(cast_kernel)->exec;
 
   ExecContext exec_context;
   KernelContext kernel_context(&exec_context);
@@ -84,7 +85,7 @@ void BM_CastDispatchBaseline(benchmark::State& state) {  // NOLINT non-const ref
   for (auto _ : state) {
     Datum timestamp_scalar = MakeNullScalar(double_type);
     for (Datum int_scalar : int_scalars) {
-      cast_kernel->exec(&kernel_context, {{std::move(int_scalar)}, 1}, &timestamp_scalar);
+      exec(&kernel_context, {{std::move(int_scalar)}, 1}, &timestamp_scalar);
       ABORT_NOT_OK(kernel_context.status());
     }
     benchmark::DoNotOptimize(timestamp_scalar);

--- a/cpp/src/arrow/compute/function_test.cc
+++ b/cpp/src/arrow/compute/function_test.cc
@@ -126,7 +126,7 @@ void CheckAddDispatch(FunctionType* func) {
   KernelType invalid_kernel({boolean()}, boolean(), ExecNYI);
   ASSERT_RAISES(Invalid, func->AddKernel(invalid_kernel));
 
-  ASSERT_OK_AND_ASSIGN(const KernelType* kernel, func->DispatchExact({int32(), int32()}));
+  ASSERT_OK_AND_ASSIGN(const Kernel* kernel, func->DispatchExact({int32(), int32()}));
   KernelSignature expected_sig(in_types1, out_type1);
   ASSERT_TRUE(kernel->signature->Equals(expected_sig));
 
@@ -164,7 +164,7 @@ TEST(ArrayFunction, VarArgs) {
   ASSERT_RAISES(Invalid, va_func.AddKernel(non_va_kernel));
 
   std::vector<ValueDescr> args = {ValueDescr::Scalar(int8()), int8(), int8()};
-  ASSERT_OK_AND_ASSIGN(const ScalarKernel* kernel, va_func.DispatchExact(args));
+  ASSERT_OK_AND_ASSIGN(const Kernel* kernel, va_func.DispatchExact(args));
   ASSERT_TRUE(kernel->signature->MatchesInputs(args));
 
   // No dispatch possible because args incompatible
@@ -215,8 +215,7 @@ TEST(ScalarAggregateFunction, DispatchExact) {
   ASSERT_RAISES(Invalid, func.AddKernel(kernel));
 
   std::vector<ValueDescr> dispatch_args = {ValueDescr::Array(int8())};
-  ASSERT_OK_AND_ASSIGN(const ScalarAggregateKernel* selected_kernel,
-                       func.DispatchExact(dispatch_args));
+  ASSERT_OK_AND_ASSIGN(const Kernel* selected_kernel, func.DispatchExact(dispatch_args));
   ASSERT_EQ(func.kernels()[0], selected_kernel);
   ASSERT_TRUE(selected_kernel->signature->MatchesInputs(dispatch_args));
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
@@ -41,7 +41,7 @@ template <typename in_type, typename out_type>
 void ShiftTime(KernelContext* ctx, const util::DivideOrMultiply factor_op,
                const int64_t factor, const ArrayData& input, ArrayData* output) {
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
-  const in_type* in_data = input.GetValues<in_type>(1);
+  auto in_data = input.GetValues<in_type>(1);
   auto out_data = output->GetMutableValues<out_type>(1);
 
   if (factor == 1) {


### PR DESCRIPTION
This is a sub PR of ARROW-10322.

The motivation is to defer dispatch and state initialization instead of handling these within FunctionExecutor, which will allow us to avoid multiple dispatches in the case of repeated execution of the same kernel(s). Initialization of KernelState is also deferred so that expensive state (for example hash table construction in the set lookup kernels) may be easily reused for multiple executions.

A microbenchmark of kernel dispatch performance is also added. The changes here do not affect dispatch time.

```
Before:
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_CastDispatch/min_time:1.000            1515564 ns    1515530 ns        916   659.835k items/s
BM_CastDispatchBaseline/min_time:1.000     236472 ns     236468 ns       5919   4.12978M items/s
BM_AddDispatch/min_time:1.000                 284 ns        284 ns    4921359   3.35523M items/s

After:
------------------------------------------------------------------------------
Benchmark                                       Time           CPU Iterations
------------------------------------------------------------------------------
BM_CastDispatch/min_time:1.000            1583169 ns    1583129 ns        884    631.66k items/s
BM_CastDispatchBaseline/min_time:1.000     233199 ns     233194 ns       5990   4.18776M items/s
BM_AddDispatch/min_time:1.000                 284 ns        284 ns    4901845   3.35489M items/s
```