### PR TITLE
ARROW-10654: [Rust] Specialize parsing of floats / bools in CSV Reader

### DIFF
--- a/rust/arrow/Cargo.toml
+++ b/rust/arrow/Cargo.toml
@@ -50,6 +50,7 @@ chrono = "0.4"
 flatbuffers = "0.6"
 hex = "0.4"
 prettytable-rs = { version = "0.8.0", optional = true }
+lexical-core = "^0.7"
 
 [features]
 default = []

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -229,7 +229,8 @@ pub struct Reader<R: Read> {
     /// Optional projection for which columns to load (zero-based column indices)
     projection: Option<Vec<usize>>,
     /// File reader
-    record_iter: Buffered<Skip<Take<StringRecordsIntoIter<BufReader<R>>>>, StringRecord, Error>,
+    record_iter:
+        Buffered<Skip<Take<StringRecordsIntoIter<BufReader<R>>>>, StringRecord, Error>,
     /// Current line number
     line_number: usize,
 }
@@ -404,17 +405,39 @@ fn parse(
             let i = *i;
             let field = &fields[i];
             match field.data_type() {
-                &DataType::Boolean => build_primitive_array::<BooleanType>(line_number, rows, i),
-                &DataType::Int8 => build_primitive_array::<Int8Type>(line_number, rows, i),
-                &DataType::Int16 => build_primitive_array::<Int16Type>(line_number, rows, i),
-                &DataType::Int32 => build_primitive_array::<Int32Type>(line_number, rows, i),
-                &DataType::Int64 => build_primitive_array::<Int64Type>(line_number, rows, i),
-                &DataType::UInt8 => build_primitive_array::<UInt8Type>(line_number, rows, i),
-                &DataType::UInt16 => build_primitive_array::<UInt16Type>(line_number, rows, i),
-                &DataType::UInt32 => build_primitive_array::<UInt32Type>(line_number, rows, i),
-                &DataType::UInt64 => build_primitive_array::<UInt64Type>(line_number, rows, i),
-                &DataType::Float32 => build_primitive_array::<Float32Type>(line_number, rows, i),
-                &DataType::Float64 => build_primitive_array::<Float64Type>(line_number, rows, i),
+                &DataType::Boolean => {
+                    build_primitive_array::<BooleanType>(line_number, rows, i)
+                }
+                &DataType::Int8 => {
+                    build_primitive_array::<Int8Type>(line_number, rows, i)
+                }
+                &DataType::Int16 => {
+                    build_primitive_array::<Int16Type>(line_number, rows, i)
+                }
+                &DataType::Int32 => {
+                    build_primitive_array::<Int32Type>(line_number, rows, i)
+                }
+                &DataType::Int64 => {
+                    build_primitive_array::<Int64Type>(line_number, rows, i)
+                }
+                &DataType::UInt8 => {
+                    build_primitive_array::<UInt8Type>(line_number, rows, i)
+                }
+                &DataType::UInt16 => {
+                    build_primitive_array::<UInt16Type>(line_number, rows, i)
+                }
+                &DataType::UInt32 => {
+                    build_primitive_array::<UInt32Type>(line_number, rows, i)
+                }
+                &DataType::UInt64 => {
+                    build_primitive_array::<UInt64Type>(line_number, rows, i)
+                }
+                &DataType::Float32 => {
+                    build_primitive_array::<Float32Type>(line_number, rows, i)
+                }
+                &DataType::Float64 => {
+                    build_primitive_array::<Float64Type>(line_number, rows, i)
+                }
                 &DataType::Utf8 => {
                     let mut builder = StringBuilder::new(rows.len());
                     for row in rows.iter() {
@@ -433,7 +456,8 @@ fn parse(
         })
         .collect();
 
-    let projected_fields: Vec<Field> = projection.iter().map(|i| fields[*i].clone()).collect();
+    let projected_fields: Vec<Field> =
+        projection.iter().map(|i| fields[*i].clone()).collect();
 
     let projected_schema = Arc::new(Schema::new(projected_fields));
 
@@ -705,7 +729,8 @@ mod tests {
             Field::new("lng", DataType::Float64, false),
         ]);
 
-        let file_with_headers = File::open("test/data/uk_cities_with_headers.csv").unwrap();
+        let file_with_headers =
+            File::open("test/data/uk_cities_with_headers.csv").unwrap();
         let file_without_headers = File::open("test/data/uk_cities.csv").unwrap();
         let both_files = file_with_headers
             .chain(Cursor::new("\n".to_string()))

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -369,24 +369,6 @@ impl<R: Read> Iterator for Reader<R> {
     }
 }
 
-trait Parser: ArrowPrimitiveType {
-    fn parse(string: &str) -> Option<Self::Native> {
-        string.parse::<Self::Native>().ok()
-    }
-}
-
-impl Parser for BooleanType {
-    fn parse(string: &str) -> Option<bool> {
-        if string.eq_ignore_ascii_case("false") {
-            return Some(false);
-        }
-        if string.eq_ignore_ascii_case("true") {
-            return Some(true);
-        }
-        None
-    }
-}
-
 /// parses a slice of [csv_crate::StringRecord] into a [array::record_batch::RecordBatch].
 fn parse(
     rows: &[StringRecord],
@@ -462,6 +444,24 @@ fn parse(
     let projected_schema = Arc::new(Schema::new(projected_fields));
 
     arrays.and_then(|arr| RecordBatch::try_new(projected_schema, arr))
+}
+
+trait Parser: ArrowPrimitiveType {
+    fn parse(string: &str) -> Option<Self::Native> {
+        string.parse::<Self::Native>().ok()
+    }
+}
+
+impl Parser for BooleanType {
+    fn parse(string: &str) -> Option<bool> {
+        if string.eq_ignore_ascii_case("false") {
+            return Some(false);
+        }
+        if string.eq_ignore_ascii_case("true") {
+            return Some(true);
+        }
+        None
+    }
 }
 
 impl Parser for Float32Type {

--- a/rust/arrow/src/csv/reader.rs
+++ b/rust/arrow/src/csv/reader.rs
@@ -454,11 +454,11 @@ trait Parser: ArrowPrimitiveType {
 
 impl Parser for BooleanType {
     fn parse(string: &str) -> Option<bool> {
-        if string.eq_ignore_ascii_case("false") {
-            return Some(false);
-        }
-        if string.eq_ignore_ascii_case("true") {
+        if string == "false" || string == "FALSE" || string == "False" {
             return Some(true);
+        }
+        if string == "true" || string == "TRUE" || string == "True" {
+            return Some(false);
         }
         None
     }


### PR DESCRIPTION
Internal rust float parser is known to be slow.

This change allows to have specialized implementations rather than relying on FromStr::parse.

Also avoids calling `to_lowercase` for booleans.

Would be nice to benchmark this.