### PR TITLE
ARROW-10634: [C#][CI] Change the build version from 2.2 to 3.1 in CI

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: [2.2.103]
+        dotnet: ['3.1.x']
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v1
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: [2.2.103]
+        dotnet: ['3.1.x']
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v1
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: [2.2.103]
+        dotnet: ['3.1.x']
     steps:
       - name: Install C#
         uses: actions/setup-dotnet@v1

--- a/csharp/Directory.Build.props
+++ b/csharp/Directory.Build.props
@@ -33,7 +33,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>7.2</LangVersion>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <LangVersion>8.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(CSharpDir)ApacheArrow.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/csharp/test/Apache.Arrow.Benchmarks/Apache.Arrow.Benchmarks.csproj
+++ b/csharp/test/Apache.Arrow.Benchmarks/Apache.Arrow.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
+++ b/csharp/test/Apache.Arrow.Tests/Apache.Arrow.Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
Upgraded build version to 3.1 and C# version to 8.
Also added EmbedUntrackedSources so auto generated code will work with sourcelink.

This change is a requirement for #8694 and is isolating some of the changes that it required regarding upgrading net core version.