### PR TITLE
ARROW-10504: [C++] Suppress UBSAN pointer-overflow warning in RapidJSON

### DIFF
--- a/cpp/build-support/sanitizer-disallowed-entries.txt
+++ b/cpp/build-support/sanitizer-disallowed-entries.txt
@@ -20,3 +20,6 @@
 # Seen error:
 # thirdparty/gmock-1.7.0/include/gmock/gmock-spec-builders.h:1529:12: runtime error: member call on null pointer of type 'testing::internal::ActionResultHolder<void>'
 fun:*testing*internal*InvokeWith*
+
+# Workaround for RapidJSON https://github.com/Tencent/rapidjson/issues/1724
+src:*/rapidjson/internal/*


### PR DESCRIPTION
Also dodge some null pointer arithmetic in `/Optional(|Binary)BitBlockCounter/`