### PR TITLE
ARROW-10651: [C++] Fix alloc-dealloc-mismatch in S3-related factory

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -608,7 +608,7 @@ class StringViewStream : Aws::Utils::Stream::PreallocatedStreamBuf, public std::
 // See https://github.com/aws/aws-sdk-cpp/issues/64 for an alternative but
 // functionally similar recipe.
 Aws::IOStreamFactory AwsWriteableStreamFactory(void* data, int64_t nbytes) {
-  return [=]() { return new StringViewStream(data, nbytes); };
+  return [=]() { return Aws::New<StringViewStream>("", data, nbytes); };
 }
 
 Result<S3Model::GetObjectResult> GetObjectRange(Aws::S3::S3Client* client,


### PR DESCRIPTION
aws-sdk-cpp requires to use matched Aws::New and Aws::Delete. Since the
AwsWriteableStreamFactory provides an Aws::IOStreamFactory object that
would be called inside aws-sdk-cpp, it is supposed to use an Aws::New
instead of the native cpp new operator.