### PR TITLE
ARROW-10688: [Rust] [DataFusion] Implement CASE WHEN logical plan

### DIFF
--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -222,21 +222,19 @@ fn create_logical_plan(ctx: &mut ExecutionContext, query: usize) -> Result<Logic
                 .aggregate(
                     vec![col("l_shipmode")],
                     vec![
-                        sum(case_when()
-                            .when(or(
-                                col("o_orderpriority").eq(lit("1-URGENT")),
-                                col("o_orderpriority").eq(lit("2-HIGH")),
-                            ))
-                            .then(lit(1))
-                            .or_else(lit(0)))
+                        sum(case_when(or(
+                            col("o_orderpriority").eq(lit("1-URGENT")),
+                            col("o_orderpriority").eq(lit("2-HIGH")),
+                        ))
+                        .then(lit(1))
+                        .or_else(lit(0)))
                         .alias("high_line_count"),
-                        sum(case_when()
-                            .when(and(
-                                col("o_orderpriority").not_eq(lit("1-URGENT")),
-                                col("o_orderpriority").not_eq(lit("2-HIGH")),
-                            ))
-                            .then(lit(1))
-                            .or_else(lit(0)))
+                        sum(case_when(and(
+                            col("o_orderpriority").not_eq(lit("1-URGENT")),
+                            col("o_orderpriority").not_eq(lit("2-HIGH")),
+                        ))
+                        .then(lit(1))
+                        .or_else(lit(0)))
                         .alias("low_line_count"),
                     ],
                 )?

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -237,7 +237,7 @@ fn create_logical_plan(ctx: &mut ExecutionContext, query: usize) -> Result<Logic
                             ))
                             .then(lit(1))
                             .or_else(lit(0)))
-                        .alias("high_line_count"),
+                        .alias("low_line_count"),
                     ],
                 )?
                 .to_logical_plan())

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -222,7 +222,6 @@ fn create_logical_plan(ctx: &mut ExecutionContext, query: usize) -> Result<Logic
                 .aggregate(
                     vec![col("l_shipmode")],
                     vec![
-                        // we do not support CASE WHEN yet, so faking this part
                         sum(case_when()
                             .when(or(
                                 col("o_orderpriority").eq(lit("1-URGENT")),

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -26,7 +26,7 @@ use arrow::util::pretty;
 use datafusion::datasource::parquet::ParquetTable;
 use datafusion::datasource::{CsvFile, MemTable, TableProvider};
 use datafusion::error::{DataFusionError, Result};
-use datafusion::logical_plan::LogicalPlan;
+use datafusion::logical_plan::{and, case_when, or, LogicalPlan};
 use datafusion::physical_plan::csv::CsvExec;
 use datafusion::prelude::*;
 
@@ -223,8 +223,22 @@ fn create_logical_plan(ctx: &mut ExecutionContext, query: usize) -> Result<Logic
                     vec![col("l_shipmode")],
                     vec![
                         // we do not support CASE WHEN yet, so faking this part
-                        sum(lit(1)).alias("high_line_count"),
-                        sum(lit(0)).alias("low_line_count"),
+                        sum(case_when()
+                            .when(or(
+                                col("o_orderpriority").eq(lit("1-URGENT")),
+                                col("o_orderpriority").eq(lit("2-HIGH")),
+                            ))
+                            .then(lit(1))
+                            .or_else(lit(0)))
+                        .alias("high_line_count"),
+                        sum(case_when()
+                            .when(and(
+                                col("o_orderpriority").not_eq(lit("1-URGENT")),
+                                col("o_orderpriority").not_eq(lit("2-HIGH")),
+                            ))
+                            .then(lit(1))
+                            .or_else(lit(0)))
+                        .alias("high_line_count"),
                     ],
                 )?
                 .to_logical_plan())

--- a/rust/benchmarks/src/bin/tpch.rs
+++ b/rust/benchmarks/src/bin/tpch.rs
@@ -229,7 +229,7 @@ fn create_logical_plan(ctx: &mut ExecutionContext, query: usize) -> Result<Logic
                             ),
                             lit(1),
                         )
-                        .otherwise(lit(0)))
+                        .otherwise(lit(0))?)
                         .alias("high_line_count"),
                         sum(when(
                             and(
@@ -238,7 +238,7 @@ fn create_logical_plan(ctx: &mut ExecutionContext, query: usize) -> Result<Logic
                             ),
                             lit(1),
                         )
-                        .otherwise(lit(0)))
+                        .otherwise(lit(0))?)
                         .alias("low_line_count"),
                     ],
                 )?

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -386,28 +386,23 @@ impl Expr {
     }
 }
 
