### PR TITLE
ARROW-10545: [C++] Fix crash on invalid Parquet file (OSS-Fuzz)

### DIFF
--- a/cpp/src/parquet/level_conversion.h
+++ b/cpp/src/parquet/level_conversion.h
@@ -138,13 +138,13 @@ struct PARQUET_EXPORT LevelInfo {
 struct PARQUET_EXPORT ValidityBitmapInputOutput {
   // Input only.
   // The maximum number of values_read expected (actual
-  // values read must be less than or equal to this value.
+  // values read must be less than or equal to this value).
   // If this number is exceeded methods will throw a
   // ParquetException. Exceeding this limit indicates
   // either a corrupt or incorrectly written file.
   int64_t values_read_upper_bound = 0;
   // Output only. The number of values added to the encountered
-  // (this is logicallyt he count of the number of elements
+  // (this is logically the count of the number of elements
   // for an Arrow array).
   int64_t values_read = 0;
   // Input/Output. The number of nulls encountered.


### PR DESCRIPTION
Also removed a memory allocation (probably not performance-critical).