### PR TITLE
ARROW-10666: [Rust][DataFusion] Support nested SELECT statements.

### DIFF
--- a/rust/datafusion/README.md
+++ b/rust/datafusion/README.md
@@ -67,7 +67,7 @@ DataFusion includes a simple command-line interactive SQL utility. See the [CLI 
 - [x] Sorting
 - [ ] Nested types
 - [ ] Lists
-- [ ] Subqueries
+- [x] Subqueries
 - [ ] Joins
 
 ## Data Sources

--- a/rust/datafusion/tests/sql.rs
+++ b/rust/datafusion/tests/sql.rs
@@ -228,6 +228,34 @@ async fn parquet_list_columns() {
 }
 
 #[tokio::test]
+async fn csv_select_nested() -> Result<()> {
+    let mut ctx = ExecutionContext::new();
+    register_aggregate_csv(&mut ctx)?;
+    let sql = "SELECT o1, o2, c3
+               FROM (
+                 SELECT c1 AS o1, c2 + 1 AS o2, c3
+                 FROM (
+                   SELECT c1, c2, c3, c4
+                   FROM aggregate_test_100
+                   WHERE c1 = 'a' AND c2 >= 4
+                   ORDER BY c2 ASC, c3 ASC
+                 )
+               )";
+    let actual = execute(&mut ctx, sql).await;
+    let expected = vec![
+        vec!["a", "5", "-101"],
+        vec!["a", "5", "-54"],
+        vec!["a", "5", "-38"],
+        vec!["a", "5", "65"],
+        vec!["a", "6", "-101"],
+        vec!["a", "6", "-31"],
+        vec!["a", "6", "36"],
+    ];
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn csv_count_star() -> Result<()> {
     let mut ctx = ExecutionContext::new();
     register_aggregate_csv(&mut ctx)?;


### PR DESCRIPTION
[ARROW-10666](https://issues.apache.org/jira/browse/ARROW-10666) This PR enables nested `SELECT` statements. Note that table aliases remain unsupported, and no optimizations are made during the planning stages. 