### PR TITLE
ARROW-10690: [Java] Fix ComplexCopier bug for list vector

### DIFF
--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -178,6 +178,9 @@ public class Union${listName}Writer extends AbstractFieldWriter {
   <#if listName == "LargeList">
   @Override
   public void startList() {
+    if (vector.getLastSet() >= idx()){
+      vector.setLastSet(idx() - 1);
+    }
     vector.startNewValue(idx());
     writer.setPosition(checkedCastToInt(vector.getOffsetBuffer().getLong(((long) idx() + 1L) * OFFSET_WIDTH)));
   }
@@ -190,6 +193,9 @@ public class Union${listName}Writer extends AbstractFieldWriter {
   <#else>
   @Override
   public void startList() {
+    if (vector.getLastSet() >= idx()){
+      vector.setLastSet(idx() - 1);
+    }
     vector.startNewValue(idx());
     writer.setPosition(vector.getOffsetBuffer().getInt((idx() + 1) * OFFSET_WIDTH));
   }

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -178,9 +178,6 @@ public class Union${listName}Writer extends AbstractFieldWriter {
   <#if listName == "LargeList">
   @Override
   public void startList() {
-    if (vector.getLastSet() >= idx()){
-      vector.setLastSet(idx() - 1);
-    }
     vector.startNewValue(idx());
     writer.setPosition(checkedCastToInt(vector.getOffsetBuffer().getLong(((long) idx() + 1L) * OFFSET_WIDTH)));
   }
@@ -193,9 +190,6 @@ public class Union${listName}Writer extends AbstractFieldWriter {
   <#else>
   @Override
   public void startList() {
-    if (vector.getLastSet() >= idx()){
-      vector.setLastSet(idx() - 1);
-    }
     vector.startNewValue(idx());
     writer.setPosition(vector.getOffsetBuffer().getInt((idx() + 1) * OFFSET_WIDTH));
   }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -804,6 +804,9 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
     while (index >= getValidityAndOffsetValueCapacity()) {
       reallocValidityAndOffsetBuffers();
     }
+    if (lastSet >= index) {
+      lastSet = index - 1;
+    }
     for (int i = lastSet + 1; i <= index; i++) {
       final int currentOffset = offsetBuffer.getInt(i * OFFSET_WIDTH);
       offsetBuffer.setInt((i + 1) * OFFSET_WIDTH, currentOffset);

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestComplexCopier.java
@@ -209,6 +209,57 @@ public class TestComplexCopier {
   }
 
   @Test
+  public void testCopyListVectorToANonEmptyList() {
+    try (ListVector from = ListVector.empty("v", allocator);
+         ListVector to = ListVector.empty("v", allocator)) {
+
+      UnionListWriter listWriter = from.getWriter();
+      listWriter.allocate();
+
+      for (int i = 0; i < COUNT; i++) {
+        listWriter.setPosition(i);
+        listWriter.startList();
+        listWriter.integer().writeInt(i);
+        listWriter.integer().writeInt(i * 2);
+        listWriter.endList();
+      }
+      from.setValueCount(COUNT);
+
+      // copy values
+      FieldReader in = from.getReader();
+      FieldWriter out = to.getWriter();
+      for (int i = 0; i < COUNT; i++) {
+        in.setPosition(i);
+        out.setPosition(i);
+        ComplexCopier.copy(in, out);
+      }
+      to.setValueCount(COUNT);
+      // validate equals
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
+
+      // Copy again to the target vector which is non-empty
+      for (int i = 0; i < COUNT; i++) {
+        in.setPosition(i);
+        out.setPosition(i);
+        ComplexCopier.copy(in, out);
+      }
+      to.setValueCount(COUNT);
+
+      // validate equals
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
+
+      // copy using copyFromSafe method
+      for (int i = 0; i < COUNT; i++) {
+        to.copyFromSafe(i, i, from);
+      }
+      to.setValueCount(COUNT);
+
+      // validate equals
+      assertTrue(VectorEqualsVisitor.vectorEquals(from, to));
+    }
+  }
+
+  @Test
   public void testCopyListVectorWithNulls() {
     try (ListVector from = ListVector.empty("v", allocator);
          ListVector to = ListVector.empty("v", allocator)) {


### PR DESCRIPTION
When copying a list vector using ComplexCopier, if the target list vector is non-empty, the result vector is incorrect. For example, if src = [[1,2], [3, 4]], tgt = [[5, 6], [7, 8]], copying src to tgt gives tgt = [[5, 6, 1, 2], [3, 4]] instead of [[1,2], [3, 4]]
Similary when using copyFrom(/Safe) method if the vector at the index is non-empty, the listElement is appended instead. For above src and tgt vector, tgt.copyFrom(0, 0, src) gives [[5, 6, 1, 2], []] instead of [[1,2], [7, 8]]