### PR TITLE
ARROW-10143: [C++] Rewrite Array(Range)Equals

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -628,6 +628,7 @@ if(ARROW_COMPUTE)
 endif()
 
 add_arrow_benchmark(builder_benchmark)
+add_arrow_benchmark(compare_benchmark)
 add_arrow_benchmark(memory_pool_benchmark)
 add_arrow_benchmark(type_benchmark)
 

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -53,6 +53,8 @@ using internal::checked_cast;
 using internal::checked_pointer_cast;
 using internal::MakeLazyRange;
 
+namespace {
+
 template <typename ArrayType>
 auto GetView(const ArrayType& array, int64_t index) -> decltype(array.GetView(index)) {
   return array.GetView(index);
@@ -71,7 +73,7 @@ struct Slice {
 
 template <typename ArrayType, typename T = typename ArrayType::TypeClass,
           typename = enable_if_list_like<T>>
-static Slice GetView(const ArrayType& array, int64_t index) {
+Slice GetView(const ArrayType& array, int64_t index) {
   return Slice{array.values().get(), array.value_offset(index),
                array.value_length(index)};
 }
@@ -88,11 +90,11 @@ struct UnitSlice {
 
 // FIXME(bkietz) this is inefficient;
 // StructArray's fields can be diffed independently then merged
-static UnitSlice GetView(const StructArray& array, int64_t index) {
+UnitSlice GetView(const StructArray& array, int64_t index) {
   return UnitSlice{&array, index};
 }
 
-static UnitSlice GetView(const UnionArray& array, int64_t index) {
+UnitSlice GetView(const UnionArray& array, int64_t index) {
   return UnitSlice{&array, index};
 }
 
@@ -157,14 +159,20 @@ struct EditPoint {
 class QuadraticSpaceMyersDiff {
  public:
   QuadraticSpaceMyersDiff(const Array& base, const Array& target, MemoryPool* pool)
+      : QuadraticSpaceMyersDiff(base, target, 0, base.length(), 0, target.length(),
+                                pool) {}
+
+  QuadraticSpaceMyersDiff(const Array& base, const Array& target, int64_t base_offset,
+                          int64_t base_length, int64_t target_offset,
+                          int64_t target_length, MemoryPool* pool)
       : base_(base),
         target_(target),
         pool_(pool),
         value_comparator_(GetValueComparator(*base.type())),
-        base_begin_(0),
-        base_end_(base.length()),
-        target_begin_(0),
-        target_end_(target.length()),
+        base_begin_(base_offset),
+        base_end_(base_offset + base_length),
+        target_begin_(target_offset),
+        target_end_(target_offset + target_length),
         endpoint_base_({ExtendFrom({base_begin_, target_begin_}).base}),
         insert_({true}) {
     if ((base_end_ - base_begin_ == target_end_ - target_begin_) &&
@@ -331,8 +339,8 @@ class QuadraticSpaceMyersDiff {
   ValueComparator value_comparator_;
   int64_t finish_index_ = -1;
   int64_t edit_count_ = 0;
-  int64_t base_begin_, base_end_;
-  int64_t target_begin_, target_end_;
+  const int64_t base_begin_, base_end_;
+  const int64_t target_begin_, target_end_;
   // each element of endpoint_base_ is the furthest position in base reachable given an
   // edit_count and (# insertions) - (# deletions). Each bit of insert_ records whether
   // the corresponding furthest position was reached via an insertion or a deletion
@@ -342,11 +350,12 @@ class QuadraticSpaceMyersDiff {
   std::vector<bool> insert_;
 };
 
-Result<std::shared_ptr<StructArray>> NullDiff(const Array& base, const Array& target,
-                                              MemoryPool* pool) {
-  bool insert = base.length() < target.length();
-  auto run_length = std::min(base.length(), target.length());
-  auto edit_count = std::max(base.length(), target.length()) - run_length;
+Result<std::shared_ptr<StructArray>> NullDiffRanges(
+    const Array& base, const Array& target, int64_t base_offset, int64_t base_length,
+    int64_t target_offset, int64_t target_length, MemoryPool* pool) {
+  const bool insert = base_length < target_length;
+  const auto run_length = std::min(base_length, target_length);
+  const auto edit_count = std::max(base_length, target_length) - run_length;
 
   TypedBufferBuilder<bool> insert_builder(pool);
   RETURN_NOT_OK(insert_builder.Resize(edit_count + 1));
@@ -368,28 +377,49 @@ Result<std::shared_ptr<StructArray>> NullDiff(const Array& base, const Array& ta
                            {field("insert", boolean()), field("run_length", int64())});
 }
 
-Result<std::shared_ptr<StructArray>> Diff(const Array& base, const Array& target,
-                                          MemoryPool* pool) {
+}  // namespace
+
+Result<std::shared_ptr<StructArray>> DiffRanges(const Array& base, const Array& target,
+                                                int64_t base_offset, int64_t base_length,
+                                                int64_t target_offset,
+                                                int64_t target_length, MemoryPool* pool) {
   if (!base.type()->Equals(target.type())) {
     return Status::TypeError("only taking the diff of like-typed arrays is supported.");
   }
+  if (base_offset + base_length > base.length()) {
+    return Status::Invalid("diff offset and length for base array out of bounds");
+  }
+  if (target_offset + target_length > target.length()) {
+    return Status::Invalid("diff offset and length for target array out of bounds");
+  }
 
   if (base.type()->id() == Type::NA) {
-    return NullDiff(base, target, pool);
+    return NullDiffRanges(base, target, base_offset, base_length, target_offset,
+                          target_length, pool);
   } else if (base.type()->id() == Type::EXTENSION) {
     auto base_storage = checked_cast<const ExtensionArray&>(base).storage();
     auto target_storage = checked_cast<const ExtensionArray&>(target).storage();
-    return Diff(*base_storage, *target_storage, pool);
+    return DiffRanges(*base_storage, *target_storage, base_offset, base_length,
+                      target_offset, target_length, pool);
   } else if (base.type()->id() == Type::DICTIONARY) {
     return Status::NotImplemented("diffing arrays of type ", *base.type());
   } else {
-    return QuadraticSpaceMyersDiff(base, target, pool).Diff();
+    return QuadraticSpaceMyersDiff(base, target, base_offset, base_length, target_offset,
+                                   target_length, pool)
+        .Diff();
   }
 }
 
+Result<std::shared_ptr<StructArray>> Diff(const Array& base, const Array& target,
+                                          MemoryPool* pool) {
+  return DiffRanges(base, target, 0, base.length(), 0, target.length(), pool);
+}
+
+namespace {
+
 using Formatter = std::function<void(const Array&, int64_t index, std::ostream*)>;
 
-static Result<Formatter> MakeFormatter(const DataType& type);
+Result<Formatter> MakeFormatter(const DataType& type);
 
 class MakeFormatterImpl {
  public:
@@ -400,7 +430,7 @@ class MakeFormatterImpl {
 
  private:
   template <typename VISITOR>
-  friend Status VisitTypeInline(const DataType&, VISITOR*);
+  friend Status arrow::VisitTypeInline(const DataType&, VISITOR*);
 
   // factory implementation
   Status Visit(const BooleanType&) {
@@ -673,9 +703,11 @@ class MakeFormatterImpl {
   Formatter impl_;
 };
 
-static Result<Formatter> MakeFormatter(const DataType& type) {
+Result<Formatter> MakeFormatter(const DataType& type) {
   return MakeFormatterImpl{}.Make(type);
 }
+
+}  // namespace
 
 Status VisitEditScript(
     const Array& edits,
@@ -714,6 +746,8 @@ Status VisitEditScript(
   }
   return Status::OK();
 }
+
+namespace {
 
 class UnifiedDiffFormatter {
  public:
@@ -763,6 +797,8 @@ class UnifiedDiffFormatter {
   const Array* target_ = nullptr;
   Formatter formatter_;
 };
+
+}  // namespace
 
 Result<std::function<Status(const Array& edits, const Array& base, const Array& target)>>
 MakeUnifiedDiffFormatter(const DataType& type, std::ostream* os) {

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -49,8 +49,6 @@ namespace arrow {
 ///   {"insert": false, "run_length": 0} // delete("o") then an empty run
 /// ]
 ///
-/// Diffing arrays containing nulls is not currently supported.
-///
 /// \param[in] base baseline for comparison
 /// \param[in] target an array of identical type to base whose elements differ from base's
 /// \param[in] pool memory to store the result will be allocated from this memory pool
@@ -58,6 +56,27 @@ namespace arrow {
 ARROW_EXPORT
 Result<std::shared_ptr<StructArray>> Diff(const Array& base, const Array& target,
                                           MemoryPool* pool = default_memory_pool());
+
+/// \brief Compare two array ranges, returning an edit script which expresses the
+/// difference between them
+///
+/// Same as Diff(), but only the ranges defined by the given offsets and lengths
+/// are compared.
+///
+/// \param[in] base baseline for comparison
+/// \param[in] target an array of identical type to base whose elements differ from base's
+/// \param[in] base_offset the start offset of the range to consider inside `base`
+/// \param[in] base_length the length of the range to consider inside `base`
+/// \param[in] target_offset the start offset of the range to consider inside `target`
+/// \param[in] target_length the length of the range to consider inside `target`
+/// \param[in] pool memory to store the result will be allocated from this memory pool
+/// \return an edit script array which can be applied to base to produce target
+ARROW_EXPORT
+Result<std::shared_ptr<StructArray>> DiffRanges(const Array& base, const Array& target,
+                                                int64_t base_offset, int64_t base_length,
+                                                int64_t target_offset,
+                                                int64_t target_length,
+                                                MemoryPool* pool = default_memory_pool());
 
 /// \brief visitor interface for easy traversal of an edit script
 ///

--- a/cpp/src/arrow/array/diff.h
+++ b/cpp/src/arrow/array/diff.h
@@ -49,6 +49,8 @@ namespace arrow {
 ///   {"insert": false, "run_length": 0} // delete("o") then an empty run
 /// ]
 ///
+/// Diffing arrays containing nulls is not currently supported.
+///
 /// \param[in] base baseline for comparison
 /// \param[in] target an array of identical type to base whose elements differ from base's
 /// \param[in] pool memory to store the result will be allocated from this memory pool
@@ -56,27 +58,6 @@ namespace arrow {
 ARROW_EXPORT
 Result<std::shared_ptr<StructArray>> Diff(const Array& base, const Array& target,
                                           MemoryPool* pool = default_memory_pool());
-
-/// \brief Compare two array ranges, returning an edit script which expresses the
-/// difference between them
-///
-/// Same as Diff(), but only the ranges defined by the given offsets and lengths
-/// are compared.
-///
-/// \param[in] base baseline for comparison
-/// \param[in] target an array of identical type to base whose elements differ from base's
-/// \param[in] base_offset the start offset of the range to consider inside `base`
-/// \param[in] base_length the length of the range to consider inside `base`
-/// \param[in] target_offset the start offset of the range to consider inside `target`
-/// \param[in] target_length the length of the range to consider inside `target`
-/// \param[in] pool memory to store the result will be allocated from this memory pool
-/// \return an edit script array which can be applied to base to produce target
-ARROW_EXPORT
-Result<std::shared_ptr<StructArray>> DiffRanges(const Array& base, const Array& target,
-                                                int64_t base_offset, int64_t base_length,
-                                                int64_t target_offset,
-                                                int64_t target_length,
-                                                MemoryPool* pool = default_memory_pool());
 
 /// \brief visitor interface for easy traversal of an edit script
 ///

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -38,8 +38,10 @@
 #include "arrow/tensor.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/bit_block_counter.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/bitmap_reader.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
@@ -49,700 +51,441 @@
 namespace arrow {
 
 using internal::BitmapEquals;
+using internal::BitmapReader;
+using internal::BitmapUInt64Reader;
 using internal::checked_cast;
+using internal::OptionalBitBlockCounter;
+using internal::OptionalBitmapEquals;
 
 // ----------------------------------------------------------------------
 // Public method implementations
 
 namespace {
 
-// These helper functions assume we already checked the arrays have equal
-// sizes and null bitmaps.
+bool CompareArrayRanges(const ArrayData& left, const ArrayData& right,
+                        int64_t left_start_idx, int64_t left_end_idx,
+                        int64_t right_start_idx, const EqualOptions& options,
+                        bool floating_approximate);
 
-template <typename ArrowType, typename EqualityFunc>
-inline bool BaseFloatingEquals(const NumericArray<ArrowType>& left,
-                               const NumericArray<ArrowType>& right,
-                               EqualityFunc&& equals) {
-  using T = typename ArrowType::c_type;
-
-  const T* left_data = left.raw_values();
-  const T* right_data = right.raw_values();
-
-  if (left.null_count() > 0) {
-    for (int64_t i = 0; i < left.length(); ++i) {
-      if (left.IsNull(i)) continue;
-      if (!equals(left_data[i], right_data[i])) {
-        return false;
-      }
-    }
-  } else {
-    for (int64_t i = 0; i < left.length(); ++i) {
-      if (!equals(left_data[i], right_data[i])) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
-template <typename ArrowType>
-inline bool FloatingEquals(const NumericArray<ArrowType>& left,
-                           const NumericArray<ArrowType>& right,
-                           const EqualOptions& opts) {
-  using T = typename ArrowType::c_type;
-
-  if (opts.nans_equal()) {
-    return BaseFloatingEquals<ArrowType>(left, right, [](T x, T y) -> bool {
-      return (x == y) || (std::isnan(x) && std::isnan(y));
-    });
-  } else {
-    return BaseFloatingEquals<ArrowType>(left, right,
-                                         [](T x, T y) -> bool { return x == y; });
-  }
-}
-
-template <typename ArrowType>
-inline bool FloatingApproxEquals(const NumericArray<ArrowType>& left,
-                                 const NumericArray<ArrowType>& right,
-                                 const EqualOptions& opts) {
-  using T = typename ArrowType::c_type;
-  const T epsilon = static_cast<T>(opts.atol());
-
-  if (opts.nans_equal()) {
-    return BaseFloatingEquals<ArrowType>(left, right, [epsilon](T x, T y) -> bool {
-      return (fabs(x - y) <= epsilon) || (x == y) || (std::isnan(x) && std::isnan(y));
-    });
-  } else {
-    return BaseFloatingEquals<ArrowType>(left, right, [epsilon](T x, T y) -> bool {
-      return (fabs(x - y) <= epsilon) || (x == y);
-    });
-  }
-}
-
-// RangeEqualsVisitor assumes the range sizes are equal
-
-class RangeEqualsVisitor {
+class RangeDataEqualsImpl {
  public:
-  RangeEqualsVisitor(const Array& right, int64_t left_start_idx, int64_t left_end_idx,
-                     int64_t right_start_idx)
-      : right_(right),
+  // PRE-CONDITIONS:
+  // - the types are equal
+  // - the ranges are in bounds
+  RangeDataEqualsImpl(const EqualOptions& options, bool floating_approximate,
+                      const ArrayData& left, const ArrayData& right,
+                      int64_t left_start_idx, int64_t right_start_idx,
+                      int64_t range_length)
+      : options_(options),
+        floating_approximate_(floating_approximate),
+        left_(left),
+        right_(right),
         left_start_idx_(left_start_idx),
-        left_end_idx_(left_end_idx),
         right_start_idx_(right_start_idx),
+        range_length_(range_length),
         result_(false) {}
 
-  template <typename ArrayType>
-  inline Status CompareValues(const ArrayType& left) {
-    const auto& right = checked_cast<const ArrayType&>(right_);
-
-    for (int64_t i = left_start_idx_, o_i = right_start_idx_; i < left_end_idx_;
-         ++i, ++o_i) {
-      const bool is_null = left.IsNull(i);
-      if (is_null != right.IsNull(o_i) ||
-          (!is_null && left.Value(i) != right.Value(o_i))) {
-        result_ = false;
-        return Status::OK();
-      }
-    }
-    result_ = true;
-    return Status::OK();
-  }
-
-  template <typename ArrayType, typename CompareValuesFunc>
-  bool CompareWithOffsets(const ArrayType& left,
-                          CompareValuesFunc&& compare_values) const {
-    const auto& right = checked_cast<const ArrayType&>(right_);
-
-    for (int64_t i = left_start_idx_, o_i = right_start_idx_; i < left_end_idx_;
-         ++i, ++o_i) {
-      const bool is_null = left.IsNull(i);
-      if (is_null != right.IsNull(o_i)) {
-        return false;
-      }
-      if (is_null) continue;
-      const auto begin_offset = left.value_offset(i);
-      const auto end_offset = left.value_offset(i + 1);
-      const auto right_begin_offset = right.value_offset(o_i);
-      const auto right_end_offset = right.value_offset(o_i + 1);
-      // Underlying can't be equal if the size isn't equal
-      if (end_offset - begin_offset != right_end_offset - right_begin_offset) {
-        return false;
-      }
-
-      if (!compare_values(left, right, begin_offset, right_begin_offset,
-                          end_offset - begin_offset)) {
+  bool Compare() {
+    // Compare null bitmaps
+    if (left_start_idx_ == 0 && right_start_idx_ == 0 && range_length_ == left_.length &&
+        range_length_ == right_.length) {
+      // If we're comparing entire arrays, we can first compare the cached null counts
+      if (left_.GetNullCount() != right_.GetNullCount()) {
         return false;
       }
     }
-    return true;
-  }
-
-  template <typename BinaryArrayType>
-  bool CompareBinaryRange(const BinaryArrayType& left) const {
-    using offset_type = typename BinaryArrayType::offset_type;
-
-    auto compare_values = [](const BinaryArrayType& left, const BinaryArrayType& right,
-                             offset_type left_offset, offset_type right_offset,
-                             offset_type nvalues) {
-      if (nvalues == 0) {
-        return true;
-      }
-      return std::memcmp(left.value_data()->data() + left_offset,
-                         right.value_data()->data() + right_offset,
-                         static_cast<size_t>(nvalues)) == 0;
-    };
-    return CompareWithOffsets(left, compare_values);
-  }
-
-  template <typename ListArrayType>
-  bool CompareLists(const ListArrayType& left) {
-    using offset_type = typename ListArrayType::offset_type;
-    const auto& right = checked_cast<const ListArrayType&>(right_);
-    const std::shared_ptr<Array>& left_values = left.values();
-    const std::shared_ptr<Array>& right_values = right.values();
-
-    auto compare_values = [&](const ListArrayType& left, const ListArrayType& right,
-                              offset_type left_offset, offset_type right_offset,
-                              offset_type nvalues) {
-      if (nvalues == 0) {
-        return true;
-      }
-      return left_values->RangeEquals(left_offset, left_offset + nvalues, right_offset,
-                                      right_values);
-    };
-    return CompareWithOffsets(left, compare_values);
-  }
-
-  bool CompareMaps(const MapArray& left) {
-    // We need a specific comparison helper for maps to avoid comparing
-    // struct field names (which are indifferent for maps)
-    using offset_type = typename MapArray::offset_type;
-    const auto& right = checked_cast<const MapArray&>(right_);
-    const auto left_keys = left.keys();
-    const auto left_items = left.items();
-    const auto right_keys = right.keys();
-    const auto right_items = right.items();
-
-    auto compare_values = [&](const MapArray& left, const MapArray& right,
-                              offset_type left_offset, offset_type right_offset,
-                              offset_type nvalues) {
-      if (nvalues == 0) {
-        return true;
-      }
-      return left_keys->RangeEquals(left_offset, left_offset + nvalues, right_offset,
-                                    right_keys) &&
-             left_items->RangeEquals(left_offset, left_offset + nvalues, right_offset,
-                                     right_items);
-    };
-    return CompareWithOffsets(left, compare_values);
-  }
-
-  bool CompareStructs(const StructArray& left) {
-    const auto& right = checked_cast<const StructArray&>(right_);
-    bool equal_fields = true;
-    for (int64_t i = left_start_idx_, o_i = right_start_idx_; i < left_end_idx_;
-         ++i, ++o_i) {
-      if (left.IsNull(i) != right.IsNull(o_i)) {
-        return false;
-      }
-      if (left.IsNull(i)) continue;
-      for (int j = 0; j < left.num_fields(); ++j) {
-        // TODO: really we should be comparing stretches of non-null data rather
-        // than looking at one value at a time.
-        equal_fields = left.field(j)->RangeEquals(i, i + 1, o_i, right.field(j));
-        if (!equal_fields) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-
-  bool CompareUnions(const UnionArray& left) const {
-    const auto& right = checked_cast<const UnionArray&>(right_);
-
-    const UnionMode::type union_mode = left.mode();
-    if (union_mode != right.mode()) {
+    if (!OptionalBitmapEquals(left_.buffers[0], left_.offset + left_start_idx_,
+                              right_.buffers[0], right_.offset + right_start_idx_,
+                              range_length_)) {
       return false;
     }
+    // Compare values
+    return CompareWithType(*left_.type);
+  }
 
-    const auto& left_type = checked_cast<const UnionType&>(*left.type());
+  bool CompareWithType(const DataType& type) {
+    result_ = true;
+    if (range_length_ != 0) {
+      ARROW_CHECK_OK(VisitTypeInline(type, this));
+    }
+    return result_;
+  }
 
-    const std::vector<int>& child_ids = left_type.child_ids();
+  Status Visit(const NullType&) { return Status::OK(); }
 
-    const int8_t* left_codes = left.raw_type_codes();
-    const int8_t* right_codes = right.raw_type_codes();
+  template <typename TypeClass>
+  enable_if_primitive_ctype<TypeClass, Status> Visit(const TypeClass& type) {
+    return ComparePrimitive(type);
+  }
 
-    for (int64_t i = left_start_idx_, o_i = right_start_idx_; i < left_end_idx_;
-         ++i, ++o_i) {
-      if (left.IsNull(i) != right.IsNull(o_i)) {
-        return false;
-      }
-      if (left.IsNull(i)) continue;
-      if (left_codes[i] != right_codes[o_i]) {
-        return false;
-      }
+  template <typename TypeClass>
+  enable_if_t<is_temporal_type<TypeClass>::value, Status> Visit(const TypeClass& type) {
+    return ComparePrimitive(type);
+  }
 
-      auto child_num = child_ids[left_codes[i]];
-
-      // TODO(wesm): really we should be comparing stretches of non-null data
-      // rather than looking at one value at a time.
-      if (union_mode == UnionMode::SPARSE) {
-        if (!left.field(child_num)->RangeEquals(i, i + 1, o_i, right.field(child_num))) {
-          return false;
+  Status Visit(const BooleanType&) {
+    const uint8_t* left_bits = left_.GetValues<uint8_t>(1, 0);
+    const uint8_t* right_bits = right_.GetValues<uint8_t>(1, 0);
+    auto compare_runs = [&](int64_t i, int64_t length) -> bool {
+      if (length <= 8) {
+        // Avoid the BitmapUInt64Reader overhead for very small runs
+        for (int64_t j = i; j < i + length; ++j) {
+          if (BitUtil::GetBit(left_bits, left_start_idx_ + left_.offset + j) !=
+              BitUtil::GetBit(right_bits, right_start_idx_ + right_.offset + j)) {
+            return false;
+          }
         }
+        return true;
       } else {
-        const int32_t offset =
-            checked_cast<const DenseUnionArray&>(left).raw_value_offsets()[i];
-        const int32_t o_offset =
-            checked_cast<const DenseUnionArray&>(right).raw_value_offsets()[o_i];
-        if (!left.field(child_num)->RangeEquals(offset, offset + 1, o_offset,
-                                                right.field(child_num))) {
+        BitmapUInt64Reader left_reader(left_bits, left_start_idx_ + left_.offset + i,
+                                       length);
+        BitmapUInt64Reader right_reader(right_bits, right_start_idx_ + right_.offset + i,
+                                        length);
+        while (left_reader.position() < length) {
+          if (left_reader.NextWord() != right_reader.NextWord()) {
+            return false;
+          }
+        }
+        DCHECK_EQ(right_reader.position(), length);
+      }
+      return true;
+    };
+    VisitValidRuns(compare_runs);
+    return Status::OK();
+  }
+
+  Status Visit(const FloatType& type) { return CompareFloating(type); }
+
+  Status Visit(const DoubleType& type) { return CompareFloating(type); }
+
+  // Also matches StringType
+  Status Visit(const BinaryType& type) { return CompareBinary(type); }
+
+  // Also matches LargeStringType
+  Status Visit(const LargeBinaryType& type) { return CompareBinary(type); }
+
+  Status Visit(const FixedSizeBinaryType& type) {
+    const auto byte_width = type.byte_width();
+    const uint8_t* left_data = left_.GetValues<uint8_t>(1, 0);
+    const uint8_t* right_data = right_.GetValues<uint8_t>(1, 0);
+
+    if (left_data != nullptr && right_data != nullptr) {
+      auto compare_runs = [&](int64_t i, int64_t length) -> bool {
+        return memcmp(left_data + (left_start_idx_ + left_.offset + i) * byte_width,
+                      right_data + (right_start_idx_ + right_.offset + i) * byte_width,
+                      length * byte_width) == 0;
+      };
+      VisitValidRuns(compare_runs);
+    } else {
+      auto compare_runs = [&](int64_t i, int64_t length) -> bool { return true; };
+      VisitValidRuns(compare_runs);
+    }
+    return Status::OK();
+  }
+
+  // Also matches MapType
+  Status Visit(const ListType& type) { return CompareList(type); }
+
+  Status Visit(const LargeListType& type) { return CompareList(type); }
+
+  Status Visit(const FixedSizeListType& type) {
+    const auto list_size = type.list_size();
+    const ArrayData& left_data = *left_.child_data[0];
+    const ArrayData& right_data = *right_.child_data[0];
+
+    auto compare_runs = [&](int64_t i, int64_t length) -> bool {
+      RangeDataEqualsImpl impl(options_, floating_approximate_, left_data, right_data,
+                               (left_start_idx_ + left_.offset + i) * list_size,
+                               (right_start_idx_ + right_.offset + i) * list_size,
+                               length * list_size);
+      return impl.Compare();
+    };
+    VisitValidRuns(compare_runs);
+    return Status::OK();
+  }
+
+  Status Visit(const StructType& type) {
+    const int32_t num_fields = type.num_fields();
+
+    auto compare_runs = [&](int64_t i, int64_t length) -> bool {
+      for (int32_t f = 0; f < num_fields; ++f) {
+        RangeDataEqualsImpl impl(options_, floating_approximate_, *left_.child_data[f],
+                                 *right_.child_data[f],
+                                 left_start_idx_ + left_.offset + i,
+                                 right_start_idx_ + right_.offset + i, length);
+        if (!impl.Compare()) {
           return false;
         }
       }
-    }
-    return true;
-  }
-
-  Status Visit(const BinaryArray& left) {
-    result_ = CompareBinaryRange(left);
+      return true;
+    };
+    VisitValidRuns(compare_runs);
     return Status::OK();
   }
 
-  Status Visit(const LargeBinaryArray& left) {
-    result_ = CompareBinaryRange(left);
-    return Status::OK();
-  }
+  Status Visit(const SparseUnionType& type) {
+    const auto& child_ids = type.child_ids();
+    const int8_t* left_codes = left_.GetValues<int8_t>(1);
+    const int8_t* right_codes = right_.GetValues<int8_t>(1);
 
-  Status Visit(const FixedSizeBinaryArray& left) {
-    const auto& right = checked_cast<const FixedSizeBinaryArray&>(right_);
-
-    int32_t width = left.byte_width();
-
-    const uint8_t* left_data = nullptr;
-    const uint8_t* right_data = nullptr;
-
-    if (left.values()) {
-      left_data = left.raw_values();
-    }
-
-    if (right.values()) {
-      right_data = right.raw_values();
-    }
-
-    for (int64_t i = left_start_idx_, o_i = right_start_idx_; i < left_end_idx_;
-         ++i, ++o_i) {
-      const bool is_null = left.IsNull(i);
-      if (is_null != right.IsNull(o_i)) {
-        result_ = false;
-        return Status::OK();
+    VisitValidRuns([&](int64_t i, int64_t length) {
+      for (int64_t j = i; j < i + length; ++j) {
+        const auto type_id = left_codes[left_start_idx_ + j];
+        if (type_id != right_codes[right_start_idx_ + j]) {
+          return false;
+        }
+        const auto child_num = child_ids[type_id];
+        // XXX can we instead detect runs of same-child union values?
+        RangeDataEqualsImpl impl(
+            options_, floating_approximate_, *left_.child_data[child_num],
+            *right_.child_data[child_num], left_start_idx_ + left_.offset + j,
+            right_start_idx_ + right_.offset + j, 1);
+        if (!impl.Compare()) {
+          return false;
+        }
       }
-      if (is_null) continue;
+      return true;
+    });
+    return Status::OK();
+  }
 
-      if (std::memcmp(left_data + width * i, right_data + width * o_i, width)) {
-        result_ = false;
-        return Status::OK();
+  Status Visit(const DenseUnionType& type) {
+    const auto& child_ids = type.child_ids();
+    const int8_t* left_codes = left_.GetValues<int8_t>(1);
+    const int8_t* right_codes = right_.GetValues<int8_t>(1);
+    const int32_t* left_offsets = left_.GetValues<int32_t>(2);
+    const int32_t* right_offsets = right_.GetValues<int32_t>(2);
+
+    VisitValidRuns([&](int64_t i, int64_t length) {
+      for (int64_t j = i; j < i + length; ++j) {
+        const auto type_id = left_codes[left_start_idx_ + j];
+        if (type_id != right_codes[right_start_idx_ + j]) {
+          return false;
+        }
+        const auto child_num = child_ids[type_id];
+        RangeDataEqualsImpl impl(
+            options_, floating_approximate_, *left_.child_data[child_num],
+            *right_.child_data[child_num], left_offsets[left_start_idx_ + j],
+            right_offsets[right_start_idx_ + j], 1);
+        if (!impl.Compare()) {
+          return false;
+        }
       }
+      return true;
+    });
+    return Status::OK();
+  }
+
+  Status Visit(const DictionaryType& type) {
+    // Compare dictionaries
+    result_ &= CompareArrayRanges(
+        *left_.dictionary, *right_.dictionary,
+        /*left_start_idx=*/0,
+        /*left_end_idx=*/std::max(left_.dictionary->length, right_.dictionary->length),
+        /*right_start_idx=*/0, options_, floating_approximate_);
+    if (result_) {
+      // Compare indices
+      result_ &= CompareWithType(*type.index_type());
     }
-    result_ = true;
     return Status::OK();
   }
 
-  Status Visit(const Decimal128Array& left) {
-    return Visit(checked_cast<const FixedSizeBinaryArray&>(left));
-  }
-
-  Status Visit(const Decimal256Array& left) {
-    return Visit(checked_cast<const FixedSizeBinaryArray&>(left));
-  }
-
-  Status Visit(const NullArray& left) {
-    ARROW_UNUSED(left);
-    result_ = true;
+  Status Visit(const ExtensionType& type) {
+    // Compare storages
+    result_ &= CompareWithType(*type.storage_type());
     return Status::OK();
   }
-
-  template <typename T>
-  typename std::enable_if<std::is_base_of<PrimitiveArray, T>::value, Status>::type Visit(
-      const T& left) {
-    return CompareValues<T>(left);
-  }
-
-  Status Visit(const ListArray& left) {
-    result_ = CompareLists(left);
-    return Status::OK();
-  }
-
-  Status Visit(const LargeListArray& left) {
-    result_ = CompareLists(left);
-    return Status::OK();
-  }
-
-  Status Visit(const FixedSizeListArray& left) {
-    const auto& right = checked_cast<const FixedSizeListArray&>(right_);
-    result_ = left.values()->RangeEquals(
-        left.value_offset(left_start_idx_), left.value_offset(left_end_idx_),
-        right.value_offset(right_start_idx_), right.values());
-    return Status::OK();
-  }
-
-  Status Visit(const MapArray& left) {
-    result_ = CompareMaps(left);
-    return Status::OK();
-  }
-
-  Status Visit(const StructArray& left) {
-    result_ = CompareStructs(left);
-    return Status::OK();
-  }
-
-  Status Visit(const UnionArray& left) {
-    result_ = CompareUnions(left);
-    return Status::OK();
-  }
-
-  Status Visit(const DictionaryArray& left) {
-    const auto& right = checked_cast<const DictionaryArray&>(right_);
-    if (!left.dictionary()->Equals(right.dictionary())) {
-      result_ = false;
-      return Status::OK();
-    }
-    result_ = left.indices()->RangeEquals(left_start_idx_, left_end_idx_,
-                                          right_start_idx_, right.indices());
-    return Status::OK();
-  }
-
-  Status Visit(const ExtensionArray& left) {
-    result_ = (right_.type()->Equals(*left.type()) &&
-               ArrayRangeEquals(*left.storage(),
-                                *static_cast<const ExtensionArray&>(right_).storage(),
-                                left_start_idx_, left_end_idx_, right_start_idx_));
-    return Status::OK();
-  }
-
-  bool result() const { return result_; }
 
  protected:
-  const Array& right_;
-  int64_t left_start_idx_;
-  int64_t left_end_idx_;
-  int64_t right_start_idx_;
+  template <typename TypeClass, typename CType = typename TypeClass::c_type>
+  Status ComparePrimitive(const TypeClass&) {
+    const CType* left_values = left_.GetValues<CType>(1);
+    const CType* right_values = right_.GetValues<CType>(1);
+    VisitValidRuns([&](int64_t i, int64_t length) {
+      return memcmp(left_values + left_start_idx_ + i,
+                    right_values + right_start_idx_ + i, length * sizeof(CType)) == 0;
+    });
+    return Status::OK();
+  }
+
+  template <typename TypeClass>
+  Status CompareFloating(const TypeClass&) {
+    using T = typename TypeClass::c_type;
+    const T* left_values = left_.GetValues<T>(1);
+    const T* right_values = right_.GetValues<T>(1);
+
+    if (floating_approximate_) {
+      const T epsilon = static_cast<T>(options_.atol());
+      if (options_.nans_equal()) {
+        VisitValues([&](int64_t i) {
+          const T x = left_values[i + left_start_idx_];
+          const T y = right_values[i + right_start_idx_];
+          return (fabs(x - y) <= epsilon) || (x == y) || (std::isnan(x) && std::isnan(y));
+        });
+      } else {
+        VisitValues([&](int64_t i) {
+          const T x = left_values[i + left_start_idx_];
+          const T y = right_values[i + right_start_idx_];
+          return (fabs(x - y) <= epsilon) || (x == y);
+        });
+      }
+    } else {
+      if (options_.nans_equal()) {
+        VisitValues([&](int64_t i) {
+          const T x = left_values[i + left_start_idx_];
+          const T y = right_values[i + right_start_idx_];
+          return (x == y) || (std::isnan(x) && std::isnan(y));
+        });
+      } else {
+        VisitValues([&](int64_t i) {
+          const T x = left_values[i + left_start_idx_];
+          const T y = right_values[i + right_start_idx_];
+          return x == y;
+        });
+      }
+    }
+    return Status::OK();
+  }
+
+  template <typename TypeClass>
+  Status CompareBinary(const TypeClass&) {
+    const uint8_t* left_data = left_.GetValues<uint8_t>(2, 0);
+    const uint8_t* right_data = right_.GetValues<uint8_t>(2, 0);
+
+    if (left_data != nullptr && right_data != nullptr) {
+      const auto compare_ranges = [&](int64_t left_offset, int64_t right_offset,
+                                      int64_t length) -> bool {
+        return memcmp(left_data + left_offset, right_data + right_offset, length) == 0;
+      };
+      CompareWithOffsets<typename TypeClass::offset_type>(1, compare_ranges);
+    } else {
+      // One of the arrays is an array of empty strings and nulls.
+      // We just need to compare the offsets.
+      // (note we must not call memcmp() with null data pointers)
+      const auto compare_ranges = [&](int64_t left_offset, int64_t right_offset,
+                                      int64_t length) -> bool { return true; };
+      CompareWithOffsets<typename TypeClass::offset_type>(1, compare_ranges);
+    }
+    return Status::OK();
+  }
+
+  template <typename TypeClass>
+  Status CompareList(const TypeClass&) {
+    const ArrayData& left_data = *left_.child_data[0];
+    const ArrayData& right_data = *right_.child_data[0];
+
+    const auto compare_ranges = [&](int64_t left_offset, int64_t right_offset,
+                                    int64_t length) -> bool {
+      RangeDataEqualsImpl impl(options_, floating_approximate_, left_data, right_data,
+                               left_offset, right_offset, length);
+      return impl.Compare();
+    };
+
+    CompareWithOffsets<typename TypeClass::offset_type>(1, compare_ranges);
+    return Status::OK();
+  }
+
+  template <typename offset_type, typename CompareRanges>
+  void CompareWithOffsets(int offsets_buffer_index, CompareRanges&& compare_ranges) {
+    const offset_type* left_offsets =
+        left_.GetValues<offset_type>(offsets_buffer_index) + left_start_idx_;
+    const offset_type* right_offsets =
+        right_.GetValues<offset_type>(offsets_buffer_index) + right_start_idx_;
+
+    const auto compare_runs = [&](int64_t i, int64_t length) {
+      for (int64_t j = i; j < i + length; ++j) {
+        if (left_offsets[j + 1] - left_offsets[j] !=
+            right_offsets[j + 1] - right_offsets[j]) {
+          return false;
+        }
+      }
+      if (!compare_ranges(left_offsets[i], right_offsets[i],
+                          left_offsets[i + length] - left_offsets[i])) {
+        return false;
+      }
+      return true;
+    };
+
+    VisitValidRuns(compare_runs);
+  }
+
+  template <typename CompareValues>
+  void VisitValues(CompareValues&& compare_values) {
+    internal::VisitBitBlocksVoid(
+        left_.buffers[0], left_.offset + left_start_idx_, range_length_,
+        [&](int64_t position) { result_ &= compare_values(position); }, []() {});
+  }
+
+  // Visit and compare runs of non-null values
+  template <typename CompareRuns>
+  void VisitValidRuns(CompareRuns&& compare_runs) {
+    int64_t i = 0;
+    const uint8_t* left_null_bitmap = left_.GetValues<uint8_t>(0, 0);
+    // TODO may use BitRunReader or equivalent?
+    OptionalBitBlockCounter bit_blocks(left_null_bitmap, left_.offset + left_start_idx_,
+                                       range_length_);
+
+    while (result_ && i < range_length_) {
+      const auto block = bit_blocks.NextBlock();
+      if (block.AllSet()) {
+        if (!compare_runs(i, block.length)) {
+          result_ = false;
+          return;
+        }
+      } else if (block.NoneSet()) {
+        // Nothing to do
+      } else {
+        // Compare non-null values one at a time
+        for (int64_t j = i; j < i + block.length; ++j) {
+          if (BitUtil::GetBit(left_null_bitmap, left_.offset + left_start_idx_ + j)) {
+            if (!compare_runs(j, 1)) {
+              result_ = false;
+              return;
+            }
+          }
+        }
+      }
+      i += block.length;
+    }
+  }
+
+  const EqualOptions& options_;
+  const bool floating_approximate_;
+  const ArrayData& left_;
+  const ArrayData& right_;
+  const int64_t left_start_idx_;
+  const int64_t right_start_idx_;
+  const int64_t range_length_;
 
   bool result_;
 };
 
-static bool IsEqualPrimitive(const PrimitiveArray& left, const PrimitiveArray& right) {
-  const int byte_width = internal::GetByteWidth(*left.type());
-
-  const uint8_t* left_data = nullptr;
-  const uint8_t* right_data = nullptr;
-
-  if (left.values()) {
-    left_data = left.values()->data() + left.offset() * byte_width;
-  }
-
-  if (right.values()) {
-    right_data = right.values()->data() + right.offset() * byte_width;
-  }
-
-  if (byte_width == 0) {
-    // Special case 0-width data, as the data pointers may be null
-    for (int64_t i = 0; i < left.length(); ++i) {
-      if (left.IsNull(i) != right.IsNull(i)) {
-        return false;
-      }
-    }
-    return true;
-  } else if (left.null_count() > 0) {
-    for (int64_t i = 0; i < left.length(); ++i) {
-      const bool left_null = left.IsNull(i);
-      const bool right_null = right.IsNull(i);
-      if (left_null != right_null) {
-        return false;
-      }
-      if (!left_null && memcmp(left_data, right_data, byte_width) != 0) {
-        return false;
-      }
-      left_data += byte_width;
-      right_data += byte_width;
-    }
-    return true;
-  } else {
-    auto number_of_bytes_to_compare = static_cast<size_t>(byte_width * left.length());
-    return memcmp(left_data, right_data, number_of_bytes_to_compare) == 0;
-  }
-}
-
-// A bit confusing: ArrayEqualsVisitor inherits from RangeEqualsVisitor but
-// doesn't share the same preconditions.
-// When RangeEqualsVisitor is called, we only know the range sizes equal.
-// When ArrayEqualsVisitor is called, we know the sizes and null bitmaps are equal.
-
-class ArrayEqualsVisitor : public RangeEqualsVisitor {
- public:
-  explicit ArrayEqualsVisitor(const Array& right, const EqualOptions& opts)
-      : RangeEqualsVisitor(right, 0, right.length(), 0), opts_(opts) {}
-
-  Status Visit(const NullArray& left) {
-    ARROW_UNUSED(left);
-    result_ = true;
-    return Status::OK();
-  }
-
-  Status Visit(const BooleanArray& left) {
-    const auto& right = checked_cast<const BooleanArray&>(right_);
-
-    if (left.null_count() > 0) {
-      const uint8_t* left_data = left.values()->data();
-      const uint8_t* right_data = right.values()->data();
-
-      for (int64_t i = 0; i < left.length(); ++i) {
-        if (left.IsValid(i) && BitUtil::GetBit(left_data, i + left.offset()) !=
-                                   BitUtil::GetBit(right_data, i + right.offset())) {
-          result_ = false;
-          return Status::OK();
-        }
-      }
-      result_ = true;
-    } else {
-      result_ = BitmapEquals(left.values()->data(), left.offset(), right.values()->data(),
-                             right.offset(), left.length());
-    }
-    return Status::OK();
-  }
-
-  template <typename T>
-  typename std::enable_if<std::is_base_of<PrimitiveArray, T>::value &&
-                              !std::is_base_of<FloatArray, T>::value &&
-                              !std::is_base_of<DoubleArray, T>::value &&
-                              !std::is_base_of<BooleanArray, T>::value,
-                          Status>::type
-  Visit(const T& left) {
-    result_ = IsEqualPrimitive(left, checked_cast<const PrimitiveArray&>(right_));
-    return Status::OK();
-  }
-
-  // TODO nan-aware specialization for half-floats
-
-  Status Visit(const FloatArray& left) {
-    result_ =
-        FloatingEquals<FloatType>(left, checked_cast<const FloatArray&>(right_), opts_);
-    return Status::OK();
-  }
-
-  Status Visit(const DoubleArray& left) {
-    result_ =
-        FloatingEquals<DoubleType>(left, checked_cast<const DoubleArray&>(right_), opts_);
-    return Status::OK();
-  }
-
-  template <typename ArrayType>
-  bool ValueOffsetsEqual(const ArrayType& left) {
-    using offset_type = typename ArrayType::offset_type;
-
-    const auto& right = checked_cast<const ArrayType&>(right_);
-
-    if (left.offset() == 0 && right.offset() == 0) {
-      return left.value_offsets()->Equals(*right.value_offsets(),
-                                          (left.length() + 1) * sizeof(offset_type));
-    } else {
-      // One of the arrays is sliced; logic is more complicated because the
-      // value offsets are not both 0-based
-      auto left_offsets =
-          reinterpret_cast<const offset_type*>(left.value_offsets()->data()) +
-          left.offset();
-      auto right_offsets =
-          reinterpret_cast<const offset_type*>(right.value_offsets()->data()) +
-          right.offset();
-
-      for (int64_t i = 0; i < left.length() + 1; ++i) {
-        if (left_offsets[i] - left_offsets[0] != right_offsets[i] - right_offsets[0]) {
-          return false;
-        }
-      }
-      return true;
-    }
-  }
-
-  template <typename BinaryArrayType>
-  bool CompareBinary(const BinaryArrayType& left) {
-    const auto& right = checked_cast<const BinaryArrayType&>(right_);
-
-    bool equal_offsets = ValueOffsetsEqual<BinaryArrayType>(left);
-    if (!equal_offsets) {
-      return false;
-    }
-
-    if (!left.value_data() && !(right.value_data())) {
-      return true;
-    }
-    if (left.value_offset(left.length()) == left.value_offset(0)) {
-      return true;
-    }
-
-    const uint8_t* left_data = left.value_data()->data();
-    const uint8_t* right_data = right.value_data()->data();
-
-    if (left.null_count() == 0) {
-      // Fast path for null count 0, single memcmp
-      if (left.offset() == 0 && right.offset() == 0) {
-        return std::memcmp(left_data, right_data,
-                           left.raw_value_offsets()[left.length()]) == 0;
-      } else {
-        const int64_t total_bytes =
-            left.value_offset(left.length()) - left.value_offset(0);
-        return std::memcmp(left_data + left.value_offset(0),
-                           right_data + right.value_offset(0),
-                           static_cast<size_t>(total_bytes)) == 0;
-      }
-    } else {
-      // ARROW-537: Only compare data in non-null slots
-      auto left_offsets = left.raw_value_offsets();
-      auto right_offsets = right.raw_value_offsets();
-      for (int64_t i = 0; i < left.length(); ++i) {
-        if (left.IsNull(i)) {
-          continue;
-        }
-        if (std::memcmp(left_data + left_offsets[i], right_data + right_offsets[i],
-                        left.value_length(i))) {
-          return false;
-        }
-      }
-      return true;
-    }
-  }
-
-  template <typename ListArrayType>
-  bool CompareList(const ListArrayType& left) {
-    const auto& right = checked_cast<const ListArrayType&>(right_);
-
-    bool equal_offsets = ValueOffsetsEqual<ListArrayType>(left);
-    if (!equal_offsets) {
-      return false;
-    }
-
-    return left.values()->RangeEquals(left.value_offset(0),
-                                      left.value_offset(left.length()),
-                                      right.value_offset(0), right.values());
-  }
-
-  Status Visit(const BinaryArray& left) {
-    result_ = CompareBinary(left);
-    return Status::OK();
-  }
-
-  Status Visit(const LargeBinaryArray& left) {
-    result_ = CompareBinary(left);
-    return Status::OK();
-  }
-
-  Status Visit(const ListArray& left) {
-    result_ = CompareList(left);
-    return Status::OK();
-  }
-
-  Status Visit(const LargeListArray& left) {
-    result_ = CompareList(left);
-    return Status::OK();
-  }
-
-  Status Visit(const FixedSizeListArray& left) {
-    const auto& right = checked_cast<const FixedSizeListArray&>(right_);
-    result_ =
-        left.values()->RangeEquals(left.value_offset(0), left.value_offset(left.length()),
-                                   right.value_offset(0), right.values());
-    return Status::OK();
-  }
-
-  Status Visit(const DictionaryArray& left) {
-    const auto& right = checked_cast<const DictionaryArray&>(right_);
-    if (!left.dictionary()->Equals(right.dictionary())) {
-      result_ = false;
-    } else {
-      result_ = left.indices()->Equals(right.indices());
-    }
-    return Status::OK();
-  }
-
-  template <typename T>
-  typename std::enable_if<std::is_base_of<NestedType, typename T::TypeClass>::value,
-                          Status>::type
-  Visit(const T& left) {
-    return RangeEqualsVisitor::Visit(left);
-  }
-
-  Status Visit(const ExtensionArray& left) {
-    result_ = (right_.type()->Equals(*left.type()) &&
-               ArrayEquals(*left.storage(),
-                           *static_cast<const ExtensionArray&>(right_).storage()));
-    return Status::OK();
-  }
-
- protected:
-  const EqualOptions opts_;
-};
-
-class ApproxEqualsVisitor : public ArrayEqualsVisitor {
- public:
-  explicit ApproxEqualsVisitor(const Array& right, const EqualOptions& opts)
-      : ArrayEqualsVisitor(right, opts) {}
-
-  using ArrayEqualsVisitor::Visit;
-
-  // TODO half-floats
-
-  Status Visit(const FloatArray& left) {
-    result_ = FloatingApproxEquals<FloatType>(
-        left, checked_cast<const FloatArray&>(right_), opts_);
-    return Status::OK();
-  }
-
-  Status Visit(const DoubleArray& left) {
-    result_ = FloatingApproxEquals<DoubleType>(
-        left, checked_cast<const DoubleArray&>(right_), opts_);
-    return Status::OK();
-  }
-};
-
-static bool BaseDataEquals(const Array& left, const Array& right) {
-  if (left.length() != right.length() || left.null_count() != right.null_count() ||
-      left.type_id() != right.type_id()) {
+bool CompareArrayRanges(const ArrayData& left, const ArrayData& right,
+                        int64_t left_start_idx, int64_t left_end_idx,
+                        int64_t right_start_idx, const EqualOptions& options,
+                        bool floating_approximate) {
+  if (left.type->id() != right.type->id() ||
+      !TypeEquals(*left.type, *right.type, false /* check_metadata */)) {
     return false;
   }
-  // ARROW-2567: Ensure that not only the type id but also the type equality
-  // itself is checked.
-  if (!TypeEquals(*left.type(), *right.type(), false /* check_metadata */)) {
+
+  const int64_t range_length = left_end_idx - left_start_idx;
+  DCHECK_GE(range_length, 0);
+  if (left_start_idx + range_length > left.length) {
+    // Left range too small
     return false;
   }
-  if (left.null_count() > 0 && left.null_count() < left.length()) {
-    return BitmapEquals(left.null_bitmap()->data(), left.offset(),
-                        right.null_bitmap()->data(), right.offset(), left.length());
+  if (right_start_idx + range_length > right.length) {
+    // Right range too small
+    return false;
   }
-  return true;
-}
-
-template <typename VISITOR, typename... Extra>
-inline bool ArrayEqualsImpl(const Array& left, const Array& right, Extra&&... extra) {
-  bool are_equal;
-  // The arrays are the same object
-  if (&left == &right) {
-    are_equal = true;
-  } else if (!BaseDataEquals(left, right)) {
-    are_equal = false;
-  } else if (left.length() == 0) {
-    are_equal = true;
-  } else if (left.null_count() == left.length()) {
-    are_equal = true;
-  } else {
-    VISITOR visitor(right, std::forward<Extra>(extra)...);
-    auto error = VisitArrayInline(left, &visitor);
-    if (!error.ok()) {
-      DCHECK(false) << "Arrays are not comparable: " << error.ToString();
-    }
-    are_equal = visitor.result();
+  if (&left == &right && left_start_idx == right_start_idx) {
+    return true;
   }
-  return are_equal;
+  // Compare values
+  RangeDataEqualsImpl impl(options, floating_approximate, left, right, left_start_idx,
+                           right_start_idx, range_length);
+  return impl.Compare();
 }
 
 class TypeEqualsVisitor {
@@ -1006,7 +749,11 @@ class ScalarEqualsVisitor {
   const EqualOptions options_;
 };
 
-Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
+Status PrintDiff(const Array& left, const Array& right, std::ostream* os);
+
+Status PrintDiff(const Array& left, const Array& right, int64_t left_offset,
+                 int64_t left_length, int64_t right_offset, int64_t right_length,
+                 std::ostream* os) {
   if (os == nullptr) {
     return Status::OK();
   }
@@ -1039,48 +786,65 @@ Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
     return Status::OK();
   }
 
-  ARROW_ASSIGN_OR_RAISE(auto edits, Diff(left, right, default_memory_pool()));
+  ARROW_ASSIGN_OR_RAISE(auto edits,
+                        DiffRanges(left, right, left_offset, left_length, right_offset,
+                                   right_length, default_memory_pool()));
   ARROW_ASSIGN_OR_RAISE(auto formatter, MakeUnifiedDiffFormatter(*left.type(), os));
   return formatter(*edits, left, right);
 }
 
-}  // namespace
-
-bool ArrayEquals(const Array& left, const Array& right, const EqualOptions& opts) {
-  bool are_equal = ArrayEqualsImpl<ArrayEqualsVisitor>(left, right, opts);
-  if (!are_equal) {
-    ARROW_IGNORE_EXPR(PrintDiff(left, right, opts.diff_sink()));
-  }
-  return are_equal;
-}
-
-bool ArrayApproxEquals(const Array& left, const Array& right, const EqualOptions& opts) {
-  bool are_equal = ArrayEqualsImpl<ApproxEqualsVisitor>(left, right, opts);
-  if (!are_equal) {
-    DCHECK_OK(PrintDiff(left, right, opts.diff_sink()));
-  }
-  return are_equal;
+Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {
+  return PrintDiff(left, right, 0, left.length(), 0, right.length(), os);
 }
 
 bool ArrayRangeEquals(const Array& left, const Array& right, int64_t left_start_idx,
-                      int64_t left_end_idx, int64_t right_start_idx) {
-  bool are_equal;
-  if (&left == &right) {
-    are_equal = true;
-  } else if (left.type_id() != right.type_id() ||
-             !TypeEquals(*left.type(), *right.type(), false /* check_metadata */)) {
-    are_equal = false;
-  } else if (left.length() == 0) {
-    are_equal = true;
-  } else {
-    RangeEqualsVisitor visitor(right, left_start_idx, left_end_idx, right_start_idx);
-    auto error = VisitArrayInline(left, &visitor);
-    if (!error.ok()) {
-      DCHECK(false) << "Arrays are not comparable: " << error.ToString();
-    }
-    are_equal = visitor.result();
+                      int64_t left_end_idx, int64_t right_start_idx,
+                      const EqualOptions& options, bool floating_approximate) {
+  bool are_equal =
+      CompareArrayRanges(*left.data(), *right.data(), left_start_idx, left_end_idx,
+                         right_start_idx, options, floating_approximate);
+  if (!are_equal) {
+    ARROW_IGNORE_EXPR(PrintDiff(
+        left, right, left_start_idx, left_end_idx, right_start_idx,
+        right_start_idx + (left_end_idx - left_start_idx), options.diff_sink()));
   }
   return are_equal;
+}
+
+}  // namespace
+
+bool ArrayRangeEquals(const Array& left, const Array& right, int64_t left_start_idx,
+                      int64_t left_end_idx, int64_t right_start_idx,
+                      const EqualOptions& options) {
+  const bool floating_approximate = false;
+  return ArrayRangeEquals(left, right, left_start_idx, left_end_idx, right_start_idx,
+                          options, floating_approximate);
+}
+
+bool ArrayRangeApproxEquals(const Array& left, const Array& right, int64_t left_start_idx,
+                            int64_t left_end_idx, int64_t right_start_idx,
+                            const EqualOptions& options) {
+  const bool floating_approximate = true;
+  return ArrayRangeEquals(left, right, left_start_idx, left_end_idx, right_start_idx,
+                          options, floating_approximate);
+}
+
+bool ArrayEquals(const Array& left, const Array& right, const EqualOptions& opts) {
+  if (left.length() != right.length()) {
+    ARROW_IGNORE_EXPR(PrintDiff(left, right, opts.diff_sink()));
+    return false;
+  }
+  const bool floating_approximate = false;
+  return ArrayRangeEquals(left, right, 0, left.length(), 0, opts, floating_approximate);
+}
+
+bool ArrayApproxEquals(const Array& left, const Array& right, const EqualOptions& opts) {
+  if (left.length() != right.length()) {
+    ARROW_IGNORE_EXPR(PrintDiff(left, right, opts.diff_sink()));
+    return false;
+  }
+  const bool floating_approximate = true;
+  return ArrayRangeEquals(left, right, 0, left.length(), 0, opts, floating_approximate);
 }
 
 namespace {

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -786,11 +786,12 @@ Status PrintDiff(const Array& left, const Array& right, int64_t left_offset,
     return Status::OK();
   }
 
+  const auto left_slice = left.Slice(left_offset, left_length);
+  const auto right_slice = right.Slice(right_offset, right_length);
   ARROW_ASSIGN_OR_RAISE(auto edits,
-                        DiffRanges(left, right, left_offset, left_length, right_offset,
-                                   right_length, default_memory_pool()));
+                        Diff(*left_slice, *right_slice, default_memory_pool()));
   ARROW_ASSIGN_OR_RAISE(auto formatter, MakeUnifiedDiffFormatter(*left.type(), os));
-  return formatter(*edits, left, right);
+  return formatter(*edits, *left_slice, *right_slice);
 }
 
 Status PrintDiff(const Array& left, const Array& right, std::ostream* os) {

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -83,22 +83,29 @@ class EqualOptions {
 bool ARROW_EXPORT ArrayEquals(const Array& left, const Array& right,
                               const EqualOptions& = EqualOptions::Defaults());
 
+/// Returns true if the arrays are approximately equal. For non-floating point
+/// types, this is equivalent to ArrayEquals(left, right)
+bool ARROW_EXPORT ArrayApproxEquals(const Array& left, const Array& right,
+                                    const EqualOptions& = EqualOptions::Defaults());
+
+/// Returns true if indicated equal-length segment of arrays are exactly equal
+bool ARROW_EXPORT ArrayRangeEquals(const Array& left, const Array& right,
+                                   int64_t start_idx, int64_t end_idx,
+                                   int64_t other_start_idx,
+                                   const EqualOptions& = EqualOptions::Defaults());
+
+/// Returns true if indicated equal-length segment of arrays are approximately equal
+bool ARROW_EXPORT ArrayRangeApproxEquals(const Array& left, const Array& right,
+                                         int64_t start_idx, int64_t end_idx,
+                                         int64_t other_start_idx,
+                                         const EqualOptions& = EqualOptions::Defaults());
+
 bool ARROW_EXPORT TensorEquals(const Tensor& left, const Tensor& right,
                                const EqualOptions& = EqualOptions::Defaults());
 
 /// EXPERIMENTAL: Returns true if the given sparse tensors are exactly equal
 bool ARROW_EXPORT SparseTensorEquals(const SparseTensor& left, const SparseTensor& right,
                                      const EqualOptions& = EqualOptions::Defaults());
-
-/// Returns true if the arrays are approximately equal. For non-floating point
-/// types, this is equivalent to ArrayEquals(left, right)
-bool ARROW_EXPORT ArrayApproxEquals(const Array& left, const Array& right,
-                                    const EqualOptions& = EqualOptions::Defaults());
-
-/// Returns true if indicated equal-length segment of arrays is exactly equal
-bool ARROW_EXPORT ArrayRangeEquals(const Array& left, const Array& right,
-                                   int64_t start_idx, int64_t end_idx,
-                                   int64_t other_start_idx);
 
 /// Returns true if the type metadata are exactly equal
 /// \param[in] left a DataType

--- a/cpp/src/arrow/compare_benchmark.cc
+++ b/cpp/src/arrow/compare_benchmark.cc
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "benchmark/benchmark.h"
+
+#include "arrow/array.h"
+#include "arrow/compare.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/util/benchmark_util.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/macros.h"
+
+namespace arrow {
+
+constexpr auto kSeed = 0x94378165;
+
+static void BenchmarkArrayRangeEquals(const std::shared_ptr<Array>& array,
+                                      benchmark::State& state) {
+  const auto left_array = array;
+  // Make sure pointer equality can't be used as a shortcut
+  // (should we would deep-copy child_data and buffers?)
+  const auto right_array =
+      MakeArray(array->data()->Copy())->Slice(1, array->length() - 1);
+
+  for (auto _ : state) {
+    const bool are_ok = ArrayRangeEquals(*left_array, *right_array,
+                                         /*left_start_idx=*/1,
+                                         /*left_end_idx=*/array->length() - 2,
+                                         /*right_start_idx=*/0);
+    if (ARROW_PREDICT_FALSE(!are_ok)) {
+      ARROW_LOG(FATAL) << "Arrays should have compared equal";
+    }
+  }
+}
+
+static void ArrayRangeEqualsInt32(benchmark::State& state) {
+  RegressionArgs args(state, /*size_is_bytes=*/false);
+
+  auto rng = random::RandomArrayGenerator(kSeed);
+  auto array = rng.Int32(args.size, 0, 100, args.null_proportion);
+
+  BenchmarkArrayRangeEquals(array, state);
+}
+
+static void ArrayRangeEqualsFloat32(benchmark::State& state) {
+  RegressionArgs args(state, /*size_is_bytes=*/false);
+
+  auto rng = random::RandomArrayGenerator(kSeed);
+  auto array = rng.Float32(args.size, 0, 100, args.null_proportion);
+
+  BenchmarkArrayRangeEquals(array, state);
+}
+
+static void ArrayRangeEqualsBoolean(benchmark::State& state) {
+  RegressionArgs args(state, /*size_is_bytes=*/false);
+
+  auto rng = random::RandomArrayGenerator(kSeed);
+  auto array = rng.Boolean(args.size, /*true_probability=*/0.3, args.null_proportion);
+
+  BenchmarkArrayRangeEquals(array, state);
+}
+
+static void ArrayRangeEqualsString(benchmark::State& state) {
+  RegressionArgs args(state, /*size_is_bytes=*/false);
+
+  auto rng = random::RandomArrayGenerator(kSeed);
+  auto array =
+      rng.String(args.size, /*min_length=*/0, /*max_length=*/15, args.null_proportion);
+
+  BenchmarkArrayRangeEquals(array, state);
+}
+
+static void ArrayRangeEqualsFixedSizeBinary(benchmark::State& state) {
+  RegressionArgs args(state, /*size_is_bytes=*/false);
+
+  auto rng = random::RandomArrayGenerator(kSeed);
+  auto array = rng.FixedSizeBinary(args.size, /*byte_width=*/8, args.null_proportion);
+
+  BenchmarkArrayRangeEquals(array, state);
+}
+
+static void ArrayRangeEqualsListOfInt32(benchmark::State& state) {
+  RegressionArgs args(state, /*size_is_bytes=*/false);
+
+  auto rng = random::RandomArrayGenerator(kSeed);
+  auto values = rng.Int32(args.size * 10, 0, 100, args.null_proportion);
+  // Force empty list null entries, since it is overwhelmingly the common case.
+  auto array = rng.List(*values, /*size=*/args.size, args.null_proportion,
+                        /*force_empty_nulls=*/true);
+
+  BenchmarkArrayRangeEquals(array, state);
+}
+
+static void ArrayRangeEqualsStruct(benchmark::State& state) {
+  // struct<int32, utf8>
+  RegressionArgs args(state, /*size_is_bytes=*/false);
+
+  auto rng = random::RandomArrayGenerator(kSeed);
+  auto values1 = rng.Int32(args.size, 0, 100, args.null_proportion);
+  auto values2 =
+      rng.String(args.size, /*min_length=*/0, /*max_length=*/15, args.null_proportion);
+  auto null_bitmap = rng.NullBitmap(args.size, args.null_proportion);
+  auto array = *StructArray::Make({values1, values2},
+                                  std::vector<std::string>{"ints", "strs"}, null_bitmap);
+
+  BenchmarkArrayRangeEquals(array, state);
+}
+
+static void ArrayRangeEqualsSparseUnion(benchmark::State& state) {
+  // sparse_union<int32, utf8>
+  RegressionArgs args(state, /*size_is_bytes=*/false);
+
+  auto rng = random::RandomArrayGenerator(kSeed);
+  auto values1 = rng.Int32(args.size, 0, 100, args.null_proportion);
+  auto values2 =
+      rng.String(args.size, /*min_length=*/0, /*max_length=*/15, args.null_proportion);
+  auto array = rng.SparseUnion({values1, values2}, args.size);
+
+  BenchmarkArrayRangeEquals(array, state);
+}
+
+static void ArrayRangeEqualsDenseUnion(benchmark::State& state) {
+  // dense_union<int32, utf8>
+  RegressionArgs args(state, /*size_is_bytes=*/false);
+
+  auto rng = random::RandomArrayGenerator(kSeed);
+  auto values1 = rng.Int32(args.size, 0, 100, args.null_proportion);
+  auto values2 =
+      rng.String(args.size, /*min_length=*/0, /*max_length=*/15, args.null_proportion);
+  auto array = rng.DenseUnion({values1, values2}, args.size);
+
+  BenchmarkArrayRangeEquals(array, state);
+}
+
+BENCHMARK(ArrayRangeEqualsInt32)->Apply(RegressionSetArgs);
+BENCHMARK(ArrayRangeEqualsFloat32)->Apply(RegressionSetArgs);
+BENCHMARK(ArrayRangeEqualsBoolean)->Apply(RegressionSetArgs);
+BENCHMARK(ArrayRangeEqualsString)->Apply(RegressionSetArgs);
+BENCHMARK(ArrayRangeEqualsFixedSizeBinary)->Apply(RegressionSetArgs);
+BENCHMARK(ArrayRangeEqualsListOfInt32)->Apply(RegressionSetArgs);
+BENCHMARK(ArrayRangeEqualsStruct)->Apply(RegressionSetArgs);
+BENCHMARK(ArrayRangeEqualsSparseUnion)->Apply(RegressionSetArgs);
+BENCHMARK(ArrayRangeEqualsDenseUnion)->Apply(RegressionSetArgs);
+
+}  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_benchmark.cc
@@ -20,11 +20,11 @@
 #include <vector>
 
 #include "arrow/compute/api.h"
-#include "arrow/memory_pool.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/util/benchmark_util.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap_reader.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -31,6 +31,7 @@
 #include "arrow/compute/kernels/test_util.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/bitmap_reader.h"
 #include "arrow/util/checked_cast.h"
 
 #include "arrow/testing/gtest_common.h"

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -286,10 +286,13 @@ TEST_P(TestFeather, PrimitiveNullRoundTrip) {
     std::vector<std::shared_ptr<Array>> expected_fields;
     for (int i = 0; i < batch->num_columns(); ++i) {
       ASSERT_EQ(batch->column_name(i), reader_->schema()->field(i)->name());
-      StringArray str_values(batch->column(i)->length(), nullptr, nullptr,
-                             batch->column(i)->null_bitmap(),
-                             batch->column(i)->null_count());
-      AssertArraysEqual(str_values, *result->column(i)->chunk(0));
+      ASSERT_OK_AND_ASSIGN(auto expected, MakeArrayOfNull(utf8(), batch->num_rows()));
+      AssertArraysEqual(*expected, *result->column(i)->chunk(0));
+      //       StringArray str_values(batch->column(i)->length(), nullptr, nullptr,
+      //                              batch->column(i)->null_bitmap(),
+      //                              batch->column(i)->null_count());
+      //       AssertArraysEqual(str_values, *result->column(i)->chunk(0),
+      //       /*verbose=*/true);
     }
   } else {
     AssertTablesEqual(*table, *result);

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -288,11 +288,6 @@ TEST_P(TestFeather, PrimitiveNullRoundTrip) {
       ASSERT_EQ(batch->column_name(i), reader_->schema()->field(i)->name());
       ASSERT_OK_AND_ASSIGN(auto expected, MakeArrayOfNull(utf8(), batch->num_rows()));
       AssertArraysEqual(*expected, *result->column(i)->chunk(0));
-      //       StringArray str_values(batch->column(i)->length(), nullptr, nullptr,
-      //                              batch->column(i)->null_bitmap(),
-      //                              batch->column(i)->null_count());
-      //       AssertArraysEqual(str_values, *result->column(i)->chunk(0),
-      //       /*verbose=*/true);
     }
   } else {
     AssertTablesEqual(*table, *result);

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -283,6 +283,16 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
                                            int32_t min_length, int32_t max_length,
                                            double null_probability = 0);
 
+  /// \brief Generate a random FixedSizeBinaryArray
+  ///
+  /// \param[in] size the size of the array to generate
+  /// \param[in] byte_width the byte width of fixed-size binary items
+  /// \param[in] null_probability the probability of a row being null
+  ///
+  /// \return a generated Array
+  std::shared_ptr<Array> FixedSizeBinary(int64_t size, int32_t byte_width,
+                                         double null_probability = 0);
+
   /// \brief Generate a random ListArray
   ///
   /// \param[in] values The underlying values array
@@ -293,6 +303,25 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \return a generated Array
   std::shared_ptr<Array> List(const Array& values, int64_t size, double null_probability,
                               bool force_empty_nulls = false);
+
+  /// \brief Generate a random SparseUnionArray
+  ///
+  /// The type ids are chosen randomly, according to a uniform distribution,
+  /// amongst the given child fields.
+  ///
+  /// \param[in] fields Vector of Arrays containing the data for each union field
+  /// \param[in] size The size of the generated sparse union array
+  std::shared_ptr<Array> SparseUnion(const ArrayVector& fields, int64_t size);
+
+  /// \brief Generate a random DenseUnionArray
+  ///
+  /// The type ids are chosen randomly, according to a uniform distribution,
+  /// amongst the given child fields.  The offsets are incremented along
+  /// each child field.
+  ///
+  /// \param[in] fields Vector of Arrays containing the data for each union field
+  /// \param[in] size The size of the generated sparse union array
+  std::shared_ptr<Array> DenseUnion(const ArrayVector& fields, int64_t size);
 
   /// \brief Generate a random Array of the specified type, size, and null_probability.
   ///

--- a/cpp/src/arrow/util/bit_run_reader.cc
+++ b/cpp/src/arrow/util/bit_run_reader.cc
@@ -45,7 +45,7 @@ BitRunReader::BitRunReader(const uint8_t* bitmap, int64_t start_offset, int64_t 
 
   // Prepare for inversion in NextRun.
   // Clear out any preceding bits.
-  word_ = word_ & ~BitUtil::LeastSignficantBitMask(position_);
+  word_ = word_ & ~BitUtil::LeastSignificantBitMask(position_);
 }
 
 #endif

--- a/cpp/src/arrow/util/bit_run_reader.h
+++ b/cpp/src/arrow/util/bit_run_reader.h
@@ -40,8 +40,12 @@ struct BitRun {
   }
 };
 
-static inline bool operator==(const BitRun& lhs, const BitRun& rhs) {
+inline bool operator==(const BitRun& lhs, const BitRun& rhs) {
   return lhs.length == rhs.length && lhs.set == rhs.set;
+}
+
+inline bool operator!=(const BitRun& lhs, const BitRun& rhs) {
+  return lhs.length != rhs.length || lhs.set != rhs.set;
 }
 
 class BitRunReaderLinear {
@@ -96,7 +100,7 @@ class ARROW_EXPORT BitRunReader {
     int64_t start_bit_offset = start_position & 63;
     // Invert the word for proper use of CountTrailingZeros and
     // clear bits so CountTrailingZeros can do it magic.
-    word_ = ~word_ & ~BitUtil::LeastSignficantBitMask(start_bit_offset);
+    word_ = ~word_ & ~BitUtil::LeastSignificantBitMask(start_bit_offset);
 
     // Go  forward until the next change from unset to set.
     int64_t new_bits = BitUtil::CountTrailingZeros(word_) - start_bit_offset;
@@ -161,6 +165,8 @@ class ARROW_EXPORT BitRunReader {
 #else
 using BitRunReader = BitRunReaderLinear;
 #endif
+
+// TODO SetBitRunReader?
 
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -141,7 +141,7 @@ constexpr bool IsMultipleOf8(int64_t n) { return (n & 7) == 0; }
 
 // Returns a mask for the bit_index lower order bits.
 // Only valid for bit_index in the range [0, 64).
-constexpr uint64_t LeastSignficantBitMask(int64_t bit_index) {
+constexpr uint64_t LeastSignificantBitMask(int64_t bit_index) {
   return (static_cast<uint64_t>(1) << bit_index) - 1;
 }
 

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -33,6 +33,7 @@
 #include "arrow/array/array_base.h"
 #include "arrow/array/data.h"
 #include "arrow/buffer.h"
+#include "arrow/buffer_builder.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/testing/gtest_common.h"
@@ -84,6 +85,31 @@ void BitmapFromVector(const std::vector<int>& values, int64_t bit_offset,
   ASSERT_OK_AND_ASSIGN(*out_buffer, AllocateEmptyBitmap(length + bit_offset));
   auto writer = internal::BitmapWriter((*out_buffer)->mutable_data(), bit_offset, length);
   WriteVectorToWriter(writer, values);
+}
+
+std::shared_ptr<Buffer> BitmapFromString(const std::string& s) {
+  TypedBufferBuilder<bool> builder;
+  ABORT_NOT_OK(builder.Reserve(s.size()));
+  for (const char c : s) {
+    switch (c) {
+      case '0':
+        builder.UnsafeAppend(false);
+        break;
+      case '1':
+        builder.UnsafeAppend(true);
+        break;
+      case ' ':
+      case '\t':
+      case '\n':
+      case '\r':
+        break;
+      default:
+        ARROW_LOG(FATAL) << "Unexpected character in bitmap string";
+    }
+  }
+  std::shared_ptr<Buffer> buffer;
+  ABORT_NOT_OK(builder.Finish(&buffer));
+  return buffer;
 }
 
 #define ASSERT_READER_SET(reader)    \
@@ -199,6 +225,121 @@ TEST(BitmapReader, DoesNotReadOutOfBounds) {
 
   // Does not access invalid memory
   internal::BitmapReader r3(nullptr, 0, 0);
+}
+
+class TestBitmapUInt64Reader : public ::testing::Test {
+ public:
+  void AssertWords(const Buffer& buffer, int64_t start_offset, int64_t length,
+                   const std::vector<uint64_t>& expected) {
+    internal::BitmapUInt64Reader reader(buffer.data(), start_offset, length);
+    ASSERT_EQ(reader.position(), 0);
+    ASSERT_EQ(reader.length(), length);
+    for (const uint64_t word : expected) {
+      ASSERT_EQ(reader.NextWord(), word);
+    }
+    ASSERT_EQ(reader.position(), length);
+  }
+
+  void Check(const Buffer& buffer, int64_t start_offset, int64_t length) {
+    internal::BitmapUInt64Reader reader(buffer.data(), start_offset, length);
+    for (int64_t i = 0; i < length; i += 64) {
+      ASSERT_EQ(reader.position(), i);
+      const auto nbits = std::min<int64_t>(64, length - i);
+      uint64_t word = reader.NextWord();
+      for (int64_t j = 0; j < nbits; ++j) {
+        ASSERT_EQ(word & 1, BitUtil::GetBit(buffer.data(), start_offset + i + j));
+        word >>= 1;
+      }
+    }
+    ASSERT_EQ(reader.position(), length);
+  }
+
+  void CheckExtensive(const Buffer& buffer) {
+    for (const int64_t offset : kTestOffsets) {
+      for (int64_t length : kTestOffsets) {
+        if (offset + length <= buffer.size()) {
+          Check(buffer, offset, length);
+          length = buffer.size() - offset - length;
+          if (offset + length <= buffer.size()) {
+            Check(buffer, offset, length);
+          }
+        }
+      }
+    }
+  }
+
+ protected:
+  const std::vector<int64_t> kTestOffsets = {0, 1, 6, 7, 8, 33, 62, 63, 64, 65};
+};
+
+TEST_F(TestBitmapUInt64Reader, Empty) {
+  for (const int64_t offset : kTestOffsets) {
+    // Does not access invalid memory
+    internal::BitmapUInt64Reader reader(nullptr, offset, 0);
+    ASSERT_EQ(reader.position(), 0);
+    ASSERT_EQ(reader.length(), 0);
+  }
+}
+
+TEST_F(TestBitmapUInt64Reader, Small) {
+  auto buffer = BitmapFromString(
+      "11111111 10000000 00000000 00000000 00000000 00000000 00000001 11111111"
+      "11111111 10000000 00000000 00000000 00000000 00000000 00000001 11111111"
+      "11111111 10000000 00000000 00000000 00000000 00000000 00000001 11111111"
+      "11111111 10000000 00000000 00000000 00000000 00000000 00000001 11111111");
+
+  // One word
+  AssertWords(*buffer, 0, 9, {0x1ff});
+  AssertWords(*buffer, 1, 9, {0xff});
+  AssertWords(*buffer, 7, 9, {0x3});
+  AssertWords(*buffer, 8, 9, {0x1});
+  AssertWords(*buffer, 9, 9, {0x0});
+
+  AssertWords(*buffer, 54, 10, {0x3fe});
+  AssertWords(*buffer, 54, 9, {0x1fe});
+  AssertWords(*buffer, 54, 8, {0xfe});
+
+  AssertWords(*buffer, 55, 9, {0x1ff});
+  AssertWords(*buffer, 56, 8, {0xff});
+  AssertWords(*buffer, 57, 7, {0x7f});
+  AssertWords(*buffer, 63, 1, {0x1});
+
+  AssertWords(*buffer, 0, 64, {0xff800000000001ffULL});
+
+  // One straddling word
+  AssertWords(*buffer, 54, 12, {0xffe});
+  AssertWords(*buffer, 63, 2, {0x3});
+
+  // One word (start_offset >= 64)
+  AssertWords(*buffer, 96, 64, {0x000001ffff800000ULL});
+
+  // Two words
+  AssertWords(*buffer, 0, 128, {0xff800000000001ffULL, 0xff800000000001ffULL});
+  AssertWords(*buffer, 0, 127, {0xff800000000001ffULL, 0x7f800000000001ffULL});
+  AssertWords(*buffer, 1, 127, {0xffc00000000000ffULL, 0x7fc00000000000ffULL});
+  AssertWords(*buffer, 1, 128, {0xffc00000000000ffULL, 0xffc00000000000ffULL});
+  AssertWords(*buffer, 63, 128, {0xff000000000003ffULL, 0xff000000000003ffULL});
+  AssertWords(*buffer, 63, 65, {0xff000000000003ffULL, 0x1});
+
+  // More than two words
+  AssertWords(*buffer, 0, 256,
+              {0xff800000000001ffULL, 0xff800000000001ffULL, 0xff800000000001ffULL,
+               0xff800000000001ffULL});
+  AssertWords(*buffer, 1, 255,
+              {0xffc00000000000ffULL, 0xffc00000000000ffULL, 0xffc00000000000ffULL,
+               0x7fc00000000000ffULL});
+  AssertWords(*buffer, 63, 193,
+              {0xff000000000003ffULL, 0xff000000000003ffULL, 0xff000000000003ffULL, 0x1});
+  AssertWords(*buffer, 63, 192,
+              {0xff000000000003ffULL, 0xff000000000003ffULL, 0xff000000000003ffULL});
+
+  CheckExtensive(*buffer);
+}
+
+TEST_F(TestBitmapUInt64Reader, Random) {
+  random::RandomArrayGenerator rng(42);
+  auto buffer = rng.NullBitmap(500, 0.5);
+  CheckExtensive(*buffer);
 }
 
 namespace internal {

--- a/cpp/src/arrow/util/bitmap.h
+++ b/cpp/src/arrow/util/bitmap.h
@@ -110,8 +110,8 @@ class ARROW_EXPORT Bitmap : public util::ToStringOstreamable<Bitmap>,
   ///
   /// TODO(bkietz) allow for early termination
   template <size_t N, typename Visitor,
-            typename Word =
-                typename internal::call_traits::argument_type<0, Visitor&&>::value_type>
+            typename Word = typename std::decay<
+                internal::call_traits::argument_type<0, Visitor&&>>::type::value_type>
   static int64_t VisitWords(const Bitmap (&bitmaps_arg)[N], Visitor&& visitor) {
     constexpr int64_t kBitWidth = sizeof(Word) * 8;
 

--- a/cpp/src/arrow/util/bitmap_generate.h
+++ b/cpp/src/arrow/util/bitmap_generate.h
@@ -24,7 +24,6 @@
 #include "arrow/memory_pool.h"
 #include "arrow/result.h"
 #include "arrow/util/bit_util.h"
-#include "arrow/util/bitmap_reader.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -429,6 +429,26 @@ bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right
   return true;
 }
 
+bool OptionalBitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+                          int64_t right_offset, int64_t length) {
+  if (left == nullptr && right == nullptr) {
+    return true;
+  } else if (left != nullptr && right != nullptr) {
+    return BitmapEquals(left, left_offset, right, right_offset, length);
+  } else if (left != nullptr) {
+    return CountSetBits(left, left_offset, length) == length;
+  } else {
+    return CountSetBits(right, right_offset, length) == length;
+  }
+}
+
+bool OptionalBitmapEquals(const std::shared_ptr<Buffer>& left, int64_t left_offset,
+                          const std::shared_ptr<Buffer>& right, int64_t right_offset,
+                          int64_t length) {
+  return OptionalBitmapEquals(left ? left->data() : nullptr, left_offset,
+                              right ? right->data() : nullptr, right_offset, length);
+}
+
 namespace {
 
 template <template <typename> class BitOp>

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -96,6 +96,17 @@ ARROW_EXPORT
 bool BitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                   int64_t right_offset, int64_t length);
 
+// Same as BitmapEquals, but considers a NULL bitmap pointer the same as an
+// all-ones bitmap.
+ARROW_EXPORT
+bool OptionalBitmapEquals(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+                          int64_t right_offset, int64_t length);
+
+ARROW_EXPORT
+bool OptionalBitmapEquals(const std::shared_ptr<Buffer>& left, int64_t left_offset,
+                          const std::shared_ptr<Buffer>& right, int64_t right_offset,
+                          int64_t length);
+
 /// \brief Do a "bitmap and" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
 /// the results in out_buffer starting at the given bit-offset.

--- a/cpp/src/arrow/util/bitmap_reader.h
+++ b/cpp/src/arrow/util/bitmap_reader.h
@@ -69,6 +69,77 @@ class BitmapReader {
   int64_t bit_offset_;
 };
 
+// XXX Cannot name it BitmapWordReader because the name is already used
+// in bitmap_ops.cc
+
+class BitmapUInt64Reader {
+ public:
+  BitmapUInt64Reader(const uint8_t* bitmap, int64_t start_offset, int64_t length)
+      : bitmap_(bitmap + start_offset / 8),
+        num_carry_bits_(8 - start_offset % 8),
+        length_(length),
+        remaining_length_(length_) {
+    if (length_ > 0) {
+      // Load carry bits from the first byte's MSBs
+      if (length_ >= num_carry_bits_) {
+        carry_bits_ =
+            LoadPartialWord(static_cast<int8_t>(8 - num_carry_bits_), num_carry_bits_);
+      } else {
+        carry_bits_ = LoadPartialWord(static_cast<int8_t>(8 - num_carry_bits_), length_);
+      }
+    }
+  }
+
+  uint64_t NextWord() {
+    if (ARROW_PREDICT_TRUE(remaining_length_ >= 64 + num_carry_bits_)) {
+      // We can load a full word
+      uint64_t next_word = LoadFullWord();
+      // Carry bits come first, then the (64 - num_carry_bits_) LSBs from next_word
+      uint64_t word = carry_bits_ | (next_word << num_carry_bits_);
+      carry_bits_ = next_word >> (64 - num_carry_bits_);
+      remaining_length_ -= 64;
+      return word;
+    } else if (remaining_length_ > num_carry_bits_) {
+      // We can load a partial word
+      uint64_t next_word =
+          LoadPartialWord(/*bit_offset=*/0, remaining_length_ - num_carry_bits_);
+      uint64_t word = carry_bits_ | (next_word << num_carry_bits_);
+      carry_bits_ = next_word >> (64 - num_carry_bits_);
+      remaining_length_ = std::max<int64_t>(remaining_length_ - 64, 0);
+      return word;
+    } else {
+      remaining_length_ = 0;
+      return carry_bits_;
+    }
+  }
+
+  int64_t position() const { return length_ - remaining_length_; }
+
+  int64_t length() const { return length_; }
+
+ private:
+  uint64_t LoadFullWord() {
+    uint64_t word;
+    memcpy(&word, bitmap_, 8);
+    bitmap_ += 8;
+    return word;
+  }
+
+  uint64_t LoadPartialWord(int8_t bit_offset, int64_t num_bits) {
+    uint64_t word;
+    const int64_t num_bytes = BitUtil::BytesForBits(num_bits);
+    memcpy(&word, bitmap_, num_bytes);
+    bitmap_ += num_bytes;
+    return (word >> bit_offset) & BitUtil::LeastSignificantBitMask(num_bits);
+  }
+
+  const uint8_t* bitmap_;
+  const int64_t num_carry_bits_;  // in [1, 8]
+  const int64_t length_;
+  int64_t remaining_length_;
+  uint64_t carry_bits_;
+};
+
 /// \brief Index into a possibly non-existent bitmap
 struct OptionalBitIndexer {
   const uint8_t* bitmap;

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -226,7 +226,7 @@ static void AppendLittleEndianArrayToString(const std::array<uint64_t, n>& array
       // *elem = dividend / 1e9;
       // remainder = dividend % 1e9.
       uint32_t hi = static_cast<uint32_t>(*elem >> 32);
-      uint32_t lo = static_cast<uint32_t>(*elem & BitUtil::LeastSignficantBitMask(32));
+      uint32_t lo = static_cast<uint32_t>(*elem & BitUtil::LeastSignificantBitMask(32));
       uint64_t dividend_hi = (static_cast<uint64_t>(remainder) << 32) | hi;
       uint64_t quotient_hi = dividend_hi / k1e9;
       remainder = static_cast<uint32_t>(dividend_hi % k1e9);


### PR DESCRIPTION
ArrayEquals now defers to ArrayRangeEquals under the hood.
ArrayRangeEquals now allows passing an EqualOptions argument.
Also add ArrayRangeApproxEquals.

Comparison speed is massively improved on many input types:
```
                                      benchmark            baseline           contender   change %                                                                                                                                                                               counters
26               ArrayRangeEqualsStruct/32768/0    6.338m items/sec  797.926m items/sec  12490.248                 {'run_name': 'ArrayRangeEqualsStruct/32768/0', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 135, 'null_percent': 0.0}
16              ArrayRangeEqualsBoolean/32768/0  839.237m items/sec   51.203b items/sec   6001.168              {'run_name': 'ArrayRangeEqualsBoolean/32768/0', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 17929, 'null_percent': 0.0}
28      ArrayRangeEqualsFixedSizeBinary/32768/0  369.542m items/sec   14.798b items/sec   3904.348       {'run_name': 'ArrayRangeEqualsFixedSizeBinary/32768/0', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 8130, 'null_percent': 0.0}
24           ArrayRangeEqualsStruct/32768/10000    6.251m items/sec  240.453m items/sec   3746.338            {'run_name': 'ArrayRangeEqualsStruct/32768/10000', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 134, 'null_percent': 0.01}
36               ArrayRangeEqualsStruct/32768/1  412.074m items/sec   13.733b items/sec   3232.616              {'run_name': 'ArrayRangeEqualsStruct/32768/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 8817, 'null_percent': 100.0}
9                ArrayRangeEqualsString/32768/0   67.419m items/sec    1.937b items/sec   2772.931                {'run_name': 'ArrayRangeEqualsString/32768/0', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1441, 'null_percent': 0.0}
25          ArrayRangeEqualsListOfInt32/32768/1  524.231m items/sec   13.774b items/sec   2527.447        {'run_name': 'ArrayRangeEqualsListOfInt32/32768/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 11179, 'null_percent': 100.0}
44               ArrayRangeEqualsString/32768/1  577.902m items/sec   13.686b items/sec   2268.185             {'run_name': 'ArrayRangeEqualsString/32768/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 12328, 'null_percent': 100.0}
53      ArrayRangeEqualsFixedSizeBinary/32768/1  596.284m items/sec   13.140b items/sec   2103.587    {'run_name': 'ArrayRangeEqualsFixedSizeBinary/32768/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 12703, 'null_percent': 100.0}
11           ArrayRangeEqualsString/32768/10000   67.501m items/sec    1.382b items/sec   1947.876           {'run_name': 'ArrayRangeEqualsString/32768/10000', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1442, 'null_percent': 0.01}
46          ArrayRangeEqualsListOfInt32/32768/0   42.696m items/sec  833.958m items/sec   1853.229            {'run_name': 'ArrayRangeEqualsListOfInt32/32768/0', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 911, 'null_percent': 0.0}
14              ArrayRangeEqualsBoolean/32768/1  698.866m items/sec   13.374b items/sec   1813.652            {'run_name': 'ArrayRangeEqualsBoolean/32768/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 14929, 'null_percent': 100.0}
38                ArrayRangeEqualsInt32/32768/1  835.824m items/sec   13.688b items/sec   1537.720              {'run_name': 'ArrayRangeEqualsInt32/32768/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 17818, 'null_percent': 100.0}
29  ArrayRangeEqualsFixedSizeBinary/32768/10000  278.025m items/sec    4.375b items/sec   1473.475  {'run_name': 'ArrayRangeEqualsFixedSizeBinary/32768/10000', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 5937, 'null_percent': 0.01}
17                ArrayRangeEqualsInt32/32768/0    2.104b items/sec   32.033b items/sec   1422.785                {'run_name': 'ArrayRangeEqualsInt32/32768/0', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 44741, 'null_percent': 0.0}
18              ArrayRangeEqualsFloat32/32768/1  838.934m items/sec   12.432b items/sec   1381.896            {'run_name': 'ArrayRangeEqualsFloat32/32768/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 17895, 'null_percent': 100.0}
19            ArrayRangeEqualsInt32/32768/10000  757.797m items/sec    6.848b items/sec    803.693           {'run_name': 'ArrayRangeEqualsInt32/32768/10000', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 16177, 'null_percent': 0.01}
15      ArrayRangeEqualsListOfInt32/32768/10000   28.438m items/sec  210.226m items/sec    639.253       {'run_name': 'ArrayRangeEqualsListOfInt32/32768/10000', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 606, 'null_percent': 0.01}
39          ArrayRangeEqualsFloat32/32768/10000  694.965m items/sec    4.706b items/sec    577.178         {'run_name': 'ArrayRangeEqualsFloat32/32768/10000', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 14833, 'null_percent': 0.01}
3           ArrayRangeEqualsBoolean/32768/10000  538.353m items/sec    2.968b items/sec    451.394         {'run_name': 'ArrayRangeEqualsBoolean/32768/10000', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 11475, 'null_percent': 0.01}
41              ArrayRangeEqualsFloat32/32768/0    2.036b items/sec   10.235b items/sec    402.761              {'run_name': 'ArrayRangeEqualsFloat32/32768/0', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 43978, 'null_percent': 0.0}
23             ArrayRangeEqualsStruct/32768/100    6.298m items/sec   26.042m items/sec    313.515               {'run_name': 'ArrayRangeEqualsStruct/32768/100', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 133, 'null_percent': 1.0}
1              ArrayRangeEqualsString/32768/100   68.074m items/sec  275.727m items/sec    305.039              {'run_name': 'ArrayRangeEqualsString/32768/100', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1453, 'null_percent': 1.0}
42          ArrayRangeEqualsSparseUnion/32768/0   12.649m items/sec   38.360m items/sec    203.256            {'run_name': 'ArrayRangeEqualsSparseUnion/32768/0', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 274, 'null_percent': 0.0}
45           ArrayRangeEqualsDenseUnion/32768/0   12.995m items/sec   38.503m items/sec    196.287             {'run_name': 'ArrayRangeEqualsDenseUnion/32768/0', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 277, 'null_percent': 0.0}
7     ArrayRangeEqualsFixedSizeBinary/32768/100  274.991m items/sec  633.253m items/sec    130.281     {'run_name': 'ArrayRangeEqualsFixedSizeBinary/32768/100', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 5864, 'null_percent': 1.0}
13              ArrayRangeEqualsInt32/32768/100  729.634m items/sec    1.644b items/sec    125.256              {'run_name': 'ArrayRangeEqualsInt32/32768/100', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 15582, 'null_percent': 1.0}
12              ArrayRangeEqualsStruct/32768/10    6.948m items/sec   14.273m items/sec    105.427               {'run_name': 'ArrayRangeEqualsStruct/32768/10', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 147, 'null_percent': 10.0}
34               ArrayRangeEqualsStruct/32768/2   11.923m items/sec   23.845m items/sec     99.993                {'run_name': 'ArrayRangeEqualsStruct/32768/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 255, 'null_percent': 50.0}
10              ArrayRangeEqualsString/32768/10   73.461m items/sec  146.598m items/sec     99.558              {'run_name': 'ArrayRangeEqualsString/32768/10', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 1568, 'null_percent': 10.0}
48            ArrayRangeEqualsBoolean/32768/100  525.635m items/sec    1.026b items/sec     95.102            {'run_name': 'ArrayRangeEqualsBoolean/32768/100', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 11216, 'null_percent': 1.0}
21          ArrayRangeEqualsSparseUnion/32768/1   14.032m items/sec   26.225m items/sec     86.889          {'run_name': 'ArrayRangeEqualsSparseUnion/32768/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 300, 'null_percent': 100.0}
47          ArrayRangeEqualsSparseUnion/32768/2   12.643m items/sec   23.030m items/sec     82.160           {'run_name': 'ArrayRangeEqualsSparseUnion/32768/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 272, 'null_percent': 50.0}
43      ArrayRangeEqualsSparseUnion/32768/10000   12.596m items/sec   22.801m items/sec     81.018       {'run_name': 'ArrayRangeEqualsSparseUnion/32768/10000', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 264, 'null_percent': 0.01}
52         ArrayRangeEqualsSparseUnion/32768/10   12.717m items/sec   22.911m items/sec     80.168          {'run_name': 'ArrayRangeEqualsSparseUnion/32768/10', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 272, 'null_percent': 10.0}
0         ArrayRangeEqualsSparseUnion/32768/100   12.783m items/sec   22.714m items/sec     77.694          {'run_name': 'ArrayRangeEqualsSparseUnion/32768/100', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 275, 'null_percent': 1.0}
31           ArrayRangeEqualsDenseUnion/32768/1   14.509m items/sec   25.576m items/sec     76.279           {'run_name': 'ArrayRangeEqualsDenseUnion/32768/1', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 309, 'null_percent': 100.0}
20       ArrayRangeEqualsDenseUnion/32768/10000   13.193m items/sec   22.447m items/sec     70.152        {'run_name': 'ArrayRangeEqualsDenseUnion/32768/10000', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 280, 'null_percent': 0.01}
35         ArrayRangeEqualsDenseUnion/32768/100   13.204m items/sec   22.256m items/sec     68.561           {'run_name': 'ArrayRangeEqualsDenseUnion/32768/100', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 282, 'null_percent': 1.0}
40          ArrayRangeEqualsDenseUnion/32768/10   13.183m items/sec   22.191m items/sec     68.338           {'run_name': 'ArrayRangeEqualsDenseUnion/32768/10', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 279, 'null_percent': 10.0}
4            ArrayRangeEqualsDenseUnion/32768/2   13.148m items/sec   21.996m items/sec     67.297            {'run_name': 'ArrayRangeEqualsDenseUnion/32768/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 280, 'null_percent': 50.0}
22            ArrayRangeEqualsFloat32/32768/100  671.171m items/sec    1.097b items/sec     63.414            {'run_name': 'ArrayRangeEqualsFloat32/32768/100', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 14325, 'null_percent': 1.0}
30               ArrayRangeEqualsString/32768/2   94.060m items/sec  149.539m items/sec     58.983               {'run_name': 'ArrayRangeEqualsString/32768/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 2008, 'null_percent': 50.0}
37     ArrayRangeEqualsFixedSizeBinary/32768/10  250.975m items/sec  305.864m items/sec     21.870     {'run_name': 'ArrayRangeEqualsFixedSizeBinary/32768/10', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 5341, 'null_percent': 10.0}
32               ArrayRangeEqualsInt32/32768/10  607.891m items/sec  676.139m items/sec     11.227              {'run_name': 'ArrayRangeEqualsInt32/32768/10', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 12895, 'null_percent': 10.0}
8       ArrayRangeEqualsFixedSizeBinary/32768/2  187.404m items/sec  207.700m items/sec     10.830      {'run_name': 'ArrayRangeEqualsFixedSizeBinary/32768/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 3971, 'null_percent': 50.0}
49             ArrayRangeEqualsBoolean/32768/10  468.989m items/sec  518.521m items/sec     10.561             {'run_name': 'ArrayRangeEqualsBoolean/32768/10', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 9996, 'null_percent': 10.0}
5                 ArrayRangeEqualsInt32/32768/2  259.891m items/sec  270.547m items/sec      4.100                {'run_name': 'ArrayRangeEqualsInt32/32768/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 5505, 'null_percent': 50.0}
33              ArrayRangeEqualsFloat32/32768/2  262.994m items/sec  268.155m items/sec      1.962              {'run_name': 'ArrayRangeEqualsFloat32/32768/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 5580, 'null_percent': 50.0}
50             ArrayRangeEqualsFloat32/32768/10  577.200m items/sec  573.157m items/sec     -0.701            {'run_name': 'ArrayRangeEqualsFloat32/32768/10', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 12270, 'null_percent': 10.0}
2               ArrayRangeEqualsBoolean/32768/2  242.498m items/sec  230.947m items/sec     -4.763              {'run_name': 'ArrayRangeEqualsBoolean/32768/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 5152, 'null_percent': 50.0}
27        ArrayRangeEqualsListOfInt32/32768/100   28.080m items/sec   25.874m items/sec     -7.855          {'run_name': 'ArrayRangeEqualsListOfInt32/32768/100', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 598, 'null_percent': 1.0}
51          ArrayRangeEqualsListOfInt32/32768/2   18.613m items/sec   12.136m items/sec    -34.798           {'run_name': 'ArrayRangeEqualsListOfInt32/32768/2', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 397, 'null_percent': 50.0}
6          ArrayRangeEqualsListOfInt32/32768/10   26.194m items/sec   12.610m items/sec    -51.859          {'run_name': 'ArrayRangeEqualsListOfInt32/32768/10', 'run_type': 'iteration', 'repetitions': 0, 'repetition_index': 0, 'threads': 1, 'iterations': 560, 'null_percent': 10.0}
```