### PR TITLE
ARROW-10495: [Packaging][deb] Move FindRE2.cmake to libarrow-dev

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow/Rakefile
@@ -82,20 +82,6 @@ class ApacheArrowPackageTask < PackageTask
          "--output", @full_archive_name)
     end
   end
-
-  def detect_llvm_version
-    detect_env("LLVM")
-  end
-
-  def docker_image(os, architecture)
-    "#{super}-llvm-#{detect_llvm_version}"
-  end
-
-  def docker_build_options(os, architecture)
-    [
-      "--build-arg", "LLVM=#{detect_llvm_version}",
-    ]
-  end
 end
 
 task = ApacheArrowPackageTask.new

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-buster/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-buster/Dockerfile
@@ -35,18 +35,8 @@ RUN \
     /etc/apt/sources.list.d/backports.list
 
 ARG DEBUG
-ARG LLVM
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
-  apt update ${quiet} && \
-  apt install -y -V ${quiet} \
-    apt-transport-https \
-    ca-certificates \
-    gnupg \
-    wget && \
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-  echo "deb https://apt.llvm.org/buster/ llvm-toolchain-buster-${LLVM} main" > \
-    /etc/apt/sources.list.d/llvm.list && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
     build-essential \
@@ -83,11 +73,9 @@ RUN \
     rapidjson-dev \
     tzdata \
     zlib1g-dev && \
-  if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
-      clang-${LLVM} \
-      llvm-${LLVM}-dev; \
-  fi && \
+  apt install -y -V -t buster-backports ${quiet} \
+    clang-8 \
+    llvm-8-dev && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
     apt install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/debian-stretch/Dockerfile
@@ -37,21 +37,12 @@ RUN \
     /etc/apt/sources.list.d/backports-sloppy.list
 
 ARG DEBUG
-ARG LLVM
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
-    apt-transport-https \
-    ca-certificates \
-    gnupg \
-    wget && \
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-  echo "deb https://apt.llvm.org/stretch/ llvm-toolchain-stretch-${LLVM} main" > \
-    /etc/apt/sources.list.d/llvm.list && \
-  apt update ${quiet} && \
-  apt install -y -V ${quiet} \
     build-essential \
+    clang-7 \
     cmake \
     devscripts \
     fakeroot \
@@ -73,6 +64,7 @@ RUN \
     libssl-dev \
     libutf8proc-dev \
     libzstd-dev \
+    llvm-7-dev \
     lsb-release \
     ninja-build \
     pkg-config \
@@ -90,11 +82,6 @@ RUN \
     libgmock-dev \
     libgtest-dev \
     rapidjson-dev && \
-  if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
-      clang-${LLVM} \
-      llvm-${LLVM}-dev; \
-  fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
     apt install -y -V -t stretch-backports ${quiet} nvidia-cuda-toolkit; \
   fi && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-bionic/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-bionic/Dockerfile
@@ -29,21 +29,12 @@ RUN \
     /etc/apt/apt.conf.d/disable-install-recommends
 
 ARG DEBUG
-ARG LLVM
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
-    apt-transport-https \
-    ca-certificates \
-    gnupg \
-    wget && \
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-  echo "deb https://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM} main" > \
-    /etc/apt/sources.list.d/llvm.list && \
-  apt update ${quiet} && \
-  apt install -y -V ${quiet} \
     build-essential \
+    clang-10 \
     cmake \
     devscripts \
     fakeroot \
@@ -65,6 +56,7 @@ RUN \
     libssl-dev \
     libutf8proc-dev \
     libzstd-dev \
+    llvm-10-dev \
     lsb-release \
     ninja-build \
     pkg-config \
@@ -76,11 +68,6 @@ RUN \
     rapidjson-dev \
     tzdata \
     zlib1g-dev && \
-  if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
-      clang-${LLVM} \
-      llvm-${LLVM}-dev; \
-  fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
     apt install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-focal/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-focal/Dockerfile
@@ -29,21 +29,12 @@ RUN \
     /etc/apt/apt.conf.d/disable-install-recommends
 
 ARG DEBUG
