### PR TITLE
ARROW-10631: [Rust] Fixed error in computing equality of fixed-sized binary.

### DIFF
--- a/rust/arrow/src/array/equal/fixed_binary.rs
+++ b/rust/arrow/src/array/equal/fixed_binary.rs
@@ -31,8 +31,8 @@ pub(super) fn fixed_binary_equal(
         _ => unreachable!(),
     };
 
-    let lhs_values = lhs.buffer::<u8>(0);
-    let rhs_values = rhs.buffer::<u8>(0);
+    let lhs_values = &lhs.buffers()[0].data()[lhs.offset() * size..];
+    let rhs_values = &rhs.buffers()[0].data()[rhs.offset() * size..];
 
     if lhs.null_count() == 0 && rhs.null_count() == 0 {
         equal_len(

--- a/rust/arrow/src/array/equal/mod.rs
+++ b/rust/arrow/src/array/equal/mod.rs
@@ -602,6 +602,10 @@ mod tests {
         let a_slice = a.slice(4, 1);
         let b_slice = b.slice(4, 1);
         test_equal(&a_slice, &b_slice, true);
+
+        let a_slice = a.slice(3, 1);
+        let b_slice = b.slice(3, 1);
+        test_equal(&a_slice, &b_slice, false);
     }
 
     /// Create a fixed size list of 2 value lengths


### PR DESCRIPTION
This fixes a bug on the equality for fixed-sized binary arrays. For these types, the number of bytes of a slot equals the specified size. However, we were not taking that into account when offsetting in number of slots in the comparison.