### PR TITLE
ARROW-10560: [Python] Fix crash when creating array from huge string

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -174,8 +174,10 @@ from pyarrow.lib import (ChunkedArray, RecordBatch, Table, table,
                          concat_arrays, concat_tables)
 
 # Exceptions
-from pyarrow.lib import (ArrowException,
+from pyarrow.lib import (ArrowCapacityError,
+                         ArrowException,
                          ArrowKeyError,
+                         ArrowIndexError,
                          ArrowInvalid,
                          ArrowIOError,
                          ArrowMemoryError,

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -761,6 +761,16 @@ def test_large_binary_value(ty):
     assert len(buf) == len(s) * nrepeats
 
 
+@pytest.mark.large_memory
+@pytest.mark.parametrize("ty", [pa.binary(), pa.string()])
+def test_string_too_large(ty):
+    # Construct a binary array with a single value larger than 4GB
+    s = b"0123456789abcdefghijklmnopqrstuvwxyz"
+    nrepeats = math.ceil((2**32 + 5) / len(s))
+    with pytest.raises(pa.ArrowCapacityError):
+        pa.array([b"foo", s * nrepeats, None, b"bar"], type=ty)
+
+
 def test_sequence_bytes():
     u1 = b'ma\xc3\xb1ana'
 


### PR DESCRIPTION
Error out cleanly if an individual string is larger than 2**31 bytes when creating a binary or string array.