-ARG LLVM
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
-    apt-transport-https \
-    ca-certificates \
-    gnupg \
-    wget && \
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-  echo "deb https://apt.llvm.org/focal/ llvm-toolchain-focal-${LLVM} main" > \
-    /etc/apt/sources.list.d/llvm.list && \
-  apt update ${quiet} && \
-  apt install -y -V ${quiet} \
     build-essential \
+    clang-10 \
     cmake \
     debhelper \
     devscripts \
@@ -67,6 +58,7 @@ RUN \
     libthrift-dev \
     libutf8proc-dev \
     libzstd-dev \
+    llvm-10-dev \
     lsb-release \
     ninja-build \
     pkg-config \
@@ -77,11 +69,6 @@ RUN \
     rapidjson-dev \
     tzdata \
     zlib1g-dev && \
-  if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
-      clang-${LLVM} \
-      llvm-${LLVM}-dev; \
-  fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
     apt install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-xenial/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-xenial/Dockerfile
@@ -29,25 +29,13 @@ RUN \
     /etc/apt/apt.conf.d/disable-install-recommends
 
 ARG DEBUG
-# LLVM 10 or later requires C++ 14 but g++-5's C++ 14 support is limited.
-# cpp/src/arrow/vendored/datetime/date.h doesn't work.
-# ARG LLVM
-ENV LLVM=8
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
   apt install -y -V ${quiet} \
-    apt-transport-https \
-    ca-certificates \
-    gnupg \
-    wget && \
-  wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-  echo "deb https://apt.llvm.org/xenial/ llvm-toolchain-xenial-${LLVM} main" > \
-    /etc/apt/sources.list.d/llvm.list && \
-  apt update ${quiet} && \
-  apt install -y -V ${quiet} \
     autoconf-archive \
     build-essential \
+    clang-8 \
     cmake \
     devscripts \
     dh-autoreconf \
@@ -71,17 +59,13 @@ RUN \
     libssl-dev \
     libutf8proc-dev \
     libzstd1-dev \
+    llvm-8-dev \
     lsb-release \
     pkg-config \
     protobuf-compiler \
     python3-dev \
     python3-numpy \
     zlib1g-dev && \
-  if [ "$(dpkg --print-architecture)" != "arm64" ]; then \
-    apt install -y -V ${quiet} \
-      clang-${LLVM} \
-      llvm-${LLVM}-dev; \
-  fi && \
   if apt list | grep '^nvidia-cuda-toolkit/'; then \
     apt install -y -V ${quiet} nvidia-cuda-toolkit; \
   fi && \

--- a/dev/tasks/linux-packages/apache-arrow/debian.ubuntu-xenial/control
+++ b/dev/tasks/linux-packages/apache-arrow/debian.ubuntu-xenial/control
@@ -137,7 +137,7 @@ Description: Apache Arrow is a data processing library for analysis
 
 Package: libgandiva300
 Section: libs
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends:
@@ -151,7 +151,7 @@ Description: Gandiva is a toolset for compiling and evaluating expressions
 
 Package: libgandiva-dev
 Section: libdevel
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
@@ -364,7 +364,7 @@ Description: Apache Arrow is a data processing library for analysis
 
 Package: libgandiva-glib300
 Section: libs
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends:
@@ -379,7 +379,7 @@ Description: Gandiva is a toolset for compiling and evaluating expressions
 
 Package: gir1.2-gandiva-1.0
 Section: introspection
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Depends:
   ${gir:Depends},
@@ -391,7 +391,7 @@ Description: Gandiva is a toolset for compiling and evaluating expressions
 
 Package: libgandiva-glib-dev
 Section: libdevel
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
@@ -406,7 +406,7 @@ Description: Gandiva is a toolset for compiling and evaluating expressions
 
 Package: libgandiva-glib-doc
 Section: doc
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: foreign
 Depends:
   ${misc:Depends}

--- a/dev/tasks/linux-packages/apache-arrow/debian.ubuntu-xenial/libarrow-dev.install
+++ b/dev/tasks/linux-packages/apache-arrow/debian.ubuntu-xenial/libarrow-dev.install
@@ -5,6 +5,7 @@ usr/lib/*/cmake/arrow/ArrowTargets*.cmake
 usr/lib/*/cmake/arrow/FindArrow.cmake
 usr/lib/*/cmake/arrow/FindBrotli.cmake
 usr/lib/*/cmake/arrow/FindLz4.cmake
