### PR TITLE
ARROW-10475: [C++][FlightRPC] handle IPv6 hosts

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -876,7 +876,8 @@ class FlightClient::FlightClientImpl {
     std::stringstream grpc_uri;
     std::shared_ptr<grpc::ChannelCredentials> creds;
     if (scheme == kSchemeGrpc || scheme == kSchemeGrpcTcp || scheme == kSchemeGrpcTls) {
-      grpc_uri << location.uri_->host() << ":" << location.uri_->port_text();
+      grpc_uri << arrow::internal::UriEncodeHost(location.uri_->host()) << ':'
+               << location.uri_->port_text();
 
       if (scheme == kSchemeGrpcTls) {
         if (options.disable_server_verification) {

--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -289,6 +289,23 @@ TEST(TestFlight, GetPort) {
   ASSERT_GT(server->port(), 0);
 }
 
+// CI environments don't have an IPv6 interface configured
+TEST(TestFlight, DISABLED_IpV6Port) {
+  Location location, location2;
+  std::unique_ptr<FlightServerBase> server = ExampleTestServer();
+
+  ASSERT_OK(Location::ForGrpcTcp("[::1]", 0, &location));
+  FlightServerOptions options(location);
+  ASSERT_OK(server->Init(options));
+  ASSERT_GT(server->port(), 0);
+
+  ASSERT_OK(Location::ForGrpcTcp("[::1]", server->port(), &location2));
+  std::unique_ptr<FlightClient> client;
+  ASSERT_OK(FlightClient::Connect(location2, &client));
+  std::unique_ptr<FlightListing> listing;
+  ASSERT_OK(client->ListFlights(&listing));
+}
+
 TEST(TestFlight, BuilderHook) {
   Location location;
   std::unique_ptr<FlightServerBase> server = ExampleTestServer();

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -822,7 +822,8 @@ Status FlightServerBase::Init(const FlightServerOptions& options) {
   const std::string scheme = location.scheme();
   if (scheme == kSchemeGrpc || scheme == kSchemeGrpcTcp || scheme == kSchemeGrpcTls) {
     std::stringstream address;
-    address << location.uri_->host() << ':' << location.uri_->port_text();
+    address << arrow::internal::UriEncodeHost(location.uri_->host()) << ':'
+            << location.uri_->port_text();
 
     std::shared_ptr<grpc::ServerCredentials> creds;
     if (scheme == kSchemeGrpcTls) {

--- a/cpp/src/arrow/util/uri.cc
+++ b/cpp/src/arrow/util/uri.cc
@@ -80,6 +80,19 @@ std::string UriEscape(const std::string& s) {
   return escaped;
 }
 
+std::string UriEncodeHost(const std::string& host) {
+  // Fairly naive check: if it contains a ':', it's IPv6 and needs
+  // brackets, else it's OK
+  if (host.find(":") != std::string::npos) {
+    std::string result = "[";
+    result += host;
+    result += ']';
+    return result;
+  } else {
+    return host;
+  }
+}
+
 struct Uri::Impl {
   Impl() : string_rep_(""), port_(-1) { memset(&uri_, 0, sizeof(uri_)); }
 

--- a/cpp/src/arrow/util/uri.h
+++ b/cpp/src/arrow/util/uri.h
@@ -91,5 +91,10 @@ class ARROW_EXPORT Uri {
 ARROW_EXPORT
 std::string UriEscape(const std::string& s);
 
+/// Encode a host for use within a URI, such as "localhost",
+/// "127.0.0.1", or "[::1]".
+ARROW_EXPORT
+std::string UriEncodeHost(const std::string& host);
+
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/uri_test.cc
+++ b/cpp/src/arrow/util/uri_test.cc
@@ -35,6 +35,12 @@ TEST(UriEscape, Basics) {
   ASSERT_EQ(UriEscape("/El Niño/"), "%2FEl%20Ni%C3%B1o%2F");
 }
 
+TEST(UriEncodeHost, Basics) {
+  ASSERT_EQ(UriEncodeHost("::1"), "[::1]");
+  ASSERT_EQ(UriEscape("arrow.apache.org"), "arrow.apache.org");
+  ASSERT_EQ(UriEscape("192.168.1.1"), "192.168.1.1");
+}
+
 TEST(Uri, Empty) {
   Uri uri;
   ASSERT_EQ(uri.scheme(), "");


### PR DESCRIPTION
uriparser has a more detailed hostData struct that exposes whether the host is IPv4, IPv6, or something else, but doesn't provide apparent ways to convert back. There's also already tests for the current behavior (IPv6 host gets returned without brackets). If we don't care about those tests, we can simply check if uriparser thinks the host is IPv6, and if so, add the brackets back, without writing an IPv6/IPv4 address formatter. (Though that's technically wrong, I suppose - the host is really the unbracketed address, and the brackets only come into play when formatted as a URI.) 

Otherwise, here I check if the host looks like IPv6 inside Flight and add the brackets back.