### PR TITLE
ARROW-10595: [Rust] Simplify inner loop of min/max kernels for non-null case

### DIFF
--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -94,24 +94,27 @@ where
 {
     let null_count = array.null_count();
 
+    // Includes case array.len() == 0
     if null_count == array.len() {
         return None;
     }
 
-    let mut n: T::Native = T::default_value();
-    let mut has_value = false;
     let data = array.data();
     let m = array.value_slice(0, data.len());
+    let mut n;
 
     if null_count == 0 {
         // optimized path for arrays without null values
-        for item in m {
-            if !has_value || cmp(&n, item) {
-                has_value = true;
+        n = m[0];
+
+        for item in &m[1..] {
+            if cmp(&n, item) {
                 n = *item
             }
         }
     } else {
+        n = T::default_value();
+        let mut has_value = false;
         for (i, item) in m.iter().enumerate() {
             if data.is_valid(i) && (!has_value || cmp(&n, item)) {
                 has_value = true;


### PR DESCRIPTION
Keeping track of `has_value` is not needed when there are no nulls in the array, we can just pick the first item.

Micro benchmark results are a bit noisy, but the `min 512` seems to be consistently faster:

```
min 512                 time:   [442.25 ns 444.75 ns 448.21 ns]                    
                        change: [-34.516% -33.618% -32.659%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  8 (8.00%) high mild
  10 (10.00%) high severe
```

