### PR TITLE
ARROW-10492: [Java][JDBC] Allow users to config the mapping between SQL types and Arrow types

### DIFF
--- a/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
+++ b/java/adapter/jdbc/src/main/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigBuilder.java
@@ -21,9 +21,11 @@ import static org.apache.arrow.adapter.jdbc.JdbcToArrowConfig.DEFAULT_TARGET_BAT
 
 import java.util.Calendar;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.util.Preconditions;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 
 /**
  * This class builds {@link JdbcToArrowConfig}s.
@@ -36,6 +38,7 @@ public class JdbcToArrowConfigBuilder {
   private Map<String, JdbcFieldInfo> arraySubTypesByColumnName;
 
   private int targetBatchSize;
+  private Function<JdbcFieldInfo, ArrowType> jdbcToArrowTypeConverter;
 
   /**
    * Default constructor for the <code>JdbcToArrowConfigBuilder}</code>.
@@ -163,6 +166,12 @@ public class JdbcToArrowConfigBuilder {
     return this;
   }
 
+  public JdbcToArrowConfigBuilder setJdbcToArrowTypeConverter(
+      Function<JdbcFieldInfo, ArrowType> jdbcToArrowTypeConverter) {
+    this.jdbcToArrowTypeConverter = jdbcToArrowTypeConverter;
+    return this;
+  }
+
   /**
    * This builds the {@link JdbcToArrowConfig} from the provided
    * {@link BufferAllocator} and {@link Calendar}.
@@ -177,6 +186,7 @@ public class JdbcToArrowConfigBuilder {
         includeMetadata,
         arraySubTypesByColumnIndex,
         arraySubTypesByColumnName,
-        targetBatchSize);
+        targetBatchSize,
+        jdbcToArrowTypeConverter);
   }
 }

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/JdbcToArrowConfigTest.java
@@ -17,7 +17,11 @@
 
 package org.apache.arrow.adapter.jdbc;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.sql.Types;
 import java.util.Calendar;
@@ -113,11 +117,11 @@ public class JdbcToArrowConfigTest {
     assertTrue(config.shouldIncludeMetadata());
 
     config = new JdbcToArrowConfig(allocator, calendar, true, null,
-        null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE);
+        null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
     assertTrue(config.shouldIncludeMetadata());
 
     config = new JdbcToArrowConfig(allocator, calendar, false, null,
-        null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE);
+        null, JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE, null);
     assertFalse(config.shouldIncludeMetadata());
   }
 

--- a/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
+++ b/java/adapter/jdbc/src/test/java/org/apache/arrow/adapter/jdbc/h2/JdbcToArrowVectorIteratorTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -49,6 +50,7 @@ import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
@@ -62,6 +64,8 @@ import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VarBinaryVector;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -368,6 +372,56 @@ public class JdbcToArrowVectorIteratorTest extends JdbcToArrowTest {
       for (int i = 0; i < vector.getValueCount(); i++) {
         assertEquals(values[index++].intValue(), vector.get(i));
       }
+    }
+  }
+
+  /**
+   * Runs a simple query, and encapsulates the result into a field vector.
+   */
+  private FieldVector getQueryResult(JdbcToArrowConfig config) throws SQLException, IOException {
+    ArrowVectorIterator iterator = JdbcToArrow.sqlToArrowVectorIterator(
+        conn.createStatement().executeQuery("select real_field8 from table1"), config);
+
+    VectorSchemaRoot root = iterator.next();
+
+    // only one vector, since there is one column in the select statement.
+    assertEquals(1, root.getFieldVectors().size());
+    FieldVector result = root.getVector(0);
+
+    // make sure some data is actually read
+    assertTrue(result.getValueCount() > 0);
+
+    return result;
+  }
+
+  @Test
+  public void testJdbcToArrowCustomTypeConversion() throws SQLException, IOException {
+    JdbcToArrowConfigBuilder builder = new JdbcToArrowConfigBuilder(new RootAllocator(Integer.MAX_VALUE),
+        Calendar.getInstance()).setTargetBatchSize(JdbcToArrowConfig.NO_LIMIT_BATCH_SIZE);
+
+    // first experiment, using default type converter
+    JdbcToArrowConfig config = builder.build();
+
+    try (FieldVector vector = getQueryResult(config)) {
+      // the default converter translates real to float4
+      assertTrue(vector instanceof Float4Vector);
+    }
+
+    // second experiment, using customized type converter
+    builder.setJdbcToArrowTypeConverter(fieldInfo -> {
+      switch (fieldInfo.getJdbcType()) {
+        case Types.REAL:
+          // this is different from the default type converter
+          return new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+        default:
+          return null;
+      }
+    });
+    config = builder.build();
+
+    try (FieldVector vector = getQueryResult(config)) {
+      // the customized converter translates real to float8
+      assertTrue(vector instanceof Float8Vector);
     }
   }
 }


### PR DESCRIPTION
According to the current implementation of JDBC adapter, the conversion between SQL types and Arrow types is hard-coded. This will cause some problems in practice:

1. The appropriate conversion may vary for different databases. For example, for SQL Server, type real corresponds to 4 byte floating point values (https://docs.microsoft.com/en-us/sql/t-sql/data-types/float-and-real-transact-sql?view=sql-server-ver15), whereas for SQLite, real corresponds to 8 byte floating point values (https://www.sqlitetutorial.net/sqlite-data-types/). If the maping is not right, some extra conversion would happen, which can impact performance severely. 

2. Our current implementation determines the type conversion solely based on the type ID. However, the appropriate conversion may also depend some other information, like precision and scale. For example, for FLOAT( n ), it should correspond to 4 byte 
floating point values, if n <= 24, otherwise, it should correspond to 8 byte floating point values.  

To address the problems, we should allow users to customize the conversion between SQL and Arrow types. 