### PR TITLE
ARROW-10519: [Python] Fix deadlock when importing pandas from several threads

### DIFF
--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -265,23 +265,39 @@ bool PyFloat_IsNaN(PyObject* obj) {
 
 namespace {
 
-static std::once_flag pandas_static_initialized;
+static bool pandas_static_initialized = false;
 
+// Once initialized, these variables hold borrowed references to Pandas static data.
+// We should not use OwnedRef here because Python destructors would be
+// called on a finalized interpreter.
 static PyObject* pandas_NA = nullptr;
 static PyObject* pandas_NaT = nullptr;
 static PyObject* pandas_Timedelta = nullptr;
 static PyObject* pandas_Timestamp = nullptr;
 static PyTypeObject* pandas_NaTType = nullptr;
 
-void GetPandasStaticSymbols() {
+}  // namespace
+
+void InitPandasStaticData() {
+  // NOTE: This is called with the GIL held.  We needn't (and shouldn't,
+  // to avoid deadlocks) use an additional C++ lock (ARROW-10519).
+  if (pandas_static_initialized) {
+    return;
+  }
+
   OwnedRef pandas;
 
-  // import pandas
+  // Import pandas
   Status s = ImportModule("pandas", &pandas);
   if (!s.ok()) {
     return;
   }
 
+  // Since ImportModule can release the GIL, another thread could have
+  // already initialized the static data.
+  if (pandas_static_initialized) {
+    return;
+  }
   OwnedRef ref;
 
   // set NaT sentinel and its type
@@ -306,12 +322,8 @@ void GetPandasStaticSymbols() {
   if (ImportFromModule(pandas.obj(), "NA", &ref).ok()) {
     pandas_NA = ref.obj();
   }
-}
 
-}  // namespace
-
-void InitPandasStaticData() {
-  std::call_once(pandas_static_initialized, GetPandasStaticSymbols);
+  pandas_static_initialized = true;
 }
 
 bool PandasObjectIsNull(PyObject* obj) {

--- a/cpp/src/arrow/python/helpers.cc
+++ b/cpp/src/arrow/python/helpers.cc
@@ -21,7 +21,6 @@
 #include "arrow/python/helpers.h"
 
 #include <limits>
-#include <mutex>
 #include <sstream>
 #include <type_traits>
 #include <typeinfo>

--- a/python/pyarrow/tests/pandas_threaded_import.py
+++ b/python/pyarrow/tests/pandas_threaded_import.py
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file is called from a test in test_pandas.py.
+
+from concurrent.futures import ThreadPoolExecutor
+import faulthandler
+import sys
+
+import pyarrow as pa
+
+num_threads = 60
+timeout = 10  # seconds
+
+
+def thread_func(i):
+    pa.array([i]).to_pandas()
+
+
+def main():
+    # In case of import deadlock, crash after a finite timeout
+    faulthandler.dump_traceback_later(timeout, exit=True)
+    with ThreadPoolExecutor(num_threads) as pool:
+        assert "pandas" not in sys.modules  # pandas is imported lazily
+        list(pool.map(thread_func, range(num_threads)))
+        assert "pandas" in sys.modules
+
+
+if __name__ == "__main__":
+    main()

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -34,7 +34,7 @@ import pytest
 import pytz
 
 from pyarrow.pandas_compat import get_logical_type, _pandas_api
-from pyarrow.tests.util import random_ascii, rands
+from pyarrow.tests.util import invoke_script, random_ascii, rands
 import pyarrow.tests.strategies as past
 
 import pyarrow as pa
@@ -4238,3 +4238,7 @@ def test_timestamp_as_object_non_nanosecond(resolution, tz, dt):
             assert result[0].tzinfo is None
             expected = dt
         assert result[0] == expected
+
+
+def test_threaded_pandas_import():
+    invoke_script("pandas_threaded_import.py")


### PR DESCRIPTION
Fix a lock ordering-induced deadlock between the Python GIL
and the `std::once_flag` lock used in `arrow::py::internal::InitPandasStaticData`.

Thread A:
* takes the GIL
* calls `arrow::py::internal::InitPandasStaticData`
  * which calls `std::call_once`, which acquires the lock inside the `std::once_flag`
    * which imports the `pandas` module
      * which releases the GIL before reading the code object from disk
      * and then tries to re-acquire the GIL

Thread B:
* takes the GIL
* calls `arrow::py::internal::InitPandasStaticData`
  * which calls `std::call_once`, which tries to acquire the lock inside the `std::once_flag`