### PR TITLE
ARROW-10596: [Rust] Improve take benchmark

### DIFF
--- a/rust/arrow/benches/take_kernels.rs
+++ b/rust/arrow/benches/take_kernels.rs
@@ -20,7 +20,6 @@ extern crate criterion;
 use criterion::Criterion;
 
 use rand::distributions::{Alphanumeric, Distribution, Standard};
-use rand::prelude::random;
 use rand::Rng;
 
 use std::sync::Arc;
@@ -28,18 +27,24 @@ use std::sync::Arc;
 extern crate arrow;
 
 use arrow::array::*;
-use arrow::compute::{cast, take};
+use arrow::compute::take;
 use arrow::datatypes::*;
 use arrow::util::test_util::seedable_rng;
 
 // cast array from specified primitive array type to desired data type
-fn create_numeric<T>(size: usize) -> ArrayRef
+fn create_primitive<T>(size: usize) -> ArrayRef
 where
-    T: ArrowNumericType,
+    T: ArrowPrimitiveType,
     Standard: Distribution<T::Native>,
     PrimitiveArray<T>: std::convert::From<Vec<T::Native>>,
 {
-    Arc::new(PrimitiveArray::<T>::from(vec![random::<T::Native>(); size])) as ArrayRef
+    let array: PrimitiveArray<T> = seedable_rng()
+        .sample_iter(&Standard)
+        .take(size)
+        .map(|v| Some(v))
+        .collect();
+
+    Arc::new(array) as ArrayRef
 }
 
 fn create_strings(size: usize) -> ArrayRef {
@@ -57,15 +62,18 @@ fn create_strings(size: usize) -> ArrayRef {
     ))
 }
 
-fn create_random_index(size: usize) -> UInt32Array {
+fn create_random_index(size: usize, null_density: f32) -> UInt32Array {
     let mut rng = seedable_rng();
-    let ints = Int32Array::from(vec![rng.gen_range(-24i32, size as i32); size]);
-    // cast to u32, conveniently marking negative values as nulls
-    UInt32Array::from(
-        cast(&(Arc::new(ints) as ArrayRef), &DataType::UInt32)
-            .unwrap()
-            .data(),
-    )
+    let mut builder = UInt32Builder::new(size);
+    for _ in 0..size {
+        if rng.gen::<f32>() < null_density {
+            let value = rng.gen_range::<u32, _, _>(0u32, size as u32);
+            builder.append_value(value).unwrap();
+        } else {
+            builder.append_null().unwrap()
+        }
+    }
+    builder.finish()
 }
 
 fn bench_take(values: &ArrayRef, indices: &UInt32Array) {
@@ -73,34 +81,66 @@ fn bench_take(values: &ArrayRef, indices: &UInt32Array) {
 }
 
 fn add_benchmark(c: &mut Criterion) {
-    let values = create_numeric::<Int32Type>(512);
-    let indices = create_random_index(512);
+    let values = create_primitive::<Int32Type>(512);
+    let indices = create_random_index(512, 0.0);
     c.bench_function("take i32 512", |b| b.iter(|| bench_take(&values, &indices)));
-    let values = create_numeric::<Int32Type>(1024);
-    let indices = create_random_index(1024);
+    let values = create_primitive::<Int32Type>(1024);
+    let indices = create_random_index(1024, 0.0);
     c.bench_function("take i32 1024", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
 
-    let values = Arc::new(BooleanArray::from(vec![random::<bool>(); 512])) as ArrayRef;
-    let indices = create_random_index(512);
-    c.bench_function("take bool 512", |b| {
+    let indices = create_random_index(512, 0.5);
+    c.bench_function("take i32 nulls 512", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+    let values = create_primitive::<Int32Type>(1024);
+    let indices = create_random_index(1024, 0.5);
+    c.bench_function("take i32 nulls 1024", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
 
-    let values = Arc::new(BooleanArray::from(vec![random::<bool>(); 1024])) as ArrayRef;
-    let indices = create_random_index(1024);
+    let values = create_primitive::<BooleanType>(512);
+    let indices = create_random_index(512, 0.0);
+    c.bench_function("take bool 512", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+    let values = create_primitive::<BooleanType>(1024);
+    let indices = create_random_index(1024, 0.0);
     c.bench_function("take bool 1024", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
 
+    let values = create_primitive::<BooleanType>(512);
+    let indices = create_random_index(512, 0.5);
+    c.bench_function("take bool nulls 512", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+    let values = create_primitive::<BooleanType>(1024);
+    let indices = create_random_index(1024, 0.5);
+    c.bench_function("take bool nulls 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
     let values = create_strings(512);
-    let indices = create_random_index(512);
+    let indices = create_random_index(512, 0.0);
     c.bench_function("take str 512", |b| b.iter(|| bench_take(&values, &indices)));
 
     let values = create_strings(1024);
-    let indices = create_random_index(1024);
+    let indices = create_random_index(1024, 0.0);
     c.bench_function("take str 1024", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_strings(512);
+    let indices = create_random_index(512, 0.5);
+    c.bench_function("take str nulls 512", |b| {
+        b.iter(|| bench_take(&values, &indices))
+    });
+
+    let values = create_strings(1024);
+    let indices = create_random_index(1024, 0.5);
+    c.bench_function("take str nulls 1024", |b| {
         b.iter(|| bench_take(&values, &indices))
     });
 }


### PR DESCRIPTION
This fixes 3 issues on the take benchmark:

1. it is always taking the same element (indices is a constant vector), which is very easy to speculatively predict what the element is going to be.
2. It also does not compare with vs without nulls
3. all elements of the array are equal, which is again easy to speculatively predict
