### PR TITLE
ARROW-10660: [Rust] Implement AVX-512 bit or operation

### DIFF
--- a/rust/arrow/benches/buffer_bit_ops.rs
+++ b/rust/arrow/benches/buffer_bit_ops.rs
@@ -28,7 +28,7 @@ fn create_buffer(size: usize) -> Buffer {
     let mut result = MutableBuffer::new(size).with_bitset(size, false);
 
     for i in 0..size {
-        result.data_mut()[i] = 0b01010101;
+        result.data_mut()[i] = 0b01010101 << i << (i % 4);
     }
 
     result.freeze()
@@ -38,11 +38,20 @@ fn bench_buffer_and(left: &Buffer, right: &Buffer) {
     criterion::black_box((left & right).unwrap());
 }
 
+fn bench_buffer_or(left: &Buffer, right: &Buffer) {
+    criterion::black_box((left | right).unwrap());
+}
+
 fn bit_ops_benchmark(c: &mut Criterion) {
     let left = create_buffer(512 * 10);
     let right = create_buffer(512 * 10);
+
     c.bench_function("buffer_bit_ops and", |b| {
         b.iter(|| bench_buffer_and(&left, &right))
+    });
+
+    c.bench_function("buffer_bit_ops or", |b| {
+        b.iter(|| bench_buffer_or(&left, &right))
     });
 }
 

--- a/rust/arrow/src/arch/avx512.rs
+++ b/rust/arrow/src/arch/avx512.rs
@@ -1,0 +1,73 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+pub(crate) const AVX512_U8X64_LANES: usize = 64;
+
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn avx512_bin_and(left: &[u8], right: &[u8], res: &mut [u8]) {
+    use core::arch::x86_64::{__m512i, _mm512_and_si512, _mm512_loadu_epi64};
+
+    let l: __m512i = _mm512_loadu_epi64(left.as_ptr() as *const _);
+    let r: __m512i = _mm512_loadu_epi64(right.as_ptr() as *const _);
+    let f = _mm512_and_si512(l, r);
+    let s = &f as *const __m512i as *const u8;
+    let d = res.get_unchecked_mut(0) as *mut _ as *mut u8;
+    std::ptr::copy_nonoverlapping(s, d, std::mem::size_of::<__m512i>());
+}
+
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn avx512_bin_or(left: &[u8], right: &[u8], res: &mut [u8]) {
+    use core::arch::x86_64::{__m512i, _mm512_loadu_epi64, _mm512_or_si512};
+
+    let l: __m512i = _mm512_loadu_epi64(left.as_ptr() as *const _);
+    let r: __m512i = _mm512_loadu_epi64(right.as_ptr() as *const _);
+    let f = _mm512_or_si512(l, r);
+    let s = &f as *const __m512i as *const u8;
+    let d = res.get_unchecked_mut(0) as *mut _ as *mut u8;
+    std::ptr::copy_nonoverlapping(s, d, std::mem::size_of::<__m512i>());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bitwise_and_avx512() {
+        let buf1 = [0b00110011u8; 64];
+        let buf2 = [0b11110000u8; 64];
+        let mut buf3 = [0b00000000; 64];
+        unsafe {
+            avx512_bin_and(&buf1, &buf2, &mut buf3);
+        };
+        for i in buf3.iter() {
+            assert_eq!(&0b00110000u8, i);
+        }
+    }
+
+    #[test]
+    fn test_bitwise_or_avx512() {
+        let buf1 = [0b00010011u8; 64];
+        let buf2 = [0b11100000u8; 64];
+        let mut buf3 = [0b00000000; 64];
+        unsafe {
+            avx512_bin_or(&buf1, &buf2, &mut buf3);
+        };
+        for i in buf3.iter() {
+            assert_eq!(&0b11110011u8, i);
+        }
+    }
+}

--- a/rust/arrow/src/arch/mod.rs
+++ b/rust/arrow/src/arch/mod.rs
@@ -1,0 +1,22 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+///
+/// Arch module contains architecture specific code.
+/// Be aware that not all machines have these specific operations available.
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
+pub(crate) mod avx512;

--- a/rust/arrow/src/buffer.rs
+++ b/rust/arrow/src/buffer.rs
@@ -30,6 +30,8 @@ use std::ptr::NonNull;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::sync::Arc;
 
+#[cfg(feature = "avx512")]
+use crate::arch::avx512::*;
 use crate::datatypes::ArrowNativeType;
 use crate::error::{ArrowError, Result};
 use crate::memory;
@@ -474,22 +476,6 @@ where
 }
 
 #[cfg(all(target_arch = "x86_64", feature = "avx512"))]
-const AVX512_U8X64_LANES: usize = 64;
-
-#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
-#[target_feature(enable = "avx512f")]
-pub(super) unsafe fn avx512_bin_and(left: &[u8], right: &[u8], res: &mut [u8]) {
-    use core::arch::x86_64::{__m512i, _mm512_and_si512, _mm512_loadu_ps};
-
-    let l: __m512i = std::mem::transmute(_mm512_loadu_ps(left.as_ptr() as *const _));
-    let r: __m512i = std::mem::transmute(_mm512_loadu_ps(right.as_ptr() as *const _));
-    let f = _mm512_and_si512(l, r);
-    let s = &f as *const __m512i as *const u8;
-    let d = res.get_unchecked_mut(0) as *mut _ as *mut u8;
-    std::ptr::copy_nonoverlapping(s, d, std::mem::size_of::<__m512i>());
-}
-
-#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
 pub(super) fn buffer_bin_and(
     left: &Buffer,
     left_offset_in_bits: usize,
@@ -599,6 +585,7 @@ pub(super) fn buffer_bin_and(
     )
 }
 
