### PR TITLE
ARROW-10297: [Rust] Optional json output in parquet-read binary

### DIFF
--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -41,6 +41,7 @@ chrono = "0.4"
 num-bigint = "0.3"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT", optional = true }
 base64 = { version = "*", optional = true }
+serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [dev-dependencies]
 rand = "0.7"
@@ -50,7 +51,6 @@ flate2 = "1.0"
 lz4 = "1.23"
 zstd = "0.5"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT" }
-serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [features]
 default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]

--- a/rust/parquet/Cargo.toml
+++ b/rust/parquet/Cargo.toml
@@ -41,7 +41,7 @@ chrono = "0.4"
 num-bigint = "0.3"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT", optional = true }
 base64 = { version = "*", optional = true }
-serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_json = { version = "1.0", features = ["preserve_order"], optional = true }
 
 [dev-dependencies]
 rand = "0.7"
@@ -51,6 +51,8 @@ flate2 = "1.0"
 lz4 = "1.23"
 zstd = "0.5"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT" }
+serde_json = { version = "1.0", features = ["preserve_order"] }
 
 [features]
+json_output = ["serde_json", "base64"]
 default = ["arrow", "snap", "brotli", "flate2", "lz4", "zstd", "base64"]

--- a/rust/parquet/src/bin/parquet-read.rs
+++ b/rust/parquet/src/bin/parquet-read.rs
@@ -50,6 +50,17 @@ extern crate parquet;
 use std::{env, fs::File, path::Path, process};
 
 use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::record::Row;
