### PR TITLE
ARROW-10609: [Rust] Optimize min/max of non null strings

### DIFF
--- a/rust/arrow/benches/aggregate_kernels.rs
+++ b/rust/arrow/benches/aggregate_kernels.rs
@@ -91,7 +91,7 @@ fn add_benchmark(c: &mut Criterion) {
     let arr_b = create_string_array(512, false);
     c.bench_function("min string 512", |b| b.iter(|| bench_min_string(&arr_b)));
 
-    let arr_b = create_string_array(512, false);
+    let arr_b = create_string_array(512, true);
     c.bench_function("min nulls string 512", |b| {
         b.iter(|| bench_min_string(&arr_b))
     });

--- a/rust/arrow/benches/aggregate_kernels.rs
+++ b/rust/arrow/benches/aggregate_kernels.rs
@@ -43,7 +43,7 @@ fn create_array(size: usize, with_nulls: bool) -> ArrayRef {
     Arc::new(builder.finish())
 }
 
-fn create_string_array(size: usize, with_nulls: bool) -> &'static GenericStringArray<i32> {
+fn create_string_array(size: usize, with_nulls: bool) -> ArrayRef {
     // use random numbers to avoid spurious compiler optimizations wrt to branching
     let mut rng = seedable_rng();
     let mut builder = StringBuilder::new(size);
@@ -59,7 +59,7 @@ fn create_string_array(size: usize, with_nulls: bool) -> &'static GenericStringA
             builder.append_value(&string).unwrap();
         }
     }
