### PR TITLE
ARROW-10679: [Rust] [DataFusion] Implement CASE WHEN physical expression

### DIFF
--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1790,7 +1790,6 @@ impl PhysicalExpr for CaseExpr {
                 //TODO:
                 // - This is currently hard-coded for Int32 return value and needs to be made
                 //   generic over all types
-                // - Add support for scalars
 
                 let mut result: Option<ArrayRef> = None;
                 let row_count = batch.num_rows();

--- a/rust/datafusion/src/physical_plan/filter.rs
+++ b/rust/datafusion/src/physical_plan/filter.rs
@@ -128,7 +128,7 @@ fn batch_filter(
 ) -> ArrowResult<RecordBatch> {
     predicate
         .evaluate(&batch)
-        .map(|v| v.into_array(batch))
+        .map(|v| v.into_array(batch.num_rows()))
         .map_err(DataFusionError::into_arrow_external_error)
         .and_then(|array| {
             array

--- a/rust/datafusion/src/physical_plan/functions.rs
+++ b/rust/datafusion/src/physical_plan/functions.rs
@@ -348,7 +348,7 @@ impl PhysicalExpr for ScalarFunctionExpr {
         let inputs = self
             .args
             .iter()
-            .map(|e| e.evaluate(batch).map(|v| v.into_array(batch)))
+            .map(|e| e.evaluate(batch).map(|v| v.into_array(batch.num_rows())))
             .collect::<Result<Vec<_>>>()?;
 
         // evaluate the function
@@ -382,7 +382,7 @@ mod tests {
 
         // evaluate works
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), columns)?;
-        let result = expr.evaluate(&batch)?.into_array(&batch);
+        let result = expr.evaluate(&batch)?.into_array(batch.num_rows());
 
         // downcast works
         let result = result.as_any().downcast_ref::<Float64Array>().unwrap();
@@ -423,7 +423,7 @@ mod tests {
 
         // evaluate works
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), columns)?;
-        let result = expr.evaluate(&batch)?.into_array(&batch);
+        let result = expr.evaluate(&batch)?.into_array(batch.num_rows());
 
         // downcast works
         let result = result.as_any().downcast_ref::<StringArray>().unwrap();
@@ -476,7 +476,7 @@ mod tests {
 
         // evaluate works
         let batch = RecordBatch::try_new(Arc::new(schema.clone()), columns)?;
-        let result = expr.evaluate(&batch)?.into_array(&batch);
+        let result = expr.evaluate(&batch)?.into_array(batch.num_rows());
 
         // downcast works
         let result = result

--- a/rust/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/rust/datafusion/src/physical_plan/hash_aggregate.rs
@@ -433,7 +433,7 @@ fn evaluate(
 ) -> Result<Vec<ArrayRef>> {
     expr.iter()
         .map(|expr| expr.evaluate(&batch))
-        .map(|r| r.map(|v| v.into_array(batch)))
+        .map(|r| r.map(|v| v.into_array(batch.num_rows())))
         .collect::<Result<Vec<_>>>()
 }
 
@@ -562,7 +562,7 @@ fn aggregate_batch(
             let values = &expr
                 .iter()
                 .map(|e| e.evaluate(batch))
-                .map(|r| r.map(|v| v.into_array(batch)))
+                .map(|r| r.map(|v| v.into_array(batch.num_rows())))
                 .collect::<Result<Vec<_>>>()?;
 
             // 1.3

--- a/rust/datafusion/src/physical_plan/hash_join.rs
+++ b/rust/datafusion/src/physical_plan/hash_join.rs
@@ -202,7 +202,7 @@ fn update_hash(
     // evaluate the keys
     let keys_values = on
         .iter()
-        .map(|name| Ok(col(name).evaluate(batch)?.into_array(batch)))
+        .map(|name| Ok(col(name).evaluate(batch)?.into_array(batch.num_rows())))
         .collect::<Result<Vec<_>>>()?;
 
     let mut key = Vec::with_capacity(keys_values.len());

--- a/rust/datafusion/src/physical_plan/mod.rs
+++ b/rust/datafusion/src/physical_plan/mod.rs
@@ -126,10 +126,10 @@ impl ColumnarValue {
         }
     }
 
-    fn into_array(self, batch: &RecordBatch) -> ArrayRef {
+    fn into_array(self, num_rows: usize) -> ArrayRef {
         match self {
             ColumnarValue::Array(array) => array,
-            ColumnarValue::Scalar(scalar) => scalar.to_array_of_size(batch.num_rows()),
+            ColumnarValue::Scalar(scalar) => scalar.to_array_of_size(num_rows),
         }
     }
 }

--- a/rust/datafusion/src/physical_plan/projection.rs
+++ b/rust/datafusion/src/physical_plan/projection.rs
@@ -130,7 +130,7 @@ fn batch_project(
     expressions
         .iter()
         .map(|expr| expr.evaluate(&batch))
-        .map(|r| r.map(|v| v.into_array(batch)))
+        .map(|r| r.map(|v| v.into_array(batch.num_rows())))
         .collect::<Result<Vec<_>>>()
         .map_or_else(
             |e| Err(DataFusionError::into_arrow_external_error(e)),


### PR DESCRIPTION
This PR implements the physical expression for the SQL CASE expression.

The CASE expression is similar to a series of nested if/else and there are two forms that can be used. 

The first form consists of a series of boolean "when" expressions with corresponding "then" expressions and an optional "else" expression.

```sql
CASE WHEN condition THEN result
     [WHEN ...]
     [ELSE result]
END
```

The second form uses a base expression and then a series of "when" clauses that match on a literal value.

```sql
CASE expression
    WHEN value THEN result
    [WHEN ...]
    [ELSE result]
END
```

The implementation is quite simple/naive and I have not attempted to optimize this yet. I would prefer to get this plumbed through and tested with TPC-H before optimizing.
