### PR TITLE
ARROW-10573: [C++] Align written buffers to specified value

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -129,11 +129,6 @@ class ArrayLoader {
     if (length < 0) {
       return Status::Invalid("Negative length for reading buffer ", buffer_index_);
     }
-    // This construct permits overriding GetBuffer at compile time
-    if (!BitUtil::IsMultipleOf8(offset)) {
-      return Status::Invalid("Buffer ", buffer_index_,
-                             " did not start on 8-byte aligned offset: ", offset);
-    }
     return file_->ReadAt(offset, length).Value(out);
   }
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -559,7 +559,7 @@ Status WriteIpcPayload(const IpcPayload& payload, const IpcWriteOptions& options
   RETURN_NOT_OK(WriteMessage(*payload.metadata, options, dst, metadata_length));
 
 #ifndef NDEBUG
-  RETURN_NOT_OK(CheckAligned(dst));
+  RETURN_NOT_OK(CheckAligned(dst, options.alignment));
 #endif
 
   // Now write the buffers
@@ -571,7 +571,7 @@ Status WriteIpcPayload(const IpcPayload& payload, const IpcWriteOptions& options
     // The buffer might be null if we are handling zero row lengths.
     if (buffer) {
       size = buffer->size();
-      padding = BitUtil::RoundUpToMultipleOf8(size) - size;
+      padding = BitUtil::RoundUp(size, options.alignment) - size;
     }
 
     if (size > 0) {
@@ -584,7 +584,7 @@ Status WriteIpcPayload(const IpcPayload& payload, const IpcWriteOptions& options
   }
 
 #ifndef NDEBUG
-  RETURN_NOT_OK(CheckAligned(dst));
+  RETURN_NOT_OK(CheckAligned(dst, options.alignment));
 #endif
 
   return Status::OK();
@@ -1081,7 +1081,7 @@ class StreamBookKeeper {
 
   Status UpdatePositionCheckAligned() {
     RETURN_NOT_OK(UpdatePosition());
-    DCHECK_EQ(0, position_ % 8) << "Stream is not aligned";
+    DCHECK_EQ(0, position_ % options_.alignment) << "Stream is not aligned";
     return Status::OK();
   }
 

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -230,7 +230,7 @@ class RecordBatchSerializer {
       // The buffer might be null if we are handling zero row lengths.
       if (buffer) {
         size = buffer->size();
-        padding = BitUtil::RoundUpToMultipleOf8(size) - size;
+        padding = BitUtil::RoundUp(size, options_.alignment) - size;
       }
 
       buffer_meta_.push_back({offset, size});
@@ -238,7 +238,6 @@ class RecordBatchSerializer {
     }
 
     out_->body_length = offset - buffer_start_offset_;
-    DCHECK(BitUtil::IsMultipleOf8(out_->body_length));
 
     // Now that we have computed the locations of all of the buffers in shared
     // memory, the data header can be converted to a flatbuffer and written out

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -61,6 +61,8 @@ cdef class IpcWriteOptions(_Weakrefable):
     use_threads: bool
         Whether to use the global CPU thread pool to parallelize any
         computational tasks like compression.
+    alignment : int, default 8
+        Byte alignment for metadata, body & buffers
     """
     __slots__ = ()
 
@@ -68,13 +70,15 @@ cdef class IpcWriteOptions(_Weakrefable):
 
     def __init__(self, *, metadata_version=MetadataVersion.V5,
                  use_legacy_format=False, compression=None,
-                 bint use_threads=True):
+                 bint use_threads=True, alignment=None):
         self.c_options = CIpcWriteOptions.Defaults()
         self.use_legacy_format = use_legacy_format
         self.metadata_version = metadata_version
         if compression is not None:
             self.compression = compression
         self.use_threads = use_threads
+        if alignment is not None:
+            self.alignment = alignment
 
     @property
     def use_legacy_format(self):
@@ -83,6 +87,15 @@ cdef class IpcWriteOptions(_Weakrefable):
     @use_legacy_format.setter
     def use_legacy_format(self, bint value):
         self.c_options.write_legacy_ipc_format = value
+
+    @property
+    def alignment(self):
+        return self.c_options.alignment
+
+    @alignment.setter
+    def alignment(self, value):
+        assert value >= 1, "unsupported alignment"
+        self.c_options.alignment = value
 
     @property
     def metadata_version(self):

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -29,12 +29,14 @@ import numpy as np
 import pyarrow as pa
 from pyarrow.tests.util import changed_environ
 
+
 try:
     from pandas.core.internals import Block, BlockManager
     from pandas.testing import assert_frame_equal, assert_series_equal
     import pandas as pd
 except ImportError:
     pass
+
 
 # TODO(wesm): The IPC tests depend a lot on pandas currently, so all excluded
 # when it is not installed
@@ -103,6 +105,7 @@ class FileFormatFixture(IpcFixture):
 
 
 class StreamFormatFixture(IpcFixture):
+
     # ARROW-6474, for testing writing old IPC protocol with 4-byte prefix
     use_legacy_ipc_format = False
     # ARROW-9395, for testing writing old metadata version
@@ -689,8 +692,8 @@ class StreamReaderServer(threading.Thread):
             connection.close()
 
     def get_result(self):
-        return (self._schema, self._table if self._do_read_all
-        else self._batches)
+        return(self._schema, self._table if self._do_read_all
+               else self._batches)
 
 
 class SocketStreamFixture(IpcFixture):


### PR DESCRIPTION
IPC messages are forced to 8-byte alignment and ignore the `alignment` `IpcWriteOptions` setting. This inhibits zero-copy optimisations as non-8-byte-sized types can't be stored in contiguous memory.