### PR TITLE
ARROW-10543: [Developer] Add a note about being patient after gitbox is enabled

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -24,8 +24,12 @@ testing, or committing to Arrow.
 
 Merging a pull request requires being a committer on the project. In addition
 you need to have linked your GitHub and ASF accounts on
-https://gitbox.apache.org/setup/ to be able to push to GitHub as the main
+https://gitbox.apache.org/setup/ to be able to push to GitHub as the mainshe
 remote.
+
+NOTE: It may take some time (a few hours) between when you complete
+the setup at GitBox, and when your github account will be added as a
+committer.
 
 ## How to merge a Pull request
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -28,7 +28,7 @@ https://gitbox.apache.org/setup/ to be able to push to GitHub as the main
 remote.
 
 NOTE: It may take some time (a few hours) between when you complete
-the setup at GitBox, and when your github account will be added as a
+the setup at GitBox, and when your GitHub account will be added as a
 committer.
 
 ## How to merge a Pull request

--- a/dev/README.md
+++ b/dev/README.md
@@ -24,7 +24,7 @@ testing, or committing to Arrow.
 
 Merging a pull request requires being a committer on the project. In addition
 you need to have linked your GitHub and ASF accounts on
-https://gitbox.apache.org/setup/ to be able to push to GitHub as the mainshe
+https://gitbox.apache.org/setup/ to be able to push to GitHub as the main
 remote.
 
 NOTE: It may take some time (a few hours) between when you complete


### PR DESCRIPTION
When following the developer instructions, I was hung up for a while on the fact that there seemed to be a time lag between when I completed the gitbox setup and when permissions were actually granted to the repo. Update the docs to try and help the next person.

FYI @wesm and @jorgecarleitao  (I wonder if Jorge hit the same issue when he reported the same symptoms I was seeing here https://lists.apache.org/thread.html/r2420f6d13601913100ed49bc955bb7925fc4a91b5601995190467bbb%40%3Cdev.arrow.apache.org%3E)