### PR TITLE
ARROW-10638: [Rust] Improved tests of boolean kernel.

### DIFF
--- a/rust/arrow/src/compute/kernels/boolean.rs
+++ b/rust/arrow/src/compute/kernels/boolean.rs
@@ -159,10 +159,10 @@ mod tests {
         let a = BooleanArray::from(vec![false, false, true, true]);
         let b = BooleanArray::from(vec![false, true, false, true]);
         let c = and(&a, &b).unwrap();
-        assert_eq!(false, c.value(0));
-        assert_eq!(false, c.value(1));
-        assert_eq!(false, c.value(2));
-        assert_eq!(true, c.value(3));
+
+        let expected = BooleanArray::from(vec![false, false, false, true]);
+
+        assert_eq!(c, expected);
     }
 
     #[test]
@@ -170,42 +170,102 @@ mod tests {
         let a = BooleanArray::from(vec![false, false, true, true]);
         let b = BooleanArray::from(vec![false, true, false, true]);
         let c = or(&a, &b).unwrap();
-        assert_eq!(false, c.value(0));
-        assert_eq!(true, c.value(1));
-        assert_eq!(true, c.value(2));
-        assert_eq!(true, c.value(3));
+
+        let expected = BooleanArray::from(vec![false, true, true, true]);
+
+        assert_eq!(c, expected);
     }
 
     #[test]
     fn test_bool_array_or_nulls() {
-        let a = BooleanArray::from(vec![None, Some(false), None, Some(false)]);
-        let b = BooleanArray::from(vec![None, None, Some(false), Some(false)]);
+        let a = BooleanArray::from(vec![
+            None,
+            None,
+            None,
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(true),
+        ]);
+        let b = BooleanArray::from(vec![
+            None,
+            Some(false),
+            Some(true),
+            None,
+            Some(false),
+            Some(true),
+            None,
+            Some(false),
+            Some(true),
+        ]);
         let c = or(&a, &b).unwrap();
-        assert_eq!(true, c.is_null(0));
-        assert_eq!(true, c.is_null(1));
-        assert_eq!(true, c.is_null(2));
-        assert_eq!(false, c.is_null(3));
+
+        let expected = BooleanArray::from(vec![
+            None,
+            None,
+            None,
+            None,
+            Some(false),
+            Some(true),
+            None,
+            Some(true),
+            Some(true),
+        ]);
+
+        assert_eq!(c, expected);
     }
 
     #[test]
     fn test_bool_array_not() {
-        let a = BooleanArray::from(vec![false, false, true, true]);
+        let a = BooleanArray::from(vec![false, true]);
         let c = not(&a).unwrap();
-        assert_eq!(true, c.value(0));
-        assert_eq!(true, c.value(1));
-        assert_eq!(false, c.value(2));
-        assert_eq!(false, c.value(3));
+
+        let expected = BooleanArray::from(vec![true, false]);
+
+        assert_eq!(c, expected);
     }
 
     #[test]
     fn test_bool_array_and_nulls() {
-        let a = BooleanArray::from(vec![None, Some(false), None, Some(false)]);
-        let b = BooleanArray::from(vec![None, None, Some(false), Some(false)]);
+        let a = BooleanArray::from(vec![
+            None,
+            None,
+            None,
+            Some(false),
+            Some(false),
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(true),
+        ]);
+        let b = BooleanArray::from(vec![
+            None,
+            Some(false),
+            Some(true),
+            None,
+            Some(false),
+            Some(true),
+            None,
+            Some(false),
+            Some(true),
+        ]);
         let c = and(&a, &b).unwrap();
-        assert_eq!(true, c.is_null(0));
-        assert_eq!(true, c.is_null(1));
-        assert_eq!(true, c.is_null(2));
-        assert_eq!(false, c.is_null(3));
+
+        let expected = BooleanArray::from(vec![
+            None,
+            None,
+            None,
+            None,
+            Some(false),
+            Some(false),
+            None,
+            Some(false),
+            Some(true),
+        ]);
+
+        assert_eq!(c, expected);
     }
 
     #[test]
