### PR TITLE
ARROW-9128: [C++] Implement string space trimming kernels: trim, ltrim, and rtrim

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -92,6 +92,13 @@ struct ARROW_EXPORT StrptimeOptions : public FunctionOptions {
   TimeUnit::type unit;
 };
 
+struct ARROW_EXPORT TrimOptions : public FunctionOptions {
+  explicit TrimOptions(std::string characters) : characters(std::move(characters)) {}
+
+  /// The individual characters that can be trimmed from the string.
+  std::string characters;
+};
+
 enum CompareOperator : int8_t {
   EQUAL,
   NOT_EQUAL,

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -126,6 +126,36 @@ struct OptionsWrapper : public KernelState {
   OptionsType options;
 };
 
+/// KernelState adapter for when the state is an instance constructed with the
+/// KernelContext and the FunctionOptions as argument
+template <typename StateType, typename OptionsType>
+struct KernelStateFromFunctionOptions : public KernelState {
+  explicit KernelStateFromFunctionOptions(KernelContext* ctx, OptionsType state)
+      : state(StateType(ctx, std::move(state))) {}
+
+  static std::unique_ptr<KernelState> Init(KernelContext* ctx,
+                                           const KernelInitArgs& args) {
+    if (auto options = static_cast<const OptionsType*>(args.options)) {
+      auto wrapper =
+          ::arrow::internal::make_unique<KernelStateFromFunctionOptions>(ctx, *options);
+      return wrapper;
+    }
+
+    ctx->SetStatus(
+        Status::Invalid("Attempted to initialize KernelState from null FunctionOptions"));
+    return NULLPTR;
+  }
+
+  static const StateType& Get(const KernelState& state) {
+    return ::arrow::internal::checked_cast<const KernelStateFromFunctionOptions&>(state)
+        .state;
+  }
+
+  static const StateType& Get(KernelContext* ctx) { return Get(*ctx->state()); }
+
+  StateType state;
+};
+
 // ----------------------------------------------------------------------
 // Input and output value type definitions
 

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -136,9 +136,8 @@ struct KernelStateFromFunctionOptions : public KernelState {
   static std::unique_ptr<KernelState> Init(KernelContext* ctx,
                                            const KernelInitArgs& args) {
     if (auto options = static_cast<const OptionsType*>(args.options)) {
-      auto wrapper =
-          ::arrow::internal::make_unique<KernelStateFromFunctionOptions>(ctx, *options);
-      return wrapper;
+      return ::arrow::internal::make_unique<KernelStateFromFunctionOptions>(ctx,
+                                                                            *options);
     }
 
     ctx->SetStatus(

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1302,14 +1302,14 @@ struct UTF8TrimBase : StringTransform<Type, Derived> {
   using Base = StringTransform<Type, Derived>;
   using offset_type = typename Base::offset_type;
   using State = OptionsWrapper<TrimOptions>;
-  TrimOptions options;
-  std::vector<bool> codepoints;
+  TrimOptions options_;
+  std::vector<bool> codepoints_;
 
-  explicit UTF8TrimBase(TrimOptions options) : options(options) {
+  explicit UTF8TrimBase(TrimOptions options) : options_(options) {
     // TODO: check return / can we raise an exception here?
-    arrow::util::UTF8ForEach(options.characters, [&](uint32_t c) {
-      codepoints.resize(std::max(c + 1, static_cast<uint32_t>(codepoints.size())));
-      codepoints.at(c) = true;
+    arrow::util::UTF8ForEach(options_.characters, [&](uint32_t c) {
+      codepoints_.resize(std::max(c + 1, static_cast<uint32_t>(codepoints_.size())));
+      codepoints_.at(c) = true;
     });
   }
 
@@ -1331,7 +1331,7 @@ struct UTF8TrimBase : StringTransform<Type, Derived> {
     const uint8_t* begin_trimmed = begin;
 
     auto predicate = [&](uint32_t c) {
-      bool contains = codepoints[c];
+      bool contains = codepoints_[c];
       return !contains;
     };
     if (left && !ARROW_PREDICT_TRUE(
@@ -1408,12 +1408,12 @@ struct AsciiTrimBase : StringTransform<Type, Derived> {
   using Base = StringTransform<Type, Derived>;
   using offset_type = typename Base::offset_type;
   using State = OptionsWrapper<TrimOptions>;
-  TrimOptions options;
-  std::vector<bool> characters;
+  TrimOptions options_;
+  std::vector<bool> characters_;
 
-  explicit AsciiTrimBase(TrimOptions options) : options(options), characters(256) {
-    std::for_each(options.characters.begin(), options.characters.end(),
-                  [&](char c) { characters[static_cast<unsigned char>(c)] = true; });
+  explicit AsciiTrimBase(TrimOptions options) : options_(options), characters_(256) {
+    std::for_each(options_.characters.begin(), options_.characters.end(),
+                  [&](char c) { characters_[static_cast<unsigned char>(c)] = true; });
   }
 
   static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
@@ -1429,7 +1429,7 @@ struct AsciiTrimBase : StringTransform<Type, Derived> {
     const uint8_t* begin_trimmed;
 
     auto predicate = [&](unsigned char c) {
-      bool contains = characters[c];
+      bool contains = characters_[c];
       return !contains;
     };
 

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1305,7 +1305,7 @@ struct UTF8TrimBase : StringTransform<Type, Derived> {
   TrimOptions options_;
   std::vector<bool> codepoints_;
 
-  explicit UTF8TrimBase(TrimOptions options) : options_(options) {
+  explicit UTF8TrimBase(TrimOptions options) : options_(std::move(options)) {
     // TODO: check return / can we raise an exception here?
     arrow::util::UTF8ForEach(options_.characters, [&](uint32_t c) {
       codepoints_.resize(std::max(c + 1, static_cast<uint32_t>(codepoints_.size())));
@@ -1411,7 +1411,8 @@ struct AsciiTrimBase : StringTransform<Type, Derived> {
   TrimOptions options_;
   std::vector<bool> characters_;
 
-  explicit AsciiTrimBase(TrimOptions options) : options_(options), characters_(256) {
+  explicit AsciiTrimBase(TrimOptions options)
+      : options_(std::move(options)), characters_(256) {
     std::for_each(options_.characters.begin(), options_.characters.end(),
                   [&](char c) { characters_[static_cast<unsigned char>(c)] = true; });
   }

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1465,89 +1465,86 @@ struct AsciiRTrim : AsciiTrimBase<Type, false, true, AsciiRTrim<Type>> {
 
 const FunctionDoc utf8_trim_whitespace_doc(
     "Trim leading and trailing whitespace characters",
-    ("For each string in `strings`, emit a string with leading and trailing whitespace "
-     "characters removed, where whitespace characters are defined by the Unicode "
+    ("For each string in `strings`, emit a string with leading and trailing whitespace\n"
+     "characters removed, where whitespace characters are defined by the Unicode\n"
      "standard.  Null values emit null."),
     {"strings"});
 
 const FunctionDoc utf8_ltrim_whitespace_doc(
     "Trim leading whitespace characters",
-    ("For each string in `strings`, emit a string with leading whitespace "
-     "characters removed, where whitespace characters are defined by the Unicode "
+    ("For each string in `strings`, emit a string with leading whitespace\n"
+     "characters removed, where whitespace characters are defined by the Unicode\n"
      "standard.  Null values emit null."),
     {"strings"});
 
 const FunctionDoc utf8_rtrim_whitespace_doc(
     "Trim trailing whitespace characters",
-    ("For each string in `strings`, emit a string with trailing whitespace "
-     "characters removed, where whitespace characters are defined by the Unicode "
+    ("For each string in `strings`, emit a string with trailing whitespace\n"
+     "characters removed, where whitespace characters are defined by the Unicode\n"
      "standard.  Null values emit null."),
     {"strings"});
 
 const FunctionDoc ascii_trim_whitespace_doc(
     "Trim leading and trailing ASCII whitespace characters",
-    ("For each string in `strings`, emit a string with leading and trailing ASCII "
-     "whitespace characters removed. Use `utf8_trim_whitespace` to trim Unicode "
+    ("For each string in `strings`, emit a string with leading and trailing ASCII\n"
+     "whitespace characters removed. Use `utf8_trim_whitespace` to trim Unicode\n"
      "whitespace characters. Null values emit null."),
     {"strings"});
 
 const FunctionDoc ascii_ltrim_whitespace_doc(
     "Trim leading ASCII whitespace characters",
-    ("For each string in `strings`, emit a string with leading ASCII whitespace "
-     "characters removed.  Use `utf8_ltrim_whitespace` to trim leading Unicode "
+    ("For each string in `strings`, emit a string with leading ASCII whitespace\n"
+     "characters removed.  Use `utf8_ltrim_whitespace` to trim leading Unicode\n"
      "whitespace characters. Null values emit null."),
     {"strings"});
 
 const FunctionDoc ascii_rtrim_whitespace_doc(
     "Trim trailing ASCII whitespace characters",
-    ("For each string in `strings`, emit a string with trailing ASCII whitespace "
-     "characters removed. Use `utf8_rtrim_whitespace` to trim trailing Unicode "
+    ("For each string in `strings`, emit a string with trailing ASCII whitespace\n"
+     "characters removed. Use `utf8_rtrim_whitespace` to trim trailing Unicode\n"
      "whitespace characters. Null values emit null."),
     {"strings"});
 
 const FunctionDoc utf8_trim_doc(
     "Trim leading and trailing characters present in the `characters` arguments",
-    ("For each string in `strings`, emit a string with leading and trailing "
-     "characters removed that are present in the `characters` argument.  Null values "
-     "emit "
-     "null."),
+    ("For each string in `strings`, emit a string with leading and trailing\n"
+     "characters removed that are present in the `characters` argument.  Null values\n"
+     "emit null."),
     {"strings"}, "TrimOptions");
 
 const FunctionDoc utf8_ltrim_doc(
     "Trim leading characters present in the `characters` arguments",
-    ("For each string in `strings`, emit a string with leading "
-     "characters removed that are present in the `characters` argument.  Null values "
-     "emit "
-     "null."),
+    ("For each string in `strings`, emit a string with leading\n"
+     "characters removed that are present in the `characters` argument.  Null values\n"
+     "emit null."),
     {"strings"}, "TrimOptions");
 
 const FunctionDoc utf8_rtrim_doc(
     "Trim trailing characters present in the `characters` arguments",
     ("For each string in `strings`, emit a string with leading "
-     "characters removed that are present in the `characters` argument.  Null values "
-     "emit "
-     "null."),
+     "characters removed that are present in the `characters` argument.  Null values\n"
+     "emit null."),
     {"strings"}, "TrimOptions");
 
 const FunctionDoc ascii_trim_doc(
     utf8_trim_doc.summary + "",
     utf8_trim_doc.description +
-        ("Both the input string as the `characters` argument are interepreted as ASCII "
-         "characters, to trim non-ASCII characters, use `utf8_trim"),
+        ("\nBoth the input string as the `characters` argument are interepreted as\n"
+         "ASCII characters, to trim non-ASCII characters, use `utf8_trim`."),
     {"strings"}, "TrimOptions");
 
 const FunctionDoc ascii_ltrim_doc(
     utf8_ltrim_doc.summary + "",
     utf8_ltrim_doc.description +
-        ("Both the input string as the `characters` argument are interepreted as ASCII "
-         "characters, to trim non-ASCII characters, use `utf8_trim"),
+        ("\nBoth the input string as the `characters` argument are interepreted as\n"
+         "ASCII characters, to trim non-ASCII characters, use `utf8_trim`."),
     {"strings"}, "TrimOptions");
 
 const FunctionDoc ascii_rtrim_doc(
     utf8_rtrim_doc.summary + "",
     utf8_rtrim_doc.description +
-        ("Both the input string as the `characters` argument are interepreted as ASCII "
-         "characters, to trim non-ASCII characters, use `utf8_trim"),
+        ("\nBoth the input string as the `characters` argument are interepreted as\n"
+         "ASCII characters, to trim non-ASCII characters, use `utf8_trim`."),
     {"strings"}, "TrimOptions");
 
 const FunctionDoc strptime_doc(

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1308,8 +1308,8 @@ struct UTF8TrimBase : StringTransform<Type, Derived> {
   explicit UTF8TrimBase(TrimOptions options) : options(options) {
     // TODO: check return / can we raise an exception here?
     arrow::util::UTF8ForEach(options.characters, [&](uint32_t c) {
-      codepoints.resize(c);
-      codepoints[c] = true;
+      codepoints.resize(std::max(c + 1, static_cast<uint32_t>(codepoints.size())));
+      codepoints.at(c) = true;
     });
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -174,8 +174,9 @@ struct StringTransform {
 
 #ifdef ARROW_WITH_UTF8PROC
 
+// transforms per codepoint
 template <typename Type, typename Derived>
-struct UTF8Transform : StringTransform<Type, Derived> {
+struct StringTransformCodepoint : StringTransform<Type, Derived> {
   using Base = StringTransform<Type, Derived>;
   using offset_type = typename Base::offset_type;
 
@@ -207,7 +208,7 @@ struct UTF8Transform : StringTransform<Type, Derived> {
 };
 
 template <typename Type>
-struct UTF8Upper : UTF8Transform<Type, UTF8Upper<Type>> {
+struct UTF8Upper : StringTransformCodepoint<Type, UTF8Upper<Type>> {
   inline static uint32_t TransformCodepoint(uint32_t codepoint) {
     return codepoint <= kMaxCodepointLookup ? lut_upper_codepoint[codepoint]
                                             : utf8proc_toupper(codepoint);
@@ -215,7 +216,7 @@ struct UTF8Upper : UTF8Transform<Type, UTF8Upper<Type>> {
 };
 
 template <typename Type>
-struct UTF8Lower : UTF8Transform<Type, UTF8Lower<Type>> {
+struct UTF8Lower : StringTransformCodepoint<Type, UTF8Lower<Type>> {
   inline static uint32_t TransformCodepoint(uint32_t codepoint) {
     return codepoint <= kMaxCodepointLookup ? lut_lower_codepoint[codepoint]
                                             : utf8proc_tolower(codepoint);

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <set>
 #include <string>
 
 #ifdef ARROW_WITH_UTF8PROC
@@ -86,25 +87,19 @@ void EnsureLookupTablesFilled() {
   });
 }
 
+#endif  // ARROW_WITH_UTF8PROC
+
+/// Transform string -> string with a reasonable guess on the maximum number of codepoints
 template <typename Type, typename Derived>
-struct UTF8Transform {
+struct StringTransform {
   using offset_type = typename Type::offset_type;
   using ArrayType = typename TypeTraits<Type>::ArrayType;
 
-  static bool Transform(const uint8_t* input, offset_type input_string_ncodeunits,
-                        uint8_t* output, offset_type* output_written) {
-    uint8_t* output_start = output;
-    if (ARROW_PREDICT_FALSE(
-            !arrow::util::UTF8Transform(input, input + input_string_ncodeunits, &output,
-                                        Derived::TransformCodepoint))) {
-      return false;
-    }
-    *output_written = static_cast<offset_type>(output - output_start);
-    return true;
-  }
-
+  static int64_t MaxCodepoints(offset_type input_ncodeunits) { return input_ncodeunits; }
   static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
-    EnsureLookupTablesFilled();
+    Derived().Execute(ctx, batch, out);
+  }
+  void Execute(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
     if (batch[0].kind() == Datum::ARRAY) {
       const ArrayData& input = *batch[0].array();
       ArrayType input_boxed(batch[0].array());
@@ -113,14 +108,7 @@ struct UTF8Transform {
       offset_type input_ncodeunits = input_boxed.total_values_length();
       offset_type input_nstrings = static_cast<offset_type>(input.length);
 
-      // Section 5.18 of the Unicode spec claim that the number of codepoints for case
-      // mapping can grow by a factor of 3. This means grow by a factor of 3 in bytes
-      // However, since we don't support all casings (SpecialCasing.txt) the growth
-      // is actually only at max 3/2 (as covered by the unittest).
-      // Note that rounding down the 3/2 is ok, since only codepoints encoded by
-      // two code units (even) can grow to 3 code units.
-
-      int64_t output_ncodeunits_max = static_cast<int64_t>(input_ncodeunits) * 3 / 2;
+      int64_t output_ncodeunits_max = Derived::MaxCodepoints(input_ncodeunits);
       if (output_ncodeunits_max > std::numeric_limits<offset_type>::max()) {
         ctx->SetStatus(Status::CapacityError(
             "Result might not fit in a 32bit utf8 array, convert to large_utf8"));
@@ -141,9 +129,9 @@ struct UTF8Transform {
         offset_type input_string_ncodeunits;
         const uint8_t* input_string = input_boxed.GetValue(i, &input_string_ncodeunits);
         offset_type encoded_nbytes = 0;
-        if (ARROW_PREDICT_FALSE(!Derived::Transform(input_string, input_string_ncodeunits,
-                                                    output_str + output_ncodeunits,
-                                                    &encoded_nbytes))) {
+        if (ARROW_PREDICT_FALSE(!static_cast<Derived&>(*this).Transform(
+                input_string, input_string_ncodeunits, output_str + output_ncodeunits,
+                &encoded_nbytes))) {
           ctx->SetStatus(Status::Invalid("Invalid UTF8 sequence in input"));
           return;
         }
@@ -161,8 +149,7 @@ struct UTF8Transform {
         result->is_valid = true;
         offset_type data_nbytes = static_cast<offset_type>(input.value->size());
 
-        // See note above in the Array version explaining the 3 / 2
-        int64_t output_ncodeunits_max = static_cast<int64_t>(data_nbytes) * 3 / 2;
+        int64_t output_ncodeunits_max = Derived::MaxCodepoints(data_nbytes);
         if (output_ncodeunits_max > std::numeric_limits<offset_type>::max()) {
           ctx->SetStatus(Status::CapacityError(
               "Result might not fit in a 32bit utf8 array, convert to large_utf8"));
@@ -172,9 +159,9 @@ struct UTF8Transform {
                                ctx->Allocate(output_ncodeunits_max));
         result->value = value_buffer;
         offset_type encoded_nbytes = 0;
-        if (ARROW_PREDICT_FALSE(!Derived::Transform(input.value->data(), data_nbytes,
-                                                    value_buffer->mutable_data(),
-                                                    &encoded_nbytes))) {
+        if (ARROW_PREDICT_FALSE(!static_cast<Derived&>(*this).Transform(
+                input.value->data(), data_nbytes, value_buffer->mutable_data(),
+                &encoded_nbytes))) {
           ctx->SetStatus(Status::Invalid("Invalid UTF8 sequence in input"));
           return;
         }
@@ -183,6 +170,40 @@ struct UTF8Transform {
       }
       out->value = result;
     }
+  }
+};
+
+#ifdef ARROW_WITH_UTF8PROC
+
+template <typename Type, typename Derived>
+struct UTF8Transform : StringTransform<Type, Derived> {
+  using Base = StringTransform<Type, Derived>;
+  using offset_type = typename Base::offset_type;
+
+  bool Transform(const uint8_t* input, offset_type input_string_ncodeunits,
+                 uint8_t* output, offset_type* output_written) {
+    uint8_t* output_start = output;
+    if (ARROW_PREDICT_FALSE(
+            !arrow::util::UTF8Transform(input, input + input_string_ncodeunits, &output,
+                                        Derived::TransformCodepoint))) {
+      return false;
+    }
+    *output_written = static_cast<offset_type>(output - output_start);
+    return true;
+  }
+  static int64_t MaxCodepoints(offset_type input_ncodeunits) {
+    // Section 5.18 of the Unicode spec claim that the number of codepoints for case
+    // mapping can grow by a factor of 3. This means grow by a factor of 3 in bytes
+    // However, since we don't support all casings (SpecialCasing.txt) the growth
+    // is actually only at max 3/2 (as covered by the unittest).
+    // Note that rounding down the 3/2 is ok, since only codepoints encoded by
+    // two code units (even) can grow to 3 code units.
+
+    return static_cast<int64_t>(input_ncodeunits) * 3 / 2;
+  }
+  void Execute(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    EnsureLookupTablesFilled();
+    Base::Execute(ctx, batch, out);
   }
 };
 
@@ -1231,6 +1252,302 @@ Result<ValueDescr> StrptimeResolve(KernelContext* ctx, const std::vector<ValueDe
   return Status::Invalid("strptime does not provide default StrptimeOptions");
 }
 
+#ifdef ARROW_WITH_UTF8PROC
+
+template <typename Type, bool left, bool right, typename Derived>
+struct UTF8TrimWhitespaceBase : StringTransform<Type, Derived> {
+  using Base = StringTransform<Type, Derived>;
+  using offset_type = typename Base::offset_type;
+  bool Transform(const uint8_t* input, offset_type input_string_ncodeunits,
+                 uint8_t* output, offset_type* output_written) {
+    const uint8_t* begin = input;
+    const uint8_t* end = input + input_string_ncodeunits;
+    const uint8_t* end_trimmed = end;
+    const uint8_t* begin_trimmed = begin;
+
+    auto predicate = [](uint32_t c) { return !IsSpaceCharacterUnicode(c); };
+    if (left && !ARROW_PREDICT_TRUE(
+                    arrow::util::UTF8FindIf(begin, end, predicate, &begin_trimmed))) {
+      return false;
+    }
+    if (right && (begin_trimmed < end)) {
+      if (!ARROW_PREDICT_TRUE(arrow::util::UTF8FindIfReverse(begin_trimmed, end,
+                                                             predicate, &end_trimmed))) {
+        return false;
+      }
+    }
+    std::copy(begin_trimmed, end_trimmed, output);
+    *output_written = static_cast<offset_type>(end_trimmed - begin_trimmed);
+    return true;
+  }
+  void Execute(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    EnsureLookupTablesFilled();
+    Base::Execute(ctx, batch, out);
+  }
+};
+
+template <typename Type>
+struct UTF8TrimWhitespace
+    : UTF8TrimWhitespaceBase<Type, true, true, UTF8TrimWhitespace<Type>> {};
+
+template <typename Type>
+struct UTF8LTrimWhitespace
+    : UTF8TrimWhitespaceBase<Type, true, false, UTF8LTrimWhitespace<Type>> {};
+
+template <typename Type>
+struct UTF8RTrimWhitespace
+    : UTF8TrimWhitespaceBase<Type, false, true, UTF8RTrimWhitespace<Type>> {};
+
+template <typename Type, bool left, bool right, typename Derived>
+struct UTF8TrimBase : StringTransform<Type, Derived> {
+  using Base = StringTransform<Type, Derived>;
+  using offset_type = typename Base::offset_type;
+  using State = OptionsWrapper<TrimOptions>;
+  TrimOptions options;
+  std::set<uint32_t> codepoints;
+
+  explicit UTF8TrimBase(TrimOptions options) : options(options) {
+    // TODO: check return / can we raise an exception here?
+    arrow::util::UTF8ForEach(options.characters,
+                             [&](uint32_t c) { codepoints.insert(c); });
+  }
+
+  static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    TrimOptions options = State::Get(ctx);
+    Derived(options).Execute(ctx, batch, out);
+  }
+
+  void Execute(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    EnsureLookupTablesFilled();
+    Base::Execute(ctx, batch, out);
+  }
+
+  bool Transform(const uint8_t* input, offset_type input_string_ncodeunits,
+                 uint8_t* output, offset_type* output_written) {
+    const uint8_t* begin = input;
+    const uint8_t* end = input + input_string_ncodeunits;
+    const uint8_t* end_trimmed = end;
+    const uint8_t* begin_trimmed = begin;
+
+    auto predicate = [&](uint32_t c) {
+      bool contains = codepoints.find(c) != codepoints.end();
+      return !contains;
+    };
+    if (left && !ARROW_PREDICT_TRUE(
+                    arrow::util::UTF8FindIf(begin, end, predicate, &begin_trimmed))) {
+      return false;
+    }
+    if (right && (begin_trimmed < end)) {
+      if (!ARROW_PREDICT_TRUE(arrow::util::UTF8FindIfReverse(begin_trimmed, end,
+                                                             predicate, &end_trimmed))) {
+        return false;
+      }
+    }
+    std::copy(begin_trimmed, end_trimmed, output);
+    *output_written = static_cast<offset_type>(end_trimmed - begin_trimmed);
+    return true;
+  }
+};
+template <typename Type>
+struct UTF8Trim : UTF8TrimBase<Type, true, true, UTF8Trim<Type>> {
+  using Base = UTF8TrimBase<Type, true, true, UTF8Trim<Type>>;
+  using Base::Base;
+};
+
+template <typename Type>
+struct UTF8LTrim : UTF8TrimBase<Type, true, false, UTF8LTrim<Type>> {
+  using Base = UTF8TrimBase<Type, true, false, UTF8LTrim<Type>>;
+  using Base::Base;
+};
+
+template <typename Type>
+struct UTF8RTrim : UTF8TrimBase<Type, false, true, UTF8RTrim<Type>> {
+  using Base = UTF8TrimBase<Type, false, true, UTF8RTrim<Type>>;
+  using Base::Base;
+};
+
+#endif
+
+template <typename Type, bool left, bool right, typename Derived>
+struct AsciiTrimWhitespaceBase : StringTransform<Type, Derived> {
+  using offset_type = typename Type::offset_type;
+  bool Transform(const uint8_t* input, offset_type input_string_ncodeunits,
+                 uint8_t* output, offset_type* output_written) {
+    const uint8_t* begin = input;
+    const uint8_t* end = input + input_string_ncodeunits;
+    const uint8_t* end_trimmed = end;
+
+    auto predicate = [](unsigned char c) { return !IsSpaceCharacterAscii(c); };
+    const uint8_t* begin_trimmed = left ? std::find_if(begin, end, predicate) : begin;
+    if (right & (begin_trimmed < end)) {
+      std::reverse_iterator<const uint8_t*> rbegin(end);
+      std::reverse_iterator<const uint8_t*> rend(begin_trimmed);
+      end_trimmed = std::find_if(rbegin, rend, predicate).base();
+    }
+    std::copy(begin_trimmed, end_trimmed, output);
+    *output_written = static_cast<offset_type>(end_trimmed - begin_trimmed);
+    return true;
+  }
+};
+
+template <typename Type>
+struct AsciiTrimWhitespace
+    : AsciiTrimWhitespaceBase<Type, true, true, AsciiTrimWhitespace<Type>> {};
+
+template <typename Type>
+struct AsciiLTrimWhitespace
+    : AsciiTrimWhitespaceBase<Type, true, false, AsciiLTrimWhitespace<Type>> {};
+
+template <typename Type>
+struct AsciiRTrimWhitespace
+    : AsciiTrimWhitespaceBase<Type, false, true, AsciiRTrimWhitespace<Type>> {};
+
+template <typename Type, bool left, bool right, typename Derived>
+struct AsciiTrimBase : StringTransform<Type, Derived> {
+  using Base = StringTransform<Type, Derived>;
+  using offset_type = typename Base::offset_type;
+  using State = OptionsWrapper<TrimOptions>;
+  TrimOptions options;
+  std::set<char> characters;
+
+  explicit AsciiTrimBase(TrimOptions options) : options(options) {
+    characters.insert(options.characters.begin(), options.characters.end());
+  }
+
+  static void Exec(KernelContext* ctx, const ExecBatch& batch, Datum* out) {
+    TrimOptions options = State::Get(ctx);
+    Derived(options).Execute(ctx, batch, out);
+  }
+
+  bool Transform(const uint8_t* input, offset_type input_string_ncodeunits,
+                 uint8_t* output, offset_type* output_written) {
+    const uint8_t* begin = input;
+    const uint8_t* end = input + input_string_ncodeunits;
+    const uint8_t* end_trimmed = end;
+    const uint8_t* begin_trimmed;
+
+    auto predicate = [&](unsigned char c) {
+      bool contains = characters.find(static_cast<char>(c)) != characters.end();
+      return !contains;
+    };
+
+    begin_trimmed = left ? std::find_if(begin, end, predicate) : begin;
+    if (right & (begin_trimmed < end)) {
+      std::reverse_iterator<const uint8_t*> rbegin(end);
+      std::reverse_iterator<const uint8_t*> rend(begin_trimmed);
+      end_trimmed = std::find_if(rbegin, rend, predicate).base();
+    }
+    std::copy(begin_trimmed, end_trimmed, output);
+    *output_written = static_cast<offset_type>(end_trimmed - begin_trimmed);
+    return true;
+  }
+};
+
+template <typename Type>
+struct AsciiTrim : AsciiTrimBase<Type, true, true, AsciiTrim<Type>> {
+  using Base = AsciiTrimBase<Type, true, true, AsciiTrim<Type>>;
+  using Base::Base;
+};
+
+template <typename Type>
+struct AsciiLTrim : AsciiTrimBase<Type, true, false, AsciiLTrim<Type>> {
+  using Base = AsciiTrimBase<Type, true, false, AsciiLTrim<Type>>;
+  using Base::Base;
+};
+
+template <typename Type>
+struct AsciiRTrim : AsciiTrimBase<Type, false, true, AsciiRTrim<Type>> {
+  using Base = AsciiTrimBase<Type, false, true, AsciiRTrim<Type>>;
+  using Base::Base;
+};
+
+const FunctionDoc utf8_trim_whitespace_doc(
+    "Trim leading and trailing whitespace characters",
+    ("For each string in `strings`, emit a string with leading and trailing whitespace "
+     "characters removed, where whitespace characters are defined by the Unicode "
+     "standard.  Null values emit null."),
+    {"strings"});
+
+const FunctionDoc utf8_ltrim_whitespace_doc(
+    "Trim leading whitespace characters",
+    ("For each string in `strings`, emit a string with leading whitespace "
+     "characters removed, where whitespace characters are defined by the Unicode "
+     "standard.  Null values emit null."),
+    {"strings"});
+
+const FunctionDoc utf8_rtrim_whitespace_doc(
+    "Trim trailing whitespace characters",
+    ("For each string in `strings`, emit a string with trailing whitespace "
+     "characters removed, where whitespace characters are defined by the Unicode "
+     "standard.  Null values emit null."),
+    {"strings"});
+
+const FunctionDoc ascii_trim_whitespace_doc(
+    "Trim leading and trailing ASCII whitespace characters",
+    ("For each string in `strings`, emit a string with leading and trailing ASCII "
+     "whitespace characters removed. Use `utf8_trim_whitespace` to trim Unicode "
+     "whitespace characters. Null values emit null."),
+    {"strings"});
+
+const FunctionDoc ascii_ltrim_whitespace_doc(
+    "Trim leading ASCII whitespace characters",
+    ("For each string in `strings`, emit a string with leading ASCII whitespace "
+     "characters removed.  Use `utf8_ltrim_whitespace` to trim leading Unicode "
+     "whitespace characters. Null values emit null."),
+    {"strings"});
+
+const FunctionDoc ascii_rtrim_whitespace_doc(
+    "Trim trailing ASCII whitespace characters",
+    ("For each string in `strings`, emit a string with trailing ASCII whitespace "
+     "characters removed. Use `utf8_rtrim_whitespace` to trim trailing Unicode "
+     "whitespace characters. Null values emit null."),
+    {"strings"});
+
+const FunctionDoc utf8_trim_doc(
+    "Trim leading and trailing characters present in the `characters` arguments",
+    ("For each string in `strings`, emit a string with leading and trailing "
+     "characters removed that are present in the `characters` argument.  Null values "
+     "emit "
+     "null."),
+    {"strings"}, "TrimOptions");
+
+const FunctionDoc utf8_ltrim_doc(
+    "Trim leading characters present in the `characters` arguments",
+    ("For each string in `strings`, emit a string with leading "
+     "characters removed that are present in the `characters` argument.  Null values "
+     "emit "
+     "null."),
+    {"strings"}, "TrimOptions");
+
+const FunctionDoc utf8_rtrim_doc(
+    "Trim trailing characters present in the `characters` arguments",
+    ("For each string in `strings`, emit a string with leading "
+     "characters removed that are present in the `characters` argument.  Null values "
+     "emit "
+     "null."),
+    {"strings"}, "TrimOptions");
+
+const FunctionDoc ascii_trim_doc(
+    utf8_trim_doc.summary + "",
+    utf8_trim_doc.description +
+        ("Both the input string as the `characters` argument are interepreted as ASCII "
+         "characters, to trim non-ASCII characters, use `utf8_trim"),
+    {"strings"}, "TrimOptions");
+
+const FunctionDoc ascii_ltrim_doc(
+    utf8_ltrim_doc.summary + "",
+    utf8_ltrim_doc.description +
+        ("Both the input string as the `characters` argument are interepreted as ASCII "
+         "characters, to trim non-ASCII characters, use `utf8_trim"),
+    {"strings"}, "TrimOptions");
+
+const FunctionDoc ascii_rtrim_doc(
+    utf8_rtrim_doc.summary + "",
+    utf8_rtrim_doc.description +
+        ("Both the input string as the `characters` argument are interepreted as ASCII "
+         "characters, to trim non-ASCII characters, use `utf8_trim"),
+    {"strings"}, "TrimOptions");
+
 const FunctionDoc strptime_doc(
     "Parse timestamps",
     ("For each string in `strings`, parse it as a timestamp.\n"
@@ -1283,6 +1600,26 @@ void MakeUnaryStringBatchKernel(
   {
     auto exec_64 = ExecFunctor<LargeStringType>::Exec;
     ScalarKernel kernel{{large_utf8()}, large_utf8(), exec_64};
+    kernel.mem_allocation = mem_allocation;
+    DCHECK_OK(func->AddKernel(std::move(kernel)));
+  }
+  DCHECK_OK(registry->AddFunction(std::move(func)));
+}
+
+template <template <typename> class ExecFunctor>
+void MakeUnaryStringBatchKernelWithState(
+    std::string name, FunctionRegistry* registry, const FunctionDoc* doc,
+    MemAllocation::type mem_allocation = MemAllocation::PREALLOCATE) {
+  auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), doc);
+  {
+    using t32 = ExecFunctor<StringType>;
+    ScalarKernel kernel{{utf8()}, utf8(), t32::Exec, t32::State::Init};
+    kernel.mem_allocation = mem_allocation;
+    DCHECK_OK(func->AddKernel(std::move(kernel)));
+  }
+  {
+    using t64 = ExecFunctor<LargeStringType>;
+    ScalarKernel kernel{{large_utf8()}, large_utf8(), t64::Exec, t64::State::Init};
     kernel.mem_allocation = mem_allocation;
     DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
@@ -1458,6 +1795,18 @@ void RegisterScalarStringAscii(FunctionRegistry* registry) {
                                          MemAllocation::NO_PREALLOCATE);
   MakeUnaryStringBatchKernel<AsciiLower>("ascii_lower", registry, &ascii_lower_doc,
                                          MemAllocation::NO_PREALLOCATE);
+  MakeUnaryStringBatchKernel<AsciiTrimWhitespace>("ascii_trim_whitespace", registry,
+                                                  &ascii_trim_whitespace_doc);
+  MakeUnaryStringBatchKernel<AsciiLTrimWhitespace>("ascii_ltrim_whitespace", registry,
+                                                   &ascii_ltrim_whitespace_doc);
+  MakeUnaryStringBatchKernel<AsciiRTrimWhitespace>("ascii_rtrim_whitespace", registry,
+                                                   &ascii_rtrim_whitespace_doc);
+  MakeUnaryStringBatchKernelWithState<AsciiTrim>("ascii_trim", registry,
+                                                 &ascii_lower_doc);
+  MakeUnaryStringBatchKernelWithState<AsciiLTrim>("ascii_ltrim", registry,
+                                                  &ascii_lower_doc);
+  MakeUnaryStringBatchKernelWithState<AsciiRTrim>("ascii_rtrim", registry,
+                                                  &ascii_lower_doc);
 
   AddUnaryStringPredicate<IsAscii>("string_is_ascii", registry, &string_is_ascii_doc);
 
@@ -1478,6 +1827,15 @@ void RegisterScalarStringAscii(FunctionRegistry* registry) {
 #ifdef ARROW_WITH_UTF8PROC
   MakeUnaryStringUTF8TransformKernel<UTF8Upper>("utf8_upper", registry, &utf8_upper_doc);
   MakeUnaryStringUTF8TransformKernel<UTF8Lower>("utf8_lower", registry, &utf8_lower_doc);
+  MakeUnaryStringBatchKernel<UTF8TrimWhitespace>("utf8_trim_whitespace", registry,
+                                                 &utf8_trim_whitespace_doc);
+  MakeUnaryStringBatchKernel<UTF8LTrimWhitespace>("utf8_ltrim_whitespace", registry,
+                                                  &utf8_ltrim_whitespace_doc);
+  MakeUnaryStringBatchKernel<UTF8RTrimWhitespace>("utf8_rtrim_whitespace", registry,
+                                                  &utf8_rtrim_whitespace_doc);
+  MakeUnaryStringBatchKernelWithState<UTF8Trim>("utf8_trim", registry, &utf8_trim_doc);
+  MakeUnaryStringBatchKernelWithState<UTF8LTrim>("utf8_ltrim", registry, &utf8_ltrim_doc);
+  MakeUnaryStringBatchKernelWithState<UTF8RTrim>("utf8_rtrim", registry, &utf8_rtrim_doc);
 
   AddUnaryStringPredicate<IsAlphaNumericUnicode>("utf8_is_alnum", registry,
                                                  &utf8_is_alnum_doc);

--- a/cpp/src/arrow/compute/kernels/scalar_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string.cc
@@ -1308,7 +1308,7 @@ struct UTF8TrimBase : StringTransform<Type, Derived> {
   explicit UTF8TrimBase(TrimOptions options) : options(options) {
     // TODO: check return / can we raise an exception here?
     arrow::util::UTF8ForEach(options.characters, [&](uint32_t c) {
-      codepoints.reserve(c);
+      codepoints.resize(c);
       codepoints[c] = true;
     });
   }

--- a/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_benchmark.cc
@@ -71,6 +71,16 @@ static void SplitPattern(benchmark::State& state) {
   UnaryStringBenchmark(state, "split_pattern", &options);
 }
 
+static void TrimSingleAscii(benchmark::State& state) {
+  TrimOptions options("a");
+  UnaryStringBenchmark(state, "ascii_trim", &options);
+}
+
+static void TrimManyAscii(benchmark::State& state) {
+  TrimOptions options("abcdefgABCDEFG");
+  UnaryStringBenchmark(state, "ascii_trim", &options);
+}
+
 #ifdef ARROW_WITH_UTF8PROC
 static void Utf8Upper(benchmark::State& state) {
   UnaryStringBenchmark(state, "utf8_upper");
@@ -83,6 +93,15 @@ static void Utf8Lower(benchmark::State& state) {
 static void IsAlphaNumericUnicode(benchmark::State& state) {
   UnaryStringBenchmark(state, "utf8_is_alnum");
 }
+static void TrimSingleUtf8(benchmark::State& state) {
+  TrimOptions options("a");
+  UnaryStringBenchmark(state, "utf8_trim", &options);
+}
+
+static void TrimManyUtf8(benchmark::State& state) {
+  TrimOptions options("abcdefgABCDEFG");
+  UnaryStringBenchmark(state, "utf8_trim", &options);
+}
 #endif
 
 BENCHMARK(AsciiLower);
@@ -90,10 +109,14 @@ BENCHMARK(AsciiUpper);
 BENCHMARK(IsAlphaNumericAscii);
 BENCHMARK(MatchSubstring);
 BENCHMARK(SplitPattern);
+BENCHMARK(TrimSingleAscii);
+BENCHMARK(TrimManyAscii);
 #ifdef ARROW_WITH_UTF8PROC
 BENCHMARK(Utf8Lower);
 BENCHMARK(Utf8Upper);
 BENCHMARK(IsAlphaNumericUnicode);
+BENCHMARK(TrimSingleUtf8);
+BENCHMARK(TrimManyUtf8);
 #endif
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -429,6 +429,59 @@ TYPED_TEST(TestStringKernels, StrptimeDoesNotProvideDefaultOptions) {
 }
 
 #ifdef ARROW_WITH_UTF8PROC
+
+TYPED_TEST(TestStringKernels, TrimWhitespaceUTF8) {
+  // \xe2\x80\x88 is punctuation space
+  this->CheckUnary("utf8_trim_whitespace",
+                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   this->type(), "[\"foo\", null, \"bar\", \"foo bar\"]");
+  this->CheckUnary("utf8_rtrim_whitespace",
+                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   this->type(), "[\" foo\", null, \"bar\", \" \xe2\x80\x88 foo bar\"]");
+  this->CheckUnary("utf8_ltrim_whitespace",
+                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   this->type(), "[\"foo\", null, \"bar  \", \"foo bar \"]");
+}
+
+TYPED_TEST(TestStringKernels, TrimUTF8) {
+  TrimOptions options{"ȺA"};
+  this->CheckUnary("utf8_trim", "[\"ȺȺfooȺAȺ\", null, \"barȺAȺ\", \"ȺAȺfooȺAȺbarA\"]",
+                   this->type(), "[\"foo\", null, \"bar\", \"fooȺAȺbar\"]", &options);
+  this->CheckUnary("utf8_ltrim", "[\"ȺȺfooȺAȺ\", null, \"barȺAȺ\", \"ȺAȺfooȺAȺbarA\"]",
+                   this->type(), "[\"fooȺAȺ\", null, \"barȺAȺ\", \"fooȺAȺbarA\"]",
+                   &options);
+  this->CheckUnary("utf8_rtrim", "[\"ȺȺfooȺAȺ\", null, \"barȺAȺ\", \"ȺAȺfooȺAȺbarA\"]",
+                   this->type(), "[\"ȺȺfoo\", null, \"bar\", \"ȺAȺfooȺAȺbar\"]",
+                   &options);
+}
+#endif
+
+TYPED_TEST(TestStringKernels, TrimWhitespaceAscii) {
+  // \xe2\x80\x88 is punctuation space
+  this->CheckUnary("ascii_trim_whitespace",
+                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   this->type(), "[\"foo\", null, \"bar\", \"\xe2\x80\x88 foo bar\"]");
+  this->CheckUnary("ascii_rtrim_whitespace",
+                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   this->type(), "[\" foo\", null, \"bar\", \" \xe2\x80\x88 foo bar\"]");
+  this->CheckUnary("ascii_ltrim_whitespace",
+                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   this->type(), "[\"foo\", null, \"bar  \", \"\xe2\x80\x88 foo bar \"]");
+}
+
+TYPED_TEST(TestStringKernels, TrimAscii) {
+  TrimOptions options{"BA"};
+  this->CheckUnary("ascii_trim", "[\"BBfooBAB\", null, \"barBAB\", \"BABfooBABbarA\"]",
+                   this->type(), "[\"foo\", null, \"bar\", \"fooBABbar\"]", &options);
+  this->CheckUnary("ascii_ltrim", "[\"BBfooBAB\", null, \"barBAB\", \"BABfooBABbarA\"]",
+                   this->type(), "[\"fooBAB\", null, \"barBAB\", \"fooBABbarA\"]",
+                   &options);
+  this->CheckUnary("ascii_rtrim", "[\"BBfooBAB\", null, \"barBAB\", \"BABfooBABbarA\"]",
+                   this->type(), "[\"BBfoo\", null, \"bar\", \"BABfooBABbar\"]",
+                   &options);
+}
+
+#ifdef ARROW_WITH_UTF8PROC
 TEST(TestStringKernels, UnicodeLibraryAssumptions) {
   uint8_t output[4];
   for (utf8proc_int32_t codepoint = 0x100; codepoint < 0x110000; codepoint++) {

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -433,13 +433,14 @@ TYPED_TEST(TestStringKernels, StrptimeDoesNotProvideDefaultOptions) {
 TYPED_TEST(TestStringKernels, TrimWhitespaceUTF8) {
   // \xe2\x80\x88 is punctuation space
   this->CheckUnary("utf8_trim_whitespace",
-                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   "[\" \\tfoo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
                    this->type(), "[\"foo\", null, \"bar\", \"foo bar\"]");
   this->CheckUnary("utf8_rtrim_whitespace",
-                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
-                   this->type(), "[\" foo\", null, \"bar\", \" \xe2\x80\x88 foo bar\"]");
+                   "[\" \\tfoo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   this->type(),
+                   "[\" \\tfoo\", null, \"bar\", \" \xe2\x80\x88 foo bar\"]");
   this->CheckUnary("utf8_ltrim_whitespace",
-                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   "[\" \\tfoo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
                    this->type(), "[\"foo\", null, \"bar  \", \"foo bar \"]");
 }
 
@@ -459,13 +460,14 @@ TYPED_TEST(TestStringKernels, TrimUTF8) {
 TYPED_TEST(TestStringKernels, TrimWhitespaceAscii) {
   // \xe2\x80\x88 is punctuation space
   this->CheckUnary("ascii_trim_whitespace",
-                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   "[\" \\tfoo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
                    this->type(), "[\"foo\", null, \"bar\", \"\xe2\x80\x88 foo bar\"]");
   this->CheckUnary("ascii_rtrim_whitespace",
-                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
-                   this->type(), "[\" foo\", null, \"bar\", \" \xe2\x80\x88 foo bar\"]");
+                   "[\" \\tfoo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   this->type(),
+                   "[\" \\tfoo\", null, \"bar\", \" \xe2\x80\x88 foo bar\"]");
   this->CheckUnary("ascii_ltrim_whitespace",
-                   "[\" foo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
+                   "[\" \\tfoo\", null, \"bar  \", \" \xe2\x80\x88 foo bar \"]",
                    this->type(), "[\"foo\", null, \"bar  \", \"\xe2\x80\x88 foo bar \"]");
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -454,6 +454,11 @@ TYPED_TEST(TestStringKernels, TrimUTF8) {
   this->CheckUnary("utf8_rtrim", "[\"ȺȺfooȺAȺ\", null, \"barȺAȺ\", \"ȺAȺfooȺAȺbarA\"]",
                    this->type(), "[\"ȺȺfoo\", null, \"bar\", \"ȺAȺfooȺAȺbar\"]",
                    &options);
+
+  TrimOptions options_invalid{"ɑa\xFFɑ"};
+  auto input = ArrayFromJSON(this->type(), "[\"foo\"]");
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, testing::HasSubstr("Invalid UTF8"),
+                                  CallFunction("utf8_trim", {input}, &options_invalid));
 }
 #endif
 

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -475,11 +475,14 @@ static inline bool UTF8FindIf(const uint8_t* first, const uint8_t* last,
   return true;
 }
 
-// same semantics as std::find_if using reverse iterators when the return value
+// Same semantics as std::find_if using reverse iterators with the return value
 // having the same semantics as std::reverse_iterator<..>.base()
+// A reverse iterator physically points to the next address, e.g.:
+// &*reverse_iterator(i) == &*(i + 1)
 template <class Predicate>
 static inline bool UTF8FindIfReverse(const uint8_t* first, const uint8_t* last,
                                      Predicate&& predicate, const uint8_t** position) {
+  // converts to a normal point
   const uint8_t* i = last - 1;
   while (i >= first) {
     uint32_t codepoint = 0;
@@ -488,10 +491,13 @@ static inline bool UTF8FindIfReverse(const uint8_t* first, const uint8_t* last,
       return false;
     }
     if (predicate(codepoint)) {
+      // converts normal pointer to 'reverse iterator semantics'.
       *position = current + 1;
       return true;
     }
   }
+  // similar to how an end pointer point to 1 beyond the last, reverse iterators point
+  // to the 'first' pointer to indicate out of range.
   *position = first;
   return true;
 }

--- a/cpp/src/arrow/util/utf8.h
+++ b/cpp/src/arrow/util/utf8.h
@@ -511,7 +511,7 @@ static inline bool UTF8ForEach(const uint8_t* first, const uint8_t* last,
 }
 
 template <class UnaryFunction>
-static inline bool UTF8ForEach(std::string s, UnaryFunction&& f) {
+static inline bool UTF8ForEach(const std::string& s, UnaryFunction&& f) {
   return UTF8ForEach(reinterpret_cast<const uint8_t*>(s.data()),
                      reinterpret_cast<const uint8_t*>(s.data() + s.length()),
                      std::forward<UnaryFunction>(f));

--- a/cpp/src/arrow/util/utf8_util_test.cc
+++ b/cpp/src/arrow/util/utf8_util_test.cc
@@ -429,14 +429,45 @@ TEST(UTF8FindIf, Basics) {
     EXPECT_EQ(std::find_if(begin, end, predicate) - begin, left - begin);
     EXPECT_EQ(std::find_if(rbegin, rend, predicate).base() - begin, right - begin);
   };
+  auto CheckOkUTF8 = [](const std::string& s, uint32_t test, int64_t offset_left,
+                        int64_t offset_right) -> void {
+    const uint8_t* begin = reinterpret_cast<const uint8_t*>(s.c_str());
+    const uint8_t* end = begin + s.length();
+    std::reverse_iterator<const uint8_t*> rbegin(end);
+    std::reverse_iterator<const uint8_t*> rend(begin);
+    const uint8_t* left;
+    const uint8_t* right;
+    auto predicate = [&](uint32_t c) { return c == test; };
+    EXPECT_TRUE(UTF8FindIf(begin, end, predicate, &left));
+    EXPECT_TRUE(UTF8FindIfReverse(begin, end, predicate, &right));
+    EXPECT_EQ(offset_left, left - begin);
+    EXPECT_EQ(offset_right, right - begin);
+    // we cannot check the unicode version with find_if semantics, because it's byte based
+    // EXPECT_EQ(std::find_if(begin, end, predicate) - begin, left - begin);
+    // EXPECT_EQ(std::find_if(rbegin, rend, predicate).base() - begin, right - begin);
+  };
 
   CheckOk("aaaba", 'a', 0, 5);
+  CheckOkUTF8("aaaβa", 'a', 0, 6);
+
   CheckOk("aaaba", 'b', 3, 4);
+  CheckOkUTF8("aaaβa", U'β', 3, 5);
+
   CheckOk("aaababa", 'b', 3, 6);
+  CheckOkUTF8("aaaβaβa", U'β', 3, 8);
+
   CheckOk("aaababa", 'c', 7, 0);
+  CheckOk("aaaβaβa", 'c', 9, 0);
+  CheckOkUTF8("aaaβaβa", U'ɑ', 9, 0);
+
   CheckOk("a", 'a', 0, 1);
+  CheckOkUTF8("ɑ", U'ɑ', 0, 2);
+
   CheckOk("a", 'b', 1, 0);
+  CheckOkUTF8("ɑ", 'b', 2, 0);
+
   CheckOk("", 'b', 0, 0);
+  CheckOkUTF8("", U'β', 0, 0);
 }
 
 }  // namespace util

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -379,6 +379,53 @@ String transforms
 * \(3) Each UTF8-encoded character in the input is converted to lowercase or
   uppercase.
 
+
+String trimming
+~~~~~~~~~~~~~~~
+
+These functions trim off characters on both sides (trim), or the left (ltrim) or right side (rtrim).
+
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| Function name            | Arity      | Input types             | Output type         | Options class                          | Notes   |
++==========================+============+=========================+=====================+========================================+=========+
+| ascii_ltrim              | Unary      | String-like             | String-like         | :struct:`TrimOptions`                  | \(1)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| ascii_ltrim_whitespace   | Unary      | String-like             | String-like         |                                        | \(2)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| ascii_rtrim              | Unary      | String-like             | String-like         | :struct:`TrimOptions`                  | \(1)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| ascii_rtrim_whitespace   | Unary      | String-like             | String-like         |                                        | \(2)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| ascii_trim               | Unary      | String-like             | String-like         | :struct:`TrimOptions`                  | \(1)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| ascii_trim_whitespace    | Unary      | String-like             | String-like         |                                        | \(2)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| utf8_ltrim               | Unary      | String-like             | String-like         | :struct:`TrimOptions`                  | \(3)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| utf8_ltrim_whitespace    | Unary      | String-like             | String-like         |                                        | \(4)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| utf8_rtrim               | Unary      | String-like             | String-like         | :struct:`TrimOptions`                  | \(3)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| utf8_rtrim_whitespace    | Unary      | String-like             | String-like         |                                        | \(4)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| utf8_trim                | Unary      | String-like             | String-like         | :struct:`TrimOptions`                  | \(3)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+| utf8_trim_whitespace     | Unary      | String-like             | String-like         |                                        | \(4)    |
++--------------------------+------------+-------------------------+---------------------+----------------------------------------+---------+
+
+* \(1) Only characters specified in :member:`TrimOptions::characters` will be
+trimmed off. Both the input string as the `characters` argument are interepreted
+as ASCII characters.
+
+* \(2) Only trim off ASCII whitespace characters (``'\t'``, ``'\n'``, ``'\v'``,
+``'\f'``, ``'\r'``  and ``' '``).
+
+* \(3) Only characters specified in :member:`TrimOptions::characters` will be
+trimmed off.
+
+* \(4) Only trim off Unicode whitespace characters.
+
+
 Containment tests
 ~~~~~~~~~~~~~~~~~
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -606,6 +606,23 @@ class MatchSubstringOptions(_MatchSubstringOptions):
         self._set_options(pattern)
 
 
+cdef class _TrimOptions(FunctionOptions):
+    cdef:
+        unique_ptr[CTrimOptions] trim_options
+
+    cdef const CFunctionOptions* get_options(self) except NULL:
+        return self.trim_options.get()
+
+    def _set_options(self, characters):
+        self.trim_options.reset(
+            new CTrimOptions(tobytes(characters)))
+
+
+class TrimOptions(_TrimOptions):
+    def __init__(self, characters):
+        self._set_options(characters)
+
+
 cdef class _FilterOptions(FunctionOptions):
     cdef:
         CFilterOptions filter_options

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -33,6 +33,7 @@ from pyarrow._compute import (  # noqa
     MatchSubstringOptions,
     SplitOptions,
     SplitPatternOptions,
+    TrimOptions,
     MinMaxOptions,
     ModeOptions,
     PartitionNthOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1704,6 +1704,11 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         CMatchSubstringOptions(c_string pattern)
         c_string pattern
 
+    cdef cppclass CTrimOptions \
+            "arrow::compute::TrimOptions"(CFunctionOptions):
+        CTrimOptions(c_string characters)
+        c_string characters
+
     cdef cppclass CSplitOptions \
             "arrow::compute::SplitOptions"(CFunctionOptions):
         CSplitOptions(int64_t max_splits, c_bool reverse)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -269,6 +269,24 @@ def test_match_substring():
     assert expected.equals(result)
 
 
+def test_trim():
+    # \u3000 is unicode whitespace
+    arr = pa.array([" foo", None, " \u3000foo bar \t"])
+    result = pc.utf8_trim_whitespace(arr)
+    expected = pa.array(["foo", None, "foo bar"])
+    assert expected.equals(result)
+
+    arr = pa.array([" foo", None, " \u3000foo bar \t"])
+    result = pc.ascii_trim_whitespace(arr)
+    expected = pa.array(["foo", None, "\u3000foo bar"])
+    assert expected.equals(result)
+
+    arr = pa.array([" foo", None, " \u3000foo bar \t"])
+    result = pc.utf8_trim(arr, characters=' f\u3000')
+    expected = pa.array(["oo", None, "oo bar \t"])
+    assert expected.equals(result)
+
+
 def test_split_pattern():
     arr = pa.array(["-foo---bar--", "---foo---b"])
     result = pc.split_pattern(arr, pattern="---")


### PR DESCRIPTION
There is one obvious loose end in this PR, which is where to generate the `std::set` based on the `TrimOptions` (now in the ctor of UTF8TrimBase). I'm not sure what the lifetime guarantees are for this object (TrimOptions), where it makes sense to initialize this set, and when an (utf8 decoding) error occurs, how/where to report this.

Although this is not a costly operation, assuming people don't pass in a billion characters to trim, I do wonder what the best approach here is in general. It does not make much sense to create the `std::set` at each `Exec` call, but that is what happens now. (This also seems to happen in `TransformMatchSubstring` for creating the `prefix_table` btw.)

Maybe a good place to put per-kernel pre-compute results are the `*Options` objects, but I'm not sure if that makes sense in the current architecture.

Another idea is to explore alternatives to the `std::set`. It seem that (based on the TrimManyAscii benchmark), `std::unordered_set` seemed a bit slower, and simply using a linear search: `std::find(options.characters.begin(), options.characters.end(), c) != options.characters.end()` in the predicate instead of the set doesn't seem to affect performance that much.

In CPython, a bloom filter is used, I could explore to see if that makes sense, but the implementation in Arrow lives under the parquet namespace.




