### PR TITLE
ARROW-10337: [C++] More liberal parsing of ISO8601 timestamps with fractional seconds

### DIFF
--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -486,25 +486,55 @@ static inline bool ParseHH_MM_SS(const char* s, Duration* out) {
 
 static inline bool ParseSubSeconds(const char* s, size_t length, TimeUnit::type unit,
                                    uint32_t* out) {
-  switch (length) {
-    case 4:  // .mmm
-      if (ARROW_PREDICT_FALSE(unit != TimeUnit::MILLI)) return false;
+
+  // The decimal point has been peeled off at this point
+
+  // Fail if number of decimal places provided exceeds what the unit can hold.
+  // Calculate how many trailing decimal places are omitted for the unit
+  // e.g. if 4 decimal places are provided and unit is MICRO, 2 are missing
+  uint8_t omitted = 0;
+  switch (unit)
+  {
+    case TimeUnit::MILLI:
+      if (ARROW_PREDICT_FALSE(length > 3)) return false;
+      if (ARROW_PREDICT_FALSE(length < 3)) omitted = 3 - length;
       break;
-    case 7:  // .uuuuuu
-      if (ARROW_PREDICT_FALSE(unit != TimeUnit::MICRO)) return false;
+    case TimeUnit::MICRO:
+      if (ARROW_PREDICT_FALSE(length > 6)) return false;
+      if (ARROW_PREDICT_FALSE(length < 6)) omitted = 6 - length;
       break;
-    case 10:  // .nnnnnnnnn
-      if (ARROW_PREDICT_FALSE(unit != TimeUnit::NANO)) return false;
+    case TimeUnit::NANO:
+      if (ARROW_PREDICT_FALSE(length > 9)) return false;
+      if (ARROW_PREDICT_FALSE(length < 9)) omitted = 9 - length;
       break;
     default:
       return false;
   }
 
-  if (ARROW_PREDICT_FALSE(s[0] != '.')) {
-    return false;
+  if (ARROW_PREDICT_TRUE(omitted == 0)) {
+    return ParseUnsigned(s, length, out);
+  } else {
+    uint32_t subseconds;
+    bool success = ParseUnsigned(s, length, &subseconds);
+    if (ARROW_PREDICT_TRUE(success)) {
+      switch (omitted)
+      {
+        case 1: *out = subseconds * 10; break;
+        case 2: *out = subseconds * 100; break;
+        case 3: *out = subseconds * 1000; break;
+        case 4: *out = subseconds * 10000; break;
+        case 5: *out = subseconds * 100000; break;
+        case 6: *out = subseconds * 1000000; break;
+        case 7: *out = subseconds * 10000000; break;
+        case 8: *out = subseconds * 100000000; break;
+        default: return false;
+      }
+      return true;
+    } else {
+      return false;
+    }
   }
 
-  return ParseUnsigned(s + 1, length - 1, out);
 }
 
 }  // namespace detail
@@ -516,26 +546,21 @@ static inline bool ParseTimestampISO8601(const char* s, size_t length,
 
   // We allow the following formats for all units:
   // - "YYYY-MM-DD"
-  // - "YYYY-MM-DD[ T]hh"
-  // - "YYYY-MM-DD[ T]hhZ"
-  // - "YYYY-MM-DD[ T]hh:mm"
-  // - "YYYY-MM-DD[ T]hh:mmZ"
-  // - "YYYY-MM-DD[ T]hh:mm:ss"
-  // - "YYYY-MM-DD[ T]hh:mm:ssZ"
+  // - "YYYY-MM-DD[ T]hhZ?"
+  // - "YYYY-MM-DD[ T]hh:mmZ?"
+  // - "YYYY-MM-DD[ T]hh:mm:ssZ?"
   //
-  // We allow the following formats for unit==MILLI:
-  // - "YYYY-MM-DD[ T]hh:mm:ss.mmm"
-  // - "YYYY-MM-DD[ T]hh:mm:ss.mmmZ"
+  // We allow the following formats for unit == MILLI, MICRO, or NANO:
+  // - "YYYY-MM-DD[ T]hh:mm:ss.s{1,3}Z?"
   //
-  // We allow the following formats for unit==MICRO:
-  // - "YYYY-MM-DD[ T]hh:mm:ss.uuuuuu"
-  // - "YYYY-MM-DD[ T]hh:mm:ss.uuuuuuZ"
+  // We allow the following formats for unit == MICRO, or NANO:
+  // - "YYYY-MM-DD[ T]hh:mm:ss.s{4,6}Z?"
   //
-  // We allow the following formats for unit==NANO:
-  // - "YYYY-MM-DD[ T]hh:mm:ss.nnnnnnnnn"
-  // - "YYYY-MM-DD[ T]hh:mm:ss.nnnnnnnnnZ"
+  // We allow the following formats for unit == NANO:
+  // - "YYYY-MM-DD[ T]hh:mm:ss.s{7,9}Z?"
   //
   // UTC is always assumed, and the DataType's timezone is ignored.
+  //
 
   if (ARROW_PREDICT_FALSE(length < 10)) return false;
 
@@ -570,9 +595,15 @@ static inline bool ParseTimestampISO8601(const char* s, size_t length,
       }
       break;
     case 19:  // YYYY-MM-DD[ T]hh:mm:ss
-    case 23:  // YYYY-MM-DD[ T]hh:mm:ss.mmm
-    case 26:  // YYYY-MM-DD[ T]hh:mm:ss.uuuuuu
-    case 29:  // YYYY-MM-DD[ T]hh:mm:ss.nnnnnnnnn
+    case 21:  // YYYY-MM-DD[ T]hh:mm:ss.s
+    case 22:  // YYYY-MM-DD[ T]hh:mm:ss.ss
+    case 23:  // YYYY-MM-DD[ T]hh:mm:ss.sss
+    case 24:  // YYYY-MM-DD[ T]hh:mm:ss.ssss
+    case 25:  // YYYY-MM-DD[ T]hh:mm:ss.sssss
+    case 26:  // YYYY-MM-DD[ T]hh:mm:ss.ssssss
+    case 27:  // YYYY-MM-DD[ T]hh:mm:ss.sssssss
+    case 28:  // YYYY-MM-DD[ T]hh:mm:ss.ssssssss
+    case 29:  // YYYY-MM-DD[ T]hh:mm:ss.sssssssss
       if (ARROW_PREDICT_FALSE(!detail::ParseHH_MM_SS(s + 11, &seconds_since_midnight))) {
         return false;
       }
@@ -588,9 +619,13 @@ static inline bool ParseTimestampISO8601(const char* s, size_t length,
     return true;
   }
 
+  if (ARROW_PREDICT_FALSE(s[19] != '.')) {
+    return false;
+  }
+
   uint32_t subseconds = 0;
   if (ARROW_PREDICT_FALSE(
-          !detail::ParseSubSeconds(s + 19, length - 19, unit, &subseconds))) {
+          !detail::ParseSubSeconds(s + 20, length - 20, unit, &subseconds))) {
     return false;
   }
 

--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -727,7 +727,7 @@ struct StringConverter<TIME_TYPE, enable_if_time<TIME_TYPE>> {
 
     uint32_t subseconds_count = 0;
     if (ARROW_PREDICT_FALSE(
-            !detail::ParseSubSeconds(s + 8, length - 8, unit, &subseconds_count))) {
+            !detail::ParseSubSeconds(s + 9, length - 9, unit, &subseconds_count))) {
       return false;
     }
 

--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -486,26 +486,36 @@ static inline bool ParseHH_MM_SS(const char* s, Duration* out) {
 
 static inline bool ParseSubSeconds(const char* s, size_t length, TimeUnit::type unit,
                                    uint32_t* out) {
-
   // The decimal point has been peeled off at this point
 
   // Fail if number of decimal places provided exceeds what the unit can hold.
   // Calculate how many trailing decimal places are omitted for the unit
   // e.g. if 4 decimal places are provided and unit is MICRO, 2 are missing
-  uint8_t omitted = 0;
-  switch (unit)
-  {
+  size_t omitted = 0;
+  switch (unit) {
     case TimeUnit::MILLI:
-      if (ARROW_PREDICT_FALSE(length > 3)) return false;
-      if (ARROW_PREDICT_FALSE(length < 3)) omitted = 3 - length;
+      if (ARROW_PREDICT_FALSE(length > 3)) {
+        return false;
+      }
+      if (length < 3) {
+        omitted = 3 - length;
+      }
       break;
     case TimeUnit::MICRO:
-      if (ARROW_PREDICT_FALSE(length > 6)) return false;
-      if (ARROW_PREDICT_FALSE(length < 6)) omitted = 6 - length;
+      if (ARROW_PREDICT_FALSE(length > 6)) {
+        return false;
+      }
+      if (length < 6) {
+        omitted = 6 - length;
+      }
       break;
     case TimeUnit::NANO:
-      if (ARROW_PREDICT_FALSE(length > 9)) return false;
-      if (ARROW_PREDICT_FALSE(length < 9)) omitted = 9 - length;
+      if (ARROW_PREDICT_FALSE(length > 9)) {
+        return false;
+      }
+      if (length < 9) {
+        omitted = 9 - length;
+      }
       break;
     default:
       return false;
@@ -517,24 +527,40 @@ static inline bool ParseSubSeconds(const char* s, size_t length, TimeUnit::type 
     uint32_t subseconds;
     bool success = ParseUnsigned(s, length, &subseconds);
     if (ARROW_PREDICT_TRUE(success)) {
-      switch (omitted)
-      {
-        case 1: *out = subseconds * 10; break;
-        case 2: *out = subseconds * 100; break;
-        case 3: *out = subseconds * 1000; break;
-        case 4: *out = subseconds * 10000; break;
-        case 5: *out = subseconds * 100000; break;
-        case 6: *out = subseconds * 1000000; break;
-        case 7: *out = subseconds * 10000000; break;
-        case 8: *out = subseconds * 100000000; break;
-        default: return false;
+      switch (omitted) {
+        case 1:
+          *out = subseconds * 10;
+          break;
+        case 2:
+          *out = subseconds * 100;
+          break;
+        case 3:
+          *out = subseconds * 1000;
+          break;
+        case 4:
+          *out = subseconds * 10000;
+          break;
+        case 5:
+          *out = subseconds * 100000;
+          break;
+        case 6:
+          *out = subseconds * 1000000;
+          break;
+        case 7:
+          *out = subseconds * 10000000;
+          break;
+        case 8:
+          *out = subseconds * 100000000;
+          break;
+        default:
+          // Impossible case
+          break;
       }
       return true;
     } else {
       return false;
     }
   }
-
 }
 
 }  // namespace detail

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -357,9 +357,17 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "1900-02-28 12:34:56", -2203932304000LL);
     AssertConversion(type, "2018-11-13T17:11:10.777Z", 1542129070777LL);
 
+    AssertConversion(type, "1900-02-28 12:34:56.1",   -2203932304000LL + 100LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12",  -2203932304000LL + 120LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123", -2203932304000LL + 123LL);
+
     // Invalid subseconds
-    AssertConversionFails(type, "1900-02-28 12:34:56.1");
+    AssertConversionFails(type, "1900-02-28 12:34:56.1234");
+    AssertConversionFails(type, "1900-02-28 12:34:56.12345");
     AssertConversionFails(type, "1900-02-28 12:34:56.123456");
+    AssertConversionFails(type, "1900-02-28 12:34:56.1234567");
+    AssertConversionFails(type, "1900-02-28 12:34:56.12345678");
+    AssertConversionFails(type, "1900-02-28 12:34:56.123456789");
   }
   {
     TimestampType type{TimeUnit::MICRO};
@@ -371,9 +379,16 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "2018-11-13T17:11:10.777000", 1542129070777000LL);
     AssertConversion(type, "3989-07-14T11:22:33.000777Z", 63730322553000777LL);
 
+    AssertConversion(type, "1900-02-28 12:34:56.1",      -2203932304000000LL + 100000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12",     -2203932304000000LL + 120000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123",    -2203932304000000LL + 123000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.1234",   -2203932304000000LL + 123400LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12345",  -2203932304000000LL + 123450LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456", -2203932304000000LL + 123456LL);
+
     // Invalid subseconds
-    AssertConversionFails(type, "1900-02-28 12:34:56.1");
-    AssertConversionFails(type, "2018-11-13T17:11:10.777");
+    AssertConversionFails(type, "1900-02-28 12:34:56.1234567");
+    AssertConversionFails(type, "1900-02-28 12:34:56.12345678");
     AssertConversionFails(type, "1900-02-28 12:34:56.123456789");
   }
   {
@@ -386,10 +401,17 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "2018-11-13T17:11:10.000777000Z", 1542129070000777000LL);
     AssertConversion(type, "1969-12-31 23:59:59.999999999", -1);
 
+    AssertConversion(type, "1900-02-28 12:34:56.1",         -2203932304000000000LL + 100000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12",        -2203932304000000000LL + 120000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123",       -2203932304000000000LL + 123000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.1234",      -2203932304000000000LL + 123400000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12345",     -2203932304000000000LL + 123450000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456",    -2203932304000000000LL + 123456000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.1234567",   -2203932304000000000LL + 123456700LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12345678",  -2203932304000000000LL + 123456780LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456789", -2203932304000000000LL + 123456789LL);
+
     // Invalid subseconds
-    AssertConversionFails(type, "1900-02-28 12:34:56.1");
-    AssertConversionFails(type, "1900-02-28 12:34:56.123");
-    AssertConversionFails(type, "1900-02-28 12:34:56.123456");
   }
 }
 

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -357,8 +357,8 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "1900-02-28 12:34:56", -2203932304000LL);
     AssertConversion(type, "2018-11-13T17:11:10.777Z", 1542129070777LL);
 
