### PR TITLE
ARROW-10491: [FlightRPC][Java] Fix NPE when using makeContext

### DIFF
--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/FlightService.java
@@ -68,9 +68,14 @@ class FlightService extends FlightServiceImplBase {
 
   private CallContext makeContext(ServerCallStreamObserver<?> responseObserver) {
     // Try to get the peer identity from middleware first (using the auth2 interfaces).
-    String peerIdentity = RequestContextAdapter.REQUEST_CONTEXT_KEY.get().get(Auth2Constants.PEER_IDENTITY_KEY);
+    final RequestContext context = RequestContextAdapter.REQUEST_CONTEXT_KEY.get();
+    String peerIdentity = null;
+    if (context != null) {
+      peerIdentity = context.get(Auth2Constants.PEER_IDENTITY_KEY);
+    }
+
     if (Strings.isNullOrEmpty(peerIdentity)) {
-      // Try the legacy auth interface.
+      // Try the legacy auth interface, which defaults to empty string.
       peerIdentity = AuthConstants.PEER_IDENTITY_KEY.get();
     }
 

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/RequestContextAdapter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/RequestContextAdapter.java
@@ -30,7 +30,7 @@ import io.grpc.Context;
  */
 public class RequestContextAdapter implements RequestContext {
   public static final Context.Key<RequestContext> REQUEST_CONTEXT_KEY =
-          Context.keyWithDefault("arrow-flight-request-context", new RequestContextAdapter());
+          Context.key("arrow-flight-request-context");
   private final HashMap<String, String> map = new HashMap<>();
 
   @Override

--- a/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/RequestContextAdapter.java
+++ b/java/flight/flight-core/src/main/java/org/apache/arrow/flight/grpc/RequestContextAdapter.java
@@ -30,7 +30,7 @@ import io.grpc.Context;
  */
 public class RequestContextAdapter implements RequestContext {
   public static final Context.Key<RequestContext> REQUEST_CONTEXT_KEY =
-          Context.key("arrow-flight-request-context");
+          Context.keyWithDefault("arrow-flight-request-context", new RequestContextAdapter());
   private final HashMap<String, String> map = new HashMap<>();
 
   @Override

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightService.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightService.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.arrow.flight;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.arrow.flight.impl.Flight;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.util.AutoCloseables;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.grpc.stub.ServerCallStreamObserver;
+
+public class TestFlightService {
+
+  private BufferAllocator allocator;
+
+  @Before
+  public void setup() {
+    allocator = new RootAllocator(Long.MAX_VALUE);
+  }
+
+  @After
+  public void cleanup() throws Exception {
+    AutoCloseables.close(allocator);
+  }
+
+  @Test
+  public void testFlightServiceWithNoAuthHandlerOrInterceptors() {
+    // Arrange
+    final FlightProducer producer = new NoOpFlightProducer() {
+      @Override
+      public void getStream(CallContext context, Ticket ticket,
+                            ServerStreamListener listener) {
+        listener.completed();
+      }
+    };
+
+    // This response observer notifies that the test failed if onError() is called.
+    final ServerCallStreamObserver<ArrowMessage> observer = new ServerCallStreamObserver<ArrowMessage>() {
+      @Override
+      public boolean isCancelled() {
+        return false;
+      }
+
+      @Override
+      public void setOnCancelHandler(Runnable runnable) {
+
+      }
+
+      @Override
+      public void setCompression(String s) {
+
+      }
+
+      @Override
+      public boolean isReady() {
+        return false;
+      }
+
+      @Override
+      public void setOnReadyHandler(Runnable runnable) {
+
+      }
+
+      @Override
+      public void disableAutoInboundFlowControl() {
+
+      }
+
+      @Override
+      public void request(int i) {
+
+      }
+
+      @Override
+      public void setMessageCompression(boolean b) {
+
+      }
+
+      @Override
+      public void onNext(ArrowMessage arrowMessage) {
+
+      }
+
+      @Override
+      public void onError(Throwable throwable) {
+        fail(throwable);
+      }
+
+      @Override
+      public void onCompleted() {
+
+      }
+    };
+    final FlightService flightService = new FlightService(allocator, producer, null, null);
+
+    // Act
+    flightService.doGetCustom(Flight.Ticket.newBuilder().build(), observer);
+
+    // fail() would have been called if an error happened during doGetCustom(), so this test passed.
+  }
+}

--- a/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightService.java
+++ b/java/flight/flight-core/src/test/java/org/apache/arrow/flight/TestFlightService.java
@@ -45,6 +45,10 @@ public class TestFlightService {
 
   @Test
   public void testFlightServiceWithNoAuthHandlerOrInterceptors() {
+    // This test is for ARROW-10491. There was a bug where FlightService would try to access the RequestContext,
+    // but the RequestContext was getting set to null because no interceptors were active to initialize it
+    // when using FlightService directly rather than starting up a FlightServer.
+
     // Arrange
     final FlightProducer producer = new NoOpFlightProducer() {
       @Override


### PR DESCRIPTION
Fix NPE trying to access the peer identity from RequestContext when using
FlightService directly without FlightServer.

This issue happens because the server middleware interceptors may not have
been configured to run and inject the context.