### PR TITLE
ARROW-10476: [Rust] Allow string arrays to be built from Option<&str> or Option<String>

### DIFF
--- a/rust/arrow/src/array/array.rs
+++ b/rust/arrow/src/array/array.rs
@@ -1548,17 +1548,16 @@ impl<OffsetSize: StringOffsetSizeTrait> GenericStringArray<OffsetSize> {
     }
 
     pub(crate) fn from_opt_vec(v: Vec<Option<&str>>) -> Self {
-        let iter = v.iter().map(|e| e.map(|e| e.to_string()));
-        GenericStringArray::from_iter(iter)
+        GenericStringArray::from_iter(v.into_iter())
     }
 }
 
-impl<'a, Ptr, OffsetSize: StringOffsetSizeTrait> FromIterator<Ptr>
+impl<'a, Ptr, OffsetSize: StringOffsetSizeTrait> FromIterator<Option<Ptr>>
     for GenericStringArray<OffsetSize>
 where
-    Ptr: Borrow<Option<String>>,
+    Ptr: AsRef<str>,
 {
-    fn from_iter<I: IntoIterator<Item = Ptr>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = Option<Ptr>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let (_, data_len) = iter.size_hint();
         let data_len = data_len.expect("Iterator must be sized"); // panic if no upper bound.
@@ -1570,7 +1569,8 @@ where
         offsets.push(length_so_far);
 
         for (i, s) in iter.enumerate() {
-            if let Some(s) = s.borrow() {
+            if let Some(s) = s {
+                let s = s.as_ref();
                 // set null bit
                 let null_slice = null_buf.data_mut();
                 bit_util::set_bit(null_slice, i);
@@ -3914,6 +3914,23 @@ mod tests {
             "LargeStringArray\n[\n  \"hello\",\n  \"arrow\",\n]",
             format!("{:?}", arr)
         );
+    }
+
+    #[test]
+    fn test_string_array_from_iter() {
+        let data = vec![Some("hello"), None, Some("arrow")];
+        // from Vec<Option<&str>>
+        let array1 = StringArray::from(data.clone());
+        // from Iterator<Option<&str>>
+        let array2: StringArray = data.clone().into_iter().collect();
+        // from Iterator<Option<String>>
+        let array3: StringArray = data
+            .into_iter()
+            .map(|x| x.map(|s| format!("{}", s)))
+            .collect();
+
+        assert_eq!(array1, array2);
+        assert_eq!(array2, array3);
     }
 
     #[test]


### PR DESCRIPTION
Currently, our code-base supports creating a `StringArray` from an iterator of `String`.

However, from arrow's perspective, we should not care if it is a `String` or a `&str`, as long as it can be represented by an `AsRef<str>`. A user sometimes is able to create an iterator of `&str` instead of `String`, and should not have to convert one to the other before passing it to Arrow.

This PR makes this change.