### PR TITLE
ARROW-10585: [Rust] [DataFusion] Add join support to DataFrame and LogicalPlan

### DIFF
--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -169,8 +169,8 @@ pub trait DataFrame {
         &self,
         right: Arc<dyn DataFrame>,
         join_type: JoinType,
-        left_cols: Vec<&str>,
-        right_cols: Vec<&str>,
+        left_cols: &[&str],
+        right_cols: &[&str],
     ) -> Result<Arc<dyn DataFrame>>;
 
     /// Executes this DataFrame and collects all results into a vector of RecordBatch.

--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -19,7 +19,7 @@
 
 use crate::arrow::record_batch::RecordBatch;
 use crate::error::Result;
-use crate::logical_plan::{Expr, FunctionRegistry, LogicalPlan};
+use crate::logical_plan::{Expr, FunctionRegistry, JoinType, LogicalPlan};
 use arrow::datatypes::Schema;
 use std::sync::Arc;
 
@@ -145,6 +145,29 @@ pub trait DataFrame {
     /// # }
     /// ```
     fn sort(&self, expr: Vec<Expr>) -> Result<Arc<dyn DataFrame>>;
+
+    /// Join this DataFrame with another DataFrame using the specified columns as join keys
+    ///
+    /// ```
+    /// # use datafusion::prelude::*;
+    /// # use datafusion::error::Result;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<()> {
+    /// let mut ctx = ExecutionContext::new();
+    /// let left = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
+    /// let right = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
+    /// let join = left.join(right, JoinType::Inner, vec!["a", "b"], vec!["a", "b"])?;
+    /// let batches = join.collect().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn join(
+        &self,
+        right: Arc<dyn DataFrame>,
+        join_type: JoinType,
+        left_cols: Vec<&str>,
+        right_cols: Vec<&str>,
+    ) -> Result<Arc<dyn DataFrame>>;
 
     /// Executes this DataFrame and collects all results into a vector of RecordBatch.
     ///

