### PR TITLE
ARROW-10441: [Java] Prevent closure of shared channels for FlightClient

### DIFF
--- a/java/flight/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
+++ b/java/flight/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
@@ -19,17 +19,111 @@ package org.apache.arrow.flight;
 
 import java.util.Collections;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.arrow.flight.auth.ServerAuthHandler;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.util.VisibleForTesting;
 
 import io.grpc.BindableService;
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
 
 /**
  * Exposes Flight GRPC service & client.
  */
 public class FlightGrpcUtils {
+  /**
+   * Proxy class for ManagedChannel that makes closure a no-op.
+   */
+  @VisibleForTesting
+  static class ProxyManagedChannel extends ManagedChannel {
+    private final ManagedChannel channel;
+    private boolean isShutdown;
+
+    ProxyManagedChannel(ManagedChannel channel) {
+      this.channel = channel;
+      this.isShutdown = channel.isShutdown();
+    }
+
+    @Override
+    public ManagedChannel shutdown() {
+      isShutdown = true;
+      return this;
+    }
+
+    @Override
+    public boolean isShutdown() {
+      if (this.channel.isShutdown()) {
+        // If the underlying channel is shut down, ensure we're updated to match.
+        shutdown();
+      }
+      return isShutdown;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return this.isShutdown();
+    }
+
+    @Override
+    public ManagedChannel shutdownNow() {
+      return shutdown();
+    }
+
+    @Override
+    public boolean awaitTermination(long l, TimeUnit timeUnit) {
+      // Don't actually await termination, since it'll be a no-op, so simply return whether or not
+      // the channel has been shut down already.
+      return this.isShutdown();
+    }
+
+    @Override
+    public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(
+        MethodDescriptor<RequestT, ResponseT> methodDescriptor, CallOptions callOptions) {
+      if (this.isShutdown()) {
+        throw new IllegalStateException("Channel has been shut down.");
+      }
+
+      return this.channel.newCall(methodDescriptor, callOptions);
+    }
+
+    @Override
+    public String authority() {
+      return this.channel.authority();
+    }
+
+    @Override
+    public ConnectivityState getState(boolean requestConnection) {
+      if (this.isShutdown()) {
+        return ConnectivityState.SHUTDOWN;
+      }
+
+      return this.channel.getState(requestConnection);
+    }
+
+    @Override
+    public void notifyWhenStateChanged(ConnectivityState source, Runnable callback) {
+      // The proxy has no insight into the underlying channel state changes, so we'll have to leak the abstraction
+      // a bit here and simply pass to the underlying channel, even though it will never transition to shutdown via
+      // the proxy. This should be fine, since it's mainly targeted at the FlightClient and there's no getter for
+      // the channel.
+      this.channel.notifyWhenStateChanged(source, callback);
+    }
+
+    @Override
+    public void resetConnectBackoff() {
+      this.channel.resetConnectBackoff();
+    }
+
+    @Override
+    public void enterIdle() {
+      this.channel.enterIdle();
+    }
+  }
 
   private FlightGrpcUtils() {}
 
@@ -49,10 +143,10 @@ public class FlightGrpcUtils {
   /**
    * Creates a Flight client.
    * @param incomingAllocator  Memory allocator
-   * @param channel provides a connection to a gRPC server
+   * @param channel provides a connection to a gRPC server. Will not be closed on closure of the returned FlightClient.
    * @return FlightClient
    */
   public static FlightClient createFlightClient(BufferAllocator incomingAllocator, ManagedChannel channel) {
-    return new FlightClient(incomingAllocator, channel, Collections.emptyList());
+    return new FlightClient(incomingAllocator, new ProxyManagedChannel(channel), Collections.emptyList());
   }
 }

--- a/java/flight/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
+++ b/java/flight/flight-grpc/src/main/java/org/apache/arrow/flight/FlightGrpcUtils.java
@@ -40,11 +40,11 @@ public class FlightGrpcUtils {
    * Proxy class for ManagedChannel that makes closure a no-op.
    */
   @VisibleForTesting
-  static class ProxyManagedChannel extends ManagedChannel {
+  static class NonClosingProxyManagedChannel extends ManagedChannel {
     private final ManagedChannel channel;
     private boolean isShutdown;
 
-    ProxyManagedChannel(ManagedChannel channel) {
+    NonClosingProxyManagedChannel(ManagedChannel channel) {
       this.channel = channel;
       this.isShutdown = channel.isShutdown();
     }
@@ -143,10 +143,19 @@ public class FlightGrpcUtils {
   /**
    * Creates a Flight client.
    * @param incomingAllocator  Memory allocator
-   * @param channel provides a connection to a gRPC server. Will not be closed on closure of the returned FlightClient.
-   * @return FlightClient
+   * @param channel provides a connection to a gRPC server.
    */
   public static FlightClient createFlightClient(BufferAllocator incomingAllocator, ManagedChannel channel) {
-    return new FlightClient(incomingAllocator, new ProxyManagedChannel(channel), Collections.emptyList());
+    return new FlightClient(incomingAllocator, channel, Collections.emptyList());
+  }
+
+  /**
+   * Creates a Flight client.
+   * @param incomingAllocator  Memory allocator
+   * @param channel provides a connection to a gRPC server. Will not be closed on closure of the returned FlightClient.
+   */
+  public static FlightClient createFlightClientWithSharedChannel(
+      BufferAllocator incomingAllocator, ManagedChannel channel) {
+    return new FlightClient(incomingAllocator, new NonClosingProxyManagedChannel(channel), Collections.emptyList());
   }
 }

--- a/java/flight/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
+++ b/java/flight/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
@@ -26,12 +26,15 @@ import java.util.concurrent.Executors;
 import org.apache.arrow.flight.auth.ServerAuthHandler;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.google.protobuf.Empty;
 
 import io.grpc.BindableService;
+import io.grpc.ConnectivityState;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
 import io.grpc.inprocess.InProcessChannelBuilder;
@@ -42,6 +45,34 @@ import io.grpc.stub.StreamObserver;
  * Unit test which adds 2 services to same server end point.
  */
 public class TestFlightGrpcUtils {
+  private Server server;
+  private BufferAllocator allocator;
+  private String serverName;
+
+  @Before
+  public void setup() throws IOException {
+    //Defines flight service
+    allocator = new RootAllocator(Integer.MAX_VALUE);
+    final NoOpFlightProducer producer = new NoOpFlightProducer();
+    final ServerAuthHandler authHandler = ServerAuthHandler.NO_OP;
+    final ExecutorService exec = Executors.newCachedThreadPool();
+    final BindableService flightBindingService = FlightGrpcUtils.createFlightService(allocator, producer,
+        authHandler, exec);
+
+    //initializes server with 2 services - FlightBindingService & TestService
+    serverName = InProcessServerBuilder.generateName();
+    server = InProcessServerBuilder.forName(serverName)
+        .directExecutor()
+        .addService(flightBindingService)
+        .addService(new TestServiceAdapter())
+        .build();
+    server.start();
+  }
+
+  @After
+  public void cleanup() {
+    server.shutdownNow();
+  }
 
   /**
    * This test checks if multiple gRPC services can be added to the same
@@ -50,24 +81,6 @@ public class TestFlightGrpcUtils {
    */
   @Test
   public void testMultipleGrpcServices() throws IOException {
-
-    //Defines flight service
-    final BufferAllocator allocator = new RootAllocator(Integer.MAX_VALUE);
-    final NoOpFlightProducer producer = new NoOpFlightProducer();
-    final ServerAuthHandler authHandler = ServerAuthHandler.NO_OP;
-    final ExecutorService exec = Executors.newCachedThreadPool();
-    final BindableService flightBindingService = FlightGrpcUtils.createFlightService(allocator, producer,
-        authHandler, exec);
-
-    //initializes server with 2 services - FlightBindingService & TestService
-    final String serverName = InProcessServerBuilder.generateName();
-    final Server server = InProcessServerBuilder.forName(serverName)
-            .directExecutor()
-            .addService(flightBindingService)
-            .addService(new TestServiceAdapter())
-            .build();
-    server.start();
-
     //Initializes channel so that multiple clients can communicate with server
     final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
             .directExecutor()
@@ -83,6 +96,79 @@ public class TestFlightGrpcUtils {
     //Define Test client as a blocking stub and call test method which correctly returns an empty protobuf object
     final TestServiceGrpc.TestServiceBlockingStub blockingStub = TestServiceGrpc.newBlockingStub(managedChannel);
     Assert.assertEquals(Empty.newBuilder().build(), blockingStub.test(Empty.newBuilder().build()));
+  }
+
+  @Test
+  public void testShutdown() throws IOException, InterruptedException {
+    //Initializes channel so that multiple clients can communicate with server
+    final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
+        .directExecutor()
+        .build();
+
+    //Defines flight client and calls service method. Since we use a NoOpFlightProducer we expect the service
+    //to throw a RunTimeException
+    final FlightClient flightClient = FlightGrpcUtils.createFlightClient(allocator, managedChannel);
+
+    // Should be a no-op.
+    flightClient.close();
+    Assert.assertFalse(managedChannel.isShutdown());
+    Assert.assertFalse(managedChannel.isTerminated());
+    Assert.assertEquals(ConnectivityState.IDLE, managedChannel.getState(false));
+    managedChannel.shutdownNow();
+  }
+
+  @Test
+  public void testProxyChannel() throws IOException, InterruptedException {
+    //Initializes channel so that multiple clients can communicate with server
+    final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
+        .directExecutor()
+        .build();
+
+    final FlightGrpcUtils.ProxyManagedChannel proxyChannel = new FlightGrpcUtils.ProxyManagedChannel(managedChannel);
+    Assert.assertFalse(proxyChannel.isShutdown());
+    Assert.assertFalse(proxyChannel.isTerminated());
+    proxyChannel.shutdown();
+    Assert.assertTrue(proxyChannel.isShutdown());
+    Assert.assertTrue(proxyChannel.isTerminated());
+    Assert.assertEquals(ConnectivityState.SHUTDOWN, proxyChannel.getState(false));
+    try {
+      proxyChannel.newCall(null, null);
+      Assert.fail();
+    } catch (IllegalStateException e) {
+      // This is expected, since the proxy channel is shut down.
+    }
+
+    Assert.assertFalse(managedChannel.isShutdown());
+    Assert.assertFalse(managedChannel.isTerminated());
+    Assert.assertEquals(ConnectivityState.IDLE, managedChannel.getState(false));
+
+    managedChannel.shutdownNow();
+  }
+
+  @Test
+  public void testProxyChannelWithClosedChannel() throws IOException, InterruptedException {
+    //Initializes channel so that multiple clients can communicate with server
+    final ManagedChannel managedChannel = InProcessChannelBuilder.forName(serverName)
+        .directExecutor()
+        .build();
+
+    final FlightGrpcUtils.ProxyManagedChannel proxyChannel = new FlightGrpcUtils.ProxyManagedChannel(managedChannel);
+    Assert.assertFalse(proxyChannel.isShutdown());
+    Assert.assertFalse(proxyChannel.isTerminated());
+    managedChannel.shutdownNow();
+    Assert.assertTrue(proxyChannel.isShutdown());
+    Assert.assertTrue(proxyChannel.isTerminated());
+    Assert.assertEquals(ConnectivityState.SHUTDOWN, proxyChannel.getState(false));
+    try {
+      proxyChannel.newCall(null, null);
+      Assert.fail();
+    } catch (IllegalStateException e) {
+      // This is expected, since the proxy channel is shut down.
+    }
+
+    Assert.assertTrue(managedChannel.isShutdown());
+    Assert.assertTrue(managedChannel.isTerminated());
+    Assert.assertEquals(ConnectivityState.SHUTDOWN, managedChannel.getState(false));
   }
 
   /**

--- a/java/flight/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
+++ b/java/flight/flight-grpc/src/test/java/org/apache/arrow/flight/TestFlightGrpcUtils.java
@@ -107,7 +107,7 @@ public class TestFlightGrpcUtils {
 
     //Defines flight client and calls service method. Since we use a NoOpFlightProducer we expect the service
     //to throw a RunTimeException
-    final FlightClient flightClient = FlightGrpcUtils.createFlightClient(allocator, managedChannel);
+    final FlightClient flightClient = FlightGrpcUtils.createFlightClientWithSharedChannel(allocator, managedChannel);
 
     // Should be a no-op.
     flightClient.close();
@@ -124,7 +124,8 @@ public class TestFlightGrpcUtils {
         .directExecutor()
         .build();
 
-    final FlightGrpcUtils.ProxyManagedChannel proxyChannel = new FlightGrpcUtils.ProxyManagedChannel(managedChannel);
+    final FlightGrpcUtils.NonClosingProxyManagedChannel proxyChannel =
+        new FlightGrpcUtils.NonClosingProxyManagedChannel(managedChannel);
     Assert.assertFalse(proxyChannel.isShutdown());
     Assert.assertFalse(proxyChannel.isTerminated());
     proxyChannel.shutdown();
@@ -152,7 +153,8 @@ public class TestFlightGrpcUtils {
         .directExecutor()
         .build();
 
-    final FlightGrpcUtils.ProxyManagedChannel proxyChannel = new FlightGrpcUtils.ProxyManagedChannel(managedChannel);
+    final FlightGrpcUtils.NonClosingProxyManagedChannel proxyChannel =
+        new FlightGrpcUtils.NonClosingProxyManagedChannel(managedChannel);
     Assert.assertFalse(proxyChannel.isShutdown());
     Assert.assertFalse(proxyChannel.isTerminated());
     managedChannel.shutdownNow();


### PR DESCRIPTION
Add a proxy for ManagedChannel to prevent closure of shared 
channels when specified for FlightClient in FlightGrpcUtils.