### PR TITLE
ARROW-7363: [Python] add combine_chunks method to ChunkedArray

### DIFF
--- a/docs/source/python/api/tables.rst
+++ b/docs/source/python/api/tables.rst
@@ -30,6 +30,7 @@ Factory Functions
 
    chunked_array
    combine_chunks
+   concat_arrays
    concat_tables
    record_batch
    table

--- a/docs/source/python/api/tables.rst
+++ b/docs/source/python/api/tables.rst
@@ -29,7 +29,6 @@ Factory Functions
    :toctree: ../generated/
 
    chunked_array
-   combine_chunks
    concat_arrays
    concat_tables
    record_batch

--- a/docs/source/python/api/tables.rst
+++ b/docs/source/python/api/tables.rst
@@ -29,6 +29,7 @@ Factory Functions
    :toctree: ../generated/
 
    chunked_array
+   combine_chunks
    concat_tables
    record_batch
    table

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -309,7 +309,7 @@ cdef class ChunkedArray(_PandasConvertible):
             flattened = GetResultValue(self.chunked_array.Flatten(pool))
 
         return [pyarrow_wrap_chunked_array(col) for col in flattened]
-    
+
     def combine_chunks(self, MemoryPool memory_pool=None):
         """
         Flatten this ChunkedArray into a single non-chunked array.

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -309,6 +309,21 @@ cdef class ChunkedArray(_PandasConvertible):
             flattened = GetResultValue(self.chunked_array.Flatten(pool))
 
         return [pyarrow_wrap_chunked_array(col) for col in flattened]
+    
+    def combine_chunks(self, MemoryPool memory_pool=None):
+        """
+        Flatten this ChunkedArray into a single non-chunked array.
+
+        Parameters
+        ----------
+        memory_pool : MemoryPool, default None
+            For memory allocations, if required, otherwise use default pool
+
+        Returns
+        -------
+        result : Array
+        """
+        return concat_arrays(self.chunks)
 
     def unique(self):
         """

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2668,6 +2668,13 @@ def test_concat_array_invalid_type():
     with pytest.raises(TypeError, match="should contain Array objects"):
         pa.concat_arrays(arr)
 
+def test_combine_chunks():
+    # ARROW-77363
+    arr = pa.array([1, 2])
+    chunked_arr = pa.chunked_array([arr, arr])
+    res = chunked_arr.combine_chunks()
+    expected = pa.array([1, 2, 1, 2])
+    assert res.equals(expected)
 
 @pytest.mark.pandas
 def test_to_pandas_timezone():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2669,15 +2669,6 @@ def test_concat_array_invalid_type():
         pa.concat_arrays(arr)
 
 
-def test_combine_chunks():
-    # ARROW-77363
-    arr = pa.array([1, 2])
-    chunked_arr = pa.chunked_array([arr, arr])
-    res = chunked_arr.combine_chunks()
-    expected = pa.array([1, 2, 1, 2])
-    assert res.equals(expected)
-
-
 @pytest.mark.pandas
 def test_to_pandas_timezone():
     # https://issues.apache.org/jira/browse/ARROW-6652

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2668,6 +2668,7 @@ def test_concat_array_invalid_type():
     with pytest.raises(TypeError, match="should contain Array objects"):
         pa.concat_arrays(arr)
 
+
 def test_combine_chunks():
     # ARROW-77363
     arr = pa.array([1, 2])
@@ -2675,6 +2676,7 @@ def test_combine_chunks():
     res = chunked_arr.combine_chunks()
     expected = pa.array([1, 2, 1, 2])
     assert res.equals(expected)
+
 
 @pytest.mark.pandas
 def test_to_pandas_timezone():

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -105,6 +105,15 @@ def test_chunked_array_construction():
     assert pa.chunked_array([[]], type=pa.string()).type == pa.string()
 
 
+def test_combine_chunks():
+    # ARROW-77363
+    arr = pa.array([1, 2])
+    chunked_arr = pa.chunked_array([arr, arr])
+    res = chunked_arr.combine_chunks()
+    expected = pa.array([1, 2, 1, 2])
+    assert res.equals(expected)
+
+
 def test_chunked_array_to_numpy():
     data = pa.chunked_array([
         [1, 2, 3],


### PR DESCRIPTION
As discussed on JIRA we currently don't have a convenience method that converts `ChunkedArray` into a non-chunked `Array`. `flatten` doesn't do this when called on a `ChunkedArray` instance so this PR provides a wrapper of `pa.concat_arrays` which does. 