-    AssertConversion(type, "1900-02-28 12:34:56.1",   -2203932304000LL + 100LL);
-    AssertConversion(type, "1900-02-28 12:34:56.12",  -2203932304000LL + 120LL);
+    AssertConversion(type, "1900-02-28 12:34:56.1", -2203932304000LL + 100LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12", -2203932304000LL + 120LL);
     AssertConversion(type, "1900-02-28 12:34:56.123", -2203932304000LL + 123LL);
 
     // Invalid subseconds
@@ -379,11 +379,11 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "2018-11-13T17:11:10.777000", 1542129070777000LL);
     AssertConversion(type, "3989-07-14T11:22:33.000777Z", 63730322553000777LL);
 
-    AssertConversion(type, "1900-02-28 12:34:56.1",      -2203932304000000LL + 100000LL);
-    AssertConversion(type, "1900-02-28 12:34:56.12",     -2203932304000000LL + 120000LL);
-    AssertConversion(type, "1900-02-28 12:34:56.123",    -2203932304000000LL + 123000LL);
-    AssertConversion(type, "1900-02-28 12:34:56.1234",   -2203932304000000LL + 123400LL);
-    AssertConversion(type, "1900-02-28 12:34:56.12345",  -2203932304000000LL + 123450LL);
+    AssertConversion(type, "1900-02-28 12:34:56.1", -2203932304000000LL + 100000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12", -2203932304000000LL + 120000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123", -2203932304000000LL + 123000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.1234", -2203932304000000LL + 123400LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12345", -2203932304000000LL + 123450LL);
     AssertConversion(type, "1900-02-28 12:34:56.123456", -2203932304000000LL + 123456LL);
 
     // Invalid subseconds