+usr/lib/*/cmake/arrow/FindRE2.cmake
 usr/lib/*/cmake/arrow/FindSnappy.cmake
 usr/lib/*/cmake/arrow/Findutf8proc.cmake
 usr/lib/*/cmake/arrow/Findzstd.cmake

--- a/dev/tasks/linux-packages/apache-arrow/debian.ubuntu-xenial/libgandiva-dev.install
+++ b/dev/tasks/linux-packages/apache-arrow/debian.ubuntu-xenial/libgandiva-dev.install
@@ -2,7 +2,6 @@ usr/include/gandiva/
 usr/lib/*/cmake/arrow/GandivaConfig*.cmake
 usr/lib/*/cmake/arrow/GandivaTargets*.cmake
 usr/lib/*/cmake/arrow/FindGandiva.cmake
-usr/lib/*/cmake/arrow/FindRE2.cmake
 usr/lib/*/libgandiva.a
 usr/lib/*/libgandiva.so
 usr/lib/*/pkgconfig/gandiva.pc

--- a/dev/tasks/linux-packages/apache-arrow/debian/control
+++ b/dev/tasks/linux-packages/apache-arrow/debian/control
@@ -190,7 +190,7 @@ Description: Apache Arrow is a data processing library for analysis
 
 Package: libgandiva300
 Section: libs
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends:
@@ -204,7 +204,7 @@ Description: Gandiva is a toolset for compiling and evaluating expressions
 
 Package: libgandiva-dev
 Section: libdevel
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
@@ -417,7 +417,7 @@ Description: Apache Arrow is a data processing library for analysis
 
 Package: libgandiva-glib300
 Section: libs
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends:
@@ -432,7 +432,7 @@ Description: Gandiva is a toolset for compiling and evaluating expressions
 
 Package: gir1.2-gandiva-1.0
 Section: introspection
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Depends:
   ${gir:Depends},
@@ -444,7 +444,7 @@ Description: Gandiva is a toolset for compiling and evaluating expressions
 
 Package: libgandiva-glib-dev
 Section: libdevel
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
@@ -459,7 +459,7 @@ Description: Gandiva is a toolset for compiling and evaluating expressions
 
 Package: libgandiva-glib-doc
 Section: doc
-Architecture: i386 amd64
+Architecture: any
 Multi-Arch: foreign
 Depends:
   ${misc:Depends}

--- a/dev/tasks/linux-packages/apache-arrow/debian/libarrow-dev.install
+++ b/dev/tasks/linux-packages/apache-arrow/debian/libarrow-dev.install
@@ -5,6 +5,7 @@ usr/lib/*/cmake/arrow/ArrowTargets*.cmake
 usr/lib/*/cmake/arrow/FindArrow.cmake
 usr/lib/*/cmake/arrow/FindBrotli.cmake
 usr/lib/*/cmake/arrow/FindLz4.cmake
+usr/lib/*/cmake/arrow/FindRE2.cmake
 usr/lib/*/cmake/arrow/FindSnappy.cmake
 usr/lib/*/cmake/arrow/Findutf8proc.cmake
 usr/lib/*/cmake/arrow/Findzstd.cmake

--- a/dev/tasks/linux-packages/apache-arrow/debian/libgandiva-dev.install
+++ b/dev/tasks/linux-packages/apache-arrow/debian/libgandiva-dev.install
@@ -2,7 +2,6 @@ usr/include/gandiva/
 usr/lib/*/cmake/arrow/GandivaConfig*.cmake
 usr/lib/*/cmake/arrow/GandivaTargets*.cmake
 usr/lib/*/cmake/arrow/FindGandiva.cmake
-usr/lib/*/cmake/arrow/FindRE2.cmake
 usr/lib/*/libgandiva.a
 usr/lib/*/libgandiva.so
 usr/lib/*/pkgconfig/gandiva.pc


### PR DESCRIPTION
It's required for libarrow_bundled_dependencies.a in libarrow-dev. So
we need to put FindRE2.cmake to libarrow-dev not libgandiva-dev.