### PR TITLE
ARROW-10079: [Rust] Benchmark and improve count bits

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -116,3 +116,7 @@ harness = false
 [[bench]]
 name = "equal"
 harness = false
+
+[[bench]]
+name = "array_slice"
+harness = false

--- a/rust/arrow/benches/array_slice.rs
+++ b/rust/arrow/benches/array_slice.rs
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+
+extern crate arrow;
+
+use arrow::array::*;
+use std::sync::Arc;
+
+fn create_array_slice(array: &ArrayRef, length: usize) -> ArrayRef {
+    array.slice(0, length)
+}
+
+fn create_array_with_nulls(size: usize) -> ArrayRef {
+    let array: Float64Array = (0..size)
+        .map(|i| if i % 2 == 0 { Some(1.0) } else { None })
+        .collect();
+    Arc::new(array)
+}
+
+fn array_slice_benchmark(c: &mut Criterion) {
+    let array = create_array_with_nulls(4096);
+    c.bench_function("array_slice 128", |b| {
+        b.iter(|| create_array_slice(&array, 128))
+    });
+    c.bench_function("array_slice 512", |b| {
+        b.iter(|| create_array_slice(&array, 512))
+    });
+    c.bench_function("array_slice 2048", |b| {
+        b.iter(|| create_array_slice(&array, 2048))
+    });
+}
+
+criterion_group!(benches, array_slice_benchmark);
+criterion_main!(benches);

--- a/rust/arrow/src/array/array_struct.rs
+++ b/rust/arrow/src/array/array_struct.rs
@@ -23,13 +23,10 @@ use std::{any::Any, sync::Arc};
 
 use super::{make_array, Array, ArrayData, ArrayDataRef, ArrayRef};
 use crate::datatypes::DataType;
+use crate::error::{ArrowError, Result};
 use crate::{
     buffer::{buffer_bin_or, Buffer},
     datatypes::Field,
-};
-use crate::{
-    error::{ArrowError, Result},
-    util::bit_util,
 };
 
 /// A nested array type where each child (called *field*) is represented by a separate
