### PR TITLE
ARROW-10619: [C++] Fix IPC validation regressions

### DIFF
--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -196,6 +196,7 @@ struct DictionaryMemo::Impl {
           return Status::NotImplemented(
               "Encountered delta dictionary with an unresolved nested dictionary");
         }
+        RETURN_NOT_OK(::arrow::internal::ValidateArray(*data));
         RETURN_NOT_OK(::arrow::internal::ValidateArrayFull(*data));
         to_combine.push_back(MakeArray(data));
       }

--- a/cpp/src/arrow/visitor_inline.h
+++ b/cpp/src/arrow/visitor_inline.h
@@ -199,6 +199,9 @@ struct ArrayDataInlineVisitor<T, enable_if_base_binary<T>> {
     using offset_type = typename T::offset_type;
     constexpr char empty_value = 0;
 
+    if (arr.length == 0) {
+      return Status::OK();
+    }
     const offset_type* offsets = arr.GetValues<offset_type>(1);
     const char* data;
     if (!arr.buffers[2]) {
@@ -229,6 +232,9 @@ struct ArrayDataInlineVisitor<T, enable_if_base_binary<T>> {
     using offset_type = typename T::offset_type;
     constexpr uint8_t empty_value = 0;
 
+    if (arr.length == 0) {
+      return;
+    }
     const offset_type* offsets = arr.GetValues<offset_type>(1);
     const uint8_t* data;
     if (!arr.buffers[2]) {


### PR DESCRIPTION
Some cases of invalid IPC stream were missed following the ARROW-10619 refactor.