@@ -225,11 +285,10 @@ mod tests {
         let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
 
         let c = and(&a, &b).unwrap();
-        assert_eq!(4, c.len());
-        assert_eq!(false, c.value(0));
-        assert_eq!(false, c.value(1));
-        assert_eq!(false, c.value(2));
-        assert_eq!(true, c.value(3));
+
+        let expected = BooleanArray::from(vec![false, false, false, true]);
+
+        assert_eq!(expected, c);
     }
 
     #[test]
@@ -249,11 +308,10 @@ mod tests {
         let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
 
         let c = and(&a, &b).unwrap();
-        assert_eq!(4, c.len());
-        assert_eq!(false, c.value(0));
-        assert_eq!(false, c.value(1));
-        assert_eq!(false, c.value(2));
-        assert_eq!(true, c.value(3));
+
+        let expected = BooleanArray::from(vec![false, false, false, true]);
+
+        assert_eq!(expected, c);
     }
 
     #[test]
@@ -268,11 +326,10 @@ mod tests {
         let a = a.as_any().downcast_ref::<BooleanArray>().unwrap();
 
         let c = and(&a, &b).unwrap();
-        assert_eq!(4, c.len());
-        assert_eq!(false, c.value(0));
-        assert_eq!(false, c.value(1));
-        assert_eq!(false, c.value(2));
-        assert_eq!(true, c.value(3));
+
+        let expected = BooleanArray::from(vec![false, false, false, true]);
+
+        assert_eq!(expected, c);
     }
 
     #[test]
@@ -287,11 +344,36 @@ mod tests {
         let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
 
         let c = and(&a, &b).unwrap();
-        assert_eq!(4, c.len());
-        assert_eq!(false, c.value(0));
-        assert_eq!(false, c.value(1));
-        assert_eq!(false, c.value(2));
-        assert_eq!(true, c.value(3));
+
+        let expected = BooleanArray::from(vec![false, false, false, true]);
+
+        assert_eq!(expected, c);
+    }
+
+    #[test]
+    fn test_bool_array_and_nulls_offset() {
+        let a = BooleanArray::from(vec![None, Some(false), Some(true), None, Some(true)]);
+        let a = a.slice(1, 4);
+        let a = a.as_any().downcast_ref::<BooleanArray>().unwrap();
+
+        let b = BooleanArray::from(vec![
+            None,
+            None,
+            Some(true),
+            Some(false),
+            Some(true),
+            Some(true),
+        ]);
+
+        let b = b.slice(2, 4);
+        let b = b.as_any().downcast_ref::<BooleanArray>().unwrap();
+
+        let c = and(&a, &b).unwrap();
+
+        let expected =
+            BooleanArray::from(vec![Some(false), Some(false), None, Some(true)]);
+
+        assert_eq!(expected, c);
     }
 
     #[test]
@@ -300,13 +382,10 @@ mod tests {
 
         let res = is_null(&a).unwrap();
 
-        assert_eq!(4, res.len());
-        assert_eq!(0, res.null_count());
+        let expected = BooleanArray::from(vec![false, false, false, false]);
+
+        assert_eq!(expected, res);
         assert_eq!(&None, res.data_ref().null_bitmap());
-        assert_eq!(false, res.value(0));
-        assert_eq!(false, res.value(1));
-        assert_eq!(false, res.value(2));
-        assert_eq!(false, res.value(3));
     }
 
     #[test]
@@ -318,13 +397,10 @@ mod tests {
 
         let res = is_null(&a).unwrap();
 
-        assert_eq!(4, res.len());
-        assert_eq!(0, res.null_count());
+        let expected = BooleanArray::from(vec![false, false, false, false]);
+
+        assert_eq!(expected, res);
         assert_eq!(&None, res.data_ref().null_bitmap());
-        assert_eq!(false, res.value(0));
-        assert_eq!(false, res.value(1));
-        assert_eq!(false, res.value(2));
-        assert_eq!(false, res.value(3));
     }
 
     #[test]
