### PR TITLE
ARROW-10649: [Rust] Parse manually in infer_field_schema, remove lazy static dependency

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -44,7 +44,6 @@ rand = "0.7"
 csv = "1.1"
 num = "0.3"
 regex = "1.3"
-lazy_static = "1.4"
 packed_simd = { version = "0.3.4", optional = true, package = "packed_simd_2" }
 chrono = "0.4"
 flatbuffers = "0.6"

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -75,11 +75,16 @@ fn infer_field_schema(string: &str) -> DataType {
         return DataType::Boolean;
     }
     let skip_minus = if string.starts_with('-') { 1 } else { 0 };
-    let mut parts = string[skip_minus..].split('.');
+    let mut parts = string[skip_minus..].splitn(3, '.');
     let (left, right) = (parts.next(), parts.next());
     let left_is_number = left.map_or(false, all_digit);
     if left_is_number && right.map_or(false, all_digit) {
-        return DataType::Float64;
+        let no_remainder = parts.next().is_none();
+        if no_remainder {
+            return DataType::Float64;
+        } else {
+            return DataType::Utf8;
+        }
     } else if left_is_number {
         return DataType::Int64;
     }

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -77,18 +77,19 @@ fn infer_field_schema(string: &str) -> DataType {
     let skip_minus = if string.starts_with('-') { 1 } else { 0 };
     let mut parts = string[skip_minus..].splitn(3, '.');
     let (left, right) = (parts.next(), parts.next());
-    let left_is_number = left.map_or(false, all_digit);
-    if left_is_number && right.map_or(false, all_digit) {
-        let no_remainder = parts.next().is_none();
-        if no_remainder {
-            return DataType::Float64;
-        } else {
-            return DataType::Utf8;
+
+    match (left, right) {
+        (Some(l), None) if all_digit(l) => DataType::Int64,
+        (Some(l), Some(r)) if all_digit(l) && all_digit(r) => {
+            let no_remainder = parts.next().is_none();
+            if no_remainder {
+                return DataType::Float64;
+            } else {
+                return DataType::Utf8;
+            }
         }
-    } else if left_is_number {
-        return DataType::Int64;
+        _ => DataType::Utf8,
     }
-    DataType::Utf8
 }
 
 /// Infer the schema of a CSV file by reading through the first n records of the file,

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -70,8 +70,7 @@ fn infer_field_schema(string: &str) -> DataType {
         return DataType::Utf8;
     }
     // match regex in a particular order
-    let lower = string.to_ascii_lowercase();
-    if lower == "true" || lower == "false" {
+    if string.eq_ignore_ascii_case("true") || string.eq_ignore_ascii_case("false") {
         return DataType::Boolean;
     }
     let skip_minus = if string.starts_with('-') { 1 } else { 0 };

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -76,11 +76,10 @@ fn infer_field_schema(string: &str) -> DataType {
     }
     let skip_minus = if string.starts_with('-') { 1 } else { 0 };
     let mut parts = string[skip_minus..].splitn(3, '.');
-    let (left, right) = (parts.next(), parts.next());
 
-    match (left, right) {
-        (Some(l), None) if all_digit(l) => DataType::Int64,
-        (Some(l), Some(r)) if all_digit(l) && all_digit(r) => {
+    match (parts.next(), parts.next()) {
+        (Some(left), None) if all_digit(left) => DataType::Int64,
+        (Some(left), Some(right)) if all_digit(left) && all_digit(right) => {
             let no_remainder = parts.next().is_none();
             if no_remainder {
                 return DataType::Float64;

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -81,9 +81,9 @@ fn infer_field_schema(string: &str) -> DataType {
         (Some(left), Some(right)) if all_digit(left) && all_digit(right) => {
             let no_remainder = parts.next().is_none();
             if no_remainder {
-                return DataType::Float64;
+                DataType::Float64
             } else {
-                return DataType::Utf8;
+                DataType::Utf8
             }
         }
         _ => DataType::Utf8,


### PR DESCRIPTION
Changes infer_field_schema to parse manually.

lazy_static is no longer needed as (direct) dependency.

Probably could be a bit faster as well.