### PR TITLE
ARROW-10622: [R] Nameof should not use "void" as the crib

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -66,12 +66,9 @@ groups:
     - test*-r-*
     - homebrew-r-autobrew
     # r-conda tasks
-    - conda-linux-gcc-py36-cpu
-    - conda-linux-gcc-py37-cpu
-    - conda-osx-clang-py36
-    - conda-osx-clang-py37
-    - conda-win-vs2017-py36
-    - conda-win-vs2017-py37
+    - conda-linux-gcc-py*-cpu-r*
+    - conda-osx-clang-py*-r*
+    - conda-win-vs2017-py*-r*
 
   ruby:
     - test-*ruby*
@@ -152,7 +149,7 @@ tasks:
   #   generated and to be synced regularly from the feedstock. We have no way
   #   yet to generate them inside the arrow repository automatically.
 
-  conda-linux-gcc-py36-cpu:
+  conda-linux-gcc-py36-cpu-r36:
     ci: azure
     template: conda-recipes/azure.linux.yml
     params:
@@ -162,7 +159,7 @@ tasks:
       - arrow-cpp-{no_rc_version}-py36(h[a-z0-9]+)_0_cpu.tar.bz2
       - pyarrow-{no_rc_version}-py36(h[a-z0-9]+)_0_cpu.tar.bz2
 
-  conda-linux-gcc-py37-cpu:
+  conda-linux-gcc-py37-cpu-r40:
     ci: azure
     template: conda-recipes/azure.linux.yml
     params:
@@ -237,7 +234,7 @@ tasks:
 
   ############################## Conda OSX ####################################
 
-  conda-osx-clang-py36:
+  conda-osx-clang-py36-r36:
     ci: azure
     template: conda-recipes/azure.osx.yml
     params:
@@ -247,7 +244,7 @@ tasks:
       - arrow-cpp-{no_rc_version}-py36(h[a-z0-9]+)_0_cpu.tar.bz2
       - pyarrow-{no_rc_version}-py36(h[a-z0-9]+)_0_cpu.tar.bz2
 
-  conda-osx-clang-py37:
+  conda-osx-clang-py37-r40:
     ci: azure
     template: conda-recipes/azure.osx.yml
     params:
@@ -268,7 +265,7 @@ tasks:
 
   ############################## Conda Windows ################################
 
-  conda-win-vs2017-py36:
+  conda-win-vs2017-py36-r36:
     ci: azure
     template: conda-recipes/azure.win.yml
     params:
@@ -278,7 +275,7 @@ tasks:
       - arrow-cpp-{no_rc_version}-py36(h[a-z0-9]+)_0_cpu.tar.bz2
       - pyarrow-{no_rc_version}-py36(h[a-z0-9]+)_0_cpu.tar.bz2
 
-  conda-win-vs2017-py37:
+  conda-win-vs2017-py37-r40:
     ci: azure
     template: conda-recipes/azure.win.yml
     params:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -65,6 +65,13 @@ groups:
   r:
     - test*-r-*
     - homebrew-r-autobrew
+    # r-conda tasks
+    - conda-linux-gcc-py36-cpu
+    - conda-linux-gcc-py37-cpu
+    - conda-osx-clang-py36
+    - conda-osx-clang-py37
+    - conda-win-vs2017-py36
+    - conda-win-vs2017-py37
 
   ruby:
     - test-*ruby*

--- a/docs/source/developers/crossbow.rst
+++ b/docs/source/developers/crossbow.rst
@@ -220,13 +220,13 @@ Run multiple builds:
 
 .. code:: bash
 
-   $ python crossbow.py submit debian-stretch conda-linux-gcc-py37
+   $ python crossbow.py submit debian-stretch conda-linux-gcc-py37-r40
    Repository: https://github.com/kszucs/arrow@tasks
    Commit SHA: 810a718836bb3a8cefc053055600bdcc440e6702
    Version: 0.9.1.dev48+g810a7188.d20180414
    Pushed branches:
     - debian-stretch
-    - conda-linux-gcc-py37
+    - conda-linux-gcc-py37-r40
 
 Just render without applying or committing the changes:
 

--- a/r/src/nameof.h
+++ b/r/src/nameof.h
@@ -50,7 +50,7 @@ constexpr size_t search(char const* haystack, char const* needle) {
              : search(haystack + 1, needle) + 1;
 }
 
-const size_t typename_prefix = search(raw<void>(), "void");
+const size_t typename_prefix = search(raw<double>(), "double");
 
 template <typename T>
 size_t struct_class_prefix() {
@@ -65,9 +65,9 @@ size_t struct_class_prefix() {
 
 template <typename T>
 size_t typename_length() {
-  // raw_sizeof<T>() - raw_sizeof<void>() == (length of T's name) - strlen("void")
-  // (length of T's name) == raw_sizeof<T>() - raw_sizeof<void>() + strlen("void")
-  return raw_sizeof<T>() - raw_sizeof<void>() + 4;
+  // raw_sizeof<T>() - raw_sizeof<double>() == (length of T's name) - strlen("double")
+  // (length of T's name) == raw_sizeof<T>() - raw_sizeof<double>() + strlen("double")
+  return raw_sizeof<T>() - struct_class_prefix<T>() - raw_sizeof<double>() + 6;
 }
 
 template <typename T>


### PR DESCRIPTION
On `r-arrow` (which uses the `clang` compiler's msvc compatibility mode), `arrow::util::detail::raw<T>()` is stringified as `arrow::util::detail::raw<T>(void)` which breaks the assumption that "void" can be searched for to find the offset of the typename. "double" is safer