--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -155,8 +155,12 @@ pub trait DataFrame {
     /// # async fn main() -> Result<()> {
     /// let mut ctx = ExecutionContext::new();
     /// let left = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
-    /// let right = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?;
-    /// let join = left.join(right, JoinType::Inner, vec!["a", "b"], vec!["a", "b"])?;
+    /// let right = ctx.read_csv("tests/example.csv", CsvReadOptions::new())?
+    ///   .select(vec![
+    ///     col("a").alias("a2"),
+    ///     col("b").alias("b2"),
+    ///     col("c").alias("c2")])?;
+    /// let join = left.join(right, JoinType::Inner, vec!["a", "b"], vec!["a2", "b2"])?;
     /// let batches = join.collect().await?;
     /// # Ok(())
     /// # }

--- a/rust/datafusion/src/dataframe.rs
+++ b/rust/datafusion/src/dataframe.rs
@@ -160,7 +160,7 @@ pub trait DataFrame {
     ///     col("a").alias("a2"),
     ///     col("b").alias("b2"),
     ///     col("c").alias("c2")])?;
-    /// let join = left.join(right, JoinType::Inner, vec!["a", "b"], vec!["a2", "b2"])?;
+    /// let join = left.join(right, JoinType::Inner, &["a", "b"], &["a2", "b2"])?;
     /// let batches = join.collect().await?;
     /// # Ok(())
     /// # }

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -23,7 +23,9 @@ use crate::arrow::record_batch::RecordBatch;
 use crate::dataframe::*;
 use crate::error::Result;
 use crate::execution::context::{ExecutionContext, ExecutionContextState};
-use crate::logical_plan::{col, Expr, FunctionRegistry, LogicalPlan, LogicalPlanBuilder};
+use crate::logical_plan::{
+    col, Expr, FunctionRegistry, JoinType, LogicalPlan, LogicalPlanBuilder,
+};
 use arrow::datatypes::Schema;
 
 use async_trait::async_trait;
@@ -99,6 +101,25 @@ impl DataFrame for DataFrameImpl {
     /// Sort by specified sorting expressions
     fn sort(&self, expr: Vec<Expr>) -> Result<Arc<dyn DataFrame>> {
         let plan = LogicalPlanBuilder::from(&self.plan).sort(expr)?.build()?;
+        Ok(Arc::new(DataFrameImpl::new(self.ctx_state.clone(), &plan)))
+    }
+
+    /// Join with another DataFrame
+    fn join(
+        &self,
+        right: Arc<dyn DataFrame>,
+        join_type: JoinType,
+        left_cols: Vec<&str>,
+        right_cols: Vec<&str>,
+    ) -> Result<Arc<dyn DataFrame>> {
+        let plan = LogicalPlanBuilder::from(&self.plan)
+            .join(
+                Arc::new(right.to_logical_plan()),
+                join_type,
+                left_cols,
+                right_cols,
+            )?
+            .build()?;
         Ok(Arc::new(DataFrameImpl::new(self.ctx_state.clone(), &plan)))
     }
 

--- a/rust/datafusion/src/execution/dataframe_impl.rs
+++ b/rust/datafusion/src/execution/dataframe_impl.rs
@@ -232,9 +232,12 @@ mod tests {
         let right_rows = right.collect().await?;
         let join = left.join(right, JoinType::Inner, &["c1"], &["c1"])?;
         let join_rows = join.collect().await?;
-        assert_eq!(100, left_rows.len());
-        assert_eq!(100, right_rows.len());
-        assert_eq!(1000, join_rows.len()); //TODO determine expected number but should be > 100
+        assert_eq!(1, left_rows.len());
+        assert_eq!(100, left_rows[0].num_rows());
+        assert_eq!(1, right_rows.len());
+        assert_eq!(100, right_rows[0].num_rows());
+        assert_eq!(1, join_rows.len());
+        assert_eq!(2008, join_rows[0].num_rows());
         Ok(())
     }
 

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -213,8 +213,11 @@ impl LogicalPlanBuilder {
             Ok(Self::from(&LogicalPlan::Join {
                 left: Arc::new(self.plan.clone()),
                 right,
-                left_keys: left_keys.iter().map(|k| k.to_string()).collect(),
-                right_keys: right_keys.iter().map(|k| k.to_string()).collect(),
+                on: left_keys
+                    .iter()
+                    .zip(right_keys.iter())
+                    .map(|(l, r)| (l.to_string(), r.to_string()))
+                    .collect(),
                 join_type,
                 schema: Arc::new(physical_schema),
             }))

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -210,6 +210,9 @@ impl LogicalPlanBuilder {
                 &on,
                 &physical_join_type,
             );
+            println!("left: {:?}", self.plan.schema());
+            println!("right: {:?}", right.schema());
+            println!("join: {:?}", physical_schema);
             Ok(Self::from(&LogicalPlan::Join {
                 left: Arc::new(self.plan.clone()),
                 right,

--- a/rust/datafusion/src/logical_plan/builder.rs
+++ b/rust/datafusion/src/logical_plan/builder.rs
@@ -188,8 +188,8 @@ impl LogicalPlanBuilder {
         &self,
         right: Arc<LogicalPlan>,
         join_type: JoinType,
-        left_keys: Vec<&str>,
-        right_keys: Vec<&str>,
+        left_keys: &[&str],
+        right_keys: &[&str],
     ) -> Result<Self> {
         if left_keys.len() != right_keys.len() {
             Err(DataFusionError::Plan(
@@ -210,9 +210,6 @@ impl LogicalPlanBuilder {
                 &on,
                 &physical_join_type,
             );
-            println!("left: {:?}", self.plan.schema());
-            println!("right: {:?}", right.schema());
-            println!("join: {:?}", physical_schema);
             Ok(Self::from(&LogicalPlan::Join {
                 left: Arc::new(self.plan.clone()),
                 right,

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -38,5 +38,7 @@ pub use expr::{
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;
-pub use plan::{LogicalPlan, PlanType, PlanVisitor, StringifiedPlan, TableSource};
+pub use plan::{
+    JoinType, LogicalPlan, PlanType, PlanVisitor, StringifiedPlan, TableSource,
+};
 pub use registry::FunctionRegistry;

--- a/rust/datafusion/src/logical_plan/plan.rs
+++ b/rust/datafusion/src/logical_plan/plan.rs
@@ -107,10 +107,8 @@ pub enum LogicalPlan {
         left: Arc<LogicalPlan>,
         /// Right input
         right: Arc<LogicalPlan>,
-        /// Columns in left input to use for join keys
-        left_keys: Vec<String>,
-        /// Columns in right input to use for join keys
-        right_keys: Vec<String>,
+        /// Equijoin clause expressed as pairs of (left, right) join columns
+        on: Vec<(String, String)>,
         /// Join type
         join_type: JoinType,
         /// The output schema, containing fields from the left and right inputs
@@ -581,16 +579,9 @@ impl LogicalPlan {
                         }
                         Ok(())
                     }
-                    LogicalPlan::Join {
-                        ref left_keys,
-                        ref right_keys,
-                        ..
-                    } => {
-                        let join_expr: Vec<String> = left_keys
-                            .iter()
-                            .zip(right_keys)
-                            .map(|(l, r)| format!("{} = {}", l, r))
-                            .collect();
+                    LogicalPlan::Join { on: ref keys, .. } => {
+                        let join_expr: Vec<String> =
+                            keys.iter().map(|(l, r)| format!("{} = {}", l, r)).collect();
                         write!(f, "Join: {}", join_expr.join(", "))
                     }
                     LogicalPlan::Limit { ref n, .. } => write!(f, "Limit: {}", n),

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -312,6 +312,7 @@ fn optimize_plan(
         | LogicalPlan::Filter { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::Sort { .. }
+        | LogicalPlan::Join { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Extension { .. } => {
             let expr = utils::expressions(plan);

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -186,16 +186,14 @@ pub fn from_plan(
         }),
         LogicalPlan::Join {
             join_type,
-            left_keys,
-            right_keys,
+            on,
             schema,
             ..
         } => Ok(LogicalPlan::Join {
             left: Arc::new(inputs[0].clone()),
             right: Arc::new(inputs[1].clone()),
             join_type: join_type.clone(),
-            left_keys: left_keys.clone(),
-            right_keys: right_keys.clone(),
+            on: on.clone(),
             schema: schema.clone(),
         }),
         LogicalPlan::Limit { n, .. } => Ok(LogicalPlan::Limit {

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -118,9 +118,6 @@ pub fn expressions(plan: &LogicalPlan) -> Vec<Expr> {
             result.extend(aggr_expr.clone());
             result
         }
-        LogicalPlan::Join { .. } => {
-            vec![]
-        }
         LogicalPlan::Sort { expr, .. } => expr.clone(),
         LogicalPlan::Extension { node } => node.expressions(),
         // plans without expressions
@@ -130,6 +127,7 @@ pub fn expressions(plan: &LogicalPlan) -> Vec<Expr> {
         | LogicalPlan::CsvScan { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::Limit { .. }
+        | LogicalPlan::Join { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Explain { .. } => vec![],
     }

--- a/rust/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/rust/datafusion/src/physical_plan/distinct_expressions.rs
@@ -262,7 +262,7 @@ mod tests {
         let mut states = state1
             .iter()
             .zip(state2.iter())
-            .map(|(a, b)| (a.clone(), b.clone()))
+            .map(|(l, r)| (l.clone(), r.clone()))
             .collect::<Vec<(Option<T>, Option<S>)>>();
         states.sort();
         states

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -487,6 +487,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn join_one_no_shared_column_names() -> Result<()> {
+        let left = build_table(
+            ("a1", &vec![1, 2, 3]),
+            ("b1", &vec![4, 5, 5]), // this has a repetition
+            ("c1", &vec![7, 8, 9]),
+        );
+        let right = build_table(
+            ("a2", &vec![10, 20, 30]),
+            ("b2", &vec![4, 5, 6]),
+            ("c2", &vec![70, 80, 90]),
+        );
+        let on = &[("b1", "b2")];
+
+        let join = join(left, right, on)?;
+
+        let columns = columns(&join.schema());
+        assert_eq!(columns, vec!["a1", "b1", "c1", "a2", "b2", "c2"]);
+
+        let stream = join.execute(0).await?;
+        let batches = common::collect(stream).await?;
+
+        let result = format_batch(&batches[0]);
+        let expected = vec!["2,5,8,20,5,80", "3,5,9,20,5,80", "1,4,7,10,4,70"];
+
+        assert_same_rows(&result, &expected);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn join_two() -> Result<()> {
         let left = build_table(
             ("a1", &vec![1, 2, 2]),

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -130,11 +130,7 @@ impl ExecutionPlan for HashJoinExec {
             2 => Ok(Arc::new(HashJoinExec::try_new(
                 children[0].clone(),
                 children[1].clone(),
-                &self
-                    .on
-                    .iter()
-                    .map(|(x, y)| (x.as_str(), y.as_str()))
-                    .collect::<Vec<_>>(),
+                &self.on,
                 &self.join_type,
             )?)),
             _ => Err(DataFusionError::Internal(
@@ -438,9 +434,13 @@ mod tests {
     fn join(
         left: Arc<dyn ExecutionPlan>,
         right: Arc<dyn ExecutionPlan>,
-        on: &JoinOn,
+        on: &[(&str, &str)],
     ) -> Result<HashJoinExec> {
-        HashJoinExec::try_new(left, right, on, &JoinType::Inner)
+        let on: Vec<_> = on
+            .iter()
+            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .collect();
+        HashJoinExec::try_new(left, right, &on, &JoinType::Inner)
     }
 
     /// Asserts that the rows are the same, taking into account that their order

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -438,7 +438,7 @@ mod tests {
     ) -> Result<HashJoinExec> {
         let on: Vec<_> = on
             .iter()
-            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .map(|(l, r)| (l.to_string(), r.to_string()))
             .collect();
         HashJoinExec::try_new(left, right, &on, &JoinType::Inner)
     }

--- a/rust/datafusion/src/physical_plan/hash_utils.rs
+++ b/rust/datafusion/src/physical_plan/hash_utils.rs
@@ -125,7 +125,7 @@ mod tests {
         let right = right.iter().map(|x| x.to_string()).collect::<HashSet<_>>();
         let on: Vec<_> = on
             .iter()
-            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .map(|(l, r)| (l.to_string(), r.to_string()))
             .collect();
         check_join_set_is_valid(&left, &right, &on)
     }

--- a/rust/datafusion/src/physical_plan/hash_utils.rs
+++ b/rust/datafusion/src/physical_plan/hash_utils.rs
@@ -29,7 +29,7 @@ pub enum JoinType {
 }
 
 /// The on clause of the join, as vector of (left, right) columns.
-pub type JoinOn<'a> = [(&'a str, &'a str)];
+pub type JoinOn = [(String, String)];
 
 /// Checks whether the schemas "left" and "right" and columns "on" represent a valid join.
 /// They are valid whenever their columns' intersection equals the set `on`
@@ -119,8 +119,11 @@ mod tests {
     fn check(left: &[&str], right: &[&str], on: &[(&str, &str)]) -> Result<()> {
         let left = left.iter().map(|x| x.to_string()).collect::<HashSet<_>>();
         let right = right.iter().map(|x| x.to_string()).collect::<HashSet<_>>();
-
-        check_join_set_is_valid(&left, &right, on)
+        let on: Vec<_> = on
+            .iter()
+            .map(|(a, b)| (a.to_string(), b.to_string()))
+            .collect();
+        check_join_set_is_valid(&left, &right, &on)
     }
 
     #[test]

--- a/rust/datafusion/src/physical_plan/hash_utils.rs
+++ b/rust/datafusion/src/physical_plan/hash_utils.rs
@@ -94,15 +94,19 @@ pub fn build_join_schema(
 ) -> Schema {
     let fields: Vec<Field> = match join_type {
         JoinType::Inner => {
-            // inner: all fields are there
-            let on_right = &on.iter().map(|on| on.1.to_string()).collect::<HashSet<_>>();
+            // remove right-side join keys if they have the same names as the left-side
+            let duplicate_keys = &on
+                .iter()
+                .filter(|(l, r)| l == r)
+                .map(|on| on.1.to_string())
+                .collect::<HashSet<_>>();
 
             let left_fields = left.fields().iter();
 
             let right_fields = right
                 .fields()
                 .iter()
-                .filter(|f| !on_right.contains(f.name()));
+                .filter(|f| !duplicate_keys.contains(f.name()));
 
             // left then right
             left_fields.chain(right_fields).cloned().collect()

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -293,8 +293,7 @@ impl DefaultPhysicalPlanner {
             LogicalPlan::Join {
                 left,
                 right,
-                left_keys,
-                right_keys,
+                on: keys,
                 join_type,
                 schema,
             } => {
@@ -303,13 +302,8 @@ impl DefaultPhysicalPlanner {
                 let physical_join_type = match join_type {
                     JoinType::Inner => hash_utils::JoinType::Inner,
                 };
-                let on: Vec<_> = left_keys
-                    .iter()
-                    .zip(right_keys.iter())
-                    .map(|(a, b)| (a.to_string(), b.to_string()))
-                    .collect();
                 let hash_join =
-                    HashJoinExec::try_new(left, right, &on, &physical_join_type)?;
+                    HashJoinExec::try_new(left, right, &keys, &physical_join_type)?;
                 if schema.as_ref() == hash_join.schema().as_ref() {
                     Ok(Arc::new(hash_join))
                 } else {

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -287,6 +287,11 @@ impl DefaultPhysicalPlanner {
                     ctx_state.config.concurrency,
                 )?))
             }
+            LogicalPlan::Join { .. } => {
+                // TODO once https://github.com/apache/arrow/pull/8709 is merged we can
+                // create the physical operator here
+                todo!()
+            }
             LogicalPlan::EmptyRelation {
                 produce_one_row,
                 schema,

--- a/rust/datafusion/src/prelude.rs
+++ b/rust/datafusion/src/prelude.rs
@@ -28,6 +28,6 @@
 pub use crate::dataframe::DataFrame;
 pub use crate::execution::context::{ExecutionConfig, ExecutionContext};
 pub use crate::logical_plan::{
-    array, avg, col, concat, count, create_udf, length, lit, max, min, sum,
+    array, avg, col, concat, count, create_udf, length, lit, max, min, sum, JoinType,
 };
 pub use crate::physical_plan::csv::CsvReadOptions;


### PR DESCRIPTION
This PR adds `DataFrame.join` and plumbs it through to the physical join plan.