+
+#[cfg(feature = "json_output")]
+fn print_row(row: &Row) {
+    println!("{}", row.to_json_value())
+}
+
+#[cfg(not(feature = "json_output"))]
+fn print_row(row: &Row) {
+    println!("{}", row.to_string())
+}
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -79,7 +90,7 @@ fn main() {
 
     while all_records || start < end {
         match iter.next() {
-            Some(row) => println!("{}", row.to_json_value()),
+            Some(row) => print_row(&row),
             None => break,
         }
         start += 1;

--- a/rust/parquet/src/bin/parquet-read.rs
+++ b/rust/parquet/src/bin/parquet-read.rs
@@ -79,7 +79,7 @@ fn main() {
 
     while all_records || start < end {
         match iter.next() {
-            Some(row) => println!("{}", row),
+            Some(row) => println!("{}", row.to_json_value()),
             None => break,
         }
         start += 1;

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -651,10 +651,10 @@ impl Field {
             Field::UInt(n) => Value::Number(serde_json::Number::from(*n)),
             Field::ULong(n) => Value::Number(serde_json::Number::from(*n)),
             Field::Float(n) => serde_json::Number::from_f64(*n as f64)
-                .map(|n| Value::Number(n))
+                .map(Value::Number)
                 .unwrap_or(Value::Null),
             Field::Double(n) => serde_json::Number::from_f64(*n)
-                .map(|n| Value::Number(n))
+                .map(Value::Number)
                 .unwrap_or(Value::Null),
             Field::Decimal(n) => Value::String(convert_decimal_to_string(&n)),
             Field::Str(s) => Value::String(s.to_owned()),

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -670,8 +670,13 @@ impl Field {
             Field::MapInternal(map) => Value::Object(
                 map.entries
                     .iter()
-                    .map(|(key, value)| {
-                        (key.to_json_value().to_string(), value.to_json_value())
+                    .map(|(key_field, value_field)| {
+                        let key_val = key_field.to_json_value();
+                        let key_str = key_val
+                            .as_str()
+                            .map(|s| s.to_owned())
+                            .unwrap_or_else(|| key_val.to_string());
+                        (key_str, value_field.to_json_value())
                     })
                     .collect(),
             ),

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -655,7 +655,7 @@ impl Field {
                 .unwrap_or(Value::Null),
             Field::Decimal(n) => Value::String(convert_decimal_to_string(&n)),
             Field::Str(s) => Value::String(s.to_owned()),
-            Field::Bytes(b) => Value::String(String::from_utf8_lossy(b.data()).into()),
+            Field::Bytes(b) => Value::String(base64::encode(b.data())),
             Field::Date(d) => Value::String(convert_date_to_string(*d)),
             Field::TimestampMillis(ts) => {
                 Value::String(convert_timestamp_millis_to_string(*ts))

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -26,6 +26,7 @@ use crate::basic::{LogicalType, Type as PhysicalType};
 use crate::data_type::{ByteArray, Decimal, Int96};
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
+#[cfg(feature = "json_output")]
 use serde_json::Value;
 
 /// Macro as a shortcut to generate 'not yet implemented' panic error.
@@ -77,6 +78,7 @@ impl Row {
         }
     }
 
+    #[cfg(feature = "json_output")]
     pub fn to_json_value(&self) -> Value {
         Value::Object(
             self.fields
@@ -635,6 +637,7 @@ impl Field {
         }
     }
 
+    #[cfg(feature = "json_output")]
     pub fn to_json_value(&self) -> Value {
         match &self {
             Field::Null => Value::Null,

--- a/rust/parquet/src/record/api.rs
+++ b/rust/parquet/src/record/api.rs
@@ -26,6 +26,7 @@ use crate::basic::{LogicalType, Type as PhysicalType};
 use crate::data_type::{ByteArray, Decimal, Int96};
 use crate::errors::{ParquetError, Result};
 use crate::schema::types::ColumnDescPtr;
+use serde_json::Value;
 
 /// Macro as a shortcut to generate 'not yet implemented' panic error.
 macro_rules! nyi {
@@ -74,6 +75,15 @@ impl Row {
             curr: 0,
             count: self.fields.len(),
         }
+    }
+
+    pub fn to_json_value(&self) -> Value {
+        Value::Object(
+            self.fields
+                .iter()
+                .map(|(key, field)| (key.to_owned(), field.to_json_value()))
+                .collect(),
+        )
     }
 }
 
@@ -622,6 +632,49 @@ impl Field {
                 _ => nyi!(descr, value),
             },
             _ => nyi!(descr, value),
+        }
+    }
+
+    pub fn to_json_value(&self) -> Value {
+        match &self {
+            Field::Null => Value::Null,
+            Field::Bool(b) => Value::Bool(*b),
+            Field::Byte(n) => Value::Number(serde_json::Number::from(*n)),
+            Field::Short(n) => Value::Number(serde_json::Number::from(*n)),
+            Field::Int(n) => Value::Number(serde_json::Number::from(*n)),
+            Field::Long(n) => Value::Number(serde_json::Number::from(*n)),
+            Field::UByte(n) => Value::Number(serde_json::Number::from(*n)),
+            Field::UShort(n) => Value::Number(serde_json::Number::from(*n)),
+            Field::UInt(n) => Value::Number(serde_json::Number::from(*n)),
+            Field::ULong(n) => Value::Number(serde_json::Number::from(*n)),
+            Field::Float(n) => serde_json::Number::from_f64(*n as f64)
+                .map(|n| Value::Number(n))
+                .unwrap_or(Value::Null),
+            Field::Double(n) => serde_json::Number::from_f64(*n)
+                .map(|n| Value::Number(n))
+                .unwrap_or(Value::Null),
+            Field::Decimal(n) => Value::String(convert_decimal_to_string(&n)),
+            Field::Str(s) => Value::String(s.to_owned()),
+            Field::Bytes(b) => Value::String(String::from_utf8_lossy(b.data()).into()),
+            Field::Date(d) => Value::String(convert_date_to_string(*d)),
+            Field::TimestampMillis(ts) => {
+                Value::String(convert_timestamp_millis_to_string(*ts))
+            }
+            Field::TimestampMicros(ts) => {
+                Value::String(convert_timestamp_micros_to_string(*ts))
+            }
+            Field::Group(row) => row.to_json_value(),
+            Field::ListInternal(fields) => {
+                Value::Array(fields.elements.iter().map(|f| f.to_json_value()).collect())
+            }
+            Field::MapInternal(map) => Value::Object(
+                map.entries
+                    .iter()
+                    .map(|(key, value)| {
+                        (key.to_json_value().to_string(), value.to_json_value())
+                    })
+                    .collect(),
+            ),
         }
     }
 }


### PR DESCRIPTION
This makes it much easier to analyze parquet files, for example by processing the output with other command line tools like `jq`.

I'm opening this as a draft for now since I'd like some feedback on whether this should be the default or whether the dependency on `serde_json` should be optional.

Example output:

```
$ parquet-read parquet-testing/data/alltypes_plain.parquet 2 | jq .
{
  "id": 4,
  "bool_col": true,
  "tinyint_col": 0,
  "smallint_col": 0,
  "int_col": 0,
  "bigint_col": 0,
  "float_col": 0,
  "double_col": 0,
  "date_string_col": "MDMvMDEvMDk=",
  "string_col": "MA==",
  "timestamp_col": "2009-03-01 01:00:00 +01:00"
}
{
  "id": 5,
  "bool_col": false,
  "tinyint_col": 1,
  "smallint_col": 1,
  "int_col": 1,
  "bigint_col": 10,
  "float_col": 1.100000023841858,
  "double_col": 10.1,
  "date_string_col": "MDMvMDEvMDk=",
  "string_col": "MQ==",
  "timestamp_col": "2009-03-01 01:01:00 +01:00"
}
```

Note that in this file `string_col` and `date_string_col` are binary and so get printed using base64 encoding. If the column has the Utf8 logical type it will get printed as a normal string.