@@ -401,15 +401,23 @@ TEST(StringConversion, ToTimestampDateTime_ISO8601) {
     AssertConversion(type, "2018-11-13T17:11:10.000777000Z", 1542129070000777000LL);
     AssertConversion(type, "1969-12-31 23:59:59.999999999", -1);
 
-    AssertConversion(type, "1900-02-28 12:34:56.1",         -2203932304000000000LL + 100000000LL);
-    AssertConversion(type, "1900-02-28 12:34:56.12",        -2203932304000000000LL + 120000000LL);
-    AssertConversion(type, "1900-02-28 12:34:56.123",       -2203932304000000000LL + 123000000LL);
-    AssertConversion(type, "1900-02-28 12:34:56.1234",      -2203932304000000000LL + 123400000LL);
-    AssertConversion(type, "1900-02-28 12:34:56.12345",     -2203932304000000000LL + 123450000LL);
-    AssertConversion(type, "1900-02-28 12:34:56.123456",    -2203932304000000000LL + 123456000LL);
-    AssertConversion(type, "1900-02-28 12:34:56.1234567",   -2203932304000000000LL + 123456700LL);
-    AssertConversion(type, "1900-02-28 12:34:56.12345678",  -2203932304000000000LL + 123456780LL);
-    AssertConversion(type, "1900-02-28 12:34:56.123456789", -2203932304000000000LL + 123456789LL);
+    AssertConversion(type, "1900-02-28 12:34:56.1", -2203932304000000000LL + 100000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12",
+                     -2203932304000000000LL + 120000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123",
+                     -2203932304000000000LL + 123000000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.1234",
+                     -2203932304000000000LL + 123400000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12345",
+                     -2203932304000000000LL + 123450000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456",
+                     -2203932304000000000LL + 123456000LL);
+    AssertConversion(type, "1900-02-28 12:34:56.1234567",
+                     -2203932304000000000LL + 123456700LL);
+    AssertConversion(type, "1900-02-28 12:34:56.12345678",
+                     -2203932304000000000LL + 123456780LL);
+    AssertConversion(type, "1900-02-28 12:34:56.123456789",
+                     -2203932304000000000LL + 123456789LL);
 
     // Invalid subseconds
   }


### PR DESCRIPTION
The current ISO8601 timestamp parser assumes MILLI timestamps have 3 decimal places, MICRO have 6 and NANO have 9. 

This patch change the parser to accept 1 to 3 digits for MILLI, 1 to 6 digits for MICRO, and 1 to 9 digits for NANO. This allows for parsing of timestamps when e.g. a CSV file does not write timestamps with trailing zeroes. See comments in ParseTimestampISO8601 for details of format.