### PR TITLE
ARROW-10490: [CI] pin Xcode 11.7 (the new default 12.0.1 does not build)

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -207,6 +207,8 @@ jobs:
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_ZLIB: ON
       ARROW_WITH_ZSTD: ON
+      # Pin Xcode to 11.7 instead of the default of 12.0.1
+      DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -136,6 +136,8 @@ jobs:
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
       CMAKE_ARGS: "-DPYTHON_EXECUTABLE=/usr/local/bin/python3"
+      # Pin Xcode to 11.7 instead of the default of 12.0.1
+      DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -118,6 +118,8 @@ jobs:
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_ZLIB: ON
       ARROW_WITH_ZSTD: ON
+      # Pin Xcode to 11.7 instead of the default of 12.0.1
+      DEVELOPER_DIR: /Applications/Xcode_11.7.app/Contents/Developer
       XML_CATALOG_FILES: /usr/local/etc/xml/catalog
     steps:
       - name: Checkout Arrow


### PR DESCRIPTION
Xcode for GitHub actions has been changed to default to Xcode 12.0.1 (https://github.com/actions/virtual-environments/issues/1712), but this breaks the build. This change pins builds to Xcode 11.7 until it can be fixed.