### PR TITLE
ARROW-10484: [C++] Make Future<> more generic

### DIFF
--- a/cpp/src/arrow/flight/flight_benchmark.cc
+++ b/cpp/src/arrow/flight/flight_benchmark.cc
@@ -272,7 +272,7 @@ Status RunPerformanceTest(FlightClient* client, bool test_put) {
   // }
 
   ARROW_ASSIGN_OR_RAISE(auto pool, ThreadPool::Make(FLAGS_num_threads));
-  std::vector<Future<Status>> tasks;
+  std::vector<Future<>> tasks;
   for (const auto& endpoint : plan->endpoints()) {
     ARROW_ASSIGN_OR_RAISE(auto task, pool->Submit(ConsumeStream, endpoint));
     tasks.push_back(std::move(task));

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -158,7 +158,7 @@ ReadRangeCache::ReadRangeCache(std::shared_ptr<RandomAccessFile> file, AsyncCont
   impl_->options = options;
 }
 
-ReadRangeCache::~ReadRangeCache() {}
+ReadRangeCache::~ReadRangeCache() = default;
 
 Status ReadRangeCache::Cache(std::vector<ReadRange> ranges) {
   ranges = internal::CoalesceReadRanges(std::move(ranges), impl_->options.hole_size_limit,

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -128,13 +128,9 @@ Future<std::shared_ptr<Buffer>> RandomAccessFile::ReadAsync(const AsyncContext& 
   TaskHints hints;
   hints.io_size = nbytes;
   hints.external_id = ctx.external_id;
-  auto maybe_fut = ctx.executor->Submit(std::move(hints), [self, position, nbytes] {
+  return DeferNotOk(ctx.executor->Submit(std::move(hints), [self, position, nbytes] {
     return self->ReadAt(position, nbytes);
-  });
-  if (!maybe_fut.ok()) {
-    return Future<std::shared_ptr<Buffer>>::MakeFinished(maybe_fut.status());
-  }
-  return *std::move(maybe_fut);
+  }));
 }
 
 // Default WillNeed() implementation: no-op

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -448,6 +448,9 @@ class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
 /// WARNING: ARROW_ASSIGN_OR_RAISE expands into multiple statements;
 /// it cannot be used in a single statement (e.g. as the body of an if
 /// statement without {})!
+///
+/// WARNING: ARROW_ASSIGN_OR_RAISE `std::move`s its right operand. If you have
+/// an lvalue Result which you *don't* want to move out of cast appropriately.
 #define ARROW_ASSIGN_OR_RAISE(lhs, rexpr)                                              \
   ARROW_ASSIGN_OR_RAISE_IMPL(ARROW_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), \
                              lhs, rexpr);

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <new>
 #include <string>
 #include <type_traits>
@@ -423,6 +424,8 @@ class ARROW_MUST_USE_TYPE Result : public util::EqualityComparable<Result<T>> {
 
   void Destroy() {
     if (ARROW_PREDICT_TRUE(status_.ok())) {
+      static_assert(offsetof(Result<T>, status_) == 0,
+                    "Status is guaranteed to be at the start of Result<>");
       internal::launder(reinterpret_cast<const T*>(&data_))->~T();
     }
   }

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -73,7 +73,7 @@ class FutureWaiterImpl : public FutureWaiter {
     }
   }
 
-  ~FutureWaiterImpl() {
+  ~FutureWaiterImpl() override {
     for (auto future : futures_) {
       future->RemoveWaiter(this);
     }
@@ -174,9 +174,9 @@ FutureWaiterImpl* GetConcreteWaiter(FutureWaiter* waiter) {
 
 }  // namespace
 
-FutureWaiter::FutureWaiter() {}
+FutureWaiter::FutureWaiter() = default;
 
-FutureWaiter::~FutureWaiter() {}
+FutureWaiter::~FutureWaiter() = default;
 
 std::unique_ptr<FutureWaiter> FutureWaiter::Make(Kind kind,
                                                  std::vector<FutureImpl*> futures) {
@@ -275,6 +275,12 @@ ConcreteFutureImpl* GetConcreteFuture(FutureImpl* future) {
 
 std::unique_ptr<FutureImpl> FutureImpl::Make() {
   return std::unique_ptr<FutureImpl>(new ConcreteFutureImpl());
+}
+
+std::unique_ptr<FutureImpl> FutureImpl::MakeFinished(FutureState state) {
+  std::unique_ptr<ConcreteFutureImpl> ptr(new ConcreteFutureImpl());
+  ptr->state_ = state;
+  return ptr;
 }
 
 FutureImpl::FutureImpl() : state_(FutureState::PENDING) {}

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -280,7 +280,7 @@ std::unique_ptr<FutureImpl> FutureImpl::Make() {
 std::unique_ptr<FutureImpl> FutureImpl::MakeFinished(FutureState state) {
   std::unique_ptr<ConcreteFutureImpl> ptr(new ConcreteFutureImpl());
   ptr->state_ = state;
-  return ptr;
+  return std::move(ptr);
 }
 
 FutureImpl::FutureImpl() : state_(FutureState::PENDING) {}

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -40,8 +40,6 @@ inline bool IsFutureFinished(FutureState state) { return state != FutureState::P
 // Type-erased helpers
 
 class FutureWaiter;
-template <typename T>
-class Future;
 
 class ARROW_EXPORT FutureImpl {
  public:
@@ -52,10 +50,10 @@ class ARROW_EXPORT FutureImpl {
   FutureState state() { return state_.load(); }
 
   static std::unique_ptr<FutureImpl> Make();
+  static std::unique_ptr<FutureImpl> MakeFinished(FutureState state);
 
  protected:
   FutureImpl();
-  ARROW_DISALLOW_COPY_AND_ASSIGN(FutureImpl);
 
   // Future API
   void MarkFinished();
@@ -67,12 +65,15 @@ class ARROW_EXPORT FutureImpl {
   inline FutureState SetWaiter(FutureWaiter* w, int future_num);
   inline void RemoveWaiter(FutureWaiter* w);
 
-  std::atomic<FutureState> state_;
+  std::atomic<FutureState> state_{FutureState::PENDING};
+
+  // Type erased storage for arbitrary results
+  // XXX small objects could be stored alongside state_ instead of boxed in a pointer
+  using Storage = std::unique_ptr<void, void (*)(void*)>;
+  Storage result_{NULLPTR, NULLPTR};
 
   template <typename T>
   friend class Future;
-  template <typename T>
-  friend class FutureStorage;
   friend class FutureWaiter;
   friend class FutureWaiterImpl;
 };
@@ -107,7 +108,7 @@ class ARROW_EXPORT FutureWaiter {
   static std::vector<FutureImpl*> ExtractFutures(const std::vector<FutureType>& futures) {
     std::vector<FutureImpl*> base_futures(futures.size());
     for (int i = 0; i < static_cast<int>(futures.size()); ++i) {
-      base_futures[i] = futures[i].impl_;
+      base_futures[i] = futures[i].impl_.get();
     }
     return base_futures;
   }
@@ -118,7 +119,7 @@ class ARROW_EXPORT FutureWaiter {
       const std::vector<FutureType*>& futures) {
     std::vector<FutureImpl*> base_futures(futures.size());
     for (int i = 0; i < static_cast<int>(futures.size()); ++i) {
-      base_futures[i] = futures[i]->impl_;
+      base_futures[i] = futures[i]->impl_.get();
     }
     return base_futures;
   }
@@ -132,96 +133,36 @@ class ARROW_EXPORT FutureWaiter {
   friend class ConcreteFutureImpl;
 };
 
-// ---------------------------------------------------------------------
-// An intermediate class for storing Future results
-
-class FutureStorageBase {
- public:
-  FutureStorageBase() : impl_(FutureImpl::Make()) {}
-
- protected:
-  ARROW_DISALLOW_COPY_AND_ASSIGN(FutureStorageBase);
-  std::unique_ptr<FutureImpl> impl_;
-
-  template <typename T>
-  friend class Future;
-};
+namespace detail {
 
 template <typename T>
-class FutureStorage : public FutureStorageBase {
- public:
-  static constexpr bool HasValue = true;
+struct FutureStoredType {
+  using type = T;
+};
 
-  Status status() const { return result_.status(); }
-
-  void MarkFinished(Result<T> result) {
-    result_ = std::move(result);
-    if (ARROW_PREDICT_TRUE(result_.ok())) {
-      impl_->MarkFinished();
-    } else {
-      impl_->MarkFailed();
+struct Empty {
+  static Result<Empty> ToResult(Status s) {
+    if (ARROW_PREDICT_TRUE(s.ok())) {
+      return Empty{};
     }
+    return s;
   }
 
-  template <typename Func>
-  void ExecuteAndMarkFinished(Func&& func) {
-    MarkFinished(func());
-  }
-
- protected:
-  Result<T> result_;
-  friend class Future<T>;
+  template <typename T>
+  using EnableIfSame = typename std::enable_if<std::is_same<Empty, T>::value>::type;
 };
 
-// A Future<void> just stores a Status (always ok for now, but that could change
-// if we implement cancellation).
+// Future<Status> and Future<void> just store a Status.
 template <>
-class FutureStorage<void> : public FutureStorageBase {
- public:
-  static constexpr bool HasValue = false;
-
-  Status status() const { return status_; }
-
-  void MarkFinished(Status st = Status::OK()) {
-    status_ = std::move(st);
-    impl_->MarkFinished();
-  }
-
-  template <typename Func>
-  void ExecuteAndMarkFinished(Func&& func) {
-    func();
-    MarkFinished();
-  }
-
- protected:
-  Status status_;
+struct FutureStoredType<Status> {
+  using type = Empty;
 };
-
-// A Future<Status> just stores a Status.
 template <>
-class FutureStorage<Status> : public FutureStorageBase {
- public:
-  static constexpr bool HasValue = false;
-
-  Status status() const { return status_; }
-
-  void MarkFinished(Status st) {
-    status_ = std::move(st);
-    if (ARROW_PREDICT_TRUE(status_.ok())) {
-      impl_->MarkFinished();
-    } else {
-      impl_->MarkFailed();
-    }
-  }
-
-  template <typename Func>
-  void ExecuteAndMarkFinished(Func&& func) {
-    MarkFinished(func());
-  }
-
- protected:
-  Status status_;
+struct FutureStoredType<void> {
+  using type = Empty;
 };
+
+}  // namespace detail
 
 // ---------------------------------------------------------------------
 // Public API
@@ -237,13 +178,10 @@ class FutureStorage<Status> : public FutureStorageBase {
 /// The consumer API allows querying a Future's current state, wait for it
 /// to complete, or wait on multiple Futures at once (using WaitForAll,
 /// WaitForAny or AsCompletedIterator).
-template <typename T>
+template <typename T = void>
 class Future {
-  static constexpr bool HasValue = FutureStorage<T>::HasValue;
-  template <typename U>
-  using EnableResult = typename std::enable_if<HasValue, Result<U>>::type;
-
  public:
+  using ValueType = typename detail::FutureStoredType<T>::type;
   static constexpr double kInfinity = FutureImpl::kInfinity;
 
   // The default constructor creates an invalid Future.  Use Future::Make()
@@ -253,7 +191,7 @@ class Future {
 
   // Consumer API
 
-  bool is_valid() const { return storage_ != NULLPTR; }
+  bool is_valid() const { return impl_ != NULLPTR; }
 
   /// \brief Return the Future's current state
   ///
@@ -265,29 +203,17 @@ class Future {
   }
 
   /// \brief Wait for the Future to complete and return its Result
-  ///
-  /// This function is not available on Future<void> and Future<Status>.
-  /// For these specializations, please call status() instead.
-  template <typename U = T>
-  const Result<T>& result(EnableResult<U>* = NULLPTR) const& {
-    CheckValid();
+  const Result<ValueType>& result() const& {
     Wait();
-    return storage_->result_;
+    return *GetResult();
   }
-
-  template <typename U = T>
-  Result<T> result(EnableResult<U>* = NULLPTR) && {
-    CheckValid();
+  Result<ValueType>&& result() && {
     Wait();
-    return std::move(storage_->result_);
+    return std::move(*GetResult());
   }
 
   /// \brief Wait for the Future to complete and return its Status
-  Status status() const {
-    CheckValid();
-    Wait();
-    return storage_->status();
-  }
+  const Status& status() const { return result().status(); }
 
   /// \brief Wait for the Future to complete
   void Wait() const {
@@ -310,39 +236,17 @@ class Future {
     return impl_->Wait(seconds);
   }
 
-  /// If a Result<Future> holds an error instead of a Future, construct a finished Future
-  /// holding that error.
-  static Future DeferNotOk(Result<Future> maybe_future) {
-    if (ARROW_PREDICT_FALSE(!maybe_future.ok())) {
-      return MakeFinished(std::move(maybe_future).status());
-    }
-    return std::move(maybe_future).MoveValueUnsafe();
-  }
-
   // Producer API
-
-  /// \brief Producer API: execute function and mark Future finished
-  ///
-  /// The function's return value is used to set the Future's result.
-  /// The function can have the following return types:
-  /// - `T`
-  /// - `Result<T>`, if T is neither `void` nor `Status`
-  template <typename Func>
-  void ExecuteAndMarkFinished(Func&& func) {
-    storage_->ExecuteAndMarkFinished(std::forward<Func>(func));
-  }
 
   /// \brief Producer API: mark Future finished
   ///
-  /// The arguments are used to set the Future's result.
-  /// This function accepts the following signatures:
-  /// - `(T val)`, if T is neither `void` nor `Status`
-  /// - `(Result<T> val)`, if T is neither `void` nor `Status`
-  /// - `(Status st)`, if T is `void` or `Status`
-  /// - `()`, if T is `void`
-  template <typename... Args>
-  void MarkFinished(Args&&... args) {
-    storage_->MarkFinished(std::forward<Args>(args)...);
+  /// The Future's result is set to `res`.
+  void MarkFinished(Result<ValueType> res) { DoMarkFinished(std::move(res)); }
+
+  /// \brief Mark a Future<void> or Future<Status> completed with the provided Status.
+  template <typename E = ValueType>
+  detail::Empty::EnableIfSame<E> MarkFinished(Status s = Status::OK()) {
+    return DoMarkFinished(E::ToResult(std::move(s)));
   }
 
   /// \brief Producer API: instantiate a valid Future
@@ -350,23 +254,48 @@ class Future {
   /// The Future's state is initialized with PENDING.
   static Future Make() {
     Future fut;
-    fut.storage_ = std::make_shared<FutureStorage<T>>();
-    fut.impl_ = fut.storage_->impl_.get();
+    fut.impl_ = FutureImpl::Make();
     return fut;
   }
 
   /// \brief Producer API: instantiate a finished Future
-  ///
-  /// The given arguments are passed to MarkFinished().
-  template <typename... Args>
-  static Future MakeFinished(Args&&... args) {
-    // TODO we can optimize this by directly creating a finished FutureImpl
-    auto fut = Make();
-    fut.MarkFinished(std::forward<Args>(args)...);
+  static Future MakeFinished(Result<ValueType> res) {
+    Future fut;
+    if (ARROW_PREDICT_TRUE(res.ok())) {
+      fut.impl_ = FutureImpl::MakeFinished(FutureState::SUCCESS);
+    } else {
+      fut.impl_ = FutureImpl::MakeFinished(FutureState::FAILURE);
+    }
+    fut.SetResult(std::move(res));
     return fut;
   }
 
+  /// \brief Make a finished Future<void> or Future<Status> with the provided Status.
+  template <typename E = ValueType>
+  detail::Empty::EnableIfSame<E> MakeFinished(Status s = Status::OK()) {
+    return MakeFinished(E::ToResult(std::move(s)));
+  }
+
  protected:
+  Result<ValueType>* GetResult() const {
+    return static_cast<Result<ValueType>*>(impl_->result_.get());
+  }
+
+  void SetResult(Result<ValueType> res) {
+    impl_->result_ = {new Result<ValueType>(std::move(res)),
+                      [](void* p) { delete static_cast<Result<ValueType>*>(p); }};
+  }
+
+  void DoMarkFinished(Result<ValueType> res) {
+    SetResult(std::move(res));
+
+    if (ARROW_PREDICT_TRUE(GetResult()->ok())) {
+      impl_->MarkFinished();
+    } else {
+      impl_->MarkFailed();
+    }
+  }
+
   void CheckValid() const {
 #ifndef NDEBUG
     if (!is_valid()) {
@@ -375,11 +304,35 @@ class Future {
 #endif
   }
 
-  std::shared_ptr<FutureStorage<T>> storage_;
-  FutureImpl* impl_ = NULLPTR;
+  std::shared_ptr<FutureImpl> impl_;
 
   friend class FutureWaiter;
 };
+
+/// If a Result<Future> holds an error instead of a Future, construct a finished Future
+/// holding that error.
+template <typename T>
+static Future<T> DeferNotOk(Result<Future<T>> maybe_future) {
+  if (ARROW_PREDICT_FALSE(!maybe_future.ok())) {
+    return Future<T>::MakeFinished(std::move(maybe_future).status());
+  }
+  return std::move(maybe_future).MoveValueUnsafe();
+}
+
+namespace detail {
+
+template <typename T, typename F>
+void ExecuteAndMarkFinished(Future<T>* fut, F&& f) {
+  fut->MarkFinished(std::forward<F>(f)());
+}
+
+template <typename F>
+void ExecuteAndMarkFinished(Future<void>* fut, F&& f) {
+  std::forward<F>(f)();
+  fut->MarkFinished(detail::Empty{});
+}
+
+}  // namespace detail
 
 /// \brief Wait for all the futures to end, or for the given timeout to expire.
 ///

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -201,7 +201,7 @@ class Future {
   const Status& status() const { return result().status(); }
 
   /// \brief Future<T> is convertible to Future<>, which views only the
-  /// Status of the original. Marking this Future Finished is not supported.
+  /// Status of the original. Marking the returned Future Finished is not supported.
   explicit operator Future<>() const {
     Future<> status_future;
     status_future.impl_ = impl_;
@@ -236,7 +236,7 @@ class Future {
   /// The Future's result is set to `res`.
   void MarkFinished(Result<ValueType> res) { DoMarkFinished(std::move(res)); }
 
-  /// \brief Mark a Future<> or Future<> completed with the provided Status.
+  /// \brief Mark a Future<> completed with the provided Status.
   template <typename E = ValueType>
   detail::Empty::EnableIfSame<E> MarkFinished(Status s = Status::OK()) {
     return DoMarkFinished(E::ToResult(std::move(s)));
@@ -263,9 +263,9 @@ class Future {
     return fut;
   }
 
-  /// \brief Make a finished Future<> or Future<> with the provided Status.
+  /// \brief Make a finished Future<> with the provided Status.
   template <typename E = ValueType>
-  detail::Empty::EnableIfSame<E> MakeFinished(Status s = Status::OK()) {
+  static detail::Empty::EnableIfSame<E> MakeFinished(Status s = Status::OK()) {
     return MakeFinished(E::ToResult(std::move(s)));
   }
 

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -264,8 +264,8 @@ class Future {
   }
 
   /// \brief Make a finished Future<> with the provided Status.
-  template <typename E = ValueType>
-  static detail::Empty::EnableIfSame<E> MakeFinished(Status s = Status::OK()) {
+  template <typename E = ValueType, typename = detail::Empty::EnableIfSame<E>>
+  static Future<> MakeFinished(Status s = Status::OK()) {
     return MakeFinished(E::ToResult(std::move(s)));
   }
 

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -233,6 +233,17 @@ TEST(FutureSyncTest, Int) {
     ASSERT_EQ(*res, 42);
   }
   {
+    // MakeFinished(int)
+    auto fut = Future<int>::MakeFinished(42);
+    AssertSuccessful(fut);
+    auto res = fut.result();
+    ASSERT_OK(res);
+    ASSERT_EQ(*res, 42);
+    res = std::move(fut.result());
+    ASSERT_OK(res);
+    ASSERT_EQ(*res, 42);
+  }
+  {
     // MarkFinished(Result<int>)
     auto fut = Future<int>::Make();
     AssertNotFinished(fut);
@@ -246,6 +257,12 @@ TEST(FutureSyncTest, Int) {
     auto fut = Future<int>::Make();
     AssertNotFinished(fut);
     fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    AssertFailed(fut);
+    ASSERT_RAISES(IOError, fut.result());
+  }
+  {
+    // MakeFinished(Status)
+    auto fut = Future<int>::MakeFinished(Status::IOError("xxx"));
     AssertFailed(fut);
     ASSERT_RAISES(IOError, fut.result());
   }

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -70,9 +70,9 @@ struct MoveOnlyDataType {
   MoveOnlyDataType(const MoveOnlyDataType& other) = delete;
   MoveOnlyDataType& operator=(const MoveOnlyDataType& other) = delete;
 
-  MoveOnlyDataType(MoveOnlyDataType&& other) { MoveFrom(other); }
+  MoveOnlyDataType(MoveOnlyDataType&& other) { MoveFrom(&other); }
   MoveOnlyDataType& operator=(MoveOnlyDataType&& other) {
-    MoveFrom(other);
+    MoveFrom(&other);
     return *this;
   }
 
@@ -85,10 +85,10 @@ struct MoveOnlyDataType {
     }
   }
 
-  void MoveFrom(MoveOnlyDataType& other) {
+  void MoveFrom(MoveOnlyDataType* other) {
     Destroy();
-    data = other.data;
-    other.data = nullptr;
+    data = other->data;
+    other->data = nullptr;
   }
 
   int ToInt() const { return data == nullptr ? -42 : *data; }
@@ -158,9 +158,9 @@ IteratorResults<T> IteratorToResults(Iterator<T> iterator) {
 }
 
 // So that main thread may wait a bit for a future to be finished
-static const auto kYieldDuration = std::chrono::microseconds(50);
-static const double kTinyWait = 1e-5;  // seconds
-static const double kLargeWait = 5.0;  // seconds
+constexpr auto kYieldDuration = std::chrono::microseconds(50);
+constexpr double kTinyWait = 1e-5;  // seconds
+constexpr double kLargeWait = 5.0;  // seconds
 
 template <typename T>
 class SimpleExecutor {
@@ -347,31 +347,55 @@ TEST(FutureSyncTest, MoveOnlyDataType) {
   }
 }
 
-TEST(FutureSyncTest, void) {
+TEST(FutureSyncTest, Empty) {
   {
     // MarkFinished()
-    auto fut = Future<void>::Make();
+    auto fut = Future<>::Make();
     AssertNotFinished(fut);
     fut.MarkFinished();
     AssertSuccessful(fut);
   }
-}
-
-TEST(FutureSyncTest, Status) {
   {
     // MarkFinished(Status)
-    auto fut = Future<Status>::Make();
+    auto fut = Future<>::Make();
     AssertNotFinished(fut);
     fut.MarkFinished(Status::OK());
     AssertSuccessful(fut);
   }
   {
     // MarkFinished(Status)
-    auto fut = Future<Status>::Make();
+    auto fut = Future<>::Make();
     AssertNotFinished(fut);
     fut.MarkFinished(Status::IOError("xxx"));
     AssertFailed(fut);
     ASSERT_RAISES(IOError, fut.status());
+  }
+}
+
+TEST(FutureSyncTest, GetStatusFuture) {
+  {
+    auto fut = Future<MoveOnlyDataType>::Make();
+    Future<> status_future(fut);
+
+    AssertNotFinished(fut);
+    AssertNotFinished(status_future);
+
+    fut.MarkFinished(MoveOnlyDataType(42));
+    AssertSuccessful(fut);
+    AssertSuccessful(status_future);
+    ASSERT_EQ(&fut.status(), &status_future.status());
+  }
+  {
+    auto fut = Future<MoveOnlyDataType>::Make();
+    Future<> status_future(fut);
+
+    AssertNotFinished(fut);
+    AssertNotFinished(status_future);
+
+    fut.MarkFinished(Status::IOError("xxx"));
+    AssertFailed(fut);
+    AssertFailed(status_future);
+    ASSERT_EQ(&fut.status(), &status_future.status());
   }
 }
 
@@ -693,7 +717,7 @@ class FutureTestBase : public ::testing::Test {
 template <typename T>
 class FutureTest : public FutureTestBase<T> {};
 
-typedef ::testing::Types<int, Foo, MoveOnlyDataType> FutureTestTypes;
+using FutureTestTypes = ::testing::Types<int, Foo, MoveOnlyDataType>;
 
 TYPED_TEST_SUITE(FutureTest, FutureTestTypes);
 
@@ -718,7 +742,7 @@ TYPED_TEST(FutureTest, StressWaitForAll) { this->TestStressWaitForAll(); }
 template <typename T>
 class FutureIteratorTest : public FutureTestBase<T> {};
 
-typedef ::testing::Types<Foo, MoveOnlyDataType> FutureIteratorTestTypes;
+using FutureIteratorTestTypes = ::testing::Types<Foo, MoveOnlyDataType>;
 
 TYPED_TEST_SUITE(FutureIteratorTest, FutureIteratorTestTypes);
 

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -356,11 +356,27 @@ TEST(FutureSyncTest, Empty) {
     AssertSuccessful(fut);
   }
   {
+    // MakeFinished()
+    auto fut = Future<>::MakeFinished();
+    AssertSuccessful(fut);
+    auto res = fut.result();
+    ASSERT_OK(res);
+    res = std::move(fut.result());
+    ASSERT_OK(res);
+  }
+  {
     // MarkFinished(Status)
     auto fut = Future<>::Make();
     AssertNotFinished(fut);
     fut.MarkFinished(Status::OK());
     AssertSuccessful(fut);
+  }
+  {
+    // MakeFinished(Status)
+    auto fut = Future<>::MakeFinished(Status::OK());
+    AssertSuccessful(fut);
+    fut = Future<>::MakeFinished(Status::IOError("xxx"));
+    AssertFailed(fut);
   }
   {
     // MarkFinished(Status)

--- a/cpp/src/arrow/util/parallel.h
+++ b/cpp/src/arrow/util/parallel.h
@@ -32,7 +32,7 @@ namespace internal {
 template <class FUNCTION>
 Status ParallelFor(int num_tasks, FUNCTION&& func) {
   auto pool = internal::GetCpuThreadPool();
-  std::vector<Future<Status>> futures(num_tasks);
+  std::vector<Future<>> futures(num_tasks);
 
   for (int i = 0; i < num_tasks; ++i) {
     ARROW_ASSIGN_OR_RAISE(futures[i], pool->Submit(func, i));

--- a/cpp/src/arrow/util/thread_pool.h
+++ b/cpp/src/arrow/util/thread_pool.h
@@ -129,10 +129,12 @@ class ARROW_EXPORT Executor {
     return future;
   }
 
-  template <typename Function, typename... Args>
-  auto Submit(Function&& func, Args&&... args)
-      -> decltype(Submit(TaskHints{}, std::forward<Function>(func),
-                         std::forward<Args>(args)...)) {
+  template <
+      typename Function, typename... Args,
+      typename FunctionRetType = typename std::result_of<Function && (Args && ...)>::type,
+      typename ValueType =
+          typename detail::ExecutorResultTraits<FunctionRetType>::ValueType>
+  Result<Future<ValueType>> Submit(Function&& func, Args&&... args) {
     return Submit(TaskHints{}, std::forward<Function>(func), std::forward<Args>(args)...);
   }
 

--- a/cpp/src/plasma/client.cc
+++ b/cpp/src/plasma/client.cc
@@ -796,7 +796,7 @@ bool PlasmaClient::Impl::ComputeObjectHashParallel(XXH64_state_t* hash_state,
   // | num_threads * chunk_size | suffix |, where chunk_size = k * block_size.
   // Each thread gets a "chunk" of k blocks, except the suffix thread.
 
-  std::vector<arrow::Future<void>> futures;
+  std::vector<arrow::Future<>> futures;
   for (int i = 0; i < num_threads; i++) {
     futures.push_back(*pool->Submit(
         ComputeBlockHash, reinterpret_cast<uint8_t*>(data_address) + i * chunk_size,


### PR DESCRIPTION
`Future<Status>` and `Future<void>` have been removed in favor of `Future<>`, whose `ValueType` is an empty struct. This is a statusy future but still provides a `result()` member function, which simplifies generic code handling `Future<T>` since special cases which avoid `result()` need not be written. Additionally, `Future<T>` is now convertible to a `Future<>` which views only its status, without allocation of new state/storage. This will expedite observing the statuses of heterogeneous collections of futures.

Details:
- `DeferNotOk` and `ExecuteAndMarkFinished` are no longer members of `Future<>`
- Constructing finished Futures no longer locks the waiter mutex
- Future now holds a `shared_ptr<FutureImpl>` directly. `FutureImpl` stores the Future's result in a type erased allocation.
- `FutureStorage<>` and `FutureStorageBase` are obviated and have been removed
- deleted `Executor::SubmitAsFuture()` since it isn't used and can be trivially replaced: `ex->SubmitAsFuture(f)` -> `DeferNotOk(ex->Submit(f))`