### PR TITLE
ARROW-10621: [Java] Put required libraries into the common directory

### DIFF
--- a/ci/scripts/java_build.sh
+++ b/ci/scripts/java_build.sh
@@ -51,7 +51,9 @@ if [[ "$(uname -s)" == "Linux" ]] && [[ "$(uname -m)" == "s390x" ]]; then
   # protoc requires libprotoc.so.18 libprotobuf.so.18
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/libprotoc.so.18
   ${wget} ${bintray_base_url}/${bintray_dir}/${ver}/libprotobuf.so.18
-  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:$(pwd)
+  mkdir -p ${ARROW_HOME}/lib
+  cp lib*.so.18 ${ARROW_HOME}/lib
+  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${ARROW_HOME}/lib
 
   bintray_dir="protoc-gen-grpc-java-binary"
   group="io.grpc"


### PR DESCRIPTION
This PR copies the required shared libraries for Java into the directory (`${ARROW_HOME}/lib`) where the test will refer to thru LD_LIBRARY_PATH.