### PR TITLE
ARROW-10667: [Rust] [Parquet] Add a convenience type for writing Parquet to memory

### DIFF
--- a/rust/parquet/src/util/cursor.rs
+++ b/rust/parquet/src/util/cursor.rs
@@ -15,9 +15,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom};
-use std::sync::Arc;
+use std::io::{self, Cursor, Error, ErrorKind, Read, Seek, SeekFrom, Write};
+use std::sync::{Arc, Mutex};
 use std::{cmp, fmt};
+
+use crate::file::writer::TryClone;
 
 /// This is object to use if your file is already in memory.
 /// The sliceable cursor is similar to std::io::Cursor, except that it makes it easy to create "cursor slices".
@@ -126,6 +128,56 @@ impl Seek for SliceableCursor {
             self.pos = new_pos as u64;
             Ok(self.start)
         }
+    }
+}
+
+/// Use this type to write Parquet to memory rather than a file.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryWriteableCursor {
+    buffer: Arc<Mutex<Cursor<Vec<u8>>>>,
+}
+
+impl InMemoryWriteableCursor {
+    /// Consume this instance and return the underlying buffer as long as there are no other
+    /// references to this instance.
+    pub fn into_inner(self) -> Option<Vec<u8>> {
+        Arc::try_unwrap(self.buffer)
+            .ok()
+            .and_then(|mutex| mutex.into_inner().ok())
+            .map(|cursor| cursor.into_inner())
+    }
+
+    /// Returns a clone of the underlying buffer
+    pub fn data(&self) -> Vec<u8> {
+        let inner = self.buffer.lock().unwrap();
+        inner.get_ref().to_vec()
+    }
+}
+
+impl TryClone for InMemoryWriteableCursor {
+    fn try_clone(&self) -> std::io::Result<Self> {
+        Ok(Self {
+            buffer: self.buffer.clone(),
+        })
+    }
+}
+
+impl Write for InMemoryWriteableCursor {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut inner = self.buffer.lock().unwrap();
+        inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let mut inner = self.buffer.lock().unwrap();
+        inner.flush()
+    }
+}
+
+impl Seek for InMemoryWriteableCursor {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let mut inner = self.buffer.lock().unwrap();
+        inner.seek(pos)
     }
 }
 


### PR DESCRIPTION
Similar to the [`SliceableCursor`](https://github.com/apache/arrow/blob/0e841aa666b637e24e2889acab7621aa01fb7bcf/rust/parquet/src/util/cursor.rs#L22-L27) type that provides a convenience for reading Parquet from memory, I would like to propose a type to make it convenient to write Parquet to memory.

This is possible for clients to implement today, but seems common enough to want to provide for everyone to use.
