### PR TITLE
ARROW-4637: [Python] Must lock on import, to avoid deadlock due to circular imports

### DIFF
--- a/python/pyarrow/pandas-shim.pxi
+++ b/python/pyarrow/pandas-shim.pxi
@@ -18,6 +18,10 @@
 # pandas lazy-loading API shim that reduces API call and import overhead
 
 import warnings
+import threading
+
+
+LOCK = threading.Lock()
 
 
 cdef class _PandasAPIShim(object):
@@ -44,8 +48,9 @@ cdef class _PandasAPIShim(object):
 
     cdef _import_pandas(self, bint raise_):
         try:
-            import pandas as pd
-            import pyarrow.pandas_compat as pdcompat
+            with LOCK:
+                import pandas as pd
+                import pyarrow.pandas_compat as pdcompat
         except ImportError:
             self._have_pandas = False
             if raise_:


### PR DESCRIPTION
This fixes an issue where multithreaded use of the library would cause import deadlock issues due to the lazy Pandas importing mechanism. Multiple threads importing pandas at the same time can cause this problem because pandas internally has various circular imports.