@@ -133,10 +130,18 @@ impl TryFrom<Vec<(&str, ArrayRef)>> for StructArray {
             ));
 
             if let Some(child_null_buffer) = child_datum.null_buffer() {
+                let child_datum_offset = child_datum.offset();
+
                 null = Some(if let Some(null_buffer) = &null {
-                    buffer_bin_or(null_buffer, 0, child_null_buffer, 0, child_datum_len)
+                    buffer_bin_or(
+                        null_buffer,
+                        0,
+                        child_null_buffer,
+                        child_datum_offset,
+                        child_datum_len,
+                    )
                 } else {
-                    child_null_buffer.clone()
+                    child_null_buffer.bit_slice(child_datum_offset, child_datum_len)
                 });
             } else if null.is_some() {
                 // when one of the fields has no nulls, them there is no null in the array
@@ -149,7 +154,7 @@ impl TryFrom<Vec<(&str, ArrayRef)>> for StructArray {
             .len(len)
             .child_data(child_data);
         if let Some(null_buffer) = null {
-            let null_count = len - bit_util::count_set_bits(null_buffer.data());
+            let null_count = len - null_buffer.count_set_bits();
             builder = builder.null_count(null_count).null_bit_buffer(null_buffer);
         }
 

--- a/rust/arrow/src/array/array_union.rs
+++ b/rust/arrow/src/array/array_union.rs
@@ -230,6 +230,8 @@ impl UnionArray {
     pub fn value_offset(&self, index: usize) -> i32 {
         assert!(index - self.offset() < self.len());
         if self.is_dense() {
+            // In format v4 unions had their own validity bitmap and offsets are compressed by omitting null values
+            // Starting with v5 unions don't have a validity bitmap and it's possible to directly index into the offsets buffer
             let valid_slots = match self.data.null_buffer() {
                 Some(b) => b.count_set_bits_offset(0, index),
                 None => index,

--- a/rust/arrow/src/array/array_union.rs
+++ b/rust/arrow/src/array/array_union.rs
@@ -78,7 +78,6 @@ use crate::buffer::Buffer;
 use crate::datatypes::*;
 use crate::error::{ArrowError, Result};
 
-use crate::util::bit_util;
 use core::fmt;
 use std::any::Any;
 use std::mem;
@@ -145,7 +144,7 @@ impl UnionArray {
         bitmap: Option<Buffer>,
     ) -> Result<Self> {
         let bitmap_data = bitmap.map(|b| {
-            let null_count = type_ids.len() - bit_util::count_set_bits(b.data());
+            let null_count = type_ids.len() - b.count_set_bits();
             (b, null_count)
         });
 
@@ -232,7 +231,7 @@ impl UnionArray {
         assert!(index - self.offset() < self.len());
         if self.is_dense() {
             let valid_slots = match self.data.null_buffer() {
-                Some(b) => bit_util::count_set_bits_offset(b.data(), 0, index),
+                Some(b) => b.count_set_bits_offset(0, index),
                 None => index,
             };
             self.data().buffers()[1].data()[valid_slots * size_of::<i32>()] as i32

--- a/rust/arrow/src/array/builder.rs
+++ b/rust/arrow/src/array/builder.rs
@@ -602,7 +602,7 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
     pub fn finish(&mut self) -> PrimitiveArray<T> {
         let len = self.len();
         let null_bit_buffer = self.bitmap_builder.finish();
-        let null_count = len - bit_util::count_set_bits(null_bit_buffer.data());
+        let null_count = len - null_bit_buffer.count_set_bits();
         let mut builder = ArrayData::builder(T::DATA_TYPE)
             .len(len)
             .add_buffer(self.values_builder.finish());
@@ -619,7 +619,7 @@ impl<T: ArrowPrimitiveType> PrimitiveBuilder<T> {
     pub fn finish_dict(&mut self, values: ArrayRef) -> DictionaryArray<T> {
         let len = self.len();
         let null_bit_buffer = self.bitmap_builder.finish();
-        let null_count = len - bit_util::count_set_bits(null_bit_buffer.data());
+        let null_count = len - null_bit_buffer.count_set_bits();
         let data_type = DataType::Dictionary(
             Box::new(T::DATA_TYPE),
             Box::new(values.data_type().clone()),
@@ -831,7 +831,7 @@ where
 
         let offset_buffer = self.offsets_builder.finish();
         let null_bit_buffer = self.bitmap_builder.finish();
-        let nulls = bit_util::count_set_bits(null_bit_buffer.data());
+        let nulls = null_bit_buffer.count_set_bits();
         self.offsets_builder.append(0).unwrap();
         let data = ArrayData::builder(DataType::List(Box::new(Field::new(
             "item",
@@ -1043,7 +1043,7 @@ where
 
         let offset_buffer = self.offsets_builder.finish();
         let null_bit_buffer = self.bitmap_builder.finish();
-        let nulls = bit_util::count_set_bits(null_bit_buffer.data());
+        let nulls = null_bit_buffer.count_set_bits();
         self.offsets_builder.append(0).unwrap();
         let data = ArrayData::builder(DataType::LargeList(Box::new(Field::new(
             "item",
@@ -1234,7 +1234,7 @@ where
         }
 
         let null_bit_buffer = self.bitmap_builder.finish();
-        let nulls = bit_util::count_set_bits(null_bit_buffer.data());
+        let nulls = null_bit_buffer.count_set_bits();
         let data = ArrayData::builder(DataType::FixedSizeList(
             Box::new(Field::new("item", values_data.data_type().clone(), true)),
             self.list_len,
@@ -2134,7 +2134,7 @@ impl StructBuilder {
         }
 
         let null_bit_buffer = self.bitmap_builder.finish();
-        let null_count = self.len - bit_util::count_set_bits(null_bit_buffer.data());
+        let null_count = self.len - null_bit_buffer.count_set_bits();
         let mut builder = ArrayData::builder(DataType::Struct(self.fields.clone()))
             .len(self.len)
             .child_data(child_data);

--- a/rust/arrow/src/array/data.rs
+++ b/rust/arrow/src/array/data.rs
@@ -23,7 +23,6 @@ use std::sync::Arc;
 
 use crate::buffer::Buffer;
 use crate::datatypes::DataType;
-use crate::util::bit_util;
 use crate::{bitmap::Bitmap, datatypes::ArrowNativeType};
 
 use super::equal::equal;
@@ -31,7 +30,7 @@ use super::equal::equal;
 #[inline]
 fn count_nulls(null_bit_buffer: Option<&Buffer>, offset: usize, len: usize) -> usize {
     if let Some(ref buf) = null_bit_buffer {
-        len.checked_sub(bit_util::count_set_bits_offset(buf.data(), offset, len))
+        len.checked_sub(buf.count_set_bits_offset(offset, len))
             .unwrap()
     } else {
         0

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -266,17 +266,21 @@ impl Buffer {
         bitwise_unary_op_helper(&self, offset, len, |a| a)
     }
 
+    /// Returns a `BitChunks` instance which can be used to iterate over this buffers bits
+    /// in larger chunks and starting at arbitrary bit offsets.
+    /// Note that both `offset` and `length` are measured in bits.
     pub fn bit_chunks(&self, offset: usize, len: usize) -> BitChunks {
         BitChunks::new(&self, offset, len)
     }
 
-    /// Returns the number of 1-bits in `data`
+    /// Returns the number of 1-bits in this buffer.
     pub fn count_set_bits(&self) -> usize {
         let len_in_bits = self.len() * 8;
+        // self.offset is already taken into consideration by the bit_chunks implementation
         self.count_set_bits_offset(0, len_in_bits)
     }
 
-    /// Returns the number of 1-bits in `data`, starting from `offset` with `length` bits
+    /// Returns the number of 1-bits in this buffer, starting from `offset` with `length` bits
     /// inspected. Note that both `offset` and `length` are measured in bits.
     pub fn count_set_bits_offset(&self, offset: usize, len: usize) -> usize {
         let chunks = self.bit_chunks(offset, len);
@@ -1111,12 +1115,46 @@ mod tests {
     }
 
     #[test]
-    fn test_count_bits_slice() {
+    fn test_count_bits() {
         assert_eq!(0, Buffer::from(&[0b00000000]).count_set_bits());
         assert_eq!(8, Buffer::from(&[0b11111111]).count_set_bits());
         assert_eq!(3, Buffer::from(&[0b00001101]).count_set_bits());
         assert_eq!(6, Buffer::from(&[0b01001001, 0b01010010]).count_set_bits());
         assert_eq!(16, Buffer::from(&[0b11111111, 0b11111111]).count_set_bits());
+    }
+
+    #[test]
+    fn test_count_bits_slice() {
+        assert_eq!(
+            0,
+            Buffer::from(&[0b11111111, 0b00000000])
+                .slice(1)
+                .count_set_bits()
+        );
+        assert_eq!(
+            8,
+            Buffer::from(&[0b11111111, 0b11111111])
+                .slice(1)
+                .count_set_bits()
+        );
+        assert_eq!(
+            3,
+            Buffer::from(&[0b11111111, 0b11111111, 0b00001101])
+                .slice(2)
+                .count_set_bits()
+        );
+        assert_eq!(
+            6,
+            Buffer::from(&[0b11111111, 0b01001001, 0b01010010])
+                .slice(1)
+                .count_set_bits()
+        );
+        assert_eq!(
+            16,
+            Buffer::from(&[0b11111111, 0b11111111, 0b11111111, 0b11111111])
+                .slice(2)
+                .count_set_bits()
+        );
     }
 
     #[test]

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -1109,4 +1109,55 @@ mod tests {
         check_as_typed_data!(&[1f32, 3f32, 6f32], f32);
         check_as_typed_data!(&[1f64, 3f64, 6f64], f64);
     }
+
+    #[test]
+    fn test_count_bits_slice() {
+        assert_eq!(0, Buffer::from(&[0b00000000]).count_set_bits());
+        assert_eq!(8, Buffer::from(&[0b11111111]).count_set_bits());
+        assert_eq!(3, Buffer::from(&[0b00001101]).count_set_bits());
+        assert_eq!(6, Buffer::from(&[0b01001001, 0b01010010]).count_set_bits());
+        assert_eq!(16, Buffer::from(&[0b11111111, 0b11111111]).count_set_bits());
+    }
+
+    #[test]
+    fn test_count_bits_offset_slice() {
+        assert_eq!(8, Buffer::from(&[0b11111111]).count_set_bits_offset(0, 8));
+        assert_eq!(3, Buffer::from(&[0b11111111]).count_set_bits_offset(0, 3));
+        assert_eq!(5, Buffer::from(&[0b11111111]).count_set_bits_offset(3, 5));
+        assert_eq!(1, Buffer::from(&[0b11111111]).count_set_bits_offset(3, 1));
+        assert_eq!(0, Buffer::from(&[0b11111111]).count_set_bits_offset(8, 0));
+        assert_eq!(2, Buffer::from(&[0b01010101]).count_set_bits_offset(0, 3));
+        assert_eq!(
+            16,
+            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(0, 16)
+        );
+        assert_eq!(
+            10,
+            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(0, 10)
+        );
+        assert_eq!(
+            10,
+            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(3, 10)
+        );
+        assert_eq!(
+            8,
+            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(8, 8)
+        );
+        assert_eq!(
+            5,
+            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(11, 5)
+        );
+        assert_eq!(
+            0,
+            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(16, 0)
+        );
+        assert_eq!(
+            2,
+            Buffer::from(&[0b01101101, 0b10101010]).count_set_bits_offset(7, 5)
+        );
+        assert_eq!(
+            4,
+            Buffer::from(&[0b01101101, 0b10101010]).count_set_bits_offset(7, 9)
+        );
+    }
 }

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -319,9 +319,11 @@ impl FilterContext {
             ));
         }
         let filter_mask: Vec<u64> = (0..64).map(|x| 1u64 << x).collect();
-        let filter_bytes = filter_array.data_ref().buffers()[0].data();
-        let filtered_count =
-            bit_util::count_set_bits_offset(filter_bytes, 0, filter_array.len());
+        let filter_buffer = &filter_array.data_ref().buffers()[0];
+        let filtered_count = filter_buffer
+            .count_set_bits_offset(0, filter_array.len());
+
+        let filter_bytes = filter_buffer.data();
 
         // transmute filter_bytes to &[u64]
         let mut u64_buffer = MutableBuffer::new(filter_bytes.len());

--- a/rust/arrow/src/compute/kernels/filter.rs
+++ b/rust/arrow/src/compute/kernels/filter.rs
@@ -320,8 +320,7 @@ impl FilterContext {
         }
         let filter_mask: Vec<u64> = (0..64).map(|x| 1u64 << x).collect();
         let filter_buffer = &filter_array.data_ref().buffers()[0];
-        let filtered_count = filter_buffer
-            .count_set_bits_offset(0, filter_array.len());
+        let filtered_count = filter_buffer.count_set_bits_offset(0, filter_array.len());
 
         let filter_bytes = filter_buffer.data();
 

--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -120,7 +120,6 @@ mod tests {
     use std::collections::HashSet;
 
     use super::*;
-    use crate::buffer::Buffer;
     use crate::util::test_util::seedable_rng;
     use rand::Rng;
 
@@ -269,57 +268,6 @@ mod tests {
         for i in 0..NUM_BYTES * 8 {
             assert_eq!(v.contains(&i), get_bit(&buffer[..], i));
         }
-    }
-
-    #[test]
-    fn test_count_bits_slice() {
-        assert_eq!(0, Buffer::from(&[0b00000000]).count_set_bits());
-        assert_eq!(8, Buffer::from(&[0b11111111]).count_set_bits());
-        assert_eq!(3, Buffer::from(&[0b00001101]).count_set_bits());
-        assert_eq!(6, Buffer::from(&[0b01001001, 0b01010010]).count_set_bits());
-        assert_eq!(16, Buffer::from(&[0b11111111, 0b11111111]).count_set_bits());
-    }
-
-    #[test]
-    fn test_count_bits_offset_slice() {
-        assert_eq!(8, Buffer::from(&[0b11111111]).count_set_bits_offset(0, 8));
-        assert_eq!(3, Buffer::from(&[0b11111111]).count_set_bits_offset(0, 3));
-        assert_eq!(5, Buffer::from(&[0b11111111]).count_set_bits_offset(3, 5));
-        assert_eq!(1, Buffer::from(&[0b11111111]).count_set_bits_offset(3, 1));
-        assert_eq!(0, Buffer::from(&[0b11111111]).count_set_bits_offset(8, 0));
-        assert_eq!(2, Buffer::from(&[0b01010101]).count_set_bits_offset(0, 3));
-        assert_eq!(
-            16,
-            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(0, 16)
-        );
-        assert_eq!(
-            10,
-            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(0, 10)
-        );
-        assert_eq!(
-            10,
-            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(3, 10)
-        );
-        assert_eq!(
-            8,
-            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(8, 8)
-        );
-        assert_eq!(
-            5,
-            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(11, 5)
-        );
-        assert_eq!(
-            0,
-            Buffer::from(&[0b11111111, 0b11111111]).count_set_bits_offset(16, 0)
-        );
-        assert_eq!(
-            2,
-            Buffer::from(&[0b01101101, 0b10101010]).count_set_bits_offset(7, 5)
-        );
-        assert_eq!(
-            4,
-            Buffer::from(&[0b01101101, 0b10101010]).count_set_bits_offset(7, 9)
-        );
     }
 
     #[test]


### PR DESCRIPTION
This refactors the calculation of null counts by using the bitchunk iterator and `count_ones` intrinsic. The performance of array creation improves by between 3%-5%. The biggest impact is on getting a slice of an existing array, for a slice length of 2048 the performance in a microbenchmark doubles.

Benchmark results on a Ryzen 3700U. LLVM seems to be able to vectorize the `count_ones` intrinsic, so performance on machines with better AVX units should be even higher.

```
Running /home/jhorstmann/Source/github/apache/arrow/rust/target/release/deps/array_slice-d438c5aeed9bef19
Gnuplot not found, using plotters backend
array_slice 128         time:   [150.68 ns 151.74 ns 153.14 ns]                            
                        change: [-11.525% -10.357% -9.3284%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

array_slice 512         time:   [158.77 ns 161.03 ns 163.62 ns]                            
                        change: [-25.922% -24.956% -23.945%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe

array_slice 2048        time:   [170.17 ns 171.24 ns 172.60 ns]                             
                        change: [-50.388% -49.865% -49.375%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  2 (2.00%) high mild
  4 (4.00%) high severe
```


```
Running /home/jhorstmann/Source/github/apache/arrow/rust/target/release/deps/array_from_vec-8a972c208e7a6334
Gnuplot not found, using plotters backend
array_from_vec 128      time:   [750.62 ns 751.69 ns 752.85 ns]                                
                        change: [-8.2512% -7.3658% -6.5917%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

array_from_vec 256      time:   [1.2501 us 1.2580 us 1.2676 us]                                
                        change: [-0.9517% +0.1364% +1.1850%] (p = 0.81 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

array_from_vec 512      time:   [2.1603 us 2.1643 us 2.1690 us]                                
                        change: [-2.8122% -2.1984% -1.6379%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  10 (10.00%) high mild
  3 (3.00%) high severe

array_string_from_vec 128                                                                             
                        time:   [3.2196 us 3.2288 us 3.2395 us]
                        change: [+1.4107% +1.9839% +2.5419%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe

array_string_from_vec 256                                                                             
                        time:   [4.8112 us 4.8352 us 4.8685 us]
                        change: [-5.2564% -3.8312% -2.7672%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  4 (4.00%) high mild
  10 (10.00%) high severe

array_string_from_vec 512                                                                             
                        time:   [8.2588 us 8.2802 us 8.3049 us]
                        change: [-0.5974% -0.2991% +0.0027%] (p = 0.05 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

struct_array_from_vec 128                                                                             
                        time:   [4.5771 us 4.5947 us 4.6206 us]
                        change: [-6.6706% -5.3873% -4.2340%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  5 (5.00%) high mild
  10 (10.00%) high severe

struct_array_from_vec 256                                                                             
                        time:   [6.7617 us 6.7887 us 6.8182 us]
                        change: [-4.9262% -4.2419% -3.6528%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

struct_array_from_vec 512                                                                             
                        time:   [9.8926 us 9.9639 us 10.052 us]
                        change: [-5.4057% -3.9331% -2.5242%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

struct_array_from_vec 1024                                                                             
                        time:   [15.812 us 15.862 us 15.922 us]
                        change: [-6.1966% -5.6634% -5.0338%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) high mild
  8 (8.00%) high severe
```



```
Running /home/jhorstmann/Source/github/apache/arrow/rust/target/release/deps/builder-26beb41d8ad91167
Gnuplot not found, using plotters backend
bench_primitive         time:   [4.8277 ms 4.8879 ms 4.9558 ms]                             
                        thrpt:  [807.14 MiB/s 818.35 MiB/s 828.55 MiB/s]
                 change:
                        time:   [-5.3415% -3.4401% -1.3973%] (p = 0.00 < 0.05)
                        thrpt:  [+1.4171% +3.5626% +5.6429%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

bench_bool              time:   [2.5176 ms 2.5230 ms 2.5292 ms]                        
                        thrpt:  [197.69 MiB/s 198.18 MiB/s 198.60 MiB/s]
                 change:
                        time:   [-19.412% -19.203% -18.988%] (p = 0.00 < 0.05)
                        thrpt:  [+23.438% +23.767% +24.088%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
```
