### PR TITLE
ARROW-10021: [C++][Compute] Return top-n modes in mode kernel

### DIFF
--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -41,8 +41,8 @@ Result<Datum> MinMax(const Datum& value, const MinMaxOptions& options, ExecConte
   return CallFunction("min_max", {value}, &options, ctx);
 }
 
-Result<Datum> Mode(const Datum& value, ExecContext* ctx) {
-  return CallFunction("mode", {value}, ctx);
+Result<Datum> Mode(const Datum& value, const ModeOptions& options, ExecContext* ctx) {
+  return CallFunction("mode", {value}, &options, ctx);
 }
 
 Result<Datum> Stddev(const Datum& value, const VarianceOptions& options,

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -81,11 +81,11 @@ struct ARROW_EXPORT MinMaxOptions : public FunctionOptions {
 /// Returns top-n common values and counts.
 /// By default, returns the most common value and count.
 struct ARROW_EXPORT ModeOptions : public FunctionOptions {
-  explicit ModeOptions(int n = 1) : n(n) {}
+  explicit ModeOptions(int64_t n = 1) : n(n) {}
 
   static ModeOptions Defaults() { return ModeOptions{}; }
 
-  int n = 1;
+  int64_t n = 1;
 };
 
 /// \brief Control Delta Degrees of Freedom (ddof) of Variance and Stddev kernel

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -76,6 +76,18 @@ struct ARROW_EXPORT MinMaxOptions : public FunctionOptions {
   enum Mode null_handling;
 };
 
+/// \brief Control Mode kernel behavior
+///
+/// Returns top-n common values and counts.
+/// By default, returns the most common value and count.
+struct ARROW_EXPORT ModeOptions : public FunctionOptions {
+  explicit ModeOptions(int n = 1) : n(n) {}
+
+  static ModeOptions Defaults() { return ModeOptions{}; }
+
+  int n = 1;
+};
+
 /// \brief Control Delta Degrees of Freedom (ddof) of Variance and Stddev kernel
 ///
 /// The divisor used in calculations is N - ddof, where N is the number of elements.
@@ -142,20 +154,24 @@ Result<Datum> MinMax(const Datum& value,
                      const MinMaxOptions& options = MinMaxOptions::Defaults(),
                      ExecContext* ctx = NULLPTR);
 
-/// \brief Calculate the modal (most common) value of a numeric array
+/// \brief Calculate the modal (most common) values of a numeric array
 ///
-/// This function returns both mode and count as a struct scalar, with type
-/// struct<mode: T, count: int64>, where T is the input type.
-/// If there is more than one such value, the smallest one is returned.
+/// This function returns top-n most common values and number of times they occur as
+/// an array of `struct<mode: T, count: int64>`, where T is the input type.
+/// Values with larger counts are returned before smaller ones.
+/// If there are more than one values with same count, smaller value is returned first.
 ///
 /// \param[in] value input datum, expecting Array or ChunkedArray
+/// \param[in] options see ModeOptions for more information
 /// \param[in] ctx the function execution context, optional
-/// \return resulting datum as a struct<mode: T, count: int64> scalar
+/// \return resulting datum as an array of struct<mode: T, count: int64>
 ///
 /// \since 2.0.0
 /// \note API not yet finalized
 ARROW_EXPORT
-Result<Datum> Mode(const Datum& value, ExecContext* ctx = NULLPTR);
+Result<Datum> Mode(const Datum& value,
+                   const ModeOptions& options = ModeOptions::Defaults(),
+                   ExecContext* ctx = NULLPTR);
 
 /// \brief Calculate the standard deviation of a numeric array
 ///

--- a/cpp/src/arrow/compute/kernels/aggregate_mode.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <cmath>
+#include <queue>
 #include <unordered_map>
 
 #include "arrow/compute/api_aggregate.h"
@@ -27,6 +28,9 @@ namespace compute {
 namespace internal {
 
 namespace {
+
+constexpr char kModeFieldName[] = "modes";
+constexpr char kCountFieldName[] = "counts";
 
 // {value:count} map
 template <typename CType>
@@ -165,23 +169,55 @@ struct ModeState {
     }
   }
 
-  std::pair<CType, int64_t> Finalize() {
-    CType mode = std::numeric_limits<CType>::min();
-    int64_t count = 0;
+  // find top-n value/count pairs with min-heap (priority queue with '>' comparator)
+  void Finalize(CType* modes, int64_t* counts, const int n) {
+    DCHECK(n >= 1 && n <= this->DistinctValues());
 
-    for (const auto& value_count : this->value_counts) {
-      auto this_value = value_count.first;
-      auto this_count = value_count.second;
-      if (this_count > count || (this_count == count && this_value < mode)) {
-        count = this_count;
-        mode = this_value;
+    // mode 'greater than' comparator: larger count or same count with smaller value
+    using ValueCountPair = std::pair<CType, int64_t>;
+    auto mode_gt = [](const ValueCountPair& lhs, const ValueCountPair& rhs) {
+      const bool rhs_is_nan = rhs.first != rhs.first;  // nan as largest value
+      return lhs.second > rhs.second ||
+             (lhs.second == rhs.second && (lhs.first < rhs.first || rhs_is_nan));
+    };
+
+    // initialize min-heap with first n modes
+    std::vector<ValueCountPair> vector(n);
+    // push nan if exists
+    const bool has_nan = is_floating_type<ArrowType>::value && this->nan_count > 0;
+    if (has_nan) {
+      vector[0] = std::make_pair(NAN, this->nan_count);
+    }
+    // push n or n-1 modes
+    auto it = this->value_counts.cbegin();
+    for (int i = has_nan; i < n; ++i) {
+      vector[i] = *it++;
+    }
+    // turn to min-heap
+    std::priority_queue<ValueCountPair, std::vector<ValueCountPair>, decltype(mode_gt)>
+        min_heap(std::move(mode_gt), std::move(vector));
+
+    // iterate and insert modes into min-heap
+    // - mode < heap top: ignore mode
+    // - mode > heap top: discard heap top, insert mode
+    for (; it != this->value_counts.cend(); ++it) {
+      if (mode_gt(*it, min_heap.top())) {
+        min_heap.pop();
+        min_heap.push(*it);
       }
     }
-    if (is_floating_type<ArrowType>::value && this->nan_count > count) {
-      count = this->nan_count;
-      mode = static_cast<CType>(NAN);
+
+    // pop modes from min-heap and insert into output array (in reverse order)
+    DCHECK_EQ(min_heap.size(), static_cast<size_t>(n));
+    for (int i = n - 1; i >= 0; --i) {
+      std::tie(modes[i], counts[i]) = min_heap.top();
+      min_heap.pop();
     }
-    return std::make_pair(mode, count);
+  }
+
+  int64_t DistinctValues() const {
+    return this->value_counts.size() +
+           (is_floating_type<ArrowType>::value && this->nan_count > 0);
   }
 
   int64_t nan_count = 0;  // only make sense to floating types
@@ -192,8 +228,10 @@ template <typename ArrowType>
 struct ModeImpl : public ScalarAggregator {
   using ThisType = ModeImpl<ArrowType>;
   using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
+  using CType = typename ArrowType::c_type;
 
-  explicit ModeImpl(const std::shared_ptr<DataType>& out_type) : out_type(out_type) {}
+  ModeImpl(const std::shared_ptr<DataType>& out_type, const ModeOptions& options)
+      : out_type(out_type), options(options) {}
 
   void Consume(KernelContext*, const ExecBatch& batch) override {
     ArrayType array(batch[0].array());
@@ -205,24 +243,47 @@ struct ModeImpl : public ScalarAggregator {
     this->state.MergeFrom(std::move(other.state));
   }
 
-  void Finalize(KernelContext*, Datum* out) override {
-    using ModeType = typename TypeTraits<ArrowType>::ScalarType;
-    using CountType = typename TypeTraits<Int64Type>::ScalarType;
+  static std::shared_ptr<ArrayData> MakeArrayData(
+      const std::shared_ptr<DataType>& data_type, int64_t n) {
+    auto data = ArrayData::Make(data_type, n, 0);
+    data->buffers.resize(2);
+    data->buffers[0] = nullptr;
+    return data;
+  }
 
-    std::vector<std::shared_ptr<Scalar>> values;
-    auto mode_count = this->state.Finalize();
-    auto mode = mode_count.first;
-    auto count = mode_count.second;
-    if (count == 0) {
-      values = {std::make_shared<ModeType>(), std::make_shared<CountType>()};
-    } else {
-      values = {std::make_shared<ModeType>(mode), std::make_shared<CountType>(count)};
+  void Finalize(KernelContext* ctx, Datum* out) override {
+    const auto& mode_type = TypeTraits<ArrowType>::type_singleton();
+    const auto& count_type = int64();
+    const auto& out_type =
+        struct_({field(kModeFieldName, mode_type), field(kCountFieldName, count_type)});
+
+    int n = this->options.n;
+    if (n > state.DistinctValues()) {
+      n = state.DistinctValues();
     }
-    out->value = std::make_shared<StructScalar>(std::move(values), this->out_type);
+    if (n <= 0) {
+      *out = Datum(StructArray(out_type, 0, ArrayVector{}).data());
+      return;
+    }
+
+    auto mode_data = this->MakeArrayData(mode_type, n);
+    auto count_data = this->MakeArrayData(count_type, n);
+    KERNEL_ASSIGN_OR_RAISE(mode_data->buffers[1], ctx, ctx->Allocate(n * sizeof(CType)));
+    KERNEL_ASSIGN_OR_RAISE(count_data->buffers[1], ctx,
+                           ctx->Allocate(n * sizeof(int64_t)));
+
+    CType* mode_buffer = mode_data->template GetMutableValues<CType>(1);
+    int64_t* count_buffer = count_data->template GetMutableValues<int64_t>(1);
+    this->state.Finalize(mode_buffer, count_buffer, n);
+
+    *out = Datum(
+        StructArray(out_type, n, ArrayVector{MakeArray(mode_data), MakeArray(count_data)})
+            .data());
   }
 
   std::shared_ptr<DataType> out_type;
   ModeState<ArrowType> state;
+  ModeOptions options;
 };
 
 struct ModeInitState {
@@ -230,10 +291,11 @@ struct ModeInitState {
   KernelContext* ctx;
   const DataType& in_type;
   const std::shared_ptr<DataType>& out_type;
+  const ModeOptions& options;
 
   ModeInitState(KernelContext* ctx, const DataType& in_type,
-                const std::shared_ptr<DataType>& out_type)
-      : ctx(ctx), in_type(in_type), out_type(out_type) {}
+                const std::shared_ptr<DataType>& out_type, const ModeOptions& options)
+      : ctx(ctx), in_type(in_type), out_type(out_type), options(options) {}
 
   Status Visit(const DataType&) { return Status::NotImplemented("No mode implemented"); }
 
@@ -244,7 +306,7 @@ struct ModeInitState {
   template <typename Type>
   enable_if_t<is_number_type<Type>::value || is_boolean_type<Type>::value, Status> Visit(
       const Type&) {
-    state.reset(new ModeImpl<Type>(out_type));
+    state.reset(new ModeImpl<Type>(out_type, options));
     return Status::OK();
   }
 
@@ -256,32 +318,36 @@ struct ModeInitState {
 
 std::unique_ptr<KernelState> ModeInit(KernelContext* ctx, const KernelInitArgs& args) {
   ModeInitState visitor(ctx, *args.inputs[0].type,
-                        args.kernel->signature->out_type().type());
+                        args.kernel->signature->out_type().type(),
+                        static_cast<const ModeOptions&>(*args.options));
   return visitor.Create();
 }
 
 void AddModeKernels(KernelInit init, const std::vector<std::shared_ptr<DataType>>& types,
                     ScalarAggregateFunction* func) {
   for (const auto& ty : types) {
-    // array[T] -> scalar[struct<mode: T, count: int64_t>]
-    auto out_ty = struct_({field("mode", ty), field("count", int64())});
-    auto sig = KernelSignature::Make({InputType::Array(ty)}, ValueDescr::Scalar(out_ty));
+    // array[T] -> array[struct<mode: T, count: int64_t>]
+    auto out_ty = struct_({field(kModeFieldName, ty), field(kCountFieldName, int64())});
+    auto sig = KernelSignature::Make({InputType::Array(ty)}, ValueDescr::Array(out_ty));
     AddAggKernel(std::move(sig), init, func);
   }
 }
 
 const FunctionDoc mode_doc{
-    "Calculate the modal (most common) value of a numeric array",
-    ("This function returns both mode and count as a struct scalar,\n"
-     "with type `struct<mode: T, count: int64>`, where T is the input type.\n"
-     "If there is more than one such value, the smallest one is returned.\n"
+    "Calculate the modal (most common) values of a numeric array",
+    ("Returns top-n most common values and number of times they occur in an array.\n"
+     "Result is an array of `struct<mode: T, count: int64>`, where T is the input type.\n"
+     "Values with larger counts are returned before smaller counts.\n"
+     "If there are more than one values with same count, smaller one is returned first.\n"
      "Nulls are ignored.  If there are no non-null values in the array,\n"
      "null is returned."),
-    {"array"}};
+    {"array"},
+    "ModeOptions"};
 
 std::shared_ptr<ScalarAggregateFunction> AddModeAggKernels() {
-  auto func =
-      std::make_shared<ScalarAggregateFunction>("mode", Arity::Unary(), &mode_doc);
+  static auto default_mode_options = ModeOptions::Defaults();
+  auto func = std::make_shared<ScalarAggregateFunction>("mode", Arity::Unary(), &mode_doc,
+                                                        &default_mode_options);
   AddModeKernels(ModeInit, {boolean()}, func.get());
   AddModeKernels(ModeInit, NumericTypes(), func.get());
   return func;

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -735,71 +735,63 @@ class TestPrimitiveModeKernel : public ::testing::Test {
  public:
   using ArrowType = T;
   using Traits = TypeTraits<ArrowType>;
-  using c_type = typename ArrowType::c_type;
-  using ModeType = typename Traits::ScalarType;
-  using CountType = typename TypeTraits<Int64Type>::ScalarType;
+  using CType = typename ArrowType::c_type;
 
-  void AssertModeIs(const Datum& array, c_type expected_mode, int64_t expected_count) {
-    ASSERT_OK_AND_ASSIGN(Datum out, Mode(array));
-    const StructScalar& value = out.scalar_as<StructScalar>();
+  void AssertModesAre(const Datum& array, const int n,
+                      const std::vector<CType>& expected_modes,
+                      const std::vector<int64_t>& expected_counts) {
+    ASSERT_OK_AND_ASSIGN(Datum out, Mode(array, ModeOptions{n}));
+    const StructArray out_array(out.array());
+    ASSERT_EQ(out_array.length(), expected_modes.size());
+    ASSERT_EQ(out_array.num_fields(), 2);
 
-    const auto& out_mode = checked_cast<const ModeType&>(*value.value[0]);
-    ASSERT_EQ(expected_mode, out_mode.value);
-
-    const auto& out_count = checked_cast<const CountType&>(*value.value[1]);
-    ASSERT_EQ(expected_count, out_count.value);
+    const CType* out_modes = out_array.field(0)->data()->GetValues<CType>(1);
+    const int64_t* out_counts = out_array.field(1)->data()->GetValues<int64_t>(1);
+    for (int i = 0; i < out_array.length(); ++i) {
+      // equal or nan equal
+      ASSERT_TRUE(
+          (expected_modes[i] == out_modes[i]) ||
+          (expected_modes[i] != expected_modes[i] && out_modes[i] != out_modes[i]));
+      ASSERT_EQ(expected_counts[i], out_counts[i]);
+    }
   }
 
-  void AssertModeIs(const std::string& json, c_type expected_mode,
+  void AssertModesAre(const std::string& json, const int n,
+                      const std::vector<CType>& expected_modes,
+                      const std::vector<int64_t>& expected_counts) {
+    auto array = ArrayFromJSON(type_singleton(), json);
+    AssertModesAre(array, n, expected_modes, expected_counts);
+  }
+
+  void AssertModeIs(const Datum& array, CType expected_mode, int64_t expected_count) {
+    AssertModesAre(array, 1, {expected_mode}, {expected_count});
+  }
+
+  void AssertModeIs(const std::string& json, CType expected_mode,
                     int64_t expected_count) {
     auto array = ArrayFromJSON(type_singleton(), json);
     AssertModeIs(array, expected_mode, expected_count);
   }
 
-  void AssertModeIs(const std::vector<std::string>& json, c_type expected_mode,
+  void AssertModeIs(const std::vector<std::string>& json, CType expected_mode,
                     int64_t expected_count) {
     auto chunked = ChunkedArrayFromJSON(type_singleton(), json);
     AssertModeIs(chunked, expected_mode, expected_count);
   }
 
-  void AssertModeIsNull(const Datum& array) {
-    ASSERT_OK_AND_ASSIGN(Datum out, Mode(array));
-    const StructScalar& value = out.scalar_as<StructScalar>();
-
-    for (const auto& val : value.value) {
-      ASSERT_FALSE(val->is_valid);
-    }
+  void AssertModeIsNull(const Datum& array, int n) {
+    ASSERT_OK_AND_ASSIGN(Datum out, Mode(array, ModeOptions{n}));
+    ASSERT_EQ(out.array()->length, 0);
   }
 
-  void AssertModeIsNull(const std::string& json) {
+  void AssertModeIsNull(const std::string& json, int n = 1) {
     auto array = ArrayFromJSON(type_singleton(), json);
-    AssertModeIsNull(array);
+    AssertModeIsNull(array, n);
   }
 
-  void AssertModeIsNull(const std::vector<std::string>& json) {
+  void AssertModeIsNull(const std::vector<std::string>& json, int n = 1) {
     auto chunked = ChunkedArrayFromJSON(type_singleton(), json);
-    AssertModeIsNull(chunked);
-  }
-
-  void AssertModeIsNaN(const Datum& array, int64_t expected_count) {
-    ASSERT_OK_AND_ASSIGN(Datum out, Mode(array));
-    const StructScalar& value = out.scalar_as<StructScalar>();
-
-    const auto& out_mode = checked_cast<const ModeType&>(*value.value[0]);
-    ASSERT_NE(out_mode.value, out_mode.value);  // NaN != NaN
-
-    const auto& out_count = checked_cast<const CountType&>(*value.value[1]);
-    ASSERT_EQ(expected_count, out_count.value);
-  }
-
-  void AssertModeIsNaN(const std::string& json, int64_t expected_count) {
-    auto array = ArrayFromJSON(type_singleton(), json);
-    AssertModeIsNaN(array, expected_count);
-  }
-
-  void AssertModeIsNaN(const std::vector<std::string>& json, int64_t expected_count) {
-    auto chunked = ChunkedArrayFromJSON(type_singleton(), json);
-    AssertModeIsNaN(chunked, expected_count);
+    AssertModeIsNull(chunked, n);
   }
 
   std::shared_ptr<DataType> type_singleton() { return Traits::type_singleton(); }
@@ -830,6 +822,12 @@ TEST_F(TestBooleanModeKernel, Basics) {
   this->AssertModeIs({"[true, false]", "[true, true]", "[false, false]"}, false, 3);
   this->AssertModeIs({"[true, null]", "[]", "[null, false]"}, false, 1);
   this->AssertModeIsNull({"[null, null]", "[]", "[null]"});
+
+  this->AssertModesAre("[false, false, true, true, true, false]", 2, {false, true},
+                       {3, 3});
+  this->AssertModesAre("[true, null, false, false, null, true, null, null, true]", 100,
+                       {true, false}, {3, 2});
+  this->AssertModeIsNull({"[null, null]", "[]", "[null]"}, 4);
 }
 
 TYPED_TEST_SUITE(TestIntegerModeKernel, IntegralArrowTypes);
@@ -845,6 +843,10 @@ TYPED_TEST(TestIntegerModeKernel, Basics) {
   this->AssertModeIs({"[5]", "[1, 1, 5]", "[5]"}, 5, 3);
   this->AssertModeIs({"[5]", "[1, 1, 5]", "[5, 1]"}, 1, 3);
   this->AssertModeIsNull({"[null, null]", "[]", "[null]"});
+
+  this->AssertModesAre("[127, 0, 127, 127, 0, 1, 0, 127]", 2, {127, 0}, {4, 3});
+  this->AssertModesAre("[null, null, 2, null, 1]", 3, {1, 2}, {1, 1});
+  this->AssertModeIsNull("[null, null, null]", 10);
 }
 
 TYPED_TEST_SUITE(TestFloatingModeKernel, RealArrowTypes);
@@ -860,13 +862,16 @@ TYPED_TEST(TestFloatingModeKernel, Floats) {
   this->AssertModeIsNull("[null, null, null]");
   this->AssertModeIsNull("[]");
 
-  this->AssertModeIsNaN("[NaN, NaN, 1]", 2);
-  this->AssertModeIsNaN("[NaN, NaN, null]", 2);
-  this->AssertModeIsNaN("[NaN, NaN, NaN]", 3);
+  this->AssertModeIs("[NaN, NaN, 1]", NAN, 2);
+  this->AssertModeIs("[NaN, NaN, null]", NAN, 2);
+  this->AssertModeIs("[NaN, NaN, NaN]", NAN, 3);
 
   this->AssertModeIs({"[Inf, 100]", "[Inf, 100]", "[Inf]"}, INFINITY, 3);
   this->AssertModeIsNull({"[null, null]", "[]", "[null]"});
-  this->AssertModeIsNaN({"[NaN, 1]", "[NaN, 1]", "[NaN]"}, 3);
+  this->AssertModeIs({"[NaN, 1]", "[NaN, 1]", "[NaN]"}, NAN, 3);
+
+  this->AssertModesAre("[Inf, 100, Inf, 100, Inf]", 2, {INFINITY, 100}, {3, 2});
+  this->AssertModesAre("[NaN, NaN, 1, null, 1, 2, 2]", 3, {1, 2, NAN}, {2, 2, 2});
 }
 
 TEST_F(TestInt8ModeKernelValueRange, Basics) {
@@ -914,22 +919,20 @@ ModeResult<ArrowType> NaiveMode(const Array& array) {
 
 template <typename ArrowType, typename CTYPE = typename ArrowType::c_type>
 void CheckModeWithRange(CTYPE range_min, CTYPE range_max) {
-  using ModeScalar = typename TypeTraits<ArrowType>::ScalarType;
-  using CountScalar = typename TypeTraits<Int64Type>::ScalarType;
-
   auto rand = random::RandomArrayGenerator(0x5487655);
   // 32K items (>= counting mode cutoff) within range, 10% null
   auto array = rand.Numeric<ArrowType>(32 * 1024, range_min, range_max, 0.1);
 
   auto expected = NaiveMode<ArrowType>(*array);
   ASSERT_OK_AND_ASSIGN(Datum out, Mode(array));
-  const StructScalar& value = out.scalar_as<StructScalar>();
+  const StructArray out_array(out.array());
+  ASSERT_EQ(out_array.length(), 1);
+  ASSERT_EQ(out_array.num_fields(), 2);
 
-  ASSERT_TRUE(value.is_valid);
-  const auto& out_mode = checked_cast<const ModeScalar&>(*value.value[0]);
-  const auto& out_count = checked_cast<const CountScalar&>(*value.value[1]);
-  ASSERT_EQ(out_mode.value, expected.mode);
-  ASSERT_EQ(out_count.value, expected.count);
+  const CTYPE* out_modes = out_array.field(0)->data()->GetValues<CTYPE>(1);
+  const int64_t* out_counts = out_array.field(1)->data()->GetValues<int64_t>(1);
+  ASSERT_EQ(out_modes[0], expected.mode);
+  ASSERT_EQ(out_counts[0], expected.count);
 }
 
 TEST_F(TestInt32ModeKernel, SmallValueRange) {

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -151,11 +151,14 @@ Aggregations
 
 Notes:
 
-* \(1) Output is a ``{"min": input type, "max": input type}`` Struct
+* \(1) Output is a ``{"min": input type, "max": input type}`` Struct.
 
-* \(2) Output is an array of ``{"mode": input type, "count": Int64}`` Struct
-  Each output element corresponds to a unique value (mode) in the input,
-  sorted by the number of times (count) it appears in descending order.
+* \(2) Output is an array of ``{"mode": input type, "count": Int64}`` Struct.
+  It contains the *N* most common elements in the input, in descending
+  order, where *N* is given in :member:`ModeOptions::n`.
+  If two values have the same count, the smallest one comes first.
+  Note that the output can have less than *N* elements if the input has
+  less than *N* distinct values.
 
 * \(3) Output is Int64, UInt64 or Float64, depending on the input type
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -140,7 +140,7 @@ Aggregations
 +--------------------------+------------+--------------------+-----------------------+--------------------------------------------+
 | min_max                  | Unary      | Numeric            | Scalar Struct  (1)    | :struct:`MinMaxOptions`                    |
 +--------------------------+------------+--------------------+-----------------------+--------------------------------------------+
-| mode                     | Unary      | Numeric            | Scalar Struct  (2)    | :struct:`ModeOptions`                      |
+| mode                     | Unary      | Numeric            | Struct  (2)           | :struct:`ModeOptions`                      |
 +--------------------------+------------+--------------------+-----------------------+--------------------------------------------+
 | stddev                   | Unary      | Numeric            | Scalar Float64        | :struct:`VarianceOptions`                  |
 +--------------------------+------------+--------------------+-----------------------+--------------------------------------------+
@@ -154,6 +154,8 @@ Notes:
 * \(1) Output is a ``{"min": input type, "max": input type}`` Struct
 
 * \(2) Output is an array of ``{"mode": input type, "count": Int64}`` Struct
+  Each output element corresponds to a unique value (mode) in the input,
+  sorted by the number of times (count) it appears in descending order.
 
 * \(3) Output is Int64, UInt64 or Float64, depending on the input type
 

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -140,7 +140,7 @@ Aggregations
 +--------------------------+------------+--------------------+-----------------------+--------------------------------------------+
 | min_max                  | Unary      | Numeric            | Scalar Struct  (1)    | :struct:`MinMaxOptions`                    |
 +--------------------------+------------+--------------------+-----------------------+--------------------------------------------+
-| mode                     | Unary      | Numeric            | Scalar Struct  (2)    |                                            |
+| mode                     | Unary      | Numeric            | Scalar Struct  (2)    | :struct:`ModeOptions`                      |
 +--------------------------+------------+--------------------+-----------------------+--------------------------------------------+
 | stddev                   | Unary      | Numeric            | Scalar Float64        | :struct:`VarianceOptions`                  |
 +--------------------------+------------+--------------------+-----------------------+--------------------------------------------+
@@ -153,7 +153,7 @@ Notes:
 
 * \(1) Output is a ``{"min": input type, "max": input type}`` Struct
 
-* \(2) Output is a ``{"mode": input type, "count": Int64}`` Struct
+* \(2) Output is an array of ``{"mode": input type, "count": Int64}`` Struct
 
 * \(3) Output is Int64, UInt64 or Float64, depending on the input type
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -706,6 +706,11 @@ cdef class _CountOptions(FunctionOptions):
                 .format(count_mode))
 
 
+class CountOptions(_CountOptions):
+    def __init__(self, count_mode='count_non_null'):
+        self._set_options(count_mode)
+
+
 cdef class _ModeOptions(FunctionOptions):
     cdef:
         CModeOptions mode_options
@@ -718,13 +723,8 @@ cdef class _ModeOptions(FunctionOptions):
 
 
 class ModeOptions(_ModeOptions):
-    def __init__(self, *, n=1):
+    def __init__(self, n=1):
         self._set_options(n)
-
-
-class CountOptions(_CountOptions):
-    def __init__(self, count_mode='count_non_null'):
-        self._set_options(count_mode)
 
 
 cdef class _SetLookupOptions(FunctionOptions):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -706,6 +706,22 @@ cdef class _CountOptions(FunctionOptions):
                 .format(count_mode))
 
 
+cdef class _ModeOptions(FunctionOptions):
+    cdef:
+        CModeOptions mode_options
+
+    cdef const CFunctionOptions* get_options(self) except NULL:
+        return &self.mode_options
+
+    def _set_options(self, n):
+        self.mode_options.n = n
+
+
+class ModeOptions(_ModeOptions):
+    def __init__(self, *, n=1):
+        self._set_options(n)
+
+
 class CountOptions(_CountOptions):
     def __init__(self, count_mode='count_non_null'):
         self._set_options(count_mode)

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -34,6 +34,7 @@ from pyarrow._compute import (  # noqa
     SplitOptions,
     SplitPatternOptions,
     MinMaxOptions,
+    ModeOptions,
     PartitionNthOptions,
     SetLookupOptions,
     StrptimeOptions,
@@ -308,11 +309,11 @@ def sum(array):
     return call_function('sum', [array])
 
 
-def mode(array):
+def mode(array, n=1):
     """
-    Return the mode (most common value) of a passed numerical
-    (chunked) array. If there is more than one such value, only
-    the smallest is returned.
+    Return top-n most common values and number of times they occur in a passed
+    numerical (chunked) array, in descending order of occurance. If there are
+    more than one values with same count, smaller one is returned first.
 
     Parameters
     ----------
@@ -320,18 +321,21 @@ def mode(array):
 
     Returns
     -------
-    mode : pyarrow.StructScalar
+    An array of <input type "Mode", int64_t "Count"> structs
 
     Examples
     --------
     >>> import pyarrow as pa
     >>> import pyarrow.compute as pc
     >>> arr = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
-    >>> pc.mode(arr)
+    >>> modes = pc.mode(arr, 2)
+    >>> modes[0]
     <pyarrow.StructScalar: {'mode': 2, 'count': 5}>
-
+    >>> modes[1]
+    <pyarrow.StructScalar: {'mode': 1, 'count': 2}>
     """
-    return call_function("mode", [array])
+    options = ModeOptions(n=n)
+    return call_function("mode", [array], options)
 
 
 def filter(data, mask, null_selection_behavior='drop'):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1764,6 +1764,10 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         CMinMaxMode_EMIT_NULL \
             "arrow::compute::MinMaxOptions::EMIT_NULL"
 
+    cdef cppclass CModeOptions \
+            "arrow::compute::ModeOptions"(CFunctionOptions):
+        int64_t n
+
     cdef cppclass CMinMaxOptions \
             "arrow::compute::MinMaxOptions"(CFunctionOptions):
         CMinMaxMode null_handling

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -225,24 +225,34 @@ def test_sum_chunked_array(arrow_type):
 def test_mode_array():
     # ARROW-9917
     arr = pa.array([1, 1, 3, 4, 3, 5], type='int64')
-    expected = {"mode": 1, "count": 2}
-    assert pc.mode(arr).as_py() == {"mode": 1, "count": 2}
+    mode = pc.mode(arr)
+    assert len(mode) == 1
+    assert mode[0].as_py() == {"mode": 1, "count": 2}
+
+    mode = pc.mode(arr, 2)
+    assert len(mode) == 2
+    assert mode[0].as_py() == {"mode": 1, "count": 2}
+    assert mode[1].as_py() == {"mode": 3, "count": 2}
 
     arr = pa.array([], type='int64')
-    expected = {"mode": None, "count": None}
-    assert pc.mode(arr).as_py() == expected
+    assert len(pc.mode(arr)) == 0
 
 
 def test_mode_chunked_array():
     # ARROW-9917
     arr = pa.chunked_array([pa.array([1, 1, 3, 4, 3, 5], type='int64')])
-    expected = {"mode": 1, "count": 2}
-    assert pc.mode(arr).as_py() == expected
+    mode = pc.mode(arr)
+    assert len(mode) == 1
+    assert mode[0].as_py() == {"mode": 1, "count": 2}
+
+    mode = pc.mode(arr, 2)
+    assert len(mode) == 2
+    assert mode[0].as_py() == {"mode": 1, "count": 2}
+    assert mode[1].as_py() == {"mode": 3, "count": 2}
 
     arr = pa.chunked_array((), type='int64')
-    expected = {"mode": None, "count": None}
     assert arr.num_chunks == 0
-    assert pc.mode(arr).as_py() == expected
+    assert len(pc.mode(arr)) == 0
 
 
 def test_variance():


### PR DESCRIPTION
This patch generalize mode kernel to return top-n modes.
No performance difference for normal benchmarks.
About 35% performance drop for 100% null benchmarks.