### PR TITLE
ARROW-10182: [C++] Add basic continuation support to Future

### DIFF
--- a/cpp/src/arrow/io/hdfs.h
+++ b/cpp/src/arrow/io/hdfs.h
@@ -111,8 +111,8 @@ class ARROW_EXPORT HadoopFileSystem : public FileSystem {
   Status MakeDirectory(const std::string& path) override;
 
   // Delete file or directory
-  // @param path: absolute path to data
-  // @param recursive: if path is a directory, delete contents as well
+  // @param path absolute path to data
+  // @param recursive if path is a directory, delete contents as well
   // @returns error status on failure
   Status Delete(const std::string& path, bool recursive = false);
 
@@ -188,9 +188,9 @@ class ARROW_EXPORT HadoopFileSystem : public FileSystem {
 
   // FileMode::WRITE options
   // @param path complete file path
-  // @param buffer_size, 0 for default
-  // @param replication, 0 for default
-  // @param default_block_size, 0 for default
+  // @param buffer_size 0 by default
+  // @param replication 0 by default
+  // @param default_block_size 0 by default
   Status OpenWritable(const std::string& path, bool append, int32_t buffer_size,
                       int16_t replication, int64_t default_block_size,
                       std::shared_ptr<HdfsOutputStream>* file);

--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -53,6 +53,10 @@ struct call_traits {
   static typename std::tuple_element<I, std::tuple<A...>>::type argument_type_impl(
       R (F::*)(A...) const);
 
+  template <std::size_t I, typename F, typename R, typename... A>
+  static typename std::tuple_element<I, std::tuple<A...>>::type argument_type_impl(
+      R (F::*)(A...) &&);
+
   /// bool constant indicating whether F is a callable with more than one possible
   /// signature. Will be true_type for objects which define multiple operator() or which
   /// define a template operator()
@@ -103,7 +107,7 @@ class FnOnce<R(A...)> {
 
   R operator()(A... a) && {
     auto bye = std::move(impl_);
-    return bye->invoke(static_cast<A>(a)...);
+    return bye->invoke(static_cast<A&&>(a)...);
   }
 
  private:
@@ -115,7 +119,7 @@ class FnOnce<R(A...)> {
   template <typename Fn>
   struct FnImpl : Impl {
     explicit FnImpl(Fn fn) : fn_(std::move(fn)) {}
-    R invoke(A... a) override { return std::move(fn_)(static_cast<A>(a)...); }
+    R invoke(A... a) override { return std::move(fn_)(static_cast<A&&>(a)...); }
     Fn fn_;
   };
 

--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -107,19 +107,19 @@ class FnOnce<R(A...)> {
 
   R operator()(A... a) && {
     auto bye = std::move(impl_);
-    return bye->invoke(static_cast<A&&>(a)...);
+    return bye->invoke(std::forward<A&&>(a)...);
   }
 
  private:
   struct Impl {
     virtual ~Impl() = default;
-    virtual R invoke(A... a) = 0;
+    virtual R invoke(A&&... a) = 0;
   };
 
   template <typename Fn>
   struct FnImpl : Impl {
     explicit FnImpl(Fn fn) : fn_(std::move(fn)) {}
-    R invoke(A... a) override { return std::move(fn_)(static_cast<A&&>(a)...); }
+    R invoke(A&&... a) override { return std::move(fn_)(std::forward<A&&>(a)...); }
     Fn fn_;
   };
 

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -254,7 +254,12 @@ class ConcreteFutureImpl : public FutureImpl {
     }
     cv_.notify_all();
 
-    // run callbacks
+    // run callbacks, lock not needed since the future is finsihed by this
+    // point so nothing else can modify the callbacks list and it is safe
+    // to iterate.
+    //
+    // In fact, it is important not to hold the locks because the callback
+    // may be slow or do its own locking on other resources
     for (auto&& callback : callbacks_) {
       std::move(callback)();
     }

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -439,6 +439,7 @@ class ARROW_MUST_USE_TYPE Future {
     struct Callback {
       void operator()(const Result<T>& result) && {
         if (ARROW_PREDICT_TRUE(result.ok())) {
+          // move on_failure to a(n immediately destroyed) temporary to free its resources
           ARROW_UNUSED(OnFailure(std::move(on_failure)));
           detail::Continue(std::move(next), std::move(on_success), result.ValueOrDie());
         } else {

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <cmath>
+#include <functional>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -26,25 +27,114 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/util/functional.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/type_fwd.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
+
+namespace detail {
+
+struct Empty {
+  static Result<Empty> ToResult(Status s) {
+    if (ARROW_PREDICT_TRUE(s.ok())) {
+      return Empty{};
+    }
+    return s;
+  }
+};
+
+template <typename>
+struct is_future : std::false_type {};
+
+template <typename T>
+struct is_future<Future<T>> : std::true_type {};
+
+template <typename Signature>
+using result_of_t = typename std::result_of<Signature>::type;
+
+constexpr struct ContinueFuture {
+  template <typename Return>
+  struct ForReturnImpl;
+
+  template <typename Return>
+  using ForReturn = typename ForReturnImpl<Return>::type;
+
+  template <typename Signature>
+  using ForSignature = ForReturn<result_of_t<Signature>>;
+
+  template <typename F, typename... A, typename R = result_of_t<F && (A && ...)>,
+            typename N = ForReturn<R>>
+  typename std::enable_if<std::is_void<R>::value>::type operator()(N next, F&& f,
+                                                                   A&&... a) const {
+    std::forward<F>(f)(std::forward<A>(a)...);
+    next.MarkFinished();
+  }
+
+  template <typename F, typename... A, typename R = result_of_t<F && (A && ...)>,
+            typename N = ForReturn<R>>
+  typename std::enable_if<!std::is_void<R>::value && !is_future<R>::value>::type
+  operator()(N next, F&& f, A&&... a) const {
+    next.MarkFinished(std::forward<F>(f)(std::forward<A>(a)...));
+  }
+
+  template <typename F, typename... A, typename R = result_of_t<F && (A && ...)>,
+            typename N = ForReturn<R>>
+  typename std::enable_if<is_future<R>::value>::type operator()(N next, F&& f,
+                                                                A&&... a) const {
+    R signal_to_complete_next = std::forward<F>(f)(std::forward<A>(a)...);
+
+    struct MarkNextFinished {
+      void operator()() && { next.MarkFinished(signal_to_complete_next.get().result()); }
+      N next;
+      WeakFuture<typename R::ValueType> signal_to_complete_next;
+    };
+
+    signal_to_complete_next.impl_->AddCallback(MarkNextFinished{
+        std::move(next), WeakFuture<typename R::ValueType>(signal_to_complete_next)});
+  }
+} Continue;
+
+template <>
+struct ContinueFuture::ForReturnImpl<void> {
+  using type = Future<>;
+};
+
+template <>
+struct ContinueFuture::ForReturnImpl<Status> {
+  using type = Future<>;
+};
+
+template <typename R>
+struct ContinueFuture::ForReturnImpl {
+  using type = Future<R>;
+};
+
+template <typename T>
+struct ContinueFuture::ForReturnImpl<Result<T>> {
+  using type = Future<T>;
+};
+
+template <typename T>
+struct ContinueFuture::ForReturnImpl<Future<T>> {
+  using type = Future<T>;
+};
+
+}  // namespace detail
 
 /// A Future's execution or completion status
 enum class FutureState : int8_t { PENDING, SUCCESS, FAILURE };
 
 inline bool IsFutureFinished(FutureState state) { return state != FutureState::PENDING; }
 
-// ---------------------------------------------------------------------
-// Type-erased helpers
+constexpr struct {
+} StatusOnly;
 
-class FutureWaiter;
-
+// Untyped private implementation
 class ARROW_EXPORT FutureImpl {
  public:
-  static constexpr double kInfinity = HUGE_VAL;
-
+  FutureImpl();
   virtual ~FutureImpl() = default;
 
   FutureState state() { return state_.load(); }
@@ -52,14 +142,14 @@ class ARROW_EXPORT FutureImpl {
   static std::unique_ptr<FutureImpl> Make();
   static std::unique_ptr<FutureImpl> MakeFinished(FutureState state);
 
- protected:
-  FutureImpl();
-
   // Future API
   void MarkFinished();
   void MarkFailed();
   void Wait();
   bool Wait(double seconds);
+
+  using Callback = internal::FnOnce<void()>;
+  void AddCallback(Callback callback);
 
   // Waiter API
   inline FutureState SetWaiter(FutureWaiter* w, int future_num);
@@ -68,14 +158,11 @@ class ARROW_EXPORT FutureImpl {
   std::atomic<FutureState> state_{FutureState::PENDING};
 
   // Type erased storage for arbitrary results
-  // XXX small objects could be stored alongside state_ instead of boxed in a pointer
+  // XXX small objects could be stored inline instead of boxed in a pointer
   using Storage = std::unique_ptr<void, void (*)(void*)>;
   Storage result_{NULLPTR, NULLPTR};
 
-  template <typename T>
-  friend class Future;
-  friend class FutureWaiter;
-  friend class FutureWaiterImpl;
+  std::vector<Callback> callbacks_;
 };
 
 // An object that waits on multiple futures at once.  Only one waiter
@@ -84,7 +171,7 @@ class ARROW_EXPORT FutureWaiter {
  public:
   enum Kind : int8_t { ANY, ALL, ALL_OR_FIRST_FAILED, ITERATE };
 
-  static constexpr double kInfinity = FutureImpl::kInfinity;
+  static constexpr double kInfinity = HUGE_VAL;
 
   static std::unique_ptr<FutureWaiter> Make(Kind kind, std::vector<FutureImpl*> futures);
 
@@ -133,22 +220,6 @@ class ARROW_EXPORT FutureWaiter {
   friend class ConcreteFutureImpl;
 };
 
-namespace detail {
-
-struct Empty {
-  static Result<Empty> ToResult(Status s) {
-    if (ARROW_PREDICT_TRUE(s.ok())) {
-      return Empty{};
-    }
-    return s;
-  }
-
-  template <typename T>
-  using EnableIfSame = typename std::enable_if<std::is_same<Empty, T>::value>::type;
-};
-
-}  // namespace detail
-
 // ---------------------------------------------------------------------
 // Public API
 
@@ -163,11 +234,10 @@ struct Empty {
 /// The consumer API allows querying a Future's current state, wait for it
 /// to complete, or wait on multiple Futures at once (using WaitForAll,
 /// WaitForAny or AsCompletedIterator).
-template <typename T = detail::Empty>
-class Future {
+template <typename T>
+class ARROW_MUST_USE_TYPE Future {
  public:
   using ValueType = T;
-  static constexpr double kInfinity = FutureImpl::kInfinity;
 
   // The default constructor creates an invalid Future.  Use Future::Make()
   // for a valid Future.  This constructor is mostly for the convenience
@@ -246,8 +316,9 @@ class Future {
   void MarkFinished(Result<ValueType> res) { DoMarkFinished(std::move(res)); }
 
   /// \brief Mark a Future<> completed with the provided Status.
-  template <typename E = ValueType>
-  detail::Empty::EnableIfSame<E> MarkFinished(Status s = Status::OK()) {
+  template <typename E = ValueType, typename = typename std::enable_if<
+                                        std::is_same<E, detail::Empty>::value>::type>
+  void MarkFinished(Status s = Status::OK()) {
     return DoMarkFinished(E::ToResult(std::move(s)));
   }
 
@@ -273,9 +344,113 @@ class Future {
   }
 
   /// \brief Make a finished Future<> with the provided Status.
-  template <typename E = ValueType, typename = detail::Empty::EnableIfSame<E>>
+  template <typename E = ValueType, typename = typename std::enable_if<
+                                        std::is_same<E, detail::Empty>::value>::type>
   static Future<> MakeFinished(Status s = Status::OK()) {
     return MakeFinished(E::ToResult(std::move(s)));
+  }
+
+  /// \brief Consumer API: Register a continuation to run when this future completes
+  ///
+  /// The continuation will run in the same thread that called MarkFinished (whatever
+  /// callback is registered with this function will run before MarkFinished returns).
+  /// Avoid long-running callbacks in favor of submitting a task to an Executor and
+  /// returning the future.
+  ///
+  /// Two callbacks are supported:
+  /// - OnSuccess, called against the result (const ValueType&) on successul completion.
+  /// - OnFailure, called against the error (const Status&) on failed completion.
+  ///
+  /// Then() returns a Future whose ValueType is derived from the return type of the
+  /// callbacks. If a callback returns:
+  /// - void, a Future<> will be produced which will completes successully as soon
+  ///   as the callback runs.
+  /// - Status, a Future<> will be produced which will complete with the returned Status
+  ///   as soon as the callback runs.
+  /// - V or Result<V>, a Future<V> will be produced which will complete with the result
+  ///   of invoking the callback as soon as the callback runs.
+  /// - Future<V>, a Future<V> will be produced which will be marked complete when the
+  ///   future returned by the callback completes (and will complete with the same
+  ///   result).
+  ///
+  /// The continued Future type must be the same for both callbacks.
+  ///
+  /// Note that OnFailure can swallow errors, allowing continued Futures to successully
+  /// complete even if this Future fails.
+  ///
+  /// If this future is already completed then the callback will be run immediately
+  /// (before this method returns) and the returned future may already be marked complete
+  /// (it will definitely be marked complete if the callback returns a non-future or a
+  /// completed future).
+  template <typename OnSuccess, typename OnFailure,
+            typename ContinuedFuture =
+                detail::ContinueFuture::ForSignature<OnSuccess && (const T&)>>
+  ContinuedFuture Then(OnSuccess&& on_success, OnFailure&& on_failure) const {
+    static_assert(
+        std::is_same<detail::ContinueFuture::ForSignature<OnFailure && (const Status&)>,
+                     ContinuedFuture>::value,
+        "OnSuccess and OnFailure must continue with the same future type");
+
+    auto next = ContinuedFuture::Make();
+
+    struct Callback {
+      void operator()() && {
+        auto self = weak_self.get();
+        const auto& result = *self.GetResult();
+        if (ARROW_PREDICT_TRUE(result.ok())) {
+          detail::Continue(std::move(next), std::move(on_success), result.ValueOrDie());
+        } else {
+          detail::Continue(std::move(next), std::move(on_failure), result.status());
+        }
+      }
+
+      WeakFuture<T> weak_self;
+      OnSuccess on_success;
+      OnFailure on_failure;
+      ContinuedFuture next;
+    };
+
+    // We know impl_ will not be dangling when invoking callbacks because at least one
+    // thread will be waiting for MarkFinished to return. Thus it's safe to keep a
+    // weak reference to impl_ here
+    impl_->AddCallback(Callback{WeakFuture<T>(*this), std::forward<OnSuccess>(on_success),
+                                std::forward<OnFailure>(on_failure), next});
+
+    return next;
+  }
+
+  /// \brief Overload without OnFailure. Failures will be passed through unchanged.
+  template <typename OnSuccess,
+            typename ContinuedFuture =
+                detail::ContinueFuture::ForSignature<OnSuccess && (const T&)>>
+  ContinuedFuture Then(OnSuccess&& on_success) const {
+    return Then(std::forward<OnSuccess>(on_success), [](const Status& s) {
+      return Result<typename ContinuedFuture::ValueType>(s);
+    });
+  }
+
+  template <typename OnComplete,
+            typename ContinuedFuture = typename detail::ContinueFuture::ForSignature<
+                OnComplete && (const Status&)>>
+  ContinuedFuture Then(decltype(StatusOnly), OnComplete&& on_complete) const {
+    auto next = ContinuedFuture::Make();
+
+    struct Callback {
+      void operator()() && {
+        auto self = weak_self.get();
+        const auto& result = *self.GetResult();
+        detail::Continue(std::move(next), std::move(on_complete), result.status());
+      }
+
+      WeakFuture<T> weak_self;
+      OnComplete on_complete;
+      ContinuedFuture next;
+    };
+
+    impl_->AddCallback(
+        Callback{WeakFuture<T>(*this), std::forward<OnComplete>(on_complete), next});
+
+    return next;
   }
 
  protected:
@@ -306,12 +481,31 @@ class Future {
 #endif
   }
 
+  explicit Future(std::shared_ptr<FutureImpl> impl) : impl_(std::move(impl)) {}
+
   std::shared_ptr<FutureImpl> impl_;
 
   friend class FutureWaiter;
+  friend struct detail::ContinueFuture;
 
   template <typename U>
   friend class Future;
+  friend class WeakFuture<T>;
+
+  FRIEND_TEST(FutureRefTest, ChainRemoved);
+  FRIEND_TEST(FutureRefTest, TailRemoved);
+  FRIEND_TEST(FutureRefTest, HeadRemoved);
+};
+
+template <typename T>
+class WeakFuture {
+ public:
+  explicit WeakFuture(const Future<T>& future) : impl_(future.impl_) {}
+
+  Future<T> get() { return Future<T>{impl_.lock()}; }
+
+ private:
+  std::weak_ptr<FutureImpl> impl_;
 };
 
 /// If a Result<Future> holds an error instead of a Future, construct a finished Future

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -419,7 +419,7 @@ TEST(FutureCompletionTest, Void) {
     // Propagate failure by returning it from on_failure
     auto fut = Future<int>::Make();
     auto fut2 = fut.Then([](...) {}, [](const Status& s) { return s; });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertFailed(fut2);
     ASSERT_TRUE(fut2.status().IsIOError());
   }
@@ -462,8 +462,8 @@ TEST(FutureCompletionTest, NonVoid) {
   {
     // Simple callback
     auto fut = Future<int>::Make();
-    auto fut2 = fut.Then([](const Result<int>& result) {
-      auto passed_in_result = *result;
+    auto fut2 = fut.Then([](int result) {
+      auto passed_in_result = result;
       return passed_in_result * passed_in_result;
     });
     fut.MarkFinished(42);
@@ -475,12 +475,12 @@ TEST(FutureCompletionTest, NonVoid) {
     // Propagate failure by not having on_failure
     auto fut = Future<int>::Make();
     auto cb_was_run = false;
-    auto fut2 = fut.Then([&cb_was_run](const Result<int>& result) {
+    auto fut2 = fut.Then([&cb_was_run](int result) {
       cb_was_run = true;
-      auto passed_in_result = *result;
+      auto passed_in_result = result;
       return passed_in_result * passed_in_result;
     });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertFailed(fut2);
     ASSERT_TRUE(fut2.status().IsIOError());
     ASSERT_FALSE(cb_was_run);
@@ -494,7 +494,7 @@ TEST(FutureCompletionTest, NonVoid) {
                            was_io_error = s.IsIOError();
                            return 100;
                          });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertSuccessful(fut2);
     auto result = *fut2.result();
     ASSERT_EQ(result, 100);
@@ -525,8 +525,8 @@ TEST(FutureCompletionTest, FutureNonVoid) {
     auto fut = Future<int>::Make();
     auto innerFut = Future<std::string>::Make();
     int passed_in_result = 0;
-    auto fut2 = fut.Then([&passed_in_result, innerFut](const Result<int>& result) {
-      passed_in_result = *result;
+    auto fut2 = fut.Then([&passed_in_result, innerFut](int result) {
+      passed_in_result = result;
       return innerFut;
     });
     fut.MarkFinished(42);
@@ -542,11 +542,11 @@ TEST(FutureCompletionTest, FutureNonVoid) {
     auto fut = Future<int>::Make();
     auto innerFut = Future<std::string>::Make();
     auto was_cb_run = false;
-    auto fut2 = fut.Then([innerFut, &was_cb_run](const Result<int>& result) {
+    auto fut2 = fut.Then([innerFut, &was_cb_run](int) {
       return innerFut;
       was_cb_run = true;
     });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertFailed(fut2);
     ASSERT_TRUE(fut2.status().IsIOError());
     ASSERT_FALSE(was_cb_run);
@@ -566,7 +566,7 @@ TEST(FutureCompletionTest, FutureNonVoid) {
           was_io_error = s.IsIOError();
           return innerFut;
         });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertNotFinished(fut2);
     innerFut.MarkFinished("hello");
     AssertSuccessful(fut2);
@@ -609,8 +609,8 @@ TEST(FutureCompletionTest, Status) {
     // Simple callback
     auto fut = Future<int>::Make();
     int passed_in_result = 0;
-    Future<> fut2 = fut.Then([&passed_in_result](const Result<int>& result) {
-      passed_in_result = *result;
+    Future<> fut2 = fut.Then([&passed_in_result](int result) {
+      passed_in_result = result;
       return Status::OK();
     });
     fut.MarkFinished(42);
@@ -621,11 +621,11 @@ TEST(FutureCompletionTest, Status) {
     // Propagate failure by not having on_failure
     auto fut = Future<int>::Make();
     auto was_cb_run = false;
-    auto fut2 = fut.Then([&was_cb_run](const Result<int>& result) {
+    auto fut2 = fut.Then([&was_cb_run](int) {
       was_cb_run = true;
       return Status::OK();
     });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertFailed(fut2);
     ASSERT_TRUE(fut2.status().IsIOError());
     ASSERT_FALSE(was_cb_run);
@@ -644,7 +644,7 @@ TEST(FutureCompletionTest, Status) {
           was_io_error = s.IsIOError();
           return Status::OK();
         });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertSuccessful(fut2);
     ASSERT_TRUE(was_io_error);
     ASSERT_FALSE(was_cb_run);
@@ -694,7 +694,7 @@ TEST(FutureCompletionTest, Result) {
       auto passed_in_result = i;
       return Result<int>(passed_in_result * passed_in_result);
     });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertFailed(fut2);
     ASSERT_TRUE(fut2.status().IsIOError());
     ASSERT_FALSE(was_cb_run);
@@ -713,7 +713,7 @@ TEST(FutureCompletionTest, Result) {
           was_io_error = s.IsIOError();
           return Result<int>(100);
         });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertSuccessful(fut2);
     auto result = *fut2.result();
     ASSERT_EQ(result, 100);
@@ -787,7 +787,7 @@ TEST(FutureCompletionTest, FutureVoid) {
       was_cb_run = true;
       return innerFut;
     });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertFailed(fut2);
     if (IsFutureFinished(fut2.state())) {
       ASSERT_TRUE(fut2.status().IsIOError());
@@ -805,7 +805,7 @@ TEST(FutureCompletionTest, FutureVoid) {
           return innerFut;
         },
         [innerFut](const Status& s) { return innerFut; });
-    fut.MarkFinished(Result<int>(Status::IOError("xxx")));
+    fut.MarkFinished(Status::IOError("xxx"));
     AssertNotFinished(fut2);
     innerFut.MarkFinished();
     AssertSuccessful(fut2);

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -125,7 +125,6 @@ void AssertFinished(const Future<T>& fut) {
 // Assert the future is successful *now*
 template <typename T>
 void AssertSuccessful(const Future<T>& fut) {
-  ASSERT_TRUE(fut.Wait(0.1));
   if (IsFutureFinished(fut.state())) {
     ASSERT_EQ(fut.state(), FutureState::SUCCESS);
     ASSERT_OK(fut.status());
@@ -135,7 +134,6 @@ void AssertSuccessful(const Future<T>& fut) {
 // Assert the future is failed *now*
 template <typename T>
 void AssertFailed(const Future<T>& fut) {
-  ASSERT_TRUE(fut.Wait(0.1));
   if (IsFutureFinished(fut.state())) {
     ASSERT_EQ(fut.state(), FutureState::FAILURE);
     ASSERT_FALSE(fut.status().ok());

--- a/cpp/src/arrow/util/future_test.cc
+++ b/cpp/src/arrow/util/future_test.cc
@@ -367,13 +367,15 @@ TEST(FutureTest, StressCallback) {
     std::thread callback_adder([&] {
       auto test_thread = std::this_thread::get_id();
       while (!finished.load()) {
-        fut.AddCallback([&test_thread, &count_finished_immediately, &count_finished_deferred] (const Result<arrow::Future<arrow::detail::Empty>::ValueType>& result) {
-          if (std::this_thread::get_id() == test_thread) {
-            count_finished_immediately++;
-          } else {
-            count_finished_deferred++;
-          }
-        });
+        fut.AddCallback(
+            [&test_thread, &count_finished_immediately, &count_finished_deferred](
+                const Result<arrow::Future<arrow::detail::Empty>::ValueType>& result) {
+              if (std::this_thread::get_id() == test_thread) {
+                count_finished_immediately++;
+              } else {
+                count_finished_deferred++;
+              }
+            });
         callbacks_added++;
       }
     });

--- a/cpp/src/arrow/util/task_group.cc
+++ b/cpp/src/arrow/util/task_group.cc
@@ -75,10 +75,7 @@ class ThreadedTaskGroup : public TaskGroup {
   }
 
   void AppendReal(std::function<Status()> task) override {
-    // This check below could/should be enabled but it wasn't
-    // and I am worried existing code may be relying on it
-    // being disabled.
-    // DCHECK(!finished_);
+    DCHECK(!finished_);
     // The hot path is unlocked thanks to atomics
     // Only if an error occurs is the lock taken
     if (ok_.load(std::memory_order_acquire)) {

--- a/cpp/src/arrow/util/task_group.cc
+++ b/cpp/src/arrow/util/task_group.cc
@@ -75,7 +75,7 @@ class ThreadedTaskGroup : public TaskGroup {
   }
 
   void AppendReal(std::function<Status()> task) override {
-    // This check below could/should be enabled but it wasn't 
+    // This check below could/should be enabled but it wasn't
     // and I am worried existing code may be relying on it
     // being disabled.
     // DCHECK(!finished_);

--- a/cpp/src/arrow/util/task_group.cc
+++ b/cpp/src/arrow/util/task_group.cc
@@ -75,6 +75,9 @@ class ThreadedTaskGroup : public TaskGroup {
   }
 
   void AppendReal(std::function<Status()> task) override {
+    // This check below could/should be enabled but it wasn't 
+    // and I am worried existing code may be relying on it
+    // being disabled.
     // DCHECK(!finished_);
     // The hot path is unlocked thanks to atomics
     // Only if an error occurs is the lock taken

--- a/cpp/src/arrow/util/task_group.h
+++ b/cpp/src/arrow/util/task_group.h
@@ -22,14 +22,13 @@
 #include <utility>
 
 #include "arrow/status.h"
+#include "arrow/util/future.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/type_fwd.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
 namespace internal {
-
-// TODO Simplify this.  Subgroups don't seem necessary.
 
 /// \brief A group of related tasks
 ///
@@ -38,6 +37,18 @@ namespace internal {
 /// implementation.  When Finish() returns, it is guaranteed that all
 /// tasks have finished, or at least one has errored.
 ///
+/// Once an error has occurred any tasks that are submitted to the task group
+/// will not run.  The call to Append will simply return without scheduling the
+/// task.
+///
+/// If the task group is parallel it is possible that multiple tasks could be
+/// running at the same time and one of those tasks fails.  This will put the
+/// task group in a failure state (so additional tasks cannot be run) however
+/// it will not interrupt running tasks.  Finish will not complete
+/// until all running tasks have finished, even if one task fails.
+///
+/// Once a task group has finished new tasks may not be added to it.  If you need to start
+/// a new batch of work then you should create a new task group.
 class ARROW_EXPORT TaskGroup : public std::enable_shared_from_this<TaskGroup> {
  public:
   /// Add a Status-returning function to execute.  Execution order is
@@ -56,20 +67,12 @@ class ARROW_EXPORT TaskGroup : public std::enable_shared_from_this<TaskGroup> {
   /// The current aggregate error Status.  Non-blocking, useful for stopping early.
   virtual Status current_status() = 0;
 
-  /// Whether some tasks have already failed.  Non-blocking , useful for stopping early.
+  /// Whether some tasks have already failed.  Non-blocking, useful for stopping early.
   virtual bool ok() = 0;
 
   /// How many tasks can typically be executed in parallel.
   /// This is only a hint, useful for testing or debugging.
   virtual int parallelism() = 0;
-
-  /// Create a subgroup of this group.  This group can only finish
-  /// when all subgroups have finished (this means you must be
-  /// be careful to call Finish() on subgroups before calling it
-  /// on the main group).
-  // XXX if a subgroup errors out, should it propagate immediately to the parent
-  // and to children?
-  virtual std::shared_ptr<TaskGroup> MakeSubGroup() = 0;
 
   static std::shared_ptr<TaskGroup> MakeSerial();
   static std::shared_ptr<TaskGroup> MakeThreaded(internal::Executor*);

--- a/cpp/src/arrow/util/task_group.h
+++ b/cpp/src/arrow/util/task_group.h
@@ -22,7 +22,6 @@
 #include <utility>
 
 #include "arrow/status.h"
-#include "arrow/util/future.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/type_fwd.h"
 #include "arrow/util/visibility.h"

--- a/cpp/src/arrow/util/task_group_test.cc
+++ b/cpp/src/arrow/util/task_group_test.cc
@@ -22,6 +22,7 @@
 #include <memory>
 #include <random>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -76,20 +77,27 @@ void TestTaskGroupErrors(std::shared_ptr<TaskGroup> task_group) {
 
   std::atomic<int> count(0);
 
-  for (int i = 0; i < NSUCCESSES; ++i) {
-    task_group->Append([&]() {
-      count++;
-      return Status::OK();
-    });
-  }
-  ASSERT_TRUE(task_group->ok());
-  for (int i = 0; i < NERRORS; ++i) {
-    task_group->Append([&]() {
-      SleepFor(1e-2);
-      count++;
-      return Status::Invalid("some message");
-    });
-  }
+  auto task_group_was_ok = true;
+  task_group->Append([&]() -> Status {
+    for (int i = 0; i < NSUCCESSES; ++i) {
+      task_group->Append([&]() {
+        count++;
+        return Status::OK();
+      });
+    }
+    task_group_was_ok = task_group->ok();
+    for (int i = 0; i < NERRORS; ++i) {
+      task_group->Append([&]() {
+        SleepFor(1e-2);
+        count++;
+        return Status::Invalid("some message");
+      });
+    }
+
+    return Status::OK();
+  });
+
+  ASSERT_TRUE(task_group_was_ok);
 
   // Task error is propagated
   ASSERT_RAISES(Invalid, task_group->Finish());
@@ -106,80 +114,32 @@ void TestTaskGroupErrors(std::shared_ptr<TaskGroup> task_group) {
   ASSERT_RAISES(Invalid, task_group->Finish());
 }
 
-// Check TaskGroup behaviour with a bunch of all-successful tasks and task groups
-void TestTaskSubGroupsSuccess(std::shared_ptr<TaskGroup> task_group) {
-  const int NTASKS = 50;
-  const int NGROUPS = 7;
+class CopyCountingTask {
+ public:
+  explicit CopyCountingTask(std::shared_ptr<uint8_t> target)
+      : counter(0), target(std::move(target)) {}
 
-  auto sleeps = RandomSleepDurations(NTASKS, 1e-4, 1e-3);
-  std::vector<std::shared_ptr<TaskGroup>> groups = {task_group};
+  CopyCountingTask(const CopyCountingTask& other)
+      : counter(other.counter + 1), target(other.target) {}
 
-  // Create some subgroups
-  for (int i = 0; i < NGROUPS - 1; ++i) {
-    groups.push_back(task_group->MakeSubGroup());
+  CopyCountingTask& operator=(const CopyCountingTask& other) {
+    counter = other.counter + 1;
+    target = other.target;
+    return *this;
   }
 
-  // Add NTASKS sleeps amongst all groups
-  std::atomic<int> count(0);
-  for (int i = 0; i < NTASKS; ++i) {
-    groups[i % NGROUPS]->Append([&, i]() {
-      SleepFor(sleeps[i]);
-      count += i;
-      return Status::OK();
-    });
-  }
-  ASSERT_TRUE(task_group->ok());
+  CopyCountingTask(CopyCountingTask&& other) = default;
+  CopyCountingTask& operator=(CopyCountingTask&& other) = default;
 
-  // Finish all subgroups first, then main group
-  for (int i = NGROUPS - 1; i >= 0; --i) {
-    ASSERT_OK(groups[i]->Finish());
-  }
-  ASSERT_TRUE(task_group->ok());
-  ASSERT_EQ(count.load(), NTASKS * (NTASKS - 1) / 2);
-  // Finish() is idempotent
-  ASSERT_OK(task_group->Finish());
-}
-
-// Check TaskGroup behaviour with both successful and failing tasks and task groups
-void TestTaskSubGroupsErrors(std::shared_ptr<TaskGroup> task_group) {
-  const int NTASKS = 50;
-  const int NGROUPS = 7;
-  const int FAIL_EVERY = 17;
-  std::vector<std::shared_ptr<TaskGroup>> groups = {task_group};
-
-  // Create some subgroups
-  for (int i = 0; i < NGROUPS - 1; ++i) {
-    groups.push_back(task_group->MakeSubGroup());
+  Status operator()() {
+    *target = counter;
+    return Status::OK();
   }
 
-  // Add NTASKS sleeps amongst all groups
-  for (int i = 0; i < NTASKS; ++i) {
-    groups[i % NGROUPS]->Append([&, i]() {
-      SleepFor(1e-3);
-      // As NGROUPS > NTASKS / FAIL_EVERY, some subgroups are successful
-      if (i % FAIL_EVERY == 0) {
-        return Status::Invalid("some message");
-      } else {
-        return Status::OK();
-      }
-    });
-  }
-
-  // Finish all subgroups first, then main group
-  int nsuccessful = 0;
-  for (int i = NGROUPS - 1; i > 0; --i) {
-    Status st = groups[i]->Finish();
-    if (st.ok()) {
-      ++nsuccessful;
-    } else {
-      ASSERT_RAISES(Invalid, st);
-    }
-  }
-  ASSERT_RAISES(Invalid, task_group->Finish());
-  ASSERT_FALSE(task_group->ok());
-  // Finish() is idempotent
-  ASSERT_RAISES(Invalid, task_group->Finish());
-}
+ private:
+  uint8_t counter;
+  std::shared_ptr<uint8_t> target;
+};
 
 // Check TaskGroup behaviour with tasks spawning other tasks
 void TestTasksSpawnTasks(std::shared_ptr<TaskGroup> task_group) {
@@ -276,19 +236,21 @@ void StressFailingTaskGroupLifetime(std::function<std::shared_ptr<TaskGroup>()> 
   }
 }
 
+void TestNoCopyTask(std::shared_ptr<TaskGroup> task_group) {
+  auto counter = std::make_shared<uint8_t>(0);
+  CopyCountingTask task(counter);
+  task_group->Append(std::move(task));
+  ASSERT_OK(task_group->Finish());
+  ASSERT_EQ(0, *counter);
+}
+
 TEST(SerialTaskGroup, Success) { TestTaskGroupSuccess(TaskGroup::MakeSerial()); }
 
 TEST(SerialTaskGroup, Errors) { TestTaskGroupErrors(TaskGroup::MakeSerial()); }
 
 TEST(SerialTaskGroup, TasksSpawnTasks) { TestTasksSpawnTasks(TaskGroup::MakeSerial()); }
 
-TEST(SerialTaskGroup, SubGroupsSuccess) {
-  TestTaskSubGroupsSuccess(TaskGroup::MakeSerial());
-}
-
-TEST(SerialTaskGroup, SubGroupsErrors) {
-  TestTaskSubGroupsErrors(TaskGroup::MakeSerial());
-}
+TEST(SerialTaskGroup, NoCopyTask) { TestNoCopyTask(TaskGroup::MakeSerial()); }
 
 TEST(ThreadedTaskGroup, Success) {
   auto task_group = TaskGroup::MakeThreaded(GetCpuThreadPool());
@@ -309,18 +271,10 @@ TEST(ThreadedTaskGroup, TasksSpawnTasks) {
   TestTasksSpawnTasks(task_group);
 }
 
-TEST(ThreadedTaskGroup, SubGroupsSuccess) {
+TEST(ThreadedTaskGroup, NoCopyTask) {
   std::shared_ptr<ThreadPool> thread_pool;
   ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(4));
-
-  TestTaskSubGroupsSuccess(TaskGroup::MakeThreaded(thread_pool.get()));
-}
-
-TEST(ThreadedTaskGroup, SubGroupsErrors) {
-  std::shared_ptr<ThreadPool> thread_pool;
-  ASSERT_OK_AND_ASSIGN(thread_pool, ThreadPool::Make(4));
-
-  TestTaskSubGroupsErrors(TaskGroup::MakeThreaded(thread_pool.get()));
+  TestNoCopyTask(TaskGroup::MakeThreaded(thread_pool.get()));
 }
 
 TEST(ThreadedTaskGroup, StressTaskGroupLifetime) {

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -32,10 +32,10 @@
 namespace arrow {
 namespace internal {
 
-Executor::~Executor() {}
+Executor::~Executor() = default;
 
 struct ThreadPool::State {
-  State() : desired_capacity_(0), please_shutdown_(false), quick_shutdown_(false) {}
+  State() = default;
 
   // NOTE: in case locking becomes too expensive, we can investigate lock-free FIFOs
   // such as https://github.com/cameron314/concurrentqueue
@@ -50,10 +50,10 @@ struct ThreadPool::State {
   std::deque<std::function<void()>> pending_tasks_;
 
   // Desired number of threads
-  int desired_capacity_;
+  int desired_capacity_ = 0;
   // Are we shutting down?
-  bool please_shutdown_;
-  bool quick_shutdown_;
+  bool please_shutdown_ = false;
+  bool quick_shutdown_ = false;
 };
 
 // The worker loop is an independent function so that it can keep running

--- a/cpp/src/arrow/util/type_fwd.h
+++ b/cpp/src/arrow/util/type_fwd.h
@@ -19,8 +19,15 @@
 
 namespace arrow {
 
-template <typename T>
+namespace detail {
+struct Empty;
+}  // namespace detail
+
+template <typename T = detail::Empty>
 class Future;
+template <typename T = detail::Empty>
+class WeakFuture;
+class FutureWaiter;
 
 class TimestampParser;
 


### PR DESCRIPTION
Adds `Future<T>::Then(OnSuccess, OnFailure)` which registers callbacks to be executed on completion of the future and yields a future which wraps the result of those callbacks; if a callback returns:

- `void`, Then() returns a `Future<>` which completes successully as soon as the callback runs.
- `Status`, Then() returns a `Future<>` which completes with the returned `Status` as soon as the callback runs.
- `V` or `Result<V>`, Then() returns a `Future<V>` which completes with whatever the callback returns.
- `Future<V>`, Then() returns a `Future<V>` which will be marked complete when the future returned by the callback completes (and will complete with the same result).