+#[cfg(all(target_arch = "x86_64", feature = "avx512"))]
 pub(super) fn buffer_bin_or(
     left: &Buffer,
     left_offset_in_bits: usize,
@@ -606,25 +593,43 @@ pub(super) fn buffer_bin_or(
     right_offset_in_bits: usize,
     len_in_bits: usize,
 ) -> Buffer {
-    // SIMD implementation if available and byte-aligned
-    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
     if left_offset_in_bits % 8 == 0
         && right_offset_in_bits % 8 == 0
         && len_in_bits % 8 == 0
     {
-        return bitwise_bin_op_simd_helper(
-            &left,
-            left_offset_in_bits / 8,
-            &right,
-            right_offset_in_bits / 8,
-            len_in_bits / 8,
-            |a, b| a | b,
-            |a, b| a | b,
-        );
-    }
-    // Default implementation
-    #[allow(unreachable_code)]
-    {
+        let len = len_in_bits / 8;
+        let left_offset = left_offset_in_bits / 8;
+        let right_offset = right_offset_in_bits / 8;
+
+        let mut result = MutableBuffer::new(len).with_bitset(len, false);
+
+        let mut left_chunks = left.data()[left_offset..].chunks_exact(AVX512_U8X64_LANES);
+        let mut right_chunks =
+            right.data()[right_offset..].chunks_exact(AVX512_U8X64_LANES);
+        let mut result_chunks = result.data_mut().chunks_exact_mut(AVX512_U8X64_LANES);
+
+        result_chunks
+            .borrow_mut()
+            .zip(left_chunks.borrow_mut().zip(right_chunks.borrow_mut()))
+            .for_each(|(res, (left, right))| unsafe {
+                avx512_bin_or(left, right, res);
+            });
+
+        result_chunks
+            .into_remainder()
+            .iter_mut()
+            .zip(
+                left_chunks
+                    .remainder()
+                    .iter()
+                    .zip(right_chunks.remainder().iter()),
+            )
+            .for_each(|(res, (left, right))| {
+                *res = *left | *right;
+            });
+
+        result.freeze()
+    } else {
         bitwise_bin_op_helper(
             &left,
             left_offset_in_bits,
@@ -634,6 +639,60 @@ pub(super) fn buffer_bin_or(
             |a, b| a | b,
         )
     }
+}
+
+#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
+pub(super) fn buffer_bin_or(
+    left: &Buffer,
+    left_offset_in_bits: usize,
+    right: &Buffer,
+    right_offset_in_bits: usize,
+    len_in_bits: usize,
+) -> Buffer {
+    if left_offset_in_bits % 8 == 0
+        && right_offset_in_bits % 8 == 0
+        && len_in_bits % 8 == 0
+    {
+        bitwise_bin_op_simd_helper(
+            &left,
+            left_offset_in_bits / 8,
+            &right,
+            right_offset_in_bits / 8,
+            len_in_bits / 8,
+            |a, b| a | b,
+            |a, b| a | b,
+        )
+    } else {
+        bitwise_bin_op_helper(
+            &left,
+            left_offset_in_bits,
+            right,
+            right_offset_in_bits,
+            len_in_bits,
+            |a, b| a | b,
+        )
+    }
+}
+
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    not(any(feature = "simd", feature = "avx512"))
+))]
+pub(super) fn buffer_bin_or(
+    left: &Buffer,
+    left_offset_in_bits: usize,
+    right: &Buffer,
+    right_offset_in_bits: usize,
+    len_in_bits: usize,
+) -> Buffer {
+    bitwise_bin_op_helper(
+        &left,
+        left_offset_in_bits,
+        right,
+        right_offset_in_bits,
+        len_in_bits,
+        |a, b| a | b,
+    )
 }
 
 pub(super) fn buffer_unary_not(

--- a/rust/arrow/src/lib.rs
+++ b/rust/arrow/src/lib.rs
@@ -143,6 +143,7 @@
     clippy::type_complexity
 )]
 
+mod arch;
 pub mod array;
 pub mod bitmap;
 pub mod buffer;

--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -287,22 +287,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "avx512"))]
-    fn test_bitwise_and_avx512() {
-        use crate::buffer::avx512_bin_and;
-
-        let buf1 = [0b00110011u8; 64];
-        let buf2 = [0b11110000u8; 64];
-        let mut buf3 = [0b00000000; 64];
-        unsafe {
-            avx512_bin_and(&buf1, &buf2, &mut buf3);
-        };
-        for i in buf3.iter() {
-            assert_eq!(&0b00110000u8, i);
-        }
-    }
-
-    #[test]
     #[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), feature = "simd"))]
     fn test_bitwise_and_simd() {
         let buf1 = [0b00110011u8; 64];


### PR DESCRIPTION
Implements AVX-512 bit or operation

Before
```
buffer_bit_ops or       time:   [681.78 ns 682.42 ns 683.36 ns]                               
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe
```

After
```
buffer_bit_ops or       time:   [536.78 ns 537.75 ns 539.16 ns]                               
                        change: [-21.354% -20.879% -20.123%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```