### PR TITLE
[Rust] [RFC] Native Rust Arrow SQL IO

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,4 +25,5 @@ members = [
         "arrow-flight",
         "integration-testing",
 	"benchmarks",
+	"sql",
 ]

--- a/rust/arrow/src/error.rs
+++ b/rust/arrow/src/error.rs
@@ -36,6 +36,7 @@ pub enum ArrowError {
     InvalidArgumentError(String),
     ParquetError(String),
     DictionaryKeyOverflowError,
+    SqlError(String),
 }
 
 impl ArrowError {
@@ -106,6 +107,7 @@ impl Display for ArrowError {
             ArrowError::DictionaryKeyOverflowError => {
                 write!(f, "Dictionary key bigger than the key type")
             }
+            ArrowError::SqlError(desc) => write!(f, "SQL error: {}", desc),
         }
     }
 }

--- a/rust/datafusion/Cargo.toml
+++ b/rust/datafusion/Cargo.toml
@@ -47,6 +47,7 @@ cli = ["rustyline"]
 ahash = "0.5"
 arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT", features = ["prettyprint"] }
 parquet = { path = "../parquet", version = "3.0.0-SNAPSHOT", features = ["arrow"] }
+arrow-sql = { path = "../sql", version = "3.0.0-SNAPSHOT" }
 sqlparser = "0.6.1"
 clap = "2.33"
 rustyline = {version = "6.0", optional = true}

--- a/rust/datafusion/examples/database_sql.rs
+++ b/rust/datafusion/examples/database_sql.rs
@@ -1,0 +1,59 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::util::pretty;
+
+use datafusion::error::Result;
+use datafusion::prelude::*;
+
+/// This example demonstrates executing a simple query against a SQL database and
+/// fetching results.
+/// The example assumes that one has a table called `nyc_yellow_taxi` in a postgresql
+/// database.
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Please note, the example is to demonstrate functionality, and it reads in
+    // a lot of data. The intention is to create a small table for CI, which
+    // we can also use to run examples
+
+    // create local execution context
+    let mut ctx = ExecutionContext::new();
+
+    // register csv file with the execution context
+    ctx.register_sql_source(
+        "nyctaxi",
+        "postgres://postgres:password@localhost:5432/postgres",
+        "select * from nyc_yellow_taxi limit 1048576 * 2",
+    )?;
+
+    // execute the query
+    let df = ctx.sql(
+        "SELECT vendorId, RateCodeID, MIN(passenger_count) as min_passengers, \
+        MAX(passenger_count) as max_passengers, \
+        AVG(passenger_count) as avg_passengers \
+        FROM nyctaxi \
+        WHERE trip_distance > 10.0 AND passenger_count > 0 \
+        GROUP BY vendorId, RateCodeID \
+        ORDER BY RateCodeID DESC",
+    )?;
+    let results = df.collect().await?;
+
+    // print the results
+    pretty::print_batches(&results)?;
+
+    Ok(())
+}

--- a/rust/datafusion/src/datasource/mod.rs
+++ b/rust/datafusion/src/datasource/mod.rs
@@ -21,6 +21,7 @@ pub mod csv;
 pub mod datasource;
 pub mod memory;
 pub mod parquet;
+pub mod sql;
 
 pub use self::csv::{CsvFile, CsvReadOptions};
 pub use self::datasource::TableProvider;

