### PR TITLE
ARROW-10665: [Rust] like/nlike utf8 scalar fast paths, bug fixes in like/nlike

### DIFF
--- a/rust/arrow/benches/comparison_kernels.rs
+++ b/rust/arrow/benches/comparison_kernels.rs
@@ -209,23 +209,23 @@ fn add_benchmark(c: &mut Criterion) {
         b.iter(|| bench_like_utf8_scalar(&arr_string, "%xx_xx%xxx"))
     });
 
-    c.bench_function("like_utf8 scalar equals", |b| {
+    c.bench_function("nlike_utf8 scalar equals", |b| {
         b.iter(|| bench_nlike_utf8_scalar(&arr_string, "xxxx"))
     });
 
-    c.bench_function("like_utf8 scalar contains", |b| {
+    c.bench_function("nlike_utf8 scalar contains", |b| {
         b.iter(|| bench_nlike_utf8_scalar(&arr_string, "%xxxx%"))
     });
 
-    c.bench_function("like_utf8 scalar ends with", |b| {
+    c.bench_function("nlike_utf8 scalar ends with", |b| {
         b.iter(|| bench_nlike_utf8_scalar(&arr_string, "xxxx%"))
     });
 
-    c.bench_function("like_utf8 scalar starts with", |b| {
+    c.bench_function("nlike_utf8 scalar starts with", |b| {
         b.iter(|| bench_nlike_utf8_scalar(&arr_string, "%xxxx"))
     });
 
-    c.bench_function("like_utf8 scalar complex", |b| {
+    c.bench_function("nlike_utf8 scalar complex", |b| {
         b.iter(|| bench_nlike_utf8_scalar(&arr_string, "%xx_xx%xxx"))
     });
 }

--- a/rust/arrow/benches/comparison_kernels.rs
+++ b/rust/arrow/benches/comparison_kernels.rs
@@ -154,35 +154,35 @@ fn add_benchmark(c: &mut Criterion) {
 
     let arr_string = create_string_array(size, false);
 
-    // c.bench_function("eq Float32", |b| b.iter(|| bench_eq(&arr_a, &arr_b)));
-    // c.bench_function("eq scalar Float32", |b| {
-    //     b.iter(|| bench_eq_scalar(&arr_a, 1.0))
-    // });
+    c.bench_function("eq Float32", |b| b.iter(|| bench_eq(&arr_a, &arr_b)));
+    c.bench_function("eq scalar Float32", |b| {
+        b.iter(|| bench_eq_scalar(&arr_a, 1.0))
+    });
 
-    // c.bench_function("neq Float32", |b| b.iter(|| bench_neq(&arr_a, &arr_b)));
-    // c.bench_function("neq scalar Float32", |b| {
-    //     b.iter(|| bench_neq_scalar(&arr_a, 1.0))
-    // });
+    c.bench_function("neq Float32", |b| b.iter(|| bench_neq(&arr_a, &arr_b)));
+    c.bench_function("neq scalar Float32", |b| {
+        b.iter(|| bench_neq_scalar(&arr_a, 1.0))
+    });
 
-    // c.bench_function("lt Float32", |b| b.iter(|| bench_lt(&arr_a, &arr_b)));
-    // c.bench_function("lt scalar Float32", |b| {
-    //     b.iter(|| bench_lt_scalar(&arr_a, 1.0))
-    // });
+    c.bench_function("lt Float32", |b| b.iter(|| bench_lt(&arr_a, &arr_b)));
+    c.bench_function("lt scalar Float32", |b| {
+        b.iter(|| bench_lt_scalar(&arr_a, 1.0))
+    });
 
-    // c.bench_function("lt_eq Float32", |b| b.iter(|| bench_lt_eq(&arr_a, &arr_b)));
-    // c.bench_function("lt_eq scalar Float32", |b| {
-    //     b.iter(|| bench_lt_eq_scalar(&arr_a, 1.0))
-    // });
+    c.bench_function("lt_eq Float32", |b| b.iter(|| bench_lt_eq(&arr_a, &arr_b)));
+    c.bench_function("lt_eq scalar Float32", |b| {
+        b.iter(|| bench_lt_eq_scalar(&arr_a, 1.0))
+    });
 
-    // c.bench_function("gt Float32", |b| b.iter(|| bench_gt(&arr_a, &arr_b)));
-    // c.bench_function("gt scalar Float32", |b| {
-    //     b.iter(|| bench_gt_scalar(&arr_a, 1.0))
-    // });
+    c.bench_function("gt Float32", |b| b.iter(|| bench_gt(&arr_a, &arr_b)));
+    c.bench_function("gt scalar Float32", |b| {
+        b.iter(|| bench_gt_scalar(&arr_a, 1.0))
+    });
 
-    // c.bench_function("gt_eq Float32", |b| b.iter(|| bench_gt_eq(&arr_a, &arr_b)));
-    // c.bench_function("gt_eq scalar Float32", |b| {
-    //     b.iter(|| bench_gt_eq_scalar(&arr_a, 1.0))
-    // });
+    c.bench_function("gt_eq Float32", |b| b.iter(|| bench_gt_eq(&arr_a, &arr_b)));
+    c.bench_function("gt_eq scalar Float32", |b| {
+        b.iter(|| bench_gt_eq_scalar(&arr_a, 1.0))
+    });
 
     c.bench_function("like_utf8 scalar equals", |b| {
         b.iter(|| bench_like_utf8_scalar(&arr_string, "xxxx"))

--- a/rust/arrow/benches/comparison_kernels.rs
+++ b/rust/arrow/benches/comparison_kernels.rs
@@ -203,8 +203,6 @@ fn add_benchmark(c: &mut Criterion) {
     c.bench_function("like_utf8 scalar complex", |b| {
         b.iter(|| bench_like_utf8_scalar(&arr_string, "%xx_xx%xxx"))
     });
-
-
 }
 
 criterion_group!(benches, add_benchmark);

--- a/rust/arrow/benches/comparison_kernels.rs
+++ b/rust/arrow/benches/comparison_kernels.rs
@@ -24,6 +24,9 @@ extern crate arrow;
 use arrow::array::*;
 use arrow::compute::*;
 use arrow::datatypes::ArrowNumericType;
+use arrow::util::test_util::seedable_rng;
+use rand::distributions::Alphanumeric;
+use rand::Rng;
 
 fn create_array(size: usize) -> Float32Array {
     let mut builder = Float32Builder::new(size);
@@ -32,6 +35,25 @@ fn create_array(size: usize) -> Float32Array {
             builder.append_value(1.0).unwrap();
         } else {
             builder.append_value(0.0).unwrap();
+        }
+    }
+    builder.finish()
+}
+
+fn create_string_array(size: usize, with_nulls: bool) -> StringArray {
+    // use random numbers to avoid spurious compiler optimizations wrt to branching
+    let mut rng = seedable_rng();
+    let mut builder = StringBuilder::new(size);
+
+    for _ in 0..size {
+        if with_nulls && rng.gen::<f32>() > 0.5 {
+            builder.append_null().unwrap();
+        } else {
+            let string = seedable_rng()
+                .sample_iter(&Alphanumeric)
+                .take(10)
+                .collect::<String>();
+            builder.append_value(&string).unwrap();
         }
     }
     builder.finish()
@@ -121,40 +143,68 @@ where
     gt_eq_scalar(criterion::black_box(arr_a), criterion::black_box(value_b)).unwrap();
 }
 
+fn bench_like_utf8_scalar(arr_a: &StringArray, value_b: &str) {
+    like_utf8_scalar(criterion::black_box(arr_a), criterion::black_box(value_b)).unwrap();
+}
+
 fn add_benchmark(c: &mut Criterion) {
     let size = 65536;
     let arr_a = create_array(size);
     let arr_b = create_array(size);
 
-    c.bench_function("eq Float32", |b| b.iter(|| bench_eq(&arr_a, &arr_b)));
-    c.bench_function("eq scalar Float32", |b| {
-        b.iter(|| bench_eq_scalar(&arr_a, 1.0))
+    let arr_string = create_string_array(size, false);
+
+    // c.bench_function("eq Float32", |b| b.iter(|| bench_eq(&arr_a, &arr_b)));
+    // c.bench_function("eq scalar Float32", |b| {
+    //     b.iter(|| bench_eq_scalar(&arr_a, 1.0))
+    // });
+
+    // c.bench_function("neq Float32", |b| b.iter(|| bench_neq(&arr_a, &arr_b)));
+    // c.bench_function("neq scalar Float32", |b| {
+    //     b.iter(|| bench_neq_scalar(&arr_a, 1.0))
+    // });
+
+    // c.bench_function("lt Float32", |b| b.iter(|| bench_lt(&arr_a, &arr_b)));
+    // c.bench_function("lt scalar Float32", |b| {
+    //     b.iter(|| bench_lt_scalar(&arr_a, 1.0))
+    // });
+
+    // c.bench_function("lt_eq Float32", |b| b.iter(|| bench_lt_eq(&arr_a, &arr_b)));
+    // c.bench_function("lt_eq scalar Float32", |b| {
+    //     b.iter(|| bench_lt_eq_scalar(&arr_a, 1.0))
+    // });
+
+    // c.bench_function("gt Float32", |b| b.iter(|| bench_gt(&arr_a, &arr_b)));
+    // c.bench_function("gt scalar Float32", |b| {
+    //     b.iter(|| bench_gt_scalar(&arr_a, 1.0))
+    // });
+
+    // c.bench_function("gt_eq Float32", |b| b.iter(|| bench_gt_eq(&arr_a, &arr_b)));
+    // c.bench_function("gt_eq scalar Float32", |b| {
+    //     b.iter(|| bench_gt_eq_scalar(&arr_a, 1.0))
+    // });
+
+    c.bench_function("like_utf8 scalar equals", |b| {
+        b.iter(|| bench_like_utf8_scalar(&arr_string, "xxxx"))
     });
 
-    c.bench_function("neq Float32", |b| b.iter(|| bench_neq(&arr_a, &arr_b)));
-    c.bench_function("neq scalar Float32", |b| {
-        b.iter(|| bench_neq_scalar(&arr_a, 1.0))
+    c.bench_function("like_utf8 scalar contains", |b| {
+        b.iter(|| bench_like_utf8_scalar(&arr_string, "%xxxx%"))
     });
 
-    c.bench_function("lt Float32", |b| b.iter(|| bench_lt(&arr_a, &arr_b)));
-    c.bench_function("lt scalar Float32", |b| {
-        b.iter(|| bench_lt_scalar(&arr_a, 1.0))
+    c.bench_function("like_utf8 scalar ends with", |b| {
+        b.iter(|| bench_like_utf8_scalar(&arr_string, "xxxx%"))
     });
 
-    c.bench_function("lt_eq Float32", |b| b.iter(|| bench_lt_eq(&arr_a, &arr_b)));
-    c.bench_function("lt_eq scalar Float32", |b| {
-        b.iter(|| bench_lt_eq_scalar(&arr_a, 1.0))
+    c.bench_function("like_utf8 scalar starts with", |b| {
+        b.iter(|| bench_like_utf8_scalar(&arr_string, "%xxxx"))
     });
 
-    c.bench_function("gt Float32", |b| b.iter(|| bench_gt(&arr_a, &arr_b)));
-    c.bench_function("gt scalar Float32", |b| {
-        b.iter(|| bench_gt_scalar(&arr_a, 1.0))
+    c.bench_function("like_utf8 scalar complex", |b| {
+        b.iter(|| bench_like_utf8_scalar(&arr_string, "%xx_xx%xxx"))
     });
 
-    c.bench_function("gt_eq Float32", |b| b.iter(|| bench_gt_eq(&arr_a, &arr_b)));
-    c.bench_function("gt_eq scalar Float32", |b| {
-        b.iter(|| bench_gt_eq_scalar(&arr_a, 1.0))
-    });
+
 }
 
 criterion_group!(benches, add_benchmark);

--- a/rust/arrow/benches/comparison_kernels.rs
+++ b/rust/arrow/benches/comparison_kernels.rs
@@ -147,6 +147,11 @@ fn bench_like_utf8_scalar(arr_a: &StringArray, value_b: &str) {
     like_utf8_scalar(criterion::black_box(arr_a), criterion::black_box(value_b)).unwrap();
 }
 
+fn bench_nlike_utf8_scalar(arr_a: &StringArray, value_b: &str) {
+    nlike_utf8_scalar(criterion::black_box(arr_a), criterion::black_box(value_b))
+        .unwrap();
+}
+
 fn add_benchmark(c: &mut Criterion) {
     let size = 65536;
     let arr_a = create_array(size);
@@ -202,6 +207,26 @@ fn add_benchmark(c: &mut Criterion) {
 
     c.bench_function("like_utf8 scalar complex", |b| {
         b.iter(|| bench_like_utf8_scalar(&arr_string, "%xx_xx%xxx"))
+    });
+
+    c.bench_function("like_utf8 scalar equals", |b| {
+        b.iter(|| bench_nlike_utf8_scalar(&arr_string, "xxxx"))
+    });
+
+    c.bench_function("like_utf8 scalar contains", |b| {
+        b.iter(|| bench_nlike_utf8_scalar(&arr_string, "%xxxx%"))
+    });
+
+    c.bench_function("like_utf8 scalar ends with", |b| {
+        b.iter(|| bench_nlike_utf8_scalar(&arr_string, "xxxx%"))
+    });
+
+    c.bench_function("like_utf8 scalar starts with", |b| {
+        b.iter(|| bench_nlike_utf8_scalar(&arr_string, "%xxxx"))
+    });
+
+    c.bench_function("like_utf8 scalar complex", |b| {
+        b.iter(|| bench_nlike_utf8_scalar(&arr_string, "%xx_xx%xxx"))
     });
 }
 

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -170,12 +170,12 @@ pub fn like_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray>
         }
     } else if right.ends_with('%') && !right[..right.len() - 1].contains(is_like_pattern)
     {
-        // fast path, can use ends_with
+        // fast path, can use starts_with
         for i in 0..left.len() {
             result.append(left.value(i).starts_with(right))?;
         }
     } else if right.starts_with('%') && !right[1..].contains(is_like_pattern) {
-        // fast path, can use starts_with
+        // fast path, can use ends_with
         for i in 0..left.len() {
             result.append(left.value(i).ends_with(right))?;
         }

--- a/rust/arrow/src/compute/kernels/comparison.rs
+++ b/rust/arrow/src/compute/kernels/comparison.rs
@@ -130,7 +130,7 @@ pub fn like_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray
             regex
         } else {
             let re_pattern = pat.replace("%", ".*").replace("_", ".");
-            let re = Regex::new(&re_pattern).map_err(|e| {
+            let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
                 ArrowError::ComputeError(format!(
                     "Unable to build regex from LIKE pattern: {}",
                     e
@@ -155,15 +155,15 @@ pub fn like_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArray
     Ok(PrimitiveArray::<BooleanType>::from(Arc::new(data)))
 }
 
+fn is_like_pattern(c: char) -> bool {
+    c == '%' || c == '_'
+}
+
 pub fn like_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray> {
     let null_bit_buffer = left.data().null_buffer().cloned();
     let mut result = BooleanBufferBuilder::new(left.len());
 
-    fn is_like_pattern(c: char) -> bool {
-        c == '%' || c == '_'
-    }
-
-    if !right.contains(|x| x == '%' || x == '.') {
+    if !right.contains(is_like_pattern) {
         // fast path, can use equals
         for i in 0..left.len() {
             result.append(left.value(i) == right)?;
@@ -172,16 +172,16 @@ pub fn like_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray>
     {
         // fast path, can use ends_with
         for i in 0..left.len() {
-            result.append(left.value(i).starts_with(right))?;
+            result.append(left.value(i).starts_with(&right[..right.len() - 1]))?;
         }
     } else if right.starts_with('%') && !right[1..].contains(is_like_pattern) {
         // fast path, can use starts_with
         for i in 0..left.len() {
-            result.append(left.value(i).ends_with(right))?;
+            result.append(left.value(i).ends_with(&right[1..]))?;
         }
     } else {
         let re_pattern = right.replace("%", ".*").replace("_", ".");
-        let re = Regex::new(&re_pattern).map_err(|e| {
+        let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
             ArrowError::ComputeError(format!(
                 "Unable to build regex from LIKE pattern: {}",
                 e
@@ -226,7 +226,7 @@ pub fn nlike_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArra
             regex
         } else {
             let re_pattern = pat.replace("%", ".*").replace("_", ".");
-            let re = Regex::new(&re_pattern).map_err(|e| {
+            let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
                 ArrowError::ComputeError(format!(
                     "Unable to build regex from LIKE pattern: {}",
                     e
@@ -253,18 +253,36 @@ pub fn nlike_utf8(left: &StringArray, right: &StringArray) -> Result<BooleanArra
 
 pub fn nlike_utf8_scalar(left: &StringArray, right: &str) -> Result<BooleanArray> {
     let null_bit_buffer = left.data().null_buffer().cloned();
-    let re_pattern = right.replace("%", ".*").replace("_", ".");
-    let re = Regex::new(&re_pattern).map_err(|e| {
-        ArrowError::ComputeError(format!(
-            "Unable to build regex from LIKE pattern: {}",
-            e
-        ))
-    })?;
-
     let mut result = BooleanBufferBuilder::new(left.len());
-    for i in 0..left.len() {
-        let haystack = left.value(i);
-        result.append(!re.is_match(haystack))?;
+
+    if !right.contains(is_like_pattern) {
+        // fast path, can use equals
+        for i in 0..left.len() {
+            result.append(left.value(i) != right)?;
+        }
+    } else if right.ends_with('%') && !right[..right.len() - 1].contains(is_like_pattern)
+    {
+        // fast path, can use ends_with
+        for i in 0..left.len() {
+            result.append(!left.value(i).starts_with(&right[..right.len() - 1]))?;
+        }
+    } else if right.starts_with('%') && !right[1..].contains(is_like_pattern) {
+        // fast path, can use starts_with
+        for i in 0..left.len() {
+            result.append(!left.value(i).ends_with(&right[1..]))?;
+        }
+    } else {
+        let re_pattern = right.replace("%", ".*").replace("_", ".");
+        let re = Regex::new(&format!("^{}$", re_pattern)).map_err(|e| {
+            ArrowError::ComputeError(format!(
+                "Unable to build regex from LIKE pattern: {}",
+                e
+            ))
+        })?;
+        for i in 0..left.len() {
+            let haystack = left.value(i);
+            result.append(!re.is_match(haystack))?;
+        }
     }
 
     let data = ArrayData::new(
@@ -1155,11 +1173,12 @@ mod tests {
 
     test_utf8!(
         test_utf8_array_like,
-        vec!["arrow", "arrow", "arrow", "arrow"],
-        vec!["arrow", "ar%", "%ro%", "foo"],
+        vec!["arrow", "arrow", "arrow", "arrow", "arrow", "arrows", "arrow"],
+        vec!["arrow", "ar%", "%ro%", "foo", "arr", "arrow_", "arrow_"],
         like_utf8,
-        vec![true, true, true, false]
+        vec![true, true, true, false, false, true, false]
     );
+
     test_utf8_scalar!(
         test_utf8_array_like_scalar,
         vec!["arrow", "parquet", "datafusion", "flight"],
@@ -1167,12 +1186,44 @@ mod tests {
         like_utf8_scalar,
         vec![true, true, false, false]
     );
+    test_utf8_scalar!(
+        test_utf8_array_like_scalar_start,
+        vec!["arrow", "parrow", "arrows", "arr"],
+        "arrow%",
+        like_utf8_scalar,
+        vec![true, false, true, false]
+    );
+
+    test_utf8_scalar!(
+        test_utf8_array_like_scalar_end,
+        vec!["arrow", "parrow", "arrows", "arr"],
+        "%arrow",
+        like_utf8_scalar,
+        vec![true, true, false, false]
+    );
+
+    test_utf8_scalar!(
+        test_utf8_array_like_scalar_equals,
+        vec!["arrow", "parrow", "arrows", "arr"],
+        "arrow",
+        like_utf8_scalar,
+        vec![true, false, false, false]
+    );
+
+    test_utf8_scalar!(
+        test_utf8_array_like_scalar_one,
+        vec!["arrow", "arrows", "parrow", "arr"],
+        "arrow_",
+        like_utf8_scalar,
+        vec![false, true, false, false]
+    );
+
     test_utf8!(
         test_utf8_array_nlike,
-        vec!["arrow", "arrow", "arrow", "arrow"],
-        vec!["arrow", "ar%", "%ro%", "foo"],
+        vec!["arrow", "arrow", "arrow", "arrow", "arrow", "arrows", "arrow"],
+        vec!["arrow", "ar%", "%ro%", "foo", "arr", "arrow_", "arrow_"],
         nlike_utf8,
-        vec![false, false, false, true]
+        vec![false, false, false, true, true, false, true]
     );
     test_utf8_scalar!(
         test_utf8_array_nlike_scalar,
@@ -1195,6 +1246,38 @@ mod tests {
         "arrow",
         eq_utf8_scalar,
         vec![true, false, false, false]
+    );
+
+    test_utf8_scalar!(
+        test_utf8_array_nlike_scalar_start,
+        vec!["arrow", "parrow", "arrows", "arr"],
+        "arrow%",
+        nlike_utf8_scalar,
+        vec![false, true, false, true]
+    );
+
+    test_utf8_scalar!(
+        test_utf8_array_nlike_scalar_end,
+        vec!["arrow", "parrow", "arrows", "arr"],
+        "%arrow",
+        nlike_utf8_scalar,
+        vec![false, false, true, true]
+    );
+
+    test_utf8_scalar!(
+        test_utf8_array_nlike_scalar_equals,
+        vec!["arrow", "parrow", "arrows", "arr"],
+        "arrow",
+        nlike_utf8_scalar,
+        vec![false, true, true, true]
+    );
+
+    test_utf8_scalar!(
+        test_utf8_array_nlike_scalar_one,
+        vec!["arrow", "arrows", "parrow", "arr"],
+        "arrow_",
+        nlike_utf8_scalar,
+        vec![true, false, true, true]
     );
 
     test_utf8!(


### PR DESCRIPTION
Commonly used patterns '%xxx'  'xxx%' and 'xxx' can use faster methods from Rust standard lib instead.

```
like_utf8 scalar equals time:   [828.13 us 830.08 us 832.39 us]                                    
                        change: [-43.306% -42.962% -42.610%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)

like_utf8 scalar ends with                                                                            
                        time:   [927.93 us 929.31 us 930.88 us]
                        change: [-59.220% -59.149% -59.082%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

like_utf8 scalar starts with                                                                            
                        time:   [930.96 us 931.70 us 932.63 us]
                        change: [-43.537% -43.432% -43.325%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Also tried fast path for contains (`%xxx%`), but that was (almost 2 times) slower than using the regex.
