### PR TITLE
ARROW-10590: [Rust] Remove Date32(Millisecond) from casts

### DIFF
--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -2975,8 +2975,6 @@ mod tests {
             Timestamp(TimeUnit::Microsecond, Some(tz_name.clone())),
             Timestamp(TimeUnit::Nanosecond, Some(tz_name.clone())),
             Date32(DateUnit::Day),
-            Date64(DateUnit::Day),
-            Date32(DateUnit::Millisecond),
             Date64(DateUnit::Millisecond),
             Time32(TimeUnit::Second),
             Time32(TimeUnit::Millisecond),


### PR DESCRIPTION
In the arrow spec, Date32 and Date64 are always in days and milliseconds respectively. This removes them from a test about casting.

There is a broader problem to be solved, on which we should remove the possibility to create these variants, but I left it as a separate exercise (as it is a bit more disruptive).