### PR TITLE
ARROW-10646: [C++][FlightRPC] Disable flaky Flight test on Windows

### DIFF
--- a/cpp/src/arrow/flight/flight_test.cc
+++ b/cpp/src/arrow/flight/flight_test.cc
@@ -1700,7 +1700,11 @@ TEST_F(TestAuthHandler, CheckPeerIdentity) {
   ASSERT_OK(results->Next(&result));
   ASSERT_NE(result, nullptr);
   // Action returns the peer address as the result.
+#ifndef _WIN32
+  // On Windows gRPC sometimes returns a blank peer address, so don't
+  // bother checking for it.
   ASSERT_NE(result->body->ToString(), "");
+#endif
 }
 
 TEST_F(TestBasicAuthHandler, PassAuthenticatedCalls) {


### PR DESCRIPTION
On Windows, gRPC sometimes gives us a blank peer address.