### PR TITLE
ARROW-10652: [C++][Gandiva] Make gandiva cache size configurable

### DIFF
--- a/cpp/src/gandiva/CMakeLists.txt
+++ b/cpp/src/gandiva/CMakeLists.txt
@@ -52,6 +52,7 @@ set_source_files_properties(${GANDIVA_PRECOMPILED_CC_PATH} PROPERTIES GENERATED 
 set(SRC_FILES
     annotator.cc
     bitmap_accumulator.cc
+    cache.cc
     cast_time.cc
     configuration.cc
     context_helper.cc

--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -1,0 +1,44 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/logging.h"
+#include "gandiva/cache.h"
+
+namespace gandiva {
+
+static const int DEFAULT_CACHE_SIZE = 500;
+
+int GetCapacity() {
+  int capacity;
+  const char* env_cache_size = std::getenv("GANDIVA_CACHE_SIZE");
+  if (env_cache_size != nullptr) {
+    capacity = std::atoi(env_cache_size);
+    if (capacity <= 0) {
+      ARROW_LOG(WARNING) << "Invalid cache size provided. Using default cache size: " << DEFAULT_CACHE_SIZE;
+      capacity = DEFAULT_CACHE_SIZE;
+    }
+  } else {
+    capacity = DEFAULT_CACHE_SIZE;
+  }
+  return capacity;
+}
+
+void LogCacheSize(size_t capacity) {
+  ARROW_LOG(INFO) << "Creating gandiva cache with capacity: " << capacity;
+}
+
+}  // namespace gandiva

--- a/cpp/src/gandiva/cache.cc
+++ b/cpp/src/gandiva/cache.cc
@@ -15,8 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/util/logging.h"
 #include "gandiva/cache.h"
+#include "arrow/util/logging.h"
 
 namespace gandiva {
 
@@ -28,7 +28,8 @@ int GetCapacity() {
   if (env_cache_size != nullptr) {
     capacity = std::atoi(env_cache_size);
     if (capacity <= 0) {
-      ARROW_LOG(WARNING) << "Invalid cache size provided. Using default cache size: " << DEFAULT_CACHE_SIZE;
+      ARROW_LOG(WARNING) << "Invalid cache size provided. Using default cache size: "
+                         << DEFAULT_CACHE_SIZE;
       capacity = DEFAULT_CACHE_SIZE;
     }
   } else {

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <cstdlib>
+#include <iostream>
 #include <mutex>
 
 #include "gandiva/lru_cache.h"
@@ -26,7 +28,12 @@ namespace gandiva {
 template <class KeyType, typename ValueType>
 class Cache {
  public:
-  explicit Cache(size_t capacity = CACHE_SIZE) : cache_(capacity) {}
+  explicit Cache(size_t capacity) : cache_(capacity) {
+    std::cout << "Creating gandiva cache with capacity: " << capacity << std::endl;
+  }
+
+  Cache() : Cache(GetCapacity()) {}
+
   ValueType GetModule(KeyType cache_key) {
     arrow::util::optional<ValueType> result;
     mtx_.lock();
@@ -42,8 +49,24 @@ class Cache {
   }
 
  private:
+  static int GetCapacity() {
+    int capacity;
+    const char* env_cache_size = std::getenv("GANDIVA_CACHE_SIZE");
+    if (env_cache_size != nullptr) {
+      capacity = std::atoi(env_cache_size);
+      if (capacity <= 0) {
+        std::cout << "Invalid cache size provided. Using default cache size."
+                  << std::endl;
+        capacity = DEFAULT_CACHE_SIZE;
+      }
+    } else {
+      capacity = DEFAULT_CACHE_SIZE;
+    }
+    return capacity;
+  }
+
   LruCache<KeyType, ValueType> cache_;
-  static const int CACHE_SIZE = 250;
+  static const int DEFAULT_CACHE_SIZE = 500;
   std::mutex mtx_;
 };
 }  // namespace gandiva

--- a/cpp/src/gandiva/cache.h
+++ b/cpp/src/gandiva/cache.h
@@ -18,19 +18,23 @@
 #pragma once
 
 #include <cstdlib>
-#include <iostream>
 #include <mutex>
 
 #include "gandiva/lru_cache.h"
+#include "gandiva/visibility.h"
 
 namespace gandiva {
+
+GANDIVA_EXPORT
+int GetCapacity();
+
+GANDIVA_EXPORT
+void LogCacheSize(size_t capacity);
 
 template <class KeyType, typename ValueType>
 class Cache {
  public:
-  explicit Cache(size_t capacity) : cache_(capacity) {
-    std::cout << "Creating gandiva cache with capacity: " << capacity << std::endl;
-  }
+  explicit Cache(size_t capacity) : cache_(capacity) { LogCacheSize(capacity); }
 
   Cache() : Cache(GetCapacity()) {}
 
@@ -49,24 +53,7 @@ class Cache {
   }
 
  private:
-  static int GetCapacity() {
-    int capacity;
-    const char* env_cache_size = std::getenv("GANDIVA_CACHE_SIZE");
-    if (env_cache_size != nullptr) {
-      capacity = std::atoi(env_cache_size);
-      if (capacity <= 0) {
-        std::cout << "Invalid cache size provided. Using default cache size."
-                  << std::endl;
-        capacity = DEFAULT_CACHE_SIZE;
-      }
-    } else {
-      capacity = DEFAULT_CACHE_SIZE;
-    }
-    return capacity;
-  }
-
   LruCache<KeyType, ValueType> cache_;
-  static const int DEFAULT_CACHE_SIZE = 500;
   std::mutex mtx_;
 };
 }  // namespace gandiva


### PR DESCRIPTION
Configure the cache size using an environment variable GANDIVA_CACHE_SIZE. Default size is changed to 500.