-pub struct CaseWhenBuilder {
+pub struct CaseBuilder {
     expr: Option<Box<Expr>>,
     when_expr: Vec<Expr>,
     then_expr: Vec<Expr>,
 }
 
-pub struct CaseThenBuilder {
-    expr: Option<Box<Expr>>,
-    when_expr: Vec<Expr>,
-    then_expr: Vec<Expr>,
-}
-
-impl CaseWhenBuilder {
-    pub fn when(&mut self, expr: Expr) -> CaseThenBuilder {
-        self.when_expr.push(expr);
-        CaseThenBuilder {
+impl CaseBuilder {
+    pub fn when(&mut self, when: Expr, then: Expr) -> CaseBuilder {
+        self.when_expr.push(when);
+        self.then_expr.push(then);
+        CaseBuilder {
             expr: self.expr.clone(),
             when_expr: self.when_expr.clone(),
             then_expr: self.then_expr.clone(),
         }
     }
-    pub fn or_else(&mut self, else_expr: Expr) -> Expr {
+    pub fn otherwise(&mut self, else_expr: Expr) -> Expr {
         Expr::Case {
             expr: self.expr.clone(),
             when_then_expr: self
@@ -433,20 +428,9 @@ impl CaseWhenBuilder {
     }
 }
 
-impl CaseThenBuilder {
-    pub fn then(&mut self, expr: Expr) -> CaseWhenBuilder {
-        self.then_expr.push(expr);
-        CaseWhenBuilder {
-            expr: self.expr.clone(),
-            when_expr: self.when_expr.clone(),
-            then_expr: self.then_expr.clone(),
-        }
-    }
-}
-
 /// Create a CASE WHEN statement with literal WHEN expressions for comparison to the base expression.
-pub fn case(expr: Expr) -> CaseWhenBuilder {
-    CaseWhenBuilder {
+pub fn case(expr: Expr) -> CaseBuilder {
+    CaseBuilder {
         expr: Some(Box::new(expr)),
         when_expr: vec![],
         then_expr: vec![],
@@ -454,11 +438,11 @@ pub fn case(expr: Expr) -> CaseWhenBuilder {
 }
 
 /// Create a CASE WHEN statement with boolean WHEN expressions and no base expression.
-pub fn case_when(when_expr: Expr) -> CaseThenBuilder {
-    CaseThenBuilder {
+pub fn when(when: Expr, then: Expr) -> CaseBuilder {
+    CaseBuilder {
         expr: None,
-        when_expr: vec![when_expr],
-        then_expr: vec![],
+        when_expr: vec![when],
+        then_expr: vec![then],
     }
 }
 

--- a/rust/datafusion/src/logical_plan/expr.rs
+++ b/rust/datafusion/src/logical_plan/expr.rs
@@ -454,10 +454,10 @@ pub fn case(expr: Expr) -> CaseWhenBuilder {
 }
 
 /// Create a CASE WHEN statement with boolean WHEN expressions and no base expression.
-pub fn case_when() -> CaseWhenBuilder {
-    CaseWhenBuilder {
+pub fn case_when(when_expr: Expr) -> CaseThenBuilder {
+    CaseThenBuilder {
         expr: None,
-        when_expr: vec![],
+        when_expr: vec![when_expr],
         then_expr: vec![],
     }
 }

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -32,9 +32,10 @@ mod registry;
 pub use builder::LogicalPlanBuilder;
 pub use display::display_schema;
 pub use expr::{
-    abs, acos, and, array, asin, atan, avg, binary_expr, ceil, col, concat, cos, count,
-    create_udaf, create_udf, exp, exprlist_to_fields, floor, length, lit, ln, log10,
-    log2, max, min, round, signum, sin, sqrt, sum, tan, trunc, Expr, Literal,
+    abs, acos, and, array, asin, atan, avg, binary_expr, case, case_when, ceil, col,
+    concat, cos, count, create_udaf, create_udf, exp, exprlist_to_fields, floor, length,
+    lit, ln, log10, log2, max, min, or, round, signum, sin, sqrt, sum, tan, trunc, Expr,
+    Literal,
 };
 pub use extension::UserDefinedLogicalNode;
 pub use operators::Operator;

--- a/rust/datafusion/src/logical_plan/mod.rs
+++ b/rust/datafusion/src/logical_plan/mod.rs
@@ -32,9 +32,9 @@ mod registry;
 pub use builder::LogicalPlanBuilder;
 pub use display::display_schema;
 pub use expr::{
-    abs, acos, and, array, asin, atan, avg, binary_expr, case, case_when, ceil, col,
-    concat, cos, count, create_udaf, create_udf, exp, exprlist_to_fields, floor, length,
-    lit, ln, log10, log2, max, min, or, round, signum, sin, sqrt, sum, tan, trunc, Expr,
+    abs, acos, and, array, asin, atan, avg, binary_expr, case, ceil, col, concat, cos,
+    count, create_udaf, create_udf, exp, exprlist_to_fields, floor, length, lit, ln,
+    log10, log2, max, min, or, round, signum, sin, sqrt, sum, tan, trunc, when, Expr,
     Literal,
 };
 pub use extension::UserDefinedLogicalNode;

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -93,7 +93,9 @@ fn issue_filters(
     let predicate = predicates
         .iter()
         .skip(1)
-        .fold(predicates[0].clone(), |acc, predicate| and(acc, (*predicate).clone()));
+        .fold(predicates[0].clone(), |acc, predicate| {
+            and(acc, (*predicate).clone())
+        });
 
     // add a new filter node with the predicates
     let plan = LogicalPlan::Filter {

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -94,7 +94,7 @@ fn issue_filters(
         .iter()
         .skip(1)
         .fold(predicates[0].clone(), |acc, predicate| {
-            and(acc, (*predicate).clone())
+            and(acc, (*predicate).to_owned())
         });
 
     // add a new filter node with the predicates

--- a/rust/datafusion/src/optimizer/filter_push_down.rs
+++ b/rust/datafusion/src/optimizer/filter_push_down.rs
@@ -93,7 +93,7 @@ fn issue_filters(
     let predicate = predicates
         .iter()
         .skip(1)
-        .fold(predicates[0].clone(), |acc, predicate| and(&acc, predicate));
+        .fold(predicates[0].clone(), |acc, predicate| and(acc, (*predicate).clone()));
 
     // add a new filter node with the predicates
     let plan = LogicalPlan::Filter {

--- a/rust/datafusion/src/optimizer/projection_push_down.rs
+++ b/rust/datafusion/src/optimizer/projection_push_down.rs
@@ -113,6 +113,7 @@ fn optimize_plan(
     required_columns: &HashSet<String>, // set of columns required up to this step
     has_projection: bool,
 ) -> Result<LogicalPlan> {
+    let mut new_required_columns = required_columns.clone();
     match plan {
         LogicalPlan::Projection {
             input,
@@ -125,7 +126,6 @@ fn optimize_plan(
 
             let mut new_expr = Vec::new();
             let mut new_fields = Vec::new();
-            let mut new_required_columns = HashSet::new();
 
             // Gather all columns needed for expressions in this Projection
             schema
@@ -165,7 +165,6 @@ fn optimize_plan(
             join_type,
             schema,
         } => {
-            let mut new_required_columns = HashSet::new();
             for (l, r) in on {
                 new_required_columns.insert(l.to_owned());
                 new_required_columns.insert(r.to_owned());
@@ -200,7 +199,6 @@ fn optimize_plan(
             // * remove any aggregate expression that is not required
             // * construct the new set of required columns
 
-            let mut new_required_columns = HashSet::new();
             utils::exprlist_to_column_names(group_expr, &mut new_required_columns)?;
 
             // Gather all columns needed for expressions in this Aggregate
@@ -347,7 +345,6 @@ fn optimize_plan(
         | LogicalPlan::Extension { .. } => {
             let expr = utils::expressions(plan);
             // collect all required columns by this plan
-            let mut new_required_columns = required_columns.clone();
             utils::exprlist_to_column_names(&expr, &mut new_required_columns)?;
 
             // apply the optimization to all inputs of the plan

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -315,9 +315,9 @@ pub fn rewrite_expression(expr: &Expr, expressions: &Vec<Expr>) -> Result<Expr> 
             args: expressions.clone(),
         }),
         Expr::Case { .. } => {
-            let mut _expr: Option<Box<Expr>> = None;
-            let mut _when_then: Vec<(Box<Expr>, Box<Expr>)> = vec![];
-            let mut _else_expr: Option<Box<Expr>> = None;
+            let mut base_expr: Option<Box<Expr>> = None;
+            let mut when_then: Vec<(Box<Expr>, Box<Expr>)> = vec![];
+            let mut else_expr: Option<Box<Expr>> = None;
             let mut i = 0;
 
             while i < expressions.len() {
@@ -325,17 +325,17 @@ pub fn rewrite_expression(expr: &Expr, expressions: &Vec<Expr>) -> Result<Expr> 
                     Expr::Literal(ScalarValue::Utf8(Some(str)))
                         if str == CASE_EXPR_MARKER =>
                     {
-                        _expr = Some(Box::new(expressions[i + 1].clone()));
+                        base_expr = Some(Box::new(expressions[i + 1].clone()));
                         i += 2;
                     }
                     Expr::Literal(ScalarValue::Utf8(Some(str)))
                         if str == CASE_ELSE_MARKER =>
                     {
-                        _expr = Some(Box::new(expressions[i + 1].clone()));
+                        else_expr = Some(Box::new(expressions[i + 1].clone()));
                         i += 2;
                     }
                     _ => {
-                        _when_then.push((
+                        when_then.push((
                             Box::new(expressions[i].clone()),
                             Box::new(expressions[i + 1].clone()),
                         ));
@@ -344,15 +344,11 @@ pub fn rewrite_expression(expr: &Expr, expressions: &Vec<Expr>) -> Result<Expr> 
                 }
             }
 
-            let x = Expr::Case {
-                expr: _expr,
-                when_then_expr: _when_then,
-                else_expr: _else_expr,
-            };
-
-            println!("rewrite: {:?}", x);
-
-            Ok(x)
+            Ok(Expr::Case {
+                expr: base_expr,
+                when_then_expr: when_then,
+                else_expr,
+            })
         }
         Expr::Cast { data_type, .. } => Ok(Expr::Cast {
             expr: Box::new(expressions[0].clone()),

--- a/rust/datafusion/src/optimizer/utils.rs
+++ b/rust/datafusion/src/optimizer/utils.rs
@@ -344,11 +344,15 @@ pub fn rewrite_expression(expr: &Expr, expressions: &Vec<Expr>) -> Result<Expr> 
                 }
             }
 
-            Ok(Expr::Case {
+            let x = Expr::Case {
                 expr: _expr,
                 when_then_expr: _when_then,
                 else_expr: _else_expr,
-            })
+            };
+
+            println!("rewrite: {:?}", x);
+
+            Ok(x)
         }
         Expr::Cast { data_type, .. } => Ok(Expr::Cast {
             expr: Box::new(expressions[0].clone()),

--- a/rust/datafusion/src/physical_plan/expressions.rs
+++ b/rust/datafusion/src/physical_plan/expressions.rs
@@ -1718,7 +1718,7 @@ pub fn is_not_null(arg: Arc<dyn PhysicalExpr>) -> Result<Arc<dyn PhysicalExpr>> 
 ///     [ELSE result]
 /// END
 #[derive(Debug)]
-struct CaseExpr {
+pub struct CaseExpr {
     /// Optional base expression that can be compared to literal values in the "when" expressions
     expr: Option<Arc<dyn PhysicalExpr>>,
     /// One or more when/then expressions
@@ -1744,6 +1744,7 @@ impl fmt::Display for CaseExpr {
 }
 
 impl CaseExpr {
+    /// Create a new CASE WHEN expression
     pub fn try_new(
         expr: Option<Arc<dyn PhysicalExpr>>,
         when_then_expr: &[(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)],


### PR DESCRIPTION
This PR builds on https://github.com/apache/arrow/pull/8740 and introduces functions and builders for creating CASE WHEN statements as part of the logical plan via the DataFrame API.

Here is an example from TPC-H query 12:

```rust
sum(when(or(
        col("o_orderpriority").eq(lit("1-URGENT")),
        col("o_orderpriority").eq(lit("2-HIGH")),
    ), lit(1))
    .otherwise(lit(0)))
.alias("high_line_count"),
sum(when(and(
        col("o_orderpriority").not_eq(lit("1-URGENT")),
        col("o_orderpriority").not_eq(lit("2-HIGH")),
    ), lit(1))
    .otherwise(lit(0)))
.alias("low_line_count"),

```

The query produces the following output:

```
Optimized logical plan:
Aggregate: groupBy=[[#l_shipmode]], aggr=[[SUM(CASE WHEN #o_orderpriority Eq Utf8("1-URGENT") Or #o_orderpriority Eq Utf8("2-HIGH") THEN Int32(1) ELSE Int32(0) END) AS high_line_count, SUM(CASE WHEN #o_orderpriority NotEq Utf8("1-URGENT") And #o_orderpriority NotEq Utf8("2-HIGH") THEN Int32(1) ELSE Int32(0) END) AS low_line_count]]
  Join: l_orderkey = o_orderkey
    Filter: #l_receiptdate Lt Utf8("1995-01-01") And #l_receiptdate GtEq Utf8("1994-01-01") And #l_shipdate Lt #l_commitdate And #l_commitdate Lt #l_receiptdate And #l_shipmode Eq Utf8("MAIL") Or #l_shipmode Eq Utf8("SHIP")
      TableScan: lineitem projection=Some([0, 10, 11, 12, 14])
    TableScan: orders projection=Some([0, 5])
+------------+-----------------+----------------+
| l_shipmode | high_line_count | low_line_count |
+------------+-----------------+----------------+
| MAIL       | 6202            | 9324           |
| SHIP       | 6200            | 9262           |
+------------+-----------------+----------------+
Query 12 iteration 0 took 10538 ms

```