### PR TITLE
ARROW-10525: [C++] Fix crash on unsupported IPC stream

### DIFF
--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -142,6 +142,27 @@ int DictionaryFieldMapper::num_fields() const { return impl_->num_fields(); }
 // ----------------------------------------------------------------------
 // DictionaryMemo implementation
 
+namespace {
+
+bool HasUnresolvedNestedDict(const ArrayData& data) {
+  if (data.type->id() == Type::DICTIONARY) {
+    if (data.dictionary == nullptr) {
+      return true;
+    }
+    if (HasUnresolvedNestedDict(*data.dictionary)) {
+      return true;
+    }
+  }
+  for (const auto& child : data.child_data) {
+    if (HasUnresolvedNestedDict(*child)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
 struct DictionaryMemo::Impl {
   // Map of dictionary id to dictionary array(s) (several in case of deltas)
   std::unordered_map<int64_t, ArrayDataVector> id_to_dictionary_;
@@ -169,8 +190,12 @@ struct DictionaryMemo::Impl {
       // We need to validate it, as concatenation can crash on invalid or
       // corrupted data.  Full validation is necessary for certain types
       // (for example nested dictionaries).
-      // XXX: this won't work if there are unresolved nested dictionaries.
       for (const auto& data : *data_vector) {
+        // This explicit test is required to avoid crashing later
+        if (HasUnresolvedNestedDict(*data)) {
+          return Status::NotImplemented(
+              "Encountered delta dictionary with an unresolved nested dictionary");
+        }
         to_combine.push_back(MakeArray(data));
         RETURN_NOT_OK(to_combine.back()->ValidateFull());
       }


### PR DESCRIPTION
Detect situations where we have a delta dictionary with an unresolved nested dictionary.
Found by OSS-Fuzz.

Should fix the following issue:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=26581