@@ -333,13 +409,10 @@ mod tests {
 
         let res = is_not_null(&a).unwrap();
 
-        assert_eq!(4, res.len());
-        assert_eq!(0, res.null_count());
+        let expected = BooleanArray::from(vec![true, true, true, true]);
+
+        assert_eq!(expected, res);
         assert_eq!(&None, res.data_ref().null_bitmap());
-        assert_eq!(true, res.value(0));
-        assert_eq!(true, res.value(1));
-        assert_eq!(true, res.value(2));
-        assert_eq!(true, res.value(3));
     }
 
     #[test]
@@ -351,13 +424,10 @@ mod tests {
 
         let res = is_not_null(&a).unwrap();
 
-        assert_eq!(4, res.len());
-        assert_eq!(0, res.null_count());
+        let expected = BooleanArray::from(vec![true, true, true, true]);
+
+        assert_eq!(expected, res);
         assert_eq!(&None, res.data_ref().null_bitmap());
-        assert_eq!(true, res.value(0));
-        assert_eq!(true, res.value(1));
-        assert_eq!(true, res.value(2));
-        assert_eq!(true, res.value(3));
     }
 
     #[test]
@@ -366,13 +436,10 @@ mod tests {
 
         let res = is_null(&a).unwrap();
 
-        assert_eq!(4, res.len());
-        assert_eq!(0, res.null_count());
+        let expected = BooleanArray::from(vec![false, true, false, true]);
+
+        assert_eq!(expected, res);
         assert_eq!(&None, res.data_ref().null_bitmap());
-        assert_eq!(false, res.value(0));
-        assert_eq!(true, res.value(1));
-        assert_eq!(false, res.value(2));
-        assert_eq!(true, res.value(3));
     }
 
     #[test]
@@ -400,13 +467,10 @@ mod tests {
 
         let res = is_null(&a).unwrap();
 
-        assert_eq!(4, res.len());
-        assert_eq!(0, res.null_count());
+        let expected = BooleanArray::from(vec![false, true, false, true]);
+
+        assert_eq!(expected, res);
         assert_eq!(&None, res.data_ref().null_bitmap());
-        assert_eq!(false, res.value(0));
-        assert_eq!(true, res.value(1));
-        assert_eq!(false, res.value(2));
-        assert_eq!(true, res.value(3));
     }
 
     #[test]
@@ -415,13 +479,10 @@ mod tests {
 
         let res = is_not_null(&a).unwrap();
 
-        assert_eq!(4, res.len());
-        assert_eq!(0, res.null_count());
+        let expected = BooleanArray::from(vec![true, false, true, false]);
+
+        assert_eq!(expected, res);
         assert_eq!(&None, res.data_ref().null_bitmap());
-        assert_eq!(true, res.value(0));
-        assert_eq!(false, res.value(1));
-        assert_eq!(true, res.value(2));
-        assert_eq!(false, res.value(3));
     }
 
     #[test]
@@ -449,12 +510,9 @@ mod tests {
 
         let res = is_not_null(&a).unwrap();
 
-        assert_eq!(4, res.len());
-        assert_eq!(0, res.null_count());
+        let expected = BooleanArray::from(vec![true, false, true, false]);
+
+        assert_eq!(expected, res);
         assert_eq!(&None, res.data_ref().null_bitmap());
-        assert_eq!(true, res.value(0));
-        assert_eq!(false, res.value(1));
-        assert_eq!(true, res.value(2));
-        assert_eq!(false, res.value(3));
     }
 }


### PR DESCRIPTION
* made some tests be exhaustive
* made most tests use the array equality, that covers more areas (null count, data type, etc.)
