### PR TITLE
ARROW-10412: [C++] Improve grpc_cpp_plugin detection

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2530,11 +2530,6 @@ if(ARROW_WITH_GRPC)
     endif()
   endif()
 
-  get_target_property(GRPC_CPP_PLUGIN gRPC::grpc_cpp_plugin IMPORTED_LOCATION)
-  if(NOT GRPC_CPP_PLUGIN)
-    get_target_property(GRPC_CPP_PLUGIN gRPC::grpc_cpp_plugin IMPORTED_LOCATION_RELEASE)
-  endif()
-
   if(TARGET gRPC::address_sorting)
     set(GRPC_HAS_ADDRESS_SORTING TRUE)
   else()

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -54,7 +54,7 @@ add_custom_command(OUTPUT ${FLIGHT_GENERATED_PROTO_FILES}
                    COMMAND ${ARROW_PROTOBUF_PROTOC}
                            "-I${FLIGHT_PROTO_PATH}"
                            "--grpc_out=${CMAKE_CURRENT_BINARY_DIR}"
-                           "--plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN}"
+                           "--plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin>"
                            "${FLIGHT_PROTO}")
 
 set_source_files_properties(${FLIGHT_GENERATED_PROTO_FILES} PROPERTIES GENERATED TRUE)


### PR DESCRIPTION
If gRPC::grpc_cpp_plugin doesn't use IMPORTED_LOCATION nor
IMPORTED_LOCATION_RELEASE such as IMPORTED_LOCATION_RELWITHDEBINFO,
grpc_cpp_plugin wasn't found.