### PR TITLE
ARROW-9911: [Rust][DataFusion] SELECT <expression> with no FROM clause should produce a single row of output

### DIFF
--- a/rust/datafusion/src/execution/context.rs
+++ b/rust/datafusion/src/execution/context.rs
@@ -142,12 +142,12 @@ impl ExecutionContext {
                             .schema(&schema)
                             .has_header(*has_header),
                     )?;
-                    let plan = LogicalPlanBuilder::empty().build()?;
+                    let plan = LogicalPlanBuilder::empty(false).build()?;
                     Ok(Arc::new(DataFrameImpl::new(self.state.clone(), &plan)))
                 }
                 FileType::Parquet => {
                     self.register_parquet(name, location)?;
-                    let plan = LogicalPlanBuilder::empty().build()?;
+                    let plan = LogicalPlanBuilder::empty(false).build()?;
                     Ok(Arc::new(DataFrameImpl::new(self.state.clone(), &plan)))
                 }
                 _ => Err(DataFusionError::NotImplemented(format!(

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -41,9 +41,12 @@ impl LogicalPlanBuilder {
         Self { plan: plan.clone() }
     }
 
-    /// Create an empty relation
-    pub fn empty() -> Self {
+    /// Create an empty relation.
+    ///
+    /// `produce_one_row` set to true means this empty node needs to produce a placeholder row.
+    pub fn empty(produce_one_row: bool) -> Self {
         Self::from(&LogicalPlan::EmptyRelation {
+            produce_one_row,
             schema: SchemaRef::new(Schema::empty()),
         })
     }

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -146,6 +146,8 @@ pub enum LogicalPlan {
     },
     /// Produces no rows: An empty relation with an empty schema
     EmptyRelation {
+        /// Whether to produce a placeholder row
+        produce_one_row: bool,
         /// The schema description of the output
         schema: SchemaRef,
     },
@@ -192,7 +194,7 @@ impl LogicalPlan {
     /// Get a reference to the logical plan's schema
     pub fn schema(&self) -> &SchemaRef {
         match self {
-            LogicalPlan::EmptyRelation { schema } => &schema,
+            LogicalPlan::EmptyRelation { schema, .. } => &schema,
             LogicalPlan::InMemoryScan {
                 projected_schema, ..
             } => &projected_schema,

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -320,7 +320,7 @@ mod tests {
     fn test_optimize_explain() -> Result<()> {
         let mut optimizer = TestOptimizer {};
 
-        let empty_plan = LogicalPlanBuilder::empty().build()?;
+        let empty_plan = LogicalPlanBuilder::empty(false).build()?;
         let schema = LogicalPlan::explain_schema();
 
         let optimized_explain = optimize_explain(

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -287,9 +287,13 @@ impl DefaultPhysicalPlanner {
                     ctx_state.config.concurrency,
                 )?))
             }
-            LogicalPlan::EmptyRelation { schema } => {
-                Ok(Arc::new(EmptyExec::new(Arc::new(schema.as_ref().clone()))))
-            }
+            LogicalPlan::EmptyRelation {
+                produce_one_row,
+                schema,
+            } => Ok(Arc::new(EmptyExec::new(
+                *produce_one_row,
+                Arc::new(schema.as_ref().clone()),
+            ))),
             LogicalPlan::Limit { input, n, .. } => {
                 let limit = *n;
                 let input = self.create_physical_plan(input, ctx_state)?;

--- a/rust/datafusion/src/physical_plan/projection.rs
+++ b/rust/datafusion/src/physical_plan/projection.rs
@@ -18,7 +18,7 @@
 //! Defines the projection execution plan. A projection determines which columns or expressions
 //! are returned from a query. The SQL statement `SELECT a, b, a+b FROM t1` is an example
 //! of a projection on table `t1` where the expressions `a`, `b`, and `a+b` are the
-//! projection expressions.
+//! projection expressions. `SELECT` without `FROM` will only evaluate expressions.
 
 use std::any::Any;
 use std::pin::Pin;
@@ -26,8 +26,11 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use crate::error::{DataFusionError, Result};
+use crate::physical_plan::empty::EmptyExec;
+use crate::physical_plan::memory::MemoryStream;
 use crate::physical_plan::{ExecutionPlan, Partitioning, PhysicalExpr};
-use arrow::datatypes::{Field, Schema, SchemaRef};
+use arrow::array::NullArray;
+use arrow::datatypes::{DataType, Field, Schema, SchemaRef};
 use arrow::error::Result as ArrowResult;
 use arrow::record_batch::RecordBatch;
 
@@ -114,12 +117,31 @@ impl ExecutionPlan for ProjectionExec {
     }
 
     async fn execute(&self, partition: usize) -> Result<SendableRecordBatchStream> {
+        let input = if self.input.as_any().downcast_ref::<EmptyExec>().is_some() {
+            placeholder_stream(self.schema.clone())?
+        } else {
+            self.input.execute(partition).await?
+        };
+
         Ok(Box::pin(ProjectionStream {
             schema: self.schema.clone(),
             expr: self.expr.iter().map(|x| x.0.clone()).collect(),
-            input: self.input.execute(partition).await?,
+            input,
         }))
     }
+}
+
+// Makes a stream only contains one null element
+fn placeholder_stream(schema: Arc<Schema>) -> Result<SendableRecordBatchStream> {
+    let data = vec![RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "placeholder",
+            DataType::Null,
+            true,
+        )])),
+        vec![Arc::new(NullArray::new(1))],
+    )?];
+    Ok(Box::pin(MemoryStream::try_new(data, schema, None)?))
 }
 
 fn batch_project(

--- a/rust/datafusion/src/sql/planner.rs
+++ b/rust/datafusion/src/sql/planner.rs
@@ -209,7 +209,7 @@ impl<'a, S: SchemaProvider> SqlToRel<'a, S> {
 
     fn from_join_to_plan(&self, from: &Vec<TableWithJoins>) -> Result<LogicalPlan> {
         if from.len() == 0 {
-            return Ok(LogicalPlanBuilder::empty().build()?);
+            return Ok(LogicalPlanBuilder::empty(true).build()?);
         }
         if from.len() != 1 {
             return Err(DataFusionError::NotImplemented(

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -1399,3 +1399,22 @@ async fn query_on_string_dictionary() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn query_without_from() -> Result<()> {
+    // Test for SELECT <expression> without FROM.
+    // Should evaluate expressions in project position.
+    let mut ctx = ExecutionContext::new();
+
+    let sql = "SELECT 1";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["1"]];
+    assert_eq!(expected, actual);
+
+    let sql = "SELECT 1+2, 3/4, cos(0)";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![vec!["3", "0", "1"]];
+    assert_eq!(expected, actual);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR makes datafusion will output evaluation result of `SELECT` expression without `FROM` clause.

prev:
```
> select 1 ;
0 rows in set. Query took 0 seconds.
```

now:
```
> select 1;
+----------+
| Int64(1) |
+----------+
| 1        |
+----------+
1 rows in set. Query took 0 seconds.
```

Previously, datafusion will generate an `EmptyExec` as input for outer `ProjectionExec`.  `EmptyExec` will return an empty stream when executing. And `ProjectionExec` won't evaluate its expression as it gets nothing from its "input". So I made a stream with one null value as a placeholder to feed it instead of `EmptyExec`.

Signed-off-by: wayne <i@waynest.com>