### PR TITLE
Arrow 10427: [Flight][Java] Add optional session header

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightConstants.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightConstants.java
@@ -23,7 +23,7 @@ package org.apache.arrow.flight;
 public interface FlightConstants {
 
   String SERVICE = "arrow.flight.protocol.FlightService";
-  String SET_SESSION_HEADER = "set-session";
-  String SESSION_HEADER = "session";
+  String SET_SESSION_HEADER = "Set-Session";
+  String SESSION_HEADER = "Session";
 
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
@@ -199,7 +199,7 @@ public class FlightServer implements AutoCloseable {
       }
 
       if (sessionHandler != ServerSessionHandler.NO_OP) {
-        this.middleware(FlightServerMiddleware.Key.of(FlightConstants.SESSION_HEADER),
+        this.middleware(FlightServerMiddleware.Key.of(FlightConstants.SET_SESSION_HEADER),
                 new ServerSessionMiddleware.Factory(sessionHandler));
       }
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightServer.java
@@ -168,6 +168,7 @@ public class FlightServer implements AutoCloseable {
     private final Map<String, Object> builderOptions;
     private ServerAuthHandler authHandler = ServerAuthHandler.NO_OP;
     private CallHeaderAuthenticator headerAuthenticator = CallHeaderAuthenticator.NO_OP;
+    private ServerSessionHandler sessionHandler = ServerSessionHandler.NO_OP;
     private ExecutorService executor = null;
     private int maxInboundMessageSize = MAX_GRPC_MESSAGE_SIZE;
     private InputStream certChain;
@@ -196,6 +197,12 @@ public class FlightServer implements AutoCloseable {
         this.middleware(FlightServerMiddleware.Key.of(Auth2Constants.AUTHORIZATION_HEADER),
             new ServerCallHeaderAuthMiddleware.Factory(headerAuthenticator));
       }
+
+      if (sessionHandler != ServerSessionHandler.NO_OP) {
+        this.middleware(FlightServerMiddleware.Key.of(FlightConstants.SESSION_HEADER),
+                new ServerSessionMiddleware.Factory(sessionHandler));
+      }
+
       final NettyServerBuilder builder;
       switch (location.getUri().getScheme()) {
         case LocationSchemes.GRPC_DOMAIN_SOCKET: {
@@ -348,6 +355,14 @@ public class FlightServer implements AutoCloseable {
      */
     public Builder headerAuthenticator(CallHeaderAuthenticator headerAuthenticator) {
       this.headerAuthenticator = headerAuthenticator;
+      return this;
+    }
+
+    /**
+     * Set the session handler.
+     */
+    public Builder sessionHandler(ServerSessionHandler sessionHandler) {
+      this.sessionHandler = sessionHandler;
       return this;
     }
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionHandler.java
@@ -38,9 +38,9 @@ public interface ServerSessionHandler {
   };
 
   /**
-   * Creates and return the session ID.
+   * Creates and return the session.
    *
-   * @return the session ID for the current session.
+   * @return the session for the current session.
    */
   String beginSession(CallHeaders headers);
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionHandler.java
@@ -27,7 +27,7 @@ public interface ServerSessionHandler {
    */
   ServerSessionHandler NO_OP = new ServerSessionHandler() {
     @Override
-    public String getSessionID() {
+    public String getSessionId() {
           return null;
       }
 
@@ -44,7 +44,7 @@ public interface ServerSessionHandler {
    * @return the current session ID.
    * @throws FlightRuntimeException with CallStatus {@code UNAUTHENTICATED} if session ID has expired.
    */
-  String getSessionID();
+  String getSessionId();
 
   /**
    * Validates an incoming session ID. Returns true if sessionId is valid; returns false otherwise.

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionHandler.java
@@ -18,7 +18,7 @@
 package org.apache.arrow.flight;
 
 /**
- * ServerSessionHandler interface to retrieve the current session ID.
+ * ServerSessionHandler interface to retrieve the current session.
  */
 public interface ServerSessionHandler {
   /**
@@ -27,30 +27,32 @@ public interface ServerSessionHandler {
    */
   ServerSessionHandler NO_OP = new ServerSessionHandler() {
     @Override
-    public String getSessionId() {
-          return null;
-      }
+    public String beginSession(CallHeaders headers) {
+      return null;
+    }
 
     @Override
-    public boolean isValid(String sessionId) {
-          return false;
-      }
+    public String getSession(CallHeaders headers) {
+      return null;
+    }
   };
 
   /**
-   * Retrieves the current session ID. Generates a new session ID if there is no pre-existing
-   * session ID.
+   * Creates and return the session ID.
    *
-   * @return the current session ID.
-   * @throws FlightRuntimeException with CallStatus {@code UNAUTHENTICATED} if session ID has expired.
+   * @return the session ID for the current session.
    */
-  String getSessionId();
+  String beginSession(CallHeaders headers);
 
   /**
-   * Validates an incoming session ID. Returns true if sessionId is valid; returns false otherwise.
+   * Retrieves the current session for the corresponding client.
    *
-   * @param sessionId the incoming session ID to validate.
-   * @return true if incoming session ID is valid; false otherwise.
+   * @param headers CallHeaders to inspect.
+   * @return the corresponding session.
+   * @throws FlightRuntimeException
+   *     with CallStatus {@code UNAUTHENTICATED} if the session has expired.
+   *     with CallStatus {@code INVALID_ARGUMENT} if the session header contains unrecognised properties.
+   *     with CallStatus {@code NOT_FOUND} if the session header is not found.
    */
-  boolean isValid(String sessionId);
+  String getSession(CallHeaders headers);
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionHandler.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionHandler.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+/**
+ * ServerSessionHandler interface to retrieve the current session ID.
+ */
+public interface ServerSessionHandler {
+  /**
+   * A session handler that does not support sessions.
+   * It is used as the default handler for a Flight server with no session capabilities.
+   */
+  ServerSessionHandler NO_OP = new ServerSessionHandler() {
+    @Override
+    public String getSessionID() {
+          return null;
+      }
+
+    @Override
+    public boolean isValid(String sessionId) {
+          return false;
+      }
+  };
+
+  /**
+   * Retrieves the current session ID. Generates a new session ID if there is no pre-existing
+   * session ID.
+   *
+   * @return the current session ID.
+   * @throws FlightRuntimeException with CallStatus {@code UNAUTHENTICATED} if session ID has expired.
+   */
+  String getSessionID();
+
+  /**
+   * Validates an incoming session ID. Returns true if sessionId is valid; returns false otherwise.
+   *
+   * @param sessionId the incoming session ID to validate.
+   * @return true if incoming session ID is valid; false otherwise.
+   */
+  boolean isValid(String sessionId);
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+/**
+ * Middleware to add a SET-SESSION header.
+ */
+public class ServerSessionMiddleware implements FlightServerMiddleware {
+
+  /**
+   * Factory class to provide instances of ServerSessionMiddleware for each call.
+   */
+  public static class Factory implements FlightServerMiddleware.Factory<ServerSessionMiddleware> {
+    private final ServerSessionHandler sessionHandler;
+
+    public Factory(ServerSessionHandler sessionHandler) {
+      this.sessionHandler = sessionHandler;
+    }
+
+    @Override
+    public ServerSessionMiddleware onCallStarted(CallInfo info, CallHeaders incomingHeaders,
+                                                 RequestContext context) {
+      if (incomingHeaders.containsKey(FlightConstants.SESSION_HEADER)) {
+        // Client is re-using pre-existing session ID.
+        // ServerSessionHandler validates client session ID before proceeding.
+        final String sessionId = incomingHeaders.get(FlightConstants.SESSION_HEADER);
+        if (!sessionHandler.isValid(sessionId)) {
+          throw CallStatus.UNAUTHENTICATED.toRuntimeException();
+        }
+      } else {
+        // Insert SET-SESSION header if ServerSessionHandler returns a non-null session ID.
+        final String sessionId = sessionHandler.getSessionID();
+        if (sessionId != null) {
+          incomingHeaders.insert(FlightConstants.SESSION_HEADER, sessionId);
+        }
+      }
+
+      return new ServerSessionMiddleware(sessionHandler);
+    }
+  }
+
+  private ServerSessionHandler sessionHandler;
+
+  private ServerSessionMiddleware(ServerSessionHandler sessionHandler) {
+    this.sessionHandler = sessionHandler;
+  }
+
+  @Override
+  public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
+    String sessionId = sessionHandler.getSessionID();
+    if (sessionId != null) {
+      outgoingHeaders.insert(FlightConstants.SESSION_HEADER, sessionId);
+    }
+  }
+
+  @Override
+  public void onCallCompleted(CallStatus status) {
+    // No-op
+  }
+
+  @Override
+  public void onCallErrored(Throwable err) {
+    // No-op
+  }
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/ServerSessionMiddleware.java
@@ -36,15 +36,16 @@ public class ServerSessionMiddleware implements FlightServerMiddleware {
     public ServerSessionMiddleware onCallStarted(CallInfo info, CallHeaders incomingHeaders,
                                                  RequestContext context) {
       if (incomingHeaders.containsKey(FlightConstants.SESSION_HEADER)) {
-        // Client is re-using pre-existing session ID.
+        // Client is re-using existing session ID.
         // ServerSessionHandler validates client session ID before proceeding.
-        final String sessionId = incomingHeaders.get(FlightConstants.SESSION_HEADER);
-        if (!sessionHandler.isValid(sessionId)) {
+        final String existingSessionId = incomingHeaders.get(FlightConstants.SESSION_HEADER);
+        if (!sessionHandler.isValid(existingSessionId)) {
           throw CallStatus.UNAUTHENTICATED.toRuntimeException();
         }
       } else {
+        // No existing session ID provided, establishing a new session.
         // Insert SET-SESSION header if ServerSessionHandler returns a non-null session ID.
-        final String sessionId = sessionHandler.getSessionID();
+        final String sessionId = sessionHandler.getSessionId();
         if (sessionId != null) {
           incomingHeaders.insert(FlightConstants.SESSION_HEADER, sessionId);
         }
@@ -62,7 +63,7 @@ public class ServerSessionMiddleware implements FlightServerMiddleware {
 
   @Override
   public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
-    String sessionId = sessionHandler.getSessionID();
+    String sessionId = sessionHandler.getSessionId();
     if (sessionId != null) {
       outgoingHeaders.insert(FlightConstants.SESSION_HEADER, sessionId);
     }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionMiddleware.java
@@ -56,10 +56,8 @@ public class ClientSessionMiddleware implements FlightClientMiddleware {
 
   @Override
   public void onHeadersReceived(CallHeaders incomingHeaders) {
-    final String sessionId = incomingHeaders.get(FlightConstants.SESSION_HEADER);
-    if (sessionId != null) {
-      sessionWriter.setSessionId(sessionId);
-    }
+    final String sessionId = incomingHeaders.get(FlightConstants.SET_SESSION_HEADER);
+    sessionWriter.setSession(sessionId);
   }
 
   @Override

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionMiddleware.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.client;
+
+import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.CallInfo;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.FlightClientMiddleware;
+import org.apache.arrow.flight.FlightConstants;
+
+/**
+ * Client middleware to re-use the existing session ID provided by the server.
+ */
+public class ClientSessionMiddleware implements FlightClientMiddleware {
+  /**
+   * Factory to create instances of ClientSessionMiddleware for each call.
+   */
+  public static class Factory implements FlightClientMiddleware.Factory {
+    private final ClientSessionWriter sessionWriter;
+
+    public Factory() {
+      sessionWriter = new ClientSessionWriter();
+    }
+
+    @Override
+    public FlightClientMiddleware onCallStarted(CallInfo info) {
+      return new ClientSessionMiddleware(sessionWriter);
+    }
+  }
+
+  private final ClientSessionWriter sessionWriter;
+
+  public ClientSessionMiddleware(ClientSessionWriter sessionWriter) {
+    this.sessionWriter = sessionWriter;
+  }
+
+  @Override
+  public void onBeforeSendingHeaders(CallHeaders outgoingHeaders) {
+    sessionWriter.accept(outgoingHeaders);
+  }
+
+  @Override
+  public void onHeadersReceived(CallHeaders incomingHeaders) {
+    final String sessionId = incomingHeaders.get(FlightConstants.SESSION_HEADER);
+    if (sessionId != null) {
+      sessionWriter.setSessionId(sessionId);
+    }
+  }
+
+  @Override
+  public void onCallCompleted(CallStatus status) {
+    // No-op
+  }
+}

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionMiddleware.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionMiddleware.java
@@ -24,7 +24,7 @@ import org.apache.arrow.flight.FlightClientMiddleware;
 import org.apache.arrow.flight.FlightConstants;
 
 /**
- * Client middleware to re-use the existing session ID provided by the server.
+ * Client middleware to re-use the existing session provided by the server.
  */
 public class ClientSessionMiddleware implements FlightClientMiddleware {
   /**

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionWriter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionWriter.java
@@ -20,7 +20,6 @@ package org.apache.arrow.flight.client;
 import java.util.function.Consumer;
 
 import org.apache.arrow.flight.CallHeaders;
-import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightConstants;
 import org.apache.arrow.util.VisibleForTesting;
 
@@ -28,45 +27,33 @@ import org.apache.arrow.util.VisibleForTesting;
  * Session ID from the server.
  */
 public class ClientSessionWriter implements Consumer<CallHeaders> {
-  private volatile String sessionId;
+  private volatile String session;
 
   /**
-   * Retrieves the current stored session ID.
+   * Retrieves the current stored session.
    *
-   * @return the current session ID.
+   * @return the current session.
    */
   @VisibleForTesting
-  public String getSessionId() {
-    return this.sessionId;
+  public String getSession() {
+    return this.session;
   }
 
   /**
-   * Sets the session ID.
+   * Sets the session.
    *
-   * The session ID is not available when the ClientSessionWriter is instantiated.
-   * The setting of session ID is deferred until one is provided by the server.
-   *
-   * @param sessionId the session ID from the server.
-   * @throws org.apache.arrow.flight.FlightRuntimeException if session ID provided does not match the
-   *         the existing session ID stored in this ClientSessionWriter.
+   * @param session the session from the server.
    */
-  public void setSessionId(String sessionId) {
+  public void setSession(String session) {
     synchronized (this) {
-      if (this.sessionId != null) {
-        if (!sessionId.equals(this.sessionId)) {
-          throw CallStatus.UNAUTHENTICATED.toRuntimeException();
-        }
-      } else {
-        this.sessionId = sessionId;
-      }
-
+      this.session = session;
     }
   }
 
   @Override
   public void accept(CallHeaders outgoingHeaders) {
-    if (sessionId != null) {
-      outgoingHeaders.insert(FlightConstants.SESSION_HEADER, sessionId);
+    if (session != null) {
+      outgoingHeaders.insert(FlightConstants.SESSION_HEADER, session);
     }
   }
 }

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionWriter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionWriter.java
@@ -24,7 +24,7 @@ import org.apache.arrow.flight.FlightConstants;
 import org.apache.arrow.util.VisibleForTesting;
 
 /**
- * Session ID from the server.
+ * Caches session from the server.
  */
 public class ClientSessionWriter implements Consumer<CallHeaders> {
   private volatile String session;

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionWriter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/client/ClientSessionWriter.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.client;
+
+import java.util.function.Consumer;
+
+import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.CallStatus;
+import org.apache.arrow.flight.FlightConstants;
+import org.apache.arrow.util.VisibleForTesting;
+
+/**
+ * Session ID from the server.
+ */
+public class ClientSessionWriter implements Consumer<CallHeaders> {
+  private volatile String sessionId;
+
+  /**
+   * Retrieves the current stored session ID.
+   *
+   * @return the current session ID.
+   */
+  @VisibleForTesting
+  public String getSessionId() {
+    return this.sessionId;
+  }
+
+  /**
+   * Sets the session ID.
+   *
+   * The session ID is not available when the ClientSessionWriter is instantiated.
+   * The setting of session ID is deferred until one is provided by the server.
+   *
+   * @param sessionId the session ID from the server.
+   * @throws org.apache.arrow.flight.FlightRuntimeException if session ID provided does not match the
+   *         the existing session ID stored in this ClientSessionWriter.
+   */
+  public void setSessionId(String sessionId) {
+    synchronized (this) {
+      if (this.sessionId != null) {
+        if (!sessionId.equals(this.sessionId)) {
+          throw CallStatus.UNAUTHENTICATED.toRuntimeException();
+        }
+      } else {
+        this.sessionId = sessionId;
+      }
+
+    }
+  }
+
+  @Override
+  public void accept(CallHeaders outgoingHeaders) {
+    if (sessionId != null) {
+      outgoingHeaders.insert(FlightConstants.SESSION_HEADER, sessionId);
+    }
+  }
+}

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
@@ -17,12 +17,5 @@
 
 package org.apache.arrow.flight;
 
-/**
- * String constants relevant to flight implementations.
- */
-public interface FlightConstants {
-
-  String SERVICE = "arrow.flight.protocol.FlightService";
-  String SESSION_HEADER = "SET-SESSION";
-
+public class TestServerSessionHandling {
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
@@ -127,7 +127,7 @@ public class TestServerSessionHandling {
   }
 
   @Test
-  public void testClientReuseValidSessionId() {
+  public void testClientReuseValidSession() {
     // Setup
     ServerSessionMiddleware.Factory factory =
         new ServerSessionMiddleware.Factory(new SimpleServerSessionHandler());

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
@@ -17,5 +17,34 @@
 
 package org.apache.arrow.flight;
 
+import org.junit.Test;
+
+/**
+ * Tests for ServerSessionHandler and ServerSessionMiddleware.
+ */
 public class TestServerSessionHandling {
+  @Test
+  public void testNoOpSessionHandler() {
+    // TODO
+  }
+
+  @Test
+  public void testInitialSessionId() {
+    // TODO
+  }
+
+  @Test
+  public void testClientReuseValidSessionId() {
+    // TODO
+  }
+
+  @Test
+  public void testClientProvideFalseSessionId() {
+    // TODO
+  }
+
+  @Test
+  public void testSessionHeaderToClient() {
+    // TODO
+  }
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
@@ -33,8 +33,8 @@ import com.google.common.collect.ImmutableList;
  * Tests for ServerSessionHandler and ServerSessionMiddleware.
  */
 public class TestServerSessionHandling {
-  private static final String SESSION_HEADER_KEY = "session";
-  private static final String SET_SESSION_HEADER_KEY = "set-session";
+  private static final String SESSION_HEADER_KEY = "Session";
+  private static final String SET_SESSION_HEADER_KEY = "Set-Session";
   private static final String TEST_SESSION = "name=test-session;id=session-id;max-age=100";
   private static final List<String> VALID_PROPERTY_KEYS = ImmutableList.of(
           "name",

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestServerSessionHandling.java
@@ -17,34 +17,143 @@
 
 package org.apache.arrow.flight;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import org.apache.arrow.flight.grpc.RequestContextAdapter;
 import org.junit.Test;
+
+import com.google.common.collect.Iterators;
 
 /**
  * Tests for ServerSessionHandler and ServerSessionMiddleware.
  */
 public class TestServerSessionHandling {
+  private static final String SESSION_HEADER_KEY = "SET-SESSION";
+  private static final String TEST_SESSION_ID = "test-session-id";
+
+  private class SimpleServerSessionHandler implements ServerSessionHandler {
+    private String sessionId;
+
+    public SimpleServerSessionHandler() {
+      this.sessionId = null;
+    }
+
+    @Override
+    public String getSessionId() {
+      if (sessionId == null) {
+        this.sessionId = TEST_SESSION_ID;
+      }
+      return sessionId;
+    }
+
+    @Override
+    public boolean isValid(String sessionId) {
+      // The sessionId never expires in this simple test implementation.
+      // Production implementations should provide expiration validation.
+      return sessionId.equals(this.sessionId);
+    }
+  }
+
+  private ServerSessionMiddleware onCallStarted(ServerSessionMiddleware.Factory factory,
+                                                CallHeaders headers) {
+    // Use dummy CallInfo and RequestContext object.
+    return factory.onCallStarted(new CallInfo(FlightMethod.DO_ACTION),
+            headers, new RequestContextAdapter());
+  }
+
+  private void testFailed() throws Exception {
+    throw new Exception("Test failed, expected exception.");
+  }
+
   @Test
-  public void testNoOpSessionHandler() {
-    // TODO
+  public void testNoOpSessionHandlerInitial() {
+    // Setup
+    ServerSessionMiddleware.Factory factory =
+        new ServerSessionMiddleware.Factory(ServerSessionHandler.NO_OP);
+    CallHeaders headers = new ErrorFlightMetadata();
+    onCallStarted(factory, headers);
+
+    // Test
+    assertFalse(headers.containsKey(SESSION_HEADER_KEY));
+  }
+
+  @Test
+  public void testNoOpSessionHandlerHeaderToClient() {
+    // Setup
+    ServerSessionMiddleware.Factory factory =
+        new ServerSessionMiddleware.Factory(ServerSessionHandler.NO_OP);
+    CallHeaders headers = new ErrorFlightMetadata();
+    ServerSessionMiddleware middleware = onCallStarted(factory, headers);
+    CallHeaders headersToClient = new ErrorFlightMetadata();
+    middleware.onBeforeSendingHeaders(headersToClient);
+
+    // Test
+    assertFalse(headers.containsKey(SESSION_HEADER_KEY));
+    assertFalse(headersToClient.containsKey(SESSION_HEADER_KEY));
   }
 
   @Test
   public void testInitialSessionId() {
-    // TODO
-  }
+    // Setup
+    ServerSessionMiddleware.Factory factory =
+        new ServerSessionMiddleware.Factory(new SimpleServerSessionHandler());
+    CallHeaders headers = new ErrorFlightMetadata();
+    onCallStarted(factory, headers);
 
-  @Test
-  public void testClientReuseValidSessionId() {
-    // TODO
-  }
-
-  @Test
-  public void testClientProvideFalseSessionId() {
-    // TODO
+    // Test
+    assertEquals(TEST_SESSION_ID, headers.get(SESSION_HEADER_KEY));
   }
 
   @Test
   public void testSessionHeaderToClient() {
-    // TODO
+    // Setup
+    ServerSessionMiddleware.Factory factory =
+        new ServerSessionMiddleware.Factory(new SimpleServerSessionHandler());
+    CallHeaders headers = new ErrorFlightMetadata();
+    ServerSessionMiddleware middleware = onCallStarted(factory, headers);
+    CallHeaders headersToClient = new ErrorFlightMetadata();
+    middleware.onBeforeSendingHeaders(headersToClient);
+
+    // Test
+    assertEquals(TEST_SESSION_ID, headers.get(SESSION_HEADER_KEY));
+    assertEquals(TEST_SESSION_ID, headersToClient.get(SESSION_HEADER_KEY));
+  }
+
+  @Test
+  public void testClientReuseValidSessionId() {
+    // Setup
+    ServerSessionMiddleware.Factory factory =
+        new ServerSessionMiddleware.Factory(new SimpleServerSessionHandler());
+    CallHeaders initialHeaders = new ErrorFlightMetadata();
+    onCallStarted(factory, initialHeaders);
+
+    CallHeaders nextCallHeaders = new ErrorFlightMetadata();
+    nextCallHeaders.insert(SESSION_HEADER_KEY, TEST_SESSION_ID);
+    onCallStarted(factory, nextCallHeaders);
+
+    // Test
+    assertEquals(1, Iterators.size(initialHeaders.getAll(SESSION_HEADER_KEY).iterator()));
+    assertEquals(TEST_SESSION_ID, initialHeaders.get(SESSION_HEADER_KEY));
+    assertEquals(1, Iterators.size(nextCallHeaders.getAll(SESSION_HEADER_KEY).iterator()));
+    assertEquals(TEST_SESSION_ID, nextCallHeaders.get(SESSION_HEADER_KEY));
+
+  }
+
+  @Test
+  public void testClientProvideFalseSessionId() throws Exception {
+    // Setup
+    ServerSessionMiddleware.Factory factory =
+        new ServerSessionMiddleware.Factory(new SimpleServerSessionHandler());
+    CallHeaders headers = new ErrorFlightMetadata();
+    headers.insert(SESSION_HEADER_KEY, "invalid-session-id-from-client");
+
+    // Test
+    try {
+      onCallStarted(factory, headers);
+      testFailed();
+    } catch (FlightRuntimeException ex) {
+      assertEquals(FlightStatusCode.UNAUTHENTICATED, ex.status().code());
+    }
   }
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestSessions.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestSessions.java
@@ -17,13 +17,5 @@
 
 package org.apache.arrow.flight;
 
-/**
- * String constants relevant to flight implementations.
- */
-public interface FlightConstants {
-
-  String SERVICE = "arrow.flight.protocol.FlightService";
-  String SET_SESSION_HEADER = "set-session";
-  String SESSION_HEADER = "session";
-
+public class TestSessions {
 }

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestClientSessionHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestClientSessionHandling.java
@@ -27,8 +27,8 @@ import org.junit.Test;
  * Tests for ClientSessionWriter and ClientSessionMiddleware.
  */
 public class TestClientSessionHandling {
-  private static final String SET_SESSION_HEADER_KEY = "set-session";
-  private static final String SESSION_HEADER_KEY = "session";
+  private static final String SET_SESSION_HEADER_KEY = "Set-Session";
+  private static final String SESSION_HEADER_KEY = "Session";
 
   @Test
   public void testSimpleOnHeadersReceived() {

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestClientSessionHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestClientSessionHandling.java
@@ -59,7 +59,7 @@ public class TestClientSessionHandling {
   }
 
   @Test
-  public void testSessionIdPersistence() {
+  public void testSessionPersistence() {
     // Setup
     final ClientSessionWriter writer = new ClientSessionWriter();
     final ClientSessionMiddleware middleware = new ClientSessionMiddleware(writer);

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestClientSessionHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestClientSessionHandling.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight.client;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.arrow.flight.CallHeaders;
+import org.apache.arrow.flight.ErrorFlightMetadata;
+import org.apache.arrow.flight.FlightRuntimeException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TestClientSessionHandling {
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private static final String SESSION_HEADER_KEY = "SET-SESSION";
+
+  @Test
+  public void testSimpleOnHeadersReceived() {
+    // Setup
+    final ClientSessionWriter writer = new ClientSessionWriter();
+    final ClientSessionMiddleware middleware = new ClientSessionMiddleware(writer);
+    final CallHeaders headers = new ErrorFlightMetadata();
+    final String sessionId = "test-session-id";
+    headers.insert(SESSION_HEADER_KEY, sessionId);
+
+    // Test
+    middleware.onHeadersReceived(headers);
+    assertEquals(sessionId, writer.getSessionId());
+  }
+
+  @Test
+  public void testSimpleOnBeforeSendingHeaders() {
+    // Setup
+    final ClientSessionWriter writer = new ClientSessionWriter();
+    final ClientSessionMiddleware middleware = new ClientSessionMiddleware(writer);
+    final CallHeaders headers = new ErrorFlightMetadata();
+    final String sessionId = "test-session-id";
+    writer.setSessionId(sessionId);
+
+    // Test
+    middleware.onBeforeSendingHeaders(headers);
+    assertEquals(sessionId, headers.get(SESSION_HEADER_KEY));
+  }
+
+  @Test
+  public void testSessionIdPersistence() {
+    // Setup
+    final ClientSessionWriter writer = new ClientSessionWriter();
+    final ClientSessionMiddleware middleware = new ClientSessionMiddleware(writer);
+    final CallHeaders receivedHeaders = new ErrorFlightMetadata();
+    final String sessionId = "test-session-id";
+    receivedHeaders.insert(SESSION_HEADER_KEY, sessionId);
+    final CallHeaders outgoingHeaders = new ErrorFlightMetadata();
+
+    // Test
+    middleware.onHeadersReceived(receivedHeaders);
+    assertEquals(sessionId, writer.getSessionId());
+
+    middleware.onBeforeSendingHeaders(outgoingHeaders);
+    assertEquals(sessionId, outgoingHeaders.get(SESSION_HEADER_KEY));
+  }
+
+  @Test
+  public void testReceivingDifferentSessionId() {
+    // Setup
+    final ClientSessionWriter writer = new ClientSessionWriter();
+    final ClientSessionMiddleware middleware = new ClientSessionMiddleware(writer);
+
+    final CallHeaders receivedHeaders = new ErrorFlightMetadata();
+    final String sessionId = "test-session-id";
+    receivedHeaders.insert(SESSION_HEADER_KEY, sessionId);
+
+    final CallHeaders outgoingHeaders = new ErrorFlightMetadata();
+
+    final CallHeaders receivedHeadersWithFalseId = new ErrorFlightMetadata();
+    final String falseSessionId = "test-session-id-false";
+    receivedHeadersWithFalseId.insert(SESSION_HEADER_KEY, falseSessionId);
+
+    // Test
+    middleware.onHeadersReceived(receivedHeaders);
+    assertEquals(sessionId, writer.getSessionId());
+
+    middleware.onBeforeSendingHeaders(outgoingHeaders);
+    assertEquals(sessionId, outgoingHeaders.get(SESSION_HEADER_KEY));
+
+    thrown.expect(FlightRuntimeException.class);
+    middleware.onHeadersReceived(receivedHeadersWithFalseId);
+  }
+}

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestClientSessionHandling.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/client/TestClientSessionHandling.java
@@ -26,6 +26,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+/**
+ * Tests for ClientSessionWriter and ClientSessionMiddleware.
+ */
 public class TestClientSessionHandling {
   @Rule
   public ExpectedException thrown = ExpectedException.none();


### PR DESCRIPTION
- Add ClientSessionMiddleware and ClientSessionWriter to support session ID re-use.
- Add ServerSessionMiddleware and ServerSessionHandler API to enable sessions.
- Unit tests for ClientSessionMiddleware and ClientSessionWriter.
- Unit tests for ServerSessionMiddleware and ServerSessionHandler API.
- TODO: End-to-end tests 