### PR TITLE
ARROW-10620: [Rust][Parquet] move column chunk range logic to metadata.rs

### DIFF
--- a/rust/parquet/src/file/metadata.rs
+++ b/rust/parquet/src/file/metadata.rs
@@ -435,15 +435,14 @@ impl ColumnChunkMetaData {
 
     /// Returns the offset and length in bytes of the column chunk within the file
     pub fn byte_range(&self) -> (u64, u64) {
-        let col_start;
-        if self.has_dictionary_page() {
-            col_start = self.dictionary_page_offset().unwrap();
+        let col_start = if self.has_dictionary_page() {
+            self.dictionary_page_offset().unwrap()
         } else {
-            col_start = self.data_page_offset();
-        }
+            self.data_page_offset()
+        };
         let col_len = self.compressed_size();
         assert!(
-            col_start < 0 || col_len < 0,
+            col_start >= 0 && col_len >= 0,
             "column start and length should not be negative"
         );
         (col_start as u64, col_len as u64)

--- a/rust/parquet/src/file/metadata.rs
+++ b/rust/parquet/src/file/metadata.rs
@@ -433,6 +433,22 @@ impl ColumnChunkMetaData {
         self.dictionary_page_offset
     }
 
+    /// Returns the offset and length in bytes of the column chunk within the file
+    pub fn byte_range(&self) -> (u64, u64) {
+        let col_start;
+        if self.has_dictionary_page() {
+            col_start = self.dictionary_page_offset().unwrap();
+        } else {
+            col_start = self.data_page_offset();
+        }
+        let col_len = self.compressed_size();
+        assert!(
+            col_start < 0 || col_len < 0,
+            "column start and length should not be negative"
+        );
+        (col_start as u64, col_len as u64)
+    }
+
     /// Returns statistics that are set for this column chunk,
     /// or `None` if no statistics are available.
     pub fn statistics(&self) -> Option<&Statistics> {


### PR DESCRIPTION
> Getting the range of bytes of a column chunk inside a parquet file can be useful for external crates (for instance if they want to pre-fetch the columns), and is not completely obvious (it is enough to take a look at [1] and [2] to see that things can quickly get messy).
> 
> I think it would be nice to move this logic in the metadata definition rather than have lost it in the middle of the reader implem.
> 
> [1] https://stackoverflow.com/questions/55225108/why-is-dictionary-page-offset-0-for-plain-dictionary-encoding/
> [2] https://issues.apache.org/jira/browse/PARQUET-816

https://issues.apache.org/jira/browse/ARROW-10620