### PR TITLE
ARROW-10664: [Rust] Implement AVX512 sort

### DIFF
--- a/rust/arrow/src/arch/avx512.rs
+++ b/rust/arrow/src/arch/avx512.rs
@@ -41,6 +41,155 @@ pub(crate) unsafe fn avx512_bin_or(left: &[u8], right: &[u8], res: &mut [u8]) {
     std::ptr::copy_nonoverlapping(s, d, std::mem::size_of::<__m512i>());
 }
 
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn avx512_vec_sort_i64_single<'a>(input: &[i64]) -> [i64; 8] {
+    use core::arch::x86_64::{
+        __m512i, _mm512_loadu_epi64, _mm512_mask_mov_epi64, _mm512_max_epi64,
+        _mm512_min_epi64, _mm512_permutexvar_epi64, _mm512_set_epi64,
+    };
+
+    let mut inp: __m512i = _mm512_loadu_epi64(input.as_ptr() as *const _);
+    let idxnn1: __m512i = _mm512_set_epi64(6, 7, 4, 5, 2, 3, 0, 1);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn1, inp);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, inp);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, inp);
+    inp = _mm512_mask_mov_epi64(wire_n_min, 0xAA, wire_n_max);
+
+    let idxnn2: __m512i = _mm512_set_epi64(4, 5, 6, 7, 0, 1, 2, 3);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn2, inp);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, inp);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, inp);
+    inp = _mm512_mask_mov_epi64(wire_n_min, 0xCC, wire_n_max);
+
+    let idxnn3: __m512i = _mm512_set_epi64(6, 7, 4, 5, 2, 3, 0, 1);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn3, inp);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, inp);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, inp);
+    inp = _mm512_mask_mov_epi64(wire_n_min, 0xAA, wire_n_max);
+
+    let idxnn4: __m512i = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn4, inp);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, inp);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, inp);
+    inp = _mm512_mask_mov_epi64(wire_n_min, 0xF0, wire_n_max);
+
+    let idxnn5: __m512i = _mm512_set_epi64(5, 4, 7, 6, 1, 0, 3, 2);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn5, inp);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, inp);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, inp);
+    inp = _mm512_mask_mov_epi64(wire_n_min, 0xCC, wire_n_max);
+
+    let idxnn6: __m512i = _mm512_set_epi64(6, 7, 4, 5, 2, 3, 0, 1);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn6, inp);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, inp);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, inp);
+    inp = _mm512_mask_mov_epi64(wire_n_min, 0xAA, wire_n_max);
+
+    std::mem::transmute(inp)
+}
+
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn avx512_vec_sort_i64_double(
+    left: &[i64],
+    right: &[i64],
+) -> [[i64; 8]; 2] {
+    use core::arch::x86_64::{
+        __m512i, _mm512_loadu_epi64, _mm512_mask_mov_epi64, _mm512_max_epi64,
+        _mm512_min_epi64, _mm512_permutexvar_epi64, _mm512_set_epi64,
+    };
+
+    let (l, r) = (
+        avx512_vec_sort_i64_single(left),
+        avx512_vec_sort_i64_single(right),
+    );
+
+    let mut l: __m512i = _mm512_loadu_epi64(l.as_ptr() as *const _);
+    let mut r: __m512i = _mm512_loadu_epi64(r.as_ptr() as *const _);
+
+    let idxnn1: __m512i = _mm512_set_epi64(0, 1, 2, 3, 4, 5, 6, 7);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn1, l);
+    l = _mm512_min_epi64(r, wire_n);
+    r = _mm512_max_epi64(r, wire_n);
+
+    let idxnn2: __m512i = _mm512_set_epi64(3, 2, 1, 0, 7, 6, 5, 4);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn2, l);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, l);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, l);
+    l = _mm512_mask_mov_epi64(wire_n_min, 0xF0, wire_n_max); // 0x33
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn2, r);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, r);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, r);
+    r = _mm512_mask_mov_epi64(wire_n_min, 0xF0, wire_n_max); // 0x33
+
+    let idxnn3: __m512i = _mm512_set_epi64(5, 4, 7, 6, 1, 0, 3, 2);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn3, l);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, l);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, l);
+    l = _mm512_mask_mov_epi64(wire_n_min, 0xCC, wire_n_max);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn3, r);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, r);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, r);
+    r = _mm512_mask_mov_epi64(wire_n_min, 0xCC, wire_n_max);
+
+    let idxnn4: __m512i = _mm512_set_epi64(6, 7, 4, 5, 2, 3, 0, 1);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn4, l);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, l);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, l);
+    l = _mm512_mask_mov_epi64(wire_n_min, 0xAA, wire_n_max);
+    let wire_n: __m512i = _mm512_permutexvar_epi64(idxnn4, r);
+    let wire_n_min: __m512i = _mm512_min_epi64(wire_n, r);
+    let wire_n_max: __m512i = _mm512_max_epi64(wire_n, r);
+    r = _mm512_mask_mov_epi64(wire_n_min, 0xAA, wire_n_max);
+
+    let lf: [i64; 8] = std::mem::transmute(l);
+    let rf: [i64; 8] = std::mem::transmute(r);
+
+    [lf, rf]
+}
+
+///
+/// Permute exchange width for the AVX-512 SIMD application
+pub(crate) const PERMUTE_EXCHANGE_WIDTH: usize = 8;
+
+fn merger_net(mut input: Vec<i64>) -> Vec<i64> {
+    let half = input.len() / 2;
+    if half > PERMUTE_EXCHANGE_WIDTH {
+        (0..half).into_iter().for_each(|e| unsafe {
+            if input[e] > input[e + half] {
+                let pl: *mut i64 = &mut input[e];
+                let pr: *mut i64 = &mut input[e + half];
+                std::ptr::swap(pl, pr);
+            }
+        });
+        merger_net(input[..half].to_vec());
+        merger_net(input[half..].to_vec());
+    }
+    input
+}
+
+#[inline]
+#[cold]
+fn cold() {}
+
+pub(crate) unsafe fn avx512_vec_sort_i64(input: &[i64]) -> Vec<i64> {
+    if (input.len() / 2) == PERMUTE_EXCHANGE_WIDTH {
+        let v: Vec<&[i64]> = input.chunks_exact(PERMUTE_EXCHANGE_WIDTH).collect();
+        let x = avx512_vec_sort_i64_double(&v[0], &v[1]);
+        [x[0], x[1]].concat()
+    } else {
+        if (input.len() / 2) == 0 {
+            cold();
+            input.to_vec()
+        } else {
+            let mut it = input.chunks_exact(input.len() / 2);
+            let l = avx512_vec_sort_i64(it.next().unwrap());
+            let r = avx512_vec_sort_i64(it.next().unwrap());
+            let c = [l, r].concat();
+            merger_net(c)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -69,5 +218,34 @@ mod tests {
         for i in buf3.iter() {
             assert_eq!(&0b11110011u8, i);
         }
+    }
+
+    #[test]
+    fn test_vec_sort_i64_single_avx512() {
+        let buf1 = [9_i64, 4, 2, 0, 1, 10, 8, 7];
+        let res = unsafe { avx512_vec_sort_i64_single(&buf1) };
+        assert_eq!(res, [0_i64, 1, 2, 4, 7, 8, 9, 10]);
+    }
+
+    #[test]
+    fn test_vec_sort_i64_double_avx512() {
+        let buf1 = [9_i64, 4, 2, 0, 1, 10, 8, 7];
+        let buf2 = [3_i64, 71, 13, 100, 67, 5, -1, 89];
+        let res = unsafe { avx512_vec_sort_i64_double(&buf1, &buf2) };
+        assert_eq!(
+            res,
+            [[-1, 0, 1, 2, 3, 4, 5, 7], [8, 9, 10, 13, 67, 71, 89, 100]]
+        );
+    }
+
+    #[test]
+    fn test_vec_sort_i64_avx512() {
+        let buf1 = (0..128_i64).into_iter().rev().collect::<Vec<i64>>();
+        let res = unsafe { avx512_vec_sort_i64(&buf1) };
+        assert_eq!(res, (0..128_i64).into_iter().collect::<Vec<i64>>());
+
+        let buf1 = (0..8192_i64).into_iter().rev().collect::<Vec<i64>>();
+        let res = unsafe { avx512_vec_sort_i64(&buf1) };
+        assert_eq!(res, (0..8192_i64).into_iter().collect::<Vec<i64>>());
     }
 }

--- a/rust/arrow/src/compute/kernels/sort.rs
+++ b/rust/arrow/src/compute/kernels/sort.rs
@@ -956,6 +956,18 @@ mod tests {
     }
 
     #[test]
+    fn test_sort_primitives_large() {
+        let data = [0, 1, 2, 3_u8]
+            .repeat(100_000)
+            .iter()
+            .map(|e| Some(*e))
+            .collect::<Vec<Option<u8>>>();
+        let mut expected = data.clone();
+        expected.sort();
+        test_sort_primitive_arrays::<UInt8Type>(data, None, expected);
+    }
+
+    #[test]
     fn test_sort_primitives() {
         // default case
         test_sort_primitive_arrays::<UInt8Type>(

--- a/rust/arrow/src/util/bit_util.rs
+++ b/rust/arrow/src/util/bit_util.rs
@@ -35,6 +35,12 @@ pub fn round_upto_power_of_2(num: usize, factor: usize) -> usize {
     (num + (factor - 1)) & !(factor - 1)
 }
 
+///
+/// Checks whether given number is power of 2
+pub fn is_power_of_two(num: usize) -> bool {
+    (num & (num - 1)) == 0
+}
+
 /// Returns whether bit at position `i` in `data` is set or not
 #[inline]
 pub fn get_bit(data: &[u8], i: usize) -> bool {


### PR DESCRIPTION
Before:
```
sort 2^10               time:   [94.137 us 94.154 us 94.174 us]                      
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

sort 2^12               time:   [483.03 us 483.08 us 483.13 us]                      
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  4 (4.00%) high mild
  1 (1.00%) high severe

sort nulls 2^10         time:   [59.782 us 59.800 us 59.818 us]                            
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

sort nulls 2^12         time:   [296.84 us 296.89 us 296.97 us]                            
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

```

After:
```
sort 2^10               time:   [73.098 us 73.119 us 73.148 us]                      
                        change: [-22.404% -22.381% -22.356%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe

sort 2^12               time:   [354.82 us 354.98 us 355.23 us]                      
                        change: [-26.550% -26.530% -26.505%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  4 (4.00%) high severe

sort nulls 2^10         time:   [53.570 us 53.577 us 53.585 us]                            
                        change: [-10.407% -10.378% -10.350%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) low mild
  3 (3.00%) high mild

sort nulls 2^12         time:   [238.46 us 238.50 us 238.55 us]                            
                        change: [-19.670% -19.650% -19.627%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild
  2 (2.00%) high severe

```

~Note: Waiting for other bit or PR to merge to rebase on top of it.~ Merged.