### PR TITLE
ARROW-10639: [Rust] Added examples to is_null kernel and simplified signature.

### DIFF
--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1638,7 +1638,7 @@ impl PhysicalExpr for IsNullExpr {
         let arg = self.arg.evaluate(batch)?;
         match arg {
             ColumnarValue::Array(array) => Ok(ColumnarValue::Array(Arc::new(
-                arrow::compute::is_null(&array)?,
+                arrow::compute::is_null(array.as_ref())?,
             ))),
             ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::Scalar(
                 ScalarValue::Boolean(Some(scalar.is_null())),
@@ -1683,7 +1683,7 @@ impl PhysicalExpr for IsNotNullExpr {
         let arg = self.arg.evaluate(batch)?;
         match arg {
             ColumnarValue::Array(array) => Ok(ColumnarValue::Array(Arc::new(
-                arrow::compute::is_not_null(&array)?,
+                arrow::compute::is_not_null(array.as_ref())?,
             ))),
             ColumnarValue::Scalar(scalar) => Ok(ColumnarValue::Scalar(
                 ScalarValue::Boolean(Some(!scalar.is_null())),


### PR DESCRIPTION
The change in signature was motivated while writing the example: there is no reason to wrap a concrete array on an `Arc` just to be able to pass it to the kernel. All kernels require an immutable reference to anything that implements `Array`, and thus asking for `&Arc<dyn Array>` seems to be equivalent / worse as asking for `&Vec<>` instead of `&[]` that clippy complaints about.

Apart from that, this adds the examples.