### PR TITLE
ARROW-10483: [C++] Move Executor to future.h

### DIFF
--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -301,4 +301,6 @@ void FutureImpl::MarkFinished() { GetConcreteFuture(this)->DoMarkFinished(); }
 
 void FutureImpl::MarkFailed() { GetConcreteFuture(this)->DoMarkFailed(); }
 
+internal::Executor::~Executor() = default;
+
 }  // namespace arrow

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -32,10 +32,8 @@
 namespace arrow {
 namespace internal {
 
-Executor::~Executor() {}
-
 struct ThreadPool::State {
-  State() : desired_capacity_(0), please_shutdown_(false), quick_shutdown_(false) {}
+  State() = default;
 
   // NOTE: in case locking becomes too expensive, we can investigate lock-free FIFOs
   // such as https://github.com/cameron314/concurrentqueue
@@ -50,10 +48,10 @@ struct ThreadPool::State {
   std::deque<std::function<void()>> pending_tasks_;
 
   // Desired number of threads
-  int desired_capacity_;
+  int desired_capacity_ = 0;
   // Are we shutting down?
-  bool please_shutdown_;
-  bool quick_shutdown_;
+  bool please_shutdown_ = false;
+  bool quick_shutdown_ = false;
 };
 
 // The worker loop is an independent function so that it can keep running

--- a/cpp/src/arrow/util/type_fwd.h
+++ b/cpp/src/arrow/util/type_fwd.h
@@ -21,6 +21,7 @@ namespace arrow {
 
 template <typename T>
 class Future;
+class FutureWaiter;
 
 class TimestampParser;
 


### PR DESCRIPTION
This change is a supporting PR of ARROW-10183.

Moving `Executor` to future.h will allow continuations to specify where they should be executed with an `Executor*`.

This necessitated making ThreadPool a non-exported class; references to ThreadPool have been replaced with Executor. ThreadPool::SetCapacity is no longer public and only the main thread pool's capacity can be set (through SetCpuThreadPoolCapacity). ThreadPool::Shutdown is still public; it's now a part of the Executor interface. I'm not 100% confident these are the correct interface decisions:
- Should SetCapacity be part of the interface of any Executor?
- Shutdown is only referenced in tests and benchmarks, is in necessary?