--- a/rust/datafusion/src/datasource/sql.rs
+++ b/rust/datafusion/src/datasource/sql.rs
@@ -1,0 +1,315 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! SQL data source
+
+use std::string::String;
+use std::sync::Arc;
+
+use arrow::datatypes::*;
+
+use crate::datasource::TableProvider;
+use crate::error::Result;
+use crate::physical_plan::sql::SqlExec;
+use crate::physical_plan::ExecutionPlan;
+
+/// Table-based representation of a `ParquetFile`.
+pub struct SqlTable {
+    connection: String,
+    query: String,
+    schema: SchemaRef,
+}
+
+impl SqlTable {
+    /// Attempt to initialize a new `SqlTable` from a connection string.
+    pub fn try_new(connection: &str, query: &str) -> Result<Self> {
+        let sql_exec = SqlExec::try_new(connection, query, None, 65536)?;
+        let schema = sql_exec.schema();
+        Ok(Self {
+            connection: connection.to_string(),
+            query: query.to_string(),
+            schema,
+        })
+    }
+}
+
+impl TableProvider for SqlTable {
+    /// Get the schema for this parquet file.
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    /// Scan the table/query, using the provided projection, and return one BatchIterator per
+    /// partition.
+    fn scan(
+        &self,
+        projection: &Option<Vec<usize>>,
+        batch_size: usize,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        Ok(Arc::new(SqlExec::try_new(
+            &self.connection,
+            &self.query,
+            projection.clone(),
+            batch_size,
+        )?))
+    }
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use arrow::array::{
+//         BinaryArray, BooleanArray, Float32Array, Float64Array, Int32Array,
+//         TimestampNanosecondArray,
+//     };
+//     use arrow::record_batch::RecordBatch;
+//     use futures::StreamExt;
+//     use std::env;
+
+//     #[tokio::test]
+//     async fn read_small_batches() -> Result<()> {
+//         let table = load_table("alltypes_plain.parquet")?;
+//         let projection = None;
+//         let exec = table.scan(&projection, 2)?;
+//         let stream = exec.execute(0).await?;
+
+//         let count = stream
+//             .map(|batch| {
+//                 let batch = batch.unwrap();
+//                 assert_eq!(11, batch.num_columns());
+//                 assert_eq!(2, batch.num_rows());
+//             })
+//             .fold(0, |acc, _| async move { acc + 1i32 })
+//             .await;
+
+//         // we should have seen 4 batches of 2 rows
+//         assert_eq!(4, count);
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn read_alltypes_plain_parquet() -> Result<()> {
+//         let table = load_table("alltypes_plain.parquet")?;
+
+//         let x: Vec<String> = table
+//             .schema()
+//             .fields()
+//             .iter()
+//             .map(|f| format!("{}: {:?}", f.name(), f.data_type()))
+//             .collect();
+//         let y = x.join("\n");
+//         assert_eq!(
+//             "id: Int32\n\
+//              bool_col: Boolean\n\
+//              tinyint_col: Int32\n\
+//              smallint_col: Int32\n\
+//              int_col: Int32\n\
+//              bigint_col: Int64\n\
+//              float_col: Float32\n\
+//              double_col: Float64\n\
+//              date_string_col: Binary\n\
+//              string_col: Binary\n\
+//              timestamp_col: Timestamp(Nanosecond, None)",
+//             y
+//         );
+
+//         let projection = None;
+//         let batch = get_first_batch(table, &projection).await?;
+
+//         assert_eq!(11, batch.num_columns());
+//         assert_eq!(8, batch.num_rows());
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn read_bool_alltypes_plain_parquet() -> Result<()> {
+//         let table = load_table("alltypes_plain.parquet")?;
+//         let projection = Some(vec![1]);
+//         let batch = get_first_batch(table, &projection).await?;
+
+//         assert_eq!(1, batch.num_columns());
+//         assert_eq!(8, batch.num_rows());
+
+//         let array = batch
+//             .column(0)
+//             .as_any()
+//             .downcast_ref::<BooleanArray>()
+//             .unwrap();
+//         let mut values: Vec<bool> = vec![];
+//         for i in 0..batch.num_rows() {
+//             values.push(array.value(i));
+//         }
+
+//         assert_eq!(
+//             "[true, false, true, false, true, false, true, false]",
+//             format!("{:?}", values)
+//         );
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn read_i32_alltypes_plain_parquet() -> Result<()> {
+//         let table = load_table("alltypes_plain.parquet")?;
+//         let projection = Some(vec![0]);
+//         let batch = get_first_batch(table, &projection).await?;
+
+//         assert_eq!(1, batch.num_columns());
+//         assert_eq!(8, batch.num_rows());
+
+//         let array = batch
+//             .column(0)
+//             .as_any()
+//             .downcast_ref::<Int32Array>()
+//             .unwrap();
+//         let mut values: Vec<i32> = vec![];
+//         for i in 0..batch.num_rows() {
+//             values.push(array.value(i));
+//         }
+
+//         assert_eq!("[4, 5, 6, 7, 2, 3, 0, 1]", format!("{:?}", values));
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn read_i96_alltypes_plain_parquet() -> Result<()> {
+//         let table = load_table("alltypes_plain.parquet")?;
+//         let projection = Some(vec![10]);
+//         let batch = get_first_batch(table, &projection).await?;
+
+//         assert_eq!(1, batch.num_columns());
+//         assert_eq!(8, batch.num_rows());
+
+//         let array = batch
+//             .column(0)
+//             .as_any()
+//             .downcast_ref::<TimestampNanosecondArray>()
+//             .unwrap();
+//         let mut values: Vec<i64> = vec![];
+//         for i in 0..batch.num_rows() {
+//             values.push(array.value(i));
+//         }
+
+//         assert_eq!("[1235865600000000000, 1235865660000000000, 1238544000000000000, 1238544060000000000, 1233446400000000000, 1233446460000000000, 1230768000000000000, 1230768060000000000]", format!("{:?}", values));
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn read_f32_alltypes_plain_parquet() -> Result<()> {
+//         let table = load_table("alltypes_plain.parquet")?;
+//         let projection = Some(vec![6]);
+//         let batch = get_first_batch(table, &projection).await?;
+
+//         assert_eq!(1, batch.num_columns());
+//         assert_eq!(8, batch.num_rows());
+
+//         let array = batch
+//             .column(0)
+//             .as_any()
+//             .downcast_ref::<Float32Array>()
+//             .unwrap();
+//         let mut values: Vec<f32> = vec![];
+//         for i in 0..batch.num_rows() {
+//             values.push(array.value(i));
+//         }
+
+//         assert_eq!(
+//             "[0.0, 1.1, 0.0, 1.1, 0.0, 1.1, 0.0, 1.1]",
+//             format!("{:?}", values)
+//         );
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn read_f64_alltypes_plain_parquet() -> Result<()> {
+//         let table = load_table("alltypes_plain.parquet")?;
+//         let projection = Some(vec![7]);
+//         let batch = get_first_batch(table, &projection).await?;
+
+//         assert_eq!(1, batch.num_columns());
+//         assert_eq!(8, batch.num_rows());
+
+//         let array = batch
+//             .column(0)
+//             .as_any()
+//             .downcast_ref::<Float64Array>()
+//             .unwrap();
+//         let mut values: Vec<f64> = vec![];
+//         for i in 0..batch.num_rows() {
+//             values.push(array.value(i));
+//         }
+
+//         assert_eq!(
+//             "[0.0, 10.1, 0.0, 10.1, 0.0, 10.1, 0.0, 10.1]",
+//             format!("{:?}", values)
+//         );
+
+//         Ok(())
+//     }
+
+//     #[tokio::test]
+//     async fn read_binary_alltypes_plain_parquet() -> Result<()> {
+//         let table = load_table("alltypes_plain.parquet")?;
+//         let projection = Some(vec![9]);
+//         let batch = get_first_batch(table, &projection).await?;
+
+//         assert_eq!(1, batch.num_columns());
+//         assert_eq!(8, batch.num_rows());
+
+//         let array = batch
+//             .column(0)
+//             .as_any()
+//             .downcast_ref::<BinaryArray>()
+//             .unwrap();
+//         let mut values: Vec<&str> = vec![];
+//         for i in 0..batch.num_rows() {
+//             values.push(std::str::from_utf8(array.value(i)).unwrap());
+//         }
+
+//         assert_eq!(
+//             "[\"0\", \"1\", \"0\", \"1\", \"0\", \"1\", \"0\", \"1\"]",
+//             format!("{:?}", values)
+//         );
+
+//         Ok(())
+//     }
+
+//     fn load_table(name: &str) -> Result<Box<dyn TableProvider>> {
+//         let testdata =
+//             env::var("PARQUET_TEST_DATA").expect("PARQUET_TEST_DATA not defined");
+//         let filename = format!("{}/{}", testdata, name);
+//         let table = SqlTable::try_new(&filename)?;
+//         Ok(Box::new(table))
+//     }
+
+//     async fn get_first_batch(
+//         table: Box<dyn TableProvider>,
+//         projection: &Option<Vec<usize>>,
+//     ) -> Result<RecordBatch> {
+//         let exec = table.scan(projection, 1024)?;
+//         let mut it = exec.execute(0).await?;
+//         it.next()
+//             .await
+//             .expect("should have received at least one batch")
+//             .map_err(|e| e.into())
+//     }
+// }

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -329,6 +329,28 @@ fn optimize_plan(
                 projected_schema: projected_schema,
             })
         }
+        LogicalPlan::SqlScan {
+            connection,
+            query,
+            schema,
+            projection,
+            ..
+        } => {
+            let (projection, projected_schema) = get_projected_schema(
+                &schema,
+                projection,
+                required_columns,
+                has_projection,
+            )?;
+
+            Ok(LogicalPlan::SqlScan {
+                connection: connection.to_owned(),
+                query: query.to_owned(),
+                schema: schema.clone(),
+                projection: Some(projection),
+                projected_schema,
+            })
+        }
         LogicalPlan::Explain {
             verbose,
             plan,

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -150,6 +150,7 @@ pub fn expressions(plan: &LogicalPlan) -> Vec<Expr> {
         | LogicalPlan::InMemoryScan { .. }
         | LogicalPlan::ParquetScan { .. }
         | LogicalPlan::CsvScan { .. }
+        | LogicalPlan::SqlScan { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::Limit { .. }
         | LogicalPlan::CreateExternalTable { .. }
@@ -172,6 +173,7 @@ pub fn inputs(plan: &LogicalPlan) -> Vec<&LogicalPlan> {
         | LogicalPlan::InMemoryScan { .. }
         | LogicalPlan::ParquetScan { .. }
         | LogicalPlan::CsvScan { .. }
+        | LogicalPlan::SqlScan { .. }
         | LogicalPlan::EmptyRelation { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Explain { .. } => vec![],
@@ -230,6 +232,7 @@ pub fn from_plan(
         | LogicalPlan::InMemoryScan { .. }
         | LogicalPlan::ParquetScan { .. }
         | LogicalPlan::CsvScan { .. }
+        | LogicalPlan::SqlScan { .. }
         | LogicalPlan::CreateExternalTable { .. }
         | LogicalPlan::Explain { .. } => Ok(plan.clone()),
     }

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -245,6 +245,7 @@ pub mod parquet;
 pub mod planner;
 pub mod projection;
 pub mod sort;
+pub mod sql;
 pub mod string_expressions;
 pub mod type_coercion;
 pub mod udaf;

--- a/rust/datafusion/src/physical_plan/planner.rs
+++ b/rust/datafusion/src/physical_plan/planner.rs
@@ -38,6 +38,7 @@ use crate::physical_plan::merge::MergeExec;
 use crate::physical_plan::parquet::ParquetExec;
 use crate::physical_plan::projection::ProjectionExec;
 use crate::physical_plan::sort::SortExec;
+use crate::physical_plan::sql::SqlExec;
 use crate::physical_plan::udf;
 use crate::physical_plan::{expressions, Distribution};
 use crate::physical_plan::{AggregateExpr, ExecutionPlan, PhysicalExpr, PhysicalPlanner};
@@ -185,6 +186,17 @@ impl DefaultPhysicalPlanner {
                 path, projection, ..
             } => Ok(Arc::new(ParquetExec::try_new(
                 path,
+                projection.to_owned(),
+                batch_size,
+            )?)),
+            LogicalPlan::SqlScan {
+                connection,
+                query,
+                projection,
+                ..
+            } => Ok(Arc::new(SqlExec::try_new(
+                connection,
+                query,
                 projection.to_owned(),
                 batch_size,
             )?)),

--- a/rust/datafusion/src/physical_plan/sql.rs
+++ b/rust/datafusion/src/physical_plan/sql.rs
@@ -1,0 +1,246 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! Execution plan for reading Parquet files
+
+use std::any::Any;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::{fmt, thread};
+
+use super::{RecordBatchStream, SendableRecordBatchStream};
+use crate::error::{DataFusionError, Result};
+use crate::physical_plan::ExecutionPlan;
+use crate::physical_plan::Partitioning;
+use arrow::datatypes::SchemaRef;
+use arrow::error::{ArrowError, Result as ArrowResult};
+use arrow::record_batch::RecordBatch;
+use arrow_sql::postgres::PostgresReadIterator;
+use crossbeam::channel::{bounded, Receiver, RecvError, Sender};
+use fmt::Debug;
+
+use async_trait::async_trait;
+use futures::stream::Stream;
+
+/// Execution plan for scanning a SQL data source
+#[derive(Debug, Clone)]
+pub struct SqlExec {
+    /// SQL connection
+    connection: String,
+    /// SQL query
+    query: String,
+    /// Schema after projection is applied
+    schema: SchemaRef,
+    /// Projection for which columns to load
+    projection: Vec<usize>,
+    /// Batch size
+    batch_size: usize,
+}
+
+impl SqlExec {
+    /// Create a new SQL reader execution plan
+    pub fn try_new(
+        connection: &str,
+        query: &str,
+        projection: Option<Vec<usize>>,
+        batch_size: usize,
+    ) -> Result<Self> {
+        // TODO: we could/should determine the type of database at this point
+        let reader =
+            PostgresReadIterator::try_new(connection, query, Some(1), batch_size)?;
+        let schema = Arc::new(reader.schema().clone());
+        let projection =
+            projection.unwrap_or_else(|| (0..schema.fields().len()).collect());
+
+        Ok(Self {
+            connection: connection.to_string(),
+            query: query.to_string(),
+            schema,
+            projection,
+            batch_size,
+        })
+    }
+}
+
+#[async_trait]
+impl ExecutionPlan for SqlExec {
+    /// Return a reference to Any that can be used for downcasting
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        // this is a leaf node and has no children
+        vec![]
+    }
+
+    /// Get the output partitioning of this plan
+    fn output_partitioning(&self) -> Partitioning {
+        // TODO: we could determine the record length (via a cancellable query?)
+        // then use this to determine partitioning
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn with_new_children(
+        &self,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        if children.is_empty() {
+            Ok(Arc::new(self.clone()))
+        } else {
+            Err(DataFusionError::Internal(format!(
+                "Children cannot be replaced in {:?}",
+                self
+            )))
+        }
+    }
+
+    async fn execute(&self, _partition: usize) -> Result<SendableRecordBatchStream> {
+        // each connection should be created on its own thread
+        let (response_tx, response_rx): (
+            Sender<Option<ArrowResult<RecordBatch>>>,
+            Receiver<Option<ArrowResult<RecordBatch>>>,
+        ) = bounded(2);
+
+        let connection = self.connection.clone();
+        let query = self.query.clone();
+        let projection = self.projection.clone();
+        let batch_size = self.batch_size;
+
+        thread::spawn(move || {
+            if let Err(e) =
+                run_query(&connection, &query, projection, batch_size, response_tx)
+            {
+                println!("Parquet reader thread terminated due to error: {:?}", e);
+            }
+        });
+
+        Ok(Box::pin(SqlStream {
+            schema: self.schema.clone(),
+            response_rx,
+        }))
+    }
+}
+
+fn send_result(
+    response_tx: &Sender<Option<ArrowResult<RecordBatch>>>,
+    result: Option<ArrowResult<RecordBatch>>,
+) -> Result<()> {
+    response_tx
+        .send(result)
+        .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+    Ok(())
+}
+
+fn run_query(
+    connection: &str,
+    query: &str,
+    _projection: Vec<usize>,
+    batch_size: usize,
+    response_tx: Sender<Option<ArrowResult<RecordBatch>>>,
+) -> Result<()> {
+    let mut batch_reader =
+        PostgresReadIterator::try_new(connection, query, None, batch_size)?;
+    loop {
+        match batch_reader.next() {
+            Some(Ok(batch)) => send_result(&response_tx, Some(Ok(batch)))?,
+            None => {
+                // finished reading file
+                send_result(&response_tx, None)?;
+                break;
+            }
+            Some(Err(e)) => {
+                let err_msg =
+                    format!("Error reading batch from SQL query: {}", e.to_string());
+                // send error to operator
+                send_result(
+                    &response_tx,
+                    Some(Err(ArrowError::SqlError(err_msg.clone()))),
+                )?;
+                // terminate thread with error
+                return Err(DataFusionError::Execution(err_msg));
+            }
+        }
+    }
+    Ok(())
+}
+
+struct SqlStream {
+    schema: SchemaRef,
+    response_rx: Receiver<Option<ArrowResult<RecordBatch>>>,
+}
+
+impl Stream for SqlStream {
+    type Item = ArrowResult<RecordBatch>;
+
+    fn poll_next(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        match self.response_rx.recv() {
+            Ok(batch) => Poll::Ready(batch),
+            // RecvError means receiver has exited and closed the channel
+            Err(RecvError) => Poll::Ready(None),
+        }
+    }
+}
+
+impl RecordBatchStream for SqlStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn test() -> Result<()> {
+        let connection = "";
+        let query = "";
+        let sql_exec = SqlExec::try_new(connection, query, None, 1024)?;
+        assert_eq!(sql_exec.output_partitioning().partition_count(), 1);
+
+        let mut results = sql_exec.execute(0).await?;
+        let batch = results.next().await.unwrap()?;
+
+        assert_eq!(8, batch.num_rows());
+        assert_eq!(3, batch.num_columns());
+
+        let schema = batch.schema();
+        let field_names: Vec<&str> =
+            schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(vec!["id", "bool_col", "tinyint_col"], field_names);
+
+        let batch = results.next().await;
+        assert!(batch.is_none());
+
+        let batch = results.next().await;
+        assert!(batch.is_none());
+
+        let batch = results.next().await;
+        assert!(batch.is_none());
+
+        Ok(())
+    }
+}

--- a/rust/sql/Cargo.toml
+++ b/rust/sql/Cargo.toml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[package]
+name = "arrow-sql"
+description = "SQL connectors that return Apache Arrow record batches"
+version = "3.0.0-SNAPSHOT"
+homepage = "https://github.com/apache/arrow"
+repository = "https://github.com/apache/arrow"
+authors = ["Apache Arrow <dev@arrow.apache.org>"]
+license = "Apache-2.0"
+keywords = [ "arrow", "query", "sql" ]
+include = [
+    "benches/*.rs",
+    "src/**/*.rs",
+    "Cargo.toml",
+]
+edition = "2018"
+
+[dependencies]
+arrow = { path = "../arrow", version = "3.0.0-SNAPSHOT", features = ["prettyprint"] }
+sqlparser = "0.6.1"
+postgres = {version = "0.18", features = ["with-chrono-0_4", "with-uuid-0_8"]}
+chrono = "0.4"
+byteorder = "1"
+# async-trait = "0.1.41"
+# futures = "0.3"
+# pin-project-lite= "^0.2.0"
+# tokio = { version = "0.3", features = ["macros", "rt", "rt-multi-thread"] }
+
+[dev-dependencies]
+criterion = "0.3"
+tempfile = "3"

--- a/rust/sql/README.md
+++ b/rust/sql/README.md
@@ -1,0 +1,25 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# Arrow SQL Connectors
+
+Traits and implementations for reading and writing bulk data between SQL databases and Apache Arrow.
+
+# Supported SQL Databases/Protocols
+

--- a/rust/sql/src/lib.rs
+++ b/rust/sql/src/lib.rs
@@ -28,9 +28,9 @@ pub mod postgres;
 /// a SQL data source, used to read data from a SQL database into Arrow batches
 pub trait SqlDataSource {
     /// Get the schema of a table
-    /// 
-    /// A reader (e.g. DataFusion) is expected to use this even for queries, 
-    /// as it could be useful to know what a table looks like, before parsing 
+    ///
+    /// A reader (e.g. DataFusion) is expected to use this even for queries,
+    /// as it could be useful to know what a table looks like, before parsing
     /// its schema by projecting only the necessary columns
     fn get_table_schema(connection: &str, table_name: &str) -> Result<Schema>;
 
@@ -61,11 +61,8 @@ pub trait SqlDataSink {
     /// Create a new table from an Arrow schema reference
     ///
     /// TODO: provide options such as whether to overwrite existing table
-    fn create_table(
-        connection: &str,
-        table_name: &str,
-        schema: &SchemaRef,
-    ) -> Result<()>;
+    fn create_table(connection: &str, table_name: &str, schema: &SchemaRef)
+        -> Result<()>;
 
     /// Write record batches to a SQL table
     ///

--- a/rust/sql/src/lib.rs
+++ b/rust/sql/src/lib.rs
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#![allow(dead_code)]
+
+use arrow::datatypes::{Schema, SchemaRef};
+use arrow::error::Result;
+use arrow::record_batch::RecordBatch;
+
+// supported database modules
+pub mod postgres;
+
+///
+/// a SQL data source, used to read data from a SQL database into Arrow batches
+pub trait SqlDataSource {
+    /// Get the schema of a table
+    /// 
+    /// A reader (e.g. DataFusion) is expected to use this even for queries, 
+    /// as it could be useful to know what a table looks like, before parsing 
+    /// its schema by projecting only the necessary columns
+    fn get_table_schema(connection: &str, table_name: &str) -> Result<Schema>;
+
+    /// Read a table into record batches, applying any necessary limit.
+    ///
+    /// TODO: this returns a vector of batches, but we should change it to return
+    /// an iterator or a stream for its async counterpart.
+    /// The idea is that we can use the batch_size and limit to alter SQL queries
+    /// to skip n records
+    fn read_table(
+        connection: &str,
+        table_name: &str,
+        limit: Option<usize>,
+        batch_size: usize,
+    ) -> Result<Vec<RecordBatch>>;
+
+    /// Run a SQL query, and return its results as record batches, applying any
+    /// necessary limit.
+    fn read_query(
+        connection: &str,
+        query: &str,
+        limit: Option<usize>,
+        batch_size: usize,
+    ) -> Result<Vec<RecordBatch>>;
+}
+
+pub trait SqlDataSink {
+    /// Create a new table from an Arrow schema reference
+    ///
+    /// TODO: provide options such as whether to overwrite existing table
+    fn create_table(
+        connection: &str,
+        table_name: &str,
+        schema: &SchemaRef,
+    ) -> Result<()>;
+
+    /// Write record batches to a SQL table
+    ///
+    /// TODO: provide options (append, overwrite, fail)
+    /// TODO: how should we validate schemas or map against database schemas (in append)
+    fn write_to_table(
+        connection: &str,
+        table_name: &str,
+        batches: &[RecordBatch],
+    ) -> Result<()>;
+}

--- a/rust/sql/src/postgres/mod.rs
+++ b/rust/sql/src/postgres/mod.rs
@@ -39,4 +39,12 @@ pub struct PostgresReadIterator {
     schema: arrow::datatypes::Schema,
     read_records: usize,
     is_complete: bool,
+    buffers: Buffers,
+}
+
+/// Buffers that can be preallocated, to reduce overall allocations
+pub(super) struct Buffers {
+    pub(super) data_buffers: Vec<Vec<u8>>,
+    pub(super) null_buffers: Vec<Vec<bool>>,
+    pub(super) offset_buffers: Vec<Vec<i32>>,
 }

--- a/rust/sql/src/postgres/mod.rs
+++ b/rust/sql/src/postgres/mod.rs
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//! An interface for reading and writing record batches to and from PostgreSQL
+
+pub mod reader;
+pub mod writer;
+
+/// PGCOPY header
+pub const MAGIC: &[u8] = b"PGCOPY\n\xff\r\n\0";
+pub const EPOCH_DAYS: i32 = 10957;
+pub const EPOCH_MICROS: i64 = 946684800000000;
+
+pub const UNSUPPORTED_TYPE_ERR: arrow::error::ArrowError =
+    arrow::error::ArrowError::SqlError(String::new());
+
+pub struct Postgres;
+
+/// A Postgres reader that returns an iterator of record batches
+pub struct PostgresReadIterator {
+    client: postgres::Client,
+    query: String,
+    limit: usize,
+    batch_size: usize,
+    schema: arrow::datatypes::Schema,
+    read_records: usize,
+    is_complete: bool,
+}

--- a/rust/sql/src/postgres/reader.rs
+++ b/rust/sql/src/postgres/reader.rs
@@ -1,0 +1,894 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::convert::TryFrom;
+use std::{
+    io::{Read, Write},
+    sync::Arc,
+};
+
+use arrow::array::*;
+use arrow::buffer::Buffer;
+use arrow::datatypes::{
+    DataType, DateUnit, Field, IntervalUnit, Schema, TimeUnit, ToByteSlice,
+};
+use arrow::error::{ArrowError, Result};
+use arrow::record_batch::{RecordBatch, RecordBatchReader};
+use byteorder::{NetworkEndian, ReadBytesExt};
+use chrono::Timelike;
+use postgres::types::*;
+use postgres::{Client, NoTls, Row};
+
+use super::{
+    Postgres, PostgresReadIterator, EPOCH_DAYS, EPOCH_MICROS, MAGIC, UNSUPPORTED_TYPE_ERR,
+};
+use crate::SqlDataSource;
+
+impl SqlDataSource for Postgres {
+    fn get_table_schema(connection_string: &str, table_name: &str) -> Result<Schema> {
+        let (table_schema, table_name) = if table_name.contains('.') {
+            let split = table_name.split('.').collect::<Vec<&str>>();
+            if split.len() != 2 {
+                return Err(ArrowError::IoError(
+                    "table name must have schema and table name only, or just table name"
+                        .to_string(),
+                ));
+            }
+            (
+                format!("table_schema = '{}'", split[0]),
+                format!(" and table_name = '{}'", split[1]),
+            )
+        } else {
+            (String::new(), format!("table_name = '{}'", table_name))
+        };
+        let mut client = Client::connect(connection_string, NoTls).unwrap();
+        let results = client
+            .query(format!("select column_name, ordinal_position, is_nullable, data_type, character_maximum_length, numeric_precision, datetime_precision from information_schema.columns where {}{}", table_schema, table_name).as_str(), &[])
+            .unwrap();
+        let fields: Result<Vec<Field>> = results
+            .iter()
+            .map(|row| PgDataType {
+                column_name: row.get("column_name"),
+                ordinal_position: row.get("ordinal_position"),
+                is_nullable: row.get("is_nullable"),
+                data_type: row.get("data_type"),
+                char_max_length: row.get("character_maximum_length"),
+                numeric_precision: row.get("numeric_precision"),
+                datetime_precision: row.get("datetime_precision"),
+            })
+            .map(Field::try_from)
+            .collect();
+        Ok(Schema::new(fields.unwrap()))
+    }
+
+    fn read_table(
+        connection: &str,
+        table_name: &str,
+        limit: Option<usize>,
+        _batch_size: usize,
+    ) -> Result<Vec<RecordBatch>> {
+        // create connection
+        let mut client = Client::connect(connection, NoTls).unwrap();
+        let total_rows = client
+            .query_one(
+                format!("select count(1) as freq from {}", table_name).as_str(),
+                &[],
+            )
+            .expect("Unable to get row count");
+        let total_rows: i64 = total_rows.get("freq");
+        let limit = limit.unwrap_or(std::usize::MAX).min(total_rows as usize);
+        // get schema
+        // TODO: reuse connection
+        // TODO: split read into multiple batches, using limit and skip
+        let schema = Postgres::get_table_schema(connection, table_name)?;
+        let reader = get_binary_reader(
+            &mut client,
+            format!("select * from {} limit {}", table_name, limit).as_str(),
+        )?;
+        read_from_binary(reader, &schema).map(|batch| vec![batch])
+    }
+
+    fn read_query(
+        connection: &str,
+        query: &str,
+        limit: Option<usize>,
+        _batch_size: usize,
+    ) -> Result<Vec<RecordBatch>> {
+        // create connection
+        let mut client = Client::connect(connection, NoTls).unwrap();
+        let total_rows = client
+            .query_one(
+                format!("select count(1) as freq from ({}) a", query).as_str(),
+                &[],
+            )
+            .expect("Unable to get row count");
+        let total_rows: i64 = total_rows.get("freq");
+        let limit = limit.unwrap_or(std::usize::MAX).min(total_rows as usize);
+        // get schema
+        // TODO: reuse connection
+        // TODO: split read into multiple batches, using limit and skip
+        let row = client
+            .query_one(
+                format!("select a.* from ({}) a limit 1", query).as_str(),
+                &[],
+            )
+            .unwrap();
+        let schema = row_to_schema(&row).expect("Unable to get schema from row");
+        let reader = get_binary_reader(
+            &mut client,
+            format!("select a.* from ({}) a limit {}", query, limit).as_str(),
+        )?;
+        read_from_binary(reader, &schema).map(|batch| vec![batch])
+    }
+}
+
+impl PostgresReadIterator {
+    /// Create a new Postgres reader
+    pub fn try_new(
+        connection: &str,
+        query: &str,
+        limit: Option<usize>,
+        batch_size: usize,
+    ) -> Result<Self> {
+        let mut client = Client::connect(connection, NoTls).unwrap();
+        // get schema
+        let row = client
+            .query_one(
+                format!("select a.* from ({}) a limit 1", query).as_str(),
+                &[],
+            )
+            .unwrap();
+        let schema = row_to_schema(&row).expect("Unable to get schema from row");
+        Ok(Self {
+            client,
+            query: query.to_string(),
+            limit: limit.unwrap_or(std::usize::MAX),
+            batch_size,
+            schema,
+            read_records: 0,
+            is_complete: false,
+        })
+    }
+
+    /// Read the next batch
+    fn read_batch(&mut self) -> Result<Option<RecordBatch>> {
+        if self.is_complete {
+            return Ok(None);
+        }
+        let reader = get_binary_reader(
+            &mut self.client,
+            format!(
+                "select a.* from ({}) a limit {} offset {}",
+                self.query, self.batch_size, self.read_records
+            )
+            .as_str(),
+        )?;
+        let batch = read_from_binary(reader, &self.schema)?;
+        println!(
+            "Read {} records from offset {}",
+            batch.num_rows(),
+            self.read_records
+        );
+        self.read_records += batch.num_rows();
+        if batch.num_rows() == 0 {
+            self.is_complete = true;
+            return Ok(None);
+        } else if self.read_records >= self.limit {
+            self.is_complete = true;
+            return Ok(Some(batch));
+        }
+        Ok(Some(batch))
+    }
+
+    /// Get a reference to the table's schema
+    pub fn schema(&self) -> &Schema {
+        &self.schema
+    }
+}
+
+impl RecordBatchReader for PostgresReadIterator {
+    fn schema(&self) -> arrow::datatypes::SchemaRef {
+        Arc::new(self.schema.clone())
+    }
+
+    fn next_batch(&mut self) -> arrow::error::Result<Option<RecordBatch>> {
+        self.next().transpose()
+    }
+}
+
+impl Iterator for PostgresReadIterator {
+    type Item = arrow::error::Result<RecordBatch>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.read_batch()
+            .map_err(|e| {
+                eprintln!("Postgres error: {:?}", e);
+                arrow::error::ArrowError::IoError("Postgres error".to_string())
+            })
+            .transpose()
+    }
+}
+
+fn get_binary_reader<'a>(
+    client: &'a mut Client,
+    query: &str,
+) -> Result<postgres::CopyOutReader<'a>> {
+    Ok(client
+        .copy_out(format!("COPY ({}) TO stdout with (format binary)", query).as_str())
+        .unwrap())
+}
+
+struct PgDataType {
+    column_name: String,
+    ordinal_position: i32,
+    is_nullable: String,
+    data_type: String,
+    char_max_length: Option<i32>,
+    numeric_precision: Option<i32>,
+    datetime_precision: Option<i32>,
+}
+
+impl TryFrom<PgDataType> for Field {
+    type Error = ArrowError;
+    fn try_from(field: PgDataType) -> Result<Self> {
+        let data_type = match field.data_type.as_str() {
+            "int" | "integer" => match field.numeric_precision {
+                Some(8) => Ok(DataType::Int8),
+                Some(16) => Ok(DataType::Int16),
+                Some(32) => Ok(DataType::Int32),
+                Some(64) => Ok(DataType::Int64),
+                _ => Err(UNSUPPORTED_TYPE_ERR),
+            },
+            "bigint" => Ok(DataType::Int64),
+            "\"char\"" | "character" => {
+                if field.char_max_length == Some(1) {
+                    Ok(DataType::UInt8)
+                } else {
+                    Ok(DataType::Binary)
+                }
+            }
+            // "anyarray" | "ARRAY" => Err(UNSUPPORTED_TYPE_ERR),
+            "boolean" => Ok(DataType::Boolean),
+            "bytea" => Ok(DataType::Binary),
+            "character varying" => Ok(DataType::Utf8),
+            "date" => Ok(DataType::Date32(DateUnit::Day)),
+            "double precision" => Ok(DataType::Float64),
+            // "inet" => Err(UNSUPPORTED_TYPE_ERR),
+            "interval" => Ok(DataType::Interval(IntervalUnit::DayTime)), // TODO: use appropriate unit
+            // "name" => Err(UNSUPPORTED_TYPE_ERR),
+            "numeric" => Ok(DataType::Float64),
+            // "oid" => Err(UNSUPPORTED_TYPE_ERR),
+            "real" => Ok(DataType::Float32),
+            "smallint" => Ok(DataType::Int16),
+            "text" => Ok(DataType::Utf8),
+            "time" | "time without time zone" => {
+                Ok(DataType::Time64(TimeUnit::Microsecond))
+            } // TODO: use datetime_precision to determine correct type
+            "timestamp with time zone" => {
+                Ok(DataType::Timestamp(TimeUnit::Microsecond, None))
+            }
+            "timestamp" | "timestamp without time zone" => {
+                Ok(DataType::Timestamp(TimeUnit::Microsecond, None))
+            }
+            "uuid" => Ok(DataType::Binary), // TODO: use a more specialised data type
+            t => {
+                eprintln!("Conversion not set for data type: {:?}", t);
+                Err(UNSUPPORTED_TYPE_ERR)
+            }
+        };
+        Ok(Field::new(
+            &field.column_name,
+            data_type.unwrap(),
+            &field.is_nullable == "YES",
+        ))
+    }
+}
+
+/// Convert Postgres Type to Arrow DataType
+///
+/// Not all types are covered, but can be easily added
+fn pg_to_arrow_type(dt: &Type) -> Option<DataType> {
+    match dt {
+        &Type::BOOL => Some(DataType::Boolean),
+        &Type::BYTEA
+        | &Type::CHAR
+        | &Type::BPCHAR
+        | &Type::NAME
+        | &Type::TEXT
+        | &Type::VARCHAR => Some(DataType::Utf8),
+        &Type::INT2 => Some(DataType::Int16),
+        &Type::INT4 => Some(DataType::Int32),
+        &Type::INT8 => Some(DataType::Int64),
+        // &Type::NUMERIC => Some(DataType::Float64),
+        //        &OID => None,
+        //        &JSON => None,
+        &Type::FLOAT4 => Some(DataType::Float32),
+        &Type::FLOAT8 => Some(DataType::Float64),
+        //        &ABSTIME => None,
+        //        &RELTIME => None,
+        //        &TINTERVAL => None,
+        //        &MONEY => None,
+        &Type::BOOL_ARRAY => Some(DataType::List(Box::new(Field::new(
+            "list",
+            DataType::Boolean,
+            true,
+        )))),
+        &Type::BYTEA_ARRAY | &Type::CHAR_ARRAY | &Type::NAME_ARRAY => Some(
+            DataType::List(Box::new(Field::new("list", DataType::Utf8, true))),
+        ),
+        //        &INT2_ARRAY => None,
+        //        &INT2_VECTOR => None,
+        //        &INT2_VECTOR_ARRAY => None,
+        //        &INT4_ARRAY => None,
+        //        &TEXT_ARRAY => None,
+        //        &INT8_ARRAY => None,
+        //        &FLOAT4_ARRAY => None,
+        //        &FLOAT8_ARRAY => None,
+        //        &ABSTIME_ARRAY => None,
+        //        &RELTIME_ARRAY => None,
+        //        &TINTERVAL_ARRAY => None,
+        &Type::DATE => Some(DataType::Date32(DateUnit::Day)),
+        &Type::TIME => Some(DataType::Time64(TimeUnit::Microsecond)),
+        &Type::INTERVAL => Some(DataType::Interval(IntervalUnit::DayTime)),
+        &Type::TIMESTAMP | &Type::TIMESTAMPTZ => {
+            Some(DataType::Timestamp(TimeUnit::Microsecond, None))
+        }
+        //        &TIMESTAMP_ARRAY => None,
+        &Type::DATE_ARRAY => Some(DataType::List(Box::new(Field::new(
+            "item",
+            DataType::Date32(DateUnit::Day),
+            true,
+        )))),
+        //        &TIME_ARRAY => None,
+        //        &TIMESTAMPTZ => None,
+        //        &TIMESTAMPTZ_ARRAY => None,
+        //        &INTERVAL => None,
+        //        &INTERVAL_ARRAY => None,
+        //        &NUMERIC_ARRAY => None,
+        //        &TIMETZ => None,
+        //        &BIT => None,
+        //        &BIT_ARRAY => None,
+        //        &VARBIT => None,
+        //        &NUMERIC => None,
+        &Type::UUID => Some(DataType::FixedSizeBinary(16)),
+        t => panic!("Postgres type {:?} not supported", t),
+    }
+}
+
+fn read_table_by_rows(
+    connection_string: &str,
+    table_name: &str,
+    _limit: usize,
+    batch_size: usize,
+) -> Result<Vec<RecordBatch>> {
+    // create connection
+    let mut client = Client::connect(connection_string, NoTls).unwrap();
+    let results = client
+        .query(format!("SELECT * FROM {}", table_name).as_str(), &[])
+        .unwrap();
+    if results.is_empty() {
+        return Ok(vec![]);
+    }
+
+    // TODO: replace with metadata version of call
+    let schema = row_to_schema(results.get(0).unwrap()).unwrap();
+    let field_len = schema.fields().len();
+    let mut builder = StructBuilder::from_fields(schema.fields().clone(), batch_size);
+    let chunks = results.chunks(batch_size);
+    let mut batches = vec![];
+    chunks.for_each(|chunk: &[Row]| {
+        for j in 0..field_len {
+            match schema.field(j).data_type() {
+                DataType::Int32 => {
+                    let field_builder = builder.field_builder::<Int32Builder>(j).unwrap();
+                    for i in 0..chunk.len() {
+                        let row: &Row = chunk.get(i).unwrap();
+                        match row.try_get(j) {
+                            Ok(value) => field_builder.append_value(value).unwrap(),
+                            Err(_) => field_builder.append_null().unwrap(),
+                        };
+                    }
+                }
+                DataType::Int64 => {
+                    let field_builder = builder.field_builder::<Int64Builder>(j).unwrap();
+                    for i in 0..chunk.len() {
+                        let row: &Row = chunk.get(i).unwrap();
+                        match row.try_get(j) {
+                            Ok(value) => field_builder.append_value(value).unwrap(),
+                            Err(_) => field_builder.append_null().unwrap(),
+                        };
+                    }
+                }
+                DataType::Float64 => {
+                    let field_builder =
+                        builder.field_builder::<Float64Builder>(j).unwrap();
+                    for i in 0..chunk.len() {
+                        let row: &Row = chunk.get(i).unwrap();
+                        match row.try_get(j) {
+                            Ok(value) => field_builder.append_value(value).unwrap(),
+                            Err(_) => field_builder.append_null().unwrap(),
+                        };
+                    }
+                }
+                DataType::Timestamp(TimeUnit::Millisecond, _) => {
+                    let field_builder = builder
+                        .field_builder::<TimestampMillisecondBuilder>(j)
+                        .unwrap();
+                    for i in 0..chunk.len() {
+                        let row: &Row = chunk.get(i).unwrap();
+                        let timestamp: chrono::NaiveDateTime = row.get(j);
+                        field_builder
+                            .append_value(timestamp.timestamp_millis())
+                            .unwrap();
+                    }
+                }
+                DataType::Time64(TimeUnit::Microsecond) => {
+                    let field_builder = builder
+                        .field_builder::<Time64MicrosecondBuilder>(j)
+                        .unwrap();
+                    for i in 0..chunk.len() {
+                        let row: &Row = chunk.get(i).unwrap();
+                        let time: chrono::NaiveTime = row.get(j);
+                        field_builder
+                            .append_value(
+                                time.num_seconds_from_midnight() as i64 * 1000000
+                                    + time.nanosecond() as i64 / 1000,
+                            )
+                            .unwrap();
+                    }
+                }
+                DataType::Boolean => {
+                    let field_builder =
+                        builder.field_builder::<BooleanBuilder>(j).unwrap();
+                    for i in 0..chunk.len() {
+                        let row: &Row = chunk.get(i).unwrap();
+                        field_builder.append_value(row.get(j)).unwrap();
+                    }
+                }
+                DataType::Utf8 => {
+                    let field_builder =
+                        builder.field_builder::<StringBuilder>(j).unwrap();
+                    for i in 0..chunk.len() {
+                        let row: &Row = chunk.get(i).unwrap();
+                        field_builder.append_value(row.get(j)).unwrap();
+                    }
+                }
+                t => panic!("Field builder for {:?} not yet supported", t),
+            }
+        }
+        // TODO perhaps change the order of processing so we can do this earlier
+        for _ in 0..chunk.len() {
+            builder.append(true).unwrap();
+        }
+        let batch: RecordBatch = RecordBatch::from(&builder.finish());
+        batches.push(batch);
+    });
+    Ok(batches)
+}
+
+/// Generate Arrow schema from a row
+fn row_to_schema(row: &postgres::Row) -> Result<Schema> {
+    let mut metadata = std::collections::HashMap::new();
+    let fields = row
+        .columns()
+        .iter()
+        .map(|col: &postgres::Column| {
+            metadata.insert(col.name().to_string(), col.type_().to_string());
+            Field::new(col.name(), pg_to_arrow_type(col.type_()).unwrap(), true)
+        })
+        .collect();
+    Ok(Schema::new_with_metadata(fields, metadata))
+}
+
+fn read_from_binary<R>(mut reader: R, schema: &Schema) -> Result<RecordBatch>
+where
+    R: Read,
+{
+    // read signature
+    let mut bytes = [0u8; 11];
+    reader.read_exact(&mut bytes).unwrap();
+    if bytes != MAGIC {
+        eprintln!("Unexpected binary format type");
+        return Err(ArrowError::IoError(
+            "Unexpected Postgres binary type".to_string(),
+        ));
+    }
+    // read flags
+    let mut bytes: [u8; 4] = [0; 4];
+    reader.read_exact(&mut bytes).unwrap();
+    let _size = u32::from_be_bytes(bytes);
+
+    // header extension area length
+    let mut bytes: [u8; 4] = [0; 4];
+    reader.read_exact(&mut bytes).unwrap();
+    let _size = u32::from_be_bytes(bytes);
+
+    read_rows(&mut reader, schema)
+}
+
+/// Read row tuples
+fn read_rows<R>(mut reader: R, schema: &Schema) -> Result<RecordBatch>
+where
+    R: Read,
+{
+    let mut is_done = false;
+    let field_len = schema.fields().len();
+
+    let mut buffers: Vec<Vec<u8>> = vec![vec![]; field_len];
+    let mut null_buffers: Vec<Vec<bool>> = vec![vec![]; field_len];
+    let mut offset_buffers: Vec<Vec<i32>> = vec![vec![]; field_len];
+
+    let default_values: Vec<Vec<u8>> = schema
+        .fields()
+        .iter()
+        .map(|f| match f.data_type() {
+            DataType::Null => vec![],
+            DataType::Boolean => vec![0],
+            DataType::Int8 => vec![0],
+            DataType::Int16 => vec![0; 2],
+            DataType::Int32 => vec![0; 4],
+            DataType::Int64 => vec![0; 8],
+            DataType::UInt8 => vec![0],
+            DataType::UInt16 => vec![0; 2],
+            DataType::UInt32 => vec![0; 4],
+            DataType::UInt64 => vec![0; 8],
+            DataType::Float16 => vec![0; 2],
+            DataType::Float32 => vec![0; 4],
+            DataType::Float64 => vec![0; 8],
+            DataType::Timestamp(_, _) => vec![0; 8],
+            DataType::Date32(_) => vec![0; 4],
+            DataType::Date64(_) => vec![0; 8],
+            DataType::Time32(_) => vec![0; 4],
+            DataType::Time64(_) => vec![0; 8],
+            DataType::Duration(_) => vec![0; 8],
+            DataType::Interval(_) => vec![0; 8],
+            DataType::Binary => vec![],
+            DataType::FixedSizeBinary(len) => vec![0; *len as usize],
+            DataType::Utf8 => vec![],
+            DataType::List(_) => vec![],
+            DataType::FixedSizeList(_, len) => vec![0; *len as usize],
+            DataType::Struct(_) => vec![],
+            DataType::Union(_) => vec![],
+            DataType::Dictionary(_, _) => vec![],
+            DataType::LargeBinary => vec![],
+            DataType::LargeUtf8 => vec![],
+            DataType::LargeList(_) => vec![],
+            DataType::Decimal(_, _) => vec![],
+        })
+        .collect();
+
+    let mut record_num = -1;
+    while !is_done {
+        record_num += 1;
+        // tuple length
+        let mut bytes: [u8; 2] = [0; 2];
+        reader.read_exact(&mut bytes).unwrap();
+        let size = i16::from_be_bytes(bytes);
+        if size == -1 {
+            // trailer
+            is_done = true;
+            continue;
+        }
+        let size = size as usize;
+        // in almost all cases, the tuple length should equal schema field length
+        assert_eq!(size, field_len);
+        for i in 0..field_len {
+            let mut bytes = [0u8; 4];
+            reader.read_exact(&mut bytes).unwrap();
+            let col_length = i32::from_be_bytes(bytes);
+            // populate offsets for types that need them
+            match schema.field(i).data_type() {
+                DataType::Binary | DataType::Utf8 => {
+                    offset_buffers[i].push(col_length);
+                }
+                DataType::FixedSizeBinary(binary_size) => {
+                    offset_buffers[i].push(record_num * binary_size);
+                }
+                DataType::List(_) => {}
+                DataType::FixedSizeList(_, _) => {}
+                DataType::Struct(_) => {}
+                _ => {}
+            }
+            // populate values
+            if col_length == -1 {
+                // null value
+                null_buffers[i].push(false);
+                buffers[i].write_all(default_values[i].as_slice())?;
+            } else {
+                null_buffers[i].push(true);
+                // big endian data, needs to be converted to little endian
+                let mut data = read_col(
+                    &mut reader,
+                    schema.field(i).data_type(),
+                    col_length as usize,
+                )
+                .expect("Unable to read data");
+                buffers[i].append(&mut data);
+            }
+        }
+    }
+
+    let mut arrays = vec![];
+    // build record batches
+    buffers
+        .into_iter()
+        .zip(null_buffers.into_iter())
+        .zip(schema.fields().iter())
+        .enumerate()
+        .for_each(|(i, ((b, n), f))| {
+            let null_count = n.iter().filter(|v| v == &&false).count();
+            let mut null_buffer = BooleanBufferBuilder::new(n.len() / 8 + 1);
+            null_buffer.append_slice(&n[..]).unwrap();
+            let null_buffer = null_buffer.finish();
+            match f.data_type() {
+                DataType::Boolean => {
+                    let bools = b.iter().map(|v| v == &0).collect::<Vec<bool>>();
+                    let mut bool_buffer = BooleanBufferBuilder::new(bools.len());
+                    bool_buffer.append_slice(&bools[..]).unwrap();
+                    let bool_buffer = bool_buffer.finish();
+                    let data = ArrayData::new(
+                        f.data_type().clone(),
+                        n.len(),
+                        Some(null_count),
+                        Some(null_buffer),
+                        0,
+                        vec![bool_buffer],
+                        vec![],
+                    );
+                    arrays.push(Arc::new(BooleanArray::from(Arc::new(data))) as ArrayRef)
+                }
+                DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+                | DataType::Float32
+                | DataType::Float64
+                | DataType::Timestamp(_, _)
+                | DataType::Date32(_)
+                | DataType::Date64(_)
+                | DataType::Time32(_)
+                | DataType::Time64(_)
+                | DataType::Duration(_)
+                | DataType::Interval(_) => {
+                    let data = ArrayData::new(
+                        f.data_type().clone(),
+                        n.len(),
+                        Some(null_count),
+                        Some(null_buffer),
+                        0,
+                        vec![Buffer::from(b)],
+                        vec![],
+                    );
+                    arrays.push(arrow::array::make_array(Arc::new(data)))
+                }
+                DataType::FixedSizeBinary(_size) => {
+                    // TODO: do we need to calculate any offsets?
+                    let data = ArrayData::new(
+                        f.data_type().clone(),
+                        n.len(),
+                        Some(null_count),
+                        Some(null_buffer),
+                        0,
+                        vec![Buffer::from(b)],
+                        vec![],
+                    );
+                    arrays.push(arrow::array::make_array(Arc::new(data)))
+                }
+                DataType::Binary
+                | DataType::Utf8
+                | DataType::LargeBinary
+                | DataType::LargeUtf8 => {
+                    // recontruct offsets
+                    let mut offset = 0;
+                    let mut offsets = vec![0];
+                    offset_buffers[i].iter().for_each(|o| {
+                        offsets.push(offset + o);
+                        offset += o;
+                    });
+                    let data = ArrayData::new(
+                        f.data_type().clone(),
+                        n.len(),
+                        Some(null_count),
+                        Some(null_buffer),
+                        0,
+                        vec![Buffer::from(offsets.to_byte_slice()), Buffer::from(b)],
+                        vec![],
+                    );
+                    arrays.push(arrow::array::make_array(Arc::new(data)))
+                }
+                DataType::List(_) | DataType::LargeList(_) => {
+                    let data = ArrayData::new(
+                        f.data_type().clone(),
+                        n.len(),
+                        Some(null_count),
+                        Some(null_buffer),
+                        0,
+                        vec![Buffer::from(b)],
+                        vec![],
+                    );
+                    arrays.push(arrow::array::make_array(Arc::new(data)))
+                }
+                DataType::FixedSizeList(_, _) => {
+                    let data = ArrayData::new(
+                        f.data_type().clone(),
+                        n.len(),
+                        Some(null_count),
+                        Some(null_buffer),
+                        0,
+                        vec![Buffer::from(b)],
+                        vec![],
+                    );
+                    arrays.push(arrow::array::make_array(Arc::new(data)))
+                }
+                DataType::Float16 => panic!("Float16 not yet implemented"),
+                DataType::Struct(_) => panic!("Reading struct arrays not implemented"),
+                DataType::Dictionary(_, _) => {
+                    panic!("Reading dictionary arrays not implemented")
+                }
+                DataType::Union(_) => panic!("Union not supported"),
+                DataType::Null => panic!("Null not supported"),
+                DataType::Decimal(_, _) => panic!("Decimal not suported"),
+            }
+        });
+    Ok(RecordBatch::try_new(Arc::new(schema.clone()), arrays)?)
+}
+
+fn read_col<R: Read>(
+    reader: &mut R,
+    data_type: &DataType,
+    length: usize,
+) -> Result<Vec<u8>> {
+    match data_type {
+        DataType::Boolean => read_bool(reader),
+        DataType::Int8 => read_i8(reader),
+        DataType::Int16 => read_i16(reader),
+        DataType::Int32 => read_i32(reader),
+        DataType::Int64 => read_i64(reader),
+        DataType::UInt8 => read_u8(reader),
+        DataType::UInt16 => read_u16(reader),
+        DataType::UInt32 => read_u32(reader),
+        DataType::UInt64 => read_u64(reader),
+        DataType::Float16 => Err(ArrowError::InvalidArgumentError(
+            "Float 16 is not yet supported".to_string(),
+        )),
+        DataType::Float32 => read_f32(reader),
+        DataType::Float64 => read_f64(reader),
+        DataType::Timestamp(_, _) => read_timestamp64(reader),
+        DataType::Date32(_) => read_date32(reader),
+        DataType::Date64(_) => unreachable!(),
+        DataType::Time32(_) => read_i32(reader),
+        DataType::Time64(_) => read_time64(reader),
+        DataType::Duration(_) => read_i64(reader),
+        DataType::Interval(_) => read_i64(reader),
+        DataType::Binary => read_string(reader, length), // TODO we'd need the length of the binary
+        DataType::FixedSizeBinary(_) => read_string(reader, length),
+        DataType::Utf8 => read_string(reader, length),
+        DataType::List(_) => Err(UNSUPPORTED_TYPE_ERR),
+        DataType::FixedSizeList(_, _) => Err(UNSUPPORTED_TYPE_ERR),
+        DataType::Struct(_) => Err(UNSUPPORTED_TYPE_ERR),
+        DataType::Dictionary(_, _) => Err(UNSUPPORTED_TYPE_ERR),
+        DataType::Union(_) => Err(UNSUPPORTED_TYPE_ERR),
+        DataType::Null => Err(UNSUPPORTED_TYPE_ERR),
+        DataType::LargeBinary => Err(UNSUPPORTED_TYPE_ERR),
+        DataType::LargeUtf8 => Err(UNSUPPORTED_TYPE_ERR),
+        DataType::LargeList(_) => Err(UNSUPPORTED_TYPE_ERR),
+        DataType::Decimal(_, _) => Err(UNSUPPORTED_TYPE_ERR),
+    }
+}
+
+fn read_u8<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_u8()
+        .map(|v| vec![v])
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+
+fn read_i8<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_i8()
+        .map(|v| vec![v as u8])
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+
+fn read_u16<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_u16::<NetworkEndian>()
+        .map(|v| v.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+fn read_i16<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_i16::<NetworkEndian>()
+        .map(|v| v.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+fn read_u32<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_u32::<NetworkEndian>()
+        .map(|v| v.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+fn read_i32<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_i32::<NetworkEndian>()
+        .map(|v| v.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+fn read_u64<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_u64::<NetworkEndian>()
+        .map(|v| v.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+fn read_i64<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_i64::<NetworkEndian>()
+        .map(|v| v.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+fn read_bool<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_u8()
+        .map(|v| vec![v])
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+fn read_string<R: Read>(reader: &mut R, len: usize) -> Result<Vec<u8>> {
+    let mut buf = vec![0; len];
+    reader
+        .read_exact(&mut buf)
+        .map_err(|e| ArrowError::SqlError(e.to_string()))?;
+    Ok(buf)
+}
+fn read_f32<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_f32::<NetworkEndian>()
+        .map(|v| v.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+fn read_f64<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_f64::<NetworkEndian>()
+        .map(|v| v.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+
+/// Postgres dates are days since epoch of 01-01-2000, so we add 10957 days
+fn read_date32<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_i32::<NetworkEndian>()
+        .map(|v| { EPOCH_DAYS + v }.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+
+fn read_timestamp64<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_i64::<NetworkEndian>()
+        .map(|v| { EPOCH_MICROS + v }.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}
+
+/// we do not support time with time zone as it is 48-bit,
+/// time without a zone is 32-bit but arrow only supports 64-bit at microsecond resolution
+fn read_time64<R: Read>(reader: &mut R) -> Result<Vec<u8>> {
+    reader
+        .read_i32::<NetworkEndian>()
+        .map(|v| { v as i64 }.to_le_bytes().to_vec())
+        .map_err(|e| ArrowError::SqlError(e.to_string()))
+}

--- a/rust/sql/src/postgres/reader.rs
+++ b/rust/sql/src/postgres/reader.rs
@@ -99,9 +99,8 @@ impl SqlDataSource for Postgres {
         batch_size: usize,
     ) -> Result<Vec<RecordBatch>> {
         // create iterator
-        let iterator = PostgresReadIterator::try_new(
-            connection, query, limit, batch_size
-        )?;
+        let iterator =
+            PostgresReadIterator::try_new(connection, query, limit, batch_size)?;
         iterator.collect()
     }
 }
@@ -151,11 +150,11 @@ impl PostgresReadIterator {
             .as_str(),
         )?;
         let batch = read_from_binary(reader, &self.schema)?;
-        println!(
-            "Read {} records from offset {}",
-            batch.num_rows(),
-            self.read_records
-        );
+        // println!(
+        //     "Read {} records from offset {}",
+        //     batch.num_rows(),
+        //     self.read_records
+        // );
         self.read_records += batch.num_rows();
         if batch.num_rows() == 0 {
             self.is_complete = true;
@@ -187,9 +186,7 @@ impl Iterator for PostgresReadIterator {
     type Item = arrow::error::Result<RecordBatch>;
     fn next(&mut self) -> Option<Self::Item> {
         self.read_batch()
-            .map_err(|e| {
-                arrow::error::ArrowError::SqlError(e.to_string())
-            })
+            .map_err(|e| arrow::error::ArrowError::SqlError(e.to_string()))
             .transpose()
     }
 }
@@ -566,7 +563,10 @@ where
             let col_length = i32::from_be_bytes(bytes);
             // populate offsets for types that need them
             match schema.field(i).data_type() {
-                DataType::Binary | DataType::LargeBinary | DataType::Utf8 | DataType::LargeUtf8 => {
+                DataType::Binary
+                | DataType::LargeBinary
+                | DataType::Utf8
+                | DataType::LargeUtf8 => {
                     offset_buffers[i].push(col_length);
                 }
                 DataType::FixedSizeBinary(binary_size) => {
@@ -665,8 +665,7 @@ where
                     );
                     arrays.push(arrow::array::make_array(Arc::new(data)))
                 }
-                DataType::Binary
-                | DataType::Utf8 => {
+                DataType::Binary | DataType::Utf8 => {
                     // recontruct offsets
                     let mut offset = 0;
                     let mut offsets = vec![0];
@@ -685,8 +684,7 @@ where
                     );
                     arrays.push(arrow::array::make_array(Arc::new(data)))
                 }
-                DataType::LargeBinary
-                | DataType::LargeUtf8 => {
+                DataType::LargeBinary | DataType::LargeUtf8 => {
                     // recontruct offsets
                     let mut offset = 0i64;
                     let mut offsets = vec![0i64];

--- a/rust/sql/src/postgres/writer.rs
+++ b/rust/sql/src/postgres/writer.rs
@@ -1,0 +1,513 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use arrow::array::*;
+use arrow::datatypes::{DataType, DateUnit, Field, Schema, TimeUnit};
+use arrow::error::{ArrowError, Result};
+use arrow::{compute::cast, record_batch::RecordBatch};
+use byteorder::{NetworkEndian, WriteBytesExt};
+use postgres::{Client, CopyInWriter, NoTls};
+
+use super::{Postgres, EPOCH_DAYS, EPOCH_MICROS, MAGIC};
+use crate::SqlDataSink;
+
+impl SqlDataSink for Postgres {
+    fn create_table(
+        connection: &str,
+        table_name: &str,
+        schema: &Arc<Schema>,
+    ) -> Result<()> {
+        let mut table = String::new();
+        let field_len = schema.fields().len();
+        for i in 0..field_len {
+            table.push_str(
+                format!(
+                    "{} {}",
+                    schema.field(i).name(),
+                    get_postgres_type(schema.field(i))?
+                )
+                .as_str(),
+            );
+            if i + 1 < field_len {
+                table.push_str(",\n");
+            }
+        }
+
+        let mut client = Client::connect(connection, NoTls).unwrap();
+        client
+            .execute(format!("DROP TABLE IF EXISTS {}", table_name).as_str(), &[])
+            .unwrap();
+        client
+            .execute(
+                format!("CREATE TABLE IF NOT EXISTS {} ({})", table_name, table).as_str(),
+                &[],
+            )
+            .unwrap();
+        Ok(())
+    }
+    fn write_to_table(
+        connection: &str,
+        table_name: &str,
+        batches: &[RecordBatch],
+    ) -> Result<()> {
+        if batches.is_empty() {
+            return Err(ArrowError::IoError(
+                "At least one batch should be provided to the SQL writer".to_string(),
+            ));
+        }
+
+        let mut client = Client::connect(connection, NoTls).unwrap();
+        let mut writer = get_binary_writer(&mut client, table_name)?;
+
+        for batch in batches {
+            // write out batch
+            write_to_binary(&mut writer, batch)?;
+        }
+        writer.write_i16::<NetworkEndian>(-1)?;
+        println!("Done writing values, finishing");
+
+        writer.finish().unwrap();
+        Ok(())
+    }
+}
+
+fn get_postgres_type(field: &Field) -> Result<String> {
+    let nullable = if !field.is_nullable() {
+        " not null"
+    } else {
+        ""
+    };
+    let dtype = match field.data_type() {
+        DataType::Boolean => "boolean",
+        DataType::Int8 => {
+            return Err(ArrowError::SqlError(
+                "Int8 not mapped to any PostgreSQL type".to_string(),
+            ))
+        }
+        DataType::Int16 => "smallint",
+        DataType::Int32 => "integer",
+        DataType::Int64 => "bigint",
+        DataType::UInt8 => "character",
+        DataType::UInt16 => "bigint",
+        DataType::UInt32 => "bigint",
+        DataType::UInt64 => "bigint",
+        DataType::Float16 => {
+            return Err(ArrowError::InvalidArgumentError(
+                "Float16 not supported".to_string(),
+            ))
+        }
+        DataType::Float32 => "real",
+        DataType::Float64 => "double precision",
+        DataType::Timestamp(_, timezone) => match timezone {
+            Some(_) => "timestamp with time zone",
+            None => "timestamp",
+        },
+        DataType::Date32(_) | DataType::Date64(_) => "date",
+        DataType::Time32(_) | DataType::Time64(_) => "time",
+        DataType::Duration(_) => {
+            return Err(ArrowError::SqlError(
+                "Duration write not support not yet implemented".to_string(),
+            ))
+        }
+        DataType::Interval(_) => {
+            return Err(ArrowError::SqlError(
+                "Interval write not support not yet implemented".to_string(),
+            ))
+        }
+        DataType::Binary => "bytea",
+        DataType::FixedSizeBinary(_) => {
+            return Err(ArrowError::SqlError(
+                "FixedSizeBinary write not support not yet implemented".to_string(),
+            ))
+        }
+        DataType::Utf8 => "text",
+        DataType::List(_) => {
+            return Err(ArrowError::SqlError(
+                "List write not support not yet implemented".to_string(),
+            ))
+        }
+        DataType::FixedSizeList(_, _) => {
+            return Err(ArrowError::SqlError(
+                "FixedSizeList write not support not yet implemented".to_string(),
+            ))
+        }
+        DataType::Struct(_) => {
+            return Err(ArrowError::SqlError(
+                "Struct write not support not yet implemented".to_string(),
+            ))
+        }
+        DataType::Dictionary(_, _) => {
+            return Err(ArrowError::SqlError(
+                "Dictionary write not support not yet implemented".to_string(),
+            ))
+        }
+        DataType::Null => {
+            return Err(ArrowError::SqlError(
+                "Null write not support not yet implemented".to_string(),
+            ))
+        }
+        DataType::Union(_) => {
+            return Err(ArrowError::SqlError(
+                "Union type not yet supported".to_string(),
+            ));
+        }
+        DataType::LargeBinary => {
+            return Err(ArrowError::SqlError("Type not yet supported".to_string()));
+        }
+        DataType::LargeUtf8 => {
+            return Err(ArrowError::SqlError("Type not yet supported".to_string()));
+        }
+        DataType::LargeList(_) => {
+            return Err(ArrowError::SqlError("Type not yet supported".to_string()));
+        }
+        DataType::Decimal(_, _) => {
+            return Err(ArrowError::SqlError("Type not yet supported".to_string()));
+        }
+    };
+    Ok(format!("{} {}", dtype, nullable))
+}
+
+fn get_binary_writer<'a>(
+    client: &'a mut Client,
+    table_name: &str,
+) -> Result<CopyInWriter<'a>> {
+    Ok(client
+        .copy_in(format!("COPY {} FROM stdin with (format binary)", table_name).as_str())
+        .unwrap())
+}
+
+fn write_to_binary(writer: &mut CopyInWriter, batch: &RecordBatch) -> Result<u64> {
+    // write header
+    writer.write_all(MAGIC)?;
+    // write flags
+    writer.write_all(&[0; 4])?;
+    // write header extension
+    writer.write_all(&[0; 4])?;
+
+    let column_len = batch.num_columns();
+
+    // start writing rows
+    for row in 0..batch.num_rows() {
+        // write row/tuple length
+        writer.write_i16::<NetworkEndian>(column_len as i16)?;
+
+        for (arr, field) in batch.columns().iter().zip(batch.schema().fields().iter()) {
+            match field.data_type() {
+                arrow::datatypes::DataType::Boolean => {
+                    let arr = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Int8 => {
+                    let arr = arr.as_any().downcast_ref::<Int8Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Int16 => {
+                    let arr = arr.as_any().downcast_ref::<Int16Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Int32 => {
+                    let arr = arr.as_any().downcast_ref::<Int32Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Int64 => {
+                    let arr = arr.as_any().downcast_ref::<Int64Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::UInt8 => {
+                    let arr = arr.as_any().downcast_ref::<UInt8Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::UInt16 => {
+                    return Err(ArrowError::SqlError(
+                        "No PostgreSQL data type has been mapped to UInt16Type"
+                            .to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::UInt32 => {
+                    let arr = arr.as_any().downcast_ref::<UInt32Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::UInt64 => {
+                    let arr = arr.as_any().downcast_ref::<UInt64Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Float16 => {
+                    return Err(ArrowError::SqlError(
+                        "Float16 type not yet supported by Arrow".to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::Float32 => {
+                    let arr = arr.as_any().downcast_ref::<Float32Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Float64 => {
+                    let arr = arr.as_any().downcast_ref::<Float64Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Date32(_)
+                | arrow::datatypes::DataType::Date64(_) => {
+                    let arr = cast(arr, &DataType::Date32(DateUnit::Day))?;
+                    let arr = arr.as_any().downcast_ref::<Date32Array>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Timestamp(_, _) => {
+                    let arr =
+                        cast(arr, &DataType::Timestamp(TimeUnit::Microsecond, None))?;
+                    let arr = arr
+                        .as_any()
+                        .downcast_ref::<TimestampMicrosecondArray>()
+                        .unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Time32(_)
+                | arrow::datatypes::DataType::Time64(_) => {
+                    let arr = cast(arr, &DataType::Time64(TimeUnit::Microsecond))?;
+                    let arr = arr
+                        .as_any()
+                        .downcast_ref::<Time64MicrosecondArray>()
+                        .unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::Duration(_) => {
+                    return Err(ArrowError::SqlError(
+                        "Duration type not yet supported by PostgreSQL writer"
+                            .to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::Interval(_) => {
+                    return Err(ArrowError::SqlError(
+                        "Writing Intervals not yet implemented".to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::Binary => {
+                    let arr = arr.as_any().downcast_ref::<BinaryArray>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::LargeBinary => {
+                    return Err(ArrowError::SqlError(
+                        "Type not yet supported by PostgreSQL writer".to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::FixedSizeBinary(_) => {
+                    return Err(ArrowError::SqlError(
+                        "Type not yet supported by PostgreSQL writer".to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::Utf8 => {
+                    let arr = arr.as_any().downcast_ref::<StringArray>().unwrap();
+                    arr.write_to_binary(writer, row)?;
+                }
+                arrow::datatypes::DataType::LargeUtf8 => {
+                    return Err(ArrowError::SqlError(
+                        "Type not yet supported by PostgreSQL writer".to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::List(_)
+                | arrow::datatypes::DataType::LargeList(_) => {
+                    return Err(ArrowError::SqlError(
+                        "Type not yet supported by PostgreSQL writer".to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::FixedSizeList(_, _) => {
+                    return Err(ArrowError::SqlError(
+                        "Duration type not yet supported by PostgreSQL writer"
+                            .to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::Struct(_) => {
+                    return Err(ArrowError::SqlError(
+                        "Duration type not yet supported by PostgreSQL writer"
+                            .to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::Dictionary(_, _) => {
+                    return Err(ArrowError::SqlError(
+                        "Duration type not yet supported by PostgreSQL writer"
+                            .to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::Union(_) => {
+                    return Err(ArrowError::SqlError(
+                        "Union type not yet supported by PostgreSQL writer".to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::Null => {
+                    // TODO: write it out as an all-null i8?
+                    return Err(ArrowError::SqlError(
+                        "Null type not yet supported by PostgreSQL writer".to_string(),
+                    ));
+                }
+                arrow::datatypes::DataType::Decimal(_, _) => {
+                    return Err(ArrowError::SqlError(
+                        "Decimal type not yet supported by PostgreSQL writer".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    Ok(0)
+}
+
+/// A trait to write various supported array values to PostgreSQL's binary format
+///
+/// This assumes that nullness has been checked by the caller, and thus does not check this.
+/// It is also the responsibility of the caller to ensure that the array has been converted to
+///  a compatible array type for the Postgres column type
+trait WriteToBinary {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()>;
+}
+
+fn write_null_to_binary<W: Write>(writer: &mut W) -> Result<()> {
+    writer.write_i32::<NetworkEndian>(-1)?;
+    Ok(())
+}
+
+fn write_length_to_binary<W: Write>(writer: &mut W, length: usize) -> Result<()> {
+    writer.write_i32::<NetworkEndian>(length as i32)?;
+    Ok(())
+}
+
+impl WriteToBinary for BooleanArray {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<u8>())?;
+        if self.value(index) {
+            writer.write_u8(1)
+        } else {
+            writer.write_u8(0)
+        }?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for UInt8Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<u8>())?;
+        writer.write_u8(self.value(index))?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for Int8Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<i8>())?;
+        writer.write_i8(self.value(index))?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for Int16Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<i16>())?;
+        writer.write_i16::<NetworkEndian>(self.value(index))?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for Int32Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<i32>())?;
+        writer.write_i32::<NetworkEndian>(self.value(index))?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for UInt32Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<u32>())?;
+        writer.write_u32::<NetworkEndian>(self.value(index))?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for UInt64Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<u32>())?;
+        writer.write_u64::<NetworkEndian>(self.value(index))?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for Int64Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<i64>())?;
+        writer.write_i64::<NetworkEndian>(self.value(index))?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for Float32Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<f32>())?;
+        writer.write_f32::<NetworkEndian>(self.value(index))?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for Float64Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<f64>())?;
+        writer.write_f64::<NetworkEndian>(self.value(index))?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for TimestampMicrosecondArray {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<i64>())?;
+        writer.write_i64::<NetworkEndian>(self.value(index) - EPOCH_MICROS)?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for Date32Array {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<i32>())?;
+        writer.write_i32::<NetworkEndian>(self.value(index) - EPOCH_DAYS)?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for Time64MicrosecondArray {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        write_length_to_binary(writer, std::mem::size_of::<i32>())?;
+        writer.write_i32::<NetworkEndian>(self.value(index) as i32)?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for StringArray {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        let value = self.value(index).as_bytes();
+        dbg!(&value);
+        write_length_to_binary(writer, value.len())?;
+        writer.write_all(value)?;
+        Ok(())
+    }
+}
+
+impl WriteToBinary for BinaryArray {
+    fn write_to_binary<W: Write>(&self, writer: &mut W, index: usize) -> Result<()> {
+        let value = self.value(index);
+        write_length_to_binary(writer, value.len())?;
+        writer.write_all(value)?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is a PR to solicit feedback on a possible Arrow <> SQL interface

It provides `SqlDataSource` and a `SqlDataSink` traits, which express the ability to read and write `RecordBatch` from and to SQL databases.
It is very incomplete, but I provide a PostgreSQL implementation which mostly works (though not optimised to reduce allocations, or to support more types).

It is meant to support bulk IO where supported by the underlying database. The PostgreSQL implementation relies on the binary copy protocol.
Where databases don't have a bulk copy or binary option, we or implementors could look at applying alternative optimisations.
It's generally inefficient to read data as rows from SQL crates, then convert them to columns. Where Rust crates support a lower-level way of interacting with its relevant SQL protocol, we would prefer that option.

The idea is that this could be used by DataFusion and other libraries to support SQL databases.
For integration with DataFusion, we could need the ability to convert a logical plan into a SQL query (or queries for distribution)

The interface and the initial commits are very simplistic, and could support a lot more functionality such as:

- Allowing database implementations to declare their capabilities and preferences, e.g.
   - If a database is good/better at certain computations than the compute engine, we could pass them down to it
   - If a SQL dialect supports projections, a reader could pass a table, and let the source project it
- Having sync and async versions which return iterators and streams
- Parsing SQL queries for validation, and then applying optimisations (projections, casts)
- Reusing connections

This work is a nearly-direct extract of the logic that I wrote in [rust-dataframe](https://github.com/nevi-me/rust-dataframe/tree/master/src/io/sql). The rust-dataframe project is really a research project, and I don't expect it to materialise into something productive in the near future. At the same time, trying to work on this connector logic was not benefiting from any visibility, so if it ends up living in Arrow, I'm hoping that more interested contributors can work on it.

I initially wanted to create a more general `connector` logic, which would allow implementors to use generic traits, but also declare their capabilities (a Parquet source could declare that it can project nested data, it can apply predicates on stats, etc).

A `connector` implementation would be a lot of work, but we should look at the C++ `Dataset` API for guidance and inspiration.

Relation to Flight SQL (https://docs.google.com/document/d/1WQz32bDF06GgMdEYyzhakqUigBZkALFwDF2y1x3DTAI/):

I think this completements Flight SQL, in that Flight would be the transport layer, and this would have the logic to read and write SQL data, and hand off to Flight. I however haven't looked at the Flight SQL spec, and I'm largely going on intuition.

Request for feedback:

- Is this a good idea? Can it work for us?
- Similar to the above, is it implementable for DataFusion?
- How can we design interfaces?
- Is supporting sync and async a good idea? (There would be consumers that would be interested in sync)
- What databases could we potentially support, would we feature-gate them, or go all in?
- Even with limited database support, could implementors like DataFusion still be able to provide an API which allows a user to register a reader/writer that supports the traits offered here?

Pending work for me:

- Provide some benchmarks of this interface vs an ODBC approach (https://github.com/nevi-me/odbc2arrow), and a JDBC approach (haven't pushed my work to GH, wrote something in Kotlin as part of old work that I did).

Also of interest: MongoDB Arrow IO (https://github.com/TheDataEngine/mongodb-arrow-connector), which was meant to be another IO target that could support IO traits.