### PR TITLE
ARROW-10547: [Rust][DataFusion] Do not lose Filters with UserDefined plan nodes

### DIFF
--- a/rust/datafusion/src/test/mod.rs
+++ b/rust/datafusion/src/test/mod.rs
@@ -249,6 +249,7 @@ pub fn assert_fields_eq(plan: &LogicalPlan, expected: Vec<&str>) {
     assert_eq!(actual, expected);
 }
 
+pub mod user_defined;
 pub mod variable;
 
 mod tests {

--- a/rust/datafusion/src/test/user_defined.rs
+++ b/rust/datafusion/src/test/user_defined.rs
@@ -52,7 +52,6 @@ impl UserDefinedLogicalNode for TestUserDefinedPlanNode {
         vec![&self.input]
     }
 
-    /// Schema for TestUserDefined is the same as the input
     fn schema(&self) -> &SchemaRef {
         self.input.schema()
     }
@@ -61,7 +60,6 @@ impl UserDefinedLogicalNode for TestUserDefinedPlanNode {
         vec![]
     }
 
-    /// For example: `TestUserDefined: k=10`
     fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "TestUserDefined")
     }

--- a/rust/datafusion/src/test/user_defined.rs
+++ b/rust/datafusion/src/test/user_defined.rs
@@ -1,0 +1,80 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Simple user defined logical plan node for testing
+
+use std::{
+    any::Any,
+    fmt::{self, Debug},
+    sync::Arc,
+};
+
+use arrow::datatypes::SchemaRef;
+
+use crate::logical_plan::{Expr, LogicalPlan, UserDefinedLogicalNode};
+
+/// Create a new user defined plan node, for testing
+pub fn new(input: LogicalPlan) -> LogicalPlan {
+    let node = Arc::new(TestUserDefinedPlanNode { input });
+    LogicalPlan::Extension { node }
+}
+
+struct TestUserDefinedPlanNode {
+    input: LogicalPlan,
+}
+
+impl Debug for TestUserDefinedPlanNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.fmt_for_explain(f)
+    }
+}
+
+impl UserDefinedLogicalNode for TestUserDefinedPlanNode {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    /// Schema for TestUserDefined is the same as the input
+    fn schema(&self) -> &SchemaRef {
+        self.input.schema()
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    /// For example: `TestUserDefined: k=10`
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "TestUserDefined")
+    }
+
+    fn from_template(
+        &self,
+        exprs: &Vec<Expr>,
+        inputs: &Vec<LogicalPlan>,
+    ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
+        assert_eq!(inputs.len(), 1, "input size inconsistent");
+        assert_eq!(exprs.len(), 0, "expression size inconsistent");
+        Arc::new(TestUserDefinedPlanNode {
+            input: inputs[0].clone(),
+        })
+    }
+}


### PR DESCRIPTION
I have a LogicalPlan like this (where "Extension" is some extension node type):


```
    Extension [non_null_column:Utf8]
      Filter: #state Eq Utf8("MA") [city:Utf8;N, state:Utf8;N, borough:Utf8;N]
        InMemoryScan: projection=None [city:Utf8;N, state:Utf8;N, borough:Utf8;N]
```

When I run this plan through {{ExecutionContext::optimize}} the plan that results is as follows (note the filter has been lost):

```
    Extension [non_null_column:Utf8]
      InMemoryScan: projection=Some([0, 1, 2]) [city:Utf8;N, state:Utf8;N, borough:Utf8;N]
````

I have debugged the problem and the root cause of the issue is that the `FilterPushDown` logic is not recursing into the inputs of user defined nodes. 

This PR has a fix for the problem

