### PR TITLE
ARROW-10518: [C++][Gandiva] Adding NativeFunction::kCanReturnErrors to cast function in gandiva

### DIFF
--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -69,18 +69,20 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      "lower_utf8", NativeFunction::kNeedsContext),
 
       NativeFunction("castINT", {}, DataTypeVector{utf8()}, int32(), kResultNullIfNull,
-                     "gdv_fn_castINT_utf8", NativeFunction::kNeedsContext),
+                     "gdv_fn_castINT_utf8",
+                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("castBIGINT", {}, DataTypeVector{utf8()}, int64(), kResultNullIfNull,
-                     "gdv_fn_castBIGINT_utf8", NativeFunction::kNeedsContext),
+                     "gdv_fn_castBIGINT_utf8",
+                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("castFLOAT4", {}, DataTypeVector{utf8()}, float32(),
                      kResultNullIfNull, "gdv_fn_castFLOAT4_utf8",
-                     NativeFunction::kNeedsContext),
+                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("castFLOAT8", {}, DataTypeVector{utf8()}, float64(),
                      kResultNullIfNull, "gdv_fn_castFLOAT8_utf8",
-                     NativeFunction::kNeedsContext),
+                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("castVARCHAR", {}, DataTypeVector{utf8(), int64()}, utf8(),
                      kResultNullIfNull, "castVARCHAR_utf8_int64",

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -15,13 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <cmath>
+#include "gandiva/projector.h"
 
 #include <gtest/gtest.h>
 
-#include "arrow/memory_pool.h"
+#include <cmath>
 
-#include "gandiva/projector.h"
+#include "arrow/memory_pool.h"
 #include "gandiva/tests/test_util.h"
 #include "gandiva/tree_expr_builder.h"
 
@@ -766,4 +766,56 @@ TEST_F(TestProjector, TestOffset) {
   EXPECT_ARROW_ARRAY_EQUALS(exp_sum, outputs.at(0));
 }
 
+// Test to ensure behaviour of cast functions when the validity is false for an input. The
+// function should not run for that input.
+TEST_F(TestProjector, TestCastFunction) {
+  auto field0 = field("f0", arrow::utf8());
+  auto schema = arrow::schema({field0});
+
+  // output fields
+  auto res_float4 = field("res_float4", arrow::float32());
+  auto res_float8 = field("res_float8", arrow::float64());
+  auto res_int4 = field("castINT", arrow::int32());
+  auto res_int8 = field("castBIGINT", arrow::int64());
+
+  // Build expression
+  auto cast_expr_float4 =
+      TreeExprBuilder::MakeExpression("castFLOAT4", {field0}, res_float4);
+  auto cast_expr_float8 =
+      TreeExprBuilder::MakeExpression("castFLOAT8", {field0}, res_float8);
+  auto cast_expr_int4 = TreeExprBuilder::MakeExpression("castINT", {field0}, res_int4);
+  auto cast_expr_int8 = TreeExprBuilder::MakeExpression("castBIGINT", {field0}, res_int8);
+
+  std::shared_ptr<Projector> projector;
+
+  //  {cast_expr_float4, cast_expr_float8, cast_expr_int4, cast_expr_int8}
+  auto status = Projector::Make(
+      schema, {cast_expr_float4, cast_expr_float8, cast_expr_int4, cast_expr_int8},
+      TestConfiguration(), &projector);
+  EXPECT_TRUE(status.ok());
+
+  // Create a row-batch with some sample data
+  int num_records = 4;
+
+  // Last validity is false and the cast functions throw error when input is empty. Should
+  // not be evaluated due to addition of NativeFunction::kCanReturnErrors
+  auto array0 = MakeArrowArrayUtf8({"1", "2", "3", ""}, {true, true, true, false});
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});
+
+  auto out_float4 = MakeArrowArrayFloat32({1, 2, 3, 0}, {true, true, true, false});
+  auto out_float8 = MakeArrowArrayFloat64({1, 2, 3, 0}, {true, true, true, false});
+  auto out_int4 = MakeArrowArrayInt32({1, 2, 3, 0}, {true, true, true, false});
+  auto out_int8 = MakeArrowArrayInt64({1, 2, 3, 0}, {true, true, true, false});
+
+  arrow::ArrayVector outputs;
+
+  // Evaluate expression
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  EXPECT_TRUE(status.ok());
+
+  EXPECT_ARROW_ARRAY_EQUALS(out_float4, outputs.at(0));
+  EXPECT_ARROW_ARRAY_EQUALS(out_float8, outputs.at(1));
+  EXPECT_ARROW_ARRAY_EQUALS(out_int4, outputs.at(2));
+  EXPECT_ARROW_ARRAY_EQUALS(out_int8, outputs.at(3));
+}
 }  // namespace gandiva


### PR DESCRIPTION
In a refactoring done earlier function definitions for cast function which were earlier 

`UNARY_UNS[AFE_NULL_IF_NULL(castINT, {}, utf8, int32)`
`UNARY_UNSAFE_NULL_IF_NULL(castBIGINT, {}, utf8, int64)`
`UNARY_UNSAFE_NULL_IF_NULL(castFLOAT4, {}, utf8, float32)`
`UNARY_UNSAFE_NULL_IF_NULL(castFLOAT8, {}, utf8, float64)`
 
 were changed to 

    `  NativeFunction("castINT", {}, DataTypeVector{utf8()}, int32(), kResultNullIfNull,
                      "gdv_fn_castINT_utf8", NativeFunction::kNeedsContext),

       NativeFunction("castBIGINT", {}, DataTypeVector{utf8()}, int64(), kResultNullIfNull,
                      "gdv_fn_castBIGINT_utf8", NativeFunction::kNeedsContext),

       NativeFunction("castFLOAT4", {}, DataTypeVector{utf8()}, float32(),
                      kResultNullIfNull, "gdv_fn_castFLOAT4_utf8",
                      NativeFunction::kNeedsContext),

       NativeFunction("castFLOAT8", {}, DataTypeVector{utf8()}, float64(),
                      kResultNullIfNull, "gdv_fn_castFLOAT8_utf8",
                      NativeFunction::kNeedsContext) `

UNARY_UNSAFE_NULL_IF_NULL will add `NativeFunction::CanReturnErrors`
to the definitions so the functions won’t be evaluated for inputs whose validity is false which was removed when the definitions were refactored. Adding it back to fix some failing tests in Dremio

Earlier change
[https://github.com/apache/arrow/commit/36bf7a43eefd3bc5563fcfa8d04bc35a49c97978](https://github.com/apache/arrow/commit/36bf7a43eefd3bc5563fcfa8d04bc35a49c97978)