-    Arc::new(builder.finish().clone()).as_any().downcast_ref::<StringArray>().unwrap().clone()
+    Arc::new(builder.finish())
 }
 
 fn bench_sum(arr_a: &ArrayRef) {
@@ -72,8 +72,9 @@ fn bench_min(arr_a: &ArrayRef) {
     criterion::black_box(min(&arr_a).unwrap());
 }
 
-fn bench_min_string(arr_a: &StringArray) {
-    criterion::black_box(min_string(arr_a).unwrap());
+fn bench_min_string(arr_a: &ArrayRef) {
+    let arr_a = arr_a.as_any().downcast_ref::<StringArray>().unwrap();
+    criterion::black_box(min_string(&arr_a).unwrap());
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/rust/arrow/benches/aggregate_kernels.rs
+++ b/rust/arrow/benches/aggregate_kernels.rs
@@ -20,7 +20,6 @@ extern crate criterion;
 use criterion::Criterion;
 
 use rand::{distributions::Alphanumeric, Rng};
-use std::sync::Arc;
 
 extern crate arrow;
 

--- a/rust/arrow/benches/aggregate_kernels.rs
+++ b/rust/arrow/benches/aggregate_kernels.rs
@@ -43,7 +43,7 @@ fn create_array(size: usize, with_nulls: bool) -> ArrayRef {
     Arc::new(builder.finish())
 }
 
-fn create_string_array(size: usize, with_nulls: bool) -> ArrayRef {
+fn create_string_array(size: usize, with_nulls: bool) -> &'static GenericStringArray<i32> {
     // use random numbers to avoid spurious compiler optimizations wrt to branching
     let mut rng = seedable_rng();
     let mut builder = StringBuilder::new(size);
@@ -59,7 +59,7 @@ fn create_string_array(size: usize, with_nulls: bool) -> ArrayRef {
             builder.append_value(&string).unwrap();
         }
     }
-    Arc::new(builder.finish())
+    Arc::new(builder.finish().clone()).as_any().downcast_ref::<StringArray>().unwrap().clone()
 }
 
 fn bench_sum(arr_a: &ArrayRef) {
@@ -72,9 +72,8 @@ fn bench_min(arr_a: &ArrayRef) {
     criterion::black_box(min(&arr_a).unwrap());
 }
 
-fn bench_min_string(arr_a: &ArrayRef) {
-    let arr_a = arr_a.as_any().downcast_ref::<StringArray>().unwrap();
-    criterion::black_box(min_string(&arr_a).unwrap());
+fn bench_min_string(arr_a: &StringArray) {
+    criterion::black_box(min_string(arr_a).unwrap());
 }
 
 fn add_benchmark(c: &mut Criterion) {

--- a/rust/arrow/benches/aggregate_kernels.rs
+++ b/rust/arrow/benches/aggregate_kernels.rs
@@ -28,7 +28,7 @@ use arrow::array::*;
 use arrow::compute::kernels::aggregate::*;
 use arrow::util::test_util::seedable_rng;
 
-fn create_array(size: usize, with_nulls: bool) -> ArrayRef {
+fn create_array(size: usize, with_nulls: bool) -> Float32Array {
     // use random numbers to avoid spurious compiler optimizations wrt to branching
     let mut rng = seedable_rng();
     let mut builder = Float32Builder::new(size);
@@ -40,10 +40,10 @@ fn create_array(size: usize, with_nulls: bool) -> ArrayRef {
             builder.append_value(rng.gen()).unwrap();
         }
     }
-    Arc::new(builder.finish())
+    builder.finish()
 }
 
-fn create_string_array(size: usize, with_nulls: bool) -> ArrayRef {
+fn create_string_array(size: usize, with_nulls: bool) -> StringArray {
     // use random numbers to avoid spurious compiler optimizations wrt to branching
     let mut rng = seedable_rng();
     let mut builder = StringBuilder::new(size);
@@ -59,21 +59,18 @@ fn create_string_array(size: usize, with_nulls: bool) -> ArrayRef {
             builder.append_value(&string).unwrap();
         }
     }
-    Arc::new(builder.finish())
+    builder.finish()
 }
 
-fn bench_sum(arr_a: &ArrayRef) {
-    let arr_a = arr_a.as_any().downcast_ref::<Float32Array>().unwrap();
+fn bench_sum(arr_a: &Float32Array) {
     criterion::black_box(sum(&arr_a).unwrap());
 }
 
-fn bench_min(arr_a: &ArrayRef) {
-    let arr_a = arr_a.as_any().downcast_ref::<Float32Array>().unwrap();
+fn bench_min(arr_a: &Float32Array) {
     criterion::black_box(min(&arr_a).unwrap());
 }
 
-fn bench_min_string(arr_a: &ArrayRef) {
-    let arr_a = arr_a.as_any().downcast_ref::<StringArray>().unwrap();
+fn bench_min_string(arr_a: &StringArray) {
     criterion::black_box(min_string(&arr_a).unwrap());
 }
 

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -32,19 +32,20 @@ fn min_max_string<T: StringOffsetSizeTrait, F: Fn(&str, &str) -> bool>(
     if null_count == array.len() {
         return None;
     }
-    let mut n = "";
-    let mut has_value = false;
     let data = array.data();
-
+    let mut n;
     if null_count == 0 {
-        for i in 0..data.len() {
+        n = array.value(0);
+        for i in 1..data.len() {
             let item = array.value(i);
-            if !has_value || cmp(&n, item) {
-                has_value = true;
+            if cmp(&n, item) {
                 n = item;
             }
         }
     } else {
+        n = "";
+        let mut has_value = false;
+
         for i in 0..data.len() {
             let item = array.value(i);
             if data.is_valid(i) && (!has_value || cmp(&n, item)) {

--- a/rust/arrow/src/compute/kernels/aggregate.rs
+++ b/rust/arrow/src/compute/kernels/aggregate.rs
@@ -106,13 +106,9 @@ where
 
     if null_count == 0 {
         // optimized path for arrays without null values
-        n = m[0];
-
-        for item in &m[1..] {
-            if cmp(&n, item) {
-                n = *item
-            }
-        }
+        n = m[1..]
+            .iter()
+            .fold(m[0], |max, item| if cmp(&max, item) { *item } else { max });
     } else {
         n = T::default_value();
         let mut has_value = false;

--- a/rust/arrow/src/compute/kernels/cast.rs
+++ b/rust/arrow/src/compute/kernels/cast.rs
@@ -2740,14 +2740,14 @@ mod tests {
                     (Ok(_), false) => {
                         panic!("Was able to cast array from {:?} to {:?} but can_cast_types reported false",
                                array.data_type(), to_type)
-                    },
+                    }
                     (Err(e), true) => {
                         panic!("Was not able to cast array from {:?} to {:?} but can_cast_types reported true. \
                                 Error was {:?}",
                                array.data_type(), to_type, e)
-                    },
+                    }
                     // otherwise it was a match
-                    _=> {},
+                    _ => {}
                 };
             }
         }


### PR DESCRIPTION
Applies the same optimization as in ARROW-10595. Difference is smaller, but still there:

```
min string 512          time:   [3.4096 us 3.4378 us 3.4683 us]                            
                        change: [-13.563% -13.111% -12.628%] (p = 0.00 < 0.05)
                        Performance has improved.
```